### PR TITLE
repo/benchmarks: Fix the benchmarks

### DIFF
--- a/.gitlab/scripts/analyze-results.sh
+++ b/.gitlab/scripts/analyze-results.sh
@@ -21,6 +21,6 @@ cd /benchmark-analyzer
   --extra-params="{\"dd_trace_go\":\"main\"}" \
   "${ARTIFACTS_DIR}/main_bench.txt"
 
-./benchmark_analyzer compare pairwise --outpath ${REPORTS_DIR}/report.md --format md-nodejs pr.json main.json
-./benchmark_analyzer compare pairwise --outpath ${REPORTS_DIR}/report_full.html --format html pr.json main.json
+./benchmark_analyzer compare pairwise --outpath ${REPORTS_DIR}/report.md --format md-nodejs main.json pr.json
+./benchmark_analyzer compare pairwise --outpath ${REPORTS_DIR}/report_full.html --format html main.json pr.json
 

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -379,6 +379,7 @@ func (t *tracer) pushTrace(trace *finishedTrace) {
 
 // StartSpan creates, starts, and returns a new Span with the given `operationName`.
 func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOption) ddtrace.Span {
+	time.Sleep(5 * time.Millisecond)
 	var opts ddtrace.StartSpanConfig
 	for _, fn := range options {
 		fn(&opts)

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -379,7 +379,6 @@ func (t *tracer) pushTrace(trace *finishedTrace) {
 
 // StartSpan creates, starts, and returns a new Span with the given `operationName`.
 func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOption) ddtrace.Span {
-	time.Sleep(5 * time.Millisecond)
 	var opts ddtrace.StartSpanConfig
 	for _, fn := range options {
 		fn(&opts)


### PR DESCRIPTION
We had the candidate and baseline flipped for comparison. This fixes it.

This also resolves an issue where the Concurrent benchmark wasn't actually waiting for the go routines to finish so it wasn't measuring anything useful. This is why the performance for the concurrent tracing benchmark appears significantly worse (and why the allocs "got better" due to goroutines existing across benchmark boundaries in main)