### PR TITLE
contrib/gocql/gocql: add NoDebugStack option

### DIFF
--- a/contrib/gocql/gocql/gocql.go
+++ b/contrib/gocql/gocql/gocql.go
@@ -86,7 +86,6 @@ func (tq *Query) newChildSpan(ctx context.Context) ddtrace.Span {
 	return span
 }
 
-// FinishSpan ends child span
 func (tq *Query) finishSpan(span ddtrace.Span, err error) {
 	if tq.params.config.noDebugStack {
 		span.Finish(tracer.WithError(err), tracer.NoDebugStack())

--- a/contrib/gocql/gocql/gocql.go
+++ b/contrib/gocql/gocql/gocql.go
@@ -86,8 +86,8 @@ func (tq *Query) newChildSpan(ctx context.Context) ddtrace.Span {
 	return span
 }
 
-// FinishChildSpan ends child span
-func (tq *Query) finishChildSpan(span ddtrace.Span, err error) {
+// FinishSpan ends child span
+func (tq *Query) finishSpan(span ddtrace.Span, err error) {
 	if tq.params.config.noDebugStack {
 		span.Finish(tracer.WithError(err), tracer.NoDebugStack())
 	} else {
@@ -104,7 +104,7 @@ func (tq *Query) Exec() error {
 func (tq *Query) MapScan(m map[string]interface{}) error {
 	span := tq.newChildSpan(tq.ctx)
 	err := tq.Query.MapScan(m)
-	tq.finishChildSpan(span, err)
+	tq.finishSpan(span, err)
 	return err
 }
 
@@ -112,7 +112,7 @@ func (tq *Query) MapScan(m map[string]interface{}) error {
 func (tq *Query) Scan(dest ...interface{}) error {
 	span := tq.newChildSpan(tq.ctx)
 	err := tq.Query.Scan(dest...)
-	tq.finishChildSpan(span, err)
+	tq.finishSpan(span, err)
 	return err
 }
 
@@ -120,7 +120,7 @@ func (tq *Query) Scan(dest ...interface{}) error {
 func (tq *Query) ScanCAS(dest ...interface{}) (applied bool, err error) {
 	span := tq.newChildSpan(tq.ctx)
 	applied, err = tq.Query.ScanCAS(dest...)
-	tq.finishChildSpan(span, err)
+	tq.finishSpan(span, err)
 	return applied, err
 }
 

--- a/contrib/gocql/gocql/option.go
+++ b/contrib/gocql/gocql/option.go
@@ -2,6 +2,7 @@ package gocql
 
 type queryConfig struct {
 	serviceName, resourceName string
+	noDebugStack              bool
 	analyticsRate             float64
 }
 
@@ -45,5 +46,14 @@ func WithAnalytics(on bool) WrapOption {
 func WithAnalyticsRate(rate float64) WrapOption {
 	return func(cfg *queryConfig) {
 		cfg.analyticsRate = rate
+	}
+}
+
+// NoDebugStack prevents any error presented using the WithError finishing option
+// from generating a stack trace. This is useful in situations where errors are frequent
+// and performance is critical.
+func NoDebugStack() WrapOption {
+	return func(cfg *queryConfig) {
+		cfg.noDebugStack = true
 	}
 }

--- a/contrib/gocql/gocql/option.go
+++ b/contrib/gocql/gocql/option.go
@@ -49,9 +49,9 @@ func WithAnalyticsRate(rate float64) WrapOption {
 	}
 }
 
-// NoDebugStack prevents any error presented using the WithError finishing option
-// from generating a stack trace. This is useful in situations where errors are frequent
-// and performance is critical.
+// NoDebugStack prevents stack traces from being attached to spans finishing
+// with an error. This is useful in situations where errors are frequent and
+// performance is critical.
 func NoDebugStack() WrapOption {
 	return func(cfg *queryConfig) {
 		cfg.noDebugStack = true


### PR DESCRIPTION
Allow adding NoDebugStack option to WrapQuery to prevent generating stack traces on errors.

Needed when a service makes a lot of calls to cassandra at bootstrap (to retrieve state for example) that should be able to retry quickly without blocking & using too much memory when generating errors stack traces.
