### PR TITLE
ddtrace/tracer: remove false claim from documentation

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -154,8 +154,8 @@ func FinishTime(t time.Time) FinishOption {
 	}
 }
 
-// WithError adds the given error to the span before marking it as finished. If it is
-// nil it will be disregarded.
+// WithError marks the span as having had an error. It uses the information from
+// err to set tags such as the error message, error type and stack trace.
 func WithError(err error) FinishOption {
 	return func(cfg *ddtrace.FinishConfig) {
 		cfg.Error = err


### PR DESCRIPTION
Documentation states that passing a "nil" error to the `WithError`
option would not mark the span as erroneous. This is false under
circumstances when the error points to a nil pointer interface.

Since this is a subtle difference, the change removes this statement
from the documentation to avoid misleading beginners.

See: https://golang.org/doc/faq#nil_error