### PR TITLE
contrib/go-redis/redis: fix context race in client

### DIFF
--- a/contrib/go-redis/redis/redis.go
+++ b/contrib/go-redis/redis/redis.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
@@ -20,6 +21,9 @@ import (
 type Client struct {
 	*redis.Client
 	*params
+
+	mu  sync.RWMutex // guards ctx
+	ctx context.Context
 }
 
 var _ redis.Cmdable = (*Client)(nil)
@@ -28,6 +32,8 @@ var _ redis.Cmdable = (*Client)(nil)
 type Pipeliner struct {
 	redis.Pipeliner
 	*params
+
+	ctx context.Context
 }
 
 var _ redis.Pipeliner = (*Pipeliner)(nil)
@@ -65,14 +71,17 @@ func WrapClient(c *redis.Client, opts ...ClientOption) *Client {
 		db:     strconv.Itoa(opt.DB),
 		config: cfg,
 	}
-	tc := &Client{c, params}
+	tc := &Client{Client: c, params: params}
 	tc.Client.WrapProcess(createWrapperFromClient(tc))
 	return tc
 }
 
 // Pipeline creates a Pipeline from a Client
 func (c *Client) Pipeline() redis.Pipeliner {
-	return &Pipeliner{c.Client.Pipeline(), c.params}
+	c.mu.RLock()
+	ctx := c.ctx
+	c.mu.RUnlock()
+	return &Pipeliner{c.Client.Pipeline(), c.params, ctx}
 }
 
 // ExecWithContext calls Pipeline.Exec(). It ensures that the resulting Redis calls
@@ -83,7 +92,7 @@ func (c *Pipeliner) ExecWithContext(ctx context.Context) ([]redis.Cmder, error) 
 
 // Exec calls Pipeline.Exec() ensuring that the resulting Redis calls are traced.
 func (c *Pipeliner) Exec() ([]redis.Cmder, error) {
-	return c.execWithContext(context.Background())
+	return c.execWithContext(c.ctx)
 }
 
 func (c *Pipeliner) execWithContext(ctx context.Context) ([]redis.Cmder, error) {
@@ -120,8 +129,18 @@ func commandsToString(cmds []redis.Cmder) string {
 
 // WithContext sets a context on a Client. Use it to ensure that emitted spans have the correct parent.
 func (c *Client) WithContext(ctx context.Context) *Client {
-	c.Client = c.Client.WithContext(ctx)
+	c.mu.Lock()
+	c.ctx = ctx
+	c.mu.Unlock()
 	return c
+}
+
+// Context returns the active context in the client.
+func (c *Client) Context() context.Context {
+	c.mu.RLock()
+	ctx := c.ctx
+	c.mu.RUnlock()
+	return ctx
 }
 
 // createWrapperFromClient returns a new createWrapper function which wraps the processor with tracing
@@ -130,7 +149,9 @@ func (c *Client) WithContext(ctx context.Context) *Client {
 func createWrapperFromClient(tc *Client) func(oldProcess func(cmd redis.Cmder) error) func(cmd redis.Cmder) error {
 	return func(oldProcess func(cmd redis.Cmder) error) func(cmd redis.Cmder) error {
 		return func(cmd redis.Cmder) error {
-			ctx := tc.Client.Context()
+			tc.mu.RLock()
+			ctx := tc.ctx
+			tc.mu.RUnlock()
 			raw := cmderToString(cmd)
 			parts := strings.Split(raw, " ")
 			length := len(parts) - 1

--- a/contrib/go-redis/redis/redis_test.go
+++ b/contrib/go-redis/redis/redis_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ func TestMain(m *testing.M) {
 	}
 	os.Exit(m.Run())
 }
+
 func TestClientEvalSha(t *testing.T) {
 	opts := &redis.Options{Addr: "127.0.0.1:6379"}
 	assert := assert.New(t)
@@ -48,6 +50,27 @@ func TestClientEvalSha(t *testing.T) {
 	assert.Equal("127.0.0.1", span.Tag(ext.TargetHost))
 	assert.Equal("6379", span.Tag(ext.TargetPort))
 	assert.Equal("evalsha", span.Tag(ext.ResourceName))
+}
+
+// https://github.com/DataDog/dd-trace-go/issues/387
+func TestIssue387(t *testing.T) {
+	opts := &redis.Options{Addr: "127.0.0.1:6379"}
+	client := NewClient(opts, WithServiceName("my-redis"))
+	n := 1000
+
+	client.Set("test_key", "test_value", 0)
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			client.WithContext(context.Background()).Get("test_key").Result()
+		}()
+	}
+	wg.Wait()
+
+	// should not result in a race
 }
 
 func TestClient(t *testing.T) {


### PR DESCRIPTION
Fixes a race condition when using the client concurrently with `WithContext`.

Fixes https://github.com/DataDog/dd-trace-go/issues/387