### PR TITLE
contrib/99designs/gqlgen: implement github.com/99designs/gqlgen integration.

### DIFF
--- a/contrib/99designs/gqlgen/example_test.go
+++ b/contrib/99designs/gqlgen/example_test.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package gqlgen_test
+
+import (
+	"log"
+	"net/http"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/contrib/99designs/gqlgen"
+
+	"github.com/99designs/gqlgen/example/todo"
+	"github.com/99designs/gqlgen/handler"
+)
+
+func ExampleNew() {
+	tracer := gqlgen.New(
+		gqlgen.WithAnalytics(true),
+		gqlgen.WithServiceName("todoServer"),
+	)
+	http.Handle("/query", handler.GraphQL(
+		todo.NewExecutableSchema(todo.New()),
+		// We can add our tracer in when we set up the query handler.
+		handler.Tracer(tracer),
+	))
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/contrib/99designs/gqlgen/example_test.go
+++ b/contrib/99designs/gqlgen/example_test.go
@@ -22,7 +22,6 @@ func ExampleNew() {
 	)
 	http.Handle("/query", handler.GraphQL(
 		todo.NewExecutableSchema(todo.New()),
-		// We can add our tracer in when we set up the query handler.
 		handler.Tracer(tracer),
 	))
 	log.Fatal(http.ListenAndServe(":8080", nil))

--- a/contrib/99designs/gqlgen/example_test.go
+++ b/contrib/99designs/gqlgen/example_test.go
@@ -10,15 +10,19 @@ import (
 	"net/http"
 
 	gqlgentrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/99designs/gqlgen"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	"github.com/99designs/gqlgen/example/todo"
 	"github.com/99designs/gqlgen/handler"
 )
 
 func ExampleNew() {
-	tracer := gqlgentrace.New(
+	tracer.Start()
+	defer tracer.Stop()
+
+	tracer := gqlgentrace.NewTracer(
 		gqlgentrace.WithAnalytics(true),
-		gqlgentrace.WithServiceName("todoServer"),
+		gqlgentrace.WithServiceName("todo.server"),
 	)
 	http.Handle("/query", handler.GraphQL(
 		todo.NewExecutableSchema(todo.New()),

--- a/contrib/99designs/gqlgen/example_test.go
+++ b/contrib/99designs/gqlgen/example_test.go
@@ -9,16 +9,16 @@ import (
 	"log"
 	"net/http"
 
-	"gopkg.in/DataDog/dd-trace-go.v1/contrib/99designs/gqlgen"
+	gqlgentrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/99designs/gqlgen"
 
 	"github.com/99designs/gqlgen/example/todo"
 	"github.com/99designs/gqlgen/handler"
 )
 
 func ExampleNew() {
-	tracer := gqlgen.New(
-		gqlgen.WithAnalytics(true),
-		gqlgen.WithServiceName("todoServer"),
+	tracer := gqlgentrace.New(
+		gqlgentrace.WithAnalytics(true),
+		gqlgentrace.WithServiceName("todoServer"),
 	)
 	http.Handle("/query", handler.GraphQL(
 		todo.NewExecutableSchema(todo.New()),

--- a/contrib/99designs/gqlgen/option.go
+++ b/contrib/99designs/gqlgen/option.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package gqlgen
+
+import (
+	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+)
+
+const defaultServiceName = "gqlgen"
+
+type config struct {
+	serviceName   string
+	analyticsRate float64
+}
+
+// Option instances can be passed to New to configure the integration.
+type Option func(t *config)
+
+func defaults(t *config) {
+	t.serviceName = defaultServiceName
+	t.analyticsRate = globalconfig.AnalyticsRate()
+}
+
+// WithAnalytics enables or disables Trace Analytics for all started spans.
+func WithAnalytics(on bool) Option {
+	if on {
+		return WithAnalyticsRate(1.0)
+	}
+	return WithAnalyticsRate(math.NaN())
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events correlated to started spans.
+func WithAnalyticsRate(rate float64) Option {
+	return func(t *config) {
+		t.analyticsRate = rate
+	}
+}
+
+// WithServiceName sets the given service name for the gqlgen server.
+func WithServiceName(name string) Option {
+	return func(t *config) {
+		t.serviceName = name
+	}
+}

--- a/contrib/99designs/gqlgen/option.go
+++ b/contrib/99designs/gqlgen/option.go
@@ -18,7 +18,7 @@ type config struct {
 	analyticsRate float64
 }
 
-// Option instances can be passed to New to configure the integration.
+// An Option configures the gqlgen integration.
 type Option func(t *config)
 
 func defaults(t *config) {

--- a/contrib/99designs/gqlgen/tracer.go
+++ b/contrib/99designs/gqlgen/tracer.go
@@ -5,6 +5,8 @@
 
 // Package gqlgen contains an implementation of a gqlgen tracer, and functions to construct and configure the tracer.
 // The tracer can be passed to the gqlgen handler (see package github.com/99designs/gqlgen/handler)
+//
+// When enabling introspection, please note that introspection queries may cause large traces to be created.
 package gqlgen
 
 import (

--- a/contrib/99designs/gqlgen/tracer.go
+++ b/contrib/99designs/gqlgen/tracer.go
@@ -1,0 +1,123 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+// Package gqlgen contains an implementation of a gqlgen tracer, and functions to construct and configure the tracer.
+// The tracer can be passed to the gqlgen handler (see package github.com/99designs/gqlgen/handler)
+package gqlgen
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+
+	"github.com/99designs/gqlgen/graphql"
+)
+
+const (
+	resolverObject = "resolver.object"
+	resolverField  = "resolver.field"
+	defaultResourceName = "gqlgen"
+)
+
+type gqlTracer struct {
+	cfg config
+}
+
+// New creates an a graphql.Tracer instance that can be passed to a gqlgen handler.
+// Options can be passed in for further configuration.
+func New(opts ...Option) graphql.Tracer {
+	var t gqlTracer
+	defaults(&t.cfg)
+	for _, o := range opts {
+		o(&t.cfg)
+	}
+	return &t
+}
+
+// gqlTracer implements the graphql.Tracer interface.
+func (t *gqlTracer) StartOperationParsing(ctx context.Context) context.Context {
+	return ctx
+}
+
+// gqlTracer implements the graphql.Tracer interface.
+func (t *gqlTracer) EndOperationParsing(ctx context.Context) {
+}
+
+// gqlTracer implements the graphql.Tracer interface.
+func (t *gqlTracer) StartOperationValidation(ctx context.Context) context.Context {
+	return ctx
+}
+
+// gqlTracer implements the graphql.Tracer interface.
+func (t *gqlTracer) EndOperationValidation(ctx context.Context) {
+}
+
+func (t *gqlTracer) StartOperationExecution(ctx context.Context) context.Context {
+	rctx := graphql.GetRequestContext(ctx)
+	name := defaultResourceName
+	if rctx != nil && rctx.OperationName != "" {
+		name = rctx.OperationName
+	}
+	opts := []ddtrace.StartSpanOption{
+		tracer.SpanType(ext.SpanTypeGraphql),
+		tracer.ResourceName(name),
+		tracer.ServiceName(t.cfg.serviceName),
+	}
+	if !math.IsNaN(t.cfg.analyticsRate) {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, t.cfg.analyticsRate))
+	}
+	if s, ok := tracer.SpanFromContext(ctx); ok {
+		opts = append(opts, tracer.ChildOf(s.Context()))
+	}
+	_, ctx = tracer.StartSpanFromContext(ctx, name, opts...)
+	return ctx
+}
+
+func (t *gqlTracer) StartFieldExecution(ctx context.Context, field graphql.CollectedField) context.Context {
+	span, ctx := tracer.StartSpanFromContext(ctx, "Field_"+field.Name)
+	span.SetTag("field", field.Name)
+	return ctx
+}
+
+func (t *gqlTracer) StartFieldResolverExecution(ctx context.Context, rc *graphql.ResolverContext) context.Context {
+	// This will be the span created in StartFieldExecution.
+	// StartFieldResolverExecution is called only once per StartFieldExecution, so we can add context to the
+	// span rather than starting a child span.
+	span, _ := tracer.SpanFromContext(ctx)
+	span.SetTag(ext.SpanName, rc.Object+"_"+rc.Field.Name)
+	span.SetTag(ext.ResourceName, rc.Object+"_"+rc.Field.Name)
+	span.SetTag(resolverObject, rc.Object)
+	span.SetTag(resolverField, rc.Field.Name)
+	return ctx
+}
+
+// gqlTracer implements the graphql.Tracer interface.
+func (t *gqlTracer) StartFieldChildExecution(ctx context.Context) context.Context {
+	return ctx
+}
+
+func (t *gqlTracer) EndFieldExecution(ctx context.Context) {
+	span, _ := tracer.SpanFromContext(ctx)
+	defer span.Finish()
+	resCtx := graphql.GetResolverContext(ctx)
+	reqCtx := graphql.GetRequestContext(ctx)
+	errList := reqCtx.GetErrors(resCtx)
+	if len(errList) != 0 {
+		span.SetTag(ext.Error, true)
+		for idx, err := range errList {
+			span.SetTag(fmt.Sprintf("gqlgen.error_%d.message", idx), err.Error())
+			span.SetTag(fmt.Sprintf("gqlgen.error_%d.kind", idx), fmt.Sprintf("%T", err))
+		}
+	}
+}
+
+func (t *gqlTracer) EndOperationExecution(ctx context.Context) {
+	span, _ := tracer.SpanFromContext(ctx)
+	span.Finish()
+}

--- a/contrib/99designs/gqlgen/tracer_test.go
+++ b/contrib/99designs/gqlgen/tracer_test.go
@@ -1,0 +1,151 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package gqlgen
+
+import (
+	"testing"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+
+	"github.com/99designs/gqlgen/client"
+	"github.com/99designs/gqlgen/example/todo"
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/99designs/gqlgen/handler"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImplementsTracer(t *testing.T) {
+	var _ graphql.Tracer = (*gqlTracer)(nil)
+}
+
+func createTodoClient(t graphql.Tracer) *client.Client {
+
+	c := client.New(handler.GraphQL(
+		todo.NewExecutableSchema(todo.New()),
+		handler.Tracer(t),
+	))
+	return c
+}
+
+// findRootSpan returns the first root span it finds in a slice of spans, or nil if none is found.
+func findRootSpan(spans []mocktracer.Span) mocktracer.Span {
+	for _, span := range spans {
+		if span.ParentID() == 0 {
+			return span
+		}
+	}
+	return nil
+}
+
+// findRootSpan returns the first span it finds with a matching tag value in a slice of spans, or nil if none is found.
+func findSpanWithTag(spans []mocktracer.Span, tag string, val interface{}) mocktracer.Span {
+	for _, span := range spans {
+		if span.Tag(tag) == val {
+			return span
+		}
+	}
+	return nil
+}
+
+func TestRootSpan(t *testing.T) {
+	for name, tt := range map[string]struct {
+		clientOpts []client.Option
+		tracerOpts []Option
+		test       func(assert *assert.Assertions, spans []mocktracer.Span)
+	}{
+		"Defaults": {
+			test: func(assert *assert.Assertions, spans []mocktracer.Span) {
+				root := findRootSpan(spans)
+				assert.NotNil(root)
+				assert.Equal(root.Tag(ext.ResourceName), defaultResourceName)
+				assert.Equal(root.Tag(ext.ServiceName), defaultServiceName)
+				assert.Equal(root.Tag(ext.SpanType), ext.SpanTypeGraphql)
+				assert.Nil(root.Tag(ext.EventSampleRate))
+			},
+		},
+		"OperationName": {
+			clientOpts: []client.Option{client.Operation("CreateTodo")},
+			test: func(assert *assert.Assertions, spans []mocktracer.Span) {
+				root := findRootSpan(spans)
+				assert.NotNil(root)
+				assert.Equal(root.Tag(ext.ResourceName), "CreateTodo")
+			},
+		},
+		"ServiceName": {
+			tracerOpts: []Option{WithServiceName("TodoServer")},
+			test: func(assert *assert.Assertions, spans []mocktracer.Span) {
+				root := findRootSpan(spans)
+				assert.NotNil(root)
+				assert.Equal(root.Tag(ext.ServiceName), "TodoServer")
+			},
+		},
+		"WithAnalytics/true": {
+			tracerOpts: []Option{WithAnalytics(true)},
+			test: func(assert *assert.Assertions, spans []mocktracer.Span) {
+				root := findRootSpan(spans)
+				assert.NotNil(root)
+				assert.Equal(1.0, root.Tag(ext.EventSampleRate))
+			},
+		},
+		"WithAnalytics/false": {
+			tracerOpts: []Option{WithAnalytics(false)},
+			test: func(assert *assert.Assertions, spans []mocktracer.Span) {
+				root := findRootSpan(spans)
+				assert.NotNil(root)
+				assert.Nil(root.Tag(ext.EventSampleRate))
+			},
+		},
+		"WithAnalyticsRate": {
+			tracerOpts: []Option{WithAnalyticsRate(0.5)},
+			test: func(assert *assert.Assertions, spans []mocktracer.Span) {
+				root := findRootSpan(spans)
+				assert.NotNil(root)
+				assert.Equal(0.5, root.Tag(ext.EventSampleRate))
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			mt := mocktracer.Start()
+			defer mt.Stop()
+			c := createTodoClient(New(tt.tracerOpts...))
+
+			var createResp struct {
+				CreateTodo struct{ ID string }
+			}
+			err := c.Post(`mutation CreateTodo{ createTodo(todo: {text: "todo text"}) {id} }`, &createResp, tt.clientOpts...)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			spans := mt.FinishedSpans()
+			tt.test(assert, spans)
+		})
+	}
+}
+
+func TestResolver(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	c := createTodoClient(New())
+
+	var createResp struct {
+		CreateTodo struct{ ID string }
+	}
+	err := c.Post(`mutation CreateTodo{ createTodo(todo: {text: "todo text"}) {id} }`, &createResp)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	spans := mt.FinishedSpans()
+	span := findSpanWithTag(spans, ext.ResourceName, "MyMutation_createTodo")
+	assert.NotNil(span)
+	assert.Equal("MyMutation_createTodo", span.Tag(ext.SpanName))
+	assert.Equal("MyMutation", span.Tag(resolverObject))
+	assert.Equal("createTodo", span.Tag(resolverField))
+}

--- a/ddtrace/ext/app_types.go
+++ b/ddtrace/ext/app_types.go
@@ -75,4 +75,7 @@ const (
 
 	// SpanTypeConsul marks a span as a Consul operation.
 	SpanTypeConsul = "consul"
+
+	// SpanTypeGraphql marks a span as a gqlgen operation.
+	SpanTypeGraphql = "graphql"
 )

--- a/ddtrace/ext/app_types.go
+++ b/ddtrace/ext/app_types.go
@@ -77,5 +77,5 @@ const (
 	SpanTypeConsul = "consul"
 
 	// SpanTypeGraphql marks a span as a gqlgen operation.
-	SpanTypeGraphql = "graphql"
+	SpanTypeGraphQL = "graphql"
 )


### PR DESCRIPTION
This PR implements an integration for [github.com/99designs/gqlgen](https://github.com/99designs/gqlgen)

gqlgen provides the ability to trace activity through a tracer interface:
http://godoc.org/pkg/github.com/99designs/gqlgen/graphql/#Tracer

These methods are triggered during various request activities and allow us to start and finish spans, and collect relevant information from the context.