### PR TITLE
.circleci/config.yml vendor gnostic for k8s.io/client-go

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,7 @@ jobs:
         # This step checks out k8s.io/client-go and vendors 
         # github.com/googleapis/gnostic to fix a breaking change made in
         # gnostic. See kubernetes/client-go#741
+        # TODO(knusbaum): remove this once the breaking change is resolved or propagated
         command: |
           git clone https://github.com/kubernetes/client-go $GOPATH/src/k8s.io/client-go
           git clone --branch v0.4.0 https://github.com/googleapis/gnostic $GOPATH/src/k8s.io/client-go/vendor/github.com/googleapis/gnostic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
         name: Vendor github.com/googleapis/gnostic for k8s.io/client-go
         # This step checks out k8s.io/client-go and vendors 
         # github.com/googleapis/gnostic to fix a breaking change made in
-        # gnostic. See kubernetes/client-go#731
+        # gnostic. See kubernetes/client-go#741
         command: |
           git clone https://github.com/kubernetes/client-go $GOPATH/src/k8s.io/client-go
           git clone --branch v0.4.0 https://github.com/googleapis/gnostic $GOPATH/src/k8s.io/client-go/vendor/github.com/googleapis/gnostic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,15 @@ jobs:
           contrib/go-redis/redis/vendor/github.com/go-redis/redis
 
     - run:
+        name: Vendor github.com/googleapis/gnostic for k8s.io/client-go
+        # This step checks out k8s.io/client-go and vendors 
+        # github.com/googleapis/gnostic to fix a breaking change made in
+        # gnostic. See kubernetes/client-go#731
+        command: |
+          git clone https://github.com/kubernetes/client-go $GOPATH/src/k8s.io/client-go
+          git clone --branch v0.4.0 https://github.com/googleapis/gnostic $GOPATH/src/k8s.io/client-go/vendor/github.com/googleapis/gnostic
+
+    - run:
         name: Fetching dependencies
         command: |
           go get -v -t ./...


### PR DESCRIPTION
`k8s.io/client-go` has `github.com/googleapis/gnostic` as a dependency.
Recently, gnostic renamed some packages to be consistent with go style (https://github.com/googleapis/gnostic/pull/155) 
This change breaks `client-go`, which will no longer build when clients are checked out with e.g. `go get k8s.io/client-go/kubernetes`.

`k8s.io/client-go` has not made it clear when/if they will fix their imports. They are closing issues opened against the repository with instructions on how to use go modules to circumvent the problem (https://github.com/kubernetes/client-go/issues/741, https://github.com/kubernetes/client-go/issues/743)

`go get gopkg.in/DataDog/dd-trace-go.v1/...` still works as expected. Unit tests still run, and I am still able to build against dd-trace-go. I have not tried building a program using the `contrib/k8s.io/client-go/kubernetes` integration.

This break in `k8s.io/client-go` is causing our CI to fail. This PR addresses the issue by checking out `k8s.io/client-go` manually and vendoring the last working version of `gnostic` in `k8s.io/client-go/vendor`.
