### PR TITLE
ddtrace/tracer: fix flushing when payload gets too large.

### DIFF
--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -173,7 +173,7 @@ func newTracer(opts ...StartOption) *tracer {
 	t := &tracer{
 		config:           c,
 		payload:          newPayload(),
-		flushChan:        make(chan struct{}),
+		flushChan:        make(chan struct{}, 1),
 		exitChan:         make(chan struct{}),
 		payloadChan:      make(chan []*span, payloadQueueSize),
 		stopped:          make(chan struct{}),


### PR DESCRIPTION
In pushPayload, if the payload size is getting too large, it attempts to trigger a flush.
However, flushChan is an unbuffered channel which means it will only succeed if
there is a goroutine waiting on the other end of the channel. Because pushPayload is
only called from within the worker, the worker will never be waiting on the other end of
flushChan, so pushPayload will always fail to trigger a flush.

This commit changes flushChan to be a buffered channel with 1 space, so a flush can
be queued. When pushPayload sends on the channel, it will be received when the worker
returns to its select loop.