### PR TITLE
internal/telemetry: fix seqID atomic alignment bug

### DIFF
--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -18,7 +18,6 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal"
@@ -355,13 +354,13 @@ func getOSVersion() string {
 // newRequests populates a request with the common fields shared by all requests
 // sent through this Client
 func (c *Client) newRequest(t RequestType) *Request {
-	seqID := atomic.AddInt64(&c.seqID, 1)
+	c.seqID += 1
 	return &Request{
 		APIVersion:  "v1",
 		RequestType: t,
 		TracerTime:  time.Now().Unix(),
 		RuntimeID:   globalconfig.RuntimeID(),
-		SeqID:       seqID,
+		SeqID:       c.seqID,
 		Debug:       c.debug,
 		Application: Application{
 			ServiceName:     c.Service,


### PR DESCRIPTION
Accessing Client.seqID atomically lead to alignment errors on 32-bit
architectures, e.g.:

	$ env GOARCH=arm go test -exec=/usr/bin/qemu ./internal/telemetry
	--- FAIL: TestClient (0.02s)
	panic: unaligned 64-bit atomic operation [recovered]
		panic: unaligned 64-bit atomic operation

	goroutine 17 [running]:
	testing.tRunner.func1.2({0x300328, 0x3b0728})
		/home/vagrant/sdk/go1.18.3/src/testing/testing.go:1389 +0x27c
	testing.tRunner.func1()
		/home/vagrant/sdk/go1.18.3/src/testing/testing.go:1392 +0x3f4
	panic({0x300328, 0x3b0728})
		/home/vagrant/sdk/go1.18.3/src/runtime/panic.go:838 +0x23c
	runtime/internal/atomic.panicUnaligned()
		/home/vagrant/sdk/go1.18.3/src/runtime/internal/atomic/unaligned.go:8 +0x24
	runtime/internal/atomic.Xadd64(0x94c054, 0x1)
		/home/vagrant/sdk/go1.18.3/src/runtime/internal/atomic/atomic_arm.s:258 +0x14
	gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.(*Client).newRequest(0x94c000, {0x33d35f, 0xb})
		/dd-trace-go/internal/telemetry/client.go:358 +0x34
	...

But all accesses to Client.seqID are guarded by Client.mu, so the atomic
access isn't necessary.
