### PR TITLE
tracer/time: implement nowTime in Windows

### DIFF
--- a/ddtrace/tracer/time_windows.go
+++ b/ddtrace/tracer/time_windows.go
@@ -37,3 +37,12 @@ var now func() int64 = func() func() int64 {
 		return highPrecisionNow
 	}
 }()
+
+var nowTime func() time.Time = func() func() time.Time {
+	if err := windows.LoadGetSystemTimePreciseAsFileTime(); err != nil {
+		log.Warn("Unable to load high precison timer, defaulting to time.Now()")
+		return func() time.Time { return time.Unix(0, lowPrecisionNow()) }
+	} else {
+		return func() time.Time { return time.Unix(0, highPrecisionNow()) }
+	}
+}()


### PR DESCRIPTION
https://github.com/DataDog/dd-trace-go/pull/1509 introduced nowTime for non-Windows GOOS setups in order to allow for mocking out parts of our implementation for testing. This PR didn't include the implementation of nowTIme in Windows.