### PR TITLE
contrib: standardize span types

### DIFF
--- a/contrib/database/sql/driver.go
+++ b/contrib/database/sql/driver.go
@@ -14,10 +14,6 @@ import (
 
 var _ driver.Driver = (*tracedDriver)(nil)
 
-// SQLSpanType is the span type sent to DataDog for SQL operations.
-// This is set to "sql"
-const SQLSpanType = "sql"
-
 // tracedDriver wraps an inner sql driver with tracing. It implements the (database/sql).driver.Driver interface.
 type tracedDriver struct {
 	driver.Driver
@@ -59,7 +55,7 @@ type traceParams struct {
 func (tp *traceParams) newChildSpanFromContext(ctx context.Context, resource string, query string) ddtrace.Span {
 	name := fmt.Sprintf("%s.query", tp.driverName)
 	span, _ := tracer.StartSpanFromContext(ctx, name,
-		tracer.SpanType(SQLSpanType),
+		tracer.SpanType(ext.SpanTypeSQL),
 		tracer.ServiceName(tp.config.serviceName),
 	)
 	if query != "" {

--- a/contrib/database/sql/example_test.go
+++ b/contrib/database/sql/example_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	sqltrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	"github.com/go-sql-driver/mysql"
@@ -41,7 +42,7 @@ func Example_context() {
 
 	// Create a root span, giving name, server and resource.
 	_, ctx := tracer.StartSpanFromContext(context.Background(), "my-query",
-		tracer.SpanType(sqltrace.SQLSpanType),
+		tracer.SpanType(ext.SpanTypeSQL),
 		tracer.ServiceName("my-db"),
 		tracer.ResourceName("initial-access"),
 	)

--- a/contrib/database/sql/sql_test.go
+++ b/contrib/database/sql/sql_test.go
@@ -41,7 +41,7 @@ func TestMySQL(t *testing.T) {
 		ExpectName: "mysql.query",
 		ExpectTags: map[string]interface{}{
 			ext.ServiceName: "mysql.db",
-			ext.SpanType:    "sql",
+			ext.SpanType:    ext.SpanTypeSQL,
 			ext.TargetHost:  "127.0.0.1",
 			ext.TargetPort:  "3306",
 			"db.user":       "test",
@@ -66,7 +66,7 @@ func TestPostgres(t *testing.T) {
 		ExpectName: "postgres.query",
 		ExpectTags: map[string]interface{}{
 			ext.ServiceName: "postgres-test",
-			ext.SpanType:    "sql",
+			ext.SpanType:    ext.SpanTypeSQL,
 			ext.TargetHost:  "127.0.0.1",
 			ext.TargetPort:  "5432",
 			"db.user":       "postgres",

--- a/contrib/garyburd/redigo/redigo.go
+++ b/contrib/garyburd/redigo/redigo.go
@@ -30,10 +30,6 @@ type params struct {
 	port    string
 }
 
-// spanType is the value that span.type is set to for traces
-// in Redis calls
-const spanType = "redis"
-
 // parseOptions parses a set of arbitrary options (which can be of type redis.DialOption
 // or the local DialOption) and returns the corresponding redis.DialOption set as well as
 // a configured dialConfig.
@@ -96,7 +92,7 @@ func DialURL(rawurl string, options ...interface{}) (redis.Conn, error) {
 func (tc Conn) newChildSpan(ctx context.Context) ddtrace.Span {
 	p := tc.params
 	span, _ := tracer.StartSpanFromContext(ctx, "redis.command",
-		tracer.SpanType(spanType),
+		tracer.SpanType(ext.SpanTypeRedis),
 		tracer.ServiceName(p.config.serviceName),
 	)
 	span.SetTag("out.network", p.network)

--- a/contrib/garyburd/redigo/redigo_test.go
+++ b/contrib/garyburd/redigo/redigo_test.go
@@ -37,7 +37,7 @@ func TestClient(t *testing.T) {
 
 	span := spans[0]
 	assert.Equal("redis.command", span.OperationName())
-	assert.Equal("redis", span.Tag(ext.SpanType))
+	assert.Equal(ext.SpanTypeRedis, span.Tag(ext.SpanType))
 	assert.Equal("my-service", span.Tag(ext.ServiceName))
 	assert.Equal("SET", span.Tag(ext.ResourceName))
 	assert.Equal("127.0.0.1", span.Tag(ext.TargetHost))

--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -20,7 +20,7 @@ func Middleware(service string) gin.HandlerFunc {
 		opts := []ddtrace.StartSpanOption{
 			tracer.ServiceName(service),
 			tracer.ResourceName(resource),
-			tracer.SpanType(ext.AppTypeWeb),
+			tracer.SpanType(ext.SpanTypeWeb),
 			tracer.Tag(ext.HTTPMethod, c.Request.Method),
 			tracer.Tag(ext.HTTPURL, c.Request.URL.Path),
 		}

--- a/contrib/gin-gonic/gin/gintrace_test.go
+++ b/contrib/gin-gonic/gin/gintrace_test.go
@@ -67,7 +67,7 @@ func TestTrace200(t *testing.T) {
 	}
 	span := spans[0]
 	assert.Equal("http.request", span.OperationName())
-	assert.Equal(ext.AppTypeWeb, span.Tag(ext.SpanType))
+	assert.Equal(ext.SpanTypeWeb, span.Tag(ext.SpanType))
 	assert.Equal("foobar", span.Tag(ext.ServiceName))
 	assert.Contains(span.Tag(ext.ResourceName), "gin.TestTrace200")
 	assert.Equal("200", span.Tag(ext.HTTPCode))

--- a/contrib/go-redis/redis/example_test.go
+++ b/contrib/go-redis/redis/example_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-redis/redis"
 	redistrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/go-redis/redis"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
@@ -21,7 +22,7 @@ func Example() {
 
 	// optionally, create a new root span
 	root, ctx := tracer.StartSpanFromContext(context.Background(), "parent.request",
-		tracer.SpanType("redis"),
+		tracer.SpanType(ext.SpanTypeRedis),
 		tracer.ServiceName("web"),
 		tracer.ResourceName("/home"),
 	)

--- a/contrib/go-redis/redis/redis.go
+++ b/contrib/go-redis/redis/redis.go
@@ -35,10 +35,6 @@ type params struct {
 	config *clientConfig
 }
 
-// spanType is the value that span.type is set to when recording
-// a trace through a Redis call.
-const spanType = "redis"
-
 // NewClient returns a new Client that is traced with the default tracer under
 // the service name "redis".
 func NewClient(opt *redis.Options, opts ...ClientOption) *Client {
@@ -88,7 +84,7 @@ func (c *Pipeliner) Exec() ([]redis.Cmder, error) {
 func (c *Pipeliner) execWithContext(ctx context.Context) ([]redis.Cmder, error) {
 	p := c.params
 	span, _ := tracer.StartSpanFromContext(ctx, "redis.command",
-		tracer.SpanType(spanType),
+		tracer.SpanType(ext.SpanTypeRedis),
 		tracer.ServiceName(p.config.serviceName),
 		tracer.ResourceName("redis"),
 		tracer.Tag(ext.TargetHost, p.host),
@@ -135,7 +131,7 @@ func createWrapperFromClient(tc *Client) func(oldProcess func(cmd redis.Cmder) e
 			length := len(parts) - 1
 			p := tc.params
 			span, _ := tracer.StartSpanFromContext(ctx, "redis.command",
-				tracer.SpanType(spanType),
+				tracer.SpanType(ext.SpanTypeRedis),
 				tracer.ServiceName(p.config.serviceName),
 				tracer.ResourceName(parts[0]),
 				tracer.Tag(ext.TargetHost, p.host),

--- a/contrib/go-redis/redis/redis_test.go
+++ b/contrib/go-redis/redis/redis_test.go
@@ -40,7 +40,7 @@ func TestClient(t *testing.T) {
 
 	span := spans[0]
 	assert.Equal("redis.command", span.OperationName())
-	assert.Equal("redis", span.Tag(ext.SpanType))
+	assert.Equal(ext.SpanTypeRedis, span.Tag(ext.SpanType))
 	assert.Equal("my-redis", span.Tag(ext.ServiceName))
 	assert.Equal("127.0.0.1", span.Tag(ext.TargetHost))
 	assert.Equal("6379", span.Tag(ext.TargetPort))
@@ -66,7 +66,7 @@ func TestPipeline(t *testing.T) {
 
 	span := spans[0]
 	assert.Equal("redis.command", span.OperationName())
-	assert.Equal("redis", span.Tag(ext.SpanType))
+	assert.Equal(ext.SpanTypeRedis, span.Tag(ext.SpanType))
 	assert.Equal("my-redis", span.Tag(ext.ServiceName))
 	assert.Equal("expire pipeline_counter 3600: false\n", span.Tag(ext.ResourceName))
 	assert.Equal("127.0.0.1", span.Tag(ext.TargetHost))
@@ -85,7 +85,7 @@ func TestPipeline(t *testing.T) {
 
 	span = spans[0]
 	assert.Equal("redis.command", span.OperationName())
-	assert.Equal("redis", span.Tag(ext.SpanType))
+	assert.Equal(ext.SpanTypeRedis, span.Tag(ext.SpanType))
 	assert.Equal("my-redis", span.Tag(ext.ServiceName))
 	assert.Equal("expire pipeline_counter 3600: false\nexpire pipeline_counter_1 60: false\n", span.Tag(ext.ResourceName))
 	assert.Equal("2", span.Tag("redis.pipeline_length"))

--- a/contrib/gocql/gocql/example_test.go
+++ b/contrib/gocql/gocql/example_test.go
@@ -18,7 +18,7 @@ func Example() {
 
 	// Use context to pass information down the call chain
 	_, ctx := tracer.StartSpanFromContext(context.Background(), "parent.request",
-		tracer.SpanType(ext.AppTypeDB),
+		tracer.SpanType(ext.SpanTypeCassandra),
 		tracer.ServiceName("web"),
 		tracer.ResourceName("/home"),
 	)

--- a/contrib/gocql/gocql/gocql.go
+++ b/contrib/gocql/gocql/gocql.go
@@ -34,10 +34,6 @@ type params struct {
 	paginated bool
 }
 
-// spanType the value that span.type is set to when tracing a
-// Cassandra call.
-const spanType = "cassandra"
-
 // WrapQuery wraps a gocql.Query into a traced Query under the given service name.
 // Note that the returned Query structure embeds the original gocql.Query structure.
 // This means that any method returning the query for chaining that is not part
@@ -85,7 +81,7 @@ func (tq *Query) PageState(state []byte) *Query {
 func (tq *Query) newChildSpan(ctx context.Context) ddtrace.Span {
 	p := tq.params
 	span, _ := tracer.StartSpanFromContext(ctx, ext.CassandraQuery,
-		tracer.SpanType(spanType),
+		tracer.SpanType(ext.SpanTypeCassandra),
 		tracer.ServiceName(p.config.serviceName),
 		tracer.ResourceName(p.config.resourceName),
 		tracer.Tag(ext.CassandraPaginated, fmt.Sprintf("%t", p.paginated)),

--- a/contrib/internal/httputil/trace.go
+++ b/contrib/internal/httputil/trace.go
@@ -16,7 +16,7 @@ import (
 // TraceAndServe will apply tracing to the given http.Handler using the passed tracer under the given service and resource.
 func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, service, resource string, spanopts ...ddtrace.StartSpanOption) {
 	opts := append([]ddtrace.StartSpanOption{
-		tracer.SpanType(ext.AppTypeWeb),
+		tracer.SpanType(ext.SpanTypeWeb),
 		tracer.ServiceName(service),
 		tracer.ResourceName(resource),
 		tracer.Tag(ext.HTTPMethod, r.Method),

--- a/contrib/internal/httputil/trace_test.go
+++ b/contrib/internal/httputil/trace_test.go
@@ -38,7 +38,7 @@ func TestTraceAndServe(t *testing.T) {
 
 		assert.True(called)
 		assert.Len(spans, 1)
-		assert.Equal(ext.AppTypeWeb, span.Tag(ext.SpanType))
+		assert.Equal(ext.SpanTypeWeb, span.Tag(ext.SpanType))
 		assert.Equal("service", span.Tag(ext.ServiceName))
 		assert.Equal("resource", span.Tag(ext.ResourceName))
 		assert.Equal("GET", span.Tag(ext.HTTPMethod))

--- a/contrib/jmoiron/sqlx/sql_test.go
+++ b/contrib/jmoiron/sqlx/sql_test.go
@@ -42,7 +42,7 @@ func TestMySQL(t *testing.T) {
 		ExpectName: "mysql.query",
 		ExpectTags: map[string]interface{}{
 			ext.ServiceName: "mysql-test",
-			ext.SpanType:    "sql",
+			ext.SpanType:    ext.SpanTypeSQL,
 			ext.TargetHost:  "127.0.0.1",
 			ext.TargetPort:  "3306",
 			"db.user":       "test",
@@ -67,7 +67,7 @@ func TestPostgres(t *testing.T) {
 		ExpectName: "postgres.query",
 		ExpectTags: map[string]interface{}{
 			ext.ServiceName: "postgres.db",
-			ext.SpanType:    "sql",
+			ext.SpanType:    ext.SpanTypeSQL,
 			ext.TargetHost:  "127.0.0.1",
 			ext.TargetPort:  "5432",
 			"db.user":       "postgres",

--- a/contrib/olivere/elastic/elastictrace.go
+++ b/contrib/olivere/elastic/elastictrace.go
@@ -24,10 +24,6 @@ func NewHTTPClient(opts ...ClientOption) *http.Client {
 	return &http.Client{Transport: &httpTransport{config: cfg}}
 }
 
-// spanType the value that `span.type` is set to when sending
-// ElasticSearch trace data to DataDog.
-const spanType = "elasticsearch"
-
 // httpTransport is a traced HTTP transport that captures Elasticsearch spans.
 type httpTransport struct{ config *clientConfig }
 
@@ -43,7 +39,7 @@ func (t *httpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	resource := quantize(url, method)
 	span, _ := tracer.StartSpanFromContext(req.Context(), "elasticsearch.query",
 		tracer.ServiceName(t.config.serviceName),
-		tracer.SpanType(spanType),
+		tracer.SpanType(ext.SpanTypeElasticSearch),
 		tracer.ResourceName(resource),
 		tracer.Tag("elasticsearch.method", method),
 		tracer.Tag("elasticsearch.url", url),

--- a/ddtrace/ext/app_types.go
+++ b/ddtrace/ext/app_types.go
@@ -1,23 +1,55 @@
 package ext // import "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 
+// App types determine how to categorize a trace in the Datadog application.
+// For more fine-grained behaviour, use the SpanType* constants.
 const (
+	// DEPRECATED: Use SpanTypeWeb
 	// AppTypeWeb specifies the Web span type and can be used as a tag value
 	// for a span's SpanType tag.
 	AppTypeWeb = "web"
 
-	// AppTypeHTTP specifies the HTTP span type and can be used as a tag value
-	// for a span's SpanType tag.
-	AppTypeHTTP = "http"
-
 	// AppTypeDB specifies the DB span type and can be used as a tag value
-	// for a span's SpanType tag.
+	// for a span's SpanType tag. If possible, use one of the SpanType*
+	// constants for a more accurate indication.
 	AppTypeDB = "db"
 
 	// AppTypeCache specifies the Cache span type and can be used as a tag value
-	// for a span's SpanType tag.
+	// for a span's SpanType tag. If possible, consider using SpanTypeRedis or
+	// SpanTypeMemcached.
 	AppTypeCache = "cache"
 
 	// AppTypeRPC specifies the RPC span type and can be used as a tag value
 	// for a span's SpanType tag.
 	AppTypeRPC = "rpc"
+)
+
+// Span types have similar behaviour to "app types" and help categorize
+// traces in the Datadog application. They can also help fine grain agent
+// level bahviours such as obfuscation and quantization, when these are
+// enabled in the agent's configuration.
+const (
+	// SpanTypeWeb marks a span as an HTTP server request.
+	SpanTypeWeb = "web"
+
+	// SpanTypeHTTP marks a span as an HTTP client request.
+	SpanTypeHTTP = "http"
+
+	// SpanTypeSQL marks a span as an SQL operation. These spans may
+	// have an "sql.command" tag.
+	SpanTypeSQL = "sql"
+
+	// SpanTypeCassandra marks a span as a Cassandra operation. These
+	// spans may have an "sql.command" tag.
+	SpanTypeCassandra = "cassandra"
+
+	// SpanTypeRedis marks a span as a Redis operation. These spans may
+	// also have a "redis.raw_command" tag.
+	SpanTypeRedis = "redis"
+
+	// SpanTypeMemcached marks a span as a memcached operation.
+	SpanTypeMemcached = "memcached"
+
+	// SpanTypeElasticSearch marks a span as an ElasticSearch operation.
+	// These spans may also have an "elasticsearch.body" tag.
+	SpanTypeElasticSearch = "elasticsearch"
 )

--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -27,6 +27,10 @@ const (
 	// HTTPURL sets the HTTP URL for a span.
 	HTTPURL = "http.url"
 
+	// TODO: In the next major version, suffix these constants (SpanType, etc)
+	// with "*Key" (SpanTypeKey, etc) to more easily differentiate between
+	// constants representing tag values and constants representing keys.
+
 	// SpanType defines the Span type (web, db, cache).
 	SpanType = "span.type"
 


### PR DESCRIPTION
This change adds a set of `SpanType*` constants to the `ext` package
outlining all the possible span types that are currently used or can be
used by the agent. It also updates the entire codebase to make use of
these constants wherever possible.

The remaining `AppType*` constants are being discouraged from usage and
should be used only to categorize traces in the UI when no better
alternative exists.