### PR TITLE
ddtrace/tracer: initialize sampled field

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 )
 
 // HTTPHeadersCarrier wraps an http.Header as a TextMapWriter and TextMapReader, allowing
@@ -180,6 +181,9 @@ func (p *propagator) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 				return ErrSpanContextCorrupted
 			}
 			ctx.hasPriority = true
+			if ctx.priority == ext.PriorityAutoKeep || ctx.priority == ext.PriorityUserKeep {
+				ctx.sampled = true
+			}
 		default:
 			if strings.HasPrefix(key, p.cfg.BaggagePrefix) {
 				ctx.setBaggageItem(strings.TrimPrefix(key, p.cfg.BaggagePrefix), v)


### PR DESCRIPTION
When receiving the propagation headers, the `sampled` field was not set based on the incoming header values. This field is used to decide whether traces are [submitted to the agent](https://github.com/DataDog/dd-trace-go/blob/v1/ddtrace/tracer/span.go#L204-L207).

This PR sets the value of the sampled boolean based on the received sampling priority.