### PR TITLE
contrib/net/http: add RTWithServiceName

### DIFF
--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -55,6 +55,7 @@ type roundTripperConfig struct {
 	before        RoundTripperBeforeFunc
 	after         RoundTripperAfterFunc
 	analyticsRate float64
+	serviceName   string
 }
 
 func newRoundTripperConfig() *roundTripperConfig {
@@ -96,5 +97,12 @@ func RTWithAnalytics(on bool) RoundTripperOption {
 func RTWithAnalyticsRate(rate float64) RoundTripperOption {
 	return func(cfg *roundTripperConfig) {
 		cfg.analyticsRate = rate
+	}
+}
+
+// RTWithServiceName sets the service name for the started spans.
+func RTWithServiceName(serviceName string) RoundTripperOption {
+	return func(cfg *roundTripperConfig) {
+		cfg.serviceName = serviceName
 	}
 }

--- a/contrib/net/http/roundtripper.go
+++ b/contrib/net/http/roundtripper.go
@@ -25,8 +25,11 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (res *http.Response, err er
 		tracer.Tag(ext.HTTPMethod, req.Method),
 		tracer.Tag(ext.HTTPURL, req.URL.Path),
 	}
-	if rate := rt.cfg.analyticsRate; rate > 0 {
-		opts = append(opts, tracer.Tag(ext.EventSampleRate, rate))
+	if rt.cfg.analyticsRate > 0 {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, rt.cfg.analyticsRate))
+	}
+	if rt.cfg.serviceName != "" {
+		opts = append(opts, tracer.ServiceName(rt.cfg.serviceName))
 	}
 	span, ctx := tracer.StartSpanFromContext(req.Context(), defaultResourceName, opts...)
 	defer func() {

--- a/ddtrace/mocktracer/mocktracer_test.go
+++ b/ddtrace/mocktracer/mocktracer_test.go
@@ -19,6 +19,17 @@ func TestStart(t *testing.T) {
 	}
 }
 
+func TestStartWithOptions(t *testing.T) {
+	trc := StartWithOptions(WithServiceName("yadda"))
+	if tt, ok := internal.GetGlobalTracer().(Tracer); !ok || tt != trc {
+		t.Fatal("not global tracer")
+	}
+	s := trc.(*mocktracer).StartSpan("op").(*mockspan)
+	if s.Tag(ext.ServiceName) != "yadda" {
+		t.Fatal("wrong service name in span")
+	}
+}
+
 func TestTracerStop(t *testing.T) {
 	Start().Stop()
 	if _, ok := internal.GetGlobalTracer().(*internal.NoopTracer); !ok {


### PR DESCRIPTION
Allow to specify the service name in WrapClient and WrapRoundTripper, for symmetry with e.g. the [gRPC client middleware](https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc#WithServiceName).