### PR TITLE
profiler: log when profiler is stopped

### DIFF
--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -432,6 +432,9 @@ func (p *profiler) stop() {
 		p.telemetry.Stop()
 	})
 	p.wg.Wait()
+	if p.cfg.logStartup {
+		log.Info("Profiling stopped")
+	}
 }
 
 // StatsdClient implementations can count and time certain event occurrences that happen


### PR DESCRIPTION
This is mainly motivated by a support case where the user did

	profiler.Start(...)
	profiler.Stop()

instead of

	profiler.Start(...)
	defer profiler.Stop()

and wasn't getting any profiles. Explicitly logging when the profiler is
stopped makes that easier to catch. Only log if startup logging is also
enabled to avoid log spam.
