### PR TITLE
[elastictraced] check the StatusCode only if there are no errors

### DIFF
--- a/tracer/contrib/elastictraced/elastictraced_test.go
+++ b/tracer/contrib/elastictraced/elastictraced_test.go
@@ -80,6 +80,76 @@ func TestClientV3(t *testing.T) {
 	checkErrTrace(assert, testTracer, testTransport)
 }
 
+func TestClientV3Failure(t *testing.T) {
+	assert := assert.New(t)
+	testTracer, testTransport := getTestTracer()
+	testTracer.DebugLoggingEnabled = debug
+
+	tc := NewTracedHTTPClient("my-es-service", testTracer)
+	client, err := elasticv3.NewClient(
+		// not existing service, it must fail
+		elasticv3.SetURL("http://127.0.0.1:29201"),
+		elasticv3.SetHttpClient(tc),
+		elasticv3.SetSniff(false),
+		elasticv3.SetHealthcheck(false),
+	)
+	assert.NoError(err)
+
+	_, err = client.Index().
+		Index("twitter").Id("1").
+		Type("tweet").
+		BodyString(`{"user": "test", "message": "hello"}`).
+		DoC(context.TODO())
+	assert.Error(err)
+
+	testTracer.FlushTraces()
+	traces := testTransport.Traces()
+	assert.Len(traces, 1)
+	spans := traces[0]
+	assert.Equal("my-es-service", spans[0].Service)
+	assert.Equal("elasticsearch.query", spans[0].Resource)
+	assert.Equal("/twitter/tweet/1", spans[0].GetMeta("elasticsearch.url"))
+	assert.Equal("PUT", spans[0].GetMeta("elasticsearch.method"))
+
+	assert.NotEmpty(spans[0].GetMeta("error.msg"))
+	assert.Equal("*net.OpError", spans[0].GetMeta("error.type"))
+}
+
+func TestClientV5Failure(t *testing.T) {
+	assert := assert.New(t)
+	testTracer, testTransport := getTestTracer()
+	testTracer.DebugLoggingEnabled = debug
+
+	tc := NewTracedHTTPClient("my-es-service", testTracer)
+	client, err := elasticv5.NewClient(
+		// not existing service, it must fail
+		elasticv5.SetURL("http://127.0.0.1:29200"),
+		elasticv5.SetHttpClient(tc),
+		elasticv5.SetSniff(false),
+		elasticv5.SetHealthcheck(false),
+	)
+	assert.NoError(err)
+
+	_, err = client.Index().
+		Index("twitter").Id("1").
+		Type("tweet").
+		BodyString(`{"user": "test", "message": "hello"}`).
+		Do(context.TODO())
+	assert.Error(err)
+
+	testTracer.FlushTraces()
+	traces := testTransport.Traces()
+	assert.Len(traces, 1)
+	spans := traces[0]
+	assert.Equal("my-es-service", spans[0].Service)
+	assert.Equal("elasticsearch.query", spans[0].Resource)
+	assert.Equal("/twitter/tweet/1", spans[0].GetMeta("elasticsearch.url"))
+	assert.Equal("PUT", spans[0].GetMeta("elasticsearch.method"))
+
+	assert.NotEmpty(spans[0].GetMeta("error.msg"))
+	assert.Equal("*net.OpError", spans[0].GetMeta("error.type"))
+}
+
 func checkPUTTrace(assert *assert.Assertions, tracer *tracer.Tracer, transport *tracer.DummyTransport) {
 	tracer.FlushTraces()
 	traces := transport.Traces()


### PR DESCRIPTION
### What it does

Attaches the `HTTPCode` in the span only if we don't have errors while reading the `Transport` response. We hit an `invalid memory address or nil pointer dereference` error.