### PR TITLE
contrib/go-chi/chi: Added option to set custom error status check

### DIFF
--- a/contrib/go-chi/chi/chi.go
+++ b/contrib/go-chi/chi/chi.go
@@ -67,7 +67,7 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 			}
 			span.SetTag(ext.HTTPCode, strconv.Itoa(status))
 
-			if status >= 500 && status < 600 {
+			if cfg.isError(status) {
 				// mark 5xx server error
 				span.SetTag(ext.Error, fmt.Errorf("%d: %s", status, http.StatusText(status)))
 			}

--- a/contrib/go-chi/chi/chi.go
+++ b/contrib/go-chi/chi/chi.go
@@ -67,7 +67,7 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 			}
 			span.SetTag(ext.HTTPCode, strconv.Itoa(status))
 
-			if cfg.isError(status) {
+			if cfg.statusCheck(status) {
 				// mark 5xx server error
 				span.SetTag(ext.Error, fmt.Errorf("%d: %s", status, http.StatusText(status)))
 			}

--- a/contrib/go-chi/chi/chi.go
+++ b/contrib/go-chi/chi/chi.go
@@ -67,7 +67,7 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 			}
 			span.SetTag(ext.HTTPCode, strconv.Itoa(status))
 
-			if cfg.statusCheck(status) {
+			if cfg.isStatusError(status) {
 				// mark 5xx server error
 				span.SetTag(ext.Error, fmt.Errorf("%d: %s", status, http.StatusText(status)))
 			}

--- a/contrib/go-chi/chi/chi_test.go
+++ b/contrib/go-chi/chi/chi_test.go
@@ -150,7 +150,7 @@ func TestError(t *testing.T) {
 
 		router.Use(Middleware(
 			WithServiceName("foobar"),
-			WithIsErrorCheck(func(statusCode int) bool {
+			WithStatusCheck(func(statusCode int) bool {
 				return statusCode >= 400
 			}),
 		))

--- a/contrib/go-chi/chi/chi_test.go
+++ b/contrib/go-chi/chi/chi_test.go
@@ -137,7 +137,6 @@ func TestError(t *testing.T) {
 		// verify the errors and status are correct
 		spans := mt.FinishedSpans()
 		assertSpan(assert, spans, code)
-
 	})
 
 	t.Run("with custome isError function", func(t *testing.T) {
@@ -155,7 +154,6 @@ func TestError(t *testing.T) {
 		))
 
 		code := 404
-
 		// a handler with an error and make the requests
 		router.Get("/err", func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, fmt.Sprintf("%d!", code), code)

--- a/contrib/go-chi/chi/chi_test.go
+++ b/contrib/go-chi/chi/chi_test.go
@@ -114,7 +114,7 @@ func TestError(t *testing.T) {
 		wantErr := fmt.Sprintf("%d: %s", code, http.StatusText(code))
 		assert.Equal(wantErr, span.Tag(ext.Error).(error).Error())
 	}
-	t.Run("with default isError function", func(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
 		assert := assert.New(t)
 		mt := mocktracer.Start()
 		defer mt.Stop()
@@ -139,7 +139,7 @@ func TestError(t *testing.T) {
 		assertSpan(assert, spans, code)
 	})
 
-	t.Run("with custome isError function", func(t *testing.T) {
+	t.Run("custom", func(t *testing.T) {
 		assert := assert.New(t)
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/contrib/go-chi/chi/chi_test.go
+++ b/contrib/go-chi/chi/chi_test.go
@@ -114,6 +114,7 @@ func TestError(t *testing.T) {
 		wantErr := fmt.Sprintf("%d: %s", code, http.StatusText(code))
 		assert.Equal(wantErr, span.Tag(ext.Error).(error).Error())
 	}
+
 	t.Run("default", func(t *testing.T) {
 		assert := assert.New(t)
 		mt := mocktracer.Start()
@@ -152,7 +153,6 @@ func TestError(t *testing.T) {
 				return statusCode >= 400
 			}),
 		))
-
 		code := 404
 		// a handler with an error and make the requests
 		router.Get("/err", func(w http.ResponseWriter, r *http.Request) {

--- a/contrib/go-chi/chi/chi_test.go
+++ b/contrib/go-chi/chi/chi_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
@@ -99,37 +100,78 @@ func TestTrace200(t *testing.T) {
 }
 
 func TestError(t *testing.T) {
-	assert := assert.New(t)
-	mt := mocktracer.Start()
-	defer mt.Stop()
+	assertSpan := func(assert *assert.Assertions, spans []mocktracer.Span, code int) {
+		assert.Len(spans, 1)
+		if len(spans) < 1 {
+			t.Fatalf("no spans")
+		}
+		span := spans[0]
+		assert.Equal("http.request", span.OperationName())
+		assert.Equal("foobar", span.Tag(ext.ServiceName))
 
-	// setup
-	router := chi.NewRouter()
-	router.Use(Middleware(WithServiceName("foobar")))
-	code := 500
-	wantErr := fmt.Sprintf("%d: %s", code, http.StatusText(code))
+		assert.Equal(strconv.Itoa(code), span.Tag(ext.HTTPCode))
 
-	// a handler with an error and make the requests
-	router.Get("/err", func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, fmt.Sprintf("%d!", code), code)
-	})
-	r := httptest.NewRequest("GET", "/err", nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, r)
-	response := w.Result()
-	assert.Equal(response.StatusCode, 500)
-
-	// verify the errors and status are correct
-	spans := mt.FinishedSpans()
-	assert.Len(spans, 1)
-	if len(spans) < 1 {
-		t.Fatalf("no spans")
+		wantErr := fmt.Sprintf("%d: %s", code, http.StatusText(code))
+		assert.Equal(wantErr, span.Tag(ext.Error).(error).Error())
 	}
-	span := spans[0]
-	assert.Equal("http.request", span.OperationName())
-	assert.Equal("foobar", span.Tag(ext.ServiceName))
-	assert.Equal("500", span.Tag(ext.HTTPCode))
-	assert.Equal(wantErr, span.Tag(ext.Error).(error).Error())
+	t.Run("with default isError function", func(t *testing.T) {
+		assert := assert.New(t)
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		// setup
+		router := chi.NewRouter()
+		router.Use(Middleware(WithServiceName("foobar")))
+		code := 500
+
+		// a handler with an error and make the requests
+		router.Get("/err", func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, fmt.Sprintf("%d!", code), code)
+		})
+		r := httptest.NewRequest("GET", "/err", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, r)
+		response := w.Result()
+		assert.Equal(response.StatusCode, code)
+
+		// verify the errors and status are correct
+		spans := mt.FinishedSpans()
+		assertSpan(assert, spans, code)
+
+	})
+
+	t.Run("with custome isError function", func(t *testing.T) {
+		assert := assert.New(t)
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		// setup
+		router := chi.NewRouter()
+
+		router.Use(Middleware(
+			WithServiceName("foobar"),
+			WithIsErrorCheck(func(statusCode int) bool {
+				return statusCode >= 400
+			}),
+		))
+
+		code := 404
+
+		// a handler with an error and make the requests
+		router.Get("/err", func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, fmt.Sprintf("%d!", code), code)
+		})
+		r := httptest.NewRequest("GET", "/err", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, r)
+		response := w.Result()
+		assert.Equal(response.StatusCode, code)
+
+		// verify the errors and status are correct
+		spans := mt.FinishedSpans()
+		assertSpan(assert, spans, code)
+	})
+
 }
 
 func TestGetSpanNotInstrumented(t *testing.T) {

--- a/contrib/go-chi/chi/chi_test.go
+++ b/contrib/go-chi/chi/chi_test.go
@@ -147,7 +147,6 @@ func TestError(t *testing.T) {
 
 		// setup
 		router := chi.NewRouter()
-
 		router.Use(Middleware(
 			WithServiceName("foobar"),
 			WithStatusCheck(func(statusCode int) bool {
@@ -171,7 +170,6 @@ func TestError(t *testing.T) {
 		spans := mt.FinishedSpans()
 		assertSpan(assert, spans, code)
 	})
-
 }
 
 func TestGetSpanNotInstrumented(t *testing.T) {

--- a/contrib/go-chi/chi/option.go
+++ b/contrib/go-chi/chi/option.go
@@ -17,7 +17,7 @@ type config struct {
 	serviceName   string
 	spanOpts      []ddtrace.StartSpanOption // additional span options to be applied
 	analyticsRate float64
-	isStatusError   func(statusCode int) bool
+	isStatusError func(statusCode int) bool
 }
 
 // Option represents an option that can be passed to NewRouter.
@@ -78,7 +78,7 @@ func WithAnalyticsRate(rate float64) Option {
 // statusCode should be considered an error.
 func WithStatusCheck(fn func(statusCode int) bool) Option {
 	return func(cfg *config) {
-		cfg.isStatusError = isStatusError
+		cfg.isStatusError = fn
 	}
 }
 

--- a/contrib/go-chi/chi/option.go
+++ b/contrib/go-chi/chi/option.go
@@ -75,9 +75,9 @@ func WithAnalyticsRate(rate float64) Option {
 	}
 }
 
-// WithStatusCheck sets the function which is used to decide whther the
-// status should be marked as an error
-func WithStatusCheck(statusCheck func(statusCode int) bool) Option {
+// WithStatusCheck specifies a function fn which reports whether the passed
+// statusCode should be considered an error.
+func WithStatusCheck(fn func(statusCode int) bool) Option {
 	return func(cfg *config) {
 		cfg.statusCheck = statusCheck
 	}

--- a/contrib/go-chi/chi/option.go
+++ b/contrib/go-chi/chi/option.go
@@ -17,7 +17,7 @@ type config struct {
 	serviceName   string
 	spanOpts      []ddtrace.StartSpanOption // additional span options to be applied
 	analyticsRate float64
-	statusCheck   func(statusCode int) bool
+	isStatusError   func(statusCode int) bool
 }
 
 // Option represents an option that can be passed to NewRouter.
@@ -33,7 +33,7 @@ func defaults(cfg *config) {
 	} else {
 		cfg.analyticsRate = globalconfig.AnalyticsRate()
 	}
-	cfg.statusCheck = isServerError
+	cfg.isStatusError = isServerError
 }
 
 // WithServiceName sets the given service name for the router.
@@ -78,7 +78,7 @@ func WithAnalyticsRate(rate float64) Option {
 // statusCode should be considered an error.
 func WithStatusCheck(fn func(statusCode int) bool) Option {
 	return func(cfg *config) {
-		cfg.statusCheck = statusCheck
+		cfg.isStatusError = isStatusError
 	}
 }
 

--- a/contrib/go-chi/chi/option.go
+++ b/contrib/go-chi/chi/option.go
@@ -33,7 +33,6 @@ func defaults(cfg *config) {
 	} else {
 		cfg.analyticsRate = globalconfig.AnalyticsRate()
 	}
-
 	cfg.statusCheck = isServerError
 }
 

--- a/contrib/go-chi/chi/option.go
+++ b/contrib/go-chi/chi/option.go
@@ -17,7 +17,7 @@ type config struct {
 	serviceName   string
 	spanOpts      []ddtrace.StartSpanOption // additional span options to be applied
 	analyticsRate float64
-	isError       func(statusCode int) bool
+	statusCheck   func(statusCode int) bool
 }
 
 // Option represents an option that can be passed to NewRouter.
@@ -34,7 +34,7 @@ func defaults(cfg *config) {
 		cfg.analyticsRate = globalconfig.AnalyticsRate()
 	}
 
-	cfg.isError = defaultIsError
+	cfg.statusCheck = isServerError
 }
 
 // WithServiceName sets the given service name for the router.
@@ -75,14 +75,14 @@ func WithAnalyticsRate(rate float64) Option {
 	}
 }
 
-// WithIsErrorCheck sets the function which is used to decide whther the
+// WithStatusCheck sets the function which is used to decide whther the
 // status should be marked as an error
-func WithIsErrorCheck(isError func(statusCode int) bool) Option {
+func WithStatusCheck(statusCheck func(statusCode int) bool) Option {
 	return func(cfg *config) {
-		cfg.isError = isError
+		cfg.statusCheck = statusCheck
 	}
 }
 
-func defaultIsError(statusCode int) bool {
+func isServerError(statusCode int) bool {
 	return statusCode >= 500 && statusCode < 600
 }

--- a/contrib/go-chi/chi/option.go
+++ b/contrib/go-chi/chi/option.go
@@ -17,6 +17,7 @@ type config struct {
 	serviceName   string
 	spanOpts      []ddtrace.StartSpanOption // additional span options to be applied
 	analyticsRate float64
+	isError       func(statusCode int) bool
 }
 
 // Option represents an option that can be passed to NewRouter.
@@ -32,6 +33,8 @@ func defaults(cfg *config) {
 	} else {
 		cfg.analyticsRate = globalconfig.AnalyticsRate()
 	}
+
+	cfg.isError = defaultIsError
 }
 
 // WithServiceName sets the given service name for the router.
@@ -70,4 +73,16 @@ func WithAnalyticsRate(rate float64) Option {
 			cfg.analyticsRate = math.NaN()
 		}
 	}
+}
+
+// WithIsErrorCheck sets the function which is used to decide whther the
+// status should be marked as an error
+func WithIsErrorCheck(isError func(statusCode int) bool) Option {
+	return func(cfg *config) {
+		cfg.isError = isError
+	}
+}
+
+func defaultIsError(statusCode int) bool {
+	return statusCode >= 500 && statusCode < 600
 }


### PR DESCRIPTION
In this change I introduced a new option for the chi tracing package, called `WithIsErrorCheck` which can be used to provide custom status code checking logic (For example, in our case we'd like 4xx status codes to be displayed as errors)  

I hope the naming is acceptable, if not I'll happily fix it. 