### PR TITLE
ddtrace/tracer: updated DD_TAGS parsing to support space separation

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -140,6 +140,7 @@ func newConfig(opts ...StartOption) *config {
 	if v := os.Getenv("DD_TAGS"); v != "" {
 		sep := " "
 		if strings.Index(v, ",") > -1 {
+			// falling back to comma as separator
 			sep = ","
 		}
 		for _, tag := range strings.Split(v, sep) {

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -138,23 +138,23 @@ func newConfig(opts ...StartOption) *config {
 		c.version = ver
 	}
 	if v := os.Getenv("DD_TAGS"); v != "" {
-		sep, trim := " ", ","
+		sep := " "
 		if strings.Index(v, ",") > -1 {
-			sep, trim = trim, sep
+			sep = ","
 		}
 		for _, tag := range strings.Split(v, sep) {
-			tag = strings.Trim(tag, trim)
+			tag = strings.TrimSpace(tag)
 			if tag == "" {
 				continue
 			}
 			kv := strings.SplitN(tag, ":", 2)
-			key := strings.Trim(kv[0], trim)
+			key := strings.TrimSpace(kv[0])
 			if key == "" {
 				continue
 			}
 			var val string
 			if len(kv) == 2 {
-				val = strings.Trim(kv[1], trim)
+				val = strings.TrimSpace(kv[1])
 			}
 			WithGlobalTag(key, val)(c)
 		}

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -138,19 +138,25 @@ func newConfig(opts ...StartOption) *config {
 		c.version = ver
 	}
 	if v := os.Getenv("DD_TAGS"); v != "" {
-		for _, tag := range strings.Split(v, ",") {
-			tag = strings.TrimSpace(tag)
+		sep, trim := " ", ","
+		if strings.Index(v, ",") > -1 {
+			sep, trim = trim, sep
+		}
+		for _, tag := range strings.Split(v, sep) {
+			tag = strings.Trim(tag, trim)
 			if tag == "" {
 				continue
 			}
 			kv := strings.SplitN(tag, ":", 2)
-			k := strings.TrimSpace(kv[0])
-			switch len(kv) {
-			case 1:
-				WithGlobalTag(k, "")(c)
-			case 2:
-				WithGlobalTag(k, strings.TrimSpace(kv[1]))(c)
+			key := strings.Trim(kv[0], trim)
+			if key == "" {
+				continue
 			}
+			var val string
+			if len(kv) == 2 {
+				val = strings.Trim(kv[1], trim)
+			}
+			WithGlobalTag(key, val)(c)
 		}
 	}
 	if _, ok := os.LookupEnv("AWS_LAMBDA_FUNCTION_NAME"); ok {

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -263,19 +263,22 @@ func TestTagSeparators(t *testing.T) {
 					"env":  "test",
 					"aKey": "aVal",
 					"bKey": "bVal",
-					"cKey": ""}},
+					"cKey": ""},
+			},
 			{
 				in: "env:test,aKey:aVal,bKey:bVal,cKey:",
 				expected: map[string]string{
 					"env":  "test",
 					"aKey": "aVal",
 					"bKey": "bVal",
-					"cKey": ""}},
+					"cKey": ""},
+			},
 			{
 				in: "env:test,aKey:aVal bKey:bVal cKey:",
 				expected: map[string]string{
 					"env":  "test",
-					"aKey": "aVal bKey:bVal cKey:"}},
+					"aKey": "aVal bKey:bVal cKey:"},
+			},
 			{
 				in: "env:test     bKey :bVal dKey: dVal cKey:",
 				expected: map[string]string{
@@ -283,37 +286,44 @@ func TestTagSeparators(t *testing.T) {
 					"bKey": "",
 					"dKey": "",
 					"dVal": "",
-					"cKey": ""}},
+					"cKey": ""},
+			},
 			{
 				in: "env :test, aKey : aVal bKey:bVal cKey:",
 				expected: map[string]string{
 					"env":  "test",
-					"aKey": "aVal bKey:bVal cKey:"}},
+					"aKey": "aVal bKey:bVal cKey:"},
+			},
 			{
 				in: "env:keyWithA:Semicolon bKey:bVal cKey",
 				expected: map[string]string{
 					"env":  "keyWithA:Semicolon",
 					"bKey": "bVal",
-					"cKey": ""}},
+					"cKey": ""},
+			},
 			{
 				in: "env:keyWith:  , ,   Lots:Of:Semicolons ",
 				expected: map[string]string{
 					"env":  "keyWith:",
-					"Lots": "Of:Semicolons"}},
+					"Lots": "Of:Semicolons"},
+			},
 			{
 				in: "a:b,c,d",
 				expected: map[string]string{
 					"a": "b",
 					"c": "",
-					"d": ""}},
+					"d": ""},
+			},
 			{
 				in: "a,1",
 				expected: map[string]string{
 					"a": "",
-					"1": ""}},
+					"1": ""},
+			},
 			{
 				in:       "a:b:c:d",
-				expected: map[string]string{"a": "b:c:d"}},
+				expected: map[string]string{"a": "b:c:d"},
+			},
 		} {
 			os.Setenv("DD_TAGS", tag.in)
 			c := newConfig()

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -249,6 +249,84 @@ func TestServiceName(t *testing.T) {
 	})
 }
 
+func TestTagSeparators(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("env-tags", func(t *testing.T) {
+		for ind, tag := range []struct {
+			in       string
+			expected map[string]string
+		}{
+			{
+				in: "env:test aKey:aVal bKey:bVal cKey:",
+				expected: map[string]string{
+					"env":  "test",
+					"aKey": "aVal",
+					"bKey": "bVal",
+					"cKey": ""}},
+			{
+				in: "env:test,aKey:aVal,bKey:bVal,cKey:",
+				expected: map[string]string{
+					"env":  "test",
+					"aKey": "aVal",
+					"bKey": "bVal",
+					"cKey": ""}},
+			{
+				in: "env:test,aKey:aVal bKey:bVal cKey:",
+				expected: map[string]string{
+					"env":  "test",
+					"aKey": "aVal bKey:bVal cKey:"}},
+			{
+				in: "env:test     bKey :bVal dKey: dVal cKey:",
+				expected: map[string]string{
+					"env":  "test",
+					"bKey": "",
+					"dKey": "",
+					"dVal": "",
+					"cKey": ""}},
+			{
+				in: "env :test, aKey : aVal bKey:bVal cKey:",
+				expected: map[string]string{
+					"env":  "test",
+					"aKey": "aVal bKey:bVal cKey:"}},
+			{
+				in: "env:keyWithA:Semicolon bKey:bVal cKey",
+				expected: map[string]string{
+					"env":  "keyWithA:Semicolon",
+					"bKey": "bVal",
+					"cKey": ""}},
+			{
+				in: "env:keyWith:  , ,   Lots:Of:Semicolons ",
+				expected: map[string]string{
+					"env":  "keyWith:",
+					"Lots": "Of:Semicolons"}},
+			{
+				in: "a:b,c,d",
+				expected: map[string]string{
+					"a": "b",
+					"c": "",
+					"d": ""}},
+			{
+				in: "a,1",
+				expected: map[string]string{
+					"a": "",
+					"1": ""}},
+			{
+				in:       "a:b:c:d",
+				expected: map[string]string{"a": "b:c:d"}},
+		} {
+			os.Setenv("DD_TAGS", tag.in)
+			c := newConfig()
+			for key, expected := range tag.expected {
+				actual, ok := c.globalTags[key]
+				assert.Truef(ok, "ind %v, exp %v", ind, expected)
+				assert.Equal(expected, actual)
+			}
+		}
+		defer os.Unsetenv("DD_TAGS")
+	})
+}
+
 func TestVersionConfig(t *testing.T) {
 	t.Run("WithServiceVersion", func(t *testing.T) {
 		assert := assert.New(t)

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -256,14 +256,14 @@ func TestTagSeparators(t *testing.T) {
 		in  string
 		out map[string]string
 	}{{
-			in: "env:test aKey:aVal bKey:bVal cKey:",
-			out: map[string]string{
-				"env":  "test",
-				"aKey": "aVal",
-				"bKey": "bVal",
-				"cKey": "",
-			},
+		in: "env:test aKey:aVal bKey:bVal cKey:",
+		out: map[string]string{
+			"env":  "test",
+			"aKey": "aVal",
+			"bKey": "bVal",
+			"cKey": "",
 		},
+	},
 		{
 			in: "env:test,aKey:aVal,bKey:bVal,cKey:",
 			out: map[string]string{
@@ -334,11 +334,12 @@ func TestTagSeparators(t *testing.T) {
 	} {
 		t.Run("", func(t *testing.T) {
 			os.Setenv("DD_TAGS", tag.in)
+			defer os.Unsetenv("DD_TAGS")
 			c := newConfig()
 			for key, expected := range tag.out {
-				actual, ok := c.globalTags[key]
+				got, ok := c.globalTags[key]
 				assert.True(ok, "tag not found")
-				assert.Equal(expected, actual)
+				assert.Equal(expected, got)
 			}
 		})
 	}

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -252,89 +252,96 @@ func TestServiceName(t *testing.T) {
 func TestTagSeparators(t *testing.T) {
 	assert := assert.New(t)
 
-	t.Run("env-tags", func(t *testing.T) {
-		for ind, tag := range []struct {
-			in       string
-			expected map[string]string
-		}{
-			{
-				in: "env:test aKey:aVal bKey:bVal cKey:",
-				expected: map[string]string{
-					"env":  "test",
-					"aKey": "aVal",
-					"bKey": "bVal",
-					"cKey": ""},
+	for _, tag := range []struct {
+		in  string
+		out map[string]string
+	}{{
+			in: "env:test aKey:aVal bKey:bVal cKey:",
+			out: map[string]string{
+				"env":  "test",
+				"aKey": "aVal",
+				"bKey": "bVal",
+				"cKey": "",
 			},
-			{
-				in: "env:test,aKey:aVal,bKey:bVal,cKey:",
-				expected: map[string]string{
-					"env":  "test",
-					"aKey": "aVal",
-					"bKey": "bVal",
-					"cKey": ""},
+		},
+		{
+			in: "env:test,aKey:aVal,bKey:bVal,cKey:",
+			out: map[string]string{
+				"env":  "test",
+				"aKey": "aVal",
+				"bKey": "bVal",
+				"cKey": "",
 			},
-			{
-				in: "env:test,aKey:aVal bKey:bVal cKey:",
-				expected: map[string]string{
-					"env":  "test",
-					"aKey": "aVal bKey:bVal cKey:"},
+		},
+		{
+			in: "env:test,aKey:aVal bKey:bVal cKey:",
+			out: map[string]string{
+				"env":  "test",
+				"aKey": "aVal bKey:bVal cKey:",
 			},
-			{
-				in: "env:test     bKey :bVal dKey: dVal cKey:",
-				expected: map[string]string{
-					"env":  "test",
-					"bKey": "",
-					"dKey": "",
-					"dVal": "",
-					"cKey": ""},
+		},
+		{
+			in: "env:test     bKey :bVal dKey: dVal cKey:",
+			out: map[string]string{
+				"env":  "test",
+				"bKey": "",
+				"dKey": "",
+				"dVal": "",
+				"cKey": "",
 			},
-			{
-				in: "env :test, aKey : aVal bKey:bVal cKey:",
-				expected: map[string]string{
-					"env":  "test",
-					"aKey": "aVal bKey:bVal cKey:"},
+		},
+		{
+			in: "env :test, aKey : aVal bKey:bVal cKey:",
+			out: map[string]string{
+				"env":  "test",
+				"aKey": "aVal bKey:bVal cKey:",
 			},
-			{
-				in: "env:keyWithA:Semicolon bKey:bVal cKey",
-				expected: map[string]string{
-					"env":  "keyWithA:Semicolon",
-					"bKey": "bVal",
-					"cKey": ""},
+		},
+		{
+			in: "env:keyWithA:Semicolon bKey:bVal cKey",
+			out: map[string]string{
+				"env":  "keyWithA:Semicolon",
+				"bKey": "bVal",
+				"cKey": "",
 			},
-			{
-				in: "env:keyWith:  , ,   Lots:Of:Semicolons ",
-				expected: map[string]string{
-					"env":  "keyWith:",
-					"Lots": "Of:Semicolons"},
+		},
+		{
+			in: "env:keyWith:  , ,   Lots:Of:Semicolons ",
+			out: map[string]string{
+				"env":  "keyWith:",
+				"Lots": "Of:Semicolons",
 			},
-			{
-				in: "a:b,c,d",
-				expected: map[string]string{
-					"a": "b",
-					"c": "",
-					"d": ""},
+		},
+		{
+			in: "a:b,c,d",
+			out: map[string]string{
+				"a": "b",
+				"c": "",
+				"d": "",
 			},
-			{
-				in: "a,1",
-				expected: map[string]string{
-					"a": "",
-					"1": ""},
+		},
+		{
+			in: "a,1",
+			out: map[string]string{
+				"a": "",
+				"1": "",
 			},
-			{
-				in:       "a:b:c:d",
-				expected: map[string]string{"a": "b:c:d"},
-			},
-		} {
+		},
+		{
+			in:  "a:b:c:d",
+			out: map[string]string{"a": "b:c:d"},
+		},
+	} {
+		t.Run("", func(t *testing.T) {
 			os.Setenv("DD_TAGS", tag.in)
 			c := newConfig()
-			for key, expected := range tag.expected {
+			for key, expected := range tag.out {
 				actual, ok := c.globalTags[key]
-				assert.Truef(ok, "ind %v, exp %v", ind, expected)
+				assert.True(ok, "tag not found")
 				assert.Equal(expected, actual)
 			}
-		}
-		defer os.Unsetenv("DD_TAGS")
-	})
+		})
+	}
 }
 
 func TestVersionConfig(t *testing.T) {

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -156,12 +156,13 @@ func defaultConfig() *config {
 		WithVersion(v)(&c)
 	}
 	if v := os.Getenv("DD_TAGS"); v != "" {
-		sep, trim := " ", ","
+		sep := " "
 		if strings.Index(v, ",") > -1 {
-			sep, trim = trim, sep
+			// falling back to comma as separator
+			sep = ","
 		}
 		for _, tag := range strings.Split(v, sep) {
-			tag = strings.Trim(tag, trim)
+			tag = strings.TrimSpace(tag)
 			if tag == "" {
 				continue
 			}

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -156,8 +156,12 @@ func defaultConfig() *config {
 		WithVersion(v)(&c)
 	}
 	if v := os.Getenv("DD_TAGS"); v != "" {
-		for _, tag := range strings.Split(v, ",") {
-			tag = strings.TrimSpace(tag)
+		sep, trim := " ", ","
+		if strings.Index(v, ",") > -1 {
+			sep, trim = trim, sep
+		}
+		for _, tag := range strings.Split(v, sep) {
+			tag = strings.Trim(tag, trim)
 			if tag == "" {
 				continue
 			}


### PR DESCRIPTION
DD_TAGS were split by commas only. Unless there is a comma in a string, tag list will be split by spaces. In either case, commas/spaces will be trimmed.