### PR TITLE
profiler/internal/fastdelta: skip fuzz tests on Go 1.18 + Windows

### DIFF
--- a/profiler/internal/fastdelta/fuzz_test.go
+++ b/profiler/internal/fastdelta/fuzz_test.go
@@ -3,7 +3,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022 Datadog, Inc.
 
-//go:build go1.18
+// Reading the fuzz corpus from testdata/ during CI fails on Windows runners
+// using Go 1.18, due to carriage return/line feed issues. This is fixed in Go
+// 1.19 (see https://go.dev/cl/402074), but we can just skip these tests on Go
+// 1.18 + Windows.
+//go:build go1.19 || (!windows && go1.18)
 
 package fastdelta_test
 


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Don't run the fastdelta fuzz tests on Windows using Go 1.18.

### Motivation

Reading the fuzz corpus from testdata/ during CI fails on Windows
runners using Go 1.18, due to carriage return/line feed issues. This is
fixed in Go 1.19 (see https://go.dev/cl/402074), but we can just skip
these tests on Go 1.18 + Windows.

Example failure: https://github.com/DataDog/dd-trace-go/actions/runs/3451647231/jobs/5761017411#step:6:353
