### PR TITLE
Use span read lock when reading span meta from span context

### DIFF
--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -127,8 +127,8 @@ func (c *spanContext) baggageItem(key string) string {
 }
 
 func (c *spanContext) meta(key string) (val string, ok bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.span.RLock()
+	defer c.span.RLock()
 	val, ok = c.span.Meta[key]
 	return val, ok
 }


### PR DESCRIPTION
This was a big oversight when I implemented https://github.com/DataDog/dd-trace-go/pull/1226. Instead of using the span's mutex to protect the reading of the span's meta, I used the span context's mutex. This caused a race condition/panic when a concurrent goroutine called `trace.finishedOne`. 