### PR TITLE
contrib/olivere/elastic: remove max condition on peek function

### DIFF
--- a/contrib/olivere/elastic/elastictrace.go
+++ b/contrib/olivere/elastic/elastictrace.go
@@ -94,7 +94,7 @@ func quantize(url, method string) string {
 // of the stream contained in the reader. If unknown, it should be -1. If 0 < max < n it
 // will override n.
 func peek(rc io.ReadCloser, max int, n int) (string, io.ReadCloser, error) {
-	if rc == nil || max == 0 {
+	if rc == nil {
 		return "", rc, errors.New("empty stream")
 	}
 	if max > 0 && max < n {

--- a/contrib/olivere/elastic/elastictrace_test.go
+++ b/contrib/olivere/elastic/elastictrace_test.go
@@ -299,9 +299,10 @@ func TestPeek(t *testing.T) {
 			snip: "AB",
 		},
 		4: {
-			txt: "ABCDEFG",
-			max: 0,
-			err: errors.New("empty stream"),
+			txt:  "ABCDEFG",
+			max:  0,
+			n:    1,
+			snip: "A",
 		},
 		5: {
 			n:   4,


### PR DESCRIPTION
As per the official documentation for (http.Request).ContentLength:

> For client requests, a value of 0 with a non-nil Body is also treated as unknown.

For this reason, it was an error to have it here and was stopping the
body to be recorded in cases where the length was unknown.