### PR TITLE
[opentracing] add Tags compatibility layer for Service, Resource and SpanType

### DIFF
--- a/opentracing/span.go
+++ b/opentracing/span.go
@@ -50,9 +50,24 @@ func (s *Span) BaggageItem(key string) string {
 // SetTag adds a tag to the span, overwriting pre-existing values for
 // the given `key`.
 func (s *Span) SetTag(key string, value interface{}) ot.Span {
-	// NOTE: locking is not required because the `SetMeta` is
-	// already thread-safe
-	s.Span.SetMeta(key, value.(string))
+	switch key {
+	case ServiceName:
+		s.Span.Lock()
+		defer s.Span.Unlock()
+		s.Span.Service = value.(string)
+	case ResourceName:
+		s.Span.Lock()
+		defer s.Span.Unlock()
+		s.Span.Resource = value.(string)
+	case SpanType:
+		s.Span.Lock()
+		defer s.Span.Unlock()
+		s.Span.Type = value.(string)
+	default:
+		// NOTE: locking is not required because the `SetMeta` is
+		// already thread-safe
+		s.Span.SetMeta(key, value.(string))
+	}
 	return s
 }
 

--- a/opentracing/span_test.go
+++ b/opentracing/span_test.go
@@ -23,15 +23,6 @@ func TestSpanContext(t *testing.T) {
 	assert.NotNil(span.Context())
 }
 
-func TestSpanSetTag(t *testing.T) {
-	assert := assert.New(t)
-
-	span := NewSpan("web.request")
-	span.Span.Meta = make(map[string]string)
-	span.SetTag("component", "tracer")
-	assert.Equal("tracer", span.Meta["component"])
-}
-
 func TestSpanOperationName(t *testing.T) {
 	assert := assert.New(t)
 
@@ -58,4 +49,25 @@ func TestSpanFinishWithTime(t *testing.T) {
 
 	duration := finishTime.UnixNano() - span.Span.Start
 	assert.Equal(duration, span.Span.Duration)
+}
+
+func TestSpanSetTag(t *testing.T) {
+	assert := assert.New(t)
+
+	span := NewSpan("web.request")
+	span.SetTag("component", "tracer")
+	assert.Equal("tracer", span.Meta["component"])
+}
+
+func TestSpanSetDatadogTags(t *testing.T) {
+	assert := assert.New(t)
+
+	span := NewSpan("web.request")
+	span.SetTag("span.type", "http")
+	span.SetTag("service.name", "db-cluster")
+	span.SetTag("resource.name", "SELECT * FROM users;")
+
+	assert.Equal("http", span.Span.Type)
+	assert.Equal("db-cluster", span.Span.Service)
+	assert.Equal("SELECT * FROM users;", span.Span.Resource)
 }

--- a/opentracing/tags.go
+++ b/opentracing/tags.go
@@ -1,0 +1,16 @@
+package opentracing
+
+const (
+	// SpanType defines the Span type (web, db, cache)
+	SpanType = "span.type"
+	// ServiceName defines the Service name for this Span
+	ServiceName = "service.name"
+	// ResourceName defines the Resource name for the Span
+	ResourceName = "resource.name"
+	// ErrorMsg defines the error message
+	ErrorMsg = "error.msg"
+	// ErrorType defines the error class
+	ErrorType = "error.type"
+	// ErrorStack defines the stack for the given error or panic
+	ErrorStack = "error.stack"
+)


### PR DESCRIPTION
### Overview

Our system requires some extra tags to provide better stats. This change leverage the `Span.SetTag()` method so that it can be used to set internal Span values that are not part of the OpenTracing specification. For instance if you have an OpenTracing `Span` you can:
```go
span := opentracing.StartSpan("web.request")

span.SetTag("span.type", "http")                      // sets the Span.Type
span.SetTag("service.name", "db-cluster")             // sets the Span.Service
span.SetTag("resource.name", "SELECT * FROM users;")  // sets the Span.Resource
```