### PR TITLE
ddtrace/tracer: format injected traceid header with leading zeros

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -307,8 +307,8 @@ func (*propagatorB3) injectTextMap(spanCtx ddtrace.SpanContext, writer TextMapWr
 	if !ok || ctx.traceID == 0 || ctx.spanID == 0 {
 		return ErrInvalidSpanContext
 	}
-	writer.Set(b3TraceIDHeader, fmt.Sprintf("%016x", strconv.FormatUint(ctx.traceID, 16)))
-	writer.Set(b3SpanIDHeader, strconv.FormatUint(ctx.spanID, 16))
+	writer.Set(b3TraceIDHeader, fmt.Sprintf("%016x", ctx.traceID))
+	writer.Set(b3SpanIDHeader, fmt.Sprintf("%016x", ctx.spanID))
 	if p, ok := ctx.samplingPriority(); ok {
 		if p >= ext.PriorityAutoKeep {
 			writer.Set(b3SampledHeader, "1")

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -6,6 +6,7 @@
 package tracer
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"strconv"
@@ -306,7 +307,7 @@ func (*propagatorB3) injectTextMap(spanCtx ddtrace.SpanContext, writer TextMapWr
 	if !ok || ctx.traceID == 0 || ctx.spanID == 0 {
 		return ErrInvalidSpanContext
 	}
-	writer.Set(b3TraceIDHeader, strconv.FormatUint(ctx.traceID, 16))
+	writer.Set(b3TraceIDHeader, fmt.Sprintf("%016x", strconv.FormatUint(ctx.traceID, 16)))
 	writer.Set(b3SpanIDHeader, strconv.FormatUint(ctx.spanID, 16))
 	if p, ok := ctx.samplingPriority(); ok {
 		if p >= ext.PriorityAutoKeep {

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -7,7 +7,6 @@ package tracer
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"os"
 	"strconv"
@@ -207,19 +206,52 @@ func TestB3(t *testing.T) {
 		os.Setenv("DD_PROPAGATION_STYLE_INJECT", "B3")
 		defer os.Unsetenv("DD_PROPAGATION_STYLE_INJECT")
 
-		tracer := newTracer()
-		root := tracer.StartSpan("web.request").(*span)
-		root.SetTag(ext.SamplingPriority, -1)
-		root.SetBaggageItem("item", "x")
-		ctx := root.Context().(*spanContext)
-		headers := TextMapCarrier(map[string]string{})
-		err := tracer.Inject(ctx, headers)
+		var tests = []struct {
+			in  []uint64
+			out map[string]string
+		}{
+			{
+				[]uint64{1412508178991881, 1842642739201064},
+				map[string]string{
+					b3TraceIDHeader: "000504ab30404b09",
+					b3SpanIDHeader:  "00068bdfb1eb0428",
+				},
+			},
+			{
+				[]uint64{9530669991610245, 9455715668862222},
+				map[string]string{
+					b3TraceIDHeader: "0021dc1807524785",
+					b3SpanIDHeader:  "002197ec5d8a250e",
+				},
+			},
+			{
+				[]uint64{1, 1},
+				map[string]string{
+					b3TraceIDHeader: "0000000000000001",
+					b3SpanIDHeader:  "0000000000000001",
+				},
+			},
+		}
 
-		assert := assert.New(t)
-		assert.Nil(err)
-		assert.Equal(headers[b3TraceIDHeader], fmt.Sprintf("%016x", strconv.FormatUint(root.TraceID, 16)))
-		assert.Equal(headers[b3SpanIDHeader], strconv.FormatUint(root.SpanID, 16))
-		assert.Equal(headers[b3SampledHeader], "0")
+		for _, test := range tests {
+			t.Run("", func(t *testing.T) {
+				tracer := newTracer()
+				root := tracer.StartSpan("web.request").(*span)
+				root.SetTag(ext.SamplingPriority, -1)
+				root.SetBaggageItem("item", "x")
+				ctx, ok := root.Context().(*spanContext)
+				ctx.traceID = test.in[0]
+				ctx.spanID = test.in[1]
+				headers := TextMapCarrier(map[string]string{})
+				err := tracer.Inject(ctx, headers)
+
+				assert := assert.New(t)
+				assert.True(ok)
+				assert.Nil(err)
+				assert.Equal(test.out[b3TraceIDHeader], headers[b3TraceIDHeader])
+				assert.Equal(test.out[b3SpanIDHeader], headers[b3SpanIDHeader])
+			})
+		}
 	})
 
 	t.Run("extract", func(t *testing.T) {

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -7,6 +7,7 @@ package tracer
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"strconv"
@@ -216,8 +217,7 @@ func TestB3(t *testing.T) {
 
 		assert := assert.New(t)
 		assert.Nil(err)
-
-		assert.Equal(headers[b3TraceIDHeader], strconv.FormatUint(root.TraceID, 16))
+		assert.Equal(headers[b3TraceIDHeader], fmt.Sprintf("%016x", strconv.FormatUint(root.TraceID, 16)))
 		assert.Equal(headers[b3SpanIDHeader], strconv.FormatUint(root.SpanID, 16))
 		assert.Equal(headers[b3SampledHeader], "0")
 	})


### PR DESCRIPTION
Refactors `ctx.traceID` and `ctx.spanID` in `injectTextMap()` to format injected headers as exactly 16 characters long.

Fixes #695