### PR TITLE
opentracing: set Span error when adding error tags

### DIFF
--- a/opentracing/span.go
+++ b/opentracing/span.go
@@ -64,6 +64,15 @@ func (s *Span) SetTag(key string, value interface{}) ot.Span {
 		s.Span.Lock()
 		defer s.Span.Unlock()
 		s.Span.Type = fmt.Sprint(value)
+	case Error:
+		switch v := value.(type) {
+		case nil:
+			// no error
+		case error:
+			s.Span.SetError(v)
+		default:
+			s.Span.SetError(fmt.Errorf("%v", v))
+		}
 	default:
 		// NOTE: locking is not required because the `SetMeta` is
 		// already thread-safe

--- a/opentracing/tags.go
+++ b/opentracing/tags.go
@@ -7,10 +7,6 @@ const (
 	ServiceName = "service.name"
 	// ResourceName defines the Resource name for the Span
 	ResourceName = "resource.name"
-	// ErrorMsg defines the error message
-	ErrorMsg = "error.msg"
-	// ErrorType defines the error class
-	ErrorType = "error.type"
-	// ErrorStack defines the stack for the given error or panic
-	ErrorStack = "error.stack"
+	// Error defines an error.
+	Error = "error.error"
 )


### PR DESCRIPTION
This change allows setting a tag of name Error ("error") having a value
of error (but covers for other types to) which will in turn set the
error properties of the Span internally.

Fixes #144