### PR TITLE
contrib/k8s.io/client-go: inject the traceID as kube auditID

### DIFF
--- a/contrib/k8s.io/client-go/kubernetes/kubernetes.go
+++ b/contrib/k8s.io/client-go/kubernetes/kubernetes.go
@@ -25,6 +25,7 @@ func WrapRoundTripper(rt http.RoundTripper) http.RoundTripper {
 			span.SetTag(ext.ResourceName, RequestToResource(req.Method, req.URL.Path))
 			traceID := span.Context().TraceID()
 			if traceID == 0 {
+			    // tracer is not running
 				return
 			}
 			kubeAuditID := strconv.FormatUint(traceID, 10)

--- a/contrib/k8s.io/client-go/kubernetes/kubernetes.go
+++ b/contrib/k8s.io/client-go/kubernetes/kubernetes.go
@@ -29,10 +29,11 @@ func WrapRoundTripper(rt http.RoundTripper) http.RoundTripper {
 			}
 			kubeAuditID := strconv.FormatUint(traceID, 10)
 			req.Header.Set("Audit-Id", kubeAuditID)
-			span.SetTag("kubernetes.auditID", kubeAuditID)
+			span.SetTag("kubernetes.audit_id", kubeAuditID)
 		}))
 }
 
+// RequestToResource parse a kubernetes request to extract a resource name from it
 func RequestToResource(method, path string) string {
 	if !strings.HasPrefix(path, prefixAPI) {
 		return method

--- a/contrib/k8s.io/client-go/kubernetes/kubernetes.go
+++ b/contrib/k8s.io/client-go/kubernetes/kubernetes.go
@@ -25,7 +25,7 @@ func WrapRoundTripper(rt http.RoundTripper) http.RoundTripper {
 			span.SetTag(ext.ResourceName, RequestToResource(req.Method, req.URL.Path))
 			traceID := span.Context().TraceID()
 			if traceID == 0 {
-			    // tracer is not running
+				// tracer is not running
 				return
 			}
 			kubeAuditID := strconv.FormatUint(traceID, 10)

--- a/contrib/k8s.io/client-go/kubernetes/kubernetes.go
+++ b/contrib/k8s.io/client-go/kubernetes/kubernetes.go
@@ -3,6 +3,7 @@ package kubernetes // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/k8s.io/cli
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 
 	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
@@ -21,11 +22,18 @@ func WrapRoundTripper(rt http.RoundTripper) http.RoundTripper {
 	return httptrace.WrapRoundTripper(rt,
 		httptrace.WithBefore(func(req *http.Request, span ddtrace.Span) {
 			span.SetTag(ext.ServiceName, "kubernetes")
-			span.SetTag(ext.ResourceName, requestToResource(req.Method, req.URL.Path))
+			span.SetTag(ext.ResourceName, RequestToResource(req.Method, req.URL.Path))
+			traceID := span.Context().TraceID()
+			if traceID == 0 {
+				return
+			}
+			kubeAuditID := strconv.FormatUint(traceID, 10)
+			req.Header.Set("Audit-Id", kubeAuditID)
+			span.SetTag("kubernetes.auditID", kubeAuditID)
 		}))
 }
 
-func requestToResource(method, path string) string {
+func RequestToResource(method, path string) string {
 	if !strings.HasPrefix(path, prefixAPI) {
 		return method
 	}

--- a/contrib/k8s.io/client-go/kubernetes/kubernetes.go
+++ b/contrib/k8s.io/client-go/kubernetes/kubernetes.go
@@ -34,7 +34,7 @@ func WrapRoundTripper(rt http.RoundTripper) http.RoundTripper {
 		}))
 }
 
-// RequestToResource parse a kubernetes request to extract a resource name from it
+// RequestToResource parses a Kubernetes request and extracts a resource name from it.
 func RequestToResource(method, path string) string {
 	if !strings.HasPrefix(path, prefixAPI) {
 		return method

--- a/contrib/k8s.io/client-go/kubernetes/kubernetes_test.go
+++ b/contrib/k8s.io/client-go/kubernetes/kubernetes_test.go
@@ -32,7 +32,7 @@ func TestPathToResource(t *testing.T) {
 	}
 
 	for path, expectedResource := range expected {
-		assert.Equal(t, "GET "+expectedResource, requestToResource("GET", path), "mapping %v", path)
+		assert.Equal(t, "GET "+expectedResource, RequestToResource("GET", path), "mapping %v", path)
 	}
 }
 
@@ -54,7 +54,7 @@ func TestKubernetes(t *testing.T) {
 	client, err := kubernetes.NewForConfig(cfg)
 	assert.NoError(t, err)
 
-	client.Core().Namespaces().List(meta_v1.ListOptions{})
+	client.CoreV1().Namespaces().List(meta_v1.ListOptions{})
 
 	spans := mt.FinishedSpans()
 	assert.Len(t, spans, 1)
@@ -66,5 +66,8 @@ func TestKubernetes(t *testing.T) {
 		assert.Equal(t, "200", s.Tag(ext.HTTPCode))
 		assert.Equal(t, "GET", s.Tag(ext.HTTPMethod))
 		assert.Equal(t, "/api/v1/namespaces", s.Tag(ext.HTTPURL))
+		auditID, ok := s.Tag("kubernetes.audit_id").(string)
+		assert.True(t, ok)
+		assert.True(t, len(auditID) > 0)
 	}
 }

--- a/contrib/net/http/roundtripper.go
+++ b/contrib/net/http/roundtripper.go
@@ -19,7 +19,7 @@ type roundTripper struct {
 }
 
 func (rt *roundTripper) RoundTrip(req *http.Request) (res *http.Response, err error) {
-	span, _ := tracer.StartSpanFromContext(req.Context(), "http.request",
+	span, _ := tracer.StartSpanFromContext(req.Context(), defaultResourceName,
 		tracer.SpanType(ext.SpanTypeHTTP),
 		tracer.ResourceName(defaultResourceName),
 		tracer.Tag(ext.HTTPMethod, req.Method),


### PR DESCRIPTION
This allows to provide the Kubernetes Audit-ID to the kube-apiserver [see](https://github.com/kubernetes/apiserver/blob/92e87e143ad53972f794f1070bec41711ebe4c99/pkg/audit/request.go#L54-L61).

With this change, we could then use datadog distributing tracing capabilities (audit logs) in the apiserver side.