### PR TITLE
ddtrace/tracer: add WithServiceNameMatch option

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -537,9 +537,10 @@ func WithServiceName(name string) StartOption {
 	}
 }
 
-// WithServiceNameMatch allows specifying whether span service name and config service name
+// WithUniversalVersion allows specifying whether span service name and config service name
 // should match to set application version tag
-func WithServiceNameMatch(shouldMatch bool) StartOption {
+// See: WithService, WithServiceVersion
+func WithUniversalVersion(shouldMatch bool) StartOption {
 	return func(c *config) {
 		c.serviceNameMatch = shouldMatch
 	}

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -66,6 +66,10 @@ type config struct {
 	// serviceName specifies the name of this application.
 	serviceName string
 
+	// serviceNameMatch, reports whether span service name and config service name
+	// should match to set application version tag. Defaults to true
+	serviceNameMatch bool
+
 	// version specifies the version of this application
 	version string
 
@@ -179,6 +183,7 @@ func newConfig(opts ...StartOption) *config {
 	c.sampler = NewAllSampler()
 	c.agentAddr = resolveAgentAddr()
 	c.httpClient = defaultHTTPClient()
+	c.serviceNameMatch = true
 
 	if internal.BoolEnv("DD_TRACE_ANALYTICS_ENABLED", false) {
 		globalconfig.SetAnalyticsRate(1.0)
@@ -529,6 +534,14 @@ func WithServiceName(name string) StartOption {
 				"with `WithService` or `DD_SERVICE`; integration service name will not be set.")
 		}
 		globalconfig.SetServiceName("")
+	}
+}
+
+// WithServiceNameMatch allows specifying whether span service name and config service name
+// should match to set application version tag
+func WithServiceNameMatch(shouldMatch bool) StartOption {
+	return func(c *config) {
+		c.serviceNameMatch = shouldMatch
 	}
 }
 

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -422,7 +422,7 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		delete(span.Metrics, keyMeasured)
 	}
 	if t.config.version != "" {
-		if !t.config.serviceNameMatch || (t.config.serviceNameMatch && span.Service == t.config.serviceName) {
+		if t.config.universalVersion || (!t.config.universalVersion && span.Service == t.config.serviceName) {
 			span.setMeta(ext.Version, t.config.version)
 		}
 	}

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -421,8 +421,10 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		// all top level spans are measured. So the measured tag is redundant.
 		delete(span.Metrics, keyMeasured)
 	}
-	if t.config.version != "" && span.Service == t.config.serviceName {
-		span.setMeta(ext.Version, t.config.version)
+	if t.config.version != "" {
+		if !t.config.serviceNameMatch || (t.config.serviceNameMatch && span.Service == t.config.serviceName) {
+			span.setMeta(ext.Version, t.config.version)
+		}
 	}
 	if t.config.env != "" {
 		span.setMeta(ext.Environment, t.config.env)

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1390,20 +1390,40 @@ func TestVersion(t *testing.T) {
 		v := sp.Meta[ext.Version]
 		assert.Equal("4.5.6", v)
 	})
-
-	t.Run("unset/match-disabled", func(t *testing.T) {
+	t.Run("service", func(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t, WithServiceVersion("4.5.6"),
-			WithService("servenv"), WithUniversalVersion(false))
+			WithService("servenv"))
 		defer stop()
 
 		assert := assert.New(t)
 		sp := tracer.StartSpan("http.request", ServiceName("otherservenv")).(*span)
 		_, ok := sp.Meta[ext.Version]
-		assert.True(ok)
+		assert.False(ok)
 	})
-	t.Run("unset/match-enabled", func(t *testing.T) {
+	t.Run("universal", func(t *testing.T) {
+		tracer, _, _, stop := startTestTracer(t, WithService("servenv"), WithUniversalVersion("4.5.6"))
+		defer stop()
+
+		assert := assert.New(t)
+		sp := tracer.StartSpan("http.request", ServiceName("otherservenv")).(*span)
+		v, ok := sp.Meta[ext.Version]
+		assert.True(ok)
+		assert.Equal("4.5.6", v)
+	})
+	t.Run("service/universal", func(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t, WithServiceVersion("4.5.6"),
-			WithService("servenv"), WithUniversalVersion(true))
+			WithService("servenv"), WithUniversalVersion("1.2.3"))
+		defer stop()
+
+		assert := assert.New(t)
+		sp := tracer.StartSpan("http.request", ServiceName("otherservenv")).(*span)
+		v, ok := sp.Meta[ext.Version]
+		assert.True(ok)
+		assert.Equal("1.2.3", v)
+	})
+	t.Run("universal/service", func(t *testing.T) {
+		tracer, _, _, stop := startTestTracer(t, WithUniversalVersion("1.2.3"),
+			WithServiceVersion("4.5.6"), WithService("servenv"))
 		defer stop()
 
 		assert := assert.New(t)

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1391,8 +1391,19 @@ func TestVersion(t *testing.T) {
 		assert.Equal("4.5.6", v)
 	})
 
-	t.Run("unset", func(t *testing.T) {
-		tracer, _, _, stop := startTestTracer(t, WithServiceVersion("4.5.6"), WithService("servenv"))
+	t.Run("unset/match-disabled", func(t *testing.T) {
+		tracer, _, _, stop := startTestTracer(t, WithServiceVersion("4.5.6"),
+			WithService("servenv"), WithServiceNameMatch(false))
+		defer stop()
+
+		assert := assert.New(t)
+		sp := tracer.StartSpan("http.request", ServiceName("otherservenv")).(*span)
+		_, ok := sp.Meta[ext.Version]
+		assert.True(ok)
+	})
+	t.Run("unset/match-enabled", func(t *testing.T) {
+		tracer, _, _, stop := startTestTracer(t, WithServiceVersion("4.5.6"),
+			WithService("servenv"), WithServiceNameMatch(true))
 		defer stop()
 
 		assert := assert.New(t)

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1393,7 +1393,7 @@ func TestVersion(t *testing.T) {
 
 	t.Run("unset/match-disabled", func(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t, WithServiceVersion("4.5.6"),
-			WithService("servenv"), WithServiceNameMatch(false))
+			WithService("servenv"), WithUniversalVersion(false))
 		defer stop()
 
 		assert := assert.New(t)
@@ -1403,7 +1403,7 @@ func TestVersion(t *testing.T) {
 	})
 	t.Run("unset/match-enabled", func(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t, WithServiceVersion("4.5.6"),
-			WithService("servenv"), WithServiceNameMatch(true))
+			WithService("servenv"), WithUniversalVersion(true))
 		defer stop()
 
 		assert := assert.New(t)


### PR DESCRIPTION
Removed limitation of having service name match the name defined when starting the tracer for version tracking.

Closes #1161 