### PR TITLE
ddtrace/tracer: add debug line to Stop()

### DIFF
--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -100,6 +100,7 @@ func Start(opts ...StartOption) {
 
 // Stop stops the started tracer. Subsequent calls are valid but become no-op.
 func Stop() {
+	log.Debug("Datadog Tracer is stopping...")
 	internal.SetGlobalTracer(&internal.NoopTracer{})
 	log.Flush()
 }


### PR DESCRIPTION
Adding this as it is useful information to know when diagnosing setup issues.