### PR TITLE
ddtrace/tracer: add support for DD_PROPAGATION_STYLE_INJECT + EXTRACT

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -142,7 +142,7 @@ func makeInjectors(cfg *PropagatorConfig) []Propagator {
 	if ps == "" {
 		return []Propagator{dd}
 	}
-	styles := propagationStyleList(ps)
+	styles := strings.Split(ps, ",")
 
 	var injectors []Propagator
 	for _, v := range styles {
@@ -171,7 +171,7 @@ func makeExtractors(cfg *PropagatorConfig) []Propagator {
 	if ps == "" {
 		return []Propagator{dd}
 	}
-	styles := propagationStyleList(ps)
+	styles := strings.Split(ps, ",")
 
 	var extractors []Propagator
 	for _, v := range styles {
@@ -190,20 +190,6 @@ func makeExtractors(cfg *PropagatorConfig) []Propagator {
 		return []Propagator{dd}
 	}
 	return extractors
-}
-
-// propagationStyleList splits a string containing propagation styles
-// separated by space or comma, and returns a []string containing
-// only the propagation styles.
-func propagationStyleList(s string) []string {
-	f := func(r rune) bool {
-		switch r {
-		case ' ', ',':
-			return true
-		}
-		return false
-	}
-	return strings.FieldsFunc(s, f)
 }
 
 // Inject defines the Propagator to propagate SpanContext data

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -3,6 +3,7 @@ package tracer
 import (
 	"errors"
 	"net/http"
+	"os"
 	"strconv"
 	"testing"
 
@@ -194,4 +195,84 @@ func TestTextMapPropagatorInjectExtract(t *testing.T) {
 	assert.Equal(xctx.baggage, ctx.baggage)
 	assert.Equal(xctx.priority, ctx.priority)
 	assert.Equal(xctx.hasPriority, ctx.hasPriority)
+}
+
+func TestEnvOverrideInject(t *testing.T) {
+	os.Setenv("DD_PROPAGATION_STYLE_INJECT", "B3")
+	defer os.Unsetenv("DD_PROPAGATION_STYLE_INJECT")
+
+	tracer := newTracer()
+	root := tracer.StartSpan("web.request").(*span)
+	root.SetTag(ext.SamplingPriority, -1)
+	root.SetBaggageItem("item", "x")
+	ctx := root.Context().(*spanContext)
+	headers := TextMapCarrier(map[string]string{})
+	err := tracer.Inject(ctx, headers)
+
+	assert := assert.New(t)
+	assert.Nil(err)
+
+	assert.Equal(headers[b3TraceIDHeader], strconv.FormatUint(root.TraceID, 16))
+	assert.Equal(headers[b3SpanIDHeader], strconv.FormatUint(root.SpanID, 16))
+	assert.Equal(headers[b3SampledHeader], "0")
+}
+
+func TestEnvOverrideExtractB3(t *testing.T) {
+	os.Setenv("DD_PROPAGATION_STYLE_EXTRACT", "B3")
+	defer os.Unsetenv("DD_PROPAGATION_STYLE_EXTRACT")
+
+	headers := TextMapCarrier(map[string]string{
+		b3TraceIDHeader: "1",
+		b3SpanIDHeader:  "1",
+	})
+
+	tracer := newTracer()
+	assert := assert.New(t)
+	ctx, err := tracer.Extract(headers)
+	assert.Nil(err)
+	sctx, ok := ctx.(*spanContext)
+	assert.True(ok)
+
+	assert.Equal(sctx.traceID, uint64(1))
+	assert.Equal(sctx.spanID, uint64(1))
+}
+
+func TestEnvOverrideExtractMultiple(t *testing.T) {
+	os.Setenv("DD_PROPAGATION_STYLE_EXTRACT", "Datadog,B3")
+	defer os.Unsetenv("DD_PROPAGATION_STYLE_EXTRACT")
+
+	b3Headers := TextMapCarrier(map[string]string{
+		b3TraceIDHeader: "1",
+		b3SpanIDHeader:  "1",
+		b3SampledHeader: "1",
+	})
+
+	tracer := newTracer()
+	assert := assert.New(t)
+
+	ctx, err := tracer.Extract(b3Headers)
+	assert.Nil(err)
+	sctx, ok := ctx.(*spanContext)
+	assert.True(ok)
+
+	assert.Equal(sctx.traceID, uint64(1))
+	assert.Equal(sctx.spanID, uint64(1))
+	assert.True(sctx.hasSamplingPriority())
+	assert.Equal(sctx.samplingPriority(), 1)
+
+	ddHeaders := TextMapCarrier(map[string]string{
+		DefaultTraceIDHeader:  "2",
+		DefaultParentIDHeader: "2",
+		DefaultPriorityHeader: "2",
+	})
+
+	ctx, err = tracer.Extract(ddHeaders)
+	assert.Nil(err)
+	sctx, ok = ctx.(*spanContext)
+	assert.True(ok)
+
+	assert.Equal(sctx.traceID, uint64(2))
+	assert.Equal(sctx.spanID, uint64(2))
+	assert.True(sctx.hasSamplingPriority())
+	assert.Equal(sctx.samplingPriority(), 2)
 }


### PR DESCRIPTION
This permits using B3 headers for injecting and extracting traces when propagated between different programs.
It is backward-compatible with existing behavior, but provides support for either Datadog, B3 or both headers when they are propagated.

The environment variables `DD_PROPAGATION_STYLE_INJECT` and `DD_PROPAGATION_STYLE_EXTRACT` support values that are comma separated (current valid values are: `datadog` and `b3`). They are case insensitive. When extracting, the list order is presumed. 

This functionality is currently not being added to the API (eg: `PropagatorConfig`), but may be exposed in the future if needed.