### PR TITLE
codecov: disable the coverage comment

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,7 @@
 codecov:
   branch: main
 
-comment:
-  layout: "reach, diff, flags, files"
-  behavior: new
-  require_changes: false  # if true: only post the comment if coverage changes
+comment: false
 
 flags:
   core:


### PR DESCRIPTION
The comment is far too spammy. The minor changes in coverage due to
normal variance from running CI on an oversubscribed system are much
more distracting than informative. The coverage reports will still be
uploaded for now, assuming any developers want to see them.
