### PR TITLE
contrib/olivere/elastic: handle gzipped body when reporting

### DIFF
--- a/contrib/olivere/elastic/elastictrace.go
+++ b/contrib/olivere/elastic/elastictrace.go
@@ -123,7 +123,6 @@ func peek(rc io.ReadCloser, encoding string, max, n int) (string, io.ReadCloser,
 	if err != nil {
 		return string(snip), rc2, err
 	}
-
 	if encoding == "gzip" {
 		// unpack the snippet
 		gzr, err := gzip.NewReader(bytes.NewReader(snip))
@@ -132,9 +131,7 @@ func peek(rc io.ReadCloser, encoding string, max, n int) (string, io.ReadCloser,
 			return string(snip), rc2, nil
 		}
 		defer gzr.Close()
-
 		snip, err = ioutil.ReadAll(gzr)
 	}
-
 	return string(snip), rc2, err
 }

--- a/contrib/olivere/elastic/elastictrace.go
+++ b/contrib/olivere/elastic/elastictrace.go
@@ -55,7 +55,8 @@ func (t *httpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	span, _ := tracer.StartSpanFromContext(req.Context(), "elasticsearch.query", opts...)
 	defer span.Finish()
 
-	snip, rc, err := peek(req.Body, req.Header.Get("Content-Encoding"), int(req.ContentLength), bodyCutoff)
+	contentEncoding := req.Header.Get("Content-Encoding")
+	snip, rc, err := peek(req.Body, contentEncoding, int(req.ContentLength), bodyCutoff)
 	if err == nil {
 		span.SetTag("elasticsearch.body", snip)
 	}
@@ -67,7 +68,7 @@ func (t *httpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		span.SetTag(ext.Error, err)
 	} else if res.StatusCode < 200 || res.StatusCode > 299 {
 		// HTTP error
-		snip, rc, err := peek(res.Body, req.Header.Get("Content-Encoding"), int(res.ContentLength), bodyCutoff)
+		snip, rc, err := peek(res.Body, contentEncoding, int(res.ContentLength), bodyCutoff)
 		if err != nil {
 			snip = http.StatusText(res.StatusCode)
 		}

--- a/contrib/olivere/elastic/elastictrace.go
+++ b/contrib/olivere/elastic/elastictrace.go
@@ -135,7 +135,7 @@ func peek(rc io.ReadCloser, gzipped bool, max, n int) (string, io.ReadCloser, er
 			return string(snip), rc2, err
 		}
 
-		snip = buf.String()
+		snip = buf.Bytes()
 	}
 
 	return string(snip), rc2, err

--- a/contrib/olivere/elastic/elastictrace.go
+++ b/contrib/olivere/elastic/elastictrace.go
@@ -100,7 +100,7 @@ func quantize(url, method string) string {
 // from to access the entire data including the snippet. max is used to specify the length
 // of the stream contained in the reader. If unknown, it should be -1. If 0 < max < n it
 // will override n.
-func peek(rc io.ReadCloser, gzipped bool, max int, n int) (string, io.ReadCloser, error) {
+func peek(rc io.ReadCloser, gzipped bool, max, n int) (string, io.ReadCloser, error) {
 	if rc == nil {
 		return "", rc, errors.New("empty stream")
 	}

--- a/contrib/olivere/elastic/elastictrace.go
+++ b/contrib/olivere/elastic/elastictrace.go
@@ -118,21 +118,22 @@ func peek(rc io.ReadCloser, encoding string, max, n int) (string, io.ReadCloser,
 	}
 	snip, err := r.Peek(n)
 	if err == io.EOF {
-		return string(snip), rc2, nil
+		err = nil
+	}
+	if err != nil {
+		return string(snip), rc2, err
 	}
 
 	if encoding == "gzip" {
 		// unpack the snippet
 		gzr, err := gzip.NewReader(bytes.NewReader(snip))
 		if err != nil {
+			// snip wasn't gzip; return it as is
 			return string(snip), rc2, nil
 		}
 		defer gzr.Close()
 
 		snip, err = ioutil.ReadAll(gzr)
-		if err != nil {
-			return string(snip), rc2, nil
-		}
 	}
 
 	return string(snip), rc2, err

--- a/contrib/olivere/elastic/elastictrace_test.go
+++ b/contrib/olivere/elastic/elastictrace_test.go
@@ -418,7 +418,7 @@ func TestPeek(t *testing.T) {
 		if tt.txt != "" {
 			readcloser = ioutil.NopCloser(bytes.NewBufferString(tt.txt))
 		}
-		snip, rc, err := peek(readcloser, tt.max, tt.n)
+		snip, rc, err := peek(readcloser, false, tt.max, tt.n)
 		assert.Equal(tt.err, err)
 		assert.Equal(tt.snip, snip)
 

--- a/contrib/olivere/elastic/elastictrace_test.go
+++ b/contrib/olivere/elastic/elastictrace_test.go
@@ -418,7 +418,7 @@ func TestPeek(t *testing.T) {
 		if tt.txt != "" {
 			readcloser = ioutil.NopCloser(bytes.NewBufferString(tt.txt))
 		}
-		snip, rc, err := peek(readcloser, false, tt.max, tt.n)
+		snip, rc, err := peek(readcloser, "", tt.max, tt.n)
 		assert.Equal(tt.err, err)
 		assert.Equal(tt.snip, snip)
 

--- a/contrib/olivere/elastic/elastictrace_test.go
+++ b/contrib/olivere/elastic/elastictrace_test.go
@@ -65,6 +65,42 @@ func TestClientV5(t *testing.T) {
 	checkErrTrace(assert, mt)
 }
 
+func TestClientV5Gzip(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	tc := NewHTTPClient(WithServiceName("my-es-service"))
+	client, err := elasticv5.NewClient(
+		elasticv5.SetURL("http://127.0.0.1:9201"),
+		elasticv5.SetHttpClient(tc),
+		elasticv5.SetSniff(false),
+		elasticv5.SetHealthcheck(false),
+		elasticv5.SetGzip(true),
+	)
+	assert.NoError(err)
+
+	_, err = client.Index().
+		Index("twitter").Id("1").
+		Type("tweet").
+		BodyString(`{"user": "test", "message": "hello"}`).
+		Do(context.TODO())
+	assert.NoError(err)
+	checkPUTTrace(assert, mt)
+
+	mt.Reset()
+	_, err = client.Get().Index("twitter").Type("tweet").
+		Id("1").Do(context.TODO())
+	assert.NoError(err)
+	checkGETTrace(assert, mt)
+
+	mt.Reset()
+	_, err = client.Get().Index("not-real-index").
+		Id("1").Do(context.TODO())
+	assert.Error(err)
+	checkErrTrace(assert, mt)
+}
+
 func TestClientErrorCutoffV3(t *testing.T) {
 	assert := assert.New(t)
 	mt := mocktracer.Start()


### PR DESCRIPTION
For contrib/olivere/elastictrace, when `elastic.SetGzip(true)` is used, the body that is reported to DataDog is a garbled mess.

<img width="1166" alt="dd-et" src="https://user-images.githubusercontent.com/70804/60058709-b52eee00-96a6-11e9-9d8b-1aca45611506.png">

This PR detects the gzip encoding and decompresses to the original string representation before calling `span.SetTag("elasticsearch.body", snip)`

Fixes #464 