### PR TITLE
profiler: add WithSite option and DD_SITE environment variable.

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -35,8 +35,8 @@ const (
 )
 
 const (
-	defaultSite = "datadoghq.com"
-	defaultEnv  = "none"
+	defaultAPIURL = "https://intake.profile.datadoghq.com/v1/input"
+	defaultEnv    = "none"
 )
 
 var defaultProfileTypes = []ProfileType{CPUProfile, HeapProfile}
@@ -57,10 +57,8 @@ type config struct {
 
 func urlForSite(site string) (string, error) {
 	u := fmt.Sprintf("https://intake.profile.%s/v1/input", site)
-	if _, err := url.Parse(u); err != nil {
-		return "", err
-	}
-	return u, nil
+	_, err := url.Parse(u)
+	return u, err
 }
 
 func (c *config) addProfileType(t ProfileType) {
@@ -71,10 +69,9 @@ func (c *config) addProfileType(t ProfileType) {
 }
 
 func defaultConfig() *config {
-	u, _ := urlForSite(defaultSite)
 	c := config{
 		env:           defaultEnv,
-		apiURL:        u,
+		apiURL:        defaultAPIURL,
 		service:       filepath.Base(os.Args[0]),
 		statsd:        &statsd.NoOpClient{},
 		period:        DefaultPeriod,
@@ -196,7 +193,7 @@ func WithSite(site string) Option {
 	return func(cfg *config) {
 		u, err := urlForSite(site)
 		if err != nil {
-			log.Warn("profiler: ignoring invalid site %s: %s", site, err)
+			log.Error("profiler: invalid site provided, using %s (%s)", defaultAPIURL, err)
 			return
 		}
 		cfg.apiURL = u

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -196,7 +196,7 @@ func WithSite(site string) Option {
 	return func(cfg *config) {
 		u, err := urlForSite(site)
 		if err != nil {
-			log.Warn("profiler: ignoring bad site %s: %s", site, err)
+			log.Warn("profiler: ignoring invalid site %s: %s", site, err)
 			return
 		}
 		cfg.apiURL = u

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -64,16 +64,16 @@ func TestOptions(t *testing.T) {
 
 	t.Run("WithSite", func(t *testing.T) {
 		var cfg config
-		WithSite("some.other.site")(&cfg)
-		assert.Equal(t, "https://intake.profile.some.other.site/v1/input", cfg.apiURL)
+		WithSite("datadog.eu")(&cfg)
+		assert.Equal(t, "https://intake.profile.datadog.eu/v1/input", cfg.apiURL)
 	})
 
 	t.Run("WithSite/override", func(t *testing.T) {
 		os.Setenv("DD_SITE", "wrong.site")
 		defer os.Unsetenv("DD_SITE")
 		cfg := defaultConfig()
-		WithSite("some.other.site")(cfg)
-		assert.Equal(t, "https://intake.profile.some.other.site/v1/input", cfg.apiURL)
+		WithSite("datadog.eu")(cfg)
+		assert.Equal(t, "https://intake.profile.datadog.eu/v1/input", cfg.apiURL)
 	})
 
 	t.Run("WithEnv", func(t *testing.T) {
@@ -127,10 +127,10 @@ func TestOptions(t *testing.T) {
 
 func TestEnvVars(t *testing.T) {
 	t.Run("DD_SITE", func(t *testing.T) {
-		os.Setenv("DD_SITE", "some.other.site")
+		os.Setenv("DD_SITE", "datadog.eu")
 		defer os.Unsetenv("DD_SITE")
 		cfg := defaultConfig()
-		assert.Equal(t, "https://intake.profile.some.other.site/v1/input", cfg.apiURL)
+		assert.Equal(t, "https://intake.profile.datadog.eu/v1/input", cfg.apiURL)
 	})
 
 	t.Run("DD_ENV", func(t *testing.T) {
@@ -168,7 +168,7 @@ func TestDefaultConfig(t *testing.T) {
 	t.Run("base", func(t *testing.T) {
 		cfg := defaultConfig()
 		assert := assert.New(t)
-		assert.Equal("https://intake.profile.datadoghq.com/v1/input", cfg.apiURL)
+		assert.Equal(defaultAPIURL, cfg.apiURL)
 		assert.Equal(defaultEnv, cfg.env)
 		assert.Equal(filepath.Base(os.Args[0]), cfg.service)
 		assert.Equal(len(defaultProfileTypes), len(cfg.types))

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -62,6 +62,20 @@ func TestOptions(t *testing.T) {
 		assert.Equal(t, "serviceName", cfg.service)
 	})
 
+	t.Run("WithSite", func(t *testing.T) {
+		var cfg config
+		WithSite("some.other.site")(&cfg)
+		assert.Equal(t, "https://intake.profile.some.other.site/v1/input", cfg.apiURL)
+	})
+
+	t.Run("WithSite/override", func(t *testing.T) {
+		os.Setenv("DD_SITE", "wrong.site")
+		defer os.Unsetenv("DD_SITE")
+		cfg := defaultConfig()
+		WithSite("some.other.site")(cfg)
+		assert.Equal(t, "https://intake.profile.some.other.site/v1/input", cfg.apiURL)
+	})
+
 	t.Run("WithEnv", func(t *testing.T) {
 		var cfg config
 		WithEnv("envName")(&cfg)
@@ -112,6 +126,13 @@ func TestOptions(t *testing.T) {
 }
 
 func TestEnvVars(t *testing.T) {
+	t.Run("DD_SITE", func(t *testing.T) {
+		os.Setenv("DD_SITE", "some.other.site")
+		defer os.Unsetenv("DD_SITE")
+		cfg := defaultConfig()
+		assert.Equal(t, "https://intake.profile.some.other.site/v1/input", cfg.apiURL)
+	})
+
 	t.Run("DD_ENV", func(t *testing.T) {
 		os.Setenv("DD_ENV", "someEnv")
 		defer os.Unsetenv("DD_ENV")
@@ -147,7 +168,7 @@ func TestDefaultConfig(t *testing.T) {
 	t.Run("base", func(t *testing.T) {
 		cfg := defaultConfig()
 		assert := assert.New(t)
-		assert.Equal(defaultAPIURL, cfg.apiURL)
+		assert.Equal("https://intake.profile.datadoghq.com/v1/input", cfg.apiURL)
 		assert.Equal(defaultEnv, cfg.env)
 		assert.Equal(filepath.Base(os.Args[0]), cfg.service)
 		assert.Equal(len(defaultProfileTypes), len(cfg.types))

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -36,6 +36,7 @@ func TestStart(t *testing.T) {
 		if host, err := os.Hostname(); err != nil {
 			assert.Equal(host, activeProfiler.cfg.hostname)
 		}
+		assert.Equal(defaultAPIURL, activeProfiler.cfg.apiURL)
 		assert.Equal(DefaultPeriod, activeProfiler.cfg.period)
 		assert.Equal(len(defaultProfileTypes), len(activeProfiler.cfg.types))
 		for _, pt := range defaultProfileTypes {

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -36,7 +36,6 @@ func TestStart(t *testing.T) {
 		if host, err := os.Hostname(); err != nil {
 			assert.Equal(host, activeProfiler.cfg.hostname)
 		}
-		assert.Equal(defaultAPIURL, activeProfiler.cfg.apiURL)
 		assert.Equal(DefaultPeriod, activeProfiler.cfg.period)
 		assert.Equal(len(defaultProfileTypes), len(activeProfiler.cfg.types))
 		for _, pt := range defaultProfileTypes {


### PR DESCRIPTION
WithSite and DD_SITE will determine the apiURL that profiles are sent to.

I'm not sure if `WithURL` should be deprecated. Looking for feedback on this approach to implementing `DD_SITE` given we have `WithURL`.