### PR TITLE
internal/appsec/waf: metrics fixes

### DIFF
--- a/internal/appsec/waf/types.go
+++ b/internal/appsec/waf/types.go
@@ -13,9 +13,6 @@ import (
 // RunError the WAF can return when running it.
 type RunError int
 
-// AtomicU64 can be used to perform atomic operations on an uint64 type
-type AtomicU64 uint64
-
 // RulesetInfo stores the information - provided by the WAF - about WAF rules initialization.
 type RulesetInfo struct {
 	// Number of rules successfully loaded
@@ -59,6 +56,9 @@ func (e RunError) Error() string {
 	}
 }
 
+// AtomicU64 can be used to perform atomic operations on an uint64 type
+type AtomicU64 uint64
+
 // Add atomically sums the current atomic value with the provided value `v`.
 func (a *AtomicU64) Add(v uint64) {
 	atomic.AddUint64((*uint64)(a), v)
@@ -67,4 +67,8 @@ func (a *AtomicU64) Add(v uint64) {
 // Inc atomically increments the atomic value by 1
 func (a *AtomicU64) Inc() {
 	atomic.AddUint64((*uint64)(a), 1)
+}
+
+func (a *AtomicU64) Load() uint64 {
+	return atomic.LoadUint64((*uint64)(a))
 }

--- a/internal/appsec/waf/types.go
+++ b/internal/appsec/waf/types.go
@@ -69,6 +69,7 @@ func (a *AtomicU64) Inc() {
 	atomic.AddUint64((*uint64)(a), 1)
 }
 
+// Load atomically loads the value.
 func (a *AtomicU64) Load() uint64 {
 	return atomic.LoadUint64((*uint64)(a))
 }

--- a/internal/appsec/waf/waf.go
+++ b/internal/appsec/waf/waf.go
@@ -128,7 +128,7 @@ func NewHandle(jsonRule []byte, keyRegex, valueRegex string) (*Handle, error) {
 	incNbLiveCObjects()
 
 	// Decode the ruleset information returned by the WAF
-	errors, err := decodeMap((*wafObject)(&wafRInfo.errors))
+	errors, err := decodeErrors((*wafObject)(&wafRInfo.errors))
 	if err != nil {
 		C.ddwaf_destroy(handle)
 		decNbLiveCObjects()
@@ -198,8 +198,10 @@ func (waf *Handle) Close() {
 // become available. Each request must have its own Context.
 type Context struct {
 	waf *Handle
-	// Cumulated WAF runtime - in nanoseconds - for this context.
+	// Cumulated internal WAF run time - in nanoseconds - for this context.
 	totalRuntimeNs AtomicU64
+	// Cumulated overall run time - in nanoseconds - for this context.
+	totalOverallRuntimeNs AtomicU64
 	// Cumulated timeout count for this context.
 	timeoutCount AtomicU64
 
@@ -233,6 +235,15 @@ func NewContext(waf *Handle) *Context {
 
 // Run the WAF with the given Go values and timeout.
 func (c *Context) Run(values map[string]interface{}, timeout time.Duration) (matches []byte, err error) {
+	now := time.Now()
+	defer func() {
+		dt := time.Since(now)
+		c.totalOverallRuntimeNs.Add(uint64(dt.Nanoseconds()))
+	}()
+	return c.run(values, timeout)
+}
+
+func (c *Context) run(values map[string]interface{}, timeout time.Duration) (matches []byte, err error) {
 	if len(values) == 0 {
 		return
 	}
@@ -271,13 +282,13 @@ func (c *Context) Close() {
 
 // TotalRuntime returns the cumulated waf runtime across various run calls within the same WAF context.
 // Returned time is in nanoseconds.
-func (c *Context) TotalRuntime() uint64 {
-	return uint64(c.totalRuntimeNs)
+func (c *Context) TotalRuntime() (overallRuntimeNs, internalRuntimeNs uint64) {
+	return c.totalOverallRuntimeNs.Load(), c.totalRuntimeNs.Load()
 }
 
 // TotalTimeouts returns the cumulated amount of WAF timeouts across various run calls within the same WAF context.
 func (c *Context) TotalTimeouts() uint64 {
-	return uint64(c.timeoutCount)
+	return c.timeoutCount.Load()
 }
 
 // Translate libddwaf return values into return values suitable to a Go program.
@@ -578,6 +589,17 @@ func (e *encoder) encodeUint64(n uint64, wo *wafObject) error {
 	// TODO(Julio-Guerra): clarify with libddwaf when should it be an actual
 	//   uint64
 	return e.encodeString(strconv.FormatUint(n, 10), wo)
+}
+
+func decodeErrors(wo *wafObject) (map[string]interface{}, error) {
+	v, err := decodeMap(wo)
+	if err != nil {
+		return nil, err
+	}
+	if len(v) == 0 {
+		v = nil // enforce a nil map when the ddwaf map was empty
+	}
+	return v, nil
 }
 
 func decodeObject(wo *wafObject) (v interface{}, err error) {

--- a/internal/appsec/waf/waf_test.go
+++ b/internal/appsec/waf/waf_test.go
@@ -497,8 +497,11 @@ func TestMetrics(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, matches)
 		// Make sure that WAF runtime was set
-		require.Greater(t, wafCtx.TotalRuntime(), uint64(0), "wafCtx runtime metric is not set")
-		require.LessOrEqual(t, wafCtx.TotalRuntime(), uint64(elapsedNS), "wafCtx runtime metric is incorrect")
+		overall, internal := wafCtx.TotalRuntime()
+		require.Greater(t, overall, uint64(0))
+		require.Greater(t, internal, uint64(0))
+		require.Greater(t, overall, internal)
+		require.LessOrEqual(t, overall, uint64(elapsedNS))
 	})
 
 	t.Run("Timeouts", func(t *testing.T) {

--- a/internal/appsec/waf_unit_test.go
+++ b/internal/appsec/waf_unit_test.go
@@ -19,14 +19,6 @@ import (
 
 // Test that internal functions used to set span tags use the correct types
 func TestTagsTypes(t *testing.T) {
-	const (
-		eventRulesErrorsTag = "_dd.appsec.event_rules.errors"
-		eventRulesLoadedTag = "_dd.appsec.event_rules.loaded"
-		eventRulesFailedTag = "_dd.appsec.event_rules.error_count"
-		wafDurationTag      = "_dd.appsec.waf.duration"
-		wafDurationExtTag   = "_dd.appsec.waf.duration_ext"
-	)
-
 	th := instrumentation.NewTagsHolder()
 	rInfo := waf.RulesetInfo{
 		Version: "1.3.0",
@@ -35,15 +27,14 @@ func TestTagsTypes(t *testing.T) {
 		Errors:  map[string]interface{}{"test": []string{"1", "2"}},
 	}
 
-	addRulesetInfoTags(&th, rInfo)
-	addWAFDurationTags(&th, 1.0, 2.0)
+	addRulesMonitoringTags(&th, rInfo)
+	addWAFMonitoringTags(&th, "1.2.3", 2, 1, 3)
 
 	tags := th.Tags()
 	_, ok := tags[eventRulesErrorsTag].(string)
 	require.True(t, ok)
 
-	for _, tag := range []string{eventRulesLoadedTag, eventRulesFailedTag, wafDurationTag, wafDurationExtTag} {
-		_, ok := tags[tag].(float64)
-		require.True(t, ok)
+	for _, tag := range []string{eventRulesLoadedTag, eventRulesFailedTag, wafDurationTag, wafDurationExtTag, wafVersionTag} {
+		require.Contains(t, tags, tag)
 	}
 }


### PR DESCRIPTION
The 1st goal was actually fixing the fact the gRPC rule metrics were
sent on every request instead of the first one only. This was due to
the sync.Once variable not being at the right place.

I then realized we should read the AtomicU64 values using atomic.LoadUint64
to be totally safe regarding the atomic operations (atomic stores involves
atomic loads to safely read).

I finally refactored a bit further the helper functions for tags.