### PR TITLE
internal/appsec: add appsec.event span tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,9 +213,9 @@ jobs:
             go get cloud.google.com/go/pubsub@v1.6.1
             # Temporarily enforce this version. 1.9.0 is incompatible with go < 1.16
             go get github.com/hashicorp/consul/api@v1.8.1
-            # github.com/hashicorp/vault/sdk >= v0.2.1 doesn't compile with go1.14
+            # github.com/hashicorp/vault/sdk > v0.2.0 doesn't compile with go1.14
             go get github.com/hashicorp/vault/sdk@v0.2.0
-            # Shopify/sarama >= v1.22 doesn't compile with go1.14
+            # Shopify/sarama > v1.22 doesn't compile with go1.14
             go get github.com/Shopify/sarama@v1.22.0
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,8 @@ jobs:
             go get cloud.google.com/go/pubsub@v1.6.1
             # Temporarily enforce this version. 1.9.0 is incompatible with go < 1.16
             go get github.com/hashicorp/consul/api@v1.8.1
+            # github.com/hashicorp/vault/sdk < v0.2.1 doesn't compile with go1.14
+            go get github.com/hashicorp/vault/sdk@v0.2.0
             # Shopify/sarama < v1.22 doesn't compile with go1.14
             go get github.com/Shopify/sarama@v1.22.0
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,9 +213,9 @@ jobs:
             go get cloud.google.com/go/pubsub@v1.6.1
             # Temporarily enforce this version. 1.9.0 is incompatible with go < 1.16
             go get github.com/hashicorp/consul/api@v1.8.1
-            # github.com/hashicorp/vault/sdk < v0.2.1 doesn't compile with go1.14
+            # github.com/hashicorp/vault/sdk >= v0.2.1 doesn't compile with go1.14
             go get github.com/hashicorp/vault/sdk@v0.2.0
-            # Shopify/sarama < v1.22 doesn't compile with go1.14
+            # Shopify/sarama >= v1.22 doesn't compile with go1.14
             go get github.com/Shopify/sarama@v1.22.0
 
       - run:

--- a/internal/appsec/waf.go
+++ b/internal/appsec/waf.go
@@ -106,6 +106,8 @@ func newWAFEventListener(handle *waf.Handle, addresses []string, appsec *appsec)
 				event = withSpanContext(event, spanCtx.TraceID(), spanCtx.SpanID())
 				// Keep this span due to the security event
 				span.SetTag(ext.ManualKeep, true)
+				// Set the appsec.event tag needed by the appsec backend
+				span.SetTag("appsec.event", true)
 			}
 			appsec.sendEvent(event)
 		}))


### PR DESCRIPTION
Add the `appsec.event` span tag needed by the appsec backend to receives spans where appsec events happened.