### PR TITLE
contrib/google.golang.org/grpc: allow setting non-error codes

### DIFF
--- a/contrib/google.golang.org/grpc/client.go
+++ b/contrib/google.golang.org/grpc/client.go
@@ -32,7 +32,7 @@ func (cs *clientStream) RecvMsg(m interface{}) (err error) {
 		if p, ok := peer.FromContext(cs.Context()); ok {
 			setSpanTargetFromPeer(span, *p)
 		}
-		defer func() { finishWithError(span, err, cs.cfg.noDebugStack) }()
+		defer func() { finishWithError(span, err, cs.cfg) }()
 	}
 	err = cs.ClientStream.RecvMsg(m)
 	return err
@@ -50,7 +50,7 @@ func (cs *clientStream) SendMsg(m interface{}) (err error) {
 		if p, ok := peer.FromContext(cs.Context()); ok {
 			setSpanTargetFromPeer(span, *p)
 		}
-		defer func() { finishWithError(span, err, cs.cfg.noDebugStack) }()
+		defer func() { finishWithError(span, err, cs.cfg) }()
 	}
 	err = cs.ClientStream.SendMsg(m)
 	return err
@@ -74,7 +74,7 @@ func StreamClientInterceptor(opts ...Option) grpc.StreamClientInterceptor {
 					return err
 				})
 			if err != nil {
-				finishWithError(span, err, cfg.noDebugStack)
+				finishWithError(span, err, cfg)
 				return nil, err
 			}
 
@@ -86,7 +86,7 @@ func StreamClientInterceptor(opts ...Option) grpc.StreamClientInterceptor {
 
 			go func() {
 				<-stream.Context().Done()
-				finishWithError(span, stream.Context().Err(), cfg.noDebugStack)
+				finishWithError(span, stream.Context().Err(), cfg)
 			}()
 		} else {
 			// if call tracing is disabled, just call streamer, but still return
@@ -123,7 +123,7 @@ func UnaryClientInterceptor(opts ...Option) grpc.UnaryClientInterceptor {
 			func(ctx context.Context, opts []grpc.CallOption) error {
 				return invoker(ctx, method, req, reply, cc, opts...)
 			})
-		finishWithError(span, err, cfg.noDebugStack)
+		finishWithError(span, err, cfg)
 		return err
 	}
 }

--- a/contrib/google.golang.org/grpc/grpc.go
+++ b/contrib/google.golang.org/grpc/grpc.go
@@ -37,7 +37,7 @@ func startSpanFromContext(
 }
 
 // finishWithError applies finish option and a tag with gRPC status code, disregarding OK, EOF and Canceled errors.
-func finishWithError(span ddtrace.Span, err error, noDebugStack bool) {
+func finishWithError(span ddtrace.Span, err error, cfg *config) {
 	if err == io.EOF || err == context.Canceled {
 		err = nil
 	}
@@ -49,7 +49,7 @@ func finishWithError(span ddtrace.Span, err error, noDebugStack bool) {
 	finishOptions := []tracer.FinishOption{
 		tracer.WithError(err),
 	}
-	if noDebugStack {
+	if cfg.noDebugStack {
 		finishOptions = append(finishOptions, tracer.NoDebugStack())
 	}
 	span.Finish(finishOptions...)

--- a/contrib/google.golang.org/grpc/grpc.go
+++ b/contrib/google.golang.org/grpc/grpc.go
@@ -42,7 +42,7 @@ func finishWithError(span ddtrace.Span, err error, cfg *config) {
 		err = nil
 	}
 	errcode := status.Code(err)
-	if errcode == codes.Canceled || errcode == codes.OK {
+	if errcode == codes.OK || cfg.nonErrorCodes[errcode] {
 		err = nil
 	}
 	span.SetTag(tagCode, errcode.String())

--- a/contrib/google.golang.org/grpc/server.go
+++ b/contrib/google.golang.org/grpc/server.go
@@ -34,7 +34,7 @@ func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 			ss.cfg.serverServiceName(),
 			ss.cfg.analyticsRate,
 		)
-		defer func() { finishWithError(span, err, ss.cfg.noDebugStack) }()
+		defer func() { finishWithError(span, err, ss.cfg) }()
 	}
 	err = ss.ServerStream.RecvMsg(m)
 	return err
@@ -49,7 +49,7 @@ func (ss *serverStream) SendMsg(m interface{}) (err error) {
 			ss.cfg.serverServiceName(),
 			ss.cfg.analyticsRate,
 		)
-		defer func() { finishWithError(span, err, ss.cfg.noDebugStack) }()
+		defer func() { finishWithError(span, err, ss.cfg) }()
 	}
 	err = ss.ServerStream.SendMsg(m)
 	return err
@@ -78,7 +78,7 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
 				cfg.serviceName,
 				cfg.analyticsRate,
 			)
-			defer func() { finishWithError(span, err, cfg.noDebugStack) }()
+			defer func() { finishWithError(span, err, cfg) }()
 		}
 
 		// call the original handler with a new stream, which traces each send
@@ -110,7 +110,7 @@ func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
 			cfg.analyticsRate,
 		)
 		resp, err := handler(ctx, req)
-		finishWithError(span, err, cfg.noDebugStack)
+		finishWithError(span, err, cfg)
 		return resp, err
 	}
 }

--- a/contrib/google.golang.org/grpc/stats_client.go
+++ b/contrib/google.golang.org/grpc/stats_client.go
@@ -53,7 +53,7 @@ func (h *clientStatsHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
 			span.SetTag(ext.TargetPort, port)
 		}
 	case *stats.End:
-		finishWithError(span, rs.Error, h.cfg.noDebugStack)
+		finishWithError(span, rs.Error, h.cfg)
 	}
 }
 

--- a/contrib/google.golang.org/grpc/stats_server.go
+++ b/contrib/google.golang.org/grpc/stats_server.go
@@ -42,7 +42,7 @@ func (h *serverStatsHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
 		return
 	}
 	if v, ok := rs.(*stats.End); ok {
-		finishWithError(span, v.Error, h.cfg.noDebugStack)
+		finishWithError(span, v.Error, h.cfg)
 	}
 }
 


### PR DESCRIPTION
Sorry @gbbr & @ewang: I decided to just start hacking on this issue, because I really want to suppress the wast amount of `NotFound` errors for certain services at the company I'm working for. 😅
I hope this PR is fine for you / the maintainers. 🙂

Fixes #333 