### PR TITLE
contrib/labstack/{echo, echo.v4}: improve error detection

### DIFF
--- a/contrib/labstack/echo.v4/echotrace.go
+++ b/contrib/labstack/echo.v4/echotrace.go
@@ -7,7 +7,9 @@
 package echo
 
 import (
+	"fmt"
 	"math"
+	"net/http"
 	"strconv"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace"
@@ -80,16 +82,28 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 				// This is the best we can do.
 				switch err := err.(type) {
 				case *echo.HTTPError:
-					if err.Code >= 500 {
+					if cfg.isStatusError(err.Code) {
 						finishOpts = append(finishOpts, tracer.WithError(err))
 					}
 					span.SetTag(ext.HTTPCode, strconv.Itoa(err.Code))
 				default:
 					// Any non-HTTPError errors appear as 5xx errors.
-					finishOpts = append(finishOpts, tracer.WithError(err))
+					if cfg.isStatusError(500) {
+						finishOpts = append(finishOpts, tracer.WithError(err))
+					}
 					span.SetTag(ext.HTTPCode, "500")
 				}
+			} else if status := c.Response().Status; status > 0 {
+				if cfg.isStatusError(status) {
+					// mark 5xx server error
+					finishOpts = append(finishOpts, tracer.WithError(fmt.Errorf("%d: %s", status, http.StatusText(status))))
+				}
+				span.SetTag(ext.HTTPCode, strconv.Itoa(status))
 			} else {
+				if cfg.isStatusError(200) {
+					// mark 5xx server error
+					finishOpts = append(finishOpts, tracer.WithError(fmt.Errorf("%d: %s", 200, http.StatusText(200))))
+				}
 				span.SetTag(ext.HTTPCode, "200")
 			}
 			return err

--- a/contrib/labstack/echo.v4/echotrace.go
+++ b/contrib/labstack/echo.v4/echotrace.go
@@ -63,7 +63,8 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 
 			span, ctx := httptrace.StartRequestSpan(request, opts...)
 			defer func() {
-				httptrace.FinishRequestSpan(span, c.Response().Status, finishOpts...)
+				//httptrace.FinishRequestSpan(span, c.Response().Status, finishOpts...)
+				span.Finish(finishOpts...)
 			}()
 
 			// pass the span through the request context

--- a/contrib/labstack/echo.v4/echotrace.go
+++ b/contrib/labstack/echo.v4/echotrace.go
@@ -73,7 +73,6 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 			}
 			err := next(c)
 			if err != nil {
-				finishOpts = append(finishOpts, tracer.WithError(err))
 				// invokes the registered HTTP error handler
 				c.Error(err)
 
@@ -82,12 +81,12 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 				switch err := err.(type) {
 				case *echo.HTTPError:
 					if err.Code >= 500 {
-						span.SetTag(ext.Error, err)
+						finishOpts = append(finishOpts, tracer.WithError(err))
 					}
 					span.SetTag(ext.HTTPCode, strconv.Itoa(err.Code))
 				default:
 					// Any non-HTTPError errors appear as 5xx errors.
-					span.SetTag(ext.Error, err)
+					finishOpts = append(finishOpts, tracer.WithError(err))
 					span.SetTag(ext.HTTPCode, "500")
 				}
 			} else {

--- a/contrib/labstack/echo.v4/echotrace_test.go
+++ b/contrib/labstack/echo.v4/echotrace_test.go
@@ -79,7 +79,7 @@ func TestTrace200(t *testing.T) {
 	assert.True(traced)
 
 	spans := mt.FinishedSpans()
-	assert.Len(spans, 1)
+	require.Len(t, spans, 1)
 
 	span := spans[0]
 	assert.Equal("http.request", span.OperationName())
@@ -127,7 +127,7 @@ func TestTraceAnalytics(t *testing.T) {
 	assert.True(traced)
 
 	spans := mt.FinishedSpans()
-	assert.Len(spans, 1)
+	require.Len(t, spans, 1)
 
 	span := spans[0]
 	assert.Equal("http.request", span.OperationName())
@@ -174,7 +174,7 @@ func TestError(t *testing.T) {
 	assert.True(traced)
 
 	spans := mt.FinishedSpans()
-	assert.Len(spans, 1)
+	require.Len(t, spans, 1)
 
 	span := spans[0]
 	assert.Equal("http.request", span.OperationName())
@@ -214,7 +214,7 @@ func TestErrorHandling(t *testing.T) {
 	assert.True(traced)
 
 	spans := mt.FinishedSpans()
-	assert.Len(spans, 1)
+	require.Len(t, spans, 1)
 
 	span := spans[0]
 	assert.Equal("http.request", span.OperationName())
@@ -314,7 +314,7 @@ func TestStatusError(t *testing.T) {
 			router.ServeHTTP(w, r)
 
 			spans := mt.FinishedSpans()
-			assert.Len(spans, 1)
+			require.Len(t, spans, 1)
 			span := spans[0]
 			assert.Equal("http.request", span.OperationName())
 			assert.Equal(ext.SpanTypeWeb, span.Tag(ext.SpanType))
@@ -384,7 +384,7 @@ func TestNoDebugStack(t *testing.T) {
 	assert.True(traced)
 
 	spans := mt.FinishedSpans()
-	assert.Len(spans, 1)
+	require.Len(t, spans, 1)
 
 	span := spans[0]
 	assert.Equal(wantErr.Error(), span.Tag(ext.Error).(error).Error())

--- a/contrib/labstack/echo.v4/echotrace_test.go
+++ b/contrib/labstack/echo.v4/echotrace_test.go
@@ -224,6 +224,66 @@ func TestErrorHandling(t *testing.T) {
 	assert.Equal(ext.SpanKindServer, span.Tag(ext.SpanKind))
 }
 
+func TestStatusError(t *testing.T) {
+	for _, tt := range []struct {
+		err     error
+		code    string
+		handler func(c echo.Context) error
+	}{
+		{
+			err:  errors.New("oh no"),
+			code: "500",
+			handler: func(c echo.Context) error {
+				return errors.New("oh no")
+			},
+		},
+		{
+			err:  echo.NewHTTPError(http.StatusInternalServerError, "my error message"),
+			code: "500",
+			handler: func(c echo.Context) error {
+				return echo.NewHTTPError(http.StatusInternalServerError, "my error message")
+			},
+		},
+		{
+			err:  nil,
+			code: "400",
+			handler: func(c echo.Context) error {
+				return echo.NewHTTPError(http.StatusBadRequest, "my error message")
+			},
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			assert := assert.New(t)
+			mt := mocktracer.Start()
+			defer mt.Stop()
+
+			router := echo.New()
+			router.Use(Middleware(WithServiceName("foobar")))
+			router.GET("/err", tt.handler)
+			r := httptest.NewRequest("GET", "/err", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, r)
+
+			spans := mt.FinishedSpans()
+			assert.Len(spans, 1)
+			span := spans[0]
+			assert.Equal("http.request", span.OperationName())
+			assert.Equal(ext.SpanTypeWeb, span.Tag(ext.SpanType))
+			assert.Equal("foobar", span.Tag(ext.ServiceName))
+			assert.Contains(span.Tag(ext.ResourceName), "/err")
+			assert.Equal(tt.code, span.Tag(ext.HTTPCode))
+			assert.Equal("GET", span.Tag(ext.HTTPMethod))
+			err := span.Tag(ext.Error)
+			if tt.err != nil {
+				assert.NotNil(err)
+				assert.Equal(tt.err.Error(), err.(error).Error())
+			} else {
+				assert.Nil(err)
+			}
+		})
+	}
+}
+
 func TestGetSpanNotInstrumented(t *testing.T) {
 	assert := assert.New(t)
 	router := echo.New()

--- a/contrib/labstack/echo.v4/echotrace_test.go
+++ b/contrib/labstack/echo.v4/echotrace_test.go
@@ -7,6 +7,7 @@ package echo
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -226,9 +227,10 @@ func TestErrorHandling(t *testing.T) {
 
 func TestStatusError(t *testing.T) {
 	for _, tt := range []struct {
-		err     error
-		code    string
-		handler func(c echo.Context) error
+		isStatusError func(statusCode int) bool
+		err           error
+		code          string
+		handler       func(c echo.Context) error
 	}{
 		{
 			err:  errors.New("oh no"),
@@ -251,6 +253,49 @@ func TestStatusError(t *testing.T) {
 				return echo.NewHTTPError(http.StatusBadRequest, "my error message")
 			},
 		},
+		{
+			isStatusError: func(statusCode int) bool { return statusCode >= 400 && statusCode < 500 },
+			err:           nil,
+			code:          "500",
+			handler: func(c echo.Context) error {
+				return errors.New("oh no")
+			},
+		},
+		{
+			isStatusError: func(statusCode int) bool { return statusCode >= 400 && statusCode < 500 },
+			err:           nil,
+			code:          "500",
+			handler: func(c echo.Context) error {
+				return echo.NewHTTPError(http.StatusInternalServerError, "my error message")
+			},
+		},
+		{
+			isStatusError: func(statusCode int) bool { return statusCode >= 400 },
+			err:           echo.NewHTTPError(http.StatusBadRequest, "my error message"),
+			code:          "400",
+			handler: func(c echo.Context) error {
+				return echo.NewHTTPError(http.StatusBadRequest, "my error message")
+			},
+		},
+		{
+			isStatusError: func(statusCode int) bool { return statusCode >= 200 },
+			err:           fmt.Errorf("201: Created"),
+			code:          "201",
+			handler: func(c echo.Context) error {
+				c.JSON(201, map[string]string{"status": "ok", "type": "test"})
+				return nil
+			},
+		},
+		{
+			isStatusError: func(statusCode int) bool { return statusCode >= 200 },
+			err:           fmt.Errorf("200: OK"),
+			code:          "200",
+			handler: func(c echo.Context) error {
+				// It's not clear if unset (0) status is possible naturally, but we can simulate that situation.
+				c.Response().Status = 0
+				return nil
+			},
+		},
 	} {
 		t.Run("", func(t *testing.T) {
 			assert := assert.New(t)
@@ -258,7 +303,11 @@ func TestStatusError(t *testing.T) {
 			defer mt.Stop()
 
 			router := echo.New()
-			router.Use(Middleware(WithServiceName("foobar")))
+			opts := []Option{WithServiceName("foobar")}
+			if tt.isStatusError != nil {
+				opts = append(opts, WithStatusCheck(tt.isStatusError))
+			}
+			router.Use(Middleware(opts...))
 			router.GET("/err", tt.handler)
 			r := httptest.NewRequest("GET", "/err", nil)
 			w := httptest.NewRecorder()
@@ -275,7 +324,9 @@ func TestStatusError(t *testing.T) {
 			assert.Equal("GET", span.Tag(ext.HTTPMethod))
 			err := span.Tag(ext.Error)
 			if tt.err != nil {
-				assert.NotNil(err)
+				if !assert.NotNil(err) {
+					return
+				}
 				assert.Equal(tt.err.Error(), err.(error).Error())
 			} else {
 				assert.Nil(err)

--- a/contrib/labstack/echo.v4/option.go
+++ b/contrib/labstack/echo.v4/option.go
@@ -18,6 +18,7 @@ type config struct {
 	analyticsRate     float64
 	noDebugStack      bool
 	ignoreRequestFunc IgnoreRequestFunc
+	isStatusError func(statusCode int) bool
 }
 
 // Option represents an option that can be passed to Middleware.
@@ -32,6 +33,7 @@ func defaults(cfg *config) {
 		cfg.serviceName = svc
 	}
 	cfg.analyticsRate = math.NaN()
+	cfg.isStatusError = isServerError
 }
 
 // WithServiceName sets the given service name for the system.
@@ -64,6 +66,7 @@ func WithAnalyticsRate(rate float64) Option {
 	}
 }
 
+
 // NoDebugStack prevents stack traces from being attached to spans finishing
 // with an error. This is useful in situations where errors are frequent and
 // performance is critical.
@@ -79,4 +82,15 @@ func WithIgnoreRequest(ignoreRequestFunc IgnoreRequestFunc) Option {
 	return func(cfg *config) {
 		cfg.ignoreRequestFunc = ignoreRequestFunc
 	}
+
+// WithStatusCheck specifies a function fn which reports whether the passed
+// statusCode should be considered an error.
+func WithStatusCheck(fn func(statusCode int) bool) Option {
+	return func(cfg *config) {
+		cfg.isStatusError = fn
+	}
+}
+
+func isServerError(statusCode int) bool {
+	return statusCode >= 500 && statusCode < 600
 }

--- a/contrib/labstack/echo.v4/option.go
+++ b/contrib/labstack/echo.v4/option.go
@@ -18,7 +18,7 @@ type config struct {
 	analyticsRate     float64
 	noDebugStack      bool
 	ignoreRequestFunc IgnoreRequestFunc
-	isStatusError func(statusCode int) bool
+	isStatusError     func(statusCode int) bool
 }
 
 // Option represents an option that can be passed to Middleware.
@@ -66,7 +66,6 @@ func WithAnalyticsRate(rate float64) Option {
 	}
 }
 
-
 // NoDebugStack prevents stack traces from being attached to spans finishing
 // with an error. This is useful in situations where errors are frequent and
 // performance is critical.
@@ -82,6 +81,7 @@ func WithIgnoreRequest(ignoreRequestFunc IgnoreRequestFunc) Option {
 	return func(cfg *config) {
 		cfg.ignoreRequestFunc = ignoreRequestFunc
 	}
+}
 
 // WithStatusCheck specifies a function fn which reports whether the passed
 // statusCode should be considered an error.

--- a/contrib/labstack/echo/echotrace.go
+++ b/contrib/labstack/echo/echotrace.go
@@ -51,7 +51,8 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 
 			span, ctx := httptrace.StartRequestSpan(request, opts...)
 			defer func() {
-				httptrace.FinishRequestSpan(span, c.Response().Status, finishOpts...)
+				//httptrace.FinishRequestSpan(span, c.Response().Status, finishOpts...)
+				span.Finish(finishOpts...)
 			}()
 
 			// pass the span through the request context
@@ -68,12 +69,14 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 				switch err := err.(type) {
 				case *echo.HTTPError:
 					if cfg.isStatusError(err.Code) {
+						fmt.Printf("FINISH OPTS ADDING ERROR!\n")
 						finishOpts = append(finishOpts, tracer.WithError(err))
 					}
 					span.SetTag(ext.HTTPCode, strconv.Itoa(err.Code))
 				default:
 					// Any non-HTTPError errors appear as 5xx errors.
 					if cfg.isStatusError(500) {
+						fmt.Printf("FINISH OPTS ADDING ERROR!\n")
 						finishOpts = append(finishOpts, tracer.WithError(err))
 					}
 					span.SetTag(ext.HTTPCode, "500")
@@ -81,12 +84,14 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 			} else if status := c.Response().Status; status > 0 {
 				if cfg.isStatusError(status) {
 					// mark 5xx server error
+					fmt.Printf("FINISH OPTS ADDING ERROR!\n")
 					finishOpts = append(finishOpts, tracer.WithError(fmt.Errorf("%d: %s", status, http.StatusText(status))))
 				}
 				span.SetTag(ext.HTTPCode, strconv.Itoa(status))
 			} else {
 				if cfg.isStatusError(200) {
 					// mark 5xx server error
+					fmt.Printf("FINISH OPTS ADDING ERROR!\n")
 					finishOpts = append(finishOpts, tracer.WithError(fmt.Errorf("%d: %s", 200, http.StatusText(200))))
 				}
 				span.SetTag(ext.HTTPCode, "200")

--- a/contrib/labstack/echo/echotrace.go
+++ b/contrib/labstack/echo/echotrace.go
@@ -7,7 +7,9 @@
 package echo
 
 import (
+	"fmt"
 	"math"
+	"net/http"
 	"strconv"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace"
@@ -65,16 +67,28 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 				// This is the best we can do.
 				switch err := err.(type) {
 				case *echo.HTTPError:
-					if err.Code >= 500 {
+					if cfg.isStatusError(err.Code) {
 						finishOpts = append(finishOpts, tracer.WithError(err))
 					}
 					span.SetTag(ext.HTTPCode, strconv.Itoa(err.Code))
 				default:
 					// Any non-HTTPError errors appear as 5xx errors.
-					finishOpts = append(finishOpts, tracer.WithError(err))
+					if cfg.isStatusError(500) {
+						finishOpts = append(finishOpts, tracer.WithError(err))
+					}
 					span.SetTag(ext.HTTPCode, "500")
 				}
+			} else if status := c.Response().Status; status > 0 {
+				if cfg.isStatusError(status) {
+					// mark 5xx server error
+					finishOpts = append(finishOpts, tracer.WithError(fmt.Errorf("%d: %s", status, http.StatusText(status))))
+				}
+				span.SetTag(ext.HTTPCode, strconv.Itoa(status))
 			} else {
+				if cfg.isStatusError(200) {
+					// mark 5xx server error
+					finishOpts = append(finishOpts, tracer.WithError(fmt.Errorf("%d: %s", 200, http.StatusText(200))))
+				}
 				span.SetTag(ext.HTTPCode, "200")
 			}
 			return err

--- a/contrib/labstack/echo/echotrace.go
+++ b/contrib/labstack/echo/echotrace.go
@@ -58,7 +58,6 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 			// serve the request to the next middleware
 			err := next(c)
 			if err != nil {
-				finishOpts = append(finishOpts, tracer.WithError(err))
 				// invokes the registered HTTP error handler
 				c.Error(err)
 
@@ -67,12 +66,12 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 				switch err := err.(type) {
 				case *echo.HTTPError:
 					if err.Code >= 500 {
-						span.SetTag(ext.Error, err)
+						finishOpts = append(finishOpts, tracer.WithError(err))
 					}
 					span.SetTag(ext.HTTPCode, strconv.Itoa(err.Code))
 				default:
 					// Any non-HTTPError errors appear as 5xx errors.
-					span.SetTag(ext.Error, err)
+					finishOpts = append(finishOpts, tracer.WithError(err))
 					span.SetTag(ext.HTTPCode, "500")
 				}
 			} else {

--- a/contrib/labstack/echo/echotrace.go
+++ b/contrib/labstack/echo/echotrace.go
@@ -8,6 +8,7 @@ package echo
 
 import (
 	"math"
+	"strconv"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
@@ -60,8 +61,23 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 				finishOpts = append(finishOpts, tracer.WithError(err))
 				// invokes the registered HTTP error handler
 				c.Error(err)
-			}
 
+				// It is impossible to determine what the final status code of a request is in echo.
+				// This is the best we can do.
+				switch err := err.(type) {
+				case *echo.HTTPError:
+					if err.Code >= 500 {
+						span.SetTag(ext.Error, err)
+					}
+					span.SetTag(ext.HTTPCode, strconv.Itoa(err.Code))
+				default:
+					// Any non-HTTPError errors appear as 5xx errors.
+					span.SetTag(ext.Error, err)
+					span.SetTag(ext.HTTPCode, "500")
+				}
+			} else {
+				span.SetTag(ext.HTTPCode, "200")
+			}
 			return err
 		}
 	}

--- a/contrib/labstack/echo/echotrace.go
+++ b/contrib/labstack/echo/echotrace.go
@@ -69,29 +69,23 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 				switch err := err.(type) {
 				case *echo.HTTPError:
 					if cfg.isStatusError(err.Code) {
-						fmt.Printf("FINISH OPTS ADDING ERROR!\n")
 						finishOpts = append(finishOpts, tracer.WithError(err))
 					}
 					span.SetTag(ext.HTTPCode, strconv.Itoa(err.Code))
 				default:
-					// Any non-HTTPError errors appear as 5xx errors.
+					// Any error that is not an *echo.HTTPError will be treated as an error with 500 status code.
 					if cfg.isStatusError(500) {
-						fmt.Printf("FINISH OPTS ADDING ERROR!\n")
 						finishOpts = append(finishOpts, tracer.WithError(err))
 					}
 					span.SetTag(ext.HTTPCode, "500")
 				}
 			} else if status := c.Response().Status; status > 0 {
 				if cfg.isStatusError(status) {
-					// mark 5xx server error
-					fmt.Printf("FINISH OPTS ADDING ERROR!\n")
 					finishOpts = append(finishOpts, tracer.WithError(fmt.Errorf("%d: %s", status, http.StatusText(status))))
 				}
 				span.SetTag(ext.HTTPCode, strconv.Itoa(status))
 			} else {
 				if cfg.isStatusError(200) {
-					// mark 5xx server error
-					fmt.Printf("FINISH OPTS ADDING ERROR!\n")
 					finishOpts = append(finishOpts, tracer.WithError(fmt.Errorf("%d: %s", 200, http.StatusText(200))))
 				}
 				span.SetTag(ext.HTTPCode, "200")

--- a/contrib/labstack/echo/echotrace.go
+++ b/contrib/labstack/echo/echotrace.go
@@ -7,6 +7,7 @@
 package echo
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -66,13 +67,13 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 
 				// It is impossible to determine what the final status code of a request is in echo.
 				// This is the best we can do.
-				switch err := err.(type) {
-				case *echo.HTTPError:
-					if cfg.isStatusError(err.Code) {
+				var echoErr *echo.HTTPError
+				if errors.As(err, &echoErr) {
+					if cfg.isStatusError(echoErr.Code) {
 						finishOpts = append(finishOpts, tracer.WithError(err))
 					}
-					span.SetTag(ext.HTTPCode, strconv.Itoa(err.Code))
-				default:
+					span.SetTag(ext.HTTPCode, strconv.Itoa(echoErr.Code))
+				} else {
 					// Any error that is not an *echo.HTTPError will be treated as an error with 500 status code.
 					if cfg.isStatusError(500) {
 						finishOpts = append(finishOpts, tracer.WithError(err))

--- a/contrib/labstack/echo/echotrace_test.go
+++ b/contrib/labstack/echo/echotrace_test.go
@@ -251,7 +251,7 @@ func TestStatusError(t *testing.T) {
 				return echo.NewHTTPError(http.StatusBadRequest, "my error message")
 			},
 		},
-		{ //03
+		{
 			isStatusError: func(statusCode int) bool { return statusCode >= 400 && statusCode < 500 },
 			err:           nil,
 			code:          "500",
@@ -259,7 +259,7 @@ func TestStatusError(t *testing.T) {
 				return errors.New("oh no")
 			},
 		},
-		{ //04
+		{
 			isStatusError: func(statusCode int) bool { return statusCode >= 400 && statusCode < 500 },
 			err:           nil,
 			code:          "500",

--- a/contrib/labstack/echo/echotrace_test.go
+++ b/contrib/labstack/echo/echotrace_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestChildSpan(t *testing.T) {
@@ -175,6 +176,7 @@ func TestError(t *testing.T) {
 	assert.Equal("http.request", span.OperationName())
 	assert.Equal("foobar", span.Tag(ext.ServiceName))
 	assert.Equal("500", span.Tag(ext.HTTPCode))
+	require.NotNil(t, span.Tag(ext.Error))
 	assert.Equal(wantErr.Error(), span.Tag(ext.Error).(error).Error())
 	assert.Equal("labstack/echo", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindServer, span.Tag(ext.SpanKind))
@@ -215,6 +217,7 @@ func TestErrorHandling(t *testing.T) {
 	assert.Equal("http.request", span.OperationName())
 	assert.Equal("foobar", span.Tag(ext.ServiceName))
 	assert.Equal("500", span.Tag(ext.HTTPCode))
+	require.NotNil(t, span.Tag(ext.Error))
 	assert.Equal(wantErr.Error(), span.Tag(ext.Error).(error).Error())
 	assert.Equal("labstack/echo", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindServer, span.Tag(ext.SpanKind))
@@ -248,7 +251,7 @@ func TestStatusError(t *testing.T) {
 				return echo.NewHTTPError(http.StatusBadRequest, "my error message")
 			},
 		},
-		{
+		{ //03
 			isStatusError: func(statusCode int) bool { return statusCode >= 400 && statusCode < 500 },
 			err:           nil,
 			code:          "500",
@@ -256,7 +259,7 @@ func TestStatusError(t *testing.T) {
 				return errors.New("oh no")
 			},
 		},
-		{
+		{ //04
 			isStatusError: func(statusCode int) bool { return statusCode >= 400 && statusCode < 500 },
 			err:           nil,
 			code:          "500",
@@ -320,6 +323,7 @@ func TestStatusError(t *testing.T) {
 			err := span.Tag(ext.Error)
 			if tt.err != nil {
 				assert.NotNil(err)
+				require.NotNil(t, span.Tag(ext.Error))
 				assert.Equal(tt.err.Error(), err.(error).Error())
 			} else {
 				assert.Nil(err)
@@ -380,6 +384,7 @@ func TestNoDebugStack(t *testing.T) {
 	assert.Len(spans, 1)
 
 	span := spans[0]
+	require.NotNil(t, span.Tag(ext.Error))
 	assert.Equal(wantErr.Error(), span.Tag(ext.Error).(error).Error())
 	assert.Equal("<debug stack disabled>", span.Tag(ext.ErrorStack))
 	assert.Equal("labstack/echo", span.Tag(ext.Component))

--- a/contrib/labstack/echo/option.go
+++ b/contrib/labstack/echo/option.go
@@ -16,6 +16,7 @@ type config struct {
 	serviceName   string
 	analyticsRate float64
 	noDebugStack  bool
+	isStatusError func(statusCode int) bool
 }
 
 // Option represents an option that can be passed to Middleware.
@@ -31,6 +32,7 @@ func defaults(cfg *config) {
 	} else {
 		cfg.analyticsRate = math.NaN()
 	}
+	cfg.isStatusError = isServerError
 }
 
 // WithServiceName sets the given service name for the system.
@@ -63,6 +65,7 @@ func WithAnalyticsRate(rate float64) Option {
 	}
 }
 
+<<<<<<< HEAD
 // NoDebugStack prevents stack traces from being attached to spans finishing
 // with an error. This is useful in situations where errors are frequent and
 // performance is critical.
@@ -71,3 +74,16 @@ func NoDebugStack() Option {
 		cfg.noDebugStack = true
 	}
 }
+=======
+// WithStatusCheck specifies a function fn which reports whether the passed
+// statusCode should be considered an error.
+func WithStatusCheck(fn func(statusCode int) bool) Option {
+	return func(cfg *config) {
+		cfg.isStatusError = fn
+	}
+}
+
+func isServerError(statusCode int) bool {
+	return statusCode >= 500 && statusCode < 600
+}
+>>>>>>> add WithStatusCheck option

--- a/contrib/labstack/echo/option.go
+++ b/contrib/labstack/echo/option.go
@@ -65,7 +65,6 @@ func WithAnalyticsRate(rate float64) Option {
 	}
 }
 
-<<<<<<< HEAD
 // NoDebugStack prevents stack traces from being attached to spans finishing
 // with an error. This is useful in situations where errors are frequent and
 // performance is critical.
@@ -74,7 +73,7 @@ func NoDebugStack() Option {
 		cfg.noDebugStack = true
 	}
 }
-=======
+
 // WithStatusCheck specifies a function fn which reports whether the passed
 // statusCode should be considered an error.
 func WithStatusCheck(fn func(statusCode int) bool) Option {
@@ -86,4 +85,3 @@ func WithStatusCheck(fn func(statusCode int) bool) Option {
 func isServerError(statusCode int) bool {
 	return statusCode >= 500 && statusCode < 600
 }
->>>>>>> add WithStatusCheck option


### PR DESCRIPTION
This adds improved error detection to the echo integrations. Previously,
any returned error was recorded as an error in the echo span. This patch
causes the integration to inspect the returned error to determine if it is
a echo.HTTPError which it can use to discriminate between real errors (5xx
and up by default) or non-errors (below 5xx by default)

This also adds a WithStatusCheck Option which allows users to configure
which errors/statuses are reported as errors. 

Fixes #987