### PR TITLE
contrib/aws/aws-sdk-go: add aws sdk integration

### DIFF
--- a/contrib/aws/aws-sdk-go/aws/aws.go
+++ b/contrib/aws/aws-sdk-go/aws/aws.go
@@ -1,4 +1,5 @@
-package aws
+// Package aws provides functions to trace aws/aws-sdk-go (https://github.com/aws/aws-sdk-go).
+package aws // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/aws/aws-sdk-go/aws"
 
 import (
 	"strconv"
@@ -9,14 +10,19 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
+const (
+	tagAWSAgent     = "aws.agent"
+	tagAWSOperation = "aws.operation"
+	tagAWSRegion    = "aws.region"
+)
+
 type handlers struct {
 	cfg *config
 }
 
-// WrapSession wraps an aws Session so that requests/responses are traced.
+// WrapSession wraps a session.Session, causing requests and responses to be traced.
 func WrapSession(s *session.Session, opts ...Option) *session.Session {
 	cfg := new(config)
-	defaults(cfg)
 	for _, opt := range opts {
 		opt(cfg)
 	}
@@ -35,12 +41,12 @@ func WrapSession(s *session.Session, opts ...Option) *session.Session {
 
 func (h *handlers) Send(req *request.Request) {
 	_, ctx := tracer.StartSpanFromContext(req.Context(), h.operationName(req),
-		tracer.SpanType(ext.AppTypeHTTP),
+		tracer.SpanType(ext.SpanTypeHTTP),
 		tracer.ServiceName(h.serviceName(req)),
 		tracer.ResourceName(h.resourceName(req)),
-		tracer.Tag(awsAgentTag, h.awsAgent(req)),
-		tracer.Tag(awsOperationTag, h.awsOperation(req)),
-		tracer.Tag(awsRegionTag, h.awsRegion(req)),
+		tracer.Tag(tagAWSAgent, h.awsAgent(req)),
+		tracer.Tag(tagAWSOperation, h.awsOperation(req)),
+		tracer.Tag(tagAWSRegion, h.awsRegion(req)),
 		tracer.Tag(ext.HTTPMethod, req.Operation.HTTPMethod),
 		tracer.Tag(ext.HTTPURL, req.HTTPRequest.URL.String()),
 	)

--- a/contrib/aws/aws-sdk-go/aws/aws_test.go
+++ b/contrib/aws/aws-sdk-go/aws/aws_test.go
@@ -1,0 +1,78 @@
+package aws
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+func TestAWS(t *testing.T) {
+
+	cfg := aws.NewConfig().
+		WithRegion("us-west-2").
+		WithDisableSSL(true).
+		WithCredentials(credentials.AnonymousCredentials)
+
+	session := WrapSession(session.Must(session.NewSession(cfg)))
+
+	t.Run("s3", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		root, ctx := tracer.StartSpanFromContext(context.Background(), "test")
+		s3api := s3.New(session)
+		s3api.CreateBucketWithContext(ctx, &s3.CreateBucketInput{
+			Bucket: aws.String("BUCKET"),
+		})
+		root.Finish()
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 2)
+		assert.Equal(t, spans[1].TraceID(), spans[0].TraceID())
+
+		s := spans[0]
+		assert.Equal(t, "s3.command", s.OperationName())
+		assert.Contains(t, s.Tag(awsAgentTag), "aws-sdk-go")
+		assert.Equal(t, "CreateBucket", s.Tag(awsOperationTag))
+		assert.Equal(t, "us-west-2", s.Tag(awsRegionTag))
+		assert.Equal(t, "s3.CreateBucket", s.Tag(ext.ResourceName))
+		assert.Equal(t, "aws.s3", s.Tag(ext.ServiceName))
+		assert.Equal(t, "403", s.Tag(ext.HTTPCode))
+		assert.Equal(t, "PUT", s.Tag(ext.HTTPMethod))
+		assert.Equal(t, "http://s3.us-west-2.amazonaws.com/BUCKET", s.Tag(ext.HTTPURL))
+	})
+
+	t.Run("ec2", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		root, ctx := tracer.StartSpanFromContext(context.Background(), "test")
+		ec2api := ec2.New(session)
+		ec2api.DescribeInstancesWithContext(ctx, &ec2.DescribeInstancesInput{})
+		root.Finish()
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 2)
+		assert.Equal(t, spans[1].TraceID(), spans[0].TraceID())
+
+		s := spans[0]
+		assert.Equal(t, "ec2.command", s.OperationName())
+		assert.Contains(t, s.Tag(awsAgentTag), "aws-sdk-go")
+		assert.Equal(t, "DescribeInstances", s.Tag(awsOperationTag))
+		assert.Equal(t, "us-west-2", s.Tag(awsRegionTag))
+		assert.Equal(t, "ec2.DescribeInstances", s.Tag(ext.ResourceName))
+		assert.Equal(t, "aws.ec2", s.Tag(ext.ServiceName))
+		assert.Equal(t, "400", s.Tag(ext.HTTPCode))
+		assert.Equal(t, "POST", s.Tag(ext.HTTPMethod))
+		assert.Equal(t, "http://ec2.us-west-2.amazonaws.com/", s.Tag(ext.HTTPURL))
+	})
+}

--- a/contrib/aws/aws-sdk-go/aws/aws_test.go
+++ b/contrib/aws/aws-sdk-go/aws/aws_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestAWS(t *testing.T) {
-
 	cfg := aws.NewConfig().
 		WithRegion("us-west-2").
 		WithDisableSSL(true).
@@ -41,9 +40,9 @@ func TestAWS(t *testing.T) {
 
 		s := spans[0]
 		assert.Equal(t, "s3.command", s.OperationName())
-		assert.Contains(t, s.Tag(awsAgentTag), "aws-sdk-go")
-		assert.Equal(t, "CreateBucket", s.Tag(awsOperationTag))
-		assert.Equal(t, "us-west-2", s.Tag(awsRegionTag))
+		assert.Contains(t, s.Tag(tagAWSAgent), "aws-sdk-go")
+		assert.Equal(t, "CreateBucket", s.Tag(tagAWSOperation))
+		assert.Equal(t, "us-west-2", s.Tag(tagAWSRegion))
 		assert.Equal(t, "s3.CreateBucket", s.Tag(ext.ResourceName))
 		assert.Equal(t, "aws.s3", s.Tag(ext.ServiceName))
 		assert.Equal(t, "403", s.Tag(ext.HTTPCode))
@@ -66,9 +65,9 @@ func TestAWS(t *testing.T) {
 
 		s := spans[0]
 		assert.Equal(t, "ec2.command", s.OperationName())
-		assert.Contains(t, s.Tag(awsAgentTag), "aws-sdk-go")
-		assert.Equal(t, "DescribeInstances", s.Tag(awsOperationTag))
-		assert.Equal(t, "us-west-2", s.Tag(awsRegionTag))
+		assert.Contains(t, s.Tag(tagAWSAgent), "aws-sdk-go")
+		assert.Equal(t, "DescribeInstances", s.Tag(tagAWSOperation))
+		assert.Equal(t, "us-west-2", s.Tag(tagAWSRegion))
 		assert.Equal(t, "ec2.DescribeInstances", s.Tag(ext.ResourceName))
 		assert.Equal(t, "aws.ec2", s.Tag(ext.ServiceName))
 		assert.Equal(t, "400", s.Tag(ext.HTTPCode))

--- a/contrib/aws/aws-sdk-go/aws/example_test.go
+++ b/contrib/aws/aws-sdk-go/aws/example_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // To start tracing requests, wrap the AWS session.Session by invoking
-// awstrace.WrapSession
+// awstrace.WrapSession.
 func Example() {
 	cfg := aws.NewConfig().WithRegion("us-west-2")
 	sess := session.Must(session.NewSession(cfg))

--- a/contrib/aws/aws-sdk-go/aws/example_test.go
+++ b/contrib/aws/aws-sdk-go/aws/example_test.go
@@ -1,0 +1,21 @@
+package aws_test
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	awstrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/aws/aws-sdk-go/aws"
+)
+
+// To start tracing requests, wrap the AWS session.Session by invoking
+// awstrace.WrapSession
+func Example() {
+	cfg := aws.NewConfig().WithRegion("us-west-2")
+	sess := session.Must(session.NewSession(cfg))
+	sess = awstrace.WrapSession(sess)
+
+	s3api := s3.New(sess)
+	s3api.CreateBucket(&s3.CreateBucketInput{
+		Bucket: aws.String("some-bucket-name"),
+	})
+}

--- a/contrib/aws/aws-sdk-go/aws/option.go
+++ b/contrib/aws/aws-sdk-go/aws/option.go
@@ -1,0 +1,26 @@
+package aws // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/aws/aws-sdk-go/aws"
+
+const (
+	awsAgentTag     = "aws.agent"
+	awsOperationTag = "aws.operation"
+	awsRegionTag    = "aws.region"
+)
+
+type config struct {
+	// when set to the empty string, the service name will be inferred based on
+	// the request to AWS
+	serviceName string
+}
+
+// Option represents an option that can be passed to Dial.
+type Option func(*config)
+
+func defaults(cfg *config) {
+}
+
+// WithServiceName sets the given service name for the dialled connection.
+func WithServiceName(name string) Option {
+	return func(cfg *config) {
+		cfg.serviceName = name
+	}
+}

--- a/contrib/aws/aws-sdk-go/aws/option.go
+++ b/contrib/aws/aws-sdk-go/aws/option.go
@@ -1,24 +1,15 @@
-package aws // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/aws/aws-sdk-go/aws"
-
-const (
-	awsAgentTag     = "aws.agent"
-	awsOperationTag = "aws.operation"
-	awsRegionTag    = "aws.region"
-)
+package aws
 
 type config struct {
-	// when set to the empty string, the service name will be inferred based on
-	// the request to AWS
 	serviceName string
 }
 
 // Option represents an option that can be passed to Dial.
 type Option func(*config)
 
-func defaults(cfg *config) {
-}
-
 // WithServiceName sets the given service name for the dialled connection.
+// When the service name is not explicitly set it will be inferred based on the
+// request to AWS.
 func WithServiceName(name string) Option {
 	return func(cfg *config) {
 		cfg.serviceName = name


### PR DESCRIPTION
Fixes https://github.com/DataDog/dd-trace-go/issues/284

This uses a `WrapSession` function:

```go
func Example() {
	cfg := aws.NewConfig().WithRegion("us-west-2")
	sess := session.Must(session.NewSession(cfg))
	sess = awstrace.WrapSession(sess)
 	s3api := s3.New(sess)
	s3api.CreateBucket(&s3.CreateBucketInput{
		Bucket: aws.String("some-bucket-name"),
	})
}
```

I used our existing boto integration as an example for many of the tags.