### PR TITLE
ddtrace/tracer: increase small timeout to avoid flaky tests.

### DIFF
--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -65,7 +65,7 @@ func TestMain(m *testing.M) {
 }
 
 func (t *tracer) awaitPayload(tst *testing.T, n int) {
-	timeout := time.After(200 * time.Millisecond * timeMultiplicator)
+	timeout := time.After(time.Second * timeMultiplicator)
 loop:
 	for {
 		select {
@@ -1520,7 +1520,7 @@ func startTestTracer(t interface {
 			tick <- time.Now()
 			return
 		}
-		d := 200 * time.Millisecond * timeMultiplicator
+		d := time.Second * timeMultiplicator
 		expire := time.After(d)
 	loop:
 		for {


### PR DESCRIPTION
Apparently 200ms is not enough in all cases for async things to happen,
resulting in flaky tests. This increases the timeout to one second. If it
is not enough this can be increased more. Since these are not performance
tests we don't really care how long it takes.

Fixes #1324