### PR TITLE
.github: allow upload steps to fail

### DIFF
--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -100,6 +100,7 @@ jobs:
 
       - name: Upload the results to Datadog CI App
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/dd-ci-upload
         with:
           dd-api-key: ${{ secrets.DD_CI_API_KEY }}
@@ -237,6 +238,7 @@ jobs:
 
       - name: Upload the results to Datadog CI App
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/dd-ci-upload
         with:
           dd-api-key: ${{ secrets.DD_CI_API_KEY }}
@@ -245,6 +247,7 @@ jobs:
 
       - name: Upload Coverage
         if: always()
+        continue-on-error: true
         shell: bash
         run: bash <(curl -s https://codecov.io/bash)
 


### PR DESCRIPTION
This is required for 3rd-party authors who do not have access to secrets.