### PR TITLE
contrib/jinzhu/gorm: connect traces using context

### DIFF
--- a/contrib/jinzhu/gorm/gorm.go
+++ b/contrib/jinzhu/gorm/gorm.go
@@ -7,17 +7,106 @@
 package gorm
 
 import (
+	"context"
+	"math"
+
 	sqltraced "gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	"github.com/jinzhu/gorm"
 )
 
+const (
+	gormContextKey = "dd-trace-go:context"
+	gormConfigKey  = "dd-trace-go:config"
+)
+
 // Open opens a new (traced) database connection. The used dialect must be formerly registered
 // using (gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql).Register.
-func Open(dialect, source string) (*gorm.DB, error) {
-	db, err := sqltraced.Open(dialect, source)
+func Open(dialect, source string, opts ...Option) (*gorm.DB, error) {
+	sqldb, err := sqltraced.Open(dialect, source)
 	if err != nil {
 		return nil, err
 	}
-	return gorm.Open(dialect, db)
+	db, err := gorm.Open(dialect, sqldb)
+	if err != nil {
+		return db, err
+	}
+
+	cfg := new(config)
+	defaults(cfg)
+	for _, fn := range opts {
+		fn(cfg)
+	}
+
+	cb := db.Callback()
+	cb.Create().Before("dd-trace-go").Register("dd-trace-go:before_create", beforeFunc("gorm.create"))
+	cb.Create().After("dd-trace-go").Register("dd-trace-go:after_create", after)
+	cb.Update().Before("dd-trace-go").Register("dd-trace-go:before_update", beforeFunc("gorm.update"))
+	cb.Update().After("dd-trace-go").Register("dd-trace-go:after_update", after)
+	cb.Delete().Before("dd-trace-go").Register("dd-trace-go:before_delete", beforeFunc("gorm.delete"))
+	cb.Delete().After("dd-trace-go").Register("dd-trace-go:after_delete", after)
+	cb.Query().Before("dd-trace-go").Register("dd-trace-go:before_query", beforeFunc("gorm.query"))
+	cb.Query().After("dd-trace-go").Register("dd-trace-go:after_query", after)
+	cb.RowQuery().Before("dd-trace-go").Register("dd-trace-go:before_row_query", beforeFunc("gorm.row_query"))
+	cb.RowQuery().After("dd-trace-go").Register("dd-trace-go:after_row_query", after)
+
+	return db.Set(gormConfigKey, cfg), err
+}
+
+func AddContext(ctx context.Context, db *gorm.DB) *gorm.DB {
+	if ctx == nil {
+		return db
+	}
+	db = db.Set(gormContextKey, ctx)
+	return db
+}
+
+func beforeFunc(operationName string) func(*gorm.Scope) {
+	return func(scope *gorm.Scope) {
+		before(scope, operationName)
+	}
+}
+
+func before(scope *gorm.Scope, operationName string) {
+	v, ok := scope.Get(gormContextKey)
+	if !ok {
+		return
+	}
+	ctx := v.(context.Context)
+
+	c, ok := scope.Get(gormConfigKey)
+	if !ok {
+		return
+	}
+	cfg := c.(*config)
+
+	opts := []ddtrace.StartSpanOption{
+		tracer.ServiceName(cfg.serviceName),
+		tracer.SpanType(ext.SpanTypeSQL),
+		tracer.ResourceName(scope.TableName()),
+		tracer.Tag(ext.DBStatement, scope.SQL),
+	}
+	if !math.IsNaN(cfg.analyticsRate) {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
+	}
+	_, ctx = tracer.StartSpanFromContext(ctx, operationName, opts...)
+	scope.Set(gormContextKey, ctx)
+}
+
+func after(scope *gorm.Scope) {
+	v, ok := scope.Get(gormContextKey)
+	if !ok {
+		return
+	}
+	ctx := v.(context.Context)
+
+	span, ok := tracer.SpanFromContext(ctx)
+	if !ok {
+		return
+	}
+
+	span.Finish(tracer.WithError(scope.DB().Error))
 }

--- a/contrib/jinzhu/gorm/gorm.go
+++ b/contrib/jinzhu/gorm/gorm.go
@@ -40,6 +40,9 @@ func Open(dialect, source string, opts ...Option) (*gorm.DB, error) {
 }
 
 // WithCallbacks registers callbacks to the gorm.DB for tracing.
+// It should be called once, after opening the db.
+// The callbacks are triggered by Create, Update, Delete,
+// Query and RowQuery operations.
 func WithCallbacks(db *gorm.DB, opts ...Option) *gorm.DB {
 	afterFunc := func(operationName string) func(*gorm.Scope) {
 		return func(scope *gorm.Scope) {
@@ -67,8 +70,9 @@ func WithCallbacks(db *gorm.DB, opts ...Option) *gorm.DB {
 	return db.Set(gormConfigKey, cfg)
 }
 
-// WithContext returns a new gorm.DB with the context added
-// to its settings store.
+// WithContext attaches the specified context to the given db. The context will
+// be used as a basis for creating new spans. An example use case is providing
+// a context which contains a span to be used as a parent.
 func WithContext(ctx context.Context, db *gorm.DB) *gorm.DB {
 	if ctx == nil {
 		return db

--- a/contrib/jinzhu/gorm/gorm.go
+++ b/contrib/jinzhu/gorm/gorm.go
@@ -41,6 +41,13 @@ func Open(dialect, source string, opts ...Option) (*gorm.DB, error) {
 		fn(cfg)
 	}
 
+	WithCallbacks(db)
+
+	return db.Set(gormConfigKey, cfg), err
+}
+
+// WithCallbacks registers callbacks to the gorm.DB for tracing.
+func WithCallbacks(db *gorm.DB) {
 	cb := db.Callback()
 	cb.Create().Before("dd-trace-go").Register("dd-trace-go:before_create", beforeFunc("gorm.create"))
 	cb.Create().After("dd-trace-go").Register("dd-trace-go:after_create", after)
@@ -52,11 +59,11 @@ func Open(dialect, source string, opts ...Option) (*gorm.DB, error) {
 	cb.Query().After("dd-trace-go").Register("dd-trace-go:after_query", after)
 	cb.RowQuery().Before("dd-trace-go").Register("dd-trace-go:before_row_query", beforeFunc("gorm.row_query"))
 	cb.RowQuery().After("dd-trace-go").Register("dd-trace-go:after_row_query", after)
-
-	return db.Set(gormConfigKey, cfg), err
 }
 
-func AddContext(ctx context.Context, db *gorm.DB) *gorm.DB {
+// WithContext returns a new gorm.DB with the context added
+// to its settings store.
+func WithContext(ctx context.Context, db *gorm.DB) *gorm.DB {
 	if ctx == nil {
 		return db
 	}
@@ -86,8 +93,7 @@ func before(scope *gorm.Scope, operationName string) {
 	opts := []ddtrace.StartSpanOption{
 		tracer.ServiceName(cfg.serviceName),
 		tracer.SpanType(ext.SpanTypeSQL),
-		tracer.ResourceName(scope.TableName()),
-		tracer.Tag(ext.DBStatement, scope.SQL),
+		tracer.ResourceName(scope.SQL),
 	}
 	if !math.IsNaN(cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))

--- a/contrib/jinzhu/gorm/gorm_test.go
+++ b/contrib/jinzhu/gorm/gorm_test.go
@@ -157,13 +157,14 @@ func TestCallbacks(t *testing.T) {
 		parentSpan.Finish()
 
 		spans := mt.FinishedSpans()
-		assert.True(len(spans) >= 2)
+		assert.True(len(spans) >= 3)
 
-		span := spans[len(spans)-2]
-		assert.Equal(span.OperationName(), "gorm.create")
-		assert.Equal(span.Tag(ext.SpanType), ext.SpanTypeSQL)
-		assert.Equal(span.Tag(ext.ResourceName),
-			`INSERT  INTO "products" ("created_at","updated_at","deleted_at","code","price") VALUES ($1,$2,$3,$4,$5) RETURNING "products"."id"`)
+		span := spans[len(spans)-3]
+		assert.Equal("gorm.create", span.OperationName())
+		assert.Equal(ext.SpanTypeSQL, span.Tag(ext.SpanType))
+		assert.Equal(
+			`INSERT  INTO "products" ("created_at","updated_at","deleted_at","code","price") VALUES ($1,$2,$3,$4,$5) RETURNING "products"."id"`,
+			span.Tag(ext.ResourceName))
 	})
 
 	t.Run("query", func(t *testing.T) {
@@ -182,11 +183,11 @@ func TestCallbacks(t *testing.T) {
 		assert.True(len(spans) >= 2)
 
 		span := spans[len(spans)-2]
-		assert.Equal(span.OperationName(), "gorm.query")
-		assert.Equal(span.Tag(ext.SpanType), ext.SpanTypeSQL)
-		assert.Equal(span.Tag(ext.ResourceName),
-			`SELECT * FROM "products"  WHERE "products"."deleted_at" IS NULL AND ((code = $1)) ORDER BY "products"."id" ASC LIMIT 1`)
-
+		assert.Equal("gorm.query", span.OperationName())
+		assert.Equal(ext.SpanTypeSQL, span.Tag(ext.SpanType))
+		assert.Equal(
+			`SELECT * FROM "products"  WHERE "products"."deleted_at" IS NULL AND ((code = $1)) ORDER BY "products"."id" ASC LIMIT 1`,
+			span.Tag(ext.ResourceName))
 	})
 
 	t.Run("update", func(t *testing.T) {
@@ -203,13 +204,14 @@ func TestCallbacks(t *testing.T) {
 		parentSpan.Finish()
 
 		spans := mt.FinishedSpans()
-		assert.True(len(spans) >= 2)
+		assert.True(len(spans) >= 3)
 
-		span := spans[len(spans)-2]
-		assert.Equal(span.OperationName(), "gorm.update")
-		assert.Equal(span.Tag(ext.SpanType), ext.SpanTypeSQL)
-		assert.Equal(span.Tag(ext.ResourceName),
-			`UPDATE "products" SET "price" = $1, "updated_at" = $2  WHERE "products"."deleted_at" IS NULL AND "products"."id" = $3`)
+		span := spans[len(spans)-3]
+		assert.Equal("gorm.update", span.OperationName())
+		assert.Equal(ext.SpanTypeSQL, span.Tag(ext.SpanType))
+		assert.Equal(
+			`UPDATE "products" SET "price" = $1, "updated_at" = $2  WHERE "products"."deleted_at" IS NULL AND "products"."id" = $3`,
+			span.Tag(ext.ResourceName))
 	})
 
 	t.Run("delete", func(t *testing.T) {
@@ -226,13 +228,14 @@ func TestCallbacks(t *testing.T) {
 		parentSpan.Finish()
 
 		spans := mt.FinishedSpans()
-		assert.True(len(spans) >= 2)
+		assert.True(len(spans) >= 3)
 
-		span := spans[len(spans)-2]
-		assert.Equal(span.OperationName(), "gorm.delete")
-		assert.Equal(span.Tag(ext.SpanType), ext.SpanTypeSQL)
-		assert.Equal(span.Tag(ext.ResourceName),
-			`UPDATE "products" SET "deleted_at"=$1  WHERE "products"."deleted_at" IS NULL AND "products"."id" = $2`)
+		span := spans[len(spans)-3]
+		assert.Equal("gorm.delete", span.OperationName())
+		assert.Equal(ext.SpanTypeSQL, span.Tag(ext.SpanType))
+		assert.Equal(
+			`UPDATE "products" SET "deleted_at"=$1  WHERE "products"."deleted_at" IS NULL AND "products"."id" = $2`,
+			span.Tag(ext.ResourceName))
 	})
 }
 
@@ -267,8 +270,8 @@ func TestAnalyticsSettings(t *testing.T) {
 		parentSpan.Finish()
 
 		spans := mt.FinishedSpans()
-		assert.True(t, len(spans) > 2)
-		s := spans[len(spans)-2]
+		assert.True(t, len(spans) > 3)
+		s := spans[len(spans)-3]
 		assert.Equal(t, rate, s.Tag(ext.EventSampleRate))
 	}
 

--- a/contrib/jinzhu/gorm/gorm_test.go
+++ b/contrib/jinzhu/gorm/gorm_test.go
@@ -162,7 +162,8 @@ func TestCallbacks(t *testing.T) {
 		span := spans[len(spans)-2]
 		assert.Equal(span.OperationName(), "gorm.create")
 		assert.Equal(span.Tag(ext.SpanType), ext.SpanTypeSQL)
-		assert.Equal(span.Tag(ext.ResourceName), "products")
+		assert.Equal(span.Tag(ext.ResourceName),
+			`INSERT  INTO "products" ("created_at","updated_at","deleted_at","code","price") VALUES ($1,$2,$3,$4,$5) RETURNING "products"."id"`)
 	})
 
 	t.Run("query", func(t *testing.T) {
@@ -183,7 +184,9 @@ func TestCallbacks(t *testing.T) {
 		span := spans[len(spans)-2]
 		assert.Equal(span.OperationName(), "gorm.query")
 		assert.Equal(span.Tag(ext.SpanType), ext.SpanTypeSQL)
-		assert.Equal(span.Tag(ext.ResourceName), "products")
+		assert.Equal(span.Tag(ext.ResourceName),
+			`SELECT * FROM "products"  WHERE "products"."deleted_at" IS NULL AND ((code = $1)) ORDER BY "products"."id" ASC LIMIT 1`)
+
 	})
 
 	t.Run("update", func(t *testing.T) {
@@ -205,7 +208,8 @@ func TestCallbacks(t *testing.T) {
 		span := spans[len(spans)-2]
 		assert.Equal(span.OperationName(), "gorm.update")
 		assert.Equal(span.Tag(ext.SpanType), ext.SpanTypeSQL)
-		assert.Equal(span.Tag(ext.ResourceName), "products")
+		assert.Equal(span.Tag(ext.ResourceName),
+			`UPDATE "products" SET "price" = $1, "updated_at" = $2  WHERE "products"."deleted_at" IS NULL AND "products"."id" = $3`)
 	})
 
 	t.Run("delete", func(t *testing.T) {
@@ -227,7 +231,8 @@ func TestCallbacks(t *testing.T) {
 		span := spans[len(spans)-2]
 		assert.Equal(span.OperationName(), "gorm.delete")
 		assert.Equal(span.Tag(ext.SpanType), ext.SpanTypeSQL)
-		assert.Equal(span.Tag(ext.ResourceName), "products")
+		assert.Equal(span.Tag(ext.ResourceName),
+			`UPDATE "products" SET "deleted_at"=$1  WHERE "products"."deleted_at" IS NULL AND "products"."id" = $2`)
 	})
 }
 

--- a/contrib/jinzhu/gorm/gorm_test.go
+++ b/contrib/jinzhu/gorm/gorm_test.go
@@ -94,7 +94,7 @@ type Product struct {
 	Price uint
 }
 
-func TestAddContext(t *testing.T) {
+func TestWithContext(t *testing.T) {
 	assert := assert.New(t)
 	sqltrace.Register("postgres", &pq.Driver{})
 	db, err := Open("postgres", "postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable")
@@ -115,8 +115,8 @@ func TestAddContext(t *testing.T) {
 	)
 	defer s2.Finish()
 
-	db1 := AddContext(ctx1, db)
-	db2 := AddContext(ctx2, db)
+	db1 := WithContext(ctx1, db)
+	db2 := WithContext(ctx2, db)
 
 	_, ok := db.Get(gormContextKey)
 	assert.False(ok)
@@ -151,7 +151,7 @@ func TestCallbacks(t *testing.T) {
 			tracer.SpanType(ext.SpanTypeWeb),
 		)
 
-		db = AddContext(ctx, db)
+		db = WithContext(ctx, db)
 		db.Create(&Product{Code: "L1212", Price: 1000})
 
 		parentSpan.Finish()
@@ -171,7 +171,7 @@ func TestCallbacks(t *testing.T) {
 			tracer.SpanType(ext.SpanTypeWeb),
 		)
 
-		db = AddContext(ctx, db)
+		db = WithContext(ctx, db)
 		var product Product
 		db.First(&product, "code = ?", "L1212")
 
@@ -192,7 +192,7 @@ func TestCallbacks(t *testing.T) {
 			tracer.SpanType(ext.SpanTypeWeb),
 		)
 
-		db = AddContext(ctx, db)
+		db = WithContext(ctx, db)
 		var product Product
 		db.First(&product, "code = ?", "L1212")
 		db.Model(&product).Update("Price", 2000)
@@ -214,7 +214,7 @@ func TestCallbacks(t *testing.T) {
 			tracer.SpanType(ext.SpanTypeWeb),
 		)
 
-		db = AddContext(ctx, db)
+		db = WithContext(ctx, db)
 		var product Product
 		db.First(&product, "code = ?", "L1212")
 		db.Delete(&product)
@@ -256,7 +256,7 @@ func TestAnalyticsSettings(t *testing.T) {
 			tracer.SpanType(ext.SpanTypeWeb),
 		)
 
-		db = AddContext(ctx, db)
+		db = WithContext(ctx, db)
 		db.Create(&Product{Code: "L1212", Price: 1000})
 
 		parentSpan.Finish()

--- a/contrib/jinzhu/gorm/option.go
+++ b/contrib/jinzhu/gorm/option.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package gorm
+
+import (
+	"math"
+)
+
+type config struct {
+	serviceName   string
+	analyticsRate float64
+	dsn           string
+}
+
+// Option represents an option that can be passed to Register, Open or OpenDB.
+type Option func(*config)
+
+func defaults(cfg *config) {
+	cfg.serviceName = "gorm.db"
+	// cfg.analyticsRate = globalconfig.AnalyticsRate()
+	cfg.analyticsRate = math.NaN()
+}
+
+// WithServiceName sets the given service name when registering a driver,
+// or opening a database connection.
+func WithServiceName(name string) Option {
+	return func(cfg *config) {
+		cfg.serviceName = name
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) Option {
+	return func(cfg *config) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
+	}
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) Option {
+	return func(cfg *config) {
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
+	}
+}


### PR DESCRIPTION
This provides a partial solution for connecting gorm spans in distributed traces.
A full solution cannot be provided because of jinzhu/gorm#1231 - it has no support for `context.Context`. The issue is nearly 3 years old.

At the moment, `gormtrace` does not produce traces directly, but activates tracing on the underlying `database/sql` interactions. That makes lots of independent traces, and can't be connected to a distributed trace.

This PR makes `gorm` produce the spans, and provides `WithContext` to pass in a `context.Context` from externally, eg: HTTP handler or GRPC call implementation.
Only the `gorm` span is connected to the distributed trace, the underlying SQL interactions still produce independent/detached traces. If gorm adds support for `context.Context` in the future, this can be corrected.

This can also be used without activating tracing from `database/sql` by using `gorm.Open()` directly, then adding the tracing callbacks: `db = gormtrace.WithCallbacks(db)`

The context needs to be manually attached inside HTTP handlers or GRPC call implementations.
`db = gormtrace.WithContext(ctx, db)` before calling other methods on `db`.

Also added the usual Options that are common to most contribs.
 
Fixes #474 