### PR TITLE
contrib: add support for httprouter

### DIFF
--- a/tracer/contrib/gorilla/muxtrace/muxtrace.go
+++ b/tracer/contrib/gorilla/muxtrace/muxtrace.go
@@ -115,7 +115,7 @@ func SetRequestSpan(r *http.Request, span *tracer.Span) *http.Request {
 		return r
 	}
 
-	ctx := tracer.ContextWithSpan(r.Context(), span)
+	ctx := span.Context(r.Context())
 	return r.WithContext(ctx)
 }
 

--- a/tracer/contrib/httprouter/httproutertrace/httproutertrace.go
+++ b/tracer/contrib/httprouter/httproutertrace/httproutertrace.go
@@ -1,0 +1,116 @@
+// Package httproutertrace provides an easy way to trace github.com/julienschmidt/httprouter
+package httproutertrace
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/DataDog/dd-trace-go/tracer"
+	"github.com/DataDog/dd-trace-go/tracer/ext"
+	"github.com/julienschmidt/httprouter"
+)
+
+// HTTPRouterTracer is used to trace requests in a mux server.
+type HTTPRouterTracer struct {
+	tracer  *tracer.Tracer
+	service string
+	router  *httprouter.Router
+}
+
+// NewHTTPRouterTracer creates an HttpRouterTracer for the given service and tracer.
+func NewHTTPRouterTracer(service string, t *tracer.Tracer, r *httprouter.Router) *HTTPRouterTracer {
+	t.SetServiceInfo(service, "http", ext.AppTypeWeb)
+	return &HTTPRouterTracer{
+		tracer:  t,
+		service: service,
+		router:  r,
+	}
+}
+
+// SetRequestSpan sets the span on the request's context.
+func SetRequestSpan(r *http.Request, span *tracer.Span) *http.Request {
+	if r == nil || span == nil {
+		return r
+	}
+	ctx := span.Context(r.Context())
+	return r.WithContext(ctx)
+}
+
+// span will create a span for the given request.
+func (ht *HTTPRouterTracer) trace(req *http.Request) (*http.Request, *tracer.Span) {
+	path := req.URL.Path
+	resource := req.Method + " " + path
+	span := ht.tracer.NewRootSpan("http.request", ht.service, resource)
+	span.Type = ext.HTTPType
+	span.SetMeta(ext.HTTPMethod, req.Method)
+	span.SetMeta(ext.HTTPURL, path)
+
+	// patch the span onto the request context.
+	treq := SetRequestSpan(req, span)
+	return treq, span
+}
+
+// Middleware creates a new standard http middleware to use with middleware chainers such as alice, negroni
+func (ht *HTTPRouterTracer) Middleware() func(http.Handler) http.Handler {
+	return func(h http.Handler) http.Handler {
+		return ht.TraceHandlerFunc(h.ServeHTTP)
+	}
+}
+
+// TraceHandlerFunc will return a HandlerFunc that will wrap tracing around the
+// given handler func.
+func (ht *HTTPRouterTracer) TraceHandlerFunc(handler http.HandlerFunc) http.HandlerFunc {
+	return func(writer http.ResponseWriter, req *http.Request) {
+
+		// bail our if tracing isn't enabled.
+		if !ht.tracer.Enabled() {
+			handler(writer, req)
+			return
+		}
+
+		// trace the request
+		tracedRequest, span := ht.trace(req)
+		defer span.Finish()
+
+		// trace the response
+		tracedWriter := newTracedResponseWriter(span, writer)
+
+		// run the request
+		handler(tracedWriter, tracedRequest)
+	}
+}
+
+// tracedResponseWriter is a small wrapper around an http response writer that will
+// intercept and store the status of a request.
+type tracedResponseWriter struct {
+	span   *tracer.Span
+	w      http.ResponseWriter
+	status int
+}
+
+func newTracedResponseWriter(span *tracer.Span, w http.ResponseWriter) *tracedResponseWriter {
+	return &tracedResponseWriter{
+		span: span,
+		w:    w,
+	}
+}
+
+func (t *tracedResponseWriter) Header() http.Header {
+	return t.w.Header()
+}
+
+func (t *tracedResponseWriter) Write(b []byte) (int, error) {
+	if t.status == 0 {
+		t.WriteHeader(http.StatusOK)
+	}
+	return t.w.Write(b)
+}
+
+func (t *tracedResponseWriter) WriteHeader(status int) {
+	t.w.WriteHeader(status)
+	t.status = status
+	t.span.SetMeta(ext.HTTPCode, strconv.Itoa(status))
+	if status >= 500 && status < 600 {
+		t.span.Error = 1
+	}
+}

--- a/tracer/contrib/httprouter/httproutertrace/httproutertrace_test.go
+++ b/tracer/contrib/httprouter/httproutertrace/httproutertrace_test.go
@@ -1,0 +1,169 @@
+package httproutertrace
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/tracer"
+	"github.com/julienschmidt/httprouter"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPRouterTracerDisabled(t *testing.T) {
+	assert := assert.New(t)
+	router := httprouter.New()
+	testTracer, testTransport, httprouterTracer := getTestTracer("disabled-service", router)
+	router.HandlerFunc("GET", "/disabled", httprouterTracer.TraceHandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte("disabled!"))
+		assert.Nil(err)
+		// Ensure we have no tracing context.
+		span, ok := tracer.SpanFromContext(r.Context())
+		assert.Nil(span)
+		assert.False(ok)
+	}))
+	testTracer.SetEnabled(false) // the key line in this test.
+
+	// make the request
+	req := httptest.NewRequest("GET", "/disabled", nil)
+	writer := httptest.NewRecorder()
+	router.ServeHTTP(writer, req)
+	assert.Equal(writer.Code, 200)
+	assert.Equal(writer.Body.String(), "disabled!")
+
+	// assert nothing was traced.
+	testTracer.ForceFlush()
+	traces := testTransport.Traces()
+	assert.Len(traces, 0)
+}
+
+func TestHTTPRouterTracer200(t *testing.T) {
+	assert := assert.New(t)
+
+	// setup
+	tracer, transport, router := setup(t)
+
+	// Send and verify a 200 request
+	url := "/200"
+	req := httptest.NewRequest("GET", url, nil)
+	writer := httptest.NewRecorder()
+	router.ServeHTTP(writer, req)
+	assert.Equal(writer.Code, 200)
+	assert.Equal(writer.Body.String(), "200!")
+
+	// ensure properly traced
+	tracer.ForceFlush()
+	traces := transport.Traces()
+	assert.Len(traces, 1)
+	spans := traces[0]
+	assert.Len(spans, 1)
+
+	s := spans[0]
+	assert.Equal(s.Name, "http.request")
+	assert.Equal(s.Service, "my-service")
+	assert.Equal(s.Resource, "GET "+url)
+	assert.Equal(s.GetMeta("http.status_code"), "200")
+	assert.Equal(s.GetMeta("http.method"), "GET")
+	assert.Equal(s.GetMeta("http.url"), url)
+	assert.Equal(s.Error, int32(0))
+}
+
+func TestHTTPRouterTracer500(t *testing.T) {
+	assert := assert.New(t)
+
+	// setup
+	tracer, transport, router := setup(t)
+
+	// Send and verify a 200 request
+	url := "/500"
+	req := httptest.NewRequest("GET", url, nil)
+	writer := httptest.NewRecorder()
+	router.ServeHTTP(writer, req)
+	assert.Equal(writer.Code, 500)
+	assert.Equal(writer.Body.String(), "500!\n")
+
+	// ensure properly traced
+	tracer.ForceFlush()
+	traces := transport.Traces()
+	assert.Len(traces, 1)
+	spans := traces[0]
+	assert.Len(spans, 1)
+
+	s := spans[0]
+	assert.Equal(s.Name, "http.request")
+	assert.Equal(s.Service, "my-service")
+	assert.Equal(s.Resource, "GET "+url)
+	assert.Equal(s.GetMeta("http.status_code"), "500")
+	assert.Equal(s.GetMeta("http.method"), "GET")
+	assert.Equal(s.GetMeta("http.url"), url)
+	assert.Equal(s.Error, int32(1))
+}
+
+// test handlers
+
+func handler200(t *testing.T) http.HandlerFunc {
+	assert := assert.New(t)
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte("200!"))
+		assert.Nil(err)
+		span := tracer.SpanFromContextDefault(r.Context())
+		assert.Equal(span.Service, "my-service")
+		assert.Equal(span.Duration, int64(0))
+	}
+}
+
+func handler500(t *testing.T) http.HandlerFunc {
+	assert := assert.New(t)
+	return func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "500!", http.StatusInternalServerError)
+		span := tracer.SpanFromContextDefault(r.Context())
+		assert.Equal(span.Service, "my-service")
+		assert.Equal(span.Duration, int64(0))
+	}
+}
+
+func setup(t *testing.T) (*tracer.Tracer, *dummyTransport, *httprouter.Router) {
+	r := httprouter.New()
+	tracer, transport, ht := getTestTracer("my-service", r)
+
+	h200 := handler200(t)
+	h500 := handler500(t)
+
+	// Ensure we can use HandleFunc and it returns a route
+	r.HandlerFunc("GET", "/200", ht.TraceHandlerFunc(h200)) // And we can allso handle a bare func
+	r.HandlerFunc("GET", "/500", ht.TraceHandlerFunc(h500))
+
+	return tracer, transport, r
+}
+
+// getTestTracer returns a Tracer with a DummyTransport
+func getTestTracer(service string, router *httprouter.Router) (*tracer.Tracer, *dummyTransport, *HTTPRouterTracer) {
+	transport := &dummyTransport{}
+	tracer := tracer.NewTracerTransport(transport)
+	httprouterTracer := NewHTTPRouterTracer(service, tracer, router)
+	return tracer, transport, httprouterTracer
+}
+
+// dummyTransport is a transport that just buffers spans and encoding
+type dummyTransport struct {
+	traces   [][]*tracer.Span
+	services map[string]tracer.Service
+}
+
+func (t *dummyTransport) SendTraces(traces [][]*tracer.Span) (*http.Response, error) {
+	t.traces = append(t.traces, traces...)
+	return nil, nil
+}
+
+func (t *dummyTransport) SendServices(services map[string]tracer.Service) (*http.Response, error) {
+	t.services = services
+	return nil, nil
+}
+
+func (t *dummyTransport) Traces() [][]*tracer.Span {
+	traces := t.traces
+	t.traces = nil
+	return traces
+}
+
+func (t *dummyTransport) SetHeader(key, value string) {}


### PR DESCRIPTION
Hi everyone, 
I implemented full support for github.com/julienschmidt/httprouter, as it is a very popular http mux. This requires a specific implementation to deal with url named parameters.
