### PR TITLE
profiler: collect metrics, goroutine wait profiles at end of profiling period

### DIFF
--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -133,6 +133,8 @@ var profileTypes = map[ProfileType]profileType{
 				return nil, fmt.Errorf("skipping goroutines wait profile: %d goroutines exceeds DD_PROFILING_WAIT_PROFILE_MAX_GOROUTINES limit of %d", n, p.cfg.maxGoroutinesWait)
 			}
 
+			p.interruptibleSleep(p.cfg.period)
+
 			var (
 				now   = now()
 				text  = &bytes.Buffer{}
@@ -150,6 +152,7 @@ var profileTypes = map[ProfileType]profileType{
 		Filename: "metrics.json",
 		Collect: func(p *profiler) ([]byte, error) {
 			var buf bytes.Buffer
+			p.interruptibleSleep(p.cfg.period)
 			err := p.met.report(now(), &buf)
 			return buf.Bytes(), err
 		},

--- a/profiler/profile_test.go
+++ b/profiler/profile_test.go
@@ -225,7 +225,7 @@ main.main()
 ...additional frames elided...
 `
 
-		p, err := unstartedProfiler()
+		p, err := unstartedProfiler(WithPeriod(10 * time.Millisecond))
 		p.testHooks.lookupProfile = func(_ string, w io.Writer, _ int) error {
 			_, err := w.Write([]byte(sample))
 			return err


### PR DESCRIPTION
After moving to collecting profiles concurrently, our intention was to
preserve the previous behavior where all profiles were collected at the
end of the profiling period so that they all cover the same time span of
program execution. We missed the metrics profile (which collected at the
beginning and sometimes overlapped with uploading, see PR #1377) and
the goroutine wait profile, so this commit adds (interruptible) sleeps
to collect those profiles at the end of the profiling period.
