### PR TITLE
internal/telemetry: add default URLs and endpoints

### DIFF
--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -19,6 +19,16 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 )
 
+func TestClientDefaultURL(t *testing.T) {
+	var c telemetry.Client
+	c.Start(nil, nil)
+	c.Stop()
+	expected := "http://localhost:8126/telemetry/proxy/api/v2/apmtelemetry"
+	if c.URL != expected {
+		t.Errorf("bad default URL. Got %s, expected %s", c.URL, expected)
+	}
+}
+
 func TestClient(t *testing.T) {
 	heartbeat := make(chan struct{})
 


### PR DESCRIPTION
The telemetry proxy endpoint has been added to the Datadog agent, and there is at least one direct endpoint for telemetry upload. So we can now add those to the client library and set defaults for Client.URL.