### PR TITLE
[WIP] profiler: add client-side symbol demangling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -219,3 +219,5 @@ require (
 	mellium.im/sasl v0.2.1 // indirect
 	sigs.k8s.io/yaml v1.1.0 // indirect
 )
+
+require github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639

--- a/go.sum
+++ b/go.sum
@@ -417,6 +417,7 @@ github.com/hashicorp/vault/sdk v0.1.14-0.20200519221838-e0cfd64bc267/go.mod h1:W
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639 h1:mV02weKRL81bEnm8A0HT1/CAelMQDBuQIfLw8n+d6xI=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/profiler/demangle.go
+++ b/profiler/demangle.go
@@ -1,0 +1,41 @@
+package profiler
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+
+	"github.com/ianlancetaylor/demangle"
+	"gopkg.in/DataDog/dd-trace-go.v1/profiler/internal/pproflite"
+)
+
+// demangleCPUProfile demangles C++ or Rust symbol names appearing in the string
+// table for the given profile, and returns a new profile.
+func demangleCPUProfile(p []byte) ([]byte, error) {
+	r, err := gzip.NewReader(bytes.NewReader(p))
+	if err != nil {
+		return nil, err
+	}
+	p, err = io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	out := new(bytes.Buffer)
+	w := gzip.NewWriter(out)
+	defer w.Close()
+	enc := pproflite.NewEncoder(w)
+
+	pproflite.NewDecoder(p).FieldEach(func(field pproflite.Field) error {
+		switch t := field.(type) {
+		case *pproflite.StringTable:
+			demangled := demangle.Filter(string(t.Value))
+			v := pproflite.StringTable{Value: []byte(demangled)}
+			enc.Encode(v)
+		default:
+			enc.Encode(field)
+		}
+		return nil
+	})
+
+	return out.Bytes(), nil
+}

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -107,6 +107,7 @@ type config struct {
 	deltaProfiles     bool
 	deltaMethod       string
 	logStartup        bool
+	demangle          bool
 }
 
 // logStartup records the configuration to the configured logger in JSON format
@@ -513,5 +514,13 @@ func WithLogStartup(enabled bool) Option {
 func WithHostname(hostname string) Option {
 	return func(cfg *config) {
 		cfg.hostname = hostname
+	}
+}
+
+// WithDemangledSymbols will demangle symbol names which are mangled, such as those
+// coming from C++ or Rust libraries. Defaults to false.
+func WithDemangledSymbols(enabled bool) Option {
+	return func(c *config) {
+		c.demangle = enabled
 	}
 }

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -102,7 +102,10 @@ var profileTypes = map[ProfileType]profileType{
 			// the other profile types
 			p.pendingProfiles.Wait()
 			p.stopCPUProfile()
-			return buf.Bytes(), nil
+			if !p.cfg.demangle {
+				return buf.Bytes(), nil
+			}
+			return demangleCPUProfile(buf.Bytes())
 		},
 	},
 	// HeapProfile is complex due to how the Go runtime exposes it. It contains 4


### PR DESCRIPTION
**WIP:** This PR is mainly for demonstration purposes.

This PR adds optional client-side C++/Rust symbol demangling for CPU profiles.
