### PR TITLE
ddtrace/tracer: check if value implements fmt.Stringer in span.SetTag

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -118,7 +118,11 @@ func (s *span) SetTag(key string, value interface{}) {
 		s.setMetric(key, v)
 		return
 	}
-	// not numeric, not a string, not a bool, and not an error
+	if v, ok := value.(fmt.Stringer); ok {
+		s.setMeta(key, v.String())
+		return
+	}
+	// not numeric, not a string, not a fmt.Stringer, not a bool, and not an error
 	s.setMeta(key, fmt.Sprint(value))
 }
 

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -522,6 +522,17 @@ func BenchmarkSetTagString(b *testing.B) {
 	}
 }
 
+func BenchmarkSetTagStringer(b *testing.B) {
+	span := newBasicSpan("bench.span")
+	keys := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	value := &stringer{}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		k := string(keys[i%len(keys)])
+		span.SetTag(k, value)
+	}
+}
+
 func BenchmarkSetTagField(b *testing.B) {
 	span := newBasicSpan("bench.span")
 	keys := []string{ext.ServiceName, ext.ResourceName, ext.SpanType}
@@ -536,3 +547,9 @@ func BenchmarkSetTagField(b *testing.B) {
 type boomError struct{}
 
 func (e *boomError) Error() string { return "boom" }
+
+type stringer struct{}
+
+func (s *stringer) String() string {
+	return "string"
+}


### PR DESCRIPTION
It avoids to call fmt.Sprint, which uses reflection and is slower.

Fixes https://github.com/DataDog/dd-trace-go/issues/798

Benchmark:

```
go test -v -run=^$ -bench=^BenchmarkSetTag -benchmem -benchtime=10s -cpu=1 ./ddtrace/tracer

benchstat -delta-test none old.txt new.txt
name            old time/op    new time/op    delta
SetTagMetric      63.3ns ± 0%    64.8ns ± 0%   +2.37%
SetTagString      61.8ns ± 0%    61.4ns ± 0%   -0.65%
SetTagStringer     247ns ± 0%      77ns ± 0%  -68.87%
SetTagField       26.8ns ± 0%    26.8ns ± 0%    0.00%

name            old alloc/op   new alloc/op   delta
SetTagMetric       4.00B ± 0%     4.00B ± 0%    0.00%
SetTagString       4.00B ± 0%     4.00B ± 0%    0.00%
SetTagStringer     16.0B ± 0%      4.0B ± 0%  -75.00%
SetTagField        0.00B          0.00B         0.00%

name            old allocs/op  new allocs/op  delta
SetTagMetric        1.00 ± 0%      1.00 ± 0%    0.00%
SetTagString        1.00 ± 0%      1.00 ± 0%    0.00%
SetTagStringer      2.00 ± 0%      1.00 ± 0%  -50.00%
SetTagField         0.00           0.00         0.00%
```