### PR TITLE
contrib/google.golang.org/grpc: add appsec monitoring of received rpc messages

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,3 +14,4 @@
 
 # appsec
 /internal/appsec          @DataDog/appsec-go
+/contrib/**/appsec.go     @DataDog/appsec-go

--- a/contrib/google.golang.org/grpc/appsec.go
+++ b/contrib/google.golang.org/grpc/appsec.go
@@ -11,6 +11,7 @@ import (
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation/grpcsec"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation/httpsec"
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -20,7 +21,7 @@ import (
 
 // UnaryHandler wrapper to use when AppSec is enabled to monitor its execution.
 func appsecUnaryHandlerMiddleware(span ddtrace.Span, handler grpc.UnaryHandler) grpc.UnaryHandler {
-	span.SetTag("_dd.appsec.enabled", true)
+	httpsec.SetAppSecTags(span)
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		op := grpcsec.StartHandlerOperation(grpcsec.HandlerOperationArgs{}, nil)
 		defer func() {
@@ -37,7 +38,7 @@ func appsecUnaryHandlerMiddleware(span ddtrace.Span, handler grpc.UnaryHandler) 
 
 // StreamHandler wrapper to use when AppSec is enabled to monitor its execution.
 func appsecStreamHandlerMiddleware(span ddtrace.Span, handler grpc.StreamHandler) grpc.StreamHandler {
-	span.SetTag("_dd.appsec.enabled", true)
+	httpsec.SetAppSecTags(span)
 	return func(srv interface{}, stream grpc.ServerStream) error {
 		op := grpcsec.StartHandlerOperation(grpcsec.HandlerOperationArgs{}, nil)
 		defer func() {

--- a/contrib/google.golang.org/grpc/appsec.go
+++ b/contrib/google.golang.org/grpc/appsec.go
@@ -1,0 +1,77 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package grpc
+
+import (
+	"encoding/json"
+	"net"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation/grpcsec"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+)
+
+// UnaryHandler wrapper to use when AppSec is enabled to monitor its execution.
+func appsecUnaryHandlerMiddleware(span ddtrace.Span, handler grpc.UnaryHandler) grpc.UnaryHandler {
+	span.SetTag("_dd.appsec.enabled", true)
+	return func(ctx context.Context, req interface{}) (interface{}, error) {
+		op := grpcsec.StartHandlerOperation(grpcsec.HandlerOperationArgs{}, nil)
+		defer func() {
+			events := op.Finish(grpcsec.HandlerOperationRes{})
+			if len(events) == 0 {
+				return
+			}
+			setAppSecTags(ctx, span, events)
+		}()
+		defer grpcsec.StartReceiveOperation(grpcsec.ReceiveOperationArgs{}, op).Finish(grpcsec.ReceiveOperationRes{Message: req})
+		return handler(ctx, req)
+	}
+}
+
+// StreamHandler wrapper to use when AppSec is enabled to monitor its execution.
+func appsecStreamHandlerMiddleware(span ddtrace.Span, handler grpc.StreamHandler) grpc.StreamHandler {
+	span.SetTag("_dd.appsec.enabled", true)
+	return func(srv interface{}, stream grpc.ServerStream) error {
+		op := grpcsec.StartHandlerOperation(grpcsec.HandlerOperationArgs{}, nil)
+		defer func() {
+			events := op.Finish(grpcsec.HandlerOperationRes{})
+			if len(events) == 0 {
+				return
+			}
+			setAppSecTags(stream.Context(), span, events)
+		}()
+		return handler(srv, appsecServerStream{ServerStream: stream, handlerOperation: op})
+	}
+}
+
+type appsecServerStream struct {
+	grpc.ServerStream
+	handlerOperation *grpcsec.HandlerOperation
+}
+
+// RecvMsg implements grpc.ServerStream interface method to monitor its
+// execution with AppSec.
+func (ss appsecServerStream) RecvMsg(m interface{}) error {
+	op := grpcsec.StartReceiveOperation(grpcsec.ReceiveOperationArgs{}, ss.handlerOperation)
+	defer func() {
+		op.Finish(grpcsec.ReceiveOperationRes{Message: m})
+	}()
+	return ss.ServerStream.RecvMsg(m)
+}
+
+// Set the AppSec tags when security events were found.
+func setAppSecTags(ctx context.Context, span ddtrace.Span, events []json.RawMessage) {
+	md, _ := metadata.FromIncomingContext(ctx)
+	var addr net.Addr
+	if p, ok := peer.FromContext(ctx); ok {
+		addr = p.Addr
+	}
+	grpcsec.SetSecurityEventTags(span, events, addr, md)
+}

--- a/contrib/google.golang.org/grpc/appsec_test.go
+++ b/contrib/google.golang.org/grpc/appsec_test.go
@@ -29,7 +29,7 @@ func TestAppSec(t *testing.T) {
 
 	client := rig.client
 
-	t.Run("unary rpc", func(t *testing.T) {
+	t.Run("unary", func(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
@@ -48,7 +48,7 @@ func TestAppSec(t *testing.T) {
 		require.True(t, strings.Contains(event.(string), "crs-941-100"))
 	})
 
-	t.Run("streaming rpc", func(t *testing.T) {
+	t.Run("stream", func(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 

--- a/contrib/google.golang.org/grpc/appsec_test.go
+++ b/contrib/google.golang.org/grpc/appsec_test.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package grpc
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
+)
+
+func TestAppSec(t *testing.T) {
+	appsec.Start()
+	defer appsec.Stop()
+	if !appsec.Enabled() {
+		t.Skip("appsec disabled")
+	}
+
+	rig, err := newRig(false)
+	require.NoError(t, err)
+	defer rig.Close()
+
+	client := rig.client
+
+	t.Run("unary rpc", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		// Send a XSS attack
+		res, err := client.Ping(context.Background(), &FixtureRequest{Name: "<script>alert('xss');</script>"})
+		// Check that the handler was properly called
+		require.NoError(t, err)
+		require.Equal(t, "passed", res.Message)
+
+		finished := mt.FinishedSpans()
+		require.Len(t, finished, 1)
+
+		// The request should have the XSS attack attempt event (appsec rule id crs-941-100).
+		event := finished[0].Tag("_dd.appsec.json")
+		require.NotNil(t, event)
+		require.True(t, strings.Contains(event.(string), "crs-941-100"))
+	})
+
+	t.Run("streaming rpc", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		stream, err := client.StreamPing(context.Background())
+		require.NoError(t, err)
+
+		// Send a XSS attack
+		err = stream.Send(&FixtureRequest{Name: "<script>alert('xss');</script>"})
+		require.NoError(t, err)
+
+		// Check that the handler was properly called
+		res, err := stream.Recv()
+		require.Equal(t, "passed", res.Message)
+		require.NoError(t, err)
+
+		// Send a SQLi attack
+		err = stream.Send(&FixtureRequest{Name: "something UNION SELECT * from users"})
+		require.NoError(t, err)
+
+		// Check that the handler was properly called
+		res, err = stream.Recv()
+		require.Equal(t, "passed", res.Message)
+		require.NoError(t, err)
+
+		err = stream.CloseSend()
+		require.NoError(t, err)
+		// to flush the spans
+		stream.Recv()
+
+		finished := mt.FinishedSpans()
+		require.Len(t, finished, 6)
+
+		// The request should both attacks: the XSS and SQLi attack attempt
+		// events (appsec rule id crs-941-100, crs-942-100).
+		event := finished[5].Tag("_dd.appsec.json")
+		require.NotNil(t, event)
+		require.True(t, strings.Contains(event.(string), "crs-941-100"))
+		require.True(t, strings.Contains(event.(string), "crs-942-100"))
+	})
+}

--- a/contrib/google.golang.org/grpc/server.go
+++ b/contrib/google.golang.org/grpc/server.go
@@ -102,7 +102,6 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
 				span.SetTag(tagMethodKind, methodKindClientStream)
 			}
 			defer func() { finishWithError(span, err, cfg) }()
-
 			if appsec.Enabled() {
 				handler = appsecStreamHandlerMiddleware(span, handler)
 			}
@@ -157,7 +156,6 @@ func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
 				}
 			}
 		}
-		
 		if appsec.Enabled() {
 			handler = appsecUnaryHandlerMiddleware(span, handler)
 		}

--- a/contrib/google.golang.org/grpc/server.go
+++ b/contrib/google.golang.org/grpc/server.go
@@ -8,11 +8,12 @@ package grpc
 import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
-	context "golang.org/x/net/context"
+	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -101,18 +102,20 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
 				span.SetTag(tagMethodKind, methodKindClientStream)
 			}
 			defer func() { finishWithError(span, err, cfg) }()
+
+			if appsec.Enabled() {
+				handler = appsecStreamHandlerMiddleware(span, handler)
+			}
 		}
 
 		// call the original handler with a new stream, which traces each send
 		// and recv if message tracing is enabled
-		err = handler(srv, &serverStream{
+		return handler(srv, &serverStream{
 			ServerStream: ss,
 			cfg:          cfg,
 			method:       info.FullMethod,
 			ctx:          ctx,
 		})
-
-		return err
 	}
 }
 
@@ -153,6 +156,10 @@ func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
 					span.SetTag(tagRequest, s)
 				}
 			}
+		}
+		
+		if appsec.Enabled() {
+			handler = appsecUnaryHandlerMiddleware(span, handler)
 		}
 		resp, err := handler(ctx, req)
 		finishWithError(span, err, cfg)

--- a/contrib/google.golang.org/grpc/stats_server_test.go
+++ b/contrib/google.golang.org/grpc/stats_server_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	context "golang.org/x/net/context"
+	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/stats"

--- a/internal/appsec/dyngo/instrumentation/grpcsec/grpc.go
+++ b/internal/appsec/dyngo/instrumentation/grpcsec/grpc.go
@@ -1,0 +1,177 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+// Package grpcsec is the gRPC instrumentation API and contract for AppSec
+// defining an abstract run-time representation of gRPC handlers.
+// gRPC integrations must use this package to enable AppSec features for gRPC,
+// which listens to this package's operation events.
+package grpcsec
+
+import (
+	"encoding/json"
+	"reflect"
+	"sync"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo"
+)
+
+// Abstract gRPC server handler operation definitions. It is based on two
+// operations allowing to describe every type of RPC: the HandlerOperation type
+// which represents the RPC handler, and the ReceiveOperation type which
+// represents the messages the RPC handler receives during its lifetime.
+// This means that the ReceiveOperation(s) will happen within the
+// HandlerOperation.
+// Every type of RPC, unary, client streaming, server streaming, and
+// bidirectional streaming RPCs, can be all represented with a HandlerOperation
+// having one or several ReceiveOperation.
+// The send operation is not required for now and therefore not defined, which
+// means that server and bidirectional streaming RPCs currently have the same
+// run-time representation as unary and client streaming RPCs.
+type (
+	// HandlerOperation represents a gRPC server handler operation.
+	// It must be created with StartHandlerOperation() and finished with its
+	// Finish() method.
+	// Security events observed during the operation lifetime should be added
+	// to the operation using its AddSecurityEvent() method.
+	HandlerOperation struct {
+		dyngo.Operation
+
+		events []json.RawMessage
+		mu     sync.Mutex
+	}
+	// HandlerOperationArgs is the grpc handler arguments. Empty as of today.
+	HandlerOperationArgs struct{}
+	// HandlerOperationRes is the grpc handler results. Empty as of today.
+	HandlerOperationRes struct{}
+
+	// ReceiveOperation type representing an gRPC server handler operation. It must
+	// be created with StartReceiveOperation() and finished with its Finish().
+	ReceiveOperation struct {
+		dyngo.Operation
+	}
+	// ReceiveOperationArgs is the gRPC handler receive operation arguments
+	// Empty as of today.
+	ReceiveOperationArgs struct{}
+	// ReceiveOperationRes is the gRPC handler receive operation results which
+	// contains the message the gRPC handler received.
+	ReceiveOperationRes struct {
+		// Message received by the gRPC handler.
+		// Corresponds to the address `grpc.server.request.message`.
+		Message interface{}
+	}
+)
+
+// TODO(Julio-Guerra): create a go-generate tool to generate the types, vars and methods below
+
+// StartHandlerOperation starts an gRPC server handler operation, along with the
+// given arguments and parent operation, and emits a start event up in the
+// operation stack. When parent is nil, the operation is linked to the global
+// root operation.
+func StartHandlerOperation(args HandlerOperationArgs, parent dyngo.Operation) *HandlerOperation {
+	op := &HandlerOperation{Operation: dyngo.NewOperation(parent)}
+	dyngo.StartOperation(op, args)
+	return op
+}
+
+// Finish the gRPC handler operation, along with the given results, and emit a
+// finish event up in the operation stack.
+func (op *HandlerOperation) Finish(res HandlerOperationRes) []json.RawMessage {
+	dyngo.FinishOperation(op, res)
+	return op.events
+}
+
+// AddSecurityEvent adds the security event to the list of events observed
+// during the operation lifetime.
+func (op *HandlerOperation) AddSecurityEvent(event json.RawMessage) {
+	op.mu.Lock()
+	defer op.mu.Unlock()
+	op.events = append(op.events, event)
+}
+
+// gRPC handler operation's start and finish event callback function types.
+type (
+	// OnHandlerOperationStart function type, called when an gRPC handler
+	// operation starts.
+	OnHandlerOperationStart func(*HandlerOperation, HandlerOperationArgs)
+	// OnHandlerOperationFinish function type, called when an gRPC handler
+	// operation finishes.
+	OnHandlerOperationFinish func(*HandlerOperation, HandlerOperationRes)
+)
+
+var (
+	handlerOperationArgsType = reflect.TypeOf((*HandlerOperationArgs)(nil)).Elem()
+	handlerOperationResType  = reflect.TypeOf((*HandlerOperationRes)(nil)).Elem()
+)
+
+// ListenedType returns the type a OnHandlerOperationStart event listener
+// listens to, which is the HandlerOperationArgs type.
+func (OnHandlerOperationStart) ListenedType() reflect.Type { return handlerOperationArgsType }
+
+// Call the underlying event listener function by performing the type-assertion
+// on v whose type is the one returned by ListenedType().
+func (f OnHandlerOperationStart) Call(op dyngo.Operation, v interface{}) {
+	f(op.(*HandlerOperation), v.(HandlerOperationArgs))
+}
+
+// ListenedType returns the type a OnHandlerOperationFinish event listener
+// listens to, which is the HandlerOperationRes type.
+func (OnHandlerOperationFinish) ListenedType() reflect.Type { return handlerOperationResType }
+
+// Call the underlying event listener function by performing the type-assertion
+// on v whose type is the one returned by ListenedType().
+func (f OnHandlerOperationFinish) Call(op dyngo.Operation, v interface{}) {
+	f(op.(*HandlerOperation), v.(HandlerOperationRes))
+}
+
+// StartReceiveOperation starts a receive operation of a gRPC handler, along
+// with the given arguments and parent operation, and emits a start event up in
+// the operation stack. When parent is nil, the operation is linked to the
+// global root operation.
+func StartReceiveOperation(args ReceiveOperationArgs, parent dyngo.Operation) ReceiveOperation {
+	op := ReceiveOperation{Operation: dyngo.NewOperation(parent)}
+	dyngo.StartOperation(op, args)
+	return op
+}
+
+// Finish the gRPC handler operation, along with the given results, and emits a
+// finish event up in the operation stack.
+func (op ReceiveOperation) Finish(res ReceiveOperationRes) {
+	dyngo.FinishOperation(op, res)
+}
+
+// gRPC receive operation's start and finish event callback function types.
+type (
+	// OnReceiveOperationStart function type, called when a gRPC receive
+	// operation starts.
+	OnReceiveOperationStart func(ReceiveOperation, ReceiveOperationArgs)
+	// OnReceiveOperationFinish function type, called when a grpc receive
+	// operation finishes.
+	OnReceiveOperationFinish func(ReceiveOperation, ReceiveOperationRes)
+)
+
+var (
+	receiveOperationArgsType = reflect.TypeOf((*ReceiveOperationArgs)(nil)).Elem()
+	receiveOperationResType  = reflect.TypeOf((*ReceiveOperationRes)(nil)).Elem()
+)
+
+// ListenedType returns the type a OnHandlerOperationStart event listener
+// listens to, which is the HandlerOperationArgs type.
+func (OnReceiveOperationStart) ListenedType() reflect.Type { return receiveOperationArgsType }
+
+// Call the underlying event listener function by performing the type-assertion
+// on v whose type is the one returned by ListenedType().
+func (f OnReceiveOperationStart) Call(op dyngo.Operation, v interface{}) {
+	f(op.(ReceiveOperation), v.(ReceiveOperationArgs))
+}
+
+// ListenedType returns the type a OnHandlerOperationFinish event listener
+// listens to, which is the HandlerOperationRes type.
+func (OnReceiveOperationFinish) ListenedType() reflect.Type { return receiveOperationResType }
+
+// Call the underlying event listener function by performing the type-assertion
+// on v whose type is the one returned by ListenedType().
+func (f OnReceiveOperationFinish) Call(op dyngo.Operation, v interface{}) {
+	f(op.(ReceiveOperation), v.(ReceiveOperationRes))
+}

--- a/internal/appsec/dyngo/instrumentation/grpcsec/grpc_test.go
+++ b/internal/appsec/dyngo/instrumentation/grpcsec/grpc_test.go
@@ -1,0 +1,85 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package grpcsec_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation/grpcsec"
+)
+
+func TestUsage(t *testing.T) {
+	testRPCRepresentation := func(expectedRecvOperation int) func(*testing.T) {
+		return func(t *testing.T) {
+			type (
+				rootArgs struct{}
+				rootRes  struct{}
+			)
+			localRootOp := dyngo.NewOperation(nil)
+			dyngo.StartOperation(localRootOp, rootArgs{})
+			defer dyngo.FinishOperation(localRootOp, rootRes{})
+
+			var handlerStarted, handlerFinished, recvStarted, recvFinished int
+			defer func() {
+				require.Equal(t, 1, handlerStarted)
+				require.Equal(t, 1, handlerFinished)
+				require.Equal(t, expectedRecvOperation, recvStarted)
+				require.Equal(t, expectedRecvOperation, recvFinished)
+			}()
+
+			const expectedMessageFormat = "message number %d"
+
+			localRootOp.On(grpcsec.OnHandlerOperationStart(func(handlerOp *grpcsec.HandlerOperation, args grpcsec.HandlerOperationArgs) {
+				handlerStarted++
+
+				handlerOp.On(grpcsec.OnReceiveOperationStart(func(op grpcsec.ReceiveOperation, _ grpcsec.ReceiveOperationArgs) {
+					recvStarted++
+
+					op.On(grpcsec.OnReceiveOperationFinish(func(_ grpcsec.ReceiveOperation, res grpcsec.ReceiveOperationRes) {
+						expectedMessage := fmt.Sprintf(expectedMessageFormat, recvStarted)
+						require.Equal(t, expectedMessage, res.Message)
+						recvFinished++
+
+						handlerOp.AddSecurityEvent(json.RawMessage(expectedMessage))
+					}))
+				}))
+
+				handlerOp.On(grpcsec.OnHandlerOperationFinish(func(*grpcsec.HandlerOperation, grpcsec.HandlerOperationRes) {
+					handlerFinished++
+				}))
+			}))
+
+			rpcOp := grpcsec.StartHandlerOperation(grpcsec.HandlerOperationArgs{}, localRootOp)
+
+			for i := 1; i <= expectedRecvOperation; i++ {
+				recvOp := grpcsec.StartReceiveOperation(grpcsec.ReceiveOperationArgs{}, rpcOp)
+				recvOp.Finish(grpcsec.ReceiveOperationRes{Message: fmt.Sprintf(expectedMessageFormat, i)})
+			}
+
+			secEvents := rpcOp.Finish(grpcsec.HandlerOperationRes{})
+
+			require.Len(t, secEvents, expectedRecvOperation)
+			for i, e := range secEvents {
+				require.Equal(t, fmt.Sprintf(expectedMessageFormat, i+1), string(e))
+			}
+		}
+	}
+
+	// Unary RPCs are represented by a single receive operation
+	t.Run("unary-representation", testRPCRepresentation(1))
+	// Client streaming RPCs are represented by many receive operations.
+	t.Run("client-streaming-representation", testRPCRepresentation(10))
+	// Server and bidirectional streaming RPCs cannot be tested for now because
+	// the send operations are not used nor defined yet, server streaming RPCs
+	// are currently represented like unary RPCs (1 client message, N server
+	// messages), and bidirectional RPCs like client streaming RPCs (N client
+	// messages, M server messages).
+}

--- a/internal/appsec/dyngo/instrumentation/grpcsec/tags.go
+++ b/internal/appsec/dyngo/instrumentation/grpcsec/tags.go
@@ -1,0 +1,104 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package grpcsec
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation/httpsec"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+
+	"google.golang.org/grpc/metadata"
+)
+
+// SetSecurityEventTags sets the AppSec-specific span tags when a security event
+// occurred into the service entry span.
+func SetSecurityEventTags(span ddtrace.Span, events []json.RawMessage, addr net.Addr, md metadata.MD) {
+	if err := setSecurityEventTags(span, events, addr, md); err != nil {
+		log.Error("appsec: %v", err)
+	}
+}
+
+func setSecurityEventTags(span ddtrace.Span, events []json.RawMessage, addr net.Addr, md metadata.MD) error {
+	if err := setEventSpanTags(span, events); err != nil {
+		return err
+	}
+	var ip string
+	switch actual := addr.(type) {
+	case *net.UDPAddr:
+		ip = actual.IP.String()
+	case *net.TCPAddr:
+		ip = actual.IP.String()
+	}
+	if ip != "" {
+		span.SetTag("network.client.ip", ip)
+	}
+	for h, v := range httpsec.NormalizeHTTPHeaders(md) {
+		span.SetTag("grpc.metadata."+h, v)
+	}
+	return nil
+}
+
+// setEventSpanTags sets the security event span tags into the service entry span.
+func setEventSpanTags(span ddtrace.Span, events []json.RawMessage) error {
+	// Set the appsec event span tag
+	val, err := makeEventTagValue(events)
+	if err != nil {
+		return err
+	}
+	span.SetTag("_dd.appsec.json", string(val))
+	// Keep this span due to the security event
+	span.SetTag(ext.ManualKeep, true)
+	span.SetTag("_dd.origin", "appsec")
+	// Set the appsec.event tag needed by the appsec backend
+	span.SetTag("appsec.event", true)
+	return nil
+}
+
+// Create the value of the security event tag.
+// TODO(Julio-Guerra): a future libddwaf version should return something
+//   avoiding us the following events concatenation logic which currently
+//   involves unserializing the top-level JSON arrays to concatenate them
+//   together.
+// TODO(Julio-Guerra): avoid serializing the json in the request hot path
+func makeEventTagValue(events []json.RawMessage) (json.RawMessage, error) {
+	var v interface{}
+	if l := len(events); l == 1 {
+		// eventTag is the structure to use in the `_dd.appsec.json` span tag.
+		// In this case of 1 event, it already is an array as expected.
+		type eventTag struct {
+			Triggers json.RawMessage `json:"triggers"`
+		}
+		v = eventTag{Triggers: events[0]}
+	} else {
+		// eventTag is the structure to use in the `_dd.appsec.json` span tag.
+		// With more than one event, we need to concatenate the arrays together
+		// (ie. convert [][]json.RawMessage into []json.RawMessage).
+		type eventTag struct {
+			Triggers []json.RawMessage `json:"triggers"`
+		}
+		concatenated := make([]json.RawMessage, 0, l) // at least len(events)
+		for _, event := range events {
+			// Unmarshal the top level array
+			var tmp []json.RawMessage
+			if err := json.Unmarshal(event, &tmp); err != nil {
+				return nil, fmt.Errorf("unexpected error while unserializing the appsec event `%s`: %v", string(event), err)
+			}
+			concatenated = append(concatenated, tmp...)
+		}
+		v = eventTag{Triggers: concatenated}
+	}
+
+	tag, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("unexpected error while serializing the appsec event span tag: %v", err)
+	}
+	return tag, nil
+}

--- a/internal/appsec/dyngo/instrumentation/grpcsec/tags.go
+++ b/internal/appsec/dyngo/instrumentation/grpcsec/tags.go
@@ -14,19 +14,17 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation/httpsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
-
-	"google.golang.org/grpc/metadata"
 )
 
 // SetSecurityEventTags sets the AppSec-specific span tags when a security event
 // occurred into the service entry span.
-func SetSecurityEventTags(span ddtrace.Span, events []json.RawMessage, addr net.Addr, md metadata.MD) {
+func SetSecurityEventTags(span ddtrace.Span, events []json.RawMessage, addr net.Addr, md map[string][]string) {
 	if err := setSecurityEventTags(span, events, addr, md); err != nil {
 		log.Error("appsec: %v", err)
 	}
 }
 
-func setSecurityEventTags(span ddtrace.Span, events []json.RawMessage, addr net.Addr, md metadata.MD) error {
+func setSecurityEventTags(span ddtrace.Span, events []json.RawMessage, addr net.Addr, md map[string][]string) error {
 	if err := setEventSpanTags(span, events); err != nil {
 		return err
 	}

--- a/internal/appsec/dyngo/instrumentation/grpcsec/tags_test.go
+++ b/internal/appsec/dyngo/instrumentation/grpcsec/tags_test.go
@@ -1,0 +1,183 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package grpcsec
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+)
+
+func TestSetSecurityEventTags(t *testing.T) {
+	for _, eventCase := range []struct {
+		name          string
+		events        []json.RawMessage
+		expectedTag   string
+		expectedError bool
+	}{
+		{
+			name:        "one-event",
+			events:      []json.RawMessage{json.RawMessage(`["one","two"]`)},
+			expectedTag: `{"triggers":["one","two"]}`,
+		},
+		{
+			name:          "one-event-with-json-error",
+			events:        []json.RawMessage{json.RawMessage(`["one",two"]`)},
+			expectedError: true,
+		},
+		{
+			name:        "two-events",
+			events:      []json.RawMessage{json.RawMessage(`["one","two"]`), json.RawMessage(`["three","four"]`)},
+			expectedTag: `{"triggers":["one","two","three","four"]}`,
+		},
+		{
+			name:          "two-events-with-json-error",
+			events:        []json.RawMessage{json.RawMessage(`["one","two"]`), json.RawMessage(`["three,"four"]`)},
+			expectedError: true,
+		},
+		{
+			name:          "three-events-with-json-error",
+			events:        []json.RawMessage{json.RawMessage(`["one","two"]`), json.RawMessage(`["three","four"]`), json.RawMessage(`"five"`)},
+			expectedError: true,
+		},
+	} {
+		eventCase := eventCase
+		for _, addrCase := range []struct {
+			name        string
+			addr        net.Addr
+			expectedTag string
+		}{
+			{
+				name:        "tcp-ipv4-address",
+				addr:        &net.TCPAddr{IP: net.ParseIP("1.2.3.4"), Port: 6789},
+				expectedTag: "1.2.3.4",
+			},
+			{
+				name:        "tcp-ipv6-address",
+				addr:        &net.TCPAddr{IP: net.ParseIP("::1"), Port: 6789},
+				expectedTag: "::1",
+			},
+			{
+				name:        "udp-ipv4-address",
+				addr:        &net.UDPAddr{IP: net.ParseIP("1.2.3.4"), Port: 6789},
+				expectedTag: "1.2.3.4",
+			},
+			{
+				name:        "udp-ipv6-address",
+				addr:        &net.UDPAddr{IP: net.ParseIP("::1"), Port: 6789},
+				expectedTag: "::1",
+			},
+			{
+				name: "unix-socket-address",
+				addr: &net.UnixAddr{Name: "/var/my.sock"},
+			},
+		} {
+			addrCase := addrCase
+			for _, metadataCase := range []struct {
+				name         string
+				md           map[string][]string
+				expectedTags map[string]string
+			}{
+				{
+					name: "zero-metadata",
+				},
+				{
+					name: "xff-metadata",
+					md: map[string][]string{
+						"x-forwarded-for": {"1.2.3.4", "4.5.6.7"},
+						":authority":      {"something"},
+					},
+					expectedTags: map[string]string{
+						"grpc.metadata.x-forwarded-for": "1.2.3.4,4.5.6.7",
+					},
+				},
+				{
+					name: "xff-metadata",
+					md: map[string][]string{
+						"x-forwarded-for": {"1.2.3.4"},
+						":authority":      {"something"},
+					},
+					expectedTags: map[string]string{
+						"grpc.metadata.x-forwarded-for": "1.2.3.4",
+					},
+				},
+				{
+					name: "no-monitored-metadata",
+					md: map[string][]string{
+						":authority": {"something"},
+					},
+				},
+			} {
+				metadataCase := metadataCase
+				t.Run(fmt.Sprintf("%s-%s-%s", eventCase.name, addrCase.name, metadataCase.name), func(t *testing.T) {
+					var span MockSpan
+					err := setSecurityEventTags(&span, eventCase.events, addrCase.addr, metadataCase.md)
+					if eventCase.expectedError {
+						require.Error(t, err)
+						return
+					} else {
+						require.NoError(t, err)
+					}
+
+					expectedTags := map[string]interface{}{
+						"_dd.appsec.json": eventCase.expectedTag,
+						"manual.keep":     true,
+						"appsec.event":    true,
+						"_dd.origin":      "appsec",
+					}
+
+					if addr := addrCase.expectedTag; addr != "" {
+						expectedTags["network.client.ip"] = addr
+					}
+
+					for k, v := range metadataCase.expectedTags {
+						expectedTags[k] = v
+					}
+
+					require.Equal(t, expectedTags, span.tags)
+					require.False(t, span.finished)
+				})
+			}
+		}
+	}
+}
+
+type MockSpan struct {
+	tags     map[string]interface{}
+	finished bool
+}
+
+func (m *MockSpan) SetTag(key string, value interface{}) {
+	if m.tags == nil {
+		m.tags = make(map[string]interface{})
+	}
+	m.tags[key] = value
+}
+
+func (m *MockSpan) SetOperationName(operationName string) {
+	panic("unused")
+}
+
+func (m *MockSpan) BaggageItem(key string) string {
+	panic("unused")
+}
+
+func (m *MockSpan) SetBaggageItem(key, val string) {
+	panic("unused")
+}
+
+func (m *MockSpan) Finish(opts ...ddtrace.FinishOption) {
+	m.finished = true
+}
+
+func (m *MockSpan) Context() ddtrace.SpanContext {
+	panic("unused")
+}

--- a/internal/appsec/dyngo/instrumentation/grpcsec/tags_test.go
+++ b/internal/appsec/dyngo/instrumentation/grpcsec/tags_test.go
@@ -123,9 +123,8 @@ func TestSetSecurityEventTags(t *testing.T) {
 					if eventCase.expectedError {
 						require.Error(t, err)
 						return
-					} else {
-						require.NoError(t, err)
 					}
+					require.NoError(t, err)
 
 					expectedTags := map[string]interface{}{
 						"_dd.appsec.json": eventCase.expectedTag,

--- a/internal/appsec/dyngo/instrumentation/httpsec/tags.go
+++ b/internal/appsec/dyngo/instrumentation/httpsec/tags.go
@@ -47,7 +47,7 @@ func setEventSpanTags(span ddtrace.Span, events json.RawMessage) {
 func SetSecurityEventTags(span ddtrace.Span, events json.RawMessage, remoteIP string, headers map[string][]string) {
 	setEventSpanTags(span, events)
 	span.SetTag("network.client.ip", remoteIP)
-	for h, v := range normalizeHTTPHeaders(headers) {
+	for h, v := range NormalizeHTTPHeaders(headers) {
 		span.SetTag("http.request.headers."+h, v)
 	}
 }
@@ -80,8 +80,9 @@ func init() {
 	sort.Strings(collectedHTTPHeaders[:])
 }
 
-// normalizeHTTPHeaders returns the HTTP headers following Datadog's normalization format.
-func normalizeHTTPHeaders(headers map[string][]string) (normalized map[string]string) {
+// NormalizeHTTPHeaders returns the HTTP headers following Datadog's
+// normalization format.
+func NormalizeHTTPHeaders(headers map[string][]string) (normalized map[string]string) {
 	if len(headers) == 0 {
 		return nil
 	}

--- a/internal/appsec/dyngo/instrumentation/httpsec/tags_test.go
+++ b/internal/appsec/dyngo/instrumentation/httpsec/tags_test.go
@@ -45,7 +45,7 @@ func TestNormalizeHTTPHeaders(t *testing.T) {
 			},
 		},
 	} {
-		headers := normalizeHTTPHeaders(tc.headers)
+		headers := NormalizeHTTPHeaders(tc.headers)
 		require.Equal(t, tc.expected, headers)
 	}
 }

--- a/internal/appsec/waf.go
+++ b/internal/appsec/waf.go
@@ -12,9 +12,12 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation/grpcsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation/httpsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/waf"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
@@ -48,24 +51,38 @@ func registerWAF(rules []byte, timeout time.Duration) (unreg dyngo.UnregisterFun
 		return nil, errors.New("no addresses found in the rule")
 	}
 	// Check there are supported addresses in the rule
-	addresses, notSupported := supportedAddresses(ruleAddresses)
-	if len(addresses) == 0 {
+	httpAddresses, grpcAddresses, notSupported := supportedAddresses(ruleAddresses)
+	if len(httpAddresses) == 0 && len(grpcAddresses) == 0 {
 		return nil, fmt.Errorf("the addresses present in the rule are not supported: %v", notSupported)
 	} else if len(notSupported) > 0 {
-		log.Debug("appsec: the addresses present in the rule are partially supported: supported=%v, not supported=%v", addresses, notSupported)
+		log.Debug("appsec: the addresses present in the rule are partially supported: not supported=%v", notSupported)
 	}
 
 	// Register the WAF event listener
-	unregister := dyngo.Register(newWAFEventListener(waf, addresses, timeout))
+	var unregisterHTTP, unregisterGRPC dyngo.UnregisterFunc
+	if len(httpAddresses) > 0 {
+		log.Debug("appsec: registering http waf listening to addresses %v", httpAddresses)
+		unregisterHTTP = dyngo.Register(newHTTPWAFEventListener(waf, httpAddresses, timeout))
+	}
+	if len(grpcAddresses) > 0 {
+		log.Debug("appsec: registering grpc waf listening to addresses %v", grpcAddresses)
+		unregisterGRPC = dyngo.Register(newGRPCWAFEventListener(waf, grpcAddresses, timeout))
+	}
+
 	// Return an unregistration function that will also release the WAF instance.
 	return func() {
 		defer waf.Close()
-		unregister()
+		if unregisterHTTP != nil {
+			unregisterHTTP()
+		}
+		if unregisterGRPC != nil {
+			unregisterGRPC()
+		}
 	}, nil
 }
 
 // newWAFEventListener returns the WAF event listener to register in order to enable it.
-func newWAFEventListener(handle *waf.Handle, addresses []string, timeout time.Duration) dyngo.EventListener {
+func newHTTPWAFEventListener(handle *waf.Handle, addresses []string, timeout time.Duration) dyngo.EventListener {
 	return httpsec.OnHandlerOperationStart(func(op *httpsec.Operation, args httpsec.HandlerOperationArgs) {
 		// At the moment, AppSec doesn't block the requests, and so we can use the fact we are in monitoring-only mode
 		// to call the WAF only once at the end of the handler operation.
@@ -106,6 +123,53 @@ func newWAFEventListener(handle *waf.Handle, addresses []string, timeout time.Du
 	})
 }
 
+// newGRPCWAFEventListener returns the WAF event listener to register in order
+// to enable it.
+func newGRPCWAFEventListener(handle *waf.Handle, addresses []string, timeout time.Duration) dyngo.EventListener {
+	return grpcsec.OnHandlerOperationStart(func(op *grpcsec.HandlerOperation, _ grpcsec.HandlerOperationArgs) {
+		// Limit the maximum number of security events, as a streaming RPC could
+		// receive unlimited number of messages where we could find security events
+		const maxWAFEventsPerRequest = 10
+		var (
+			nbEvents uint32
+			logOnce  sync.Once
+		)
+		op.On(grpcsec.OnReceiveOperationFinish(func(_ grpcsec.ReceiveOperation, res grpcsec.ReceiveOperationRes) {
+			if atomic.LoadUint32(&nbEvents) == maxWAFEventsPerRequest {
+				logOnce.Do(func() {
+					log.Debug("appsec: ignoring the rpc message due to the maximum number of security events per grpc call reached")
+				})
+				return
+			}
+			// The current workaround of the WAF context limitations is to
+			// simply instantiate and release the WAF context for the operation
+			// lifetime so that:
+			//   1. We avoid growing the memory usage of the context every time
+			//      a grpc.server.request.message value is added to it during
+			//      the RPC lifetime.
+			//   2. We avoid the limitation of 1 event per attack type.
+			// TODO(Julio-Guerra): a future libddwaf API should solve this out.
+			wafCtx := waf.NewContext(handle)
+			if wafCtx == nil {
+				// The WAF event listener got concurrently released
+				return
+			}
+			defer wafCtx.Close()
+			// Run the WAF on the rule addresses available in the args
+			// Note that we don't check if the address is present in the rules
+			// as we only support one at the moment, so this callback cannot be
+			// set when the address is not present.
+			events := runWAF(wafCtx, map[string]interface{}{grpcServerRequestMessage: res.Message}, timeout)
+			if len(events) == 0 {
+				return
+			}
+			log.Debug("appsec: attack detected by the grpc waf")
+			atomic.AddUint32(&nbEvents, 1)
+			op.AddSecurityEvent(events)
+		}))
+	})
+}
+
 func runWAF(wafCtx *waf.Context, values map[string]interface{}, timeout time.Duration) []byte {
 	matches, err := wafCtx.Run(values, timeout)
 	if err != nil {
@@ -119,7 +183,7 @@ func runWAF(wafCtx *waf.Context, values map[string]interface{}, timeout time.Dur
 	return matches
 }
 
-// Rule addresses currently supported by the WAF
+// HTTP rule addresses currently supported by the WAF
 const (
 	serverRequestRawURIAddr           = "server.request.uri.raw"
 	serverRequestHeadersNoCookiesAddr = "server.request.headers.no_cookies"
@@ -128,8 +192,8 @@ const (
 	serverResponseStatusAddr          = "server.response.status"
 )
 
-// List of rule addresses currently supported by the WAF
-var supportedAddressesList = []string{
+// List of HTTP rule addresses currently supported by the WAF
+var httpAddresses = []string{
 	serverRequestRawURIAddr,
 	serverRequestHeadersNoCookiesAddr,
 	serverRequestCookiesAddr,
@@ -137,23 +201,34 @@ var supportedAddressesList = []string{
 	serverResponseStatusAddr,
 }
 
+// gRPC rule addresses currently supported by the WAF
+const (
+	grpcServerRequestMessage = "grpc.server.request.message"
+)
+
+// List of gRPC rule addresses currently supported by the WAF
+var grpcAddresses = []string{
+	grpcServerRequestMessage,
+}
+
 func init() {
-	sort.Strings(supportedAddressesList)
+	// sort the address lists to avoid mistakes and use sort.SearchStrings()
+	sort.Strings(httpAddresses)
+	sort.Strings(grpcAddresses)
 }
 
 // supportedAddresses returns the list of addresses we actually support from the
 // given rule addresses.
-func supportedAddresses(ruleAddresses []string) (supported, notSupported []string) {
+func supportedAddresses(ruleAddresses []string) (supportedHTTP, supportedGRPC, notSupported []string) {
 	// Filter the supported addresses only
-	l := len(supportedAddressesList)
-	supported = make([]string, 0, l)
 	for _, addr := range ruleAddresses {
-		if i := sort.SearchStrings(supportedAddressesList, addr); i < l && supportedAddressesList[i] == addr {
-			supported = append(supported, addr)
+		if i := sort.SearchStrings(httpAddresses, addr); i < len(httpAddresses) && httpAddresses[i] == addr {
+			supportedHTTP = append(supportedHTTP, addr)
+		} else if i := sort.SearchStrings(grpcAddresses, addr); i < len(grpcAddresses) && grpcAddresses[i] == addr {
+			supportedGRPC = append(supportedGRPC, addr)
 		} else {
 			notSupported = append(notSupported, addr)
 		}
 	}
-	// Check the resulting situation we are in
-	return supported, notSupported
+	return
 }


### PR DESCRIPTION
First version of the appsec integration into gRPC by monitoring the
messages an RPC handler receives. To do so, the security rule address
`grpc.server.request.message` is introduced in the WAF, and a new
set of instrumentation gateway operations are now available in `grpcsec`.

More details in the specification at https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2278064284/gRPC+Protocol+Support