### PR TITLE
ddtrace/tracer: return no-op spans when client sampler rejects trace

### DIFF
--- a/ddtrace/tracer/droppedspan.go
+++ b/ddtrace/tracer/droppedspan.go
@@ -1,6 +1,8 @@
 package tracer
 
 import (
+	"sync"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 )
@@ -8,35 +10,35 @@ import (
 // droppedSpan represents a span which was dropped by the local sampler.
 type droppedSpan struct {
 	traceID uint64
+	once    sync.Once
 	sctx    *droppedSpanContext
 }
 
-func (droppedSpan) SetTag(_ string, _ interface{})      {}
-func (droppedSpan) SetOperationName(_ string)           {}
-func (droppedSpan) BaggageItem(_ string) string         { return "" }
-func (droppedSpan) SetBaggageItem(_ string, val string) {}
-func (droppedSpan) Finish(_ ...ddtrace.FinishOption)    {}
+func (*droppedSpan) SetTag(_ string, _ interface{})      {}
+func (*droppedSpan) SetOperationName(_ string)           {}
+func (*droppedSpan) BaggageItem(_ string) string         { return "" }
+func (*droppedSpan) SetBaggageItem(_ string, val string) {}
+func (*droppedSpan) Finish(_ ...ddtrace.FinishOption)    {}
 
 // Context returns the span context of this dropped span. It ensures that distributed
 // parts of a trace are also dropped, in order to avoid broken traces, but that they
 // do reach the agent for stats computations.
 func (d *droppedSpan) Context() ddtrace.SpanContext {
-	if d.sctx != nil {
-		return d.sctx
-	}
-	sctx := &spanContext{
-		spanID:  d.traceID,
-		traceID: d.traceID,
-		trace: &trace{
-			priority: func(i float64) *float64 {
-				return &i
-			}(ext.PriorityUserReject),
-		},
-	}
-	d.sctx = &droppedSpanContext{
-		droppedSpan: d,
-		spanContext: sctx,
-	}
+	d.once.Do(func() {
+		sctx := &spanContext{
+			spanID:  d.traceID,
+			traceID: d.traceID,
+			trace: &trace{
+				priority: func(i float64) *float64 {
+					return &i
+				}(ext.PriorityUserReject),
+			},
+		}
+		d.sctx = &droppedSpanContext{
+			droppedSpan: d,
+			spanContext: sctx,
+		}
+	})
 	return d.sctx
 }
 

--- a/ddtrace/tracer/droppedspan.go
+++ b/ddtrace/tracer/droppedspan.go
@@ -1,0 +1,46 @@
+package tracer
+
+import (
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+)
+
+// droppedSpan represents a span which was dropped by the local sampler.
+type droppedSpan struct {
+	traceID uint64
+	sctx    *droppedSpanContext
+}
+
+func (droppedSpan) SetTag(_ string, _ interface{})      {}
+func (droppedSpan) SetOperationName(_ string)           {}
+func (droppedSpan) BaggageItem(_ string) string         { return "" }
+func (droppedSpan) SetBaggageItem(_ string, val string) {}
+func (droppedSpan) Finish(_ ...ddtrace.FinishOption)    {}
+
+// Context returns the span context of this dropped span. It ensures that distributed
+// parts of a trace are also dropped, in order to avoid broken traces, but that they
+// do reach the agent for stats computations.
+func (d *droppedSpan) Context() ddtrace.SpanContext {
+	if d.sctx != nil {
+		return d.sctx
+	}
+	sctx := &spanContext{
+		spanID:  d.traceID,
+		traceID: d.traceID,
+		trace: &trace{
+			priority: func(i float64) *float64 {
+				return &i
+			}(ext.PriorityUserReject),
+		},
+	}
+	d.sctx = &droppedSpanContext{
+		droppedSpan: d,
+		spanContext: sctx,
+	}
+	return d.sctx
+}
+
+type droppedSpanContext struct {
+	*spanContext
+	droppedSpan *droppedSpan
+}

--- a/ddtrace/tracer/droppedspan_test.go
+++ b/ddtrace/tracer/droppedspan_test.go
@@ -1,0 +1,18 @@
+package tracer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDroppedSpan(t *testing.T) {
+	assert := assert.New(t)
+	ds := &droppedSpan{traceID: 1}
+	assert.Nil(ds.sctx)
+	ctx := ds.Context().(*droppedSpanContext)
+	assert.NotNil(ds.sctx)
+	assert.EqualValues(1, ctx.traceID)
+	assert.EqualValues(1, ctx.spanID)
+	assert.EqualValues(-1, *ctx.trace.priority)
+}

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -297,11 +297,6 @@ func (s *span) finish(finishTime int64) {
 		s.Duration = finishTime - s.Start
 	}
 	s.finished = true
-
-	if s.context.drop {
-		// not sampled by local sampler
-		return
-	}
 	s.context.finish()
 }
 

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -24,7 +24,6 @@ type spanContext struct {
 
 	trace *trace // reference to the trace that this span belongs too
 	span  *span  // reference to the span that hosts this context
-	drop  bool   // when true, the span will not be sent to the agent
 
 	// the below group should propagate cross-process
 
@@ -49,7 +48,6 @@ func newSpanContext(span *span, parent *spanContext) *spanContext {
 	}
 	if parent != nil {
 		context.trace = parent.trace
-		context.drop = parent.drop
 		context.origin = parent.origin
 		parent.ForeachBaggageItem(func(k, v string) bool {
 			context.setBaggageItem(k, v)

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -303,11 +303,8 @@ func TestSpanContextParent(t *testing.T) {
 		"basic": &spanContext{
 			baggage: map[string]string{"A": "A", "B": "B"},
 			trace:   newTrace(),
-			drop:    true,
 		},
-		"nil-trace": &spanContext{
-			drop: true,
-		},
+		"nil-trace": &spanContext{},
 		"priority": &spanContext{
 			baggage: map[string]string{"A": "A", "B": "B"},
 			trace: &trace{
@@ -333,7 +330,6 @@ func TestSpanContextParent(t *testing.T) {
 			if parentCtx.trace != nil {
 				assert.Equal(ctx.trace.priority, parentCtx.trace.priority)
 			}
-			assert.Equal(ctx.drop, parentCtx.drop)
 			assert.Equal(ctx.baggage, parentCtx.baggage)
 			assert.Equal(ctx.origin, parentCtx.origin)
 		})

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -209,21 +209,31 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 	for _, fn := range options {
 		fn(&opts)
 	}
+	id := opts.SpanID
+	if id == 0 {
+		id = random.Uint64()
+	}
+	var parent *spanContext
+	if opts.Parent != nil {
+		switch ctx := opts.Parent.(type) {
+		case *spanContext:
+			parent = ctx
+		case *droppedSpanContext:
+			// this trace was dropped by the client sampler; we return the same
+			// no-op span for every started child
+			return ctx.droppedSpan
+		}
+	} else {
+		if !t.isLocallySampled(id, &opts) {
+			// this is a local root and the client sampler decided to drop the trace
+			return &droppedSpan{traceID: id}
+		}
+	}
 	var startTime int64
 	if opts.StartTime.IsZero() {
 		startTime = now()
 	} else {
 		startTime = opts.StartTime.UnixNano()
-	}
-	var context *spanContext
-	if opts.Parent != nil {
-		if ctx, ok := opts.Parent.(*spanContext); ok {
-			context = ctx
-		}
-	}
-	id := opts.SpanID
-	if id == 0 {
-		id = random.Uint64()
 	}
 	// span defaults
 	span := &span{
@@ -238,28 +248,28 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		Start:    startTime,
 		taskEnd:  startExecutionTracerTask(operationName),
 	}
-	if context != nil {
+	if parent != nil {
 		// this is a child span
-		span.TraceID = context.traceID
-		span.ParentID = context.spanID
-		if context.hasSamplingPriority() {
-			span.Metrics[keySamplingPriority] = float64(context.samplingPriority())
+		span.TraceID = parent.traceID
+		span.ParentID = parent.spanID
+		if parent.hasSamplingPriority() {
+			span.Metrics[keySamplingPriority] = float64(parent.samplingPriority())
 		}
-		if context.span != nil {
-			// local parent, inherit service
-			context.span.RLock()
-			span.Service = context.span.Service
-			context.span.RUnlock()
+		if parent.span != nil {
+			// the span has a local parent; inherit its service
+			parent.span.RLock()
+			span.Service = parent.span.Service
+			parent.span.RUnlock()
 		} else {
-			// remote parent
-			if context.origin != "" {
-				// mark origin
-				span.Meta[keyOrigin] = context.origin
+			// the span has a remote parent
+			if parent.origin != "" {
+				// the remote propagated an origin; mark it
+				span.Meta[keyOrigin] = parent.origin
 			}
 		}
 	}
-	span.context = newSpanContext(span, context)
-	if context == nil || context.span == nil {
+	span.context = newSpanContext(span, parent)
+	if parent == nil || parent.span == nil {
 		// this is either a root span or it has a remote parent, we should add the PID.
 		span.SetTag(ext.Pid, t.pid)
 		if t.hostname != "" {
@@ -279,9 +289,9 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 	for k, v := range t.config.globalTags {
 		span.SetTag(k, v)
 	}
-	if context == nil {
-		// this is a brand new trace, sample it
-		t.sample(span)
+	if parent == nil && !span.context.hasSamplingPriority() {
+		// this is a brand new trace with no sampling priority
+		t.prioritySampling.apply(span)
 	}
 	return span
 }
@@ -299,6 +309,9 @@ func (t *tracer) Stop() {
 
 // Inject uses the configured or default TextMap Propagator.
 func (t *tracer) Inject(ctx ddtrace.SpanContext, carrier interface{}) error {
+	if dctx, ok := ctx.(*droppedSpanContext); ok {
+		ctx = dctx.spanContext
+	}
 	return t.config.propagator.Inject(ctx, carrier)
 }
 
@@ -344,22 +357,31 @@ func (t *tracer) pushPayload(trace []*span) {
 	}
 }
 
+// isLocallySampled reports whether a newly started span with the given configuration
+// and id should be sampled. The function may also alter cfg by introducing further
+// tags.
+func (t *tracer) isLocallySampled(id uint64, cfg *ddtrace.StartSpanConfig) bool {
+	_, ok1 := cfg.Tags[ext.SamplingPriority]
+	_, ok2 := cfg.Tags[keySamplingPriority]
+	if ok1 || ok2 {
+		// a span with user defined sampling priority stays
+		return true
+	}
+	rs, ok := t.config.sampler.(*rateSampler)
+	if !ok || rs.Rate() >= 1 {
+		// either not a rate sampler or all-permissive
+		return true
+	}
+	// TODO(v2): This is hacky and renders the Sampler interface useless. See issue #508.
+	if !sampledByRate(id, rs.Rate()) {
+		return false
+	}
+	if cfg.Tags == nil {
+		cfg.Tags = make(map[string]interface{}, 1)
+	}
+	cfg.Tags[sampleRateMetricKey] = rs.Rate()
+	return true
+}
+
 // sampleRateMetricKey is the metric key holding the applied sample rate. Has to be the same as the Agent.
 const sampleRateMetricKey = "_sample_rate"
-
-// Sample samples a span with the internal sampler.
-func (t *tracer) sample(span *span) {
-	if span.context.hasSamplingPriority() {
-		// sampling decision was already made
-		return
-	}
-	sampler := t.config.sampler
-	if !sampler.Sample(span) {
-		span.context.drop = true
-		return
-	}
-	if rs, ok := sampler.(RateSampler); ok && rs.Rate() < 1 {
-		span.Metrics[sampleRateMetricKey] = rs.Rate()
-	}
-	t.prioritySampling.apply(span)
-}

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -552,9 +552,9 @@ func TestTracerEdgeSampler(t *testing.T) {
 	count := payloadQueueSize / 3
 
 	for i := 0; i < count; i++ {
-		span0 := tracer0.newRootSpan("pylons.request", "pylons", "/")
+		span0 := tracer0.StartSpan("pylons.request", ServiceName("pylons"), ResourceName("/"))
 		span0.Finish()
-		span1 := tracer1.newRootSpan("pylons.request", "pylons", "/")
+		span1 := tracer1.StartSpan("pylons.request", ServiceName("pylons"), ResourceName("/"))
 		span1.Finish()
 	}
 

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -726,6 +726,50 @@ func TestTracerTraceMaxSize(t *testing.T) {
 	wg.Wait()
 }
 
+func TestStartDroppedSpan(t *testing.T) {
+	tracer, _, stop := startTestTracer(WithSampler(NewRateSampler(0)))
+	defer stop()
+
+	t.Run("root", func(t *testing.T) {
+		root := tracer.StartSpan("root")
+		span, ok := root.(*droppedSpan)
+		assert.True(t, ok)
+		assert.True(t, span.traceID > 0)
+	})
+
+	t.Run("child", func(t *testing.T) {
+		root := tracer.StartSpan("root")
+		child := tracer.StartSpan("child", ChildOf(root.Context()))
+		span, ok := child.(*droppedSpan)
+		assert.True(t, ok)
+		assert.True(t, span.traceID > 0)
+	})
+
+	t.Run("priority", func(t *testing.T) {
+		root := tracer.StartSpan("root", Tag(ext.SamplingPriority, 0))
+		_, ok := root.(*droppedSpan)
+		assert.False(t, ok)
+	})
+
+	t.Run("priority-private", func(t *testing.T) {
+		root := tracer.StartSpan("root", Tag(keySamplingPriority, 0))
+		_, ok := root.(*droppedSpan)
+		assert.False(t, ok)
+	})
+
+	t.Run("propagation", func(t *testing.T) {
+		root := tracer.StartSpan("root")
+		textmap := make(TextMapCarrier)
+		err := tracer.Inject(root.Context(), textmap)
+		assert.NoError(t, err)
+		assert.Equal(t, "-1", textmap[DefaultPriorityHeader])
+		assert.Equal(t, fmt.Sprint(root.(*droppedSpan).traceID), textmap[DefaultTraceIDHeader])
+		assert.Equal(t, fmt.Sprint(root.(*droppedSpan).traceID), textmap[DefaultParentIDHeader])
+		_, err = tracer.Extract(textmap)
+		assert.NoError(t, err)
+	})
+}
+
 func TestTracerRace(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
In environments with very high throughput, it can sometimes be optimal to enable client sampling. In these scenarios, it is critical that CPU and memory usage is minimal. In the current implementation, a span which is not elected by the local sampler will go through the same process as any other span: allowing tags to be added, buffering a trace in memory, etc. This is resource consuming.

This change introduces a no-op span which is returned every time a trace is dropped by the local sampler. When this span is propagated to another service, that service receives a sampling priority of `UserReject` to signal that trace to be dropped on the agent side, while allowing it to reach the agent for stats computations.

This change also brings out problems with the architecture of the sampler interfaces underlined in issue #508.