### PR TITLE
ddtrace/tracer: add support for lambda tracing

### DIFF
--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -30,8 +30,7 @@ type Tracer interface {
 	// Inject injects a span context into the given carrier.
 	Inject(context SpanContext, carrier interface{}) error
 
-	// Stop stops the active tracer and sets the global tracer to a no-op. Calls to
-	// Stop should be idempotent.
+	// Stop stops the tracer. Calls to Stop should be idempotent.
 	Stop()
 }
 

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -31,7 +31,7 @@ type config struct {
 	debug bool
 
 	// lambda, when true, enables the lambda trace writer
-	lambda bool
+	logToStdout bool
 
 	// logStartup, when true, causes various startup info to be written
 	// when the tracer starts.
@@ -151,7 +151,7 @@ func newConfig(opts ...StartOption) *config {
 	if _, ok := os.LookupEnv("AWS_LAMBDA_FUNCTION_NAME"); ok {
 		// AWS_LAMBDA_FUNCTION_NAME being set indicates that we're running in an AWS Lambda environment.
 		// See: https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html
-		c.lambda = true
+		c.logToStdout = true
 	}
 	c.logStartup = internal.BoolEnv("DD_TRACE_STARTUP_LOGS", true)
 	c.runtimeMetrics = internal.BoolEnv("DD_RUNTIME_METRICS_ENABLED", false)
@@ -259,7 +259,7 @@ func WithDebugMode(enabled bool) StartOption {
 // WithLambdaMode enables lambda mode on the tracer, for use with AWS Lambda.
 func WithLambdaMode(enabled bool) StartOption {
 	return func(c *config) {
-		c.lambda = enabled
+		c.logToStdout = enabled
 	}
 }
 

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -30,6 +30,9 @@ type config struct {
 	// debug, when true, writes details to logs.
 	debug bool
 
+	// lambda, when true, enables the lambda trace writer
+	lambda bool
+
 	// logStartup, when true, causes various startup info to be written
 	// when the tracer starts.
 	logStartup bool
@@ -145,6 +148,11 @@ func newConfig(opts ...StartOption) *config {
 			}
 		}
 	}
+	if _, ok := os.LookupEnv("AWS_LAMBDA_FUNCTION_NAME"); ok {
+		// AWS_LAMBDA_FUNCTION_NAME being set indicates that we're running in an AWS Lambda environment.
+		// See: https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html
+		c.lambda = true
+	}
 	c.logStartup = internal.BoolEnv("DD_TRACE_STARTUP_LOGS", true)
 	c.runtimeMetrics = internal.BoolEnv("DD_RUNTIME_METRICS_ENABLED", false)
 	c.debug = internal.BoolEnv("DD_TRACE_DEBUG", false)
@@ -245,6 +253,13 @@ func WithPrioritySampling() StartOption {
 func WithDebugMode(enabled bool) StartOption {
 	return func(c *config) {
 		c.debug = enabled
+	}
+}
+
+// WithLambdaMode enables lambda mode on the tracer, for use with AWS Lambda.
+func WithLambdaMode(enabled bool) StartOption {
+	return func(c *config) {
+		c.lambda = enabled
 	}
 }
 

--- a/ddtrace/tracer/sampler_test.go
+++ b/ddtrace/tracer/sampler_test.go
@@ -498,7 +498,6 @@ func BenchmarkRulesSampler(b *testing.B) {
 	benchmarkStartSpan := func(b *testing.B, t *tracer) {
 		internal.SetGlobalTracer(t)
 		defer func() {
-			close(t.stop)
 			internal.SetGlobalTracer(&internal.NoopTracer{})
 		}()
 		t.prioritySampling.readRatesJSON(ioutil.NopCloser(strings.NewReader(
@@ -527,8 +526,8 @@ func BenchmarkRulesSampler(b *testing.B) {
 				spans[j].Finish()
 			}
 			d := 0
-			for len(t.payloadChan) > 0 {
-				<-t.payloadChan
+			for len(t.out) > 0 {
+				<-t.out
 				d++
 			}
 		}

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -84,7 +84,7 @@ func TestSpanFinishTwice(t *testing.T) {
 	tracer, _, _, stop := startTestTracer(t)
 	defer stop()
 
-	assert.Equal(tracer.payload.itemCount(), 0)
+	assert.Equal(tracer.traceWriter.(*agentTraceWriter).payload.itemCount(), 0)
 
 	// the finish must be idempotent
 	span := tracer.newRootSpan("pylons.request", "pylons", "/")
@@ -367,7 +367,7 @@ func TestSpanModifyWhileFlushing(t *testing.T) {
 		case <-done:
 			return
 		default:
-			tracer.flush()
+			tracer.traceWriter.flush()
 			time.Sleep(10 * time.Millisecond)
 		}
 	}

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -143,7 +143,7 @@ func newUnstartedTracer(opts ...StartOption) *tracer {
 	}
 	sampler := newPrioritySampler()
 	var writer traceWriter
-	if c.lambda {
+	if c.logToStdout {
 		writer = newLogTraceWriter(c)
 	} else {
 		writer = newAgentTraceWriter(c, sampler)

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -29,13 +29,13 @@ var _ ddtrace.Tracer = (*tracer)(nil)
 // queues to be processed by the payload encoder.
 type tracer struct {
 	*config
-	*payload
 
-	// payloadChan receives traces to be added to the payload.
-	payloadChan chan []*span
+	// traceWriter is responsible for sending finished traces to their
+	// destination, such as the Trace Agent or Datadog Forwarder.
+	traceWriter traceWriter
 
-	// climit limits the number of concurrent outgoing connections
-	climit chan struct{}
+	// out receives traces to be added to the payload.
+	out chan []*span
 
 	// stop causes the tracer to shut down when closed.
 	stop chan struct{}
@@ -141,14 +141,20 @@ func newUnstartedTracer(opts ...StartOption) *tracer {
 	if envRules != nil {
 		c.samplingRules = envRules
 	}
+	sampler := newPrioritySampler()
+	var writer traceWriter
+	if c.lambda {
+		writer = newLogTraceWriter(c)
+	} else {
+		writer = newAgentTraceWriter(c, sampler)
+	}
 	return &tracer{
 		config:           c,
-		payload:          newPayload(),
-		payloadChan:      make(chan []*span, payloadQueueSize),
+		traceWriter:      writer,
+		out:              make(chan []*span, payloadQueueSize),
 		stop:             make(chan struct{}),
 		rulesSampling:    newRulesSampler(c.samplingRules),
-		climit:           make(chan struct{}, concurrentConnectionLimit),
-		prioritySampling: newPrioritySampler(),
+		prioritySampling: sampler,
 		pid:              strconv.Itoa(os.Getpid()),
 	}
 }
@@ -188,16 +194,14 @@ func newTracer(opts ...StartOption) *tracer {
 // worker receives finished traces to be added into the payload, as well
 // as periodically flushes traces to the transport.
 func (t *tracer) worker(tick <-chan time.Time) {
-	defer t.config.statsd.Close()
-
 	for {
 		select {
-		case trace := <-t.payloadChan:
-			t.pushPayload(trace)
+		case trace := <-t.out:
+			t.traceWriter.add(trace)
 
 		case <-tick:
 			t.config.statsd.Incr("datadog.tracer.flush_triggered", []string{"reason:scheduled"}, 1)
-			t.flush()
+			t.traceWriter.flush()
 
 		case <-t.stop:
 		loop:
@@ -205,15 +209,12 @@ func (t *tracer) worker(tick <-chan time.Time) {
 			// before the final flush to ensure no traces are lost (see #526)
 			for {
 				select {
-				case trace := <-t.payloadChan:
-					t.pushPayload(trace)
+				case trace := <-t.out:
+					t.traceWriter.add(trace)
 				default:
 					break loop
 				}
 			}
-			t.config.statsd.Incr("datadog.tracer.flush_triggered", []string{"reason:shutdown"}, 1)
-			t.flush()
-			t.config.statsd.Incr("datadog.tracer.stopped", nil, 1)
 			return
 		}
 	}
@@ -226,7 +227,7 @@ func (t *tracer) pushTrace(trace []*span) {
 	default:
 	}
 	select {
-	case t.payloadChan <- trace:
+	case t.out <- trace:
 	default:
 		log.Error("payload queue full, dropping %d traces", len(trace))
 	}
@@ -322,8 +323,11 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 func (t *tracer) Stop() {
 	t.stopOnce.Do(func() {
 		close(t.stop)
+		t.config.statsd.Incr("datadog.tracer.stopped", nil, 1)
 	})
 	t.wg.Wait()
+	t.traceWriter.stop()
+	t.config.statsd.Close()
 }
 
 // Inject uses the configured or default TextMap Propagator.
@@ -334,49 +338,6 @@ func (t *tracer) Inject(ctx ddtrace.SpanContext, carrier interface{}) error {
 // Extract uses the configured or default TextMap Propagator.
 func (t *tracer) Extract(carrier interface{}) (ddtrace.SpanContext, error) {
 	return t.config.propagator.Extract(carrier)
-}
-
-// flush will push any currently buffered traces to the server.
-func (t *tracer) flush() {
-	if t.payload.itemCount() == 0 {
-		return
-	}
-	t.wg.Add(1)
-	t.climit <- struct{}{}
-	go func(p *payload) {
-		defer func(start time.Time) {
-			<-t.climit
-			t.wg.Done()
-			t.config.statsd.Timing("datadog.tracer.flush_duration", time.Since(start), nil, 1)
-		}(time.Now())
-		size, count := p.size(), p.itemCount()
-		log.Debug("Sending payload: size: %d traces: %d\n", size, count)
-		rc, err := t.config.transport.send(p)
-		if err != nil {
-			t.config.statsd.Count("datadog.tracer.traces_dropped", int64(count), []string{"reason:send_failed"}, 1)
-			log.Error("lost %d traces: %v", count, err)
-		} else {
-			t.config.statsd.Count("datadog.tracer.flush_bytes", int64(size), nil, 1)
-			t.config.statsd.Count("datadog.tracer.flush_traces", int64(count), nil, 1)
-			if err := t.prioritySampling.readRatesJSON(rc); err != nil {
-				t.config.statsd.Incr("datadog.tracer.decode_error", nil, 1)
-			}
-		}
-	}(t.payload)
-	t.payload = newPayload()
-}
-
-// pushPayload pushes the trace onto the payload. If the payload becomes
-// larger than the threshold as a result, it sends a flush request.
-func (t *tracer) pushPayload(trace []*span) {
-	if err := t.payload.push(trace); err != nil {
-		t.config.statsd.Incr("datadog.tracer.traces_dropped", []string{"reason:encoding_error"}, 1)
-		log.Error("error encoding msgpack: %v", err)
-	}
-	if t.payload.size() > payloadSizeLimit {
-		t.config.statsd.Incr("datadog.tracer.flush_triggered", []string{"reason:size"}, 1)
-		t.flush()
-	}
 }
 
 // sampleRateMetricKey is the metric key holding the applied sample rate. Has to be the same as the Agent.

--- a/ddtrace/tracer/writer.go
+++ b/ddtrace/tracer/writer.go
@@ -1,0 +1,301 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package tracer
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"math"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+)
+
+type traceWriter interface {
+	// add adds traces to be sent by the writer.
+	add([]*span)
+
+	// flush causes the writer to send any buffered traces.
+	flush()
+
+	// stop gracefully shuts down the writer.
+	stop()
+}
+
+type agentTraceWriter struct {
+	// config holds the tracer configuration
+	config *config
+
+	// payload encodes and buffers traces in msgpack format
+	payload *payload
+
+	// climit limits the number of concurrent outgoing connections
+	climit chan struct{}
+
+	// wg waits for all uploads to finish
+	wg sync.WaitGroup
+
+	// prioritySampling is the prioritySampler into which agentTraceWriter will
+	// read sampling rates sent by the agent
+	prioritySampling *prioritySampler
+}
+
+func newAgentTraceWriter(c *config, s *prioritySampler) *agentTraceWriter {
+	return &agentTraceWriter{
+		config:           c,
+		payload:          newPayload(),
+		climit:           make(chan struct{}, concurrentConnectionLimit),
+		prioritySampling: s,
+	}
+}
+
+func (h *agentTraceWriter) add(trace []*span) {
+	if err := h.payload.push(trace); err != nil {
+		h.config.statsd.Incr("datadog.tracer.traces_dropped", []string{"reason:encoding_error"}, 1)
+		log.Error("error encoding msgpack: %v", err)
+	}
+	if h.payload.size() > payloadSizeLimit {
+		h.config.statsd.Incr("datadog.tracer.flush_triggered", []string{"reason:size"}, 1)
+		h.flush()
+	}
+}
+
+func (h *agentTraceWriter) stop() {
+	h.config.statsd.Incr("datadog.tracer.flush_triggered", []string{"reason:shutdown"}, 1)
+	h.flush()
+	h.wg.Wait()
+}
+
+// flush will push any currently buffered traces to the server.
+func (h *agentTraceWriter) flush() {
+	if h.payload.itemCount() == 0 {
+		return
+	}
+	h.wg.Add(1)
+	h.climit <- struct{}{}
+	go func(p *payload) {
+		defer func(start time.Time) {
+			<-h.climit
+			h.wg.Done()
+			h.config.statsd.Timing("datadog.tracer.flush_duration", time.Since(start), nil, 1)
+		}(time.Now())
+		size, count := p.size(), p.itemCount()
+		log.Debug("Sending payload: size: %d traces: %d\n", size, count)
+		rc, err := h.config.transport.send(p)
+		if err != nil {
+			h.config.statsd.Count("datadog.tracer.traces_dropped", int64(count), []string{"reason:send_failed"}, 1)
+			log.Error("lost %d traces: %v", count, err)
+		} else {
+			h.config.statsd.Count("datadog.tracer.flush_bytes", int64(size), nil, 1)
+			h.config.statsd.Count("datadog.tracer.flush_traces", int64(count), nil, 1)
+			if err := h.prioritySampling.readRatesJSON(rc); err != nil {
+				h.config.statsd.Incr("datadog.tracer.decode_error", nil, 1)
+			}
+		}
+	}(h.payload)
+	h.payload = newPayload()
+}
+
+// logTraceWriter encodes traces into a format understood by the Datadog Forwarder
+// (https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring)
+// and writes them to os.Stdout. This is used to send traces from an AWS Lambda environment.
+type logTraceWriter struct {
+	config    *config
+	buf       bytes.Buffer
+	hasTraces bool
+	w         io.Writer
+}
+
+func newLogTraceWriter(c *config) *logTraceWriter {
+	w := &logTraceWriter{
+		config: c,
+		w:      os.Stdout,
+	}
+	w.resetBuffer()
+	return w
+}
+
+const (
+	// maxFloatLength is the maximum length that a string encoded by encodeFloat will be.
+	maxFloatLength = 24
+
+	// logBufferSuffix is the final string that the trace writer has to append to a buffer to close
+	// the JSON.
+	logBufferSuffix = "]}\n"
+
+	// logBufferLimit is the maximum size log line allowed by cloudwatch
+	logBufferLimit = 256 * 1024
+)
+
+func (h *logTraceWriter) resetBuffer() {
+	h.buf.Reset()
+	h.buf.WriteString(`{"traces": [`)
+	h.hasTraces = false
+}
+
+// encodeFloat correctly encodes float64 into the JSON format followed by ES6.
+// This code is reworked from Go's encoding/json package
+// (https://github.com/golang/go/blob/go1.15/src/encoding/json/encode.go#L573)
+//
+// One important departure from encoding/json is that infinities and nans are encoded
+// as null rather than signalling an error.
+func encodeFloat(p []byte, f float64) []byte {
+	if math.IsInf(f, -1) || math.IsInf(f, 1) || math.IsNaN(f) {
+		return append(p, "null"...)
+	}
+	abs := math.Abs(f)
+	if abs != 0 && (abs < 1e-6 || abs >= 1e21) {
+		p = strconv.AppendFloat(p, f, 'e', -1, 64)
+		// clean up e-09 to e-9
+		n := len(p)
+		if n >= 4 && p[n-4] == 'e' && p[n-3] == '-' && p[n-2] == '0' {
+			p[n-2] = p[n-1]
+			p = p[:n-1]
+		}
+	} else {
+		p = strconv.AppendFloat(p, f, 'f', -1, 64)
+	}
+	return p
+}
+
+func (h *logTraceWriter) encodeSpan(s *span) {
+	var scratch [maxFloatLength]byte
+	h.buf.WriteString(`{"trace_id":"`)
+	h.buf.Write(strconv.AppendUint(scratch[:0], uint64(s.TraceID), 16))
+	h.buf.WriteString(`","span_id":"`)
+	h.buf.Write(strconv.AppendUint(scratch[:0], uint64(s.SpanID), 16))
+	h.buf.WriteString(`","parent_id":"`)
+	h.buf.Write(strconv.AppendUint(scratch[:0], uint64(s.ParentID), 16))
+	h.buf.WriteString(`","name":"`)
+	h.buf.WriteString(s.Name)
+	h.buf.WriteString(`","resource":"`)
+	h.buf.WriteString(s.Resource)
+	h.buf.WriteString(`","error":`)
+	h.buf.Write(strconv.AppendInt(scratch[:0], int64(s.Error), 10))
+	h.buf.WriteString(`,"meta":{`)
+	first := true
+	for k, v := range s.Meta {
+		if first {
+			h.buf.WriteByte('"')
+			first = false
+		} else {
+			h.buf.WriteString(`,"`)
+		}
+		h.buf.WriteString(k)
+		h.buf.WriteString(`":"`)
+		h.buf.WriteString(v)
+		h.buf.WriteString(`"`)
+	}
+	h.buf.WriteString(`},"metrics":{`)
+	first = true
+	for k, v := range s.Metrics {
+		if first {
+			h.buf.WriteByte('"')
+			first = false
+		} else {
+			h.buf.WriteString(`,"`)
+		}
+		h.buf.WriteString(k)
+		h.buf.WriteString(`":`)
+		h.buf.Write(encodeFloat(scratch[:0], v))
+	}
+	h.buf.WriteString(`},"start":`)
+	h.buf.Write(strconv.AppendInt(scratch[:0], s.Start, 10))
+	h.buf.WriteString(`,"duration":`)
+	h.buf.Write(strconv.AppendInt(scratch[:0], s.Duration, 10))
+	h.buf.WriteString(`,"service":"`)
+	h.buf.WriteString(s.Service)
+	h.buf.WriteString(`"}`)
+}
+
+type encodingError struct {
+	cause      error
+	dropReason string
+}
+
+// writeTrace makes an effort to write the trace into the current buffer. It returns
+// the number of spans (n) that it wrote and an error (err), if one occurred.
+// n may be less than len(trace), meaning that only the first n spans of the trace
+// fit into the current buffer. Once the buffer is flushed, the remaining spans
+// from the trace can be retried.
+// An error, if one is returned, indicates that a span in the trace is too large
+// to fit in one buffer, and the trace cannot be written.
+func (h *logTraceWriter) writeTrace(trace []*span) (n int, err *encodingError) {
+	startn := h.buf.Len()
+	if !h.hasTraces {
+		h.buf.WriteByte('[')
+	} else {
+		h.buf.WriteString(", [")
+	}
+	written := 0
+	for i, s := range trace {
+		n := h.buf.Len()
+		if i > 0 {
+			h.buf.WriteByte(',')
+		}
+		h.encodeSpan(s)
+		if h.buf.Len() > logBufferLimit-len(logBufferSuffix) {
+			// This span is too big to fit in the current buffer.
+			if i == 0 {
+				// This was the first span in this trace. This means we should truncate
+				// everything we wrote in writeTrace
+				h.buf.Truncate(startn)
+				if !h.hasTraces {
+					// This is the first span of the first trace in the buffer and it's too big.
+					// We will never be able to send this trace, so we will drop it.
+					return 0, &encodingError{cause: errors.New("span too large for buffer"), dropReason: "trace_too_large"}
+				}
+				return 0, nil
+			}
+			// This span was too big, but it might fit in the next buffer.
+			// We can finish this trace and try again with an empty buffer (see *logTaceWriter.add)
+			h.buf.Truncate(n)
+			break
+		}
+		written++
+	}
+	h.buf.WriteByte(']')
+	h.hasTraces = true
+	return written, nil
+}
+
+// add adds a trace to the writer's buffer.
+func (h *logTraceWriter) add(trace []*span) {
+	// Try adding traces to the buffer until we flush them all or encounter an error.
+	for len(trace) > 0 {
+		n, err := h.writeTrace(trace)
+		if err != nil {
+			log.Error("Lost a trace: %s", err.cause)
+			h.config.statsd.Count("datadog.tracer.traces_dropped", 1, []string{"reason:" + err.dropReason}, 1)
+			return
+		}
+		trace = trace[n:]
+		// If there are traces left that didn't fit into the buffer, flush the buffer and loop to
+		// write the remaining spans.
+		if len(trace) > 0 {
+			h.flush()
+		}
+	}
+}
+
+func (h *logTraceWriter) stop() {
+	h.config.statsd.Incr("datadog.tracer.flush_triggered", []string{"reason:shutdown"}, 1)
+	h.flush()
+}
+
+// flush will write any buffered traces to standard output.
+func (h *logTraceWriter) flush() {
+	if !h.hasTraces {
+		return
+	}
+	h.buf.WriteString(logBufferSuffix)
+	h.w.Write(h.buf.Bytes())
+	h.resetBuffer()
+}

--- a/ddtrace/tracer/writer_test.go
+++ b/ddtrace/tracer/writer_test.go
@@ -1,0 +1,299 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package tracer
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+)
+
+var _ traceWriter = &agentTraceWriter{}
+var _ traceWriter = &logTraceWriter{}
+
+// makeSpan returns a span, adding n entries to meta and metrics each.
+func makeSpan(n int) *span {
+	s := newSpan("encodeName", "encodeService", "encodeResource", random.Uint64(), random.Uint64(), random.Uint64())
+	for i := 0; i < n; i++ {
+		istr := fmt.Sprintf("%0.10d", i)
+		s.Meta[istr] = istr
+		s.Metrics[istr] = float64(i)
+	}
+	return s
+}
+
+func TestEncodeFloat(t *testing.T) {
+	for _, tt := range []struct {
+		f      float64
+		expect string
+	}{
+		{
+			9.9999999999999990e20,
+			"999999999999999900000",
+		},
+		{
+			9.9999999999999999e20,
+			"1e+21",
+		},
+		{
+			-9.9999999999999990e20,
+			"-999999999999999900000",
+		},
+		{
+			-9.9999999999999999e20,
+			"-1e+21",
+		},
+		{
+			0.000001,
+			"0.000001",
+		},
+		{
+			0.0000009,
+			"9e-7",
+		},
+		{
+			-0.000001,
+			"-0.000001",
+		},
+		{
+			-0.0000009,
+			"-9e-7",
+		},
+		{
+			math.NaN(),
+			"null",
+		},
+		{
+			math.Inf(-1),
+			"null",
+		},
+		{
+			math.Inf(1),
+			"null",
+		},
+	} {
+		t.Run(tt.expect, func(t *testing.T) {
+			assert.Equal(t, tt.expect, string(encodeFloat(nil, tt.f)))
+		})
+	}
+
+}
+
+func TestLogWriter(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		assert := assert.New(t)
+		var buf bytes.Buffer
+		h := newLogTraceWriter(newConfig())
+		h.w = &buf
+		s := makeSpan(0)
+		for i := 0; i < 20; i++ {
+			h.add([]*span{s, s})
+		}
+		h.flush()
+		v := struct{ Traces [][]map[string]interface{} }{}
+		d := json.NewDecoder(&buf)
+		err := d.Decode(&v)
+		assert.NoError(err)
+		assert.Len(v.Traces, 20, "Expected 20 traces, but have %d", len(v.Traces))
+		for _, t := range v.Traces {
+			assert.Len(t, 2, "Expected 2 spans, but have %d", len(t))
+		}
+		err = d.Decode(&v)
+		assert.Equal(io.EOF, err)
+	})
+
+	t.Run("inf+nan", func(t *testing.T) {
+		assert := assert.New(t)
+		var buf bytes.Buffer
+		h := newLogTraceWriter(newConfig())
+		h.w = &buf
+		s := makeSpan(0)
+		s.Metrics["nan"] = math.NaN()
+		s.Metrics["+inf"] = math.Inf(1)
+		s.Metrics["-inf"] = math.Inf(-1)
+		h.add([]*span{s})
+		h.flush()
+		json := string(buf.Bytes())
+		assert.NotContains(json, `"nan":0`)
+		assert.Contains(json, `"+inf":null`)
+		assert.Contains(json, `"-inf":null`)
+	})
+
+	t.Run("fullspan", func(t *testing.T) {
+		assert := assert.New(t)
+		var buf bytes.Buffer
+		h := newLogTraceWriter(newConfig())
+		h.w = &buf
+		type jsonSpan struct {
+			TraceID  string             `json:"trace_id"`
+			SpanID   string             `json:"span_id"`
+			ParentID string             `json:"parent_id"`
+			Name     string             `json:"name"`
+			Resource string             `json:"resource"`
+			Error    int32              `json:"error"`
+			Meta     map[string]string  `json:"meta"`
+			Metrics  map[string]float64 `json:"metrics"`
+			Start    int64              `json:"start"`
+			Duration int64              `json:"duration"`
+			Service  string             `json:"service"`
+		}
+		type jsonPayload struct {
+			Traces [][]jsonSpan `json:"traces"`
+		}
+		s := &span{
+			Name:     "basicName",
+			Service:  "basicService",
+			Resource: "basicResource",
+			Meta: map[string]string{
+				"env":     "prod",
+				"version": "1.26.0",
+			},
+			Metrics: map[string]float64{
+				"widgets": 1e26,
+				"zero":    0.0,
+				"big":     math.MaxFloat64,
+				"small":   math.SmallestNonzeroFloat64,
+				"nan":     math.NaN(),
+				"-inf":    math.Inf(-1),
+				"+inf":    math.Inf(1),
+			},
+			SpanID:   10,
+			TraceID:  11,
+			ParentID: 12,
+			Start:    123,
+			Duration: 456,
+			Error:    789,
+		}
+		expected := jsonSpan{
+			Name:     "basicName",
+			Service:  "basicService",
+			Resource: "basicResource",
+			Meta: map[string]string{
+				"env":     "prod",
+				"version": "1.26.0",
+			},
+			Metrics: map[string]float64{
+				"widgets": 1e26,
+				"zero":    0.0,
+				"big":     math.MaxFloat64,
+				"small":   math.SmallestNonzeroFloat64,
+				"-inf":    0,
+				"+inf":    0,
+				"nan":     0,
+			},
+			SpanID:   "a",
+			TraceID:  "b",
+			ParentID: "c",
+			Start:    123,
+			Duration: 456,
+			Error:    789,
+		}
+		h.add([]*span{s})
+		h.flush()
+		d := json.NewDecoder(&buf)
+		var payload jsonPayload
+		err := d.Decode(&payload)
+		assert.NoError(err)
+		assert.Equal(jsonPayload{[][]jsonSpan{{expected}}}, payload)
+	})
+}
+
+func TestLogWriterOverflow(t *testing.T) {
+	log.UseLogger(new(testLogger))
+	t.Run("single-too-big", func(t *testing.T) {
+		assert := assert.New(t)
+		var buf bytes.Buffer
+		var tg testStatsdClient
+		h := newLogTraceWriter(newConfig(withStatsdClient(&tg)))
+		h.w = &buf
+		s := makeSpan(10000)
+		h.add([]*span{s})
+		h.flush()
+		v := struct{ Traces [][]map[string]interface{} }{}
+		d := json.NewDecoder(&buf)
+		err := d.Decode(&v)
+		assert.Equal(io.EOF, err)
+		assert.Contains(tg.CallNames(), "datadog.tracer.traces_dropped")
+	})
+
+	t.Run("split", func(t *testing.T) {
+		assert := assert.New(t)
+		var buf bytes.Buffer
+		var tg testStatsdClient
+		h := newLogTraceWriter(newConfig(withStatsdClient(&tg)))
+		h.w = &buf
+		s := makeSpan(10)
+		var trace []*span
+		for i := 0; i < 500; i++ {
+			trace = append(trace, s)
+		}
+		h.add(trace)
+		h.flush()
+		v := struct{ Traces [][]map[string]interface{} }{}
+		d := json.NewDecoder(&buf)
+		err := d.Decode(&v)
+		assert.NoError(err)
+		assert.Len(v.Traces, 1, "Expected 1 trace, but have %d", len(v.Traces))
+		spann := len(v.Traces[0])
+		err = d.Decode(&v)
+		assert.NoError(err)
+		assert.Len(v.Traces, 1, "Expected 1 trace, but have %d", len(v.Traces))
+		spann += len(v.Traces[0])
+		assert.Equal(500, spann)
+		err = d.Decode(&v)
+		assert.Equal(io.EOF, err)
+	})
+
+	t.Run("two-large", func(t *testing.T) {
+		assert := assert.New(t)
+		var buf bytes.Buffer
+		h := newLogTraceWriter(newConfig())
+		h.w = &buf
+		s := makeSpan(4000)
+		h.add([]*span{s})
+		h.add([]*span{s})
+		h.flush()
+		v := struct{ Traces [][]map[string]interface{} }{}
+		d := json.NewDecoder(&buf)
+		err := d.Decode(&v)
+		assert.NoError(err)
+		assert.Len(v.Traces, 1, "Expected 1 trace, but have %d", len(v.Traces))
+		assert.Len(v.Traces[0], 1, "Expected 1 span, but have %d", len(v.Traces[0]))
+		err = d.Decode(&v)
+		assert.NoError(err)
+		assert.Len(v.Traces, 1, "Expected 1 trace, but have %d", len(v.Traces))
+		assert.Len(v.Traces[0], 1, "Expected 1 span, but have %d", len(v.Traces[0]))
+		err = d.Decode(&v)
+		assert.Equal(io.EOF, err)
+	})
+}
+
+func BenchmarkJsonEncodeSpan(b *testing.B) {
+	s := makeSpan(10)
+	s.Metrics["nan"] = math.NaN()
+	s.Metrics["+inf"] = math.Inf(1)
+	s.Metrics["-inf"] = math.Inf(-1)
+	h := &logTraceWriter{}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		h.resetBuffer()
+		h.encodeSpan(s)
+	}
+}
+
+func BenchmarkJsonEncodeFloat(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var ba = make([]byte, 25)
+		bs := ba[:0]
+		encodeFloat(bs, float64(1e-9))
+	}
+}

--- a/ddtrace/tracer/writer_test.go
+++ b/ddtrace/tracer/writer_test.go
@@ -123,9 +123,9 @@ func TestLogWriter(t *testing.T) {
 		h.add([]*span{s})
 		h.flush()
 		json := string(buf.Bytes())
-		assert.NotContains(json, `"nan":0`)
-		assert.Contains(json, `"+inf":null`)
-		assert.Contains(json, `"-inf":null`)
+		assert.NotContains(json, `"nan":`)
+		assert.NotContains(json, `"+inf":`)
+		assert.NotContains(json, `"-inf":`)
 	})
 
 	t.Run("fullspan", func(t *testing.T) {
@@ -186,9 +186,6 @@ func TestLogWriter(t *testing.T) {
 				"zero":    0.0,
 				"big":     math.MaxFloat64,
 				"small":   math.SmallestNonzeroFloat64,
-				"-inf":    0,
-				"+inf":    0,
-				"nan":     0,
 			},
 			SpanID:   "a",
 			TraceID:  "b",

--- a/ddtrace/tracer/writer_test.go
+++ b/ddtrace/tracer/writer_test.go
@@ -17,8 +17,10 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 )
 
-var _ traceWriter = &agentTraceWriter{}
-var _ traceWriter = &logTraceWriter{}
+func TestImplementsTraceWriter(t *testing.T) {
+	assert.Implements(t, (*traceWriter)(nil), &agentTraceWriter{})
+	assert.Implements(t, (*traceWriter)(nil), &logTraceWriter{})
+}
 
 // makeSpan returns a span, adding n entries to meta and metrics each.
 func makeSpan(n int) *span {

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -38,6 +38,7 @@ var (
 
 // UseLogger sets l as the active logger.
 func UseLogger(l ddtrace.Logger) {
+	Flush()
 	mu.Lock()
 	defer mu.Unlock()
 	logger = l


### PR DESCRIPTION
This commit abstracts the handling of finished traces, and includes 2
handlers. One implements the usual behavior, sending traces to the trace
agent. The other supports sending traces in a serverless environment by
writing completed traces to the log.

Fixes #701