### PR TITLE
[opentracing] add Compatibility Layer

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -6,6 +6,7 @@
 
 # ignore integrations dependencies
 ignored = [
+  "github.com/opentracing/*",
   "github.com/cihub/seelog",
   "github.com/gin-gonic/gin",
   "github.com/go-redis/redis",

--- a/opentracing/config.go
+++ b/opentracing/config.go
@@ -1,0 +1,65 @@
+package opentracing
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+
+	datadog "github.com/DataDog/dd-trace-go/tracer"
+	ot "github.com/opentracing/opentracing-go"
+)
+
+// Configuration struct to configure a Datadog Tracer
+type Configuration struct {
+	Enabled       bool    // when disabled, a no-op implementation is returned
+	Debug         bool    // when enabled, more details are written in logs
+	ServiceName   string  // define the service name for this application
+	SampleRate    float64 // set the Tracer sample rate [0, 1]
+	AgentHostname string  // change the hostname where traces are sent
+	AgentPort     string  // change the port where traces are sent
+}
+
+// NewConfiguration creates a `Configuration` object with default values.
+func NewConfiguration() *Configuration {
+	// default service name is the Go binary name
+	binaryName := filepath.Base(os.Args[0])
+
+	// Configuration struct with default values
+	return &Configuration{
+		Enabled:       true,
+		Debug:         false,
+		ServiceName:   binaryName,
+		SampleRate:    1,
+		AgentHostname: "localhost",
+		AgentPort:     "8126",
+	}
+}
+
+type noopCloser struct{}
+
+func (c *noopCloser) Close() error { return nil }
+
+// NewDatadogTracer uses a Configuration object to initialize a
+// Datadog Tracer. The initialization returns a `io.Closer` that
+// can be used to graceful shutdown the tracer. If the configuration object
+// defines a disabled Tracer, a no-op implementation is returned.
+func NewDatadogTracer(config *Configuration) (ot.Tracer, io.Closer, error) {
+	if config.ServiceName == "" {
+		// abort initialization if a `ServiceName` is not defined
+		return nil, nil, errors.New("A Datadog Tracer requires a valid `ServiceName` set")
+	}
+
+	if config.Enabled == false {
+		// return a no-op implementation so Datadog provides the minimum overhead
+		return &ot.NoopTracer{}, &noopCloser{}, nil
+	}
+
+	// configure a Datadog Tracer
+	transport := datadog.NewTransport(config.AgentHostname, config.AgentPort)
+	tracer := &Tracer{impl: datadog.NewTracerTransport(transport)}
+	tracer.impl.SetDebugLogging(config.Debug)
+	tracer.impl.SetSampleRate(config.SampleRate)
+
+	return tracer, tracer, nil
+}

--- a/opentracing/config.go
+++ b/opentracing/config.go
@@ -57,7 +57,10 @@ func NewTracer(config *Configuration) (ot.Tracer, io.Closer, error) {
 
 	// configure a Datadog Tracer
 	transport := datadog.NewTransport(config.AgentHostname, config.AgentPort)
-	tracer := &Tracer{impl: datadog.NewTracerTransport(transport)}
+	tracer := &Tracer{
+		impl:        datadog.NewTracerTransport(transport),
+		serviceName: config.ServiceName,
+	}
 	tracer.impl.SetDebugLogging(config.Debug)
 	tracer.impl.SetSampleRate(config.SampleRate)
 

--- a/opentracing/config.go
+++ b/opentracing/config.go
@@ -40,11 +40,11 @@ type noopCloser struct{}
 
 func (c *noopCloser) Close() error { return nil }
 
-// NewDatadogTracer uses a Configuration object to initialize a
-// Datadog Tracer. The initialization returns a `io.Closer` that
-// can be used to graceful shutdown the tracer. If the configuration object
-// defines a disabled Tracer, a no-op implementation is returned.
-func NewDatadogTracer(config *Configuration) (ot.Tracer, io.Closer, error) {
+// NewTracer uses a Configuration object to initialize a Datadog Tracer.
+// The initialization returns a `io.Closer` that can be used to graceful
+// shutdown the tracer. If the configuration object defines a disabled
+// Tracer, a no-op implementation is returned.
+func NewTracer(config *Configuration) (ot.Tracer, io.Closer, error) {
 	if config.ServiceName == "" {
 		// abort initialization if a `ServiceName` is not defined
 		return nil, nil, errors.New("A Datadog Tracer requires a valid `ServiceName` set")

--- a/opentracing/config.go
+++ b/opentracing/config.go
@@ -1,13 +1,8 @@
 package opentracing
 
 import (
-	"errors"
-	"io"
 	"os"
 	"path/filepath"
-
-	datadog "github.com/DataDog/dd-trace-go/tracer"
-	ot "github.com/opentracing/opentracing-go"
 )
 
 // Configuration struct to configure a Datadog Tracer
@@ -39,30 +34,3 @@ func NewConfiguration() *Configuration {
 type noopCloser struct{}
 
 func (c *noopCloser) Close() error { return nil }
-
-// NewTracer uses a Configuration object to initialize a Datadog Tracer.
-// The initialization returns a `io.Closer` that can be used to graceful
-// shutdown the tracer. If the configuration object defines a disabled
-// Tracer, a no-op implementation is returned.
-func NewTracer(config *Configuration) (ot.Tracer, io.Closer, error) {
-	if config.ServiceName == "" {
-		// abort initialization if a `ServiceName` is not defined
-		return nil, nil, errors.New("A Datadog Tracer requires a valid `ServiceName` set")
-	}
-
-	if config.Enabled == false {
-		// return a no-op implementation so Datadog provides the minimum overhead
-		return &ot.NoopTracer{}, &noopCloser{}, nil
-	}
-
-	// configure a Datadog Tracer
-	transport := datadog.NewTransport(config.AgentHostname, config.AgentPort)
-	tracer := &Tracer{
-		impl:        datadog.NewTracerTransport(transport),
-		serviceName: config.ServiceName,
-	}
-	tracer.impl.SetDebugLogging(config.Debug)
-	tracer.impl.SetSampleRate(config.SampleRate)
-
-	return tracer, tracer, nil
-}

--- a/opentracing/config_test.go
+++ b/opentracing/config_test.go
@@ -18,7 +18,32 @@ func TestConfigurationDefaults(t *testing.T) {
 	assert.Equal("8126", config.AgentPort)
 }
 
+func TestConfiguration(t *testing.T) {
+	assert := assert.New(t)
+
+	config := NewConfiguration()
+	config.SampleRate = 0
+	config.AgentHostname = "ddagent.consul.local"
+	config.AgentPort = "58126"
+	tracer, closer, err := NewTracer(config)
+	assert.NotNil(tracer)
+	assert.NotNil(closer)
+	assert.Nil(err)
+}
+
 func TestTracerConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	config := NewConfiguration()
+	config.ServiceName = "api-intake"
+	tracer, closer, err := NewTracer(config)
+	assert.Nil(err)
+	assert.NotNil(closer)
+	assert.NotNil(tracer)
+	assert.Equal("api-intake", tracer.(*Tracer).serviceName)
+}
+
+func TestTracerServiceName(t *testing.T) {
 	assert := assert.New(t)
 
 	config := NewConfiguration()
@@ -38,18 +63,5 @@ func TestDisabledTracer(t *testing.T) {
 	tracer, closer, err := NewTracer(config)
 	assert.IsType(&ot.NoopTracer{}, tracer)
 	assert.IsType(&noopCloser{}, closer)
-	assert.Nil(err)
-}
-
-func TestConfiguration(t *testing.T) {
-	assert := assert.New(t)
-
-	config := NewConfiguration()
-	config.SampleRate = 0
-	config.AgentHostname = "ddagent.consul.local"
-	config.AgentPort = "58126"
-	tracer, closer, err := NewTracer(config)
-	assert.NotNil(tracer)
-	assert.NotNil(closer)
 	assert.Nil(err)
 }

--- a/opentracing/config_test.go
+++ b/opentracing/config_test.go
@@ -1,0 +1,55 @@
+package opentracing
+
+import (
+	"testing"
+
+	ot "github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigurationDefaults(t *testing.T) {
+	assert := assert.New(t)
+
+	config := NewConfiguration()
+	assert.Equal(true, config.Enabled)
+	assert.Equal(false, config.Debug)
+	assert.Equal("opentracing.test", config.ServiceName)
+	assert.Equal("localhost", config.AgentHostname)
+	assert.Equal("8126", config.AgentPort)
+}
+
+func TestTracerConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	config := NewConfiguration()
+	config.ServiceName = ""
+	tracer, closer, err := NewDatadogTracer(config)
+	assert.Nil(tracer)
+	assert.Nil(closer)
+	assert.NotNil(err)
+	assert.Equal("A Datadog Tracer requires a valid `ServiceName` set", err.Error())
+}
+
+func TestDisabledTracer(t *testing.T) {
+	assert := assert.New(t)
+
+	config := NewConfiguration()
+	config.Enabled = false
+	tracer, closer, err := NewDatadogTracer(config)
+	assert.IsType(&ot.NoopTracer{}, tracer)
+	assert.IsType(&noopCloser{}, closer)
+	assert.Nil(err)
+}
+
+func TestConfiguration(t *testing.T) {
+	assert := assert.New(t)
+
+	config := NewConfiguration()
+	config.SampleRate = 0
+	config.AgentHostname = "ddagent.consul.local"
+	config.AgentPort = "58126"
+	tracer, closer, err := NewDatadogTracer(config)
+	assert.NotNil(tracer)
+	assert.NotNil(closer)
+	assert.Nil(err)
+}

--- a/opentracing/config_test.go
+++ b/opentracing/config_test.go
@@ -24,23 +24,13 @@ func TestConfiguration(t *testing.T) {
 
 	config := NewConfiguration()
 	config.SampleRate = 0
+	config.ServiceName = "api-intake"
 	config.AgentHostname = "ddagent.consul.local"
 	config.AgentPort = "58126"
 	tracer, closer, err := NewTracer(config)
 	assert.NotNil(tracer)
 	assert.NotNil(closer)
 	assert.Nil(err)
-}
-
-func TestTracerConstructor(t *testing.T) {
-	assert := assert.New(t)
-
-	config := NewConfiguration()
-	config.ServiceName = "api-intake"
-	tracer, closer, err := NewTracer(config)
-	assert.Nil(err)
-	assert.NotNil(closer)
-	assert.NotNil(tracer)
 	assert.Equal("api-intake", tracer.(*Tracer).serviceName)
 }
 

--- a/opentracing/config_test.go
+++ b/opentracing/config_test.go
@@ -23,7 +23,7 @@ func TestTracerConstructor(t *testing.T) {
 
 	config := NewConfiguration()
 	config.ServiceName = ""
-	tracer, closer, err := NewDatadogTracer(config)
+	tracer, closer, err := NewTracer(config)
 	assert.Nil(tracer)
 	assert.Nil(closer)
 	assert.NotNil(err)
@@ -35,7 +35,7 @@ func TestDisabledTracer(t *testing.T) {
 
 	config := NewConfiguration()
 	config.Enabled = false
-	tracer, closer, err := NewDatadogTracer(config)
+	tracer, closer, err := NewTracer(config)
 	assert.IsType(&ot.NoopTracer{}, tracer)
 	assert.IsType(&noopCloser{}, closer)
 	assert.Nil(err)
@@ -48,7 +48,7 @@ func TestConfiguration(t *testing.T) {
 	config.SampleRate = 0
 	config.AgentHostname = "ddagent.consul.local"
 	config.AgentPort = "58126"
-	tracer, closer, err := NewDatadogTracer(config)
+	tracer, closer, err := NewTracer(config)
 	assert.NotNil(tracer)
 	assert.NotNil(closer)
 	assert.Nil(err)

--- a/opentracing/config_test.go
+++ b/opentracing/config_test.go
@@ -13,6 +13,7 @@ func TestConfigurationDefaults(t *testing.T) {
 	config := NewConfiguration()
 	assert.Equal(true, config.Enabled)
 	assert.Equal(false, config.Debug)
+	assert.Equal(float64(1), config.SampleRate)
 	assert.Equal("opentracing.test", config.ServiceName)
 	assert.Equal("localhost", config.AgentHostname)
 	assert.Equal("8126", config.AgentPort)

--- a/opentracing/context.go
+++ b/opentracing/context.go
@@ -7,6 +7,7 @@ type SpanContext struct {
 	spanID   uint64
 	parentID uint64
 	sampled  bool
+	span     *Span
 	baggage  map[string]string
 }
 
@@ -34,5 +35,12 @@ func (c SpanContext) WithBaggageItem(key, val string) SpanContext {
 		newBaggage[key] = val
 	}
 	// Use positional parameters so the compiler will help catch new fields.
-	return SpanContext{c.traceID, c.spanID, c.parentID, c.sampled, newBaggage}
+	return SpanContext{
+		traceID:  c.traceID,
+		spanID:   c.spanID,
+		parentID: c.parentID,
+		sampled:  c.sampled,
+		span:     c.span,
+		baggage:  newBaggage,
+	}
 }

--- a/opentracing/context.go
+++ b/opentracing/context.go
@@ -1,0 +1,12 @@
+package opentracing
+
+// SpanContext represents Span state that must propagate to descendant Spans
+// and across process boundaries.
+type SpanContext struct {
+}
+
+// ForeachBaggageItem grants access to all baggage items stored in the
+// SpanContext
+func (n SpanContext) ForeachBaggageItem(handler func(k, v string) bool) {
+	// TODO: implementation required
+}

--- a/opentracing/context.go
+++ b/opentracing/context.go
@@ -3,10 +3,36 @@ package opentracing
 // SpanContext represents Span state that must propagate to descendant Spans
 // and across process boundaries.
 type SpanContext struct {
+	traceID  uint64
+	spanID   uint64
+	parentID uint64
+	sampled  bool
+	baggage  map[string]string
 }
 
 // ForeachBaggageItem grants access to all baggage items stored in the
 // SpanContext
-func (n SpanContext) ForeachBaggageItem(handler func(k, v string) bool) {
-	// TODO: implementation required
+func (c SpanContext) ForeachBaggageItem(handler func(k, v string) bool) {
+	for k, v := range c.baggage {
+		if !handler(k, v) {
+			break
+		}
+	}
+}
+
+// WithBaggageItem returns an entirely new SpanContext with the
+// given key:value baggage pair set.
+func (c SpanContext) WithBaggageItem(key, val string) SpanContext {
+	var newBaggage map[string]string
+	if c.baggage == nil {
+		newBaggage = map[string]string{key: val}
+	} else {
+		newBaggage = make(map[string]string, len(c.baggage)+1)
+		for k, v := range c.baggage {
+			newBaggage[k] = v
+		}
+		newBaggage[key] = val
+	}
+	// Use positional parameters so the compiler will help catch new fields.
+	return SpanContext{c.traceID, c.spanID, c.parentID, c.sampled, newBaggage}
 }

--- a/opentracing/context_test.go
+++ b/opentracing/context_test.go
@@ -1,0 +1,29 @@
+package opentracing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpanContextBaggage(t *testing.T) {
+	assert := assert.New(t)
+
+	ctx := SpanContext{}
+	ctx = ctx.WithBaggageItem("key", "value")
+	assert.Equal("value", ctx.baggage["key"])
+}
+
+func TestSpanContextIterator(t *testing.T) {
+	assert := assert.New(t)
+
+	baggageIterator := make(map[string]string)
+	ctx := SpanContext{baggage: map[string]string{"key": "value"}}
+	ctx.ForeachBaggageItem(func(k, v string) bool {
+		baggageIterator[k] = v
+		return true
+	})
+
+	assert.Len(baggageIterator, 1)
+	assert.Equal("value", baggageIterator["key"])
+}

--- a/opentracing/span.go
+++ b/opentracing/span.go
@@ -9,7 +9,7 @@ import (
 // Span represents an active, un-finished span in the OpenTracing system.
 // Spans are created by the Tracer interface.
 type Span struct {
-	datadog.Span
+	*datadog.Span
 	context SpanContext
 	tracer  *Tracer
 }
@@ -96,4 +96,13 @@ func (s *Span) LogEventWithPayload(event string, payload interface{}) {
 // Log is deprecated: use LogFields or LogKV
 func (s *Span) Log(data ot.LogData) {
 	// TODO: implementation missing
+}
+
+// NewSpan is the OpenTracing Span constructor
+func NewSpan(operationName string) *Span {
+	return &Span{
+		Span: &datadog.Span{
+			Name: operationName,
+		},
+	}
 }

--- a/opentracing/span.go
+++ b/opentracing/span.go
@@ -100,9 +100,21 @@ func (s *Span) Log(data ot.LogData) {
 
 // NewSpan is the OpenTracing Span constructor
 func NewSpan(operationName string) *Span {
-	return &Span{
-		Span: &datadog.Span{
-			Name: operationName,
+	span := &datadog.Span{
+		Name: operationName,
+	}
+
+	otSpan := &Span{
+		Span: span,
+		context: SpanContext{
+			traceID:  span.TraceID,
+			spanID:   span.SpanID,
+			parentID: span.ParentID,
+			sampled:  span.Sampled,
 		},
 	}
+
+	// SpanContext is propagated and used to create children
+	otSpan.context.span = otSpan
+	return otSpan
 }

--- a/opentracing/span.go
+++ b/opentracing/span.go
@@ -1,6 +1,8 @@
 package opentracing
 
 import (
+	"time"
+
 	datadog "github.com/DataDog/dd-trace-go/tracer"
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
@@ -56,8 +58,12 @@ func (s *Span) SetTag(key string, value interface{}) ot.Span {
 
 // FinishWithOptions is like Finish() but with explicit control over
 // timestamps and log data.
-func (s *Span) FinishWithOptions(opts ot.FinishOptions) {
-	// TODO: implementation missing
+func (s *Span) FinishWithOptions(options ot.FinishOptions) {
+	if options.FinishTime.IsZero() {
+		options.FinishTime = time.Now().UTC()
+	}
+
+	s.Span.FinishWithTime(options.FinishTime.UnixNano())
 }
 
 // SetOperationName sets or changes the operation name.

--- a/opentracing/span.go
+++ b/opentracing/span.go
@@ -1,7 +1,7 @@
 package opentracing
 
 import (
-	"github.com/DataDog/dd-trace-go/tracer"
+	datadog "github.com/DataDog/dd-trace-go/tracer"
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 )
@@ -9,9 +9,14 @@ import (
 // Span represents an active, un-finished span in the OpenTracing system.
 // Spans are created by the Tracer interface.
 type Span struct {
-	*tracer.Span
+	datadog.Span
 	context SpanContext
 	tracer  *Tracer
+}
+
+// Tracer provides access to the `Tracer`` that created this Span.
+func (s *Span) Tracer() ot.Tracer {
+	return s.tracer
 }
 
 // Context yields the SpanContext for this Span. Note that the return
@@ -24,18 +29,43 @@ func (s *Span) Context() ot.SpanContext {
 // SetBaggageItem sets a key:value pair on this Span and its SpanContext
 // that also propagates to descendants of this Span.
 func (s *Span) SetBaggageItem(key, val string) ot.Span {
+	s.Span.Lock()
+	defer s.Span.Unlock()
+
+	s.context = s.context.WithBaggageItem(key, val)
 	return s
 }
 
 // BaggageItem gets the value for a baggage item given its key. Returns the empty string
 // if the value isn't found in this Span.
 func (s *Span) BaggageItem(key string) string {
-	return ""
+	s.Span.Lock()
+	defer s.Span.Unlock()
+
+	return s.context.baggage[key]
 }
 
 // SetTag adds a tag to the span, overwriting pre-existing values for
 // the given `key`.
 func (s *Span) SetTag(key string, value interface{}) ot.Span {
+	// NOTE: locking is not required because the `SetMeta` is
+	// already thread-safe
+	s.Span.SetMeta(key, value.(string))
+	return s
+}
+
+// FinishWithOptions is like Finish() but with explicit control over
+// timestamps and log data.
+func (s *Span) FinishWithOptions(opts ot.FinishOptions) {
+	// TODO: implementation missing
+}
+
+// SetOperationName sets or changes the operation name.
+func (s *Span) SetOperationName(operationName string) ot.Span {
+	s.Span.Lock()
+	defer s.Span.Unlock()
+
+	s.Span.Name = operationName
 	return s
 }
 
@@ -43,37 +73,27 @@ func (s *Span) SetTag(key string, value interface{}) ot.Span {
 // logging data about a Span, though the programming interface is a little
 // more verbose than LogKV().
 func (s *Span) LogFields(fields ...log.Field) {
+	// TODO: implementation missing
 }
 
 // LogKV is a concise, readable way to record key:value logging data about
 // a Span, though unfortunately this also makes it less efficient and less
 // type-safe than LogFields().
 func (s *Span) LogKV(keyVals ...interface{}) {
-}
-
-// FinishWithOptions is like Finish() but with explicit control over
-// timestamps and log data.
-func (s *Span) FinishWithOptions(opts ot.FinishOptions) {
-}
-
-// SetOperationName sets or changes the operation name.
-func (s *Span) SetOperationName(operationName string) ot.Span {
-	return s
-}
-
-// Tracer provides access to the `Tracer`` that created this Span.
-func (s *Span) Tracer() ot.Tracer {
-	return s.tracer
+	// TODO: implementation missing
 }
 
 // LogEvent is deprecated: use LogFields or LogKV
 func (s *Span) LogEvent(event string) {
+	// TODO: implementation missing
 }
 
 // LogEventWithPayload deprecated: use LogFields or LogKV
 func (s *Span) LogEventWithPayload(event string, payload interface{}) {
+	// TODO: implementation missing
 }
 
 // Log is deprecated: use LogFields or LogKV
 func (s *Span) Log(data ot.LogData) {
+	// TODO: implementation missing
 }

--- a/opentracing/span.go
+++ b/opentracing/span.go
@@ -1,0 +1,79 @@
+package opentracing
+
+import (
+	"github.com/DataDog/dd-trace-go/tracer"
+	ot "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+)
+
+// Span represents an active, un-finished span in the OpenTracing system.
+// Spans are created by the Tracer interface.
+type Span struct {
+	*tracer.Span
+	context SpanContext
+	tracer  *Tracer
+}
+
+// Context yields the SpanContext for this Span. Note that the return
+// value of Context() is still valid after a call to Span.Finish(), as is
+// a call to Span.Context() after a call to Span.Finish().
+func (s *Span) Context() ot.SpanContext {
+	return s.context
+}
+
+// SetBaggageItem sets a key:value pair on this Span and its SpanContext
+// that also propagates to descendants of this Span.
+func (s *Span) SetBaggageItem(key, val string) ot.Span {
+	return s
+}
+
+// BaggageItem gets the value for a baggage item given its key. Returns the empty string
+// if the value isn't found in this Span.
+func (s *Span) BaggageItem(key string) string {
+	return ""
+}
+
+// SetTag adds a tag to the span, overwriting pre-existing values for
+// the given `key`.
+func (s *Span) SetTag(key string, value interface{}) ot.Span {
+	return s
+}
+
+// LogFields is an efficient and type-checked way to record key:value
+// logging data about a Span, though the programming interface is a little
+// more verbose than LogKV().
+func (s *Span) LogFields(fields ...log.Field) {
+}
+
+// LogKV is a concise, readable way to record key:value logging data about
+// a Span, though unfortunately this also makes it less efficient and less
+// type-safe than LogFields().
+func (s *Span) LogKV(keyVals ...interface{}) {
+}
+
+// FinishWithOptions is like Finish() but with explicit control over
+// timestamps and log data.
+func (s *Span) FinishWithOptions(opts ot.FinishOptions) {
+}
+
+// SetOperationName sets or changes the operation name.
+func (s *Span) SetOperationName(operationName string) ot.Span {
+	return s
+}
+
+// Tracer provides access to the `Tracer`` that created this Span.
+func (s *Span) Tracer() ot.Tracer {
+	return s.tracer
+}
+
+// LogEvent is deprecated: use LogFields or LogKV
+func (s *Span) LogEvent(event string) {
+}
+
+// LogEventWithPayload deprecated: use LogFields or LogKV
+func (s *Span) LogEventWithPayload(event string, payload interface{}) {
+}
+
+// Log is deprecated: use LogFields or LogKV
+func (s *Span) Log(data ot.LogData) {
+}

--- a/opentracing/span_test.go
+++ b/opentracing/span_test.go
@@ -2,7 +2,9 @@ package opentracing
 
 import (
 	"testing"
+	"time"
 
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,4 +38,24 @@ func TestSpanOperationName(t *testing.T) {
 	span := NewSpan("web.request")
 	span.SetOperationName("http.request")
 	assert.Equal("http.request", span.Span.Name)
+}
+
+func TestSpanFinish(t *testing.T) {
+	assert := assert.New(t)
+
+	span := NewSpan("web.request")
+	span.Finish()
+
+	assert.True(span.Span.Duration > 0)
+}
+
+func TestSpanFinishWithTime(t *testing.T) {
+	assert := assert.New(t)
+
+	finishTime := time.Now().Add(10 * time.Second)
+	span := NewSpan("web.request")
+	span.FinishWithOptions(opentracing.FinishOptions{FinishTime: finishTime})
+
+	duration := finishTime.UnixNano() - span.Span.Start
+	assert.Equal(duration, span.Span.Duration)
 }

--- a/opentracing/span_test.go
+++ b/opentracing/span_test.go
@@ -1,0 +1,39 @@
+package opentracing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpanBaggage(t *testing.T) {
+	assert := assert.New(t)
+
+	span := &Span{}
+	span.SetBaggageItem("key", "value")
+	assert.Equal("value", span.BaggageItem("key"))
+}
+
+func TestSpanContext(t *testing.T) {
+	assert := assert.New(t)
+
+	span := &Span{}
+	assert.NotNil(span.Context())
+}
+
+func TestSpanSetTag(t *testing.T) {
+	assert := assert.New(t)
+
+	span := &Span{}
+	span.Span.Meta = make(map[string]string)
+	span.SetTag("component", "tracer")
+	assert.Equal("tracer", span.Meta["component"])
+}
+
+func TestSpanOperationName(t *testing.T) {
+	assert := assert.New(t)
+
+	span := &Span{}
+	span.SetOperationName("http.request")
+	assert.Equal("http.request", span.Span.Name)
+}

--- a/opentracing/span_test.go
+++ b/opentracing/span_test.go
@@ -9,7 +9,7 @@ import (
 func TestSpanBaggage(t *testing.T) {
 	assert := assert.New(t)
 
-	span := &Span{}
+	span := NewSpan("web.request")
 	span.SetBaggageItem("key", "value")
 	assert.Equal("value", span.BaggageItem("key"))
 }
@@ -17,14 +17,14 @@ func TestSpanBaggage(t *testing.T) {
 func TestSpanContext(t *testing.T) {
 	assert := assert.New(t)
 
-	span := &Span{}
+	span := NewSpan("web.request")
 	assert.NotNil(span.Context())
 }
 
 func TestSpanSetTag(t *testing.T) {
 	assert := assert.New(t)
 
-	span := &Span{}
+	span := NewSpan("web.request")
 	span.Span.Meta = make(map[string]string)
 	span.SetTag("component", "tracer")
 	assert.Equal("tracer", span.Meta["component"])
@@ -33,7 +33,7 @@ func TestSpanSetTag(t *testing.T) {
 func TestSpanOperationName(t *testing.T) {
 	assert := assert.New(t)
 
-	span := &Span{}
+	span := NewSpan("web.request")
 	span.SetOperationName("http.request")
 	assert.Equal("http.request", span.Span.Name)
 }

--- a/opentracing/tracer.go
+++ b/opentracing/tracer.go
@@ -1,0 +1,32 @@
+package opentracing
+
+import (
+	"github.com/DataDog/dd-trace-go/tracer"
+	ot "github.com/opentracing/opentracing-go"
+)
+
+// Tracer is a simple, thin interface for Span creation and SpanContext
+// propagation.
+type Tracer struct {
+	tracer *tracer.Tracer
+}
+
+// StartSpan creates, starts, and returns a new Span with the given `operationName`
+// A Span with no SpanReference options (e.g., opentracing.ChildOf() or
+// opentracing.FollowsFrom()) becomes the root of its own trace.
+func (t *Tracer) StartSpan(operationName string, opts ...ot.StartSpanOption) ot.Span {
+	// TODO: implementation missing; returning an empty Span to validate OpenTracing API
+	return &Span{}
+}
+
+// Inject takes the `sm` SpanContext instance and injects it for
+// propagation within `carrier`. The actual type of `carrier` depends on
+// the value of `format`.
+func (t *Tracer) Inject(sp ot.SpanContext, format interface{}, carrier interface{}) error {
+	return nil
+}
+
+// Extract returns a SpanContext instance given `format` and `carrier`.
+func (t *Tracer) Extract(format interface{}, carrier interface{}) (ot.SpanContext, error) {
+	return nil, nil
+}

--- a/opentracing/tracer.go
+++ b/opentracing/tracer.go
@@ -1,14 +1,14 @@
 package opentracing
 
 import (
-	"github.com/DataDog/dd-trace-go/tracer"
+	datadog "github.com/DataDog/dd-trace-go/tracer"
 	ot "github.com/opentracing/opentracing-go"
 )
 
 // Tracer is a simple, thin interface for Span creation and SpanContext
 // propagation.
 type Tracer struct {
-	tracer *tracer.Tracer
+	impl *datadog.Tracer
 }
 
 // StartSpan creates, starts, and returns a new Span with the given `operationName`
@@ -29,4 +29,12 @@ func (t *Tracer) Inject(sp ot.SpanContext, format interface{}, carrier interface
 // Extract returns a SpanContext instance given `format` and `carrier`.
 func (t *Tracer) Extract(format interface{}, carrier interface{}) (ot.SpanContext, error) {
 	return nil, nil
+}
+
+// Close method implements `io.Closer` interface to graceful shutdown the Datadog
+// Tracer. Note that this is a blocking operation that waits for the flushing Go
+// routine.
+func (t *Tracer) Close() error {
+	t.impl.Stop()
+	return nil
 }

--- a/opentracing/tracer.go
+++ b/opentracing/tracer.go
@@ -1,6 +1,8 @@
 package opentracing
 
 import (
+	"errors"
+	"io"
 	"time"
 
 	datadog "github.com/DataDog/dd-trace-go/tracer"
@@ -110,4 +112,31 @@ func (t *Tracer) Extract(format interface{}, carrier interface{}) (ot.SpanContex
 func (t *Tracer) Close() error {
 	t.impl.Stop()
 	return nil
+}
+
+// NewTracer uses a Configuration object to initialize a Datadog Tracer.
+// The initialization returns a `io.Closer` that can be used to graceful
+// shutdown the tracer. If the configuration object defines a disabled
+// Tracer, a no-op implementation is returned.
+func NewTracer(config *Configuration) (ot.Tracer, io.Closer, error) {
+	if config.ServiceName == "" {
+		// abort initialization if a `ServiceName` is not defined
+		return nil, nil, errors.New("A Datadog Tracer requires a valid `ServiceName` set")
+	}
+
+	if config.Enabled == false {
+		// return a no-op implementation so Datadog provides the minimum overhead
+		return &ot.NoopTracer{}, &noopCloser{}, nil
+	}
+
+	// configure a Datadog Tracer
+	transport := datadog.NewTransport(config.AgentHostname, config.AgentPort)
+	tracer := &Tracer{
+		impl:        datadog.NewTracerTransport(transport),
+		serviceName: config.ServiceName,
+	}
+	tracer.impl.SetDebugLogging(config.Debug)
+	tracer.impl.SetSampleRate(config.SampleRate)
+
+	return tracer, tracer, nil
 }

--- a/opentracing/tracer.go
+++ b/opentracing/tracer.go
@@ -6,9 +6,11 @@ import (
 )
 
 // Tracer is a simple, thin interface for Span creation and SpanContext
-// propagation.
+// propagation. In the current state, this Tracer is a compatibility layer
+// that wraps the Datadog Tracer implementation.
 type Tracer struct {
-	impl *datadog.Tracer
+	impl        *datadog.Tracer // a Datadog Tracer implementation
+	serviceName string          // default Service Name defined in the configuration
 }
 
 // StartSpan creates, starts, and returns a new Span with the given `operationName`

--- a/opentracing/tracer.go
+++ b/opentracing/tracer.go
@@ -79,6 +79,13 @@ func (t *Tracer) startSpanWithOptions(operationName string, options ot.StartSpan
 		}
 	}
 
+	// set tags if available
+	if len(options.Tags) > 0 {
+		for k, v := range options.Tags {
+			otSpan.SetTag(k, v)
+		}
+	}
+
 	return otSpan
 }
 

--- a/opentracing/tracer_test.go
+++ b/opentracing/tracer_test.go
@@ -2,6 +2,7 @@ package opentracing
 
 import (
 	"testing"
+	"time"
 
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
@@ -88,4 +89,17 @@ func TestTracerSpanTags(t *testing.T) {
 	assert.True(ok)
 
 	assert.Equal("value", span.Span.Meta["key"])
+}
+
+func TestTracerSpanStartTime(t *testing.T) {
+	assert := assert.New(t)
+
+	config := NewConfiguration()
+	tracer, _, _ := NewTracer(config)
+
+	startTime := time.Now().Add(-10 * time.Second)
+	span, ok := tracer.StartSpan("web.request", opentracing.StartTime(startTime)).(*Span)
+	assert.True(ok)
+
+	assert.Equal(startTime.UnixNano(), span.Span.Start)
 }

--- a/opentracing/tracer_test.go
+++ b/opentracing/tracer_test.go
@@ -1,0 +1,44 @@
+package opentracing
+
+import (
+	"testing"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTracerStartSpan(t *testing.T) {
+	assert := assert.New(t)
+
+	config := NewConfiguration()
+	tracer, _, _ := NewTracer(config)
+
+	span, ok := tracer.StartSpan("web.request").(*Span)
+	assert.True(ok)
+
+	assert.NotEqual(uint64(0), span.Span.TraceID)
+	assert.NotEqual(uint64(0), span.Span.SpanID)
+	assert.Equal(uint64(0), span.Span.ParentID)
+	assert.Equal("web.request", span.Span.Name)
+	assert.Equal("opentracing.test", span.Span.Service)
+	assert.NotNil(span.Span.Tracer())
+}
+
+func TestTracerStartChildSpan(t *testing.T) {
+	assert := assert.New(t)
+
+	config := NewConfiguration()
+	tracer, _, _ := NewTracer(config)
+
+	root := tracer.StartSpan("web.request")
+	child := tracer.StartSpan("db.query", opentracing.ChildOf(root.Context()))
+	tRoot, ok := root.(*Span)
+	assert.True(ok)
+	tChild, ok := child.(*Span)
+	assert.True(ok)
+
+	assert.NotEqual(uint64(0), tChild.Span.TraceID)
+	assert.NotEqual(uint64(0), tChild.Span.SpanID)
+	assert.Equal(tRoot.Span.SpanID, tChild.Span.ParentID)
+	assert.Equal(tRoot.Span.TraceID, tChild.Span.ParentID)
+}

--- a/opentracing/tracer_test.go
+++ b/opentracing/tracer_test.go
@@ -76,3 +76,16 @@ func TestTracerBaggageImmutability(t *testing.T) {
 	assert.Equal("value", parentContext.baggage["key"])
 	assert.Equal("changed!", childContext.baggage["key"])
 }
+
+func TestTracerSpanTags(t *testing.T) {
+	assert := assert.New(t)
+
+	config := NewConfiguration()
+	tracer, _, _ := NewTracer(config)
+
+	tag := opentracing.Tag{Key: "key", Value: "value"}
+	span, ok := tracer.StartSpan("web.request", tag).(*Span)
+	assert.True(ok)
+
+	assert.Equal("value", span.Span.Meta["key"])
+}

--- a/tasks/common.rb
+++ b/tasks/common.rb
@@ -6,7 +6,7 @@ module Tasks
 
     # returns a list of Go packages
     def self.get_go_packages
-      `go list ./tracer ./contrib/...`.split("\n")
+      `go list ./opentracing ./tracer ./contrib/...`.split("\n")
     end
   end
 end

--- a/tasks/testing.rb
+++ b/tasks/testing.rb
@@ -6,17 +6,17 @@ namespace :test do
   task :lint do
     # enable-gc is required because with a full linting process we may finish workers memory
     # fast is used temporarily for a faster CI
-    sh 'gometalinter --deadline 60s --fast --enable-gc --errors --vendor ./tracer ./contrib/...'
+    sh 'gometalinter --deadline 60s --fast --enable-gc --errors --vendor ./opentracing ./tracer ./contrib/...'
   end
 
   desc 'Test all packages'
   task :all do
-    sh 'go test ./tracer ./contrib/...'
+    sh 'go test ./opentracing ./tracer ./contrib/...'
   end
 
   desc 'Test all packages with -race flag'
   task :race do
-    sh 'go test -race ./tracer ./contrib/...'
+    sh 'go test -race ./opentracing ./tracer ./contrib/...'
   end
 
   desc 'Run test coverage'

--- a/tasks/vendors.rb
+++ b/tasks/vendors.rb
@@ -5,6 +5,7 @@ task :init do
   sh 'gometalinter --install'
 
   sh "go get -t -v ./contrib/..."
+  sh "go get -v github.com/opentracing/opentracing-go"
 end
 
 namespace :vendors do

--- a/tracer/span.go
+++ b/tracer/span.go
@@ -207,6 +207,16 @@ func (s *Span) SetError(err error) {
 // current Span. Once a Span has been finished, methods that modify the Span
 // will become no-ops.
 func (s *Span) Finish() {
+	s.finish(now())
+}
+
+// FinishWithTime closes this Span at the given `finishTime`. The
+// behavior is the same as `Finish()`.
+func (s *Span) FinishWithTime(finishTime int64) {
+	s.finish(finishTime)
+}
+
+func (s *Span) finish(finishTime int64) {
 	if s == nil {
 		return
 	}
@@ -215,7 +225,7 @@ func (s *Span) Finish() {
 	finished := s.finished
 	if !finished {
 		if s.Duration == 0 {
-			s.Duration = now() - s.Start
+			s.Duration = finishTime - s.Start
 		}
 		s.finished = true
 	}


### PR DESCRIPTION
### Overview

Compatibility layer for [OpenTracing](http://opentracing.io/) specification. The PR implements:
* a OT-compatible `Tracer`
* a `Configuration` struct to configure a Datadog Tracer
* the `Span` and `SpanContext` implementation
* the compatibility layer for OpenTracing `Tags`

This PR is an initial work to support entirely OpenTracing. In the current state, the OT-compatible `Tracer` wraps our previous implementation, so internals are the same. To set the Datadog Tracer as a `GlobalTracer`, you should add the following code to initialize the `Tracer`:
```go
import (
    // datadog namespace is suggested
    datadog "github.com/DataDog/dd-trace-go/opentracing"
    opentracing "github.com/opentracing/opentracing-go"
)

func Example_initialization() {
    // create a Tracer configuration
    config := datadog.NewConfiguration()
    config.ServiceName = "api-intake"
    config.AgentHostname = "ddagent.consul.local"

    // initialize a Tracer and ensure a graceful shutdown
    // using the `closer.Close()`
    tracer, closer, err := datadog.NewTracer(config)
    if err != nil {
        // handle the configuration error
    }
    defer closer.Close()

    // set the Datadog tracer as a GlobalTracer
    opentracing.SetGlobalTracer(tracer)
}
```

Default values for `Configuration` are provided, and if you don't set a `ServiceName`, the binary name is used.