### PR TITLE
contrib/google.golang.org/grpc: support differentiation between streaming and unary RPCs

### DIFF
--- a/contrib/google.golang.org/grpc/client.go
+++ b/contrib/google.golang.org/grpc/client.go
@@ -150,10 +150,6 @@ func doClientRequest(
 	ctx context.Context, cfg *config, method string, methodKind string, opts []grpc.CallOption,
 	handler func(ctx context.Context, opts []grpc.CallOption) error,
 ) (ddtrace.Span, error) {
-	var spanOpts []ddtrace.StartSpanOption
-	if methodKind != "" {
-		spanOpts = []ddtrace.StartSpanOption{tracer.Tag(tagMethodKind, methodKind)}
-	}
 	// inject the trace id into the metadata
 	span, ctx := startSpanFromContext(
 		ctx,
@@ -161,8 +157,10 @@ func doClientRequest(
 		"grpc.client",
 		cfg.clientServiceName(),
 		cfg.analyticsRate,
-		spanOpts...,
 	)
+	if methodKind != "" {
+		span.SetTag(tagMethodKind, methodKind)
+	}
 	ctx = injectSpanIntoContext(ctx)
 
 	// fill in the peer so we can add it to the tags

--- a/contrib/google.golang.org/grpc/client.go
+++ b/contrib/google.golang.org/grpc/client.go
@@ -78,6 +78,7 @@ func StreamClientInterceptor(opts ...Option) grpc.StreamClientInterceptor {
 					stream, err = streamer(ctx, desc, cc, method, opts...)
 					return err
 				})
+			span.SetTag(tagMethodKind, streamDescMethodKind(desc))
 			if err != nil {
 				finishWithError(span, err, cfg)
 				return nil, err
@@ -128,6 +129,7 @@ func UnaryClientInterceptor(opts ...Option) grpc.UnaryClientInterceptor {
 			func(ctx context.Context, opts []grpc.CallOption) error {
 				return invoker(ctx, method, req, reply, cc, opts...)
 			})
+		span.SetTag(tagMethodKind, methodKindUnary)
 		finishWithError(span, err, cfg)
 		return err
 	}

--- a/contrib/google.golang.org/grpc/client.go
+++ b/contrib/google.golang.org/grpc/client.go
@@ -78,7 +78,14 @@ func StreamClientInterceptor(opts ...Option) grpc.StreamClientInterceptor {
 					stream, err = streamer(ctx, desc, cc, method, opts...)
 					return err
 				})
-			span.SetTag(tagMethodKind, streamDescMethodKind(desc))
+			switch {
+			case desc.ServerStreams && desc.ClientStreams:
+				span.SetTag(tagMethodKind, methodKindBidiStreaming)
+			case desc.ServerStreams:
+				span.SetTag(tagMethodKind, methodKindServerStreaming)
+			default:
+				span.SetTag(tagMethodKind, methodKindClientStreaming)
+			}
 			if err != nil {
 				finishWithError(span, err, cfg)
 				return nil, err

--- a/contrib/google.golang.org/grpc/client.go
+++ b/contrib/google.golang.org/grpc/client.go
@@ -152,7 +152,7 @@ func doClientRequest(
 ) (ddtrace.Span, error) {
 	var spanOpts []ddtrace.StartSpanOption
 	if methodKind != "" {
-		spanOpts = []ddtrace.StartSpanOption{ tracer.Tag(tagMethodKind, methodKind) }
+		spanOpts = []ddtrace.StartSpanOption{tracer.Tag(tagMethodKind, methodKind)}
 	}
 	// inject the trace id into the metadata
 	span, ctx := startSpanFromContext(
@@ -161,7 +161,7 @@ func doClientRequest(
 		"grpc.client",
 		cfg.clientServiceName(),
 		cfg.analyticsRate,
-		spanOpts...
+		spanOpts...,
 	)
 	ctx = injectSpanIntoContext(ctx)
 

--- a/contrib/google.golang.org/grpc/grpc.go
+++ b/contrib/google.golang.org/grpc/grpc.go
@@ -24,14 +24,14 @@ import (
 )
 
 func startSpanFromContext(
-	ctx context.Context, method, operation, service string, rate float64,
+	ctx context.Context, method, operation, service string, rate float64, opts ...ddtrace.StartSpanOption,
 ) (ddtrace.Span, context.Context) {
-	opts := []ddtrace.StartSpanOption{
+	opts = append(opts, 
 		tracer.ServiceName(service),
 		tracer.ResourceName(method),
-		tracer.Tag(tagMethod, method),
+		tracer.Tag(tagMethodName, method),
 		tracer.SpanType(ext.AppTypeRPC),
-	}
+	)
 	if !math.IsNaN(rate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, rate))
 	}

--- a/contrib/google.golang.org/grpc/grpc.go
+++ b/contrib/google.golang.org/grpc/grpc.go
@@ -26,7 +26,7 @@ import (
 func startSpanFromContext(
 	ctx context.Context, method, operation, service string, rate float64, opts ...ddtrace.StartSpanOption,
 ) (ddtrace.Span, context.Context) {
-	opts = append(opts, 
+	opts = append(opts,
 		tracer.ServiceName(service),
 		tracer.ResourceName(method),
 		tracer.Tag(tagMethodName, method),

--- a/contrib/google.golang.org/grpc/grpc.go
+++ b/contrib/google.golang.org/grpc/grpc.go
@@ -24,14 +24,14 @@ import (
 )
 
 func startSpanFromContext(
-	ctx context.Context, method, operation, service string, rate float64, opts ...ddtrace.StartSpanOption,
+	ctx context.Context, method, operation, service string, rate float64,
 ) (ddtrace.Span, context.Context) {
-	opts = append(opts,
+	opts := []ddtrace.StartSpanOption{
 		tracer.ServiceName(service),
 		tracer.ResourceName(method),
 		tracer.Tag(tagMethodName, method),
 		tracer.SpanType(ext.AppTypeRPC),
-	)
+	}
 	if !math.IsNaN(rate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, rate))
 	}

--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -154,9 +154,9 @@ func TestStreaming(t *testing.T) {
 					"expected target host port to be set in span: %v", span)
 				fallthrough
 			case "grpc.server":
-				assert.Equal(t, methodKindBidiStreaming, span.Tag(tagMethodKind),
+				assert.Equal(t, methodKindBidiStream, span.Tag(tagMethodKind),
 					"expected tag %s == %s, but found %s.",
-					tagMethodKind, methodKindBidiStreaming, span.Tag(tagMethodKind))
+					tagMethodKind, methodKindBidiStream, span.Tag(tagMethodKind))
 				fallthrough
 			case "grpc.message":
 				wantCode := codes.OK
@@ -169,7 +169,7 @@ func TestStreaming(t *testing.T) {
 					"expected grpc code to be set in span: %v", span)
 				assert.Equal(t, "/grpc.Fixture/StreamPing", span.Tag(ext.ResourceName),
 					"expected resource name to be set in span: %v", span)
-				assert.Equal(t, "/grpc.Fixture/StreamPing", span.Tag(tagMethod),
+				assert.Equal(t, "/grpc.Fixture/StreamPing", span.Tag(tagMethodName),
 					"expected grpc method name to be set in span: %v", span)
 			}
 		}

--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -96,10 +96,12 @@ func TestUnary(t *testing.T) {
 			assert.Equal(clientSpan.Tag(ext.TargetPort), rig.port)
 			assert.Equal(clientSpan.Tag(tagCode), tt.wantCode.String())
 			assert.Equal(clientSpan.TraceID(), rootSpan.TraceID())
+			assert.Equal(clientSpan.Tag(tagMethodKind), methodKindUnary)
 			assert.Equal(serverSpan.Tag(ext.ServiceName), "grpc")
 			assert.Equal(serverSpan.Tag(ext.ResourceName), "/grpc.Fixture/Ping")
 			assert.Equal(serverSpan.Tag(tagCode), tt.wantCode.String())
 			assert.Equal(serverSpan.TraceID(), rootSpan.TraceID())
+			assert.Equal(serverSpan.Tag(tagMethodKind), methodKindUnary)
 		})
 	}
 }
@@ -151,7 +153,12 @@ func TestStreaming(t *testing.T) {
 				assert.Equal(t, rig.port, span.Tag(ext.TargetPort),
 					"expected target host port to be set in span: %v", span)
 				fallthrough
-			case "grpc.server", "grpc.message":
+			case "grpc.server":
+				assert.Equal(t, methodKindBidiStreaming, span.Tag(tagMethodKind),
+					"expected tag %s == %s, but found %s.",
+					tagMethodKind, methodKindBidiStreaming, span.Tag(tagMethodKind))
+				fallthrough
+			case "grpc.message":
 				wantCode := codes.OK
 				if errTag := span.Tag("error"); errTag != nil {
 					if err, ok := errTag.(error); ok {

--- a/contrib/google.golang.org/grpc/server.go
+++ b/contrib/google.golang.org/grpc/server.go
@@ -84,7 +84,14 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
 				cfg.analyticsRate,
 			)
 			defer func() { finishWithError(span, err, cfg) }()
-			span.SetTag(tagMethodKind, streamDescMethodKind(desc))
+			switch {
+			case info.IsServerStream && info.IsClientStream:
+				span.SetTag(tagMethodKind, methodKindBidiStreaming)
+			case info.IsServerStream:
+				span.SetTag(tagMethodKind, methodKindServerStreaming)
+			default:
+				span.SetTag(tagMethodKind, methodKindClientStreaming)
+			}
 		}
 
 		// call the original handler with a new stream, which traces each send

--- a/contrib/google.golang.org/grpc/server.go
+++ b/contrib/google.golang.org/grpc/server.go
@@ -84,6 +84,7 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
 				cfg.analyticsRate,
 			)
 			defer func() { finishWithError(span, err, cfg) }()
+			span.SetTag(tagMethodKind, streamDescMethodKind(desc))
 		}
 
 		// call the original handler with a new stream, which traces each send
@@ -114,6 +115,7 @@ func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
 			cfg.serverServiceName(),
 			cfg.analyticsRate,
 		)
+		span.SetTag(tagMethodKind, methodKindUnary)
 		resp, err := handler(ctx, req)
 		finishWithError(span, err, cfg)
 		return resp, err

--- a/contrib/google.golang.org/grpc/server.go
+++ b/contrib/google.golang.org/grpc/server.go
@@ -89,7 +89,7 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
 			}
 			var spanOpts []ddtrace.StartSpanOption
 			if methodKind != "" {
-				spanOpts = []ddtrace.StartSpanOption{ tracer.Tag(tagMethodKind, methodKind) }
+				spanOpts = []ddtrace.StartSpanOption{tracer.Tag(tagMethodKind, methodKind)}
 			}
 			var span ddtrace.Span
 			span, ctx = startSpanFromContext(

--- a/contrib/google.golang.org/grpc/stats_client_test.go
+++ b/contrib/google.golang.org/grpc/stats_client_test.go
@@ -53,7 +53,7 @@ func TestClientStatsHandler(t *testing.T) {
 		"grpc.code":     codes.OK.String(),
 		"service.name":  serviceName,
 		"resource.name": "/grpc.Fixture/Ping",
-		"grpc.method":   "/grpc.Fixture/Ping",
+		tagMethodName:   "/grpc.Fixture/Ping",
 		ext.TargetHost:  "127.0.0.1",
 		ext.TargetPort:  server.port,
 	}, span.Tags())

--- a/contrib/google.golang.org/grpc/stats_server_test.go
+++ b/contrib/google.golang.org/grpc/stats_server_test.go
@@ -49,7 +49,7 @@ func TestServerStatsHandler(t *testing.T) {
 		"grpc.code":     codes.OK.String(),
 		"service.name":  serviceName,
 		"resource.name": "/grpc.Fixture/Ping",
-		"grpc.method":   "/grpc.Fixture/Ping",
+		tagMethodName:   "/grpc.Fixture/Ping",
 	}, span.Tags())
 }
 

--- a/contrib/google.golang.org/grpc/tags.go
+++ b/contrib/google.golang.org/grpc/tags.go
@@ -5,8 +5,29 @@
 
 package grpc
 
+import "google.golang.org/grpc"
+
 // Tags used for gRPC
 const (
-	tagMethod = "grpc.method"
-	tagCode   = "grpc.code"
+	tagMethod     = "grpc.method"
+	tagCode       = "grpc.code"
+	tagMethodKind = "grpc.method.kind"
 )
+
+const (
+	methodKindUnary           = "unary"
+	methodKindClientStreaming = "client_streaming"
+	methodKindServerStreaming = "server_streaming"
+	methodKindBidiStreaming   = "bidi_streaming"
+)
+
+func streamDescMethodKind(desc *grpc.StreamDesc) string {
+	switch {
+	case desc.ServerStreams && desc.ClientStreams:
+		return methodKindBidiStreaming
+	case desc.ServerStreams:
+		return methodKindServerStreaming
+	default:
+		return methodKindClientStreaming
+	}
+}

--- a/contrib/google.golang.org/grpc/tags.go
+++ b/contrib/google.golang.org/grpc/tags.go
@@ -5,8 +5,6 @@
 
 package grpc
 
-import "google.golang.org/grpc"
-
 // Tags used for gRPC
 const (
 	tagMethod     = "grpc.method"
@@ -20,14 +18,3 @@ const (
 	methodKindServerStreaming = "server_streaming"
 	methodKindBidiStreaming   = "bidi_streaming"
 )
-
-func streamDescMethodKind(desc *grpc.StreamDesc) string {
-	switch {
-	case desc.ServerStreams && desc.ClientStreams:
-		return methodKindBidiStreaming
-	case desc.ServerStreams:
-		return methodKindServerStreaming
-	default:
-		return methodKindClientStreaming
-	}
-}

--- a/contrib/google.golang.org/grpc/tags.go
+++ b/contrib/google.golang.org/grpc/tags.go
@@ -7,14 +7,14 @@ package grpc
 
 // Tags used for gRPC
 const (
-	tagMethod     = "grpc.method"
-	tagCode       = "grpc.code"
+	tagMethodName = "grpc.method.name"
 	tagMethodKind = "grpc.method.kind"
+	tagCode       = "grpc.code"
 )
 
 const (
 	methodKindUnary           = "unary"
-	methodKindClientStreaming = "client_streaming"
-	methodKindServerStreaming = "server_streaming"
-	methodKindBidiStreaming   = "bidi_streaming"
+	methodKindClientStream = "client_streaming"
+	methodKindServerStream = "server_streaming"
+	methodKindBidiStream   = "bidi_streaming"
 )

--- a/contrib/google.golang.org/grpc/tags.go
+++ b/contrib/google.golang.org/grpc/tags.go
@@ -13,7 +13,7 @@ const (
 )
 
 const (
-	methodKindUnary           = "unary"
+	methodKindUnary        = "unary"
 	methodKindClientStream = "client_streaming"
 	methodKindServerStream = "server_streaming"
 	methodKindBidiStream   = "bidi_streaming"


### PR DESCRIPTION
gRPC defines several method 'kinds' (https://grpc.io/docs/guides/concepts/)
 * Unary
 * Client Streaming
 * Server Streaming
 * Bidirectional Streaming

Customers wanted to know what kind of gRPC method is being called.
To achieve this, we add the "grpc.method.kind" tag to every request span.

Resolves #521