### PR TITLE
circleci: use go1.10 as specified in the README

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     resource_class: xlarge
 
     docker:
-    - image: circleci/golang:latest
+    - image: circleci/golang:1.10
     - image: cassandra:3.7
     - image: circleci/mysql:5.7
       environment:


### PR DESCRIPTION
This change ensures that whatever minimum version is specified in the
README can be built.

Updates #502