### PR TITLE
ddtrace/tracer: add support for agent discovery endpoint, feature flags, stats & drops

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,19 +199,19 @@ jobs:
       - run:
           name: Testing outlier gRPC v1.2
           command: |
+                # This hacky approach is necessary because running the tests regularly
+                # do not allow using grpc-go@v1.2.0 alongside sketches-go@v1.0.0
                 go mod vendor
 
+                # Checkout grpc-go@v1.2.0
                 cd vendor/google.golang.org && rm -rf grpc
                 git clone git@github.com:grpc/grpc-go grpc && cd grpc
-                git fetch origin && git checkout v1.2.0
+                git fetch origin && git checkout v1.2.0 && cd ../..
 
-                cd ../..
-
+                # Checkout sketches-go@v1.0.0
                 cd vendor/github.com/DataDog && rm -rf sketches-go
                 git clone git@github.com:DataDog/sketches-go && cd sketches-go
-                git fetch origin && git checkout v1.0.0
-
-                cd ../..
+                git fetch origin && git checkout v1.0.0 && cd ../..
 
                 go test -mod=vendor -v ./contrib/google.golang.org/grpc.v12/...
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,13 +186,34 @@ jobs:
           command: dockerize -wait http://localhost:8500 -timeout 1m
 
       - run:
-          name: Testing
+          name: Testing integrations
           command: |
                 INTEGRATION=1 go test -v -race -coverprofile=coverage.txt -covermode=atomic `go list ./contrib/... | grep -v -e grpc.v12 -e google.golang.org/api`
+
+      - run:
+          name: Testing outlier google.golang.org/api
+          command: |
                 go get google.golang.org/grpc@v1.29.0 # https://github.com/grpc/grpc-go/issues/3726
                 go test -v ./contrib/google.golang.org/api/...
-                go get google.golang.org/grpc@v1.2.0
-                go test -v ./contrib/google.golang.org/grpc.v12/...
+
+      - run:
+          name: Testing outlier gRPC v1.2
+          command: |
+                go mod vendor
+
+                cd vendor/google.golang.org && rm -rf grpc
+                git clone git@github.com:grpc/grpc-go grpc && cd grpc
+                git fetch origin && git checkout v1.2.0
+
+                cd ../..
+
+                cd vendor/github.com/DataDog && rm -rf sketches-go
+                git clone git@github.com:DataDog/sketches-go && cd sketches-go
+                git fetch origin && git checkout v1.0.0
+
+                cd ../..
+
+                go test -mod=vendor -v ./contrib/google.golang.org/grpc.v12/...
 
       - run:
           name: Upload coverage report to Codecov

--- a/ddtrace/internal/globaltracer.go
+++ b/ddtrace/internal/globaltracer.go
@@ -19,12 +19,15 @@ var (
 // SetGlobalTracer sets the global tracer to t.
 func SetGlobalTracer(t ddtrace.Tracer) {
 	mu.Lock()
-	defer mu.Unlock()
+	old := globalTracer
+	globalTracer = t
+	// Unlock before potentially calling Stop, to allow any shutdown mechanism
+	// to retrieve the active tracer without causing a deadlock on mutex mu.
+	mu.Unlock()
 	if !Testing {
 		// avoid infinite loop when calling (*mocktracer.Tracer).Stop
-		globalTracer.Stop()
+		old.Stop()
 	}
-	globalTracer = t
 }
 
 // GetGlobalTracer returns the currently active tracer.

--- a/ddtrace/tracer/log.go
+++ b/ddtrace/tracer/log.go
@@ -47,6 +47,7 @@ type startupInfo struct {
 	Architecture          string            `json:"architecture"`            // Architecture of host machine
 	GlobalService         string            `json:"global_service"`          // Global service string. If not-nil should be same as Service. (#614)
 	LambdaMode            string            `json:"lambda_mode"`             // Whether or not the client has enabled lambda mode
+	AgentFeatures         agentFeatures     `json:"agent_features"`          // Lists the capabilities of the agent.
 }
 
 // checkEndpoint tries to connect to the URL specified by endpoint.
@@ -70,7 +71,7 @@ func checkEndpoint(endpoint string) error {
 // JSON format.
 func logStartup(t *tracer) {
 	tags := make(map[string]string)
-	for k, v := range t.globalTags {
+	for k, v := range t.config.globalTags {
 		tags[k] = fmt.Sprintf("%v", v)
 	}
 
@@ -83,7 +84,7 @@ func logStartup(t *tracer) {
 		LangVersion:           runtime.Version(),
 		Env:                   t.config.env,
 		Service:               t.config.serviceName,
-		AgentURL:              t.transport.endpoint(),
+		AgentURL:              t.config.transport.endpoint(),
 		Debug:                 t.config.debug,
 		AnalyticsEnabled:      !math.IsNaN(globalconfig.AnalyticsRate()),
 		SampleRate:            fmt.Sprintf("%f", t.rulesSampling.globalRate),
@@ -95,14 +96,15 @@ func logStartup(t *tracer) {
 		Architecture:          runtime.GOARCH,
 		GlobalService:         globalconfig.ServiceName(),
 		LambdaMode:            fmt.Sprintf("%t", t.config.logToStdout),
+		AgentFeatures:         t.features.Load(),
 	}
 	if _, err := samplingRulesFromEnv(); err != nil {
 		info.SamplingRulesError = fmt.Sprintf("%s", err)
 	}
 	if !t.config.logToStdout {
-		if err := checkEndpoint(t.transport.endpoint()); err != nil {
+		if err := checkEndpoint(t.config.transport.endpoint()); err != nil {
 			info.AgentError = fmt.Sprintf("%s", err)
-			log.Warn("DIAGNOSTICS Unable to reach agent: %s", err)
+			log.Warn("DIAGNOSTICS Unable to reach agent intake: %s", err)
 		}
 	}
 	bs, err := json.Marshal(info)

--- a/ddtrace/tracer/log_test.go
+++ b/ddtrace/tracer/log_test.go
@@ -25,7 +25,7 @@ func TestStartupLog(t *testing.T) {
 		tp.Reset()
 		logStartup(tracer)
 		assert.Len(tp.Lines(), 2)
-		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sampling_rules":null,"sampling_rules_error":"","tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"false"}`, tp.Lines()[1])
+		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sampling_rules":null,"sampling_rules_error":"","tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"false","agent_features":{"DropP0s":false,"V05":false,"Stats":false}}`, tp.Lines()[1])
 	})
 
 	t.Run("configured", func(t *testing.T) {
@@ -53,7 +53,7 @@ func TestStartupLog(t *testing.T) {
 		tp.Reset()
 		logStartup(tracer)
 		assert.Len(tp.Lines(), 2)
-		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"configuredEnv","service":"configured.service","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":true,"analytics_enabled":true,"sample_rate":"0\.123000","sampling_rules":\[{"service":"mysql","name":"","sample_rate":0\.75}\],"sampling_rules_error":"","tags":{"runtime-id":"[^"]*","tag":"value","tag2":"NaN"},"runtime_metrics_enabled":true,"health_metrics_enabled":true,"dd_version":"2.3.4","architecture":"[^"]*","global_service":"configured.service","lambda_mode":"false"}`, tp.Lines()[1])
+		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"configuredEnv","service":"configured.service","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":true,"analytics_enabled":true,"sample_rate":"0\.123000","sampling_rules":\[{"service":"mysql","name":"","sample_rate":0\.75}\],"sampling_rules_error":"","tags":{"runtime-id":"[^"]*","tag":"value","tag2":"NaN"},"runtime_metrics_enabled":true,"health_metrics_enabled":true,"dd_version":"2.3.4","architecture":"[^"]*","global_service":"configured.service","lambda_mode":"false","agent_features":{"DropP0s":false,"V05":false,"Stats":false}}`, tp.Lines()[1])
 	})
 
 	t.Run("errors", func(t *testing.T) {
@@ -67,7 +67,7 @@ func TestStartupLog(t *testing.T) {
 		tp.Reset()
 		logStartup(tracer)
 		assert.Len(tp.Lines(), 2)
-		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sampling_rules":\[{"service":"some.service","name":"","sample_rate":0\.234}\],"sampling_rules_error":"found errors:\\n\\tat index 1: rate not provided","tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"false"}`, tp.Lines()[1])
+		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sampling_rules":\[{"service":"some.service","name":"","sample_rate":0\.234}\],"sampling_rules_error":"found errors:\\n\\tat index 1: rate not provided","tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"false","agent_features":{"DropP0s":false,"V05":false,"Stats":false}}`, tp.Lines()[1])
 	})
 
 	t.Run("lambda", func(t *testing.T) {
@@ -79,7 +79,7 @@ func TestStartupLog(t *testing.T) {
 		tp.Reset()
 		logStartup(tracer)
 		assert.Len(tp.Lines(), 1)
-		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test","agent_url":"http://localhost:9/v0.4/traces","agent_error":"","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sampling_rules":null,"sampling_rules_error":"","tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"true"}`, tp.Lines()[0])
+		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test","agent_url":"http://localhost:9/v0.4/traces","agent_error":"","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sampling_rules":null,"sampling_rules_error":"","tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"true","agent_features":{"DropP0s":false,"V05":false,"Stats":false}}`, tp.Lines()[0])
 	})
 }
 
@@ -104,7 +104,7 @@ func TestLogAgentReachable(t *testing.T) {
 	tp.Reset()
 	logStartup(tracer)
 	assert.Len(tp.Lines(), 2)
-	assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ WARN: DIAGNOSTICS Unable to reach agent: Post`, tp.Lines()[0])
+	assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ WARN: DIAGNOSTICS Unable to reach agent intake: Post`, tp.Lines()[0])
 }
 
 func TestLogFormat(t *testing.T) {

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -377,11 +377,8 @@ func newAggregableSpan(s *span, cfg *config) *aggregableSpan {
 		Resource:   s.Resource,
 		Service:    s.Service,
 		Type:       s.Type,
-		Hostname:   cfg.hostname,
 		Synthetics: strings.HasPrefix(s.Meta[keyOrigin], "synthetics"),
-		Env:        cfg.env,
 		StatusCode: statusCode,
-		Version:    cfg.version,
 	}
 	return &aggregableSpan{
 		key:      key,

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -15,12 +15,14 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 
 	"github.com/tinylib/msgp/msgp"
 	"golang.org/x/xerrors"
@@ -130,21 +132,32 @@ func (s *span) SetTag(key string, value interface{}) {
 // setTagError sets the error tag. It accounts for various valid scenarios.
 // This method is not safe for concurrent use.
 func (s *span) setTagError(value interface{}, cfg errorConfig) {
+	setError := func(yes bool) {
+		if yes {
+			if s.Error == 0 {
+				// new error
+				atomic.AddInt64(&s.context.errors, 1)
+			}
+			s.Error = 1
+		} else {
+			if s.Error > 0 {
+				// flip from active to inactive
+				atomic.AddInt64(&s.context.errors, -1)
+			}
+			s.Error = 0
+		}
+	}
 	if s.finished {
 		return
 	}
 	switch v := value.(type) {
 	case bool:
 		// bool value as per Opentracing spec.
-		if !v {
-			s.Error = 0
-		} else {
-			s.Error = 1
-		}
+		setError(v)
 	case error:
 		// if anyone sets an error value as the tag, be nice here
 		// and provide all the benefits.
-		s.Error = 1
+		setError(true)
 		s.setMeta(ext.ErrorMsg, v.Error())
 		s.setMeta(ext.ErrorType, reflect.TypeOf(v).String())
 		if !cfg.noDebugStack {
@@ -159,11 +172,11 @@ func (s *span) setTagError(value interface{}, cfg errorConfig) {
 		}
 	case nil:
 		// no error
-		s.Error = 0
+		setError(false)
 	default:
 		// in all other cases, let's assume that setting this tag
 		// is the result of an error.
-		s.Error = 1
+		setError(true)
 	}
 }
 
@@ -319,11 +332,92 @@ func (s *span) finish(finishTime int64) {
 	}
 	s.finished = true
 
+	if t, ok := internal.GetGlobalTracer().(*tracer); ok {
+		// we have an active tracer
+		feats := t.features.Load()
+		if feats.Stats && shouldComputeStats(s) {
+			// the agent supports computed stats
+			select {
+			case t.stats.In <- newAggregableSpan(s, t.config):
+				// ok
+			default:
+				log.Error("Stats channel full, disregarding span.")
+			}
+		}
+		if feats.DropP0s {
+			// the agent supports dropping p0's in the client
+			if shouldDrop(s) {
+				// ...and this span can be dropped
+				atomic.AddUint64(&t.droppedP0Spans, 1)
+				if s == s.context.trace.root {
+					atomic.AddUint64(&t.droppedP0Traces, 1)
+				}
+				return
+			}
+		}
+	}
 	if s.context.drop {
 		// not sampled by local sampler
 		return
 	}
 	s.context.finish()
+}
+
+// newAggregableSpan creates a new summary for the span s, within an application
+// version version.
+func newAggregableSpan(s *span, cfg *config) *aggregableSpan {
+	var statusCode uint32
+	if sc, ok := s.Meta["http.status_code"]; ok && sc != "" {
+		if c, err := strconv.Atoi(sc); err == nil {
+			statusCode = uint32(c)
+		}
+	}
+	key := aggregation{
+		Name:       s.Name,
+		Resource:   s.Resource,
+		Service:    s.Service,
+		Type:       s.Type,
+		Hostname:   cfg.hostname,
+		Synthetics: strings.HasPrefix(s.Meta[keyOrigin], "synthetics"),
+		Env:        cfg.env,
+		StatusCode: statusCode,
+		Version:    cfg.version,
+	}
+	return &aggregableSpan{
+		key:      key,
+		Start:    s.Start,
+		Duration: s.Duration,
+		TopLevel: s.Metrics[keyTopLevel] == 1,
+		Error:    s.Error,
+	}
+}
+
+// shouldDrop reports whether it's fine to drop the span s.
+func shouldDrop(s *span) bool {
+	if p, ok := s.context.samplingPriority(); ok && p > 0 {
+		// positive sampling priorities stay
+		return false
+	}
+	if atomic.LoadInt64(&s.context.errors) > 0 {
+		// traces with any span containing an error get kept
+		return false
+	}
+	if v, ok := s.Metrics[ext.EventSampleRate]; ok {
+		return !sampledByRate(s.TraceID, v)
+	}
+	return true
+}
+
+// shouldComputeStats mentions whether this span needs to have stats computed for.
+// Warning: callers must guard!
+func shouldComputeStats(s *span) bool {
+	if v, ok := s.Metrics[keyMeasured]; ok && v == 1 {
+		return true
+	}
+	if v, ok := s.Metrics[keyTopLevel]; ok && v == 1 {
+		return true
+	}
+	return false
 }
 
 // String returns a human readable representation of the span. Not for

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -97,6 +98,58 @@ func TestSpanFinishTwice(t *testing.T) {
 	span.Finish()
 	assert.Equal(previousDuration, span.Duration)
 	tracer.awaitPayload(t, 1)
+}
+
+func TestShouldDrop(t *testing.T) {
+	for _, tt := range []struct {
+		prio   int
+		errors int64
+		rate   float64
+		want   bool
+	}{
+		{1, 0, 0, false},
+		{2, 1, 0, false},
+		{0, 1, 0, false},
+		{0, 0, 1, false},
+		{0, 0, 0.5, false},
+		{0, 0, 0.00001, true},
+		{0, 0, 0, true},
+	} {
+		t.Run("", func(t *testing.T) {
+			s := newSpan("", "", "", 1, 1, 0)
+			s.SetTag(ext.SamplingPriority, tt.prio)
+			s.SetTag(ext.EventSampleRate, tt.rate)
+			atomic.StoreInt64(&s.context.errors, tt.errors)
+			assert.Equal(t, shouldDrop(s), tt.want)
+		})
+	}
+
+	t.Run("none", func(t *testing.T) {
+		s := newSpan("", "", "", 1, 1, 0)
+		assert.Equal(t, shouldDrop(s), true)
+	})
+}
+
+func TestShouldComputeStats(t *testing.T) {
+	for _, tt := range []struct {
+		metrics map[string]float64
+		want    bool
+	}{
+		{map[string]float64{keyMeasured: 2}, false},
+		{map[string]float64{keyMeasured: 1}, true},
+		{map[string]float64{keyMeasured: 0}, false},
+		{map[string]float64{keyTopLevel: 0}, false},
+		{map[string]float64{keyTopLevel: 1}, true},
+		{map[string]float64{keyTopLevel: 2}, false},
+		{map[string]float64{keyTopLevel: 2, keyMeasured: 1}, true},
+		{map[string]float64{keyTopLevel: 1, keyMeasured: 2}, true},
+		{map[string]float64{keyTopLevel: 2, keyMeasured: 2}, false},
+		{map[string]float64{}, false},
+	} {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, shouldComputeStats(&span{Metrics: tt.metrics}), tt.want)
+		})
+	}
 }
 
 func TestSpanFinishWithTime(t *testing.T) {

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -23,9 +23,10 @@ var _ ddtrace.SpanContext = (*spanContext)(nil)
 type spanContext struct {
 	// the below group should propagate only locally
 
-	trace *trace // reference to the trace that this span belongs too
-	span  *span  // reference to the span that hosts this context
-	drop  bool   // when true, the span will not be sent to the agent
+	trace  *trace // reference to the trace that this span belongs too
+	span   *span  // reference to the span that hosts this context
+	drop   bool   // when true, the span will not be sent to the agent
+	errors int64  // number of spans with errors in this trace
 
 	// the below group should propagate cross-process
 
@@ -53,6 +54,7 @@ func newSpanContext(span *span, parent *spanContext) *spanContext {
 		context.trace = parent.trace
 		context.drop = parent.drop
 		context.origin = parent.origin
+		context.errors = parent.errors
 		parent.ForeachBaggageItem(func(k, v string) bool {
 			context.setBaggageItem(k, v)
 			return true

--- a/ddtrace/tracer/stats.go
+++ b/ddtrace/tracer/stats.go
@@ -1,0 +1,332 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+//go:generate msgp -unexported -marshal=false -o=stats_msgp.go -tests=false
+
+package tracer
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/sketches-go/ddsketch"
+)
+
+// aggregableSpan holds necessary information about a span that can be used to
+// aggregate statistics in a bucket.
+type aggregableSpan struct {
+	// key specifies the aggregation key under which this span can be placed into
+	// grouped inside a bucket.
+	key aggregation
+
+	Start, Duration int64
+	Error           int32
+	TopLevel        bool
+}
+
+// defaultStatsBucketSize specifies the default span of time that will be
+// covered in one stats bucket.
+var defaultStatsBucketSize = (10 * time.Second).Nanoseconds()
+
+// concentrator aggregates and stores statistics on incoming spans in time buckets,
+// flushing them occasionally to the underlying transport located in the given
+// tracer config.
+type concentrator struct {
+	// In specifies the channel to be used for feeding data to the concentrator.
+	// In order for In to have a consumer, the concentrator must be started using
+	// a call to Start.
+	In chan *aggregableSpan
+
+	// mu guards below fields
+	mu sync.Mutex
+
+	// buckets maintains a set of buckets, where the map key represents
+	// the starting point in time of that bucket, in nanoseconds.
+	buckets map[int64]*rawBucket
+
+	// stopped reports whether the concentrator is stopped (when non-zero)
+	stopped uint64
+
+	wg         sync.WaitGroup // waits for any active goroutines
+	bucketSize int64          // the size of a bucket in nanoseconds
+	stop       chan struct{}  // closing this channel triggers shutdown
+	cfg        *config        // tracer startup configuration
+}
+
+// newConcentrator creates a new concentrator using the given tracer
+// configuration c. It creates buckets of bucketSize nanoseconds duration.
+func newConcentrator(c *config, bucketSize int64) *concentrator {
+	return &concentrator{
+		In:         make(chan *aggregableSpan, 10000),
+		bucketSize: bucketSize,
+		stopped:    1,
+		buckets:    make(map[int64]*rawBucket),
+		cfg:        c,
+	}
+}
+
+// alignTs returns the provided timestamp truncated to the bucket size.
+// It gives us the start time of the time bucket in which such timestamp falls.
+func alignTs(ts, bucketSize int64) int64 { return ts - ts%bucketSize }
+
+// Start starts the concentrator. A started concentrator needs to be stopped
+// in order to gracefully shut down, using Stop.
+func (c *concentrator) Start() {
+	if atomic.SwapUint64(&c.stopped, 0) == 0 {
+		// already running
+		log.Warn("(*concentrator).Start called more than once. This is likely a programming error.")
+		return
+	}
+	c.stop = make(chan struct{})
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		tick := time.NewTicker(time.Duration(c.bucketSize) * time.Nanosecond)
+		defer tick.Stop()
+		c.runFlusher(tick.C)
+	}()
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		c.runIngester()
+	}()
+}
+
+// runFlusher runs the flushing loop which sends stats to the underlying transport.
+func (c *concentrator) runFlusher(tick <-chan time.Time) {
+	for {
+		select {
+		case now := <-tick:
+			p := c.flush(now)
+			if len(p.Stats) == 0 {
+				// nothing to flush
+				continue
+			}
+			c.statsd().Incr("datadog.tracer.stats.flush_payloads", nil, 1)
+			c.statsd().Incr("datadog.tracer.stats.flush_buckets", nil, float64(len(p.Stats)))
+			if err := c.cfg.transport.sendStats(&p); err != nil {
+				c.statsd().Incr("datadog.tracer.stats.flush_errors", nil, 1)
+				log.Error("Error sending stats payload: %v", err)
+			}
+		case <-c.stop:
+			return
+		}
+	}
+}
+
+// statsd returns any tracer configured statsd client, or a no-op.
+func (c *concentrator) statsd() statsdClient {
+	if c.cfg.statsd == nil {
+		return &statsd.NoOpClient{}
+	}
+	return c.cfg.statsd
+}
+
+// runIngester runs the loop which accepts incoming data on the concentrator's In
+// channel.
+func (c *concentrator) runIngester() {
+	for {
+		select {
+		case s := <-c.In:
+			c.statsd().Incr("datadog.tracer.stats.spans_in", nil, 1)
+			c.add(s)
+		case <-c.stop:
+			return
+		}
+	}
+}
+
+// add adds s into the concentrator's internal stats buckets.
+func (c *concentrator) add(s *aggregableSpan) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	btime := alignTs(s.Start+s.Duration, c.bucketSize)
+	b, ok := c.buckets[btime]
+	if !ok {
+		b = newRawBucket(uint64(btime), c.bucketSize)
+		c.buckets[btime] = b
+	}
+	b.handleSpan(s)
+}
+
+// Stop stops the concentrator and blocks until the operation completes.
+func (c *concentrator) Stop() {
+	if atomic.SwapUint64(&c.stopped, 1) > 0 {
+		return
+	}
+	close(c.stop)
+	c.wg.Wait()
+}
+
+func (c *concentrator) flush(timenow time.Time) statsPayload {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := timenow.UnixNano()
+	sp := statsPayload{
+		Hostname: c.cfg.hostname,
+		Env:      c.cfg.env,
+		Version:  c.cfg.version,
+		Stats:    make([]statsBucket, 0, len(c.buckets)),
+	}
+	for ts, srb := range c.buckets {
+		if ts > now-c.bucketSize {
+			// do not flush the current bucket
+			continue
+		}
+		log.Debug("Flushing bucket %d", ts)
+		sp.Stats = append(sp.Stats, srb.Export())
+		delete(c.buckets, ts)
+	}
+	return sp
+}
+
+// aggregation specifies a uniquely identifiable key under which a certain set
+// of stats are grouped inside a bucket.
+type aggregation struct {
+	Name       string
+	Env        string
+	Type       string
+	Resource   string
+	Service    string
+	Hostname   string
+	StatusCode uint32
+	Version    string
+	Synthetics bool
+}
+
+type rawBucket struct {
+	start, duration uint64
+	data            map[aggregation]*rawGroupedStats
+}
+
+func newRawBucket(btime uint64, bsize int64) *rawBucket {
+	return &rawBucket{
+		start:    btime,
+		duration: uint64(bsize),
+		data:     make(map[aggregation]*rawGroupedStats),
+	}
+}
+
+func (sb *rawBucket) handleSpan(s *aggregableSpan) {
+	gs, ok := sb.data[s.key]
+	if !ok {
+		gs = newRawGroupedStats()
+		sb.data[s.key] = gs
+	}
+	if s.TopLevel {
+		gs.topLevelHits++
+	}
+	gs.hits++
+	if s.Error != 0 {
+		gs.errors++
+	}
+	gs.duration += uint64(s.Duration)
+	// alter resolution of duration distro
+	trundur := nsTimestampToFloat(s.Duration)
+	if s.Error != 0 {
+		gs.errDistribution.Add(trundur)
+	} else {
+		gs.okDistribution.Add(trundur)
+	}
+}
+
+// Export transforms a RawBucket into a statsBucket, typically used
+// before communicating data to the API, as RawBucket is the internal
+// type while statsBucket is the public, shared one.
+func (sb *rawBucket) Export() statsBucket {
+	csb := statsBucket{
+		Start:    sb.start,
+		Duration: sb.duration,
+		Stats:    make([]groupedStats, len(sb.data)),
+	}
+	for k, v := range sb.data {
+		b, err := v.export(k)
+		if err != nil {
+			log.Error("Could not export stats bucket: %v.", err)
+			continue
+		}
+		csb.Stats = append(csb.Stats, b)
+	}
+	return csb
+}
+
+type rawGroupedStats struct {
+	hits            uint64
+	topLevelHits    uint64
+	errors          uint64
+	duration        uint64
+	okDistribution  *ddsketch.DDSketch
+	errDistribution *ddsketch.DDSketch
+}
+
+func newRawGroupedStats() *rawGroupedStats {
+	const (
+		// relativeAccuracy is the value accuracy we have on the percentiles. For example, we can
+		// say that p99 is 100ms +- 1ms
+		relativeAccuracy = 0.01
+		// maxNumBins is the maximum number of bins of the ddSketch we use to store percentiles.
+		// It can affect relative accuracy, but in practice, 2048 bins is enough to have 1% relative accuracy from
+		// 80 micro second to 1 year: http://www.vldb.org/pvldb/vol12/p2195-masson.pdf
+		maxNumBins = 2048
+	)
+	okSketch, err := ddsketch.LogCollapsingLowestDenseDDSketch(relativeAccuracy, maxNumBins)
+	if err != nil {
+		log.Error("Error when creating ddsketch: %v", err)
+	}
+	errSketch, err := ddsketch.LogCollapsingLowestDenseDDSketch(relativeAccuracy, maxNumBins)
+	if err != nil {
+		log.Error("Error when creating ddsketch: %v", err)
+	}
+	return &rawGroupedStats{
+		okDistribution:  okSketch,
+		errDistribution: errSketch,
+	}
+}
+
+func (s *rawGroupedStats) export(k aggregation) (groupedStats, error) {
+	msg := s.okDistribution.ToProto()
+	okSummary, err := proto.Marshal(msg)
+	if err != nil {
+		return groupedStats{}, err
+	}
+	msg = s.errDistribution.ToProto()
+	errSummary, err := proto.Marshal(msg)
+	if err != nil {
+		return groupedStats{}, err
+	}
+	return groupedStats{
+		Service:        k.Service,
+		Name:           k.Name,
+		Resource:       k.Resource,
+		HTTPStatusCode: k.StatusCode,
+		Type:           k.Type,
+		Hits:           s.hits,
+		Errors:         s.errors,
+		Duration:       s.duration,
+		TopLevelHits:   s.topLevelHits,
+		OkSummary:      okSummary,
+		ErrorSummary:   errSummary,
+		Synthetics:     k.Synthetics,
+	}, nil
+}
+
+// nsTimestampToFloat converts a nanosec timestamp into a float nanosecond timestamp truncated to a fixed precision
+func nsTimestampToFloat(ns int64) float64 {
+	// 10 bits precision (any value will be +/- 1/1024)
+	const roundMask int64 = 1 << 10
+	var shift uint
+	for ns > roundMask {
+		ns = ns >> 1
+		shift++
+	}
+	return float64(ns << shift)
+}

--- a/ddtrace/tracer/stats.go
+++ b/ddtrace/tracer/stats.go
@@ -193,13 +193,10 @@ func (c *concentrator) flush(timenow time.Time) statsPayload {
 // of stats are grouped inside a bucket.
 type aggregation struct {
 	Name       string
-	Env        string
 	Type       string
 	Resource   string
 	Service    string
-	Hostname   string
 	StatusCode uint32
-	Version    string
 	Synthetics bool
 }
 

--- a/ddtrace/tracer/stats_payload.go
+++ b/ddtrace/tracer/stats_payload.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+//go:generate msgp -unexported -marshal=false -o=stats_payload_msgp.go -tests=false
+
+package tracer
+
+// statsPayload specifies information about client computed stats and is encoded
+// to be sent to the agent.
+type statsPayload struct {
+	// Hostname specifies the hostname of the application.
+	Hostname string
+
+	// Env specifies the env. of the application, as defined by the user.
+	Env string
+
+	// Version specifies the application version.
+	Version string
+
+	// Stats holds all stats buckets computed within this payload.
+	Stats []statsBucket
+}
+
+// statsBucket specifies a set of stats computed over a duration.
+type statsBucket struct {
+	// Start specifies the beginning of this bucket.
+	Start uint64
+
+	// Duration specifies the duration of this bucket.
+	Duration uint64
+
+	// Stats contains a set of statistics computed for the duration of this bucket.
+	Stats []groupedStats
+}
+
+// groupedStats contains a set of statistics grouped under various aggregation keys.
+type groupedStats struct {
+	// These fields indicate the properties under which the stats were aggregated.
+	Service        string `json:"service,omitempty"`
+	Name           string `json:"name,omitempty"`
+	Resource       string `json:"resource,omitempty"`
+	HTTPStatusCode uint32 `json:"HTTP_status_code,omitempty"`
+	Type           string `json:"type,omitempty"`
+	DBType         string `json:"DB_type,omitempty"`
+
+	// These fields specify the stats for the above aggregation.
+	Hits         uint64 `json:"hits,omitempty"`
+	Errors       uint64 `json:"errors,omitempty"`
+	Duration     uint64 `json:"duration,omitempty"`
+	OkSummary    []byte `json:"okSummary,omitempty"`
+	ErrorSummary []byte `json:"errorSummary,omitempty"`
+	Synthetics   bool   `json:"synthetics,omitempty"`
+	TopLevelHits uint64 `json:"topLevelHits,omitempty"`
+}

--- a/ddtrace/tracer/stats_payload_msgp.go
+++ b/ddtrace/tracer/stats_payload_msgp.go
@@ -1,0 +1,450 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package tracer
+
+// NOTE: THIS FILE WAS PRODUCED BY THE
+// MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
+// DO NOT EDIT
+
+import (
+	"github.com/tinylib/msgp/msgp"
+)
+
+// DecodeMsg implements msgp.Decodable
+func (z *groupedStats) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Service":
+			z.Service, err = dc.ReadString()
+			if err != nil {
+				return
+			}
+		case "Name":
+			z.Name, err = dc.ReadString()
+			if err != nil {
+				return
+			}
+		case "Resource":
+			z.Resource, err = dc.ReadString()
+			if err != nil {
+				return
+			}
+		case "HTTPStatusCode":
+			z.HTTPStatusCode, err = dc.ReadUint32()
+			if err != nil {
+				return
+			}
+		case "Type":
+			z.Type, err = dc.ReadString()
+			if err != nil {
+				return
+			}
+		case "DBType":
+			z.DBType, err = dc.ReadString()
+			if err != nil {
+				return
+			}
+		case "Hits":
+			z.Hits, err = dc.ReadUint64()
+			if err != nil {
+				return
+			}
+		case "Errors":
+			z.Errors, err = dc.ReadUint64()
+			if err != nil {
+				return
+			}
+		case "Duration":
+			z.Duration, err = dc.ReadUint64()
+			if err != nil {
+				return
+			}
+		case "OkSummary":
+			z.OkSummary, err = dc.ReadBytes(z.OkSummary)
+			if err != nil {
+				return
+			}
+		case "ErrorSummary":
+			z.ErrorSummary, err = dc.ReadBytes(z.ErrorSummary)
+			if err != nil {
+				return
+			}
+		case "Synthetics":
+			z.Synthetics, err = dc.ReadBool()
+			if err != nil {
+				return
+			}
+		case "TopLevelHits":
+			z.TopLevelHits, err = dc.ReadUint64()
+			if err != nil {
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *groupedStats) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 13
+	// write "Service"
+	err = en.Append(0x8d, 0xa7, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.Service)
+	if err != nil {
+		return
+	}
+	// write "Name"
+	err = en.Append(0xa4, 0x4e, 0x61, 0x6d, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.Name)
+	if err != nil {
+		return
+	}
+	// write "Resource"
+	err = en.Append(0xa8, 0x52, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.Resource)
+	if err != nil {
+		return
+	}
+	// write "HTTPStatusCode"
+	err = en.Append(0xae, 0x48, 0x54, 0x54, 0x50, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x43, 0x6f, 0x64, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint32(z.HTTPStatusCode)
+	if err != nil {
+		return
+	}
+	// write "Type"
+	err = en.Append(0xa4, 0x54, 0x79, 0x70, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.Type)
+	if err != nil {
+		return
+	}
+	// write "DBType"
+	err = en.Append(0xa6, 0x44, 0x42, 0x54, 0x79, 0x70, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.DBType)
+	if err != nil {
+		return
+	}
+	// write "Hits"
+	err = en.Append(0xa4, 0x48, 0x69, 0x74, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint64(z.Hits)
+	if err != nil {
+		return
+	}
+	// write "Errors"
+	err = en.Append(0xa6, 0x45, 0x72, 0x72, 0x6f, 0x72, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint64(z.Errors)
+	if err != nil {
+		return
+	}
+	// write "Duration"
+	err = en.Append(0xa8, 0x44, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint64(z.Duration)
+	if err != nil {
+		return
+	}
+	// write "OkSummary"
+	err = en.Append(0xa9, 0x4f, 0x6b, 0x53, 0x75, 0x6d, 0x6d, 0x61, 0x72, 0x79)
+	if err != nil {
+		return
+	}
+	err = en.WriteBytes(z.OkSummary)
+	if err != nil {
+		return
+	}
+	// write "ErrorSummary"
+	err = en.Append(0xac, 0x45, 0x72, 0x72, 0x6f, 0x72, 0x53, 0x75, 0x6d, 0x6d, 0x61, 0x72, 0x79)
+	if err != nil {
+		return
+	}
+	err = en.WriteBytes(z.ErrorSummary)
+	if err != nil {
+		return
+	}
+	// write "Synthetics"
+	err = en.Append(0xaa, 0x53, 0x79, 0x6e, 0x74, 0x68, 0x65, 0x74, 0x69, 0x63, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteBool(z.Synthetics)
+	if err != nil {
+		return
+	}
+	// write "TopLevelHits"
+	err = en.Append(0xac, 0x54, 0x6f, 0x70, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x48, 0x69, 0x74, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint64(z.TopLevelHits)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *groupedStats) Msgsize() (s int) {
+	s = 1 + 8 + msgp.StringPrefixSize + len(z.Service) + 5 + msgp.StringPrefixSize + len(z.Name) + 9 + msgp.StringPrefixSize + len(z.Resource) + 15 + msgp.Uint32Size + 5 + msgp.StringPrefixSize + len(z.Type) + 7 + msgp.StringPrefixSize + len(z.DBType) + 5 + msgp.Uint64Size + 7 + msgp.Uint64Size + 9 + msgp.Uint64Size + 10 + msgp.BytesPrefixSize + len(z.OkSummary) + 13 + msgp.BytesPrefixSize + len(z.ErrorSummary) + 11 + msgp.BoolSize + 13 + msgp.Uint64Size
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *statsBucket) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Start":
+			z.Start, err = dc.ReadUint64()
+			if err != nil {
+				return
+			}
+		case "Duration":
+			z.Duration, err = dc.ReadUint64()
+			if err != nil {
+				return
+			}
+		case "Stats":
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
+			if err != nil {
+				return
+			}
+			if cap(z.Stats) >= int(zb0002) {
+				z.Stats = (z.Stats)[:zb0002]
+			} else {
+				z.Stats = make([]groupedStats, zb0002)
+			}
+			for za0001 := range z.Stats {
+				err = z.Stats[za0001].DecodeMsg(dc)
+				if err != nil {
+					return
+				}
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *statsBucket) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 3
+	// write "Start"
+	err = en.Append(0x83, 0xa5, 0x53, 0x74, 0x61, 0x72, 0x74)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint64(z.Start)
+	if err != nil {
+		return
+	}
+	// write "Duration"
+	err = en.Append(0xa8, 0x44, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint64(z.Duration)
+	if err != nil {
+		return
+	}
+	// write "Stats"
+	err = en.Append(0xa5, 0x53, 0x74, 0x61, 0x74, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteArrayHeader(uint32(len(z.Stats)))
+	if err != nil {
+		return
+	}
+	for za0001 := range z.Stats {
+		err = z.Stats[za0001].EncodeMsg(en)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *statsBucket) Msgsize() (s int) {
+	s = 1 + 6 + msgp.Uint64Size + 9 + msgp.Uint64Size + 6 + msgp.ArrayHeaderSize
+	for za0001 := range z.Stats {
+		s += z.Stats[za0001].Msgsize()
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *statsPayload) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Hostname":
+			z.Hostname, err = dc.ReadString()
+			if err != nil {
+				return
+			}
+		case "Env":
+			z.Env, err = dc.ReadString()
+			if err != nil {
+				return
+			}
+		case "Version":
+			z.Version, err = dc.ReadString()
+			if err != nil {
+				return
+			}
+		case "Stats":
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
+			if err != nil {
+				return
+			}
+			if cap(z.Stats) >= int(zb0002) {
+				z.Stats = (z.Stats)[:zb0002]
+			} else {
+				z.Stats = make([]statsBucket, zb0002)
+			}
+			for za0001 := range z.Stats {
+				err = z.Stats[za0001].DecodeMsg(dc)
+				if err != nil {
+					return
+				}
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *statsPayload) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 4
+	// write "Hostname"
+	err = en.Append(0x84, 0xa8, 0x48, 0x6f, 0x73, 0x74, 0x6e, 0x61, 0x6d, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.Hostname)
+	if err != nil {
+		return
+	}
+	// write "Env"
+	err = en.Append(0xa3, 0x45, 0x6e, 0x76)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.Env)
+	if err != nil {
+		return
+	}
+	// write "Version"
+	err = en.Append(0xa7, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.Version)
+	if err != nil {
+		return
+	}
+	// write "Stats"
+	err = en.Append(0xa5, 0x53, 0x74, 0x61, 0x74, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteArrayHeader(uint32(len(z.Stats)))
+	if err != nil {
+		return
+	}
+	for za0001 := range z.Stats {
+		err = z.Stats[za0001].EncodeMsg(en)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *statsPayload) Msgsize() (s int) {
+	s = 1 + 9 + msgp.StringPrefixSize + len(z.Hostname) + 4 + msgp.StringPrefixSize + len(z.Env) + 8 + msgp.StringPrefixSize + len(z.Version) + 6 + msgp.ArrayHeaderSize
+	for za0001 := range z.Stats {
+		s += z.Stats[za0001].Msgsize()
+	}
+	return
+}

--- a/ddtrace/tracer/stats_test.go
+++ b/ddtrace/tracer/stats_test.go
@@ -1,0 +1,163 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package tracer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// waitForBuckets reports whether concentrator c contains n buckets within a 5ms
+// period.
+func waitForBuckets(c *concentrator, n int) bool {
+	for i := 0; i < 5; i++ {
+		time.Sleep(time.Millisecond)
+		c.mu.Lock()
+		if len(c.buckets) == n {
+			return true
+		}
+		c.mu.Unlock()
+	}
+	return false
+}
+
+func TestAlignTs(t *testing.T) {
+	now := time.Now().UnixNano()
+	got := alignTs(now, defaultStatsBucketSize)
+	want := now - now%((10 * time.Second).Nanoseconds())
+	assert.Equal(t, got, want)
+}
+
+func TestConcentrator(t *testing.T) {
+	key1 := aggregation{
+		Name: "http.request",
+		Env:  "prod",
+	}
+	ss1 := &aggregableSpan{
+		key:      key1,
+		Start:    time.Now().UnixNano() + 2*defaultStatsBucketSize,
+		Duration: (2 * time.Second).Nanoseconds(),
+	}
+	key2 := aggregation{
+		Name: "sql.query",
+		Env:  "staging",
+	}
+	ss2 := &aggregableSpan{
+		key:      key2,
+		Start:    time.Now().UnixNano() + 3*defaultStatsBucketSize,
+		Duration: (3 * time.Second).Nanoseconds(),
+	}
+
+	t.Run("new", func(t *testing.T) {
+		assert := assert.New(t)
+		cfg := &config{version: "1.2.3"}
+		c := newConcentrator(cfg, defaultStatsBucketSize)
+		assert.Equal(cap(c.In), 10000)
+		assert.Nil(c.stop)
+		assert.NotNil(c.buckets)
+		assert.Equal(c.cfg, cfg)
+		assert.EqualValues(c.stopped, 1)
+	})
+
+	t.Run("start-stop", func(t *testing.T) {
+		assert := assert.New(t)
+		c := newConcentrator(&config{}, defaultStatsBucketSize)
+		assert.EqualValues(c.stopped, 1)
+		c.Start()
+		assert.EqualValues(c.stopped, 0)
+		c.Stop()
+		c.Stop()
+		assert.EqualValues(c.stopped, 1)
+		c.Start()
+		assert.EqualValues(c.stopped, 0)
+		c.Start()
+		c.Start()
+		assert.EqualValues(c.stopped, 0)
+		c.Stop()
+		c.Stop()
+		assert.EqualValues(c.stopped, 1)
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		c := newConcentrator(&config{}, defaultStatsBucketSize)
+		btime := alignTs(ss1.Start+ss1.Duration, defaultStatsBucketSize)
+		c.add(ss1)
+		assert.Len(t, c.buckets, 1)
+		b, ok := c.buckets[btime]
+		assert.True(t, ok)
+		assert.Equal(t, b.start, uint64(btime))
+		assert.Equal(t, b.duration, uint64(defaultStatsBucketSize))
+	})
+
+	t.Run("grouping", func(t *testing.T) {
+		c := newConcentrator(&config{}, defaultStatsBucketSize)
+		c.add(ss1)
+		c.add(ss1)
+		assert.Len(t, c.buckets, 1)
+		_, ok := c.buckets[alignTs(ss1.Start+ss1.Duration, defaultStatsBucketSize)]
+		assert.True(t, ok)
+		c.add(ss2)
+		assert.Len(t, c.buckets, 2)
+		_, ok = c.buckets[alignTs(ss2.Start+ss2.Duration, defaultStatsBucketSize)]
+		assert.True(t, ok)
+	})
+
+	t.Run("ingester", func(t *testing.T) {
+		c := newConcentrator(&config{}, defaultStatsBucketSize)
+		c.Start()
+		assert.Len(t, c.buckets, 0)
+		c.In <- ss1
+		if !waitForBuckets(c, 1) {
+			t.Fatal("sending to channel did not work")
+		}
+		c.Stop()
+	})
+
+	t.Run("flusher", func(t *testing.T) {
+		t.Run("old", func(t *testing.T) {
+			transport := newDummyTransport()
+			c := newConcentrator(&config{transport: transport}, 500000)
+			assert.Len(t, transport.Stats(), 0)
+			c.Start()
+			c.In <- &aggregableSpan{
+				key: key2,
+				// Start must be older than latest bucket to get flushed
+				Start:    time.Now().UnixNano() - 3*500000,
+				Duration: 1,
+			}
+			c.In <- &aggregableSpan{
+				key: key2,
+				// Start must be older than latest bucket to get flushed
+				Start:    time.Now().UnixNano() - 4*500000,
+				Duration: 1,
+			}
+			time.Sleep(2 * time.Millisecond)
+			c.Stop()
+			assert.NotZero(t, transport.Stats())
+		})
+
+		t.Run("recent", func(t *testing.T) {
+			transport := newDummyTransport()
+			c := newConcentrator(&config{transport: transport}, 500000)
+			assert.Len(t, transport.Stats(), 0)
+			c.Start()
+			c.In <- &aggregableSpan{
+				key:      key2,
+				Start:    time.Now().UnixNano() + 5*500000,
+				Duration: 1,
+			}
+			c.In <- &aggregableSpan{
+				key:      key1,
+				Start:    time.Now().UnixNano() + 6*500000,
+				Duration: 1,
+			}
+			c.Stop()
+			assert.Zero(t, transport.Stats())
+		})
+	})
+}

--- a/ddtrace/tracer/stats_test.go
+++ b/ddtrace/tracer/stats_test.go
@@ -36,7 +36,6 @@ func TestAlignTs(t *testing.T) {
 func TestConcentrator(t *testing.T) {
 	key1 := aggregation{
 		Name: "http.request",
-		Env:  "prod",
 	}
 	ss1 := &aggregableSpan{
 		key:      key1,
@@ -45,7 +44,6 @@ func TestConcentrator(t *testing.T) {
 	}
 	key2 := aggregation{
 		Name: "sql.query",
-		Env:  "staging",
 	}
 	ss2 := &aggregableSpan{
 		key:      key2,

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -6,6 +6,9 @@
 package tracer
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 	"sync"
@@ -28,7 +31,15 @@ var _ ddtrace.Tracer = (*tracer)(nil)
 // channels. It additionally holds two buffers which accumulates error and trace
 // queues to be processed by the payload encoder.
 type tracer struct {
-	*config
+	config *config
+
+	// features holds the capabilities of the agent and determines some
+	// of the behaviour of the tracer.
+	features *agentFeatures
+
+	// stats specifies the concentrator used to compute statistics, when client-side
+	// stats are enabled.
+	stats *concentrator
 
 	// traceWriter is responsible for sending finished traces to their
 	// destination, such as the Trace Agent or Datadog Forwarder.
@@ -59,6 +70,9 @@ type tracer struct {
 	// These integers track metrics about spans and traces as they are started,
 	// finished, and dropped
 	spansStarted, spansFinished, tracesDropped int64
+
+	// Records the number of dropped P0 traces and spans.
+	droppedP0Traces, droppedP0Spans uint64
 
 	// rulesSampling holds an instance of the rules sampler. These are user-defined
 	// rules for applying a sampling rate to spans that match the designated service
@@ -96,6 +110,9 @@ func Start(opts ...StartOption) {
 		return // mock tracer active
 	}
 	t := newTracer(opts...)
+	if t.config.HasFeature("discovery") {
+		t.loadAgentFeatures()
+	}
 	internal.SetGlobalTracer(t)
 	if t.config.logStartup {
 		logStartup(t)
@@ -152,7 +169,7 @@ func newUnstartedTracer(opts ...StartOption) *tracer {
 	} else {
 		writer = newAgentTraceWriter(c, sampler)
 	}
-	return &tracer{
+	t := &tracer{
 		config:           c,
 		traceWriter:      writer,
 		out:              make(chan []*span, payloadQueueSize),
@@ -161,7 +178,10 @@ func newUnstartedTracer(opts ...StartOption) *tracer {
 		rulesSampling:    newRulesSampler(c.samplingRules),
 		prioritySampling: sampler,
 		pid:              strconv.Itoa(os.Getpid()),
+		features:         &agentFeatures{},
+		stats:            newConcentrator(c, defaultStatsBucketSize),
 	}
+	return t
 }
 
 func newTracer(opts ...StartOption) *tracer {
@@ -192,6 +212,7 @@ func newTracer(opts ...StartOption) *tracer {
 		defer t.wg.Done()
 		t.reportHealthMetrics(statsInterval)
 	}()
+	t.stats.Start()
 	return t
 }
 
@@ -216,6 +237,78 @@ func (t *tracer) flushSync() {
 	done := make(chan struct{})
 	t.flush <- done
 	<-done
+}
+
+// agentFeatures holds information about the trace-agent's capabilities.
+type agentFeatures struct {
+	mu sync.RWMutex
+
+	// DropP0s reports whether it's ok for the tracer to not send any
+	// P0 traces to the agent.
+	DropP0s bool
+
+	// V05 reports whether it's ok to use the /v0.5/traces endpoint format.
+	V05 bool // TODO(x): Not yet implemented
+
+	// Stats reports whether the agent can receive client-computed stats on
+	// the /v0.6/stats endpoint.
+	Stats bool
+}
+
+// Load returns the current features.
+func (f *agentFeatures) Load() agentFeatures {
+	f.mu.RLock()
+	out := *f
+	f.mu.RUnlock()
+	return out
+}
+
+// Store stores the new features.
+func (f *agentFeatures) Store(newf agentFeatures) {
+	f.mu.Lock()
+	f.DropP0s = newf.DropP0s
+	f.V05 = newf.V05
+	f.Stats = newf.Stats
+	f.mu.Unlock()
+}
+
+// loadAgentFeatures queries the trace-agent for its capabilities and updates
+// the tracer's behaviour.
+func (t *tracer) loadAgentFeatures() {
+	if t.config.logToStdout {
+		// there is no agent
+		return
+	}
+	resp, err := http.Get(fmt.Sprintf("http://%s/info", t.config.agentAddr))
+	if err != nil {
+		log.Error("Loading features: %v", err)
+		return
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		// agent is older than 7.28.0, features not discoverable
+		t.features.Store(agentFeatures{})
+		return
+	}
+	defer resp.Body.Close()
+	type infoResponse struct {
+		Endpoints     []string `json:"endpoints"`
+		ClientDropP0s bool     `json:"client_drop_p0s"`
+	}
+	var info infoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		log.Error("Decoding features: %v", err)
+		return
+	}
+	f := agentFeatures{DropP0s: info.ClientDropP0s}
+	for _, endpoint := range info.Endpoints {
+		switch endpoint {
+		case "/v0.6/stats":
+			f.Stats = true
+		case "/v0.5/traces":
+			f.V05 = true
+		}
+	}
+	t.features.Store(f)
 }
 
 // worker receives finished traces to be added into the payload, as well
@@ -301,8 +394,8 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		taskEnd:      startExecutionTracerTask(operationName),
 		noDebugStack: t.config.noDebugStack,
 	}
-	if t.hostname != "" {
-		span.setMeta(keyHostname, t.hostname)
+	if t.config.hostname != "" {
+		span.setMeta(keyHostname, t.config.hostname)
 	}
 	if context != nil {
 		// this is a child span
@@ -351,7 +444,7 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		span.SetTag(ext.Version, t.config.version)
 	}
 	if t.config.env != "" {
-		span.SetTag(ext.Environment, t.env)
+		span.SetTag(ext.Environment, t.config.env)
 	}
 	if context == nil {
 		// this is a brand new trace, sample it
@@ -367,6 +460,7 @@ func (t *tracer) Stop() {
 		close(t.stop)
 		t.config.statsd.Incr("datadog.tracer.stopped", nil, 1)
 	})
+	t.stats.Stop()
 	t.wg.Wait()
 	t.traceWriter.stop()
 	t.config.statsd.Close()

--- a/ddtrace/tracer/transport.go
+++ b/ddtrace/tracer/transport.go
@@ -6,6 +6,7 @@
 package tracer
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net"
@@ -14,10 +15,14 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
+	traceinternal "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/version"
+
+	"github.com/tinylib/msgp/msgp"
 )
 
 const (
@@ -53,13 +58,22 @@ const (
 	traceCountHeader   = "X-Datadog-Trace-Count" // header containing the number of traces in the payload
 )
 
-// transport is an interface for span submission to the agent.
+// transport is an interface for communicating data to the agent.
 type transport interface {
 	// send sends the payload p to the agent using the transport set up.
 	// It returns a non-nil response body when no error occurred.
 	send(p *payload) (body io.ReadCloser, err error)
+	// sendStats sends the given stats payload to the agent.
+	sendStats(s *statsPayload) error
 	// endpoint returns the URL to which the transport will send traces.
 	endpoint() string
+}
+
+type httpTransport struct {
+	traceURL string            // the delivery URL for traces
+	statsURL string            // the delivery URL for stats
+	client   *http.Client      // the HTTP client used in the POST
+	headers  map[string]string // the Transport headers
 }
 
 // newTransport returns a new Transport implementation that sends traces to a
@@ -72,26 +86,10 @@ type transport interface {
 // running on a non-default port, if it's located on another machine, or when
 // otherwise needing to customize the transport layer, for instance when using
 // a unix domain socket.
-func newTransport(addr string, client *http.Client) transport {
+func newHTTPTransport(addr string, client *http.Client) *httpTransport {
 	if client == nil {
 		client = defaultClient
 	}
-	return newHTTPTransport(addr, client)
-}
-
-// newDefaultTransport return a default transport for this tracing client
-func newDefaultTransport() transport {
-	return newHTTPTransport(defaultAddress, defaultClient)
-}
-
-type httpTransport struct {
-	traceURL string            // the delivery URL for traces
-	client   *http.Client      // the HTTP client used in the POST
-	headers  map[string]string // the Transport headers
-}
-
-// newHTTPTransport returns an httpTransport for the given endpoint
-func newHTTPTransport(addr string, client *http.Client) *httpTransport {
 	// initialize the default EncoderPool with Encoder headers
 	defaultHeaders := map[string]string{
 		"Datadog-Meta-Lang":             "go",
@@ -105,9 +103,38 @@ func newHTTPTransport(addr string, client *http.Client) *httpTransport {
 	}
 	return &httpTransport{
 		traceURL: fmt.Sprintf("http://%s/v0.4/traces", resolveAddr(addr)),
+		statsURL: fmt.Sprintf("http://%s/v0.6/stats", resolveAddr(addr)),
 		client:   client,
 		headers:  defaultHeaders,
 	}
+}
+
+func (t *httpTransport) sendStats(p *statsPayload) error {
+	var buf bytes.Buffer
+	if err := msgp.Encode(&buf, p); err != nil {
+		return err
+	}
+	req, err := http.NewRequest("POST", t.statsURL, &buf)
+	if err != nil {
+		return err
+	}
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return err
+	}
+	if code := resp.StatusCode; code >= 400 {
+		// error, check the body for context information and
+		// return a nice error.
+		msg := make([]byte, 1000)
+		n, _ := resp.Body.Read(msg)
+		resp.Body.Close()
+		txt := http.StatusText(code)
+		if n > 0 {
+			return fmt.Errorf("%s (Status: %s)", msg[:n], txt)
+		}
+		return fmt.Errorf("%s", txt)
+	}
+	return nil
 }
 
 func (t *httpTransport) send(p *payload) (body io.ReadCloser, err error) {
@@ -121,6 +148,19 @@ func (t *httpTransport) send(p *payload) (body io.ReadCloser, err error) {
 	req.Header.Set(traceCountHeader, strconv.Itoa(p.itemCount()))
 	req.Header.Set("Content-Length", strconv.Itoa(p.size()))
 	req.Header.Set(headerComputedTopLevel, "yes")
+	if t, ok := traceinternal.GetGlobalTracer().(*tracer); ok {
+		if t.features.Load().Stats {
+			req.Header.Set("Datadog-Client-Computed-Stats", "yes")
+		}
+		droppedTraces := int(atomic.SwapUint64(&t.droppedP0Traces, 0))
+		droppedSpans := int(atomic.SwapUint64(&t.droppedP0Spans, 0))
+		if stats := t.config.statsd; stats != nil {
+			stats.Count("datadog.tracer.dropped_p0_traces", int64(droppedTraces), nil, 1)
+			stats.Count("datadog.tracer.dropped_p0_spans", int64(droppedSpans), nil, 1)
+		}
+		req.Header.Set("Datadog-Client-Dropped-P0-Traces", strconv.Itoa(droppedTraces))
+		req.Header.Set("Datadog-Client-Dropped-P0-Spans", strconv.Itoa(droppedSpans))
+	}
 	response, err := t.client.Do(req)
 	if err != nil {
 		return nil, err

--- a/ddtrace/tracer/writer.go
+++ b/ddtrace/tracer/writer.go
@@ -60,7 +60,7 @@ func newAgentTraceWriter(c *config, s *prioritySampler) *agentTraceWriter {
 func (h *agentTraceWriter) add(trace []*span) {
 	if err := h.payload.push(trace); err != nil {
 		h.config.statsd.Incr("datadog.tracer.traces_dropped", []string{"reason:encoding_error"}, 1)
-		log.Error("error encoding msgpack: %v", err)
+		log.Error("Error encoding msgpack: %v", err)
 	}
 	if h.payload.size() > payloadSizeLimit {
 		h.config.statsd.Incr("datadog.tracer.flush_triggered", []string{"reason:size"}, 1)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/DataDog/datadog-go v4.4.0+incompatible
 	github.com/DataDog/gostackparse v0.5.0
+	github.com/DataDog/sketches-go v1.0.0
 	github.com/google/pprof v0.0.0-20210125172800-10e9aeb4a998
 	github.com/tinylib/msgp v1.1.2
 )


### PR DESCRIPTION
This change adds a multitude of new features, such as support for feature flags, agent discovery, client-side stats computations and enabling the dropping of P0 traces in the client.

### Feature flags

Support for feature flags by means of:
* `WithFeatureFlags` tracer start option.
* `DD_TRACE_FEATURES` environment variable which takes a list of comma or space separated flag tokens.

### Agent discovery

When the feature flag `discovery` is set, support for detecting features by means of the new agent (7.27.0) discovery endpoint added in https://github.com/DataDog/datadog-agent/pull/7344 and https://github.com/DataDog/datadog-agent/pull/7495 becomes enabled.

### Client-computed stats and dropping p0's

When `discovery` is enabled, if the agent supports client-computed stats and dropping p0's in the client, the tracer can now do this by means of the newly added concentrator and drop logic.

### TODO

* Obfuscation is not yet supported in the client but will be added in a subsequent PR by factoring out the obfuscator code from the agent into a separate package to be shared with this module.