### PR TITLE
circleci: vendor the correct k8s.io/apimachinery

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,7 @@ jobs:
         # TODO(knusbaum): remove this once the breaking change is resolved or propagated
         command: |
           git clone --branch v0.17.3 https://github.com/kubernetes/client-go $GOPATH/src/k8s.io/client-go
+          git clone --branch v0.17.3 https://github.com/kubernetes/apimachinery $GOPATH/src/k8s.io/apimachinery
           git clone --branch v0.4.0 https://github.com/googleapis/gnostic $GOPATH/src/k8s.io/client-go/vendor/github.com/googleapis/gnostic
 
     - run:


### PR DESCRIPTION
k8s.io/apimachinery needs to match the one required by
k8s.io/client-go's `go.mod` file, otherwise errors are thrown (newer
versions require `go1.13`)

Fixes CI.