### PR TITLE
contrib/google.golang.org/grpc: add unit test for metadata

### DIFF
--- a/contrib/google.golang.org/grpc/client.go
+++ b/contrib/google.golang.org/grpc/client.go
@@ -161,7 +161,7 @@ func injectSpanIntoContext(ctx context.Context) context.Context {
 	if !ok {
 		return ctx
 	}
-	md, ok := metadata.FromIncomingContext(ctx)
+	md, ok := metadata.FromOutgoingContext(ctx)
 	if ok {
 		// we have to copy the metadata because its not safe to modify
 		md = md.Copy()


### PR DESCRIPTION
Closes https://github.com/DataDog/dd-trace-go/pull/327.

This adds a unit test to the work done by @osamingo. I confirmed that the test fails with the original code and passes with the new code.