### PR TITLE
ddtrace/ext: add constant for setting the environment tag.

### DIFF
--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -47,4 +47,7 @@ const (
 
 	// ErrorStack specifies the stack dump.
 	ErrorStack = "error.stack"
+
+	// Environment specifies the environment to use with a trace.
+	Environment = "env"
 )


### PR DESCRIPTION
Most important tag names have their own constants. So should the `env` tag as it is quite central to our app.