### PR TITLE
contrib/go-chi/chi: fix resource issue

### DIFF
--- a/contrib/go-chi/chi/chi.go
+++ b/contrib/go-chi/chi/chi.go
@@ -43,6 +43,10 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 
 			// set the resource name as we get it only once the handler is executed
 			resourceName := chi.RouteContext(r.Context()).RoutePattern()
+			if resourceName == "" {
+				resourceName = "unknown"
+			}
+			resourceName = r.Method + " " + resourceName
 			span.SetTag(ext.ResourceName, resourceName)
 
 			// set the status code

--- a/contrib/go-chi/chi/chi_test.go
+++ b/contrib/go-chi/chi/chi_test.go
@@ -65,7 +65,7 @@ func TestTrace200(t *testing.T) {
 	assert.Equal("http.request", span.OperationName())
 	assert.Equal(ext.SpanTypeWeb, span.Tag(ext.SpanType))
 	assert.Equal("foobar", span.Tag(ext.ServiceName))
-	assert.Equal("/user/{id}", span.Tag(ext.ResourceName))
+	assert.Equal("GET /user/{id}", span.Tag(ext.ResourceName))
 	assert.Equal("200", span.Tag(ext.HTTPCode))
 	assert.Equal("GET", span.Tag(ext.HTTPMethod))
 	assert.Equal("/user/123", span.Tag(ext.HTTPURL))


### PR DESCRIPTION
This change adds the request method to the resource and covers for the
case when resource is empty.

Closes https://github.com/DataDog/dd-trace-go/issues/404