### PR TITLE
contrib/miekg/dns: fix flaky test

### DIFF
--- a/contrib/miekg/dns/dns_test.go
+++ b/contrib/miekg/dns/dns_test.go
@@ -44,6 +44,7 @@ func TestDNS(t *testing.T) {
 	_, err := Exchange(m, addr)
 	assert.NoError(t, err)
 
+	time.Sleep(100 * time.Millisecond) // Wait for span to be closed after DNS request
 	spans := mt.FinishedSpans()
 	assert.Len(t, spans, 2)
 	for _, s := range spans {


### PR DESCRIPTION
This test was a bit flaky. It was possible for the `Exchange` function to return before the DNS server closed its span. This meant that occasionally the test would only see one span when it expected to see two.

~~I couldn't find a better way to fix this than to add a sleep before grabbing the finished spans, but if anyone sees a better way let me know.~~ 