### PR TITLE
Bump tracer version

### DIFF
--- a/tracer/ext/tracer.go
+++ b/tracer/ext/tracer.go
@@ -8,7 +8,7 @@ import (
 const (
 	Lang          = "go"
 	Interpreter   = runtime.Compiler + "-" + runtime.GOARCH + "-" + runtime.GOOS
-	TracerVersion = "v0.5.0"
+	TracerVersion = "v0.6.1"
 )
 
 var LangVersion = strings.TrimPrefix(runtime.Version(), Lang)


### PR DESCRIPTION
Bump to 0.6.1. It has no effect as this isn't the released tag.
We should bump it every time, right before a release.