### PR TITLE
ddtrace/tracer: increase wait times for AppSec tests.

### DIFF
--- a/ddtrace/tracer/stats_test.go
+++ b/ddtrace/tracer/stats_test.go
@@ -16,7 +16,7 @@ import (
 // period.
 func waitForBuckets(c *concentrator, n int) bool {
 	for i := 0; i < 5; i++ {
-		time.Sleep(time.Millisecond)
+		time.Sleep(time.Millisecond * timeMultiplicator)
 		c.mu.Lock()
 		if len(c.buckets) == n {
 			return true
@@ -134,7 +134,7 @@ func TestConcentrator(t *testing.T) {
 				Start:    time.Now().UnixNano() - 4*500000,
 				Duration: 1,
 			}
-			time.Sleep(2 * time.Millisecond)
+			time.Sleep(2 * time.Millisecond * timeMultiplicator)
 			c.Stop()
 			assert.NotZero(t, transport.Stats())
 		})

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -22,6 +22,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
+	maininternal "gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 
@@ -44,8 +45,27 @@ func (t *tracer) newChildSpan(name string, parent *span) *span {
 	return t.StartSpan(name, ChildOf(parent.Context())).(*span)
 }
 
+var (
+	// timeMultiplicator specifies by how long to extend waiting times.
+	// It may be altered in some envinronment (like AppSec) where things
+	// move slower and could otherwise create flaky tests.
+	timeMultiplicator = time.Duration(1)
+
+	// integration indicates if the test suite should run integration tests.
+	integration bool
+)
+
+func TestMain(m *testing.M) {
+	if maininternal.BoolEnv("DD_APPSEC_ENABLED", false) {
+		// things are slower with AppSec; double wait times
+		timeMultiplicator = time.Duration(2)
+	}
+	_, integration = os.LookupEnv("INTEGRATION")
+	os.Exit(m.Run())
+}
+
 func (t *tracer) awaitPayload(tst *testing.T, n int) {
-	timeout := time.After(200 * time.Millisecond)
+	timeout := time.After(200 * time.Millisecond * timeMultiplicator)
 loop:
 	for {
 		select {
@@ -74,9 +94,8 @@ func TestTracerCleanStop(t *testing.T) {
 	if testing.Short() {
 		return
 	}
-	// Avoid CI timeouts due to AppSec slowing down this test due to its init
-	// time.
 	if old := os.Getenv("DD_APPSEC_ENABLED"); old != "" {
+		// avoid CI timeouts due to AppSec slowing down this test
 		os.Unsetenv("DD_APPSEC_ENABLED")
 		defer os.Setenv("DD_APPSEC_ENABLED", old)
 	}
@@ -1027,7 +1046,7 @@ func TestWorker(t *testing.T) {
 	}
 
 	flush(-1)
-	timeout := time.After(2 * time.Second)
+	timeout := time.After(2 * time.Second * timeMultiplicator)
 loop:
 	for {
 		select {
@@ -1323,7 +1342,7 @@ func startTestTracer(t interface {
 			tick <- time.Now()
 			return
 		}
-		d := 200 * time.Millisecond
+		d := 200 * time.Millisecond * timeMultiplicator
 		expire := time.After(d)
 	loop:
 		for {

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -21,14 +21,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// integration indicates if the test suite should run integration tests.
-var integration bool
-
-func TestMain(m *testing.M) {
-	_, integration = os.LookupEnv("INTEGRATION")
-	os.Exit(m.Run())
-}
-
 // getTestSpan returns a Span with different fields set
 func getTestSpan() *span {
 	return &span{


### PR DESCRIPTION
This change introduces a wait time multiplicator that gets applied to
certain tests and scenarios when DD_APPSEC_ENABLED=true. This was
previously causing flaky tests.