### PR TITLE
profiler: remove WithAPIKey from example

### DIFF
--- a/profiler/example_test.go
+++ b/profiler/example_test.go
@@ -14,7 +14,6 @@ import (
 // This example illustrates how to run (and later stop) the Datadog Profiler.
 func Example() {
 	err := profiler.Start(
-		profiler.WithAPIKey("123key"),
 		profiler.WithService("users-db"),
 		profiler.WithEnv("staging"),
 		profiler.WithTags("version:1.2.0"),


### PR DESCRIPTION
WithAPIKey is used for agentless uploading, which we don't officially support.
On top of that, the example doesn't have WithAgentlessUpload so the user would
get a warning if they ran the example code as-is.