### PR TITLE
ddtrace/tracer: add noDebugStack to config when setting error tags

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -102,7 +102,9 @@ func (s *span) SetTag(key string, value interface{}) {
 	}
 	switch key {
 	case ext.Error:
-		s.setTagError(value, &errorConfig{})
+		s.setTagError(value, errorConfig{
+			noDebugStack: s.noDebugStack,
+		})
 		return
 	}
 	if v, ok := value.(bool); ok {
@@ -127,7 +129,7 @@ func (s *span) SetTag(key string, value interface{}) {
 
 // setTagError sets the error tag. It accounts for various valid scenarios.
 // This method is not safe for concurrent use.
-func (s *span) setTagError(value interface{}, cfg *errorConfig) {
+func (s *span) setTagError(value interface{}, cfg errorConfig) {
 	if s.finished {
 		return
 	}
@@ -280,7 +282,7 @@ func (s *span) Finish(opts ...ddtrace.FinishOption) {
 		}
 		if cfg.Error != nil {
 			s.Lock()
-			s.setTagError(cfg.Error, &errorConfig{
+			s.setTagError(cfg.Error, errorConfig{
 				noDebugStack: cfg.NoDebugStack,
 				stackFrames:  cfg.StackFrames,
 				stackSkip:    cfg.SkipStackFrames,

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -204,6 +204,22 @@ func TestSpanSetTag(t *testing.T) {
 	assert.Equal("false", span.Meta["some.other.bool"])
 }
 
+func TestSpanSetTagError(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("off", func(t *testing.T) {
+		span := newBasicSpan("web.request")
+		span.setTagError(errors.New("error value with no trace"), errorConfig{noDebugStack: true})
+		assert.Empty(span.Meta[ext.ErrorStack])
+	})
+
+	t.Run("on", func(t *testing.T) {
+		span := newBasicSpan("web.request")
+		span.setTagError(errors.New("error value with trace"), errorConfig{noDebugStack: false})
+		assert.NotEmpty(span.Meta[ext.ErrorStack])
+	})
+}
+
 func TestSpanSetDatadogTags(t *testing.T) {
 	assert := assert.New(t)
 

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -453,15 +453,22 @@ func TestTracerSpanGlobalTags(t *testing.T) {
 
 func TestTracerNoDebugStack(t *testing.T) {
 	assert := assert.New(t)
-	tracer := newTracer(WithDebugStack(false))
-	s := tracer.StartSpan("web.request").(*span)
-	err := errors.New("test error")
-	s.Finish(WithError(err))
 
-	assert.Equal(int32(1), s.Error)
-	assert.Equal("test error", s.Meta[ext.ErrorMsg])
-	assert.Equal("*errors.errorString", s.Meta[ext.ErrorType])
-	assert.Empty(s.Meta[ext.ErrorStack])
+	t.Run("Finish", func(t *testing.T) {
+		tracer := newTracer(WithDebugStack(false))
+		s := tracer.StartSpan("web.request").(*span)
+		err := errors.New("test error")
+		s.Finish(WithError(err))
+		assert.Empty(s.Meta[ext.ErrorStack])
+	})
+
+	t.Run("SetTag", func(t *testing.T) {
+		tracer := newTracer(WithDebugStack(false))
+		s := tracer.StartSpan("web.request").(*span)
+		err := errors.New("error value with no trace")
+		s.SetTag(ext.Error, err)
+		assert.Empty(s.Meta[ext.ErrorStack])
+	})
 }
 
 func TestNewSpan(t *testing.T) {


### PR DESCRIPTION
Sets `noDebugStack` option in `errorConfig` so that `setTagError` only adds debug stack traces when this option is set as false. Added tests to check if tags set as errors properly acknowledge the `noDebugStack` option set by `WithDebugStack()`.