### PR TITLE
ddtrace/tracer: add span.SetTags method

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -105,7 +105,7 @@ func (s *span) SetTag(key string, value interface{}) {
 }
 
 // SetTags adds multiple key/value metadata to the span from the map.
-func (s *span) SetTags(tags map[string]interface{}) {
+func (s *span) SetTags(tags map[string]string) {
 	s.Lock()
 	defer s.Unlock()
 	// We don't lock spans when flushing, so we could have a data race when
@@ -115,7 +115,7 @@ func (s *span) SetTags(tags map[string]interface{}) {
 		return
 	}
 	for key, value := range tags {
-		s.setTag(key, value)
+		s.setMeta(key, value)
 	}
 }
 

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -209,7 +209,7 @@ func TestSpanSetTags(t *testing.T) {
 
 	span := newBasicSpan("test")
 	tags := map[string]string{
-		"component": "tracer",
+		"component":          "tracer",
 		"git.repository_url": "https://github.com/DataDog/dd-trace-go.git",
 	}
 	span.SetTags(tags)
@@ -217,7 +217,6 @@ func TestSpanSetTags(t *testing.T) {
 		assert.Equal(value, span.Meta[key])
 	}
 }
-
 
 func TestSpanSetDatadogTags(t *testing.T) {
 	assert := assert.New(t)

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -204,6 +204,22 @@ func TestSpanSetTag(t *testing.T) {
 	assert.Equal("false", span.Meta["some.other.bool"])
 }
 
+func TestSpanSetTags(t *testing.T) {
+	assert := assert.New(t)
+
+	span := newBasicSpan("test")
+	tags := map[string]interface{}{
+		"component": "tracer",
+		"tagInt": 1234,
+		"some.bool": true,
+	}
+	span.SetTags(tags)
+	assert.Equal("tracer", span.Meta["component"])
+	assert.Equal(float64(1234), span.Metrics["tagInt"])
+	assert.Equal("true", span.Meta["some.bool"])
+}
+
+
 func TestSpanSetDatadogTags(t *testing.T) {
 	assert := assert.New(t)
 

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -208,15 +208,14 @@ func TestSpanSetTags(t *testing.T) {
 	assert := assert.New(t)
 
 	span := newBasicSpan("test")
-	tags := map[string]interface{}{
+	tags := map[string]string{
 		"component": "tracer",
-		"tagInt": 1234,
-		"some.bool": true,
+		"git.repository_url": "https://github.com/DataDog/dd-trace-go.git",
 	}
 	span.SetTags(tags)
-	assert.Equal("tracer", span.Meta["component"])
-	assert.Equal(float64(1234), span.Metrics["tagInt"])
-	assert.Equal("true", span.Meta["some.bool"])
+	for key, value := range tags {
+		assert.Equal(value, span.Meta[key])
+	}
 }
 
 


### PR DESCRIPTION
Add `SetTags` method to help with setting multiple tags at once.

1. **It avoids locking per key for spans with many tags.**
1. This method is particularly useful in combination with #770 which extract multiple tags from CI providers at once.
1. Brings a feature parity with [`dd-trace-py`](https://github.com/DataDog/dd-trace-py/blob/9640832e67d20580f5e23f1c2d213a12e1331081/ddtrace/span.py#L269-L275), [`dd-trace-rb`](https://github.com/DataDog/dd-trace-rb/blob/4c8285d26880be48aba9ba5d7bf8eae60852f4b6/lib/ddtrace/span.rb#L128-L130), 

