### PR TITLE
contrib/net/http: add tracing for http.RoundTripper

### DIFF
--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -1,5 +1,11 @@
 package http
 
+import (
+	"net/http"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+)
+
 type muxConfig struct{ serviceName string }
 
 // MuxOption represents an option that can be passed to NewServeMux.
@@ -13,5 +19,38 @@ func defaults(cfg *muxConfig) {
 func WithServiceName(name string) MuxOption {
 	return func(cfg *muxConfig) {
 		cfg.serviceName = name
+	}
+}
+
+// A RoundTripperBeforeFunc can be used to modify a span before an http
+// RoundTrip is made.
+type RoundTripperBeforeFunc func(*http.Request, ddtrace.Span)
+
+// A RoundTripperAfterFunc can be used to modify a span after an http
+// RoundTrip is made. It is possible for the http Response to be nil.
+type RoundTripperAfterFunc func(*http.Response, ddtrace.Span)
+
+type roundTripperConfig struct {
+	before RoundTripperBeforeFunc
+	after  RoundTripperAfterFunc
+}
+
+// A RoundTripperOption represents an option that can be passed to
+// WrapRoundTripper.
+type RoundTripperOption func(*roundTripperConfig)
+
+// WithBefore adds a RoundTripperBeforeFunc to the RoundTripper
+// config.
+func WithBefore(f RoundTripperBeforeFunc) RoundTripperOption {
+	return func(cfg *roundTripperConfig) {
+		cfg.before = f
+	}
+}
+
+// WithAfter adds a RoundTripperAfterFunc to the RoundTripper
+// config.
+func WithAfter(f RoundTripperAfterFunc) RoundTripperOption {
+	return func(cfg *roundTripperConfig) {
+		cfg.after = f
 	}
 }

--- a/contrib/net/http/roundtripper_test.go
+++ b/contrib/net/http/roundtripper_test.go
@@ -1,0 +1,61 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+func TestRoundTripper(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(r.Header))
+		assert.NoError(t, err)
+
+		span := tracer.StartSpan("test",
+			tracer.ChildOf(spanctx))
+		defer span.Finish()
+
+		w.Write([]byte("Hello World"))
+	}))
+	defer s.Close()
+
+	rt := WrapRoundTripper(http.DefaultTransport,
+		WithBefore(func(req *http.Request, span ddtrace.Span) {
+			span.SetTag("CalledBefore", true)
+		}),
+		WithAfter(func(res *http.Response, span ddtrace.Span) {
+			span.SetTag("CalledAfter", true)
+		}))
+
+	client := &http.Client{
+		Transport: rt,
+	}
+
+	client.Get(s.URL + "/hello/world")
+
+	spans := mt.FinishedSpans()
+	assert.Len(t, spans, 2)
+	assert.Equal(t, spans[0].TraceID(), spans[1].TraceID())
+
+	s0 := spans[0]
+	assert.Equal(t, "test", s0.OperationName())
+	assert.Equal(t, "test", s0.Tag(ext.ResourceName))
+
+	s1 := spans[1]
+	assert.Equal(t, "http.request", s1.OperationName())
+	assert.Equal(t, "http.request", s1.Tag(ext.ResourceName))
+	assert.Equal(t, "200", s1.Tag(ext.HTTPCode))
+	assert.Equal(t, "GET", s1.Tag(ext.HTTPMethod))
+	assert.Equal(t, "/hello/world", s1.Tag(ext.HTTPURL))
+	assert.Equal(t, true, s1.Tag("CalledBefore"))
+	assert.Equal(t, true, s1.Tag("CalledAfter"))
+}


### PR DESCRIPTION
This pulls the http.RoundTripper out of https://github.com/DataDog/dd-trace-go/pull/298 into its own pull request. I attempted to make the relavant requested changes as well.

This fixes https://github.com/DataDog/dd-trace-go/issues/172