### PR TITLE
opentracing: tracer.Extract() returns ErrSpanContextNotFound when no context was found

### DIFF
--- a/opentracing/propagators.go
+++ b/opentracing/propagators.go
@@ -74,6 +74,10 @@ func (p *textMapPropagator) Extract(carrier interface{}) (ot.SpanContext, error)
 		return nil
 	})
 
+	if traceID == 0 && parentID == 0 && len(decodedBaggage) == 0 {
+		return nil, ot.ErrSpanContextNotFound
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/opentracing/propagators_test.go
+++ b/opentracing/propagators_test.go
@@ -1,0 +1,20 @@
+package opentracing
+
+import (
+	"testing"
+
+	ot "github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractNoContext(t *testing.T) {
+	assert := assert.New(t)
+
+	tmp := textMapPropagator{}
+	carrier := ot.TextMapCarrier{}
+
+	span, err := tmp.Extract(carrier)
+
+	assert.Nil(span)
+	assert.EqualError(err, ot.ErrSpanContextNotFound.Error())
+}


### PR DESCRIPTION
The opentracing spec [states that](https://github.com/opentracing/opentracing-go/blob/eaaf4e1eeb7a5373b38e70901270c83577dc6fb9/tracer.go#L102-L103): 
> If there was simply no SpanContext to extract in `carrier`, Extract() returns `(nil, opentracing.ErrSpanContextNotFound)`

But it was returning
```golang
SpanContext{
    traceID: 0,
    spanID:  0,
    baggage: map[],
}, nil
```

It now returns an error when we couldn't extract the span.
