### PR TITLE
ddtrace/tracer: resolve agent addresses more accurately.

### DIFF
--- a/ddtrace/tracer/transport.go
+++ b/ddtrace/tracer/transport.go
@@ -57,16 +57,8 @@ func newHTTPTransport(addr string) *httpTransport {
 		"Datadog-Meta-Tracer-Version":   tracerVersion,
 		"Content-Type":                  "application/msgpack",
 	}
-	host, port, _ := net.SplitHostPort(addr)
-	if host == "" {
-		host = defaultHostname
-	}
-	if port == "" {
-		port = defaultPort
-	}
-	addr = fmt.Sprintf("%s:%s", host, port)
 	return &httpTransport{
-		traceURL: fmt.Sprintf("http://%s/v0.3/traces", addr),
+		traceURL: fmt.Sprintf("http://%s/v0.3/traces", resolveAddr(addr)),
 		client: &http.Client{
 			// We copy the transport to avoid using the default one, as it might be
 			// augmented with tracing and we don't want these calls to be recorded.
@@ -117,4 +109,21 @@ func (t *httpTransport) send(p *payload) error {
 		return fmt.Errorf("%s", txt)
 	}
 	return nil
+}
+
+// resolveAddr resolves the given agent address and fills in any missing host
+// and port using the defaults.
+func resolveAddr(addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		// no port in addr
+		host = addr
+	}
+	if host == "" {
+		host = defaultHostname
+	}
+	if port == "" {
+		port = defaultPort
+	}
+	return fmt.Sprintf("%s:%s", host, port)
 }

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -99,6 +99,23 @@ func TestTracesAgentIntegration(t *testing.T) {
 	}
 }
 
+func TestResolveAddr(t *testing.T) {
+	for _, tt := range []struct {
+		in, out string
+	}{
+		{"host", fmt.Sprintf("host:%s", defaultPort)},
+		{"www.my-address.com", fmt.Sprintf("www.my-address.com:%s", defaultPort)},
+		{"localhost", fmt.Sprintf("localhost:%s", defaultPort)},
+		{":1111", fmt.Sprintf("%s:1111", defaultHostname)},
+		{"", defaultAddress},
+		{"custom:1234", "custom:1234"},
+	} {
+		t.Run(tt.in, func(t *testing.T) {
+			assert.Equal(t, resolveAddr(tt.in), tt.out)
+		})
+	}
+}
+
 func TestTransportResponseError(t *testing.T) {
 	assert := assert.New(t)
 	ln, err := net.Listen("tcp4", ":0")


### PR DESCRIPTION
This change ensures that a larger flexibility is permitted when
specifying host[:port] address for the agent. Previously, unexpected
behaviour happened when specifying only the hostname, as an example.

Closes #210 