### PR TITLE
profiler: don't clobber tags when uploading profiles or metrics (#1377)

### DIFF
--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -192,7 +192,9 @@ func collectGenericProfile(name string, delta *pprofutils.Delta) func(p *profile
 
 		start := time.Now()
 		delta, err := p.deltaProfile(name, delta, data, extra...)
-		tags := append(p.cfg.tags, fmt.Sprintf("profile_type:%s", name))
+		tags := make([]string, len(p.cfg.tags), len(p.cfg.tags)+1)
+		copy(tags, p.cfg.tags)
+		tags = append(tags, fmt.Sprintf("profile_type:%s", name))
 		p.cfg.statsd.Timing("datadog.profiling.go.delta_time", time.Since(start), tags, 1)
 		if err != nil {
 			return nil, fmt.Errorf("delta profile error: %s", err)
@@ -260,7 +262,9 @@ func (p *profiler) runProfile(pt ProfileType) ([]*profile, error) {
 		return nil, err
 	}
 	end := now()
-	tags := append(p.cfg.tags, pt.Tag())
+	tags := make([]string, len(p.cfg.tags), len(p.cfg.tags)+1)
+	copy(tags, p.cfg.tags)
+	tags = append(tags, pt.Tag())
 	filename := t.Filename
 	// TODO(fg): Consider making Collect() return the filename.
 	if p.cfg.deltaProfiles && t.SupportsDelta {

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -240,7 +240,9 @@ func (p *profiler) collect(ticker <-chan time.Time) {
 					profs, err := p.runProfile(t)
 					if err != nil {
 						log.Error("Error getting %s profile: %v; skipping.", t, err)
-						p.cfg.statsd.Count("datadog.profiling.go.collect_error", 1, append(p.cfg.tags, t.Tag()), 1)
+						tags := make([]string, len(p.cfg.tags), len(p.cfg.tags)+1)
+						copy(tags, p.cfg.tags)
+						p.cfg.statsd.Count("datadog.profiling.go.collect_error", 1, append(tags, t.Tag()), 1)
 					}
 					mu.Lock()
 					defer mu.Unlock()

--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -68,7 +68,9 @@ func (e retriableError) Error() string { return e.err.Error() }
 // doRequest makes an HTTP POST request to the Datadog Profiling API with the
 // given profile.
 func (p *profiler) doRequest(bat batch) error {
-	tags := append(p.cfg.tags,
+	tags := make([]string, len(p.cfg.tags))
+	copy(tags, p.cfg.tags)
+	tags = append(tags,
 		fmt.Sprintf("service:%s", p.cfg.service),
 		fmt.Sprintf("env:%s", p.cfg.env),
 	)


### PR DESCRIPTION
This is a cherry-pick of hotfix v1.39.1

There are multiple places where additional tags are appended to the tag
slice (p.cfg.tags) for uploading the profiles or emitting statsd
metrics. All of these appends are writing to the same backing memory,
causing the tags after the user-supplied tags to be clobbered. For
example:

	// function 1
	tags := append(p.cfg.tag, "service:foobar")
	// function 2
	tags := append(p.cfg.tag, "profile_type:cpu")

Function 2 could override the "service:foobar" tag added by function 1
with the "profile_type:cpu" if the two functions run concurrently.

This manifests as the "service:<name>" tag getting overwritten in user
profiles. The agent sees the missing tag and adds
"service:unnamed-service".

Instead, we should always use a new copy of the tags slice if we want to
add more tags.

Adds a regression tests which starts a profiler with some custom tags
and checks the uploaded tags several times to see that they aren't clobbered.
