### PR TITLE
profiler: fix outdated error message

### DIFF
--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -83,7 +83,7 @@ func newProfiler(opts ...Option) (*profiler, error) {
 		hostname, err := os.Hostname()
 		if err != nil {
 			if cfg.targetURL == cfg.apiURL {
-				return nil, fmt.Errorf("could not obtain hostname: %v; try specifying it using profiler.WithHostname", err)
+				return nil, fmt.Errorf("could not obtain hostname: %v", err)
 			}
 			log.Warn("unable to look up hostname: %v", err)
 		}


### PR DESCRIPTION
profiler.WithHostname might have existed at some point before the
profiler code was added to this repository, but it doesn't exist
anymore, so we shouldn't gaslight people with this confusing error
message.