### PR TITLE
profiler: make configured tags read-only

### DIFF
--- a/profiler/internal/immutable/stringslice.go
+++ b/profiler/internal/immutable/stringslice.go
@@ -13,7 +13,7 @@ type StringSlice struct {
 	s []string
 }
 
-// NewStringSlice wraps a copy of the input slice
+// NewStringSlice creates a StringSlice from a copy of the input slice
 func NewStringSlice(s []string) StringSlice {
 	return StringSlice{s: append([]string{}, s...)}
 }

--- a/profiler/internal/immutable/stringslice.go
+++ b/profiler/internal/immutable/stringslice.go
@@ -7,7 +7,8 @@
 package immutable
 
 // StringSlice is a wrapped slice which cannot be modified and must be copied to
-// access. The zero value for a StringSlice is ready to use
+// access. The zero value for a StringSlice is ready to use. All StringSlice
+// methods are safe to call from multiple goroutines concurrently.
 type StringSlice struct {
 	s []string
 }

--- a/profiler/internal/immutable/stringslice.go
+++ b/profiler/internal/immutable/stringslice.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+// Package immutable provides read-only types
+package immutable
+
+// StringSlice is a wrapped slice which cannot be modified and must be copied to
+// access. The zero value for a StringSlice is ready to use
+type StringSlice struct {
+	s []string
+}
+
+// NewStringSlice wraps a copy of the input slice
+func NewStringSlice(s []string) StringSlice {
+	return StringSlice{s: append([]string{}, s...)}
+}
+
+// Get returns a copy of the wrapped slice
+func (s StringSlice) Get() []string {
+	return append([]string{}, s.s...)
+}
+
+// Append creates a new StringSlice by concatenating the given strings to a copy
+// of the slice wrapped by f.
+func (s StringSlice) Append(strings ...string) StringSlice {
+	dup := make([]string, len(s.s)+len(strings))
+	copy(dup, s.s)
+	copy(dup[len(s.s):], strings)
+	return StringSlice{s: dup}
+}

--- a/profiler/internal/immutable/stringslice.go
+++ b/profiler/internal/immutable/stringslice.go
@@ -6,8 +6,8 @@
 // Package immutable provides read-only types
 package immutable
 
-// StringSlice is a wrapped slice which cannot be modified and must be copied to
-// access. The zero value for a StringSlice is ready to use. All StringSlice
+// StringSlice holds a slice which cannot be modified and must be copied to
+// access. The zero value for a StringSlice is an empty slice (not nil). All StringSlice
 // methods are safe to call from multiple goroutines concurrently.
 type StringSlice struct {
 	s []string
@@ -18,13 +18,13 @@ func NewStringSlice(s []string) StringSlice {
 	return StringSlice{s: append([]string{}, s...)}
 }
 
-// Get returns a copy of the wrapped slice
-func (s StringSlice) Get() []string {
+// Slice returns a copy of the slice held by s
+func (s StringSlice) Slice() []string {
 	return append([]string{}, s.s...)
 }
 
 // Append creates a new StringSlice by concatenating the given strings to a copy
-// of the slice wrapped by f.
+// of the slice held by s.
 func (s StringSlice) Append(strings ...string) StringSlice {
 	dup := make([]string, len(s.s)+len(strings))
 	copy(dup, s.s)

--- a/profiler/internal/immutable/stringslice_test.go
+++ b/profiler/internal/immutable/stringslice_test.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package immutable_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/DataDog/dd-trace-go.v1/profiler/internal/immutable"
+)
+
+func TestStringSlice(t *testing.T) {
+	tags := []string{"service:foo", "env:bar", "ggthingy:baz"}
+	f := immutable.NewStringSlice(tags)
+	assert.Equal(t, tags, f.Get())
+}
+
+func TestStringSliceModify(t *testing.T) {
+	t.Run("modify-original", func(t *testing.T) {
+		tags := []string{"service:foo", "env:bar", "thingy:baz"}
+		f := immutable.NewStringSlice(tags)
+		tags[0] = "service:different"
+		assert.Equal(t, "service:foo", f.Get()[0])
+		t.Log(f.Get())
+		t.Log(tags)
+	})
+
+	t.Run("modify-copy", func(t *testing.T) {
+		tags := []string{"service:foo", "env:bar", "thingy:baz"}
+		f := immutable.NewStringSlice(tags)
+		dup := f.Get()
+		dup[0] = "service:different"
+		assert.Equal(t, "service:foo", tags[0])
+	})
+
+	t.Run("modify-2-copies", func(t *testing.T) {
+		tags := []string{"service:foo", "env:bar", "thingy:baz"}
+		f := immutable.NewStringSlice(tags)
+		dup := f.Get()
+		dup[0] = "service:different"
+		dup2 := f.Get()
+		dup2[0] = "service:alsodifferent"
+		assert.Equal(t, "service:foo", tags[0])
+		assert.Equal(t, "service:different", dup[0])
+		assert.Equal(t, "service:alsodifferent", dup2[0])
+	})
+
+	t.Run("append-duplicates", func(t *testing.T) {
+		var f immutable.StringSlice
+		before := f.Get()
+		g := f.Append("foo:bar")
+		h := f.Append("other:tag")
+		after := g.Get()
+		after2 := h.Get()
+		assert.NotEqual(t, before, after)
+		assert.NotEqual(t, before, after2)
+		assert.NotEqual(t, after, after2)
+	})
+}

--- a/profiler/internal/immutable/stringslice_test.go
+++ b/profiler/internal/immutable/stringslice_test.go
@@ -16,7 +16,7 @@ import (
 func TestStringSlice(t *testing.T) {
 	tags := []string{"service:foo", "env:bar", "ggthingy:baz"}
 	f := immutable.NewStringSlice(tags)
-	assert.Equal(t, tags, f.Get())
+	assert.Equal(t, tags, f.Slice())
 }
 
 func TestStringSliceModify(t *testing.T) {
@@ -24,15 +24,13 @@ func TestStringSliceModify(t *testing.T) {
 		tags := []string{"service:foo", "env:bar", "thingy:baz"}
 		f := immutable.NewStringSlice(tags)
 		tags[0] = "service:different"
-		assert.Equal(t, "service:foo", f.Get()[0])
-		t.Log(f.Get())
-		t.Log(tags)
+		assert.Equal(t, "service:foo", f.Slice()[0])
 	})
 
 	t.Run("modify-copy", func(t *testing.T) {
 		tags := []string{"service:foo", "env:bar", "thingy:baz"}
 		f := immutable.NewStringSlice(tags)
-		dup := f.Get()
+		dup := f.Slice()
 		dup[0] = "service:different"
 		assert.Equal(t, "service:foo", tags[0])
 	})
@@ -40,9 +38,9 @@ func TestStringSliceModify(t *testing.T) {
 	t.Run("modify-2-copies", func(t *testing.T) {
 		tags := []string{"service:foo", "env:bar", "thingy:baz"}
 		f := immutable.NewStringSlice(tags)
-		dup := f.Get()
+		dup := f.Slice()
 		dup[0] = "service:different"
-		dup2 := f.Get()
+		dup2 := f.Slice()
 		dup2[0] = "service:alsodifferent"
 		assert.Equal(t, "service:foo", tags[0])
 		assert.Equal(t, "service:different", dup[0])
@@ -51,11 +49,11 @@ func TestStringSliceModify(t *testing.T) {
 
 	t.Run("append-duplicates", func(t *testing.T) {
 		var f immutable.StringSlice
-		before := f.Get()
+		before := f.Slice()
 		g := f.Append("foo:bar")
 		h := f.Append("other:tag")
-		after := g.Get()
-		after2 := h.Get()
+		after := g.Slice()
+		after2 := h.Slice()
 		assert.NotEqual(t, before, after)
 		assert.NotEqual(t, before, after2)
 		assert.NotEqual(t, after, after2)

--- a/profiler/internal/immutable/stringslice_test.go
+++ b/profiler/internal/immutable/stringslice_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/profiler/internal/immutable"
 )
 

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -26,7 +26,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/osinfo"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/version"
 	"gopkg.in/DataDog/dd-trace-go.v1/profiler/internal/extensions"
-  "gopkg.in/DataDog/dd-trace-go.v1/profiler/internal/immutable"
+	"gopkg.in/DataDog/dd-trace-go.v1/profiler/internal/immutable"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 )

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -151,7 +151,7 @@ func logStartup(c *config) {
 		Env:                  c.env,
 		TargetURL:            c.targetURL,
 		Agentless:            c.agentless,
-		Tags:                 c.tags.Get(),
+		Tags:                 c.tags.Slice(),
 		ProfilePeriod:        c.period.String(),
 		CPUDuration:          c.cpuDuration.String(),
 		CPUProfileRate:       c.cpuProfileRate,

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -181,7 +181,7 @@ func TestOptions(t *testing.T) {
 	t.Run("WithVersion", func(t *testing.T) {
 		var cfg config
 		WithVersion("1.2.3")(&cfg)
-		assert.Contains(t, cfg.tags, "version:1.2.3")
+		assert.Contains(t, cfg.tags.Get(), "version:1.2.3")
 	})
 
 	t.Run("WithVersion/override", func(t *testing.T) {
@@ -190,15 +190,16 @@ func TestOptions(t *testing.T) {
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
 		WithVersion("1.2.3")(cfg)
-		assert.Contains(t, cfg.tags, "version:1.2.3")
+		assert.Contains(t, cfg.tags.Get(), "version:1.2.3")
 	})
 
 	t.Run("WithTags", func(t *testing.T) {
 		var cfg config
 		WithTags("a:1", "b:2", "c:3")(&cfg)
-		assert.Contains(t, cfg.tags, "a:1")
-		assert.Contains(t, cfg.tags, "b:2")
-		assert.Contains(t, cfg.tags, "c:3")
+		tags := cfg.tags.Get()
+		assert.Contains(t, tags, "a:1")
+		assert.Contains(t, tags, "b:2")
+		assert.Contains(t, tags, "c:3")
 	})
 
 	t.Run("WithTags/override", func(t *testing.T) {
@@ -207,11 +208,12 @@ func TestOptions(t *testing.T) {
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
 		WithTags("a:1", "b:2", "c:3")(cfg)
-		assert.Contains(t, cfg.tags, "a:1")
-		assert.Contains(t, cfg.tags, "b:2")
-		assert.Contains(t, cfg.tags, "c:3")
-		assert.Contains(t, cfg.tags, "env1:tag1")
-		assert.Contains(t, cfg.tags, "env2:tag2")
+		tags := cfg.tags.Get()
+		assert.Contains(t, tags, "a:1")
+		assert.Contains(t, tags, "b:2")
+		assert.Contains(t, tags, "c:3")
+		assert.Contains(t, tags, "env1:tag1")
+		assert.Contains(t, tags, "env2:tag2")
 	})
 
 	t.Run("WithDeltaProfiles", func(t *testing.T) {
@@ -295,7 +297,7 @@ func TestEnvVars(t *testing.T) {
 		defer os.Unsetenv("DD_VERSION")
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
-		assert.Contains(t, cfg.tags, "version:1.2.3")
+		assert.Contains(t, cfg.tags.Get(), "version:1.2.3")
 	})
 
 	t.Run("DD_TAGS", func(t *testing.T) {
@@ -303,9 +305,10 @@ func TestEnvVars(t *testing.T) {
 		defer os.Unsetenv("DD_TAGS")
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
-		assert.Contains(t, cfg.tags, "a:1")
-		assert.Contains(t, cfg.tags, "b:2")
-		assert.Contains(t, cfg.tags, "c:3")
+		tags := cfg.tags.Get()
+		assert.Contains(t, tags, "a:1")
+		assert.Contains(t, tags, "b:2")
+		assert.Contains(t, tags, "c:3")
 	})
 
 	t.Run("DD_PROFILING_DELTA", func(t *testing.T) {
@@ -339,7 +342,7 @@ func TestDefaultConfig(t *testing.T) {
 		assert.Equal(0, cfg.cpuProfileRate)
 		assert.Equal(DefaultMutexFraction, cfg.mutexFraction)
 		assert.Equal(DefaultBlockRate, cfg.blockRate)
-		assert.Contains(cfg.tags, "runtime-id:"+globalconfig.RuntimeID())
+		assert.Contains(cfg.tags.Get(), "runtime-id:"+globalconfig.RuntimeID())
 		assert.Equal(true, cfg.deltaProfiles)
 	})
 }

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -181,7 +181,7 @@ func TestOptions(t *testing.T) {
 	t.Run("WithVersion", func(t *testing.T) {
 		var cfg config
 		WithVersion("1.2.3")(&cfg)
-		assert.Contains(t, cfg.tags.Get(), "version:1.2.3")
+		assert.Contains(t, cfg.tags.Slice(), "version:1.2.3")
 	})
 
 	t.Run("WithVersion/override", func(t *testing.T) {
@@ -190,13 +190,13 @@ func TestOptions(t *testing.T) {
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
 		WithVersion("1.2.3")(cfg)
-		assert.Contains(t, cfg.tags.Get(), "version:1.2.3")
+		assert.Contains(t, cfg.tags.Slice(), "version:1.2.3")
 	})
 
 	t.Run("WithTags", func(t *testing.T) {
 		var cfg config
 		WithTags("a:1", "b:2", "c:3")(&cfg)
-		tags := cfg.tags.Get()
+		tags := cfg.tags.Slice()
 		assert.Contains(t, tags, "a:1")
 		assert.Contains(t, tags, "b:2")
 		assert.Contains(t, tags, "c:3")
@@ -208,7 +208,7 @@ func TestOptions(t *testing.T) {
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
 		WithTags("a:1", "b:2", "c:3")(cfg)
-		tags := cfg.tags.Get()
+		tags := cfg.tags.Slice()
 		assert.Contains(t, tags, "a:1")
 		assert.Contains(t, tags, "b:2")
 		assert.Contains(t, tags, "c:3")
@@ -297,7 +297,7 @@ func TestEnvVars(t *testing.T) {
 		defer os.Unsetenv("DD_VERSION")
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
-		assert.Contains(t, cfg.tags.Get(), "version:1.2.3")
+		assert.Contains(t, cfg.tags.Slice(), "version:1.2.3")
 	})
 
 	t.Run("DD_TAGS", func(t *testing.T) {
@@ -305,7 +305,7 @@ func TestEnvVars(t *testing.T) {
 		defer os.Unsetenv("DD_TAGS")
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
-		tags := cfg.tags.Get()
+		tags := cfg.tags.Slice()
 		assert.Contains(t, tags, "a:1")
 		assert.Contains(t, tags, "b:2")
 		assert.Contains(t, tags, "c:3")
@@ -342,7 +342,7 @@ func TestDefaultConfig(t *testing.T) {
 		assert.Equal(0, cfg.cpuProfileRate)
 		assert.Equal(DefaultMutexFraction, cfg.mutexFraction)
 		assert.Equal(DefaultBlockRate, cfg.blockRate)
-		assert.Contains(cfg.tags.Get(), "runtime-id:"+globalconfig.RuntimeID())
+		assert.Contains(cfg.tags.Slice(), "runtime-id:"+globalconfig.RuntimeID())
 		assert.Equal(true, cfg.deltaProfiles)
 	})
 }

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -192,7 +192,7 @@ func collectGenericProfile(name string, delta *pprofutils.Delta) func(p *profile
 
 		start := time.Now()
 		delta, err := p.deltaProfile(name, delta, data, extra...)
-		tags := append(p.cfg.tags.Get(), fmt.Sprintf("profile_type:%s", name))
+		tags := append(p.cfg.tags.Slice(), fmt.Sprintf("profile_type:%s", name))
 		p.cfg.statsd.Timing("datadog.profiling.go.delta_time", time.Since(start), tags, 1)
 		if err != nil {
 			return nil, fmt.Errorf("delta profile error: %s", err)
@@ -260,7 +260,7 @@ func (p *profiler) runProfile(pt ProfileType) ([]*profile, error) {
 		return nil, err
 	}
 	end := now()
-	tags := append(p.cfg.tags.Get(), pt.Tag())
+	tags := append(p.cfg.tags.Slice(), pt.Tag())
 	filename := t.Filename
 	// TODO(fg): Consider making Collect() return the filename.
 	if p.cfg.deltaProfiles && t.SupportsDelta {

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -192,9 +192,7 @@ func collectGenericProfile(name string, delta *pprofutils.Delta) func(p *profile
 
 		start := time.Now()
 		delta, err := p.deltaProfile(name, delta, data, extra...)
-		tags := make([]string, len(p.cfg.tags), len(p.cfg.tags)+1)
-		copy(tags, p.cfg.tags)
-		tags = append(tags, fmt.Sprintf("profile_type:%s", name))
+		tags := append(p.cfg.tags.Get(), fmt.Sprintf("profile_type:%s", name))
 		p.cfg.statsd.Timing("datadog.profiling.go.delta_time", time.Since(start), tags, 1)
 		if err != nil {
 			return nil, fmt.Errorf("delta profile error: %s", err)
@@ -262,9 +260,7 @@ func (p *profiler) runProfile(pt ProfileType) ([]*profile, error) {
 		return nil, err
 	}
 	end := now()
-	tags := make([]string, len(p.cfg.tags), len(p.cfg.tags)+1)
-	copy(tags, p.cfg.tags)
-	tags = append(tags, pt.Tag())
+	tags := append(p.cfg.tags.Get(), pt.Tag())
 	filename := t.Filename
 	// TODO(fg): Consider making Collect() return the filename.
 	if p.cfg.deltaProfiles && t.SupportsDelta {

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -240,8 +240,8 @@ func (p *profiler) collect(ticker <-chan time.Time) {
 					profs, err := p.runProfile(t)
 					if err != nil {
 						log.Error("Error getting %s profile: %v; skipping.", t, err)
-						tags := append(p.cfg.tags.Get(), t.Tag())
-						p.cfg.statsd.Count("datadog.profiling.go.collect_error", 1, append(tags, t.Tag()), 1)
+						tags := append(p.cfg.tags.Slice(), t.Tag())
+						p.cfg.statsd.Count("datadog.profiling.go.collect_error", 1, tags, 1)
 					}
 					mu.Lock()
 					defer mu.Unlock()
@@ -294,7 +294,7 @@ func (p *profiler) enqueueUpload(bat batch) {
 			// queue is full; evict oldest
 			select {
 			case <-p.out:
-				p.cfg.statsd.Count("datadog.profiling.go.queue_full", 1, p.cfg.tags.Get(), 1)
+				p.cfg.statsd.Count("datadog.profiling.go.queue_full", 1, p.cfg.tags.Slice(), 1)
 				log.Warn("Evicting one profile batch from the upload queue to make room.")
 			default:
 				// this case should be almost impossible to trigger, it would require a

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -240,8 +240,7 @@ func (p *profiler) collect(ticker <-chan time.Time) {
 					profs, err := p.runProfile(t)
 					if err != nil {
 						log.Error("Error getting %s profile: %v; skipping.", t, err)
-						tags := make([]string, len(p.cfg.tags), len(p.cfg.tags)+1)
-						copy(tags, p.cfg.tags)
+						tags := append(p.cfg.tags.Get(), t.Tag())
 						p.cfg.statsd.Count("datadog.profiling.go.collect_error", 1, append(tags, t.Tag()), 1)
 					}
 					mu.Lock()
@@ -295,7 +294,7 @@ func (p *profiler) enqueueUpload(bat batch) {
 			// queue is full; evict oldest
 			select {
 			case <-p.out:
-				p.cfg.statsd.Count("datadog.profiling.go.queue_full", 1, p.cfg.tags, 1)
+				p.cfg.statsd.Count("datadog.profiling.go.queue_full", 1, p.cfg.tags.Get(), 1)
 				log.Warn("Evicting one profile batch from the upload queue to make room.")
 			default:
 				// this case should be almost impossible to trigger, it would require a

--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -68,7 +68,7 @@ func (e retriableError) Error() string { return e.err.Error() }
 // doRequest makes an HTTP POST request to the Datadog Profiling API with the
 // given profile.
 func (p *profiler) doRequest(bat batch) error {
-	tags := append(p.cfg.tags.Get(),
+	tags := append(p.cfg.tags.Slice(),
 		fmt.Sprintf("service:%s", p.cfg.service),
 		fmt.Sprintf("env:%s", p.cfg.env),
 	)

--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -68,9 +68,7 @@ func (e retriableError) Error() string { return e.err.Error() }
 // doRequest makes an HTTP POST request to the Datadog Profiling API with the
 // given profile.
 func (p *profiler) doRequest(bat batch) error {
-	tags := make([]string, len(p.cfg.tags))
-	copy(tags, p.cfg.tags)
-	tags = append(tags,
+	tags := append(p.cfg.tags.Get(),
 		fmt.Sprintf("service:%s", p.cfg.service),
 		fmt.Sprintf("env:%s", p.cfg.env),
 	)


### PR DESCRIPTION
After being bitten by a bug which was in part caused by implicitly
relying on append() creating a slice backed by new memory rather than
sharing the same allocation, we should regard the configured tags as
read-only. See PR #1377.

This commit adds a small immutable package with a StringSlice type which
wraps the slice and provides fresh copies on any access or modification,
and uses the package for the configured tags.
