### PR TITLE
profiler: make TestSetProfileFraction more isolated

### DIFF
--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -277,23 +277,23 @@ func TestProfilerInternal(t *testing.T) {
 
 func TestSetProfileFraction(t *testing.T) {
 	t.Run("on", func(t *testing.T) {
-		start := runtime.SetMutexProfileFraction(-1)
+		start := runtime.SetMutexProfileFraction(0)
 		defer runtime.SetMutexProfileFraction(start)
 		p, err := unstartedProfiler(WithProfileTypes(MutexProfile))
 		require.NoError(t, err)
 		p.run()
 		p.stop()
-		assert.NotEqual(t, start, runtime.SetMutexProfileFraction(-1))
+		assert.Equal(t, DefaultMutexFraction, runtime.SetMutexProfileFraction(-1))
 	})
 
 	t.Run("off", func(t *testing.T) {
-		start := runtime.SetMutexProfileFraction(-1)
+		start := runtime.SetMutexProfileFraction(0)
 		defer runtime.SetMutexProfileFraction(start)
 		p, err := unstartedProfiler()
 		require.NoError(t, err)
 		p.run()
 		p.stop()
-		assert.Equal(t, start, runtime.SetMutexProfileFraction(-1))
+		assert.Zero(t, runtime.SetMutexProfileFraction(-1))
 	})
 }
 


### PR DESCRIPTION
TestAllUploaded starts the mutex profiler. Currently the profiler
doesn't re-set the profile rate when Stop is called. This causes
TestSetProfileFraction/on to fail if it's run after TestAllUploaded
since the test checks that the old rate is different than the new rate,
but in both cases the rates are the default rate.

This commit changes the test to start by setting the rate to 0 and then
checking that it's either the default value or still 0 after starting
the profiler. This makes the test more isolated and not influenced by
what other tests do to the mutex profile fraction.

Fixes #1279