### PR TITLE
contrib/net/http: add WithIgnoreRequest option

### DIFF
--- a/contrib/net/http/http.go
+++ b/contrib/net/http/http.go
@@ -39,6 +39,10 @@ func NewServeMux(opts ...Option) *ServeMux {
 // We only need to rewrite this function to be able to trace
 // all the incoming requests to the underlying multiplexer
 func (mux *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if mux.cfg.ignoreRequest(r) {
+		mux.ServeMux.ServeHTTP(w, r)
+		return
+	}
 	// get the resource associated to this request
 	_, route := mux.Handler(r)
 	resource := r.Method + " " + route

--- a/contrib/net/http/http_test.go
+++ b/contrib/net/http/http_test.go
@@ -201,6 +201,40 @@ func TestAnalyticsSettings(t *testing.T) {
 	}
 }
 
+func TestIgnoreRequestOption(t *testing.T) {
+	tests := []struct {
+		url       string
+		spanCount int
+	}{
+		{
+			url:       "/skip",
+			spanCount: 0,
+		},
+		{
+			url:       "/200",
+			spanCount: 1,
+		},
+	}
+	mux := NewServeMux(WithIgnoreRequest(func(req *http.Request) bool {
+		return req.URL.Path == "/skip"
+	}))
+	mux.HandleFunc("/skip", handler200)
+	mux.HandleFunc("/200", handler200)
+
+	for _, test := range tests {
+		t.Run(test.url, func(t *testing.T) {
+			mt := mocktracer.Start()
+			defer mt.Stop()
+			r := httptest.NewRequest("GET", "http://localhost"+test.url, nil)
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, r)
+
+			spans := mt.FinishedSpans()
+			assert.Equal(t, test.spanCount, len(spans))
+		})
+	}
+}
+
 func router() http.Handler {
 	mux := NewServeMux(WithServiceName("my-service"), WithSpanOptions(tracer.Tag("foo", "bar")))
 	mux.HandleFunc("/200", handler200)

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -21,6 +21,7 @@ type config struct {
 	analyticsRate float64
 	spanOpts      []ddtrace.StartSpanOption
 	finishOpts    []ddtrace.FinishOption
+	ignoreRequest func(*http.Request) bool
 }
 
 // MuxOption has been deprecated in favor of Option.
@@ -42,6 +43,15 @@ func defaults(cfg *config) {
 	cfg.spanOpts = []ddtrace.StartSpanOption{tracer.Measured()}
 	if !math.IsNaN(cfg.analyticsRate) {
 		cfg.spanOpts = append(cfg.spanOpts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
+	}
+	cfg.ignoreRequest = func(_ *http.Request) bool { return false }
+}
+
+// WithIgnoreRequest holds the function to use for determining if the
+// incoming HTTP request tracing should be skipped.
+func WithIgnoreRequest(f func(*http.Request) bool) MuxOption {
+	return func(cfg *config) {
+		cfg.ignoreRequest = f
 	}
 }
 


### PR DESCRIPTION
This PR add option to skip endpoints for net/http

Fixed: https://github.com/DataDog/dd-trace-go/issues/947