### PR TITLE
ddtrace/opentracer: s/Start/New and return tracer

### DIFF
--- a/ddtrace/opentracer/tracer.go
+++ b/ddtrace/opentracer/tracer.go
@@ -8,15 +8,11 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
-// Start starts the tracer using the given options and registers it as the global
-// opentracing tracer using opentracing.SetGlobalTracer. After calling Start, you
-// may use the opentracing API as usual. Using this API in parallel with the tracer
-// API is fully supported as both implementations are using the same tracer under
-// the hood.
-func Start(opts ...tracer.StartOption) {
+// New creates, instantiates and returns an Opentracing compatible version of the
+// Datadog tracer using the provided set of options.
+func New(opts ...tracer.StartOption) opentracing.Tracer {
 	tracer.Start(opts...)
-	t := &opentracer{internal.GlobalTracer}
-	opentracing.SetGlobalTracer(t)
+	return &opentracer{internal.GlobalTracer}
 }
 
 var _ opentracing.Tracer = (*opentracer)(nil)

--- a/ddtrace/opentracer/tracer_test.go
+++ b/ddtrace/opentracer/tracer_test.go
@@ -6,16 +6,15 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
 
-	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestStart(t *testing.T) {
 	assert := assert.New(t)
-	Start()
+	ot := New()
 	dd, ok := internal.GlobalTracer.(ddtrace.Tracer)
 	assert.True(ok)
-	ot, ok := opentracing.GlobalTracer().(*opentracer)
+	ott, ok := ot.(*opentracer)
 	assert.True(ok)
-	assert.Equal(ot.Tracer, dd)
+	assert.Equal(ott.Tracer, dd)
 }


### PR DESCRIPTION
This change alters the instantiation of the Opentracing method to one
that is more in line with other implementations in the wild, meaning
that now the call is named `New` and it returns the
`opentracing.Tracer` which can be used with
`opentracing.SetGlobalTracer` as per the official documentation.

This is more useful when using libraries such as `opentracing-contrib`
where the tracer is needed, and could potentially reduce some calls to
`opentracing.GlobalTracer`.