### PR TITLE
contrib/hashicorp/consul: add tracing for consul clients

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
         POSTGRES_PASSWORD: postgres
         POSTGRES_USER: postgres
         POSTGRES_DB: postgres
+    - image: consul:1.6.0
     - image: redis:3.2
     - image: elasticsearch:2
       environment:
@@ -133,6 +134,10 @@ jobs:
     - run:
         name: Wait for Mongo
         command: dockerize -wait tcp://localhost:27017 -timeout 1m
+
+    - run:
+        name: Wait for Consul
+        command: dockerize -wait http://localhost:8500 -timeout 1m
 
     - run:
         name: Linting

--- a/contrib/hashicorp/consul/benchmark_test.go
+++ b/contrib/hashicorp/consul/benchmark_test.go
@@ -3,6 +3,9 @@ package consul
 import (
 	"testing"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+
 	consul "github.com/hashicorp/consul/api"
 )
 
@@ -21,6 +24,8 @@ func BenchmarkKV(b *testing.B) {
 
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
+			mt := mocktracer.Start()
+			defer mt.Stop()
 			client, err := consul.NewClient(consul.DefaultConfig())
 			if err != nil {
 				b.FailNow()
@@ -53,6 +58,8 @@ func BenchmarkTracedKV(b *testing.B) {
 
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
+			tracer.Start()
+			defer tracer.Stop()
 			client, err := NewClient(consul.DefaultConfig())
 			if err != nil {
 				b.FailNow()

--- a/contrib/hashicorp/consul/benchmark_test.go
+++ b/contrib/hashicorp/consul/benchmark_test.go
@@ -1,0 +1,77 @@
+package consul
+
+import (
+	"testing"
+
+	consul "github.com/hashicorp/consul/api"
+)
+
+func getKV(b *testing.B) *consul.KV {
+	defer b.ResetTimer()
+
+	client, err := consul.NewClient(consul.DefaultConfig())
+	if err != nil {
+		panic(err)
+	}
+	kv := client.KV()
+	return kv
+}
+
+func getTracedKV(b *testing.B) *KV {
+	defer b.ResetTimer()
+
+	client, err := NewClient(consul.DefaultConfig())
+	if err != nil {
+		panic(err)
+	}
+	kv := client.KV()
+	return kv
+}
+
+func BenchmarkKV_Put(b *testing.B) {
+	kv := getKV(b)
+	p := &consul.KVPair{Key: "test", Value: []byte("1000")}
+	for i := 0; i < b.N; i++ {
+		_, err := kv.Put(p, nil)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkTracedKV_Put(b *testing.B) {
+	kv := getTracedKV(b)
+	p := &consul.KVPair{Key: "test", Value: []byte("1000")}
+	for i := 0; i < b.N; i++ {
+		_, err := kv.Put(p, nil)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkKV_Get(b *testing.B) {
+	kv := getKV(b)
+	for i := 0; i < b.N; i++ {
+		pair, _, err := kv.Get("test", nil)
+		if err != nil {
+			panic(err)
+		}
+		if pair == nil {
+			panic(pair)
+		}
+	}
+}
+
+func BenchmarkTracedKV_Get(b *testing.B) {
+	kv := getTracedKV(b)
+	for i := 0; i < b.N; i++ {
+		pair, _, err := kv.Get("test", nil)
+		if err != nil {
+			panic(err)
+		}
+		if pair == nil {
+			panic(pair)
+		}
+	}
+}

--- a/contrib/hashicorp/consul/benchmark_test.go
+++ b/contrib/hashicorp/consul/benchmark_test.go
@@ -11,14 +11,13 @@ import (
 func BenchmarkKV(b *testing.B) {
 	key := "test.key"
 	pair := &consul.KVPair{Key: key, Value: []byte("test_value")}
-	testCases := map[string](func(k *consul.KV) error){
+
+	for name, testFunc := range map[string](func(k *consul.KV) error){
 		"Put":    func(kv *consul.KV) error { _, err := kv.Put(pair, nil); return err },
 		"Get":    func(kv *consul.KV) error { _, _, err := kv.Get(key, nil); return err },
 		"List":   func(kv *consul.KV) error { _, _, err := kv.List(key, nil); return err },
 		"Delete": func(kv *consul.KV) error { _, err := kv.Delete(key, nil); return err },
-	}
-
-	for name, testFunc := range testCases {
+	} {
 		b.Run(name, func(b *testing.B) {
 			client, err := consul.NewClient(consul.DefaultConfig())
 			if err != nil {
@@ -40,14 +39,13 @@ func BenchmarkKV(b *testing.B) {
 func BenchmarkTracedKV(b *testing.B) {
 	key := "test.key"
 	pair := &consul.KVPair{Key: key, Value: []byte("test_value")}
-	testCases := map[string](func(k *KV) error){
+
+	for name, testFunc := range map[string](func(k *KV) error){
 		"Put":    func(kv *KV) error { _, err := kv.Put(pair, nil); return err },
 		"Get":    func(kv *KV) error { _, _, err := kv.Get(key, nil); return err },
 		"List":   func(kv *KV) error { _, _, err := kv.List(key, nil); return err },
 		"Delete": func(kv *KV) error { _, err := kv.Delete(key, nil); return err },
-	}
-
-	for name, testFunc := range testCases {
+	} {
 		b.Run(name, func(b *testing.B) {
 			tracer.Start()
 			defer tracer.Stop()

--- a/contrib/hashicorp/consul/consul.go
+++ b/contrib/hashicorp/consul/consul.go
@@ -10,14 +10,14 @@ import (
 	consul "github.com/hashicorp/consul/api"
 )
 
-// A Client is used to trace requests to Consul
+// Client wraps the regular *consul.Client and augments it with tracing. Use NewClient to initialize it.
 type Client struct {
 	*consul.Client
 
 	ctx context.Context
 }
 
-// NewClient returns a traced Consul client
+// NewClient returns a traced Consul client.
 func NewClient(config *consul.Config) (*Client, error) {
 	c, err := consul.NewClient(config)
 	if err != nil {
@@ -32,14 +32,14 @@ func (c *Client) WithContext(ctx context.Context) *Client {
 	return c
 }
 
-// A KV is used to trace requests to Consul's KV
+// A KV is used to trace requests to Consul's KV.
 type KV struct {
 	*consul.KV
 
 	ctx context.Context
 }
 
-// KV returns the KV for the Client
+// KV returns the KV for the Client.
 func (c *Client) KV() *KV {
 	ctx := c.ctx
 	return &KV{c.Client.KV(), ctx}
@@ -74,7 +74,7 @@ func (k *KV) Get(key string, q *consul.QueryOptions) (*consul.KVPair, *consul.Qu
 	return pair, meta, err
 }
 
-// List is used to lookup all keys under a prefix
+// List is used to lookup all keys under a prefix.
 func (k *KV) List(prefix string, q *consul.QueryOptions) ([]*consul.KVPair, *consul.QueryMeta, error) {
 	span := k.startSpan("LIST", prefix)
 	pairs, meta, err := k.KV.List(prefix, q)
@@ -121,7 +121,7 @@ func (k *KV) Release(p *consul.KVPair, q *consul.WriteOptions) (bool, *consul.Wr
 	return r, meta, err
 }
 
-// Delete is used to delete a single key
+// Delete is used to delete a single key.
 func (k *KV) Delete(key string, w *consul.WriteOptions) (*consul.WriteMeta, error) {
 	span := k.startSpan("DELETE", key)
 	meta, err := k.KV.Delete(key, w)
@@ -138,7 +138,7 @@ func (k *KV) DeleteCAS(p *consul.KVPair, q *consul.WriteOptions) (bool, *consul.
 	return r, meta, err
 }
 
-// DeleteTree is used to delete all keys under a prefix
+// DeleteTree is used to delete all keys under a prefix.
 func (k *KV) DeleteTree(prefix string, w *consul.WriteOptions) (*consul.WriteMeta, error) {
 	span := k.startSpan("DELETETREE", prefix)
 	meta, err := k.KV.DeleteTree(prefix, w)

--- a/contrib/hashicorp/consul/consul.go
+++ b/contrib/hashicorp/consul/consul.go
@@ -1,0 +1,146 @@
+package consul
+
+import (
+	"context"
+
+	consul "github.com/hashicorp/consul/api"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+// A Client is used to trace requests to Consul
+type Client struct {
+	*consul.Client
+
+	ctx context.Context
+}
+
+// NewClient returns a traced Consul client
+func NewClient(config *consul.Config) (*Client, error) {
+	c, err := consul.NewClient(config)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{c, context.Background()}, nil
+}
+
+// WithContext sets a context on a Client. Use it to ensure that emitted spans have the correct parent.
+func (c *Client) WithContext(ctx context.Context) *Client {
+	c.ctx = ctx
+	return c
+}
+
+// A KV is used to trace requests to Consul's KV
+type KV struct {
+	*consul.KV
+
+	ctx context.Context
+}
+
+// KV returns the KV for the Client
+func (c *Client) KV() *KV {
+	ctx := c.ctx
+	return &KV{c.Client.KV(), ctx}
+}
+
+func (k *KV) startSpan(resourceName string, key string) ddtrace.Span {
+	opts := []ddtrace.StartSpanOption{
+		tracer.ResourceName(resourceName),
+		tracer.ServiceName("consul"),
+		tracer.SpanType(ext.SpanTypeConsul),
+		tracer.Tag("consul.key", key),
+	}
+	span, _ := tracer.StartSpanFromContext(k.ctx, "consul.command", opts...)
+	return span
+}
+
+// Put is used to write a new value. Only the
+// Key, Flags and Value is respected.
+func (k *KV) Put(p *consul.KVPair, q *consul.WriteOptions) (*consul.WriteMeta, error) {
+	span := k.startSpan("PUT", p.Key)
+	meta, err := k.KV.Put(p, q)
+	defer span.Finish(tracer.WithError(err))
+	return meta, err
+}
+
+// Get is used to lookup a single key. The returned pointer
+// to the KVPair will be nil if the key does not exist.
+func (k *KV) Get(key string, q *consul.QueryOptions) (*consul.KVPair, *consul.QueryMeta, error) {
+	span := k.startSpan("GET", key)
+	pair, meta, err := k.KV.Get(key, q)
+	defer span.Finish(tracer.WithError(err))
+	return pair, meta, err
+}
+
+// List is used to lookup all keys under a prefix
+func (k *KV) List(prefix string, q *consul.QueryOptions) ([]*consul.KVPair, *consul.QueryMeta, error) {
+	span := k.startSpan("LIST", prefix)
+	pairs, meta, err := k.KV.List(prefix, q)
+	defer span.Finish(tracer.WithError(err))
+	return pairs, meta, err
+}
+
+// Keys is used to list all the keys under a prefix. Optionally,
+// a separator can be used to limit the responses.
+func (k *KV) Keys(prefix, separator string, q *consul.QueryOptions) ([]string, *consul.QueryMeta, error) {
+	span := k.startSpan("KEYS", prefix)
+	entries, meta, err := k.KV.Keys(prefix, separator, q)
+	defer span.Finish(tracer.WithError(err))
+	return entries, meta, err
+}
+
+// CAS is used for a Check-And-Set operation. The Key,
+// ModifyIndex, Flags and Value are respected. Returns true
+// on success or false on failures.
+func (k *KV) CAS(p *consul.KVPair, q *consul.WriteOptions) (bool, *consul.WriteMeta, error) {
+	span := k.startSpan("CAS", p.Key)
+	r, meta, err := k.KV.CAS(p, q)
+	defer span.Finish(tracer.WithError(err))
+	return r, meta, err
+}
+
+// Acquire is used for a lock acquisition operation. The Key,
+// Flags, Value and Session are respected. Returns true
+// on success or false on failures.
+func (k *KV) Acquire(p *consul.KVPair, q *consul.WriteOptions) (bool, *consul.WriteMeta, error) {
+	span := k.startSpan("ACQUIRE", p.Key)
+	r, meta, err := k.KV.Acquire(p, q)
+	defer span.Finish(tracer.WithError(err))
+	return r, meta, err
+}
+
+// Release is used for a lock release operation. The Key,
+// Flags, Value and Session are respected. Returns true
+// on success or false on failures.
+func (k *KV) Release(p *consul.KVPair, q *consul.WriteOptions) (bool, *consul.WriteMeta, error) {
+	span := k.startSpan("RELEASE", p.Key)
+	r, meta, err := k.KV.Release(p, q)
+	defer span.Finish(tracer.WithError(err))
+	return r, meta, err
+}
+
+// Delete is used to delete a single key
+func (k *KV) Delete(key string, w *consul.WriteOptions) (*consul.WriteMeta, error) {
+	span := k.startSpan("DELETE", key)
+	meta, err := k.KV.Delete(key, w)
+	defer span.Finish(tracer.WithError(err))
+	return meta, err
+}
+
+// DeleteCAS is used for a Delete Check-And-Set operation. The Key
+// and ModifyIndex are respected. Returns true on success or false on failures.
+func (k *KV) DeleteCAS(p *consul.KVPair, q *consul.WriteOptions) (bool, *consul.WriteMeta, error) {
+	span := k.startSpan("DELETECAS", p.Key)
+	r, meta, err := k.KV.DeleteCAS(p, q)
+	defer span.Finish(tracer.WithError(err))
+	return r, meta, err
+}
+
+// DeleteTree is used to delete all keys under a prefix
+func (k *KV) DeleteTree(prefix string, w *consul.WriteOptions) (*consul.WriteMeta, error) {
+	span := k.startSpan("DELETETREE", prefix)
+	meta, err := k.KV.DeleteTree(prefix, w)
+	defer span.Finish(tracer.WithError(err))
+	return meta, err
+}

--- a/contrib/hashicorp/consul/consul.go
+++ b/contrib/hashicorp/consul/consul.go
@@ -3,10 +3,11 @@ package consul
 import (
 	"context"
 
-	consul "github.com/hashicorp/consul/api"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+
+	consul "github.com/hashicorp/consul/api"
 )
 
 // A Client is used to trace requests to Consul

--- a/contrib/hashicorp/consul/consul.go
+++ b/contrib/hashicorp/consul/consul.go
@@ -67,7 +67,7 @@ func (k *KV) startSpan(resourceName string, key string) ddtrace.Span {
 	if !math.IsNaN(k.config.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, k.config.analyticsRate))
 	}
-	span, _ := tracer.StartSpanFromContext(k.ctx, k.config.spanName, opts...)
+	span, _ := tracer.StartSpanFromContext(k.ctx, "consul.command", opts...)
 	return span
 }
 

--- a/contrib/hashicorp/consul/consul_test.go
+++ b/contrib/hashicorp/consul/consul_test.go
@@ -28,9 +28,7 @@ func TestClient(t *testing.T) {
 	defer mt.Stop()
 
 	client, err := NewClient(consul.DefaultConfig())
-	if err != nil {
-		panic(err)
-	}
+	assert.NoError(err)
 
 	assert.NotNil(client)
 	assert.Nil(err)
@@ -82,9 +80,7 @@ func TestKV(t *testing.T) {
 			mt := mocktracer.Start()
 			defer mt.Stop()
 			client, err := NewClient(consul.DefaultConfig())
-			if err != nil {
-				panic(err)
-			}
+			assert.NoError(err)
 			kv := client.KV()
 
 			testFunc(kv)

--- a/contrib/hashicorp/consul/consul_test.go
+++ b/contrib/hashicorp/consul/consul_test.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"testing"
 
-	consul "github.com/hashicorp/consul/api"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 
+	consul "github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/contrib/hashicorp/consul/consul_test.go
+++ b/contrib/hashicorp/consul/consul_test.go
@@ -66,11 +66,9 @@ func TestClient_KV(t *testing.T) {
 	defer mt.Stop()
 
 	client, _ := NewClient(consul.DefaultConfig())
-	clientCtx := client.ctx
 	kv := client.KV()
-	kvCtx := kv.ctx
 
-	assert.Equal(clientCtx, kvCtx)
+	assert.Equal(client.ctx, kv.ctx)
 }
 
 func TestKV_Put(t *testing.T) {

--- a/contrib/hashicorp/consul/consul_test.go
+++ b/contrib/hashicorp/consul/consul_test.go
@@ -1,0 +1,249 @@
+package consul
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	consul "github.com/hashicorp/consul/api"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	_, ok := os.LookupEnv("INTEGRATION")
+	if !ok {
+		fmt.Println("--- SKIP: to enable integration test, set the INTEGRATION environment variable")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+func kv() *KV {
+	client, err := NewClient(consul.DefaultConfig())
+	if err != nil {
+		panic(err)
+	}
+	// Get a handle to the KV API
+	kv := client.KV()
+	return kv
+}
+
+func TestClient(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	client, err := NewClient(consul.DefaultConfig())
+	if err != nil {
+		panic(err)
+	}
+
+	assert.NotNil(client)
+	assert.Nil(err)
+}
+
+func TestClient_error(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	var config = &consul.Config{
+		Address: "badscheme://baduri",
+	}
+
+	client, err := NewClient(config)
+	assert.Nil(client)
+	assert.Error(err)
+
+}
+
+func TestClient_KV(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	client, _ := NewClient(consul.DefaultConfig())
+	clientCtx := client.ctx
+	kv := client.KV()
+	kvCtx := kv.ctx
+
+	assert.Equal(clientCtx, kvCtx)
+}
+
+func TestKV_Put(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	kv := kv()
+
+	p := &consul.KVPair{Key: "test_key", Value: []byte("test_value")}
+	kv.Put(p, nil)
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 1)
+	span := spans[0]
+	assert.Equal("consul.command", span.OperationName())
+	assert.Equal("PUT", span.Tag(ext.ResourceName))
+	assert.Equal(ext.SpanTypeConsul, span.Tag(ext.SpanType))
+	assert.Equal("consul", span.Tag(ext.ServiceName))
+}
+
+func TestKV_Get(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	kv := kv()
+
+	kv.Get("test", nil)
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 1)
+	span := spans[0]
+	assert.Equal("consul.command", span.OperationName())
+	assert.Equal("GET", span.Tag(ext.ResourceName))
+	assert.Equal(ext.SpanTypeConsul, span.Tag(ext.SpanType))
+	assert.Equal("consul", span.Tag(ext.ServiceName))
+}
+
+func TestKV_List(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	kv := kv()
+
+	kv.List("test", nil)
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 1)
+	span := spans[0]
+	assert.Equal("consul.command", span.OperationName())
+	assert.Equal("LIST", span.Tag(ext.ResourceName))
+	assert.Equal(ext.SpanTypeConsul, span.Tag(ext.SpanType))
+	assert.Equal("consul", span.Tag(ext.ServiceName))
+}
+
+func TestKV_Keys(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	kv := kv()
+
+	kv.Keys("test", "", nil)
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 1)
+	span := spans[0]
+	assert.Equal("consul.command", span.OperationName())
+	assert.Equal("KEYS", span.Tag(ext.ResourceName))
+	assert.Equal(ext.SpanTypeConsul, span.Tag(ext.SpanType))
+	assert.Equal("consul", span.Tag(ext.ServiceName))
+}
+
+func TestKV_CAS(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	kv := kv()
+
+	p := &consul.KVPair{Key: "test_key", Value: []byte("test_value")}
+	kv.CAS(p, nil)
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 1)
+	span := spans[0]
+	assert.Equal("consul.command", span.OperationName())
+	assert.Equal("CAS", span.Tag(ext.ResourceName))
+	assert.Equal(ext.SpanTypeConsul, span.Tag(ext.SpanType))
+	assert.Equal("consul", span.Tag(ext.ServiceName))
+}
+
+func TestKV_Acquire(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	kv := kv()
+
+	p := &consul.KVPair{Key: "test_key", Value: []byte("test_value")}
+	kv.Acquire(p, nil)
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 1)
+	span := spans[0]
+	assert.Equal("consul.command", span.OperationName())
+	assert.Equal("ACQUIRE", span.Tag(ext.ResourceName))
+	assert.Equal(ext.SpanTypeConsul, span.Tag(ext.SpanType))
+	assert.Equal("consul", span.Tag(ext.ServiceName))
+}
+
+func TestKV_Release(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	kv := kv()
+
+	p := &consul.KVPair{Key: "test_key", Value: []byte("test_value")}
+	kv.Release(p, nil)
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 1)
+	span := spans[0]
+	assert.Equal("consul.command", span.OperationName())
+	assert.Equal("RELEASE", span.Tag(ext.ResourceName))
+	assert.Equal(ext.SpanTypeConsul, span.Tag(ext.SpanType))
+	assert.Equal("consul", span.Tag(ext.ServiceName))
+}
+
+func TestKV_Delete(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	kv := kv()
+
+	kv.Delete("test", nil)
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 1)
+	span := spans[0]
+	assert.Equal("consul.command", span.OperationName())
+	assert.Equal("DELETE", span.Tag(ext.ResourceName))
+	assert.Equal(ext.SpanTypeConsul, span.Tag(ext.SpanType))
+	assert.Equal("consul", span.Tag(ext.ServiceName))
+}
+
+func TestKV_DeleteCAS(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	kv := kv()
+
+	p := &consul.KVPair{Key: "test_key", Value: []byte("test_value")}
+	kv.DeleteCAS(p, nil)
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 1)
+	span := spans[0]
+	assert.Equal("consul.command", span.OperationName())
+	assert.Equal("DELETECAS", span.Tag(ext.ResourceName))
+	assert.Equal(ext.SpanTypeConsul, span.Tag(ext.SpanType))
+	assert.Equal("consul", span.Tag(ext.ServiceName))
+}
+
+func TestKV_DeleteTree(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	kv := kv()
+
+	kv.DeleteTree("test", nil)
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 1)
+	span := spans[0]
+	assert.Equal("consul.command", span.OperationName())
+	assert.Equal("DELETETREE", span.Tag(ext.ResourceName))
+	assert.Equal(ext.SpanTypeConsul, span.Tag(ext.SpanType))
+	assert.Equal("consul", span.Tag(ext.ServiceName))
+}

--- a/contrib/hashicorp/consul/consul_test.go
+++ b/contrib/hashicorp/consul/consul_test.go
@@ -36,7 +36,7 @@ func TestClient(t *testing.T) {
 	assert.Nil(err)
 }
 
-func TestClient_error(t *testing.T) {
+func TestClientError(t *testing.T) {
 	assert := assert.New(t)
 	mt := mocktracer.Start()
 	defer mt.Stop()
@@ -51,7 +51,7 @@ func TestClient_error(t *testing.T) {
 
 }
 
-func TestClient_KV(t *testing.T) {
+func TestClientKV(t *testing.T) {
 	assert := assert.New(t)
 	mt := mocktracer.Start()
 	defer mt.Stop()

--- a/contrib/hashicorp/consul/consul_test.go
+++ b/contrib/hashicorp/consul/consul_test.go
@@ -65,7 +65,7 @@ func TestClientKV(t *testing.T) {
 func TestKV(t *testing.T) {
 	key := "test.key"
 	pair := &consul.KVPair{Key: key, Value: []byte("test_value")}
-	testCases := map[string]func(kv *KV){
+	for name, testFunc := range map[string]func(kv *KV){
 		"Put":        func(kv *KV) { kv.Put(pair, nil) },
 		"Get":        func(kv *KV) { kv.Get(key, nil) },
 		"List":       func(kv *KV) { kv.List(key, nil) },
@@ -76,9 +76,7 @@ func TestKV(t *testing.T) {
 		"Delete":     func(kv *KV) { kv.Delete(key, nil) },
 		"DeleteCAS":  func(kv *KV) { kv.DeleteCAS(pair, nil) },
 		"DeleteTree": func(kv *KV) { kv.DeleteTree(key, nil) },
-	}
-
-	for name, testFunc := range testCases {
+	} {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 			mt := mocktracer.Start()

--- a/contrib/hashicorp/consul/example_test.go
+++ b/contrib/hashicorp/consul/example_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	consul "github.com/hashicorp/consul/api"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+
+	consul "github.com/hashicorp/consul/api"
 )
 
 func Example() {

--- a/contrib/hashicorp/consul/example_test.go
+++ b/contrib/hashicorp/consul/example_test.go
@@ -18,7 +18,7 @@ func Example() {
 
 	// Optionally, create a new root span
 	root, ctx := tracer.StartSpanFromContext(context.Background(), "parent.request",
-		tracer.SpanType(ext.SpanTypeRedis),
+		tracer.SpanType(ext.SpanTypeConsul),
 		tracer.ServiceName("consul.example"),
 		tracer.ResourceName("/home"),
 	)

--- a/contrib/hashicorp/consul/example_test.go
+++ b/contrib/hashicorp/consul/example_test.go
@@ -1,0 +1,46 @@
+package consul
+
+import (
+	"context"
+	"fmt"
+
+	consul "github.com/hashicorp/consul/api"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+func Example() {
+	// Get a new Consul client
+	client, err := NewClient(consul.DefaultConfig())
+	if err != nil {
+		panic(err)
+	}
+
+	// Optionally, create a new root span
+	root, ctx := tracer.StartSpanFromContext(context.Background(), "parent.request",
+		tracer.SpanType(ext.SpanTypeRedis),
+		tracer.ServiceName("consul.example"),
+		tracer.ResourceName("/home"),
+	)
+	defer root.Finish()
+	client = client.WithContext(ctx)
+
+	// Get a handle to the KV API
+	kv := client.KV()
+
+	// PUT a new KV pair
+	p := &consul.KVPair{Key: "test", Value: []byte("1000")}
+	_, err = kv.Put(p, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	// Lookup the pair
+	pair, _, err := kv.Get("test", nil)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%v: %s\n", pair.Key, pair.Value)
+	// Output:
+	// test: 1000
+}

--- a/contrib/hashicorp/consul/example_test.go
+++ b/contrib/hashicorp/consul/example_test.go
@@ -3,6 +3,7 @@ package consul
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -14,7 +15,7 @@ func Example() {
 	// Get a new Consul client
 	client, err := NewClient(consul.DefaultConfig(), WithServiceName("consul.example"))
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
 	// Optionally, create a new root span
@@ -32,13 +33,13 @@ func Example() {
 	p := &consul.KVPair{Key: "test", Value: []byte("1000")}
 	_, err = kv.Put(p, nil)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
 	// Lookup the pair
 	pair, _, err := kv.Get("test", nil)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 	fmt.Printf("%v: %s\n", pair.Key, pair.Value)
 	// Output:

--- a/contrib/hashicorp/consul/example_test.go
+++ b/contrib/hashicorp/consul/example_test.go
@@ -11,6 +11,7 @@ import (
 	consul "github.com/hashicorp/consul/api"
 )
 
+// Here's an example illustrating a simple use case for interacting with consul with tracing enabled.
 func Example() {
 	// Get a new Consul client
 	client, err := NewClient(consul.DefaultConfig(), WithServiceName("consul.example"))

--- a/contrib/hashicorp/consul/example_test.go
+++ b/contrib/hashicorp/consul/example_test.go
@@ -12,16 +12,15 @@ import (
 
 func Example() {
 	// Get a new Consul client
-	client, err := NewClient(consul.DefaultConfig())
+	client, err := NewClient(consul.DefaultConfig(), WithServiceName("consul.example"))
 	if err != nil {
 		panic(err)
 	}
 
 	// Optionally, create a new root span
-	root, ctx := tracer.StartSpanFromContext(context.Background(), "parent.request",
+	root, ctx := tracer.StartSpanFromContext(context.Background(), "root_span",
 		tracer.SpanType(ext.SpanTypeConsul),
-		tracer.ServiceName("consul.example"),
-		tracer.ResourceName("/home"),
+		tracer.ServiceName("example"),
 	)
 	defer root.Finish()
 	client = client.WithContext(ctx)

--- a/contrib/hashicorp/consul/option.go
+++ b/contrib/hashicorp/consul/option.go
@@ -4,12 +4,10 @@ import "math"
 
 const (
 	serviceName = "consul"
-	spanName    = "consul.command"
 )
 
 type clientConfig struct {
 	serviceName   string
-	spanName      string
 	analyticsRate float64
 }
 
@@ -18,7 +16,6 @@ type ClientOption func(*clientConfig)
 
 func defaults(cfg *clientConfig) {
 	cfg.serviceName = serviceName
-	cfg.spanName = spanName
 	cfg.analyticsRate = math.NaN()
 }
 
@@ -26,13 +23,6 @@ func defaults(cfg *clientConfig) {
 func WithServiceName(name string) ClientOption {
 	return func(cfg *clientConfig) {
 		cfg.serviceName = name
-	}
-}
-
-// WithSpanName sets the given span name for the client.
-func WithSpanName(name string) ClientOption {
-	return func(cfg *clientConfig) {
-		cfg.spanName = name
 	}
 }
 

--- a/contrib/hashicorp/consul/option.go
+++ b/contrib/hashicorp/consul/option.go
@@ -1,0 +1,60 @@
+package consul
+
+import "math"
+
+const (
+	serviceName = "consul"
+	spanName    = "consul.command"
+)
+
+type clientConfig struct {
+	serviceName   string
+	spanName      string
+	analyticsRate float64
+}
+
+// ClientOption represents an option that can be used to create or wrap a client.
+type ClientOption func(*clientConfig)
+
+func defaults(cfg *clientConfig) {
+	cfg.serviceName = serviceName
+	cfg.spanName = spanName
+	cfg.analyticsRate = math.NaN()
+}
+
+// WithServiceName sets the given service name for the client.
+func WithServiceName(name string) ClientOption {
+	return func(cfg *clientConfig) {
+		cfg.serviceName = name
+	}
+}
+
+// WithSpanName sets the given span name for the client.
+func WithSpanName(name string) ClientOption {
+	return func(cfg *clientConfig) {
+		cfg.spanName = name
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) ClientOption {
+	return func(cfg *clientConfig) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
+	}
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) ClientOption {
+	return func(cfg *clientConfig) {
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
+	}
+}

--- a/ddtrace/ext/app_types.go
+++ b/ddtrace/ext/app_types.go
@@ -72,4 +72,7 @@ const (
 
 	// SpanTypeMessageProducer marks a span as a queue operation.
 	SpanTypeMessageProducer = "queue"
+
+	// SpanTypeConsul marks a span as a Consul operation.
+	SpanTypeConsul = "consul"
 )


### PR DESCRIPTION
This PR adds tracing for [hashicorp/consul/api](https://github.com/hashicorp/consul/tree/master/api).

# Example Use

```Golang
// Get a new Consul client
client, err := NewClient(consul.DefaultConfig())
if err != nil {
	panic(err)
}

// Create a new root span
root, ctx := tracer.StartSpanFromContext(context.Background(), "parent.request",
	tracer.SpanType(ext.SpanTypeRedis),
	tracer.ServiceName("consul.example"),
	tracer.ResourceName("/home"),
)
defer root.Finish()
client = client.WithContext(ctx)

// Get a handle to the KV API
kv := client.KV()

// PUT a new KV pair
p := &consul.KVPair{Key: "test", Value: []byte("1000")}
r, err = kv.Put(p, nil)
```

This will send a root span named `parent.request` for the `consul.example` service, and a child span named `PUT` for the `consul` service, with the tag `consul.key = "test"`.

# Collected Data

The span's resource name will be the name of the function called, in all caps (e.g. `PUT`). All spans also include a `consul.key` tag with the key or prefix they were called with.

# Traced Calls

Only calls to the KV are traced. All KV functions are supported, including:
* Put
* Get
* List
* Keys
* CAS
* Acquire
* Release
* Delete
* DeleteCAS
* DeleteTree

# Benchmarks

The results of the included benchmarks are presented below. All benchmarks were run using `INTEGRATION=true go test -v -bench .` against a local consul server running in Docker.

| Function | Untraced Execution Time (ms) | Traced Execution Time (ms) | Difference (ms) | Difference (%) |
|----------|------------------------------|----------------------------|-----------------|----------------|
| Put      | 1.371122                     | 1.437806                   | 0.066684        | 4.86%          |
| Get      | 1.042376                     | 1.121287                   | 0.078911        | 7.57%          |
| List     | 1.05023                      | 1.094199                   | 0.043969        | 4.19%          |
| Delete   | 1.347029                     | 1.453241                   | 0.106212        |  7.88%         |

Resolves #495 