### PR TITLE
contrib/google.golang.org/grpc: monitor grpc metadata headers

### DIFF
--- a/contrib/google.golang.org/grpc/appsec.go
+++ b/contrib/google.golang.org/grpc/appsec.go
@@ -23,7 +23,8 @@ import (
 func appsecUnaryHandlerMiddleware(span ddtrace.Span, handler grpc.UnaryHandler) grpc.UnaryHandler {
 	httpsec.SetAppSecTags(span)
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
-		op := grpcsec.StartHandlerOperation(grpcsec.HandlerOperationArgs{}, nil)
+		md, _ := metadata.FromIncomingContext(ctx)
+		op := grpcsec.StartHandlerOperation(grpcsec.HandlerOperationArgs{Metadata: md}, nil)
 		defer func() {
 			events := op.Finish(grpcsec.HandlerOperationRes{})
 			if len(events) == 0 {
@@ -40,7 +41,8 @@ func appsecUnaryHandlerMiddleware(span ddtrace.Span, handler grpc.UnaryHandler) 
 func appsecStreamHandlerMiddleware(span ddtrace.Span, handler grpc.StreamHandler) grpc.StreamHandler {
 	httpsec.SetAppSecTags(span)
 	return func(srv interface{}, stream grpc.ServerStream) error {
-		op := grpcsec.StartHandlerOperation(grpcsec.HandlerOperationArgs{}, nil)
+		md, _ := metadata.FromIncomingContext(stream.Context())
+		op := grpcsec.StartHandlerOperation(grpcsec.HandlerOperationArgs{Metadata: md}, nil)
 		defer func() {
 			events := op.Finish(grpcsec.HandlerOperationRes{})
 			if len(events) == 0 {

--- a/internal/appsec/dyngo/instrumentation/grpcsec/grpc.go
+++ b/internal/appsec/dyngo/instrumentation/grpcsec/grpc.go
@@ -42,7 +42,11 @@ type (
 		mu     sync.Mutex
 	}
 	// HandlerOperationArgs is the grpc handler arguments. Empty as of today.
-	HandlerOperationArgs struct{}
+	HandlerOperationArgs struct {
+		// Message received by the gRPC handler.
+		// Corresponds to the address `grpc.server.request.metadata`.
+		Metadata map[string][]string
+	}
 	// HandlerOperationRes is the grpc handler results. Empty as of today.
 	HandlerOperationRes struct{}
 


### PR DESCRIPTION
Add support for gRPC metadata headers received by RPC handlers in order to monitor them with AppSec.
This unlocks the new canary rule for gRPC allowing to easily trigger an AppSec event by using the gRPC metadata `dd-canary: dd-test-scanner-log`.