### PR TITLE
ddtrace/tracer: fix issue extracting B3 tracing ID of 128 bits

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -334,6 +334,10 @@ func (*propagatorB3) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 		key := strings.ToLower(k)
 		switch key {
 		case b3TraceIDHeader:
+			if len(v) > 16 {
+				v = v[len(v)-16:]
+			}
+
 			ctx.traceID, err = strconv.ParseUint(v, 16, 64)
 			if err != nil {
 				return ErrSpanContextCorrupted

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -337,7 +337,6 @@ func (*propagatorB3) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 			if len(v) > 16 {
 				v = v[len(v)-16:]
 			}
-
 			ctx.traceID, err = strconv.ParseUint(v, 16, 64)
 			if err != nil {
 				return ErrSpanContextCorrupted

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -226,40 +226,50 @@ func TestB3(t *testing.T) {
 		os.Setenv("DD_PROPAGATION_STYLE_EXTRACT", "b3")
 		defer os.Unsetenv("DD_PROPAGATION_STYLE_EXTRACT")
 
-		headers := TextMapCarrier(map[string]string{
-			b3TraceIDHeader: "1",
-			b3SpanIDHeader:  "1",
-		})
+		var tests = []struct {
+			label string
+			in    TextMapCarrier
+			out   []uint64 // contains [<trace_id>, <span_id>]
+		}{
+			{
+				"only_ones",
+				TextMapCarrier{
+					b3TraceIDHeader: "1",
+					b3SpanIDHeader:  "1",
+				},
+				[]uint64{1, 1},
+			},
+			{
+				"64_bits",
+				TextMapCarrier{
+					b3TraceIDHeader: "feeb0599801f4700",
+					b3SpanIDHeader:  "f8f5c76089ad8da5",
+				},
+				[]uint64{18368781661998368512, 17939463908140879269},
+			},
+			{
+				"128_bits",
+				TextMapCarrier{
+					b3TraceIDHeader: "6e96719ded9c1864a21ba1551789e3f5",
+					b3SpanIDHeader:  "a1eb5bf36e56e50e",
+				},
+				[]uint64{11681107445354718197, 11667520360719770894},
+			},
+		}
 
-		tracer := newTracer()
-		assert := assert.New(t)
-		ctx, err := tracer.Extract(headers)
-		assert.Nil(err)
-		sctx, ok := ctx.(*spanContext)
-		assert.True(ok)
+		for _, test := range tests {
+			t.Run(test.label, func(t *testing.T) {
+				tracer := newTracer()
+				assert := assert.New(t)
+				ctx, err := tracer.Extract(test.in)
+				assert.Nil(err)
+				sctx, ok := ctx.(*spanContext)
+				assert.True(ok)
 
-		assert.Equal(sctx.traceID, uint64(1))
-		assert.Equal(sctx.spanID, uint64(1))
-	})
-
-	t.Run("extract_32", func(t *testing.T) {
-		os.Setenv("DD_PROPAGATION_STYLE_EXTRACT", "b3")
-		defer os.Unsetenv("DD_PROPAGATION_STYLE_EXTRACT")
-
-		headers := TextMapCarrier(map[string]string{
-			b3TraceIDHeader: "6e96719ded9c1864a21ba1551789e3f5",
-			b3SpanIDHeader:  "a1eb5bf36e56e50e",
-		})
-
-		tracer := newTracer()
-		assert := assert.New(t)
-		ctx, err := tracer.Extract(headers)
-		assert.Nil(err)
-		sctx, ok := ctx.(*spanContext)
-		assert.True(ok)
-
-		assert.Equal(sctx.traceID, uint64(11681107445354718197))
-		assert.Equal(sctx.spanID, uint64(11667520360719770894))
+				assert.Equal(sctx.traceID, test.out[0])
+				assert.Equal(sctx.spanID, test.out[1])
+			})
+		}
 	})
 
 	t.Run("multiple", func(t *testing.T) {

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -242,6 +242,26 @@ func TestB3(t *testing.T) {
 		assert.Equal(sctx.spanID, uint64(1))
 	})
 
+	t.Run("extract_32", func(t *testing.T) {
+		os.Setenv("DD_PROPAGATION_STYLE_EXTRACT", "b3")
+		defer os.Unsetenv("DD_PROPAGATION_STYLE_EXTRACT")
+
+		headers := TextMapCarrier(map[string]string{
+			b3TraceIDHeader: "6e96719ded9c1864a21ba1551789e3f5",
+			b3SpanIDHeader:  "a1eb5bf36e56e50e",
+		})
+
+		tracer := newTracer()
+		assert := assert.New(t)
+		ctx, err := tracer.Extract(headers)
+		assert.Nil(err)
+		sctx, ok := ctx.(*spanContext)
+		assert.True(ok)
+
+		assert.Equal(sctx.traceID, uint64(11681107445354718197))
+		assert.Equal(sctx.spanID, uint64(11667520360719770894))
+	})
+
 	t.Run("multiple", func(t *testing.T) {
 		os.Setenv("DD_PROPAGATION_STYLE_EXTRACT", "Datadog,B3")
 		defer os.Unsetenv("DD_PROPAGATION_STYLE_EXTRACT")

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -227,12 +227,10 @@ func TestB3(t *testing.T) {
 		defer os.Unsetenv("DD_PROPAGATION_STYLE_EXTRACT")
 
 		var tests = []struct {
-			label string
-			in    TextMapCarrier
-			out   []uint64 // contains [<trace_id>, <span_id>]
+			in  TextMapCarrier
+			out []uint64 // contains [<trace_id>, <span_id>]
 		}{
 			{
-				"only_ones",
 				TextMapCarrier{
 					b3TraceIDHeader: "1",
 					b3SpanIDHeader:  "1",
@@ -240,7 +238,6 @@ func TestB3(t *testing.T) {
 				[]uint64{1, 1},
 			},
 			{
-				"64_bits",
 				TextMapCarrier{
 					b3TraceIDHeader: "feeb0599801f4700",
 					b3SpanIDHeader:  "f8f5c76089ad8da5",
@@ -248,7 +245,6 @@ func TestB3(t *testing.T) {
 				[]uint64{18368781661998368512, 17939463908140879269},
 			},
 			{
-				"128_bits",
 				TextMapCarrier{
 					b3TraceIDHeader: "6e96719ded9c1864a21ba1551789e3f5",
 					b3SpanIDHeader:  "a1eb5bf36e56e50e",
@@ -258,7 +254,7 @@ func TestB3(t *testing.T) {
 		}
 
 		for _, test := range tests {
-			t.Run(test.label, func(t *testing.T) {
+			t.Run("", func(t *testing.T) {
 				tracer := newTracer()
 				assert := assert.New(t)
 				ctx, err := tracer.Extract(test.in)


### PR DESCRIPTION
Current solution were only supporting parsing 16 encoded lower-hex characters.
Update make sure the take the last characters before parsing, fixing the issue.

Fixes for issue https://github.com/DataDog/dd-trace-go/issues/779