### PR TITLE
codecov: replace ci status by a pr comment

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,11 +8,13 @@ comment:
 
 flags:
   core:
+    carryforward: true
     paths:
       - ddtrace/*
       - internal/*
       - profiler/*
   contrib:
+    carryforward: true
     paths:
       - contrib/*
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,32 +1,17 @@
-comment: false
+codecov:
+  branch: main
 
-coverage:
-  status:
-    project:
-      default: false
-      core:
-        target: 80%
-        flags:
-          - core
-      contrib:
-        target: 75%
-        flags:
-          - contrib
-    patch:
-      default:
-        target: 90%
-        # Only run this check for pull requests, but skip it for merged
-        # commits. This highlights patches with potential coverage problems
-        # during development, but doesn't make our v1 (release) branch look
-        # like it fails CI checks as we consider this check to be optional.
-        only_pulls: true
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: new
+  require_changes: false  # if true: only post the comment if coverage changes
 
 flags:
   core:
     paths:
       - ddtrace/*
-            - internal/*
-            - profiler/*
+      - internal/*
+      - profiler/*
   contrib:
     paths:
       - contrib/*


### PR DESCRIPTION
As long as we don't correctly report our coverage to codecov, we should disable the CI status and replace it by a simple PR comment for now. This avoids having the CI status being KO due to codecov.