### PR TITLE
profiler: ensure that CPU profile records profiler work

### DIFF
--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -75,10 +75,13 @@ type profileType struct {
 // profileTypes maps every ProfileType to its implementation.
 var profileTypes = map[ProfileType]profileType{
 	CPUProfile: {
-		Name:     "cpu",
 		Filename: "cpu.pprof",
 		Collect: func(p *profiler) ([]byte, error) {
 			var buf bytes.Buffer
+			// Start the CPU profiler at the end of the profiling
+			// period so that we're sure to capture the CPU usage of
+			// this library, which mostly happens at the end
+			p.interruptibleSleep(p.cfg.period - p.cfg.cpuDuration)
 			if p.cfg.cpuProfileRate != 0 {
 				// The profile has to be set each time before
 				// profiling is started. Otherwise,

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -97,7 +97,6 @@ var profileTypes = map[ProfileType]profileType{
 			// properly record all of our profile processing work for
 			// the other profile types
 			for _, ch := range p.done {
-				// TODO: also wait for p.exit?
 				<-ch
 			}
 			p.stopCPUProfile()

--- a/profiler/profile_test.go
+++ b/profiler/profile_test.go
@@ -171,7 +171,7 @@ main;bar 0 0 8 16
 	})
 
 	t.Run("cpu", func(t *testing.T) {
-		p, err := unstartedProfiler(CPUDuration(10 * time.Millisecond))
+		p, err := unstartedProfiler(CPUDuration(10*time.Millisecond), WithPeriod(10*time.Millisecond))
 		p.testHooks.startCPUProfile = func(w io.Writer) error {
 			_, err := w.Write([]byte("my-cpu-profile"))
 			return err

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -304,10 +304,14 @@ func (p *profiler) collect(ticker <-chan time.Time) {
 		p.seq++
 
 		completed = completed[:0]
+		// We need to increment pendingProfiles for every non-CPU
+		// profile _before_ entering the next loop so that we know CPU
+		// profiling will not complete until every other profile is
+		// finished (because p.pendingProfiles will have been
+		// incremented to count every non-CPU profile before CPU
+		// profiling starts)
 		for _, t := range p.enabledProfileTypes() {
 			if t != CPUProfile {
-				// pendingProfiles should be updated before
-				// starting the CPU profiler
 				p.pendingProfiles.Add(1)
 			}
 		}


### PR DESCRIPTION
Our profiler library does post-processing of profiles, such as computing
deltas for heap, block, and mutex profiles, which has non-zero CPU
overhead. Right now there's no guarantee that that work will be captured
in the CPU profile. Add synchronization so that the CPU profiler will
only be stopped after all other profiles are completed.
