### PR TITLE
contrib/confluentinc/confluent-kafka-go: ReadMessage method support

### DIFF
--- a/contrib/confluentinc/confluent-kafka-go/kafka/headers.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/headers.go
@@ -8,7 +8,7 @@ package kafka
 import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
-	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
+	"github.com/confluentinc/confluent-kafka-go/kafka"
 )
 
 // A MessageCarrier injects and extracts traces from a sarama.ProducerMessage.

--- a/contrib/confluentinc/confluent-kafka-go/kafka/kafka.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/kafka.go
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 
-	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
+	"github.com/confluentinc/confluent-kafka-go/kafka"
 )
 
 // NewConsumer calls kafka.NewConsumer and wraps the resulting Consumer.

--- a/contrib/confluentinc/confluent-kafka-go/kafka/kafka_test.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/kafka_test.go
@@ -8,6 +8,7 @@ package kafka
 import (
 	"os"
 	"testing"
+	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
@@ -154,6 +155,79 @@ func TestConsumerPoll(t *testing.T) {
 	assert.NoError(t, err)
 
 	msg2, _ := c.Poll(3000).(*kafka.Message)
+	assert.Equal(t, msg1.String(), msg2.String())
+
+	c.Close()
+
+	// now verify the spans
+	spans := mt.FinishedSpans()
+	assert.Len(t, spans, 2)
+	// they should be linked via headers
+	assert.Equal(t, spans[0].TraceID(), spans[1].TraceID())
+
+	s0 := spans[0] // produce
+	assert.Equal(t, "kafka.produce", s0.OperationName())
+	assert.Equal(t, "kafka", s0.Tag(ext.ServiceName))
+	assert.Equal(t, "Produce Topic gotest", s0.Tag(ext.ResourceName))
+	assert.Equal(t, 0.1, s0.Tag(ext.EventSampleRate))
+	assert.Equal(t, "queue", s0.Tag(ext.SpanType))
+	assert.Equal(t, int32(0), s0.Tag("partition"))
+
+	s1 := spans[1] // consume
+	assert.Equal(t, "kafka.consume", s1.OperationName())
+	assert.Equal(t, "kafka", s1.Tag(ext.ServiceName))
+	assert.Equal(t, "Consume Topic gotest", s1.Tag(ext.ResourceName))
+	assert.Equal(t, nil, s1.Tag(ext.EventSampleRate))
+	assert.Equal(t, "queue", s1.Tag(ext.SpanType))
+	assert.Equal(t, int32(0), s1.Tag("partition"))
+}
+
+func TestConsumerReadMessage(t *testing.T) {
+	if _, ok := os.LookupEnv("INTEGRATION"); !ok {
+		t.Skip("to enable integration test, set the INTEGRATION environment variable")
+	}
+
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	// first write a message to the topic
+
+	p, err := NewProducer(&kafka.ConfigMap{
+		"group.id":            testGroupID,
+		"bootstrap.servers":   "127.0.0.1:9092",
+		"go.delivery.reports": true,
+	}, WithAnalyticsRate(0.1))
+	assert.NoError(t, err)
+	delivery := make(chan kafka.Event, 1)
+	err = p.Produce(&kafka.Message{
+		TopicPartition: kafka.TopicPartition{
+			Topic:     &testTopic,
+			Partition: 0,
+		},
+		Key:   []byte("key2"),
+		Value: []byte("value2"),
+	}, delivery)
+	assert.NoError(t, err)
+	msg1, _ := (<-delivery).(*kafka.Message)
+	p.Close()
+
+	// next attempt to consume the message
+
+	c, err := NewConsumer(&kafka.ConfigMap{
+		"group.id":                 testGroupID,
+		"bootstrap.servers":        "127.0.0.1:9092",
+		"socket.timeout.ms":        1000,
+		"session.timeout.ms":       1000,
+		"enable.auto.offset.store": false,
+	})
+	assert.NoError(t, err)
+
+	err = c.Assign([]kafka.TopicPartition{
+		{Topic: &testTopic, Partition: 0, Offset: msg1.TopicPartition.Offset},
+	})
+	assert.NoError(t, err)
+
+	msg2, _ := c.ReadMessage(3000 * time.Millisecond)
 	assert.Equal(t, msg1.String(), msg2.String())
 
 	c.Close()

--- a/contrib/confluentinc/confluent-kafka-go/kafka/kafka_test.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/kafka_test.go
@@ -12,7 +12,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 
-	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
+	"github.com/confluentinc/confluent-kafka-go/kafka"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/contrib/confluentinc/confluent-kafka-go/kafka/kafka_test.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/kafka_test.go
@@ -111,7 +111,11 @@ to run the integration test locally:
 */
 
 func TestConsumerFunctional(t *testing.T) {
-	tests := []struct {
+	if _, ok := os.LookupEnv("INTEGRATION"); !ok {
+		t.Skip("to enable integration test, set the INTEGRATION environment variable")
+	}
+
+	for _, tt := range []struct {
 		name   string
 		action func(c *Consumer) (*kafka.Message, error)
 	}{
@@ -132,13 +136,8 @@ func TestConsumerFunctional(t *testing.T) {
 				return c.ReadMessage(3000 * time.Millisecond)
 			},
 		},
-	}
-	for _, tt := range tests {
+	} {
 		t.Run(tt.name, func(t *testing.T) {
-			if _, ok := os.LookupEnv("INTEGRATION"); !ok {
-				t.Skip("to enable integration test, set the INTEGRATION environment variable")
-			}
-
 			mt := mocktracer.Start()
 			defer mt.Stop()
 


### PR DESCRIPTION
### what

add support for missing public method `ReadMessage` of kafka consumer

### why
closes #846
