### PR TITLE
profiler: respect DD_TRACE_STARTUP_LOGS environment variable

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -213,7 +213,7 @@ func defaultConfig() (*config, error) {
 		maxGoroutinesWait: 1000, // arbitrary value, should limit STW to ~30ms
 		tags:              []string{fmt.Sprintf("process_id:%d", os.Getpid())},
 		deltaProfiles:     internal.BoolEnv("DD_PROFILING_DELTA", true),
-		logStartup:        true,
+		logStartup:        internal.BoolEnv("DD_TRACE_STARTUP_LOGS", true),
 		cmemprofEnabled:   false,
 		cmemprofRate:      extensions.DefaultCAllocationSamplingRate,
 	}


### PR DESCRIPTION
The tracer will disable startup configuration logging if the
`DD_TRACE_STARTUP_LOGS` environment variable is set to "false", "0", or
any other false-y value accepted by strconv.ParseBool. Do the same thing
for the profiler.
