### PR TITLE
ddtrace/tracer: fix infinite recursion in (*safeSource).Seed call

### DIFF
--- a/ddtrace/tracer/rand.go
+++ b/ddtrace/tracer/rand.go
@@ -51,6 +51,6 @@ func (rs *safeSource) Uint64() uint64 { return uint64(rs.Int63()) }
 
 func (rs *safeSource) Seed(seed int64) {
 	rs.Lock()
-	rs.Seed(seed)
+	rs.source.Seed(seed)
 	rs.Unlock()
 }


### PR DESCRIPTION
This probably has never occurred since `Seed` doesn't appear to be called anywhere, but it's a bug nonetheless. 

I'll also mention that it's worth using linters[1][2], which nicely assist catching these subtle bugs.

1. golangci-lint: https://github.com/golangci/golangci-lint
2. https://staticcheck.io/docs/checks#SA5007