### PR TITLE
ddtrace: remove possibility of chaining

### DIFF
--- a/contrib/garyburd/redigo/redigo.go
+++ b/contrib/garyburd/redigo/redigo.go
@@ -95,10 +95,10 @@ func (tc Conn) newChildSpan(ctx context.Context) ddtrace.Span {
 		tracer.SpanType(ext.AppTypeDB),
 		tracer.ServiceName(p.config.serviceName),
 	)
-	return span.
-		SetTag("out.network", p.network).
-		SetTag(ext.TargetPort, p.port).
-		SetTag(ext.TargetHost, p.host)
+	span.SetTag("out.network", p.network)
+	span.SetTag(ext.TargetPort, p.port)
+	span.SetTag(ext.TargetHost, p.host)
+	return span
 }
 
 // Do wraps redis.Conn.Do. It sends a command to the Redis server and returns the received reply.

--- a/contrib/go-redis/redis/redis.go
+++ b/contrib/go-redis/redis/redis.go
@@ -91,10 +91,9 @@ func (c *Pipeliner) execWithContext(ctx context.Context) ([]redis.Cmder, error) 
 		tracer.Tag("out.db", p.db),
 	)
 	cmds, err := c.Pipeliner.Exec()
-	span.
-		SetTag(ext.ResourceName, commandsToString(cmds)).
-		SetTag("redis.pipeline_length", strconv.Itoa(len(cmds))).
-		Finish(tracer.WithError(err))
+	span.SetTag(ext.ResourceName, commandsToString(cmds))
+	span.SetTag("redis.pipeline_length", strconv.Itoa(len(cmds)))
+	span.Finish(tracer.WithError(err))
 
 	return cmds, err
 }

--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -23,17 +23,17 @@ type Tracer interface {
 // Span represents a computation.
 type Span interface {
 	// SetTag sets a given tag on the span.
-	SetTag(key string, value interface{}) Span
+	SetTag(key string, value interface{})
 
 	// SetOperationName resets the original operation name to the given one.
-	SetOperationName(operationName string) Span
+	SetOperationName(operationName string)
 
 	// BaggageItem returns the baggage item with the given key.
 	BaggageItem(key string) string
 
 	// SetBaggageItem sets a new baggage item at the given key. The baggage
 	// item should propagate to all descendant spans, both in- and cross-process.
-	SetBaggageItem(key, val string) Span
+	SetBaggageItem(key, val string)
 
 	// Finish finishes the current span with the given options.
 	Finish(opts ...FinishOption)

--- a/ddtrace/internal/globaltracer.go
+++ b/ddtrace/internal/globaltracer.go
@@ -40,16 +40,16 @@ var _ ddtrace.Span = (*NoopSpan)(nil)
 type NoopSpan struct{}
 
 // SetTag implements ddtrace.Span.
-func (NoopSpan) SetTag(key string, value interface{}) ddtrace.Span { return NoopSpan{} }
+func (NoopSpan) SetTag(key string, value interface{}) {}
 
 // SetOperationName implements ddtrace.Span.
-func (NoopSpan) SetOperationName(operationName string) ddtrace.Span { return NoopSpan{} }
+func (NoopSpan) SetOperationName(operationName string) {}
 
 // BaggageItem implements ddtrace.Span.
 func (NoopSpan) BaggageItem(key string) string { return "" }
 
 // SetBaggageItem implements ddtrace.Span.
-func (NoopSpan) SetBaggageItem(key, val string) ddtrace.Span { return NoopSpan{} }
+func (NoopSpan) SetBaggageItem(key, val string) {}
 
 // Finish implements ddtrace.Span.
 func (NoopSpan) Finish(opts ...ddtrace.FinishOption) {}

--- a/ddtrace/mocktracer/mockspan.go
+++ b/ddtrace/mocktracer/mockspan.go
@@ -89,14 +89,14 @@ type mockspan struct {
 }
 
 // SetTag sets a given tag on the span.
-func (s *mockspan) SetTag(key string, value interface{}) ddtrace.Span {
+func (s *mockspan) SetTag(key string, value interface{}) {
 	s.Lock()
 	defer s.Unlock()
 	if s.tags == nil {
 		s.tags = make(map[string]interface{}, 1)
 	}
 	s.tags[key] = value
-	return s
+	return
 }
 
 func (s *mockspan) FinishTime() time.Time {
@@ -137,11 +137,11 @@ func (s *mockspan) OperationName() string {
 }
 
 // SetOperationName resets the original operation name to the given one.
-func (s *mockspan) SetOperationName(operationName string) ddtrace.Span {
+func (s *mockspan) SetOperationName(operationName string) {
 	s.Lock()
 	defer s.Unlock()
 	s.name = operationName
-	return s
+	return
 }
 
 // BaggageItem returns the baggage item with the given key.
@@ -151,9 +151,9 @@ func (s *mockspan) BaggageItem(key string) string {
 
 // SetBaggageItem sets a new baggage item at the given key. The baggage
 // item should propagate to all descendant spans, both in- and cross-process.
-func (s *mockspan) SetBaggageItem(key, val string) ddtrace.Span {
+func (s *mockspan) SetBaggageItem(key, val string) {
 	s.context.setBaggageItem(key, val)
-	return s
+	return
 }
 
 // Finish finishes the current span with the given options.

--- a/ddtrace/mocktracer/mockspan_test.go
+++ b/ddtrace/mocktracer/mockspan_test.go
@@ -63,9 +63,8 @@ func TestNewSpan(t *testing.T) {
 
 func TestSpanSetTag(t *testing.T) {
 	s := basicSpan("http.request")
-	s.
-		SetTag("a", "b").
-		SetTag("c", "d")
+	s.SetTag("a", "b")
+	s.SetTag("c", "d")
 
 	assert := assert.New(t)
 	assert.Len(s.Tags(), 3)

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -116,7 +116,8 @@ func TestTextMapPropagatorInjectHeader(t *testing.T) {
 	propagator := NewPropagator("bg-", "tid", "pid")
 	tracer := newTracer(WithPropagator(propagator))
 
-	root := tracer.StartSpan("web.request").SetBaggageItem("item", "x").(*span)
+	root := tracer.StartSpan("web.request").(*span)
+	root.SetBaggageItem("item", "x")
 	ctx := root.Context()
 	headers := http.Header{}
 
@@ -135,7 +136,8 @@ func TestTextMapPropagatorInjectHeader(t *testing.T) {
 func TestTextMapPropagatorInjectExtract(t *testing.T) {
 	propagator := NewPropagator("bg-", "tid", "pid")
 	tracer := newTracer(WithPropagator(propagator))
-	root := tracer.StartSpan("web.request").SetBaggageItem("item", "x").(*span)
+	root := tracer.StartSpan("web.request").(*span)
+	root.SetBaggageItem("item", "x")
 	ctx := root.Context().(*spanContext)
 	headers := TextMapCarrier(map[string]string{})
 	err := tracer.Inject(ctx, headers)


### PR DESCRIPTION
This change removes the possibility of misusing the API in multiple ways by chaining calls. It is a result of feedback from various teams going through the migration process.

Before, it was possible to do:
```go
span.SetTag("A", "B").
    SetTag("C", "D").
    SetTag("E", "F")
```
Now, the only possibility remains:
```go
span.SetTag("A", "B")
span.SetTag("C", "D")
span.SetTag("E", "F")
```
We should have only one way to do the same thing.