### PR TITLE
profiler: goroutineswait saw-stop mechanism

### DIFF
--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -233,7 +233,7 @@ func goroutineProfile(cfg *config) (*profile, error) {
 
 func goroutineWaitProfile(cfg *config) (*profile, error) {
 	if n := runtime.NumGoroutine(); n > cfg.maxGoroutinesWait {
-		return nil, fmt.Errorf("%d goroutines exceeds DD_PROFILING_WAIT_PROFILE_MAX_GOROUTINES limit of %d", n, cfg.maxGoroutinesWait)
+		return nil, fmt.Errorf("skipping goroutines wait profile: %d goroutines exceeds DD_PROFILING_WAIT_PROFILE_MAX_GOROUTINES limit of %d", n, cfg.maxGoroutinesWait)
 	}
 
 	var (

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"runtime"
 	"runtime/pprof"
 	"time"
 
@@ -231,6 +232,10 @@ func goroutineProfile(cfg *config) (*profile, error) {
 }
 
 func goroutineWaitProfile(cfg *config) (*profile, error) {
+	if n := runtime.NumGoroutine(); n > cfg.maxGoroutinesWait {
+		return nil, fmt.Errorf("%d goroutines exceeds DD_PROFILING_WAIT_PROFILE_MAX_GOROUTINES limit of %d", n, cfg.maxGoroutinesWait)
+	}
+
 	var (
 		text  = &bytes.Buffer{}
 		pprof = &bytes.Buffer{}

--- a/profiler/profile_test.go
+++ b/profiler/profile_test.go
@@ -170,7 +170,7 @@ main.main()
 		})
 	})
 
-	t.Run("goroutineswait DD_PROFILING_WAIT_PROFILE_MAX_GOROUTINES", func(t *testing.T) {
+	t.Run("goroutineswaitLimit", func(t *testing.T) {
 		// spawGoroutines spawns n goroutines and then returns a func to stop them.
 		spawnGoroutines := func(n int) func() {
 			launched := make(chan struct{})

--- a/profiler/profile_test.go
+++ b/profiler/profile_test.go
@@ -171,16 +171,19 @@ main.main()
 	})
 
 	t.Run("goroutineswaitLimit", func(t *testing.T) {
-		// spawGoroutines spawns n goroutines and then returns a func to stop them.
+		// spawGoroutines spawns n goroutines, waits for them to start executing,
+		// and then returns a func to stop them. For more details about `executing`
+		// see:
+		// https://github.com/DataDog/dd-trace-go/pull/942#discussion_r656924335
 		spawnGoroutines := func(n int) func() {
-			launched := make(chan struct{})
+			executing := make(chan struct{})
 			stopped := make(chan struct{})
 			for i := 0; i < n; i++ {
 				go func() {
-					launched <- struct{}{}
+					executing <- struct{}{}
 					stopped <- struct{}{}
 				}()
-				<-launched
+				<-executing
 			}
 			return func() {
 				for i := 0; i < n; i++ {

--- a/profiler/profile_test.go
+++ b/profiler/profile_test.go
@@ -177,17 +177,17 @@ main.main()
 		// https://github.com/DataDog/dd-trace-go/pull/942#discussion_r656924335
 		spawnGoroutines := func(n int) func() {
 			executing := make(chan struct{})
-			stopped := make(chan struct{})
+			stopping := make(chan struct{})
 			for i := 0; i < n; i++ {
 				go func() {
 					executing <- struct{}{}
-					stopped <- struct{}{}
+					stopping <- struct{}{}
 				}()
 				<-executing
 			}
 			return func() {
 				for i := 0; i < n; i++ {
-					<-stopped
+					<-stopping
 				}
 			}
 		}

--- a/profiler/profile_test.go
+++ b/profiler/profile_test.go
@@ -209,7 +209,7 @@ main.main()
 		require.NoError(t, err)
 		_, err = p.runProfile(expGoroutineWaitProfile)
 		var errRoutines, errLimit int
-		msg := "%d goroutines exceeds DD_PROFILING_WAIT_PROFILE_MAX_GOROUTINES limit of %d"
+		msg := "skipping goroutines wait profile: %d goroutines exceeds DD_PROFILING_WAIT_PROFILE_MAX_GOROUTINES limit of %d"
 		fmt.Sscanf(err.Error(), msg, &errRoutines, &errLimit)
 		require.GreaterOrEqual(t, errRoutines, goroutines)
 		require.Equal(t, limit, errLimit)


### PR DESCRIPTION
This is a safety mechanism for the new goroutineWaitProfile that
automatically disables the profile if the number of goroutines is too
high in order to avoid excessive stop-the-world pauses.

The default limit is 1000 which is somewhat arbitrary and should limit
STW pauses to ~30ms. It can be overwritten with
DD_PROFILING_WAIT_PROFILE_MAX_GOROUTINES.

WARNING: The goroutineWaitProfile is still experimental and not meant to
be used by users outside of datadog.

Fixes PROF-3234