### PR TITLE
proposal: contrib/gofiber/fiber.v2: resource name should use route instead of path

### DIFF
--- a/contrib/gofiber/fiber.v2/example_test.go
+++ b/contrib/gofiber/fiber.v2/example_test.go
@@ -6,10 +6,10 @@
 package fiber_test
 
 import (
-	"github.com/gofiber/fiber/v2"
-
 	fibertrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/gofiber/fiber.v2"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+
+	"github.com/gofiber/fiber/v2"
 )
 
 func Example() {

--- a/contrib/gofiber/fiber.v2/fiber.go
+++ b/contrib/gofiber/fiber.v2/fiber.go
@@ -48,15 +48,10 @@ func Middleware(opts ...Option) func(c *fiber.Ctx) error {
 		// pass the span through the request UserContext
 		c.SetUserContext(ctx)
 
-		resourceName := c.Path()
-		if resourceName == "" {
-			resourceName = "unknown"
-		}
-		resourceName = c.Method() + " " + resourceName
-		span.SetTag(ext.ResourceName, resourceName)
-
 		// pass the execution down the line
 		err := c.Next()
+
+		span.SetTag(ext.ResourceName, cfg.resourceNamer(c))
 
 		status := c.Response().StatusCode()
 		// on the off chance we don't yet have a status after the rest of the things have run

--- a/contrib/gofiber/fiber.v2/fiber.go
+++ b/contrib/gofiber/fiber.v2/fiber.go
@@ -12,12 +12,12 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/gofiber/fiber/v2"
-
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+
+	"github.com/gofiber/fiber/v2"
 )
 
 // Middleware returns middleware that will trace incoming requests.

--- a/contrib/gofiber/fiber.v2/fiber_test.go
+++ b/contrib/gofiber/fiber.v2/fiber_test.go
@@ -60,7 +60,7 @@ func TestTrace200(t *testing.T) {
 		assert.Equal("http.request", span.OperationName())
 		assert.Equal(ext.SpanTypeWeb, span.Tag(ext.SpanType))
 		assert.Equal("foobar", span.Tag(ext.ServiceName))
-		assert.Equal("GET /user/123", span.Tag(ext.ResourceName))
+		assert.Equal("GET /user/:id", span.Tag(ext.ResourceName))
 		assert.Equal("200", span.Tag(ext.HTTPCode))
 		assert.Equal("GET", span.Tag(ext.HTTPMethod))
 		assert.Equal("/user/123", span.Tag(ext.HTTPURL))

--- a/contrib/gofiber/fiber.v2/option.go
+++ b/contrib/gofiber/fiber.v2/option.go
@@ -8,11 +8,11 @@ package fiber
 import (
 	"math"
 
-	"github.com/gofiber/fiber/v2"
-
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+
+	"github.com/gofiber/fiber/v2"
 )
 
 type config struct {


### PR DESCRIPTION
This PR fixes resource naming in gofiber/fiber.v2 module. It also adds the functionality to automatically extract and set the route parameters as a span tag on `http.path.<parameter>`.

fixes: #1197 