### PR TITLE
contrib/go.mongodb.org/mongo-driver/mongo: query tag should be "mongodb.query"

### DIFF
--- a/contrib/go.mongodb.org/mongo-driver/mongo/mongo.go
+++ b/contrib/go.mongodb.org/mongo-driver/mongo/mongo.go
@@ -44,7 +44,7 @@ func (m *monitor) Started(ctx context.Context, evt *event.CommandStartedEvent) {
 		tracer.ServiceName(m.cfg.serviceName),
 		tracer.ResourceName("mongo." + evt.CommandName),
 		tracer.Tag(ext.DBInstance, evt.DatabaseName),
-		tracer.Tag(ext.DBStatement, string(b)),
+		tracer.Tag("mongodb.query", string(b)),
 		tracer.Tag(ext.DBType, "mongo"),
 		tracer.Tag(ext.PeerHostname, hostname),
 		tracer.Tag(ext.PeerPort, port),


### PR DESCRIPTION
The trace agent obfuscator expects mongo queries to be tagged as
"mongodb.query" in order to be obfuscated. They are currently tagged as
ext.DBStatement, meaning they will not be obfuscated.

Fixes #995
