### PR TITLE
tracer: add option to skip and limit stack frames

### DIFF
--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -78,18 +78,6 @@ type StartSpanOption func(cfg *StartSpanConfig)
 // FinishOption is a configuration option that can be used with a Span's Finish method.
 type FinishOption func(cfg *FinishConfig)
 
-// ErrorConfig is configuration for stack trace attached to error
-type ErrorConfig struct {
-	// NoDebugStack will prevent any set errors from generating an attached stack trace tag.
-	NoDebugStack bool
-
-	// StackFrames specifies the number of stack frames to be attached in spans that finish with errors.
-	StackFrames uint
-
-	// SkipStackFrames specifies the offset at which to start reporting stack frames from the stack.
-	SkipStackFrames uint
-}
-
 // FinishConfig holds the configuration for finishing a span. It is usually passed around by
 // reference to one or more FinishOption functions which shape it into its final form.
 type FinishConfig struct {
@@ -101,8 +89,14 @@ type FinishConfig struct {
 	// finishing.
 	Error error
 
-	// ErrorConfig is configuration for stack trace attached to error
-	ErrorConfig
+	// NoDebugStack will prevent any set errors from generating an attached stack trace tag.
+	NoDebugStack bool
+
+	// StackFrames specifies the number of stack frames to be attached in spans that finish with errors.
+	StackFrames uint
+
+	// SkipStackFrames specifies the offset at which to start reporting stack frames from the stack.
+	SkipStackFrames uint
 }
 
 // StartSpanConfig holds the configuration for starting a new span. It is usually passed

--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -78,6 +78,18 @@ type StartSpanOption func(cfg *StartSpanConfig)
 // FinishOption is a configuration option that can be used with a Span's Finish method.
 type FinishOption func(cfg *FinishConfig)
 
+// ErrorConfig is configuration for stack trace attached to error
+type ErrorConfig struct {
+	// NoDebugStack will prevent any set errors from generating an attached stack trace tag.
+	NoDebugStack bool
+
+	// StackFrames specifies the number of stack frames to be attached in spans that finish with errors.
+	StackFrames uint
+
+	// SkipStackFrames specifies the offset at which to start reporting stack frames from the stack.
+	SkipStackFrames uint
+}
+
 // FinishConfig holds the configuration for finishing a span. It is usually passed around by
 // reference to one or more FinishOption functions which shape it into its final form.
 type FinishConfig struct {
@@ -89,8 +101,8 @@ type FinishConfig struct {
 	// finishing.
 	Error error
 
-	// NoDebugStack will prevent any set errors from generating an attached stack trace tag.
-	NoDebugStack bool
+	// ErrorConfig is configuration for stack trace attached to error
+	ErrorConfig
 }
 
 // StartSpanConfig holds the configuration for starting a new span. It is usually passed

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -221,3 +221,14 @@ func NoDebugStack() FinishOption {
 		cfg.NoDebugStack = true
 	}
 }
+
+// StackFrames limits the number of stack frames included into erroneous spans to n, starting from skip.
+func StackFrames(n, skip uint) FinishOption {
+	if n == 0 {
+		return NoDebugStack()
+	}
+	return func(cfg *ddtrace.FinishConfig) {
+		cfg.StackFrames = n
+		cfg.SkipStackFrames = skip
+	}
+}

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -149,14 +149,16 @@ func (s *span) setTagError(value interface{}, cfg *errorConfig) {
 }
 
 // takeStacktrace takes stacktrace
-func takeStacktrace(n, offset uint) string {
+func takeStacktrace(n, skip uint) string {
 	var builder strings.Builder
 	pcs := make([]uintptr, n)
 
 	// +2 to exclude runtime.Callers and takeStacktrace
-	numFrames := runtime.Callers(2+int(offset), pcs)
+	numFrames := runtime.Callers(2+int(skip), pcs)
+	if numFrames == 0 {
+		return ""
+	}
 	frames := runtime.CallersFrames(pcs[:numFrames])
-
 	for i := 0; ; i++ {
 		frame, more := frames.Next()
 		if i != 0 {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1074,21 +1074,33 @@ func cpspan(s *span) *span {
 	}
 }
 
-func Test_takeStackTrace(t *testing.T) {
-	t.Run("skips self", func(t *testing.T) {
+func TestTakeStackTrace(t *testing.T) {
+	t.Run("n=12", func(t *testing.T) {
 		val := takeStacktrace(12, 0)
 		// top frame should be runtime.main or runtime.goexit, in case of tests that's goexit
-		assert.Contains(t, val, "runtime.goexit", "should contain ")
-		assert.Contains(t, val, "testing.tRunner", "should contain parent function")
-		assert.Contains(t, val, "tracer.Test_takeStackTrace", "should contain this function")
+		assert.Contains(t, val, "runtime.goexit")
+		assert.Contains(t, val, "testing.tRunner")
+		assert.Contains(t, val, "tracer.TestTakeStackTrace")
 	})
 
-	t.Run("takes requested number of frames", func(t *testing.T) {
+	t.Run("n=15,skip=2", func(t *testing.T) {
+		val := takeStacktrace(3, 2)
+		// top frame should be runtime.main or runtime.goexit, in case of tests that's goexit
+		assert.Contains(t, val, "runtime.goexit")
+		numFrames := strings.Count(val, "\n\t")
+		assert.Equal(t, 1, numFrames)
+	})
+
+	t.Run("n=1", func(t *testing.T) {
 		val := takeStacktrace(1, 0)
-		assert.Contains(t, val, "tracer.Test_takeStackTrace", "should contain this function")
+		assert.Contains(t, val, "tracer.TestTakeStackTrace", "should contain this function")
 		// each frame consists of two strings separated by \n\t, thus number of frames == number of \n\t
 		numFrames := strings.Count(val, "\n\t")
-		assert.Equal(t, 1, numFrames, "should have length one if only one frame was requested")
+		assert.Equal(t, 1, numFrames)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		assert.Empty(t, takeStacktrace(100, 115))
 	})
 }
 


### PR DESCRIPTION
Adds option to limit the number of reported stack frames
as well as skip requested number of stack frames.

Fixes: https://github.com/DataDog/dd-trace-go/issues/435