### PR TITLE
contrib/net/http: Add `ignoreRequest()` to `WrapHandler()`

### DIFF
--- a/contrib/net/http/http.go
+++ b/contrib/net/http/http.go
@@ -64,6 +64,10 @@ func WrapHandler(h http.Handler, service, resource string, opts ...Option) http.
 	}
 	log.Debug("contrib/net/http: Wrapping Handler: Service: %s, Resource: %s, %#v", service, resource, cfg)
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if cfg.ignoreRequest(req) {
+			h.ServeHTTP(w, req)
+			return
+		}
 		httputil.TraceAndServe(h, &httputil.TraceConfig{
 			ResponseWriter: w,
 			Request:        req,


### PR DESCRIPTION
**What this PR does**

Add the logic to ignore requests when we use `http.WrapHandler()`.

**Motivation**

We can't ignore request when use `http.WrapHandler()` even though `WithIgnoreRequest()` can be set as an option.
