### PR TITLE
contrib/labstack/echo: Add analytics option

### DIFF
--- a/contrib/labstack/echo/echotrace.go
+++ b/contrib/labstack/echo/echotrace.go
@@ -30,6 +30,9 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 				tracer.Tag(ext.HTTPURL, request.URL.Path),
 			}
 
+			if rate := cfg.analyticsRate; rate > 0 {
+				opts = append(opts, tracer.Tag(ext.EventSampleRate, rate))
+			}
 			if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(request.Header)); err == nil {
 				opts = append(opts, tracer.ChildOf(spanctx))
 			}

--- a/contrib/labstack/echo/option.go
+++ b/contrib/labstack/echo/option.go
@@ -1,7 +1,8 @@
 package echo
 
 type config struct {
-	serviceName string
+	serviceName   string
+	analyticsRate float64
 }
 
 // Option represents an option that can be passed to Middleware.
@@ -15,5 +16,21 @@ func defaults(cfg *config) {
 func WithServiceName(name string) Option {
 	return func(cfg *config) {
 		cfg.serviceName = name
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) Option {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(0.0)
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) Option {
+	return func(cfg *config) {
+		cfg.analyticsRate = rate
 	}
 }


### PR DESCRIPTION
New option to enable analytics for the Labstack Echo framework.