### PR TITLE
.circleci: bump to go1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2
 
-plain-go113: &plain-go113
+plain-go114: &plain-go114
   working_directory: /home/circleci/dd-trace-go.v1
   docker:
-    - image: circleci/golang:1.13
+    - image: circleci/golang:1.14
       environment:
         GOPATH: "/home/circleci/go"
 
@@ -24,7 +24,7 @@ jobs:
           go build ./ddtrace/... ./profiler/...
 
   metadata:
-    <<: *plain-go113
+    <<: *plain-go114
 
     steps:
     - checkout
@@ -40,7 +40,7 @@ jobs:
           go run checkcopyright.go
 
   lint:
-    <<: *plain-go113
+    <<: *plain-go114
 
     steps:
     - checkout
@@ -62,7 +62,7 @@ jobs:
 
   test-core:
     resource_class: xlarge
-    <<: *plain-go113
+    <<: *plain-go114
 
     steps:
       - checkout
@@ -74,7 +74,7 @@ jobs:
     resource_class: xlarge
     working_directory: /home/circleci/dd-trace-go.v1
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.14
         environment:
           GOPATH: "/home/circleci/go"
       - image: cassandra:3.7

--- a/contrib/go-pg/pg.v10/pg_go_test.go
+++ b/contrib/go-pg/pg.v10/pg_go_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-pg/pg/v10"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestImplementsHook(t *testing.T) {
@@ -45,6 +46,7 @@ func TestSelect(t *testing.T) {
 	parentSpan.Finish()
 	spans := mt.FinishedSpans()
 
+	require.NoError(t, err)
 	assert.Equal(1, res.RowsAffected())
 	assert.Equal(1, res.RowsReturned())
 	assert.Equal(2, len(spans))

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,4 +8,4 @@ package version
 // Tag specifies the current release tag. It needs to be manually
 // updated. A test checks that the value of Tag never points to a
 // git tag that is older than HEAD.
-const Tag = "v1.29.0"
+const Tag = "v1.30.0"


### PR DESCRIPTION
This change bumps the CI go version to `go1.14` due to a dependency failure which requires it (for redis.v8 and go-pg.v10):
```
# go.opentelemetry.io/otel/trace
../go/pkg/mod/go.opentelemetry.io/otel/trace@v0.18.0/config.go:119:2: duplicate method private
note: module requires Go 1.14
```