### PR TITLE
contrib/go-redis/redis: return a new client from WithContext to eliminate race conditions.

### DIFF
--- a/contrib/go-redis/redis/redis.go
+++ b/contrib/go-redis/redis/redis.go
@@ -134,13 +134,13 @@ func commandsToString(cmds []redis.Cmder) string {
 
 // WithContext sets a context on a Client. Use it to ensure that emitted spans have the correct parent.
 func (c *Client) WithContext(ctx context.Context) *Client {
-	newClient := &Client{
+	clone := &Client{
 		Client:  c.Client.WithContext(ctx),
 		params:  c.params,
 		process: c.process,
 	}
-	newClient.Client.WrapProcess(createWrapperFromClient(newClient))
-	return newClient
+	clone.Client.WrapProcess(createWrapperFromClient(clone))
+	return clone
 }
 
 // Context returns the active context in the client.

--- a/contrib/go-redis/redis/redis.go
+++ b/contrib/go-redis/redis/redis.go
@@ -143,11 +143,6 @@ func (c *Client) WithContext(ctx context.Context) *Client {
 	return clone
 }
 
-// Context returns the active context in the client.
-func (c *Client) Context() context.Context {
-	return c.Client.Context()
-}
-
 // createWrapperFromClient returns a new createWrapper function which wraps the processor with tracing
 // information obtained from the provided Client. To understand this functionality better see the
 // documentation for the github.com/go-redis/redis.(*baseClient).WrapProcess function.

--- a/contrib/go-redis/redis/redis.go
+++ b/contrib/go-redis/redis/redis.go
@@ -4,6 +4,7 @@
 // Copyright 2016-2019 Datadog, Inc.
 
 // Package redis provides tracing functions for tracing the go-redis/redis package (https://github.com/go-redis/redis).
+// This package supports versions up to go-redis 6.15.
 package redis
 
 import (

--- a/contrib/go-redis/redis/redis_test.go
+++ b/contrib/go-redis/redis/redis_test.go
@@ -314,8 +314,6 @@ func TestAnalyticsSettings(t *testing.T) {
 	})
 }
 
-type testKey string
-
 func TestWithContext(t *testing.T) {
 	opts := &redis.Options{Addr: "127.0.0.1:6379"}
 	assert := assert.New(t)
@@ -323,8 +321,8 @@ func TestWithContext(t *testing.T) {
 	defer mt.Stop()
 
 	client := NewClient(opts, WithServiceName("my-redis"))
-	s1, ctx := tracer.StartSpanFromContext(context.Background(), "span1.name")
-	client = client.WithContext(ctx)
+	s1, ctx1 := tracer.StartSpanFromContext(context.Background(), "span1.name")
+	client = client.WithContext(ctx1)
 	s2, ctx2 := tracer.StartSpanFromContext(context.Background(), "span2.name")
 	client2 := client.WithContext(ctx2)
 	client.Set("test_key", "test_value", 0)
@@ -347,7 +345,7 @@ func TestWithContext(t *testing.T) {
 			getSpan = s
 		}
 	}
-	assert.Equal(ctx, client.Context())
+	assert.Equal(ctx1, client.Context())
 	assert.Equal(ctx2, client2.Context())
 	assert.NotNil(span1)
 	assert.NotNil(span2)

--- a/contrib/go-redis/redis/redis_test.go
+++ b/contrib/go-redis/redis/redis_test.go
@@ -320,12 +320,12 @@ func TestWithContext(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client1 := NewClient(opts, WithServiceName("my-redis"))
 	s1, ctx1 := tracer.StartSpanFromContext(context.Background(), "span1.name")
-	client = client.WithContext(ctx1)
+	client1 = client1.WithContext(ctx1)
 	s2, ctx2 := tracer.StartSpanFromContext(context.Background(), "span2.name")
-	client2 := client.WithContext(ctx2)
-	client.Set("test_key", "test_value", 0)
+	client2 := client1.WithContext(ctx2)
+	client1.Set("test_key", "test_value", 0)
 	client2.Get("test_key")
 	s1.Finish()
 	s2.Finish()
@@ -345,7 +345,7 @@ func TestWithContext(t *testing.T) {
 			getSpan = s
 		}
 	}
-	assert.Equal(ctx1, client.Context())
+	assert.Equal(ctx1, client1.Context())
 	assert.Equal(ctx2, client2.Context())
 	assert.NotNil(span1)
 	assert.NotNil(span2)

--- a/contrib/go-redis/redis/redis_test.go
+++ b/contrib/go-redis/redis/redis_test.go
@@ -314,11 +314,13 @@ func TestAnalyticsSettings(t *testing.T) {
 	})
 }
 
+type testKey string
+
 func TestWithContextRace(t *testing.T) {
 	opts := &redis.Options{Addr: "127.0.0.1:6379"}
 	assert := assert.New(t)
 
-	k := "key"
+	k := testKey("key")
 	v := "val"
 	v2 := "val2"
 	ctx := context.WithValue(context.Background(), k, v)


### PR DESCRIPTION
Client should be thread-safe, but WithContext currently sets the context on the existing client,
so multiple goroutines calling WithContext at the same time will race.

This commit casues WithContext to return a pointer to a new Client, meaning multiple
goroutines can use WithContext at the same time.

Resolves #387