### PR TITLE
contrib/go-chi/chi: Handle 0 status code correctly

### DIFF
--- a/contrib/go-chi/chi/chi.go
+++ b/contrib/go-chi/chi/chi.go
@@ -61,6 +61,10 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 
 			// set the status code
 			status := ww.Status()
+			// 0 status means one has not yet been sent in which case net/http library will write StatusOK
+			if ww.Status() == 0 {
+				status = http.StatusOK
+			}
 			span.SetTag(ext.HTTPCode, strconv.Itoa(status))
 
 			if status >= 500 && status < 600 {


### PR DESCRIPTION
When the user doesn't call `w.WriteHeader(...)` or `w.Write(...)` in the request handler or any of the middlewares the status isn't set and `WrapResponseWriter.Status()` returns 0. This is well documented behavior: https://github.com/go-chi/chi/blob/cf97bef8b1405c9177bd88eca166ed4f16b9fc80/middleware/wrap_writer.go#L45

In such a case `net/http` library takes the matters into its own hands and writes 200 status code: https://github.com/golang/go/blob/7e9369a517d9ebf867748719948d8cbccec3bc57/src/net/http/server.go#L1618


Try this code:
```
package main

import (
	"net/http"

	"github.com/go-chi/chi"
	"github.com/go-chi/chi/middleware"
)

func main() {
	r := chi.NewRouter()
	r.Use(middleware.Logger)
	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
	})
	http.ListenAndServe(":3000", r)
}
```
with:
```
curl -i http://localhost:3000
```

Result:
```
HTTP/1.1 200 OK
Date: Mon, 21 Sep 2020 12:00:00 GMT
Content-Length: 0
```

Observe the 000 status code logged by chi's logging middleware that similarly relies on `ww.Status()` https://github.com/go-chi/chi/blob/cf97bef8b1405c9177bd88eca166ed4f16b9fc80/middleware/logger.go#L43:
```
2020/09/21 12:00:00 "GET http://localhost:3000/ HTTP/1.1" from [::1]:50000 - 000 0B in 10.001µs
```

Without changes proposed in this PR traces have empty status code in similar cases.