### PR TITLE
ddtrace/tracer: add WithDebugStack StartOption to configure stack traces.

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -92,6 +92,10 @@ type config struct {
 	// tickChan specifies a channel which will receive the time every time the tracer must flush.
 	// It defaults to time.Ticker; replaced in tests.
 	tickChan <-chan time.Time
+
+	// noDebugStack disables the collection of debug stack traces globally. No traces reporting
+	// errors will record a stack trace when this option is set.
+	noDebugStack bool
 }
 
 // StartOption represents a function that can be provided as a parameter to Start.
@@ -246,6 +250,15 @@ func WithLogger(logger ddtrace.Logger) StartOption {
 func WithPrioritySampling() StartOption {
 	return func(c *config) {
 		// This is now enabled by default.
+	}
+}
+
+// WithDebugStack can be used to globally enable or disable the collection of stack traces when
+// spans finish with errors. It is enabled by default. This is a global version of the NoDebugStack
+// FinishOption.
+func WithDebugStack(enabled bool) StartOption {
+	return func(c *config) {
+		c.noDebugStack = !enabled
 	}
 }
 

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -264,6 +264,7 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		TraceID:  id,
 		Start:    startTime,
 		taskEnd:  startExecutionTracerTask(operationName),
+		errCfg:   errorConfig{noDebugStack: t.config.noDebugStack},
 	}
 	if context != nil {
 		// this is a child span

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -257,14 +257,14 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 	}
 	// span defaults
 	span := &span{
-		Name:     operationName,
-		Service:  t.config.serviceName,
-		Resource: operationName,
-		SpanID:   id,
-		TraceID:  id,
-		Start:    startTime,
-		taskEnd:  startExecutionTracerTask(operationName),
-		errCfg:   errorConfig{noDebugStack: t.config.noDebugStack},
+		Name:         operationName,
+		Service:      t.config.serviceName,
+		Resource:     operationName,
+		SpanID:       id,
+		TraceID:      id,
+		Start:        startTime,
+		taskEnd:      startExecutionTracerTask(operationName),
+		noDebugStack: t.config.noDebugStack,
 	}
 	if context != nil {
 		// this is a child span


### PR DESCRIPTION
By default a stack trace is collected when a span is finished with an
error. This can be disabled by passing tracer.NoDebugStack to
span.Finish(). Sometimes it is desirable to disable this option globally,
which is now possible with the WithDebugStack StartOption that this commit
introduces.
