### PR TITLE
[gocql] consider ErrNotFound as an acceptable error

### DIFF
--- a/contrib/gocql/gocql/gocql.go
+++ b/contrib/gocql/gocql/gocql.go
@@ -111,6 +111,18 @@ func (tq *Query) newChildSpan(ctx context.Context) ddtrace.Span {
 }
 
 func (tq *Query) finishSpan(span ddtrace.Span, err error) {
+	// ErrNotFound is technically an error from gocql point of view.
+	//
+	// However, it is returned when "no data is available", even if
+	// the request was perfectly correct and executed well. It is
+	// only a marker of "zero rows returned".
+	//
+	// So APM graphs/data can expose a very high error rate if queries
+	// happen to try and select data which is just not there.
+	if err == gocql.ErrNotFound {
+		err = nil
+	}
+
 	if tq.params.config.noDebugStack {
 		span.Finish(tracer.WithError(err), tracer.NoDebugStack())
 	} else {
@@ -259,6 +271,11 @@ func (tb *Batch) newChildSpan(ctx context.Context) ddtrace.Span {
 }
 
 func (tb *Batch) finishSpan(span ddtrace.Span, err error) {
+	// ErrNotFound only means 0 rows found matching the selector.
+	if err == gocql.ErrNotFound {
+		err = nil
+	}
+
 	if tb.params.config.noDebugStack {
 		span.Finish(tracer.WithError(err), tracer.NoDebugStack())
 	} else {


### PR DESCRIPTION
This is an opinionated change: what I have found is that some services report a super high level of errors, when it's only queries returning no data because the selectors do not match. As show in the example, if you just `SELECT ...` something that is not in the DB -> returns as an error.

This only happens when using `Scan` though, using an iterator, the "problem" does not surface.

The patch removes the error annotation from spans, if the error is `gocql.ErrNotFound`. Which is something good, I think, it is interesting to have it as an error when calling `Scan` because, at some point, there would be no other way to figure out that the data is not there. Maybe the problem could be solved by an API that would return `(bool, error)` with `true, nil` if success, `false, nil` if success but no data and `false, err` when it's a true error. In any case we can not change the prototype, but I think there's something around those lines.

The patch would affect existing services reporting Cassandra errors, and very likely "hide" the fact that some requests return no data. Again, I think it's fine to `SELECT` and have zero rows, not something you want to alert on.