### PR TITLE
ddtrace/trace: add support for app tags

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -387,6 +387,7 @@ const (
 	keyRulesSamplerAppliedRate = "_dd.rule_psr"
 	keyRulesSamplerLimiterRate = "_dd.limit_psr"
 	keyMeasured                = "_dd.measured"
+	keyMetadataSpan            = "_dd.chunk_metadata"
 	// keyTopLevel is the key of top level metric indicating if a span is top level.
 	// A top level span is a local root (parent span of the local trace) or the first span of each service.
 	keyTopLevel = "_dd.top_level"

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1356,6 +1356,44 @@ func TestTakeStackTrace(t *testing.T) {
 	})
 }
 
+func TestAppTagsSetting(t *testing.T) {
+	t.Run("WithAppTags/default", func(t *testing.T) {
+		assert := assert.New(t)
+		tracer := newTracer()
+		tracer.appTags["tag"] = "value"
+		tracer.appTags["v"] = 1
+		internal.SetGlobalTracer(tracer)
+
+		parent := StartSpan("app-tag").(*span)
+		child := StartSpan("app-tag", ChildOf(parent.context)).(*span)
+
+		assert.Equal("value", parent.Meta["tag"])
+		assert.Equal(float64(1), parent.Metrics["v"])
+
+		assert.NotContains(child.Meta, "tag")
+		assert.NotContains(child.Metrics, "v")
+	})
+
+	t.Run("WithAppTags/override", func(t *testing.T) {
+		assert := assert.New(t)
+		tracer := newTracer()
+		tracer.appTags["tag"] = "value"
+		tracer.appTags["v"] = 1
+		internal.SetGlobalTracer(tracer)
+
+		parent := StartSpan("app-tag").(*span)
+		parent.setMeta("tag", "no-override")
+		parent.setMetric("v", 2)
+		child := StartSpan("app-tag", ChildOf(parent.context)).(*span)
+
+		assert.Equal("no-override", parent.Meta["tag"])
+		assert.Equal(float64(2), parent.Metrics["v"])
+
+		assert.NotContains(child.Meta, "tag")
+		assert.NotContains(child.Metrics, "v")
+	})
+}
+
 // BenchmarkTracerStackFrames tests the performance of taking stack trace.
 func BenchmarkTracerStackFrames(b *testing.B) {
 	tracer, _, _, stop := startTestTracer(b, WithSampler(NewRateSampler(0)))


### PR DESCRIPTION
To avoid setting same global tags on all spans, it was resolved to set them on only one span in a group of spans sent to the agent. This span will also have a '_dd.chunk_metadata' tag set to mark him as the one holding global tags