### PR TITLE
 contrib/graph-gophers/graphql-go: exposing operation name in the tracer

### DIFF
--- a/contrib/graph-gophers/graphql-go/graphql.go
+++ b/contrib/graph-gophers/graphql-go/graphql.go
@@ -25,10 +25,10 @@ import (
 )
 
 const (
-	tagGraphqlField     = "graphql.field"
-	tagGraphqlQuery     = "graphql.query"
-	tagGraphqlType      = "graphql.type"
-	tagGraphqlOperation = "graphql.operation"
+	tagGraphqlField         = "graphql.field"
+	tagGraphqlQuery         = "graphql.query"
+	tagGraphqlType          = "graphql.type"
+	tagGraphqlOperationName = "graphql.operation.name"
 )
 
 // A Tracer implements the graphql-go/trace.Tracer interface by sending traces
@@ -44,7 +44,7 @@ func (t *Tracer) TraceQuery(ctx context.Context, queryString string, operationNa
 	opts := []ddtrace.StartSpanOption{
 		tracer.ServiceName(t.cfg.serviceName),
 		tracer.Tag(tagGraphqlQuery, queryString),
-		tracer.Tag(tagGraphqlOperation, operationName),
+		tracer.Tag(tagGraphqlOperationName, operationName),
 	}
 	if !math.IsNaN(t.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, t.cfg.analyticsRate))

--- a/contrib/graph-gophers/graphql-go/graphql.go
+++ b/contrib/graph-gophers/graphql-go/graphql.go
@@ -25,9 +25,10 @@ import (
 )
 
 const (
-	tagGraphqlField = "graphql.field"
-	tagGraphqlQuery = "graphql.query"
-	tagGraphqlType  = "graphql.type"
+	tagGraphqlField     = "graphql.field"
+	tagGraphqlQuery     = "graphql.query"
+	tagGraphqlType      = "graphql.type"
+	tagGraphqlOperation = "graphql.operation"
 )
 
 // A Tracer implements the graphql-go/trace.Tracer interface by sending traces
@@ -43,6 +44,7 @@ func (t *Tracer) TraceQuery(ctx context.Context, queryString string, operationNa
 	opts := []ddtrace.StartSpanOption{
 		tracer.ServiceName(t.cfg.serviceName),
 		tracer.Tag(tagGraphqlQuery, queryString),
+		tracer.Tag(tagGraphqlOperation, operationName),
 	}
 	if !math.IsNaN(t.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, t.cfg.analyticsRate))

--- a/contrib/graph-gophers/graphql-go/graphql_test.go
+++ b/contrib/graph-gophers/graphql-go/graphql_test.go
@@ -41,7 +41,8 @@ func Test(t *testing.T) {
 	defer mt.Stop()
 
 	http.Post(srv.URL, "application/json", strings.NewReader(`{
-		"query": "{ hello }"
+		"query": "query TestQuery() { hello }",
+		"operationName": "TestQuery"
 	}`))
 
 	spans := mt.FinishedSpans()
@@ -60,7 +61,8 @@ func Test(t *testing.T) {
 
 	{
 		s := spans[1]
-		assert.Equal(t, "{ hello }", s.Tag(tagGraphqlQuery))
+		assert.Equal(t, "query TestQuery() { hello }", s.Tag(tagGraphqlQuery))
+		assert.Equal(t, "TestQuery", s.Tag(tagGraphqlOperation))
 		assert.Nil(t, s.Tag(ext.Error))
 		assert.Equal(t, "test-graphql-service", s.Tag(ext.ServiceName))
 		assert.Equal(t, "graphql.request", s.OperationName())

--- a/contrib/graph-gophers/graphql-go/graphql_test.go
+++ b/contrib/graph-gophers/graphql-go/graphql_test.go
@@ -62,7 +62,7 @@ func Test(t *testing.T) {
 	{
 		s := spans[1]
 		assert.Equal(t, "query TestQuery() { hello }", s.Tag(tagGraphqlQuery))
-		assert.Equal(t, "TestQuery", s.Tag(tagGraphqlOperation))
+		assert.Equal(t, "TestQuery", s.Tag(tagGraphqlOperationName))
 		assert.Nil(t, s.Tag(ext.Error))
 		assert.Equal(t, "test-graphql-service", s.Tag(ext.ServiceName))
 		assert.Equal(t, "graphql.request", s.OperationName())


### PR DESCRIPTION
Fixes #590