### PR TITLE
ddtrace/tracer: remove syncPush and flushChan

### DIFF
--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -45,7 +45,7 @@ func TestSpanFromContext(t *testing.T) {
 }
 
 func TestStartSpanFromContext(t *testing.T) {
-	_, _, stop := startTestTracer()
+	_, _, _, stop := startTestTracer(t)
 	defer stop()
 
 	parent := &span{context: &spanContext{spanID: 123, traceID: 456}}

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -71,6 +71,10 @@ type config struct {
 	// samplingRules contains user-defined rules determine the sampling rate to apply
 	// to spans.
 	samplingRules []SamplingRule
+
+	// tickChan specifies a channel which will receive the time every time the tracer must flush.
+	// It defaults to time.Ticker; replaced in tests.
+	tickChan <-chan time.Time
 }
 
 // StartOption represents a function that can be provided as a parameter to Start.

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"testing"
+	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
@@ -19,6 +20,12 @@ import (
 func withTransport(t transport) StartOption {
 	return func(c *config) {
 		c.transport = t
+	}
+}
+
+func withTickChan(ch <-chan time.Time) StartOption {
+	return func(c *config) {
+		c.tickChan = ch
 	}
 }
 

--- a/ddtrace/tracer/payload.go
+++ b/ddtrace/tracer/payload.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
+	"sync/atomic"
 
 	"github.com/tinylib/msgp/msgp"
 )
@@ -64,14 +65,14 @@ func (p *payload) push(t spanList) error {
 	if err := msgp.Encode(&p.buf, t); err != nil {
 		return err
 	}
-	p.count++
+	atomic.AddUint64(&p.count, 1)
 	p.updateHeader()
 	return nil
 }
 
 // itemCount returns the number of items available in the srteam.
 func (p *payload) itemCount() int {
-	return int(p.count)
+	return int(atomic.LoadUint64(&p.count))
 }
 
 // size returns the payload size in bytes. After the first read the value becomes
@@ -83,7 +84,7 @@ func (p *payload) size() int {
 // reset resets the internal buffer, counter and read offset.
 func (p *payload) reset() {
 	p.off = 8
-	p.count = 0
+	atomic.StoreUint64(&p.count, 0)
 	p.buf.Reset()
 	select {
 	case <-p.closed:
@@ -102,7 +103,7 @@ const (
 // updateHeader updates the payload header based on the number of items currently
 // present in the stream.
 func (p *payload) updateHeader() {
-	n := p.count
+	n := atomic.LoadUint64(&p.count)
 	switch {
 	case n <= 15:
 		p.header[7] = msgpackArrayFix + byte(n)

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -80,7 +80,7 @@ func TestSpanFinishTwice(t *testing.T) {
 	assert := assert.New(t)
 	wait := time.Millisecond * 2
 
-	tracer, _, stop := startTestTracer()
+	tracer, _, _, stop := startTestTracer(t)
 	defer stop()
 
 	assert.Equal(tracer.payload.itemCount(), 0)
@@ -89,13 +89,13 @@ func TestSpanFinishTwice(t *testing.T) {
 	span := tracer.newRootSpan("pylons.request", "pylons", "/")
 	time.Sleep(wait)
 	span.Finish()
-	assert.Equal(tracer.payload.itemCount(), 1)
+	tracer.awaitPayload(t, 1)
 
 	previousDuration := span.Duration
 	time.Sleep(wait)
 	span.Finish()
 	assert.Equal(previousDuration, span.Duration)
-	assert.Equal(tracer.payload.itemCount(), 1)
+	tracer.awaitPayload(t, 1)
 }
 
 func TestSpanFinishWithTime(t *testing.T) {
@@ -345,7 +345,7 @@ func TestSpanErrorNil(t *testing.T) {
 
 // Prior to a bug fix, this failed when running `go test -race`
 func TestSpanModifyWhileFlushing(t *testing.T) {
-	tracer, _, stop := startTestTracer()
+	tracer, _, _, stop := startTestTracer(t)
 	defer stop()
 
 	done := make(chan struct{})
@@ -366,7 +366,7 @@ func TestSpanModifyWhileFlushing(t *testing.T) {
 		case <-done:
 			return
 		default:
-			tracer.flushChan <- struct{}{}
+			tracer.flush()
 			time.Sleep(10 * time.Millisecond)
 		}
 	}

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -31,7 +31,7 @@ func TestNewSpanContextPushError(t *testing.T) {
 	defer setupteardown(2, 2)()
 
 	tp := new(testLogger)
-	_, _, stop := startTestTracer(WithLogger(tp))
+	_, _, _, stop := startTestTracer(t, WithLogger(tp))
 	defer stop()
 	parent := newBasicSpan("test1")                  // 1st span in trace
 	parent.context.trace.push(newBasicSpan("test2")) // 2nd span in trace
@@ -48,7 +48,7 @@ func TestNewSpanContextPushError(t *testing.T) {
 func TestAsyncSpanRace(t *testing.T) {
 	// This tests a regression where asynchronously finishing spans would
 	// modify a flushing root's sampling priority.
-	_, _, stop := startTestTracer()
+	_, _, _, stop := startTestTracer(t)
 	defer stop()
 
 	for i := 0; i < 100; i++ {
@@ -100,7 +100,7 @@ func TestSpanTracePushOne(t *testing.T) {
 
 	assert := assert.New(t)
 
-	tracer, transport, stop := startTestTracer()
+	_, transport, flush, stop := startTestTracer(t)
 	defer stop()
 
 	traceID := random.Uint64()
@@ -111,7 +111,7 @@ func TestSpanTracePushOne(t *testing.T) {
 	assert.Equal(root, trace.spans[0], "the span is the one pushed before")
 
 	root.Finish()
-	tracer.flushAndWait(t, 1)
+	flush(1)
 
 	traces := transport.Traces()
 	assert.Len(traces, 1)
@@ -127,7 +127,7 @@ func TestSpanTracePushNoFinish(t *testing.T) {
 	assert := assert.New(t)
 
 	tp := new(testLogger)
-	_, _, stop := startTestTracer(WithLogger(tp))
+	_, _, _, stop := startTestTracer(t, WithLogger(tp))
 	defer stop()
 
 	buffer := newTrace()
@@ -153,7 +153,7 @@ func TestSpanTracePushSeveral(t *testing.T) {
 
 	assert := assert.New(t)
 
-	tracer, transport, stop := startTestTracer()
+	_, transport, flush, stop := startTestTracer(t)
 	defer stop()
 	buffer := newTrace()
 	assert.NotNil(buffer)
@@ -177,7 +177,7 @@ func TestSpanTracePushSeveral(t *testing.T) {
 	for _, span := range trace {
 		span.Finish()
 	}
-	tracer.flushAndWait(t, 1)
+	flush(1)
 
 	traces := transport.Traces()
 	assert.Len(traces, 1)
@@ -192,7 +192,7 @@ func TestSpanTracePushSeveral(t *testing.T) {
 // priority metric set by inheriting it from a child.
 func TestSpanFinishPriority(t *testing.T) {
 	assert := assert.New(t)
-	tracer, transport, stop := startTestTracer()
+	tracer, transport, flush, stop := startTestTracer(t)
 	defer stop()
 
 	root := tracer.StartSpan(
@@ -207,7 +207,7 @@ func TestSpanFinishPriority(t *testing.T) {
 	child.Finish()
 	root.Finish()
 
-	tracer.flushAndWait(t, 1)
+	flush(1)
 
 	traces := transport.Traces()
 	assert.Len(traces, 1)
@@ -274,7 +274,7 @@ func TestNewSpanContext(t *testing.T) {
 	})
 
 	t.Run("root", func(t *testing.T) {
-		_, _, stop := startTestTracer()
+		_, _, _, stop := startTestTracer(t)
 		defer stop()
 		assert := assert.New(t)
 		ctx, err := NewPropagator(nil).Extract(TextMapCarrier(map[string]string{
@@ -344,7 +344,7 @@ func TestSpanContextPushFull(t *testing.T) {
 	defer func(old int) { traceMaxSize = old }(traceMaxSize)
 	traceMaxSize = 2
 	tp := new(testLogger)
-	_, _, stop := startTestTracer(WithLogger(tp))
+	_, _, _, stop := startTestTracer(t, WithLogger(tp))
 	defer stop()
 
 	span1 := newBasicSpan("span1")


### PR DESCRIPTION
This change cleans up the code slightly by getting rid of `syncPush`
which was a hack to help synchronize test code and the unnecessary
`flushChan`.

The cost is slightly more complex test helper functions, which do make
sense and arguably simplify readability of test code.