### PR TITLE
ddtracer/tracer: set hostname meta tag on each span

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -429,6 +429,12 @@ func WithServiceVersion(version string) StartOption {
 	}
 }
 
+// WithHostname sets the hostname for the program.
+func WithHostname(name string) StartOption {
+	return func(c *config) {
+		c.hostname = name
+	}
+}
 // StartSpanOption is a configuration option for StartSpan. It is aliased in order
 // to help godoc group all the functions returning it together. It is considered
 // more correct to refer to it as the type as the origin, ddtrace.StartSpanOption.

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -429,7 +429,7 @@ func WithServiceVersion(version string) StartOption {
 	}
 }
 
-// WithHostname sets the hostname for the program.
+// WithHostname allows specifying the hostname with which to mark outgoing traces.
 func WithHostname(name string) StartOption {
 	return func(c *config) {
 		c.hostname = name

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -435,6 +435,7 @@ func WithHostname(name string) StartOption {
 		c.hostname = name
 	}
 }
+
 // StartSpanOption is a configuration option for StartSpan. It is aliased in order
 // to help godoc group all the functions returning it together. It is considered
 // more correct to refer to it as the type as the origin, ddtrace.StartSpanOption.

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -127,6 +127,9 @@ func newConfig(opts ...StartOption) *config {
 			log.Warn("unable to look up hostname: %v", err)
 		}
 	}
+	if v := os.Getenv("DD_TRACE_SOURCE_HOSTNAME"); v != "" {
+		c.hostname = v
+	}
 	if v := os.Getenv("DD_ENV"); v != "" {
 		c.env = v
 	}

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -377,3 +377,28 @@ func TestGlobalTag(t *testing.T) {
 	WithGlobalTag("k", "v")(&c)
 	assert.Contains(t, statsTags(&c), "k:v")
 }
+
+func TestWithHostname(t *testing.T) {
+	t.Run("WithHostname", func(t *testing.T) {
+		assert := assert.New(t)
+		c := newConfig(WithHostname("hostname"))
+		assert.Equal("hostname", c.hostname)
+	})
+
+	t.Run("env", func(t *testing.T) {
+		assert := assert.New(t)
+		os.Setenv("DD_TRACE_SOURCE_HOSTNAME", "hostname-env")
+		defer os.Unsetenv("DD_TRACE_SOURCE_HOSTNAME")
+		c := newConfig()
+		assert.Equal("hostname-env", c.hostname)
+	})
+
+	t.Run("env-override", func(t *testing.T) {
+		assert := assert.New(t)
+
+		os.Setenv("DD_TRACE_SOURCE_HOSTNAME", "hostname-env")
+		defer os.Unsetenv("DD_TRACE_SOURCE_HOSTNAME")
+		c := newConfig(WithHostname("hostname-middleware"))
+		assert.Equal("hostname-middleware", c.hostname)
+	})
+}

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -265,6 +265,9 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		Start:        startTime,
 		taskEnd:      startExecutionTracerTask(operationName),
 		noDebugStack: t.config.noDebugStack,
+		Meta: map[string]string{
+			"_dd.hostname": t.config.hostname,
+		},
 	}
 	if context != nil {
 		// this is a child span

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -265,9 +265,9 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		Start:        startTime,
 		taskEnd:      startExecutionTracerTask(operationName),
 		noDebugStack: t.config.noDebugStack,
-		Meta: map[string]string{
-			"_dd.hostname": t.config.hostname,
-		},
+	}
+	if t.hostname != "" {
+		span.setMeta(keyHostname, t.hostname)
 	}
 	if context != nil {
 		// this is a child span
@@ -293,9 +293,6 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 	if context == nil || context.span == nil {
 		// this is either a root span or it has a remote parent, we should add the PID.
 		span.setMeta(ext.Pid, t.pid)
-		if t.hostname != "" {
-			span.setMeta(keyHostname, t.hostname)
-		}
 		if _, ok := opts.Tags[ext.ServiceName]; !ok && t.config.runtimeMetrics {
 			// this is a root span in the global service; runtime metrics should
 			// be linked to it:

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1082,7 +1082,7 @@ func TestTracerReportsHostname(t *testing.T) {
 		assert.Equal(got, hostname)
 	})
 
-	t.Run("DD_TRACE_SOURCE_HOSTNAME", func(t *testing.T) {
+	t.Run("DD_TRACE_SOURCE_HOSTNAME/set", func(t *testing.T) {
 		os.Setenv("DD_TRACE_SOURCE_HOSTNAME", "hostname-test")
 		defer os.Unsetenv("DD_TRACE_SOURCE_HOSTNAME")
 
@@ -1104,7 +1104,8 @@ func TestTracerReportsHostname(t *testing.T) {
 		assert.True(ok)
 		assert.Equal(got, hostname)
 	})
-	t.Run("DD_TRACE_REPORT_HOSTNAME/nil", func(t *testing.T) {
+
+	t.Run("DD_TRACE_SOURCE_HOSTNAME/unset", func(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
 
@@ -1120,7 +1121,6 @@ func TestTracerReportsHostname(t *testing.T) {
 		_, ok = child.Meta[keyHostname]
 		assert.False(ok)
 	})
-
 }
 
 func TestVersion(t *testing.T) {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1022,7 +1022,7 @@ func TestTracerFlush(t *testing.T) {
 func TestTracerReportsHostname(t *testing.T) {
 	const hostname = "hostname-test"
 
-	t.Run("DD_TRACE_REPORT_HOSTNAME/true", func(t *testing.T) {
+	t.Run("DD_TRACE_REPORT_HOSTNAME/set", func(t *testing.T) {
 		os.Setenv("DD_TRACE_REPORT_HOSTNAME", "true")
 		defer os.Unsetenv("DD_TRACE_REPORT_HOSTNAME")
 
@@ -1045,7 +1045,7 @@ func TestTracerReportsHostname(t *testing.T) {
 		assert.Equal(name, tracer.hostname)
 	})
 
-	t.Run("DD_TRACE_REPORT_HOSTNAME/false", func(t *testing.T) {
+	t.Run("DD_TRACE_REPORT_HOSTNAME/unset", func(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
 

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1020,7 +1020,9 @@ func TestTracerFlush(t *testing.T) {
 }
 
 func TestTracerReportsHostname(t *testing.T) {
-	t.Run("enabled", func(t *testing.T) {
+	const hostname = "hostname-test"
+
+	t.Run("DD_TRACE_REPORT_HOSTNAME/true", func(t *testing.T) {
 		os.Setenv("DD_TRACE_REPORT_HOSTNAME", "true")
 		defer os.Unsetenv("DD_TRACE_REPORT_HOSTNAME")
 
@@ -1038,11 +1040,12 @@ func TestTracerReportsHostname(t *testing.T) {
 		assert.True(ok)
 		assert.Equal(name, tracer.hostname)
 
-		_, ok = child.Meta[keyHostname]
+		name, ok = child.Meta[keyHostname]
 		assert.True(ok)
+		assert.Equal(name, tracer.hostname)
 	})
 
-	t.Run("disabled", func(t *testing.T) {
+	t.Run("DD_TRACE_REPORT_HOSTNAME/false", func(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
 
@@ -1058,6 +1061,66 @@ func TestTracerReportsHostname(t *testing.T) {
 		_, ok = child.Meta[keyHostname]
 		assert.False(ok)
 	})
+
+	t.Run("WithHostname", func(t *testing.T) {
+		tracer, _, _, stop := startTestTracer(t, WithHostname(hostname))
+		defer stop()
+
+		root := tracer.StartSpan("root").(*span)
+		child := tracer.StartSpan("child", ChildOf(root.Context())).(*span)
+		child.Finish()
+		root.Finish()
+
+		assert := assert.New(t)
+
+		got, ok := root.Meta[keyHostname]
+		assert.True(ok)
+		assert.Equal(got, hostname)
+
+		got, ok = child.Meta[keyHostname]
+		assert.True(ok)
+		assert.Equal(got, hostname)
+	})
+
+	t.Run("DD_TRACE_SOURCE_HOSTNAME", func(t *testing.T) {
+		os.Setenv("DD_TRACE_SOURCE_HOSTNAME", "hostname-test")
+		defer os.Unsetenv("DD_TRACE_SOURCE_HOSTNAME")
+
+		tracer, _, _, stop := startTestTracer(t)
+		defer stop()
+
+		root := tracer.StartSpan("root").(*span)
+		child := tracer.StartSpan("child", ChildOf(root.Context())).(*span)
+		child.Finish()
+		root.Finish()
+
+		assert := assert.New(t)
+
+		got, ok := root.Meta[keyHostname]
+		assert.True(ok)
+		assert.Equal(got, hostname)
+
+		got, ok = child.Meta[keyHostname]
+		assert.True(ok)
+		assert.Equal(got, hostname)
+	})
+	t.Run("DD_TRACE_REPORT_HOSTNAME/nil", func(t *testing.T) {
+		tracer, _, _, stop := startTestTracer(t)
+		defer stop()
+
+		root := tracer.StartSpan("root").(*span)
+		child := tracer.StartSpan("child", ChildOf(root.Context())).(*span)
+		child.Finish()
+		root.Finish()
+
+		assert := assert.New(t)
+
+		_, ok := root.Meta[keyHostname]
+		assert.False(ok)
+		_, ok = child.Meta[keyHostname]
+		assert.False(ok)
+	})
+
 }
 
 func TestVersion(t *testing.T) {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1039,7 +1039,7 @@ func TestTracerReportsHostname(t *testing.T) {
 		assert.Equal(name, tracer.hostname)
 
 		_, ok = child.Meta[keyHostname]
-		assert.False(ok)
+		assert.True(ok)
 	})
 
 	t.Run("disabled", func(t *testing.T) {


### PR DESCRIPTION
Added DD_TRACE_SOURCE_HOSTNAME variable read to allow setting the hostname manually by the user. Hostname is added to each span as a meta tag of `_dd.hostname`