### PR TITLE
mux: Implement the http.Hijacker interface to support websockets.

### DIFF
--- a/tracer/contrib/gorilla/muxtrace/muxtrace.go
+++ b/tracer/contrib/gorilla/muxtrace/muxtrace.go
@@ -2,6 +2,9 @@
 package muxtrace
 
 import (
+	"bufio"
+	"errors"
+	"net"
 	"net/http"
 	"strconv"
 
@@ -107,6 +110,14 @@ func (t *tracedResponseWriter) WriteHeader(status int) {
 	if status >= 500 && status < 600 {
 		t.span.Error = 1
 	}
+}
+
+func (t *tracedResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := t.w.(http.Hijacker)
+	if !ok {
+		return nil, nil, errors.New("the ResponseWriter doesn't support the Hijacker interface")
+	}
+	return hijacker.Hijack()
 }
 
 // SetRequestSpan sets the span on the request's context.


### PR DESCRIPTION
The http.Hijacker interface is used by the gorilla/websocket library to
upgrade the websocket connection. Without this change we see the
following error when using this lib:

`could not upgrade connection: websocket: response does not implement http.Hijacker`