### PR TITLE
profiler: WithAPIKey Warning, WithAgentlessUpload

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -159,6 +159,9 @@ func defaultConfig() (*config, error) {
 	if v := os.Getenv("DD_API_KEY"); v != "" {
 		WithAPIKey(v)(&c)
 	}
+	if v := os.Getenv("DD_PROFILING_AGENTLESS"); v == "true" {
+		WithAgentlessUpload()(&c)
+	}
 	if v := os.Getenv("DD_SITE"); v != "" {
 		WithSite(v)(&c)
 	}

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -77,7 +77,8 @@ var defaultClient = &http.Client{
 var defaultProfileTypes = []ProfileType{MetricsProfile, CPUProfile, HeapProfile}
 
 type config struct {
-	apiKey string
+	apiKey    string
+	agentless bool
 	// targetURL is the upload destination URL. It will be set by the profiler on start to either apiURL or agentURL
 	// based on the other options.
 	targetURL     string
@@ -209,12 +210,26 @@ func WithAgentAddr(hostport string) Option {
 	}
 }
 
-// WithAPIKey is deprecated and might be removed in future versions of this
-// package. It allows to skip the agent and talk to the Datadog API directly
-// using the provided API key.
+// WithAPIKey sets a datadog API key and enables agentless uploading by
+// default. This option takes precedence over the DD_API_KEY env variable.
+// WARNING: In the next release of this library setting an API Key will no
+// longer enable agentless uploading and default to agent based uploading
+// instead. If you don't have an agent running on the default localhost:8126
+// hostport you need to set it up, or use WithAgentAddr to specify the hostport
+// you are using. See WithAgentlessUpload for more information.
 func WithAPIKey(key string) Option {
 	return func(cfg *config) {
 		cfg.apiKey = key
+	}
+}
+
+// WithAgentlessUpload is currently for internal usage only and not officially
+// supported. You should not enable it unless somebody at Datadog instructed
+// you to do so. It allows to skip the agent and talk to the Datadog API
+// directly using the provided API key.
+func WithAgentlessUpload() Option {
+	return func(cfg *config) {
+		cfg.agentless = true
 	}
 }
 

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -82,6 +82,13 @@ func newProfiler(opts ...Option) (*profiler, error) {
 		if !isAPIKeyValid(cfg.apiKey) {
 			return nil, errors.New("API key has incorrect format")
 		}
+		if cfg.agentless {
+			log.Warn("profiler.WithAgentlessUpload is currently for internal usage only and not officially supported. You should not enable it unless somebody at Datadog instructed you to do so.")
+		} else {
+			// TODO(fg) once this has been released, make a new PR to default to agent
+			// based uploading unless agentless is explicitly configured.
+			log.Warn("The next version of this library might break your profiling integration. Please check the go documentation for profiler.WithAPIKey of the dd-trace-go version you are using for more information.")
+		}
 		cfg.targetURL = cfg.apiURL
 	} else {
 		cfg.targetURL = cfg.agentURL


### PR DESCRIPTION
@gbbr don't review this yet. We're still having internal discussions.

This pull request warns users of WithAPIKey that the option alone will
no longer enable agentless uploading by default in the future. It can
still be enabled via WithAgentlessUpload but this is discouraged and not
officially supported.