### PR TITLE
internal/log: Improve API for testing

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -182,15 +182,24 @@ type DiscardLogger struct{}
 // Log implements ddtrace.Logger.
 func (d DiscardLogger) Log(msg string) {}
 
-// RecordLogger appends every call to Log() to Logs.
+// RecordLogger records every call to Log() and makes it available via Logs().
 type RecordLogger struct {
 	m    sync.Mutex
-	Logs []string
+	logs []string
 }
 
 // Log implements ddtrace.Logger.
 func (r *RecordLogger) Log(msg string) {
 	r.m.Lock()
 	defer r.m.Unlock()
-	r.Logs = append(r.Logs, msg)
+	r.logs = append(r.logs, msg)
+}
+
+// Logs returns the ordered list of logs recorded by the logger.
+func (r *RecordLogger) Logs() []string {
+	r.m.Lock()
+	defer r.m.Unlock()
+	copied := make([]string, len(r.logs))
+	copy(copied, r.logs)
+	return copied
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -36,15 +36,17 @@ var (
 	logger ddtrace.Logger = &defaultLogger{l: log.New(os.Stderr, "", log.LstdFlags)}
 )
 
-// UseLogger sets l as the active logger and returns the previously configured
-// logger.
-func UseLogger(l ddtrace.Logger) ddtrace.Logger {
+// UseLogger sets l as the active logger and returns a function to restore the
+// previous logger. The return value is mostly useful when testing.
+func UseLogger(l ddtrace.Logger) (undo func()) {
 	Flush()
 	mu.Lock()
 	defer mu.Unlock()
 	old := logger
 	logger = l
-	return old
+	return func() {
+		logger = old
+	}
 }
 
 // SetLevel sets the given lvl for logging.

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -62,8 +62,7 @@ func TestStart(t *testing.T) {
 
 	t.Run("options/GoodAPIKey/Agent", func(t *testing.T) {
 		rl := &log.RecordLogger{}
-		old := log.UseLogger(rl)
-		defer log.UseLogger(old)
+		defer log.UseLogger(rl)()
 
 		err := Start(WithAPIKey("12345678901234567890123456789012"))
 		defer Stop()
@@ -75,8 +74,7 @@ func TestStart(t *testing.T) {
 
 	t.Run("options/GoodAPIKey/Agentless", func(t *testing.T) {
 		rl := &log.RecordLogger{}
-		old := log.UseLogger(rl)
-		defer log.UseLogger(old)
+		defer log.UseLogger(rl)()
 
 		err := Start(
 			WithAPIKey("12345678901234567890123456789012"),

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -15,9 +15,10 @@ import (
 	"testing"
 	"time"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 )
 
 func TestStart(t *testing.T) {

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -68,8 +68,8 @@ func TestStart(t *testing.T) {
 		defer Stop()
 		assert.Nil(t, err)
 		assert.Equal(t, activeProfiler.cfg.agentURL, activeProfiler.cfg.targetURL)
-		assert.Equal(t, 1, len(rl.Logs))
-		assert.Contains(t, rl.Logs[0], "profiler.WithAPIKey")
+		assert.Equal(t, 1, len(rl.Logs()))
+		assert.Contains(t, rl.Logs()[0], "profiler.WithAPIKey")
 	})
 
 	t.Run("options/GoodAPIKey/Agentless", func(t *testing.T) {
@@ -84,8 +84,8 @@ func TestStart(t *testing.T) {
 		defer Stop()
 		assert.Nil(t, err)
 		assert.Equal(t, activeProfiler.cfg.apiURL, activeProfiler.cfg.targetURL)
-		assert.Equal(t, 1, len(rl.Logs))
-		assert.Contains(t, rl.Logs[0], "profiler.WithAgentlessUpload")
+		assert.Equal(t, 1, len(rl.Logs()))
+		assert.Contains(t, rl.Logs()[0], "profiler.WithAgentlessUpload")
 	})
 
 	t.Run("options/BadAPIKey", func(t *testing.T) {


### PR DESCRIPTION
I just noticed that d9472a0d caused the profiler package to always emit
some log output, regardless of `go test -v` being used or not. I'm very
sorry about this. IMO tests should never print to stdout unless
requested.

This patch is my attempt to fix this by making it easy for individual
tests to capture the log output (see UseLogger, RecordLogger). I've also
added DiscardLogger since it can be very convenient for tests that want
to ignore log output without capturing it. Arguably RecordLogger could
be used for this as well, but that would do a poor job of capturing the
intend of such code.