### PR TITLE
contrib/net/http: inherit context of StartSpanFromContext into base RoundTripper

### DIFF
--- a/contrib/net/http/roundtripper.go
+++ b/contrib/net/http/roundtripper.go
@@ -19,7 +19,7 @@ type roundTripper struct {
 }
 
 func (rt *roundTripper) RoundTrip(req *http.Request) (res *http.Response, err error) {
-	span, _ := tracer.StartSpanFromContext(req.Context(), defaultResourceName,
+	span, ctx := tracer.StartSpanFromContext(req.Context(), defaultResourceName,
 		tracer.SpanType(ext.SpanTypeHTTP),
 		tracer.ResourceName(defaultResourceName),
 		tracer.Tag(ext.HTTPMethod, req.Method),
@@ -40,7 +40,7 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (res *http.Response, err er
 		// this should never happen
 		fmt.Fprintf(os.Stderr, "failed to inject http headers for round tripper: %v\n", err)
 	}
-	res, err = rt.base.RoundTrip(req)
+	res, err = rt.base.RoundTrip(req.WithContext(ctx))
 	if err != nil {
 		span.SetTag("http.errors", err.Error())
 	} else {


### PR DESCRIPTION
If the base round tripper start a new span, it will be a brothers rather than parent-child.

I think there are no reasons to ignore context.