### PR TITLE
contrib/google.golang.org/grpc: add an option to disable stack traces

### DIFF
--- a/contrib/google.golang.org/grpc/client.go
+++ b/contrib/google.golang.org/grpc/client.go
@@ -26,7 +26,7 @@ func (cs *clientStream) RecvMsg(m interface{}) (err error) {
 		if p, ok := peer.FromContext(cs.Context()); ok {
 			setSpanTargetFromPeer(span, *p)
 		}
-		defer finishWithError(span, err)
+		defer finishWithError(span, err, cs.cfg.noDebugStack)
 	}
 	err = cs.ClientStream.RecvMsg(m)
 	return err
@@ -38,7 +38,7 @@ func (cs *clientStream) SendMsg(m interface{}) (err error) {
 		if p, ok := peer.FromContext(cs.Context()); ok {
 			setSpanTargetFromPeer(span, *p)
 		}
-		defer finishWithError(span, err)
+		defer finishWithError(span, err, cs.cfg.noDebugStack)
 	}
 	err = cs.ClientStream.SendMsg(m)
 	return err
@@ -62,7 +62,7 @@ func StreamClientInterceptor(opts ...InterceptorOption) grpc.StreamClientInterce
 					return err
 				})
 			if err != nil {
-				finishWithError(span, err)
+				finishWithError(span, err, cfg.noDebugStack)
 				return nil, err
 			}
 
@@ -74,7 +74,7 @@ func StreamClientInterceptor(opts ...InterceptorOption) grpc.StreamClientInterce
 
 			go func() {
 				<-stream.Context().Done()
-				finishWithError(span, stream.Context().Err())
+				finishWithError(span, stream.Context().Err(), cfg.noDebugStack)
 			}()
 		} else {
 			// if call tracing is disabled, just call streamer, but still return
@@ -111,7 +111,7 @@ func UnaryClientInterceptor(opts ...InterceptorOption) grpc.UnaryClientIntercept
 			func(ctx context.Context, opts []grpc.CallOption) error {
 				return invoker(ctx, method, req, reply, cc, opts...)
 			})
-		finishWithError(span, err)
+		finishWithError(span, err, cfg.noDebugStack)
 		return err
 	}
 }

--- a/contrib/google.golang.org/grpc/option.go
+++ b/contrib/google.golang.org/grpc/option.go
@@ -3,6 +3,7 @@ package grpc
 type interceptorConfig struct {
 	serviceName                           string
 	traceStreamCalls, traceStreamMessages bool
+	noDebugStack                          bool
 }
 
 func (cfg *interceptorConfig) serverServiceName() string {
@@ -47,5 +48,14 @@ func WithStreamCalls(enabled bool) InterceptorOption {
 func WithStreamMessages(enabled bool) InterceptorOption {
 	return func(cfg *interceptorConfig) {
 		cfg.traceStreamMessages = enabled
+	}
+}
+
+// NoDebugStack will disable generating a stack trace for all call errors. This can
+// be used in systems where errors are frequent to improve performance by reducing
+// calls to debug.Stack().
+func NoDebugStack() InterceptorOption {
+	return func(cfg *interceptorConfig) {
+		cfg.noDebugStack = true
 	}
 }

--- a/contrib/google.golang.org/grpc/server.go
+++ b/contrib/google.golang.org/grpc/server.go
@@ -28,7 +28,7 @@ func (ss *serverStream) Context() context.Context {
 func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 	if ss.cfg.traceStreamMessages {
 		span, _ := startSpanFromContext(ss.ctx, ss.method, "grpc.message", ss.cfg.serverServiceName())
-		defer finishWithError(span, err)
+		defer finishWithError(span, err, ss.cfg.noDebugStack)
 	}
 	err = ss.ServerStream.RecvMsg(m)
 	return err
@@ -37,7 +37,7 @@ func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 func (ss *serverStream) SendMsg(m interface{}) (err error) {
 	if ss.cfg.traceStreamMessages {
 		span, _ := startSpanFromContext(ss.ctx, ss.method, "grpc.message", ss.cfg.serverServiceName())
-		defer finishWithError(span, err)
+		defer finishWithError(span, err, ss.cfg.noDebugStack)
 	}
 	err = ss.ServerStream.SendMsg(m)
 	return err
@@ -60,7 +60,7 @@ func StreamServerInterceptor(opts ...InterceptorOption) grpc.StreamServerInterce
 		if cfg.traceStreamCalls {
 			var span ddtrace.Span
 			span, ctx = startSpanFromContext(ctx, info.FullMethod, "grpc.server", cfg.serviceName)
-			defer finishWithError(span, err)
+			defer finishWithError(span, err, cfg.noDebugStack)
 		}
 
 		// call the original handler with a new stream, which traces each send
@@ -86,7 +86,7 @@ func UnaryServerInterceptor(opts ...InterceptorOption) grpc.UnaryServerIntercept
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		span, ctx := startSpanFromContext(ctx, info.FullMethod, "grpc.server", cfg.serverServiceName())
 		resp, err := handler(ctx, req)
-		finishWithError(span, err)
+		finishWithError(span, err, cfg.noDebugStack)
 		return resp, err
 	}
 }

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -156,6 +156,11 @@ func FinishTime(t time.Time) FinishOption {
 
 // WithError marks the span as having had an error. It uses the information from
 // err to set tags such as the error message, error type and stack trace.
+//
+// To avoid generating a stack trace in situations of critical performance where errors
+// are of a high frequency, simply set the "error" tag to true and add any additional
+// metadata tags as needed, avoiding the use of this option and avoiding the setting of
+// the "error" tag to a value of type error.
 func WithError(err error) FinishOption {
 	return func(cfg *ddtrace.FinishConfig) {
 		cfg.Error = err


### PR DESCRIPTION
This change adds an option to the gRPC integration to allow the disabling of stack traces. This is useful in situations where errors are occurring at high frequency and generating a stack trace might have a performance impact.

Fixes #354