### PR TITLE
profiler: stop profiler in TestProfilerPassthrough

### DIFF
--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -309,6 +309,7 @@ func TestProfilerPassthrough(t *testing.T) {
 		return nil
 	}
 	p.run()
+	defer p.stop()
 	var bat batch
 	select {
 	case bat = <-out:


### PR DESCRIPTION
TestProfilerPassthrough starts a profiler via the internal
profiler.run() method and doesn't stop it. The internal profiler
functions assume that only one profiler is actually running. The other
profiler tests muck with internal variables such as lookupProfile,
assuming there's only one profiler running, in a way that causes tests
to randomly fail or report data races when run multiple times, e.g via

	go test -race -count=10

Running the tests in a random order might surface the same issues.

The immediately correct thing to do is stop the profiler at the end of
the test. Looking at the bigger picture, the real correct thing to do
is test this library in a way that's not so heavily dependent on the
internal implementation details of the library.