### PR TITLE
ddtrace/tracer: StartSpanFromContext should work nil ctx on Go 1.15

### DIFF
--- a/ddtrace/tracer/context.go
+++ b/ddtrace/tracer/context.go
@@ -40,11 +40,10 @@ func SpanFromContext(ctx context.Context) (Span, bool) {
 // option is passed, the span from context will take precedence over it as the parent span.
 // If ctx is nil, this will use context.Background().
 func StartSpanFromContext(ctx context.Context, operationName string, opts ...StartSpanOption) (Span, context.Context) {
-	// default to context.Background() to avoid panics on Go >= 1.15
 	if ctx == nil {
+		// default to context.Background() to avoid panics on Go >= 1.15
 		ctx = context.Background()
 	}
-
 	if s, ok := SpanFromContext(ctx); ok {
 		opts = append(opts, ChildOf(s.Context()))
 	}

--- a/ddtrace/tracer/context.go
+++ b/ddtrace/tracer/context.go
@@ -38,7 +38,6 @@ func SpanFromContext(ctx context.Context) (Span, bool) {
 // StartSpanFromContext returns a new span with the given operation name and options. If a span
 // is found in the context, it will be used as the parent of the resulting span. If the ChildOf
 // option is passed, the span from context will take precedence over it as the parent span.
-// If ctx is nil, this will use context.Background().
 func StartSpanFromContext(ctx context.Context, operationName string, opts ...StartSpanOption) (Span, context.Context) {
 	if ctx == nil {
 		// default to context.Background() to avoid panics on Go >= 1.15

--- a/ddtrace/tracer/context.go
+++ b/ddtrace/tracer/context.go
@@ -38,7 +38,13 @@ func SpanFromContext(ctx context.Context) (Span, bool) {
 // StartSpanFromContext returns a new span with the given operation name and options. If a span
 // is found in the context, it will be used as the parent of the resulting span. If the ChildOf
 // option is passed, the span from context will take precedence over it as the parent span.
+// If ctx is nil, this will use context.Background().
 func StartSpanFromContext(ctx context.Context, operationName string, opts ...StartSpanOption) (Span, context.Context) {
+	// default to context.Background() to avoid panics on Go >= 1.15
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	if s, ok := SpanFromContext(ctx); ok {
 		opts = append(opts, ChildOf(s.Context()))
 	}

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -74,3 +74,24 @@ func TestStartSpanFromContext(t *testing.T) {
 	assert.Equal("gin", got.Service)
 	assert.Equal("/", got.Resource)
 }
+
+func TestStartSpanFromNilContext(t *testing.T) {
+	_, _, _, stop := startTestTracer(t)
+	defer stop()
+
+	// Go before 1.15: StartSpanFromContext(nil, ...) worked; calling ctx.Value would segfault
+	// Go == 1.15: StartSpanFromContext(nil, ...) would panic: cannot create context from nil parent
+	child, ctx := StartSpanFromContext(nil, "http.request")
+	assert := assert.New(t)
+	// ensure the returned context works
+	assert.Nil(ctx.Value("not_found_key"))
+
+	internalSpan, ok := child.(*span)
+	assert.True(ok)
+	assert.Equal("http.request", internalSpan.Name)
+
+	// the returned context includes the span
+	ctxSpan, ok := SpanFromContext(ctx)
+	assert.True(ok)
+	assert.Equal(child, ctxSpan)
+}

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -79,8 +79,6 @@ func TestStartSpanFromNilContext(t *testing.T) {
 	_, _, _, stop := startTestTracer(t)
 	defer stop()
 
-	// Go before 1.15: StartSpanFromContext(nil, ...) worked; calling ctx.Value would segfault
-	// Go == 1.15: StartSpanFromContext(nil, ...) would panic: cannot create context from nil parent
 	child, ctx := StartSpanFromContext(nil, "http.request")
 	assert := assert.New(t)
 	// ensure the returned context works


### PR DESCRIPTION
Previously, StartSpanFromContext would "work" with nil ctx. Using the
ctx (e.g. ctx.Value) would later cause a segfault. With Go 1.15,
calling StartSpanFromContext now panics. Preserve the existing
behaviour by defaulting to context.Background(). Document this
behaviour. Add a test.

Without the fix, on Go 1.14 this new test panics with "runtime error:
invalid memory address or nil pointer dereference" when calling
context.Value. On Go 1.15 it fails with "cannot create context from
nil parent" when calling StartSpanFromContext.