### PR TITLE
ddtrace/tracer: improve SpanFromContext API

### DIFF
--- a/contrib/gin-gonic/gin/gintrace_test.go
+++ b/contrib/gin-gonic/gin/gintrace_test.go
@@ -26,8 +26,8 @@ func TestChildSpan(t *testing.T) {
 	router := gin.New()
 	router.Use(Middleware("foobar"))
 	router.GET("/user/:id", func(c *gin.Context) {
-		span := tracer.SpanFromContext(c.Request.Context())
-		assert.NotNil(span)
+		_, ok := tracer.SpanFromContext(c.Request.Context())
+		assert.True(ok)
 	})
 
 	r := httptest.NewRequest("GET", "/user/123", nil)
@@ -44,8 +44,8 @@ func TestTrace200(t *testing.T) {
 	router := gin.New()
 	router.Use(Middleware("foobar"))
 	router.GET("/user/:id", func(c *gin.Context) {
-		span := tracer.SpanFromContext(c.Request.Context())
-		assert.NotNil(span)
+		span, ok := tracer.SpanFromContext(c.Request.Context())
+		assert.True(ok)
 		assert.Equal(span.(mocktracer.Span).Tag(ext.ServiceName), "foobar")
 		id := c.Param("id")
 		c.Writer.Write([]byte(id))
@@ -157,7 +157,8 @@ func TestGetSpanNotInstrumented(t *testing.T) {
 	router := gin.New()
 	router.GET("/ping", func(c *gin.Context) {
 		// Assert we don't have a span on the context.
-		assert.Nil(tracer.SpanFromContext(c.Request.Context()))
+		_, ok := tracer.SpanFromContext(c.Request.Context())
+		assert.False(ok)
 		c.Writer.Write([]byte("ok"))
 	})
 	r := httptest.NewRequest("GET", "/ping", nil)

--- a/contrib/google.golang.org/grpc.v12/grpc_test.go
+++ b/contrib/google.golang.org/grpc.v12/grpc_test.go
@@ -145,7 +145,7 @@ func (s *fixtureServer) Ping(ctx context.Context, in *FixtureRequest) (*FixtureR
 		span.Finish()
 		return &FixtureReply{Message: "child"}, nil
 	case in.Name == "disabled":
-		if tracer.SpanFromContext(ctx) != nil {
+		if _, ok := tracer.SpanFromContext(ctx); ok {
 			panic("should be disabled")
 		}
 		return &FixtureReply{Message: "disabled"}, nil

--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -145,7 +145,7 @@ func (s *fixtureServer) Ping(ctx context.Context, in *FixtureRequest) (*FixtureR
 		span.Finish()
 		return &FixtureReply{Message: "child"}, nil
 	case in.Name == "disabled":
-		if tracer.SpanFromContext(ctx) != nil {
+		if _, ok := tracer.SpanFromContext(ctx); ok {
 			panic("should be disabled")
 		}
 		return &FixtureReply{Message: "disabled"}, nil

--- a/ddtrace/tracer/context.go
+++ b/ddtrace/tracer/context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
 )
 
 type contextKey struct{}
@@ -15,23 +16,24 @@ func ContextWithSpan(ctx context.Context, s Span) context.Context {
 	return context.WithValue(ctx, activeSpanKey, s)
 }
 
-// SpanFromContext returns the span contained in the given context. If no span is
-// found, it returns nil.
-func SpanFromContext(ctx context.Context) Span {
+// SpanFromContext returns the span contained in the given context. A second return
+// value indicates if a span was found in the context. If no span is found, a no-op
+// span is returned.
+func SpanFromContext(ctx context.Context) (Span, bool) {
 	if ctx == nil {
-		return nil
+		return &internal.NoopSpan{}, false
 	}
 	v := ctx.Value(activeSpanKey)
 	if s, ok := v.(ddtrace.Span); ok {
-		return s
+		return s, true
 	}
-	return nil
+	return &internal.NoopSpan{}, false
 }
 
 // StartSpanFromContext returns a new span with the given operation name and options. If a span
 // is found in the context, it will be used as the parent of the resulting span.
 func StartSpanFromContext(ctx context.Context, operationName string, opts ...StartSpanOption) (Span, context.Context) {
-	if s := SpanFromContext(ctx); s != nil {
+	if s, ok := SpanFromContext(ctx); ok {
 		opts = append(opts, ChildOf(s.Context()))
 	}
 	s := StartSpan(operationName, opts...)


### PR DESCRIPTION
This change provides for a safer API to SpanFromContext which assures
that the value `nil` is not returned anymore. This was confusing
and could potentially crash an app where one would attempt to call
methods on the span without formerly checking its non-nil value.

Now, when a span is not found, the second return value will be `false`
and the returned span will be a no-op, allowing users to call methods on
it without having to explicitly check that the span was found in the
context, if there is no interest to, while at the same time providing
the option to do so.