### PR TITLE
appsec/config: default obfuscator config update

### DIFF
--- a/internal/appsec/config.go
+++ b/internal/appsec/config.go
@@ -28,9 +28,10 @@ const (
 )
 
 const (
-	defaultWAFTimeout              = 4 * time.Millisecond
-	defaultTraceRate          uint = 100 // up to 100 appsec traces/s
-	defaultObfuscatorKeyRegex      = "(?i)(p(ass)?w(or)?d|pass(_?phrase)?|secret|(api_?|private_?|public_?)key)|token|consumer_?(id|key|secret)|sign(ed|ature)|bearer|authorization"
+	defaultWAFTimeout           = 4 * time.Millisecond
+	defaultTraceRate            = 100 // up to 100 appsec traces/s
+	defaultObfuscatorKeyRegex   = `(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?)key)|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization`
+	defaultObfuscatorValueRegex = `(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:\s*=[^;]|"\s*:\s*"[^"]+")|bearer\s+[a-z0-9\._\-]+|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\w=-]+\.ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}[^\-]+[\-]{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*[a-z0-9\/\.+]{100,}`
 )
 
 // config is the AppSec configuration.
@@ -123,28 +124,23 @@ func readRateLimitConfig() (rate uint) {
 }
 
 func readObfuscatorConfig() ObfuscatorConfig {
-	keyRegex, kPresent := os.LookupEnv(obfuscatorKeyEnvVar)
-	valueRegex, vPresent := os.LookupEnv(obfuscatorValueEnvVar)
+	keyRE := readObfuscatorConfigRegexp(obfuscatorKeyEnvVar, defaultObfuscatorKeyRegex, "keys")
+	valueRE := readObfuscatorConfigRegexp(obfuscatorValueEnvVar, defaultObfuscatorValueRegex, "values")
+	return ObfuscatorConfig{KeyRegex: keyRE, ValueRegex: valueRE}
+}
 
-	if keyRegex == "" && !kPresent {
-		log.Debug("appsec: starting with the default regexp for matched parameter keys obfuscation")
-		keyRegex = defaultObfuscatorKeyRegex
-	} else if _, err := regexp.Compile(keyRegex); err == nil {
-		log.Debug("appsec: starting with the configured regexp for matched parameter keys obfuscation")
-	} else {
-		log.Error("appsec: could not compile the configured regexp for parameter keys. Using default instead")
-		keyRegex = defaultObfuscatorKeyRegex
+func readObfuscatorConfigRegexp(name, defaultValue, what string) string {
+	val, present := os.LookupEnv(name)
+	if !present {
+		log.Debug("appsec: starting with the default obfuscator regular expression for matched parameter %s", what)
+		return defaultValue
 	}
-	if valueRegex == "" && !vPresent {
-		log.Debug("appsec: starting with the default empty regexp for matched parameter values/highlights obfuscation")
-	} else if _, err := regexp.Compile(valueRegex); err == nil {
-		log.Debug("appsec: starting with the configured regexp for matched parameter values/highlights obfuscation")
-	} else {
-		log.Error("appsec: could not compile the configured regexp for parameter value/highlights. Using empty regexp instead")
-		valueRegex = ""
+	if _, err := regexp.Compile(val); err != nil {
+		log.Error("appsec: could not compile the configured obfuscator regular expression `%s=%s`. Using the default value instead", name, val)
+		return defaultValue
 	}
-
-	return ObfuscatorConfig{KeyRegex: keyRegex, ValueRegex: valueRegex}
+	log.Debug("appsec: starting with the configured obfuscator regular expression with %s for matched parameter %s", name, what)
+	return val
 }
 
 func readRulesConfig() (rules []byte, err error) {

--- a/internal/appsec/config.go
+++ b/internal/appsec/config.go
@@ -124,22 +124,22 @@ func readRateLimitConfig() (rate uint) {
 }
 
 func readObfuscatorConfig() ObfuscatorConfig {
-	keyRE := readObfuscatorConfigRegexp(obfuscatorKeyEnvVar, defaultObfuscatorKeyRegex, "keys")
-	valueRE := readObfuscatorConfigRegexp(obfuscatorValueEnvVar, defaultObfuscatorValueRegex, "values")
+	keyRE := readObfuscatorConfigRegexp(obfuscatorKeyEnvVar, defaultObfuscatorKeyRegex)
+	valueRE := readObfuscatorConfigRegexp(obfuscatorValueEnvVar, defaultObfuscatorValueRegex)
 	return ObfuscatorConfig{KeyRegex: keyRE, ValueRegex: valueRE}
 }
 
-func readObfuscatorConfigRegexp(name, defaultValue, what string) string {
+func readObfuscatorConfigRegexp(name, defaultValue string) string {
 	val, present := os.LookupEnv(name)
 	if !present {
-		log.Debug("appsec: starting with the default obfuscator regular expression for matched parameter %s", what)
+		log.Debug("appsec: %s not defined, starting with the default obfuscator regular expression", name)
 		return defaultValue
 	}
 	if _, err := regexp.Compile(val); err != nil {
 		log.Error("appsec: could not compile the configured obfuscator regular expression `%s=%s`. Using the default value instead", name, val)
 		return defaultValue
 	}
-	log.Debug("appsec: starting with the configured obfuscator regular expression with %s for matched parameter %s", name, what)
+	log.Debug("appsec: starting with the configured obfuscator regular expression %s", name)
 	return val
 }
 

--- a/internal/appsec/config_test.go
+++ b/internal/appsec/config_test.go
@@ -23,7 +23,8 @@ func TestConfig(t *testing.T) {
 		wafTimeout:     defaultWAFTimeout,
 		traceRateLimit: defaultTraceRate,
 		obfuscator: ObfuscatorConfig{
-			KeyRegex: defaultObfuscatorKeyRegex,
+			KeyRegex:   defaultObfuscatorKeyRegex,
+			ValueRegex: defaultObfuscatorValueRegex,
 		},
 	}
 
@@ -228,12 +229,14 @@ func TestConfig(t *testing.T) {
 				require.Equal(t, &expCfg, cfg)
 			})
 			t.Run("env-var-empty", func(t *testing.T) {
+				expCfg := *expectedDefaultConfig
+				expCfg.obfuscator.ValueRegex = ""
 				restoreEnv := cleanEnv()
 				defer restoreEnv()
 				require.NoError(t, os.Setenv(obfuscatorValueEnvVar, ""))
 				cfg, err := newConfig()
 				require.NoError(t, err)
-				require.Equal(t, expectedDefaultConfig, cfg)
+				require.Equal(t, &expCfg, cfg)
 			})
 			t.Run("compile-error", func(t *testing.T) {
 				restoreEnv := cleanEnv()


### PR DESCRIPTION
Now enable the obfuscation of matched parameter values by default so
that it obfuscates sensitive data that might be contained into raw
payload values.