### PR TITLE
contrib/internal/httputil: only set status once with WriteHeader

### DIFF
--- a/contrib/internal/httputil/trace.go
+++ b/contrib/internal/httputil/trace.go
@@ -63,6 +63,9 @@ func (w *responseWriter) Write(b []byte) (int, error) {
 // WriteHeader sends an HTTP response header with status code.
 // It also sets the status code to the span.
 func (w *responseWriter) WriteHeader(status int) {
+	if w.status != 0 {
+		return
+	}
 	w.ResponseWriter.WriteHeader(status)
 	w.status = status
 	w.span.SetTag(ext.HTTPCode, strconv.Itoa(status))


### PR DESCRIPTION
The net/http only respects the first call to WriteHeader, ignoring others.
This commit changes our responseWriter wrapper to do the same so we will
get accurate reporting of status codes and errors when users call
WriteHeader multiple times.

Fixes #623