### PR TITLE
ddtrace/tracer: rename TextMapPropagator to Propagator

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -31,8 +31,8 @@ type config struct {
 	// transport specifies the Transport interface which will be used to send data to the agent.
 	transport transport
 
-	// textMapPropagator propagates text maps
-	textMapPropagator Propagator
+	// propagator propagates span context cross-process
+	propagator Propagator
 }
 
 // StartOption represents a function that can be provided as a parameter to Start.
@@ -52,10 +52,10 @@ func WithDebugMode(enabled bool) StartOption {
 	}
 }
 
-// WithTextMapPropagator sets a custom TextMap propagator on the tracer.
-func WithTextMapPropagator(p Propagator) StartOption {
+// WithPropagator sets a custom TextMap propagator on the tracer.
+func WithPropagator(p Propagator) StartOption {
 	return func(c *config) {
-		c.textMapPropagator = p
+		c.propagator = p
 	}
 }
 

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -76,34 +76,34 @@ func TestTextMapCarrierForeachKeyError(t *testing.T) {
 }
 
 func TestTextMapPropagatorErrors(t *testing.T) {
-	textMapPropagator := NewTextMapPropagator("", "", "")
+	propagator := NewPropagator("", "", "")
 	assert := assert.New(t)
 
-	err := textMapPropagator.Inject(&spanContext{}, 2)
+	err := propagator.Inject(&spanContext{}, 2)
 	assert.Equal(ErrInvalidCarrier, err)
-	err = textMapPropagator.Inject(internal.NoopSpanContext{}, TextMapCarrier(map[string]string{}))
+	err = propagator.Inject(internal.NoopSpanContext{}, TextMapCarrier(map[string]string{}))
 	assert.Equal(ErrInvalidSpanContext, err)
-	err = textMapPropagator.Inject(&spanContext{}, TextMapCarrier(map[string]string{}))
+	err = propagator.Inject(&spanContext{}, TextMapCarrier(map[string]string{}))
 	assert.Equal(ErrInvalidSpanContext, err) // no traceID and spanID
-	err = textMapPropagator.Inject(&spanContext{traceID: 1}, TextMapCarrier(map[string]string{}))
+	err = propagator.Inject(&spanContext{traceID: 1}, TextMapCarrier(map[string]string{}))
 	assert.Equal(ErrInvalidSpanContext, err) // no spanID
 
-	_, err = textMapPropagator.Extract(2)
+	_, err = propagator.Extract(2)
 	assert.Equal(ErrInvalidCarrier, err)
 
-	_, err = textMapPropagator.Extract(TextMapCarrier(map[string]string{
+	_, err = propagator.Extract(TextMapCarrier(map[string]string{
 		defaultTraceIDHeader:  "1",
 		defaultParentIDHeader: "A",
 	}))
 	assert.Equal(ErrSpanContextCorrupted, err)
 
-	_, err = textMapPropagator.Extract(TextMapCarrier(map[string]string{
+	_, err = propagator.Extract(TextMapCarrier(map[string]string{
 		defaultTraceIDHeader:  "A",
 		defaultParentIDHeader: "2",
 	}))
 	assert.Equal(ErrSpanContextCorrupted, err)
 
-	_, err = textMapPropagator.Extract(TextMapCarrier(map[string]string{
+	_, err = propagator.Extract(TextMapCarrier(map[string]string{
 		defaultTraceIDHeader:  "0",
 		defaultParentIDHeader: "0",
 	}))
@@ -113,8 +113,8 @@ func TestTextMapPropagatorErrors(t *testing.T) {
 func TestTextMapPropagatorInjectHeader(t *testing.T) {
 	assert := assert.New(t)
 
-	textMapPropagator := NewTextMapPropagator("bg-", "tid", "pid")
-	tracer := newTracer(WithTextMapPropagator(textMapPropagator))
+	propagator := NewPropagator("bg-", "tid", "pid")
+	tracer := newTracer(WithPropagator(propagator))
 
 	root := tracer.StartSpan("web.request").SetBaggageItem("item", "x").(*span)
 	ctx := root.Context()
@@ -133,8 +133,8 @@ func TestTextMapPropagatorInjectHeader(t *testing.T) {
 }
 
 func TestTextMapPropagatorInjectExtract(t *testing.T) {
-	textMapPropagator := NewTextMapPropagator("bg-", "tid", "pid")
-	tracer := newTracer(WithTextMapPropagator(textMapPropagator))
+	propagator := NewPropagator("bg-", "tid", "pid")
+	tracer := newTracer(WithPropagator(propagator))
 	root := tracer.StartSpan("web.request").SetBaggageItem("item", "x").(*span)
 	ctx := root.Context().(*spanContext)
 	headers := TextMapCarrier(map[string]string{})

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -107,8 +107,8 @@ func newTracer(opts ...StartOption) *tracer {
 	if c.transport == nil {
 		c.transport = newTransport(c.agentAddr)
 	}
-	if c.textMapPropagator == nil {
-		c.textMapPropagator = NewTextMapPropagator("", "", "")
+	if c.propagator == nil {
+		c.propagator = NewPropagator("", "", "")
 	}
 	t := &tracer{
 		config:           c,
@@ -301,12 +301,12 @@ func (t *tracer) SetServiceInfo(name, app, appType string) {
 
 // Inject uses the configured or default TextMap Propagator.
 func (t *tracer) Inject(ctx ddtrace.SpanContext, carrier interface{}) error {
-	return t.config.textMapPropagator.Inject(ctx, carrier)
+	return t.config.propagator.Inject(ctx, carrier)
 }
 
 // Extract uses the configured or default TextMap Propagator.
 func (t *tracer) Extract(carrier interface{}) (ddtrace.SpanContext, error) {
-	return t.config.textMapPropagator.Extract(carrier)
+	return t.config.propagator.Extract(carrier)
 }
 
 func (t *tracer) getTraces() [][]*span {


### PR DESCRIPTION
Our propagator will support both text map, binary and possibly other formats, so it would be confusing (and counter intuitive) to call it _text map_. We won't be able to change this later if we want to keep backwards compatibility.