### PR TITLE
profiler, internal/telemetry: use testing.T.Setenv

### DIFF
--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"reflect"
 	"sort"
 	"sync"
@@ -121,24 +120,12 @@ func TestMetrics(t *testing.T) {
 	}
 }
 
-// testSetEnv is a copy of testing.T.Setenv so we can build this library
-// for Go versions prior to 1.17
-func testSetEnv(t *testing.T, key, val string) {
-	prev, ok := os.LookupEnv(key)
-	if ok {
-		t.Cleanup(func() { os.Setenv(key, prev) })
-	} else {
-		t.Cleanup(func() { os.Unsetenv(key) })
-	}
-	os.Setenv(key, val)
-}
-
 func TestDisabledClient(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("shouldn't have got any requests")
 	}))
 	defer server.Close()
-	testSetEnv(t, "DD_INSTRUMENTATION_TELEMETRY_ENABLED", "0")
+	t.Setenv("DD_INSTRUMENTATION_TELEMETRY_ENABLED", "0")
 
 	client := &telemetry.Client{
 		URL:                server.URL,

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -54,10 +54,8 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("WithAgentAddr/override", func(t *testing.T) {
-		os.Setenv("DD_AGENT_HOST", "bad_host")
-		defer os.Unsetenv("DD_AGENT_HOST")
-		os.Setenv("DD_TRACE_AGENT_PORT", "bad_port")
-		defer os.Unsetenv("DD_TRACE_AGENT_PORT")
+		t.Setenv("DD_AGENT_HOST", "bad_host")
+		t.Setenv("DD_TRACE_AGENT_PORT", "bad_port")
 		var cfg config
 		WithAgentAddr("test:123")(&cfg)
 		expectedURL := "http://test:123/profiling/v1/input"
@@ -78,8 +76,7 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("WithAPIKey/override", func(t *testing.T) {
-		os.Setenv("DD_API_KEY", "apikey")
-		defer os.Unsetenv("DD_API_KEY")
+		t.Setenv("DD_API_KEY", "apikey")
 		var testAPIKey = "12345678901234567890123456789012"
 		var cfg config
 		WithAPIKey(testAPIKey)(&cfg)
@@ -139,8 +136,7 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("WithService/override", func(t *testing.T) {
-		os.Setenv("DD_SERVICE", "envService")
-		defer os.Unsetenv("DD_SERVICE")
+		t.Setenv("DD_SERVICE", "envService")
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
 		WithService("serviceName")(cfg)
@@ -154,8 +150,7 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("WithSite/override", func(t *testing.T) {
-		os.Setenv("DD_SITE", "wrong.site")
-		defer os.Unsetenv("DD_SITE")
+		t.Setenv("DD_SITE", "wrong.site")
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
 		WithSite("datadog.eu")(cfg)
@@ -169,8 +164,7 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("WithEnv/override", func(t *testing.T) {
-		os.Setenv("DD_ENV", "envEnv")
-		defer os.Unsetenv("DD_ENV")
+		t.Setenv("DD_ENV", "envEnv")
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
 		WithEnv("envName")(cfg)
@@ -184,8 +178,7 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("WithVersion/override", func(t *testing.T) {
-		os.Setenv("DD_VERSION", "envVersion")
-		defer os.Unsetenv("DD_VERSION")
+		t.Setenv("DD_VERSION", "envVersion")
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
 		WithVersion("1.2.3")(cfg)
@@ -202,8 +195,7 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("WithTags/override", func(t *testing.T) {
-		os.Setenv("DD_TAGS", "env1:tag1,env2:tag2")
-		defer os.Unsetenv("DD_TAGS")
+		t.Setenv("DD_TAGS", "env1:tag1,env2:tag2")
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
 		WithTags("a:1", "b:2", "c:3")(cfg)
@@ -226,82 +218,71 @@ func TestOptions(t *testing.T) {
 
 func TestEnvVars(t *testing.T) {
 	t.Run("DD_AGENT_HOST", func(t *testing.T) {
-		os.Setenv("DD_AGENT_HOST", "agent_host_1")
-		defer os.Unsetenv("DD_AGENT_HOST")
+		t.Setenv("DD_AGENT_HOST", "agent_host_1")
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
 		assert.Equal(t, "http://agent_host_1:8126/profiling/v1/input", cfg.agentURL)
 	})
 
 	t.Run("DD_TRACE_AGENT_PORT", func(t *testing.T) {
-		os.Setenv("DD_TRACE_AGENT_PORT", "6218")
-		defer os.Unsetenv("DD_TRACE_AGENT_PORT")
+		t.Setenv("DD_TRACE_AGENT_PORT", "6218")
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
 		assert.Equal(t, "http://localhost:6218/profiling/v1/input", cfg.agentURL)
 	})
 
 	t.Run("DD_PROFILING_UPLOAD_TIMEOUT", func(t *testing.T) {
-		os.Setenv("DD_PROFILING_UPLOAD_TIMEOUT", "3s")
-		defer os.Unsetenv("DD_PROFILING_UPLOAD_TIMEOUT")
+		t.Setenv("DD_PROFILING_UPLOAD_TIMEOUT", "3s")
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
 		assert.Equal(t, 3*time.Second, cfg.uploadTimeout)
 	})
 
 	t.Run("DD_AGENT_HOST+DD_TRACE_AGENT_PORT", func(t *testing.T) {
-		os.Setenv("DD_AGENT_HOST", "agent_host_1")
-		defer os.Unsetenv("DD_AGENT_HOST")
-		os.Setenv("DD_TRACE_AGENT_PORT", "6218")
-		defer os.Unsetenv("DD_TRACE_AGENT_PORT")
+		t.Setenv("DD_AGENT_HOST", "agent_host_1")
+		t.Setenv("DD_TRACE_AGENT_PORT", "6218")
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
 		assert.Equal(t, "http://agent_host_1:6218/profiling/v1/input", cfg.agentURL)
 	})
 
 	t.Run("DD_API_KEY", func(t *testing.T) {
-		os.Setenv("DD_API_KEY", testAPIKey)
-		defer os.Unsetenv("DD_API_KEY")
+		t.Setenv("DD_API_KEY", testAPIKey)
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
 		assert.Equal(t, testAPIKey, cfg.apiKey)
 	})
 
 	t.Run("DD_SITE", func(t *testing.T) {
-		os.Setenv("DD_SITE", "datadog.eu")
-		defer os.Unsetenv("DD_SITE")
+		t.Setenv("DD_SITE", "datadog.eu")
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
 		assert.Equal(t, "https://intake.profile.datadog.eu/v1/input", cfg.apiURL)
 	})
 
 	t.Run("DD_ENV", func(t *testing.T) {
-		os.Setenv("DD_ENV", "someEnv")
-		defer os.Unsetenv("DD_ENV")
+		t.Setenv("DD_ENV", "someEnv")
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
 		assert.Equal(t, "someEnv", cfg.env)
 	})
 
 	t.Run("DD_SERVICE", func(t *testing.T) {
-		os.Setenv("DD_SERVICE", "someService")
-		defer os.Unsetenv("DD_SERVICE")
+		t.Setenv("DD_SERVICE", "someService")
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
 		assert.Equal(t, "someService", cfg.service)
 	})
 
 	t.Run("DD_VERSION", func(t *testing.T) {
-		os.Setenv("DD_VERSION", "1.2.3")
-		defer os.Unsetenv("DD_VERSION")
+		t.Setenv("DD_VERSION", "1.2.3")
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
 		assert.Contains(t, cfg.tags.Slice(), "version:1.2.3")
 	})
 
 	t.Run("DD_TAGS", func(t *testing.T) {
-		os.Setenv("DD_TAGS", "a:1,b:2,c:3")
-		defer os.Unsetenv("DD_TAGS")
+		t.Setenv("DD_TAGS", "a:1,b:2,c:3")
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
 		tags := cfg.tags.Slice()
@@ -311,8 +292,7 @@ func TestEnvVars(t *testing.T) {
 	})
 
 	t.Run("DD_PROFILING_DELTA", func(t *testing.T) {
-		os.Setenv("DD_PROFILING_DELTA", "false")
-		defer os.Unsetenv("DD_PROFILING_DELTA")
+		t.Setenv("DD_PROFILING_DELTA", "false")
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
 		assert.Equal(t, cfg.deltaProfiles, false)
@@ -377,8 +357,7 @@ func TestWith_outputDir(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Use env to enable this like a user would.
-	os.Setenv("DD_PROFILING_OUTPUT_DIR", tmpDir)
-	defer os.Unsetenv("DD_PROFILING_OUTPUT_DIR")
+	t.Setenv("DD_PROFILING_OUTPUT_DIR", tmpDir)
 
 	p, err := unstartedProfiler()
 	require.NoError(t, err)

--- a/profiler/profile_test.go
+++ b/profiler/profile_test.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -303,10 +302,7 @@ main.main()
 
 		stop := spawnGoroutines(goroutines)
 		defer stop()
-		envVar := "DD_PROFILING_WAIT_PROFILE_MAX_GOROUTINES"
-		oldVal := os.Getenv(envVar)
-		os.Setenv(envVar, strconv.Itoa(limit))
-		defer os.Setenv(envVar, oldVal)
+		t.Setenv("DD_PROFILING_WAIT_PROFILE_MAX_GOROUTINES", strconv.Itoa(limit))
 
 		p, err := unstartedProfiler()
 		p.testHooks.lookupProfile = func(_ string, w io.Writer, _ int) error {

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -28,22 +28,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setenv(t *testing.T, key, value string) {
-	t.Helper()
-	// re-implemented testing.T.Setenv since that function requires Go 1.17
-	old, ok := os.LookupEnv(key)
-	os.Setenv(key, value)
-	if ok {
-		t.Cleanup(func() {
-			os.Setenv(key, old)
-		})
-	} else {
-		t.Cleanup(func() {
-			os.Unsetenv(key)
-		})
-	}
-}
-
 func TestMain(m *testing.M) {
 	// Profiling configuration is logged by default when starting a profile,
 	// so we want to discard it during tests to avoid flooding the terminal
@@ -364,7 +348,7 @@ func TestAllUploaded(t *testing.T) {
 	}))
 	defer server.Close()
 
-	setenv(t, "DD_PROFILING_WAIT_PROFILE", "1")
+	t.Setenv("DD_PROFILING_WAIT_PROFILE", "1")
 	Start(
 		WithAgentAddr(server.Listener.Addr().String()),
 		WithProfileTypes(
@@ -483,7 +467,7 @@ func TestTelemetryEnabled(t *testing.T) {
 	}))
 	defer server.Close()
 
-	setenv(t, "DD_INSTRUMENTATION_TELEMETRY_ENABLED", "true")
+	t.Setenv("DD_INSTRUMENTATION_TELEMETRY_ENABLED", "true")
 	Start(
 		WithAgentAddr(server.Listener.Addr().String()),
 		WithProfileTypes(


### PR DESCRIPTION
Now that we've bumped our minimum supported Go version to 1.17 (see #1410) we
can use [testing.T.Setenv](https://pkg.go.dev/testing#T.Setenv). This function
is a test helper which sets an environment variable, and restores it to its
previous value when the test ends (including un-setting the variable if it was
un-set). There are a few reimplementations of this in the tests which can now
be removed.
