### PR TITLE
contrib/google.golang.org/{grpc, grpc.v12}: add support for WithSpanOptions

### DIFF
--- a/contrib/google.golang.org/grpc.v12/grpc_test.go
+++ b/contrib/google.golang.org/grpc.v12/grpc_test.go
@@ -287,4 +287,35 @@ func TestAnalyticsSettings(t *testing.T) {
 
 		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
 	})
+
+	t.Run("spanOpts", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.33), WithSpanOptions(tracer.AnalyticsRate(0.23)))
+	})
+}
+
+func TestSpanOpts(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	rig, err := newRigWithOpts(true, WithSpanOptions(tracer.Tag("foo", "bar")))
+	if err != nil {
+		t.Fatalf("error setting up rig: %s", err)
+	}
+	defer rig.Close()
+	client := rig.client
+
+	resp, err := client.Ping(context.Background(), &FixtureRequest{Name: "pass"})
+	assert.Nil(err)
+	assert.Equal(resp.Message, "passed")
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 2)
+
+	for _, s := range spans {
+		assert.Equal(s.Tags()["foo"], "bar")
+	}
 }

--- a/contrib/google.golang.org/grpc.v12/option.go
+++ b/contrib/google.golang.org/grpc.v12/option.go
@@ -8,12 +8,14 @@ package grpc
 import (
 	"math"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 )
 
 type interceptorConfig struct {
-	serviceName   string
-	analyticsRate float64
+	serviceName string
+	spanOpts    []ddtrace.StartSpanOption
 }
 
 // InterceptorOption represents an option that can be passed to the grpc unary
@@ -22,11 +24,11 @@ type InterceptorOption func(*interceptorConfig)
 
 func defaults(cfg *interceptorConfig) {
 	// cfg.serviceName default set in interceptor
-	// cfg.analyticsRate = globalconfig.AnalyticsRate()
+	// cfg.spanOpts = append(cfg.spanOpts, tracer.AnalyticsRate(globalconfig.AnalyticsRate()))
 	if internal.BoolEnv("DD_TRACE_GRPC_ANALYTICS_ENABLED", false) {
-		cfg.analyticsRate = 1.0
+		cfg.spanOpts = append(cfg.spanOpts, tracer.AnalyticsRate(1.0))
 	} else {
-		cfg.analyticsRate = math.NaN()
+		cfg.spanOpts = append(cfg.spanOpts, tracer.AnalyticsRate(math.NaN()))
 	}
 }
 
@@ -41,9 +43,9 @@ func WithServiceName(name string) InterceptorOption {
 func WithAnalytics(on bool) InterceptorOption {
 	return func(cfg *interceptorConfig) {
 		if on {
-			cfg.analyticsRate = 1.0
+			WithSpanOptions(tracer.AnalyticsRate(1.0))(cfg)
 		} else {
-			cfg.analyticsRate = math.NaN()
+			WithSpanOptions(tracer.AnalyticsRate(math.NaN()))(cfg)
 		}
 	}
 }
@@ -53,9 +55,17 @@ func WithAnalytics(on bool) InterceptorOption {
 func WithAnalyticsRate(rate float64) InterceptorOption {
 	return func(cfg *interceptorConfig) {
 		if rate >= 0.0 && rate <= 1.0 {
-			cfg.analyticsRate = rate
+			WithSpanOptions(tracer.AnalyticsRate(rate))(cfg)
 		} else {
-			cfg.analyticsRate = math.NaN()
+			WithSpanOptions(tracer.AnalyticsRate(math.NaN()))(cfg)
 		}
+	}
+}
+
+// WithSpanOptions defines a set of additional ddtrace.StartSpanOption to be added
+// to spans started by the integration.
+func WithSpanOptions(opts ...ddtrace.StartSpanOption) InterceptorOption {
+	return func(cfg *interceptorConfig) {
+		cfg.spanOpts = append(cfg.spanOpts, opts...)
 	}
 }

--- a/contrib/google.golang.org/grpc/client.go
+++ b/contrib/google.golang.org/grpc/client.go
@@ -39,7 +39,7 @@ func (cs *clientStream) RecvMsg(m interface{}) (err error) {
 			cs.method,
 			"grpc.message",
 			cs.cfg.clientServiceName(),
-			tracer.AnalyticsRate(cs.cfg.analyticsRate),
+			cs.cfg.spanOpts...,
 		)
 		if p, ok := peer.FromContext(cs.Context()); ok {
 			setSpanTargetFromPeer(span, *p)
@@ -57,7 +57,7 @@ func (cs *clientStream) SendMsg(m interface{}) (err error) {
 			cs.method,
 			"grpc.message",
 			cs.cfg.clientServiceName(),
-			tracer.AnalyticsRate(cs.cfg.analyticsRate),
+			cs.cfg.spanOpts...,
 		)
 		if p, ok := peer.FromContext(cs.Context()); ok {
 			setSpanTargetFromPeer(span, *p)
@@ -170,7 +170,7 @@ func doClientRequest(
 		method,
 		"grpc.client",
 		cfg.clientServiceName(),
-		tracer.AnalyticsRate(cfg.analyticsRate),
+		cfg.spanOpts...,
 	)
 	if methodKind != "" {
 		span.SetTag(tagMethodKind, methodKind)

--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -678,6 +678,13 @@ func TestAnalyticsSettings(t *testing.T) {
 
 		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
 	})
+
+	t.Run("spanOpts", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.33), WithSpanOptions(tracer.AnalyticsRate(0.23)))
+	})
 }
 
 func TestIgnoredMethods(t *testing.T) {
@@ -794,4 +801,62 @@ func TestIgnoredMetadata(t *testing.T) {
 		rig.Close()
 		mt.Reset()
 	}
+}
+
+func TestSpanOpts(t *testing.T) {
+	t.Run("unary", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+		rig, err := newRig(true, WithSpanOptions(tracer.Tag("foo", "bar")))
+		if err != nil {
+			t.Fatalf("error setting up rig: %s", err)
+		}
+		client := rig.client
+		resp, err := client.Ping(context.Background(), &FixtureRequest{Name: "pass"})
+		assert.Nil(t, err)
+		assert.Equal(t, resp.Message, "passed")
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 2)
+
+		for _, span := range spans {
+			assert.Equal(t, span.Tags()["foo"], "bar")
+		}
+		rig.Close()
+		mt.Reset()
+	})
+
+	t.Run("stream", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+		rig, err := newRig(true, WithSpanOptions(tracer.Tag("foo", "bar")))
+		if err != nil {
+			t.Fatalf("error setting up rig: %s", err)
+		}
+
+		ctx, done := context.WithCancel(context.Background())
+		client := rig.client
+		stream, err := client.StreamPing(ctx)
+		assert.NoError(t, err)
+
+		err = stream.Send(&FixtureRequest{Name: "pass"})
+		assert.NoError(t, err)
+
+		resp, err := stream.Recv()
+		assert.NoError(t, err)
+		assert.Equal(t, resp.Message, "passed")
+
+		assert.NoError(t, stream.CloseSend())
+		done() // close stream from client side
+		rig.Close()
+
+		waitForSpans(mt, 7, 5*time.Second)
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 7)
+		for _, span := range spans {
+			assert.Equal(t, span.Tags()["foo"], "bar")
+		}
+		mt.Reset()
+	})
 }

--- a/contrib/google.golang.org/grpc/stats_client.go
+++ b/contrib/google.golang.org/grpc/stats_client.go
@@ -36,7 +36,7 @@ func (h *clientStatsHandler) TagRPC(ctx context.Context, rti *stats.RPCTagInfo) 
 		rti.FullMethodName,
 		"grpc.client",
 		h.cfg.clientServiceName(),
-		tracer.AnalyticsRate(h.cfg.analyticsRate),
+		h.cfg.spanOpts...,
 	)
 	ctx = injectSpanIntoContext(ctx)
 	return ctx

--- a/contrib/google.golang.org/grpc/stats_client_test.go
+++ b/contrib/google.golang.org/grpc/stats_client_test.go
@@ -25,7 +25,7 @@ func TestClientStatsHandler(t *testing.T) {
 	assert := assert.New(t)
 
 	serviceName := "grpc-service"
-	statsHandler := NewClientStatsHandler(WithServiceName(serviceName))
+	statsHandler := NewClientStatsHandler(WithServiceName(serviceName), WithSpanOptions(tracer.Tag("foo", "bar")))
 	server, err := newClientStatsHandlerTestServer(statsHandler)
 	if err != nil {
 		t.Fatalf("failed to start test server: %s", err)
@@ -56,6 +56,7 @@ func TestClientStatsHandler(t *testing.T) {
 	assert.Equal("/grpc.Fixture/Ping", tags[tagMethodName])
 	assert.Equal("127.0.0.1", tags[ext.TargetHost])
 	assert.Equal(server.port, tags[ext.TargetPort])
+	assert.Equal("bar", tags["foo"])
 }
 
 func newClientStatsHandlerTestServer(statsHandler stats.Handler) (*rig, error) {

--- a/contrib/google.golang.org/grpc/stats_server.go
+++ b/contrib/google.golang.org/grpc/stats_server.go
@@ -30,13 +30,13 @@ type serverStatsHandler struct {
 
 // TagRPC starts a new span for the initiated RPC request.
 func (h *serverStatsHandler) TagRPC(ctx context.Context, rti *stats.RPCTagInfo) context.Context {
+	h.cfg.spanOpts = append(h.cfg.spanOpts, tracer.Measured())
 	_, ctx = startSpanFromContext(
 		ctx,
 		rti.FullMethodName,
 		"grpc.server",
 		h.cfg.serverServiceName(),
-		tracer.AnalyticsRate(h.cfg.analyticsRate),
-		tracer.Measured(),
+		h.cfg.spanOpts...,
 	)
 	return ctx
 }

--- a/contrib/google.golang.org/grpc/stats_server_test.go
+++ b/contrib/google.golang.org/grpc/stats_server_test.go
@@ -18,13 +18,14 @@ import (
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 func TestServerStatsHandler(t *testing.T) {
 	assert := assert.New(t)
 
 	serviceName := "grpc-service"
-	statsHandler := NewServerStatsHandler(WithServiceName(serviceName))
+	statsHandler := NewServerStatsHandler(WithServiceName(serviceName), WithSpanOptions(tracer.Tag("foo", "bar")))
 	server, err := newServerStatsHandlerTestServer(statsHandler)
 	if err != nil {
 		t.Fatalf("failed to start test server: %s", err)
@@ -51,6 +52,7 @@ func TestServerStatsHandler(t *testing.T) {
 	assert.Equal("/grpc.Fixture/Ping", tags["resource.name"])
 	assert.Equal("/grpc.Fixture/Ping", tags[tagMethodName])
 	assert.Equal(1, tags["_dd.measured"])
+	assert.Equal("bar", tags["foo"])
 }
 
 func newServerStatsHandlerTestServer(statsHandler stats.Handler) (*rig, error) {


### PR DESCRIPTION
This PR add's support for WithSpanOptions for both contrib/google.golang.org/grpc and contrib/google.golang.org/grpc.v12

Fixes: #1125
