### PR TITLE
contrib/google.golang.org/grpc: use service name from function

### DIFF
--- a/contrib/google.golang.org/grpc/server.go
+++ b/contrib/google.golang.org/grpc/server.go
@@ -83,7 +83,7 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
 				ctx,
 				info.FullMethod,
 				"grpc.server",
-				cfg.serviceName,
+				cfg.serverServiceName(),
 				tracer.AnalyticsRate(cfg.analyticsRate),
 				tracer.Measured(),
 			)


### PR DESCRIPTION
This commit changes the service name in a call to startSpanFromContex from
cfg.serviceName to cfg.serverServiceName(). Everywhere else in the grpc
server integration, the service name is taken from cfg.serverServiceName(),
except this one place which erroneously uses cfg.serviceName directly.