### PR TITLE
contrib/database/sql: implement driver.NamedValueChecker

### DIFF
--- a/contrib/database/sql/conn.go
+++ b/contrib/database/sql/conn.go
@@ -126,6 +126,13 @@ func (tc *tracedConn) QueryContext(ctx context.Context, query string, args []dri
 	return rows, err
 }
 
+func (tc *tracedConn) CheckNamedValue(value *driver.NamedValue) error {
+	if checker, ok := tc.Conn.(driver.NamedValueChecker); ok {
+		return checker.CheckNamedValue(value)
+	}
+	return driver.ErrSkip
+}
+
 // traceParams stores all information related to tracing the driver.Conn
 type traceParams struct {
 	cfg        *config

--- a/contrib/database/sql/sql_test.go
+++ b/contrib/database/sql/sql_test.go
@@ -6,10 +6,8 @@
 package sql
 
 import (
-	"context"
 	"fmt"
 	"log"
-	"math"
 	"os"
 	"testing"
 
@@ -18,7 +16,6 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/lib/pq"
-	"github.com/stretchr/testify/assert"
 )
 
 // tableName holds the SQL table that these tests will be run against. It must be unique cross-repo.
@@ -56,22 +53,9 @@ func TestMySQL(t *testing.T) {
 			ext.DBName:          "test",
 			ext.EventSampleRate: nil,
 		},
+		SupportsUint64: true,
 	}
 	sqltest.RunAll(t, testConfig)
-	// additional test for uint64 values, supported by go-sql-driver/mysql
-	t.Run("Uint64", func(t *testing.T) {
-		assert := assert.New(t)
-		rows, err := db.QueryContext(context.Background(), "SELECT ?", uint64(math.MaxUint64))
-		assert.NoError(err)
-		assert.NotNil(rows)
-		assert.True(rows.Next())
-		var result uint64
-		rows.Scan(&result)
-		assert.Equal(uint64(math.MaxUint64), result)
-		assert.False(rows.Next())
-		assert.NoError(rows.Err())
-		assert.NoError(rows.Close())
-	})
 }
 
 func TestPostgres(t *testing.T) {

--- a/contrib/internal/sqltest/sqltest.go
+++ b/contrib/internal/sqltest/sqltest.go
@@ -10,7 +10,6 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
-	"math"
 	"testing"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
@@ -50,18 +49,13 @@ func RunAll(t *testing.T, cfg *Config) {
 	cfg.mockTracer = mocktracer.Start()
 	defer cfg.mockTracer.Stop()
 
-	tests := map[string]func(*Config) func(*testing.T){
+	for name, test := range map[string]func(*Config) func(*testing.T){
 		"Ping":          testPing,
 		"Query":         testQuery,
 		"Statement":     testStatement,
 		"BeginRollback": testBeginRollback,
 		"Exec":          testExec,
-	}
-	if cfg.SupportsUint64 {
-		tests["Uint64"] = testUint64
-	}
-
-	for name, test := range tests {
+	} {
 		t.Run(name, test(cfg))
 	}
 }
@@ -216,29 +210,12 @@ func testExec(cfg *Config) func(*testing.T) {
 	}
 }
 
-func testUint64(cfg *Config) func(*testing.T) {
-	return func(t *testing.T) {
-		assert := assert.New(t)
-		rows, err := cfg.DB.Query("SELECT ?", uint64(math.MaxUint64))
-		assert.NoError(err)
-		assert.NotNil(rows)
-		assert.True(rows.Next())
-		var result uint64
-		rows.Scan(&result)
-		assert.Equal(uint64(math.MaxUint64), result)
-		assert.False(rows.Next())
-		assert.NoError(rows.Err())
-		assert.NoError(rows.Close())
-	}
-}
-
 // Config holds the test configuration.
 type Config struct {
 	*sql.DB
-	mockTracer     mocktracer.Tracer
-	DriverName     string
-	TableName      string
-	ExpectName     string
-	ExpectTags     map[string]interface{}
-	SupportsUint64 bool
+	mockTracer mocktracer.Tracer
+	DriverName string
+	TableName  string
+	ExpectName string
+	ExpectTags map[string]interface{}
 }


### PR DESCRIPTION
This fixes a reported issue by implementing the `NamedValueChecker` on the tracer's wrapper for `driver.Conn`. 

From https://golang.org/pkg/database/sql/driver/#NamedValueChecker
>  The sql package checks for value checkers in the following order, stopping at the first found match: Stmt.NamedValueChecker, Conn.NamedValueChecker, Stmt.ColumnConverter, DefaultParameterConverter. 

Searching github, I wasn't able to find drivers that implemented `Stmt.NamedValueChecker`, so didn't attempt that.

Fixes #563 