### PR TITLE
ddtrace/tracer: do not propagate unknown sampling decision

### DIFF
--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -368,7 +368,7 @@ func TestTraceManualKeepAndManualDrop(t *testing.T) {
 		t.Run(fmt.Sprintf("%s/non-local", scenario.tag), func(t *testing.T) {
 			tracer := newTracer()
 			spanCtx := &spanContext{traceID: 42, spanID: 42}
-			spanCtx.setSamplingPriority(scenario.p, samplernames.Upstream, math.NaN())
+			spanCtx.setSamplingPriority(scenario.p, samplernames.RemoteRate, math.NaN())
 			span := tracer.StartSpan("non-local root span", ChildOf(spanCtx)).(*span)
 			span.SetTag(scenario.tag, true)
 			assert.Equal(t, scenario.keep, shouldKeep(span))

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -6,7 +6,6 @@
 package tracer
 
 import (
-	"math"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -205,7 +204,7 @@ func (t *trace) samplingPriority() (p int, ok bool) {
 func (t *trace) setSamplingPriority(p int, sampler samplernames.SamplerName, rate float64, span *span) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.setSamplingPriorityLocked(p, sampler, rate, span)
+	t.setSamplingPriorityLocked(p, sampler)
 }
 
 func (t *trace) keep() {
@@ -246,7 +245,7 @@ func (t *trace) unsetPropagatingTag(key string) {
 	delete(t.propagatingTags, key)
 }
 
-func (t *trace) setSamplingPriorityLocked(p int, sampler samplernames.SamplerName, rate float64, span *span) {
+func (t *trace) setSamplingPriorityLocked(p int, sampler samplernames.SamplerName) {
 	if t.locked {
 		return
 	}
@@ -255,8 +254,9 @@ func (t *trace) setSamplingPriorityLocked(p int, sampler samplernames.SamplerNam
 	}
 	*t.priority = float64(p)
 	_, ok := t.propagatingTags[keyDecisionMaker]
-	if p > 0 && !ok {
-		// we have a positive priority and the sampling mechanism isn't set
+	if p > 0 && !ok && sampler != samplernames.Unknown {
+		// We have a positive priority and the sampling mechanism isn't set.
+		// Send nothing when sampler is `Unknown` for RFC compliance.
 		t.setPropagatingTagLocked(keyDecisionMaker, "-"+strconv.Itoa(int(sampler)))
 	}
 	if p <= 0 && ok {
@@ -284,7 +284,7 @@ func (t *trace) push(sp *span) {
 		return
 	}
 	if v, ok := sp.Metrics[keySamplingPriority]; ok {
-		t.setSamplingPriorityLocked(int(v), samplernames.Upstream, math.NaN(), nil)
+		t.setSamplingPriorityLocked(int(v), samplernames.Unknown)
 	}
 	t.spans = append(t.spans, sp)
 	if haveTracer {

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -16,6 +16,7 @@ import (
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/samplernames"
 )
 
 func setupteardown(start, max int) func() {
@@ -460,4 +461,35 @@ func removeAppSec(lines []string) []string {
 		res = append(res, line)
 	}
 	return res
+}
+
+func TestSetSamplingPriorityLocked(t *testing.T) {
+	t.Run("NoPriorAndP0IsIgnored", func(t *testing.T) {
+		tr := trace{
+			propagatingTags: map[string]string{},
+		}
+		tr.setSamplingPriorityLocked(0, samplernames.RemoteRate)
+		assert.Empty(t, tr.propagatingTags[keyDecisionMaker])
+	})
+	t.Run("UnknownSamplerIsIgnored", func(t *testing.T) {
+		tr := trace{
+			propagatingTags: map[string]string{},
+		}
+		tr.setSamplingPriorityLocked(0, samplernames.Unknown)
+		assert.Empty(t, tr.propagatingTags[keyDecisionMaker])
+	})
+	t.Run("NoPriorAndP1IsAccepted", func(t *testing.T) {
+		tr := trace{
+			propagatingTags: map[string]string{},
+		}
+		tr.setSamplingPriorityLocked(1, samplernames.RemoteRate)
+		assert.Equal(t, "-2", tr.propagatingTags[keyDecisionMaker])
+	})
+	t.Run("PriorAndP1IsIgnored", func(t *testing.T) {
+		tr := trace{
+			propagatingTags: map[string]string{keyDecisionMaker: "-1"},
+		}
+		tr.setSamplingPriorityLocked(1, samplernames.RemoteRate)
+		assert.Equal(t, "-1", tr.propagatingTags[keyDecisionMaker])
+	})
 }

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -334,7 +334,7 @@ func (p *propagator) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 			if err != nil {
 				return ErrSpanContextCorrupted
 			}
-			ctx.setSamplingPriority(priority, samplernames.Upstream, math.NaN())
+			ctx.setSamplingPriority(priority, samplernames.Unknown, math.NaN())
 		case originHeader:
 			ctx.origin = v
 		case traceTagsHeader:
@@ -444,7 +444,7 @@ func (*propagatorB3) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 			if err != nil {
 				return ErrSpanContextCorrupted
 			}
-			ctx.setSamplingPriority(priority, samplernames.Upstream, math.NaN())
+			ctx.setSamplingPriority(priority, samplernames.Unknown, math.NaN())
 		default:
 		}
 		return nil

--- a/internal/samplernames/samplernames.go
+++ b/internal/samplernames/samplernames.go
@@ -5,18 +5,14 @@
 
 package samplernames
 
-import "math"
-
 // SamplerName specifies the name of a sampler which was
 // responsible for a certain sampling decision.
 type SamplerName int8
 
 const (
-	// Upstream specifies that the sampling decision was made in an upstream service
-	// and no sampling needs to be done.
-	Upstream SamplerName = math.MinInt8
 	// Unknown specifies that the span was sampled
 	// but, the tracer was unable to identify the sampler.
+	// No sampling decision maker will be propagated.
 	Unknown SamplerName = -1
 	// Default specifies that the span was sampled without any sampler.
 	Default SamplerName = 0


### PR DESCRIPTION
When an upstream service started the trace but did not propagate a sampling decision maker we should not propagate any data.