### PR TITLE
Revert "contrib/go-redis/redis: fix context race in client (#388)"

### DIFF
--- a/contrib/go-redis/redis/redis_test.go
+++ b/contrib/go-redis/redis/redis_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -26,7 +25,6 @@ func TestMain(m *testing.M) {
 	}
 	os.Exit(m.Run())
 }
-
 func TestClientEvalSha(t *testing.T) {
 	opts := &redis.Options{Addr: "127.0.0.1:6379"}
 	assert := assert.New(t)
@@ -50,27 +48,6 @@ func TestClientEvalSha(t *testing.T) {
 	assert.Equal("127.0.0.1", span.Tag(ext.TargetHost))
 	assert.Equal("6379", span.Tag(ext.TargetPort))
 	assert.Equal("evalsha", span.Tag(ext.ResourceName))
-}
-
-// https://github.com/DataDog/dd-trace-go/issues/387
-func TestIssue387(t *testing.T) {
-	opts := &redis.Options{Addr: "127.0.0.1:6379"}
-	client := NewClient(opts, WithServiceName("my-redis"))
-	n := 1000
-
-	client.Set("test_key", "test_value", 0)
-
-	var wg sync.WaitGroup
-	wg.Add(n)
-	for i := 0; i < n; i++ {
-		go func() {
-			defer wg.Done()
-			client.WithContext(context.Background()).Get("test_key").Result()
-		}()
-	}
-	wg.Wait()
-
-	// should not result in a race
 }
 
 func TestClient(t *testing.T) {


### PR DESCRIPTION
This reverts commit 61d8c99c511e0edf8b27364bd6cc053623720662.

This change reverts the fix from #388 because it introduces a new bug, where setting a context in one goroutine would change the context for other goroutines as well.

Re-opens #387 