### PR TITLE
ddtrace/tracer: make doc clearer.

### DIFF
--- a/ddtrace/tracer/doc.go
+++ b/ddtrace/tracer/doc.go
@@ -10,9 +10,9 @@
 // The tracing client can perform trace sampling. While the trace agent
 // already samples traces to reduce bandwidth usage, client sampling reduces
 // performance overhead. To make use of it, the package comes with a ready-to-use
-// rate sampler that can be passed to the tracer. To use it and cut down 50% of the
+// rate sampler that can be passed to the tracer. To use it and keep only 30% of the
 // requests, one would do:
-//   s := tracer.NewRateSampler(0.5)
+//   s := tracer.NewRateSampler(0.3)
 //   tracer.Start(tracer.WithSampler(s))
 //
 // All spans created by the tracer contain a context hereby referred to as the span


### PR DESCRIPTION
The previous phrasing made it unclear weather the `0.5` argument was for
the amount kept or dropped. Now it's clear that `0.3` means keep 30%.