### PR TITLE
contrib/labstack/echo: Add error handling

### DIFF
--- a/contrib/labstack/echo/echotrace.go
+++ b/contrib/labstack/echo/echotrace.go
@@ -43,15 +43,8 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 			err := next(c)
 			if err != nil {
 				span.SetTag(ext.Error, err)
-			}
-
-			if err != nil && cfg.errorHandling {
-				span.SetTag(ext.Error, err)
-
 				// invokes the registered HTTP error handler
 				c.Error(err)
-				// error was already handled, don't propagate it
-				err = nil
 			}
 
 			span.SetTag(ext.HTTPCode, strconv.Itoa(c.Response().Status))

--- a/contrib/labstack/echo/echotrace_test.go
+++ b/contrib/labstack/echo/echotrace_test.go
@@ -132,7 +132,7 @@ func TestErrorHandling(t *testing.T) {
 	router.HTTPErrorHandler = func(err error, ctx echo.Context) {
 		ctx.Response().WriteHeader(http.StatusInternalServerError)
 	}
-	router.Use(Middleware(WithServiceName("foobar"), WithErrorHandling()))
+	router.Use(Middleware(WithServiceName("foobar")))
 	wantErr := errors.New("oh no")
 
 	// a handler with an error and make the requests

--- a/contrib/labstack/echo/echotrace_test.go
+++ b/contrib/labstack/echo/echotrace_test.go
@@ -2,6 +2,7 @@ package echo
 
 import (
 	"errors"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -101,6 +102,44 @@ func TestError(t *testing.T) {
 		err := wantErr
 		c.Error(err)
 		return err
+	})
+	r := httptest.NewRequest("GET", "/err", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	// verify the errors and status are correct
+	assert.True(called)
+	assert.True(traced)
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 1)
+
+	span := spans[0]
+	assert.Equal("http.request", span.OperationName())
+	assert.Equal("foobar", span.Tag(ext.ServiceName))
+	assert.Equal("500", span.Tag(ext.HTTPCode))
+	assert.Equal(wantErr.Error(), span.Tag(ext.Error).(error).Error())
+}
+
+func TestErrorHandling(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	var called, traced bool
+
+	// setup
+	router := echo.New()
+	router.HTTPErrorHandler = func(err error, ctx echo.Context) {
+		ctx.Response().WriteHeader(http.StatusInternalServerError)
+	}
+	router.Use(Middleware(WithServiceName("foobar"), WithErrorHandling()))
+	wantErr := errors.New("oh no")
+
+	// a handler with an error and make the requests
+	router.GET("/err", func(c echo.Context) error {
+		_, traced = tracer.SpanFromContext(c.Request().Context())
+		called = true
+		return wantErr
 	})
 	r := httptest.NewRequest("GET", "/err", nil)
 	w := httptest.NewRecorder()

--- a/contrib/labstack/echo/option.go
+++ b/contrib/labstack/echo/option.go
@@ -1,7 +1,8 @@
 package echo
 
 type config struct {
-	serviceName string
+	serviceName   string
+	errorHandling bool
 }
 
 // Option represents an option that can be passed to Middleware.
@@ -15,5 +16,14 @@ func defaults(cfg *config) {
 func WithServiceName(name string) Option {
 	return func(cfg *config) {
 		cfg.serviceName = name
+	}
+}
+
+// WithErrorHandling enables the middleware to call the echo context Error
+// method. This is useful to send the correct HTTP status code, as by default
+// the error handling is done after the middlewares.
+func WithErrorHandling() Option {
+	return func(cfg *config) {
+		cfg.errorHandling = true
 	}
 }

--- a/contrib/labstack/echo/option.go
+++ b/contrib/labstack/echo/option.go
@@ -1,8 +1,7 @@
 package echo
 
 type config struct {
-	serviceName   string
-	errorHandling bool
+	serviceName string
 }
 
 // Option represents an option that can be passed to Middleware.
@@ -16,14 +15,5 @@ func defaults(cfg *config) {
 func WithServiceName(name string) Option {
 	return func(cfg *config) {
 		cfg.serviceName = name
-	}
-}
-
-// WithErrorHandling enables the middleware to call the echo context Error
-// method. This is useful to send the correct HTTP status code, as by default
-// the error handling is done after the middlewares.
-func WithErrorHandling() Option {
-	return func(cfg *config) {
-		cfg.errorHandling = true
 	}
 }


### PR DESCRIPTION
~~New option to~~ handle the framework error inside this middleware. This is an important feature to return the correct HTTP status code to APM.