### PR TITLE
contrib/gin-gonic/gin: Extract parent span info from HTTP Headers

### DIFF
--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
@@ -16,13 +17,17 @@ import (
 func Middleware(service string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		resource := c.HandlerName()
-		span, ctx := tracer.StartSpanFromContext(c.Request.Context(), "http.request",
+		opts := []ddtrace.StartSpanOption{
 			tracer.ServiceName(service),
 			tracer.ResourceName(resource),
 			tracer.SpanType(ext.AppTypeWeb),
 			tracer.Tag(ext.HTTPMethod, c.Request.Method),
 			tracer.Tag(ext.HTTPURL, c.Request.URL.Path),
-		)
+		}
+		if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(c.Request.Header)); err == nil {
+			opts = append(opts, tracer.ChildOf(spanctx))
+		}
+		span, ctx := tracer.StartSpanFromContext(c.Request.Context(), "http.request", opts...)
 		defer span.Finish()
 
 		// pass the span through the request context


### PR DESCRIPTION
Use propagation features to try to get some span context in the incoming
request headers.

If the headers are not set, the comportment is the same as before

If a span is already present in the request's context, it will be
used primarily as the parent span.