### PR TITLE
tracer: replaces INJECT/EXTRACT environment variable names

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -65,8 +65,12 @@ func (c TextMapCarrier) ForeachKey(handler func(key, val string) error) error {
 }
 
 const (
-	headerPropagationStyleInject  = "DD_PROPAGATION_STYLE_INJECT"
-	headerPropagationStyleExtract = "DD_PROPAGATION_STYLE_EXTRACT"
+	headerPropagationStyleInject  = "DD_TRACE_PROPAGATION_STYLE_INJECT"
+	headerPropagationStyleExtract = "DD_TRACE_PROPAGATION_STYLE_EXTRACT"
+	headerPropagationStyle        = "DD_TRACE_PROPAGATION_STYLE"
+
+	headerPropagationStyleInjectDeprecated  = "DD_PROPAGATION_STYLE_INJECT"  // deprecated
+	headerPropagationStyleExtractDeprecated = "DD_PROPAGATION_STYLE_EXTRACT" // deprecated
 )
 
 const (
@@ -127,6 +131,13 @@ type PropagatorConfig struct {
 // NewPropagator returns a new propagator which uses TextMap to inject
 // and extract values. It propagates trace and span IDs and baggage.
 // To use the defaults, nil may be provided in place of the config.
+//
+// The inject and extract propagators are determined using environment variables
+// with the following order of precedence:
+//  1. DD_TRACE_PROPAGATION_STYLE_INJECT
+//  2. DD_PROPAGATION_STYLE_INJECT (deprecated)
+//  3. DD_TRACE_PROPAGATION_STYLE (applies to both inject and extract)
+//  4. If none of the above, use default values
 func NewPropagator(cfg *PropagatorConfig, propagators ...Propagator) Propagator {
 	if cfg == nil {
 		cfg = new(PropagatorConfig)
@@ -149,9 +160,21 @@ func NewPropagator(cfg *PropagatorConfig, propagators ...Propagator) Propagator 
 			extractors: propagators,
 		}
 	}
+	injectorsPs := os.Getenv(headerPropagationStyleInject)
+	if injectorsPs == "" {
+		if injectorsPs = os.Getenv(headerPropagationStyleInjectDeprecated); injectorsPs != "" {
+			log.Warn("%v is deprecated. Please use %v or %v instead.\n", headerPropagationStyleInjectDeprecated, headerPropagationStyleInject, headerPropagationStyle)
+		}
+	}
+	extractorsPs := os.Getenv(headerPropagationStyleExtract)
+	if extractorsPs == "" {
+		if extractorsPs = os.Getenv(headerPropagationStyleExtractDeprecated); extractorsPs != "" {
+			log.Warn("%v is deprecated. Please use %v or %v instead.\n", headerPropagationStyleExtractDeprecated, headerPropagationStyleExtract, headerPropagationStyle)
+		}
+	}
 	return &chainedPropagator{
-		injectors:  getPropagators(cfg, headerPropagationStyleInject),
-		extractors: getPropagators(cfg, headerPropagationStyleExtract),
+		injectors:  getPropagators(cfg, injectorsPs),
+		extractors: getPropagators(cfg, extractorsPs),
 	}
 }
 
@@ -163,19 +186,22 @@ type chainedPropagator struct {
 	extractors []Propagator
 }
 
-// getPropagators returns a list of propagators based on the list found in the
-// given environment variable. If the list doesn't contain any valid values the
+// getPropagators returns a list of propagators based on ps, which is a comma seperated
+// list of propagators. If the list doesn't contain any valid values, the
 // default propagator will be returned. Any invalid values in the list will log
 // a warning and be ignored.
-func getPropagators(cfg *PropagatorConfig, env string) []Propagator {
+func getPropagators(cfg *PropagatorConfig, ps string) []Propagator {
 	dd := &propagator{cfg}
-	ps := os.Getenv(env)
 	defaultPs := []Propagator{dd}
 	if cfg.B3 {
 		defaultPs = append(defaultPs, &propagatorB3{})
 	}
 	if ps == "" {
-		return defaultPs
+		if prop := os.Getenv(headerPropagationStyle); prop != "" {
+			ps = prop // use the generic DD_TRACE_PROPAGATION_STYLE if set
+		} else {
+			return defaultPs // no env set, so use default from configuration
+		}
 	}
 	if ps == "none" {
 		return nil
@@ -201,8 +227,7 @@ func getPropagators(cfg *PropagatorConfig, env string) []Propagator {
 		}
 	}
 	if len(list) == 0 {
-		// return the default
-		return defaultPs
+		return defaultPs // no valid propagators, so return default
 	}
 	return list
 }

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -220,8 +220,8 @@ func getPropagators(cfg *PropagatorConfig, ps string) []Propagator {
 				list = append(list, &propagatorB3{})
 			}
 		case "none":
-			log.Warn("Propagator \"none\" has no effect when combined with other propagators. "+
-				"To disable the propagator, set `%s=none`", env)
+			log.Warn("Propagator \"none\" has no effect when combined with other propagators. " +
+				"To disable the propagator, set to `none`")
 		default:
 			log.Warn("unrecognized propagator: %s\n", v)
 		}

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -355,205 +355,238 @@ func TestTextMapPropagator(t *testing.T) {
 	})
 }
 
-func testB3(t *testing.T, b3Header string) {
-	t.Run("inject", func(t *testing.T) {
-		os.Setenv("DD_PROPAGATION_STYLE_INJECT", b3Header)
-		defer os.Unsetenv("DD_PROPAGATION_STYLE_INJECT")
+func TestEnvVars(t *testing.T) {
+	var testEnvs []map[string]string
 
-		var tests = []struct {
-			in  []uint64
-			out map[string]string
-		}{
-			{
-				[]uint64{1412508178991881, 1842642739201064},
-				map[string]string{
-					b3TraceIDHeader: "000504ab30404b09",
-					b3SpanIDHeader:  "00068bdfb1eb0428",
+	testEnvs = []map[string]string{
+		{headerPropagationStyleInject: "b3"},
+		{headerPropagationStyleInjectDeprecated: "b3"},
+		{headerPropagationStyle: "b3"},
+		{headerPropagationStyleInject: "b3multi", headerPropagationStyleInjectDeprecated: "datadog" /* this should have no affect */},
+		{headerPropagationStyleInject: "b3multi", headerPropagationStyle: "datadog" /* this should have no affect */},
+	}
+	for _, testEnv := range testEnvs {
+		t.Run(fmt.Sprintf("inject with env=%q", testEnv), func(t *testing.T) {
+			for k, v := range testEnv {
+				os.Setenv(k, v)
+				defer os.Unsetenv(k)
+			}
+			var tests = []struct {
+				in  []uint64
+				out map[string]string
+			}{
+				{
+					[]uint64{1412508178991881, 1842642739201064},
+					map[string]string{
+						b3TraceIDHeader: "000504ab30404b09",
+						b3SpanIDHeader:  "00068bdfb1eb0428",
+					},
 				},
-			},
-			{
-				[]uint64{9530669991610245, 9455715668862222},
-				map[string]string{
-					b3TraceIDHeader: "0021dc1807524785",
-					b3SpanIDHeader:  "002197ec5d8a250e",
+				{
+					[]uint64{9530669991610245, 9455715668862222},
+					map[string]string{
+						b3TraceIDHeader: "0021dc1807524785",
+						b3SpanIDHeader:  "002197ec5d8a250e",
+					},
 				},
-			},
-			{
-				[]uint64{1, 1},
-				map[string]string{
-					b3TraceIDHeader: "0000000000000001",
-					b3SpanIDHeader:  "0000000000000001",
+				{
+					[]uint64{1, 1},
+					map[string]string{
+						b3TraceIDHeader: "0000000000000001",
+						b3SpanIDHeader:  "0000000000000001",
+					},
 				},
-			},
-		}
+			}
 
-		for _, test := range tests {
-			t.Run("", func(t *testing.T) {
-				tracer := newTracer()
-				root := tracer.StartSpan("web.request").(*span)
-				root.SetTag(ext.SamplingPriority, -1)
-				root.SetBaggageItem("item", "x")
-				ctx, ok := root.Context().(*spanContext)
-				ctx.traceID = test.in[0]
-				ctx.spanID = test.in[1]
-				headers := TextMapCarrier(map[string]string{})
-				err := tracer.Inject(ctx, headers)
+			for _, test := range tests {
+				t.Run("", func(t *testing.T) {
+					tracer := newTracer()
+					root := tracer.StartSpan("web.request").(*span)
+					root.SetTag(ext.SamplingPriority, -1)
+					root.SetBaggageItem("item", "x")
+					ctx, ok := root.Context().(*spanContext)
+					ctx.traceID = test.in[0]
+					ctx.spanID = test.in[1]
+					headers := TextMapCarrier(map[string]string{})
+					err := tracer.Inject(ctx, headers)
 
-				assert := assert.New(t)
-				assert.True(ok)
-				assert.Nil(err)
-				assert.Equal(test.out[b3TraceIDHeader], headers[b3TraceIDHeader])
-				assert.Equal(test.out[b3SpanIDHeader], headers[b3SpanIDHeader])
-			})
-		}
-	})
-
-	t.Run("extract", func(t *testing.T) {
-		os.Setenv("DD_PROPAGATION_STYLE_EXTRACT", b3Header)
-		defer os.Unsetenv("DD_PROPAGATION_STYLE_EXTRACT")
-
-		var tests = []struct {
-			in  TextMapCarrier
-			out []uint64 // contains [<trace_id>, <span_id>]
-		}{
-			{
-				TextMapCarrier{
-					b3TraceIDHeader: "1",
-					b3SpanIDHeader:  "1",
-				},
-				[]uint64{1, 1},
-			},
-			{
-				TextMapCarrier{
-					b3TraceIDHeader: "feeb0599801f4700",
-					b3SpanIDHeader:  "f8f5c76089ad8da5",
-				},
-				[]uint64{18368781661998368512, 17939463908140879269},
-			},
-			{
-				TextMapCarrier{
-					b3TraceIDHeader: "6e96719ded9c1864a21ba1551789e3f5",
-					b3SpanIDHeader:  "a1eb5bf36e56e50e",
-				},
-				[]uint64{11681107445354718197, 11667520360719770894},
-			},
-		}
-
-		for _, test := range tests {
-			t.Run("", func(t *testing.T) {
-				tracer := newTracer()
-				assert := assert.New(t)
-				ctx, err := tracer.Extract(test.in)
-				assert.Nil(err)
-				sctx, ok := ctx.(*spanContext)
-				assert.True(ok)
-
-				assert.Equal(sctx.traceID, test.out[0])
-				assert.Equal(sctx.spanID, test.out[1])
-			})
-		}
-	})
-
-	t.Run("multiple", func(t *testing.T) {
-		os.Setenv("DD_PROPAGATION_STYLE_EXTRACT", fmt.Sprintf("Datadog,%s", b3Header))
-		defer os.Unsetenv("DD_PROPAGATION_STYLE_EXTRACT")
-
-		b3Headers := TextMapCarrier(map[string]string{
-			b3TraceIDHeader: "1",
-			b3SpanIDHeader:  "1",
-			b3SampledHeader: "1",
+					assert := assert.New(t)
+					assert.True(ok)
+					assert.Nil(err)
+					assert.Equal(test.out[b3TraceIDHeader], headers[b3TraceIDHeader])
+					assert.Equal(test.out[b3SpanIDHeader], headers[b3SpanIDHeader])
+				})
+			}
 		})
+	}
 
-		tracer := newTracer()
-		assert := assert.New(t)
+	testEnvs = []map[string]string{
+		{headerPropagationStyleExtract: "b3"},
+		{headerPropagationStyleExtractDeprecated: "b3"},
+		{headerPropagationStyle: "b3"},
+		{headerPropagationStyleExtract: "b3multi", headerPropagationStyleExtractDeprecated: "datadog" /* this should have no affect */},
+		{headerPropagationStyleExtract: "b3multi", headerPropagationStyle: "datadog" /* this should have no affect */},
+	}
+	for _, testEnv := range testEnvs {
+		t.Run(fmt.Sprintf("extract with env=%q", testEnv), func(t *testing.T) {
+			for k, v := range testEnv {
+				os.Setenv(k, v)
+				defer os.Unsetenv(k)
+			}
+			var tests = []struct {
+				in  TextMapCarrier
+				out []uint64 // contains [<trace_id>, <span_id>]
+			}{
+				{
+					TextMapCarrier{
+						b3TraceIDHeader: "1",
+						b3SpanIDHeader:  "1",
+					},
+					[]uint64{1, 1},
+				},
+				{
+					TextMapCarrier{
+						b3TraceIDHeader: "feeb0599801f4700",
+						b3SpanIDHeader:  "f8f5c76089ad8da5",
+					},
+					[]uint64{18368781661998368512, 17939463908140879269},
+				},
+				{
+					TextMapCarrier{
+						b3TraceIDHeader: "6e96719ded9c1864a21ba1551789e3f5",
+						b3SpanIDHeader:  "a1eb5bf36e56e50e",
+					},
+					[]uint64{11681107445354718197, 11667520360719770894},
+				},
+			}
 
-		ctx, err := tracer.Extract(b3Headers)
-		assert.Nil(err)
-		sctx, ok := ctx.(*spanContext)
-		assert.True(ok)
+			for _, test := range tests {
+				t.Run("", func(t *testing.T) {
+					tracer := newTracer()
+					assert := assert.New(t)
+					ctx, err := tracer.Extract(test.in)
+					assert.Nil(err)
+					sctx, ok := ctx.(*spanContext)
+					assert.True(ok)
 
-		assert.Equal(sctx.traceID, uint64(1))
-		assert.Equal(sctx.spanID, uint64(1))
-		p, ok := sctx.samplingPriority()
-		assert.True(ok)
-		assert.Equal(1, p)
-
-		ddHeaders := TextMapCarrier(map[string]string{
-			DefaultTraceIDHeader:  "2",
-			DefaultParentIDHeader: "2",
-			DefaultPriorityHeader: "2",
+					assert.Equal(sctx.traceID, test.out[0])
+					assert.Equal(sctx.spanID, test.out[1])
+				})
+			}
 		})
+	}
 
-		ctx, err = tracer.Extract(ddHeaders)
-		assert.Nil(err)
-		sctx, ok = ctx.(*spanContext)
-		assert.True(ok)
-
-		assert.Equal(sctx.traceID, uint64(2))
-		assert.Equal(sctx.spanID, uint64(2))
-		p, ok = sctx.samplingPriority()
-		assert.True(ok)
-		assert.Equal(2, p)
-	})
-
-}
-
-func TestB3(t *testing.T) {
-	testB3(t, "b3")
-	testB3(t, "b3multi")
-	testB3(t, "none,b3multi")
-
-	t.Run("config", func(t *testing.T) {
-		os.Setenv("DD_PROPAGATION_STYLE_INJECT", "datadog")
-		defer os.Unsetenv("DD_PROPAGATION_STYLE_INJECT")
-
-		var tests = []struct {
-			in  []uint64
-			out map[string]string
-		}{
-			{
-				[]uint64{1412508178991881, 1842642739201064},
-				map[string]string{
-					b3TraceIDHeader: "000504ab30404b09",
-					b3SpanIDHeader:  "00068bdfb1eb0428",
+	testEnvs = []map[string]string{
+		{headerPropagationStyleInject: "datadog"},
+		{headerPropagationStyleInjectDeprecated: "datadog"},
+		{headerPropagationStyle: "datadog"},
+		{headerPropagationStyleInject: "datadog", headerPropagationStyleInjectDeprecated: "b3" /* this should have no affect */},
+		{headerPropagationStyleInject: "datadog", headerPropagationStyle: "b3multi" /* this should have no affect */},
+	}
+	for _, testEnv := range testEnvs {
+		t.Run(fmt.Sprintf("inject with env=%q", testEnv), func(t *testing.T) {
+			os.Setenv("DD_PROPAGATION_STYLE_INJECT", "datadog")
+			defer os.Unsetenv("DD_PROPAGATION_STYLE_INJECT")
+			var tests = []struct {
+				in  []uint64
+				out map[string]string
+			}{
+				{
+					[]uint64{1412508178991881, 1842642739201064},
+					map[string]string{
+						b3TraceIDHeader: "000504ab30404b09",
+						b3SpanIDHeader:  "00068bdfb1eb0428",
+					},
 				},
-			},
-			{
-				[]uint64{9530669991610245, 9455715668862222},
-				map[string]string{
-					b3TraceIDHeader: "0021dc1807524785",
-					b3SpanIDHeader:  "002197ec5d8a250e",
+				{
+					[]uint64{9530669991610245, 9455715668862222},
+					map[string]string{
+						b3TraceIDHeader: "0021dc1807524785",
+						b3SpanIDHeader:  "002197ec5d8a250e",
+					},
 				},
-			},
-			{
-				[]uint64{1, 1},
-				map[string]string{
-					b3TraceIDHeader: "0000000000000001",
-					b3SpanIDHeader:  "0000000000000001",
+				{
+					[]uint64{1, 1},
+					map[string]string{
+						b3TraceIDHeader: "0000000000000001",
+						b3SpanIDHeader:  "0000000000000001",
+					},
 				},
-			},
-		}
+			}
 
-		for _, test := range tests {
-			t.Run("", func(t *testing.T) {
-				tracer := newTracer(WithPropagator(NewPropagator(&PropagatorConfig{B3: true})))
-				root := tracer.StartSpan("web.request").(*span)
-				root.SetTag(ext.SamplingPriority, -1)
-				root.SetBaggageItem("item", "x")
-				ctx, ok := root.Context().(*spanContext)
-				ctx.traceID = test.in[0]
-				ctx.spanID = test.in[1]
-				headers := TextMapCarrier(map[string]string{})
-				err := tracer.Inject(ctx, headers)
+			for _, test := range tests {
+				t.Run("", func(t *testing.T) {
+					tracer := newTracer(WithPropagator(NewPropagator(&PropagatorConfig{B3: true})))
+					root := tracer.StartSpan("web.request").(*span)
+					root.SetTag(ext.SamplingPriority, -1)
+					root.SetBaggageItem("item", "x")
+					ctx, ok := root.Context().(*spanContext)
+					ctx.traceID = test.in[0]
+					ctx.spanID = test.in[1]
+					headers := TextMapCarrier(map[string]string{})
+					err := tracer.Inject(ctx, headers)
 
-				assert := assert.New(t)
-				assert.True(ok)
-				assert.Nil(err)
-				assert.Equal(test.out[b3TraceIDHeader], headers[b3TraceIDHeader])
-				assert.Equal(test.out[b3SpanIDHeader], headers[b3SpanIDHeader])
-			})
-		}
-	})
+					assert := assert.New(t)
+					assert.True(ok)
+					assert.Nil(err)
+					assert.Equal(test.out[b3TraceIDHeader], headers[b3TraceIDHeader])
+					assert.Equal(test.out[b3SpanIDHeader], headers[b3SpanIDHeader])
+				})
+			}
+		})
+	}
+
+	testEnvs = []map[string]string{
+		{headerPropagationStyleExtract: fmt.Sprintf("Datadog,%s", "b3")},
+		{headerPropagationStyleExtractDeprecated: fmt.Sprintf("Datadog,%s", "b3")},
+		{headerPropagationStyle: fmt.Sprintf("Datadog,%s", "b3")},
+	}
+	for _, testEnv := range testEnvs {
+		t.Run(fmt.Sprintf("extract with env=%q", testEnv), func(t *testing.T) {
+			for k, v := range testEnv {
+				os.Setenv(k, v)
+				defer os.Unsetenv(k)
+			}
+			var tests = []struct {
+				in  TextMapCarrier
+				out uint64
+			}{
+				{
+					TextMapCarrier{
+						b3TraceIDHeader: "1",
+						b3SpanIDHeader:  "1",
+						b3SampledHeader: "1",
+					},
+					1,
+				},
+				{
+					TextMapCarrier{
+						DefaultTraceIDHeader:  "2",
+						DefaultParentIDHeader: "2",
+						DefaultPriorityHeader: "2",
+					},
+					2,
+				},
+			}
+			for _, test := range tests {
+				t.Run("", func(t *testing.T) {
+					tracer := newTracer()
+					assert := assert.New(t)
+
+					ctx, err := tracer.Extract(test.in)
+					assert.Nil(err)
+					sctx, ok := ctx.(*spanContext)
+					assert.True(ok)
+
+					assert.Equal(sctx.traceID, test.out)
+					assert.Equal(sctx.spanID, test.out)
+					p, ok := sctx.samplingPriority()
+					assert.True(ok)
+					assert.Equal(int(test.out), p)
+				})
+			}
+		})
+	}
 }
 
 func TestNonePropagator(t *testing.T) {

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -360,10 +360,10 @@ func TestEnvVars(t *testing.T) {
 
 	testEnvs = []map[string]string{
 		{headerPropagationStyleInject: "b3"},
-		{headerPropagationStyleInjectDeprecated: "b3,none"},
+		{headerPropagationStyleInjectDeprecated: "b3,none" /* none should have no affect */},
 		{headerPropagationStyle: "b3"},
-		{headerPropagationStyleInject: "b3multi", headerPropagationStyleInjectDeprecated: "none" /* this should have no affect */},
-		{headerPropagationStyleInject: "b3multi", headerPropagationStyle: "none" /* this should have no affect */},
+		{headerPropagationStyleInject: "b3multi", headerPropagationStyleInjectDeprecated: "none" /* none should have no affect */},
+		{headerPropagationStyleInject: "b3multi", headerPropagationStyle: "none" /* none should have no affect */},
 	}
 	for _, testEnv := range testEnvs {
 		t.Run(fmt.Sprintf("inject with env=%q", testEnv), func(t *testing.T) {
@@ -423,9 +423,9 @@ func TestEnvVars(t *testing.T) {
 	testEnvs = []map[string]string{
 		{headerPropagationStyleExtract: "b3"},
 		{headerPropagationStyleExtractDeprecated: "b3"},
-		{headerPropagationStyle: "b3,none"},
-		{headerPropagationStyleExtract: "b3multi", headerPropagationStyleExtractDeprecated: "none" /* this should have no affect */},
-		{headerPropagationStyleExtract: "b3multi", headerPropagationStyle: "none" /* this should have no affect */},
+		{headerPropagationStyle: "b3,none" /* none should have no affect */},
+		{headerPropagationStyleExtract: "b3multi", headerPropagationStyleExtractDeprecated: "none" /* none should have no affect */},
+		{headerPropagationStyleExtract: "b3multi", headerPropagationStyle: "none" /* none should have no affect */},
 	}
 	for _, testEnv := range testEnvs {
 		t.Run(fmt.Sprintf("extract with env=%q", testEnv), func(t *testing.T) {
@@ -478,10 +478,10 @@ func TestEnvVars(t *testing.T) {
 
 	testEnvs = []map[string]string{
 		{headerPropagationStyleInject: "datadog"},
-		{headerPropagationStyleInjectDeprecated: "datadog"},
+		{headerPropagationStyleInjectDeprecated: "datadog,none" /* none should have no affect */},
 		{headerPropagationStyle: "datadog"},
-		{headerPropagationStyleInject: "datadog", headerPropagationStyleInjectDeprecated: "none" /* this should have no affect */},
-		{headerPropagationStyleInject: "datadog", headerPropagationStyle: "none" /* this should have no affect */},
+		{headerPropagationStyleInject: "datadog", headerPropagationStyleInjectDeprecated: "none" /* none should have no affect */},
+		{headerPropagationStyleInject: "datadog", headerPropagationStyle: "none" /* none should have no affect */},
 	}
 	for _, testEnv := range testEnvs {
 		t.Run(fmt.Sprintf("inject with env=%q", testEnv), func(t *testing.T) {
@@ -537,10 +537,10 @@ func TestEnvVars(t *testing.T) {
 	}
 
 	testEnvs = []map[string]string{
-		{headerPropagationStyleExtract: fmt.Sprintf("Datadog,b3")},
-		{headerPropagationStyleExtractDeprecated: fmt.Sprintf("Datadog,b3multi")},
-		{headerPropagationStyle: fmt.Sprintf("Datadog,b3")},
-		{headerPropagationStyle: fmt.Sprintf("Datadog,b3,none")},
+		{headerPropagationStyleExtract: "Datadog,b3"},
+		{headerPropagationStyleExtractDeprecated: "Datadog,b3multi"},
+		{headerPropagationStyle: "Datadog,b3"},
+		{headerPropagationStyle: "none,Datadog,b3" /* none should have no affect */},
 	}
 	for _, testEnv := range testEnvs {
 		t.Run(fmt.Sprintf("extract with env=%q", testEnv), func(t *testing.T) {
@@ -592,7 +592,7 @@ func TestEnvVars(t *testing.T) {
 
 func TestNonePropagator(t *testing.T) {
 	t.Run("inject/none", func(t *testing.T) {
-		t.Setenv("DD_PROPAGATION_STYLE_INJECT", "none")
+		t.Setenv(headerPropagationStyleInject, "none")
 		tracer := newTracer()
 		root := tracer.StartSpan("web.request").(*span)
 		root.SetTag(ext.SamplingPriority, -1)
@@ -610,7 +610,7 @@ func TestNonePropagator(t *testing.T) {
 	})
 
 	t.Run("inject/none,b3", func(t *testing.T) {
-		t.Setenv("DD_PROPAGATION_STYLE_INJECT", "none,b3")
+		t.Setenv(headerPropagationStyleInject, "none,b3")
 		tp := new(testLogger)
 		tracer := newTracer(WithLogger(tp))
 		// reinitializing to capture log output, since propagators are parsed before logger is set
@@ -629,12 +629,10 @@ func TestNonePropagator(t *testing.T) {
 		assert.Nil(err)
 		assert.Equal("0000000000000001", headers[b3TraceIDHeader])
 		assert.Equal("0000000000000001", headers[b3SpanIDHeader])
-		assert.Contains(tp.lines[0], "Propagator \"none\" has no effect when combined with other propagators. "+
-			"To disable the propagator, set `DD_PROPAGATION_STYLE_INJECT=none`")
 	})
 
 	t.Run("extract/none", func(t *testing.T) {
-		t.Setenv("DD_PROPAGATION_STYLE_EXTRACT", "none")
+		t.Setenv(headerPropagationStyleExtract, "none")
 		assert := assert.New(t)
 		tracer := newTracer()
 		root := tracer.StartSpan("web.request").(*span)
@@ -649,8 +647,7 @@ func TestNonePropagator(t *testing.T) {
 	})
 
 	t.Run("inject,extract/none", func(t *testing.T) {
-		t.Setenv("DD_PROPAGATION_STYLE_INJECT", "none")
-		t.Setenv("DD_PROPAGATION_STYLE_EXTRACT", "none")
+		t.Setenv(headerPropagationStyle, "none")
 		tracer := newTracer()
 		root := tracer.StartSpan("web.request").(*span)
 		root.SetTag(ext.SamplingPriority, -1)

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -629,6 +629,8 @@ func TestNonePropagator(t *testing.T) {
 		assert.Nil(err)
 		assert.Equal("0000000000000001", headers[b3TraceIDHeader])
 		assert.Equal("0000000000000001", headers[b3SpanIDHeader])
+		assert.Contains(tp.lines[0], "Propagator \"none\" has no effect when combined with other propagators. "+
+			"To disable the propagator, set to `none`")
 	})
 
 	t.Run("extract/none", func(t *testing.T) {

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -366,58 +366,52 @@ func TestEnvVars(t *testing.T) {
 		{headerPropagationStyleInject: "b3multi", headerPropagationStyle: "none" /* none should have no affect */},
 	}
 	for _, testEnv := range testEnvs {
-		t.Run(fmt.Sprintf("inject with env=%q", testEnv), func(t *testing.T) {
-			for k, v := range testEnv {
-				os.Setenv(k, v)
-				defer os.Unsetenv(k)
-			}
-			var tests = []struct {
-				in  []uint64
-				out map[string]string
-			}{
-				{
-					[]uint64{1412508178991881, 1842642739201064},
-					map[string]string{
-						b3TraceIDHeader: "000504ab30404b09",
-						b3SpanIDHeader:  "00068bdfb1eb0428",
-					},
+		for k, v := range testEnv {
+			t.Setenv(k, v)
+		}
+		var tests = []struct {
+			in  []uint64
+			out map[string]string
+		}{
+			{
+				[]uint64{1412508178991881, 1842642739201064},
+				map[string]string{
+					b3TraceIDHeader: "000504ab30404b09",
+					b3SpanIDHeader:  "00068bdfb1eb0428",
 				},
-				{
-					[]uint64{9530669991610245, 9455715668862222},
-					map[string]string{
-						b3TraceIDHeader: "0021dc1807524785",
-						b3SpanIDHeader:  "002197ec5d8a250e",
-					},
+			},
+			{
+				[]uint64{9530669991610245, 9455715668862222},
+				map[string]string{
+					b3TraceIDHeader: "0021dc1807524785",
+					b3SpanIDHeader:  "002197ec5d8a250e",
 				},
-				{
-					[]uint64{1, 1},
-					map[string]string{
-						b3TraceIDHeader: "0000000000000001",
-						b3SpanIDHeader:  "0000000000000001",
-					},
+			},
+			{
+				[]uint64{1, 1},
+				map[string]string{
+					b3TraceIDHeader: "0000000000000001",
+					b3SpanIDHeader:  "0000000000000001",
 				},
-			}
+			},
+		}
+		for _, test := range tests {
+			t.Run(fmt.Sprintf("inject with env=%q", testEnv), func(t *testing.T) {
+				tracer := newTracer()
+				root := tracer.StartSpan("web.request").(*span)
+				ctx, ok := root.Context().(*spanContext)
+				ctx.traceID = test.in[0]
+				ctx.spanID = test.in[1]
+				headers := TextMapCarrier(map[string]string{})
+				err := tracer.Inject(ctx, headers)
 
-			for _, test := range tests {
-				t.Run("", func(t *testing.T) {
-					tracer := newTracer()
-					root := tracer.StartSpan("web.request").(*span)
-					root.SetTag(ext.SamplingPriority, -1)
-					root.SetBaggageItem("item", "x")
-					ctx, ok := root.Context().(*spanContext)
-					ctx.traceID = test.in[0]
-					ctx.spanID = test.in[1]
-					headers := TextMapCarrier(map[string]string{})
-					err := tracer.Inject(ctx, headers)
-
-					assert := assert.New(t)
-					assert.True(ok)
-					assert.Nil(err)
-					assert.Equal(test.out[b3TraceIDHeader], headers[b3TraceIDHeader])
-					assert.Equal(test.out[b3SpanIDHeader], headers[b3SpanIDHeader])
-				})
-			}
-		})
+				assert := assert.New(t)
+				assert.True(ok)
+				assert.Nil(err)
+				assert.Equal(test.out[b3TraceIDHeader], headers[b3TraceIDHeader])
+				assert.Equal(test.out[b3SpanIDHeader], headers[b3SpanIDHeader])
+			})
+		}
 	}
 
 	testEnvs = []map[string]string{
@@ -428,52 +422,48 @@ func TestEnvVars(t *testing.T) {
 		{headerPropagationStyleExtract: "b3multi", headerPropagationStyle: "none" /* none should have no affect */},
 	}
 	for _, testEnv := range testEnvs {
-		t.Run(fmt.Sprintf("extract with env=%q", testEnv), func(t *testing.T) {
-			for k, v := range testEnv {
-				os.Setenv(k, v)
-				defer os.Unsetenv(k)
-			}
-			var tests = []struct {
-				in  TextMapCarrier
-				out []uint64 // contains [<trace_id>, <span_id>]
-			}{
-				{
-					TextMapCarrier{
-						b3TraceIDHeader: "1",
-						b3SpanIDHeader:  "1",
-					},
-					[]uint64{1, 1},
+		for k, v := range testEnv {
+			t.Setenv(k, v)
+		}
+		var tests = []struct {
+			in  TextMapCarrier
+			out []uint64 // contains [<trace_id>, <span_id>]
+		}{
+			{
+				TextMapCarrier{
+					b3TraceIDHeader: "1",
+					b3SpanIDHeader:  "1",
 				},
-				{
-					TextMapCarrier{
-						b3TraceIDHeader: "feeb0599801f4700",
-						b3SpanIDHeader:  "f8f5c76089ad8da5",
-					},
-					[]uint64{18368781661998368512, 17939463908140879269},
+				[]uint64{1, 1},
+			},
+			{
+				TextMapCarrier{
+					b3TraceIDHeader: "feeb0599801f4700",
+					b3SpanIDHeader:  "f8f5c76089ad8da5",
 				},
-				{
-					TextMapCarrier{
-						b3TraceIDHeader: "6e96719ded9c1864a21ba1551789e3f5",
-						b3SpanIDHeader:  "a1eb5bf36e56e50e",
-					},
-					[]uint64{11681107445354718197, 11667520360719770894},
+				[]uint64{18368781661998368512, 17939463908140879269},
+			},
+			{
+				TextMapCarrier{
+					b3TraceIDHeader: "6e96719ded9c1864a21ba1551789e3f5",
+					b3SpanIDHeader:  "a1eb5bf36e56e50e",
 				},
-			}
+				[]uint64{11681107445354718197, 11667520360719770894},
+			},
+		}
+		for _, test := range tests {
+			t.Run(fmt.Sprintf("extract with env=%q", testEnv), func(t *testing.T) {
+				tracer := newTracer()
+				assert := assert.New(t)
+				ctx, err := tracer.Extract(test.in)
+				assert.Nil(err)
+				sctx, ok := ctx.(*spanContext)
+				assert.True(ok)
 
-			for _, test := range tests {
-				t.Run("", func(t *testing.T) {
-					tracer := newTracer()
-					assert := assert.New(t)
-					ctx, err := tracer.Extract(test.in)
-					assert.Nil(err)
-					sctx, ok := ctx.(*spanContext)
-					assert.True(ok)
-
-					assert.Equal(sctx.traceID, test.out[0])
-					assert.Equal(sctx.spanID, test.out[1])
-				})
-			}
-		})
+				assert.Equal(sctx.traceID, test.out[0])
+				assert.Equal(sctx.spanID, test.out[1])
+			})
+		}
 	}
 
 	testEnvs = []map[string]string{
@@ -484,56 +474,52 @@ func TestEnvVars(t *testing.T) {
 		{headerPropagationStyleInject: "datadog", headerPropagationStyle: "none" /* none should have no affect */},
 	}
 	for _, testEnv := range testEnvs {
-		t.Run(fmt.Sprintf("inject with env=%q", testEnv), func(t *testing.T) {
-			os.Setenv("DD_PROPAGATION_STYLE_INJECT", "datadog")
-			defer os.Unsetenv("DD_PROPAGATION_STYLE_INJECT")
-			var tests = []struct {
-				in  []uint64
-				out map[string]string
-			}{
-				{
-					[]uint64{1412508178991881, 1842642739201064},
-					map[string]string{
-						b3TraceIDHeader: "000504ab30404b09",
-						b3SpanIDHeader:  "00068bdfb1eb0428",
-					},
+		for k, v := range testEnv {
+			t.Setenv(k, v)
+		}
+		var tests = []struct {
+			in  []uint64
+			out map[string]string
+		}{
+			{
+				[]uint64{1412508178991881, 1842642739201064},
+				map[string]string{
+					b3TraceIDHeader: "000504ab30404b09",
+					b3SpanIDHeader:  "00068bdfb1eb0428",
 				},
-				{
-					[]uint64{9530669991610245, 9455715668862222},
-					map[string]string{
-						b3TraceIDHeader: "0021dc1807524785",
-						b3SpanIDHeader:  "002197ec5d8a250e",
-					},
+			},
+			{
+				[]uint64{9530669991610245, 9455715668862222},
+				map[string]string{
+					b3TraceIDHeader: "0021dc1807524785",
+					b3SpanIDHeader:  "002197ec5d8a250e",
 				},
-				{
-					[]uint64{1, 1},
-					map[string]string{
-						b3TraceIDHeader: "0000000000000001",
-						b3SpanIDHeader:  "0000000000000001",
-					},
+			},
+			{
+				[]uint64{1, 1},
+				map[string]string{
+					b3TraceIDHeader: "0000000000000001",
+					b3SpanIDHeader:  "0000000000000001",
 				},
-			}
+			},
+		}
+		for _, test := range tests {
+			t.Run(fmt.Sprintf("inject with env=%q", testEnv), func(t *testing.T) {
+				tracer := newTracer(WithPropagator(NewPropagator(&PropagatorConfig{B3: true})))
+				root := tracer.StartSpan("web.request").(*span)
+				ctx, ok := root.Context().(*spanContext)
+				ctx.traceID = test.in[0]
+				ctx.spanID = test.in[1]
+				headers := TextMapCarrier(map[string]string{})
+				err := tracer.Inject(ctx, headers)
 
-			for _, test := range tests {
-				t.Run("", func(t *testing.T) {
-					tracer := newTracer(WithPropagator(NewPropagator(&PropagatorConfig{B3: true})))
-					root := tracer.StartSpan("web.request").(*span)
-					root.SetTag(ext.SamplingPriority, -1)
-					root.SetBaggageItem("item", "x")
-					ctx, ok := root.Context().(*spanContext)
-					ctx.traceID = test.in[0]
-					ctx.spanID = test.in[1]
-					headers := TextMapCarrier(map[string]string{})
-					err := tracer.Inject(ctx, headers)
-
-					assert := assert.New(t)
-					assert.True(ok)
-					assert.Nil(err)
-					assert.Equal(test.out[b3TraceIDHeader], headers[b3TraceIDHeader])
-					assert.Equal(test.out[b3SpanIDHeader], headers[b3SpanIDHeader])
-				})
-			}
-		})
+				assert := assert.New(t)
+				assert.True(ok)
+				assert.Nil(err)
+				assert.Equal(test.out[b3TraceIDHeader], headers[b3TraceIDHeader])
+				assert.Equal(test.out[b3SpanIDHeader], headers[b3SpanIDHeader])
+			})
+		}
 	}
 
 	testEnvs = []map[string]string{
@@ -587,6 +573,71 @@ func TestEnvVars(t *testing.T) {
 				})
 			}
 		})
+	}
+
+	testEnvs = []map[string]string{
+		{headerPropagationStyleInject: "datadog", headerPropagationStyleExtract: "datadog"},
+		{headerPropagationStyleInjectDeprecated: "datadog", headerPropagationStyleExtractDeprecated: "datadog"},
+		{headerPropagationStyleInject: "datadog", headerPropagationStyle: "datadog"},
+		{headerPropagationStyle: "datadog"},
+	}
+	for _, testEnv := range testEnvs {
+		for k, v := range testEnv {
+			t.Setenv(k, v)
+		}
+		var tests = []struct {
+			in  []uint64
+			out map[string]string
+		}{
+			{
+				[]uint64{1412508178991881, 1842642739201064},
+				map[string]string{
+					b3TraceIDHeader: "000504ab30404b09",
+					b3SpanIDHeader:  "00068bdfb1eb0428",
+				},
+			},
+			{
+				[]uint64{9530669991610245, 9455715668862222},
+				map[string]string{
+					b3TraceIDHeader: "0021dc1807524785",
+					b3SpanIDHeader:  "002197ec5d8a250e",
+				},
+			},
+			{
+				[]uint64{1, 1},
+				map[string]string{
+					b3TraceIDHeader: "0000000000000001",
+					b3SpanIDHeader:  "0000000000000001",
+				},
+			},
+		}
+		for _, test := range tests {
+			t.Run(fmt.Sprintf("inject and extract with env=%q", testEnv), func(t *testing.T) {
+				tracer := newTracer()
+				root := tracer.StartSpan("web.request").(*span)
+				root.SetTag(ext.SamplingPriority, -1)
+				root.SetBaggageItem("item", "x")
+				ctx, ok := root.Context().(*spanContext)
+				ctx.traceID = test.in[0]
+				ctx.spanID = test.in[1]
+				headers := TextMapCarrier(map[string]string{})
+				err := tracer.Inject(ctx, headers)
+
+				assert := assert.New(t)
+				assert.True(ok)
+				assert.Nil(err)
+
+				sctx, err := tracer.Extract(headers)
+				assert.Nil(err)
+
+				xctx, ok := sctx.(*spanContext)
+				assert.True(ok)
+				assert.Equal(ctx.traceID, xctx.traceID)
+				assert.Equal(ctx.spanID, xctx.spanID)
+				assert.Equal(ctx.baggage, xctx.baggage)
+				assert.Equal(ctx.trace.priority, xctx.trace.priority)
+			})
+		}
 	}
 }
 

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -360,10 +360,10 @@ func TestEnvVars(t *testing.T) {
 
 	testEnvs = []map[string]string{
 		{headerPropagationStyleInject: "b3"},
-		{headerPropagationStyleInjectDeprecated: "b3"},
+		{headerPropagationStyleInjectDeprecated: "b3,none"},
 		{headerPropagationStyle: "b3"},
-		{headerPropagationStyleInject: "b3multi", headerPropagationStyleInjectDeprecated: "datadog" /* this should have no affect */},
-		{headerPropagationStyleInject: "b3multi", headerPropagationStyle: "datadog" /* this should have no affect */},
+		{headerPropagationStyleInject: "b3multi", headerPropagationStyleInjectDeprecated: "none" /* this should have no affect */},
+		{headerPropagationStyleInject: "b3multi", headerPropagationStyle: "none" /* this should have no affect */},
 	}
 	for _, testEnv := range testEnvs {
 		t.Run(fmt.Sprintf("inject with env=%q", testEnv), func(t *testing.T) {
@@ -423,9 +423,9 @@ func TestEnvVars(t *testing.T) {
 	testEnvs = []map[string]string{
 		{headerPropagationStyleExtract: "b3"},
 		{headerPropagationStyleExtractDeprecated: "b3"},
-		{headerPropagationStyle: "b3"},
-		{headerPropagationStyleExtract: "b3multi", headerPropagationStyleExtractDeprecated: "datadog" /* this should have no affect */},
-		{headerPropagationStyleExtract: "b3multi", headerPropagationStyle: "datadog" /* this should have no affect */},
+		{headerPropagationStyle: "b3,none"},
+		{headerPropagationStyleExtract: "b3multi", headerPropagationStyleExtractDeprecated: "none" /* this should have no affect */},
+		{headerPropagationStyleExtract: "b3multi", headerPropagationStyle: "none" /* this should have no affect */},
 	}
 	for _, testEnv := range testEnvs {
 		t.Run(fmt.Sprintf("extract with env=%q", testEnv), func(t *testing.T) {
@@ -480,8 +480,8 @@ func TestEnvVars(t *testing.T) {
 		{headerPropagationStyleInject: "datadog"},
 		{headerPropagationStyleInjectDeprecated: "datadog"},
 		{headerPropagationStyle: "datadog"},
-		{headerPropagationStyleInject: "datadog", headerPropagationStyleInjectDeprecated: "b3" /* this should have no affect */},
-		{headerPropagationStyleInject: "datadog", headerPropagationStyle: "b3multi" /* this should have no affect */},
+		{headerPropagationStyleInject: "datadog", headerPropagationStyleInjectDeprecated: "none" /* this should have no affect */},
+		{headerPropagationStyleInject: "datadog", headerPropagationStyle: "none" /* this should have no affect */},
 	}
 	for _, testEnv := range testEnvs {
 		t.Run(fmt.Sprintf("inject with env=%q", testEnv), func(t *testing.T) {
@@ -537,9 +537,10 @@ func TestEnvVars(t *testing.T) {
 	}
 
 	testEnvs = []map[string]string{
-		{headerPropagationStyleExtract: fmt.Sprintf("Datadog,%s", "b3")},
-		{headerPropagationStyleExtractDeprecated: fmt.Sprintf("Datadog,%s", "b3")},
-		{headerPropagationStyle: fmt.Sprintf("Datadog,%s", "b3")},
+		{headerPropagationStyleExtract: fmt.Sprintf("Datadog,b3")},
+		{headerPropagationStyleExtractDeprecated: fmt.Sprintf("Datadog,b3multi")},
+		{headerPropagationStyle: fmt.Sprintf("Datadog,b3")},
+		{headerPropagationStyle: fmt.Sprintf("Datadog,b3,none")},
 	}
 	for _, testEnv := range testEnvs {
 		t.Run(fmt.Sprintf("extract with env=%q", testEnv), func(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Deprecates `DD_PROPAGATION_STYLE_INJECT` and `DD_PROPAGATION_STYLE_EXTRACT`. Introduces new environment variables `DD_TRACE_PROPAGATION_STYLE_INJECT`, `DD_TRACE_PROPAGATION_STYLE_EXTRACT`, and `DD_TRACE_PROPAGATION_STYLE` (which generally applies to both inject and extract). They will take the following precendence: 

  1. DD_TRACE_PROPAGATION_STYLE_INJECT
  2. DD_PROPAGATION_STYLE_INJECT (deprecated)
  3. DD_TRACE_PROPAGATION_STYLE (applies to both inject and extract)
  4. If none of the above, use default values

Although the diff in `textmap_test.go` looks significant, the testing behavior didn't change drastically. The only difference is that all of the tests run repeatedly using a mix of environment variables to ensure that the correct precedence is used, and each of the 3 ways to configure inject/extract is fully supported.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

This creates feature parity between the tracers.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

In a tracer setup that injects and extracts headers, set various configurations of these environment variables to ensure that they take the correct precedence. Verify that using the deprecated variables will log a warning.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.