### PR TITLE
profiler: simplify multipart request handling in tests

### DIFF
--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -333,7 +333,7 @@ func TestAllUploaded(t *testing.T) {
 			default:
 			}
 		}()
-		if err := r.ParseMultipartForm(-1); err != nil {
+		if err := r.ParseMultipartForm(50 << 20); err != nil {
 			t.Fatalf("bad multipart form: %s", err)
 			return
 		}

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -386,7 +386,7 @@ func TestCorrectTags(t *testing.T) {
 		defer func() {
 			got <- tags
 		}()
-		if err := r.ParseMultipartForm(-1); err != nil {
+		if err := r.ParseMultipartForm(50 << 20); err != nil {
 			t.Fatalf("bad multipart form: %s", err)
 			return
 		}

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -8,9 +8,6 @@ package profiler
 import (
 	"encoding/json"
 	"fmt"
-	"io"
-	"mime"
-	"mime/multipart"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -336,29 +333,14 @@ func TestAllUploaded(t *testing.T) {
 			default:
 			}
 		}()
-		_, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
-		if err != nil {
-			t.Fatalf("bad media type: %s", err)
+		if err := r.ParseMultipartForm(-1); err != nil {
+			t.Fatalf("bad multipart form: %s", err)
 			return
 		}
-		mr := multipart.NewReader(r.Body, params["boundary"])
-		for {
-			p, err := mr.NextPart()
-			if err == io.EOF {
-				return
-			}
-			if err != nil {
-				t.Fatalf("next part: %s", err)
-			}
-			if p.FormName() == "tags[]" {
-				val, err := io.ReadAll(p)
-				if err != nil {
-					t.Fatalf("next part: %s", err)
-				}
-				profile.tags = append(profile.tags, string(val))
-			}
-			if p.FileName() == "pprof-data" {
-				profile.files = append(profile.files, p.FormName())
+		profile.tags = append(profile.tags, r.Form["tags[]"]...)
+		for k, v := range r.MultipartForm.File {
+			if v[0].Filename == "pprof-data" {
+				profile.files = append(profile.files, k)
 			}
 		}
 	}))
@@ -404,28 +386,11 @@ func TestCorrectTags(t *testing.T) {
 		defer func() {
 			got <- tags
 		}()
-		_, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
-		if err != nil {
-			t.Fatalf("bad media type: %s", err)
+		if err := r.ParseMultipartForm(-1); err != nil {
+			t.Fatalf("bad multipart form: %s", err)
 			return
 		}
-		mr := multipart.NewReader(r.Body, params["boundary"])
-		for {
-			p, err := mr.NextPart()
-			if err == io.EOF {
-				return
-			}
-			if err != nil {
-				t.Fatalf("next part: %s", err)
-			}
-			if p.FormName() == "tags[]" {
-				tag, err := io.ReadAll(p)
-				if err != nil {
-					t.Fatalf("reading tags: %s", err)
-				}
-				tags = append(tags, string(tag))
-			}
-		}
+		tags = append(tags, r.Form["tags[]"]...)
 	}))
 	defer server.Close()
 

--- a/profiler/upload_test.go
+++ b/profiler/upload_test.go
@@ -219,7 +219,7 @@ func newTestServer(t *testing.T, statusCode int) *testServer {
 		t.Helper()
 		w.WriteHeader(statusCode)
 		ts.header = req.Header
-		if err := req.ParseMultipartForm(-1); err != nil {
+		if err := req.ParseMultipartForm(50 << 20); err != nil {
 			t.Fatalf("bad multipart form: %s", err)
 			return
 		}

--- a/profiler/upload_test.go
+++ b/profiler/upload_test.go
@@ -232,6 +232,7 @@ func newTestServer(t *testing.T, statusCode int) *testServer {
 			if err != nil {
 				t.Fatal(err)
 			}
+			defer file.Close()
 			body, err := io.ReadAll(file)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
The http.Request type has methods for dealing with multipart requests,
and we can use them to simplify the request handlers for some of our
tests.
