### PR TITLE
circleci: update cache key for librdkafka

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
 
     - restore_cache:
         keys:
-        - v1-librdkafka-v1.1.0
+        - v1-librdkafka-v1.1.0-{{ checksum "/etc/os-release" }}
     - run:
         name: Install librdkafka v1.1.0
         command: |
@@ -63,7 +63,7 @@ jobs:
           (cd /tmp/librdkafka-v1.1.0 && sudo make install)
           sudo ldconfig
     - save_cache:
-        key: v1-librdkafka-v1.1.0
+        key: v1-librdkafka-v1.1.0-{{ checksum "/etc/os-release" }}
         paths:
         - /tmp/librdkafka-v1.1.0
 


### PR DESCRIPTION
This is to clear up the CI failures after changing the build image to `circleci/golang:1.10`.
Pinning to os-release within the container seem reasonable, and would handle any future changes to the build image.