### PR TITLE
[core] using the agent API v03

### DIFF
--- a/tracer/encoder.go
+++ b/tracer/encoder.go
@@ -25,9 +25,9 @@ func newJSONEncoder() *jsonEncoder {
 // Encode returns a byte array related to the marshalling
 // of a list of spans. It resets the JSONEncoder internal buffer
 // and proceeds with the encoding.
-func (e *jsonEncoder) Encode(spans []*Span) error {
+func (e *jsonEncoder) Encode(traces [][]*Span) error {
 	e.b.Reset()
-	return e.j.Encode(spans)
+	return e.j.Encode(traces)
 }
 
 // Read values from the internal buffer

--- a/tracer/encoder_test.go
+++ b/tracer/encoder_test.go
@@ -9,34 +9,38 @@ import (
 func TestJSONEncoder(t *testing.T) {
 	assert := assert.New(t)
 
-	// create a spans list with a single span
+	// create a traces list with a single span
+	var traces [][]*Span
 	var spans []*Span
 	span := NewSpan("pylons.request", "pylons", "/", 0, 0, 0, nil)
 	span.Start = 0
 	spans = append(spans, span)
+	traces = append(traces, spans)
 
 	// the encoder must return a valid JSON byte array that ends with a \n
-	want := `[{"name":"pylons.request","service":"pylons","resource":"/","type":"","start":0,"duration":0,"span_id":0,"trace_id":0,"parent_id":0,"error":0}]`
+	want := `[[{"name":"pylons.request","service":"pylons","resource":"/","type":"","start":0,"duration":0,"span_id":0,"trace_id":0,"parent_id":0,"error":0}]]`
 	want += "\n"
 
 	encoder := newJSONEncoder()
-	err := encoder.Encode(spans)
+	err := encoder.Encode(traces)
 	assert.Nil(err)
-	assert.Equal(encoder.b.String(), want)
+	assert.Equal(want, encoder.b.String())
 }
 
 func TestJSONRead(t *testing.T) {
 	assert := assert.New(t)
 
-	// create a spans list with a single span
+	// create a traces list with a single span
+	var traces [][]*Span
 	var spans []*Span
 	span := NewSpan("pylons.request", "pylons", "/", 0, 0, 0, nil)
 	span.Start = 0
 	spans = append(spans, span)
+	traces = append(traces, spans)
 
 	// fill the encoder internal buffer
 	encoder := newJSONEncoder()
-	_ = encoder.Encode(spans)
+	_ = encoder.Encode(traces)
 	expectedSize := encoder.b.Len()
 
 	// the Read function must be used to get the value of the internal buffer
@@ -44,10 +48,10 @@ func TestJSONRead(t *testing.T) {
 	_, err := encoder.Read(buff)
 
 	// it should match the encoding payload
-	want := `[{"name":"pylons.request","service":"pylons","resource":"/","type":"","start":0,"duration":0,"span_id":0,"trace_id":0,"parent_id":0,"error":0}]`
+	want := `[[{"name":"pylons.request","service":"pylons","resource":"/","type":"","start":0,"duration":0,"span_id":0,"trace_id":0,"parent_id":0,"error":0}]]`
 	want += "\n"
 	assert.Nil(err)
-	assert.Equal(string(buff), want)
+	assert.Equal(want, string(buff))
 }
 
 func TestPoolBorrowCreate(t *testing.T) {

--- a/tracer/span_test.go
+++ b/tracer/span_test.go
@@ -103,7 +103,7 @@ func TestSpanFinishTwice(t *testing.T) {
 	assert := assert.New(t)
 	wait := time.Millisecond * 2
 
-	tracer := getTestTracer()
+	tracer, _ := getTestTracer()
 
 	assert.Equal(tracer.buffer.Len(), 0)
 

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	defaultDeliveryURL = "http://localhost:7777/v0.1/spans"
+	defaultDeliveryURL = "http://localhost:7777/v0.3/traces"
 	flushInterval      = 2 * time.Second
 )
 
@@ -133,7 +133,10 @@ func (t *Tracer) Flush() error {
 		return nil
 	}
 
-	_, err := t.transport.Send(spans)
+	// TODO[manu]: this doesn't make sense! change it with a proper buffer
+	var traces [][]*Span
+	traces = append(traces, spans)
+	_, err := t.transport.Send(traces)
 	return err
 
 }

--- a/tracer/tracer_test.go
+++ b/tracer/tracer_test.go
@@ -163,10 +163,10 @@ type DummyTransport struct {
 	pool *encoderPool
 }
 
-func (t *DummyTransport) Send(spans []*Span) (*http.Response, error) {
+func (t *DummyTransport) Send(traces [][]*Span) (*http.Response, error) {
 	encoder := t.pool.Borrow()
 	defer t.pool.Return(encoder)
-	return nil, encoder.Encode(spans)
+	return nil, encoder.Encode(traces)
 }
 
 func BenchmarkTracerAddSpans(b *testing.B) {

--- a/tracer/transport_test.go
+++ b/tracer/transport_test.go
@@ -46,6 +46,9 @@ func TestTracesAgentIntegration(t *testing.T) {
 		payload [][]*Span
 	}{
 		{getTestTrace(1, 1)},
+		{getTestTrace(10, 1)},
+		{getTestTrace(1, 10)},
+		{getTestTrace(10, 10)},
 	}
 
 	for _, tc := range testCases {

--- a/tracer/transport_test.go
+++ b/tracer/transport_test.go
@@ -24,30 +24,35 @@ func getTestSpan() *Span {
 	}
 }
 
-// getTestTrace returns a []Span that is composed by ``size`` number of spans
-func getTestTrace(size int) []*Span {
-	spans := []*Span{}
+// getTestTrace returns a list of traces that is composed by ``traceN`` number
+// of traces, each one composed by ``size`` number of spans.
+func getTestTrace(traceN, size int) [][]*Span {
+	var traces [][]*Span
 
-	for i := 0; i < size; i++ {
-		spans = append(spans, getTestSpan())
+	for i := 0; i < traceN; i++ {
+		trace := []*Span{}
+		for j := 0; j < size; j++ {
+			trace = append(trace, getTestSpan())
+		}
+		traces = append(traces, trace)
 	}
-	return spans
+	return traces
 }
 
 func TestTracesAgentIntegration(t *testing.T) {
 	assert := assert.New(t)
 
 	testCases := []struct {
-		payload []*Span
+		payload [][]*Span
 	}{
-		{getTestTrace(1)},
-		{getTestTrace(10)},
+		{getTestTrace(1, 1)},
 	}
 
 	for _, tc := range testCases {
-		transport := newHTTPTransport("http://localhost:7777/v0.1/spans")
+		transport := newHTTPTransport(defaultDeliveryURL)
 		response, err := transport.Send(tc.payload)
 		assert.Nil(err)
+		assert.NotNil(response)
 		assert.Equal(200, response.StatusCode)
 	}
 }


### PR DESCRIPTION
### What it does

* supports the ``datadog-trace-agent`` API ``v0.3``
* adds all integration tests for the JSON encoding
* it doesn't use a flat span list because it's incompatible with the new API

### What's missing

* in another PR we have to optimize the path to rebuild traces. We can easily remove this step if we refactor the code using channels. In the meantime I've added this step to prevent any changes to the current implementation because ``msgpack`` will be a big change and I don't want to introduce two big things to debug in case of errors