### PR TITLE
contrib/confluentinc/confluent-kafka-go - use GitHub package

### DIFF
--- a/contrib/confluentinc/confluent-kafka-go/kafka/headers.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/headers.go
@@ -8,7 +8,7 @@ package kafka
 import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
-	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
+	"github.com/confluentinc/confluent-kafka-go/kafka"
 )
 
 // A MessageCarrier injects and extracts traces from a sarama.ProducerMessage.

--- a/contrib/confluentinc/confluent-kafka-go/kafka/kafka.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/kafka.go
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 
-	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
+	"github.com/confluentinc/confluent-kafka-go/kafka"
 )
 
 // NewConsumer calls kafka.NewConsumer and wraps the resulting Consumer.

--- a/contrib/confluentinc/confluent-kafka-go/kafka/kafka_test.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/kafka_test.go
@@ -12,7 +12,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 
-	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
+	"github.com/confluentinc/confluent-kafka-go/kafka"
 
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
fixes #844