### PR TITLE
ddtrace/tracer: add support for various environment variables

### DIFF
--- a/contrib/Shopify/sarama/option.go
+++ b/contrib/Shopify/sarama/option.go
@@ -8,6 +8,7 @@ package sarama
 import (
 	"math"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
@@ -24,7 +25,11 @@ func defaults(cfg *config) {
 		cfg.consumerServiceName = svc
 	}
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
-	cfg.analyticsRate = math.NaN()
+	if internal.BoolEnv("DD_TRACE_SARAMA_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = math.NaN()
+	}
 }
 
 // An Option is used to customize the config for the sarama tracer.

--- a/contrib/aws/aws-sdk-go/aws/option.go
+++ b/contrib/aws/aws-sdk-go/aws/option.go
@@ -7,6 +7,8 @@ package aws
 
 import (
 	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 )
 
 type config struct {
@@ -19,7 +21,11 @@ type Option func(*config)
 
 func defaults(cfg *config) {
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
-	cfg.analyticsRate = math.NaN()
+	if internal.BoolEnv("DD_TRACE_AWS_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = math.NaN()
+	}
 }
 
 // WithServiceName sets the given service name for the dialled connection.

--- a/contrib/bradfitz/gomemcache/memcache/option.go
+++ b/contrib/bradfitz/gomemcache/memcache/option.go
@@ -7,6 +7,8 @@ package memcache
 
 import (
 	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 )
 
 const (
@@ -25,7 +27,11 @@ type ClientOption func(*clientConfig)
 func defaults(cfg *clientConfig) {
 	cfg.serviceName = serviceName
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
-	cfg.analyticsRate = math.NaN()
+	if internal.BoolEnv("DD_TRACE_MEMCACHE_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = math.NaN()
+	}
 }
 
 // WithServiceName sets the given service name for the dialled connection.

--- a/contrib/confluentinc/confluent-kafka-go/kafka/option.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/option.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"math"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
@@ -29,6 +30,9 @@ func newConfig(opts ...Option) *config {
 		producerServiceName: "kafka",
 		// analyticsRate: globalconfig.AnalyticsRate(),
 		analyticsRate: math.NaN(),
+	}
+	if internal.BoolEnv("DD_TRACE_KAFKA_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
 	}
 	if svc := globalconfig.ServiceName(); svc != "" {
 		cfg.consumerServiceName = svc

--- a/contrib/database/sql/option.go
+++ b/contrib/database/sql/option.go
@@ -7,6 +7,8 @@ package sql
 
 import (
 	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 )
 
 type config struct {
@@ -26,7 +28,11 @@ type RegisterOption = Option
 func defaults(cfg *config) {
 	// default cfg.serviceName set in Register based on driver name
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
-	cfg.analyticsRate = math.NaN()
+	if internal.BoolEnv("DD_TRACE_SQL_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = math.NaN()
+	}
 }
 
 // WithServiceName sets the given service name when registering a driver,

--- a/contrib/emicklei/go-restful/option.go
+++ b/contrib/emicklei/go-restful/option.go
@@ -8,6 +8,7 @@ package restful
 import (
 	"math"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
@@ -17,9 +18,13 @@ type config struct {
 }
 
 func newConfig() *config {
+	rate := globalconfig.AnalyticsRate()
+	if internal.BoolEnv("DD_TRACE_RESTFUL_ANALYTICS_ENABLED", false) {
+		rate = 1.0
+	}
 	return &config{
 		serviceName:   "go-restful",
-		analyticsRate: globalconfig.AnalyticsRate(),
+		analyticsRate: rate,
 	}
 }
 

--- a/contrib/garyburd/redigo/option.go
+++ b/contrib/garyburd/redigo/option.go
@@ -7,6 +7,8 @@ package redigo // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/garyburd/redig
 
 import (
 	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 )
 
 type dialConfig struct {
@@ -20,7 +22,11 @@ type DialOption func(*dialConfig)
 func defaults(cfg *dialConfig) {
 	cfg.serviceName = "redis.conn"
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
-	cfg.analyticsRate = math.NaN()
+	if internal.BoolEnv("DD_TRACE_REDIGO_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = math.NaN()
+	}
 }
 
 // WithServiceName sets the given service name for the dialled connection.

--- a/contrib/gin-gonic/gin/option.go
+++ b/contrib/gin-gonic/gin/option.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
@@ -19,8 +20,12 @@ type config struct {
 }
 
 func newConfig() *config {
+	rate := globalconfig.AnalyticsRate()
+	if internal.BoolEnv("DD_TRACE_GIN_ANALYTICS_ENABLED", false) {
+		rate = 1.0
+	}
 	return &config{
-		analyticsRate: globalconfig.AnalyticsRate(),
+		analyticsRate: rate,
 		resourceNamer: defaultResourceNamer,
 	}
 }

--- a/contrib/globalsign/mgo/option.go
+++ b/contrib/globalsign/mgo/option.go
@@ -8,6 +8,8 @@ package mgo
 import (
 	"context"
 	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 )
 
 type mongoConfig struct {
@@ -17,11 +19,15 @@ type mongoConfig struct {
 }
 
 func newConfig() *mongoConfig {
+	rate := math.NaN()
+	if internal.BoolEnv("DD_TRACE_GIN_ANALYTICS_ENABLED", false) {
+		rate = 1.0
+	}
 	return &mongoConfig{
 		serviceName: "mongodb",
 		ctx:         context.Background(),
 		// analyticsRate: globalconfig.AnalyticsRate(),
-		analyticsRate: math.NaN(),
+		analyticsRate: rate,
 	}
 }
 

--- a/contrib/go-chi/chi/option.go
+++ b/contrib/go-chi/chi/option.go
@@ -9,6 +9,7 @@ import (
 	"math"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
@@ -26,7 +27,11 @@ func defaults(cfg *config) {
 	if svc := globalconfig.ServiceName(); svc != "" {
 		cfg.serviceName = svc
 	}
-	cfg.analyticsRate = globalconfig.AnalyticsRate()
+	if internal.BoolEnv("DD_TRACE_CHI_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = globalconfig.AnalyticsRate()
+	}
 }
 
 // WithServiceName sets the given service name for the router.

--- a/contrib/go-redis/redis/option.go
+++ b/contrib/go-redis/redis/option.go
@@ -7,6 +7,8 @@ package redis // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/go-redis/redis"
 
 import (
 	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 )
 
 type clientConfig struct {
@@ -20,7 +22,11 @@ type ClientOption func(*clientConfig)
 func defaults(cfg *clientConfig) {
 	cfg.serviceName = "redis.client"
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
-	cfg.analyticsRate = math.NaN()
+	if internal.BoolEnv("DD_TRACE_REDIS_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = math.NaN()
+	}
 }
 
 // WithServiceName sets the given service name for the client.

--- a/contrib/go.mongodb.org/mongo-driver/mongo/option.go
+++ b/contrib/go.mongodb.org/mongo-driver/mongo/option.go
@@ -7,6 +7,8 @@ package mongo
 
 import (
 	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 )
 
 type config struct {
@@ -20,7 +22,11 @@ type Option func(*config)
 func defaults(cfg *config) {
 	cfg.serviceName = "mongo"
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
-	cfg.analyticsRate = math.NaN()
+	if internal.BoolEnv("DD_TRACE_MONGO_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = math.NaN()
+	}
 }
 
 // WithServiceName sets the given service name for the dialled connection.

--- a/contrib/gocql/gocql/option.go
+++ b/contrib/gocql/gocql/option.go
@@ -7,6 +7,8 @@ package gocql
 
 import (
 	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 )
 
 type queryConfig struct {
@@ -21,7 +23,11 @@ type WrapOption func(*queryConfig)
 func defaults(cfg *queryConfig) {
 	cfg.serviceName = "gocql.query"
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
-	cfg.analyticsRate = math.NaN()
+	if internal.BoolEnv("DD_TRACE_GOCQL_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = math.NaN()
+	}
 }
 
 // WithServiceName sets the given service name for the returned query.

--- a/contrib/gomodule/redigo/option.go
+++ b/contrib/gomodule/redigo/option.go
@@ -7,6 +7,8 @@ package redigo // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/gomodule/redig
 
 import (
 	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 )
 
 type dialConfig struct {
@@ -20,7 +22,11 @@ type DialOption func(*dialConfig)
 func defaults(cfg *dialConfig) {
 	cfg.serviceName = "redis.conn"
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
-	cfg.analyticsRate = math.NaN()
+	if internal.BoolEnv("DD_TRACE_REDIGO_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = math.NaN()
+	}
 }
 
 // WithServiceName sets the given service name for the dialled connection.

--- a/contrib/google.golang.org/api/option.go
+++ b/contrib/google.golang.org/api/option.go
@@ -8,6 +8,8 @@ package api
 import (
 	"context"
 	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 )
 
 type config struct {
@@ -18,10 +20,14 @@ type config struct {
 }
 
 func newConfig(options ...Option) *config {
+	rate := math.NaN()
+	if internal.BoolEnv("DD_TRACE_GOOGLE_API_ANALYTICS_ENABLED", false) {
+		rate = 1.0
+	}
 	cfg := &config{
 		ctx: context.Background(),
 		// analyticsRate: globalconfig.AnalyticsRate(),
-		analyticsRate: math.NaN(),
+		analyticsRate: rate,
 	}
 	for _, opt := range options {
 		opt(cfg)

--- a/contrib/google.golang.org/grpc.v12/option.go
+++ b/contrib/google.golang.org/grpc.v12/option.go
@@ -7,6 +7,8 @@ package grpc
 
 import (
 	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 )
 
 type interceptorConfig struct {
@@ -21,7 +23,11 @@ type InterceptorOption func(*interceptorConfig)
 func defaults(cfg *interceptorConfig) {
 	// cfg.serviceName default set in interceptor
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
-	cfg.analyticsRate = math.NaN()
+	if internal.BoolEnv("DD_TRACE_GRPC_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = math.NaN()
+	}
 }
 
 // WithServiceName sets the given service name for the intercepted client.

--- a/contrib/google.golang.org/grpc/option.go
+++ b/contrib/google.golang.org/grpc/option.go
@@ -8,6 +8,7 @@ package grpc
 import (
 	"math"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 
 	"google.golang.org/grpc/codes"
@@ -58,7 +59,11 @@ func defaults(cfg *config) {
 	cfg.traceStreamMessages = true
 	cfg.nonErrorCodes = map[codes.Code]bool{codes.Canceled: true}
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
-	cfg.analyticsRate = math.NaN()
+	if internal.BoolEnv("DD_TRACE_GRPC_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = math.NaN()
+	}
 	cfg.ignoredMetadata = map[string]struct{}{
 		"x-datadog-trace-id":          {},
 		"x-datadog-parent-id":         {},

--- a/contrib/gorilla/mux/option.go
+++ b/contrib/gorilla/mux/option.go
@@ -11,6 +11,7 @@ import (
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
@@ -26,7 +27,11 @@ type routerConfig struct {
 type RouterOption func(*routerConfig)
 
 func defaults(cfg *routerConfig) {
-	cfg.analyticsRate = globalconfig.AnalyticsRate()
+	if internal.BoolEnv("DD_TRACE_MUX_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = globalconfig.AnalyticsRate()
+	}
 	cfg.serviceName = "mux.router"
 	if svc := globalconfig.ServiceName(); svc != "" {
 		cfg.serviceName = svc

--- a/contrib/graph-gophers/graphql-go/option.go
+++ b/contrib/graph-gophers/graphql-go/option.go
@@ -8,6 +8,7 @@ package graphql
 import (
 	"math"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
@@ -25,7 +26,11 @@ func defaults(cfg *config) {
 		cfg.serviceName = svc
 	}
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
-	cfg.analyticsRate = math.NaN()
+	if internal.BoolEnv("DD_TRACE_GRAPHQL_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = math.NaN()
+	}
 }
 
 // WithServiceName sets the given service name for the client.

--- a/contrib/hashicorp/consul/option.go
+++ b/contrib/hashicorp/consul/option.go
@@ -5,7 +5,11 @@
 
 package consul
 
-import "math"
+import (
+	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
+)
 
 const (
 	serviceName = "consul"
@@ -21,7 +25,11 @@ type ClientOption func(*clientConfig)
 
 func defaults(cfg *clientConfig) {
 	cfg.serviceName = serviceName
-	cfg.analyticsRate = math.NaN()
+	if internal.BoolEnv("DD_TRACE_CONSUL_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = math.NaN()
+	}
 }
 
 // WithServiceName sets the given service name for the client.

--- a/contrib/hashicorp/vault/option.go
+++ b/contrib/hashicorp/vault/option.go
@@ -8,6 +8,7 @@ package vault
 import (
 	"math"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
@@ -23,7 +24,11 @@ type Option func(*config)
 
 func defaults(cfg *config) {
 	cfg.serviceName = defaultServiceName
-	cfg.analyticsRate = globalconfig.AnalyticsRate()
+	if internal.BoolEnv("DD_TRACE_VAULT_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = globalconfig.AnalyticsRate()
+	}
 }
 
 // WithAnalytics enables or disables Trace Analytics for all started spans.

--- a/contrib/jinzhu/gorm/option.go
+++ b/contrib/jinzhu/gorm/option.go
@@ -7,6 +7,8 @@ package gorm
 
 import (
 	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 )
 
 type config struct {
@@ -21,7 +23,11 @@ type Option func(*config)
 func defaults(cfg *config) {
 	cfg.serviceName = "gorm.db"
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
-	cfg.analyticsRate = math.NaN()
+	if internal.BoolEnv("DD_TRACE_GORM_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = math.NaN()
+	}
 }
 
 // WithServiceName sets the given service name when registering a driver,

--- a/contrib/julienschmidt/httprouter/option.go
+++ b/contrib/julienschmidt/httprouter/option.go
@@ -9,6 +9,7 @@ import (
 	"math"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
@@ -22,7 +23,11 @@ type routerConfig struct {
 type RouterOption func(*routerConfig)
 
 func defaults(cfg *routerConfig) {
-	cfg.analyticsRate = globalconfig.AnalyticsRate()
+	if internal.BoolEnv("DD_TRACE_HTTPROUTER_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = globalconfig.AnalyticsRate()
+	}
 	cfg.serviceName = "http.router"
 	if svc := globalconfig.ServiceName(); svc != "" {
 		cfg.serviceName = svc

--- a/contrib/labstack/echo/option.go
+++ b/contrib/labstack/echo/option.go
@@ -8,6 +8,7 @@ package echo
 import (
 	"math"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
@@ -24,7 +25,11 @@ func defaults(cfg *config) {
 	if svc := globalconfig.ServiceName(); svc != "" {
 		cfg.serviceName = svc
 	}
-	cfg.analyticsRate = math.NaN()
+	if internal.BoolEnv("DD_TRACE_ECHO_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = math.NaN()
+	}
 }
 
 // WithServiceName sets the given service name for the system.

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
@@ -29,7 +30,11 @@ type MuxOption = Option
 type Option func(*config)
 
 func defaults(cfg *config) {
-	cfg.analyticsRate = globalconfig.AnalyticsRate()
+	if internal.BoolEnv("DD_TRACE_HTTP_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = globalconfig.AnalyticsRate()
+	}
 	cfg.serviceName = "http.router"
 	if svc := globalconfig.ServiceName(); svc != "" {
 		cfg.serviceName = svc

--- a/contrib/olivere/elastic/option.go
+++ b/contrib/olivere/elastic/option.go
@@ -8,6 +8,8 @@ package elastic
 import (
 	"math"
 	"net/http"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 )
 
 type clientConfig struct {
@@ -25,7 +27,11 @@ func defaults(cfg *clientConfig) {
 	cfg.transport = http.DefaultTransport.(*http.Transport)
 	cfg.resourceNamer = quantize
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
-	cfg.analyticsRate = math.NaN()
+	if internal.BoolEnv("DD_TRACE_ELASTIC_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = math.NaN()
+	}
 }
 
 // WithServiceName sets the given service name for the client.

--- a/contrib/syndtr/goleveldb/leveldb/option.go
+++ b/contrib/syndtr/goleveldb/leveldb/option.go
@@ -8,6 +8,8 @@ package leveldb
 import (
 	"context"
 	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 )
 
 type config struct {
@@ -22,6 +24,9 @@ func newConfig(opts ...Option) *config {
 		ctx:         context.Background(),
 		// cfg.analyticsRate: globalconfig.AnalyticsRate(),
 		analyticsRate: math.NaN(),
+	}
+	if internal.BoolEnv("DD_TRACE_LEVELDB_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
 	}
 	for _, opt := range opts {
 		opt(cfg)

--- a/contrib/tidwall/buntdb/option.go
+++ b/contrib/tidwall/buntdb/option.go
@@ -8,6 +8,8 @@ package buntdb
 import (
 	"context"
 	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 )
 
 type config struct {
@@ -20,7 +22,11 @@ func defaults(cfg *config) {
 	cfg.serviceName = "buntdb"
 	cfg.ctx = context.Background()
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
-	cfg.analyticsRate = math.NaN()
+	if internal.BoolEnv("DD_TRACE_BUNTDB_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = math.NaN()
+	}
 }
 
 // An Option customizes the config.

--- a/contrib/twitchtv/twirp/option.go
+++ b/contrib/twitchtv/twirp/option.go
@@ -8,6 +8,7 @@ package twirp
 import (
 	"math"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
@@ -20,7 +21,11 @@ type config struct {
 type Option func(*config)
 
 func defaults(cfg *config) {
-	cfg.analyticsRate = globalconfig.AnalyticsRate()
+	if internal.BoolEnv("DD_TRACE_TWIRP_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = globalconfig.AnalyticsRate()
+	}
 }
 
 func (cfg *config) serverServiceName() string {

--- a/contrib/zenazn/goji.v1/web/option.go
+++ b/contrib/zenazn/goji.v1/web/option.go
@@ -10,6 +10,7 @@ import (
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
@@ -24,7 +25,11 @@ type config struct {
 type Option func(*config)
 
 func defaults(cfg *config) {
-	cfg.analyticsRate = globalconfig.AnalyticsRate()
+	if internal.BoolEnv("DD_TRACE_GOJI_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = globalconfig.AnalyticsRate()
+	}
 	cfg.serviceName = "http.router"
 }
 

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -12,12 +12,12 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/version"
@@ -145,7 +145,14 @@ func newConfig(opts ...StartOption) *config {
 			}
 		}
 	}
-	c.logStartup = boolEnv("DD_TRACE_STARTUP_LOGS", true)
+	c.logStartup = internal.BoolEnv("DD_TRACE_STARTUP_LOGS", true)
+	if internal.BoolEnv("DD_TRACE_ANALYTICS_ENABLED", false) {
+		globalconfig.SetAnalyticsRate(1.0)
+	} else {
+		globalconfig.SetAnalyticsRate(math.NaN())
+	}
+	c.runtimeMetrics = internal.BoolEnv("DD_RUNTIME_METRICS_ENABLED", false)
+	c.debug = internal.BoolEnv("DD_TRACE_DEBUG", false)
 	for _, fn := range opts {
 		fn(c)
 	}
@@ -495,14 +502,4 @@ func StackFrames(n, skip uint) FinishOption {
 		cfg.StackFrames = n
 		cfg.SkipStackFrames = skip
 	}
-}
-
-// boolEnv returns the parsed boolean value of an environment variable, or
-// def if it fails to parse.
-func boolEnv(key string, def bool) bool {
-	v, err := strconv.ParseBool(os.Getenv(key))
-	if err != nil {
-		return def
-	}
-	return v
 }

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -109,7 +109,7 @@ func newConfig(opts ...StartOption) *config {
 	}
 	c.dogstatsdAddr = net.JoinHostPort(statsdHost, statsdPort)
 
-	if boolEnv("DD_TRACE_ANALYTICS_ENABLED", false) {
+	if internal.BoolEnv("DD_TRACE_ANALYTICS_ENABLED", false) {
 		globalconfig.SetAnalyticsRate(1.0)
 	}
 	if os.Getenv("DD_TRACE_REPORT_HOSTNAME") == "true" {
@@ -146,11 +146,6 @@ func newConfig(opts ...StartOption) *config {
 		}
 	}
 	c.logStartup = internal.BoolEnv("DD_TRACE_STARTUP_LOGS", true)
-	if internal.BoolEnv("DD_TRACE_ANALYTICS_ENABLED", false) {
-		globalconfig.SetAnalyticsRate(1.0)
-	} else {
-		globalconfig.SetAnalyticsRate(math.NaN())
-	}
 	c.runtimeMetrics = internal.BoolEnv("DD_RUNTIME_METRICS_ENABLED", false)
 	c.debug = internal.BoolEnv("DD_TRACE_DEBUG", false)
 	for _, fn := range opts {

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -70,27 +70,6 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		})
 	})
 
-	t.Run("analyticsEnv", func(t *testing.T) {
-		assert := assert.New(t)
-		assert.True(math.IsNaN(globalconfig.AnalyticsRate()))
-		os.Setenv("DD_TRACE_ANALYTICS_ENABLED", "true")
-		defer os.Unsetenv("DD_TRACE_ANALYTICS_ENABLED")
-		newTracer()
-		assert.Equal(1.0, globalconfig.AnalyticsRate())
-		os.Setenv("DD_TRACE_ANALYTICS_ENABLED", "false")
-		newTracer()
-		assert.True(math.IsNaN(globalconfig.AnalyticsRate()))
-		os.Setenv("DD_TRACE_ANALYTICS_ENABLED", "true")
-		newTracer(WithAnalytics(false))
-		assert.True(math.IsNaN(globalconfig.AnalyticsRate()))
-		os.Setenv("DD_TRACE_ANALYTICS_ENABLED", "false")
-		newTracer(WithAnalytics(true))
-		assert.Equal(1.0, globalconfig.AnalyticsRate())
-		os.Setenv("DD_TRACE_ANALYTICS_ENABLED", "false")
-		newTracer(WithAnalyticsRate(0.5))
-		assert.Equal(0.5, globalconfig.AnalyticsRate())
-	})
-
 	t.Run("dogstatsd", func(t *testing.T) {
 		t.Run("default", func(t *testing.T) {
 			tracer := newTracer()

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -70,6 +70,27 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		})
 	})
 
+	t.Run("analyticsEnv", func(t *testing.T) {
+		assert := assert.New(t)
+		assert.True(math.IsNaN(globalconfig.AnalyticsRate()))
+		os.Setenv("DD_TRACE_ANALYTICS_ENABLED", "true")
+		defer os.Unsetenv("DD_TRACE_ANALYTICS_ENABLED")
+		newTracer()
+		assert.Equal(1.0, globalconfig.AnalyticsRate())
+		os.Setenv("DD_TRACE_ANALYTICS_ENABLED", "false")
+		newTracer()
+		assert.True(math.IsNaN(globalconfig.AnalyticsRate()))
+		os.Setenv("DD_TRACE_ANALYTICS_ENABLED", "true")
+		newTracer(WithAnalytics(false))
+		assert.True(math.IsNaN(globalconfig.AnalyticsRate()))
+		os.Setenv("DD_TRACE_ANALYTICS_ENABLED", "false")
+		newTracer(WithAnalytics(true))
+		assert.Equal(1.0, globalconfig.AnalyticsRate())
+		os.Setenv("DD_TRACE_ANALYTICS_ENABLED", "false")
+		newTracer(WithAnalyticsRate(0.5))
+		assert.Equal(0.5, globalconfig.AnalyticsRate())
+	})
+
 	t.Run("dogstatsd", func(t *testing.T) {
 		t.Run("default", func(t *testing.T) {
 			tracer := newTracer()

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -226,6 +226,24 @@ func TestTracerRuntimeMetrics(t *testing.T) {
 		assert.Contains(t, tp.Lines()[0], "DEBUG: Runtime metrics enabled")
 	})
 
+	t.Run("env", func(t *testing.T) {
+		os.Setenv("DD_RUNTIME_METRICS_ENABLED", "true")
+		defer os.Unsetenv("DD_RUNTIME_METRICS_ENABLED")
+		tp := new(testLogger)
+		tracer := newTracer(WithLogger(tp), WithDebugMode(true))
+		defer tracer.Stop()
+		assert.Contains(t, tp.Lines()[0], "DEBUG: Runtime metrics enabled")
+	})
+
+	t.Run("overrideEnv", func(t *testing.T) {
+		os.Setenv("DD_RUNTIME_METRICS_ENABLED", "false")
+		defer os.Unsetenv("DD_RUNTIME_METRICS_ENABLED")
+		tp := new(testLogger)
+		tracer := newTracer(WithRuntimeMetrics(), WithLogger(tp), WithDebugMode(true))
+		defer tracer.Stop()
+		assert.Contains(t, tp.Lines()[0], "DEBUG: Runtime metrics enabled")
+	})
+
 	t.Run("off", func(t *testing.T) {
 		tp := new(testLogger)
 		tracer := newTracer(WithLogger(tp), WithDebugMode(true))

--- a/internal/env.go
+++ b/internal/env.go
@@ -11,7 +11,7 @@ import (
 )
 
 // BoolEnv returns the parsed boolean value of an environment variable, or
-// def if it fails to parse.
+// def otherwise.
 func BoolEnv(key string, def bool) bool {
 	v, err := strconv.ParseBool(os.Getenv(key))
 	if err != nil {

--- a/internal/env.go
+++ b/internal/env.go
@@ -1,0 +1,16 @@
+package internal
+
+import (
+	"os"
+	"strconv"
+)
+
+// BoolEnv returns the parsed boolean value of an environment variable, or
+// def if it fails to parse.
+func BoolEnv(key string, def bool) bool {
+	v, err := strconv.ParseBool(os.Getenv(key))
+	if err != nil {
+		return def
+	}
+	return v
+}

--- a/internal/env.go
+++ b/internal/env.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
 package internal
 
 import (


### PR DESCRIPTION
This PR adds support for the following environment varables
* `DD_<INTEGRATION>_ANALYTICS_ENABLED`
* `DD_RUNTIME_METRICS_ENABLED`
* `DD_TRACE_DEBUG`