### PR TITLE
[tracer] allowing SetMeta at tracer level

### DIFF
--- a/tracer/span.go
+++ b/tracer/span.go
@@ -68,6 +68,7 @@ func NewSpan(name, service, resource string, spanID, traceID, parentID uint64, t
 		Name:     name,
 		Service:  service,
 		Resource: resource,
+		Meta:     tracer.getAllMeta(),
 		SpanID:   spanID,
 		TraceID:  traceID,
 		ParentID: parentID,

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -162,7 +162,7 @@ func (t *Tracer) getAllMeta() map[string]string {
 
 	t.metaMu.RLock()
 	if t.meta != nil {
-		meta = make(map[string]string)
+		meta = make(map[string]string, len(t.meta))
 		for key, value := range t.meta {
 			meta[key] = value
 		}


### PR DESCRIPTION
This should make the go client on par with the Python & Ruby ones, allowing application to set per tracer meta values (AKA tags).