### PR TITLE
internal/appsec: send http response headers on security events

### DIFF
--- a/contrib/labstack/echo.v4/echotrace.go
+++ b/contrib/labstack/echo.v4/echotrace.go
@@ -85,7 +85,7 @@ func withAppSec(next echo.HandlerFunc) echo.HandlerFunc {
 				if err != nil {
 					remoteIP = req.RemoteAddr
 				}
-				httpsec.SetSecurityEventTags(span, events, remoteIP, args.Headers)
+				httpsec.SetSecurityEventTags(span, events, remoteIP, args.Headers, c.Response().Writer.Header())
 			}
 		}()
 		return next(c)

--- a/internal/appsec/dyngo/instrumentation/httpsec/http.go
+++ b/internal/appsec/dyngo/instrumentation/httpsec/http.go
@@ -66,7 +66,7 @@ func WrapHandler(handler http.Handler, span ddtrace.Span) http.Handler {
 			if err != nil {
 				remoteIP = r.RemoteAddr
 			}
-			SetSecurityEventTags(span, events, remoteIP, args.Headers)
+			SetSecurityEventTags(span, events, remoteIP, args.Headers, w.Header())
 		}()
 		handler.ServeHTTP(w, r)
 	})

--- a/internal/appsec/dyngo/instrumentation/httpsec/tags.go
+++ b/internal/appsec/dyngo/instrumentation/httpsec/tags.go
@@ -44,11 +44,14 @@ func setEventSpanTags(span ddtrace.Span, events json.RawMessage) {
 }
 
 // SetSecurityEventTags sets the AppSec-specific span tags when a security event occurred into the service entry span.
-func SetSecurityEventTags(span ddtrace.Span, events json.RawMessage, remoteIP string, headers map[string][]string) {
+func SetSecurityEventTags(span ddtrace.Span, events json.RawMessage, remoteIP string, headers, respHeaders map[string][]string) {
 	setEventSpanTags(span, events)
 	span.SetTag("network.client.ip", remoteIP)
 	for h, v := range normalizeHTTPHeaders(headers) {
 		span.SetTag("http.request.headers."+h, v)
+	}
+	for h, v := range normalizeHTTPHeaders(respHeaders) {
+		span.SetTag("http.response.headers."+h, v)
 	}
 }
 
@@ -87,6 +90,7 @@ func normalizeHTTPHeaders(headers map[string][]string) (normalized map[string]st
 	}
 	normalized = make(map[string]string)
 	for k, v := range headers {
+		k = strings.ToLower(k)
 		if i := sort.SearchStrings(collectedHTTPHeaders[:], k); i < len(collectedHTTPHeaders) && collectedHTTPHeaders[i] == k {
 			normalized[k] = strings.Join(v, ",")
 		}


### PR DESCRIPTION
This set of commits adds response headers collection, similar to what already exists for request headers

- Add a Headers field to HandlerOperationRes and make sure to fill it roperly
- Retrieve the response headers through http.ResponseWritter public API.
- Add a parameter to SetSecurityEventTags for the function to also process response headers in the same call.
- Also make sure header normalization uses lower case to catch all headers, since http.ResponsWritter.Header() doesn't unify headers case