### PR TITLE
 contrib/gin-gonic/gin: Add WithResourceNamer to gintrace

### DIFF
--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -26,7 +26,7 @@ func Middleware(service string, opts ...Option) gin.HandlerFunc {
 		opt(cfg)
 	}
 	return func(c *gin.Context) {
-		resource := c.HandlerName()
+		resource := cfg.resourceNamer(c)
 		opts := []ddtrace.StartSpanOption{
 			tracer.ServiceName(service),
 			tracer.ResourceName(resource),

--- a/contrib/gin-gonic/gin/gintrace_test.go
+++ b/contrib/gin-gonic/gin/gintrace_test.go
@@ -297,8 +297,9 @@ func TestResourceNamerSettings(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	urlNamer := func(c *gin.Context) string {
-		return c.Request.URL.Path
+	staticName := "foo"
+	staticNamer := func(c *gin.Context) string {
+		return staticName
 	}
 
 	t.Run("default", func(t *testing.T) {
@@ -324,7 +325,26 @@ func TestResourceNamerSettings(t *testing.T) {
 		defer mt.Stop()
 
 		router := gin.New()
-		router.Use(Middleware("foobar", WithResourceNamer(urlNamer)))
+		router.Use(Middleware("foobar", WithResourceNamer(staticNamer)))
+
+		router.GET("/test", func(c *gin.Context) {
+			span, ok := tracer.SpanFromContext(c.Request.Context())
+			assert.True(ok)
+			assert.Equal(span.(mocktracer.Span).Tag(ext.ResourceName), staticName)
+		})
+
+		r := httptest.NewRequest("GET", "/test", nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, r)
+	})
+
+	t.Run("custom - URLPathResourceNamer", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		router := gin.New()
+		router.Use(Middleware("foobar", WithResourceNamer(URLPathResourceNamer)))
 
 		router.GET("/test", func(c *gin.Context) {
 			span, ok := tracer.SpanFromContext(c.Request.Context())

--- a/contrib/gin-gonic/gin/gintrace_test.go
+++ b/contrib/gin-gonic/gin/gintrace_test.go
@@ -310,7 +310,7 @@ func TestResourceNamerSettings(t *testing.T) {
 		router.GET("/test", func(c *gin.Context) {
 			span, ok := tracer.SpanFromContext(c.Request.Context())
 			assert.True(ok)
-			assert.Equal(span.(mocktracer.Span).Tag(ext.ResourceName), "foobar")
+			assert.Equal(span.(mocktracer.Span).Tag(ext.ResourceName), c.HandlerName())
 		})
 
 		r := httptest.NewRequest("GET", "/test", nil)

--- a/contrib/gin-gonic/gin/gintrace_test.go
+++ b/contrib/gin-gonic/gin/gintrace_test.go
@@ -338,23 +338,4 @@ func TestResourceNamerSettings(t *testing.T) {
 
 		router.ServeHTTP(w, r)
 	})
-
-	t.Run("custom - URLPathResourceNamer", func(t *testing.T) {
-		mt := mocktracer.Start()
-		defer mt.Stop()
-
-		router := gin.New()
-		router.Use(Middleware("foobar", WithResourceNamer(URLPathResourceNamer)))
-
-		router.GET("/test", func(c *gin.Context) {
-			span, ok := tracer.SpanFromContext(c.Request.Context())
-			assert.True(ok)
-			assert.Equal(span.(mocktracer.Span).Tag(ext.ResourceName), "/test")
-		})
-
-		r := httptest.NewRequest("GET", "/test", nil)
-		w := httptest.NewRecorder()
-
-		router.ServeHTTP(w, r)
-	})
 }

--- a/contrib/gin-gonic/gin/option.go
+++ b/contrib/gin-gonic/gin/option.go
@@ -8,16 +8,19 @@ package gin
 import (
 	"math"
 
+	"github.com/gin-gonic/gin"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
 type config struct {
 	analyticsRate float64
+	resourceNamer func(c *gin.Context) string
 }
 
 func newConfig() *config {
 	return &config{
 		analyticsRate: globalconfig.AnalyticsRate(),
+		resourceNamer: handlerResourceName,
 	}
 }
 
@@ -45,4 +48,16 @@ func WithAnalyticsRate(rate float64) Option {
 			cfg.analyticsRate = math.NaN()
 		}
 	}
+}
+
+// WithResourceNamer specifies a function which will be used to obtain a resource name for a given
+// gin request, using the request's context.
+func WithResourceNamer(namer func(c *gin.Context) string) Option {
+	return func(cfg *config) {
+		cfg.resourceNamer = namer
+	}
+}
+
+func handlerResourceName(c *gin.Context) string {
+	return c.HandlerName()
 }

--- a/contrib/gin-gonic/gin/option.go
+++ b/contrib/gin-gonic/gin/option.go
@@ -58,7 +58,8 @@ func WithResourceNamer(namer func(c *gin.Context) string) Option {
 	}
 }
 
-// Function for WithResourceNamer that returns the request URL path as the resource name
+// URLPathResourceNamer can be used for WithResourceNamer and returns the
+// request URL path as the resource name
 func URLPathResourceNamer(c *gin.Context) string {
 	return c.Request.URL.Path
 }

--- a/contrib/gin-gonic/gin/option.go
+++ b/contrib/gin-gonic/gin/option.go
@@ -58,6 +58,11 @@ func WithResourceNamer(namer func(c *gin.Context) string) Option {
 	}
 }
 
+// Function for WithResourceNamer that returns the request URL path as the resource name
+func URLPathResourceNamer(c *gin.Context) string {
+	return c.Request.URL.Path
+}
+
 func handlerResourceName(c *gin.Context) string {
 	return c.HandlerName()
 }

--- a/contrib/gin-gonic/gin/option.go
+++ b/contrib/gin-gonic/gin/option.go
@@ -20,7 +20,7 @@ type config struct {
 func newConfig() *config {
 	return &config{
 		analyticsRate: globalconfig.AnalyticsRate(),
-		resourceNamer: handlerResourceName,
+		resourceNamer: defaultResourceNamer,
 	}
 }
 
@@ -58,12 +58,6 @@ func WithResourceNamer(namer func(c *gin.Context) string) Option {
 	}
 }
 
-// URLPathResourceNamer can be used for WithResourceNamer and returns the
-// request URL path as the resource name
-func URLPathResourceNamer(c *gin.Context) string {
-	return c.Request.URL.Path
-}
-
-func handlerResourceName(c *gin.Context) string {
+func defaultResourceNamer(c *gin.Context) string {
 	return c.HandlerName()
 }


### PR DESCRIPTION
Addresses this issue: https://github.com/DataDog/dd-trace-go/issues/476 

Allows one to specify a custom resource namer function.