### PR TITLE
contrib/database/sql: add context key to support additional tags

### DIFF
--- a/contrib/database/sql/conn.go
+++ b/contrib/database/sql/conn.go
@@ -140,7 +140,7 @@ const spanTagsKey contextKey = 0 // map[string]string
 // WithSpanTags is used if you want to set the span tag in a context.
 // You can set span tag in the context like this
 //
-// WithSpanTags(ctx, map[string]string{"tag_nane":"tag_value"})
+// ctx = WithSpanTags(ctx, map[string]string{"tag_nane":"tag_value"})
 // db.QueryContext(ctx, stmt, ...)
 func WithSpanTags(ctx context.Context, tags map[string]string) context.Context {
 	return context.WithValue(ctx, spanTagsKey, tags)

--- a/contrib/database/sql/conn.go
+++ b/contrib/database/sql/conn.go
@@ -137,19 +137,10 @@ type contextKey int
 
 const spanTagsKey contextKey = 0 // map[string]string
 
-// WithSpanTags is used if you want to set the span tag in a context.
-// You can set span tag in the context like this
-//
-// ctx = WithSpanTags(ctx, map[string]string{"tag_nane":"tag_value"})
-// db.QueryContext(ctx, stmt, ...)
+// WithSpanTags creates a new context containing the given set of tags. They will be added
+// to any query created with the returned context.
 func WithSpanTags(ctx context.Context, tags map[string]string) context.Context {
 	return context.WithValue(ctx, spanTagsKey, tags)
-}
-
-// SpanTagsFromContext is used if you want to get the span tags from a context.
-func SpanTagsFromContext(ctx context.Context) (map[string]string, bool) {
-	tags, ok := ctx.Value(spanTagsKey).(map[string]string)
-	return tags, ok
 }
 
 // tryTrace will create a span using the given arguments, but will act as a no-op when err is driver.ErrSkip.
@@ -178,7 +169,7 @@ func (tp *traceParams) tryTrace(ctx context.Context, resource string, query stri
 	for k, v := range tp.meta {
 		span.SetTag(k, v)
 	}
-	if meta, ok := SpanTagsFromContext(ctx); ok {
+	if meta, ok := ctx.Value(spanTagsKey).(map[string]string); ok {
 		for k, v := range meta {
 			span.SetTag(k, v)
 		}

--- a/contrib/database/sql/conn_test.go
+++ b/contrib/database/sql/conn_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Code-Hex/dd-trace-go/ddtrace/ext"
-	"github.com/Code-Hex/dd-trace-go/ddtrace/mocktracer"
 	"github.com/google/go-cmp/cmp"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 )
 
 func TestWithSpanTags(t *testing.T) {

--- a/contrib/database/sql/conn_test.go
+++ b/contrib/database/sql/conn_test.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package sql
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestWithSpanTags(t *testing.T) {
+	type args struct {
+		ctx  context.Context
+		tags map[string]string
+	}
+	tests := []struct {
+		name   string
+		args   args
+		wantOK bool
+	}{
+		{
+			name: "valid get tags",
+			args: args{
+				ctx: context.Background(),
+				tags: map[string]string{
+					"tag": "value",
+				},
+			},
+			wantOK: true,
+		},
+		{
+			name: "invalid when context is nil",
+			args: args{
+				ctx: nil,
+				tags: map[string]string{
+					"tag": "value",
+				},
+			},
+			wantOK: false,
+		},
+		{
+			name: "invalid when tags is nil",
+			args: args{
+				ctx:  context.Background(),
+				tags: nil,
+			},
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := WithSpanTags(tt.args.ctx, tt.args.tags)
+			meta, ok := ctx.Value(spanTagsKey).(map[string]string)
+			if ok != tt.wantOK {
+				t.Errorf("got %t, want %t", ok, tt.wantOK)
+			}
+			if !reflect.DeepEqual(meta, tt.args.tags) {
+				t.Errorf("WithSpanTags() = %v, want %v", meta, tt.args.tags)
+			}
+		})
+	}
+}

--- a/contrib/database/sql/conn_test.go
+++ b/contrib/database/sql/conn_test.go
@@ -23,6 +23,7 @@ func TestWithSpanTags(t *testing.T) {
 		name   string
 		dsn    string
 		driver driver.Driver
+		opts   []RegisterOption
 	}
 	type want struct {
 		opName  string
@@ -39,6 +40,7 @@ func TestWithSpanTags(t *testing.T) {
 				name:   "mysql",
 				dsn:    "test:test@tcp(127.0.0.1:3306)/test",
 				driver: &mysql.MySQLDriver{},
+				opts:   []RegisterOption{},
 			},
 			want: want{
 				opName: "mysql.query",
@@ -55,6 +57,10 @@ func TestWithSpanTags(t *testing.T) {
 				name:   "postgres",
 				dsn:    "postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable",
 				driver: &pq.Driver{},
+				opts: []RegisterOption{
+					WithServiceName("postgres-test"),
+					WithAnalyticsRate(0.2),
+				},
 			},
 			want: want{
 				opName: "postgres.query",
@@ -69,7 +75,7 @@ func TestWithSpanTags(t *testing.T) {
 	defer mt.Stop()
 	for _, tt := range testcases {
 		t.Run(tt.name, func(t *testing.T) {
-			Register(tt.sqlRegister.name, tt.sqlRegister.driver)
+			Register(tt.sqlRegister.name, tt.sqlRegister.driver, tt.sqlRegister.opts...)
 			db, err := Open(tt.sqlRegister.name, tt.sqlRegister.dsn)
 			if err != nil {
 				log.Fatal(err)

--- a/contrib/database/sql/conn_test.go
+++ b/contrib/database/sql/conn_test.go
@@ -7,59 +7,58 @@ package sql
 
 import (
 	"context"
-	"reflect"
 	"testing"
+	"time"
+
+	"github.com/Code-Hex/dd-trace-go/ddtrace/ext"
+	"github.com/Code-Hex/dd-trace-go/ddtrace/mocktracer"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestWithSpanTags(t *testing.T) {
-	type args struct {
-		ctx  context.Context
-		tags map[string]string
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	// set tags
+	ctxTags := map[string]string{
+		"ctx_tag1": "value1",
+		"ctx_tag2": "value2",
+		"ctx_tag3": "value3",
 	}
-	tests := []struct {
-		name   string
-		args   args
-		wantOK bool
-	}{
-		{
-			name: "valid get tags",
-			args: args{
-				ctx: context.Background(),
-				tags: map[string]string{
-					"tag": "value",
-				},
-			},
-			wantOK: true,
+	ctx := WithSpanTags(context.Background(), ctxTags)
+	query := "SELECT 1"
+	startTime := time.Date(2019, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	tp := &traceParams{
+		cfg: &config{
+			serviceName: "mysql",
 		},
-		{
-			name: "invalid when context is nil",
-			args: args{
-				ctx: nil,
-				tags: map[string]string{
-					"tag": "value",
-				},
-			},
-			wantOK: false,
-		},
-		{
-			name: "invalid when tags is nil",
-			args: args{
-				ctx:  context.Background(),
-				tags: nil,
-			},
-			wantOK: false,
-		},
+		driverName: "mysql",
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := WithSpanTags(tt.args.ctx, tt.args.tags)
-			meta, ok := ctx.Value(spanTagsKey).(map[string]string)
-			if ok != tt.wantOK {
-				t.Errorf("got %t, want %t", ok, tt.wantOK)
-			}
-			if !reflect.DeepEqual(meta, tt.args.tags) {
-				t.Errorf("WithSpanTags() = %v, want %v", meta, tt.args.tags)
-			}
-		})
+
+	// try trace
+	tp.tryTrace(ctx, ext.SQLType, query, startTime, nil)
+
+	// check span
+	spans := mt.FinishedSpans()
+	if len(spans) != 1 {
+		t.Fatalf("unexpected span size: %d", len(spans))
+	}
+	tags := spans[0].Tags()
+	if len(tags) == 0 {
+		t.Fatalf("unexpected tags size: %d", len(tags))
+	}
+
+	want := map[string]interface{}{
+		"resource.name": "SELECT 1",
+		"ctx_tag1":      "value1",
+		"ctx_tag2":      "value2",
+		"ctx_tag3":      "value3",
+		"service.name":  "mysql",
+		"span.type":     "sql",
+		"_dd1.sr.eausr": 0.000000, // for analysis
+	}
+	if diff := cmp.Diff(want, tags); diff != "" {
+		t.Errorf("failed (-want, +got):\n%v", diff)
 	}
 }

--- a/contrib/database/sql/conn_test.go
+++ b/contrib/database/sql/conn_test.go
@@ -11,10 +11,11 @@ import (
 	"log"
 	"testing"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+
 	"github.com/go-sql-driver/mysql"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 )
 
 func TestWithSpanTags(t *testing.T) {

--- a/contrib/database/sql/conn_test.go
+++ b/contrib/database/sql/conn_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 )
 
@@ -80,14 +79,14 @@ func TestWithSpanTags(t *testing.T) {
 			ctx := WithSpanTags(context.Background(), tt.want.ctxTags)
 
 			rows, err := db.QueryContext(ctx, "SELECT 1")
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			rows.Close()
 
 			spans := mt.FinishedSpans()
-			require.Len(t, spans, 1)
+			assert.Len(t, spans, 1)
 
 			span := spans[0]
-			require.Equal(t, tt.want.opName, span.OperationName())
+			assert.Equal(t, tt.want.opName, span.OperationName())
 			for k, v := range tt.want.ctxTags {
 				assert.Equal(t, v, span.Tag(k), "Value mismatch on tag %s", k)
 			}

--- a/contrib/database/sql/option_test.go
+++ b/contrib/database/sql/option_test.go
@@ -8,8 +8,9 @@ package sql
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAnalyticsSettings(t *testing.T) {

--- a/contrib/database/sql/option_test.go
+++ b/contrib/database/sql/option_test.go
@@ -8,8 +8,8 @@ package sql
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
-	"gotest.tools/assert"
 )
 
 func TestAnalyticsSettings(t *testing.T) {


### PR DESCRIPTION
## What

Added span tag context key for sql tracer.
It becomes possible to set the tag dynamically.

## Why

As an example, I want to know what queries are issued for each endpoint.

Fixes #485 