### PR TITLE
contrib: Fixes memory leak for spankind and component

### DIFF
--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -30,6 +30,8 @@ func Middleware(service string, opts ...Option) gin.HandlerFunc {
 	log.Debug("contrib/gin-gonic/gin: Configuring Middleware: Service: %s, %#v", cfg.serviceName, cfg)
 	spanOpts := []tracer.StartSpanOption{
 		tracer.ServiceName(cfg.serviceName),
+		tracer.Tag(ext.Component, "gin-gonic/gin"),
+		tracer.Tag(ext.SpanKind, ext.SpanKindServer),
 	}
 	return func(c *gin.Context) {
 		if cfg.ignoreRequest(c) {
@@ -40,8 +42,6 @@ func Middleware(service string, opts ...Option) gin.HandlerFunc {
 			opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 		}
 		opts = append(opts, tracer.Tag(ext.HTTPRoute, c.FullPath()))
-		opts = append(opts, tracer.Tag(ext.Component, "gin-gonic/gin"))
-		opts = append(opts, tracer.Tag(ext.SpanKind, ext.SpanKindServer))
 
 		span, ctx := httptrace.StartRequestSpan(c.Request, opts...)
 		defer func() {

--- a/contrib/go-chi/chi.v5/chi.go
+++ b/contrib/go-chi/chi.v5/chi.go
@@ -30,6 +30,8 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 	}
 	log.Debug("contrib/go-chi/chi.v5: Configuring Middleware: %#v", cfg)
 	spanOpts := append(cfg.spanOpts, tracer.ServiceName(cfg.serviceName))
+	spanOpts = append(cfg.spanOpts, tracer.Tag(ext.Component, "go-chi/chi.v5"))
+	spanOpts = append(cfg.spanOpts, tracer.Tag(ext.SpanKind, ext.SpanKindServer))
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if cfg.ignoreRequest(r) {
@@ -37,8 +39,6 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 				return
 			}
 			opts := spanOpts
-			opts = append(opts, tracer.Tag(ext.Component, "go-chi/chi.v5"))
-			opts = append(opts, tracer.Tag(ext.SpanKind, ext.SpanKindServer))
 			if !math.IsNaN(cfg.analyticsRate) {
 				opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 			}

--- a/contrib/gorilla/mux/mux.go
+++ b/contrib/gorilla/mux/mux.go
@@ -100,8 +100,6 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		route, _ = match.Route.GetPathTemplate()
 	}
 	spanopts = append(spanopts, r.config.spanOpts...)
-	spanopts = append(spanopts, tracer.Tag(ext.Component, "gorilla/mux"))
-	spanopts = append(spanopts, tracer.Tag(ext.SpanKind, ext.SpanKindServer))
 
 	if r.config.headerTags {
 		spanopts = append(spanopts, headerTagsFromRequest(req))
@@ -122,6 +120,8 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // requests and responses served by the router.
 func WrapRouter(router *mux.Router, opts ...RouterOption) *Router {
 	cfg := newConfig(opts)
+	cfg.spanOpts = append(cfg.spanOpts, tracer.Tag(ext.Component, "gorilla/mux"))
+	cfg.spanOpts = append(cfg.spanOpts, tracer.Tag(ext.SpanKind, ext.SpanKindServer))
 	log.Debug("contrib/gorilla/mux: Configuring Router: %#v", cfg)
 	return &Router{
 		Router: router,

--- a/contrib/julienschmidt/httprouter/httprouter.go
+++ b/contrib/julienschmidt/httprouter/httprouter.go
@@ -35,6 +35,10 @@ func New(opts ...RouterOption) *Router {
 	if !math.IsNaN(cfg.analyticsRate) {
 		cfg.spanOpts = append(cfg.spanOpts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 	}
+
+	cfg.spanOpts = append(cfg.spanOpts, tracer.Tag(ext.SpanKind, ext.SpanKindServer))
+	cfg.spanOpts = append(cfg.spanOpts, tracer.Tag(ext.Component, "julienschmidt/httprouter"))
+
 	log.Debug("contrib/julienschmidt/httprouter: Configuring Router: %#v", cfg)
 	return &Router{httprouter.New(), cfg}
 }
@@ -48,9 +52,6 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		route = strings.Replace(route, param.Value, ":"+param.Key, 1)
 	}
 	resource := req.Method + " " + route
-
-	r.config.spanOpts = append(r.config.spanOpts, tracer.Tag(ext.SpanKind, ext.SpanKindServer))
-	r.config.spanOpts = append(r.config.spanOpts, tracer.Tag(ext.Component, "julienschmidt/httprouter"))
 
 	httptrace.TraceAndServe(r.Router, w, req, &httptrace.ServeConfig{
 		Service:  r.config.serviceName,

--- a/contrib/urfave/negroni/negroni.go
+++ b/contrib/urfave/negroni/negroni.go
@@ -29,8 +29,6 @@ func (m *DatadogMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, ne
 	if !math.IsNaN(m.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, m.cfg.analyticsRate))
 	}
-	opts = append(opts, tracer.Tag(ext.Component, "urfave/negroni"))
-	opts = append(opts, tracer.Tag(ext.SpanKind, ext.SpanKindServer))
 
 	span, ctx := httptrace.StartRequestSpan(r, opts...)
 	defer func() {
@@ -59,6 +57,8 @@ func Middleware(opts ...Option) *DatadogMiddleware {
 	for _, fn := range opts {
 		fn(cfg)
 	}
+	cfg.spanOpts = append(cfg.spanOpts, tracer.Tag(ext.Component, "urfave/negroni"))
+	cfg.spanOpts = append(cfg.spanOpts, tracer.Tag(ext.SpanKind, ext.SpanKindServer))
 	log.Debug("contrib/urgave/negroni: Configuring Middleware: %#v", cfg)
 
 	m := DatadogMiddleware{


### PR DESCRIPTION

### What does this PR do?

Fixes memory leak by calling `span.kind` and `component` unnecessarily in several integrations

