### PR TITLE
ddtrace/{ext,opentracer,tracer}: allow setting span name via tag

### DIFF
--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -31,6 +31,11 @@ const (
 	// with "Key*" (KeySpanType, etc) to more easily differentiate between
 	// constants representing tag values and constants representing keys.
 
+	// SpanName is a pseudo-key for setting a span's operation name by means of
+	// a tag. It is mostly here to facilitate vendor-agnostic frameworks like Opentracing
+	// and OpenCensus.
+	SpanName = "span.name"
+
 	// SpanType defines the Span type (web, db, cache).
 	SpanType = "span.type"
 

--- a/ddtrace/opentracer/option.go
+++ b/ddtrace/opentracer/option.go
@@ -18,6 +18,11 @@ func ResourceName(name string) opentracing.StartSpanOption {
 	return opentracing.Tag{Key: ext.ResourceName, Value: name}
 }
 
+// SpanName sets the Datadog operation name for the span.
+func SpanName(name string) opentracing.StartSpanOption {
+	return opentracing.Tag{Key: ext.SpanName, Value: name}
+}
+
 // SpanType can be used with opentracing.StartSpan to set the type of a span.
 func SpanType(name string) opentracing.StartSpanOption {
 	return opentracing.Tag{Key: ext.SpanType, Value: name}

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -133,6 +133,8 @@ func (s *span) setTagError(value interface{}, debugStack bool) {
 // setTagString sets a string tag. This method is not safe for concurrent use.
 func (s *span) setTagString(key, v string) {
 	switch key {
+	case ext.SpanName:
+		s.Name = v
 	case ext.ServiceName:
 		s.Service = v
 	case ext.ResourceName:

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -173,6 +173,13 @@ func TestTracerStartSpan(t *testing.T) {
 		span := tracer.StartSpan("web.request", Tag(ext.SamplingPriority, ext.PriorityUserKeep)).(*span)
 		assert.Equal(t, float64(ext.PriorityUserKeep), span.Metrics[keySamplingPriority])
 	})
+
+	t.Run("name", func(t *testing.T) {
+		tracer := newTracer()
+		span := tracer.StartSpan("/home/user", Tag(ext.SpanName, "db.query")).(*span)
+		assert.Equal(t, "db.query", span.Name)
+		assert.Equal(t, "/home/user", span.Resource)
+	})
 }
 
 func TestTracerStartSpanOptions(t *testing.T) {


### PR DESCRIPTION
This change adds a special tag called "span.name" (constant
ext.SpanName) to allow setting the operation name externally by means of
a tag when using vendor agnostic libraries like Opentracing or
OpenCensus.