### PR TITLE
ddtrace/tracer: Use DD_AGENT_HOST to set trace agent hostname before querying the trace-agent for its features

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -190,6 +190,9 @@ func newConfig(opts ...StartOption) *config {
 	if v := os.Getenv("DD_TRACE_SOURCE_HOSTNAME"); v != "" {
 		c.hostname = v
 	}
+	if v := os.Getenv("DD_AGENT_HOST"); v != "" {
+		c.agentAddr = v
+	}
 	if v := os.Getenv("DD_ENV"); v != "" {
 		c.env = v
 	}

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -174,7 +174,7 @@ func forEachStringTag(str string, fn func(key string, val string)) {
 func newConfig(opts ...StartOption) *config {
 	c := new(config)
 	c.sampler = NewAllSampler()
-	c.agentAddr = defaultAddress
+	c.agentAddr = resolveAgentAddr(defaultAddress)
 	c.httpClient = defaultHTTPClient()
 
 	if internal.BoolEnv("DD_TRACE_ANALYTICS_ENABLED", false) {
@@ -189,9 +189,6 @@ func newConfig(opts ...StartOption) *config {
 	}
 	if v := os.Getenv("DD_TRACE_SOURCE_HOSTNAME"); v != "" {
 		c.hostname = v
-	}
-	if v := os.Getenv("DD_AGENT_HOST"); v != "" {
-		c.agentAddr = v
 	}
 	if v := os.Getenv("DD_ENV"); v != "" {
 		c.env = v

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -308,7 +308,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		defer os.Unsetenv("DD_AGENT_HOST")
 		tracer := newTracer()
 		c := tracer.config
-		assert.Equal(t, "trace-agent", c.agentAddr)
+		assert.Equal(t, "trace-agent:8126", c.agentAddr)
 	})
 
 	t.Run("override", func(t *testing.T) {

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -303,6 +303,14 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		})
 	})
 
+	t.Run("env-agentAddr", func(t *testing.T) {
+		os.Setenv("DD_AGENT_HOST", "trace-agent")
+		defer os.Unsetenv("DD_AGENT_HOST")
+		tracer := newTracer()
+		c := tracer.config
+		assert.Equal(t, "trace-agent", c.agentAddr)
+	})
+
 	t.Run("override", func(t *testing.T) {
 		os.Setenv("DD_ENV", "dev")
 		defer os.Unsetenv("DD_ENV")

--- a/ddtrace/tracer/transport.go
+++ b/ddtrace/tracer/transport.go
@@ -101,8 +101,8 @@ func newHTTPTransport(addr string, client *http.Client) *httpTransport {
 		defaultHeaders["Datadog-Container-ID"] = cid
 	}
 	return &httpTransport{
-		traceURL: fmt.Sprintf("http://%s/v0.4/traces", resolveAddr(addr)),
-		statsURL: fmt.Sprintf("http://%s/v0.6/stats", resolveAddr(addr)),
+		traceURL: fmt.Sprintf("http://%s/v0.4/traces", resolveAgentAddr(addr)),
+		statsURL: fmt.Sprintf("http://%s/v0.6/stats", resolveAgentAddr(addr)),
 		client:   client,
 		headers:  defaultHeaders,
 	}
@@ -183,10 +183,10 @@ func (t *httpTransport) endpoint() string {
 	return t.traceURL
 }
 
-// resolveAddr resolves the given agent address and fills in any missing host
+// resolveAgentAddr resolves the given agent address and fills in any missing host
 // and port using the defaults. Some environment variable settings will
 // take precedence over configuration.
-func resolveAddr(addr string) string {
+func resolveAgentAddr(addr string) string {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		// no port in addr

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -77,7 +77,7 @@ func TestTracesAgentIntegration(t *testing.T) {
 	}
 }
 
-func TestResolveAddr(t *testing.T) {
+func TestResolveAgentAdddr(t *testing.T) {
 	for _, tt := range []struct {
 		in, envHost, envPort, out string
 	}{
@@ -107,7 +107,7 @@ func TestResolveAddr(t *testing.T) {
 				os.Setenv("DD_TRACE_AGENT_PORT", tt.envPort)
 				defer os.Unsetenv("DD_TRACE_AGENT_PORT")
 			}
-			assert.Equal(t, resolveAddr(tt.in), tt.out)
+			assert.Equal(t, resolveAgentAddr(tt.in), tt.out)
 		})
 	}
 }

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -77,7 +77,7 @@ func TestTracesAgentIntegration(t *testing.T) {
 	}
 }
 
-func TestResolveAgentAdddr(t *testing.T) {
+func TestResolveAgentAddr(t *testing.T) {
 	for _, tt := range []struct {
 		in, envHost, envPort, out string
 	}{


### PR DESCRIPTION
If the env var `DD_AGENT_HOST` is set and the trace-agent is not running
on localhost, then the call to the agent's `/info` endpoint fails as its
using the wrong hostname.