### PR TITLE
contrib/labstack/echo.v4: add WithIgnoreRequest

### DIFF
--- a/contrib/labstack/echo.v4/echotrace.go
+++ b/contrib/labstack/echo.v4/echotrace.go
@@ -33,7 +33,6 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 	}
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-
 			// If we have an ignoreRequestFunc, use it to see if we proceed with tracing
 			if cfg.ignoreRequestFunc != nil && cfg.ignoreRequestFunc(c) {
 				if err := next(c); err != nil {

--- a/contrib/labstack/echo.v4/echotrace.go
+++ b/contrib/labstack/echo.v4/echotrace.go
@@ -34,8 +34,8 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 
-			// If we have a skip function, use it to see if we proceed with tracing
-			if cfg.skipFunc != nil && cfg.skipFunc(c) {
+			// If we have an ignoreRequestFunc, use it to see if we proceed with tracing
+			if cfg.ignoreRequestFunc != nil && cfg.ignoreRequestFunc(c) {
 				if err := next(c); err != nil {
 					c.Error(err)
 					return err

--- a/contrib/labstack/echo.v4/echotrace.go
+++ b/contrib/labstack/echo.v4/echotrace.go
@@ -33,6 +33,16 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 	}
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
+
+			// If we have a skip function, use it to see if we proceed with tracing
+			if cfg.skipFunc != nil && cfg.skipFunc(c) {
+				if err := next(c); err != nil {
+					c.Error(err)
+					return err
+				}
+				return nil
+			}
+
 			request := c.Request()
 			route := c.Path()
 			resource := request.Method + " " + route

--- a/contrib/labstack/echo.v4/echotrace_test.go
+++ b/contrib/labstack/echo.v4/echotrace_test.go
@@ -272,18 +272,18 @@ func TestNoDebugStack(t *testing.T) {
 	assert.Equal("<debug stack disabled>", span.Tag(ext.ErrorStack))
 }
 
-func TestSkipFunc(t *testing.T) {
+func TestIgnoreRequestFunc(t *testing.T) {
 	assert := assert.New(t)
 	mt := mocktracer.Start()
 	defer mt.Stop()
 	var called, traced bool
 
 	// setup
-	skipFunc := func(c echo.Context) bool {
+	ignoreRequestFunc := func(c echo.Context) bool {
 		return true
 	}
 	router := echo.New()
-	router.Use(Middleware(WithIgnoreRequest(skipFunc)))
+	router.Use(Middleware(WithIgnoreRequest(ignoreRequestFunc)))
 
 	// a handler with an error and make the requests
 	router.GET("/err", func(c echo.Context) error {

--- a/contrib/labstack/echo.v4/echotrace_test.go
+++ b/contrib/labstack/echo.v4/echotrace_test.go
@@ -283,7 +283,7 @@ func TestSkipFunc(t *testing.T) {
 		return true
 	}
 	router := echo.New()
-	router.Use(Middleware(WithSkipFunction(skipFunc)))
+	router.Use(Middleware(WithIgnoreRequest(skipFunc)))
 
 	// a handler with an error and make the requests
 	router.GET("/err", func(c echo.Context) error {

--- a/contrib/labstack/echo.v4/option.go
+++ b/contrib/labstack/echo.v4/option.go
@@ -8,6 +8,8 @@ package echo
 import (
 	"math"
 
+	"github.com/labstack/echo/v4"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 )
 
@@ -15,10 +17,14 @@ type config struct {
 	serviceName   string
 	analyticsRate float64
 	noDebugStack  bool
+	skipFunc      SkipFunction
 }
 
 // Option represents an option that can be passed to Middleware.
 type Option func(*config)
+
+// SkipFunction detmines if tracing will be skipped for a request.
+type SkipFunction func(c echo.Context) bool
 
 func defaults(cfg *config) {
 	cfg.serviceName = "echo"
@@ -64,5 +70,13 @@ func WithAnalyticsRate(rate float64) Option {
 func NoDebugStack() Option {
 	return func(cfg *config) {
 		cfg.noDebugStack = true
+	}
+}
+
+// WithSkipFunction sets a function which determines if tracing will be
+// skipped for a given request.
+func WithSkipFunction(skipFunc SkipFunction) Option {
+	return func(cfg *config) {
+		cfg.skipFunc = skipFunc
 	}
 }

--- a/contrib/labstack/echo.v4/option.go
+++ b/contrib/labstack/echo.v4/option.go
@@ -73,9 +73,9 @@ func NoDebugStack() Option {
 	}
 }
 
-// WithSkipFunction sets a function which determines if tracing will be
+// WithIgnoreRequest sets a function which determines if tracing will be
 // skipped for a given request.
-func WithSkipFunction(skipFunc SkipFunction) Option {
+func WithIgnoreRequest(skipFunc SkipFunction) Option {
 	return func(cfg *config) {
 		cfg.skipFunc = skipFunc
 	}

--- a/contrib/labstack/echo.v4/option.go
+++ b/contrib/labstack/echo.v4/option.go
@@ -14,17 +14,17 @@ import (
 )
 
 type config struct {
-	serviceName   string
-	analyticsRate float64
-	noDebugStack  bool
-	skipFunc      SkipFunction
+	serviceName       string
+	analyticsRate     float64
+	noDebugStack      bool
+	ignoreRequestFunc IgnoreRequestFunc
 }
 
 // Option represents an option that can be passed to Middleware.
 type Option func(*config)
 
-// SkipFunction determines if tracing will be skipped for a request.
-type SkipFunction func(c echo.Context) bool
+// IgnoreRequestFunc determines if tracing will be skipped for a request.
+type IgnoreRequestFunc func(c echo.Context) bool
 
 func defaults(cfg *config) {
 	cfg.serviceName = "echo"
@@ -75,8 +75,8 @@ func NoDebugStack() Option {
 
 // WithIgnoreRequest sets a function which determines if tracing will be
 // skipped for a given request.
-func WithIgnoreRequest(skipFunc SkipFunction) Option {
+func WithIgnoreRequest(ignoreRequestFunc IgnoreRequestFunc) Option {
 	return func(cfg *config) {
-		cfg.skipFunc = skipFunc
+		cfg.ignoreRequestFunc = ignoreRequestFunc
 	}
 }

--- a/contrib/labstack/echo.v4/option.go
+++ b/contrib/labstack/echo.v4/option.go
@@ -23,7 +23,7 @@ type config struct {
 // Option represents an option that can be passed to Middleware.
 type Option func(*config)
 
-// SkipFunction detmines if tracing will be skipped for a request.
+// SkipFunction determines if tracing will be skipped for a request.
 type SkipFunction func(c echo.Context) bool
 
 func defaults(cfg *config) {


### PR DESCRIPTION
contrib/labstack/echo.v4: introducing a SkipFunction option to selectively bypass tracing

This allows the user to provide a function which will make the decision on whether to trace a request, based on its echo.Context. This is of use to me because I'd like to stop tracing load-balancer checks every 15s.

I can see that there has been some interest in this feature for other frameworks:
- [net/http](https://github.com/DataDog/dd-trace-go/issues/947)
- [gorilla/mux](https://github.com/DataDog/dd-trace-go/issues/790)
- [labstack/echo](https://github.com/DataDog/dd-trace-go/issues/735)