### PR TITLE
Removed links to internal resources

### DIFF
--- a/contrib/internal/httptrace/config.go
+++ b/contrib/internal/httptrace/config.go
@@ -27,7 +27,6 @@ const (
 )
 
 // defaultQueryStringRegexp is the regexp used for query string obfuscation if `envQueryStringRegexp` is empty.
-// The regexp is taken from https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2490990623/QueryString+-+Sensitive+Data+Obfuscation
 var defaultQueryStringRegexp = regexp.MustCompile("(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:(?:\\s|%20)*(?:=|%3D)[^&]+|(?:\"|%22)(?:\\s|%20)*(?::|%3A)(?:\\s|%20)*(?:\"|%22)(?:%2[^2]|%[^2]|[^\"%])+(?:\"|%22))|bearer(?:\\s|%20)+[a-z0-9\\._\\-]|token(?::|%3A)[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L](?:[\\w=-]|%3D)+\\.ey[I-L](?:[\\w=-]|%3D)+(?:\\.(?:[\\w.+\\/=-]|%3D|%2F|%2B)+)?|[\\-]{5}BEGIN(?:[a-z\\s]|%20)+PRIVATE(?:\\s|%20)KEY[\\-]{5}[^\\-]+[\\-]{5}END(?:[a-z\\s]|%20)+PRIVATE(?:\\s|%20)KEY|ssh-rsa(?:\\s|%20)*(?:[a-z0-9\\/\\.+]|%2F|%5C|%2B){100,}")
 
 type config struct {

--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -40,6 +40,10 @@ var (
 	cfg = newConfig()
 )
 
+// multipleIPHeaders sets the multiple ip header tag used internally to tell the backend an error occurred when
+// retrieving an HTTP request client IP.
+const multipleIPHeaders = "_dd.multiple-ip-headers"
+
 // StartRequestSpan starts an HTTP request span with the standard list of HTTP request span tags (http.method, http.url,
 // http.useragent). Any further span start option can be added with opts.
 func StartRequestSpan(r *http.Request, opts ...ddtrace.StartSpanOption) (tracer.Span, context.Context) {
@@ -91,7 +95,6 @@ func ippref(s string) *netaddr.IPPrefix {
 }
 
 // genClientIPSpanTags generates the client IP related tags that need to be added to the span.
-// See https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2118779066/Client+IP+addresses+resolution
 func genClientIPSpanTags(r *http.Request) []ddtrace.StartSpanOption {
 	ipHeaders := defaultIPHeaders
 	if len(cfg.clientIPHeader) > 0 {
@@ -122,7 +125,7 @@ func genClientIPSpanTags(r *http.Request) []ddtrace.StartSpanOption {
 		for i := range ips {
 			opts = append(opts, tracer.Tag(ext.HTTPRequestHeaders+"."+headers[i], ips[i]))
 		}
-		opts = append(opts, tracer.Tag(ext.MultipleIPHeaders, strings.Join(headers, ",")))
+		opts = append(opts, tracer.Tag(multipleIPHeaders, strings.Join(headers, ",")))
 	}
 	return opts
 }
@@ -157,7 +160,6 @@ func isGlobal(ip netaddr.IP) bool {
 
 // urlFromRequest returns the full URL from the HTTP request. If query params are collected, they are obfuscated granted
 // obfuscation is not disabled by the user (through DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP)
-// For more information see https://datadoghq.atlassian.net/wiki/spaces/APM/pages/2357395856/Span+attributes#http.url
 func urlFromRequest(r *http.Request) string {
 	// Quoting net/http comments about net.Request.URL on server requests:
 	// "For most requests, fields other than Path and RawQuery will be
@@ -175,7 +177,6 @@ func urlFromRequest(r *http.Request) string {
 		url = path
 	}
 	// Collect the query string if we are allowed to report it and obfuscate it if possible/allowed
-	// https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2490990623/QueryString+-+Sensitive+Data+Obfuscation
 	if cfg.queryString && r.URL.RawQuery != "" {
 		query := r.URL.RawQuery
 		if cfg.queryStringRegexp != nil {

--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -95,6 +95,7 @@ func ippref(s string) *netaddr.IPPrefix {
 }
 
 // genClientIPSpanTags generates the client IP related tags that need to be added to the span.
+// See https://docs.datadoghq.com/tracing/configure_data_security#configuring-a-client-ip-header for more information.
 func genClientIPSpanTags(r *http.Request) []ddtrace.StartSpanOption {
 	ipHeaders := defaultIPHeaders
 	if len(cfg.clientIPHeader) > 0 {
@@ -160,6 +161,7 @@ func isGlobal(ip netaddr.IP) bool {
 
 // urlFromRequest returns the full URL from the HTTP request. If query params are collected, they are obfuscated granted
 // obfuscation is not disabled by the user (through DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP)
+// See https://docs.datadoghq.com/tracing/configure_data_security#redacting-the-query-in-the-url for more information.
 func urlFromRequest(r *http.Request) string {
 	// Quoting net/http comments about net.Request.URL on server requests:
 	// "For most requests, fields other than Path and RawQuery will be

--- a/contrib/internal/httptrace/httptrace_test.go
+++ b/contrib/internal/httptrace/httptrace_test.go
@@ -189,11 +189,11 @@ func TestIPHeaders(t *testing.T) {
 			}
 			if tc.expectedIP.IsValid() {
 				require.Equal(t, tc.expectedIP.String(), spanCfg.Tags[ext.HTTPClientIP])
-				require.Nil(t, spanCfg.Tags[ext.MultipleIPHeaders])
+				require.Nil(t, spanCfg.Tags[multipleIPHeaders])
 			} else {
 				require.Nil(t, spanCfg.Tags[ext.HTTPClientIP])
 				if tc.multiHeaders != "" {
-					require.Equal(t, tc.multiHeaders, spanCfg.Tags[ext.MultipleIPHeaders])
+					require.Equal(t, tc.multiHeaders, spanCfg.Tags[multipleIPHeaders])
 					for hdr, ip := range tc.headers {
 						require.Equal(t, ip, spanCfg.Tags[ext.HTTPRequestHeaders+"."+hdr])
 					}

--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -42,14 +42,9 @@ const (
 	// HTTPClientIP sets the HTTP client IP tag.
 	HTTPClientIP = "http.client_ip"
 
-	// MultipleIPHeaders sets the multiple ip header tag used internally to tell the backend an error occurred when
-	// retrieving an HTTP request client IP.
-	// See https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2118779066/Client+IP+addresses+resolution
-	MultipleIPHeaders = "_dd.multiple-ip-headers"
-
 	// HTTPRequestHeaders sets the HTTP request headers partial tag
 	// This tag is meant to be composed, i.e http.request.headers.headerX, http.request.headers.headerY, etc...
-	// See https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2302444638/DD+TRACE+HEADER+TAGS
+	// See https://docs.datadoghq.com/tracing/trace_collection/tracing_naming_convention/#http-requests
 	HTTPRequestHeaders = "http.request.headers"
 
 	// SpanName is a pseudo-key for setting a span's operation name by means of


### PR DESCRIPTION
References PRs #1350 and #1346 

- multipleIPHeaders is documented to be used internally, so I removed it from ext/tags.go list of public API tags
- removed links to internal resources 

TODO:
- add a page of public documentation on DD_TRACE_HEADER_TAGS at https://docs.datadoghq.com/tracing/trace_collection/library_config/go/ or https://docs.datadoghq.com/tracing/trace_collection/tracing_naming_convention/#http-requests

