### PR TITLE
Add skipper option for echo integrations

### DIFF
--- a/contrib/labstack/echo.v4/echotrace.go
+++ b/contrib/labstack/echo.v4/echotrace.go
@@ -26,6 +26,10 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 			fn(cfg)
 		}
 		return func(c echo.Context) error {
+			if cfg.skipper(c) {
+				return next(c)
+			}
+
 			request := c.Request()
 			resource := request.Method + " " + c.Path()
 			opts := []ddtrace.StartSpanOption{

--- a/contrib/labstack/echo.v4/option.go
+++ b/contrib/labstack/echo.v4/option.go
@@ -9,11 +9,14 @@ import (
 	"math"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+
+	"github.com/labstack/echo/v4/middleware"
 )
 
 type config struct {
 	serviceName   string
 	analyticsRate float64
+	skipper       middleware.Skipper
 }
 
 // Option represents an option that can be passed to Middleware.
@@ -25,6 +28,7 @@ func defaults(cfg *config) {
 		cfg.serviceName = svc
 	}
 	cfg.analyticsRate = math.NaN()
+	cfg.skipper = middleware.DefaultSkipper
 }
 
 // WithServiceName sets the given service name for the system.
@@ -54,5 +58,13 @@ func WithAnalyticsRate(rate float64) Option {
 		} else {
 			cfg.analyticsRate = math.NaN()
 		}
+	}
+}
+
+// WithSkipper defines a function to skip middleware. Returning true skips processing
+// the middleware.
+func WithSkipper(skipper middleware.Skipper) Option {
+	return func(cfg *config) {
+		cfg.skipper = skipper
 	}
 }

--- a/contrib/labstack/echo/echotrace.go
+++ b/contrib/labstack/echo/echotrace.go
@@ -26,6 +26,10 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 			fn(cfg)
 		}
 		return func(c echo.Context) error {
+			if cfg.skipper(c) {
+				return next(c)
+			}
+
 			request := c.Request()
 			resource := request.Method + " " + c.Path()
 			opts := []ddtrace.StartSpanOption{

--- a/contrib/labstack/echo/option.go
+++ b/contrib/labstack/echo/option.go
@@ -10,11 +10,14 @@ import (
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+
+	"github.com/labstack/echo/middleware"
 )
 
 type config struct {
 	serviceName   string
 	analyticsRate float64
+	skipper       middleware.Skipper
 }
 
 // Option represents an option that can be passed to Middleware.
@@ -30,6 +33,7 @@ func defaults(cfg *config) {
 	} else {
 		cfg.analyticsRate = math.NaN()
 	}
+	cfg.skipper = middleware.DefaultSkipper
 }
 
 // WithServiceName sets the given service name for the system.
@@ -59,5 +63,13 @@ func WithAnalyticsRate(rate float64) Option {
 		} else {
 			cfg.analyticsRate = math.NaN()
 		}
+	}
+}
+
+// WithSkipper defines a function to skip middleware. Returning true skips processing
+// the middleware.
+func WithSkipper(skipper middleware.Skipper) Option {
+	return func(cfg *config) {
+		cfg.skipper = skipper
 	}
 }


### PR DESCRIPTION
Most of the middlewares that come from labstack itself have the option to skip the middleware. In my case, I want to skip tracing health check requests.

This PR is related to #735. 