### PR TITLE
contrib/gin-gonic/gin: correct resource name

### DIFF
--- a/contrib/gin-gonic/gin/gintrace_test.go
+++ b/contrib/gin-gonic/gin/gintrace_test.go
@@ -76,7 +76,7 @@ func TestTrace200(t *testing.T) {
 	assert.Equal("http.request", span.OperationName())
 	assert.Equal(ext.SpanTypeWeb, span.Tag(ext.SpanType))
 	assert.Equal("foobar", span.Tag(ext.ServiceName))
-	assert.Contains(span.Tag(ext.ResourceName), "gin.TestTrace200")
+	assert.Contains(span.Tag(ext.ResourceName), "GET /user/:id")
 	assert.Equal("200", span.Tag(ext.HTTPCode))
 	assert.Equal("GET", span.Tag(ext.HTTPMethod))
 	// TODO(x) would be much nicer to have "/user/:id" here
@@ -311,7 +311,7 @@ func TestResourceNamerSettings(t *testing.T) {
 		router.GET("/test", func(c *gin.Context) {
 			span, ok := tracer.SpanFromContext(c.Request.Context())
 			assert.True(ok)
-			assert.Equal(span.(mocktracer.Span).Tag(ext.ResourceName), c.HandlerName())
+			assert.Equal(span.(mocktracer.Span).Tag(ext.ResourceName), "GET /test")
 		})
 
 		r := httptest.NewRequest("GET", "/test", nil)

--- a/contrib/gin-gonic/gin/option.go
+++ b/contrib/gin-gonic/gin/option.go
@@ -59,5 +59,5 @@ func WithResourceNamer(namer func(c *gin.Context) string) Option {
 }
 
 func defaultResourceNamer(c *gin.Context) string {
-	return c.HandlerName()
+	return c.Request.Method + " " + c.FullPath()
 }


### PR DESCRIPTION
We didn't actually need to revert #574. That was my mistake. At any rate, this will put the v1 branch back where we want it.

There was a mistake with setting the resource name for this integration.
We previously had used `(*gin.Context).HandlerName` to set the resource
which was wrong and returns the name of the function (e.g.
`main.main.func1`).

This change ensures that the resource name is set correctly, as in all
our HTTP integrations to method and path (e.g. "GET /path")