### PR TITLE
contrib/gocql/gocql: improve resource computation performance

### DIFF
--- a/contrib/gocql/gocql/gocql.go
+++ b/contrib/gocql/gocql/gocql.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
@@ -50,14 +49,7 @@ func WrapQuery(q *gocql.Query, opts ...WrapOption) *Query {
 		fn(cfg)
 	}
 	if cfg.resourceName == "" {
-		q := `"` + strings.SplitN(q.String(), "\"", 3)[1] + `"`
-		q, err := strconv.Unquote(q)
-		if err != nil {
-			// avoid having an empty resource as it will cause the trace
-			// to be dropped.
-			q = "_"
-		}
-		cfg.resourceName = q
+		cfg.resourceName = q.Statement()
 	}
 	tq := &Query{q, &params{config: cfg}, context.Background()}
 	return tq


### PR DESCRIPTION
Some performance test shown that if the resourceName was not provided, the computation involved a cpu-expensive operation to compute it. We can just derive it from the statement directly.

For the record, on top of strconv and split involved here, the underlying q.String() calls fmt.Sprintf()

After digging with @furmmon, it seems related to https://github.com/gocql/gocql/issues/1108