### PR TITLE
Add pipeline to upload benchmark samples to S3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,5 @@
 stages:
   - benchmarks
+  - upload-to-s3
 
 include: ".gitlab/benchmarks.yml"

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -26,3 +26,15 @@ benchmark:
   variables:
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-go
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+
+upload-to-s3:
+  stage: upload-to-s3
+  when: on_success
+  trigger:
+    project: DataDog/apm-reliability/relenv-microbenchmarking-platform
+    branch: ddyurchenko/temp-s3-uploader
+  variables:
+    UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
+    UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
+    UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME
+    UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -33,6 +33,7 @@ upload-to-s3:
   trigger:
     project: DataDog/apm-reliability/relenv-microbenchmarking-platform
     branch: ddyurchenko/temp-s3-uploader
+    strategy: depend
   variables:
     UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
     UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME

--- a/.gitlab/scripts/analyze-results.sh
+++ b/.gitlab/scripts/analyze-results.sh
@@ -24,3 +24,9 @@ cd /benchmark-analyzer
 ./benchmark_analyzer compare pairwise --outpath ${REPORTS_DIR}/report.md --format md-nodejs main.json pr.json
 ./benchmark_analyzer compare pairwise --outpath ${REPORTS_DIR}/report_full.html --format html main.json pr.json
 
+# Extra artifacts for S3 uploader job
+cp "${ARTIFACTS_DIR}/pr_bench.txt" "$REPORTS_DIR/pr_bench.txt"
+cp "${ARTIFACTS_DIR}/main_bench.txt" "$REPORTS_DIR/main_bench.txt"
+cp "/benchmark-analyzer/pr.json" "$REPORTS_DIR/pr_bench.json"
+cp "/benchmark-analyzer/main.json" "$REPORTS_DIR/main_bench.json"
+echo "UPSTREAM_JOB_ID=$CI_JOB_ID" >> "$REPORTS_DIR/benchmark.env"

--- a/.gitlab/scripts/run-benchmarks.sh
+++ b/.gitlab/scripts/run-benchmarks.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+REPORTS_DIR="$(pwd)/reports/"
 ARTIFACTS_DIR="/artifacts/${CI_JOB_ID}"
 mkdir -p "${ARTIFACTS_DIR}"
 


### PR DESCRIPTION
Hi folks!

This PR enables a way to upload your benchmark results to S3 bucket.

**Successful jobs:**

https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-go/-/jobs/197504283
https://gitlab.ddbuild.io/DataDog/apm-reliability/relenv-microbenchmarking-platform/-/jobs/197505955

**Screenshot of S3 bucket:**

![Screenshot from 2022-11-24 14-27-30](https://user-images.githubusercontent.com/88330911/203795982-9e6c963d-4853-448a-9de6-b212c82bbfb1.png)

### Motivation

We can't apply changes to S3 bucket permissions for you during production freeze that will last till December 5th. 

Realizing that you may want to have fast & dirty solution to upload to S3, I implemented this PR and relevant changes in https://github.com/DataDog/relenv-microbenchmarking-platform/tree/ddyurchenko/temp-s3-uploader. There are couple of downsides to this setup, but at least it should allow you to store your benchmarks results that we can import into Benchmarking Platform dashboard and visualize history.

As soon as freeze ends, we can remove temporary fix and move forward with standard solution.