### PR TITLE
Added SetMetas(), similar to ddtrace-python's set_tags()

### DIFF
--- a/tracer/span.go
+++ b/tracer/span.go
@@ -120,6 +120,14 @@ func (s *Span) SetMeta(key, value string) {
 
 }
 
+// SetMetas adds arbitrary meta fields from a given map to the current Span.
+// If the Span has been finished, it will not be modified by the method.
+func (s *Span) SetMetas(metas map[string]string) {
+	for k, v := range metas {
+		s.SetMeta(k, v)
+	}
+}
+
 // GetMeta will return the value for the given tag or the empty string if it
 // doesn't exist.
 func (s *Span) GetMeta(key string) string {

--- a/tracer/span_test.go
+++ b/tracer/span_test.go
@@ -45,6 +45,38 @@ func TestSpanSetMeta(t *testing.T) {
 	assert.Equal(span.Meta["finished.test"], "")
 }
 
+func TestSpanSetMetas(t *testing.T) {
+	assert := assert.New(t)
+	tracer := NewTracer()
+	span := tracer.NewRootSpan("pylons.request", "pylons", "/")
+	metas := map[string]string{
+		"error.msg":   "Something wrong",
+		"error.type":  "*errors.errorString",
+		"status.code": "200",
+	}
+	nopMetas := map[string]string{
+		"nopKey1": "nopValue1",
+		"nopKey2": "nopValue2",
+	}
+
+	// check the map is properly initialized
+	span.SetMetas(metas)
+	assert.Equal(len(span.Meta), len(metas))
+	for k := range metas {
+		assert.Equal(metas[k], span.Meta[k])
+	}
+	assert.Equal(span.Meta["status.code"], "200")
+
+	// operating on a finished span is a no-op
+	span.Finish()
+	span.SetMetas(nopMetas)
+	assert.Equal(len(span.Meta), len(metas))
+	for k := range nopMetas {
+		assert.Equal("", span.Meta[k])
+	}
+
+}
+
 func TestSpanSetMetric(t *testing.T) {
 	assert := assert.New(t)
 	tracer := NewTracer()


### PR DESCRIPTION
I noticed that ddtrace-python had a method that allowed a user to update a Span's metadata with a map. I thought this feature would be similarly useful and easy to add.