### PR TITLE
contrib/jinzhu/gorm: add context getter for gorm.db

### DIFF
--- a/contrib/jinzhu/gorm/gorm.go
+++ b/contrib/jinzhu/gorm/gorm.go
@@ -81,6 +81,17 @@ func WithContext(ctx context.Context, db *gorm.DB) *gorm.DB {
 	return db
 }
 
+// Context returns the context attached to a given db (via WithContext). If a
+// context has not been attached to db, returns context.Background.
+func Context(db *gorm.DB) context.Context {
+	if v, ok := db.Get(gormContextKey); ok {
+		if ctx, ok := v.(context.Context); ok {
+			return ctx
+		}
+	}
+	return context.Background()
+}
+
 func before(scope *gorm.Scope) {
 	scope.Set(gormSpanStartTimeKey, time.Now())
 }

--- a/contrib/jinzhu/gorm/gorm.go
+++ b/contrib/jinzhu/gorm/gorm.go
@@ -81,7 +81,7 @@ func WithContext(ctx context.Context, db *gorm.DB) *gorm.DB {
 	return db
 }
 
-// Context returns the context attached to a given db (via WithContext). If a
+// ContextFromDB returns the context attached to a given db (via WithContext). If a
 // context has not been attached to db, returns context.Background.
 func ContextFromDB(db *gorm.DB) context.Context {
 	if v, ok := db.Get(gormContextKey); ok {

--- a/contrib/jinzhu/gorm/gorm.go
+++ b/contrib/jinzhu/gorm/gorm.go
@@ -83,7 +83,7 @@ func WithContext(ctx context.Context, db *gorm.DB) *gorm.DB {
 
 // Context returns the context attached to a given db (via WithContext). If a
 // context has not been attached to db, returns context.Background.
-func Context(db *gorm.DB) context.Context {
+func ContextFromDB(db *gorm.DB) context.Context {
 	if v, ok := db.Get(gormContextKey); ok {
 		if ctx, ok := v.(context.Context); ok {
 			return ctx

--- a/contrib/jinzhu/gorm/gorm.go
+++ b/contrib/jinzhu/gorm/gorm.go
@@ -81,8 +81,8 @@ func WithContext(ctx context.Context, db *gorm.DB) *gorm.DB {
 	return db
 }
 
-// ContextFromDB returns the context attached to a given db (via WithContext). If a
-// context has not been attached to db, returns context.Background.
+// ContextFromDB returns any context previously attached to db using WithContext,
+// otherwise returning context.Background.
 func ContextFromDB(db *gorm.DB) context.Context {
 	if v, ok := db.Get(gormContextKey); ok {
 		if ctx, ok := v.(context.Context); ok {

--- a/contrib/jinzhu/gorm/gorm_test.go
+++ b/contrib/jinzhu/gorm/gorm_test.go
@@ -291,7 +291,6 @@ func TestContext(t *testing.T) {
 	defer db.Close()
 
 	t.Run("with", func(t *testing.T) {
-		// should not use basic type string as key in context.WithValue (golint)
 		type key string
 		testCtx := context.WithValue(context.Background(), key("test context"), true)
 		db := WithContext(testCtx, db)

--- a/contrib/jinzhu/gorm/gorm_test.go
+++ b/contrib/jinzhu/gorm/gorm_test.go
@@ -293,12 +293,12 @@ func TestContext(t *testing.T) {
 	t.Run("with", func(t *testing.T) {
 		testCtx := context.WithValue(context.Background(), "test context", true)
 		db := WithContext(testCtx, db)
-		ctx := Context(db)
+		ctx := ContextFromDB(db)
 		assert.Equal(t, testCtx, ctx)
 	})
 
 	t.Run("without", func(t *testing.T) {
-		ctx := Context(db)
+		ctx := ContextFromDB(db)
 		assert.Equal(t, context.Background(), ctx)
 	})
 }

--- a/contrib/jinzhu/gorm/gorm_test.go
+++ b/contrib/jinzhu/gorm/gorm_test.go
@@ -290,14 +290,14 @@ func TestContext(t *testing.T) {
 	}
 	defer db.Close()
 
-	t.Run("db with context", func(t *testing.T) {
+	t.Run("with", func(t *testing.T) {
 		testCtx := context.WithValue(context.Background(), "test context", true)
 		db := WithContext(testCtx, db)
 		ctx := Context(db)
 		assert.Equal(t, testCtx, ctx)
 	})
 
-	t.Run("db without context", func(t *testing.T) {
+	t.Run("without", func(t *testing.T) {
 		ctx := Context(db)
 		assert.Equal(t, context.Background(), ctx)
 	})

--- a/contrib/jinzhu/gorm/gorm_test.go
+++ b/contrib/jinzhu/gorm/gorm_test.go
@@ -291,7 +291,9 @@ func TestContext(t *testing.T) {
 	defer db.Close()
 
 	t.Run("with", func(t *testing.T) {
-		testCtx := context.WithValue(context.Background(), "test context", true)
+		// should not use basic type string as key in context.WithValue (golint)
+		type key string
+		testCtx := context.WithValue(context.Background(), key("test context"), true)
 		db := WithContext(testCtx, db)
 		ctx := ContextFromDB(db)
 		assert.Equal(t, testCtx, ctx)

--- a/contrib/jinzhu/gorm/gorm_test.go
+++ b/contrib/jinzhu/gorm/gorm_test.go
@@ -281,3 +281,24 @@ func TestAnalyticsSettings(t *testing.T) {
 		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
 	})
 }
+
+func TestContext(t *testing.T) {
+	sqltrace.Register("postgres", &pq.Driver{})
+	db, err := Open("postgres", "postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	t.Run("db with context", func(t *testing.T) {
+		testCtx := context.WithValue(context.Background(), "test context", true)
+		db := WithContext(testCtx, db)
+		ctx := Context(db)
+		assert.Equal(t, testCtx, ctx)
+	})
+
+	t.Run("db without context", func(t *testing.T) {
+		ctx := Context(db)
+		assert.Equal(t, context.Background(), ctx)
+	})
+}


### PR DESCRIPTION
contrib/jinzhu/gorm: add context getter for gorm.db

Allows access to the context added to a gorm.db added using WithContext

Resolves #666 