### PR TITLE
Improve compatibility with Opentracing

### DIFF
--- a/ddtrace/opentracer/tracer.go
+++ b/ddtrace/opentracer/tracer.go
@@ -15,67 +15,11 @@
 package opentracer
 
 import (
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
-// New creates, instantiates and returns an Opentracing compatible version of the
-// Datadog tracer using the provided set of options.
 func New(opts ...tracer.StartOption) opentracing.Tracer {
-	tracer.Start(opts...)
-	return &opentracer{internal.GetGlobalTracer()}
-}
-
-var _ opentracing.Tracer = (*opentracer)(nil)
-
-// opentracer implements opentracing.Tracer on top of ddtrace.Tracer.
-type opentracer struct{ ddtrace.Tracer }
-
-// StartSpan implements opentracing.Tracer.
-func (t *opentracer) StartSpan(operationName string, options ...opentracing.StartSpanOption) opentracing.Span {
-	var sso opentracing.StartSpanOptions
-	for _, o := range options {
-		o.Apply(&sso)
-	}
-	opts := []ddtrace.StartSpanOption{tracer.StartTime(sso.StartTime)}
-	for _, ref := range sso.References {
-		if v, ok := ref.ReferencedContext.(ddtrace.SpanContext); ok && ref.Type == opentracing.ChildOfRef {
-			opts = append(opts, tracer.ChildOf(v))
-			break // can only have one parent
-		}
-	}
-	for k, v := range sso.Tags {
-		opts = append(opts, tracer.Tag(k, v))
-	}
-	return &span{
-		Span:       t.Tracer.StartSpan(operationName, opts...),
-		opentracer: t,
-	}
-}
-
-// Inject implements opentracing.Tracer.
-func (t *opentracer) Inject(ctx opentracing.SpanContext, format interface{}, carrier interface{}) error {
-	sctx, ok := ctx.(ddtrace.SpanContext)
-	if !ok {
-		return opentracing.ErrUnsupportedFormat
-	}
-	switch format {
-	case opentracing.TextMap, opentracing.HTTPHeaders:
-		return t.Tracer.Inject(sctx, carrier)
-	default:
-		return opentracing.ErrUnsupportedFormat
-	}
-}
-
-// Extract implements opentracing.Tracer.
-func (t *opentracer) Extract(format interface{}, carrier interface{}) (opentracing.SpanContext, error) {
-	switch format {
-	case opentracing.TextMap, opentracing.HTTPHeaders:
-		return t.Tracer.Extract(carrier)
-	default:
-		return nil, opentracing.ErrUnsupportedFormat
-	}
+	return tracer.NewOpenTracer(opts...)
 }

--- a/ddtrace/opentracer/tracer.go
+++ b/ddtrace/opentracer/tracer.go
@@ -20,6 +20,8 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
+// New creates, instantiates and returns an Opentracing compatible version of the
+// Datadog tracer using the provided set of options.
 func New(opts ...tracer.StartOption) opentracing.Tracer {
 	return tracer.NewOpenTracer(opts...)
 }

--- a/ddtrace/tracer/context.go
+++ b/ddtrace/tracer/context.go
@@ -20,7 +20,7 @@ func ContextWithSpan(ctx context.Context, s Span) context.Context {
 		return context.WithValue(ctx, activeSpanKey, s)
 	}
 	return opentracing.ContextWithSpan(ctx, &openSpan{
-		Span:s,
+		Span:       s,
 		opentracer: ot,
 	})
 }

--- a/ddtrace/tracer/opentracer.go
+++ b/ddtrace/tracer/opentracer.go
@@ -1,0 +1,80 @@
+// Package opentracer provides a wrapper on top of the Datadog tracer that can be used with Opentracing.
+// It also provides a set of opentracing.StartSpanOption that are specific to Datadog's APM product.
+// To use it, simply call "New".
+//
+// Note that there are currently some small incompatibilities between the Opentracing spec and the Datadog
+// APM product, which we are in the process of addressing on the long term. When using Datadog, the
+// Opentracing operation name is what is called resource in Datadog's terms and the Opentracing "component"
+// tag is Datadog's operation name. Meaning that in order to define (in Opentracing terms) a span that
+// has the operation name "/user/profile" and the component "http.request", one would do:
+//  opentracing.StartSpan("http.request", opentracer.ResourceName("/user/profile"))
+//
+// Some libraries and frameworks are supported out-of-the-box by using our integrations. You can see a list
+// of supported integrations here: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib. They are fully
+// compatible with the Opentracing implementation.
+package tracer
+
+import (
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
+
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+// New creates, instantiates and returns an Opentracing compatible version of the
+// Datadog tracer using the provided set of options.
+func NewOpenTracer(opts ...StartOption) opentracing.Tracer {
+	Start(opts...)
+	return &opentracer{internal.GetGlobalTracer()}
+}
+
+var _ opentracing.Tracer = (*opentracer)(nil)
+
+// opentracer implements opentracing.Tracer on top of ddtrace.Tracer.
+type opentracer struct{ ddtrace.Tracer }
+
+// StartSpan implements opentracing.Tracer.
+func (t *opentracer) StartSpan(operationName string, options ...opentracing.StartSpanOption) opentracing.Span {
+	var sso opentracing.StartSpanOptions
+	for _, o := range options {
+		o.Apply(&sso)
+	}
+	opts := []ddtrace.StartSpanOption{StartTime(sso.StartTime)}
+	for _, ref := range sso.References {
+		if v, ok := ref.ReferencedContext.(ddtrace.SpanContext); ok && ref.Type == opentracing.ChildOfRef {
+			opts = append(opts, ChildOf(v))
+			break // can only have one parent
+		}
+	}
+	for k, v := range sso.Tags {
+		opts = append(opts, Tag(k, v))
+	}
+	return &openSpan{
+		Span:       t.Tracer.StartSpan(operationName, opts...),
+		opentracer: t,
+	}
+}
+
+// Inject implements opentracing.Tracer.
+func (t *opentracer) Inject(ctx opentracing.SpanContext, format interface{}, carrier interface{}) error {
+	sctx, ok := ctx.(ddtrace.SpanContext)
+	if !ok {
+		return opentracing.ErrUnsupportedFormat
+	}
+	switch format {
+	case opentracing.TextMap, opentracing.HTTPHeaders:
+		return t.Tracer.Inject(sctx, carrier)
+	default:
+		return opentracing.ErrUnsupportedFormat
+	}
+}
+
+// Extract implements opentracing.Tracer.
+func (t *opentracer) Extract(format interface{}, carrier interface{}) (opentracing.SpanContext, error) {
+	switch format {
+	case opentracing.TextMap, opentracing.HTTPHeaders:
+		return t.Tracer.Extract(carrier)
+	default:
+		return nil, opentracing.ErrUnsupportedFormat
+	}
+}

--- a/ddtrace/tracer/opentracer.go
+++ b/ddtrace/tracer/opentracer.go
@@ -1,17 +1,3 @@
-// Package opentracer provides a wrapper on top of the Datadog tracer that can be used with Opentracing.
-// It also provides a set of opentracing.StartSpanOption that are specific to Datadog's APM product.
-// To use it, simply call "New".
-//
-// Note that there are currently some small incompatibilities between the Opentracing spec and the Datadog
-// APM product, which we are in the process of addressing on the long term. When using Datadog, the
-// Opentracing operation name is what is called resource in Datadog's terms and the Opentracing "component"
-// tag is Datadog's operation name. Meaning that in order to define (in Opentracing terms) a span that
-// has the operation name "/user/profile" and the component "http.request", one would do:
-//  opentracing.StartSpan("http.request", opentracer.ResourceName("/user/profile"))
-//
-// Some libraries and frameworks are supported out-of-the-box by using our integrations. You can see a list
-// of supported integrations here: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib. They are fully
-// compatible with the Opentracing implementation.
 package tracer
 
 import (

--- a/ddtrace/tracer/opentracer.go
+++ b/ddtrace/tracer/opentracer.go
@@ -21,7 +21,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
-// New creates, instantiates and returns an Opentracing compatible version of the
+// NewOpenTracer creates, instantiates and returns an Opentracing compatible version of the
 // Datadog tracer using the provided set of options.
 func NewOpenTracer(opts ...StartOption) opentracing.Tracer {
 	Start(opts...)

--- a/ddtrace/tracer/opentracer_test.go
+++ b/ddtrace/tracer/opentracer_test.go
@@ -1,4 +1,4 @@
-package opentracer
+package tracer
 
 import (
 	"testing"
@@ -11,7 +11,7 @@ import (
 
 func TestStart(t *testing.T) {
 	assert := assert.New(t)
-	ot := New()
+	ot := NewOpenTracer()
 	dd, ok := internal.GetGlobalTracer().(ddtrace.Tracer)
 	assert.True(ok)
 	ott, ok := ot.(*opentracer)


### PR DESCRIPTION
A span started using `opentracing.SpanFromContext` uses a different key than one started via `tracer.StartSpanFromContext`. This makes impossible to use the contrib integrations together with components that integrate OpenTracing.

In this PR I modified the functions that extract and create the Span to use the OpenTracing context instead of the local context if OpenTracing is used.

I had to move and rename the internal structures `opentracer/span` and `opentracer/tracer` due to the inability to access the underlying span (needed to maintain the compatibility with the existing code), but this shouldn't break the compatibility with existing code.

