### PR TITLE
contrib/net/http: copy request in RoundTrip

### DIFF
--- a/contrib/net/http/roundtripper.go
+++ b/contrib/net/http/roundtripper.go
@@ -49,7 +49,6 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (res *http.Response, err er
 	if rt.cfg.before != nil {
 		rt.cfg.before(req, span)
 	}
-	fmt.Printf("%p req url: ", req.URL)
 	r2 := req.WithContext(ctx)
 	// deep copy of the Header
 	r2.Header = make(http.Header, len(req.Header))

--- a/contrib/net/http/roundtripper_test.go
+++ b/contrib/net/http/roundtripper_test.go
@@ -229,7 +229,7 @@ func TestRoundTripperAnalyticsSettings(t *testing.T) {
 	})
 }
 
-// TestRoundTripperDuplicate is a regression test ensuring that RoundTrip
+// TestRoundTripperCopy is a regression test ensuring that RoundTrip
 // does not modify the request per the RoundTripper contract. See:
 // https://cs.opensource.google/go/go/+/refs/tags/go1.18.1:src/net/http/client.go;l=129-133
 func TestRoundTripperCopy(t *testing.T) {

--- a/contrib/net/http/roundtripper_test.go
+++ b/contrib/net/http/roundtripper_test.go
@@ -21,6 +21,32 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
+// TestRoundTripperDuplicate is a regression test ensuring that RoundTrip
+// does not modify the request per the RoundTripper contract. See:
+// https://cs.opensource.google/go/go/+/refs/tags/go1.18.1:src/net/http/client.go;l=129-133
+func TestRoundTripperCopy(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := tracer.Extract(tracer.HTTPHeadersCarrier(r.Header))
+		assert.NoError(t, err)
+
+		w.Write([]byte("Hello World"))
+	}))
+	defer s.Close()
+
+	initial_req, err := http.NewRequest("GET", s.URL+"/hello/world", nil)
+	assert.NoError(t, err)
+	req, err := http.NewRequest("GET", s.URL+"/hello/world", nil)
+	assert.NoError(t, err)
+	rt := WrapRoundTripper(http.DefaultTransport).(*roundTripper)
+	_, err = rt.RoundTrip(req)
+	assert.NoError(t, err)
+	assert.Len(t, req.Header, 0)
+	assert.Equal(t, initial_req, req)
+}
+
 func TestRoundTripper(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()

--- a/contrib/net/http/roundtripper_test.go
+++ b/contrib/net/http/roundtripper_test.go
@@ -239,7 +239,6 @@ func TestRoundTripperCopy(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := tracer.Extract(tracer.HTTPHeadersCarrier(r.Header))
 		assert.NoError(t, err)
-
 		w.Write([]byte("Hello World"))
 	}))
 	defer s.Close()


### PR DESCRIPTION
This PR copy's the Request in the `RoundTrip()` function to comply with the RoundTripper spec ([link](https://cs.opensource.google/go/go/+/refs/tags/go1.18.1:src/net/http/client.go;l=129-133)):
> 	// RoundTrip should not modify the request, except for
	// consuming and closing the Request's Body. RoundTrip may
	// read fields of the request in a separate goroutine. Callers
	// should not mutate or reuse the request until the Response's
	// Body has been closed.

With this change, a shallow copy of the request is made (`r.WithContext(ctx)` returns a shallow copy of r), and then a deep copy of the Header map is made before calling `tracer.Inject()`.

Fixes: #1090