### PR TITLE
ddtrace/tracer: add an alias tag (analytics.event) for setting event rate

### DIFF
--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -63,4 +63,8 @@ const (
 	// EventSampleRate specifies the rate at which this span will be sampled
 	// as an APM event.
 	EventSampleRate = "_dd1.sr.eausr"
+
+	// AnalyticsEvent specifies whether the span should be recorded as a Trace
+	// Search & Analytics event.
+	AnalyticsEvent = "analytics.event"
 )

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -80,9 +80,21 @@ func (s *span) SetTag(key string, value interface{}) {
 	if s.finished {
 		return
 	}
-	if key == ext.Error {
+	switch key {
+	case ext.Error:
 		s.setTagError(value, true)
 		return
+	case ext.AnalyticsEvent:
+		// "analytics.event" is a boolean alias for setting the event sampling
+		// rate to 0.0 or 1.0
+		if set, ok := value.(bool); ok {
+			if set {
+				s.setTagNumeric(ext.EventSampleRate, 1.0)
+			} else {
+				s.setTagNumeric(ext.EventSampleRate, 0.0)
+			}
+			return
+		}
 	}
 	if v, ok := value.(string); ok {
 		s.setTagString(key, v)

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -161,6 +161,12 @@ func TestSpanSetTag(t *testing.T) {
 
 	span.SetTag(ext.SamplingPriority, 2)
 	assert.Equal(float64(2), span.Metrics[keySamplingPriority])
+
+	span.SetTag(ext.AnalyticsEvent, true)
+	assert.Equal(1.0, span.Metrics[ext.EventSampleRate])
+
+	span.SetTag(ext.AnalyticsEvent, false)
+	assert.Equal(0.0, span.Metrics[ext.EventSampleRate])
 }
 
 func TestSpanSetDatadogTags(t *testing.T) {


### PR DESCRIPTION
This change adds support for a new boolean tag ("analytics.event") to serve as
an alias for setting the event sample rate to 0.0 or 1.0.

For example:
```go
span.SetTag(ext.AnalyticsEvent, true)  // record this event
span.SetTag(ext.AnalyticsEvent, false) // don't record this event
```