### PR TITLE
contrib/net/http: add a convenience WrapClient method

### DIFF
--- a/contrib/net/http/roundtripper.go
+++ b/contrib/net/http/roundtripper.go
@@ -61,6 +61,9 @@ func WrapRoundTripper(rt http.RoundTripper, opts ...RoundTripperOption) http.Rou
 	for _, opt := range opts {
 		opt(cfg)
 	}
+	if wrapped, ok := rt.(*roundTripper); ok {
+		rt = wrapped.base
+	}
 	return &roundTripper{
 		base: rt,
 		cfg:  cfg,

--- a/contrib/net/http/roundtripper.go
+++ b/contrib/net/http/roundtripper.go
@@ -66,3 +66,12 @@ func WrapRoundTripper(rt http.RoundTripper, opts ...RoundTripperOption) http.Rou
 		cfg:  cfg,
 	}
 }
+
+// WrapClient modifies the given client's transport to augment it with tracing and returns it.
+func WrapClient(c *http.Client, opts ...RoundTripperOption) *http.Client {
+	if c.Transport == nil {
+		c.Transport = http.DefaultTransport
+	}
+	c.Transport = WrapRoundTripper(c.Transport, opts...)
+	return c
+}

--- a/contrib/net/http/roundtripper_test.go
+++ b/contrib/net/http/roundtripper_test.go
@@ -59,3 +59,10 @@ func TestRoundTripper(t *testing.T) {
 	assert.Equal(t, true, s1.Tag("CalledBefore"))
 	assert.Equal(t, true, s1.Tag("CalledAfter"))
 }
+
+func TestWrapClient(t *testing.T) {
+	c := WrapClient(http.DefaultClient)
+	assert.Equal(t, c, http.DefaultClient)
+	_, ok := c.Transport.(*roundTripper)
+	assert.True(t, ok)
+}


### PR DESCRIPTION
This will facilitate integrating with libraries such as `go-github`