### PR TITLE
profiler: wrap delta profiling in a type

### DIFF
--- a/profiler/internal/pprofutils/delta.go
+++ b/profiler/internal/pprofutils/delta.go
@@ -30,10 +30,7 @@ type Delta struct {
 // profile. Samples that end up with a delta of 0 are dropped. WARNING: Profile
 // a will be mutated by this function. You should pass a copy if that's
 // undesirable.
-//
-// Other profiles that should be merged into the resulting profile can be passed
-// through the extra parameter.
-func (d Delta) Convert(a, b *profile.Profile, extra ...*profile.Profile) (*profile.Profile, error) {
+func (d Delta) Convert(a, b *profile.Profile) (*profile.Profile, error) {
 	ratios := make([]float64, len(a.SampleType))
 
 	found := 0
@@ -61,10 +58,7 @@ func (d Delta) Convert(a, b *profile.Profile, extra ...*profile.Profile) (*profi
 
 	a.ScaleN(ratios)
 
-	profiles := make([]*profile.Profile, 0, 2+len(extra))
-	profiles = append(profiles, a, b)
-	profiles = append(profiles, extra...)
-	delta, err := profile.Merge(profiles)
+	delta, err := profile.Merge([]*profile.Profile{a, b})
 	if err != nil {
 		return nil, err
 	}

--- a/profiler/internal/pprofutils/delta.go
+++ b/profiler/internal/pprofutils/delta.go
@@ -17,8 +17,6 @@ type Delta struct {
 	// SampleTypes limits the delta calcultion to the given sample types. Other
 	// sample types will retain the values of profile b. The defined sample types
 	// must exist in the profile, otherwise derivation will fail with an error.
-	// If the slice is empty, all sample types are subject to delta profile
-	// derivation.
 	//
 	// The use case for this for this is to deal with the heap profile which
 	// contains alloc and inuse sample types, but delta profiling makes no sense
@@ -35,13 +33,7 @@ func (d Delta) Convert(a, b *profile.Profile) (*profile.Profile, error) {
 
 	found := 0
 	for i, st := range a.SampleType {
-		// Empty c.SampleTypes means we calculate the delta for every st
-		if len(d.SampleTypes) == 0 {
-			ratios[i] = -1
-			continue
-		}
-
-		// Otherwise we only calcuate the delta for any st that is listed in
+		// We only calcuate the delta for any st that is listed in
 		// c.SampleTypes. st's not listed in there will default to ratio 0, which
 		// means we delete them from pa, so only the pb values remain in the final
 		// profile.

--- a/profiler/internal/pprofutils/delta_test.go
+++ b/profiler/internal/pprofutils/delta_test.go
@@ -18,6 +18,7 @@ func TestDelta(t *testing.T) {
 		var deltaText bytes.Buffer
 
 		profA, err := Text{}.Convert(strings.NewReader(strings.TrimSpace(`
+x/count
 main;foo 5
 main;foo;bar 3
 main;foobar 4
@@ -25,13 +26,14 @@ main;foobar 4
 		require.NoError(t, err)
 
 		profB, err := Text{}.Convert(strings.NewReader(strings.TrimSpace(`
+x/count
 main;foo 8
 main;foo;bar 3
 main;foobar 5
 `)))
 		require.NoError(t, err)
 
-		delta, err := Delta{}.Convert(profA, profB)
+		delta, err := Delta{SampleTypes: []ValueType{{Type: "x", Unit: "count"}}}.Convert(profA, profB)
 		require.NoError(t, err)
 
 		require.NoError(t, Protobuf{}.Convert(delta, &deltaText))

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -202,7 +202,7 @@ func collectGenericProfile(name string, pt ProfileType) func(p *profiler) ([]byt
 		var buf bytes.Buffer
 		err := p.lookupProfile(name, &buf, 0)
 		data := buf.Bytes()
-		dp, ok := p.deltas[name]
+		dp, ok := p.deltas[pt]
 		if !ok || !p.cfg.deltaProfiles {
 			return data, err
 		}

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -302,6 +302,15 @@ type deltaProfiler struct {
 	prev  *pprofile.Profile
 }
 
+// newDeltaProfiler returns an initialized deltaProfiler. If value types
+// are given (e.g. "alloc_space", "alloc_objects"), only those values will have
+// deltas computed. Otherwise, deltas will be computed for every value.
+func newDeltaProfiler(v ...pprofutils.ValueType) *deltaProfiler {
+	return &deltaProfiler{
+		delta: &pprofutils.Delta{SampleTypes: v},
+	}
+}
+
 // Delta derives the delta profile between curData and the profile passed to the
 // previous call to Delta. The first call to Delta will return the profile
 // unchanged.

--- a/profiler/profile_test.go
+++ b/profiler/profile_test.go
@@ -115,7 +115,7 @@ main;bar 0 0 8 16
 				// followed by prof2 when calling runProfile().
 				deltaProfiler := func(prof1, prof2 []byte, opts ...Option) (*profiler, func()) {
 					returnProfs := [][]byte{prof1, prof2}
-					opts = append(opts, WithPeriod(5*time.Millisecond))
+					opts = append(opts, WithPeriod(5*time.Millisecond), WithProfileTypes(HeapProfile, MutexProfile, BlockProfile))
 					p, err := unstartedProfiler(opts...)
 					p.testHooks.lookupProfile = func(_ string, w io.Writer, _ int) error {
 						_, err := w.Write(returnProfs[0])

--- a/profiler/profile_test.go
+++ b/profiler/profile_test.go
@@ -43,29 +43,29 @@ func TestRunProfile(t *testing.T) {
 				Prof1: textProfile{
 					Time: timeA,
 					Text: `
-stuff/count
-main 3
-main;bar 2
-main;foo 5
+contentions/count delay/nanoseconds
+main 3 1
+main;bar 2 1
+main;foo 5 1
 `,
 				},
 				Prof2: textProfile{
 					Time: timeB,
 					Text: `
-stuff/count
-main 4
-main;bar 2
-main;foo 8
-main;foobar 7
+contentions/count delay/nanoseconds
+main 4 1
+main;bar 2 1
+main;foo 8 1
+main;foobar 7 1
 `,
 				},
 				WantDelta: textProfile{
 					Time: timeA,
 					Text: `
-stuff/count
-main;foobar 7
-main;foo 3
-main 1
+contentions/count delay/nanoseconds
+main;foobar 7 1
+main;foo 3 0
+main 1 0
 `,
 				},
 				WantDuration: deltaPeriod,

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -20,8 +20,6 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
-
-	pprofile "github.com/google/pprof/profile"
 )
 
 // outChannelSize specifies the size of the profile output channel.
@@ -64,15 +62,14 @@ func Stop() {
 // profiler collects and sends preset profiles to the Datadog API at a given frequency
 // using a given configuration.
 type profiler struct {
-	mu              sync.Mutex
-	cfg             *config                      // profile configuration
-	out             chan batch                   // upload queue
-	uploadFunc      func(batch) error            // defaults to (*profiler).upload; replaced in tests
-	exit            chan struct{}                // exit signals the profiler to stop; it is closed after stopping
-	stopOnce        sync.Once                    // stopOnce ensures the profiler is stopped exactly once.
-	wg              sync.WaitGroup               // wg waits for all goroutines to exit when stopping.
-	met             *metrics                     // metric collector state
-	prev            map[string]*pprofile.Profile // previous collection results for delta profiling
+	cfg             *config           // profile configuration
+	out             chan batch        // upload queue
+	uploadFunc      func(batch) error // defaults to (*profiler).upload; replaced in tests
+	exit            chan struct{}     // exit signals the profiler to stop; it is closed after stopping
+	stopOnce        sync.Once         // stopOnce ensures the profiler is stopped exactly once.
+	wg              sync.WaitGroup    // wg waits for all goroutines to exit when stopping.
+	met             *metrics          // metric collector state
+	deltas          map[string]*deltaProfiler
 	telemetry       *telemetry.Client
 	seq             uint64         // seq is the value of the profile_seq tag
 	pendingProfiles sync.WaitGroup // signal that profile collection is done, for stopping CPU profiling
@@ -182,11 +179,16 @@ func newProfiler(opts ...Option) (*profiler, error) {
 	}
 
 	p := profiler{
-		cfg:  cfg,
-		out:  make(chan batch, outChannelSize),
-		exit: make(chan struct{}),
-		met:  newMetrics(),
-		prev: make(map[string]*pprofile.Profile),
+		cfg:    cfg,
+		out:    make(chan batch, outChannelSize),
+		exit:   make(chan struct{}),
+		met:    newMetrics(),
+		deltas: make(map[string]*deltaProfiler),
+	}
+	for pt := range cfg.types {
+		if d := profileTypes[pt].Delta; d != nil {
+			p.deltas[pt.lookup().Name] = &deltaProfiler{delta: d}
+		}
 	}
 	p.uploadFunc = p.upload
 	p.telemetry = &telemetry.Client{

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -69,7 +69,7 @@ type profiler struct {
 	stopOnce        sync.Once         // stopOnce ensures the profiler is stopped exactly once.
 	wg              sync.WaitGroup    // wg waits for all goroutines to exit when stopping.
 	met             *metrics          // metric collector state
-	deltas          map[string]*deltaProfiler
+	deltas          map[ProfileType]*deltaProfiler
 	telemetry       *telemetry.Client
 	seq             uint64         // seq is the value of the profile_seq tag
 	pendingProfiles sync.WaitGroup // signal that profile collection is done, for stopping CPU profiling
@@ -183,11 +183,11 @@ func newProfiler(opts ...Option) (*profiler, error) {
 		out:    make(chan batch, outChannelSize),
 		exit:   make(chan struct{}),
 		met:    newMetrics(),
-		deltas: make(map[string]*deltaProfiler),
+		deltas: make(map[ProfileType]*deltaProfiler),
 	}
 	for pt := range cfg.types {
 		if d := profileTypes[pt].DeltaValues; len(d) > 0 {
-			p.deltas[pt.lookup().Name] = newDeltaProfiler(d...)
+			p.deltas[pt] = newDeltaProfiler(d...)
 		}
 	}
 	p.uploadFunc = p.upload

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -187,7 +187,7 @@ func newProfiler(opts ...Option) (*profiler, error) {
 	}
 	for pt := range cfg.types {
 		if d := profileTypes[pt].Delta; d != nil {
-			p.deltas[pt.lookup().Name] = &deltaProfiler{delta: d}
+			p.deltas[pt.lookup().Name] = newDeltaProfiler(d.SampleTypes...)
 		}
 	}
 	p.uploadFunc = p.upload

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -186,8 +186,8 @@ func newProfiler(opts ...Option) (*profiler, error) {
 		deltas: make(map[string]*deltaProfiler),
 	}
 	for pt := range cfg.types {
-		if d := profileTypes[pt].Delta; d != nil {
-			p.deltas[pt.lookup().Name] = newDeltaProfiler(d.SampleTypes...)
+		if d := profileTypes[pt].DeltaValues; len(d) > 0 {
+			p.deltas[pt.lookup().Name] = newDeltaProfiler(d...)
 		}
 	}
 	p.uploadFunc = p.upload


### PR DESCRIPTION
Wrap up delta profiling in a type with a `Delta` method. This type holds
any information about the previous profile needed to compute the delta
with the newest profile. The profiler keeps an instance of type for each
profile type which supports delta profiling. This better encapsulates
the implementation details of delta profiling, and facilitates upcoming
implementation changes.

As part of this change, pull the logic for merging in "extra" profiles
out of the delta profiling code path. This logic was implemented for C
allocation profiling, and the extra data was passed through to delta
profiling mainly for efficiency. However, merging in extra data is
orthogonal to delta profiling and we can find other ways to make that
more efficient if we need to.
