### PR TITLE
ddtrace/tracer: support int64 ids for the text map reader

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -165,12 +165,12 @@ func (p *propagator) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 		key := strings.ToLower(k)
 		switch key {
 		case p.cfg.TraceHeader:
-			ctx.traceID, err = strconv.ParseUint(v, 10, 64)
+			ctx.traceID, err = parseUint64(v)
 			if err != nil {
 				return ErrSpanContextCorrupted
 			}
 		case p.cfg.ParentHeader:
-			ctx.spanID, err = strconv.ParseUint(v, 10, 64)
+			ctx.spanID, err = parseUint64(v)
 			if err != nil {
 				return ErrSpanContextCorrupted
 			}

--- a/ddtrace/tracer/util.go
+++ b/ddtrace/tracer/util.go
@@ -1,5 +1,10 @@
 package tracer
 
+import (
+	"strconv"
+	"strings"
+)
+
 // toFloat64 attempts to convert value into a float64. If it succeeds it returns
 // the value and true, otherwise 0 and false.
 func toFloat64(value interface{}) (f float64, ok bool) {
@@ -29,4 +34,17 @@ func toFloat64(value interface{}) (f float64, ok bool) {
 	default:
 		return 0, false
 	}
+}
+
+// parseUint64 parses a uint64 from either an unsigned 64 bit base-10 string
+// or a signed 64 bit base-10 string representing an unsigned integer
+func parseUint64(str string) (uint64, error) {
+	if strings.HasPrefix(str, "-") {
+		id, err := strconv.ParseInt(str, 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		return uint64(id), nil
+	}
+	return strconv.ParseUint(str, 10, 64)
 }

--- a/ddtrace/tracer/util_test.go
+++ b/ddtrace/tracer/util_test.go
@@ -2,7 +2,10 @@ package tracer
 
 import (
 	"fmt"
+	"math"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestToFloat64(t *testing.T) {
@@ -35,4 +38,21 @@ func TestToFloat64(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseUint64(t *testing.T) {
+	t.Run("negative", func(t *testing.T) {
+		id, err := parseUint64("-8809075535603237910")
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(9637668538106313706), id)
+	})
+	t.Run("positive", func(t *testing.T) {
+		id, err := parseUint64(fmt.Sprintf("%d", uint64(math.MaxUint64)))
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(math.MaxUint64), id)
+	})
+	t.Run("invalid", func(t *testing.T) {
+		_, err := parseUint64("abcd")
+		assert.Error(t, err)
+	})
 }

--- a/ddtrace/tracer/util_test.go
+++ b/ddtrace/tracer/util_test.go
@@ -46,11 +46,13 @@ func TestParseUint64(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, uint64(9637668538106313706), id)
 	})
+
 	t.Run("positive", func(t *testing.T) {
 		id, err := parseUint64(fmt.Sprintf("%d", uint64(math.MaxUint64)))
 		assert.NoError(t, err)
 		assert.Equal(t, uint64(math.MaxUint64), id)
 	})
+
 	t.Run("invalid", func(t *testing.T) {
 		_, err := parseUint64("abcd")
 		assert.Error(t, err)


### PR DESCRIPTION
For distributed tracing some languages are passing through int64s instead of uint64s. It's fairly straightforward to support both.