### PR TITLE
contrib/gorilla/mux: add host information as "mux.host" when defined

### DIFF
--- a/contrib/gorilla/mux/mux_test.go
+++ b/contrib/gorilla/mux/mux_test.go
@@ -77,6 +77,21 @@ func TestHttpTracer(t *testing.T) {
 	}
 }
 
+func TestDomain(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	mux := NewRouter(WithServiceName("my-service"))
+	mux.Handle("/200", okHandler()).Host("localhost")
+	r := httptest.NewRequest("GET", "http://localhost/200", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, r)
+
+	spans := mt.FinishedSpans()
+	assert.Equal(1, len(spans))
+	assert.Equal("localhost", spans[0].Tag("mux.host"))
+}
+
 // TestImplementingMethods is a regression tests asserting that all the mux.Router methods
 // returning the router will return the modified traced version of it and not the original
 // router.

--- a/contrib/internal/httputil/trace.go
+++ b/contrib/internal/httputil/trace.go
@@ -14,14 +14,14 @@ import (
 )
 
 // TraceAndServe will apply tracing to the given http.Handler using the passed tracer under the given service and resource.
-func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, service, resource string) {
-	opts := []ddtrace.StartSpanOption{
+func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, service, resource string, spanopts ...ddtrace.StartSpanOption) {
+	opts := append([]ddtrace.StartSpanOption{
 		tracer.SpanType(ext.AppTypeWeb),
 		tracer.ServiceName(service),
 		tracer.ResourceName(resource),
 		tracer.Tag(ext.HTTPMethod, r.Method),
 		tracer.Tag(ext.HTTPURL, r.URL.Path),
-	}
+	}, spanopts...)
 	if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(r.Header)); err == nil {
 		opts = append(opts, tracer.ChildOf(spanctx))
 	}


### PR DESCRIPTION
This change adds an additional tag on the gorilla/mux router showing the
value of the host template.

Additionally, it modifies the internal httputil package to accept extra
tags for the created span.

Closes https://github.com/DataDog/dd-trace-go/issues/250