### PR TITLE
contrib/gorilla/mux: empty route bug fixed

### DIFF
--- a/contrib/gorilla/mux/mux.go
+++ b/contrib/gorilla/mux/mux.go
@@ -40,8 +40,12 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	)
 	// get the resource associated to this request
 	if r.Match(req, &match) {
-		route, err = match.Route.GetPathTemplate()
-		if err != nil {
+		if match.Route != nil {
+			route, err = match.Route.GetPathTemplate()
+			if err != nil {
+				route = "unknown"
+			}
+		} else {
 			route = "unknown"
 		}
 	} else {

--- a/contrib/gorilla/mux/mux.go
+++ b/contrib/gorilla/mux/mux.go
@@ -39,8 +39,8 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	)
 	// get the resource associated to this request
 	if r.Match(req, &match) && match.Route != nil {
-		if routeTmp, err := match.Route.GetPathTemplate(); err == nil {
-			route = routeTmp
+		if r, err := match.Route.GetPathTemplate(); err == nil {
+			route = r
 		}
 	}
 	resource := req.Method + " " + route

--- a/contrib/gorilla/mux/mux.go
+++ b/contrib/gorilla/mux/mux.go
@@ -35,21 +35,13 @@ func NewRouter(opts ...RouterOption) *Router {
 func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	var (
 		match mux.RouteMatch
-		route string
-		err   error
+		route = "unknown"
 	)
 	// get the resource associated to this request
-	if r.Match(req, &match) {
-		if match.Route != nil {
-			route, err = match.Route.GetPathTemplate()
-			if err != nil {
-				route = "unknown"
-			}
-		} else {
-			route = "unknown"
+	if r.Match(req, &match) && match.Route != nil {
+		if routeTmp, err := match.Route.GetPathTemplate(); err == nil {
+			route = routeTmp
 		}
-	} else {
-		route = "unknown"
 	}
 	resource := req.Method + " " + route
 	httputil.TraceAndServe(r.Router, w, req, r.config.serviceName, resource)

--- a/contrib/gorilla/mux/mux_test.go
+++ b/contrib/gorilla/mux/mux_test.go
@@ -21,12 +21,29 @@ func TestHttpTracer(t *testing.T) {
 		resourceName string
 		errorStr     string
 	}{
-		{http.StatusOK, "GET", "/200", "GET /200", ""},
-		{http.StatusNotFound, "GET", "/not_a_real_route", "GET unknown", ""},
-		{http.StatusMethodNotAllowed, "POST", "/405", "POST unknown", ""},
-		{http.StatusInternalServerError, "GET", "/500", "GET /500", "500: Internal Server Error"},
+		{
+			code:         http.StatusOK,
+			method:       "GET",
+			url:          "/200",
+			resourceName: "GET /200"},
+		{
+			code:         http.StatusNotFound,
+			method:       "GET",
+			url:          "/not_a_real_route",
+			resourceName: "GET unknown"},
+		{
+			code:         http.StatusMethodNotAllowed,
+			method:       "POST",
+			url:          "/405",
+			resourceName: "POST unknown"},
+		{
+			code:         http.StatusInternalServerError,
+			method:       "GET",
+			url:          "/500",
+			resourceName: "GET /500",
+			errorStr:     "500: Internal Server Error"},
 	} {
-		t.Run(ht.method+ht.url, func(t *testing.T) {
+		t.Run(http.StatusText(ht.code), func(t *testing.T) {
 			assert := assert.New(t)
 			mt := mocktracer.Start()
 			defer mt.Stop()

--- a/contrib/gorilla/mux/mux_test.go
+++ b/contrib/gorilla/mux/mux_test.go
@@ -38,6 +38,56 @@ func TestHttpTracer200(t *testing.T) {
 	assert.Equal(nil, s.Tag(ext.Error))
 }
 
+func TestHttpTracer404(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	// Send and verify a 500 request
+	url := "/not_a_real_route"
+	r := httptest.NewRequest("GET", url, nil)
+	w := httptest.NewRecorder()
+	router().ServeHTTP(w, r)
+	assert.Equal(404, w.Code)
+	assert.Equal("404!\n", w.Body.String())
+
+	spans := mt.FinishedSpans()
+	assert.Equal(1, len(spans))
+
+	s := spans[0]
+	assert.Equal("http.request", s.OperationName())
+	assert.Equal("my-service", s.Tag(ext.ServiceName))
+	assert.Equal("GET unknown", s.Tag(ext.ResourceName))
+	assert.Equal("404", s.Tag(ext.HTTPCode))
+	assert.Equal("GET", s.Tag(ext.HTTPMethod))
+	assert.Equal(url, s.Tag(ext.HTTPURL))
+}
+
+func TestHttpTracer405(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	// Send and verify a 500 request
+	url := "/method"
+	r := httptest.NewRequest("POST", url, nil)
+	w := httptest.NewRecorder()
+	router().ServeHTTP(w, r)
+	assert.Equal(405, w.Code)
+	assert.Equal("405!\n", w.Body.String())
+
+	spans := mt.FinishedSpans()
+	assert.Equal(1, len(spans))
+
+	s := spans[0]
+	assert.Equal("http.request", s.OperationName())
+	assert.Equal("my-service", s.Tag(ext.ServiceName))
+	assert.Equal("POST unknown", s.Tag(ext.ResourceName))
+	assert.Equal("405", s.Tag(ext.HTTPCode))
+	assert.Equal("POST", s.Tag(ext.HTTPMethod))
+	assert.Equal(url, s.Tag(ext.HTTPURL))
+}
+
 func TestHttpTracer500(t *testing.T) {
 	assert := assert.New(t)
 	mt := mocktracer.Start()
@@ -68,11 +118,26 @@ func router() http.Handler {
 	mux := NewRouter(WithServiceName("my-service"))
 	mux.HandleFunc("/200", handler200)
 	mux.HandleFunc("/500", handler500)
+	mux.HandleFunc("/method", handler200).Methods("GET")
+	mux.NotFoundHandler = get404Handler()
+	mux.MethodNotAllowedHandler = get405Handler()
 	return mux
 }
 
 func handler200(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("OK\n"))
+}
+
+func get404Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "404!", http.StatusNotFound)
+	})
+}
+
+func get405Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "405!", http.StatusMethodNotAllowed)
+	})
 }
 
 func handler500(w http.ResponseWriter, r *http.Request) {

--- a/contrib/gorilla/mux/mux_test.go
+++ b/contrib/gorilla/mux/mux_test.go
@@ -32,7 +32,7 @@ func TestHttpTracer(t *testing.T) {
 			defer mt.Stop()
 			responseCodeStr := strconv.Itoa(ht.responseCode)
 
-			// Send and verify a 500 request
+			// Send and verify a request
 			r := httptest.NewRequest(ht.httpMethod, ht.url, nil)
 			w := httptest.NewRecorder()
 			router().ServeHTTP(w, r)

--- a/contrib/gorilla/mux/mux_test.go
+++ b/contrib/gorilla/mux/mux_test.go
@@ -25,23 +25,27 @@ func TestHttpTracer(t *testing.T) {
 			code:         http.StatusOK,
 			method:       "GET",
 			url:          "/200",
-			resourceName: "GET /200"},
+			resourceName: "GET /200",
+		},
 		{
 			code:         http.StatusNotFound,
 			method:       "GET",
 			url:          "/not_a_real_route",
-			resourceName: "GET unknown"},
+			resourceName: "GET unknown",
+		},
 		{
 			code:         http.StatusMethodNotAllowed,
 			method:       "POST",
 			url:          "/405",
-			resourceName: "POST unknown"},
+			resourceName: "POST unknown",
+		},
 		{
 			code:         http.StatusInternalServerError,
 			method:       "GET",
 			url:          "/500",
 			resourceName: "GET /500",
-			errorStr:     "500: Internal Server Error"},
+			errorStr:     "500: Internal Server Error",
+		},
 	} {
 		t.Run(http.StatusText(ht.code), func(t *testing.T) {
 			assert := assert.New(t)


### PR DESCRIPTION
This PR fixes a bug reported here: https://github.com/DataDog/dd-trace-go/issues/173

This fixes a `nil pointer dereference` error, that was triggered when the `NotFoundHandler` or the `MethodNotAllowedHandler` were called.