### PR TITLE
[contrib/garyburd/redigo] Support go 1.15

### DIFF
--- a/contrib/garyburd/redigo/redigo.go
+++ b/contrib/garyburd/redigo/redigo.go
@@ -127,6 +127,10 @@ func (tc Conn) Do(commandName string, args ...interface{}) (reply interface{}, e
 		}
 	}
 
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	span := tc.newChildSpan(ctx)
 	defer func() {
 		span.Finish(tracer.WithError(err))


### PR DESCRIPTION
go 1.15 doesn't support to create context from nil parent.