### PR TITLE
ddtrace/tracer: better trace and span ID randomness

### DIFF
--- a/ddtrace/tracer/sqlcomment.go
+++ b/ddtrace/tracer/sqlcomment.go
@@ -53,7 +53,7 @@ type SQLCommentCarrier struct {
 
 // Inject injects a span context in the carrier's Query field as a comment.
 func (c *SQLCommentCarrier) Inject(spanCtx ddtrace.SpanContext) error {
-	c.SpanID = random.Uint64()
+	c.SpanID = generateSpanID(now())
 	tags := make(map[string]string)
 	switch c.Mode {
 	case SQLInjectionUndefined:

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -406,7 +406,7 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 	}
 	id := opts.SpanID
 	if id == 0 {
-		id = random.Uint64()
+		id = generateSpanID(startTime)
 	}
 	// span defaults
 	span := &span{
@@ -496,6 +496,13 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 			span, span.Name, span.Resource, span.Meta, span.Metrics)
 	}
 	return span
+}
+
+// generateSpanID returns a random uint64 that has been XORd with the startTime.
+// This is done to get around the 32-bit random seed limitation that may create collisions if there is a large number
+// of go services all generating spans.
+func generateSpanID(startTime int64) uint64 {
+	return random.Uint64() ^ uint64(startTime)
 }
 
 // applyPPROFLabels applies pprof labels for the profiler's code hotspots and

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -47,7 +47,7 @@ func (t *tracer) newChildSpan(name string, parent *span) *span {
 
 var (
 	// timeMultiplicator specifies by how long to extend waiting times.
-	// It may be altered in some envinronment (like AppSec) where things
+	// It may be altered in some environments (like AppSec) where things
 	// move slower and could otherwise create flaky tests.
 	timeMultiplicator = time.Duration(1)
 


### PR DESCRIPTION
This resolves an issue that _could_ cause collisions due to `random` only using a 32 bit seed. Even though we're generating a nice cryptographically secure 64 bit seed it actually is only using 32 bits. This means that if a customer is running a large number (e.g. > 30k) of go service instances that generate spans, there is a possibility for a traceid / spanID collision.

To resolve this we XOR the generated 64 bit number with the span start time, this keeps the random numbers evenly distributed but reduces the likelihood of a collision should two instances of a service get the same random seed.