### PR TITLE
ddtrace/tracer: add LocalRootSpan() to retrieve the root span

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -170,6 +170,17 @@ func (s *span) setSamplingPriority(priority int, sampler samplernames.SamplerNam
 	s.setSamplingPriorityLocked(priority, sampler)
 }
 
+// Return the root span of the span's trace.
+func (s *span) localRootSpan() *span {
+	if s.context == nil {
+		return nil
+	}
+	if s.context.trace == nil {
+		return nil
+	}
+	return s.context.trace.root
+}
+
 // SetUser associates user information to the current trace which the
 // provided span belongs to. The options can be used to tune which user
 // bit of information gets monitored. In case of distributed traces,
@@ -180,7 +191,7 @@ func (s *span) SetUser(id string, opts ...UserMonitoringOption) {
 	for _, fn := range opts {
 		fn(&cfg)
 	}
-	root := s.context.trace.root
+	root := s.localRootSpan()
 	trace := root.context.trace
 	root.Lock()
 	defer root.Unlock()

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -186,6 +186,18 @@ func SetUser(s Span, id string, opts ...UserMonitoringOption) {
 	sp.SetUser(id, opts...)
 }
 
+// LocalRootSpan returns the local root span of the given span's trace.
+func LocalRootSpan(s Span) Span {
+	if s == nil {
+		return nil
+	}
+	sp, ok := s.(*span)
+	if !ok {
+		return nil
+	}
+	return sp.localRootSpan()
+}
+
 // payloadQueueSize is the buffer size of the trace channel.
 const payloadQueueSize = 1000
 
@@ -520,8 +532,7 @@ func (t *tracer) applyPPROFLabels(ctx gocontext.Context, span *span) {
 		labels = append(labels, traceprof.SpanID, strconv.FormatUint(span.SpanID, 10))
 	}
 	// nil checks might not be needed, but better be safe than sorry
-	if span.context.trace != nil && span.context.trace.root != nil {
-		localRootSpan := span.context.trace.root
+	if localRootSpan := span.localRootSpan(); localRootSpan != nil {
 		if t.config.profilerHotspots {
 			labels = append(labels, traceprof.LocalRootSpanID, strconv.FormatUint(localRootSpan.SpanID, 10))
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Expose a new `tracer` function `LocalRootSpan(Span) Span` allowing to retrieve the trace's root span from the given span.

I took the name "local root span" from dd-trace-java, and it is not strictly named the same accross dd-trace-{py,java,rb,php}, so we can basically choose what we prefer here.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

ASM will use root span tags in Q1 as transport for custom events (eg. if a user wants to monitor any of its own business logic, they will do it with a root span tag then monitored backend-side). This is tied to the way Datadog's backend is designed and can only do these kind on monitoring on the root spans.

This feature already exists in dd-trace-{py,java,rb,php} and is part of datadog's public documentation ([dd-trace-py example](https://docs.datadoghq.com/tracing/trace_collection/custom_instrumentation/python?tab=rootspan#accessing-active-spans)).


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

100% Go unit tests

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.