### PR TITLE
tracer/transport: Added URL info to error messages.

### DIFF
--- a/ddtrace/tracer/transport.go
+++ b/ddtrace/tracer/transport.go
@@ -85,7 +85,7 @@ func (t *httpTransport) send(p *payload) error {
 	// prepare the client and send the payload
 	req, err := http.NewRequest("POST", t.traceURL, p)
 	if err != nil {
-		return fmt.Errorf("cannot create http request: %v", err)
+		return fmt.Errorf("cannot create http request (URL: %s): %v", t.traceURL, err)
 	}
 	for header, value := range t.headers {
 		req.Header.Set(header, value)
@@ -94,7 +94,7 @@ func (t *httpTransport) send(p *payload) error {
 	req.Header.Set("Content-Length", strconv.Itoa(p.size()))
 	response, err := t.client.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("send to %s failed: %v", t.traceURL, err)
 	}
 	defer response.Body.Close()
 	if code := response.StatusCode; code >= 400 {
@@ -104,9 +104,9 @@ func (t *httpTransport) send(p *payload) error {
 		n, _ := response.Body.Read(msg)
 		txt := http.StatusText(code)
 		if n > 0 {
-			return fmt.Errorf("%s (Status: %s)", msg[:n], txt)
+			return fmt.Errorf("%s (URL: %s) (Status: %s)", msg[:n], t.traceURL, txt)
 		}
-		return fmt.Errorf("%s", txt)
+		return fmt.Errorf("%s (URL: %s)", txt, t.traceURL)
 	}
 	return nil
 }

--- a/ddtrace/tracer/transport.go
+++ b/ddtrace/tracer/transport.go
@@ -85,7 +85,7 @@ func (t *httpTransport) send(p *payload) error {
 	// prepare the client and send the payload
 	req, err := http.NewRequest("POST", t.traceURL, p)
 	if err != nil {
-		return fmt.Errorf("cannot create http request (URL: %s): %v", t.traceURL, err)
+		return fmt.Errorf("cannot create http request (url: %s): %v", t.traceURL, err)
 	}
 	for header, value := range t.headers {
 		req.Header.Set(header, value)
@@ -104,9 +104,9 @@ func (t *httpTransport) send(p *payload) error {
 		n, _ := response.Body.Read(msg)
 		txt := http.StatusText(code)
 		if n > 0 {
-			return fmt.Errorf("%s (URL: %s) (Status: %s)", msg[:n], t.traceURL, txt)
+			return fmt.Errorf("%s (url: %s) (status: %s)", msg[:n], t.traceURL, txt)
 		}
-		return fmt.Errorf("%s (URL: %s)", txt, t.traceURL)
+		return fmt.Errorf("%s (url: %s)", txt, t.traceURL)
 	}
 	return nil
 }

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -129,7 +129,7 @@ func TestTransportResponseError(t *testing.T) {
 	log.Println(addr)
 	transport := newHTTPTransport(addr)
 	err = transport.send(newPayload())
-	want := fmt.Sprintf("%s (URL: http://%s/v0.3/traces) (Status: Bad Request)", strings.Repeat("X", 1000), addr)
+	want := fmt.Sprintf("%s (url: http://%s/v0.3/traces) (status: Bad Request)", strings.Repeat("X", 1000), addr)
 	assert.Equal(want, err.Error())
 }
 

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -129,7 +129,7 @@ func TestTransportResponseError(t *testing.T) {
 	log.Println(addr)
 	transport := newHTTPTransport(addr)
 	err = transport.send(newPayload())
-	want := fmt.Sprintf("%s (Status: Bad Request)", strings.Repeat("X", 1000))
+	want := fmt.Sprintf("%s (URL: http://%s/v0.3/traces) (Status: Bad Request)", strings.Repeat("X", 1000), addr)
 	assert.Equal(want, err.Error())
 }
 


### PR DESCRIPTION
Currently, when the Go integration library fails to send span data to the agent, it doesn't include information about the endpoint to which it is attempting to post.  Making it difficult to debug why the error is happening.  This PR adds the URL to the error messages being returned by `send` in order to make debugging easier.