### PR TITLE
.circleci: add codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,12 @@ jobs:
       - checkout
       - run:
           name: Testing
-          command: go test -v -race `go list ./... | grep -v /contrib/`
+          command: go test -v -race -coverprofile=coverage.txt -covermode=atomic `go list ./... | grep -v /contrib/`
+
+      - run:
+          name: Upload coverage report to Codecov
+          command: bash <(curl -s https://codecov.io/bash)
+
 
   test-contrib:
     resource_class: xlarge
@@ -183,11 +188,15 @@ jobs:
       - run:
           name: Testing
           command: |
-                INTEGRATION=1 go test -v -race `go list ./contrib/... | grep -v -e grpc.v12 -e google.golang.org/api`
+                INTEGRATION=1 go test -v -race -coverprofile=coverage.txt -covermode=atomic `go list ./contrib/... | grep -v -e grpc.v12 -e google.golang.org/api`
                 go get google.golang.org/grpc@v1.29.0 # https://github.com/grpc/grpc-go/issues/3726
                 go test -v ./contrib/google.golang.org/api/...
                 go get google.golang.org/grpc@v1.2.0
                 go test -v ./contrib/google.golang.org/grpc.v12/...
+
+      - run:
+          name: Upload coverage report to Codecov
+          command: bash <(curl -s https://codecov.io/bash)
 
 workflows:
   version: 2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![CircleCI](https://circleci.com/gh/DataDog/dd-trace-go/tree/v1.svg?style=svg)](https://circleci.com/gh/DataDog/dd-trace-go/tree/v1)
 [![Godoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace)
+[![codecov](https://codecov.io/gh/DataDog/dd-trace-go/branch/v1/graph/badge.svg?token=jGG20Xhv8i)](https://codecov.io/gh/DataDog/dd-trace-go)
 
 ### Installing
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,30 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default: false
+      core:
+        target: 80%
+        flags:
+          - core
+      contrib:
+        target: 75%
+        flags:
+          - contrib
+    patch:
+      default:
+        target: 100%
+
+flags:
+  core:
+    paths:
+      - ddtrace/*
+            - internal/*
+            - profiler/*
+  contrib:
+    paths:
+      - contrib/*
+
+github_checks:
+  annotations: false


### PR DESCRIPTION
Enable Codecov app integration with `dd-trace-go` to upload coverage reports for unit test coverage in the CircleCI `test-core` job. 

This PR modifies the CircleCI config file to utilize Codecov to add [GitHub Checks](https://docs.codecov.io/docs/github-checks-beta#yaml-configuration-for-github-checks-and-codecov) to each PR to automatically check if test coverage reaches a target percentage of the codebase. GitHub checks break down code coverage percentages for PR-specific changes, `core` and `contrib` tests.

Code coverage for this repo is hosted [here](https://codecov.io/github/DataDog/dd-trace-go).