### PR TITLE
ddtrace/opentracer: consider FollowsFrom references as children

### DIFF
--- a/ddtrace/opentracer/tracer.go
+++ b/ddtrace/opentracer/tracer.go
@@ -49,7 +49,9 @@ func (t *opentracer) StartSpan(operationName string, options ...opentracing.Star
 	}
 	opts := []ddtrace.StartSpanOption{tracer.StartTime(sso.StartTime)}
 	for _, ref := range sso.References {
-		if v, ok := ref.ReferencedContext.(ddtrace.SpanContext); ok && ref.Type == opentracing.ChildOfRef {
+		if v, ok := ref.ReferencedContext.(ddtrace.SpanContext); ok {
+			// opentracing.ChildOfRef and opentracing.FollowsFromRef will both be represented as
+			// children because Datadog APM does not have a concept of FollowsFrom references.
 			opts = append(opts, tracer.ChildOf(v))
 			break // can only have one parent
 		}


### PR DESCRIPTION
This change ensures that Opentracing spans using FollowsFrom references
will be considered as child spans.

Closes #376