### PR TITLE
contrib/bradfitz/gomemcache: trace item info for memcached operations

### DIFF
--- a/contrib/bradfitz/gomemcache/memcache/memcache.go
+++ b/contrib/bradfitz/gomemcache/memcache/memcache.go
@@ -81,8 +81,10 @@ func (c *Client) Add(item *memcache.Item) error {
 	span := c.startSpan("Add")
 	err := c.Client.Add(item)
 	span.SetTag("item.key", item.Key)
-	span.SetTag("item.value", item.Value)
-	span.SetTag("item.expiration", item.Expiration)
+	if c.cfg.withValueTags {
+		span.SetTag("item.value", item.Value)
+		span.SetTag("item.expiration", item.Expiration)
+	}
 	span.Finish(tracer.WithError(err))
 	return err
 }
@@ -92,8 +94,10 @@ func (c *Client) CompareAndSwap(item *memcache.Item) error {
 	span := c.startSpan("CompareAndSwap")
 	err := c.Client.CompareAndSwap(item)
 	span.SetTag("item.key", item.Key)
-	span.SetTag("item.value", item.Value)
-	span.SetTag("item.expiration", item.Expiration)
+	if c.cfg.withValueTags {
+		span.SetTag("item.value", item.Value)
+		span.SetTag("item.expiration", item.Expiration)
+	}
 	span.Finish(tracer.WithError(err))
 	return err
 }
@@ -103,8 +107,10 @@ func (c *Client) Decrement(key string, delta uint64) (newValue uint64, err error
 	span := c.startSpan("Decrement")
 	newValue, err = c.Client.Decrement(key, delta)
 	span.SetTag("item.key", key)
-	span.SetTag("item.value.before", newValue-delta)
-	span.SetTag("item.value.after", newValue)
+	if c.cfg.withValueTags {
+		span.SetTag("item.value.before", newValue-delta)
+		span.SetTag("item.value.after", newValue)
+	}
 	span.Finish(tracer.WithError(err))
 	return newValue, err
 }
@@ -157,8 +163,10 @@ func (c *Client) Increment(key string, delta uint64) (newValue uint64, err error
 	span := c.startSpan("Increment")
 	newValue, err = c.Client.Increment(key, delta)
 	span.SetTag("item.key", key)
-	span.SetTag("item.value.before", newValue-delta)
-	span.SetTag("item.value.after", newValue)
+	if c.cfg.withValueTags {
+		span.SetTag("item.value.before", newValue-delta)
+		span.SetTag("item.value.after", newValue)
+	}
 	span.Finish(tracer.WithError(err))
 	return newValue, err
 }
@@ -168,8 +176,10 @@ func (c *Client) Replace(item *memcache.Item) error {
 	span := c.startSpan("Replace")
 	err := c.Client.Replace(item)
 	span.SetTag("item.key", item.Key)
-	span.SetTag("item.value", item.Value)
-	span.SetTag("item.expiration", item.Expiration)
+	if c.cfg.withValueTags {
+		span.SetTag("item.value", item.Value)
+		span.SetTag("item.expiration", item.Expiration)
+	}
 	span.Finish(tracer.WithError(err))
 	return err
 }
@@ -179,8 +189,10 @@ func (c *Client) Set(item *memcache.Item) error {
 	span := c.startSpan("Set")
 	err := c.Client.Set(item)
 	span.SetTag("item.key", item.Key)
-	span.SetTag("item.value", item.Value)
-	span.SetTag("item.expiration", item.Expiration)
+	if c.cfg.withValueTags {
+		span.SetTag("item.value", item.Value)
+		span.SetTag("item.expiration", item.Expiration)
+	}
 	span.Finish(tracer.WithError(err))
 	return err
 }
@@ -190,7 +202,9 @@ func (c *Client) Touch(key string, seconds int32) error {
 	span := c.startSpan("Touch")
 	err := c.Client.Touch(key, seconds)
 	span.SetTag("item.key", key)
-	span.SetTag("item.expiration", seconds)
+	if c.cfg.withValueTags {
+		span.SetTag("item.expiration", seconds)
+	}
 	span.Finish(tracer.WithError(err))
 	return err
 }

--- a/contrib/bradfitz/gomemcache/memcache/memcache.go
+++ b/contrib/bradfitz/gomemcache/memcache/memcache.go
@@ -80,6 +80,9 @@ func (c *Client) startSpan(resourceName string) ddtrace.Span {
 func (c *Client) Add(item *memcache.Item) error {
 	span := c.startSpan("Add")
 	err := c.Client.Add(item)
+	span.SetTag("item.key", item.Key)
+	span.SetTag("item.value", item.Value)
+	span.SetTag("item.expiration", item.Expiration)
 	span.Finish(tracer.WithError(err))
 	return err
 }
@@ -88,6 +91,9 @@ func (c *Client) Add(item *memcache.Item) error {
 func (c *Client) CompareAndSwap(item *memcache.Item) error {
 	span := c.startSpan("CompareAndSwap")
 	err := c.Client.CompareAndSwap(item)
+	span.SetTag("item.key", item.Key)
+	span.SetTag("item.value", item.Value)
+	span.SetTag("item.expiration", item.Expiration)
 	span.Finish(tracer.WithError(err))
 	return err
 }
@@ -96,6 +102,9 @@ func (c *Client) CompareAndSwap(item *memcache.Item) error {
 func (c *Client) Decrement(key string, delta uint64) (newValue uint64, err error) {
 	span := c.startSpan("Decrement")
 	newValue, err = c.Client.Decrement(key, delta)
+	span.SetTag("item.key", key)
+	span.SetTag("item.value.before", newValue-delta)
+	span.SetTag("item.value.after", newValue)
 	span.Finish(tracer.WithError(err))
 	return newValue, err
 }
@@ -104,6 +113,7 @@ func (c *Client) Decrement(key string, delta uint64) (newValue uint64, err error
 func (c *Client) Delete(key string) error {
 	span := c.startSpan("Delete")
 	err := c.Client.Delete(key)
+	span.SetTag("item.key", key)
 	span.Finish(tracer.WithError(err))
 	return err
 }
@@ -128,6 +138,7 @@ func (c *Client) FlushAll() error {
 func (c *Client) Get(key string) (item *memcache.Item, err error) {
 	span := c.startSpan("Get")
 	item, err = c.Client.Get(key)
+	span.SetTag("item.key", key)
 	span.Finish(tracer.WithError(err))
 	return item, err
 }
@@ -136,6 +147,7 @@ func (c *Client) Get(key string) (item *memcache.Item, err error) {
 func (c *Client) GetMulti(keys []string) (map[string]*memcache.Item, error) {
 	span := c.startSpan("GetMulti")
 	items, err := c.Client.GetMulti(keys)
+	span.SetTag("item.keys", keys)
 	span.Finish(tracer.WithError(err))
 	return items, err
 }
@@ -144,6 +156,9 @@ func (c *Client) GetMulti(keys []string) (map[string]*memcache.Item, error) {
 func (c *Client) Increment(key string, delta uint64) (newValue uint64, err error) {
 	span := c.startSpan("Increment")
 	newValue, err = c.Client.Increment(key, delta)
+	span.SetTag("item.key", key)
+	span.SetTag("item.value.before", newValue-delta)
+	span.SetTag("item.value.after", newValue)
 	span.Finish(tracer.WithError(err))
 	return newValue, err
 }
@@ -152,6 +167,9 @@ func (c *Client) Increment(key string, delta uint64) (newValue uint64, err error
 func (c *Client) Replace(item *memcache.Item) error {
 	span := c.startSpan("Replace")
 	err := c.Client.Replace(item)
+	span.SetTag("item.key", item.Key)
+	span.SetTag("item.value", item.Value)
+	span.SetTag("item.expiration", item.Expiration)
 	span.Finish(tracer.WithError(err))
 	return err
 }
@@ -160,6 +178,9 @@ func (c *Client) Replace(item *memcache.Item) error {
 func (c *Client) Set(item *memcache.Item) error {
 	span := c.startSpan("Set")
 	err := c.Client.Set(item)
+	span.SetTag("item.key", item.Key)
+	span.SetTag("item.value", item.Value)
+	span.SetTag("item.expiration", item.Expiration)
 	span.Finish(tracer.WithError(err))
 	return err
 }
@@ -168,6 +189,8 @@ func (c *Client) Set(item *memcache.Item) error {
 func (c *Client) Touch(key string, seconds int32) error {
 	span := c.startSpan("Touch")
 	err := c.Client.Touch(key, seconds)
+	span.SetTag("item.key", key)
+	span.SetTag("item.expiration", seconds)
 	span.Finish(tracer.WithError(err))
 	return err
 }

--- a/contrib/bradfitz/gomemcache/memcache/memcache.go
+++ b/contrib/bradfitz/gomemcache/memcache/memcache.go
@@ -83,8 +83,8 @@ func (c *Client) Add(item *memcache.Item) error {
 	span.SetTag("item.key", item.Key)
 	if c.cfg.withValueTags {
 		span.SetTag("item.value", item.Value)
-		span.SetTag("item.expiration", item.Expiration)
 	}
+	span.SetTag("item.expiration", item.Expiration)
 	span.Finish(tracer.WithError(err))
 	return err
 }
@@ -96,8 +96,8 @@ func (c *Client) CompareAndSwap(item *memcache.Item) error {
 	span.SetTag("item.key", item.Key)
 	if c.cfg.withValueTags {
 		span.SetTag("item.value", item.Value)
-		span.SetTag("item.expiration", item.Expiration)
 	}
+	span.SetTag("item.expiration", item.Expiration)
 	span.Finish(tracer.WithError(err))
 	return err
 }
@@ -178,8 +178,8 @@ func (c *Client) Replace(item *memcache.Item) error {
 	span.SetTag("item.key", item.Key)
 	if c.cfg.withValueTags {
 		span.SetTag("item.value", item.Value)
-		span.SetTag("item.expiration", item.Expiration)
 	}
+	span.SetTag("item.expiration", item.Expiration)
 	span.Finish(tracer.WithError(err))
 	return err
 }
@@ -191,8 +191,8 @@ func (c *Client) Set(item *memcache.Item) error {
 	span.SetTag("item.key", item.Key)
 	if c.cfg.withValueTags {
 		span.SetTag("item.value", item.Value)
-		span.SetTag("item.expiration", item.Expiration)
 	}
+	span.SetTag("item.expiration", item.Expiration)
 	span.Finish(tracer.WithError(err))
 	return err
 }
@@ -202,9 +202,7 @@ func (c *Client) Touch(key string, seconds int32) error {
 	span := c.startSpan("Touch")
 	err := c.Client.Touch(key, seconds)
 	span.SetTag("item.key", key)
-	if c.cfg.withValueTags {
-		span.SetTag("item.expiration", seconds)
-	}
+	span.SetTag("item.expiration", seconds)
 	span.Finish(tracer.WithError(err))
 	return err
 }

--- a/contrib/bradfitz/gomemcache/memcache/memcache_test.go
+++ b/contrib/bradfitz/gomemcache/memcache/memcache_test.go
@@ -76,8 +76,9 @@ func testMemcache(t *testing.T, addr string) {
 		err := client.
 			WithContext(ctx).
 			Add(&memcache.Item{
-				Key:   "key2",
-				Value: []byte("value2"),
+				Key:        "key2",
+				Value:      []byte("value2"),
+				Expiration: 10,
 			})
 		assert.Nil(t, err)
 
@@ -89,6 +90,9 @@ func testMemcache(t *testing.T, addr string) {
 		assert.Equal(t, span, spans[1])
 		assert.Equal(t, spans[1].TraceID(), spans[0].TraceID(),
 			"memcache span should be part of the parent trace")
+		assert.Equal(t, "key2", spans[0].Tag("item.key"))
+		assert.Equal(t, []byte("value2"), spans[0].Tag("item.value"))
+		assert.Equal(t, int32(10), spans[0].Tag("item.expiration"))
 	})
 }
 

--- a/contrib/bradfitz/gomemcache/memcache/memcache_test.go
+++ b/contrib/bradfitz/gomemcache/memcache/memcache_test.go
@@ -38,7 +38,7 @@ func TestMemcacheIntegration(t *testing.T) {
 }
 
 func testMemcache(t *testing.T, addr string) {
-	client := WrapClient(memcache.New(addr), WithServiceName("test-memcache"), WithValueTags(true))
+	client := WrapClient(memcache.New(addr), WithServiceName("test-memcache"), WithValueTags())
 	defer client.DeleteAll()
 
 	validateMemcacheSpan := func(t *testing.T, span mocktracer.Span, resourceName string) {

--- a/contrib/bradfitz/gomemcache/memcache/memcache_test.go
+++ b/contrib/bradfitz/gomemcache/memcache/memcache_test.go
@@ -38,7 +38,7 @@ func TestMemcacheIntegration(t *testing.T) {
 }
 
 func testMemcache(t *testing.T, addr string) {
-	client := WrapClient(memcache.New(addr), WithServiceName("test-memcache"))
+	client := WrapClient(memcache.New(addr), WithServiceName("test-memcache"), WithValueTags(true))
 	defer client.DeleteAll()
 
 	validateMemcacheSpan := func(t *testing.T, span mocktracer.Span, resourceName string) {

--- a/contrib/bradfitz/gomemcache/memcache/option.go
+++ b/contrib/bradfitz/gomemcache/memcache/option.go
@@ -17,6 +17,7 @@ const (
 type clientConfig struct {
 	serviceName   string
 	analyticsRate float64
+	withValueTags bool
 }
 
 // ClientOption represents an option that can be passed to Dial.
@@ -55,5 +56,12 @@ func WithAnalyticsRate(rate float64) ClientOption {
 		} else {
 			cfg.analyticsRate = math.NaN()
 		}
+	}
+}
+
+// WithValueTags enables tracing of values used in operations
+func WithValueTags(on bool) ClientOption {
+	return func(cfg *clientConfig) {
+		cfg.withValueTags = on
 	}
 }

--- a/contrib/bradfitz/gomemcache/memcache/option.go
+++ b/contrib/bradfitz/gomemcache/memcache/option.go
@@ -59,9 +59,10 @@ func WithAnalyticsRate(rate float64) ClientOption {
 	}
 }
 
-// WithValueTags enables tracing of values used in operations
-func WithValueTags(on bool) ClientOption {
+// WithValueTags specifies whether values assigned to keys in memcache operations
+// should be added to spans as tags.
+func WithValueTags() ClientOption {
 	return func(cfg *clientConfig) {
-		cfg.withValueTags = on
+		cfg.withValueTags = true
 	}
 }


### PR DESCRIPTION
Currently, the memcached tracer is just creating a span and does not
trace anything except env tag. This commit adds some tags of valuable
information for each memcached operations.

Fixes #640