### PR TITLE
ddtrace/tracer: add go runtime metrics

### DIFF
--- a/ddtrace/tracer/metrics.go
+++ b/ddtrace/tracer/metrics.go
@@ -1,0 +1,98 @@
+package tracer
+
+import (
+	"runtime"
+	"runtime/debug"
+	"time"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+)
+
+// defaultMetricsReportInterval specifies the interval at which runtime metrics will
+// be reported.
+const defaultMetricsReportInterval = 10 * time.Second
+
+type gauger interface {
+	Gauge(name string, value float64, tags []string, rate float64) error
+}
+
+// reportMetrics periodically reports go runtime metrics to the specified gauger at
+// the given interval.
+func (t *tracer) reportMetrics(statsd gauger, interval time.Duration) {
+	var (
+		ms   runtime.MemStats
+		tags []string
+	)
+	if t.config.serviceName != "" {
+		tags = append(tags, "service:"+t.config.serviceName)
+	}
+	if t.config.hostname != "" {
+		tags = append(tags, "host:"+t.config.hostname)
+	}
+	if v, ok := t.config.globalTags[ext.Environment]; ok {
+		if vv, ok := v.(string); ok {
+			tags = append(tags, "env:"+vv)
+		}
+	}
+	gc := debug.GCStats{PauseQuantiles: make([]time.Duration, 5)}
+
+	tick := time.NewTicker(interval)
+	defer tick.Stop()
+	for {
+		select {
+		case <-tick.C:
+			log.Debug("Reporting runtime metrics...")
+			runtime.ReadMemStats(&ms)
+			debug.ReadGCStats(&gc)
+
+			// CPU statistics
+			statsd.Gauge("runtime.go.num_cpu", float64(runtime.NumCPU()), tags, 1)
+			statsd.Gauge("runtime.go.num_goroutine", float64(runtime.NumGoroutine()), tags, 1)
+			statsd.Gauge("runtime.go.num_cgo_call", float64(runtime.NumCgoCall()), tags, 1)
+			// General statistics
+			statsd.Gauge("runtime.go.mem_stats.alloc", float64(ms.Alloc), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.total_alloc", float64(ms.TotalAlloc), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.sys", float64(ms.Sys), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.lookups", float64(ms.Lookups), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.mallocs", float64(ms.Mallocs), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.frees", float64(ms.Frees), tags, 1)
+			// Heap memory statistics
+			statsd.Gauge("runtime.go.mem_stats.heap_alloc", float64(ms.HeapAlloc), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.heap_sys", float64(ms.HeapSys), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.heap_idle", float64(ms.HeapIdle), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.heap_inuse", float64(ms.HeapInuse), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.heap_released", float64(ms.HeapReleased), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.heap_objects", float64(ms.HeapObjects), tags, 1)
+			// Stack memory statistics
+			statsd.Gauge("runtime.go.mem_stats.stack_inuse", float64(ms.StackInuse), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.stack_sys", float64(ms.StackSys), tags, 1)
+			// Off-heap memory statistics
+			statsd.Gauge("runtime.go.mem_stats.m_span_inuse", float64(ms.MSpanInuse), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.m_span_sys", float64(ms.MSpanSys), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.m_cache_inuse", float64(ms.MCacheInuse), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.m_cache_sys", float64(ms.MCacheSys), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.buck_hash_sys", float64(ms.BuckHashSys), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.gc_sys", float64(ms.GCSys), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.other_sys", float64(ms.OtherSys), tags, 1)
+			// Garbage collector statistics
+			statsd.Gauge("runtime.go.mem_stats.next_gc", float64(ms.NextGC), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.last_gc", float64(ms.LastGC), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.pause_total_ns", float64(ms.PauseTotalNs), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.num_gc", float64(ms.NumGC), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.num_forced_gc", float64(ms.NumForcedGC), tags, 1)
+			statsd.Gauge("runtime.go.mem_stats.gc_cpu_fraction", ms.GCCPUFraction, tags, 1)
+			if ms.EnableGC {
+				statsd.Gauge("runtime.go.mem_stats.enable_gc", float64(1), tags, 1)
+				for i, p := range []string{"min", "25p", "50p", "75p", "max"} {
+					statsd.Gauge("runtime.go.gc_stats.pause_quantiles."+p, float64(gc.PauseQuantiles[i]), tags, 1)
+				}
+			} else {
+				statsd.Gauge("runtime.go.mem_stats.enable_gc", float64(0), tags, 1)
+			}
+
+		case <-t.stopped:
+			return
+		}
+	}
+}

--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -1,0 +1,68 @@
+package tracer
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+)
+
+func TestReportMetrics(t *testing.T) {
+	trc := &tracer{
+		stopped: make(chan struct{}),
+		config: &config{
+			serviceName: "my-service",
+			hostname:    "my-host",
+			globalTags:  map[string]interface{}{ext.Environment: "my-env"},
+		},
+	}
+
+	var tg testGauger
+	go trc.reportMetrics(&tg, time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
+	close(trc.stopped)
+	assert := assert.New(t)
+	calls := tg.CallNames()
+	tags := tg.Tags()
+	assert.True(len(calls) > 30)
+	assert.Contains(calls, "runtime.go.num_cpu")
+	assert.Contains(calls, "runtime.go.mem_stats.alloc")
+	assert.Contains(calls, "runtime.go.gc_stats.pause_quantiles.75p")
+	assert.Contains(tags, "service:my-service")
+	assert.Contains(tags, "env:my-env")
+	assert.Contains(tags, "host:my-host")
+}
+
+type testGauger struct {
+	mu    sync.RWMutex
+	calls []string
+	tags  []string
+}
+
+func (tg *testGauger) Gauge(name string, value float64, tags []string, rate float64) error {
+	tg.mu.Lock()
+	defer tg.mu.Unlock()
+	tg.calls = append(tg.calls, name)
+	tg.tags = tags
+	return nil
+}
+
+func (tg *testGauger) CallNames() []string {
+	tg.mu.RLock()
+	defer tg.mu.RUnlock()
+	return tg.calls
+}
+
+func (tg *testGauger) Tags() []string {
+	tg.mu.RLock()
+	defer tg.mu.RUnlock()
+	return tg.tags
+}
+
+func (tg *testGauger) Reset() {
+	tg.mu.Lock()
+	defer tg.mu.Unlock()
+	tg.calls = tg.calls[:0]
+}

--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestReportMetrics(t *testing.T) {

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -6,8 +6,8 @@
 package tracer
 
 import (
-	"fmt"
 	"math"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -80,7 +80,7 @@ func defaults(c *config) {
 	if v := os.Getenv("DD_DOGSTATSD_PORT"); v != "" {
 		statsdPort = v
 	}
-	c.dogstatsdAddr = fmt.Sprintf("%s:%s", statsdHost, statsdPort)
+	c.dogstatsdAddr = net.JoinHostPort(statsdHost, statsdPort)
 
 	if os.Getenv("DD_TRACE_REPORT_HOSTNAME") == "true" {
 		var err error

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -77,9 +77,9 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		})
 
 		t.Run("option", func(t *testing.T) {
-			tracer := newTracer(WithDogstatsdAddress("1.2.3:4"))
+			tracer := newTracer(WithDogstatsdAddress("10.1.0.12:4002"))
 			c := tracer.config
-			assert.Equal(t, c.dogstatsdAddr, "1.2.3:4")
+			assert.Equal(t, c.dogstatsdAddr, "10.1.0.12:4002")
 		})
 	})
 

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -7,6 +7,7 @@ package tracer
 
 import (
 	"math"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,6 +28,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		assert.Equal(float64(1), c.sampler.(RateSampler).Rate())
 		assert.Equal("tracer.test", c.serviceName)
 		assert.Equal("localhost:8126", c.agentAddr)
+		assert.Equal("localhost:8125", c.dogstatsdAddr)
 		assert.Equal(nil, c.httpRoundTripper)
 	})
 
@@ -39,6 +41,46 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		assert.True(math.IsNaN(globalconfig.AnalyticsRate()))
 		newTracer(WithAnalytics(true))
 		assert.Equal(1., globalconfig.AnalyticsRate())
+	})
+
+	t.Run("dogstatsd", func(t *testing.T) {
+		t.Run("default", func(t *testing.T) {
+			tracer := newTracer()
+			c := tracer.config
+			assert.Equal(t, c.dogstatsdAddr, "localhost:8125")
+		})
+
+		t.Run("env-host", func(t *testing.T) {
+			os.Setenv("DD_AGENT_HOST", "my-host")
+			defer os.Unsetenv("DD_AGENT_HOST")
+			tracer := newTracer()
+			c := tracer.config
+			assert.Equal(t, c.dogstatsdAddr, "my-host:8125")
+		})
+
+		t.Run("env-port", func(t *testing.T) {
+			os.Setenv("DD_DOGSTATSD_PORT", "123")
+			defer os.Unsetenv("DD_DOGSTATSD_PORT")
+			tracer := newTracer()
+			c := tracer.config
+			assert.Equal(t, c.dogstatsdAddr, "localhost:123")
+		})
+
+		t.Run("env-both", func(t *testing.T) {
+			os.Setenv("DD_AGENT_HOST", "my-host")
+			os.Setenv("DD_DOGSTATSD_PORT", "123")
+			defer os.Unsetenv("DD_AGENT_HOST")
+			defer os.Unsetenv("DD_DOGSTATSD_PORT")
+			tracer := newTracer()
+			c := tracer.config
+			assert.Equal(t, c.dogstatsdAddr, "my-host:123")
+		})
+
+		t.Run("option", func(t *testing.T) {
+			tracer := newTracer(WithDogstatsdAddress("1.2.3:4"))
+			c := tracer.config
+			assert.Equal(t, c.dogstatsdAddr, "1.2.3:4")
+		})
 	})
 
 	t.Run("other", func(t *testing.T) {

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -140,11 +140,7 @@ func newTracer(opts ...StartOption) *tracer {
 		pid:              strconv.Itoa(os.Getpid()),
 	}
 	if c.runtimeMetrics {
-		statsd, err := statsd.New(
-			t.config.dogstatsdAddr,
-			statsd.Buffered(),
-			statsd.WithMaxMessagesPerPayload(40),
-		)
+		statsd, err := statsd.NewBuffered(t.config.dogstatsdAddr, 40)
 		if err != nil {
 			log.Warn("Runtime metrics disabled: %v", err)
 		} else {


### PR DESCRIPTION
This change adds an option to enable reporting runtime metrics. It
reports the `runtime.MemStats` structure and the pause quantiles from
the `debug.GCStats` structure of the standard library.

To use the feature, simply start the tracer using the new `WithRuntimeMetrics`
option, and metrics will be sent to Datadog every 10 seconds. If your Datadog
Agent dogstatsd address differs from the default `localhost:8125` you may
change it using the added `WithDogstatsdAddress` option or the standard
environment variables `DD_AGENT_HOST` and `DD_DOGSTATSD_PORT`.

For example:
```go
tracer.Start(tracer.WithRuntimeMetrics())
```