### PR TITLE
README: reminder to update public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Datadog APM for Go is built upon dependencies defined in specific versions of th
 | <span id="support-legacy">Legacy</span>                | Legacy implementation. May have limited function, but no maintenance provided. [Contact our customer support team for special requests.](https://www.datadoghq.com/support/) |
 
 ### Supported Versions
-
+<!-- NOTE: When updating the below section ensure you update the minimum supported version listed in the public docs here: https://docs.datadoghq.com/tracing/setup_overview/setup/go/?tab=containers#compatibility-requirements -->
 | **Go Version** | **Support level**                   |
 |----------------|-------------------------------------|
 | 1.18           | [GA](#support-ga)                   |
@@ -45,6 +45,7 @@ Datadog APM for Go is built upon dependencies defined in specific versions of th
 | 1.16           | [Maintenance](#support-maintenance) |
 
 * Datadog's Trace Agent >= 5.21.1
+
 
 #### Package Versioning
 


### PR DESCRIPTION
Adds a comment reminder (so users won't see it, but editors will) to update the public documentation when updating the supported versions