### PR TITLE
contrib/gin-gonic: add option to ignore request

### DIFF
--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -29,6 +29,10 @@ func Middleware(service string, opts ...Option) gin.HandlerFunc {
 	}
 	log.Debug("contrib/gin-gonic/gin: Configuring Middleware: Service: %s, %#v", service, cfg)
 	return func(c *gin.Context) {
+		if cfg.ignoreRequest(c) {
+			return
+		}
+		
 		resource := cfg.resourceNamer(c)
 		opts := []ddtrace.StartSpanOption{
 			tracer.ServiceName(cfg.serviceName),

--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -32,7 +32,6 @@ func Middleware(service string, opts ...Option) gin.HandlerFunc {
 		if cfg.ignoreRequest(c) {
 			return
 		}
-
 		resource := cfg.resourceNamer(c)
 		opts := []ddtrace.StartSpanOption{
 			tracer.ServiceName(cfg.serviceName),

--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -32,7 +32,7 @@ func Middleware(service string, opts ...Option) gin.HandlerFunc {
 		if cfg.ignoreRequest(c) {
 			return
 		}
-		
+
 		resource := cfg.resourceNamer(c)
 		opts := []ddtrace.StartSpanOption{
 			tracer.ServiceName(cfg.serviceName),

--- a/contrib/gin-gonic/gin/gintrace_test.go
+++ b/contrib/gin-gonic/gin/gintrace_test.go
@@ -356,8 +356,8 @@ func TestIgnoreRequestSettings(t *testing.T) {
 	})
 
 	for path, shouldSkip := range map[string]bool{
-		"/OK": false,
-		"/skip": true,
+		"/OK":      false,
+		"/skip":    true,
 		"/skipfoo": true,
 	} {
 		mt := mocktracer.Start()

--- a/contrib/gin-gonic/gin/option.go
+++ b/contrib/gin-gonic/gin/option.go
@@ -75,7 +75,7 @@ func WithResourceNamer(namer func(c *gin.Context) string) Option {
 	}
 }
 
-// WithIgnoreRequest holds the function to use for determining if the
+// WithIgnoreRequest specifies a function to use for determining if the
 // incoming HTTP request tracing should be skipped.
 func WithIgnoreRequest(f func(c *gin.Context) bool) Option {
 	return func(cfg *config) {

--- a/contrib/gin-gonic/gin/option.go
+++ b/contrib/gin-gonic/gin/option.go
@@ -19,6 +19,7 @@ type config struct {
 	analyticsRate float64
 	resourceNamer func(c *gin.Context) string
 	serviceName   string
+	ignoreRequest func(c *gin.Context) bool
 }
 
 func newConfig(service string) *config {
@@ -36,6 +37,7 @@ func newConfig(service string) *config {
 		analyticsRate: rate,
 		resourceNamer: defaultResourceNamer,
 		serviceName:   service,
+		ignoreRequest: func(_ *gin.Context) bool { return false },
 	}
 }
 
@@ -70,6 +72,14 @@ func WithAnalyticsRate(rate float64) Option {
 func WithResourceNamer(namer func(c *gin.Context) string) Option {
 	return func(cfg *config) {
 		cfg.resourceNamer = namer
+	}
+}
+
+// WithIgnoreRequest holds the function to use for determining if the
+// incoming HTTP request tracing should be skipped.
+func WithIgnoreRequest(f func(c *gin.Context) bool) Option {
+	return func(cfg *config) {
+		cfg.ignoreRequest = f
 	}
 }
 


### PR DESCRIPTION
This PR add's an option to ignore requests for contrib/gin-gonic.

Fixes: #1060 