### PR TITLE
ddtrace/tracer: add the WithEnv StartOption to the tracer.

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -89,6 +89,9 @@ func defaults(c *config) {
 			log.Warn("unable to look up hostname: %v", err)
 		}
 	}
+	if v := os.Getenv("DD_ENV"); v != "" {
+		WithEnv(v)(c)
+	}
 }
 
 // WithLogger sets logger as the tracer's error printer.
@@ -138,9 +141,8 @@ func WithAgentAddr(addr string) StartOption {
 	}
 }
 
-// WithEnv sets the global environment name. If set, the tracer will tag all
-// traces with "env":"<environment name>". By default, the environment name
-// is not set.
+// WithEnv sets the environment to which all traces started by the tracer will be submitted.
+// The default value is the environment variable DD_ENV, if it is set.
 func WithEnv(env string) StartOption {
 	return WithGlobalTag(ext.Environment, env)
 }

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -138,6 +138,13 @@ func WithAgentAddr(addr string) StartOption {
 	}
 }
 
+// WithEnv sets the global environment name. If set, the tracer will tag all
+// traces with "env":"<environment name>". By default, the environment name
+// is not set.
+func WithEnv(env string) StartOption {
+	return WithGlobalTag(ext.Environment, env)
+}
+
 // WithGlobalTag sets a key/value pair which will be set as a tag on all spans
 // created by tracer. This option may be used multiple times.
 func WithGlobalTag(k string, v interface{}) StartOption {

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -10,8 +10,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func withTransport(t transport) StartOption {
@@ -91,6 +93,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			WithAgentAddr("ddagent.consul.local:58126"),
 			WithGlobalTag("k", "v"),
 			WithDebugMode(true),
+			WithEnv("testEnv"),
 		)
 		c := tracer.config
 		assert.Equal(float64(0.5), c.sampler.(RateSampler).Rate())
@@ -98,6 +101,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		assert.Equal("ddagent.consul.local:58126", c.agentAddr)
 		assert.NotNil(c.globalTags)
 		assert.Equal("v", c.globalTags["k"])
+		assert.Equal("testEnv", c.globalTags[ext.Environment])
 		assert.True(c.debug)
 	})
 }

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -93,15 +93,14 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		})
 	})
 
-	t.Run("envOverride", func(t *testing.T) {
-		os.Setenv("DD_ENV", "DD_ENV")
+	t.Run("override", func(t *testing.T) {
+		os.Setenv("DD_ENV", "dev")
 		defer os.Unsetenv("DD_ENV")
 		assert := assert.New(t)
-		tracer := newTracer(
-			WithEnv("testEnv"),
-		)
+		env := "production"
+		tracer := newTracer(WithEnv(env))
 		c := tracer.config
-		assert.Equal("testEnv", c.globalTags[ext.Environment])
+		assert.Equal(env, c.globalTags[ext.Environment])
 	})
 
 	t.Run("other", func(t *testing.T) {

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -78,7 +78,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			assert.Equal(t, c.dogstatsdAddr, "my-host:123")
 		})
 
-		t.Run("env-dd_env", func(t *testing.T) {
+		t.Run("env-env", func(t *testing.T) {
 			os.Setenv("DD_ENV", "testEnv")
 			defer os.Unsetenv("DD_ENV")
 			tracer := newTracer()
@@ -94,8 +94,8 @@ func TestTracerOptionsDefaults(t *testing.T) {
 	})
 
 	t.Run("other", func(t *testing.T) {
-		// Set a DD_ENV to ensure WithEnv overrides it.
-		os.Setenv("DD_ENV", "doodo")
+		// Set DD_ENV to ensure WithEnv overrides it.
+		os.Setenv("DD_ENV", "DD_ENV")
 		defer os.Unsetenv("DD_ENV")
 		assert := assert.New(t)
 		tracer := newTracer(

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -93,10 +93,18 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		})
 	})
 
-	t.Run("other", func(t *testing.T) {
-		// Set DD_ENV to ensure WithEnv overrides it.
+	t.Run("envOverride", func(t *testing.T) {
 		os.Setenv("DD_ENV", "DD_ENV")
 		defer os.Unsetenv("DD_ENV")
+		assert := assert.New(t)
+		tracer := newTracer(
+			WithEnv("testEnv"),
+		)
+		c := tracer.config
+		assert.Equal("testEnv", c.globalTags[ext.Environment])
+	})
+
+	t.Run("other", func(t *testing.T) {
 		assert := assert.New(t)
 		tracer := newTracer(
 			WithSampler(NewRateSampler(0.5)),

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -78,6 +78,14 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			assert.Equal(t, c.dogstatsdAddr, "my-host:123")
 		})
 
+		t.Run("env-dd_env", func(t *testing.T) {
+			os.Setenv("DD_ENV", "testEnv")
+			defer os.Unsetenv("DD_ENV")
+			tracer := newTracer()
+			c := tracer.config
+			assert.Equal(t, "testEnv", c.globalTags[ext.Environment])
+		})
+
 		t.Run("option", func(t *testing.T) {
 			tracer := newTracer(WithDogstatsdAddress("10.1.0.12:4002"))
 			c := tracer.config
@@ -86,6 +94,9 @@ func TestTracerOptionsDefaults(t *testing.T) {
 	})
 
 	t.Run("other", func(t *testing.T) {
+		// Set a DD_ENV to ensure WithEnv overrides it.
+		os.Setenv("DD_ENV", "doodo")
+		defer os.Unsetenv("DD_ENV")
 		assert := assert.New(t)
 		tracer := newTracer(
 			WithSampler(NewRateSampler(0.5)),


### PR DESCRIPTION
Setting the `env` is confusing. 

The current way to set the env with the go API is to [set a global tag](https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#WithGlobalTag) with the key `env` when starting the tracer.

This PR adds a `StartOption` called `WithEnv` that will add the global tag. 