### PR TITLE
ddtrace/tracer: update example to be usable by default

### DIFF
--- a/ddtrace/tracer/example_test.go
+++ b/ddtrace/tracer/example_test.go
@@ -34,10 +34,7 @@ func Example() {
 
 func doSomething(ctx context.Context) {
 	// Create a child, using the context of the parent span.
-	opts := []tracer.StartSpanOption{
-		tracer.Tag(ext.ResourceName, "alarm"),
-	}
-	span, ctx := tracer.StartSpanFromContext(ctx, "do.something", opts...)
+	span, ctx := tracer.StartSpanFromContext(ctx, "do.something", tracer.Tag(ext.ResourceName, "alarm"))
 	defer func() {
 		span.Finish(tracer.WithError(ctx.Err()))
 	}()

--- a/ddtrace/tracer/example_test.go
+++ b/ddtrace/tracer/example_test.go
@@ -29,14 +29,17 @@ func Example() {
 	defer span.Finish()
 
 	// Run some code.
-	doSomething(ctx)
+	err := doSomething(ctx)
+	if err != nil {
+		panic(err)
+	}
 }
 
-func doSomething(ctx context.Context) {
+func doSomething(ctx context.Context) (err error) {
 	// Create a child, using the context of the parent span.
 	span, ctx := tracer.StartSpanFromContext(ctx, "do.something", tracer.Tag(ext.ResourceName, "alarm"))
 	defer func() {
-		span.Finish(tracer.WithError(ctx.Err()))
+		span.Finish(tracer.WithError(err))
 	}()
 
 	// Perform an operation.
@@ -44,6 +47,7 @@ func doSomething(ctx context.Context) {
 	case <-time.After(5 * time.Millisecond):
 		fmt.Println("ding!")
 	case <-ctx.Done():
-		fmt.Println("overslept :(")
+		fmt.Println("timed out :(")
 	}
+	return ctx.Err()
 }

--- a/ddtrace/tracer/example_test.go
+++ b/ddtrace/tracer/example_test.go
@@ -3,37 +3,47 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
-package tracer
+package tracer_test
 
 import (
-	"io/ioutil"
+	"context"
 	"log"
+	"math/rand"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 // A basic example demonstrating how to start the tracer, as well as how
 // to create a root span and a child span that is a descendant of it.
 func Example() {
+	ctx := context.Background()
+
 	// Start the tracer and defer the Stop method.
-	Start(WithAgentAddr("host:port"))
-	defer Stop()
+	tracer.Start()
+	defer tracer.Stop()
 
 	// Start a root span.
-	span := StartSpan("get.data")
+	span, ctx := tracer.StartSpanFromContext(ctx, "your.work")
 	defer span.Finish()
 
-	// Create a child of it, computing the time needed to read a file.
-	child := StartSpan("read.file", ChildOf(span.Context()))
-	child.SetTag(ext.ResourceName, "test.json")
-
-	// Perform an operation.
-	_, err := ioutil.ReadFile("~/test.json")
-
-	// We may finish the child span using the returned error. If it's
-	// nil, it will be disregarded.
-	child.Finish(WithError(err))
-	if err != nil {
-		log.Fatal(err)
+	yourCode := func(ctx context.Context) error {
+		// Perform an operation.
+		b := make([]byte, 100000)
+		_, err := rand.Read(b)
+		if err != nil {
+			log.Fatal(err)
+		}
+		return err
 	}
+
+	// Create a child, using the context of the parent span.
+	child, ctx := tracer.StartSpanFromContext(ctx, "this.service")
+	child.SetTag(ext.ResourceName, "randomization")
+
+	// Run some code.
+	err := yourCode(ctx)
+
+	// Finish the span.
+	child.Finish(tracer.WithError(err))
 }


### PR DESCRIPTION
The previous example would not work by default if
copied into a fresh main() function since it was
reading a test.json file that wouldn't exist.

The new example uses context to create child spans,
which is a common use case for connecting spans. It
will also run by default if someone has the datadog
agent setup and running locally.