### PR TITLE
contrib/labstack/echo: Add filter option to whitelist requests with trace

### DIFF
--- a/contrib/labstack/echo/echotrace.go
+++ b/contrib/labstack/echo/echotrace.go
@@ -27,6 +27,10 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 		}
 		return func(c echo.Context) error {
 			request := c.Request()
+			if cfg.filter != nil && !cfg.filter(request) {
+				return next(c)
+			}
+
 			resource := request.Method + " " + c.Path()
 			opts := []ddtrace.StartSpanOption{
 				tracer.ServiceName(cfg.serviceName),

--- a/contrib/labstack/echo/option.go
+++ b/contrib/labstack/echo/option.go
@@ -7,11 +7,13 @@ package echo
 
 import (
 	"math"
+	"net/http"
 )
 
 type config struct {
 	serviceName   string
 	analyticsRate float64
+	filter        func(r *http.Request) bool
 }
 
 // Option represents an option that can be passed to Middleware.
@@ -49,5 +51,14 @@ func WithAnalyticsRate(rate float64) Option {
 		} else {
 			cfg.analyticsRate = math.NaN()
 		}
+	}
+}
+
+// WithFilter allows to select the requests that will have trace added. If
+// filter returns true the trace will be added, otherwise all middleware actions
+// will be skipped.
+func WithFilter(filter func(r *http.Request) bool) Option {
+	return func(cfg *config) {
+		cfg.filter = filter
 	}
 }


### PR DESCRIPTION
Add new option so it's possible to select the requests that the trace will be added. This is useful to disable tracing on some environments or URIs.