### PR TITLE
ddtrace/tracer: handle parent-id header of 0 for synthetics

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -310,7 +310,7 @@ func (p *propagator) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 	if err != nil {
 		return nil, err
 	}
-	if ctx.traceID == 0 || ctx.spanID == 0 {
+	if ctx.traceID == 0 || (ctx.spanID == 0 && ctx.origin != "synthetics") {
 		return nil, ErrSpanContextNotFound
 	}
 	return &ctx, nil

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -117,6 +117,12 @@ func TestTextMapPropagatorErrors(t *testing.T) {
 		DefaultParentIDHeader: "0",
 	}))
 	assert.Equal(ErrSpanContextNotFound, err)
+
+	_, err = propagator.Extract(TextMapCarrier(map[string]string{
+		DefaultTraceIDHeader:  "3",
+		DefaultParentIDHeader: "0",
+	}))
+	assert.Equal(ErrSpanContextNotFound, err)
 }
 
 func TestTextMapPropagatorInjectHeader(t *testing.T) {
@@ -173,6 +179,26 @@ func TestTextMapPropagatorOrigin(t *testing.T) {
 	if dst[originHeader] != "synthetics" {
 		t.Fatal("didn't inject header")
 	}
+}
+
+func TestExtractOriginSynthetics(t *testing.T) {
+	src := TextMapCarrier(map[string]string{
+		originHeader:          "synthetics",
+		DefaultTraceIDHeader:  "3",
+		DefaultParentIDHeader: "0",
+	})
+	tracer := newTracer()
+	ctx, err := tracer.Extract(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sctx, ok := ctx.(*spanContext)
+	if !ok {
+		t.Fatal("not a *spanContext")
+	}
+	assert.Equal(t, sctx.spanID, uint64(0))
+	assert.Equal(t, sctx.traceID, uint64(3))
+	assert.Equal(t, sctx.origin, "synthetics")
 }
 
 func TestTextMapPropagatorInvalidTraceTagsHeader(t *testing.T) {


### PR DESCRIPTION
Synthetic tests set the header `x-datadog-parent-id` to 0. Currently, the tracer mishandles this and considers that the span id is not set when it is 0. 

This PR makes sure that header `x-datadog-parent-id` of value 0 is handled correctly when the origin is synthetics.

See APMGO-242