### PR TITLE
contrib/olivere/elastic: fix ineffectual assignment

### DIFF
--- a/contrib/olivere/elastic/elastictrace.go
+++ b/contrib/olivere/elastic/elastictrace.go
@@ -134,8 +134,8 @@ func peek(rc io.ReadCloser, encoding string, max, n int) (string, io.ReadCloser,
 	}
 	if encoding == "gzip" {
 		// unpack the snippet
-		gzr, err := gzip.NewReader(bytes.NewReader(snip))
-		if err != nil {
+		gzr, err2 := gzip.NewReader(bytes.NewReader(snip))
+		if err2 != nil {
 			// snip wasn't gzip; return it as is
 			return string(snip), rc2, nil
 		}


### PR DESCRIPTION
`snip, err = ioutil.ReadAll(gzr)` was ineffectual assignment.