### PR TITLE
Added support for space and comma separated tag lists

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,3 +15,8 @@ Fixes #113
 ```
 Please apply the same logic for Pull Requests and Issues: start with the package name, followed by a colon and a description of the change, just like
 the official [Go language](https://github.com/golang/go/pulls).
+
+### Style guidelines
+
+A set of [Style guidelines](https://github.com/DataDog/dd-trace-go/wiki/Style-guidelines) was added to our Wiki. Please spend some time browsing it.
+It will help tremendously in avoiding comments and speeding up the PR process.

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -138,7 +138,10 @@ func newConfig(opts ...StartOption) *config {
 		c.version = ver
 	}
 	if v := os.Getenv("DD_TAGS"); v != "" {
-		for _, tag := range strings.Split(v, ",") {
+		tags := strings.FieldsFunc(v, func(r rune) bool {
+			return r == ',' || r == ' '
+		})
+		for _, tag := range tags {
 			tag = strings.TrimSpace(tag)
 			if tag == "" {
 				continue
@@ -149,6 +152,9 @@ func newConfig(opts ...StartOption) *config {
 			case 1:
 				WithGlobalTag(k, "")(c)
 			case 2:
+				if len(k) == 0 {
+					continue
+				}
 				WithGlobalTag(k, strings.TrimSpace(kv[1]))(c)
 			}
 		}

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -249,6 +249,44 @@ func TestServiceName(t *testing.T) {
 	})
 }
 
+//DD_TAGS applicable only
+func TestTagSeparators(t *testing.T) {
+	t.Run("env-tags", func(t *testing.T) {
+		os.Setenv("DD_TAGS", "env:test,aKey:aVal bKey:bVal cKey:")
+		defer os.Unsetenv("DD_TAGS")
+
+		assert := assert.New(t)
+		c := newConfig()
+
+		assert.Equal("test", c.globalTags["env"])
+		assert.Equal("aVal", c.globalTags["aKey"])
+		assert.Equal("bVal", c.globalTags["bKey"])
+		assert.Equal("", c.globalTags["cKey"])
+
+		dVal, ok := c.globalTags["dKey"]
+		assert.False(ok)
+		assert.Equal(nil, dVal)
+	})
+
+	t.Run("env-tags", func(t *testing.T) {
+		os.Setenv("DD_TAGS", "env:test aKey:aVal     bKey :bVal dKey: dVal cKey:")
+		defer os.Unsetenv("DD_TAGS")
+
+		assert := assert.New(t)
+		c := newConfig()
+
+		assert.Equal("test", c.globalTags["env"])
+		assert.Equal("aVal", c.globalTags["aKey"])
+		assert.Equal("", c.globalTags["bKey"])
+		assert.NotContains(c.globalTags, "bVal")
+		assert.Equal("", c.globalTags["cKey"])
+
+		fVal, ok := c.globalTags["fKey"]
+		assert.False(ok)
+		assert.Equal(nil, fVal)
+	})
+}
+
 func TestVersionConfig(t *testing.T) {
 	t.Run("WithServiceVersion", func(t *testing.T) {
 		assert := assert.New(t)

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -200,6 +200,7 @@ func (s *span) setMeta(key, v string) {
 	if s.Meta == nil {
 		s.Meta = make(map[string]string, 1)
 	}
+	delete(s.Metrics, key)
 	switch key {
 	case ext.SpanName:
 		s.Name = v
@@ -246,6 +247,7 @@ func (s *span) setMetric(key string, v float64) {
 	if s.Metrics == nil {
 		s.Metrics = make(map[string]float64, 1)
 	}
+	delete(s.Meta, key)
 	switch key {
 	case ext.SamplingPriority:
 		// setting sampling priority per spec

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -352,7 +352,7 @@ func TestUniqueTagKeys(t *testing.T) {
 	span.SetTag("foo.bar", 12)
 	span.SetTag("foo.bar", "val")
 
-	assert.Equal(0.0, span.Metrics["foo.bar"])
+	assert.NotContains(span.Metrics, "foo.bar")
 	assert.Equal("val", span.Meta["foo.bar"])
 
 	//check to see if setMetric correctly wipes out a meta tag
@@ -360,8 +360,7 @@ func TestUniqueTagKeys(t *testing.T) {
 	span.SetTag("foo.bar", 12)
 
 	assert.Equal(12.0, span.Metrics["foo.bar"])
-	assert.Equal("", span.Meta["foo.bar"])
-
+	assert.NotContains(span.Meta, "foo.bar")
 }
 
 // Prior to a bug fix, this failed when running `go test -race`

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -344,6 +344,26 @@ func TestSpanErrorNil(t *testing.T) {
 	assert.Equal(nMeta, len(span.Meta))
 }
 
+func TestUniqueTagKeys(t *testing.T) {
+	assert := assert.New(t)
+	span := newBasicSpan("web.request")
+
+	//check to see if setMeta correctly wipes out a metric tag
+	span.SetTag("foo.bar", 12)
+	span.SetTag("foo.bar", "val")
+
+	assert.Equal(0.0, span.Metrics["foo.bar"])
+	assert.Equal("val", span.Meta["foo.bar"])
+
+	//check to see if setMetric correctly wipes out a meta tag
+	span.SetTag("foo.bar", "val")
+	span.SetTag("foo.bar", 12)
+
+	assert.Equal(12.0, span.Metrics["foo.bar"])
+	assert.Equal("", span.Meta["foo.bar"])
+
+}
+
 // Prior to a bug fix, this failed when running `go test -race`
 func TestSpanModifyWhileFlushing(t *testing.T) {
 	tracer, _, _, stop := startTestTracer(t)

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -156,7 +156,10 @@ func defaultConfig() *config {
 		WithVersion(v)(&c)
 	}
 	if v := os.Getenv("DD_TAGS"); v != "" {
-		for _, tag := range strings.Split(v, ",") {
+		tags := strings.FieldsFunc(v, func(r rune) bool {
+			return r == ',' || r == ' '
+		})
+		for _, tag := range tags {
 			tag = strings.TrimSpace(tag)
 			if tag == "" {
 				continue


### PR DESCRIPTION
Before dd-trace-go interpreted DD_TAGS as a comma-separated list of tags. The agent interprets DD_TAGS as a space-separated list instead. Support for  space-separation was added in a backwards-compatible way.