### PR TITLE
profiler/internal/cmemprof: add full mappings to the profile

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,3 +1,4 @@
 Component,Origin,License,Copyright
 import,io.opentracing,Apache-2.0,Copyright 2016-2017 The OpenTracing Authors
 appsec,https://github.com/DataDog/libddwaf,Apache-2.0 OR BSD-3-Clause,Copyright (c) 2021 Datadog <info@datadoghq.com>
+golang,https://go.googlesource.com/go,BSD-3-Clause,Copyright (c) 2009 The Go Authors

--- a/profiler/internal/cmemprof/LICENSE-go
+++ b/profiler/internal/cmemprof/LICENSE-go
@@ -1,0 +1,24 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/profiler/internal/cmemprof/pprof.go
+++ b/profiler/internal/cmemprof/pprof.go
@@ -61,7 +61,7 @@ func init() {
 	sc := bufio.NewScanner(bytes.NewReader(data))
 	for sc.Scan() {
 		fields := bytes.Fields(sc.Bytes())
-		if len(fields) != 5 {
+		if len(fields) != 6 {
 			continue
 		}
 		addrs := bytes.Split(fields[0], []byte("-"))

--- a/profiler/internal/cmemprof/pprof.go
+++ b/profiler/internal/cmemprof/pprof.go
@@ -58,6 +58,11 @@ func init() {
 		return
 	}
 
+	mappings = parseMappings(data)
+}
+
+func parseMappings(data []byte) []*profile.Mapping {
+	var results []*profile.Mapping
 	sc := bufio.NewScanner(bytes.NewReader(data))
 	for sc.Scan() {
 		fields := bytes.Fields(sc.Bytes())
@@ -84,8 +89,8 @@ func init() {
 		// We don't need the dev or inode fields (3 and 4)
 		file := string(fields[5])
 
-		mappings = append(mappings, &profile.Mapping{
-			ID:     uint64(len(mappings) + 1),
+		results = append(results, &profile.Mapping{
+			ID:     uint64(len(results) + 1),
 			Start:  lo,
 			Limit:  hi,
 			Offset: offset,
@@ -93,9 +98,10 @@ func init() {
 		})
 	}
 
-	sort.Slice(mappings, func(i, j int) bool {
-		return mappings[i].Start < mappings[j].Start
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Start < results[j].Start
 	})
+	return results
 }
 
 func (c *Profile) build() *profile.Profile {

--- a/profiler/internal/cmemprof/pprof_test.go
+++ b/profiler/internal/cmemprof/pprof_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022 Datadog, Inc.
+
 package cmemprof
 
 import (

--- a/profiler/internal/cmemprof/pprof_test.go
+++ b/profiler/internal/cmemprof/pprof_test.go
@@ -1,0 +1,147 @@
+package cmemprof
+
+import (
+	"bytes"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/google/pprof/profile"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_parseMapping(t *testing.T) {
+	implementations := []struct {
+		Name string
+		Func func([]byte) []*profile.Mapping
+	}{
+		{"parseMappingsOriginal", parseMappingsOriginal},
+		{"parseMappings", parseMappings},
+	}
+	example := strings.TrimSpace(`
+address           perms offset  dev   inode       pathname
+00400000-00452000 r-xp 00000000 08:02 173521      /usr/bin/dbus-daemon
+00300000-00352000 r-xp 00000000 08:02 173521      /usr/bin/white space/daemon
+`) + "\n"
+
+	for _, impl := range implementations {
+		t.Run(impl.Name, func(t *testing.T) {
+			got := impl.Func([]byte(example))
+			require.Equal(t, []*profile.Mapping{
+				{
+					ID:              2,
+					Start:           3145728,
+					Limit:           3481600,
+					Offset:          0,
+					File:            "/usr/bin/white space/daemon",
+					BuildID:         "",
+					HasFunctions:    false,
+					HasFilenames:    false,
+					HasLineNumbers:  false,
+					HasInlineFrames: false,
+				},
+				{
+					ID:              1,
+					Start:           4194304,
+					Limit:           4530176,
+					Offset:          0,
+					File:            "/usr/bin/dbus-daemon",
+					BuildID:         "",
+					HasFunctions:    false,
+					HasFilenames:    false,
+					HasLineNumbers:  false,
+					HasInlineFrames: false,
+				},
+			}, got)
+		})
+	}
+}
+
+// bytes.Cut, but backported so we can still support Go 1.17
+func bytesCut(s, sep []byte) (before, after []byte, found bool) {
+	if i := bytes.Index(s, sep); i >= 0 {
+		return s[:i], s[i+len(sep):], true
+	}
+	return s, nil, false
+}
+
+func stringsCut(s, sep string) (before, after string, found bool) {
+	if i := strings.Index(s, sep); i >= 0 {
+		return s[:i], s[i+len(sep):], true
+	}
+	return s, "", false
+}
+
+func parseMappingsOriginal(data []byte) []*profile.Mapping {
+	var results []*profile.Mapping
+	var line []byte
+	// next removes and returns the next field in the line.
+	// It also removes from line any spaces following the field.
+	next := func() []byte {
+		var f []byte
+		f, line, _ = bytesCut(line, []byte(" "))
+		line = bytes.TrimLeft(line, " ")
+		return f
+	}
+
+	for len(data) > 0 {
+		line, data, _ = bytesCut(data, []byte("\n"))
+		addr := next()
+		loStr, hiStr, ok := stringsCut(string(addr), "-")
+		if !ok {
+			continue
+		}
+		lo, err := strconv.ParseUint(loStr, 16, 64)
+		if err != nil {
+			continue
+		}
+		hi, err := strconv.ParseUint(hiStr, 16, 64)
+		if err != nil {
+			continue
+		}
+		perm := next()
+		if len(perm) < 4 || perm[2] != 'x' {
+			// Only interested in executable mappings.
+			continue
+		}
+		offset, err := strconv.ParseUint(string(next()), 16, 64)
+		if err != nil {
+			continue
+		}
+		next()          // dev
+		inode := next() // inode
+		if line == nil {
+			continue
+		}
+		file := string(line)
+
+		// Trim deleted file marker.
+		deletedStr := " (deleted)"
+		deletedLen := len(deletedStr)
+		if len(file) >= deletedLen && file[len(file)-deletedLen:] == deletedStr {
+			file = file[:len(file)-deletedLen]
+		}
+
+		if len(inode) == 1 && inode[0] == '0' && file == "" {
+			// Huge-page text mappings list the initial fragment of
+			// mapped but unpopulated memory as being inode 0.
+			// Don't report that part.
+			// But [vdso] and [vsyscall] are inode 0, so let non-empty file names through.
+			continue
+		}
+
+		results = append(results, &profile.Mapping{
+			ID:     uint64(len(results) + 1),
+			Start:  lo,
+			Limit:  hi,
+			Offset: offset,
+			File:   file,
+		})
+	}
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Start < results[j].Start
+	})
+
+	return results
+}


### PR DESCRIPTION
Since the C allocation profile might contain samples from shared
libraries, the profile should have appropriate mappings for the
different libraries, rather than a single "default" mapping. In
addition, even if we don't have function & file information for a
sample, we can at least show the library it came from.
