### PR TITLE
ddtrace/tracer: prevent trace from acknowledging more spans after cap is reached

### DIFF
--- a/ddtrace/tracer/errors.go
+++ b/ddtrace/tracer/errors.go
@@ -14,10 +14,10 @@ func (e *traceEncodingError) Error() string {
 	return fmt.Sprintf("error encoding trace: %s", e.context)
 }
 
-type spanBufferFullError struct{ count int }
+type spanBufferFullError struct{}
 
 func (e *spanBufferFullError) Error() string {
-	return fmt.Sprintf("span buffer full, lost %d spans", e.count)
+	return fmt.Sprintf("trace span cap (%d) reached, dropping trace", traceMaxSize)
 }
 
 type dataLossError struct {

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -90,6 +90,7 @@ type trace struct {
 	mu       sync.RWMutex // guards below fields
 	spans    []*span      // all the spans that are part of this trace
 	finished int          // the number of finished spans
+	full     bool         // signifies that the span buffer is full
 }
 
 var (
@@ -116,11 +117,16 @@ func newTrace() *trace {
 func (t *trace) push(sp *span) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-
+	if t.full {
+		return
+	}
 	if len(t.spans) >= traceMaxSize {
+		// capacity is reached, we will not be able to complete this trace.
+		t.full = true
+		t.spans = nil // GC
 		if tr, ok := internal.GetGlobalTracer().(*tracer); ok {
 			// we have a tracer we can submit errors too.
-			tr.pushError(&spanBufferFullError{count: len(t.spans)})
+			tr.pushError(&spanBufferFullError{})
 		}
 		return
 	}
@@ -132,7 +138,13 @@ func (t *trace) push(sp *span) {
 func (t *trace) ackFinish() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-
+	if t.full {
+		// capacity has been reached, the buffer is no longer tracking
+		// all the spans in the trace, so the below conditions will not
+		// be accurate and would trigger a pre-mature flush, exposing us
+		// to a race condition where spans can be modified while flushing.
+		return
+	}
 	t.finished++
 	if len(t.spans) != t.finished {
 		return

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -33,7 +33,7 @@ func TestNewSpanContextPushError(t *testing.T) {
 
 	select {
 	case err := <-tracer.errorBuffer:
-		assert.Equal(t, &spanBufferFullError{count: 2}, err)
+		assert.Equal(t, &spanBufferFullError{}, err)
 	default:
 		t.Fatal("no error pushed")
 	}
@@ -211,7 +211,7 @@ func TestSpanContextPushFull(t *testing.T) {
 	buffer.push(span3)
 	assert.Len(tracer.errorBuffer, 1)
 	err := <-tracer.errorBuffer
-	assert.Equal(&spanBufferFullError{count: 2}, err)
+	assert.Equal(&spanBufferFullError{}, err)
 }
 
 func TestSpanContextBaggage(t *testing.T) {


### PR DESCRIPTION
This change ensures that once the span buffer reaches capacity, we will
not be handling nor flushing the trace anymore since we can no longer
keep track of the spans that are part of it. Otherwise, the flush
condition is met prematurely when not all spans in the buffer are
completed and we are open for a race condition: modifying a span while
flushing.