### PR TITLE
contrib/elastic/go-elasticsearch: Add support for github.com/elastic/go-elasticsearch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,15 @@ jobs:
       - image: elasticsearch:5
         environment:
           ES_JAVA_OPTS: "-Xms750m -Xmx750m" # https://github.com/10up/wp-local-docker/issues/6
+      - image: elasticsearch:6.8.13
+        environment:
+          http.port: 9202-9300
+          ES_JAVA_OPTS: "-Xms750m -Xmx750m" # https://github.com/10up/wp-local-docker/issues/6
+      - image: elasticsearch:7.10.1
+        environment:
+          http.port: 9203-9300
+          discovery.type: single-node
+          ES_JAVA_OPTS: "-Xms750m -Xmx750m" # https://github.com/10up/wp-local-docker/issues/6
       - image: datadog/docker-dd-agent
         environment:
           DD_APM_ENABLED: "true"
@@ -157,12 +166,18 @@ jobs:
           command: dockerize -wait tcp://localhost:6379 -timeout 1m
 
       - run:
-          name: Wait for ElasticSearch (1)
+          name: Wait for ElasticSearch (2)
           command: dockerize -wait http://localhost:9200 -timeout 1m
 
       - run:
-          name: Wait for ElasticSearch (2)
+          name: Wait for ElasticSearch (5)
           command: dockerize -wait http://localhost:9201 -timeout 1m
+      - run:
+          name: Wait for ElasticSearch (6)
+          command: dockerize -wait http://localhost:9202 -timeout 1m
+      - run:
+          name: Wait for ElasticSearch (7)
+          command: dockerize -wait http://localhost:9203 -timeout 1m
 
       - run:
           name: Wait for Datadog Agent

--- a/contrib/elastic/go-elasticsearch.v5/elastictrace.go
+++ b/contrib/elastic/go-elasticsearch.v5/elastictrace.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-2020 Datadog, Inc.
+// Copyright 2016 Datadog, Inc.
 
 // Package elastic provides functions to trace the github.com/elastic/go-elasticsearch packages.
 package elastic // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/elastic/go-elasticsearch

--- a/contrib/elastic/go-elasticsearch.v5/elastictrace.go
+++ b/contrib/elastic/go-elasticsearch.v5/elastictrace.go
@@ -1,0 +1,147 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// Package elastic provides functions to trace the github.com/elastic/go-elasticsearch packages.
+package elastic // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/elastic/go-elasticsearch
+
+import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math"
+	"net/http"
+	"regexp"
+	"strconv"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+// NewRoundTripper returns a new http.Client which traces requests under the given service name.
+func NewRoundTripper(opts ...ClientOption) http.RoundTripper {
+	cfg := new(clientConfig)
+	defaults(cfg)
+	for _, fn := range opts {
+		fn(cfg)
+	}
+	return &roundTripper{config: *cfg}
+}
+
+// bodyCutoff specifies the maximum number of bytes that will be stored as a tag
+// value obtained from an HTTP request or response body.
+var bodyCutoff = 5 * 1024
+
+// TracedRoundTripper is a traced HTTP transport that captures Elasticsearch spans.
+type roundTripper struct {
+	config clientConfig
+}
+
+// RoundTrip satisfies the RoundTripper interface, wraps the sub Transport and
+// captures a span of the Elasticsearch request.
+func (t *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	url := req.URL.Path
+	method := req.Method
+	resource := t.config.resourceNamer(url, method)
+	opts := []ddtrace.StartSpanOption{
+		tracer.ServiceName(t.config.serviceName),
+		tracer.SpanType(ext.SpanTypeElasticSearch),
+		tracer.ResourceName(resource),
+		tracer.Tag("elasticsearch.method", method),
+		tracer.Tag("elasticsearch.url", url),
+		tracer.Tag("elasticsearch.params", req.URL.Query().Encode()),
+	}
+	if !math.IsNaN(t.config.analyticsRate) {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, t.config.analyticsRate))
+	}
+	span, _ := tracer.StartSpanFromContext(req.Context(), "elasticsearch.query", opts...)
+	defer span.Finish()
+
+	contentEncoding := req.Header.Get("Content-Encoding")
+	snip, rc, err := peek(req.Body, contentEncoding, int(req.ContentLength), bodyCutoff)
+	if err == nil {
+		span.SetTag("elasticsearch.body", snip)
+	}
+	req.Body = rc
+	// process using the standard transport
+	res, err := t.config.transport.RoundTrip(req)
+	if err != nil {
+		// roundtrip error
+		span.SetTag(ext.Error, err)
+	} else if res.StatusCode < 200 || res.StatusCode > 299 {
+		// HTTP error
+		snip, rc, err := peek(res.Body, contentEncoding, int(res.ContentLength), bodyCutoff)
+		if err != nil {
+			snip = http.StatusText(res.StatusCode)
+		}
+		span.SetTag(ext.Error, errors.New(snip))
+		res.Body = rc
+	}
+	if res != nil {
+		span.SetTag(ext.HTTPCode, strconv.Itoa(res.StatusCode))
+	}
+	return res, err
+
+}
+
+var (
+	idRegexp         = regexp.MustCompile("/([0-9]+)([/\\?]|$)")
+	idPlaceholder    = []byte("/?$2")
+	indexRegexp      = regexp.MustCompile("[0-9]{2,}")
+	indexPlaceholder = []byte("?")
+)
+
+// quantize quantizes an Elasticsearch to extract a meaningful resource from the request.
+// We quantize based on the method+url with some cleanup applied to the URL.
+// URLs with an ID will be generalized as will (potential) timestamped indices.
+func quantize(url, method string) string {
+	quantizedURL := idRegexp.ReplaceAll([]byte(url), idPlaceholder)
+	quantizedURL = indexRegexp.ReplaceAll(quantizedURL, indexPlaceholder)
+	return fmt.Sprintf("%s %s", method, quantizedURL)
+}
+
+// peek attempts to return the first n bytes, as a string, from the provided io.ReadCloser.
+// It returns a new io.ReadCloser which points to the same underlying stream and can be read
+// from to access the entire data including the snippet. max is used to specify the length
+// of the stream contained in the reader. If unknown, it should be -1. If 0 < max < n it
+// will override n.
+func peek(rc io.ReadCloser, encoding string, max, n int) (string, io.ReadCloser, error) {
+	if rc == nil {
+		return "", rc, errors.New("empty stream")
+	}
+	if max > 0 && max < n {
+		n = max
+	}
+	r := bufio.NewReaderSize(rc, n)
+	rc2 := struct {
+		io.Reader
+		io.Closer
+	}{
+		Reader: r,
+		Closer: rc,
+	}
+	snip, err := r.Peek(n)
+	if err == io.EOF {
+		err = nil
+	}
+	if err != nil {
+		return string(snip), rc2, err
+	}
+	if encoding == "gzip" {
+		// unpack the snippet
+		gzr, err := gzip.NewReader(bytes.NewReader(snip))
+		if err != nil {
+			// snip wasn't gzip; return it as is
+			return string(snip), rc2, nil
+		}
+		defer gzr.Close()
+		snip, err = ioutil.ReadAll(gzr)
+	}
+	return string(snip), rc2, err
+}

--- a/contrib/elastic/go-elasticsearch.v5/elastictrace_test.go
+++ b/contrib/elastic/go-elasticsearch.v5/elastictrace_test.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-2020 Datadog, Inc.
+// Copyright 2016 Datadog, Inc.
 
 package elastic
 

--- a/contrib/elastic/go-elasticsearch.v5/elastictrace_test.go
+++ b/contrib/elastic/go-elasticsearch.v5/elastictrace_test.go
@@ -1,0 +1,167 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package elastic
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+)
+
+const debug = false
+
+const (
+	elasticV5URL = "http://127.0.0.1:9201"
+	elasticV6URL = "http://127.0.0.1:9202"
+	elasticV7URL = "http://127.0.0.1:9203"
+)
+
+func TestMain(m *testing.M) {
+	// _, ok := os.LookupEnv("INTEGRATION")
+	// if !ok {
+	// 	fmt.Println("--- SKIP: to enable integration test, set the INTEGRATION environment variable")
+	// 	os.Exit(0)
+	// }
+	os.Exit(m.Run())
+}
+
+func checkPUTTrace(assert *assert.Assertions, mt mocktracer.Tracer) {
+	span := mt.FinishedSpans()[0]
+	assert.Equal("my-es-service", span.Tag(ext.ServiceName))
+	assert.Equal("PUT /twitter/tweet/?", span.Tag(ext.ResourceName))
+	assert.Equal("/twitter/tweet/1", span.Tag("elasticsearch.url"))
+	assert.Equal("PUT", span.Tag("elasticsearch.method"))
+	assert.Equal(`{"user": "test", "message": "hello"}`, span.Tag("elasticsearch.body"))
+}
+
+func checkGETTrace(assert *assert.Assertions, mt mocktracer.Tracer) {
+	span := mt.FinishedSpans()[0]
+	assert.Equal("my-es-service", span.Tag(ext.ServiceName))
+	assert.Equal("GET /twitter/tweet/?", span.Tag(ext.ResourceName))
+	assert.Equal("/twitter/tweet/1", span.Tag("elasticsearch.url"))
+	assert.Equal("GET", span.Tag("elasticsearch.method"))
+}
+
+func checkErrTrace(assert *assert.Assertions, mt mocktracer.Tracer) {
+	span := mt.FinishedSpans()[0]
+	assert.Equal("my-es-service", span.Tag(ext.ServiceName))
+	assert.Equal("GET /not-real-index/_doc/?", span.Tag(ext.ResourceName))
+	assert.Equal("/not-real-index/_doc/1", span.Tag("elasticsearch.url"))
+	assert.NotEmpty(span.Tag(ext.Error))
+	assert.Equal("*errors.errorString", fmt.Sprintf("%T", span.Tag(ext.Error).(error)))
+}
+
+func TestQuantize(t *testing.T) {
+	for _, tc := range []struct {
+		url, method string
+		expected    string
+	}{
+		{
+			url:      "/twitter/tweets",
+			method:   "POST",
+			expected: "POST /twitter/tweets",
+		},
+		{
+			url:      "/logs_2016_05/event/_search",
+			method:   "GET",
+			expected: "GET /logs_?_?/event/_search",
+		},
+		{
+			url:      "/twitter/tweets/123",
+			method:   "GET",
+			expected: "GET /twitter/tweets/?",
+		},
+		{
+			url:      "/logs_2016_05/event/123",
+			method:   "PUT",
+			expected: "PUT /logs_?_?/event/?",
+		},
+	} {
+		assert.Equal(t, tc.expected, quantize(tc.url, tc.method))
+	}
+}
+
+func TestPeek(t *testing.T) {
+	assert := assert.New(t)
+
+	for _, tt := range [...]struct {
+		max  int    // content length
+		txt  string // stream
+		n    int    // bytes to peek at
+		snip string // expected snippet
+		err  error  // expected error
+	}{
+		0: {
+			// extract 3 bytes from a content of length 7
+			txt:  "ABCDEFG",
+			max:  7,
+			n:    3,
+			snip: "ABC",
+		},
+		1: {
+			// extract 7 bytes from a content of length 7
+			txt:  "ABCDEFG",
+			max:  7,
+			n:    7,
+			snip: "ABCDEFG",
+		},
+		2: {
+			// extract 100 bytes from a content of length 9 (impossible scenario)
+			txt:  "ABCDEFG",
+			max:  9,
+			n:    100,
+			snip: "ABCDEFG",
+		},
+		3: {
+			// extract 5 bytes from a content of length 2 (impossible scenario)
+			txt:  "ABCDEFG",
+			max:  2,
+			n:    5,
+			snip: "AB",
+		},
+		4: {
+			txt:  "ABCDEFG",
+			max:  0,
+			n:    1,
+			snip: "A",
+		},
+		5: {
+			n:   4,
+			max: 4,
+			err: errors.New("empty stream"),
+		},
+		6: {
+			txt:  "ABCDEFG",
+			n:    4,
+			max:  -1,
+			snip: "ABCD",
+		},
+	} {
+		var readcloser io.ReadCloser
+		if tt.txt != "" {
+			readcloser = ioutil.NopCloser(bytes.NewBufferString(tt.txt))
+		}
+		snip, rc, err := peek(readcloser, "", tt.max, tt.n)
+		assert.Equal(tt.err, err)
+		assert.Equal(tt.snip, snip)
+
+		if readcloser != nil {
+			// if a non-nil io.ReadCloser was sent, the returned io.ReadCloser
+			// must always return the entire original content.
+			all, err := ioutil.ReadAll(rc)
+			assert.Nil(err)
+			assert.Equal(tt.txt, string(all))
+		}
+	}
+}

--- a/contrib/elastic/go-elasticsearch.v5/elastictrace_v5_test.go
+++ b/contrib/elastic/go-elasticsearch.v5/elastictrace_v5_test.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-2020 Datadog, Inc.
+// Copyright 2016 Datadog, Inc.
 
 package elastic
 

--- a/contrib/elastic/go-elasticsearch.v5/elastictrace_v5_test.go
+++ b/contrib/elastic/go-elasticsearch.v5/elastictrace_v5_test.go
@@ -1,0 +1,243 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package elastic
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	elasticsearch5 "github.com/elastic/go-elasticsearch/v5"
+	esapi5 "github.com/elastic/go-elasticsearch/v5/esapi"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+)
+
+func TestClientV5(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	cfg := elasticsearch5.Config{
+		Transport: NewRoundTripper(WithServiceName("my-es-service")),
+		Addresses: []string{
+			elasticV5URL,
+		},
+	}
+	client, err := elasticsearch5.NewClient(cfg)
+	assert.NoError(err)
+
+	_, err = esapi5.IndexRequest{
+		Index:        "twitter",
+		DocumentID:   "1",
+		DocumentType: "tweet",
+		Body:         strings.NewReader(`{"user": "test", "message": "hello"}`),
+	}.Do(context.TODO(), client)
+	assert.NoError(err)
+
+	mt.Reset()
+	_, err = esapi5.GetRequest{
+		Index:        "twitter",
+		DocumentID:   "1",
+		DocumentType: "tweet",
+	}.Do(context.TODO(), client)
+	assert.NoError(err)
+	checkGETTrace(assert, mt)
+
+	mt.Reset()
+	_, err = esapi5.GetRequest{
+		Index:      "not-real-index",
+		DocumentID: "1",
+	}.Do(context.TODO(), client)
+	assert.NoError(err)
+	checkErrTrace(assert, mt)
+
+}
+
+func TestClientErrorCutoffV5(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	oldCutoff := bodyCutoff
+	defer func() {
+		bodyCutoff = oldCutoff
+	}()
+	bodyCutoff = 10
+
+	cfg := elasticsearch5.Config{
+		Transport: NewRoundTripper(WithServiceName("my-es-service")),
+		Addresses: []string{
+			elasticV5URL,
+		},
+	}
+	client, err := elasticsearch5.NewClient(cfg)
+	assert.NoError(err)
+
+	_, err = esapi5.GetRequest{
+		Index:      "not-real-index",
+		DocumentID: "1",
+	}.Do(context.TODO(), client)
+	assert.NoError(err)
+
+	span := mt.FinishedSpans()[0]
+	assert.Equal(`{"error":{`, span.Tag(ext.Error).(error).Error())
+}
+
+func TestClientV5Failure(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	cfg := elasticsearch5.Config{
+		Transport: NewRoundTripper(WithServiceName("my-es-service")),
+		Addresses: []string{
+			"http://127.0.0.1:9207", // inexistent service, it must fail
+		},
+	}
+	client, err := elasticsearch5.NewClient(cfg)
+	assert.NoError(err)
+
+	_, err = esapi5.IndexRequest{
+		Index:        "twitter",
+		DocumentID:   "1",
+		DocumentType: "tweet",
+		Body:         strings.NewReader(`{"user": "test", "message": "hello"}`),
+	}.Do(context.TODO(), client)
+	assert.Error(err)
+
+	spans := mt.FinishedSpans()
+	checkPUTTrace(assert, mt)
+
+	assert.NotEmpty(spans[0].Tag(ext.Error))
+	assert.Equal("*net.OpError", fmt.Sprintf("%T", spans[0].Tag(ext.Error).(error)))
+}
+
+func TestResourceNamerSettingsV5(t *testing.T) {
+	staticName := "static resource name"
+	staticNamer := func(url, method string) string {
+		return staticName
+	}
+
+	t.Run("default", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		cfg := elasticsearch5.Config{
+			Transport: NewRoundTripper(),
+			Addresses: []string{
+				elasticV5URL,
+			},
+		}
+		client, err := elasticsearch5.NewClient(cfg)
+		assert.NoError(t, err)
+
+		_, err = esapi5.GetRequest{
+			Index:        "logs_2017_05/event/_search",
+			DocumentID:   "1",
+			DocumentType: "tweet",
+		}.Do(context.TODO(), client)
+
+		span := mt.FinishedSpans()[0]
+		assert.Equal(t, "GET /logs_?_?/event/_search/tweet/?", span.Tag(ext.ResourceName))
+	})
+
+	t.Run("custom", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		cfg := elasticsearch5.Config{
+			Transport: NewRoundTripper(WithResourceNamer(staticNamer)),
+			Addresses: []string{
+				elasticV5URL,
+			},
+		}
+		client, err := elasticsearch5.NewClient(cfg)
+		assert.NoError(t, err)
+
+		_, err = esapi5.GetRequest{
+			Index:        "logs_2017_05/event/_search",
+			DocumentID:   "1",
+			DocumentType: "tweet",
+		}.Do(context.TODO(), client)
+
+		span := mt.FinishedSpans()[0]
+		assert.Equal(t, staticName, span.Tag(ext.ResourceName))
+	})
+}
+
+func TestAnalyticsSettingsV5(t *testing.T) {
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...ClientOption) {
+
+		cfg := elasticsearch5.Config{
+			Transport: NewRoundTripper(opts...),
+			Addresses: []string{
+				elasticV5URL,
+			},
+		}
+		client, err := elasticsearch5.NewClient(cfg)
+		assert.NoError(t, err)
+
+		_, err = esapi5.IndexRequest{
+			Index:        "twitter",
+			DocumentID:   "1",
+			DocumentType: "tweet",
+			Body:         strings.NewReader(`{"user": "test", "message": "hello"}`),
+		}.Do(context.TODO(), client)
+		assert.NoError(t, err)
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+		s := spans[0]
+		assert.Equal(t, rate, s.Tag(ext.EventSampleRate))
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil)
+	})
+
+	t.Run("global", func(t *testing.T) {
+		t.Skip("global flag disabled")
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.4)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 1.0, WithAnalytics(true))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil, WithAnalytics(false))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
+	})
+}

--- a/contrib/elastic/go-elasticsearch.v5/elastictrace_v6_test.go
+++ b/contrib/elastic/go-elasticsearch.v5/elastictrace_v6_test.go
@@ -1,0 +1,243 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package elastic
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	elasticsearch6 "github.com/elastic/go-elasticsearch/v6"
+	esapi6 "github.com/elastic/go-elasticsearch/v6/esapi"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+)
+
+func TestClientV6(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	cfg := elasticsearch6.Config{
+		Transport: NewRoundTripper(WithServiceName("my-es-service")),
+		Addresses: []string{
+			elasticV6URL,
+		},
+	}
+	client, err := elasticsearch6.NewClient(cfg)
+	assert.NoError(err)
+
+	_, err = esapi6.IndexRequest{
+		Index:        "twitter",
+		DocumentID:   "1",
+		DocumentType: "tweet",
+		Body:         strings.NewReader(`{"user": "test", "message": "hello"}`),
+	}.Do(context.TODO(), client)
+	assert.NoError(err)
+
+	mt.Reset()
+	_, err = esapi6.GetRequest{
+		Index:        "twitter",
+		DocumentID:   "1",
+		DocumentType: "tweet",
+	}.Do(context.TODO(), client)
+	assert.NoError(err)
+	checkGETTrace(assert, mt)
+
+	mt.Reset()
+	_, err = esapi6.GetRequest{
+		Index:      "not-real-index",
+		DocumentID: "1",
+	}.Do(context.TODO(), client)
+	assert.NoError(err)
+	checkErrTrace(assert, mt)
+
+}
+
+func TestClientErrorCutoffV6(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	oldCutoff := bodyCutoff
+	defer func() {
+		bodyCutoff = oldCutoff
+	}()
+	bodyCutoff = 10
+
+	cfg := elasticsearch6.Config{
+		Transport: NewRoundTripper(WithServiceName("my-es-service")),
+		Addresses: []string{
+			elasticV6URL,
+		},
+	}
+	client, err := elasticsearch6.NewClient(cfg)
+	assert.NoError(err)
+
+	_, err = esapi6.GetRequest{
+		Index:      "not-real-index",
+		DocumentID: "1",
+	}.Do(context.TODO(), client)
+	assert.NoError(err)
+
+	span := mt.FinishedSpans()[0]
+	assert.Equal(`{"error":{`, span.Tag(ext.Error).(error).Error())
+}
+
+func TestClientV6Failure(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	cfg := elasticsearch6.Config{
+		Transport: NewRoundTripper(WithServiceName("my-es-service")),
+		Addresses: []string{
+			"http://127.0.0.1:9207", // inexistent service, it must fail
+		},
+	}
+	client, err := elasticsearch6.NewClient(cfg)
+	assert.NoError(err)
+
+	_, err = esapi6.IndexRequest{
+		Index:        "twitter",
+		DocumentID:   "1",
+		DocumentType: "tweet",
+		Body:         strings.NewReader(`{"user": "test", "message": "hello"}`),
+	}.Do(context.TODO(), client)
+	assert.Error(err)
+
+	spans := mt.FinishedSpans()
+	checkPUTTrace(assert, mt)
+
+	assert.NotEmpty(spans[0].Tag(ext.Error))
+	assert.Equal("*net.OpError", fmt.Sprintf("%T", spans[0].Tag(ext.Error).(error)))
+}
+
+func TestResourceNamerSettingsV6(t *testing.T) {
+	staticName := "static resource name"
+	staticNamer := func(url, method string) string {
+		return staticName
+	}
+
+	t.Run("default", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		cfg := elasticsearch6.Config{
+			Transport: NewRoundTripper(),
+			Addresses: []string{
+				elasticV6URL,
+			},
+		}
+		client, err := elasticsearch6.NewClient(cfg)
+		assert.NoError(t, err)
+
+		_, err = esapi6.GetRequest{
+			Index:        "logs_2017_05/event/_search",
+			DocumentID:   "1",
+			DocumentType: "tweet",
+		}.Do(context.TODO(), client)
+
+		span := mt.FinishedSpans()[0]
+		assert.Equal(t, "GET /logs_?_?/event/_search/tweet/?", span.Tag(ext.ResourceName))
+	})
+
+	t.Run("custom", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		cfg := elasticsearch6.Config{
+			Transport: NewRoundTripper(WithResourceNamer(staticNamer)),
+			Addresses: []string{
+				elasticV6URL,
+			},
+		}
+		client, err := elasticsearch6.NewClient(cfg)
+		assert.NoError(t, err)
+
+		_, err = esapi6.GetRequest{
+			Index:        "logs_2017_05/event/_search",
+			DocumentID:   "1",
+			DocumentType: "tweet",
+		}.Do(context.TODO(), client)
+
+		span := mt.FinishedSpans()[0]
+		assert.Equal(t, staticName, span.Tag(ext.ResourceName))
+	})
+}
+
+func TestAnalyticsSettingsV6(t *testing.T) {
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...ClientOption) {
+
+		cfg := elasticsearch6.Config{
+			Transport: NewRoundTripper(opts...),
+			Addresses: []string{
+				elasticV6URL,
+			},
+		}
+		client, err := elasticsearch6.NewClient(cfg)
+		assert.NoError(t, err)
+
+		_, err = esapi6.IndexRequest{
+			Index:        "twitter",
+			DocumentID:   "1",
+			DocumentType: "tweet",
+			Body:         strings.NewReader(`{"user": "test", "message": "hello"}`),
+		}.Do(context.TODO(), client)
+		assert.NoError(t, err)
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+		s := spans[0]
+		assert.Equal(t, rate, s.Tag(ext.EventSampleRate))
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil)
+	})
+
+	t.Run("global", func(t *testing.T) {
+		t.Skip("global flag disabled")
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.4)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 1.0, WithAnalytics(true))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil, WithAnalytics(false))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
+	})
+}

--- a/contrib/elastic/go-elasticsearch.v5/elastictrace_v6_test.go
+++ b/contrib/elastic/go-elasticsearch.v5/elastictrace_v6_test.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-2020 Datadog, Inc.
+// Copyright 2016 Datadog, Inc.
 
 package elastic
 

--- a/contrib/elastic/go-elasticsearch.v5/elastictrace_v7_test.go
+++ b/contrib/elastic/go-elasticsearch.v5/elastictrace_v7_test.go
@@ -1,0 +1,243 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package elastic
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	elasticsearch7 "github.com/elastic/go-elasticsearch/v7"
+	esapi7 "github.com/elastic/go-elasticsearch/v7/esapi"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+)
+
+func TestClientV7(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	cfg := elasticsearch7.Config{
+		Transport: NewRoundTripper(WithServiceName("my-es-service")),
+		Addresses: []string{
+			elasticV7URL,
+		},
+	}
+	client, err := elasticsearch7.NewClient(cfg)
+	assert.NoError(err)
+
+	_, err = esapi7.IndexRequest{
+		Index:        "twitter",
+		DocumentID:   "1",
+		DocumentType: "tweet",
+		Body:         strings.NewReader(`{"user": "test", "message": "hello"}`),
+	}.Do(context.TODO(), client)
+	assert.NoError(err)
+
+	mt.Reset()
+	_, err = esapi7.GetRequest{
+		Index:        "twitter",
+		DocumentID:   "1",
+		DocumentType: "tweet",
+	}.Do(context.TODO(), client)
+	assert.NoError(err)
+	checkGETTrace(assert, mt)
+
+	mt.Reset()
+	_, err = esapi7.GetRequest{
+		Index:      "not-real-index",
+		DocumentID: "1",
+	}.Do(context.TODO(), client)
+	assert.NoError(err)
+	checkErrTrace(assert, mt)
+
+}
+
+func TestClientErrorCutoffV7(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	oldCutoff := bodyCutoff
+	defer func() {
+		bodyCutoff = oldCutoff
+	}()
+	bodyCutoff = 10
+
+	cfg := elasticsearch7.Config{
+		Transport: NewRoundTripper(WithServiceName("my-es-service")),
+		Addresses: []string{
+			elasticV7URL,
+		},
+	}
+	client, err := elasticsearch7.NewClient(cfg)
+	assert.NoError(err)
+
+	_, err = esapi7.GetRequest{
+		Index:      "not-real-index",
+		DocumentID: "1",
+	}.Do(context.TODO(), client)
+	assert.NoError(err)
+
+	span := mt.FinishedSpans()[0]
+	assert.Equal(`{"error":{`, span.Tag(ext.Error).(error).Error())
+}
+
+func TestClientV7Failure(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	cfg := elasticsearch7.Config{
+		Transport: NewRoundTripper(WithServiceName("my-es-service")),
+		Addresses: []string{
+			"http://127.0.0.1:9207", // inexistent service, it must fail
+		},
+	}
+	client, err := elasticsearch7.NewClient(cfg)
+	assert.NoError(err)
+
+	_, err = esapi7.IndexRequest{
+		Index:        "twitter",
+		DocumentID:   "1",
+		DocumentType: "tweet",
+		Body:         strings.NewReader(`{"user": "test", "message": "hello"}`),
+	}.Do(context.TODO(), client)
+	assert.Error(err)
+
+	spans := mt.FinishedSpans()
+	checkPUTTrace(assert, mt)
+
+	assert.NotEmpty(spans[0].Tag(ext.Error))
+	assert.Equal("*net.OpError", fmt.Sprintf("%T", spans[0].Tag(ext.Error).(error)))
+}
+
+func TestResourceNamerSettingsV7(t *testing.T) {
+	staticName := "static resource name"
+	staticNamer := func(url, method string) string {
+		return staticName
+	}
+
+	t.Run("default", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		cfg := elasticsearch7.Config{
+			Transport: NewRoundTripper(),
+			Addresses: []string{
+				elasticV7URL,
+			},
+		}
+		client, err := elasticsearch7.NewClient(cfg)
+		assert.NoError(t, err)
+
+		_, err = esapi7.GetRequest{
+			Index:        "logs_2017_05/event/_search",
+			DocumentID:   "1",
+			DocumentType: "tweet",
+		}.Do(context.TODO(), client)
+
+		span := mt.FinishedSpans()[0]
+		assert.Equal(t, "GET /logs_?_?/event/_search/tweet/?", span.Tag(ext.ResourceName))
+	})
+
+	t.Run("custom", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		cfg := elasticsearch7.Config{
+			Transport: NewRoundTripper(WithResourceNamer(staticNamer)),
+			Addresses: []string{
+				elasticV7URL,
+			},
+		}
+		client, err := elasticsearch7.NewClient(cfg)
+		assert.NoError(t, err)
+
+		_, err = esapi7.GetRequest{
+			Index:        "logs_2017_05/event/_search",
+			DocumentID:   "1",
+			DocumentType: "tweet",
+		}.Do(context.TODO(), client)
+
+		span := mt.FinishedSpans()[0]
+		assert.Equal(t, staticName, span.Tag(ext.ResourceName))
+	})
+}
+
+func TestAnalyticsSettingsV7(t *testing.T) {
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...ClientOption) {
+
+		cfg := elasticsearch7.Config{
+			Transport: NewRoundTripper(opts...),
+			Addresses: []string{
+				elasticV7URL,
+			},
+		}
+		client, err := elasticsearch7.NewClient(cfg)
+		assert.NoError(t, err)
+
+		_, err = esapi7.IndexRequest{
+			Index:        "twitter",
+			DocumentID:   "1",
+			DocumentType: "tweet",
+			Body:         strings.NewReader(`{"user": "test", "message": "hello"}`),
+		}.Do(context.TODO(), client)
+		assert.NoError(t, err)
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+		s := spans[0]
+		assert.Equal(t, rate, s.Tag(ext.EventSampleRate))
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil)
+	})
+
+	t.Run("global", func(t *testing.T) {
+		t.Skip("global flag disabled")
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.4)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 1.0, WithAnalytics(true))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil, WithAnalytics(false))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
+	})
+}

--- a/contrib/elastic/go-elasticsearch.v5/elastictrace_v7_test.go
+++ b/contrib/elastic/go-elasticsearch.v5/elastictrace_v7_test.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-2020 Datadog, Inc.
+// Copyright 2016 Datadog, Inc.
 
 package elastic
 

--- a/contrib/elastic/go-elasticsearch.v5/example_test.go
+++ b/contrib/elastic/go-elasticsearch.v5/example_test.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-2020 Datadog, Inc.
+// Copyright 2016 Datadog, Inc.
 package elastic_test
 
 import (

--- a/contrib/elastic/go-elasticsearch.v5/example_test.go
+++ b/contrib/elastic/go-elasticsearch.v5/example_test.go
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+package elastic_test
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	elasticsearch "github.com/elastic/go-elasticsearch/v7"
+	"github.com/elastic/go-elasticsearch/v7/esapi"
+	elastictrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/elastic/go-elasticsearch.v5"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+func Example_v7() {
+	cfg := elasticsearch.Config{
+		Transport: elastictrace.NewRoundTripper(elastictrace.WithServiceName("my-es-service")),
+		Addresses: []string{
+			"http://127.0.0.1:9200",
+		},
+	}
+	es, err := elasticsearch.NewClient(cfg)
+	if err != nil {
+		log.Fatalf("Error creating the client: %s", err)
+	}
+
+	_, err = esapi.IndexRequest{
+		Index:        "twitter",
+		DocumentID:   "1",
+		DocumentType: "tweet",
+		Body:         strings.NewReader(`{"user": "test", "message": "hello"}`),
+	}.Do(context.Background(), es)
+
+	if err != nil {
+		log.Fatalf("Error creating index: %s", err)
+	}
+
+	// Use a context to pass information down the call chain
+	root, ctx := tracer.StartSpanFromContext(context.Background(), "parent.request",
+		tracer.ServiceName("web"),
+		tracer.ResourceName("/tweet/1"),
+	)
+
+	_, err = esapi.GetRequest{
+		Index:        "twitter",
+		DocumentID:   "1",
+		DocumentType: "tweet",
+	}.Do(ctx, es)
+
+	if err != nil {
+		log.Fatalf("Error getting index: %s", err)
+	}
+
+	root.Finish()
+
+}

--- a/contrib/elastic/go-elasticsearch.v5/option.go
+++ b/contrib/elastic/go-elasticsearch.v5/option.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-2020 Datadog, Inc.
+// Copyright 2016 Datadog, Inc.
 
 package elastic
 

--- a/contrib/elastic/go-elasticsearch.v5/option.go
+++ b/contrib/elastic/go-elasticsearch.v5/option.go
@@ -1,0 +1,82 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package elastic
+
+import (
+	"math"
+	"net/http"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
+)
+
+type clientConfig struct {
+	serviceName   string
+	transport     http.RoundTripper
+	analyticsRate float64
+	resourceNamer func(url, method string) string
+}
+
+// ClientOption represents an option that can be used when creating a client.
+type ClientOption func(*clientConfig)
+
+func defaults(cfg *clientConfig) {
+	cfg.serviceName = "elastic.client"
+	cfg.transport = http.DefaultTransport
+	cfg.resourceNamer = quantize
+	// cfg.analyticsRate = globalconfig.AnalyticsRate()
+	if internal.BoolEnv("DD_TRACE_ELASTIC_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = math.NaN()
+	}
+}
+
+// WithTransport sets the given transport as an http.Transport for the client.
+func WithTransport(t *http.RoundTripper) ClientOption {
+	return func(cfg *clientConfig) {
+		cfg.transport = *t
+	}
+}
+
+// WithServiceName sets the given service name for the client.
+func WithServiceName(name string) ClientOption {
+	return func(cfg *clientConfig) {
+		cfg.serviceName = name
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) ClientOption {
+	return func(cfg *clientConfig) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
+	}
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) ClientOption {
+	return func(cfg *clientConfig) {
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
+	}
+}
+
+// WithResourceNamer specifies a quantizing function which will be used to obtain a resource name for a given
+// ElasticSearch request, using the request's URL and method. Note that the default quantizer obfuscates
+// IDs and indexes and by replacing it, sensitive data could possibly be exposed, unless the new quantizer
+// specifically takes care of that.
+func WithResourceNamer(namer func(url, method string) string) ClientOption {
+	return func(cfg *clientConfig) {
+		cfg.resourceNamer = namer
+	}
+}


### PR DESCRIPTION
contrib/elastic/go-elasticsearch.v5: Add support for github.com/elastic/go-elasticsearch

given the olivier/elasticsearch is tentative on v8 and the official support is the long term choice for most customers it is important to add support for elastic/go-elasticsearch.

Fixes #778