### PR TITLE
contrib/jmoiron/sqlx: allow options to sqlx.Open

### DIFF
--- a/contrib/jmoiron/sqlx/sql.go
+++ b/contrib/jmoiron/sqlx/sql.go
@@ -20,8 +20,8 @@ import (
 
 // Open opens a new (traced) connection to the database using the given driver and source.
 // Note that the driver must formerly be registered using database/sql integration's Register.
-func Open(driverName, dataSourceName string) (*sqlx.DB, error) {
-	db, err := sqltraced.Open(driverName, dataSourceName)
+func Open(driverName, dataSourceName string, opts ...sqltraced.Option) (*sqlx.DB, error) {
+	db, err := sqltraced.Open(driverName, dataSourceName, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR provides additional options to open database connection with sqlx.Open, same as following PullRequest.
https://github.com/DataDog/dd-trace-go/pull/466

It allow us to override some parameters, such as service name, for multiple database connection.