### PR TITLE
[span] adding a default 'go' service is none is given

### DIFF
--- a/tracer/span.go
+++ b/tracer/span.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	errorMsgKey   = "error.msg"
-	errorTypeKey  = "error.type"
-	errorStackKey = "error.stack"
+	errorMsgKey    = "error.msg"
+	errorTypeKey   = "error.type"
+	errorStackKey  = "error.stack"
+	defaultService = "go"
 )
 
 // Span represents a computation. Callers must call Finish when a span is

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -153,6 +153,9 @@ func (t *Tracer) NewChildSpanFromContext(name string, ctx context.Context) *Span
 // record queues the finished span for further processing.
 func (t *Tracer) record(span *Span) {
 	if t.enabled && span.Sampled {
+		if span.Service == "" {
+			span.Service = defaultService
+		}
 		t.buffer.Push(span)
 	}
 }

--- a/tracer/tracer_test.go
+++ b/tracer/tracer_test.go
@@ -210,6 +210,21 @@ func TestTracerConcurrentMultipleSpans(t *testing.T) {
 	assert.Len(traces[1], 2)
 }
 
+func TestTracerSpanDefaultService(t *testing.T) {
+	assert := assert.New(t)
+	tracer, transport := getTestTracer()
+
+	trace := tracer.NewRootSpan("http.serve", "", "/")
+	trace.Finish()
+
+	tracer.FlushTraces()
+	traces := transport.Traces()
+	assert.Len(traces, 1)
+	assert.Len(traces[0], 1)
+	span := traces[0][0]
+	assert.Equal("go", span.Service)
+}
+
 func TestTracerServices(t *testing.T) {
 	assert := assert.New(t)
 	tracer, transport := getTestTracer()


### PR DESCRIPTION
It's technically possible to create a span without a service, and this is valid, it should inherit the service from its parent in that case. However root spans have no parent so it's impossible to infer/guess a valid name. This patch provides a default value (`go`) in that case.

Our go implementation (compared to our Python and Ruby) really makes it harder to have no service as it has explicit CreateRoot and CreateChild calls. Still, it's probably good to have similar behaviours in all languages.