### PR TITLE
contrib/go.mongodb.org/mongo-driver: add span type

### DIFF
--- a/contrib/go.mongodb.org/mongo-driver/mongo/mongo.go
+++ b/contrib/go.mongodb.org/mongo-driver/mongo/mongo.go
@@ -39,6 +39,7 @@ func (m *monitor) Started(ctx context.Context, evt *event.CommandStartedEvent) {
 	hostname, port := peerInfo(evt)
 	b, _ := bson.MarshalExtJSON(evt.Command, false, false)
 	opts := []ddtrace.StartSpanOption{
+		tracer.SpanType(ext.SpanTypeMongoDB),
 		tracer.ServiceName(m.cfg.serviceName),
 		tracer.ResourceName("mongo." + evt.CommandName),
 		tracer.Tag(ext.DBInstance, evt.DatabaseName),

--- a/contrib/go.mongodb.org/mongo-driver/mongo/mongo_test.go
+++ b/contrib/go.mongodb.org/mongo-driver/mongo/mongo_test.go
@@ -65,6 +65,7 @@ func Test(t *testing.T) {
 	assert.Equal(t, spans[0].TraceID(), spans[1].TraceID())
 
 	s := spans[0]
+	assert.Equal(t, ext.SpanTypeMongoDB, s.Tag(ext.SpanType))
 	assert.Equal(t, "mongo", s.Tag(ext.ServiceName))
 	assert.Equal(t, "mongo.insert", s.Tag(ext.ResourceName))
 	assert.Equal(t, hostname, s.Tag(ext.PeerHostname))


### PR DESCRIPTION
This was reported to Datadog support. Without specifying a span type, the span renders as "custom".
Added the tag and updated the test to ensure it's set. This matches `contrib/globalsign/mgo`.