### PR TITLE
ddtrace/tracer: mark top level spans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ bin/
 *.cov
 *.lock
 *.swp
+.idea
+dd-trace-go.iml
 
 /contrib/google.golang.org/grpc.v12/vendor/
 

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -66,6 +66,7 @@ type span struct {
 	TraceID  uint64             `msg:"trace_id"`          // identifier of the root span
 	ParentID uint64             `msg:"parent_id"`         // identifier of the span's direct parent
 	Error    int32              `msg:"error"`             // error status of the span; 0 means no errors
+	TopLevel bool               `msg:"top_level"`         // boolean indicating if the span is a top level
 
 	noDebugStack bool         `msg:"-"` // disables debug stack traces
 	finished     bool         `msg:"-"` // true if the span has been submitted to a tracer.
@@ -256,6 +257,12 @@ func (s *span) setMetric(key string, v float64) {
 	}
 }
 
+// unsetMetric unsets a numeric tag, in our case called a metric. This method
+// is not safe for concurrent use.
+func (s *span) unsetMetric(key string) {
+	delete(s.Metrics, key)
+}
+
 // Finish closes this Span (but not its children) providing the duration
 // of its part of the tracing session.
 func (s *span) Finish(opts ...ddtrace.FinishOption) {
@@ -381,4 +388,7 @@ const (
 	keyRulesSamplerAppliedRate = "_dd.rule_psr"
 	keyRulesSamplerLimiterRate = "_dd.limit_psr"
 	keyMeasured                = "_dd.measured"
+	// topLevelKey is the key of top level metric indicating if a span is top level.
+	// a top level span is a local root (parent span of the local trace) or the first span of each service.
+	topLevelKey = "_top_level"
 )

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -66,7 +66,6 @@ type span struct {
 	TraceID  uint64             `msg:"trace_id"`          // identifier of the root span
 	ParentID uint64             `msg:"parent_id"`         // identifier of the span's direct parent
 	Error    int32              `msg:"error"`             // error status of the span; 0 means no errors
-	TopLevel bool               `msg:"top_level"`         // boolean indicating if the span is a top level
 
 	noDebugStack bool         `msg:"-"` // disables debug stack traces
 	finished     bool         `msg:"-"` // true if the span has been submitted to a tracer.
@@ -257,12 +256,6 @@ func (s *span) setMetric(key string, v float64) {
 	}
 }
 
-// unsetMetric unsets a numeric tag, in our case called a metric. This method
-// is not safe for concurrent use.
-func (s *span) unsetMetric(key string) {
-	delete(s.Metrics, key)
-}
-
 // Finish closes this Span (but not its children) providing the duration
 // of its part of the tracing session.
 func (s *span) Finish(opts ...ddtrace.FinishOption) {
@@ -388,7 +381,7 @@ const (
 	keyRulesSamplerAppliedRate = "_dd.rule_psr"
 	keyRulesSamplerLimiterRate = "_dd.limit_psr"
 	keyMeasured                = "_dd.measured"
-	// topLevelKey is the key of top level metric indicating if a span is top level.
-	// a top level span is a local root (parent span of the local trace) or the first span of each service.
-	topLevelKey = "_top_level"
+	// keyTopLevel is the key of top level metric indicating if a span is top level.
+	// A top level span is a local root (parent span of the local trace) or the first span of each service.
+	keyTopLevel = "_top_level"
 )

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -500,25 +500,6 @@ func TestSpanLog(t *testing.T) {
 	})
 }
 
-func TestUnsetMetric(t *testing.T) {
-	t.Run("default", func(t *testing.T) {
-		span := span{Metrics: map[string]float64{"key": 1}}
-		span.unsetMetric("key")
-		_, ok := span.Metrics["key"]
-		assert.False(t, ok)
-	})
-	t.Run("nil metrics", func(t *testing.T) {
-		span := span{}
-		span.unsetMetric("key")
-		assert.Nil(t, span.Metrics)
-	})
-	t.Run("empty metrics", func(t *testing.T) {
-		span := span{Metrics: make(map[string]float64)}
-		span.unsetMetric("key")
-		assert.Len(t, span.Metrics, 0)
-	})
-}
-
 func BenchmarkSetTagMetric(b *testing.B) {
 	span := newBasicSpan("bench.span")
 	keys := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -244,7 +244,7 @@ const (
 func TestSpanSetMetric(t *testing.T) {
 	for name, tt := range map[string]func(assert *assert.Assertions, span *span){
 		"init": func(assert *assert.Assertions, span *span) {
-			assert.Equal(2, len(span.Metrics))
+			assert.Equal(3, len(span.Metrics))
 			_, ok := span.Metrics[keySamplingPriority]
 			assert.True(ok)
 			_, ok = span.Metrics[keySamplingPriorityRate]
@@ -279,7 +279,7 @@ func TestSpanSetMetric(t *testing.T) {
 		"finished": func(assert *assert.Assertions, span *span) {
 			span.Finish()
 			span.SetTag("finished.test", 1337)
-			assert.Equal(2, len(span.Metrics))
+			assert.Equal(3, len(span.Metrics))
 			_, ok := span.Metrics["finished.test"]
 			assert.False(ok)
 		},
@@ -497,6 +497,25 @@ func TestSpanLog(t *testing.T) {
 		stop()
 		expect := fmt.Sprintf(`dd.service=tracer.test dd.env=testenv dd.version=1.2.3 dd.trace_id="%d" dd.span_id="%d"`, span.TraceID, span.SpanID)
 		assert.Equal(expect, fmt.Sprintf("%v", span))
+	})
+}
+
+func TestUnsetMetric(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		span := span{Metrics: map[string]float64{"key": 1}}
+		span.unsetMetric("key")
+		_, ok := span.Metrics["key"]
+		assert.False(t, ok)
+	})
+	t.Run("nil metrics", func(t *testing.T) {
+		span := span{}
+		span.unsetMetric("key")
+		assert.Nil(t, span.Metrics)
+	})
+	t.Run("empty metrics", func(t *testing.T) {
+		span := span{Metrics: make(map[string]float64)}
+		span.unsetMetric("key")
+		assert.Len(t, span.Metrics, 0)
 	})
 }
 

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -307,6 +307,11 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 	for k, v := range t.config.globalTags {
 		span.SetTag(k, v)
 	}
+	if context == nil || context.span == nil || context.span.Service != span.Service {
+		span.setMetric(topLevelKey, 1)
+		// all top level spans are measured. So the measured tag is redundant.
+		span.unsetMetric(keyMeasured)
+	}
 	if t.config.version != "" && span.Service == t.config.serviceName {
 		span.SetTag(ext.Version, t.config.version)
 	}

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -308,9 +308,9 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		span.SetTag(k, v)
 	}
 	if context == nil || context.span == nil || context.span.Service != span.Service {
-		span.setMetric(topLevelKey, 1)
+		span.setMetric(keyTopLevel, 1)
 		// all top level spans are measured. So the measured tag is redundant.
-		span.unsetMetric(keyMeasured)
+		delete(span.Metrics, keyMeasured)
 	}
 	if t.config.version != "" && span.Service == t.config.serviceName {
 		span.SetTag(ext.Version, t.config.version)

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -217,8 +217,9 @@ func TestTracerStartSpan(t *testing.T) {
 		span := tracer.StartSpan("/home/user", Measured()).(*span)
 		_, ok := span.Metrics[keyMeasured]
 		assert.False(t, ok)
-		assert.Equal(t, 1.0, span.Metrics[topLevelKey])
+		assert.Equal(t, 1.0, span.Metrics[keyTopLevel])
 	})
+
 	t.Run("measured_non_top_level", func(t *testing.T) {
 		tracer := newTracer()
 		parent := tracer.StartSpan("/home/user").(*span)
@@ -294,7 +295,7 @@ func TestTracerStartSpanOptions(t *testing.T) {
 	assert.Equal(now.UnixNano(), span.Start)
 	assert.Equal(uint64(420), span.SpanID)
 	assert.Equal(uint64(420), span.TraceID)
-	assert.Equal(1.0, span.Metrics[topLevelKey])
+	assert.Equal(1.0, span.Metrics[keyTopLevel])
 }
 
 func TestTracerStartChildSpan(t *testing.T) {

--- a/ddtrace/tracer/transport.go
+++ b/ddtrace/tracer/transport.go
@@ -20,6 +20,12 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/version"
 )
 
+const (
+	// headerComputedTopLevel specifies that the client has marked top-level spans, when set.
+	// Any non-empty value will mean 'yes'.
+	headerComputedTopLevel = "Datadog-Client-Computed-Top-Level"
+)
+
 var defaultClient = &http.Client{
 	// We copy the transport to avoid using the default one, as it might be
 	// augmented with tracing and we don't want these calls to be recorded.
@@ -114,6 +120,7 @@ func (t *httpTransport) send(p *payload) (body io.ReadCloser, err error) {
 	}
 	req.Header.Set(traceCountHeader, strconv.Itoa(p.itemCount()))
 	req.Header.Set("Content-Length", strconv.Itoa(p.size()))
+	req.Header.Set(headerComputedTopLevel, "yes")
 	response, err := t.client.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Set top level flag directly in tracer. Not in agent.
That way, we don't need to have access to the whole chunk in the agent.