### PR TITLE
elastic: Quantize span in both error and success cases

### DIFF
--- a/tracer/contrib/elastictraced/elastictraced.go
+++ b/tracer/contrib/elastictraced/elastictraced.go
@@ -55,11 +55,7 @@ func (t *TracedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	if err != nil {
 		span.SetError(err)
-		return res, err
-	}
-
-	// handle status codes that are not 200
-	if res.StatusCode < 200 || res.StatusCode > 299 {
+	} else if res.StatusCode < 200 || res.StatusCode > 299 {
 		buf, err := ioutil.ReadAll(res.Body)
 		if err != nil {
 			// Status text is best we can do if if we can't read the body.

--- a/tracer/contrib/elastictraced/elastictraced_test.go
+++ b/tracer/contrib/elastictraced/elastictraced_test.go
@@ -107,7 +107,7 @@ func TestClientV3Failure(t *testing.T) {
 	assert.Len(traces, 1)
 	spans := traces[0]
 	assert.Equal("my-es-service", spans[0].Service)
-	assert.Equal("elasticsearch.query", spans[0].Resource)
+	assert.Equal("PUT /twitter/tweet/?", spans[0].Resource)
 	assert.Equal("/twitter/tweet/1", spans[0].GetMeta("elasticsearch.url"))
 	assert.Equal("PUT", spans[0].GetMeta("elasticsearch.method"))
 
@@ -142,7 +142,7 @@ func TestClientV5Failure(t *testing.T) {
 	assert.Len(traces, 1)
 	spans := traces[0]
 	assert.Equal("my-es-service", spans[0].Service)
-	assert.Equal("elasticsearch.query", spans[0].Resource)
+	assert.Equal("PUT /twitter/tweet/?", spans[0].Resource)
 	assert.Equal("/twitter/tweet/1", spans[0].GetMeta("elasticsearch.url"))
 	assert.Equal("PUT", spans[0].GetMeta("elasticsearch.method"))
 


### PR DESCRIPTION
Fixes the resource names to be correct in the error case, fixing an issue introduced in #71