### PR TITLE
profiler: disable TestStopLatency

### DIFF
--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -184,6 +184,7 @@ func TestStartStopIdempotency(t *testing.T) {
 // TestStopLatency tries to make sure that calling Stop() doesn't hang, i.e.
 // that ongoing profiling or upload operations are immediately canceled.
 func TestStopLatency(t *testing.T) {
+	t.Skip("broken test, see issue #1294")
 	p, err := newProfiler(
 		WithURL("http://invalid.invalid/"),
 		WithPeriod(1000*time.Millisecond),


### PR DESCRIPTION
The test needs to be re-evaluated as it should never have passed in the first place. See issue #1294.