### PR TITLE
profiler: Implement WithUploadTimeout

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -316,7 +316,8 @@ func WithStatsd(client StatsdClient) Option {
 
 // WithUploadTimeout specifies the timeout to use for uploading profiles. The
 // default timeout is specified by DefaultUploadTimeout or the
-// DD_PROFILING_UPLOAD_TIMEOUT env variable.
+// DD_PROFILING_UPLOAD_TIMEOUT env variable. Using a negative value or 0 will
+// cause an error when starting the profiler.
 func WithUploadTimeout(d time.Duration) Option {
 	return func(cfg *config) {
 		cfg.uploadTimeout = d

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -42,14 +42,18 @@ const (
 
 	// DefaultDuration specifies the default length of the CPU profile snapshot.
 	DefaultDuration = time.Second * 15
+
+	// DefaultUploadTimeout specifies the default timeout for uploading profiles.
+	// It can be overwritten using the DD_PROFILING_UPLOAD_TIMEOUT env variable
+	// or the WithUploadTimeout option.
+	DefaultUploadTimeout = 10 * time.Second
 )
 
 const (
-	defaultAPIURL      = "https://intake.profile.datadoghq.com/v1/input"
-	defaultAgentHost   = "localhost"
-	defaultAgentPort   = "8126"
-	defaultEnv         = "none"
-	defaultHTTPTimeout = 10 * time.Second // defines the current timeout before giving up with the send process
+	defaultAPIURL    = "https://intake.profile.datadoghq.com/v1/input"
+	defaultAgentHost = "localhost"
+	defaultAgentPort = "8126"
+	defaultEnv       = "none"
 )
 
 var defaultClient = &http.Client{
@@ -68,7 +72,6 @@ var defaultClient = &http.Client{
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	},
-	Timeout: defaultHTTPTimeout,
 }
 
 var defaultProfileTypes = []ProfileType{MetricsProfile, CPUProfile, HeapProfile}
@@ -88,6 +91,7 @@ type config struct {
 	types         map[ProfileType]struct{}
 	period        time.Duration
 	cpuDuration   time.Duration
+	uploadTimeout time.Duration
 	mutexFraction int
 	blockRate     int
 }
@@ -118,7 +122,7 @@ func (c *config) addProfileType(t ProfileType) {
 	c.types[t] = struct{}{}
 }
 
-func defaultConfig() *config {
+func defaultConfig() (*config, error) {
 	c := config{
 		env:           defaultEnv,
 		apiURL:        defaultAPIURL,
@@ -129,6 +133,7 @@ func defaultConfig() *config {
 		cpuDuration:   DefaultDuration,
 		blockRate:     DefaultBlockRate,
 		mutexFraction: DefaultMutexFraction,
+		uploadTimeout: DefaultUploadTimeout,
 		tags:          []string{fmt.Sprintf("pid:%d", os.Getpid())},
 	}
 	for _, t := range defaultProfileTypes {
@@ -143,6 +148,13 @@ func defaultConfig() *config {
 		agentPort = v
 	}
 	WithAgentAddr(net.JoinHostPort(agentHost, agentPort))(&c)
+	if v := os.Getenv("DD_PROFILING_UPLOAD_TIMEOUT"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return nil, fmt.Errorf("DD_PROFILING_UPLOAD_TIMEOUT: %s", err)
+		}
+		WithUploadTimeout(d)(&c)
+	}
 	if v := os.Getenv("DD_API_KEY"); v != "" {
 		WithAPIKey(v)(&c)
 	}
@@ -184,7 +196,7 @@ func defaultConfig() *config {
 	if v := os.Getenv("DD_PROFILING_URL"); v != "" {
 		WithURL(v)(&c)
 	}
-	return &c
+	return &c, nil
 }
 
 // An Option is used to configure the profiler's behaviour.
@@ -302,6 +314,15 @@ func WithStatsd(client StatsdClient) Option {
 	}
 }
 
+// WithUploadTimeout specifies the timeout to use for uploading profiles. The
+// default timeout is specified by DefaultUploadTimeout or the
+// DD_PROFILING_UPLOAD_TIMEOUT env variable.
+func WithUploadTimeout(d time.Duration) Option {
+	return func(cfg *config) {
+		cfg.uploadTimeout = d
+	}
+}
+
 // WithSite specifies the datadog site (datadoghq.com, datadoghq.eu, etc.)
 // which profiles will be sent to.
 func WithSite(site string) Option {
@@ -332,6 +353,5 @@ func WithUDS(socketPath string) Option {
 				return net.Dial("unix", socketPath)
 			},
 		},
-		Timeout: defaultHTTPTimeout,
 	})
 }

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
@@ -60,6 +61,12 @@ func TestOptions(t *testing.T) {
 		WithAgentAddr("test:123")(&cfg)
 		expectedURL := "http://test:123/profiling/v1/input"
 		assert.Equal(t, expectedURL, cfg.agentURL)
+	})
+
+	t.Run("WithUploadTimeout", func(t *testing.T) {
+		var cfg config
+		WithUploadTimeout(5 * time.Second)(&cfg)
+		assert.Equal(t, 5*time.Second, cfg.uploadTimeout)
 	})
 
 	t.Run("WithAPIKey", func(t *testing.T) {
@@ -127,7 +134,8 @@ func TestOptions(t *testing.T) {
 	t.Run("WithService/override", func(t *testing.T) {
 		os.Setenv("DD_SERVICE", "envService")
 		defer os.Unsetenv("DD_SERVICE")
-		cfg := defaultConfig()
+		cfg, err := defaultConfig()
+		require.NoError(t, err)
 		WithService("serviceName")(cfg)
 		assert.Equal(t, "serviceName", cfg.service)
 	})
@@ -141,7 +149,8 @@ func TestOptions(t *testing.T) {
 	t.Run("WithSite/override", func(t *testing.T) {
 		os.Setenv("DD_SITE", "wrong.site")
 		defer os.Unsetenv("DD_SITE")
-		cfg := defaultConfig()
+		cfg, err := defaultConfig()
+		require.NoError(t, err)
 		WithSite("datadog.eu")(cfg)
 		assert.Equal(t, "https://intake.profile.datadog.eu/v1/input", cfg.apiURL)
 	})
@@ -155,7 +164,8 @@ func TestOptions(t *testing.T) {
 	t.Run("WithEnv/override", func(t *testing.T) {
 		os.Setenv("DD_ENV", "envEnv")
 		defer os.Unsetenv("DD_ENV")
-		cfg := defaultConfig()
+		cfg, err := defaultConfig()
+		require.NoError(t, err)
 		WithEnv("envName")(cfg)
 		assert.Equal(t, "envName", cfg.env)
 	})
@@ -169,7 +179,8 @@ func TestOptions(t *testing.T) {
 	t.Run("WithVersion/override", func(t *testing.T) {
 		os.Setenv("DD_VERSION", "envVersion")
 		defer os.Unsetenv("DD_VERSION")
-		cfg := defaultConfig()
+		cfg, err := defaultConfig()
+		require.NoError(t, err)
 		WithVersion("1.2.3")(cfg)
 		assert.Contains(t, cfg.tags, "version:1.2.3")
 	})
@@ -185,7 +196,8 @@ func TestOptions(t *testing.T) {
 	t.Run("WithTags/override", func(t *testing.T) {
 		os.Setenv("DD_TAGS", "env1:tag1,env2:tag2")
 		defer os.Unsetenv("DD_TAGS")
-		cfg := defaultConfig()
+		cfg, err := defaultConfig()
+		require.NoError(t, err)
 		WithTags("a:1", "b:2", "c:3")(cfg)
 		assert.Contains(t, cfg.tags, "a:1")
 		assert.Contains(t, cfg.tags, "b:2")
@@ -199,15 +211,25 @@ func TestEnvVars(t *testing.T) {
 	t.Run("DD_AGENT_HOST", func(t *testing.T) {
 		os.Setenv("DD_AGENT_HOST", "agent_host_1")
 		defer os.Unsetenv("DD_AGENT_HOST")
-		cfg := defaultConfig()
+		cfg, err := defaultConfig()
+		require.NoError(t, err)
 		assert.Equal(t, "http://agent_host_1:8126/profiling/v1/input", cfg.agentURL)
 	})
 
 	t.Run("DD_TRACE_AGENT_PORT", func(t *testing.T) {
 		os.Setenv("DD_TRACE_AGENT_PORT", "6218")
 		defer os.Unsetenv("DD_TRACE_AGENT_PORT")
-		cfg := defaultConfig()
+		cfg, err := defaultConfig()
+		require.NoError(t, err)
 		assert.Equal(t, "http://localhost:6218/profiling/v1/input", cfg.agentURL)
+	})
+
+	t.Run("DD_PROFILING_UPLOAD_TIMEOUT", func(t *testing.T) {
+		os.Setenv("DD_PROFILING_UPLOAD_TIMEOUT", "3s")
+		defer os.Unsetenv("DD_PROFILING_UPLOAD_TIMEOUT")
+		cfg, err := defaultConfig()
+		require.NoError(t, err)
+		assert.Equal(t, 3*time.Second, cfg.uploadTimeout)
 	})
 
 	t.Run("DD_AGENT_HOST+DD_TRACE_AGENT_PORT", func(t *testing.T) {
@@ -215,49 +237,56 @@ func TestEnvVars(t *testing.T) {
 		defer os.Unsetenv("DD_AGENT_HOST")
 		os.Setenv("DD_TRACE_AGENT_PORT", "6218")
 		defer os.Unsetenv("DD_TRACE_AGENT_PORT")
-		cfg := defaultConfig()
+		cfg, err := defaultConfig()
+		require.NoError(t, err)
 		assert.Equal(t, "http://agent_host_1:6218/profiling/v1/input", cfg.agentURL)
 	})
 
 	t.Run("DD_API_KEY", func(t *testing.T) {
 		os.Setenv("DD_API_KEY", testAPIKey)
 		defer os.Unsetenv("DD_API_KEY")
-		cfg := defaultConfig()
+		cfg, err := defaultConfig()
+		require.NoError(t, err)
 		assert.Equal(t, testAPIKey, cfg.apiKey)
 	})
 
 	t.Run("DD_SITE", func(t *testing.T) {
 		os.Setenv("DD_SITE", "datadog.eu")
 		defer os.Unsetenv("DD_SITE")
-		cfg := defaultConfig()
+		cfg, err := defaultConfig()
+		require.NoError(t, err)
 		assert.Equal(t, "https://intake.profile.datadog.eu/v1/input", cfg.apiURL)
 	})
 
 	t.Run("DD_ENV", func(t *testing.T) {
 		os.Setenv("DD_ENV", "someEnv")
 		defer os.Unsetenv("DD_ENV")
-		cfg := defaultConfig()
+		cfg, err := defaultConfig()
+		require.NoError(t, err)
 		assert.Equal(t, "someEnv", cfg.env)
 	})
 
 	t.Run("DD_SERVICE", func(t *testing.T) {
 		os.Setenv("DD_SERVICE", "someService")
 		defer os.Unsetenv("DD_SERVICE")
-		cfg := defaultConfig()
+		cfg, err := defaultConfig()
+		require.NoError(t, err)
 		assert.Equal(t, "someService", cfg.service)
 	})
 
 	t.Run("DD_VERSION", func(t *testing.T) {
 		os.Setenv("DD_VERSION", "1.2.3")
 		defer os.Unsetenv("DD_VERSION")
-		cfg := defaultConfig()
+		cfg, err := defaultConfig()
+		require.NoError(t, err)
 		assert.Contains(t, cfg.tags, "version:1.2.3")
 	})
 
 	t.Run("DD_TAGS", func(t *testing.T) {
 		os.Setenv("DD_TAGS", "a:1,b:2,c:3")
 		defer os.Unsetenv("DD_TAGS")
-		cfg := defaultConfig()
+		cfg, err := defaultConfig()
+		require.NoError(t, err)
 		assert.Contains(t, cfg.tags, "a:1")
 		assert.Contains(t, cfg.tags, "b:2")
 		assert.Contains(t, cfg.tags, "c:3")
@@ -267,7 +296,8 @@ func TestEnvVars(t *testing.T) {
 func TestDefaultConfig(t *testing.T) {
 	t.Run("base", func(t *testing.T) {
 		defaultAgentURL := "http://" + net.JoinHostPort(defaultAgentHost, defaultAgentPort) + "/profiling/v1/input"
-		cfg := defaultConfig()
+		cfg, err := defaultConfig()
+		require.NoError(t, err)
 		assert := assert.New(t)
 		assert.Equal(defaultAPIURL, cfg.apiURL)
 		assert.Equal(defaultAgentURL, cfg.agentURL)
@@ -291,7 +321,8 @@ func TestDefaultConfig(t *testing.T) {
 func TestAddProfileType(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		assert := assert.New(t)
-		cfg := defaultConfig()
+		cfg, err := defaultConfig()
+		require.NoError(t, err)
 		_, ok := cfg.types[MutexProfile]
 		assert.False(ok)
 		n := len(cfg.types)

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -67,7 +67,10 @@ type profiler struct {
 
 // newProfiler creates a new, unstarted profiler.
 func newProfiler(opts ...Option) (*profiler, error) {
-	cfg := defaultConfig()
+	cfg, err := defaultConfig()
+	if err != nil {
+		return nil, err
+	}
 	for _, opt := range opts {
 		opt(cfg)
 	}

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -96,6 +96,17 @@ func newProfiler(opts ...Option) (*profiler, error) {
 		}
 		cfg.hostname = hostname
 	}
+	// uploadTimeout defaults to DefaultUploadTimeout, but in theory a user might
+	// set it to 0 or a negative value. However, it's not clear what this should
+	// mean, and most meanings we could assign seem to be bad: Not having a
+	// timeout is dangerous, having a timeout that fires immediately breaks
+	// uploading, and silently defaulting to the default timeout is confusing.
+	// So let's just stay clear of all of this by not allowing such values.
+	//
+	// see similar discussion: https://github.com/golang/go/issues/39177
+	if cfg.uploadTimeout <= 0 {
+		return nil, fmt.Errorf("invalid upload timeout, must be > 0: %s", cfg.uploadTimeout)
+	}
 	p := profiler{
 		cfg:  cfg,
 		out:  make(chan batch, outChannelSize),

--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -7,6 +7,7 @@ package profiler
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -69,7 +70,13 @@ func (p *profiler) doRequest(bat batch) error {
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest("POST", p.cfg.targetURL, body)
+	ctx := context.Background()
+	if p.cfg.uploadTimeout != 0 {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(context.Background(), p.cfg.uploadTimeout)
+		defer cancel()
+	}
+	req, err := http.NewRequestWithContext(ctx, "POST", p.cfg.targetURL, body)
 	if err != nil {
 		return err
 	}

--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -70,12 +70,9 @@ func (p *profiler) doRequest(bat batch) error {
 	if err != nil {
 		return err
 	}
-	ctx := context.Background()
-	if p.cfg.uploadTimeout != 0 {
-		var cancel func()
-		ctx, cancel = context.WithTimeout(context.Background(), p.cfg.uploadTimeout)
-		defer cancel()
-	}
+	// uploadTimeout is guaranteed to be >= 0, see newProfiler.
+	ctx, cancel := context.WithTimeout(context.Background(), p.cfg.uploadTimeout)
+	defer cancel()
 	// TODO(fg) use NewRequestWithContext once go 1.12 support is dropped.
 	req, err := http.NewRequest("POST", p.cfg.targetURL, body)
 	if err != nil {

--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -76,10 +76,12 @@ func (p *profiler) doRequest(bat batch) error {
 		ctx, cancel = context.WithTimeout(context.Background(), p.cfg.uploadTimeout)
 		defer cancel()
 	}
-	req, err := http.NewRequestWithContext(ctx, "POST", p.cfg.targetURL, body)
+	// TODO(fg) use NewRequestWithContext once go 1.12 support is dropped.
+	req, err := http.NewRequest("POST", p.cfg.targetURL, body)
 	if err != nil {
 		return err
 	}
+	req = req.WithContext(ctx)
 	if p.cfg.apiKey != "" {
 		req.Header.Set("DD-API-KEY", p.cfg.apiKey)
 	}


### PR DESCRIPTION
Also add support for the DD_PROFILING_UPLOAD_TIMEOUT used by other
DD profilers such as Java.

The timeout is implemented using a request context, which allows
removing the timeout option from the defaultClient and WithUDS option.

defaultHTTPTimeout is promoted to DefaultUploadTimeout to be consistent
with the other default options.

The order of preference is:
1. DefaultUploadTimeout
2. DD_PROFILING_UPLOAD_TIMEOUT
3. WithUploadTimeout()

Implements PROF-2810