### PR TITLE
revert: StartSpanFromContext for Tracer interface

### DIFF
--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -126,7 +126,7 @@ type StartSpanConfig struct {
 	// then this will also set the TraceID to the same value.
 	SpanID uint64
 
-	// Context holds the context associated with this span.
+	// Context is the parent context where the span should be stored.
 	Context context.Context
 }
 

--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -25,12 +25,6 @@ type Tracer interface {
 	// StartSpan starts a span with the given operation name and options.
 	StartSpan(operationName string, opts ...StartSpanOption) Span
 
-	// StartSpanFromContext starts a span with the given operation name and
-	// options. If a span is found in the context, it will be used as the parent
-	// of the resulting span. If the ChildOf option is passed, the span from
-	// context will take precedence over it as the parent span.
-	StartSpanFromContext(ctx context.Context, operationName string, opts ...StartSpanOption) (Span, context.Context)
-
 	// Extract extracts a span context from a given carrier. Note that baggage item
 	// keys will always be lower-cased to maintain consistency. It is impossible to
 	// maintain the original casing due to MIME header canonicalization standards.
@@ -131,6 +125,9 @@ type StartSpanConfig struct {
 	// Force-set the SpanID, rather than use a random number. If no Parent SpanContext is present,
 	// then this will also set the TraceID to the same value.
 	SpanID uint64
+
+	// Context holds the context associated with this span.
+	Context context.Context
 }
 
 // Logger implementations are able to log given messages that the tracer might output.

--- a/ddtrace/internal/globaltracer.go
+++ b/ddtrace/internal/globaltracer.go
@@ -6,7 +6,6 @@
 package internal // import "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
 
 import (
-	"context"
 	"sync"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
@@ -50,11 +49,6 @@ type NoopTracer struct{}
 // StartSpan implements ddtrace.Tracer.
 func (NoopTracer) StartSpan(operationName string, opts ...ddtrace.StartSpanOption) ddtrace.Span {
 	return NoopSpan{}
-}
-
-// StartSpanFromContext implements ddtrace.Tracer.
-func (NoopTracer) StartSpanFromContext(ctx context.Context, operationName string, options ...ddtrace.StartSpanOption) (ddtrace.Span, context.Context) {
-	return NoopSpan{}, context.Background()
 }
 
 // SetServiceInfo implements ddtrace.Tracer.

--- a/ddtrace/mocktracer/mocktracer.go
+++ b/ddtrace/mocktracer/mocktracer.go
@@ -13,7 +13,6 @@
 package mocktracer
 
 import (
-	"context"
 	"strconv"
 	"strings"
 	"sync"
@@ -74,20 +73,9 @@ func (*mocktracer) Stop() {
 }
 
 func (t *mocktracer) StartSpan(operationName string, opts ...ddtrace.StartSpanOption) ddtrace.Span {
-	span, _ := t.StartSpanFromContext(context.Background(), operationName, opts...)
-	return span
-}
-
-func (t *mocktracer) StartSpanFromContext(ctx context.Context, operationName string, opts ...ddtrace.StartSpanOption) (ddtrace.Span, context.Context) {
 	var cfg ddtrace.StartSpanConfig
 	for _, fn := range opts {
 		fn(&cfg)
-	}
-	if ctx == nil {
-		ctx = context.Background()
-	} else if s, ok := tracer.SpanFromContext(ctx); ok {
-		// span in ctx overwrite ChildOf() parent if any
-		cfg.Parent = s.Context()
 	}
 	span := newSpan(t, operationName, &cfg)
 
@@ -95,7 +83,7 @@ func (t *mocktracer) StartSpanFromContext(ctx context.Context, operationName str
 	t.openSpans[span.SpanID()] = span
 	t.Unlock()
 
-	return span, tracer.ContextWithSpan(ctx, span)
+	return span
 }
 
 func (t *mocktracer) OpenSpans() []Span {

--- a/ddtrace/tracer/context.go
+++ b/ddtrace/tracer/context.go
@@ -39,5 +39,19 @@ func SpanFromContext(ctx context.Context) (Span, bool) {
 // is found in the context, it will be used as the parent of the resulting span. If the ChildOf
 // option is passed, the span from context will take precedence over it as the parent span.
 func StartSpanFromContext(ctx context.Context, operationName string, opts ...StartSpanOption) (Span, context.Context) {
-	return internal.GetGlobalTracer().StartSpanFromContext(ctx, operationName, opts...)
+	if ctx == nil {
+		// default to context.Background() to avoid panics on Go >= 1.15
+		ctx = context.Background()
+	} else if s, ok := SpanFromContext(ctx); ok {
+		opts = append(opts, ChildOf(s.Context()))
+	}
+	opts = append(opts, withContext(ctx))
+	s := StartSpan(operationName, opts...)
+	if span, ok := s.(*span); ok && span.pprofCtxActive != nil {
+		// If pprof labels were applied for this span, use the derived ctx that
+		// includes them. Otherwise a child of this span wouldn't be able to
+		// correctly restore the labels of its parent when it finishes.
+		ctx = span.pprofCtxActive
+	}
+	return s, ContextWithSpan(ctx, s)
 }

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -753,6 +753,13 @@ func ChildOf(ctx ddtrace.SpanContext) StartSpanOption {
 	}
 }
 
+// withContext associates the ctx with the span.
+func withContext(ctx context.Context) StartSpanOption {
+	return func(cfg *ddtrace.StartSpanConfig) {
+		cfg.Context = ctx
+	}
+}
+
 // StartTime sets a custom time as the start time for the created span. By
 // default a span is started using the creation time.
 func StartTime(t time.Time) StartSpanOption {

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -6,7 +6,6 @@
 package tracer
 
 import (
-	"context"
 	gocontext "context"
 	"fmt"
 	"os"
@@ -315,23 +314,11 @@ func (t *tracer) pushTrace(trace []*span) {
 	}
 }
 
-// StartSpan implements ddtrace.Tracer.
+// StartSpan creates, starts, and returns a new Span with the given `operationName`.
 func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOption) ddtrace.Span {
-	span, _ := t.StartSpanFromContext(gocontext.Background(), operationName, options...)
-	return span
-}
-
-// StartSpanFromContext implements ddtrace.Tracer.
-func (t *tracer) StartSpanFromContext(ctx gocontext.Context, operationName string, options ...ddtrace.StartSpanOption) (ddtrace.Span, gocontext.Context) {
 	var opts ddtrace.StartSpanConfig
 	for _, fn := range options {
 		fn(&opts)
-	}
-	if ctx == nil {
-		ctx = gocontext.Background()
-	} else if s, ok := SpanFromContext(ctx); ok {
-		// span in ctx overwrite ChildOf() parent if any
-		opts.Parent = s.Context()
 	}
 	var startTime int64
 	if opts.StartTime.IsZero() {
@@ -340,16 +327,15 @@ func (t *tracer) StartSpanFromContext(ctx gocontext.Context, operationName strin
 		startTime = opts.StartTime.UnixNano()
 	}
 	var context *spanContext
-	pprofCtx := ctx
+	pprofContext := opts.Context
 	if opts.Parent != nil {
-		if parentContext, ok := opts.Parent.(*spanContext); ok {
-			context = parentContext
-			if pprofCtx == gocontext.Background() && parentContext.span != nil && parentContext.span.pprofCtxActive != nil {
-				// Inherit the pprof labels from parent span if it was propagated using
-				// ChildOf() rather than StartSpanFromContext(). Having a separate ctx
-				// and pprofCtx is done to avoid subtle problems with callers relying
-				// on the details of the ContextWithSpan() wrapping below.
-				pprofCtx = parentContext.span.pprofCtxActive
+		if ctx, ok := opts.Parent.(*spanContext); ok {
+			context = ctx
+			if pprofContext == nil && ctx.span != nil {
+				// Inherit the context.Context from parent span if it was propagated
+				// using ChildOf() rather than StartSpanFromContext(), see
+				// applyPPROFLabels() below.
+				pprofContext = ctx.span.pprofCtxActive
 			}
 		}
 	}
@@ -425,7 +411,7 @@ func (t *tracer) StartSpanFromContext(ctx gocontext.Context, operationName strin
 		t.sample(span)
 	}
 	if t.config.profilerHotspots || t.config.profilerEndpoints {
-		ctx = t.applyPPROFLabels(pprofCtx, span)
+		t.applyPPROFLabels(pprofContext, span)
 	}
 	if t.config.serviceMappings != nil {
 		if newSvc, ok := t.config.serviceMappings[span.Service]; ok {
@@ -433,13 +419,13 @@ func (t *tracer) StartSpanFromContext(ctx gocontext.Context, operationName strin
 		}
 	}
 	log.Debug("Started Span: %v, Operation: %s, Resource: %s, Tags: %v, %v", span, span.Name, span.Resource, span.Meta, span.Metrics)
-	return span, ContextWithSpan(ctx, span)
+	return span
 }
 
 // applyPPROFLabels applies pprof labels for the profiler's code hotspots and
 // endpoint filtering feature to span. When span finishes, any pprof labels
 // found in ctx are restored.
-func (t *tracer) applyPPROFLabels(ctx gocontext.Context, span *span) context.Context {
+func (t *tracer) applyPPROFLabels(ctx gocontext.Context, span *span) {
 	var labels []string
 	if t.config.profilerHotspots {
 		labels = append(labels, traceprof.SpanID, strconv.FormatUint(span.SpanID, 10))
@@ -458,9 +444,7 @@ func (t *tracer) applyPPROFLabels(ctx gocontext.Context, span *span) context.Con
 		span.pprofCtxRestore = ctx
 		span.pprofCtxActive = pprof.WithLabels(ctx, pprof.Labels(labels...))
 		pprof.SetGoroutineLabels(span.pprofCtxActive)
-		return span.pprofCtxActive
 	}
-	return ctx
 }
 
 // spanResourcePIISafe returns true if s.Resource can be considered to not

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -327,6 +327,8 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		startTime = opts.StartTime.UnixNano()
 	}
 	var context *spanContext
+	// The default pprof context is taken from the start options and is
+	// not nil when using StartSpanFromContext()
 	pprofContext := opts.Context
 	if opts.Parent != nil {
 		if ctx, ok := opts.Parent.(*spanContext); ok {


### PR DESCRIPTION
Remove StartSpanFromContext method from ddtrace.Tracer interface to
avoid breaking users that implement this interface.

Revert tracer.StartSpanFromContext to its old behavior of inherting the
span contained in the passed context. This makes sure that users who
write tests that rely on the default NoopTracer see the same behavior as
previously.

This reverts commits 5f95c9f and 6661a9d.