### PR TITLE
circleci: improve build speed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,10 @@ jobs:
     steps:
     - checkout
 
-    # - run:
-    #     name: Check milestone
-    #     command: |
-    #       go run checkmilestone.go
+    - run:
+        name: Check milestone
+        command: |
+          go run checkmilestone.go
 
     - run:
         name: Check copyright

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,8 +127,8 @@ jobs:
           - go-pkg-part-1-cache-v1
     - restore_cache:
         keys:
-          - go-pkg-part-2-cache-v1-{{ checksum "ddtrace/Gopkg.toml" }}
-          - go-pkg-part-2-cache-v1
+          - go-pkg-part-2-cache-v2-{{ checksum "ddtrace/Gopkg.toml" }}
+          - go-pkg-part-2-cache-v2
     - run:
         name: Fetching dependencies
         command: |
@@ -141,10 +141,10 @@ jobs:
           - /go/src/github.com
           - /go/src/golang.org
     - save_cache:
-        key: go-pkg-part-2-cache-v1-{{ checksum "ddtrace/Gopkg.toml" }}
+        key: go-pkg-part-2-cache-v2-{{ checksum "ddtrace/Gopkg.toml" }}
         paths:
           - /go/src/cloud.google.com
-          - /go/src/google.google.com
+          - /go/src/google.google.org
           - /go/src/go.mongodb.org
           - /go/src/go.opencensus.io
           - /go/src/golang.org

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,10 @@ jobs:
     steps:
     - checkout
 
-    - run:
-        name: Check milestone
-        command: |
-          go run checkmilestone.go
+    # - run:
+    #     name: Check milestone
+    #     command: |
+    #       go run checkmilestone.go
 
     - run:
         name: Check copyright

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,13 @@ jobs:
           - /go/src/golang.org
 
     - run:
+        name: Check gofmt
+        command: |
+          ls /go/src/
+          ls /go/src/k8s.io || true
+          ls /go/src/gopkg.in || true
+
+    - run:
         name: Vendor klog v0.4.0
         # Temporary, until kubernetes/client-go#656 gets resolved.
         command: >

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,8 +118,12 @@ jobs:
     
     - restore_cache:
         keys:
-          - go-pkg-cache-v1-{{ checksum "ddtrace/Gopkg.toml" }}
-          - go-pkg-cache-v1
+          - go-pkg-part-1-cache-v1-{{ checksum "ddtrace/Gopkg.toml" }}
+          - go-pkg-part-1-cache-v1
+    - restore_cache:
+        keys:
+          - go-pkg-part-2-cache-v1-{{ checksum "ddtrace/Gopkg.toml" }}
+          - go-pkg-part-2-cache-v1
     - run:
         name: Fetching dependencies
         command: |
@@ -127,14 +131,24 @@ jobs:
           go get -v -u golang.org/x/lint/golint
           go get -v -u github.com/alecthomas/gometalinter
     - save_cache:
-        key: go-pkg-cache-v1-{{ checksum "ddtrace/Gopkg.toml" }}
+        key: go-pkg-part-1-cache-v1-{{ checksum "ddtrace/Gopkg.toml" }}
         # caching gopkg.in can be gnarly until we move to go.mod
         paths:
           - /go/src/github.com
           - /go/src/golang.org
+    - save_cache:
+        key: go-pkg-part-2-cache-v1-{{ checksum "ddtrace/Gopkg.toml" }}
+        paths:
+          - /go/src/cloud.google.com
+          - /go/src/google.google.com
+          - /go/src/go.mongodb.org
+          - /go/src/go.opencensus.io
+          - /go/src/golang.org
+          - /go/src/sigs.k8s.io
+          - /go/src/k8s.io
 
     - run:
-        name: Check gofmt
+        name: list sources.
         command: |
           ls /go/src/
           ls /go/src/k8s.io || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,13 +152,6 @@ jobs:
           - /go/src/k8s.io
 
     - run:
-        name: list sources.
-        command: |
-          ls /go/src/
-          ls /go/src/k8s.io || true
-          ls /go/src/gopkg.in || true
-
-    - run:
         name: Vendor klog v0.4.0
         # Temporary, until kubernetes/client-go#656 gets resolved.
         command: >

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,13 +115,23 @@ jobs:
           git clone --branch v0.17.3 https://github.com/kubernetes/client-go $GOPATH/src/k8s.io/client-go
           git clone --branch v0.17.3 https://github.com/kubernetes/apimachinery $GOPATH/src/k8s.io/apimachinery
           git clone --branch v0.4.0 https://github.com/googleapis/gnostic $GOPATH/src/k8s.io/client-go/vendor/github.com/googleapis/gnostic
-
+    
+    - restore_cache:
+        keys:
+          - go-pkg-cache-v1-{{ checksum "ddtrace/Gopkg.toml" }}
+          - go-pkg-cache-v1
     - run:
         name: Fetching dependencies
         command: |
           go get -v -t ./...
           go get -v -u golang.org/x/lint/golint
           go get -v -u github.com/alecthomas/gometalinter
+    - save_cache:
+        key: go-pkg-cache-v1-{{ checksum "ddtrace/Gopkg.toml" }}
+        # caching gopkg.in can be gnarly until we move to go.mod
+        paths:
+          - /go/src/github.com
+          - /go/src/golang.org
 
     - run:
         name: Vendor klog v0.4.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,11 @@ jobs:
           git clone --branch v0.17.3 https://github.com/kubernetes/apimachinery $GOPATH/src/k8s.io/apimachinery
           git clone --branch v0.4.0 https://github.com/googleapis/gnostic $GOPATH/src/k8s.io/client-go/vendor/github.com/googleapis/gnostic
     
+    # CircleCI recommends caches be ~500MB. We split the cache into 
+    # two parts to achieve this.
+    # We specifically do not cache gopkg.in to avoid caching Datadog
+    # We can cache other packages here or wait to move to go modules
+    # in the future.
     - restore_cache:
         keys:
           - go-pkg-part-1-cache-v1-{{ checksum "ddtrace/Gopkg.toml" }}
@@ -132,7 +137,6 @@ jobs:
           go get -v -u github.com/alecthomas/gometalinter
     - save_cache:
         key: go-pkg-part-1-cache-v1-{{ checksum "ddtrace/Gopkg.toml" }}
-        # caching gopkg.in can be gnarly until we move to go.mod
         paths:
           - /go/src/github.com
           - /go/src/golang.org


### PR DESCRIPTION
Improving caching between builds.

Before caching fetch dependencies took anywhere from ~3m 5 to ~3m 20s
![image](https://user-images.githubusercontent.com/678239/80853690-9020db00-8be7-11ea-94a4-09619ef787b3.png)


After caching fetch dependencies (+ restore cache) takes: ~2m 
![image](https://user-images.githubusercontent.com/678239/80853744-0ae9f600-8be8-11ea-8139-6689989b30e0.png)

Note: we can improve this by caching directories within gopkg.in specifically(like shopify/sarama) except datadog. I will follow up with more PRs if you folks are up for it.
