### PR TITLE
contrib/gin-gonic/gin: remove confusing documentation line

### DIFF
--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -13,7 +13,6 @@ import (
 )
 
 // Middleware returns middleware that will trace incoming requests.
-// The last parameter is optional and can be used to pass a custom tracer.
 func Middleware(service string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		resource := c.HandlerName()


### PR DESCRIPTION
Removing a confusing documentation line describing an additional parameter. Since the tracer.StartSpanFromContext logic now finds a global tracer configured, its up to user to start a tracer and configure it themselves.