### PR TITLE
all: add runtime-id to profiler and tracer global tags.

### DIFF
--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -82,4 +82,7 @@ const (
 	// ManualDrop is a tag which specifies that the trace to which this span
 	// belongs to should be dropped when set to true.
 	ManualDrop = "manual.drop"
+
+	// RuntimeID is a tag that contains a unique id for this process.
+	RuntimeID = "runtime-id"
 )

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -138,7 +138,7 @@ func newConfig(opts ...StartOption) *config {
 	for _, fn := range opts {
 		fn(c)
 	}
-	WithGlobalTag(ext.RuntimeID, globalconfig.GetRuntimeID())(c)
+	WithGlobalTag(ext.RuntimeID, globalconfig.RuntimeID())(c)
 	if c.env == "" {
 		if v, ok := c.globalTags["env"]; ok {
 			if e, ok := v.(string); ok {

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -138,6 +138,7 @@ func newConfig(opts ...StartOption) *config {
 	for _, fn := range opts {
 		fn(c)
 	}
+	WithGlobalTag(ext.RuntimeID, globalconfig.GetRuntimeID())(c)
 	if c.env == "" {
 		if v, ok := c.globalTags["env"]; ok {
 			if e, ok := v.(string); ok {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -191,7 +191,8 @@ func TestTracerStartSpan(t *testing.T) {
 		// A span is not measured unless made so specifically
 		_, ok := span.Meta[keyMeasured]
 		assert.False(ok)
-		assert.Equal(globalconfig.GetRuntimeID(), span.Meta[ext.RuntimeID])
+		assert.Equal(globalconfig.RuntimeID(), span.Meta[ext.RuntimeID])
+		assert.NotEqual("", span.Meta[ext.RuntimeID])
 	})
 
 	t.Run("priority", func(t *testing.T) {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -21,6 +21,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 
 	"github.com/stretchr/testify/assert"
@@ -190,6 +191,7 @@ func TestTracerStartSpan(t *testing.T) {
 		// A span is not measured unless made so specifically
 		_, ok := span.Meta[keyMeasured]
 		assert.False(ok)
+		assert.Equal(globalconfig.GetRuntimeID(), span.Meta[ext.RuntimeID])
 	})
 
 	t.Run("priority", func(t *testing.T) {

--- a/internal/globalconfig/globalconfig.go
+++ b/internal/globalconfig/globalconfig.go
@@ -56,8 +56,8 @@ func SetServiceName(name string) {
 	cfg.serviceName = name
 }
 
-// GetRuntimeID returns this process's unique runtime id.
-func GetRuntimeID() string {
+// RuntimeID returns this process's unique runtime id.
+func RuntimeID() string {
 	cfg.mu.RLock()
 	defer cfg.mu.RUnlock()
 	return cfg.runtimeID

--- a/internal/globalconfig/globalconfig.go
+++ b/internal/globalconfig/globalconfig.go
@@ -10,16 +10,20 @@ package globalconfig
 import (
 	"math"
 	"sync"
+
+	"github.com/google/uuid"
 )
 
 var cfg = &config{
 	analyticsRate: math.NaN(),
+	runtimeID:     uuid.New().String(),
 }
 
 type config struct {
 	mu            sync.RWMutex
 	analyticsRate float64
 	serviceName   string
+	runtimeID     string
 }
 
 // AnalyticsRate returns the sampling rate at which events should be marked. It uses
@@ -50,4 +54,10 @@ func SetServiceName(name string) {
 	cfg.mu.Lock()
 	defer cfg.mu.Unlock()
 	cfg.serviceName = name
+}
+
+func GetRuntimeID() string {
+	cfg.mu.RLock()
+	defer cfg.mu.RUnlock()
+	return cfg.runtimeID
 }

--- a/internal/globalconfig/globalconfig.go
+++ b/internal/globalconfig/globalconfig.go
@@ -56,6 +56,7 @@ func SetServiceName(name string) {
 	cfg.serviceName = name
 }
 
+// GetRuntimeID returns this process's unique runtime id.
 func GetRuntimeID() string {
 	cfg.mu.RLock()
 	defer cfg.mu.RUnlock()

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/version"
 
@@ -131,6 +132,7 @@ func defaultConfig() *config {
 		"runtime_compiler:"+runtime.Compiler,
 		"runtime_arch:"+runtime.GOARCH,
 		"runtime_os:"+runtime.GOOS,
+		"runtime-id:"+globalconfig.GetRuntimeID(),
 	)(&c)
 	// not for public use
 	if v := os.Getenv("DD_PROFILING_URL"); v != "" {

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -132,7 +132,7 @@ func defaultConfig() *config {
 		"runtime_compiler:"+runtime.Compiler,
 		"runtime_arch:"+runtime.GOARCH,
 		"runtime_os:"+runtime.GOOS,
-		"runtime-id:"+globalconfig.GetRuntimeID(),
+		"runtime-id:"+globalconfig.RuntimeID(),
 	)(&c)
 	// not for public use
 	if v := os.Getenv("DD_PROFILING_URL"); v != "" {

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
 func TestOptions(t *testing.T) {
@@ -242,6 +243,7 @@ func TestDefaultConfig(t *testing.T) {
 		assert.Equal(DefaultDuration, cfg.cpuDuration)
 		assert.Equal(DefaultMutexFraction, cfg.mutexFraction)
 		assert.Equal(DefaultBlockRate, cfg.blockRate)
+		assert.Contains(cfg.tags, "runtime-id:"+globalconfig.GetRuntimeID())
 	})
 }
 

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -243,7 +243,7 @@ func TestDefaultConfig(t *testing.T) {
 		assert.Equal(DefaultDuration, cfg.cpuDuration)
 		assert.Equal(DefaultMutexFraction, cfg.mutexFraction)
 		assert.Equal(DefaultBlockRate, cfg.blockRate)
-		assert.Contains(cfg.tags, "runtime-id:"+globalconfig.GetRuntimeID())
+		assert.Contains(cfg.tags, "runtime-id:"+globalconfig.RuntimeID())
 	})
 }
 

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -8,7 +8,6 @@ package profiler
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
 	"runtime/pprof"
 	"time"
@@ -30,8 +29,6 @@ const (
 	// MutexProfile reports the lock contentions. When you think your CPU is not fully utilized due
 	// to a mutex contention, use this profile. Mutex profile is not enabled by default.
 	MutexProfile
-	// GoroutineProfile reports stack traces of all current goroutines
-	GoroutineProfile
 )
 
 func (t ProfileType) String() string {
@@ -44,8 +41,6 @@ func (t ProfileType) String() string {
 		return "mutex"
 	case BlockProfile:
 		return "block"
-	case GoroutineProfile:
-		return "goroutine"
 	default:
 		return "unknown"
 	}
@@ -80,8 +75,6 @@ func (p *profiler) runProfile(t ProfileType) (*profile, error) {
 		return mutexProfile(p.cfg)
 	case BlockProfile:
 		return blockProfile(p.cfg)
-	case GoroutineProfile:
-		return goroutineProfile(p.cfg)
 	default:
 		return nil, errors.New("profile type not implemented")
 	}
@@ -167,10 +160,6 @@ func mutexProfile(cfg *config) (*profile, error) {
 		types: []string{"contentions"},
 		data:  buf.Bytes(),
 	}, nil
-}
-
-func goroutineProfile(cfg *config) (*profile, error) {
-	return nil, fmt.Errorf("Goroutine profile not available yet.")
 }
 
 // now returns current time in UTC.

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -8,6 +8,7 @@ package profiler
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"runtime/pprof"
 	"time"
@@ -29,6 +30,8 @@ const (
 	// MutexProfile reports the lock contentions. When you think your CPU is not fully utilized due
 	// to a mutex contention, use this profile. Mutex profile is not enabled by default.
 	MutexProfile
+	// GoroutineProfile reports stack traces of all current goroutines
+	GoroutineProfile
 )
 
 func (t ProfileType) String() string {
@@ -41,6 +44,8 @@ func (t ProfileType) String() string {
 		return "mutex"
 	case BlockProfile:
 		return "block"
+	case GoroutineProfile:
+		return "goroutine"
 	default:
 		return "unknown"
 	}
@@ -75,6 +80,8 @@ func (p *profiler) runProfile(t ProfileType) (*profile, error) {
 		return mutexProfile(p.cfg)
 	case BlockProfile:
 		return blockProfile(p.cfg)
+	case GoroutineProfile:
+		return goroutineProfile(p.cfg)
 	default:
 		return nil, errors.New("profile type not implemented")
 	}
@@ -160,6 +167,10 @@ func mutexProfile(cfg *config) (*profile, error) {
 		types: []string{"contentions"},
 		data:  buf.Bytes(),
 	}, nil
+}
+
+func goroutineProfile(cfg *config) (*profile, error) {
+	return nil, fmt.Errorf("Goroutine profile not available yet.")
 }
 
 // now returns current time in UTC.

--- a/profiler/upload_test.go
+++ b/profiler/upload_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/version"
 
 	"github.com/stretchr/testify/assert"
@@ -75,6 +76,7 @@ func TestTryUpload(t *testing.T) {
 		fmt.Sprintf("runtime_compiler:%s", runtime.Compiler),
 		fmt.Sprintf("runtime_arch:%s", runtime.GOARCH),
 		fmt.Sprintf("runtime_os:%s", runtime.GOOS),
+		fmt.Sprintf("runtime-id:%s", globalconfig.GetRuntimeID()),
 	}, tags)
 	for k, v := range map[string]string{
 		"format":   "pprof",

--- a/profiler/upload_test.go
+++ b/profiler/upload_test.go
@@ -76,7 +76,7 @@ func TestTryUpload(t *testing.T) {
 		fmt.Sprintf("runtime_compiler:%s", runtime.Compiler),
 		fmt.Sprintf("runtime_arch:%s", runtime.GOARCH),
 		fmt.Sprintf("runtime_os:%s", runtime.GOOS),
-		fmt.Sprintf("runtime-id:%s", globalconfig.GetRuntimeID()),
+		fmt.Sprintf("runtime-id:%s", globalconfig.RuntimeID()),
 	}, tags)
 	for k, v := range map[string]string{
 		"format":   "pprof",


### PR DESCRIPTION
This commit adds a `runtime-id` tag to the global tags in the tracer and the profiler. The `runtime-id` is a per-process random UUID that identifies a running process, and allows us to link traces and profiles from the same process.