### PR TITLE
profiler: clamp CPU duration at profile period

### DIFF
--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -173,6 +173,9 @@ func newProfiler(opts ...Option) (*profiler, error) {
 			return nil, fmt.Errorf("unknown profile type: %d", pt)
 		}
 	}
+	if cfg.cpuDuration > cfg.period {
+		cfg.cpuDuration = cfg.period
+	}
 	if cfg.logStartup {
 		logStartup(cfg)
 	}

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -203,7 +203,6 @@ func TestStopLatency(t *testing.T) {
 	Start(
 		WithAgentAddr(server.Listener.Addr().String()),
 		WithPeriod(time.Second),
-		CPUDuration(time.Second),
 		WithUploadTimeout(time.Hour),
 	)
 
@@ -412,7 +411,6 @@ func TestCorrectTags(t *testing.T) {
 			HeapProfile,
 		),
 		WithPeriod(10*time.Millisecond),
-		CPUDuration(10*time.Millisecond),
 		WithService("xyz"),
 		WithEnv("testing"),
 		WithTags("foo:bar", "baz:bonk"),


### PR DESCRIPTION
If a user sets a profile period shorter than the default CPU duration,
but neglects to update the CPU duration, CPU profiling will still take
the default duration, exceeding the expected profile period. Add a check
to clamp the CPU duration at the configured period.
