### PR TITLE
ddtrace/tracer: Always count dropped p0 traces and spans

### DIFF
--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -335,6 +335,8 @@ func (t *tracer) sampleFinishedTrace(info *finishedTrace) {
 		return
 	}
 	if !t.rulesSampling.HasSpanRules() {
+		atomic.AddUint64(&t.droppedP0Traces, 1)
+		atomic.AddUint64(&t.droppedP0Spans, uint64(len(info.spans)))
 		info.spans = nil
 		return
 	}

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -351,6 +351,11 @@ func TestSamplingDecision(t *testing.T) {
 
 	t.Run("client_dropped", func(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t)
+		defer func() {
+			// Must check these after tracer is stopped to avoid flakiness
+			assert.Equal(t, uint64(1), tracer.droppedP0Traces)
+			assert.Equal(t, uint64(2), tracer.droppedP0Spans)
+		}()
 		defer stop()
 		tracer.config.agent.DropP0s = true
 		tracer.config.sampler = NewRateSampler(0)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,4 +8,4 @@ package version
 // Tag specifies the current release tag. It needs to be manually
 // updated. A test checks that the value of Tag never points to a
 // git tag that is older than HEAD.
-const Tag = "v1.41.0"
+const Tag = "v1.41.1"


### PR DESCRIPTION
Fixes an issue where if using client side stats not all dropped p0 traces and spans would be counted.
Note this PR is against the release-v1.41.x branch so it can be released as a hotfix for v1.41