### PR TITLE
ddtrace/tracer: enable runtime metrics by default

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -217,7 +217,7 @@ func newConfig(opts ...StartOption) *config {
 		c.logToStdout = true
 	}
 	c.logStartup = internal.BoolEnv("DD_TRACE_STARTUP_LOGS", true)
-	c.runtimeMetrics = internal.BoolEnv("DD_RUNTIME_METRICS_ENABLED", false)
+	c.runtimeMetrics = internal.BoolEnv("DD_RUNTIME_METRICS_ENABLED", true)
 	c.debug = internal.BoolEnv("DD_TRACE_DEBUG", false)
 	c.enabled = internal.BoolEnv("DD_TRACE_ENABLED", true)
 	// TODO(fg): set these to true before going GA with this.


### PR DESCRIPTION
This change enables runtime metrics by default, whereas they were
previously disabled by default. This change corresponds to new runtime
metrics dashboards for the Go Tracer in the Datadog UI.

Fixes: #1094