### PR TITLE
ddtrace/ext: Updated encoding for no-sample decision based tracer rules from -3 to -2

### DIFF
--- a/ddtrace/ext/priority.go
+++ b/ddtrace/ext/priority.go
@@ -10,7 +10,7 @@ package ext
 
 const (
 	// PriorityRuleSamplerReject specifies that the rule sampler has decided that this trace should be rejected.
-	PriorityRuleSamplerReject = -3
+	PriorityRuleSamplerReject = -2
 
 	// PriorityUserReject informs the backend that a trace should be rejected and not stored.
 	// This should be used by user code overriding default priority.


### PR DESCRIPTION
Updated encoding for no-sample decision based tracer rules from -3 to -2 to keep consistency with previous encodings (1,0) and (2,-1)

See updated documentation on priority encodings here: https://docs.google.com/document/d/1lVhgeG6uS0C9DVmN3t74tBDL7h44duwynIQqExljxRc/edit

See thread discussing these values: https://dd.slack.com/archives/CKXKHAKFG/p1634550894018500?thread_ts=1634158499.011900&cid=CKXKHAKFG

There is no impact on changing these values as they are not yet interpreted by the backend and the agent doesn't treat these values in any special way.

See related PR: https://github.com/DataDog/dd-trace-go/pull/1012