### PR TITLE
all: introduce correlation IDs into SpanContext.

### DIFF
--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -60,6 +60,12 @@ type Span interface {
 // spawn a direct descendant of the span that it belongs to. It can be used
 // to create distributed tracing by propagating it using the provided interfaces.
 type SpanContext interface {
+	// SpanID returns the span ID that this context is carrying.
+	SpanID() uint64
+
+	// TraceID returns the trace ID that this context is carrying.
+	TraceID() uint64
+
 	// ForeachBaggageItem provides an iterator over the key/value pairs set as
 	// baggage within this context. Iteration stops when the handler returns
 	// false.

--- a/ddtrace/internal/globaltracer.go
+++ b/ddtrace/internal/globaltracer.go
@@ -84,5 +84,11 @@ var _ ddtrace.SpanContext = (*NoopSpanContext)(nil)
 // NoopSpanContext is an implementation of ddtrace.SpanContext that is a no-op.
 type NoopSpanContext struct{}
 
+// SpanID implements ddtrace.SpanContext.
+func (NoopSpanContext) SpanID() uint64 { return 0 }
+
+// TraceID implements ddtrace.SpanContext.
+func (NoopSpanContext) TraceID() uint64 { return 0 }
+
 // ForeachBaggageItem implements ddtrace.SpanContext.
 func (NoopSpanContext) ForeachBaggageItem(handler func(k, v string) bool) {}

--- a/ddtrace/mocktracer/mockspancontext.go
+++ b/ddtrace/mocktracer/mockspancontext.go
@@ -20,6 +20,10 @@ type spanContext struct {
 	span    *mockspan // context owner
 }
 
+func (sc *spanContext) TraceID() uint64 { return sc.traceID }
+
+func (sc *spanContext) SpanID() uint64 { return sc.spanID }
+
 func (sc *spanContext) ForeachBaggageItem(handler func(k, v string) bool) {
 	sc.RLock()
 	defer sc.RUnlock()

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -65,7 +65,13 @@ func newSpanContext(span *span, parent *spanContext) *spanContext {
 	return context
 }
 
-// ForeachBaggageItem implements SpanContext.
+// SpanID implements ddtrace.SpanContext.
+func (c *spanContext) SpanID() uint64 { return c.spanID }
+
+// TraceID implements ddtrace.SpanContext.
+func (c *spanContext) TraceID() uint64 { return c.traceID }
+
+// ForeachBaggageItem implements ddtrace.SpanContext.
 func (c *spanContext) ForeachBaggageItem(handler func(k, v string) bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -177,6 +177,8 @@ func TestNewSpanContext(t *testing.T) {
 		assert := assert.New(t)
 		assert.Equal(ctx.traceID, span.TraceID)
 		assert.Equal(ctx.spanID, span.SpanID)
+		assert.Equal(ctx.TraceID(), span.TraceID)
+		assert.Equal(ctx.SpanID(), span.SpanID)
 		assert.Equal(ctx.priority, 1)
 		assert.True(ctx.hasPriority)
 		assert.NotNil(ctx.trace)


### PR DESCRIPTION
This change adds two new methods to the `SpanContext` interface,
allowing it to return the span and trace IDs in order for them to
potentially be used to correlate traces to logs.