### PR TITLE
contrib/gocql/gocql: add WithResourceName option.

### DIFF
--- a/contrib/gocql/gocql/gocql_test.go
+++ b/contrib/gocql/gocql/gocql_test.go
@@ -53,7 +53,7 @@ func TestErrorWrapper(t *testing.T) {
 	session, err := cluster.CreateSession()
 	assert.Nil(err)
 	q := session.Query("CREATE KEYSPACE trace WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };")
-	err = WrapQuery(q, WithServiceName("ServiceName")).Exec()
+	err = WrapQuery(q, WithServiceName("ServiceName"), WithResourceName("CREATE KEYSPACE")).Exec()
 
 	spans := mt.FinishedSpans()
 	assert.Len(spans, 1)
@@ -61,7 +61,7 @@ func TestErrorWrapper(t *testing.T) {
 
 	assert.Equal(span.Tag(ext.Error).(error), err)
 	assert.Equal(span.OperationName(), ext.CassandraQuery)
-	assert.Equal(span.Tag(ext.ResourceName), "CREATE KEYSPACE trace WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };")
+	assert.Equal(span.Tag(ext.ResourceName), "CREATE KEYSPACE")
 	assert.Equal(span.Tag(ext.ServiceName), "ServiceName")
 	assert.Equal(span.Tag(ext.CassandraConsistencyLevel), "4")
 	assert.Equal(span.Tag(ext.CassandraPaginated), "false")

--- a/contrib/gocql/gocql/option.go
+++ b/contrib/gocql/gocql/option.go
@@ -1,6 +1,6 @@
 package gocql
 
-type queryConfig struct{ serviceName string }
+type queryConfig struct{ serviceName, resourceName string }
 
 // WrapOption represents an option that can be passed to WrapQuery.
 type WrapOption func(*queryConfig)
@@ -13,5 +13,17 @@ func defaults(cfg *queryConfig) {
 func WithServiceName(name string) WrapOption {
 	return func(cfg *queryConfig) {
 		cfg.serviceName = name
+	}
+}
+
+// WithResourceName sets a custom resource name to be used with the traced query.
+// By default, the query statement is extracted automatically. This method should
+// be used when a different resource name is desired or in performance critical
+// environments. The gocql library returns the query statement using an fmt.Sprintf
+// call, which can be costly when called repeatedly. Using WithResourceName will
+// avoid that call. Under normal circumstances, it is safe to rely on the default.
+func WithResourceName(name string) WrapOption {
+	return func(cfg *queryConfig) {
+		cfg.resourceName = name
 	}
 }


### PR DESCRIPTION
Adds `WithResourceName` option to `WrapQuery` to allow specifying the resource name (query statement) in performance-critical environments where repeatedly calling `query.String()` can become costly.