### PR TITLE
ddtrace/tracer: send all global tags instead of just env

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -147,9 +147,9 @@ func statsTags(c *config) []string {
 	if c.hostname != "" {
 		tags = append(tags, "host:"+c.hostname)
 	}
-	if v, ok := c.globalTags[ext.Environment]; ok {
-		if vv, ok := v.(string); ok {
-			tags = append(tags, "env:"+vv)
+	for k, v := range c.globalTags {
+		if vstr, ok := v.(string); ok {
+			tags = append(tags, k+":"+vstr)
 		}
 	}
 	return tags

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -190,3 +190,9 @@ func TestServiceName(t *testing.T) {
 		assert.Equal("", globalconfig.ServiceName())
 	})
 }
+
+func TestGlobalTag(t *testing.T) {
+	var c config
+	WithGlobalTag("k", "v")(&c)
+	assert.Contains(t, statsTags(&c), "k:v")
+}


### PR DESCRIPTION
Instead of only looking for Environment tag, send all global tags
for metrics recorded by the statsd client (runtime metrics).

This also removes the remapping of ext.Environment to hardcoded "env".

Fixes: #671