### PR TITLE
[core] drop legacy port 7777 in favor of 8126

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ dependencies:
     - rm -Rf /home/ubuntu/.go_workspace/src/*
     - rake lint:install
     # run the agent
-    - docker run -d -e DD_API_KEY=invalid_key_but_this_is_fine -e DD_BIND_HOST=0.0.0.0 -e DD_APM_ENABLED=true -p 127.0.0.1:8126:8126 -p 127.0.0.1:7777:7777 datadog/docker-dd-agent
+    - docker run -d -e DD_API_KEY=invalid_key_but_this_is_fine -e DD_BIND_HOST=0.0.0.0 -e DD_APM_ENABLED=true -p 127.0.0.1:8126:8126 datadog/docker-dd-agent
 
   override:
     # put the package in the right $GOPATH

--- a/tracer/transport.go
+++ b/tracer/transport.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	defaultHostname    = "localhost"
-	defaultPort        = "7777"
+	defaultPort        = "8126"
 	defaultEncoder     = MSGPACK_ENCODER // defines the default encoder used when the Transport is initialized
 	legacyEncoder      = JSON_ENCODER    // defines the legacy encoder used with earlier agent versions
 	defaultHTTPTimeout = time.Second     // defines the current timeout before giving up with the send process
@@ -27,7 +27,7 @@ type Transport interface {
 // NewTransport returns a new Transport implementation that sends traces to a
 // trace agent running on the given hostname and port. If the zero values for
 // hostname and port are provided, the default values will be used ("localhost"
-// for hostname, and "7777" for port).
+// for hostname, and "8126" for port).
 //
 // In general, using this method is only necessary if you have a trace agent
 // running on a non-default port or if it's located on another machine.

--- a/tracer/transport_test.go
+++ b/tracer/transport_test.go
@@ -69,7 +69,7 @@ func TestTracesAgentIntegration(t *testing.T) {
 func TestAPIDowngrade(t *testing.T) {
 	assert := assert.New(t)
 	transport := newHTTPTransport(defaultHostname, defaultPort)
-	transport.traceURL = "http://localhost:7777/v0.0/traces"
+	transport.traceURL = "http://localhost:8126/v0.0/traces"
 
 	// if we get a 404 we should downgrade the API
 	traces := getTestTrace(2, 2)
@@ -82,7 +82,7 @@ func TestAPIDowngrade(t *testing.T) {
 func TestEncoderDowngrade(t *testing.T) {
 	assert := assert.New(t)
 	transport := newHTTPTransport(defaultHostname, defaultPort)
-	transport.traceURL = "http://localhost:7777/v0.2/traces"
+	transport.traceURL = "http://localhost:8126/v0.2/traces"
 
 	// if we get a 415 because of a wrong encoder, we should downgrade the encoder
 	traces := getTestTrace(2, 2)
@@ -107,7 +107,7 @@ func TestTransportServicesDowngrade_0_0(t *testing.T) {
 	assert := assert.New(t)
 
 	transport := newHTTPTransport(defaultHostname, defaultPort)
-	transport.serviceURL = "http://localhost:7777/v0.0/services"
+	transport.serviceURL = "http://localhost:8126/v0.0/services"
 
 	response, err := transport.SendServices(getTestServices())
 	assert.Nil(err)
@@ -119,7 +119,7 @@ func TestTransportServicesDowngrade_0_2(t *testing.T) {
 	assert := assert.New(t)
 
 	transport := newHTTPTransport(defaultHostname, defaultPort)
-	transport.serviceURL = "http://localhost:7777/v0.2/services"
+	transport.serviceURL = "http://localhost:8126/v0.2/services"
 
 	response, err := transport.SendServices(getTestServices())
 	assert.Nil(err)


### PR DESCRIPTION
### What it does

**Breaking change**

The tracing client uses the port ``8126``. Using a Trace Agent older than version ``5.11.0`` will **not** work with the current version of the client.