### PR TITLE
contrib: refactor go-redis

### DIFF
--- a/contrib/go-redis/redis/example_test.go
+++ b/contrib/go-redis/redis/example_test.go
@@ -19,7 +19,7 @@ func Example() {
 		Password: "", // no password set
 		DB:       0,  // use default db
 	}
-	c := redistrace.NewTracedClient(opts, tracer.DefaultTracer, "my-redis-backend")
+	c := redistrace.NewClient(opts, "my-redis-backend", tracer.DefaultTracer)
 	// Emit spans per command by using your Redis connection as usual
 	c.Set("test_key", "test_value", 0)
 
@@ -35,7 +35,7 @@ func Example() {
 	// Contexts can be easily passed between Datadog integrations
 	r := gin.Default()
 	r.Use(gintrace.Middleware("web-admin"))
-	client := redistrace.NewTracedClient(opts, tracer.DefaultTracer, "redis-img-backend")
+	client := redistrace.NewClient(opts, "redis-img-backend", tracer.DefaultTracer)
 
 	r.GET("/user/settings/:id", func(ctx *gin.Context) {
 		// create a span that is a child of your http request
@@ -51,8 +51,7 @@ func Example_pipeline() {
 		Password: "", // no password set
 		DB:       0,  // use default db
 	}
-	c := redistrace.NewTracedClient(opts, tracer.DefaultTracer, "my-redis-backend")
-	// pipe is a TracedPipeliner
+	c := redistrace.NewClient(opts, "my-redis-backend", tracer.DefaultTracer)
 	pipe := c.Pipeline()
 	pipe.Incr("pipeline_counter")
 	pipe.Expire("pipeline_counter", time.Hour)
@@ -60,13 +59,13 @@ func Example_pipeline() {
 	pipe.Exec()
 }
 
-func ExampleNewTracedClient() {
+func ExampleNewClient() {
 	opts := &redis.Options{
 		Addr:     "127.0.0.1:6379",
 		Password: "", // no password set
 		DB:       0,  // use default db
 	}
-	c := redistrace.NewTracedClient(opts, tracer.DefaultTracer, "my-redis-backend")
+	c := redistrace.NewClient(opts, "my-redis-backend", tracer.DefaultTracer)
 	// Emit spans per command by using your Redis connection as usual
 	c.Set("test_key", "test_value", 0)
 

--- a/contrib/go-redis/redis/example_test.go
+++ b/contrib/go-redis/redis/example_test.go
@@ -19,7 +19,7 @@ func Example() {
 		Password: "", // no password set
 		DB:       0,  // use default db
 	}
-	c := redistrace.NewClient(opts, "my-redis-backend", tracer.DefaultTracer)
+	c := redistrace.NewClient(opts, "my-redis-backend")
 	// Emit spans per command by using your Redis connection as usual
 	c.Set("test_key", "test_value", 0)
 
@@ -35,7 +35,7 @@ func Example() {
 	// Contexts can be easily passed between Datadog integrations
 	r := gin.Default()
 	r.Use(gintrace.Middleware("web-admin"))
-	client := redistrace.NewClient(opts, "redis-img-backend", tracer.DefaultTracer)
+	client := redistrace.NewClient(opts, "redis-img-backend")
 
 	r.GET("/user/settings/:id", func(ctx *gin.Context) {
 		// create a span that is a child of your http request
@@ -51,7 +51,7 @@ func Example_pipeline() {
 		Password: "", // no password set
 		DB:       0,  // use default db
 	}
-	c := redistrace.NewClient(opts, "my-redis-backend", tracer.DefaultTracer)
+	c := redistrace.NewClient(opts, "my-redis-backend")
 	pipe := c.Pipeline()
 	pipe.Incr("pipeline_counter")
 	pipe.Expire("pipeline_counter", time.Hour)
@@ -65,7 +65,7 @@ func ExampleNewClient() {
 		Password: "", // no password set
 		DB:       0,  // use default db
 	}
-	c := redistrace.NewClient(opts, "my-redis-backend", tracer.DefaultTracer)
+	c := redistrace.NewClient(opts, "my-redis-backend")
 	// Emit spans per command by using your Redis connection as usual
 	c.Set("test_key", "test_value", 0)
 

--- a/contrib/go-redis/redis/redis.go
+++ b/contrib/go-redis/redis/redis.go
@@ -11,16 +11,10 @@ import (
 	"strings"
 )
 
-// TracedClient is used to trace requests to a redis server.
-type TracedClient struct {
+// Client is used to trace requests to a redis server.
+type Client struct {
 	*redis.Client
-	traceParams traceParams
-}
-
-// TracedPipeline is used to trace pipelines executed on a redis server.
-type TracedPipeliner struct {
-	redis.Pipeliner
-	traceParams traceParams
+	*traceParams
 }
 
 type traceParams struct {
@@ -31,53 +25,72 @@ type traceParams struct {
 	tracer  *tracer.Tracer
 }
 
-// NewTracedClient takes a Client returned by redis.NewClient and configures it to emit spans under the given service name
-func NewTracedClient(opt *redis.Options, t *tracer.Tracer, service string) *TracedClient {
-	var host, port string
+// NewClient takes a Client returned by redis.NewClient and configures it to emit spans under the given service name
+func NewClient(opt *redis.Options, service string, t *tracer.Tracer) *Client {
+	var port string
+	if t == nil {
+		t = tracer.DefaultTracer
+	}
+	t.SetServiceInfo(service, "redis", ext.AppTypeDB)
+
 	addr := strings.Split(opt.Addr, ":")
 	if len(addr) == 2 && addr[1] != "" {
 		port = addr[1]
 	} else {
 		port = "6379"
 	}
-	host = addr[0]
+	host := addr[0]
 	db := strconv.Itoa(opt.DB)
 
 	client := redis.NewClient(opt)
-	t.SetServiceInfo(service, "redis", ext.AppTypeDB)
-	tc := &TracedClient{
+	c := &Client{
 		client,
-		traceParams{
+		&traceParams{
 			host,
 			port,
 			db,
 			service,
-			t},
+			t,
+		},
 	}
 
-	tc.Client.WrapProcess(createWrapperFromClient(tc))
-	return tc
+	c.WrapProcess(createWrapperFromClient(c))
+	return c
 }
 
-// Pipeline creates a TracedPipeline from a TracedClient
-func (c *TracedClient) Pipeline() *TracedPipeliner {
-	return &TracedPipeliner{
+// SetContext sets a context on a Client. Use it to ensure that emitted spans have the correct parent
+func (c *Client) SetContext(ctx context.Context) {
+	c.Client = c.Client.WithContext(ctx)
+}
+
+// Pipeline allocates and returns a Pipeline from a Client
+func (c *Client) Pipeline() *Pipeline {
+	return &Pipeline{
 		c.Client.Pipeline(),
 		c.traceParams,
 	}
 }
 
-// ExecWithContext calls Pipeline.Exec(). It ensures that the resulting Redis calls
+// Pipeline is used to trace pipelines executed on a redis server.
+type Pipeline struct {
+	redis.Pipeliner
+	*traceParams
+}
+
+// ExecContext calls Pipeline.Exec(). It ensures that the resulting Redis calls
 // are traced, and that emitted spans are children of the given Context
-func (c *TracedPipeliner) ExecWithContext(ctx context.Context) ([]redis.Cmder, error) {
-	span := c.traceParams.tracer.NewChildSpanFromContext("redis.command", ctx)
-	span.Service = c.traceParams.service
+func (p *Pipeline) ExecContext(ctx context.Context) ([]redis.Cmder, error) {
+	span := p.tracer.NewChildSpanFromContext("redis.command", ctx)
+	if span == nil {
+		p.tracer.NewRootSpan("redis.command", p.service, "redis")
+	}
+	span.Service = p.service
 
-	span.SetMeta("out.host", c.traceParams.host)
-	span.SetMeta("out.port", c.traceParams.port)
-	span.SetMeta("out.db", c.traceParams.db)
+	span.SetMeta("out.host", p.host)
+	span.SetMeta("out.port", p.port)
+	span.SetMeta("out.db", p.db)
 
-	cmds, err := c.Pipeliner.Exec()
+	cmds, err := p.Pipeliner.Exec()
 	if err != nil {
 		span.SetError(err)
 	}
@@ -87,22 +100,39 @@ func (c *TracedPipeliner) ExecWithContext(ctx context.Context) ([]redis.Cmder, e
 	return cmds, err
 }
 
-// Exec calls Pipeline.Exec() ensuring that the resulting Redis calls are traced
-func (c *TracedPipeliner) Exec() ([]redis.Cmder, error) {
-	span := c.traceParams.tracer.NewRootSpan("redis.command", c.traceParams.service, "redis")
+// Exec calls Pipeline.ExecContext() with a non-nil empty context
+func (p *Pipeline) Exec() ([]redis.Cmder, error) {
+	return p.ExecContext(context.Background())
+}
 
-	span.SetMeta("out.host", c.traceParams.host)
-	span.SetMeta("out.port", c.traceParams.port)
-	span.SetMeta("out.db", c.traceParams.db)
+// createWrapperFromClient wraps tracing into redis.Process().
+func createWrapperFromClient(c *Client) func(oldProcess func(cmd redis.Cmder) error) func(cmd redis.Cmder) error {
+	return func(oldProcess func(cmd redis.Cmder) error) func(cmd redis.Cmder) error {
+		return func(cmd redis.Cmder) error {
+			ctx := c.Client.Context()
 
-	cmds, err := c.Pipeliner.Exec()
-	if err != nil {
-		span.SetError(err)
+			var resource string
+			resource = strings.Split(cmd.String(), " ")[0]
+			args_length := len(strings.Split(cmd.String(), " ")) - 1
+			span := c.tracer.NewChildSpanFromContext("redis.command", ctx)
+
+			span.Service = c.service
+			span.Resource = resource
+
+			span.SetMeta("redis.raw_command", cmd.String())
+			span.SetMeta("redis.args_length", strconv.Itoa(args_length))
+			span.SetMeta("out.host", c.host)
+			span.SetMeta("out.port", c.port)
+			span.SetMeta("out.db", c.db)
+
+			err := oldProcess(cmd)
+			if err != nil {
+				span.SetError(err)
+			}
+			span.Finish()
+			return err
+		}
 	}
-	span.Resource = String(cmds)
-	span.SetMeta("redis.pipeline_length", strconv.Itoa(len(cmds)))
-	span.Finish()
-	return cmds, err
 }
 
 // String returns a string representation of a slice of redis Commands, separated by newlines
@@ -113,39 +143,4 @@ func String(cmds []redis.Cmder) string {
 		b.WriteString("\n")
 	}
 	return b.String()
-}
-
-// SetContext sets a context on a TracedClient. Use it to ensure that emitted spans have the correct parent
-func (c *TracedClient) SetContext(ctx context.Context) {
-	c.Client = c.Client.WithContext(ctx)
-}
-
-// createWrapperFromClient wraps tracing into redis.Process().
-func createWrapperFromClient(tc *TracedClient) func(oldProcess func(cmd redis.Cmder) error) func(cmd redis.Cmder) error {
-	return func(oldProcess func(cmd redis.Cmder) error) func(cmd redis.Cmder) error {
-		return func(cmd redis.Cmder) error {
-			ctx := tc.Client.Context()
-
-			var resource string
-			resource = strings.Split(cmd.String(), " ")[0]
-			args_length := len(strings.Split(cmd.String(), " ")) - 1
-			span := tc.traceParams.tracer.NewChildSpanFromContext("redis.command", ctx)
-
-			span.Service = tc.traceParams.service
-			span.Resource = resource
-
-			span.SetMeta("redis.raw_command", cmd.String())
-			span.SetMeta("redis.args_length", strconv.Itoa(args_length))
-			span.SetMeta("out.host", tc.traceParams.host)
-			span.SetMeta("out.port", tc.traceParams.port)
-			span.SetMeta("out.db", tc.traceParams.db)
-
-			err := oldProcess(cmd)
-			if err != nil {
-				span.SetError(err)
-			}
-			span.Finish()
-			return err
-		}
-	}
 }

--- a/contrib/go-redis/redis/redis_test.go
+++ b/contrib/go-redis/redis/redis_test.go
@@ -24,7 +24,7 @@ func TestClient(t *testing.T) {
 	testTracer, testTransport := getTestTracer()
 	testTracer.DebugLoggingEnabled = debug
 
-	client := NewTracedClient(opts, testTracer, "my-redis")
+	client := NewClient(opts, "my-redis", testTracer)
 	client.Set("test_key", "test_value", 0)
 
 	testTracer.ForceFlush()
@@ -52,12 +52,12 @@ func TestPipeline(t *testing.T) {
 	testTracer, testTransport := getTestTracer()
 	testTracer.DebugLoggingEnabled = debug
 
-	client := NewTracedClient(opts, testTracer, "my-redis")
+	client := NewClient(opts, "my-redis", testTracer)
 	pipeline := client.Pipeline()
 	pipeline.Expire("pipeline_counter", time.Hour)
 
 	// Exec with context test
-	pipeline.ExecWithContext(context.Background())
+	pipeline.ExecContext(context.Background())
 
 	testTracer.ForceFlush()
 	traces := testTransport.Traces()
@@ -106,7 +106,7 @@ func TestChildSpan(t *testing.T) {
 	parent_span := testTracer.NewChildSpanFromContext("parent_span", ctx)
 	ctx = tracer.ContextWithSpan(ctx, parent_span)
 
-	client := NewTracedClient(opts, testTracer, "my-redis")
+	client := NewClient(opts, "my-redis", testTracer)
 	client.SetContext(ctx)
 
 	client.Set("test_key", "test_value", 0)
@@ -146,7 +146,7 @@ func TestMultipleCommands(t *testing.T) {
 	testTracer, testTransport := getTestTracer()
 	testTracer.DebugLoggingEnabled = debug
 
-	client := NewTracedClient(opts, testTracer, "my-redis")
+	client := NewClient(opts, "my-redis", testTracer)
 	client.Set("test_key", "test_value", 0)
 	client.Get("test_key")
 	client.Incr("int_key")
@@ -179,7 +179,7 @@ func TestError(t *testing.T) {
 	testTracer, testTransport := getTestTracer()
 	testTracer.DebugLoggingEnabled = debug
 
-	client := NewTracedClient(opts, testTracer, "my-redis")
+	client := NewClient(opts, "my-redis", testTracer)
 	err := client.Get("non_existent_key")
 
 	testTracer.ForceFlush()


### PR DESCRIPTION
We try to keep our contrib APIs as close to their original library as possible + as consistent as possible between each other.