### PR TITLE
contrib/database/sql: only record spans for implemented driver methods

### DIFF
--- a/contrib/database/sql/conn.go
+++ b/contrib/database/sql/conn.go
@@ -3,8 +3,7 @@ package sql // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql"
 import (
 	"context"
 	"database/sql/driver"
-
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"time"
 )
 
 var _ driver.Conn = (*tracedConn)(nil)
@@ -15,18 +14,17 @@ type tracedConn struct {
 }
 
 func (tc *tracedConn) BeginTx(ctx context.Context, opts driver.TxOptions) (tx driver.Tx, err error) {
-	span := tc.newChildSpanFromContext(ctx, "Begin", "")
-	defer func() {
-		span.Finish(tracer.WithError(err))
-	}()
+	start := time.Now()
 	if connBeginTx, ok := tc.Conn.(driver.ConnBeginTx); ok {
 		tx, err = connBeginTx.BeginTx(ctx, opts)
+		tc.tryTrace(ctx, "Begin", "", start, err)
 		if err != nil {
 			return nil, err
 		}
 		return &tracedTx{tx, tc.traceParams, ctx}, nil
 	}
 	tx, err = tc.Conn.Begin()
+	tc.tryTrace(ctx, "Begin", "", start, err)
 	if err != nil {
 		return nil, err
 	}
@@ -34,18 +32,17 @@ func (tc *tracedConn) BeginTx(ctx context.Context, opts driver.TxOptions) (tx dr
 }
 
 func (tc *tracedConn) PrepareContext(ctx context.Context, query string) (stmt driver.Stmt, err error) {
-	span := tc.newChildSpanFromContext(ctx, "Prepare", query)
-	defer func() {
-		span.Finish(tracer.WithError(err))
-	}()
+	start := time.Now()
 	if connPrepareCtx, ok := tc.Conn.(driver.ConnPrepareContext); ok {
 		stmt, err := connPrepareCtx.PrepareContext(ctx, query)
+		tc.tryTrace(ctx, "Prepare", query, start, err)
 		if err != nil {
 			return nil, err
 		}
 		return &tracedStmt{stmt, tc.traceParams, ctx, query}, nil
 	}
 	stmt, err = tc.Prepare(query)
+	tc.tryTrace(ctx, "Prepare", query, start, err)
 	if err != nil {
 		return nil, err
 	}
@@ -60,12 +57,11 @@ func (tc *tracedConn) Exec(query string, args []driver.Value) (driver.Result, er
 }
 
 func (tc *tracedConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (r driver.Result, err error) {
-	span := tc.newChildSpanFromContext(ctx, "Exec", query)
-	defer func() {
-		span.Finish(tracer.WithError(err))
-	}()
+	start := time.Now()
 	if execContext, ok := tc.Conn.(driver.ExecerContext); ok {
-		return execContext.ExecContext(ctx, query, args)
+		r, err := execContext.ExecContext(ctx, query, args)
+		tc.tryTrace(ctx, "Exec", query, start, err)
+		return r, err
 	}
 	dargs, err := namedValueToValue(args)
 	if err != nil {
@@ -76,19 +72,19 @@ func (tc *tracedConn) ExecContext(ctx context.Context, query string, args []driv
 		return nil, ctx.Err()
 	default:
 	}
-	return tc.Exec(query, dargs)
+	r, err = tc.Exec(query, dargs)
+	tc.tryTrace(ctx, "Exec", query, start, err)
+	return r, err
 }
 
 // tracedConn has a Ping method in order to implement the pinger interface
 func (tc *tracedConn) Ping(ctx context.Context) (err error) {
-	span := tc.newChildSpanFromContext(ctx, "Ping", "")
-	defer func() {
-		span.Finish(tracer.WithError(err))
-	}()
+	start := time.Now()
 	if pinger, ok := tc.Conn.(driver.Pinger); ok {
-		return pinger.Ping(ctx)
+		err = pinger.Ping(ctx)
 	}
-	return nil
+	tc.tryTrace(ctx, "Ping", "", start, err)
+	return err
 }
 
 func (tc *tracedConn) Query(query string, args []driver.Value) (driver.Rows, error) {
@@ -99,12 +95,11 @@ func (tc *tracedConn) Query(query string, args []driver.Value) (driver.Rows, err
 }
 
 func (tc *tracedConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (rows driver.Rows, err error) {
-	span := tc.newChildSpanFromContext(ctx, "Query", query)
-	defer func() {
-		span.Finish(tracer.WithError(err))
-	}()
+	start := time.Now()
 	if queryerContext, ok := tc.Conn.(driver.QueryerContext); ok {
-		return queryerContext.QueryContext(ctx, query, args)
+		rows, err := queryerContext.QueryContext(ctx, query, args)
+		tc.tryTrace(ctx, "Query", query, start, err)
+		return rows, err
 	}
 	dargs, err := namedValueToValue(args)
 	if err != nil {
@@ -115,5 +110,7 @@ func (tc *tracedConn) QueryContext(ctx context.Context, query string, args []dri
 		return nil, ctx.Err()
 	default:
 	}
-	return tc.Query(query, dargs)
+	rows, err = tc.Query(query, dargs)
+	tc.tryTrace(ctx, "Query", query, start, err)
+	return rows, err
 }

--- a/contrib/database/sql/tx.go
+++ b/contrib/database/sql/tx.go
@@ -3,8 +3,7 @@ package sql
 import (
 	"context"
 	"database/sql/driver"
-
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"time"
 )
 
 var _ driver.Tx = (*tracedTx)(nil)
@@ -18,18 +17,16 @@ type tracedTx struct {
 
 // Commit sends a span at the end of the transaction
 func (t *tracedTx) Commit() (err error) {
-	span := t.newChildSpanFromContext(t.ctx, "Commit", "")
-	defer func() {
-		span.Finish(tracer.WithError(err))
-	}()
-	return t.Tx.Commit()
+	start := time.Now()
+	err = t.Tx.Commit()
+	t.tryTrace(t.ctx, "Commit", "", start, err)
+	return err
 }
 
 // Rollback sends a span if the connection is aborted
 func (t *tracedTx) Rollback() (err error) {
-	span := t.newChildSpanFromContext(t.ctx, "Rollback", "")
-	defer func() {
-		span.Finish(tracer.WithError(err))
-	}()
-	return t.Tx.Rollback()
+	start := time.Now()
+	err = t.Tx.Rollback()
+	t.tryTrace(t.ctx, "Rollback", "", start, err)
+	return err
 }

--- a/contrib/mongodb/mongo-go-driver/mongo/mongo.go
+++ b/contrib/mongodb/mongo-go-driver/mongo/mongo.go
@@ -1,5 +1,6 @@
 // Package mongo provides functions to trace the mongodb/mongo-go-driver package (https://github.com/mongodb/mongo-go-driver). The
-// minimum required version is v0.0.13.
+// minimum required version is v0.0.15 (Alpha 15). Since this driver is still in Alpha and subject to change from one release to
+// another, stability of this package can not be guaranteed.
 //
 // `NewMonitor` will return an event.CommandMonitor which is used to trace requests.
 package mongo

--- a/contrib/mongodb/mongo-go-driver/mongo/mongo_test.go
+++ b/contrib/mongodb/mongo-go-driver/mongo/mongo_test.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/bson/bsoncodec"
 	"github.com/mongodb/mongo-go-driver/core/result"
 	"github.com/mongodb/mongo-go-driver/core/wiremessage"
 	"github.com/mongodb/mongo-go-driver/mongo"
@@ -119,7 +120,7 @@ func mockMongo() (net.Listener, error) {
 							panic(err)
 						}
 
-						bs, _ := bson.Marshal(result.IsMaster{
+						bs, _ := bsoncodec.Marshal(result.IsMaster{
 							IsMaster:                     true,
 							OK:                           1,
 							MaxBSONObjectSize:            16777216,


### PR DESCRIPTION
Instrumentation for some packages (such as `jmoiron/sqlx`) is tracing calls returning `driver.ErrSkip`, causing not only duplicate traces, but also APM errors where in fact there were none.

From [`(database/sql/driver).ErrSkip`](https://golang.org/pkg/database/sql/driver/#ErrSkip):
```go
// ErrSkip may be returned by some optional interfaces' methods to
// indicate at runtime that the fast path is unavailable and the sql
// package should continue as if the optional interface was not
// implemented. ErrSkip is only supported where explicitly
// documented.
var ErrSkip = errors.New("driver: skip fast-path; continue as if unimplemented")
```

This is not a user error and in these cases we should not perform any tracing. See #270 for a detailed overview of the problem.

Fixes #270 

**TODO**
- [ ] Test with Datadog app.
- [ ] Try to write a unit test.