### PR TITLE
contrib/google.golang.org/grpc: add support for WithUntracedMethods

### DIFF
--- a/contrib/google.golang.org/grpc/client.go
+++ b/contrib/google.golang.org/grpc/client.go
@@ -33,7 +33,7 @@ func (cs *clientStream) Context() context.Context {
 }
 
 func (cs *clientStream) RecvMsg(m interface{}) (err error) {
-	if cs.cfg.traceStreamMessages {
+	if _, ok := cs.cfg.untracedMethods[cs.method]; cs.cfg.traceStreamMessages && !ok {
 		span, _ := startSpanFromContext(
 			cs.Context(),
 			cs.method,
@@ -51,7 +51,7 @@ func (cs *clientStream) RecvMsg(m interface{}) (err error) {
 }
 
 func (cs *clientStream) SendMsg(m interface{}) (err error) {
-	if cs.cfg.traceStreamMessages {
+	if _, ok := cs.cfg.untracedMethods[cs.method]; cs.cfg.traceStreamMessages && !ok {
 		span, _ := startSpanFromContext(
 			cs.Context(),
 			cs.method,
@@ -90,7 +90,7 @@ func StreamClientInterceptor(opts ...Option) grpc.StreamClientInterceptor {
 			}
 		}
 		var stream grpc.ClientStream
-		if cfg.traceStreamCalls {
+		if _, ok := cfg.untracedMethods[method]; cfg.traceStreamCalls && !ok {
 			var (
 				span tracer.Span
 				err  error
@@ -149,12 +149,16 @@ func UnaryClientInterceptor(opts ...Option) grpc.UnaryClientInterceptor {
 	}
 	log.Debug("contrib/google.golang.org/grpc: Configuring UnaryClientInterceptor: %#v", cfg)
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		span, _, err := doClientRequest(ctx, cfg, method, methodKindUnary, opts,
-			func(ctx context.Context, opts []grpc.CallOption) error {
-				return invoker(ctx, method, req, reply, cc, opts...)
-			})
-		finishWithError(span, err, cfg)
-		return err
+		if _, ok := cfg.untracedMethods[method]; !ok {
+			span, _, err := doClientRequest(ctx, cfg, method, methodKindUnary, opts,
+				func(ctx context.Context, opts []grpc.CallOption) error {
+					return invoker(ctx, method, req, reply, cc, opts...)
+				})
+			finishWithError(span, err, cfg)
+			return err
+		} else {
+			return invoker(ctx, method, req, reply, cc, opts...)
+		}
 	}
 }
 

--- a/contrib/google.golang.org/grpc/example_test.go
+++ b/contrib/google.golang.org/grpc/example_test.go
@@ -38,8 +38,8 @@ func Example_server() {
 	}
 
 	// Create the server interceptor using the grpc trace package.
-	si := grpctrace.StreamServerInterceptor(grpctrace.WithServiceName("my-grpc-client"))
-	ui := grpctrace.UnaryServerInterceptor(grpctrace.WithServiceName("my-grpc-client"))
+	si := grpctrace.StreamServerInterceptor(grpctrace.WithServiceName("my-grpc-server"))
+	ui := grpctrace.UnaryServerInterceptor(grpctrace.WithServiceName("my-grpc-server"))
 
 	// Initialize the grpc server as normal, using the tracing interceptor.
 	s := grpc.NewServer(grpc.StreamInterceptor(si), grpc.UnaryInterceptor(ui))

--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -593,7 +593,6 @@ func newRig(traceClient bool, interceptorOpts ...Option) (*rig, error) {
 func waitForSpans(mt mocktracer.Tracer, sz int, maxWait time.Duration) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-
 	for len(mt.FinishedSpans()) < sz {
 		select {
 		case <-ctx.Done():
@@ -725,6 +724,79 @@ func TestIgnoredMethods(t *testing.T) {
 			{ignore: []string{"/grpc.Fixture/StreamPing", "/additional/endpoint"}, exp: 3},
 		} {
 			rig, err := newRig(true, WithIgnoredMethods(c.ignore...))
+			if err != nil {
+				t.Fatalf("error setting up rig: %s", err)
+			}
+
+			ctx, done := context.WithCancel(context.Background())
+			client := rig.client
+			stream, err := client.StreamPing(ctx)
+			assert.NoError(t, err)
+
+			err = stream.Send(&FixtureRequest{Name: "pass"})
+			assert.NoError(t, err)
+
+			resp, err := stream.Recv()
+			assert.NoError(t, err)
+			assert.Equal(t, resp.Message, "passed")
+
+			assert.NoError(t, stream.CloseSend())
+			done() // close stream from client side
+			rig.Close()
+
+			waitForSpans(mt, c.exp, 5*time.Second)
+
+			spans := mt.FinishedSpans()
+			assert.Len(t, spans, c.exp)
+			mt.Reset()
+		}
+	})
+}
+
+func TestUntracedMethods(t *testing.T) {
+	t.Run("unary", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+		for _, c := range []struct {
+			ignore []string
+			exp    int
+		}{
+			{ignore: []string{}, exp: 2},
+			{ignore: []string{"/some/endpoint"}, exp: 2},
+			{ignore: []string{"/grpc.Fixture/Ping"}, exp: 0},
+			{ignore: []string{"/grpc.Fixture/Ping", "/additional/endpoint"}, exp: 0},
+		} {
+			rig, err := newRig(true, WithUntracedMethods(c.ignore...))
+			if err != nil {
+				t.Fatalf("error setting up rig: %s", err)
+			}
+			client := rig.client
+			resp, err := client.Ping(context.Background(), &FixtureRequest{Name: "pass"})
+			assert.Nil(t, err)
+			assert.Equal(t, resp.Message, "passed")
+
+			spans := mt.FinishedSpans()
+			assert.Len(t, spans, c.exp)
+			rig.Close()
+			mt.Reset()
+		}
+	})
+
+	t.Run("stream", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+		for _, c := range []struct {
+			ignore []string
+			exp    int
+		}{
+			// client span: 1 send + 1 recv(OK) + 1 stream finish (OK)
+			// server span: 1 send + 2 recv(OK + EOF) + 1 stream finish(EOF)
+			{ignore: []string{}, exp: 7},
+			{ignore: []string{"/some/endpoint"}, exp: 7},
+			{ignore: []string{"/grpc.Fixture/StreamPing"}, exp: 0},
+			{ignore: []string{"/grpc.Fixture/StreamPing", "/additional/endpoint"}, exp: 0},
+		} {
+			rig, err := newRig(true, WithUntracedMethods(c.ignore...))
 			if err != nil {
 				t.Fatalf("error setting up rig: %s", err)
 			}

--- a/contrib/google.golang.org/grpc/option.go
+++ b/contrib/google.golang.org/grpc/option.go
@@ -26,6 +26,7 @@ type config struct {
 	traceStreamMessages bool
 	noDebugStack        bool
 	ignoredMethods      map[string]struct{}
+	untracedMethods     map[string]struct{}
 	withMetadataTags    bool
 	ignoredMetadata     map[string]struct{}
 	withRequestTags     bool
@@ -139,6 +140,9 @@ func WithAnalyticsRate(rate float64) Option {
 
 // WithIgnoredMethods specifies full methods to be ignored by the server side interceptor.
 // When an incoming request's full method is in ms, no spans will be created.
+//
+// Deprecated: This is deprecated in favor of WithUntracedMethods which applies to both
+// the server side and client side interceptors.
 func WithIgnoredMethods(ms ...string) Option {
 	ims := make(map[string]struct{}, len(ms))
 	for _, e := range ms {
@@ -146,6 +150,18 @@ func WithIgnoredMethods(ms ...string) Option {
 	}
 	return func(cfg *config) {
 		cfg.ignoredMethods = ims
+	}
+}
+
+// WithUntracedMethods specifies full methods to be ignored by the server side and client
+// side interceptors. When a request's full method is in ms, no spans will be created.
+func WithUntracedMethods(ms ...string) Option {
+	ums := make(map[string]struct{}, len(ms))
+	for _, e := range ms {
+		ums[e] = struct{}{}
+	}
+	return func(cfg *config) {
+		cfg.untracedMethods = ums
 	}
 }
 


### PR DESCRIPTION
This PR adds support for `WithUntracedMethods` and marks `WithIgnoredMethods` as deprecated.
Fixes: #1491