### PR TITLE
 profiler: Start() doesn't unlock mutex on error

### DIFF
--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -30,6 +30,7 @@ var (
 // the WithAPIKey option, or if a hostname is not found.
 func Start(opts ...Option) error {
 	mu.Lock()
+	defer mu.Unlock()
 	if activeProfiler != nil {
 		activeProfiler.stop()
 	}
@@ -39,7 +40,6 @@ func Start(opts ...Option) error {
 	}
 	activeProfiler = p
 	activeProfiler.run()
-	mu.Unlock()
 	return nil
 }
 

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -59,13 +59,19 @@ func TestStart(t *testing.T) {
 	})
 
 	t.Run("options/GoodAPIKey", func(t *testing.T) {
-		_, err := newProfiler(WithAPIKey("12345678901234567890123456789012"))
+		err := Start(WithAPIKey("12345678901234567890123456789012"))
+		defer Stop()
 		assert.Nil(t, err)
 	})
 
 	t.Run("options/BadAPIKey", func(t *testing.T) {
-		_, err := newProfiler(WithAPIKey("aaaa"))
+		err := Start(WithAPIKey("aaaa"))
 		assert.NotNil(t, err)
+		defer Stop()
+
+		// Check that mu gets unlocked, even if newProfiler() returns an error.
+		mu.Lock()
+		mu.Unlock()
 	})
 }
 

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -66,8 +66,8 @@ func TestStart(t *testing.T) {
 
 	t.Run("options/BadAPIKey", func(t *testing.T) {
 		err := Start(WithAPIKey("aaaa"))
-		assert.NotNil(t, err)
 		defer Stop()
+		assert.NotNil(t, err)
 
 		// Check that mu gets unlocked, even if newProfiler() returns an error.
 		mu.Lock()


### PR DESCRIPTION
Hopefully this PR fixes a non-imaginary bug : ). PTAL