### PR TITLE
circleci: vendor klog v0.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,12 +86,21 @@ jobs:
           git clone --branch v6.15.3
           https://github.com/go-redis/redis
           contrib/go-redis/redis/vendor/github.com/go-redis/redis
+
     - run:
         name: Fetching dependencies
         command: |
           go get -v -t ./...
           go get -v -u golang.org/x/lint/golint
           go get -v -u github.com/alecthomas/gometalinter
+
+    - run:
+        name: Vendor klog v0.4.0
+        # Temporary, until kubernetes/client-go#656 gets resolved.
+        command: >
+          git clone --branch v0.4.0
+          https://github.com/kubernetes/klog
+          $GOPATH/src/k8s.io/client-go/vendor/k8s.io/klog
 
     - run:
         name: Wait for MySQL

--- a/contrib/k8s.io/client-go/kubernetes/kubernetes_test.go
+++ b/contrib/k8s.io/client-go/kubernetes/kubernetes_test.go
@@ -10,11 +10,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+
+	"github.com/stretchr/testify/assert"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"


### PR DESCRIPTION
This change vendors klog v0.4.0 for the duration of the CI run. It's
temporary and should be removed once kubernetes/client-go#656 gets
resolved.