### PR TITLE
Add tracer.NewChildSpanFromContext

### DIFF
--- a/tracer/example_context_test.go
+++ b/tracer/example_context_test.go
@@ -15,7 +15,7 @@ func saveFile(ctx context.Context, path string, r io.Reader) error {
 	// Start a new span that is the child of the span stored in the context, and
 	// attach it to the current context. If the context has no span, it will
 	// return an empty root span.
-	span, ctx := tracer.Span("filestore.saveFile", ctx)
+	span, ctx := tracer.NewChildSpanWithContext("filestore.saveFile", ctx)
 	defer span.Finish()
 
 	// save the file contents.

--- a/tracer/example_context_test.go
+++ b/tracer/example_context_test.go
@@ -12,9 +12,10 @@ import (
 )
 
 func saveFile(ctx context.Context, path string, r io.Reader) error {
-	// Start a new span that is the child of the span stored in the context. If the span
-	// has no context, it will return an empty one.
-	span := tracer.NewChildSpanFromContext("filestore.saveFile", ctx)
+	// Start a new span that is the child of the span stored in the context, and
+	// attach it to the current context. If the context has no span, it will
+	// return an empty root span.
+	span, ctx := tracer.Span("filestore.saveFile", ctx)
 	defer span.Finish()
 
 	// save the file contents.

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -361,6 +361,14 @@ func NewChildSpanFromContext(name string, ctx context.Context) *Span {
 	return DefaultTracer.NewChildSpanFromContext(name, ctx)
 }
 
+// NewChildSpanWithContext will create and return a child span of the span contained in the given
+// context, as well as a copy of the parent context containing the created
+// child span. If the context contains no span, an empty root span will be returned.
+// If nil is passed in for the context, a context will be created.
+func NewChildSpanWithContext(name string, ctx context.Context) (*Span, context.Context) {
+	return DefaultTracer.NewChildSpanWithContext(name, ctx)
+}
+
 // Enable will enable the default tracer.
 func Enable() {
 	DefaultTracer.SetEnabled(true)

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -212,6 +212,15 @@ func (t *Tracer) NewChildSpanFromContext(name string, ctx context.Context) *Span
 	return t.NewChildSpan(name, span)
 }
 
+// Span will create and return a child span of the span contained in the given
+// context, as well as a copy of the parent context containing the created
+// child span. If the context contains no span, an empty root span will be returned.
+// If nil is passed in for the context, a context will be created.
+func (t *Tracer) Span(name string, ctx context.Context) (*Span, context.Context) {
+	span := NewChildSpanFromContext(name, ctx)
+	return span, span.Context(ctx)
+}
+
 // record queues the finished span for further processing.
 func (t *Tracer) record(span *Span) {
 	if t.Enabled() && span.Sampled {

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -212,11 +212,11 @@ func (t *Tracer) NewChildSpanFromContext(name string, ctx context.Context) *Span
 	return t.NewChildSpan(name, span)
 }
 
-// Span will create and return a child span of the span contained in the given
+// NewChildSpanWithContext will create and return a child span of the span contained in the given
 // context, as well as a copy of the parent context containing the created
 // child span. If the context contains no span, an empty root span will be returned.
 // If nil is passed in for the context, a context will be created.
-func (t *Tracer) Span(name string, ctx context.Context) (*Span, context.Context) {
+func (t *Tracer) NewChildSpanWithContext(name string, ctx context.Context) (*Span, context.Context) {
 	span := NewChildSpanFromContext(name, ctx)
 	return span, span.Context(ctx)
 }

--- a/tracer/tracer_test.go
+++ b/tracer/tracer_test.go
@@ -68,12 +68,12 @@ func TestNewSpanFromContextNil(t *testing.T) {
 
 }
 
-func TestSpan(t *testing.T) {
+func TestNewChildSpanWithContext(t *testing.T) {
 	assert := assert.New(t)
 	tracer := NewTracer()
 
 	// nil context
-	span, ctx := tracer.Span("abc", nil)
+	span, ctx := tracer.NewChildSpanWithContext("abc", nil)
 	assert.Equal("abc", span.Name)
 	assert.Equal("", span.Service)
 	assert.Equal(span.ParentID, span.SpanID) // it should be a root span
@@ -84,7 +84,7 @@ func TestSpan(t *testing.T) {
 	assert.Equal(span, ctxSpan)
 
 	// context without span
-	span, ctx = tracer.Span("abc", context.Background())
+	span, ctx = tracer.NewChildSpanWithContext("abc", context.Background())
 	assert.Equal("abc", span.Name)
 	assert.Equal("", span.Service)
 	assert.Equal(span.ParentID, span.SpanID) // it should be a root span
@@ -97,7 +97,7 @@ func TestSpan(t *testing.T) {
 	// context with span
 	parent := tracer.NewRootSpan("pylons.request", "pylons", "/")
 	parentCTX := ContextWithSpan(context.Background(), parent)
-	span, ctx = tracer.Span("def", parentCTX)
+	span, ctx = tracer.NewChildSpanWithContext("def", parentCTX)
 	assert.Equal("def", span.Name)
 	assert.Equal("pylons", span.Service)
 	assert.Equal(parent.Service, span.Service)

--- a/tracer/tracer_test.go
+++ b/tracer/tracer_test.go
@@ -68,6 +68,48 @@ func TestNewSpanFromContextNil(t *testing.T) {
 
 }
 
+func TestSpan(t *testing.T) {
+	assert := assert.New(t)
+	tracer := NewTracer()
+
+	// nil context
+	span, ctx := tracer.Span("abc", nil)
+	assert.Equal("abc", span.Name)
+	assert.Equal("", span.Service)
+	assert.Equal(span.ParentID, span.SpanID) // it should be a root span
+	// the returned ctx should contain the created span
+	assert.NotNil(ctx)
+	ctxSpan, ok := SpanFromContext(ctx)
+	assert.True(ok)
+	assert.Equal(span, ctxSpan)
+
+	// context without span
+	span, ctx = tracer.Span("abc", context.Background())
+	assert.Equal("abc", span.Name)
+	assert.Equal("", span.Service)
+	assert.Equal(span.ParentID, span.SpanID) // it should be a root span
+	// the returned ctx should contain the created span
+	assert.NotNil(ctx)
+	ctxSpan, ok = SpanFromContext(ctx)
+	assert.True(ok)
+	assert.Equal(span, ctxSpan)
+
+	// context with span
+	parent := tracer.NewRootSpan("pylons.request", "pylons", "/")
+	parentCTX := ContextWithSpan(context.Background(), parent)
+	span, ctx = tracer.Span("def", parentCTX)
+	assert.Equal("def", span.Name)
+	assert.Equal("pylons", span.Service)
+	assert.Equal(parent.Service, span.Service)
+	// the created span should be a child of the parent span
+	assert.Equal(span.ParentID, parent.SpanID)
+	// the returned ctx should contain the created span
+	assert.NotNil(ctx)
+	ctxSpan, ok = SpanFromContext(ctx)
+	assert.True(ok)
+	assert.Equal(ctxSpan, span)
+}
+
 func TestNewSpanFromContext(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
This PR addresses https://github.com/DataDog/dd-trace-go/issues/65

I've created `tracer.Span`, which is allows us to replace:

``` go
span := tracer.NewChildSpanFromContext("name", ctx)
ctx = span.Context(ctx)
```

with:

``` go
span, ctx := tracer.NewChildSpanWithContext("name", ctx)
```