### PR TITLE
grpc: Use provided service name for all spans

### DIFF
--- a/tracer/contrib/tracegrpc/grpc.go
+++ b/tracer/contrib/tracegrpc/grpc.go
@@ -3,7 +3,6 @@ package tracegrpc
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/DataDog/dd-trace-go/tracer"
 	"github.com/DataDog/dd-trace-go/tracer/ext"
@@ -65,9 +64,7 @@ func UnaryClientInterceptor(service string, t *tracer.Tracer) grpc.UnaryClientIn
 }
 
 func serverSpan(t *tracer.Tracer, ctx context.Context, method, service string) *tracer.Span {
-	resource := parseMethod(method)
-
-	span := t.NewRootSpan("grpc.server", service, resource)
+	span := t.NewRootSpan("grpc.server", service, method)
 	span.SetMeta("gprc.method", method)
 	span.Type = "go"
 
@@ -78,14 +75,6 @@ func serverSpan(t *tracer.Tracer, ctx context.Context, method, service string) *
 	}
 
 	return span
-}
-
-func parseMethod(method string) (resource string) {
-	if idx := strings.LastIndexByte(method, '/'); idx > 0 {
-		return method[idx+1:]
-	}
-
-	return ""
 }
 
 // setIDs will set the trace ids on the context{

--- a/tracer/contrib/tracegrpc/grpc_test.go
+++ b/tracer/contrib/tracegrpc/grpc_test.go
@@ -108,7 +108,7 @@ func TestChild(t *testing.T) {
 	s = spans[1]
 	assert.Equal(s.Error, int32(0))
 	assert.Equal(s.Service, "tracegrpc")
-	assert.Equal(s.Resource, "Ping")
+	assert.Equal(s.Resource, "/tracegrpc.Fixture/Ping")
 	assert.True(s.Duration > 0)
 }
 
@@ -137,7 +137,7 @@ func TestPass(t *testing.T) {
 	assert.Equal(s.Error, int32(0))
 	assert.Equal(s.Name, "grpc.server")
 	assert.Equal(s.Service, "tracegrpc")
-	assert.Equal(s.Resource, "Ping")
+	assert.Equal(s.Resource, "/tracegrpc.Fixture/Ping")
 	assert.Equal(s.Type, "go")
 	assert.True(s.Duration > 0)
 }

--- a/tracer/contrib/tracegrpc/grpc_test.go
+++ b/tracer/contrib/tracegrpc/grpc_test.go
@@ -101,13 +101,13 @@ func TestChild(t *testing.T) {
 
 	s := spans[0]
 	assert.Equal(s.Error, int32(0))
-	assert.Equal(s.Service, "tracegrpc.Fixture")
+	assert.Equal(s.Service, "tracegrpc")
 	assert.Equal(s.Resource, "child")
 	assert.True(s.Duration > 0)
 
 	s = spans[1]
 	assert.Equal(s.Error, int32(0))
-	assert.Equal(s.Service, "tracegrpc.Fixture")
+	assert.Equal(s.Service, "tracegrpc")
 	assert.Equal(s.Resource, "Ping")
 	assert.True(s.Duration > 0)
 }
@@ -136,7 +136,7 @@ func TestPass(t *testing.T) {
 	s := spans[0]
 	assert.Equal(s.Error, int32(0))
 	assert.Equal(s.Name, "grpc.server")
-	assert.Equal(s.Service, "tracegrpc.Fixture")
+	assert.Equal(s.Service, "tracegrpc")
 	assert.Equal(s.Resource, "Ping")
 	assert.Equal(s.Type, "go")
 	assert.True(s.Duration > 0)
@@ -189,7 +189,7 @@ func (r *rig) Close() {
 
 func newRig(t *tracer.Tracer, traceClient bool) (*rig, error) {
 
-	server := grpc.NewServer(grpc.UnaryInterceptor(UnaryServerInterceptor("foo", t)))
+	server := grpc.NewServer(grpc.UnaryInterceptor(UnaryServerInterceptor("tracegrpc", t)))
 
 	RegisterFixtureServer(server, newFixtureServer())
 
@@ -206,7 +206,7 @@ func newRig(t *tracer.Tracer, traceClient bool) (*rig, error) {
 	}
 
 	if traceClient {
-		opts = append(opts, grpc.WithUnaryInterceptor(UnaryClientInterceptor("foo", t)))
+		opts = append(opts, grpc.WithUnaryInterceptor(UnaryClientInterceptor("tracegrpc", t)))
 	}
 
 	conn, err := grpc.Dial(li.Addr().String(), opts...)


### PR DESCRIPTION
Previously we were parsing the service from the rpc endpoint but we were never actually using the service name that was provided.

Note that while the API doesn't change this will rename every service so we may want make this an option instead to enable it going forward. I'm open to whichever is preferred!