### PR TITLE
ddtrace/tracer: replace headers when injecting

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -17,8 +17,7 @@ var _ TextMapReader = (*HTTPHeadersCarrier)(nil)
 
 // Set implements TextMapWriter.
 func (c HTTPHeadersCarrier) Set(key, val string) {
-	h := http.Header(c)
-	h.Add(key, val)
+	http.Header(c).Set(key, val)
 }
 
 // ForeachKey implements TextMapReader.


### PR DESCRIPTION
Previously, we were using `Add` to inject propagation headers. This could
be problematic when a request is forwarded from another service and
already has headers injected. The resulting target may pick up the wrong
context. We should use `Set` to replace any existing values.