### PR TITLE
internal: add a shared memstats reader

### DIFF
--- a/ddtrace/tracer/metrics.go
+++ b/ddtrace/tracer/metrics.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 )
 
@@ -29,7 +30,6 @@ type statsdClient interface {
 // reportRuntimeMetrics periodically reports go runtime metrics at
 // the given interval.
 func (t *tracer) reportRuntimeMetrics(interval time.Duration) {
-	var ms runtime.MemStats
 	gc := debug.GCStats{
 		// When len(stats.PauseQuantiles) is 5, it will be filled with the
 		// minimum, 25%, 50%, 75%, and maximum pause times. See the documentation
@@ -43,7 +43,7 @@ func (t *tracer) reportRuntimeMetrics(interval time.Duration) {
 		select {
 		case <-tick.C:
 			log.Debug("Reporting runtime metrics...")
-			runtime.ReadMemStats(&ms)
+			ms := internal.MemStats()
 			debug.ReadGCStats(&gc)
 
 			statsd := t.config.statsd

--- a/internal/memstats.go
+++ b/internal/memstats.go
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package internal
+
+import (
+	"runtime"
+	"sync"
+	"time"
+)
+
+var (
+	mu       sync.Mutex // guards below fields
+	lastRead time.Time  // time of most recent read
+	memStats = new(runtime.MemStats)
+)
+
+// interval specifies the allowed interval at which reading *runtime.MemStats is
+// allowed to reduce "stopTheWorld" calls.
+const interval = 10 * time.Second
+
+// MemStats returns the most recently read *runtime.MemStats. It only returns
+// more recent values if at least 10 seconds have passed since the last read.
+func MemStats() *runtime.MemStats {
+	mu.Lock()
+	defer mu.Unlock()
+	now := time.Now()
+	if memStats == nil || now.Sub(lastRead) >= interval {
+		runtime.ReadMemStats(memStats)
+		lastRead = now
+	}
+	return memStats
+}


### PR DESCRIPTION
This change adds a new `internal` package method which allows sharing
the read `*runtime.MemStats` structure. The new method will only read
new data if 10 seconds have passed since the previous read, otherwise it
keeps returning the same data in order to reduce [`stopTheWorld`](https://github.com/golang/go/blob/go1.13.8/src/runtime/mstats.go#L446) calls.

This is a PR which kickstarts the work of having the profiler send "_memstats_" too.