### PR TITLE
Add default service name to gorm and sql

### DIFF
--- a/contrib/database/sql/option.go
+++ b/contrib/database/sql/option.go
@@ -9,6 +9,7 @@ import (
 	"math"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
 type config struct {
@@ -32,6 +33,9 @@ func defaults(cfg *config) {
 		cfg.analyticsRate = 1.0
 	} else {
 		cfg.analyticsRate = math.NaN()
+	}
+	if svc := globalconfig.ServiceName(); svc != "" {
+		cfg.serviceName = svc + ".db"
 	}
 }
 

--- a/contrib/jinzhu/gorm/option.go
+++ b/contrib/jinzhu/gorm/option.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 
 	"github.com/jinzhu/gorm"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
 type config struct {
@@ -25,7 +26,11 @@ type config struct {
 type Option func(*config)
 
 func defaults(cfg *config) {
-	cfg.serviceName = "gorm.db"
+	if svc := globalconfig.ServiceName(); svc != "" {
+		cfg.serviceName = svc + ".db"
+	} else {
+		cfg.serviceName = "gorm.db"
+	}
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
 	if internal.BoolEnv("DD_TRACE_GORM_ANALYTICS_ENABLED", false) {
 		cfg.analyticsRate = 1.0


### PR DESCRIPTION
Use globalconfig to set proper and default service name in gorm and sql contrib.

Update:
Today the default name for this service is `gorm.db` and  `driver.db`.
These default names only make sense if one service use these services. However, when multiple start using gorm or the same driver it looks like multiple services are using the same databases.
This change would allow to create one db service per service.