### PR TITLE
Add http.url to mux integration

### DIFF
--- a/tracer/contrib/gorilla/muxtrace/muxtrace.go
+++ b/tracer/contrib/gorilla/muxtrace/muxtrace.go
@@ -56,26 +56,22 @@ func (m *MuxTracer) HandleFunc(router *mux.Router, pattern string, handler http.
 
 // span will create a span for the given request.
 func (m *MuxTracer) trace(req *http.Request) (*http.Request, *tracer.Span) {
-	resource := getResource(req)
-
-	span := m.tracer.NewRootSpan("mux.request", m.service, resource)
-	span.Type = ext.HTTPType
-	span.SetMeta(ext.HTTPMethod, req.Method)
-
-	// patch the span onto the request context.
-	treq := SetRequestSpan(req, span)
-	return treq, span
-}
-
-// getResource returns a resource name for the given http requests. Must be
-// called in the scope of a mux handler.
-func getResource(req *http.Request) string {
 	route := mux.CurrentRoute(req)
 	path, err := route.GetPathTemplate()
 	if err != nil {
 		path = "unknown" // FIXME[matt] when will this happen?
 	}
-	return req.Method + " " + path
+
+	resource := req.Method + " " + path
+
+	span := m.tracer.NewRootSpan("mux.request", m.service, resource)
+	span.Type = ext.HTTPType
+	span.SetMeta(ext.HTTPMethod, req.Method)
+	span.SetMeta(ext.HTTPURL, path)
+
+	// patch the span onto the request context.
+	treq := SetRequestSpan(req, span)
+	return treq, span
 }
 
 // tracedResponseWriter is a small wrapper around an http response writer that will

--- a/tracer/contrib/gorilla/muxtrace/muxtrace.go
+++ b/tracer/contrib/gorilla/muxtrace/muxtrace.go
@@ -59,7 +59,8 @@ func (m *MuxTracer) trace(req *http.Request) (*http.Request, *tracer.Span) {
 	route := mux.CurrentRoute(req)
 	path, err := route.GetPathTemplate()
 	if err != nil {
-		path = "unknown" // FIXME[matt] when will this happen?
+		// when route doesn't define a path
+		path = "unknown"
 	}
 
 	resource := req.Method + " " + path

--- a/tracer/contrib/gorilla/muxtrace/muxtrace_test.go
+++ b/tracer/contrib/gorilla/muxtrace/muxtrace_test.go
@@ -63,6 +63,7 @@ func TestMuxTracerSubrequest(t *testing.T) {
 		assert.Equal(s.Resource, "GET "+url)
 		assert.Equal(s.GetMeta("http.status_code"), "200")
 		assert.Equal(s.GetMeta("http.method"), "GET")
+		assert.Equal(s.GetMeta("http.url"), url)
 		assert.Equal(s.Error, int32(0))
 	}
 }
@@ -74,7 +75,8 @@ func TestMuxTracer200(t *testing.T) {
 	tracer, transport, router := setup(t)
 
 	// Send and verify a 200 request
-	req := httptest.NewRequest("GET", "/200", nil)
+	url := "/200"
+	req := httptest.NewRequest("GET", url, nil)
 	writer := httptest.NewRecorder()
 	router.ServeHTTP(writer, req)
 	assert.Equal(writer.Code, 200)
@@ -90,9 +92,10 @@ func TestMuxTracer200(t *testing.T) {
 	s := spans[0]
 	assert.Equal(s.Name, "mux.request")
 	assert.Equal(s.Service, "my-service")
-	assert.Equal(s.Resource, "GET /200")
+	assert.Equal(s.Resource, "GET "+url)
 	assert.Equal(s.GetMeta("http.status_code"), "200")
 	assert.Equal(s.GetMeta("http.method"), "GET")
+	assert.Equal(s.GetMeta("http.url"), url)
 	assert.Equal(s.Error, int32(0))
 }
 
@@ -103,7 +106,8 @@ func TestMuxTracer500(t *testing.T) {
 	tracer, transport, router := setup(t)
 
 	// SEnd and verify a 200 request
-	req := httptest.NewRequest("GET", "/500", nil)
+	url := "/500"
+	req := httptest.NewRequest("GET", url, nil)
 	writer := httptest.NewRecorder()
 	router.ServeHTTP(writer, req)
 	assert.Equal(writer.Code, 500)
@@ -119,8 +123,10 @@ func TestMuxTracer500(t *testing.T) {
 	s := spans[0]
 	assert.Equal(s.Name, "mux.request")
 	assert.Equal(s.Service, "my-service")
-	assert.Equal(s.Resource, "GET /500")
+	assert.Equal(s.Resource, "GET "+url)
 	assert.Equal(s.GetMeta("http.status_code"), "500")
+	assert.Equal(s.GetMeta("http.method"), "GET")
+	assert.Equal(s.GetMeta("http.url"), url)
 	assert.Equal(s.Error, int32(1))
 }
 


### PR DESCRIPTION
- add missing `http.url` meta to the mux integration
- update tests accordingly