### PR TITLE
ddtrace/tracer: add error.details tag

### DIFF
--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -57,6 +57,9 @@ const (
 	// ErrorStack specifies the stack dump.
 	ErrorStack = "error.stack"
 
+	// ErrorDetails holds details about an error which implements a formatter.
+	ErrorDetails = "error.details"
+
 	// Environment specifies the environment to use with a trace.
 	Environment = "env"
 

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -12,9 +12,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/tinylib/msgp/msgp"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+
+	"github.com/tinylib/msgp/msgp"
+	"golang.org/x/xerrors"
 )
 
 type (
@@ -137,6 +139,13 @@ func (s *span) setTagError(value interface{}, cfg *errorConfig) {
 			} else {
 				s.Meta[ext.ErrorStack] = takeStacktrace(cfg.stackFrames, cfg.stackSkip)
 			}
+		}
+		switch v.(type) {
+		case xerrors.Formatter:
+			s.Meta[ext.ErrorDetails] = fmt.Sprintf("%+v", v)
+		case fmt.Formatter:
+			// pkg/errors approach
+			s.Meta[ext.ErrorDetails] = fmt.Sprintf("%+v", v)
 		}
 	case nil:
 		// no error


### PR DESCRIPTION
In accordance to the new [errors spec](https://go.googlesource.com/proposal/+/master/design/29934-error-values.md) coming in go1.13, this change ensures that when an error has details to display (such as a localized stack trace), they are printed as part of another tag called `error.details`. A special use case is added to provide support for `pkg/errors`, which respects the same logic by implementing `fmt.Formatter`. The `go1.13` approach takes precedence over `pkg/errors`.

Closes #445