### PR TITLE
contrib/globalsign/mgo: fix infinite loop

### DIFF
--- a/contrib/globalsign/mgo/mgo_test.go
+++ b/contrib/globalsign/mgo/mgo_test.go
@@ -118,6 +118,33 @@ func TestCollection_UpdateId(t *testing.T) {
 	assert.Equal("mongodb.query", spans[3].OperationName())
 }
 
+func TestIssue874(t *testing.T) {
+	// regression test for DataDog/dd-trace-go#873
+	assert := assert.New(t)
+
+	entity := bson.D{
+		bson.DocElem{
+			Name: "entity",
+			Value: bson.DocElem{
+				Name:  "index",
+				Value: 0}}}
+
+	insert := func(collection *Collection) {
+		collection.Insert(entity)
+		var r bson.D
+		collection.Find(entity).All(&r)
+		collection.Find(entity).Apply(mgo.Change{Update: entity}, &r)
+		collection.Find(entity).Count()
+		collection.Find(entity).Distinct("index", &r)
+		collection.Find(entity).Explain(&r)
+		collection.Find(entity).One(&r)
+		collection.UpdateId(r.Map()["_id"], entity)
+	}
+
+	spans := testMongoCollectionCommand(assert, insert)
+	assert.Equal(9, len(spans))
+}
+
 func TestCollection_Upsert(t *testing.T) {
 	assert := assert.New(t)
 

--- a/contrib/globalsign/mgo/query.go
+++ b/contrib/globalsign/mgo/query.go
@@ -34,7 +34,7 @@ func (q *Query) Iter() *Iter {
 // All invokes and traces Query.All
 func (q *Query) All(result interface{}) error {
 	span := newChildSpanFromContext(q.cfg, q.tags)
-	err := q.All(result)
+	err := q.Query.All(result)
 	span.Finish(tracer.WithError(err))
 	return err
 }
@@ -42,7 +42,7 @@ func (q *Query) All(result interface{}) error {
 // Apply invokes and traces Query.Apply
 func (q *Query) Apply(change mgo.Change, result interface{}) (info *mgo.ChangeInfo, err error) {
 	span := newChildSpanFromContext(q.cfg, q.tags)
-	info, err = q.Apply(change, result)
+	info, err = q.Query.Apply(change, result)
 	span.Finish(tracer.WithError(err))
 	return info, err
 }
@@ -50,7 +50,7 @@ func (q *Query) Apply(change mgo.Change, result interface{}) (info *mgo.ChangeIn
 // Count invokes and traces Query.Count
 func (q *Query) Count() (n int, err error) {
 	span := newChildSpanFromContext(q.cfg, q.tags)
-	n, err = q.Count()
+	n, err = q.Query.Count()
 	span.Finish(tracer.WithError(err))
 	return n, err
 }
@@ -58,7 +58,7 @@ func (q *Query) Count() (n int, err error) {
 // Distinct invokes and traces Query.Distinct
 func (q *Query) Distinct(key string, result interface{}) error {
 	span := newChildSpanFromContext(q.cfg, q.tags)
-	err := q.Distinct(key, result)
+	err := q.Query.Distinct(key, result)
 	span.Finish(tracer.WithError(err))
 	return err
 }
@@ -66,7 +66,7 @@ func (q *Query) Distinct(key string, result interface{}) error {
 // Explain invokes and traces Query.Explain
 func (q *Query) Explain(result interface{}) error {
 	span := newChildSpanFromContext(q.cfg, q.tags)
-	err := q.Explain(result)
+	err := q.Query.Explain(result)
 	span.Finish(tracer.WithError(err))
 	return err
 }
@@ -74,7 +74,7 @@ func (q *Query) Explain(result interface{}) error {
 // For invokes and traces Query.For
 func (q *Query) For(result interface{}, f func() error) error {
 	span := newChildSpanFromContext(q.cfg, q.tags)
-	err := q.For(result, f)
+	err := q.Query.For(result, f)
 	span.Finish(tracer.WithError(err))
 	return err
 }
@@ -82,7 +82,7 @@ func (q *Query) For(result interface{}, f func() error) error {
 // MapReduce invokes and traces Query.MapReduce
 func (q *Query) MapReduce(job *mgo.MapReduce, result interface{}) (info *mgo.MapReduceInfo, err error) {
 	span := newChildSpanFromContext(q.cfg, q.tags)
-	info, err = q.MapReduce(job, result)
+	info, err = q.Query.MapReduce(job, result)
 	span.Finish(tracer.WithError(err))
 	return info, err
 }
@@ -90,7 +90,7 @@ func (q *Query) MapReduce(job *mgo.MapReduce, result interface{}) (info *mgo.Map
 // One invokes and traces Query.One
 func (q *Query) One(result interface{}) error {
 	span := newChildSpanFromContext(q.cfg, q.tags)
-	err := q.One(result)
+	err := q.Query.One(result)
 	span.Finish(tracer.WithError(err))
 	return err
 }


### PR DESCRIPTION
This change fixes an issue which caused an infinite loop due to a
programming error.

Closes #873