### PR TITLE
profiler: upgrade to v2.4 upload format

### DIFF
--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -8,12 +8,14 @@ package profiler
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"math/rand"
 	"mime/multipart"
 	"net/http"
+	"strings"
 	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
@@ -123,41 +125,53 @@ func (p *profiler) doRequest(bat batch) error {
 	return errors.New(resp.Status)
 }
 
+type uploadEvent struct {
+	Start       string   `json:"start"`
+	End         string   `json:"end"`
+	Attachments []string `json:"attachments"`
+	Tags        string   `json:"tags_profiler"`
+	Family      string   `json:"family"`
+	Version     string   `json:"version"`
+}
+
 // encode encodes the profile as a multipart mime request.
 func encode(bat batch, tags []string) (contentType string, body io.Reader, err error) {
 	var buf bytes.Buffer
 
 	mw := multipart.NewWriter(&buf)
-	// write all of the profile metadata (including some useless ones)
-	// with a small helper function that makes error tracking less verbose.
-	writeField := func(k, v string) {
-		if err == nil {
-			err = mw.WriteField(k, v)
-		}
-	}
-	writeField("version", "3")
-	writeField("family", "go")
-	writeField("start", bat.start.Format(time.RFC3339))
-	writeField("end", bat.end.Format(time.RFC3339))
+
 	if bat.host != "" {
-		writeField("tags[]", fmt.Sprintf("host:%s", bat.host))
+		tags = append(tags, fmt.Sprintf("host:%s", bat.host))
 	}
-	writeField("tags[]", "runtime:go")
-	for _, tag := range tags {
-		writeField("tags[]", tag)
+	tags = append(tags, "runtime:go")
+
+	event := &uploadEvent{
+		Version: "4",
+		Family:  "go",
+		Start:   bat.start.Format(time.RFC3339),
+		End:     bat.end.Format(time.RFC3339),
+		Tags:    strings.Join(tags, ","),
 	}
-	if err != nil {
-		return "", nil, err
-	}
+
 	for _, p := range bat.profiles {
-		formFile, err := mw.CreateFormFile(fmt.Sprintf("data[%s]", p.name), "pprof-data")
+		event.Attachments = append(event.Attachments, p.name)
+		f, err := mw.CreateFormFile(p.name, p.name)
 		if err != nil {
 			return "", nil, err
 		}
-		if _, err := formFile.Write(p.data); err != nil {
+		if _, err := f.Write(p.data); err != nil {
 			return "", nil, err
 		}
 	}
+
+	f, err := mw.CreateFormFile("event", "event.json")
+	if err != nil {
+		return "", nil, err
+	}
+	if err := json.NewEncoder(f).Encode(event); err != nil {
+		return "", nil, err
+	}
+
 	if err := mw.Close(); err != nil {
 		return "", nil, err
 	}

--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -15,6 +15,7 @@ import (
 	"math/rand"
 	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"strings"
 	"time"
 
@@ -164,7 +165,10 @@ func encode(bat batch, tags []string) (contentType string, body io.Reader, err e
 		}
 	}
 
-	f, err := mw.CreateFormFile("event", "event.json")
+	f, err := mw.CreatePart(textproto.MIMEHeader{
+		"Content-Disposition": []string{`form-data; name="event"; filename="event.json"`},
+		"Content-Type":        []string{"application/json"},
+	})
 	if err != nil {
 		return "", nil, err
 	}

--- a/profiler/upload_test.go
+++ b/profiler/upload_test.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"runtime"
 	"strings"
@@ -47,10 +46,11 @@ func TestTryUpload(t *testing.T) {
 	defer func(cid string) { containerID = cid }(containerID)
 	containerID = ""
 
-	srv := startHTTPTestServer(t, 200)
-	defer srv.close()
+	profiles := make(chan profileMeta, 1)
+	server := httptest.NewServer(&mockBackend{t: t, profiles: profiles})
+	defer server.Close()
 	p, err := unstartedProfiler(
-		WithAgentAddr(srv.address),
+		WithAgentAddr(server.Listener.Addr().String()),
 		WithService("my-service"),
 		WithEnv("my-env"),
 		WithTags("tag1:1", "tag2:2"),
@@ -58,10 +58,10 @@ func TestTryUpload(t *testing.T) {
 	require.NoError(t, err)
 	err = p.doRequest(testBatch)
 	require.NoError(t, err)
-	header, fields, tags := srv.wait()
+	profile := <-profiles
 
 	assert := assert.New(t)
-	assert.Empty(header.Get("Datadog-Container-ID"))
+	assert.Empty(profile.headers.Get("Datadog-Container-ID"))
 	assert.ElementsMatch([]string{
 		"host:my-host",
 		"runtime:go",
@@ -77,48 +77,54 @@ func TestTryUpload(t *testing.T) {
 		fmt.Sprintf("runtime_arch:%s", runtime.GOARCH),
 		fmt.Sprintf("runtime_os:%s", runtime.GOOS),
 		fmt.Sprintf("runtime-id:%s", globalconfig.RuntimeID()),
-	}, tags)
-	for k, v := range map[string]string{
-		"version":          "3",
-		"family":           "go",
-		"data[cpu.pprof]":  "my-cpu-profile",
-		"data[heap.pprof]": "my-heap-profile",
+	}, profile.tags)
+	assert.Equal(profile.event.Version, "4")
+	assert.Equal(profile.event.Family, "go")
+	assert.NotNil(profile.event.Start)
+	assert.NotNil(profile.event.End)
+	for k, v := range map[string][]byte{
+		"cpu.pprof":  []byte("my-cpu-profile"),
+		"heap.pprof": []byte("my-heap-profile"),
 	} {
-		assert.Equal(v, fields[k], k)
-	}
-	for _, k := range []string{"start", "end"} {
-		_, ok := fields[k]
-		assert.True(ok, "key should be present: %s", k)
-	}
-	for _, k := range []string{"runtime", "format"} {
-		_, ok := fields[k]
-		assert.False(ok, "key should not be present: %s", k)
+		assert.Equal(v, profile.attachments[k])
 	}
 }
 
 func TestTryUploadUDS(t *testing.T) {
-	srv := startSocketTestServer(t, 200)
-	defer srv.close()
+	profiles := make(chan profileMeta, 1)
+	server := httptest.NewUnstartedServer(&mockBackend{t: t, profiles: profiles})
+	udsPath := "/tmp/com.datadoghq.dd-trace-go.profiler.test.sock"
+	l, err := net.Listen("unix", udsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	server.Listener = l
+	server.Start()
+	defer server.Close()
+
 	p, err := unstartedProfiler(
-		WithUDS(srv.address),
+		WithUDS(udsPath),
 	)
 	require.NoError(t, err)
 	err = p.doRequest(testBatch)
 	require.NoError(t, err)
-	_, _, tags := srv.wait()
+	profile := <-profiles
 
 	assert := assert.New(t)
-	assert.ElementsMatch([]string{
+	assert.Subset(profile.tags, []string{
 		"host:my-host",
 		"runtime:go",
-	}, tags[0:2])
+	})
 }
 
 func Test202Accepted(t *testing.T) {
-	srv := startHTTPTestServer(t, 202)
-	defer srv.close()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
 	p, err := unstartedProfiler(
-		WithAgentAddr(srv.address),
+		WithAgentAddr(server.Listener.Addr().String()),
 		WithService("my-service"),
 		WithEnv("my-env"),
 		WithTags("tag1:1", "tag2:2"),
@@ -129,10 +135,12 @@ func Test202Accepted(t *testing.T) {
 }
 
 func TestOldAgent(t *testing.T) {
-	srv := startHTTPTestServer(t, 404)
-	defer srv.close()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
 	p, err := unstartedProfiler(
-		WithAgentAddr(srv.address),
+		WithAgentAddr(server.Listener.Addr().String()),
 		WithService("my-service"),
 		WithEnv("my-env"),
 		WithTags("tag1:1", "tag2:2"),
@@ -147,10 +155,11 @@ func TestContainerIDHeader(t *testing.T) {
 	defer func(cid string) { containerID = cid }(containerID)
 	containerID = "fakeContainerID"
 
-	srv := startHTTPTestServer(t, 200)
-	defer srv.close()
+	profiles := make(chan profileMeta, 1)
+	server := httptest.NewServer(&mockBackend{t: t, profiles: profiles})
+	defer server.Close()
 	p, err := unstartedProfiler(
-		WithAgentAddr(srv.address),
+		WithAgentAddr(server.Listener.Addr().String()),
 		WithService("my-service"),
 		WithEnv("my-env"),
 		WithTags("tag1:1", "tag2:2"),
@@ -159,8 +168,8 @@ func TestContainerIDHeader(t *testing.T) {
 	err = p.doRequest(testBatch)
 	require.NoError(t, err)
 
-	header, _, _ := srv.wait()
-	assert.Equal(t, containerID, header.Get("Datadog-Container-Id"))
+	profile := <-profiles
+	assert.Equal(t, containerID, profile.headers.Get("Datadog-Container-Id"))
 }
 
 func BenchmarkDoRequest(b *testing.B) {
@@ -191,104 +200,4 @@ func BenchmarkDoRequest(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		p.doRequest(bat)
 	}
-}
-
-type testServerWaiter func() (http.Header, map[string]string, []string)
-
-type testServer struct {
-	t       *testing.T
-	handler http.HandlerFunc
-
-	// for recording request state
-	waitc  chan struct{}
-	header http.Header
-	fields map[string]string
-	tags   []string
-
-	address string
-	close   func() error
-}
-
-func newTestServer(t *testing.T, statusCode int) *testServer {
-	ts := &testServer{
-		t:      t,
-		waitc:  make(chan struct{}),
-		fields: make(map[string]string),
-	}
-	ts.handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		t.Helper()
-		w.WriteHeader(statusCode)
-		ts.header = req.Header
-		if err := req.ParseMultipartForm(50 << 20); err != nil {
-			t.Fatalf("bad multipart form: %s", err)
-			return
-		}
-		ts.tags = append(ts.tags, req.Form["tags[]"]...)
-		for k, v := range req.MultipartForm.Value {
-			ts.fields[k] = v[0]
-		}
-		for k, v := range req.MultipartForm.File {
-			file, err := v[0].Open()
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer file.Close()
-			body, err := io.ReadAll(file)
-			if err != nil {
-				t.Fatal(err)
-			}
-			ts.fields[k] = string(body)
-		}
-		close(ts.waitc)
-	})
-	return ts
-}
-
-func (ts *testServer) wait() (http.Header, map[string]string, []string) {
-	ts.t.Helper()
-	select {
-	case <-ts.waitc:
-		// OK
-		return ts.header, ts.fields, ts.tags
-	case <-time.After(time.Second):
-		ts.t.Fatalf("timeout")
-		return nil, nil, nil
-	}
-}
-
-func startHTTPTestServer(t *testing.T, statusCode int) *testServer {
-	t.Helper()
-	ts := newTestServer(t, statusCode)
-	server := httptest.NewServer(ts.handler)
-	ts.close = func() error {
-		server.Close()
-		return nil
-	}
-
-	srvURL, err := url.Parse(server.URL)
-	if err != nil {
-		server.Close()
-		t.Fatalf("failed to parse server url")
-		return nil
-	}
-	ts.address = srvURL.Host
-
-	return ts
-}
-
-func startSocketTestServer(t *testing.T, statusCode int) *testServer {
-	t.Helper()
-	udsPath := "/tmp/com.datadoghq.dd-trace-go.profiler.test.sock"
-	ts := newTestServer(t, statusCode)
-	server := http.Server{Handler: ts.handler}
-	ts.close = server.Close
-	ts.address = udsPath
-
-	unixListener, err := net.Listen("unix", udsPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	go server.Serve(unixListener)
-
-	return ts
 }


### PR DESCRIPTION
Upgrading to format v2.4 lets us add custom attributes to uploaded
profiles, which have more rich type information than tags and allow for
better querying & sorting in the Datadog UI.

Along the way, consolidate some of the duplicated testing code for
creating test servers in the profiler and upload tests.
