### PR TITLE
ddtrace/tracer: use UDS connection when relevant socket paths are available

### DIFF
--- a/ddtrace/tracer/log.go
+++ b/ddtrace/tracer/log.go
@@ -98,7 +98,7 @@ func logStartup(t *tracer) {
 		Architecture:          runtime.GOARCH,
 		GlobalService:         globalconfig.ServiceName(),
 		LambdaMode:            fmt.Sprintf("%t", t.config.logToStdout),
-		AgentFeatures:         t.features.Load(),
+		AgentFeatures:         t.config.features,
 		AppSec:                appsec.Status(),
 	}
 	if _, err := samplingRulesFromEnv(); err != nil {

--- a/ddtrace/tracer/log_test.go
+++ b/ddtrace/tracer/log_test.go
@@ -26,7 +26,7 @@ func TestStartupLog(t *testing.T) {
 		logStartup(tracer)
 		lines := removeAppSec(tp.Lines())
 		assert.Len(lines, 2)
-		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sampling_rules":null,"sampling_rules_error":"","tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"false","appsec":"((enabled)|(disabled))","agent_features":{"DropP0s":false,"V05":false,"Stats":false}}`, lines[1])
+		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sampling_rules":null,"sampling_rules_error":"","tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"false","appsec":"((enabled)|(disabled))","agent_features":{"DropP0s":false,"Stats":false,"StatsdPort":0}}`, lines[1])
 	})
 
 	t.Run("configured", func(t *testing.T) {
@@ -54,7 +54,7 @@ func TestStartupLog(t *testing.T) {
 		tp.Reset()
 		logStartup(tracer)
 		assert.Len(tp.Lines(), 2)
-		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"configuredEnv","service":"configured.service","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":true,"analytics_enabled":true,"sample_rate":"0\.123000","sampling_rules":\[{"service":"mysql","name":"","sample_rate":0\.75}\],"sampling_rules_error":"","tags":{"runtime-id":"[^"]*","tag":"value","tag2":"NaN"},"runtime_metrics_enabled":true,"health_metrics_enabled":true,"dd_version":"2.3.4","architecture":"[^"]*","global_service":"configured.service","lambda_mode":"false","appsec":"((enabled)|(disabled))","agent_features":{"DropP0s":false,"V05":false,"Stats":false}}`, tp.Lines()[1])
+		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"configuredEnv","service":"configured.service","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":true,"analytics_enabled":true,"sample_rate":"0\.123000","sampling_rules":\[{"service":"mysql","name":"","sample_rate":0\.75}\],"sampling_rules_error":"","tags":{"runtime-id":"[^"]*","tag":"value","tag2":"NaN"},"runtime_metrics_enabled":true,"health_metrics_enabled":true,"dd_version":"2.3.4","architecture":"[^"]*","global_service":"configured.service","lambda_mode":"false","appsec":"((enabled)|(disabled))","agent_features":{"DropP0s":false,"Stats":false,"StatsdPort":0}}`, tp.Lines()[1])
 	})
 
 	t.Run("errors", func(t *testing.T) {
@@ -68,7 +68,7 @@ func TestStartupLog(t *testing.T) {
 		tp.Reset()
 		logStartup(tracer)
 		assert.Len(tp.Lines(), 2)
-		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sampling_rules":\[{"service":"some.service","name":"","sample_rate":0\.234}\],"sampling_rules_error":"found errors:\\n\\tat index 1: rate not provided","tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"false","appsec":"((enabled)|(disabled))","agent_features":{"DropP0s":false,"V05":false,"Stats":false}}`, tp.Lines()[1])
+		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sampling_rules":\[{"service":"some.service","name":"","sample_rate":0\.234}\],"sampling_rules_error":"found errors:\\n\\tat index 1: rate not provided","tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"false","appsec":"((enabled)|(disabled))","agent_features":{"DropP0s":false,"Stats":false,"StatsdPort":0}}`, tp.Lines()[1])
 	})
 
 	t.Run("lambda", func(t *testing.T) {
@@ -80,7 +80,7 @@ func TestStartupLog(t *testing.T) {
 		tp.Reset()
 		logStartup(tracer)
 		assert.Len(tp.Lines(), 1)
-		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test","agent_url":"http://localhost:9/v0.4/traces","agent_error":"","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sampling_rules":null,"sampling_rules_error":"","tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"true","appsec":"((enabled)|(disabled))","agent_features":{"DropP0s":false,"V05":false,"Stats":false}}`, tp.Lines()[0])
+		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test","agent_url":"http://localhost:9/v0.4/traces","agent_error":"","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sampling_rules":null,"sampling_rules_error":"","tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"true","appsec":"((enabled)|(disabled))","agent_features":{"DropP0s":false,"Stats":false,"StatsdPort":0}}`, tp.Lines()[0])
 	})
 }
 

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -246,10 +246,11 @@ func newConfig(opts ...StartOption) *config {
 		// configure statsd client
 		addr := c.dogstatsdAddr
 		if addr == "" {
-			// no config defined address
+			// no config defined address; use defaults
 			addr = defaultDogstatsdAddr()
 		}
 		if agentport := c.features.StatsdPort; agentport > 0 {
+			// the agent reported a non-standard port
 			host, _, err := net.SplitHostPort(addr)
 			if err == nil {
 				// we have a valid host:port address; replace the port because

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -7,12 +7,15 @@ package tracer
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"math"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -40,6 +43,10 @@ var (
 type config struct {
 	// debug, when true, writes details to logs.
 	debug bool
+
+	// features holds the capabilities of the agent and determines some
+	// of the behaviour of the tracer.
+	features agentFeatures
 
 	// featureFlags specifies any enabled feature flags.
 	featureFlags map[string]struct{}
@@ -122,14 +129,6 @@ func (c *config) HasFeature(f string) bool {
 	return ok
 }
 
-// client returns the HTTP client to use.
-func (c *config) client() *http.Client {
-	if c.httpClient == nil {
-		return defaultClient
-	}
-	return c.httpClient
-}
-
 // StartOption represents a function that can be provided as a parameter to Start.
 type StartOption func(*config)
 
@@ -140,7 +139,6 @@ func newConfig(opts ...StartOption) *config {
 	c.sampler = NewAllSampler()
 	c.agentAddr = defaultAddress
 	c.httpClient = defaultHTTPClient()
-	c.dogstatsdAddr = defaultDogstatsdAddr()
 
 	if internal.BoolEnv("DD_TRACE_ANALYTICS_ENABLED", false) {
 		globalconfig.SetAnalyticsRate(1.0)
@@ -232,7 +230,7 @@ func newConfig(opts ...StartOption) *config {
 		}
 	}
 	if c.transport == nil {
-		c.transport = newHTTPTransport(c.agentAddr, c.client())
+		c.transport = newHTTPTransport(c.agentAddr, c.httpClient)
 	}
 	if c.propagator == nil {
 		c.propagator = NewPropagator(nil)
@@ -243,8 +241,28 @@ func newConfig(opts ...StartOption) *config {
 	if c.debug {
 		log.SetLevel(log.LevelDebug)
 	}
+	c.loadAgentFeatures()
 	if c.statsd == nil {
-		client, err := statsd.New(c.dogstatsdAddr, statsd.WithMaxMessagesPerPayload(40), statsd.WithTags(statsTags(c)))
+		// configure statsd client
+		addr := c.dogstatsdAddr
+		if addr == "" {
+			// no config defined address
+			addr = defaultDogstatsdAddr()
+		}
+		if agentport := c.features.StatsdPort; agentport > 0 {
+			host, _, err := net.SplitHostPort(addr)
+			if err == nil {
+				// we have a valid host:port address; replace the port because
+				// the agent knows better
+				if host == "" {
+					host = defaultHostname
+				}
+				addr = net.JoinHostPort(host, strconv.Itoa(agentport))
+			}
+			// not a valid TCP address, leave it as it is (could be a socket connection)
+		}
+		c.dogstatsdAddr = addr
+		client, err := statsd.New(addr, statsd.WithMaxMessagesPerPayload(40), statsd.WithTags(statsTags(c)))
 		if err != nil {
 			log.Warn("Runtime and health metrics disabled: %v", err)
 			c.statsd = &statsd.NoOpClient{}
@@ -269,8 +287,11 @@ func udsClient(socketPath string) *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
-			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial("unix", socketPath)
+			DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+				return defaultDialer.DialContext(ctx, "unix", (&net.UnixAddr{
+					Name: socketPath,
+					Net:  "unix",
+				}).String())
 			},
 			MaxIdleConns:          100,
 			IdleConnTimeout:       90 * time.Second,
@@ -284,23 +305,76 @@ func udsClient(socketPath string) *http.Client {
 // defaultDogstatsdAddr returns the default connection address for Dogstatsd.
 func defaultDogstatsdAddr() string {
 	envHost, envPort := os.Getenv("DD_AGENT_HOST"), os.Getenv("DD_DOGSTATSD_PORT")
-	host, port := "localhost", "8125"
-	if v := envHost; v != "" {
-		host = v
-	}
-	if v := envPort; v != "" {
-		port = v
-	}
-	if envHost != "" || envPort != "" {
-		// the user specified his choice via env. vars.
-		return net.JoinHostPort(host, port)
-	}
-	if _, err := os.Stat(defaultSocketDSD); err == nil {
-		// we have a socket file, use it
+	if _, err := os.Stat(defaultSocketDSD); err == nil && envHost == "" && envPort == "" {
+		// socket exists and user didn't specify otherwise via env vars
 		return "unix://" + defaultSocketDSD
 	}
-	// no choice, nor socket file available, default to localhost:8125
-	return "localhost:8125"
+	host, port := defaultHostname, "8125"
+	if envHost != "" {
+		host = envHost
+	}
+	if envPort != "" {
+		port = envPort
+	}
+	return net.JoinHostPort(host, port)
+}
+
+// agentFeatures holds information about the trace-agent's capabilities.
+// When running WithLambdaMode, a zero-value of this struct will be used
+// as features.
+type agentFeatures struct {
+	// DropP0s reports whether it's ok for the tracer to not send any
+	// P0 traces to the agent.
+	DropP0s bool
+
+	// Stats reports whether the agent can receive client-computed stats on
+	// the /v0.6/stats endpoint.
+	Stats bool
+
+	// StatsdPort specifies the Dogstatsd port as provided by the agent.
+	// If it's the default, it will be 0, which means 8125.
+	StatsdPort int
+}
+
+// loadAgentFeatures queries the trace-agent for its capabilities and updates
+// the tracer's behaviour.
+func (c *config) loadAgentFeatures() {
+	c.features = agentFeatures{}
+	if c.logToStdout {
+		// there is no agent; all features off
+		return
+	}
+	resp, err := c.httpClient.Get(fmt.Sprintf("http://%s/info", c.agentAddr))
+	if err != nil {
+		log.Error("Loading features: %v", err)
+		return
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		// agent is older than 7.28.0, features not discoverable
+		return
+	}
+	defer resp.Body.Close()
+	type infoResponse struct {
+		Endpoints     []string `json:"endpoints"`
+		ClientDropP0s bool     `json:"client_drop_p0s"`
+		StatsdPort    int      `json:"statsd_port"`
+	}
+	var info infoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		log.Error("Decoding features: %v", err)
+		return
+	}
+	c.features.DropP0s = info.ClientDropP0s
+	c.features.StatsdPort = info.StatsdPort
+	for _, endpoint := range info.Endpoints {
+		switch endpoint {
+		case "/v0.6/stats":
+			if c.HasFeature("discovery") {
+				// client-stats computation is off by default
+				c.features.Stats = true
+			}
+		}
+	}
 }
 
 func statsTags(c *config) []string {

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -40,15 +40,15 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		assert.Equal("localhost:8126", c.agentAddr)
 		assert.Equal("localhost:8125", c.dogstatsdAddr)
 		assert.Nil(nil, c.httpClient)
-		assert.Equal(defaultClient, c.client())
+		assert.Equal(defaultClient, c.httpClient)
 	})
 
 	t.Run("http-client", func(t *testing.T) {
 		c := newConfig()
-		assert.Equal(t, defaultClient, c.client())
+		assert.Equal(t, defaultClient, c.httpClient)
 		client := &http.Client{}
 		WithHTTPClient(client)(c)
-		assert.Equal(t, client, c.client())
+		assert.Equal(t, client, c.httpClient)
 	})
 
 	t.Run("analytics", func(t *testing.T) {

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -350,7 +350,7 @@ func (s *span) finish(finishTime int64) {
 	keep := true
 	if t, ok := internal.GetGlobalTracer().(*tracer); ok {
 		// we have an active tracer
-		feats := t.features.Load()
+		feats := t.config.features
 		if feats.Stats && shouldComputeStats(s) {
 			// the agent supports computed stats
 			select {

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -33,7 +33,7 @@ func TestNewSpanContextPushError(t *testing.T) {
 	defer setupteardown(2, 2)()
 
 	tp := new(testLogger)
-	_, _, _, stop := startTestTracer(t, WithLogger(tp))
+	_, _, _, stop := startTestTracer(t, WithLogger(tp), WithLambdaMode(true))
 	defer stop()
 	parent := newBasicSpan("test1")                  // 1st span in trace
 	parent.context.trace.push(newBasicSpan("test2")) // 2nd span in trace
@@ -129,7 +129,7 @@ func TestSpanTracePushNoFinish(t *testing.T) {
 	assert := assert.New(t)
 
 	tp := new(testLogger)
-	_, _, _, stop := startTestTracer(t, WithLogger(tp))
+	_, _, _, stop := startTestTracer(t, WithLogger(tp), WithLambdaMode(true))
 	defer stop()
 
 	buffer := newTrace()
@@ -353,7 +353,7 @@ func TestSpanContextPushFull(t *testing.T) {
 	defer func(old int) { traceMaxSize = old }(traceMaxSize)
 	traceMaxSize = 2
 	tp := new(testLogger)
-	_, _, _, stop := startTestTracer(t, WithLogger(tp))
+	_, _, _, stop := startTestTracer(t, WithLogger(tp), WithLambdaMode(true))
 	defer stop()
 
 	span1 := newBasicSpan("span1")

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -6,9 +6,7 @@
 package tracer
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"os"
 	"strconv"
 	"sync"
@@ -34,10 +32,6 @@ var _ ddtrace.Tracer = (*tracer)(nil)
 // queues to be processed by the payload encoder.
 type tracer struct {
 	config *config
-
-	// features holds the capabilities of the agent and determines some
-	// of the behaviour of the tracer.
-	features *agentFeatures
 
 	// stats specifies the concentrator used to compute statistics, when client-side
 	// stats are enabled.
@@ -115,9 +109,6 @@ func Start(opts ...StartOption) {
 	if !t.config.enabled {
 		return
 	}
-	if t.config.HasFeature("discovery") {
-		t.loadAgentFeatures()
-	}
 	internal.SetGlobalTracer(t)
 	if t.config.logStartup {
 		logStartup(t)
@@ -183,7 +174,6 @@ func newUnstartedTracer(opts ...StartOption) *tracer {
 		rulesSampling:    newRulesSampler(c.samplingRules),
 		prioritySampling: sampler,
 		pid:              strconv.Itoa(os.Getpid()),
-		features:         &agentFeatures{},
 		stats:            newConcentrator(c, defaultStatsBucketSize),
 	}
 	return t
@@ -219,7 +209,7 @@ func newTracer(opts ...StartOption) *tracer {
 	}()
 	t.stats.Start()
 	appsec.Start(&appsec.Config{
-		Client:   c.client(),
+		Client:   c.httpClient,
 		Version:  version.Tag,
 		AgentURL: fmt.Sprintf("http://%s/", resolveAddr(c.agentAddr)),
 		Hostname: c.hostname,
@@ -254,78 +244,6 @@ func (t *tracer) flushSync() {
 	done := make(chan struct{})
 	t.flush <- done
 	<-done
-}
-
-// agentFeatures holds information about the trace-agent's capabilities.
-type agentFeatures struct {
-	mu sync.RWMutex
-
-	// DropP0s reports whether it's ok for the tracer to not send any
-	// P0 traces to the agent.
-	DropP0s bool
-
-	// V05 reports whether it's ok to use the /v0.5/traces endpoint format.
-	V05 bool // TODO(x): Not yet implemented
-
-	// Stats reports whether the agent can receive client-computed stats on
-	// the /v0.6/stats endpoint.
-	Stats bool
-}
-
-// Load returns the current features.
-func (f *agentFeatures) Load() agentFeatures {
-	f.mu.RLock()
-	out := *f
-	f.mu.RUnlock()
-	return out
-}
-
-// Store stores the new features.
-func (f *agentFeatures) Store(newf agentFeatures) {
-	f.mu.Lock()
-	f.DropP0s = newf.DropP0s
-	f.V05 = newf.V05
-	f.Stats = newf.Stats
-	f.mu.Unlock()
-}
-
-// loadAgentFeatures queries the trace-agent for its capabilities and updates
-// the tracer's behaviour.
-func (t *tracer) loadAgentFeatures() {
-	if t.config.logToStdout {
-		// there is no agent
-		return
-	}
-	resp, err := t.config.client().Get(fmt.Sprintf("http://%s/info", t.config.agentAddr))
-	if err != nil {
-		log.Error("Loading features: %v", err)
-		return
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		// agent is older than 7.28.0, features not discoverable
-		t.features.Store(agentFeatures{})
-		return
-	}
-	defer resp.Body.Close()
-	type infoResponse struct {
-		Endpoints     []string `json:"endpoints"`
-		ClientDropP0s bool     `json:"client_drop_p0s"`
-	}
-	var info infoResponse
-	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
-		log.Error("Decoding features: %v", err)
-		return
-	}
-	f := agentFeatures{DropP0s: info.ClientDropP0s}
-	for _, endpoint := range info.Endpoints {
-		switch endpoint {
-		case "/v0.6/stats":
-			f.Stats = true
-		case "/v0.5/traces":
-			f.V05 = true
-		}
-	}
-	t.features.Store(f)
 }
 
 // worker receives finished traces to be added into the payload, as well

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -296,7 +296,7 @@ func (t *tracer) loadAgentFeatures() {
 		// there is no agent
 		return
 	}
-	resp, err := http.Get(fmt.Sprintf("http://%s/info", t.config.agentAddr))
+	resp, err := t.config.client().Get(fmt.Sprintf("http://%s/info", t.config.agentAddr))
 	if err != nil {
 		log.Error("Loading features: %v", err)
 		return

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -274,7 +274,7 @@ func TestSamplingDecision(t *testing.T) {
 	t.Run("dropped", func(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
-		tracer.features.DropP0s = true
+		tracer.config.features.DropP0s = true
 		tracer.prioritySampling.defaultRate = 0
 		tracer.config.serviceName = "test_service"
 		span := tracer.StartSpan("name_1").(*span)
@@ -288,7 +288,7 @@ func TestSamplingDecision(t *testing.T) {
 	t.Run("events_sampled", func(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
-		tracer.features.DropP0s = true
+		tracer.config.features.DropP0s = true
 		tracer.prioritySampling.defaultRate = 0
 		tracer.config.serviceName = "test_service"
 		span := tracer.StartSpan("name_1").(*span)
@@ -303,7 +303,7 @@ func TestSamplingDecision(t *testing.T) {
 	t.Run("client_dropped", func(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
-		tracer.features.DropP0s = true
+		tracer.config.features.DropP0s = true
 		tracer.config.sampler = NewRateSampler(0)
 		tracer.prioritySampling.defaultRate = 0
 		tracer.config.serviceName = "test_service"

--- a/ddtrace/tracer/transport.go
+++ b/ddtrace/tracer/transport.go
@@ -31,17 +31,19 @@ const (
 	headerComputedTopLevel = "Datadog-Client-Computed-Top-Level"
 )
 
+var defaultDialer = &net.Dialer{
+	Timeout:   30 * time.Second,
+	KeepAlive: 30 * time.Second,
+	DualStack: true,
+}
+
 var defaultClient = &http.Client{
 	// We copy the transport to avoid using the default one, as it might be
 	// augmented with tracing and we don't want these calls to be recorded.
 	// See https://golang.org/pkg/net/http/#DefaultTransport .
 	Transport: &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-			DualStack: true,
-		}).DialContext,
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           defaultDialer.DialContext,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
@@ -146,7 +148,7 @@ func (t *httpTransport) send(p *payload) (body io.ReadCloser, err error) {
 	req.Header.Set("Content-Length", strconv.Itoa(p.size()))
 	req.Header.Set(headerComputedTopLevel, "yes")
 	if t, ok := traceinternal.GetGlobalTracer().(*tracer); ok {
-		if t.features.Load().Stats {
+		if t.config.features.Stats {
 			req.Header.Set("Datadog-Client-Computed-Stats", "yes")
 		}
 		droppedTraces := int(atomic.SwapUint64(&t.droppedP0Traces, 0))

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -267,7 +267,7 @@ func TestWithUDS(t *testing.T) {
 		t.Fatal(err)
 	}
 	var hits int
-	srv := &http.Server{Handler: http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+	srv := http.Server{Handler: http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		hits++
 	})}
 	go srv.Serve(unixListener)

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -60,26 +60,6 @@ func getTestTrace(traceN, size int) [][]*span {
 	return traces
 }
 
-type mockDatadogAPIHandler struct {
-	t *testing.T
-}
-
-func (m mockDatadogAPIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	assert := assert.New(m.t)
-
-	header := r.Header.Get("X-Datadog-Trace-Count")
-	assert.NotEqual("", header, "X-Datadog-Trace-Count header should be here")
-	count, err := strconv.Atoi(header)
-	assert.Nil(err, "header should be an int")
-	assert.NotEqual(0, count, "there should be a non-zero amount of traces")
-}
-
-func mockDatadogAPINewServer(t *testing.T) *httptest.Server {
-	handler := mockDatadogAPIHandler{t: t}
-	server := httptest.NewServer(handler)
-	return server
-}
-
 func TestTracesAgentIntegration(t *testing.T) {
 	if !integration {
 		t.Skip("to enable integration test, set the INTEGRATION environment variable")
@@ -191,22 +171,27 @@ func TestTraceCountHeader(t *testing.T) {
 		{getTestTrace(100, 10)},
 	}
 
-	receiver := mockDatadogAPINewServer(t)
-	parsedURL, err := url.Parse(receiver.URL)
-	assert.NoError(err)
-	host := parsedURL.Host
-	_, port, err := net.SplitHostPort(host)
-	assert.Nil(err)
-	assert.NotEmpty(port, "port should be given, as it's chosen randomly")
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if r.URL.Path == "/info" {
+			return
+		}
+		header := r.Header.Get("X-Datadog-Trace-Count")
+		assert.NotEqual("", header, "X-Datadog-Trace-Count header should be here")
+		count, err := strconv.Atoi(header)
+		assert.Nil(err, "header should be an int")
+		assert.NotEqual(0, count, "there should be a non-zero amount of traces")
+	}))
+	defer srv.Close()
 	for _, tc := range testCases {
-		transport := newHTTPTransport(host, defaultClient)
+		transport := newHTTPTransport(strings.TrimPrefix(srv.URL, "http://"), defaultClient)
 		p, err := encode(tc.payload)
 		assert.NoError(err)
 		_, err = transport.send(p)
 		assert.NoError(err)
 	}
-
-	receiver.Close()
+	assert.Equal(hits, len(testCases))
 }
 
 type recordingRoundTripper struct {
@@ -226,32 +211,34 @@ func (r *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 func TestCustomTransport(t *testing.T) {
 	assert := assert.New(t)
 
-	receiver := mockDatadogAPINewServer(t)
-	defer receiver.Close()
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		hits++
+	}))
+	defer srv.Close()
 
-	parsedURL, err := url.Parse(receiver.URL)
-	assert.NoError(err)
-	host := parsedURL.Host
-	_, port, err := net.SplitHostPort(host)
-	assert.Nil(err)
-	assert.NotEmpty(port, "port should be given, as it's chosen randomly")
-
-	customRoundTripper := newRecordingRoundTripper(defaultClient)
-	transport := newHTTPTransport(host, &http.Client{Transport: customRoundTripper})
+	crt := newRecordingRoundTripper(defaultClient)
+	transport := newHTTPTransport(strings.TrimPrefix(srv.URL, "http://"), &http.Client{
+		Transport: crt,
+	})
 	p, err := encode(getTestTrace(1, 1))
 	assert.NoError(err)
 	_, err = transport.send(p)
 	assert.NoError(err)
 
 	// make sure our custom round tripper was used
-	assert.Len(customRoundTripper.reqs, 1)
+	assert.Len(crt.reqs, 1)
+	assert.Equal(hits, 1)
 }
 
 func TestWithHTTPClient(t *testing.T) {
 	os.Setenv("DD_TRACE_STARTUP_LOGS", "0")
 	defer os.Unsetenv("DD_TRACE_STARTUP_LOGS")
 	assert := assert.New(t)
-	srv := mockDatadogAPINewServer(t)
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		hits++
+	}))
 	defer srv.Close()
 
 	u, err := url.Parse(srv.URL)
@@ -264,7 +251,10 @@ func TestWithHTTPClient(t *testing.T) {
 	assert.NoError(err)
 	_, err = trc.config.transport.send(p)
 	assert.NoError(err)
-	assert.Len(rt.reqs, 1)
+	assert.Len(rt.reqs, 2)
+	assert.Contains(rt.reqs[0].URL.Path, "/info")
+	assert.Contains(rt.reqs[1].URL.Path, "/traces")
+	assert.Equal(hits, 2)
 }
 
 func TestWithUDS(t *testing.T) {
@@ -276,7 +266,10 @@ func TestWithUDS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	srv := &http.Server{Handler: mockDatadogAPIHandler{t: t}}
+	var hits int
+	srv := &http.Server{Handler: http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		hits++
+	})}
 	go srv.Serve(unixListener)
 	defer srv.Close()
 
@@ -290,5 +283,6 @@ func TestWithUDS(t *testing.T) {
 	assert.NoError(err)
 	_, err = trc.config.transport.send(p)
 	assert.NoError(err)
-	assert.Len(rt.reqs, 1)
+	assert.Len(rt.reqs, 2)
+	assert.Equal(hits, 2)
 }

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -261,7 +262,12 @@ func TestWithUDS(t *testing.T) {
 	os.Setenv("DD_TRACE_STARTUP_LOGS", "0")
 	defer os.Unsetenv("DD_TRACE_STARTUP_LOGS")
 	assert := assert.New(t)
-	udsPath := "/tmp/com.datadoghq.dd-trace-go.tracer.test.sock"
+	dir, err := ioutil.TempDir("", "socket")
+	if err != nil {
+		t.Fatal(err)
+	}
+	udsPath := filepath.Join(dir, "apm.socket")
+	defer os.RemoveAll(udsPath)
 	unixListener, err := net.Listen("unix", udsPath)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This change alters the default HTTP transport client and Dogstatsd
connection so that it takes into account socket paths when available.

* /var/run/datadog/apm.socket for traces
* /var/run/datadog/dsd.socket for stats

User-config can and will override these when set.

Closes #985 