### PR TITLE
ddtrace/tracer: increase performance of SetTag

### DIFF
--- a/ddtrace/tracer/util.go
+++ b/ddtrace/tracer/util.go
@@ -9,7 +9,7 @@ func toFloat64(value interface{}) (f float64, ok bool) {
 	case float32:
 		return float64(i), true
 	case float64:
-		return float64(i), true
+		return i, true
 	case int:
 		return float64(i), true
 	case int16:


### PR DESCRIPTION
This change adds benchmarks for SetTag and increases the performance of
setting string values, which is our most common scenario.

```
name            old time/op    new time/op    delta
SetTagString-4     178ns ± 0%      99ns ± 0%  -44.16%

name            old alloc/op   new alloc/op   delta
SetTagString-4     16.0B ± 0%      4.0B ± 0%  -75.00%

name            old allocs/op  new allocs/op  delta
SetTagString-4      2.00 ± 0%      1.00 ± 0%  -50.00%
```