### PR TITLE
contrib/nats.io/nats.go: initial support for nats.io

### DIFF
--- a/contrib/nats.io/nats.go/example_test.go
+++ b/contrib/nats.io/nats.go/example_test.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+package nats
+
+import (
+	"context"
+	"fmt"
+
+	natstrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/nats.io/nats.go"
+
+	"github.com/nats-io/nats.go"
+)
+
+func Example() {
+	// Open a regular connection onto your NATS server
+	nc, err := nats.Connect("nats://127.0.0.1:4222")
+	if err != nil {
+		panic(err)
+	}
+
+	// Wrap it
+	wnc := natstrace.WrapConn(nc)
+
+	// Subscribe to a topic
+	s, err := wnc.SubscribeSync("mytopic")
+	if err != nil {
+		panic(err)
+	}
+	defer s.Drain()
+
+	// Echo messages published in the subscribed topic
+	go func() {
+		for {
+			msgs, err := s.Fetch(context.TODO(), 1)
+			if err != nil {
+				panic(err)
+			}
+
+			for _, msg := range msgs {
+				fmt.Printf("received message %v", msg.Data)
+			}
+		}
+	}()
+
+	// Publish a message to the topic
+	err = wnc.PublishMsg(context.TODO(), &nats.Msg{
+		Subject: "mytopic",
+		Data:    []byte("coucou"),
+	})
+	if err != nil {
+		panic(err)
+	}
+}

--- a/contrib/nats.io/nats.go/nats.go
+++ b/contrib/nats.io/nats.go/nats.go
@@ -1,0 +1,198 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+// Package nats provides functions to trace the github.com/nats-io/nats.go package.
+package nats
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+
+	"github.com/nats-io/nats.go"
+)
+
+type Conn struct {
+	*nats.Conn
+	cfg wrapConfig
+}
+
+type Subscription struct {
+	*nats.Subscription
+	cfg wrapConfig
+}
+
+type Msg struct {
+	*nats.Msg
+	cfg wrapConfig
+}
+
+// WrapConn wraps a *nats.Conn so that all requests are traced using the
+// default tracer with the service name "nats".
+func WrapConn(conn *nats.Conn, opts ...WrapOption) (c *Conn) {
+	cfg := newWrapConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	return &Conn{
+		Conn: conn,
+		cfg:  cfg,
+	}
+}
+
+// WrapSubscription wraps a *nats.Subscription so that all requests are traced using the
+// default tracer with the service name "nats".
+func (c *Conn) WrapSubscription(subscription *nats.Subscription) (s *Subscription) {
+	return &Subscription{
+		Subscription: subscription,
+		cfg:          c.cfg,
+	}
+}
+
+// startSpanFromContext starts a span from a context.
+func startSpanFromContext(ctx context.Context, resourceName, serviceName string) ddtrace.Span {
+	span, _ := tracer.StartSpanFromContext(ctx, operationName, []ddtrace.StartSpanOption{
+		tracer.SpanType(ext.AppTypeRPC),
+		tracer.ServiceName(serviceName),
+		tracer.ResourceName(resourceName),
+	}...)
+	return span
+}
+
+// StartSpanFromMsg starts a span based on a Msg headers.
+func StartSpanFromMsg(msg *Msg, resourceName string) ddtrace.Span {
+	traceHeaders := map[string]string{}
+	re := regexp.MustCompile(`^_dd_apm_`)
+	for k, v := range msg.Header {
+		fmt.Println(k, v)
+		if re.MatchString(k) {
+			traceHeaders[strings.Replace(k, "_dd_apm_", "", 1)] = strings.Join(v, ",")
+		}
+	}
+
+	parentSpan, err := tracer.Extract(tracer.TextMapCarrier(traceHeaders))
+	if err != nil {
+		// Start a span from a new context instead
+		span, _ := tracer.StartSpanFromContext(context.Background(), operationName, []ddtrace.StartSpanOption{
+			tracer.SpanType(ext.AppTypeRPC),
+			tracer.ServiceName(msg.cfg.serviceName),
+			tracer.ResourceName(resourceName),
+		}...)
+		return span
+	}
+
+	return tracer.StartSpan(
+		operationName,
+		tracer.SpanType(ext.AppTypeRPC),
+		tracer.ServiceName(msg.cfg.serviceName),
+		tracer.ResourceName(resourceName),
+		tracer.ChildOf(parentSpan),
+	)
+}
+
+// injectTracingHeadersIntoNatsMsg adds span tracing context into a *nats.Msg as headers.
+func injectTracingHeadersIntoNatsMsg(span ddtrace.Span, msg *nats.Msg) (err error) {
+	traceHeaders := map[string]string{}
+	if err = tracer.Inject(span.Context(), tracer.TextMapCarrier(traceHeaders)); err != nil {
+		return
+	}
+
+	if msg.Header == nil {
+		msg.Header = nats.Header{}
+	}
+
+	for k, v := range traceHeaders {
+		msg.Header.Add(fmt.Sprintf("_dd_apm_%s", k), v)
+	}
+	return
+}
+
+// PublishMsg invokes and traces *nats.Conn.PublishMsg().
+func (c *Conn) PublishMsg(ctx context.Context, msg *nats.Msg) (err error) {
+	span := startSpanFromContext(ctx, "publish", c.cfg.serviceName)
+	defer span.Finish(tracer.WithError(err))
+
+	_ = injectTracingHeadersIntoNatsMsg(span, msg)
+	err = c.Conn.PublishMsg(msg)
+	return
+}
+
+// RequestMsg invokes and traces *nats.Conn.RequestMsg().
+func (c *Conn) RequestMsg(ctx context.Context, msg *nats.Msg, timeout time.Duration) (resp *Msg, err error) {
+	span := startSpanFromContext(ctx, "request", c.cfg.serviceName)
+	defer span.Finish(tracer.WithError(err))
+
+	_ = injectTracingHeadersIntoNatsMsg(span, msg)
+	resp = &Msg{cfg: c.cfg}
+	resp.Msg, err = c.Conn.RequestMsg(msg, timeout)
+	return
+}
+
+// RequestMsgWithContext invokes and traces *nats.Conn.RequestMsgWithContext().
+func (c *Conn) RequestMsgWithContext(ctx context.Context, msg *nats.Msg) (resp *Msg, err error) {
+	span := startSpanFromContext(ctx, "request", c.cfg.serviceName)
+	defer span.Finish(tracer.WithError(err))
+
+	_ = injectTracingHeadersIntoNatsMsg(span, msg)
+	resp = &Msg{cfg: c.cfg}
+	resp.Msg, err = c.Conn.RequestMsgWithContext(ctx, msg)
+	return
+}
+
+// SubscribeSync invokes *nats.Conn.SubscribeSync() and returns a traceable *Subscription.
+func (c *Conn) SubscribeSync(subj string) (s *Subscription, err error) {
+	var subscription *nats.Subscription
+	subscription, err = c.Conn.SubscribeSync(subj)
+	s = c.WrapSubscription(subscription)
+	return
+}
+
+// RespondMsg invokes and traces *nats.Msg.RespondMsg().
+func (m *Msg) RespondMsg(msg *nats.Msg) (err error) {
+	span := StartSpanFromMsg(m, "msg.respond")
+	defer span.Finish(tracer.WithError(err))
+
+	_ = injectTracingHeadersIntoNatsMsg(span, msg)
+	err = m.Msg.RespondMsg(msg)
+	return
+}
+
+// Fetch invokes and traces *nats.Subscription.Fetch().
+func (s *Subscription) Fetch(ctx context.Context, batch int, opts ...nats.PullOpt) (msgs []*Msg, err error) {
+	span := startSpanFromContext(ctx, "subscription.fetch", s.cfg.serviceName)
+	defer span.Finish(tracer.WithError(err))
+
+	var fetchedMsgs []*nats.Msg
+	fetchedMsgs, err = s.Subscription.Fetch(batch, opts...)
+	for _, msg := range fetchedMsgs {
+		msgs = append(msgs, &Msg{
+			Msg: msg,
+			cfg: s.cfg,
+		})
+	}
+
+	return
+}
+
+// NextMsg invokes and traces *nats.Subscription.NextMsg().
+func (s *Subscription) NextMsg(ctx context.Context, timeout time.Duration) (msg *Msg, err error) {
+	span := startSpanFromContext(ctx, "subscription.nextmsg", s.cfg.serviceName)
+	defer span.Finish(tracer.WithError(err))
+
+	var nextMsg *nats.Msg
+	nextMsg, err = s.Subscription.NextMsg(timeout)
+	msg = &Msg{
+		Msg: nextMsg,
+		cfg: s.cfg,
+	}
+	return
+}

--- a/contrib/nats.io/nats.go/nats_test.go
+++ b/contrib/nats.io/nats.go/nats_test.go
@@ -1,0 +1,121 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+package nats
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	natsd "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+)
+
+var (
+	conn        *nats.Conn
+	wrappedConn *Conn
+)
+
+func TestMain(m *testing.M) {
+	natsURL, _ := url.Parse("nats://127.0.0.1:4223")
+	natsPort, _ := strconv.Atoi(natsURL.Port())
+
+	s, err := natsd.NewServer(&natsd.Options{
+		Host:    natsURL.Hostname(),
+		Port:    natsPort,
+		LogFile: "/dev/stdout",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	go s.Start()
+
+	if !s.ReadyForConnections(10 * time.Second) {
+		panic("nats server didn't start")
+	}
+
+	conn, err = nats.Connect(natsURL.String())
+	if err != nil {
+		panic(err)
+	}
+
+	wrappedConn = WrapConn(conn, WithServiceName("natstest"))
+	defer wrappedConn.Close()
+
+	os.Exit(m.Run())
+}
+
+func validateSpanGenerics(t *testing.T, span mocktracer.Span, resourceName string) {
+	assert.Equal(t, "natstest", span.Tag(ext.ServiceName))
+	assert.Equal(t, "nats.query", span.OperationName())
+	assert.Equal(t, resourceName, span.Tag(ext.ResourceName))
+}
+
+func TestPublishMsg(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	err := wrappedConn.PublishMsg(context.Background(), &nats.Msg{
+		Subject: "foo",
+		Data:    []byte("bar"),
+	})
+	assert.NoError(t, err)
+
+	spans := mt.FinishedSpans()
+	assert.Len(t, spans, 1)
+	validateSpanGenerics(t, spans[0], "publish")
+}
+
+func TestRequestMsg(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	s, err := wrappedConn.SubscribeSync("request_respond")
+	if err != nil {
+		panic(err)
+	}
+	defer s.Drain()
+
+	go func(t *testing.T) {
+		msg, err := s.NextMsg(context.Background(), 5*time.Second)
+		require.NoError(t, err)
+		require.NotNil(t, msg)
+		//require.NotNil(t, msg.Msg)
+
+		err = msg.RespondMsg(&nats.Msg{
+			Data: []byte("baz"),
+		})
+		assert.NoError(t, err)
+	}(t)
+
+	resp, err := wrappedConn.RequestMsg(
+		context.Background(),
+		&nats.Msg{
+			Subject: "request_respond",
+			Data:    []byte("bar"),
+		},
+		time.Second,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotNil(t, resp.Msg)
+
+	spans := mt.FinishedSpans()
+	assert.Len(t, spans, 3)
+	validateSpanGenerics(t, spans[0], "subscription.nextmsg")
+	validateSpanGenerics(t, spans[1], "msg.respond")
+	validateSpanGenerics(t, spans[2], "request")
+	assert.Equal(t, spans[1].ParentID(), spans[2].TraceID())
+}

--- a/contrib/nats.io/nats.go/option.go
+++ b/contrib/nats.io/nats.go/option.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+package nats
+
+const (
+	serviceName   = "nats"
+	operationName = "nats.query"
+)
+
+type wrapConfig struct {
+	serviceName string
+}
+
+func newWrapConfig() wrapConfig {
+	return wrapConfig{
+		serviceName: serviceName,
+	}
+}
+
+// WrapOption represents an option that can be used to create or wrap a client.
+type WrapOption func(*wrapConfig)
+
+// WithServiceName sets the given service name for the wrapped resource.
+func WithServiceName(name string) WrapOption {
+	return func(cfg *wrapConfig) {
+		cfg.serviceName = name
+	}
+}


### PR DESCRIPTION
This commit adds initial support for https://github.com/nats-io/nats.go client.
Already known limitations:
  - No JetStream support
  - No EncodedConn support