### PR TITLE
contrib: refactor http request span tags

### DIFF
--- a/contrib/emicklei/go-restful/restful.go
+++ b/contrib/emicklei/go-restful/restful.go
@@ -9,7 +9,7 @@ package restful
 import (
 	"math"
 
-	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"

--- a/contrib/emicklei/go-restful/restful.go
+++ b/contrib/emicklei/go-restful/restful.go
@@ -31,7 +31,7 @@ func FilterFunc(configOpts ...Option) restful.FilterFunction {
 		if !math.IsNaN(cfg.analyticsRate) {
 			spanOpts = append(spanOpts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 		}
-		span, ctx := httptrace.StartRequestSpan(req.Request, false, spanOpts...)
+		span, ctx := httptrace.StartRequestSpan(req.Request, spanOpts...)
 		defer func() {
 			httptrace.FinishRequestSpan(span, resp.StatusCode(), tracer.WithError(resp.Error()))
 		}()
@@ -44,7 +44,7 @@ func FilterFunc(configOpts ...Option) restful.FilterFunction {
 
 // Filter is deprecated. Please use FilterFunc.
 func Filter(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
-	span, ctx := httptrace.StartRequestSpan(req.Request, false, tracer.ResourceName(req.SelectedRoutePath()))
+	span, ctx := httptrace.StartRequestSpan(req.Request, tracer.ResourceName(req.SelectedRoutePath()))
 	defer func() {
 		httptrace.FinishRequestSpan(span, resp.StatusCode(), tracer.WithError(resp.Error()))
 	}()

--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"math"
 
-	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"

--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -40,13 +40,12 @@ func Middleware(service string, opts ...Option) gin.HandlerFunc {
 			opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 		}
 		span, ctx := httptrace.StartRequestSpan(c.Request, cfg.serviceName, cfg.resourceNamer(c), false, opts...)
-
-		// pass the span through the request context
-		c.Request = c.Request.WithContext(ctx)
-
 		defer func() {
 			httptrace.FinishRequestSpan(span, c.Writer.Status())
 		}()
+
+		// pass the span through the request context
+		c.Request = c.Request.WithContext(ctx)
 
 		// Use AppSec if enabled by user
 		if appsecEnabled {

--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -33,9 +33,7 @@ func Middleware(service string, opts ...Option) gin.HandlerFunc {
 		if cfg.ignoreRequest(c) {
 			return
 		}
-		opts := []ddtrace.StartSpanOption{
-			tracer.Measured(),
-		}
+		var opts []ddtrace.StartSpanOption
 		if !math.IsNaN(cfg.analyticsRate) {
 			opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 		}

--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -39,7 +39,7 @@ func Middleware(service string, opts ...Option) gin.HandlerFunc {
 		if !math.IsNaN(cfg.analyticsRate) {
 			opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 		}
-		span, ctx := httptrace.StartRequestSpan(c.Request, false, opts...)
+		span, ctx := httptrace.StartRequestSpan(c.Request, opts...)
 		defer func() {
 			httptrace.FinishRequestSpan(span, c.Writer.Status())
 		}()

--- a/contrib/go-chi/chi.v5/chi.go
+++ b/contrib/go-chi/chi.v5/chi.go
@@ -11,7 +11,7 @@ import (
 	"math"
 	"net/http"
 
-	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"

--- a/contrib/go-chi/chi.v5/chi.go
+++ b/contrib/go-chi/chi.v5/chi.go
@@ -40,7 +40,7 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 			if !math.IsNaN(cfg.analyticsRate) {
 				opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 			}
-			span, ctx := httptrace.StartRequestSpan(r, false, opts...)
+			span, ctx := httptrace.StartRequestSpan(r, opts...)
 			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 			defer func() {
 				status := ww.Status()

--- a/contrib/go-chi/chi.v5/chi.go
+++ b/contrib/go-chi/chi.v5/chi.go
@@ -35,7 +35,7 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 				next.ServeHTTP(w, r)
 				return
 			}
-			opts := append(cfg.spanOpts, tracer.Measured())
+			opts := cfg.spanOpts
 			if !math.IsNaN(cfg.analyticsRate) {
 				opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 			}

--- a/contrib/go-chi/chi.v5/chi.go
+++ b/contrib/go-chi/chi.v5/chi.go
@@ -29,17 +29,18 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 		fn(cfg)
 	}
 	log.Debug("contrib/go-chi/chi.v5: Configuring Middleware: %#v", cfg)
+	spanOpts := append(cfg.spanOpts, tracer.ServiceName(cfg.serviceName))
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if cfg.ignoreRequest(r) {
 				next.ServeHTTP(w, r)
 				return
 			}
-			opts := cfg.spanOpts
+			opts := spanOpts
 			if !math.IsNaN(cfg.analyticsRate) {
 				opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 			}
-			span, ctx := httptrace.StartRequestSpan(r, cfg.serviceName, "", false, opts...)
+			span, ctx := httptrace.StartRequestSpan(r, false, opts...)
 			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 			defer func() {
 				status := ww.Status()

--- a/contrib/go-chi/chi/chi.go
+++ b/contrib/go-chi/chi/chi.go
@@ -11,7 +11,7 @@ import (
 	"math"
 	"net/http"
 
-	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"

--- a/contrib/go-chi/chi/chi.go
+++ b/contrib/go-chi/chi/chi.go
@@ -40,7 +40,7 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 			if !math.IsNaN(cfg.analyticsRate) {
 				opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 			}
-			span, ctx := httptrace.StartRequestSpan(r, false, opts...)
+			span, ctx := httptrace.StartRequestSpan(r, opts...)
 			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 			defer func() {
 				status := ww.Status()

--- a/contrib/go-chi/chi/chi.go
+++ b/contrib/go-chi/chi/chi.go
@@ -10,9 +10,8 @@ import (
 	"fmt"
 	"math"
 	"net/http"
-	"strconv"
 
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
@@ -36,22 +35,24 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 				next.ServeHTTP(w, r)
 				return
 			}
-			opts := []ddtrace.StartSpanOption{
-				tracer.SpanType(ext.SpanTypeWeb),
-				tracer.ServiceName(cfg.serviceName),
-				tracer.Tag(ext.HTTPMethod, r.Method),
-				tracer.Tag(ext.HTTPURL, r.URL.Path),
-				tracer.Measured(),
-			}
+			opts := append(cfg.spanOpts, tracer.Measured())
 			if !math.IsNaN(cfg.analyticsRate) {
 				opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 			}
-			if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(r.Header)); err == nil {
-				opts = append(opts, tracer.ChildOf(spanctx))
-			}
 			opts = append(opts, cfg.spanOpts...)
-			span, ctx := tracer.StartSpanFromContext(r.Context(), "http.request", opts...)
-			defer span.Finish()
+			span, ctx := httptrace.StartRequestSpan(r, cfg.serviceName, "", false, opts...)
+
+			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+			r = r.WithContext(ctx)
+
+			defer func() {
+				status := ww.Status()
+				var opts []tracer.FinishOption
+				if cfg.isStatusError(status) {
+					opts = []tracer.FinishOption{tracer.WithError(fmt.Errorf("%d: %s", status, http.StatusText(status)))}
+				}
+				httptrace.FinishRequestSpan(span, status, opts...)
+			}()
 
 			next := next // avoid modifying the value of next in the outer closure scope
 			if appsec.Enabled() {
@@ -60,10 +61,8 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 				// implements the `interface { Status() int }` expected by httpsec.
 			}
 
-			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
-
 			// pass the span through the request context and serve the request to the next middleware
-			next.ServeHTTP(ww, r.WithContext(ctx))
+			next.ServeHTTP(ww, r)
 
 			// set the resource name as we get it only once the handler is executed
 			resourceName := chi.RouteContext(r.Context()).RoutePattern()
@@ -72,19 +71,6 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 			}
 			resourceName = r.Method + " " + resourceName
 			span.SetTag(ext.ResourceName, resourceName)
-
-			// set the status code
-			status := ww.Status()
-			// 0 status means one has not yet been sent in which case net/http library will write StatusOK
-			if ww.Status() == 0 {
-				status = http.StatusOK
-			}
-			span.SetTag(ext.HTTPCode, strconv.Itoa(status))
-
-			if cfg.isStatusError(status) {
-				// mark 5xx server error
-				span.SetTag(ext.Error, fmt.Errorf("%d: %s", status, http.StatusText(status)))
-			}
 		})
 	}
 }

--- a/contrib/go-chi/chi/chi.go
+++ b/contrib/go-chi/chi/chi.go
@@ -35,11 +35,10 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 				next.ServeHTTP(w, r)
 				return
 			}
-			opts := append(cfg.spanOpts, tracer.Measured())
+			opts := cfg.spanOpts
 			if !math.IsNaN(cfg.analyticsRate) {
 				opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 			}
-			opts = append(opts, cfg.spanOpts...)
 			span, ctx := httptrace.StartRequestSpan(r, cfg.serviceName, "", false, opts...)
 			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 			defer func() {

--- a/contrib/gorilla/mux/option.go
+++ b/contrib/gorilla/mux/option.go
@@ -39,7 +39,6 @@ func newConfig(opts []RouterOption) *routerConfig {
 	if !math.IsNaN(cfg.analyticsRate) {
 		cfg.spanOpts = append(cfg.spanOpts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 	}
-	cfg.spanOpts = append(cfg.spanOpts, tracer.Measured())
 	return cfg
 }
 

--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -33,13 +33,13 @@ const (
 
 // StartRequestSpan starts an HTTP request span with the standard list of HTTP request span tags. URL query parameters
 // are added to the URL tag when queryParams is true. Any further span start option can be added with opts.
-func StartRequestSpan(r *http.Request, service, resource string, opts ...ddtrace.StartSpanOption) (tracer.Span, context.Context) {
+func StartRequestSpan(r *http.Request, service, resource string, queryParams bool, opts ...ddtrace.StartSpanOption) (tracer.Span, context.Context) {
 	opts = append([]ddtrace.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeWeb),
 		tracer.ServiceName(service),
 		tracer.ResourceName(resource),
 		tracer.Tag(HTTPMethod, r.Method),
-		tracer.Tag(HTTPURL, makeURLTag(r)),
+		tracer.Tag(HTTPURL, makeURLTag(r, queryParams)),
 		tracer.Tag(HTTPUserAgent, r.UserAgent()),
 		tracer.Measured(),
 	}, opts...)
@@ -73,7 +73,7 @@ func FinishRequestSpan(s tracer.Span, status int, opts ...tracer.FinishOption) {
 
 // Create the standard http.url value out of the given HTTP request in the form
 // `scheme://host[:port]/path[?query][#fragment]`
-func makeURLTag(r *http.Request) string {
+func makeURLTag(r *http.Request, queryParams bool) string {
 	var u strings.Builder
 	if r.TLS != nil {
 		u.WriteString("https")
@@ -82,7 +82,7 @@ func makeURLTag(r *http.Request) string {
 	}
 	u.WriteString(r.URL.Host)
 	u.WriteString(r.URL.EscapedPath())
-	if query := r.URL.RawQuery; query != "" {
+	if query := r.URL.RawQuery; queryParams && query != "" {
 		u.WriteByte('?')
 		u.WriteString(query)
 	}

--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -44,7 +44,8 @@ func StartRequestSpan(r *http.Request, service, resource string, queryParams boo
 	return tracer.StartSpanFromContext(r.Context(), "http.request", opts...)
 }
 
-// FinishRequestSpan finishes the given HTTP request span with the standard list of HTTP request span tags.
+// FinishRequestSpan finishes the given HTTP request span with its Finish() method along with the standard list of HTTP
+// request span tags.
 // Any further span finish option can be added with opts.
 func FinishRequestSpan(s tracer.Span, status int, opts ...tracer.FinishOption) {
 	var statusStr string

--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -54,9 +54,8 @@ func StartRequestSpan(r *http.Request, service, resource string, queryParams boo
 	return tracer.StartSpanFromContext(r.Context(), "http.request", opts...)
 }
 
-// FinishRequestSpan finishes the given HTTP request span with its Finish() method along with the standard list of HTTP
-// request span tags.
-// Any further span finish option can be added with opts.
+// FinishRequestSpan finishes the given HTTP request span and sets the expected response-related tags such as the status
+// code. Any further span finish option can be added with opts.
 func FinishRequestSpan(s tracer.Span, status int, opts ...tracer.FinishOption) {
 	var statusStr string
 	if status == 0 {

--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+// Package httptrace provides functionalities to trace HTTP requests that are commonly required and used across
+// contrib/** integrations.
+package httptrace
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+// StartRequestSpan starts an HTTP request span with the standard list of HTTP request span tags. URL query parameters
+// are added to the URL tag when queryParams is true. Any further span start option can be added with opts.
+func StartRequestSpan(r *http.Request, service, resource string, queryParams bool, opts ...ddtrace.StartSpanOption) (tracer.Span, context.Context) {
+	path := r.URL.Path
+	if queryParams {
+		path += "?" + r.URL.RawQuery
+	}
+	opts = append([]ddtrace.StartSpanOption{
+		tracer.SpanType(ext.SpanTypeWeb),
+		tracer.ServiceName(service),
+		tracer.ResourceName(resource),
+		tracer.Tag(ext.HTTPMethod, r.Method),
+		tracer.Tag(ext.HTTPURL, path),
+		tracer.Tag(ext.HTTPUserAgent, r.UserAgent()),
+	}, opts...)
+	if r.URL.Host != "" {
+		opts = append([]ddtrace.StartSpanOption{
+			tracer.Tag("http.host", r.URL.Host),
+		}, opts...)
+	}
+	if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(r.Header)); err == nil {
+		opts = append(opts, tracer.ChildOf(spanctx))
+	}
+	return tracer.StartSpanFromContext(r.Context(), "http.request", opts...)
+}
+
+// FinishRequestSpan finishes the given HTTP request span with the standard list of HTTP request span tags.
+// Any further span finish option can be added with opts.
+func FinishRequestSpan(s tracer.Span, status int, opts ...tracer.FinishOption) {
+	var statusStr string
+	if status == 0 {
+		statusStr = "200"
+	} else {
+		statusStr = strconv.Itoa(status)
+	}
+	s.SetTag(ext.HTTPCode, statusStr)
+	if status >= 500 && status < 600 {
+		s.SetTag(ext.Error, fmt.Errorf("%d: %s", status, http.StatusText(status)))
+	}
+	s.Finish(opts...)
+}

--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -33,11 +33,9 @@ const (
 
 // StartRequestSpan starts an HTTP request span with the standard list of HTTP request span tags. URL query parameters
 // are added to the URL tag when queryParams is true. Any further span start option can be added with opts.
-func StartRequestSpan(r *http.Request, service, resource string, queryParams bool, opts ...ddtrace.StartSpanOption) (tracer.Span, context.Context) {
+func StartRequestSpan(r *http.Request, queryParams bool, opts ...ddtrace.StartSpanOption) (tracer.Span, context.Context) {
 	opts = append([]ddtrace.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeWeb),
-		tracer.ServiceName(service),
-		tracer.ResourceName(resource),
 		tracer.Tag(HTTPMethod, r.Method),
 		tracer.Tag(HTTPURL, makeURLTag(r, queryParams)),
 		tracer.Tag(HTTPUserAgent, r.UserAgent()),
@@ -70,24 +68,13 @@ func FinishRequestSpan(s tracer.Span, status int, opts ...tracer.FinishOption) {
 	s.Finish(opts...)
 }
 
-// Create the standard http.url value out of the given HTTP request in the form
-// `scheme://host[:port]/path[?query][#fragment]`
+// Create the http.url value out of the given HTTP request.
 func makeURLTag(r *http.Request, queryParams bool) string {
 	var u strings.Builder
-	if r.TLS != nil {
-		u.WriteString("https")
-	} else {
-		u.WriteString("http")
-	}
-	u.WriteString(r.URL.Host)
 	u.WriteString(r.URL.EscapedPath())
 	if query := r.URL.RawQuery; queryParams && query != "" {
 		u.WriteByte('?')
 		u.WriteString(query)
-	}
-	if fragment := r.URL.Fragment; fragment != "" {
-		u.WriteByte('#')
-		u.WriteString(fragment)
 	}
 	return u.String()
 }

--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -32,6 +32,7 @@ func StartRequestSpan(r *http.Request, service, resource string, queryParams boo
 		tracer.Tag(ext.HTTPMethod, r.Method),
 		tracer.Tag(ext.HTTPURL, path),
 		tracer.Tag(ext.HTTPUserAgent, r.UserAgent()),
+		tracer.Measured(),
 	}, opts...)
 	if r.URL.Host != "" {
 		opts = append([]ddtrace.StartSpanOption{

--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -55,7 +55,7 @@ func FinishRequestSpan(s tracer.Span, status int, opts ...tracer.FinishOption) {
 	}
 	s.SetTag(ext.HTTPCode, statusStr)
 	if status >= 500 && status < 600 {
-		s.SetTag(ext.Error, fmt.Errorf("%d: %s", status, http.StatusText(status)))
+		s.SetTag(ext.Error, fmt.Errorf("%s: %s", statusStr, http.StatusText(status)))
 	}
 	s.Finish(opts...)
 }

--- a/contrib/julienschmidt/httprouter/httprouter.go
+++ b/contrib/julienschmidt/httprouter/httprouter.go
@@ -35,7 +35,6 @@ func New(opts ...RouterOption) *Router {
 	if !math.IsNaN(cfg.analyticsRate) {
 		cfg.spanOpts = append(cfg.spanOpts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 	}
-	cfg.spanOpts = append(cfg.spanOpts, tracer.Measured())
 	log.Debug("contrib/julienschmidt/httprouter: Configuring Router: %#v", cfg)
 	return &Router{httprouter.New(), cfg}
 }

--- a/contrib/labstack/echo.v4/echotrace.go
+++ b/contrib/labstack/echo.v4/echotrace.go
@@ -46,7 +46,7 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 				finishOpts = []tracer.FinishOption{tracer.NoDebugStack()}
 			}
 
-			span, ctx := httptrace.StartRequestSpan(request, false, opts...)
+			span, ctx := httptrace.StartRequestSpan(request, opts...)
 			defer func() {
 				httptrace.FinishRequestSpan(span, c.Response().Status, finishOpts...)
 			}()

--- a/contrib/labstack/echo.v4/echotrace.go
+++ b/contrib/labstack/echo.v4/echotrace.go
@@ -9,7 +9,7 @@ package echo
 import (
 	"math"
 
-	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"

--- a/contrib/labstack/echo.v4/echotrace.go
+++ b/contrib/labstack/echo.v4/echotrace.go
@@ -8,8 +8,8 @@ package echo
 
 import (
 	"math"
-	"strconv"
 
+	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -30,27 +30,23 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 		return func(c echo.Context) error {
 			request := c.Request()
 			resource := request.Method + " " + c.Path()
+
 			opts := []ddtrace.StartSpanOption{
-				tracer.ServiceName(cfg.serviceName),
-				tracer.ResourceName(resource),
-				tracer.SpanType(ext.SpanTypeWeb),
-				tracer.Tag(ext.HTTPMethod, request.Method),
-				tracer.Tag(ext.HTTPURL, request.URL.Path),
 				tracer.Measured(),
 			}
-
 			if !math.IsNaN(cfg.analyticsRate) {
 				opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 			}
-			if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(request.Header)); err == nil {
-				opts = append(opts, tracer.ChildOf(spanctx))
-			}
+
 			var finishOpts []tracer.FinishOption
 			if cfg.noDebugStack {
-				finishOpts = append(finishOpts, tracer.NoDebugStack())
+				finishOpts = []tracer.FinishOption{tracer.NoDebugStack()}
 			}
-			span, ctx := tracer.StartSpanFromContext(request.Context(), "http.request", opts...)
-			defer func() { span.Finish(finishOpts...) }()
+
+			span, ctx := httptrace.StartRequestSpan(request, cfg.serviceName, resource, false, opts...)
+			defer func() {
+				httptrace.FinishRequestSpan(span, c.Response().Status, finishOpts...)
+			}()
 
 			// pass the span through the request context
 			c.SetRequest(request.WithContext(ctx))
@@ -66,7 +62,6 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 				c.Error(err)
 			}
 
-			span.SetTag(ext.HTTPCode, strconv.Itoa(c.Response().Status))
 			return err
 		}
 	}

--- a/contrib/labstack/echo.v4/echotrace.go
+++ b/contrib/labstack/echo.v4/echotrace.go
@@ -31,9 +31,7 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 			request := c.Request()
 			resource := request.Method + " " + c.Path()
 
-			opts := []ddtrace.StartSpanOption{
-				tracer.Measured(),
-			}
+			var opts []ddtrace.StartSpanOption
 			if !math.IsNaN(cfg.analyticsRate) {
 				opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 			}

--- a/contrib/labstack/echo/echotrace.go
+++ b/contrib/labstack/echo/echotrace.go
@@ -9,7 +9,7 @@ package echo
 import (
 	"math"
 
-	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"

--- a/contrib/labstack/echo/echotrace.go
+++ b/contrib/labstack/echo/echotrace.go
@@ -34,7 +34,7 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 			request := c.Request()
 			resource := request.Method + " " + c.Path()
 			opts := append(spanOpts, tracer.ResourceName(resource))
-			
+
 			if !math.IsNaN(cfg.analyticsRate) {
 				opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 			}

--- a/contrib/labstack/echo/echotrace.go
+++ b/contrib/labstack/echo/echotrace.go
@@ -44,7 +44,7 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 				finishOpts = []tracer.FinishOption{tracer.NoDebugStack()}
 			}
 
-			span, ctx := httptrace.StartRequestSpan(request, false, opts...)
+			span, ctx := httptrace.StartRequestSpan(request, opts...)
 			defer func() {
 				httptrace.FinishRequestSpan(span, c.Response().Status, finishOpts...)
 			}()

--- a/contrib/labstack/echo/echotrace.go
+++ b/contrib/labstack/echo/echotrace.go
@@ -31,9 +31,7 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 		return func(c echo.Context) error {
 			request := c.Request()
 			resource := request.Method + " " + c.Path()
-			opts := []ddtrace.StartSpanOption{
-				tracer.Measured(),
-			}
+			var opts []ddtrace.StartSpanOption
 			if !math.IsNaN(cfg.analyticsRate) {
 				opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 			}

--- a/contrib/net/http/trace.go
+++ b/contrib/net/http/trace.go
@@ -12,6 +12,7 @@ import (
 
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation/httpsec"
 )
@@ -41,7 +42,8 @@ func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, cfg *
 	if cfg == nil {
 		cfg = new(ServeConfig)
 	}
-	span, ctx := httptrace.StartRequestSpan(r, cfg.Service, cfg.Resource, cfg.QueryParams, cfg.SpanOpts...)
+	opts := append(cfg.SpanOpts, tracer.ServiceName(cfg.Service), tracer.ResourceName(cfg.Resource))
+	span, ctx := httptrace.StartRequestSpan(r, cfg.QueryParams, opts...)
 	rw, ddrw := wrapResponseWriter(w)
 	defer func() {
 		httptrace.FinishRequestSpan(span, ddrw.status, cfg.FinishOpts...)

--- a/contrib/net/http/trace.go
+++ b/contrib/net/http/trace.go
@@ -54,6 +54,8 @@ func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, cfg *
 	h.ServeHTTP(rw, r.WithContext(ctx))
 }
 
+// StartRequestSpan starts an HTTP request span with the standard list of HTTP request span tags. URL query parameters
+// are added to the URL tag when queryParams is true. Any further span start option can be added with opts.
 func StartRequestSpan(r *http.Request, service, resource string, queryParams bool, opts ...ddtrace.StartSpanOption) (tracer.Span, context.Context) {
 	path := r.URL.Path
 	if queryParams {
@@ -78,6 +80,8 @@ func StartRequestSpan(r *http.Request, service, resource string, queryParams boo
 	return tracer.StartSpanFromContext(r.Context(), "http.request", opts...)
 }
 
+// FinishRequestSpan finishes the given HTTP request span with the standard list of HTTP request span tags.
+// Any further span finish option can be added with opts.
 func FinishRequestSpan(s tracer.Span, status int, opts ...tracer.FinishOption) {
 	var statusStr string
 	if status == 0 {

--- a/contrib/net/http/trace.go
+++ b/contrib/net/http/trace.go
@@ -8,7 +8,6 @@ package http // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
 //go:generate sh -c "go run make_responsewriter.go | gofmt > trace_gen.go"
 
 import (
-	"fmt"
 	"net/http"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace"
@@ -46,7 +45,7 @@ func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, cfg *
 	}
 	opts := append(cfg.SpanOpts, tracer.ServiceName(cfg.Service), tracer.ResourceName(cfg.Resource))
 	if cfg.QueryParams {
-		opts = append(opts, tracer.Tag(ext.HTTPURL, fmt.Sprintf("%s?%s", r.URL.Path, r.URL.RawQuery)))
+		opts = append(opts, tracer.Tag(ext.HTTPURL, r.URL.Path+"?"+r.URL.RawQuery))
 	}
 	span, ctx := httptrace.StartRequestSpan(r, opts...)
 	rw, ddrw := wrapResponseWriter(w)

--- a/contrib/net/http/trace.go
+++ b/contrib/net/http/trace.go
@@ -38,6 +38,9 @@ type ServeConfig struct {
 // TraceAndServe serves the handler h using the given ResponseWriter and Request, applying tracing
 // according to the specified config.
 func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, cfg *ServeConfig) {
+	if cfg == nil {
+		cfg = new(ServeConfig)
+	}
 	span, ctx := httptrace.StartRequestSpan(r, cfg.Service, cfg.Resource, cfg.QueryParams, cfg.SpanOpts...)
 	rw, ddrw := wrapResponseWriter(w)
 	defer func() {

--- a/contrib/urfave/negroni/negroni.go
+++ b/contrib/urfave/negroni/negroni.go
@@ -29,7 +29,7 @@ func (m *DatadogMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, ne
 	if !math.IsNaN(m.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, m.cfg.analyticsRate))
 	}
-	span, ctx := httptrace.StartRequestSpan(r, false, opts...)
+	span, ctx := httptrace.StartRequestSpan(r, opts...)
 	defer func() {
 		// check if the responseWriter is of type negroni.ResponseWriter
 		var (

--- a/contrib/urfave/negroni/negroni.go
+++ b/contrib/urfave/negroni/negroni.go
@@ -25,7 +25,7 @@ type DatadogMiddleware struct {
 }
 
 func (m *DatadogMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	opts := append(m.cfg.spanOpts, tracer.Measured())
+	opts := m.cfg.spanOpts
 	if !math.IsNaN(m.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, m.cfg.analyticsRate))
 	}

--- a/contrib/urfave/negroni/negroni.go
+++ b/contrib/urfave/negroni/negroni.go
@@ -33,17 +33,17 @@ func (m *DatadogMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, ne
 	defer func() {
 		// check if the responseWriter is of type negroni.ResponseWriter
 		var (
-			status    int
-			withError tracer.FinishOption
+			status int
+			opts   []tracer.FinishOption
 		)
 		responseWriter, ok := w.(negroni.ResponseWriter)
 		if ok {
 			status = responseWriter.Status()
 			if m.cfg.isStatusError(status) {
-				withError = tracer.WithError(fmt.Errorf("%d: %s", status, http.StatusText(status)))
+				opts = []tracer.FinishOption{tracer.WithError(fmt.Errorf("%d: %s", status, http.StatusText(status)))}
 			}
 		}
-		httptrace.FinishRequestSpan(span, status, withError)
+		httptrace.FinishRequestSpan(span, status, opts...)
 	}()
 
 	next(w, r.WithContext(ctx))

--- a/contrib/urfave/negroni/negroni.go
+++ b/contrib/urfave/negroni/negroni.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/urfave/negroni"
 
-	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"

--- a/contrib/urfave/negroni/negroni.go
+++ b/contrib/urfave/negroni/negroni.go
@@ -25,11 +25,11 @@ type DatadogMiddleware struct {
 }
 
 func (m *DatadogMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	opts := m.cfg.spanOpts
+	opts := append(m.cfg.spanOpts, tracer.ServiceName(m.cfg.serviceName), tracer.ResourceName(m.cfg.resourceNamer(r)))
 	if !math.IsNaN(m.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, m.cfg.analyticsRate))
 	}
-	span, ctx := httptrace.StartRequestSpan(r, m.cfg.serviceName, m.cfg.resourceNamer(r), false, opts...)
+	span, ctx := httptrace.StartRequestSpan(r, false, opts...)
 	defer func() {
 		// check if the responseWriter is of type negroni.ResponseWriter
 		var (

--- a/ddtrace/ext/app_types.go
+++ b/ddtrace/ext/app_types.go
@@ -30,7 +30,7 @@ const (
 
 // Span types have similar behaviour to "app types" and help categorize
 // traces in the Datadog application. They can also help fine grain agent
-// level bahviours such as obfuscation and quantization, when these are
+// level behaviours such as obfuscation and quantization, when these are
 // enabled in the agent's configuration.
 const (
 	// SpanTypeWeb marks a span as an HTTP server request.

--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -33,6 +33,9 @@ const (
 	// HTTPURL sets the HTTP URL for a span.
 	HTTPURL = "http.url"
 
+	// HTTPUserAgent is the user agent header value of the HTTP request.
+	HTTPUserAgent = "http.useragent"
+
 	// SpanName is a pseudo-key for setting a span's operation name by means of
 	// a tag. It is mostly here to facilitate vendor-agnostic frameworks like Opentracing
 	// and OpenCensus.

--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -33,9 +33,6 @@ const (
 	// HTTPURL sets the HTTP URL for a span.
 	HTTPURL = "http.url"
 
-	// HTTPUserAgent sets the HTTP user agent tag.
-	HTTPUserAgent = "http.useragent"
-
 	// SpanName is a pseudo-key for setting a span's operation name by means of
 	// a tag. It is mostly here to facilitate vendor-agnostic frameworks like Opentracing
 	// and OpenCensus.

--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -33,6 +33,9 @@ const (
 	// HTTPURL sets the HTTP URL for a span.
 	HTTPURL = "http.url"
 
+	// HTTPUserAgent sets the HTTP user agent tag.
+	HTTPUserAgent = "http.useragent"
+
 	// SpanName is a pseudo-key for setting a span's operation name by means of
 	// a tag. It is mostly here to facilitate vendor-agnostic frameworks like Opentracing
 	// and OpenCensus.


### PR DESCRIPTION
Refactor the start and finish of http request spans into functions
shared across contribs so that the expected set of http request span
tags are properly implemented.

The new standard `http.useragent` is added in this PR as a first example of span tag addition spread out to every HTTP integration.