### PR TITLE
contrib/go-chi: fix closure mistake

### DIFF
--- a/contrib/go-chi/chi.v4/chi.go
+++ b/contrib/go-chi/chi.v4/chi.go
@@ -53,6 +53,7 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 			span, ctx := tracer.StartSpanFromContext(r.Context(), "http.request", opts...)
 			defer span.Finish()
 
+			next := next // avoid modifying the value of next in the outer closure scope
 			if appsec.Enabled() {
 				next = withAppsec(next, r, span)
 				// Note that the following response writer passed to the handler

--- a/contrib/go-chi/chi.v5/chi.go
+++ b/contrib/go-chi/chi.v5/chi.go
@@ -53,6 +53,7 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 			span, ctx := tracer.StartSpanFromContext(r.Context(), "http.request", opts...)
 			defer span.Finish()
 
+			next := next // avoid modifying the value of next in the outer closure scope
 			if appsec.Enabled() {
 				next = withAppsec(next, r, span)
 				// Note that the following response writer passed to the handler

--- a/contrib/go-chi/chi/chi.go
+++ b/contrib/go-chi/chi/chi.go
@@ -53,6 +53,7 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 			span, ctx := tracer.StartSpanFromContext(r.Context(), "http.request", opts...)
 			defer span.Finish()
 
+			next := next // avoid modifying the value of next in the outer closure scope
 			if appsec.Enabled() {
 				next = withAppsec(next, r, span)
 				// Note that the following response writer passed to the handler


### PR DESCRIPTION
Fix a nasty - and classic - mistake with the value `next` being modified in the handler as a value in the current scope while it actually is from the outer function closure scope.

It resulted in calling the httpsec middleware several times. It was caught by system tests and this is fixes the issue (ie. system tests working).