### PR TITLE
contrib/dimfeld/httptreemux/v5: add support for httptreemux

### DIFF
--- a/contrib/dimfeld/httptreemux/v5/example_test.go
+++ b/contrib/dimfeld/httptreemux/v5/example_test.go
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package httptreemux_test
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/dimfeld/httptreemux/v5"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+func Index(w http.ResponseWriter, r *http.Request, _ map[string]string) {
+	fmt.Fprint(w, "Welcome!\n")
+}
+
+func Hello(w http.ResponseWriter, r *http.Request, params map[string]string) {
+	fmt.Fprintf(w, "hello, %s!\n", params["name"])
+}
+
+func Example() {
+	router := httptrace.New()
+	router.GET("/", Index)
+	router.GET("/hello/:name", Hello)
+
+	log.Fatal(http.ListenAndServe(":8080", router))
+}
+
+func Example_withServiceName() {
+	router := httptrace.New(httptrace.WithServiceName("http.router"))
+	router.GET("/", Index)
+	router.GET("/hello/:name", Hello)
+
+	log.Fatal(http.ListenAndServe(":8080", router))
+}
+
+func Example_withSpanOpts() {
+	router := httptrace.New(
+		httptrace.WithServiceName("http.router"),
+		httptrace.WithSpanOptions(
+			tracer.Tag(ext.SamplingPriority, ext.PriorityUserKeep),
+		),
+	)
+
+	router.GET("/", Index)
+	router.GET("/hello/:name", Hello)
+
+	log.Fatal(http.ListenAndServe(":8080", router))
+}

--- a/contrib/dimfeld/httptreemux/v5/httptreemux.go
+++ b/contrib/dimfeld/httptreemux/v5/httptreemux.go
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+// Package httptreemux provides functions to trace the dimfeld/httptreemux/v5 package (https://github.com/dimfeld/httptreemux).
+package httptreemux // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/dimfeld/httptreemux/v5"
+
+import (
+	"math"
+	"net/http"
+	"strings"
+
+	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+
+	"github.com/dimfeld/httptreemux/v5"
+)
+
+// Router is a traced version of httptreemux.TreeMux.
+type Router struct {
+	*httptreemux.TreeMux
+	config *routerConfig
+}
+
+// New returns a new router augmented with tracing.
+func New(opts ...RouterOption) *Router {
+	cfg := new(routerConfig)
+	defaults(cfg)
+	for _, fn := range opts {
+		fn(cfg)
+	}
+	if !math.IsNaN(cfg.analyticsRate) {
+		cfg.spanOpts = append(cfg.spanOpts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
+	}
+	cfg.spanOpts = append(cfg.spanOpts, tracer.Measured())
+	log.Debug("contrib/dimfeld/httptreemux/v5: Configuring Router: %#v", cfg)
+	return &Router{httptreemux.New(), cfg}
+}
+
+// ServeHTTP implements http.Handler.
+func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	// get the resource associated to this request
+	route := req.URL.Path
+	lr, _ := r.Lookup(w, req)
+	for k, v := range lr.Params {
+		// replace parameter values in URL path with their names
+		route = strings.Replace(route, v, ":"+k, 1)
+	}
+	resource := req.Method + " " + route
+	// pass r.TreeMux to avoid a circular reference panic on calling r.ServeHTTP
+	httptrace.TraceAndServe(r.TreeMux, w, req, &httptrace.ServeConfig{
+		Service:  r.config.serviceName,
+		Resource: resource,
+		SpanOpts: r.config.spanOpts,
+	})
+}

--- a/contrib/dimfeld/httptreemux/v5/httptreemux_test.go
+++ b/contrib/dimfeld/httptreemux/v5/httptreemux_test.go
@@ -1,0 +1,151 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package httptreemux
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHttpTracer200(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	// Send and verify a 200 request
+	url := "/200"
+	r := httptest.NewRequest("GET", url, nil)
+	w := httptest.NewRecorder()
+	router().ServeHTTP(w, r)
+	assert.Equal(200, w.Code)
+	assert.Equal("OK\n", w.Body.String())
+
+	spans := mt.FinishedSpans()
+	assert.Equal(1, len(spans))
+
+	s := spans[0]
+	assert.Equal("http.request", s.OperationName())
+	assert.Equal("my-service", s.Tag(ext.ServiceName))
+	assert.Equal("GET "+url, s.Tag(ext.ResourceName))
+	assert.Equal("200", s.Tag(ext.HTTPCode))
+	assert.Equal("GET", s.Tag(ext.HTTPMethod))
+	assert.Equal("http://example.com"+url, s.Tag(ext.HTTPURL))
+	assert.Equal("testvalue", s.Tag("testkey"))
+	assert.Equal(nil, s.Tag(ext.Error))
+}
+
+func TestHttpTracer500(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	// Send and verify a 500 request
+	url := "/500"
+	r := httptest.NewRequest("GET", url, nil)
+	w := httptest.NewRecorder()
+	router().ServeHTTP(w, r)
+	assert.Equal(500, w.Code)
+	assert.Equal("500!\n", w.Body.String())
+
+	spans := mt.FinishedSpans()
+	assert.Equal(1, len(spans))
+
+	s := spans[0]
+	assert.Equal("http.request", s.OperationName())
+	assert.Equal("my-service", s.Tag(ext.ServiceName))
+	assert.Equal("GET "+url, s.Tag(ext.ResourceName))
+	assert.Equal("500", s.Tag(ext.HTTPCode))
+	assert.Equal("GET", s.Tag(ext.HTTPMethod))
+	assert.Equal("http://example.com"+url, s.Tag(ext.HTTPURL))
+	assert.Equal("testvalue", s.Tag("testkey"))
+	assert.Equal("500: Internal Server Error", s.Tag(ext.Error).(error).Error())
+}
+
+func TestAnalyticsSettings(t *testing.T) {
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...RouterOption) {
+		router := New(opts...)
+		router.GET("/200", handler200)
+		r := httptest.NewRequest("GET", "/200", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, r)
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+		s := spans[0]
+		assert.Equal(t, rate, s.Tag(ext.EventSampleRate))
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil)
+	})
+
+	t.Run("global", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.4)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 1.0, WithAnalytics(true))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, nil, WithAnalytics(false))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
+	})
+}
+
+func router() http.Handler {
+	router := New(
+		WithServiceName("my-service"),
+		WithSpanOptions(tracer.Tag("testkey", "testvalue")),
+	)
+
+	router.GET("/200", handler200)
+	router.GET("/500", handler500)
+
+	return router
+}
+
+func handler200(w http.ResponseWriter, r *http.Request, _ map[string]string) {
+	w.Write([]byte("OK\n"))
+}
+
+func handler500(w http.ResponseWriter, r *http.Request, _ map[string]string) {
+	http.Error(w, "500!", http.StatusInternalServerError)
+}

--- a/contrib/dimfeld/httptreemux/v5/option.go
+++ b/contrib/dimfeld/httptreemux/v5/option.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+// Package httptreemux provides functions to trace the dimfeld/httptreemux/v5 package (https://github.com/dimfeld/httptreemux).
+package httptreemux
+
+import (
+	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+)
+
+type routerConfig struct {
+	serviceName   string
+	spanOpts      []ddtrace.StartSpanOption
+	analyticsRate float64
+}
+
+// RouterOption represents an option that can be passed to New.
+type RouterOption func(*routerConfig)
+
+func defaults(cfg *routerConfig) {
+	if internal.BoolEnv("DD_TRACE_HTTPROUTER_ANALYTICS_ENABLED", false) {
+		cfg.analyticsRate = 1.0
+	} else {
+		cfg.analyticsRate = globalconfig.AnalyticsRate()
+	}
+	cfg.serviceName = "http.router"
+	if svc := globalconfig.ServiceName(); svc != "" {
+		cfg.serviceName = svc
+	}
+}
+
+// WithServiceName sets the given service name for the returned router.
+func WithServiceName(name string) RouterOption {
+	return func(cfg *routerConfig) {
+		cfg.serviceName = name
+	}
+}
+
+// WithSpanOptions applies the given set of options to the span started by the router.
+func WithSpanOptions(opts ...ddtrace.StartSpanOption) RouterOption {
+	return func(cfg *routerConfig) {
+		cfg.spanOpts = opts
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) RouterOption {
+	return func(cfg *routerConfig) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
+	}
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) RouterOption {
+	return func(cfg *routerConfig) {
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/bradfitz/gomemcache v0.0.0-20220106215444-fb4bf637b56d
 	github.com/confluentinc/confluent-kafka-go v1.4.0
 	github.com/denisenkom/go-mssqldb v0.11.0
+	github.com/dimfeld/httptreemux/v5 v5.5.0
 	github.com/elastic/go-elasticsearch/v6 v6.8.5
 	github.com/elastic/go-elasticsearch/v7 v7.17.1
 	github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,10 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
+github.com/dimfeld/httptreemux/v5 v5.4.0 h1:IiHYEjh+A7pYbhWyjmGnj5HZK6gpOOvyBXCJ+BE8/Gs=
+github.com/dimfeld/httptreemux/v5 v5.4.0/go.mod h1:QeEylH57C0v3VO0tkKraVz9oD3Uu93CKPnTLbsidvSw=
+github.com/dimfeld/httptreemux/v5 v5.5.0 h1:p8jkiMrCuZ0CmhwYLcbNbl7DDo21fozhKHQ2PccwOFQ=
+github.com/dimfeld/httptreemux/v5 v5.5.0/go.mod h1:QeEylH57C0v3VO0tkKraVz9oD3Uu93CKPnTLbsidvSw=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=


### PR DESCRIPTION
Adding support to trace the dimfeld/httptreemux/v5 router package. The changes are almost identical to those that were required to instrument julienschmidt/httprouter, since httptreemux is based on httprouter.

Resolves #1520.