### PR TITLE
contrib/gin-gonic: add AppSec support to gin framework

### DIFF
--- a/contrib/gin-gonic/gin/appsec.go
+++ b/contrib/gin-gonic/gin/appsec.go
@@ -6,11 +6,12 @@
 package gin
 
 import (
-	"github.com/gin-gonic/gin"
 	"net"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation/httpsec"
+
+	"github.com/gin-gonic/gin"
 )
 
 func useAppSec(c *gin.Context) {

--- a/contrib/gin-gonic/gin/appsec.go
+++ b/contrib/gin-gonic/gin/appsec.go
@@ -19,9 +19,12 @@ func useAppSec(c *gin.Context) {
 	span, ok := tracer.SpanFromContext(req.Context())
 	if ok {
 		httpsec.SetAppSecTags(span)
-		params := make(map[string]string)
-		for _, p := range c.Params {
-			params[p.Key] = p.Value
+		var params map[string]string
+		if l := len(c.Params); l > 0 {
+			params = make(map[string]string, l)
+			for _, p := range c.Params {
+				params[p.Key] = p.Value
+			}
 		}
 		args := httpsec.MakeHandlerOperationArgs(req, params)
 		op := httpsec.StartOperation(args, nil)

--- a/contrib/gin-gonic/gin/appsec.go
+++ b/contrib/gin-gonic/gin/appsec.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022 Datadog, Inc.
+
+package gin
+
+import (
+	"github.com/gin-gonic/gin"
+	"net"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation/httpsec"
+)
+
+func useAppSec(c *gin.Context) {
+	req := c.Request
+	span, ok := tracer.SpanFromContext(req.Context())
+	if ok {
+		httpsec.SetAppSecTags(span)
+		params := make(map[string]string)
+		for _, p := range c.Params {
+			params[p.Key] = p.Value
+		}
+		args := httpsec.MakeHandlerOperationArgs(req, params)
+		op := httpsec.StartOperation(args, nil)
+		defer func() {
+			events := op.Finish(httpsec.HandlerOperationRes{Status: c.Writer.Status()})
+			if len(events) > 0 {
+				remoteIP, _, err := net.SplitHostPort(req.RemoteAddr)
+				if err != nil {
+					remoteIP = req.RemoteAddr
+				}
+				httpsec.SetSecurityEventTags(span, events, remoteIP, args.Headers, c.Writer.Header())
+			}
+		}()
+	}
+	c.Next()
+}

--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -56,7 +56,7 @@ func Middleware(service string, opts ...Option) gin.HandlerFunc {
 
 		// Use AppSec if enabled by user
 		if appsec.Enabled() {
-			useAppSec(c)
+			useAppSec(c, span)
 		}
 
 		// serve the request to the next middleware

--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -8,7 +8,6 @@ package gin // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/gin-gonic/gin"
 
 import (
 	"fmt"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
 	"math"
 	"net/http"
 	"strconv"
@@ -16,6 +15,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 
 	"github.com/gin-gonic/gin"

--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -25,6 +25,7 @@ import (
 // default service name will be used.
 func Middleware(service string, opts ...Option) gin.HandlerFunc {
 	cfg := newConfig(service)
+	appsecEnabled := appsec.Enabled()
 	for _, opt := range opts {
 		opt(cfg)
 	}
@@ -55,8 +56,9 @@ func Middleware(service string, opts ...Option) gin.HandlerFunc {
 		c.Request = c.Request.WithContext(ctx)
 
 		// Use AppSec if enabled by user
-		if appsec.Enabled() {
-			useAppSec(c, span)
+		if appsecEnabled {
+			afterMiddleware := useAppSec(c, span)
+			defer afterMiddleware()
 		}
 
 		// serve the request to the next middleware

--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -8,6 +8,7 @@ package gin // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/gin-gonic/gin"
 
 import (
 	"fmt"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
 	"math"
 	"net/http"
 	"strconv"
@@ -52,6 +53,11 @@ func Middleware(service string, opts ...Option) gin.HandlerFunc {
 
 		// pass the span through the request context
 		c.Request = c.Request.WithContext(ctx)
+
+		// Use AppSec if enabled by user
+		if appsec.Enabled() {
+			useAppSec(c)
+		}
 
 		// serve the request to the next middleware
 		c.Next()

--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -24,8 +24,8 @@ import (
 // Middleware returns middleware that will trace incoming requests. If service is empty then the
 // default service name will be used.
 func Middleware(service string, opts ...Option) gin.HandlerFunc {
-	cfg := newConfig(service)
 	appsecEnabled := appsec.Enabled()
+	cfg := newConfig(service)
 	for _, opt := range opts {
 		opt(cfg)
 	}

--- a/contrib/gin-gonic/gin/gintrace_test.go
+++ b/contrib/gin-gonic/gin/gintrace_test.go
@@ -9,17 +9,22 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"io/ioutil"
+	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -458,5 +463,114 @@ func TestServiceName(t *testing.T) {
 		assert.Len(spans, 1)
 		span := spans[0]
 		assert.Equal("my-service", span.Tag(ext.ServiceName))
+	})
+}
+
+func TestAppSec(t *testing.T) {
+
+	appsec.Start()
+	defer appsec.Stop()
+	if !appsec.Enabled() {
+		t.Skip("appsec disabled")
+	}
+
+	r := gin.New()
+	r.Use(Middleware("appsec"))
+
+	statusCodes := []int{200, 403, 404, 500}
+	for _, code := range statusCodes {
+		strC := strconv.Itoa(code)
+		code := code
+		r.Any("/"+strC, func(c *gin.Context) {
+			c.String(code, "Hello "+strC+"\n")
+		})
+	}
+
+	r.Any("/lfi/*allPaths", func(c *gin.Context) {
+		c.String(200, "Hello World!\n")
+	})
+	r.Any("/path0.0/:myPathParam0/path0.1/:myPathParam1/path0.2/:myPathParam2/path0.3/*param3", func(c *gin.Context) {
+		c.String(200, "Hello Params!\n")
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	t.Run("request-uri", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+		// Send an LFI attack (according to appsec rule id crs-930-100)
+		req, err := http.NewRequest("POST", srv.URL+"/lfi/../../../secret.txt", nil)
+		if err != nil {
+			panic(err)
+		}
+		res, err := srv.Client().Do(req)
+		require.NoError(t, err)
+		// Check that the server behaved as intended
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		b, err := ioutil.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Equal(t, "Hello World!\n", string(b))
+		// The span should contain the security event
+		finished := mt.FinishedSpans()
+		require.Len(t, finished, 1)
+
+		// The first 301 redirection should contain the attack via the request uri
+		event := finished[0].Tag("_dd.appsec.json").(string)
+		require.NotNil(t, event)
+		require.True(t, strings.Contains(event, "server.request.uri.raw"))
+		require.True(t, strings.Contains(event, "crs-930-100"))
+	})
+
+	// Test a security scanner attack via path parameters
+	t.Run("path-params", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+		// Send a security scanner attack (according to appsec rule id crs-913-120)
+		req, err := http.NewRequest("POST", srv.URL+"/path0.0/param0/path0.1/param1/path0.2/appscan_fingerprint/path0.3/param3", nil)
+		if err != nil {
+			panic(err)
+		}
+		res, err := srv.Client().Do(req)
+		require.NoError(t, err)
+		// Check that the handler was properly called
+		b, err := ioutil.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Equal(t, "Hello Params!\n", string(b))
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		// The span should contain the security event
+		finished := mt.FinishedSpans()
+		require.Len(t, finished, 1)
+		event := finished[0].Tag("_dd.appsec.json").(string)
+		require.NotNil(t, event)
+		require.True(t, strings.Contains(event, "crs-913-120"))
+		require.True(t, strings.Contains(event, "myPathParam2"))
+		require.True(t, strings.Contains(event, "server.request.path_params"))
+	})
+
+	t.Run("status-code", func(t *testing.T) {
+		for _, code := range statusCodes {
+			codeStr := strconv.Itoa(code)
+			t.Run(codeStr, func(t *testing.T) {
+				mt := mocktracer.Start()
+				defer mt.Stop()
+
+				req, err := http.NewRequest("POST", srv.URL+"/"+codeStr, nil)
+				req.Header.Set("User-agent", "Arachni/v1.0")
+				if err != nil {
+					panic(err)
+				}
+				res, err := srv.Client().Do(req)
+				require.NoError(t, err)
+				require.Equal(t, code, res.StatusCode)
+
+				finished := mt.FinishedSpans()
+				require.Len(t, finished, 1)
+				tagStatusCode := finished[0].Tag("http.status_code").(string)
+				require.NotNil(t, tagStatusCode)
+				require.Equal(t, codeStr, tagStatusCode)
+
+			})
+		}
 	})
 }

--- a/contrib/gin-gonic/gin/gintrace_test.go
+++ b/contrib/gin-gonic/gin/gintrace_test.go
@@ -467,7 +467,6 @@ func TestServiceName(t *testing.T) {
 }
 
 func TestAppSec(t *testing.T) {
-
 	appsec.Start()
 	defer appsec.Stop()
 	if !appsec.Enabled() {

--- a/contrib/gin-gonic/gin/gintrace_test.go
+++ b/contrib/gin-gonic/gin/gintrace_test.go
@@ -573,4 +573,25 @@ func TestAppSec(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("nfd-000-001", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		req, err := http.NewRequest("POST", srv.URL+"/etc/", nil)
+		if err != nil {
+			panic(err)
+		}
+		res, err := srv.Client().Do(req)
+		require.NoError(t, err)
+		require.Equal(t, 404, res.StatusCode)
+
+		finished := mt.FinishedSpans()
+		require.Len(t, finished, 1)
+		event := finished[0].Tag("_dd.appsec.json").(string)
+		require.NotNil(t, event)
+		require.True(t, strings.Contains(event, "server.response.status"))
+		require.True(t, strings.Contains(event, "nfd-000-001"))
+
+	})
 }


### PR DESCRIPTION
- Add call to `useAppsec` in _gintrace.go_ when AppSec is enabled
- Add testing of AppSec functionalities in _gintrace_test.go_
- Add _appsec.go_ file that holds AppSec handling for gin