### PR TITLE
profiler: remove API key reference from package doc

### DIFF
--- a/profiler/doc.go
+++ b/profiler/doc.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
-// Package profiler periodically collects and sends profiles to the Datadog API. Use
-// Start to start the profiler. An API key needs to be specified by means of the WithAPIKey
-// option.
+// Package profiler periodically collects and sends profiles to the Datadog API.
+// Use Start to start the profiler.
 package profiler // import "gopkg.in/DataDog/dd-trace-go.v1/profiler"


### PR DESCRIPTION
Going through the agent is the preferred way to upload profiles now, not going
directly to the API.
