### PR TITLE
profiler: randomize wait duration before retrying upload

### DIFF
--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -39,9 +39,9 @@ func (p *profiler) upload(bat batch) error {
 		err = p.doRequest(bat)
 		if rerr, ok := err.(*retriableError); ok {
 			statsd.Count("datadog.profiling.go.upload_retry", 1, nil, 1)
-			wait := time.Duration(rand.Int63n(p.cfg.period.Nanoseconds()))
+			wait := time.Duration(rand.Int63n(p.cfg.period.Nanoseconds())) * time.Nanosecond
 			log.Error("Uploading profile failed: %v. Trying again in %s...", rerr, wait)
-			p.interruptibleSleep(time.Second)
+			p.interruptibleSleep(wait)
 			continue
 		}
 		if err != nil {


### PR DESCRIPTION
PR #827 introduced a randomized wait duration before retrying a failed
profile upload. This was done to reduce the likelihood of flooding the
backend with uploads. The wait was done to be an average of half the
profiling perdio. However, PR #961 lost this behavior when introducing
interruptible sleeps. This commit restores the lost behavior.

Fixes #1395
