### PR TITLE
Raphael/go redis

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,10 +19,6 @@ dependencies:
     - rake lint:install
     # run the agent
     - docker-compose up -d | cat
-    - redis-cli ping
-    - redis-cli
-    - set mykey somevalue
-    - redis-cli shutdown
 
   override:
     # put the package in the right $GOPATH

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ dependencies:
     - rake lint:install
     # run the agent
     - docker run -d -e DD_API_KEY=invalid_key_but_this_is_fine -e DD_BIND_HOST=0.0.0.0 -e DD_APM_ENABLED=true -p 127.0.0.1:8126:8126 datadog/docker-dd-agent
-    - docker run --name redis-client -d redis -p 127.0.0.1:6379:6379
+    - docker run --name redis-client -d redis -p 6379:6379
     - redis-cli ping
     - redis-cli
     - set mykey somevalue

--- a/circle.yml
+++ b/circle.yml
@@ -19,6 +19,7 @@ dependencies:
     - rake lint:install
     # run the agent
     - docker run -d -e DD_API_KEY=invalid_key_but_this_is_fine -e DD_BIND_HOST=0.0.0.0 -e DD_APM_ENABLED=true -p 127.0.0.1:8126:8126 datadog/docker-dd-agent
+    - docker run --name some-redis -d redis
 
   override:
     # put the package in the right $GOPATH

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ dependencies:
     - rake lint:install
     # run the agent
     - docker run -d -e DD_API_KEY=invalid_key_but_this_is_fine -e DD_BIND_HOST=0.0.0.0 -e DD_APM_ENABLED=true -p 127.0.0.1:8126:8126 datadog/docker-dd-agent
-    - docker run --name some-redis -d redis
+    - docker run --name some-redis -d redis -p 127.0.0.1:56379:6379
 
   override:
     # put the package in the right $GOPATH

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ dependencies:
     - rake lint:install
     # run the agent
     - docker run -d -e DD_API_KEY=invalid_key_but_this_is_fine -e DD_BIND_HOST=0.0.0.0 -e DD_APM_ENABLED=true -p 127.0.0.1:8126:8126 datadog/docker-dd-agent
-    - docker run --name redis-client -d redis -p 127.0.0.1:56379:6379
+    - docker run --name redis-client -d redis -p 127.0.0.1:6379
     - redis-cli ping
     - redis-cli
     - set mykey somevalue

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,11 @@ dependencies:
     - rake lint:install
     # run the agent
     - docker run -d -e DD_API_KEY=invalid_key_but_this_is_fine -e DD_BIND_HOST=0.0.0.0 -e DD_APM_ENABLED=true -p 127.0.0.1:8126:8126 datadog/docker-dd-agent
-    - docker run --name some-redis -d redis -p 127.0.0.1:56379:6379
+    - docker run --name redis-client -d redis -p 127.0.0.1:56379:6379
+    - redis-cli ping
+    - redis-cli
+    - set mykey somevalue
+    - redis-cli shutdown
 
   override:
     # put the package in the right $GOPATH

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ dependencies:
     - rake lint:install
     # run the agent
     - docker run -d -e DD_API_KEY=invalid_key_but_this_is_fine -e DD_BIND_HOST=0.0.0.0 -e DD_APM_ENABLED=true -p 127.0.0.1:8126:8126 datadog/docker-dd-agent
-    - docker run --name redis-client -d redis -p 127.0.0.1:6379
+    - docker run --name redis-client -d redis -p 127.0.0.1:6379:6379
     - redis-cli ping
     - redis-cli
     - set mykey somevalue

--- a/circle.yml
+++ b/circle.yml
@@ -18,8 +18,7 @@ dependencies:
     - rm -Rf /home/ubuntu/.go_workspace/src/*
     - rake lint:install
     # run the agent
-    - docker run -d -e DD_API_KEY=invalid_key_but_this_is_fine -e DD_BIND_HOST=0.0.0.0 -e DD_APM_ENABLED=true -p 127.0.0.1:8126:8126 datadog/docker-dd-agent
-    - docker run --name redis-client -d redis -p 6379:6379
+    - docker-compose up -d | cat
     - redis-cli ping
     - redis-cli
     - set mykey somevalue

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ redis:
 ddagent:
         image: datadog/docker-dd-agent
         environment:
-                - DD_APM_ENABLED=true
                 - DD_BIND_HOST=0.0.0.0
                 - DD_API_KEY=invalid_key_but_this_is_fine
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ redis:
 ddagent:
         image: datadog/docker-dd-agent
         environment:
+                - DD_APM_ENABLED=true
                 - DD_BIND_HOST=0.0.0.0
                 - DD_API_KEY=invalid_key_but_this_is_fine
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+# File for develipment/ testing purposes
+redis:
+        image: redis:3.2
+        ports:
+                - "127.0.0.1:6379:6379"
+ddagent:
+        image: datadog/docker-dd-agent
+        environment:
+                - DD_APM_ENABLED=true
+                - DD_BIND_HOST=0.0.0.0
+                - DD_API_KEY=invalid_key_but_this_is_fine
+        ports:
+                - "127.0.0.1:8126:8126"

--- a/tracer/contrib/go-redis/example_test.go
+++ b/tracer/contrib/go-redis/example_test.go
@@ -1,0 +1,67 @@
+package goredistrace_test
+
+import (
+	"context"
+	"github.com/DataDog/dd-trace-go/tracer"
+	"github.com/DataDog/dd-trace-go/tracer/contrib/go-redis"
+	redis "github.com/go-redis/redis"
+	"time"
+)
+
+// To start tracing Redis commands, use the NewTracedClient function to create a traced Redis clienty,
+// passing in a service name of choice.
+func Example() {
+	opts := &redis.Options{
+		Addr:     "127.0.0.1:6379",
+		Password: "", // no password set
+		DB:       0,  // use default db
+	}
+	c := goredistrace.NewTracedClient(opts, tracer.DefaultTracer, "my-redis-backend")
+	// Emit spans per command by using your Redis connection as usual
+	c.Set("test_key", "test_value", 0)
+
+	// Use a context to pass information down the call chain
+	root := tracer.NewRootSpan("parent.request", "web", "/home")
+	ctx := root.Context(context.Background())
+
+	// When set with a context, the traced client will emit a span inheriting from 'parent.request'
+	c.SetContext(ctx)
+	c.Set("food", "cheese", 0)
+	root.Finish()
+}
+
+// You can also trace Redis Pipelines
+func Example_pipeline() {
+	opts := &redis.Options{
+		Addr:     "127.0.0.1:6379",
+		Password: "", // no password set
+		DB:       0,  // use default db
+	}
+	c := goredistrace.NewTracedClient(opts, tracer.DefaultTracer, "my-redis-backend")
+	// p is a TracedPipeline
+	pipe := c.Pipeline()
+	pipe.Incr("pipeline_counter")
+	pipe.Expire("pipeline_counter", time.Hour)
+
+	pipe.Exec()
+}
+
+func ExampleNewTracedClient() {
+	opts := &redis.Options{
+		Addr:     "127.0.0.1:6379",
+		Password: "", // no password set
+		DB:       0,  // use default db
+	}
+	c := goredistrace.NewTracedClient(opts, tracer.DefaultTracer, "my-redis-backend")
+	// Emit spans per command by using your Redis connection as usual
+	c.Set("test_key", "test_value", 0)
+
+	// Use a context to pass information down the call chain
+	root := tracer.NewRootSpan("parent.request", "web", "/home")
+	ctx := root.Context(context.Background())
+
+	// When set with a context, the traced client will emit a span inheriting from 'parent.request'
+	c.SetContext(ctx)
+	c.Set("food", "cheese", 0)
+	root.Finish()
+}

--- a/tracer/contrib/go-redis/example_test.go
+++ b/tracer/contrib/go-redis/example_test.go
@@ -52,7 +52,7 @@ func Example_pipeline() {
 		DB:       0,  // use default db
 	}
 	c := goredistrace.NewTracedClient(opts, tracer.DefaultTracer, "my-redis-backend")
-	// p is a TracedPipeline
+	// p is a TracedPipeliner
 	pipe := c.Pipeline()
 	pipe.Incr("pipeline_counter")
 	pipe.Expire("pipeline_counter", time.Hour)

--- a/tracer/contrib/go-redis/example_test.go
+++ b/tracer/contrib/go-redis/example_test.go
@@ -40,7 +40,7 @@ func Example() {
 	r.GET("/user/settings/:id", func(ctx *gin.Context) {
 		// create a span that is a child of your http request
 		client.SetContext(ctx)
-		client.Get(fmt.Sprintf("cached_user_details_%d", ctx.Param("id")))
+		client.Get(fmt.Sprintf("cached_user_details_%s", ctx.Param("id")))
 	})
 }
 

--- a/tracer/contrib/go-redis/example_test.go
+++ b/tracer/contrib/go-redis/example_test.go
@@ -2,6 +2,7 @@ package goredistrace_test
 
 import (
 	"context"
+	"fmt"
 	"github.com/DataDog/dd-trace-go/tracer"
 	"github.com/DataDog/dd-trace-go/tracer/contrib/gin-gonic/gintrace"
 	"github.com/DataDog/dd-trace-go/tracer/contrib/go-redis"
@@ -39,7 +40,7 @@ func Example() {
 	r.GET("/user/settings/:id", func(ctx *gin.Context) {
 		// create a span that is a child of your http request
 		client.SetContext(ctx)
-		client.Get("cached_user_details", ctx.Param("id"))
+		client.Get(fmt.Sprintf("cached_user_details_%d", ctx.Param("id")))
 	})
 }
 

--- a/tracer/contrib/go-redis/tracedredis.go
+++ b/tracer/contrib/go-redis/tracedredis.go
@@ -1,6 +1,7 @@
 package tracedredis
 
 import (
+	"bytes"
 	"context"
 	"github.com/DataDog/dd-trace-go/tracer"
 	"github.com/DataDog/dd-trace-go/tracer/ext"
@@ -9,6 +10,28 @@ import (
 	"strings"
 )
 
+// TracedClient is used to trace requests to a redis server.
+type TracedClient struct {
+	*redis.Client
+	traceParams TraceParams
+}
+
+// TracedPipeline is used to trace pipelines with a redis server.
+type TracedPipeline struct {
+	*redis.Pipeline
+	traceParams TraceParams
+}
+
+// TraceParams contains the tracer and params that we want to trace.
+type TraceParams struct {
+	host    string
+	port    string
+	db      string
+	service string
+	tracer  *tracer.Tracer
+}
+
+// NewTracedClient needs to be called instead of NewClient to trace the calls.
 func NewTracedClient(opt *redis.Options, t *tracer.Tracer, service string) *TracedClient {
 	var host, port string
 	addr := strings.Split(opt.Addr, ":")
@@ -20,93 +43,79 @@ func NewTracedClient(opt *redis.Options, t *tracer.Tracer, service string) *Trac
 	t.SetServiceInfo(service, "redis", ext.AppTypeDB)
 	tc := &TracedClient{
 		client,
-		host,
-		port,
-		db,
-		service,
-		t,
+		TraceParams{
+			host,
+			port,
+			db,
+			service,
+			t},
 	}
 
 	tc.Client.WrapProcess(createWrapperFromClient(tc))
 	return tc
 }
 
-type TracedClient struct {
-	*redis.Client
-	host    string
-	port    string
-	db      string
-	service string
-	tracer  *tracer.Tracer
+// Pipeline overwrites redis.Pipeline function to create a TracedPipeline.
+func (c *TracedClient) Pipeline() *TracedPipeline {
+	return &TracedPipeline{
+		c.Client.Pipeline(),
+		c.traceParams,
+	}
 }
 
+// ExecWithContext executes traced Exec call with a particular context.
+func (c *TracedPipeline) ExecWithContext(ctx context.Context) ([]redis.Cmder, error) {
+	span := c.traceParams.tracer.NewChildSpanFromContext("redis.command", ctx)
+	span.Service = c.traceParams.service
+
+	span.SetMeta("out.host", c.traceParams.host)
+	span.SetMeta("out.port", c.traceParams.port)
+	span.SetMeta("out.db", c.traceParams.db)
+
+	cmds, err := c.Pipeline.Exec()
+	if err != nil {
+		span.SetError(err)
+	}
+	span.Resource = String(cmds)
+	span.SetMeta("redis.pipeline_length", strconv.Itoa(len(cmds)))
+	span.Finish()
+	return cmds, err
+}
+
+// Exec overwrites redis.Exec so that calls made via a TracedClient are traced.
+func (c *TracedPipeline) Exec() ([]redis.Cmder, error) {
+	span := c.traceParams.tracer.NewRootSpan("redis.command", c.traceParams.service, "redis")
+
+	span.SetMeta("out.host", c.traceParams.host)
+	span.SetMeta("out.port", c.traceParams.port)
+	span.SetMeta("out.db", c.traceParams.db)
+
+	cmds, err := c.Pipeline.Exec()
+	if err != nil {
+		span.SetError(err)
+	}
+	span.Resource = String(cmds)
+	span.SetMeta("redis.pipeline_length", strconv.Itoa(len(cmds)))
+	span.Finish()
+	return cmds, err
+}
+
+// String is a used to return a string of all the comands, one comand per line.
+func String(cmds []redis.Cmder) string {
+	var b bytes.Buffer
+	for _, cmd := range cmds {
+		b.WriteString(cmd.String())
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// SetContext allows to set a context to a TracedClient.
 func (c *TracedClient) SetContext(ctx context.Context) {
 	c.Client = c.Client.WithContext(ctx)
 }
 
-type TracedPipeline struct {
-	*redis.Pipeline
-	host    string
-	port    string
-	db      string
-	service string
-	tracer  *tracer.Tracer
-}
-
-func (c *TracedClient) Pipeline() *TracedPipeline {
-	return &TracedPipeline{
-		c.Client.Pipeline(),
-		c.host,
-		c.port,
-		c.db,
-		c.service,
-		c.tracer,
-	}
-}
-
-func (c *TracedPipeline) ExecWithContext(ctx context.Context) ([]redis.Cmder, error) {
-	span := c.tracer.NewChildSpanFromContext("redis.command", ctx)
-	span.Service = c.service
-
-	span.SetMeta("out.host", c.host)
-	span.SetMeta("out.port", c.port)
-	span.SetMeta("out.db", c.db)
-
-	cmds, err := c.Pipeline.Exec()
-	if err != nil {
-		span.SetError(err)
-	}
-	span.Resource = String(cmds)
-	span.SetMeta("redis.pipeline_length", strconv.Itoa(len(cmds)))
-	span.Finish()
-	return cmds, err
-}
-
-func (c *TracedPipeline) Exec() ([]redis.Cmder, error) {
-	span := c.tracer.NewRootSpan("redis.command", c.service, "redis")
-
-	span.SetMeta("out.host", c.host)
-	span.SetMeta("out.port", c.port)
-	span.SetMeta("out.db", c.db)
-
-	cmds, err := c.Pipeline.Exec()
-	if err != nil {
-		span.SetError(err)
-	}
-	span.Resource = String(cmds)
-	span.SetMeta("redis.pipeline_length", strconv.Itoa(len(cmds)))
-	span.Finish()
-	return cmds, err
-}
-
-func String(cmds []redis.Cmder) string {
-	cmd_string := ""
-	for _, cmd := range cmds {
-		cmd_string += cmd.String() + "\n"
-	}
-	return cmd_string
-}
-
+// createWrapperFromClient wraps tracing into redis.Process().
 func createWrapperFromClient(tc *TracedClient) func(oldProcess func(cmd redis.Cmder) error) func(cmd redis.Cmder) error {
 	return func(oldProcess func(cmd redis.Cmder) error) func(cmd redis.Cmder) error {
 		return func(cmd redis.Cmder) error {
@@ -115,16 +124,16 @@ func createWrapperFromClient(tc *TracedClient) func(oldProcess func(cmd redis.Cm
 			var resource string
 			resource = strings.Split(cmd.String(), " ")[0]
 			args_length := len(strings.Split(cmd.String(), " ")) - 1
-			span := tc.tracer.NewChildSpanFromContext("redis.command", ctx)
+			span := tc.traceParams.tracer.NewChildSpanFromContext("redis.command", ctx)
 
-			span.Service = tc.service
+			span.Service = tc.traceParams.service
 			span.Resource = resource
 
 			span.SetMeta("redis.raw_command", cmd.String())
 			span.SetMeta("redis.args_length", strconv.Itoa(args_length))
-			span.SetMeta("out.host", tc.host)
-			span.SetMeta("out.port", tc.port)
-			span.SetMeta("out.db", tc.db)
+			span.SetMeta("out.host", tc.traceParams.host)
+			span.SetMeta("out.port", tc.traceParams.port)
+			span.SetMeta("out.db", tc.traceParams.db)
 
 			err := oldProcess(cmd)
 			if err != nil {

--- a/tracer/contrib/go-redis/tracedredis.go
+++ b/tracer/contrib/go-redis/tracedredis.go
@@ -3,6 +3,7 @@ package tracedredis
 import (
 	"context"
 	"github.com/DataDog/dd-trace-go/tracer"
+	"github.com/DataDog/dd-trace-go/tracer/ext"
 	"github.com/go-redis/redis"
 	"strconv"
 	"strings"
@@ -16,7 +17,7 @@ func NewTracedClient(opt *redis.Options, t *tracer.Tracer, service string) *Trac
 	db := strconv.Itoa(opt.DB)
 
 	client := redis.NewClient(opt)
-
+	t.SetServiceInfo(service, "redis", ext.AppTypeDB)
 	tc := &TracedClient{
 		client,
 		host,

--- a/tracer/contrib/go-redis/tracedredis.go
+++ b/tracer/contrib/go-redis/tracedredis.go
@@ -1,0 +1,96 @@
+package tracedredis
+
+import (
+	"context"
+	"fmt"
+	"github.com/DataDog/dd-trace-go/tracer"
+	"github.com/go-redis/redis"
+	"strconv"
+	"strings"
+)
+
+func NewTracedClient(opt *redis.Options, ctx context.Context, t *tracer.Tracer) *redis.Client {
+	var host, port string
+	addr := strings.Split(opt.Addr, ":")
+	host = addr[0]
+	port = addr[1]
+	db := strconv.Itoa(opt.DB)
+	ctx = context.WithValue(ctx, "_datadog_host", host)
+	ctx = context.WithValue(ctx, "_datadog_port", port)
+	ctx = context.WithValue(ctx, "_datadog_db", db)
+	client := redis.NewClient(opt)
+	client.WithContext(ctx)
+	client.WrapProcess(createWrapperWithContext(ctx, t))
+
+	return client
+
+}
+
+func createWrapperWithContext(ctx context.Context, t *tracer.Tracer) func(oldProcess func(cmd redis.Cmder) error) func(cmd redis.Cmder) error {
+	return func(oldProcess func(cmd redis.Cmder) error) func(cmd redis.Cmder) error {
+		return func(cmd redis.Cmder) error {
+
+			var resource string
+			resource = strings.Split(cmd.String(), " ")[0]
+			span := t.NewChildSpanFromContext("redis.command", ctx)
+			span.Resource = resource
+			span.SetMeta("redis.raw_command", cmd.String())
+
+			host_str, ok_host := ctx.Value("_datadog_host").(string)
+			port_str, ok_port := ctx.Value("_datadog_port").(string)
+			db_str, ok_db := ctx.Value("_datadog_db").(string)
+
+			if ok_host {
+				span.SetMeta("host", host_str)
+			}
+			if ok_port {
+				span.SetMeta("port", port_str)
+			}
+			if ok_db {
+				span.SetMeta("db", db_str)
+			}
+			err := oldProcess(cmd)
+			if err != nil {
+				span.SetError(err)
+			}
+			fmt.Printf("%s", span.String())
+			span.Finish()
+			return err
+		}
+	}
+}
+
+func ExampleNewClient() *redis.Client {
+	client := redis.NewClient(&redis.Options{
+		Addr:     "localhost:6379",
+		Password: "", // no password set
+		DB:       0,  // use default DB
+	})
+
+	return client
+	// Output: PONG <nil>
+}
+
+func main() {
+	opt := &redis.Options{
+		Addr:     "localhost:6379",
+		Password: "", // no password set
+		DB:       0,  // use default DB
+	}
+	ctx := context.Background()
+	t := tracer.NewTracer()
+	span := t.NewChildSpanFromContext("first_span", ctx)
+	span.SetMeta("MetaMeta", "22")
+
+	ctx = tracer.ContextWithSpan(ctx, span)
+
+	client := NewTracedClient(opt, ctx, t)
+
+	client.Set("test", 3, 0)
+	result, _ := client.Get("test").Result()
+	fmt.Printf("%s", span.String())
+	s2, _ := tracer.SpanFromContext(ctx)
+	fmt.Printf(s2.String())
+	span.Finish()
+	fmt.Printf(result)
+}

--- a/tracer/contrib/go-redis/tracedredis.go
+++ b/tracer/contrib/go-redis/tracedredis.go
@@ -35,8 +35,12 @@ type TraceParams struct {
 func NewTracedClient(opt *redis.Options, t *tracer.Tracer, service string) *TracedClient {
 	var host, port string
 	addr := strings.Split(opt.Addr, ":")
+	if len(addr) == 2 && addr[1] != "" {
+		port = addr[1]
+	} else {
+		port = "6379"
+	}
 	host = addr[0]
-	port = addr[1]
 	db := strconv.Itoa(opt.DB)
 
 	client := redis.NewClient(opt)

--- a/tracer/contrib/go-redis/tracedredis.go
+++ b/tracer/contrib/go-redis/tracedredis.go
@@ -59,38 +59,3 @@ func createWrapperWithContext(ctx context.Context, t *tracer.Tracer) func(oldPro
 		}
 	}
 }
-
-func ExampleNewClient() *redis.Client {
-	client := redis.NewClient(&redis.Options{
-		Addr:     "localhost:6379",
-		Password: "", // no password set
-		DB:       0,  // use default DB
-	})
-
-	return client
-	// Output: PONG <nil>
-}
-
-func main() {
-	opt := &redis.Options{
-		Addr:     "localhost:6379",
-		Password: "", // no password set
-		DB:       0,  // use default DB
-	}
-	ctx := context.Background()
-	t := tracer.NewTracer()
-	span := t.NewChildSpanFromContext("first_span", ctx)
-	span.SetMeta("MetaMeta", "22")
-
-	ctx = tracer.ContextWithSpan(ctx, span)
-
-	client := NewTracedClient(opt, ctx, t)
-
-	client.Set("test", 3, 0)
-	result, _ := client.Get("test").Result()
-	fmt.Printf("%s", span.String())
-	s2, _ := tracer.SpanFromContext(ctx)
-	fmt.Printf(s2.String())
-	span.Finish()
-	fmt.Printf(result)
-}

--- a/tracer/contrib/go-redis/tracedredis.go
+++ b/tracer/contrib/go-redis/tracedredis.go
@@ -1,4 +1,5 @@
-package tracedredis
+// Package goredistrace provides tracing for the go-redis Redis client (https://github.com/go-redis/redis)
+package goredistrace
 
 import (
 	"bytes"
@@ -13,17 +14,16 @@ import (
 // TracedClient is used to trace requests to a redis server.
 type TracedClient struct {
 	*redis.Client
-	traceParams TraceParams
+	traceParams traceParams
 }
 
 // TracedPipeline is used to trace pipelines with a redis server.
 type TracedPipeline struct {
 	*redis.Pipeline
-	traceParams TraceParams
+	traceParams traceParams
 }
 
-// TraceParams contains the tracer and params that we want to trace.
-type TraceParams struct {
+type traceParams struct {
 	host    string
 	port    string
 	db      string
@@ -47,7 +47,7 @@ func NewTracedClient(opt *redis.Options, t *tracer.Tracer, service string) *Trac
 	t.SetServiceInfo(service, "redis", ext.AppTypeDB)
 	tc := &TracedClient{
 		client,
-		TraceParams{
+		traceParams{
 			host,
 			port,
 			db,
@@ -104,7 +104,7 @@ func (c *TracedPipeline) Exec() ([]redis.Cmder, error) {
 	return cmds, err
 }
 
-// String is a used to return a string of all the comands, one comand per line.
+// String returns a string representation of a slice of redis Commands, separated by newlines
 func String(cmds []redis.Cmder) string {
 	var b bytes.Buffer
 	for _, cmd := range cmds {

--- a/tracer/contrib/go-redis/tracedredis.go
+++ b/tracer/contrib/go-redis/tracedredis.go
@@ -46,9 +46,9 @@ type TracedPipeline struct {
 	tracer *tracer.Tracer
 }
 
-func (c *TracedClient) TracedPipeline() *TracedPipeline {
+func (c *TracedClient) Pipeline() *TracedPipeline {
 	return &TracedPipeline{
-		c.Pipeline(),
+		c.Client.Pipeline(),
 		c.host,
 		c.port,
 		c.db,

--- a/tracer/contrib/go-redis/tracedredis_test.go
+++ b/tracer/contrib/go-redis/tracedredis_test.go
@@ -121,8 +121,8 @@ func TestError(t *testing.T) {
 	assert.Len(spans, 1)
 	span := spans[0]
 
-	assert.Equal(span.Error, 1)
-	assert.Equal(span.GetMeta("error.msg"), err.Err())
+	assert.Equal(int32(span.Error), int32(1))
+	assert.Equal(span.GetMeta("error.msg"), err.Err().Error())
 	assert.Equal(span.Name, "redis.command")
 	assert.Equal(span.GetMeta("host"), "127.0.0.1")
 	assert.Equal(span.GetMeta("port"), "6379")

--- a/tracer/contrib/go-redis/tracedredis_test.go
+++ b/tracer/contrib/go-redis/tracedredis_test.go
@@ -15,7 +15,7 @@ const (
 
 func TestClient(t *testing.T) {
 	default_opt := &redis.Options{
-		Addr:     "127.0.0.1:6379",
+		Addr:     "localhost:6379",
 		Password: "", // no password set
 		DB:       0,  // use default DB
 	}
@@ -34,14 +34,14 @@ func TestClient(t *testing.T) {
 
 	span := spans[0]
 	assert.Equal(span.Name, "redis.command")
-	assert.Equal(span.GetMeta("host"), "127.0.0.1")
+	assert.Equal(span.GetMeta("host"), "localhost")
 	assert.Equal(span.GetMeta("port"), "6379")
 	assert.Equal(span.GetMeta("redis.raw_command"), "set test_key test_value: ")
 }
 
 func TestChildSpan(t *testing.T) {
 	default_opt := &redis.Options{
-		Addr:     "127.0.0.1:6379",
+		Addr:     "localhost:6379",
 		Password: "", // no password set
 		DB:       0,  // use default DB
 	}
@@ -68,14 +68,14 @@ func TestChildSpan(t *testing.T) {
 	assert.Equal(pspan.Name, "parent_span")
 	assert.Equal(child_span.ParentID, pspan.SpanID)
 	assert.Equal(child_span.Name, "redis.command")
-	assert.Equal(child_span.GetMeta("host"), "127.0.0.1")
+	assert.Equal(child_span.GetMeta("host"), "localhost")
 	assert.Equal(child_span.GetMeta("port"), "6379")
 	assert.Equal(child_span.GetMeta("redis.raw_command"), "set test_key test_value: ")
 }
 
 func TestMultipleCommands(t *testing.T) {
 	default_opt := &redis.Options{
-		Addr:     "127.0.0.1:6379",
+		Addr:     "localhost:6379",
 		Password: "", // no password set
 		DB:       0,  // use default DB
 	}
@@ -103,7 +103,7 @@ func TestMultipleCommands(t *testing.T) {
 
 func TestError(t *testing.T) {
 	default_opt := &redis.Options{
-		Addr:     "127.0.0.1:6379",
+		Addr:     "localhost:6379",
 		Password: "", // no password set
 		DB:       0,  // use default DB
 	}
@@ -124,7 +124,7 @@ func TestError(t *testing.T) {
 	assert.Equal(span.Error, 1)
 	assert.Equal(span.GetMeta("error.msg"), err.Err())
 	assert.Equal(span.Name, "redis.command")
-	assert.Equal(span.GetMeta("host"), "127.0.0.1")
+	assert.Equal(span.GetMeta("host"), "localhost")
 	assert.Equal(span.GetMeta("port"), "6379")
 	assert.Equal(span.GetMeta("redis.raw_command"), "get non_existent_key: ")
 }

--- a/tracer/contrib/go-redis/tracedredis_test.go
+++ b/tracer/contrib/go-redis/tracedredis_test.go
@@ -15,7 +15,7 @@ const (
 
 func TestClient(t *testing.T) {
 	default_opt := &redis.Options{
-		Addr:     "localhost:6379",
+		Addr:     "127.0.0.1:6379",
 		Password: "", // no password set
 		DB:       0,  // use default DB
 	}
@@ -34,14 +34,14 @@ func TestClient(t *testing.T) {
 
 	span := spans[0]
 	assert.Equal(span.Name, "redis.command")
-	assert.Equal(span.GetMeta("host"), "localhost")
+	assert.Equal(span.GetMeta("host"), "127.0.0.1")
 	assert.Equal(span.GetMeta("port"), "6379")
 	assert.Equal(span.GetMeta("redis.raw_command"), "set test_key test_value: ")
 }
 
 func TestChildSpan(t *testing.T) {
 	default_opt := &redis.Options{
-		Addr:     "localhost:6379",
+		Addr:     "127.0.0.1:6379",
 		Password: "", // no password set
 		DB:       0,  // use default DB
 	}
@@ -68,14 +68,14 @@ func TestChildSpan(t *testing.T) {
 	assert.Equal(pspan.Name, "parent_span")
 	assert.Equal(child_span.ParentID, pspan.SpanID)
 	assert.Equal(child_span.Name, "redis.command")
-	assert.Equal(child_span.GetMeta("host"), "localhost")
+	assert.Equal(child_span.GetMeta("host"), "127.0.0.1")
 	assert.Equal(child_span.GetMeta("port"), "6379")
 	assert.Equal(child_span.GetMeta("redis.raw_command"), "set test_key test_value: ")
 }
 
 func TestMultipleCommands(t *testing.T) {
 	default_opt := &redis.Options{
-		Addr:     "localhost:6379",
+		Addr:     "127.0.0.1:6379",
 		Password: "", // no password set
 		DB:       0,  // use default DB
 	}
@@ -103,7 +103,7 @@ func TestMultipleCommands(t *testing.T) {
 
 func TestError(t *testing.T) {
 	default_opt := &redis.Options{
-		Addr:     "localhost:6379",
+		Addr:     "127.0.0.1:6379",
 		Password: "", // no password set
 		DB:       0,  // use default DB
 	}
@@ -124,7 +124,7 @@ func TestError(t *testing.T) {
 	assert.Equal(span.Error, 1)
 	assert.Equal(span.GetMeta("error.msg"), err.Err())
 	assert.Equal(span.Name, "redis.command")
-	assert.Equal(span.GetMeta("host"), "localhost")
+	assert.Equal(span.GetMeta("host"), "127.0.0.1")
 	assert.Equal(span.GetMeta("port"), "6379")
 	assert.Equal(span.GetMeta("redis.raw_command"), "get non_existent_key: ")
 }

--- a/tracer/contrib/go-redis/tracedredis_test.go
+++ b/tracer/contrib/go-redis/tracedredis_test.go
@@ -52,7 +52,7 @@ func TestPipeline(t *testing.T) {
 	testTracer.DebugLoggingEnabled = debug
 
 	client := NewTracedClient(opts, context.Background(), testTracer)
-	pipeline := client.TracedPipeline()
+	pipeline := client.Pipeline()
 	pipeline.Incr("pipeline_counter")
 	pipeline.Expire("pipeline_counter", time.Hour)
 	pipeline.TracedExec(context.Background())

--- a/tracer/contrib/go-redis/tracedredis_test.go
+++ b/tracer/contrib/go-redis/tracedredis_test.go
@@ -94,11 +94,16 @@ func TestMultipleCommands(t *testing.T) {
 	assert.Len(traces, 4)
 	spans := traces[0]
 	assert.Len(spans, 1)
-	// assert.Equal(traces[0][0].GetMeta("redis.raw_command"), "set test_key test_value: ")
-	// assert.Equal(traces[1][0].GetMeta("redis.raw_command"), "get test_key: ")
-	// assert.Equal(traces[2][0].GetMeta("redis.raw_command"), "incr int_key: 0")
-	// assert.Equal(traces[3][0].GetMeta("redis.raw_command"), "client list: ")
 
+	// Checking all commands were recorded
+	var commands [4]string
+	for i := 0; i < 4; i++ {
+		commands[i] = traces[i][0].GetMeta("redis.raw_command")
+	}
+	assert.Contains(commands, "set test_key test_value: ")
+	assert.Contains(commands, "get test_key: ")
+	assert.Contains(commands, "incr int_key: 0")
+	assert.Contains(commands, "client list: ")
 }
 
 func TestError(t *testing.T) {

--- a/tracer/contrib/go-redis/tracedredis_test.go
+++ b/tracer/contrib/go-redis/tracedredis_test.go
@@ -15,7 +15,7 @@ const (
 
 func TestClient(t *testing.T) {
 	default_opt := &redis.Options{
-		Addr:     "127.0.0.1:56379",
+		Addr:     "127.0.0.1:6379",
 		Password: "", // no password set
 		DB:       0,  // use default DB
 	}
@@ -34,14 +34,14 @@ func TestClient(t *testing.T) {
 
 	span := spans[0]
 	assert.Equal(span.Name, "redis.command")
-	assert.Equal(span.GetMeta("host"), "localhost")
+	assert.Equal(span.GetMeta("host"), "127.0.0.1")
 	assert.Equal(span.GetMeta("port"), "6379")
 	assert.Equal(span.GetMeta("redis.raw_command"), "set test_key test_value: ")
 }
 
 func TestChildSpan(t *testing.T) {
 	default_opt := &redis.Options{
-		Addr:     "127.0.0.1:56379",
+		Addr:     "127.0.0.1:6379",
 		Password: "", // no password set
 		DB:       0,  // use default DB
 	}
@@ -68,14 +68,14 @@ func TestChildSpan(t *testing.T) {
 	assert.Equal(pspan.Name, "parent_span")
 	assert.Equal(child_span.ParentID, pspan.SpanID)
 	assert.Equal(child_span.Name, "redis.command")
-	assert.Equal(child_span.GetMeta("host"), "localhost")
+	assert.Equal(child_span.GetMeta("host"), "127.0.0.1")
 	assert.Equal(child_span.GetMeta("port"), "6379")
 	assert.Equal(child_span.GetMeta("redis.raw_command"), "set test_key test_value: ")
 }
 
 func TestMultipleCommands(t *testing.T) {
 	default_opt := &redis.Options{
-		Addr:     "127.0.0.1:56379",
+		Addr:     "127.0.0.1:6379",
 		Password: "", // no password set
 		DB:       0,  // use default DB
 	}
@@ -103,7 +103,7 @@ func TestMultipleCommands(t *testing.T) {
 
 func TestError(t *testing.T) {
 	default_opt := &redis.Options{
-		Addr:     "127.0.0.1:56379",
+		Addr:     "127.0.0.1:6379",
 		Password: "", // no password set
 		DB:       0,  // use default DB
 	}
@@ -124,7 +124,7 @@ func TestError(t *testing.T) {
 	assert.Equal(span.Error, 1)
 	assert.Equal(span.GetMeta("error.msg"), err.Err())
 	assert.Equal(span.Name, "redis.command")
-	assert.Equal(span.GetMeta("host"), "localhost")
+	assert.Equal(span.GetMeta("host"), "127.0.0.1")
 	assert.Equal(span.GetMeta("port"), "6379")
 	assert.Equal(span.GetMeta("redis.raw_command"), "get non_existent_key: ")
 }

--- a/tracer/contrib/go-redis/tracedredis_test.go
+++ b/tracer/contrib/go-redis/tracedredis_test.go
@@ -1,0 +1,70 @@
+package tracedredis
+
+import (
+	"context"
+	"github.com/DataDog/dd-trace-go/tracer"
+	"github.com/go-redis/redis"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+const (
+	debug = false
+)
+
+func TestClient(t *testing.T) {
+	default_opt := &redis.Options{
+		Addr:     "localhost:6379",
+		Password: "", // no password set
+		DB:       0,  // use default DB
+	}
+	assert := assert.New(t)
+	testTracer, testTransport := getTestTracer()
+	testTracer.DebugLoggingEnabled = debug
+
+	client := NewTracedClient(default_opt, context.Background(), testTracer)
+	client.Set("test_key", "test_value", 0)
+
+	testTracer.FlushTraces()
+	traces := testTransport.Traces()
+	assert.Len(traces, 1)
+	spans := traces[0]
+	assert.Len(spans, 1)
+
+	span := spans[0]
+	assert.Equal(span.Name, "redis.command")
+	assert.Equal(span.GetMeta("host"), "localhost")
+	assert.Equal(span.GetMeta("port"), "6379")
+	assert.Equal(span.GetMeta("redis.raw_command"), "set test_key test_value: ")
+}
+
+// getTestTracer returns a Tracer with a DummyTransport
+func getTestTracer() (*tracer.Tracer, *dummyTransport) {
+	transport := &dummyTransport{}
+	tracer := tracer.NewTracerTransport(transport)
+	return tracer, transport
+}
+
+// dummyTransport is a transport that just buffers spans and encoding
+type dummyTransport struct {
+	traces   [][]*tracer.Span
+	services map[string]tracer.Service
+}
+
+func (t *dummyTransport) SendTraces(traces [][]*tracer.Span) (*http.Response, error) {
+	t.traces = append(t.traces, traces...)
+	return nil, nil
+}
+
+func (t *dummyTransport) SendServices(services map[string]tracer.Service) (*http.Response, error) {
+	t.services = services
+	return nil, nil
+}
+
+func (t *dummyTransport) Traces() [][]*tracer.Span {
+	traces := t.traces
+	t.traces = nil
+	return traces
+}
+func (t *dummyTransport) SetHeader(key, value string) {}

--- a/tracer/contrib/go-redis/tracedredis_test.go
+++ b/tracer/contrib/go-redis/tracedredis_test.go
@@ -1,4 +1,4 @@
-package tracedredis
+package goredistrace
 
 import (
 	"context"

--- a/tracer/contrib/go-redis/tracedredis_test.go
+++ b/tracer/contrib/go-redis/tracedredis_test.go
@@ -70,7 +70,7 @@ func TestPipeline(t *testing.T) {
 	assert.Equal(span.Name, "redis.command")
 	assert.Equal(span.GetMeta("out.port"), "6379")
 	assert.Equal(span.GetMeta("redis.pipeline_length"), "1")
-	assert.Equal(span.Resource, "expire pipeline_counter 3600: true\n")
+	assert.Equal(span.Resource, "expire pipeline_counter 3600: false\n")
 
 	pipeline.Expire("pipeline_counter", time.Hour)
 	pipeline.Expire("pipeline_counter_1", time.Minute)
@@ -88,7 +88,7 @@ func TestPipeline(t *testing.T) {
 	assert.Equal(span.Service, "my-redis")
 	assert.Equal(span.Name, "redis.command")
 	assert.Equal(span.GetMeta("redis.pipeline_length"), "2")
-	assert.Equal(span.Resource, "expire pipeline_counter 3600: true\nexpire pipeline_counter_1 60: true\n")
+	assert.Equal(span.Resource, "expire pipeline_counter 3600: false\nexpire pipeline_counter_1 60: false\n")
 }
 
 func TestChildSpan(t *testing.T) {

--- a/tracer/contrib/go-redis/tracedredis_test.go
+++ b/tracer/contrib/go-redis/tracedredis_test.go
@@ -94,10 +94,10 @@ func TestMultipleCommands(t *testing.T) {
 	assert.Len(traces, 4)
 	spans := traces[0]
 	assert.Len(spans, 1)
-	assert.Equal(traces[0][0].GetMeta("redis.raw_command"), "set test_key test_value: ")
-	assert.Equal(traces[1][0].GetMeta("redis.raw_command"), "get test_key: ")
-	assert.Equal(traces[2][0].GetMeta("redis.raw_command"), "incr int_key: 0")
-	assert.Equal(traces[3][0].GetMeta("redis.raw_command"), "client list: ")
+	// assert.Equal(traces[0][0].GetMeta("redis.raw_command"), "set test_key test_value: ")
+	// assert.Equal(traces[1][0].GetMeta("redis.raw_command"), "get test_key: ")
+	// assert.Equal(traces[2][0].GetMeta("redis.raw_command"), "incr int_key: 0")
+	// assert.Equal(traces[3][0].GetMeta("redis.raw_command"), "client list: ")
 
 }
 

--- a/tracer/contrib/go-redis/tracedredis_test.go
+++ b/tracer/contrib/go-redis/tracedredis_test.go
@@ -15,7 +15,7 @@ const (
 
 func TestClient(t *testing.T) {
 	default_opt := &redis.Options{
-		Addr:     "localhost:6379",
+		Addr:     "127.0.0.1:56379",
 		Password: "", // no password set
 		DB:       0,  // use default DB
 	}
@@ -41,7 +41,7 @@ func TestClient(t *testing.T) {
 
 func TestChildSpan(t *testing.T) {
 	default_opt := &redis.Options{
-		Addr:     "localhost:6379",
+		Addr:     "127.0.0.1:56379",
 		Password: "", // no password set
 		DB:       0,  // use default DB
 	}
@@ -75,7 +75,7 @@ func TestChildSpan(t *testing.T) {
 
 func TestMultipleCommands(t *testing.T) {
 	default_opt := &redis.Options{
-		Addr:     "localhost:6379",
+		Addr:     "127.0.0.1:56379",
 		Password: "", // no password set
 		DB:       0,  // use default DB
 	}
@@ -103,7 +103,7 @@ func TestMultipleCommands(t *testing.T) {
 
 func TestError(t *testing.T) {
 	default_opt := &redis.Options{
-		Addr:     "localhost:6379",
+		Addr:     "127.0.0.1:56379",
 		Password: "", // no password set
 		DB:       0,  // use default DB
 	}


### PR DESCRIPTION
# Summary
- Adding a go-redis contrib that traces all redis calls via a the go-redis library (https://github.com/go-redis/redis/)
- Tracing also pipelines
- Adding docker-compose file, redis is installed with it, moved the agent installation in it, this will be helpful for futur contribs

# Exemple span:
```
Name:
- redis.command
Meta:
- redis.raw_command: "set test_key test_value: "
- redis.args_length: 2
- out.host: 127.0.0.1
- out.port: 6379
- out.db: 0

```

# Patching guide:
- simple commands:
Instead of using `redis.NewClient(connection_options)` you call `tracedredis.NewTracedClient(connection_options, context , tracer)`
Nothing else to change

- pipelines
Instead of 
```
client := redis.NewClient(connection_options)
...
pipeline.Exec()
```
You use
```
client := tracedredis.NewTracedClient(connection_options, context , tracer)
...
pipeline.TracedExec(context)
```
On the new client and pipeline you can always use non traced functions, the Process method for the traced client will be patched by default