### PR TITLE
Remove tlsConfigRegister in MySQL DSN parser

### DIFF
--- a/tracer/contrib/sqltraced/parsedsn/mysql/dsn.go
+++ b/tracer/contrib/sqltraced/parsedsn/mysql/dsn.go
@@ -12,7 +12,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"net"
 	"net/url"
 	"strconv"
 	"strings"
@@ -292,23 +291,9 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 				cfg.TLSConfig = vl
 				cfg.tls = &tls.Config{InsecureSkipVerify: true}
 			} else {
-				name, err := url.QueryUnescape(value)
+				_, err := url.QueryUnescape(value)
 				if err != nil {
 					return fmt.Errorf("invalid value for TLS config name: %v", err)
-				}
-
-				if tlsConfig, ok := tlsConfigRegister[name]; ok {
-					if len(tlsConfig.ServerName) == 0 && !tlsConfig.InsecureSkipVerify {
-						host, _, err := net.SplitHostPort(cfg.Addr)
-						if err == nil {
-							tlsConfig.ServerName = host
-						}
-					}
-
-					cfg.TLSConfig = name
-					cfg.tls = tlsConfig
-				} else {
-					return errors.New("invalid value / unknown config name: " + name)
 				}
 			}
 

--- a/tracer/contrib/sqltraced/parsedsn/mysql/utils.go
+++ b/tracer/contrib/sqltraced/parsedsn/mysql/utils.go
@@ -8,12 +8,6 @@
 
 package mysql
 
-import "crypto/tls"
-
-var (
-	tlsConfigRegister map[string]*tls.Config // Register for custom tls.Configs
-)
-
 // Returns the bool value of the input.
 // The 2nd return value indicates if the input was a valid bool value
 func readBool(input string) (value bool, valid bool) {


### PR DESCRIPTION
If you do include a custom TLS config in the MySQL DSN, this code will return an error because it hasn't been registered in this particular tlsConfigRegister (and there isn't even a function available for doing so), even if you correctly register with the go-sql-driver/mysql driver. Since the TLS config isn't used in any of the trace metadata, we can just remove this bit.