### PR TITLE
contrib/internal/httptrace: record errors in span tags while retrieving client IP

### DIFF
--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -46,6 +46,7 @@ var (
 // http.useragent). Any further span start option can be added with opts.
 func StartRequestSpan(r *http.Request, opts ...ddtrace.StartSpanOption) (tracer.Span, context.Context) {
 	// Append our span options before the given ones so that the caller can "overwrite" them.
+	// TODO(): rework span start option handling (https://github.com/DataDog/dd-trace-go/issues/1352)
 	opts = append([]ddtrace.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeWeb),
 		tracer.Tag(ext.HTTPMethod, r.Method),

--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -101,13 +101,10 @@ func genClientIPSpanTags(r *http.Request) []ddtrace.StartSpanOption {
 		}
 		return tags
 	}
-	sb := strings.Builder{}
 	for _, hdr := range matches {
 		tags = append(tags, tracer.Tag(ext.HTTPRequestHeaders+"."+hdr, ip))
-		sb.WriteString(hdr + ",")
 	}
-	hdrList := sb.String()
-	tags = append(tags, tracer.Tag(ext.MultipleIPHeaders, hdrList[:len(hdrList)-1]))
+	tags = append(tags, tracer.Tag(ext.MultipleIPHeaders, strings.Join(matches, ",")))
 	return tags
 }
 

--- a/contrib/internal/httptrace/httptrace_test.go
+++ b/contrib/internal/httptrace/httptrace_test.go
@@ -36,7 +36,7 @@ type IPTestCase struct {
 	remoteAddr      string
 	headers         map[string]string
 	expectedIP      netaddr.IP
-	expectedMatches map[string]string
+	expectedMatches []string
 	clientIPHeader  string
 }
 
@@ -111,13 +111,13 @@ func genIPTestCases() []IPTestCase {
 			name:            "ipv4-multi-header-1",
 			headers:         map[string]string{"x-forwarded-for": "127.0.0.1", "forwarded-for": ipv4Global},
 			expectedIP:      netaddr.IP{},
-			expectedMatches: map[string]string{"x-forwarded-for": "127.0.0.1", "forwarded-for": ipv4Global},
+			expectedMatches: []string{"x-forwarded-for", "forwarded-for"},
 		},
 		{
 			name:            "ipv4-multi-header-2",
 			headers:         map[string]string{"forwarded-for": ipv4Global, "x-forwarded-for": "127.0.0.1"},
 			expectedIP:      netaddr.IP{},
-			expectedMatches: map[string]string{"x-forwarded-for": "127.0.0.1", "forwarded-for": ipv4Global},
+			expectedMatches: []string{"x-forwarded-for", "forwarded-for"},
 		},
 		{
 			name:       "invalid-ipv6",
@@ -133,13 +133,13 @@ func genIPTestCases() []IPTestCase {
 			name:            "ipv6-multi-header-1",
 			headers:         map[string]string{"x-forwarded-for": "2001:0db8:2001:zzzz::", "forwarded-for": ipv6Global},
 			expectedIP:      netaddr.IP{},
-			expectedMatches: map[string]string{"x-forwarded-for": "2001:0db8:2001:zzzz::", "forwarded-for": ipv6Global},
+			expectedMatches: []string{"x-forwarded-for", "forwarded-for"},
 		},
 		{
 			name:            "ipv6-multi-header-2",
 			headers:         map[string]string{"forwarded-for": ipv6Global, "x-forwarded-for": "2001:0db8:2001:zzzz::"},
 			expectedIP:      netaddr.IP{},
-			expectedMatches: map[string]string{"x-forwarded-for": "2001:0db8:2001:zzzz::", "forwarded-for": ipv6Global},
+			expectedMatches: []string{"x-forwarded-for", "forwarded-for"},
 		},
 	}, tcs...)
 	tcs = append([]IPTestCase{
@@ -183,7 +183,6 @@ func TestIPHeaders(t *testing.T) {
 			ip, matches := getClientIP(&r)
 			require.Equal(t, tc.expectedIP, ip)
 			require.Equal(t, tc.expectedMatches, matches)
-			genClientIPSpanTags(&http.Request{Header: header, RemoteAddr: tc.remoteAddr})
 		})
 	}
 }

--- a/contrib/internal/httptrace/httptrace_test.go
+++ b/contrib/internal/httptrace/httptrace_test.go
@@ -193,6 +193,9 @@ func TestIPHeaders(t *testing.T) {
 				require.Nil(t, cfg.Tags[ext.HTTPClientIP])
 				if tc.multiHeaders != "" {
 					require.Equal(t, tc.multiHeaders, cfg.Tags[ext.MultipleIPHeaders])
+					for hdr, ip := range tc.headers {
+						require.Equal(t, ip, cfg.Tags[ext.HTTPRequestHeaders+"."+hdr])
+					}
 				}
 			}
 		})

--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -42,6 +42,16 @@ const (
 	// HTTPClientIP sets the HTTP client IP tag.
 	HTTPClientIP = "http.client_ip"
 
+	// MultipleIPHeaders sets the multiple ip header tag used internally to tell the backend an error occurred when
+	// retrieving an HTTP request client IP.
+	// See https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2118779066/Client+IP+addresses+resolution
+	MultipleIPHeaders = "_dd.multiple-ip-headers"
+
+	// HTTPRequestHeaders sets the HTTP request headers partial tag
+	// This tag is meant to be composed, i.e http.request.headers.headerX, http.request.headers.headerY, etc...
+	// See https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2302444638/DD+TRACE+HEADER+TAGS
+	HTTPRequestHeaders = "http.request.headers"
+
 	// SpanName is a pseudo-key for setting a span's operation name by means of
 	// a tag. It is mostly here to facilitate vendor-agnostic frameworks like Opentracing
 	// and OpenCensus.


### PR DESCRIPTION
This change follows the RFC update: https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2118779066/Client+IP+addresses+resolution.
In case multiple IP related headers are found in a request, we need to record information for the backend in the span tags.

Added tags:

- http.request.headers.*
- _dd.multiple-ip-headers

Changes:
- Change the behaviour of `getClientIP` so that it builds the list of IP headers encountered while retrieving the client IP.
- If the list compiled by `getClientIP` holds more than one element, the new tags are set with information from this list
- `genClientIPSpanTags` abstracts this decision logic and returns a map of tag key/values to set for the span
- Add an env var to disable client ip collection altogether