### PR TITLE
contrib/net/http: fix flaky roundtrip test

### DIFF
--- a/contrib/net/http/roundtripper_test.go
+++ b/contrib/net/http/roundtripper_test.go
@@ -124,12 +124,8 @@ func TestRoundTripperNetworkError(t *testing.T) {
 	defer mt.Stop()
 
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(r.Header))
+		_, err := tracer.Extract(tracer.HTTPHeadersCarrier(r.Header))
 		assert.NoError(t, err)
-
-		span := tracer.StartSpan("test",
-			tracer.ChildOf(spanctx))
-		defer span.Finish()
 		time.Sleep(10 * time.Millisecond)
 		w.Write([]byte("Timeout"))
 	}))


### PR DESCRIPTION
This test would fail periodically as the "test" server span could appear in the finished spans list when it was unexpected. It doesn't appear the test span was useful in anyway (or tested anything) so I simply removed it which will prevent this failure mode from re-occurring.