### PR TITLE
ddtrace/tracer: fix flake in metrics test

### DIFF
--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -6,6 +6,7 @@
 package tracer
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -95,7 +96,7 @@ func (tg *testGauger) Wait(n int, d time.Duration) error {
 	tg.mu.Lock()
 	if tg.waitCh != nil {
 		tg.mu.Unlock()
-		return fmt.Errorf("already waiting")
+		return errors.New("already waiting")
 	}
 	tg.waitCh = make(chan struct{})
 	tg.n = n
@@ -105,6 +106,6 @@ func (tg *testGauger) Wait(n int, d time.Duration) error {
 	case <-tg.waitCh:
 		return nil
 	case <-time.After(d):
-		return fmt.Errorf("timed out after waiting %v for gauge events", d)
+		return fmt.Errorf("timed out after waiting %s for gauge events", d)
 	}
 }

--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -84,6 +84,7 @@ func (tg *testGauger) Reset() {
 	tg.tags = tg.tags[:0]
 	if tg.waitCh != nil {
 		close(tg.waitCh)
+		tg.waitCh = nil
 	}
 	tg.n = 0
 }


### PR DESCRIPTION
Sometimes 5ms isn't enough to schedule the goroutine and collect the initial sweep of metrics.
This failed on CI for head of v1 branch.

```
--- FAIL: TestReportMetrics (0.01s)
        Error Trace:    metrics_test.go:35
        Error:      	Should be true
        Test:       	TestReportMetrics
        Error Trace:    metrics_test.go:36
        Error:      	"[]" does not contain "runtime.go.num_cpu"
        Test:       	TestReportMetrics
        ...snip...
FAIL
exit status 1
```

This uses a channel to report back the `Guage` calls on the testGuage, making sure we get 30+ calls before doing checks.