### PR TITLE
Remove kubernetes tracer service tag.

### DIFF
--- a/contrib/k8s.io/client-go/kubernetes/kubernetes.go
+++ b/contrib/k8s.io/client-go/kubernetes/kubernetes.go
@@ -39,7 +39,6 @@ func WrapRoundTripper(rt http.RoundTripper) http.RoundTripper {
 
 func wrapRoundTripperWithOptions(rt http.RoundTripper, opts ...httptrace.RoundTripperOption) http.RoundTripper {
 	opts = append(opts, httptrace.WithBefore(func(req *http.Request, span ddtrace.Span) {
-		span.SetTag(ext.ServiceName, "kubernetes")
 		span.SetTag(ext.ResourceName, RequestToResource(req.Method, req.URL.Path))
 		traceID := span.Context().TraceID()
 		if traceID == 0 {

--- a/contrib/k8s.io/client-go/kubernetes/kubernetes_test.go
+++ b/contrib/k8s.io/client-go/kubernetes/kubernetes_test.go
@@ -69,7 +69,6 @@ func TestKubernetes(t *testing.T) {
 	{
 		s := spans[0]
 		assert.Equal(t, "http.request", s.OperationName())
-		assert.Equal(t, "kubernetes", s.Tag(ext.ServiceName))
 		assert.Equal(t, "GET namespaces", s.Tag(ext.ResourceName))
 		assert.Equal(t, "200", s.Tag(ext.HTTPCode))
 		assert.Equal(t, "GET", s.Tag(ext.HTTPMethod))


### PR DESCRIPTION
The service tag in the kubernetes tracer appears to override the global
service tag. The service tag has been removed from the kubernetes
tracer.