### PR TITLE
ddtrace/tracer: tracer defaults from environment variables

### DIFF
--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -61,7 +61,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 	})
 
 	t.Run("envs", func(t *testing.T) {
-		if err := os.Setenv("DD_SERVICE_NAME", "env:test, aKey:aVal,bKey:bVal"); err != nil {
+		if err := os.Setenv("DD_SERVICE_NAME", "TEST_SERVICE"); err != nil {
 			panic("could not set environment variable DD_SERVICE_NAME during testing")
 		}
 		if err := os.Setenv("DD_TRACE_GLOBAL_TAGS", "env:test, aKey:aVal,bKey:bVal"); err != nil {

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -87,6 +87,10 @@ func TestTracerOptionsDefaults(t *testing.T) {
 
 		cVal, ok := c.globalTags["cKey"]
 		assert.False(ok, "does not have cKey")
-		assert.Equal("", cVal)
+		assert.Equal(nil, cVal)
+
+		// unset the environment variables
+		os.Unsetenv("DD_SERVICE_NAME")
+		os.Unsetenv("DD_TRACE_GLOBAL_TAGS")
 	})
 }

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -7,6 +7,7 @@ package tracer
 
 import (
 	"math"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,5 +58,35 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		assert.NotNil(c.globalTags)
 		assert.Equal("v", c.globalTags["k"])
 		assert.True(c.debug)
+	})
+
+	t.Run("envs", func(t *testing.T) {
+		if err := os.Setenv("DD_SERVICE_NAME", "env:test, aKey:aVal,bKey:bVal"); err != nil {
+			panic("could not set environment variable DD_SERVICE_NAME during testing")
+		}
+		if err := os.Setenv("DD_TRACE_GLOBAL_TAGS", "env:test, aKey:aVal,bKey:bVal"); err != nil {
+			panic("could not set environment variable DD_TRACE_GLOBAL_TAGS during testing")
+		}
+
+		assert := assert.New(t)
+		var c config
+		defaults(&c)
+		assert.Equal("TEST_SERVICE", c.serviceName)
+
+		env, ok := c.globalTags["env"]
+		assert.True(ok, "has the env key")
+		assert.Equal("test", env)
+
+		aVal, ok := c.globalTags["aKey"]
+		assert.True(ok, "has aKey key")
+		assert.Equal("aVal", aVal)
+
+		bVal, ok := c.globalTags["bKey"]
+		assert.True(ok, "has bKey key")
+		assert.Equal("bVal", bVal)
+
+		cVal, ok := c.globalTags["cKey"]
+		assert.False(ok, "does not have cKey")
+		assert.Equal("", cVal)
 	})
 }


### PR DESCRIPTION
This feature adds in reading environment variables to set default values for the tracer.

Currently supporting environment variables:
- `DD_SERVICE_NAME`
- `DD_TRACE_GLOBAL_TAGS`

Fixes #16 