### PR TITLE
set sampling priority tag for sampled spans

### DIFF
--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -258,6 +258,9 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		span.SetTag(ext.Pid, strconv.Itoa(os.Getpid()))
 		t.sample(span)
 	}
+	if span.context.sampled {
+		span.SetTag(ext.SamplingPriority, ext.PriorityAutoKeep)
+	}
 	// add tags from options
 	for k, v := range opts.Tags {
 		span.SetTag(k, v)


### PR DESCRIPTION
This fixes an issue where sampling state for a given trace is not
propagated cross-process if the root of the trace is in the current
process.