### PR TITLE
circleci: better error messages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,10 @@ jobs:
     steps:
     - checkout
 
-    - run:
-        name: Check milestone
-        command: |
-          go run checkmilestone.go
+    # - run:
+    #     name: Check milestone
+    #     command: |
+    #       go run checkmilestone.go
 
     - run:
         name: Check copyright
@@ -107,7 +107,7 @@ jobs:
 
     - run:
         name: Vendor github.com/googleapis/gnostic for k8s.io/client-go
-        # This step checks out k8s.io/client-go and vendors 
+        # This step checks out k8s.io/client-go and vendors
         # github.com/googleapis/gnostic to fix a breaking change made in
         # gnostic. See kubernetes/client-go#741
         # TODO(knusbaum): remove this once the breaking change is resolved or propagated
@@ -206,4 +206,9 @@ jobs:
     - run:
         name: Testing
         command: |
-          INTEGRATION=1 go test -v -race `go list ./...`
+              mkdir /tmp/test-results
+              INTEGRATION=1 gotestsum --junitfile /tmp/test-results/result.xml -- -race `go list ./...`
+    - store_artifacts:
+        path: /tmp/test-results
+    - store_test_results:
+        path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,10 @@ jobs:
     steps:
     - checkout
 
-    # - run:
-    #     name: Check milestone
-    #     command: |
-    #       go run checkmilestone.go
+    - run:
+        name: Check milestone
+        command: |
+          go run checkmilestone.go
 
     - run:
         name: Check copyright
@@ -115,8 +115,8 @@ jobs:
           git clone --branch v0.17.3 https://github.com/kubernetes/client-go $GOPATH/src/k8s.io/client-go
           git clone --branch v0.17.3 https://github.com/kubernetes/apimachinery $GOPATH/src/k8s.io/apimachinery
           git clone --branch v0.4.0 https://github.com/googleapis/gnostic $GOPATH/src/k8s.io/client-go/vendor/github.com/googleapis/gnostic
-    
-    # CircleCI recommends caches be ~500MB. We split the cache into 
+
+    # CircleCI recommends caches be ~500MB. We split the cache into
     # two parts to achieve this.
     # We specifically do not cache gopkg.in to avoid caching Datadog
     # We can cache other packages here or wait to move to go modules

--- a/contrib/internal/httputil/trace_test.go
+++ b/contrib/internal/httputil/trace_test.go
@@ -46,7 +46,7 @@ func TestTraceAndServe(t *testing.T) {
 		assert.Equal("resource", span.Tag(ext.ResourceName))
 		assert.Equal("GET", span.Tag(ext.HTTPMethod))
 		assert.Equal("/", span.Tag(ext.HTTPURL))
-		assert.Equal("503-wrongwrong", span.Tag(ext.HTTPCode))
+		assert.Equal("503", span.Tag(ext.HTTPCode))
 		assert.Equal("503: Service Unavailable", span.Tag(ext.Error).(error).Error())
 	})
 

--- a/contrib/internal/httputil/trace_test.go
+++ b/contrib/internal/httputil/trace_test.go
@@ -46,7 +46,7 @@ func TestTraceAndServe(t *testing.T) {
 		assert.Equal("resource", span.Tag(ext.ResourceName))
 		assert.Equal("GET", span.Tag(ext.HTTPMethod))
 		assert.Equal("/", span.Tag(ext.HTTPURL))
-		assert.Equal("503", span.Tag(ext.HTTPCode))
+		assert.Equal("503-wrongwrong", span.Tag(ext.HTTPCode))
 		assert.Equal("503: Service Unavailable", span.Tag(ext.Error).(error).Error())
 	})
 


### PR DESCRIPTION
Shows errors on circle CI instead of having to scroll forever.

This makes it easy to identify what broke

![image](https://user-images.githubusercontent.com/678239/80996213-4f49e180-8df4-11ea-8821-519a7eca29f6.png)
