### PR TITLE
ci: Move to non-deprecated linting tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,8 @@ jobs:
     - run:
         name: lint
         command: |
+          go get google.golang.org/grpc@v1.29.0 # https://github.com/grpc/grpc-go/issues/3726
+          go mod tidy # Go1.16 doesn't update the sum file correctly after the go get, this tidy fixes it
           go vet ./...
 
   test-core:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,9 +71,8 @@ jobs:
     - run:
         name: lint
         command: |
-          go get google.golang.org/grpc@v1.29.0 # https://github.com/grpc/grpc-go/issues/3726
-          go mod tidy # Go1.16 doesn't update the sum file correctly after the go get, this tidy fixes it
-          go vet ./...
+          PACKAGE_NAMES=$(go list ./... | grep -v -e grpc.v12) # grpc.v12 is broken so skip it
+          go vet -- $PACKAGE_NAMES
 
   test-core:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,10 +71,7 @@ jobs:
     - run:
         name: lint
         command: |
-          go get -u golang.org/x/lint/golint
-          curl -L https://git.io/vp6lP | sh # https://github.com/alecthomas/gometalinter#binary-releases
-          ./bin/gometalinter --disable-all --vendor --deadline=60s --enable=golint ./...
-
+          go vet ./...
 
   test-core:
     parameters:

--- a/appsec/example_test.go
+++ b/appsec/example_test.go
@@ -44,7 +44,7 @@ func ExampleMonitorParsedHTTPBody() {
 }
 
 // Monitor HTTP request parsed body with a framework customized context type
-func ExampleMonitorParsedHTTPBody_CustomContext() {
+func ExampleMonitorParsedHTTPBody_customContext() {
 	r := echo.New()
 	r.Use(echotrace.Middleware())
 	r.POST("/body", func(c echo.Context) (e error) {

--- a/contrib/cloud.google.com/go/pubsub.v1/example_test.go
+++ b/contrib/cloud.google.com/go/pubsub.v1/example_test.go
@@ -27,7 +27,7 @@ func ExamplePublish() {
 	}
 }
 
-func ExampleReceive() {
+func ExampleSubscription_Receive() {
 	client, err := pubsub.NewClient(context.Background(), "project-id")
 	if err != nil {
 		log.Fatal(err)

--- a/contrib/confluentinc/confluent-kafka-go/kafka/example_test.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/example_test.go
@@ -20,7 +20,7 @@ var (
 )
 
 // This example shows how a span context can be passed from a producer to a consumer.
-func ExampleDistributedTracing() {
+func Example() {
 
 	tracer.Start()
 	defer tracer.Stop()
@@ -41,7 +41,7 @@ func ExampleDistributedTracing() {
 	// Create the span to be passed
 	parentSpan := tracer.StartSpan("test_parent_span")
 
-	/// Produce a message with a span
+	// Produce a message with a span
 	go func() {
 		msg := &kafka.Message{
 			TopicPartition: kafka.TopicPartition{

--- a/contrib/miekg/dns/dns_test.go
+++ b/contrib/miekg/dns/dns_test.go
@@ -38,7 +38,6 @@ func TestDNS(t *testing.T) {
 		err := server.ListenAndServe()
 		if err != nil {
 			t.Error(err)
-			return
 		}
 	}()
 	waitTillUDPReady(t, addr)

--- a/contrib/miekg/dns/dns_test.go
+++ b/contrib/miekg/dns/dns_test.go
@@ -37,7 +37,8 @@ func TestDNS(t *testing.T) {
 	go func() {
 		err := server.ListenAndServe()
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 	}()
 	waitTillUDPReady(t, addr)

--- a/contrib/segmentio/kafka.go.v0/kafka_test.go
+++ b/contrib/segmentio/kafka.go.v0/kafka_test.go
@@ -57,7 +57,7 @@ func TestReadMessageFunctional(t *testing.T) {
 	err = w.Close()
 	assert.NoError(t, err)
 
-	tctx, _ := context.WithTimeout(context.Background(), 30*time.Second)
+	tctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	r := NewReader(kafka.ReaderConfig{
 		Brokers: []string{"localhost:9092"},
 		GroupID: testGroupID,
@@ -66,6 +66,7 @@ func TestReadMessageFunctional(t *testing.T) {
 	msg2, err := r.ReadMessage(tctx)
 	assert.NoError(t, err, "Expected to consume message")
 	assert.Equal(t, msg1[0].Value, msg2.Value, "Values should be equal")
+	cancel()
 	r.Close()
 
 	// now verify the spans
@@ -114,7 +115,7 @@ func TestFetchMessageFunctional(t *testing.T) {
 	err = w.Close()
 	assert.NoError(t, err)
 
-	tctx, _ := context.WithTimeout(context.Background(), 30*time.Second)
+	tctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	r := NewReader(kafka.ReaderConfig{
 		Brokers: []string{"localhost:9092"},
 		GroupID: testGroupID,
@@ -128,6 +129,7 @@ func TestFetchMessageFunctional(t *testing.T) {
 	assert.NoError(t, err, "Expected CommitMessages to not return an error")
 
 	r.Close()
+	cancel()
 
 	// now verify the spans
 	spans := mt.FinishedSpans()

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -268,7 +268,6 @@ type panicStringer struct {
 // String causes panic which SetTag should not handle.
 func (p *panicStringer) String() string {
 	panic("This should not be handled.")
-	return ""
 }
 
 func TestSpanSetTag(t *testing.T) {


### PR DESCRIPTION
This also fixes the issues found by `go vet`