### PR TITLE
 contrib/graph-gophers/graphql-go: add graphql tracing support

### DIFF
--- a/contrib/graph-gophers/graphql-go/example_test.go
+++ b/contrib/graph-gophers/graphql-go/example_test.go
@@ -23,7 +23,7 @@ func Example() {
 		}
 	`
 	schema := graphql.MustParseSchema(s, new(resolver),
-		graphql.Tracer(graphqltrace.New()))
+		graphql.Tracer(graphqltrace.NewTracer()))
 	http.Handle("/query", &relay.Handler{Schema: schema})
 	log.Fatal(http.ListenAndServe(":8080", nil))
 

--- a/contrib/graph-gophers/graphql-go/example_test.go
+++ b/contrib/graph-gophers/graphql-go/example_test.go
@@ -1,0 +1,32 @@
+package graphql_test
+
+import (
+	"log"
+	"net/http"
+
+	graphql "github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+	graphqltrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/graph-gophers/graphql-go"
+)
+
+type resolver struct{}
+
+func (*resolver) Hello() string { return "Hello, world!" }
+
+func Example() {
+	s := `
+		schema {
+			query: Query
+		}
+		type Query {
+			hello: String!
+		}
+	`
+	schema := graphql.MustParseSchema(s, new(resolver),
+		graphql.Tracer(graphqltrace.New()))
+	http.Handle("/query", &relay.Handler{Schema: schema})
+	log.Fatal(http.ListenAndServe(":8080", nil))
+
+	// then:
+	// $ curl -XPOST -d '{"query": "{ hello }"}' localhost:8080/query
+}

--- a/contrib/graph-gophers/graphql-go/graphql.go
+++ b/contrib/graph-gophers/graphql-go/graphql.go
@@ -50,7 +50,12 @@ func (t *Tracer) TraceField(ctx context.Context, label string, typeName string, 
 		tracer.Tag(graphqlTypeTag, typeName),
 	)
 	return ctx, func(err *errors.QueryError) {
-		span.Finish(tracer.WithError(err))
+		// this is necessary otherwise the span gets marked as an error
+		if err != nil {
+			span.Finish(tracer.WithError(err))
+		} else {
+			span.Finish()
+		}
 	}
 }
 

--- a/contrib/graph-gophers/graphql-go/graphql.go
+++ b/contrib/graph-gophers/graphql-go/graphql.go
@@ -28,6 +28,8 @@ type Tracer struct {
 	cfg *config
 }
 
+var _ trace.Tracer = (*Tracer)(nil)
+
 // TraceQuery traces a GraphQL query.
 func (t *Tracer) TraceQuery(ctx context.Context, queryString string, operationName string, variables map[string]interface{}, varTypes map[string]*introspection.Type) (context.Context, trace.TraceQueryFinishFunc) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "graphql.request",

--- a/contrib/graph-gophers/graphql-go/graphql.go
+++ b/contrib/graph-gophers/graphql-go/graphql.go
@@ -1,0 +1,67 @@
+package graphql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/graph-gophers/graphql-go/errors"
+	"github.com/graph-gophers/graphql-go/introspection"
+	"github.com/graph-gophers/graphql-go/trace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+const (
+	graphqlFieldTag = "graphql.field"
+	graphqlQueryTag = "graphql.query"
+	graphqlTypeTag  = "graphql.type"
+)
+
+// A Tracer implements the graphql-go/trace.Tracer interface by sending traces
+// to the Datadog tracer.
+type Tracer struct {
+	cfg *config
+}
+
+// TraceQuery traces a GraphQL query.
+func (t *Tracer) TraceQuery(ctx context.Context, queryString string, operationName string, variables map[string]interface{}, varTypes map[string]*introspection.Type) (context.Context, trace.TraceQueryFinishFunc) {
+	span, ctx := tracer.StartSpanFromContext(ctx, "graphql.request",
+		tracer.ServiceName(t.cfg.serviceName),
+		tracer.Tag(graphqlQueryTag, queryString),
+	)
+
+	return ctx, func(errs []*errors.QueryError) {
+		var err error
+		if len(errs) == 1 {
+			err = errs[0]
+		} else if len(errs) > 1 {
+			msg := errs[0].Error() +
+				fmt.Sprintf(" (and %d more errors)", len(errs)-1)
+			err = errors.Errorf("%s", msg)
+		}
+		span.Finish(tracer.WithError(err))
+	}
+}
+
+// TraceField traces a GraphQL field access.
+func (t *Tracer) TraceField(ctx context.Context, label string, typeName string, fieldName string, trivial bool, args map[string]interface{}) (context.Context, trace.TraceFieldFinishFunc) {
+	span, ctx := tracer.StartSpanFromContext(ctx, "graphql.field",
+		tracer.ServiceName(t.cfg.serviceName),
+		tracer.Tag(graphqlFieldTag, fieldName),
+		tracer.Tag(graphqlTypeTag, typeName),
+	)
+	return ctx, func(err *errors.QueryError) {
+		span.Finish(tracer.WithError(err))
+	}
+}
+
+// New creates a new Tracer.
+func New(opts ...Option) trace.Tracer {
+	cfg := new(config)
+	defaults(cfg)
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return &Tracer{
+		cfg: cfg,
+	}
+}

--- a/contrib/graph-gophers/graphql-go/graphql.go
+++ b/contrib/graph-gophers/graphql-go/graphql.go
@@ -1,4 +1,10 @@
-package graphql
+// Package graphql provides functions to trace the graph-gophers/graphql-go package (https://github.com/graph-gophers/graphql-go).
+//
+// We use the tracing mechanism available in the
+// https://godoc.org/github.com/graph-gophers/graphql-go/trace subpackage.
+// Create a new Tracer with `NewTracer` and pass it as an additional option to
+// `MustParseSchema`.
+package graphql // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/graph-gophers/graphql-go"
 
 import (
 	"context"

--- a/contrib/graph-gophers/graphql-go/graphql_test.go
+++ b/contrib/graph-gophers/graphql-go/graphql_test.go
@@ -1,0 +1,63 @@
+package graphql
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	graphql "github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+)
+
+type testResolver struct{}
+
+func (*testResolver) Hello() string { return "Hello, world!" }
+
+func Test(t *testing.T) {
+	s := `
+		schema {
+			query: Query
+		}
+		type Query {
+			hello: String!
+		}
+	`
+	schema := graphql.MustParseSchema(s, new(testResolver),
+		graphql.Tracer(New(WithServiceName("test-graphql-service"))))
+	srv := httptest.NewServer(&relay.Handler{Schema: schema})
+	defer srv.Close()
+
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	http.Post(srv.URL, "application/json", strings.NewReader(`{
+		"query": "{ hello }"
+	}`))
+
+	spans := mt.FinishedSpans()
+	assert.Len(t, spans, 2)
+	assert.Equal(t, spans[1].TraceID(), spans[0].TraceID())
+
+	{
+		s := spans[0]
+		assert.Equal(t, "hello", s.Tag(graphqlFieldTag))
+		assert.Nil(t, s.Tag(ext.Error))
+		assert.Equal(t, "test-graphql-service", s.Tag(ext.ServiceName))
+		assert.Equal(t, "Query", s.Tag(graphqlTypeTag))
+		assert.Equal(t, "graphql.field", s.OperationName())
+		assert.Equal(t, "graphql.field", s.Tag(ext.ResourceName))
+	}
+
+	{
+		s := spans[1]
+		assert.Equal(t, "{ hello }", s.Tag(graphqlQueryTag))
+		assert.Nil(t, s.Tag(ext.Error))
+		assert.Equal(t, "test-graphql-service", s.Tag(ext.ServiceName))
+		assert.Equal(t, "graphql.request", s.OperationName())
+		assert.Equal(t, "graphql.request", s.Tag(ext.ResourceName))
+	}
+}

--- a/contrib/graph-gophers/graphql-go/graphql_test.go
+++ b/contrib/graph-gophers/graphql-go/graphql_test.go
@@ -27,7 +27,7 @@ func Test(t *testing.T) {
 		}
 	`
 	schema := graphql.MustParseSchema(s, new(testResolver),
-		graphql.Tracer(New(WithServiceName("test-graphql-service"))))
+		graphql.Tracer(NewTracer(WithServiceName("test-graphql-service"))))
 	srv := httptest.NewServer(&relay.Handler{Schema: schema})
 	defer srv.Close()
 
@@ -44,17 +44,17 @@ func Test(t *testing.T) {
 
 	{
 		s := spans[0]
-		assert.Equal(t, "hello", s.Tag(graphqlFieldTag))
+		assert.Equal(t, "hello", s.Tag(tagGraphqlField))
 		assert.Nil(t, s.Tag(ext.Error))
 		assert.Equal(t, "test-graphql-service", s.Tag(ext.ServiceName))
-		assert.Equal(t, "Query", s.Tag(graphqlTypeTag))
+		assert.Equal(t, "Query", s.Tag(tagGraphqlType))
 		assert.Equal(t, "graphql.field", s.OperationName())
 		assert.Equal(t, "graphql.field", s.Tag(ext.ResourceName))
 	}
 
 	{
 		s := spans[1]
-		assert.Equal(t, "{ hello }", s.Tag(graphqlQueryTag))
+		assert.Equal(t, "{ hello }", s.Tag(tagGraphqlQuery))
 		assert.Nil(t, s.Tag(ext.Error))
 		assert.Equal(t, "test-graphql-service", s.Tag(ext.ServiceName))
 		assert.Equal(t, "graphql.request", s.OperationName())

--- a/contrib/graph-gophers/graphql-go/option.go
+++ b/contrib/graph-gophers/graphql-go/option.go
@@ -1,0 +1,17 @@
+package graphql // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/graph-gophers/graphql-go"
+
+type config struct{ serviceName string }
+
+// Option represents an option that can be used customize the Tracer.
+type Option func(*config)
+
+func defaults(cfg *config) {
+	cfg.serviceName = "graphql.server"
+}
+
+// WithServiceName sets the given service name for the client.
+func WithServiceName(name string) Option {
+	return func(cfg *config) {
+		cfg.serviceName = name
+	}
+}

--- a/contrib/graph-gophers/graphql-go/option.go
+++ b/contrib/graph-gophers/graphql-go/option.go
@@ -1,4 +1,4 @@
-package graphql // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/graph-gophers/graphql-go"
+package graphql
 
 type config struct{ serviceName string }
 


### PR DESCRIPTION
Fixes: https://github.com/DataDog/dd-trace-go/issues/286

This adds GraphQL server tracing support.