### PR TITLE
ddtrace/tracer: add rule-based sampler

### DIFF
--- a/ddtrace/tracer/doc.go
+++ b/ddtrace/tracer/doc.go
@@ -39,9 +39,9 @@
 //
 // Sampling rules can also be configured at runtime using the DD_TRACE_SAMPLING_RULES
 // environment variable. When set, it overrides rules set by tracer.WithSamplingRules.
-// The value is a JSON array of objects. Each object must have a "rate", and the "name"
-// and "service" fields are optional.
-//    export DD_TRACE_SAMPLING_RULES='[{"name": "web.request", "rate": 1.0}]'
+// The value is a JSON array of objects. Each object must have a "sample_rate", and the
+// "name" and "service" fields are optional.
+//    export DD_TRACE_SAMPLING_RULES='[{"name": "web.request", "sample_rate": 1.0}]'
 //
 // All spans created by the tracer contain a context hereby referred to as the span
 // context. Note that this is different from Go's context. The span context is used

--- a/ddtrace/tracer/doc.go
+++ b/ddtrace/tracer/doc.go
@@ -20,6 +20,29 @@
 //   s := tracer.NewRateSampler(0.3)
 //   tracer.Start(tracer.WithSampler(s))
 //
+// More precise control of sampling rates can be configured using sampling rules.
+// This can be applied based on span name, service or both, and is used to determine
+// the sampling rate to apply.
+//   rules := []tracer.SamplingRule{
+//         // sample 10% of traces with the span name "web.request"
+//         tracer.NameRule("web.request", 0.1),
+//         // sample 20% of traces for the service "test-service"
+//         tracer.ServiceRule("test-service", 0.2),
+//         // sample 30% of traces when the span name is "db.query" and the service
+//         // is "postgres.db"
+//         tracer.NameServiceRule("db.query", "postgres.db", 0.3),
+//         // sample 100% of traces when service and name match these regular expressions
+//         {Service: regexp.MustCompile("^test-"), Name: regexp.MustCompile("http\\..*"), Rate: 1.0},
+//   }
+//   tracer.Start(tracer.WithSamplingRules(rules))
+//   defer tracer.Stop()
+//
+// Sampling rules can also be configured at runtime using the DD_TRACE_SAMPLING_RULES
+// environment variable. When set, it overrides rules set by tracer.WithSamplingRules.
+// The value is a JSON array of objects. Each object must have a "rate", and the "name"
+// and "service" fields are optional.
+//    export DD_TRACE_SAMPLING_RULES='[{"name": "web.request", "rate": 1.0}]'
+//
 // All spans created by the tracer contain a context hereby referred to as the span
 // context. Note that this is different from Go's context. The span context is used
 // to package essential information from a span, which is needed when creating child

--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -285,6 +285,7 @@ func TestReportHealthMetrics(t *testing.T) {
 		exitChan:         make(chan struct{}),
 		payloadChan:      make(chan []*span, payloadQueueSize),
 		stopped:          make(chan struct{}),
+		rulesSampling:    newRulesSampler(nil),
 		prioritySampling: newPrioritySampler(),
 	}
 	internal.SetGlobalTracer(trc)

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -68,8 +68,9 @@ type config struct {
 	// statsd is used for tracking metrics associated with the runtime and the tracer.
 	statsd statsdClient
 
-	// rulesConfig ...
-	samplingRules []*SamplingRule
+	// samplingRules contains user-defined rules determine the sampling rate to apply
+	// to spans.
+	samplingRules []SamplingRule
 }
 
 // StartOption represents a function that can be provided as a parameter to Start.
@@ -245,7 +246,7 @@ func WithDogstatsdAddress(addr string) StartOption {
 
 // WithSamplingRules specifies the sampling rates to apply to spans based on the
 // provided rules.
-func WithSamplingRules(rules []*SamplingRule) StartOption {
+func WithSamplingRules(rules []SamplingRule) StartOption {
 	return func(cfg *config) {
 		cfg.samplingRules = rules
 	}

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -69,7 +69,7 @@ type config struct {
 	statsd statsdClient
 
 	// rulesConfig ...
-	samplingRules []SamplingRule
+	samplingRules []*SamplingRule
 }
 
 // StartOption represents a function that can be provided as a parameter to Start.
@@ -245,7 +245,7 @@ func WithDogstatsdAddress(addr string) StartOption {
 
 // WithSamplingRules specifies the sampling rates to apply to spans based on the
 // provided rules.
-func WithSamplingRules(rules []SamplingRule) StartOption {
+func WithSamplingRules(rules []*SamplingRule) StartOption {
 	return func(cfg *config) {
 		cfg.samplingRules = rules
 	}

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -245,7 +245,7 @@ func WithDogstatsdAddress(addr string) StartOption {
 
 // WithSamplingRules specifies the sampling rates to apply to spans based on the
 // provided rules.
-func WithSamplingRules(rules ...SamplingRule) StartOption {
+func WithSamplingRules(rules []SamplingRule) StartOption {
 	return func(cfg *config) {
 		cfg.samplingRules = rules
 	}

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -69,7 +69,7 @@ type config struct {
 	statsd statsdClient
 
 	// rulesConfig ...
-	rulesConfig string
+	samplingRules []SamplingRule
 }
 
 // StartOption represents a function that can be provided as a parameter to Start.
@@ -245,9 +245,9 @@ func WithDogstatsdAddress(addr string) StartOption {
 
 // WithSamplingRules specifies the sampling rates to apply to spans based on the
 // provided rules.
-func WithSamplingRules(rules string) StartOption {
+func WithSamplingRules(rules ...SamplingRule) StartOption {
 	return func(cfg *config) {
-		cfg.rulesConfig = rules
+		cfg.samplingRules = rules
 	}
 }
 

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -67,6 +67,9 @@ type config struct {
 
 	// statsd is used for tracking metrics associated with the runtime and the tracer.
 	statsd statsdClient
+
+	// rulesConfig ...
+	rulesConfig string
 }
 
 // StartOption represents a function that can be provided as a parameter to Start.
@@ -237,6 +240,14 @@ func WithRuntimeMetrics() StartOption {
 func WithDogstatsdAddress(addr string) StartOption {
 	return func(cfg *config) {
 		cfg.dogstatsdAddr = addr
+	}
+}
+
+// WithSamplingRules specifies the sampling rates to apply to spans based on the
+// provided rules.
+func WithSamplingRules(rules string) StartOption {
+	return func(cfg *config) {
+		cfg.rulesConfig = rules
 	}
 }
 

--- a/ddtrace/tracer/sampler.go
+++ b/ddtrace/tracer/sampler.go
@@ -219,9 +219,11 @@ func samplingRules(rules []*SamplingRule) []*SamplingRule {
 	for _, v := range rules {
 		if v.err != nil {
 			log.Warn("ignoring rule %+v: %v", v, v.err)
+			continue
 		}
-		if v.Rate < 0.0 || v.Rate > 1.0 {
+		if !(v.Rate >= 0.0 && v.Rate <= 1.0) {
 			log.Warn("ignoring rule %+v: rate is out of range", v)
+			continue
 		}
 		validRules = append(validRules, v)
 	}
@@ -368,9 +370,10 @@ func ServiceOperationRule(service string, operation string, rate float64) *Sampl
 		sr.err = fmt.Errorf("service '%s' is invalid: %v", service, err)
 	}
 	sr.Operation, err = regexp.Compile(anchoredRE(operation))
-	if err != nil && sr.err != nil {
+	if err != nil && sr.err == nil {
 		sr.err = fmt.Errorf("operation '%s' is invalid: %v", operation, err)
 	}
+	sr.Rate = rate
 	return sr
 }
 

--- a/ddtrace/tracer/sampler.go
+++ b/ddtrace/tracer/sampler.go
@@ -172,7 +172,7 @@ func newRulesSampler(rules []SamplingRule) *rulesSampler {
 	return &rulesSampler{
 		rules:   samplingRules(rules),
 		rate:    rate,
-		limiter: rateLimiter(rate),
+		limiter: newRateLimiter(rate),
 	}
 }
 
@@ -229,7 +229,7 @@ func sampleRate() float64 {
 	return rate
 }
 
-func rateLimiter(r float64) *rate.Limiter {
+func newRateLimiter(r float64) *rate.Limiter {
 	v := os.Getenv("DD_TRACE_RATE_LIMIT")
 	if v == "" {
 		return nil

--- a/ddtrace/tracer/sampler.go
+++ b/ddtrace/tracer/sampler.go
@@ -203,7 +203,7 @@ func appliedSamplingRules(rules []SamplingRule) []SamplingRule {
 		jsonRules := []struct {
 			Service string      `json:"service"`
 			Name    string      `json:"name"`
-			Rate    json.Number `json:"rate"`
+			Rate    json.Number `json:"sample_rate"`
 		}{}
 		err := json.Unmarshal([]byte(rulesFromEnv), &jsonRules)
 		if err != nil {

--- a/ddtrace/tracer/sampler.go
+++ b/ddtrace/tracer/sampler.go
@@ -244,20 +244,20 @@ func appliedSamplingRules(rules []SamplingRule) []SamplingRule {
 // sampleRate returns the sampling rate found in the DD_TRACE_SAMPLE_RATE environment variable. If it is invalid and
 // not within the 0-1 range, the default value of 0 is returned.
 func sampleRate() float64 {
-	const defaultRate = 0.0
+	defaultRate := math.NaN()
 	v := os.Getenv("DD_TRACE_SAMPLE_RATE")
 	if v == "" {
 		return defaultRate
 	}
 	r, err := strconv.ParseFloat(v, 64)
 	if err != nil {
-		log.Warn("using default rate %f because DD_TRACE_SAMPLE_RATE is invalid: %v", defaultRate, err)
+		log.Warn("ignoring DD_TRACE_SAMPLE_RATE: error: %v", err)
 		return defaultRate
 	}
 	if r >= 0.0 && r <= 1.0 {
 		return r
 	}
-	log.Warn("using default rate %f because provided value is out of range: %f", defaultRate, r)
+	log.Warn("ignoring DD_TRACE_SAMPLE_RATE: out of range %f", r)
 	return defaultRate
 }
 
@@ -295,7 +295,7 @@ func (rs *rulesSampler) apply(span *span) bool {
 			break
 		}
 	}
-	if !matched && rate == 0.0 {
+	if !matched && math.IsNaN(rate) {
 		// no matching rule or global rate, so we want to fall back
 		// to priority sampling
 		return false

--- a/ddtrace/tracer/sampler.go
+++ b/ddtrace/tracer/sampler.go
@@ -286,6 +286,11 @@ func newRateLimiter(r float64) *rate.Limiter {
 // set using DD_TRACE_SAMPLE_RATE, then it returns false and the span is not
 // modified.
 func (rs *rulesSampler) apply(span *span) bool {
+	if len(rs.rules) == 0 && math.IsNaN(rs.rate) {
+		// short path when disabled
+		return false
+	}
+
 	var matched bool
 	rate := rs.rate
 	for _, rule := range rs.rules {

--- a/ddtrace/tracer/sampler.go
+++ b/ddtrace/tracer/sampler.go
@@ -348,6 +348,9 @@ func (sr *SamplingRule) optimalMatch(mf *matchFunc, s string) {
 }
 
 func (sr *SamplingRule) match(spn *span) bool {
+	if sr.err != nil {
+		return false
+	}
 	if sr.service != nil && !sr.service(spn.Service) {
 		return false
 	}

--- a/ddtrace/tracer/sampler.go
+++ b/ddtrace/tracer/sampler.go
@@ -253,7 +253,7 @@ func globalSampleRate() float64 {
 }
 
 // newSamplingLimiter returns a rate limiter which restricts the number of traces sampled per second.
-// This defaults to 100.0. The DD_TRACE_LIMIT environment variable may override the default.
+// This defaults to 100.0. The DD_TRACE_RATE_LIMIT environment variable may override the default.
 func newSamplingLimiter() *samplingLimiter {
 	limit := 100.0
 	v := os.Getenv("DD_TRACE_RATE_LIMIT")

--- a/ddtrace/tracer/sampler_test.go
+++ b/ddtrace/tracer/sampler_test.go
@@ -245,12 +245,12 @@ func TestRuleEnvVars(t *testing.T) {
 		assert.Len(validRules, 0)
 
 		// valid rules
-		os.Setenv("DD_TRACE_SAMPLING_RULES", `[{"service": "abcd", "rate": 1.0}]`)
+		os.Setenv("DD_TRACE_SAMPLING_RULES", `[{"service": "abcd", "sample_rate": 1.0}]`)
 		validRules = appliedSamplingRules(rules)
 		assert.Len(validRules, 1)
 
 		// invalid rule ignored
-		os.Setenv("DD_TRACE_SAMPLING_RULES", `[{"service": "abcd", "rate": 42.0}]`)
+		os.Setenv("DD_TRACE_SAMPLING_RULES", `[{"service": "abcd", "sample_rate": 42.0}]`)
 		validRules = appliedSamplingRules(rules)
 		assert.Len(validRules, 0)
 	})

--- a/ddtrace/tracer/sampler_test.go
+++ b/ddtrace/tracer/sampler_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
@@ -307,4 +308,155 @@ func TestRulesSampler(t *testing.T) {
 			})
 		}
 	})
+}
+
+func BenchmarkRulesSampler(b *testing.B) {
+	b.Run("no-rules", func(b *testing.B) {
+		tracer := newTracer()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			tracer.StartSpan("web.request", Tag(ext.SamplingPriority, ext.PriorityUserKeep)).Finish()
+		}
+	})
+
+	b.Run("unmatching-rules", func(b *testing.B) {
+		rules := []SamplingRule{
+			ServiceRule("test-service", 1.0),
+			ServiceOperationRule("postgres.db", "db.query", 1.0),
+			OperationRule("notweb.request", 1.0),
+		}
+		tracer := newTracer(WithSamplingRules(rules))
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			tracer.StartSpan("web.request", Tag(ext.SamplingPriority, ext.PriorityUserKeep)).Finish()
+		}
+	})
+
+	b.Run("matching-rules", func(b *testing.B) {
+		rules := []SamplingRule{
+			ServiceRule("test-service", 1.0),
+			ServiceOperationRule("postgres.db", "db.query", 1.0),
+			OperationRule("web.request", 1.0),
+		}
+		tracer := newTracer(WithSamplingRules(rules))
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			tracer.StartSpan("web.request", Tag(ext.SamplingPriority, ext.PriorityUserKeep)).Finish()
+		}
+	})
+}
+
+// https://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go#compiler-optimisation
+var matched bool
+
+func BenchmarkRulesSamplerImpls(b *testing.B) {
+	b.Run("structs", func(b *testing.B) {
+		rules := []SamplingRule{
+			ServiceRule("test-service", 1.0),
+			ServiceOperationRule("postgres.db", "db.query", 1.0),
+			OperationRule("web.request", 1.0),
+		}
+		sampler := newRulesSampler(rules)
+		span := newSpan("web.request", "xyz-service", "", 0, 0, 0)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			matched = sampler.apply(span)
+		}
+	})
+
+	b.Run("pointers", func(b *testing.B) {
+		rules := []SamplingRule{
+			ServiceRule("test-service", 1.0),
+			ServiceOperationRule("postgres.db", "db.query", 1.0),
+			OperationRule("web.request", 1.0),
+		}
+		sampler := newRulesSamplerP(rules)
+		span := newSpan("web.request", "xyz-service", "", 0, 0, 0)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			matched = sampler.apply(span)
+		}
+	})
+}
+
+type rulesSamplerP struct {
+	rules   []*SamplingRule
+	rate    float64
+	limiter *rate.Limiter
+
+	// "effective rate" calculations
+	mu           sync.Mutex // guards below fields
+	ts           int64      // timestamp, to detect when counters need resetting
+	allowed      int        // number of spans allowed by rate limiter
+	total        int        // number of spans checked by rate limiter
+	previousRate float64    // previous second's rate, averaged with current rate for smoothing
+}
+
+func newRulesSamplerP(rules []SamplingRule) *rulesSamplerP {
+	rate := sampleRate()
+	rules = samplingRules(rules)
+	rulesP := make([]*SamplingRule, len(rules))
+	for i := range rules {
+		r := new(SamplingRule)
+		*r = rules[i]
+		rulesP[i] = r
+	}
+	return &rulesSamplerP{
+		rules:   rulesP,
+		rate:    rate,
+		limiter: newRateLimiter(rate),
+	}
+}
+
+func (rs *rulesSamplerP) apply(span *span) bool {
+	matched := false
+	rate := 0.0
+	for _, v := range rs.rules {
+		if v.match(span) {
+			matched = true
+			rate = v.Rate
+			break
+		}
+	}
+	if !matched {
+		if rs.rate == 0.0 {
+			// no matching rule or global rate, so we want to fall back
+			// to priority sampling
+			return false
+		}
+		rate = rs.rate
+	}
+	// rate sample
+	span.SetTag("_dd.rule_psr", rate)
+	if !sampledByRate(span.TraceID, rate) {
+		span.SetTag(ext.SamplingPriority, ext.PriorityAutoReject)
+		return true
+	}
+	// global rate limit and effective rate calculations
+	defer rs.mu.Unlock()
+	rs.mu.Lock()
+	if ts := time.Now().Unix(); ts > rs.ts {
+		// update "previous rate" and reset
+		if ts-rs.ts == 1 && rs.total > 0 && rs.allowed > 0 {
+			rs.previousRate = float64(rs.allowed) / float64(rs.total)
+		} else {
+			rs.previousRate = 0.0
+		}
+		rs.ts = ts
+		rs.allowed = 0
+		rs.total = 0
+	}
+
+	rs.total++
+	if rs.limiter != nil && !rs.limiter.Allow() {
+		span.SetTag(ext.SamplingPriority, ext.PriorityAutoReject)
+	} else {
+		rs.allowed++
+		span.SetTag(ext.SamplingPriority, ext.PriorityAutoKeep)
+	}
+	// calculate effective rate, and tag the span
+	er := (rs.previousRate + (float64(rs.allowed) / float64(rs.total))) / 2.0
+	span.SetTag("_dd.limit_psr", er)
+
+	return true
 }

--- a/ddtrace/tracer/sampler_test.go
+++ b/ddtrace/tracer/sampler_test.go
@@ -273,9 +273,9 @@ func TestRulesSampler(t *testing.T) {
 	t.Run("matching", func(t *testing.T) {
 		ruleSets := [][]SamplingRule{
 			{ServiceRule("test-service", 1.0)},
-			{OperationRule("http.request", 1.0)},
-			{ServiceOperationRule("test-service", "http.request", 1.0)},
-			{{Service: regexp.MustCompile("^test-"), Operation: regexp.MustCompile("http\\..*"), Rate: 1.0}},
+			{NameRule("http.request", 1.0)},
+			{NameServiceRule("http.request", "test-service", 1.0)},
+			{{Service: regexp.MustCompile("^test-"), Name: regexp.MustCompile("http\\..*"), Rate: 1.0}},
 			{ServiceRule("other-service-1", 0.0), ServiceRule("other-service-2", 0.0), ServiceRule("test-service", 1.0)},
 		}
 		for _, v := range ruleSets {
@@ -447,8 +447,8 @@ func BenchmarkRulesSampler(b *testing.B) {
 	b.Run("unmatching-rules", func(b *testing.B) {
 		rules := []SamplingRule{
 			ServiceRule("test-service", 1.0),
-			ServiceOperationRule("postgres.db", "db.query", 1.0),
-			OperationRule("notweb.request", 1.0),
+			NameServiceRule("db.query", "postgres.db", 1.0),
+			NameRule("notweb.request", 1.0),
 		}
 		tracer := newTracer(WithSamplingRules(rules))
 		benchmarkStartSpan(b, tracer)
@@ -457,8 +457,8 @@ func BenchmarkRulesSampler(b *testing.B) {
 	b.Run("matching-rules", func(b *testing.B) {
 		rules := []SamplingRule{
 			ServiceRule("test-service", 1.0),
-			ServiceOperationRule("postgres.db", "db.query", 1.0),
-			OperationRule("web.request", 1.0),
+			NameServiceRule("db.query", "postgres.db", 1.0),
+			NameRule("web.request", 1.0),
 		}
 		tracer := newTracer(WithSamplingRules(rules))
 		benchmarkStartSpan(b, tracer)
@@ -467,28 +467,28 @@ func BenchmarkRulesSampler(b *testing.B) {
 	b.Run("mega-rules", func(b *testing.B) {
 		rules := []SamplingRule{
 			ServiceRule("test-service", 1.0),
-			ServiceOperationRule("postgres.db", "db.query", 1.0),
-			OperationRule("notweb.request", 1.0),
-			OperationRule("notweb.request", 1.0),
-			OperationRule("notweb.request", 1.0),
-			OperationRule("notweb.request", 1.0),
-			OperationRule("notweb.request", 1.0),
-			OperationRule("notweb.request", 1.0),
-			OperationRule("notweb.request", 1.0),
-			OperationRule("notweb.request", 1.0),
-			OperationRule("notweb.request", 1.0),
-			OperationRule("notweb.request", 1.0),
-			OperationRule("notweb.request", 1.0),
-			OperationRule("notweb.request", 1.0),
-			OperationRule("notweb.request", 1.0),
-			OperationRule("notweb.request", 1.0),
-			OperationRule("notweb.request", 1.0),
-			OperationRule("notweb.request", 1.0),
-			OperationRule("notweb.request", 1.0),
-			OperationRule("notweb.request", 1.0),
-			OperationRule("notweb.request", 1.0),
-			OperationRule("notweb.request", 1.0),
-			OperationRule("web.request", 1.0),
+			NameServiceRule("db.query", "postgres.db", 1.0),
+			NameRule("notweb.request", 1.0),
+			NameRule("notweb.request", 1.0),
+			NameRule("notweb.request", 1.0),
+			NameRule("notweb.request", 1.0),
+			NameRule("notweb.request", 1.0),
+			NameRule("notweb.request", 1.0),
+			NameRule("notweb.request", 1.0),
+			NameRule("notweb.request", 1.0),
+			NameRule("notweb.request", 1.0),
+			NameRule("notweb.request", 1.0),
+			NameRule("notweb.request", 1.0),
+			NameRule("notweb.request", 1.0),
+			NameRule("notweb.request", 1.0),
+			NameRule("notweb.request", 1.0),
+			NameRule("notweb.request", 1.0),
+			NameRule("notweb.request", 1.0),
+			NameRule("notweb.request", 1.0),
+			NameRule("notweb.request", 1.0),
+			NameRule("notweb.request", 1.0),
+			NameRule("notweb.request", 1.0),
+			NameRule("web.request", 1.0),
 		}
 		tracer := newTracer(WithSamplingRules(rules))
 		benchmarkStartSpan(b, tracer)

--- a/ddtrace/tracer/sampler_test.go
+++ b/ddtrace/tracer/sampler_test.go
@@ -192,16 +192,20 @@ func TestRuleEnvVars(t *testing.T) {
 			in  string
 			out float64
 		}{
-			{in: "", out: 0.0},
+			{in: "", out: math.NaN()},
 			{in: "0.0", out: 0.0},
 			{in: "0.5", out: 0.5},
 			{in: "1.0", out: 1.0},
-			{in: "42.0", out: 0.0},    // default if out of range
-			{in: "1point0", out: 0.0}, // default if invalid value
+			{in: "42.0", out: math.NaN()},    // default if out of range
+			{in: "1point0", out: math.NaN()}, // default if invalid value
 		} {
 			os.Setenv("DD_TRACE_SAMPLE_RATE", tt.in)
 			res := sampleRate()
-			assert.Equal(tt.out, res)
+			if math.IsNaN(tt.out) {
+				assert.True(math.IsNaN(res))
+			} else {
+				assert.Equal(tt.out, res)
+			}
 		}
 	})
 

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -338,8 +338,10 @@ func (s *span) String() string {
 }
 
 const (
-	keySamplingPriority     = "_sampling_priority_v1"
-	keySamplingPriorityRate = "_sampling_priority_rate_v1"
-	keyOrigin               = "_dd.origin"
-	keyHostname             = "_dd.hostname"
+	keySamplingPriority        = "_sampling_priority_v1"
+	keySamplingPriorityRate    = "_sampling_priority_rate_v1"
+	keyOrigin                  = "_dd.origin"
+	keyHostname                = "_dd.hostname"
+	keyRulesSamplerAppliedRate = "_dd.rule_psr"
+	keyRulesSamplerLimiterRate = "_dd.limit_psr"
 )

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -170,7 +170,7 @@ func newTracer(opts ...StartOption) *tracer {
 		exitChan:         make(chan struct{}),
 		payloadChan:      make(chan []*span, payloadQueueSize),
 		stopped:          make(chan struct{}),
-		rulesSampling:    newRulesSampler(c.rulesConfig),
+		rulesSampling:    newRulesSampler(c.samplingRules),
 		prioritySampling: newPrioritySampler(),
 		pid:              strconv.Itoa(os.Getpid()),
 	}


### PR DESCRIPTION
(This is a followup PR from #539)

This PR allows users to define sampling rates for traces based on rules defined at compile-time or at runtime.

The rules currently match against
- service name
- operation name
- both
- neither

When the rule matches, the sampling rate defined by that rule is applied to spans.

Rules can be either exact-match (using helper functions), or more complicated matches can be provided using regular expressions.

The tracer can be configured in code with sampling rules via a StartOption: tracer.WithSamplingRules([]tracer.SamplingRule)
The slice is composed of rules defined directly by users or using helpers such as `tracer.ServiceRule()`

To configure these rules at runtime, and other properties of the rule-based sampler, there are environment variables that can be set.
The environment variables override the behavior of settings configured in code.
- `DD_TRACE_SAMPLING_RULES`: configures the rules sampler using JSON, eg: `[{"service": "abcd", "rate": 1.0}]` configures the rules sampler
  with one rule, spans with service == `abcd` are 100% sampled (`1.0`)
- `DD_TRACE_SAMPLE_RATE`: a fall-back rate to apply. When spans do not match any defined rule, if this is set to a valid rate (0.0-1.0),
  then this rate is used for those spans.
- `DD_TRACE_RATE_LIMIT`: an upper limit for spans to be sampled by the rules sampler. If not set, then any span matching rules or
  a fall-back rate are sampled. If this volume is excessive, this variable can be set to the desired number of sampled spans per second.

The rules-sampler is currently "opt-in", so if no rules or environment variables related to it are set, then it behaves the same as before.
In future releases, this may change to "opt-out" with defaults for sample rate and rate limits.
