### PR TITLE
contrib/gorilla/mux: add router wrapper

### DIFF
--- a/contrib/gorilla/mux/mux.go
+++ b/contrib/gorilla/mux/mux.go
@@ -7,13 +7,11 @@
 package mux // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/gorilla/mux"
 
 import (
-	"math"
 	"net/http"
 	"strings"
 
 	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 
@@ -76,20 +74,7 @@ func (r *Router) UseEncodedPath() *Router {
 
 // NewRouter returns a new router instance traced with the global tracer.
 func NewRouter(opts ...RouterOption) *Router {
-	cfg := new(routerConfig)
-	defaults(cfg)
-	for _, fn := range opts {
-		fn(cfg)
-	}
-	if !math.IsNaN(cfg.analyticsRate) {
-		cfg.spanOpts = append(cfg.spanOpts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
-	}
-	cfg.spanOpts = append(cfg.spanOpts, tracer.Measured())
-	log.Debug("contrib/gorilla/mux: Configuring Router: %#v", cfg)
-	return &Router{
-		Router: mux.NewRouter(),
-		config: cfg,
-	}
+	return WrapRouter(mux.NewRouter(), opts...)
 }
 
 // ServeHTTP dispatches the request to the handler
@@ -124,6 +109,17 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		QueryParams: r.config.queryParams,
 		RouteParams: match.Vars,
 	})
+}
+
+// WrapRouter returns the given router wrapped with the tracing of the HTTP
+// requests and responses served by the router.
+func WrapRouter(router *mux.Router, opts ...RouterOption) *Router {
+	cfg := newConfig(opts)
+	log.Debug("contrib/gorilla/mux: Configuring Router: %#v", cfg)
+	return &Router{
+		Router: router,
+		config: cfg,
+	}
 }
 
 // defaultResourceNamer attempts to quantize the resource for an HTTP request by


### PR DESCRIPTION
Based on user feedback we had that didn't want to totally replace their gorilla/mux imports by ours, we would like to propose them the alternative of rather importing our contrib to wrap their gorilla router instead. To do so, we introduced a new function called `WrapRouter()` that wraps the given gorilla mux router with our wrapper.

Note that a pure gorilla middleware is not a good option for us because they do not get called when the route is not found, leading the missing all the 404 on routes that were not found on the router. This impacts both the APM tracing and the AppSec monitoring. So the current solution with `WrapRouter` instead is the best possible solution to be able to monitor every request entering the router.