### PR TITLE
ddtrace/ext: add a key for event sampling rate

### DIFF
--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -27,8 +27,8 @@ const (
 	// HTTPURL sets the HTTP URL for a span.
 	HTTPURL = "http.url"
 
-	// TODO: In the next major version, suffix these constants (SpanType, etc)
-	// with "*Key" (SpanTypeKey, etc) to more easily differentiate between
+	// TODO: In the next major version, prefix these constants (SpanType, etc)
+	// with "Key*" (KeySpanType, etc) to more easily differentiate between
 	// constants representing tag values and constants representing keys.
 
 	// SpanType defines the Span type (web, db, cache).
@@ -54,4 +54,8 @@ const (
 
 	// Environment specifies the environment to use with a trace.
 	Environment = "env"
+
+	// EventSampleRate specifies the rate at which this span will be sampled
+	// as an APM event.
+	EventSampleRate = "_dd1.sr.eausr"
 )


### PR DESCRIPTION
This change adds a new constant representing the event sampling rate
key for APM events.