### PR TITLE
contrib/google.golang.org/grpc: trace metadata/request for grpc calls

### DIFF
--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -683,9 +683,9 @@ func TestIgnoredMetadata(t *testing.T) {
 		ignore []string
 		exp    int
 	}{
-		{ignore: []string{}, exp: 1},
-		{ignore: []string{tagMetadataPrefix + "unknown"}, exp: 1},
-		{ignore: []string{tagMetadataPrefix + "test-key"}, exp: 0},
+		{ignore: []string{}, exp: 4},
+		{ignore: []string{"unknown"}, exp: 5},
+		{ignore: []string{"test-key"}, exp: 4},
 	} {
 		rig, err := newRig(true, WithMetadataTags(), WithIgnoredMetadata(c.ignore...))
 		if err != nil {

--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -114,7 +114,7 @@ func TestUnary(t *testing.T) {
 func TestStreaming(t *testing.T) {
 	// creates a stream, then sends/recvs two pings, then closes the stream
 	runPings := func(t *testing.T, ctx context.Context, client FixtureClient) {
-		stream, err := client.Streamaing(ctx)
+		stream, err := client.StreamPing(ctx)
 		assert.NoError(t, err)
 
 		for i := 0; i < 2; i++ {

--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -683,16 +683,16 @@ func TestIgnoredMetadata(t *testing.T) {
 		ignore []string
 		exp    int
 	}{
-		{ignore: []string{}, exp: 4},
-		{ignore: []string{"unknown"}, exp: 5},
+		{ignore: []string{}, exp: 5},
 		{ignore: []string{"test-key"}, exp: 4},
+		{ignore: []string{"test-key", "test-key2"}, exp: 3},
 	} {
 		rig, err := newRig(true, WithMetadataTags(), WithIgnoredMetadata(c.ignore...))
 		if err != nil {
 			t.Fatalf("error setting up rig: %s", err)
 		}
 		ctx := context.Background()
-		ctx = metadata.AppendToOutgoingContext(ctx, "test-key", "test-value")
+		ctx = metadata.AppendToOutgoingContext(ctx, "test-key", "test-value", "test-key2", "test-value2")
 		span, ctx := tracer.StartSpanFromContext(ctx, "x", tracer.ServiceName("y"), tracer.ResourceName("z"))
 		rig.client.Ping(ctx, &FixtureRequest{Name: "pass"})
 		span.Finish()
@@ -713,7 +713,7 @@ func TestIgnoredMetadata(t *testing.T) {
 				cnt++
 			}
 		}
-		assert.Equal(t, cnt, c.exp)
+		assert.Equal(t, c.exp, cnt)
 		rig.Close()
 		mt.Reset()
 	}

--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -723,7 +723,6 @@ func TestIgnoredMetadata(t *testing.T) {
 		spans := mt.FinishedSpans()
 
 		var serverSpan mocktracer.Span
-
 		for _, s := range spans {
 			switch s.OperationName() {
 			case "grpc.server":
@@ -732,13 +731,11 @@ func TestIgnoredMetadata(t *testing.T) {
 		}
 
 		var cnt int
-
 		for k := range serverSpan.Tags() {
 			if strings.HasPrefix(k, tagMetadataPrefix) {
 				cnt++
 			}
 		}
-
 		assert.Equal(t, cnt, c.exp)
 		rig.Close()
 		mt.Reset()

--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -319,7 +319,9 @@ func TestPass(t *testing.T) {
 
 	client := rig.client
 
-	resp, err := client.Ping(context.Background(), &FixtureRequest{Name: "pass"})
+	ctx := context.Background()
+	ctx = metadata.AppendToOutgoingContext(ctx, "test-key", "test-value")
+	resp, err := client.Ping(ctx, &FixtureRequest{Name: "pass"})
 	assert.Nil(err)
 	assert.Equal(resp.Message, "passed")
 
@@ -332,6 +334,8 @@ func TestPass(t *testing.T) {
 	assert.Equal(s.Tag(ext.ServiceName), "grpc")
 	assert.Equal(s.Tag(ext.ResourceName), "/grpc.Fixture/Ping")
 	assert.Equal(s.Tag(ext.SpanType), ext.AppTypeRPC)
+	assert.NotContains(s.Tags(), tagRequest)
+	assert.NotContains(s.Tags(), tagMetadataPrefix+"test-key")
 	assert.True(s.FinishTime().Sub(s.StartTime()) > 0)
 }
 

--- a/contrib/google.golang.org/grpc/option.go
+++ b/contrib/google.golang.org/grpc/option.go
@@ -150,7 +150,8 @@ func WithMetadataTags() Option {
 	}
 }
 
-// WithIgnoredMetadata specifies keys to be ignored while tracing the metadata.
+// WithIgnoredMetadata specifies keys to be ignored while tracing the metadata. Must be used
+// in conjunction with WithMetadataTags.
 func WithIgnoredMetadata(ms ...string) Option {
 	return func(cfg *config) {
 		for _, e := range ms {

--- a/contrib/google.golang.org/grpc/option.go
+++ b/contrib/google.golang.org/grpc/option.go
@@ -25,6 +25,9 @@ type config struct {
 	traceStreamMessages bool
 	noDebugStack        bool
 	ignoredMethods      map[string]struct{}
+	withMetadataTags    bool
+	ignoredMetadata     map[string]struct{}
+	withRequestTags     bool
 }
 
 func (cfg *config) serverServiceName() string {
@@ -56,6 +59,11 @@ func defaults(cfg *config) {
 	cfg.nonErrorCodes = map[codes.Code]bool{codes.Canceled: true}
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
 	cfg.analyticsRate = math.NaN()
+	cfg.ignoredMetadata = map[string]struct{}{
+		"x-datadog-trace-id":          {},
+		"x-datadog-parent-id":         {},
+		"x-datadog-sampling-priority": {},
+	}
 }
 
 // WithServiceName sets the given service name for the intercepted client.
@@ -132,5 +140,28 @@ func WithIgnoredMethods(ms ...string) Option {
 	}
 	return func(cfg *config) {
 		cfg.ignoredMethods = ims
+	}
+}
+
+// WithMetadataTags specifies whether gRPC metadata should be added to spans as tags.
+func WithMetadataTags() Option {
+	return func(cfg *config) {
+		cfg.withMetadataTags = true
+	}
+}
+
+// WithIgnoredMetadata specifies keys to be ignored while tracing the metadata.
+func WithIgnoredMetadata(ms ...string) Option {
+	return func(cfg *config) {
+		for _, e := range ms {
+			cfg.ignoredMetadata[e] = struct{}{}
+		}
+	}
+}
+
+// WithRequestTags specifies whether gRPC requests should be added to spans as tags.
+func WithRequestTags() Option {
+	return func(cfg *config) {
+		cfg.withRequestTags = true
 	}
 }

--- a/contrib/google.golang.org/grpc/server.go
+++ b/contrib/google.golang.org/grpc/server.go
@@ -6,16 +6,14 @@
 package grpc
 
 import (
-	"google.golang.org/grpc/metadata"
-
-	"github.com/golang/protobuf/jsonpb"
-	"github.com/golang/protobuf/proto"
-
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
 	context "golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 type serverStream struct {
@@ -146,7 +144,7 @@ func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
 			}
 		}
 		if cfg.withRequestTags {
-			m := jsonpb.Marshaler{}
+			var m jsonpb.Marshaler
 			if p, ok := req.(proto.Message); ok {
 				if s, err := m.MarshalToString(p); err == nil {
 					span.SetTag(tagRequest, s)

--- a/contrib/google.golang.org/grpc/tags.go
+++ b/contrib/google.golang.org/grpc/tags.go
@@ -7,9 +7,11 @@ package grpc
 
 // Tags used for gRPC
 const (
-	tagMethodName = "grpc.method.name"
-	tagMethodKind = "grpc.method.kind"
-	tagCode       = "grpc.code"
+	tagMethodName     = "grpc.method.name"
+	tagMethodKind     = "grpc.method.kind"
+	tagCode           = "grpc.code"
+	tagMetadataPrefix = "grpc.metadata."
+	tagRequest        = "grpc.request"
 )
 
 const (


### PR DESCRIPTION
This change add tags for gRPC metadata and request parameters, along with option to ignore metadata fields

Closes #643 