### PR TITLE
profiler: add WithHostname option

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -514,3 +514,12 @@ func WithLogStartup(enabled bool) Option {
 		cfg.logStartup = enabled
 	}
 }
+
+// WithHostname sets the hostname which will be added to uploaded profiles
+// through the "host:<hostname>" tag. If no hostname is given, the hostname will
+// default to the output of os.Hostname()
+func WithHostname(hostname string) Option {
+	return func(cfg *config) {
+		cfg.hostname = hostname
+	}
+}

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -222,6 +222,12 @@ func TestOptions(t *testing.T) {
 		WithDeltaProfiles(false)(&cfg)
 		assert.Equal(t, false, cfg.deltaProfiles)
 	})
+
+	t.Run("WithHostname", func(t *testing.T) {
+		var cfg config
+		WithHostname("example")(&cfg)
+		assert.Equal(t, "example", cfg.hostname)
+	})
 }
 
 func TestEnvVars(t *testing.T) {

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -439,6 +439,7 @@ func TestCorrectTags(t *testing.T) {
 		WithService("xyz"),
 		WithEnv("testing"),
 		WithTags("foo:bar", "baz:bonk"),
+		WithHostname("example"),
 	)
 	defer Stop()
 	expected := []string{
@@ -446,6 +447,7 @@ func TestCorrectTags(t *testing.T) {
 		"env:testing",
 		"foo:bar",
 		"service:xyz",
+		"host:example",
 	}
 	for i := 0; i < 20; i++ {
 		// We check the tags we get several times to try to have a


### PR DESCRIPTION
This allows overriding the value used for the `"host"` tag, consistent
with the `WithHostname` tracer option.

Fixes #1441
