### PR TITLE
contrib: use functional options

### DIFF
--- a/contrib/database/sql/example_test.go
+++ b/contrib/database/sql/example_test.go
@@ -30,7 +30,7 @@ func Example() {
 
 func Example_context() {
 	// Register the driver that we will be using (in this case mysql) under a custom service name.
-	sqltrace.RegisterWithServiceName("my-db", "mysql", &mysql.MySQLDriver{})
+	sqltrace.Register("mysql", &mysql.MySQLDriver{}, sqltrace.WithServiceName("my-db"))
 
 	// Open a connection to the DB using the driver we've just registered with tracing.
 	db, err := sqltrace.Open("mysql", "user:password@/dbname")

--- a/contrib/database/sql/option.go
+++ b/contrib/database/sql/option.go
@@ -1,0 +1,28 @@
+package sql
+
+import "github.com/DataDog/dd-trace-go/tracer"
+
+type registerConfig struct {
+	serviceName string
+	tracer      *tracer.Tracer // TODO(gbbr): Remove this when we switch.
+}
+
+// RegisterOption represents an option that can be passed to Register.
+type RegisterOption func(*registerConfig)
+
+func defaults(cfg *registerConfig) {
+	cfg.tracer = tracer.DefaultTracer
+}
+
+// WithServiceName sets the given service name for the registered driver.
+func WithServiceName(name string) RegisterOption {
+	return func(cfg *registerConfig) {
+		cfg.serviceName = name
+	}
+}
+
+func WithTracer(t *tracer.Tracer) RegisterOption {
+	return func(cfg *registerConfig) {
+		cfg.tracer = t
+	}
+}

--- a/contrib/database/sql/sql_test.go
+++ b/contrib/database/sql/sql_test.go
@@ -64,7 +64,7 @@ func TestPostgres(t *testing.T) {
 	defer func() {
 		tracer.DefaultTracer = originalTracer
 	}()
-	RegisterWithServiceName("postgres-test", "postgres", &pq.Driver{})
+	Register("postgres", &pq.Driver{}, WithServiceName("postgres-test"))
 	db, err := Open("postgres", "postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable")
 	if err != nil {
 		log.Fatal(err)

--- a/contrib/garyburd/redigo/example_test.go
+++ b/contrib/garyburd/redigo/example_test.go
@@ -3,9 +3,11 @@ package redigo_test
 import (
 	"context"
 	"log"
+	"time"
 
 	redigotrace "github.com/DataDog/dd-trace-go/contrib/garyburd/redigo"
 	"github.com/DataDog/dd-trace-go/tracer"
+
 	"github.com/garyburd/redigo/redis"
 )
 
@@ -30,7 +32,11 @@ func Example() {
 }
 
 func Example_tracedConn() {
-	c, err := redigotrace.DialWithServiceName("my-redis-backend", tracer.DefaultTracer, "tcp", "127.0.0.1:6379")
+	c, err := redigotrace.Dial("tcp", "127.0.0.1:6379",
+		redigotrace.WithServiceName("my-redis-backend"),
+		redigotrace.WithTracer(tracer.DefaultTracer),
+		redis.DialKeepAlive(time.Minute),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -60,7 +66,10 @@ func Example_dialURL() {
 func Example_pool() {
 	pool := &redis.Pool{
 		Dial: func() (redis.Conn, error) {
-			return redigotrace.DialWithServiceName("my-redis-backend", tracer.DefaultTracer, "tcp", "127.0.0.1:6379")
+			return redigotrace.Dial("tcp", "127.0.0.1:6379",
+				redigotrace.WithServiceName("my-redis-backend"),
+				redigotrace.WithTracer(tracer.DefaultTracer),
+			)
 		},
 	}
 

--- a/contrib/garyburd/redigo/option.go
+++ b/contrib/garyburd/redigo/option.go
@@ -1,0 +1,29 @@
+package redigo
+
+import "github.com/DataDog/dd-trace-go/tracer"
+
+type dialConfig struct {
+	serviceName string
+	tracer      *tracer.Tracer // TODO(gbbr): Remove this when we switch.
+}
+
+// DialOption represents an option that can be passed to Dial.
+type DialOption func(*dialConfig)
+
+func defaults(cfg *dialConfig) {
+	cfg.serviceName = "redis.conn"
+	cfg.tracer = tracer.DefaultTracer
+}
+
+// WithServiceName sets the given service name for the dialled connection.
+func WithServiceName(name string) DialOption {
+	return func(cfg *dialConfig) {
+		cfg.serviceName = name
+	}
+}
+
+func WithTracer(t *tracer.Tracer) DialOption {
+	return func(cfg *dialConfig) {
+		cfg.tracer = t
+	}
+}

--- a/contrib/garyburd/redigo/redigo_test.go
+++ b/contrib/garyburd/redigo/redigo_test.go
@@ -19,7 +19,10 @@ func TestClient(t *testing.T) {
 	testTracer, testTransport := tracertest.GetTestTracer()
 	testTracer.SetDebugLogging(debug)
 
-	c, err := DialWithServiceName("my-service", testTracer, "tcp", "127.0.0.1:6379")
+	c, err := Dial("tcp", "127.0.0.1:6379",
+		WithServiceName("my-service"),
+		WithTracer(testTracer),
+	)
 	assert.Nil(err)
 	c.Do("SET", 1, "truck")
 
@@ -44,7 +47,10 @@ func TestCommandError(t *testing.T) {
 	testTracer, testTransport := tracertest.GetTestTracer()
 	testTracer.SetDebugLogging(debug)
 
-	c, err := DialWithServiceName("my-service", testTracer, "tcp", "127.0.0.1:6379")
+	c, err := Dial("tcp", "127.0.0.1:6379",
+		WithServiceName("my-service"),
+		WithTracer(testTracer),
+	)
 	assert.Nil(err)
 	_, err = c.Do("NOT_A_COMMAND", context.Background())
 	assert.NotNil(err)
@@ -71,7 +77,10 @@ func TestConnectionError(t *testing.T) {
 	testTracer, _ := tracertest.GetTestTracer()
 	testTracer.SetDebugLogging(debug)
 
-	_, err := DialWithServiceName("redis-service", testTracer, "tcp", "127.0.0.1:1000")
+	_, err := Dial("tcp", "127.0.0.1:1000",
+		WithServiceName("redis-service"),
+		WithTracer(testTracer),
+	)
 
 	assert.NotNil(err)
 	assert.Contains(err.Error(), "dial tcp 127.0.0.1:1000")
@@ -86,7 +95,10 @@ func TestInheritance(t *testing.T) {
 	ctx := context.Background()
 	parentSpan := testTracer.NewChildSpanFromContext("parentSpan", ctx)
 	ctx = tracer.ContextWithSpan(ctx, parentSpan)
-	client, err := DialWithServiceName("my_service", testTracer, "tcp", "127.0.0.1:6379")
+	client, err := Dial("tcp", "127.0.0.1:6379",
+		WithServiceName("redis-service"),
+		WithTracer(testTracer),
+	)
 	assert.Nil(err)
 	client.Do("SET", "water", "bottle", ctx)
 	parentSpan.Finish()
@@ -125,7 +137,10 @@ func TestCommandsToSring(t *testing.T) {
 	testTracer.SetDebugLogging(debug)
 
 	str := stringifyTest{A: 57, B: 8}
-	c, err := DialWithServiceName("my-service", testTracer, "tcp", "127.0.0.1:6379")
+	c, err := Dial("tcp", "127.0.0.1:6379",
+		WithServiceName("my-service"),
+		WithTracer(testTracer),
+	)
 	assert.Nil(err)
 	c.Do("SADD", "testSet", "a", int(0), int32(1), int64(2), str, context.Background())
 
@@ -155,7 +170,10 @@ func TestPool(t *testing.T) {
 		IdleTimeout: 23,
 		Wait:        true,
 		Dial: func() (redis.Conn, error) {
-			return DialWithServiceName("my-service", testTracer, "tcp", "127.0.0.1:6379")
+			return Dial("tcp", "127.0.0.1:6379",
+				WithServiceName("my-service"),
+				WithTracer(testTracer),
+			)
 		},
 	}
 
@@ -175,7 +193,7 @@ func TestTracingDialUrl(t *testing.T) {
 	testTracer, testTransport := tracertest.GetTestTracer()
 	testTracer.SetDebugLogging(debug)
 	url := "redis://127.0.0.1:6379"
-	client, err := DialURLWithServiceName("redis-service", testTracer, url)
+	client, err := DialURL(url, WithServiceName("redis-service"), WithTracer(testTracer))
 	assert.Nil(err)
 	client.Do("SET", "ONE", " TWO", context.Background())
 

--- a/contrib/go-redis/redis/example_test.go
+++ b/contrib/go-redis/redis/example_test.go
@@ -38,7 +38,7 @@ func Example() {
 func Example_pipeliner() {
 	// create a client
 	opts := &redis.Options{Addr: "127.0.0.1", Password: "", DB: 0}
-	c := redistrace.NewClient(opts)
+	c := redistrace.NewClient(opts, redistrace.WithServiceName("my-redis-service"))
 
 	// open the pipeline
 	pipe := c.Pipeline()

--- a/contrib/go-redis/redis/option.go
+++ b/contrib/go-redis/redis/option.go
@@ -1,0 +1,29 @@
+package redis
+
+import "github.com/DataDog/dd-trace-go/tracer"
+
+type clientConfig struct {
+	serviceName string
+	tracer      *tracer.Tracer // TODO(gbbr): Remove this when we switch.
+}
+
+// ClientOption represents an option that can be used to create or wrap a client.
+type ClientOption func(*clientConfig)
+
+func defaults(cfg *clientConfig) {
+	cfg.tracer = tracer.DefaultTracer
+	cfg.serviceName = "redis.client"
+}
+
+// WithServiceName sets the given service name for the client.
+func WithServiceName(name string) ClientOption {
+	return func(cfg *clientConfig) {
+		cfg.serviceName = name
+	}
+}
+
+func WithTracer(t *tracer.Tracer) ClientOption {
+	return func(cfg *clientConfig) {
+		cfg.tracer = t
+	}
+}

--- a/contrib/go-redis/redis/redis_test.go
+++ b/contrib/go-redis/redis/redis_test.go
@@ -19,7 +19,7 @@ func TestClient(t *testing.T) {
 	testTracer, testTransport := tracertest.GetTestTracer()
 	testTracer.SetDebugLogging(debug)
 
-	client := NewClientWithServiceName(opts, "my-redis", testTracer)
+	client := NewClient(opts, WithServiceName("my-redis"), WithTracer(testTracer))
 	client.Set("test_key", "test_value", 0)
 
 	testTracer.ForceFlush()
@@ -43,7 +43,7 @@ func TestPipeline(t *testing.T) {
 	testTracer, testTransport := tracertest.GetTestTracer()
 	testTracer.SetDebugLogging(debug)
 
-	client := NewClientWithServiceName(opts, "my-redis", testTracer)
+	client := NewClient(opts, WithServiceName("my-redis"), WithTracer(testTracer))
 	pipeline := client.Pipeline()
 	pipeline.Expire("pipeline_counter", time.Hour)
 
@@ -93,7 +93,7 @@ func TestChildSpan(t *testing.T) {
 	parent_span := testTracer.NewChildSpanFromContext("parent_span", ctx)
 	ctx = tracer.ContextWithSpan(ctx, parent_span)
 
-	client := NewClientWithServiceName(opts, "my-redis", testTracer)
+	client := NewClient(opts, WithServiceName("my-redis"), WithTracer(testTracer))
 	client = client.WithContext(ctx)
 
 	client.Set("test_key", "test_value", 0)
@@ -129,7 +129,7 @@ func TestMultipleCommands(t *testing.T) {
 	testTracer, testTransport := tracertest.GetTestTracer()
 	testTracer.SetDebugLogging(debug)
 
-	client := NewClientWithServiceName(opts, "my-redis", testTracer)
+	client := NewClient(opts, WithServiceName("my-redis"), WithTracer(testTracer))
 	client.Set("test_key", "test_value", 0)
 	client.Get("test_key")
 	client.Incr("int_key")
@@ -158,7 +158,7 @@ func TestError(t *testing.T) {
 	testTracer, testTransport := tracertest.GetTestTracer()
 	testTracer.SetDebugLogging(debug)
 
-	client := NewClientWithServiceName(opts, "my-redis", testTracer)
+	client := NewClient(opts, WithServiceName("my-redis"), WithTracer(testTracer))
 	err := client.Get("non_existent_key")
 
 	testTracer.ForceFlush()

--- a/contrib/gocql/gocql/example_test.go
+++ b/contrib/gocql/gocql/example_test.go
@@ -20,7 +20,7 @@ func Example() {
 	ctx := root.Context(context.Background())
 
 	// Wrap the query to trace it and pass the context for inheritance
-	tracedQuery := gocqltrace.WrapQuery(query, "ServiceName", tracer.DefaultTracer)
+	tracedQuery := gocqltrace.WrapQuery(query, gocqltrace.WithServiceName("ServiceName"))
 	tracedQuery.WithContext(ctx)
 
 	// Execute your query as usual

--- a/contrib/gocql/gocql/gocql_test.go
+++ b/contrib/gocql/gocql/gocql_test.go
@@ -52,7 +52,7 @@ func TestErrorWrapper(t *testing.T) {
 	session, err := cluster.CreateSession()
 	assert.Nil(err)
 	q := session.Query("CREATE KEYSPACE trace WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };")
-	err = WrapQuery(q, "ServiceName", testTracer).Exec()
+	err = WrapQuery(q, WithServiceName("ServiceName"), WithTracer(testTracer)).Exec()
 
 	testTracer.ForceFlush()
 	traces := testTransport.Traces()
@@ -90,7 +90,7 @@ func TestChildWrapperSpan(t *testing.T) {
 	session, err := cluster.CreateSession()
 	assert.Nil(err)
 	q := session.Query("SELECT * from trace.person")
-	tq := WrapQuery(q, "TestServiceName", testTracer)
+	tq := WrapQuery(q, WithServiceName("TestServiceName"), WithTracer(testTracer))
 	tq.WithContext(ctx).Exec()
 	parentSpan.Finish()
 

--- a/contrib/gocql/gocql/option.go
+++ b/contrib/gocql/gocql/option.go
@@ -1,0 +1,29 @@
+package gocql
+
+import "github.com/DataDog/dd-trace-go/tracer"
+
+type queryConfig struct {
+	serviceName string
+	tracer      *tracer.Tracer // TODO(gbbr): Remove this when we switch.
+}
+
+// WrapOption represents an option that can be passed to WrapQuery.
+type WrapOption func(*queryConfig)
+
+func defaults(cfg *queryConfig) {
+	cfg.serviceName = "gocql.query"
+	cfg.tracer = tracer.DefaultTracer
+}
+
+// WithServiceName sets the given service name for the returned query.
+func WithServiceName(name string) WrapOption {
+	return func(cfg *queryConfig) {
+		cfg.serviceName = name
+	}
+}
+
+func WithTracer(t *tracer.Tracer) WrapOption {
+	return func(cfg *queryConfig) {
+		cfg.tracer = t
+	}
+}

--- a/contrib/google.golang.org/grpc.v12/example_test.go
+++ b/contrib/google.golang.org/grpc.v12/example_test.go
@@ -12,7 +12,10 @@ import (
 
 func Example_client() {
 	// Create the client interceptor using the grpc trace package.
-	i := grpctrace.UnaryClientInterceptor("my-grpc-client", tracer.DefaultTracer)
+	i := grpctrace.UnaryClientInterceptor(
+		grpctrace.WithServiceName("my-grpc-client"),
+		grpctrace.WithTracer(tracer.DefaultTracer),
+	)
 
 	// Create initialization options for dialing into a server. Make sure
 	// to include the created interceptor.
@@ -39,7 +42,10 @@ func Example_server() {
 	}
 
 	// Create the unary server interceptor using the grpc trace package.
-	i := grpctrace.UnaryServerInterceptor("my-grpc-client", tracer.DefaultTracer)
+	i := grpctrace.UnaryServerInterceptor(
+		grpctrace.WithServiceName("my-grpc-client"),
+		grpctrace.WithTracer(tracer.DefaultTracer),
+	)
 
 	// Initialize the grpc server as normal, using the tracing interceptor.
 	s := grpc.NewServer(grpc.UnaryInterceptor(i))

--- a/contrib/google.golang.org/grpc.v12/grpc_test.go
+++ b/contrib/google.golang.org/grpc.v12/grpc_test.go
@@ -220,7 +220,10 @@ func (r *rig) Close() {
 }
 
 func newRig(t *tracer.Tracer, traceClient bool) (*rig, error) {
-	server := grpc.NewServer(grpc.UnaryInterceptor(UnaryServerInterceptor("grpc", t)))
+	server := grpc.NewServer(
+		grpc.UnaryInterceptor(
+			UnaryServerInterceptor(WithServiceName("grpc"), WithTracer(t)),
+		))
 
 	RegisterFixtureServer(server, new(fixtureServer))
 
@@ -233,7 +236,9 @@ func newRig(t *tracer.Tracer, traceClient bool) (*rig, error) {
 
 	opts := []grpc.DialOption{grpc.WithInsecure()}
 	if traceClient {
-		opts = append(opts, grpc.WithUnaryInterceptor(UnaryClientInterceptor("grpc", t)))
+		opts = append(opts, grpc.WithUnaryInterceptor(
+			UnaryClientInterceptor(WithServiceName("grpc"), WithTracer(t)),
+		))
 	}
 	conn, err := grpc.Dial(li.Addr().String(), opts...)
 	if err != nil {

--- a/contrib/google.golang.org/grpc.v12/option.go
+++ b/contrib/google.golang.org/grpc.v12/option.go
@@ -1,0 +1,30 @@
+package grpc
+
+import "github.com/DataDog/dd-trace-go/tracer"
+
+type interceptorConfig struct {
+	serviceName string
+	tracer      *tracer.Tracer // TODO(gbbr): Remove this when we switch.
+}
+
+// InterceptorOption represents an option that can be passed to the grpc unary
+// client and server interceptors.
+type InterceptorOption func(*interceptorConfig)
+
+func defaults(cfg *interceptorConfig) {
+	cfg.serviceName = "grpc.client"
+	cfg.tracer = tracer.DefaultTracer
+}
+
+// WithServiceName sets the given service name for the intercepted client.
+func WithServiceName(name string) InterceptorOption {
+	return func(cfg *interceptorConfig) {
+		cfg.serviceName = name
+	}
+}
+
+func WithTracer(t *tracer.Tracer) InterceptorOption {
+	return func(cfg *interceptorConfig) {
+		cfg.tracer = t
+	}
+}

--- a/contrib/google.golang.org/grpc/example_test.go
+++ b/contrib/google.golang.org/grpc/example_test.go
@@ -12,7 +12,10 @@ import (
 
 func Example_client() {
 	// Create the client interceptor using the grpc trace package.
-	i := grpctrace.UnaryClientInterceptor("my-grpc-client", tracer.DefaultTracer)
+	i := grpctrace.UnaryClientInterceptor(
+		grpctrace.WithServiceName("my-grpc-client"),
+		grpctrace.WithTracer(tracer.DefaultTracer),
+	)
 
 	// Create initialization options for dialing into a server. Make sure
 	// to include the created interceptor.
@@ -39,7 +42,10 @@ func Example_server() {
 	}
 
 	// Create the unary server interceptor using the grpc trace package.
-	i := grpctrace.UnaryServerInterceptor("my-grpc-client", tracer.DefaultTracer)
+	i := grpctrace.UnaryServerInterceptor(
+		grpctrace.WithServiceName("my-grpc-client"),
+		grpctrace.WithTracer(tracer.DefaultTracer),
+	)
 
 	// Initialize the grpc server as normal, using the tracing interceptor.
 	s := grpc.NewServer(grpc.UnaryInterceptor(i))

--- a/contrib/google.golang.org/grpc/grpc.go
+++ b/contrib/google.golang.org/grpc/grpc.go
@@ -20,13 +20,22 @@ const (
 )
 
 // UnaryServerInterceptor will trace requests to the given grpc server.
-func UnaryServerInterceptor(service string, t *tracer.Tracer) grpc.UnaryServerInterceptor {
-	t.SetServiceInfo(service, "grpc-server", ext.AppTypeRPC)
+func UnaryServerInterceptor(opts ...InterceptorOption) grpc.UnaryServerInterceptor {
+	cfg := new(interceptorConfig)
+	defaults(cfg)
+	for _, fn := range opts {
+		fn(cfg)
+	}
+	if cfg.serviceName == "" {
+		cfg.serviceName = "grpc.server"
+	}
+	t := cfg.tracer
+	t.SetServiceInfo(cfg.serviceName, "grpc-server", ext.AppTypeRPC)
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		if !t.Enabled() {
 			return handler(ctx, req)
 		}
-		span := serverSpan(t, ctx, info.FullMethod, service)
+		span := serverSpan(t, ctx, info.FullMethod, cfg.serviceName)
 		resp, err := handler(tracer.ContextWithSpan(ctx, span), req)
 		span.FinishWithErr(err)
 		return resp, err
@@ -34,8 +43,17 @@ func UnaryServerInterceptor(service string, t *tracer.Tracer) grpc.UnaryServerIn
 }
 
 // UnaryClientInterceptor will add tracing to a gprc client.
-func UnaryClientInterceptor(service string, t *tracer.Tracer) grpc.UnaryClientInterceptor {
-	t.SetServiceInfo(service, "grpc-client", ext.AppTypeRPC)
+func UnaryClientInterceptor(opts ...InterceptorOption) grpc.UnaryClientInterceptor {
+	cfg := new(interceptorConfig)
+	defaults(cfg)
+	for _, fn := range opts {
+		fn(cfg)
+	}
+	if cfg.serviceName == "" {
+		cfg.serviceName = "grpc.client"
+	}
+	t := cfg.tracer
+	t.SetServiceInfo(cfg.serviceName, "grpc-client", ext.AppTypeRPC)
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		var child *tracer.Span
 		span, ok := tracer.SpanFromContext(ctx)

--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -220,7 +220,10 @@ func (r *rig) Close() {
 }
 
 func newRig(t *tracer.Tracer, traceClient bool) (*rig, error) {
-	server := grpc.NewServer(grpc.UnaryInterceptor(UnaryServerInterceptor("grpc", t)))
+	server := grpc.NewServer(
+		grpc.UnaryInterceptor(
+			UnaryServerInterceptor(WithServiceName("grpc"), WithTracer(t)),
+		))
 
 	RegisterFixtureServer(server, new(fixtureServer))
 
@@ -233,7 +236,9 @@ func newRig(t *tracer.Tracer, traceClient bool) (*rig, error) {
 
 	opts := []grpc.DialOption{grpc.WithInsecure()}
 	if traceClient {
-		opts = append(opts, grpc.WithUnaryInterceptor(UnaryClientInterceptor("grpc", t)))
+		opts = append(opts, grpc.WithUnaryInterceptor(
+			UnaryClientInterceptor(WithServiceName("grpc"), WithTracer(t)),
+		))
 	}
 	conn, err := grpc.Dial(li.Addr().String(), opts...)
 	if err != nil {

--- a/contrib/google.golang.org/grpc/option.go
+++ b/contrib/google.golang.org/grpc/option.go
@@ -1,0 +1,29 @@
+package grpc
+
+import "github.com/DataDog/dd-trace-go/tracer"
+
+type interceptorConfig struct {
+	serviceName string
+	tracer      *tracer.Tracer // TODO(gbbr): Remove this when we switch.
+}
+
+// InterceptorOption represents an option that can be passed to the grpc unary
+// client and server interceptors.
+type InterceptorOption func(*interceptorConfig)
+
+func defaults(cfg *interceptorConfig) {
+	cfg.tracer = tracer.DefaultTracer
+}
+
+// WithServiceName sets the given service name for the intercepted client.
+func WithServiceName(name string) InterceptorOption {
+	return func(cfg *interceptorConfig) {
+		cfg.serviceName = name
+	}
+}
+
+func WithTracer(t *tracer.Tracer) InterceptorOption {
+	return func(cfg *interceptorConfig) {
+		cfg.tracer = t
+	}
+}

--- a/contrib/gorilla/mux/example_test.go
+++ b/contrib/gorilla/mux/example_test.go
@@ -15,3 +15,9 @@ func Example() {
 	mux.HandleFunc("/", handler)
 	http.ListenAndServe(":8080", mux)
 }
+
+func Example_withServiceName() {
+	mux := muxtrace.NewRouter(muxtrace.WithServiceName("mux.route"))
+	mux.HandleFunc("/", handler)
+	http.ListenAndServe(":8080", mux)
+}

--- a/contrib/gorilla/mux/mux_test.go
+++ b/contrib/gorilla/mux/mux_test.go
@@ -16,7 +16,7 @@ func TestHttpTracerDisabled(t *testing.T) {
 	testTracer, testTransport := tracertest.GetTestTracer()
 	testTracer.SetEnabled(false)
 
-	mux := NewRouterWithServiceName("my-service", testTracer)
+	mux := NewRouter(WithServiceName("my-service"), WithTracer(testTracer))
 	mux.HandleFunc("/disabled", func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write([]byte("disabled!"))
 		assert.Nil(err)
@@ -103,7 +103,7 @@ func setup(t *testing.T) (*tracer.Tracer, *tracertest.DummyTransport, http.Handl
 	h500 := handler500(t)
 	tracer, transport := tracertest.GetTestTracer()
 
-	mux := NewRouterWithServiceName("my-service", tracer)
+	mux := NewRouter(WithServiceName("my-service"), WithTracer(tracer))
 	mux.HandleFunc("/200", h200)
 	mux.HandleFunc("/500", h500)
 

--- a/contrib/gorilla/mux/option.go
+++ b/contrib/gorilla/mux/option.go
@@ -1,0 +1,29 @@
+package mux
+
+import "github.com/DataDog/dd-trace-go/tracer"
+
+type routerConfig struct {
+	serviceName string
+	tracer      *tracer.Tracer // TODO(gbbr): Remove this when we switch.
+}
+
+// RouterOption represents an option that can be passed to NewRouter.
+type RouterOption func(*routerConfig)
+
+func defaults(cfg *routerConfig) {
+	cfg.serviceName = "mux.router"
+	cfg.tracer = tracer.DefaultTracer
+}
+
+// WithServiceName sets the given service name for the router.
+func WithServiceName(name string) RouterOption {
+	return func(cfg *routerConfig) {
+		cfg.serviceName = name
+	}
+}
+
+func WithTracer(t *tracer.Tracer) RouterOption {
+	return func(cfg *routerConfig) {
+		cfg.tracer = t
+	}
+}

--- a/contrib/jmoiron/sqlx/example_test.go
+++ b/contrib/jmoiron/sqlx/example_test.go
@@ -6,14 +6,15 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
 
+	sqltrace "github.com/DataDog/dd-trace-go/contrib/database/sql"
 	sqlxtrace "github.com/DataDog/dd-trace-go/contrib/jmoiron/sqlx"
 )
 
-func Example() {
+func ExampleOpen() {
 	// Register informs the sqlxtrace package of the driver that we will be using in our program.
 	// It uses a default service name, in the below case "postgres.db". To use a custom service
 	// name use RegisterWithServiceName.
-	sqlxtrace.Register("postgres", &pq.Driver{})
+	sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithServiceName("my-service"))
 	db, err := sqlxtrace.Open("postgres", "postgres://pqgotest:password@localhost/pqgotest?sslmode=disable")
 	if err != nil {
 		log.Fatal(err)

--- a/contrib/jmoiron/sqlx/sql.go
+++ b/contrib/jmoiron/sqlx/sql.go
@@ -8,24 +8,13 @@
 package sqlx
 
 import (
-	"database/sql/driver"
-
 	sqltraced "github.com/DataDog/dd-trace-go/contrib/database/sql"
 
 	"github.com/jmoiron/sqlx"
 )
 
-// Register tells the sqlx integration package about the driver that we will be tracing. Internally it
-// registers a new version of the driver that is augmented with tracing. It must be called before
-// Open, if that connection is to be traced. It uses the driverName suffixed with ".db" as the
-// default service name. To set a custom service name, use RegisterWithServiceName.
-func Register(driverName string, driver driver.Driver) { sqltraced.Register(driverName, driver) }
-
-// RegisterWithServiceName performs the same operation as Register, but it allows setting a custom service name.
-func RegisterWithServiceName(serviceName, driverName string, driver driver.Driver) {
-	sqltraced.Register(driverName, driver, sqltraced.WithServiceName(serviceName))
-}
-
+// Open opens a new (traced) connection to the database using the given driver and source.
+// Note that the driver must formerly be registered using database/sql integration's Register.
 func Open(driverName, dataSourceName string) (*sqlx.DB, error) {
 	db, err := sqltraced.Open(driverName, dataSourceName)
 	if err != nil {
@@ -35,6 +24,8 @@ func Open(driverName, dataSourceName string) (*sqlx.DB, error) {
 }
 
 // MustOpen is the same as Open, but panics on error.
+// To get tracing, the driver must be formerly registered using the database/sql integration's
+// Register.
 func MustOpen(driverName, dataSourceName string) (*sqlx.DB, error) {
 	db, err := sqltraced.Open(driverName, dataSourceName)
 	if err != nil {
@@ -43,6 +34,9 @@ func MustOpen(driverName, dataSourceName string) (*sqlx.DB, error) {
 	return sqlx.NewDb(db, driverName), nil
 }
 
+// Connect connects to the data source using the given driver.
+// To get tracing, the driver must be formerly registered using the database/sql integration's
+// Register.
 func Connect(driverName, dataSourceName string) (*sqlx.DB, error) {
 	db, err := Open(driverName, dataSourceName)
 	if err != nil {
@@ -57,6 +51,8 @@ func Connect(driverName, dataSourceName string) (*sqlx.DB, error) {
 }
 
 // MustConnect connects to a database and panics on error.
+// To get tracing, the driver must be formerly registered using the database/sql integration's
+// Register.
 func MustConnect(driverName, dataSourceName string) *sqlx.DB {
 	db, err := Connect(driverName, dataSourceName)
 	if err != nil {

--- a/contrib/jmoiron/sqlx/sql.go
+++ b/contrib/jmoiron/sqlx/sql.go
@@ -23,7 +23,7 @@ func Register(driverName string, driver driver.Driver) { sqltraced.Register(driv
 
 // RegisterWithServiceName performs the same operation as Register, but it allows setting a custom service name.
 func RegisterWithServiceName(serviceName, driverName string, driver driver.Driver) {
-	sqltraced.RegisterWithServiceName(serviceName, driverName, driver)
+	sqltraced.Register(driverName, driver, sqltraced.WithServiceName(serviceName))
 }
 
 func Open(driverName, dataSourceName string) (*sqlx.DB, error) {

--- a/contrib/jmoiron/sqlx/sql_test.go
+++ b/contrib/jmoiron/sqlx/sql_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	sqltrace "github.com/DataDog/dd-trace-go/contrib/database/sql"
 	"github.com/DataDog/dd-trace-go/contrib/internal/sqltest"
 	"github.com/DataDog/dd-trace-go/tracer"
 	"github.com/DataDog/dd-trace-go/tracer/tracertest"
@@ -28,7 +29,7 @@ func TestMySQL(t *testing.T) {
 	defer func() {
 		tracer.DefaultTracer = originalTracer
 	}()
-	RegisterWithServiceName("mysql-test", "mysql", &mysql.MySQLDriver{})
+	sqltrace.Register("mysql", &mysql.MySQLDriver{}, sqltrace.WithServiceName("mysql-test"))
 	dbx, err := Open("mysql", "test:test@tcp(127.0.0.1:3306)/test")
 	if err != nil {
 		log.Fatal(err)
@@ -64,7 +65,7 @@ func TestPostgres(t *testing.T) {
 	defer func() {
 		tracer.DefaultTracer = originalTracer
 	}()
-	Register("postgres", &pq.Driver{})
+	sqltrace.Register("postgres", &pq.Driver{})
 	dbx, err := Open("postgres", "postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable")
 	if err != nil {
 		log.Fatal(err)

--- a/contrib/julienschmidt/httprouter/example_test.go
+++ b/contrib/julienschmidt/httprouter/example_test.go
@@ -25,3 +25,11 @@ func Example() {
 
 	log.Fatal(http.ListenAndServe(":8080", router))
 }
+
+func Example_withServiceName() {
+	router := httptrace.New(httptrace.WithServiceName("http.router"))
+	router.GET("/", Index)
+	router.GET("/hello/:name", Hello)
+
+	log.Fatal(http.ListenAndServe(":8080", router))
+}

--- a/contrib/julienschmidt/httprouter/httprouter_test.go
+++ b/contrib/julienschmidt/httprouter/httprouter_test.go
@@ -18,7 +18,7 @@ func TestHttpTracerDisabled(t *testing.T) {
 	testTracer, testTransport := tracertest.GetTestTracer()
 	testTracer.SetEnabled(false)
 
-	router := NewWithServiceName("my-service", testTracer)
+	router := New(WithServiceName("my-service"), WithTracer(testTracer))
 	router.GET("/disabled", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		_, err := w.Write([]byte("disabled!"))
 		assert.Nil(err)
@@ -105,7 +105,7 @@ func setup(t *testing.T) (*tracer.Tracer, *tracertest.DummyTransport, http.Handl
 	h500 := handler500(t)
 	tracer, transport := tracertest.GetTestTracer()
 
-	router := NewWithServiceName("my-service", tracer)
+	router := New(WithServiceName("my-service"), WithTracer(tracer))
 	router.GET("/200", h200)
 	router.GET("/500", h500)
 

--- a/contrib/julienschmidt/httprouter/option.go
+++ b/contrib/julienschmidt/httprouter/option.go
@@ -1,0 +1,29 @@
+package httprouter
+
+import "github.com/DataDog/dd-trace-go/tracer"
+
+type routerConfig struct {
+	serviceName string
+	tracer      *tracer.Tracer // TODO(gbbr): Remove this when we switch.
+}
+
+// RouterOption represents an option that can be passed to New.
+type RouterOption func(*routerConfig)
+
+func defaults(cfg *routerConfig) {
+	cfg.serviceName = "http.router"
+	cfg.tracer = tracer.DefaultTracer
+}
+
+// WithServiceName sets the given service name for the returned router.
+func WithServiceName(name string) RouterOption {
+	return func(cfg *routerConfig) {
+		cfg.serviceName = name
+	}
+}
+
+func WithTracer(t *tracer.Tracer) RouterOption {
+	return func(cfg *routerConfig) {
+		cfg.tracer = t
+	}
+}

--- a/contrib/net/http/example_test.go
+++ b/contrib/net/http/example_test.go
@@ -13,3 +13,11 @@ func Example() {
 	})
 	http.ListenAndServe(":8080", mux)
 }
+
+func Example_withServiceName() {
+	mux := httptrace.NewServeMux(httptrace.WithServiceName("my-service"))
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Hello World!\n"))
+	})
+	http.ListenAndServe(":8080", mux)
+}

--- a/contrib/net/http/http_test.go
+++ b/contrib/net/http/http_test.go
@@ -16,7 +16,7 @@ func TestHttpTracerDisabled(t *testing.T) {
 	testTracer, testTransport := tracertest.GetTestTracer()
 	testTracer.SetEnabled(false)
 
-	mux := NewServeMuxWithServiceName("my-service", testTracer)
+	mux := NewServeMux(WithServiceName("my-service"), WithTracer(testTracer))
 	mux.HandleFunc("/disabled", func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write([]byte("disabled!"))
 		assert.Nil(err)
@@ -133,7 +133,7 @@ func setup(t *testing.T) (*tracer.Tracer, *tracertest.DummyTransport, http.Handl
 	h500 := handler500(t)
 	tracer, transport := tracertest.GetTestTracer()
 
-	mux := NewServeMuxWithServiceName("my-service", tracer)
+	mux := NewServeMux(WithServiceName("my-service"), WithTracer(tracer))
 	mux.HandleFunc("/200", h200)
 	mux.HandleFunc("/500", h500)
 

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -1,0 +1,29 @@
+package http
+
+import "github.com/DataDog/dd-trace-go/tracer"
+
+type muxConfig struct {
+	serviceName string
+	tracer      *tracer.Tracer // TODO(gbbr): Remove this when we switch.
+}
+
+// MuxOption represents an option that can be passed to NewServeMux.
+type MuxOption func(*muxConfig)
+
+func defaults(cfg *muxConfig) {
+	cfg.serviceName = "http.router"
+	cfg.tracer = tracer.DefaultTracer
+}
+
+// WithServiceName sets the given service name for the returned ServeMux.
+func WithServiceName(name string) MuxOption {
+	return func(cfg *muxConfig) {
+		cfg.serviceName = name
+	}
+}
+
+func WithTracer(t *tracer.Tracer) MuxOption {
+	return func(cfg *muxConfig) {
+		cfg.tracer = t
+	}
+}

--- a/contrib/olivere/elastic/elastictrace_test.go
+++ b/contrib/olivere/elastic/elastictrace_test.go
@@ -19,7 +19,7 @@ func TestClientV5(t *testing.T) {
 	testTracer, testTransport := tracertest.GetTestTracer()
 	testTracer.SetDebugLogging(debug)
 
-	tc := NewHTTPClient("my-es-service", testTracer)
+	tc := NewHTTPClient(WithServiceName("my-es-service"), WithTracer(testTracer))
 	client, err := elasticv5.NewClient(
 		elasticv5.SetURL("http://127.0.0.1:9201"),
 		elasticv5.SetHttpClient(tc),
@@ -52,7 +52,7 @@ func TestClientV3(t *testing.T) {
 	testTracer, testTransport := tracertest.GetTestTracer()
 	testTracer.SetDebugLogging(debug)
 
-	tc := NewHTTPClient("my-es-service", testTracer)
+	tc := NewHTTPClient(WithServiceName("my-es-service"), WithTracer(testTracer))
 	client, err := elasticv3.NewClient(
 		elasticv3.SetURL("http://127.0.0.1:9200"),
 		elasticv3.SetHttpClient(tc),
@@ -85,7 +85,7 @@ func TestClientV3Failure(t *testing.T) {
 	testTracer, testTransport := tracertest.GetTestTracer()
 	testTracer.SetDebugLogging(debug)
 
-	tc := NewHTTPClient("my-es-service", testTracer)
+	tc := NewHTTPClient(WithServiceName("my-es-service"), WithTracer(testTracer))
 	client, err := elasticv3.NewClient(
 		// inexistent service, it must fail
 		elasticv3.SetURL("http://127.0.0.1:29200"),
@@ -120,7 +120,7 @@ func TestClientV5Failure(t *testing.T) {
 	testTracer, testTransport := tracertest.GetTestTracer()
 	testTracer.SetDebugLogging(debug)
 
-	tc := NewHTTPClient("my-es-service", testTracer)
+	tc := NewHTTPClient(WithServiceName("my-es-service"), WithTracer(testTracer))
 	client, err := elasticv5.NewClient(
 		// inexistent service, it must fail
 		elasticv5.SetURL("http://127.0.0.1:29201"),

--- a/contrib/olivere/elastic/example_test.go
+++ b/contrib/olivere/elastic/example_test.go
@@ -12,7 +12,7 @@ import (
 // To start tracing elastic.v5 requests, create a new TracedHTTPClient that you will
 // use when initializing the elastic.Client.
 func Example_v5() {
-	tc := elastictrace.NewHTTPClient("my-elasticsearch-service", tracer.DefaultTracer)
+	tc := elastictrace.NewHTTPClient(elastictrace.WithServiceName("my-es-service"))
 	client, _ := elasticv5.NewClient(
 		elasticv5.SetURL("http://127.0.0.1:9200"),
 		elasticv5.SetHttpClient(tc),
@@ -36,7 +36,7 @@ func Example_v5() {
 // To trace elastic.v3 you create a TracedHTTPClient in the same way but all requests must use
 // the DoC() call to pass the request context.
 func Example_v3() {
-	tc := elastictrace.NewHTTPClient("my-elasticsearch-service", tracer.DefaultTracer)
+	tc := elastictrace.NewHTTPClient(elastictrace.WithServiceName("my-es-service"))
 	client, _ := elasticv3.NewClient(
 		elasticv3.SetURL("http://127.0.0.1:9200"),
 		elasticv3.SetHttpClient(tc),

--- a/contrib/olivere/elastic/option.go
+++ b/contrib/olivere/elastic/option.go
@@ -1,0 +1,41 @@
+package elastic
+
+import (
+	"net/http"
+
+	"github.com/DataDog/dd-trace-go/tracer"
+)
+
+type clientConfig struct {
+	serviceName string
+	transport   *http.Transport
+	tracer      *tracer.Tracer // TODO(gbbr): Remove this when we switch.
+}
+
+// ClientOption represents an option that can be used when creating a client.
+type ClientOption func(*clientConfig)
+
+func defaults(cfg *clientConfig) {
+	cfg.tracer = tracer.DefaultTracer
+	cfg.serviceName = "elastic.client"
+	cfg.transport = http.DefaultTransport.(*http.Transport)
+}
+
+// WithServiceName sets the given service name for the registered driver.
+func WithServiceName(name string) ClientOption {
+	return func(cfg *clientConfig) {
+		cfg.serviceName = name
+	}
+}
+
+func WithTransport(t *http.Transport) ClientOption {
+	return func(cfg *clientConfig) {
+		cfg.transport = t
+	}
+}
+
+func WithTracer(t *tracer.Tracer) ClientOption {
+	return func(cfg *clientConfig) {
+		cfg.tracer = t
+	}
+}


### PR DESCRIPTION
### Description

This PR removes the set of methods suffixed `*WithServiceName` from the integrations and instead adds functional options to each one.

### Reasoning

This will reduce the number of methods, match the original API 100% and allow versatile per-integration configurations.

### PR structure

Within the scope of this change each integration undergoes (more or less) the same set of changes within their own commit, except some special cases:

- Removed `Register` from `jmoiron/sqlx`. It was just a wrapper over the standard [`Register`](https://github.com/DataDog/dd-trace-go/blob/master/contrib/database/sql/sql.go#L25) from our integrations which can be used directly ([`jmoiron/sqlx`](https://godoc.org/github.com/jmoiron/sqlx#Register) has no Register method).
- `gabryburd/redigo` can take options of two types `redis.DialOption` as well as a local `DialOption` which configures the integration.