### PR TITLE
Added net/http-tracer

### DIFF
--- a/tracer/contrib/net/httptrace/example_test.go
+++ b/tracer/contrib/net/httptrace/example_test.go
@@ -16,8 +16,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 func Example() {
 	mux := http.NewServeMux()
-	mux.Handle("/users", hander)
-	mux.Handle("/anything", hander)
+	mux.Handle("/users", handler)
+	mux.Handle("/anything", handler)
 	httpTracer := httptrace.NewHttpTracer("fake-service", tracer.DefaultTracer)
 
 	http.ListenAndServe(":8080", httpTracer.Handler(mux))

--- a/tracer/contrib/net/httptrace/example_test.go
+++ b/tracer/contrib/net/httptrace/example_test.go
@@ -1,0 +1,24 @@
+package httptrace_test
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/DataDog/dd-trace-go/tracer"
+	"github.com/DataDog/dd-trace-go/tracer/contrib/net/httptrace"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	span := tracer.SpanFromContextDefault(r.Context())
+	fmt.Printf("tracing service:%s resource:%s", span.Service, span.Resource)
+	w.Write([]byte("hello world"))
+}
+
+func Example() {
+	mux := http.NewServeMux()
+	mux.Handle("/users", hander)
+	mux.Handle("/anything", hander)
+	httpTracer := httptrace.NewHttpTracer("fake-service", tracer.DefaultTracer)
+
+	http.ListenAndServe(":8080", httpTracer.Handler(mux))
+}

--- a/tracer/contrib/net/httptrace/httptrace.go
+++ b/tracer/contrib/net/httptrace/httptrace.go
@@ -23,9 +23,17 @@ func NewHttpTracer(service string, t *tracer.Tracer) *HttpTracer {
 	}
 }
 
-// TraceHandleFunc will return a HandlerFunc that will wrap tracing around the
+// Handler will return a Handler that will wrap tracing around the
+// given handler.
+func (h *HttpTracer) Handler(handler http.Handler) http.Handler {
+	return h.TraceHandlerFunc(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		handler.ServeHTTP(writer, req)
+	}))
+}
+
+// TraceHandlerFunc will return a HandlerFunc that will wrap tracing around the
 // given handler func.
-func (h *HttpTracer) Handler(handler http.HandlerFunc) http.HandlerFunc {
+func (h *HttpTracer) TraceHandlerFunc(handler http.HandlerFunc) http.HandlerFunc {
 
 	return func(writer http.ResponseWriter, req *http.Request) {
 

--- a/tracer/contrib/net/httptrace/httptrace.go
+++ b/tracer/contrib/net/httptrace/httptrace.go
@@ -1,0 +1,114 @@
+package httptrace
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/DataDog/dd-trace-go/tracer"
+	"github.com/DataDog/dd-trace-go/tracer/ext"
+)
+
+// HttpTracer is used to trace requests in a net/http server.
+type HttpTracer struct {
+	tracer  *tracer.Tracer
+	service string
+}
+
+// NewHttpTracer creates a HttpTracer for the given service and tracer.
+func NewHttpTracer(service string, t *tracer.Tracer) *HttpTracer {
+	t.SetServiceInfo(service, "net/http", ext.AppTypeWeb)
+	return &HttpTracer{
+		tracer:  t,
+		service: service,
+	}
+}
+
+// TraceHandleFunc will return a HandlerFunc that will wrap tracing around the
+// given handler func.
+func (h *HttpTracer) Handler(handler http.HandlerFunc) http.HandlerFunc {
+
+	return func(writer http.ResponseWriter, req *http.Request) {
+
+		// bail our if tracing isn't enabled.
+		if !h.tracer.Enabled() {
+			handler(writer, req)
+			return
+		}
+
+		// trace the request
+		tracedRequest, span := h.trace(req)
+		defer span.Finish()
+
+		// trace the response
+		tracedWriter := newTracedResponseWriter(span, writer)
+
+		// run the request
+		handler(tracedWriter, tracedRequest)
+	}
+}
+
+// span will create a span for the given request.
+func (h *HttpTracer) trace(req *http.Request) (*http.Request, *tracer.Span) {
+	resource := req.Method + " " + req.URL.Path
+
+	span := h.tracer.NewRootSpan("http.request", h.service, resource)
+	span.Type = ext.HTTPType
+	span.SetMeta(ext.HTTPMethod, req.Method)
+	span.SetMeta(ext.HTTPURL, req.URL.Path)
+
+	// patch the span onto the request context.
+	treq := SetRequestSpan(req, span)
+	return treq, span
+}
+
+// tracedResponseWriter is a small wrapper around an http response writer that will
+// intercept and store the status of a request.
+type tracedResponseWriter struct {
+	span   *tracer.Span
+	w      http.ResponseWriter
+	status int
+}
+
+func newTracedResponseWriter(span *tracer.Span, w http.ResponseWriter) *tracedResponseWriter {
+	return &tracedResponseWriter{
+		span: span,
+		w:    w,
+	}
+}
+
+func (t *tracedResponseWriter) Header() http.Header {
+	return t.w.Header()
+}
+
+func (t *tracedResponseWriter) Write(b []byte) (int, error) {
+	if t.status == 0 {
+		t.WriteHeader(http.StatusOK)
+	}
+	return t.w.Write(b)
+}
+
+func (t *tracedResponseWriter) WriteHeader(status int) {
+	t.w.WriteHeader(status)
+	t.status = status
+	t.span.SetMeta(ext.HTTPCode, strconv.Itoa(status))
+	if status >= 500 && status < 600 {
+		t.span.Error = 1
+	}
+}
+
+// SetRequestSpan sets the span on the request's context.
+func SetRequestSpan(r *http.Request, span *tracer.Span) *http.Request {
+	if r == nil || span == nil {
+		return r
+	}
+
+	ctx := tracer.ContextWithSpan(r.Context(), span)
+	return r.WithContext(ctx)
+}
+
+// GetRequestSpan will return the span associated with the given request. It
+// will return nil/false if it doesn't exist.
+func GetRequestSpan(r *http.Request) (*tracer.Span, bool) {
+	span, ok := tracer.SpanFromContext(r.Context())
+	return span, ok
+}

--- a/tracer/contrib/net/httptrace/httptrace.go
+++ b/tracer/contrib/net/httptrace/httptrace.go
@@ -37,7 +37,7 @@ func (h *HttpTracer) TraceHandlerFunc(handler http.HandlerFunc) http.HandlerFunc
 
 	return func(writer http.ResponseWriter, req *http.Request) {
 
-		// bail our if tracing isn't enabled.
+		// bail out if tracing isn't enabled.
 		if !h.tracer.Enabled() {
 			handler(writer, req)
 			return

--- a/tracer/contrib/net/httptrace/httptrace_test.go
+++ b/tracer/contrib/net/httptrace/httptrace_test.go
@@ -1,0 +1,168 @@
+package httptrace
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/tracer"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHttpTracerDisabled(t *testing.T) {
+	assert := assert.New(t)
+
+	testTracer, testTransport, httpTracer := getTestTracer("disabled-service")
+	handler := httpTracer.Handler(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte("disabled!"))
+		assert.Nil(err)
+		// Ensure we have no tracing context.
+		span, ok := tracer.SpanFromContext(r.Context())
+		assert.Nil(span)
+		assert.False(ok)
+	})
+	testTracer.SetEnabled(false) // the key line in this test.
+
+	// make the request
+	req := httptest.NewRequest("GET", "/disabled", nil)
+	writer := httptest.NewRecorder()
+	handler.ServeHTTP(writer, req)
+	assert.Equal(writer.Code, 200)
+	assert.Equal(writer.Body.String(), "disabled!")
+
+	// assert nothing was traced.
+	testTracer.ForceFlush()
+	traces := testTransport.Traces()
+	assert.Len(traces, 0)
+}
+
+func TestHttpTracer200(t *testing.T) {
+	assert := assert.New(t)
+
+	// setup
+	tracer, transport, router := setup(t)
+
+	// Send and verify a 200 request
+	url := "/200"
+	req := httptest.NewRequest("GET", url, nil)
+	writer := httptest.NewRecorder()
+	router.ServeHTTP(writer, req)
+	assert.Equal(writer.Code, 200)
+	assert.Equal(writer.Body.String(), "200!")
+
+	// ensure properly traced
+	tracer.ForceFlush()
+	traces := transport.Traces()
+	assert.Len(traces, 1)
+	spans := traces[0]
+	assert.Len(spans, 1)
+
+	s := spans[0]
+	assert.Equal(s.Name, "http.request")
+	assert.Equal(s.Service, "my-service")
+	assert.Equal(s.Resource, "GET "+url)
+	assert.Equal(s.GetMeta("http.status_code"), "200")
+	assert.Equal(s.GetMeta("http.method"), "GET")
+	assert.Equal(s.GetMeta("http.url"), url)
+	assert.Equal(s.Error, int32(0))
+}
+
+func TestHttpTracer500(t *testing.T) {
+	assert := assert.New(t)
+
+	// setup
+	tracer, transport, router := setup(t)
+
+	// SEnd and verify a 200 request
+	url := "/500"
+	req := httptest.NewRequest("GET", url, nil)
+	writer := httptest.NewRecorder()
+	router.ServeHTTP(writer, req)
+	assert.Equal(writer.Code, 500)
+	assert.Equal(writer.Body.String(), "500!\n")
+
+	// ensure properly traced
+	tracer.ForceFlush()
+	traces := transport.Traces()
+	assert.Len(traces, 1)
+	spans := traces[0]
+	assert.Len(spans, 1)
+
+	s := spans[0]
+	assert.Equal(s.Name, "http.request")
+	assert.Equal(s.Service, "my-service")
+	assert.Equal(s.Resource, "GET "+url)
+	assert.Equal(s.GetMeta("http.status_code"), "500")
+	assert.Equal(s.GetMeta("http.method"), "GET")
+	assert.Equal(s.GetMeta("http.url"), url)
+	assert.Equal(s.Error, int32(1))
+}
+
+// test handlers
+
+func handler200(t *testing.T) http.HandlerFunc {
+	assert := assert.New(t)
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte("200!"))
+		assert.Nil(err)
+		span := tracer.SpanFromContextDefault(r.Context())
+		assert.Equal(span.Service, "my-service")
+		assert.Equal(span.Duration, int64(0))
+	}
+}
+
+func handler500(t *testing.T) http.HandlerFunc {
+	assert := assert.New(t)
+	return func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "500!", http.StatusInternalServerError)
+		span := tracer.SpanFromContextDefault(r.Context())
+		assert.Equal(span.Service, "my-service")
+		assert.Equal(span.Duration, int64(0))
+	}
+}
+
+func setup(t *testing.T) (*tracer.Tracer, *dummyTransport, *http.ServeMux) {
+	tracer, transport, ht := getTestTracer("my-service")
+
+	mux := http.NewServeMux()
+
+	h200 := handler200(t)
+	h500 := handler500(t)
+
+	mux.Handle("/200", ht.Handler(h200))
+	mux.Handle("/500", ht.Handler(h500))
+
+	return tracer, transport, mux
+}
+
+// getTestTracer returns a Tracer with a DummyTransport
+func getTestTracer(service string) (*tracer.Tracer, *dummyTransport, *HttpTracer) {
+	transport := &dummyTransport{}
+	tracer := tracer.NewTracerTransport(transport)
+	muxTracer := NewHttpTracer(service, tracer)
+	return tracer, transport, muxTracer
+}
+
+// dummyTransport is a transport that just buffers spans and encoding
+type dummyTransport struct {
+	traces   [][]*tracer.Span
+	services map[string]tracer.Service
+}
+
+func (t *dummyTransport) SendTraces(traces [][]*tracer.Span) (*http.Response, error) {
+	t.traces = append(t.traces, traces...)
+	return nil, nil
+}
+
+func (t *dummyTransport) SendServices(services map[string]tracer.Service) (*http.Response, error) {
+	t.services = services
+	return nil, nil
+}
+
+func (t *dummyTransport) Traces() [][]*tracer.Span {
+	traces := t.traces
+	t.traces = nil
+	return traces
+}
+
+func (t *dummyTransport) SetHeader(key, value string) {}

--- a/tracer/contrib/net/httptrace/httptrace_test.go
+++ b/tracer/contrib/net/httptrace/httptrace_test.go
@@ -13,7 +13,7 @@ func TestHttpTracerDisabled(t *testing.T) {
 	assert := assert.New(t)
 
 	testTracer, testTransport, httpTracer := getTestTracer("disabled-service")
-	handler := httpTracer.Handler(func(w http.ResponseWriter, r *http.Request) {
+	handler := httpTracer.TraceHandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write([]byte("disabled!"))
 		assert.Nil(err)
 		// Ensure we have no tracing context.


### PR DESCRIPTION
This adds a generic handler for a net/http server.

I think it may be good to have gorilla use this as the core tracer in the future.