### PR TITLE
contrib/gin-gonic/gin: support globalconfig.ServiceName()

### DIFF
--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -19,16 +19,17 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// Middleware returns middleware that will trace incoming requests.
+// Middleware returns middleware that will trace incoming requests. If service is empty then the
+// default service name will be used.
 func Middleware(service string, opts ...Option) gin.HandlerFunc {
-	cfg := newConfig()
+	cfg := newConfig(service)
 	for _, opt := range opts {
 		opt(cfg)
 	}
 	return func(c *gin.Context) {
 		resource := cfg.resourceNamer(c)
 		opts := []ddtrace.StartSpanOption{
-			tracer.ServiceName(service),
+			tracer.ServiceName(cfg.serviceName),
 			tracer.ResourceName(resource),
 			tracer.SpanType(ext.SpanTypeWeb),
 			tracer.Tag(ext.HTTPMethod, c.Request.Method),

--- a/contrib/gin-gonic/gin/option.go
+++ b/contrib/gin-gonic/gin/option.go
@@ -17,9 +17,16 @@ import (
 type config struct {
 	analyticsRate float64
 	resourceNamer func(c *gin.Context) string
+	serviceName   string
 }
 
-func newConfig() *config {
+func newConfig(service string) *config {
+	if service == "" {
+		service = "gin.router"
+		if svc := globalconfig.ServiceName(); svc != "" {
+			service = svc
+		}
+	}
 	rate := globalconfig.AnalyticsRate()
 	if internal.BoolEnv("DD_TRACE_GIN_ANALYTICS_ENABLED", false) {
 		rate = 1.0
@@ -27,6 +34,7 @@ func newConfig() *config {
 	return &config{
 		analyticsRate: rate,
 		resourceNamer: defaultResourceNamer,
+		serviceName:   service,
 	}
 }
 


### PR DESCRIPTION
This change adds support for `globalconfig.ServiceName()` to the gin
trace middleware. Because this middleware does not follow the same pattern
as other http frameworks and requires a service parameter to be passed in
we use the empty string value as an indicator that the default service
name should be used.

Fixes #767