### PR TITLE
sql: Changing Span Type from `db` to `sql`

### DIFF
--- a/contrib/database/sql/driver.go
+++ b/contrib/database/sql/driver.go
@@ -14,6 +14,10 @@ import (
 
 var _ driver.Driver = (*tracedDriver)(nil)
 
+// SpanType is the span type sent to DataDog for SQL operations.
+// This is set to "sql"
+var SQLSpanType = "sql"
+
 // tracedDriver wraps an inner sql driver with tracing. It implements the (database/sql).driver.Driver interface.
 type tracedDriver struct {
 	driver.Driver
@@ -55,7 +59,7 @@ type traceParams struct {
 func (tp *traceParams) newChildSpanFromContext(ctx context.Context, resource string, query string) ddtrace.Span {
 	name := fmt.Sprintf("%s.query", tp.driverName)
 	span, _ := tracer.StartSpanFromContext(ctx, name,
-		tracer.SpanType(ext.AppTypeDB),
+		tracer.SpanType(SQLSpanType),
 		tracer.ServiceName(tp.config.serviceName),
 	)
 	if query != "" {

--- a/contrib/database/sql/example_test.go
+++ b/contrib/database/sql/example_test.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	sqltrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	"github.com/go-sql-driver/mysql"
@@ -42,7 +41,7 @@ func Example_context() {
 
 	// Create a root span, giving name, server and resource.
 	_, ctx := tracer.StartSpanFromContext(context.Background(), "my-query",
-		tracer.SpanType(ext.AppTypeDB),
+		tracer.SpanType(sqltrace.SQLSpanType),
 		tracer.ServiceName("my-db"),
 		tracer.ResourceName("initial-access"),
 	)

--- a/contrib/database/sql/sql_test.go
+++ b/contrib/database/sql/sql_test.go
@@ -41,7 +41,7 @@ func TestMySQL(t *testing.T) {
 		ExpectName: "mysql.query",
 		ExpectTags: map[string]interface{}{
 			ext.ServiceName: "mysql.db",
-			ext.SpanType:    ext.AppTypeDB,
+			ext.SpanType:    "sql",
 			ext.TargetHost:  "127.0.0.1",
 			ext.TargetPort:  "3306",
 			"db.user":       "test",
@@ -66,7 +66,7 @@ func TestPostgres(t *testing.T) {
 		ExpectName: "postgres.query",
 		ExpectTags: map[string]interface{}{
 			ext.ServiceName: "postgres-test",
-			ext.SpanType:    ext.AppTypeDB,
+			ext.SpanType:    "sql",
 			ext.TargetHost:  "127.0.0.1",
 			ext.TargetPort:  "5432",
 			"db.user":       "postgres",

--- a/contrib/internal/sqltest/sqltest.go
+++ b/contrib/internal/sqltest/sqltest.go
@@ -67,7 +67,7 @@ func testPing(cfg *Config) func(*testing.T) {
 		span := spans[0]
 		assert.Equal(cfg.ExpectName, span.OperationName())
 		for k, v := range cfg.ExpectTags {
-			assert.Equal(v, span.Tag(k), "tag mismatch")
+			assert.Equal(v, span.Tag(k), "Value mismatch on tag %s", k)
 		}
 	}
 }
@@ -87,7 +87,7 @@ func testQuery(cfg *Config) func(*testing.T) {
 		span := spans[0]
 		assert.Equal(cfg.ExpectName, span.OperationName())
 		for k, v := range cfg.ExpectTags {
-			assert.Equal(v, span.Tag(k), "tag mismatch")
+			assert.Equal(v, span.Tag(k), "Value mismatch on tag %s", k)
 		}
 	}
 }
@@ -112,7 +112,7 @@ func testStatement(cfg *Config) func(*testing.T) {
 		span := spans[0]
 		assert.Equal(cfg.ExpectName, span.OperationName())
 		for k, v := range cfg.ExpectTags {
-			assert.Equal(v, span.Tag(k), "tag mismatch")
+			assert.Equal(v, span.Tag(k), "Value mismatch on tag %s", k)
 		}
 
 		cfg.mockTracer.Reset()
@@ -124,7 +124,7 @@ func testStatement(cfg *Config) func(*testing.T) {
 		span = spans[0]
 		assert.Equal(cfg.ExpectName, span.OperationName())
 		for k, v := range cfg.ExpectTags {
-			assert.Equal(v, span.Tag(k), "tag mismatch")
+			assert.Equal(v, span.Tag(k), "Value mismatch on tag %s", k)
 		}
 	}
 }
@@ -143,7 +143,7 @@ func testBeginRollback(cfg *Config) func(*testing.T) {
 		span := spans[0]
 		assert.Equal(cfg.ExpectName, span.OperationName())
 		for k, v := range cfg.ExpectTags {
-			assert.Equal(v, span.Tag(k), "tag mismatch")
+			assert.Equal(v, span.Tag(k), "Value mismatch on tag %s", k)
 		}
 
 		cfg.mockTracer.Reset()
@@ -155,7 +155,7 @@ func testBeginRollback(cfg *Config) func(*testing.T) {
 		span = spans[0]
 		assert.Equal(cfg.ExpectName, span.OperationName())
 		for k, v := range cfg.ExpectTags {
-			assert.Equal(v, span.Tag(k), "tag mismatch")
+			assert.Equal(v, span.Tag(k), "Value mismatch on tag %s", k)
 		}
 	}
 }
@@ -191,7 +191,7 @@ func testExec(cfg *Config) func(*testing.T) {
 		}
 		assert.NotNil(span, "span not found")
 		for k, v := range cfg.ExpectTags {
-			assert.Equal(v, span.Tag(k), "tag mismatch")
+			assert.Equal(v, span.Tag(k), "Value mismatch on tag %s", k)
 		}
 		for _, s := range spans {
 			if s.OperationName() == cfg.ExpectName && s.Tag(ext.ResourceName) == "Commit" {
@@ -200,7 +200,7 @@ func testExec(cfg *Config) func(*testing.T) {
 		}
 		assert.NotNil(span, "span not found")
 		for k, v := range cfg.ExpectTags {
-			assert.Equal(v, span.Tag(k), "tag mismatch")
+			assert.Equal(v, span.Tag(k), "Value mismatch on tag %s", k)
 		}
 	}
 }

--- a/contrib/jmoiron/sqlx/sql_test.go
+++ b/contrib/jmoiron/sqlx/sql_test.go
@@ -42,7 +42,7 @@ func TestMySQL(t *testing.T) {
 		ExpectName: "mysql.query",
 		ExpectTags: map[string]interface{}{
 			ext.ServiceName: "mysql-test",
-			ext.SpanType:    ext.AppTypeDB,
+			ext.SpanType:    "sql",
 			ext.TargetHost:  "127.0.0.1",
 			ext.TargetPort:  "3306",
 			"db.user":       "test",
@@ -67,7 +67,7 @@ func TestPostgres(t *testing.T) {
 		ExpectName: "postgres.query",
 		ExpectTags: map[string]interface{}{
 			ext.ServiceName: "postgres.db",
-			ext.SpanType:    ext.AppTypeDB,
+			ext.SpanType:    "sql",
 			ext.TargetHost:  "127.0.0.1",
 			ext.TargetPort:  "5432",
 			"db.user":       "postgres",


### PR DESCRIPTION
The Span Type being set for SQL traces was `db`, this is incorrect, it ought to be `sql`.  Having the wrong SpanType impedes certain functionality.