### PR TITLE
ddtrace/tracer: Add test for env on spans

### DIFF
--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1315,6 +1315,28 @@ func TestVersion(t *testing.T) {
 	})
 }
 
+func TestEnvironment(t *testing.T) {
+	t.Run("normal", func(t *testing.T) {
+		tracer, _, _, stop := startTestTracer(t, WithEnv("test"))
+		defer stop()
+
+		assert := assert.New(t)
+		sp := tracer.StartSpan("http.request").(*span)
+		v := sp.Meta[ext.Environment]
+		assert.Equal("test", v)
+	})
+
+	t.Run("unset", func(t *testing.T) {
+		tracer, _, _, stop := startTestTracer(t)
+		defer stop()
+
+		assert := assert.New(t)
+		sp := tracer.StartSpan("http.request").(*span)
+		_, ok := sp.Meta[ext.Environment]
+		assert.False(ok)
+	})
+}
+
 // BenchmarkConcurrentTracing tests the performance of spawning a lot of
 // goroutines where each one creates a trace with a parent and a child.
 func BenchmarkConcurrentTracing(b *testing.B) {


### PR DESCRIPTION
While investigating how to save some memory allocations in StartSpan
I noticed that the code that sets the "env" tag did not appear to be
triggered by any test cases. Add a test based on the version test.