### PR TITLE
contrib/go-redis/redis: correct analytics rate for Pipeline()

### DIFF
--- a/contrib/go-redis/redis/redis.go
+++ b/contrib/go-redis/redis/redis.go
@@ -176,8 +176,8 @@ func createWrapperFromClient(tc *Client) func(oldProcess func(cmd redis.Cmder) e
 				tracer.Tag("redis.raw_command", raw),
 				tracer.Tag("redis.args_length", strconv.Itoa(length)),
 			}
-			if rate := p.config.analyticsRate; rate > 0 {
-				opts = append(opts, tracer.Tag(ext.EventSampleRate, rate))
+			if !math.IsNaN(p.config.analyticsRate) {
+				opts = append(opts, tracer.Tag(ext.EventSampleRate, p.config.analyticsRate))
 			}
 			span, _ := tracer.StartSpanFromContext(ctx, "redis.command", opts...)
 			err := oldProcess(cmd)


### PR DESCRIPTION
This bit was missed from implementing #456. Updated code and test so pipeline spans are correctly tagged for analytics rate == `0.0`.
Spotted by @phil-dd 