### PR TITLE
profiler: fix goroutineswait profile frame order

### DIFF
--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -327,7 +327,7 @@ func goroutineDebug2ToPprof(r io.Reader, w io.Writer, t time.Time) (err error) {
 			p.Location = append(p.Location, location)
 			locationID++
 
-			sample.Location = append([]*pprofile.Location{location}, sample.Location...)
+			sample.Location = append(sample.Location, location)
 		}
 
 		p.Sample = append(p.Sample, sample)


### PR DESCRIPTION
The frames were showing up in reverse in the UI. Not sure why I wrote
the code to prepend instead of append the frames, but it's wrong and
this patch fixes it.

Fixes PROF-2908

**Screenshot of wrong stack frame order in goroutine wait profile:**

![Screenshot of wrong stack frame order in goroutine wait profile:](https://user-images.githubusercontent.com/15000/108393003-85d1db00-7213-11eb-8871-1169c9e3a8bf.png)

**Screenshot of correct stack frame order in goroutine profile:**

![Screenshot of correct stack frame order in goroutine profile](https://user-images.githubusercontent.com/15000/108393015-88343500-7213-11eb-85c4-3cb6352520be.png)

