### PR TITLE
Raphael/gocql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,9 @@
 # File for development/ testing purposes
+
+cassandra:
+        image: cassandra:3.7
+        ports:
+                - "127.0.0.1:9042:9042"
 redis:
         image: redis:3.2
         ports:

--- a/tracer/contrib/gocql/gocqltrace.go
+++ b/tracer/contrib/gocql/gocqltrace.go
@@ -37,8 +37,13 @@ type traceParams struct {
 
 // TraceQuery wraps a gocql.Query into a TracedQuery
 func TraceQuery(service string, tracer *tracer.Tracer, q *gocql.Query) *TracedQuery {
-	string_query := strings.SplitN(q.String(), "\"", 3)[1]
-	string_query, _ = strconv.Unquote(string_query)
+	string_query := `"` + strings.SplitN(q.String(), "\"", 3)[1] + `"`
+	string_query, err := strconv.Unquote(string_query)
+	if err != nil {
+		// An invalid string, so that the trace is not dropped
+		// due to having an empty resource
+		string_query = "_"
+	}
 
 	q.NoSkipMetadata()
 	tq := &TracedQuery{q, traceParams{tracer, service, "", "false", strconv.Itoa(int(q.GetConsistency())), string_query}, context.Background()}

--- a/tracer/contrib/gocql/gocqltrace.go
+++ b/tracer/contrib/gocql/gocqltrace.go
@@ -3,11 +3,13 @@ package gocqltrace
 
 import (
 	"context"
-	"github.com/DataDog/dd-trace-go/tracer"
-	"github.com/DataDog/dd-trace-go/tracer/ext"
-	"github.com/gocql/gocql"
 	"strconv"
 	"strings"
+
+	"github.com/DataDog/dd-trace-go/tracer"
+	"github.com/DataDog/dd-trace-go/tracer/ext"
+
+	"github.com/gocql/gocql"
 )
 
 // TracedQuery inherits from gocql.Query, it keeps the tracer and the context.
@@ -36,6 +38,8 @@ type traceParams struct {
 // TraceQuery wraps a gocql.Query into a TracedQuery
 func TraceQuery(service string, tracer *tracer.Tracer, q *gocql.Query) *TracedQuery {
 	string_query := strings.SplitN(q.String(), "\"", 3)[1]
+	string_query, _ = strconv.Unquote(string_query)
+
 	q.NoSkipMetadata()
 	tq := &TracedQuery{q, traceParams{tracer, service, "", "false", strconv.Itoa(int(q.GetConsistency())), string_query}, context.Background()}
 	tracer.SetServiceInfo(service, ext.CassandraType, ext.AppTypeDB)

--- a/tracer/contrib/gocql/gocqltrace.go
+++ b/tracer/contrib/gocql/gocqltrace.go
@@ -1,0 +1,184 @@
+// Package gocqltrace provides tracing for the Cassandra Gocql client (https://github.com/gocql/gocql)
+package gocqltrace
+
+import (
+	"context"
+	"github.com/DataDog/dd-trace-go/tracer"
+	"github.com/DataDog/dd-trace-go/tracer/ext"
+	"github.com/gocql/gocql"
+	"strconv"
+	"strings"
+)
+
+type TracedQuery struct {
+	*gocql.Query
+	p            traceParams
+	traceContext context.Context
+}
+
+type TracedIter struct {
+	*gocql.Iter
+	span *tracer.Span
+}
+
+type traceParams struct {
+	tracer      *tracer.Tracer
+	service     string
+	port        string
+	keyspace    string
+	paginated   string
+	consistancy string
+	query       string
+}
+
+// Without wrapper code
+
+type TracedClusterConfig struct {
+	*gocql.ClusterConfig
+}
+
+type TracedSession struct {
+	*gocql.Session
+	p traceParams
+}
+
+func NewTracedCluster(hosts ...string) *TracedClusterConfig {
+	tcfg := &TracedClusterConfig{gocql.NewCluster(hosts...)}
+	return tcfg
+}
+
+func NewTracedClusterConfig(clg *gocql.ClusterConfig) *TracedClusterConfig {
+	return &TracedClusterConfig{clg}
+}
+
+func (tcfg *TracedClusterConfig) CreateTracedSession(service string, tracer *tracer.Tracer) (*TracedSession, error) {
+	return NewTracedSession(service, tracer, *tcfg.ClusterConfig)
+}
+
+func NewTracedSession(service string, tracer *tracer.Tracer, cfg gocql.ClusterConfig) (*TracedSession, error) {
+	s, err := gocql.NewSession(cfg)
+	ts := &TracedSession{s, traceParams{tracer, service, strconv.Itoa(cfg.Port), cfg.Keyspace, "false", "", ""}}
+	return ts, err
+}
+
+func (ts *TracedSession) Query(stmt string, values ...interface{}) *TracedQuery {
+	q := ts.Session.Query(stmt, values...)
+	p := ts.p
+	p.query = stmt
+	tq := &TracedQuery{q, p, context.Background()}
+	return tq
+}
+
+func (ts *TracedSession) Bind(stmt string, b func(q *gocql.QueryInfo) ([]interface{}, error)) *TracedQuery {
+	q := ts.Session.Bind(stmt, b)
+	tq := &TracedQuery{q, ts.p, context.Background()}
+	return tq
+}
+
+// Wrapper
+
+func TraceQuery(service string, tracer *tracer.Tracer, q *gocql.Query) *TracedQuery {
+	string_query := strings.SplitN(q.String(), "\"", 3)[1]
+	q.NoSkipMetadata()
+	tq := &TracedQuery{q, traceParams{tracer, service, "", "", "false", strconv.Itoa(int(q.GetConsistency())), string_query}, context.Background()}
+	tracer.SetServiceInfo(service, ext.CassandraType, ext.AppTypeDB)
+	return tq
+}
+
+// Common code
+
+func (tq *TracedQuery) WithContext(ctx context.Context) *TracedQuery {
+	tq.traceContext = ctx
+	tq.Query.WithContext(ctx)
+	return tq
+}
+
+func (tq *TracedQuery) PageState(state []byte) *TracedQuery {
+	tq.p.paginated = "true"
+	tq.Query = tq.Query.PageState(state)
+	return tq
+}
+
+func (tq *TracedQuery) NewChildSpan(ctx context.Context) *tracer.Span {
+	span := tq.p.tracer.NewChildSpanFromContext(ext.CassandraQuery, ctx)
+	span.Type = ext.CassandraType
+	span.Service = tq.p.service
+	span.Resource = tq.p.query
+	span.SetMeta(ext.CassandraPaginated, tq.p.paginated)
+	span.SetMeta(ext.CassandraKeyspace, tq.p.keyspace)
+	span.SetMeta(ext.TargetPort, tq.p.port)
+	return span
+}
+
+func (tq *TracedQuery) Exec() error {
+	return tq.Iter().Close()
+}
+
+func (tq *TracedQuery) MapScan(m map[string]interface{}) error {
+	span := tq.NewChildSpan(tq.traceContext)
+	defer span.Finish()
+	err := tq.Query.MapScan(m)
+	if err != nil {
+		span.SetError(err)
+	}
+	return err
+}
+
+func (tq *TracedQuery) Scan(dest ...interface{}) error {
+	span := tq.NewChildSpan(tq.traceContext)
+	defer span.Finish()
+	err := tq.Query.Scan(dest...)
+	if err != nil {
+		span.SetError(err)
+	}
+	return err
+}
+
+func (tq *TracedQuery) ScanCAS(dest ...interface{}) (applied bool, err error) {
+	span := tq.NewChildSpan(tq.traceContext)
+	defer span.Finish()
+	applied, err = tq.Query.ScanCAS(dest...)
+	if err != nil {
+		span.SetError(err)
+	}
+	return applied, err
+}
+
+func (tq *TracedQuery) Iter() *TracedIter {
+	span := tq.NewChildSpan(tq.traceContext)
+	iter := tq.Query.Iter()
+	span.SetMeta(ext.CassandraRowCount, strconv.Itoa(iter.NumRows()))
+	span.SetMeta(ext.CassandraConsistencyLevel, strconv.Itoa(int(tq.GetConsistency())))
+
+	columns := iter.Columns()
+	if len(columns) > 0 {
+		span.SetMeta(ext.CassandraKeyspace, columns[0].Keyspace)
+	} else {
+	}
+	tIter := &TracedIter{iter, span}
+	if tIter.Host() != nil {
+		tIter.span.SetMeta(ext.TargetHost, tIter.Iter.Host().HostID())
+		tIter.span.SetMeta(ext.TargetPort, strconv.Itoa(tIter.Iter.Host().Port()))
+		tIter.span.SetMeta(ext.CassandraCluster, tIter.Iter.Host().DataCenter())
+
+	}
+	return tIter
+}
+
+func (tIter *TracedIter) Close() error {
+	columns := tIter.Iter.Columns()
+	if len(columns) > 0 {
+		tIter.span.SetMeta(ext.CassandraKeyspace, columns[0].Keyspace)
+	}
+	err := tIter.Iter.Close()
+	if err != nil {
+		tIter.span.SetError(err)
+	}
+	if tIter.Host() != nil {
+		tIter.span.SetMeta(ext.TargetHost, tIter.Iter.Host().HostID())
+		tIter.span.SetMeta(ext.TargetPort, strconv.Itoa(tIter.Iter.Host().Port()))
+		tIter.span.SetMeta(ext.CassandraCluster, tIter.Iter.Host().DataCenter())
+	}
+	tIter.span.Finish()
+	return err
+}

--- a/tracer/contrib/gocql/gocqltrace_test.go
+++ b/tracer/contrib/gocql/gocqltrace_test.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"github.com/DataDog/dd-trace-go/tracer"
 	"github.com/DataDog/dd-trace-go/tracer/ext"
-	//"github.com/gocql/gocql"
-	"github.com/furmmon/gocql"
+	"github.com/gocql/gocql"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -20,7 +19,7 @@ func TestMain(m *testing.M) {
 	session, _ := cluster.CreateSession()
 
 	// Ensures test keyspace and table person exists.
-	session.Query("CREATE KEYSPACE if not exists test WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor': 1}").Exec()
+	session.Query("CREATE KEYSPACE if not exists trace WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor': 1}").Exec()
 	session.Query("CREATE TABLE if not exists test.person (name text PRIMARY KEY, age int, description text)").Exec()
 	session.Query("INSERT INTO test.person (name, age, description) VALUES ('Cassandra', 100, 'A cruel mistress')").Exec()
 
@@ -52,75 +51,11 @@ func TestErrorWrapper(t *testing.T) {
 	assert.Equal(span.GetMeta(ext.CassandraConsistencyLevel), "4")
 	assert.Equal(span.GetMeta(ext.CassandraPaginated), "false")
 
-	// Not Working
+	// Not added in case of an error
 	assert.Equal(span.GetMeta(ext.TargetHost), "")
 	assert.Equal(span.GetMeta(ext.TargetPort), "")
 	assert.Equal(span.GetMeta(ext.CassandraCluster), "")
 	assert.Equal(span.GetMeta(ext.CassandraKeyspace), "")
-}
-
-func TestError(t *testing.T) {
-	assert := assert.New(t)
-	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
-
-	cluster := NewTracedCluster("127.0.0.1")
-	session, _ := cluster.CreateTracedSession("ServiceName", testTracer)
-	q := session.Query("CREATE KEYSPACE test WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };")
-	err := q.Exec()
-
-	testTracer.FlushTraces()
-	traces := testTransport.Traces()
-	assert.Len(traces, 1)
-	spans := traces[0]
-	assert.Len(spans, 1)
-	span := spans[0]
-
-	assert.Equal(int32(span.Error), int32(1))
-	assert.Equal(span.GetMeta("error.msg"), err.Error())
-	assert.Equal(span.Name, ext.CassandraQuery)
-	assert.Equal(span.Resource, "CREATE KEYSPACE test WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };")
-	assert.Equal(span.Service, "ServiceName")
-	assert.Equal(span.GetMeta(ext.CassandraConsistencyLevel), "4")
-	assert.Equal(span.GetMeta(ext.CassandraPaginated), "false")
-
-	// Not Working
-	assert.Equal(span.GetMeta(ext.TargetPort), "")
-	assert.Equal(span.GetMeta(ext.TargetHost), "")
-	assert.Equal(span.GetMeta(ext.CassandraCluster), "")
-	assert.Equal(span.GetMeta(ext.CassandraKeyspace), "")
-
-}
-
-func TestChildSpan(t *testing.T) {
-	assert := assert.New(t)
-	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
-
-	// Parent span
-	ctx := context.Background()
-	parent_span := testTracer.NewChildSpanFromContext("parent_span", ctx)
-	ctx = tracer.ContextWithSpan(ctx, parent_span)
-
-	cluster := NewTracedCluster("127.0.0.1")
-	session, _ := cluster.CreateTracedSession("ServiceName", testTracer)
-	q := session.Query("CREATE TABLE if not exists test.person (name text PRIMARY KEY, age int, description text)")
-	q.WithContext(ctx).Exec()
-	parent_span.Finish()
-
-	testTracer.FlushTraces()
-	traces := testTransport.Traces()
-	assert.Len(traces, 1)
-	spans := traces[0]
-	assert.Len(spans, 2)
-
-	child_span := spans[0]
-	pspan := spans[1]
-	assert.Equal(pspan.Name, "parent_span")
-	assert.Equal(child_span.ParentID, pspan.SpanID)
-	assert.Equal(child_span.Name, ext.CassandraQuery)
-	assert.Equal(child_span.GetMeta(ext.TargetPort), "9042")
-	assert.Equal(child_span.Resource, "CREATE TABLE if not exists test.person (name text PRIMARY KEY, age int, description text)")
 }
 
 func TestChildWrapperSpan(t *testing.T) {
@@ -152,11 +87,12 @@ func TestChildWrapperSpan(t *testing.T) {
 	assert.Equal(child_span.ParentID, pspan.SpanID)
 	assert.Equal(child_span.Name, ext.CassandraQuery)
 	assert.Equal(child_span.Resource, "SELECT * from test.person")
-
-	assert.Equal(child_span.GetMeta(ext.TargetPort), "9042")
-	assert.Equal(child_span.GetMeta(ext.TargetHost), "127.0.0.1")
-	assert.Equal(child_span.GetMeta(ext.CassandraCluster), "datacenter1")
 	assert.Equal(child_span.GetMeta(ext.CassandraKeyspace), "test")
+
+	// Will work only after gocql fix (PR #918)
+	// assert.Equal(child_span.GetMeta(ext.TargetPort), "9042")
+	// assert.Equal(child_span.GetMeta(ext.TargetHost), "127.0.0.1")
+	// assert.Equal(child_span.GetMeta(ext.CassandraCluster), "datacenter1")
 }
 
 // getTestTracer returns a Tracer with a DummyTransport

--- a/tracer/contrib/gocql/gocqltrace_test.go
+++ b/tracer/contrib/gocql/gocqltrace_test.go
@@ -1,0 +1,154 @@
+package gocqltrace
+
+import (
+	"context"
+	"github.com/DataDog/dd-trace-go/tracer"
+	"github.com/DataDog/dd-trace-go/tracer/ext"
+	//"github.com/gocql/gocql"
+	"github.com/gocql/gocql"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+const (
+	debug = false
+)
+
+func TestErrorWrapper(t *testing.T) {
+	assert := assert.New(t)
+	testTracer, testTransport := getTestTracer()
+	testTracer.DebugLoggingEnabled = debug
+
+	cluster := gocql.NewCluster("127.0.0.1")
+	session, _ := cluster.CreateSession()
+	q := session.Query("CREATE KEYSPACE TestKeySpace WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };")
+	TraceQuery("Test_service_name", testTracer, q).Exec()
+	q = session.Query("CREATE KEYSPACE TestKeySpace WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };")
+	err := TraceQuery("Test_service_name", testTracer, q).Exec()
+
+	testTracer.FlushTraces()
+	traces := testTransport.Traces()
+	assert.Len(traces, 2)
+	spans := traces[1]
+	assert.Len(spans, 1)
+	span := spans[0]
+
+	assert.Equal(int32(span.Error), int32(1))
+	assert.Equal(span.GetMeta("error.msg"), err.Error())
+	assert.Equal(span.Name, ext.CassandraQuery)
+	assert.Equal(span.Resource, "CREATE KEYSPACE TestKeySpace WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };")
+	assert.Equal(span.Service, "Test_service_name")
+	assert.Equal(span.GetMeta(ext.CassandraConsistencyLevel), "4")
+	assert.Equal(span.GetMeta(ext.CassandraPaginated), "false")
+
+	// Not Working
+	assert.Equal(span.GetMeta(ext.TargetHost), "")
+	assert.Equal(span.GetMeta(ext.TargetPort), "")
+	assert.Equal(span.GetMeta(ext.CassandraCluster), "")
+	assert.Equal(span.GetMeta(ext.CassandraKeyspace), "")
+}
+
+func TestError(t *testing.T) {
+	assert := assert.New(t)
+	testTracer, testTransport := getTestTracer()
+	testTracer.DebugLoggingEnabled = debug
+
+	cluster := NewTracedCluster("127.0.0.1")
+	session, _ := cluster.CreateTracedSession("Test_service_name", testTracer)
+	q := session.Query("CREATE KEYSPACE TestKeySpace WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };")
+	q.Exec()
+	q = session.Query("CREATE KEYSPACE TestKeySpace WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };")
+	err := q.Exec()
+
+	testTracer.FlushTraces()
+	traces := testTransport.Traces()
+	assert.Len(traces, 2)
+	spans := traces[1]
+	assert.Len(spans, 1)
+	span := spans[0]
+
+	assert.Equal(int32(span.Error), int32(1))
+	assert.Equal(span.GetMeta("error.msg"), err.Error())
+	assert.Equal(span.Name, ext.CassandraQuery)
+	assert.Equal(span.Resource, "CREATE KEYSPACE TestKeySpace WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };")
+	assert.Equal(span.Service, "Test_service_name")
+	assert.Equal(span.GetMeta(ext.CassandraConsistencyLevel), "4")
+	assert.Equal(span.GetMeta(ext.CassandraPaginated), "false")
+	assert.Equal(span.GetMeta(ext.TargetPort), "9042")
+
+	// Not Working
+	assert.Equal(span.GetMeta(ext.TargetHost), "")
+	assert.Equal(span.GetMeta(ext.CassandraCluster), "")
+	assert.Equal(span.GetMeta(ext.CassandraKeyspace), "")
+
+}
+
+func TestChildSPan(t *testing.T) {
+	assert := assert.New(t)
+	testTracer, testTransport := getTestTracer()
+	testTracer.DebugLoggingEnabled = debug
+
+	// Parent span
+	ctx := context.Background()
+	parent_span := testTracer.NewChildSpanFromContext("parent_span", ctx)
+	ctx = tracer.ContextWithSpan(ctx, parent_span)
+
+	cluster := NewTracedCluster("127.0.0.1")
+	session, _ := cluster.CreateTracedSession("Test_service_name", testTracer)
+	q := session.Query("CREATE KEYSPACE TestKeySpace WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };")
+	q.WithContext(ctx).Exec()
+	parent_span.Finish()
+
+	testTracer.FlushTraces()
+	traces := testTransport.Traces()
+	assert.Len(traces, 1)
+	spans := traces[0]
+	assert.Len(spans, 2)
+
+	child_span := spans[0]
+	pspan := spans[1]
+	assert.Equal(pspan.Name, "parent_span")
+	assert.Equal(child_span.ParentID, pspan.SpanID)
+	assert.Equal(child_span.Name, ext.CassandraQuery)
+	assert.Equal(child_span.GetMeta(ext.TargetPort), "9042")
+	assert.Equal(child_span.Resource, "CREATE KEYSPACE TestKeySpace WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };")
+}
+
+func TestChildWrapperSpan(t *testing.T) {
+	assert := assert.New(t)
+	testTracer, testTransport := getTestTracer()
+	testTracer.DebugLoggingEnabled = debug
+
+	// Parent span
+	ctx := context.Background()
+	parent_span := testTracer.NewChildSpanFromContext("parent_span", ctx)
+	ctx = tracer.ContextWithSpan(ctx, parent_span)
+
+	cluster := gocql.NewCluster("127.0.0.1")
+	session, _ := cluster.CreateSession()
+	q := session.Query("CREATE KEYSPACE TestKeySpace WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };")
+	tq := TraceQuery("Test_service_name", testTracer, q)
+	tq.WithContext(ctx).Exec()
+	parent_span.Finish()
+
+	testTracer.FlushTraces()
+	traces := testTransport.Traces()
+	assert.Len(traces, 1)
+	spans := traces[0]
+	assert.Len(spans, 2)
+
+	child_span := spans[0]
+	pspan := spans[1]
+	assert.Equal(pspan.Name, "parent_span")
+	assert.Equal(child_span.ParentID, pspan.SpanID)
+	assert.Equal(child_span.Name, ext.CassandraQuery)
+	assert.Equal(child_span.GetMeta(ext.TargetPort), "")
+	assert.Equal(child_span.Resource, "CREATE KEYSPACE TestKeySpace WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };")
+}
+
+// getTestTracer returns a Tracer with a DummyTransport
+func getTestTracer() (*tracer.Tracer, *tracer.DummyTransport) {
+	transport := &tracer.DummyTransport{}
+	tracer := tracer.NewTracerTransport(transport)
+	return tracer, transport
+}

--- a/tracer/ext/cassandra.go
+++ b/tracer/ext/cassandra.go
@@ -1,0 +1,11 @@
+package ext
+
+const (
+	CassandraType             = "cassandra"
+	CassandraQuery            = "cassandra.query"
+	CassandraConsistencyLevel = "cassandra.consistency_level"
+	CassandraCluster          = "cassandra.cluster"
+	CassandraRowCount         = "cassandra.row_count"
+	CassandraKeyspace         = "cassandra.keyspace"
+	CassandraPaginated        = "cassandra.paginated"
+)

--- a/tracer/ext/net.go
+++ b/tracer/ext/net.go
@@ -1,0 +1,6 @@
+package ext
+
+const (
+	TargetHost = "out.host"
+	TargetPort = "out.port"
+)


### PR DESCRIPTION
# Gocql query wrapper

Implementation:
```
After creating your query, wrap it with a function for it to be traced
query := session.Query("my-query ...")
traced_query = gocqltrace.TraceQuery("Service name", Tracer, query)
```
Data we get 100% time: `query, errors, row count, pagestate`
Data we only get when the query returns columns: `keyspace`
Data we will get once this is merged https://github.com/gocql/gocql/pull/918 : `host, port, clustername`


<img width="1176" alt="screen shot 2017-06-02 at 4 14 44 pm" src="https://user-images.githubusercontent.com/22001182/27042915-6b363292-4f66-11e7-8ca3-66f5390dc1e4.png">
