### PR TITLE
internal/appsec: rate-limit appsec traces to 100 per second

### DIFF
--- a/internal/appsec/config.go
+++ b/internal/appsec/config.go
@@ -16,12 +16,16 @@ import (
 )
 
 const (
-	enabledEnvVar    = "DD_APPSEC_ENABLED"
-	rulesEnvVar      = "DD_APPSEC_RULES"
-	wafTimeoutEnvVar = "DD_APPSEC_WAF_TIMEOUT"
+	enabledEnvVar        = "DD_APPSEC_ENABLED"
+	rulesEnvVar          = "DD_APPSEC_RULES"
+	wafTimeoutEnvVar     = "DD_APPSEC_WAF_TIMEOUT"
+	traceRateLimitEnvVar = "DD_APPSEC_TRACE_RATE_LIMIT"
 )
 
-const defaultWAFTimeout = 4 * time.Millisecond
+const (
+	defaultWAFTimeout      = 4 * time.Millisecond
+	defaultTraceRate  uint = 100 // up to 100 appsec traces/s
+)
 
 // config is the AppSec configuration.
 type config struct {
@@ -29,6 +33,8 @@ type config struct {
 	rules []byte
 	// Maximum WAF execution time
 	wafTimeout time.Duration
+	// AppSec trace rate limit (traces per second).
+	traceRateLimit uint
 }
 
 // isEnabled returns true when appsec is enabled when the environment variable
@@ -46,36 +52,74 @@ func isEnabled() (bool, error) {
 }
 
 func newConfig() (*config, error) {
-	cfg := &config{}
+	rules, err := readRulesConfig()
+	if err != nil {
+		return nil, err
+	}
+	return &config{
+		rules:          rules,
+		wafTimeout:     readWAFTimeoutConfig(),
+		traceRateLimit: readRateLimitConfig(),
+	}, nil
+}
 
+func readWAFTimeoutConfig() (timeout time.Duration) {
+	timeout = defaultWAFTimeout
+	value := os.Getenv(wafTimeoutEnvVar)
+	if value == "" {
+		return
+	}
+	parsed, err := time.ParseDuration(value)
+	if err != nil {
+		logEnvVarParsingError(wafTimeoutEnvVar, value, err, timeout)
+	}
+	if parsed <= 0 {
+		logUnexpectedEnvVarValue(wafTimeoutEnvVar, parsed, "expecting a strictly positive duration", timeout)
+		return
+	}
+	return parsed
+}
+
+func readRateLimitConfig() (rate uint) {
+	rate = defaultTraceRate
+	value := os.Getenv(traceRateLimitEnvVar)
+	if value == "" {
+		return rate
+	}
+	parsed, err := strconv.ParseUint(value, 10, 0)
+	if err != nil {
+		logEnvVarParsingError(traceRateLimitEnvVar, value, err, rate)
+		return
+	}
+	if rate == 0 {
+		logUnexpectedEnvVarValue(traceRateLimitEnvVar, parsed, "expecting a value strictly greater than 0", rate)
+		return
+	}
+	return uint(parsed)
+}
+
+func readRulesConfig() (rules []byte, err error) {
+	rules = []byte(staticRecommendedRule)
 	filepath := os.Getenv(rulesEnvVar)
-	if filepath != "" {
-		rules, err := ioutil.ReadFile(filepath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				log.Error("appsec: could not find the rules file in path %s: %v.", filepath, err)
-			}
-			return nil, err
-		}
-		cfg.rules = rules
-		log.Info("appsec: starting with the security rules from file %s", filepath)
-	} else {
+	if filepath == "" {
 		log.Info("appsec: starting with the default recommended security rules")
-		cfg.rules = []byte(staticRecommendedRule)
+		return rules, nil
 	}
-
-	cfg.wafTimeout = defaultWAFTimeout
-	if wafTimeout := os.Getenv(wafTimeoutEnvVar); wafTimeout != "" {
-		if timeout, err := time.ParseDuration(wafTimeout); err == nil {
-			if timeout <= 0 {
-				log.Error("appsec: unexpected configuration value of %s=%s: expecting a strictly positive duration. Using default value %s.", wafTimeoutEnvVar, wafTimeout, cfg.wafTimeout)
-			} else {
-				cfg.wafTimeout = timeout
-			}
-		} else {
-			log.Error("appsec: could not parse the value of %s %s as a duration: %v. Using default value %s.", wafTimeoutEnvVar, wafTimeout, err, cfg.wafTimeout)
+	buf, err := ioutil.ReadFile(filepath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Error("appsec: could not find the rules file in path %s: %v.", filepath, err)
 		}
+		return nil, err
 	}
+	log.Info("appsec: starting with the security rules from file %s", filepath)
+	return buf, nil
+}
 
-	return cfg, nil
+func logEnvVarParsingError(name, value string, err error, defaultValue interface{}) {
+	log.Error("appsec: could not parse the env var %s=%s as a duration: %v. Using default value %v.", name, value, err, defaultValue)
+}
+
+func logUnexpectedEnvVarValue(name string, value interface{}, reason string, defaultValue interface{}) {
+	log.Error("appsec: unexpected configuration value of %s=%v: %s. Using default value %v.", name, value, reason, defaultValue)
 }

--- a/internal/appsec/config_test.go
+++ b/internal/appsec/config_test.go
@@ -19,8 +19,9 @@ import (
 
 func TestConfig(t *testing.T) {
 	expectedDefaultConfig := &config{
-		rules:      []byte(staticRecommendedRule),
-		wafTimeout: defaultWAFTimeout,
+		rules:          []byte(staticRecommendedRule),
+		wafTimeout:     defaultWAFTimeout,
+		traceRateLimit: defaultTraceRate,
 	}
 
 	t.Run("default", func(t *testing.T) {
@@ -41,8 +42,9 @@ func TestConfig(t *testing.T) {
 			require.Equal(
 				t,
 				&config{
-					rules:      []byte(staticRecommendedRule),
-					wafTimeout: 5 * time.Second,
+					rules:          []byte(staticRecommendedRule),
+					wafTimeout:     5 * time.Second,
+					traceRateLimit: defaultTraceRate,
 				},
 				cfg,
 			)
@@ -61,6 +63,15 @@ func TestConfig(t *testing.T) {
 			restoreEnv := cleanEnv()
 			defer restoreEnv()
 			require.NoError(t, os.Setenv(wafTimeoutEnvVar, "-1s"))
+			cfg, err := newConfig()
+			require.NoError(t, err)
+			require.Equal(t, expectedDefaultConfig, cfg)
+		})
+
+		t.Run("zero", func(t *testing.T) {
+			restoreEnv := cleanEnv()
+			defer restoreEnv()
+			require.NoError(t, os.Setenv(wafTimeoutEnvVar, "0"))
 			cfg, err := newConfig()
 			require.NoError(t, err)
 			require.Equal(t, expectedDefaultConfig, cfg)
@@ -111,9 +122,65 @@ func TestConfig(t *testing.T) {
 			cfg, err := newConfig()
 			require.NoError(t, err)
 			require.Equal(t, &config{
-				rules:      []byte(expectedRules),
-				wafTimeout: defaultWAFTimeout,
+				rules:          []byte(expectedRules),
+				wafTimeout:     defaultWAFTimeout,
+				traceRateLimit: defaultTraceRate,
 			}, cfg)
+		})
+	})
+
+	t.Run("trace-rate-limit", func(t *testing.T) {
+		t.Run("parsable", func(t *testing.T) {
+			restoreEnv := cleanEnv()
+			defer restoreEnv()
+			require.NoError(t, os.Setenv(traceRateLimitEnvVar, "1234567890"))
+			cfg, err := newConfig()
+			require.NoError(t, err)
+			require.Equal(
+				t,
+				&config{
+					rules:          []byte(staticRecommendedRule),
+					wafTimeout:     defaultWAFTimeout,
+					traceRateLimit: 1234567890,
+				},
+				cfg,
+			)
+		})
+
+		t.Run("not-parsable", func(t *testing.T) {
+			restoreEnv := cleanEnv()
+			defer restoreEnv()
+			require.NoError(t, os.Setenv(wafTimeoutEnvVar, "not a uint"))
+			cfg, err := newConfig()
+			require.NoError(t, err)
+			require.Equal(t, expectedDefaultConfig, cfg)
+		})
+
+		t.Run("negative", func(t *testing.T) {
+			restoreEnv := cleanEnv()
+			defer restoreEnv()
+			require.NoError(t, os.Setenv(wafTimeoutEnvVar, "-1"))
+			cfg, err := newConfig()
+			require.NoError(t, err)
+			require.Equal(t, expectedDefaultConfig, cfg)
+		})
+
+		t.Run("zero", func(t *testing.T) {
+			restoreEnv := cleanEnv()
+			defer restoreEnv()
+			require.NoError(t, os.Setenv(wafTimeoutEnvVar, "0"))
+			cfg, err := newConfig()
+			require.NoError(t, err)
+			require.Equal(t, expectedDefaultConfig, cfg)
+		})
+
+		t.Run("empty-string", func(t *testing.T) {
+			restoreEnv := cleanEnv()
+			defer restoreEnv()
+			require.NoError(t, os.Setenv(wafTimeoutEnvVar, ""))
+			cfg, err := newConfig()
+			require.NoError(t, err)
+			require.Equal(t, expectedDefaultConfig, cfg)
 		})
 	})
 }
@@ -127,9 +194,14 @@ func cleanEnv() func() {
 	if err := os.Unsetenv(rulesEnvVar); err != nil {
 		panic(err)
 	}
+	traceRateLimit := os.Getenv(traceRateLimitEnvVar)
+	if err := os.Unsetenv(traceRateLimitEnvVar); err != nil {
+		panic(err)
+	}
 	return func() {
 		restoreEnv(wafTimeoutEnvVar, wafTimeout)
 		restoreEnv(rulesEnvVar, rules)
+		restoreEnv(traceRateLimitEnvVar, traceRateLimit)
 	}
 }
 

--- a/internal/appsec/dyngo/instrumentation/grpcsec/grpc.go
+++ b/internal/appsec/dyngo/instrumentation/grpcsec/grpc.go
@@ -84,10 +84,10 @@ func (op *HandlerOperation) Finish(res HandlerOperationRes) []json.RawMessage {
 
 // AddSecurityEvent adds the security event to the list of events observed
 // during the operation lifetime.
-func (op *HandlerOperation) AddSecurityEvent(event json.RawMessage) {
+func (op *HandlerOperation) AddSecurityEvent(events []json.RawMessage) {
 	op.mu.Lock()
 	defer op.mu.Unlock()
-	op.events = append(op.events, event)
+	op.events = append(op.events, events...)
 }
 
 // gRPC handler operation's start and finish event callback function types.

--- a/internal/appsec/dyngo/instrumentation/grpcsec/grpc_test.go
+++ b/internal/appsec/dyngo/instrumentation/grpcsec/grpc_test.go
@@ -48,7 +48,7 @@ func TestUsage(t *testing.T) {
 						require.Equal(t, expectedMessage, res.Message)
 						recvFinished++
 
-						handlerOp.AddSecurityEvent(json.RawMessage(expectedMessage))
+						handlerOp.AddSecurityEvent([]json.RawMessage{json.RawMessage(expectedMessage)})
 					}))
 				}))
 

--- a/internal/appsec/limiter.go
+++ b/internal/appsec/limiter.go
@@ -90,8 +90,9 @@ func (t *TokenTicker) updateBucket(ticksChan <-chan time.Time, startTime time.Ti
 }
 
 func (t *TokenTicker) Start() {
+	timeNow := time.Now()
 	t.ticker = time.NewTicker(500 * time.Microsecond)
-	t.start(t.ticker.C, time.Now(), false)
+	t.start(t.ticker.C, timeNow, false)
 }
 
 // start() is used for internal testing. Controlling the ticker means being able to test per-tick

--- a/internal/appsec/limiter.go
+++ b/internal/appsec/limiter.go
@@ -1,0 +1,96 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022 Datadog, Inc.
+
+//go:build appsec
+// +build appsec
+
+package appsec
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+type Limiter interface {
+	Allow() bool
+}
+
+//The token ticker is a thread-safe and lock-free rate limiter based on a token bucket.
+//The idea is to have a goroutine that will update  the bucket with fresh tokens at regular intervals using a time.Ticker.
+//The advantage of using a goroutine here is  that the implementation becomes easily thread-safe using a few
+//atomic operations with little overhead overall. TokenTicker.Start() *must* be called before the first call to
+//TokenTicker.Allow() and TokenTicker.Stop() *must* be called once done using.
+type TokenTicker struct {
+	tokens    int64
+	maxTokens int64
+	ticker    *time.Ticker
+	stopChan  chan bool
+}
+
+func NewTokenTicker(tokens, maxTokens int64) *TokenTicker {
+	return &TokenTicker{
+		tokens:    tokens,
+		maxTokens: maxTokens,
+		stopChan:  make(chan bool),
+	}
+}
+
+func (t *TokenTicker) Start() {
+	if t.ticker != nil {
+		t.Stop()
+	}
+
+	t.ticker = time.NewTicker(500 * time.Microsecond)
+	//Ticker goroutine: ticks every 500ms to check whether tokens can be added to the bucket or not
+	go func(t *TokenTicker) {
+		ticksPerToken := (time.Second.Nanoseconds() / t.maxTokens)
+		ticks := int64(0)
+		prevStamp := time.Now()
+
+		for {
+			select {
+			case <-t.stopChan:
+				return
+			case stamp := <-t.ticker.C:
+				ticks += stamp.Sub(prevStamp).Nanoseconds()
+				prevStamp = stamp
+				if ticks >= ticksPerToken {
+					for {
+						tokens := atomic.LoadInt64(&t.tokens)
+						if tokens == t.maxTokens {
+							break
+						}
+						inc := ticks / ticksPerToken
+						if tokens+inc > t.maxTokens {
+							inc -= (tokens + inc) % t.maxTokens
+						}
+						if atomic.CompareAndSwapInt64(&t.tokens, tokens, tokens+inc) {
+							ticks = ticks % ticksPerToken
+							break
+						}
+					}
+				}
+			}
+		}
+	}(t)
+}
+
+func (t *TokenTicker) Stop() {
+	t.ticker.Stop()
+	t.stopChan <- true
+}
+
+func (t *TokenTicker) Allow() bool {
+	for {
+		tokens := atomic.LoadInt64(&t.tokens)
+		if tokens == 0 {
+			break
+		} else if atomic.CompareAndSwapInt64(&t.tokens, tokens, tokens-1) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/appsec/limiter.go
+++ b/internal/appsec/limiter.go
@@ -49,6 +49,9 @@ func (t *TokenTicker) updateBucket(startTime time.Time) {
 			return
 		case stamp := <-t.ticker.C:
 			ticks += stamp.Sub(prevStamp).Nanoseconds()
+			if ticks > t.maxTokens*ticksPerToken {
+				ticks = t.maxTokens * ticksPerToken
+			}
 			prevStamp = stamp
 			if ticks >= ticksPerToken {
 				for {

--- a/internal/appsec/limiter.go
+++ b/internal/appsec/limiter.go
@@ -26,14 +26,14 @@ type TokenTicker struct {
 	tokens    int64
 	maxTokens int64
 	ticker    *time.Ticker
-	stopChan  chan bool
+	stopChan  chan struct{}
 }
 
 func NewTokenTicker(tokens, maxTokens int64) *TokenTicker {
 	return &TokenTicker{
 		tokens:    tokens,
 		maxTokens: maxTokens,
-		stopChan:  make(chan bool),
+		stopChan:  make(chan struct{}),
 	}
 }
 
@@ -79,7 +79,7 @@ func (t *TokenTicker) Start() {
 
 func (t *TokenTicker) Stop() {
 	t.ticker.Stop()
-	t.stopChan <- true
+	close(t.stopChan)
 }
 
 func (t *TokenTicker) Allow() bool {

--- a/internal/appsec/limiter_test.go
+++ b/internal/appsec/limiter_test.go
@@ -137,15 +137,13 @@ func TestLimiter(t *testing.T) {
 			skipped := int64(0)
 			kept := int64(0)
 			l := NewTokenTicker(0, 100)
-			l.Start()
-			defer l.Stop()
 
 			for n := 0; n < nbUsers; n++ {
 				go func(l Limiter, kept *int64, skipped *int64) {
 					startBarrier.Wait()      // Sync the starts of the goroutines
 					defer stopBarrier.Done() // Signal we are done when returning
 
-					for tStart := time.Now(); time.Since(tStart) <= 1*time.Second; {
+					for tStart := time.Now(); time.Since(tStart) < 1*time.Second; {
 						if !l.Allow() {
 							atomic.AddInt64(skipped, 1)
 						} else {
@@ -155,6 +153,8 @@ func TestLimiter(t *testing.T) {
 				}(l, &kept, &skipped)
 			}
 
+			l.Start()
+			defer l.Stop()
 			start := time.Now()
 			startBarrier.Done() // Unblock the user goroutines
 			stopBarrier.Wait()  // Wait for the user goroutines to be done

--- a/internal/appsec/limiter_test.go
+++ b/internal/appsec/limiter_test.go
@@ -1,0 +1,202 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022 Datadog, Inc.
+
+//go:build appsec
+// +build appsec
+
+package appsec
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimiterUnit(t *testing.T) {
+
+	t.Run("consecutive-allow-1", func(t *testing.T) {
+		l := NewTokenTicker(1, 100)
+		l.Start()
+		defer l.Stop()
+		require.True(t, l.Allow(), "First call to limiter.Allow() should return True")
+		require.False(t, l.Allow(), "Second call to limiter.Allow() should return False")
+	})
+
+	t.Run("consecutive-allow-2", func(t *testing.T) {
+		l := NewTokenTicker(100, 100)
+		l.Start()
+		defer l.Stop()
+		for i := 0; i < 10; i++ {
+			require.True(t, l.Allow(), "Call to limiter.Allow() should return True")
+		}
+	})
+
+	t.Run("11ms-sleep-gapped-allow", func(t *testing.T) {
+		l := NewTokenTicker(1, 100)
+		l.Start()
+		defer l.Stop()
+		require.True(t, l.Allow(), "First call to limiter.Allow() should return True")
+		time.Sleep(11 * time.Millisecond)
+		require.True(t, l.Allow(), "Second call to limiter.Allow() after 11ms should return True")
+	})
+
+	t.Run("9ms-sleep-gapped-allow", func(t *testing.T) {
+		l := NewTokenTicker(1, 100)
+		l.Start()
+		defer l.Stop()
+		require.True(t, l.Allow(), "First call to limiter.Allow() should return True")
+		time.Sleep(9 * time.Millisecond)
+		require.False(t, l.Allow(), "Second call to limiter.Allow() after 9ms should return False")
+	})
+
+	t.Run("1s-rate", func(t *testing.T) {
+		l := NewTokenTicker(1, 1)
+		l.Start()
+		defer l.Stop()
+		require.True(t, l.Allow(), "First call to limiter.Allow() should return True with 1s per token")
+		require.False(t, l.Allow(), "Second call to limiter.Allow() should return False with 1s per Token")
+	})
+
+	t.Run("100-requests-burst", func(t *testing.T) {
+		l := NewTokenTicker(100, 100)
+		l.Start()
+		defer l.Stop()
+		for i := 0; i < 100; i++ {
+			require.True(t, l.Allow(),
+				"Burst call %d to limiter.Allow() should return True with 100 initial tokens", i)
+		}
+	})
+
+	t.Run("101-requests-burst", func(t *testing.T) {
+		l := NewTokenTicker(100, 100)
+		l.Start()
+		defer l.Stop()
+		for i := 0; i < 100; i++ {
+			require.True(t, l.Allow(),
+				"Burst call %d to limiter.Allow() should return True with 100 initial tokens", i)
+		}
+		require.False(t, l.Allow(),
+			"Burst call 101 to limiter.Allow() should return False with 100 initial tokens")
+	})
+}
+
+func TestLimiter(t *testing.T) {
+	//Tests the limiter's ability to sample the traces when subjected to a continuous flow of requests
+	//Each goroutine will continuously call the WAF and the rate limiter for 1 second
+	for nbUsers := 1; nbUsers <= 1000; nbUsers *= 10 {
+		t.Run(fmt.Sprintf("continuous-requests-%d-users", nbUsers), func(t *testing.T) {
+			var startBarrier, stopBarrier sync.WaitGroup
+			// Create a start barrier to synchronize every goroutine's launch and
+			// increase the chances of parallel accesses
+			startBarrier.Add(1)
+			// Create a stopBarrier to signal when all user goroutines are done.
+			stopBarrier.Add(nbUsers)
+			skipped := int64(0)
+			kept := int64(0)
+			l := NewTokenTicker(1, 100)
+			l.Start()
+			defer l.Stop()
+
+			for n := 0; n < nbUsers; n++ {
+				go func(l Limiter, kept *int64, skipped *int64) {
+					startBarrier.Wait()      // Sync the starts of the goroutines
+					defer stopBarrier.Done() // Signal we are done when returning
+
+					for tStart := time.Now(); time.Since(tStart) <= 1*time.Second; {
+						if !l.Allow() {
+							atomic.AddInt64(skipped, 1)
+						} else {
+							atomic.AddInt64(kept, 1)
+						}
+					}
+				}(l, &kept, &skipped)
+			}
+
+			start := time.Now()
+			startBarrier.Done() // Unblock the user goroutines
+			stopBarrier.Wait()  // Wait for the user goroutines to be done
+			duration := time.Since(start).Seconds()
+			//Limiter started with 1 token, expecting a margin of error of 1
+			maxExpectedKept := 1 + int64(math.Ceil(duration)*100)
+
+			require.LessOrEqualf(t, kept, maxExpectedKept,
+				"Expected at most %d kept tokens for a %fs duration", maxExpectedKept, duration)
+		})
+	}
+
+	//Tests the limiter's ability to sample the traces when subjected sporadic bursts of requests.
+	//The limiter starts with a bucket filled with 100 tokens to handle a potential immediate first burst
+	for burstAmount := 10; burstAmount < 100; burstAmount += 10 {
+		t.Run(fmt.Sprintf("requests-bursts-%d-iterations", burstAmount), func(t *testing.T) {
+			burstFreq := 100 * time.Millisecond
+			burstSize := 10
+			skipped := 0
+			kept := 0
+			reqCount := 0
+			l := NewTokenTicker(100, 100)
+			l.Start()
+			defer l.Stop()
+
+			for c := 0; c < burstAmount; c++ {
+				for i := 0; i < burstSize; i++ {
+					reqCount++
+					//Let's not run the WAF if we already know the limiter will ask to discard the trace
+					if !l.Allow() {
+						skipped++
+					} else {
+						kept++
+					}
+				}
+				//Sleep until next burst
+				time.Sleep(burstFreq)
+			}
+			require.Equalf(t, kept, burstAmount*burstSize, "Expected all %d burst requests to be kept", burstAmount*burstSize)
+		})
+	}
+}
+
+func BenchmarkLimiter(b *testing.B) {
+	for nbUsers := 1; nbUsers <= 1000; nbUsers *= 10 {
+		b.Run(fmt.Sprintf("%d-users", nbUsers), func(b *testing.B) {
+			var skipped int64
+			var kept int64
+			limiter := NewTokenTicker(0, 100)
+			limiter.Start()
+			defer limiter.Stop()
+			b.ResetTimer()
+
+			for n := 0; n < b.N; n++ {
+				var startBarrier, stopBarrier sync.WaitGroup
+				// Create a start barrier to synchronize every goroutine's launch and
+				// increase the chances of parallel accesses
+				startBarrier.Add(1)
+				// Create a stopBarrier to signal when all user goroutines are done.
+				stopBarrier.Add(nbUsers)
+
+				for n := 0; n < nbUsers; n++ {
+					go func(l Limiter, kept *int64, skipped *int64) {
+						startBarrier.Wait()      // Sync the starts of the goroutines
+						defer stopBarrier.Done() // Signal we are done when returning
+
+						for i := 0; i < 100; i++ {
+							if !l.Allow() {
+								atomic.AddInt64(skipped, 1)
+							} else {
+								atomic.AddInt64(kept, 1)
+							}
+						}
+					}(limiter, &kept, &skipped)
+				}
+				startBarrier.Done() // Unblock the user goroutines
+				stopBarrier.Wait()  // Wait for the user goroutines to be done
+			}
+		})
+	}
+}

--- a/internal/appsec/limiter_test.go
+++ b/internal/appsec/limiter_test.go
@@ -21,7 +21,9 @@ import (
 
 func TestLimiterUnit(t *testing.T) {
 	ticksChan := make(chan time.Time)
+	defer close(ticksChan)
 	ticker := time.Ticker{C: ticksChan}
+	defer ticker.Stop()
 	startTime := time.Now()
 
 	t.Run("no-ticks-1", func(t *testing.T) {
@@ -95,9 +97,6 @@ func TestLimiterUnit(t *testing.T) {
 		require.False(t, l.Allow(),
 			"Burst call 101 to limiter.Allow() should return False with 100 initial tokens")
 	})
-
-	ticker.Stop()
-	close(ticksChan)
 }
 
 func TestLimiter(t *testing.T) {

--- a/internal/appsec/limiter_test.go
+++ b/internal/appsec/limiter_test.go
@@ -36,9 +36,10 @@ func TestLimiterUnit(t *testing.T) {
 		l.start(startTime)
 		defer l.stop()
 		// No ticks between the requests
-		for i := 0; i < 10; i++ {
-			require.True(t, l.Allow(), "Call to limiter.Allow() should return True")
+		for i := 0; i < 100; i++ {
+			require.True(t, l.Allow())
 		}
+		require.False(t, l.Allow())
 	})
 
 	t.Run("10ms-ticks", func(t *testing.T) {
@@ -46,8 +47,9 @@ func TestLimiterUnit(t *testing.T) {
 		l.start(startTime)
 		defer l.stop()
 		require.True(t, l.Allow(), "First call to limiter.Allow() should return True")
+		require.False(t, l.Allow(), "Second call to limiter.Allow() should return false")
 		l.tick(startTime.Add(10 * time.Millisecond))
-		require.True(t, l.Allow(), "Second call to limiter.Allow() after 10ms should return True")
+		require.True(t, l.Allow(), "Third call to limiter.Allow() after 10ms should return True")
 	})
 
 	t.Run("9ms-ticks", func(t *testing.T) {
@@ -57,8 +59,8 @@ func TestLimiterUnit(t *testing.T) {
 		require.True(t, l.Allow(), "First call to limiter.Allow() should return True")
 		l.tick(startTime.Add(9 * time.Millisecond))
 		require.False(t, l.Allow(), "Second call to limiter.Allow() after 9ms should return False")
-		l.tick(startTime.Add(18 * time.Millisecond))
-		require.True(t, l.Allow(), "Third call to limiter.Allow() after 18ms should return True")
+		l.tick(startTime.Add(10 * time.Millisecond))
+		require.True(t, l.Allow(), "Third call to limiter.Allow() after 10ms should return True")
 	})
 
 	t.Run("1s-rate", func(t *testing.T) {
@@ -151,8 +153,8 @@ func TestLimiterUnit(t *testing.T) {
 
 func TestLimiter(t *testing.T) {
 	t.Run("concurrency", func(t *testing.T) {
-		//Tests the limiter's ability to sample the traces when subjected to a continuous flow of requests
-		//Each goroutine will continuously call the rate limiter for 1 second
+		// Tests the limiter's ability to sample the traces when subjected to a continuous flow of requests
+		// Each goroutine will continuously call the rate limiter for 1 second
 		for nbUsers := 1; nbUsers <= 10; nbUsers *= 10 {
 			t.Run(fmt.Sprintf("continuous-requests-%d-users", nbUsers), func(t *testing.T) {
 				var startBarrier, stopBarrier sync.WaitGroup
@@ -292,7 +294,7 @@ func (t *TestTicker) start(timeStamp time.Time) {
 func (t *TestTicker) stop() {
 	t.t.Stop()
 	close(t.C)
-	//syncChan is closed by the token ticker when sure that nothing else will be sent on it
+	// syncChan is closed by the token ticker when sure that nothing else will be sent on it
 }
 
 func (t *TestTicker) tick(timeStamp time.Time) {

--- a/internal/appsec/waf.go
+++ b/internal/appsec/waf.go
@@ -9,6 +9,7 @@
 package appsec
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -24,7 +25,7 @@ import (
 )
 
 // Register the WAF event listener.
-func registerWAF(rules []byte, timeout time.Duration) (unreg dyngo.UnregisterFunc, err error) {
+func registerWAF(rules []byte, timeout time.Duration, limiter Limiter) (unreg dyngo.UnregisterFunc, err error) {
 	// Check the WAF is healthy
 	if _, err := waf.Health(); err != nil {
 		return nil, err
@@ -59,11 +60,11 @@ func registerWAF(rules []byte, timeout time.Duration) (unreg dyngo.UnregisterFun
 	var unregisterHTTP, unregisterGRPC dyngo.UnregisterFunc
 	if len(httpAddresses) > 0 {
 		log.Debug("appsec: registering http waf listening to addresses %v", httpAddresses)
-		unregisterHTTP = dyngo.Register(newHTTPWAFEventListener(waf, httpAddresses, timeout))
+		unregisterHTTP = dyngo.Register(newHTTPWAFEventListener(waf, httpAddresses, timeout, limiter))
 	}
 	if len(grpcAddresses) > 0 {
 		log.Debug("appsec: registering grpc waf listening to addresses %v", grpcAddresses)
-		unregisterGRPC = dyngo.Register(newGRPCWAFEventListener(waf, grpcAddresses, timeout))
+		unregisterGRPC = dyngo.Register(newGRPCWAFEventListener(waf, grpcAddresses, timeout, limiter))
 	}
 
 	// Return an unregistration function that will also release the WAF instance.
@@ -79,7 +80,7 @@ func registerWAF(rules []byte, timeout time.Duration) (unreg dyngo.UnregisterFun
 }
 
 // newWAFEventListener returns the WAF event listener to register in order to enable it.
-func newHTTPWAFEventListener(handle *waf.Handle, addresses []string, timeout time.Duration) dyngo.EventListener {
+func newHTTPWAFEventListener(handle *waf.Handle, addresses []string, timeout time.Duration, limiter Limiter) dyngo.EventListener {
 	return httpsec.OnHandlerOperationStart(func(op *httpsec.Operation, args httpsec.HandlerOperationArgs) {
 		// At the moment, AppSec doesn't block the requests, and so we can use the fact we are in monitoring-only mode
 		// to call the WAF only once at the end of the handler operation.
@@ -124,7 +125,9 @@ func newHTTPWAFEventListener(handle *waf.Handle, addresses []string, timeout tim
 				return
 			}
 			log.Debug("appsec: attack detected by the waf")
-			op.AddSecurityEvent(matches)
+			if limiter.Allow() {
+				op.AddSecurityEvent(matches)
+			}
 		}))
 
 	})
@@ -132,7 +135,7 @@ func newHTTPWAFEventListener(handle *waf.Handle, addresses []string, timeout tim
 
 // newGRPCWAFEventListener returns the WAF event listener to register in order
 // to enable it.
-func newGRPCWAFEventListener(handle *waf.Handle, _ []string, timeout time.Duration) dyngo.EventListener {
+func newGRPCWAFEventListener(handle *waf.Handle, _ []string, timeout time.Duration, limiter Limiter) dyngo.EventListener {
 	return grpcsec.OnHandlerOperationStart(func(op *grpcsec.HandlerOperation, _ grpcsec.HandlerOperationArgs) {
 		// Limit the maximum number of security events, as a streaming RPC could
 		// receive unlimited number of messages where we could find security events
@@ -140,6 +143,9 @@ func newGRPCWAFEventListener(handle *waf.Handle, _ []string, timeout time.Durati
 		var (
 			nbEvents uint32
 			logOnce  sync.Once
+
+			events []json.RawMessage
+			mu     sync.Mutex
 		)
 		op.On(grpcsec.OnReceiveOperationFinish(func(_ grpcsec.ReceiveOperation, res grpcsec.ReceiveOperationRes) {
 			if atomic.LoadUint32(&nbEvents) == maxWAFEventsPerRequest {
@@ -166,13 +172,20 @@ func newGRPCWAFEventListener(handle *waf.Handle, _ []string, timeout time.Durati
 			// Note that we don't check if the address is present in the rules
 			// as we only support one at the moment, so this callback cannot be
 			// set when the address is not present.
-			events := runWAF(wafCtx, map[string]interface{}{grpcServerRequestMessage: res.Message}, timeout)
-			if len(events) == 0 {
+			event := runWAF(wafCtx, map[string]interface{}{grpcServerRequestMessage: res.Message}, timeout)
+			if len(event) == 0 {
 				return
 			}
 			log.Debug("appsec: attack detected by the grpc waf")
 			atomic.AddUint32(&nbEvents, 1)
-			op.AddSecurityEvent(events)
+			mu.Lock()
+			events = append(events, event)
+			mu.Unlock()
+		}))
+		op.On(grpcsec.OnHandlerOperationFinish(func(op *grpcsec.HandlerOperation, _ grpcsec.HandlerOperationRes) {
+			if len(events) > 0 && limiter.Allow() {
+				op.AddSecurityEvent(events)
+			}
 		}))
 	})
 }


### PR DESCRIPTION
# Introducing AppSec rate limiting

- RFC: https://docs.google.com/document/d/1X64XQOk3N-aS_F0bJuZLkUiJqlYneDxo_b8WnkfFy_0/edit
- Goal: adding a ceiling to the number of traces AppSec can force the APM intake to ingest

## Changes
### Global
- Add rate limiting mechanism to report at most 100 traces/sec to APM if those traces hold appsec events
- Introduce DD_APPSEC_TRACE_RATE_LIMIT to appsec config
- Add testing for rate limier

### Files
- internal/appsec/limiter.go: lock-free rate limiter implementation using a ticker to refill the token bucket
- internal/appsec/limiter_test.go: unit/validation testing
- internal/appsec/waf.go: use limiter for http/grpc traces rate limiting
- internal/appsec/config.go: add DD_APPSEC_TRACE_RATE_LIMIT env var handling
- internal/appsec/config_test.go: add testing cases for DD_APPSEC_TRACE_RATE_LIMIT usage
- internal/appsec/appsec.go: add limiter to appsec struct and start/stop limiter

## Next

This is not a definitive implementation. This is introduced as a quick way to implement rate limiting that suits our needs for the next release. The long term goal is to be able to re-use APM code for rate limiting if possible, if we can figure out a way to modify it that works for all parties involved (mainly move it to a lock-free implementation).

## Testing

### net-http
![system-tests-net-http](https://user-images.githubusercontent.com/19765952/150983573-d1a2a984-a940-4f38-8e8c-0dcc42a5c255.png)

### Gorilla
![system-tests-gorilla](https://user-images.githubusercontent.com/19765952/150983579-c16ff1e7-4638-4d7f-a57a-759c168d6ab6.png)


