### PR TITLE
contrib/google.golang.org/grpc: Fix adding errors to spans and traces

### DIFF
--- a/contrib/google.golang.org/grpc/client.go
+++ b/contrib/google.golang.org/grpc/client.go
@@ -26,7 +26,7 @@ func (cs *clientStream) RecvMsg(m interface{}) (err error) {
 		if p, ok := peer.FromContext(cs.Context()); ok {
 			setSpanTargetFromPeer(span, *p)
 		}
-		defer finishWithError(span, err, cs.cfg.noDebugStack)
+		defer func() { finishWithError(span, err, cs.cfg.noDebugStack) }()
 	}
 	err = cs.ClientStream.RecvMsg(m)
 	return err
@@ -38,7 +38,7 @@ func (cs *clientStream) SendMsg(m interface{}) (err error) {
 		if p, ok := peer.FromContext(cs.Context()); ok {
 			setSpanTargetFromPeer(span, *p)
 		}
-		defer finishWithError(span, err, cs.cfg.noDebugStack)
+		defer func() { finishWithError(span, err, cs.cfg.noDebugStack) }()
 	}
 	err = cs.ClientStream.SendMsg(m)
 	return err

--- a/contrib/google.golang.org/grpc/grpc.go
+++ b/contrib/google.golang.org/grpc/grpc.go
@@ -33,8 +33,11 @@ func startSpanFromContext(ctx context.Context, method, operation, service string
 
 // finishWithError applies finish option and a tag with gRPC status code, disregarding OK, EOF and Canceled errors.
 func finishWithError(span ddtrace.Span, err error, noDebugStack bool) {
+	if err == io.EOF || err == context.Canceled {
+		err = nil
+	}
 	errcode := status.Code(err)
-	if err == io.EOF || errcode == codes.Canceled || errcode == codes.OK || err == context.Canceled {
+	if errcode == codes.Canceled || errcode == codes.OK {
 		err = nil
 	}
 	span.SetTag(tagCode, errcode.String())

--- a/contrib/google.golang.org/grpc/server.go
+++ b/contrib/google.golang.org/grpc/server.go
@@ -28,7 +28,7 @@ func (ss *serverStream) Context() context.Context {
 func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 	if ss.cfg.traceStreamMessages {
 		span, _ := startSpanFromContext(ss.ctx, ss.method, "grpc.message", ss.cfg.serverServiceName())
-		defer finishWithError(span, err, ss.cfg.noDebugStack)
+		defer func() { finishWithError(span, err, ss.cfg.noDebugStack) }()
 	}
 	err = ss.ServerStream.RecvMsg(m)
 	return err
@@ -37,7 +37,7 @@ func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 func (ss *serverStream) SendMsg(m interface{}) (err error) {
 	if ss.cfg.traceStreamMessages {
 		span, _ := startSpanFromContext(ss.ctx, ss.method, "grpc.message", ss.cfg.serverServiceName())
-		defer finishWithError(span, err, ss.cfg.noDebugStack)
+		defer func() { finishWithError(span, err, ss.cfg.noDebugStack) }()
 	}
 	err = ss.ServerStream.SendMsg(m)
 	return err
@@ -60,7 +60,7 @@ func StreamServerInterceptor(opts ...InterceptorOption) grpc.StreamServerInterce
 		if cfg.traceStreamCalls {
 			var span ddtrace.Span
 			span, ctx = startSpanFromContext(ctx, info.FullMethod, "grpc.server", cfg.serviceName)
-			defer finishWithError(span, err, cfg.noDebugStack)
+			defer func() { finishWithError(span, err, cfg.noDebugStack) }()
 		}
 
 		// call the original handler with a new stream, which traces each send


### PR DESCRIPTION
- Put `finishWithError` calls inside closure functions because the deferred
function's arguments are evaluated when the defer statement is
evaluated. More at https://golang.org/doc/effective_go.html#defer
Before this commit, `finishWithError` deferred with nil error (initial value)
and any other changes of the initial value were not added to span. This bug
affects only grpc streaming.
- Clean `tagCode` in case of disregarded error.
- Add tests for checking if span contains error.