### PR TITLE
ci: add checkcopyright script to run on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,11 @@ jobs:
     steps:
     - checkout
 
+    - run:
+        name: Check copyright
+        command: |
+          go run checkcopyright.go
+
     - restore_cache:
         keys:
         - v1-librdkafka-v1.1.0-{{ checksum "/etc/os-release" }}

--- a/checkcopyright.go
+++ b/checkcopyright.go
@@ -1,0 +1,48 @@
+// +build ignore
+
+// This tool validates that all *.go files in the repository have the copyright text attached.
+package main
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var copyrightText = []byte("// Copyright 2016-2019 Datadog, Inc.")
+
+func main() {
+	var missing bool
+	if err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if filepath.Ext(path) != ".go" || info.IsDir() || strings.Contains(path, "vendor") {
+			return nil
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		// read 1KB, header should be there
+		snip := make([]byte, 1024)
+		_, err = f.Read(snip)
+		if err != nil {
+			return err
+		}
+		if !bytes.Contains(snip, copyrightText) {
+			// report missing header
+			missing = true
+			log.Printf("Copyright header missing in %q.\n", path)
+		}
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+	if missing {
+		// some files are missing the header, exit code 1 to fail CI
+		os.Exit(1)
+	}
+}

--- a/checkcopyright.go
+++ b/checkcopyright.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
 // +build ignore
 
 // This tool validates that all *.go files in the repository have the copyright text attached.
@@ -5,16 +10,18 @@ package main
 
 import (
 	"bytes"
+	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
-
-var copyrightText = []byte("// Copyright 2016-2019 Datadog, Inc.")
 
 func main() {
 	var missing bool
+	copyrightText := []byte(fmt.Sprintf("// Copyright 2016-%s Datadog, Inc.", time.Now().Format("2006")))
 	if err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -26,10 +33,11 @@ func main() {
 		if err != nil {
 			return err
 		}
+		defer f.Close()
 		// read 1KB, header should be there
 		snip := make([]byte, 1024)
 		_, err = f.Read(snip)
-		if err != nil {
+		if err != nil && err != io.EOF {
 			return err
 		}
 		if !bytes.Contains(snip, copyrightText) {

--- a/contrib/hashicorp/consul/benchmark_test.go
+++ b/contrib/hashicorp/consul/benchmark_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
 package consul
 
 import (

--- a/contrib/hashicorp/consul/consul.go
+++ b/contrib/hashicorp/consul/consul.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
 package consul
 
 import (

--- a/contrib/hashicorp/consul/consul_test.go
+++ b/contrib/hashicorp/consul/consul_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
 package consul
 
 import (

--- a/contrib/hashicorp/consul/example_test.go
+++ b/contrib/hashicorp/consul/example_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
 package consul
 
 import (

--- a/contrib/hashicorp/consul/option.go
+++ b/contrib/hashicorp/consul/option.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
 package consul
 
 import "math"


### PR DESCRIPTION
We keep forgetting to add copyright headers, so...

This change adds a script that will run on CI, checking that all files
have a copyright text in the first 1KB of source code.

Example:

<img width="1335" alt="Screenshot 2019-10-10 at 15 04 47" src="https://user-images.githubusercontent.com/6686356/66571334-53b85f80-eb6f-11e9-9f93-03ff49898bf3.png">
