### PR TITLE
profiler: add the Name field back for the CPU profile

### DIFF
--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -79,6 +79,7 @@ type profileType struct {
 // profileTypes maps every ProfileType to its implementation.
 var profileTypes = map[ProfileType]profileType{
 	CPUProfile: {
+		Name:     "cpu",
 		Filename: "cpu.pprof",
 		Collect: func(p *profiler) ([]byte, error) {
 			var buf bytes.Buffer

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -48,8 +48,8 @@ func TestStart(t *testing.T) {
 		// that we log some default configuration, e.g. enabled profiles
 		assert.LessOrEqual(t, 1, len(rl.Logs()))
 		startupLog := strings.Join(rl.Logs(), " ")
-		assert.Contains(t, startupLog, "cpu")
-		assert.Contains(t, startupLog, "heap")
+		assert.Contains(t, startupLog, "\"cpu\"")
+		assert.Contains(t, startupLog, "\"heap\"")
 
 		mu.Lock()
 		require.NotNil(t, activeProfiler)


### PR DESCRIPTION
Accidentally removed by #1485
