### PR TITLE
Add LogAttributes so you can use these w/ log.WithFields and JSONFormatter

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -335,23 +335,23 @@ func (s *span) LogAttributes() map[string]interface{} {
 	}
 
 	if svc := globalconfig.ServiceName(); svc != "" {
-		results["dd.service"] = svc
+		results["service"] = svc
 	}
 
 	if tr, ok := internal.GetGlobalTracer().(*tracer); ok {
 		if tr.config.env != "" {
-			results["dd.env"] = tr.config.env
+			results["env"] = tr.config.env
 		}
 
 		if tr.config.version != "" {
-			results["dd.version"] = tr.config.version
+			results["version"] = tr.config.version
 		}
 	} else {
 		if env := os.Getenv("DD_ENV"); env != "" {
-			results["dd.env"] = env
+			results["env"] = env
 		}
 		if v := os.Getenv("DD_VERSION"); v != "" {
-			results["dd.version"] = v
+			results["version"] = v
 		}
 	}
 


### PR DESCRIPTION
I submitted a ticket asking if there was a supported way to do this already but am waiting for a response.

Right now this example of how to use a JSONFormatter and logrus
https://docs.datadoghq.com/logs/log_collection/go/#configure-your-logger

And this documentation on how to add span/trace connection
https://docs.datadoghq.com/tracing/connect_logs_and_traces/go/

Seem incompatible. If I do what is suggested w/ the JSONFormatter I get a log message where the msg json hash is
```
msg="Span dd.service=webhooks dd.env=local-tpavlu dd.trace_id=\"6753113782047895803\" dd.span_id=\"6753113782047895803\"
```

This results in this in datadog's UI
<img width="853" alt="Screen Shot 2021-02-19 at 9 09 33 AM" src="https://user-images.githubusercontent.com/29345336/108537203-31ba0b80-7292-11eb-891b-8c6ef848d0a9.png">

I did a hack to parse the Format string of the span and injected that data w/ the log.WithFields function and things worked as expected.
https://gist.github.com/tpavlu/9f06bd7c27f26d798888b12413b384a6
<img width="803" alt="Screen Shot 2021-02-19 at 9 10 44 AM" src="https://user-images.githubusercontent.com/29345336/108537338-5ada9c00-7292-11eb-8d87-4d0ebce00020.png">

The addition of this LogAttributes function would allow users of the library to do this without the munging of strings
```
log.WithFields(log.Fields(span.LogAttributes)).Info("Span data")
```

If there is a better way to do this already please LMK.
