### PR TITLE
profiler: add support for standard environment variables.

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -73,6 +73,26 @@ func defaultConfig() *config {
 	for _, t := range defaultProfileTypes {
 		c.addProfileType(t)
 	}
+
+	if v := os.Getenv("DD_ENV"); v != "" {
+		WithEnv(v)(c)
+	}
+	if v := os.Getenv("DD_SERVICE"); v != "" {
+		WithService(v)(c)
+	}
+	if v := os.Getenv("DD_VERSION"); v != "" {
+		WithVersion(v)(c)
+	}
+	if v := os.Getenv("DD_TAGS"); v != "" {
+		for _, tag := range strings.Split(v, ",") {
+			tag = strings.TrimSpace(tag)
+			if tag == "" {
+				continue
+			}
+			WithTags(tag)(c)
+		}
+	}
+
 	// TODO(x): add support for environment variables once we figure out
 	// the naming standards.
 	return &c
@@ -122,7 +142,7 @@ func WithProfileTypes(types ...ProfileType) Option {
 	}
 }
 
-// WithService specifies the service name to attach a profile.
+// WithService specifies the service name to attach to a profile.
 func WithService(name string) Option {
 	return func(cfg *config) {
 		cfg.service = name
@@ -134,6 +154,11 @@ func WithEnv(env string) Option {
 	return func(cfg *config) {
 		cfg.env = env
 	}
+}
+
+// WithVersion specifies the service version tag to attach to profiles
+func WithVersion(version string) Option {
+	return WithTags("version:" + version)
 }
 
 // WithTags specifies a set of tags to be attached to the profiler. These may help

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-go/statsd"
@@ -75,13 +76,13 @@ func defaultConfig() *config {
 	}
 
 	if v := os.Getenv("DD_ENV"); v != "" {
-		WithEnv(v)(c)
+		WithEnv(v)(&c)
 	}
 	if v := os.Getenv("DD_SERVICE"); v != "" {
-		WithService(v)(c)
+		WithService(v)(&c)
 	}
 	if v := os.Getenv("DD_VERSION"); v != "" {
-		WithVersion(v)(c)
+		WithVersion(v)(&c)
 	}
 	if v := os.Getenv("DD_TAGS"); v != "" {
 		for _, tag := range strings.Split(v, ",") {
@@ -89,7 +90,7 @@ func defaultConfig() *config {
 			if tag == "" {
 				continue
 			}
-			WithTags(tag)(c)
+			WithTags(tag)(&c)
 		}
 	}
 

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -93,9 +93,6 @@ func defaultConfig() *config {
 			WithTags(tag)(&c)
 		}
 	}
-
-	// TODO(x): add support for environment variables once we figure out
-	// the naming standards.
 	return &c
 }
 

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -47,6 +47,101 @@ func TestOptions(t *testing.T) {
 		assert.True(t, ok)
 		assert.Len(t, cfg.types, 1)
 	})
+
+	t.Run("WithService", func(t *testing.T) {
+		var cfg config
+		WithService("serviceName")(&cfg)
+		assert.Equal(t, "serviceName", cfg.service)
+	})
+
+	t.Run("WithService/override", func(t *testing.T) {
+		os.Setenv("DD_SERVICE", "envService")
+		defer os.Unsetenv("DD_SERVICE")
+		cfg := defaultConfig()
+		WithService("serviceName")(cfg)
+		assert.Equal(t, "serviceName", cfg.service)
+	})
+
+	t.Run("WithEnv", func(t *testing.T) {
+		var cfg config
+		WithEnv("envName")(&cfg)
+		assert.Equal(t, "envName", cfg.env)
+	})
+
+	t.Run("WithEnv/override", func(t *testing.T) {
+		os.Setenv("DD_ENV", "envEnv")
+		defer os.Unsetenv("DD_ENV")
+		cfg := defaultConfig()
+		WithEnv("envName")(cfg)
+		assert.Equal(t, "envName", cfg.env)
+	})
+
+	t.Run("WithVersion", func(t *testing.T) {
+		var cfg config
+		WithVersion("1.2.3")(&cfg)
+		assert.Contains(t, cfg.tags, "version:1.2.3")
+	})
+
+	t.Run("WithVersion/override", func(t *testing.T) {
+		os.Setenv("DD_VERSION", "envVersion")
+		defer os.Unsetenv("DD_VERSION")
+		cfg := defaultConfig()
+		WithVersion("1.2.3")(cfg)
+		assert.Contains(t, cfg.tags, "version:1.2.3")
+	})
+
+	t.Run("WithTags", func(t *testing.T) {
+		var cfg config
+		WithTags("a:1", "b:2", "c:3")(&cfg)
+		assert.Contains(t, cfg.tags, "a:1")
+		assert.Contains(t, cfg.tags, "b:2")
+		assert.Contains(t, cfg.tags, "c:3")
+	})
+
+	t.Run("WithTags/override", func(t *testing.T) {
+		os.Setenv("DD_TAGS", "env1:tag1,env2:tag2")
+		defer os.Unsetenv("DD_TAGS")
+		cfg := defaultConfig()
+		WithTags("a:1", "b:2", "c:3")(cfg)
+		assert.Contains(t, cfg.tags, "a:1")
+		assert.Contains(t, cfg.tags, "b:2")
+		assert.Contains(t, cfg.tags, "c:3")
+		assert.Contains(t, cfg.tags, "env1:tag1")
+		assert.Contains(t, cfg.tags, "env2:tag2")
+	})
+}
+
+func TestEnvVars(t *testing.T) {
+	t.Run("DD_ENV", func(t *testing.T) {
+		os.Setenv("DD_ENV", "someEnv")
+		defer os.Unsetenv("DD_ENV")
+		cfg := defaultConfig()
+		assert.Equal(t, "someEnv", cfg.env)
+	})
+
+	t.Run("DD_SERVICE", func(t *testing.T) {
+		os.Setenv("DD_SERVICE", "someService")
+		defer os.Unsetenv("DD_SERVICE")
+		cfg := defaultConfig()
+		assert.Equal(t, "someService", cfg.service)
+	})
+
+	t.Run("DD_VERSION", func(t *testing.T) {
+		os.Setenv("DD_VERSION", "1.2.3")
+		defer os.Unsetenv("DD_VERSION")
+		cfg := defaultConfig()
+		assert.Contains(t, cfg.tags, "version:1.2.3")
+	})
+
+	t.Run("DD_TAGS", func(t *testing.T) {
+		os.Setenv("DD_TAGS", "a:1,b:2,c:3")
+		defer os.Unsetenv("DD_TAGS")
+		cfg := defaultConfig()
+		assert.Contains(t, cfg.tags, "a:1")
+		assert.Contains(t, cfg.tags, "b:2")
+		assert.Contains(t, cfg.tags, "c:3")
+	})
+
 }
 
 func TestDefaultConfig(t *testing.T) {

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -141,7 +141,6 @@ func TestEnvVars(t *testing.T) {
 		assert.Contains(t, cfg.tags, "b:2")
 		assert.Contains(t, cfg.tags, "c:3")
 	})
-
 }
 
 func TestDefaultConfig(t *testing.T) {


### PR DESCRIPTION
This commit adds profiler support for the DD_ENV, DD_SERVICE, DD_VERSION,
and DD_TAGS environment variables. It also adds the WithVersion Option

Fixes #630