### PR TITLE
tracer: dual sampling, make sure priorities -1 and 2 are handled

### DIFF
--- a/tracer/ext/priority.go
+++ b/tracer/ext/priority.go
@@ -1,0 +1,19 @@
+package ext
+
+// Priority is a hint given to the backend so that it knows which traces to reject or kept.
+// In a distributed context, it should be set before any context propagation (fork, RPC calls) to be effective.
+
+const (
+	// PriorityUserReject informs the backend that a trace should be rejected and not stored.
+	// This should be used by user code overriding default priority.
+	PriorityUserReject = -1
+	// PriorityAutoReject informs the backend that a trace should be rejected and not stored.
+	// This is used by the builtin sampler.
+	PriorityAutoReject = 0
+	// PriorityAutoReject informs the backend that a trace should be kept and not stored.
+	// This is used by the builtin sampler.
+	PriorityAutoKeep = 1
+	// PriorityUserReject informs the backend that a trace should be kept and not stored.
+	// This should be used by user code overriding default priority.
+	PriorityUserKeep = 2
+)

--- a/tracer/span.go
+++ b/tracer/span.go
@@ -315,11 +315,7 @@ func (s *Span) Tracer() *Tracer {
 	return s.tracer
 }
 
-// SetSamplingPriority sets the sampling priority. Possible values are:
-// -1: The user asked not to keep the trace;
-// 0: The sampler automatically decided not to keep the trace;
-// 1: The sampler automatically decided to keep the trace;
-// 2: The user asked to keep the trace.
+// SetSamplingPriority sets the sampling priority.
 func (s *Span) SetSamplingPriority(priority int) {
 	s.SetMetric(samplingPriorityKey, float64(priority))
 }

--- a/tracer/span.go
+++ b/tracer/span.go
@@ -315,9 +315,11 @@ func (s *Span) Tracer() *Tracer {
 	return s.tracer
 }
 
-// SetSamplingPriority sets the sampling priority.
-// Default is 0, any higher value is interpreted as a hint on
-// how interesting this span is, and should be kept by the backend.
+// SetSamplingPriority sets the sampling priority. Possible values are:
+// -1: The user asked not to keep the trace;
+// 0: The sampler automatically decided not to keep the trace;
+// 1: The sampler automatically decided to keep the trace;
+// 2: The user asked to keep the trace.
 func (s *Span) SetSamplingPriority(priority int) {
 	s.SetMetric(samplingPriorityKey, float64(priority))
 }

--- a/tracer/span.go
+++ b/tracer/span.go
@@ -319,9 +319,7 @@ func (s *Span) Tracer() *Tracer {
 // Default is 0, any higher value is interpreted as a hint on
 // how interesting this span is, and should be kept by the backend.
 func (s *Span) SetSamplingPriority(priority int) {
-	if priority >= 0 {
-		s.SetMetric(samplingPriorityKey, float64(priority))
-	}
+	s.SetMetric(samplingPriorityKey, float64(priority))
 }
 
 // HasSamplingPriority returns true if sampling priority is set.

--- a/tracer/span_test.go
+++ b/tracer/span_test.go
@@ -265,37 +265,15 @@ func TestSpanSamplingPriority(t *testing.T) {
 	assert.Equal(span.HasSamplingPriority(), childSpan.HasSamplingPriority())
 	assert.Equal(span.GetSamplingPriority(), childSpan.GetSamplingPriority())
 
-	span.SetSamplingPriority(0)
-	assert.Equal(0.0, span.Metrics["_sampling_priority_v1"], "key has been deleted")
-	assert.Equal(0, span.GetSamplingPriority(), "by default, sampling priority is 0")
-	childSpan = tracer.NewChildSpan("my.child", span)
-	assert.Equal(span.Metrics["_sampling_priority_v1"], childSpan.Metrics["_sampling_priority_v1"])
-	assert.Equal(span.HasSamplingPriority(), childSpan.HasSamplingPriority())
-	assert.Equal(span.GetSamplingPriority(), childSpan.GetSamplingPriority())
-
-	span.SetSamplingPriority(-1)
-	assert.Equal(0.0, span.Metrics["_sampling_priority_v1"], "key has been deleted")
-	assert.Equal(0, span.GetSamplingPriority(), "by default, sampling priority can't be negative")
-	childSpan = tracer.NewChildSpan("my.child", span)
-	assert.Equal(span.Metrics["_sampling_priority_v1"], childSpan.Metrics["_sampling_priority_v1"])
-	assert.Equal(span.HasSamplingPriority(), childSpan.HasSamplingPriority())
-	assert.Equal(span.GetSamplingPriority(), childSpan.GetSamplingPriority())
-
-	span.SetSamplingPriority(1)
-	assert.Equal(1.0, span.Metrics["_sampling_priority_v1"], "sampling priority is now 1")
-	assert.Equal(1, span.GetSamplingPriority(), "sampling priority is now 1")
-	childSpan = tracer.NewChildSpan("my.child", span)
-	assert.Equal(span.Metrics["_sampling_priority_v1"], childSpan.Metrics["_sampling_priority_v1"])
-	assert.Equal(span.HasSamplingPriority(), childSpan.HasSamplingPriority())
-	assert.Equal(span.GetSamplingPriority(), childSpan.GetSamplingPriority())
-
-	span.SetSamplingPriority(42)
-	assert.Equal(42.0, span.Metrics["_sampling_priority_v1"], "sampling priority works for values above 1")
-	assert.Equal(42, span.GetSamplingPriority(), "sampling priority works for values above 1")
-	childSpan = tracer.NewChildSpan("my.child", span)
-	assert.Equal(span.Metrics["_sampling_priority_v1"], childSpan.Metrics["_sampling_priority_v1"])
-	assert.Equal(span.HasSamplingPriority(), childSpan.HasSamplingPriority())
-	assert.Equal(span.GetSamplingPriority(), childSpan.GetSamplingPriority())
+	for _, priority := range []int{-1, 0, 1, 2, 999} {
+		span.SetSamplingPriority(priority)
+		assert.True(span.HasSamplingPriority())
+		assert.Equal(priority, span.GetSamplingPriority())
+		childSpan = tracer.NewChildSpan("my.child", span)
+		assert.Equal(span.Metrics["_sampling_priority_v1"], childSpan.Metrics["_sampling_priority_v1"])
+		assert.Equal(span.HasSamplingPriority(), childSpan.HasSamplingPriority())
+		assert.Equal(span.GetSamplingPriority(), childSpan.GetSamplingPriority())
+	}
 }
 
 type boomError struct{}

--- a/tracer/span_test.go
+++ b/tracer/span_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/dd-trace-go/tracer/ext"
 )
 
 func TestSpanStart(t *testing.T) {
@@ -265,7 +267,13 @@ func TestSpanSamplingPriority(t *testing.T) {
 	assert.Equal(span.HasSamplingPriority(), childSpan.HasSamplingPriority())
 	assert.Equal(span.GetSamplingPriority(), childSpan.GetSamplingPriority())
 
-	for _, priority := range []int{-1, 0, 1, 2, 999} {
+	for _, priority := range []int{
+		ext.PriorityUserReject,
+		ext.PriorityAutoReject,
+		ext.PriorityAutoKeep,
+		ext.PriorityUserKeep,
+		999, // not used yet, but we should allow it
+	} {
 		span.SetSamplingPriority(priority)
 		assert.True(span.HasSamplingPriority())
 		assert.Equal(priority, span.GetSamplingPriority())


### PR DESCRIPTION
Allow usage of `-1` as a priority sampling value, `2` was already handled, but negative values were blocked.