### PR TITLE
[opentracing] Inject and Extract method for Distributed Tracing

### DIFF
--- a/opentracing/propagators.go
+++ b/opentracing/propagators.go
@@ -1,0 +1,86 @@
+package opentracing
+
+import (
+	"strconv"
+	"strings"
+
+	ot "github.com/opentracing/opentracing-go"
+)
+
+type textMapPropagator struct{}
+
+const (
+	prefixBaggage     = "ot-baggage-"
+	prefixTracerState = "x-datadog-"
+
+	fieldNameTraceID  = prefixTracerState + "trace-id"
+	fieldNameParentID = prefixTracerState + "parent-id"
+)
+
+// Inject defines the textMapPropagator to propagate SpanContext data
+// out of the current process. The implementation propagates the
+// TraceID and the current active SpanID, as well as the Span baggage.
+func (p *textMapPropagator) Inject(context ot.SpanContext, carrier interface{}) error {
+	ctx, ok := context.(SpanContext)
+	if !ok {
+		return ot.ErrInvalidSpanContext
+	}
+	writer, ok := carrier.(ot.TextMapWriter)
+	if !ok {
+		return ot.ErrInvalidCarrier
+	}
+
+	// propagate the TraceID and the current active SpanID
+	writer.Set(fieldNameTraceID, strconv.FormatUint(ctx.traceID, 16))
+	writer.Set(fieldNameParentID, strconv.FormatUint(ctx.spanID, 16))
+
+	// propagate OpenTracing baggage
+	for k, v := range ctx.baggage {
+		writer.Set(prefixBaggage+k, v)
+	}
+	return nil
+}
+
+// Extract does
+func (p *textMapPropagator) Extract(carrier interface{}) (ot.SpanContext, error) {
+	reader, ok := carrier.(ot.TextMapReader)
+	if !ok {
+		return nil, ot.ErrInvalidCarrier
+	}
+	var err error
+	var traceID, parentID uint64
+	decodedBaggage := make(map[string]string)
+
+	// extract SpanContext fields
+	err = reader.ForeachKey(func(k, v string) error {
+		switch strings.ToLower(k) {
+		case fieldNameTraceID:
+			traceID, err = strconv.ParseUint(v, 16, 64)
+			if err != nil {
+				return ot.ErrSpanContextCorrupted
+			}
+		case fieldNameParentID:
+			parentID, err = strconv.ParseUint(v, 16, 64)
+			if err != nil {
+				return ot.ErrSpanContextCorrupted
+			}
+		default:
+			lowercaseK := strings.ToLower(k)
+			if strings.HasPrefix(lowercaseK, prefixBaggage) {
+				decodedBaggage[strings.TrimPrefix(lowercaseK, prefixBaggage)] = v
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return SpanContext{
+		traceID: traceID,
+		spanID:  parentID,
+		baggage: decodedBaggage,
+	}, nil
+}

--- a/opentracing/tracer_test.go
+++ b/opentracing/tracer_test.go
@@ -1,6 +1,7 @@
 package opentracing
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -114,4 +115,45 @@ func TestTracerSpanStartTime(t *testing.T) {
 	assert.True(ok)
 
 	assert.Equal(startTime.UnixNano(), span.Span.Start)
+}
+
+func TestTracerPropagation(t *testing.T) {
+	assert := assert.New(t)
+
+	config := NewConfiguration()
+	tracer, _, _ := NewTracer(config)
+
+	root := tracer.StartSpan("web.request")
+	ctx := root.Context()
+	headers := http.Header{}
+
+	// inject the SpanContext
+	carrier := opentracing.HTTPHeadersCarrier(headers)
+	err := tracer.Inject(ctx, opentracing.HTTPHeaders, carrier)
+	assert.Nil(err)
+
+	// retrieve the SpanContext
+	propagated, err := tracer.Extract(opentracing.HTTPHeaders, carrier)
+	assert.Nil(err)
+
+	tCtx, ok := ctx.(SpanContext)
+	assert.True(ok)
+	tPropagated, ok := propagated.(SpanContext)
+	assert.True(ok)
+
+	// compare if there is a Context match
+	assert.Equal(tCtx.traceID, tPropagated.traceID)
+	assert.Equal(tCtx.spanID, tPropagated.spanID)
+
+	// ensure a child can be created
+	child := tracer.StartSpan("db.query", opentracing.ChildOf(propagated))
+	tRoot, ok := root.(*Span)
+	assert.True(ok)
+	tChild, ok := child.(*Span)
+	assert.True(ok)
+
+	assert.NotEqual(uint64(0), tChild.Span.TraceID)
+	assert.NotEqual(uint64(0), tChild.Span.SpanID)
+	assert.Equal(tRoot.Span.SpanID, tChild.Span.ParentID)
+	assert.Equal(tRoot.Span.TraceID, tChild.Span.ParentID)
 }


### PR DESCRIPTION
### Overview

Implements a `TextMapPropagator` for TextMap and HTTPHeaders `SpanContext` propagation. This is used to propagate/read `SpanID` and `TraceID` to/from another process. Usage is described in [OpenTracing documentation](https://github.com/opentracing/opentracing-go#serializing-to-the-wire).