### PR TITLE
contrib/go-redis/redis: make go-redis traced Client a true redis.Cmdable

### DIFF
--- a/contrib/go-redis/redis/redis.go
+++ b/contrib/go-redis/redis/redis.go
@@ -21,11 +21,15 @@ type Client struct {
 	*params
 }
 
+var _ redis.Cmdable = (*Client)(nil)
+
 // Pipeliner is used to trace pipelines executed on a Redis server.
 type Pipeliner struct {
 	redis.Pipeliner
 	*params
 }
+
+var _ redis.Pipeliner = (*Pipeliner)(nil)
 
 // params holds the tracer and a set of parameters which are recorded with every trace.
 type params struct {
@@ -66,7 +70,7 @@ func WrapClient(c *redis.Client, opts ...ClientOption) *Client {
 }
 
 // Pipeline creates a Pipeline from a Client
-func (c *Client) Pipeline() *Pipeliner {
+func (c *Client) Pipeline() redis.Pipeliner {
 	return &Pipeliner{c.Client.Pipeline(), c.params}
 }
 

--- a/contrib/go-redis/redis/redis_test.go
+++ b/contrib/go-redis/redis/redis_test.go
@@ -59,7 +59,7 @@ func TestPipeline(t *testing.T) {
 	pipeline.Expire("pipeline_counter", time.Hour)
 
 	// Exec with context test
-	pipeline.ExecWithContext(context.Background())
+	pipeline.(*Pipeliner).ExecWithContext(context.Background())
 
 	spans := mt.FinishedSpans()
 	assert.Len(spans, 1)


### PR DESCRIPTION
I'm experiencing problems using a traced client. The baseline is: I try to have the same code running when it's traced and when it's not, keeping an option "I want to trace this or not" at runtime.

As I view it one option is to consider the client is just a https://godoc.org/github.com/go-redis/redis#Cmdable be it traced or not.

Now I hit a problem, the `Pipeline()` func has the wrong prototype. While it's true `*Pipeliner` implements `redis.Pipeliner`, the signature is different and just because of that detail it's impossible to use `Client` as a generic Cmdable.

This patch changes the prototype. It *is* a breaking change, as I had to update a test. Indeed, caller
can not assume `Pipeline()` returns a concrete `*Pipeliner`. So a cast is required. But OTOH the client is a truely generic `redis.Cmdable`...