### PR TITLE
contrib/net/http: Allow passthrough of http trace span options

### DIFF
--- a/contrib/net/http/http.go
+++ b/contrib/net/http/http.go
@@ -46,8 +46,8 @@ func (mux *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // WrapHandler wraps an http.Handler with tracing using the given service and resource.
-func WrapHandler(h http.Handler, service, resource string) http.Handler {
+func WrapHandler(h http.Handler, service, resource string, spanopts ...ddtrace.StartSpanOption) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		httputil.TraceAndServe(h, w, req, service, resource)
+		httputil.TraceAndServe(h, w, req, service, resource, spanopts...)
 	})
 }

--- a/contrib/net/http/http.go
+++ b/contrib/net/http/http.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httputil"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )

--- a/contrib/net/http/http.go
+++ b/contrib/net/http/http.go
@@ -10,8 +10,6 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
-type Option = MuxOption
-
 // ServeMux is an HTTP request multiplexer that traces all the incoming requests.
 type ServeMux struct {
 	*http.ServeMux

--- a/contrib/net/http/http.go
+++ b/contrib/net/http/http.go
@@ -38,7 +38,7 @@ func (mux *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// get the resource associated to this request
 	_, route := mux.Handler(r)
 	resource := r.Method + " " + route
-	var opts []ddtrace.StartSpanOption
+	opts := mux.cfg.spanOpts
 	if mux.cfg.analyticsRate > 0 {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, mux.cfg.analyticsRate))
 	}

--- a/contrib/net/http/http_test.go
+++ b/contrib/net/http/http_test.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -9,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 

--- a/contrib/net/http/http_test.go
+++ b/contrib/net/http/http_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -35,6 +36,7 @@ func TestHttpTracer200(t *testing.T) {
 	assert.Equal("GET", s.Tag(ext.HTTPMethod))
 	assert.Equal(url, s.Tag(ext.HTTPURL))
 	assert.Equal(nil, s.Tag(ext.Error))
+	assert.Equal("bar", s.Tag("foo"))
 }
 
 func TestHttpTracer500(t *testing.T) {
@@ -62,6 +64,7 @@ func TestHttpTracer500(t *testing.T) {
 	assert.Equal("GET", s.Tag(ext.HTTPMethod))
 	assert.Equal(url, s.Tag(ext.HTTPURL))
 	assert.Equal("500: Internal Server Error", s.Tag(ext.Error).(error).Error())
+	assert.Equal("bar", s.Tag("foo"))
 }
 
 func TestWrapHandler200(t *testing.T) {
@@ -69,7 +72,8 @@ func TestWrapHandler200(t *testing.T) {
 	defer mt.Stop()
 	assert := assert.New(t)
 
-	handler := WrapHandler(http.HandlerFunc(handler200), "my-service", "my-resource")
+	handler := WrapHandler(http.HandlerFunc(handler200), "my-service", "my-resource",
+		WithSpanOptions(tracer.Tag("foo", "bar")))
 
 	url := "/"
 	r := httptest.NewRequest("GET", url, nil)
@@ -89,10 +93,11 @@ func TestWrapHandler200(t *testing.T) {
 	assert.Equal("GET", s.Tag(ext.HTTPMethod))
 	assert.Equal(url, s.Tag(ext.HTTPURL))
 	assert.Equal(nil, s.Tag(ext.Error))
+	assert.Equal("bar", s.Tag("foo"))
 }
 
 func TestAnalyticsSettings(t *testing.T) {
-	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...MuxOption) {
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...Option) {
 		mux := NewServeMux(opts...)
 		mux.HandleFunc("/200", handler200)
 		r := httptest.NewRequest("GET", "/200", nil)
@@ -150,7 +155,7 @@ func TestAnalyticsSettings(t *testing.T) {
 }
 
 func router() http.Handler {
-	mux := NewServeMux(WithServiceName("my-service"))
+	mux := NewServeMux(WithServiceName("my-service"), WithSpanOptions(tracer.Tag("foo", "bar")))
 	mux.HandleFunc("/200", handler200)
 	mux.HandleFunc("/500", handler500)
 	return mux

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -13,7 +13,7 @@ type config struct {
 	spanOpts      []ddtrace.StartSpanOption
 }
 
-// MuxOption DEPRECATED: Use Option in favor of MuxOption.
+// MuxOption has been deprecated in favor of Option.
 type MuxOption func(*config)
 
 // Option represents an option that can be passed to NewServeMux or WrapHandler.

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -16,6 +16,9 @@ type config struct {
 // MuxOption represents an option that can be passed to NewServeMux.
 type MuxOption func(*config)
 
+// Option represents an option that can be passed to NewServeMux or WrapHandler.
+type Option = MuxOption
+
 func defaults(cfg *config) {
 	cfg.analyticsRate = globalconfig.AnalyticsRate()
 	cfg.serviceName = "http.router"
@@ -44,6 +47,7 @@ func WithAnalyticsRate(rate float64) MuxOption {
 	}
 }
 
+// WithSpanOptions sets additional options for the traced Span
 func WithSpanOptions(opts ...ddtrace.StartSpanOption) Option {
 	return func(cfg *config) {
 		cfg.spanOpts = opts

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -7,22 +7,23 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
-type muxConfig struct {
+type config struct {
 	serviceName   string
 	analyticsRate float64
+	spanOpts      []ddtrace.StartSpanOption
 }
 
 // MuxOption represents an option that can be passed to NewServeMux.
-type MuxOption func(*muxConfig)
+type MuxOption func(*config)
 
-func defaults(cfg *muxConfig) {
+func defaults(cfg *config) {
 	cfg.analyticsRate = globalconfig.AnalyticsRate()
 	cfg.serviceName = "http.router"
 }
 
 // WithServiceName sets the given service name for the returned ServeMux.
 func WithServiceName(name string) MuxOption {
-	return func(cfg *muxConfig) {
+	return func(cfg *config) {
 		cfg.serviceName = name
 	}
 }
@@ -38,8 +39,14 @@ func WithAnalytics(on bool) MuxOption {
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) MuxOption {
-	return func(cfg *muxConfig) {
+	return func(cfg *config) {
 		cfg.analyticsRate = rate
+	}
+}
+
+func WithSpanOptions(opts ...ddtrace.StartSpanOption) Option {
+	return func(cfg *config) {
+		cfg.spanOpts = opts
 	}
 }
 

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -13,7 +13,7 @@ type config struct {
 	spanOpts      []ddtrace.StartSpanOption
 }
 
-// MuxOption represents an option that can be passed to NewServeMux.
+// DEPRECATED in favor of Option.
 type MuxOption func(*config)
 
 // Option represents an option that can be passed to NewServeMux or WrapHandler.
@@ -47,7 +47,8 @@ func WithAnalyticsRate(rate float64) MuxOption {
 	}
 }
 
-// WithSpanOptions sets additional options for the traced Span
+// WithSpanOptions defines a set of additional ddtrace.StartSpanOption to be added
+// to spans started by the integration.
 func WithSpanOptions(opts ...ddtrace.StartSpanOption) Option {
 	return func(cfg *config) {
 		cfg.spanOpts = opts

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -13,7 +13,7 @@ type config struct {
 	spanOpts      []ddtrace.StartSpanOption
 }
 
-// DEPRECATED: Use Option in favor of MuxOption.
+// MuxOption DEPRECATED: Use Option in favor of MuxOption.
 type MuxOption func(*config)
 
 // Option represents an option that can be passed to NewServeMux or WrapHandler.

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -51,7 +51,7 @@ func WithAnalyticsRate(rate float64) MuxOption {
 // to spans started by the integration.
 func WithSpanOptions(opts ...ddtrace.StartSpanOption) Option {
 	return func(cfg *config) {
-		cfg.spanOpts = opts
+		cfg.spanOpts = append(cfg.spanOpts, opts...)
 	}
 }
 

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -13,7 +13,7 @@ type config struct {
 	spanOpts      []ddtrace.StartSpanOption
 }
 
-// DEPRECATED in favor of Option.
+// DEPRECATED: Use Option in favor of MuxOption.
 type MuxOption func(*config)
 
 // Option represents an option that can be passed to NewServeMux or WrapHandler.


### PR DESCRIPTION
* Adds a new `spanopts ...ddtrace.StartSpanOption` parameter to the `WrapHandler` func.

Fixes #428