### PR TITLE
profiler: rename pid tag to process_id

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -204,7 +204,7 @@ func defaultConfig() (*config, error) {
 		mutexFraction:     DefaultMutexFraction,
 		uploadTimeout:     DefaultUploadTimeout,
 		maxGoroutinesWait: 1000, // arbitrary value, should limit STW to ~30ms
-		tags:              []string{fmt.Sprintf("pid:%d", os.Getpid())},
+		tags:              []string{fmt.Sprintf("process_id:%d", os.Getpid())},
 		deltaProfiles:     internal.BoolEnv("DD_PROFILING_DELTA", true),
 		logStartup:        true,
 	}

--- a/profiler/upload_test.go
+++ b/profiler/upload_test.go
@@ -71,7 +71,7 @@ func TestTryUpload(t *testing.T) {
 		"env:my-env",
 		"tag1:1",
 		"tag2:2",
-		fmt.Sprintf("pid:%d", os.Getpid()),
+		fmt.Sprintf("process_id:%d", os.Getpid()),
 		fmt.Sprintf("profiler_version:%s", version.Tag),
 		fmt.Sprintf("runtime_version:%s", strings.TrimPrefix(runtime.Version(), "go")),
 		fmt.Sprintf("runtime_compiler:%s", runtime.Compiler),


### PR DESCRIPTION
The profiler is tagging profiles with the "pid" tag whereas other Datadog
products use a different tag – "process_id".

Based on internal discussions, we decided to align on "process_id".

See PROF-5111 for more details.