### PR TITLE
span: add Span.Context method

### DIFF
--- a/tracer/context.go
+++ b/tracer/context.go
@@ -9,7 +9,7 @@ type datadogContextKey struct{}
 var spanKey = datadogContextKey{}
 
 // ContextWithSpan will return a new context that includes the given span.
-// DE
+// DEPRECATED: use span.Context(ctx) instead.
 func ContextWithSpan(ctx context.Context, span *Span) context.Context {
 	if span == nil {
 		return ctx

--- a/tracer/context.go
+++ b/tracer/context.go
@@ -9,8 +9,12 @@ type datadogContextKey struct{}
 var spanKey = datadogContextKey{}
 
 // ContextWithSpan will return a new context that includes the given span.
+// DE
 func ContextWithSpan(ctx context.Context, span *Span) context.Context {
-	return context.WithValue(ctx, spanKey, span)
+	if span == nil {
+		return ctx
+	}
+	return span.Context(ctx)
 }
 
 // SpanFromContext returns the stored *Span from the Context if it's available.

--- a/tracer/example_context_test.go
+++ b/tracer/example_context_test.go
@@ -43,7 +43,7 @@ func saveFileHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Add the span to the request's context so we can pass the tracing information
 	// down the stack.
-	ctx := tracer.ContextWithSpan(r.Context(), span)
+	ctx := span.Context(r.Context())
 
 	// Do the work.
 	err := saveFile(ctx, "/tmp/example", r.Body)

--- a/tracer/span.go
+++ b/tracer/span.go
@@ -1,6 +1,7 @@
 package tracer
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -196,8 +197,20 @@ func (s *Span) String() string {
 	return strings.Join(lines, "\n")
 }
 
+// Context returns a copy of the given context that includes this span.
+// This span can be accessed downstream with SpanFromContext and friends.
+func (s *Span) Context(ctx context.Context) context.Context {
+	if s == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, spanKey, s)
+}
+
 // Tracer returns the tracer that created this span.
 func (s *Span) Tracer() *Tracer {
+	if s == nil {
+		return nil
+	}
 	return s.tracer
 }
 

--- a/tracer/span_test.go
+++ b/tracer/span_test.go
@@ -1,6 +1,7 @@
 package tracer
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -117,4 +118,19 @@ func TestSpanFinishTwice(t *testing.T) {
 	span.Finish()
 	assert.Equal(span.Duration, previousDuration)
 	assert.Equal(tracer.buffer.Len(), 1)
+}
+
+func TestSpanContext(t *testing.T) {
+	ctx := context.Background()
+	_, ok := SpanFromContext(ctx)
+	assert.False(t, ok)
+
+	tracer := NewTracer()
+	span := tracer.NewRootSpan("pylons.request", "pylons", "/")
+
+	ctx = span.Context(ctx)
+	s2, ok := SpanFromContext(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, s2.SpanID, span.SpanID)
+
 }

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -168,7 +168,7 @@ func NewChildSpan(name string, parent *Span) *Span {
 }
 
 // NewChildSpanFromContext will create a child span of the span contained in
-// the given context. If the context contains to span, a span with
+// the given context. If the context contains no span, a span with
 // no service or resource will be returned.
 func NewChildSpanFromContext(name string, ctx context.Context) *Span {
 	return DefaultTracer.NewChildSpanFromContext(name, ctx)


### PR DESCRIPTION
makes it easier to do things like:

```
foo(span.Context(ctx), ...)
```

@elijahandrews 
