### PR TITLE
contrib/google.golang.org/api: update grpc contrib to work with API changes.

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,4 +8,4 @@ package version
 // Tag specifies the current release tag. It needs to be manually
 // updated. A test checks that the value of Tag never points to a
 // git tag that is older than HEAD.
-const Tag = "v1.20.0"
+const Tag = "v1.21.0"


### PR DESCRIPTION
Google's grpc API has changed, and so our contrib no longer compiles.
This commit updates the contrib package to use the new API.