### PR TITLE
CODEOWNERS: change internal/telemetry owner to apm-go

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,3 +16,6 @@
 /appsec                   @DataDog/appsec-go
 /internal/appsec          @DataDog/appsec-go
 /contrib/**/appsec.go     @DataDog/appsec-go
+
+# telemetry
+/internal/telemetry       @DataDog/apm-go


### PR DESCRIPTION
The telemetry client library will be a shared internal dependency of appsec, profiling, and tracing. Anybody from those teams should be able to independently review and approve changes to the client library.