### PR TITLE
{ddtrace/tracer,internal/globalconfig,contrib/*}: allow setting analytics rate to 0.0

### DIFF
--- a/contrib/Shopify/sarama/option.go
+++ b/contrib/Shopify/sarama/option.go
@@ -1,5 +1,9 @@
 package sarama
 
+import (
+	"math"
+)
+
 type config struct {
 	serviceName   string
 	analyticsRate float64
@@ -8,6 +12,7 @@ type config struct {
 func defaults(cfg *config) {
 	cfg.serviceName = "kafka"
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
+	cfg.analyticsRate = math.NaN()
 }
 
 // An Option is used to customize the config for the sarama tracer.
@@ -22,16 +27,23 @@ func WithServiceName(name string) Option {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) Option {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *config) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) Option {
 	return func(cfg *config) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/Shopify/sarama/sarama.go
+++ b/contrib/Shopify/sarama/sarama.go
@@ -2,6 +2,8 @@
 package sarama // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/Shopify/sarama"
 
 import (
+	"math"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -44,7 +46,7 @@ func WrapPartitionConsumer(pc sarama.PartitionConsumer, opts ...Option) sarama.P
 				tracer.Tag("partition", msg.Partition),
 				tracer.Tag("offset", msg.Offset),
 			}
-			if cfg.analyticsRate > 0 {
+			if !math.IsNaN(cfg.analyticsRate) {
 				opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 			}
 			// kafka supports headers, so try to extract a span context
@@ -242,7 +244,7 @@ func startProducerSpan(cfg *config, version sarama.KafkaVersion, msg *sarama.Pro
 		tracer.ResourceName("Produce Topic " + msg.Topic),
 		tracer.SpanType(ext.SpanTypeMessageProducer),
 	}
-	if cfg.analyticsRate > 0 {
+	if !math.IsNaN(cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 	}
 	// if there's a span context in the headers, use that as the parent

--- a/contrib/aws/aws-sdk-go/aws/aws.go
+++ b/contrib/aws/aws-sdk-go/aws/aws.go
@@ -2,6 +2,7 @@
 package aws // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/aws/aws-sdk-go/aws"
 
 import (
+	"math"
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -53,7 +54,7 @@ func (h *handlers) Send(req *request.Request) {
 		tracer.Tag(ext.HTTPMethod, req.Operation.HTTPMethod),
 		tracer.Tag(ext.HTTPURL, req.HTTPRequest.URL.String()),
 	}
-	if h.cfg.analyticsRate > 0 {
+	if !math.IsNaN(h.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, h.cfg.analyticsRate))
 	}
 	_, ctx := tracer.StartSpanFromContext(req.Context(), h.operationName(req), opts...)

--- a/contrib/aws/aws-sdk-go/aws/option.go
+++ b/contrib/aws/aws-sdk-go/aws/option.go
@@ -1,5 +1,9 @@
 package aws
 
+import (
+	"math"
+)
+
 type config struct {
 	serviceName   string
 	analyticsRate float64
@@ -10,6 +14,7 @@ type Option func(*config)
 
 func defaults(cfg *config) {
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
+	cfg.analyticsRate = math.NaN()
 }
 
 // WithServiceName sets the given service name for the dialled connection.
@@ -23,16 +28,23 @@ func WithServiceName(name string) Option {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) Option {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *config) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) Option {
 	return func(cfg *config) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/bradfitz/gomemcache/memcache/memcache.go
+++ b/contrib/bradfitz/gomemcache/memcache/memcache.go
@@ -8,6 +8,7 @@ package memcache // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/bradfitz/gom
 
 import (
 	"context"
+	"math"
 
 	"github.com/bradfitz/gomemcache/memcache"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
@@ -61,8 +62,8 @@ func (c *Client) startSpan(resourceName string) ddtrace.Span {
 		tracer.ServiceName(c.cfg.serviceName),
 		tracer.ResourceName(resourceName),
 	}
-	if rate := c.cfg.analyticsRate; rate > 0 {
-		opts = append(opts, tracer.Tag(ext.EventSampleRate, rate))
+	if !math.IsNaN(c.cfg.analyticsRate) {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, c.cfg.analyticsRate))
 	}
 	span, _ := tracer.StartSpanFromContext(c.context, operationName, opts...)
 	return span

--- a/contrib/bradfitz/gomemcache/memcache/option.go
+++ b/contrib/bradfitz/gomemcache/memcache/option.go
@@ -1,5 +1,9 @@
 package memcache
 
+import (
+	"math"
+)
+
 const (
 	serviceName   = "memcached"
 	operationName = "memcached.query"
@@ -16,6 +20,7 @@ type ClientOption func(*clientConfig)
 func defaults(cfg *clientConfig) {
 	cfg.serviceName = serviceName
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
+	cfg.analyticsRate = math.NaN()
 }
 
 // WithServiceName sets the given service name for the dialled connection.
@@ -27,16 +32,23 @@ func WithServiceName(name string) ClientOption {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) ClientOption {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *clientConfig) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) ClientOption {
 	return func(cfg *clientConfig) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/confluentinc/confluent-kafka-go/kafka/kafka.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/kafka.go
@@ -2,6 +2,8 @@
 package kafka // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/confluentinc/confluent-kafka-go/kafka"
 
 import (
+	"math"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -87,7 +89,7 @@ func (c *Consumer) startSpan(msg *kafka.Message) ddtrace.Span {
 		tracer.Tag("partition", msg.TopicPartition.Partition),
 		tracer.Tag("offset", msg.TopicPartition.Offset),
 	}
-	if c.cfg.analyticsRate > 0 {
+	if !math.IsNaN(c.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, c.cfg.analyticsRate))
 	}
 	// kafka supports headers, so try to extract a span context
@@ -176,7 +178,7 @@ func (p *Producer) startSpan(msg *kafka.Message) ddtrace.Span {
 		tracer.SpanType(ext.SpanTypeMessageProducer),
 		tracer.Tag("partition", msg.TopicPartition.Partition),
 	}
-	if p.cfg.analyticsRate > 0 {
+	if !math.IsNaN(p.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, p.cfg.analyticsRate))
 	}
 	carrier := NewMessageCarrier(msg)

--- a/contrib/confluentinc/confluent-kafka-go/kafka/option.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/option.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"context"
+	"math"
 )
 
 type config struct {
@@ -18,6 +19,7 @@ func newConfig(opts ...Option) *config {
 		serviceName: "kafka",
 		ctx:         context.Background(),
 		// analyticsRate: globalconfig.AnalyticsRate(),
+		analyticsRate: math.NaN(),
 	}
 	for _, opt := range opts {
 		opt(cfg)
@@ -41,16 +43,23 @@ func WithServiceName(serviceName string) Option {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) Option {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *config) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) Option {
 	return func(cfg *config) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/confluentinc/confluent-kafka-go/kafka/option_test.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/option_test.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,7 @@ import (
 func TestAnalyticsSettings(t *testing.T) {
 	t.Run("defaults", func(t *testing.T) {
 		cfg := newConfig()
-		assert.Equal(t, 0.0, cfg.analyticsRate)
+		assert.True(t, math.IsNaN(cfg.analyticsRate))
 	})
 
 	t.Run("global", func(t *testing.T) {

--- a/contrib/database/sql/driver.go
+++ b/contrib/database/sql/driver.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"math"
 	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql/internal"
@@ -68,8 +69,8 @@ func (tp *traceParams) tryTrace(ctx context.Context, resource string, query stri
 		tracer.ServiceName(tp.config.serviceName),
 		tracer.StartTime(startTime),
 	}
-	if rate := tp.config.analyticsRate; rate > 0 {
-		opts = append(opts, tracer.Tag(ext.EventSampleRate, rate))
+	if !math.IsNaN(tp.config.analyticsRate) {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, tp.config.analyticsRate))
 	}
 	span, _ := tracer.StartSpanFromContext(ctx, name, opts...)
 	if query != "" {

--- a/contrib/database/sql/option.go
+++ b/contrib/database/sql/option.go
@@ -1,5 +1,9 @@
 package sql
 
+import (
+	"math"
+)
+
 type registerConfig struct {
 	serviceName   string
 	analyticsRate float64
@@ -11,6 +15,7 @@ type RegisterOption func(*registerConfig)
 func defaults(cfg *registerConfig) {
 	// default cfg.serviceName set in Register based on driver name
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
+	cfg.analyticsRate = math.NaN()
 }
 
 // WithServiceName sets the given service name for the registered driver.
@@ -22,16 +27,23 @@ func WithServiceName(name string) RegisterOption {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) RegisterOption {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *registerConfig) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) RegisterOption {
 	return func(cfg *registerConfig) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/emicklei/go-restful/option.go
+++ b/contrib/emicklei/go-restful/option.go
@@ -1,6 +1,10 @@
 package restful
 
-import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+import (
+	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+)
 
 type config struct {
 	serviceName   string
@@ -26,16 +30,23 @@ func WithServiceName(name string) Option {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) Option {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *config) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) Option {
 	return func(cfg *config) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/emicklei/go-restful/restful.go
+++ b/contrib/emicklei/go-restful/restful.go
@@ -2,6 +2,7 @@
 package restful
 
 import (
+	"math"
 	"strconv"
 
 	"github.com/emicklei/go-restful"
@@ -25,7 +26,7 @@ func FilterFunc(configOpts ...Option) restful.FilterFunction {
 			tracer.Tag(ext.HTTPMethod, req.Request.Method),
 			tracer.Tag(ext.HTTPURL, req.Request.URL.Path),
 		}
-		if cfg.analyticsRate > 0 {
+		if !math.IsNaN(cfg.analyticsRate) {
 			opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 		}
 		if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(req.Request.Header)); err == nil {

--- a/contrib/garyburd/redigo/option.go
+++ b/contrib/garyburd/redigo/option.go
@@ -1,5 +1,9 @@
 package redigo // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/garyburd/redigo"
 
+import (
+	"math"
+)
+
 type dialConfig struct {
 	serviceName   string
 	analyticsRate float64
@@ -11,6 +15,7 @@ type DialOption func(*dialConfig)
 func defaults(cfg *dialConfig) {
 	cfg.serviceName = "redis.conn"
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
+	cfg.analyticsRate = math.NaN()
 }
 
 // WithServiceName sets the given service name for the dialled connection.
@@ -22,16 +27,23 @@ func WithServiceName(name string) DialOption {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) DialOption {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *dialConfig) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) DialOption {
 	return func(cfg *dialConfig) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/garyburd/redigo/redigo.go
+++ b/contrib/garyburd/redigo/redigo.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"net"
 	"net/url"
 	"strconv"
@@ -95,8 +96,8 @@ func (tc Conn) newChildSpan(ctx context.Context) ddtrace.Span {
 		tracer.SpanType(ext.SpanTypeRedis),
 		tracer.ServiceName(p.config.serviceName),
 	}
-	if rate := p.config.analyticsRate; rate > 0 {
-		opts = append(opts, tracer.Tag(ext.EventSampleRate, rate))
+	if !math.IsNaN(p.config.analyticsRate) {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, p.config.analyticsRate))
 	}
 	span, _ := tracer.StartSpanFromContext(ctx, "redis.command", opts...)
 	span.SetTag("out.network", p.network)

--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -3,6 +3,7 @@ package gin // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/gin-gonic/gin"
 
 import (
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 
@@ -28,7 +29,7 @@ func Middleware(service string, opts ...Option) gin.HandlerFunc {
 			tracer.Tag(ext.HTTPMethod, c.Request.Method),
 			tracer.Tag(ext.HTTPURL, c.Request.URL.Path),
 		}
-		if cfg.analyticsRate > 0 {
+		if !math.IsNaN(cfg.analyticsRate) {
 			opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 		}
 		if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(c.Request.Header)); err == nil {

--- a/contrib/gin-gonic/gin/option.go
+++ b/contrib/gin-gonic/gin/option.go
@@ -1,6 +1,10 @@
 package gin
 
-import "gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+import (
+	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+)
 
 type config struct {
 	analyticsRate float64
@@ -17,16 +21,23 @@ type Option func(*config)
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) Option {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *config) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) Option {
 	return func(cfg *config) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/globalsign/mgo/mgo.go
+++ b/contrib/globalsign/mgo/mgo.go
@@ -2,6 +2,7 @@
 package mgo // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/globalsign/mgo"
 
 import (
+	"math"
 	"strings"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
@@ -43,7 +44,7 @@ func newChildSpanFromContext(cfg *mongoConfig, tags map[string]string) ddtrace.S
 		tracer.ServiceName(cfg.serviceName),
 		tracer.ResourceName("mongodb.query"),
 	}
-	if cfg.analyticsRate > 0 {
+	if !math.IsNaN(cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 	}
 	span, _ := tracer.StartSpanFromContext(cfg.ctx, "mongodb.query", opts...)

--- a/contrib/globalsign/mgo/option.go
+++ b/contrib/globalsign/mgo/option.go
@@ -2,6 +2,7 @@ package mgo
 
 import (
 	"context"
+	"math"
 )
 
 type mongoConfig struct {
@@ -15,6 +16,7 @@ func newConfig() *mongoConfig {
 		serviceName: "mongodb",
 		ctx:         context.Background(),
 		// analyticsRate: globalconfig.AnalyticsRate(),
+		analyticsRate: math.NaN(),
 	}
 }
 
@@ -37,16 +39,23 @@ func WithContext(ctx context.Context) DialOption {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) DialOption {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *mongoConfig) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) DialOption {
 	return func(cfg *mongoConfig) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/go-chi/chi/chi.go
+++ b/contrib/go-chi/chi/chi.go
@@ -3,6 +3,7 @@ package chi // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/go-chi/chi"
 
 import (
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 
@@ -29,7 +30,7 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 				tracer.Tag(ext.HTTPMethod, r.Method),
 				tracer.Tag(ext.HTTPURL, r.URL.Path),
 			}
-			if cfg.analyticsRate > 0 {
+			if !math.IsNaN(cfg.analyticsRate) {
 				opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 			}
 			if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(r.Header)); err == nil {

--- a/contrib/go-chi/chi/option.go
+++ b/contrib/go-chi/chi/option.go
@@ -1,6 +1,8 @@
 package chi
 
 import (
+	"math"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
@@ -36,16 +38,23 @@ func WithSpanOptions(opts ...ddtrace.StartSpanOption) Option {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) Option {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *config) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) Option {
 	return func(cfg *config) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/go-redis/redis/option.go
+++ b/contrib/go-redis/redis/option.go
@@ -1,5 +1,9 @@
 package redis // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/go-redis/redis"
 
+import (
+	"math"
+)
+
 type clientConfig struct {
 	serviceName   string
 	analyticsRate float64
@@ -11,6 +15,7 @@ type ClientOption func(*clientConfig)
 func defaults(cfg *clientConfig) {
 	cfg.serviceName = "redis.client"
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
+	cfg.analyticsRate = math.NaN()
 }
 
 // WithServiceName sets the given service name for the client.
@@ -22,16 +27,23 @@ func WithServiceName(name string) ClientOption {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) ClientOption {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *clientConfig) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) ClientOption {
 	return func(cfg *clientConfig) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/go-redis/redis/redis.go
+++ b/contrib/go-redis/redis/redis.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"net"
 	"strconv"
 	"strings"
@@ -105,8 +106,8 @@ func (c *Pipeliner) execWithContext(ctx context.Context) ([]redis.Cmder, error) 
 		tracer.Tag(ext.TargetPort, p.port),
 		tracer.Tag("out.db", p.db),
 	}
-	if rate := p.config.analyticsRate; rate > 0 {
-		opts = append(opts, tracer.Tag(ext.EventSampleRate, rate))
+	if !math.IsNaN(p.config.analyticsRate) {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, p.config.analyticsRate))
 	}
 	span, _ := tracer.StartSpanFromContext(ctx, "redis.command", opts...)
 	cmds, err := c.Pipeliner.Exec()

--- a/contrib/gocql/gocql/gocql.go
+++ b/contrib/gocql/gocql/gocql.go
@@ -4,6 +4,7 @@ package gocql // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/gocql/gocql"
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -87,8 +88,8 @@ func (tq *Query) newChildSpan(ctx context.Context) ddtrace.Span {
 		tracer.Tag(ext.CassandraPaginated, fmt.Sprintf("%t", p.paginated)),
 		tracer.Tag(ext.CassandraKeyspace, p.keyspace),
 	}
-	if rate := p.config.analyticsRate; rate > 0 {
-		opts = append(opts, tracer.Tag(ext.EventSampleRate, rate))
+	if !math.IsNaN(p.config.analyticsRate) {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, p.config.analyticsRate))
 	}
 	span, _ := tracer.StartSpanFromContext(ctx, ext.CassandraQuery, opts...)
 	return span

--- a/contrib/gocql/gocql/option.go
+++ b/contrib/gocql/gocql/option.go
@@ -1,5 +1,9 @@
 package gocql
 
+import (
+	"math"
+)
+
 type queryConfig struct {
 	serviceName, resourceName string
 	noDebugStack              bool
@@ -12,6 +16,7 @@ type WrapOption func(*queryConfig)
 func defaults(cfg *queryConfig) {
 	cfg.serviceName = "gocql.query"
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
+	cfg.analyticsRate = math.NaN()
 }
 
 // WithServiceName sets the given service name for the returned query.
@@ -35,17 +40,24 @@ func WithResourceName(name string) WrapOption {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) WrapOption {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *queryConfig) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) WrapOption {
 	return func(cfg *queryConfig) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }
 

--- a/contrib/gomodule/redigo/option.go
+++ b/contrib/gomodule/redigo/option.go
@@ -1,5 +1,9 @@
 package redigo // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/gomodule/redigo"
 
+import (
+	"math"
+)
+
 type dialConfig struct {
 	serviceName   string
 	analyticsRate float64
@@ -11,6 +15,7 @@ type DialOption func(*dialConfig)
 func defaults(cfg *dialConfig) {
 	cfg.serviceName = "redis.conn"
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
+	cfg.analyticsRate = math.NaN()
 }
 
 // WithServiceName sets the given service name for the dialled connection.
@@ -22,16 +27,23 @@ func WithServiceName(name string) DialOption {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) DialOption {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *dialConfig) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) DialOption {
 	return func(cfg *dialConfig) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/gomodule/redigo/redigo.go
+++ b/contrib/gomodule/redigo/redigo.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"net"
 	"net/url"
 	"strconv"
@@ -94,8 +95,8 @@ func (tc Conn) newChildSpan(ctx context.Context) ddtrace.Span {
 		tracer.SpanType(ext.SpanTypeRedis),
 		tracer.ServiceName(p.config.serviceName),
 	}
-	if rate := p.config.analyticsRate; rate > 0 {
-		opts = append(opts, tracer.Tag(ext.EventSampleRate, rate))
+	if !math.IsNaN(p.config.analyticsRate) {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, p.config.analyticsRate))
 	}
 	span, _ := tracer.StartSpanFromContext(ctx, "redis.command", opts...)
 	span.SetTag("out.network", p.network)

--- a/contrib/google.golang.org/api/api.go
+++ b/contrib/google.golang.org/api/api.go
@@ -4,6 +4,7 @@ package api // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org
 //go:generate go run make_endpoints.go
 
 import (
+	"math"
 	"net/http"
 
 	"golang.org/x/oauth2/google"
@@ -48,7 +49,7 @@ func WrapRoundTripper(transport http.RoundTripper, options ...Option) http.Round
 			}
 		}),
 	}
-	if cfg.analyticsRate > 0 {
+	if !math.IsNaN(cfg.analyticsRate) {
 		rtOpts = append(rtOpts, httptrace.RTWithAnalyticsRate(cfg.analyticsRate))
 	}
 	return httptrace.WrapRoundTripper(transport, rtOpts...)

--- a/contrib/google.golang.org/api/option.go
+++ b/contrib/google.golang.org/api/option.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"math"
 )
 
 type config struct {
@@ -15,6 +16,7 @@ func newConfig(options ...Option) *config {
 	cfg := &config{
 		ctx: context.Background(),
 		// analyticsRate: globalconfig.AnalyticsRate(),
+		analyticsRate: math.NaN(),
 	}
 	for _, opt := range options {
 		opt(cfg)
@@ -50,16 +52,23 @@ func WithServiceName(serviceName string) Option {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) Option {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *config) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) Option {
 	return func(cfg *config) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/google.golang.org/grpc.v12/grpc.go
+++ b/contrib/google.golang.org/grpc.v12/grpc.go
@@ -4,6 +4,7 @@
 package grpc // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc.v12"
 
 import (
+	"math"
 	"net"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/internal/grpcutil"
@@ -42,7 +43,7 @@ func startSpanFromContext(ctx context.Context, method, service string, rate floa
 		tracer.Tag(tagMethod, method),
 		tracer.SpanType(ext.AppTypeRPC),
 	}
-	if rate > 0 {
+	if !math.IsNaN(rate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, rate))
 	}
 	md, _ := metadata.FromContext(ctx) // nil is ok
@@ -71,7 +72,7 @@ func UnaryClientInterceptor(opts ...InterceptorOption) grpc.UnaryClientIntercept
 			tracer.Tag(tagMethod, method),
 			tracer.SpanType(ext.AppTypeRPC),
 		}
-		if cfg.analyticsRate > 0 {
+		if !math.IsNaN(cfg.analyticsRate) {
 			spanopts = append(spanopts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 		}
 		span, ctx = tracer.StartSpanFromContext(ctx, "grpc.client", spanopts...)

--- a/contrib/google.golang.org/grpc.v12/option.go
+++ b/contrib/google.golang.org/grpc.v12/option.go
@@ -1,5 +1,9 @@
 package grpc
 
+import (
+	"math"
+)
+
 type interceptorConfig struct {
 	serviceName   string
 	analyticsRate float64
@@ -12,6 +16,7 @@ type InterceptorOption func(*interceptorConfig)
 func defaults(cfg *interceptorConfig) {
 	// cfg.serviceName default set in interceptor
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
+	cfg.analyticsRate = math.NaN()
 }
 
 // WithServiceName sets the given service name for the intercepted client.
@@ -23,16 +28,23 @@ func WithServiceName(name string) InterceptorOption {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) InterceptorOption {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *interceptorConfig) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) InterceptorOption {
 	return func(cfg *interceptorConfig) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/google.golang.org/grpc/grpc.go
+++ b/contrib/google.golang.org/grpc/grpc.go
@@ -5,6 +5,7 @@ package grpc // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.or
 
 import (
 	"io"
+	"math"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/internal/grpcutil"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
@@ -26,7 +27,7 @@ func startSpanFromContext(
 		tracer.Tag(tagMethod, method),
 		tracer.SpanType(ext.AppTypeRPC),
 	}
-	if rate > 0 {
+	if !math.IsNaN(rate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, rate))
 	}
 	md, _ := metadata.FromIncomingContext(ctx) // nil is ok

--- a/contrib/google.golang.org/grpc/option.go
+++ b/contrib/google.golang.org/grpc/option.go
@@ -1,6 +1,8 @@
 package grpc
 
 import (
+	"math"
+
 	"google.golang.org/grpc/codes"
 )
 
@@ -42,6 +44,7 @@ func defaults(cfg *config) {
 	cfg.traceStreamMessages = true
 	cfg.nonErrorCodes = map[codes.Code]bool{codes.Canceled: true}
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
+	cfg.analyticsRate = math.NaN()
 }
 
 // WithServiceName sets the given service name for the intercepted client.
@@ -88,16 +91,23 @@ func NonErrorCodes(cs ...codes.Code) InterceptorOption {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) Option {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *config) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) Option {
 	return func(cfg *config) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/gorilla/mux/mux.go
+++ b/contrib/gorilla/mux/mux.go
@@ -2,6 +2,7 @@
 package mux // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/gorilla/mux"
 
 import (
+	"math"
 	"net/http"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httputil"
@@ -73,7 +74,7 @@ func NewRouter(opts ...RouterOption) *Router {
 	for _, fn := range opts {
 		fn(cfg)
 	}
-	if cfg.analyticsRate > 0 {
+	if !math.IsNaN(cfg.analyticsRate) {
 		cfg.spanOpts = append(cfg.spanOpts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 	}
 	return &Router{

--- a/contrib/gorilla/mux/option.go
+++ b/contrib/gorilla/mux/option.go
@@ -1,6 +1,8 @@
 package mux
 
 import (
+	"math"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
@@ -36,16 +38,23 @@ func WithSpanOptions(opts ...ddtrace.StartSpanOption) RouterOption {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) RouterOption {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *routerConfig) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) RouterOption {
 	return func(cfg *routerConfig) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/graph-gophers/graphql-go/graphql.go
+++ b/contrib/graph-gophers/graphql-go/graphql.go
@@ -9,6 +9,7 @@ package graphql // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/graph-gophers
 import (
 	"context"
 	"fmt"
+	"math"
 
 	"github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/introspection"
@@ -38,7 +39,7 @@ func (t *Tracer) TraceQuery(ctx context.Context, queryString string, operationNa
 		tracer.ServiceName(t.cfg.serviceName),
 		tracer.Tag(tagGraphqlQuery, queryString),
 	}
-	if t.cfg.analyticsRate > 0 {
+	if !math.IsNaN(t.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, t.cfg.analyticsRate))
 	}
 	span, ctx := tracer.StartSpanFromContext(ctx, "graphql.request", opts...)
@@ -64,7 +65,7 @@ func (t *Tracer) TraceField(ctx context.Context, label string, typeName string, 
 		tracer.Tag(tagGraphqlField, fieldName),
 		tracer.Tag(tagGraphqlType, typeName),
 	}
-	if t.cfg.analyticsRate > 0 {
+	if !math.IsNaN(t.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, t.cfg.analyticsRate))
 	}
 	span, ctx := tracer.StartSpanFromContext(ctx, "graphql.field", opts...)

--- a/contrib/graph-gophers/graphql-go/option.go
+++ b/contrib/graph-gophers/graphql-go/option.go
@@ -1,5 +1,9 @@
 package graphql
 
+import (
+	"math"
+)
+
 type config struct {
 	serviceName   string
 	analyticsRate float64
@@ -11,6 +15,7 @@ type Option func(*config)
 func defaults(cfg *config) {
 	cfg.serviceName = "graphql.server"
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
+	cfg.analyticsRate = math.NaN()
 }
 
 // WithServiceName sets the given service name for the client.
@@ -22,16 +27,23 @@ func WithServiceName(name string) Option {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) Option {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *config) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) Option {
 	return func(cfg *config) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/julienschmidt/httprouter/httprouter.go
+++ b/contrib/julienschmidt/httprouter/httprouter.go
@@ -2,6 +2,7 @@
 package httprouter // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/julienschmidt/httprouter"
 
 import (
+	"math"
 	"net/http"
 	"strings"
 
@@ -25,7 +26,7 @@ func New(opts ...RouterOption) *Router {
 	for _, fn := range opts {
 		fn(cfg)
 	}
-	if cfg.analyticsRate > 0 {
+	if !math.IsNaN(cfg.analyticsRate) {
 		cfg.spanOpts = append(cfg.spanOpts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 	}
 	return &Router{httprouter.New(), cfg}

--- a/contrib/julienschmidt/httprouter/option.go
+++ b/contrib/julienschmidt/httprouter/option.go
@@ -1,6 +1,8 @@
 package httprouter
 
 import (
+	"math"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
@@ -35,16 +37,23 @@ func WithSpanOptions(opts ...ddtrace.StartSpanOption) RouterOption {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) RouterOption {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *routerConfig) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) RouterOption {
 	return func(cfg *routerConfig) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/labstack/echo/echotrace.go
+++ b/contrib/labstack/echo/echotrace.go
@@ -2,6 +2,7 @@
 package echo
 
 import (
+	"math"
 	"strconv"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
@@ -30,8 +31,8 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 				tracer.Tag(ext.HTTPURL, request.URL.Path),
 			}
 
-			if rate := cfg.analyticsRate; rate > 0 {
-				opts = append(opts, tracer.Tag(ext.EventSampleRate, rate))
+			if !math.IsNaN(cfg.analyticsRate) {
+				opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 			}
 			if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(request.Header)); err == nil {
 				opts = append(opts, tracer.ChildOf(spanctx))

--- a/contrib/labstack/echo/option.go
+++ b/contrib/labstack/echo/option.go
@@ -1,5 +1,9 @@
 package echo
 
+import (
+	"math"
+)
+
 type config struct {
 	serviceName   string
 	analyticsRate float64
@@ -10,6 +14,7 @@ type Option func(*config)
 
 func defaults(cfg *config) {
 	cfg.serviceName = "echo"
+	cfg.analyticsRate = math.NaN()
 }
 
 // WithServiceName sets the given service name for the system.
@@ -21,16 +26,23 @@ func WithServiceName(name string) Option {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) Option {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *config) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) Option {
 	return func(cfg *config) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/mongodb/mongo-go-driver/mongo/mongo.go
+++ b/contrib/mongodb/mongo-go-driver/mongo/mongo.go
@@ -7,6 +7,7 @@ package mongo
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 
@@ -41,7 +42,7 @@ func (m *monitor) Started(ctx context.Context, evt *event.CommandStartedEvent) {
 		tracer.Tag(ext.PeerHostname, hostname),
 		tracer.Tag(ext.PeerPort, port),
 	}
-	if m.cfg.analyticsRate > 0 {
+	if !math.IsNaN(m.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, m.cfg.analyticsRate))
 	}
 	span, _ := tracer.StartSpanFromContext(ctx, "mongodb.query", opts...)

--- a/contrib/mongodb/mongo-go-driver/mongo/option.go
+++ b/contrib/mongodb/mongo-go-driver/mongo/option.go
@@ -1,5 +1,9 @@
 package mongo
 
+import (
+	"math"
+)
+
 type config struct {
 	serviceName   string
 	analyticsRate float64
@@ -11,6 +15,7 @@ type Option func(*config)
 func defaults(cfg *config) {
 	cfg.serviceName = "mongo"
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
+	cfg.analyticsRate = math.NaN()
 }
 
 // WithServiceName sets the given service name for the dialled connection.
@@ -24,16 +29,23 @@ func WithServiceName(name string) Option {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) Option {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *config) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) Option {
 	return func(cfg *config) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/net/http/http.go
+++ b/contrib/net/http/http.go
@@ -2,6 +2,7 @@
 package http // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
 
 import (
+	"math"
 	"net/http"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httputil"
@@ -38,7 +39,7 @@ func (mux *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, route := mux.Handler(r)
 	resource := r.Method + " " + route
 	opts := mux.cfg.spanOpts
-	if mux.cfg.analyticsRate > 0 {
+	if !math.IsNaN(mux.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, mux.cfg.analyticsRate))
 	}
 	httputil.TraceAndServe(mux.ServeMux, w, r, mux.cfg.serviceName, resource, opts...)

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"math"
 	"net/http"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
@@ -33,17 +34,24 @@ func WithServiceName(name string) MuxOption {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) MuxOption {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *config) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) MuxOption {
 	return func(cfg *config) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }
 
@@ -97,16 +105,23 @@ func WithAfter(f RoundTripperAfterFunc) RoundTripperOption {
 
 // RTWithAnalytics enables Trace Analytics for all started spans.
 func RTWithAnalytics(on bool) RoundTripperOption {
-	if on {
-		return RTWithAnalyticsRate(1.0)
+	return func(cfg *roundTripperConfig) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return RTWithAnalyticsRate(0.0)
 }
 
 // RTWithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func RTWithAnalyticsRate(rate float64) RoundTripperOption {
 	return func(cfg *roundTripperConfig) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/net/http/roundtripper.go
+++ b/contrib/net/http/roundtripper.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"fmt"
+	"math"
 	"net/http"
 	"os"
 	"strconv"
@@ -25,8 +26,8 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (res *http.Response, err er
 		tracer.Tag(ext.HTTPMethod, req.Method),
 		tracer.Tag(ext.HTTPURL, req.URL.Path),
 	}
-	if rate := rt.cfg.analyticsRate; rate > 0 {
-		opts = append(opts, tracer.Tag(ext.EventSampleRate, rate))
+	if !math.IsNaN(rt.cfg.analyticsRate) {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, rt.cfg.analyticsRate))
 	}
 	span, ctx := tracer.StartSpanFromContext(req.Context(), defaultResourceName, opts...)
 	defer func() {

--- a/contrib/olivere/elastic/elastictrace.go
+++ b/contrib/olivere/elastic/elastictrace.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -49,7 +50,7 @@ func (t *httpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		tracer.Tag("elasticsearch.url", url),
 		tracer.Tag("elasticsearch.params", req.URL.Query().Encode()),
 	}
-	if t.config.analyticsRate > 0 {
+	if !math.IsNaN(t.config.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, t.config.analyticsRate))
 	}
 	span, _ := tracer.StartSpanFromContext(req.Context(), "elasticsearch.query", opts...)

--- a/contrib/syndtr/goleveldb/leveldb/leveldb.go
+++ b/contrib/syndtr/goleveldb/leveldb/leveldb.go
@@ -3,6 +3,7 @@ package leveldb // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/syndtr/goleve
 
 import (
 	"context"
+	"math"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
@@ -263,7 +264,7 @@ func startSpan(cfg *config, name string) ddtrace.Span {
 		tracer.ServiceName(cfg.serviceName),
 		tracer.ResourceName(name),
 	}
-	if cfg.analyticsRate > 0 {
+	if !math.IsNaN(cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 	}
 	span, _ := tracer.StartSpanFromContext(cfg.ctx, "leveldb.query", opts...)

--- a/contrib/syndtr/goleveldb/leveldb/option.go
+++ b/contrib/syndtr/goleveldb/leveldb/option.go
@@ -2,6 +2,7 @@ package leveldb
 
 import (
 	"context"
+	"math"
 )
 
 type config struct {
@@ -15,6 +16,7 @@ func newConfig(opts ...Option) *config {
 		serviceName: "leveldb",
 		ctx:         context.Background(),
 		// cfg.analyticsRate: globalconfig.AnalyticsRate(),
+		analyticsRate: math.NaN(),
 	}
 	for _, opt := range opts {
 		opt(cfg)
@@ -41,16 +43,23 @@ func WithServiceName(serviceName string) Option {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) Option {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *config) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) Option {
 	return func(cfg *config) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/contrib/tidwall/buntdb/buntdb.go
+++ b/contrib/tidwall/buntdb/buntdb.go
@@ -2,6 +2,7 @@ package buntdb
 
 import (
 	"context"
+	"math"
 	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
@@ -91,7 +92,7 @@ func (tx *Tx) startSpan(name string) ddtrace.Span {
 		tracer.ServiceName(tx.cfg.serviceName),
 		tracer.ResourceName(name),
 	}
-	if tx.cfg.analyticsRate > 0 {
+	if !math.IsNaN(tx.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, tx.cfg.analyticsRate))
 	}
 	span, _ := tracer.StartSpanFromContext(tx.cfg.ctx, "buntdb.query", opts...)

--- a/contrib/tidwall/buntdb/option.go
+++ b/contrib/tidwall/buntdb/option.go
@@ -1,6 +1,9 @@
 package buntdb
 
-import "context"
+import (
+	"context"
+	"math"
+)
 
 type config struct {
 	ctx           context.Context
@@ -12,6 +15,7 @@ func defaults(cfg *config) {
 	cfg.serviceName = "buntdb"
 	cfg.ctx = context.Background()
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
+	cfg.analyticsRate = math.NaN()
 }
 
 // An Option customizes the config.
@@ -33,16 +37,23 @@ func WithServiceName(serviceName string) Option {
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) Option {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *config) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) Option {
 	return func(cfg *config) {
-		cfg.analyticsRate = rate
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
 	}
 }

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -1,6 +1,7 @@
 package tracer
 
 import (
+	"math"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -145,16 +146,23 @@ func WithHTTPRoundTripper(r http.RoundTripper) StartOption {
 // WithAnalytics allows specifying whether Trace Search & Analytics should be enabled
 // for integrations.
 func WithAnalytics(on bool) StartOption {
-	if on {
-		return WithAnalyticsRate(1.0)
+	return func(cfg *config) {
+		if on {
+			globalconfig.SetAnalyticsRate(1.0)
+		} else {
+			globalconfig.SetAnalyticsRate(math.NaN())
+		}
 	}
-	return WithAnalyticsRate(0.0)
 }
 
 // WithAnalyticsRate sets the global sampling rate for sampling APM events.
 func WithAnalyticsRate(rate float64) StartOption {
 	return func(_ *config) {
-		globalconfig.SetAnalyticsRate(rate)
+		if rate >= 0.0 && rate <= 1.0 {
+			globalconfig.SetAnalyticsRate(rate)
+		} else {
+			globalconfig.SetAnalyticsRate(math.NaN())
+		}
 	}
 }
 

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -1,6 +1,7 @@
 package tracer
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,11 +27,11 @@ func TestTracerOptionsDefaults(t *testing.T) {
 
 	t.Run("analytics", func(t *testing.T) {
 		assert := assert.New(t)
-		assert.Equal(0., globalconfig.AnalyticsRate())
+		assert.True(math.IsNaN(globalconfig.AnalyticsRate()))
 		newTracer(WithAnalyticsRate(0.5))
 		assert.Equal(0.5, globalconfig.AnalyticsRate())
 		newTracer(WithAnalytics(false))
-		assert.Equal(0., globalconfig.AnalyticsRate())
+		assert.True(math.IsNaN(globalconfig.AnalyticsRate()))
 		newTracer(WithAnalytics(true))
 		assert.Equal(1., globalconfig.AnalyticsRate())
 	})

--- a/internal/globalconfig/globalconfig.go
+++ b/internal/globalconfig/globalconfig.go
@@ -2,9 +2,14 @@
 // and integrations.
 package globalconfig
 
-import "sync"
+import (
+	"math"
+	"sync"
+)
 
-var cfg = &config{}
+var cfg = &config{
+	analyticsRate: math.NaN(),
+}
 
 type config struct {
 	mu            sync.RWMutex


### PR DESCRIPTION
This change permits the value 0.0 for analytics rate, and will tag spans with that value.
It also changes WithAnalyticsRate to restrict valid values from 0.0 to 1.0 inclusive.

Instead of dealing with an additional boolean or using a pointer to indicate "not set", this uses `math.NaN()` to indicate when the rate has not been set and `math.IsNaN()` to check it.

An additional change in gocql was required to get this passing in CI.
I'll put a review comment on those lines, but I'm not sure why it suddenly popped up.
