### PR TITLE
contrib/gofiber/fiber.v2: capture error from fiber handler

### DIFF
--- a/contrib/gofiber/fiber.v2/fiber.go
+++ b/contrib/gofiber/fiber.v2/fiber.go
@@ -64,7 +64,9 @@ func Middleware(opts ...Option) func(c *fiber.Ctx) error {
 		}
 		span.SetTag(ext.HTTPCode, strconv.Itoa(status))
 
-		if cfg.isStatusError(status) {
+		if err != nil {
+			span.SetTag(ext.Error, err)
+		} else if cfg.isStatusError(status) {
 			// mark 5xx server error
 			span.SetTag(ext.Error, fmt.Errorf("%d: %s", status, http.StatusText(status)))
 		}


### PR DESCRIPTION
The error returned from the fiber handler was being ignored by the middleware. It now correctly captures the error and
sets it on the span by default, falling back to the previous behavior if no error is present.

Fixes #978