### PR TITLE
ddtrace/tracer: fix race in SetOperationName

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -376,7 +376,13 @@ func (s *span) Finish(opts ...ddtrace.FinishOption) {
 func (s *span) SetOperationName(operationName string) {
 	s.Lock()
 	defer s.Unlock()
-
+	// We don't lock spans when flushing, so we could have a data race when
+	// modifying a span as it's being flushed. This protects us against that
+	// race, since spans are marked `finished` before we flush them.
+	if s.finished {
+		// already finished
+		return
+	}
 	s.Name = operationName
 }
 

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -549,6 +549,7 @@ func TestSpanModifyWhileFlushing(t *testing.T) {
 		span.Finish()
 		// It doesn't make much sense to update the span after it's been finished,
 		// but an error in a user's code could lead to this.
+		span.SetOperationName("race_test")
 		span.SetTag("race_test", "true")
 		span.SetTag("race_test2", 133.7)
 		span.SetTag("race_test3", 133.7)


### PR DESCRIPTION
Because we don't lock spans when flushing, a race condition occurs when `SetOperationName` is called on a finished span. Although this should not happen, this PR defend's against it in the case of an error in user code. 
With the fix, calling `SetOperationName` on a finished span is a no-op.

Test: Without the fix, `TestSpanModifyWhileFlushing` fails when run with the `-race` flag.