### PR TITLE
[tools] add dep to manage vendor folder

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,0 +1,29 @@
+# Gopkg.toml:
+# this `dep` file is used only to lock Tracer dependencies. It's not meant to be 
+# used by end users so no integrations dependencies must be added here. If you update 
+# or add a new dependency, remember to commit the `vendor` folder. To prepare
+# your development environment, remember to use `rake init` instead.
+
+# ignore integrations dependencies
+ignored = [
+  "github.com/cihub/seelog",
+  "github.com/gin-gonic/gin",
+  "github.com/go-redis/redis",
+  "github.com/go-sql-driver/mysql",
+  "github.com/gocql/gocql",
+  "github.com/gorilla/mux",
+  "github.com/jmoiron/sqlx",
+  "github.com/lib/pq",
+  "google.golang.org/grpc",
+  "gopkg.in/olivere/elastic.v3",
+  "gopkg.in/olivere/elastic.v5",
+  "github.com/stretchr/*",
+  "github.com/garyburd/*",
+  "github.com/golang/*",
+  "google.golang.org/*",
+  "golang.org/x/*",
+]
+
+[[constraint]]
+  name = "github.com/ugorji/go"
+  revision = "9c7f9b7a2bc3a520f7c7b30b34b7f85f47fe27b6"

--- a/tasks/vendors.rb
+++ b/tasks/vendors.rb
@@ -1,6 +1,6 @@
 desc 'Initialize the development environment'
 task :init do
-  sh 'go get -u github.com/tools/godep'
+  sh 'go get -u github.com/golang/dep/cmd/dep'
   sh 'go get -u github.com/alecthomas/gometalinter'
   sh 'gometalinter --install'
 
@@ -11,12 +11,6 @@ namespace :vendors do
   desc "Update the vendors list"
   task :update do
     # download and update our vendors
-    sh "go get -u github.com/ugorji/go/codec"
-    # clean the current folder and start vendoring
-    sh "rm -r vendor/"
-    sh "godep save ./tracer"
-    # remove extra stuff
-    sh "rm -r Godeps/"
-    sh "rm -r vendor/github.com/stretchr/"
+    sh 'dep ensure'
   end
 end


### PR DESCRIPTION
### Overview

The previous approach relied on `go get` and `godep` to get / update internal dependencies. Since we're vendoring, we don't need a vendor tool, but having `dep` to manage the `vendor` folder helps us keeping stable commits.