### PR TITLE
Revert "ddtrace/tracer: implement Formatter interface to support log injection"

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -337,24 +337,6 @@ func (s *span) String() string {
 	return strings.Join(lines, "\n")
 }
 
-// Format implements fmt.Formatter.
-func (s *span) Format(f fmt.State, c rune) {
-	switch c {
-	case 's':
-		fmt.Fprint(f, s.String())
-	case 'v':
-		fmt.Fprintf(f, "dd.trace_id=%d dd.span_id=%d dd.service=%s", s.TraceID, s.SpanID, s.Service)
-		if e := s.Meta[ext.Environment]; e != "" {
-			fmt.Fprintf(f, " dd.env=%s", e)
-		}
-		if v := s.Meta[ext.Version]; v != "" {
-			fmt.Fprintf(f, " dd.version=%s", v)
-		}
-	default:
-		fmt.Fprintf(f, "%%!%c(ddtrace.Span=%v)", c, s)
-	}
-}
-
 const (
 	keySamplingPriority        = "_sampling_priority_v1"
 	keySamplingPriorityRate    = "_sampling_priority_rate_v1"

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -404,44 +404,6 @@ func TestSpanSamplingPriority(t *testing.T) {
 	}
 }
 
-func TestSpanLog(t *testing.T) {
-	t.Run("default", func(t *testing.T) {
-		assert := assert.New(t)
-		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"))
-		defer stop()
-		span := tracer.StartSpan("test.request").(*span)
-		expect := fmt.Sprintf("dd.trace_id=%d dd.span_id=%d dd.service=tracer.test", span.TraceID, span.SpanID)
-		assert.Equal(expect, fmt.Sprintf("%v", span))
-	})
-
-	t.Run("env", func(t *testing.T) {
-		assert := assert.New(t)
-		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithEnv("testenv"))
-		defer stop()
-		span := tracer.StartSpan("test.request").(*span)
-		expect := fmt.Sprintf("dd.trace_id=%d dd.span_id=%d dd.service=tracer.test dd.env=testenv", span.TraceID, span.SpanID)
-		assert.Equal(expect, fmt.Sprintf("%v", span))
-	})
-
-	t.Run("version", func(t *testing.T) {
-		assert := assert.New(t)
-		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithServiceVersion("1.2.3"))
-		defer stop()
-		span := tracer.StartSpan("test.request").(*span)
-		expect := fmt.Sprintf("dd.trace_id=%d dd.span_id=%d dd.service=tracer.test dd.version=1.2.3", span.TraceID, span.SpanID)
-		assert.Equal(expect, fmt.Sprintf("%v", span))
-	})
-
-	t.Run("badformat", func(t *testing.T) {
-		assert := assert.New(t)
-		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithServiceVersion("1.2.3"))
-		defer stop()
-		span := tracer.StartSpan("test.request").(*span)
-		expect := fmt.Sprintf("%%!b(ddtrace.Span=dd.trace_id=%d dd.span_id=%d dd.service=tracer.test dd.version=1.2.3)", span.TraceID, span.SpanID)
-		assert.Equal(expect, fmt.Sprintf("%b", span))
-	})
-}
-
 func BenchmarkSetTagMetric(b *testing.B) {
 	span := newBasicSpan("bench.span")
 	keys := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"


### PR DESCRIPTION
Reverts DataDog/dd-trace-go#639