### PR TITLE
dd-trace: unbreak osinfo_default

### DIFF
--- a/ddtrace/tracer/osinfo_default.go
+++ b/ddtrace/tracer/osinfo_default.go
@@ -16,5 +16,5 @@ func osName() string {
 }
 
 func osVersion() string {
-	return unknownVersion
+	return unknown
 }


### PR DESCRIPTION
unknownVersion is undefined, so replace it with unknown to allow
building on (at least) BSD systems.