### PR TITLE
tracer: profiler endpoints for spans without type

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -690,9 +690,10 @@ func WithProfilerCodeHotspots(enabled bool) StartOption {
 // WithProfilerEndpoints enables the endpoints integration between the tracer
 // and profiler. This is done by automatically attaching a pprof label called
 // "trace endpoint" holding the resource name of the top-level service span if
-// its type is http or rpc. You should not use this label name in your own code
-// when this is enabled. The enabled value defaults to the value of the
-// DD_PROFILING_ENDPOINT_COLLECTION_ENABLED env variable or false.
+// its type is "http", "rpc" or "" (default). You should not use this label
+// name in your own code when this is enabled. The enabled value defaults to
+// the value of the DD_PROFILING_ENDPOINT_COLLECTION_ENABLED env variable or
+// false.
 func WithProfilerEndpoints(enabled bool) StartOption {
 	return func(c *config) {
 		c.profilerEndpoints = enabled

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -461,9 +461,9 @@ func (t *tracer) applyPPROFLabels(ctx gocontext.Context, span *span) {
 
 // spanResourcePIISafe returns true if s.Resource can be considered to not
 // include PII with reasonable confidence. E.g. SQL queries may contain PII,
-// but http or rpc endpoint names generally do not.
+// but http, rpc or custom (s.Type == "") span resource names generally do not.
 func spanResourcePIISafe(s *span) bool {
-	return s.Type == ext.SpanTypeWeb || s.Type == ext.AppTypeRPC
+	return s.Type == ext.SpanTypeWeb || s.Type == ext.AppTypeRPC || s.Type == ""
 }
 
 // Stop stops the tracer.

--- a/internal/traceprof/traceproftest/app.go
+++ b/internal/traceprof/traceproftest/app.go
@@ -38,6 +38,9 @@ const (
 	HTTPWorkEndpoint = "/work/:secret"
 	// GRPCWorkEndpoint is the grpc endpoint used for the demo app.
 	GRPCWorkEndpoint = "/testapp.TestApp/Work"
+	// DirectEndpoint is the name of the expected endpoint when the root span
+	// is created directly.
+	DirectEndpoint = "workHandler"
 )
 
 // CustomLabels are the user-defined pprof labels to apply in the work endpoint
@@ -72,7 +75,7 @@ const (
 func (a testAppType) Endpoint() string {
 	switch a {
 	case Direct:
-		return ""
+		return DirectEndpoint
 	case GRPC:
 		return GRPCWorkEndpoint
 	case HTTP:
@@ -215,7 +218,7 @@ func (a *App) Work(ctx context.Context, req *pb.WorkReq) (*pb.WorkRes, error) {
 	localRootSpan, ok := tracer.SpanFromContext(ctx)
 	// We run our handler in a reqSpan so we can test that we still include the
 	// correct "local root span id" in the profiler labels.
-	reqSpan, reqSpanCtx := tracer.StartSpanFromContext(ctx, "workHandler")
+	reqSpan, reqSpanCtx := tracer.StartSpanFromContext(ctx, DirectEndpoint)
 	defer reqSpan.Finish()
 	if !ok {
 		// when app type is Direct, reqSpan is our local root span

--- a/internal/traceprof/traceproftest/traceprof_test.go
+++ b/internal/traceprof/traceproftest/traceprof_test.go
@@ -85,9 +85,7 @@ func TestEndpointsAndCodeHotspots(t *testing.T) {
 				})
 				require.Zero(t, prof.LabelDuration(traceprof.SpanID, res.SpanId))
 				require.Zero(t, prof.LabelDuration(traceprof.LocalRootSpanID, res.LocalRootSpanId))
-				if appType != Direct {
-					require.GreaterOrEqual(t, prof.LabelDuration(traceprof.TraceEndpoint, appType.Endpoint()), minCPUDuration)
-				}
+				require.GreaterOrEqual(t, prof.LabelDuration(traceprof.TraceEndpoint, appType.Endpoint()), minCPUDuration)
 			})
 
 			t.Run("code-hotspots", func(t *testing.T) {
@@ -112,9 +110,7 @@ func TestEndpointsAndCodeHotspots(t *testing.T) {
 					traceprof.SpanID:          res.SpanId,
 					traceprof.LocalRootSpanID: res.LocalRootSpanId,
 				}
-				if appType != Direct {
-					wantLabels[traceprof.TraceEndpoint] = appType.Endpoint()
-				}
+				wantLabels[traceprof.TraceEndpoint] = appType.Endpoint()
 				require.GreaterOrEqual(t, prof.LabelsDuration(wantLabels), minCPUDuration)
 			})
 


### PR DESCRIPTION
See PROF-4730 (dd internal) for more info.

This should be the last missing thing before v1.35.0 can go out 🥳 