### PR TITLE
contrib/gocql/gocql: update with latest changes to WithContext

### DIFF
--- a/contrib/gocql/gocql/gocql.go
+++ b/contrib/gocql/gocql/gocql.go
@@ -65,14 +65,14 @@ func WrapQuery(q *gocql.Query, opts ...WrapOption) *Query {
 		}
 		cfg.resourceName = q
 	}
-	tq := &Query{q, &params{config: cfg}, context.Background()}
+	tq := &Query{q, &params{config: cfg}, q.Context()}
 	return tq
 }
 
 // WithContext adds the specified context to the traced Query structure.
 func (tq *Query) WithContext(ctx context.Context) *Query {
 	tq.ctx = ctx
-	tq.Query.WithContext(ctx)
+	tq.Query = tq.Query.WithContext(ctx)
 	return tq
 }
 

--- a/contrib/gocql/gocql/gocql.go
+++ b/contrib/gocql/gocql/gocql.go
@@ -65,7 +65,7 @@ func WrapQuery(q *gocql.Query, opts ...WrapOption) *Query {
 		}
 		cfg.resourceName = q
 	}
-	tq := &Query{q, &params{config: cfg}, q.Context()}
+	tq := &Query{q, &params{config: cfg}, context.Background()}
 	return tq
 }
 


### PR DESCRIPTION
Update gocql WithContext function to work with gocql PR 1228, from Oct 25, 2018, https://github.com/gocql/gocql/pull/1228. That PR modified Query.WithContext to make a copy of the query.
We also modify WrapQuery to use the context already in the query.

Closes #625.