### PR TITLE
ddtrace/tracer: reset payload after every transport attempt

### DIFF
--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -300,16 +300,10 @@ func (t *tracer) flushTraces() {
 		log.Printf("Sending payload: size: %d traces: %d\n", size, count)
 	}
 	err := t.config.transport.send(t.payload)
-	if err != nil && size > payloadMaxLimit {
-		// we couldn't send the payload and it is getting too big to be
-		// accepted by the agent, we have to drop it.
-		t.payload.reset()
+	if err != nil {
 		t.pushError(&dataLossError{context: err, count: count})
 	}
-	if err == nil {
-		// send succeeded
-		t.payload.reset()
-	}
+	t.payload.reset()
 }
 
 // flushErrors will process log messages that were queued


### PR DESCRIPTION
**TODO**
- [x] Revert staged version (Aug 22 10:45 AM EDT) before merging.

**Change description**

Previously, we were attempting to save the payload as long as the size
allows it in order to attempt and send it again on subsequent retries to
minimize the loss of traces.

This has proven to be a bad approach because there were cases where the
trace agent did only partial reads from the payload before failing,
leaving the payload in a state where it was impossible to decode using
msgpack (part of the buffer was already read).

This fix is an intermediary easy solution to the problem (we have
experimented with different approaches too, see #275). We can potentially
experiment later on with retry policies.

Closes #276 