### PR TITLE
Upgrade echo version

### DIFF
--- a/contrib/labstack/echo/echotrace.go
+++ b/contrib/labstack/echo/echotrace.go
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
-	"github.com/labstack/echo"
+	"github.com/labstack/echo/v4"
 )
 
 // Middleware returns echo middleware which will trace incoming requests.

--- a/contrib/labstack/echo/echotrace_test.go
+++ b/contrib/labstack/echo/echotrace_test.go
@@ -15,7 +15,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
-	"github.com/labstack/echo"
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/contrib/labstack/echo/example_test.go
+++ b/contrib/labstack/echo/example_test.go
@@ -8,7 +8,7 @@ package echo
 import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
-	"github.com/labstack/echo"
+	"github.com/labstack/echo/v4"
 )
 
 // To start tracing requests, add the trace middleware to your echo router.


### PR DESCRIPTION
Upgrade labstack/echo to v4.
In using `labstack/echo/v4`, you cannot pass this middleware to datadog trace's it.