### PR TITLE
ddtrace/tracer: always use custom stack trace retrieval code

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -166,7 +166,7 @@ func (s *span) setTagError(value interface{}, cfg *errorConfig) {
 }
 
 // defaultStackLength specifies the default maximum size of a stack trace.
-const defaultStackLength = 20
+const defaultStackLength = 32
 
 // takeStacktrace takes a stack trace of maximum n entries, skipping the first skip entries.
 // If n is 0, up to 20 entries are retrieved.

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"reflect"
 	"runtime"
-	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -147,11 +146,7 @@ func (s *span) setTagError(value interface{}, cfg *errorConfig) {
 		s.setMeta(ext.ErrorMsg, v.Error())
 		s.setMeta(ext.ErrorType, reflect.TypeOf(v).String())
 		if !cfg.noDebugStack {
-			if cfg.stackFrames == 0 {
-				s.setMeta(ext.ErrorStack, string(debug.Stack()))
-			} else {
-				s.setMeta(ext.ErrorStack, takeStacktrace(cfg.stackFrames, cfg.stackSkip))
-			}
+			s.setMeta(ext.ErrorStack, takeStacktrace(cfg.stackFrames, cfg.stackSkip))
 		}
 		switch v.(type) {
 		case xerrors.Formatter:
@@ -170,8 +165,15 @@ func (s *span) setTagError(value interface{}, cfg *errorConfig) {
 	}
 }
 
-// takeStacktrace takes stacktrace
+// defaultStackLength specifies the default maximum size of a stack trace.
+const defaultStackLength = 20
+
+// takeStacktrace takes a stack trace of maximum n entries, skipping the first skip entries.
+// If n is 0, up to 20 entries are retrieved.
 func takeStacktrace(n, skip uint) string {
+	if n == 0 {
+		n = defaultStackLength
+	}
 	var builder strings.Builder
 	pcs := make([]uintptr, n)
 


### PR DESCRIPTION
This change removes the usage of `debug.Stack` in favour of a custom implementation, which significantly improves performance.