### PR TITLE
opentracing: sample propagated spans after setting trace id

### DIFF
--- a/opentracing/tracer.go
+++ b/opentracing/tracer.go
@@ -65,6 +65,7 @@ func (t *Tracer) startSpanWithOptions(operationName string, options ot.StartSpan
 			// values manually
 			span.TraceID = context.traceID
 			span.ParentID = context.spanID
+			t.impl.Sample(span)
 		}
 	} else {
 		// create a child Span that inherits from a parent


### PR DESCRIPTION
This fix is to use the propagated trace id when setting the `sampled` field in a propagated span. 
the `Sampled` function is called in `NewRootSpan` and determines whether or not a span is sampled based on its `TraceID`. However, when a trace is propagated from another process, its `TraceID` and `ParentID` become that of the parent SpanContext after the new root span is created. The TraceID that determines sampling should be the SpanContext's trace id propagated from the previous process in order to consistently have full sampled spans.  
Adding another call to `Sample` after setting the `TraceID` and `ParentID` ensures this. 