### PR TITLE
ddtrace/tracer: disable statsd client for long-running test

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -274,6 +274,13 @@ func statsTags(c *config) []string {
 	return tags
 }
 
+// withNoopStats is used for testing to disable statsd client
+func withNoopStats() StartOption {
+	return func(c *config) {
+		c.statsd = &statsd.NoOpClient{}
+	}
+}
+
 // WithFeatureFlags specifies a set of feature flags to enable. Please take into account
 // that most, if not all features flags are considered to be experimental and result in
 // unexpected bugs.

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -109,10 +109,10 @@ func TestTracerCleanStop(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < n; i++ {
 			// Lambda mode is used to avoid the startup cost associated with agent discovery.
-			Start(withTransport(transport), WithLambdaMode(true))
+			Start(withTransport(transport), WithLambdaMode(true), withNoopStats())
 			time.Sleep(time.Millisecond)
-			Start(withTransport(transport), WithLambdaMode(true), WithSampler(NewRateSampler(0.99)))
-			Start(withTransport(transport), WithLambdaMode(true), WithSampler(NewRateSampler(0.99)))
+			Start(withTransport(transport), WithLambdaMode(true), WithSampler(NewRateSampler(0.99)), withNoopStats())
+			Start(withTransport(transport), WithLambdaMode(true), WithSampler(NewRateSampler(0.99)), withNoopStats())
 		}
 	}()
 


### PR DESCRIPTION
TestTracerCleanStop is quite slow. Upon investigation, a major portion of
the cost is associated with the startup of the statsd client, which is not
important for the test to function. This change adds an unexported
StartOption to the package that uses a statsd.NoOpClient, which is much
cheaper, reducing the wall time of the test by about 90% in some cases.