### PR TITLE
Fix encoder pool issues

### DIFF
--- a/tracer/encoder_test.go
+++ b/tracer/encoder_test.go
@@ -112,11 +112,3 @@ func TestMsgpackEncoding(t *testing.T) {
 		}
 	}
 }
-
-func TestEncoderFactoryGet(t *testing.T) {
-	assert := assert.New(t)
-
-	factory, _ := newEncoderFactory(msgpackType)
-	encoder := factory.Get()
-	assert.NotNil(encoder)
-}

--- a/tracer/encoder_test.go
+++ b/tracer/encoder_test.go
@@ -113,47 +113,10 @@ func TestMsgpackEncoding(t *testing.T) {
 	}
 }
 
-func TestPoolBorrowCreate(t *testing.T) {
+func TestEncoderFactoryGet(t *testing.T) {
 	assert := assert.New(t)
 
-	// borrow an encoder from the pool
-	pool, _ := newEncoderPool(MSGPACK_ENCODER, 1)
-	encoder := pool.Borrow()
+	factory, _ := newEncoderFactory(msgpackType)
+	encoder := factory.Get()
 	assert.NotNil(encoder)
-}
-
-func TestPoolReuseEncoder(t *testing.T) {
-	assert := assert.New(t)
-
-	// borrow, return and borrow again an encoder from the pool
-	pool, _ := newEncoderPool(MSGPACK_ENCODER, 1)
-	encoder := pool.Borrow()
-	pool.Return(encoder)
-	anotherEncoder := pool.Borrow()
-	assert.Equal(anotherEncoder, encoder)
-}
-
-func TestPoolSize(t *testing.T) {
-	pool, _ := newEncoderPool(MSGPACK_ENCODER, 1)
-	encoder := newMsgpackEncoder()
-	anotherEncoder := newMsgpackEncoder()
-
-	// put two encoders in the pool with a maximum size of 1
-	// doesn't hang the caller
-	pool.Return(encoder)
-	pool.Return(anotherEncoder)
-}
-
-func TestPoolReturn(t *testing.T) {
-	assert := assert.New(t)
-
-	// an encoder can return in the pool
-	pool, _ := newEncoderPool(MSGPACK_ENCODER, 5)
-	encoder := newMsgpackEncoder()
-	pool.pool <- encoder
-	pool.Return(encoder)
-
-	// the encoder is the one we get before
-	returnedEncoder := <-pool.pool
-	assert.Equal(returnedEncoder, encoder)
 }

--- a/tracer/tracer_test.go
+++ b/tracer/tracer_test.go
@@ -604,17 +604,16 @@ func BenchmarkTracerAddSpans(b *testing.B) {
 
 // getTestTracer returns a Tracer with a DummyTransport
 func getTestTracer() (*Tracer, *dummyTransport) {
-	factory, _ := newEncoderFactory(msgpackType)
-	transport := &dummyTransport{encoderFactory: factory}
+	transport := &dummyTransport{getEncoder: msgpackEncoderFactory}
 	tracer := NewTracerTransport(transport)
 	return tracer, transport
 }
 
 // Mock Transport with a real Encoder
 type dummyTransport struct {
-	encoderFactory *encoderFactory
-	traces         [][]*Span
-	services       map[string]Service
+	getEncoder encoderFactory
+	traces     [][]*Span
+	services   map[string]Service
 
 	sync.RWMutex // required because of some poll-testing (eg: worker)
 }
@@ -624,7 +623,7 @@ func (t *dummyTransport) SendTraces(traces [][]*Span) (*http.Response, error) {
 	t.traces = append(t.traces, traces...)
 	t.Unlock()
 
-	encoder := t.encoderFactory.Get()
+	encoder := t.getEncoder()
 	return nil, encoder.EncodeTraces(traces)
 }
 
@@ -633,7 +632,7 @@ func (t *dummyTransport) SendServices(services map[string]Service) (*http.Respon
 	t.services = services
 	t.Unlock()
 
-	encoder := t.encoderFactory.Get()
+	encoder := t.getEncoder()
 	return nil, encoder.EncodeServices(services)
 }
 

--- a/tracer/transport_test.go
+++ b/tracer/transport_test.go
@@ -166,17 +166,17 @@ func TestTransportEncoderPool(t *testing.T) {
 	transport := newHTTPTransport(defaultHostname, defaultPort)
 
 	// MsgpackEncoder is the default encoder of the pool
-	encoder := transport.pool.Borrow()
+	encoder := transport.encoderFactory.Get()
 	assert.Equal("application/msgpack", encoder.ContentType())
 }
 
 func TestTransportSwitchEncoder(t *testing.T) {
 	assert := assert.New(t)
 	transport := newHTTPTransport(defaultHostname, defaultPort)
-	transport.changeEncoder(JSON_ENCODER)
+	transport.changeEncoder(jsonType)
 
 	// MsgpackEncoder is the default encoder of the pool
-	encoder := transport.pool.Borrow()
+	encoder := transport.encoderFactory.Get()
 	contentType := transport.headers["Content-Type"]
 	assert.Equal("application/json", encoder.ContentType())
 	assert.Equal("application/json", contentType)

--- a/tracer/transport_test.go
+++ b/tracer/transport_test.go
@@ -152,34 +152,23 @@ func TestTransportServicesDowngrade_0_2(t *testing.T) {
 	assert.Equal(200, response.StatusCode)
 }
 
-func TestTransportHeaders(t *testing.T) {
-	assert := assert.New(t)
-	transport := newHTTPTransport(defaultHostname, defaultPort)
-
-	// msgpack is the default Header
-	contentType := transport.headers["Content-Type"]
-	assert.Equal("application/msgpack", contentType)
-}
-
 func TestTransportEncoderPool(t *testing.T) {
 	assert := assert.New(t)
 	transport := newHTTPTransport(defaultHostname, defaultPort)
 
 	// MsgpackEncoder is the default encoder of the pool
-	encoder := transport.encoderFactory.Get()
+	encoder := transport.getEncoder()
 	assert.Equal("application/msgpack", encoder.ContentType())
 }
 
 func TestTransportSwitchEncoder(t *testing.T) {
 	assert := assert.New(t)
 	transport := newHTTPTransport(defaultHostname, defaultPort)
-	transport.changeEncoder(jsonType)
+	transport.changeEncoder(jsonEncoderFactory)
 
 	// MsgpackEncoder is the default encoder of the pool
-	encoder := transport.encoderFactory.Get()
-	contentType := transport.headers["Content-Type"]
+	encoder := transport.getEncoder()
 	assert.Equal("application/json", encoder.ContentType())
-	assert.Equal("application/json", contentType)
 }
 
 func TestTraceCountHeader(t *testing.T) {


### PR DESCRIPTION
After several race conditions / unexpected panics due to reusing the underlying buffers via a pool of encoders, we need to make the following changes:

- **allocating a new encoder each time we flush** (= a new `bytes.Buffer`)  => performance overhead, but necessary since neither the `encoder` nor the `bytes.Buffer` is thread-safe.
- **removing the encoder pool** who was not used anyway, since the worker was working synchronously (flush traces -> encode traces -> send the encoder -> return the encoder -> new cycle for the worker). 

_Note:_ Since [we only flush every 2s](https://github.com/DataDog/dd-trace-go/blob/master/tracer/tracer.go#L16), allocating a new encoder at every flush is acceptable.

## TODO
This PR needs to be merged to avoid the apps using our go tracer from panicking.
However, we should work on a way to improve our tracer efficiency.
Here are some ideas:
- **make the worker asynchronous**, _ie_ sending traces/services from a new goroutine (but make sure we don't introduce new race conditions)
- **encoding the traces/services into a thread-safe struct that can be sent over the network**, to be able to reuse the encoders and avoid allocated a new encoder anytime we flush. _But make sure we don't introduce any race condition._

_Note:_ We should also work on a way to precisely measure the performance impact of our tracer on real apps in production (I tried to use [out-of-the-box expvar metrics](https://github.com/gabsn/go-perf), but this was not conclusive).

## Issues this PR solves
### Unexpected panic
```
panic: runtime error: slice bounds out of range

goroutine 18 [running]:
bytes.(*Buffer).Bytes(...)
        /home/vagrant/.gimme/versions/go1.9.linux.amd64/src/bytes/buffer.go:52
github.com/DataDog/dd-go/vendor/github.com/DataDog/dd-trace-go/tracer.(*httpTransport).SendTraces(0xc4201380c0, 0xc438f4fb00, 0x8, 0x8, 0x0, 0x0, 0x0)
        /home/vagrant/go/src/github.com/DataDog/dd-go/vendor/github.com/DataDog/dd-trace-go/tracer/transport.go:117 +0x80d
github.com/DataDog/dd-go/vendor/github.com/DataDog/dd-trace-go/tracer.(*Tracer).flushTraces(0xc4201341a0)
        /home/vagrant/go/src/github.com/DataDog/dd-go/vendor/github.com/DataDog/dd-trace-go/tracer/tracer.go:286 +0x33d
github.com/DataDog/dd-go/vendor/github.com/DataDog/dd-trace-go/tracer.(*Tracer).flush(0xc4201341a0)
        /home/vagrant/go/src/github.com/DataDog/dd-go/vendor/github.com/DataDog/dd-trace-go/tracer/tracer.go:329 +0x2b
github.com/DataDog/dd-go/vendor/github.com/DataDog/dd-trace-go/tracer.(*Tracer).worker(0xc4201341a0)
        /home/vagrant/go/src/github.com/DataDog/dd-go/vendor/github.com/DataDog/dd-trace-go/tracer/tracer.go:352 +0x321
created by github.com/DataDog/dd-go/vendor/github.com/DataDog/dd-trace-go/tracer.NewTracerTransport
        /home/vagrant/go/src/github.com/DataDog/dd-go/vendor/github.com/DataDog/dd-trace-go/tracer/tracer.go:87 +0x3d6
```
### Race condition (already solved by #112)
```
==================
WARNING: DATA RACE
Write at 0x00c42005a300 by goroutine 7:
  bytes.(*Buffer).Truncate()
      /home/vagrant/.gimme/versions/go1.8.linux.amd64/src/bytes/buffer.go:71 +0x40
  bytes.(*Buffer).Reset()
      /home/vagrant/.gimme/versions/go1.8.linux.amd64/src/bytes/buffer.go:85 +0x41
  github.com/DataDog/dd-trace-go/tracer.(*msgpackEncoder).EncodeTraces()
      /home/vagrant/go/src/github.com/DataDog/dd-trace-go/tracer/encoder.go:42 +0x50
  github.com/DataDog/dd-trace-go/tracer.(*httpTransport).SendTraces()
      /home/vagrant/go/src/github.com/DataDog/dd-trace-go/tracer/transport.go:103 +0x21d
  github.com/DataDog/dd-trace-go/tracer.(*Tracer).flushTraces()
      /home/vagrant/go/src/github.com/DataDog/dd-trace-go/tracer/tracer.go:275 +0x457
  github.com/DataDog/dd-trace-go/tracer.(*Tracer).flush()
      /home/vagrant/go/src/github.com/DataDog/dd-trace-go/tracer/tracer.go:318 +0x38
  github.com/DataDog/dd-trace-go/tracer.(*Tracer).worker()
      /home/vagrant/go/src/github.com/DataDog/dd-trace-go/tracer/tracer.go:346 +0x217

Previous write at 0x00c42005a300 by goroutine 276:
  [failed to restore the stack]

Goroutine 7 (running) created at:
  github.com/DataDog/dd-trace-go/tracer.NewTracerTransport()
      /home/vagrant/go/src/github.com/DataDog/dd-trace-go/tracer/tracer.go:85 +0x5b5
  github.com/DataDog/dd-trace-go/tracer.NewTracer()
      /home/vagrant/go/src/github.com/DataDog/dd-trace-go/tracer/tracer.go:61 +0x46
  github.com/DataDog/dd-trace-go/tracer.init()
      /home/vagrant/go/src/github.com/DataDog/dd-trace-go/tracer/tracer.go:374 +0x108
  main.init()
      /home/vagrant/go/src/github.com/DataDog/dd-go/apps/hms-resolver/stats.go:114 +0xd1

Goroutine 276 (finished) created at:
  net/http.(*Transport).dialConn()
      /home/vagrant/.gimme/versions/go1.8.linux.amd64/src/net/http/transport.go:1118 +0xc2c
  net/http.(*Transport).getConn.func4()
      /home/vagrant/.gimme/versions/go1.8.linux.amd64/src/net/http/transport.go:908 +0xa2
==================
```
