### PR TITLE
contrib/net/http: add method RTWithSpanOptions

### DIFF
--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -118,6 +118,7 @@ type roundTripperConfig struct {
 	analyticsRate float64
 	serviceName   string
 	resourceNamer func(req *http.Request) string
+	spanOpts      []ddtrace.StartSpanOption
 }
 
 func newRoundTripperConfig() *roundTripperConfig {
@@ -152,6 +153,14 @@ func WithAfter(f RoundTripperAfterFunc) RoundTripperOption {
 func RTWithResourceNamer(namer func(req *http.Request) string) RoundTripperOption {
 	return func(cfg *roundTripperConfig) {
 		cfg.resourceNamer = namer
+	}
+}
+
+// RTWithSpanOptions defines a set of additional ddtrace.StartSpanOption to be added
+// to spans started by the integration.
+func RTWithSpanOptions(opts ...ddtrace.StartSpanOption) RoundTripperOption {
+	return func(cfg *roundTripperConfig) {
+		cfg.spanOpts = append(cfg.spanOpts, opts...)
 	}
 }
 

--- a/contrib/net/http/roundtripper.go
+++ b/contrib/net/http/roundtripper.go
@@ -36,6 +36,9 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (res *http.Response, err er
 	if rt.cfg.serviceName != "" {
 		opts = append(opts, tracer.ServiceName(rt.cfg.serviceName))
 	}
+	if len(rt.cfg.spanOpts) > 0 {
+		opts = append(opts, rt.cfg.spanOpts...)
+	}
 	span, ctx := tracer.StartSpanFromContext(req.Context(), "http.request", opts...)
 	defer func() {
 		if rt.cfg.after != nil {

--- a/contrib/net/http/roundtripper_test.go
+++ b/contrib/net/http/roundtripper_test.go
@@ -313,16 +313,12 @@ func TestSpanOptions(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.Write([]byte("")) }))
 	defer s.Close()
 
-	const (
-		tagKey   = "foo"
-		tagValue = "bar"
-	)
-	var (
-		mt     = mocktracer.Start()
-		rt     = WrapRoundTripper(http.DefaultTransport, RTWithSpanOptions(tracer.Tag(tagKey, tagValue)))
-		client = &http.Client{Transport: rt}
-	)
+	tagKey := "foo"
+	tagValue := "bar"
+	mt := mocktracer.Start()
 	defer mt.Stop()
+	rt := WrapRoundTripper(http.DefaultTransport, RTWithSpanOptions(tracer.Tag(tagKey, tagValue)))
+	client := &http.Client{Transport: rt}
 
 	client.Get(s.URL)
 


### PR DESCRIPTION
Allowing to provide additional options
when starting a new span with the round tripper.

Related issue: https://github.com/DataDog/dd-trace-go/issues/984