### PR TITLE
contrib/hashicorp/vault: add integration for vault api.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     resource_class: xlarge
 
     docker:
-    - image: circleci/golang:1.10
+    - image: circleci/golang:1.12
     - image: cassandra:3.7
     - image: circleci/mysql:5.7
       environment:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ go get gopkg.in/DataDog/dd-trace-go.v1/ddtrace
 
 Requires:
 
-* Go >= 1.10
+* Go >= 1.12
 * Datadog's Trace Agent >= 5.21.1
 
 ### Documentation

--- a/contrib/hashicorp/vault/example_test.go
+++ b/contrib/hashicorp/vault/example_test.go
@@ -17,7 +17,7 @@ func ExampleNewHTTPClient() {
 		Address:    "http://vault.mydomain.com:8200",
 	})
 	if err != nil {
-		log.Panicf("Failed to create vault client: %s\n", err)
+		log.Fatalf("Failed to create vault client: %s\n", err)
 	}
 
 	// This call wil be traced
@@ -34,7 +34,7 @@ func ExampleNewHTTPClient_withOptions() {
 		Address: "http://vault.mydomain.com:8200",
 	})
 	if err != nil {
-		log.Panicf("Failed to create vault client: %s\n", err)
+		log.Fatalf("Failed to create vault client: %s\n", err)
 	}
 
 	// This call wil be traced
@@ -59,7 +59,7 @@ func ExampleWrapHTTPClient() {
 		Address:    "http://vault.mydomain.com:8200",
 	})
 	if err != nil {
-		log.Panicf("Failed to create vault client: %s\n", err)
+		log.Fatalf("Failed to create vault client: %s\n", err)
 	}
 
 	// This call wil be traced
@@ -87,7 +87,7 @@ func ExampleWrapHTTPClient_withOptions() {
 		Address: "http://vault.mydomain.com:8200",
 	})
 	if err != nil {
-		log.Panicf("Failed to create vault client: %s\n", err)
+		log.Fatalf("Failed to create vault client: %s\n", err)
 	}
 
 	// This call wil be traced

--- a/contrib/hashicorp/vault/example_test.go
+++ b/contrib/hashicorp/vault/example_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
 package vault_test
 
 import (

--- a/contrib/hashicorp/vault/example_test.go
+++ b/contrib/hashicorp/vault/example_test.go
@@ -1,55 +1,95 @@
 package vault_test
 
 import (
+	"fmt"
+	"log"
 	"net/http"
 
-	"github.com/hashicorp/vault/api"
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/hashicorp/vault"
-	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+
+	"github.com/hashicorp/vault/api"
 )
 
-func ExampleNewHTTPClient() (*api.Client, error) {
-	vaultClient, err := api.NewClient(&api.Config{
+// This is the most basic way to enable tracing with Vault
+func ExampleNewHTTPClient() {
+	c, err := api.NewClient(&api.Config{
 		HttpClient: vault.NewHTTPClient(),
 		Address:    "http://vault.mydomain.com:8200",
 	})
-	return vaultClient, err
+	if err != nil {
+		log.Panicf("Failed to create vault client: %s\n", err)
+	}
+
+	// This call wil be traced
+	c.Logical().Read("/secret/key")
 }
 
 // Options can be passed in to configure the tracer
-func ExampleNewHTTPClient_withOptions() (*api.Client, error) {
-	vaultClient, err := api.NewClient(
-		&api.Config{
-			HttpClient: vault.NewHTTPClient(
-				httptrace.RTWithAnalytics(true),
-				httptrace.RTWithAnalyticsRate(1.0)),
-			Address: "http://vault.mydomain.com:8200",
-		})
-	return vaultClient, err
-}
-
-func ExampleWrapHTTPTransport() (*api.Client, error) {
-	var myHttpClient *http.Client
-	myHttpClient = &http.Client{}
-
-	vaultClient, err := api.NewClient(&api.Config{
-		HttpClient: vault.WrapHTTPTransport(myHttpClient),
-		Address:    "http://vault.mydomain.com:8200",
-	})
-	return vaultClient, err
-}
-
-// Options can be passed in to configure the tracer
-func ExampleWrapHTTPTransport_withOptions() (*api.Client, error) {
-	var myHttpClient *http.Client
-	myHttpClient = &http.Client{}
-
-	vaultClient, err := api.NewClient(&api.Config{
-		HttpClient: vault.WrapHTTPTransport(
-			myHttpClient,
-			httptrace.RTWithAnalytics(true),
-			httptrace.RTWithAnalyticsRate(1.0)),
+func ExampleNewHTTPClient_withOptions() {
+	c, err := api.NewClient(&api.Config{
+		HttpClient: vault.NewHTTPClient(
+			vault.WithServiceName("my.vault"),
+			vault.WithAnalytics(true),
+			vault.WithAnalyticsRate(1.0)),
 		Address: "http://vault.mydomain.com:8200",
 	})
-	return vaultClient, err
+	if err != nil {
+		log.Panicf("Failed to create vault client: %s\n", err)
+	}
+
+	// This call wil be traced
+	c.Logical().Read("/secret/key")
+}
+
+// If you already have an *http.Client that you're using (c in this example), you can continue to use it by
+// calling WrapHTTPClient to wrap the tracing code around its Transport.
+func ExampleWrapHTTPClient() {
+	// We use a custom *http.Client to talk to vault.
+	c := &http.Client{
+		CheckRedirect: func(r *http.Request, via []*http.Request) error {
+			if len(via) > 5 {
+				return fmt.Errorf("Won't perform more that 5 redirects.")
+			}
+			return nil
+		},
+	}
+
+	client, err := api.NewClient(&api.Config{
+		HttpClient: vault.WrapHTTPClient(c),
+		Address:    "http://vault.mydomain.com:8200",
+	})
+	if err != nil {
+		log.Panicf("Failed to create vault client: %s\n", err)
+	}
+
+	// This call wil be traced
+	client.Logical().Read("/secret/key")
+}
+
+// Options can be passed in to configure the tracer
+func ExampleWrapHTTPClient_withOptions() {
+	// We use a custom *http.Client to talk to vault.
+	c := &http.Client{
+		CheckRedirect: func(r *http.Request, via []*http.Request) error {
+			if len(via) > 5 {
+				return fmt.Errorf("Won't perform more that 5 redirects.")
+			}
+			return nil
+		},
+	}
+
+	client, err := api.NewClient(&api.Config{
+		HttpClient: vault.WrapHTTPClient(
+			c,
+			vault.WithServiceName("my.vault"),
+			vault.WithAnalytics(true),
+			vault.WithAnalyticsRate(1.0)),
+		Address: "http://vault.mydomain.com:8200",
+	})
+	if err != nil {
+		log.Panicf("Failed to create vault client: %s\n", err)
+	}
+
+	// This call wil be traced
+	client.Logical().Read("/secret/key")
 }

--- a/contrib/hashicorp/vault/example_test.go
+++ b/contrib/hashicorp/vault/example_test.go
@@ -5,46 +5,44 @@ import (
 	"log"
 	"net/http"
 
-	"gopkg.in/DataDog/dd-trace-go.v1/contrib/hashicorp/vault"
+	vaulttrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/hashicorp/vault"
 
 	"github.com/hashicorp/vault/api"
 )
 
-// This is the most basic way to enable tracing with Vault
+// This is the most basic way to enable tracing with Vault.
 func ExampleNewHTTPClient() {
 	c, err := api.NewClient(&api.Config{
-		HttpClient: vault.NewHTTPClient(),
+		HttpClient: vaulttrace.NewHTTPClient(),
 		Address:    "http://vault.mydomain.com:8200",
 	})
 	if err != nil {
-		log.Fatalf("Failed to create vault client: %s\n", err)
+		log.Fatalf("Failed to create Vault client: %s\n", err)
 	}
-
 	// This call wil be traced
 	c.Logical().Read("/secret/key")
 }
 
-// Options can be passed in to configure the tracer
+// NewHTTPClient can be called with additional options to configure the integration.
 func ExampleNewHTTPClient_withOptions() {
 	c, err := api.NewClient(&api.Config{
-		HttpClient: vault.NewHTTPClient(
-			vault.WithServiceName("my.vault"),
-			vault.WithAnalytics(true),
-			vault.WithAnalyticsRate(1.0)),
+		HttpClient: vaulttrace.NewHTTPClient(
+			vaulttrace.WithServiceName("my.vault"),
+			vaulttrace.WithAnalytics(true),
+		),
 		Address: "http://vault.mydomain.com:8200",
 	})
 	if err != nil {
-		log.Fatalf("Failed to create vault client: %s\n", err)
+		log.Fatalf("Failed to create Vault client: %s\n", err)
 	}
-
 	// This call wil be traced
 	c.Logical().Read("/secret/key")
 }
 
-// If you already have an *http.Client that you're using (c in this example), you can continue to use it by
-// calling WrapHTTPClient to wrap the tracing code around its Transport.
+// If you already have an http.Client that you're using, you can add tracing to it
+// with WrapHTTPClient.
 func ExampleWrapHTTPClient() {
-	// We use a custom *http.Client to talk to vault.
+	// We use a custom *http.Client to talk to Vault.
 	c := &http.Client{
 		CheckRedirect: func(r *http.Request, via []*http.Request) error {
 			if len(via) > 5 {
@@ -53,22 +51,21 @@ func ExampleWrapHTTPClient() {
 			return nil
 		},
 	}
-
 	client, err := api.NewClient(&api.Config{
-		HttpClient: vault.WrapHTTPClient(c),
+		HttpClient: vaulttrace.WrapHTTPClient(c),
 		Address:    "http://vault.mydomain.com:8200",
 	})
 	if err != nil {
-		log.Fatalf("Failed to create vault client: %s\n", err)
+		log.Fatalf("Failed to create Vault client: %s\n", err)
 	}
 
 	// This call wil be traced
 	client.Logical().Read("/secret/key")
 }
 
-// Options can be passed in to configure the tracer
+// WrapHTTPClient can be called with additional options to configure the integration.
 func ExampleWrapHTTPClient_withOptions() {
-	// We use a custom *http.Client to talk to vault.
+	// We use a custom *http.Client to talk to Vault.
 	c := &http.Client{
 		CheckRedirect: func(r *http.Request, via []*http.Request) error {
 			if len(via) > 5 {
@@ -77,19 +74,17 @@ func ExampleWrapHTTPClient_withOptions() {
 			return nil
 		},
 	}
-
 	client, err := api.NewClient(&api.Config{
-		HttpClient: vault.WrapHTTPClient(
+		HttpClient: vaulttrace.WrapHTTPClient(
 			c,
-			vault.WithServiceName("my.vault"),
-			vault.WithAnalytics(true),
-			vault.WithAnalyticsRate(1.0)),
+			vaulttrace.WithServiceName("my.vault"),
+			vaulttrace.WithAnalytics(true),
+		),
 		Address: "http://vault.mydomain.com:8200",
 	})
 	if err != nil {
-		log.Fatalf("Failed to create vault client: %s\n", err)
+		log.Fatalf("Failed to create Vault client: %s\n", err)
 	}
-
 	// This call wil be traced
 	client.Logical().Read("/secret/key")
 }

--- a/contrib/hashicorp/vault/example_test.go
+++ b/contrib/hashicorp/vault/example_test.go
@@ -23,7 +23,7 @@ func ExampleNewHTTPClient() {
 	c.Logical().Read("/secret/key")
 }
 
-// NewHTTPClient can be called with additional options to configure the integration.
+// NewHTTPClient can be called with additional options for further configuration.
 func ExampleNewHTTPClient_withOptions() {
 	c, err := api.NewClient(&api.Config{
 		HttpClient: vaulttrace.NewHTTPClient(

--- a/contrib/hashicorp/vault/example_test.go
+++ b/contrib/hashicorp/vault/example_test.go
@@ -1,0 +1,55 @@
+package vault_test
+
+import (
+	"net/http"
+
+	"github.com/hashicorp/vault/api"
+	"gopkg.in/DataDog/dd-trace-go.v1/contrib/hashicorp/vault"
+	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+)
+
+func ExampleNewHTTPClient() (*api.Client, error) {
+	vaultClient, err := api.NewClient(&api.Config{
+		HttpClient: vault.NewHTTPClient(),
+		Address:    "http://vault.mydomain.com:8200",
+	})
+	return vaultClient, err
+}
+
+// Options can be passed in to configure the tracer
+func ExampleNewHTTPClient_withOptions() (*api.Client, error) {
+	vaultClient, err := api.NewClient(
+		&api.Config{
+			HttpClient: vault.NewHTTPClient(
+				httptrace.RTWithAnalytics(true),
+				httptrace.RTWithAnalyticsRate(1.0)),
+			Address: "http://vault.mydomain.com:8200",
+		})
+	return vaultClient, err
+}
+
+func ExampleWrapHTTPTransport() (*api.Client, error) {
+	var myHttpClient *http.Client
+	myHttpClient = &http.Client{}
+
+	vaultClient, err := api.NewClient(&api.Config{
+		HttpClient: vault.WrapHTTPTransport(myHttpClient),
+		Address:    "http://vault.mydomain.com:8200",
+	})
+	return vaultClient, err
+}
+
+// Options can be passed in to configure the tracer
+func ExampleWrapHTTPTransport_withOptions() (*api.Client, error) {
+	var myHttpClient *http.Client
+	myHttpClient = &http.Client{}
+
+	vaultClient, err := api.NewClient(&api.Config{
+		HttpClient: vault.WrapHTTPTransport(
+			myHttpClient,
+			httptrace.RTWithAnalytics(true),
+			httptrace.RTWithAnalyticsRate(1.0)),
+		Address: "http://vault.mydomain.com:8200",
+	})
+	return vaultClient, err
+}

--- a/contrib/hashicorp/vault/option.go
+++ b/contrib/hashicorp/vault/option.go
@@ -3,24 +3,26 @@ package vault
 import "math"
 
 type config struct {
-	withAnalytics bool
 	analyticsRate float64
 	serviceName   string
 }
+
+const serviceName = "vault"
 
 // Option can be passed to NewHTTPClient and WrapHTTPClient to configure the integration.
 type Option func(*config)
 
 func defaults(cfg *config) {
-	cfg.serviceName = "vault"
+	cfg.serviceName = serviceName
 	cfg.analyticsRate = math.NaN()
 }
 
 // WithAnalytics enables or disables Trace Analytics for all started spans.
 func WithAnalytics(on bool) Option {
-	return func(c *config) {
-		c.withAnalytics = on
+	if on {
+		return WithAnalyticsRate(1.0)
 	}
+	return WithAnalyticsRate(math.NaN())
 }
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events correlated to started spans.

--- a/contrib/hashicorp/vault/option.go
+++ b/contrib/hashicorp/vault/option.go
@@ -1,0 +1,39 @@
+package vault
+
+import "math"
+
+type config struct {
+	withAnalytics bool
+	analyticsRate float64
+	serviceName   string
+}
+
+// Option can be passed to NewHTTPClient and WrapHTTPClient to configure the tracer.
+// They can be created with the functions WithAnalytics, WithAnalyticsRate, and WithServiceName
+type Option func(*config)
+
+func defaults(cfg *config) {
+	cfg.serviceName = "vault"
+	cfg.analyticsRate = math.NaN()
+}
+
+// WithAnalytics enables or disables Trace Analytics for all started spans.
+func WithAnalytics(on bool) Option {
+	return func(c *config) {
+		c.withAnalytics = on
+	}
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events correlated to started spans.
+func WithAnalyticsRate(rate float64) Option {
+	return func(c *config) {
+		c.analyticsRate = rate
+	}
+}
+
+// WithServiceName sets the given service name for the http.Client.
+func WithServiceName(name string) Option {
+	return func(c *config) {
+		c.serviceName = name
+	}
+}

--- a/contrib/hashicorp/vault/option.go
+++ b/contrib/hashicorp/vault/option.go
@@ -8,8 +8,7 @@ type config struct {
 	serviceName   string
 }
 
-// Option can be passed to NewHTTPClient and WrapHTTPClient to configure the tracer.
-// They can be created with the functions WithAnalytics, WithAnalyticsRate, and WithServiceName
+// Option can be passed to NewHTTPClient and WrapHTTPClient to configure the integration.
 type Option func(*config)
 
 func defaults(cfg *config) {

--- a/contrib/hashicorp/vault/option.go
+++ b/contrib/hashicorp/vault/option.go
@@ -5,7 +5,11 @@
 
 package vault
 
-import "math"
+import (
+	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+)
 
 type config struct {
 	analyticsRate float64
@@ -19,7 +23,7 @@ type Option func(*config)
 
 func defaults(cfg *config) {
 	cfg.serviceName = defaultServiceName
-	cfg.analyticsRate = math.NaN()
+	cfg.analyticsRate = globalconfig.AnalyticsRate()
 }
 
 // WithAnalytics enables or disables Trace Analytics for all started spans.

--- a/contrib/hashicorp/vault/option.go
+++ b/contrib/hashicorp/vault/option.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
 package vault
 
 import "math"
@@ -7,13 +12,13 @@ type config struct {
 	serviceName   string
 }
 
-const serviceName = "vault"
+const defaultServiceName = "vault"
 
 // Option can be passed to NewHTTPClient and WrapHTTPClient to configure the integration.
 type Option func(*config)
 
 func defaults(cfg *config) {
-	cfg.serviceName = serviceName
+	cfg.serviceName = defaultServiceName
 	cfg.analyticsRate = math.NaN()
 }
 

--- a/contrib/hashicorp/vault/vault.go
+++ b/contrib/hashicorp/vault/vault.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
 // Package vault contains functions to construct or augment an http.Client that
 // will integrate with the github.com/hashicorp/vault/api and collect traces to
 // send to Datadog.

--- a/contrib/hashicorp/vault/vault.go
+++ b/contrib/hashicorp/vault/vault.go
@@ -3,25 +3,11 @@
 // to DataDog.
 //
 // The easiest way to use this package is to create an *http.Client with
-// NewHttpClient, and put it in the vault api config that's passed to the
-// NewClient function.
-//    import "github.com/hashicorp/vault/api"
-//    import trace "gopkg.in/DataDog/dd-trace-go.v1/contrib/hashicorp/vault"
-//
-//    func ... {
-//        api.NewClient(&api.Config{HttpClient: trace.NewHttpClient()})
-//    }
+// NewHTTPClient, and put it in the vault api config that's passed to the
 //
 // If you are already using your own *http.Client with vault, you can use the
-// WrapHttpTransport function to wrap the client with the tracer code. Your
+// WrapHTTPTransport function to wrap the client with the tracer code. Your
 // *http.Client will continue to work as before, but will also capture traces.
-//
-//    func ... {
-//        var myHttpClient *http.Client
-//        myHttpClient = ...
-//        api.NewClient(&api.Config{HttpClient: trace.WrapHttpTransport(myHttpClient)})
-//    }
-//
 package vault
 
 import (
@@ -35,16 +21,16 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 
-	vault "github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 )
 
-// NewHttpClient returns an *http.Client for use in the config for the vault api
-// Client.
-func NewHttpClient() *http.Client {
-	dc := vault.DefaultConfig()
+// NewHTTPClient returns an *http.Client for use in the config for the vault api
+// Client. Options can be optionally passed in to configure various tracer features such as Analytics
+func NewHTTPClient(opts ...httptrace.RoundTripperOption) *http.Client {
+	dc := api.DefaultConfig()
 	c := dc.HttpClient
-	WrapHttpTransport(c)
+	WrapHTTPTransport(c, opts...)
 	return c
 }
 
@@ -52,47 +38,53 @@ type vaultErrors struct {
 	Errors []string `json:"errors"`
 }
 
-// WrapHttpTransport takes an existing *http.Client and wraps the transport with
-// the tracing code.
-func WrapHttpTransport(client *http.Client) *http.Client {
-	wrapped := httptrace.WrapRoundTripper(client.Transport,
+// WrapHTTPTransport takes an existing *http.Client and wraps the transport with
+// the tracing code. This will leave the existing Transport in place underneath,
+// only adding tracing code around it.
+func WrapHTTPTransport(client *http.Client, opts ...httptrace.RoundTripperOption) *http.Client {
+	if client.Transport == nil {
+		client.Transport = http.DefaultTransport
+	}
+	wrapperOpts := []httptrace.RoundTripperOption{
 		httptrace.WithBefore(func(req *http.Request, span ddtrace.Span) {
 			span.SetTag(ext.ServiceName, "vault")
 			span.SetTag(ext.HTTPURL, req.URL.Path)
 			span.SetTag(ext.HTTPMethod, req.Method)
 			span.SetTag(ext.ResourceName, req.Method+" "+req.URL.Path)
-			span.SetTag(ext.SpanType, ext.SpanTypeVault)
-			namespace := req.Header.Get(consts.NamespaceHeaderName)
-			if namespace != "" {
-				span.SetTag("vault.namespace", namespace)
+			span.SetTag(ext.SpanType, ext.SpanTypeHTTP)
+			if ns := req.Header.Get(consts.NamespaceHeaderName); ns != "" {
+				span.SetTag("vault.namespace", ns)
 			}
 		}),
 		httptrace.WithAfter(func(resp *http.Response, span ddtrace.Span) {
-			if resp != nil {
-				span.SetTag(ext.HTTPCode, resp.StatusCode)
-				if resp.StatusCode >= 400 {
-					// See: https://www.vaultproject.io/api/overview.html#error-response
-					errs := []string{}
-					defer resp.Body.Close()
-					bodyBytes, err := ioutil.ReadAll(resp.Body)
+			if resp == nil {
+				return
+			}
+			span.SetTag(ext.HTTPCode, resp.StatusCode)
+			if resp.StatusCode >= 400 {
+				// See: https://www.vaultproject.io/api/overview.html#error-response
+				errs := []string{}
+				defer resp.Body.Close()
+				bodyBytes, err := ioutil.ReadAll(resp.Body)
+				if err != nil {
+					errs = append(errs, err.Error())
+				} else {
+					resp.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+					vaultErrors := vaultErrors{}
+					err = json.Unmarshal(bodyBytes, &vaultErrors)
 					if err != nil {
 						errs = append(errs, err.Error())
 					} else {
-						resp.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
-						vaultErrors := vaultErrors{}
-						err = json.Unmarshal(bodyBytes, &vaultErrors)
-						if err != nil {
-							errs = append(errs, err.Error())
-						} else {
-							errs = append(errs, vaultErrors.Errors...)
-						}
+						errs = append(errs, vaultErrors.Errors...)
 					}
-					span.SetTag(ext.Error, fmt.Errorf("%d: %s", resp.StatusCode, http.StatusText(resp.StatusCode)))
-					span.SetTag(ext.ErrorDetails, errs)
 				}
+				span.SetTag(ext.Error, fmt.Errorf("%d: %s", resp.StatusCode, http.StatusText(resp.StatusCode)))
+				span.SetTag(ext.ErrorDetails, errs)
 			}
 		}),
-	)
+	}
+	wrapperOpts = append(wrapperOpts, opts...)
+	wrapped := httptrace.WrapRoundTripper(client.Transport, wrapperOpts...)
 	client.Transport = wrapped
 	return client
 }

--- a/contrib/hashicorp/vault/vault.go
+++ b/contrib/hashicorp/vault/vault.go
@@ -1,4 +1,4 @@
-// The vault package contains functions to construct an *http.Client that will
+// Package vault contains functions to construct an *http.Client that will
 // integrate with the github.com/hashicorp/vault/api and collect traces to send
 // to DataDog.
 //
@@ -6,15 +6,12 @@
 // NewHTTPClient, and put it in the vault api config that's passed to the
 //
 // If you are already using your own *http.Client with vault, you can use the
-// WrapHTTPTransport function to wrap the client with the tracer code. Your
+// WrapHTTPClient function to wrap the client with the tracer code. Your
 // *http.Client will continue to work as before, but will also capture traces.
 package vault
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
@@ -27,64 +24,48 @@ import (
 
 // NewHTTPClient returns an *http.Client for use in the config for the vault api
 // Client. Options can be optionally passed in to configure various tracer features such as Analytics
-func NewHTTPClient(opts ...httptrace.RoundTripperOption) *http.Client {
+func NewHTTPClient(opts ...Option) *http.Client {
 	dc := api.DefaultConfig()
 	c := dc.HttpClient
-	WrapHTTPTransport(c, opts...)
+	WrapHTTPClient(c, opts...)
 	return c
 }
 
-type vaultErrors struct {
-	Errors []string `json:"errors"`
-}
-
-// WrapHTTPTransport takes an existing *http.Client and wraps the transport with
+// WrapHTTPClient takes an existing *http.Client and wraps the transport with
 // the tracing code. This will leave the existing Transport in place underneath,
 // only adding tracing code around it.
-func WrapHTTPTransport(client *http.Client, opts ...httptrace.RoundTripperOption) *http.Client {
-	if client.Transport == nil {
-		client.Transport = http.DefaultTransport
+func WrapHTTPClient(c *http.Client, opts ...Option) *http.Client {
+	if c.Transport == nil {
+		c.Transport = http.DefaultTransport
 	}
-	wrapperOpts := []httptrace.RoundTripperOption{
-		httptrace.WithBefore(func(req *http.Request, span ddtrace.Span) {
-			span.SetTag(ext.ServiceName, "vault")
-			span.SetTag(ext.HTTPURL, req.URL.Path)
-			span.SetTag(ext.HTTPMethod, req.Method)
-			span.SetTag(ext.ResourceName, req.Method+" "+req.URL.Path)
-			span.SetTag(ext.SpanType, ext.SpanTypeHTTP)
-			if ns := req.Header.Get(consts.NamespaceHeaderName); ns != "" {
-				span.SetTag("vault.namespace", ns)
+	var conf config
+	defaults(&conf)
+	for _, o := range opts {
+		o(&conf)
+	}
+	c.Transport = httptrace.WrapRoundTripper(c.Transport,
+		httptrace.RTWithAnalytics(conf.withAnalytics),
+		httptrace.RTWithAnalyticsRate(conf.analyticsRate),
+		httptrace.WithBefore(func(r *http.Request, s ddtrace.Span) {
+			s.SetTag(ext.ServiceName, conf.serviceName)
+			s.SetTag(ext.HTTPURL, r.URL.Path)
+			s.SetTag(ext.HTTPMethod, r.Method)
+			s.SetTag(ext.ResourceName, r.Method+" "+r.URL.Path)
+			s.SetTag(ext.SpanType, ext.SpanTypeHTTP)
+			if ns := r.Header.Get(consts.NamespaceHeaderName); ns != "" {
+				s.SetTag("vault.namespace", ns)
 			}
 		}),
-		httptrace.WithAfter(func(resp *http.Response, span ddtrace.Span) {
-			if resp == nil {
+		httptrace.WithAfter(func(r *http.Response, s ddtrace.Span) {
+			if r == nil {
+				// An error occurred during the request.
 				return
 			}
-			span.SetTag(ext.HTTPCode, resp.StatusCode)
-			if resp.StatusCode >= 400 {
-				// See: https://www.vaultproject.io/api/overview.html#error-response
-				errs := []string{}
-				defer resp.Body.Close()
-				bodyBytes, err := ioutil.ReadAll(resp.Body)
-				if err != nil {
-					errs = append(errs, err.Error())
-				} else {
-					resp.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
-					vaultErrors := vaultErrors{}
-					err = json.Unmarshal(bodyBytes, &vaultErrors)
-					if err != nil {
-						errs = append(errs, err.Error())
-					} else {
-						errs = append(errs, vaultErrors.Errors...)
-					}
-				}
-				span.SetTag(ext.Error, fmt.Errorf("%d: %s", resp.StatusCode, http.StatusText(resp.StatusCode)))
-				span.SetTag(ext.ErrorDetails, errs)
+			s.SetTag(ext.HTTPCode, r.StatusCode)
+			if r.StatusCode >= 400 {
+				s.SetTag(ext.Error, fmt.Errorf("%d: %s", r.StatusCode, http.StatusText(r.StatusCode)))
 			}
 		}),
-	}
-	wrapperOpts = append(wrapperOpts, opts...)
-	wrapped := httptrace.WrapRoundTripper(client.Transport, wrapperOpts...)
-	client.Transport = wrapped
-	return client
+	)
+	return c
 }

--- a/contrib/hashicorp/vault/vault.go
+++ b/contrib/hashicorp/vault/vault.go
@@ -44,7 +44,6 @@ func WrapHTTPClient(c *http.Client, opts ...Option) *http.Client {
 		o(&conf)
 	}
 	c.Transport = httptrace.WrapRoundTripper(c.Transport,
-		httptrace.RTWithAnalytics(conf.withAnalytics),
 		httptrace.RTWithAnalyticsRate(conf.analyticsRate),
 		httptrace.WithBefore(func(r *http.Request, s ddtrace.Span) {
 			s.SetTag(ext.ServiceName, conf.serviceName)

--- a/contrib/hashicorp/vault/vault.go
+++ b/contrib/hashicorp/vault/vault.go
@@ -1,0 +1,98 @@
+// The vault package contains functions to construct an *http.Client that will
+// integrate with the github.com/hashicorp/vault/api and collect traces to send
+// to DataDog.
+//
+// The easiest way to use this package is to create an *http.Client with
+// NewHttpClient, and put it in the vault api config that's passed to the
+// NewClient function.
+//    import "github.com/hashicorp/vault/api"
+//    import trace "gopkg.in/DataDog/dd-trace-go.v1/contrib/hashicorp/vault"
+//
+//    func ... {
+//        api.NewClient(&api.Config{HttpClient: trace.NewHttpClient()})
+//    }
+//
+// If you are already using your own *http.Client with vault, you can use the
+// WrapHttpTransport function to wrap the client with the tracer code. Your
+// *http.Client will continue to work as before, but will also capture traces.
+//
+//    func ... {
+//        var myHttpClient *http.Client
+//        myHttpClient = ...
+//        api.NewClient(&api.Config{HttpClient: trace.WrapHttpTransport(myHttpClient)})
+//    }
+//
+package vault
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+
+	vault "github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/sdk/helper/consts"
+)
+
+// NewHttpClient returns an *http.Client for use in the config for the vault api
+// Client.
+func NewHttpClient() *http.Client {
+	dc := vault.DefaultConfig()
+	c := dc.HttpClient
+	WrapHttpTransport(c)
+	return c
+}
+
+type vaultErrors struct {
+	Errors []string `json:"errors"`
+}
+
+// WrapHttpTransport takes an existing *http.Client and wraps the transport with
+// the tracing code.
+func WrapHttpTransport(client *http.Client) *http.Client {
+	wrapped := httptrace.WrapRoundTripper(client.Transport,
+		httptrace.WithBefore(func(req *http.Request, span ddtrace.Span) {
+			span.SetTag(ext.ServiceName, "vault")
+			span.SetTag(ext.HTTPURL, req.URL.Path)
+			span.SetTag(ext.HTTPMethod, req.Method)
+			span.SetTag(ext.ResourceName, req.Method+" "+req.URL.Path)
+			span.SetTag(ext.SpanType, ext.SpanTypeVault)
+			namespace := req.Header.Get(consts.NamespaceHeaderName)
+			if namespace != "" {
+				span.SetTag("vault.namespace", namespace)
+			}
+		}),
+		httptrace.WithAfter(func(resp *http.Response, span ddtrace.Span) {
+			if resp != nil {
+				span.SetTag(ext.HTTPCode, resp.StatusCode)
+				if resp.StatusCode >= 400 {
+					// See: https://www.vaultproject.io/api/overview.html#error-response
+					errs := []string{}
+					defer resp.Body.Close()
+					bodyBytes, err := ioutil.ReadAll(resp.Body)
+					if err != nil {
+						errs = append(errs, err.Error())
+					} else {
+						resp.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+						vaultErrors := vaultErrors{}
+						err = json.Unmarshal(bodyBytes, &vaultErrors)
+						if err != nil {
+							errs = append(errs, err.Error())
+						} else {
+							errs = append(errs, vaultErrors.Errors...)
+						}
+					}
+					span.SetTag(ext.Error, fmt.Errorf("%d: %s", resp.StatusCode, http.StatusText(resp.StatusCode)))
+					span.SetTag(ext.ErrorDetails, errs)
+				}
+			}
+		}),
+	)
+	client.Transport = wrapped
+	return client
+}

--- a/contrib/hashicorp/vault/vault.go
+++ b/contrib/hashicorp/vault/vault.go
@@ -1,13 +1,14 @@
-// Package vault contains functions to construct an *http.Client that will
-// integrate with the github.com/hashicorp/vault/api and collect traces to send
-// to DataDog.
+// Package vault contains functions to construct or augment an http.Client that
+// will integrate with the github.com/hashicorp/vault/api and collect traces to
+// send to DataDog.
 //
-// The easiest way to use this package is to create an *http.Client with
-// NewHTTPClient, and put it in the vault api config that's passed to the
+// The easiest way to use this package is to create an http.Client with
+// NewHTTPClient, and put it in the Vault API config that is passed to the
 //
-// If you are already using your own *http.Client with vault, you can use the
-// WrapHTTPClient function to wrap the client with the tracer code. Your
-// *http.Client will continue to work as before, but will also capture traces.
+// If you are already using your own http.Client with the Vault API, you can
+// use the WrapHTTPClient function to wrap the client with the tracer code.
+// Your http.Client will continue to work as before, but will also capture
+// traces.
 package vault
 
 import (
@@ -22,8 +23,9 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/consts"
 )
 
-// NewHTTPClient returns an *http.Client for use in the config for the vault api
-// Client. Options can be optionally passed in to configure various tracer features such as Analytics
+// NewHTTPClient returns an http.Client for use in the config for the vault api
+// Client. Options can be optionally passed in to configure various tracer
+// features such as Analytics
 func NewHTTPClient(opts ...Option) *http.Client {
 	dc := api.DefaultConfig()
 	c := dc.HttpClient
@@ -31,7 +33,7 @@ func NewHTTPClient(opts ...Option) *http.Client {
 	return c
 }
 
-// WrapHTTPClient takes an existing *http.Client and wraps the transport with
+// WrapHTTPClient takes an existing http.Client and wraps the transport with
 // the tracing code. This will leave the existing Transport in place underneath,
 // only adding tracing code around it.
 func WrapHTTPClient(c *http.Client, opts ...Option) *http.Client {
@@ -63,7 +65,8 @@ func WrapHTTPClient(c *http.Client, opts ...Option) *http.Client {
 			}
 			s.SetTag(ext.HTTPCode, r.StatusCode)
 			if r.StatusCode >= 400 {
-				s.SetTag(ext.Error, fmt.Errorf("%d: %s", r.StatusCode, http.StatusText(r.StatusCode)))
+				s.SetTag(ext.Error, true)
+				s.SetTag(ext.ErrorMsg, fmt.Sprintf("%d: %s", r.StatusCode, http.StatusText(r.StatusCode)))
 			}
 		}),
 	)

--- a/contrib/hashicorp/vault/vault_test.go
+++ b/contrib/hashicorp/vault/vault_test.go
@@ -307,84 +307,73 @@ func TestOption(t *testing.T) {
 	ts, cleanup := setupServer(t)
 	defer cleanup()
 
-	for _, tt := range []struct {
-		name string
+	for ttName, tt := range map[string]struct {
 		opts []Option
 		test func(assert *assert.Assertions, span mocktracer.Span)
 	}{
-		{
-			name: "Default options",
+		"DefaultOptions": {
 			opts: []Option{},
 			test: func(assert *assert.Assertions, span mocktracer.Span) {
 				assert.Equal(defaultServiceName, span.Tag(ext.ServiceName))
 				assert.Nil(span.Tag(ext.EventSampleRate))
 			},
 		},
-		{
-			name: "Custom service name",
+		"CustomServiceName": {
 			opts: []Option{WithServiceName("someServiceName")},
 			test: func(assert *assert.Assertions, span mocktracer.Span) {
 				assert.Equal("someServiceName", span.Tag(ext.ServiceName))
 			},
 		},
-		{
-			name: "WithAnalytics(true)",
+		"WithAnalyticsTrue": {
 			opts: []Option{WithAnalytics(true)},
 			test: func(assert *assert.Assertions, span mocktracer.Span) {
 				assert.Equal(1.0, span.Tag(ext.EventSampleRate))
 			},
 		},
-		{
-			name: "WithAnalytics(false)",
+		"WithAnalyticsFalse": {
 			opts: []Option{WithAnalytics(false)},
 			test: func(assert *assert.Assertions, span mocktracer.Span) {
 				assert.Nil(span.Tag(ext.EventSampleRate))
 			},
 		},
-		{
-			name: "WithAnalytics Last option wins",
+		"WithAnalyticsLastOptionWins": {
 			opts: []Option{WithAnalyticsRate(0.7), WithAnalytics(true)},
 			test: func(assert *assert.Assertions, span mocktracer.Span) {
 				assert.Equal(1.0, span.Tag(ext.EventSampleRate))
 			},
 		},
-		{
-			name: "WithAnalyticsRate Negative rate",
+		"WithAnalyticsRateNegative": {
 			opts: []Option{WithAnalyticsRate(-10.0)},
 			test: func(assert *assert.Assertions, span mocktracer.Span) {
 				assert.Nil(span.Tag(ext.EventSampleRate))
 			},
 		},
-		{
-			name: "WithAnalyticsRate Greater than 1 rate",
+		"WithAnalyticsRateGreaterThanOne": {
 			opts: []Option{WithAnalyticsRate(10.0)},
 			test: func(assert *assert.Assertions, span mocktracer.Span) {
 				assert.Nil(span.Tag(ext.EventSampleRate))
 			},
 		},
-		{
-			name: "WithAnalyticsRate(1.0)",
+		"WithAnalyticsRateMax": {
 			opts: []Option{WithAnalyticsRate(1.0)},
 			test: func(assert *assert.Assertions, span mocktracer.Span) {
 				assert.Equal(1.0, span.Tag(ext.EventSampleRate))
 			},
 		},
-		{
-			name: "WithAnalyticsRate(0.0)",
+		"WithAnalyticsRateMin": {
 			opts: []Option{WithAnalyticsRate(0.0)},
 			test: func(assert *assert.Assertions, span mocktracer.Span) {
 				assert.Equal(0.0, span.Tag(ext.EventSampleRate))
 			},
 		},
-		{
-			name: "WithAnalyticsRate Last option wins",
+		"WithAnalyticsRateLastOptionWins": {
 			opts: []Option{WithAnalytics(true), WithAnalyticsRate(0.7)},
 			test: func(assert *assert.Assertions, span mocktracer.Span) {
 				assert.Equal(0.7, span.Tag(ext.EventSampleRate))
 			},
 		},
 	} {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(ttName, func(t *testing.T) {
 			assert := assert.New(t)
 			config := &api.Config{
 				HttpClient: NewHTTPClient(tt.opts...),

--- a/contrib/hashicorp/vault/vault_test.go
+++ b/contrib/hashicorp/vault/vault_test.go
@@ -28,6 +28,7 @@ func TestClient(t *testing.T) {
 		assert.NotNil(client)
 		assert.Nil(err)
 	})
+
 	t.Run("error", func(t *testing.T) {
 		assert := assert.New(t)
 		var config = &api.Config{
@@ -150,6 +151,7 @@ func testMountReadWrite(c *api.Client, t *testing.T) {
 		assert.Equal(ext.SpanTypeHTTP, span.Tag(ext.SpanType))
 		assert.Equal(200, span.Tag(ext.HTTPCode))
 		assert.Zero(span.Tag(ext.Error))
+		assert.Zero(span.Tag(ext.ErrorMsg))
 		assert.Zero(span.Tag("vault.namespace"))
 	})
 
@@ -174,6 +176,7 @@ func testMountReadWrite(c *api.Client, t *testing.T) {
 		assert.Equal(ext.SpanTypeHTTP, span.Tag(ext.SpanType))
 		assert.Equal(200, span.Tag(ext.HTTPCode))
 		assert.Zero(span.Tag(ext.Error))
+		assert.Zero(span.Tag(ext.ErrorMsg))
 		assert.Zero(span.Tag("vault.namespace"))
 	})
 
@@ -205,6 +208,7 @@ func testMountReadWrite(c *api.Client, t *testing.T) {
 		assert.Equal(ext.SpanTypeHTTP, span.Tag(ext.SpanType))
 		assert.Equal(200, span.Tag(ext.HTTPCode))
 		assert.Zero(span.Tag(ext.Error))
+		assert.Zero(span.Tag(ext.ErrorMsg))
 		assert.Zero(span.Tag("vault.namespace"))
 	})
 }
@@ -239,7 +243,8 @@ func TestReadError(t *testing.T) {
 	assert.Equal(http.MethodGet+" "+fullPath, span.Tag(ext.ResourceName))
 	assert.Equal(ext.SpanTypeHTTP, span.Tag(ext.SpanType))
 	assert.Equal(404, span.Tag(ext.HTTPCode))
-	assert.NotZero(span.Tag(ext.Error))
+	assert.Equal(true, span.Tag(ext.Error))
+	assert.NotZero(span.Tag(ext.ErrorMsg))
 	assert.Zero(span.Tag("vault.namespace"))
 }
 
@@ -258,6 +263,7 @@ func TestNamespace(t *testing.T) {
 	client.SetNamespace(namespace)
 	key := secretMountPath + "/testNamespace"
 	fullPath := "/v1" + key
+
 	t.Run("write", func(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
@@ -279,8 +285,10 @@ func TestNamespace(t *testing.T) {
 		assert.Equal(ext.SpanTypeHTTP, span.Tag(ext.SpanType))
 		assert.Equal(200, span.Tag(ext.HTTPCode))
 		assert.Zero(span.Tag(ext.Error))
+		assert.Zero(span.Tag(ext.ErrorMsg))
 		assert.Equal(namespace, span.Tag("vault.namespace"))
 	})
+
 	t.Run("read", func(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
@@ -307,6 +315,7 @@ func TestNamespace(t *testing.T) {
 		assert.Equal(ext.SpanTypeHTTP, span.Tag(ext.SpanType))
 		assert.Equal(200, span.Tag(ext.HTTPCode))
 		assert.Zero(span.Tag(ext.Error))
+		assert.Zero(span.Tag(ext.ErrorMsg))
 		assert.Equal(namespace, span.Tag("vault.namespace"))
 	})
 }

--- a/contrib/hashicorp/vault/vault_test.go
+++ b/contrib/hashicorp/vault/vault_test.go
@@ -342,18 +342,6 @@ func TestOption(t *testing.T) {
 				assert.Equal(1.0, span.Tag(ext.EventSampleRate))
 			},
 		},
-		"WithAnalyticsRateNegative": {
-			opts: []Option{WithAnalyticsRate(-10.0)},
-			test: func(assert *assert.Assertions, span mocktracer.Span) {
-				assert.Nil(span.Tag(ext.EventSampleRate))
-			},
-		},
-		"WithAnalyticsRateGreaterThanOne": {
-			opts: []Option{WithAnalyticsRate(10.0)},
-			test: func(assert *assert.Assertions, span mocktracer.Span) {
-				assert.Nil(span.Tag(ext.EventSampleRate))
-			},
-		},
 		"WithAnalyticsRateMax": {
 			opts: []Option{WithAnalyticsRate(1.0)},
 			test: func(assert *assert.Assertions, span mocktracer.Span) {

--- a/contrib/hashicorp/vault/vault_test.go
+++ b/contrib/hashicorp/vault/vault_test.go
@@ -11,173 +11,218 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 
-	vault "github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestClient(t *testing.T) {
-	assert := assert.New(t)
-	mt := mocktracer.Start()
-	defer mt.Stop()
-
-	client, err := vault.NewClient(&vault.Config{HttpClient: NewHttpClient()})
-	assert.NoError(err)
-
-	assert.NotNil(client)
-	assert.Nil(err)
-}
-
-func TestClientError(t *testing.T) {
-	assert := assert.New(t)
-	mt := mocktracer.Start()
-	defer mt.Stop()
-
-	var config = &vault.Config{
-		HttpClient: NewHttpClient(),
-		Address:    "http://bad host.com",
-	}
-
-	client, err := vault.NewClient(config)
-	assert.Nil(client)
-	assert.Error(err)
-}
 
 const (
 	secretMountPath = "/ns1/ns2/secret"
 )
 
-func setupServer(t *testing.T) *httptest.Server {
+func TestClient(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	t.Run("ok", func(t *testing.T) {
+		assert := assert.New(t)
+		client, err := api.NewClient(&api.Config{HttpClient: NewHTTPClient()})
+		assert.NoError(err)
+		assert.NotNil(client)
+		assert.Nil(err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		assert := assert.New(t)
+		var config = &api.Config{
+			HttpClient: NewHTTPClient(),
+			Address:    "http://bad host.com",
+		}
+		client, err := api.NewClient(config)
+		assert.Nil(client)
+		assert.Error(err)
+	})
+}
+
+func setupServer(t *testing.T) (*httptest.Server, func()) {
 	storage := make(map[string]string)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "PUT" {
-			fmt.Fprintln(w, "{}")
-			defer r.Body.Close()
-			bodyBytes, err := ioutil.ReadAll(r.Body)
-			body := string(bodyBytes)
+		switch r.Method {
+		case http.MethodPut:
+			slurp, err := ioutil.ReadAll(r.Body)
 			if err != nil {
-				t.Error(err)
+				t.Fatal(err)
+			}
+			defer r.Body.Close()
+			storage[r.URL.Path] = string(slurp)
+			fmt.Fprintln(w, "{}")
+		case http.MethodGet:
+			value, ok := storage[r.URL.Path]
+			if !ok {
+				http.Error(w, "No data for key.", http.StatusNotFound)
 				return
 			}
-			storage[r.URL.Path] = body
-		} else if r.Method == "GET" {
-			if value, ok := storage[r.URL.Path]; ok {
-				secret := vault.Secret{}
-				secret.Data = make(map[string]interface{})
-				json.Unmarshal([]byte(value), &secret.Data)
-				secretJson, err := json.Marshal(secret)
-				if err != nil {
-					t.Error(err)
-					return
-				}
-				fmt.Fprintf(w, "%s\n", secretJson)
-			} else {
-				http.Error(w, "No data for key.", http.StatusNotFound)
+			secret := api.Secret{}
+			secret.Data = make(map[string]interface{})
+			json.Unmarshal([]byte(value), &secret.Data)
+			secretJson, err := json.Marshal(secret)
+			if err != nil {
+				t.Fatal(err)
 			}
+			fmt.Fprintf(w, "%s\n", secretJson)
 		}
 	}))
-	return ts
+	return ts, func() {
+		ts.Close()
+	}
 }
 
-func cleanupServer(ts *httptest.Server) {
-	ts.Close()
-}
-
-func setupVault(ts *httptest.Server) (*vault.Client, error) {
-	var config = &vault.Config{
-		HttpClient: NewHttpClient(),
+func setupClient(ts *httptest.Server) (*api.Client, error) {
+	config := &api.Config{
+		HttpClient: NewHTTPClient(),
 		Address:    ts.URL,
 	}
 
-	client, err := vault.NewClient(config)
-	client.SetToken("myroot")
-
-	secretMount := vault.MountInput{
-		Type:        "kv",
-		Description: "Test KV Store",
-		Local:       true,
-	}
-	err = client.Sys().Mount(secretMountPath, &secretMount)
+	client, err := api.NewClient(config)
 	if err != nil {
 		return nil, err
 	}
 	return client, nil
 }
 
-func cleanupVault(client *vault.Client) {
-	client.Sys().Unmount(secretMountPath)
+func TestNewHTTPClient(t *testing.T) {
+	ts, cleanupTs := setupServer(t)
+	defer cleanupTs()
+
+	client, err := setupClient(ts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testMountReadWrite(client, t)
 }
 
-func TestMountReadWrite(t *testing.T) {
+func TestWrapHTTPTransport(t *testing.T) {
+	ts, cleanupTs := setupServer(t)
+	defer cleanupTs()
+
+	httpClient := http.Client{}
+	config := &api.Config{
+		HttpClient: WrapHTTPTransport(&httpClient),
+		Address:    ts.URL,
+	}
+
+	client, err := api.NewClient(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.SetToken("myroot")
+
+	testMountReadWrite(client, t)
+}
+
+func mountKV(client *api.Client, t *testing.T) func() {
+	secretMount := api.MountInput{
+		Type:        "kv",
+		Description: "Test KV Store",
+		Local:       true,
+	}
+
+	if err := client.Sys().Mount(secretMountPath, &secretMount); err != nil {
+		t.Fatal(err)
+	}
+
+	return func() {
+		client.Sys().Unmount(secretMountPath)
+	}
+}
+
+func testMountReadWrite(client *api.Client, t *testing.T) {
 	assert := assert.New(t)
-	mt := mocktracer.Start()
-	defer mt.Stop()
-
-	ts := setupServer(t)
-	defer cleanupServer(ts)
-	client, err := setupVault(ts)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	defer cleanupVault(client)
-
 	key := secretMountPath + "/test"
-	secretData := map[string]interface{}{"Key1": "Val1", "Key2": "Val2"}
-	secret, err := client.Logical().Write(key, secretData)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	secret, err = client.Logical().Read(key)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	assert.Equal(secret.Data["Key1"], secretData["Key1"])
-	assert.Equal(secret.Data["Key2"], secretData["Key2"])
-
-	spans := mt.FinishedSpans()
-	assert.Len(spans, 3)
-	mount := spans[0]
-	write := spans[1]
-	read := spans[2]
-
 	fullPath := "/v1" + key
+	secretData := map[string]interface{}{"Key1": "Val1", "Key2": "Val2"}
 
-	// Mount operation
-	assert.Equal("vault", mount.Tag(ext.ServiceName))
-	assert.Equal("/v1/sys/mounts/ns1/ns2/secret", mount.Tag(ext.HTTPURL))
-	assert.Equal(http.MethodPost, mount.Tag(ext.HTTPMethod))
-	assert.Equal(http.MethodPost+" /v1/sys/mounts/ns1/ns2/secret", mount.Tag(ext.ResourceName))
-	assert.Equal(ext.SpanTypeVault, mount.Tag(ext.SpanType))
-	assert.Equal(200, mount.Tag(ext.HTTPCode))
-	assert.Zero(mount.Tag(ext.Error))
-	assert.Zero(mount.Tag(ext.ErrorDetails))
-	assert.Zero(mount.Tag("vault.namespace"))
+	t.Run("mount", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+		defer mountKV(client, t)()
 
-	// Write key
-	assert.Equal("vault", write.Tag(ext.ServiceName))
-	assert.Equal(fullPath, write.Tag(ext.HTTPURL))
-	assert.Equal(http.MethodPut, write.Tag(ext.HTTPMethod))
-	assert.Equal(http.MethodPut+" "+fullPath, write.Tag(ext.ResourceName))
-	assert.Equal(ext.SpanTypeVault, write.Tag(ext.SpanType))
-	assert.Equal(200, write.Tag(ext.HTTPCode))
-	assert.Zero(write.Tag(ext.Error))
-	assert.Zero(write.Tag(ext.ErrorDetails))
-	assert.Zero(write.Tag("vault.namespace"))
+		spans := mt.FinishedSpans()
+		assert.Len(spans, 1)
+		mount := spans[0]
 
-	// Read key
-	assert.Equal("vault", read.Tag(ext.ServiceName))
-	assert.Equal(fullPath, read.Tag(ext.HTTPURL))
-	assert.Equal(http.MethodGet, read.Tag(ext.HTTPMethod))
-	assert.Equal(http.MethodGet+" "+fullPath, read.Tag(ext.ResourceName))
-	assert.Equal(ext.SpanTypeVault, read.Tag(ext.SpanType))
-	assert.Equal(200, read.Tag(ext.HTTPCode))
-	assert.Zero(read.Tag(ext.Error))
-	assert.Zero(read.Tag(ext.ErrorDetails))
-	assert.Zero(read.Tag("vault.namespace"))
+		// Mount operation
+		assert.Equal("vault", mount.Tag(ext.ServiceName))
+		assert.Equal("/v1/sys/mounts/ns1/ns2/secret", mount.Tag(ext.HTTPURL))
+		assert.Equal(http.MethodPost, mount.Tag(ext.HTTPMethod))
+		assert.Equal(http.MethodPost+" /v1/sys/mounts/ns1/ns2/secret", mount.Tag(ext.ResourceName))
+		assert.Equal(ext.SpanTypeHTTP, mount.Tag(ext.SpanType))
+		assert.Equal(200, mount.Tag(ext.HTTPCode))
+		assert.Zero(mount.Tag(ext.Error))
+		assert.Zero(mount.Tag(ext.ErrorDetails))
+		assert.Zero(mount.Tag("vault.namespace"))
+	})
+
+	t.Run("write", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+		defer mountKV(client, t)()
+
+		// Write key
+		_, err := client.Logical().Write(key, secretData)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		spans := mt.FinishedSpans()
+		assert.Len(spans, 2)
+		write := spans[1]
+
+		assert.Equal("vault", write.Tag(ext.ServiceName))
+		assert.Equal(fullPath, write.Tag(ext.HTTPURL))
+		assert.Equal(http.MethodPut, write.Tag(ext.HTTPMethod))
+		assert.Equal(http.MethodPut+" "+fullPath, write.Tag(ext.ResourceName))
+		assert.Equal(ext.SpanTypeHTTP, write.Tag(ext.SpanType))
+		assert.Equal(200, write.Tag(ext.HTTPCode))
+		assert.Zero(write.Tag(ext.Error))
+		assert.Zero(write.Tag(ext.ErrorDetails))
+		assert.Zero(write.Tag("vault.namespace"))
+	})
+
+	t.Run("read", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+		defer mountKV(client, t)()
+
+		// Write the key first
+		_, err := client.Logical().Write(key, secretData)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Read key
+		secret, err := client.Logical().Read(key)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(secret.Data["Key1"], secretData["Key1"])
+		assert.Equal(secret.Data["Key2"], secretData["Key2"])
+
+		spans := mt.FinishedSpans()
+		assert.Len(spans, 3)
+		read := spans[2]
+
+		assert.Equal("vault", read.Tag(ext.ServiceName))
+		assert.Equal(fullPath, read.Tag(ext.HTTPURL))
+		assert.Equal(http.MethodGet, read.Tag(ext.HTTPMethod))
+		assert.Equal(http.MethodGet+" "+fullPath, read.Tag(ext.ResourceName))
+		assert.Equal(ext.SpanTypeHTTP, read.Tag(ext.SpanType))
+		assert.Equal(200, read.Tag(ext.HTTPCode))
+		assert.Zero(read.Tag(ext.Error))
+		assert.Zero(read.Tag(ext.ErrorDetails))
+		assert.Zero(read.Tag("vault.namespace"))
+	})
 }
 
 func TestReadError(t *testing.T) {
@@ -185,20 +230,18 @@ func TestReadError(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	ts := setupServer(t)
-	defer cleanupServer(ts)
-	client, err := setupVault(ts)
+	ts, cleanupTs := setupServer(t)
+	defer cleanupTs()
+	client, err := setupClient(ts)
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
-	defer cleanupVault(client)
+	defer mountKV(client, t)()
 
 	key := "/some/bad/key"
 	secret, err := client.Logical().Read(key)
 	if err == nil {
-		t.Errorf("Expected error when reading key from %s, but it returned: %#v", key, secret)
-		return
+		t.Fatalf("Expected error when reading key from %s, but it returned: %#v", key, secret)
 	}
 
 	spans := mt.FinishedSpans()
@@ -212,7 +255,7 @@ func TestReadError(t *testing.T) {
 	assert.Equal(fullPath, readErr.Tag(ext.HTTPURL))
 	assert.Equal(http.MethodGet, readErr.Tag(ext.HTTPMethod))
 	assert.Equal(http.MethodGet+" "+fullPath, readErr.Tag(ext.ResourceName))
-	assert.Equal(ext.SpanTypeVault, readErr.Tag(ext.SpanType))
+	assert.Equal(ext.SpanTypeHTTP, readErr.Tag(ext.SpanType))
 	assert.Equal(404, readErr.Tag(ext.HTTPCode))
 	assert.NotZero(readErr.Tag(ext.Error))
 	assert.NotZero(readErr.Tag(ext.ErrorDetails))
@@ -221,61 +264,76 @@ func TestReadError(t *testing.T) {
 
 func TestNamespace(t *testing.T) {
 	assert := assert.New(t)
-	mt := mocktracer.Start()
-	defer mt.Stop()
 
-	ts := setupServer(t)
-	defer cleanupServer(ts)
-	client, err := setupVault(ts)
+	ts, cleanupTs := setupServer(t)
+	defer cleanupTs()
+	client, err := setupClient(ts)
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
-	defer cleanupVault(client)
+	defer mountKV(client, t)()
 
 	namespace := "/some/namespace"
 	client.SetNamespace(namespace)
 
 	key := secretMountPath + "/testNamespace"
-	secretData := map[string]interface{}{"Key1": "Val1", "Key2": "Val2"}
-	_, err = client.Logical().Write(key, secretData)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	_, err = client.Logical().Read(key)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	spans := mt.FinishedSpans()
-	assert.Len(spans, 3)
-	writeWithNamespace := spans[1]
-	readWithNamespace := spans[2]
-
 	fullPath := "/v1" + key
 
-	// Write key with namespace
-	assert.Equal("vault", writeWithNamespace.Tag(ext.ServiceName))
-	assert.Equal(fullPath, writeWithNamespace.Tag(ext.HTTPURL))
-	assert.Equal(http.MethodPut, writeWithNamespace.Tag(ext.HTTPMethod))
-	assert.Equal(http.MethodPut+" "+fullPath, writeWithNamespace.Tag(ext.ResourceName))
-	assert.Equal(ext.SpanTypeVault, writeWithNamespace.Tag(ext.SpanType))
-	assert.Equal(200, writeWithNamespace.Tag(ext.HTTPCode))
-	assert.Zero(writeWithNamespace.Tag(ext.Error))
-	assert.Zero(writeWithNamespace.Tag(ext.ErrorDetails))
-	assert.Equal(namespace, writeWithNamespace.Tag("vault.namespace"))
+	t.Run("write", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
 
-	// Read key with namespace
-	assert.Equal("vault", readWithNamespace.Tag(ext.ServiceName))
-	assert.Equal(fullPath, readWithNamespace.Tag(ext.HTTPURL))
-	assert.Equal(http.MethodGet, readWithNamespace.Tag(ext.HTTPMethod))
-	assert.Equal(http.MethodGet+" "+fullPath, readWithNamespace.Tag(ext.ResourceName))
-	assert.Equal(ext.SpanTypeVault, readWithNamespace.Tag(ext.SpanType))
-	assert.Equal(200, readWithNamespace.Tag(ext.HTTPCode))
-	assert.Zero(readWithNamespace.Tag(ext.Error))
-	assert.Zero(readWithNamespace.Tag(ext.ErrorDetails))
-	assert.Equal(namespace, readWithNamespace.Tag("vault.namespace"))
+		// Write key with namespace
+		secretData := map[string]interface{}{"Key1": "Val1", "Key2": "Val2"}
+		_, err = client.Logical().Write(key, secretData)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		spans := mt.FinishedSpans()
+		assert.Len(spans, 1)
+		writeWithNamespace := spans[0]
+
+		assert.Equal("vault", writeWithNamespace.Tag(ext.ServiceName))
+		assert.Equal(fullPath, writeWithNamespace.Tag(ext.HTTPURL))
+		assert.Equal(http.MethodPut, writeWithNamespace.Tag(ext.HTTPMethod))
+		assert.Equal(http.MethodPut+" "+fullPath, writeWithNamespace.Tag(ext.ResourceName))
+		assert.Equal(ext.SpanTypeHTTP, writeWithNamespace.Tag(ext.SpanType))
+		assert.Equal(200, writeWithNamespace.Tag(ext.HTTPCode))
+		assert.Zero(writeWithNamespace.Tag(ext.Error))
+		assert.Zero(writeWithNamespace.Tag(ext.ErrorDetails))
+		assert.Equal(namespace, writeWithNamespace.Tag("vault.namespace"))
+	})
+
+	t.Run("read", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		// Write key with namespace first
+		secretData := map[string]interface{}{"Key1": "Val1", "Key2": "Val2"}
+		_, err = client.Logical().Write(key, secretData)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Read key with namespace
+		_, err = client.Logical().Read(key)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		spans := mt.FinishedSpans()
+		assert.Len(spans, 2)
+		readWithNamespace := spans[1]
+
+		assert.Equal("vault", readWithNamespace.Tag(ext.ServiceName))
+		assert.Equal(fullPath, readWithNamespace.Tag(ext.HTTPURL))
+		assert.Equal(http.MethodGet, readWithNamespace.Tag(ext.HTTPMethod))
+		assert.Equal(http.MethodGet+" "+fullPath, readWithNamespace.Tag(ext.ResourceName))
+		assert.Equal(ext.SpanTypeHTTP, readWithNamespace.Tag(ext.SpanType))
+		assert.Equal(200, readWithNamespace.Tag(ext.HTTPCode))
+		assert.Zero(readWithNamespace.Tag(ext.Error))
+		assert.Zero(readWithNamespace.Tag(ext.ErrorDetails))
+		assert.Equal(namespace, readWithNamespace.Tag("vault.namespace"))
+	})
 }

--- a/contrib/hashicorp/vault/vault_test.go
+++ b/contrib/hashicorp/vault/vault_test.go
@@ -1,0 +1,281 @@
+package vault
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+
+	vault "github.com/hashicorp/vault/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	client, err := vault.NewClient(&vault.Config{HttpClient: NewHttpClient()})
+	assert.NoError(err)
+
+	assert.NotNil(client)
+	assert.Nil(err)
+}
+
+func TestClientError(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	var config = &vault.Config{
+		HttpClient: NewHttpClient(),
+		Address:    "http://bad host.com",
+	}
+
+	client, err := vault.NewClient(config)
+	assert.Nil(client)
+	assert.Error(err)
+}
+
+const (
+	secretMountPath = "/ns1/ns2/secret"
+)
+
+func setupServer(t *testing.T) *httptest.Server {
+	storage := make(map[string]string)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PUT" {
+			fmt.Fprintln(w, "{}")
+			defer r.Body.Close()
+			bodyBytes, err := ioutil.ReadAll(r.Body)
+			body := string(bodyBytes)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			storage[r.URL.Path] = body
+		} else if r.Method == "GET" {
+			if value, ok := storage[r.URL.Path]; ok {
+				secret := vault.Secret{}
+				secret.Data = make(map[string]interface{})
+				json.Unmarshal([]byte(value), &secret.Data)
+				secretJson, err := json.Marshal(secret)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				fmt.Fprintf(w, "%s\n", secretJson)
+			} else {
+				http.Error(w, "No data for key.", http.StatusNotFound)
+			}
+		}
+	}))
+	return ts
+}
+
+func cleanupServer(ts *httptest.Server) {
+	ts.Close()
+}
+
+func setupVault(ts *httptest.Server) (*vault.Client, error) {
+	var config = &vault.Config{
+		HttpClient: NewHttpClient(),
+		Address:    ts.URL,
+	}
+
+	client, err := vault.NewClient(config)
+	client.SetToken("myroot")
+
+	secretMount := vault.MountInput{
+		Type:        "kv",
+		Description: "Test KV Store",
+		Local:       true,
+	}
+	err = client.Sys().Mount(secretMountPath, &secretMount)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+func cleanupVault(client *vault.Client) {
+	client.Sys().Unmount(secretMountPath)
+}
+
+func TestMountReadWrite(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	ts := setupServer(t)
+	defer cleanupServer(ts)
+	client, err := setupVault(ts)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer cleanupVault(client)
+
+	key := secretMountPath + "/test"
+	secretData := map[string]interface{}{"Key1": "Val1", "Key2": "Val2"}
+	secret, err := client.Logical().Write(key, secretData)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	secret, err = client.Logical().Read(key)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	assert.Equal(secret.Data["Key1"], secretData["Key1"])
+	assert.Equal(secret.Data["Key2"], secretData["Key2"])
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 3)
+	mount := spans[0]
+	write := spans[1]
+	read := spans[2]
+
+	fullPath := "/v1" + key
+
+	// Mount operation
+	assert.Equal("vault", mount.Tag(ext.ServiceName))
+	assert.Equal("/v1/sys/mounts/ns1/ns2/secret", mount.Tag(ext.HTTPURL))
+	assert.Equal(http.MethodPost, mount.Tag(ext.HTTPMethod))
+	assert.Equal(http.MethodPost+" /v1/sys/mounts/ns1/ns2/secret", mount.Tag(ext.ResourceName))
+	assert.Equal(ext.SpanTypeVault, mount.Tag(ext.SpanType))
+	assert.Equal(200, mount.Tag(ext.HTTPCode))
+	assert.Zero(mount.Tag(ext.Error))
+	assert.Zero(mount.Tag(ext.ErrorDetails))
+	assert.Zero(mount.Tag("vault.namespace"))
+
+	// Write key
+	assert.Equal("vault", write.Tag(ext.ServiceName))
+	assert.Equal(fullPath, write.Tag(ext.HTTPURL))
+	assert.Equal(http.MethodPut, write.Tag(ext.HTTPMethod))
+	assert.Equal(http.MethodPut+" "+fullPath, write.Tag(ext.ResourceName))
+	assert.Equal(ext.SpanTypeVault, write.Tag(ext.SpanType))
+	assert.Equal(200, write.Tag(ext.HTTPCode))
+	assert.Zero(write.Tag(ext.Error))
+	assert.Zero(write.Tag(ext.ErrorDetails))
+	assert.Zero(write.Tag("vault.namespace"))
+
+	// Read key
+	assert.Equal("vault", read.Tag(ext.ServiceName))
+	assert.Equal(fullPath, read.Tag(ext.HTTPURL))
+	assert.Equal(http.MethodGet, read.Tag(ext.HTTPMethod))
+	assert.Equal(http.MethodGet+" "+fullPath, read.Tag(ext.ResourceName))
+	assert.Equal(ext.SpanTypeVault, read.Tag(ext.SpanType))
+	assert.Equal(200, read.Tag(ext.HTTPCode))
+	assert.Zero(read.Tag(ext.Error))
+	assert.Zero(read.Tag(ext.ErrorDetails))
+	assert.Zero(read.Tag("vault.namespace"))
+}
+
+func TestReadError(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	ts := setupServer(t)
+	defer cleanupServer(ts)
+	client, err := setupVault(ts)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer cleanupVault(client)
+
+	key := "/some/bad/key"
+	secret, err := client.Logical().Read(key)
+	if err == nil {
+		t.Errorf("Expected error when reading key from %s, but it returned: %#v", key, secret)
+		return
+	}
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 2)
+	readErr := spans[1]
+
+	fullPath := "/v1" + key
+
+	// Read key error
+	assert.Equal("vault", readErr.Tag(ext.ServiceName))
+	assert.Equal(fullPath, readErr.Tag(ext.HTTPURL))
+	assert.Equal(http.MethodGet, readErr.Tag(ext.HTTPMethod))
+	assert.Equal(http.MethodGet+" "+fullPath, readErr.Tag(ext.ResourceName))
+	assert.Equal(ext.SpanTypeVault, readErr.Tag(ext.SpanType))
+	assert.Equal(404, readErr.Tag(ext.HTTPCode))
+	assert.NotZero(readErr.Tag(ext.Error))
+	assert.NotZero(readErr.Tag(ext.ErrorDetails))
+	assert.Zero(readErr.Tag("vault.namespace"))
+}
+
+func TestNamespace(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	ts := setupServer(t)
+	defer cleanupServer(ts)
+	client, err := setupVault(ts)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer cleanupVault(client)
+
+	namespace := "/some/namespace"
+	client.SetNamespace(namespace)
+
+	key := secretMountPath + "/testNamespace"
+	secretData := map[string]interface{}{"Key1": "Val1", "Key2": "Val2"}
+	_, err = client.Logical().Write(key, secretData)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	_, err = client.Logical().Read(key)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 3)
+	writeWithNamespace := spans[1]
+	readWithNamespace := spans[2]
+
+	fullPath := "/v1" + key
+
+	// Write key with namespace
+	assert.Equal("vault", writeWithNamespace.Tag(ext.ServiceName))
+	assert.Equal(fullPath, writeWithNamespace.Tag(ext.HTTPURL))
+	assert.Equal(http.MethodPut, writeWithNamespace.Tag(ext.HTTPMethod))
+	assert.Equal(http.MethodPut+" "+fullPath, writeWithNamespace.Tag(ext.ResourceName))
+	assert.Equal(ext.SpanTypeVault, writeWithNamespace.Tag(ext.SpanType))
+	assert.Equal(200, writeWithNamespace.Tag(ext.HTTPCode))
+	assert.Zero(writeWithNamespace.Tag(ext.Error))
+	assert.Zero(writeWithNamespace.Tag(ext.ErrorDetails))
+	assert.Equal(namespace, writeWithNamespace.Tag("vault.namespace"))
+
+	// Read key with namespace
+	assert.Equal("vault", readWithNamespace.Tag(ext.ServiceName))
+	assert.Equal(fullPath, readWithNamespace.Tag(ext.HTTPURL))
+	assert.Equal(http.MethodGet, readWithNamespace.Tag(ext.HTTPMethod))
+	assert.Equal(http.MethodGet+" "+fullPath, readWithNamespace.Tag(ext.ResourceName))
+	assert.Equal(ext.SpanTypeVault, readWithNamespace.Tag(ext.SpanType))
+	assert.Equal(200, readWithNamespace.Tag(ext.HTTPCode))
+	assert.Zero(readWithNamespace.Tag(ext.Error))
+	assert.Zero(readWithNamespace.Tag(ext.ErrorDetails))
+	assert.Equal(namespace, readWithNamespace.Tag("vault.namespace"))
+}

--- a/ddtrace/ext/app_types.go
+++ b/ddtrace/ext/app_types.go
@@ -75,4 +75,7 @@ const (
 
 	// SpanTypeConsul marks a span as a Consul operation.
 	SpanTypeConsul = "consul"
+
+	// SpanTypeVault marks a span as a Vault operation.
+	SpanTypeVault = "vault"
 )

--- a/ddtrace/ext/app_types.go
+++ b/ddtrace/ext/app_types.go
@@ -75,7 +75,4 @@ const (
 
 	// SpanTypeConsul marks a span as a Consul operation.
 	SpanTypeConsul = "consul"
-
-	// SpanTypeVault marks a span as a Vault operation.
-	SpanTypeVault = "vault"
 )


### PR DESCRIPTION
This PR adds an integration for Vault's Go library.

The vault code can be found [here](https://github.com/hashicorp/vault/tree/master/api) with docs [here](https://godoc.org/github.com/hashicorp/vault/api)

This code takes advantage of vault's configuration, which accepts an `*http.Client` instance that it will use for all communication with vault. The `func NewHttpClient() *http.Client` returns an `*http.Client` which can be put in vault's `*api.Config` before creating the vault client with `client = api.NewClient(config)`
```
api.NewClient(&api.Config{HttpClient: trace.NewHttpClient()})
```

The client provided by this package uses our `contrib/net/http` functions to wrap the `*http.Client`'s transport and inspect outgoing http requests and incoming responses.

If our `*http.Client` isn't sufficient, the package also provides `func WrapHttpTransport(*http.Client) *http.Client` which will take an existing `*http.Client` and wrap it with the tracing code, so anyone who wants to use tracing can continue to use any `*http.Client` that they were previously using.