### PR TITLE
ddtrace/tracer: add support for DD_TRACE_ANALYTICS_ENABLED env. var.

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -94,6 +94,8 @@ type config struct {
 // StartOption represents a function that can be provided as a parameter to Start.
 type StartOption func(*config)
 
+// newConfig renders the tracer configuration based on defaults, environment variables
+// and passed user opts.
 func newConfig(opts ...StartOption) *config {
 	c := new(config)
 	c.sampler = NewAllSampler()
@@ -107,6 +109,9 @@ func newConfig(opts ...StartOption) *config {
 	}
 	c.dogstatsdAddr = net.JoinHostPort(statsdHost, statsdPort)
 
+	if v := os.Getenv("DD_TRACE_ANALYTICS_ENABLED"); v != "" {
+		globalconfig.SetAnalyticsRate(1.0)
+	}
 	if os.Getenv("DD_TRACE_REPORT_HOSTNAME") == "true" {
 		var err error
 		c.hostname, err = os.Hostname()

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -109,10 +109,8 @@ func newConfig(opts ...StartOption) *config {
 	}
 	c.dogstatsdAddr = net.JoinHostPort(statsdHost, statsdPort)
 
-	if v := os.Getenv("DD_TRACE_ANALYTICS_ENABLED"); v != "" {
-		if on, err := strconv.ParseBool(v); err == nil && on {
-			globalconfig.SetAnalyticsRate(1.0)
-		}
+	if boolEnv("DD_TRACE_ANALYTICS_ENABLED", false) {
+		globalconfig.SetAnalyticsRate(1.0)
 	}
 	if os.Getenv("DD_TRACE_REPORT_HOSTNAME") == "true" {
 		var err error

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -110,7 +110,9 @@ func newConfig(opts ...StartOption) *config {
 	c.dogstatsdAddr = net.JoinHostPort(statsdHost, statsdPort)
 
 	if v := os.Getenv("DD_TRACE_ANALYTICS_ENABLED"); v != "" {
-		globalconfig.SetAnalyticsRate(1.0)
+		if on, err := strconv.ParseBool(v); err == nil && on {
+			globalconfig.SetAnalyticsRate(1.0)
+		}
 	}
 	if os.Getenv("DD_TRACE_REPORT_HOSTNAME") == "true" {
 		var err error

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -41,14 +41,33 @@ func TestTracerOptionsDefaults(t *testing.T) {
 	})
 
 	t.Run("analytics", func(t *testing.T) {
-		assert := assert.New(t)
-		assert.True(math.IsNaN(globalconfig.AnalyticsRate()))
-		newTracer(WithAnalyticsRate(0.5))
-		assert.Equal(0.5, globalconfig.AnalyticsRate())
-		newTracer(WithAnalytics(false))
-		assert.True(math.IsNaN(globalconfig.AnalyticsRate()))
-		newTracer(WithAnalytics(true))
-		assert.Equal(1., globalconfig.AnalyticsRate())
+		t.Run("option", func(t *testing.T) {
+			defer globalconfig.SetAnalyticsRate(math.NaN())
+			assert := assert.New(t)
+			assert.True(math.IsNaN(globalconfig.AnalyticsRate()))
+			newTracer(WithAnalyticsRate(0.5))
+			assert.Equal(0.5, globalconfig.AnalyticsRate())
+			newTracer(WithAnalytics(false))
+			assert.True(math.IsNaN(globalconfig.AnalyticsRate()))
+			newTracer(WithAnalytics(true))
+			assert.Equal(1., globalconfig.AnalyticsRate())
+		})
+
+		t.Run("env/on", func(t *testing.T) {
+			os.Setenv("DD_TRACE_ANALYTICS_ENABLED", "true")
+			defer os.Unsetenv("DD_TRACE_ANALYTICS_ENABLED")
+			defer globalconfig.SetAnalyticsRate(math.NaN())
+			newConfig()
+			assert.Equal(t, 1.0, globalconfig.AnalyticsRate())
+		})
+
+		t.Run("env/off", func(t *testing.T) {
+			os.Setenv("DD_TRACE_ANALYTICS_ENABLED", "kj12")
+			defer os.Unsetenv("DD_TRACE_ANALYTICS_ENABLED")
+			defer globalconfig.SetAnalyticsRate(math.NaN())
+			newConfig()
+			assert.True(t, math.IsNaN(globalconfig.AnalyticsRate()))
+		})
 	})
 
 	t.Run("dogstatsd", func(t *testing.T) {


### PR DESCRIPTION
This change adds support for the DD_TRACE_ANALYTICS_ENABLED environment
variable, which will enable App Analytics for web integrations.