### PR TITLE
contrib/internal/httputil: add support for distributed tracing.

### DIFF
--- a/contrib/internal/httputil/trace.go
+++ b/contrib/internal/httputil/trace.go
@@ -15,13 +15,17 @@ import (
 
 // TraceAndServe will apply tracing to the given http.Handler using the passed tracer under the given service and resource.
 func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, service, resource string) {
-	span, ctx := tracer.StartSpanFromContext(r.Context(), "http.request",
+	opts := []ddtrace.StartSpanOption{
 		tracer.SpanType(ext.AppTypeWeb),
 		tracer.ServiceName(service),
 		tracer.ResourceName(resource),
 		tracer.Tag(ext.HTTPMethod, r.Method),
 		tracer.Tag(ext.HTTPURL, r.URL.Path),
-	)
+	}
+	if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(r.Header)); err == nil {
+		opts = append(opts, tracer.ChildOf(spanctx))
+	}
+	span, ctx := tracer.StartSpanFromContext(r.Context(), "http.request", opts...)
 	defer span.Finish()
 	if _, ok := w.(http.Hijacker); ok {
 		w = newHijackableResponseWriter(w, span)

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -44,8 +44,15 @@ func TestStartSpanFromContext(t *testing.T) {
 	defer stop()
 
 	parent := &span{context: &spanContext{spanID: 123, traceID: 456}}
+	parent2 := &span{context: &spanContext{spanID: 789, traceID: 456}}
 	pctx := ContextWithSpan(context.Background(), parent)
-	child, ctx := StartSpanFromContext(pctx, "http.request", ServiceName("gin"), ResourceName("/"))
+	child, ctx := StartSpanFromContext(
+		pctx,
+		"http.request",
+		ServiceName("gin"),
+		ResourceName("/"),
+		ChildOf(parent2.Context()), // we do this to assert that the span in pctx takes priority.
+	)
 	assert := assert.New(t)
 
 	got, ok := child.(*span)


### PR DESCRIPTION
Adds support for distributed tracing and some tests ensuring that the parent is taken into consideration, both when it is in the context, as well as in the HTTP request's headers.

Additionally, it adds a test into the tracer asserting that the local context takes precedence of the `ChildOf` option when calling `StartSpanFromContext`, as it is stated in the documentation.