### PR TITLE
build: make golint fail CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,5 +84,5 @@ jobs:
                     name: Testing
                     command: |
                         go vet ./...
-                        golint $(go list ./... | grep -v /vendor/)
+                        golint -set_exit_status=1 $(go list ./... | grep -v /vendor/)
                         INTEGRATION=1 go test -v -race ./...

--- a/contrib/gocql/gocql/gocql.go
+++ b/contrib/gocql/gocql/gocql.go
@@ -111,66 +111,79 @@ func (tq *Query) ScanCAS(dest ...interface{}) (applied bool, err error) {
 	return applied, err
 }
 
+// Consistency wraps the underlying gocql call.
 func (tq *Query) Consistency(c gocql.Consistency) *Query {
 	tq.Query.Consistency(c)
 	return tq
 }
 
+// Trace wraps the underlying gocql call.
 func (tq *Query) Trace(trace gocql.Tracer) *Query {
 	tq.Query.Trace(trace)
 	return tq
 }
 
+// Observer wraps the underlying gocql call.
 func (tq *Query) Observer(observer gocql.QueryObserver) *Query {
 	tq.Query.Observer(observer)
 	return tq
 }
 
+// PageSize wraps the underlying gocql call.
 func (tq *Query) PageSize(n int) *Query {
 	tq.Query.PageSize(n)
 	return tq
 }
 
+// DefaultTimestamp wraps the underlying gocql call.
 func (tq *Query) DefaultTimestamp(enable bool) *Query {
 	tq.Query.DefaultTimestamp(enable)
 	return tq
 }
 
+// WithTimestamp wraps the underlying gocql call.
 func (tq *Query) WithTimestamp(timestamp int64) *Query {
 	tq.Query.WithTimestamp(timestamp)
 	return tq
 }
 
+// RoutingKey wraps the underlying gocql call.
 func (tq *Query) RoutingKey(routingKey []byte) *Query {
 	tq.Query.RoutingKey(routingKey)
 	return tq
 }
 
+// Prefetch wraps the underlying gocql call.
 func (tq *Query) Prefetch(p float64) *Query {
 	tq.Query.Prefetch(p)
 	return tq
 }
 
+// RetryPolicy wraps the underlying gocql call.
 func (tq *Query) RetryPolicy(r gocql.RetryPolicy) *Query {
 	tq.Query.RetryPolicy(r)
 	return tq
 }
 
+// Idempontent wraps the underlying gocql call.
 func (tq *Query) Idempontent(value bool) *Query {
 	tq.Query.Idempontent(value)
 	return tq
 }
 
+// Bind wraps the underlying gocql call.
 func (tq *Query) Bind(v ...interface{}) *Query {
 	tq.Query.Bind(v)
 	return tq
 }
 
+// SerialConsistency wraps the underlying gocql call.
 func (tq *Query) SerialConsistency(cons gocql.SerialConsistency) *Query {
 	tq.Query.SerialConsistency(cons)
 	return tq
 }
 
+// NoSkipMetadata wraps the underlying gocql call.
 func (tq *Query) NoSkipMetadata() *Query {
 	tq.Query.NoSkipMetadata()
 	return tq

--- a/ddtrace/tracer/span_msgp.go
+++ b/ddtrace/tracer/span_msgp.go
@@ -63,7 +63,7 @@ func (z *span) DecodeMsg(dc *msgp.Reader) (err error) {
 			if z.Meta == nil && zb0002 > 0 {
 				z.Meta = make(map[string]string, zb0002)
 			} else if len(z.Meta) > 0 {
-				for key, _ := range z.Meta {
+				for key := range z.Meta {
 					delete(z.Meta, key)
 				}
 			}
@@ -90,7 +90,7 @@ func (z *span) DecodeMsg(dc *msgp.Reader) (err error) {
 			if z.Metrics == nil && zb0003 > 0 {
 				z.Metrics = make(map[string]float64, zb0003)
 			} else if len(z.Metrics) > 0 {
-				for key, _ := range z.Metrics {
+				for key := range z.Metrics {
 					delete(z.Metrics, key)
 				}
 			}


### PR DESCRIPTION
This change makes `golint` return exit status 1 on errors and fixes all linting errors.