### PR TITLE
contrib/database/sql: add query_type span tag

### DIFF
--- a/contrib/database/sql/stmt.go
+++ b/contrib/database/sql/stmt.go
@@ -26,7 +26,7 @@ type tracedStmt struct {
 func (s *tracedStmt) Close() (err error) {
 	start := time.Now()
 	err = s.Stmt.Close()
-	s.tryTrace(s.ctx, "Close", "", start, err)
+	s.tryTrace(s.ctx, queryTypeClose, "", start, err)
 	return err
 }
 
@@ -35,7 +35,7 @@ func (s *tracedStmt) ExecContext(ctx context.Context, args []driver.NamedValue) 
 	start := time.Now()
 	if stmtExecContext, ok := s.Stmt.(driver.StmtExecContext); ok {
 		res, err := stmtExecContext.ExecContext(ctx, args)
-		s.tryTrace(ctx, "Exec", s.query, start, err)
+		s.tryTrace(ctx, queryTypeExec, s.query, start, err)
 		return res, err
 	}
 	dargs, err := namedValueToValue(args)
@@ -48,7 +48,7 @@ func (s *tracedStmt) ExecContext(ctx context.Context, args []driver.NamedValue) 
 	default:
 	}
 	res, err = s.Exec(dargs)
-	s.tryTrace(ctx, "Exec", s.query, start, err)
+	s.tryTrace(ctx, queryTypeExec, s.query, start, err)
 	return res, err
 }
 
@@ -57,7 +57,7 @@ func (s *tracedStmt) QueryContext(ctx context.Context, args []driver.NamedValue)
 	start := time.Now()
 	if stmtQueryContext, ok := s.Stmt.(driver.StmtQueryContext); ok {
 		rows, err := stmtQueryContext.QueryContext(ctx, args)
-		s.tryTrace(ctx, "Query", s.query, start, err)
+		s.tryTrace(ctx, queryTypeQuery, s.query, start, err)
 		return rows, err
 	}
 	dargs, err := namedValueToValue(args)
@@ -70,7 +70,7 @@ func (s *tracedStmt) QueryContext(ctx context.Context, args []driver.NamedValue)
 	default:
 	}
 	rows, err = s.Query(dargs)
-	s.tryTrace(ctx, "Query", s.query, start, err)
+	s.tryTrace(ctx, queryTypeQuery, s.query, start, err)
 	return rows, err
 }
 

--- a/contrib/database/sql/tx.go
+++ b/contrib/database/sql/tx.go
@@ -24,7 +24,7 @@ type tracedTx struct {
 func (t *tracedTx) Commit() (err error) {
 	start := time.Now()
 	err = t.Tx.Commit()
-	t.tryTrace(t.ctx, "Commit", "", start, err)
+	t.tryTrace(t.ctx, queryTypeCommit, "", start, err)
 	return err
 }
 
@@ -32,6 +32,6 @@ func (t *tracedTx) Commit() (err error) {
 func (t *tracedTx) Rollback() (err error) {
 	start := time.Now()
 	err = t.Tx.Rollback()
-	t.tryTrace(t.ctx, "Rollback", "", start, err)
+	t.tryTrace(t.ctx, queryTypeRollback, "", start, err)
 	return err
 }

--- a/contrib/internal/sqltest/sqltest.go
+++ b/contrib/internal/sqltest/sqltest.go
@@ -71,6 +71,7 @@ func testPing(cfg *Config) func(*testing.T) {
 
 		span := spans[0]
 		assert.Equal(cfg.ExpectName, span.OperationName())
+		cfg.ExpectTags["sql.query_type"] = "Ping"
 		for k, v := range cfg.ExpectTags {
 			assert.Equal(v, span.Tag(k), "Value mismatch on tag %s", k)
 		}
@@ -90,6 +91,7 @@ func testQuery(cfg *Config) func(*testing.T) {
 		assert.Len(spans, 1)
 
 		span := spans[0]
+		cfg.ExpectTags["sql.query_type"] = "Query"
 		assert.Equal(cfg.ExpectName, span.OperationName())
 		for k, v := range cfg.ExpectTags {
 			assert.Equal(v, span.Tag(k), "Value mismatch on tag %s", k)
@@ -116,6 +118,7 @@ func testStatement(cfg *Config) func(*testing.T) {
 
 		span := spans[0]
 		assert.Equal(cfg.ExpectName, span.OperationName())
+		cfg.ExpectTags["sql.query_type"] = "Prepare"
 		for k, v := range cfg.ExpectTags {
 			assert.Equal(v, span.Tag(k), "Value mismatch on tag %s", k)
 		}
@@ -128,6 +131,7 @@ func testStatement(cfg *Config) func(*testing.T) {
 		assert.Len(spans, 1)
 		span = spans[0]
 		assert.Equal(cfg.ExpectName, span.OperationName())
+		cfg.ExpectTags["sql.query_type"] = "Exec"
 		for k, v := range cfg.ExpectTags {
 			assert.Equal(v, span.Tag(k), "Value mismatch on tag %s", k)
 		}
@@ -147,6 +151,7 @@ func testBeginRollback(cfg *Config) func(*testing.T) {
 
 		span := spans[0]
 		assert.Equal(cfg.ExpectName, span.OperationName())
+		cfg.ExpectTags["sql.query_type"] = "Begin"
 		for k, v := range cfg.ExpectTags {
 			assert.Equal(v, span.Tag(k), "Value mismatch on tag %s", k)
 		}
@@ -159,6 +164,7 @@ func testBeginRollback(cfg *Config) func(*testing.T) {
 		assert.Len(spans, 1)
 		span = spans[0]
 		assert.Equal(cfg.ExpectName, span.OperationName())
+		cfg.ExpectTags["sql.query_type"] = "Rollback"
 		for k, v := range cfg.ExpectTags {
 			assert.Equal(v, span.Tag(k), "Value mismatch on tag %s", k)
 		}
@@ -195,6 +201,7 @@ func testExec(cfg *Config) func(*testing.T) {
 			}
 		}
 		assert.NotNil(span, "span not found")
+		cfg.ExpectTags["sql.query_type"] = "Exec"
 		for k, v := range cfg.ExpectTags {
 			assert.Equal(v, span.Tag(k), "Value mismatch on tag %s", k)
 		}
@@ -204,6 +211,7 @@ func testExec(cfg *Config) func(*testing.T) {
 			}
 		}
 		assert.NotNil(span, "span not found")
+		cfg.ExpectTags["sql.query_type"] = "Commit"
 		for k, v := range cfg.ExpectTags {
 			assert.Equal(v, span.Tag(k), "Value mismatch on tag %s", k)
 		}


### PR DESCRIPTION
contrib/database/sql: add query_type span tag

This change is to add the query type to the span tags (previously resource). This will help differentiate the spans whenever a `query` has been provided to `tryTrace` (e.g. Prepare and Query for a prepared statement). If a `query` has been provided then the `resource.name` gets set to the query and not the resource.

Extends #270