### PR TITLE
ddtrace/tracer: add hostname tag to root spans

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
@@ -22,7 +23,7 @@ type config struct {
 	// sampler specifies the sampler that will be used for sampling traces.
 	sampler Sampler
 
-	// agentAddr specifies the hostname and  of the agent where the traces
+	// agentAddr specifies the hostname and port of the agent where the traces
 	// are sent to.
 	agentAddr string
 
@@ -38,6 +39,10 @@ type config struct {
 
 	// httpRoundTripper defines the http.RoundTripper used by the agent transport.
 	httpRoundTripper http.RoundTripper
+
+	// hostname is automatically assigned when the DD_TRACE_REPORT_HOSTNAME is set to true,
+	// and is added as a special tag to the root span of traces.
+	hostname string
 }
 
 // StartOption represents a function that can be provided as a parameter to Start.
@@ -48,6 +53,11 @@ func defaults(c *config) {
 	c.serviceName = filepath.Base(os.Args[0])
 	c.sampler = NewAllSampler()
 	c.agentAddr = defaultAddress
+
+	report := os.Getenv("DD_TRACE_REPORT_HOSTNAME")
+	if b, err := strconv.ParseBool(report); err == nil && b {
+		c.hostname, err = os.Hostname()
+	}
 }
 
 // WithPrioritySampling is deprecated, and priority sampling is enabled by default.

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -1,10 +1,10 @@
 package tracer
 
 import (
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
@@ -54,9 +54,12 @@ func defaults(c *config) {
 	c.sampler = NewAllSampler()
 	c.agentAddr = defaultAddress
 
-	report := os.Getenv("DD_TRACE_REPORT_HOSTNAME")
-	if b, err := strconv.ParseBool(report); err == nil && b {
+	if os.Getenv("DD_TRACE_REPORT_HOSTNAME") == "true" {
+		var err error
 		c.hostname, err = os.Hostname()
+		if err != nil {
+			log.Println("unable to look up hostname:", err)
+		}
 	}
 }
 

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -58,7 +58,7 @@ func defaults(c *config) {
 		var err error
 		c.hostname, err = os.Hostname()
 		if err != nil {
-			log.Println("unable to look up hostname:", err)
+			log.Printf("%sunable to look up hostname: %v\n", errorPrefix, err)
 		}
 	}
 }

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -318,4 +318,5 @@ const (
 	keySamplingPriority     = "_sampling_priority_v1"
 	keySamplingPriorityRate = "_sampling_priority_rate_v1"
 	keyOrigin               = "_dd.origin"
+	keyHostname             = "_dd.hostname"
 )

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -225,12 +225,17 @@ func (t *trace) finishedOne(s *span) {
 		return
 	}
 	t.finished++
-	if s == t.root && t.priority != nil {
-		// after the root has finished we lock down the priority;
-		// we won't be able to make changes to a span after finishing
-		// without causing a race condition.
-		t.root.Metrics[keySamplingPriority] = *t.priority
-		t.locked = true
+	if s == t.root {
+		if t.priority != nil {
+			// after the root has finished we lock down the priority;
+			// we won't be able to make changes to a span after finishing
+			// without causing a race condition.
+			t.root.Metrics[keySamplingPriority] = *t.priority
+			t.locked = true
+		}
+		if tr.hostname != "" {
+			t.root.Meta[keyHostname] = tr.hostname
+		}
 	}
 	if len(t.spans) != t.finished {
 		return

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -236,9 +236,6 @@ func (t *trace) finishedOne(s *span) {
 		return
 	}
 	if tr, ok := internal.GetGlobalTracer().(*tracer); ok {
-		if s == t.root && tr.hostname != "" {
-			t.root.Meta[keyHostname] = tr.hostname
-		}
 		// we have a tracer that can receive completed traces.
 		tr.pushTrace(t.spans)
 	}

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -273,6 +273,9 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 	if context == nil || context.span == nil {
 		// this is either a root span or it has a remote parent, we should add the PID.
 		span.SetTag(ext.Pid, t.pid)
+		if t.hostname != "" {
+			span.SetTag(keyHostname, t.hostname)
+		}
 	}
 	// add tags from options
 	for k, v := range opts.Tags {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -946,6 +946,28 @@ func TestTracerFlush(t *testing.T) {
 	})
 }
 
+func TestTracerReportsHostname(t *testing.T) {
+	os.Setenv("DD_TRACE_REPORT_HOSTNAME", "true")
+	defer os.Unsetenv("DD_TRACE_REPORT_HOSTNAME")
+
+	tracer, _, stop := startTestTracer()
+	defer stop()
+
+	root := tracer.StartSpan("root").(*span)
+	child := tracer.StartSpan("child", ChildOf(root.Context())).(*span)
+	child.Finish()
+	root.Finish()
+
+	assert := assert.New(t)
+
+	name, ok := root.Meta[keyHostname]
+	assert.True(ok)
+	assert.Equal(name, tracer.hostname)
+
+	_, ok = child.Meta[keyHostname]
+	assert.False(ok)
+}
+
 // BenchmarkConcurrentTracing tests the performance of spawning a lot of
 // goroutines where each one creates a trace with a parent and a child.
 func BenchmarkConcurrentTracing(b *testing.B) {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -968,7 +968,8 @@ func TestTracerReportsHostname(t *testing.T) {
 		_, ok = child.Meta[keyHostname]
 		assert.False(ok)
 	})
-	t.Run("not enabled", func(t *testing.T) {
+
+	t.Run("disabled", func(t *testing.T) {
 		tracer, _, stop := startTestTracer()
 		defer stop()
 


### PR DESCRIPTION
This functionality is controlled by the `DD_TRACE_REPORT_HOSTNAME`
environment variable. When set to "true", the root spans will
automatically have a tag added containing the hostname.