### PR TITLE
circleci: vendor go-redis/redis for testing.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,13 @@ jobs:
           git clone --branch v1.2.0 https://github.com/grpc/grpc-go $GRPC_DEST
 
     - run:
+        name: Vendor redis v6.15.3
+        # This step vendors go-redis/redis v6.15.3 inside our redis contrib
+        # to allow running the tests against the correct version of
+        # the redis library.
+        command: |
+          git clone --branch v6.15.3 https://github.com/go-redis/redis contrib/go-redis/redis/vendor/github.com/go-redis/redis
+    - run:
         name: Fetching dependencies
         command: |
           go get -v -t ./...
@@ -124,12 +131,4 @@ jobs:
     - run:
         name: Testing
         command: |
-          INTEGRATION=1 go test -v -race `go list ./... | grep -v contrib/go-redis/redis`
-
-    - run:
-        name: Testing contrib/go-redis/redis
-        command: |
-          (cd $GOPATH/src/github.com/go-redis/redis && git checkout v6.13.2)
-          INTEGRATION=1 go test -v -race ./contrib/go-redis/redis/...
-          (cd $GOPATH/src/github.com/go-redis/redis && git checkout master)
-          INTEGRATION=1 go test -v -race ./contrib/go-redis/redis/...
+          INTEGRATION=1 go test -v -race `go list ./...`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,19 +72,20 @@ jobs:
         # to allow running the tests against the correct version of
         # the gRPC library. The library is not committed into the
         # repository to avoid conflicts with the user's imports.
-        environment:
-          GRPC_DEST: contrib/google.golang.org/grpc.v12/vendor/google.golang.org/grpc
-        command: |
-          mkdir -p $GRPC_DEST
-          git clone --branch v1.2.0 https://github.com/grpc/grpc-go $GRPC_DEST
+        command: >
+          git clone --branch v1.2.0
+          https://github.com/grpc/grpc-go
+          contrib/google.golang.org/grpc.v12/vendor/google.golang.org/grpc
 
     - run:
         name: Vendor redis v6.15.3
         # This step vendors go-redis/redis v6.15.3 inside our redis contrib
         # to allow running the tests against the correct version of
         # the redis library.
-        command: |
-          git clone --branch v6.15.3 https://github.com/go-redis/redis contrib/go-redis/redis/vendor/github.com/go-redis/redis
+        command: >
+          git clone --branch v6.15.3
+          https://github.com/go-redis/redis
+          contrib/go-redis/redis/vendor/github.com/go-redis/redis
     - run:
         name: Fetching dependencies
         command: |


### PR DESCRIPTION
The redis package has new development on their master branch for a v7 release, and there are significant API changes. The current contrib may need a rewrite once that API is stable and released. In the meantime, this pins the version of redis that we test against, while still making sure users can choose their own version.

I'm assuming that any users who had been using master would have hit some of the breaking changes and already decided to pick a tag of their own to keep their bits working.
Committing a vendored version into the tree would override the version selected by those users, which isn't very good at the moment.
Once the redis package has a release or RC of v7, we can decide about different import paths for this package. Until then, I think the correct fix is just within our CI.

Fixes #448.