### PR TITLE
profiler: Disable agentless mode for WithAPIKey

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -159,6 +159,9 @@ func defaultConfig() (*config, error) {
 	if v := os.Getenv("DD_API_KEY"); v != "" {
 		WithAPIKey(v)(&c)
 	}
+	if v := os.Getenv("DD_PROFILING_AGENTLESS"); v == "true" {
+		WithAgentlessUpload()(&c)
+	}
 	if v := os.Getenv("DD_SITE"); v != "" {
 		WithSite(v)(&c)
 	}

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -77,7 +77,8 @@ var defaultClient = &http.Client{
 var defaultProfileTypes = []ProfileType{MetricsProfile, CPUProfile, HeapProfile}
 
 type config struct {
-	apiKey string
+	apiKey    string
+	agentless bool
 	// targetURL is the upload destination URL. It will be set by the profiler on start to either apiURL or agentURL
 	// based on the other options.
 	targetURL     string
@@ -209,12 +210,26 @@ func WithAgentAddr(hostport string) Option {
 	}
 }
 
-// WithAPIKey is deprecated and might be removed in future versions of this
-// package. It allows to skip the agent and talk to the Datadog API directly
-// using the provided API key.
+// WithAPIKey sets a datadog API key and enables agentless uploading by
+// default. This option takes precedence over the DD_API_KEY env variable.
+// WARNING: In the next release of this library setting an API Key will no
+// longer enable agentless uploading and default to agent based uploading
+// instead. If you don't have an agent running on the default localhost:8126
+// hostport you need to set it up, or use WithAgentAddr to specify the hostport
+// you are using. See WithAgentlessUpload for more information.
 func WithAPIKey(key string) Option {
 	return func(cfg *config) {
 		cfg.apiKey = key
+	}
+}
+
+// WithAgentlessUpload is currently for internal usage only and not officially
+// supported. You should not enable it unless somebody at Datadog instructed
+// you to do so. It allows to skip the agent and talk to the Datadog API
+// directly using the provided API key.
+func WithAgentlessUpload() Option {
+	return func(cfg *config) {
+		cfg.agentless = true
 	}
 }
 

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -213,13 +213,13 @@ func WithAgentAddr(hostport string) Option {
 	}
 }
 
-// WithAPIKey sets a datadog API key and enables agentless uploading by
-// default. This option takes precedence over the DD_API_KEY env variable.
-// WARNING: In the next release of this library setting an API Key will no
-// longer enable agentless uploading and default to agent based uploading
-// instead. If you don't have an agent running on the default localhost:8126
-// hostport you need to set it up, or use WithAgentAddr to specify the hostport
-// you are using. See WithAgentlessUpload for more information.
+// WithAPIKey sets the Datadog API Key and takes precedence over the DD_API_KEY
+// env variable. Historically this option was used to enable agentless
+// uploading, but as of dd-trace-go v1.30.0 the behavior has changed to always
+// default to agent based uploading which doesn't require an API key. So if you
+// currently don't have an agent running on the default localhost:8126 hostport
+// you need to set it up, or use WithAgentAddr to specify the hostport location
+// of the agent. See WithAgentlessUpload for more information.
 func WithAPIKey(key string) Option {
 	return func(cfg *config) {
 		cfg.apiKey = key

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -18,6 +18,7 @@ import (
 	"time"
 	"unicode"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/version"
@@ -159,7 +160,7 @@ func defaultConfig() (*config, error) {
 	if v := os.Getenv("DD_API_KEY"); v != "" {
 		WithAPIKey(v)(&c)
 	}
-	if v := os.Getenv("DD_PROFILING_AGENTLESS"); v == "true" {
+	if internal.BoolEnv("DD_PROFILING_AGENTLESS", false) {
 		WithAgentlessUpload()(&c)
 	}
 	if v := os.Getenv("DD_SITE"); v != "" {

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -82,6 +82,13 @@ func newProfiler(opts ...Option) (*profiler, error) {
 		if !isAPIKeyValid(cfg.apiKey) {
 			return nil, errors.New("API key has incorrect format")
 		}
+		if cfg.agentless {
+			log.Warn("profiler.WithAgentlessUpload is currently for internal usage only and not officially supported. You should not enable it unless somebody at Datadog instructed you to do so.")
+		} else {
+			// TODO(fg) once this has been released, make a new PR to default to agent
+			// based uploading unless agentless is explicitly configured.
+			log.Warn("The next version of this library might break your profiling integration. Please check the go documentation for profiler.WithAPIKey of the dd-trace-go version you are using for more information.")
+		}
 		cfg.targetURL = cfg.apiURL
 	} else {
 		cfg.targetURL = cfg.agentURL

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -86,7 +86,7 @@ func newProfiler(opts ...Option) (*profiler, error) {
 		}
 		// Always warn people against using this mode for now. All customers should
 		// use agent based uploading at this point.
-		log.Warn("profiler.WithAgentlessUpload is currently for internal usage only and not officially supported. You should not enable it unless somebody at Datadog instructed you to do so.")
+		log.Warn("profiler.WithAgentlessUpload is currently for internal usage only and not officially supported.")
 		cfg.targetURL = cfg.apiURL
 	} else {
 		// Historically people could use an API Key to enable agentless uploading.

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -82,7 +82,7 @@ func newProfiler(opts ...Option) (*profiler, error) {
 	// WithAgentlessUpload can be used to enable it for testing and debugging.
 	if cfg.agentless {
 		if !isAPIKeyValid(cfg.apiKey) {
-			return nil, errors.New("profiler.WithAgentlessUpload requires a valid API key. Use profiler.WithAPIKey or the DD_API_KEY env variable to set it.")
+			return nil, errors.New("profiler.WithAgentlessUpload requires a valid API key. Use profiler.WithAPIKey or the DD_API_KEY env variable to set it")
 		}
 		// Always warn people against using this mode for now. All customers should
 		// use agent based uploading at this point.

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -58,13 +58,21 @@ func TestStart(t *testing.T) {
 		mu.Unlock()
 	})
 
-	t.Run("options/GoodAPIKey", func(t *testing.T) {
+	t.Run("options/GoodAPIKey/Agent", func(t *testing.T) {
+		err := Start(WithAPIKey("12345678901234567890123456789012"))
+		defer Stop()
+		assert.Nil(t, err)
+		assert.Equal(t, activeProfiler.cfg.agentURL, activeProfiler.cfg.targetURL)
+	})
+
+	t.Run("options/GoodAPIKey/Agentless", func(t *testing.T) {
 		err := Start(
 			WithAPIKey("12345678901234567890123456789012"),
 			WithAgentlessUpload(),
 		)
 		defer Stop()
 		assert.Nil(t, err)
+		assert.Equal(t, activeProfiler.cfg.apiURL, activeProfiler.cfg.targetURL)
 	})
 
 	t.Run("options/BadAPIKey", func(t *testing.T) {

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -59,13 +59,16 @@ func TestStart(t *testing.T) {
 	})
 
 	t.Run("options/GoodAPIKey", func(t *testing.T) {
-		err := Start(WithAPIKey("12345678901234567890123456789012"))
+		err := Start(
+			WithAPIKey("12345678901234567890123456789012"),
+			WithAgentlessUpload(),
+		)
 		defer Stop()
 		assert.Nil(t, err)
 	})
 
 	t.Run("options/BadAPIKey", func(t *testing.T) {
-		err := Start(WithAPIKey("aaaa"))
+		err := Start(WithAPIKey("aaaa"), WithAgentlessUpload())
 		defer Stop()
 		assert.NotNil(t, err)
 


### PR DESCRIPTION
This is a backwards incompatible change, but deemed neccessary by the
profiling team. Since it's been analyzed to only impact a tiny minority
of users, it's done without a major version change.

UPGRADING:

If you are currently using profiler.WithAPIKey() or DD_API_KEY to upload
profiling data, please remove this configuration. dd-trace-go will now
default to upload through the datadog agent running at localhost:8126.
If your agent is running on another port, please use
profiler.WithAgentAddr() to configure the correct agent address.

The new profiler.WithAgentlessUpload() is not officially supported for
anything other than debugging/testing when hitting integration issues.
If you think you need it for your production environment, please contact
our support.

BACKGROUND:

Historically the profiler only supported direct uploading to the backend
without using an agent, aka "agentless mode". This integration method
was succeeded by agent based uploading which should always be the
default behavior by now. The old agentless mode is not officially
supported anymore and only meant for testing and debugging at this
point.

Up until now setting an API Key via WithAPIKey or DD_API_KEY still
allowed users to opt into the agentless mode, but this is problematic
for two reasons:

1. A DD_API_KEY might be set in the environment for unrelated reasons or
   by accident.
2. The user may have forgotten switch their integration to agent
   uploading.

Users were warned against agentless uploading via a banner that was
shown from July 2020 to February 2021 and various email campaigns. It is
now time to make sure nobody is uploading via agentless mode in
production anymore.