### PR TITLE
tracer: support `b3multi` alias for `b3` carrier

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -185,7 +185,7 @@ func getPropagators(cfg *PropagatorConfig, env string) []Propagator {
 		switch strings.ToLower(v) {
 		case "datadog":
 			list = append(list, dd)
-		case "b3":
+		case "b3", "b3multi":
 			if !cfg.B3 {
 				// propagatorB3 hasn't already been added, add a new one.
 				list = append(list, &propagatorB3{})

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -355,9 +355,9 @@ func TestTextMapPropagator(t *testing.T) {
 	})
 }
 
-func TestB3(t *testing.T) {
+func testB3(t *testing.T, b3Header string) {
 	t.Run("inject", func(t *testing.T) {
-		os.Setenv("DD_PROPAGATION_STYLE_INJECT", "B3")
+		os.Setenv("DD_PROPAGATION_STYLE_INJECT", b3Header)
 		defer os.Unsetenv("DD_PROPAGATION_STYLE_INJECT")
 
 		var tests = []struct {
@@ -409,7 +409,7 @@ func TestB3(t *testing.T) {
 	})
 
 	t.Run("extract", func(t *testing.T) {
-		os.Setenv("DD_PROPAGATION_STYLE_EXTRACT", "b3")
+		os.Setenv("DD_PROPAGATION_STYLE_EXTRACT", b3Header)
 		defer os.Unsetenv("DD_PROPAGATION_STYLE_EXTRACT")
 
 		var tests = []struct {
@@ -455,7 +455,7 @@ func TestB3(t *testing.T) {
 	})
 
 	t.Run("multiple", func(t *testing.T) {
-		os.Setenv("DD_PROPAGATION_STYLE_EXTRACT", "Datadog,B3")
+		os.Setenv("DD_PROPAGATION_STYLE_EXTRACT", fmt.Sprintf("Datadog,%v", b3Header))
 		defer os.Unsetenv("DD_PROPAGATION_STYLE_EXTRACT")
 
 		b3Headers := TextMapCarrier(map[string]string{
@@ -495,6 +495,12 @@ func TestB3(t *testing.T) {
 		assert.True(ok)
 		assert.Equal(2, p)
 	})
+
+}
+
+func TestB3(t *testing.T) {
+	testB3(t, "b3")
+	testB3(t, "b3multi")
 
 	t.Run("config", func(t *testing.T) {
 		os.Setenv("DD_PROPAGATION_STYLE_INJECT", "datadog")

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -455,7 +455,7 @@ func testB3(t *testing.T, b3Header string) {
 	})
 
 	t.Run("multiple", func(t *testing.T) {
-		os.Setenv("DD_PROPAGATION_STYLE_EXTRACT", fmt.Sprintf("Datadog,%v", b3Header))
+		os.Setenv("DD_PROPAGATION_STYLE_EXTRACT", fmt.Sprintf("Datadog,%s", b3Header))
 		defer os.Unsetenv("DD_PROPAGATION_STYLE_EXTRACT")
 
 		b3Headers := TextMapCarrier(map[string]string{


### PR DESCRIPTION
### What does this PR do?

Adds b3multi as a supported propagator for trace context extraction and injection, which will act as a new alias for the existing b3 propagator.

### Motivation

This is to align with the OTel specification.

### Describe how to test/QA your changes

Set `DD_PROPAGATION_STYLE_INJECT` and `DD_PROPAGATION_STYLE_EXTRACT` to `"b3"` and ensure that any headers headers propagate as expected. Then do the same for setting it to `"b3multi"` and verify that the behavior didn't change.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.