### PR TITLE
ddtrace/tracer: implement Formatter interface to support log injection

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -337,6 +337,7 @@ func (s *span) String() string {
 	return strings.Join(lines, "\n")
 }
 
+// Format implements fmt.Formatter.
 func (s *span) Format(f fmt.State, c rune) {
 	switch c {
 	case 's':
@@ -349,6 +350,8 @@ func (s *span) Format(f fmt.State, c rune) {
 		if v := s.Meta[ext.Version]; v != "" {
 			fmt.Fprintf(f, " dd.version=%s", v)
 		}
+	default:
+		fmt.Fprintf(f, "%%!%c(ddtrace.Span=%v)", c, s)
 	}
 }
 

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -337,6 +337,21 @@ func (s *span) String() string {
 	return strings.Join(lines, "\n")
 }
 
+func (s *span) Format(f fmt.State, c rune) {
+	switch c {
+	case 's':
+		fmt.Fprint(f, s.String())
+	case 'v':
+		fmt.Fprintf(f, "dd.trace_id=%d dd.span_id=%d dd.service=%s", s.TraceID, s.SpanID, s.Service)
+		if e := s.Meta[ext.Environment]; e != "" {
+			fmt.Fprintf(f, " dd.env=%s", e)
+		}
+		if v := s.Meta[ext.Version]; v != "" {
+			fmt.Fprintf(f, " dd.version=%s", v)
+		}
+	}
+}
+
 const (
 	keySamplingPriority        = "_sampling_priority_v1"
 	keySamplingPriorityRate    = "_sampling_priority_rate_v1"

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -404,6 +404,35 @@ func TestSpanSamplingPriority(t *testing.T) {
 	}
 }
 
+func TestSpanLog(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		assert := assert.New(t)
+		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"))
+		defer stop()
+		span := tracer.StartSpan("test.request").(*span)
+		expect := fmt.Sprintf("dd.trace_id=%d dd.span_id=%d dd.service=tracer.test", span.TraceID, span.SpanID)
+		assert.Equal(expect, fmt.Sprintf("%v", span))
+	})
+
+	t.Run("env", func(t *testing.T) {
+		assert := assert.New(t)
+		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithEnv("testenv"))
+		defer stop()
+		span := tracer.StartSpan("test.request").(*span)
+		expect := fmt.Sprintf("dd.trace_id=%d dd.span_id=%d dd.service=tracer.test dd.env=testenv", span.TraceID, span.SpanID)
+		assert.Equal(expect, fmt.Sprintf("%v", span))
+	})
+
+	t.Run("version", func(t *testing.T) {
+		assert := assert.New(t)
+		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithServiceVersion("1.2.3"))
+		defer stop()
+		span := tracer.StartSpan("test.request").(*span)
+		expect := fmt.Sprintf("dd.trace_id=%d dd.span_id=%d dd.service=tracer.test dd.version=1.2.3", span.TraceID, span.SpanID)
+		assert.Equal(expect, fmt.Sprintf("%v", span))
+	})
+}
+
 func BenchmarkSetTagMetric(b *testing.B) {
 	span := newBasicSpan("bench.span")
 	keys := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -431,6 +431,7 @@ func TestSpanLog(t *testing.T) {
 		expect := fmt.Sprintf("dd.trace_id=%d dd.span_id=%d dd.service=tracer.test dd.version=1.2.3", span.TraceID, span.SpanID)
 		assert.Equal(expect, fmt.Sprintf("%v", span))
 	})
+
 	t.Run("badformat", func(t *testing.T) {
 		assert := assert.New(t)
 		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithServiceVersion("1.2.3"))

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -431,6 +431,14 @@ func TestSpanLog(t *testing.T) {
 		expect := fmt.Sprintf("dd.trace_id=%d dd.span_id=%d dd.service=tracer.test dd.version=1.2.3", span.TraceID, span.SpanID)
 		assert.Equal(expect, fmt.Sprintf("%v", span))
 	})
+	t.Run("badformat", func(t *testing.T) {
+		assert := assert.New(t)
+		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithServiceVersion("1.2.3"))
+		defer stop()
+		span := tracer.StartSpan("test.request").(*span)
+		expect := fmt.Sprintf("%%!b(ddtrace.Span=dd.trace_id=%d dd.span_id=%d dd.service=tracer.test dd.version=1.2.3)", span.TraceID, span.SpanID)
+		assert.Equal(expect, fmt.Sprintf("%b", span))
+	})
 }
 
 func BenchmarkSetTagMetric(b *testing.B) {


### PR DESCRIPTION
This commit implements the `fmt.Formatter` interface to support log injection.

The formatter supports the `%s` and `%v` formats. `%s` is the same as `.String()` and `%v` outputs the trace_id, span_id, service name, and if set, the env and service version in a format suitable for writing in logs.

Fixes #637 