### PR TITLE
contrib/jinzhu/gorm: fix test after upstream update

### DIFF
--- a/contrib/jinzhu/gorm/gorm_test.go
+++ b/contrib/jinzhu/gorm/gorm_test.go
@@ -125,7 +125,7 @@ func TestCallbacks(t *testing.T) {
 		assert.Equal("gorm.create", span.OperationName())
 		assert.Equal(ext.SpanTypeSQL, span.Tag(ext.SpanType))
 		assert.Equal(
-			`INSERT  INTO "products" ("created_at","updated_at","deleted_at","code","price") VALUES ($1,$2,$3,$4,$5) RETURNING "products"."id"`,
+			`INSERT INTO "products" ("created_at","updated_at","deleted_at","code","price") VALUES ($1,$2,$3,$4,$5) RETURNING "products"."id"`,
 			span.Tag(ext.ResourceName))
 	})
 


### PR DESCRIPTION
Tiny change in upstream caused the test to break.
After merging, #513 will need rebasing.