### PR TITLE
ddtrace/tracer: remove limitation of having service name match the name defined when starting the tracer for version tracking

### DIFF
--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -421,7 +421,7 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		// all top level spans are measured. So the measured tag is redundant.
 		delete(span.Metrics, keyMeasured)
 	}
-	if t.config.version != "" && span.Service == t.config.serviceName {
+	if t.config.version != "" {
 		span.setMeta(ext.Version, t.config.version)
 	}
 	if t.config.env != "" {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1352,25 +1352,13 @@ func TestTracerReportsHostname(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
-	t.Run("normal", func(t *testing.T) {
-		tracer, _, _, stop := startTestTracer(t, WithServiceVersion("4.5.6"))
-		defer stop()
+	tracer, _, _, stop := startTestTracer(t, WithServiceVersion("4.5.6"))
+	defer stop()
 
-		assert := assert.New(t)
-		sp := tracer.StartSpan("http.request").(*span)
-		v := sp.Meta[ext.Version]
-		assert.Equal("4.5.6", v)
-	})
-
-	t.Run("unset", func(t *testing.T) {
-		tracer, _, _, stop := startTestTracer(t, WithServiceVersion("4.5.6"), WithService("servenv"))
-		defer stop()
-
-		assert := assert.New(t)
-		sp := tracer.StartSpan("http.request", ServiceName("otherservenv")).(*span)
-		_, ok := sp.Meta[ext.Version]
-		assert.False(ok)
-	})
+	assert := assert.New(t)
+	sp := tracer.StartSpan("http.request").(*span)
+	v := sp.Meta[ext.Version]
+	assert.Equal("4.5.6", v)
 }
 
 func TestEnvironment(t *testing.T) {


### PR DESCRIPTION
This limitation prevent the following scenarios:
- having a service name generated at runtime and set with tracer.ServiceName(serviceName), and have deployment tracking on those
- having more than one service in the same binary, yet having deployment tracking