### PR TITLE
grpc_test.go: Add test for using the NoDebugStack() option

### DIFF
--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -799,7 +799,9 @@ func TestIgnoredMetadata(t *testing.T) {
 
 func BenchmarkUnaryServerInterceptor(b *testing.B) {
 	// need to use the real tracer to get representative measurments
-	tracer.Start(tracer.WithLogger(log.DiscardLogger{}))
+	tracer.Start(tracer.WithLogger(log.DiscardLogger{}),
+		tracer.WithEnv("test"),
+		tracer.WithServiceVersion("0.1.2"))
 	defer tracer.Stop()
 
 	doNothingOKGRPCHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
@@ -868,6 +870,14 @@ func BenchmarkUnaryServerInterceptor(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			interceptor(ctx, "ignoredRequestValue", methodInfo, doNothingErrorGRPCHandler)
+		}
+	})
+	interceptorNoStack := UnaryServerInterceptor(NoDebugStack())
+	b.Run("error_no_metadata_no_stack", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			interceptorNoStack(ctx, "ignoredRequestValue", methodInfo, doNothingErrorGRPCHandler)
 		}
 	})
 }


### PR DESCRIPTION
Also add WithEnv and WithServiceVersion() options, since that
should more accurately represents how tracing and the interceptor is
typically configured. Example output now looks like:

```
goos: darwin
goarch: amd64
pkg: gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc
cpu: Intel(R) Core(TM) i7-8569U CPU @ 2.80GHz
BenchmarkUnaryServerInterceptor/ok_no_metadata-8         	  205440	      5295 ns/op	    5006 B/op	      53 allocs/op
BenchmarkUnaryServerInterceptor/ok_with_metadata_no_parent-8         	  189415	      6144 ns/op	    5635 B/op	      58 allocs/op
BenchmarkUnaryServerInterceptor/ok_with_metadata_with_parent-8       	  219744	      5451 ns/op	    4724 B/op	      49 allocs/op
BenchmarkUnaryServerInterceptor/ok_no_metadata_with_analytics_rate-8 	  214992	      5470 ns/op	    5214 B/op	      55 allocs/op
BenchmarkUnaryServerInterceptor/error_no_metadata-8                  	   91838	     12414 ns/op	   11397 B/op	      70 allocs/op
BenchmarkUnaryServerInterceptor/error_no_metadata_no_stack-8         	  169959	      6638 ns/op	    6312 B/op	      57 allocs/op
```