### PR TITLE
ddtrace/tracer: fix bug in TestReportMetrics

### DIFF
--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -35,7 +35,7 @@ func TestReportMetrics(t *testing.T) {
 	assert.NoError(err)
 	calls := tg.CallNames()
 	tags := tg.Tags()
-	assert.True(len(calls) > 30)
+	assert.True(len(calls) >= 35)
 	assert.Contains(calls, "runtime.go.num_cpu")
 	assert.Contains(calls, "runtime.go.mem_stats.alloc")
 	assert.Contains(calls, "runtime.go.gc_stats.pause_quantiles.75p")

--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -29,7 +29,7 @@ func TestReportMetrics(t *testing.T) {
 
 	var tg testGauger
 	go trc.reportMetrics(&tg, time.Millisecond)
-	err := tg.Wait(30, 1*time.Second)
+	err := tg.Wait(35, 1*time.Second)
 	close(trc.stopped)
 	assert := assert.New(t)
 	assert.NoError(err)


### PR DESCRIPTION
The Wait call in the TestReportMetrics test waits for 30 calls to the statsd client, but
we expect to see 35 calls. Waiting for only 30 causes a race between the stats reporter
and the asserts in the test which causes intermittent failures.