### PR TITLE
ddtrace/tracer: propagate _dd.p.upstream_services tags

### DIFF
--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -15,6 +15,7 @@ const (
 	TargetPort = "out.port"
 
 	// SamplingPriority is the tag that marks the sampling priority of a span.
+	// Deprecated in favor of ManualKeep and ManualDrop.
 	SamplingPriority = "sampling.priority"
 
 	// SQLType sets the sql type tag.

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -38,6 +38,9 @@ var (
 	// defaultSocketDSD specifies the socket path to use for connecting to the statsd server.
 	// Replaced in tests
 	defaultSocketDSD = "/var/run/datadog/dsd.socket"
+
+	// defaultMaxTagsHeaderLen specifies the default maximum length of the X-Datadog-Tags header value.
+	defaultMaxTagsHeaderLen = 512
 )
 
 // config holds the tracer configuration.
@@ -256,7 +259,9 @@ func newConfig(opts ...StartOption) *config {
 		c.transport = newHTTPTransport(c.agentAddr, c.httpClient)
 	}
 	if c.propagator == nil {
-		c.propagator = NewPropagator(nil)
+		c.propagator = NewPropagator(&PropagatorConfig{
+			MaxTagsHeaderLen: internal.IntEnv("DD_TRACE_TAGS_PROPAGATION_MAX_LENGTH", defaultMaxTagsHeaderLen),
+		})
 	}
 	if c.logger != nil {
 		log.UseLogger(c.logger)

--- a/ddtrace/tracer/sampler.go
+++ b/ddtrace/tracer/sampler.go
@@ -24,6 +24,36 @@ import (
 	"golang.org/x/time/rate"
 )
 
+// samplerName specifies the name of a sampler which was
+// responsible for a certain sampling decision.
+type samplerName int8
+
+const (
+	// samplerUpstream specifies that the sampling decision was made in an upstream service
+	// and no sampling needs to be done.
+	samplerUpstream samplerName = math.MinInt8
+	// samplerUnknown specifies that the span was sampled
+	// but, the tracer was unable to identify the sampler.
+	samplerUnknown samplerName = -1
+	// samplerDefault specifies that the span was sampled without any sampler.
+	samplerDefault samplerName = 0
+	// samplerAgentRate specifies that the span was sampled
+	// with a rate calculated by the trace agent.
+	samplerAgentRate samplerName = 1
+	// samplerRemoteRate specifies that the span was sampled
+	// with a dynamically calculated remote rate.
+	samplerRemoteRate samplerName = 2
+	// samplerRuleRate specifies that the span was sampled by the RuleSampler.
+	samplerRuleRate samplerName = 3
+	// samplerManual specifies that the span was sampled manually by user.
+	samplerManual samplerName = 4
+	// samplerAppSec specifies that the span was sampled by AppSec.
+	samplerAppSec samplerName = 5
+	// samplerRemoteUserRate specifies that the span was sampled
+	// with an user specified remote rate.
+	samplerRemoteUserRate samplerName = 6
+)
+
 // Sampler is the generic interface of any sampler. It must be safe for concurrent use.
 type Sampler interface {
 	// Sample returns true if the given span should be sampled.
@@ -150,9 +180,9 @@ func (ps *prioritySampler) getRate(spn *span) float64 {
 func (ps *prioritySampler) apply(spn *span) {
 	rate := ps.getRate(spn)
 	if sampledByRate(spn.TraceID, rate) {
-		spn.SetTag(ext.SamplingPriority, ext.PriorityAutoKeep)
+		spn.setSamplingPriority(ext.PriorityAutoKeep, samplerAgentRate, rate)
 	} else {
-		spn.SetTag(ext.SamplingPriority, ext.PriorityAutoReject)
+		spn.setSamplingPriority(ext.PriorityAutoReject, samplerAgentRate, rate)
 	}
 	spn.SetTag(keySamplingPriorityRate, rate)
 }
@@ -311,15 +341,15 @@ func (rs *rulesSampler) apply(span *span) bool {
 func (rs *rulesSampler) applyRate(span *span, rate float64, now time.Time) {
 	span.SetTag(keyRulesSamplerAppliedRate, rate)
 	if !sampledByRate(span.TraceID, rate) {
-		span.SetTag(ext.SamplingPriority, ext.PriorityUserReject)
+		span.setSamplingPriority(ext.PriorityUserReject, samplerRuleRate, rate)
 		return
 	}
 
 	sampled, rate := rs.limiter.allowOne(now)
 	if sampled {
-		span.SetTag(ext.SamplingPriority, ext.PriorityUserKeep)
+		span.setSamplingPriority(ext.PriorityUserKeep, samplerRuleRate, rate)
 	} else {
-		span.SetTag(ext.SamplingPriority, ext.PriorityUserReject)
+		span.setSamplingPriority(ext.PriorityUserReject, samplerRuleRate, rate)
 	}
 	span.SetTag(keyRulesSamplerLimiterRate, rate)
 }

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -10,6 +10,7 @@ package tracer
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"reflect"
 	"runtime"
@@ -148,6 +149,27 @@ func (s *span) SetTag(key string, value interface{}) {
 	s.setMeta(key, fmt.Sprint(value))
 }
 
+// setSamplingPriority locks then span, then updates the sampling priority.
+// It also updates the trace's sampling priority.
+func (s *span) setSamplingPriority(priority int, sampler samplerName, rate float64) {
+	s.Lock()
+	defer s.Unlock()
+	s.setSamplingPriorityLocked(priority, sampler, rate)
+}
+
+// setSamplingPriorityLocked updates the sampling priority.
+// It also updates the trace's sampling priority.
+func (s *span) setSamplingPriorityLocked(priority int, sampler samplerName, rate float64) {
+	// We don't lock spans when flushing, so we could have a data race when
+	// modifying a span as it's being flushed. This protects us against that
+	// race, since spans are marked `finished` before we flush them.
+	if s.finished {
+		return
+	}
+	s.setMetric(keySamplingPriority, float64(priority))
+	s.context.setSamplingPriority(s.Service, priority, sampler, rate)
+}
+
 // setTagError sets the error tag. It accounts for various valid scenarios.
 // This method is not safe for concurrent use.
 func (s *span) setTagError(value interface{}, cfg errorConfig) {
@@ -266,11 +288,11 @@ func (s *span) setTagBool(key string, v bool) {
 		}
 	case ext.ManualDrop:
 		if v {
-			s.setMetric(ext.SamplingPriority, ext.PriorityUserReject)
+			s.setSamplingPriorityLocked(ext.PriorityUserReject, samplerManual, math.NaN())
 		}
 	case ext.ManualKeep:
 		if v {
-			s.setMetric(ext.SamplingPriority, ext.PriorityUserKeep)
+			s.setSamplingPriorityLocked(ext.PriorityUserKeep, samplerManual, math.NaN())
 		}
 	default:
 		if v {
@@ -289,10 +311,14 @@ func (s *span) setMetric(key string, v float64) {
 	}
 	delete(s.Meta, key)
 	switch key {
+	case ext.ManualKeep:
+		if v == float64(samplerAppSec) {
+			s.setSamplingPriorityLocked(ext.PriorityUserKeep, samplerAppSec, math.NaN())
+		}
 	case ext.SamplingPriority:
-		// setting sampling priority per spec
-		s.Metrics[keySamplingPriority] = v
-		s.context.setSamplingPriority(int(v))
+		// ext.SamplingPriority is deprecated in favor of ext.ManualKeep and ext.ManualDrop.
+		// We have it here for backward compatibility.
+		s.setSamplingPriorityLocked(int(v), samplerManual, math.NaN())
 	default:
 		s.Metrics[key] = v
 	}
@@ -525,6 +551,7 @@ func (s *span) Format(f fmt.State, c rune) {
 const (
 	keySamplingPriority        = "_sampling_priority_v1"
 	keySamplingPriorityRate    = "_dd.agent_psr"
+	keyUpstreamServices        = "_dd.p.upstream_services"
 	keyOrigin                  = "_dd.origin"
 	keyHostname                = "_dd.hostname"
 	keyRulesSamplerAppliedRate = "_dd.rule_psr"

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -26,6 +26,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/samplernames"
 
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 	"github.com/tinylib/msgp/msgp"
@@ -151,7 +152,7 @@ func (s *span) SetTag(key string, value interface{}) {
 
 // setSamplingPriority locks then span, then updates the sampling priority.
 // It also updates the trace's sampling priority.
-func (s *span) setSamplingPriority(priority int, sampler samplerName, rate float64) {
+func (s *span) setSamplingPriority(priority int, sampler samplernames.SamplerName, rate float64) {
 	s.Lock()
 	defer s.Unlock()
 	s.setSamplingPriorityLocked(priority, sampler, rate)
@@ -159,7 +160,7 @@ func (s *span) setSamplingPriority(priority int, sampler samplerName, rate float
 
 // setSamplingPriorityLocked updates the sampling priority.
 // It also updates the trace's sampling priority.
-func (s *span) setSamplingPriorityLocked(priority int, sampler samplerName, rate float64) {
+func (s *span) setSamplingPriorityLocked(priority int, sampler samplernames.SamplerName, rate float64) {
 	// We don't lock spans when flushing, so we could have a data race when
 	// modifying a span as it's being flushed. This protects us against that
 	// race, since spans are marked `finished` before we flush them.
@@ -288,11 +289,11 @@ func (s *span) setTagBool(key string, v bool) {
 		}
 	case ext.ManualDrop:
 		if v {
-			s.setSamplingPriorityLocked(ext.PriorityUserReject, samplerManual, math.NaN())
+			s.setSamplingPriorityLocked(ext.PriorityUserReject, samplernames.Manual, math.NaN())
 		}
 	case ext.ManualKeep:
 		if v {
-			s.setSamplingPriorityLocked(ext.PriorityUserKeep, samplerManual, math.NaN())
+			s.setSamplingPriorityLocked(ext.PriorityUserKeep, samplernames.Manual, math.NaN())
 		}
 	default:
 		if v {
@@ -312,13 +313,13 @@ func (s *span) setMetric(key string, v float64) {
 	delete(s.Meta, key)
 	switch key {
 	case ext.ManualKeep:
-		if v == float64(samplerAppSec) {
-			s.setSamplingPriorityLocked(ext.PriorityUserKeep, samplerAppSec, math.NaN())
+		if v == float64(samplernames.AppSec) {
+			s.setSamplingPriorityLocked(ext.PriorityUserKeep, samplernames.AppSec, math.NaN())
 		}
 	case ext.SamplingPriority:
 		// ext.SamplingPriority is deprecated in favor of ext.ManualKeep and ext.ManualDrop.
 		// We have it here for backward compatibility.
-		s.setSamplingPriorityLocked(int(v), samplerManual, math.NaN())
+		s.setSamplingPriorityLocked(int(v), samplernames.Manual, math.NaN())
 	default:
 		s.Metrics[key] = v
 	}

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -456,7 +456,9 @@ func TestSpanError(t *testing.T) {
 	span.Finish()
 	span.SetTag(ext.Error, err)
 	assert.Equal(int32(0), span.Error)
-	assert.Equal(nMeta, len(span.Meta))
+	// '+1' is `_dd.p.upstream_services`,
+	// because we add it into Meta of the first span, when root is finished.
+	assert.Equal(nMeta+1, len(span.Meta))
 	assert.Equal("", span.Meta["error.msg"])
 	assert.Equal("", span.Meta["error.type"])
 	assert.Equal("", span.Meta["error.stack"])

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -230,13 +230,11 @@ func (t *trace) setSamplingPriorityLocked(service string, p int, sampler sampler
 	}
 	*t.priority = float64(p)
 	if sampler != samplerUpstream {
-		v := t.tags[keyUpstreamServices]
-		if v != "" {
-			v += ";" + compactUpstreamServices(service, p, sampler, rate)
+		if t.upstreamServices != "" {
+			t.setTag(keyUpstreamServices, t.upstreamServices+";"+compactUpstreamServices(service, p, sampler, rate))
 		} else {
-			v = compactUpstreamServices(service, p, sampler, rate)
+			t.setTag(keyUpstreamServices, compactUpstreamServices(service, p, sampler, rate))
 		}
-		t.setTag(keyUpstreamServices, v)
 	}
 }
 

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -17,6 +17,7 @@ import (
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/samplernames"
 )
 
 func setupteardown(start, max int) func() {
@@ -425,13 +426,13 @@ func TestBuildNewUpstreamServices(t *testing.T) {
 	var testCases = []struct {
 		service  string
 		priority int
-		sampler  samplerName
+		sampler  samplernames.SamplerName
 		rate     float64
 		expected string
 	}{
-		{"service-account", 1, samplerAgentRate, 0.99, "c2VydmljZS1hY2NvdW50|1|1|0.9900"},
-		{"service-storage", 2, samplerManual, math.NaN(), "c2VydmljZS1zdG9yYWdl|2|4|"},
-		{"service-video", 1, samplerRuleRate, 1, "c2VydmljZS12aWRlbw|1|3|1.0000"},
+		{"service-account", 1, samplernames.AgentRate, 0.99, "c2VydmljZS1hY2NvdW50|1|1|0.9900"},
+		{"service-storage", 2, samplernames.Manual, math.NaN(), "c2VydmljZS1zdG9yYWdl|2|4|"},
+		{"service-video", 1, samplernames.RuleRate, 1, "c2VydmljZS12aWRlbw|1|3|1.0000"},
 	}
 
 	for _, tt := range testCases {

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -7,6 +7,7 @@ package tracer
 
 import (
 	"context"
+	"math"
 	"strings"
 	"sync"
 	"testing"
@@ -68,6 +69,21 @@ func TestAsyncSpanRace(t *testing.T) {
 					for i := 0; i < 500; i++ {
 						for range root.(*span).Metrics {
 							// this range simulates iterating over the metrics map
+							// as we do when encoding msgpack upon flushing.
+						}
+					}
+					return
+				}
+			}()
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				select {
+				case <-done:
+					root.Finish()
+					for i := 0; i < 500; i++ {
+						for range root.(*span).Meta {
+							// this range simulates iterating over the meta map
 							// as we do when encoding msgpack upon flushing.
 						}
 					}
@@ -403,6 +419,24 @@ func TestSpanContextIteratorBreak(t *testing.T) {
 	})
 
 	assert.Len(t, got, 0)
+}
+
+func TestBuildNewUpstreamServices(t *testing.T) {
+	var testCases = []struct {
+		service  string
+		priority int
+		sampler  samplerName
+		rate     float64
+		expected string
+	}{
+		{"service-account", 1, samplerAgentRate, 0.99, "c2VydmljZS1hY2NvdW50|1|1|0.9900"},
+		{"service-storage", 2, samplerManual, math.NaN(), "c2VydmljZS1zdG9yYWdl|2|4|"},
+		{"service-video", 1, samplerRuleRate, 1, "c2VydmljZS12aWRlbw|1|3|1.0000"},
+	}
+
+	for _, tt := range testCases {
+		assert.Equal(t, tt.expected, compactUpstreamServices(tt.service, tt.priority, tt.sampler, tt.rate))
+	}
 }
 
 // testLogger implements a mock Printer.

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/samplernames"
 )
 
 // HTTPHeadersCarrier wraps an http.Header as a TextMapWriter and TextMapReader, allowing
@@ -301,7 +302,7 @@ func (p *propagator) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 			if err != nil {
 				return ErrSpanContextCorrupted
 			}
-			ctx.setSamplingPriority("", priority, samplerUpstream, math.NaN())
+			ctx.setSamplingPriority("", priority, samplernames.Upstream, math.NaN())
 		case originHeader:
 			ctx.origin = v
 		case traceTagsHeader:
@@ -398,7 +399,7 @@ func (*propagatorB3) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 			if err != nil {
 				return ErrSpanContextCorrupted
 			}
-			ctx.setSamplingPriority("", priority, samplerUpstream, math.NaN())
+			ctx.setSamplingPriority("", priority, samplernames.Upstream, math.NaN())
 		default:
 		}
 		return nil

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -240,6 +240,7 @@ func TestTracerStartSpan(t *testing.T) {
 			ext.PriorityAutoReject,
 			ext.PriorityAutoKeep,
 		}, span.Metrics[keySamplingPriority])
+		assert.Equal("dHJhY2VyLnRlc3Q|1|1|1.0000", span.context.trace.tags[keyUpstreamServices])
 		// A span is not measured unless made so specifically
 		_, ok := span.Meta[keyMeasured]
 		assert.False(ok)
@@ -251,6 +252,7 @@ func TestTracerStartSpan(t *testing.T) {
 		tracer := newTracer()
 		span := tracer.StartSpan("web.request", Tag(ext.SamplingPriority, ext.PriorityUserKeep)).(*span)
 		assert.Equal(t, float64(ext.PriorityUserKeep), span.Metrics[keySamplingPriority])
+		assert.Equal(t, "dHJhY2VyLnRlc3Q|2|4|", span.context.trace.tags[keyUpstreamServices])
 	})
 
 	t.Run("name", func(t *testing.T) {
@@ -287,6 +289,7 @@ func TestSamplingDecision(t *testing.T) {
 		child.Finish()
 		span.Finish()
 		assert.Equal(t, float64(ext.PriorityAutoReject), span.Metrics[keySamplingPriority])
+		assert.Equal(t, "dGVzdF9zZXJ2aWNl|0|1|0.0000", span.context.trace.tags[keyUpstreamServices])
 		assert.Equal(t, decisionKeep, span.context.trace.samplingDecision)
 	})
 
@@ -301,6 +304,7 @@ func TestSamplingDecision(t *testing.T) {
 		child.Finish()
 		span.Finish()
 		assert.Equal(t, float64(ext.PriorityAutoReject), span.Metrics[keySamplingPriority])
+		assert.Equal(t, "dGVzdF9zZXJ2aWNl|0|1|0.0000", span.context.trace.tags[keyUpstreamServices])
 		assert.Equal(t, decisionNone, span.context.trace.samplingDecision)
 	})
 
@@ -316,6 +320,7 @@ func TestSamplingDecision(t *testing.T) {
 		child.Finish()
 		span.Finish()
 		assert.Equal(t, float64(ext.PriorityAutoReject), span.Metrics[keySamplingPriority])
+		assert.Equal(t, "dGVzdF9zZXJ2aWNl|0|1|0.0000", span.context.trace.tags[keyUpstreamServices])
 		assert.Equal(t, decisionKeep, span.context.trace.samplingDecision)
 	})
 
@@ -332,6 +337,9 @@ func TestSamplingDecision(t *testing.T) {
 		child.Finish()
 		span.Finish()
 		assert.Equal(t, float64(ext.PriorityAutoReject), span.Metrics[keySamplingPriority])
+		// this trace won't be sent to the agent,
+		// therefore not necessary to populate keyUpstreamServices
+		assert.Equal(t, "", span.context.trace.tags[keyUpstreamServices])
 		assert.Equal(t, decisionDrop, span.context.trace.samplingDecision)
 	})
 }
@@ -524,6 +532,7 @@ func TestTracerSamplingPriorityPropagation(t *testing.T) {
 	root := tracer.StartSpan("web.request", Tag(ext.SamplingPriority, 2)).(*span)
 	child := tracer.StartSpan("db.query", ChildOf(root.Context())).(*span)
 	assert.EqualValues(2, root.Metrics[keySamplingPriority])
+	assert.Equal("dHJhY2VyLnRlc3Q|2|4|", root.context.trace.tags[keyUpstreamServices])
 	assert.EqualValues(2, child.Metrics[keySamplingPriority])
 	assert.EqualValues(2., *root.context.trace.priority)
 	assert.EqualValues(2., *child.context.trace.priority)
@@ -536,9 +545,36 @@ func TestTracerSamplingPriorityEmptySpanCtx(t *testing.T) {
 	spanCtx := &spanContext{
 		traceID: root.context.TraceID(),
 		spanID:  root.context.SpanID(),
+		trace: &trace{
+			tags: map[string]string{
+				keyUpstreamServices: "previous",
+			},
+			upstreamServices: "previous",
+		},
 	}
 	child := tracer.StartSpan("db.query", ChildOf(spanCtx)).(*span)
 	assert.EqualValues(1, child.Metrics[keySamplingPriority])
+	assert.Equal("previous;dHJhY2VyLnRlc3Q|1|1|1.0000", child.context.trace.tags[keyUpstreamServices])
+}
+
+func TestTracerDDUpstreamServicesManualKeep(t *testing.T) {
+	assert := assert.New(t)
+	tracer := newTracer()
+	root := newBasicSpan("web.request")
+	spanCtx := &spanContext{
+		traceID: root.context.TraceID(),
+		spanID:  root.context.SpanID(),
+		trace: &trace{
+			tags: map[string]string{
+				keyUpstreamServices: "previous",
+			},
+			upstreamServices: "previous",
+		},
+	}
+	child := tracer.StartSpan("db.query", ChildOf(spanCtx)).(*span)
+	grandChild := tracer.StartSpan("db.query", ChildOf(child.Context())).(*span)
+	grandChild.SetTag(ext.ManualKeep, true)
+	assert.Equal("previous;dHJhY2VyLnRlc3Q|2|4|", grandChild.context.trace.tags[keyUpstreamServices])
 }
 
 func TestTracerBaggageImmutability(t *testing.T) {
@@ -723,6 +759,7 @@ func TestTracerPrioritySampler(t *testing.T) {
 	s := tr.newEnvSpan("pylons", "")
 	assert.Equal(1., s.Metrics[keySamplingPriorityRate])
 	assert.Equal(1., s.Metrics[keySamplingPriority])
+	assert.Equal("cHlsb25z|1|1|1.0000", s.context.trace.tags[keyUpstreamServices])
 	p, ok := s.context.samplingPriority()
 	assert.True(ok)
 	assert.EqualValues(p, s.Metrics[keySamplingPriority])
@@ -758,6 +795,7 @@ func TestTracerPrioritySampler(t *testing.T) {
 		s := tr.newEnvSpan(tt.service, tt.env)
 		assert.Equal(tt.rate, s.Metrics[keySamplingPriorityRate], strconv.Itoa(i))
 		prio, ok := s.Metrics[keySamplingPriority]
+		assert.Equal(b64Encode(tt.service)+"|"+strconv.Itoa(int(prio))+"|1|"+strconv.FormatFloat(tt.rate, 'f', 4, 64), s.context.trace.tags[keyUpstreamServices])
 		assert.True(ok)
 		assert.Contains([]float64{0, 1}, prio)
 		p, ok := s.context.samplingPriority()

--- a/ddtrace/tracer/util.go
+++ b/ddtrace/tracer/util.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/samplernames"
 )
 
 // toFloat64 attempts to convert value into a float64. If the value is an integer
@@ -50,7 +52,7 @@ func toFloat64(value interface{}) (f float64, ok bool) {
 			return 0, false
 		}
 		return float64(i), true
-	case samplerName:
+	case samplernames.SamplerName:
 		return float64(i), true
 	default:
 		return 0, false

--- a/ddtrace/tracer/util.go
+++ b/ddtrace/tracer/util.go
@@ -28,6 +28,8 @@ func toFloat64(value interface{}) (f float64, ok bool) {
 		return i, true
 	case int:
 		return float64(i), true
+	case int8:
+		return float64(i), true
 	case int16:
 		return float64(i), true
 	case int32:
@@ -47,6 +49,8 @@ func toFloat64(value interface{}) (f float64, ok bool) {
 		if i > uint64(max) {
 			return 0, false
 		}
+		return float64(i), true
+	case samplerName:
 		return float64(i), true
 	default:
 		return 0, false

--- a/ddtrace/tracer/util.go
+++ b/ddtrace/tracer/util.go
@@ -6,6 +6,8 @@
 package tracer
 
 import (
+	"encoding/base64"
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -62,4 +64,60 @@ func parseUint64(str string) (uint64, error) {
 		return uint64(id), nil
 	}
 	return strconv.ParseUint(str, 10, 64)
+}
+
+func isValidPropagatableTraceTag(k, v string) error {
+	if len(k) == 0 {
+		return fmt.Errorf("key length must be greater than zero")
+	}
+	for _, ch := range k {
+		if ch < 32 || ch > 126 || ch == ' ' || ch == '=' || ch == ',' {
+			return fmt.Errorf("key contains an invalid character %d", ch)
+		}
+	}
+	if len(v) == 0 {
+		return fmt.Errorf("value length must be greater than zero")
+	}
+	for _, ch := range v {
+		if ch < 32 || ch > 126 || ch == '=' || ch == ',' {
+			return fmt.Errorf("value contains an invalid character %d", ch)
+		}
+	}
+	return nil
+}
+
+func parsePropagatableTraceTags(s string) (map[string]string, error) {
+	if len(s) == 0 {
+		return nil, nil
+	}
+	tags := make(map[string]string)
+	searchingKey, start := true, 0
+	var key string
+	for i, ch := range s {
+		switch ch {
+		case '=':
+			if !searchingKey || i-start == 0 {
+				return nil, fmt.Errorf("invalid format")
+			}
+			key = s[start:i]
+			searchingKey, start = false, i+1
+		case ',':
+			if searchingKey || i-start == 0 {
+				return nil, fmt.Errorf("invalid format")
+			}
+			tags[key] = s[start:i]
+			searchingKey, start = true, i+1
+		}
+	}
+	if searchingKey || len(s)-start == 0 {
+		return nil, fmt.Errorf("invalid format")
+	}
+	tags[key] = s[start:]
+	return tags, nil
+}
+
+var b64 = base64.StdEncoding.WithPadding(base64.NoPadding)
+
+func b64Encode(s string) string {
+	return b64.EncodeToString([]byte(s))
 }

--- a/internal/appsec/dyngo/instrumentation/grpcsec/tags.go
+++ b/internal/appsec/dyngo/instrumentation/grpcsec/tags.go
@@ -14,12 +14,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation/httpsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
-)
-
-const (
-	// samplerAppSec specifies that the span was sampled by AppSec.
-	// Full sampler list can be found in ddtrace/tracer/sampler.go.
-	samplerAppSec int8 = 5
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/samplernames"
 )
 
 // SetSecurityEventTags sets the AppSec-specific span tags when a security event
@@ -61,10 +56,10 @@ func setEventSpanTags(span ddtrace.Span, events []json.RawMessage) error {
 	// Keep this span due to the security event
 	//
 	// This is a workaround to tell the tracer that the trace was kept by AppSec.
-	// Passing any other value than `samplerAppSec` has no effect.
+	// Passing any other value than `appsec.SamplerAppSec` has no effect.
 	// Customers should use `span.SetTag(ext.ManualKeep, true)` pattern
 	// to keep the trace, manually.
-	span.SetTag(ext.ManualKeep, samplerAppSec)
+	span.SetTag(ext.ManualKeep, samplernames.AppSec)
 	span.SetTag("_dd.origin", "appsec")
 	// Set the appsec.event tag needed by the appsec backend
 	span.SetTag("appsec.event", true)

--- a/internal/appsec/dyngo/instrumentation/grpcsec/tags_test.go
+++ b/internal/appsec/dyngo/instrumentation/grpcsec/tags_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 )
 
 func TestSetSecurityEventTags(t *testing.T) {
@@ -158,7 +159,13 @@ func (m *MockSpan) SetTag(key string, value interface{}) {
 	if m.tags == nil {
 		m.tags = make(map[string]interface{})
 	}
-	m.tags[key] = value
+	if key == ext.ManualKeep {
+		if value == samplerAppSec {
+			m.tags[ext.ManualKeep] = true
+		}
+	} else {
+		m.tags[key] = value
+	}
 }
 
 func (m *MockSpan) SetOperationName(operationName string) {

--- a/internal/appsec/dyngo/instrumentation/grpcsec/tags_test.go
+++ b/internal/appsec/dyngo/instrumentation/grpcsec/tags_test.go
@@ -15,6 +15,7 @@ import (
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/samplernames"
 )
 
 func TestSetSecurityEventTags(t *testing.T) {
@@ -160,7 +161,7 @@ func (m *MockSpan) SetTag(key string, value interface{}) {
 		m.tags = make(map[string]interface{})
 	}
 	if key == ext.ManualKeep {
-		if value == samplerAppSec {
+		if value == samplernames.AppSec {
 			m.tags[ext.ManualKeep] = true
 		}
 	} else {

--- a/internal/appsec/dyngo/instrumentation/httpsec/tags.go
+++ b/internal/appsec/dyngo/instrumentation/httpsec/tags.go
@@ -13,12 +13,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
-)
-
-const (
-	// samplerAppSec specifies that the span was sampled by AppSec.
-	// Full sampler list can be found in ddtrace/tracer/sampler.go.
-	samplerAppSec int8 = 5
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/samplernames"
 )
 
 // SetAppSecTags sets the AppSec-specific span tags that are expected to be in
@@ -45,10 +40,10 @@ func setEventSpanTags(span ddtrace.Span, events json.RawMessage) {
 	// Keep this span due to the security event
 	//
 	// This is a workaround to tell the tracer that the trace was kept by AppSec.
-	// Passing any other value than `samplerAppSec` has no effect.
+	// Passing any other value than `appsec.SamplerAppSec` has no effect.
 	// Customers should use `span.SetTag(ext.ManualKeep, true)` pattern
 	// to keep the trace, manually.
-	span.SetTag(ext.ManualKeep, samplerAppSec)
+	span.SetTag(ext.ManualKeep, samplernames.AppSec)
 	span.SetTag("_dd.origin", "appsec")
 	// Set the appsec.event tag needed by the appsec backend
 	span.SetTag("appsec.event", true)

--- a/internal/appsec/dyngo/instrumentation/httpsec/tags.go
+++ b/internal/appsec/dyngo/instrumentation/httpsec/tags.go
@@ -15,6 +15,12 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 )
 
+const (
+	// samplerAppSec specifies that the span was sampled by AppSec.
+	// Full sampler list can be found in ddtrace/tracer/sampler.go.
+	samplerAppSec int8 = 5
+)
+
 // SetAppSecTags sets the AppSec-specific span tags that are expected to be in
 // the web service entry span (span of type `web`) when AppSec is enabled.
 func SetAppSecTags(span ddtrace.Span) {
@@ -37,7 +43,12 @@ func setEventSpanTags(span ddtrace.Span, events json.RawMessage) {
 	}
 	span.SetTag("_dd.appsec.json", string(event))
 	// Keep this span due to the security event
-	span.SetTag(ext.ManualKeep, true)
+	//
+	// This is a workaround to tell the tracer that the trace was kept by AppSec.
+	// Passing any other value than `samplerAppSec` has no effect.
+	// Customers should use `span.SetTag(ext.ManualKeep, true)` pattern
+	// to keep the trace, manually.
+	span.SetTag(ext.ManualKeep, samplerAppSec)
 	span.SetTag("_dd.origin", "appsec")
 	// Set the appsec.event tag needed by the appsec backend
 	span.SetTag("appsec.event", true)

--- a/internal/env.go
+++ b/internal/env.go
@@ -19,3 +19,13 @@ func BoolEnv(key string, def bool) bool {
 	}
 	return v
 }
+
+// IntEnv returns the parsed int value of an environment variable, or
+// def otherwise.
+func IntEnv(key string, def int) int {
+	v, err := strconv.Atoi(os.Getenv(key))
+	if err != nil {
+		return def
+	}
+	return v
+}

--- a/internal/samplernames/samplernames.go
+++ b/internal/samplernames/samplernames.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package samplernames
+
+import "math"
+
+// SamplerName specifies the name of a sampler which was
+// responsible for a certain sampling decision.
+type SamplerName int8
+
+const (
+	// Upstream specifies that the sampling decision was made in an upstream service
+	// and no sampling needs to be done.
+	Upstream SamplerName = math.MinInt8
+	// Unknown specifies that the span was sampled
+	// but, the tracer was unable to identify the sampler.
+	Unknown SamplerName = -1
+	// Default specifies that the span was sampled without any sampler.
+	Default SamplerName = 0
+	// AgentRate specifies that the span was sampled
+	// with a rate calculated by the trace agent.
+	AgentRate SamplerName = 1
+	// RemoteRate specifies that the span was sampled
+	// with a dynamically calculated remote rate.
+	RemoteRate SamplerName = 2
+	// RuleRate specifies that the span was sampled by the RuleSampler.
+	RuleRate SamplerName = 3
+	// Manual specifies that the span was sampled manually by user.
+	Manual SamplerName = 4
+	// AppSec specifies that the span was sampled by AppSec.
+	AppSec SamplerName = 5
+	// RemoteUserRate specifies that the span was sampled
+	// with an user specified remote rate.
+	RemoteUserRate SamplerName = 6
+)


### PR DESCRIPTION
# Changes
- Introduced a notion of trace level tags.
- Introduced a notion of propagated trace level tags.
- Introduced a new trace level tag `_dd.p.upstream_services` that holds the services changed sampling decisions.