### PR TITLE
tracer: add use UDS if the environment variable is available

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -223,6 +223,9 @@ func newConfig(opts ...StartOption) *config {
 		// See: https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html
 		c.logToStdout = true
 	}
+	if v := os.Getenv("DD_APM_RECEIVER_SOCKET"); v != "" {
+		WithUDS(v)(c)
+	}
 	c.logStartup = internal.BoolEnv("DD_TRACE_STARTUP_LOGS", true)
 	c.runtimeMetrics = internal.BoolEnv("DD_RUNTIME_METRICS_ENABLED", false)
 	c.debug = internal.BoolEnv("DD_TRACE_DEBUG", false)

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -226,6 +226,7 @@ func newConfig(opts ...StartOption) *config {
 	if v := os.Getenv("DD_APM_RECEIVER_SOCKET"); v != "" {
 		WithUDS(v)(c)
 	}
+	
 	c.logStartup = internal.BoolEnv("DD_TRACE_STARTUP_LOGS", true)
 	c.runtimeMetrics = internal.BoolEnv("DD_RUNTIME_METRICS_ENABLED", false)
 	c.debug = internal.BoolEnv("DD_TRACE_DEBUG", false)

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -223,10 +223,11 @@ func newConfig(opts ...StartOption) *config {
 		// See: https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html
 		c.logToStdout = true
 	}
-	if v := os.Getenv("DD_APM_RECEIVER_SOCKET"); v != "" {
-		WithUDS(v)(c)
+	if _, err := os.Stat(defaultSocketAPM); err == nil {
+		// Use UDS if the default socket file is available
+		WithUDS(defaultSocketAPM)(c)
 	}
-	
+
 	c.logStartup = internal.BoolEnv("DD_TRACE_STARTUP_LOGS", true)
 	c.runtimeMetrics = internal.BoolEnv("DD_RUNTIME_METRICS_ENABLED", false)
 	c.debug = internal.BoolEnv("DD_TRACE_DEBUG", false)


### PR DESCRIPTION
Rather than manually specifying "WithUds" in our client startup options like this:
```goLang
func (b *Bootstrap) startTracingDatadog(ctx context.Context) (tracetools.Span, context.Context, stopper) {
	opts := []tracer.StartOption{
		tracer.WithServiceName("buildkite_agent"),
		tracer.WithSampler(tracer.NewAllSampler()),
		tracer.WithAnalytics(true),
	}

	if sock := os.Getenv("DD_APM_RECEIVER_SOCKET"); sock != "" {
		opts = append(opts, tracer.WithUDS(sock))
	}

	// ... rest of the tracing setup
}
```

This feature has `dd-trace-go`  handle the Datadog environment variable and automatically setup `withUDS` if the variable is set.
This replicates the functionality of the Ruby, C++, and Python Datadog clients.