### PR TITLE
internal/log: fix rare race in tests

### DIFF
--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -38,7 +38,11 @@ func (tp *testLogger) Lines() []string {
 }
 
 // Reset resets the logger's internal buffer.
-func (tp *testLogger) Reset() { tp.lines = tp.lines[:0] }
+func (tp *testLogger) Reset() {
+	tp.mu.Lock()
+	tp.lines = tp.lines[:0]
+	tp.mu.Unlock()
+}
 
 func TestLog(t *testing.T) {
 	defer func(old ddtrace.Logger) { UseLogger(old) }(logger)


### PR DESCRIPTION
A race occurs when Reset is called in the tests because it was missing
synchronization. This change fixes it.

Closes #524