### PR TITLE
ddtrace/tracer: remove the waitClose mechanism

### DIFF
--- a/ddtrace/tracer/payload.go
+++ b/ddtrace/tracer/payload.go
@@ -43,9 +43,6 @@ type payload struct {
 
 	// buf holds the sequence of msgpack-encoded items.
 	buf bytes.Buffer
-
-	// closed specifies the notification channel for each Close call.
-	closed chan struct{}
 }
 
 var _ io.Reader = (*payload)(nil)
@@ -55,7 +52,6 @@ func newPayload() *payload {
 	p := &payload{
 		header: make([]byte, 8),
 		off:    8,
-		closed: make(chan struct{}, 1),
 	}
 	return p
 }
@@ -81,16 +77,22 @@ func (p *payload) size() int {
 	return p.buf.Len() + len(p.header) - p.off
 }
 
-// reset resets the internal buffer, counter and read offset.
+// reset should *not* be used. It is not implemented and is only here to serve
+// as information on how to implement it in case the same payload object ever
+// needs to be reused.
 func (p *payload) reset() {
-	p.off = 8
-	atomic.StoreUint64(&p.count, 0)
-	p.buf.Reset()
-	select {
-	case <-p.closed:
-		// ensure there is room
-	default:
-	}
+	// ⚠️  Warning!
+	//
+	// Resetting the payload for re-use requires the transport to wait for the
+	// HTTP package to Close the request body before attempting to re-use it
+	// again! This requires additional logic to be in place. See:
+	//
+	// • https://github.com/golang/go/blob/go1.16/src/net/http/client.go#L136-L138
+	// • https://github.com/DataDog/dd-trace-go/pull/475
+	// • https://github.com/DataDog/dd-trace-go/pull/549
+	// • https://github.com/DataDog/dd-trace-go/pull/976
+	//
+	panic("not implemented")
 }
 
 // https://github.com/msgpack/msgpack/blob/master/spec.md#array-format-family
@@ -118,20 +120,6 @@ func (p *payload) updateHeader() {
 		p.off = 3
 	}
 }
-
-// Close implements io.Closer
-func (p *payload) Close() error {
-	select {
-	case p.closed <- struct{}{}:
-	default:
-		// ignore subsequent Close calls
-	}
-	return nil
-}
-
-// waitClose blocks until the first Close call occurs since the payload
-// was constructed or the last reset happened.
-func (p *payload) waitClose() { <-p.closed }
 
 // Read implements io.Reader. It reads from the msgpack-encoded stream.
 func (p *payload) Read(b []byte) (n int, err error) {

--- a/ddtrace/tracer/payload_test.go
+++ b/ddtrace/tracer/payload_test.go
@@ -33,11 +33,10 @@ func newSpanList(n int) spanList {
 // the codec.
 func TestPayloadIntegrity(t *testing.T) {
 	assert := assert.New(t)
-	p := newPayload()
 	want := new(bytes.Buffer)
 	for _, n := range []int{10, 1 << 10, 1 << 17} {
 		t.Run(strconv.Itoa(n), func(t *testing.T) {
-			p.reset()
+			p := newPayload()
 			lists := make(spanLists, n)
 			for i := 0; i < n; i++ {
 				list := newSpanList(i%5 + 1)
@@ -61,10 +60,9 @@ func TestPayloadIntegrity(t *testing.T) {
 // be decoded by the codec.
 func TestPayloadDecode(t *testing.T) {
 	assert := assert.New(t)
-	p := newPayload()
 	for _, n := range []int{10, 1 << 10} {
 		t.Run(strconv.Itoa(n), func(t *testing.T) {
-			p.reset()
+			p := newPayload()
 			for i := 0; i < n; i++ {
 				p.push(newSpanList(i%5 + 1))
 			}
@@ -95,7 +93,6 @@ func benchmarkPayloadThroughput(count int) func(*testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			p.reset()
 			for p.size() < payloadMaxLimit {
 				p.push(trace)
 			}

--- a/ddtrace/tracer/payload_test.go
+++ b/ddtrace/tracer/payload_test.go
@@ -80,7 +80,8 @@ func BenchmarkPayloadThroughput(b *testing.B) {
 }
 
 // benchmarkPayloadThroughput benchmarks the throughput of the payload by subsequently
-// pushing a trace containing count spans of approximately 10KB in size each.
+// pushing a trace containing count spans of approximately 10KB in size each, until the
+// payload is filled.
 func benchmarkPayloadThroughput(count int) func(*testing.B) {
 	return func(b *testing.B) {
 		p := newPayload()
@@ -92,7 +93,14 @@ func benchmarkPayloadThroughput(count int) func(*testing.B) {
 		}
 		b.ReportAllocs()
 		b.ResetTimer()
+		reset := func() {
+			p.header = make([]byte, 8)
+			p.off = 8
+			p.count = 0
+			p.buf.Reset()
+		}
 		for i := 0; i < b.N; i++ {
+			reset()
 			for p.size() < payloadMaxLimit {
 				p.push(trace)
 			}

--- a/ddtrace/tracer/transport.go
+++ b/ddtrace/tracer/transport.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -139,7 +138,7 @@ func (t *httpTransport) sendStats(p *statsPayload) error {
 }
 
 func (t *httpTransport) send(p *payload) (body io.ReadCloser, err error) {
-	req, err := http.NewRequest("POST", t.traceURL, ioutil.NopCloser(p))
+	req, err := http.NewRequest("POST", t.traceURL, p)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create http request: %v", err)
 	}

--- a/ddtrace/tracer/transport.go
+++ b/ddtrace/tracer/transport.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -138,7 +139,7 @@ func (t *httpTransport) sendStats(p *statsPayload) error {
 }
 
 func (t *httpTransport) send(p *payload) (body io.ReadCloser, err error) {
-	req, err := http.NewRequest("POST", t.traceURL, p)
+	req, err := http.NewRequest("POST", t.traceURL, ioutil.NopCloser(p))
 	if err != nil {
 		return nil, fmt.Errorf("cannot create http request: %v", err)
 	}
@@ -165,7 +166,6 @@ func (t *httpTransport) send(p *payload) (body io.ReadCloser, err error) {
 	if err != nil {
 		return nil, err
 	}
-	p.waitClose()
 	if code := response.StatusCode; code >= 400 {
 		// error, check the body for context information and
 		// return a nice error.

--- a/ddtrace/tracer/writer.go
+++ b/ddtrace/tracer/writer.go
@@ -81,6 +81,8 @@ func (h *agentTraceWriter) flush() {
 	}
 	h.wg.Add(1)
 	h.climit <- struct{}{}
+	oldp := h.payload
+	h.payload = newPayload()
 	go func(p *payload) {
 		defer func(start time.Time) {
 			<-h.climit
@@ -100,8 +102,7 @@ func (h *agentTraceWriter) flush() {
 				h.config.statsd.Incr("datadog.tracer.decode_error", nil, 1)
 			}
 		}
-	}(h.payload)
-	h.payload = newPayload()
+	}(oldp)
 }
 
 // logWriter specifies the output target of the logTraceWriter; replaced in tests.


### PR DESCRIPTION
This change removes the `(*payload).waitClose` mechanism added in #475
because it is no longer necessary since #549, where we've stopped
reusing payloads and started sending them async.

The change also removes the `(*payload).reset` method implementation to
further emphasise that this type of use is discouraged.

See also https://github.com/golang/go/blob/go1.16/src/net/http/client.go#L136-L138

Fixes #971