### PR TITLE
 contrib/twitchtv/twirp: serviceName should be read from global config

### DIFF
--- a/contrib/twitchtv/twirp/option.go
+++ b/contrib/twitchtv/twirp/option.go
@@ -26,6 +26,9 @@ func defaults(cfg *config) {
 	} else {
 		cfg.analyticsRate = globalconfig.AnalyticsRate()
 	}
+	if svc := globalconfig.ServiceName(); svc != "" {
+		cfg.serviceName = svc
+	}
 }
 
 func (cfg *config) serverServiceName() string {


### PR DESCRIPTION
PR to read serviceName from global config

Proposal:
https://github.com/DataDog/dd-trace-go/issues/989