### PR TITLE
Improve time precision on Windows

### DIFF
--- a/tracer/span.go
+++ b/tracer/span.go
@@ -266,8 +266,3 @@ func (s *Span) Tracer() *Tracer {
 func NextSpanID() uint64 {
 	return uint64(randGen.Int63())
 }
-
-// now returns current UTC time in nanos.
-func now() int64 {
-	return time.Now().UTC().UnixNano()
-}

--- a/tracer/time.go
+++ b/tracer/time.go
@@ -1,0 +1,10 @@
+// +build !windows
+
+package tracer
+
+import "time"
+
+// now returns current UTC time in nanos.
+func now() int64 {
+	return time.Now().UTC().UnixNano()
+}

--- a/tracer/time_windows.go
+++ b/tracer/time_windows.go
@@ -1,0 +1,31 @@
+package tracer
+
+import (
+	"golang.org/x/sys/windows"
+	"time"
+)
+
+// This method is more precise than the go1.8 time.Now on Windows
+// See https://msdn.microsoft.com/en-us/library/windows/desktop/hh706895(v=vs.85).aspx
+// It is however ~10x slower and requires Windows 8+.
+func highPrecisionNow() int64 {
+	var ft windows.Filetime
+	windows.GetSystemTimePreciseAsFileTime(&ft)
+	return ft.Nanoseconds()
+}
+
+func lowPrecisonNow() int64 {
+	return time.Now().UTC().UnixNano()
+}
+
+var now func() int64
+
+// If GetSystemTimePreciseAsFileTime is not available we default to the less
+// precise implementation based on time.Now()
+func init() {
+	if err := windows.LoadGetSystemTimePreciseAsFileTime(); err != nil {
+		now = lowPrecisonNow
+	} else {
+		now = highPrecisionNow
+	}
+}

--- a/tracer/time_windows.go
+++ b/tracer/time_windows.go
@@ -2,6 +2,7 @@ package tracer
 
 import (
 	"golang.org/x/sys/windows"
+	"log"
 	"time"
 )
 
@@ -14,7 +15,7 @@ func highPrecisionNow() int64 {
 	return ft.Nanoseconds()
 }
 
-func lowPrecisonNow() int64 {
+func lowPrecisionNow() int64 {
 	return time.Now().UTC().UnixNano()
 }
 
@@ -24,8 +25,10 @@ var now func() int64
 // precise implementation based on time.Now()
 func init() {
 	if err := windows.LoadGetSystemTimePreciseAsFileTime(); err != nil {
-		now = lowPrecisonNow
+		log.Printf("Unable to load high precison timer, defaulting to time.Now()")
+		now = lowPrecisionNow
 	} else {
+		log.Printf("Using high precision timer")
 		now = highPrecisionNow
 	}
 }

--- a/tracer/time_windows_test.go
+++ b/tracer/time_windows_test.go
@@ -1,10 +1,14 @@
 package tracer
 
-import "testing"
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
 
 func BenchmarkNormalTimeNow(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		lowPrecisonNow()
+		lowPrecisionNow()
 	}
 }
 
@@ -12,4 +16,15 @@ func BenchmarkHighPrecisionTime(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		highPrecisionNow()
 	}
+}
+
+func TestHighPrecisionTimerIsMoreAccurate(t *testing.T) {
+	startLow := lowPrecisionNow()
+	startHigh := highPrecisionNow()
+	stopHigh := highPrecisionNow()
+	for stopHigh == startHigh {
+		stopHigh = highPrecisionNow()
+	}
+	stopLow := lowPrecisionNow()
+	assert.Equal(t, int64(0), stopLow-startLow)
 }

--- a/tracer/time_windows_test.go
+++ b/tracer/time_windows_test.go
@@ -1,0 +1,15 @@
+package tracer
+
+import "testing"
+
+func BenchmarkNormalTimeNow(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		lowPrecisonNow()
+	}
+}
+
+func BenchmarkHighPrecisionTime(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		highPrecisionNow()
+	}
+}


### PR DESCRIPTION
This switches from time.Now to GetSystemTimePreciseAsFileTime to improve the precision of the timestamps and duration computations from ~1ms to ~1µs. This comes at a performance cost since this call is much slower than the original one. I've run benchmarks in my VM and it makes a ~10x difference:

BenchmarkNormalTimeNow-2        100000000               12.7 ns/op
BenchmarkHighPrecisionTime-2    20000000               101 ns/op

This remain very fast, so I think the precision gain is worth the performance cost.