### PR TITLE
ddtrace/tracer: simplify encoder

### DIFF
--- a/ddtrace/tracer/encoder.go
+++ b/ddtrace/tracer/encoder.go
@@ -8,113 +8,69 @@ import (
 	"github.com/ugorji/go/codec"
 )
 
+// encoding specifies a supported encoding type that can be used by encode.
+type encoding int
+
 const (
-	jsoncontentType    = "application/json"
-	msgpackcontentType = "application/msgpack"
+	// encodingMsgpack is "msgpack" encoding.
+	encodingMsgpack encoding = iota
+
+	// encodingJSON is JSON encoding.
+	encodingJSON
 )
 
-// encoder is a generic interface that expects encoding methods for traces and
-// services, and a Read() method that will be used by the http handler
-type encoder interface {
-	io.Reader
-
-	encodeTraces(traces [][]*span) error
-	encodeServices(services map[string]service) error
-	contentType() string
+// contentType returns the HTTP content type for the encoding.
+func (e encoding) contentType() string {
+	switch e {
+	case encodingMsgpack:
+		return "application/msgpack"
+	case encodingJSON:
+		return "application/json"
+	}
+	return ""
 }
 
 var mh codec.MsgpackHandle
 
-var _ encoder = (*msgpackEncoder)(nil)
-
-// msgpackEncoder encodes a list of traces in Msgpack format
-type msgpackEncoder struct {
-	buffer         *bytes.Buffer
-	encoder        *codec.Encoder
-	msgcontentType string
-}
-
-func newMsgpackEncoder() *msgpackEncoder {
-	buffer := &bytes.Buffer{}
-	encoder := codec.NewEncoder(buffer, &mh)
-
-	return &msgpackEncoder{
-		buffer:         buffer,
-		encoder:        encoder,
-		msgcontentType: msgpackcontentType,
+// encode encodes v using the given encoding and returns an io.Reader which reads
+// the encoded data.
+func encode(e encoding, v interface{}) (io.Reader, error) {
+	var (
+		buf bytes.Buffer
+		err error
+	)
+	// It might be tempting to use an io.Pipe here instead of the buffer in an attempt
+	// to save memory. While some memory *is* saved, it comes at a great cost:
+	//
+	// name                     old time/op    new time/op     delta
+	// MsgpackEncoder/small-8      130µs ± 0%     3654µs ± 0%   ~     (p=1.000 n=1+1)
+	// MsgpackEncoder/medium-8    3.14ms ± 0%    89.58ms ± 0%   ~     (p=1.000 n=1+1)
+	// MsgpackEncoder/large-8      130ms ± 0%     3686ms ± 0%   ~     (p=1.000 n=1+1)
+	//
+	// name                     old speed      new speed       delta
+	// MsgpackEncoder/small-8    153MB/s ± 0%      5MB/s ± 0%   ~     (p=1.000 n=1+1)
+	// MsgpackEncoder/medium-8   158MB/s ± 0%      6MB/s ± 0%   ~     (p=1.000 n=1+1)
+	// MsgpackEncoder/large-8    153MB/s ± 0%      5MB/s ± 0%   ~     (p=1.000 n=1+1)
+	//
+	// name                     old alloc/op   new alloc/op    delta
+	// MsgpackEncoder/small-8      146kB ± 0%       87kB ± 0%   ~     (p=1.000 n=1+1)
+	// MsgpackEncoder/medium-8    2.21MB ± 0%     1.57MB ± 0%   ~     (p=1.000 n=1+1)
+	// MsgpackEncoder/large-8      141MB ± 0%       88MB ± 0%   ~     (p=1.000 n=1+1)
+	//
+	// name                     old allocs/op  new allocs/op   delta
+	// MsgpackEncoder/small-8       21.0 ± 0%     1918.0 ± 0%   ~     (p=1.000 n=1+1)
+	// MsgpackEncoder/medium-8      30.0 ± 0%    47525.0 ± 0%   ~     (p=1.000 n=1+1)
+	// MsgpackEncoder/large-8       43.0 ± 0%  1900047.0 ± 0%   ~     (p=1.000 n=1+1)
+	//
+	// Profiling will reveal that the (significant) loss in speed is due to the
+	// synchronization that the io.Pipe implementation uses internally.
+	switch e {
+	case encodingJSON:
+		err = json.NewEncoder(&buf).Encode(v)
+	case encodingMsgpack:
+		err = codec.NewEncoder(&buf, &mh).Encode(v)
+	default:
+		panic("unsupported encoding")
 	}
-}
-
-// encodeTraces serializes the given trace list into the internal buffer,
-// returning the error if any.
-func (e *msgpackEncoder) encodeTraces(traces [][]*span) error {
-	return e.encoder.Encode(traces)
-}
-
-// encodeServices serializes a service map into the internal buffer.
-func (e *msgpackEncoder) encodeServices(services map[string]service) error {
-	return e.encoder.Encode(services)
-}
-
-// Read values from the internal buffer
-func (e *msgpackEncoder) Read(p []byte) (int, error) {
-	return e.buffer.Read(p)
-}
-
-// contentType return the msgpackEncoder content-type
-func (e *msgpackEncoder) contentType() string {
-	return e.msgcontentType
-}
-
-var _ encoder = (*jsonEncoder)(nil)
-
-// jsonEncoder encodes a list of traces in JSON format
-type jsonEncoder struct {
-	buffer         *bytes.Buffer
-	encoder        *json.Encoder
-	msgContentType string
-}
-
-// newJSONEncoder returns a new encoder for the JSON format.
-func newJSONEncoder() *jsonEncoder {
-	buffer := &bytes.Buffer{}
-	encoder := json.NewEncoder(buffer)
-
-	return &jsonEncoder{
-		buffer:         buffer,
-		encoder:        encoder,
-		msgContentType: jsoncontentType,
-	}
-}
-
-// encodeTraces serializes the given trace list into the internal buffer,
-// returning the error if any.
-func (e *jsonEncoder) encodeTraces(traces [][]*span) error {
-	return e.encoder.Encode(traces)
-}
-
-// encodeServices serializes a service map into the internal buffer.
-func (e *jsonEncoder) encodeServices(services map[string]service) error {
-	return e.encoder.Encode(services)
-}
-
-// Read values from the internal buffer
-func (e *jsonEncoder) Read(p []byte) (int, error) {
-	return e.buffer.Read(p)
-}
-
-// contentType return the jsonEncoder content-type
-func (e *jsonEncoder) contentType() string {
-	return e.msgContentType
-}
-
-// encoderFactory will provide a new encoder each time we want to flush traces or services.
-type encoderFactory func() encoder
-
-func jsonEncoderFactory() encoder {
-	return newJSONEncoder()
-}
-
-func msgpackEncoderFactory() encoder {
-	return newMsgpackEncoder()
+	return &buf, err
 }

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -2,6 +2,7 @@ package tracer
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"
@@ -688,7 +689,7 @@ func BenchmarkTracerAddSpans(b *testing.B) {
 
 // getTestTracer returns a Tracer with a DummyTransport
 func getTestTracer(opts ...StartOption) (*tracer, *dummyTransport) {
-	transport := &dummyTransport{getEncoder: msgpackEncoderFactory}
+	transport := &dummyTransport{encoding: encodingMsgpack}
 	o := append([]StartOption{withTransport(transport)}, opts...)
 	tracer := newTracer(o...)
 	return tracer, transport
@@ -696,9 +697,9 @@ func getTestTracer(opts ...StartOption) (*tracer, *dummyTransport) {
 
 // Mock Transport with a real Encoder
 type dummyTransport struct {
-	getEncoder encoderFactory
-	traces     [][]*span
-	services   map[string]service
+	encoding
+	traces   [][]*span
+	services map[string]service
 
 	sync.RWMutex // required because of some poll-testing (eg: worker)
 }
@@ -707,9 +708,12 @@ func (t *dummyTransport) sendTraces(traces [][]*span) (*http.Response, error) {
 	t.Lock()
 	t.traces = append(t.traces, traces...)
 	t.Unlock()
-
-	encoder := t.getEncoder()
-	return nil, encoder.encodeTraces(traces)
+	r, err := encode(t.encoding, traces)
+	if err != nil {
+		return nil, err
+	}
+	_, err = ioutil.ReadAll(r)
+	return nil, err
 }
 
 func (t *dummyTransport) sendServices(services map[string]service) (*http.Response, error) {
@@ -717,8 +721,12 @@ func (t *dummyTransport) sendServices(services map[string]service) (*http.Respon
 	t.services = services
 	t.Unlock()
 
-	encoder := t.getEncoder()
-	return nil, encoder.encodeServices(services)
+	r, err := encode(t.encoding, services)
+	if err != nil {
+		return nil, err
+	}
+	_, err = ioutil.ReadAll(r)
+	return nil, err
 }
 
 func (t *dummyTransport) Traces() [][]*span {

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -152,23 +152,17 @@ func TestTransportServicesDowngrade_0_2(t *testing.T) {
 	assert.Equal(200, response.StatusCode)
 }
 
-func TestTransportEncoderPool(t *testing.T) {
+func TestTransportContentType(t *testing.T) {
 	assert := assert.New(t)
 	transport := newHTTPTransport(defaultAddress)
-
-	// MsgpackEncoder is the default encoder of the pool
-	encoder := transport.getEncoder()
-	assert.Equal("application/msgpack", encoder.contentType())
+	assert.Equal("application/msgpack", transport.encoding.contentType())
 }
 
-func TestTransportSwitchEncoder(t *testing.T) {
+func TestTransportDowngrade(t *testing.T) {
 	assert := assert.New(t)
 	transport := newHTTPTransport(defaultAddress)
-	transport.changeEncoder(jsonEncoderFactory)
-
-	// MsgpackEncoder is the default encoder of the pool
-	encoder := transport.getEncoder()
-	assert.Equal("application/json", encoder.contentType())
+	transport.apiDowngrade()
+	assert.Equal("application/json", transport.encoding.contentType())
 }
 
 func TestTraceCountHeader(t *testing.T) {


### PR DESCRIPTION
The encoder was overly engineered. This change simplifies the implementation and adds some benchmarks.