### PR TITLE
Use a new buffer to avoid race conditions

### DIFF
--- a/tracer/encoder.go
+++ b/tracer/encoder.go
@@ -66,6 +66,8 @@ func (e *msgpackEncoder) ContentType() string {
 }
 
 func (e *msgpackEncoder) Buffer() *bytes.Buffer {
+	e.Lock()
+	defer e.Unlock()
 	return e.buffer
 }
 

--- a/tracer/transport.go
+++ b/tracer/transport.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/http"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/DataDog/dd-trace-go/tracer/ext"
@@ -58,7 +57,6 @@ type httpTransport struct {
 	serviceURL        string            // the delivery URL for services
 	legacyServiceURL  string            // the legacy delivery URL for services
 	pool              *encoderPool      // encoding allocates lot of buffers (which might then be resized) so we use a pool so they can be re-used
-	bufferPool        *bufferPool       // we use this buffer pool to avoid race conditions when sending the encoder through the network
 	client            *http.Client      // the HTTP client used in the POST
 	headers           map[string]string // the Transport headers
 	compatibilityMode bool              // the Agent targets a legacy API for compatibility reasons
@@ -82,7 +80,6 @@ func newHTTPTransport(hostname, port string) *httpTransport {
 		serviceURL:       fmt.Sprintf("http://%s:%s/v0.3/services", hostname, port),
 		legacyServiceURL: fmt.Sprintf("http://%s:%s/v0.2/services", hostname, port),
 		pool:             pool,
-		bufferPool:       newBufferPool(),
 		client: &http.Client{
 			Timeout: defaultHTTPTimeout,
 		},
@@ -115,8 +112,8 @@ func (t *httpTransport) SendTraces(traces [][]*Span) (*http.Response, error) {
 	// can theoretically read the underlying buffer whereas the encoder has been returned to the pool.
 	// This can lead to a race condition and make the app panicking.
 	// That's why we create a new buffer here, though we use the same slice of bytes to avoid allocating new memory.
-	// It's fine here because the two functions that can happen at the same time are bytes.Reset and bytes.Read,
-	// and they doesn't modify the underlying data.
+	// It's fine here because the two functions that can happen at the same time (bytes.Reset and bytes.Read),
+	// doesn't modify the underlying data.
 	encoder.SetBuffer(bytes.NewBuffer(encoderBuffer.Bytes()))
 
 	// prepare the client and send the payload
@@ -224,23 +221,4 @@ func (t *httpTransport) apiDowngrade() {
 	t.traceURL = t.legacyTraceURL
 	t.serviceURL = t.legacyServiceURL
 	t.changeEncoder(legacyEncoder)
-}
-
-type bufferPool struct {
-	*sync.Pool
-}
-
-func newBufferPool() *bufferPool {
-	pool := &sync.Pool{
-		New: func() interface{} {
-			return new(bytes.Buffer)
-		},
-	}
-	return &bufferPool{pool}
-}
-
-func (p *bufferPool) Get() *bytes.Buffer {
-	b := p.Pool.Get().(*bytes.Buffer)
-	b.Reset()
-	return b
 }

--- a/tracer/transport.go
+++ b/tracer/transport.go
@@ -4,11 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/DataDog/dd-trace-go/tracer/ext"
@@ -59,6 +58,7 @@ type httpTransport struct {
 	serviceURL        string            // the delivery URL for services
 	legacyServiceURL  string            // the legacy delivery URL for services
 	pool              *encoderPool      // encoding allocates lot of buffers (which might then be resized) so we use a pool so they can be re-used
+	bufferPool        *bufferPool       // we use this buffer pool to avoid race conditions when sending the encoder through the network
 	client            *http.Client      // the HTTP client used in the POST
 	headers           map[string]string // the Transport headers
 	compatibilityMode bool              // the Agent targets a legacy API for compatibility reasons
@@ -82,6 +82,7 @@ func newHTTPTransport(hostname, port string) *httpTransport {
 		serviceURL:       fmt.Sprintf("http://%s:%s/v0.3/services", hostname, port),
 		legacyServiceURL: fmt.Sprintf("http://%s:%s/v0.2/services", hostname, port),
 		pool:             pool,
+		bufferPool:       newBufferPool(),
 		client: &http.Client{
 			Timeout: defaultHTTPTimeout,
 		},
@@ -97,13 +98,26 @@ func (t *httpTransport) SendTraces(traces [][]*Span) (*http.Response, error) {
 
 	// borrow an encoder
 	encoder := t.pool.Borrow()
-	defer t.pool.Return(encoder)
+	encoderBuffer := encoder.Buffer()
+	defer func() {
+		// We set the encoder's buffer to the old one before returning the encoder to the pool
+		encoder.SetBuffer(encoderBuffer)
+		t.pool.Return(encoder)
+	}()
 
 	// encode the spans and return the error if any
 	err := encoder.EncodeTraces(traces)
 	if err != nil {
 		return nil, err
 	}
+
+	// When we send the encoder as the request body, the persistConn.writeLoop() goroutine
+	// can theoretically read the underlying buffer whereas the encoder has been returned to the pool.
+	// This can lead to a race condition and make the app panicking.
+	// That's why we create a new buffer here, though we use the same slice of bytes to avoid allocating new memory.
+	// It's fine here because the two functions that can happen at the same time are bytes.Reset and bytes.Read,
+	// and they doesn't modify the underlying data.
+	encoder.SetBuffer(bytes.NewBuffer(encoderBuffer.Bytes()))
 
 	// prepare the client and send the payload
 	req, _ := http.NewRequest("POST", t.traceURL, encoder)
@@ -117,19 +131,7 @@ func (t *httpTransport) SendTraces(traces [][]*Span) (*http.Response, error) {
 	if err != nil {
 		return &http.Response{StatusCode: 0}, err
 	}
-	defer func() {
-		// The default HTTP client's Transport does not
-		// attempt to reuse HTTP/1.0 or HTTP/1.1 TCP connections
-		// ("keep-alive") unless the Body is read to completion and is
-		// closed.
-		// Buffer the response body so the caller doesn't need to worry about
-		// reading and closing the response. This isn't very expensive because
-		// the responses from the Agent are always short.
-		var buf bytes.Buffer
-		io.Copy(&buf, response.Body)
-		response.Body.Close()
-		response.Body = ioutil.NopCloser(&buf)
-	}()
+	defer response.Body.Close()
 
 	// if we got a 404 we should downgrade the API to a stable version (at most once)
 	if (response.StatusCode == 404 || response.StatusCode == 415) && !t.compatibilityMode {
@@ -152,11 +154,24 @@ func (t *httpTransport) SendServices(services map[string]Service) (*http.Respons
 
 	// Encode the service table
 	encoder := t.pool.Borrow()
-	defer t.pool.Return(encoder)
+	encoderBuffer := encoder.Buffer()
+	defer func() {
+		// We set the encoder's buffer to the old one before returning the encoder to the pool
+		encoder.SetBuffer(encoderBuffer)
+		t.pool.Return(encoder)
+	}()
 
 	if err := encoder.EncodeServices(services); err != nil {
 		return nil, err
 	}
+
+	// When we send the encoder as the request body, the persistConn.writeLoop() goroutine
+	// can theoretically read the underlying buffer whereas the encoder has been returned to the pool.
+	// This can lead to a race condition and make the app panicking.
+	// That's why we create a new buffer here, though we use the same slice of bytes to avoid allocating new memory.
+	// It's fine here because the two functions that can happen at the same time are bytes.Reset and bytes.Read,
+	// and they doesn't modify the underlying data.
+	encoder.SetBuffer(bytes.NewBuffer(encoderBuffer.Bytes()))
 
 	// Send it
 	req, err := http.NewRequest("POST", t.serviceURL, encoder)
@@ -171,19 +186,7 @@ func (t *httpTransport) SendServices(services map[string]Service) (*http.Respons
 	if err != nil {
 		return &http.Response{StatusCode: 0}, err
 	}
-	defer func() {
-		// The default HTTP client's Transport does not
-		// attempt to reuse HTTP/1.0 or HTTP/1.1 TCP connections
-		// ("keep-alive") unless the Body is read to completion and is
-		// closed.
-		// Buffer the response body so the caller doesn't need to worry about
-		// reading and closing the response. This isn't very expensive because
-		// the responses from the Agent are always short.
-		var buf bytes.Buffer
-		io.Copy(&buf, response.Body)
-		response.Body.Close()
-		response.Body = ioutil.NopCloser(&buf)
-	}()
+	defer response.Body.Close()
 
 	// Downgrade if necessary
 	if (response.StatusCode == 404 || response.StatusCode == 415) && !t.compatibilityMode {
@@ -221,4 +224,23 @@ func (t *httpTransport) apiDowngrade() {
 	t.traceURL = t.legacyTraceURL
 	t.serviceURL = t.legacyServiceURL
 	t.changeEncoder(legacyEncoder)
+}
+
+type bufferPool struct {
+	*sync.Pool
+}
+
+func newBufferPool() *bufferPool {
+	pool := &sync.Pool{
+		New: func() interface{} {
+			return new(bytes.Buffer)
+		},
+	}
+	return &bufferPool{pool}
+}
+
+func (p *bufferPool) Get() *bytes.Buffer {
+	b := p.Pool.Get().(*bytes.Buffer)
+	b.Reset()
+	return b
 }


### PR DESCRIPTION
Here we do **2 things**:
1. We use a **new buffer** before sending the encoder through the network to avoid race conditions (the new buffer uses the same underlying data, so there is no performance overhead)
2. We **stop fully reading the response**, to avoid those logs:
```
Unsolicited response received on idle HTTP channel starting with "HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain; charset=utf-8\r\nConnection: close\r\n\r\n400 Bad Request"; err=<nil>
```
Actually, this *trick* is according to people able to improve the client performances by reusing persistent connections, but it's not documented in the official golang documentation. Moreover, we had those unwanted logs by doing this. So my point here is we should not use this unsafe trick in such an important part of the trace and rather consider using a grpc library like [this one](https://github.com/grpc/grpc-go) that will natively use HTTP2.

I also considered using a pool of buffers to avoid reallocating memory, but it was still leading to race conditions. Indeed, once the function `client.Do(req)` has been called, the `persitentConn.writeLoop` goroutine will be spawned with a reference on the buffer, and will try to read it later, even when we will put the buffer back to the pool. That's why to be safe, it's preferable to create a new buffer each time we call `client.Do` (again, we don't really create a new buffer, since we reuse the underlying slice of bytes).