### PR TITLE
circleci: don't upload CI results without an API key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,13 +351,17 @@ commands:
       - run:
           name: Install datadog-ci binary
           command: |
-            curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/tmp/datadog-ci" && chmod +x "/tmp/datadog-ci"
+            if [ -n "${DATADOG_API_KEY}" ]; then
+              curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/tmp/datadog-ci" && chmod +x "/tmp/datadog-ci"
+            fi
           when: always
 
       - run:
           name: Upload test result to datadog ci-app
           command: |
-            DATADOG_API_KEY=${DATADOG_API_KEY} /tmp/datadog-ci junit upload --service << parameters.ci-app-service-name >> << parameters.test-result-path >>
+            if [ -n "${DATADOG_API_KEY}" ]; then
+              DATADOG_API_KEY=${DATADOG_API_KEY} /tmp/datadog-ci junit upload --service << parameters.ci-app-service-name >> << parameters.test-result-path >>
+            fi
           when: always
 
 workflows:


### PR DESCRIPTION
Pull requests from forks (as opposed to branches within this repository)
don't have access to secrets. This means they can't access the API key
needed to upload CI results to the Datadog CI app. This causes CI
pipelines from external contributors to fail, even if the actual tests
pass. Only attempt the CI upload if we actually have an API key.
