### PR TITLE
Mitigate go module issues using build tags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,25 @@ If you need to undo this for any reason, you can run:
 git update-index --no-assume-unchanged go.*
 ```
 
+Additionally there are some [known issues](https://github.com/DataDog/dd-trace-go/issues/911) caused by upstream modules not following semantic versioning. This means you're prone to see errors like this during local development:
+
+```
+$ go get -v ./...
+# gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc.v12
+contrib/google.golang.org/grpc.v12/grpc.go:61:11: undefined: metadata.FromContext
+contrib/google.golang.org/grpc.v12/grpc.go:92:13: undefined: metadata.FromContext
+contrib/google.golang.org/grpc.v12/grpc.go:97:9: undefined: metadata.NewContext
+# gopkg.in/DataDog/dd-trace-go.v1/contrib/cloud.google.com/go/pubsub.v1
+contrib/cloud.google.com/go/pubsub.v1/pubsub.go:34:33: msg.OrderingKey undefined (type *"cloud.google.com/go/pubsub".Message has no field or method OrderingKey)
+contrib/cloud.google.com/go/pubsub.v1/pubsub.go:97:34: msg.OrderingKey undefined (type *"cloud.google.com/go/pubsub".Message has no field or method OrderingKey)
+```
+
+We're working on a better solution to this problem, but for the meantime you can mitigate the problem by setting this in your local environment, perhaps using [direnv](https://direnv.net/):
+
+```
+export GOFLAGS="-tags=localdev $GOFLAGS"
+```
+
 ### Milestones
 
 The maintainers of this repository assign milestones to pull requests to classify them. `Triage` indicates that it is yet to be decided which version the change will go into. Pull requests that are ready get the upcoming release version assigned.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ contrib/cloud.google.com/go/pubsub.v1/pubsub.go:34:33: msg.OrderingKey undefined
 contrib/cloud.google.com/go/pubsub.v1/pubsub.go:97:34: msg.OrderingKey undefined (type *"cloud.google.com/go/pubsub".Message has no field or method OrderingKey)
 ```
 
-We're working on a better solution to this problem, but for the meantime you can mitigate the problem by setting this in your local environment, perhaps using [direnv](https://direnv.net/):
+We're working on a better solution to this problem, but in the meantime you can mitigate the problem by setting this in your local environment, perhaps using [direnv](https://direnv.net/):
 
 ```
 export GOFLAGS="-tags=localdev $GOFLAGS"

--- a/contrib/cloud.google.com/go/pubsub.v1/example_test.go
+++ b/contrib/cloud.google.com/go/pubsub.v1/example_test.go
@@ -1,3 +1,5 @@
+// +build !localdev
+
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).

--- a/contrib/cloud.google.com/go/pubsub.v1/pubsub.go
+++ b/contrib/cloud.google.com/go/pubsub.v1/pubsub.go
@@ -1,3 +1,5 @@
+// +build !localdev
+
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).

--- a/contrib/cloud.google.com/go/pubsub.v1/pubsub_test.go
+++ b/contrib/cloud.google.com/go/pubsub.v1/pubsub_test.go
@@ -1,3 +1,5 @@
+// +build !localdev
+
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).

--- a/contrib/google.golang.org/grpc.v12/example_test.go
+++ b/contrib/google.golang.org/grpc.v12/example_test.go
@@ -1,3 +1,5 @@
+// +build !localdev
+
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).

--- a/contrib/google.golang.org/grpc.v12/grpc.go
+++ b/contrib/google.golang.org/grpc.v12/grpc.go
@@ -1,3 +1,5 @@
+// +build !localdev
+
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).

--- a/contrib/google.golang.org/grpc.v12/grpc_test.go
+++ b/contrib/google.golang.org/grpc.v12/grpc_test.go
@@ -1,3 +1,5 @@
+// +build !localdev
+
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).

--- a/contrib/google.golang.org/grpc.v12/option.go
+++ b/contrib/google.golang.org/grpc.v12/option.go
@@ -1,3 +1,5 @@
+// +build !localdev
+
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).

--- a/contrib/google.golang.org/grpc.v12/tags.go
+++ b/contrib/google.golang.org/grpc.v12/tags.go
@@ -1,3 +1,5 @@
+// +build !localdev
+
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).


### PR DESCRIPTION
This patch adds build tags and information in CONTRIBUTING.md to reduce
the pain for contributors until we can find a better solution to #911.

I don't consider this a long term fix, but this is probably better than
nothing until we can come up with a better solution.

edit: added a picture below that shows the default experience VS Code users will have in Go 1.16 without solving this issue:

![image](https://user-images.githubusercontent.com/15000/117156602-27ea7380-adbe-11eb-94a2-e077e8d96be7.png)
