### PR TITLE
circleci: pin down grpc@v1.28.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,9 @@ jobs:
       - run:
           name: Testing
           command: |
-                INTEGRATION=1 go test -v -race `go list ./contrib/... | grep -v grpc.v12`
+                INTEGRATION=1 go test -v -race `go list ./contrib/... | grep -v -e grpc.v12 -e google.golang.org/api`
+                go get google.golang.org/grpc@v1.29.0 # https://github.com/grpc/grpc-go/issues/3726
+                go test -v ./contrib/google.golang.org/api/...
                 go get google.golang.org/grpc@v1.2.0
                 go test -v ./contrib/google.golang.org/grpc.v12/...
 


### PR DESCRIPTION
During the latest `google.golang.org/grpc` release (v1.30.0) the
deprecated `naming` package was removed, which in turn [breaks](https://github.com/googleapis/google-api-go-client/blob/v0.28.0/go.mod#L17)
`google.golang.org/api` when used as part of a repository having the
latest grpc.

This is a temporary change until the bigger problem is resolved.

See https://github.com/grpc/grpc-go/issues/3726