### PR TITLE
ddtrace/tracer: priority sampling on by default

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -50,15 +50,17 @@ func defaults(c *config) {
 	c.serviceName = filepath.Base(os.Args[0])
 	c.sampler = NewAllSampler()
 	c.agentAddr = defaultAddress
+	c.prioritySampling = newPrioritySampler()
 }
 
-// WithPrioritySampling enables priority sampling on the active tracer instance. When using
-// distributed tracing, this option must be enabled in order to get all the parts of a distributed
-// trace sampled. To learn more about priority sampling, please visit:
+// WithPrioritySampling is deprecated, and priority sampling is enabled by default.
+// When using distributed tracing, the priority sampling value is propagated in order to
+// get all the parts of a distributed trace sampled.
+// To learn more about priority sampling, please visit:
 // https://docs.datadoghq.com/tracing/getting_further/trace_sampling_and_storage/#priority-sampling-for-distributed-tracing
 func WithPrioritySampling() StartOption {
 	return func(c *config) {
-		c.prioritySampling = newPrioritySampler()
+		// This is now enabled by default.
 	}
 }
 

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -21,9 +21,6 @@ type config struct {
 	// sampler specifies the sampler that will be used for sampling traces.
 	sampler Sampler
 
-	// prioritySampling will be non-nil when priority sampling is enabled.
-	prioritySampling *prioritySampler
-
 	// agentAddr specifies the hostname and  of the agent where the traces
 	// are sent to.
 	agentAddr string
@@ -50,7 +47,6 @@ func defaults(c *config) {
 	c.serviceName = filepath.Base(os.Args[0])
 	c.sampler = NewAllSampler()
 	c.agentAddr = defaultAddress
-	c.prioritySampling = newPrioritySampler()
 }
 
 // WithPrioritySampling is deprecated, and priority sampling is enabled by default.

--- a/ddtrace/tracer/sampler.go
+++ b/ddtrace/tracer/sampler.go
@@ -62,6 +62,10 @@ const knuthFactor = uint64(1111111111111111111)
 
 // Sample returns true if the given span should be sampled.
 func (r *rateSampler) Sample(spn ddtrace.Span) bool {
+	if r.rate == 1 {
+		// fast path
+		return true
+	}
 	s, ok := spn.(*span)
 	if !ok {
 		return false

--- a/ddtrace/tracer/sampler_test.go
+++ b/ddtrace/tracer/sampler_test.go
@@ -164,7 +164,7 @@ func TestRateSampler(t *testing.T) {
 	assert.True(NewRateSampler(1).Sample(newBasicSpan("test")))
 	assert.False(NewRateSampler(0).Sample(newBasicSpan("test")))
 	assert.False(NewRateSampler(0).Sample(newBasicSpan("test")))
-	assert.False(NewRateSampler(1).Sample(internal.NoopSpan{}))
+	assert.False(NewRateSampler(0.99).Sample(internal.NoopSpan{}))
 }
 
 func TestRateSamplerSetting(t *testing.T) {

--- a/ddtrace/tracer/sampler_test.go
+++ b/ddtrace/tracer/sampler_test.go
@@ -167,19 +167,6 @@ func TestRateSampler(t *testing.T) {
 	assert.False(NewRateSampler(1).Sample(internal.NoopSpan{}))
 }
 
-func TestRateSamplerFinishedSpan(t *testing.T) {
-	rs := NewRateSampler(0.9999)
-	tracer := newTracer(WithSampler(rs)) // high probability of sampling
-	span := newBasicSpan("test")
-	span.finished = true
-	tracer.sample(span)
-	if !rs.Sample(span) {
-		t.Skip("wasn't sampled") // no flaky tests
-	}
-	_, ok := span.Metrics[sampleRateMetricKey]
-	assert.False(t, ok)
-}
-
 func TestRateSamplerSetting(t *testing.T) {
 	assert := assert.New(t)
 	rs := NewRateSampler(1)

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -201,8 +201,8 @@ func (s *span) finish(finishTime int64) {
 	}
 	s.finished = true
 
-	if !s.context.sampled {
-		// not sampled
+	if s.context.drop {
+		// not sampled by local sampler
 		return
 	}
 	s.context.finish()

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -202,14 +202,20 @@ func TestSpanSetMetric(t *testing.T) {
 
 	// check the map is properly initialized
 	span.SetTag("bytes", 1024.42)
-	assert.Equal(1, len(span.Metrics))
+	assert.Equal(3, len(span.Metrics))
 	assert.Equal(1024.42, span.Metrics["bytes"])
+	var ok bool
+	_, ok = span.Metrics[samplingPriorityKey]
+	assert.True(ok)
+	_, ok = span.Metrics[samplingPriorityRateKey]
+	assert.True(ok)
 
 	// operating on a finished span is a no-op
 	span.Finish()
 	span.SetTag("finished.test", 1337)
-	assert.Equal(1, len(span.Metrics))
-	assert.Equal(0.0, span.Metrics["finished.test"])
+	assert.Equal(3, len(span.Metrics))
+	_, ok = span.Metrics["finished.test"]
+	assert.False(ok)
 }
 
 func TestSpanError(t *testing.T) {
@@ -296,8 +302,11 @@ func TestSpanSamplingPriority(t *testing.T) {
 	tracer := newTracer(withTransport(newDefaultTransport()))
 
 	span := tracer.newRootSpan("my.name", "my.service", "my.resource")
-	_, ok := span.Metrics[samplingPriorityKey]
-	assert.False(ok)
+	var ok bool
+	_, ok = span.Metrics[samplingPriorityKey]
+	assert.True(ok)
+	_, ok = span.Metrics[samplingPriorityRateKey]
+	assert.True(ok)
 
 	for _, priority := range []int{
 		ext.PriorityUserReject,

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -204,8 +204,7 @@ func TestSpanSetMetric(t *testing.T) {
 	span.SetTag("bytes", 1024.42)
 	assert.Equal(3, len(span.Metrics))
 	assert.Equal(1024.42, span.Metrics["bytes"])
-	var ok bool
-	_, ok = span.Metrics[samplingPriorityKey]
+	_, ok := span.Metrics[samplingPriorityKey]
 	assert.True(ok)
 	_, ok = span.Metrics[samplingPriorityRateKey]
 	assert.True(ok)
@@ -302,8 +301,7 @@ func TestSpanSamplingPriority(t *testing.T) {
 	tracer := newTracer(withTransport(newDefaultTransport()))
 
 	span := tracer.newRootSpan("my.name", "my.service", "my.resource")
-	var ok bool
-	_, ok = span.Metrics[samplingPriorityKey]
+	_, ok := span.Metrics[samplingPriorityKey]
 	assert.True(ok)
 	_, ok = span.Metrics[samplingPriorityRateKey]
 	assert.True(ok)

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
 )
 
@@ -87,6 +88,11 @@ func (c *spanContext) setSamplingPriority(p int) {
 	defer c.mu.Unlock()
 	c.priority = p
 	c.hasPriority = true
+	if p == ext.PriorityAutoKeep || p == ext.PriorityUserKeep {
+		c.sampled = true
+	} else {
+		c.sampled = false
+	}
 }
 
 func (c *spanContext) samplingPriority() int {

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -88,11 +88,7 @@ func (c *spanContext) setSamplingPriority(p int) {
 	defer c.mu.Unlock()
 	c.priority = p
 	c.hasPriority = true
-	if p == ext.PriorityAutoKeep || p == ext.PriorityUserKeep {
-		c.sampled = true
-	} else {
-		c.sampled = false
-	}
+	c.sampled = p == ext.PriorityAutoKeep || p == ext.PriorityUserKeep
 }
 
 func (c *spanContext) samplingPriority() int {

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -194,15 +194,14 @@ func TestSpanContextParent(t *testing.T) {
 	}
 	for name, parentCtx := range map[string]*spanContext{
 		"basic": &spanContext{
-			sampled: false,
 			baggage: map[string]string{"A": "A", "B": "B"},
 			trace:   newTrace(),
+			drop:    true,
 		},
 		"nil-trace": &spanContext{
-			sampled: false,
+			drop: true,
 		},
 		"priority": &spanContext{
-			sampled:     true,
 			baggage:     map[string]string{"A": "A", "B": "B"},
 			trace:       &trace{spans: []*span{newBasicSpan("abc")}},
 			hasPriority: true,
@@ -221,7 +220,7 @@ func TestSpanContextParent(t *testing.T) {
 			assert.Contains(ctx.trace.spans, s)
 			assert.Equal(ctx.hasPriority, parentCtx.hasPriority)
 			assert.Equal(ctx.priority, parentCtx.priority)
-			assert.Equal(ctx.sampled, parentCtx.sampled)
+			assert.Equal(ctx.drop, parentCtx.drop)
 			assert.Equal(ctx.baggage, parentCtx.baggage)
 		})
 	}

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -175,11 +175,12 @@ func (p *propagator) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 				return ErrSpanContextCorrupted
 			}
 		case p.cfg.PriorityHeader:
-			ctx.priority, err = strconv.Atoi(v)
+			var priority int
+			priority, err = strconv.Atoi(v)
 			if err != nil {
 				return ErrSpanContextCorrupted
 			}
-			ctx.hasPriority = true
+			ctx.setSamplingPriority(priority)
 		default:
 			if strings.HasPrefix(key, p.cfg.BaggagePrefix) {
 				ctx.setBaggageItem(strings.TrimPrefix(key, p.cfg.BaggagePrefix), v)

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -175,8 +175,7 @@ func (p *propagator) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 				return ErrSpanContextCorrupted
 			}
 		case p.cfg.PriorityHeader:
-			var priority int
-			priority, err = strconv.Atoi(v)
+			priority, err := strconv.Atoi(v)
 			if err != nil {
 				return ErrSpanContextCorrupted
 			}

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -363,7 +363,7 @@ const sampleRateMetricKey = "_sample_rate"
 func (t *tracer) sample(span *span) {
 	sampler := t.config.sampler
 	sampled := sampler.Sample(span)
-	span.context.sampled = sampled
+	span.context.drop = !sampled
 	if !sampled {
 		return
 	}

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -366,9 +366,8 @@ func (t *tracer) sample(span *span) {
 		return
 	}
 	sampler := t.config.sampler
-	sampled := sampler.Sample(span)
-	span.context.drop = !sampled
-	if !sampled {
+	if !sampler.Sample(span) {
+		span.context.drop = true
 		return
 	}
 	if rs, ok := sampler.(RateSampler); ok && rs.Rate() < 1 {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -68,8 +68,8 @@ func TestTracerCleanStop(t *testing.T) {
 		for i := 0; i < n; i++ {
 			Start(withTransport(transport))
 			time.Sleep(time.Microsecond)
-			Start(withTransport(transport))
-			Start(withTransport(transport))
+			Start(withTransport(transport), WithSampler(NewRateSampler(0.99)))
+			Start(withTransport(transport), WithSampler(NewRateSampler(0.99)))
 		}
 	}()
 
@@ -358,8 +358,6 @@ func TestTracerSampler(t *testing.T) {
 		withTransport(newDefaultTransport()),
 		WithSampler(sampler),
 	)
-	// override the default (priority sampling) within this test
-	tracer.config.prioritySampling = nil
 
 	span := tracer.newRootSpan("pylons.request", "pylons", "/")
 
@@ -448,15 +446,12 @@ func TestTracerEdgeSampler(t *testing.T) {
 		withTransport(newDefaultTransport()),
 		WithSampler(NewRateSampler(0)),
 	)
-	// avoid using priority sampling for this test
-	tracer0.config.prioritySampling = nil
 	defer stop()
 	// a sample rate of 1 should sample everything
 	tracer1, _, stop := startTestTracer(
 		withTransport(newDefaultTransport()),
 		WithSampler(NewRateSampler(1)),
 	)
-	tracer1.config.prioritySampling = nil
 	defer stop()
 
 	count := payloadQueueSize / 3

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -54,9 +54,9 @@ func TestTracerCleanStop(t *testing.T) {
 			for i := 0; i < n; i++ {
 				span := StartSpan("test.span")
 				child := StartSpan("child.span", ChildOf(span.Context()))
-				time.Sleep(time.Microsecond)
+				time.Sleep(time.Millisecond)
 				child.Finish()
-				time.Sleep(time.Microsecond)
+				time.Sleep(time.Millisecond)
 				span.Finish()
 			}
 		}()
@@ -67,7 +67,7 @@ func TestTracerCleanStop(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < n; i++ {
 			Start(withTransport(transport))
-			time.Sleep(time.Microsecond)
+			time.Sleep(time.Millisecond)
 			Start(withTransport(transport), WithSampler(NewRateSampler(0.99)))
 			Start(withTransport(transport), WithSampler(NewRateSampler(0.99)))
 		}
@@ -80,7 +80,7 @@ func TestTracerCleanStop(t *testing.T) {
 			Stop()
 			Stop()
 			Stop()
-			time.Sleep(time.Microsecond)
+			time.Sleep(time.Millisecond)
 			Stop()
 			Stop()
 			Stop()

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -54,9 +54,9 @@ func TestTracerCleanStop(t *testing.T) {
 			for i := 0; i < n; i++ {
 				span := StartSpan("test.span")
 				child := StartSpan("child.span", ChildOf(span.Context()))
-				time.Sleep(time.Millisecond)
+				time.Sleep(time.Microsecond)
 				child.Finish()
-				time.Sleep(time.Millisecond)
+				time.Sleep(time.Microsecond)
 				span.Finish()
 			}
 		}()
@@ -67,7 +67,7 @@ func TestTracerCleanStop(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < n; i++ {
 			Start(withTransport(transport))
-			time.Sleep(time.Millisecond)
+			time.Sleep(time.Microsecond)
 			Start(withTransport(transport))
 			Start(withTransport(transport))
 		}
@@ -80,7 +80,7 @@ func TestTracerCleanStop(t *testing.T) {
 			Stop()
 			Stop()
 			Stop()
-			time.Sleep(time.Millisecond)
+			time.Sleep(time.Microsecond)
 			Stop()
 			Stop()
 			Stop()
@@ -358,6 +358,8 @@ func TestTracerSampler(t *testing.T) {
 		withTransport(newDefaultTransport()),
 		WithSampler(sampler),
 	)
+	// override the default (priority sampling) within this test
+	tracer.config.prioritySampling = nil
 
 	span := tracer.newRootSpan("pylons.request", "pylons", "/")
 
@@ -446,12 +448,15 @@ func TestTracerEdgeSampler(t *testing.T) {
 		withTransport(newDefaultTransport()),
 		WithSampler(NewRateSampler(0)),
 	)
+	// avoid using priority sampling for this test
+	tracer0.config.prioritySampling = nil
 	defer stop()
 	// a sample rate of 1 should sample everything
 	tracer1, _, stop := startTestTracer(
 		withTransport(newDefaultTransport()),
 		WithSampler(NewRateSampler(1)),
 	)
+	tracer1.config.prioritySampling = nil
 	defer stop()
 
 	count := payloadQueueSize / 3


### PR DESCRIPTION
This is to improve the behavior that users observe when collecting distributed traces.
With a default to on, traces that are being sampled will have the parts produced by dd-trace-go submitted to the agent.

Currently, no option is provided to disable priority sampling, but code for the original behavior has been kept. This may be reconsidered in the future.