### PR TITLE
ddtrace/mocktracer: use the same propagation headers as the regular tracer.

### DIFF
--- a/ddtrace/mocktracer/mocktracer.go
+++ b/ddtrace/mocktracer/mocktracer.go
@@ -87,10 +87,10 @@ func (t *mocktracer) addFinishedSpan(s Span) {
 }
 
 const (
-	traceHeader    = "x-mock-trace-id"
-	spanHeader     = "x-mock-span-id"
-	priorityHeader = "x-mock-sampling-priority"
-	baggagePrefix  = "x-baggage-"
+	traceHeader    = tracer.DefaultTraceIDHeader
+	spanHeader     = tracer.DefaultParentIDHeader
+	priorityHeader = tracer.DefaultPriorityHeader
+	baggagePrefix  = tracer.DefaultBaggageHeaderPrefix
 )
 
 func (t *mocktracer) Extract(carrier interface{}) (ddtrace.SpanContext, error) {


### PR DESCRIPTION
This used to create problems when testing code. Normal code was using
and expecting the default headers, but the mocktracer was not. It was
causing inconsistencies and problems.