### PR TITLE
contrib: Fixing Span Types for Redis, ElasticSearch, and Cassandra

### DIFF
--- a/contrib/garyburd/redigo/redigo.go
+++ b/contrib/garyburd/redigo/redigo.go
@@ -30,6 +30,10 @@ type params struct {
 	port    string
 }
 
+// spanType is the value that span.type is set to for traces
+// in Redis calls
+const spanType = "redis"
+
 // parseOptions parses a set of arbitrary options (which can be of type redis.DialOption
 // or the local DialOption) and returns the corresponding redis.DialOption set as well as
 // a configured dialConfig.
@@ -92,7 +96,7 @@ func DialURL(rawurl string, options ...interface{}) (redis.Conn, error) {
 func (tc Conn) newChildSpan(ctx context.Context) ddtrace.Span {
 	p := tc.params
 	span, _ := tracer.StartSpanFromContext(ctx, "redis.command",
-		tracer.SpanType(ext.AppTypeDB),
+		tracer.SpanType(spanType),
 		tracer.ServiceName(p.config.serviceName),
 	)
 	span.SetTag("out.network", p.network)

--- a/contrib/garyburd/redigo/redigo_test.go
+++ b/contrib/garyburd/redigo/redigo_test.go
@@ -37,7 +37,7 @@ func TestClient(t *testing.T) {
 
 	span := spans[0]
 	assert.Equal("redis.command", span.OperationName())
-	assert.Equal(spanType, span.Tag(ext.SpanType))
+	assert.Equal("redis", span.Tag(ext.SpanType))
 	assert.Equal("my-service", span.Tag(ext.ServiceName))
 	assert.Equal("SET", span.Tag(ext.ResourceName))
 	assert.Equal("127.0.0.1", span.Tag(ext.TargetHost))

--- a/contrib/garyburd/redigo/redigo_test.go
+++ b/contrib/garyburd/redigo/redigo_test.go
@@ -37,7 +37,7 @@ func TestClient(t *testing.T) {
 
 	span := spans[0]
 	assert.Equal("redis.command", span.OperationName())
-	assert.Equal(ext.AppTypeDB, span.Tag(ext.SpanType))
+	assert.Equal(spanType, span.Tag(ext.SpanType))
 	assert.Equal("my-service", span.Tag(ext.ServiceName))
 	assert.Equal("SET", span.Tag(ext.ResourceName))
 	assert.Equal("127.0.0.1", span.Tag(ext.TargetHost))

--- a/contrib/go-redis/redis/example_test.go
+++ b/contrib/go-redis/redis/example_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/go-redis/redis"
 	redistrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/go-redis/redis"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
@@ -22,7 +21,7 @@ func Example() {
 
 	// optionally, create a new root span
 	root, ctx := tracer.StartSpanFromContext(context.Background(), "parent.request",
-		tracer.SpanType(ext.AppTypeDB),
+		tracer.SpanType("redis"),
 		tracer.ServiceName("web"),
 		tracer.ResourceName("/home"),
 	)

--- a/contrib/go-redis/redis/redis.go
+++ b/contrib/go-redis/redis/redis.go
@@ -35,6 +35,10 @@ type params struct {
 	config *clientConfig
 }
 
+// spanType is the value that span.type is set to when recording
+// a trace through a Redis call.
+const spanType = "redis"
+
 // NewClient returns a new Client that is traced with the default tracer under
 // the service name "redis".
 func NewClient(opt *redis.Options, opts ...ClientOption) *Client {
@@ -84,7 +88,7 @@ func (c *Pipeliner) Exec() ([]redis.Cmder, error) {
 func (c *Pipeliner) execWithContext(ctx context.Context) ([]redis.Cmder, error) {
 	p := c.params
 	span, _ := tracer.StartSpanFromContext(ctx, "redis.command",
-		tracer.SpanType(ext.AppTypeDB),
+		tracer.SpanType(spanType),
 		tracer.ServiceName(p.config.serviceName),
 		tracer.ResourceName("redis"),
 		tracer.Tag(ext.TargetHost, p.host),
@@ -131,7 +135,7 @@ func createWrapperFromClient(tc *Client) func(oldProcess func(cmd redis.Cmder) e
 			length := len(parts) - 1
 			p := tc.params
 			span, _ := tracer.StartSpanFromContext(ctx, "redis.command",
-				tracer.SpanType(ext.AppTypeDB),
+				tracer.SpanType(spanType),
 				tracer.ServiceName(p.config.serviceName),
 				tracer.ResourceName(parts[0]),
 				tracer.Tag(ext.TargetHost, p.host),

--- a/contrib/go-redis/redis/redis_test.go
+++ b/contrib/go-redis/redis/redis_test.go
@@ -40,7 +40,7 @@ func TestClient(t *testing.T) {
 
 	span := spans[0]
 	assert.Equal("redis.command", span.OperationName())
-	assert.Equal(ext.AppTypeDB, span.Tag(ext.SpanType))
+	assert.Equal("redis", span.Tag(ext.SpanType))
 	assert.Equal("my-redis", span.Tag(ext.ServiceName))
 	assert.Equal("127.0.0.1", span.Tag(ext.TargetHost))
 	assert.Equal("6379", span.Tag(ext.TargetPort))
@@ -66,7 +66,7 @@ func TestPipeline(t *testing.T) {
 
 	span := spans[0]
 	assert.Equal("redis.command", span.OperationName())
-	assert.Equal(ext.AppTypeDB, span.Tag(ext.SpanType))
+	assert.Equal("redis", span.Tag(ext.SpanType))
 	assert.Equal("my-redis", span.Tag(ext.ServiceName))
 	assert.Equal("expire pipeline_counter 3600: false\n", span.Tag(ext.ResourceName))
 	assert.Equal("127.0.0.1", span.Tag(ext.TargetHost))
@@ -85,7 +85,7 @@ func TestPipeline(t *testing.T) {
 
 	span = spans[0]
 	assert.Equal("redis.command", span.OperationName())
-	assert.Equal(ext.AppTypeDB, span.Tag(ext.SpanType))
+	assert.Equal("redis", span.Tag(ext.SpanType))
 	assert.Equal("my-redis", span.Tag(ext.ServiceName))
 	assert.Equal("expire pipeline_counter 3600: false\nexpire pipeline_counter_1 60: false\n", span.Tag(ext.ResourceName))
 	assert.Equal("2", span.Tag("redis.pipeline_length"))

--- a/contrib/gocql/gocql/gocql.go
+++ b/contrib/gocql/gocql/gocql.go
@@ -34,6 +34,10 @@ type params struct {
 	paginated bool
 }
 
+// spanType the value that span.type is set to when tracing a
+// Cassandra call.
+const spanType = "cassandra"
+
 // WrapQuery wraps a gocql.Query into a traced Query under the given service name.
 // Note that the returned Query structure embeds the original gocql.Query structure.
 // This means that any method returning the query for chaining that is not part
@@ -81,7 +85,7 @@ func (tq *Query) PageState(state []byte) *Query {
 func (tq *Query) newChildSpan(ctx context.Context) ddtrace.Span {
 	p := tq.params
 	span, _ := tracer.StartSpanFromContext(ctx, ext.CassandraQuery,
-		tracer.SpanType(ext.AppTypeDB),
+		tracer.SpanType(spanType),
 		tracer.ServiceName(p.config.serviceName),
 		tracer.ResourceName(p.config.resourceName),
 		tracer.Tag(ext.CassandraPaginated, fmt.Sprintf("%t", p.paginated)),

--- a/contrib/olivere/elastic/elastictrace.go
+++ b/contrib/olivere/elastic/elastictrace.go
@@ -24,6 +24,10 @@ func NewHTTPClient(opts ...ClientOption) *http.Client {
 	return &http.Client{Transport: &httpTransport{config: cfg}}
 }
 
+// spanType the value that `span.type` is set to when sending
+// ElasticSearch trace data to DataDog.
+const spanType = "elasticsearch"
+
 // httpTransport is a traced HTTP transport that captures Elasticsearch spans.
 type httpTransport struct{ config *clientConfig }
 
@@ -39,7 +43,7 @@ func (t *httpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	resource := quantize(url, method)
 	span, _ := tracer.StartSpanFromContext(req.Context(), "elasticsearch.query",
 		tracer.ServiceName(t.config.serviceName),
-		tracer.SpanType(ext.AppTypeDB),
+		tracer.SpanType(spanType),
 		tracer.ResourceName(resource),
 		tracer.Tag("elasticsearch.method", method),
 		tracer.Tag("elasticsearch.url", url),

--- a/ddtrace/ext/app_types.go
+++ b/ddtrace/ext/app_types.go
@@ -5,6 +5,10 @@ const (
 	// for a span's SpanType tag.
 	AppTypeWeb = "web"
 
+	// AppTypeHTTP specifies the HTTP span type and can be used as a tag value
+	// for a span's SpanType tag.
+	AppTypeHTTP = "http"
+
 	// AppTypeDB specifies the DB span type and can be used as a tag value
 	// for a span's SpanType tag.
 	AppTypeDB = "db"


### PR DESCRIPTION
All database integrations were using `db` for the SpanType.  Redis, ElasticSearch, and Cassandra were all updated to use their respective Span Types.

I also verified that the web frameworks were using the correct Span Type (`web`).