### PR TITLE
contrib/google.golang.org/grpc: add WithIgnoredMethods

### DIFF
--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -456,7 +456,6 @@ type rig struct {
 func (r *rig) Close() {
 	r.server.Stop()
 	r.conn.Close()
-	r.listener.Close()
 }
 
 func newRig(traceClient bool, interceptorOpts ...Option) (*rig, error) {
@@ -589,5 +588,78 @@ func TestAnalyticsSettings(t *testing.T) {
 		globalconfig.SetAnalyticsRate(0.4)
 
 		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
+	})
+}
+
+func TestIgnoredMethods(t *testing.T) {
+	t.Run("unary", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+		for _, c := range []struct {
+			ignore []string
+			exp    int
+		}{
+			{ignore: []string{}, exp: 2},
+			{ignore: []string{"/some/endpoint"}, exp: 2},
+			{ignore: []string{"/grpc.Fixture/Ping"}, exp: 1},
+			{ignore: []string{"/grpc.Fixture/Ping", "/additional/endpoint"}, exp: 1},
+		} {
+			rig, err := newRig(true, WithIgnoredMethods(c.ignore...))
+			if err != nil {
+				t.Fatalf("error setting up rig: %s", err)
+			}
+			client := rig.client
+			resp, err := client.Ping(context.Background(), &FixtureRequest{Name: "pass"})
+			assert.Nil(t, err)
+			assert.Equal(t, resp.Message, "passed")
+
+			spans := mt.FinishedSpans()
+			assert.Len(t, spans, c.exp)
+			rig.Close()
+			mt.Reset()
+		}
+	})
+
+	t.Run("stream", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+		for _, c := range []struct {
+			ignore []string
+			exp    int
+		}{
+			// client span: 1 send + 1 recv(OK) + 1 stream finish (OK)
+			// server span: 1 send + 2 recv(OK + EOF) + 1 stream finish(EOF)
+			{ignore: []string{}, exp: 7},
+			{ignore: []string{"/some/endpoint"}, exp: 7},
+			{ignore: []string{"/grpc.Fixture/StreamPing"}, exp: 3},
+			{ignore: []string{"/grpc.Fixture/StreamPing", "/additional/endpoint"}, exp: 3},
+		} {
+			rig, err := newRig(true, WithIgnoredMethods(c.ignore...))
+			if err != nil {
+				t.Fatalf("error setting up rig: %s", err)
+			}
+
+			ctx, done := context.WithCancel(context.Background())
+			client := rig.client
+			stream, err := client.StreamPing(ctx)
+			assert.NoError(t, err)
+
+			err = stream.Send(&FixtureRequest{Name: "pass"})
+			assert.NoError(t, err)
+
+			resp, err := stream.Recv()
+			assert.NoError(t, err)
+			assert.Equal(t, resp.Message, "passed")
+
+			assert.NoError(t, stream.CloseSend())
+			done() // close stream from client side
+			rig.Close()
+
+			waitForSpans(mt, c.exp, 5*time.Second)
+
+			spans := mt.FinishedSpans()
+			assert.Len(t, spans, c.exp)
+			mt.Reset()
+		}
 	})
 }

--- a/contrib/google.golang.org/grpc/option.go
+++ b/contrib/google.golang.org/grpc/option.go
@@ -22,6 +22,7 @@ type config struct {
 	traceStreamCalls    bool
 	traceStreamMessages bool
 	noDebugStack        bool
+	ignoredMethods      map[string]struct{}
 }
 
 func (cfg *config) serverServiceName() string {
@@ -114,5 +115,17 @@ func WithAnalyticsRate(rate float64) Option {
 		} else {
 			cfg.analyticsRate = math.NaN()
 		}
+	}
+}
+
+// WithIgnoredMethods specifies full methods to be ignored by the server side interceptor.
+// When an incoming request's full method is in ms, no spans will be created.
+func WithIgnoredMethods(ms ...string) Option {
+	ims := make(map[string]struct{}, len(ms))
+	for _, e := range ms {
+		ims[e] = struct{}{}
+	}
+	return func(cfg *config) {
+		cfg.ignoredMethods = ims
 	}
 }


### PR DESCRIPTION
Fixes #576

In order to ignore health-checking-protocol requests from
server side interception, WithIgnoredMethods is added for specifying
full methods that users want to be ignored.
With this option, every request sent to server is checked if its full
method should be ignored. If so, no span will be created.