### PR TITLE
[tracer] added a test (broken for now) ensuring flush is atomic

### DIFF
--- a/tracer/buffer.go
+++ b/tracer/buffer.go
@@ -6,14 +6,23 @@ import (
 )
 
 const (
+	// spanBufferDefaultMaxSize is the maximum number of spans we keep in memory.
+	// This is to avoid memory leaks, if above that value, spans are randomly
+	// dropped and ignore, resulting in corrupted tracing data, but ensuring
+	// original program continues to work as expected.
 	spanBufferDefaultMaxSize = 10000
+	// finishedTracesSize is the initial size of the map used to stores traces
+	// considered as finished, and therefore sendable to agent.
+	finishedTracesSize = 10
 )
 
 // spansBuffer is a threadsafe buffer for spans.
 type spansBuffer struct {
-	lock    sync.Mutex
-	spans   []*Span
-	maxSize int
+	lock           sync.Mutex
+	spans          []*Span
+	maxSize        int
+	finishedTraces map[uint64]struct{} // set of traces considered as finished
+	bufferFull     int64               // number of spans we ignored because buffer was full
 }
 
 func newSpansBuffer(maxSize int) *spansBuffer {
@@ -23,7 +32,10 @@ func newSpansBuffer(maxSize int) *spansBuffer {
 		maxSize = spanBufferDefaultMaxSize
 	}
 
-	return &spansBuffer{maxSize: maxSize}
+	return &spansBuffer{
+		maxSize:        maxSize,
+		finishedTraces: make(map[uint64]struct{}, finishedTracesSize),
+	}
 }
 
 func (sb *spansBuffer) Push(span *Span) {
@@ -31,8 +43,17 @@ func (sb *spansBuffer) Push(span *Span) {
 	if len(sb.spans) < sb.maxSize {
 		sb.spans = append(sb.spans, span)
 	} else {
+		// Here we have a problem, buffer is too small. We shoot a random span
+		// and put the most recent span in that place.
+		sb.bufferFull++
 		idx := rand.Intn(sb.maxSize)
 		sb.spans[idx] = span
+	}
+	// If this was a root or a top-level / local root span, mark the trace as finished.
+	// This must really be tested on parent pointer, not on parentID (which can be set
+	// manually, typically when doing distributed tracing).
+	if span.parent == nil {
+		sb.finishedTraces[span.TraceID] = struct{}{}
 	}
 	sb.lock.Unlock()
 }
@@ -41,16 +62,45 @@ func (sb *spansBuffer) Pop() []*Span {
 	sb.lock.Lock()
 	defer sb.lock.Unlock()
 
-	if len(sb.spans) == 0 {
+	if len(sb.spans) == 0 || len(sb.finishedTraces) == 0 {
 		return nil
 	}
 
-	// FIXME[matt] on rotation, we could re-use the slices and spans here
-	// and avoid re-allocing.
-	spans := sb.spans
-	sb.spans = nil
+	j := 0
+	k := 0
+	var spansToReturn []*Span
+	var spansToKeep []*Span
 
-	return spans
+	for _, span := range sb.spans {
+		span.RLock()
+		if _, ok := sb.finishedTraces[span.TraceID]; ok {
+			// return the span, as it belongs to a finished trace
+			if spansToReturn == nil {
+				spansToReturn = make([]*Span, len(sb.spans))
+			}
+			spansToReturn[j] = span
+			j++
+		} else {
+			// put the span back in the buffer
+			if spansToKeep == nil {
+				spansToKeep = make([]*Span, len(sb.spans))
+			}
+			spansToKeep[k] = span
+			k++
+		}
+		span.RUnlock()
+	}
+
+	if spansToKeep == nil {
+		sb.spans = nil
+	} else {
+		sb.spans = spansToKeep[0:k]
+	}
+	if spansToReturn == nil {
+		return nil
+	}
+
+	return spansToReturn[0:j]
 }
 
 func (sb *spansBuffer) Len() int {

--- a/tracer/contrib/elastictraced/elastictraced_test.go
+++ b/tracer/contrib/elastictraced/elastictraced_test.go
@@ -105,7 +105,7 @@ func TestClientV3Failure(t *testing.T) {
 
 	testTracer.FlushTraces()
 	traces := testTransport.Traces()
-	assert.Len(traces, 1)
+	assert.Len(1, traces)
 	spans := traces[0]
 	assert.Equal("my-es-service", spans[0].Service)
 	assert.Equal("PUT /twitter/tweet/?", spans[0].Resource)
@@ -140,7 +140,7 @@ func TestClientV5Failure(t *testing.T) {
 
 	testTracer.FlushTraces()
 	traces := testTransport.Traces()
-	assert.Len(traces, 1)
+	assert.Len(1, traces)
 	spans := traces[0]
 	assert.Equal("my-es-service", spans[0].Service)
 	assert.Equal("PUT /twitter/tweet/?", spans[0].Resource)
@@ -154,7 +154,7 @@ func TestClientV5Failure(t *testing.T) {
 func checkPUTTrace(assert *assert.Assertions, tracer *tracer.Tracer, transport *tracertest.DummyTransport) {
 	tracer.FlushTraces()
 	traces := transport.Traces()
-	assert.Len(traces, 1)
+	assert.Len(1, traces)
 	spans := traces[0]
 	assert.Equal("my-es-service", spans[0].Service)
 	assert.Equal("PUT /twitter/tweet/?", spans[0].Resource)
@@ -165,7 +165,7 @@ func checkPUTTrace(assert *assert.Assertions, tracer *tracer.Tracer, transport *
 func checkGETTrace(assert *assert.Assertions, tracer *tracer.Tracer, transport *tracertest.DummyTransport) {
 	tracer.FlushTraces()
 	traces := transport.Traces()
-	assert.Len(traces, 1)
+	assert.Len(1, traces)
 	spans := traces[0]
 	assert.Equal("my-es-service", spans[0].Service)
 	assert.Equal("GET /twitter/tweet/?", spans[0].Resource)
@@ -176,7 +176,7 @@ func checkGETTrace(assert *assert.Assertions, tracer *tracer.Tracer, transport *
 func checkErrTrace(assert *assert.Assertions, tracer *tracer.Tracer, transport *tracertest.DummyTransport) {
 	tracer.FlushTraces()
 	traces := transport.Traces()
-	assert.Len(traces, 1)
+	assert.Len(1, traces)
 	spans := traces[0]
 	assert.Equal("my-es-service", spans[0].Service)
 	assert.Equal("GET /not-real-index/_all/?", spans[0].Resource)

--- a/tracer/contrib/sqltraced/sqltest/sqltest.go
+++ b/tracer/contrib/sqltraced/sqltest/sqltest.go
@@ -148,11 +148,13 @@ func testTransaction(t *testing.T, db *DB, expectedSpan *tracer.Span) {
 	err = tx.Commit()
 	assert.Equal(nil, err)
 
+	parentSpan.Finish() // need to do this else children are not flushed at all
+
 	db.Tracer.FlushTraces()
 	traces = db.Transport.Traces()
 	assert.Len(traces, 1)
 	spans = traces[0]
-	assert.Len(spans, 3)
+	assert.Len(spans, 4)
 
 	actualSpan = spans[1]
 	execSpan := tracertest.CopySpan(expectedSpan, db.Tracer)

--- a/tracer/span.go
+++ b/tracer/span.go
@@ -60,9 +60,15 @@ type Span struct {
 	sync.RWMutex
 	tracer   *Tracer // the tracer that generated this span
 	finished bool    // true if the span has been submitted to a tracer.
+
+	// parent contains a link to the parent. In most cases, ParentID can be inferred from this.
+	// However, ParentID can technically be overridden (typical usage: distributed tracing)
+	// and also, parent == nil is used to identify root and top-level ("local root") spans.
+	parent *Span
 }
 
-// NewSpan creates a new span.
+// NewSpan creates a new span. This is a low-level function, required for testing and advanced usage.
+// Most of the time one should prefer the Tracer NewRootSpan or NewChildSpan methods.
 func NewSpan(name, service, resource string, spanID, traceID, parentID uint64, tracer *Tracer) *Span {
 	return &Span{
 		Name:     name,

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -200,6 +200,7 @@ func (t *Tracer) NewChildSpan(name string, parent *Span) *Span {
 	span := NewSpan(name, parent.Service, name, spanID, parent.TraceID, parent.SpanID, parent.tracer)
 	// child sampling same as the parent
 	span.Sampled = parent.Sampled
+	span.parent = parent
 
 	return span
 }

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -233,32 +233,23 @@ func (t *Tracer) record(span *Span) {
 // XXX Note that it is currently exported because some tests use it. They
 // really should not.
 func (t *Tracer) FlushTraces() error {
-	spans := t.buffer.Pop()
+	traces := t.buffer.PopTraces()
 
 	if t.DebugLoggingEnabled {
-		log.Printf("Sending %d spans", len(spans))
-		for _, s := range spans {
-			log.Printf("SPAN:\n%s", s.String())
+		log.Printf("Sending %d traces", len(traces))
+		for _, trace := range traces {
+			if len(trace) > 0 {
+				log.Printf("TRACE: %d\n", trace[0].TraceID)
+				for _, span := range trace {
+					log.Printf("SPAN:\n%s", span.String())
+				}
+			}
 		}
 	}
 
 	// bal if there's nothing to do
-	if !t.Enabled() || t.transport == nil || len(spans) == 0 {
+	if !t.Enabled() || t.transport == nil || len(traces) == 0 {
 		return nil
-	}
-
-	// rebuild the traces list; this operation is done in the FlushTraces() instead
-	// after each record() because this avoids a huge number of initializations
-	// and RW mutex locks, keeping the same performance as before (except for this
-	// little overhead). The overall optimization (and idiomatic code) could be
-	// reached replacing all our buffers with channels.
-	var traces [][]*Span
-	traceBuffer := make(map[uint64][]*Span)
-	for _, s := range spans {
-		traceBuffer[s.TraceID] = append(traceBuffer[s.TraceID], s)
-	}
-	for _, t := range traceBuffer {
-		traces = append(traces, t)
 	}
 
 	_, err := t.transport.SendTraces(traces)

--- a/tracer/tracer_test.go
+++ b/tracer/tracer_test.go
@@ -299,13 +299,13 @@ func TestTracerAtomicFlush(t *testing.T) {
 	span2 := tracer.NewChildSpan("redis.command.2", span)
 	span.Finish()
 	span1.Finish()
-	root.Finish()
+	span2.Finish()
 
 	tracer.FlushTraces()
 	traces := transport.Traces()
 	assert.Len(traces, 0, "nothing should be flushed now as span2 is not finished yet")
 
-	span2.Finish()
+	root.Finish()
 
 	tracer.FlushTraces()
 	traces = transport.Traces()


### PR DESCRIPTION
Sending partial bits of traces causes problems on top-level names detection algorithm downstream (which then marks some spans as top-level as it can not identify the parents). This only happens on long traces which spread before and after a flush (several seconds, for instance).