### PR TITLE
system tests: run on repo branches only

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   system-tests:
-    if: ${{ secrets.DD_API_KEY }}
+    if: ${{ secrets.DD_API_KEY }} != ""
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   system-tests:
-    if: ${{ secrets.DD_API_KEY }} != ""
+    if: ${{ github.event.pull_request.head.repo.full_name == 'DataDog/dd-trace-go' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   system-tests:
+    if: ${{ secrets.DD_API_KEY }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Do not run the system tests on external repo branches to avoid problems with DD_API_KEY.

A more advanced solution exists and should be discussed separately.