### PR TITLE
ddtrace/tracer: improve handling of integer tags.

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -114,8 +114,6 @@ func (s *span) SetTag(key string, value interface{}) {
 		s.setMetric(key, v)
 		return
 	}
-	// not numeric, not a string and not an error, the likelihood of this
-	// happening is close to zero, but we should nevertheless account for it.
 	s.setMeta(key, fmt.Sprint(value))
 }
 

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -114,6 +114,7 @@ func (s *span) SetTag(key string, value interface{}) {
 		s.setMetric(key, v)
 		return
 	}
+	// not numeric, not a string, not a bool, and not an error
 	s.setMeta(key, fmt.Sprint(value))
 }
 

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -235,9 +235,12 @@ func TestSpanString(t *testing.T) {
 	assert.NotEqual("", span.String())
 }
 
+const (
+	intUpperLimit = int64(1) << 53
+	intLowerLimit = -intUpperLimit
+)
+
 func TestSpanSetMetric(t *testing.T) {
-	const intUpperLimit = int64(1) << 53
-	const intLowerLimit = -intUpperLimit
 	for name, tt := range map[string]func(assert *assert.Assertions, span *span){
 		"init": func(assert *assert.Assertions, span *span) {
 			assert.Equal(2, len(span.Metrics))

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -245,17 +245,30 @@ func TestSpanSetMetric(t *testing.T) {
 			assert.True(ok)
 		},
 		"float": func(assert *assert.Assertions, span *span) {
-			span.SetTag("bytes", 1024.42)
-			assert.Equal(1024.42, span.Metrics["bytes"])
+			span.SetTag("temp", 72.42)
+			assert.Equal(72.42, span.Metrics["temp"])
 		},
 		"int": func(assert *assert.Assertions, span *span) {
 			span.SetTag("bytes", 1024)
 			assert.Equal(1024.0, span.Metrics["bytes"])
 		},
+		"max": func(assert *assert.Assertions, span *span) {
+			span.SetTag("bytes", maxIntToFloat)
+			assert.Equal(float64(maxIntToFloat), span.Metrics["bytes"])
+		},
+		"min": func(assert *assert.Assertions, span *span) {
+			span.SetTag("bytes", minIntToFloat)
+			assert.Equal(float64(minIntToFloat), span.Metrics["bytes"])
+		},
 		"toobig": func(assert *assert.Assertions, span *span) {
-			span.SetTag("bytes", int64(1)<<60)
+			span.SetTag("bytes", maxIntToFloat+1)
 			assert.Equal(0.0, span.Metrics["bytes"])
-			assert.Equal(fmt.Sprint(int64(1)<<60), span.Meta["bytes"])
+			assert.Equal(fmt.Sprint(maxIntToFloat+1), span.Meta["bytes"])
+		},
+		"toosmall": func(assert *assert.Assertions, span *span) {
+			span.SetTag("bytes", minIntToFloat-1)
+			assert.Equal(0.0, span.Metrics["bytes"])
+			assert.Equal(fmt.Sprint(minIntToFloat-1), span.Meta["bytes"])
 		},
 		"finished": func(assert *assert.Assertions, span *span) {
 			span.Finish()
@@ -268,7 +281,7 @@ func TestSpanSetMetric(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 			tracer := newTracer(withTransport(newDefaultTransport()))
-			span := tracer.newRootSpan("pylons.request", "pylons", "/")
+			span := tracer.newRootSpan("http.request", "mux.router", "/")
 			tt(assert, span)
 		})
 	}

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -236,6 +236,8 @@ func TestSpanString(t *testing.T) {
 }
 
 func TestSpanSetMetric(t *testing.T) {
+	const intUpperLimit = int64(1) << 53
+	const intLowerLimit = -intUpperLimit
 	for name, tt := range map[string]func(assert *assert.Assertions, span *span){
 		"init": func(assert *assert.Assertions, span *span) {
 			assert.Equal(2, len(span.Metrics))
@@ -253,22 +255,22 @@ func TestSpanSetMetric(t *testing.T) {
 			assert.Equal(1024.0, span.Metrics["bytes"])
 		},
 		"max": func(assert *assert.Assertions, span *span) {
-			span.SetTag("bytes", maxIntToFloat)
-			assert.Equal(float64(maxIntToFloat), span.Metrics["bytes"])
+			span.SetTag("bytes", intUpperLimit-1)
+			assert.Equal(float64(intUpperLimit-1), span.Metrics["bytes"])
 		},
 		"min": func(assert *assert.Assertions, span *span) {
-			span.SetTag("bytes", minIntToFloat)
-			assert.Equal(float64(minIntToFloat), span.Metrics["bytes"])
+			span.SetTag("bytes", intLowerLimit+1)
+			assert.Equal(float64(intLowerLimit+1), span.Metrics["bytes"])
 		},
 		"toobig": func(assert *assert.Assertions, span *span) {
-			span.SetTag("bytes", maxIntToFloat+1)
+			span.SetTag("bytes", intUpperLimit)
 			assert.Equal(0.0, span.Metrics["bytes"])
-			assert.Equal(fmt.Sprint(maxIntToFloat+1), span.Meta["bytes"])
+			assert.Equal(fmt.Sprint(intUpperLimit), span.Meta["bytes"])
 		},
 		"toosmall": func(assert *assert.Assertions, span *span) {
-			span.SetTag("bytes", minIntToFloat-1)
+			span.SetTag("bytes", intLowerLimit)
 			assert.Equal(0.0, span.Metrics["bytes"])
-			assert.Equal(fmt.Sprint(minIntToFloat-1), span.Meta["bytes"])
+			assert.Equal(fmt.Sprint(intLowerLimit), span.Meta["bytes"])
 		},
 		"finished": func(assert *assert.Assertions, span *span) {
 			span.Finish()

--- a/ddtrace/tracer/util.go
+++ b/ddtrace/tracer/util.go
@@ -13,6 +13,8 @@ import (
 // toFloat64 attempts to convert value into a float64. If it succeeds it returns
 // the value and true, otherwise 0 and false.
 func toFloat64(value interface{}) (f float64, ok bool) {
+	const max = (int64(1) << 53)
+	const min = (-max)
 	switch i := value.(type) {
 	case byte:
 		return float64(i), true
@@ -27,6 +29,9 @@ func toFloat64(value interface{}) (f float64, ok bool) {
 	case int32:
 		return float64(i), true
 	case int64:
+		if i > max || i < min {
+			return 0, false
+		}
 		return float64(i), true
 	case uint:
 		return float64(i), true
@@ -35,6 +40,9 @@ func toFloat64(value interface{}) (f float64, ok bool) {
 	case uint32:
 		return float64(i), true
 	case uint64:
+		if i > uint64(max) {
+			return 0, false
+		}
 		return float64(i), true
 	default:
 		return 0, false

--- a/ddtrace/tracer/util.go
+++ b/ddtrace/tracer/util.go
@@ -10,14 +10,13 @@ import (
 	"strings"
 )
 
-const (
-	maxIntToFloat = (int64(1) << 53) - 1
-	minIntToFloat = (-maxIntToFloat)
-)
-
-// toFloat64 attempts to convert value into a float64. If it succeeds it returns
-// the value and true, otherwise 0 and false.
+// toFloat64 attempts to convert value into a float64. If the value is an integer
+// greater or equal to 2^53 or less than or equal to -2^53, it will not be converted
+// into a float64 to avoid losing precision. If it succeeds in converting, toFloat64
+// returns the value and true, otherwise 0 and false.
 func toFloat64(value interface{}) (f float64, ok bool) {
+	const max = (int64(1) << 53) - 1
+	const min = -max
 	switch i := value.(type) {
 	case byte:
 		return float64(i), true
@@ -32,7 +31,7 @@ func toFloat64(value interface{}) (f float64, ok bool) {
 	case int32:
 		return float64(i), true
 	case int64:
-		if i > maxIntToFloat || i < minIntToFloat {
+		if i > max || i < min {
 			return 0, false
 		}
 		return float64(i), true
@@ -43,7 +42,7 @@ func toFloat64(value interface{}) (f float64, ok bool) {
 	case uint32:
 		return float64(i), true
 	case uint64:
-		if i > uint64(maxIntToFloat) {
+		if i > uint64(max) {
 			return 0, false
 		}
 		return float64(i), true

--- a/ddtrace/tracer/util.go
+++ b/ddtrace/tracer/util.go
@@ -10,11 +10,14 @@ import (
 	"strings"
 )
 
+const (
+	maxIntToFloat = (int64(1) << 53) - 1
+	minIntToFloat = (-maxIntToFloat)
+)
+
 // toFloat64 attempts to convert value into a float64. If it succeeds it returns
 // the value and true, otherwise 0 and false.
 func toFloat64(value interface{}) (f float64, ok bool) {
-	const max = (int64(1) << 53)
-	const min = (-max)
 	switch i := value.(type) {
 	case byte:
 		return float64(i), true
@@ -29,7 +32,7 @@ func toFloat64(value interface{}) (f float64, ok bool) {
 	case int32:
 		return float64(i), true
 	case int64:
-		if i > max || i < min {
+		if i > maxIntToFloat || i < minIntToFloat {
 			return 0, false
 		}
 		return float64(i), true
@@ -40,7 +43,7 @@ func toFloat64(value interface{}) (f float64, ok bool) {
 	case uint32:
 		return float64(i), true
 	case uint64:
-		if i > uint64(max) {
+		if i > uint64(maxIntToFloat) {
 			return 0, false
 		}
 		return float64(i), true

--- a/ddtrace/tracer/util_test.go
+++ b/ddtrace/tracer/util_test.go
@@ -32,8 +32,13 @@ func TestToFloat64(t *testing.T) {
 		10: {"a", 0, false},
 		11: {float32(1.25), 1.25, true},
 		12: {float64(1.25), 1.25, true},
-		13: {uint64(1) << 60, 0, false},
-		14: {-(int64(1) << 60), 0, false},
+		13: {maxIntToFloat + 1, 0, false},
+		14: {maxIntToFloat + 2, 0, false},
+		15: {maxIntToFloat, float64(maxIntToFloat), true},
+		16: {minIntToFloat - 1, 0, false},
+		17: {minIntToFloat - 2, 0, false},
+		18: {minIntToFloat, float64(minIntToFloat), true},
+		19: {-1024, -1024.0, true},
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			f, ok := toFloat64(tt.value)

--- a/ddtrace/tracer/util_test.go
+++ b/ddtrace/tracer/util_test.go
@@ -32,6 +32,8 @@ func TestToFloat64(t *testing.T) {
 		10: {"a", 0, false},
 		11: {float32(1.25), 1.25, true},
 		12: {float64(1.25), 1.25, true},
+		13: {uint64(1) << 60, 0, false},
+		14: {-(int64(1) << 60), 0, false},
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			f, ok := toFloat64(tt.value)

--- a/ddtrace/tracer/util_test.go
+++ b/ddtrace/tracer/util_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestToFloat64(t *testing.T) {
+	const intUpperLimit = int64(1) << 53
+	const intLowerLimit = -intUpperLimit
 	for i, tt := range [...]struct {
 		value interface{}
 		f     float64
@@ -32,12 +34,12 @@ func TestToFloat64(t *testing.T) {
 		10: {"a", 0, false},
 		11: {float32(1.25), 1.25, true},
 		12: {float64(1.25), 1.25, true},
-		13: {maxIntToFloat + 1, 0, false},
-		14: {maxIntToFloat + 2, 0, false},
-		15: {maxIntToFloat, float64(maxIntToFloat), true},
-		16: {minIntToFloat - 1, 0, false},
-		17: {minIntToFloat - 2, 0, false},
-		18: {minIntToFloat, float64(minIntToFloat), true},
+		13: {intUpperLimit, 0, false},
+		14: {intUpperLimit + 1, 0, false},
+		15: {intUpperLimit - 1, float64(intUpperLimit - 1), true},
+		16: {intLowerLimit, 0, false},
+		17: {intLowerLimit - 1, 0, false},
+		18: {intLowerLimit + 1, float64(intLowerLimit + 1), true},
 		19: {-1024, -1024.0, true},
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {

--- a/ddtrace/tracer/util_test.go
+++ b/ddtrace/tracer/util_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestToFloat64(t *testing.T) {
-	const intUpperLimit = int64(1) << 53
-	const intLowerLimit = -intUpperLimit
 	for i, tt := range [...]struct {
 		value interface{}
 		f     float64


### PR DESCRIPTION
Make sure integers that are too large or too small to be precisely represented by a
float are represented as strings. This commit makes sure that integers greater than
2^53 or smaller than -2^53 are sent as strings in the meta field of a span.