### PR TITLE
internal/version: bump to v1.31.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,4 +8,4 @@ package version
 // Tag specifies the current release tag. It needs to be manually
 // updated. A test checks that the value of Tag never points to a
 // git tag that is older than HEAD.
-const Tag = "v1.31.0"
+const Tag = "v1.31.1"


### PR DESCRIPTION
A tag of version v1.31.0 was made in error, so we will release v1.31.1 with what has been merged since v1.30.0 to fix this situation.