### PR TITLE
.github/workflows: add parametric tests

### DIFF
--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -1,4 +1,4 @@
-name: Parametric Tests
+name: APM Parametric Tests
 
 on:
   push:

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -1,0 +1,55 @@
+name: Parametric Tests
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "**"
+  pull_request:
+    branches:
+      - "**"
+  workflow_dispatch: {}
+  schedule:
+    - cron:  '00 04 * * 2-6'
+
+jobs:
+  parametric-tests:
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'DataDog/dd-trace-go')
+    runs-on: ubuntu-latest
+    env:
+      COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }} 
+    steps:
+      - name: Checkout system tests
+        uses: actions/checkout@v3
+        with:
+          repository: 'DataDog/system-tests'
+          path: system-tests
+
+      - name: Checkout Go
+        uses: actions/checkout@v3
+        with:
+          path: system-tests/golang
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.18.7'
+      - name: Patch dd-trace-go version
+        run: |
+          cd system-tests/parametric/apps/golang
+          go get gopkg.in/DataDog/dd-trace-go.v1@$COMMIT_SHA
+
+      - name: Checkout Python
+        uses: actions/checkout@v3
+        with:
+          path: system-tests/python
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install
+        run: |
+          pip install wheel
+      - name: Run
+        run: |
+          cd system-tests/parametric
+          pip install -r requirements.txt
+          CLIENTS_ENABLED=golang ./run.sh


### PR DESCRIPTION
Parametric tests allow testing the tracers with different parameters, read more [here](https://github.com/DataDog/system-tests/tree/main/parametric).

This PR adds a job in the CI to continuously run these tests, it's similar to [how we run system-tests](https://github.com/DataDog/dd-trace-go/blob/main/.github/workflows/system-tests.yml) but in a different workflow to easily mark it not required or even disable it temporarily if needed.