### PR TITLE
contrib/olivere/elastic: add customizable resource naming

### DIFF
--- a/contrib/olivere/elastic/elastictrace.go
+++ b/contrib/olivere/elastic/elastictrace.go
@@ -37,7 +37,7 @@ var bodyCutoff = 5 * 1024
 func (t *httpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	url := req.URL.Path
 	method := req.Method
-	resource := quantize(url, method)
+	resource := t.config.resourceNamer(url, method)
 	opts := []ddtrace.StartSpanOption{
 		tracer.ServiceName(t.config.serviceName),
 		tracer.SpanType(ext.SpanTypeElasticSearch),

--- a/contrib/olivere/elastic/elastictrace_test.go
+++ b/contrib/olivere/elastic/elastictrace_test.go
@@ -285,16 +285,18 @@ func TestResourceNamerSettings(t *testing.T) {
 		client, err := elasticv5.NewClient(
 			elasticv5.SetURL("http://127.0.0.1:9200"),
 			elasticv5.SetHttpClient(tc),
+			elasticv5.SetSniff(false),
+			elasticv5.SetHealthcheck(false),
 		)
 		assert.NoError(t, err)
 
 		_, err = client.Get().
-			Index("/logs_2016_05/event/_search").
+			Index("logs_2016_05/event/_search").
 			Type("tweet").
 			Id("1").Do(context.TODO())
 
 		span := mt.FinishedSpans()[0]
-		assert.Equal(t, "GET /logs_?_?/event/_search", span.Tag(ext.ResourceName))
+		assert.Equal(t, "GET /logs_?_?/event/_search/tweet/?", span.Tag(ext.ResourceName))
 	})
 
 	t.Run("custom namer", func(t *testing.T) {
@@ -305,11 +307,13 @@ func TestResourceNamerSettings(t *testing.T) {
 		client, err := elasticv5.NewClient(
 			elasticv5.SetURL("http://127.0.0.1:9200"),
 			elasticv5.SetHttpClient(tc),
+			elasticv5.SetSniff(false),
+			elasticv5.SetHealthcheck(false),
 		)
 		assert.NoError(t, err)
 
 		_, err = client.Get().
-			Index("/logs_2016_05/event/_search").
+			Index("logs_2016_05/event/_search").
 			Type("tweet").
 			Id("1").Do(context.TODO())
 

--- a/contrib/olivere/elastic/elastictrace_test.go
+++ b/contrib/olivere/elastic/elastictrace_test.go
@@ -271,6 +271,53 @@ func TestQuantize(t *testing.T) {
 	}
 }
 
+func TestResourceNamerSettings(t *testing.T) {
+	staticName := "static resource name"
+	staticNamer := func(url, method string) string {
+		return staticName
+	}
+
+	t.Run("default", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		tc := NewHTTPClient()
+		client, err := elasticv5.NewClient(
+			elasticv5.SetURL("http://127.0.0.1:9200"),
+			elasticv5.SetHttpClient(tc),
+		)
+		assert.NoError(t, err)
+
+		_, err = client.Get().
+			Index("/logs_2016_05/event/_search").
+			Type("tweet").
+			Id("1").Do(context.TODO())
+
+		span := mt.FinishedSpans()[0]
+		assert.Equal(t, "GET /logs_?_?/event/_search", span.Tag(ext.ResourceName))
+	})
+
+	t.Run("custom namer", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		tc := NewHTTPClient(WithResourceNamer(staticNamer))
+		client, err := elasticv5.NewClient(
+			elasticv5.SetURL("http://127.0.0.1:9200"),
+			elasticv5.SetHttpClient(tc),
+		)
+		assert.NoError(t, err)
+
+		_, err = client.Get().
+			Index("/logs_2016_05/event/_search").
+			Type("tweet").
+			Id("1").Do(context.TODO())
+
+		span := mt.FinishedSpans()[0]
+		assert.Equal(t, staticName, span.Tag(ext.ResourceName))
+	})
+}
+
 func TestPeek(t *testing.T) {
 	assert := assert.New(t)
 

--- a/contrib/olivere/elastic/elastictrace_test.go
+++ b/contrib/olivere/elastic/elastictrace_test.go
@@ -299,7 +299,7 @@ func TestResourceNamerSettings(t *testing.T) {
 		assert.Equal(t, "GET /logs_?_?/event/_search/tweet/?", span.Tag(ext.ResourceName))
 	})
 
-	t.Run("custom namer", func(t *testing.T) {
+	t.Run("custom", func(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 

--- a/contrib/olivere/elastic/option.go
+++ b/contrib/olivere/elastic/option.go
@@ -49,7 +49,10 @@ func WithAnalyticsRate(rate float64) ClientOption {
 	}
 }
 
-// WithResourceNamer sets a function to set the span's resource name
+// WithResourceNamer specifies a quantizing function which will be used to obtain a resource name for a given
+// ElasticSearch request, using the request's URL and method. Note that the default quantizer obfuscates
+// IDs and indexes and by replacing it, sensitive data could possibly be exposed, unless the new quantizer
+// specifically takes care of that.
 func WithResourceNamer(namer func(url, method string) string) ClientOption {
 	return func(cfg *clientConfig) {
 		cfg.resourceNamer = namer

--- a/contrib/olivere/elastic/option.go
+++ b/contrib/olivere/elastic/option.go
@@ -6,6 +6,7 @@ type clientConfig struct {
 	serviceName   string
 	transport     *http.Transport
 	analyticsRate float64
+	resourceNamer func(url, method string) string
 }
 
 // ClientOption represents an option that can be used when creating a client.
@@ -14,6 +15,7 @@ type ClientOption func(*clientConfig)
 func defaults(cfg *clientConfig) {
 	cfg.serviceName = "elastic.client"
 	cfg.transport = http.DefaultTransport.(*http.Transport)
+	cfg.resourceNamer = quantize
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
@@ -44,5 +46,12 @@ func WithAnalytics(on bool) ClientOption {
 func WithAnalyticsRate(rate float64) ClientOption {
 	return func(cfg *clientConfig) {
 		cfg.analyticsRate = rate
+	}
+}
+
+// WithResourceNamer sets a function to set the span's resource name
+func WithResourceNamer(namer func(url, method string) string) ClientOption {
+	return func(cfg *clientConfig) {
+		cfg.resourceNamer = namer
 	}
 }


### PR DESCRIPTION
This adds a ClientOption for a custom function to use in naming resources. The default is set to use the existing `quantize` function.

Fixes #460