### PR TITLE
contrib/internal/httptrace: don't use inet.af/netaddr if Go >= 1.19

### DIFF
--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -15,15 +15,13 @@ import (
 	"strconv"
 	"strings"
 
-	"inet.af/netaddr"
-
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 var (
-	ipv6SpecialNetworks = []*netaddr.IPPrefix{
+	ipv6SpecialNetworks = []*netaddrIPPrefix{
 		ippref("fec0::/10"), // site local
 	}
 	defaultIPHeaders = []string{
@@ -87,8 +85,8 @@ func FinishRequestSpan(s tracer.Span, status int, opts ...tracer.FinishOption) {
 }
 
 // ippref returns the IP network from an IP address string s. If not possible, it returns nil.
-func ippref(s string) *netaddr.IPPrefix {
-	if prefix, err := netaddr.ParseIPPrefix(s); err == nil {
+func ippref(s string) *netaddrIPPrefix {
+	if prefix, err := netaddrParseIPPrefix(s); err == nil {
 		return &prefix
 	}
 	return nil
@@ -131,19 +129,19 @@ func genClientIPSpanTags(r *http.Request) []ddtrace.StartSpanOption {
 	return opts
 }
 
-func parseIP(s string) netaddr.IP {
-	if ip, err := netaddr.ParseIP(s); err == nil {
+func parseIP(s string) netaddrIP {
+	if ip, err := netaddrParseIP(s); err == nil {
 		return ip
 	}
 	if h, _, err := net.SplitHostPort(s); err == nil {
-		if ip, err := netaddr.ParseIP(h); err == nil {
+		if ip, err := netaddrParseIP(h); err == nil {
 			return ip
 		}
 	}
-	return netaddr.IP{}
+	return netaddrIP{}
 }
 
-func isGlobal(ip netaddr.IP) bool {
+func isGlobal(ip netaddrIP) bool {
 	// IsPrivate also checks for ipv6 ULA.
 	// We care to check for these addresses are not considered public, hence not global.
 	// See https://www.rfc-editor.org/rfc/rfc4193.txt for more details.

--- a/contrib/internal/httptrace/httptrace_test.go
+++ b/contrib/internal/httptrace/httptrace_test.go
@@ -12,8 +12,6 @@ import (
 	"net/url"
 	"testing"
 
-	"inet.af/netaddr"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -38,7 +36,7 @@ type IPTestCase struct {
 	name           string
 	remoteAddr     string
 	headers        map[string]string
-	expectedIP     netaddr.IP
+	expectedIP     netaddrIP
 	multiHeaders   string
 	clientIPHeader string
 }
@@ -54,12 +52,12 @@ func genIPTestCases() []IPTestCase {
 		tcs = append(tcs, IPTestCase{
 			name:       "ipv4-global." + header,
 			headers:    map[string]string{header: ipv4Global},
-			expectedIP: netaddr.MustParseIP(ipv4Global),
+			expectedIP: netaddrMustParseIP(ipv4Global),
 		})
 		tcs = append(tcs, IPTestCase{
 			name:       "ipv4-private." + header,
 			headers:    map[string]string{header: ipv4Private},
-			expectedIP: netaddr.IP{},
+			expectedIP: netaddrIP{},
 		})
 	}
 	// Simple ipv6 test cases over all headers
@@ -67,12 +65,12 @@ func genIPTestCases() []IPTestCase {
 		tcs = append(tcs, IPTestCase{
 			name:       "ipv6-global." + header,
 			headers:    map[string]string{header: ipv6Global},
-			expectedIP: netaddr.MustParseIP(ipv6Global),
+			expectedIP: netaddrMustParseIP(ipv6Global),
 		})
 		tcs = append(tcs, IPTestCase{
 			name:       "ipv6-private." + header,
 			headers:    map[string]string{header: ipv6Private},
-			expectedIP: netaddr.IP{},
+			expectedIP: netaddrIP{},
 		})
 	}
 	// private and global in same header
@@ -80,22 +78,22 @@ func genIPTestCases() []IPTestCase {
 		{
 			name:       "ipv4-private+global",
 			headers:    map[string]string{"x-forwarded-for": ipv4Private + "," + ipv4Global},
-			expectedIP: netaddr.MustParseIP(ipv4Global),
+			expectedIP: netaddrMustParseIP(ipv4Global),
 		},
 		{
 			name:       "ipv4-global+private",
 			headers:    map[string]string{"x-forwarded-for": ipv4Global + "," + ipv4Private},
-			expectedIP: netaddr.MustParseIP(ipv4Global),
+			expectedIP: netaddrMustParseIP(ipv4Global),
 		},
 		{
 			name:       "ipv6-private+global",
 			headers:    map[string]string{"x-forwarded-for": ipv6Private + "," + ipv6Global},
-			expectedIP: netaddr.MustParseIP(ipv6Global),
+			expectedIP: netaddrMustParseIP(ipv6Global),
 		},
 		{
 			name:       "ipv6-global+private",
 			headers:    map[string]string{"x-forwarded-for": ipv6Global + "," + ipv6Private},
-			expectedIP: netaddr.MustParseIP(ipv6Global),
+			expectedIP: netaddrMustParseIP(ipv6Global),
 		},
 	}, tcs...)
 	// Invalid IPs (or a mix of valid/invalid over a single or multiple headers)
@@ -103,67 +101,67 @@ func genIPTestCases() []IPTestCase {
 		{
 			name:       "invalid-ipv4",
 			headers:    map[string]string{"x-forwarded-for": "127..0.0.1"},
-			expectedIP: netaddr.IP{},
+			expectedIP: netaddrIP{},
 		},
 		{
 			name:       "invalid-ipv4-recover",
 			headers:    map[string]string{"x-forwarded-for": "127..0.0.1, " + ipv4Global},
-			expectedIP: netaddr.MustParseIP(ipv4Global),
+			expectedIP: netaddrMustParseIP(ipv4Global),
 		},
 		{
 			name:         "ipv4-multi-header-1",
 			headers:      map[string]string{"x-forwarded-for": "127.0.0.1", "forwarded-for": ipv4Global},
-			expectedIP:   netaddr.IP{},
+			expectedIP:   netaddrIP{},
 			multiHeaders: "x-forwarded-for,forwarded-for",
 		},
 		{
 			name:         "ipv4-multi-header-2",
 			headers:      map[string]string{"forwarded-for": ipv4Global, "x-forwarded-for": "127.0.0.1"},
-			expectedIP:   netaddr.IP{},
+			expectedIP:   netaddrIP{},
 			multiHeaders: "x-forwarded-for,forwarded-for",
 		},
 		{
 			name:       "invalid-ipv6",
 			headers:    map[string]string{"x-forwarded-for": "2001:0db8:2001:zzzz::"},
-			expectedIP: netaddr.IP{},
+			expectedIP: netaddrIP{},
 		},
 		{
 			name:       "invalid-ipv6-recover",
 			headers:    map[string]string{"x-forwarded-for": "2001:0db8:2001:zzzz::, " + ipv6Global},
-			expectedIP: netaddr.MustParseIP(ipv6Global),
+			expectedIP: netaddrMustParseIP(ipv6Global),
 		},
 		{
 			name:         "ipv6-multi-header-1",
 			headers:      map[string]string{"x-forwarded-for": "2001:0db8:2001:zzzz::", "forwarded-for": ipv6Global},
-			expectedIP:   netaddr.IP{},
+			expectedIP:   netaddrIP{},
 			multiHeaders: "x-forwarded-for,forwarded-for",
 		},
 		{
 			name:         "ipv6-multi-header-2",
 			headers:      map[string]string{"forwarded-for": ipv6Global, "x-forwarded-for": "2001:0db8:2001:zzzz::"},
-			expectedIP:   netaddr.IP{},
+			expectedIP:   netaddrIP{},
 			multiHeaders: "x-forwarded-for,forwarded-for",
 		},
 	}, tcs...)
 	tcs = append([]IPTestCase{
 		{
 			name:       "no-headers",
-			expectedIP: netaddr.IP{},
+			expectedIP: netaddrIP{},
 		},
 		{
 			name:       "header-case",
-			expectedIP: netaddr.MustParseIP(ipv4Global),
+			expectedIP: netaddrMustParseIP(ipv4Global),
 			headers:    map[string]string{"X-fOrWaRdEd-FoR": ipv4Global},
 		},
 		{
 			name:           "user-header",
-			expectedIP:     netaddr.MustParseIP(ipv4Global),
+			expectedIP:     netaddrMustParseIP(ipv4Global),
 			headers:        map[string]string{"x-forwarded-for": ipv6Global, "custom-header": ipv4Global},
 			clientIPHeader: "custom-header",
 		},
 		{
 			name:           "user-header-not-found",
-			expectedIP:     netaddr.IP{},
+			expectedIP:     netaddrIP{},
 			headers:        map[string]string{"x-forwarded-for": ipv4Global},
 			clientIPHeader: "custom-header",
 		},
@@ -297,12 +295,12 @@ func TestURLTag(t *testing.T) {
 	}
 }
 
-func randIPv4() netaddr.IP {
-	return netaddr.IPv4(uint8(rand.Uint32()), uint8(rand.Uint32()), uint8(rand.Uint32()), uint8(rand.Uint32()))
+func randIPv4() netaddrIP {
+	return netaddrIPv4(uint8(rand.Uint32()), uint8(rand.Uint32()), uint8(rand.Uint32()), uint8(rand.Uint32()))
 }
 
-func randIPv6() netaddr.IP {
-	return netaddr.IPv6Raw([16]byte{
+func randIPv6() netaddrIP {
+	return netaddrIPv6Raw([16]byte{
 		uint8(rand.Uint32()), uint8(rand.Uint32()), uint8(rand.Uint32()), uint8(rand.Uint32()),
 		uint8(rand.Uint32()), uint8(rand.Uint32()), uint8(rand.Uint32()), uint8(rand.Uint32()),
 		uint8(rand.Uint32()), uint8(rand.Uint32()), uint8(rand.Uint32()), uint8(rand.Uint32()),
@@ -310,7 +308,7 @@ func randIPv6() netaddr.IP {
 	})
 }
 
-func randGlobalIPv4() netaddr.IP {
+func randGlobalIPv4() netaddrIP {
 	for {
 		ip := randIPv4()
 		if isGlobal(ip) {
@@ -319,7 +317,7 @@ func randGlobalIPv4() netaddr.IP {
 	}
 }
 
-func randGlobalIPv6() netaddr.IP {
+func randGlobalIPv6() netaddrIP {
 	for {
 		ip := randIPv6()
 		if isGlobal(ip) {
@@ -328,7 +326,7 @@ func randGlobalIPv6() netaddr.IP {
 	}
 }
 
-func randPrivateIPv4() netaddr.IP {
+func randPrivateIPv4() netaddrIP {
 	for {
 		ip := randIPv4()
 		if !isGlobal(ip) && ip.IsPrivate() {
@@ -337,7 +335,7 @@ func randPrivateIPv4() netaddr.IP {
 	}
 }
 
-func randPrivateIPv6() netaddr.IP {
+func randPrivateIPv6() netaddrIP {
 	for {
 		ip := randIPv6()
 		if !isGlobal(ip) && ip.IsPrivate() {

--- a/contrib/internal/httptrace/ip_default.go
+++ b/contrib/internal/httptrace/ip_default.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022 Datadog, Inc.
+
+//go:build !go1.19
+// +build !go1.19
+
+package httptrace
+
+import "inet.af/netaddr"
+
+type netaddrIP = netaddr.IP
+type netaddrIPPrefix = netaddr.IPPrefix
+
+var (
+	netaddrParseIP       = netaddr.ParseIP
+	netaddrParseIPPrefix = netaddr.ParseIPPrefix
+	netaddrMustParseIP   = netaddr.MustParseIP
+	netaddrIPv4          = netaddr.IPv4
+	netaddrIPv6Raw       = netaddr.IPv6Raw
+)

--- a/contrib/internal/httptrace/ip_go119.go
+++ b/contrib/internal/httptrace/ip_go119.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022 Datadog, Inc.
+
+//go:build go1.19
+// +build go1.19
+
+package httptrace
+
+import "net/netip"
+
+type netaddrIP = netip.Addr
+type netaddrIPPrefix = netip.Prefix
+
+var (
+	netaddrParseIP       = netip.ParseAddr
+	netaddrParseIPPrefix = netip.ParsePrefix
+	netaddrMustParseIP   = netip.MustParseAddr
+	netaddrIPv6Raw       = netip.AddrFrom16
+)
+
+func netaddrIPv4(a, b, c, d byte) netaddrIP {
+	e := [4]byte{a, b, c, d}
+	return netip.AddrFrom4(e)
+}


### PR DESCRIPTION
The `inet.af/netaddr` package internally imports a package
(`go4.org/unsafe/assume-no-moving-gc`) which is designed to panic when imported
for newer Go versions. As of Go 1.19, the `inet.af/netaddr` has been added to
the Go standard library under the `net/netip` package. We can prefer this
package for versions of Go >= 1.19, and fall back to `inet.af/netaddr` for
older Go versions.

The packages have nearly identical APIs. This PR abstracts away which package
is being used, and selects either the standard library version or the
`inet.af/netaddr` version depending on the `go1.19` build tag.
