### PR TITLE
ddtrace/tracer: add manual.keep and manual.drop tags

### DIFF
--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -67,4 +67,12 @@ const (
 	// AnalyticsEvent specifies whether the span should be recorded as a Trace
 	// Search & Analytics event.
 	AnalyticsEvent = "analytics.event"
+
+	// ManualKeep is a tag which specifies that the trace to which this span
+	// belongs too should be kept when set to true.
+	ManualKeep = "manual.keep"
+
+	// ManualDrop is a tag which specifies that the trace to which this span
+	// belongs too should be dropped when set to true.
+	ManualDrop = "manual.drop"
 )

--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -69,10 +69,10 @@ const (
 	AnalyticsEvent = "analytics.event"
 
 	// ManualKeep is a tag which specifies that the trace to which this span
-	// belongs too should be kept when set to true.
+	// belongs to should be kept when set to true.
 	ManualKeep = "manual.keep"
 
 	// ManualDrop is a tag which specifies that the trace to which this span
-	// belongs too should be dropped when set to true.
+	// belongs to should be dropped when set to true.
 	ManualDrop = "manual.drop"
 )

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -168,6 +168,12 @@ func (s *span) setTagBool(key string, v bool) {
 		if v {
 			s.setTagNumeric(ext.SamplingPriority, ext.PriorityUserKeep)
 		}
+	default:
+		if v {
+			s.setTagString(key, "true")
+		} else {
+			s.setTagString(key, "false")
+		}
 	}
 }
 

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -84,17 +84,10 @@ func (s *span) SetTag(key string, value interface{}) {
 	case ext.Error:
 		s.setTagError(value, true)
 		return
-	case ext.AnalyticsEvent:
-		// "analytics.event" is a boolean alias for setting the event sampling
-		// rate to 0.0 or 1.0
-		if set, ok := value.(bool); ok {
-			if set {
-				s.setTagNumeric(ext.EventSampleRate, 1.0)
-			} else {
-				s.setTagNumeric(ext.EventSampleRate, 0.0)
-			}
-			return
-		}
+	}
+	if v, ok := value.(bool); ok {
+		s.setTagBool(key, v)
+		return
 	}
 	if v, ok := value.(string); ok {
 		s.setTagString(key, v)
@@ -155,6 +148,26 @@ func (s *span) setTagString(key, v string) {
 		s.Type = v
 	default:
 		s.Meta[key] = v
+	}
+}
+
+// setTagBool sets a boolean tag on the span.
+func (s *span) setTagBool(key string, v bool) {
+	switch key {
+	case ext.AnalyticsEvent:
+		if v {
+			s.setTagNumeric(ext.EventSampleRate, 1.0)
+		} else {
+			s.setTagNumeric(ext.EventSampleRate, 0.0)
+		}
+	case ext.ManualDrop:
+		if v {
+			s.setTagNumeric(ext.SamplingPriority, ext.PriorityUserReject)
+		}
+	case ext.ManualKeep:
+		if v {
+			s.setTagNumeric(ext.SamplingPriority, ext.PriorityUserKeep)
+		}
 	}
 }
 

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -173,6 +173,12 @@ func TestSpanSetTag(t *testing.T) {
 
 	span.SetTag(ext.ManualKeep, true)
 	assert.Equal(2., span.Metrics[keySamplingPriority])
+
+	span.SetTag("some.bool", true)
+	assert.Equal("true", span.Meta["some.bool"])
+
+	span.SetTag("some.other.bool", false)
+	assert.Equal("false", span.Meta["some.other.bool"])
 }
 
 func TestSpanSetDatadogTags(t *testing.T) {

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -167,6 +167,12 @@ func TestSpanSetTag(t *testing.T) {
 
 	span.SetTag(ext.AnalyticsEvent, false)
 	assert.Equal(0.0, span.Metrics[ext.EventSampleRate])
+
+	span.SetTag(ext.ManualDrop, true)
+	assert.Equal(-1., span.Metrics[keySamplingPriority])
+
+	span.SetTag(ext.ManualKeep, true)
+	assert.Equal(2., span.Metrics[keySamplingPriority])
 }
 
 func TestSpanSetDatadogTags(t *testing.T) {


### PR DESCRIPTION
These are aliases for simplifying user-controlled sampling priorities.