### PR TITLE
.github/workflows: set appsec testing env using the actions matrix

### DIFF
--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -50,8 +50,7 @@ jobs:
           # Install gotestsum to get the results in a junit file 
           env GOBIN=$PWD go install gotest.tools/gotestsum@latest
           # Run the tests with gotestsum
-          env CGO_ENABLED=${{ matrix.cgo_enabled }} DD_APPSEC_ENABLED=${{ matrix.appsec_enabled }}
-          ./gotestsum --junitfile $JUNIT_REPORT -- -v ${{ matrix.build_tags != '' && format('-tags="{0}"', matrix.build_tags) || ''}} $TO_TEST || true
+          env CGO_ENABLED=${{ matrix.cgo_enabled }} DD_APPSEC_ENABLED=${{ matrix.appsec_enabled }} ./gotestsum --junitfile $JUNIT_REPORT -- -v ${{ matrix.build_tags != '' && format('-tags="{0}"', matrix.build_tags) || ''}} $TO_TEST || true
 
       - name: Upload the results to Datadog CI App
         uses: ./.github/actions/dd-ci-upload


### PR DESCRIPTION
The testing env was set in a separate command, resulting in the actual env not being set while running the tests.
Fix this by inlining the env setting with the command to run the tests.