### PR TITLE
profiler: fix race in TestProfilerPassthrough

### DIFF
--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -204,6 +204,8 @@ func TestProfilerPassthrough(t *testing.T) {
 	var bat batch
 	select {
 	case bat = <-out:
+	// TODO (knusbaum) this timeout is long because we were seeing timeouts at 500ms.
+	// it would be nice to have a time-independent way to test this
 	case <-time.After(1000 * time.Millisecond):
 		t.Fatal("time expired")
 	}

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -204,7 +204,7 @@ func TestProfilerPassthrough(t *testing.T) {
 	var bat batch
 	select {
 	case bat = <-out:
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(1000 * time.Millisecond):
 		t.Fatal("time expired")
 	}
 

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -202,14 +202,10 @@ func TestProfilerPassthrough(t *testing.T) {
 	}
 	p.run()
 	var bat batch
-loop:
-	for {
-		select {
-		case bat = <-p.out:
-			break loop
-		case <-time.After(500 * time.Millisecond):
-			t.Fatal("time expired")
-		}
+	select {
+	case bat = <-out:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("time expired")
 	}
 
 	assert.Equal(t, 2, len(bat.profiles))


### PR DESCRIPTION
In CircleCI the TestProfilerPassthrough test seems to be flaky and run into the `"time expired"` failure frequently. 

The test previously was trying to read from the `p.out` channel, which was racing against the `send()` function and `uploadFunc`

This patch makes the test read from the correct `out` channel and eliminates an unnecessary loop.