### PR TITLE
contrib/grpc: update security rules in appsec tests

### DIFF
--- a/contrib/google.golang.org/grpc/appsec_test.go
+++ b/contrib/google.golang.org/grpc/appsec_test.go
@@ -47,7 +47,7 @@ func TestAppSec(t *testing.T) {
 		// The request should have the attack attempts
 		event, _ := finished[0].Tag("_dd.appsec.json").(string)
 		require.NotNil(t, event)
-		require.True(t, strings.Contains(event, "crs-941-100")) // XSS attack attempt
+		require.True(t, strings.Contains(event, "crs-941-110")) // XSS attack attempt
 		require.True(t, strings.Contains(event, "ua0-600-55x")) // canary rule attack attempt
 	})
 
@@ -89,7 +89,7 @@ func TestAppSec(t *testing.T) {
 		// The request should have the attack attempts
 		event, _ := finished[5].Tag("_dd.appsec.json").(string)
 		require.NotNil(t, event)
-		require.True(t, strings.Contains(event, "crs-941-100")) // XSS attack attempt
+		require.True(t, strings.Contains(event, "crs-941-110")) // XSS attack attempt
 		require.True(t, strings.Contains(event, "crs-942-100")) // SQL-injection attack attempt
 		require.True(t, strings.Contains(event, "ua0-600-55x")) // canary rule attack attempt
 	})


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
This change fixes the appsec-grpc-related late CI failures.
It does so by updating the checks that are made to see which WAF rules have been triggered.
Some rules used were removed in a previous rules update and were thus causing the tests to fail.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
A greener CI :green_book: 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.