### PR TITLE
contrib/go-redis/redis: support newer versions of go-redis/redis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,4 +92,12 @@ jobs:
     - run:
         name: Testing
         command: |
-          INTEGRATION=1 go test -v -race ./...
+          INTEGRATION=1 go test -v -race `go list ./... | grep -v contrib/go-redis/redis`
+
+    - run:
+        name: Testing contrib/go-redis/redis
+        command: |
+          (cd $GOPATH/src/github.com/go-redis/redis && git checkout v6.13.2)
+          INTEGRATION=1 go test -v -race ./contrib/go-redis/redis/...
+          (cd $GOPATH/src/github.com/go-redis/redis && git checkout master)
+          INTEGRATION=1 go test -v -race ./contrib/go-redis/redis/...

--- a/contrib/go-redis/redis/redis.go
+++ b/contrib/go-redis/redis/redis.go
@@ -107,7 +107,7 @@ func (c *Pipeliner) execWithContext(ctx context.Context) ([]redis.Cmder, error) 
 func commandsToString(cmds []redis.Cmder) string {
 	var b bytes.Buffer
 	for _, cmd := range cmds {
-		b.WriteString(cmd.String())
+		b.WriteString(cmderToString(cmd))
 		b.WriteString("\n")
 	}
 	return b.String()
@@ -126,7 +126,7 @@ func createWrapperFromClient(tc *Client) func(oldProcess func(cmd redis.Cmder) e
 	return func(oldProcess func(cmd redis.Cmder) error) func(cmd redis.Cmder) error {
 		return func(cmd redis.Cmder) error {
 			ctx := tc.Client.Context()
-			raw := cmd.String()
+			raw := cmderToString(cmd)
 			parts := strings.Split(raw, " ")
 			length := len(parts) - 1
 			p := tc.params
@@ -149,4 +149,24 @@ func createWrapperFromClient(tc *Client) func(oldProcess func(cmd redis.Cmder) e
 			return err
 		}
 	}
+}
+
+func cmderToString(cmd redis.Cmder) string {
+	// We want to support multiple versions of the go-redis library. In
+	// older versions Cmder implements the Stringer interface, while in
+	// newer versions that was removed, and this String method which
+	// sometimes returns an error is used instead. By doing a type assertion
+	// we can support both versions.
+	if s, ok := cmd.(interface{ String() string }); ok {
+		return s.String()
+	}
+
+	if s, ok := cmd.(interface{ String() (string, error) }); ok {
+		str, err := s.String()
+		if err == nil {
+			return str
+		}
+	}
+
+	return ""
 }


### PR DESCRIPTION
Fixes https://github.com/DataDog/dd-trace-go/issues/317. The `String` method on `Cmder` was removed.