### PR TITLE
ddtrace/tracer: log a warning when an unrecognized propagator is encountered.

### DIFF
--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -32,10 +32,6 @@ const (
 	// HTTPURL sets the HTTP URL for a span.
 	HTTPURL = "http.url"
 
-	// TODO: In the next major version, prefix these constants (SpanType, etc)
-	// with "Key*" (KeySpanType, etc) to more easily differentiate between
-	// constants representing tag values and constants representing keys.
-
 	// SpanName is a pseudo-key for setting a span's operation name by means of
 	// a tag. It is mostly here to facilitate vendor-agnostic frameworks like Opentracing
 	// and OpenCensus.

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -13,6 +13,7 @@ import (
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 )
 
 // HTTPHeadersCarrier wraps an http.Header as a TextMapWriter and TextMapReader, allowing
@@ -157,7 +158,7 @@ func getPropagators(cfg *PropagatorConfig, env string) []Propagator {
 		case "b3":
 			list = append(list, &propagatorB3{})
 		default:
-			// TODO(cgilmour): consider logging something for invalid/unknown styles.
+			log.Warn("unrecognized propagator: %s\n", v)
 		}
 	}
 	if len(list) == 0 {


### PR DESCRIPTION
Previously, unrecognized propagators would be silently ignored. This is a minor
change that causes a warning to be emitted.

Also,

ddtrace/ext: remove TODO from tags constant