### PR TITLE
reuse connections: always close the response.Body

### DIFF
--- a/ddtrace/tracer/transport.go
+++ b/ddtrace/tracer/transport.go
@@ -147,12 +147,12 @@ func (t *httpTransport) send(p *payload) (body io.ReadCloser, err error) {
 		return nil, err
 	}
 	p.waitClose()
+	defer response.Body.Close()
 	if code := response.StatusCode; code >= 400 {
 		// error, check the body for context information and
 		// return a nice error.
 		msg := make([]byte, 1000)
 		n, _ := response.Body.Read(msg)
-		response.Body.Close()
 		txt := http.StatusText(code)
 		if n > 0 {
 			return nil, fmt.Errorf("%s (Status: %s)", msg[:n], txt)


### PR DESCRIPTION
Commented on seeing errors with lost traces[1] 

## Problem
After digging deeper into [1]  my hypothesis is 
1. `lost traces` errors are caused due new connections being established which may sometimes exceed 1s(configured) timeout
2. connections aren't being reused because `response.Body` doesn't get always closed
3. every new connection may potentially result in `lost traces` errors since it may exceed the 1s timeout

## Observations
I've patched the transport locally and confirming my expectations:
- no more repeated lost traces: because connections are mostly reused
- but occasional lost trace(on startup) likely because of 3. since 1s timeout is still too short for new connection

## References

- [1] https://github.com/DataDog/dd-trace-go/issues/181#event-2801776999