### PR TITLE
profiler: increase DefaultBlockRate

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -30,9 +30,12 @@ const (
 	// For more information or for changing this value, check MutexProfileFraction
 	DefaultMutexFraction = 10
 
-	// DefaultBlockRate specifies the default block profiling rate used by the block profiler.
-	// For more information or for changing this value, check BlockProfileRate.
-	DefaultBlockRate = 100
+	// DefaultBlockRate specifies the default block profiling rate used by the
+	// block profiler. For more information or for changing this value, check
+	// BlockProfileRate. The default rate is chosen to prevent high overhead
+	// based on the research from:
+	// https://github.com/felixge/go-profiler-notes/blob/main/block.md#benchmarks
+	DefaultBlockRate = 10000
 
 	// DefaultPeriod specifies the default period at which profiles will be collected.
 	DefaultPeriod = time.Minute


### PR DESCRIPTION
@pmbauer PTAL.

@Kyle-Neale @gbbr you might have thoughts on backwards compatibility when it comes to changes like this. IMO it should be okay, but it's a bit of a grey zone.