### PR TITLE
README: Fix go get instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@
 
 ### Installing
 
-This module contains many packages, but most users should probably install the 3 packages below:
+This module contains many packages, but most users should probably install the two packages below:
 
 ```bash
 go get gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer
-go get gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer
 go get gopkg.in/DataDog/dd-trace-go.v1/profiler
 ```
 
@@ -27,8 +26,7 @@ Requires:
 
 ### Documentation
 
-The API is documented on [godoc](https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace) as well as Datadog's [official documentation](https://docs.datadoghq.com/tracing/setup/go/). If you are migrating
-from an older version of the tracer (e.g. 0.6.x) you may also find the [migration document](https://github.com/DataDog/dd-trace-go/blob/v1/MIGRATING.md) we've put together helpful.
+The API is documented on [godoc](https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace) as well as Datadog's official documentation for [Tracing Go Applications](https://docs.datadoghq.com/tracing/setup/go/) and the [Continuous Go Profiler](https://docs.datadoghq.com/tracing/profiler/getting_started/?code-lang=go). If you are migrating from an older version of the tracer (e.g. 0.6.x) you may also find the [migration document](https://github.com/DataDog/dd-trace-go/blob/v1/MIGRATING.md) we've put together helpful.
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,21 @@
 
 ### Installing
 
+This module contains many packages, but most users should probably install the 3 packages below:
+
 ```bash
 go get gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer
+go get gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer
+go get gopkg.in/DataDog/dd-trace-go.v1/profiler
 ```
+
+Additionally there are many [contrib](./contrib) packages that can be installed as needed like this:
+
+```
+go get gopkg.in/DataDog/dd-trace-go.v1/contrib/gorilla/mux
+```
+
+If you installed more packages than you intended, you can use `go mod tidy` to remove any unused packages.
 
 Requires:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### Installing
 
 ```bash
-go get gopkg.in/DataDog/dd-trace-go.v1/...
+go get gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer
 ```
 
 Requires:


### PR DESCRIPTION
Fixes #911

The grpc sub-pkg not compiling might still cause issues for some use
cases, but they are mostly related to local development. For our users
it's good enough to steer them away from the problem for now. But I'm
planning to come up with a solution for grpc as well.