### PR TITLE
checkcopyright: accept year, year range, year list

### DIFF
--- a/checkcopyright.go
+++ b/checkcopyright.go
@@ -9,18 +9,19 @@
 package main
 
 import (
-	"bytes"
-	"fmt"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
 func main() {
 	var missing bool
-	copyrightText := []byte(fmt.Sprintf("// Copyright 2016 Datadog, Inc."))
+	// copyrightRegexp matches years or year ranges like "2016", "2016-2019",
+	// "2016,2018-2020" in the copyright header.
+	copyrightRegexp := regexp.MustCompile(`// Copyright [0-9]{4}[0-9,\-]* Datadog, Inc.`)
 	if err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -39,7 +40,7 @@ func main() {
 		if err != nil && err != io.EOF {
 			return err
 		}
-		if !bytes.Contains(snip, copyrightText) {
+		if !copyrightRegexp.Match(snip) {
 			// report missing header
 			missing = true
 			log.Printf("Copyright header missing in %q.\n", path)

--- a/checkcopyright.go
+++ b/checkcopyright.go
@@ -21,7 +21,7 @@ func main() {
 	var missing bool
 	// copyrightRegexp matches years or year ranges like "2016", "2016-2019",
 	// "2016,2018-2020" in the copyright header.
-	copyrightRegexp := regexp.MustCompile(`// Copyright [0-9]{4}[0-9,\-]* Datadog, Inc.`)
+	copyrightRegexp := regexp.MustCompile(`// Copyright 20[0-9]{2}[0-9,\-]* Datadog, Inc.`)
 	if err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err


### PR DESCRIPTION
Copyright headers, if used at all, should refer to the year(s) the code
was written or substantially updated. Update checkcopyright.go to accept
anything that looks like a year, year range or year list rather than
hard coding 2016.