### PR TITLE
ddtracer/tracer: marshalled span values in encode span

### DIFF
--- a/ddtrace/tracer/writer.go
+++ b/ddtrace/tracer/writer.go
@@ -188,17 +188,9 @@ func (h *logTraceWriter) encodeSpan(s *span) {
 		} else {
 			h.buf.WriteString(`,`)
 		}
-		m, err := json.Marshal(k)
-		if err != nil {
-			log.Error("Error encoding meta key %q: %v", k, err)
-		}
-		h.buf.Write(m)
+		h.marshalString(k)
 		h.buf.WriteString(":")
-		m, err = json.Marshal(v)
-		if err != nil {
-			log.Error("Error encoding meta value %q: %v", v, err)
-		}
-		h.buf.Write(m)
+		h.marshalString(v)
 	}
 	h.buf.WriteString(`},"metrics":{`)
 	first = true
@@ -212,11 +204,7 @@ func (h *logTraceWriter) encodeSpan(s *span) {
 		} else {
 			h.buf.WriteString(`,`)
 		}
-		m, err := json.Marshal(k)
-		if err != nil {
-			log.Error("Error encoding metrics key %q: %v", k, err)
-		}
-		h.buf.Write(m)
+		h.marshalString(k)
 		h.buf.WriteString(`:`)
 		h.buf.Write(encodeFloat(scratch[:0], v))
 	}
@@ -229,8 +217,8 @@ func (h *logTraceWriter) encodeSpan(s *span) {
 	h.buf.WriteString(`}`)
 }
 
-// marshalString will sanitize strings that may hold characters
-// that would render invalid JSON.
+// marshalString marshals the string str as JSON into the writer's buffer.
+// Should be used whenever writing non-constant string data to ensure correct sanitization.
 func (h *logTraceWriter) marshalString(str string) {
 	m, err := json.Marshal(str)
 	if err != nil {

--- a/ddtrace/tracer/writer.go
+++ b/ddtrace/tracer/writer.go
@@ -7,6 +7,7 @@ package tracer
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"io"
 	"math"
@@ -183,15 +184,15 @@ func (h *logTraceWriter) encodeSpan(s *span) {
 	first := true
 	for k, v := range s.Meta {
 		if first {
-			h.buf.WriteByte('"')
 			first = false
 		} else {
-			h.buf.WriteString(`,"`)
+			h.buf.WriteString(`,`)
 		}
-		h.buf.WriteString(k)
-		h.buf.WriteString(`":"`)
-		h.buf.WriteString(v)
-		h.buf.WriteString(`"`)
+		m, _ := json.Marshal(k)
+		h.buf.Write(m)
+		h.buf.WriteString(":")
+		m, _ = json.Marshal(v)
+		h.buf.Write(m)
 	}
 	h.buf.WriteString(`},"metrics":{`)
 	first = true

--- a/ddtrace/tracer/writer.go
+++ b/ddtrace/tracer/writer.go
@@ -174,11 +174,11 @@ func (h *logTraceWriter) encodeSpan(s *span) {
 	h.buf.Write(strconv.AppendUint(scratch[:0], uint64(s.SpanID), 16))
 	h.buf.WriteString(`","parent_id":"`)
 	h.buf.Write(strconv.AppendUint(scratch[:0], uint64(s.ParentID), 16))
-	h.buf.WriteString(`","name":"`)
-	h.buf.WriteString(s.Name)
-	h.buf.WriteString(`","resource":"`)
-	h.buf.WriteString(s.Resource)
-	h.buf.WriteString(`","error":`)
+	h.buf.WriteString(`","name":`)
+	h.marshalString(s.Name)
+	h.buf.WriteString(`,"resource":`)
+	h.marshalString(s.Resource)
+	h.buf.WriteString(`,"error":`)
 	h.buf.Write(strconv.AppendInt(scratch[:0], int64(s.Error), 10))
 	h.buf.WriteString(`,"meta":{`)
 	first := true
@@ -224,9 +224,20 @@ func (h *logTraceWriter) encodeSpan(s *span) {
 	h.buf.Write(strconv.AppendInt(scratch[:0], s.Start, 10))
 	h.buf.WriteString(`,"duration":`)
 	h.buf.Write(strconv.AppendInt(scratch[:0], s.Duration, 10))
-	h.buf.WriteString(`,"service":"`)
-	h.buf.WriteString(s.Service)
-	h.buf.WriteString(`"}`)
+	h.buf.WriteString(`,"service":`)
+	h.marshalString(s.Service)
+	h.buf.WriteString(`}`)
+}
+
+// marshalString will sanitize strings that may hold characters
+// that would render invalid JSON.
+func (h *logTraceWriter) marshalString(str string) {
+	m, err := json.Marshal(str)
+	if err != nil {
+		log.Error("Error marshaling value %q: %v", str, err)
+	} else {
+		h.buf.Write(m)
+	}
 }
 
 type encodingError struct {

--- a/ddtrace/tracer/writer.go
+++ b/ddtrace/tracer/writer.go
@@ -190,13 +190,13 @@ func (h *logTraceWriter) encodeSpan(s *span) {
 		}
 		m, err := json.Marshal(k)
 		if err != nil {
-			log.Error("error encoding meta key: %v", err)
+			log.Error("Error encoding meta key %q: %v", k, err)
 		}
 		h.buf.Write(m)
 		h.buf.WriteString(":")
 		m, err = json.Marshal(v)
 		if err != nil {
-			log.Error("error encoding meta value: %v", err)
+			log.Error("Error encoding meta value %q: %v", v, err)
 		}
 		h.buf.Write(m)
 	}
@@ -208,14 +208,13 @@ func (h *logTraceWriter) encodeSpan(s *span) {
 			continue
 		}
 		if first {
-			//h.buf.WriteByte('"')
 			first = false
 		} else {
 			h.buf.WriteString(`,`)
 		}
 		m, err := json.Marshal(k)
 		if err != nil {
-			log.Error("error encoding metrics key: %v", err)
+			log.Error("Error encoding metrics key %q: %v", k, err)
 		}
 		h.buf.Write(m)
 		h.buf.WriteString(`:`)

--- a/ddtrace/tracer/writer.go
+++ b/ddtrace/tracer/writer.go
@@ -188,10 +188,16 @@ func (h *logTraceWriter) encodeSpan(s *span) {
 		} else {
 			h.buf.WriteString(`,`)
 		}
-		m, _ := json.Marshal(k)
+		m, err := json.Marshal(k)
+		if err != nil {
+			log.Error("error encoding meta key: %v", err)
+		}
 		h.buf.Write(m)
 		h.buf.WriteString(":")
-		m, _ = json.Marshal(v)
+		m, err = json.Marshal(v)
+		if err != nil {
+			log.Error("error encoding meta value: %v", err)
+		}
 		h.buf.Write(m)
 	}
 	h.buf.WriteString(`},"metrics":{`)
@@ -202,13 +208,17 @@ func (h *logTraceWriter) encodeSpan(s *span) {
 			continue
 		}
 		if first {
-			h.buf.WriteByte('"')
+			//h.buf.WriteByte('"')
 			first = false
 		} else {
-			h.buf.WriteString(`,"`)
+			h.buf.WriteString(`,`)
 		}
-		h.buf.WriteString(k)
-		h.buf.WriteString(`":`)
+		m, err := json.Marshal(k)
+		if err != nil {
+			log.Error("error encoding metrics key: %v", err)
+		}
+		h.buf.Write(m)
+		h.buf.WriteString(`:`)
 		h.buf.Write(encodeFloat(scratch[:0], v))
 	}
 	h.buf.WriteString(`},"start":`)

--- a/ddtrace/tracer/writer_test.go
+++ b/ddtrace/tracer/writer_test.go
@@ -204,6 +204,22 @@ func TestLogWriter(t *testing.T) {
 		assert.NoError(err)
 		assert.Equal(jsonPayload{[][]jsonSpan{{expected}}}, payload)
 	})
+
+	t.Run("invalid-characters", func(t *testing.T) {
+		assert := assert.New(t)
+		s := newSpan("name", "srv", "res", 2, 1, 3)
+		s.Start = 12
+		s.Meta["query\n"] = "Select * from \n Where\nvalue"
+		s.Metrics["version\n"] = 3
+
+		var w logTraceWriter
+		w.encodeSpan(s)
+
+		str := w.buf.String()
+		assert.Equal(`{"trace_id":"1","span_id":"2","parent_id":"3","name":"name","resource":"res","error":0,"meta":{"query\n":"Select * from \n Where\nvalue"},"metrics":{"version\n":3},"start":12,"duration":0,"service":"srv"}`, str)
+		assert.NotContains(w.buf.String(), "\n")
+		assert.Contains(str, "\\n")
+	})
 }
 
 func TestLogWriterOverflow(t *testing.T) {
@@ -274,21 +290,6 @@ func TestLogWriterOverflow(t *testing.T) {
 		err = d.Decode(&v)
 		assert.Equal(io.EOF, err)
 	})
-}
-func TestJSONEncodeSpanNewLines(t *testing.T) {
-	assert := assert.New(t)
-	s := newSpan("name", "srv", "res", 2, 1, 3)
-	s.Start = 12
-	s.Meta["query\n"] = "Select * from \n Where\nvalue"
-	s.Metrics["version\n"] = 3
-
-	h := &logTraceWriter{}
-	h.encodeSpan(s)
-
-	str := h.buf.String()
-	assert.Equal(`{"trace_id":"1","span_id":"2","parent_id":"3","name":"name","resource":"res","error":0,"meta":{"query\n":"Select * from \n Where\nvalue"},"metrics":{"version\n":3},"start":12,"duration":0,"service":"srv"}`, str)
-	assert.NotContains(h.buf.String(), "\n")
-	assert.Contains(str, "\\n")
 }
 
 func BenchmarkJsonEncodeSpan(b *testing.B) {

--- a/ddtrace/tracer/writer_test.go
+++ b/ddtrace/tracer/writer_test.go
@@ -217,7 +217,7 @@ func TestLogWriter(t *testing.T) {
 
 		str := w.buf.String()
 		assert.Equal(`{"trace_id":"1","span_id":"2","parent_id":"3","name":"name\n","resource":"\"res\"","error":0,"meta":{"query\n":"Select * from \n Where\nvalue"},"metrics":{"version\n":3},"start":12,"duration":0,"service":"srv\t"}`, str)
-		assert.NotContains(w.buf.String(), "\n")
+		assert.NotContains(str, "\n")
 		assert.Contains(str, "\\n")
 	})
 }

--- a/ddtrace/tracer/writer_test.go
+++ b/ddtrace/tracer/writer_test.go
@@ -275,19 +275,18 @@ func TestLogWriterOverflow(t *testing.T) {
 		assert.Equal(io.EOF, err)
 	})
 }
-func TestJsonEncodeSpanNewLines(t *testing.T) {
+func TestJSONEncodeSpanNewLines(t *testing.T) {
 	assert := assert.New(t)
 	s := newSpan("name", "srv", "res", 2, 1, 3)
 	s.Start = 12
-	s.Meta["query"] = "Select * from \n Where value"
 	s.Meta["query\n"] = "Select * from \n Where\nvalue"
+	s.Metrics["version\n"] = 3
 
 	h := &logTraceWriter{}
-	h.resetBuffer()
 	h.encodeSpan(s)
 
 	str := h.buf.String()
-	assert.Equal(`{"traces": [{"trace_id":"1","span_id":"2","parent_id":"3","name":"name","resource":"res","error":0,"meta":{"query":"Select * from \n Where value","query\n":"Select * from \n Where\nvalue"},"metrics":{},"start":12,"duration":0,"service":"srv"}`, str)
+	assert.Equal(`{"trace_id":"1","span_id":"2","parent_id":"3","name":"name","resource":"res","error":0,"meta":{"query\n":"Select * from \n Where\nvalue"},"metrics":{"version\n":3},"start":12,"duration":0,"service":"srv"}`, str)
 	assert.NotContains(h.buf.String(), "\n")
 	assert.Contains(str, "\\n")
 }

--- a/ddtrace/tracer/writer_test.go
+++ b/ddtrace/tracer/writer_test.go
@@ -275,6 +275,22 @@ func TestLogWriterOverflow(t *testing.T) {
 		assert.Equal(io.EOF, err)
 	})
 }
+func TestJsonEncodeSpanNewLines(t *testing.T) {
+	assert := assert.New(t)
+	s := newSpan("name", "srv", "res", 2, 1, 3)
+	s.Start = 12
+	s.Meta["query"] = "Select * from \n Where value"
+	s.Meta["query\n"] = "Select * from \n Where\nvalue"
+
+	h := &logTraceWriter{}
+	h.resetBuffer()
+	h.encodeSpan(s)
+
+	str := h.buf.String()
+	assert.Equal(`{"traces": [{"trace_id":"1","span_id":"2","parent_id":"3","name":"name","resource":"res","error":0,"meta":{"query":"Select * from \n Where value","query\n":"Select * from \n Where\nvalue"},"metrics":{},"start":12,"duration":0,"service":"srv"}`, str)
+	assert.NotContains(h.buf.String(), "\n")
+	assert.Contains(str, "\\n")
+}
 
 func BenchmarkJsonEncodeSpan(b *testing.B) {
 	s := makeSpan(10)

--- a/ddtrace/tracer/writer_test.go
+++ b/ddtrace/tracer/writer_test.go
@@ -207,7 +207,7 @@ func TestLogWriter(t *testing.T) {
 
 	t.Run("invalid-characters", func(t *testing.T) {
 		assert := assert.New(t)
-		s := newSpan("name", "srv", "res", 2, 1, 3)
+		s := newSpan("name\n", "srv\t", `"res"`, 2, 1, 3)
 		s.Start = 12
 		s.Meta["query\n"] = "Select * from \n Where\nvalue"
 		s.Metrics["version\n"] = 3
@@ -216,7 +216,7 @@ func TestLogWriter(t *testing.T) {
 		w.encodeSpan(s)
 
 		str := w.buf.String()
-		assert.Equal(`{"trace_id":"1","span_id":"2","parent_id":"3","name":"name","resource":"res","error":0,"meta":{"query\n":"Select * from \n Where\nvalue"},"metrics":{"version\n":3},"start":12,"duration":0,"service":"srv"}`, str)
+		assert.Equal(`{"trace_id":"1","span_id":"2","parent_id":"3","name":"name\n","resource":"\"res\"","error":0,"meta":{"query\n":"Select * from \n Where\nvalue"},"metrics":{"version\n":3},"start":12,"duration":0,"service":"srv\t"}`, str)
 		assert.NotContains(w.buf.String(), "\n")
 		assert.Contains(str, "\\n")
 	})


### PR DESCRIPTION
Illegal characters, such as newlines, were not escaped in encodeSpan function, which ruined json structure. Closes #791

This, in turn, corrupted log collection 