### PR TITLE
{ddtrace/tracer,contrib/*}: add support for Trace Analytics

### DIFF
--- a/contrib/Shopify/sarama/option.go
+++ b/contrib/Shopify/sarama/option.go
@@ -1,11 +1,13 @@
 package sarama
 
 type config struct {
-	serviceName string
+	serviceName   string
+	analyticsRate float64
 }
 
 func defaults(cfg *config) {
 	cfg.serviceName = "kafka"
+	// cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // An Option is used to customize the config for the sarama tracer.
@@ -15,5 +17,21 @@ type Option func(cfg *config)
 func WithServiceName(name string) Option {
 	return func(cfg *config) {
 		cfg.serviceName = name
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) Option {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) Option {
+	return func(cfg *config) {
+		cfg.analyticsRate = rate
 	}
 }

--- a/contrib/Shopify/sarama/sarama.go
+++ b/contrib/Shopify/sarama/sarama.go
@@ -44,6 +44,9 @@ func WrapPartitionConsumer(pc sarama.PartitionConsumer, opts ...Option) sarama.P
 				tracer.Tag("partition", msg.Partition),
 				tracer.Tag("offset", msg.Offset),
 			}
+			if cfg.analyticsRate > 0 {
+				opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
+			}
 			// kafka supports headers, so try to extract a span context
 			carrier := NewConsumerMessageCarrier(msg)
 			if spanctx, err := tracer.Extract(carrier); err == nil {
@@ -238,6 +241,9 @@ func startProducerSpan(cfg *config, version sarama.KafkaVersion, msg *sarama.Pro
 		tracer.ServiceName(cfg.serviceName),
 		tracer.ResourceName("Produce Topic " + msg.Topic),
 		tracer.SpanType(ext.SpanTypeMessageProducer),
+	}
+	if cfg.analyticsRate > 0 {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 	}
 	// if there's a span context in the headers, use that as the parent
 	if spanctx, err := tracer.Extract(carrier); err == nil {

--- a/contrib/aws/aws-sdk-go/aws/aws.go
+++ b/contrib/aws/aws-sdk-go/aws/aws.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )

--- a/contrib/aws/aws-sdk-go/aws/aws.go
+++ b/contrib/aws/aws-sdk-go/aws/aws.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -24,6 +25,7 @@ type handlers struct {
 // WrapSession wraps a session.Session, causing requests and responses to be traced.
 func WrapSession(s *session.Session, opts ...Option) *session.Session {
 	cfg := new(config)
+	defaults(cfg)
 	for _, opt := range opts {
 		opt(cfg)
 	}
@@ -41,7 +43,7 @@ func WrapSession(s *session.Session, opts ...Option) *session.Session {
 }
 
 func (h *handlers) Send(req *request.Request) {
-	_, ctx := tracer.StartSpanFromContext(req.Context(), h.operationName(req),
+	opts := []ddtrace.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeHTTP),
 		tracer.ServiceName(h.serviceName(req)),
 		tracer.ResourceName(h.resourceName(req)),
@@ -50,7 +52,11 @@ func (h *handlers) Send(req *request.Request) {
 		tracer.Tag(tagAWSRegion, h.awsRegion(req)),
 		tracer.Tag(ext.HTTPMethod, req.Operation.HTTPMethod),
 		tracer.Tag(ext.HTTPURL, req.HTTPRequest.URL.String()),
-	)
+	}
+	if h.cfg.analyticsRate > 0 {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, h.cfg.analyticsRate))
+	}
+	_, ctx := tracer.StartSpanFromContext(req.Context(), h.operationName(req), opts...)
 	req.SetContext(ctx)
 }
 

--- a/contrib/aws/aws-sdk-go/aws/aws_test.go
+++ b/contrib/aws/aws-sdk-go/aws/aws_test.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
 func TestAWS(t *testing.T) {
@@ -73,5 +74,65 @@ func TestAWS(t *testing.T) {
 		assert.Equal(t, "400", s.Tag(ext.HTTPCode))
 		assert.Equal(t, "POST", s.Tag(ext.HTTPMethod))
 		assert.Equal(t, "http://ec2.us-west-2.amazonaws.com/", s.Tag(ext.HTTPURL))
+	})
+}
+
+func TestAnalyticsSettings(t *testing.T) {
+	cfg := aws.NewConfig().
+		WithRegion("us-west-2").
+		WithDisableSSL(true).
+		WithCredentials(credentials.AnonymousCredentials)
+
+	session := session.Must(session.NewSession(cfg))
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...Option) {
+		ws := WrapSession(session, opts...)
+		ec2.New(ws).DescribeInstancesWithContext(context.TODO(), &ec2.DescribeInstancesInput{})
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+		s := spans[0]
+		assert.Equal(t, rate, s.Tag(ext.EventSampleRate))
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil)
+	})
+
+	t.Run("global", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.4)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 1.0, WithAnalytics(true))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil, WithAnalytics(false))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
 	})
 }

--- a/contrib/aws/aws-sdk-go/aws/aws_test.go
+++ b/contrib/aws/aws-sdk-go/aws/aws_test.go
@@ -101,6 +101,7 @@ func TestAnalyticsSettings(t *testing.T) {
 	})
 
 	t.Run("global", func(t *testing.T) {
+		t.Skip("global flag disabled")
 		mt := mocktracer.Start()
 		defer mt.Stop()
 

--- a/contrib/aws/aws-sdk-go/aws/option.go
+++ b/contrib/aws/aws-sdk-go/aws/option.go
@@ -1,7 +1,5 @@
 package aws
 
-import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
-
 type config struct {
 	serviceName   string
 	analyticsRate float64
@@ -11,7 +9,7 @@ type config struct {
 type Option func(*config)
 
 func defaults(cfg *config) {
-	cfg.analyticsRate = globalconfig.AnalyticsRate()
+	// cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // WithServiceName sets the given service name for the dialled connection.

--- a/contrib/aws/aws-sdk-go/aws/option.go
+++ b/contrib/aws/aws-sdk-go/aws/option.go
@@ -1,11 +1,18 @@
 package aws
 
+import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+
 type config struct {
-	serviceName string
+	serviceName   string
+	analyticsRate float64
 }
 
 // Option represents an option that can be passed to Dial.
 type Option func(*config)
+
+func defaults(cfg *config) {
+	cfg.analyticsRate = globalconfig.AnalyticsRate()
+}
 
 // WithServiceName sets the given service name for the dialled connection.
 // When the service name is not explicitly set it will be inferred based on the
@@ -13,5 +20,21 @@ type Option func(*config)
 func WithServiceName(name string) Option {
 	return func(cfg *config) {
 		cfg.serviceName = name
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) Option {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) Option {
+	return func(cfg *config) {
+		cfg.analyticsRate = rate
 	}
 }

--- a/contrib/bradfitz/gomemcache/memcache/memcache.go
+++ b/contrib/bradfitz/gomemcache/memcache/memcache.go
@@ -56,10 +56,15 @@ func (c *Client) WithContext(ctx context.Context) *Client {
 
 // startSpan starts a span from the context set with WithContext.
 func (c *Client) startSpan(resourceName string) ddtrace.Span {
-	span, _ := tracer.StartSpanFromContext(c.context, operationName,
+	opts := []ddtrace.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeMemcached),
 		tracer.ServiceName(c.cfg.serviceName),
-		tracer.ResourceName(resourceName))
+		tracer.ResourceName(resourceName),
+	}
+	if rate := c.cfg.analyticsRate; rate > 0 {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, rate))
+	}
+	span, _ := tracer.StartSpanFromContext(c.context, operationName, opts...)
 	return span
 }
 

--- a/contrib/bradfitz/gomemcache/memcache/memcache_test.go
+++ b/contrib/bradfitz/gomemcache/memcache/memcache_test.go
@@ -126,6 +126,7 @@ func TestAnalyticsSettings(t *testing.T) {
 	})
 
 	t.Run("global", func(t *testing.T) {
+		t.Skip("global flag disabled")
 		mt := mocktracer.Start()
 		defer mt.Stop()
 

--- a/contrib/bradfitz/gomemcache/memcache/memcache_test.go
+++ b/contrib/bradfitz/gomemcache/memcache/memcache_test.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
 func TestMemcache(t *testing.T) {
@@ -44,7 +45,7 @@ func testMemcache(t *testing.T, addr string) {
 			"resource name should be set to the memcache command")
 	}
 
-	t.Run("traces without context", func(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
@@ -60,7 +61,7 @@ func testMemcache(t *testing.T, addr string) {
 		validateMemcacheSpan(t, spans[0], "Add")
 	})
 
-	t.Run("traces with context", func(t *testing.T) {
+	t.Run("context", func(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
@@ -100,6 +101,65 @@ func TestFakeServer(t *testing.T) {
 	s := bufio.NewScanner(conn)
 	assert.True(t, s.Scan())
 	assert.Equal(t, "STORED", s.Text())
+}
+
+func TestAnalyticsSettings(t *testing.T) {
+	li := makeFakeServer(t)
+	defer li.Close()
+	addr := li.Addr().String()
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...ClientOption) {
+		client := WrapClient(memcache.New(addr), opts...)
+		defer client.DeleteAll()
+		err := client.Add(&memcache.Item{Key: "key1", Value: []byte("value1")})
+		assert.NoError(t, err)
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+		assert.Equal(t, rate, spans[0].Tag(ext.EventSampleRate))
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil)
+	})
+
+	t.Run("global", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.4)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 1.0, WithAnalytics(true))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil, WithAnalytics(false))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
+	})
 }
 
 func makeFakeServer(t *testing.T) net.Listener {

--- a/contrib/bradfitz/gomemcache/memcache/option.go
+++ b/contrib/bradfitz/gomemcache/memcache/option.go
@@ -1,7 +1,5 @@
 package memcache
 
-import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
-
 const (
 	serviceName   = "memcached"
 	operationName = "memcached.query"
@@ -17,7 +15,7 @@ type ClientOption func(*clientConfig)
 
 func defaults(cfg *clientConfig) {
 	cfg.serviceName = serviceName
-	cfg.analyticsRate = globalconfig.AnalyticsRate()
+	// cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // WithServiceName sets the given service name for the dialled connection.

--- a/contrib/bradfitz/gomemcache/memcache/option.go
+++ b/contrib/bradfitz/gomemcache/memcache/option.go
@@ -1,22 +1,44 @@
 package memcache
 
+import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+
 const (
 	serviceName   = "memcached"
 	operationName = "memcached.query"
 )
 
-type clientConfig struct{ serviceName string }
+type clientConfig struct {
+	serviceName   string
+	analyticsRate float64
+}
 
 // ClientOption represents an option that can be passed to Dial.
 type ClientOption func(*clientConfig)
 
 func defaults(cfg *clientConfig) {
 	cfg.serviceName = serviceName
+	cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // WithServiceName sets the given service name for the dialled connection.
 func WithServiceName(name string) ClientOption {
 	return func(cfg *clientConfig) {
 		cfg.serviceName = name
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) ClientOption {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) ClientOption {
+	return func(cfg *clientConfig) {
+		cfg.analyticsRate = rate
 	}
 }

--- a/contrib/confluentinc/confluent-kafka-go/kafka/option.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/option.go
@@ -1,10 +1,15 @@
 package kafka
 
-import "context"
+import (
+	"context"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+)
 
 type config struct {
-	serviceName string
-	ctx         context.Context
+	ctx           context.Context
+	serviceName   string
+	analyticsRate float64
 }
 
 // An Option customizes the config.
@@ -12,8 +17,9 @@ type Option func(cfg *config)
 
 func newConfig(opts ...Option) *config {
 	cfg := &config{
-		serviceName: "kafka",
-		ctx:         context.Background(),
+		serviceName:   "kafka",
+		ctx:           context.Background(),
+		analyticsRate: globalconfig.AnalyticsRate(),
 	}
 	for _, opt := range opts {
 		opt(cfg)
@@ -32,5 +38,21 @@ func WithContext(ctx context.Context) Option {
 func WithServiceName(serviceName string) Option {
 	return func(cfg *config) {
 		cfg.serviceName = serviceName
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) Option {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) Option {
+	return func(cfg *config) {
+		cfg.analyticsRate = rate
 	}
 }

--- a/contrib/confluentinc/confluent-kafka-go/kafka/option.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/option.go
@@ -2,8 +2,6 @@ package kafka
 
 import (
 	"context"
-
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
 type config struct {
@@ -17,9 +15,9 @@ type Option func(cfg *config)
 
 func newConfig(opts ...Option) *config {
 	cfg := &config{
-		serviceName:   "kafka",
-		ctx:           context.Background(),
-		analyticsRate: globalconfig.AnalyticsRate(),
+		serviceName: "kafka",
+		ctx:         context.Background(),
+		// analyticsRate: globalconfig.AnalyticsRate(),
 	}
 	for _, opt := range opts {
 		opt(cfg)

--- a/contrib/confluentinc/confluent-kafka-go/kafka/option_test.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/option_test.go
@@ -14,6 +14,7 @@ func TestAnalyticsSettings(t *testing.T) {
 	})
 
 	t.Run("global", func(t *testing.T) {
+		t.Skip("global flag disabled")
 		rate := globalconfig.AnalyticsRate()
 		defer globalconfig.SetAnalyticsRate(rate)
 		globalconfig.SetAnalyticsRate(0.4)

--- a/contrib/confluentinc/confluent-kafka-go/kafka/option_test.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/option_test.go
@@ -1,0 +1,38 @@
+package kafka
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+)
+
+func TestAnalyticsSettings(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		cfg := newConfig()
+		assert.Equal(t, 0.0, cfg.analyticsRate)
+	})
+
+	t.Run("global", func(t *testing.T) {
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		cfg := newConfig()
+		assert.Equal(t, 0.4, cfg.analyticsRate)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		cfg := newConfig(WithAnalytics(true))
+		assert.Equal(t, 1.0, cfg.analyticsRate)
+	})
+
+	t.Run("override", func(t *testing.T) {
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		cfg := newConfig(WithAnalyticsRate(0.2))
+		assert.Equal(t, 0.2, cfg.analyticsRate)
+	})
+}

--- a/contrib/database/sql/option.go
+++ b/contrib/database/sql/option.go
@@ -1,17 +1,39 @@
 package sql
 
-type registerConfig struct{ serviceName string }
+import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+
+type registerConfig struct {
+	serviceName   string
+	analyticsRate float64
+}
 
 // RegisterOption represents an option that can be passed to Register.
 type RegisterOption func(*registerConfig)
 
 func defaults(cfg *registerConfig) {
 	// default cfg.serviceName set in Register based on driver name
+	cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // WithServiceName sets the given service name for the registered driver.
 func WithServiceName(name string) RegisterOption {
 	return func(cfg *registerConfig) {
 		cfg.serviceName = name
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) RegisterOption {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) RegisterOption {
+	return func(cfg *registerConfig) {
+		cfg.analyticsRate = rate
 	}
 }

--- a/contrib/database/sql/option.go
+++ b/contrib/database/sql/option.go
@@ -1,7 +1,5 @@
 package sql
 
-import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
-
 type registerConfig struct {
 	serviceName   string
 	analyticsRate float64
@@ -12,7 +10,7 @@ type RegisterOption func(*registerConfig)
 
 func defaults(cfg *registerConfig) {
 	// default cfg.serviceName set in Register based on driver name
-	cfg.analyticsRate = globalconfig.AnalyticsRate()
+	// cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // WithServiceName sets the given service name for the registered driver.

--- a/contrib/database/sql/option_test.go
+++ b/contrib/database/sql/option_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestAnalyticsSettings(t *testing.T) {
 	t.Run("global", func(t *testing.T) {
+		t.Skip("global flag disabled")
 		rate := globalconfig.AnalyticsRate()
 		defer globalconfig.SetAnalyticsRate(rate)
 		globalconfig.SetAnalyticsRate(0.4)

--- a/contrib/database/sql/option_test.go
+++ b/contrib/database/sql/option_test.go
@@ -1,0 +1,38 @@
+package sql
+
+import (
+	"testing"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+	"gotest.tools/assert"
+)
+
+func TestAnalyticsSettings(t *testing.T) {
+	t.Run("global", func(t *testing.T) {
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		cfg := new(registerConfig)
+		defaults(cfg)
+		assert.Equal(t, 0.4, cfg.analyticsRate)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		cfg := new(registerConfig)
+		defaults(cfg)
+		WithAnalytics(true)(cfg)
+		assert.Equal(t, 1.0, cfg.analyticsRate)
+	})
+
+	t.Run("override", func(t *testing.T) {
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		cfg := new(registerConfig)
+		defaults(cfg)
+		WithAnalyticsRate(0.2)(cfg)
+		assert.Equal(t, 0.2, cfg.analyticsRate)
+	})
+}

--- a/contrib/database/sql/sql_test.go
+++ b/contrib/database/sql/sql_test.go
@@ -40,19 +40,20 @@ func TestMySQL(t *testing.T) {
 		TableName:  tableName,
 		ExpectName: "mysql.query",
 		ExpectTags: map[string]interface{}{
-			ext.ServiceName: "mysql.db",
-			ext.SpanType:    ext.SpanTypeSQL,
-			ext.TargetHost:  "127.0.0.1",
-			ext.TargetPort:  "3306",
-			ext.DBUser:      "test",
-			ext.DBName:      "test",
+			ext.ServiceName:     "mysql.db",
+			ext.SpanType:        ext.SpanTypeSQL,
+			ext.TargetHost:      "127.0.0.1",
+			ext.TargetPort:      "3306",
+			ext.DBUser:          "test",
+			ext.DBName:          "test",
+			ext.EventSampleRate: nil,
 		},
 	}
 	sqltest.RunAll(t, testConfig)
 }
 
 func TestPostgres(t *testing.T) {
-	Register("postgres", &pq.Driver{}, WithServiceName("postgres-test"))
+	Register("postgres", &pq.Driver{}, WithServiceName("postgres-test"), WithAnalyticsRate(0.2))
 	db, err := Open("postgres", "postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable")
 	if err != nil {
 		log.Fatal(err)
@@ -65,12 +66,13 @@ func TestPostgres(t *testing.T) {
 		TableName:  tableName,
 		ExpectName: "postgres.query",
 		ExpectTags: map[string]interface{}{
-			ext.ServiceName: "postgres-test",
-			ext.SpanType:    ext.SpanTypeSQL,
-			ext.TargetHost:  "127.0.0.1",
-			ext.TargetPort:  "5432",
-			ext.DBUser:      "postgres",
-			ext.DBName:      "postgres",
+			ext.ServiceName:     "postgres-test",
+			ext.SpanType:        ext.SpanTypeSQL,
+			ext.TargetHost:      "127.0.0.1",
+			ext.TargetPort:      "5432",
+			ext.DBUser:          "postgres",
+			ext.DBName:          "postgres",
+			ext.EventSampleRate: 0.2,
 		},
 	}
 	sqltest.RunAll(t, testConfig)

--- a/contrib/emicklei/go-restful/example_test.go
+++ b/contrib/emicklei/go-restful/example_test.go
@@ -15,8 +15,13 @@ func Example() {
 	// create new go-restful service
 	ws := new(restful.WebService)
 
-	// instrument the service with trace
-	ws.Filter(restfultrace.Filter)
+	// create the Datadog filter
+	filter := restfultrace.FilterFunction(
+		restfultrace.WithServiceName("my-service"),
+	)
+
+	// use it
+	ws.Filter(filter)
 
 	// set endpoint
 	ws.Route(ws.GET("/hello").To(

--- a/contrib/emicklei/go-restful/example_test.go
+++ b/contrib/emicklei/go-restful/example_test.go
@@ -16,7 +16,7 @@ func Example() {
 	ws := new(restful.WebService)
 
 	// create the Datadog filter
-	filter := restfultrace.FilterFunction(
+	filter := restfultrace.FilterFunc(
 		restfultrace.WithServiceName("my-service"),
 	)
 

--- a/contrib/emicklei/go-restful/option.go
+++ b/contrib/emicklei/go-restful/option.go
@@ -1,0 +1,41 @@
+package restful
+
+import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+
+type config struct {
+	serviceName   string
+	analyticsRate float64
+}
+
+func newConfig() *config {
+	return &config{
+		serviceName:   "go-restful",
+		analyticsRate: globalconfig.AnalyticsRate(),
+	}
+}
+
+// Option specifies instrumentation configuration options.
+type Option func(*config)
+
+// WithServiceName sets the service name to by used by the filter.
+func WithServiceName(name string) Option {
+	return func(cfg *config) {
+		cfg.serviceName = name
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) Option {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) Option {
+	return func(cfg *config) {
+		cfg.analyticsRate = rate
+	}
+}

--- a/contrib/emicklei/go-restful/restful.go
+++ b/contrib/emicklei/go-restful/restful.go
@@ -11,8 +11,8 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
-// FilterFunction returns a filter which will trace incoming request.
-func FilterFunction(configOpts ...Option) restful.FilterFunction {
+// FilterFunc returns a restful.FilterFunction which will automatically trace incoming request.
+func FilterFunc(configOpts ...Option) restful.FilterFunction {
 	cfg := newConfig()
 	for _, opt := range configOpts {
 		opt(cfg)
@@ -44,7 +44,7 @@ func FilterFunction(configOpts ...Option) restful.FilterFunction {
 	}
 }
 
-// Filter is deprecated. Please use FilterFunction.
+// Filter is deprecated. Please use FilterFunc.
 func Filter(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
 	opts := []ddtrace.StartSpanOption{
 		tracer.ResourceName(req.SelectedRoutePath()),

--- a/contrib/emicklei/go-restful/restful.go
+++ b/contrib/emicklei/go-restful/restful.go
@@ -5,12 +5,46 @@ import (
 	"strconv"
 
 	"github.com/emicklei/go-restful"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
-// Filter is a filter that will trace incoming request
+// FilterFunction returns a filter which will trace incoming request.
+func FilterFunction(configOpts ...Option) restful.FilterFunction {
+	cfg := newConfig()
+	for _, opt := range configOpts {
+		opt(cfg)
+	}
+	return func(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+		opts := []ddtrace.StartSpanOption{
+			tracer.ServiceName(cfg.serviceName),
+			tracer.ResourceName(req.SelectedRoutePath()),
+			tracer.SpanType(ext.SpanTypeWeb),
+			tracer.Tag(ext.HTTPMethod, req.Request.Method),
+			tracer.Tag(ext.HTTPURL, req.Request.URL.Path),
+		}
+		if cfg.analyticsRate > 0 {
+			opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
+		}
+		if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(req.Request.Header)); err == nil {
+			opts = append(opts, tracer.ChildOf(spanctx))
+		}
+		span, ctx := tracer.StartSpanFromContext(req.Request.Context(), "http.request", opts...)
+		defer span.Finish()
+
+		// pass the span through the request context
+		req.Request = req.Request.WithContext(ctx)
+
+		chain.ProcessFilter(req, resp)
+
+		span.SetTag(ext.HTTPCode, strconv.Itoa(resp.StatusCode()))
+		span.SetTag(ext.Error, resp.Error())
+	}
+}
+
+// Filter is deprecated. Please use FilterFunction.
 func Filter(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
 	opts := []ddtrace.StartSpanOption{
 		tracer.ResourceName(req.SelectedRoutePath()),

--- a/contrib/emicklei/go-restful/restful_test.go
+++ b/contrib/emicklei/go-restful/restful_test.go
@@ -19,7 +19,7 @@ func TestTrace200(t *testing.T) {
 	defer mt.Stop()
 
 	ws := new(restful.WebService)
-	ws.Filter(FilterFunction(WithServiceName("my-service")))
+	ws.Filter(FilterFunc(WithServiceName("my-service")))
 	ws.Route(ws.GET("/user/{id}").Param(restful.PathParameter("id", "user ID")).
 		To(func(request *restful.Request, response *restful.Response) {
 			_, ok := tracer.SpanFromContext(request.Request.Context())
@@ -58,7 +58,7 @@ func TestError(t *testing.T) {
 	wantErr := errors.New("oh no")
 
 	ws := new(restful.WebService)
-	ws.Filter(FilterFunction())
+	ws.Filter(FilterFunc())
 	ws.Route(ws.GET("/err").To(func(request *restful.Request, response *restful.Response) {
 		response.WriteError(500, wantErr)
 	}))
@@ -93,7 +93,7 @@ func TestPropagation(t *testing.T) {
 	tracer.Inject(pspan.Context(), tracer.HTTPHeadersCarrier(r.Header))
 
 	ws := new(restful.WebService)
-	ws.Filter(FilterFunction())
+	ws.Filter(FilterFunc())
 	ws.Route(ws.GET("/user/{id}").To(func(request *restful.Request, response *restful.Response) {
 		span, ok := tracer.SpanFromContext(request.Request.Context())
 		assert.True(ok)
@@ -109,7 +109,7 @@ func TestPropagation(t *testing.T) {
 func TestAnalyticsSettings(t *testing.T) {
 	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...Option) {
 		ws := new(restful.WebService)
-		ws.Filter(FilterFunction(opts...))
+		ws.Filter(FilterFunc(opts...))
 		ws.Route(ws.GET("/user/{id}").To(func(request *restful.Request, response *restful.Response) {}))
 
 		container := restful.NewContainer()

--- a/contrib/emicklei/go-restful/restful_test.go
+++ b/contrib/emicklei/go-restful/restful_test.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
 func TestTrace200(t *testing.T) {
@@ -18,7 +19,7 @@ func TestTrace200(t *testing.T) {
 	defer mt.Stop()
 
 	ws := new(restful.WebService)
-	ws.Filter(Filter)
+	ws.Filter(FilterFunction(WithServiceName("my-service")))
 	ws.Route(ws.GET("/user/{id}").Param(restful.PathParameter("id", "user ID")).
 		To(func(request *restful.Request, response *restful.Response) {
 			_, ok := tracer.SpanFromContext(request.Request.Context())
@@ -43,6 +44,7 @@ func TestTrace200(t *testing.T) {
 	assert.Equal("http.request", span.OperationName())
 	assert.Equal(ext.SpanTypeWeb, span.Tag(ext.SpanType))
 	assert.Contains(span.Tag(ext.ResourceName), "/user/{id}")
+	assert.Equal("my-service", span.Tag(ext.ServiceName))
 	assert.Equal("200", span.Tag(ext.HTTPCode))
 	assert.Equal("GET", span.Tag(ext.HTTPMethod))
 	assert.Equal("/user/123", span.Tag(ext.HTTPURL))
@@ -56,7 +58,7 @@ func TestError(t *testing.T) {
 	wantErr := errors.New("oh no")
 
 	ws := new(restful.WebService)
-	ws.Filter(Filter)
+	ws.Filter(FilterFunction())
 	ws.Route(ws.GET("/err").To(func(request *restful.Request, response *restful.Response) {
 		response.WriteError(500, wantErr)
 	}))
@@ -91,7 +93,7 @@ func TestPropagation(t *testing.T) {
 	tracer.Inject(pspan.Context(), tracer.HTTPHeadersCarrier(r.Header))
 
 	ws := new(restful.WebService)
-	ws.Filter(Filter)
+	ws.Filter(FilterFunction())
 	ws.Route(ws.GET("/user/{id}").To(func(request *restful.Request, response *restful.Response) {
 		span, ok := tracer.SpanFromContext(request.Request.Context())
 		assert.True(ok)
@@ -102,4 +104,66 @@ func TestPropagation(t *testing.T) {
 	container.Add(ws)
 
 	container.ServeHTTP(w, r)
+}
+
+func TestAnalyticsSettings(t *testing.T) {
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...Option) {
+		ws := new(restful.WebService)
+		ws.Filter(FilterFunction(opts...))
+		ws.Route(ws.GET("/user/{id}").To(func(request *restful.Request, response *restful.Response) {}))
+
+		container := restful.NewContainer()
+		container.Add(ws)
+		r := httptest.NewRequest("GET", "/user/123", nil)
+		w := httptest.NewRecorder()
+		container.ServeHTTP(w, r)
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+		s := spans[0]
+		assert.Equal(t, rate, s.Tag(ext.EventSampleRate))
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil)
+	})
+
+	t.Run("global", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.4)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 1.0, WithAnalytics(true))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil, WithAnalytics(false))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
+	})
 }

--- a/contrib/garyburd/redigo/option.go
+++ b/contrib/garyburd/redigo/option.go
@@ -1,7 +1,5 @@
 package redigo // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/garyburd/redigo"
 
-import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
-
 type dialConfig struct {
 	serviceName   string
 	analyticsRate float64
@@ -12,7 +10,7 @@ type DialOption func(*dialConfig)
 
 func defaults(cfg *dialConfig) {
 	cfg.serviceName = "redis.conn"
-	cfg.analyticsRate = globalconfig.AnalyticsRate()
+	// cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // WithServiceName sets the given service name for the dialled connection.

--- a/contrib/garyburd/redigo/option.go
+++ b/contrib/garyburd/redigo/option.go
@@ -1,17 +1,39 @@
 package redigo // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/garyburd/redigo"
 
-type dialConfig struct{ serviceName string }
+import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+
+type dialConfig struct {
+	serviceName   string
+	analyticsRate float64
+}
 
 // DialOption represents an option that can be passed to Dial.
 type DialOption func(*dialConfig)
 
 func defaults(cfg *dialConfig) {
 	cfg.serviceName = "redis.conn"
+	cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // WithServiceName sets the given service name for the dialled connection.
 func WithServiceName(name string) DialOption {
 	return func(cfg *dialConfig) {
 		cfg.serviceName = name
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) DialOption {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) DialOption {
+	return func(cfg *dialConfig) {
+		cfg.analyticsRate = rate
 	}
 }

--- a/contrib/garyburd/redigo/redigo_test.go
+++ b/contrib/garyburd/redigo/redigo_test.go
@@ -196,6 +196,7 @@ func TestAnalyticsSettings(t *testing.T) {
 	})
 
 	t.Run("global", func(t *testing.T) {
+		t.Skip("global flag disabled")
 		mt := mocktracer.Start()
 		defer mt.Stop()
 

--- a/contrib/gin-gonic/gin/gintrace_test.go
+++ b/contrib/gin-gonic/gin/gintrace_test.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -188,4 +189,65 @@ func TestPropagation(t *testing.T) {
 	})
 
 	router.ServeHTTP(w, r)
+}
+
+func TestAnalyticsSettings(t *testing.T) {
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...Option) {
+		router := gin.New()
+		router.Use(Middleware("foobar", opts...))
+		router.GET("/user/:id", func(_ *gin.Context) {})
+
+		r := httptest.NewRequest("GET", "/user/123", nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, r)
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+		s := spans[0]
+		assert.Equal(t, rate, s.Tag(ext.EventSampleRate))
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil)
+	})
+
+	t.Run("global", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.4)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 1.0, WithAnalytics(true))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil, WithAnalytics(false))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
+	})
 }

--- a/contrib/gin-gonic/gin/option.go
+++ b/contrib/gin-gonic/gin/option.go
@@ -1,0 +1,32 @@
+package gin
+
+import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+
+type config struct {
+	analyticsRate float64
+}
+
+func newConfig() *config {
+	return &config{
+		analyticsRate: globalconfig.AnalyticsRate(),
+	}
+}
+
+// Option specifies instrumentation configuration options.
+type Option func(*config)
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) Option {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) Option {
+	return func(cfg *config) {
+		cfg.analyticsRate = rate
+	}
+}

--- a/contrib/globalsign/mgo/collection.go
+++ b/contrib/globalsign/mgo/collection.go
@@ -11,12 +11,13 @@ import (
 // data used for APM Tracing.
 type Collection struct {
 	*mgo.Collection
-	cfg mongoConfig
+	cfg  *mongoConfig
+	tags map[string]string
 }
 
 // Create invokes and traces Collection.Create
 func (c *Collection) Create(info *mgo.CollectionInfo) error {
-	span := newChildSpanFromContext(c.cfg)
+	span := newChildSpanFromContext(c.cfg, c.tags)
 	err := c.Collection.Create(info)
 	span.Finish(tracer.WithError(err))
 	return err
@@ -24,7 +25,7 @@ func (c *Collection) Create(info *mgo.CollectionInfo) error {
 
 // DropCollection invokes and traces Collection.DropCollection
 func (c *Collection) DropCollection() error {
-	span := newChildSpanFromContext(c.cfg)
+	span := newChildSpanFromContext(c.cfg, c.tags)
 	err := c.Collection.DropCollection()
 	span.Finish(tracer.WithError(err))
 	return err
@@ -32,7 +33,7 @@ func (c *Collection) DropCollection() error {
 
 // EnsureIndexKey invokes and traces Collection.EnsureIndexKey
 func (c *Collection) EnsureIndexKey(key ...string) error {
-	span := newChildSpanFromContext(c.cfg)
+	span := newChildSpanFromContext(c.cfg, c.tags)
 	err := c.Collection.EnsureIndexKey(key...)
 	span.Finish(tracer.WithError(err))
 	return err
@@ -40,7 +41,7 @@ func (c *Collection) EnsureIndexKey(key ...string) error {
 
 // EnsureIndex invokes and traces Collection.EnsureIndex
 func (c *Collection) EnsureIndex(index mgo.Index) error {
-	span := newChildSpanFromContext(c.cfg)
+	span := newChildSpanFromContext(c.cfg, c.tags)
 	err := c.Collection.EnsureIndex(index)
 	span.Finish(tracer.WithError(err))
 	return err
@@ -48,7 +49,7 @@ func (c *Collection) EnsureIndex(index mgo.Index) error {
 
 // DropIndex invokes and traces Collection.DropIndex
 func (c *Collection) DropIndex(key ...string) error {
-	span := newChildSpanFromContext(c.cfg)
+	span := newChildSpanFromContext(c.cfg, c.tags)
 	err := c.Collection.DropIndex(key...)
 	span.Finish(tracer.WithError(err))
 	return err
@@ -56,7 +57,7 @@ func (c *Collection) DropIndex(key ...string) error {
 
 // DropIndexName invokes and traces Collection.DropIndexName
 func (c *Collection) DropIndexName(name string) error {
-	span := newChildSpanFromContext(c.cfg)
+	span := newChildSpanFromContext(c.cfg, c.tags)
 	err := c.Collection.DropIndexName(name)
 	span.Finish(tracer.WithError(err))
 	return err
@@ -64,7 +65,7 @@ func (c *Collection) DropIndexName(name string) error {
 
 // Indexes invokes and traces Collection.Indexes
 func (c *Collection) Indexes() (indexes []mgo.Index, err error) {
-	span := newChildSpanFromContext(c.cfg)
+	span := newChildSpanFromContext(c.cfg, c.tags)
 	indexes, err = c.Collection.Indexes()
 	span.Finish(tracer.WithError(err))
 	return indexes, err
@@ -72,7 +73,7 @@ func (c *Collection) Indexes() (indexes []mgo.Index, err error) {
 
 // Insert invokes and traces Collectin.Insert
 func (c *Collection) Insert(docs ...interface{}) error {
-	span := newChildSpanFromContext(c.cfg)
+	span := newChildSpanFromContext(c.cfg, c.tags)
 	err := c.Collection.Insert(docs...)
 	span.Finish(tracer.WithError(err))
 	return err
@@ -83,6 +84,7 @@ func (c *Collection) Find(query interface{}) *Query {
 	return &Query{
 		Query: c.Collection.Find(query),
 		cfg:   c.cfg,
+		tags:  c.tags,
 	}
 }
 
@@ -91,12 +93,13 @@ func (c *Collection) FindId(id interface{}) *Query { // nolint
 	return &Query{
 		Query: c.Collection.FindId(id),
 		cfg:   c.cfg,
+		tags:  c.tags,
 	}
 }
 
 // Count invokes and traces Collection.Count
 func (c *Collection) Count() (n int, err error) {
-	span := newChildSpanFromContext(c.cfg)
+	span := newChildSpanFromContext(c.cfg, c.tags)
 	n, err = c.Collection.Count()
 	span.Finish(tracer.WithError(err))
 	return n, err
@@ -123,12 +126,13 @@ func (c *Collection) Pipe(pipeline interface{}) *Pipe {
 	return &Pipe{
 		Pipe: c.Collection.Pipe(pipeline),
 		cfg:  c.cfg,
+		tags: c.tags,
 	}
 }
 
 // Update invokes and traces Collection.Update
 func (c *Collection) Update(selector interface{}, update interface{}) error {
-	span := newChildSpanFromContext(c.cfg)
+	span := newChildSpanFromContext(c.cfg, c.tags)
 	err := c.Collection.Update(selector, update)
 	span.Finish(tracer.WithError(err))
 	return err
@@ -136,7 +140,7 @@ func (c *Collection) Update(selector interface{}, update interface{}) error {
 
 // UpdateId invokes and traces Collection.UpdateId
 func (c *Collection) UpdateId(id interface{}, update interface{}) error { // nolint
-	span := newChildSpanFromContext(c.cfg)
+	span := newChildSpanFromContext(c.cfg, c.tags)
 	err := c.Collection.UpdateId(id, update)
 	span.Finish(tracer.WithError(err))
 	return err
@@ -144,7 +148,7 @@ func (c *Collection) UpdateId(id interface{}, update interface{}) error { // nol
 
 // UpdateAll invokes and traces Collection.UpdateAll
 func (c *Collection) UpdateAll(selector interface{}, update interface{}) (info *mgo.ChangeInfo, err error) {
-	span := newChildSpanFromContext(c.cfg)
+	span := newChildSpanFromContext(c.cfg, c.tags)
 	info, err = c.Collection.UpdateAll(selector, update)
 	span.Finish(tracer.WithError(err))
 	return info, err
@@ -152,7 +156,7 @@ func (c *Collection) UpdateAll(selector interface{}, update interface{}) (info *
 
 // Upsert invokes and traces Collection.Upsert
 func (c *Collection) Upsert(selector interface{}, update interface{}) (info *mgo.ChangeInfo, err error) {
-	span := newChildSpanFromContext(c.cfg)
+	span := newChildSpanFromContext(c.cfg, c.tags)
 	info, err = c.Collection.Upsert(selector, update)
 	span.Finish(tracer.WithError(err))
 	return info, err
@@ -160,7 +164,7 @@ func (c *Collection) Upsert(selector interface{}, update interface{}) (info *mgo
 
 // UpsertId invokes and traces Collection.UpsertId
 func (c *Collection) UpsertId(id interface{}, update interface{}) (info *mgo.ChangeInfo, err error) { // nolint
-	span := newChildSpanFromContext(c.cfg)
+	span := newChildSpanFromContext(c.cfg, c.tags)
 	info, err = c.Collection.UpsertId(id, update)
 	span.Finish(tracer.WithError(err))
 	return info, err
@@ -168,7 +172,7 @@ func (c *Collection) UpsertId(id interface{}, update interface{}) (info *mgo.Cha
 
 // Remove invokes and traces Collection.Remove
 func (c *Collection) Remove(selector interface{}) error {
-	span := newChildSpanFromContext(c.cfg)
+	span := newChildSpanFromContext(c.cfg, c.tags)
 	err := c.Collection.Remove(selector)
 	span.Finish(tracer.WithError(err))
 	return err
@@ -176,7 +180,7 @@ func (c *Collection) Remove(selector interface{}) error {
 
 // RemoveId invokes and traces Collection.RemoveId
 func (c *Collection) RemoveId(id interface{}) error { // nolint
-	span := newChildSpanFromContext(c.cfg)
+	span := newChildSpanFromContext(c.cfg, c.tags)
 	err := c.Collection.RemoveId(id)
 	span.Finish(tracer.WithError(err))
 	return err
@@ -184,7 +188,7 @@ func (c *Collection) RemoveId(id interface{}) error { // nolint
 
 // RemoveAll invokes and traces Collection.RemoveAll
 func (c *Collection) RemoveAll(selector interface{}) (info *mgo.ChangeInfo, err error) {
-	span := newChildSpanFromContext(c.cfg)
+	span := newChildSpanFromContext(c.cfg, c.tags)
 	info, err = c.Collection.RemoveAll(selector)
 	span.Finish(tracer.WithError(err))
 	return info, err
@@ -192,7 +196,7 @@ func (c *Collection) RemoveAll(selector interface{}) (info *mgo.ChangeInfo, err 
 
 // Repair invokes and traces Collection.Repair
 func (c *Collection) Repair() *Iter {
-	span := newChildSpanFromContext(c.cfg)
+	span := newChildSpanFromContext(c.cfg, c.tags)
 	iter := c.Collection.Repair()
 	span.Finish()
 	return &Iter{

--- a/contrib/globalsign/mgo/mgo_test.go
+++ b/contrib/globalsign/mgo/mgo_test.go
@@ -391,6 +391,7 @@ func TestAnalyticsSettings(t *testing.T) {
 	})
 
 	t.Run("global", func(t *testing.T) {
+		t.Skip("global flag disabled")
 		mt := mocktracer.Start()
 		defer mt.Stop()
 

--- a/contrib/globalsign/mgo/mgo_test.go
+++ b/contrib/globalsign/mgo/mgo_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
 func TestMain(m *testing.M) {
@@ -351,4 +353,76 @@ func TestCollection_Bulk(t *testing.T) {
 	spans := testMongoCollectionCommand(assert, insert)
 	assert.Equal(2, len(spans))
 	assert.Equal("mongodb.query", spans[0].OperationName())
+}
+
+func TestAnalyticsSettings(t *testing.T) {
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...DialOption) {
+		assert := assert.New(t)
+
+		session, err := Dial("localhost:27017", opts...)
+		assert.NoError(err)
+		defer session.Close()
+
+		db := session.DB("my_db")
+		collection := db.C("MyCollection")
+		bulk := collection.Bulk()
+		bulk.Insert(bson.D{
+			bson.DocElem{
+				Name: "entity",
+				Value: bson.DocElem{
+					Name:  "index",
+					Value: 0,
+				},
+			},
+		})
+		bulk.Run()
+
+		spans := mt.FinishedSpans()
+		assert.Len(spans, 1)
+		s := spans[0]
+		assert.Equal(rate, s.Tag(ext.EventSampleRate))
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil)
+	})
+
+	t.Run("global", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.4)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 1.0, WithAnalytics(true))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil, WithAnalytics(false))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
+	})
 }

--- a/contrib/globalsign/mgo/option.go
+++ b/contrib/globalsign/mgo/option.go
@@ -2,8 +2,6 @@ package mgo
 
 import (
 	"context"
-
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
 type mongoConfig struct {
@@ -14,9 +12,9 @@ type mongoConfig struct {
 
 func newConfig() *mongoConfig {
 	return &mongoConfig{
-		serviceName:   "mongodb",
-		ctx:           context.Background(),
-		analyticsRate: globalconfig.AnalyticsRate(),
+		serviceName: "mongodb",
+		ctx:         context.Background(),
+		// analyticsRate: globalconfig.AnalyticsRate(),
 	}
 }
 

--- a/contrib/globalsign/mgo/query.go
+++ b/contrib/globalsign/mgo/query.go
@@ -11,12 +11,13 @@ import (
 // Query is an mgo.Query instance along with the data necessary for tracing.
 type Query struct {
 	*mgo.Query
-	cfg mongoConfig
+	cfg  *mongoConfig
+	tags map[string]string
 }
 
 // Iter invokes and traces Query.Iter
 func (q *Query) Iter() *Iter {
-	span := newChildSpanFromContext(q.cfg)
+	span := newChildSpanFromContext(q.cfg, q.tags)
 	iter := q.Query.Iter()
 	span.Finish()
 	return &Iter{
@@ -27,7 +28,7 @@ func (q *Query) Iter() *Iter {
 
 // All invokes and traces Query.All
 func (q *Query) All(result interface{}) error {
-	span := newChildSpanFromContext(q.cfg)
+	span := newChildSpanFromContext(q.cfg, q.tags)
 	err := q.All(result)
 	span.Finish(tracer.WithError(err))
 	return err
@@ -35,39 +36,15 @@ func (q *Query) All(result interface{}) error {
 
 // Apply invokes and traces Query.Apply
 func (q *Query) Apply(change mgo.Change, result interface{}) (info *mgo.ChangeInfo, err error) {
-	span := newChildSpanFromContext(q.cfg)
+	span := newChildSpanFromContext(q.cfg, q.tags)
 	info, err = q.Apply(change, result)
 	span.Finish(tracer.WithError(err))
 	return info, err
 }
 
-// Batch invokes and traces Query.Batch
-func (q *Query) Batch(n int) *Query {
-	return &Query{
-		Query: q.Query.Batch(n),
-		cfg:   q.cfg,
-	}
-}
-
-// Collation invokes and traces Query.Collation
-func (q *Query) Collation(collation *mgo.Collation) *Query {
-	return &Query{
-		Query: q.Query.Collation(collation),
-		cfg:   q.cfg,
-	}
-}
-
-// Comment invokes and traces Query.Comment
-func (q *Query) Comment(comment string) *Query {
-	return &Query{
-		Query: q.Query.Comment(comment),
-		cfg:   q.cfg,
-	}
-}
-
 // Count invokes and traces Query.Count
 func (q *Query) Count() (n int, err error) {
-	span := newChildSpanFromContext(q.cfg)
+	span := newChildSpanFromContext(q.cfg, q.tags)
 	n, err = q.Count()
 	span.Finish(tracer.WithError(err))
 	return n, err
@@ -75,7 +52,7 @@ func (q *Query) Count() (n int, err error) {
 
 // Distinct invokes and traces Query.Distinct
 func (q *Query) Distinct(key string, result interface{}) error {
-	span := newChildSpanFromContext(q.cfg)
+	span := newChildSpanFromContext(q.cfg, q.tags)
 	err := q.Distinct(key, result)
 	span.Finish(tracer.WithError(err))
 	return err
@@ -83,7 +60,7 @@ func (q *Query) Distinct(key string, result interface{}) error {
 
 // Explain invokes and traces Query.Explain
 func (q *Query) Explain(result interface{}) error {
-	span := newChildSpanFromContext(q.cfg)
+	span := newChildSpanFromContext(q.cfg, q.tags)
 	err := q.Explain(result)
 	span.Finish(tracer.WithError(err))
 	return err
@@ -91,7 +68,7 @@ func (q *Query) Explain(result interface{}) error {
 
 // For invokes and traces Query.For
 func (q *Query) For(result interface{}, f func() error) error {
-	span := newChildSpanFromContext(q.cfg)
+	span := newChildSpanFromContext(q.cfg, q.tags)
 	err := q.For(result, f)
 	span.Finish(tracer.WithError(err))
 	return err
@@ -99,7 +76,7 @@ func (q *Query) For(result interface{}, f func() error) error {
 
 // MapReduce invokes and traces Query.MapReduce
 func (q *Query) MapReduce(job *mgo.MapReduce, result interface{}) (info *mgo.MapReduceInfo, err error) {
-	span := newChildSpanFromContext(q.cfg)
+	span := newChildSpanFromContext(q.cfg, q.tags)
 	info, err = q.MapReduce(job, result)
 	span.Finish(tracer.WithError(err))
 	return info, err
@@ -107,73 +84,15 @@ func (q *Query) MapReduce(job *mgo.MapReduce, result interface{}) (info *mgo.Map
 
 // One invokes and traces Query.One
 func (q *Query) One(result interface{}) error {
-	span := newChildSpanFromContext(q.cfg)
+	span := newChildSpanFromContext(q.cfg, q.tags)
 	err := q.One(result)
 	span.Finish(tracer.WithError(err))
 	return err
 }
 
-// Prefetch invokes Query.Prefetch and configures the
-// returned *Query for tracing.
-func (q *Query) Prefetch(p float64) *Query {
-	return &Query{
-		Query: q.Query.Prefetch(p),
-		cfg:   q.cfg,
-	}
-}
-
-// Select invokes Query.Select and configures the
-// returned *Query for tracing.
-func (q *Query) Select(selector interface{}) *Query {
-	return &Query{
-		Query: q.Query.Select(selector),
-		cfg:   q.cfg,
-	}
-}
-
-// SetMaxScan invokes and traces Query.SetMaxScan
-func (q *Query) SetMaxScan(n int) *Query {
-	return &Query{
-		Query: q.Query.SetMaxScan(n),
-		cfg:   q.cfg,
-	}
-}
-
-// SetMaxTime invokes and traces Query.SetMaxTime
-func (q *Query) SetMaxTime(d time.Duration) *Query {
-	return &Query{
-		Query: q.Query.SetMaxTime(d),
-		cfg:   q.cfg,
-	}
-}
-
-// Skip invokes and traces Query.Skip
-func (q *Query) Skip(n int) *Query {
-	return &Query{
-		Query: q.Query.Skip(n),
-		cfg:   q.cfg,
-	}
-}
-
-// Snapshot invokes and traces Query.Snapshot
-func (q *Query) Snapshot() *Query {
-	return &Query{
-		Query: q.Query.Snapshot(),
-		cfg:   q.cfg,
-	}
-}
-
-// Sort invokes and traces Query.Sort
-func (q *Query) Sort(fields ...string) *Query {
-	return &Query{
-		Query: q.Query.Sort(fields...),
-		cfg:   q.cfg,
-	}
-}
-
 // Tail invokes and traces Query.Tail
 func (q *Query) Tail(timeout time.Duration) *Iter {
-	span := newChildSpanFromContext(q.cfg)
+	span := newChildSpanFromContext(q.cfg, q.tags)
 	iter := q.Query.Tail(timeout)
 	span.Finish()
 	return &Iter{

--- a/contrib/go-chi/chi/chi.go
+++ b/contrib/go-chi/chi/chi.go
@@ -29,6 +29,9 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 				tracer.Tag(ext.HTTPMethod, r.Method),
 				tracer.Tag(ext.HTTPURL, r.URL.Path),
 			}
+			if cfg.analyticsRate > 0 {
+				opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
+			}
 			if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(r.Header)); err == nil {
 				opts = append(opts, tracer.ChildOf(spanctx))
 			}

--- a/contrib/go-chi/chi/chi_test.go
+++ b/contrib/go-chi/chi/chi_test.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 
 	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/assert"
@@ -141,4 +142,67 @@ func TestPropagation(t *testing.T) {
 	})
 
 	router.ServeHTTP(w, r)
+}
+
+func TestAnalyticsSettings(t *testing.T) {
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...Option) {
+		router := chi.NewRouter()
+		router.Use(Middleware(opts...))
+		router.Get("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
+			_, ok := tracer.SpanFromContext(r.Context())
+			assert.True(t, ok)
+		})
+
+		r := httptest.NewRequest("GET", "/user/123", nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, r)
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+		s := spans[0]
+		assert.Equal(t, rate, s.Tag(ext.EventSampleRate))
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil)
+	})
+
+	t.Run("global", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.4)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 1.0, WithAnalytics(true))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil, WithAnalytics(false))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
+	})
 }

--- a/contrib/go-chi/chi/option.go
+++ b/contrib/go-chi/chi/option.go
@@ -1,10 +1,14 @@
 package chi
 
-import "gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+import (
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+)
 
 type config struct {
-	serviceName string
-	spanOpts    []ddtrace.StartSpanOption // additional span options to be applied
+	serviceName   string
+	spanOpts      []ddtrace.StartSpanOption // additional span options to be applied
+	analyticsRate float64
 }
 
 // Option represents an option that can be passed to NewRouter.
@@ -12,6 +16,7 @@ type Option func(*config)
 
 func defaults(cfg *config) {
 	cfg.serviceName = "chi.router"
+	cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // WithServiceName sets the given service name for the router.
@@ -26,5 +31,21 @@ func WithServiceName(name string) Option {
 func WithSpanOptions(opts ...ddtrace.StartSpanOption) Option {
 	return func(cfg *config) {
 		cfg.spanOpts = opts
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) Option {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) Option {
+	return func(cfg *config) {
+		cfg.analyticsRate = rate
 	}
 }

--- a/contrib/go-chi/chi/option.go
+++ b/contrib/go-chi/chi/option.go
@@ -28,4 +28,3 @@ func WithSpanOptions(opts ...ddtrace.StartSpanOption) Option {
 		cfg.spanOpts = opts
 	}
 }
-

--- a/contrib/go-redis/redis/option.go
+++ b/contrib/go-redis/redis/option.go
@@ -1,7 +1,5 @@
 package redis // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/go-redis/redis"
 
-import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
-
 type clientConfig struct {
 	serviceName   string
 	analyticsRate float64
@@ -12,7 +10,7 @@ type ClientOption func(*clientConfig)
 
 func defaults(cfg *clientConfig) {
 	cfg.serviceName = "redis.client"
-	cfg.analyticsRate = globalconfig.AnalyticsRate()
+	// cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // WithServiceName sets the given service name for the client.

--- a/contrib/go-redis/redis/option.go
+++ b/contrib/go-redis/redis/option.go
@@ -1,17 +1,39 @@
 package redis // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/go-redis/redis"
 
-type clientConfig struct{ serviceName string }
+import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+
+type clientConfig struct {
+	serviceName   string
+	analyticsRate float64
+}
 
 // ClientOption represents an option that can be used to create or wrap a client.
 type ClientOption func(*clientConfig)
 
 func defaults(cfg *clientConfig) {
 	cfg.serviceName = "redis.client"
+	cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // WithServiceName sets the given service name for the client.
 func WithServiceName(name string) ClientOption {
 	return func(cfg *clientConfig) {
 		cfg.serviceName = name
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) ClientOption {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) ClientOption {
+	return func(cfg *clientConfig) {
+		cfg.analyticsRate = rate
 	}
 }

--- a/contrib/go-redis/redis/redis_test.go
+++ b/contrib/go-redis/redis/redis_test.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 
 	"github.com/go-redis/redis"
 	"github.com/stretchr/testify/assert"
@@ -239,5 +240,59 @@ func TestError(t *testing.T) {
 		assert.Equal("127.0.0.1", span.Tag(ext.TargetHost))
 		assert.Equal("6379", span.Tag(ext.TargetPort))
 		assert.Equal("get non_existent_key: ", span.Tag("redis.raw_command"))
+	})
+}
+func TestAnalyticsSettings(t *testing.T) {
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...ClientOption) {
+		client := NewClient(&redis.Options{Addr: "127.0.0.1:6379"}, opts...)
+		client.Set("test_key", "test_value", 0)
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+		s := spans[0]
+		assert.Equal(t, rate, s.Tag(ext.EventSampleRate))
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil)
+	})
+
+	t.Run("global", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.4)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 1.0, WithAnalytics(true))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil, WithAnalytics(false))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
 	})
 }

--- a/contrib/go-redis/redis/redis_test.go
+++ b/contrib/go-redis/redis/redis_test.go
@@ -261,6 +261,7 @@ func TestAnalyticsSettings(t *testing.T) {
 	})
 
 	t.Run("global", func(t *testing.T) {
+		t.Skip("global flag disabled")
 		mt := mocktracer.Start()
 		defer mt.Stop()
 

--- a/contrib/gocql/gocql/gocql.go
+++ b/contrib/gocql/gocql/gocql.go
@@ -17,7 +17,7 @@ import (
 type Query struct {
 	*gocql.Query
 	*params
-	traceContext context.Context
+	ctx context.Context
 }
 
 // Iter inherits from gocql.Iter and contains a span.
@@ -57,7 +57,7 @@ func WrapQuery(q *gocql.Query, opts ...WrapOption) *Query {
 
 // WithContext adds the specified context to the traced Query structure.
 func (tq *Query) WithContext(ctx context.Context) *Query {
-	tq.traceContext = ctx
+	tq.ctx = ctx
 	tq.Query.WithContext(ctx)
 	return tq
 }
@@ -72,13 +72,17 @@ func (tq *Query) PageState(state []byte) *Query {
 // NewChildSpan creates a new span from the params and the context.
 func (tq *Query) newChildSpan(ctx context.Context) ddtrace.Span {
 	p := tq.params
-	span, _ := tracer.StartSpanFromContext(ctx, ext.CassandraQuery,
+	opts := []ddtrace.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeCassandra),
 		tracer.ServiceName(p.config.serviceName),
 		tracer.ResourceName(p.config.resourceName),
 		tracer.Tag(ext.CassandraPaginated, fmt.Sprintf("%t", p.paginated)),
 		tracer.Tag(ext.CassandraKeyspace, p.keyspace),
-	)
+	}
+	if rate := p.config.analyticsRate; rate > 0 {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, rate))
+	}
+	span, _ := tracer.StartSpanFromContext(ctx, ext.CassandraQuery, opts...)
 	return span
 }
 
@@ -89,7 +93,7 @@ func (tq *Query) Exec() error {
 
 // MapScan wraps in a span query.MapScan call.
 func (tq *Query) MapScan(m map[string]interface{}) error {
-	span := tq.newChildSpan(tq.traceContext)
+	span := tq.newChildSpan(tq.ctx)
 	err := tq.Query.MapScan(m)
 	span.Finish(tracer.WithError(err))
 	return err
@@ -97,7 +101,7 @@ func (tq *Query) MapScan(m map[string]interface{}) error {
 
 // Scan wraps in a span query.Scan call.
 func (tq *Query) Scan(dest ...interface{}) error {
-	span := tq.newChildSpan(tq.traceContext)
+	span := tq.newChildSpan(tq.ctx)
 	err := tq.Query.Scan(dest...)
 	span.Finish(tracer.WithError(err))
 	return err
@@ -105,7 +109,7 @@ func (tq *Query) Scan(dest ...interface{}) error {
 
 // ScanCAS wraps in a span query.ScanCAS call.
 func (tq *Query) ScanCAS(dest ...interface{}) (applied bool, err error) {
-	span := tq.newChildSpan(tq.traceContext)
+	span := tq.newChildSpan(tq.ctx)
 	applied, err = tq.Query.ScanCAS(dest...)
 	span.Finish(tracer.WithError(err))
 	return applied, err
@@ -113,7 +117,7 @@ func (tq *Query) ScanCAS(dest ...interface{}) (applied bool, err error) {
 
 // Iter starts a new span at query.Iter call.
 func (tq *Query) Iter() *Iter {
-	span := tq.newChildSpan(tq.traceContext)
+	span := tq.newChildSpan(tq.ctx)
 	iter := tq.Query.Iter()
 	span.SetTag(ext.CassandraRowCount, strconv.Itoa(iter.NumRows()))
 	span.SetTag(ext.CassandraConsistencyLevel, tq.GetConsistency().String())

--- a/contrib/gocql/gocql/gocql_test.go
+++ b/contrib/gocql/gocql/gocql_test.go
@@ -144,6 +144,7 @@ func TestAnalyticsSettings(t *testing.T) {
 	})
 
 	t.Run("global", func(t *testing.T) {
+		t.Skip("global flag disabled")
 		mt := mocktracer.Start()
 		defer mt.Stop()
 

--- a/contrib/gocql/gocql/gocql_test.go
+++ b/contrib/gocql/gocql/gocql_test.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 
 	"github.com/gocql/gocql"
 	"github.com/stretchr/testify/assert"
@@ -118,4 +119,63 @@ func TestChildWrapperSpan(t *testing.T) {
 		assert.Equal(childSpan.Tag(ext.TargetHost), "127.0.0.1")
 		assert.Equal(childSpan.Tag(ext.CassandraCluster), "datacenter1")
 	}
+}
+
+func TestAnalyticsSettings(t *testing.T) {
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...WrapOption) {
+		cluster := newCassandraCluster()
+		session, err := cluster.CreateSession()
+		assert.Nil(t, err)
+		q := session.Query("CREATE KEYSPACE trace WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };")
+		iter := WrapQuery(q, opts...).Iter()
+		err = iter.Close()
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+		s := spans[0]
+		assert.Equal(t, rate, s.Tag(ext.EventSampleRate))
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil)
+	})
+
+	t.Run("global", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.4)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 1.0, WithAnalytics(true))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil, WithAnalytics(false))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
+	})
 }

--- a/contrib/gocql/gocql/option.go
+++ b/contrib/gocql/gocql/option.go
@@ -1,12 +1,18 @@
 package gocql
 
-type queryConfig struct{ serviceName, resourceName string }
+import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+
+type queryConfig struct {
+	serviceName, resourceName string
+	analyticsRate             float64
+}
 
 // WrapOption represents an option that can be passed to WrapQuery.
 type WrapOption func(*queryConfig)
 
 func defaults(cfg *queryConfig) {
 	cfg.serviceName = "gocql.query"
+	cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // WithServiceName sets the given service name for the returned query.
@@ -25,5 +31,21 @@ func WithServiceName(name string) WrapOption {
 func WithResourceName(name string) WrapOption {
 	return func(cfg *queryConfig) {
 		cfg.resourceName = name
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) WrapOption {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) WrapOption {
+	return func(cfg *queryConfig) {
+		cfg.analyticsRate = rate
 	}
 }

--- a/contrib/gocql/gocql/option.go
+++ b/contrib/gocql/gocql/option.go
@@ -1,7 +1,5 @@
 package gocql
 
-import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
-
 type queryConfig struct {
 	serviceName, resourceName string
 	analyticsRate             float64
@@ -12,7 +10,7 @@ type WrapOption func(*queryConfig)
 
 func defaults(cfg *queryConfig) {
 	cfg.serviceName = "gocql.query"
-	cfg.analyticsRate = globalconfig.AnalyticsRate()
+	// cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // WithServiceName sets the given service name for the returned query.

--- a/contrib/google.golang.org/api/api_test.go
+++ b/contrib/google.golang.org/api/api_test.go
@@ -127,6 +127,7 @@ func TestAnalyticsSettings(t *testing.T) {
 	})
 
 	t.Run("global", func(t *testing.T) {
+		t.Skip("global flag disabled")
 		mt := mocktracer.Start()
 		defer mt.Stop()
 

--- a/contrib/google.golang.org/api/option.go
+++ b/contrib/google.golang.org/api/option.go
@@ -1,16 +1,22 @@
 package api
 
-import "context"
+import (
+	"context"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+)
 
 type config struct {
-	serviceName string
-	ctx         context.Context
-	scopes      []string
+	serviceName   string
+	ctx           context.Context
+	analyticsRate float64
+	scopes        []string
 }
 
 func newConfig(options ...Option) *config {
 	cfg := &config{
-		ctx: context.Background(),
+		ctx:           context.Background(),
+		analyticsRate: globalconfig.AnalyticsRate(),
 	}
 	for _, opt := range options {
 		opt(cfg)
@@ -41,5 +47,21 @@ func WithScopes(scopes ...string) Option {
 func WithServiceName(serviceName string) Option {
 	return func(cfg *config) {
 		cfg.serviceName = serviceName
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) Option {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) Option {
+	return func(cfg *config) {
+		cfg.analyticsRate = rate
 	}
 }

--- a/contrib/google.golang.org/api/option.go
+++ b/contrib/google.golang.org/api/option.go
@@ -2,8 +2,6 @@ package api
 
 import (
 	"context"
-
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
 type config struct {
@@ -15,8 +13,8 @@ type config struct {
 
 func newConfig(options ...Option) *config {
 	cfg := &config{
-		ctx:           context.Background(),
-		analyticsRate: globalconfig.AnalyticsRate(),
+		ctx: context.Background(),
+		// analyticsRate: globalconfig.AnalyticsRate(),
 	}
 	for _, opt := range options {
 		opt(cfg)

--- a/contrib/google.golang.org/grpc.v12/grpc_test.go
+++ b/contrib/google.golang.org/grpc.v12/grpc_test.go
@@ -247,6 +247,7 @@ func TestAnalyticsSettings(t *testing.T) {
 	})
 
 	t.Run("global", func(t *testing.T) {
+		t.Skip("global flag disabled")
 		mt := mocktracer.Start()
 		defer mt.Stop()
 

--- a/contrib/google.golang.org/grpc.v12/grpc_test.go
+++ b/contrib/google.golang.org/grpc.v12/grpc_test.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 
 	"github.com/stretchr/testify/assert"
 	context "golang.org/x/net/context"
@@ -173,7 +174,11 @@ func (r *rig) Close() {
 }
 
 func newRig(traceClient bool) (*rig, error) {
-	server := grpc.NewServer(grpc.UnaryInterceptor(UnaryServerInterceptor(WithServiceName("grpc"))))
+	return newRigWithOpts(traceClient, WithServiceName("grpc"))
+}
+
+func newRigWithOpts(traceClient bool, iopts ...InterceptorOption) (*rig, error) {
+	server := grpc.NewServer(grpc.UnaryInterceptor(UnaryServerInterceptor(iopts...)))
 
 	RegisterFixtureServer(server, new(fixtureServer))
 
@@ -187,7 +192,7 @@ func newRig(traceClient bool) (*rig, error) {
 
 	opts := []grpc.DialOption{grpc.WithInsecure()}
 	if traceClient {
-		opts = append(opts, grpc.WithUnaryInterceptor(UnaryClientInterceptor(WithServiceName("grpc"))))
+		opts = append(opts, grpc.WithUnaryInterceptor(UnaryClientInterceptor(iopts...)))
 	}
 	conn, err := grpc.Dial(li.Addr().String(), opts...)
 	if err != nil {
@@ -200,4 +205,80 @@ func newRig(traceClient bool) (*rig, error) {
 		conn:     conn,
 		client:   NewFixtureClient(conn),
 	}, err
+}
+
+func TestAnalyticsSettings(t *testing.T) {
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...InterceptorOption) {
+		rig, err := newRigWithOpts(true, opts...)
+		if err != nil {
+			t.Fatalf("error setting up rig: %s", err)
+		}
+		defer rig.Close()
+
+		client := rig.client
+		resp, err := client.Ping(context.Background(), &FixtureRequest{Name: "pass"})
+		assert.Nil(t, err)
+		assert.Equal(t, resp.Message, "passed")
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 2)
+
+		var serverSpan, clientSpan mocktracer.Span
+
+		for _, s := range spans {
+			// order of traces in buffer is not garanteed
+			switch s.OperationName() {
+			case "grpc.server":
+				serverSpan = s
+			case "grpc.client":
+				clientSpan = s
+			}
+		}
+
+		assert.Equal(t, rate, clientSpan.Tag(ext.EventSampleRate))
+		assert.Equal(t, rate, serverSpan.Tag(ext.EventSampleRate))
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil)
+	})
+
+	t.Run("global", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.4)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 1.0, WithAnalytics(true))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil, WithAnalytics(false))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
+	})
 }

--- a/contrib/google.golang.org/grpc.v12/option.go
+++ b/contrib/google.golang.org/grpc.v12/option.go
@@ -1,6 +1,11 @@
 package grpc
 
-type interceptorConfig struct{ serviceName string }
+import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+
+type interceptorConfig struct {
+	serviceName   string
+	analyticsRate float64
+}
 
 // InterceptorOption represents an option that can be passed to the grpc unary
 // client and server interceptors.
@@ -8,11 +13,28 @@ type InterceptorOption func(*interceptorConfig)
 
 func defaults(cfg *interceptorConfig) {
 	// cfg.serviceName default set in interceptor
+	cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // WithServiceName sets the given service name for the intercepted client.
 func WithServiceName(name string) InterceptorOption {
 	return func(cfg *interceptorConfig) {
 		cfg.serviceName = name
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) InterceptorOption {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) InterceptorOption {
+	return func(cfg *interceptorConfig) {
+		cfg.analyticsRate = rate
 	}
 }

--- a/contrib/google.golang.org/grpc.v12/option.go
+++ b/contrib/google.golang.org/grpc.v12/option.go
@@ -1,7 +1,5 @@
 package grpc
 
-import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
-
 type interceptorConfig struct {
 	serviceName   string
 	analyticsRate float64
@@ -13,7 +11,7 @@ type InterceptorOption func(*interceptorConfig)
 
 func defaults(cfg *interceptorConfig) {
 	// cfg.serviceName default set in interceptor
-	cfg.analyticsRate = globalconfig.AnalyticsRate()
+	// cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // WithServiceName sets the given service name for the intercepted client.

--- a/contrib/google.golang.org/grpc/grpc.go
+++ b/contrib/google.golang.org/grpc/grpc.go
@@ -17,12 +17,17 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func startSpanFromContext(ctx context.Context, method, operation, service string) (ddtrace.Span, context.Context) {
+func startSpanFromContext(
+	ctx context.Context, method, operation, service string, rate float64,
+) (ddtrace.Span, context.Context) {
 	opts := []ddtrace.StartSpanOption{
 		tracer.ServiceName(service),
 		tracer.ResourceName(method),
 		tracer.Tag(tagMethod, method),
 		tracer.SpanType(ext.AppTypeRPC),
+	}
+	if rate > 0 {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, rate))
 	}
 	md, _ := metadata.FromIncomingContext(ctx) // nil is ok
 	if sctx, err := tracer.Extract(grpcutil.MDCarrier(md)); err == nil {

--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -543,6 +543,7 @@ func TestAnalyticsSettings(t *testing.T) {
 	})
 
 	t.Run("global", func(t *testing.T) {
+		t.Skip("global flag disabled")
 		mt := mocktracer.Start()
 		defer mt.Stop()
 

--- a/contrib/google.golang.org/grpc/option.go
+++ b/contrib/google.golang.org/grpc/option.go
@@ -1,19 +1,26 @@
 package grpc
 
-type interceptorConfig struct {
+import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+
+// Option specifies a configuration option for the grpc package. Not all options apply
+// to all instrumented structures.
+type Option = InterceptorOption
+
+type config struct {
 	serviceName                           string
 	traceStreamCalls, traceStreamMessages bool
 	noDebugStack                          bool
+	analyticsRate                         float64
 }
 
-func (cfg *interceptorConfig) serverServiceName() string {
+func (cfg *config) serverServiceName() string {
 	if cfg.serviceName == "" {
 		return "grpc.server"
 	}
 	return cfg.serviceName
 }
 
-func (cfg *interceptorConfig) clientServiceName() string {
+func (cfg *config) clientServiceName() string {
 	if cfg.serviceName == "" {
 		return "grpc.client"
 	}
@@ -22,81 +29,59 @@ func (cfg *interceptorConfig) clientServiceName() string {
 
 // InterceptorOption represents an option that can be passed to the grpc unary
 // client and server interceptors.
-type InterceptorOption func(*interceptorConfig)
+// InterceptorOption is deprecated in favor of Option.
+type InterceptorOption func(*config)
 
-func defaults(cfg *interceptorConfig) {
+func defaults(cfg *config) {
 	// cfg.serviceName defaults are set in interceptors
 	cfg.traceStreamCalls = true
 	cfg.traceStreamMessages = true
+	cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // WithServiceName sets the given service name for the intercepted client.
-func WithServiceName(name string) InterceptorOption {
-	return func(cfg *interceptorConfig) {
+func WithServiceName(name string) Option {
+	return func(cfg *config) {
 		cfg.serviceName = name
 	}
 }
 
-// WithStreamCalls enables or disables tracing of streaming calls.
-func WithStreamCalls(enabled bool) InterceptorOption {
-	return func(cfg *interceptorConfig) {
+// WithStreamCalls enables or disables tracing of streaming calls. This option does not apply to the
+// stats handler.
+func WithStreamCalls(enabled bool) Option {
+	return func(cfg *config) {
 		cfg.traceStreamCalls = enabled
 	}
 }
 
-// WithStreamMessages enables or disables tracing of streaming messages.
-func WithStreamMessages(enabled bool) InterceptorOption {
-	return func(cfg *interceptorConfig) {
+// WithStreamMessages enables or disables tracing of streaming messages. This option does not apply
+// to the stats handler.
+func WithStreamMessages(enabled bool) Option {
+	return func(cfg *config) {
 		cfg.traceStreamMessages = enabled
 	}
 }
 
 // NoDebugStack disables debug stacks for traces with errors. This is useful in situations
 // where errors are frequent and the overhead of calling debug.Stack may affect performance.
-func NoDebugStack() InterceptorOption {
-	return func(cfg *interceptorConfig) {
+func NoDebugStack() Option {
+	return func(cfg *config) {
 		cfg.noDebugStack = true
 	}
 }
 
-type statsHandlerConfig struct {
-	serviceName  string
-	noDebugStack bool
-}
-
-func newStatsHandlerConfig() *statsHandlerConfig {
-	return &statsHandlerConfig{}
-}
-
-func (cfg *statsHandlerConfig) serverServiceName() string {
-	if cfg.serviceName == "" {
-		return "grpc.server"
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) Option {
+	if on {
+		return WithAnalyticsRate(1.0)
 	}
-	return cfg.serviceName
+	return WithAnalyticsRate(0.0)
 }
 
-func (cfg *statsHandlerConfig) clientServiceName() string {
-	if cfg.serviceName == "" {
-		return "grpc.client"
-	}
-	return cfg.serviceName
-}
-
-// StatsHandlerOption represents an option that can be passed
-// to the grpc client and server stats handlers.
-type StatsHandlerOption func(*statsHandlerConfig)
-
-// StatsOptServiceName sets the given service name.
-func StatsOptServiceName(name string) StatsHandlerOption {
-	return func(cfg *statsHandlerConfig) {
-		cfg.serviceName = name
-	}
-}
-
-// StatsOptNoDebugStack disables debug stacks for traces with errors. This is useful in situations
-// where errors are frequent and the overhead of calling debug.Stack may affect performance.
-func StatsOptNoDebugStack() StatsHandlerOption {
-	return func(cfg *statsHandlerConfig) {
-		cfg.noDebugStack = true
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) Option {
+	return func(cfg *config) {
+		cfg.analyticsRate = rate
 	}
 }

--- a/contrib/google.golang.org/grpc/option.go
+++ b/contrib/google.golang.org/grpc/option.go
@@ -1,7 +1,5 @@
 package grpc
 
-import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
-
 // Option specifies a configuration option for the grpc package. Not all options apply
 // to all instrumented structures.
 type Option = InterceptorOption
@@ -36,7 +34,7 @@ func defaults(cfg *config) {
 	// cfg.serviceName defaults are set in interceptors
 	cfg.traceStreamCalls = true
 	cfg.traceStreamMessages = true
-	cfg.analyticsRate = globalconfig.AnalyticsRate()
+	// cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // WithServiceName sets the given service name for the intercepted client.

--- a/contrib/google.golang.org/grpc/server.go
+++ b/contrib/google.golang.org/grpc/server.go
@@ -8,7 +8,7 @@ import (
 
 type serverStream struct {
 	grpc.ServerStream
-	cfg    *interceptorConfig
+	cfg    *config
 	method string
 	ctx    context.Context
 }
@@ -27,7 +27,13 @@ func (ss *serverStream) Context() context.Context {
 
 func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 	if ss.cfg.traceStreamMessages {
-		span, _ := startSpanFromContext(ss.ctx, ss.method, "grpc.message", ss.cfg.serverServiceName())
+		span, _ := startSpanFromContext(
+			ss.ctx,
+			ss.method,
+			"grpc.message",
+			ss.cfg.serverServiceName(),
+			ss.cfg.analyticsRate,
+		)
 		defer func() { finishWithError(span, err, ss.cfg.noDebugStack) }()
 	}
 	err = ss.ServerStream.RecvMsg(m)
@@ -36,7 +42,13 @@ func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 
 func (ss *serverStream) SendMsg(m interface{}) (err error) {
 	if ss.cfg.traceStreamMessages {
-		span, _ := startSpanFromContext(ss.ctx, ss.method, "grpc.message", ss.cfg.serverServiceName())
+		span, _ := startSpanFromContext(
+			ss.ctx,
+			ss.method,
+			"grpc.message",
+			ss.cfg.serverServiceName(),
+			ss.cfg.analyticsRate,
+		)
 		defer func() { finishWithError(span, err, ss.cfg.noDebugStack) }()
 	}
 	err = ss.ServerStream.SendMsg(m)
@@ -44,8 +56,8 @@ func (ss *serverStream) SendMsg(m interface{}) (err error) {
 }
 
 // StreamServerInterceptor will trace streaming requests to the given gRPC server.
-func StreamServerInterceptor(opts ...InterceptorOption) grpc.StreamServerInterceptor {
-	cfg := new(interceptorConfig)
+func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
+	cfg := new(config)
 	defaults(cfg)
 	for _, fn := range opts {
 		fn(cfg)
@@ -59,7 +71,13 @@ func StreamServerInterceptor(opts ...InterceptorOption) grpc.StreamServerInterce
 		// if we've enabled call tracing, create a span
 		if cfg.traceStreamCalls {
 			var span ddtrace.Span
-			span, ctx = startSpanFromContext(ctx, info.FullMethod, "grpc.server", cfg.serviceName)
+			span, ctx = startSpanFromContext(
+				ctx,
+				info.FullMethod,
+				"grpc.server",
+				cfg.serviceName,
+				cfg.analyticsRate,
+			)
 			defer func() { finishWithError(span, err, cfg.noDebugStack) }()
 		}
 
@@ -77,14 +95,20 @@ func StreamServerInterceptor(opts ...InterceptorOption) grpc.StreamServerInterce
 }
 
 // UnaryServerInterceptor will trace requests to the given grpc server.
-func UnaryServerInterceptor(opts ...InterceptorOption) grpc.UnaryServerInterceptor {
-	cfg := new(interceptorConfig)
+func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
+	cfg := new(config)
 	defaults(cfg)
 	for _, fn := range opts {
 		fn(cfg)
 	}
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		span, ctx := startSpanFromContext(ctx, info.FullMethod, "grpc.server", cfg.serverServiceName())
+		span, ctx := startSpanFromContext(
+			ctx,
+			info.FullMethod,
+			"grpc.server",
+			cfg.serverServiceName(),
+			cfg.analyticsRate,
+		)
 		resp, err := handler(ctx, req)
 		finishWithError(span, err, cfg.noDebugStack)
 		return resp, err

--- a/contrib/google.golang.org/grpc/stats_client_test.go
+++ b/contrib/google.golang.org/grpc/stats_client_test.go
@@ -20,9 +20,7 @@ func TestClientStatsHandler(t *testing.T) {
 	assert := assert.New(t)
 
 	serviceName := "grpc-service"
-	statsHandler := NewClientStatsHandler(
-		StatsOptServiceName(serviceName),
-	)
+	statsHandler := NewClientStatsHandler(WithServiceName(serviceName))
 	server, err := newClientStatsHandlerTestServer(statsHandler)
 	if err != nil {
 		t.Fatalf("failed to start test server: %s", err)

--- a/contrib/google.golang.org/grpc/stats_server.go
+++ b/contrib/google.golang.org/grpc/stats_server.go
@@ -8,8 +8,9 @@ import (
 )
 
 // NewServerStatsHandler returns a gRPC server stats.Handler to trace RPC calls.
-func NewServerStatsHandler(opts ...StatsHandlerOption) stats.Handler {
-	cfg := newStatsHandlerConfig()
+func NewServerStatsHandler(opts ...Option) stats.Handler {
+	cfg := new(config)
+	defaults(cfg)
 	for _, fn := range opts {
 		fn(cfg)
 	}
@@ -19,12 +20,18 @@ func NewServerStatsHandler(opts ...StatsHandlerOption) stats.Handler {
 }
 
 type serverStatsHandler struct {
-	cfg *statsHandlerConfig
+	cfg *config
 }
 
 // TagRPC starts a new span for the initiated RPC request.
 func (h *serverStatsHandler) TagRPC(ctx context.Context, rti *stats.RPCTagInfo) context.Context {
-	_, ctx = startSpanFromContext(ctx, rti.FullMethodName, "grpc.server", h.cfg.serverServiceName())
+	_, ctx = startSpanFromContext(
+		ctx,
+		rti.FullMethodName,
+		"grpc.server",
+		h.cfg.serverServiceName(),
+		h.cfg.analyticsRate,
+	)
 	return ctx
 }
 

--- a/contrib/google.golang.org/grpc/stats_server_test.go
+++ b/contrib/google.golang.org/grpc/stats_server_test.go
@@ -19,9 +19,7 @@ func TestServerStatsHandler(t *testing.T) {
 	assert := assert.New(t)
 
 	serviceName := "grpc-service"
-	statsHandler := NewServerStatsHandler(
-		StatsOptServiceName(serviceName),
-	)
+	statsHandler := NewServerStatsHandler(WithServiceName(serviceName))
 	server, err := newServerStatsHandlerTestServer(statsHandler)
 	if err != nil {
 		t.Fatalf("failed to start test server: %s", err)

--- a/contrib/gorilla/mux/mux.go
+++ b/contrib/gorilla/mux/mux.go
@@ -6,6 +6,7 @@ import (
 
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httputil"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	"github.com/gorilla/mux"
@@ -71,6 +72,9 @@ func NewRouter(opts ...RouterOption) *Router {
 	defaults(cfg)
 	for _, fn := range opts {
 		fn(cfg)
+	}
+	if cfg.analyticsRate > 0 {
+		cfg.spanOpts = append(cfg.spanOpts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 	}
 	return &Router{
 		Router: mux.NewRouter(),

--- a/contrib/gorilla/mux/option.go
+++ b/contrib/gorilla/mux/option.go
@@ -1,16 +1,21 @@
 package mux
 
-import "gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+import (
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+)
 
 type routerConfig struct {
-	serviceName string
-	spanOpts    []ddtrace.StartSpanOption // additional span options to be applied
+	serviceName   string
+	spanOpts      []ddtrace.StartSpanOption // additional span options to be applied
+	analyticsRate float64
 }
 
 // RouterOption represents an option that can be passed to NewRouter.
 type RouterOption func(*routerConfig)
 
 func defaults(cfg *routerConfig) {
+	cfg.analyticsRate = globalconfig.AnalyticsRate()
 	cfg.serviceName = "mux.router"
 }
 
@@ -26,5 +31,21 @@ func WithServiceName(name string) RouterOption {
 func WithSpanOptions(opts ...ddtrace.StartSpanOption) RouterOption {
 	return func(cfg *routerConfig) {
 		cfg.spanOpts = opts
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) RouterOption {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) RouterOption {
+	return func(cfg *routerConfig) {
+		cfg.analyticsRate = rate
 	}
 }

--- a/contrib/graph-gophers/graphql-go/graphql_test.go
+++ b/contrib/graph-gophers/graphql-go/graphql_test.go
@@ -97,6 +97,7 @@ func TestAnalyticsSettings(t *testing.T) {
 	})
 
 	t.Run("global", func(t *testing.T) {
+		t.Skip("global flag disabled")
 		mt := mocktracer.Start()
 		defer mt.Stop()
 

--- a/contrib/graph-gophers/graphql-go/graphql_test.go
+++ b/contrib/graph-gophers/graphql-go/graphql_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
 type testResolver struct{}
@@ -60,4 +61,74 @@ func Test(t *testing.T) {
 		assert.Equal(t, "graphql.request", s.OperationName())
 		assert.Equal(t, "graphql.request", s.Tag(ext.ResourceName))
 	}
+}
+
+func TestAnalyticsSettings(t *testing.T) {
+	s := `
+		schema {
+			query: Query
+		}
+		type Query {
+			hello: String!
+		}
+	`
+
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...Option) {
+		schema := graphql.MustParseSchema(s, new(testResolver),
+			graphql.Tracer(NewTracer(opts...)))
+		srv := httptest.NewServer(&relay.Handler{Schema: schema})
+		defer srv.Close()
+		http.Post(srv.URL, "application/json", strings.NewReader(`{
+			"query": "{ hello }"
+		}`))
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 2)
+
+		assert.Equal(t, rate, spans[0].Tag(ext.EventSampleRate))
+		assert.Equal(t, rate, spans[1].Tag(ext.EventSampleRate))
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil)
+	})
+
+	t.Run("global", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.4)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 1.0, WithAnalytics(true))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil, WithAnalytics(false))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
+	})
 }

--- a/contrib/graph-gophers/graphql-go/option.go
+++ b/contrib/graph-gophers/graphql-go/option.go
@@ -1,17 +1,39 @@
 package graphql
 
-type config struct{ serviceName string }
+import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+
+type config struct {
+	serviceName   string
+	analyticsRate float64
+}
 
 // Option represents an option that can be used customize the Tracer.
 type Option func(*config)
 
 func defaults(cfg *config) {
 	cfg.serviceName = "graphql.server"
+	cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // WithServiceName sets the given service name for the client.
 func WithServiceName(name string) Option {
 	return func(cfg *config) {
 		cfg.serviceName = name
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) Option {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) Option {
+	return func(cfg *config) {
+		cfg.analyticsRate = rate
 	}
 }

--- a/contrib/graph-gophers/graphql-go/option.go
+++ b/contrib/graph-gophers/graphql-go/option.go
@@ -1,7 +1,5 @@
 package graphql
 
-import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
-
 type config struct {
 	serviceName   string
 	analyticsRate float64
@@ -12,7 +10,7 @@ type Option func(*config)
 
 func defaults(cfg *config) {
 	cfg.serviceName = "graphql.server"
-	cfg.analyticsRate = globalconfig.AnalyticsRate()
+	// cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // WithServiceName sets the given service name for the client.

--- a/contrib/julienschmidt/httprouter/httprouter.go
+++ b/contrib/julienschmidt/httprouter/httprouter.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httputil"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	"github.com/julienschmidt/httprouter"
 )
@@ -22,6 +24,9 @@ func New(opts ...RouterOption) *Router {
 	defaults(cfg)
 	for _, fn := range opts {
 		fn(cfg)
+	}
+	if cfg.analyticsRate > 0 {
+		cfg.spanOpts = append(cfg.spanOpts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 	}
 	return &Router{httprouter.New(), cfg}
 }

--- a/contrib/julienschmidt/httprouter/httprouter_test.go
+++ b/contrib/julienschmidt/httprouter/httprouter_test.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/stretchr/testify/assert"
@@ -65,6 +66,64 @@ func TestHttpTracer500(t *testing.T) {
 	assert.Equal(url, s.Tag(ext.HTTPURL))
 	assert.Equal("testvalue", s.Tag("testkey"))
 	assert.Equal("500: Internal Server Error", s.Tag(ext.Error).(error).Error())
+}
+
+func TestAnalyticsSettings(t *testing.T) {
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...RouterOption) {
+		router := New(opts...)
+		router.GET("/200", handler200)
+		r := httptest.NewRequest("GET", "/200", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, r)
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+		s := spans[0]
+		assert.Equal(t, rate, s.Tag(ext.EventSampleRate))
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil)
+	})
+
+	t.Run("global", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.4)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 1.0, WithAnalytics(true))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil, WithAnalytics(false))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
+	})
 }
 
 func router() http.Handler {

--- a/contrib/julienschmidt/httprouter/option.go
+++ b/contrib/julienschmidt/httprouter/option.go
@@ -1,16 +1,21 @@
 package httprouter
 
-import "gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+import (
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+)
 
 type routerConfig struct {
-	serviceName string
-	spanOpts    []ddtrace.StartSpanOption
+	serviceName   string
+	spanOpts      []ddtrace.StartSpanOption
+	analyticsRate float64
 }
 
 // RouterOption represents an option that can be passed to New.
 type RouterOption func(*routerConfig)
 
 func defaults(cfg *routerConfig) {
+	cfg.analyticsRate = globalconfig.AnalyticsRate()
 	cfg.serviceName = "http.router"
 }
 
@@ -25,5 +30,21 @@ func WithServiceName(name string) RouterOption {
 func WithSpanOptions(opts ...ddtrace.StartSpanOption) RouterOption {
 	return func(cfg *routerConfig) {
 		cfg.spanOpts = opts
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) RouterOption {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) RouterOption {
+	return func(cfg *routerConfig) {
+		cfg.analyticsRate = rate
 	}
 }

--- a/contrib/k8s.io/client-go/kubernetes/kubernetes.go
+++ b/contrib/k8s.io/client-go/kubernetes/kubernetes.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 )

--- a/contrib/k8s.io/client-go/kubernetes/kubernetes_test.go
+++ b/contrib/k8s.io/client-go/kubernetes/kubernetes_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -70,4 +72,72 @@ func TestKubernetes(t *testing.T) {
 		assert.True(t, ok)
 		assert.True(t, len(auditID) > 0)
 	}
+}
+
+func TestAnalyticsSettings(t *testing.T) {
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...httptrace.RoundTripperOption) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("Hello World"))
+		}))
+		defer srv.Close()
+
+		cfg, err := clientcmd.BuildConfigFromKubeconfigGetter(srv.URL, func() (*clientcmdapi.Config, error) {
+			return clientcmdapi.NewConfig(), nil
+		})
+		assert.NoError(t, err)
+		cfg.WrapTransport = WrapRoundTripperFunc(opts...)
+
+		client, err := kubernetes.NewForConfig(cfg)
+		assert.NoError(t, err)
+
+		client.CoreV1().Namespaces().List(meta_v1.ListOptions{})
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+
+		s := spans[0]
+		assert.Equal(t, rate, s.Tag(ext.EventSampleRate))
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil)
+	})
+
+	t.Run("global", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.4)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 1.0, httptrace.RTWithAnalytics(true))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil, httptrace.RTWithAnalytics(false))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.23, httptrace.RTWithAnalyticsRate(0.23))
+	})
 }

--- a/contrib/mongodb/mongo-go-driver/mongo/mongo_test.go
+++ b/contrib/mongodb/mongo-go-driver/mongo/mongo_test.go
@@ -17,6 +17,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
 func Test(t *testing.T) {
@@ -182,4 +183,77 @@ func mockMongo() (net.Listener, error) {
 	}()
 
 	return li, nil
+}
+
+func TestAnalyticsSettings(t *testing.T) {
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...Option) {
+		li, err := mockMongo()
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+		defer cancel()
+
+		addr := fmt.Sprintf("mongodb://%s", li.Addr().String())
+		mongopts := options.Client()
+		mongopts.SetMonitor(NewMonitor(opts...))
+		mongopts.SetSingle(true)
+		client, err := mongo.Connect(ctx, addr, mongopts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		client.
+			Database("test-database").
+			Collection("test-collection").
+			InsertOne(ctx, bson.D{{Key: "test-item", Value: "test-value"}})
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+		s := spans[0]
+		assert.Equal(t, rate, s.Tag(ext.EventSampleRate))
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil)
+	})
+
+	t.Run("global", func(t *testing.T) {
+		t.Skip("global flag disabled")
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.4)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 1.0, WithAnalytics(true))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil, WithAnalytics(false))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
+	})
 }

--- a/contrib/mongodb/mongo-go-driver/mongo/option.go
+++ b/contrib/mongodb/mongo-go-driver/mongo/option.go
@@ -1,0 +1,39 @@
+package mongo
+
+type config struct {
+	serviceName   string
+	analyticsRate float64
+}
+
+// Option represents an option that can be passed to Dial.
+type Option func(*config)
+
+func defaults(cfg *config) {
+	cfg.serviceName = "mongo"
+	// cfg.analyticsRate = globalconfig.AnalyticsRate()
+}
+
+// WithServiceName sets the given service name for the dialled connection.
+// When the service name is not explicitly set it will be inferred based on the
+// request to AWS.
+func WithServiceName(name string) Option {
+	return func(cfg *config) {
+		cfg.serviceName = name
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) Option {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) Option {
+	return func(cfg *config) {
+		cfg.analyticsRate = rate
+	}
+}

--- a/contrib/net/http/http_test.go
+++ b/contrib/net/http/http_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
 func TestHttpTracer200(t *testing.T) {
@@ -88,6 +89,64 @@ func TestWrapHandler200(t *testing.T) {
 	assert.Equal("GET", s.Tag(ext.HTTPMethod))
 	assert.Equal(url, s.Tag(ext.HTTPURL))
 	assert.Equal(nil, s.Tag(ext.Error))
+}
+
+func TestAnalyticsSettings(t *testing.T) {
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...MuxOption) {
+		mux := NewServeMux(opts...)
+		mux.HandleFunc("/200", handler200)
+		r := httptest.NewRequest("GET", "/200", nil)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, r)
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+		s := spans[0]
+		assert.Equal(t, rate, s.Tag(ext.EventSampleRate))
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil)
+	})
+
+	t.Run("global", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.4)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 1.0, WithAnalytics(true))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil, WithAnalytics(false))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
+	})
 }
 
 func router() http.Handler {

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -4,14 +4,19 @@ import (
 	"net/http"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
-type muxConfig struct{ serviceName string }
+type muxConfig struct {
+	serviceName   string
+	analyticsRate float64
+}
 
 // MuxOption represents an option that can be passed to NewServeMux.
 type MuxOption func(*muxConfig)
 
 func defaults(cfg *muxConfig) {
+	cfg.analyticsRate = globalconfig.AnalyticsRate()
 	cfg.serviceName = "http.router"
 }
 
@@ -19,6 +24,22 @@ func defaults(cfg *muxConfig) {
 func WithServiceName(name string) MuxOption {
 	return func(cfg *muxConfig) {
 		cfg.serviceName = name
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) MuxOption {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) MuxOption {
+	return func(cfg *muxConfig) {
+		cfg.analyticsRate = rate
 	}
 }
 
@@ -31,8 +52,9 @@ type RoundTripperBeforeFunc func(*http.Request, ddtrace.Span)
 type RoundTripperAfterFunc func(*http.Response, ddtrace.Span)
 
 type roundTripperConfig struct {
-	before RoundTripperBeforeFunc
-	after  RoundTripperAfterFunc
+	before        RoundTripperBeforeFunc
+	after         RoundTripperAfterFunc
+	analyticsRate float64
 }
 
 // A RoundTripperOption represents an option that can be passed to
@@ -52,5 +74,21 @@ func WithBefore(f RoundTripperBeforeFunc) RoundTripperOption {
 func WithAfter(f RoundTripperAfterFunc) RoundTripperOption {
 	return func(cfg *roundTripperConfig) {
 		cfg.after = f
+	}
+}
+
+// RTWithAnalytics enables Trace Analytics for all started spans.
+func RTWithAnalytics(on bool) RoundTripperOption {
+	if on {
+		return RTWithAnalyticsRate(1.0)
+	}
+	return RTWithAnalyticsRate(0.0)
+}
+
+// RTWithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func RTWithAnalyticsRate(rate float64) RoundTripperOption {
+	return func(cfg *roundTripperConfig) {
+		cfg.analyticsRate = rate
 	}
 }

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -57,6 +57,12 @@ type roundTripperConfig struct {
 	analyticsRate float64
 }
 
+func newRoundTripperConfig() *roundTripperConfig {
+	return &roundTripperConfig{
+		analyticsRate: globalconfig.AnalyticsRate(),
+	}
+}
+
 // A RoundTripperOption represents an option that can be passed to
 // WrapRoundTripper.
 type RoundTripperOption func(*roundTripperConfig)

--- a/contrib/net/http/roundtripper.go
+++ b/contrib/net/http/roundtripper.go
@@ -60,7 +60,7 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (res *http.Response, err er
 // WrapRoundTripper returns a new RoundTripper which traces all requests sent
 // over the transport.
 func WrapRoundTripper(rt http.RoundTripper, opts ...RoundTripperOption) http.RoundTripper {
-	cfg := new(roundTripperConfig)
+	cfg := newRoundTripperConfig()
 	for _, opt := range opts {
 		opt(cfg)
 	}

--- a/contrib/olivere/elastic/option.go
+++ b/contrib/olivere/elastic/option.go
@@ -3,8 +3,9 @@ package elastic
 import "net/http"
 
 type clientConfig struct {
-	serviceName string
-	transport   *http.Transport
+	serviceName   string
+	transport     *http.Transport
+	analyticsRate float64
 }
 
 // ClientOption represents an option that can be used when creating a client.
@@ -13,6 +14,7 @@ type ClientOption func(*clientConfig)
 func defaults(cfg *clientConfig) {
 	cfg.serviceName = "elastic.client"
 	cfg.transport = http.DefaultTransport.(*http.Transport)
+	// cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // WithServiceName sets the given service name for the client.
@@ -26,5 +28,21 @@ func WithServiceName(name string) ClientOption {
 func WithTransport(t *http.Transport) ClientOption {
 	return func(cfg *clientConfig) {
 		cfg.transport = t
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) ClientOption {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) ClientOption {
+	return func(cfg *clientConfig) {
+		cfg.analyticsRate = rate
 	}
 }

--- a/contrib/syndtr/goleveldb/leveldb/leveldb.go
+++ b/contrib/syndtr/goleveldb/leveldb/leveldb.go
@@ -258,10 +258,14 @@ func (it *Iterator) Release() {
 }
 
 func startSpan(cfg *config, name string) ddtrace.Span {
-	span, _ := tracer.StartSpanFromContext(cfg.ctx, "leveldb.query",
+	opts := []ddtrace.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeLevelDB),
 		tracer.ServiceName(cfg.serviceName),
 		tracer.ResourceName(name),
-	)
+	}
+	if cfg.analyticsRate > 0 {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
+	}
+	span, _ := tracer.StartSpanFromContext(cfg.ctx, "leveldb.query", opts...)
 	return span
 }

--- a/contrib/syndtr/goleveldb/leveldb/leveldb_test.go
+++ b/contrib/syndtr/goleveldb/leveldb/leveldb_test.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
 func TestDB(t *testing.T) {
@@ -141,5 +142,65 @@ func testAction(t *testing.T, name string, f func(mt mocktracer.Tracer, db *DB))
 		assert.Equal(t, ext.SpanTypeLevelDB, spans[0].Tag(ext.SpanType))
 		assert.Equal(t, "my-database", spans[0].Tag(ext.ServiceName))
 		assert.Equal(t, name, spans[0].Tag(ext.ResourceName))
+	})
+}
+
+func TestAnalyticsSettings(t *testing.T) {
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...Option) {
+		db, err := Open(storage.NewMemStorage(), &opt.Options{}, opts...)
+		assert.NoError(t, err)
+		defer db.Close()
+
+		iterator := db.NewIterator(nil, nil)
+		iterator.Release()
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+		s := spans[0]
+		assert.Equal(t, rate, s.Tag(ext.EventSampleRate))
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil)
+	})
+
+	t.Run("global", func(t *testing.T) {
+		t.Skip("global flag disabled")
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.4)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 1.0, WithAnalytics(true))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil, WithAnalytics(false))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
 	})
 }

--- a/contrib/syndtr/goleveldb/leveldb/option.go
+++ b/contrib/syndtr/goleveldb/leveldb/option.go
@@ -1,16 +1,20 @@
 package leveldb
 
-import "context"
+import (
+	"context"
+)
 
 type config struct {
-	serviceName string
-	ctx         context.Context
+	ctx           context.Context
+	serviceName   string
+	analyticsRate float64
 }
 
 func newConfig(opts ...Option) *config {
 	cfg := &config{
 		serviceName: "leveldb",
 		ctx:         context.Background(),
+		// cfg.analyticsRate: globalconfig.AnalyticsRate(),
 	}
 	for _, opt := range opts {
 		opt(cfg)
@@ -32,5 +36,21 @@ func WithContext(ctx context.Context) Option {
 func WithServiceName(serviceName string) Option {
 	return func(cfg *config) {
 		cfg.serviceName = serviceName
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) Option {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) Option {
+	return func(cfg *config) {
+		cfg.analyticsRate = rate
 	}
 }

--- a/contrib/tidwall/buntdb/buntdb.go
+++ b/contrib/tidwall/buntdb/buntdb.go
@@ -86,11 +86,15 @@ func WrapTx(tx *buntdb.Tx, opts ...Option) *Tx {
 }
 
 func (tx *Tx) startSpan(name string) ddtrace.Span {
-	span, _ := tracer.StartSpanFromContext(tx.cfg.ctx, "buntdb.query",
+	opts := []ddtrace.StartSpanOption{
 		tracer.SpanType(ext.AppTypeDB),
 		tracer.ServiceName(tx.cfg.serviceName),
 		tracer.ResourceName(name),
-	)
+	}
+	if tx.cfg.analyticsRate > 0 {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, tx.cfg.analyticsRate))
+	}
+	span, _ := tracer.StartSpanFromContext(tx.cfg.ctx, "buntdb.query", opts...)
 	return span
 }
 

--- a/contrib/tidwall/buntdb/buntdb_test.go
+++ b/contrib/tidwall/buntdb/buntdb_test.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
 func TestAscend(t *testing.T) {
@@ -346,6 +347,68 @@ func TestTTL(t *testing.T) {
 	})
 }
 
+func TestAnalyticsSettings(t *testing.T) {
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...Option) {
+		db := getDatabase(t, opts...)
+		defer db.Close()
+
+		err := db.View(func(tx *Tx) error {
+			_, err := tx.Len()
+			return err
+		})
+		assert.NoError(t, err)
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+		s := spans[0]
+		assert.Equal(t, rate, s.Tag(ext.EventSampleRate))
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil)
+	})
+
+	t.Run("global", func(t *testing.T) {
+		t.Skip("global flag disabled")
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.4)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 1.0, WithAnalytics(true))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil, WithAnalytics(false))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
+	})
+}
+
 func testUpdate(t *testing.T, name string, f func(tx *Tx) error) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
@@ -386,7 +449,7 @@ func testView(t *testing.T, name string, f func(tx *Tx) error) {
 	assert.Equal(t, "buntdb.query", spans[0].OperationName())
 }
 
-func getDatabase(t *testing.T) *DB {
+func getDatabase(t *testing.T, opts ...Option) *DB {
 	bdb, err := buntdb.Open(":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -421,5 +484,5 @@ func getDatabase(t *testing.T) *DB {
 		t.Fatal(err)
 	}
 
-	return WrapDB(bdb)
+	return WrapDB(bdb, opts...)
 }

--- a/contrib/tidwall/buntdb/option.go
+++ b/contrib/tidwall/buntdb/option.go
@@ -3,13 +3,15 @@ package buntdb
 import "context"
 
 type config struct {
-	serviceName string
-	ctx         context.Context
+	ctx           context.Context
+	serviceName   string
+	analyticsRate float64
 }
 
 func defaults(cfg *config) {
 	cfg.serviceName = "buntdb"
 	cfg.ctx = context.Background()
+	// cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // An Option customizes the config.
@@ -26,5 +28,21 @@ func WithContext(ctx context.Context) Option {
 func WithServiceName(serviceName string) Option {
 	return func(cfg *config) {
 		cfg.serviceName = serviceName
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) Option {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) Option {
+	return func(cfg *config) {
+		cfg.analyticsRate = rate
 	}
 }

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -8,6 +8,7 @@ import (
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
 // config holds the tracer configuration.
@@ -114,6 +115,22 @@ func WithSampler(s Sampler) StartOption {
 func WithHTTPRoundTripper(r http.RoundTripper) StartOption {
 	return func(c *config) {
 		c.httpRoundTripper = r
+	}
+}
+
+// WithAnalytics allows specifying whether Trace Search & Analytics should be enabled
+// for integrations.
+func WithAnalytics(on bool) StartOption {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the global sampling rate for sampling APM events.
+func WithAnalyticsRate(rate float64) StartOption {
+	return func(_ *config) {
+		globalconfig.SetAnalyticsRate(rate)
 	}
 }
 

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
 func withTransport(t transport) StartOption {
@@ -13,29 +14,42 @@ func withTransport(t transport) StartOption {
 }
 
 func TestTracerOptionsDefaults(t *testing.T) {
-	assert := assert.New(t)
-	var c config
-	defaults(&c)
-	assert.Equal(float64(1), c.sampler.(RateSampler).Rate())
-	assert.Equal("tracer.test", c.serviceName)
-	assert.Equal("localhost:8126", c.agentAddr)
-	assert.Equal(nil, c.httpRoundTripper)
-}
+	t.Run("defaults", func(t *testing.T) {
+		assert := assert.New(t)
+		var c config
+		defaults(&c)
+		assert.Equal(float64(1), c.sampler.(RateSampler).Rate())
+		assert.Equal("tracer.test", c.serviceName)
+		assert.Equal("localhost:8126", c.agentAddr)
+		assert.Equal(nil, c.httpRoundTripper)
+	})
 
-func TestTracerOptions(t *testing.T) {
-	assert := assert.New(t)
-	tracer := newTracer(
-		WithSampler(NewRateSampler(0.5)),
-		WithServiceName("api-intake"),
-		WithAgentAddr("ddagent.consul.local:58126"),
-		WithGlobalTag("k", "v"),
-		WithDebugMode(true),
-	)
-	c := tracer.config
-	assert.Equal(float64(0.5), c.sampler.(RateSampler).Rate())
-	assert.Equal("api-intake", c.serviceName)
-	assert.Equal("ddagent.consul.local:58126", c.agentAddr)
-	assert.NotNil(c.globalTags)
-	assert.Equal("v", c.globalTags["k"])
-	assert.True(c.debug)
+	t.Run("analytics", func(t *testing.T) {
+		assert := assert.New(t)
+		assert.Equal(0., globalconfig.AnalyticsRate())
+		newTracer(WithAnalyticsRate(0.5))
+		assert.Equal(0.5, globalconfig.AnalyticsRate())
+		newTracer(WithAnalytics(false))
+		assert.Equal(0., globalconfig.AnalyticsRate())
+		newTracer(WithAnalytics(true))
+		assert.Equal(1., globalconfig.AnalyticsRate())
+	})
+
+	t.Run("other", func(t *testing.T) {
+		assert := assert.New(t)
+		tracer := newTracer(
+			WithSampler(NewRateSampler(0.5)),
+			WithServiceName("api-intake"),
+			WithAgentAddr("ddagent.consul.local:58126"),
+			WithGlobalTag("k", "v"),
+			WithDebugMode(true),
+		)
+		c := tracer.config
+		assert.Equal(float64(0.5), c.sampler.(RateSampler).Rate())
+		assert.Equal("api-intake", c.serviceName)
+		assert.Equal("ddagent.consul.local:58126", c.agentAddr)
+		assert.NotNil(c.globalTags)
+		assert.Equal("v", c.globalTags["k"])
+		assert.True(c.debug)
+	})
 }

--- a/internal/globalconfig/globalconfig.go
+++ b/internal/globalconfig/globalconfig.go
@@ -1,0 +1,28 @@
+// package globalconfig stores configuration which applies globally to both the tracer
+// and integrations.
+package globalconfig
+
+import "sync"
+
+var cfg = &config{}
+
+type config struct {
+	mu            sync.RWMutex
+	analyticsRate float64
+}
+
+// AnalyticsRate returns the sampling rate at which events should be marked. It uses
+// synchronizing mechanisms, meaning that for optimal performance it's best to read it
+// once and store it.
+func AnalyticsRate() float64 {
+	cfg.mu.RLock()
+	defer cfg.mu.RUnlock()
+	return cfg.analyticsRate
+}
+
+// SetAnalyticsRate sets the given event sampling rate globally.
+func SetAnalyticsRate(rate float64) {
+	cfg.mu.Lock()
+	cfg.analyticsRate = rate
+	cfg.mu.Unlock()
+}

--- a/internal/globalconfig/globalconfig.go
+++ b/internal/globalconfig/globalconfig.go
@@ -1,4 +1,4 @@
-// package globalconfig stores configuration which applies globally to both the tracer
+// Package globalconfig stores configuration which applies globally to both the tracer
 // and integrations.
 package globalconfig
 


### PR DESCRIPTION
This change adds support for Trace Analytics.

### Global configuration

Two tracer configuration options were added, which enable Trace Analytics globally<sup>[1](#f1)</sup> for integrations.

Example:

```go
// Start the trace with Trace Analytics enabled.
tracer.Start(WithAnalytics(true))

// Start the trace with Trace Analytics enabled at a
// custom sample rate (e.g. 0=0%, 0.5=50%, 1=100%).
tracer.Start(WithAnalyticsRate(0.7))
```

### Local configuration

All integrations receive local options to enable Trace Analytics. These options are called the same as the global ones throughout: `WithAnalytics` and `WithAnalyticsRate`.

### Footnotes

<sup id="f1">1</sup> For this initial implementation, the global flag enables Trace Analytics only for the integrations listed below. To enable it on any other integration, the local options must be used.

* github.com/emicklei/go-restful
* github.com/gin-gonic/gin
* github.com/go-chi/chi
* github.com/gorilla/mux
* github.com/julienschmidt/httprouter
* golang.org/pkg/net/http