### PR TITLE
Added TraceID into StartSpanOption

### DIFF
--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -120,8 +120,12 @@ type StartSpanConfig struct {
 	Tags map[string]interface{}
 
 	// Force-set the SpanID, rather than use a random number. If no Parent SpanContext is present,
-	// then this will also set the TraceID to the same value.
+	// then this will also set the TraceID to the same value (if there is some no TraceID in config).
 	SpanID uint64
+
+	// Force-set the TraceID, rather than use a random number. If no Parent SpanContext is present,
+	// then this will also set from the SpanID to the same value.
+	TraceID uint64
 }
 
 // Logger implementations are able to log given messages that the tracer might output.

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -511,11 +511,18 @@ func Measured() StartSpanOption {
 }
 
 // WithSpanID sets the SpanID on the started span, instead of using a random number.
-// If there is no parent Span (eg from ChildOf), then the TraceID will also be set to the
-// value given here.
+// If there is no parent Span (eg from ChildOf)
 func WithSpanID(id uint64) StartSpanOption {
 	return func(cfg *ddtrace.StartSpanConfig) {
 		cfg.SpanID = id
+	}
+}
+
+// WithTraceID sets the TraceID on the started span, instead of using a random number.
+// If there is no parent Span (eg from ChildOf)
+func WithTraceID(id uint64) StartSpanOption {
+	return func(cfg *ddtrace.StartSpanConfig) {
+		cfg.TraceID = id
 	}
 }
 

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -379,17 +379,21 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 			context = ctx
 		}
 	}
-	id := opts.SpanID
-	if id == 0 {
-		id = random.Uint64()
+	spanID := opts.SpanID
+	if spanID == 0 {
+		spanID = random.Uint64()
+	}
+	traceID := opts.TraceID
+	if traceID == 0 {
+		traceID = spanID
 	}
 	// span defaults
 	span := &span{
 		Name:         operationName,
 		Service:      t.config.serviceName,
 		Resource:     operationName,
-		SpanID:       id,
-		TraceID:      id,
+		SpanID:       spanID,
+		TraceID:      traceID,
 		Start:        startTime,
 		taskEnd:      startExecutionTracerTask(operationName),
 		noDebugStack: t.config.noDebugStack,


### PR DESCRIPTION
When there are several tracing systems, it's important to have custom TraceID, like SpanID in StartSpanOption