### PR TITLE
ddtrace/tracer: pick up env, version, service from DD_TAGS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
         command: |
           go get -u golang.org/x/lint/golint
           curl -L https://git.io/vp6lP | sh # https://github.com/alecthomas/gometalinter#binary-releases
-          ./bin/gometalinter --disable-all --vendor --deadline=600s --enable=golint ./...
+          ./bin/gometalinter --disable-all --vendor --deadline=60s --enable=golint ./...
 
 
   test-core:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
         command: |
           go get -u golang.org/x/lint/golint
           curl -L https://git.io/vp6lP | sh # https://github.com/alecthomas/gometalinter#binary-releases
-          ./bin/gometalinter --disable-all --vendor --deadline=60s --enable=golint ./...
+          ./bin/gometalinter --disable-all --vendor --deadline=600s --enable=golint ./...
 
 
   test-core:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,13 +61,14 @@ jobs:
 
 
   test-core:
+    resource_class: xlarge
     <<: *plain-go113
 
     steps:
       - checkout
       - run:
           name: Testing
-          command: go test -v -timeout 60s -race `go list ./... | grep -v /contrib/`
+          command: go test -v -race `go list ./... | grep -v /contrib/`
 
   test-contrib:
     resource_class: xlarge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
       - checkout
       - run:
           name: Testing
-          command: go test -v -race `go list ./... | grep -v /contrib/`
+          command: go test -v -timeout 60s -race `go list ./... | grep -v /contrib/`
 
   test-contrib:
     resource_class: xlarge

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -195,9 +195,7 @@ func newConfig(opts ...StartOption) *config {
 	c := new(config)
 	c.sampler = NewAllSampler()
 	c.agentAddr = defaultAddress
-
 	c.loadEnv()
-
 	for _, fn := range opts {
 		fn(c)
 	}

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -158,8 +158,7 @@ func newConfig(opts ...StartOption) *config {
 				c.serviceName = s
 				globalconfig.SetServiceName(s)
 			}
-		}
-		else {
+		} else {
 			c.serviceName = filepath.Base(os.Args[0])
 		}
 	}

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -89,8 +89,10 @@ type config struct {
 // StartOption represents a function that can be provided as a parameter to Start.
 type StartOption func(*config)
 
-// loadEnv reads certain config values from the environment.
-func (c *config) loadEnv() {
+func newConfig(opts ...StartOption) *config {
+	c := new(config)
+	c.sampler = NewAllSampler()
+	c.agentAddr = defaultAddress
 	statsdHost, statsdPort := "localhost", "8125"
 	if v := os.Getenv("DD_AGENT_HOST"); v != "" {
 		statsdHost = v
@@ -133,23 +135,13 @@ func (c *config) loadEnv() {
 			}
 		}
 	}
-}
-
-// fallbackToTags checks if env, service, and version are set. If not,
-// it tries to load their values from globalTags.
-func (c *config) fallbackToTags() {
+	for _, fn := range opts {
+		fn(c)
+	}
 	if c.env == "" {
 		if v, ok := c.globalTags["env"]; ok {
 			if e, ok := v.(string); ok {
 				c.env = e
-			}
-		}
-	}
-	if c.serviceName == "" {
-		if v, ok := c.globalTags["service"]; ok {
-			if s, ok := v.(string); ok {
-				c.serviceName = s
-				globalconfig.SetServiceName(s)
 			}
 		}
 	}
@@ -160,13 +152,16 @@ func (c *config) fallbackToTags() {
 			}
 		}
 	}
-}
-
-// defaults ensures that certain fields in the tracer are set to their default
-// values, if a value has not been configured.
-func (c *config) defaults() {
 	if c.serviceName == "" {
-		c.serviceName = filepath.Base(os.Args[0])
+		if v, ok := c.globalTags["service"]; ok {
+			if s, ok := v.(string); ok {
+				c.serviceName = s
+				globalconfig.SetServiceName(s)
+			}
+		}
+		else {
+			c.serviceName = filepath.Base(os.Args[0])
+		}
 	}
 	if c.transport == nil {
 		c.transport = newTransport(c.agentAddr, c.httpClient)
@@ -189,18 +184,6 @@ func (c *config) defaults() {
 			c.statsd = client
 		}
 	}
-}
-
-func newConfig(opts ...StartOption) *config {
-	c := new(config)
-	c.sampler = NewAllSampler()
-	c.agentAddr = defaultAddress
-	c.loadEnv()
-	for _, fn := range opts {
-		fn(c)
-	}
-	c.fallbackToTags()
-	c.defaults()
 	return c
 }
 

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -8,10 +8,10 @@ package tracer
 import (
 	"math"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 
 	"github.com/stretchr/testify/assert"
@@ -32,8 +32,7 @@ func withTickChan(ch <-chan time.Time) StartOption {
 func TestTracerOptionsDefaults(t *testing.T) {
 	t.Run("defaults", func(t *testing.T) {
 		assert := assert.New(t)
-		var c config
-		defaults(&c)
+		c := newConfig()
 		assert.Equal(float64(1), c.sampler.(RateSampler).Rate())
 		assert.Equal("tracer.test", c.serviceName)
 		assert.Equal("localhost:8126", c.agentAddr)
@@ -90,7 +89,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			defer os.Unsetenv("DD_ENV")
 			tracer := newTracer()
 			c := tracer.config
-			assert.Equal(t, "testEnv", c.globalTags[ext.Environment])
+			assert.Equal(t, "testEnv", c.env)
 		})
 
 		t.Run("option", func(t *testing.T) {
@@ -107,7 +106,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		env := "production"
 		tracer := newTracer(WithEnv(env))
 		c := tracer.config
-		assert.Equal(env, c.globalTags[ext.Environment])
+		assert.Equal(env, c.env)
 	})
 
 	t.Run("other", func(t *testing.T) {
@@ -124,7 +123,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		assert.Equal("ddagent.consul.local:58126", c.agentAddr)
 		assert.NotNil(c.globalTags)
 		assert.Equal("v", c.globalTags["k"])
-		assert.Equal("testEnv", c.globalTags[ext.Environment])
+		assert.Equal("testEnv", c.env)
 		assert.True(c.debug)
 	})
 
@@ -133,8 +132,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		defer os.Unsetenv("DD_TAGS")
 
 		assert := assert.New(t)
-		var c config
-		defaults(&c)
+		c := newConfig()
 
 		assert.Equal("test", c.globalTags["env"])
 		assert.Equal("aVal", c.globalTags["aKey"])
@@ -149,46 +147,210 @@ func TestTracerOptionsDefaults(t *testing.T) {
 
 func TestServiceName(t *testing.T) {
 	t.Run("WithServiceName", func(t *testing.T) {
+		defer globalconfig.SetServiceName("")
 		assert := assert.New(t)
-		tracer := newTracer(
+		c := newConfig(
 			WithServiceName("api-intake"),
 		)
 
-		assert.Equal("api-intake", tracer.config.serviceName)
+		assert.Equal("api-intake", c.serviceName)
 		assert.Equal("", globalconfig.ServiceName())
 	})
 
 	t.Run("WithService", func(t *testing.T) {
+		defer globalconfig.SetServiceName("")
 		assert := assert.New(t)
-		tracer := newTracer(
+		c := newConfig(
 			WithService("api-intake"),
 		)
-		assert.Equal("api-intake", tracer.config.serviceName)
+		assert.Equal("api-intake", c.serviceName)
 		assert.Equal("api-intake", globalconfig.ServiceName())
 	})
 
 	t.Run("env", func(t *testing.T) {
+		defer globalconfig.SetServiceName("")
 		os.Setenv("DD_SERVICE", "api-intake")
 		defer os.Unsetenv("DD_SERVICE")
 		assert := assert.New(t)
-		tracer := newTracer()
+		c := newConfig()
 
-		assert.Equal("api-intake", tracer.config.serviceName)
+		assert.Equal("api-intake", c.serviceName)
 		assert.Equal("api-intake", globalconfig.ServiceName())
 	})
 
-	t.Run("combo", func(t *testing.T) {
-		os.Setenv("DD_SERVICE", "api-intake")
-		defer os.Unsetenv("DD_SERVICE")
+	t.Run("WithGlobalTag", func(t *testing.T) {
+		defer globalconfig.SetServiceName("")
 		assert := assert.New(t)
-
-		tracer := newTracer(
-			WithServiceName("api-intake"),
-		)
-
-		assert.Equal("api-intake", tracer.config.serviceName)
-		assert.Equal("", globalconfig.ServiceName())
+		c := newConfig(WithGlobalTag("service", "api-intake"))
+		assert.Equal("api-intake", c.serviceName)
+		assert.Equal("api-intake", globalconfig.ServiceName())
 	})
+
+	t.Run("DD_TAGS", func(t *testing.T) {
+		defer globalconfig.SetServiceName("")
+		os.Setenv("DD_TAGS", "service:api-intake")
+		defer os.Unsetenv("DD_TAGS")
+		assert := assert.New(t)
+		c := newConfig()
+
+		assert.Equal("api-intake", c.serviceName)
+		assert.Equal("api-intake", globalconfig.ServiceName())
+	})
+
+	t.Run("override-chain", func(t *testing.T) {
+		assert := assert.New(t)
+		globalconfig.SetServiceName("")
+		c := newConfig()
+		assert.Equal(c.serviceName, filepath.Base(os.Args[0]))
+		assert.Equal("", globalconfig.ServiceName())
+
+		os.Setenv("DD_TAGS", "service:testService")
+		defer os.Unsetenv("DD_TAGS")
+		globalconfig.SetServiceName("")
+		c = newConfig()
+		assert.Equal(c.serviceName, "testService")
+		assert.Equal("testService", globalconfig.ServiceName())
+
+		globalconfig.SetServiceName("")
+		c = newConfig(WithGlobalTag("service", "testService2"))
+		assert.Equal(c.serviceName, "testService2")
+		assert.Equal("testService2", globalconfig.ServiceName())
+
+		os.Setenv("DD_SERVICE", "testService3")
+		defer os.Unsetenv("DD_SERVICE")
+		globalconfig.SetServiceName("")
+		c = newConfig(WithGlobalTag("service", "testService2"))
+		assert.Equal(c.serviceName, "testService3")
+		assert.Equal("testService3", globalconfig.ServiceName())
+
+		globalconfig.SetServiceName("")
+		c = newConfig(WithGlobalTag("service", "testService2"), WithService("testService4"))
+		assert.Equal(c.serviceName, "testService4")
+		assert.Equal("testService4", globalconfig.ServiceName())
+	})
+}
+
+func TestVersionConfig(t *testing.T) {
+	t.Run("WithServiceVersion", func(t *testing.T) {
+		assert := assert.New(t)
+		c := newConfig(
+			WithServiceVersion("1.2.3"),
+		)
+		assert.Equal("1.2.3", c.version)
+	})
+
+	t.Run("env", func(t *testing.T) {
+		os.Setenv("DD_VERSION", "1.2.3")
+		defer os.Unsetenv("DD_VERSION")
+		assert := assert.New(t)
+		c := newConfig()
+
+		assert.Equal("1.2.3", c.version)
+	})
+
+	t.Run("WithGlobalTag", func(t *testing.T) {
+		assert := assert.New(t)
+		c := newConfig(WithGlobalTag("version", "1.2.3"))
+		assert.Equal("1.2.3", c.version)
+	})
+
+	t.Run("DD_TAGS", func(t *testing.T) {
+		os.Setenv("DD_TAGS", "version:1.2.3")
+		defer os.Unsetenv("DD_TAGS")
+		assert := assert.New(t)
+		c := newConfig()
+
+		assert.Equal("1.2.3", c.version)
+	})
+
+	t.Run("override-chain", func(t *testing.T) {
+		assert := assert.New(t)
+		c := newConfig()
+		assert.Equal(c.version, "")
+
+		os.Setenv("DD_TAGS", "version:1.1.1")
+		defer os.Unsetenv("DD_TAGS")
+		c = newConfig()
+		assert.Equal("1.1.1", c.version)
+
+		c = newConfig(WithGlobalTag("version", "1.1.2"))
+		assert.Equal("1.1.2", c.version)
+
+		os.Setenv("DD_VERSION", "1.1.3")
+		defer os.Unsetenv("DD_VERSION")
+		c = newConfig(WithGlobalTag("version", "1.1.2"))
+		assert.Equal("1.1.3", c.version)
+
+		c = newConfig(WithGlobalTag("version", "1.1.2"), WithServiceVersion("1.1.4"))
+		assert.Equal("1.1.4", c.version)
+	})
+}
+
+func TestEnvConfig(t *testing.T) {
+	t.Run("WithEnv", func(t *testing.T) {
+		assert := assert.New(t)
+		c := newConfig(
+			WithEnv("testing"),
+		)
+		assert.Equal("testing", c.env)
+	})
+
+	t.Run("env", func(t *testing.T) {
+		os.Setenv("DD_ENV", "testing")
+		defer os.Unsetenv("DD_ENV")
+		assert := assert.New(t)
+		c := newConfig()
+
+		assert.Equal("testing", c.env)
+	})
+
+	t.Run("WithGlobalTag", func(t *testing.T) {
+		assert := assert.New(t)
+		c := newConfig(WithGlobalTag("env", "testing"))
+		assert.Equal("testing", c.env)
+	})
+
+	t.Run("DD_TAGS", func(t *testing.T) {
+		os.Setenv("DD_TAGS", "env:testing")
+		defer os.Unsetenv("DD_TAGS")
+		assert := assert.New(t)
+		c := newConfig()
+
+		assert.Equal("testing", c.env)
+	})
+
+	t.Run("override-chain", func(t *testing.T) {
+		assert := assert.New(t)
+		c := newConfig()
+		assert.Equal(c.env, "")
+
+		os.Setenv("DD_TAGS", "env:testing1")
+		defer os.Unsetenv("DD_TAGS")
+		c = newConfig()
+		assert.Equal("testing1", c.env)
+
+		c = newConfig(WithGlobalTag("env", "testing2"))
+		assert.Equal("testing2", c.env)
+
+		os.Setenv("DD_ENV", "testing3")
+		defer os.Unsetenv("DD_ENV")
+		c = newConfig(WithGlobalTag("env", "testing2"))
+		assert.Equal("testing3", c.env)
+
+		c = newConfig(WithGlobalTag("env", "testing2"), WithEnv("testing4"))
+		assert.Equal("testing4", c.env)
+	})
+}
+
+func TestStatsTags(t *testing.T) {
+	assert := assert.New(t)
+	c := newConfig(WithService("serviceName"), WithEnv("envName"))
+	c.hostname = "hostName"
+	tags := statsTags(c)
+
+	assert.Contains(tags, "service:serviceName")
+	assert.Contains(tags, "env:envName")
+	assert.Contains(tags, "host:hostName")
 }
 
 func TestGlobalTag(t *testing.T) {

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -350,8 +350,8 @@ func (s *span) Format(f fmt.State, c rune) {
 			fmt.Fprintf(f, "dd.service=%s ", svc)
 		}
 		if tr, ok := internal.GetGlobalTracer().(*tracer); ok {
-			if env, ok := tr.config.globalTags[ext.Environment]; ok {
-				fmt.Fprintf(f, "dd.env=%s ", env)
+			if tr.config.env != "" {
+				fmt.Fprintf(f, "dd.env=%s ", tr.config.env)
 			}
 			if tr.config.version != "" {
 				fmt.Fprintf(f, "dd.version=%s ", tr.config.version)

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1015,23 +1015,7 @@ func TestTracerReportsHostname(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
-	t.Run("env", func(t *testing.T) {
-		os.Setenv("DD_VERSION", "1.2.3")
-		defer os.Unsetenv("DD_VERSION")
-
-		tracer, _, _, stop := startTestTracer(t)
-		defer stop()
-
-		assert := assert.New(t)
-		sp := tracer.StartSpan("http.request").(*span)
-		v := sp.Meta[ext.Version]
-		assert.Equal("1.2.3", v)
-	})
-
-	t.Run("option", func(t *testing.T) {
-		os.Setenv("DD_VERSION", "1.2.3")
-		defer os.Unsetenv("DD_VERSION")
-
+	t.Run("normal", func(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t, WithServiceVersion("4.5.6"))
 		defer stop()
 
@@ -1042,25 +1026,7 @@ func TestVersion(t *testing.T) {
 	})
 
 	t.Run("unset", func(t *testing.T) {
-		os.Setenv("DD_VERSION", "1.2.3")
-		defer os.Unsetenv("DD_VERSION")
-
-		tracer, _, _, stop := startTestTracer(t, WithService("servenv"))
-		defer stop()
-
-		assert := assert.New(t)
-		sp := tracer.StartSpan("http.request", ServiceName("otherservenv")).(*span)
-		_, ok := sp.Meta[ext.Version]
-		assert.False(ok)
-	})
-
-	t.Run("unset2", func(t *testing.T) {
-		os.Setenv("DD_SERVICE", "servenv")
-		defer os.Unsetenv("DD_SERVICE")
-		os.Setenv("DD_VERSION", "1.2.3")
-		defer os.Unsetenv("DD_VERSION")
-
-		tracer, _, _, stop := startTestTracer(t)
+		tracer, _, _, stop := startTestTracer(t, WithServiceVersion("4.5.6"), WithService("servenv"))
 		defer stop()
 
 		assert := assert.New(t)


### PR DESCRIPTION
This commit adds support for setting env, version, and service vio DD_TAGS.
It also adds tests to ensure the correct precedence for the various ways to
set the variables.

The order of precedence for the various ways to set these variables in the
tracer is:
1. Tracer StartOption: If the tracer is configured with StartOptions that
	set env, version, or service, those will be the values
2. Environment variables: DD_ENV, DD_SERVICE, DD_VERSION
3. From tags set by WithGlobalTag
4. As the tags version, env, and service from DD_TAGS
5. Default or empty (service: binary name, env: unset, version: unset)