### PR TITLE
ddtrace/tracer: fix a race condition happening with asynchronous flushes

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -74,6 +74,10 @@ func (s *span) BaggageItem(key string) string {
 func (s *span) SetTag(key string, value interface{}) {
 	s.Lock()
 	defer s.Unlock()
+	s.setTagLocked(key, value)
+}
+
+func (s *span) setTagLocked(key string, value interface{}) {
 	// We don't lock spans when flushing, so we could have a data race when
 	// modifying a span as it's being flushed. This protects us against that
 	// race, since spans are marked `finished` before we flush them.

--- a/ddtrace/tracer/transport.go
+++ b/ddtrace/tracer/transport.go
@@ -15,7 +15,7 @@ import (
 var (
 	// TODO(gbbr): find a more effective way to keep this up to date,
 	// e.g. via `go generate`
-	tracerVersion = "v1.10.0"
+	tracerVersion = "v1.13.1"
 
 	// We copy the transport to avoid using the default one, as it might be
 	// augmented with tracing and we don't want these calls to be recorded.


### PR DESCRIPTION
This change fixes a race condition that would happen on rare occasions
when using the priority sampler and flushing asynchronous child spans of
a trace that would finish later than the root, usually at the same time
when the root was being flushed.