### PR TITLE
contrib/google.golang.org/grpc{,.v12}: quantize service and method

### DIFF
--- a/contrib/google.golang.org/grpc/grpc.go
+++ b/contrib/google.golang.org/grpc/grpc.go
@@ -24,19 +24,26 @@ func UnaryServerInterceptor(opts ...InterceptorOption) grpc.UnaryServerIntercept
 	for _, fn := range opts {
 		fn(cfg)
 	}
-	if cfg.serviceName == "" {
-		cfg.serviceName = "grpc.server"
-	}
-	tracer.SetServiceInfo(cfg.serviceName, "grpc-server", ext.AppTypeRPC)
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		span, ctx := startSpanFromContext(ctx, info.FullMethod, cfg.serviceName)
+		span, ctx := startSpanFromContext(ctx, cfg.serviceName, info.FullMethod)
 		resp, err := handler(ctx, req)
 		span.Finish(tracer.WithError(err))
 		return resp, err
 	}
 }
 
-func startSpanFromContext(ctx context.Context, method, service string) (ddtrace.Span, context.Context) {
+// defaultServiceName is the default service name that will be used on
+// server spans when the user does not provide a service or a service
+// can not be extracted from the full method name in the unary server
+// info.
+const defaultServiceName = "grpc.server"
+
+func startSpanFromContext(ctx context.Context, service, method string) (ddtrace.Span, context.Context) {
+	service, method = grpcutil.QuantizeResource(service, method)
+	if service == "" {
+		service = defaultServiceName
+	}
+	tracer.SetServiceInfo(service, "grpc-server", ext.AppTypeRPC)
 	opts := []ddtrace.StartSpanOption{
 		tracer.ServiceName(service),
 		tracer.ResourceName(method),

--- a/contrib/google.golang.org/internal/grpcutil/quantize.go
+++ b/contrib/google.golang.org/internal/grpcutil/quantize.go
@@ -1,0 +1,23 @@
+package grpcutil
+
+import "strings"
+
+// QuantizeResource will quantize the given method information and attempt to return the parsed
+// service and method. If a service is passed, it will override any service extracted from the
+// method information.
+func QuantizeResource(service, method string) (string, string) {
+	switch {
+	case strings.HasPrefix(method, "/pb."):
+		method = method[4:]
+	case strings.HasPrefix(method, "/"):
+		method = method[1:]
+	}
+	if idx := strings.LastIndexByte(method, '/'); idx > 0 {
+		if service == "" {
+			// user has not chosen a custom service name
+			service = method[:idx]
+		}
+		method = method[idx+1:]
+	}
+	return service, method
+}

--- a/contrib/google.golang.org/internal/grpcutil/quantize_test.go
+++ b/contrib/google.golang.org/internal/grpcutil/quantize_test.go
@@ -1,0 +1,53 @@
+package grpcutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQuantizeResource(t *testing.T) {
+	assert := assert.New(t)
+
+	for _, tt := range []struct {
+		method, service      string
+		resource, expService string
+	}{
+		{
+			method:     "/pb.service/method",
+			resource:   "method",
+			service:    "my-service",
+			expService: "my-service",
+		},
+		{
+			method:     "/pb.service/method",
+			resource:   "method",
+			expService: "service",
+		},
+		{
+			method:     "/service/method",
+			resource:   "method",
+			expService: "service",
+		},
+		{
+			method:     "pb.service/method",
+			resource:   "method",
+			expService: "pb.service",
+		},
+		{
+			method:     "pb.service/method",
+			resource:   "method",
+			service:    "my-service",
+			expService: "my-service",
+		},
+		{
+			method:   "abcdef",
+			resource: "abcdef",
+		},
+	} {
+		s, r := QuantizeResource(tt.service, tt.method)
+
+		assert.Equal(tt.expService, s)
+		assert.Equal(tt.resource, r)
+	}
+}

--- a/ddtrace/mocktracer/mockspan_test.go
+++ b/ddtrace/mocktracer/mockspan_test.go
@@ -31,7 +31,7 @@ func TestNewSpan(t *testing.T) {
 	})
 
 	t.Run("options", func(t *testing.T) {
-		tr := &mocktracer{services: map[string]*service{"A": &service{"A", "B", "C"}}}
+		tr := &mocktracer{services: map[string]*Service{"A": &Service{"A", "B", "C"}}}
 		startTime := time.Now()
 		tags := map[string]interface{}{"k": "v", "k1": "v1"}
 		opts := &ddtrace.StartSpanConfig{

--- a/ddtrace/mocktracer/mocktracer_test.go
+++ b/ddtrace/mocktracer/mocktracer_test.go
@@ -63,6 +63,17 @@ func TestTracerStartSpan(t *testing.T) {
 	})
 }
 
+func TestTracerServices(t *testing.T) {
+	var mt mocktracer
+	mt.SetServiceInfo("a", "b", "c")
+	mt.SetServiceInfo("c", "d", "e")
+
+	assert.Equal(t, map[string]*Service{
+		"a": &Service{"a", "b", "c"},
+		"c": &Service{"c", "d", "e"},
+	}, mt.Services())
+}
+
 func TestTracerFinishedSpans(t *testing.T) {
 	var mt mocktracer
 	parent := newSpan(&mt, "http.request", &ddtrace.StartSpanConfig{})
@@ -86,7 +97,7 @@ func TestTracerFinishedSpans(t *testing.T) {
 func TestTracerSetServiceInfo(t *testing.T) {
 	var mt mocktracer
 	mt.SetServiceInfo("a", "b", "c")
-	assert.Equal(t, map[string]*service{"a": &service{"a", "b", "c"}}, mt.services)
+	assert.Equal(t, map[string]*Service{"a": &Service{"a", "b", "c"}}, mt.services)
 }
 
 func TestTracerReset(t *testing.T) {
@@ -95,7 +106,7 @@ func TestTracerReset(t *testing.T) {
 	mt.SetServiceInfo("a", "b", "c")
 
 	assert := assert.New(t)
-	assert.Equal(map[string]*service{"a": &service{"a", "b", "c"}}, mt.services)
+	assert.Equal(map[string]*Service{"a": &Service{"a", "b", "c"}}, mt.services)
 	assert.Len(mt.finishedSpans, 1)
 
 	mt.Reset()


### PR DESCRIPTION
This change attempts to introduce "normalization" logic for the service and resource names used in spans when tracing gRPC calls. It attempts to extract the service and method names from the _full method_ information found within the unary server info.

Examples:

* From `/pb.Server/Method` the service used will be `Server` and the resource will be `Method`
* For any non-standard (as in different from the point above) full method names, the full method will be used as the resource and the default service (`grpc.server`) will be used as the service, unless user-specified.

Additionally adds a `Services` method to the mock tracer, which returns the registered services.