### PR TITLE
AppSec for Opentracing

### DIFF
--- a/contrib/net/http/trace.go
+++ b/contrib/net/http/trace.go
@@ -66,6 +66,10 @@ type responseWriter struct {
 	status int
 }
 
+func WrapResponseWriter(w http.ResponseWriter) http.ResponseWriter {
+	return newResponseWriter(w)
+}
+
 func newResponseWriter(w http.ResponseWriter) *responseWriter {
 	return &responseWriter{w, 0}
 }

--- a/contrib/opentracing/opentracing.go
+++ b/contrib/opentracing/opentracing.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package opentracing
+
+import (
+	"net/http"
+
+	"github.com/opentracing/opentracing-go"
+
+	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation/httpsec"
+)
+
+func AppSecMiddleware(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := h
+		defer func() {
+			h.ServeHTTP(w, r)
+		}()
+		if !appsec.Enabled() {
+			return
+		}
+		sp := opentracing.SpanFromContext(r.Context())
+		if sp == nil {
+			return
+		}
+		w = httptrace.WrapResponseWriter(w)
+		h = httpsec.WrapHandler(h, span{Span: sp}, nil)
+	})
+}
+
+type span struct {
+	opentracing.Span
+}
+
+func (s span) SetTag(k string, v interface{}) {
+	s.Span.SetTag(k, v)
+}
+
+func (s span) GetTag(k string, v interface{}) {
+	s.Span.SetTag(k, v)
+}

--- a/contrib/opentracing/opentracing_test.go
+++ b/contrib/opentracing/opentracing_test.go
@@ -1,0 +1,114 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package opentracing
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	pappsec "gopkg.in/DataDog/dd-trace-go.v1/appsec"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
+
+	"github.com/opentracing-contrib/go-stdlib/nethttp"
+	"github.com/opentracing/opentracing-go/mocktracer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppSec(t *testing.T) {
+	appsec.Start()
+	defer appsec.Stop()
+
+	if !appsec.Enabled() {
+		t.Skip("appsec disabled")
+	}
+
+	// Start and trace an HTTP server with some testing routes
+	mux := http.NewServeMux()
+	mux.HandleFunc("/body", func(w http.ResponseWriter, r *http.Request) {
+		pappsec.MonitorParsedHTTPBody(r.Context(), "$globals")
+		_, err := w.Write([]byte("Hello Body!\n"))
+		require.NoError(t, err)
+	})
+
+	// Test an LFI attack via path parameters
+	t.Run("request-uri", func(t *testing.T) {
+		mt := mocktracer.New()
+		srv := httptest.NewServer(nethttp.Middleware(mt, AppSecMiddleware(mux)))
+		defer srv.Close()
+
+		// Send an LFI attack (according to appsec rule id crs-930-110)
+		req, err := http.NewRequest("POST", srv.URL+"/../../../secret.txt", nil)
+		if err != nil {
+			panic(err)
+		}
+		res, err := srv.Client().Do(req)
+		require.NoError(t, err)
+		// Check that the server behaved as intended (404 after the 301)
+		require.Equal(t, http.StatusNotFound, res.StatusCode)
+		// The span should contain the security event
+		finished := mt.FinishedSpans()
+		require.Len(t, finished, 2) // 301 + 404
+
+		// The first 301 redirection should contain the attack via the request uri
+		event := finished[0].Tag("_dd.appsec.json").(string)
+		require.NotNil(t, event)
+		require.True(t, strings.Contains(event, "server.request.uri.raw"))
+		require.True(t, strings.Contains(event, "crs-930-110"))
+		// The second request should contain the event via the referrer header
+		event = finished[1].Tag("_dd.appsec.json").(string)
+		require.NotNil(t, event)
+		require.True(t, strings.Contains(event, "server.request.headers.no_cookies"))
+		require.True(t, strings.Contains(event, "crs-930-110"))
+	})
+
+	t.Run("response-status", func(t *testing.T) {
+		mt := mocktracer.New()
+		srv := httptest.NewServer(nethttp.Middleware(mt, AppSecMiddleware(mux)))
+		defer srv.Close()
+
+		req, err := http.NewRequest("POST", srv.URL+"/etc/", nil)
+		if err != nil {
+			panic(err)
+		}
+		res, err := srv.Client().Do(req)
+		require.NoError(t, err)
+		require.Equal(t, 404, res.StatusCode)
+
+		finished := mt.FinishedSpans()
+		require.Len(t, finished, 1)
+		event := finished[0].Tag("_dd.appsec.json").(string)
+		require.NotNil(t, event)
+		require.True(t, strings.Contains(event, "server.response.status"))
+		require.True(t, strings.Contains(event, "nfd-000-001"))
+	})
+
+	// Test a PHP injection attack via request parsed body
+	t.Run("SDK-body", func(t *testing.T) {
+		mt := mocktracer.New()
+		srv := httptest.NewServer(nethttp.Middleware(mt, AppSecMiddleware(mux)))
+		defer srv.Close()
+
+		req, err := http.NewRequest("POST", srv.URL+"/body", nil)
+		if err != nil {
+			panic(err)
+		}
+		res, err := srv.Client().Do(req)
+		require.NoError(t, err)
+		// Check that the handler was properly called
+		b, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Equal(t, "Hello Body!\n", string(b))
+
+		finished := mt.FinishedSpans()
+		require.Len(t, finished, 1)
+		event := finished[0].Tag("_dd.appsec.json")
+		require.NotNil(t, event)
+		require.True(t, strings.Contains(event.(string), "crs-933-130"))
+	})
+}

--- a/internal/appsec/dyngo/instrumentation/common.go
+++ b/internal/appsec/dyngo/instrumentation/common.go
@@ -11,10 +11,13 @@ import (
 	"fmt"
 	"sync"
 
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/samplernames"
 )
+
+type Span interface {
+	SetTag(tag string, value interface{})
+}
 
 // TagsHolder wraps a map holding tags. The purpose of this struct is to be used by composition in an Operation
 // to allow said operation to handle tags addition/retrieval. See httpsec/http.go and grpcsec/grpc.go.
@@ -62,14 +65,14 @@ func (s *SecurityEventsHolder) Events() []json.RawMessage {
 }
 
 // SetTags fills the span tags using the key/value pairs found in `tags`
-func SetTags(span ddtrace.Span, tags map[string]interface{}) {
+func SetTags(span Span, tags map[string]interface{}) {
 	for k, v := range tags {
 		span.SetTag(k, v)
 	}
 }
 
 // SetEventSpanTags sets the security event span tags into the service entry span.
-func SetEventSpanTags(span ddtrace.Span, events []json.RawMessage) error {
+func SetEventSpanTags(span Span, events []json.RawMessage) error {
 	// Set the appsec event span tag
 	val, err := makeEventTagValue(events)
 	if err != nil {

--- a/internal/appsec/dyngo/instrumentation/httpsec/http.go
+++ b/internal/appsec/dyngo/instrumentation/httpsec/http.go
@@ -18,7 +18,6 @@ import (
 	"reflect"
 	"strings"
 
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
@@ -70,7 +69,7 @@ func MonitorParsedBody(ctx context.Context, body interface{}) {
 
 // WrapHandler wraps the given HTTP handler with the abstract HTTP operation defined by HandlerOperationArgs and
 // HandlerOperationRes.
-func WrapHandler(handler http.Handler, span ddtrace.Span, pathParams map[string]string) http.Handler {
+func WrapHandler(handler http.Handler, span instrumentation.Span, pathParams map[string]string) http.Handler {
 	SetAppSecTags(span)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		args := MakeHandlerOperationArgs(r, pathParams)

--- a/internal/appsec/dyngo/instrumentation/httpsec/tags.go
+++ b/internal/appsec/dyngo/instrumentation/httpsec/tags.go
@@ -10,19 +10,18 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation"
 )
 
 // SetAppSecTags sets the AppSec-specific span tags that are expected to be in
 // the web service entry span (span of type `web`) when AppSec is enabled.
-func SetAppSecTags(span ddtrace.Span) {
+func SetAppSecTags(span instrumentation.Span) {
 	span.SetTag("_dd.appsec.enabled", 1)
 	span.SetTag("_dd.runtime_family", "go")
 }
 
 // SetSecurityEventTags sets the AppSec-specific span tags when a security event occurred into the service entry span.
-func SetSecurityEventTags(span ddtrace.Span, events []json.RawMessage, remoteIP string, headers, respHeaders map[string][]string) {
+func SetSecurityEventTags(span instrumentation.Span, events []json.RawMessage, remoteIP string, headers, respHeaders map[string][]string) {
 	instrumentation.SetEventSpanTags(span, events)
 	span.SetTag("network.client.ip", remoteIP)
 	for h, v := range NormalizeHTTPHeaders(headers) {


### PR DESCRIPTION
As of today, the AppSec library only relies on the tracer's span method `SetTag()`. So making it compatible with Opentracing is just a matter of using their `SetTag()` method (which has a different signature than ours).

So this POC simply exposes a `net/http` middleware function with AppSec monitoring using Opentracing.

The POC was completely tested and revealed that even if it 100% works at the library level, the resulting Opentracing traces end up with different HTTP tags that will lead to AppSec backend misfunction. For example, the resulting HTTP spans do not have the `type: http` our backend relies on to filter the traces. 