### PR TITLE
profiler: add options for block and mutex rates

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -232,7 +232,7 @@ func MutexProfileFraction(rate int) Option {
 // BlockProfileRate turns on block profiles with the given rate.
 // The profiler samples an average of one blocking event per rate nanoseconds spent blocked.
 // For example, set rate to 1000000000 (aka int(time.Second.Nanoseconds())) to
-// record one sample per second a goroutine is blocked at a particular location.
+// record one sample per second a goroutine is blocked.
 // A rate of 1 catches every event.
 // Setting an aggressive rate can hurt performance.
 // For more information on this value, check runtime.SetBlockProfileRate.

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -27,11 +27,11 @@ import (
 
 const (
 	// DefaultMutexFraction specifies the mutex profile fraction to be used with the mutex profiler.
-	// For more information or for changing this value, check runtime.SetMutexProfileFraction.
+	// For more information or for changing this value, check MutexProfileFraction
 	DefaultMutexFraction = 10
 
 	// DefaultBlockRate specifies the default block profiling rate used by the block profiler.
-	// For more information or for changing this value, check runtime.SetBlockProfileRate.
+	// For more information or for changing this value, check BlockProfileRate.
 	DefaultBlockRate = 100
 
 	// DefaultPeriod specifies the default period at which profiles will be collected.
@@ -214,6 +214,32 @@ func WithPeriod(d time.Duration) Option {
 func CPUDuration(d time.Duration) Option {
 	return func(cfg *config) {
 		cfg.cpuDuration = d
+	}
+}
+
+// MutexProfileFraction turns on mutex profiles with rate indicating the fraction
+// of mutex contention events reported in the mutex profile.
+// On average, 1/rate events are reported.
+// Setting an aggressive rate can hurt performance.
+// For more information on this value, check runtime.SetMutexProfileFraction.
+func MutexProfileFraction(rate int) Option {
+	return func(cfg *config) {
+		cfg.addProfileType(MutexProfile)
+		cfg.mutexFraction = rate
+	}
+}
+
+// BlockProfileRate turns on block profiles with the given rate.
+// The profiler samples an average of one blocking event per rate nanoseconds spent blocked.
+// For example, set rate to 1000000000 (aka int(time.Second.Nanoseconds())) to
+// record one sample per second a goroutine is blocked at a particular location.
+// A rate of 1 catches every event.
+// Setting an aggressive rate can hurt performance.
+// For more information on this value, check runtime.SetBlockProfileRate.
+func BlockProfileRate(rate int) Option {
+	return func(cfg *config) {
+		cfg.addProfileType(BlockProfile)
+		cfg.blockRate = rate
 	}
 }
 

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -96,6 +96,20 @@ func TestOptions(t *testing.T) {
 		assert.Equal(t, 3*time.Second, cfg.cpuDuration)
 	})
 
+	t.Run("MutexProfileFraction", func(t *testing.T) {
+		var cfg config
+		MutexProfileFraction(1)(&cfg)
+		assert.Equal(t, 1, cfg.mutexFraction)
+		assert.Contains(t, cfg.types, MutexProfile)
+	})
+
+	t.Run("BlockProfileRate", func(t *testing.T) {
+		var cfg config
+		BlockProfileRate(1)(&cfg)
+		assert.Equal(t, 1, cfg.blockRate)
+		assert.Contains(t, cfg.types, BlockProfile)
+	})
+
 	t.Run("WithProfileTypes", func(t *testing.T) {
 		var cfg config
 		WithProfileTypes(HeapProfile)(&cfg)


### PR DESCRIPTION
Clients can modify block and mutex rates by invoking [runtime.SetBlockProfileRate](https://github.com/golang/go/blob/c3b4c7093ac46431b6e15cf1979bd9a251a400da/src/runtime/mprof.go#L380) and [runtime.SetMutexProfileFraction](https://github.com/golang/go/blob/c3b4c7093ac46431b6e15cf1979bd9a251a400da/src/runtime/mprof.go#L439) respectively, but this pull

* provides a convenience wrapper around those runtime methods in the profiler options API
* better documentation than the above-referenced runtime functions, [which are opaque](https://github.com/golang/go/issues/14689), to put it kindly.