### PR TITLE
Use string for context key

### DIFF
--- a/tracer/context.go
+++ b/tracer/context.go
@@ -6,7 +6,7 @@ import (
 
 type datadogContextKey struct{}
 
-var spanKey = datadogContextKey{}
+var spanKey = "datadog_trace_span"
 
 // ContextWithSpan will return a new context that includes the given span.
 // DEPRECATED: use span.Context(ctx) instead.

--- a/tracer/contrib/gin-gonic/gintrace/gintrace_test.go
+++ b/tracer/contrib/gin-gonic/gintrace/gintrace_test.go
@@ -19,6 +19,26 @@ func init() {
 	gin.SetMode(gin.ReleaseMode) // silence annoying log msgs
 }
 
+func TestChildSpan(t *testing.T) {
+	assert := assert.New(t)
+	testTracer, _ := getTestTracer()
+
+	middleware := newMiddleware("foobar", testTracer)
+
+	router := gin.New()
+	router.Use(middleware.Handle)
+	router.GET("/user/:id", func(c *gin.Context) {
+		span, ok := tracer.SpanFromContext(c)
+		assert.True(ok)
+		assert.NotNil(span)
+	})
+
+	r := httptest.NewRequest("GET", "/user/123", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+}
+
 func TestTrace200(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()


### PR DESCRIPTION
This PR changes `tracer.Context.spanKey` back to a string and unbreaks #26.