### PR TITLE
ddtrace/tracer: send payloads asynchronously

### DIFF
--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -281,7 +281,7 @@ func TestReportHealthMetrics(t *testing.T) {
 			transport: newDummyTransport(),
 		},
 		payload:          newPayload(),
-		flushChan:        make(chan chan<- struct{}),
+		flushChan:        make(chan struct{}),
 		exitChan:         make(chan struct{}),
 		payloadChan:      make(chan []*span, payloadQueueSize),
 		stopped:          make(chan struct{}),
@@ -318,7 +318,7 @@ func TestTracerMetrics(t *testing.T) {
 	tracer, _, stop := startTestTracer(withStatsdClient(&tg))
 
 	tracer.StartSpan("operation").Finish()
-	tracer.flushChan <- nil
+	tracer.flushChan <- struct{}{}
 	tg.Wait(5, 100*time.Millisecond)
 
 	calls := tg.CallsByName()

--- a/ddtrace/tracer/sampler_test.go
+++ b/ddtrace/tracer/sampler_test.go
@@ -505,7 +505,7 @@ func BenchmarkRulesSampler(b *testing.B) {
 		return &tracer{
 			config:           c,
 			payloadChan:      make(chan []*span, batchSize),
-			flushChan:        make(chan chan<- struct{}, 1),
+			flushChan:        make(chan struct{}, 1),
 			stopped:          make(chan struct{}),
 			exitChan:         make(chan struct{}, 1),
 			rulesSampling:    newRulesSampler(c.samplingRules),

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -345,7 +345,7 @@ func TestSpanErrorNil(t *testing.T) {
 
 // Prior to a bug fix, this failed when running `go test -race`
 func TestSpanModifyWhileFlushing(t *testing.T) {
-	tracer, transport, stop := startTestTracer()
+	tracer, _, stop := startTestTracer()
 	defer stop()
 
 	done := make(chan struct{})
@@ -366,7 +366,7 @@ func TestSpanModifyWhileFlushing(t *testing.T) {
 		case <-done:
 			return
 		default:
-			tracer.forceFlush(transport)
+			tracer.forceFlush()
 		}
 	}
 }

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -366,7 +366,8 @@ func TestSpanModifyWhileFlushing(t *testing.T) {
 		case <-done:
 			return
 		default:
-			tracer.forceFlush()
+			tracer.flushChan <- struct{}{}
+			time.Sleep(10 * time.Millisecond)
 		}
 	}
 }

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -345,7 +345,7 @@ func TestSpanErrorNil(t *testing.T) {
 
 // Prior to a bug fix, this failed when running `go test -race`
 func TestSpanModifyWhileFlushing(t *testing.T) {
-	tracer, _, stop := startTestTracer()
+	tracer, transport, stop := startTestTracer()
 	defer stop()
 
 	done := make(chan struct{})
@@ -366,7 +366,7 @@ func TestSpanModifyWhileFlushing(t *testing.T) {
 		case <-done:
 			return
 		default:
-			tracer.forceFlush()
+			tracer.forceFlush(transport)
 		}
 	}
 }

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -7,6 +7,7 @@ package tracer
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -111,7 +112,7 @@ func TestSpanTracePushOne(t *testing.T) {
 	assert.Equal(root, trace.spans[0], "the span is the one pushed before")
 
 	root.Finish()
-	tracer.forceFlush()
+	tracer.flushAndWait(1)
 
 	traces := transport.Traces()
 	assert.Len(traces, 1)
@@ -177,7 +178,9 @@ func TestSpanTracePushSeveral(t *testing.T) {
 	for _, span := range trace {
 		span.Finish()
 	}
-	tracer.forceFlush()
+	fmt.Println("flush and wait")
+	tracer.flushAndWait(1)
+	fmt.Println("flush and wait DONE")
 
 	traces := transport.Traces()
 	assert.Len(traces, 1)
@@ -207,7 +210,7 @@ func TestSpanFinishPriority(t *testing.T) {
 	child.Finish()
 	root.Finish()
 
-	tracer.forceFlush()
+	tracer.flushAndWait(1)
 
 	traces := transport.Traces()
 	assert.Len(traces, 1)

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -7,7 +7,6 @@ package tracer
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -112,7 +111,7 @@ func TestSpanTracePushOne(t *testing.T) {
 	assert.Equal(root, trace.spans[0], "the span is the one pushed before")
 
 	root.Finish()
-	tracer.flushAndWait(1)
+	tracer.flushAndWait(t, 1)
 
 	traces := transport.Traces()
 	assert.Len(traces, 1)
@@ -178,9 +177,7 @@ func TestSpanTracePushSeveral(t *testing.T) {
 	for _, span := range trace {
 		span.Finish()
 	}
-	fmt.Println("flush and wait")
-	tracer.flushAndWait(1)
-	fmt.Println("flush and wait DONE")
+	tracer.flushAndWait(t, 1)
 
 	traces := transport.Traces()
 	assert.Len(traces, 1)
@@ -210,7 +207,7 @@ func TestSpanFinishPriority(t *testing.T) {
 	child.Finish()
 	root.Finish()
 
-	tracer.flushAndWait(1)
+	tracer.flushAndWait(t, 1)
 
 	traces := transport.Traces()
 	assert.Len(traces, 1)

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -111,7 +111,7 @@ func TestSpanTracePushOne(t *testing.T) {
 	assert.Equal(root, trace.spans[0], "the span is the one pushed before")
 
 	root.Finish()
-	tracer.forceFlush()
+	tracer.forceFlush(transport)
 
 	traces := transport.Traces()
 	assert.Len(traces, 1)
@@ -177,7 +177,7 @@ func TestSpanTracePushSeveral(t *testing.T) {
 	for _, span := range trace {
 		span.Finish()
 	}
-	tracer.forceFlush()
+	tracer.forceFlush(transport)
 
 	traces := transport.Traces()
 	assert.Len(traces, 1)
@@ -207,7 +207,7 @@ func TestSpanFinishPriority(t *testing.T) {
 	child.Finish()
 	root.Finish()
 
-	tracer.forceFlush()
+	tracer.forceFlush(transport)
 
 	traces := transport.Traces()
 	assert.Len(traces, 1)

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -111,7 +111,7 @@ func TestSpanTracePushOne(t *testing.T) {
 	assert.Equal(root, trace.spans[0], "the span is the one pushed before")
 
 	root.Finish()
-	tracer.forceFlush(transport)
+	tracer.forceFlush()
 
 	traces := transport.Traces()
 	assert.Len(traces, 1)
@@ -177,7 +177,7 @@ func TestSpanTracePushSeveral(t *testing.T) {
 	for _, span := range trace {
 		span.Finish()
 	}
-	tracer.forceFlush(transport)
+	tracer.forceFlush()
 
 	traces := transport.Traces()
 	assert.Len(traces, 1)
@@ -207,7 +207,7 @@ func TestSpanFinishPriority(t *testing.T) {
 	child.Finish()
 	root.Finish()
 
-	tracer.forceFlush(transport)
+	tracer.forceFlush()
 
 	traces := transport.Traces()
 	assert.Len(traces, 1)

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -369,8 +369,8 @@ func (t *tracer) flushPayload() {
 	if t.payload.itemCount() == 0 {
 		return
 	}
-	t.climit <- struct{}{}
 	t.wg.Add(1)
+	t.climit <- struct{}{}
 	go func(p *payload) {
 		defer func(start time.Time) {
 			<-t.climit

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1099,12 +1099,11 @@ func decode(p *payload) (spanLists, error) {
 }
 
 func (t *dummyTransport) waitFlush(ts *testing.T, n int) {
-	a := time.After(1 * time.Second)
+	timeout := time.After(1 * time.Second)
 	for {
 		select {
-		case <-a:
-			//panic("timed out waiting for flush")
-			ts.Fatalf("Timed out waiting for flush.")
+		case <-timeout:
+			ts.Fatalf("Timed out waiting for %d traces.", n)
 		default:
 			t.Lock()
 			l := len(t.traces)


### PR DESCRIPTION
This patch moves the flushing of payloads to the agent into its own goroutine.
This avoids blocking the rest of the tracer, decreasing the liklihood of dropping traces
due to network latency.