### PR TITLE
ddtrace/tracer: simplify the shutdown process.

### DIFF
--- a/ddtrace/tracer/metrics.go
+++ b/ddtrace/tracer/metrics.go
@@ -87,7 +87,7 @@ func (t *tracer) reportRuntimeMetrics(interval time.Duration) {
 				statsd.Gauge("runtime.go.gc_stats.pause_quantiles."+p, float64(gc.PauseQuantiles[i]), nil, 1)
 			}
 
-		case <-t.exitChan:
+		case <-t.stop:
 			return
 		}
 	}
@@ -102,7 +102,7 @@ func (t *tracer) reportHealthMetrics(interval time.Duration) {
 			t.config.statsd.Count("datadog.tracer.spans_started", atomic.SwapInt64(&t.spansStarted, 0), nil, 1)
 			t.config.statsd.Count("datadog.tracer.spans_finished", atomic.SwapInt64(&t.spansFinished, 0), nil, 1)
 			t.config.statsd.Count("datadog.tracer.traces_dropped", atomic.SwapInt64(&t.tracesDropped, 0), []string{"reason:trace_too_large"}, 1)
-		case <-t.exitChan:
+		case <-t.stop:
 			return
 		}
 	}

--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -253,7 +253,7 @@ func TestReportRuntimeMetrics(t *testing.T) {
 		trc.reportRuntimeMetrics(time.Millisecond)
 	}()
 	err := tg.Wait(35, 1*time.Second)
-	close(trc.exitChan)
+	close(trc.stop)
 	assert := assert.New(t)
 	assert.NoError(err)
 	calls := tg.CallNames()

--- a/ddtrace/tracer/sampler_test.go
+++ b/ddtrace/tracer/sampler_test.go
@@ -500,7 +500,7 @@ func BenchmarkRulesSampler(b *testing.B) {
 	benchmarkStartSpan := func(b *testing.B, t *tracer) {
 		internal.SetGlobalTracer(t)
 		defer func() {
-			close(t.stopped)
+			close(t.stop)
 			internal.SetGlobalTracer(&internal.NoopTracer{})
 		}()
 		t.prioritySampling.readRatesJSON(ioutil.NopCloser(strings.NewReader(

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -156,14 +156,14 @@ func TestTracerStart(t *testing.T) {
 		defer stop()
 		tr.pushTrace([]*span{}) // blocks until worker is started
 		select {
-		case <-tr.stopped:
+		case <-tr.stop:
 			t.Fatal("stopped channel should be open")
 		default:
 			// OK
 		}
 		tr.Stop()
 		select {
-		case <-tr.stopped:
+		case <-tr.stop:
 			// OK
 		default:
 			t.Fatal("stopped channel should be closed")


### PR DESCRIPTION
This removes the exitChan and stopping channels and replaces them with a single channel
that serves both purposes. This is a minor change that mildly simplifies the shutdown process.