### PR TITLE
tracer: allow overriding http.RoundTripper used to emit spans

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -1,6 +1,7 @@
 package tracer
 
 import (
+	"net/http"
 	"os"
 	"path/filepath"
 	"time"
@@ -33,6 +34,9 @@ type config struct {
 
 	// propagator propagates span context cross-process
 	propagator Propagator
+
+	// httpRoundTripper defines the http.RoundTripper used by the agent transport.
+	httpRoundTripper http.RoundTripper
 }
 
 // StartOption represents a function that can be provided as a parameter to Start.
@@ -90,6 +94,15 @@ func WithGlobalTag(k string, v interface{}) StartOption {
 func WithSampler(s Sampler) StartOption {
 	return func(c *config) {
 		c.sampler = s
+	}
+}
+
+// WithHTTPRoundTripper allows customizing the underlying HTTP transport for
+// emitting spans. This is useful for advanced customization such as emitting
+// spans to a unix domain socket. The default should be used in most cases.
+func WithHTTPRoundTripper(r http.RoundTripper) StartOption {
+	return func(c *config) {
+		c.httpRoundTripper = r
 	}
 }
 

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -19,6 +19,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 	assert.Equal(float64(1), c.sampler.(RateSampler).Rate())
 	assert.Equal("tracer.test", c.serviceName)
 	assert.Equal("localhost:8126", c.agentAddr)
+	assert.Equal(nil, c.httpRoundTripper)
 }
 
 func TestTracerOptions(t *testing.T) {

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -112,7 +112,7 @@ func newTracer(opts ...StartOption) *tracer {
 		fn(c)
 	}
 	if c.transport == nil {
-		c.transport = newTransport(c.agentAddr)
+		c.transport = newTransport(c.agentAddr, c.httpRoundTripper)
 	}
 	if c.propagator == nil {
 		c.propagator = NewPropagator(nil)

--- a/ddtrace/tracer/transport.go
+++ b/ddtrace/tracer/transport.go
@@ -14,7 +14,7 @@ import (
 var (
 	// TODO(gbbr): find a more effective way to keep this up to date,
 	// e.g. via `go generate`
-	tracerVersion = "v1.5.0"
+	tracerVersion = "v1.7.0"
 
 	// We copy the transport to avoid using the default one, as it might be
 	// augmented with tracing and we don't want these calls to be recorded.


### PR DESCRIPTION
This allows customization of the transport layer, for instance adding
custom headers to every request or emitting to a unix socket. This is
useful when there is a load balancer in between the emitter and the
agent, for instance in a service mesh.