### PR TITLE
ddtrace/tracer: add rule-based sampler

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -220,7 +220,7 @@ func WithDogstatsdAddress(addr string) StartOption {
 
 // WithSamplingRules specifies the sampling rates to apply to spans based on the
 // provided rules.
-func WithSamplingRules(rules ...SamplingRule) StartOption {
+func WithSamplingRules(rules []SamplingRule) StartOption {
 	return func(cfg *config) {
 		cfg.samplingRules = rules
 	}

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -63,8 +63,9 @@ type config struct {
 	// combination of the environment variables DD_AGENT_HOST and DD_DOGSTATSD_PORT.
 	dogstatsdAddr string
 
-	// rulesConfig ...
-	samplingRules []*SamplingRule
+	// samplingRules contains user-defined rules determine the sampling rate to apply
+	// to spans.
+	samplingRules []SamplingRule
 }
 
 // StartOption represents a function that can be provided as a parameter to Start.
@@ -220,7 +221,7 @@ func WithDogstatsdAddress(addr string) StartOption {
 
 // WithSamplingRules specifies the sampling rates to apply to spans based on the
 // provided rules.
-func WithSamplingRules(rules []*SamplingRule) StartOption {
+func WithSamplingRules(rules []SamplingRule) StartOption {
 	return func(cfg *config) {
 		cfg.samplingRules = rules
 	}

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -64,7 +64,7 @@ type config struct {
 	dogstatsdAddr string
 
 	// rulesConfig ...
-	rulesConfig string
+	samplingRules []SamplingRule
 }
 
 // StartOption represents a function that can be provided as a parameter to Start.
@@ -220,9 +220,9 @@ func WithDogstatsdAddress(addr string) StartOption {
 
 // WithSamplingRules specifies the sampling rates to apply to spans based on the
 // provided rules.
-func WithSamplingRules(rules string) StartOption {
+func WithSamplingRules(rules ...SamplingRule) StartOption {
 	return func(cfg *config) {
-		cfg.rulesConfig = rules
+		cfg.samplingRules = rules
 	}
 }
 

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -62,6 +62,9 @@ type config struct {
 	// Datadog Agent. If not set, it defaults to "localhost:8125" or to the
 	// combination of the environment variables DD_AGENT_HOST and DD_DOGSTATSD_PORT.
 	dogstatsdAddr string
+
+	// rulesConfig ...
+	rulesConfig string
 }
 
 // StartOption represents a function that can be provided as a parameter to Start.
@@ -212,6 +215,14 @@ func WithRuntimeMetrics() StartOption {
 func WithDogstatsdAddress(addr string) StartOption {
 	return func(cfg *config) {
 		cfg.dogstatsdAddr = addr
+	}
+}
+
+// WithSamplingRules specifies the sampling rates to apply to spans based on the
+// provided rules.
+func WithSamplingRules(rules string) StartOption {
+	return func(cfg *config) {
+		cfg.rulesConfig = rules
 	}
 }
 

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -64,7 +64,7 @@ type config struct {
 	dogstatsdAddr string
 
 	// rulesConfig ...
-	samplingRules []SamplingRule
+	samplingRules []*SamplingRule
 }
 
 // StartOption represents a function that can be provided as a parameter to Start.
@@ -220,7 +220,7 @@ func WithDogstatsdAddress(addr string) StartOption {
 
 // WithSamplingRules specifies the sampling rates to apply to spans based on the
 // provided rules.
-func WithSamplingRules(rules []SamplingRule) StartOption {
+func WithSamplingRules(rules []*SamplingRule) StartOption {
 	return func(cfg *config) {
 		cfg.samplingRules = rules
 	}

--- a/ddtrace/tracer/sampler.go
+++ b/ddtrace/tracer/sampler.go
@@ -219,9 +219,11 @@ func samplingRules(rules []*SamplingRule) []*SamplingRule {
 	for _, v := range rules {
 		if v.err != nil {
 			log.Warn("ignoring rule %+v: %v", v, v.err)
+			continue
 		}
-		if v.Rate < 0.0 || v.Rate > 1.0 {
+		if !(v.Rate >= 0.0 && v.Rate <= 1.0) {
 			log.Warn("ignoring rule %+v: rate is out of range", v)
+			continue
 		}
 		validRules = append(validRules, v)
 	}
@@ -368,9 +370,10 @@ func ServiceOperationRule(service string, operation string, rate float64) *Sampl
 		sr.err = fmt.Errorf("service '%s' is invalid: %v", service, err)
 	}
 	sr.Operation, err = regexp.Compile(anchoredRE(operation))
-	if err != nil && sr.err != nil {
+	if err != nil && sr.err == nil {
 		sr.err = fmt.Errorf("operation '%s' is invalid: %v", operation, err)
 	}
+	sr.Rate = rate
 	return sr
 }
 

--- a/ddtrace/tracer/sampler.go
+++ b/ddtrace/tracer/sampler.go
@@ -172,7 +172,7 @@ func newRulesSampler(rules []SamplingRule) *rulesSampler {
 	return &rulesSampler{
 		rules:   samplingRules(rules),
 		rate:    rate,
-		limiter: rateLimiter(rate),
+		limiter: newRateLimiter(rate),
 	}
 }
 
@@ -229,7 +229,7 @@ func sampleRate() float64 {
 	return rate
 }
 
-func rateLimiter(r float64) *rate.Limiter {
+func newRateLimiter(r float64) *rate.Limiter {
 	v := os.Getenv("DD_TRACE_RATE_LIMIT")
 	if v == "" {
 		return nil

--- a/ddtrace/tracer/sampler.go
+++ b/ddtrace/tracer/sampler.go
@@ -348,6 +348,9 @@ func (sr *SamplingRule) optimalMatch(mf *matchFunc, s string) {
 }
 
 func (sr *SamplingRule) match(spn *span) bool {
+	if sr.err != nil {
+		return false
+	}
 	if sr.service != nil && !sr.service(spn.Service) {
 		return false
 	}

--- a/ddtrace/tracer/sampler_test.go
+++ b/ddtrace/tracer/sampler_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
@@ -307,4 +308,155 @@ func TestRulesSampler(t *testing.T) {
 			})
 		}
 	})
+}
+
+func BenchmarkRulesSampler(b *testing.B) {
+	b.Run("no-rules", func(b *testing.B) {
+		tracer := newTracer()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			tracer.StartSpan("web.request", Tag(ext.SamplingPriority, ext.PriorityUserKeep)).Finish()
+		}
+	})
+
+	b.Run("unmatching-rules", func(b *testing.B) {
+		rules := []SamplingRule{
+			ServiceRule("test-service", 1.0),
+			ServiceOperationRule("postgres.db", "db.query", 1.0),
+			OperationRule("notweb.request", 1.0),
+		}
+		tracer := newTracer(WithSamplingRules(rules))
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			tracer.StartSpan("web.request", Tag(ext.SamplingPriority, ext.PriorityUserKeep)).Finish()
+		}
+	})
+
+	b.Run("matching-rules", func(b *testing.B) {
+		rules := []SamplingRule{
+			ServiceRule("test-service", 1.0),
+			ServiceOperationRule("postgres.db", "db.query", 1.0),
+			OperationRule("web.request", 1.0),
+		}
+		tracer := newTracer(WithSamplingRules(rules))
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			tracer.StartSpan("web.request", Tag(ext.SamplingPriority, ext.PriorityUserKeep)).Finish()
+		}
+	})
+}
+
+// https://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go#compiler-optimisation
+var matched bool
+
+func BenchmarkRulesSamplerImpls(b *testing.B) {
+	b.Run("structs", func(b *testing.B) {
+		rules := []SamplingRule{
+			ServiceRule("test-service", 1.0),
+			ServiceOperationRule("postgres.db", "db.query", 1.0),
+			OperationRule("web.request", 1.0),
+		}
+		sampler := newRulesSampler(rules)
+		span := newSpan("web.request", "xyz-service", "", 0, 0, 0)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			matched = sampler.apply(span)
+		}
+	})
+
+	b.Run("pointers", func(b *testing.B) {
+		rules := []SamplingRule{
+			ServiceRule("test-service", 1.0),
+			ServiceOperationRule("postgres.db", "db.query", 1.0),
+			OperationRule("web.request", 1.0),
+		}
+		sampler := newRulesSamplerP(rules)
+		span := newSpan("web.request", "xyz-service", "", 0, 0, 0)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			matched = sampler.apply(span)
+		}
+	})
+}
+
+type rulesSamplerP struct {
+	rules   []*SamplingRule
+	rate    float64
+	limiter *rate.Limiter
+
+	// "effective rate" calculations
+	mu           sync.Mutex // guards below fields
+	ts           int64      // timestamp, to detect when counters need resetting
+	allowed      int        // number of spans allowed by rate limiter
+	total        int        // number of spans checked by rate limiter
+	previousRate float64    // previous second's rate, averaged with current rate for smoothing
+}
+
+func newRulesSamplerP(rules []SamplingRule) *rulesSamplerP {
+	rate := sampleRate()
+	rules = samplingRules(rules)
+	rulesP := make([]*SamplingRule, len(rules))
+	for i := range rules {
+		r := new(SamplingRule)
+		*r = rules[i]
+		rulesP[i] = r
+	}
+	return &rulesSamplerP{
+		rules:   rulesP,
+		rate:    rate,
+		limiter: newRateLimiter(rate),
+	}
+}
+
+func (rs *rulesSamplerP) apply(span *span) bool {
+	matched := false
+	rate := 0.0
+	for _, v := range rs.rules {
+		if v.match(span) {
+			matched = true
+			rate = v.Rate
+			break
+		}
+	}
+	if !matched {
+		if rs.rate == 0.0 {
+			// no matching rule or global rate, so we want to fall back
+			// to priority sampling
+			return false
+		}
+		rate = rs.rate
+	}
+	// rate sample
+	span.SetTag("_dd.rule_psr", rate)
+	if !sampledByRate(span.TraceID, rate) {
+		span.SetTag(ext.SamplingPriority, ext.PriorityAutoReject)
+		return true
+	}
+	// global rate limit and effective rate calculations
+	defer rs.mu.Unlock()
+	rs.mu.Lock()
+	if ts := time.Now().Unix(); ts > rs.ts {
+		// update "previous rate" and reset
+		if ts-rs.ts == 1 && rs.total > 0 && rs.allowed > 0 {
+			rs.previousRate = float64(rs.allowed) / float64(rs.total)
+		} else {
+			rs.previousRate = 0.0
+		}
+		rs.ts = ts
+		rs.allowed = 0
+		rs.total = 0
+	}
+
+	rs.total++
+	if rs.limiter != nil && !rs.limiter.Allow() {
+		span.SetTag(ext.SamplingPriority, ext.PriorityAutoReject)
+	} else {
+		rs.allowed++
+		span.SetTag(ext.SamplingPriority, ext.PriorityAutoKeep)
+	}
+	// calculate effective rate, and tag the span
+	er := (rs.previousRate + (float64(rs.allowed) / float64(rs.total))) / 2.0
+	span.SetTag("_dd.limit_psr", er)
+
+	return true
 }

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -145,7 +145,7 @@ func newTracer(opts ...StartOption) *tracer {
 		exitChan:         make(chan struct{}),
 		payloadChan:      make(chan []*span, payloadQueueSize),
 		stopped:          make(chan struct{}),
-		rulesSampling:    newRulesSampler(c.rulesConfig),
+		rulesSampling:    newRulesSampler(c.samplingRules),
 		prioritySampling: newPrioritySampler(),
 		pid:              strconv.Itoa(os.Getpid()),
 	}


### PR DESCRIPTION
This is a first-cut of rule-based sampling, for an initial review about public API changes and the method users would specify the rules.

An example of configuring it is:
```go
rules := `
service=foo name=http.request rate=0.1
service=bar rate=1.0
rate=0.25
`
tracer := tracer.Start(tracer.WithSamplingRules(rules), ...)
defer tracer.Stop()
```
Earlier attempts at this were using a more "chained API" or letting the user provide a struct-based set of rules.
A chained API (eg: `tracer.AddRule().Service("xyz").Name("abc.request").Rate(1.0)`) seemed "clever", but unreliable. Users always need to provide a rate, and the consequence of calling `Service` or `Name` multiple times in a chain are hard to explain.
Another way was for users to provide a slice of `struct Rule` containing fields they need to provide. Eg:
```
tracer.WithSamplingRules([]tracer.Rule{
    tracer.Rule{Service: "xyz", Name: "abc.request", Rate: 1.0},
}
```
It didn't seem very nice.

The underlying rules parser is intentionally a bit hacky for now.
If the rule-based sampler grows in complexity, it'll deserve a proper parser / error reporting / etc.
Since it's an internal implementation detail, that part can be changed without affecting end users.

Next steps
- [ ] review design and initial implementation, adjust based on feedback
- [ ] add tests. lots of tests. and fix bugs detected by tests
- [ ] fix comments that end up in docs or parts that need a bit more explaining
- [ ] ship it