### PR TITLE
ddtrace/tracer: add measured span option

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -288,10 +288,9 @@ func SpanType(name string) StartSpanOption {
 	return Tag(ext.SpanType, name)
 }
 
-// MeasureSpan adds the measured key to a span, thereby making it eligible for
-// APM metrics/stats calculation.
+// MeasureSpan marks this span to be measured for metrics and stats calculations.
 func MeasureSpan() StartSpanOption {
-	return Tag(keyMeasured, "1")
+	return Tag(keyMeasured, 1)
 }
 
 // WithSpanID sets the SpanID on the started span, instead of using a random number.

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -294,8 +294,8 @@ func SpanType(name string) StartSpanOption {
 	return Tag(ext.SpanType, name)
 }
 
-// MeasureSpan marks this span to be measured for metrics and stats calculations.
-func MeasureSpan() StartSpanOption {
+// Measured marks this span to be measured for metrics and stats calculations.
+func Measured() StartSpanOption {
 	return Tag(keyMeasured, 1)
 }
 

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -288,6 +288,12 @@ func SpanType(name string) StartSpanOption {
 	return Tag(ext.SpanType, name)
 }
 
+// MeasureSpan adds the measured key to a span, thereby making it eligible for
+// APM metrics/stats calculation.
+func MeasureSpan() StartSpanOption {
+	return Tag(keyMeasured, "1")
+}
+
 // WithSpanID sets the SpanID on the started span, instead of using a random number.
 // If there is no parent Span (eg from ChildOf), then the TraceID will also be set to the
 // value given here.

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -344,4 +344,5 @@ const (
 	keyHostname                = "_dd.hostname"
 	keyRulesSamplerAppliedRate = "_dd.rule_psr"
 	keyRulesSamplerLimiterRate = "_dd.limit_psr"
+	keyMeasured             = "_dd.measured"
 )

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -344,5 +344,5 @@ const (
 	keyHostname                = "_dd.hostname"
 	keyRulesSamplerAppliedRate = "_dd.rule_psr"
 	keyRulesSamplerLimiterRate = "_dd.limit_psr"
-	keyMeasured             = "_dd.measured"
+	keyMeasured                = "_dd.measured"
 )

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -204,10 +204,10 @@ func TestTracerStartSpan(t *testing.T) {
 		assert.Equal(t, "/home/user", span.Resource)
 	})
 
-	t.Run("measured span", func(t *testing.T) {
+	t.Run("measured", func(t *testing.T) {
 		tracer := newTracer()
 		span := tracer.StartSpan("/home/user", MeasureSpan()).(*span)
-		assert.Equal(t, "1", span.Meta[keyMeasured])
+		assert.Equal(t, float64(1), span.Metrics[keyMeasured])
 	})
 }
 
@@ -261,7 +261,7 @@ func TestTracerStartSpanOptions(t *testing.T) {
 	assert.Equal(now.UnixNano(), span.Start)
 	assert.Equal(uint64(420), span.SpanID)
 	assert.Equal(uint64(420), span.TraceID)
-	assert.Equal("1", span.Meta[keyMeasured])
+	assert.Equal(float64(1), span.Metrics[keyMeasured])
 }
 
 func TestTracerStartChildSpan(t *testing.T) {
@@ -339,12 +339,12 @@ func TestMeasuredSpan(t *testing.T) {
 
 	tracer := newTracer(WithServiceName("my-service"))
 	root := tracer.StartSpan("web.request", ResourceName("/resource"), MeasureSpan()).(*span)
-	assert.Equal(root.Meta[keyMeasured], "1")
+	assert.Equal(float64(1), root.Metrics[keyMeasured])
 	child := tracer.StartSpan("custom_operation", ChildOf(root.Context()), MeasureSpan()).(*span)
-	assert.Equal(child.Meta[keyMeasured], "1")
+	assert.Equal(float64(1), child.Metrics[keyMeasured])
 	// child2 will not inherit the measured flag
 	child2 := tracer.StartSpan("nested_custom_operation", ChildOf(root.Context())).(*span)
-	assert.NotEqual(child2.Meta[keyMeasured], "1")
+	assert.NotEqual(float64(1), child2.Metrics[keyMeasured])
 }
 
 func TestPropagationDefaults(t *testing.T) {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -207,7 +207,7 @@ func TestTracerStartSpan(t *testing.T) {
 
 	t.Run("measured", func(t *testing.T) {
 		tracer := newTracer()
-		span := tracer.StartSpan("/home/user", MeasureSpan()).(*span)
+		span := tracer.StartSpan("/home/user", Measured()).(*span)
 		assert.Equal(t, float64(1), span.Metrics[keyMeasured])
 	})
 }
@@ -252,7 +252,7 @@ func TestTracerStartSpanOptions(t *testing.T) {
 		ResourceName("test.resource"),
 		StartTime(now),
 		WithSpanID(420),
-		MeasureSpan(),
+		Measured(),
 	}
 	span := tracer.StartSpan("web.request", opts...).(*span)
 	assert := assert.New(t)

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -208,7 +208,7 @@ func TestTracerStartSpan(t *testing.T) {
 	t.Run("measured", func(t *testing.T) {
 		tracer := newTracer()
 		span := tracer.StartSpan("/home/user", Measured()).(*span)
-		assert.Equal(t, float64(1), span.Metrics[keyMeasured])
+		assert.Equal(t, 1.0, span.Metrics[keyMeasured])
 	})
 }
 
@@ -262,7 +262,7 @@ func TestTracerStartSpanOptions(t *testing.T) {
 	assert.Equal(now.UnixNano(), span.Start)
 	assert.Equal(uint64(420), span.SpanID)
 	assert.Equal(uint64(420), span.TraceID)
-	assert.Equal(float64(1), span.Metrics[keyMeasured])
+	assert.Equal(1.0, span.Metrics[keyMeasured])
 }
 
 func TestTracerStartChildSpan(t *testing.T) {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -188,7 +188,8 @@ func TestTracerStartSpan(t *testing.T) {
 			ext.PriorityAutoKeep,
 		}, span.Metrics[keySamplingPriority])
 		// A span is not measured unless made so specifically
-		assert.NotEqual(span.Meta[keyMeasured], "1")
+		_, ok := span.Meta[keyMeasured]
+		assert.False(ok)
 	})
 
 	t.Run("priority", func(t *testing.T) {
@@ -330,21 +331,6 @@ func TestStartSpanOrigin(t *testing.T) {
 	err = tracer.Inject(child2.Context(), carrier2)
 	assert.Nil(err)
 	assert.Equal("synthetics", carrier2[originHeader])
-}
-
-func TestMeasuredSpan(t *testing.T) {
-	// Create three spans for a single trace.
-	// The first two are measured but the third one is not.
-	assert := assert.New(t)
-
-	tracer := newTracer(WithServiceName("my-service"))
-	root := tracer.StartSpan("web.request", ResourceName("/resource"), MeasureSpan()).(*span)
-	assert.Equal(float64(1), root.Metrics[keyMeasured])
-	child := tracer.StartSpan("custom_operation", ChildOf(root.Context()), MeasureSpan()).(*span)
-	assert.Equal(float64(1), child.Metrics[keyMeasured])
-	// child2 will not inherit the measured flag
-	child2 := tracer.StartSpan("nested_custom_operation", ChildOf(root.Context())).(*span)
-	assert.NotEqual(float64(1), child2.Metrics[keyMeasured])
 }
 
 func TestPropagationDefaults(t *testing.T) {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -187,6 +187,8 @@ func TestTracerStartSpan(t *testing.T) {
 			ext.PriorityAutoReject,
 			ext.PriorityAutoKeep,
 		}, span.Metrics[keySamplingPriority])
+		// A span is not measured unless made so specifically
+		assert.NotEqual(span.Meta[keyMeasured], "1")
 	})
 
 	t.Run("priority", func(t *testing.T) {
@@ -200,6 +202,12 @@ func TestTracerStartSpan(t *testing.T) {
 		span := tracer.StartSpan("/home/user", Tag(ext.SpanName, "db.query")).(*span)
 		assert.Equal(t, "db.query", span.Name)
 		assert.Equal(t, "/home/user", span.Resource)
+	})
+
+	t.Run("measured span", func(t *testing.T) {
+		tracer := newTracer()
+		span := tracer.StartSpan("/home/user", MeasureSpan()).(*span)
+		assert.Equal(t, "1", span.Meta[keyMeasured])
 	})
 }
 
@@ -243,6 +251,7 @@ func TestTracerStartSpanOptions(t *testing.T) {
 		ResourceName("test.resource"),
 		StartTime(now),
 		WithSpanID(420),
+		MeasureSpan(),
 	}
 	span := tracer.StartSpan("web.request", opts...).(*span)
 	assert := assert.New(t)
@@ -252,6 +261,7 @@ func TestTracerStartSpanOptions(t *testing.T) {
 	assert.Equal(now.UnixNano(), span.Start)
 	assert.Equal(uint64(420), span.SpanID)
 	assert.Equal(uint64(420), span.TraceID)
+	assert.Equal("1", span.Meta[keyMeasured])
 }
 
 func TestTracerStartChildSpan(t *testing.T) {
@@ -320,6 +330,21 @@ func TestStartSpanOrigin(t *testing.T) {
 	err = tracer.Inject(child2.Context(), carrier2)
 	assert.Nil(err)
 	assert.Equal("synthetics", carrier2[originHeader])
+}
+
+func TestMeasuredSpan(t *testing.T) {
+	// Create three spans for a single trace.
+	// The first two are measured but the third one is not.
+	assert := assert.New(t)
+
+	tracer := newTracer(WithServiceName("my-service"))
+	root := tracer.StartSpan("web.request", ResourceName("/resource"), MeasureSpan()).(*span)
+	assert.Equal(root.Meta[keyMeasured], "1")
+	child := tracer.StartSpan("custom_operation", ChildOf(root.Context()), MeasureSpan()).(*span)
+	assert.Equal(child.Meta[keyMeasured], "1")
+	// child2 will not inherit the measured flag
+	child2 := tracer.StartSpan("nested_custom_operation", ChildOf(root.Context())).(*span)
+	assert.NotEqual(child2.Meta[keyMeasured], "1")
 }
 
 func TestPropagationDefaults(t *testing.T) {


### PR DESCRIPTION
This PR adds to the `StartSpanOption` API by adding a measured flag that can be set when creating a new span.

The unit tests cover:
- If a span is not marked as measured, it shouldn't have the flag.
- If the span is started with the `MeasureSpan` option, then the span should have the flag.
- A child span of a measured span should not inherit the measured flag.