### PR TITLE
[opentracing] provide more documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,44 @@
 [![CircleCI](https://circleci.com/gh/DataDog/dd-trace-go/tree/master.svg?style=svg)](https://circleci.com/gh/DataDog/dd-trace-go/tree/master)
-[![Godoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/DataDog/dd-trace-go/tracer)
+[![Godoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/DataDog/dd-trace-go/opentracing)
 
-A Go tracing package for Datadog APM.
+Datadog APM client that implements an [OpenTracing](http://opentracing.io) Tracer.
+
+## Initialization
+
+To start using the Datadog Tracer with the OpenTracing API, you should first initialize the tracer with a proper `Configuration` object:
+
+```go
+import (
+	// datadog namespace is suggested
+	datadog "github.com/DataDog/dd-trace-go/opentracing"
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+func main() {
+	// create a Tracer configuration
+	config := datadog.NewConfiguration()
+	config.ServiceName = "api-intake"
+	config.AgentHostname = "ddagent.consul.local"
+
+	// initialize a Tracer and ensure a graceful shutdown
+	// using the `closer.Close()`
+	tracer, closer, err := datadog.NewTracer(config)
+	if err != nil {
+		// handle the configuration error
+	}
+	defer closer.Close()
+
+	// set the Datadog tracer as a GlobalTracer
+	opentracing.SetGlobalTracer(tracer)
+	startWebServer()
+}
+```
+
+Function `NewTracer(config)` returns an `io.Closer` instance that can be used to gracefully shutdown the `tracer`. It's recommend ed to always call the `closer.Close()`, otherwise internal buffers are not flushed and you may lose some traces.
+
+## Usage
+
+See [Opentracing documentation](https://github.com/opentracing/opentracing-go) for some usage patters. Legacy documentation is available in [GoDoc format](https://godoc.org/github.com/DataDog/dd-trace-go/tracer).
 
 ## Contributing Quick Start
 

--- a/opentracing/doc.go
+++ b/opentracing/doc.go
@@ -1,0 +1,4 @@
+// Package opentracing implements an OpenTracing (http://opentracing.io)
+// compatible tracer. A Datadog tracer must be initialized through
+// a Configuration object as you can see in the following examples.
+package opentracing

--- a/opentracing/example_context_test.go
+++ b/opentracing/example_context_test.go
@@ -1,0 +1,30 @@
+package opentracing_test
+
+import (
+	"context"
+
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+// You can leverage the Golang `Context` for intra-process propagation of
+// Spans. In this example we create a root Span, so that it can be reused
+// in a nested function to create a child Span.
+func Example_startContext() {
+	// create a new root Span and return a new Context that includes
+	// the Span itself
+	ctx := context.Background()
+	rootSpan, ctx := opentracing.StartSpanFromContext(ctx, "web.request")
+	defer rootSpan.Finish()
+
+	requestHandler(ctx)
+}
+
+func requestHandler(ctx context.Context) {
+	// retrieve the previously set root Span
+	span := opentracing.SpanFromContext(ctx)
+	span.SetTag("resource.name", "/")
+
+	// or simply create a new child Span from the previous Context
+	childSpan, _ := opentracing.StartSpanFromContext(ctx, "sql.query")
+	defer childSpan.Finish()
+}

--- a/opentracing/example_test.go
+++ b/opentracing/example_test.go
@@ -1,0 +1,30 @@
+package opentracing_test
+
+import (
+	// datadog namespace is suggested
+	datadog "github.com/DataDog/dd-trace-go/opentracing"
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+func Example_initialization() {
+	// create a Tracer configuration
+	config := datadog.NewConfiguration()
+	config.ServiceName = "api-intake"
+	config.AgentHostname = "ddagent.consul.local"
+
+	// initialize a Tracer and ensure a graceful shutdown
+	// using the `closer.Close()`
+	tracer, closer, err := datadog.NewTracer(config)
+	if err != nil {
+		// handle the configuration error
+	}
+	defer closer.Close()
+
+	// set the Datadog tracer as a GlobalTracer
+	opentracing.SetGlobalTracer(tracer)
+	startWebServer()
+}
+
+func startWebServer() {
+	// start a web server
+}

--- a/opentracing/example_tracing_test.go
+++ b/opentracing/example_tracing_test.go
@@ -1,0 +1,24 @@
+package opentracing_test
+
+import (
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+// You can use the GlobalTracer to create a root Span. If you need to create a hierarchy,
+// simply use the `ChildOf` reference
+func Example_startSpan() {
+	// use the GlobalTracer previously set
+	rootSpan := opentracing.StartSpan("web.request")
+	defer rootSpan.Finish()
+
+	// set the reference to create a hierarchy of spans
+	reference := opentracing.ChildOf(rootSpan.Context())
+	childSpan := opentracing.StartSpan("sql.query", reference)
+	defer childSpan.Finish()
+
+	dbQuery()
+}
+
+func dbQuery() {
+	// start a database query
+}


### PR DESCRIPTION
### Overview

Provide a better `README` and more Godoc with examples (they're the same as the current state of [OpenTracing Go](https://github.com/opentracing/opentracing-go) documentation).