### PR TITLE
ddtrace/tracer: WithError is no-op with nil err

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -188,7 +188,8 @@ func FinishTime(t time.Time) FinishOption {
 }
 
 // WithError marks the span as having had an error. It uses the information from
-// err to set tags such as the error message, error type and stack trace.
+// err to set tags such as the error message, error type and stack trace. It has
+// no effect if the error is nil.
 func WithError(err error) FinishOption {
 	return func(cfg *ddtrace.FinishConfig) {
 		cfg.Error = err


### PR DESCRIPTION
To create a bound contract add mention that when nil error is passed it has no effect on trace.

Fixes: https://github.com/DataDog/dd-trace-go/issues/393