### PR TITLE
contrib/google.golang.org/grpc: fix a data race in config

### DIFF
--- a/contrib/google.golang.org/grpc/option.go
+++ b/contrib/google.golang.org/grpc/option.go
@@ -31,13 +31,13 @@ type config struct {
 }
 
 func (cfg *config) serverServiceName() string {
-	if cfg.serviceName == "" {
-		cfg.serviceName = "grpc.server"
-		if svc := globalconfig.ServiceName(); svc != "" {
-			cfg.serviceName = svc
-		}
+	if cfg.serviceName != "" {
+		return cfg.serviceName
 	}
-	return cfg.serviceName
+	if svc := globalconfig.ServiceName(); svc != "" {
+		return svc
+	}
+	return "grpc.server"
 }
 
 func (cfg *config) clientServiceName() string {


### PR DESCRIPTION
`serverServiceName` method of `config` occurs a data race because it
accesses/writes `serviceName` field without locking. This change fixes it
by making `serviceName` field to be immutable.

Fixes #669