### PR TITLE
[contrib:gocql] report readable consistency instead of int

### DIFF
--- a/contrib/gocql/gocql/gocql.go
+++ b/contrib/gocql/gocql/gocql.go
@@ -124,7 +124,7 @@ func (tq *Query) Iter() *Iter {
 	span := tq.newChildSpan(tq.traceContext)
 	iter := tq.Query.Iter()
 	span.SetTag(ext.CassandraRowCount, strconv.Itoa(iter.NumRows()))
-	span.SetTag(ext.CassandraConsistencyLevel, strconv.Itoa(int(tq.GetConsistency())))
+	span.SetTag(ext.CassandraConsistencyLevel, tq.GetConsistency().String())
 
 	columns := iter.Columns()
 	if len(columns) > 0 {

--- a/contrib/gocql/gocql/gocql_test.go
+++ b/contrib/gocql/gocql/gocql_test.go
@@ -71,7 +71,7 @@ func TestErrorWrapper(t *testing.T) {
 	assert.Equal(span.OperationName(), ext.CassandraQuery)
 	assert.Equal(span.Tag(ext.ResourceName), "CREATE KEYSPACE")
 	assert.Equal(span.Tag(ext.ServiceName), "ServiceName")
-	assert.Equal(span.Tag(ext.CassandraConsistencyLevel), "4")
+	assert.Equal(span.Tag(ext.CassandraConsistencyLevel), "QUORUM")
 	assert.Equal(span.Tag(ext.CassandraPaginated), "false")
 
 	if iter.Host() != nil {


### PR DESCRIPTION
Just a suggestion, the current integration works fine, but I tend to prefer reading `QUORUM` rather then `4`, it seems more straightforward when reading spans meta in the UI.

As a side node, this `String()` method seems to have been there for quite some time (eg in this 4 year old commit: https://github.com/gocql/gocql/commit/c78c7ab06d04ff7a318ee95d5d0eea42eb86e0b6#diff-f2fccfb96064097b73fbe8eeae3703eeR477)

Again, it's just a nitpick, and there might be reasons for keeping the number.