### PR TITLE
contrib/go-redis/redis.v8: support wrapping a go-redis v8 client

### DIFF
--- a/contrib/go-redis/redis.v8/redis.go
+++ b/contrib/go-redis/redis.v8/redis.go
@@ -38,24 +38,8 @@ type params struct {
 // NewClient returns a new Client that is traced with the default tracer under
 // the service name "redis".
 func NewClient(opt *redis.Options, opts ...ClientOption) redis.UniversalClient {
-	cfg := new(clientConfig)
-	defaults(cfg)
-	for _, fn := range opts {
-		fn(cfg)
-	}
-	host, port, err := net.SplitHostPort(opt.Addr)
-	if err != nil {
-		host = opt.Addr
-		port = "6379"
-	}
-	params := &params{
-		host:   host,
-		port:   port,
-		db:     strconv.Itoa(opt.DB),
-		config: cfg,
-	}
 	client := redis.NewClient(opt)
-	client.AddHook(&datadogHook{params: params})
+	WrapClient(client, opts...)
 	return client
 }
 


### PR DESCRIPTION
Fixes #803 

Introduce a new method, `WrapClient`, in the go-redis.v8 integration. This is [similar to the older go-redis integration](https://github.com/DataDog/dd-trace-go/blob/v1/contrib/go-redis/redis/redis.go#L61) in allowing a user to supply an already configured Redis client and have the tracing added to that rather than having the library build and return a client.

`redis.NewUniversalClient` can return a `Client`, `FailoverClient`, or `ClusterClient` instance. The important difference for this integration is the way that Redis addresses are available from a build client. A `Client` instance has a `Addr` field set to what's passed in to the constructor (e.g. `127.0.0.1:6379`), `FailoverClient` sets `Addr` to `FailoverClient` and `ClusterCleint` doesn't make this available at all. This is important because `Addr` is currently what's being used to set `host` and `port` tags on traces.

* What should we do for `host` and `port` tags for the client types that don't have a useful value?
* `ClusterClient` has a list of addresses available. Should we / can we add all of them as tags?
* Is there any other tag differences that we want to expose between the clients?

I've left the `host` and `port` tags as they were until we decide what the approach for each should be. These are also currently excluded from the test.