### PR TITLE
cntrib/google.golang.org/grpc: fix overwriting outgoing context

### DIFF
--- a/contrib/google.golang.org/grpc/client.go
+++ b/contrib/google.golang.org/grpc/client.go
@@ -161,7 +161,7 @@ func injectSpanIntoContext(ctx context.Context) context.Context {
 	if !ok {
 		return ctx
 	}
-	md, ok := metadata.FromIncomingContext(ctx)
+	md, ok := metadata.FromOutgoingContext(ctx)
 	if ok {
 		// we have to copy the metadata because its not safe to modify
 		md = md.Copy()


### PR DESCRIPTION
Fixed a bug where the previously set context value will be overwritten.
Also, official docs recommended uses `metadata.AppendToOutgoingContext` function.

ref. https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md#sending-metadata