### PR TITLE
Add pid to root spans

### DIFF
--- a/tracer/context_test.go
+++ b/tracer/context_test.go
@@ -30,7 +30,7 @@ func TestSpanFromContext(t *testing.T) {
 
 	span, ok := SpanFromContext(ctx)
 	assert.True(ok)
-	assert.Equal(span, expectedSpan)
+	assert.Equal(expectedSpan, span)
 }
 
 func TestSpanFromContextNil(t *testing.T) {
@@ -65,5 +65,5 @@ func TestSpanMissingParent(t *testing.T) {
 	// the child is finished but it's not recorded in
 	// the tracer buffer because the service is missing
 	assert.True(child.Duration > 0)
-	assert.Equal(len(tracer.channels.trace), 1)
+	assert.Equal(1, len(tracer.channels.trace))
 }

--- a/tracer/ext/system.go
+++ b/tracer/ext/system.go
@@ -1,0 +1,6 @@
+package ext
+
+// Standard error message metadata fields.
+const (
+	Pid = "system.pid"
+)

--- a/tracer/ext/system.go
+++ b/tracer/ext/system.go
@@ -1,6 +1,7 @@
 package ext
 
-// Standard error message metadata fields.
+// Standard system metadata names
 const (
+	// The pid of the traced process
 	Pid = "system.pid"
 )

--- a/tracer/span_test.go
+++ b/tracer/span_test.go
@@ -15,7 +15,7 @@ func TestSpanStart(t *testing.T) {
 	span := tracer.NewRootSpan("pylons.request", "pylons", "/")
 
 	// a new span sets the Start after the initialization
-	assert.NotEqual(span.Start, int64(0))
+	assert.NotEqual(int64(0), span.Start)
 }
 
 func TestSpanString(t *testing.T) {
@@ -35,7 +35,7 @@ func TestSpanSetMeta(t *testing.T) {
 
 	// check the map is properly initialized
 	span.SetMeta("status.code", "200")
-	assert.Equal(span.Meta["status.code"], "200")
+	assert.Equal("200", span.Meta["status.code"])
 
 	// operating on a finished span is a no-op
 	nMeta := len(span.Meta)
@@ -52,14 +52,14 @@ func TestSpanSetMetric(t *testing.T) {
 
 	// check the map is properly initialized
 	span.SetMetric("bytes", 1024.42)
-	assert.Equal(len(span.Metrics), 1)
-	assert.Equal(span.Metrics["bytes"], 1024.42)
+	assert.Equal(1, len(span.Metrics))
+	assert.Equal(1024.42, span.Metrics["bytes"])
 
 	// operating on a finished span is a no-op
 	span.Finish()
 	span.SetMetric("finished.test", 1337)
-	assert.Equal(len(span.Metrics), 1)
-	assert.Equal(span.Metrics["finished.test"], 0.0)
+	assert.Equal(1, len(span.Metrics))
+	assert.Equal(0.0, span.Metrics["finished.test"])
 }
 
 func TestSpanError(t *testing.T) {
@@ -70,21 +70,21 @@ func TestSpanError(t *testing.T) {
 	// check the error is set in the default meta
 	err := errors.New("Something wrong")
 	span.SetError(err)
-	assert.Equal(span.Error, int32(1))
-	assert.Equal(span.Meta["error.msg"], "Something wrong")
-	assert.Equal(span.Meta["error.type"], "*errors.errorString")
-	assert.NotEqual(span.Meta["error.stack"], "")
+	assert.Equal(int32(1), span.Error)
+	assert.Equal("Something wrong", span.Meta["error.msg"])
+	assert.Equal("*errors.errorString", span.Meta["error.type"])
+	assert.NotEqual("", span.Meta["error.stack"])
 
 	// operating on a finished span is a no-op
 	span = tracer.NewRootSpan("flask.request", "flask", "/")
 	nMeta := len(span.Meta)
 	span.Finish()
 	span.SetError(err)
-	assert.Equal(span.Error, int32(0))
-	assert.Equal(len(span.Meta), nMeta)
-	assert.Equal(span.Meta["error.msg"], "")
-	assert.Equal(span.Meta["error.type"], "")
-	assert.Equal(span.Meta["error.stack"], "")
+	assert.Equal(int32(0), span.Error)
+	assert.Equal(nMeta, len(span.Meta))
+	assert.Equal("", span.Meta["error.msg"])
+	assert.Equal("", span.Meta["error.type"])
+	assert.Equal("", span.Meta["error.stack"])
 }
 
 func TestSpanError_Typed(t *testing.T) {
@@ -95,10 +95,10 @@ func TestSpanError_Typed(t *testing.T) {
 	// check the error is set in the default meta
 	err := &boomError{}
 	span.SetError(err)
-	assert.Equal(span.Error, int32(1))
-	assert.Equal(span.Meta["error.msg"], "boom")
-	assert.Equal(span.Meta["error.type"], "*tracer.boomError")
-	assert.NotEqual(span.Meta["error.stack"], "")
+	assert.Equal(int32(1), span.Error)
+	assert.Equal("boom", span.Meta["error.msg"])
+	assert.Equal("*tracer.boomError", span.Meta["error.type"])
+	assert.NotEqual("", span.Meta["error.stack"])
 }
 
 func TestEmptySpan(t *testing.T) {
@@ -122,8 +122,8 @@ func TestSpanErrorNil(t *testing.T) {
 	// don't set the error if it's nil
 	nMeta := len(span.Meta)
 	span.SetError(nil)
-	assert.Equal(span.Error, int32(0))
-	assert.Equal(len(span.Meta), nMeta)
+	assert.Equal(int32(0), span.Error)
+	assert.Equal(nMeta, len(span.Meta))
 }
 
 func TestSpanFinish(t *testing.T) {
@@ -157,7 +157,7 @@ func TestSpanFinishTwice(t *testing.T) {
 	previousDuration := span.Duration
 	time.Sleep(wait)
 	span.Finish()
-	assert.Equal(span.Duration, previousDuration)
+	assert.Equal(previousDuration, span.Duration)
 	assert.Len(tracer.channels.trace, 1)
 }
 
@@ -172,7 +172,7 @@ func TestSpanContext(t *testing.T) {
 	ctx = span.Context(ctx)
 	s2, ok := SpanFromContext(ctx)
 	assert.True(t, ok)
-	assert.Equal(t, s2.SpanID, span.SpanID)
+	assert.Equal(t, span.SpanID, s2.SpanID)
 
 }
 

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -2,8 +2,11 @@ package tracer
 
 import (
 	"context"
+	"github.com/DataDog/dd-trace-go/tracer/ext"
 	"log"
 	"math/rand"
+	"os"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -172,6 +175,9 @@ func (t *Tracer) NewRootSpan(name, service, resource string) *Span {
 	span.buffer = newSpanBuffer(t.channels, 0, 0)
 	t.sampler.Sample(span)
 	span.buffer.Push(span)
+
+	// Add the process id to all root spans
+	span.SetMeta(ext.Pid, strconv.Itoa(os.Getpid()))
 
 	return span
 }

--- a/tracer/tracer_test.go
+++ b/tracer/tracer_test.go
@@ -53,10 +53,10 @@ func TestNewSpan(t *testing.T) {
 	// the tracer must create root spans
 	tracer := NewTracer()
 	span := tracer.NewRootSpan("pylons.request", "pylons", "/")
-	assert.Equal(span.ParentID, uint64(0))
-	assert.Equal(span.Service, "pylons")
-	assert.Equal(span.Name, "pylons.request")
-	assert.Equal(span.Resource, "/")
+	assert.Equal(uint64(0), span.ParentID)
+	assert.Equal("pylons", span.Service)
+	assert.Equal("pylons.request", span.Name)
+	assert.Equal("/", span.Resource)
 }
 
 func TestNewSpanFromContextNil(t *testing.T) {
@@ -64,12 +64,12 @@ func TestNewSpanFromContextNil(t *testing.T) {
 	tracer := NewTracer()
 
 	child := tracer.NewChildSpanFromContext("abc", nil)
-	assert.Equal(child.Name, "abc")
-	assert.Equal(child.Service, "")
+	assert.Equal("abc", child.Name)
+	assert.Equal("", child.Service)
 
 	child = tracer.NewChildSpanFromContext("def", context.Background())
-	assert.Equal(child.Name, "def")
-	assert.Equal(child.Service, "")
+	assert.Equal("def", child.Name)
+	assert.Equal("", child.Service)
 
 }
 
@@ -125,14 +125,14 @@ func TestNewSpanFromContext(t *testing.T) {
 
 	child := tracer.NewChildSpanFromContext("redis.command", ctx)
 	// ids and services are inherited
-	assert.Equal(child.ParentID, parent.SpanID)
-	assert.Equal(child.TraceID, parent.TraceID)
-	assert.Equal(child.Service, parent.Service)
+	assert.Equal(parent.SpanID, child.ParentID)
+	assert.Equal(parent.TraceID, child.TraceID)
+	assert.Equal(parent.Service, child.Service)
 	// the resource is not inherited and defaults to the name
-	assert.Equal(child.Resource, "redis.command")
+	assert.Equal("redis.command", child.Resource)
 	// the tracer instance is the same
-	assert.Equal(parent.tracer, tracer)
-	assert.Equal(child.tracer, tracer)
+	assert.Equal(tracer, parent.tracer)
+	assert.Equal(tracer, child.tracer)
 
 }
 
@@ -144,14 +144,14 @@ func TestNewSpanChild(t *testing.T) {
 	parent := tracer.NewRootSpan("pylons.request", "pylons", "/")
 	child := tracer.NewChildSpan("redis.command", parent)
 	// ids and services are inherited
-	assert.Equal(child.ParentID, parent.SpanID)
-	assert.Equal(child.TraceID, parent.TraceID)
-	assert.Equal(child.Service, parent.Service)
+	assert.Equal(parent.SpanID, child.ParentID)
+	assert.Equal(parent.TraceID, child.TraceID)
+	assert.Equal(parent.Service, child.Service)
 	// the resource is not inherited and defaults to the name
-	assert.Equal(child.Resource, "redis.command")
+	assert.Equal("redis.command", child.Resource)
 	// the tracer instance is the same
-	assert.Equal(parent.tracer, tracer)
-	assert.Equal(child.tracer, tracer)
+	assert.Equal(tracer, parent.tracer)
+	assert.Equal(tracer, child.tracer)
 }
 
 func TestNewRootSpanHasPid(t *testing.T) {

--- a/tracer/tracer_test.go
+++ b/tracer/tracer_test.go
@@ -3,7 +3,9 @@ package tracer
 import (
 	"context"
 	"fmt"
+	"github.com/DataDog/dd-trace-go/tracer/ext"
 	"net/http"
+	"os"
 	"strconv"
 	"sync"
 	"testing"
@@ -150,6 +152,25 @@ func TestNewSpanChild(t *testing.T) {
 	// the tracer instance is the same
 	assert.Equal(parent.tracer, tracer)
 	assert.Equal(child.tracer, tracer)
+}
+
+func TestNewRootSpanHasPid(t *testing.T) {
+	assert := assert.New(t)
+
+	tracer := NewTracer()
+	root := tracer.NewRootSpan("pylons.request", "pylons", "/")
+
+	assert.Equal(strconv.Itoa(os.Getpid()), root.GetMeta(ext.Pid))
+}
+
+func TestNewChildHasNoPid(t *testing.T) {
+	assert := assert.New(t)
+
+	tracer := NewTracer()
+	root := tracer.NewRootSpan("pylons.request", "pylons", "/")
+	child := tracer.NewChildSpan("redis.command", root)
+
+	assert.Equal("", child.GetMeta(ext.Pid))
 }
 
 func TestTracerDisabled(t *testing.T) {


### PR DESCRIPTION
This PR automatically adds the process id of the current process as a metadata when creating a new root span.