### PR TITLE
ddtrace/mocktracer: respect tracer.WithSpanID when creating a new span

### DIFF
--- a/ddtrace/mocktracer/mockspan.go
+++ b/ddtrace/mocktracer/mockspan.go
@@ -66,7 +66,10 @@ func newSpan(t *mocktracer, operationName string, cfg *ddtrace.StartSpanConfig) 
 	} else {
 		s.startTime = cfg.StartTime
 	}
-	id := nextID()
+	id := cfg.SpanID
+	if id == 0 {
+		id = nextID()
+	}
 	s.context = &spanContext{spanID: id, traceID: id, span: s}
 	if ctx, ok := cfg.Parent.(*spanContext); ok {
 		if ctx.span != nil && s.tags[ext.ServiceName] == nil {

--- a/ddtrace/mocktracer/mockspan_test.go
+++ b/ddtrace/mocktracer/mockspan_test.go
@@ -176,3 +176,11 @@ func TestSpanFinish(t *testing.T) {
 	assert.True(s.FinishTime().Before(time.Now()))
 	assert.Equal(want, s.Tag(ext.Error))
 }
+
+func TestSpanWithID(t *testing.T) {
+	spanID := uint64(123456789)
+	span := new(mocktracer).StartSpan("", tracer.WithSpanID(spanID))
+
+	assert := assert.New(t)
+	assert.Equal(spanID, span.Context().SpanID())
+}


### PR DESCRIPTION
This fix uses the same logic as in the regular tracer package.
If the specified id in WithSpanID is zero (or none is set), the
id gets chosen as usual with nextID.

Fixes #481