### PR TITLE
ddtrace/tracer: add origin to span context

### DIFF
--- a/ddtrace/tracer/sampler.go
+++ b/ddtrace/tracer/sampler.go
@@ -140,5 +140,5 @@ func (ps *prioritySampler) apply(spn *span) {
 	} else {
 		spn.SetTag(ext.SamplingPriority, ext.PriorityAutoReject)
 	}
-	spn.SetTag(samplingPriorityRateKey, rate)
+	spn.SetTag(keySamplingPriorityRate, rate)
 }

--- a/ddtrace/tracer/sampler_test.go
+++ b/ddtrace/tracer/sampler_test.go
@@ -144,18 +144,18 @@ func TestPrioritySampler(t *testing.T) {
 		testSpan1.TraceID = math.MaxUint64 - (math.MaxUint64 / 4)
 
 		ps.apply(testSpan1)
-		assert.EqualValues(ext.PriorityAutoKeep, testSpan1.Metrics[samplingPriorityKey])
-		assert.EqualValues(0.5, testSpan1.Metrics[samplingPriorityRateKey])
+		assert.EqualValues(ext.PriorityAutoKeep, testSpan1.Metrics[keySamplingPriority])
+		assert.EqualValues(0.5, testSpan1.Metrics[keySamplingPriorityRate])
 
 		testSpan1.TraceID = math.MaxUint64 - (math.MaxUint64 / 3)
 		ps.apply(testSpan1)
-		assert.EqualValues(ext.PriorityAutoReject, testSpan1.Metrics[samplingPriorityKey])
-		assert.EqualValues(0.5, testSpan1.Metrics[samplingPriorityRateKey])
+		assert.EqualValues(ext.PriorityAutoReject, testSpan1.Metrics[keySamplingPriority])
+		assert.EqualValues(0.5, testSpan1.Metrics[keySamplingPriorityRate])
 
 		testSpan1.Service = "other-service"
 		testSpan1.TraceID = 1
-		assert.EqualValues(ext.PriorityAutoReject, testSpan1.Metrics[samplingPriorityKey])
-		assert.EqualValues(0.5, testSpan1.Metrics[samplingPriorityRateKey])
+		assert.EqualValues(ext.PriorityAutoReject, testSpan1.Metrics[keySamplingPriority])
+		assert.EqualValues(0.5, testSpan1.Metrics[keySamplingPriorityRate])
 	})
 }
 

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -238,4 +238,5 @@ func (s *span) String() string {
 const (
 	keySamplingPriority     = "_sampling_priority_v1"
 	keySamplingPriorityRate = "_sampling_priority_rate_v1"
+	keyOrigin               = "_dd.origin"
 )

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -150,7 +150,7 @@ func (s *span) setTagNumeric(key string, v float64) {
 	switch key {
 	case ext.SamplingPriority:
 		// setting sampling priority per spec
-		s.Metrics[samplingPriorityKey] = v
+		s.Metrics[keySamplingPriority] = v
 		s.context.setSamplingPriority(int(v))
 	default:
 		s.Metrics[key] = v
@@ -236,6 +236,6 @@ func (s *span) String() string {
 }
 
 const (
-	samplingPriorityKey     = "_sampling_priority_v1"
-	samplingPriorityRateKey = "_sampling_priority_rate_v1"
+	keySamplingPriority     = "_sampling_priority_v1"
+	keySamplingPriorityRate = "_sampling_priority_rate_v1"
 )

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -160,7 +160,7 @@ func TestSpanSetTag(t *testing.T) {
 	assert.Equal(int32(0), span.Error)
 
 	span.SetTag(ext.SamplingPriority, 2)
-	assert.Equal(float64(2), span.Metrics[samplingPriorityKey])
+	assert.Equal(float64(2), span.Metrics[keySamplingPriority])
 }
 
 func TestSpanSetDatadogTags(t *testing.T) {
@@ -204,9 +204,9 @@ func TestSpanSetMetric(t *testing.T) {
 	span.SetTag("bytes", 1024.42)
 	assert.Equal(3, len(span.Metrics))
 	assert.Equal(1024.42, span.Metrics["bytes"])
-	_, ok := span.Metrics[samplingPriorityKey]
+	_, ok := span.Metrics[keySamplingPriority]
 	assert.True(ok)
-	_, ok = span.Metrics[samplingPriorityRateKey]
+	_, ok = span.Metrics[keySamplingPriorityRate]
 	assert.True(ok)
 
 	// operating on a finished span is a no-op
@@ -301,9 +301,9 @@ func TestSpanSamplingPriority(t *testing.T) {
 	tracer := newTracer(withTransport(newDefaultTransport()))
 
 	span := tracer.newRootSpan("my.name", "my.service", "my.resource")
-	_, ok := span.Metrics[samplingPriorityKey]
+	_, ok := span.Metrics[keySamplingPriority]
 	assert.True(ok)
-	_, ok = span.Metrics[samplingPriorityRateKey]
+	_, ok = span.Metrics[keySamplingPriorityRate]
 	assert.True(ok)
 
 	for _, priority := range []int{
@@ -314,15 +314,15 @@ func TestSpanSamplingPriority(t *testing.T) {
 		999, // not used, but we should allow it
 	} {
 		span.SetTag(ext.SamplingPriority, priority)
-		v, ok := span.Metrics[samplingPriorityKey]
+		v, ok := span.Metrics[keySamplingPriority]
 		assert.True(ok)
 		assert.EqualValues(priority, v)
 		assert.EqualValues(span.context.priority, v)
 		assert.True(span.context.hasPriority)
 
 		childSpan := tracer.newChildSpan("my.child", span)
-		v0, ok0 := span.Metrics[samplingPriorityKey]
-		v1, ok1 := childSpan.Metrics[samplingPriorityKey]
+		v0, ok0 := span.Metrics[keySamplingPriority]
+		v1, ok1 := childSpan.Metrics[keySamplingPriority]
 		assert.Equal(ok0, ok1)
 		assert.Equal(v0, v1)
 		assert.EqualValues(childSpan.context.priority, v0)

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -28,6 +28,7 @@ type spanContext struct {
 	mu          sync.RWMutex // guards below fields
 	baggage     map[string]string
 	priority    int
+	origin      string // e.g. "synthetics"
 	hasPriority bool
 }
 
@@ -42,7 +43,7 @@ func newSpanContext(span *span, parent *spanContext) *spanContext {
 		spanID:  span.SpanID,
 		span:    span,
 	}
-	if v, ok := span.Metrics[samplingPriorityKey]; ok {
+	if v, ok := span.Metrics[keySamplingPriority]; ok {
 		context.hasPriority = true
 		context.priority = int(v)
 	}

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -52,6 +52,7 @@ func newSpanContext(span *span, parent *spanContext) *spanContext {
 		context.drop = parent.drop
 		context.hasPriority = parent.hasSamplingPriority()
 		context.priority = parent.samplingPriority()
+		context.origin = parent.origin
 		parent.ForeachBaggageItem(func(k, v string) bool {
 			context.setBaggageItem(k, v)
 			return true

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -171,7 +171,7 @@ func TestNewSpanContext(t *testing.T) {
 			TraceID:  1,
 			SpanID:   2,
 			ParentID: 3,
-			Metrics:  map[string]float64{samplingPriorityKey: 1},
+			Metrics:  map[string]float64{keySamplingPriority: 1},
 		}
 		ctx := newSpanContext(span, nil)
 		assert := assert.New(t)

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -207,6 +207,10 @@ func TestSpanContextParent(t *testing.T) {
 			hasPriority: true,
 			priority:    2,
 		},
+		"origin": &spanContext{
+			trace:  &trace{spans: []*span{newBasicSpan("abc")}},
+			origin: "synthetics",
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			ctx := newSpanContext(s, parentCtx)
@@ -222,6 +226,7 @@ func TestSpanContextParent(t *testing.T) {
 			assert.Equal(ctx.priority, parentCtx.priority)
 			assert.Equal(ctx.drop, parentCtx.drop)
 			assert.Equal(ctx.baggage, parentCtx.baggage)
+			assert.Equal(ctx.origin, parentCtx.origin)
 		})
 	}
 }

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -251,7 +251,7 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		span.TraceID = context.traceID
 		span.ParentID = context.spanID
 		if context.hasSamplingPriority() {
-			span.Metrics[samplingPriorityKey] = float64(context.samplingPriority())
+			span.Metrics[keySamplingPriority] = float64(context.samplingPriority())
 		}
 		if context.span != nil {
 			// it has a local parent, inherit the service

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -254,10 +254,16 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 			span.Metrics[keySamplingPriority] = float64(context.samplingPriority())
 		}
 		if context.span != nil {
-			// it has a local parent, inherit the service
+			// local parent, inherit service
 			context.span.RLock()
 			span.Service = context.span.Service
 			context.span.RUnlock()
+		} else {
+			// remote parent
+			if context.origin != "" {
+				// mark origin
+				span.Meta[keyOrigin] = context.origin
+			}
 		}
 	}
 	span.context = newSpanContext(span, context)

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -165,13 +165,13 @@ func TestTracerStartSpan(t *testing.T) {
 		assert.Contains([]float64{
 			ext.PriorityAutoReject,
 			ext.PriorityAutoKeep,
-		}, span.Metrics[samplingPriorityKey])
+		}, span.Metrics[keySamplingPriority])
 	})
 
 	t.Run("priority", func(t *testing.T) {
 		tracer := newTracer()
 		span := tracer.StartSpan("web.request", Tag(ext.SamplingPriority, ext.PriorityUserKeep)).(*span)
-		assert.Equal(t, float64(ext.PriorityUserKeep), span.Metrics[samplingPriorityKey])
+		assert.Equal(t, float64(ext.PriorityUserKeep), span.Metrics[keySamplingPriority])
 	})
 }
 
@@ -286,8 +286,8 @@ func TestTracerSamplingPriorityPropagation(t *testing.T) {
 	tracer := newTracer()
 	root := tracer.StartSpan("web.request", Tag(ext.SamplingPriority, 2)).(*span)
 	child := tracer.StartSpan("db.query", ChildOf(root.Context())).(*span)
-	assert.EqualValues(2, root.Metrics[samplingPriorityKey])
-	assert.EqualValues(2, child.Metrics[samplingPriorityKey])
+	assert.EqualValues(2, root.Metrics[keySamplingPriority])
+	assert.EqualValues(2, child.Metrics[keySamplingPriority])
 	assert.EqualValues(2, root.context.priority)
 	assert.EqualValues(2, child.context.priority)
 	assert.True(root.context.hasPriority)
@@ -411,10 +411,10 @@ func TestTracerPrioritySampler(t *testing.T) {
 
 	// default rates (1.0)
 	s := tr.newEnvSpan("pylons", "")
-	assert.Equal(1., s.Metrics[samplingPriorityRateKey])
-	assert.Equal(1., s.Metrics[samplingPriorityKey])
+	assert.Equal(1., s.Metrics[keySamplingPriorityRate])
+	assert.Equal(1., s.Metrics[keySamplingPriority])
 	assert.True(s.context.hasSamplingPriority())
-	assert.EqualValues(s.context.samplingPriority(), s.Metrics[samplingPriorityKey])
+	assert.EqualValues(s.context.samplingPriority(), s.Metrics[keySamplingPriority])
 	s.Finish()
 
 	tr.forceFlush() // obtain new rates
@@ -443,8 +443,8 @@ func TestTracerPrioritySampler(t *testing.T) {
 		},
 	} {
 		s := tr.newEnvSpan(tt.service, tt.env)
-		assert.Equal(tt.rate, s.Metrics[samplingPriorityRateKey], strconv.Itoa(i))
-		prio, ok := s.Metrics[samplingPriorityKey]
+		assert.Equal(tt.rate, s.Metrics[keySamplingPriorityRate], strconv.Itoa(i))
+		prio, ok := s.Metrics[keySamplingPriority]
 		assert.True(ok)
 		assert.Contains([]float64{0, 1}, prio)
 		assert.True(s.context.hasSamplingPriority())


### PR DESCRIPTION
This change adds the `_dd.origin` tag to local-level root spans that have a remote parent which propagated the `x-datadog-origin` header. Currently it is mainly used by the Synthetics product.