### PR TITLE
contrib/labstack/echo: remove invoking the registered HTTP error handler

### DIFF
--- a/contrib/labstack/echo.v4/echotrace.go
+++ b/contrib/labstack/echo.v4/echotrace.go
@@ -53,6 +53,8 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 			err := next(c)
 			if err != nil {
 				span.SetTag(ext.Error, err)
+
+				c.Echo().HTTPErrorHandler(err, c)
 			}
 
 			span.SetTag(ext.HTTPCode, strconv.Itoa(c.Response().Status))

--- a/contrib/labstack/echo.v4/echotrace.go
+++ b/contrib/labstack/echo.v4/echotrace.go
@@ -53,8 +53,6 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 			err := next(c)
 			if err != nil {
 				span.SetTag(ext.Error, err)
-				// invokes the registered HTTP error handler
-				c.Error(err)
 			}
 
 			span.SetTag(ext.HTTPCode, strconv.Itoa(c.Response().Status))

--- a/contrib/labstack/echo.v4/echotrace_test.go
+++ b/contrib/labstack/echo.v4/echotrace_test.go
@@ -207,7 +207,7 @@ func TestErrorHandling(t *testing.T) {
 	span := spans[0]
 	assert.Equal("http.request", span.OperationName())
 	assert.Equal("foobar", span.Tag(ext.ServiceName))
-	assert.Equal("500", span.Tag(ext.HTTPCode))
+	assert.Equal("200", span.Tag(ext.HTTPCode))
 	assert.Equal(wantErr.Error(), span.Tag(ext.Error).(error).Error())
 }
 

--- a/contrib/labstack/echo.v4/echotrace_test.go
+++ b/contrib/labstack/echo.v4/echotrace_test.go
@@ -207,7 +207,7 @@ func TestErrorHandling(t *testing.T) {
 	span := spans[0]
 	assert.Equal("http.request", span.OperationName())
 	assert.Equal("foobar", span.Tag(ext.ServiceName))
-	assert.Equal("200", span.Tag(ext.HTTPCode))
+	assert.Equal("500", span.Tag(ext.HTTPCode))
 	assert.Equal(wantErr.Error(), span.Tag(ext.Error).(error).Error())
 }
 


### PR DESCRIPTION
We have stuck with our project because of this line. Previously we used Gorilla which was implemented correctly and after the migration we noticed that both this echo middleware and our business logic calls `c.Error` so the error messages are duplicated in the response.