### PR TITLE
ddtrace/tracer: rename top-level field

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -383,5 +383,5 @@ const (
 	keyMeasured                = "_dd.measured"
 	// keyTopLevel is the key of top level metric indicating if a span is top level.
 	// A top level span is a local root (parent span of the local trace) or the first span of each service.
-	keyTopLevel = "_top_level"
+	keyTopLevel = "_dd.top_level"
 )


### PR DESCRIPTION
We will rename the top level field set by the tracer to follow the tracer standard.
We will convert that field in the agent: https://github.com/DataDog/datadog-agent/pull/6941