### PR TITLE
julienschmidt/httprouter: support extra span options in httprouter

### DIFF
--- a/contrib/julienschmidt/httprouter/example_test.go
+++ b/contrib/julienschmidt/httprouter/example_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/julienschmidt/httprouter"
 
 	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/julienschmidt/httprouter"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 func Index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
@@ -28,6 +30,20 @@ func Example() {
 
 func Example_withServiceName() {
 	router := httptrace.New(httptrace.WithServiceName("http.router"))
+	router.GET("/", Index)
+	router.GET("/hello/:name", Hello)
+
+	log.Fatal(http.ListenAndServe(":8080", router))
+}
+
+func Example_withSpanOpts() {
+	router := httptrace.New(
+		httptrace.WithServiceName("http.router"),
+		httptrace.WithSpanOptions(
+			tracer.Tag(ext.SamplingPriority, ext.PriorityUserKeep),
+		),
+	)
+
 	router.GET("/", Index)
 	router.GET("/hello/:name", Hello)
 

--- a/contrib/julienschmidt/httprouter/httprouter.go
+++ b/contrib/julienschmidt/httprouter/httprouter.go
@@ -35,5 +35,5 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		route = strings.Replace(route, param.Value, ":"+param.Key, 1)
 	}
 	resource := req.Method + " " + route
-	httputil.TraceAndServe(r.Router, w, req, r.config.serviceName, resource)
+	httputil.TraceAndServe(r.Router, w, req, r.config.serviceName, resource, r.config.spanOpts...)
 }

--- a/contrib/julienschmidt/httprouter/httprouter_test.go
+++ b/contrib/julienschmidt/httprouter/httprouter_test.go
@@ -7,6 +7,7 @@ import (
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/stretchr/testify/assert"
@@ -35,6 +36,7 @@ func TestHttpTracer200(t *testing.T) {
 	assert.Equal("200", s.Tag(ext.HTTPCode))
 	assert.Equal("GET", s.Tag(ext.HTTPMethod))
 	assert.Equal(url, s.Tag(ext.HTTPURL))
+	assert.Equal("testvalue", s.Tag("testkey"))
 	assert.Equal(nil, s.Tag(ext.Error))
 }
 
@@ -61,13 +63,19 @@ func TestHttpTracer500(t *testing.T) {
 	assert.Equal("500", s.Tag(ext.HTTPCode))
 	assert.Equal("GET", s.Tag(ext.HTTPMethod))
 	assert.Equal(url, s.Tag(ext.HTTPURL))
+	assert.Equal("testvalue", s.Tag("testkey"))
 	assert.Equal("500: Internal Server Error", s.Tag(ext.Error).(error).Error())
 }
 
 func router() http.Handler {
-	router := New(WithServiceName("my-service"))
+	router := New(
+		WithServiceName("my-service"),
+		WithSpanOptions(tracer.Tag("testkey", "testvalue")),
+	)
+
 	router.GET("/200", handler200)
 	router.GET("/500", handler500)
+
 	return router
 }
 

--- a/contrib/julienschmidt/httprouter/option.go
+++ b/contrib/julienschmidt/httprouter/option.go
@@ -21,7 +21,7 @@ func WithServiceName(name string) RouterOption {
 	}
 }
 
-// WithSpanOptions applies the given set of options to the spans started by the router.
+// WithSpanOptions applies the given set of options to the span started by the router.
 func WithSpanOptions(opts ...ddtrace.StartSpanOption) RouterOption {
 	return func(cfg *routerConfig) {
 		cfg.spanOpts = opts

--- a/contrib/julienschmidt/httprouter/option.go
+++ b/contrib/julienschmidt/httprouter/option.go
@@ -1,6 +1,11 @@
 package httprouter
 
-type routerConfig struct{ serviceName string }
+import "gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+
+type routerConfig struct {
+	serviceName string
+	spanOpts    []ddtrace.StartSpanOption
+}
 
 // RouterOption represents an option that can be passed to New.
 type RouterOption func(*routerConfig)
@@ -13,5 +18,12 @@ func defaults(cfg *routerConfig) {
 func WithServiceName(name string) RouterOption {
 	return func(cfg *routerConfig) {
 		cfg.serviceName = name
+	}
+}
+
+// WithSpanOptions applies the given set of options to the spans started by the router.
+func WithSpanOptions(opts ...ddtrace.StartSpanOption) RouterOption {
+	return func(cfg *routerConfig) {
+		cfg.spanOpts = opts
 	}
 }


### PR DESCRIPTION
The httprouter integration did not allow for providing additional span options. I have applied the exact same logic from the gorilla/mux integration.

Closes #345