### PR TITLE
contrib/database/sql.tracedConn doesn't implement driver.SessionResetter

### DIFF
--- a/contrib/database/sql/conn.go
+++ b/contrib/database/sql/conn.go
@@ -146,6 +146,9 @@ func (tc *tracedConn) CheckNamedValue(value *driver.NamedValue) error {
 	return driver.ErrSkip
 }
 
+var _ driver.SessionResetter = (*tracedConn)(nil)
+
+// ResetSession implements driver.SessionResetter
 func (tc *tracedConn) ResetSession(ctx context.Context) error {
 	if resetter, ok := tc.Conn.(driver.SessionResetter); ok {
 		return resetter.ResetSession(ctx)

--- a/contrib/database/sql/conn.go
+++ b/contrib/database/sql/conn.go
@@ -146,6 +146,13 @@ func (tc *tracedConn) CheckNamedValue(value *driver.NamedValue) error {
 	return driver.ErrSkip
 }
 
+func (tc *tracedConn) ResetSession(ctx context.Context) error {
+	if resetter, ok := tc.Conn.(driver.SessionResetter); ok {
+		return resetter.ResetSession(ctx)
+	}
+	return driver.ErrSkip
+}
+
 // traceParams stores all information related to tracing the driver.Conn
 type traceParams struct {
 	cfg        *config


### PR DESCRIPTION
There was an issue with go-mysql-driver that a connection returns an error "invalid connection."
article: https://github.blog/2020-05-20-three-bugs-in-the-go-mysql-driver/

And the author of the article fixed it https://github.com/go-sql-driver/mysql/pull/934.

If driver.SessionResetter is implemented, returns ErrBadConn instead of ErrInvalidConn, then it retries to establish a new connection again.

So I added ResetSession to tracedConn to avoid the error occurring.