### PR TITLE
internal/version: bump version to 1.16.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,4 +3,4 @@ package version
 // Tag specifies the current release tag. It needs to be manually
 // updated. A test checks that the value of Tag never points to a
 // git tag that is older than HEAD.
-const Tag = "v1.15.0"
+const Tag = "v1.16.0"


### PR DESCRIPTION
A version bump PR to follow the release of 1.15.0.
It should be merged shortly after publishing that release so the CI check will still pass.
After that, active PRs may need rebasing.