### PR TITLE
[core] add support for Msgpack encoder

### DIFF
--- a/tracer/contrib/gin-gonic/gintrace/gintrace_test.go
+++ b/tracer/contrib/gin-gonic/gintrace/gintrace_test.go
@@ -213,3 +213,5 @@ func (t *dummyTransport) Traces() [][]*tracer.Span {
 	t.traces = nil
 	return traces
 }
+
+func (t *dummyTransport) SetHeader(key, value string) {}

--- a/tracer/contrib/gorilla/muxtrace/muxtrace_test.go
+++ b/tracer/contrib/gorilla/muxtrace/muxtrace_test.go
@@ -187,3 +187,5 @@ func (t *dummyTransport) Traces() [][]*tracer.Span {
 	t.traces = nil
 	return traces
 }
+
+func (t *dummyTransport) SetHeader(key, value string) {}

--- a/tracer/contrib/tracegrpc/grpc_test.go
+++ b/tracer/contrib/tracegrpc/grpc_test.go
@@ -246,3 +246,5 @@ func (t *dummyTransport) Traces() [][]*tracer.Span {
 	t.traces = nil
 	return traces
 }
+
+func (t *dummyTransport) SetHeader(key, value string) {}

--- a/tracer/encoder.go
+++ b/tracer/encoder.go
@@ -13,14 +13,16 @@ import (
 type Encoder interface {
 	Encode(traces [][]*Span) error
 	Read(p []byte) (int, error)
+	ContentType() string
 }
 
 var mh codec.MsgpackHandle
 
 // msgpackEncoder encodes a list of traces in Msgpack format
 type msgpackEncoder struct {
-	buffer  *bytes.Buffer
-	encoder *codec.Encoder
+	buffer      *bytes.Buffer
+	encoder     *codec.Encoder
+	contentType string
 }
 
 func newMsgpackEncoder() *msgpackEncoder {
@@ -28,8 +30,9 @@ func newMsgpackEncoder() *msgpackEncoder {
 	encoder := codec.NewEncoder(buffer, &mh)
 
 	return &msgpackEncoder{
-		buffer:  buffer,
-		encoder: encoder,
+		buffer:      buffer,
+		encoder:     encoder,
+		contentType: "application/msgpack",
 	}
 }
 
@@ -45,33 +48,45 @@ func (e *msgpackEncoder) Read(p []byte) (int, error) {
 	return e.buffer.Read(p)
 }
 
+// ContentType return the msgpackEncoder content-type
+func (e *msgpackEncoder) ContentType() string {
+	return e.contentType
+}
+
 // jsonEncoder encodes a list of traces in JSON format
 type jsonEncoder struct {
-	j *json.Encoder // the JSON encoder
-	b *bytes.Buffer // the reusable buffer
+	buffer      *bytes.Buffer
+	encoder     *json.Encoder
+	contentType string
 }
 
 // newJSONEncoder returns a new encoder for the JSON format.
 func newJSONEncoder() *jsonEncoder {
-	b := &bytes.Buffer{}
-	j := json.NewEncoder(b)
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
 
 	return &jsonEncoder{
-		j: j,
-		b: b,
+		buffer:      buffer,
+		encoder:     encoder,
+		contentType: "application/json",
 	}
 }
 
 // Encode serializes the given traces list into the internal
 // buffer, returning the error if any
 func (e *jsonEncoder) Encode(traces [][]*Span) error {
-	e.b.Reset()
-	return e.j.Encode(traces)
+	e.buffer.Reset()
+	return e.encoder.Encode(traces)
 }
 
 // Read values from the internal buffer
 func (e *jsonEncoder) Read(p []byte) (int, error) {
-	return e.b.Read(p)
+	return e.buffer.Read(p)
+}
+
+// ContentType return the jsonEncoder content-type
+func (e *jsonEncoder) ContentType() string {
+	return e.contentType
 }
 
 // EncoderPool is a pool meant to share the buffers required to encode traces.

--- a/tracer/encoder.go
+++ b/tracer/encoder.go
@@ -109,11 +109,18 @@ type agentEncoderPool struct {
 	pool        chan Encoder
 }
 
-func newAgentEncoderPool(encoderType, size int) *agentEncoderPool {
-	return &agentEncoderPool{
+func newAgentEncoderPool(encoderType, size int) (*agentEncoderPool, string) {
+	pool := &agentEncoderPool{
 		encoderType: encoderType,
 		pool:        make(chan Encoder, size),
 	}
+
+	// Borrow an encoder to retrieve the default ContentType
+	encoder := pool.Borrow()
+	pool.Return(encoder)
+
+	contentType := encoder.ContentType()
+	return pool, contentType
 }
 
 func (p *agentEncoderPool) Borrow() Encoder {

--- a/tracer/encoder_test.go
+++ b/tracer/encoder_test.go
@@ -58,7 +58,7 @@ func TestPoolBorrowCreate(t *testing.T) {
 	assert := assert.New(t)
 
 	// borrow an encoder from the pool
-	pool := newEncoderPool(1)
+	pool := newAgentEncoderPool(JSON_ENCODER, 1)
 	encoder := pool.Borrow()
 	assert.NotNil(encoder)
 }
@@ -67,7 +67,7 @@ func TestPoolReturn(t *testing.T) {
 	assert := assert.New(t)
 
 	// an encoder can return in the pool
-	pool := newEncoderPool(1)
+	pool := newAgentEncoderPool(JSON_ENCODER, 1)
 	encoder := newJSONEncoder()
 	pool.pool <- encoder
 	pool.Return(encoder)
@@ -81,7 +81,7 @@ func TestPoolReuseEncoder(t *testing.T) {
 	assert := assert.New(t)
 
 	// borrow, return and borrow again an encoder from the pool
-	pool := newEncoderPool(1)
+	pool := newAgentEncoderPool(JSON_ENCODER, 1)
 	encoder := pool.Borrow()
 	pool.Return(encoder)
 	anotherEncoder := pool.Borrow()
@@ -89,7 +89,7 @@ func TestPoolReuseEncoder(t *testing.T) {
 }
 
 func TestPoolSize(t *testing.T) {
-	pool := newEncoderPool(1)
+	pool := newAgentEncoderPool(JSON_ENCODER, 1)
 	encoder := newJSONEncoder()
 	anotherEncoder := newJSONEncoder()
 

--- a/tracer/encoder_test.go
+++ b/tracer/encoder_test.go
@@ -117,33 +117,16 @@ func TestPoolBorrowCreate(t *testing.T) {
 	assert := assert.New(t)
 
 	// borrow an encoder from the pool
-	// the fact that we're using a JSON_ENCODER is an implementation detail
-	pool := newAgentEncoderPool(JSON_ENCODER, 1)
+	pool, _ := newAgentEncoderPool(MSGPACK_ENCODER, 1)
 	encoder := pool.Borrow()
 	assert.NotNil(encoder)
-}
-
-func TestPoolReturn(t *testing.T) {
-	assert := assert.New(t)
-
-	// an encoder can return in the pool
-	// the fact that we're using a JSON_ENCODER is an implementation detail
-	pool := newAgentEncoderPool(JSON_ENCODER, 1)
-	encoder := newJSONEncoder()
-	pool.pool <- encoder
-	pool.Return(encoder)
-
-	// the encoder is the one we get before
-	returnedEncoder := <-pool.pool
-	assert.Equal(returnedEncoder, encoder)
 }
 
 func TestPoolReuseEncoder(t *testing.T) {
 	assert := assert.New(t)
 
 	// borrow, return and borrow again an encoder from the pool
-	// the fact that we're using a JSON_ENCODER is an implementation detail
-	pool := newAgentEncoderPool(JSON_ENCODER, 1)
+	pool, _ := newAgentEncoderPool(MSGPACK_ENCODER, 1)
 	encoder := pool.Borrow()
 	pool.Return(encoder)
 	anotherEncoder := pool.Borrow()
@@ -151,13 +134,26 @@ func TestPoolReuseEncoder(t *testing.T) {
 }
 
 func TestPoolSize(t *testing.T) {
-	// the fact that we're using a JSON_ENCODER is an implementation detail
-	pool := newAgentEncoderPool(JSON_ENCODER, 1)
-	encoder := newJSONEncoder()
-	anotherEncoder := newJSONEncoder()
+	pool, _ := newAgentEncoderPool(MSGPACK_ENCODER, 1)
+	encoder := newMsgpackEncoder()
+	anotherEncoder := newMsgpackEncoder()
 
 	// put two encoders in the pool with a maximum size of 1
 	// doesn't hang the caller
 	pool.Return(encoder)
 	pool.Return(anotherEncoder)
+}
+
+func TestPoolReturn(t *testing.T) {
+	assert := assert.New(t)
+
+	// an encoder can return in the pool
+	pool, _ := newAgentEncoderPool(MSGPACK_ENCODER, 5)
+	encoder := newMsgpackEncoder()
+	pool.pool <- encoder
+	pool.Return(encoder)
+
+	// the encoder is the one we get before
+	returnedEncoder := <-pool.pool
+	assert.Equal(returnedEncoder, encoder)
 }

--- a/tracer/encoder_test.go
+++ b/tracer/encoder_test.go
@@ -8,6 +8,22 @@ import (
 	"github.com/ugorji/go/codec"
 )
 
+func TestEncoderContentType(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		encoder     Encoder
+		contentType string
+	}{
+		{newJSONEncoder(), "application/json"},
+		{newMsgpackEncoder(), "application/msgpack"},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(tc.contentType, tc.encoder.ContentType())
+	}
+}
+
 func TestJSONEncoding(t *testing.T) {
 	assert := assert.New(t)
 
@@ -29,7 +45,7 @@ func TestJSONEncoding(t *testing.T) {
 
 		// decode to check the right encoding
 		var traces [][]*Span
-		dec := json.NewDecoder(encoder.b)
+		dec := json.NewDecoder(encoder.buffer)
 		err = dec.Decode(&traces)
 		assert.Nil(err)
 		assert.Len(traces, tc.traces)

--- a/tracer/encoder_test.go
+++ b/tracer/encoder_test.go
@@ -1,63 +1,107 @@
 package tracer
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/ugorji/go/codec"
 )
 
-func TestJSONEncoder(t *testing.T) {
+func TestJSONEncoding(t *testing.T) {
 	assert := assert.New(t)
 
-	// create a traces list with a single span
-	var traces [][]*Span
-	var spans []*Span
-	span := NewSpan("pylons.request", "pylons", "/", 0, 0, 0, nil)
-	span.Start = 0
-	spans = append(spans, span)
-	traces = append(traces, spans)
+	testCases := []struct {
+		traces int
+		size   int
+	}{
+		{1, 1},
+		{3, 1},
+		{1, 3},
+		{3, 3},
+	}
 
-	// the encoder must return a valid JSON byte array that ends with a \n
-	want := `[[{"name":"pylons.request","service":"pylons","resource":"/","type":"","start":0,"duration":0,"span_id":0,"trace_id":0,"parent_id":0,"error":0}]]`
-	want += "\n"
+	for _, tc := range testCases {
+		payload := getTestTrace(tc.traces, tc.size)
+		encoder := newJSONEncoder()
+		err := encoder.Encode(payload)
+		assert.Nil(err)
 
-	encoder := newJSONEncoder()
-	err := encoder.Encode(traces)
-	assert.Nil(err)
-	assert.Equal(want, encoder.b.String())
+		// decode to check the right encoding
+		var traces [][]*Span
+		dec := json.NewDecoder(encoder.b)
+		err = dec.Decode(&traces)
+		assert.Nil(err)
+		assert.Len(traces, tc.traces)
+
+		for _, trace := range traces {
+			assert.Len(trace, tc.size)
+			span := trace[0]
+			assert.Equal(uint64(42), span.TraceID)
+			assert.Equal(uint64(52), span.SpanID)
+			assert.Equal(uint64(42), span.ParentID)
+			assert.Equal("web", span.Type)
+			assert.Equal("high.throughput", span.Service)
+			assert.Equal("sending.events", span.Name)
+			assert.Equal("SEND /data", span.Resource)
+			assert.Equal(int64(1481215590883401105), span.Start)
+			assert.Equal(int64(1000000000), span.Duration)
+			assert.Equal("192.168.0.1", span.Meta["http.host"])
+			assert.Equal(float64(41.99), span.Metrics["http.monitor"])
+		}
+	}
 }
 
-func TestJSONRead(t *testing.T) {
+func TestMsgpackEncoding(t *testing.T) {
 	assert := assert.New(t)
 
-	// create a traces list with a single span
-	var traces [][]*Span
-	var spans []*Span
-	span := NewSpan("pylons.request", "pylons", "/", 0, 0, 0, nil)
-	span.Start = 0
-	spans = append(spans, span)
-	traces = append(traces, spans)
+	testCases := []struct {
+		traces int
+		size   int
+	}{
+		{1, 1},
+		{3, 1},
+		{1, 3},
+		{3, 3},
+	}
 
-	// fill the encoder internal buffer
-	encoder := newJSONEncoder()
-	_ = encoder.Encode(traces)
-	expectedSize := encoder.b.Len()
+	for _, tc := range testCases {
+		payload := getTestTrace(tc.traces, tc.size)
+		encoder := newMsgpackEncoder()
+		err := encoder.Encode(payload)
+		assert.Nil(err)
 
-	// the Read function must be used to get the value of the internal buffer
-	buff := make([]byte, expectedSize)
-	_, err := encoder.Read(buff)
+		// decode to check the right encoding
+		var traces [][]*Span
+		var mh codec.MsgpackHandle
+		dec := codec.NewDecoder(encoder.buffer, &mh)
+		err = dec.Decode(&traces)
+		assert.Nil(err)
+		assert.Len(traces, tc.traces)
 
-	// it should match the encoding payload
-	want := `[[{"name":"pylons.request","service":"pylons","resource":"/","type":"","start":0,"duration":0,"span_id":0,"trace_id":0,"parent_id":0,"error":0}]]`
-	want += "\n"
-	assert.Nil(err)
-	assert.Equal(want, string(buff))
+		for _, trace := range traces {
+			assert.Len(trace, tc.size)
+			span := trace[0]
+			assert.Equal(uint64(42), span.TraceID)
+			assert.Equal(uint64(52), span.SpanID)
+			assert.Equal(uint64(42), span.ParentID)
+			assert.Equal("web", span.Type)
+			assert.Equal("high.throughput", span.Service)
+			assert.Equal("sending.events", span.Name)
+			assert.Equal("SEND /data", span.Resource)
+			assert.Equal(int64(1481215590883401105), span.Start)
+			assert.Equal(int64(1000000000), span.Duration)
+			assert.Equal("192.168.0.1", span.Meta["http.host"])
+			assert.Equal(float64(41.99), span.Metrics["http.monitor"])
+		}
+	}
 }
 
 func TestPoolBorrowCreate(t *testing.T) {
 	assert := assert.New(t)
 
 	// borrow an encoder from the pool
+	// the fact that we're using a JSON_ENCODER is an implementation detail
 	pool := newAgentEncoderPool(JSON_ENCODER, 1)
 	encoder := pool.Borrow()
 	assert.NotNil(encoder)
@@ -67,6 +111,7 @@ func TestPoolReturn(t *testing.T) {
 	assert := assert.New(t)
 
 	// an encoder can return in the pool
+	// the fact that we're using a JSON_ENCODER is an implementation detail
 	pool := newAgentEncoderPool(JSON_ENCODER, 1)
 	encoder := newJSONEncoder()
 	pool.pool <- encoder
@@ -81,6 +126,7 @@ func TestPoolReuseEncoder(t *testing.T) {
 	assert := assert.New(t)
 
 	// borrow, return and borrow again an encoder from the pool
+	// the fact that we're using a JSON_ENCODER is an implementation detail
 	pool := newAgentEncoderPool(JSON_ENCODER, 1)
 	encoder := pool.Borrow()
 	pool.Return(encoder)
@@ -89,6 +135,7 @@ func TestPoolReuseEncoder(t *testing.T) {
 }
 
 func TestPoolSize(t *testing.T) {
+	// the fact that we're using a JSON_ENCODER is an implementation detail
 	pool := newAgentEncoderPool(JSON_ENCODER, 1)
 	encoder := newJSONEncoder()
 	anotherEncoder := newJSONEncoder()

--- a/tracer/encoder_test.go
+++ b/tracer/encoder_test.go
@@ -117,7 +117,7 @@ func TestPoolBorrowCreate(t *testing.T) {
 	assert := assert.New(t)
 
 	// borrow an encoder from the pool
-	pool, _ := newAgentEncoderPool(MSGPACK_ENCODER, 1)
+	pool, _ := newEncoderPool(MSGPACK_ENCODER, 1)
 	encoder := pool.Borrow()
 	assert.NotNil(encoder)
 }
@@ -126,7 +126,7 @@ func TestPoolReuseEncoder(t *testing.T) {
 	assert := assert.New(t)
 
 	// borrow, return and borrow again an encoder from the pool
-	pool, _ := newAgentEncoderPool(MSGPACK_ENCODER, 1)
+	pool, _ := newEncoderPool(MSGPACK_ENCODER, 1)
 	encoder := pool.Borrow()
 	pool.Return(encoder)
 	anotherEncoder := pool.Borrow()
@@ -134,7 +134,7 @@ func TestPoolReuseEncoder(t *testing.T) {
 }
 
 func TestPoolSize(t *testing.T) {
-	pool, _ := newAgentEncoderPool(MSGPACK_ENCODER, 1)
+	pool, _ := newEncoderPool(MSGPACK_ENCODER, 1)
 	encoder := newMsgpackEncoder()
 	anotherEncoder := newMsgpackEncoder()
 
@@ -148,7 +148,7 @@ func TestPoolReturn(t *testing.T) {
 	assert := assert.New(t)
 
 	// an encoder can return in the pool
-	pool, _ := newAgentEncoderPool(MSGPACK_ENCODER, 5)
+	pool, _ := newEncoderPool(MSGPACK_ENCODER, 5)
 	encoder := newMsgpackEncoder()
 	pool.pool <- encoder
 	pool.Return(encoder)

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -8,8 +8,7 @@ import (
 )
 
 const (
-	defaultDeliveryURL = "http://localhost:7777/v0.3/traces"
-	flushInterval      = 2 * time.Second
+	flushInterval = 2 * time.Second
 )
 
 // Tracer creates, buffers and submits Spans which are used to time blocks of
@@ -29,7 +28,7 @@ type Tracer struct {
 // NewTracer creates a new Tracer. Most users should use the package's
 // DefaultTracer instance.
 func NewTracer() *Tracer {
-	return NewTracerTransport(newHTTPTransport(defaultDeliveryURL))
+	return NewTracerTransport(newDefaultTransport())
 }
 
 // NewTracerTransport create a new Tracer with the given transport.

--- a/tracer/tracer_test.go
+++ b/tracer/tracer_test.go
@@ -213,8 +213,7 @@ func TestTracerConcurrentMultipleSpans(t *testing.T) {
 // BenchmarkConcurrentTracing tests the performance of spawning a lot of
 // goroutines where each one creates a trace with a parent and a child.
 func BenchmarkConcurrentTracing(b *testing.B) {
-	tracer := NewTracer()
-	tracer.transport = &dummyTransport{pool: newEncoderPool(encoderPoolSize)}
+	tracer, _ := getTestTracer()
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -232,8 +231,7 @@ func BenchmarkConcurrentTracing(b *testing.B) {
 // BenchmarkTracerAddSpans tests the performance of creating and finishing a root
 // span. It should include the encoding overhead.
 func BenchmarkTracerAddSpans(b *testing.B) {
-	tracer := NewTracer()
-	tracer.transport = &dummyTransport{pool: newEncoderPool(encoderPoolSize)}
+	tracer, _ := getTestTracer()
 
 	for n := 0; n < b.N; n++ {
 		span := tracer.NewRootSpan("pylons.request", "pylons", "/")
@@ -243,14 +241,15 @@ func BenchmarkTracerAddSpans(b *testing.B) {
 
 // getTestTracer returns a Tracer with a DummyTransport
 func getTestTracer() (*Tracer, *dummyTransport) {
-	transport := &dummyTransport{pool: newEncoderPool(encoderPoolSize)}
+	pool := newAgentEncoderPool(JSON_ENCODER, encoderPoolSize)
+	transport := &dummyTransport{pool: pool}
 	tracer := NewTracerTransport(transport)
 	return tracer, transport
 }
 
 // Mock Transport with a real Encoder
 type dummyTransport struct {
-	pool   *encoderPool
+	pool   EncoderPool
 	traces [][]*Span
 }
 

--- a/tracer/tracer_test.go
+++ b/tracer/tracer_test.go
@@ -241,7 +241,7 @@ func BenchmarkTracerAddSpans(b *testing.B) {
 
 // getTestTracer returns a Tracer with a DummyTransport
 func getTestTracer() (*Tracer, *dummyTransport) {
-	pool, _ := newAgentEncoderPool(JSON_ENCODER, encoderPoolSize)
+	pool, _ := newEncoderPool(MSGPACK_ENCODER, encoderPoolSize)
 	transport := &dummyTransport{pool: pool}
 	tracer := NewTracerTransport(transport)
 	return tracer, transport
@@ -249,7 +249,7 @@ func getTestTracer() (*Tracer, *dummyTransport) {
 
 // Mock Transport with a real Encoder
 type dummyTransport struct {
-	pool   EncoderPool
+	pool   *encoderPool
 	traces [][]*Span
 }
 

--- a/tracer/tracer_test.go
+++ b/tracer/tracer_test.go
@@ -241,7 +241,7 @@ func BenchmarkTracerAddSpans(b *testing.B) {
 
 // getTestTracer returns a Tracer with a DummyTransport
 func getTestTracer() (*Tracer, *dummyTransport) {
-	pool := newAgentEncoderPool(JSON_ENCODER, encoderPoolSize)
+	pool, _ := newAgentEncoderPool(JSON_ENCODER, encoderPoolSize)
 	transport := &dummyTransport{pool: pool}
 	tracer := NewTracerTransport(transport)
 	return tracer, transport
@@ -265,3 +265,5 @@ func (t *dummyTransport) Traces() [][]*Span {
 	t.traces = nil
 	return traces
 }
+
+func (t *dummyTransport) SetHeader(key, value string) {}

--- a/tracer/transport.go
+++ b/tracer/transport.go
@@ -18,14 +18,17 @@ type Transport interface {
 
 type httpTransport struct {
 	url    string       // the delivery URL
-	pool   *encoderPool // encoding allocates lot of buffers (which might then be resized) so we use a pool so they can be re-used
+	pool   EncoderPool  // encoding allocates lot of buffers (which might then be resized) so we use a pool so they can be re-used
 	client *http.Client // the HTTP client used in the POST
 }
 
 func newHTTPTransport(url string) *httpTransport {
+	// initialize the default EncoderPool
+	pool := newAgentEncoderPool(JSON_ENCODER, encoderPoolSize)
+
 	return &httpTransport{
 		url:  url,
-		pool: newEncoderPool(encoderPoolSize),
+		pool: pool,
 		client: &http.Client{
 			Timeout: defaultHTTPTimeout,
 		},

--- a/tracer/transport.go
+++ b/tracer/transport.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	defaultHTTPTimeout = time.Second // defines the current timeout before giving up with the send process
-	encoderPoolSize    = 5           // how many encoders are available
+	defaultEncoder     = MSGPACK_ENCODER // defines the default encoder used when the Transport is initialized
+	defaultHTTPTimeout = time.Second     // defines the current timeout before giving up with the send process
+	encoderPoolSize    = 5               // how many encoders are available
 )
 
 // Transport is an interface for span submission to the agent.
@@ -24,7 +25,7 @@ type httpTransport struct {
 
 func newHTTPTransport(url string) *httpTransport {
 	// initialize the default EncoderPool
-	pool := newAgentEncoderPool(JSON_ENCODER, encoderPoolSize)
+	pool := newAgentEncoderPool(defaultEncoder, encoderPoolSize)
 
 	return &httpTransport{
 		url:  url,
@@ -52,7 +53,7 @@ func (t *httpTransport) Send(traces [][]*Span) (*http.Response, error) {
 
 	// prepare the client and send the payload
 	req, _ := http.NewRequest("POST", t.url, encoder)
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", "application/msgpack")
 	response, err := t.client.Do(req)
 
 	// if we have an error, return an empty Response to protect against nil pointer dereference

--- a/tracer/transport.go
+++ b/tracer/transport.go
@@ -2,12 +2,16 @@ package tracer
 
 import (
 	"errors"
+	"log"
 	"net/http"
 	"time"
 )
 
 const (
+	defaultDeliveryURL = "http://localhost:7777/v0.3/traces"
+	legacyDeliveryURL  = "http://localhost:7777/v0.2/traces"
 	defaultEncoder     = MSGPACK_ENCODER // defines the default encoder used when the Transport is initialized
+	legacyEncoder      = JSON_ENCODER    // defines the legacy encoder used with earlier agent versions
 	defaultHTTPTimeout = time.Second     // defines the current timeout before giving up with the send process
 	encoderPoolSize    = 5               // how many encoders are available
 )
@@ -15,17 +19,28 @@ const (
 // Transport is an interface for span submission to the agent.
 type Transport interface {
 	Send(spans [][]*Span) (*http.Response, error)
+	SetHeader(key, value string)
+}
+
+// newDefaultTransport return a default transport for this tracing client
+func newDefaultTransport() Transport {
+	return newHTTPTransport(defaultDeliveryURL)
 }
 
 type httpTransport struct {
-	url    string       // the delivery URL
-	pool   EncoderPool  // encoding allocates lot of buffers (which might then be resized) so we use a pool so they can be re-used
-	client *http.Client // the HTTP client used in the POST
+	url               string            // the delivery URL
+	pool              EncoderPool       // encoding allocates lot of buffers (which might then be resized) so we use a pool so they can be re-used
+	client            *http.Client      // the HTTP client used in the POST
+	headers           map[string]string // the Transport headers
+	compatibilityMode bool              // the Agent targets a legacy API for compatibility reasons
 }
 
+// newHTTPTransport returns an httpTransport for the given endpoint
 func newHTTPTransport(url string) *httpTransport {
-	// initialize the default EncoderPool
-	pool := newAgentEncoderPool(defaultEncoder, encoderPoolSize)
+	// initialize the default EncoderPool with Encoder headers
+	pool, contentType := newAgentEncoderPool(defaultEncoder, encoderPoolSize)
+	defaultHeaders := make(map[string]string)
+	defaultHeaders["Content-Type"] = contentType
 
 	return &httpTransport{
 		url:  url,
@@ -33,6 +48,8 @@ func newHTTPTransport(url string) *httpTransport {
 		client: &http.Client{
 			Timeout: defaultHTTPTimeout,
 		},
+		headers:           defaultHeaders,
+		compatibilityMode: false,
 	}
 }
 
@@ -53,7 +70,9 @@ func (t *httpTransport) Send(traces [][]*Span) (*http.Response, error) {
 
 	// prepare the client and send the payload
 	req, _ := http.NewRequest("POST", t.url, encoder)
-	req.Header.Set("Content-Type", "application/msgpack")
+	for header, value := range t.headers {
+		req.Header.Set(header, value)
+	}
 	response, err := t.client.Do(req)
 
 	// if we have an error, return an empty Response to protect against nil pointer dereference
@@ -61,6 +80,36 @@ func (t *httpTransport) Send(traces [][]*Span) (*http.Response, error) {
 		return &http.Response{StatusCode: 0}, err
 	}
 
+	// if we got a 404 we should downgrade the API to a stable version (at most once)
+	if (response.StatusCode == 404 || response.StatusCode == 415) && !t.compatibilityMode {
+		log.Printf("calling the endpoint '%s' but received %d; downgrading the API\n", t.url, response.StatusCode)
+		t.apiDowngrade()
+		return t.Send(traces)
+	}
+
 	response.Body.Close()
 	return response, err
+}
+
+// SetHeader sets the internal header for the httpTransport
+func (t *httpTransport) SetHeader(key, value string) {
+	t.headers[key] = value
+}
+
+// changeEncoder switches the internal encoders pool so that a different API with different
+// format can be targeted, preventing failures because of outdated agents
+func (t *httpTransport) changeEncoder(encoderType int) {
+	pool, contentType := newAgentEncoderPool(encoderType, encoderPoolSize)
+	t.pool = pool
+	t.headers["Content-Type"] = contentType
+}
+
+// apiDowngrade downgrades the used encoder and API level. This method must fallback to a safe
+// encoder and API, so that it will success despite users' configurations. This action
+// ensures that the compatibility mode is activated so that the downgrade will be
+// executed only once.
+func (t *httpTransport) apiDowngrade() {
+	t.compatibilityMode = true
+	t.url = legacyDeliveryURL
+	t.changeEncoder(legacyEncoder)
 }

--- a/tracer/transport.go
+++ b/tracer/transport.go
@@ -29,7 +29,7 @@ func newDefaultTransport() Transport {
 
 type httpTransport struct {
 	url               string            // the delivery URL
-	pool              EncoderPool       // encoding allocates lot of buffers (which might then be resized) so we use a pool so they can be re-used
+	pool              *encoderPool      // encoding allocates lot of buffers (which might then be resized) so we use a pool so they can be re-used
 	client            *http.Client      // the HTTP client used in the POST
 	headers           map[string]string // the Transport headers
 	compatibilityMode bool              // the Agent targets a legacy API for compatibility reasons
@@ -38,7 +38,7 @@ type httpTransport struct {
 // newHTTPTransport returns an httpTransport for the given endpoint
 func newHTTPTransport(url string) *httpTransport {
 	// initialize the default EncoderPool with Encoder headers
-	pool, contentType := newAgentEncoderPool(defaultEncoder, encoderPoolSize)
+	pool, contentType := newEncoderPool(defaultEncoder, encoderPoolSize)
 	defaultHeaders := make(map[string]string)
 	defaultHeaders["Content-Type"] = contentType
 
@@ -99,7 +99,7 @@ func (t *httpTransport) SetHeader(key, value string) {
 // changeEncoder switches the internal encoders pool so that a different API with different
 // format can be targeted, preventing failures because of outdated agents
 func (t *httpTransport) changeEncoder(encoderType int) {
-	pool, contentType := newAgentEncoderPool(encoderType, encoderPoolSize)
+	pool, contentType := newEncoderPool(encoderType, encoderPoolSize)
 	t.pool = pool
 	t.headers["Content-Type"] = contentType
 }

--- a/tracer/transport_test.go
+++ b/tracer/transport_test.go
@@ -2,7 +2,6 @@ package tracer
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -17,8 +16,8 @@ func getTestSpan() *Span {
 		Service:  "high.throughput",
 		Name:     "sending.events",
 		Resource: "SEND /data",
-		Start:    time.Now().UnixNano(),
-		Duration: time.Second.Nanoseconds(),
+		Start:    1481215590883401105,
+		Duration: 1000000000,
 		Meta:     map[string]string{"http.host": "192.168.0.1"},
 		Metrics:  map[string]float64{"http.monitor": 41.99},
 	}

--- a/tracer/transport_test.go
+++ b/tracer/transport_test.go
@@ -58,3 +58,57 @@ func TestTracesAgentIntegration(t *testing.T) {
 		assert.Equal(200, response.StatusCode)
 	}
 }
+
+func TestAPIDowngrade(t *testing.T) {
+	assert := assert.New(t)
+	transport := newHTTPTransport("http://localhost:7777/v0.0/traces")
+
+	// if we get a 404 we should downgrade the API
+	traces := getTestTrace(2, 2)
+	response, err := transport.Send(traces)
+	assert.Nil(err)
+	assert.NotNil(response)
+	assert.Equal(200, response.StatusCode)
+}
+
+func TestEncoderDowngrade(t *testing.T) {
+	assert := assert.New(t)
+	transport := newHTTPTransport("http://localhost:7777/v0.2/traces")
+
+	// if we get a 415 because of a wrong encoder, we should downgrade the encoder
+	traces := getTestTrace(2, 2)
+	response, err := transport.Send(traces)
+	assert.Nil(err)
+	assert.NotNil(response)
+	assert.Equal(200, response.StatusCode)
+}
+
+func TestTransportHeaders(t *testing.T) {
+	assert := assert.New(t)
+	transport := newHTTPTransport(defaultDeliveryURL)
+
+	// msgpack is the default Header
+	contentType := transport.headers["Content-Type"]
+	assert.Equal("application/msgpack", contentType)
+}
+
+func TestTransportEncoderPool(t *testing.T) {
+	assert := assert.New(t)
+	transport := newHTTPTransport(defaultDeliveryURL)
+
+	// MsgpackEncoder is the default encoder of the pool
+	encoder := transport.pool.Borrow()
+	assert.Equal("application/msgpack", encoder.ContentType())
+}
+
+func TestTransportSwitchEncoder(t *testing.T) {
+	assert := assert.New(t)
+	transport := newHTTPTransport(defaultDeliveryURL)
+	transport.changeEncoder(JSON_ENCODER)
+
+	// MsgpackEncoder is the default encoder of the pool
+	encoder := transport.pool.Borrow()
+	contentType := transport.headers["Content-Type"]
+	assert.Equal("application/json", encoder.ContentType())
+	assert.Equal("application/json", contentType)
+}


### PR DESCRIPTION
### What it does

Adds support to the trace-agent API version ``0.3`` with msgpack format. The agent API also support JSON encoding if users want to send their traces manually.

If a 404 is hit, it means that the API is not available and so we have to downgrade the API to a stable version (``jsonEncoder`` with the ``v0.2`` API at the time of writing).

The flow is:

* use ``msgpackEncoder`` by default
* at the first call to the ``traces`` endpoint, read the status code
* if the response is a ``404``, downgrade the API and the encoder and re-try the call with the stable version
* in any other cases, keep the current encoder and API version.

A ``5xx`` or ``4xx`` doesn't mean we should change the encoder because we could have a different problem. Further improvements will come with a stable agent API + documentation.