### PR TITLE
[opentracing] change suggested namespace to ddtrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,20 @@ To start using the Datadog Tracer with the OpenTracing API, you should first ini
 
 ```go
 import (
-	// datadog namespace is suggested
-	datadog "github.com/DataDog/dd-trace-go/opentracing"
+	// ddtrace namespace is suggested
+	ddtrace "github.com/DataDog/dd-trace-go/opentracing"
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
 func main() {
 	// create a Tracer configuration
-	config := datadog.NewConfiguration()
+	config := ddtrace.NewConfiguration()
 	config.ServiceName = "api-intake"
 	config.AgentHostname = "ddagent.consul.local"
 
 	// initialize a Tracer and ensure a graceful shutdown
 	// using the `closer.Close()`
-	tracer, closer, err := datadog.NewTracer(config)
+	tracer, closer, err := ddtrace.NewTracer(config)
 	if err != nil {
 		// handle the configuration error
 	}

--- a/opentracing/example_test.go
+++ b/opentracing/example_test.go
@@ -1,20 +1,20 @@
 package opentracing_test
 
 import (
-	// datadog namespace is suggested
-	datadog "github.com/DataDog/dd-trace-go/opentracing"
+	// ddtrace namespace is suggested
+	ddtrace "github.com/DataDog/dd-trace-go/opentracing"
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
 func Example_initialization() {
 	// create a Tracer configuration
-	config := datadog.NewConfiguration()
+	config := ddtrace.NewConfiguration()
 	config.ServiceName = "api-intake"
 	config.AgentHostname = "ddagent.consul.local"
 
 	// initialize a Tracer and ensure a graceful shutdown
 	// using the `closer.Close()`
-	tracer, closer, err := datadog.NewTracer(config)
+	tracer, closer, err := ddtrace.NewTracer(config)
 	if err != nil {
 		// handle the configuration error
 	}

--- a/opentracing/span.go
+++ b/opentracing/span.go
@@ -3,7 +3,7 @@ package opentracing
 import (
 	"time"
 
-	datadog "github.com/DataDog/dd-trace-go/tracer"
+	ddtrace "github.com/DataDog/dd-trace-go/tracer"
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 )
@@ -11,7 +11,7 @@ import (
 // Span represents an active, un-finished span in the OpenTracing system.
 // Spans are created by the Tracer interface.
 type Span struct {
-	*datadog.Span
+	*ddtrace.Span
 	context SpanContext
 	tracer  *Tracer
 }
@@ -121,7 +121,7 @@ func (s *Span) Log(data ot.LogData) {
 
 // NewSpan is the OpenTracing Span constructor
 func NewSpan(operationName string) *Span {
-	span := &datadog.Span{
+	span := &ddtrace.Span{
 		Name: operationName,
 	}
 

--- a/opentracing/tracer.go
+++ b/opentracing/tracer.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"time"
 
-	datadog "github.com/DataDog/dd-trace-go/tracer"
+	ddtrace "github.com/DataDog/dd-trace-go/tracer"
 	ot "github.com/opentracing/opentracing-go"
 )
 
@@ -13,7 +13,7 @@ import (
 // propagation. In the current state, this Tracer is a compatibility layer
 // that wraps the Datadog Tracer implementation.
 type Tracer struct {
-	impl           *datadog.Tracer    // a Datadog Tracer implementation
+	impl           *ddtrace.Tracer    // a Datadog Tracer implementation
 	serviceName    string             // default Service Name defined in the configuration
 	textPropagator *textMapPropagator // injector for Context propagation
 }
@@ -38,7 +38,7 @@ func (t *Tracer) startSpanWithOptions(operationName string, options ot.StartSpan
 	var context SpanContext
 	var hasParent bool
 	var parent *Span
-	var span *datadog.Span
+	var span *ddtrace.Span
 
 	for _, ref := range options.References {
 		ctx, ok := ref.ReferencedContext.(SpanContext)
@@ -155,9 +155,9 @@ func NewTracer(config *Configuration) (ot.Tracer, io.Closer, error) {
 	}
 
 	// configure a Datadog Tracer
-	transport := datadog.NewTransport(config.AgentHostname, config.AgentPort)
+	transport := ddtrace.NewTransport(config.AgentHostname, config.AgentPort)
 	tracer := &Tracer{
-		impl:        datadog.NewTracerTransport(transport),
+		impl:        ddtrace.NewTracerTransport(transport),
 		serviceName: config.ServiceName,
 	}
 	tracer.impl.SetDebugLogging(config.Debug)
@@ -167,7 +167,7 @@ func NewTracer(config *Configuration) (ot.Tracer, io.Closer, error) {
 	// used in integrations. NOTE: this is a temporary implementation
 	// that can be removed once all integrations have been migrated
 	// to the OpenTracing API.
-	datadog.DefaultTracer = tracer.impl
+	ddtrace.DefaultTracer = tracer.impl
 
 	return tracer, tracer, nil
 }

--- a/opentracing/tracer_test.go
+++ b/opentracing/tracer_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	datadog "github.com/DataDog/dd-trace-go/tracer"
+	ddtrace "github.com/DataDog/dd-trace-go/tracer"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 )
@@ -18,7 +18,7 @@ func TestDefaultTracer(t *testing.T) {
 	tTracer, ok := tracer.(*Tracer)
 	assert.True(ok)
 
-	assert.Equal(tTracer.impl, datadog.DefaultTracer)
+	assert.Equal(tTracer.impl, ddtrace.DefaultTracer)
 }
 
 func TestTracerStartSpan(t *testing.T) {


### PR DESCRIPTION
### Overview

In our documentation, suggest to use `ddtrace` instead of `datadog` as package namespace.