### PR TITLE
[ci] integration tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,10 @@
 machine:
+  services:
+    - docker
   environment:
     GODIST: "go1.7.linux-amd64.tar.gz"
     IMPORT_PATH: "/home/ubuntu/.go_workspace/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+    AGENT_BUILD_PATH: "/home/ubuntu/agent"
     GO15VENDOREXPERIMENT: "1"
   post:
     - mkdir -p download
@@ -14,6 +17,11 @@ dependencies:
     # install requirements
     - rm -Rf /home/ubuntu/.go_workspace/src/*
     - rake lint:install
+    # prepare and run the trace agent
+    # TODO[manu]: remove this part when everything will be open source
+    - git clone git@github.com:DataDog/raclette.git $AGENT_BUILD_PATH
+    - cd $AGENT_BUILD_PATH && docker build -t datadog/trace-agent .
+    - docker run -d -e DD_API_KEY=invalid_key_but_this_is_fine -e DD_BIND_HOST=0.0.0.0 -p 127.0.0.1:7777:7777 datadog/trace-agent
 
   override:
     # put the package in the right $GOPATH

--- a/tracer/contrib/gin-gonic/gintrace/gintrace_test.go
+++ b/tracer/contrib/gin-gonic/gintrace/gintrace_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -200,9 +201,9 @@ type dummyTransport struct {
 	spans []*tracer.Span
 }
 
-func (d *dummyTransport) Send(s []*tracer.Span) error {
+func (d *dummyTransport) Send(s []*tracer.Span) (*http.Response, error) {
 	d.spans = append(d.spans, s...)
-	return nil
+	return nil, nil
 }
 
 func (d *dummyTransport) Spans() []*tracer.Span {

--- a/tracer/contrib/gorilla/muxtrace/muxtrace_test.go
+++ b/tracer/contrib/gorilla/muxtrace/muxtrace_test.go
@@ -172,9 +172,9 @@ type dummyTransport struct {
 	spans []*tracer.Span
 }
 
-func (d *dummyTransport) Send(s []*tracer.Span) error {
+func (d *dummyTransport) Send(s []*tracer.Span) (*http.Response, error) {
 	d.spans = append(d.spans, s...)
-	return nil
+	return nil, nil
 }
 
 func (d *dummyTransport) Spans() []*tracer.Span {

--- a/tracer/contrib/tracegrpc/grpc_test.go
+++ b/tracer/contrib/tracegrpc/grpc_test.go
@@ -3,6 +3,7 @@ package tracegrpc
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"testing"
 
 	"google.golang.org/grpc"
@@ -234,9 +235,9 @@ type dummyTransport struct {
 	spans []*tracer.Span
 }
 
-func (d *dummyTransport) Send(s []*tracer.Span) error {
+func (d *dummyTransport) Send(s []*tracer.Span) (*http.Response, error) {
 	d.spans = append(d.spans, s...)
-	return nil
+	return nil, nil
 }
 
 func (d *dummyTransport) Spans() []*tracer.Span {

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	defaultDeliveryURL = "http://localhost:7777/spans"
+	defaultDeliveryURL = "http://localhost:7777/v0.1/spans"
 	flushInterval      = 2 * time.Second
 )
 
@@ -133,7 +133,8 @@ func (t *Tracer) Flush() error {
 		return nil
 	}
 
-	return t.transport.Send(spans)
+	_, err := t.transport.Send(spans)
+	return err
 
 }
 

--- a/tracer/tracer_test.go
+++ b/tracer/tracer_test.go
@@ -2,6 +2,7 @@ package tracer
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -162,10 +163,10 @@ type DummyTransport struct {
 	pool *encoderPool
 }
 
-func (t *DummyTransport) Send(spans []*Span) error {
+func (t *DummyTransport) Send(spans []*Span) (*http.Response, error) {
 	encoder := t.pool.Borrow()
 	defer t.pool.Return(encoder)
-	return encoder.Encode(spans)
+	return nil, encoder.Encode(spans)
 }
 
 func BenchmarkTracerAddSpans(b *testing.B) {

--- a/tracer/transport_test.go
+++ b/tracer/transport_test.go
@@ -1,0 +1,53 @@
+package tracer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// getTestSpan returns a Span with different fields set
+func getTestSpan() *Span {
+	return &Span{
+		TraceID:  42,
+		SpanID:   52,
+		ParentID: 42,
+		Type:     "web",
+		Service:  "high.throughput",
+		Name:     "sending.events",
+		Resource: "SEND /data",
+		Start:    time.Now().UnixNano(),
+		Duration: time.Second.Nanoseconds(),
+		Meta:     map[string]string{"http.host": "192.168.0.1"},
+		Metrics:  map[string]float64{"http.monitor": 41.99},
+	}
+}
+
+// getTestTrace returns a []Span that is composed by ``size`` number of spans
+func getTestTrace(size int) []*Span {
+	spans := []*Span{}
+
+	for i := 0; i < size; i++ {
+		spans = append(spans, getTestSpan())
+	}
+	return spans
+}
+
+func TestTracesAgentIntegration(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		payload []*Span
+	}{
+		{getTestTrace(1)},
+		{getTestTrace(10)},
+	}
+
+	for _, tc := range testCases {
+		transport := newHTTPTransport("http://localhost:7777/v0.1/spans")
+		response, err := transport.Send(tc.payload)
+		assert.Nil(err)
+		assert.Equal(200, response.StatusCode)
+	}
+}


### PR DESCRIPTION
### What it does

Adds integration tests for the latest ``dd-trace-agent``. It targets the current implementation that is the ``v0.1`` API.