### PR TITLE
README: update go version to 1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ go get gopkg.in/DataDog/dd-trace-go.v1/ddtrace
 
 Requires:
 
-* Go 1.9
+* Go >= 1.10
 * Datadog's Trace Agent >= 5.21.1
 
 ### Documentation

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,4 +8,4 @@ package version
 // Tag specifies the current release tag. It needs to be manually
 // updated. A test checks that the value of Tag never points to a
 // git tag that is older than HEAD.
-const Tag = "v1.18.0"
+const Tag = "v1.19.0"


### PR DESCRIPTION
The docs suggest Go v1.9 is required.
That isn't correct after some changes in the tracer and contribs that use things from go 1.10, eg:
- `strings.Builder`
- `database/sql/driver.Connector`

Fixes #502 