### PR TITLE
contrib/gorilla/mux: add NoDebugStack option for datadog tracer

### DIFF
--- a/contrib/gorilla/mux/mux.go
+++ b/contrib/gorilla/mux/mux.go
@@ -110,5 +110,5 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	spanopts = append(spanopts, r.config.spanOpts...)
 	resource := req.Method + " " + route
-	httputil.TraceAndServe(r.Router, w, req, r.config.serviceName, resource, spanopts...)
+	httputil.TraceAndServe(r.Router, w, req, r.config.serviceName, resource, r.config.finishOpts, spanopts...)
 }

--- a/contrib/gorilla/mux/mux_test.go
+++ b/contrib/gorilla/mux/mux_test.go
@@ -128,7 +128,7 @@ func TestNoDebugStack(t *testing.T) {
 	assert.Equal(1, len(spans))
 	s := spans[0]
 	assert.EqualError(s.Tags()[ext.Error].(error), "500: Internal Server Error")
-	assert.Equal("<mock no debug stack>", spans[0].Tags()[ext.ErrorStack])
+	assert.Equal("<debug stack disabled>", spans[0].Tags()[ext.ErrorStack])
 }
 
 // TestImplementingMethods is a regression tests asserting that all the mux.Router methods

--- a/contrib/gorilla/mux/option.go
+++ b/contrib/gorilla/mux/option.go
@@ -6,11 +6,11 @@
 package mux
 
 import (
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"math"
 	"net/http"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 

--- a/contrib/gorilla/mux/option.go
+++ b/contrib/gorilla/mux/option.go
@@ -6,6 +6,7 @@
 package mux
 
 import (
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"math"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
@@ -42,11 +43,12 @@ func WithSpanOptions(opts ...ddtrace.StartSpanOption) RouterOption {
 	}
 }
 
-// WithFinishOptions applies the given set of options on finish to the spans
-// started by the router.
-func WithFinishOptions(opts ...ddtrace.FinishOption) RouterOption {
+// NoDebugStack prevents stack traces from being attached to spans finishing
+// with an error. This is useful in situations where errors are frequent and
+// performance is critical.
+func NoDebugStack() RouterOption {
 	return func(cfg *routerConfig) {
-		cfg.finishOpts = opts
+		cfg.finishOpts = append(cfg.finishOpts, tracer.NoDebugStack())
 	}
 }
 

--- a/contrib/gorilla/mux/option.go
+++ b/contrib/gorilla/mux/option.go
@@ -15,6 +15,7 @@ import (
 type routerConfig struct {
 	serviceName   string
 	spanOpts      []ddtrace.StartSpanOption // additional span options to be applied
+	finishOpts    []ddtrace.FinishOption    // span finish options to be applied
 	analyticsRate float64
 }
 
@@ -38,6 +39,14 @@ func WithServiceName(name string) RouterOption {
 func WithSpanOptions(opts ...ddtrace.StartSpanOption) RouterOption {
 	return func(cfg *routerConfig) {
 		cfg.spanOpts = opts
+	}
+}
+
+// WithFinishOptions applies the given set of options on finish to the spans
+// started by the router.
+func WithFinishOptions(opts ...ddtrace.FinishOption) RouterOption {
+	return func(cfg *routerConfig) {
+		cfg.finishOpts = opts
 	}
 }
 

--- a/contrib/internal/httputil/trace.go
+++ b/contrib/internal/httputil/trace.go
@@ -18,7 +18,8 @@ import (
 )
 
 // TraceAndServe will apply tracing to the given http.Handler using the passed tracer under the given service and resource.
-func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, service, resource string, spanopts ...ddtrace.StartSpanOption) {
+func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, service, resource string,
+	finishopts []ddtrace.FinishOption, spanopts ...ddtrace.StartSpanOption) {
 	opts := append([]ddtrace.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeWeb),
 		tracer.ServiceName(service),
@@ -30,7 +31,7 @@ func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, servi
 		opts = append(opts, tracer.ChildOf(spanctx))
 	}
 	span, ctx := tracer.StartSpanFromContext(r.Context(), "http.request", opts...)
-	defer span.Finish()
+	defer span.Finish(finishopts...)
 
 	w = wrapResponseWriter(w, span)
 

--- a/contrib/internal/httputil/trace_test.go
+++ b/contrib/internal/httputil/trace_test.go
@@ -35,7 +35,7 @@ func TestTraceAndServe(t *testing.T) {
 			http.Error(w, "some error", http.StatusServiceUnavailable)
 			called = true
 		}
-		TraceAndServe(http.HandlerFunc(handler), w, r, "service", "resource")
+		TraceAndServe(http.HandlerFunc(handler), w, r, "service", "resource", nil)
 		spans := mt.FinishedSpans()
 		span := spans[0]
 
@@ -64,7 +64,7 @@ func TestTraceAndServe(t *testing.T) {
 			called = true
 		}
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			TraceAndServe(http.HandlerFunc(handler), w, r, "service", "resource")
+			TraceAndServe(http.HandlerFunc(handler), w, r, "service", "resource", nil)
 		}))
 		defer srv.Close()
 
@@ -117,7 +117,7 @@ func TestTraceAndServe(t *testing.T) {
 		assert.NoError(err)
 		w := httptest.NewRecorder()
 
-		TraceAndServe(http.HandlerFunc(handler), w, r, "service", "resource")
+		TraceAndServe(http.HandlerFunc(handler), w, r, "service", "resource", nil)
 
 		var p, c mocktracer.Span
 		spans := mt.FinishedSpans()
@@ -149,7 +149,7 @@ func TestTraceAndServe(t *testing.T) {
 		r = r.WithContext(tracer.ContextWithSpan(r.Context(), parent))
 		w := httptest.NewRecorder()
 
-		TraceAndServe(http.HandlerFunc(handler), w, r, "service", "resource")
+		TraceAndServe(http.HandlerFunc(handler), w, r, "service", "resource", nil)
 
 		var p, c mocktracer.Span
 		spans := mt.FinishedSpans()

--- a/contrib/julienschmidt/httprouter/httprouter.go
+++ b/contrib/julienschmidt/httprouter/httprouter.go
@@ -47,5 +47,5 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		route = strings.Replace(route, param.Value, ":"+param.Key, 1)
 	}
 	resource := req.Method + " " + route
-	httputil.TraceAndServe(r.Router, w, req, r.config.serviceName, resource, r.config.spanOpts...)
+	httputil.TraceAndServe(r.Router, w, req, r.config.serviceName, resource, nil, r.config.spanOpts...)
 }

--- a/contrib/net/http/http.go
+++ b/contrib/net/http/http.go
@@ -40,7 +40,7 @@ func (mux *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// get the resource associated to this request
 	_, route := mux.Handler(r)
 	resource := r.Method + " " + route
-	httputil.TraceAndServe(mux.ServeMux, w, r, mux.cfg.serviceName, resource, mux.cfg.spanOpts...)
+	httputil.TraceAndServe(mux.ServeMux, w, r, mux.cfg.serviceName, resource, nil, mux.cfg.spanOpts...)
 }
 
 // WrapHandler wraps an http.Handler with tracing using the given service and resource.
@@ -51,6 +51,6 @@ func WrapHandler(h http.Handler, service, resource string, opts ...Option) http.
 		fn(cfg)
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		httputil.TraceAndServe(h, w, req, service, resource, cfg.spanOpts...)
+		httputil.TraceAndServe(h, w, req, service, resource, cfg.finishOpts, cfg.spanOpts...)
 	})
 }

--- a/contrib/net/http/http_test.go
+++ b/contrib/net/http/http_test.go
@@ -6,16 +6,14 @@
 package http
 
 import (
-	"net/http"
-	"net/http/httptest"
-	"testing"
-	"time"
-
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 )
 
 func TestHttpTracer200(t *testing.T) {
@@ -78,10 +76,8 @@ func TestWrapHandler200(t *testing.T) {
 	defer mt.Stop()
 	assert := assert.New(t)
 
-	then := time.Now().Add(-time.Minute)
 	handler := WrapHandler(http.HandlerFunc(handler200), "my-service", "my-resource",
 		WithSpanOptions(tracer.Tag("foo", "bar")),
-		WithFinishOptions(tracer.FinishTime(then)),
 	)
 
 	url := "/"
@@ -103,7 +99,28 @@ func TestWrapHandler200(t *testing.T) {
 	assert.Equal(url, s.Tag(ext.HTTPURL))
 	assert.Equal(nil, s.Tag(ext.Error))
 	assert.Equal("bar", s.Tag("foo"))
-	assert.Equal(then, s.FinishTime())
+}
+
+func TestNoStack(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	assert := assert.New(t)
+
+	handler := WrapHandler(http.HandlerFunc(handler500), "my-service", "my-resource",
+		NoDebugStack())
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+	assert.Equal(http.StatusInternalServerError, w.Code)
+	assert.Equal("500!\n", w.Body.String())
+
+	spans := mt.FinishedSpans()
+	assert.Equal(1, len(spans))
+	s := spans[0]
+	assert.EqualError(spans[0].Tags()[ext.Error].(error), "500: Internal Server Error")
+	assert.Equal("<mock no debug stack>", s.Tags()[ext.ErrorStack])
+
 }
 
 func TestAnalyticsSettings(t *testing.T) {

--- a/contrib/net/http/http_test.go
+++ b/contrib/net/http/http_test.go
@@ -6,14 +6,15 @@
 package http
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 )
 
 func TestHttpTracer200(t *testing.T) {

--- a/contrib/net/http/http_test.go
+++ b/contrib/net/http/http_test.go
@@ -120,7 +120,7 @@ func TestNoStack(t *testing.T) {
 	assert.Equal(1, len(spans))
 	s := spans[0]
 	assert.EqualError(spans[0].Tags()[ext.Error].(error), "500: Internal Server Error")
-	assert.Equal("<mock no debug stack>", s.Tags()[ext.ErrorStack])
+	assert.Equal("<debug stack disabled>", s.Tags()[ext.ErrorStack])
 
 }
 

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -19,6 +19,7 @@ type config struct {
 	serviceName   string
 	analyticsRate float64
 	spanOpts      []ddtrace.StartSpanOption
+	finishOpts    []ddtrace.FinishOption
 }
 
 // MuxOption has been deprecated in favor of Option.
@@ -73,6 +74,14 @@ func WithAnalyticsRate(rate float64) MuxOption {
 func WithSpanOptions(opts ...ddtrace.StartSpanOption) Option {
 	return func(cfg *config) {
 		cfg.spanOpts = append(cfg.spanOpts, opts...)
+	}
+}
+
+// WithFinishOptions defines a set of additional ddtrace.FinishOption to be applied
+// on close to spans started by the integration.
+func WithFinishOptions(opts ...ddtrace.FinishOption) Option {
+	return func(cfg *config) {
+		cfg.finishOpts = append(cfg.finishOpts, opts...)
 	}
 }
 

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -77,11 +77,12 @@ func WithSpanOptions(opts ...ddtrace.StartSpanOption) Option {
 	}
 }
 
-// WithFinishOptions defines a set of additional ddtrace.FinishOption to be applied
-// on close to spans started by the integration.
-func WithFinishOptions(opts ...ddtrace.FinishOption) Option {
+// NoDebugStack prevents stack traces from being attached to spans finishing
+// with an error. This is useful in situations where errors are frequent and
+// performance is critical.
+func NoDebugStack() Option {
 	return func(cfg *config) {
-		cfg.finishOpts = append(cfg.finishOpts, opts...)
+		cfg.finishOpts = append(cfg.finishOpts, tracer.NoDebugStack())
 	}
 }
 

--- a/contrib/zenazn/goji.v1/web/goji.go
+++ b/contrib/zenazn/goji.v1/web/goji.go
@@ -47,7 +47,7 @@ func Middleware(opts ...Option) func(*web.C, http.Handler) http.Handler {
 					log.Warn("contrib/zenazn/goji.v1: routes are unavailable. To enable them add the goji Router middleware before the tracer middleware.")
 				})
 			}
-			httputil.TraceAndServe(h, w, r, cfg.serviceName, resource, cfg.spanOpts...)
+			httputil.TraceAndServe(h, w, r, cfg.serviceName, resource, cfg.finishOpts, cfg.spanOpts...)
 		})
 	}
 }

--- a/contrib/zenazn/goji.v1/web/goji_test.go
+++ b/contrib/zenazn/goji.v1/web/goji_test.go
@@ -217,5 +217,5 @@ func TestNoDebugStack(t *testing.T) {
 	assert.Len(t, spans, 1)
 	s := spans[0]
 	assert.EqualError(t, s.Tags()[ext.Error].(error), "500: Internal Server Error")
-	assert.Equal(t, "<mock no debug stack>", spans[0].Tags()[ext.ErrorStack])
+	assert.Equal(t, "<debug stack disabled>", spans[0].Tags()[ext.ErrorStack])
 }

--- a/contrib/zenazn/goji.v1/web/option.go
+++ b/contrib/zenazn/goji.v1/web/option.go
@@ -15,6 +15,7 @@ import (
 type config struct {
 	serviceName   string
 	spanOpts      []ddtrace.StartSpanOption
+	finishOpts    []ddtrace.FinishOption
 	analyticsRate float64
 }
 
@@ -37,6 +38,13 @@ func WithServiceName(name string) Option {
 func WithSpanOptions(opts ...ddtrace.StartSpanOption) Option {
 	return func(cfg *config) {
 		cfg.spanOpts = opts
+	}
+}
+
+// WithFinishOptions applies the given set of options on finish to the span started by the mux.
+func WithFinishOptions(opts ...ddtrace.FinishOption) Option {
+	return func(cfg *config) {
+		cfg.finishOpts = opts
 	}
 }
 

--- a/contrib/zenazn/goji.v1/web/option.go
+++ b/contrib/zenazn/goji.v1/web/option.go
@@ -6,6 +6,7 @@
 package web
 
 import (
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"math"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
@@ -41,10 +42,12 @@ func WithSpanOptions(opts ...ddtrace.StartSpanOption) Option {
 	}
 }
 
-// WithFinishOptions applies the given set of options on finish to the span started by the mux.
-func WithFinishOptions(opts ...ddtrace.FinishOption) Option {
+// NoDebugStack prevents stack traces from being attached to spans finishing
+// with an error. This is useful in situations where errors are frequent and
+// performance is critical.
+func NoDebugStack() Option {
 	return func(cfg *config) {
-		cfg.finishOpts = opts
+		cfg.finishOpts = append(cfg.finishOpts, tracer.NoDebugStack())
 	}
 }
 

--- a/contrib/zenazn/goji.v1/web/option.go
+++ b/contrib/zenazn/goji.v1/web/option.go
@@ -6,10 +6,10 @@
 package web
 
 import (
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"math"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 

--- a/ddtrace/mocktracer/mockspan.go
+++ b/ddtrace/mocktracer/mockspan.go
@@ -202,7 +202,7 @@ func (s *mockspan) Finish(opts ...ddtrace.FinishOption) {
 		s.SetTag(ext.Error, cfg.Error)
 	}
 	if cfg.NoDebugStack {
-		s.SetTag(ext.ErrorStack, "<mock no debug stack>")
+		s.SetTag(ext.ErrorStack, "<debug stack disabled>")
 	}
 	s.Lock()
 	defer s.Unlock()

--- a/ddtrace/mocktracer/mockspan.go
+++ b/ddtrace/mocktracer/mockspan.go
@@ -201,6 +201,9 @@ func (s *mockspan) Finish(opts ...ddtrace.FinishOption) {
 	if cfg.Error != nil {
 		s.SetTag(ext.Error, cfg.Error)
 	}
+	if cfg.NoDebugStack {
+		s.SetTag(ext.ErrorStack, "<mock no debug stack>")
+	}
 	s.Lock()
 	defer s.Unlock()
 	if s.finished {


### PR DESCRIPTION
By allowing span finish options to be passed to all of these integrations, we can disable things like stack traces on errors.  This code retains a slice of finishOptions that it can apply at the end of the span.  I'd suggest that this is more extensible better pattern than storing a boolean for noDebugStack.

Fixes #615 