### PR TITLE
contrib/gorilla/mux: wrap methods returning mux.Router.

### DIFF
--- a/contrib/gorilla/mux/mux.go
+++ b/contrib/gorilla/mux/mux.go
@@ -15,6 +15,54 @@ type Router struct {
 	config *routerConfig
 }
 
+// StrictSlash defines the trailing slash behavior for new routes. The initial
+// value is false.
+//
+// When true, if the route path is "/path/", accessing "/path" will perform a redirect
+// to the former and vice versa. In other words, your application will always
+// see the path as specified in the route.
+//
+// When false, if the route path is "/path", accessing "/path/" will not match
+// this route and vice versa.
+//
+// The re-direct is a HTTP 301 (Moved Permanently). Note that when this is set for
+// routes with a non-idempotent method (e.g. POST, PUT), the subsequent re-directed
+// request will be made as a GET by most clients. Use middleware or client settings
+// to modify this behaviour as needed.
+//
+// Special case: when a route sets a path prefix using the PathPrefix() method,
+// strict slash is ignored for that route because the redirect behavior can't
+// be determined from a prefix alone. However, any subrouters created from that
+// route inherit the original StrictSlash setting.
+func (r *Router) StrictSlash(value bool) *Router {
+	r.Router.StrictSlash(value)
+	return r
+}
+
+// SkipClean defines the path cleaning behaviour for new routes. The initial
+// value is false. Users should be careful about which routes are not cleaned
+//
+// When true, if the route path is "/path//to", it will remain with the double
+// slash. This is helpful if you have a route like: /fetch/http://xkcd.com/534/
+//
+// When false, the path will be cleaned, so /fetch/http://xkcd.com/534/ will
+// become /fetch/http/xkcd.com/534
+func (r *Router) SkipClean(value bool) *Router {
+	r.Router.SkipClean(value)
+	return r
+}
+
+// UseEncodedPath tells the router to match the encoded original path
+// to the routes.
+// For eg. "/path/foo%2Fbar/to" will match the path "/path/{var}/to".
+//
+// If not called, the router will match the unencoded path to the routes.
+// For eg. "/path/foo%2Fbar/to" will match the path "/path/foo/bar/to"
+func (r *Router) UseEncodedPath() *Router {
+	r.Router.UseEncodedPath()
+	return r
+}
+
 // NewRouter returns a new router instance traced with the global tracer.
 func NewRouter(opts ...RouterOption) *Router {
 	cfg := new(routerConfig)

--- a/contrib/gorilla/mux/mux_test.go
+++ b/contrib/gorilla/mux/mux_test.go
@@ -77,6 +77,16 @@ func TestHttpTracer(t *testing.T) {
 	}
 }
 
+// TestImplementingMethods is a regression tests asserting that all the mux.Router methods
+// returning the router will return the modified traced version of it and not the original
+// router.
+func TestImplementingMethods(t *testing.T) {
+	r := NewRouter()
+	_ = (*Router)(r.StrictSlash(false))
+	_ = (*Router)(r.SkipClean(false))
+	_ = (*Router)(r.UseEncodedPath())
+}
+
 func router() http.Handler {
 	mux := NewRouter(WithServiceName("my-service"))
 	mux.Handle("/200", okHandler())


### PR DESCRIPTION
This change adds all the methods returning `*mux.Router` to our internal (traced)
`*Router`, ensuring that they will return the same instance instead of the embedded
one.

Documentation has been copied from `gorilla/mux`