### PR TITLE
contrib/net/http: Add error to span in round tripper

### DIFF
--- a/contrib/net/http/roundtripper.go
+++ b/contrib/net/http/roundtripper.go
@@ -55,11 +55,13 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (res *http.Response, err er
 	res, err = rt.base.RoundTrip(req.WithContext(ctx))
 	if err != nil {
 		span.SetTag("http.errors", err.Error())
+		span.SetTag(ext.Error, err)
 	} else {
 		span.SetTag(ext.HTTPCode, strconv.Itoa(res.StatusCode))
 		// treat 5XX as errors
 		if res.StatusCode/100 == 5 {
 			span.SetTag("http.errors", res.Status)
+			span.SetTag(ext.Error, fmt.Errorf("%d: %s", res.StatusCode, http.StatusText(res.StatusCode)))
 		}
 	}
 	return res, err

--- a/contrib/net/http/roundtripper_test.go
+++ b/contrib/net/http/roundtripper_test.go
@@ -158,7 +158,7 @@ func TestRoundTripperNetworkError(t *testing.T) {
 	assert.Equal(t, nil, s0.Tag(ext.HTTPCode))
 	assert.Equal(t, "GET", s0.Tag(ext.HTTPMethod))
 	assert.Equal(t, "/hello/world", s0.Tag(ext.HTTPURL))
-	assert.Equal(t, fmt.Errorf("net/http: request canceled"), s0.Tag(ext.Error))
+	assert.NotNil(t, s0.Tag(ext.Error))
 	assert.Equal(t, true, s0.Tag("CalledBefore"))
 	assert.Equal(t, true, s0.Tag("CalledAfter"))
 }

--- a/contrib/net/http/roundtripper_test.go
+++ b/contrib/net/http/roundtripper_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
@@ -65,6 +66,101 @@ func TestRoundTripper(t *testing.T) {
 	assert.Equal(t, "/hello/world", s1.Tag(ext.HTTPURL))
 	assert.Equal(t, true, s1.Tag("CalledBefore"))
 	assert.Equal(t, true, s1.Tag("CalledAfter"))
+}
+
+func TestRoundTripperServerError(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(r.Header))
+		assert.NoError(t, err)
+
+		span := tracer.StartSpan("test",
+			tracer.ChildOf(spanctx))
+		defer span.Finish()
+
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("Error"))
+	}))
+	defer s.Close()
+
+	rt := WrapRoundTripper(http.DefaultTransport,
+		WithBefore(func(req *http.Request, span ddtrace.Span) {
+			span.SetTag("CalledBefore", true)
+		}),
+		WithAfter(func(res *http.Response, span ddtrace.Span) {
+			span.SetTag("CalledAfter", true)
+		}))
+
+	client := &http.Client{
+		Transport: rt,
+	}
+
+	client.Get(s.URL + "/hello/world")
+
+	spans := mt.FinishedSpans()
+	assert.Len(t, spans, 2)
+	assert.Equal(t, spans[0].TraceID(), spans[1].TraceID())
+
+	s0 := spans[0]
+	assert.Equal(t, "test", s0.OperationName())
+	assert.Equal(t, "test", s0.Tag(ext.ResourceName))
+
+	s1 := spans[1]
+	assert.Equal(t, "http.request", s1.OperationName())
+	assert.Equal(t, "http.request", s1.Tag(ext.ResourceName))
+	assert.Equal(t, "500", s1.Tag(ext.HTTPCode))
+	assert.Equal(t, "GET", s1.Tag(ext.HTTPMethod))
+	assert.Equal(t, "/hello/world", s1.Tag(ext.HTTPURL))
+	assert.Equal(t, fmt.Errorf("500: Internal Server Error"), s1.Tag(ext.Error))
+	assert.Equal(t, true, s1.Tag("CalledBefore"))
+	assert.Equal(t, true, s1.Tag("CalledAfter"))
+}
+
+func TestRoundTripperNetworkError(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(r.Header))
+		assert.NoError(t, err)
+
+		span := tracer.StartSpan("test",
+			tracer.ChildOf(spanctx))
+		defer span.Finish()
+		time.Sleep(10 * time.Millisecond)
+		w.Write([]byte("Timeout"))
+	}))
+	defer s.Close()
+
+	rt := WrapRoundTripper(http.DefaultTransport,
+		WithBefore(func(req *http.Request, span ddtrace.Span) {
+			span.SetTag("CalledBefore", true)
+		}),
+		WithAfter(func(res *http.Response, span ddtrace.Span) {
+			span.SetTag("CalledAfter", true)
+		}))
+
+	client := &http.Client{
+		Transport: rt,
+		Timeout:   1 * time.Millisecond,
+	}
+
+	client.Get(s.URL + "/hello/world")
+
+	spans := mt.FinishedSpans()
+	assert.Len(t, spans, 1)
+
+	s0 := spans[0]
+	assert.Equal(t, "http.request", s0.OperationName())
+	assert.Equal(t, "http.request", s0.Tag(ext.ResourceName))
+	assert.Equal(t, nil, s0.Tag(ext.HTTPCode))
+	assert.Equal(t, "GET", s0.Tag(ext.HTTPMethod))
+	assert.Equal(t, "/hello/world", s0.Tag(ext.HTTPURL))
+	assert.Equal(t, fmt.Errorf("net/http: request canceled"), s0.Tag(ext.Error))
+	assert.Equal(t, true, s0.Tag("CalledBefore"))
+	assert.Equal(t, true, s0.Tag("CalledAfter"))
 }
 
 func TestWrapClient(t *testing.T) {


### PR DESCRIPTION
closes https://github.com/DataDog/dd-trace-go/issues/728