### PR TITLE
contrib/database/sql: move trace context info to w3c trace context tags

### DIFF
--- a/contrib/database/sql/injection_test.go
+++ b/contrib/database/sql/injection_test.go
@@ -97,7 +97,7 @@ func TestCommentInjection(t *testing.T) {
 				_, err := db.QueryContext(ctx, "SELECT 1 from DUAL")
 				return err
 			},
-			executed: []*regexp.Regexp{regexp.MustCompile("/\\*dddbs='test.db',dde='test-env',ddsid='\\d+',ddsn='test-service',ddsp='1',ddsv='1.0.0',ddtid='1'\\*/ SELECT 1 from DUAL")},
+			executed: []*regexp.Regexp{regexp.MustCompile("/\\*dddbs='test.db',dde='test-env',ddsn='test-service',ddsv='1.0.0',traceparent='00-00000000000000000000000000000001-[\\da-f]{16}-01'\\*/ SELECT 1 from DUAL")},
 		},
 		{
 			name: "exec",
@@ -133,7 +133,7 @@ func TestCommentInjection(t *testing.T) {
 				_, err := db.ExecContext(ctx, "SELECT 1 from DUAL")
 				return err
 			},
-			executed: []*regexp.Regexp{regexp.MustCompile("/\\*dddbs='test.db',dde='test-env',ddsid='\\d+',ddsn='test-service',ddsp='1',ddsv='1.0.0',ddtid='1'\\*/ SELECT 1 from DUAL")},
+			executed: []*regexp.Regexp{regexp.MustCompile("/\\*dddbs='test.db',dde='test-env',ddsn='test-service',ddsv='1.0.0',traceparent='00-00000000000000000000000000000001-[\\da-f]{16}-01'\\*/ SELECT 1 from DUAL")},
 		},
 	}
 
@@ -163,7 +163,7 @@ func TestCommentInjection(t *testing.T) {
 			for i, e := range tc.executed {
 				assert.Regexp(t, e, d.Executed[i])
 				// the injected span ID should not be the parent's span ID
-				assert.NotContains(t, d.Executed[i], "ddsid='1'")
+				assert.NotContains(t, d.Executed[i], "traceparent='00-00000000000000000000000000000001-0000000000000001")
 			}
 		})
 	}

--- a/contrib/database/sql/injection_test.go
+++ b/contrib/database/sql/injection_test.go
@@ -52,7 +52,7 @@ func TestCommentInjection(t *testing.T) {
 				_, err := db.PrepareContext(ctx, "SELECT 1 from DUAL")
 				return err
 			},
-			prepared: []string{"/*dddbs='test.db',dde='test-env',ddsn='test-service',ddsv='1.0.0'*/ SELECT 1 from DUAL"},
+			prepared: []string{"/*dddbs='test.db',dde='test-env',ddps='test-service',ddpv='1.0.0'*/ SELECT 1 from DUAL"},
 		},
 		{
 			name: "prepare-full",
@@ -61,7 +61,7 @@ func TestCommentInjection(t *testing.T) {
 				_, err := db.PrepareContext(ctx, "SELECT 1 from DUAL")
 				return err
 			},
-			prepared: []string{"/*dddbs='test.db',dde='test-env',ddsn='test-service',ddsv='1.0.0'*/ SELECT 1 from DUAL"},
+			prepared: []string{"/*dddbs='test.db',dde='test-env',ddps='test-service',ddpv='1.0.0'*/ SELECT 1 from DUAL"},
 		},
 		{
 			name: "query",
@@ -88,7 +88,7 @@ func TestCommentInjection(t *testing.T) {
 				_, err := db.QueryContext(ctx, "SELECT 1 from DUAL")
 				return err
 			},
-			executed: []*regexp.Regexp{regexp.MustCompile("/\\*dddbs='test.db',dde='test-env',ddsn='test-service',ddsv='1.0.0'\\*/ SELECT 1 from DUAL")},
+			executed: []*regexp.Regexp{regexp.MustCompile("/\\*dddbs='test.db',dde='test-env',ddps='test-service',ddpv='1.0.0'\\*/ SELECT 1 from DUAL")},
 		},
 		{
 			name: "query-full",
@@ -97,7 +97,7 @@ func TestCommentInjection(t *testing.T) {
 				_, err := db.QueryContext(ctx, "SELECT 1 from DUAL")
 				return err
 			},
-			executed: []*regexp.Regexp{regexp.MustCompile("/\\*dddbs='test.db',dde='test-env',ddsn='test-service',ddsv='1.0.0',traceparent='00-00000000000000000000000000000001-[\\da-f]{16}-01'\\*/ SELECT 1 from DUAL")},
+			executed: []*regexp.Regexp{regexp.MustCompile("/\\*dddbs='test.db',dde='test-env',ddps='test-service',ddpv='1.0.0',traceparent='00-00000000000000000000000000000001-[\\da-f]{16}-01'\\*/ SELECT 1 from DUAL")},
 		},
 		{
 			name: "exec",
@@ -124,7 +124,7 @@ func TestCommentInjection(t *testing.T) {
 				_, err := db.ExecContext(ctx, "SELECT 1 from DUAL")
 				return err
 			},
-			executed: []*regexp.Regexp{regexp.MustCompile("/\\*dddbs='test.db',dde='test-env',ddsn='test-service',ddsv='1.0.0'\\*/ SELECT 1 from DUAL")},
+			executed: []*regexp.Regexp{regexp.MustCompile("/\\*dddbs='test.db',dde='test-env',ddps='test-service',ddpv='1.0.0'\\*/ SELECT 1 from DUAL")},
 		},
 		{
 			name: "exec-full",
@@ -133,7 +133,7 @@ func TestCommentInjection(t *testing.T) {
 				_, err := db.ExecContext(ctx, "SELECT 1 from DUAL")
 				return err
 			},
-			executed: []*regexp.Regexp{regexp.MustCompile("/\\*dddbs='test.db',dde='test-env',ddsn='test-service',ddsv='1.0.0',traceparent='00-00000000000000000000000000000001-[\\da-f]{16}-01'\\*/ SELECT 1 from DUAL")},
+			executed: []*regexp.Regexp{regexp.MustCompile("/\\*dddbs='test.db',dde='test-env',ddps='test-service',ddpv='1.0.0',traceparent='00-00000000000000000000000000000001-[\\da-f]{16}-01'\\*/ SELECT 1 from DUAL")},
 		},
 	}
 

--- a/ddtrace/tracer/sqlcomment.go
+++ b/ddtrace/tracer/sqlcomment.go
@@ -6,6 +6,7 @@
 package tracer
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -78,24 +79,15 @@ func (c *SQLCommentCarrier) Inject(spanCtx ddtrace.SpanContext) error {
 		if samplingPriority > 0 {
 			sampled = 1
 		}
-		var b strings.Builder
-		b.WriteString(w3cContextVersion)
-		b.WriteRune('-')
 		tid := strconv.FormatUint(traceID, 16)
-		for i := 0; i < 32-len(tid); i++ {
-			b.WriteRune('0')
+		if len(tid) > 32 {
+			tid = tid[:32]
 		}
-		b.WriteString(tid)
-		b.WriteRune('-')
 		sid := strconv.FormatUint(c.SpanID, 16)
-		for i := 0; i < 16-len(sid); i++ {
-			b.WriteRune('0')
+		if len(sid) > 16 {
+			sid = sid[:16]
 		}
-		b.WriteString(sid)
-		b.WriteRune('-')
-		b.WriteRune('0')
-		b.WriteString(strconv.FormatInt(sampled, 16))
-		tags[sqlCommentTraceParent] = b.String()
+		tags[sqlCommentTraceParent] = fmt.Sprintf("%s-%032s-%016s-%02s", w3cContextVersion, tid, sid, strconv.FormatInt(sampled, 16))
 		fallthrough
 	case SQLInjectionModeService:
 		var env, version string

--- a/ddtrace/tracer/sqlcomment.go
+++ b/ddtrace/tracer/sqlcomment.go
@@ -6,7 +6,6 @@
 package tracer
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -79,15 +78,24 @@ func (c *SQLCommentCarrier) Inject(spanCtx ddtrace.SpanContext) error {
 		if samplingPriority > 0 {
 			sampled = 1
 		}
+		var b strings.Builder
+		b.WriteString(w3cContextVersion)
+		b.WriteRune('-')
 		tid := strconv.FormatUint(traceID, 16)
-		if len(tid) > 32 {
-			tid = tid[:32]
+		for i := 0; i < 32-len(tid); i++ {
+			b.WriteRune('0')
 		}
+		b.WriteString(tid)
+		b.WriteRune('-')
 		sid := strconv.FormatUint(c.SpanID, 16)
-		if len(sid) > 16 {
-			sid = sid[:16]
+		for i := 0; i < 16-len(sid); i++ {
+			b.WriteRune('0')
 		}
-		tags[sqlCommentTraceParent] = fmt.Sprintf("%s-%032s-%016s-%02s", w3cContextVersion, tid, sid, strconv.FormatInt(sampled, 16))
+		b.WriteString(sid)
+		b.WriteRune('-')
+		b.WriteRune('0')
+		b.WriteString(strconv.FormatInt(sampled, 16))
+		tags[sqlCommentTraceParent] = b.String()
 		fallthrough
 	case SQLInjectionModeService:
 		var env, version string

--- a/ddtrace/tracer/sqlcomment.go
+++ b/ddtrace/tracer/sqlcomment.go
@@ -86,7 +86,7 @@ func (c *SQLCommentCarrier) Inject(spanCtx ddtrace.SpanContext) error {
 			if v, ok := ctx.meta(ext.Version); ok {
 				version = v
 			}
-			if s := ctx.span; s != nil {
+			if ctx.span != nil {
 				tags[sqlCommentDBService] = ctx.span.Service
 			}
 		}

--- a/ddtrace/tracer/sqlcomment.go
+++ b/ddtrace/tracer/sqlcomment.go
@@ -79,15 +79,7 @@ func (c *SQLCommentCarrier) Inject(spanCtx ddtrace.SpanContext) error {
 		if samplingPriority > 0 {
 			sampled = 1
 		}
-		tid := strconv.FormatUint(traceID, 16)
-		if len(tid) > 32 {
-			tid = tid[:32]
-		}
-		sid := strconv.FormatUint(c.SpanID, 16)
-		if len(sid) > 16 {
-			sid = sid[:16]
-		}
-		tags[sqlCommentTraceParent] = fmt.Sprintf("%s-%032s-%016s-%02s", w3cContextVersion, tid, sid, strconv.FormatInt(sampled, 16))
+		tags[sqlCommentTraceParent] = fmt.Sprintf("%s-%032s-%016s-%02s", w3cContextVersion, strconv.FormatUint(traceID, 16), strconv.FormatUint(c.SpanID, 16), strconv.FormatInt(sampled, 16))
 		fallthrough
 	case SQLInjectionModeService:
 		var env, version string

--- a/ddtrace/tracer/sqlcomment.go
+++ b/ddtrace/tracer/sqlcomment.go
@@ -86,9 +86,6 @@ func (c *SQLCommentCarrier) Inject(spanCtx ddtrace.SpanContext) error {
 			if v, ok := ctx.meta(ext.Version); ok {
 				version = v
 			}
-			if ctx.span != nil {
-				tags[sqlCommentDBService] = ctx.span.Service
-			}
 		}
 		if globalconfig.ServiceName() != "" {
 			tags[sqlCommentService] = globalconfig.ServiceName()

--- a/ddtrace/tracer/sqlcomment.go
+++ b/ddtrace/tracer/sqlcomment.go
@@ -32,9 +32,9 @@ const (
 // Key names for SQL comment tags.
 const (
 	sqlCommentTraceParent   = "traceparent"
-	sqlCommentParentService = "ddsn"
+	sqlCommentParentService = "ddps"
 	sqlCommentDBService     = "dddbs"
-	sqlCommentParentVersion = "ddsv"
+	sqlCommentParentVersion = "ddpv"
 	sqlCommentParentEnv     = "dde"
 )
 

--- a/ddtrace/tracer/sqlcomment.go
+++ b/ddtrace/tracer/sqlcomment.go
@@ -86,6 +86,9 @@ func (c *SQLCommentCarrier) Inject(spanCtx ddtrace.SpanContext) error {
 			if v, ok := ctx.meta(ext.Version); ok {
 				version = v
 			}
+			if s := ctx.span; s != nil {
+				tags[sqlCommentDBService] = ctx.span.Service
+			}
 		}
 		if globalconfig.ServiceName() != "" {
 			tags[sqlCommentService] = globalconfig.ServiceName()

--- a/ddtrace/tracer/sqlcomment.go
+++ b/ddtrace/tracer/sqlcomment.go
@@ -35,7 +35,7 @@ const (
 	sqlCommentParentService = "ddps"
 	sqlCommentDBService     = "dddbs"
 	sqlCommentParentVersion = "ddpv"
-	sqlCommentParentEnv     = "dde"
+	sqlCommentEnv           = "dde"
 )
 
 // Current trace context version (see https://www.w3.org/TR/trace-context/#version)
@@ -94,7 +94,7 @@ func (c *SQLCommentCarrier) Inject(spanCtx ddtrace.SpanContext) error {
 			tags[sqlCommentParentService] = globalconfig.ServiceName()
 		}
 		if env != "" {
-			tags[sqlCommentParentEnv] = env
+			tags[sqlCommentEnv] = env
 		}
 		if version != "" {
 			tags[sqlCommentParentVersion] = version
@@ -145,7 +145,7 @@ func commentQuery(query string, tags map[string]string) string {
 	var b strings.Builder
 	// the sqlcommenter specification dictates that tags should be sorted. Since we know all injected keys,
 	// we skip a sorting operation by specifying the order of keys statically
-	orderedKeys := []string{sqlCommentDBService, sqlCommentParentEnv, sqlCommentParentService, sqlCommentParentVersion, sqlCommentTraceParent}
+	orderedKeys := []string{sqlCommentDBService, sqlCommentEnv, sqlCommentParentService, sqlCommentParentVersion, sqlCommentTraceParent}
 	first := true
 	for _, k := range orderedKeys {
 		if v, ok := tags[k]; ok {

--- a/ddtrace/tracer/sqlcomment_test.go
+++ b/ddtrace/tracer/sqlcomment_test.go
@@ -6,6 +6,7 @@
 package tracer
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -23,6 +24,7 @@ func TestSQLCommentCarrier(t *testing.T) {
 		query             string
 		mode              SQLCommentInjectionMode
 		injectSpan        bool
+		samplingPriority  int
 		expectedQuery     string
 		expectedSpanIDGen bool
 	}{
@@ -31,7 +33,7 @@ func TestSQLCommentCarrier(t *testing.T) {
 			query:             "SELECT * from FOO",
 			mode:              SQLInjectionModeFull,
 			injectSpan:        true,
-			expectedQuery:     "/*dddbs='whiskey-db',dde='test-env',ddsid='<span_id>',ddsn='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddsp='2',ddsv='1.0.0',ddtid='10'*/ SELECT * from FOO",
+			expectedQuery:     "/*dddbs='whiskey-db',dde='test-env',ddsn='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddsv='1.0.0',traceparent='00-0000000000000000000000000000000a-<span_id>-00'*/ SELECT * from FOO",
 			expectedSpanIDGen: true,
 		},
 		{
@@ -46,7 +48,7 @@ func TestSQLCommentCarrier(t *testing.T) {
 			name:              "no-trace",
 			query:             "SELECT * from FOO",
 			mode:              SQLInjectionModeFull,
-			expectedQuery:     "/*dddbs='whiskey-db',ddsid='<span_id>',ddsn='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddsp='0',ddtid='<span_id>'*/ SELECT * from FOO",
+			expectedQuery:     "/*dddbs='whiskey-db',ddsn='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',traceparent='00-0000000000000000<span_id>-<span_id>-00'*/ SELECT * from FOO",
 			expectedSpanIDGen: true,
 		},
 		{
@@ -54,7 +56,7 @@ func TestSQLCommentCarrier(t *testing.T) {
 			query:             "",
 			mode:              SQLInjectionModeFull,
 			injectSpan:        true,
-			expectedQuery:     "/*dddbs='whiskey-db',dde='test-env',ddsid='<span_id>',ddsn='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddsp='2',ddsv='1.0.0',ddtid='10'*/",
+			expectedQuery:     "/*dddbs='whiskey-db',dde='test-env',ddsn='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddsv='1.0.0',traceparent='00-0000000000000000000000000000000a-<span_id>-00'*/",
 			expectedSpanIDGen: true,
 		},
 		{
@@ -62,7 +64,8 @@ func TestSQLCommentCarrier(t *testing.T) {
 			query:             "SELECT * from FOO -- test query",
 			mode:              SQLInjectionModeFull,
 			injectSpan:        true,
-			expectedQuery:     "/*dddbs='whiskey-db',dde='test-env',ddsid='<span_id>',ddsn='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddsp='2',ddsv='1.0.0',ddtid='10'*/ SELECT * from FOO -- test query",
+			samplingPriority:  1,
+			expectedQuery:     "/*dddbs='whiskey-db',dde='test-env',ddsn='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddsv='1.0.0',traceparent='00-0000000000000000000000000000000a-<span_id>-01'*/ SELECT * from FOO -- test query",
 			expectedSpanIDGen: true,
 		},
 	}
@@ -77,31 +80,29 @@ func TestSQLCommentCarrier(t *testing.T) {
 			var spanCtx ddtrace.SpanContext
 			if tc.injectSpan {
 				root := tracer.StartSpan("service.calling.db", WithSpanID(10)).(*span)
-				root.SetTag(ext.SamplingPriority, 2)
+				root.SetTag(ext.SamplingPriority, tc.samplingPriority)
 				spanCtx = root.Context()
 			}
 
 			carrier := SQLCommentCarrier{Query: tc.query, Mode: tc.mode, DBServiceName: "whiskey-db"}
 			err := carrier.Inject(spanCtx)
 			require.NoError(t, err)
-
-			expected := strings.ReplaceAll(tc.expectedQuery, "<span_id>", strconv.FormatUint(carrier.SpanID, 10))
+			expected := strings.ReplaceAll(tc.expectedQuery, "<span_id>", fmt.Sprintf("%016s", strconv.FormatUint(carrier.SpanID, 16)))
 			assert.Equal(t, expected, carrier.Query)
 		})
 	}
 }
 
-func BenchmarkSQLCommentSerialization(b *testing.B) {
-	t := map[string]string{
-		sqlCommentEnv:     "test-env",
-		sqlCommentTraceID: "0123456789",
-		sqlCommentSpanID:  "9876543210",
-		sqlCommentVersion: "1.0.0",
-		sqlCommentService: "test-svc",
-	}
+func BenchmarkSQLCommentInjection(b *testing.B) {
+	tracer := newTracer(WithService("whiskey-service !#$%&'()*+,/:;=?@[]"), WithEnv("test-env"), WithServiceVersion("1.0.0"))
+	defer tracer.Stop()
+	root := tracer.StartSpan("service.calling.db", WithSpanID(10)).(*span)
+	root.SetTag(ext.SamplingPriority, 2)
+	spanCtx := root.Context()
+	carrier := SQLCommentCarrier{Query: "SELECT 1 FROM dual", Mode: SQLInjectionModeFull, DBServiceName: "whiskey-db"}
 
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
-		commentQuery("SELECT 1 from DUAL", t)
+		carrier.Inject(spanCtx)
 	}
 }

--- a/ddtrace/tracer/sqlcomment_test.go
+++ b/ddtrace/tracer/sqlcomment_test.go
@@ -33,7 +33,7 @@ func TestSQLCommentCarrier(t *testing.T) {
 			query:             "SELECT * from FOO",
 			mode:              SQLInjectionModeFull,
 			injectSpan:        true,
-			expectedQuery:     "/*dddbs='whiskey-db',dde='test-env',ddsn='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddsv='1.0.0',traceparent='00-0000000000000000000000000000000a-<span_id>-00'*/ SELECT * from FOO",
+			expectedQuery:     "/*dddbs='whiskey-db',dde='test-env',ddps='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddpv='1.0.0',traceparent='00-0000000000000000000000000000000a-<span_id>-00'*/ SELECT * from FOO",
 			expectedSpanIDGen: true,
 		},
 		{
@@ -41,14 +41,14 @@ func TestSQLCommentCarrier(t *testing.T) {
 			query:             "SELECT * from FOO",
 			mode:              SQLInjectionModeService,
 			injectSpan:        true,
-			expectedQuery:     "/*dddbs='whiskey-db',dde='test-env',ddsn='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddsv='1.0.0'*/ SELECT * from FOO",
+			expectedQuery:     "/*dddbs='whiskey-db',dde='test-env',ddps='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddpv='1.0.0'*/ SELECT * from FOO",
 			expectedSpanIDGen: false,
 		},
 		{
 			name:              "no-trace",
 			query:             "SELECT * from FOO",
 			mode:              SQLInjectionModeFull,
-			expectedQuery:     "/*dddbs='whiskey-db',ddsn='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',traceparent='00-0000000000000000<span_id>-<span_id>-00'*/ SELECT * from FOO",
+			expectedQuery:     "/*dddbs='whiskey-db',ddps='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',traceparent='00-0000000000000000<span_id>-<span_id>-00'*/ SELECT * from FOO",
 			expectedSpanIDGen: true,
 		},
 		{
@@ -56,7 +56,7 @@ func TestSQLCommentCarrier(t *testing.T) {
 			query:             "",
 			mode:              SQLInjectionModeFull,
 			injectSpan:        true,
-			expectedQuery:     "/*dddbs='whiskey-db',dde='test-env',ddsn='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddsv='1.0.0',traceparent='00-0000000000000000000000000000000a-<span_id>-00'*/",
+			expectedQuery:     "/*dddbs='whiskey-db',dde='test-env',ddps='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddpv='1.0.0',traceparent='00-0000000000000000000000000000000a-<span_id>-00'*/",
 			expectedSpanIDGen: true,
 		},
 		{
@@ -65,7 +65,7 @@ func TestSQLCommentCarrier(t *testing.T) {
 			mode:              SQLInjectionModeFull,
 			injectSpan:        true,
 			samplingPriority:  1,
-			expectedQuery:     "/*dddbs='whiskey-db',dde='test-env',ddsn='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddsv='1.0.0',traceparent='00-0000000000000000000000000000000a-<span_id>-01'*/ SELECT * from FOO -- test query",
+			expectedQuery:     "/*dddbs='whiskey-db',dde='test-env',ddps='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddpv='1.0.0',traceparent='00-0000000000000000000000000000000a-<span_id>-01'*/ SELECT * from FOO -- test query",
 			expectedSpanIDGen: true,
 		},
 	}


### PR DESCRIPTION
This makes an important update following the latest RFC proposals which adopts `traceparent` for trace context propagation instead of the ddtid, ddsid and ddsp tags. traceparent follows the [w3c trace context standard format](https://www.w3.org/TR/trace-context/#tracestate-header). 

A few related tweaks:
* I also renamed a few constants to match the more standard naming of "parent" instead of "client".
* I made the benchmark include the `Inject` in addition to the serialization of the comment. The reason being that `traceparent` includes some string formatting and I wanted to compare the performance before and after we switched to the formatted `traceparent`. You'll see that we get a hit from having a formatted value. It seems like an acceptable tradeoff. I did try an optimized version using string builder instead of `fmt.Sprintf` but it didn't seem to me like the difference was worth the tradeoff in readability (but curious what you'd think). You can see the optimized version in the commit history if curious.

Benchmark results (with a count of 10 to have a larger sample):
## Before `traceparent`
```
goos: darwin
goarch: amd64
pkg: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkSQLCommentInjection-8   	   10000	    121805 ns/op	  914701 B/op	      10 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    122675 ns/op	  914704 B/op	      10 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    117988 ns/op	  914703 B/op	      10 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    120263 ns/op	  914714 B/op	      10 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    120329 ns/op	  914712 B/op	      10 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    177295 ns/op	  914673 B/op	      10 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    172559 ns/op	  914685 B/op	      10 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    135637 ns/op	  914726 B/op	      10 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    119889 ns/op	  914719 B/op	      10 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    120622 ns/op	  914662 B/op	      10 allocs/op
```

## With `traceparent` using `fmt.Sprintf`:
```
goos: darwin
goarch: amd64
pkg: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkSQLCommentInjection-8   	   10000	    146027 ns/op	 1025596 B/op	      16 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    140450 ns/op	 1025594 B/op	      16 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    138458 ns/op	 1025591 B/op	      16 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    139865 ns/op	 1025600 B/op	      16 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    140585 ns/op	 1025597 B/op	      16 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    141854 ns/op	 1025597 B/op	      16 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    138637 ns/op	 1025600 B/op	      16 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    141157 ns/op	 1025598 B/op	      16 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    141207 ns/op	 1025594 B/op	      16 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    141695 ns/op	 1025596 B/op	      16 allocs/op
PASS
```

## With `traceparent` using `strings.Builder` (better results but enough to justify the tradeoff in readability?):
```
goos: darwin
goarch: amd64
pkg: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkSQLCommentInjection-8   	   10000	    138128 ns/op	 1025447 B/op	      15 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    135008 ns/op	 1025447 B/op	      15 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    128053 ns/op	 1025447 B/op	      15 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    134668 ns/op	 1025447 B/op	      15 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    133481 ns/op	 1025446 B/op	      15 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    132804 ns/op	 1025447 B/op	      15 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    131245 ns/op	 1025447 B/op	      15 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    131303 ns/op	 1025446 B/op	      15 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    133096 ns/op	 1025446 B/op	      15 allocs/op
BenchmarkSQLCommentInjection-8   	   10000	    134777 ns/op	 1025447 B/op	      15 allocs/op
PASS
```

