### PR TITLE
ddtrace/tracer: use span's configured noDebugStack when setting the error tag

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -103,7 +103,7 @@ func (s *span) SetTag(key string, value interface{}) {
 	}
 	switch key {
 	case ext.Error:
-		s.setTagError(value, &errorConfig{})
+		s.setTagError(value, &errorConfig{noDebugStack: s.noDebugStack})
 		return
 	}
 	if v, ok := value.(bool); ok {

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -204,6 +204,23 @@ func TestSpanSetTag(t *testing.T) {
 	assert.Equal("false", span.Meta["some.other.bool"])
 }
 
+func TestSpanSetTagError(t *testing.T) {
+	t.Run("with-stack", func(t *testing.T) {
+		assert := assert.New(t)
+		tracer := newTracer(withTransport(newDefaultTransport()))
+		span := tracer.StartSpan("pylons.request").(*span)
+		span.SetTag(ext.Error, errors.New("test error"))
+		assert.Contains(span.Meta, ext.ErrorStack)
+	})
+	t.Run("without-stack", func(t *testing.T) {
+		assert := assert.New(t)
+		tracer := newTracer(withTransport(newDefaultTransport()), WithDebugStack(false))
+		span := tracer.StartSpan("pylons.request").(*span)
+		span.SetTag(ext.Error, errors.New("test error"))
+		assert.NotContains(span.Meta, ext.ErrorStack)
+	})
+}
+
 func TestSpanSetDatadogTags(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
`SetTag(ext.Error, ...)` failed to take into consideration the span's configured value for `noDebugStack`. This PR fixes that omission and adds a regression test. 

