### PR TITLE
contrib/Shopify/sarama: add support for tracing the sarama kafka package

### DIFF
--- a/contrib/Shopify/sarama/example_test.go
+++ b/contrib/Shopify/sarama/example_test.go
@@ -27,13 +27,16 @@ func Example_asyncProducer() {
 }
 
 func Example_syncProducer() {
-	producer, err := sarama.NewSyncProducer([]string{"localhost:9092"}, nil)
+	cfg := sarama.NewConfig()
+	cfg.Producer.Return.Successes = true
+
+	producer, err := sarama.NewSyncProducer([]string{"localhost:9092"}, cfg)
 	if err != nil {
 		panic(err)
 	}
 	defer producer.Close()
 
-	producer = saramatrace.WrapSyncProducer(producer)
+	producer = saramatrace.WrapSyncProducer(cfg, producer)
 
 	msg := &sarama.ProducerMessage{
 		Topic: "some-topic",

--- a/contrib/Shopify/sarama/example_test.go
+++ b/contrib/Shopify/sarama/example_test.go
@@ -1,0 +1,74 @@
+package sarama_test
+
+import (
+	"log"
+
+	saramatrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/Shopify/sarama"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	sarama "gopkg.in/Shopify/sarama.v1"
+)
+
+func Example_asyncProducer() {
+	cfg := sarama.NewConfig()
+
+	producer, err := sarama.NewAsyncProducer([]string{"localhost:9092"}, cfg)
+	if err != nil {
+		panic(err)
+	}
+	defer producer.Close()
+
+	producer = saramatrace.WrapAsyncProducer(cfg, producer)
+
+	msg := &sarama.ProducerMessage{
+		Topic: "some-topic",
+		Value: sarama.StringEncoder("Hello World"),
+	}
+	producer.Input() <- msg
+}
+
+func Example_syncProducer() {
+	producer, err := sarama.NewSyncProducer([]string{"localhost:9092"}, nil)
+	if err != nil {
+		panic(err)
+	}
+	defer producer.Close()
+
+	producer = saramatrace.WrapSyncProducer(producer)
+
+	msg := &sarama.ProducerMessage{
+		Topic: "some-topic",
+		Value: sarama.StringEncoder("Hello World"),
+	}
+	_, _, err = producer.SendMessage(msg)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func Example_consumer() {
+	consumer, err := sarama.NewConsumer([]string{"localhost:9092"}, nil)
+	if err != nil {
+		panic(err)
+	}
+	defer consumer.Close()
+
+	consumer = saramatrace.WrapConsumer(consumer)
+
+	partitionConsumer, err := consumer.ConsumePartition("some-topic", 0, sarama.OffsetNewest)
+	if err != nil {
+		panic(err)
+	}
+	defer partitionConsumer.Close()
+
+	consumed := 0
+	for msg := range partitionConsumer.Messages() {
+		// if you want to use the kafka message as a parent span:
+		if spanctx, err := tracer.Extract(saramatrace.NewConsumerMessageCarrier(msg)); err == nil {
+			// you can create a span using ChildOf(spanctx)
+			_ = spanctx
+		}
+
+		log.Printf("Consumed message offset %d\n", msg.Offset)
+		consumed++
+	}
+}

--- a/contrib/Shopify/sarama/headers.go
+++ b/contrib/Shopify/sarama/headers.go
@@ -1,0 +1,90 @@
+package sarama
+
+import (
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	sarama "gopkg.in/Shopify/sarama.v1"
+)
+
+// A ProducerMessageCarrier injects and extracts traces from a sarama.ProducerMessage.
+type ProducerMessageCarrier struct {
+	msg *sarama.ProducerMessage
+}
+
+var _ interface {
+	tracer.TextMapReader
+	tracer.TextMapWriter
+} = (*ProducerMessageCarrier)(nil)
+
+// ForeachKey iterates over every header.
+func (c ProducerMessageCarrier) ForeachKey(handler func(key, val string) error) error {
+	for _, h := range c.msg.Headers {
+		err := handler(string(h.Key), string(h.Value))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Set sets a header.
+func (c ProducerMessageCarrier) Set(key, val string) {
+	// ensure uniqueness of keys
+	for i := 0; i < len(c.msg.Headers); i++ {
+		if string(c.msg.Headers[i].Key) == key {
+			c.msg.Headers = append(c.msg.Headers[:i], c.msg.Headers[i+1:]...)
+			i--
+		}
+	}
+	c.msg.Headers = append(c.msg.Headers, sarama.RecordHeader{
+		Key:   []byte(key),
+		Value: []byte(val),
+	})
+}
+
+// NewProducerMessageCarrier creates a new ProducerMessageCarrier.
+func NewProducerMessageCarrier(msg *sarama.ProducerMessage) ProducerMessageCarrier {
+	return ProducerMessageCarrier{msg}
+}
+
+// A ConsumerMessageCarrier injects and extracts traces from a sarama.ConsumerMessage.
+type ConsumerMessageCarrier struct {
+	msg *sarama.ConsumerMessage
+}
+
+var _ interface {
+	tracer.TextMapReader
+	tracer.TextMapWriter
+} = (*ConsumerMessageCarrier)(nil)
+
+// NewConsumerMessageCarrier creates a new ConsumerMessageCarrier.
+func NewConsumerMessageCarrier(msg *sarama.ConsumerMessage) ConsumerMessageCarrier {
+	return ConsumerMessageCarrier{msg}
+}
+
+// ForeachKey iterates over every header.
+func (c ConsumerMessageCarrier) ForeachKey(handler func(key, val string) error) error {
+	for _, h := range c.msg.Headers {
+		if h != nil {
+			err := handler(string(h.Key), string(h.Value))
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Set sets a header.
+func (c ConsumerMessageCarrier) Set(key, val string) {
+	// ensure uniqueness of keys
+	for i := 0; i < len(c.msg.Headers); i++ {
+		if c.msg.Headers[i] != nil && string(c.msg.Headers[i].Key) == key {
+			c.msg.Headers = append(c.msg.Headers[:i], c.msg.Headers[i+1:]...)
+			i--
+		}
+	}
+	c.msg.Headers = append(c.msg.Headers, &sarama.RecordHeader{
+		Key:   []byte(key),
+		Value: []byte(val),
+	})
+}

--- a/contrib/Shopify/sarama/option.go
+++ b/contrib/Shopify/sarama/option.go
@@ -1,0 +1,19 @@
+package sarama
+
+type config struct {
+	serviceName string
+}
+
+func defaults(cfg *config) {
+	cfg.serviceName = "kafka"
+}
+
+// An Option is used to customize the config for the sarama tracer.
+type Option func(cfg *config)
+
+// WithServiceName sets the given service name for the intercepted client.
+func WithServiceName(name string) Option {
+	return func(cfg *config) {
+		cfg.serviceName = name
+	}
+}

--- a/contrib/Shopify/sarama/sarama.go
+++ b/contrib/Shopify/sarama/sarama.go
@@ -1,4 +1,5 @@
-package sarama
+// Package sarama provides functions to trace the Shopify/sarama package (https://github.com/Shopify/sarama).
+package sarama // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/Shopify/sarama"
 
 import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"

--- a/contrib/Shopify/sarama/sarama.go
+++ b/contrib/Shopify/sarama/sarama.go
@@ -1,0 +1,232 @@
+package sarama
+
+import (
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	sarama "gopkg.in/Shopify/sarama.v1"
+)
+
+type partitionConsumer struct {
+	sarama.PartitionConsumer
+	messages chan *sarama.ConsumerMessage
+}
+
+// Messages returns the read channel for the messages that are returned by
+// the broker.
+func (pc *partitionConsumer) Messages() <-chan *sarama.ConsumerMessage {
+	return pc.messages
+}
+
+// WrapPartitionConsumer wraps a sarama.PartitionConsumer causing each received
+// message to be traced.
+func WrapPartitionConsumer(pc sarama.PartitionConsumer) sarama.PartitionConsumer {
+	wrapped := &partitionConsumer{
+		PartitionConsumer: pc,
+		messages:          make(chan *sarama.ConsumerMessage),
+	}
+	go func() {
+		msgs := pc.Messages()
+		var prev ddtrace.Span
+		for msg := range msgs {
+			// create the next span from the message
+			opts := []tracer.StartSpanOption{
+				tracer.ServiceName("kafka"),
+				tracer.ResourceName("Consume Topic " + msg.Topic),
+				tracer.SpanType(ext.SpanTypeMessageConsumer),
+				tracer.Tag("partition", msg.Partition),
+				tracer.Tag("offset", msg.Offset),
+			}
+			// kafka supports headers, so try to extract a span context
+			carrier := NewConsumerMessageCarrier(msg)
+			if spanctx, err := tracer.Extract(carrier); err == nil {
+				opts = append(opts, tracer.ChildOf(spanctx))
+			}
+			next := tracer.StartSpan("kafka.consume", opts...)
+			// reinject the span context so consumers can pick it up
+			tracer.Inject(next.Context(), carrier)
+
+			wrapped.messages <- msg
+
+			// if the next message was received, finish the previous span
+			if prev != nil {
+				prev.Finish()
+			}
+			prev = next
+		}
+		// finish any remaining span
+		if prev != nil {
+			prev.Finish()
+		}
+		close(wrapped.messages)
+	}()
+	return wrapped
+}
+
+type consumer struct {
+	sarama.Consumer
+}
+
+// ConsumePartition invokes Consumer.ConsumePartition and wraps the resulting
+// PartitionConsumer.
+func (c *consumer) ConsumePartition(topic string, partition int32, offset int64) (sarama.PartitionConsumer, error) {
+	pc, err := c.Consumer.ConsumePartition(topic, partition, offset)
+	if err != nil {
+		return pc, err
+	}
+	return WrapPartitionConsumer(pc), nil
+}
+
+// WrapConsumer wraps a sarama.Consumer wrapping any PartitionConsumer created
+// via Consumer.ConsumePartition.
+func WrapConsumer(c sarama.Consumer) sarama.Consumer {
+	return &consumer{c}
+}
+
+type syncProducer struct {
+	sarama.SyncProducer
+}
+
+// SendMessage calls sarama.SyncProducer.SendMessage and traces the request.
+func (p *syncProducer) SendMessage(msg *sarama.ProducerMessage) (partition int32, offset int64, err error) {
+	span := startProducerSpan(msg)
+	partition, offset, err = p.SyncProducer.SendMessage(msg)
+	finishProducerSpan(span, partition, offset, err)
+	return partition, offset, err
+}
+
+// SendMessages calls sarama.SyncProducer.SendMessages and traces the requests.
+func (p *syncProducer) SendMessages(msgs []*sarama.ProducerMessage) error {
+	// although there's only one call made to the SyncProducer, the messages are
+	// treated individually, so we create a span for each one
+	spans := make([]ddtrace.Span, len(msgs))
+	for i, msg := range msgs {
+		spans[i] = startProducerSpan(msg)
+	}
+	err := p.SyncProducer.SendMessages(msgs)
+	for i, span := range spans {
+		finishProducerSpan(span, msgs[i].Partition, msgs[i].Offset, err)
+	}
+	return err
+}
+
+// WrapSyncProducer wraps a sarama.SyncProducer so that all produced messages
+// are traced.
+func WrapSyncProducer(p sarama.SyncProducer) sarama.SyncProducer {
+	return &syncProducer{
+		SyncProducer: p,
+	}
+}
+
+type asyncProducer struct {
+	sarama.AsyncProducer
+	input     chan *sarama.ProducerMessage
+	successes chan *sarama.ProducerMessage
+	errors    chan *sarama.ProducerError
+}
+
+// Input returns the input channel.
+func (p *asyncProducer) Input() chan<- *sarama.ProducerMessage {
+	return p.input
+}
+
+// Successes returns the successes channel.
+func (p *asyncProducer) Successes() <-chan *sarama.ProducerMessage {
+	return p.successes
+}
+
+// Errors returns the errors channel.
+func (p *asyncProducer) Errors() <-chan *sarama.ProducerError {
+	return p.errors
+}
+
+// WrapAsyncProducer wraps a sarama.AsyncProducer so that all produced messages
+// are traced. It requires the underlying sarama Config so we can know whether
+// or not sucesses will be returned.
+func WrapAsyncProducer(cfg *sarama.Config, p sarama.AsyncProducer) sarama.AsyncProducer {
+	if cfg == nil {
+		cfg = sarama.NewConfig()
+	}
+	wrapped := &asyncProducer{
+		AsyncProducer: p,
+		input:         make(chan *sarama.ProducerMessage),
+		successes:     make(chan *sarama.ProducerMessage),
+		errors:        make(chan *sarama.ProducerError),
+	}
+	go func() {
+		type spanKey struct {
+			topic     string
+			partition int32
+			offset    int64
+		}
+		spans := make(map[spanKey]ddtrace.Span)
+		defer close(wrapped.successes)
+		defer close(wrapped.errors)
+		for {
+			select {
+			case msg := <-wrapped.input:
+				key := spanKey{msg.Topic, msg.Partition, msg.Offset}
+				span := startProducerSpan(msg)
+				p.Input() <- msg
+				if cfg.Producer.Return.Successes {
+					spans[key] = span
+				} else {
+					// if returning successes isn't enabled, we just finish the
+					// span right away because there's no way to know when it will
+					// be done
+					finishProducerSpan(span, msg.Partition, msg.Offset, nil)
+				}
+			case msg, ok := <-p.Successes():
+				if !ok {
+					// producer was closed, so exit
+					return
+				}
+
+				key := spanKey{msg.Topic, msg.Partition, msg.Offset}
+				if span, ok := spans[key]; ok {
+					delete(spans, key)
+					finishProducerSpan(span, msg.Partition, msg.Offset, nil)
+				}
+
+				wrapped.successes <- msg
+			case err, ok := <-p.Errors():
+				if !ok {
+					// producer was closed, so exit
+					return
+				}
+
+				key := spanKey{err.Msg.Topic, err.Msg.Partition, err.Msg.Offset}
+				if span, ok := spans[key]; ok {
+					delete(spans, key)
+					finishProducerSpan(span, err.Msg.Partition, err.Msg.Offset, err.Err)
+				}
+
+				wrapped.errors <- err
+			}
+		}
+	}()
+	return wrapped
+}
+
+func startProducerSpan(msg *sarama.ProducerMessage) ddtrace.Span {
+	carrier := NewProducerMessageCarrier(msg)
+	opts := []tracer.StartSpanOption{
+		tracer.ServiceName("kafka"),
+		tracer.ResourceName("Produce Topic " + msg.Topic),
+		tracer.SpanType(ext.SpanTypeMessageProducer),
+	}
+	// if there's a span context in the headers, use that as the parent
+	if spanctx, err := tracer.Extract(carrier); err == nil {
+		opts = append(opts, tracer.ChildOf(spanctx))
+	}
+	span := tracer.StartSpan("kafka.produce", opts...)
+	// re-inject the span context so consumers can pick it up
+	tracer.Inject(span.Context(), carrier)
+	return span
+}
+
+func finishProducerSpan(span ddtrace.Span, partition int32, offset int64, err error) {
+	span.SetTag("partition", partition)
+	span.SetTag("offset", offset)
+	span.Finish(tracer.WithError(err))
+}

--- a/contrib/Shopify/sarama/sarama_test.go
+++ b/contrib/Shopify/sarama/sarama_test.go
@@ -64,8 +64,8 @@ func TestConsumer(t *testing.T) {
 		assert.Equal(t, spanctx.TraceID(), s.TraceID(),
 			"span context should be injected into the consumer message headers")
 
-		assert.Equal(t, 0, s.Tag("partition"))
-		assert.Equal(t, 0, s.Tag("offset"))
+		assert.Equal(t, int32(0), s.Tag("partition"))
+		assert.Equal(t, int64(0), s.Tag("offset"))
 		assert.Equal(t, "kafka", s.Tag(ext.ServiceName))
 		assert.Equal(t, "Consume Topic test-topic", s.Tag(ext.ResourceName))
 		assert.Equal(t, "queue", s.Tag(ext.SpanType))
@@ -78,8 +78,8 @@ func TestConsumer(t *testing.T) {
 		assert.Equal(t, spanctx.TraceID(), s.TraceID(),
 			"span context should be injected into the consumer message headers")
 
-		assert.Equal(t, 0, s.Tag("partition"))
-		assert.Equal(t, 1, s.Tag("offset"))
+		assert.Equal(t, int32(0), s.Tag("partition"))
+		assert.Equal(t, int64(1), s.Tag("offset"))
 		assert.Equal(t, "kafka", s.Tag(ext.ServiceName))
 		assert.Equal(t, "Consume Topic test-topic", s.Tag(ext.ResourceName))
 		assert.Equal(t, "queue", s.Tag(ext.SpanType))
@@ -114,8 +114,8 @@ func TestSyncProducer(t *testing.T) {
 		assert.Equal(t, "queue", s.Tag(ext.SpanType))
 		assert.Equal(t, "Produce Topic my_topic", s.Tag(ext.ResourceName))
 		assert.Equal(t, "kafka.produce", s.OperationName())
-		assert.Equal(t, 0, s.Tag("partition"))
-		assert.Equal(t, 0, s.Tag("offset"))
+		assert.Equal(t, int32(0), s.Tag("partition"))
+		assert.Equal(t, int64(0), s.Tag("offset"))
 	}
 
 	mt.Reset()
@@ -133,7 +133,7 @@ func TestSyncProducer(t *testing.T) {
 		assert.Equal(t, "queue", s.Tag(ext.SpanType))
 		assert.Equal(t, "Produce Topic my_topic", s.Tag(ext.ResourceName))
 		assert.Equal(t, "kafka.produce", s.OperationName())
-		assert.Equal(t, 0, s.Tag("partition"))
+		assert.Equal(t, int32(0), s.Tag("partition"))
 	}
 
 	mt.Reset()
@@ -185,8 +185,8 @@ func TestAsyncProducer(t *testing.T) {
 			assert.Equal(t, "queue", s.Tag(ext.SpanType))
 			assert.Equal(t, "Produce Topic my_topic", s.Tag(ext.ResourceName))
 			assert.Equal(t, "kafka.produce", s.OperationName())
-			assert.Equal(t, 0, s.Tag("partition"))
-			assert.Equal(t, 0, s.Tag("offset"))
+			assert.Equal(t, int32(0), s.Tag("partition"))
+			assert.Equal(t, int64(0), s.Tag("offset"))
 		}
 	})
 
@@ -220,8 +220,8 @@ func TestAsyncProducer(t *testing.T) {
 			assert.Equal(t, "queue", s.Tag(ext.SpanType))
 			assert.Equal(t, "Produce Topic my_topic", s.Tag(ext.ResourceName))
 			assert.Equal(t, "kafka.produce", s.OperationName())
-			assert.Equal(t, 0, s.Tag("partition"))
-			assert.Equal(t, 0, s.Tag("offset"))
+			assert.Equal(t, int32(0), s.Tag("partition"))
+			assert.Equal(t, int64(0), s.Tag("offset"))
 		}
 	})
 }

--- a/contrib/Shopify/sarama/sarama_test.go
+++ b/contrib/Shopify/sarama/sarama_test.go
@@ -1,0 +1,259 @@
+package sarama
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	sarama "gopkg.in/Shopify/sarama.v1"
+)
+
+func TestConsumer(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	broker := sarama.NewMockBroker(t, 0)
+	defer broker.Close()
+
+	broker.SetHandlerByMap(map[string]sarama.MockResponse{
+		"MetadataRequest": sarama.NewMockMetadataResponse(t).
+			SetBroker(broker.Addr(), broker.BrokerID()).
+			SetLeader("test-topic", 0, broker.BrokerID()),
+		"OffsetRequest": sarama.NewMockOffsetResponse(t).
+			SetOffset("test-topic", 0, sarama.OffsetOldest, 0).
+			SetOffset("test-topic", 0, sarama.OffsetNewest, 1),
+		"FetchRequest": sarama.NewMockFetchResponse(t, 1).
+			SetMessage("test-topic", 0, 0, sarama.StringEncoder("hello")).
+			SetMessage("test-topic", 0, 1, sarama.StringEncoder("world")),
+	})
+
+	client, err := sarama.NewClient([]string{broker.Addr()}, sarama.NewConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	consumer, err := sarama.NewConsumerFromClient(client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer consumer.Close()
+
+	consumer = WrapConsumer(consumer)
+
+	partitionConsumer, err := consumer.ConsumePartition("test-topic", 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg1 := <-partitionConsumer.Messages()
+	msg2 := <-partitionConsumer.Messages()
+	partitionConsumer.Close()
+	// wait for the channel to be closed
+	<-partitionConsumer.Messages()
+
+	spans := mt.FinishedSpans()
+	assert.Len(t, spans, 2)
+	{
+		s := spans[0]
+		spanctx, err := tracer.Extract(NewConsumerMessageCarrier(msg1))
+		assert.NoError(t, err)
+		assert.Equal(t, spanctx.TraceID(), s.TraceID(),
+			"span context should be injected into the consumer message headers")
+
+		assert.Equal(t, 0, s.Tag("partition"))
+		assert.Equal(t, 0, s.Tag("offset"))
+		assert.Equal(t, "kafka", s.Tag(ext.ServiceName))
+		assert.Equal(t, "Consume Topic test-topic", s.Tag(ext.ResourceName))
+		assert.Equal(t, "queue", s.Tag(ext.SpanType))
+		assert.Equal(t, "kafka.consume", s.OperationName())
+	}
+	{
+		s := spans[1]
+		spanctx, err := tracer.Extract(NewConsumerMessageCarrier(msg2))
+		assert.NoError(t, err)
+		assert.Equal(t, spanctx.TraceID(), s.TraceID(),
+			"span context should be injected into the consumer message headers")
+
+		assert.Equal(t, 0, s.Tag("partition"))
+		assert.Equal(t, 1, s.Tag("offset"))
+		assert.Equal(t, "kafka", s.Tag(ext.ServiceName))
+		assert.Equal(t, "Consume Topic test-topic", s.Tag(ext.ResourceName))
+		assert.Equal(t, "queue", s.Tag(ext.SpanType))
+		assert.Equal(t, "kafka.consume", s.OperationName())
+	}
+}
+
+func TestSyncProducer(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	broker := newMockBroker(t)
+
+	producer, err := sarama.NewSyncProducer([]string{broker.Addr()}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	producer = WrapSyncProducer(producer)
+
+	msg1 := &sarama.ProducerMessage{
+		Topic:    "my_topic",
+		Value:    sarama.StringEncoder("test 1"),
+		Metadata: "test",
+	}
+	producer.SendMessage(msg1)
+
+	spans := mt.FinishedSpans()
+	assert.Len(t, spans, 1)
+	{
+		s := spans[0]
+		assert.Equal(t, "kafka", s.Tag(ext.ServiceName))
+		assert.Equal(t, "queue", s.Tag(ext.SpanType))
+		assert.Equal(t, "Produce Topic my_topic", s.Tag(ext.ResourceName))
+		assert.Equal(t, "kafka.produce", s.OperationName())
+		assert.Equal(t, 0, s.Tag("partition"))
+		assert.Equal(t, 0, s.Tag("offset"))
+	}
+
+	mt.Reset()
+
+	msg2 := &sarama.ProducerMessage{
+		Topic:    "my_topic",
+		Value:    sarama.StringEncoder("test 2"),
+		Metadata: "test",
+	}
+	producer.SendMessages([]*sarama.ProducerMessage{msg1, msg2})
+	spans = mt.FinishedSpans()
+	assert.Len(t, spans, 2)
+	for _, s := range spans {
+		assert.Equal(t, "kafka", s.Tag(ext.ServiceName))
+		assert.Equal(t, "queue", s.Tag(ext.SpanType))
+		assert.Equal(t, "Produce Topic my_topic", s.Tag(ext.ResourceName))
+		assert.Equal(t, "kafka.produce", s.OperationName())
+		assert.Equal(t, 0, s.Tag("partition"))
+	}
+
+	mt.Reset()
+
+	t.Run("Parent Span", func(t *testing.T) {
+		span := tracer.StartSpan("test")
+		msg3 := &sarama.ProducerMessage{
+			Topic: "my_topic",
+			Value: sarama.StringEncoder("test 1"),
+		}
+		tracer.Inject(span.Context(), NewProducerMessageCarrier(msg3))
+		producer.SendMessage(msg3)
+		span.Finish()
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 2)
+		assert.Equal(t, spans[0].TraceID(), spans[1].TraceID())
+	})
+}
+
+func TestAsyncProducer(t *testing.T) {
+	// the default for producers is a fire-and-forget model that doesn't return
+	// successes
+	t.Run("Without Successes", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		broker := newMockBroker(t)
+
+		producer, err := sarama.NewAsyncProducer([]string{broker.Addr()}, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		producer = WrapAsyncProducer(nil, producer)
+
+		msg1 := &sarama.ProducerMessage{
+			Topic: "my_topic",
+			Value: sarama.StringEncoder("test 1"),
+		}
+		producer.Input() <- msg1
+
+		waitForSpans(mt, 1, time.Second*10)
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+		{
+			s := spans[0]
+			assert.Equal(t, "kafka", s.Tag(ext.ServiceName))
+			assert.Equal(t, "queue", s.Tag(ext.SpanType))
+			assert.Equal(t, "Produce Topic my_topic", s.Tag(ext.ResourceName))
+			assert.Equal(t, "kafka.produce", s.OperationName())
+			assert.Equal(t, 0, s.Tag("partition"))
+			assert.Equal(t, 0, s.Tag("offset"))
+		}
+	})
+
+	t.Run("With Successes", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		broker := newMockBroker(t)
+
+		cfg := sarama.NewConfig()
+		cfg.Producer.Return.Successes = true
+
+		producer, err := sarama.NewAsyncProducer([]string{broker.Addr()}, cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		producer = WrapAsyncProducer(cfg, producer)
+
+		msg1 := &sarama.ProducerMessage{
+			Topic: "my_topic",
+			Value: sarama.StringEncoder("test 1"),
+		}
+		producer.Input() <- msg1
+		<-producer.Successes()
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+		{
+			s := spans[0]
+			assert.Equal(t, "kafka", s.Tag(ext.ServiceName))
+			assert.Equal(t, "queue", s.Tag(ext.SpanType))
+			assert.Equal(t, "Produce Topic my_topic", s.Tag(ext.ResourceName))
+			assert.Equal(t, "kafka.produce", s.OperationName())
+			assert.Equal(t, 0, s.Tag("partition"))
+			assert.Equal(t, 0, s.Tag("offset"))
+		}
+	})
+}
+
+func newMockBroker(t *testing.T) *sarama.MockBroker {
+	broker := sarama.NewMockBroker(t, 1)
+
+	metadataResponse := new(sarama.MetadataResponse)
+	metadataResponse.AddBroker(broker.Addr(), broker.BrokerID())
+	metadataResponse.AddTopicPartition("my_topic", 0, broker.BrokerID(), nil, nil, sarama.ErrNoError)
+	broker.Returns(metadataResponse)
+
+	prodSuccess := new(sarama.ProduceResponse)
+	prodSuccess.AddTopicPartition("my_topic", 0, sarama.ErrNoError)
+	for i := 0; i < 10; i++ {
+		broker.Returns(prodSuccess)
+	}
+	return broker
+}
+
+// waitForSpans polls the mock tracer until the expected number of spans
+// appears
+func waitForSpans(mt mocktracer.Tracer, sz int, maxWait time.Duration) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	for len(mt.FinishedSpans()) < sz {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		time.Sleep(time.Millisecond * 100)
+	}
+}

--- a/contrib/Shopify/sarama/sarama_test.go
+++ b/contrib/Shopify/sarama/sarama_test.go
@@ -243,7 +243,7 @@ func newMockBroker(t *testing.T) *sarama.MockBroker {
 }
 
 // waitForSpans polls the mock tracer until the expected number of spans
-// appears
+// appear
 func waitForSpans(mt mocktracer.Tracer, sz int, maxWait time.Duration) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()


### PR DESCRIPTION
Fixes https://github.com/DataDog/dd-trace-go/issues/295

This PR implements wrappers for `Consumer`, `SyncProducer` and `AsyncProducer`. It also implements carriers for `ProducerMessage` and `ConsumerMessage` so that span contexts can be injected and extracted.

I modeled the naming and behavior after our dd-trace-java integration.