### PR TITLE
contrib/net/http: don't set request path in Route field.

### DIFF
--- a/contrib/net/http/http.go
+++ b/contrib/net/http/http.go
@@ -75,7 +75,6 @@ func WrapHandler(h http.Handler, service, resource string, opts ...Option) http.
 			Resource:   resource,
 			FinishOpts: cfg.finishOpts,
 			SpanOpts:   cfg.spanOpts,
-			Route:      req.URL.EscapedPath(),
 		})
 	})
 }


### PR DESCRIPTION
### Problem
`http.route` tag should contain the matched route template and not the full http path. This information is not available in the `http.Handler` struct thus I chose to remove this line instead of fixing the function to provide this data.  If users want to send full http server information (including `http.route`) they should probably use `NewServeMux()` instead of `WrapHandler`
