### PR TITLE
SetTag convert value to string instead of expected a string

### DIFF
--- a/opentracing/span.go
+++ b/opentracing/span.go
@@ -1,6 +1,7 @@
 package opentracing
 
 import (
+	"fmt"
 	"time"
 
 	ddtrace "github.com/DataDog/dd-trace-go/tracer"
@@ -54,19 +55,19 @@ func (s *Span) SetTag(key string, value interface{}) ot.Span {
 	case ServiceName:
 		s.Span.Lock()
 		defer s.Span.Unlock()
-		s.Span.Service = value.(string)
+		s.Span.Service = fmt.Sprint(value)
 	case ResourceName:
 		s.Span.Lock()
 		defer s.Span.Unlock()
-		s.Span.Resource = value.(string)
+		s.Span.Resource = fmt.Sprint(value)
 	case SpanType:
 		s.Span.Lock()
 		defer s.Span.Unlock()
-		s.Span.Type = value.(string)
+		s.Span.Type = fmt.Sprint(value)
 	default:
 		// NOTE: locking is not required because the `SetMeta` is
 		// already thread-safe
-		s.Span.SetMeta(key, value.(string))
+		s.Span.SetMeta(key, fmt.Sprint(value))
 	}
 	return s
 }

--- a/opentracing/span_test.go
+++ b/opentracing/span_test.go
@@ -57,6 +57,9 @@ func TestSpanSetTag(t *testing.T) {
 	span := NewSpan("web.request")
 	span.SetTag("component", "tracer")
 	assert.Equal("tracer", span.Meta["component"])
+
+	span.SetTag("tagInt", 1234)
+	assert.Equal("1234", span.Meta["tagInt"])
 }
 
 func TestSpanSetDatadogTags(t *testing.T) {


### PR DESCRIPTION
The SetTag function accept an interface{} for the value parameter but it panic when the value is not a string. 