### PR TITLE
{profiler,ddtrace/tracer}: add UDS client options

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -358,7 +358,7 @@ func WithHTTPClient(client *http.Client) StartOption {
 	}
 }
 
-// WithUDS convenience, configures the client to dial a Unix Domain Socket
+// WithUDS configures the HTTP client to dial the Datadog Agent via the specified Unix Domain Socket path.
 func WithUDS(socketPath string) StartOption {
 	return WithHTTPClient(&http.Client{
 		Transport: &http.Transport{

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -6,6 +6,7 @@
 package tracer
 
 import (
+	"context"
 	"math"
 	"net"
 	"net/http"
@@ -355,6 +356,18 @@ func WithHTTPClient(client *http.Client) StartOption {
 	return func(c *config) {
 		c.httpClient = client
 	}
+}
+
+// WithUDS convenience, configures the client to dial a Unix Domain Socket
+func WithUDS(socketPath string) StartOption {
+	return WithHTTPClient(&http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", socketPath)
+			},
+		},
+		Timeout: defaultHTTPTimeout,
+	})
 }
 
 // WithAnalytics allows specifying whether Trace Search & Analytics should be enabled

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -212,12 +212,17 @@ func TestTraceCountHeader(t *testing.T) {
 }
 
 type recordingRoundTripper struct {
-	reqs []*http.Request
+	reqs   []*http.Request
+	client *http.Client
+}
+
+func newRecordingRoundTripper(client *http.Client) *recordingRoundTripper {
+	return &recordingRoundTripper{client: client}
 }
 
 func (r *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	r.reqs = append(r.reqs, req)
-	return defaultClient.Transport.RoundTrip(req)
+	return r.client.Transport.RoundTrip(req)
 }
 
 func TestCustomTransport(t *testing.T) {
@@ -233,7 +238,7 @@ func TestCustomTransport(t *testing.T) {
 	assert.Nil(err)
 	assert.NotEmpty(port, "port should be given, as it's chosen randomly")
 
-	customRoundTripper := new(recordingRoundTripper)
+	customRoundTripper := newRecordingRoundTripper(defaultClient)
 	transport := newHTTPTransport(host, &http.Client{Transport: customRoundTripper})
 	p, err := encode(getTestTrace(1, 1))
 	assert.NoError(err)
@@ -253,8 +258,34 @@ func TestWithHTTPClient(t *testing.T) {
 
 	u, err := url.Parse(srv.URL)
 	assert.NoError(err)
-	rt := new(recordingRoundTripper)
+	rt := newRecordingRoundTripper(defaultClient)
 	trc := newTracer(WithAgentAddr(u.Host), WithHTTPClient(&http.Client{Transport: rt}))
+	defer trc.Stop()
+
+	p, err := encode(getTestTrace(1, 1))
+	assert.NoError(err)
+	_, err = trc.config.transport.send(p)
+	assert.NoError(err)
+	assert.Len(rt.reqs, 1)
+}
+
+func TestWithUDS(t *testing.T) {
+	os.Setenv("DD_TRACE_STARTUP_LOGS", "0")
+	defer os.Unsetenv("DD_TRACE_STARTUP_LOGS")
+	assert := assert.New(t)
+	udsPath := "/tmp/com.datadoghq.dd-trace-go.tracer.test.sock"
+	unixListener, err := net.Listen("unix", udsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := &http.Server{Handler: mockDatadogAPIHandler{t: t}}
+	go srv.Serve(unixListener)
+	defer srv.Close()
+
+	dummyCfg := new(config)
+	WithUDS(udsPath)(dummyCfg)
+	rt := newRecordingRoundTripper(dummyCfg.httpClient)
+	trc := newTracer(WithHTTPClient(&http.Client{Transport: rt}))
 	defer trc.Stop()
 
 	p, err := encode(getTestTrace(1, 1))

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -287,7 +287,7 @@ func WithHTTPClient(client *http.Client) Option {
 	}
 }
 
-// WithUDS convenience, configures the client to dial a Unix Domain Socket
+// WithUDS configures the HTTP client to dial the Datadog Agent via the specified Unix Domain Socket path.
 func WithUDS(socketPath string) Option {
 	return WithHTTPClient(&http.Client{
 		Transport: &http.Transport{

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -42,10 +42,11 @@ const (
 )
 
 const (
-	defaultAPIURL    = "https://intake.profile.datadoghq.com/v1/input"
-	defaultAgentHost = "localhost"
-	defaultAgentPort = "8126"
-	defaultEnv       = "none"
+	defaultAPIURL      = "https://intake.profile.datadoghq.com/v1/input"
+	defaultAgentHost   = "localhost"
+	defaultAgentPort   = "8126"
+	defaultEnv         = "none"
+	defaultHTTPTimeout = 10 * time.Second // defines the current timeout before giving up with the send process
 )
 
 var defaultClient = &http.Client{
@@ -64,7 +65,7 @@ var defaultClient = &http.Client{
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	},
-	Timeout: 10 * time.Second,
+	Timeout: defaultHTTPTimeout,
 }
 
 var defaultProfileTypes = []ProfileType{CPUProfile, HeapProfile}
@@ -286,13 +287,14 @@ func WithHTTPClient(client *http.Client) Option {
 	}
 }
 
-// WithUDSClient convenience, configures the client to dial a Unix Domain Socket
-func WithUDSClient(socketPath string) Option {
+// WithUDS convenience, configures the client to dial a Unix Domain Socket
+func WithUDS(socketPath string) Option {
 	return WithHTTPClient(&http.Client{
 		Transport: &http.Transport{
 			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
 				return net.Dial("unix", socketPath)
 			},
 		},
+		Timeout: defaultHTTPTimeout,
 	})
 }

--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -26,10 +26,6 @@ const maxRetries = 2
 var errOldAgent = errors.New("Datadog Agent is not accepting profiles. Agent-based profiling deployments " +
 	"require Datadog Agent >= 7.20")
 
-var httpClient = &http.Client{
-	Timeout: 10 * time.Second,
-}
-
 // backoffDuration calculates the backoff duration given an attempt number and max duration
 func backoffDuration(attempt int, max time.Duration) time.Duration {
 	// https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
@@ -99,7 +95,7 @@ func (p *profiler) doRequest(bat batch) error {
 	}
 	req.Header.Set("Content-Type", contentType)
 
-	resp, err := httpClient.Do(req)
+	resp, err := p.cfg.httpClient.Do(req)
 	if err != nil {
 		return &retriableError{err}
 	}

--- a/profiler/upload_test.go
+++ b/profiler/upload_test.go
@@ -65,7 +65,7 @@ func TestTryUpload(t *testing.T) {
 			description:  "test against Unix Domain Socket server",
 			startService: makeSocketServer,
 			exopts: func(udsPath string) []Option {
-				return []Option{WithUDSClient(udsPath)}
+				return []Option{WithUDS(udsPath)}
 			},
 		},
 	}


### PR DESCRIPTION
## Background
Some customers need to override networking over which the profiler sends data.

## Description
* Allow overriding the HTTP client and transport similar to facilities provided by the trace client
* As a convenience, provide an option to create a custom client and transport that accesses a Unix Domain Socket.
* Modified upload tests to exercise both default and custom HTTP clients.