### PR TITLE
CI: fix cert issue and pin sarama dep

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,6 +198,8 @@ jobs:
             go get cloud.google.com/go/pubsub@v1.6.1
             # Temporarily enforce this version. 1.9.0 is incompatible with go < 1.16
             go get github.com/hashicorp/consul/api@v1.8.1
+            # Shopify/sarama < v1.22 doesn't compile with go1.14
+            go get github.com/Shopify/sarama@v1.22.0
 
       - run:
           name: Wait for MySQL


### PR DESCRIPTION
Fix two CI issues that showed up recently:

a) go1.12-build was showing the error below.

unable to access 'https://gopkg.in/yaml.v3/': server certificate
verification failed. CAfile: none CRLfile: none

Fix this by updating the certs in our CI image before kicking off the build.

b) test-contrib failed because later versions of Shopify/sarama depend
on newer versions of Go.

Fix this by pinning to the lowest version of Shopify/sarama that passes
our build.