### PR TITLE
fastdelta: remove sort allocations

### DIFF
--- a/profiler/internal/fastdelta/fd.go
+++ b/profiler/internal/fastdelta/fd.go
@@ -596,9 +596,8 @@ func (dc *DeltaComputer) readSample(v []byte, h hash.Hash, hash *Hash) (value Va
 		}
 		return true, nil
 	})
-	sort.Slice(dc.hashes, func(i, j int) bool {
-		return bytes.Compare(dc.hashes[i][:], dc.hashes[j][:]) == -1
-	})
+	sort.Sort(ByHash(dc.hashes))
+
 	h.Reset()
 	for _, sub := range dc.hashes {
 		copy(hash[:], sub[:])
@@ -634,6 +633,13 @@ func (dc *DeltaComputer) keepLocations(locationIDs []uint64) {
 }
 
 type Hash [16]byte
+
+type ByHash []Hash
+
+func (h ByHash) Len() int           { return len(h) }
+func (h ByHash) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+func (h ByHash) Less(i, j int) bool { return bytes.Compare(h[i][:], h[j][:]) == -1 }
+
 type Value [4]int64
 
 type StringTable struct {

--- a/profiler/internal/fastdelta/fd_test.go
+++ b/profiler/internal/fastdelta/fd_test.go
@@ -24,6 +24,7 @@ func BenchmarkFastDelta(b *testing.B) {
 	for _, f := range []string{heapFile, bigHeapFile} {
 		testFile := "testdata/" + f
 		b.Run(testFile, func(b *testing.B) {
+			b.ReportAllocs()
 			before, err := os.ReadFile(testFile)
 			if err != nil {
 				b.Fatal(err)


### PR DESCRIPTION
While looking at the internal testing that's going on, I noticed a lot of allocations caused by a `sort.Slice()`.

<img width="1880" alt="image" src="https://user-images.githubusercontent.com/15000/195282827-3971f440-0d02-473e-bcd7-faf6d60d1bda.png">

I think we can easily get rid of them by applying this PR. The benchmarks says this will reduce allocated objects by ~60% and CPU time by 10%.

Let me know what you think.

```
name                                  old time/op    new time/op    delta
FastDelta/testdata/heap.pprof-12         924µs ± 2%     827µs ± 3%  -10.53%  (p=0.008 n=5+5)
FastDelta/testdata/big-heap.pprof-12    12.2ms ± 4%    10.9ms ± 4%  -10.29%  (p=0.008 n=5+5)

name                                  old alloc/op   new alloc/op   delta
FastDelta/testdata/heap.pprof-12         289kB ± 0%     226kB ± 0%  -22.00%  (p=0.008 n=5+5)
FastDelta/testdata/big-heap.pprof-12    2.44MB ± 0%    1.71MB ± 0%  -29.77%  (p=0.008 n=5+5)

name                                  old allocs/op  new allocs/op  delta
FastDelta/testdata/heap.pprof-12         3.33k ± 0%     1.34k ± 0%  -59.66%  (p=0.008 n=5+5)
FastDelta/testdata/big-heap.pprof-12     37.2k ± 0%     14.5k ± 0%  -61.10%  (p=0.008 n=5+5)
```