### PR TITLE
ddtrace/tracer: add option to disable stack traces.

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -9,7 +9,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 )
 
-// config holds the tracer configuration.
+// config holds the tracer configuration. It not safe for concurrent use.
 type config struct {
 	// debug, when true, writes details to logs.
 	debug bool
@@ -33,6 +33,9 @@ type config struct {
 
 	// propagator propagates span context cross-process
 	propagator Propagator
+
+	// noErrorStack, when true, will disable automatic error stack generation.
+	noErrorStack bool
 }
 
 // StartOption represents a function that can be provided as a parameter to Start.
@@ -49,6 +52,15 @@ func defaults(c *config) {
 func WithDebugMode(enabled bool) StartOption {
 	return func(c *config) {
 		c.debug = enabled
+	}
+}
+
+// NoErrorStack will disable the automatic generation of error stacks when setting the
+// error tag with a value of type error. However, it will still be possible to attach the
+// error stack manually, if desired, using the "error.stack" tag.
+func NoErrorStack() StartOption {
+	return func(c *config) {
+		c.noErrorStack = true
 	}
 }
 

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -38,6 +38,7 @@ type span struct {
 	// and also, parent == nil is used to identify root and top-level ("local root") spans.
 	parent  *span
 	context *spanContext
+	cfg     *config
 }
 
 // Context yields the SpanContext for this Span. Note that the return
@@ -102,7 +103,12 @@ func (s *span) setTagError(value interface{}) {
 		s.Error = 1
 		s.Meta[ext.ErrorMsg] = v.Error()
 		s.Meta[ext.ErrorType] = reflect.TypeOf(v).String()
-		s.Meta[ext.ErrorStack] = string(debug.Stack())
+		if !s.cfg.noErrorStack {
+			s.Meta[ext.ErrorStack] = string(debug.Stack())
+		}
+	case string:
+		s.Error = 1
+		s.Meta[ext.ErrorMsg] = v
 	case nil:
 		// no error
 		s.Error = 0

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -240,6 +240,7 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		TraceID:  id,
 		ParentID: 0,
 		Start:    startTime,
+		cfg:      t.config,
 	}
 	if context != nil {
 		// this is a child span


### PR DESCRIPTION
In environments where some errors, such as timeout, occur repeatedly,
generating a stack trace could prove to be impactful on performance.
This change adds an option which allows disabling them.