### PR TITLE
profiler: set profiler upload timeout to 10s

### DIFF
--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -27,7 +27,7 @@ var errOldAgent = errors.New("Datadog Agent is not accepting profiles. Agent-bas
 	"require Datadog Agent >= 7.20")
 
 var httpClient = &http.Client{
-	Timeout: 5 * time.Second,
+	Timeout: 10 * time.Second,
 }
 
 // backoffDuration calculates the backoff duration given an attempt number and max duration


### PR DESCRIPTION
This brings it in line with the other pprof-based profilers