### PR TITLE
internal/version: bump version to 1.22.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,4 +8,4 @@ package version
 // Tag specifies the current release tag. It needs to be manually
 // updated. A test checks that the value of Tag never points to a
 // git tag that is older than HEAD.
-const Tag = "v1.21.0"
+const Tag = "v1.22.0"


### PR DESCRIPTION
We've started merging changes for v1.22.0 into the v1 branch, so we should go ahead and bump the version string.