### PR TITLE
contrib/Shopify/sarama: Fix possible deadlock in WrapAsyncProducer

### DIFF
--- a/contrib/Shopify/sarama/sarama.go
+++ b/contrib/Shopify/sarama/sarama.go
@@ -203,6 +203,7 @@ func WrapAsyncProducer(saramaConfig *sarama.Config, p sarama.AsyncProducer, opts
 	}
 	go func() {
 		spans := make(map[uint64]ddtrace.Span)
+		defer close(wrapped.input)
 		defer close(wrapped.successes)
 		defer close(wrapped.errors)
 		for {


### PR DESCRIPTION
The client can still write to the `input` channel after the goroutine created by `WrapAsyncProducer` was already shut down. Therefore the channel should be closed. Otherwise, it will deadlock.

For references, it initially fixed here: https://github.com/signalfx/signalfx-go-tracing/pull/128

I had some very dirty test to reproduce it locally but it is not worth putting to the codebase. The test was complex and the bug is pretty obvious.