### PR TITLE
ddtrace/tracer: force trace stats flush on Stop

### DIFF
--- a/ddtrace/tracer/stats.go
+++ b/ddtrace/tracer/stats.go
@@ -104,18 +104,9 @@ func (c *concentrator) runFlusher(tick <-chan time.Time) {
 	for {
 		select {
 		case now := <-tick:
-			p := c.flush(now)
-			if len(p.Stats) == 0 {
-				// nothing to flush
-				continue
-			}
-			c.statsd().Incr("datadog.tracer.stats.flush_payloads", nil, 1)
-			c.statsd().Incr("datadog.tracer.stats.flush_buckets", nil, float64(len(p.Stats)))
-			if err := c.cfg.transport.sendStats(&p); err != nil {
-				c.statsd().Incr("datadog.tracer.stats.flush_errors", nil, 1)
-				log.Error("Error sending stats payload: %v", err)
-			}
+			c.flush(now, withoutCurrentBucket)
 		case <-c.stop:
+			c.flush(time.Now(), withCurrentBucket)
 			return
 		}
 	}
@@ -166,7 +157,14 @@ func (c *concentrator) Stop() {
 	c.wg.Wait()
 }
 
-func (c *concentrator) flush(timenow time.Time) statsPayload {
+const (
+	withCurrentBucket    = true
+	withoutCurrentBucket = false
+)
+
+// flush flushes all the stats buckets with the given timestamp. The current bucket is only included if
+// includeCurrent is true, such as during shutdown.
+func (c *concentrator) flush(timenow time.Time, includeCurrent bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -178,7 +176,7 @@ func (c *concentrator) flush(timenow time.Time) statsPayload {
 		Stats:    make([]statsBucket, 0, len(c.buckets)),
 	}
 	for ts, srb := range c.buckets {
-		if ts > now-c.bucketSize {
+		if !includeCurrent && ts > now-c.bucketSize {
 			// do not flush the current bucket
 			continue
 		}
@@ -186,7 +184,16 @@ func (c *concentrator) flush(timenow time.Time) statsPayload {
 		sp.Stats = append(sp.Stats, srb.Export())
 		delete(c.buckets, ts)
 	}
-	return sp
+	if len(sp.Stats) == 0 {
+		// nothing to flush
+		return
+	}
+	c.statsd().Incr("datadog.tracer.stats.flush_payloads", nil, 1)
+	c.statsd().Incr("datadog.tracer.stats.flush_buckets", nil, float64(len(sp.Stats)))
+	if err := c.cfg.transport.sendStats(&sp); err != nil {
+		c.statsd().Incr("datadog.tracer.stats.flush_errors", nil, 1)
+		log.Error("Error sending stats payload: %v", err)
+	}
 }
 
 // aggregation specifies a uniquely identifiable key under which a certain set

--- a/ddtrace/tracer/stats.go
+++ b/ddtrace/tracer/stats.go
@@ -65,7 +65,6 @@ type concentrator struct {
 func newConcentrator(c *config, bucketSize int64) *concentrator {
 	return &concentrator{
 		In:         make(chan *aggregableSpan, 10000),
-		wg:         sync.WaitGroup{},
 		bucketSize: bucketSize,
 		stopped:    1,
 		buckets:    make(map[int64]*rawBucket),

--- a/ddtrace/tracer/stats_test.go
+++ b/ddtrace/tracer/stats_test.go
@@ -19,6 +19,7 @@ func waitForBuckets(c *concentrator, n int) bool {
 		time.Sleep(time.Millisecond * timeMultiplicator)
 		c.mu.Lock()
 		if len(c.buckets) == n {
+			c.mu.Unlock()
 			return true
 		}
 		c.mu.Unlock()
@@ -106,7 +107,8 @@ func TestConcentrator(t *testing.T) {
 	})
 
 	t.Run("ingester", func(t *testing.T) {
-		c := newConcentrator(&config{}, defaultStatsBucketSize)
+		transport := newDummyTransport()
+		c := newConcentrator(&config{transport: transport}, defaultStatsBucketSize)
 		c.Start()
 		assert.Len(t, c.buckets, 0)
 		c.In <- ss1

--- a/ddtrace/tracer/stats_test.go
+++ b/ddtrace/tracer/stats_test.go
@@ -159,5 +159,22 @@ func TestConcentrator(t *testing.T) {
 			c.Stop()
 			assert.Zero(t, transport.Stats())
 		})
+
+		// stats should be sent if the concentrator is stopped
+		t.Run("stop", func(t *testing.T) {
+			transport := newDummyTransport()
+			c := newConcentrator(&config{transport: transport}, 500000)
+			assert.Len(t, transport.Stats(), 0)
+			c.Start()
+			c.In <- &aggregableSpan{
+				key:      key1,
+				Start:    time.Now().UnixNano(),
+				Duration: 1,
+			}
+			c.Stop()
+			// TODO: race condition between In and c.stop
+			// so this assert is non-deterministic
+			assert.NotZero(t, transport.Stats())
+		})
 	})
 }

--- a/ddtrace/tracer/stats_test.go
+++ b/ddtrace/tracer/stats_test.go
@@ -157,7 +157,7 @@ func TestConcentrator(t *testing.T) {
 				Duration: 1,
 			}
 			c.Stop()
-			assert.Zero(t, transport.Stats())
+			assert.NotEmpty(t, transport.Stats())
 		})
 
 		// stats should be sent if the concentrator is stopped
@@ -172,9 +172,7 @@ func TestConcentrator(t *testing.T) {
 				Duration: 1,
 			}
 			c.Stop()
-			// TODO: race condition between In and c.stop
-			// so this assert is non-deterministic
-			assert.NotZero(t, transport.Stats())
+			assert.NotEmpty(t, transport.Stats())
 		})
 	})
 }


### PR DESCRIPTION
The trace stats were not being sent on tracer.Stop() /
tracer.stats.Stop() so any unsent buckets would never be sent.

The fix is to add an option to force the bucket out on stop.