### PR TITLE
Fix race condition while accessing DebugLoggingEnabled attribute

### DIFF
--- a/contrib/garyburd/redigo/redigo_test.go
+++ b/contrib/garyburd/redigo/redigo_test.go
@@ -17,7 +17,7 @@ const (
 func TestClient(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	c, _ := TracedDial("my-service", testTracer, "tcp", "127.0.0.1:56379")
 	c.Do("SET", 1, "truck")
@@ -41,7 +41,7 @@ func TestClient(t *testing.T) {
 func TestCommandError(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	c, _ := TracedDial("my-service", testTracer, "tcp", "127.0.0.1:56379")
 	_, err := c.Do("NOT_A_COMMAND", context.Background())
@@ -66,7 +66,7 @@ func TestCommandError(t *testing.T) {
 func TestConnectionError(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, _ := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	_, err := TracedDial("redis-service", testTracer, "tcp", "127.0.0.1:1000")
 
@@ -76,7 +76,7 @@ func TestConnectionError(t *testing.T) {
 func TestInheritance(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	// Parent span
 	ctx := context.Background()
@@ -113,7 +113,7 @@ func TestInheritance(t *testing.T) {
 func TestCommandsToSring(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	stringify_test := TestStruct{Cpython: 57, Cgo: 8}
 	c, _ := TracedDial("my-service", testTracer, "tcp", "127.0.0.1:56379")
@@ -137,7 +137,7 @@ func TestCommandsToSring(t *testing.T) {
 func TestPool(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	pool := &redis.Pool{
 		MaxIdle:     2,
@@ -163,7 +163,7 @@ func TestPool(t *testing.T) {
 func TestTracingDialUrl(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 	url := "redis://127.0.0.1:56379"
 	client, _ := TracedDialURL("redis-service", testTracer, url)
 	client.Do("SET", "ONE", " TWO", context.Background())

--- a/contrib/go-redis/redis/redis_test.go
+++ b/contrib/go-redis/redis/redis_test.go
@@ -22,7 +22,7 @@ func TestClient(t *testing.T) {
 	}
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	client := NewTracedClient(opts, testTracer, "my-redis")
 	client.Set("test_key", "test_value", 0)
@@ -50,7 +50,7 @@ func TestPipeline(t *testing.T) {
 	}
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	client := NewTracedClient(opts, testTracer, "my-redis")
 	pipeline := client.Pipeline()
@@ -99,7 +99,7 @@ func TestChildSpan(t *testing.T) {
 	}
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	// Parent span
 	ctx := context.Background()
@@ -144,7 +144,7 @@ func TestMultipleCommands(t *testing.T) {
 	}
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	client := NewTracedClient(opts, testTracer, "my-redis")
 	client.Set("test_key", "test_value", 0)
@@ -177,7 +177,7 @@ func TestError(t *testing.T) {
 	}
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	client := NewTracedClient(opts, testTracer, "my-redis")
 	err := client.Get("non_existent_key")

--- a/contrib/gocql/gocql/gocql_test.go
+++ b/contrib/gocql/gocql/gocql_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 func TestErrorWrapper(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	cluster := gocql.NewCluster("127.0.0.1:59042")
 	session, _ := cluster.CreateSession()
@@ -63,7 +63,7 @@ func TestErrorWrapper(t *testing.T) {
 func TestChildWrapperSpan(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	// Parent span
 	ctx := context.Background()

--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -22,7 +22,7 @@ func TestClient(t *testing.T) {
 	assert := assert.New(t)
 
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	rig, err := newRig(testTracer, true)
 	if err != nil {
@@ -86,7 +86,7 @@ func TestClient(t *testing.T) {
 func TestDisabled(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 	testTracer.SetEnabled(false)
 
 	rig, err := newRig(testTracer, true)
@@ -107,7 +107,7 @@ func TestDisabled(t *testing.T) {
 func TestChild(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	rig, err := newRig(testTracer, false)
 	if err != nil {
@@ -153,7 +153,7 @@ func TestChild(t *testing.T) {
 func TestPass(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	rig, err := newRig(testTracer, false)
 	if err != nil {

--- a/contrib/olivere/elastic/elastictrace_test.go
+++ b/contrib/olivere/elastic/elastictrace_test.go
@@ -18,7 +18,7 @@ const (
 func TestClientV5(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	tc := NewTracedHTTPClient("my-es-service", testTracer)
 	client, err := elasticv5.NewClient(
@@ -51,7 +51,7 @@ func TestClientV5(t *testing.T) {
 func TestClientV3(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	tc := NewTracedHTTPClient("my-es-service", testTracer)
 	client, err := elasticv3.NewClient(
@@ -84,7 +84,7 @@ func TestClientV3(t *testing.T) {
 func TestClientV3Failure(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	tc := NewTracedHTTPClient("my-es-service", testTracer)
 	client, err := elasticv3.NewClient(
@@ -119,7 +119,7 @@ func TestClientV3Failure(t *testing.T) {
 func TestClientV5Failure(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	tc := NewTracedHTTPClient("my-es-service", testTracer)
 	client, err := elasticv5.NewClient(

--- a/tracer/contrib/elastictraced/elastictraced_test.go
+++ b/tracer/contrib/elastictraced/elastictraced_test.go
@@ -18,7 +18,7 @@ const (
 func TestClientV5(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	tc := NewTracedHTTPClient("my-es-service", testTracer)
 	client, err := elasticv5.NewClient(
@@ -51,7 +51,7 @@ func TestClientV5(t *testing.T) {
 func TestClientV3(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	tc := NewTracedHTTPClient("my-es-service", testTracer)
 	client, err := elasticv3.NewClient(
@@ -84,7 +84,7 @@ func TestClientV3(t *testing.T) {
 func TestClientV3Failure(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	tc := NewTracedHTTPClient("my-es-service", testTracer)
 	client, err := elasticv3.NewClient(
@@ -119,7 +119,7 @@ func TestClientV3Failure(t *testing.T) {
 func TestClientV5Failure(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	tc := NewTracedHTTPClient("my-es-service", testTracer)
 	client, err := elasticv5.NewClient(

--- a/tracer/contrib/go-redis/tracedredis_test.go
+++ b/tracer/contrib/go-redis/tracedredis_test.go
@@ -22,7 +22,7 @@ func TestClient(t *testing.T) {
 	}
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	client := NewTracedClient(opts, testTracer, "my-redis")
 	client.Set("test_key", "test_value", 0)
@@ -50,7 +50,7 @@ func TestPipeline(t *testing.T) {
 	}
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	client := NewTracedClient(opts, testTracer, "my-redis")
 	pipeline := client.Pipeline()
@@ -99,7 +99,7 @@ func TestChildSpan(t *testing.T) {
 	}
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	// Parent span
 	ctx := context.Background()
@@ -144,7 +144,7 @@ func TestMultipleCommands(t *testing.T) {
 	}
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	client := NewTracedClient(opts, testTracer, "my-redis")
 	client.Set("test_key", "test_value", 0)
@@ -177,7 +177,7 @@ func TestError(t *testing.T) {
 	}
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	client := NewTracedClient(opts, testTracer, "my-redis")
 	err := client.Get("non_existent_key")

--- a/tracer/contrib/gocql/gocqltrace_test.go
+++ b/tracer/contrib/gocql/gocqltrace_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 func TestErrorWrapper(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	cluster := gocql.NewCluster("127.0.0.1:59042")
 	session, _ := cluster.CreateSession()
@@ -63,7 +63,7 @@ func TestErrorWrapper(t *testing.T) {
 func TestChildWrapperSpan(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	// Parent span
 	ctx := context.Background()

--- a/tracer/contrib/redigo/redigotrace_test.go
+++ b/tracer/contrib/redigo/redigotrace_test.go
@@ -17,7 +17,7 @@ const (
 func TestClient(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	c, _ := TracedDial("my-service", testTracer, "tcp", "127.0.0.1:56379")
 	c.Do("SET", 1, "truck")
@@ -41,7 +41,7 @@ func TestClient(t *testing.T) {
 func TestCommandError(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	c, _ := TracedDial("my-service", testTracer, "tcp", "127.0.0.1:56379")
 	_, err := c.Do("NOT_A_COMMAND", context.Background())
@@ -66,7 +66,7 @@ func TestCommandError(t *testing.T) {
 func TestConnectionError(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, _ := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	_, err := TracedDial("redis-service", testTracer, "tcp", "127.0.0.1:1000")
 
@@ -76,7 +76,7 @@ func TestConnectionError(t *testing.T) {
 func TestInheritance(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	// Parent span
 	ctx := context.Background()
@@ -113,7 +113,7 @@ func TestInheritance(t *testing.T) {
 func TestCommandsToSring(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	stringify_test := TestStruct{Cpython: 57, Cgo: 8}
 	c, _ := TracedDial("my-service", testTracer, "tcp", "127.0.0.1:56379")
@@ -137,7 +137,7 @@ func TestCommandsToSring(t *testing.T) {
 func TestPool(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	pool := &redis.Pool{
 		MaxIdle:     2,
@@ -163,7 +163,7 @@ func TestPool(t *testing.T) {
 func TestTracingDialUrl(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 	url := "redis://127.0.0.1:56379"
 	client, _ := TracedDialURL("redis-service", testTracer, url)
 	client.Do("SET", "ONE", " TWO", context.Background())

--- a/tracer/contrib/tracegrpc/grpc_test.go
+++ b/tracer/contrib/tracegrpc/grpc_test.go
@@ -22,7 +22,7 @@ func TestClient(t *testing.T) {
 	assert := assert.New(t)
 
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	rig, err := newRig(testTracer, true)
 	if err != nil {
@@ -86,7 +86,7 @@ func TestClient(t *testing.T) {
 func TestDisabled(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 	testTracer.SetEnabled(false)
 
 	rig, err := newRig(testTracer, true)
@@ -107,7 +107,7 @@ func TestDisabled(t *testing.T) {
 func TestChild(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	rig, err := newRig(testTracer, false)
 	if err != nil {
@@ -153,7 +153,7 @@ func TestChild(t *testing.T) {
 func TestPass(t *testing.T) {
 	assert := assert.New(t)
 	testTracer, testTransport := getTestTracer()
-	testTracer.DebugLoggingEnabled = debug
+	testTracer.SetDebugLogging(debug)
 
 	rig, err := newRig(testTracer, false)
 	if err != nil {


### PR DESCRIPTION
- [x] *On staging since 06/09*

**Note:** it's a breaking change in the core API, but there is no other solution here to prevent this race condition from happening.