### PR TITLE
ddtrace/tracer: always Stop the internal tracer when running Start/Stop

### DIFF
--- a/ddtrace/internal/globaltracer.go
+++ b/ddtrace/internal/globaltracer.go
@@ -15,6 +15,10 @@ var (
 func SetGlobalTracer(t ddtrace.Tracer) {
 	mu.Lock()
 	defer mu.Unlock()
+	if !Testing {
+		// avoid infinite loop when calling (*mocktracer.Tracer).Stop
+		globalTracer.Stop()
+	}
 	globalTracer = t
 }
 

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -64,9 +64,7 @@ func Start(opts ...StartOption) {
 	if internal.Testing {
 		return // mock tracer active
 	}
-	t := internal.GetGlobalTracer()
 	internal.SetGlobalTracer(newTracer(opts...))
-	t.Stop()
 }
 
 // Stop stops the started tracer. Subsequent calls are valid but become no-op.


### PR DESCRIPTION
This change causes the internal tracer to cleanly exit, flushing any
remaining traces to the transport whenever `tracer.Stop` and
`tracer.Start` are called.