### PR TITLE
ddtrace/tracer: Make logging configurable

### DIFF
--- a/ddtrace/tracer/errors.go
+++ b/ddtrace/tracer/errors.go
@@ -2,7 +2,6 @@ package tracer
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 )
 
@@ -55,15 +54,15 @@ func aggregateErrors(errChan <-chan error) map[string]errorSummary {
 
 // logErrors logs the errors, preventing log file flooding, when there
 // are many messages, it caps them and shows a quick summary.
-// As of today it only logs using standard golang log package, but
+// As of today it only logs using logger provided by caller, but
 // later we could send those stats to agent // TODO(ufoot).
-func logErrors(errChan <-chan error) {
+func logErrors(errChan <-chan error, l Logger) {
 	errs := aggregateErrors(errChan)
 	for _, v := range errs {
 		var repeat string
 		if v.Count > 1 {
 			repeat = " (repeated " + strconv.Itoa(v.Count) + " times)"
 		}
-		log.Println(errorPrefix + v.Example + repeat)
+		l.Println(errorPrefix + v.Example + repeat)
 	}
 }

--- a/ddtrace/tracer/logging.go
+++ b/ddtrace/tracer/logging.go
@@ -1,0 +1,10 @@
+package tracer
+
+// Logger is the interface that wraps the necessary functionality for logging of errors messages.
+//
+// It uses subset of methods from log.Logger - therefore log.Logger will always fullfil
+// requirements of interface.
+type Logger interface {
+	Println(v ...interface{})
+	Printf(format string, v ...interface{})
+}

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -1,6 +1,7 @@
 package tracer
 
 import (
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -38,6 +39,9 @@ type config struct {
 
 	// httpRoundTripper defines the http.RoundTripper used by the agent transport.
 	httpRoundTripper http.RoundTripper
+
+	// logger is used to log all errors received and not returned by tracer.
+	logger Logger
 }
 
 // StartOption represents a function that can be provided as a parameter to Start.
@@ -48,6 +52,7 @@ func defaults(c *config) {
 	c.serviceName = filepath.Base(os.Args[0])
 	c.sampler = NewAllSampler()
 	c.agentAddr = defaultAddress
+	c.logger = log.New(os.Stderr, "", log.LstdFlags)
 }
 
 // WithPrioritySampling is deprecated, and priority sampling is enabled by default.
@@ -131,6 +136,14 @@ func WithAnalytics(on bool) StartOption {
 func WithAnalyticsRate(rate float64) StartOption {
 	return func(_ *config) {
 		globalconfig.SetAnalyticsRate(rate)
+	}
+}
+
+// WithLogger sets a logger used to output any errors encountered while processing traces that are
+// not returned.
+func WithLogger(l Logger) StartOption {
+	return func(c *config) {
+		c.logger = l
 	}
 }
 

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -2,7 +2,6 @@ package tracer
 
 import (
 	"errors"
-	"log"
 	"os"
 	"strconv"
 	"time"
@@ -314,7 +313,7 @@ func (t *tracer) flushTraces() {
 	}
 	size, count := t.payload.size(), t.payload.itemCount()
 	if t.config.debug {
-		log.Printf("Sending payload: size: %d traces: %d\n", size, count)
+		t.config.logger.Printf("Sending payload: size: %d traces: %d\n", size, count)
 	}
 	rc, err := t.config.transport.send(t.payload)
 	if err != nil {
@@ -328,7 +327,7 @@ func (t *tracer) flushTraces() {
 
 // flushErrors will process log messages that were queued
 func (t *tracer) flushErrors() {
-	logErrors(t.errorBuffer)
+	logErrors(t.errorBuffer, t.config.logger)
 }
 
 func (t *tracer) flush() {


### PR DESCRIPTION
This exposes interface used by tracer for logging and adds option to
configure logger used. Default logger logs to stderr in non json manner.

Fixes: https://github.com/DataDog/dd-trace-go/issues/432