### PR TITLE
ddtrace/tracer: add execution tracer entries

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -61,6 +61,7 @@ type span struct {
 
 	finished bool         `msg:"-"` // true if the span has been submitted to a tracer.
 	context  *spanContext `msg:"-"` // span propagation context
+	taskEnd  func()       // ends execution tracer (runtime/trace) task, if started
 }
 
 // Context yields the SpanContext for this Span. Note that the return
@@ -262,6 +263,9 @@ func (s *span) Finish(opts ...ddtrace.FinishOption) {
 			stackSkip:    cfg.SkipStackFrames,
 		})
 		s.Unlock()
+	}
+	if s.taskEnd != nil {
+		s.taskEnd()
 	}
 	s.finish(t)
 }

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -217,6 +217,7 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		TraceID:  id,
 		ParentID: 0,
 		Start:    startTime,
+		taskEnd:  startExecutionTracerTask(operationName),
 	}
 	if context != nil {
 		// this is a child span

--- a/ddtrace/tracer/tracer_go11.go
+++ b/ddtrace/tracer/tracer_go11.go
@@ -1,0 +1,16 @@
+// +build go1.11
+
+package tracer
+
+import (
+	"context"
+	t "runtime/trace"
+)
+
+func startExecutionTracerTask(name string) func() {
+	if !t.IsEnabled() {
+		return func() {}
+	}
+	_, task := t.NewTask(context.TODO(), name)
+	return task.End
+}

--- a/ddtrace/tracer/tracer_nongo11.go
+++ b/ddtrace/tracer/tracer_nongo11.go
@@ -1,0 +1,7 @@
+// +build !go1.11
+
+package tracer
+
+func startExecutionTracerTask(name string) func() {
+	return func() {}
+}


### PR DESCRIPTION
This change ensures that the corresponding `runtime/trace` tasks are created for each span,
making it easier to investigate performance problems when using the `go tool trace` tool.

Updates https://github.com/DataDog/dd-trace-go/issues/468