### PR TITLE
[opentracing] ensure that creating a new OpenTracing tracer replaces the DefaultTracer for integrations

### DIFF
--- a/opentracing/tracer.go
+++ b/opentracing/tracer.go
@@ -138,5 +138,11 @@ func NewTracer(config *Configuration) (ot.Tracer, io.Closer, error) {
 	tracer.impl.SetDebugLogging(config.Debug)
 	tracer.impl.SetSampleRate(config.SampleRate)
 
+	// set the new Datadog Tracer as a `DefaultTracer` so it can be
+	// used in integrations. NOTE: this is a temporary implementation
+	// that can be removed once all integrations have been migrated
+	// to the OpenTracing API.
+	datadog.DefaultTracer = tracer.impl
+
 	return tracer, tracer, nil
 }

--- a/opentracing/tracer_test.go
+++ b/opentracing/tracer_test.go
@@ -4,9 +4,21 @@ import (
 	"testing"
 	"time"
 
+	datadog "github.com/DataDog/dd-trace-go/tracer"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestDefaultTracer(t *testing.T) {
+	assert := assert.New(t)
+
+	config := NewConfiguration()
+	tracer, _, _ := NewTracer(config)
+	tTracer, ok := tracer.(*Tracer)
+	assert.True(ok)
+
+	assert.Equal(tTracer.impl, datadog.DefaultTracer)
+}
 
 func TestTracerStartSpan(t *testing.T) {
 	assert := assert.New(t)


### PR DESCRIPTION
### Overview

When creating an OpenTracing `Tracer`, the `datadog.DefaultTracer` is replaced with the underlying implementation. This is legit since it happens only if you want to use the OpenTracing API and integrations like `gin-gonic` will work properly using the OpenTracing tracer.

This implementation is temporary and will be removed once all integrations have been ported to the OpenTracing API.