### PR TITLE
profiler: restore mutex fraction during stop()

### DIFF
--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -175,12 +175,14 @@ func TestProfilerInternal(t *testing.T) {
 func TestSetProfileFraction(t *testing.T) {
 	t.Run("on", func(t *testing.T) {
 		start := runtime.SetMutexProfileFraction(-1)
+		require.NotEqual(t, DefaultMutexFraction, start)
 		defer runtime.SetMutexProfileFraction(start)
 		p, err := unstartedProfiler(WithProfileTypes(MutexProfile))
 		require.NoError(t, err)
 		p.run()
+		require.Equal(t, DefaultMutexFraction, runtime.SetMutexProfileFraction(-1))
 		p.stop()
-		assert.NotEqual(t, start, runtime.SetMutexProfileFraction(-1))
+		require.Equal(t, start, runtime.SetMutexProfileFraction(-1))
 	})
 
 	t.Run("off", func(t *testing.T) {


### PR DESCRIPTION
@pmbauer what do you think about this? IMO it would be nice if the profiler completely cleans up after itself, i.e. restores all runtime profiling rates to their previous settings.

It gets a little tricky with rates that don't allow us to read their previous value, e.g. [`SetBlockProfileRate`](https://golang.org/pkg/runtime/#SetBlockProfileRate) but I think for those we could simply set them to 0 to disable them.

Don't merge this yet, I'm just kicking it off to get your thoughts on the matter.