### PR TITLE
codecov: add only_pulls option for patch check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,6 +15,11 @@ coverage:
     patch:
       default:
         target: 90%
+        # Only run this check for pull requests, but skip it for merged
+        # commits. This highlights patches with potential coverage problems
+        # during development, but doesn't make our v1 (release) branch look
+        # like it fails CI checks as we consider this check to be optional.
+        only_pulls: true
 
 flags:
   core:


### PR DESCRIPTION
Only run this check for pull requests, but skip it for merged commits. This
highlights patches with potential coverage problems during development, but
doesn't make our v1 (release) branch look like it fails CI checks as we
consider this check to be optional.

Example of the problem:

![image](https://user-images.githubusercontent.com/15000/145825573-e3d34131-8ac6-4f3b-ba25-ce1301505b4b.png)

Example of how it will look once we apply this patch (from a [test repo](https://github.com/felixge/codecov-test) I played around with):

**Example PR:**

![image](https://user-images.githubusercontent.com/15000/145825784-68adeb03-39bd-4253-b927-452ab9c2cd30.png)

**Example Commit on main branch:**

![image](https://user-images.githubusercontent.com/15000/145825797-9e425089-0770-4219-8373-baa827cfce24.png)
