### PR TITLE
v1.35.0 fixups

### DIFF
--- a/ddtrace/tracer/log.go
+++ b/ddtrace/tracer/log.go
@@ -26,31 +26,33 @@ const (
 
 // startupInfo contains various information about the status of the tracer on startup.
 type startupInfo struct {
-	Date                  string            `json:"date"`                    // ISO 8601 date and time of start
-	OSName                string            `json:"os_name"`                 // Windows, Darwin, Debian, etc.
-	OSVersion             string            `json:"os_version"`              // Version of the OS
-	Version               string            `json:"version"`                 // Tracer version
-	Lang                  string            `json:"lang"`                    // "Go"
-	LangVersion           string            `json:"lang_version"`            // Go version, e.g. go1.13
-	Env                   string            `json:"env"`                     // Tracer env
-	Service               string            `json:"service"`                 // Tracer Service
-	AgentURL              string            `json:"agent_url"`               // The address of the agent
-	AgentError            string            `json:"agent_error"`             // Any error that occurred trying to connect to agent
-	Debug                 bool              `json:"debug"`                   // Whether debug mode is enabled
-	AnalyticsEnabled      bool              `json:"analytics_enabled"`       // True if there is a global analytics rate set
-	SampleRate            string            `json:"sample_rate"`             // The default sampling rate for the rules sampler
-	SamplingRules         []SamplingRule    `json:"sampling_rules"`          // Rules used by the rules sampler
-	SamplingRulesError    string            `json:"sampling_rules_error"`    // Any errors that occurred while parsing sampling rules
-	ServiceMappings       map[string]string `json:"service_mappings"`        // Service Mappings
-	Tags                  map[string]string `json:"tags"`                    // Global tags
-	RuntimeMetricsEnabled bool              `json:"runtime_metrics_enabled"` // Whether or not runtime metrics are enabled
-	HealthMetricsEnabled  bool              `json:"health_metrics_enabled"`  // Whether or not health metrics are enabled
-	ApplicationVersion    string            `json:"dd_version"`              // Version of the user's application
-	Architecture          string            `json:"architecture"`            // Architecture of host machine
-	GlobalService         string            `json:"global_service"`          // Global service string. If not-nil should be same as Service. (#614)
-	LambdaMode            string            `json:"lambda_mode"`             // Whether or not the client has enabled lambda mode
-	AppSec                bool              `json:"appsec"`                  // AppSec status: true when started, false otherwise.
-	AgentFeatures         agentFeatures     `json:"agent_features"`          // Lists the capabilities of the agent.
+	Date                        string            `json:"date"`                           // ISO 8601 date and time of start
+	OSName                      string            `json:"os_name"`                        // Windows, Darwin, Debian, etc.
+	OSVersion                   string            `json:"os_version"`                     // Version of the OS
+	Version                     string            `json:"version"`                        // Tracer version
+	Lang                        string            `json:"lang"`                           // "Go"
+	LangVersion                 string            `json:"lang_version"`                   // Go version, e.g. go1.13
+	Env                         string            `json:"env"`                            // Tracer env
+	Service                     string            `json:"service"`                        // Tracer Service
+	AgentURL                    string            `json:"agent_url"`                      // The address of the agent
+	AgentError                  string            `json:"agent_error"`                    // Any error that occurred trying to connect to agent
+	Debug                       bool              `json:"debug"`                          // Whether debug mode is enabled
+	AnalyticsEnabled            bool              `json:"analytics_enabled"`              // True if there is a global analytics rate set
+	SampleRate                  string            `json:"sample_rate"`                    // The default sampling rate for the rules sampler
+	SamplingRules               []SamplingRule    `json:"sampling_rules"`                 // Rules used by the rules sampler
+	SamplingRulesError          string            `json:"sampling_rules_error"`           // Any errors that occurred while parsing sampling rules
+	ServiceMappings             map[string]string `json:"service_mappings"`               // Service Mappings
+	Tags                        map[string]string `json:"tags"`                           // Global tags
+	RuntimeMetricsEnabled       bool              `json:"runtime_metrics_enabled"`        // Whether or not runtime metrics are enabled
+	HealthMetricsEnabled        bool              `json:"health_metrics_enabled"`         // Whether or not health metrics are enabled
+	ProfilerCodeHotspotsEnabled bool              `json:"profiler_code_hotspots_enabled"` // Whether or not profiler code hotspots are enabled
+	ProfilerEndpointsEnabled    bool              `json:"profiler_endpoints_enabled"`     // Whether or not profiler endpoints are enabled
+	ApplicationVersion          string            `json:"dd_version"`                     // Version of the user's application
+	Architecture                string            `json:"architecture"`                   // Architecture of host machine
+	GlobalService               string            `json:"global_service"`                 // Global service string. If not-nil should be same as Service. (#614)
+	LambdaMode                  string            `json:"lambda_mode"`                    // Whether or not the client has enabled lambda mode
+	AppSec                      bool              `json:"appsec"`                         // AppSec status: true when started, false otherwise.
+	AgentFeatures               agentFeatures     `json:"agent_features"`                 // Lists the capabilities of the agent.
 }
 
 // checkEndpoint tries to connect to the URL specified by endpoint.
@@ -79,29 +81,31 @@ func logStartup(t *tracer) {
 	}
 
 	info := startupInfo{
-		Date:                  time.Now().Format(time.RFC3339),
-		OSName:                osName(),
-		OSVersion:             osVersion(),
-		Version:               version.Tag,
-		Lang:                  "Go",
-		LangVersion:           runtime.Version(),
-		Env:                   t.config.env,
-		Service:               t.config.serviceName,
-		AgentURL:              t.config.transport.endpoint(),
-		Debug:                 t.config.debug,
-		AnalyticsEnabled:      !math.IsNaN(globalconfig.AnalyticsRate()),
-		SampleRate:            fmt.Sprintf("%f", t.rulesSampling.globalRate),
-		SamplingRules:         t.rulesSampling.rules,
-		ServiceMappings:       t.config.serviceMappings,
-		Tags:                  tags,
-		RuntimeMetricsEnabled: t.config.runtimeMetrics,
-		HealthMetricsEnabled:  t.config.runtimeMetrics,
-		ApplicationVersion:    t.config.version,
-		Architecture:          runtime.GOARCH,
-		GlobalService:         globalconfig.ServiceName(),
-		LambdaMode:            fmt.Sprintf("%t", t.config.logToStdout),
-		AgentFeatures:         t.config.agent,
-		AppSec:                appsec.Enabled(),
+		Date:                        time.Now().Format(time.RFC3339),
+		OSName:                      osName(),
+		OSVersion:                   osVersion(),
+		Version:                     version.Tag,
+		Lang:                        "Go",
+		LangVersion:                 runtime.Version(),
+		Env:                         t.config.env,
+		Service:                     t.config.serviceName,
+		AgentURL:                    t.config.transport.endpoint(),
+		Debug:                       t.config.debug,
+		AnalyticsEnabled:            !math.IsNaN(globalconfig.AnalyticsRate()),
+		SampleRate:                  fmt.Sprintf("%f", t.rulesSampling.globalRate),
+		SamplingRules:               t.rulesSampling.rules,
+		ServiceMappings:             t.config.serviceMappings,
+		Tags:                        tags,
+		RuntimeMetricsEnabled:       t.config.runtimeMetrics,
+		HealthMetricsEnabled:        t.config.runtimeMetrics,
+		ApplicationVersion:          t.config.version,
+		ProfilerCodeHotspotsEnabled: t.config.profilerHotspots,
+		ProfilerEndpointsEnabled:    t.config.profilerEndpoints,
+		Architecture:                runtime.GOARCH,
+		GlobalService:               globalconfig.ServiceName(),
+		LambdaMode:                  fmt.Sprintf("%t", t.config.logToStdout),
+		AgentFeatures:               t.config.agent,
+		AppSec:                      appsec.Enabled(),
 	}
 	if _, err := samplingRulesFromEnv(); err != nil {
 		info.SamplingRulesError = fmt.Sprintf("%s", err)

--- a/ddtrace/tracer/log_test.go
+++ b/ddtrace/tracer/log_test.go
@@ -26,7 +26,7 @@ func TestStartupLog(t *testing.T) {
 		logStartup(tracer)
 		lines := removeAppSec(tp.Lines())
 		assert.Len(lines, 2)
-		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sampling_rules":null,"sampling_rules_error":"","service_mappings":null,"tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"false","appsec":((true)|(false)),"agent_features":{"DropP0s":false,"Stats":false,"StatsdPort":0}}`, lines[1])
+		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sampling_rules":null,"sampling_rules_error":"","service_mappings":null,"tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"profiler_code_hotspots_enabled":false,"profiler_endpoints_enabled":false,"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"false","appsec":((true)|(false)),"agent_features":{"DropP0s":false,"Stats":false,"StatsdPort":0}}`, lines[1])
 	})
 
 	t.Run("configured", func(t *testing.T) {
@@ -55,7 +55,7 @@ func TestStartupLog(t *testing.T) {
 		tp.Reset()
 		logStartup(tracer)
 		assert.Len(tp.Lines(), 2)
-		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"configuredEnv","service":"configured.service","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":true,"analytics_enabled":true,"sample_rate":"0\.123000","sampling_rules":\[{"service":"mysql","name":"","sample_rate":0\.75}\],"sampling_rules_error":"","service_mappings":{"initial_service":"new_service"},"tags":{"runtime-id":"[^"]*","tag":"value","tag2":"NaN"},"runtime_metrics_enabled":true,"health_metrics_enabled":true,"dd_version":"2.3.4","architecture":"[^"]*","global_service":"configured.service","lambda_mode":"false","appsec":((true)|(false)),"agent_features":{"DropP0s":false,"Stats":false,"StatsdPort":0}}`, tp.Lines()[1])
+		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"configuredEnv","service":"configured.service","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":true,"analytics_enabled":true,"sample_rate":"0\.123000","sampling_rules":\[{"service":"mysql","name":"","sample_rate":0\.75}\],"sampling_rules_error":"","service_mappings":{"initial_service":"new_service"},"tags":{"runtime-id":"[^"]*","tag":"value","tag2":"NaN"},"runtime_metrics_enabled":true,"health_metrics_enabled":true,"profiler_code_hotspots_enabled":false,"profiler_endpoints_enabled":false,"dd_version":"2.3.4","architecture":"[^"]*","global_service":"configured.service","lambda_mode":"false","appsec":((true)|(false)),"agent_features":{"DropP0s":false,"Stats":false,"StatsdPort":0}}`, tp.Lines()[1])
 	})
 
 	t.Run("errors", func(t *testing.T) {
@@ -69,7 +69,7 @@ func TestStartupLog(t *testing.T) {
 		tp.Reset()
 		logStartup(tracer)
 		assert.Len(tp.Lines(), 2)
-		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sampling_rules":\[{"service":"some.service","name":"","sample_rate":0\.234}\],"sampling_rules_error":"found errors:\\n\\tat index 1: rate not provided","service_mappings":null,"tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"false","appsec":((true)|(false)),"agent_features":{"DropP0s":false,"Stats":false,"StatsdPort":0}}`, tp.Lines()[1])
+		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sampling_rules":\[{"service":"some.service","name":"","sample_rate":0\.234}\],"sampling_rules_error":"found errors:\\n\\tat index 1: rate not provided","service_mappings":null,"tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"profiler_code_hotspots_enabled":false,"profiler_endpoints_enabled":false,"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"false","appsec":((true)|(false)),"agent_features":{"DropP0s":false,"Stats":false,"StatsdPort":0}}`, tp.Lines()[1])
 	})
 
 	t.Run("lambda", func(t *testing.T) {
@@ -81,7 +81,7 @@ func TestStartupLog(t *testing.T) {
 		tp.Reset()
 		logStartup(tracer)
 		assert.Len(tp.Lines(), 1)
-		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test","agent_url":"http://localhost:9/v0.4/traces","agent_error":"","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sampling_rules":null,"sampling_rules_error":"","service_mappings":null,"tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"true","appsec":((true)|(false)),"agent_features":{"DropP0s":false,"Stats":false,"StatsdPort":0}}`, tp.Lines()[0])
+		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+ INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test","agent_url":"http://localhost:9/v0.4/traces","agent_error":"","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sampling_rules":null,"sampling_rules_error":"","service_mappings":null,"tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"profiler_code_hotspots_enabled":false,"profiler_endpoints_enabled":false,"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"true","appsec":((true)|(false)),"agent_features":{"DropP0s":false,"Stats":false,"StatsdPort":0}}`, tp.Lines()[0])
 	})
 }
 

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -341,6 +341,16 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 			}
 		}
 	}
+	if pprofContext == nil {
+		// For root span's without context, there is no pprofContext, but we need
+		// one to avoid a panic() in pprof.WithLabels(). Using context.Background()
+		// is not ideal here, as it will cause us to remove all labels from the
+		// goroutine when the span finishes. However, the alternatives of not
+		// applying labels for such spans or to leave the endpoint/hotspot labels
+		// on the goroutine after it finishes are even less appealing. We'll have
+		// to properly document this for users.
+		pprofContext = gocontext.Background()
+	}
 	id := opts.SpanID
 	if id == 0 {
 		id = random.Uint64()

--- a/internal/traceprof/traceproftest/app.go
+++ b/internal/traceprof/traceproftest/app.go
@@ -251,6 +251,9 @@ func (a *App) Work(ctx context.Context, req *pb.WorkReq) (*pb.WorkRes, error) {
 	close(stop)
 	cpuSpan.Finish()
 
+	orphanSpan := tracer.StartSpan("orphan")
+	orphanSpan.Finish()
+
 	return &pb.WorkRes{
 		LocalRootSpanId: fmt.Sprintf("%d", localRootSpan.Context().SpanID()),
 		SpanId:          fmt.Sprintf("%d", cpuSpan.Context().SpanID()),


### PR DESCRIPTION
Fix a nil-pointer reference crash when clients create root spans without passing a context.

Add hotspots/endpoints to tracer startup message to help debugging.