### PR TITLE
contrib/go-redis/redis: Enable tracing of Pipelined and TxPipelined

### DIFF
--- a/contrib/go-redis/redis/redis.go
+++ b/contrib/go-redis/redis/redis.go
@@ -153,9 +153,8 @@ func (c *Pipeliner) Pipelined(fn func(redis.Pipeliner) error) ([]redis.Cmder, er
 	if err := fn(c); err != nil {
 		return nil, err
 	}
-	cmds, err := c.Exec()
-	_ = c.Close()
-	return cmds, err
+	defer c.Close()
+	return c.Exec()
 }
 
 // WithContext sets a context on a Client. Use it to ensure that emitted spans have the correct parent.

--- a/contrib/go-redis/redis/redis.go
+++ b/contrib/go-redis/redis/redis.go
@@ -86,6 +86,21 @@ func (c *Client) Pipeline() redis.Pipeliner {
 	return &Pipeliner{c.Client.Pipeline(), c.params, c.Client.Context()}
 }
 
+// Pipelined executes a function parameter to build a Pipeline and then immediately executes it.
+func (c *Client) Pipelined(fn func(redis.Pipeliner) error) ([]redis.Cmder, error) {
+	return c.Pipeline().Pipelined(fn)
+}
+
+// TxPipelined executes a function parameter to build a Transactional Pipeline and then immediately executes it.
+func (c *Client) TxPipelined(fn func(redis.Pipeliner) error) ([]redis.Cmder, error) {
+	return c.TxPipeline().Pipelined(fn)
+}
+
+// TxPipeline acts like Pipeline, but wraps queued commands with MULTI/EXEC.
+func (c *Client) TxPipeline() redis.Pipeliner {
+	return &Pipeliner{c.Client.TxPipeline(), c.params, c.Client.Context()}
+}
+
 // ExecWithContext calls Pipeline.Exec(). It ensures that the resulting Redis calls
 // are traced, and that emitted spans are children of the given Context.
 func (c *Pipeliner) ExecWithContext(ctx context.Context) ([]redis.Cmder, error) {
@@ -131,6 +146,16 @@ func commandsToString(cmds []redis.Cmder) string {
 		b.WriteString("\n")
 	}
 	return b.String()
+}
+
+// Pipelined executes a function parameter to build a Pipeline and then immediately executes the built pipeline.
+func (c *Pipeliner) Pipelined(fn func(redis.Pipeliner) error) ([]redis.Cmder, error) {
+	if err := fn(c); err != nil {
+		return nil, err
+	}
+	cmds, err := c.Exec()
+	_ = c.Close()
+	return cmds, err
 }
 
 // WithContext sets a context on a Client. Use it to ensure that emitted spans have the correct parent.

--- a/contrib/go-redis/redis/redis_test.go
+++ b/contrib/go-redis/redis/redis_test.go
@@ -144,6 +144,50 @@ func TestPipeline(t *testing.T) {
 	assert.Equal("2", span.Tag("redis.pipeline_length"))
 }
 
+func TestPipelined(t *testing.T) {
+	opts := &redis.Options{Addr: "127.0.0.1:6379"}
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	client := NewClient(opts, WithServiceName("my-redis"))
+	_, err := client.Pipelined(func(p redis.Pipeliner) error {
+		p.Expire("pipeline_counter", time.Hour)
+		return nil
+	})
+	assert.NoError(err)
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 1)
+
+	span := spans[0]
+	assert.Equal("redis.command", span.OperationName())
+	assert.Equal(ext.SpanTypeRedis, span.Tag(ext.SpanType))
+	assert.Equal("my-redis", span.Tag(ext.ServiceName))
+	assert.Equal("expire pipeline_counter 3600: false\n", span.Tag(ext.ResourceName))
+	assert.Equal("127.0.0.1", span.Tag(ext.TargetHost))
+	assert.Equal("6379", span.Tag(ext.TargetPort))
+	assert.Equal("1", span.Tag("redis.pipeline_length"))
+
+	mt.Reset()
+	_, err = client.Pipelined(func(p redis.Pipeliner) error {
+		p.Expire("pipeline_counter", time.Hour)
+		p.Expire("pipeline_counter_1", time.Minute)
+		return nil
+	})
+	assert.NoError(err)
+
+	spans = mt.FinishedSpans()
+	assert.Len(spans, 1)
+
+	span = spans[0]
+	assert.Equal("redis.command", span.OperationName())
+	assert.Equal(ext.SpanTypeRedis, span.Tag(ext.SpanType))
+	assert.Equal("my-redis", span.Tag(ext.ServiceName))
+	assert.Equal("expire pipeline_counter 3600: false\nexpire pipeline_counter_1 60: false\n", span.Tag(ext.ResourceName))
+	assert.Equal("2", span.Tag("redis.pipeline_length"))
+}
+
 func TestChildSpan(t *testing.T) {
 	opts := &redis.Options{Addr: "127.0.0.1:6379"}
 	assert := assert.New(t)


### PR DESCRIPTION
Enable tracing of Pipelined and TxPipelined calls.

Fixes #720