### PR TITLE
ddtracer/tracer: tag keys must be unique across metrics and meta tags

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -200,6 +200,7 @@ func (s *span) setMeta(key, v string) {
 	if s.Meta == nil {
 		s.Meta = make(map[string]string, 1)
 	}
+	delete(s.Metrics, key)
 	switch key {
 	case ext.SpanName:
 		s.Name = v
@@ -246,6 +247,7 @@ func (s *span) setMetric(key string, v float64) {
 	if s.Metrics == nil {
 		s.Metrics = make(map[string]float64, 1)
 	}
+	delete(s.Meta, key)
 	switch key {
 	case ext.SamplingPriority:
 		// setting sampling priority per spec

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -352,7 +352,7 @@ func TestUniqueTagKeys(t *testing.T) {
 	span.SetTag("foo.bar", 12)
 	span.SetTag("foo.bar", "val")
 
-	assert.Equal(0.0, span.Metrics["foo.bar"])
+	assert.NotContains(span.Metrics, "foo.bar")
 	assert.Equal("val", span.Meta["foo.bar"])
 
 	//check to see if setMetric correctly wipes out a meta tag
@@ -360,8 +360,7 @@ func TestUniqueTagKeys(t *testing.T) {
 	span.SetTag("foo.bar", 12)
 
 	assert.Equal(12.0, span.Metrics["foo.bar"])
-	assert.Equal("", span.Meta["foo.bar"])
-
+	assert.NotContains(span.Meta, "foo.bar")
 }
 
 // Prior to a bug fix, this failed when running `go test -race`

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -344,6 +344,26 @@ func TestSpanErrorNil(t *testing.T) {
 	assert.Equal(nMeta, len(span.Meta))
 }
 
+func TestUniqueTagKeys(t *testing.T) {
+	assert := assert.New(t)
+	span := newBasicSpan("web.request")
+
+	//check to see if setMeta correctly wipes out a metric tag
+	span.SetTag("foo.bar", 12)
+	span.SetTag("foo.bar", "val")
+
+	assert.Equal(0.0, span.Metrics["foo.bar"])
+	assert.Equal("val", span.Meta["foo.bar"])
+
+	//check to see if setMetric correctly wipes out a meta tag
+	span.SetTag("foo.bar", "val")
+	span.SetTag("foo.bar", 12)
+
+	assert.Equal(12.0, span.Metrics["foo.bar"])
+	assert.Equal("", span.Meta["foo.bar"])
+
+}
+
 // Prior to a bug fix, this failed when running `go test -race`
 func TestSpanModifyWhileFlushing(t *testing.T) {
 	tracer, _, _, stop := startTestTracer(t)


### PR DESCRIPTION
If tags were set with values of different types and the same key, both values were persisted, which is wrong
