### PR TITLE
.circleci: checkout github.com/kubernetes/client-go v0.17.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
         # gnostic. See kubernetes/client-go#741
         # TODO(knusbaum): remove this once the breaking change is resolved or propagated
         command: |
-          git clone https://github.com/kubernetes/client-go $GOPATH/src/k8s.io/client-go
+          git clone --branch v0.17.3 https://github.com/kubernetes/client-go $GOPATH/src/k8s.io/client-go
           git clone --branch v0.4.0 https://github.com/googleapis/gnostic $GOPATH/src/k8s.io/client-go/vendor/github.com/googleapis/gnostic
 
     - run:


### PR DESCRIPTION
client-go recently merged an API-breaking change on master, and so instead we
check out the latest working release of kubernetes/client-go. This is a stop-gap
solution for the dependency management issue that should be addressed
with modules as we move towards v2 (#471)