### PR TITLE
all: remove SetServiceInfo

### DIFF
--- a/contrib/database/sql/driver.go
+++ b/contrib/database/sql/driver.go
@@ -36,7 +36,6 @@ func (d *tracedDriver) Open(dsn string) (c driver.Conn, err error) {
 	if err != nil {
 		return nil, err
 	}
-	tracer.SetServiceInfo(d.config.serviceName, d.driverName, ext.AppTypeDB)
 	tp := &traceParams{
 		driverName: d.driverName,
 		config:     d.config,
@@ -56,7 +55,7 @@ type traceParams struct {
 func (tp *traceParams) newChildSpanFromContext(ctx context.Context, resource string, query string) ddtrace.Span {
 	name := fmt.Sprintf("%s.query", tp.driverName)
 	span, _ := tracer.StartSpanFromContext(ctx, name,
-		tracer.SpanType(ext.SQLType),
+		tracer.SpanType(ext.AppTypeDB),
 		tracer.ServiceName(tp.config.serviceName),
 	)
 	if query != "" {

--- a/contrib/database/sql/example_test.go
+++ b/contrib/database/sql/example_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	sqltrace "gopkg.in/DataDog/dd-trace-go.v0/contrib/database/sql"
+	"gopkg.in/DataDog/dd-trace-go.v0/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v0/ddtrace/tracer"
 
 	"github.com/go-sql-driver/mysql"
@@ -41,6 +42,7 @@ func Example_context() {
 
 	// Create a root span, giving name, server and resource.
 	_, ctx := tracer.StartSpanFromContext(context.Background(), "my-query",
+		tracer.SpanType(ext.AppTypeDB),
 		tracer.ServiceName("my-db"),
 		tracer.ResourceName("initial-access"),
 	)

--- a/contrib/database/sql/sql_test.go
+++ b/contrib/database/sql/sql_test.go
@@ -35,7 +35,7 @@ func TestMySQL(t *testing.T) {
 		ExpectName: "mysql.query",
 		ExpectTags: map[string]interface{}{
 			ext.ServiceName: "mysql.db",
-			ext.SpanType:    ext.SQLType,
+			ext.SpanType:    ext.AppTypeDB,
 			ext.TargetHost:  "127.0.0.1",
 			ext.TargetPort:  "3306",
 			"db.user":       "test",
@@ -60,7 +60,7 @@ func TestPostgres(t *testing.T) {
 		ExpectName: "postgres.query",
 		ExpectTags: map[string]interface{}{
 			ext.ServiceName: "postgres-test",
-			ext.SpanType:    ext.SQLType,
+			ext.SpanType:    ext.AppTypeDB,
 			ext.TargetHost:  "127.0.0.1",
 			ext.TargetPort:  "5432",
 			"db.user":       "postgres",

--- a/contrib/garyburd/redigo/redigo.go
+++ b/contrib/garyburd/redigo/redigo.go
@@ -60,7 +60,6 @@ func Dial(network, address string, options ...interface{}) (redis.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	tracer.SetServiceInfo(cfg.serviceName, "redis", ext.AppTypeDB)
 	tc := Conn{c, &params{cfg, network, host, port}}
 	return tc, nil
 }
@@ -92,7 +91,10 @@ func DialURL(rawurl string, options ...interface{}) (redis.Conn, error) {
 // newChildSpan creates a span inheriting from the given context. It adds to the span useful metadata about the traced Redis connection
 func (tc Conn) newChildSpan(ctx context.Context) ddtrace.Span {
 	p := tc.params
-	span, _ := tracer.StartSpanFromContext(ctx, "redis.command", tracer.ServiceName(p.config.serviceName))
+	span, _ := tracer.StartSpanFromContext(ctx, "redis.command",
+		tracer.SpanType(ext.AppTypeDB),
+		tracer.ServiceName(p.config.serviceName),
+	)
 	return span.
 		SetTag("out.network", p.network).
 		SetTag(ext.TargetPort, p.port).

--- a/contrib/garyburd/redigo/redigo_test.go
+++ b/contrib/garyburd/redigo/redigo_test.go
@@ -27,6 +27,7 @@ func TestClient(t *testing.T) {
 
 	span := spans[0]
 	assert.Equal("redis.command", span.OperationName())
+	assert.Equal(ext.AppTypeDB, span.Tag(ext.SpanType))
 	assert.Equal("my-service", span.Tag(ext.ServiceName))
 	assert.Equal("SET", span.Tag(ext.ResourceName))
 	assert.Equal("127.0.0.1", span.Tag(ext.TargetHost))

--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -14,13 +14,12 @@ import (
 // Middleware returns middleware that will trace incoming requests.
 // The last parameter is optional and can be used to pass a custom tracer.
 func Middleware(service string) gin.HandlerFunc {
-	tracer.SetServiceInfo(service, "gin-gonic/gin", ext.AppTypeWeb)
 	return func(c *gin.Context) {
 		resource := c.HandlerName()
 		span, ctx := tracer.StartSpanFromContext(c.Request.Context(), "http.request",
 			tracer.ServiceName(service),
 			tracer.ResourceName(resource),
-			tracer.SpanType(ext.HTTPType),
+			tracer.SpanType(ext.AppTypeWeb),
 			tracer.Tag(ext.HTTPMethod, c.Request.Method),
 			tracer.Tag(ext.HTTPURL, c.Request.URL.Path),
 		)

--- a/contrib/gin-gonic/gin/gintrace_test.go
+++ b/contrib/gin-gonic/gin/gintrace_test.go
@@ -67,6 +67,7 @@ func TestTrace200(t *testing.T) {
 	}
 	span := spans[0]
 	assert.Equal("http.request", span.OperationName())
+	assert.Equal(ext.AppTypeWeb, span.Tag(ext.SpanType))
 	assert.Equal("foobar", span.Tag(ext.ServiceName))
 	assert.Contains(span.Tag(ext.ResourceName), "gin.TestTrace200")
 	assert.Equal("200", span.Tag(ext.HTTPCode))

--- a/contrib/go-redis/redis/example_test.go
+++ b/contrib/go-redis/redis/example_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-redis/redis"
 	redistrace "gopkg.in/DataDog/dd-trace-go.v0/contrib/go-redis/redis"
+	"gopkg.in/DataDog/dd-trace-go.v0/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v0/ddtrace/tracer"
 )
 
@@ -21,6 +22,7 @@ func Example() {
 
 	// optionally, create a new root span
 	root, ctx := tracer.StartSpanFromContext(context.Background(), "parent.request",
+		tracer.SpanType(ext.AppTypeDB),
 		tracer.ServiceName("web"),
 		tracer.ResourceName("/home"),
 	)

--- a/contrib/go-redis/redis/redis.go
+++ b/contrib/go-redis/redis/redis.go
@@ -59,7 +59,6 @@ func WrapClient(c *redis.Client, opts ...ClientOption) *Client {
 		db:     strconv.Itoa(opt.DB),
 		config: cfg,
 	}
-	tracer.SetServiceInfo(cfg.serviceName, "redis", ext.AppTypeDB)
 	tc := &Client{c, params}
 	tc.Client.WrapProcess(createWrapperFromClient(tc))
 	return tc
@@ -84,6 +83,7 @@ func (c *Pipeliner) Exec() ([]redis.Cmder, error) {
 func (c *Pipeliner) execWithContext(ctx context.Context) ([]redis.Cmder, error) {
 	p := c.params
 	span, _ := tracer.StartSpanFromContext(ctx, "redis.command",
+		tracer.SpanType(ext.AppTypeDB),
 		tracer.ServiceName(p.config.serviceName),
 		tracer.ResourceName("redis"),
 		tracer.Tag(ext.TargetHost, p.host),
@@ -127,6 +127,7 @@ func createWrapperFromClient(tc *Client) func(oldProcess func(cmd redis.Cmder) e
 			length := len(parts) - 1
 			p := tc.params
 			span, _ := tracer.StartSpanFromContext(ctx, "redis.command",
+				tracer.SpanType(ext.AppTypeDB),
 				tracer.ServiceName(p.config.serviceName),
 				tracer.ResourceName(parts[0]),
 				tracer.Tag(ext.TargetHost, p.host),

--- a/contrib/go-redis/redis/redis_test.go
+++ b/contrib/go-redis/redis/redis_test.go
@@ -29,6 +29,7 @@ func TestClient(t *testing.T) {
 
 	span := spans[0]
 	assert.Equal("redis.command", span.OperationName())
+	assert.Equal(ext.AppTypeDB, span.Tag(ext.SpanType))
 	assert.Equal("my-redis", span.Tag(ext.ServiceName))
 	assert.Equal("127.0.0.1", span.Tag(ext.TargetHost))
 	assert.Equal("6379", span.Tag(ext.TargetPort))
@@ -54,6 +55,7 @@ func TestPipeline(t *testing.T) {
 
 	span := spans[0]
 	assert.Equal("redis.command", span.OperationName())
+	assert.Equal(ext.AppTypeDB, span.Tag(ext.SpanType))
 	assert.Equal("my-redis", span.Tag(ext.ServiceName))
 	assert.Equal("expire pipeline_counter 3600: false\n", span.Tag(ext.ResourceName))
 	assert.Equal("127.0.0.1", span.Tag(ext.TargetHost))
@@ -72,6 +74,7 @@ func TestPipeline(t *testing.T) {
 
 	span = spans[0]
 	assert.Equal("redis.command", span.OperationName())
+	assert.Equal(ext.AppTypeDB, span.Tag(ext.SpanType))
 	assert.Equal("my-redis", span.Tag(ext.ServiceName))
 	assert.Equal("expire pipeline_counter 3600: false\nexpire pipeline_counter_1 60: false\n", span.Tag(ext.ResourceName))
 	assert.Equal("2", span.Tag("redis.pipeline_length"))

--- a/contrib/gocql/gocql/example_test.go
+++ b/contrib/gocql/gocql/example_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gocql/gocql"
 	gocqltrace "gopkg.in/DataDog/dd-trace-go.v0/contrib/gocql/gocql"
+	"gopkg.in/DataDog/dd-trace-go.v0/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v0/ddtrace/tracer"
 )
 
@@ -17,6 +18,7 @@ func Example() {
 
 	// Use context to pass information down the call chain
 	_, ctx := tracer.StartSpanFromContext(context.Background(), "parent.request",
+		tracer.SpanType(ext.AppTypeDB),
 		tracer.ServiceName("web"),
 		tracer.ResourceName("/home"),
 	)

--- a/contrib/gocql/gocql/gocql.go
+++ b/contrib/gocql/gocql/gocql.go
@@ -53,7 +53,6 @@ func WrapQuery(q *gocql.Query, opts ...WrapOption) *Query {
 		config: cfg,
 		query:  query,
 	}, context.Background()}
-	tracer.SetServiceInfo(cfg.serviceName, ext.CassandraType, ext.AppTypeDB)
 	return tq
 }
 
@@ -75,7 +74,7 @@ func (tq *Query) PageState(state []byte) *Query {
 func (tq *Query) newChildSpan(ctx context.Context) ddtrace.Span {
 	p := tq.params
 	span, _ := tracer.StartSpanFromContext(ctx, ext.CassandraQuery,
-		tracer.SpanType(ext.CassandraType),
+		tracer.SpanType(ext.AppTypeDB),
 		tracer.ServiceName(p.config.serviceName),
 		tracer.ResourceName(p.query),
 		tracer.Tag(ext.CassandraPaginated, fmt.Sprintf("%t", p.paginated)),

--- a/contrib/google.golang.org/grpc.v12/grpc_test.go
+++ b/contrib/google.golang.org/grpc.v12/grpc_test.go
@@ -131,7 +131,7 @@ func TestPass(t *testing.T) {
 	assert.Equal(s.OperationName(), "grpc.server")
 	assert.Equal(s.Tag(ext.ServiceName), "grpc")
 	assert.Equal(s.Tag(ext.ResourceName), "/grpc.Fixture/Ping")
-	assert.Equal(s.Tag(ext.SpanType), "go")
+	assert.Equal(s.Tag(ext.SpanType), ext.AppTypeRPC)
 	assert.True(s.FinishTime().Sub(s.StartTime()) > 0)
 }
 

--- a/contrib/google.golang.org/grpc/grpc.go
+++ b/contrib/google.golang.org/grpc/grpc.go
@@ -27,7 +27,6 @@ func UnaryServerInterceptor(opts ...InterceptorOption) grpc.UnaryServerIntercept
 	if cfg.serviceName == "" {
 		cfg.serviceName = "grpc.server"
 	}
-	tracer.SetServiceInfo(cfg.serviceName, "grpc-server", ext.AppTypeRPC)
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		span, ctx := startSpanFromContext(ctx, info.FullMethod, cfg.serviceName)
 		resp, err := handler(ctx, req)
@@ -41,7 +40,7 @@ func startSpanFromContext(ctx context.Context, method, service string) (ddtrace.
 		tracer.ServiceName(service),
 		tracer.ResourceName(method),
 		tracer.Tag("grpc.method", method),
-		tracer.SpanType("go"),
+		tracer.SpanType(ext.AppTypeRPC),
 	}
 	md, _ := metadata.FromIncomingContext(ctx) // nil is ok
 	if sctx, err := tracer.Extract(grpcutil.MDCarrier(md)); err == nil {
@@ -60,13 +59,15 @@ func UnaryClientInterceptor(opts ...InterceptorOption) grpc.UnaryClientIntercept
 	if cfg.serviceName == "" {
 		cfg.serviceName = "grpc.client"
 	}
-	tracer.SetServiceInfo(cfg.serviceName, "grpc-client", ext.AppTypeRPC)
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		var (
 			span ddtrace.Span
 			p    peer.Peer
 		)
-		span, ctx = tracer.StartSpanFromContext(ctx, "grpc.client", tracer.Tag("grpc.method", method))
+		span, ctx = tracer.StartSpanFromContext(ctx, "grpc.client",
+			tracer.Tag("grpc.method", method),
+			tracer.SpanType(ext.AppTypeRPC),
+		)
 		md, ok := metadata.FromIncomingContext(ctx)
 		if !ok {
 			md = metadata.MD{}

--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -131,7 +131,7 @@ func TestPass(t *testing.T) {
 	assert.Equal(s.OperationName(), "grpc.server")
 	assert.Equal(s.Tag(ext.ServiceName), "grpc")
 	assert.Equal(s.Tag(ext.ResourceName), "/grpc.Fixture/Ping")
-	assert.Equal(s.Tag(ext.SpanType), "go")
+	assert.Equal(s.Tag(ext.SpanType), ext.AppTypeRPC)
 	assert.True(s.FinishTime().Sub(s.StartTime()) > 0)
 }
 

--- a/contrib/gorilla/mux/mux.go
+++ b/contrib/gorilla/mux/mux.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 
 	"gopkg.in/DataDog/dd-trace-go.v0/contrib/internal/httputil"
-	"gopkg.in/DataDog/dd-trace-go.v0/ddtrace/ext"
-	"gopkg.in/DataDog/dd-trace-go.v0/ddtrace/tracer"
 
 	"github.com/gorilla/mux"
 )
@@ -24,7 +22,6 @@ func NewRouter(opts ...RouterOption) *Router {
 	for _, fn := range opts {
 		fn(cfg)
 	}
-	tracer.SetServiceInfo(cfg.serviceName, "gorilla/mux", ext.AppTypeWeb)
 	return &Router{
 		Router: mux.NewRouter(),
 		config: cfg,

--- a/contrib/internal/httputil/trace.go
+++ b/contrib/internal/httputil/trace.go
@@ -13,7 +13,7 @@ import (
 // TraceAndServe will apply tracing to the given http.Handler using the passed tracer under the given service and resource.
 func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, service, resource string) {
 	span, ctx := tracer.StartSpanFromContext(r.Context(), "http.request",
-		tracer.SpanType(ext.HTTPType),
+		tracer.SpanType(ext.AppTypeWeb),
 		tracer.ServiceName(service),
 		tracer.ResourceName(resource),
 		tracer.Tag(ext.HTTPMethod, r.Method),

--- a/contrib/jmoiron/sqlx/sql_test.go
+++ b/contrib/jmoiron/sqlx/sql_test.go
@@ -36,7 +36,7 @@ func TestMySQL(t *testing.T) {
 		ExpectName: "mysql.query",
 		ExpectTags: map[string]interface{}{
 			ext.ServiceName: "mysql-test",
-			ext.SpanType:    ext.SQLType,
+			ext.SpanType:    ext.AppTypeDB,
 			ext.TargetHost:  "127.0.0.1",
 			ext.TargetPort:  "3306",
 			"db.user":       "test",
@@ -61,7 +61,7 @@ func TestPostgres(t *testing.T) {
 		ExpectName: "postgres.query",
 		ExpectTags: map[string]interface{}{
 			ext.ServiceName: "postgres.db",
-			ext.SpanType:    ext.SQLType,
+			ext.SpanType:    ext.AppTypeDB,
 			ext.TargetHost:  "127.0.0.1",
 			ext.TargetPort:  "5432",
 			"db.user":       "postgres",

--- a/contrib/julienschmidt/httprouter/httprouter.go
+++ b/contrib/julienschmidt/httprouter/httprouter.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 
 	"gopkg.in/DataDog/dd-trace-go.v0/contrib/internal/httputil"
-	"gopkg.in/DataDog/dd-trace-go.v0/ddtrace/ext"
-	"gopkg.in/DataDog/dd-trace-go.v0/ddtrace/tracer"
 
 	"github.com/julienschmidt/httprouter"
 )
@@ -25,7 +23,6 @@ func New(opts ...RouterOption) *Router {
 	for _, fn := range opts {
 		fn(cfg)
 	}
-	tracer.SetServiceInfo(cfg.serviceName, "julienschmidt/httprouter", ext.AppTypeWeb)
 	return &Router{httprouter.New(), cfg}
 }
 

--- a/contrib/net/http/http.go
+++ b/contrib/net/http/http.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 
 	"gopkg.in/DataDog/dd-trace-go.v0/contrib/internal/httputil"
-	"gopkg.in/DataDog/dd-trace-go.v0/ddtrace/ext"
-	"gopkg.in/DataDog/dd-trace-go.v0/ddtrace/tracer"
 )
 
 // ServeMux is an HTTP request multiplexer that traces all the incoming requests.
@@ -23,7 +21,6 @@ func NewServeMux(opts ...MuxOption) *ServeMux {
 	for _, fn := range opts {
 		fn(cfg)
 	}
-	tracer.SetServiceInfo(cfg.serviceName, "net/http", ext.AppTypeWeb)
 	return &ServeMux{
 		ServeMux: http.NewServeMux(),
 		config:   cfg,

--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -8,9 +8,6 @@ type Tracer interface {
 	// StartSpan starts a span with the given operation name and options.
 	StartSpan(operationName string, opts ...StartSpanOption) Span
 
-	// SetServiceInfo sets information about the service with the given name.
-	SetServiceInfo(name, app, appType string)
-
 	// Extract extracts a span context from a given carrier. Note that baggage item
 	// keys will always be lower-cased to maintain consistency. It is impossible to
 	// maintain the original casing due to MIME header canonicalization standards.

--- a/ddtrace/ext/cassandra.go
+++ b/ddtrace/ext/cassandra.go
@@ -1,9 +1,6 @@
 package ext
 
 const (
-	// CassandraType is the type used to identify Cassandra spans.
-	CassandraType = "cassandra"
-
 	// CassandraQuery is the tag name used for cassandra queries.
 	CassandraQuery = "cassandra.query"
 

--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -16,9 +16,6 @@ const (
 	// SQLQuery sets the sql query tag on a span.
 	SQLQuery = "sql.query"
 
-	// HTTPType sets the http type tag.
-	HTTPType = "http"
-
 	// HTTPMethod specifies the HTTP method used in a span.
 	HTTPMethod = "http.method"
 

--- a/ddtrace/mocktracer/mockspan_test.go
+++ b/ddtrace/mocktracer/mockspan_test.go
@@ -31,7 +31,7 @@ func TestNewSpan(t *testing.T) {
 	})
 
 	t.Run("options", func(t *testing.T) {
-		tr := &mocktracer{services: map[string]*service{"A": &service{"A", "B", "C"}}}
+		tr := new(mocktracer)
 		startTime := time.Now()
 		tags := map[string]interface{}{"k": "v", "k1": "v1"}
 		opts := &ddtrace.StartSpanConfig{

--- a/ddtrace/mocktracer/mocktracer.go
+++ b/ddtrace/mocktracer/mocktracer.go
@@ -38,12 +38,9 @@ func Start() Tracer {
 	return &t
 }
 
-type service struct{ name, app, appType string }
-
 type mocktracer struct {
 	sync.RWMutex  // guards below spans
 	finishedSpans []Span
-	services      map[string]*service
 }
 
 // Stop deactivates the mock tracer and sets the active tracer to a no-op.
@@ -70,7 +67,6 @@ func (t *mocktracer) Reset() {
 	t.Lock()
 	defer t.Unlock()
 	t.finishedSpans = nil
-	t.services = nil
 }
 
 func (t *mocktracer) addFinishedSpan(s Span) {
@@ -80,15 +76,6 @@ func (t *mocktracer) addFinishedSpan(s Span) {
 		t.finishedSpans = make([]Span, 0, 1)
 	}
 	t.finishedSpans = append(t.finishedSpans, s)
-}
-
-func (t *mocktracer) SetServiceInfo(name, app, appType string) {
-	t.Lock()
-	defer t.Unlock()
-	if t.services == nil {
-		t.services = make(map[string]*service, 1)
-	}
-	t.services[name] = &service{name, app, appType}
 }
 
 const (

--- a/ddtrace/mocktracer/mocktracer_test.go
+++ b/ddtrace/mocktracer/mocktracer_test.go
@@ -83,24 +83,15 @@ func TestTracerFinishedSpans(t *testing.T) {
 	assert.Equal(t, 2, found)
 }
 
-func TestTracerSetServiceInfo(t *testing.T) {
-	var mt mocktracer
-	mt.SetServiceInfo("a", "b", "c")
-	assert.Equal(t, map[string]*service{"a": &service{"a", "b", "c"}}, mt.services)
-}
-
 func TestTracerReset(t *testing.T) {
 	var mt mocktracer
 	mt.StartSpan("db.query").Finish()
-	mt.SetServiceInfo("a", "b", "c")
 
 	assert := assert.New(t)
-	assert.Equal(map[string]*service{"a": &service{"a", "b", "c"}}, mt.services)
 	assert.Len(mt.finishedSpans, 1)
 
 	mt.Reset()
 
-	assert.Nil(mt.services)
 	assert.Nil(mt.finishedSpans)
 }
 

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -43,13 +43,6 @@ func getTestTrace(traceN, size int) [][]*span {
 	return traces
 }
 
-func getTestServices() map[string]service {
-	return map[string]service{
-		"svc1": service{Name: "scv1", App: "a", AppType: "b"},
-		"svc2": service{Name: "scv2", App: "c", AppType: "d"},
-	}
-}
-
 type mockDatadogAPIHandler struct {
 	t *testing.T
 }
@@ -112,41 +105,6 @@ func TestEncoderDowngrade(t *testing.T) {
 	// if we get a 415 because of a wrong encoder, we should downgrade the encoder
 	traces := getTestTrace(2, 2)
 	response, err := transport.sendTraces(traces)
-	assert.NoError(err)
-	assert.NotNil(response)
-	assert.Equal(200, response.StatusCode)
-}
-
-func TestTransportServices(t *testing.T) {
-	assert := assert.New(t)
-
-	transport := newHTTPTransport(defaultAddress)
-
-	response, err := transport.sendServices(getTestServices())
-	assert.NoError(err)
-	assert.NotNil(response)
-	assert.Equal(200, response.StatusCode)
-}
-
-func TestTransportServicesDowngrade_0_0(t *testing.T) {
-	assert := assert.New(t)
-
-	transport := newHTTPTransport(defaultAddress)
-	transport.serviceURL = "http://localhost:8126/v0.0/services"
-
-	response, err := transport.sendServices(getTestServices())
-	assert.NoError(err)
-	assert.NotNil(response)
-	assert.Equal(200, response.StatusCode)
-}
-
-func TestTransportServicesDowngrade_0_2(t *testing.T) {
-	assert := assert.New(t)
-
-	transport := newHTTPTransport(defaultAddress)
-	transport.serviceURL = "http://localhost:8126/v0.2/services"
-
-	response, err := transport.sendServices(getTestServices())
 	assert.NoError(err)
 	assert.NotNil(response)
 	assert.Equal(200, response.StatusCode)


### PR DESCRIPTION
The more recent versions of the agent support this by inferring it from the top-level span's type. We can remove it from our API. It was a hindrance creating problems with OpenTracing integrations, as well as confusion among users and potential race conditions between setting it in parallel with integrations.