### PR TITLE
codecov.yml: Decrease target coverage to 90%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,7 +14,7 @@ coverage:
           - contrib
     patch:
       default:
-        target: 100%
+        target: 90%
 
 flags:
   core:


### PR DESCRIPTION
Based on what other Datadog teams are doing, and [recommendations from industry leaders like Google](https://testing.googleblog.com/2020/08/code-coverage-best-practices.html), we should reduce our coverage requirement to 90%.

Fixes #954 