### PR TITLE
ddtrace/tracer: add WithHTTPClient and increase default HTTP timeout

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -244,6 +244,7 @@ func WithSampler(s Sampler) StartOption {
 }
 
 // WithHTTPRoundTripper is deprecated. Please consider using WithHTTPClient instead.
+// The function allows customizing the underlying HTTP transport for emitting spans.
 func WithHTTPRoundTripper(r http.RoundTripper) StartOption {
 	return WithHTTPClient(&http.Client{
 		Transport: r,

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -50,8 +50,8 @@ type config struct {
 	// propagator propagates span context cross-process
 	propagator Propagator
 
-	// httpRoundTripper defines the http.RoundTripper used by the agent transport.
-	httpRoundTripper http.RoundTripper
+	// httpClient specifies the HTTP client to be used by the agent's transport.
+	httpClient *http.Client
 
 	// hostname is automatically assigned when the DD_TRACE_REPORT_HOSTNAME is set to true,
 	// and is added as a special tag to the root span of traces.
@@ -243,12 +243,18 @@ func WithSampler(s Sampler) StartOption {
 	}
 }
 
-// WithHTTPRoundTripper allows customizing the underlying HTTP transport for
-// emitting spans. This is useful for advanced customization such as emitting
-// spans to a unix domain socket. The default should be used in most cases.
+// WithHTTPRoundTripper is deprecated. Please consider using WithHTTPClient instead.
 func WithHTTPRoundTripper(r http.RoundTripper) StartOption {
+	return WithHTTPClient(&http.Client{
+		Transport: r,
+		Timeout:   defaultHTTPTimeout,
+	})
+}
+
+// WithHTTPClient specifies the HTTP client to use when emitting spans to the agent.
+func WithHTTPClient(client *http.Client) StartOption {
 	return func(c *config) {
-		c.httpRoundTripper = r
+		c.httpClient = client
 	}
 }
 

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -38,7 +38,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		assert.Equal("tracer.test", c.serviceName)
 		assert.Equal("localhost:8126", c.agentAddr)
 		assert.Equal("localhost:8125", c.dogstatsdAddr)
-		assert.Equal(nil, c.httpRoundTripper)
+		assert.Nil(nil, c.httpClient)
 	})
 
 	t.Run("analytics", func(t *testing.T) {

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -137,7 +137,7 @@ func newUnstartedTracer(opts ...StartOption) *tracer {
 		fn(c)
 	}
 	if c.transport == nil {
-		c.transport = newTransport(c.agentAddr, c.httpRoundTripper)
+		c.transport = newTransport(c.agentAddr, c.httpClient)
 	}
 	if c.propagator == nil {
 		c.propagator = NewPropagator(nil)

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -499,7 +499,7 @@ func TestTracerPrioritySampler(t *testing.T) {
 	addr := srv.Listener.Addr().String()
 
 	tr, _, flush, stop := startTestTracer(t,
-		withTransport(newHTTPTransport(addr, defaultRoundTripper)),
+		withTransport(newHTTPTransport(addr, defaultClient)),
 	)
 	defer stop()
 


### PR DESCRIPTION
This change adds a new option `WithHTTPClient` and marks
`WithHTTPRoundTripper` as deprecated (now superseded). Additionally, the
default client timeout is increased to 2 seconds as it has proven to be
too short (see #181).

Closes #181