### PR TITLE
.circleci: pin github.com/hashicorp/consul/api to v1.8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,8 @@ jobs:
             go get k8s.io/client-go@v0.17.0
             go get k8s.io/apimachinery@v0.17.0
             go get cloud.google.com/go/pubsub@v1.6.1
-            go get github.com/hashicorp/consul/api@v1.8.1 // Temporarily enforce this version. 1.9.0 is incompatible with go < 1.16
+            # Temporarily enforce this version. 1.9.0 is incompatible with go < 1.16
+            go get github.com/hashicorp/consul/api@v1.8.1
 
       - run:
           name: Wait for MySQL

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,7 @@ jobs:
             go get k8s.io/client-go@v0.17.0
             go get k8s.io/apimachinery@v0.17.0
             go get cloud.google.com/go/pubsub@v1.6.1
+            go get github.com/hashicorp/consul/api@v1.8.1 // Temporarily enforce this version. 1.9.0 is incompatible with go < 1.16
 
       - run:
           name: Wait for MySQL


### PR DESCRIPTION
github.com/hashicorp/consul/api@v1.9.0 has broken compatibility with
versions of go less than 1.16. For now, we are pinning this to the previous
release, v1.8.1, until the issue is resolved.

See: hashicorp/consul#10470