### PR TITLE
contrib/net/http: cause the default config to set the analytics rate in spanOpts

### DIFF
--- a/contrib/net/http/http.go
+++ b/contrib/net/http/http.go
@@ -7,12 +7,9 @@
 package http // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
 
 import (
-	"math"
 	"net/http"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httputil"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 // ServeMux is an HTTP request multiplexer that traces all the incoming requests.
@@ -43,11 +40,7 @@ func (mux *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// get the resource associated to this request
 	_, route := mux.Handler(r)
 	resource := r.Method + " " + route
-	opts := mux.cfg.spanOpts
-	if !math.IsNaN(mux.cfg.analyticsRate) {
-		opts = append(opts, tracer.Tag(ext.EventSampleRate, mux.cfg.analyticsRate))
-	}
-	httputil.TraceAndServe(mux.ServeMux, w, r, mux.cfg.serviceName, resource, opts...)
+	httputil.TraceAndServe(mux.ServeMux, w, r, mux.cfg.serviceName, resource, mux.cfg.spanOpts...)
 }
 
 // WrapHandler wraps an http.Handler with tracing using the given service and resource.

--- a/contrib/net/http/http_test.go
+++ b/contrib/net/http/http_test.go
@@ -109,10 +109,20 @@ func TestAnalyticsSettings(t *testing.T) {
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, r)
 
+		f := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			message := "Hello \n"
+			w.Write([]byte(message))
+		})
+		handler := WrapHandler(f, "my-service", "my-resource", opts...)
+		r = httptest.NewRequest("GET", "/200", nil)
+		w = httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+
 		spans := mt.FinishedSpans()
-		assert.Len(t, spans, 1)
-		s := spans[0]
-		assert.Equal(t, rate, s.Tag(ext.EventSampleRate))
+		assert.Len(t, spans, 2)
+		for _, s := range spans {
+			assert.Equal(t, rate, s.Tag(ext.EventSampleRate))
+		}
 	}
 
 	t.Run("defaults", func(t *testing.T) {

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
@@ -28,6 +30,9 @@ type Option func(*config)
 func defaults(cfg *config) {
 	cfg.analyticsRate = globalconfig.AnalyticsRate()
 	cfg.serviceName = "http.router"
+	if !math.IsNaN(cfg.analyticsRate) {
+		cfg.spanOpts = []ddtrace.StartSpanOption{tracer.Tag(ext.EventSampleRate, cfg.analyticsRate)}
+	}
 }
 
 // WithServiceName sets the given service name for the returned ServeMux.

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -47,6 +47,7 @@ func WithAnalytics(on bool) MuxOption {
 	return func(cfg *config) {
 		if on {
 			cfg.analyticsRate = 1.0
+			cfg.spanOpts = []ddtrace.StartSpanOption{tracer.Tag(ext.EventSampleRate, cfg.analyticsRate)}
 		} else {
 			cfg.analyticsRate = math.NaN()
 		}
@@ -59,6 +60,7 @@ func WithAnalyticsRate(rate float64) MuxOption {
 	return func(cfg *config) {
 		if rate >= 0.0 && rate <= 1.0 {
 			cfg.analyticsRate = rate
+			cfg.spanOpts = []ddtrace.StartSpanOption{tracer.Tag(ext.EventSampleRate, cfg.analyticsRate)}
 		} else {
 			cfg.analyticsRate = math.NaN()
 		}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,4 +8,4 @@ package version
 // Tag specifies the current release tag. It needs to be manually
 // updated. A test checks that the value of Tag never points to a
 // git tag that is older than HEAD.
-const Tag = "v1.20.0"
+const Tag = "v1.21.0"


### PR DESCRIPTION
WrapHandler fails to set the EventSampleRate tag as ServeMux.ServeHTTP does.
Rather than relying on ServeMux.ServeHTTP and WrapHandler to individually set
the tag, we will have the defaults function set the tag in the config if the global analytics
rate is not NaN.