### PR TITLE
CI: give agent continer a hostname

### DIFF
--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -69,6 +69,7 @@ jobs:
       datadog-agent:
         image: datadog/agent:latest
         env:
+          DD_HOSTNAME: "github-actions-worker"
           DD_APM_ENABLED: true
           DD_BIND_HOST: "0.0.0.0"
           DD_API_KEY: "invalid_key_but_this_is_fine"
@@ -120,6 +121,7 @@ jobs:
       datadog-agent:
         image: datadog/agent:latest
         env:
+          DD_HOSTNAME: "github-actions-worker"
           DD_APM_ENABLED: true
           DD_BIND_HOST: "0.0.0.0"
           DD_API_KEY: "invalid_key_but_this_is_fine"


### PR DESCRIPTION
### What does this PR do?

Sets the hostname (through `DD_HOSTNAME`) for the agent container in the
integration tests.

### Motivation

As of Agent version 7.40.0, the agent won't start unless it can
determine its hostname. This breaks our CI, so we need to set a hostname
explicitly. See https://github.com/DataDog/datadog-agent/releases/tag/7.40.0


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.
