### PR TITLE
contrib/gocql/gocql: support Scanner and Batch

### DIFF
--- a/contrib/gocql/gocql/gocql.go
+++ b/contrib/gocql/gocql/gocql.go
@@ -233,7 +233,7 @@ func (tb *Batch) WithTimestamp(timestamp int64) *Batch {
 	return tb
 }
 
-// Executes calls session.ExecuteBatch on the Batch, tracing the execution.
+// ExecuteBatch calls session.ExecuteBatch on the Batch, tracing the execution.
 func (tb *Batch) ExecuteBatch(session *gocql.Session) error {
 	span := tb.newChildSpan(tb.ctx)
 	err := session.ExecuteBatch(tb.Batch)

--- a/contrib/gocql/gocql/gocql.go
+++ b/contrib/gocql/gocql/gocql.go
@@ -34,6 +34,19 @@ type Iter struct {
 	span ddtrace.Span
 }
 
+// Scanner inherits from a gocql.Scanner derived from an Iter
+type Scanner struct {
+	gocql.Scanner
+	*Iter
+}
+
+// Batch inherits from gocql.Batch, it keeps the tracer and the context.
+type Batch struct {
+	*gocql.Batch
+	*params
+	ctx context.Context
+}
+
 // params containes fields and metadata useful for command tracing
 type params struct {
 	config    *queryConfig
@@ -62,7 +75,7 @@ func WrapQuery(q *gocql.Query, opts ...WrapOption) *Query {
 		}
 	}
 	log.Debug("contrib/gocql/gocql: Wrapping Query: %#v", cfg)
-	tq := &Query{q, &params{config: cfg}, context.Background()}
+	tq := &Query{q, &params{config: cfg}, q.Context()}
 	return tq
 }
 
@@ -162,4 +175,93 @@ func (tIter *Iter) Close() error {
 	}
 	tIter.span.Finish()
 	return err
+}
+
+// Scanner returns a row Scanner which provides an interface to scan rows in a
+// manner which is similar to database/sql. The Iter should NOT be used again after
+// calling this method.
+func (tIter *Iter) Scanner() gocql.Scanner {
+	return &Scanner{
+		Scanner: tIter.Iter.Scanner(),
+		Iter:    tIter,
+	}
+}
+
+// Err calls the wrapped Scanner.Err, releasing both Scanner and Iter resources.
+func (s *Scanner) Err() error {
+	if err := s.Iter.Close(); err != nil {
+		s.Scanner.Err()
+		return err
+	}
+
+	return s.Scanner.Err()
+}
+
+// WrapBatch wraps a gocql.Batch into a traced Batch under the given service name.
+// Note that the returned Batch structure embeds the original gocql.Batch structure.
+// This means that any method returning the batch for chaining that is not part
+// of this package's Batch structure should be called before WrapBatch, otherwise
+// the tracing context could be lost.
+//
+// To be more specific: it is ok (and recommended) to use and chain the return value
+// of `WithContext` and `WithTimestamp` but not that of `SerialConsistency`, `Trace`,
+// `Observer`, etc.
+func WrapBatch(b *gocql.Batch, opts ...WrapOption) *Batch {
+	cfg := new(queryConfig)
+	defaults(cfg)
+	for _, fn := range opts {
+		fn(cfg)
+	}
+	log.Debug("contrib/gocql/gocql: Wrapping Batch: %#v", cfg)
+	tb := &Batch{b, &params{config: cfg}, b.Context()}
+	return tb
+}
+
+// WithContext adds the specified context to the traced Batch structure.
+func (tb *Batch) WithContext(ctx context.Context) *Batch {
+	tb.ctx = ctx
+	tb.Batch = tb.Batch.WithContext(ctx)
+	return tb
+}
+
+// WithTimestamp will enable the with default timestamp flag on the query like
+// DefaultTimestamp does. But also allows to define value for timestamp. It works the
+// same way as USING TIMESTAMP in the query itself, but should not break prepared
+// query optimization.
+func (tb *Batch) WithTimestamp(timestamp int64) *Batch {
+	tb.Batch = tb.Batch.WithTimestamp(timestamp)
+	return tb
+}
+
+// Executes calls session.ExecuteBatch on the Batch, tracing the execution.
+func (tb *Batch) ExecuteBatch(session *gocql.Session) error {
+	span := tb.newChildSpan(tb.ctx)
+	err := session.ExecuteBatch(tb.Batch)
+	tb.finishSpan(span, err)
+	return err
+}
+
+// newChildSpan creates a new span from the params and the context.
+func (tb *Batch) newChildSpan(ctx context.Context) ddtrace.Span {
+	p := tb.params
+	opts := []ddtrace.StartSpanOption{
+		tracer.SpanType(ext.SpanTypeCassandra),
+		tracer.ServiceName(p.config.serviceName),
+		tracer.ResourceName(p.config.resourceName),
+		tracer.Tag(ext.CassandraConsistencyLevel, tb.Cons.String()),
+		tracer.Tag(ext.CassandraKeyspace, tb.Keyspace()),
+	}
+	if !math.IsNaN(p.config.analyticsRate) {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, p.config.analyticsRate))
+	}
+	span, _ := tracer.StartSpanFromContext(ctx, ext.CassandraBatch, opts...)
+	return span
+}
+
+func (tb *Batch) finishSpan(span ddtrace.Span, err error) {
+	if tb.params.config.noDebugStack {
+		span.Finish(tracer.WithError(err), tracer.NoDebugStack())
+	} else {
+		span.Finish(tracer.WithError(err))
+	}
 }

--- a/contrib/gocql/gocql/gocql_test.go
+++ b/contrib/gocql/gocql/gocql_test.go
@@ -103,6 +103,9 @@ func TestChildWrapperSpan(t *testing.T) {
 	cluster := newCassandraCluster()
 	session, err := cluster.CreateSession()
 	assert.Nil(err)
+
+	// Call WithContext before WrapQuery to prove WrapQuery needs to use the query.Context()
+	// instead of context.Background()
 	q := session.Query("SELECT * from trace.person").WithContext(ctx)
 	tq := WrapQuery(q, WithServiceName("TestServiceName"))
 	iter := tq.Iter()

--- a/contrib/gocql/gocql/gocql_test.go
+++ b/contrib/gocql/gocql/gocql_test.go
@@ -254,7 +254,7 @@ func TestBatch(t *testing.T) {
 	stmt := "INSERT INTO trace.person (name, age, description) VALUES (?, ?, ?)"
 	tb.Query(stmt, "Kate", 80, "Cassandra's sister running in kubernetes")
 	tb.Query(stmt, "Lucas", 60, "Another person")
-	err = tb.WithContext(ctx).WithTimestamp(time.Now().UnixMilli()).ExecuteBatch(session)
+	err = tb.WithContext(ctx).WithTimestamp(time.Now().Unix() * 1e3).ExecuteBatch(session)
 	assert.NoError(err)
 
 	parentSpan.Finish()

--- a/contrib/gocql/gocql/gocql_test.go
+++ b/contrib/gocql/gocql/gocql_test.go
@@ -60,7 +60,7 @@ func TestMain(m *testing.M) {
 	session.Query("CREATE TABLE if not exists trace.person (name text PRIMARY KEY, age int, description text)").Exec()
 	session.Query("INSERT INTO trace.person (name, age, description) VALUES ('Cassandra', 100, 'A cruel mistress')").Exec()
 
-	m.Run()
+	os.Exit(m.Run())
 }
 
 func TestErrorWrapper(t *testing.T) {
@@ -103,9 +103,9 @@ func TestChildWrapperSpan(t *testing.T) {
 	cluster := newCassandraCluster()
 	session, err := cluster.CreateSession()
 	assert.Nil(err)
-	q := session.Query("SELECT * from trace.person")
+	q := session.Query("SELECT * from trace.person").WithContext(ctx)
 	tq := WrapQuery(q, WithServiceName("TestServiceName"))
-	iter := tq.WithContext(ctx).Iter()
+	iter := tq.Iter()
 	iter.Close()
 	parentSpan.Finish()
 
@@ -192,4 +192,88 @@ func TestAnalyticsSettings(t *testing.T) {
 
 		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
 	})
+}
+
+func TestIterScanner(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	// Parent span
+	parentSpan, ctx := tracer.StartSpanFromContext(context.Background(), "parentSpan")
+	cluster := newCassandraCluster()
+	session, err := cluster.CreateSession()
+	assert.NoError(err)
+
+	q := session.Query("SELECT * from trace.person")
+	tq := WrapQuery(q, WithServiceName("TestServiceName"))
+	iter := tq.WithContext(ctx).Iter()
+	sc := iter.Scanner()
+	for sc.Next() {
+		var t1, t2, t3 interface{}
+		sc.Scan(&t1, t2, t3)
+	}
+	sc.Err()
+
+	parentSpan.Finish()
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 2)
+
+	var childSpan, pSpan mocktracer.Span
+	if spans[0].ParentID() == spans[1].SpanID() {
+		childSpan = spans[0]
+		pSpan = spans[1]
+	} else {
+		childSpan = spans[1]
+		pSpan = spans[0]
+	}
+
+	assert.Equal(pSpan.OperationName(), "parentSpan")
+	assert.Equal(childSpan.ParentID(), pSpan.SpanID())
+	assert.Equal(childSpan.OperationName(), ext.CassandraQuery)
+	assert.Equal(childSpan.Tag(ext.ResourceName), "SELECT * from trace.person")
+	assert.Equal(childSpan.Tag(ext.CassandraKeyspace), "trace")
+}
+
+func TestBatch(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	// Parent span
+	parentSpan, ctx := tracer.StartSpanFromContext(context.Background(), "parentSpan")
+	cluster := newCassandraCluster()
+	cluster.Keyspace = "trace"
+	session, err := cluster.CreateSession()
+	assert.NoError(err)
+
+	b := session.NewBatch(gocql.UnloggedBatch)
+	tb := WrapBatch(b, WithServiceName("TestServiceName"), WithResourceName("BatchInsert"))
+
+	stmt := "INSERT INTO trace.person (name, age, description) VALUES (?, ?, ?)"
+	tb.Query(stmt, "Kate", 80, "Cassandra's sister running in kubernetes")
+	tb.Query(stmt, "Lucas", 60, "Another person")
+	err = tb.WithContext(ctx).WithTimestamp(time.Now().UnixMilli()).ExecuteBatch(session)
+	assert.NoError(err)
+
+	parentSpan.Finish()
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 2)
+
+	var childSpan, pSpan mocktracer.Span
+	if spans[0].ParentID() == spans[1].SpanID() {
+		childSpan = spans[0]
+		pSpan = spans[1]
+	} else {
+		childSpan = spans[1]
+		pSpan = spans[0]
+	}
+
+	assert.Equal(pSpan.OperationName(), "parentSpan")
+	assert.Equal(childSpan.ParentID(), pSpan.SpanID())
+	assert.Equal(childSpan.OperationName(), ext.CassandraBatch)
+	assert.Equal(childSpan.Tag(ext.ResourceName), "BatchInsert")
+	assert.Equal(childSpan.Tag(ext.CassandraKeyspace), "trace")
 }

--- a/ddtrace/ext/cassandra.go
+++ b/ddtrace/ext/cassandra.go
@@ -9,6 +9,9 @@ const (
 	// CassandraQuery is the tag name used for cassandra queries.
 	CassandraQuery = "cassandra.query"
 
+	// CassandraBatch is the tag name used for cassandra batches.
+	CassandraBatch = "cassandra.batch"
+
 	// CassandraConsistencyLevel is the tag name to set for consitency level.
 	CassandraConsistencyLevel = "cassandra.consistency_level"
 


### PR DESCRIPTION
I lost my first commit somehow, but it got included in the second one...

Adds:
 - Support for calling Iter.Scanner() in such a way that the Iter's trace actually closes
 - Support for Batch queries including calling WithContext and adding Query's to the batch after it has been wrapped
 - batch.ExecuteBatch(session) error function which inverts the session.ExecuteBatch(batch) error signature to execute the batch with tracing
 - Test coverage

Additionally:
WrapQuery was incorrectly using context.Background() instead of the passed query's Context method that could already have a parent trace attached to it.

@gbbr I [screwed up the other pr](https://github.com/DataDog/dd-trace-go/pull/1111#issuecomment-1007156770) somehow trying to rebase... here's another one with the commits cherry picked over...