### PR TITLE
profiler/internal/cmemprof: make C.malloc safe to profile

### DIFF
--- a/profiler/internal/cmemprof/find_symbols_darwin.c
+++ b/profiler/internal/cmemprof/find_symbols_darwin.c
@@ -1,0 +1,117 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <strings.h>
+
+#include <mach-o/dyld.h>
+#include <mach-o/loader.h>
+#include <mach-o/nlist.h>
+#include <mach-o/stab.h>
+
+// This finds C.malloc wrapper functions in a Mach-O executable.
+//
+// OVERVIEW:
+//
+// The Mach-O file format is used on macos for executables and dynamic
+// libraries. We call a Mach-O file an object. Mach-O objects contain code and
+// other data needed to run a program. An object starts with a header, followed
+// by "load commands" which specify various kinds of data that a dynamic linker
+// & loader will need to actually run the program or make the functions and data
+// in a library available to other programs and libraries.
+//
+// We're looking for the following load commands:
+//
+//	* The symbol table, which specifies functions and data contained
+//	  in the object.
+//	* The string table, which contains the names of things referenced in
+//	  other parts of the object.
+//	* The *dynamic* symbol table, which points to subsets of the full
+//	  symbol table, including to symbols which are externally defined and
+//	  thus visible to other objects.
+//
+// We want to find these tables, and search them for the C.malloc wrapper
+// functions. We then find their addresses and sizes and record the instruction
+// address ranges so we can check them before profiling malloc.
+
+extern int replaced_with_safety_wrapper;
+
+static void find_mallocs(void);
+__attribute__((constructor)) static void init(void) {
+	uint32_t images = _dyld_image_count();
+	if (images > 0) {
+		find_mallocs();
+	}
+}
+
+static void find_mallocs(void) {
+	// The first image is the executable
+	const struct mach_header_64 *m = (struct mach_header_64 *) _dyld_get_image_header(0);
+	char *cursor = (char *) m;
+	// skip the header, get to the load commands
+	cursor += sizeof(struct mach_header_64);
+
+	char *strings = NULL;
+	struct symtab_command *tabcmd = NULL;
+	struct nlist_64 *symtab = NULL;
+	struct dysymtab_command *dytab = NULL;
+
+	// linkedit_base is the base "virtual" memory address of the __LINKEDIT
+	// segment which holds the string and symbol tables. Those tables have
+	// offsets relative to this address.
+	uint8_t *linkedit_base = NULL;
+	// slide is the difference between where the data is actually loaded into
+	// memory and the "virtual" memory address of the data. Addresses within
+	// the object are relative to the virtual address, and thus need to be
+	// adjusted by the slide so we can access them.
+	intptr_t slide = _dyld_get_image_vmaddr_slide(0);
+
+	for (uint32_t i = 0; i < m->ncmds; i++) {
+		struct load_command *cmd = (struct load_command *) cursor;
+		if (cmd->cmd == LC_SEGMENT_64) {
+			struct segment_command_64 *seg = (struct segment_command_64 *) cursor;
+			if (strcmp(seg->segname, SEG_LINKEDIT) == 0) {
+				linkedit_base = (uint8_t *)(seg->vmaddr - seg->fileoff);
+			}
+		}
+		if (cmd->cmd == LC_SYMTAB) {
+			tabcmd = (struct symtab_command *) cursor;
+		}
+		if (cmd->cmd == LC_DYSYMTAB) {
+			dytab = (struct dysymtab_command *) cursor;
+		}
+		cursor += cmd->cmdsize;
+	}
+
+	if ((tabcmd == NULL) || (dytab == NULL)) {
+		return;
+	}
+	strings = (char *)(linkedit_base + slide + tabcmd->stroff);
+	symtab = (struct nlist_64 *)(linkedit_base + slide + tabcmd->symoff);
+
+	uintptr_t safety_wrapper = 0;
+	// The __cgo_<...>_Cmalloc functions are external symbols
+	for (uint32_t i = 0; i < dytab->nextdefsym; i++) {
+		struct nlist_64 *sym = &symtab[i + dytab->iextdefsym];
+		if ((sym->n_type & N_TYPE) == N_SECT) {
+			// N_SECT means the symbol is actually defined in a
+			// section of this object
+			char *name = strings + sym->n_un.n_strx;
+			if (strstr(name, "_Cfunc_safety_malloc_wrapper")) {
+				safety_wrapper = (uintptr_t) sym->n_value;
+			}
+		}
+	}
+
+	for (uint32_t i = 0; i < dytab->nlocalsym; i++) {
+		struct nlist_64 *sym = &symtab[i + dytab->ilocalsym];
+		char *name = strings + sym->n_un.n_strx;
+		if (strstr(name, "_Cfunc__Cmalloc")) {
+			// TODO: Adjust these pointers??
+			uintptr_t *p = (uintptr_t *)sym->n_value;
+			*p = safety_wrapper;
+		}
+	}
+
+	if (safety_wrapper != 0) {
+		replaced_with_safety_wrapper = 1;
+	}
+}

--- a/profiler/internal/cmemprof/find_symbols_darwin.c
+++ b/profiler/internal/cmemprof/find_symbols_darwin.c
@@ -96,7 +96,7 @@ static void find_mallocs(void) {
 			// section of this object
 			char *name = strings + sym->n_un.n_strx;
 			if (strstr(name, "_Cfunc_safety_malloc_wrapper")) {
-				safety_wrapper = (uintptr_t) sym->n_value;
+				safety_wrapper = (uintptr_t)(sym->n_value + slide);
 			}
 		}
 	}
@@ -106,7 +106,7 @@ static void find_mallocs(void) {
 		char *name = strings + sym->n_un.n_strx;
 		if (strstr(name, "_Cfunc__Cmalloc")) {
 			// TODO: Adjust these pointers??
-			uintptr_t *p = (uintptr_t *)sym->n_value;
+			uintptr_t *p = (uintptr_t *)(sym->n_value + slide);
 			*p = safety_wrapper;
 		}
 	}

--- a/profiler/internal/cmemprof/find_symbols_linux.c
+++ b/profiler/internal/cmemprof/find_symbols_linux.c
@@ -31,6 +31,7 @@ static char *safe_readlink(const char *path) {
 		}
 		ssize_t nread = readlink(path, buf, size);
 		if (nread < 0) {
+			free(buf);
 			return NULL;
 		}
 	} while (nread == size);

--- a/profiler/internal/cmemprof/find_symbols_linux.c
+++ b/profiler/internal/cmemprof/find_symbols_linux.c
@@ -1,0 +1,144 @@
+#define _GNU_SOURCE
+#include <elf.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+//#define _GNU_SOURCE (why doesn't this work?)
+#include <link.h>
+//#undef _GNU_SOURCE
+
+extern int replaced_with_safety_wrapper;
+
+// safe_readlink is a wrapper around readlink which will read the link
+// in a size-independent way
+static char *safe_readlink(const char *path) {
+	size_t size = 256;
+	ssize_t nread = 0;
+	char *buf = NULL;
+	do {
+		size *= 2;
+		free(buf); // OK if buf is NULL
+		buf = calloc(1, size);
+		if (buf == NULL) {
+			return NULL;
+		}
+		ssize_t nread = readlink(path, buf, size);
+		if (nread < 0) {
+			return NULL;
+		}
+	} while (nread == size);
+	// if nread == size, we *might* have read to the end of the symlink or
+	// there might be more. Make the buffer big enough to hold the value
+	// plus room for the terminating 0 byte
+	return buf;
+}
+
+static int callback(struct dl_phdr_info *info, size_t size, void *data) {
+	uintptr_t *base_addr = data;
+	*base_addr = info->dlpi_addr;
+	return 1; // stop after the first call (covers the executable)
+}
+
+__attribute__ ((constructor)) static void init(void) {
+	// To be technically correct we should check the base address where the
+	// program was actually loaded, though I've only seen it be at base
+	// address 0 on Linux.
+	uintptr_t base_addr = 0;
+	dl_iterate_phdr(callback, &base_addr);
+
+	char *filename = safe_readlink("/proc/self/exe");
+	if (filename == NULL) {
+		return;
+	}
+	int fd = open(filename, O_RDONLY);
+	free(filename);
+	if (fd < 0) {
+		return;
+	}
+	struct stat sb;
+	if (fstat(fd, &sb) == -1) {
+		close(fd);
+		return;
+	}
+
+	void *file = mmap(
+		NULL,        // loaded address hint, NULL means kernel chooses
+		sb.st_size,  // size of data
+		PROT_READ,   // access protections, we only want to read
+		MAP_PRIVATE, // MAP_PRIVATE means copy-on-write mapping
+		fd,          // fd to map
+		0            // offset into fd
+	);
+	if (file == NULL) {
+		return;
+	}
+
+	char *cursor = file;
+	ElfW(Ehdr) *header = (ElfW(Ehdr) *) cursor;
+
+	ElfW(Shdr) *section_headers = (ElfW(Shdr) *)(cursor + header->e_shoff);
+
+	ElfW(Sym) *symtab_base = NULL;
+	char *strtab_base = NULL;
+	size_t nsyms = 0;
+
+	for (uint16_t i = 0; i < header->e_shnum; i++) {
+		ElfW(Shdr) *section = &section_headers[i];
+		if (section->sh_type == SHT_SYMTAB) {
+			symtab_base = (ElfW(Sym) *)(cursor + section->sh_offset);
+			nsyms = section->sh_size / (sizeof(ElfW(Sym)));
+
+			// The string table section corresponding to the symbol
+			// table is linked via the sh_link field of the symbol
+			// table section header.
+			ElfW(Shdr) *string_section = &section_headers[section->sh_link];
+			strtab_base = (char *)(cursor + string_section->sh_offset);
+		}
+	}
+
+	if ((symtab_base == NULL) || (strtab_base == NULL)) {
+		goto cleanup;
+	}
+
+	uintptr_t safety_wrapper = 0;
+	for (size_t i = 0; i < nsyms; i++) {
+		ElfW(Sym) *symbol = &symtab_base[i];
+		if (ELF64_ST_TYPE(symbol->st_info) != STT_FUNC) {
+			continue;
+		}
+		char *name = strtab_base + symbol->st_name;
+		if (strstr(name, "_Cfunc_safety_malloc_wrapper")) {
+			safety_wrapper = base_addr + symbol->st_value;
+		}
+	}
+	if (safety_wrapper == 0) {
+		goto cleanup;
+	}
+
+	for (size_t i = 0; i < nsyms; i++) {
+		ElfW(Sym) *symbol = &symtab_base[i];
+		if (ELF64_ST_BIND(symbol->st_info) != STB_LOCAL) {
+			continue;
+		}
+		if (ELF64_ST_TYPE(symbol->st_info) != STT_OBJECT) {
+			continue;
+		}
+		char *name = strtab_base + symbol->st_name;
+		if (strstr(name, "_Cfunc__Cmalloc") != NULL) {
+			uintptr_t *addr = (uintptr_t *)(base_addr + symbol->st_value);
+			memcpy(addr, &safety_wrapper, sizeof(void *));
+		}
+	}
+
+	replaced_with_safety_wrapper = 1;
+
+cleanup:
+	munmap(file, sb.st_size);
+}

--- a/profiler/internal/cmemprof/profile_test.go
+++ b/profiler/internal/cmemprof/profile_test.go
@@ -75,10 +75,11 @@ func TestCgoMallocNoPanic(t *testing.T) {
 	testallocator.DoAllocGo(32)
 	testallocator.DoAllocGo(32)
 
-	_, err := prof.Stop()
+	p, err := prof.Stop()
 	if err != nil {
 		t.Fatalf("running profile: %s", err)
 	}
+	t.Logf("%v", p)
 }
 
 // TestNewCgoThreadCrash checks that wrapping malloc does not cause creating a

--- a/profiler/internal/cmemprof/profiler.c
+++ b/profiler/internal/cmemprof/profiler.c
@@ -83,6 +83,10 @@ void profile_allocation(size_t size) {
 	}
 }
 
+// replaced_with_safety_wrapper indicates whether the library was able to locate
+// Go's malloc wrappers and replace them with our safe implementation.
+int replaced_with_safety_wrapper = 0;
+
 // is_unsafe_call checks whether the given return address is inside a function
 // from which it is unsafe to call back into Go code.
 //
@@ -100,6 +104,9 @@ void profile_allocation(size_t size) {
 //      goroutine's stack. If the stack grows and malloc's return value goes in
 //      the wrong place, the program can crash.
 static int is_unsafe_call(void *ret_addr) {
+	if (replaced_with_safety_wrapper == 1) {
+		return 0;
+	}
 	// TODO: Cache this whole check?
 	Dl_info info = {0};
 	if (dladdr(ret_addr, &info) == 0) {


### PR DESCRIPTION
This commit adds workarounds to make `C.malloc` safe to profile.
Essentially, we replace `C.malloc` calls with our own idential version
which includes safety checks that `C.malloc` lacked.

Previously, this function was *not* safe to profile because our sample
recording function called back into Go to record the call stack.  By
calling from C back into Go, our recording function could cause the Go
call stack to grow. Go generates a special Go wrapper for malloc by hand
that lacks a safety check for stack growth which is normally included in
C function wrappers. If we cause the stack to grow during `C.malloc`, the
return address for malloc will be written to the previous stack
location, which causes the program to panic.

The way we overcome this limitation works like this:

* For any C function called from Go, the Go compiler generates a wrapper
  which calls the C function.
* This wrapper is called through a function pointer. This function
  pointer will have a named symbol that we can locate in the program's
  symbol table (provided the program hasn't been stripped).
* We generate our own, functionally identical malloc wrapper.
* We find the address of our wrapper in the symbol table. Then we
  find the addresses of the `C.malloc` function pointers, and write
  the address of our wrapper.

The details of this are slightly different between darwin (macOS) and
Linux. In particular, darwin gives us direct access to all of the
program's load commands, which we can access at runtime. On Linux, the
function pointer symbols don't have global scope/external visibility, so
they won't be visible in the dynamic symbol table we would find by
calling `dl_iterate_phdr`. This means we have to read the executable
ourselves and locate the appropriate sections.

We add a global flag that indicates whether we succesfully found the
`C.malloc` function pointers and replaced them with our wrappers. If we
*didn't*, e.g. because the program has been stripped, we fall back to
the existing safety check.
