### PR TITLE
Allow the hostname to be configured

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -325,3 +325,10 @@ func WithUDS(socketPath string) Option {
 		Timeout: defaultHTTPTimeout,
 	})
 }
+
+// WithHostname specifies the hostname to attach to a profile
+func WithHostname(hostname string) Option {
+	return func(cfg *config) {
+		cfg.hostname = hostname
+	}
+}

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -182,6 +182,12 @@ func TestOptions(t *testing.T) {
 		assert.Contains(t, cfg.tags, "c:3")
 	})
 
+	t.Run("WithHostname", func(t *testing.T) {
+		var cfg config
+		WithHostname("abc")(&cfg)
+		assert.Contains(t, cfg.hostname, "abc")
+	})
+
 	t.Run("WithTags/override", func(t *testing.T) {
 		os.Setenv("DD_TAGS", "env1:tag1,env2:tag2")
 		defer os.Unsetenv("DD_TAGS")


### PR DESCRIPTION
What does this PR do ?
-----------------------

This PR introduces `WithHostname` in the Profiler settings that can be used to specify which hostname should be attached to the generated profiles.