### PR TITLE
contrib/database/sql: add SQL query to the span metadata

### DIFF
--- a/contrib/database/sql/driver.go
+++ b/contrib/database/sql/driver.go
@@ -59,6 +59,7 @@ func (tp *traceParams) newChildSpanFromContext(ctx context.Context, resource str
 		tracer.ServiceName(tp.config.serviceName),
 	)
 	if query != "" {
+		span.SetTag(ext.SQLQuery, query)
 		resource = query
 	}
 	span.SetTag(ext.ResourceName, resource)


### PR DESCRIPTION
Add SQL query to the span so it's easier to discover it in APM and copy it to the clipboard.

Currently the SQL query is bound as a resource which makes hard to see the full query if it's long enough:

![screen shot 2018-06-14 at 17 32 31](https://user-images.githubusercontent.com/211000/41422593-8042fb3e-6ff9-11e8-82da-c400272bae4c.png)
