### PR TITLE
contrib/Shopify/sarama: use sarama.MinVersion in tests.

### DIFF
--- a/contrib/Shopify/sarama/sarama_test.go
+++ b/contrib/Shopify/sarama/sarama_test.go
@@ -36,8 +36,9 @@ func TestConsumer(t *testing.T) {
 			SetMessage("test-topic", 0, 0, sarama.StringEncoder("hello")).
 			SetMessage("test-topic", 0, 1, sarama.StringEncoder("world")),
 	})
-
-	client, err := sarama.NewClient([]string{broker.Addr()}, sarama.NewConfig())
+	cfg := sarama.NewConfig()
+	cfg.Version = sarama.MinVersion
+	client, err := sarama.NewClient([]string{broker.Addr()}, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,6 +114,7 @@ func TestSyncProducer(t *testing.T) {
 	leader.Returns(prodSuccess)
 
 	cfg := sarama.NewConfig()
+	cfg.Version = sarama.MinVersion
 	cfg.Producer.Return.Successes = true
 
 	producer, err := sarama.NewSyncProducer([]string{seedBroker.Addr()}, cfg)
@@ -160,6 +162,7 @@ func TestSyncProducerSendMessages(t *testing.T) {
 	leader.Returns(prodSuccess)
 
 	cfg := sarama.NewConfig()
+	cfg.Version = sarama.MinVersion
 	cfg.Producer.Return.Successes = true
 	cfg.Producer.Flush.Messages = 2
 
@@ -200,7 +203,9 @@ func TestAsyncProducer(t *testing.T) {
 
 		broker := newMockBroker(t)
 
-		producer, err := sarama.NewAsyncProducer([]string{broker.Addr()}, nil)
+		cfg := sarama.NewConfig()
+		cfg.Version = sarama.MinVersion
+		producer, err := sarama.NewAsyncProducer([]string{broker.Addr()}, cfg)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -234,6 +239,7 @@ func TestAsyncProducer(t *testing.T) {
 		broker := newMockBroker(t)
 
 		cfg := sarama.NewConfig()
+		cfg.Version = sarama.MinVersion
 		cfg.Producer.Return.Successes = true
 
 		producer, err := sarama.NewAsyncProducer([]string{broker.Addr()}, cfg)


### PR DESCRIPTION
Starting in github.com/Shopify/sarama@v1.27.1, the default kafka version
that the client uses is 1.0.0 (sarama.V1_0_0_0) rather that the previous
0.8.2 (sarama.V0_8_2_0) Unfortunately, the Sarama client for Kafka 1.0.0
does not work with the mock broker, so this change breaks our tests. To
repair the situation, we specify that the client should use version 0.8.2.
If Sarama fixes their mock client in the future, we can use the default
version instead.