### PR TITLE
FAQ: Remove go.mod section

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,22 +1,6 @@
 # Frequently Asked Questions (dd-trace-go)
 This document contains answers to questions frequently asked by users. Just because something is listed here doesn't mean it's beyond question, so feel free to open an issue if you want to change or improve any of these things, but this should provide useful information about *how* things are and *why* they are that way.
 
-#### Why does dd-trace-go use go modules in a non-standard way?
-This repository currently takes an [idiosyncratic approach](https://github.com/DataDog/dd-trace-go/issues/810) to using Go modules. You may notice that the `go.mod` file does not list all dependencies of the project, but instead just lists the ones that the core logic depends on (`ddtrace/...`, `profiler/...` and a couple other packages).
-
-As a user of the `dd-trace-go` module, this should be transparent and, if anything, make life easier for you. For those wanting to contribute, this can be confusing and annoying.
-
-The primary reason that we do this is for compatibility. `dd-trace-go` contains many contrib packages for many many libraries, all of which are optional features. If we included all of the dd-trace-go dependencies in the `go.mod` file, users' projects would transitively include dependencies for multiple web frameworks, grpc, sql libraries, redis, and lots of other stuff. That's bothersome enough, but worse is that users may end up having versions of libraries forcibly updated, even when they're not using integrations for those libraries. If a user wanted to include `dd-trace-go` to trace their web router but was using an old version of `go-redis` or somesuch, they would be forced to update, even if they don't want to trace `go-redis` and `dd-trace-go` doesn't actually need it. The more integrations we include in `dd-trace-go`, the more likely this situation becomes when we add all dependencies into the `go.mod` file.
-
-Another reason is that we can't. Due to some of the projects we integrate with breaking semantic versioning, it's not possible for us to include all the required dependencies and versions, since we need to depend on multiple, incompatible minor versions of some packages, namely google.golang.org/grpc (See: https://github.com/grpc/grpc-go/issues/3726)
-
-The way forward is through submodules, allowing us to have multiple dependency sets inside `dd-trace-go` and only including what's actually necessary in a user's application. Unfortunately, a prerequisite for this is to get away from `gopkg.in`, which does not support submodules.
-
-Please follow: [848](https://github.com/DataDog/dd-trace-go/issues/848) and [922](https://github.com/DataDog/dd-trace-go/pull/922)
-
-Note also that the [Contribution Guidelines](https://github.com/DataDog/dd-trace-go/blob/v1/CONTRIBUTING.md#go-modules) contain information on working with this setup.
-
-
 #### Why do client integration spans not use the global service name?
 Integrations that are considered *clients* (http clients, grpc clients, sql clients) do **not** use the globally-configured service name. This is by design and is a product-level decision that spans across all the languages' tracers. This is likely to segregate the time spent actually doing the work of the service from the time waiting for another service (i.e. waiting on a web server to return a response).
 


### PR DESCRIPTION
Remove section obsoleted by https://github.com/DataDog/dd-trace-go/pull/1188