### PR TITLE
ddtrace/opentracer: implement Context Extension

### DIFF
--- a/ddtrace/opentracer/tracer.go
+++ b/ddtrace/opentracer/tracer.go
@@ -92,6 +92,6 @@ func (t *opentracer) ContextWithSpanHook(ctx context.Context, openSpan opentraci
 	if !ok {
 		return ctx // unchanged
 	}
-	
+
 	return tracer.ContextWithSpan(ctx, ddSpan.Span)
 }

--- a/ddtrace/opentracer/tracer.go
+++ b/ddtrace/opentracer/tracer.go
@@ -21,6 +21,7 @@ package opentracer
 
 import (
 	"context"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"

--- a/ddtrace/opentracer/tracer.go
+++ b/ddtrace/opentracer/tracer.go
@@ -37,7 +37,6 @@ func New(opts ...tracer.StartOption) opentracing.Tracer {
 }
 
 var _ opentracing.Tracer = (*opentracer)(nil)
-var _ opentracing.TracerContextWithSpanExtension = (*opentracer)(nil)
 
 // opentracer implements opentracing.Tracer on top of ddtrace.Tracer.
 type opentracer struct{ ddtrace.Tracer }
@@ -87,6 +86,8 @@ func (t *opentracer) Extract(format interface{}, carrier interface{}) (opentraci
 		return nil, opentracing.ErrUnsupportedFormat
 	}
 }
+
+var _ opentracing.TracerContextWithSpanExtension = (*opentracer)(nil)
 
 // ContextWithSpan implements opentracing.TracerContextWithSpanExtension.
 func (t *opentracer) ContextWithSpanHook(ctx context.Context, openSpan opentracing.Span) context.Context {

--- a/ddtrace/opentracer/tracer.go
+++ b/ddtrace/opentracer/tracer.go
@@ -87,6 +87,7 @@ func (t *opentracer) Extract(format interface{}, carrier interface{}) (opentraci
 	}
 }
 
+// ContextWithSpan implements opentracing.TracerContextWithSpanExtension.
 func (t *opentracer) ContextWithSpanHook(ctx context.Context, openSpan opentracing.Span) context.Context {
 	ddSpan, ok := openSpan.(*span)
 	if !ok {

--- a/ddtrace/opentracer/tracer.go
+++ b/ddtrace/opentracer/tracer.go
@@ -20,6 +20,7 @@
 package opentracer
 
 import (
+	"context"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -35,6 +36,7 @@ func New(opts ...tracer.StartOption) opentracing.Tracer {
 }
 
 var _ opentracing.Tracer = (*opentracer)(nil)
+var _ opentracing.TracerContextWithSpanExtension = (*opentracer)(nil)
 
 // opentracer implements opentracing.Tracer on top of ddtrace.Tracer.
 type opentracer struct{ ddtrace.Tracer }
@@ -83,4 +85,13 @@ func (t *opentracer) Extract(format interface{}, carrier interface{}) (opentraci
 	default:
 		return nil, opentracing.ErrUnsupportedFormat
 	}
+}
+
+func (t *opentracer) ContextWithSpanHook(ctx context.Context, openSpan opentracing.Span) context.Context {
+	ddSpan, ok := openSpan.(*span)
+	if !ok {
+		return ctx // unchanged
+	}
+	
+	return tracer.ContextWithSpan(ctx, ddSpan.Span)
 }

--- a/ddtrace/opentracer/tracer.go
+++ b/ddtrace/opentracer/tracer.go
@@ -93,6 +93,5 @@ func (t *opentracer) ContextWithSpanHook(ctx context.Context, openSpan opentraci
 	if !ok {
 		return ctx
 	}
-
 	return tracer.ContextWithSpan(ctx, ddSpan.Span)
 }

--- a/ddtrace/opentracer/tracer.go
+++ b/ddtrace/opentracer/tracer.go
@@ -91,7 +91,7 @@ func (t *opentracer) Extract(format interface{}, carrier interface{}) (opentraci
 func (t *opentracer) ContextWithSpanHook(ctx context.Context, openSpan opentracing.Span) context.Context {
 	ddSpan, ok := openSpan.(*span)
 	if !ok {
-		return ctx // unchanged
+		return ctx
 	}
 
 	return tracer.ContextWithSpan(ctx, ddSpan.Span)

--- a/ddtrace/opentracer/tracer_test.go
+++ b/ddtrace/opentracer/tracer_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/opentracing/opentracing-go"
-	
+
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -35,7 +35,9 @@ func TestSpanWithContext(t *testing.T) {
 	assert.True(ok)
 	ott, ok := ot.(*opentracer)
 	assert.True(ok)
-	openTracingSpan := ott.StartSpan("test.operation")
+
+	opentracing.SetGlobalTracer(ott)
+	openTracingSpan := opentracing.StartSpan("test.operation")
 	otWithExt, ok := ot.(opentracing.TracerContextWithSpanExtension)
 	assert.True(ok)
 	ctx := otWithExt.ContextWithSpanHook(context.Background(), openTracingSpan)

--- a/ddtrace/opentracer/tracer_test.go
+++ b/ddtrace/opentracer/tracer_test.go
@@ -7,12 +7,13 @@ package opentracer
 
 import (
 	"context"
-	"github.com/opentracing/opentracing-go"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"testing"
 
+	"github.com/opentracing/opentracing-go"
+	
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/ddtrace/opentracer/tracer_test.go
+++ b/ddtrace/opentracer/tracer_test.go
@@ -36,11 +36,9 @@ func TestSpanWithContext(t *testing.T) {
 	ott, ok := ot.(*opentracer)
 	assert.True(ok)
 
+	// start span
 	opentracing.SetGlobalTracer(ott)
-	openTracingSpan := opentracing.StartSpan("test.operation")
-	otWithExt, ok := ot.(opentracing.TracerContextWithSpanExtension)
-	assert.True(ok)
-	ctx := otWithExt.ContextWithSpanHook(context.Background(), openTracingSpan)
+	openTracingSpan, ctx := opentracing.StartSpanFromContext(context.Background(), "test.operation")
 
 	// check that the span was added to the tracer context
 	spanInContext, ok := tracer.SpanFromContext(ctx)


### PR DESCRIPTION
Solves #813.

This implements the OpenTracing context extension. If a span was started by a Datadog OpenTracer, then the underlying object should be a pointer to a `opentracer.span`. If that is the case, we're able to use the context with the underlying Datadog Span (of the opentracer.span).

I've tested this locally to connect opentracing spans with Datadog spans assuming I set the `opentracing.SetGlobalTracer(datadogOpenTracer)`.