### PR TITLE
Populate error.type and error.stack tags

### DIFF
--- a/tracer/span.go
+++ b/tracer/span.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"reflect"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
 )
 
 const (
-	errorMsgKey = "error.msg"
+	errorMsgKey   = "error.msg"
+	errorTypeKey  = "error.type"
+	errorStackKey = "error.stack"
 )
 
 // Span represents a computation. Callers must call Finish when a span is
@@ -134,6 +138,9 @@ func (s *Span) SetError(err error) {
 
 	s.Error = 1
 	s.SetMeta(errorMsgKey, err.Error())
+	s.SetMeta(errorTypeKey, reflect.TypeOf(err).String())
+	stack := debug.Stack()
+	s.SetMeta(errorStackKey, string(stack))
 }
 
 // Finish closes this Span (but not its children) providing the duration

--- a/tracer/span_test.go
+++ b/tracer/span_test.go
@@ -59,8 +59,23 @@ func TestSpanError(t *testing.T) {
 	err := errors.New("Something wrong")
 	span.SetError(err)
 	assert.Equal(span.Error, int32(1))
-	assert.Equal(len(span.Meta), 1)
+	assert.Equal(len(span.Meta), 3)
 	assert.Equal(span.Meta["error.msg"], "Something wrong")
+	assert.Equal(span.Meta["error.type"], "*errors.errorString")
+}
+
+func TestSpanError_Typed(t *testing.T) {
+	assert := assert.New(t)
+	tracer := NewTracer()
+	span := tracer.NewRootSpan("pylons.request", "pylons", "/")
+
+	// check the error is set in the default meta
+	err := &boomError{}
+	span.SetError(err)
+	assert.Equal(span.Error, int32(1))
+	assert.Equal(len(span.Meta), 3)
+	assert.Equal(span.Meta["error.msg"], "boom")
+	assert.Equal(span.Meta["error.type"], "*tracer.boomError")
 }
 
 func TestEmptySpan(t *testing.T) {
@@ -134,3 +149,7 @@ func TestSpanContext(t *testing.T) {
 	assert.Equal(t, s2.SpanID, span.SpanID)
 
 }
+
+type boomError struct{}
+
+func (e *boomError) Error() string { return "boom" }


### PR DESCRIPTION
For parity with the [Ruby client](https://github.com/DataDog/dd-trace-rb/blob/master/lib/ddtrace/span.rb#L67-L73), this will set the `error.type` and `error.stack` tags.

![](http://ejholmes.github.com.s3.amazonaws.com/HRPwVCKaafE0seuUD4kQUBjSwiL1hVlGJG.png)

I just went with [debug.Stack](https://golang.org/pkg/runtime/debug/#Stack) for simplicity. The downside is that this includes some lines from within this package. It could be changed to use [runtime.Callers](https://golang.org/pkg/runtime/#Callers) to ignore the first part of the stack, like [honeybadger does](https://github.com/honeybadger-io/honeybadger-go/blob/master/error.go#L55)