### PR TITLE
ddtrace/opentracer: translate Datadog errors to OpenTracing errors

### DIFF
--- a/ddtrace/opentracer/tracer_test.go
+++ b/ddtrace/opentracer/tracer_test.go
@@ -47,6 +47,12 @@ func TestInjectError(t *testing.T) {
 		carrier     interface{}
 		want        error
 	}{
+		"ErrInvalidSpanContext": {
+			spanContext: internal.NoopSpanContext{},
+			format:      opentracing.TextMap,
+			carrier:     opentracing.TextMapCarrier(map[string]string{}),
+			want:        opentracing.ErrInvalidSpanContext,
+		},
 		"ErrInvalidCarrier": {
 			spanContext: ot.StartSpan("test.operation").Context(),
 			format:      opentracing.TextMap,


### PR DESCRIPTION
This change fixes so that the OpenTracing implementation returns standard errors
defined in opentracing-go, as opposed to returning errors defined in ddtrace/tracer.

Fixes #998