### PR TITLE
profiler: support agent-based deployments and have those as default.

### DIFF
--- a/ddtrace/tracer/util.go
+++ b/ddtrace/tracer/util.go
@@ -6,8 +6,18 @@
 package tracer
 
 import (
+	"bufio"
+	"os"
+	"regexp"
 	"strconv"
 	"strings"
+)
+
+var (
+	// expLine matches a line in the /proc/self/cgroup file. It has a submatch for the last element (path), which contains the container ID.
+	expLine = regexp.MustCompile(`^\d+:[^:]*:(.+)$`)
+	// expContainerID matches contained IDs and sources. Source: https://github.com/Qard/container-info/blob/master/index.js
+	expContainerID = regexp.MustCompile(`([0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}|[0-9a-f]{64})(?:.scope)?$`)
 )
 
 // toFloat64 attempts to convert value into a float64. If the value is an integer
@@ -62,4 +72,23 @@ func parseUint64(str string) (uint64, error) {
 		return uint64(id), nil
 	}
 	return strconv.ParseUint(str, 10, 64)
+}
+
+func FindContainerID() string {
+	f, err := os.Open("/proc/self/cgroup")
+	if err == nil {
+		defer f.Close()
+		scn := bufio.NewScanner(f)
+		for scn.Scan() {
+			path := expLine.FindStringSubmatch(scn.Text())
+			if len(path) != 2 {
+				// invalid entry, continue
+				continue
+			}
+			if id := expContainerID.FindString(path[1]); id != "" {
+				return id
+			}
+		}
+	}
+	return ""
 }

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -20,6 +20,16 @@ func TestOptions(t *testing.T) {
 		var cfg config
 		WithAPIKey("123")(&cfg)
 		assert.Equal(t, "123", cfg.apiKey)
+		assert.True(t, cfg.agentless())
+	})
+
+	t.Run("WithAPIKey/override", func(t *testing.T) {
+		os.Setenv("DD_API_KEY", "apikey")
+		defer os.Unsetenv("DD_API_KEY")
+		var cfg config
+		WithAPIKey("123")(&cfg)
+		assert.Equal(t, "123", cfg.apiKey)
+		assert.True(t, cfg.agentless())
 	})
 
 	t.Run("WithURL", func(t *testing.T) {
@@ -126,6 +136,13 @@ func TestOptions(t *testing.T) {
 }
 
 func TestEnvVars(t *testing.T) {
+	t.Run("DD_API_KEY", func(t *testing.T) {
+		os.Setenv("DD_API_KEY", "123")
+		defer os.Unsetenv("DD_API_KEY")
+		cfg := defaultConfig()
+		assert.Equal(t, "123", cfg.apiKey)
+	})
+
 	t.Run("DD_SITE", func(t *testing.T) {
 		os.Setenv("DD_SITE", "datadog.eu")
 		defer os.Unsetenv("DD_SITE")


### PR DESCRIPTION
Adds support for deployments where uploads are routed through the agent and
updates the default configuration to use this type of deployment.

Also adds container-id header to uploaded profiles.

Ref: PROF-1557