### PR TITLE
contrib/net/http: add RTWithServiceName option for RoundTripper

### DIFF
--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -109,7 +109,7 @@ func WithAfter(f RoundTripperAfterFunc) RoundTripperOption {
 	}
 }
 
-// RTWithServiceName sets the given service name for the RoundTripper
+// RTWithServiceName sets the given service name for the RoundTripper.
 func RTWithServiceName(name string) RoundTripperOption {
 	return func(cfg *roundTripperConfig) {
 		cfg.serviceName = name

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -80,6 +80,7 @@ type roundTripperConfig struct {
 	before        RoundTripperBeforeFunc
 	after         RoundTripperAfterFunc
 	analyticsRate float64
+	serviceName   string
 }
 
 func newRoundTripperConfig() *roundTripperConfig {
@@ -105,6 +106,13 @@ func WithBefore(f RoundTripperBeforeFunc) RoundTripperOption {
 func WithAfter(f RoundTripperAfterFunc) RoundTripperOption {
 	return func(cfg *roundTripperConfig) {
 		cfg.after = f
+	}
+}
+
+// RTWithServiceName sets the given service name for the RoundTripper
+func RTWithServiceName(name string) RoundTripperOption {
+	return func(cfg *roundTripperConfig) {
+		cfg.serviceName = name
 	}
 }
 

--- a/contrib/net/http/roundtripper.go
+++ b/contrib/net/http/roundtripper.go
@@ -34,6 +34,9 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (res *http.Response, err er
 	if !math.IsNaN(rt.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, rt.cfg.analyticsRate))
 	}
+	if rt.cfg.serviceName != "" {
+		opts = append(opts, tracer.ServiceName(rt.cfg.serviceName))
+	}
 	span, ctx := tracer.StartSpanFromContext(req.Context(), defaultResourceName, opts...)
 	defer func() {
 		if rt.cfg.after != nil {

--- a/contrib/net/http/roundtripper_test.go
+++ b/contrib/net/http/roundtripper_test.go
@@ -134,3 +134,43 @@ func TestRoundTripperAnalyticsSettings(t *testing.T) {
 		assertRate(t, mt, 0.23, RTWithAnalyticsRate(0.23))
 	})
 }
+
+func TestServiceName(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Hello World"))
+	}))
+	defer s.Close()
+
+	t.Run("option", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+		serviceName := "testServer"
+		rt := WrapRoundTripper(http.DefaultTransport, RTWithServiceName(serviceName))
+		client := &http.Client{
+			Transport: rt,
+		}
+		client.Get(s.URL + "/hello/world")
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+		assert.Equal(t, serviceName, spans[0].Tag(ext.ServiceName))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+		serviceName := "testServer"
+		rt := WrapRoundTripper(http.DefaultTransport,
+			RTWithServiceName("wrongServiceName"),
+			WithBefore(func(_ *http.Request, span ddtrace.Span) {
+				span.SetTag(ext.ServiceName, serviceName)
+			}),
+		)
+		client := &http.Client{
+			Transport: rt,
+		}
+		client.Get(s.URL + "/hello/world")
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+		assert.Equal(t, serviceName, spans[0].Tag(ext.ServiceName))
+	})
+}


### PR DESCRIPTION
While ServeMux and WrapHandler take a WithServiceName option,
WrapRoundTripper and WrapClient don't have something comparable.
It is possible to add a WithBefore option that sets the service name, but
that is not an ideal situation.

This commit adds the RTWithServiceName function, which will set the
service name for the RoundTripper.