### PR TITLE
ddtrace/tracer: disable Datadog internal tag propagation

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -255,35 +255,6 @@ func (p *propagator) injectTextMap(spanCtx ddtrace.SpanContext, writer TextMapWr
 	for k, v := range ctx.baggage {
 		writer.Set(p.cfg.BaggagePrefix+k, v)
 	}
-	// propagate trace tags
-	var sb strings.Builder
-	if ctx.trace != nil {
-		ctx.trace.mu.RLock()
-		for k, v := range ctx.trace.tags {
-			if !strings.HasPrefix(k, "_dd.p.") {
-				continue
-			}
-			if err := isValidPropagatableTraceTag(k, v); err != nil {
-				log.Warn("won't propagate tag '%s' (err: %s)", k, err.Error())
-				continue
-			}
-			if sb.Len()+len(k)+len(v) > p.cfg.MaxTagsHeaderLen {
-				sb.Reset()
-				log.Warn("won't propagate trace tags (err: max trace tags header len (%d) reached)", p.cfg.MaxTagsHeaderLen)
-				break
-			}
-			if sb.Len() > 0 {
-				sb.WriteByte(',')
-			}
-			sb.WriteString(k)
-			sb.WriteByte('=')
-			sb.WriteString(v)
-		}
-		ctx.trace.mu.RUnlock()
-		if sb.Len() > 0 {
-			writer.Set(traceTagsHeader, sb.String())
-		}
-	}
 	return nil
 }
 

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -175,61 +175,6 @@ func TestTextMapPropagatorOrigin(t *testing.T) {
 	}
 }
 
-func TestTextMapPropagatorTraceTagsWithPriority(t *testing.T) {
-	src := TextMapCarrier(map[string]string{
-		DefaultPriorityHeader: "1",
-		DefaultTraceIDHeader:  "1",
-		DefaultParentIDHeader: "1",
-		traceTagsHeader:       "hello=world,_dd.p.upstream_services=abc|1|2|3;def|4|5|6",
-	})
-	tracer := newTracer()
-	ctx, err := tracer.Extract(src)
-	assert.Nil(t, err)
-	sctx, ok := ctx.(*spanContext)
-	assert.True(t, ok)
-	child := tracer.StartSpan("test", ChildOf(sctx))
-	childSpanID := child.Context().(*spanContext).spanID
-	assert.Equal(t, map[string]string{
-		"hello":                   "world",
-		"_dd.p.upstream_services": "abc|1|2|3;def|4|5|6",
-	}, sctx.trace.tags)
-	dst := map[string]string{}
-	err = tracer.Inject(child.Context(), TextMapCarrier(dst))
-	assert.Nil(t, err)
-	assert.Len(t, dst, 4)
-	assert.Equal(t, strconv.Itoa(int(childSpanID)), dst["x-datadog-parent-id"])
-	assert.Equal(t, "1", dst["x-datadog-trace-id"])
-	assert.Equal(t, "1", dst["x-datadog-sampling-priority"])
-	assertTraceTags(t, "_dd.p.upstream_services=abc|1|2|3;def|4|5|6", dst["x-datadog-tags"])
-}
-
-func TestTextMapPropagatorTraceTagsWithoutPriority(t *testing.T) {
-	src := TextMapCarrier(map[string]string{
-		DefaultTraceIDHeader:  "1",
-		DefaultParentIDHeader: "1",
-		traceTagsHeader:       "hello=world,_dd.p.upstream_services=abc|1|2|3;def|4|5|6",
-	})
-	tracer := newTracer()
-	ctx, err := tracer.Extract(src)
-	assert.Nil(t, err)
-	sctx, ok := ctx.(*spanContext)
-	assert.True(t, ok)
-	child := tracer.StartSpan("test", ChildOf(sctx))
-	childSpanID := child.Context().(*spanContext).spanID
-	assert.Equal(t, map[string]string{
-		"hello":                   "world",
-		"_dd.p.upstream_services": "abc|1|2|3;def|4|5|6;dHJhY2VyLnRlc3Q|1|1|1.0000",
-	}, sctx.trace.tags)
-	dst := map[string]string{}
-	err = tracer.Inject(child.Context(), TextMapCarrier(dst))
-	assert.Nil(t, err)
-	assert.Len(t, dst, 4)
-	assert.Equal(t, strconv.Itoa(int(childSpanID)), dst["x-datadog-parent-id"])
-	assert.Equal(t, "1", dst["x-datadog-trace-id"])
-	assert.Equal(t, "1", dst["x-datadog-sampling-priority"])
-	assertTraceTags(t, "_dd.p.upstream_services=abc|1|2|3;def|4|5|6;dHJhY2VyLnRlc3Q|1|1|1.0000", dst["x-datadog-tags"])
-}
-
 func TestTextMapPropagatorInvalidTraceTagsHeader(t *testing.T) {
 	src := TextMapCarrier(map[string]string{
 		DefaultTraceIDHeader:  "1",
@@ -272,22 +217,6 @@ func TestTextMapPropagatorTraceTagsTooLong(t *testing.T) {
 		"x-datadog-trace-id":          "1",
 		"x-datadog-sampling-priority": "1",
 	}, dst)
-}
-
-func TestTextMapPropagatorInvalidTraceTags(t *testing.T) {
-	tracer := newTracer()
-	child := tracer.StartSpan("test")
-	child.Context().(*spanContext).trace.setTag("_dd.p.hello1", "world")  // valid value
-	child.Context().(*spanContext).trace.setTag("_dd.p.hello2", "world,") // invalid value
-	childSpanID := child.Context().(*spanContext).spanID
-	dst := map[string]string{}
-	err := tracer.Inject(child.Context(), TextMapCarrier(dst))
-	assert.Nil(t, err)
-	assert.Len(t, dst, 4)
-	assert.Equal(t, strconv.Itoa(int(childSpanID)), dst["x-datadog-parent-id"])
-	assert.Equal(t, strconv.Itoa(int(childSpanID)), dst["x-datadog-trace-id"])
-	assert.Equal(t, "1", dst["x-datadog-sampling-priority"])
-	assertTraceTags(t, "_dd.p.upstream_services=dHJhY2VyLnRlc3Q|1|1|1.0000,_dd.p.hello1=world", dst["x-datadog-tags"])
 }
 
 func TestTextMapPropagatorInjectExtract(t *testing.T) {


### PR DESCRIPTION
The feature will be redesigned. It is still not used by the backend so there is no drawback in disabling it.