### PR TITLE
Fix test (process_id in metas)

### DIFF
--- a/tracer/span_test.go
+++ b/tracer/span_test.go
@@ -53,6 +53,7 @@ func TestSpanSetMetas(t *testing.T) {
 		"error.msg":   "Something wrong",
 		"error.type":  "*errors.errorString",
 		"status.code": "200",
+		"system.pid":  "29176",
 	}
 	nopMetas := map[string]string{
 		"nopKey1": "nopValue1",


### PR DESCRIPTION
Fix the test TestSpanSetMetas in span_test.go.
We now add by default the process_id to the span.Metas. This test would break by checking span.Metas lenght and L64 and L76