### PR TITLE
profiler: add API key check at initialization of Profiler object

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -78,7 +78,7 @@ func isAPIKeyValid(key string) bool {
 		return false
 	}
 	for _, c := range key {
-		if !unicode.IsLetter(c) && !unicode.IsLower(c) && !unicode.IsNumber(c) {
+		if c > unicode.MaxASCII || (!unicode.IsLower(c) && !unicode.IsNumber(c)) {
 			return false
 		}
 	}

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -85,16 +85,6 @@ func isAPIKeyValid(key string) bool {
 	return true
 }
 
-// sanitizeAPIKey prepares an API key for display, by censoring everything
-// beyond the first 8 characters of the input
-func sanitizeAPIKey(key string) string {
-	ret := []byte(key)
-	for i := 8; i < len(ret); i++ {
-		ret[i] = '*'
-	}
-	return string(ret)
-}
-
 func (c *config) addProfileType(t ProfileType) {
 	if c.types == nil {
 		c.types = make(map[ProfileType]struct{})

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -46,7 +46,7 @@ const (
 )
 
 // Length of valid API key
-const optionApiKeyLength = 32
+const optionAPIKeyLength = 32
 
 var defaultProfileTypes = []ProfileType{CPUProfile, HeapProfile}
 

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -80,7 +80,7 @@ func apiKeyCheck(key string) bool {
 		return false
 	}
 	for _, c := range key {
-		if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9'))) {
+		if !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
 			return false
 		}
 	}

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -76,7 +76,7 @@ func urlForSite(site string) (string, error) {
 
 // Check for API key constraints:
 func apiKeyCheck(key string) bool {
-	if optionApiKeyLength != len(key) {
+	if optionAPIKeyLength != len(key) {
 		return false
 	}
 	for _, c := range key {

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -46,7 +46,7 @@ const (
 )
 
 // Length of valid API key
-const optionApiKeyLength      = 32
+const optionApiKeyLength = 32
 
 var defaultProfileTypes = []ProfileType{CPUProfile, HeapProfile}
 
@@ -168,12 +168,8 @@ func WithAgentAddr(hostport string) Option {
 }
 
 // WithAPIKey specifies the API key to use when connecting to the Datadog API directly, skipping the agent.
-// If the API key might be invalid, emit a warning but otherwise do nothing.
 func WithAPIKey(key string) Option {
 	return func(cfg *config) {
-		if !apiKeyCheck(key) {
-			log.Error("profiler: invalid API key provided, will try to use $DD_API_KEY.")
-		}
 		cfg.apiKey = key
 	}
 }

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -17,7 +18,32 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
+// testAPIKey is an example API key for validation purposes
+const testAPIKey = "12345678901234567890123456789012"
+
 func TestOptions(t *testing.T) {
+	t.Run("APIKeyChecks", func(t *testing.T) {
+		var apikeytests = []struct {
+			in  string
+			out bool
+		}{
+			{"", false}, // Fail, empty string
+			{"1234567890123456789012345678901", false},   // Fail, too short
+			{"123456789012345678901234567890123", false}, // Fail, too long
+			{"12345678901234567890123456789012", true},   // Pass, numeric only
+			{"abcdefabcdabcdefabcdefabcdefabcd", true},   // Pass, alpha only
+			{"abcdefabcdabcdef7890abcdef789012", true},   // Pass, alphanumeric
+			{"abcdefabcdabcdef7890Abcdef789012", false},  // Fail, contains an uppercase
+			{"abcdefabcdabcdef7890@bcdef789012", false},  // Fail, contains an ASCII symbol
+			{"abcdefabcdabcdef7890ábcdef789012", false},  // Fail, lowercase extended ASCII
+			{"abcdefabcdabcdef7890ábcdef78901", false},   // Fail, lowercase extended ASCII, conservative
+		}
+
+		for i, tt := range apikeytests {
+			assert.Equal(t, tt.out, isAPIKeyValid(tt.in), strconv.Itoa(i)+" : "+tt.in)
+		}
+	})
+
 	t.Run("WithAgentAddr", func(t *testing.T) {
 		var cfg config
 		WithAgentAddr("test:123")(&cfg)
@@ -37,20 +63,19 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("WithAPIKey", func(t *testing.T) {
-		var validKey = "12345678901234567890123456789012"
 		var cfg config
-		WithAPIKey(validKey)(&cfg)
-		assert.Equal(t, validKey, cfg.apiKey)
+		WithAPIKey(testAPIKey)(&cfg)
+		assert.Equal(t, testAPIKey, cfg.apiKey)
 		assert.Equal(t, cfg.apiURL, cfg.targetURL)
 	})
 
 	t.Run("WithAPIKey/override", func(t *testing.T) {
 		os.Setenv("DD_API_KEY", "apikey")
 		defer os.Unsetenv("DD_API_KEY")
-		var validKey = "12345678901234567890123456789012"
+		var testAPIKey = "12345678901234567890123456789012"
 		var cfg config
-		WithAPIKey(validKey)(&cfg)
-		assert.Equal(t, validKey, cfg.apiKey)
+		WithAPIKey(testAPIKey)(&cfg)
+		assert.Equal(t, testAPIKey, cfg.apiKey)
 	})
 
 	t.Run("WithURL", func(t *testing.T) {
@@ -181,11 +206,10 @@ func TestEnvVars(t *testing.T) {
 	})
 
 	t.Run("DD_API_KEY", func(t *testing.T) {
-		var validKey = "12345678901234567890123456789012"
-		os.Setenv("DD_API_KEY", validKey)
+		os.Setenv("DD_API_KEY", testAPIKey)
 		defer os.Unsetenv("DD_API_KEY")
 		cfg := defaultConfig()
-		assert.Equal(t, validKey, cfg.apiKey)
+		assert.Equal(t, testAPIKey, cfg.apiKey)
 	})
 
 	t.Run("DD_SITE", func(t *testing.T) {

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -37,18 +37,20 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("WithAPIKey", func(t *testing.T) {
+		var validKey = "12345678901234567890123456789012"
 		var cfg config
-		WithAPIKey("123")(&cfg)
-		assert.Equal(t, "123", cfg.apiKey)
+		WithAPIKey(validKey)(&cfg)
+		assert.Equal(t, validKey, cfg.apiKey)
 		assert.Equal(t, cfg.apiURL, cfg.targetURL)
 	})
 
 	t.Run("WithAPIKey/override", func(t *testing.T) {
 		os.Setenv("DD_API_KEY", "apikey")
 		defer os.Unsetenv("DD_API_KEY")
+		var validKey = "12345678901234567890123456789012"
 		var cfg config
-		WithAPIKey("123")(&cfg)
-		assert.Equal(t, "123", cfg.apiKey)
+		WithAPIKey(validKey)(&cfg)
+		assert.Equal(t, validKey, cfg.apiKey)
 	})
 
 	t.Run("WithURL", func(t *testing.T) {
@@ -179,10 +181,11 @@ func TestEnvVars(t *testing.T) {
 	})
 
 	t.Run("DD_API_KEY", func(t *testing.T) {
-		os.Setenv("DD_API_KEY", "123")
+		var validKey = "12345678901234567890123456789012"
+		os.Setenv("DD_API_KEY", validKey)
 		defer os.Unsetenv("DD_API_KEY")
 		cfg := defaultConfig()
-		assert.Equal(t, "123", cfg.apiKey)
+		assert.Equal(t, validKey, cfg.apiKey)
 	})
 
 	t.Run("DD_SITE", func(t *testing.T) {

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -71,7 +71,7 @@ func newProfiler(opts ...Option) (*profiler, error) {
 	}
 	if cfg.apiKey != "" {
 		if !isAPIKeyValid(cfg.apiKey) {
-			return nil, fmt.Errorf("API key has incorrect format")
+			return nil, errors.New("API key has incorrect format")
 		}
 		cfg.targetURL = cfg.apiURL
 	} else {

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -71,7 +71,7 @@ func newProfiler(opts ...Option) (*profiler, error) {
 	}
 	if cfg.apiKey != "" {
 		if !apiKeyCheck(cfg.apiKey) {
-			return nil, fmt.Errorf("API key has incorrect form (must be 32-character lowercase alphanumeric string). Check calls to profiler.WithAPIKey or the DD_API_KEY environment variable. API key is not required in many configurations.")
+			return nil, fmt.Errorf("API key has incorrect format; try checking your DD_API_KEY environment variable if submitting an API key is necessary for your configuration")
 		}
 		cfg.targetURL = cfg.apiURL
 	} else {

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -71,7 +71,7 @@ func newProfiler(opts ...Option) (*profiler, error) {
 	}
 	if cfg.apiKey != "" {
 		if !isAPIKeyValid(cfg.apiKey) {
-			return nil, fmt.Errorf("API key has incorrect format: %s", sanitizeAPIKey(cfg.apiKey))
+			return nil, fmt.Errorf("API key has incorrect format")
 		}
 		cfg.targetURL = cfg.apiURL
 	} else {

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -70,6 +70,9 @@ func newProfiler(opts ...Option) (*profiler, error) {
 		opt(cfg)
 	}
 	if cfg.apiKey != "" {
+		if !apiKeyCheck(cfg.apiKey) {
+			return nil, fmt.Errorf("API key has incorrect form (must be 32-character lowercase alphanumeric string). Check calls to profiler.WithAPIKey or the DD_API_KEY environment variable. API key is not required in many configurations.")
+		}
 		cfg.targetURL = cfg.apiURL
 	} else {
 		cfg.targetURL = cfg.agentURL

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -6,6 +6,7 @@
 package profiler
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"runtime"

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -70,8 +70,8 @@ func newProfiler(opts ...Option) (*profiler, error) {
 		opt(cfg)
 	}
 	if cfg.apiKey != "" {
-		if !apiKeyCheck(cfg.apiKey) {
-			return nil, fmt.Errorf("API key has incorrect format; try checking your DD_API_KEY environment variable if submitting an API key is necessary for your configuration")
+		if !isAPIKeyValid(cfg.apiKey) {
+			return nil, fmt.Errorf("API key has incorrect format: %s", sanitizeAPIKey(cfg.apiKey))
 		}
 		cfg.targetURL = cfg.apiURL
 	} else {

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -58,6 +58,16 @@ func TestStart(t *testing.T) {
 		assert.NotEmpty(t, activeProfiler.cfg.hostname)
 		mu.Unlock()
 	})
+
+	t.Run("options/GoodAPIKey", func(t *testing.T) {
+		_, err := newProfiler(WithAPIKey("12345678901234567890123456789012"))
+		assert.Nil(t, err)
+	})
+
+	t.Run("options/BadAPIKey", func(t *testing.T) {
+		_, err := newProfiler(WithAPIKey("aaaa"))
+		assert.NotNil(t, err)
+	})
 }
 
 func TestStartStopIdempotency(t *testing.T) {


### PR DESCRIPTION
This change adds a new check which verifies the sanity of the user provided API key and returns an error if the key is invalid.

ref: PROF-1571