### PR TITLE
circleci: enforce gorm to v1.22.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,6 +249,8 @@ jobs:
             go get github.com/hashicorp/vault/sdk@v0.2.0
             # Shopify/sarama > v1.22 doesn't compile with go1.14
             go get github.com/Shopify/sarama@v1.22.0
+            # Temporary enforcing gorm to v1.22.4 to avoid the problems of v1.22.5
+            go get -v gorm.io/gorm@v1.22.4
 
       - run:
           name: Wait for MySQL


### PR DESCRIPTION
The new gorm v1.22.5 introduced some regressions in our tests (https://app.circleci.com/pipelines/github/DataDog/dd-trace-go/2532/workflows/06f37dbb-2d0b-4548-aaea-95de1345291a/jobs/17965) that I couldn't easily explain so far:
1. I see nothing obvious while debugging: the tracer correctly reports the SQL statement gorm has built.
2. I see nothing obvious neither when looking at the gorm diff: https://github.com/go-gorm/gorm/compare/v1.22.4...v1.22.5 (couldn't find any release note)

Given the test failure logs, it looks like a regression to me. So we should confirm and report it to them if that's the case, and in the meantime we can enforce our gorm version to v1.22.4 to unlock the failing pull request CIs.