### PR TITLE
.github/workflows: disable system tests for 3rd-party PRs.

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   system-tests:
+    if: github.event.pull_request.head.repo.name == 'DataDog/dd-trace-go'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -37,7 +37,7 @@ jobs:
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
     steps:
       - name: PRINT THE REPO NAME
-        run: echo ${github.event.pull_request.head.repo.name}
+        run: echo ${{ github.event.pull_request.head.repo.name }}
 
       - name: Checkout system tests
         uses: actions/checkout@v2

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -37,7 +37,7 @@ jobs:
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
     steps:
       - name: PRINT THE REPO NAME
-        run: echo ${{ github.event.pull_request.head.repo.name }}
+        run: echo ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Checkout system tests
         uses: actions/checkout@v2

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   system-tests:
-#    if: github.event.pull_request.head.repo.name == 'DataDog/dd-trace-go'
+    if: github.event.pull_request.head.repo.full_name == 'DataDog/dd-trace-go'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -36,9 +36,6 @@ jobs:
       WEBLOG_VARIANT: ${{ matrix.weblog-variant }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
     steps:
-      - name: PRINT THE REPO NAME
-        run: echo ${{ github.event.pull_request.head.repo.full_name }}
-
       - name: Checkout system tests
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   system-tests:
-    if: github.event.pull_request.head.repo.name == 'DataDog/dd-trace-go'
+#    if: github.event.pull_request.head.repo.name == 'DataDog/dd-trace-go'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -36,6 +36,9 @@ jobs:
       WEBLOG_VARIANT: ${{ matrix.weblog-variant }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
     steps:
+      - name: PRINT THE REPO NAME
+        run: echo ${github.event.pull_request.head.repo.name}
+
       - name: Checkout system tests
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
System tests don't run correctly on 3rd-party PRs, meaning that they will never be green. We should disable them so that we can merge green PR's and they don't confuse us or contributors.