### PR TITLE
Add meta about lang in the payload header

### DIFF
--- a/tracer/ext/tracer.go
+++ b/tracer/ext/tracer.go
@@ -1,0 +1,11 @@
+package ext
+
+import "runtime"
+
+const (
+	Lang          = "go"
+	Interpreter   = runtime.Compiler
+	TracerVersion = "v0.5.0"
+)
+
+var LangVersion = runtime.Version()

--- a/tracer/ext/tracer.go
+++ b/tracer/ext/tracer.go
@@ -1,11 +1,14 @@
 package ext
 
-import "runtime"
+import (
+	"runtime"
+	"strings"
+)
 
 const (
 	Lang          = "go"
-	Interpreter   = runtime.Compiler
+	Interpreter   = runtime.Compiler + "_" + runtime.GOOS + "_" + runtime.GOARCH
 	TracerVersion = "v0.5.0"
 )
 
-var LangVersion = runtime.Version()
+var LangVersion = strings.TrimPrefix(runtime.Version(), Lang)

--- a/tracer/ext/tracer.go
+++ b/tracer/ext/tracer.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	Lang          = "go"
-	Interpreter   = runtime.Compiler + "_" + runtime.GOOS + "_" + runtime.GOARCH
+	Interpreter   = runtime.Compiler + "-" + runtime.GOARCH + "-" + runtime.GOOS
 	TracerVersion = "v0.5.0"
 )
 

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -2,13 +2,14 @@ package tracer
 
 import (
 	"context"
-	"github.com/DataDog/dd-trace-go/tracer/ext"
 	"log"
 	"math/rand"
 	"os"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/DataDog/dd-trace-go/tracer/ext"
 )
 
 const (

--- a/tracer/transport.go
+++ b/tracer/transport.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/DataDog/dd-trace-go/tracer/ext"
 )
 
 const (
@@ -63,8 +65,13 @@ type httpTransport struct {
 func newHTTPTransport(hostname, port string) *httpTransport {
 	// initialize the default EncoderPool with Encoder headers
 	pool, contentType := newEncoderPool(defaultEncoder, encoderPoolSize)
-	defaultHeaders := make(map[string]string)
-	defaultHeaders["Content-Type"] = contentType
+	defaultHeaders := map[string]string{
+		"Content-Type":                  contentType,
+		"Datadog-Meta-Lang":             ext.Lang,
+		"Datadog-Meta-Lang-Version":     ext.LangVersion,
+		"Datadog-Meta-Lang-Interpreter": ext.Interpreter,
+		"Datadog-Meta-Tracer-Version":   ext.TracerVersion,
+	}
 
 	return &httpTransport{
 		traceURL:         fmt.Sprintf("http://%s:%s/v0.3/traces", hostname, port),


### PR DESCRIPTION
Adds the following headers so that Trace Agent can report it as a metrics:
```
            'Datadog-Meta-Lang': 'go',
            'Datadog-Meta-Lang-Version': 'go1.7',
            'Datadog-Meta-Lang-Interpreter': 'gc',
            'Datadog-Meta-Tracer-Version': 'v0.5.0',
```