### PR TITLE
profiler: add profiler package

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -159,8 +159,14 @@ func WithPropagator(p Propagator) StartOption {
 	}
 }
 
-// WithServiceName sets the default service name to be used with the tracer.
+// WithServiceName sets the default service name to be used with the tracer. It is
+// deprecated in favour of WithService and will be removed in the next major version.
 func WithServiceName(name string) StartOption {
+	return WithService(name)
+}
+
+// WithService sets the default service name to be used with the tracer.
+func WithService(name string) StartOption {
 	return func(c *config) {
 		c.serviceName = name
 	}

--- a/profiler/doc.go
+++ b/profiler/doc.go
@@ -6,4 +6,4 @@
 // Package profiler periodically collects and sends profiles to the Datadog API. Use
 // Start to start the profiler. An API key needs to be specified by means of the WithAPIKey
 // option.
-package profiler
+package profiler // import "gopkg.in/DataDog/dd-trace-go.v1/profiler"

--- a/profiler/doc.go
+++ b/profiler/doc.go
@@ -1,0 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// Package profiler periodically collects and sends profiles to the Datadog API. Use
+// Start to start the profiler. An API key needs to be specified by means of an option
+// or the environment variable DD_API_KEY.
+package profiler

--- a/profiler/doc.go
+++ b/profiler/doc.go
@@ -4,6 +4,6 @@
 // Copyright 2016-2020 Datadog, Inc.
 
 // Package profiler periodically collects and sends profiles to the Datadog API. Use
-// Start to start the profiler. An API key needs to be specified by means of an option
-// or the environment variable DD_API_KEY.
+// Start to start the profiler. An API key needs to be specified by means of the WithAPIKey
+// option.
 package profiler

--- a/profiler/example_test.go
+++ b/profiler/example_test.go
@@ -15,7 +15,9 @@ import (
 func Example() {
 	err := profiler.Start(
 		profiler.WithAPIKey("123key"),
+		profiler.WithService("users-db"),
 		profiler.WithEnv("staging"),
+		profiler.WithTags("version:1.2.0"),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/profiler/example_test.go
+++ b/profiler/example_test.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package profiler_test
+
+import (
+	"log"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/profiler"
+)
+
+// This example illustrates how to run (and later stop) the Datadog Profiler.
+func Example() {
+	err := profiler.Start(
+		profiler.WithAPIKey("123key"),
+		profiler.WithEnv("staging"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer profiler.Stop()
+
+	// ...
+}

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -7,7 +7,6 @@ package profiler
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -43,7 +42,6 @@ type config struct {
 	service, env  string
 	hostname      string
 	statsd        StatsdClient
-	log           *log.Logger
 	tags          []string
 	types         map[ProfileType]struct{}
 	period        time.Duration
@@ -65,7 +63,6 @@ func defaultConfig() *config {
 		env:           defaultEnv,
 		service:       filepath.Base(os.Args[0]),
 		statsd:        noopStatsdClient{},
-		log:           log.New(os.Stderr, "Datadog Profiler: ", log.LstdFlags),
 		period:        DefaultPeriod,
 		cpuDuration:   DefaultDuration,
 		blockRate:     DefaultBlockRate,
@@ -176,12 +173,5 @@ func WithTags(tags ...string) Option {
 func WithStatsd(client StatsdClient) Option {
 	return func(cfg *config) {
 		cfg.statsd = client
-	}
-}
-
-// WithLogger specifies a custom logger for logging errors.
-func WithLogger(logger *log.Logger) Option {
-	return func(cfg *config) {
-		cfg.log = logger
 	}
 }

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/DataDog/datadog-go/statsd"
 )
 
 const (
@@ -61,7 +63,7 @@ func defaultConfig() *config {
 		apiURL:        defaultAPIURL,
 		env:           defaultEnv,
 		service:       filepath.Base(os.Args[0]),
-		statsd:        noopStatsdClient{},
+		statsd:        &statsd.NoOpClient{},
 		period:        DefaultPeriod,
 		cpuDuration:   DefaultDuration,
 		blockRate:     DefaultBlockRate,

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -122,8 +122,8 @@ func WithProfileTypes(types ...ProfileType) Option {
 	}
 }
 
-// WithServiceName specifies the service name to attach a profile.
-func WithServiceName(name string) Option {
+// WithService specifies the service name to attach a profile.
+func WithService(name string) Option {
 	return func(cfg *config) {
 		cfg.service = name
 	}

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -95,13 +95,6 @@ func WithURL(url string) Option {
 	}
 }
 
-// WithHostname allows specifying a custom hostname.
-func WithHostname(hostname string) Option {
-	return func(cfg *config) {
-		cfg.hostname = hostname
-	}
-}
-
 // WithPeriod specifies the interval at which to collect profiles.
 func WithPeriod(d time.Duration) Option {
 	return func(cfg *config) {

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 )
 
@@ -72,26 +71,8 @@ func defaultConfig() *config {
 	for _, t := range defaultProfileTypes {
 		c.addProfileType(t)
 	}
-	if v := os.Getenv("DD_API_KEY"); v != "" {
-		c.apiKey = v
-	}
-	if v := os.Getenv("DD_HOSTNAME"); v != "" {
-		c.hostname = v
-	}
-	if v := os.Getenv("DD_ENV"); v != "" {
-		c.env = v
-	}
-	if v := os.Getenv("DD_SERVICE_NAME"); v != "" {
-		c.service = v
-	}
-	if v := os.Getenv("DD_PROFILE_URL"); v != "" {
-		c.apiURL = v
-	}
-	if v := os.Getenv("DD_PROFILE_TAGS"); v != "" {
-		for _, tag := range strings.Split(v, ",") {
-			c.tags = append(c.tags, tag)
-		}
-	}
+	// TODO(x): add support for environment variables once we figure out
+	// the naming standards.
 	return &c
 }
 

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -1,0 +1,187 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package profiler
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultMutexFraction specifies the mutex profile fraction to be used with the mutex profiler.
+	// For more information or for changing this value, check runtime.SetMutexProfileFraction.
+	DefaultMutexFraction = 10
+
+	// DefaultBlockRate specifies the default block profiling rate used by the block profiler.
+	// For more information or for changing this value, check runtime.SetBlockProfileRate.
+	DefaultBlockRate = 100
+
+	// DefaultPeriod specifies the default period at which profiles will be collected.
+	DefaultPeriod = time.Minute
+
+	// DefaultDuration specifies the default length of the CPU profile snapshot.
+	DefaultDuration = time.Second * 15
+)
+
+const (
+	defaultAPIURL = "https://beta-intake.profile.datadoghq.com/v1/input"
+	defaultEnv    = "none"
+)
+
+var defaultProfileTypes = []ProfileType{CPUProfile, HeapProfile}
+
+type config struct {
+	apiKey        string
+	apiURL        string
+	service, env  string
+	hostname      string
+	statsd        StatsdClient
+	log           *log.Logger
+	tags          []string
+	types         map[ProfileType]struct{}
+	period        time.Duration
+	cpuDuration   time.Duration
+	mutexFraction int
+	blockRate     int
+}
+
+func (c *config) addProfileType(t ProfileType) {
+	if c.types == nil {
+		c.types = make(map[ProfileType]struct{})
+	}
+	c.types[t] = struct{}{}
+}
+
+func defaultConfig() *config {
+	c := config{
+		apiURL:        defaultAPIURL,
+		env:           defaultEnv,
+		service:       filepath.Base(os.Args[0]),
+		statsd:        noopStatsdClient{},
+		log:           log.New(os.Stderr, "Datadog Profiler: ", log.LstdFlags),
+		period:        DefaultPeriod,
+		cpuDuration:   DefaultDuration,
+		blockRate:     DefaultBlockRate,
+		mutexFraction: DefaultMutexFraction,
+		tags:          []string{fmt.Sprintf("pid:%d", os.Getpid())},
+	}
+	for _, t := range defaultProfileTypes {
+		c.addProfileType(t)
+	}
+	if v := os.Getenv("DD_API_KEY"); v != "" {
+		c.apiKey = v
+	}
+	if v := os.Getenv("DD_HOSTNAME"); v != "" {
+		c.hostname = v
+	}
+	if v := os.Getenv("DD_ENV"); v != "" {
+		c.env = v
+	}
+	if v := os.Getenv("DD_SERVICE_NAME"); v != "" {
+		c.service = v
+	}
+	if v := os.Getenv("DD_PROFILE_URL"); v != "" {
+		c.apiURL = v
+	}
+	if v := os.Getenv("DD_PROFILE_TAGS"); v != "" {
+		for _, tag := range strings.Split(v, ",") {
+			c.tags = append(c.tags, tag)
+		}
+	}
+	return &c
+}
+
+// An Option is used to configure the profiler's behaviour.
+type Option func(*config)
+
+// WithAPIKey specifies the API key to use when connecting to the Datadog API.
+func WithAPIKey(key string) Option {
+	return func(cfg *config) {
+		cfg.apiKey = key
+	}
+}
+
+// WithURL specifies the HTTP URL for the Datadog Profiling API.
+func WithURL(url string) Option {
+	return func(cfg *config) {
+		cfg.apiURL = url
+	}
+}
+
+// WithHostname allows specifying a custom hostname.
+func WithHostname(hostname string) Option {
+	return func(cfg *config) {
+		cfg.hostname = hostname
+	}
+}
+
+// WithPeriod specifies the interval at which to collect profiles.
+func WithPeriod(d time.Duration) Option {
+	return func(cfg *config) {
+		cfg.period = d
+	}
+}
+
+// CPUDuration specifies the length at which to collect CPU profiles.
+func CPUDuration(d time.Duration) Option {
+	return func(cfg *config) {
+		cfg.cpuDuration = d
+	}
+}
+
+// WithProfileTypes specifies the profile types to be collected by the profiler.
+func WithProfileTypes(types ...ProfileType) Option {
+	return func(cfg *config) {
+		// reset the types and only use what the user has specified
+		for k := range cfg.types {
+			delete(cfg.types, k)
+		}
+		for _, t := range types {
+			cfg.addProfileType(t)
+		}
+	}
+}
+
+// WithServiceName specifies the service name to attach a profile.
+func WithServiceName(name string) Option {
+	return func(cfg *config) {
+		cfg.service = name
+	}
+}
+
+// WithEnv specifies the environment to which these profiles should be registered.
+func WithEnv(env string) Option {
+	return func(cfg *config) {
+		cfg.env = env
+	}
+}
+
+// WithTags specifies a set of tags to be attached to the profiler. These may help
+// filter the profiling view based on various information.
+func WithTags(tags ...string) Option {
+	return func(cfg *config) {
+		cfg.tags = append(cfg.tags, tags...)
+	}
+}
+
+// WithStatsd specifies an optional statsd client to use for metrics. By default,
+// no metrics are sent.
+func WithStatsd(client StatsdClient) Option {
+	return func(cfg *config) {
+		cfg.statsd = client
+	}
+}
+
+// WithLogger specifies a custom logger for logging errors.
+func WithLogger(logger *log.Logger) Option {
+	return func(cfg *config) {
+		cfg.log = logger
+	}
+}

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -1,0 +1,157 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package profiler
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptions(t *testing.T) {
+	t.Run("WithAPIKey", func(t *testing.T) {
+		var cfg config
+		WithAPIKey("123")(&cfg)
+		assert.Equal(t, "123", cfg.apiKey)
+	})
+
+	t.Run("WithURL", func(t *testing.T) {
+		var cfg config
+		WithURL("my-url")(&cfg)
+		assert.Equal(t, "my-url", cfg.apiURL)
+	})
+
+	t.Run("WithHostname", func(t *testing.T) {
+		var cfg config
+		WithHostname("my-hostname")(&cfg)
+		assert.Equal(t, "my-hostname", cfg.hostname)
+	})
+
+	t.Run("WithPeriod", func(t *testing.T) {
+		var cfg config
+		WithPeriod(2 * time.Second)(&cfg)
+		assert.Equal(t, 2*time.Second, cfg.period)
+	})
+
+	t.Run("CPUDuration", func(t *testing.T) {
+		var cfg config
+		CPUDuration(3 * time.Second)(&cfg)
+		assert.Equal(t, 3*time.Second, cfg.cpuDuration)
+	})
+
+	t.Run("WithProfileTypes", func(t *testing.T) {
+		var cfg config
+		WithProfileTypes(HeapProfile)(&cfg)
+		_, ok := cfg.types[HeapProfile]
+		assert.True(t, ok)
+		assert.Len(t, cfg.types, 1)
+	})
+}
+
+func TestDefaultConfig(t *testing.T) {
+	t.Run("base", func(t *testing.T) {
+		cfg := defaultConfig()
+		assert := assert.New(t)
+		assert.Equal(defaultAPIURL, cfg.apiURL)
+		if v := os.Getenv("DD_ENV"); v != "" {
+			assert.Equal(v, cfg.env)
+		} else {
+			assert.Equal(defaultEnv, cfg.env)
+		}
+		assert.Equal(filepath.Base(os.Args[0]), cfg.service)
+		assert.Equal(len(defaultProfileTypes), len(cfg.types))
+		for _, pt := range defaultProfileTypes {
+			_, ok := cfg.types[pt]
+			assert.True(ok)
+		}
+		_, ok := cfg.statsd.(noopStatsdClient)
+		assert.True(ok)
+		assert.Equal(DefaultPeriod, cfg.period)
+		assert.Equal(DefaultDuration, cfg.cpuDuration)
+		assert.Equal(DefaultMutexFraction, cfg.mutexFraction)
+		assert.Equal(DefaultBlockRate, cfg.blockRate)
+	})
+
+	t.Run("env", func(t *testing.T) {
+		env, val := "DD_API_KEY", "123"
+		t.Run(env, func(t *testing.T) {
+			os.Setenv(env, val)
+			cfg := defaultConfig()
+			assert.Equal(t, val, cfg.apiKey)
+			os.Unsetenv(env)
+		})
+
+		env, val = "DD_HOSTNAME", "my-hostname"
+		t.Run(env, func(t *testing.T) {
+			os.Setenv(env, val)
+			cfg := defaultConfig()
+			assert.Equal(t, val, cfg.hostname)
+			os.Unsetenv(env)
+		})
+
+		env, val = "DD_ENV", "my-env"
+		t.Run(env, func(t *testing.T) {
+			os.Setenv(env, val)
+			cfg := defaultConfig()
+			assert.Equal(t, val, cfg.env)
+			os.Unsetenv(env)
+		})
+
+		env, val = "DD_SERVICE_NAME", "my-service"
+		t.Run(env, func(t *testing.T) {
+			os.Setenv(env, val)
+			cfg := defaultConfig()
+			assert.Equal(t, val, cfg.service)
+			os.Unsetenv(env)
+		})
+
+		env, val = "DD_PROFILE_URL", "http://my.url"
+		t.Run(env, func(t *testing.T) {
+			os.Setenv(env, val)
+			cfg := defaultConfig()
+			assert.Equal(t, val, cfg.apiURL)
+			os.Unsetenv(env)
+		})
+
+		env, val = "DD_PROFILE_TAGS", "a:b,c:d"
+		t.Run(env, func(t *testing.T) {
+			os.Setenv(env, val)
+			cfg := defaultConfig()
+			assert.ElementsMatch(t, []string{
+				"a:b",
+				"c:d",
+				fmt.Sprintf("pid:%d", os.Getpid()),
+			}, cfg.tags)
+			os.Unsetenv(env)
+		})
+	})
+}
+
+func TestAddProfileType(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		cfg := defaultConfig()
+		_, ok := cfg.types[MutexProfile]
+		assert.False(t, ok)
+		n := len(cfg.types)
+		cfg.addProfileType(MutexProfile)
+		assert.Len(t, cfg.types, n+1)
+		_, ok = cfg.types[MutexProfile]
+		assert.True(t, ok)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		var cfg config
+		assert.Nil(t, cfg.types)
+		cfg.addProfileType(MutexProfile)
+		assert.Len(t, cfg.types, 1)
+		_, ok := cfg.types[MutexProfile]
+		assert.True(t, ok)
+	})
+}

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-go/statsd"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -66,7 +67,7 @@ func TestDefaultConfig(t *testing.T) {
 			_, ok := cfg.types[pt]
 			assert.True(ok)
 		}
-		_, ok := cfg.statsd.(noopStatsdClient)
+		_, ok := cfg.statsd.(*statsd.NoOpClient)
 		assert.True(ok)
 		assert.Equal(DefaultPeriod, cfg.period)
 		assert.Equal(DefaultDuration, cfg.cpuDuration)

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -6,7 +6,6 @@
 package profiler
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -60,11 +59,7 @@ func TestDefaultConfig(t *testing.T) {
 		cfg := defaultConfig()
 		assert := assert.New(t)
 		assert.Equal(defaultAPIURL, cfg.apiURL)
-		if v := os.Getenv("DD_ENV"); v != "" {
-			assert.Equal(v, cfg.env)
-		} else {
-			assert.Equal(defaultEnv, cfg.env)
-		}
+		assert.Equal(defaultEnv, cfg.env)
 		assert.Equal(filepath.Base(os.Args[0]), cfg.service)
 		assert.Equal(len(defaultProfileTypes), len(cfg.types))
 		for _, pt := range defaultProfileTypes {
@@ -77,60 +72,6 @@ func TestDefaultConfig(t *testing.T) {
 		assert.Equal(DefaultDuration, cfg.cpuDuration)
 		assert.Equal(DefaultMutexFraction, cfg.mutexFraction)
 		assert.Equal(DefaultBlockRate, cfg.blockRate)
-	})
-
-	t.Run("env", func(t *testing.T) {
-		env, val := "DD_API_KEY", "123"
-		t.Run(env, func(t *testing.T) {
-			os.Setenv(env, val)
-			cfg := defaultConfig()
-			assert.Equal(t, val, cfg.apiKey)
-			os.Unsetenv(env)
-		})
-
-		env, val = "DD_HOSTNAME", "my-hostname"
-		t.Run(env, func(t *testing.T) {
-			os.Setenv(env, val)
-			cfg := defaultConfig()
-			assert.Equal(t, val, cfg.hostname)
-			os.Unsetenv(env)
-		})
-
-		env, val = "DD_ENV", "my-env"
-		t.Run(env, func(t *testing.T) {
-			os.Setenv(env, val)
-			cfg := defaultConfig()
-			assert.Equal(t, val, cfg.env)
-			os.Unsetenv(env)
-		})
-
-		env, val = "DD_SERVICE_NAME", "my-service"
-		t.Run(env, func(t *testing.T) {
-			os.Setenv(env, val)
-			cfg := defaultConfig()
-			assert.Equal(t, val, cfg.service)
-			os.Unsetenv(env)
-		})
-
-		env, val = "DD_PROFILE_URL", "http://my.url"
-		t.Run(env, func(t *testing.T) {
-			os.Setenv(env, val)
-			cfg := defaultConfig()
-			assert.Equal(t, val, cfg.apiURL)
-			os.Unsetenv(env)
-		})
-
-		env, val = "DD_PROFILE_TAGS", "a:b,c:d"
-		t.Run(env, func(t *testing.T) {
-			os.Setenv(env, val)
-			cfg := defaultConfig()
-			assert.ElementsMatch(t, []string{
-				"a:b",
-				"c:d",
-				fmt.Sprintf("pid:%d", os.Getpid()),
-			}, cfg.tags)
-			os.Unsetenv(env)
-		})
 	})
 }
 

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -28,12 +28,6 @@ func TestOptions(t *testing.T) {
 		assert.Equal(t, "my-url", cfg.apiURL)
 	})
 
-	t.Run("WithHostname", func(t *testing.T) {
-		var cfg config
-		WithHostname("my-hostname")(&cfg)
-		assert.Equal(t, "my-hostname", cfg.hostname)
-	})
-
 	t.Run("WithPeriod", func(t *testing.T) {
 		var cfg config
 		WithPeriod(2 * time.Second)(&cfg)

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -1,0 +1,168 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package profiler
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"runtime/pprof"
+	"time"
+)
+
+// ProfileType represents a type of profile that the profiler is able to run.
+type ProfileType int
+
+const (
+	// HeapProfile reports memory allocation samples; used to monitor current
+	// and historical memory usage, and to check for memory leaks.
+	HeapProfile ProfileType = iota
+	// CPUProfile determines where a program spends its time while actively consuming
+	// CPU cycles (as opposed to while sleeping or waiting for I/O).
+	CPUProfile
+	// BlockProfile shows where goroutines block waiting on synchronization primitives
+	// (including timer channels). Block profile is not enabled by default.
+	BlockProfile
+	// MutexProfile reports the lock contentions. When you think your CPU is not fully utilized due
+	// to a mutex contention, use this profile. Mutex profile is not enabled by default.
+	MutexProfile
+)
+
+func (t ProfileType) String() string {
+	switch t {
+	case HeapProfile:
+		return "heap"
+	case CPUProfile:
+		return "cpu"
+	case MutexProfile:
+		return "mutex"
+	case BlockProfile:
+		return "block"
+	default:
+		return "unknown"
+	}
+}
+
+// profile specifies a pprof's data (gzipped protobuf), and the types contained
+// within it.
+type profile struct {
+	types []string
+	data  []byte
+}
+
+// batch is a collection of profiles of different types, collected at roughly the same time. It maps
+// to what the Datadog UI calls a profile.
+type batch struct {
+	start, end time.Time
+	host       string
+	profiles   []*profile
+}
+
+func (b *batch) addProfile(p *profile) {
+	b.profiles = append(b.profiles, p)
+}
+
+func (p *profiler) runProfile(t ProfileType) (*profile, error) {
+	switch t {
+	case HeapProfile:
+		return heapProfile(p.cfg)
+	case CPUProfile:
+		return cpuProfile(p.cfg)
+	case MutexProfile:
+		return mutexProfile(p.cfg)
+	case BlockProfile:
+		return blockProfile(p.cfg)
+	default:
+		return nil, errors.New("profile type not implemented")
+	}
+}
+
+// writeHeapProfile writes the heap profile; replaced in tests
+var writeHeapProfile = pprof.WriteHeapProfile
+
+func heapProfile(cfg *config) (*profile, error) {
+	var buf bytes.Buffer
+	start := now()
+	if err := writeHeapProfile(&buf); err != nil {
+		return nil, err
+	}
+	end := now()
+	tags := append(cfg.tags, "profile_type:heap")
+	cfg.statsd.Timing("datadog.profiler.go.collect_time", end.Sub(start), tags, 1)
+	return &profile{
+		types: []string{"alloc_objects", "alloc_space", "inuse_objects", "inuse_space"},
+		data:  buf.Bytes(),
+	}, nil
+}
+
+var (
+	// startCPUProfile starts the CPU profile; replaced in tests
+	startCPUProfile = pprof.StartCPUProfile
+	// stopCPUProfile stops the CPU profile; replaced in tests
+	stopCPUProfile = pprof.StopCPUProfile
+)
+
+func cpuProfile(cfg *config) (*profile, error) {
+	var buf bytes.Buffer
+	start := now()
+	if err := startCPUProfile(&buf); err != nil {
+		return nil, err
+	}
+	time.Sleep(cfg.cpuDuration)
+	stopCPUProfile()
+	end := now()
+	tags := append(cfg.tags, "profile_type:cpu")
+	cfg.statsd.Timing("datadog.profiler.go.collect_time", end.Sub(start), tags, 1)
+	return &profile{
+		types: []string{"samples", "cpu"},
+		data:  buf.Bytes(),
+	}, nil
+}
+
+// lookpupProfile looks up the profile with the given name and writes it to w. It returns
+// any errors encountered in the process. It is replaced in tests.
+var lookupProfile = func(name string, w io.Writer) error {
+	prof := pprof.Lookup(name)
+	if prof == nil {
+		return errors.New("profile not found")
+	}
+	return prof.WriteTo(w, 0)
+}
+
+func blockProfile(cfg *config) (*profile, error) {
+	var buf bytes.Buffer
+	start := now()
+	if err := lookupProfile("block", &buf); err != nil {
+		return nil, err
+	}
+	end := now()
+	tags := append(cfg.tags, "profile_type:block")
+	cfg.statsd.Timing("datadog.profiler.go.collect_time", end.Sub(start), tags, 1)
+	return &profile{
+		types: []string{"delay"},
+		data:  buf.Bytes(),
+	}, nil
+}
+
+func mutexProfile(cfg *config) (*profile, error) {
+	var buf bytes.Buffer
+	start := now()
+	if err := lookupProfile("mutex", &buf); err != nil {
+		return nil, err
+	}
+	end := now()
+	tags := append(cfg.tags, "profile_type:mutex")
+	cfg.statsd.Timing("datadog.profiler.go.collect_time", end.Sub(start), tags, 1)
+	return &profile{
+		types: []string{"contentions"},
+		data:  buf.Bytes(),
+	}, nil
+}
+
+// now returns current time in UTC.
+func now() time.Time {
+	return time.Now().UTC()
+}

--- a/profiler/profile_test.go
+++ b/profiler/profile_test.go
@@ -1,0 +1,85 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package profiler
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunProfile(t *testing.T) {
+	t.Run("heap", func(t *testing.T) {
+		defer func(old func(_ io.Writer) error) { writeHeapProfile = old }(writeHeapProfile)
+		writeHeapProfile = func(w io.Writer) error {
+			_, err := w.Write([]byte("my-heap-profile"))
+			return err
+		}
+		p := unstartedProfiler()
+		prof, err := p.runProfile(HeapProfile)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{
+			"alloc_objects", "alloc_space", "inuse_objects", "inuse_space",
+		}, prof.types)
+		assert.Equal(t, []byte("my-heap-profile"), prof.data)
+	})
+
+	t.Run("cpu", func(t *testing.T) {
+		defer func(old func(_ io.Writer) error) { startCPUProfile = old }(startCPUProfile)
+		startCPUProfile = func(w io.Writer) error {
+			_, err := w.Write([]byte("my-cpu-profile"))
+			return err
+		}
+		defer func(old func()) { stopCPUProfile = old }(stopCPUProfile)
+		stopCPUProfile = func() {}
+
+		p := unstartedProfiler(CPUDuration(10 * time.Millisecond))
+		start := time.Now()
+		prof, err := p.runProfile(CPUProfile)
+		end := time.Now()
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{
+			"samples", "cpu",
+		}, prof.types)
+		assert.True(t, end.Sub(start) > 10*time.Millisecond)
+		assert.Equal(t, []byte("my-cpu-profile"), prof.data)
+	})
+
+	t.Run("mutex", func(t *testing.T) {
+		defer func(old func(_ string, _ io.Writer) error) { lookupProfile = old }(lookupProfile)
+		lookupProfile = func(name string, w io.Writer) error {
+			_, err := w.Write([]byte(name))
+			return err
+		}
+
+		p := unstartedProfiler()
+		prof, err := p.runProfile(MutexProfile)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{
+			"contentions",
+		}, prof.types)
+		assert.Equal(t, []byte("mutex"), prof.data)
+	})
+
+	t.Run("block", func(t *testing.T) {
+		defer func(old func(_ string, _ io.Writer) error) { lookupProfile = old }(lookupProfile)
+		lookupProfile = func(name string, w io.Writer) error {
+			_, err := w.Write([]byte(name))
+			return err
+		}
+
+		p := unstartedProfiler()
+		prof, err := p.runProfile(BlockProfile)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{
+			"delay",
+		}, prof.types)
+		assert.Equal(t, []byte("block"), prof.data)
+	})
+}

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -181,11 +181,3 @@ type StatsdClient interface {
 	// Timing creates a distribution of the values registered as the duration of a certain event.
 	Timing(event string, duration time.Duration, tags []string, rate float64) error
 }
-
-// noopStatsdClient is a no-op implementation of StatsdClient.
-type noopStatsdClient struct{}
-
-func (noopStatsdClient) Count(name string, value int64, tags []string, rate float64) error { return nil }
-func (noopStatsdClient) Timing(name string, value time.Duration, tags []string, rate float64) error {
-	return nil
-}

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -1,0 +1,192 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package profiler
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"sync"
+	"time"
+)
+
+// outChannelSize specifies the size of the profile output channel.
+const outChannelSize = 5
+
+var (
+	mu             sync.Mutex
+	activeProfiler *profiler
+)
+
+// ErrMissingAPIKey is returned when an API key was not found by the profiler.
+var ErrMissingAPIKey = errors.New("API key is missing; provide it using the profiler.WithAPIKey option or the DD_API_KEY environment variable")
+
+// Start starts the profiler. It may return an error if an API key is not provided by means of an
+// option or the DD_API_KEY environment variable, or if a hostname is not found. In the latter case,
+// it may be provided using the WithHostname option.
+func Start(opts ...Option) error {
+	cfg := defaultConfig()
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	if cfg.apiKey == "" {
+		return ErrMissingAPIKey
+	}
+	if cfg.hostname == "" {
+		hostname, err := os.Hostname()
+		if err != nil {
+			return fmt.Errorf("could not obtain hostname: %v; try specifying it using profiler.WithHostname", err)
+		}
+		cfg.hostname = hostname
+	}
+	mu.Lock()
+	if activeProfiler != nil {
+		activeProfiler.stop()
+	}
+	activeProfiler = newProfiler(cfg)
+	activeProfiler.run()
+	mu.Unlock()
+	return nil
+}
+
+// Stop stops the profiler.
+func Stop() {
+	mu.Lock()
+	if activeProfiler != nil {
+		activeProfiler.stop()
+		activeProfiler = nil
+	}
+	mu.Unlock()
+}
+
+// profiler collects and sends preset profiles to the Datadog API at a given frequency
+// using a given configuration.
+type profiler struct {
+	cfg        *config           // profile configuration
+	out        chan batch        // upload queue
+	uploadFunc func(batch) error // defaults to (*profiler).upload; replaced in tests
+	exit       chan struct{}     // exit signals the profiler to stop; it is closed after stopping
+}
+
+// newProfiler creates a new, unstarted profiler.
+func newProfiler(cfg *config) *profiler {
+	p := profiler{
+		cfg:  cfg,
+		out:  make(chan batch, outChannelSize),
+		exit: make(chan struct{}),
+	}
+	p.uploadFunc = p.upload
+	return &p
+}
+
+// run runs the profiler.
+func (p *profiler) run() {
+	if _, ok := p.cfg.types[MutexProfile]; ok {
+		runtime.SetMutexProfileFraction(p.cfg.mutexFraction)
+	}
+	if _, ok := p.cfg.types[BlockProfile]; ok {
+		runtime.SetBlockProfileRate(p.cfg.blockRate)
+	}
+	go func() {
+		tick := time.NewTicker(p.cfg.period)
+		defer tick.Stop()
+		p.collect(tick.C)
+	}()
+	go p.send()
+}
+
+// collect runs the profile types found in the configuration whenever the ticker receives
+// an item.
+func (p *profiler) collect(ticker <-chan time.Time) {
+	defer close(p.out)
+	for {
+		select {
+		case <-ticker:
+			now := time.Now().UTC()
+			bat := batch{
+				host:  p.cfg.hostname,
+				start: now,
+				end:   now.Add(p.cfg.cpuDuration), // abstraction violation
+			}
+			for t := range p.cfg.types {
+				prof, err := p.runProfile(t)
+				if err != nil {
+					p.log("Error getting %s profile: %v; skipping.\n", t, err)
+					p.cfg.statsd.Count("datadog.profiler.go.collect_error", 1, append(p.cfg.tags, fmt.Sprintf("profile_type:%v", t)), 1)
+					continue
+				}
+				bat.addProfile(prof)
+			}
+			p.enqueueUpload(bat)
+		case <-p.exit:
+			return
+		}
+	}
+}
+
+// log logs the given message using the configured logger.
+func (p *profiler) log(fmt string, v ...interface{}) { p.cfg.log.Printf(fmt, v...) }
+
+// enqueueUpload pushes a batch of profiles onto the queue to be uploaded. If there is no room, it will
+// evict the oldest profile to make some. Typically a batch would be one of each enabled profile.
+func (p *profiler) enqueueUpload(bat batch) {
+	for {
+		select {
+		case p.out <- bat:
+			return // 👍
+		default:
+			// queue is full; evict oldest
+			select {
+			case <-p.out:
+				p.cfg.statsd.Count("datadog.profiler.go.queue_full", 1, p.cfg.tags, 1)
+				p.log("Evicting one profile batch from the upload queue to make room.\n")
+			default:
+				// queue is empty; contents likely got uploaded
+			}
+		}
+	}
+}
+
+// send takes profiles from the output queue and uploads them.
+func (p *profiler) send() {
+	defer close(p.exit)
+	for bat := range p.out {
+		if err := p.uploadFunc(bat); err != nil {
+			p.log("Failed to upload profile: %v\n", err)
+		}
+	}
+}
+
+// stop stops the profiler.
+func (p *profiler) stop() {
+	select {
+	case <-p.exit:
+		// already stopped
+		return
+	default:
+		// running
+	}
+	p.exit <- struct{}{}
+	<-p.exit
+}
+
+// StatsdClient implementations can count and time certain event occurrences that happen
+// in the profiler.
+type StatsdClient interface {
+	// Count counts how many times an event happened, at the given rate using the given tags.
+	Count(event string, times int64, tags []string, rate float64) error
+	// Timing creates a distribution of the values registered as the duration of a certain event.
+	Timing(event string, duration time.Duration, tags []string, rate float64) error
+}
+
+// noopStatsdClient is a no-op implementation of StatsdClient.
+type noopStatsdClient struct{}
+
+func (noopStatsdClient) Count(name string, value int64, tags []string, rate float64) error { return nil }
+func (noopStatsdClient) Timing(name string, value time.Duration, tags []string, rate float64) error {
+	return nil
+}

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -25,11 +25,11 @@ var (
 )
 
 // ErrMissingAPIKey is returned when an API key was not found by the profiler.
-var ErrMissingAPIKey = errors.New("API key is missing; provide it using the profiler.WithAPIKey option or the DD_API_KEY environment variable")
+var ErrMissingAPIKey = errors.New("API key is missing; provide it using the profiler.WithAPIKey option")
 
-// Start starts the profiler. It may return an error if an API key is not provided by means of an
-// option or the DD_API_KEY environment variable, or if a hostname is not found. In the latter case,
-// it may be provided using the WithHostname option.
+// Start starts the profiler. It may return an error if an API key is not provided by means of
+// the WithAPIKey option, or if a hostname is not found. In the latter case, it may be provided
+// using the WithHostname option.
 func Start(opts ...Option) error {
 	cfg := defaultConfig()
 	for _, opt := range opts {

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -28,8 +28,7 @@ var (
 var ErrMissingAPIKey = errors.New("API key is missing; provide it using the profiler.WithAPIKey option")
 
 // Start starts the profiler. It may return an error if an API key is not provided by means of
-// the WithAPIKey option, or if a hostname is not found. In the latter case, it may be provided
-// using the WithHostname option.
+// the WithAPIKey option, or if a hostname is not found.
 func Start(opts ...Option) error {
 	cfg := defaultConfig()
 	for _, opt := range opts {

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -47,14 +47,14 @@ func TestStart(t *testing.T) {
 	})
 
 	t.Run("options", func(t *testing.T) {
-		if err := Start(WithAPIKey("123"), WithHostname("my-host")); err != nil {
+		if err := Start(WithAPIKey("123")); err != nil {
 			t.Fatal(err)
 		}
 		defer Stop()
 
 		mu.Lock()
 		require.NotNil(t, activeProfiler)
-		assert.Equal(t, "my-host", activeProfiler.cfg.hostname)
+		assert.NotEmpty(t, activeProfiler.cfg.hostname)
 		mu.Unlock()
 	})
 }

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -1,0 +1,235 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package profiler
+
+import (
+	"io"
+	"os"
+	"runtime"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStart(t *testing.T) {
+	t.Run("api-key", func(t *testing.T) {
+		require.Equal(t, ErrMissingAPIKey, Start())
+	})
+
+	t.Run("defaults", func(t *testing.T) {
+		if err := Start(WithAPIKey("123")); err != nil {
+			t.Fatal(err)
+		}
+		defer Stop()
+
+		mu.Lock()
+		require.NotNil(t, activeProfiler)
+		if host, err := os.Hostname(); err != nil {
+			assert.Equal(t, host, activeProfiler.cfg.hostname)
+		}
+		assert.Equal(t, defaultAPIURL, activeProfiler.cfg.apiURL)
+		assert.Equal(t, DefaultPeriod, activeProfiler.cfg.period)
+		assert.Equal(t, len(defaultProfileTypes), len(activeProfiler.cfg.types))
+		for _, pt := range defaultProfileTypes {
+			_, ok := activeProfiler.cfg.types[pt]
+			assert.True(t, ok)
+		}
+		assert.Equal(t, DefaultDuration, activeProfiler.cfg.cpuDuration)
+		mu.Unlock()
+	})
+
+	t.Run("options", func(t *testing.T) {
+		if err := Start(WithAPIKey("123"), WithHostname("my-host")); err != nil {
+			t.Fatal(err)
+		}
+		defer Stop()
+
+		mu.Lock()
+		require.NotNil(t, activeProfiler)
+		assert.Equal(t, "my-host", activeProfiler.cfg.hostname)
+		mu.Unlock()
+	})
+}
+
+func TestStartStopIdempotency(t *testing.T) {
+	t.Run("linear", func(t *testing.T) {
+		Start(WithAPIKey("123"))
+		Start(WithAPIKey("123"))
+		Start(WithAPIKey("123"))
+		Start(WithAPIKey("123"))
+		Start(WithAPIKey("123"))
+		Start(WithAPIKey("123"))
+
+		Stop()
+		Stop()
+		Stop()
+		Stop()
+		Stop()
+	})
+
+	t.Run("parallel", func(t *testing.T) {
+		var wg sync.WaitGroup
+
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 1000; j++ {
+					Start(WithAPIKey("123"))
+				}
+			}()
+		}
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 1000; j++ {
+					Stop()
+				}
+			}()
+		}
+		wg.Wait()
+	})
+
+	t.Run("stop", func(t *testing.T) {
+		Start(WithAPIKey("123"), WithPeriod(time.Minute))
+		defer Stop()
+
+		mu.Lock()
+		require.NotNil(t, activeProfiler)
+		activeProfiler.stop()
+		activeProfiler.stop()
+		activeProfiler.stop()
+		activeProfiler.stop()
+		mu.Unlock()
+	})
+}
+
+func TestProfilerInternal(t *testing.T) {
+	t.Run("collect", func(t *testing.T) {
+		p := unstartedProfiler(
+			CPUDuration(1*time.Millisecond),
+			WithProfileTypes(HeapProfile, CPUProfile),
+		)
+		var startCPU, stopCPU, writeHeap uint64
+		defer func(old func(_ io.Writer) error) { startCPUProfile = old }(startCPUProfile)
+		startCPUProfile = func(_ io.Writer) error {
+			atomic.AddUint64(&startCPU, 1)
+			return nil
+		}
+		defer func(old func()) { stopCPUProfile = old }(stopCPUProfile)
+		stopCPUProfile = func() { atomic.AddUint64(&stopCPU, 1) }
+		defer func(old func(_ io.Writer) error) { writeHeapProfile = old }(writeHeapProfile)
+		writeHeapProfile = func(_ io.Writer) error {
+			atomic.AddUint64(&writeHeap, 1)
+			return nil
+		}
+		tick := make(chan time.Time)
+		wait := make(chan struct{})
+
+		go func() {
+			p.collect(tick)
+			close(wait)
+		}()
+
+		tick <- time.Now()
+
+		var bat batch
+		select {
+		case bat = <-p.out:
+		case <-time.After(200 * time.Millisecond):
+			t.Fatalf("missing batch")
+		}
+
+		assert.EqualValues(t, 1, writeHeap)
+		assert.EqualValues(t, 1, startCPU)
+		assert.EqualValues(t, 1, stopCPU)
+
+		assert.Equal(t, 2, len(bat.profiles))
+		firstTypes := []string{
+			bat.profiles[0].types[0],
+			bat.profiles[1].types[0],
+		}
+		sort.Strings(firstTypes)
+		assert.Equal(t, "alloc_objects", firstTypes[0])
+		assert.Equal(t, "samples", firstTypes[1])
+
+		p.exit <- struct{}{}
+		<-wait
+	})
+}
+
+func TestSetProfileFraction(t *testing.T) {
+	t.Run("on", func(t *testing.T) {
+		start := runtime.SetMutexProfileFraction(-1)
+		defer runtime.SetMutexProfileFraction(start)
+		p := unstartedProfiler(WithProfileTypes(MutexProfile))
+		p.run()
+		p.stop()
+		assert.NotEqual(t, start, runtime.SetMutexProfileFraction(-1))
+	})
+
+	t.Run("off", func(t *testing.T) {
+		start := runtime.SetMutexProfileFraction(-1)
+		defer runtime.SetMutexProfileFraction(start)
+		p := unstartedProfiler()
+		p.run()
+		p.stop()
+		assert.Equal(t, start, runtime.SetMutexProfileFraction(-1))
+	})
+}
+
+func TestProfilerPassthrough(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+	out := make(chan batch)
+	cfg := defaultConfig()
+	cfg.period = 200 * time.Millisecond
+	cfg.cpuDuration = 1 * time.Millisecond
+	p := newProfiler(cfg)
+	p.uploadFunc = func(bat batch) error {
+		out <- bat
+		return nil
+	}
+	p.run()
+	var bat batch
+loop:
+	for {
+		select {
+		case bat = <-p.out:
+			break loop
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("time expired")
+		}
+	}
+
+	assert.Equal(t, 2, len(bat.profiles))
+	firstTypes := []string{
+		bat.profiles[0].types[0],
+		bat.profiles[1].types[0],
+	}
+	sort.Strings(firstTypes)
+	assert.Equal(t, "alloc_objects", firstTypes[0])
+	assert.Equal(t, "samples", firstTypes[1])
+	assert.NotEmpty(t, bat.profiles[0].data)
+	assert.NotEmpty(t, bat.profiles[1].data)
+}
+
+func unstartedProfiler(opts ...Option) *profiler {
+	cfg := defaultConfig()
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	p := newProfiler(cfg)
+	p.uploadFunc = func(_ batch) error { return nil }
+	return p
+}

--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -16,6 +16,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 )
 
 // maxRetries specifies the maximum number of retries to have when an error occurs.
@@ -46,7 +48,7 @@ func (p *profiler) upload(bat batch) error {
 		if rerr, ok := err.(*retriableError); ok {
 			statsd.Count("datadog.profiler.go.upload_retry", 1, nil, 1)
 			wait := backoffDuration(i+1, p.cfg.cpuDuration)
-			p.log("Upload failed: %v. Trying again in %s...", rerr, wait)
+			log.Error("Uploading profile failed: %v. Trying again in %s...", rerr, wait)
 			time.Sleep(wait)
 			continue
 		}

--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -1,0 +1,149 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package profiler
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"mime/multipart"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// maxRetries specifies the maximum number of retries to have when an error occurs.
+const maxRetries = 2
+
+var httpClient = &http.Client{
+	Timeout: 5 * time.Second,
+}
+
+// backoffDuration calculates the backoff duration given an attempt number and max duration
+func backoffDuration(attempt int, max time.Duration) time.Duration {
+	// https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+	if attempt == 0 {
+		return 0
+	}
+	maxPow := float64(max / 100 * time.Millisecond)
+	pow := math.Min(math.Pow(2, float64(attempt)), maxPow)
+	ns := int64(float64(100*time.Millisecond) * pow)
+	return time.Duration(rand.Int63n(ns))
+}
+
+// upload tries to upload a batch of profiles. It has retry and backoff mechanisms.
+func (p *profiler) upload(bat batch) error {
+	statsd := p.cfg.statsd
+	var err error
+	for i := 0; i < maxRetries; i++ {
+		err = p.doRequest(bat)
+		if rerr, ok := err.(*retriableError); ok {
+			statsd.Count("datadog.profiler.go.upload_retry", 1, nil, 1)
+			wait := backoffDuration(i+1, p.cfg.cpuDuration)
+			p.log("Upload failed: %v. Trying again in %s...", rerr, wait)
+			time.Sleep(wait)
+			continue
+		}
+		if err != nil {
+			statsd.Count("datadog.profiler.go.upload_error", 1, nil, 1)
+		} else {
+			statsd.Count("datadog.profiler.go.upload_success", 1, nil, 1)
+			var b int64
+			for _, p := range bat.profiles {
+				b += int64(len(p.data))
+			}
+			statsd.Count("datadog.profiler.go.uploaded_profile_bytes", b, nil, 1)
+		}
+		return err
+	}
+	return fmt.Errorf("failed after %d retries, last error was: %v", maxRetries, err)
+}
+
+// retriableError is an error returned by the server which may be retried at a later time.
+type retriableError struct{ err error }
+
+// Error implements error.
+func (e retriableError) Error() string { return e.err.Error() }
+
+// doRequest makes an HTTP POST request to the Datadog Profiling API with the
+// given profile.
+func (p *profiler) doRequest(bat batch) error {
+	tags := append(p.cfg.tags,
+		fmt.Sprintf("service:%s", p.cfg.service),
+		fmt.Sprintf("env:%s", p.cfg.env),
+	)
+	contentType, body, err := encode(bat, tags)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest("POST", p.cfg.apiURL, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("DD-API-KEY", p.cfg.apiKey)
+	req.Header.Set("Content-Type", contentType)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return &retriableError{err}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 == 5 {
+		// 5xx can be retried
+		return &retriableError{errors.New(resp.Status)}
+	}
+	if resp.StatusCode != 200 {
+		return errors.New(resp.Status)
+	}
+	return nil
+}
+
+// encode encodes the profile as a multipart mime request.
+func encode(bat batch, tags []string) (contentType string, body io.Reader, err error) {
+	var buf bytes.Buffer
+
+	mw := multipart.NewWriter(&buf)
+	// write all of the profile metadata (including some useless ones)
+	// with a small helper function that makes error tracking less verbose.
+	writeField := func(k, v string) {
+		if err == nil {
+			err = mw.WriteField(k, v)
+		}
+	}
+	writeField("format", "pprof")
+	writeField("runtime", "go")
+	writeField("recording-start", bat.start.Format(time.RFC3339))
+	writeField("recording-end", bat.end.Format(time.RFC3339))
+	if bat.host != "" {
+		writeField("tags[]", fmt.Sprintf("host:%s", bat.host))
+	}
+	writeField("tags[]", "runtime:go")
+	for _, tag := range tags {
+		writeField("tags[]", tag)
+	}
+	for i, p := range bat.profiles {
+		writeField(fmt.Sprintf("types[%d]", i), strings.Join(p.types, ","))
+	}
+	if err != nil {
+		return "", nil, err
+	}
+	for i, p := range bat.profiles {
+		formFile, err := mw.CreateFormFile(fmt.Sprintf("data[%d]", i), "pprof-data")
+		if err != nil {
+			return "", nil, err
+		}
+		if _, err := formFile.Write(p.data); err != nil {
+			return "", nil, err
+		}
+	}
+	if err := mw.Close(); err != nil {
+		return "", nil, err
+	}
+	return mw.FormDataContentType(), &buf, nil
+}

--- a/profiler/upload_test.go
+++ b/profiler/upload_test.go
@@ -60,7 +60,7 @@ func TestTryUpload(t *testing.T) {
 	defer func(old *http.Client) { httpClient = old }(httpClient)
 	p := unstartedProfiler(
 		WithURL(srv.URL+"/"),
-		WithServiceName("my-service"),
+		WithService("my-service"),
 		WithEnv("my-env"),
 		WithTags("tag1:1", "tag2:2"),
 	)

--- a/profiler/upload_test.go
+++ b/profiler/upload_test.go
@@ -1,0 +1,142 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package profiler
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTryUpload(t *testing.T) {
+	wait := make(chan struct{})
+	fields := make(map[string]string)
+	var tags []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(200)
+		_, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		mr := multipart.NewReader(req.Body, params["boundary"])
+		defer req.Body.Close()
+		for {
+			p, err := mr.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			slurp, err := ioutil.ReadAll(p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			switch k := p.FormName(); k {
+			case "tags[]":
+				tags = append(tags, string(slurp))
+			default:
+				fields[k] = string(slurp)
+			}
+		}
+		close(wait)
+	}))
+
+	defer srv.Close()
+	defer func(old *http.Client) { httpClient = old }(httpClient)
+	p := unstartedProfiler(
+		WithURL(srv.URL+"/"),
+		WithServiceName("my-service"),
+		WithEnv("my-env"),
+		WithTags("tag1:1", "tag2:2"),
+	)
+	cpu := profile{
+		types: []string{"cpu"},
+		data:  []byte("my-cpu-profile"),
+	}
+	heap := profile{
+		types: []string{"alloc_objects", "alloc_space"},
+		data:  []byte("my-heap-profile"),
+	}
+	bat := batch{
+		start:    time.Now().Add(-10 * time.Second),
+		end:      time.Now(),
+		host:     "my-host",
+		profiles: []*profile{&cpu, &heap},
+	}
+	err := p.doRequest(bat)
+	require.NoError(t, err)
+	select {
+	case <-wait:
+		// OK
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	assert.ElementsMatch(t, []string{
+		"host:my-host",
+		"runtime:go",
+		"service:my-service",
+		"env:my-env",
+		"tag1:1",
+		"tag2:2",
+		fmt.Sprintf("pid:%d", os.Getpid()),
+	}, tags)
+	for k, v := range map[string]string{
+		"format":   "pprof",
+		"runtime":  "go",
+		"types[0]": "cpu",
+		"data[0]":  "my-cpu-profile",
+		"types[1]": "alloc_objects,alloc_space",
+		"data[1]":  "my-heap-profile",
+	} {
+		assert.Equal(t, v, fields[k], k)
+	}
+	for _, k := range []string{"recording-start", "recording-end"} {
+		_, ok := fields[k]
+		assert.True(t, ok, k)
+	}
+}
+
+func BenchmarkDoRequest(b *testing.B) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		_, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			b.Fatal(err)
+		}
+		req.Body.Close()
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+	prof := profile{
+		types: []string{"alloc_objects"},
+		data:  []byte("my-heap-profile"),
+	}
+	bat := batch{
+		start:    time.Now().Add(-10 * time.Second),
+		end:      time.Now(),
+		host:     "my-host",
+		profiles: []*profile{&prof},
+	}
+	p := unstartedProfiler()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		p.doRequest(bat)
+	}
+}


### PR DESCRIPTION
This change adds support for Datadog Profiling.

The `profiler` package is used as a standalone package and must be started separately from the tracer. Because it is part of the same repository, it will be imported using the same domain:

```
import "gopkg.in/DataDog/dd-trace-go.v1/profiler"
```

To start the profiler, make sure you pass it your Datadog API Key:

```
if err := profiler.Start(profiler.WithAPIKey("123key")); err != nil {
    log.Fatalf("Error starting profiler: %v", err)
}
defer profiler.Stop()
```

Various other options may be used and can be seen in the documentation: http://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/profiler/