### PR TITLE
ddtrace/ext: add additional tags for peers and databases

### DIFF
--- a/contrib/database/sql/internal/dsn.go
+++ b/contrib/database/sql/internal/dsn.go
@@ -3,6 +3,8 @@ package internal // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql
 import (
 	"net"
 	"strings"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 )
 
 // ParseDSN parses various supported DSN types (currently mysql and postgres) into a
@@ -30,7 +32,7 @@ func ParseDSN(driverName, dsn string) (meta map[string]string, err error) {
 // map containing only the keys relevant as tracing tags, if any.
 func reduceKeys(meta map[string]string) map[string]string {
 	var keysOfInterest = map[string]string{
-		"user":             "db.user",
+		"user":             ext.DBUser,
 		"application_name": "db.application",
 		"dbname":           "db.name",
 		"host":             "out.host",

--- a/contrib/database/sql/internal/dsn_test.go
+++ b/contrib/database/sql/internal/dsn_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 )
 
 func TestParseDSN(t *testing.T) {
@@ -17,7 +18,7 @@ func TestParseDSN(t *testing.T) {
 			driverName: "postgres",
 			dsn:        "postgres://bob:secret@1.2.3.4:5432/mydb?sslmode=verify-full",
 			expected: map[string]string{
-				"db.user":  "bob",
+				ext.DBUser: "bob",
 				"out.host": "1.2.3.4",
 				"out.port": "5432",
 				"db.name":  "mydb",
@@ -28,7 +29,7 @@ func TestParseDSN(t *testing.T) {
 			dsn:        "bob:secret@tcp(1.2.3.4:5432)/mydb",
 			expected: map[string]string{
 				"db.name":  "mydb",
-				"db.user":  "bob",
+				ext.DBUser: "bob",
 				"out.host": "1.2.3.4",
 				"out.port": "5432",
 			},
@@ -41,7 +42,7 @@ func TestParseDSN(t *testing.T) {
 				"out.host":       "master-db-master-active.postgres.service.consul",
 				"db.name":        "dogdatastaging",
 				"db.application": "trace-api",
-				"db.user":        "dog",
+				ext.DBUser:       "dog",
 			},
 		},
 	} {

--- a/contrib/database/sql/sql_test.go
+++ b/contrib/database/sql/sql_test.go
@@ -44,7 +44,7 @@ func TestMySQL(t *testing.T) {
 			ext.SpanType:    ext.SpanTypeSQL,
 			ext.TargetHost:  "127.0.0.1",
 			ext.TargetPort:  "3306",
-			"db.user":       "test",
+			ext.DBUser:      "test",
 			"db.name":       "test",
 		},
 	}
@@ -69,7 +69,7 @@ func TestPostgres(t *testing.T) {
 			ext.SpanType:    ext.SpanTypeSQL,
 			ext.TargetHost:  "127.0.0.1",
 			ext.TargetPort:  "5432",
-			"db.user":       "postgres",
+			ext.DBUser:      "postgres",
 			"db.name":       "postgres",
 		},
 	}

--- a/contrib/jmoiron/sqlx/sql_test.go
+++ b/contrib/jmoiron/sqlx/sql_test.go
@@ -45,7 +45,7 @@ func TestMySQL(t *testing.T) {
 			ext.SpanType:    ext.SpanTypeSQL,
 			ext.TargetHost:  "127.0.0.1",
 			ext.TargetPort:  "3306",
-			"db.user":       "test",
+			ext.DBUser:      "test",
 			"db.name":       "test",
 		},
 	}
@@ -70,7 +70,7 @@ func TestPostgres(t *testing.T) {
 			ext.SpanType:    ext.SpanTypeSQL,
 			ext.TargetHost:  "127.0.0.1",
 			ext.TargetPort:  "5432",
-			"db.user":       "postgres",
+			ext.DBUser:      "postgres",
 			"db.name":       "postgres",
 		},
 	}

--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -54,4 +54,24 @@ const (
 
 	// Environment specifies the environment to use with a trace.
 	Environment = "env"
+
+	// PeerHostIPV4 records IPv4 host address of the peer.
+	PeerHostIPV4 = "peer.ipv4"
+	// PeerHostIPV6 records the IPv6 host address of the peer.
+	PeerHostIPV6 = "peer.ipv6"
+	// PeerService records the service name of the peer service.
+	PeerService = "peer.service"
+	// PeerHostname records the host name of the peer.
+	PeerHostname = "peer.hostname"
+	// PeerPort records the port number of the peer.
+	PeerPort = "peer.port"
+
+	// DBType indicates the type of Database.
+	DBType = "db.type"
+	// DBInstance indicates the instance name of Database.
+	DBInstance = "db.instance"
+	// DBUser indicates the user name of Database, e.g. "readonly_user" or "reporting_user".
+	DBUser = "db.user"
+	// DBStatement records a database statement for the given database type.
+	DBStatement = "db.statement"
 )


### PR DESCRIPTION
This pulls out the `ext` changes from: https://github.com/DataDog/dd-trace-go/pull/294 and uses them in database/sql.