### PR TITLE
profiler: improve enqueueUpload comments

### DIFF
--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -156,15 +156,9 @@ func (p *profiler) collect(ticker <-chan time.Time) {
 	}
 }
 
-// enqueueUpload pushes a batch of profiles onto the queue to be uploaded. If
-// there is no room, it will evict the oldest profile to enqueue bat. Typically
-// a batch would be one of each enabled profile. This function must not be
-// called concurrently from different goroutines.
-// TODO(fg) This func could be changed to exert backpressure and stop the
-// profiling when the queue is full to avoid the profiling overhead while we
-// can't send data. Will require some discussion.
+// enqueueUpload pushes a batch of profiles onto the queue to be uploaded. If there is no room, it will
+// evict the oldest profile to make some. Typically a batch would be one of each enabled profile.
 func (p *profiler) enqueueUpload(bat batch) {
-	// If p.out is full, evict oldest entries until there is room.
 	for {
 		select {
 		case p.out <- bat:

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -172,6 +172,9 @@ func (p *profiler) enqueueUpload(bat batch) {
 			default:
 				// queue is empty; contents likely got uploaded
 			}
+
+			// p.out is guaranteed to have room for bat now
+			p.out <- bat
 		}
 	}
 }

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -164,6 +164,7 @@ func (p *profiler) collect(ticker <-chan time.Time) {
 // profiling when the queue is full to avoid the profiling overhead while we
 // can't send data. Will require some discussion.
 func (p *profiler) enqueueUpload(bat batch) {
+	// If p.out is full, evict oldest entries until there is room.
 	for {
 		select {
 		case p.out <- bat:
@@ -179,9 +180,6 @@ func (p *profiler) enqueueUpload(bat batch) {
 				// full p.out to completely drain within nanoseconds or extreme
 				// scheduling decisions by the runtime.
 			}
-			// p.out is guaranteed to have room for bat now since concurrent calls to
-			// enqueueUpload are verboten by the func comment.
-			p.out <- bat // 👍
 		}
 	}
 }


### PR DESCRIPTION
The code currently seems to drop the new bat after going through the
trouble of making room for it by potentially dropping the oldest item
from the queue. As far as I can tell this doesn't make sense, and this
patch should fix it.