### PR TITLE
Allow custom SpansBuffer max size

### DIFF
--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -100,6 +100,14 @@ func (t *Tracer) SetSampleRate(sampleRate float64) {
 	}
 }
 
+func (t *Tracer) SetSpansBufferSize(maxSize int) {
+	if maxSize > 0 {
+		t.buffer = newSpansBuffer(maxSize)
+	} else {
+		log.Printf("tracer.SetSpansBufferSize max size must be greater than 0, current: %d", t.buffer.maxSize)
+	}
+}
+
 // SetServiceInfo update the application and application type for the given
 // service.
 func (t *Tracer) SetServiceInfo(name, app, appType string) {

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -100,6 +100,10 @@ func (t *Tracer) SetSampleRate(sampleRate float64) {
 	}
 }
 
+// SetSpansBufferSize sets a buffer size for the tracer
+// this abandons the old buffer so this should be called in an init function
+// otherwise already recorded spans will be lost
+// maxSize must be greater than 0
 func (t *Tracer) SetSpansBufferSize(maxSize int) {
 	if maxSize > 0 {
 		t.buffer = newSpansBuffer(maxSize)

--- a/tracer/tracer_test.go
+++ b/tracer/tracer_test.go
@@ -149,6 +149,23 @@ func TestTracerEdgeSampler(t *testing.T) {
 	assert.Equal(count, tracer1.buffer.Len())
 }
 
+func TestTracerBuffer(t *testing.T) {
+	assert := assert.New(t)
+
+	bufferSize := 1000
+	incorrectBufferSize := -1
+	defaultBufferSize := 10000
+
+	tracer0 := NewTracer()
+	tracer0.SetSpansBufferSize(bufferSize)
+
+	tracer1 := NewTracer()
+	tracer1.SetSpansBufferSize(incorrectBufferSize)
+
+	assert.Equal(bufferSize, tracer0.buffer.maxSize)
+	assert.Equal(defaultBufferSize, tracer1.buffer.maxSize)
+}
+
 func TestTracerConcurrent(t *testing.T) {
 	assert := assert.New(t)
 	tracer, transport := getTestTracer()


### PR DESCRIPTION
Fixes #33 

This allows a custom span buffer size to be set. Following the convention already set with the custom sampler logic; all that was added was `SetSpansBufferSize` method which creates a new buffer of size `maxSize int` and replaces the old buffer in the current tracer with the new one. This adds the new functionality of being able to create custom buffers sizes while not modifying any of the existing API's making it a safe update for anyone using this library.

Let me know if you have any suggestions/comments/concerns.