### PR TITLE
contrib/confluentinc/confluent-kafka-go: Set producerServiceName if svc is set

### DIFF
--- a/contrib/confluentinc/confluent-kafka-go/kafka/option.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/option.go
@@ -36,6 +36,7 @@ func newConfig(opts ...Option) *config {
 	}
 	if svc := globalconfig.ServiceName(); svc != "" {
 		cfg.consumerServiceName = svc
+		cfg.producerServiceName = svc
 	}
 	for _, opt := range opts {
 		opt(cfg)


### PR DESCRIPTION
what
Set `producerServiceName` if svc is set.

why
More correct default behavior: if `DD_SERVICE` is set, it should apply to both producer and consumer tracing.