### PR TITLE
circleci: record junit test results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ plain-go114: &plain-go114
     - image: circleci/golang:1.14
       environment:
         GOPATH: "/home/circleci/go"
+  environment: # environment variables for the build itself
+    TEST_RESULTS: /tmp/test-results # path to where test results will be saved
 
 jobs:
   go1.12-build:
@@ -80,6 +82,13 @@ jobs:
           command: |
             PACKAGE_NAMES=$(go list ./... | grep -v /contrib/ | circleci tests split --split-by=timings --timings-type=classname)
             gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- $PACKAGE_NAMES -v -race -coverprofile=coverage.txt -covermode=atomic
+
+      - store_artifacts: # upload test summary for display in Artifacts
+          path: /tmp/test-results
+          destination: raw-test-output
+
+      - store_test_results: # upload test results for display in Test Summary
+          path: /tmp/test-results
 
       - run:
           name: Upload coverage report to Codecov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,12 @@ jobs:
 
     steps:
       - checkout
+      - run: mkdir -p $TEST_RESULTS
       - run:
           name: Testing
-          command: go test -v -race -coverprofile=coverage.txt -covermode=atomic `go list ./... | grep -v /contrib/`
+          command: |
+            PACKAGE_NAMES=$(go list ./... | grep -v /contrib/ | circleci tests split --split-by=timings --timings-type=classname)
+            gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- $PACKAGE_NAMES -v -race -coverprofile=coverage.txt -covermode=atomic
 
       - run:
           name: Upload coverage report to Codecov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,11 +77,19 @@ jobs:
     steps:
       - checkout
       - run: mkdir -p $TEST_RESULTS
+      - restore_cache: # restores saved cache if no changes are detected since last run
+          keys:
+            - go-mod-v4-{{ checksum "go.sum" }}
       - run:
           name: Testing
           command: |
             PACKAGE_NAMES=$(go list ./... | grep -v /contrib/ | circleci tests split --split-by=timings --timings-type=classname)
             gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- $PACKAGE_NAMES -v -race -coverprofile=coverage.txt -covermode=atomic
+
+      - save_cache:
+          key: go-mod-v4-{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
 
       - store_artifacts: # upload test summary for display in Artifacts
           path: /tmp/test-results
@@ -145,6 +153,9 @@ jobs:
     steps:
       - checkout
       - run: mkdir -p $TEST_RESULTS
+      - restore_cache: # restores saved cache if no changes are detected since last run
+          keys:
+            - go-mod-v4-{{ checksum "go.sum" }}
 
       - restore_cache:
           keys:
@@ -215,6 +226,11 @@ jobs:
           command: |
             PACKAGE_NAMES=$(go list ./contrib/... | grep -v -e grpc.v12 -e google.golang.org/api | circleci tests split --split-by=timings --timings-type=classname)
             gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- $PACKAGE_NAMES -v -race -coverprofile=coverage.txt -covermode=atomic
+
+      - save_cache:
+          key: go-mod-v4-{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
 
       - store_artifacts: # upload test summary for display in Artifacts
           path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,7 @@ jobs:
 
     steps:
       - checkout
+      - run: mkdir -p $TEST_RESULTS
 
       - restore_cache:
           keys:
@@ -210,7 +211,15 @@ jobs:
       - run:
           name: Testing integrations
           command: |
-                INTEGRATION=1 go test -v -race -coverprofile=coverage.txt -covermode=atomic `go list ./contrib/... | grep -v -e grpc.v12 -e google.golang.org/api`
+            PACKAGE_NAMES=$(go list ./contrib/... | grep -v -e grpc.v12 -e google.golang.org/api | circleci tests split --split-by=timings --timings-type=classname)
+            gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- $PACKAGE_NAMES -v -race -coverprofile=coverage.txt -covermode=atomic
+
+      - store_artifacts: # upload test summary for display in Artifacts
+          path: /tmp/test-results
+          destination: raw-test-output
+
+      - store_test_results: # upload test results for display in Test Summary
+          path: /tmp/test-results
 
       - run:
           name: Testing outlier google.golang.org/api

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,6 @@ plain-go114: &plain-go114
     - image: circleci/golang:1.14
       environment:
         GOPATH: "/home/circleci/go"
-  environment: # environment variables for the build itself
-    TEST_RESULTS: /tmp/test-results # path to where test results will be saved
 
 jobs:
   go1.12-build:
@@ -72,6 +70,8 @@ jobs:
 
   test-core:
     resource_class: xlarge
+    environment: # environment variables for the build itself
+      TEST_RESULTS: /tmp/test-results # path to where test results will be saved
     <<: *plain-go114
 
     steps:
@@ -97,6 +97,8 @@ jobs:
 
   test-contrib:
     resource_class: xlarge
+    environment: # environment variables for the build itself
+      TEST_RESULTS: /tmp/test-results # path to where test results will be saved
     working_directory: /home/circleci/dd-trace-go.v1
     docker:
       - image: circleci/golang:1.14

--- a/contrib/gofiber/fiber.v2/fiber.go
+++ b/contrib/gofiber/fiber.v2/fiber.go
@@ -43,7 +43,6 @@ func Middleware(opts ...Option) func(c *fiber.Ctx) error {
 		opts = append(opts, cfg.spanOpts...)
 		span, _ := tracer.StartSpanFromContext(c.Context(), "http.request", opts...)
 
-		fmt.Printf("Starting Span\n")
 		defer span.Finish()
 
 		resourceName := c.Path()

--- a/contrib/gofiber/fiber.v2/fiber.go
+++ b/contrib/gofiber/fiber.v2/fiber.go
@@ -43,7 +43,7 @@ func Middleware(opts ...Option) func(c *fiber.Ctx) error {
 		opts = append(opts, cfg.spanOpts...)
 		span, _ := tracer.StartSpanFromContext(c.Context(), "http.request", opts...)
 
-		fmt.Printf("Starting Span")
+		fmt.Printf("Starting Span\n")
 		defer span.Finish()
 
 		resourceName := c.Path()


### PR DESCRIPTION
This PR enables circle CI's [Collecting Test Metadata](https://circleci.com/docs/2.0/collect-test-data/) feature by producing JUnit XML. It's modeled after their [Language Guide: Go](https://circleci.com/docs/2.0/language-go/) docs.

The motivation behind this is to get [insights](https://circleci.com/blog/using-insights-to-discover-flaky-slow-and-failed-tests/) into flaky tests and to avoid having to scroll through the huge test result log output when a test fails. An example of this can be seen below or by following [this link](https://app.circleci.com/pipelines/github/DataDog/dd-trace-go/1509/workflows/058deb2d-8d99-4188-885c-2979cc3b9f7c/jobs/10249).

<img width="1500" alt="2021-06-28 Google Chrome test-core (10249) - DataDogdd-trace-go - 18-53-10" src="https://user-images.githubusercontent.com/15000/123674676-29766c00-d842-11eb-9064-c88501cfe19c.png">

<img width="1509" alt="2021-06-28 Google Chrome test-core (10249) - DataDogdd-trace-go - 18-53-24" src="https://user-images.githubusercontent.com/15000/123674682-2c715c80-d842-11eb-9594-b705778f3763.png">

FWIW the [Insights](https://app.circleci.com/insights/github/DataDog/dd-trace-go/workflows/build-and-test/tests?branch=felix.geisendoerfer%252Fcircle-ci-test-results&reporting-window=last-7-days) don't seem to work yet. I don't know if this will fix itself once we merge this or if there is another problem.

<img width="1041" alt="2021-06-28 Google Chrome Insights - DataDogdd-trace-goworkflowsbuild-and-test - 19-18-04" src="https://user-images.githubusercontent.com/15000/123677588-98a18f80-d845-11eb-8cc7-e765a5782563.png">
