### PR TITLE
.github/workflows: do not skip system-tests cron jobs

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   system-tests:
-    if: github.event.pull_request.head.repo.full_name == 'DataDog/dd-trace-go' || github.event_name == 'schedule'
+    if: github.event.pull_request.head.repo.full_name == 'DataDog/dd-trace-go' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   system-tests:
-    if: github.event.pull_request.head.repo.full_name == 'DataDog/dd-trace-go' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'DataDog/dd-trace-go')
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   system-tests:
-    if: github.event.pull_request.head.repo.full_name == 'DataDog/dd-trace-go'
+    if: github.event.pull_request.head.repo.full_name == 'DataDog/dd-trace-go' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
The system-tests cron jobs [have been skipped](https://github.com/DataDog/dd-trace-go/actions/workflows/system-tests.yml?query=event%3Aschedule+branch%3Amain) since https://github.com/DataDog/dd-trace-go/pull/1476 was merged. This is an attempt to fix it.

Note: I'm not familiar with Github Actions, if folks think of a simpler approach please comment! 