### PR TITLE
.circleci: pin gofiber to version 2.26.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,6 +253,9 @@ jobs:
             go get github.com/Shopify/sarama@v1.22.0
             # Temporary enforcing gorm to v1.22.4 to avoid the problems of v1.22.5
             go get -v gorm.io/gorm@v1.22.4
+            # gofiber >= v2.27.0 has a transitive dependency on a newer version of
+            # golang.org/x/net that requires Go >= 1.15, breaking our build
+            go get github.com/gofiber/fiber/v2@v2.26.0
 
       - run:
           name: Wait for MySQL


### PR DESCRIPTION
gofiber >= v2.27.0 has a transitive dependency on a newer version of
golang.org/x/net that requires Go >= 1.15, breaking our build