### PR TITLE
contrib: specify the need for the major version in the README

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -16,7 +16,7 @@ First, find the library which you'd like to integrate with. The naming conventio
 * If the package is from the standard library (eg. `database/sql`), it will be located at the same path.
 * If the package is hosted on Github (eg. `github.com/user/repo`) and has version `v2.1.0`, it will be located at the shorthand path `user/repo.v2`.
 * If the package is from anywhere else (eg. `google.golang.org/grpc`) and has no stable version, it can be found under the full import path, followed by the version suffix (in this example `.v0`).
-* All new integrations should be suffixed with `.vN` where `N` is the major version that is being covered. If no version is yet available or the library is in alpha, `.v0` should be used.
+* All new integrations should be suffixed with `.vN` where `N` is the major version that is being covered.
 
 Each integration comes with thorough documentation and usage examples. A good overview can be seen on our 
 [godoc](https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib) page.

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -14,8 +14,9 @@ All of these libraries are supported by our [APM product](https://www.datadoghq.
 First, find the library which you'd like to integrate with. The naming convention for the integration packages is:
 
 * If the package is from the standard library (eg. `database/sql`), it will be located at the same path.
-* If the package is hosted on Github (eg. `github.com/user/repo`), it will be located at the shorthand path `user/repo`.
-* If the package is from anywhere else (eg. `google.golang.org/grpc`), it can be found under the full import path.
+* If the package is hosted on Github (eg. `github.com/user/repo`) and has version `v2.1.0`, it will be located at the shorthand path `user/repo.v2`.
+* If the package is from anywhere else (eg. `google.golang.org/grpc`) and has no stable version, it can be found under the full import path, followed by the version suffix (in this example `.v0`).
+* All new integrations should be suffixed with `.vN` where `N` is the major version that is being covered. If no version is yet available or the library is in alpha, `.v0` should be used.
 
 Each integration comes with thorough documentation and usage examples. A good overview can be seen on our 
 [godoc](https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib) page.


### PR DESCRIPTION
It currently happens that libraries which we are integrating with are
releasing new major versions that we don't support. As a result, we need
to create new packages to support them. This implies not only creating a new
folder using the current convention, but also adding the version to the
path.

Since we've not done this until today, users will be tempted to use the
"versionless" paths for latest releases, which will be inaccurate.

This change adds a new convention to *always* specify the major version
number as a suffix to the path. This is also in line with the requirements
for modules.