### PR TITLE
Raphael/gocql cleaning

### DIFF
--- a/tracer/contrib/gocql/example_test.go
+++ b/tracer/contrib/gocql/example_test.go
@@ -1,0 +1,27 @@
+package gocqltrace
+
+import (
+	"context"
+	"github.com/DataDog/dd-trace-go/tracer"
+	"github.com/gocql/gocql"
+)
+
+// To trace Cassandra commands, use our query wrapper TraceQuery.
+func Example() {
+
+	// Initialise a Cassandra session as usual, create a query.
+	cluster := gocql.NewCluster("127.0.0.1")
+	session, _ := cluster.CreateSession()
+	query := session.Query("CREATE KEYSPACE if not exists trace WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor': 1}")
+
+	// Use context to pass information down the call chain
+	root := tracer.NewRootSpan("parent.request", "web", "/home")
+	ctx := root.Context(context.Background())
+
+	// Wrap the query to trace it and pass the context for inheritance
+	tracedQuery := TraceQuery("ServiceName", tracer.DefaultTracer, query)
+	tracedQuery.WithContext(ctx)
+
+	// Execute your query as usual
+	tracedQuery.Exec()
+}

--- a/tracer/contrib/gocql/gocqltrace.go
+++ b/tracer/contrib/gocql/gocqltrace.go
@@ -37,16 +37,15 @@ type traceParams struct {
 
 // TraceQuery wraps a gocql.Query into a TracedQuery
 func TraceQuery(service string, tracer *tracer.Tracer, q *gocql.Query) *TracedQuery {
-	string_query := `"` + strings.SplitN(q.String(), "\"", 3)[1] + `"`
-	string_query, err := strconv.Unquote(string_query)
+	stringQuery := `"` + strings.SplitN(q.String(), "\"", 3)[1] + `"`
+	stringQuery, err := strconv.Unquote(stringQuery)
 	if err != nil {
 		// An invalid string, so that the trace is not dropped
 		// due to having an empty resource
-		string_query = "_"
+		stringQuery = "_"
 	}
 
-	q.NoSkipMetadata()
-	tq := &TracedQuery{q, traceParams{tracer, service, "", "false", strconv.Itoa(int(q.GetConsistency())), string_query}, context.Background()}
+	tq := &TracedQuery{q, traceParams{tracer, service, "", "false", strconv.Itoa(int(q.GetConsistency())), stringQuery}, context.Background()}
 	tracer.SetServiceInfo(service, ext.CassandraType, ext.AppTypeDB)
 	return tq
 }

--- a/tracer/contrib/gocql/gocqltrace.go
+++ b/tracer/contrib/gocql/gocqltrace.go
@@ -137,18 +137,9 @@ func (tq *TracedQuery) Iter() *TracedIter {
 
 // Close closes the TracedIter and finish the span created on Iter call.
 func (tIter *TracedIter) Close() error {
-	columns := tIter.Iter.Columns()
-	if len(columns) > 0 {
-		tIter.span.SetMeta(ext.CassandraKeyspace, columns[0].Keyspace)
-	}
 	err := tIter.Iter.Close()
 	if err != nil {
 		tIter.span.SetError(err)
-	}
-	if tIter.Host() != nil {
-		tIter.span.SetMeta(ext.TargetHost, tIter.Iter.Host().Peer().String())
-		tIter.span.SetMeta(ext.TargetPort, strconv.Itoa(tIter.Iter.Host().Port()))
-		tIter.span.SetMeta(ext.CassandraCluster, tIter.Iter.Host().DataCenter())
 	}
 	tIter.span.Finish()
 	return err


### PR DESCRIPTION
Code cleaning: removing snake_case, removing the NoSkipMetaData call which is now useless.
Updating tests since gocql/gocql fix PR got merged
Adding an example file