### PR TITLE
profiles: add custom metrics payload

### DIFF
--- a/profiler/metrics.go
+++ b/profiler/metrics.go
@@ -1,0 +1,107 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package profiler
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math"
+	"runtime"
+	"time"
+)
+
+type point struct {
+	metric string
+	value  float64
+}
+
+// MarshalJSON serialize points as array tuples
+func (p point) MarshalJSON() ([]byte, error) {
+	return json.Marshal([]interface{}{
+		p.metric,
+		p.value,
+	})
+}
+
+type collectionTooFrequent struct {
+	min      time.Duration
+	observed time.Duration
+}
+
+func (e collectionTooFrequent) Error() string {
+	return fmt.Sprintf("period between metrics collection is too small min=%v observed=%v", e.min, e.observed)
+}
+
+type metrics struct {
+	collectedAt time.Time
+	stats       runtime.MemStats
+	compute     func(*runtime.MemStats, *runtime.MemStats, time.Duration) []point
+}
+
+func newMetrics() *metrics {
+	return &metrics{
+		compute: computeMetrics,
+	}
+}
+
+func (m *metrics) reset(now time.Time) {
+	m.collectedAt = now
+	runtime.ReadMemStats(&m.stats)
+}
+
+func (m *metrics) report(now time.Time, buf *bytes.Buffer) error {
+	period := now.Sub(m.collectedAt)
+
+	if period < time.Second {
+		// Profiler could be mis-configured to report more frequently than every second
+		// or a system clock issue causes time to run backwards.
+		// We can't emit valid metrics in either case.
+		return collectionTooFrequent{min: time.Second, observed: period}
+	}
+
+	previousStats := m.stats
+	m.reset(now)
+
+	points := removeInvalid(m.compute(&previousStats, &m.stats, period))
+	data, err := json.Marshal(points)
+
+	if err != nil {
+		return err
+	}
+
+	if _, err := buf.Write(data); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func computeMetrics(prev *runtime.MemStats, curr *runtime.MemStats, period time.Duration) []point {
+	return []point{
+		{metric: "go_alloc_bytes_per_sec", value: rate(curr.TotalAlloc, prev.TotalAlloc, period/time.Second)},
+		{metric: "go_allocs_per_sec", value: rate(curr.Mallocs, prev.Mallocs, period/time.Second)},
+		{metric: "go_frees_per_sec", value: rate(curr.Frees, prev.Frees, period/time.Second)},
+		{metric: "go_heap_growth_bytes_per_sec", value: rate(curr.HeapAlloc, prev.HeapAlloc, period/time.Second)},
+	}
+}
+
+func rate(curr, prev uint64, period time.Duration) float64 {
+	return float64(int64(curr)-int64(prev)) / float64(period)
+}
+
+// removeInvalid removes NaN and +/-Inf values as they can't be json-serialized
+// This is an extra safety check to ensure we don't emit bad data in case of
+// a metric computation coding error
+func removeInvalid(points []point) (result []point) {
+	for _, p := range points {
+		if math.IsNaN(p.value) || math.IsInf(p.value, 0) {
+			continue
+		}
+		result = append(result, p)
+	}
+	return result
+}

--- a/profiler/metrics.go
+++ b/profiler/metrics.go
@@ -39,7 +39,7 @@ func (e collectionTooFrequent) Error() string {
 type metrics struct {
 	collectedAt time.Time
 	stats       runtime.MemStats
-	compute     func(*runtime.MemStats, *runtime.MemStats, time.Duration) []point
+	compute     func(*runtime.MemStats, *runtime.MemStats, time.Duration, time.Time) []point
 }
 
 func newMetrics() *metrics {
@@ -66,10 +66,11 @@ func (m *metrics) report(now time.Time, buf *bytes.Buffer) error {
 	previousStats := m.stats
 	m.reset(now)
 
-	points := removeInvalid(m.compute(&previousStats, &m.stats, period))
-	data, err := json.Marshal(points)
+	points := m.compute(&previousStats, &m.stats, period, now)
+	data, err := json.Marshal(removeInvalid(points))
 
 	if err != nil {
+		// NB the minimum period check and removeInvalid ensures we don't hit this case
 		return err
 	}
 
@@ -80,17 +81,39 @@ func (m *metrics) report(now time.Time, buf *bytes.Buffer) error {
 	return nil
 }
 
-func computeMetrics(prev *runtime.MemStats, curr *runtime.MemStats, period time.Duration) []point {
+func computeMetrics(prev *runtime.MemStats, curr *runtime.MemStats, period time.Duration, now time.Time) []point {
 	return []point{
 		{metric: "go_alloc_bytes_per_sec", value: rate(curr.TotalAlloc, prev.TotalAlloc, period/time.Second)},
 		{metric: "go_allocs_per_sec", value: rate(curr.Mallocs, prev.Mallocs, period/time.Second)},
 		{metric: "go_frees_per_sec", value: rate(curr.Frees, prev.Frees, period/time.Second)},
 		{metric: "go_heap_growth_bytes_per_sec", value: rate(curr.HeapAlloc, prev.HeapAlloc, period/time.Second)},
+		{metric: "go_gcs_per_sec", value: rate(uint64(curr.NumGC), uint64(prev.NumGC), period/time.Second)},
+		{metric: "go_gc_pause_time", value: rate(curr.PauseTotalNs, prev.PauseTotalNs, period)}, // % of time spent paused
+		{metric: "go_max_gc_pause_time", value: float64(maxPauseNs(curr, now.Add(-period)))},
 	}
 }
 
 func rate(curr, prev uint64, period time.Duration) float64 {
 	return float64(int64(curr)-int64(prev)) / float64(period)
+}
+
+// maxPauseNs returns maximum pause time within the recent period, assumes stats populated at period end
+func maxPauseNs(stats *runtime.MemStats, periodStart time.Time) (max uint64) {
+	// NB
+	// stats.PauseEnd is a circular buffer of recent GC pause end times as nanoseconds since the epoch.
+	// stats.PauseNs is a circular buffer of recent GC pause times in nanoseconds.
+	// The most recent pause is indexed by (stats.NumGC+255)%256
+
+	for i := stats.NumGC + 255; i >= stats.NumGC; i-- {
+		// Stop searching if we find a PauseEnd outside the period
+		if time.Unix(0, int64(stats.PauseEnd[i%256])).Before(periodStart) {
+			break
+		}
+		if stats.PauseNs[i%256] > max {
+			max = stats.PauseNs[i%256]
+		}
+	}
+	return max
 }
 
 // removeInvalid removes NaN and +/-Inf values as they can't be json-serialized

--- a/profiler/metrics_test.go
+++ b/profiler/metrics_test.go
@@ -1,0 +1,95 @@
+package profiler
+
+import (
+	"bytes"
+	"math"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestMetrics(now time.Time) *metrics {
+	m := newMetrics()
+	m.reset(now)
+	return m
+}
+
+func TestMetricsCompute(t *testing.T) {
+	prev := runtime.MemStats{
+		TotalAlloc: 100,
+		Mallocs:    10,
+		Frees:      2,
+		HeapAlloc:  75,
+	}
+	curr := runtime.MemStats{
+		TotalAlloc: 150,
+		Mallocs:    14,
+		Frees:      30,
+		HeapAlloc:  50,
+	}
+
+	points := computeMetrics(&prev, &curr, 10*time.Second)
+	assert.Equal(t, []point{
+		{metric: "go_alloc_bytes_per_sec", value: 5},
+		{metric: "go_allocs_per_sec", value: 0.4},
+		{metric: "go_frees_per_sec", value: 2.8},
+		{metric: "go_heap_growth_bytes_per_sec", value: -2.5},
+	}, points)
+
+	assert.Equal(t, []point{
+		{metric: "go_alloc_bytes_per_sec", value: 0},
+		{metric: "go_allocs_per_sec", value: 0},
+		{metric: "go_frees_per_sec", value: 0},
+		{metric: "go_heap_growth_bytes_per_sec", value: 0},
+	}, computeMetrics(&prev, &prev, 10*time.Second), "identical memstats")
+}
+
+func TestMetricsReport(t *testing.T) {
+	now := now()
+	var err error
+	var buf bytes.Buffer
+	m := newTestMetrics(now)
+
+	m.compute = func(prev *runtime.MemStats, curr *runtime.MemStats, periodInSec time.Duration) []point {
+		return []point{{metric: "metric_name", value: 1.1}}
+	}
+
+	err = m.report(now.Add(time.Second), &buf)
+	assert.NoError(t, err)
+	assert.Equal(t, "[[\"metric_name\",1.1]]", buf.String())
+}
+
+func TestMetricsCollectFrequency(t *testing.T) {
+	now := now()
+	var err error
+	var buf bytes.Buffer
+	m := newTestMetrics(now)
+
+	err = m.report(now.Add(-time.Second), &buf)
+	assert.Error(t, err, "collection call times must be monotonically increasing")
+	assert.Empty(t, buf)
+
+	err = m.report(now.Add(time.Second-1), &buf)
+	assert.Error(t, err, "must be at least one second between collection calls")
+	assert.Empty(t, buf)
+
+	err = m.report(now.Add(time.Second), &buf)
+	assert.NoError(t, err, "one second between calls should work")
+	assert.NotEmpty(t, buf)
+}
+
+func TestMetricsRemoveInvalid(t *testing.T) {
+	assert.Equal(t,
+		[]point{
+			{metric: "bar", value: 1.0},
+		},
+		removeInvalid(
+			[]point{
+				{metric: "foo", value: math.NaN()},
+				{metric: "bar", value: 1.0},
+				{metric: "fiz", value: math.Inf(1)},
+				{metric: "buz", value: math.Inf(-1)},
+			}))
+}

--- a/profiler/metrics_test.go
+++ b/profiler/metrics_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
 package profiler
 
 import (
@@ -16,34 +21,99 @@ func newTestMetrics(now time.Time) *metrics {
 	return m
 }
 
+func valsRing(vals ...time.Duration) [256]uint64 {
+	var ring [256]uint64
+	for i := 0; i < len(vals) && i < 256; i++ {
+		ring[i] = uint64(vals[i])
+	}
+	return ring
+}
+
+func timeRing(vals ...time.Time) [256]uint64 {
+	var ring [256]uint64
+	for i := 0; i < len(vals) && i < 256; i++ {
+		ring[i] = uint64(vals[i].UnixNano())
+	}
+	return ring
+}
+
 func TestMetricsCompute(t *testing.T) {
+	now := now()
 	prev := runtime.MemStats{
-		TotalAlloc: 100,
-		Mallocs:    10,
-		Frees:      2,
-		HeapAlloc:  75,
+		TotalAlloc:   100,
+		Mallocs:      10,
+		Frees:        2,
+		HeapAlloc:    75,
+		NumGC:        1,
+		PauseTotalNs: uint64(2 * time.Second),
+		PauseEnd:     timeRing(now.Add(-11 * time.Second)),
+		PauseNs:      valsRing(2 * time.Second),
 	}
 	curr := runtime.MemStats{
-		TotalAlloc: 150,
-		Mallocs:    14,
-		Frees:      30,
-		HeapAlloc:  50,
+		TotalAlloc:   150,
+		Mallocs:      14,
+		Frees:        30,
+		HeapAlloc:    50,
+		NumGC:        3,
+		PauseTotalNs: uint64(3 * time.Second),
+		PauseEnd:     timeRing(now.Add(-11*time.Second), now.Add(-9*time.Second), now.Add(-time.Second)),
+		PauseNs:      valsRing(time.Second, time.Second/2, time.Second/2),
 	}
 
-	points := computeMetrics(&prev, &curr, 10*time.Second)
-	assert.Equal(t, []point{
-		{metric: "go_alloc_bytes_per_sec", value: 5},
-		{metric: "go_allocs_per_sec", value: 0.4},
-		{metric: "go_frees_per_sec", value: 2.8},
-		{metric: "go_heap_growth_bytes_per_sec", value: -2.5},
-	}, points)
+	assert.Equal(t,
+		[]point{
+			{metric: "go_alloc_bytes_per_sec", value: 5},
+			{metric: "go_allocs_per_sec", value: 0.4},
+			{metric: "go_frees_per_sec", value: 2.8},
+			{metric: "go_heap_growth_bytes_per_sec", value: -2.5},
+			{metric: "go_gcs_per_sec", value: 0.2},
+			{metric: "go_gc_pause_time", value: 0.1}, // % of time spent paused
+			{metric: "go_max_gc_pause_time", value: float64(time.Second / 2)},
+		},
+		computeMetrics(&prev, &curr, 10*time.Second, now))
 
-	assert.Equal(t, []point{
-		{metric: "go_alloc_bytes_per_sec", value: 0},
-		{metric: "go_allocs_per_sec", value: 0},
-		{metric: "go_frees_per_sec", value: 0},
-		{metric: "go_heap_growth_bytes_per_sec", value: 0},
-	}, computeMetrics(&prev, &prev, 10*time.Second), "identical memstats")
+	assert.Equal(t,
+		[]point{
+			{metric: "go_alloc_bytes_per_sec", value: 0},
+			{metric: "go_allocs_per_sec", value: 0},
+			{metric: "go_frees_per_sec", value: 0},
+			{metric: "go_heap_growth_bytes_per_sec", value: 0},
+			{metric: "go_gcs_per_sec", value: 0},
+			{metric: "go_gc_pause_time", value: 0},
+			{metric: "go_max_gc_pause_time", value: 0},
+		},
+		computeMetrics(&prev, &prev, 10*time.Second, now),
+		"identical memstats")
+}
+
+func TestMetricsMaxPauseNs(t *testing.T) {
+	start := now()
+
+	assert.Equal(t, uint64(0),
+		maxPauseNs(&runtime.MemStats{}, start),
+		"max is 0 for empty pause buffers")
+
+	assert.Equal(t, uint64(time.Second),
+		maxPauseNs(
+			&runtime.MemStats{
+				NumGC:    3,
+				PauseNs:  valsRing(time.Minute, time.Second, time.Millisecond),
+				PauseEnd: timeRing(start.Add(-1), start, start.Add(1)),
+			},
+			start,
+		),
+		"only values in period are considered")
+
+	assert.Equal(t, uint64(time.Minute),
+		maxPauseNs(
+			&runtime.MemStats{
+				NumGC:    1000,
+				PauseNs:  valsRing(time.Second, time.Minute, time.Millisecond),
+				PauseEnd: timeRing(),
+			},
+			time.Unix(0, 0),
+		),
+		"should terminate if all values are in period")
 }
 
 func TestMetricsReport(t *testing.T) {
@@ -52,8 +122,13 @@ func TestMetricsReport(t *testing.T) {
 	var buf bytes.Buffer
 	m := newTestMetrics(now)
 
-	m.compute = func(prev *runtime.MemStats, curr *runtime.MemStats, periodInSec time.Duration) []point {
-		return []point{{metric: "metric_name", value: 1.1}}
+	m.compute = func(_ *runtime.MemStats, _ *runtime.MemStats, _ time.Duration, _ time.Time) []point {
+		return []point{
+			{metric: "metric_name", value: 1.1},
+			{metric: "does_not_include_NaN", value: math.NaN()},
+			{metric: "does_not_include_+Inf", value: math.Inf(1)},
+			{metric: "does_not_include_-Inf", value: math.Inf(-1)},
+		}
 	}
 
 	err = m.report(now.Add(time.Second), &buf)
@@ -78,18 +153,4 @@ func TestMetricsCollectFrequency(t *testing.T) {
 	err = m.report(now.Add(time.Second), &buf)
 	assert.NoError(t, err, "one second between calls should work")
 	assert.NotEmpty(t, buf)
-}
-
-func TestMetricsRemoveInvalid(t *testing.T) {
-	assert.Equal(t,
-		[]point{
-			{metric: "bar", value: 1.0},
-		},
-		removeInvalid(
-			[]point{
-				{metric: "foo", value: math.NaN()},
-				{metric: "bar", value: 1.0},
-				{metric: "fiz", value: math.Inf(1)},
-				{metric: "buz", value: math.Inf(-1)},
-			}))
 }

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -68,7 +68,7 @@ var defaultClient = &http.Client{
 	Timeout: defaultHTTPTimeout,
 }
 
-var defaultProfileTypes = []ProfileType{CPUProfile, HeapProfile}
+var defaultProfileTypes = []ProfileType{MetricsProfile, CPUProfile, HeapProfile}
 
 type config struct {
 	apiKey string
@@ -224,6 +224,7 @@ func WithProfileTypes(types ...ProfileType) Option {
 		for k := range cfg.types {
 			delete(cfg.types, k)
 		}
+		cfg.addProfileType(MetricsProfile) // always report metrics
 		for _, t := range types {
 			cfg.addProfileType(t)
 		}

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -101,7 +101,7 @@ func TestOptions(t *testing.T) {
 		WithProfileTypes(HeapProfile)(&cfg)
 		_, ok := cfg.types[HeapProfile]
 		assert.True(t, ok)
-		assert.Len(t, cfg.types, 1)
+		assert.Len(t, cfg.types, 2)
 	})
 
 	t.Run("WithService", func(t *testing.T) {

--- a/profiler/profile_test.go
+++ b/profiler/profile_test.go
@@ -24,7 +24,7 @@ func TestRunProfile(t *testing.T) {
 		p, err := unstartedProfiler()
 		prof, err := p.runProfile(HeapProfile)
 		require.NoError(t, err)
-		assert.Equal(t, "heap", prof.name)
+		assert.Equal(t, "heap.pprof", prof.name)
 		assert.Equal(t, []byte("my-heap-profile"), prof.data)
 	})
 
@@ -43,7 +43,7 @@ func TestRunProfile(t *testing.T) {
 		end := time.Now()
 		require.NoError(t, err)
 		assert.True(t, end.Sub(start) > 10*time.Millisecond)
-		assert.Equal(t, "cpu", prof.name)
+		assert.Equal(t, "cpu.pprof", prof.name)
 		assert.Equal(t, []byte("my-cpu-profile"), prof.data)
 	})
 
@@ -57,7 +57,7 @@ func TestRunProfile(t *testing.T) {
 		p, err := unstartedProfiler()
 		prof, err := p.runProfile(MutexProfile)
 		require.NoError(t, err)
-		assert.Equal(t, "mutex", prof.name)
+		assert.Equal(t, "mutex.pprof", prof.name)
 		assert.Equal(t, []byte("mutex"), prof.data)
 	})
 
@@ -71,7 +71,7 @@ func TestRunProfile(t *testing.T) {
 		p, err := unstartedProfiler()
 		prof, err := p.runProfile(BlockProfile)
 		require.NoError(t, err)
-		assert.Equal(t, "block", prof.name)
+		assert.Equal(t, "block.pprof", prof.name)
 		assert.Equal(t, []byte("block"), prof.data)
 	})
 
@@ -85,7 +85,7 @@ func TestRunProfile(t *testing.T) {
 		p, err := unstartedProfiler()
 		prof, err := p.runProfile(GoroutineProfile)
 		require.NoError(t, err)
-		assert.Equal(t, "goroutines", prof.name)
+		assert.Equal(t, "goroutines.pprof", prof.name)
 		assert.Equal(t, []byte("goroutine"), prof.data)
 	})
 }

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -62,6 +62,7 @@ type profiler struct {
 	exit       chan struct{}     // exit signals the profiler to stop; it is closed after stopping
 	stopOnce   sync.Once         // stopOnce ensures the profiler is stopped exactly once.
 	wg         sync.WaitGroup    // wg waits for all goroutines to exit when stopping.
+	met        *metrics          // metric collector state
 }
 
 // newProfiler creates a new, unstarted profiler.
@@ -92,6 +93,7 @@ func newProfiler(opts ...Option) (*profiler, error) {
 		cfg:  cfg,
 		out:  make(chan batch, outChannelSize),
 		exit: make(chan struct{}),
+		met:  newMetrics(),
 	}
 	p.uploadFunc = p.upload
 	return &p, nil
@@ -110,6 +112,7 @@ func (p *profiler) run() {
 		defer p.wg.Done()
 		tick := time.NewTicker(p.cfg.period)
 		defer tick.Stop()
+		p.met.reset(now()) // collect baseline metrics at profiler start
 		p.collect(tick.C)
 	}()
 	p.wg.Add(1)
@@ -126,7 +129,7 @@ func (p *profiler) collect(ticker <-chan time.Time) {
 	for {
 		select {
 		case <-ticker:
-			now := time.Now().UTC()
+			now := now()
 			bat := batch{
 				host:  p.cfg.hostname,
 				start: now,
@@ -139,8 +142,9 @@ func (p *profiler) collect(ticker <-chan time.Time) {
 			for t := range p.cfg.types {
 				prof, err := p.runProfile(t)
 				if err != nil {
+					fmt.Printf("error: %v\n", err)
 					log.Error("Error getting %s profile: %v; skipping.\n", t, err)
-					p.cfg.statsd.Count("datadog.profiler.go.collect_error", 1, append(p.cfg.tags, fmt.Sprintf("profile_type:%v", t)), 1)
+					p.cfg.statsd.Count("datadog.profiler.go.collect_error", 1, append(p.cfg.tags, t.Tag()), 1)
 					continue
 				}
 				bat.addProfile(prof)

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -165,7 +165,7 @@ func TestProfilerInternal(t *testing.T) {
 		assert.EqualValues(1, startCPU)
 		assert.EqualValues(1, stopCPU)
 
-		assert.Equal(2, len(bat.profiles))
+		assert.Equal(3, len(bat.profiles))
 
 		p.exit <- struct{}{}
 		<-wait

--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -140,7 +140,7 @@ func encode(bat batch, tags []string) (contentType string, body io.Reader, err e
 		return "", nil, err
 	}
 	for _, p := range bat.profiles {
-		formFile, err := mw.CreateFormFile(fmt.Sprintf("data[%s.pprof]", p.name), "pprof-data")
+		formFile, err := mw.CreateFormFile(fmt.Sprintf("data[%s]", p.name), "pprof-data")
 		if err != nil {
 			return "", nil, err
 		}

--- a/profiler/upload_test.go
+++ b/profiler/upload_test.go
@@ -34,11 +34,11 @@ var testBatch = batch{
 	host:  "my-host",
 	profiles: []*profile{
 		{
-			name: "cpu",
+			name: CPUProfile.Filename(),
 			data: []byte("my-cpu-profile"),
 		},
 		{
-			name: "heap",
+			name: HeapProfile.Filename(),
 			data: []byte("my-heap-profile"),
 		},
 	},


### PR DESCRIPTION
### Background
go heap pprof profiles are accumulative and it's not possible to compute the number of allocations and gc pause time metrics by examining these pprofs alone.

### Solution
To bring go to parity with other runtimes like the JVM, we compute these periodic metrics in context of collecting heap and cpu profiles.  These metrics are uploaded a json tuples.  Profiling intake and analysis services have corresponding changes to support this new payload and associate the metrics with corresponding profiles.

### Considerations
This work depends on https://github.com/DataDog/dd-trace-go/pull/781