### PR TITLE
ddtrace/tracer: prevent deadlocks

### DIFF
--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -48,6 +48,20 @@ func TestTracerStart(t *testing.T) {
 		}
 		internal.Testing = false
 	})
+
+	t.Run("deadlock", func(t *testing.T) {
+		Stop()
+		Stop()
+
+		Start()
+		Start()
+		Start()
+
+		Stop()
+		Stop()
+		Stop()
+		Stop()
+	})
 }
 
 func TestTracerStartSpan(t *testing.T) {


### PR DESCRIPTION
This allows Start and Stop to be called safely multiple times, without
starting a new tracer on each call. It also ensure Stop can be called
multiple times without causing a deadlock due to sending on a channel
where no one is listening (e.g. worked is not running).