### PR TITLE
Add option to force SpanID

### DIFF
--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -108,4 +108,7 @@ type StartSpanConfig struct {
 	// Tags holds a set of key/value pairs that should be set as metadata on the
 	// new span.
 	Tags map[string]interface{}
+
+	// Force-set the SpanID, rather than use a random number.
+	SpanID *uint64
 }

--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -109,6 +109,7 @@ type StartSpanConfig struct {
 	// new span.
 	Tags map[string]interface{}
 
-	// Force-set the SpanID, rather than use a random number.
-	SpanID *uint64
+	// Force-set the SpanID, rather than use a random number. If no Parent SpanContext is present,
+	// then this will also set the TraceID to the same value.
+	SpanID uint64
 }

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -149,10 +149,12 @@ func SpanType(name string) StartSpanOption {
 	return Tag(ext.SpanType, name)
 }
 
+// WithSpanID sets the SpanID on the started span, instead of using a random number.
+// If there is no parent Span (eg from ChildOf), then the TraceID will also be set to the
+// value given here.
 func WithSpanID(id uint64) StartSpanOption {
 	return func(cfg *ddtrace.StartSpanConfig) {
-		cfg.SpanID = new(uint64)
-		*cfg.SpanID = id
+		cfg.SpanID = id
 	}
 }
 

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -149,6 +149,13 @@ func SpanType(name string) StartSpanOption {
 	return Tag(ext.SpanType, name)
 }
 
+func WithSpanID(id uint64) StartSpanOption {
+	return func(cfg *ddtrace.StartSpanConfig) {
+		cfg.SpanID = new(uint64)
+		*cfg.SpanID = id
+	}
+}
+
 // ChildOf tells StartSpan to use the given span context as a parent for the
 // created span.
 func ChildOf(ctx ddtrace.SpanContext) StartSpanOption {

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -230,7 +230,12 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 			context = ctx
 		}
 	}
-	id := random.Uint64()
+	var id uint64
+	if opts.SpanID != nil {
+		id = *opts.SpanID
+	} else {
+		id = random.Uint64()
+	}
 	// span defaults
 	span := &span{
 		Name:     operationName,

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -230,10 +230,8 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 			context = ctx
 		}
 	}
-	var id uint64
-	if opts.SpanID != nil {
-		id = *opts.SpanID
-	} else {
+	id := opts.SpanID
+	if !id {
 		id = random.Uint64()
 	}
 	// span defaults

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -183,6 +183,7 @@ func TestTracerStartSpanOptions(t *testing.T) {
 		ServiceName("test.service"),
 		ResourceName("test.resource"),
 		StartTime(now),
+		WithSpanID(420),
 	}
 	span := tracer.StartSpan("web.request", opts...).(*span)
 	assert := assert.New(t)
@@ -190,6 +191,8 @@ func TestTracerStartSpanOptions(t *testing.T) {
 	assert.Equal("test.service", span.Service)
 	assert.Equal("test.resource", span.Resource)
 	assert.Equal(now.UnixNano(), span.Start)
+	assert.Equal(420, span.SpanID)
+	assert.Equal(420, span.TraceID)
 }
 
 func TestTracerStartChildSpan(t *testing.T) {
@@ -197,12 +200,17 @@ func TestTracerStartChildSpan(t *testing.T) {
 		assert := assert.New(t)
 		tracer := newTracer()
 		root := tracer.StartSpan("web.request", ServiceName("root-service")).(*span)
-		child := tracer.StartSpan("db.query", ChildOf(root.Context()), ServiceName("child-service")).(*span)
+		child := tracer.StartSpan("db.query",
+			ChildOf(root.Context()),
+			ServiceName("child-service"),
+			WithSpanID(69)).(*span)
 
 		assert.NotEqual(uint64(0), child.TraceID)
 		assert.NotEqual(uint64(0), child.SpanID)
 		assert.Equal(root.SpanID, child.ParentID)
 		assert.Equal(root.TraceID, child.ParentID)
+		assert.Equal(root.TraceID, child.TraceID)
+		assert.Equal(69, child.SpanId)
 		assert.Equal("child-service", child.Service)
 	})
 


### PR DESCRIPTION
@gbbr would you ever accept something like this? 

Use-case: I have a tracing "surrogate". I can't directly do tracing from the target application, so I have to build (I prefer in Golang) a surrogate that will create spans using information from the target application. That target still chooses the span/trace IDs, so that it can put them in headers. So therefore the tracing surrogate must create spans with pre-decided IDs.

This isn't a complete PR (need to add setting trace ID, and tests), just an informational one to discuss with you whether it's acceptable to add this feature.