### PR TITLE
contrib/cloud.google.com/go/pubsub.v1: Add WithServiceName option

### DIFF
--- a/contrib/cloud.google.com/go/pubsub.v1/pubsub.go
+++ b/contrib/cloud.google.com/go/pubsub.v1/pubsub.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"sync"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
@@ -63,15 +64,31 @@ func (r *PublishResult) Get(ctx context.Context) (string, error) {
 	return serverID, err
 }
 
+type config struct {
+	serviceName string
+}
+
+// A ReceiveOption is used to customize spans started by WrapReceiveHandler.
+type ReceiveOption func(cfg *config)
+
+// WithServiceName sets the service name tag for traces started by WrapReceiveHandler.
+func WithServiceName(serviceName string) ReceiveOption {
+	return func(cfg *config) {
+		cfg.serviceName = serviceName
+	}
+}
+
 // WrapReceiveHandler returns a receive handler that wraps the supplied handler,
 // extracts any tracing metadata attached to the received message, and starts a
 // receive span.
-func WrapReceiveHandler(s *pubsub.Subscription, f func(context.Context, *pubsub.Message)) func(context.Context, *pubsub.Message) {
+func WrapReceiveHandler(s *pubsub.Subscription, f func(context.Context, *pubsub.Message), opts ...ReceiveOption) func(context.Context, *pubsub.Message) {
+	var cfg config
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 	return func(ctx context.Context, msg *pubsub.Message) {
 		parentSpanCtx, _ := tracer.Extract(tracer.TextMapCarrier(msg.Attributes))
-		span, ctx := tracer.StartSpanFromContext(
-			ctx,
-			"pubsub.receive",
+		opts := []ddtrace.StartSpanOption{
 			tracer.ResourceName(s.String()),
 			tracer.SpanType(ext.SpanTypeMessageConsumer),
 			tracer.Tag("message_size", len(msg.Data)),
@@ -80,7 +97,11 @@ func WrapReceiveHandler(s *pubsub.Subscription, f func(context.Context, *pubsub.
 			tracer.Tag("message_id", msg.ID),
 			tracer.Tag("publish_time", msg.PublishTime.String()),
 			tracer.ChildOf(parentSpanCtx),
-		)
+		}
+		if cfg.serviceName != "" {
+			opts = append(opts, tracer.ServiceName(cfg.serviceName))
+		}
+		span, ctx := tracer.StartSpanFromContext(ctx, "pubsub.receive", opts...)
 		if msg.DeliveryAttempt != nil {
 			span.SetTag("delivery_attempt", *msg.DeliveryAttempt)
 		}


### PR DESCRIPTION
This adds a new options parameter, as well as a new option for `WrapReceiveHandler`, so that GCP pubsub receivers can set a custom service name for their traces.

This PR also introduces an options pattern for this library, so that other options can be added in the future.

For the unit test, I was somewhat lazy, in that I simply copied the existing test and modified it to utilize the new option.

This solution will work for my use-case, but it won't be sufficient in case the pubsub receiver is started in the context of another trace. I don't think it is common to set up new receivers dynamically, but I did want to call that out as a limitation to this solution.

Feel free to leave code review notes or make commits to this branch directly. Thanks!

Fixes #752. 

cc/ #721 @CAFxX @knusbaum @gbbr 