### PR TITLE
fix NewChildSpanFromContext

### DIFF
--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -228,7 +228,7 @@ func (t *Tracer) NewChildSpanFromContext(name string, ctx context.Context) *Span
 // child span. If the context contains no span, an empty root span will be returned.
 // If nil is passed in for the context, a context will be created.
 func (t *Tracer) NewChildSpanWithContext(name string, ctx context.Context) (*Span, context.Context) {
-	span := NewChildSpanFromContext(name, ctx)
+	span := t.NewChildSpanFromContext(name, ctx)
 	return span, span.Context(ctx)
 }
 

--- a/tracer/tracer_test.go
+++ b/tracer/tracer_test.go
@@ -82,6 +82,7 @@ func TestNewChildSpanWithContext(t *testing.T) {
 	assert.Equal("abc", span.Name)
 	assert.Equal("", span.Service)
 	assert.Equal(span.ParentID, span.SpanID) // it should be a root span
+	assert.Equal(span.Tracer(), tracer)
 	// the returned ctx should contain the created span
 	assert.NotNil(ctx)
 	ctxSpan, ok := SpanFromContext(ctx)


### PR DESCRIPTION
when called on a specific tracer, it should create the span from this tracer, not from the default one