### PR TITLE
[tracer] increase span buffer from 10k to 100k

### DIFF
--- a/tracer/buffer.go
+++ b/tracer/buffer.go
@@ -14,7 +14,7 @@ const (
 	// This is to avoid memory leaks, if above that value, spans are randomly
 	// dropped and ignore, resulting in corrupted tracing data, but ensuring
 	// original program continues to work as expected.
-	spanBufferDefaultMaxSize = 10000
+	spanBufferDefaultMaxSize = 1e5
 )
 
 type spanBuffer struct {


### PR DESCRIPTION
10k is quite low, we already get some real-world use cases with more than that.

Also, the upcoming Ruby PR has a setting of 100k, so it would make sense to have them use the same value: https://github.com/DataDog/dd-trace-rb/pull/247/files#diff-7bbc8937db718dfbfe46ab70654b47ccR19