### PR TITLE
profiler: fix hanging on Stop()

### DIFF
--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -118,7 +118,7 @@ func (p *profiler) runProfile(t ProfileType) (*profile, error) {
 	case HeapProfile:
 		return heapProfile(p.cfg)
 	case CPUProfile:
-		return cpuProfile(p.cfg)
+		return p.cpuProfile()
 	case MutexProfile:
 		return mutexProfile(p.cfg)
 	case BlockProfile:
@@ -159,17 +159,17 @@ var (
 	stopCPUProfile = pprof.StopCPUProfile
 )
 
-func cpuProfile(cfg *config) (*profile, error) {
+func (p *profiler) cpuProfile() (*profile, error) {
 	var buf bytes.Buffer
 	start := now()
 	if err := startCPUProfile(&buf); err != nil {
 		return nil, err
 	}
-	time.Sleep(cfg.cpuDuration)
+	p.interruptibleSleep(p.cfg.cpuDuration)
 	stopCPUProfile()
 	end := now()
-	tags := append(cfg.tags, CPUProfile.Tag())
-	cfg.statsd.Timing("datadog.profiler.go.collect_time", end.Sub(start), tags, 1)
+	tags := append(p.cfg.tags, CPUProfile.Tag())
+	p.cfg.statsd.Timing("datadog.profiler.go.collect_time", end.Sub(start), tags, 1)
 	return &profile{
 		name: CPUProfile.Filename(),
 		data: buf.Bytes(),

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -45,7 +45,8 @@ func Start(opts ...Option) error {
 	return nil
 }
 
-// Stop stops the profiler.
+// Stop cancels any ongoing profiling or upload operations and returns after
+// everything has been stopped.
 func Stop() {
 	mu.Lock()
 	if activeProfiler != nil {

--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -30,12 +30,18 @@ func (p *profiler) upload(bat batch) error {
 	statsd := p.cfg.statsd
 	var err error
 	for i := 0; i < maxRetries; i++ {
+		select {
+		case <-p.exit:
+			return nil
+		default:
+		}
+
 		err = p.doRequest(bat)
 		if rerr, ok := err.(*retriableError); ok {
 			statsd.Count("datadog.profiler.go.upload_retry", 1, nil, 1)
 			wait := time.Duration(rand.Int63n(p.cfg.period.Nanoseconds()))
 			log.Error("Uploading profile failed: %v. Trying again in %s...", rerr, wait)
-			time.Sleep(wait)
+			p.interruptibleSleep(time.Second)
 			continue
 		}
 		if err != nil {
@@ -70,9 +76,17 @@ func (p *profiler) doRequest(bat batch) error {
 	if err != nil {
 		return err
 	}
+	funcExit := make(chan struct{})
+	defer close(funcExit)
 	// uploadTimeout is guaranteed to be >= 0, see newProfiler.
 	ctx, cancel := context.WithTimeout(context.Background(), p.cfg.uploadTimeout)
-	defer cancel()
+	go func() {
+		select {
+		case <-p.exit:
+		case <-funcExit:
+		}
+		cancel()
+	}()
 	// TODO(fg) use NewRequestWithContext once go 1.12 support is dropped.
 	req, err := http.NewRequest("POST", p.cfg.targetURL, body)
 	if err != nil {


### PR DESCRIPTION
This PR fixes several issues that can cause the profiler's Stop() function to hang and delay the graceful shutdown of a client application. See https://github.com/DataDog/dd-trace-go/issues/960 for a user experiencing this type of problem.