### PR TITLE
ddtrace/tracer: Don't drop trace if some spans must be kept

### DIFF
--- a/ddtrace/tracer/sampler.go
+++ b/ddtrace/tracer/sampler.go
@@ -292,7 +292,6 @@ func (rs *rulesSampler) apply(span *span) bool {
 	var matched bool
 	rate := rs.globalRate
 	for _, rule := range rs.rules {
-		fmt.Println("try match", rule.exactService, rule.exactName, span.Service, span.Name)
 		if rule.match(span) {
 			matched = true
 			rate = rule.Rate

--- a/ddtrace/tracer/sampler.go
+++ b/ddtrace/tracer/sampler.go
@@ -292,6 +292,7 @@ func (rs *rulesSampler) apply(span *span) bool {
 	var matched bool
 	rate := rs.globalRate
 	for _, rule := range rs.rules {
+		fmt.Println("try match", rule.exactService, rule.exactName, span.Service, span.Name)
 		if rule.match(span) {
 			matched = true
 			rate = rule.Rate

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -373,7 +373,11 @@ func (s *span) finish(finishTime int64) {
 		// client sampling enabled. This will lead to inexact APM metrics but reduces performance impact.
 		keep = false
 	}
-	s.context.finish(keep)
+	if keep {
+		// a single kept span keeps the whole trace.
+		s.context.trace.keep()
+	}
+	s.context.finish()
 }
 
 // newAggregableSpan creates a new summary for the span s, within an application

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -360,13 +360,6 @@ func (s *span) finish(finishTime int64) {
 		if feats.DropP0s {
 			// the agent supports dropping p0's in the client
 			keep = shouldKeep(s)
-			if keep {
-				// ...and this span can be dropped
-				atomic.AddUint64(&t.droppedP0Spans, 1)
-				if s == s.context.trace.root {
-					atomic.AddUint64(&t.droppedP0Traces, 1)
-				}
-			}
 		}
 	}
 	if s.context.drop {

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -416,7 +416,7 @@ func shouldKeep(s *span) bool {
 	if v, ok := s.Metrics[ext.EventSampleRate]; ok {
 		return sampledByRate(s.TraceID, v)
 	}
-	return true
+	return false
 }
 
 // shouldComputeStats mentions whether this span needs to have stats computed for.

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -362,10 +362,6 @@ func (s *span) finish(finishTime int64) {
 			keep = shouldKeep(s)
 		}
 	}
-	if s.context.drop {
-		// client sampling enabled. This will lead to inexact APM metrics but reduces performance impact.
-		keep = false
-	}
 	if keep {
 		// a single kept span keeps the whole trace.
 		s.context.trace.keep()

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -107,26 +107,26 @@ func TestShouldDrop(t *testing.T) {
 		rate   float64
 		want   bool
 	}{
-		{1, 0, 0, false},
-		{2, 1, 0, false},
-		{0, 1, 0, false},
-		{0, 0, 1, false},
-		{0, 0, 0.5, false},
-		{0, 0, 0.00001, true},
-		{0, 0, 0, true},
+		{1, 0, 0, true},
+		{2, 1, 0, true},
+		{0, 1, 0, true},
+		{0, 0, 1, true},
+		{0, 0, 0.5, true},
+		{0, 0, 0.00001, false},
+		{0, 0, 0, false},
 	} {
 		t.Run("", func(t *testing.T) {
 			s := newSpan("", "", "", 1, 1, 0)
 			s.SetTag(ext.SamplingPriority, tt.prio)
 			s.SetTag(ext.EventSampleRate, tt.rate)
 			atomic.StoreInt64(&s.context.errors, tt.errors)
-			assert.Equal(t, shouldDrop(s), tt.want)
+			assert.Equal(t, shouldKeep(s), tt.want)
 		})
 	}
 
 	t.Run("none", func(t *testing.T) {
 		s := newSpan("", "", "", 1, 1, 0)
-		assert.Equal(t, shouldDrop(s), true)
+		assert.Equal(t, shouldKeep(s), false)
 	})
 }
 

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -254,7 +254,7 @@ func (t *trace) finishedOne(s *span, keep bool) {
 		t.spans = nil
 		t.finished = 0 // important, because a buffer can be used for several flushes
 	}()
-	if !keep {
+	if !t.keep {
 		return
 	}
 	if tr, ok := internal.GetGlobalTracer().(*tracer); ok {

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -177,8 +177,7 @@ func newTrace() *trace {
 	return &trace{spans: make([]*span, 0, traceStartSize)}
 }
 
-// returns the sampling priority of the trace. Not thread safe.
-func (t *trace) samplingPriorityUnsafe() (p int, ok bool) {
+func (t *trace) samplingPriorityLocked() (p int, ok bool) {
 	if t.priority == nil {
 		return 0, false
 	}
@@ -188,7 +187,7 @@ func (t *trace) samplingPriorityUnsafe() (p int, ok bool) {
 func (t *trace) samplingPriority() (p int, ok bool) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	return t.samplingPriorityUnsafe()
+	return t.samplingPriorityLocked()
 }
 
 func (t *trace) setSamplingPriority(p float64) {
@@ -284,7 +283,7 @@ func (t *trace) finishedOne(s *span) {
 	atomic.AddInt64(&tr.spansFinished, int64(len(t.spans)))
 	sd := samplingDecision(atomic.LoadInt64((*int64)(&t.samplingDecision)))
 	if sd != decisionKeep {
-		if p, ok := t.samplingPriorityUnsafe(); ok && p == ext.PriorityAutoReject {
+		if p, ok := t.samplingPriorityLocked(); ok && p == ext.PriorityAutoReject {
 			atomic.AddUint64(&tr.droppedP0Spans, uint64(len(t.spans)))
 			atomic.AddUint64(&tr.droppedP0Traces, 1)
 		}

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -25,7 +25,7 @@ type spanContext struct {
 
 	trace  *trace // reference to the trace that this span belongs too
 	span   *span  // reference to the span that hosts this context
-	drop   bool   // when true, the span will not be sent to the agent
+	drop   bool   // when true, the span will not be sent to the agent, even when not computing stats in the tracer.
 	errors int64  // number of spans with errors in this trace
 
 	// the below group should propagate cross-process
@@ -126,7 +126,7 @@ func (c *spanContext) baggageItem(key string) string {
 }
 
 // finish marks this span as finished in the trace.
-func (c *spanContext) finish() { c.trace.finishedOne(c.span) }
+func (c *spanContext) finish(keep bool) { c.trace.finishedOne(c.span, keep) }
 
 // trace contains shared context information about a trace, such as sampling
 // priority, the root reference and a buffer of the spans which are part of the
@@ -138,6 +138,7 @@ type trace struct {
 	full     bool         // signifies that the span buffer is full
 	priority *float64     // sampling priority
 	locked   bool         // specifies if the sampling priority can be altered
+	keep bool             // keep indicates whether to send the trace to the agent or no.
 
 	// root specifies the root of the trace, if known; it is nil when a span
 	// context is extracted from a carrier, at which point there are no spans in
@@ -225,7 +226,7 @@ func (t *trace) push(sp *span) {
 // finishedOne aknowledges that another span in the trace has finished, and checks
 // if the trace is complete, in which case it calls the onFinish function. It uses
 // the given priority, if non-nil, to mark the root span.
-func (t *trace) finishedOne(s *span) {
+func (t *trace) finishedOne(s *span, keep bool) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.full {
@@ -234,6 +235,9 @@ func (t *trace) finishedOne(s *span) {
 		// be accurate and would trigger a pre-mature flush, exposing us
 		// to a race condition where spans can be modified while flushing.
 		return
+	}
+	if keep {
+		t.keep = true
 	}
 	t.finished++
 	if s == t.root && t.priority != nil {
@@ -246,11 +250,16 @@ func (t *trace) finishedOne(s *span) {
 	if len(t.spans) != t.finished {
 		return
 	}
+	defer func() {
+		t.spans = nil
+		t.finished = 0 // important, because a buffer can be used for several flushes
+	}()
+	if !keep {
+		return
+	}
 	if tr, ok := internal.GetGlobalTracer().(*tracer); ok {
 		// we have a tracer that can receive completed traces.
 		tr.pushTrace(t.spans)
 		atomic.AddInt64(&tr.spansFinished, int64(len(t.spans)))
 	}
-	t.spans = nil
-	t.finished = 0 // important, because a buffer can be used for several flushes
 }

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -304,17 +304,22 @@ func TestSpanContextParent(t *testing.T) {
 			baggage:    map[string]string{"A": "A", "B": "B"},
 			hasBaggage: 1,
 			trace:      newTrace(),
-			drop:       true,
 		},
-		"nil-trace": &spanContext{
-			drop: true,
-		},
+		"nil-trace": &spanContext{},
 		"priority": &spanContext{
 			baggage:    map[string]string{"A": "A", "B": "B"},
 			hasBaggage: 1,
 			trace: &trace{
 				spans:    []*span{newBasicSpan("abc")},
 				priority: func() *float64 { v := new(float64); *v = 2; return v }(),
+			},
+		},
+		"sampling_decision": &spanContext{
+			baggage:    map[string]string{"A": "A", "B": "B"},
+			hasBaggage: 1,
+			trace: &trace{
+				spans:            []*span{newBasicSpan("abc")},
+				samplingDecision: decisionForceKeep,
 			},
 		},
 		"origin": &spanContext{
@@ -334,8 +339,8 @@ func TestSpanContextParent(t *testing.T) {
 			assert.Contains(ctx.trace.spans, s)
 			if parentCtx.trace != nil {
 				assert.Equal(ctx.trace.priority, parentCtx.trace.priority)
+				assert.Equal(ctx.trace.samplingDecision, parentCtx.trace.samplingDecision)
 			}
-			assert.Equal(parentCtx.drop, ctx.drop)
 			assert.Equal(parentCtx.baggage, ctx.baggage)
 			assert.Equal(parentCtx.origin, ctx.origin)
 		})

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -319,7 +319,7 @@ func TestSpanContextParent(t *testing.T) {
 			hasBaggage: 1,
 			trace: &trace{
 				spans:            []*span{newBasicSpan("abc")},
-				samplingDecision: decisionForceKeep,
+				samplingDecision: decisionKeep,
 			},
 		},
 		"origin": &spanContext{

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -481,14 +481,13 @@ const sampleRateMetricKey = "_sample_rate"
 
 // Sample samples a span with the internal sampler.
 func (t *tracer) sample(span *span) {
-	// this condition is true for all spans except the local root span.
 	if _, ok := span.context.samplingPriority(); ok {
 		// sampling decision was already made
 		return
 	}
 	sampler := t.config.sampler
 	if !sampler.Sample(span) {
-		span.context.drop = true
+		span.context.trace.drop()
 		return
 	}
 	if rs, ok := sampler.(RateSampler); ok && rs.Rate() < 1 {

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -481,6 +481,7 @@ const sampleRateMetricKey = "_sample_rate"
 
 // Sample samples a span with the internal sampler.
 func (t *tracer) sample(span *span) {
+	// this condition is true for all spans except the local root span.
 	if _, ok := span.context.samplingPriority(); ok {
 		// sampling decision was already made
 		return

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -239,7 +239,7 @@ func TestTracerStartSpan(t *testing.T) {
 }
 
 func TestP0Dropping(t *testing.T) {
-	t.Run("p0 are kept by default", func(t *testing.T) {
+	t.Run("sampled", func(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
 		tracer.prioritySampling.defaultRate = 0
@@ -252,7 +252,7 @@ func TestP0Dropping(t *testing.T) {
 		assert.True(t, span.context.trace.kept)
 	})
 
-	t.Run("p0 are dropped when DropP0s flag is on", func(t *testing.T) {
+	t.Run("dropped", func(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
 		tracer.features.DropP0s = true
@@ -266,7 +266,7 @@ func TestP0Dropping(t *testing.T) {
 		assert.False(t, span.context.trace.kept)
 	})
 
-	t.Run("p0 are kept if at least one span should be kept", func(t *testing.T) {
+	t.Run("events_sampled", func(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
 		tracer.features.DropP0s = true

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -236,6 +236,16 @@ func TestTracerStartSpan(t *testing.T) {
 		child := tracer.StartSpan("home/user", Measured(), ChildOf(parent.context)).(*span)
 		assert.Equal(t, 1.0, child.Metrics[keyMeasured])
 	})
+
+	t.Run("sampling_priority", func(t *testing.T) {
+		tracer := newTracer()
+		tracer.config.serviceName = "test_service"
+		tracer.rulesSampling.rules = append(tracer.rulesSampling.rules, SamplingRule{exactService: "test_service", exactName: "web.request", Rate: 1})
+		span := tracer.StartSpan("web.request").(*span)
+		assert.Equal(t, float64(ext.PriorityAutoKeep), span.Metrics[keySamplingPriority])
+		priority, _ := span.context.samplingPriority()
+		assert.Equal(t, 1, priority)
+	})
 }
 
 func TestTracerRuntimeMetrics(t *testing.T) {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -249,7 +249,7 @@ func TestSamplingDecision(t *testing.T) {
 		child.Finish()
 		span.Finish()
 		assert.Equal(t, float64(ext.PriorityAutoReject), span.Metrics[keySamplingPriority])
-		assert.Equal(t, decisionForceKeep, span.context.trace.samplingDecision)
+		assert.Equal(t, decisionKeep, span.context.trace.samplingDecision)
 	})
 
 	t.Run("dropped", func(t *testing.T) {
@@ -263,7 +263,7 @@ func TestSamplingDecision(t *testing.T) {
 		child.Finish()
 		span.Finish()
 		assert.Equal(t, float64(ext.PriorityAutoReject), span.Metrics[keySamplingPriority])
-		assert.Equal(t, decisionDefaultDrop, span.context.trace.samplingDecision)
+		assert.Equal(t, decisionNone, span.context.trace.samplingDecision)
 	})
 
 	t.Run("events_sampled", func(t *testing.T) {
@@ -278,7 +278,7 @@ func TestSamplingDecision(t *testing.T) {
 		child.Finish()
 		span.Finish()
 		assert.Equal(t, float64(ext.PriorityAutoReject), span.Metrics[keySamplingPriority])
-		assert.Equal(t, decisionForceKeep, span.context.trace.samplingDecision)
+		assert.Equal(t, decisionKeep, span.context.trace.samplingDecision)
 	})
 
 	t.Run("client_dropped", func(t *testing.T) {
@@ -294,7 +294,7 @@ func TestSamplingDecision(t *testing.T) {
 		child.Finish()
 		span.Finish()
 		assert.Equal(t, float64(ext.PriorityAutoReject), span.Metrics[keySamplingPriority])
-		assert.Equal(t, decisionForceDrop, span.context.trace.samplingDecision)
+		assert.Equal(t, decisionDrop, span.context.trace.samplingDecision)
 	})
 }
 


### PR DESCRIPTION
The current behavior is:
Drop the trace except if all spans should be kept.

This doesn't work if:
1. a downstream span has no error, is closed (so should be dropped) but then the rest of the trace ends up having an error so should be kept.
2. a span should be kept for app analytics (event sampling), but the trace is a p0 so the whole trace is dropped.

The PR inverses the behavior:
Keep the trace except if all spans should be dropped.
