### PR TITLE
ddtrace/tracer: performance improvements for sampling priority and span finish

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -255,24 +255,24 @@ func (s *span) setMetric(key string, v float64) {
 // Finish closes this Span (but not its children) providing the duration
 // of its part of the tracing session.
 func (s *span) Finish(opts ...ddtrace.FinishOption) {
-	var cfg ddtrace.FinishConfig
-	for _, fn := range opts {
-		fn(&cfg)
-	}
-	var t int64
-	if cfg.FinishTime.IsZero() {
-		t = now()
-	} else {
-		t = cfg.FinishTime.UnixNano()
-	}
-	if cfg.Error != nil {
-		s.Lock()
-		s.setTagError(cfg.Error, &errorConfig{
-			noDebugStack: cfg.NoDebugStack,
-			stackFrames:  cfg.StackFrames,
-			stackSkip:    cfg.SkipStackFrames,
-		})
-		s.Unlock()
+	t := now()
+	if len(opts) > 0 {
+		var cfg ddtrace.FinishConfig
+		for _, fn := range opts {
+			fn(&cfg)
+		}
+		if !cfg.FinishTime.IsZero() {
+			t = cfg.FinishTime.UnixNano()
+		}
+		if cfg.Error != nil {
+			s.Lock()
+			s.setTagError(cfg.Error, &errorConfig{
+				noDebugStack: cfg.NoDebugStack,
+				stackFrames:  cfg.StackFrames,
+				stackSkip:    cfg.SkipStackFrames,
+			})
+			s.Unlock()
+		}
 	}
 	if s.taskEnd != nil {
 		s.taskEnd()

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -93,15 +93,11 @@ func (c *spanContext) setSamplingPriority(p int) {
 	c.trace.setSamplingPriority(float64(p))
 }
 
-func (c *spanContext) samplingPriority() int {
+func (c *spanContext) samplingPriority() (int, bool) {
 	if c.trace == nil {
-		return 0
+		return 0, false
 	}
 	return c.trace.samplingPriority()
-}
-
-func (c *spanContext) hasSamplingPriority() bool {
-	return c.trace != nil && c.trace.hasSamplingPriority()
 }
 
 func (c *spanContext) setBaggageItem(key, val string) {
@@ -158,19 +154,13 @@ func newTrace() *trace {
 	return &trace{spans: make([]*span, 0, traceStartSize)}
 }
 
-func (t *trace) hasSamplingPriority() bool {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	return t.priority != nil
-}
-
-func (t *trace) samplingPriority() int {
+func (t *trace) samplingPriority() (int, bool) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	if t.priority == nil {
-		return 0
+		return 0, false
 	}
-	return int(*t.priority)
+	return int(*t.priority), true
 }
 
 func (t *trace) setSamplingPriority(p float64) {

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -93,7 +93,7 @@ func (c *spanContext) setSamplingPriority(p int) {
 	c.trace.setSamplingPriority(float64(p))
 }
 
-func (c *spanContext) samplingPriority() (int, bool) {
+func (c *spanContext) samplingPriority() (p int, ok bool) {
 	if c.trace == nil {
 		return 0, false
 	}
@@ -154,7 +154,7 @@ func newTrace() *trace {
 	return &trace{spans: make([]*span, 0, traceStartSize)}
 }
 
-func (t *trace) samplingPriority() (int, bool) {
+func (t *trace) samplingPriority() (p int, ok bool) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	if t.priority == nil {

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -140,7 +140,7 @@ var (
 	// by default we allocate for a handful of spans within the trace,
 	// reasonable as span is actually way bigger, and avoids re-allocating
 	// over and over. Could be fine-tuned at runtime.
-	traceStartSize = uint32(10)
+	traceStartSize = 10
 	// traceMaxSize is the maximum number of spans we keep in memory.
 	// This is to avoid memory leaks, if above that value, spans are randomly
 	// dropped and ignore, resulting in corrupted tracing data, but ensuring
@@ -151,7 +151,7 @@ var (
 // newTrace creates a new trace using the given callback which will be called
 // upon completion of the trace.
 func newTrace() *trace {
-	return &trace{spans: make([]*span, 0, atomic.LoadUint32(&traceStartSize))}
+	return &trace{spans: make([]*span, 0, traceStartSize)}
 }
 
 func (t *trace) samplingPriority() (p int, ok bool) {
@@ -236,12 +236,6 @@ func (t *trace) finishedOne(s *span) {
 	if len(t.spans) != t.finished {
 		return
 	}
-
-	// Adjust the starting trace size to avoid allocations.
-	if uint32(len(t.spans)) > atomic.LoadUint32(&traceStartSize) {
-		atomic.StoreUint32(&traceStartSize, uint32(len(t.spans)))
-	}
-
 	if tr, ok := internal.GetGlobalTracer().(*tracer); ok {
 		// we have a tracer that can receive completed traces.
 		tr.pushTrace(t.spans)

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -19,7 +19,7 @@ import (
 func setupteardown(start, max int) func() {
 	oldStartSize := traceStartSize
 	oldMaxSize := traceMaxSize
-	traceStartSize = start
+	traceStartSize = uint32(start)
 	traceMaxSize = max
 	return func() {
 		traceStartSize = oldStartSize

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -19,7 +19,7 @@ import (
 func setupteardown(start, max int) func() {
 	oldStartSize := traceStartSize
 	oldMaxSize := traceMaxSize
-	traceStartSize = uint32(start)
+	traceStartSize = start
 	traceMaxSize = max
 	return func() {
 		traceStartSize = oldStartSize

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -220,8 +220,8 @@ func (p *propagator) injectTextMap(spanCtx ddtrace.SpanContext, writer TextMapWr
 	// propagate the TraceID and the current active SpanID
 	writer.Set(p.cfg.TraceHeader, strconv.FormatUint(ctx.traceID, 10))
 	writer.Set(p.cfg.ParentHeader, strconv.FormatUint(ctx.spanID, 10))
-	if ctx.hasSamplingPriority() {
-		writer.Set(p.cfg.PriorityHeader, strconv.Itoa(ctx.samplingPriority()))
+	if sp, ok := ctx.samplingPriority(); ok {
+		writer.Set(p.cfg.PriorityHeader, strconv.Itoa(sp))
 	}
 	if ctx.origin != "" {
 		writer.Set(originHeader, ctx.origin)
@@ -308,8 +308,8 @@ func (*propagatorB3) injectTextMap(spanCtx ddtrace.SpanContext, writer TextMapWr
 	}
 	writer.Set(b3TraceIDHeader, strconv.FormatUint(ctx.traceID, 16))
 	writer.Set(b3SpanIDHeader, strconv.FormatUint(ctx.spanID, 16))
-	if ctx.hasSamplingPriority() {
-		if ctx.samplingPriority() >= ext.PriorityAutoKeep {
+	if p, ok := ctx.samplingPriority(); ok {
+		if p >= ext.PriorityAutoKeep {
 			writer.Set(b3SampledHeader, "1")
 		} else {
 			writer.Set(b3SampledHeader, "0")

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -262,8 +262,9 @@ func TestB3(t *testing.T) {
 
 		assert.Equal(sctx.traceID, uint64(1))
 		assert.Equal(sctx.spanID, uint64(1))
-		assert.True(sctx.hasSamplingPriority())
-		assert.Equal(sctx.samplingPriority(), 1)
+		p, ok := sctx.samplingPriority()
+		assert.True(ok)
+		assert.Equal(1, p)
 
 		ddHeaders := TextMapCarrier(map[string]string{
 			DefaultTraceIDHeader:  "2",
@@ -278,7 +279,8 @@ func TestB3(t *testing.T) {
 
 		assert.Equal(sctx.traceID, uint64(2))
 		assert.Equal(sctx.spanID, uint64(2))
-		assert.True(sctx.hasSamplingPriority())
-		assert.Equal(sctx.samplingPriority(), 2)
+		p, ok = sctx.samplingPriority()
+		assert.True(ok)
+		assert.Equal(2, p)
 	})
 }

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -288,8 +288,8 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		// this is a child span
 		span.TraceID = context.traceID
 		span.ParentID = context.spanID
-		if context.hasSamplingPriority() {
-			span.setMetric(keySamplingPriority, float64(context.samplingPriority()))
+		if p, ok := context.samplingPriority(); ok {
+			span.setMetric(keySamplingPriority, float64(p))
 		}
 		if context.span != nil {
 			// local parent, inherit service
@@ -399,7 +399,7 @@ const sampleRateMetricKey = "_sample_rate"
 
 // Sample samples a span with the internal sampler.
 func (t *tracer) sample(span *span) {
-	if span.context.hasSamplingPriority() {
+	if _, ok := span.context.samplingPriority(); ok {
 		// sampling decision was already made
 		return
 	}

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -496,8 +496,9 @@ func TestTracerPrioritySampler(t *testing.T) {
 	s := tr.newEnvSpan("pylons", "")
 	assert.Equal(1., s.Metrics[keySamplingPriorityRate])
 	assert.Equal(1., s.Metrics[keySamplingPriority])
-	assert.True(s.context.hasSamplingPriority())
-	assert.EqualValues(s.context.samplingPriority(), s.Metrics[keySamplingPriority])
+	p, ok := s.context.samplingPriority()
+	assert.True(ok)
+	assert.EqualValues(p, s.Metrics[keySamplingPriority])
 	s.Finish()
 
 	tr.awaitPayload(t, 1)
@@ -532,8 +533,9 @@ func TestTracerPrioritySampler(t *testing.T) {
 		prio, ok := s.Metrics[keySamplingPriority]
 		assert.True(ok)
 		assert.Contains([]float64{0, 1}, prio)
-		assert.True(s.context.hasSamplingPriority())
-		assert.EqualValues(s.context.samplingPriority(), prio)
+		p, ok := s.context.samplingPriority()
+		assert.True(ok)
+		assert.EqualValues(p, prio)
 
 		// injectable
 		h := make(http.Header)


### PR DESCRIPTION
hasSamplingPriority and samplingPriority are often called together, one after another,
and both acquire locks. Combining them into a single call reduces contention and
overhead.

span's Finish method is often called with no options, but it still allocates a config
object. This patch avoids allocating the config object if there are no opts passed to
Finish.

This PR also causes finishedOne to increase `traceStartSize` when a finished trace is larger than the start size. This should decrease allocations happening while adding spans to a trace.