### PR TITLE
contrib/google.golang.org/grpc: send gRPC status code in interceptor

### DIFF
--- a/contrib/google.golang.org/grpc/grpc.go
+++ b/contrib/google.golang.org/grpc/grpc.go
@@ -31,11 +31,12 @@ func startSpanFromContext(ctx context.Context, method, operation, service string
 	return tracer.StartSpanFromContext(ctx, operation, opts...)
 }
 
-// withStreamError returns a tracer.WithError finish option, disregarding OK, EOF and Canceled errors.
-func withStreamError(err error) tracer.FinishOption {
+// finishWithError applies finish option and a tag with gRPC status code, disregarding OK, EOF and Canceled errors.
+func finishWithError(span ddtrace.Span, err error) {
 	errcode := status.Code(err)
 	if err == io.EOF || errcode == codes.Canceled || errcode == codes.OK || err == context.Canceled {
 		err = nil
 	}
-	return tracer.WithError(err)
+	span.SetTag(tagCode, errcode.String())
+	span.Finish(tracer.WithError(err))
 }

--- a/contrib/google.golang.org/grpc/server.go
+++ b/contrib/google.golang.org/grpc/server.go
@@ -4,7 +4,6 @@ import (
 	context "golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 type serverStream struct {
@@ -29,7 +28,7 @@ func (ss *serverStream) Context() context.Context {
 func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 	if ss.cfg.traceStreamMessages {
 		span, _ := startSpanFromContext(ss.ctx, ss.method, "grpc.message", ss.cfg.serverServiceName())
-		defer span.Finish(withStreamError(err))
+		defer finishWithError(span, err)
 	}
 	err = ss.ServerStream.RecvMsg(m)
 	return err
@@ -38,7 +37,7 @@ func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 func (ss *serverStream) SendMsg(m interface{}) (err error) {
 	if ss.cfg.traceStreamMessages {
 		span, _ := startSpanFromContext(ss.ctx, ss.method, "grpc.message", ss.cfg.serverServiceName())
-		defer span.Finish(withStreamError(err))
+		defer finishWithError(span, err)
 	}
 	err = ss.ServerStream.SendMsg(m)
 	return err
@@ -61,7 +60,7 @@ func StreamServerInterceptor(opts ...InterceptorOption) grpc.StreamServerInterce
 		if cfg.traceStreamCalls {
 			var span ddtrace.Span
 			span, ctx = startSpanFromContext(ctx, info.FullMethod, "grpc.server", cfg.serviceName)
-			defer span.Finish(withStreamError(err))
+			defer finishWithError(span, err)
 		}
 
 		// call the original handler with a new stream, which traces each send
@@ -87,7 +86,7 @@ func UnaryServerInterceptor(opts ...InterceptorOption) grpc.UnaryServerIntercept
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		span, ctx := startSpanFromContext(ctx, info.FullMethod, "grpc.server", cfg.serverServiceName())
 		resp, err := handler(ctx, req)
-		span.Finish(tracer.WithError(err))
+		finishWithError(span, err)
 		return resp, err
 	}
 }


### PR DESCRIPTION
send gRPC status code for ServerUnaryInterceptor and ServerStreamingIncetptor

fixed https://github.com/DataDog/dd-trace-go/issues/332