### PR TITLE
internal: add support for Fargate 1.4

### DIFF
--- a/internal/container.go
+++ b/internal/container.go
@@ -7,9 +7,11 @@ package internal
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"os"
 	"regexp"
+	"strings"
 )
 
 const (
@@ -17,11 +19,18 @@ const (
 	cgroupPath = "/proc/self/cgroup"
 )
 
+const (
+	uuidSource      = "[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}"
+	containerSource = "[0-9a-f]{64}"
+	taskSource      = "[0-9a-f]{32}-\\d+"
+)
+
 var (
 	// expLine matches a line in the /proc/self/cgroup file. It has a submatch for the last element (path), which contains the container ID.
 	expLine = regexp.MustCompile(`^\d+:[^:]*:(.+)$`)
+
 	// expContainerID matches contained IDs and sources. Source: https://github.com/Qard/container-info/blob/master/index.js
-	expContainerID = regexp.MustCompile(`([0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}|[0-9a-f]{64})(?:.scope)?$`)
+	expContainerID = regexp.MustCompile(fmt.Sprintf(`(%s|%s|%s)(?:.scope)?$`, uuidSource, containerSource, taskSource))
 
 	// containerID is the containerID read at init from /proc/self/cgroup
 	containerID string
@@ -41,7 +50,7 @@ func parseContainerID(r io.Reader) string {
 			continue
 		}
 		if id := expContainerID.FindString(path[1]); id != "" {
-			return id
+			return strings.TrimSuffix(id, ".scope")
 		}
 	}
 	return ""

--- a/internal/container_test.go
+++ b/internal/container_test.go
@@ -29,10 +29,18 @@ func TestReadContainerID(t *testing.T) {
 2:net_cls,net_prio:/kubepods/burstable/podfd52ef25-a87d-11e9-9423-0800271a638e/8c046cb0b72cd4c99f51b5591cd5b095967f58ee003710a45280c28ee1a9c7fa`: "8c046cb0b72cd4c99f51b5591cd5b095967f58ee003710a45280c28ee1a9c7fa",
 		"10:hugetlb:/kubepods/burstable/podfd52ef25-a87d-11e9-9423-0800271a638e/8c046cb0b72cd4c99f51b5591cd5b095967f58ee003710a45280c28ee1a9c7fa": "8c046cb0b72cd4c99f51b5591cd5b095967f58ee003710a45280c28ee1a9c7fa",
 		"10:hugetlb:/kubepods": "",
+		"11:hugetlb:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da": "432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da",
+		"1:name=systemd:/docker/34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376":                               "34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376",
+		"1:name=systemd:/uuid/34dc0b5e-626f-2c5c-4c51-70e34b10e765":                                                             "34dc0b5e-626f-2c5c-4c51-70e34b10e765",
+		"1:name=systemd:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890":                                                       "34dc0b5e626f2c5c4c5170e34b10e765-1234567890",
+		"1:name=systemd:/docker/34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376.scope":                         "34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376",
+		`1:name=systemd:/nope
+2:pids:/docker/34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376
+3:cpu:/invalid`: "34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376",
 	} {
 		id := parseContainerID(strings.NewReader(in))
 		if id != out {
-			t.Fatalf("%q -> %q", in, out)
+			t.Fatalf("%q -> %q: %q", in, out, id)
 		}
 	}
 }


### PR DESCRIPTION
/proc/self/cgroup structure has changed with Fargate 1.4, which broke
our container ID detection algorithm. This change fixes it.