### PR TITLE
profiler: Fix infinite loop in maxPauseNs

### DIFF
--- a/profiler/metrics.go
+++ b/profiler/metrics.go
@@ -104,13 +104,14 @@ func maxPauseNs(stats *runtime.MemStats, periodStart time.Time) (max uint64) {
 	// stats.PauseNs is a circular buffer of recent GC pause times in nanoseconds.
 	// The most recent pause is indexed by (stats.NumGC+255)%256
 
-	for i := stats.NumGC + 255; i >= stats.NumGC; i-- {
+	for i := 0; i < 256; i++ {
+		offset := (int(stats.NumGC) + 255 - i) % 256
 		// Stop searching if we find a PauseEnd outside the period
-		if time.Unix(0, int64(stats.PauseEnd[i%256])).Before(periodStart) {
+		if time.Unix(0, int64(stats.PauseEnd[offset])).Before(periodStart) {
 			break
 		}
-		if stats.PauseNs[i%256] > max {
-			max = stats.PauseNs[i%256]
+		if stats.PauseNs[offset] > max {
+			max = stats.PauseNs[offset]
 		}
 	}
 	return max


### PR DESCRIPTION
I noticed this issue when running the TestProfilerInternal test by
itself, which consistently produced the following error:

```
$ go test ./profiler -run TestProfilerInternal
--- FAIL: TestProfilerInternal (0.20s)
    --- FAIL: TestProfilerInternal/collect (0.20s)
        profiler_test.go:189: missing batch
FAIL
FAIL	gopkg.in/DataDog/dd-trace-go.v1/profiler	0.395s
```

The reason for this timeout is that the loop inside of maxPauseNs was
not hitting its termination conditions when stats.NumGC is 0. The reason
for this is subtle:

- i is uint32, so it will always be <= 0
- periodStart is "1729-02-04" when running the metrics profile for the first
  time. This is caused by another issue which will be addressed in a
  follow-up patch.

As far as I can tell this issue should not occur in the real world
because the periodStart will not be 1729 after `profiler.run` resets the
metrics collectedAt timestamp.