### PR TITLE
ddtrace/mocktracer: (*mockspan).Finish must be idempotent

### DIFF
--- a/ddtrace/mocktracer/mockspan.go
+++ b/ddtrace/mocktracer/mockspan.go
@@ -100,13 +100,12 @@ type mockspan struct {
 	name         string
 	tags         map[string]interface{}
 	finishTime   time.Time
+	finished     bool
 
 	startTime time.Time
 	parentID  uint64
 	context   *spanContext
 	tracer    *mocktracer
-
-	finished bool
 }
 
 // SetTag sets a given tag on the span.

--- a/ddtrace/mocktracer/mockspan_test.go
+++ b/ddtrace/mocktracer/mockspan_test.go
@@ -183,11 +183,7 @@ func TestSpanFinishTwice(t *testing.T) {
 	s.Finish(tracer.WithError(want))
 
 	assert := assert.New(t)
-	assert.False(s.FinishTime().IsZero())
-	assert.True(s.FinishTime().Before(time.Now()))
-	assert.Equal(want, s.Tag(ext.Error))
 
-	// the finish must be idempotent
 	previousFinishTime := s.finishTime
 	time.Sleep(2 * time.Millisecond)
 	s.Finish(tracer.WithError(errors.New("new error")))

--- a/ddtrace/mocktracer/mockspan_test.go
+++ b/ddtrace/mocktracer/mockspan_test.go
@@ -179,16 +179,15 @@ func TestSpanFinish(t *testing.T) {
 
 func TestSpanFinishTwice(t *testing.T) {
 	s := basicSpan("http.request")
-	want := errors.New("some error")
-	s.Finish(tracer.WithError(want))
+	wantError := errors.New("some error")
+	s.Finish(tracer.WithError(wantError))
 
 	assert := assert.New(t)
-
-	previousFinishTime := s.finishTime
+	wantTime := s.finishTime
 	time.Sleep(2 * time.Millisecond)
 	s.Finish(tracer.WithError(errors.New("new error")))
-	assert.Equal(previousFinishTime, s.finishTime)
-	assert.Equal(want, s.Tag(ext.Error))
+	assert.Equal(wantTime, s.finishTime)
+	assert.Equal(wantError, s.Tag(ext.Error))
 	assert.Equal(len(s.tracer.finishedSpans), 1)
 }
 


### PR DESCRIPTION
Currently mockspan.Finish is not idempotent while span.Finish is. This prevents us from testing code which invokes Finish multiple times. Fix for #572 