### PR TITLE
contrib/go-pg/pg.v10: fix spankind value

### DIFF
--- a/contrib/go-pg/pg.v10/pg_go.go
+++ b/contrib/go-pg/pg.v10/pg_go.go
@@ -44,7 +44,6 @@ func (h *queryHook) BeforeQuery(ctx context.Context, qe *pg.QueryEvent) (context
 		tracer.ResourceName(string(query)),
 		tracer.ServiceName(h.cfg.serviceName),
 		tracer.Tag(ext.Component, "go-pg/pg.v10"),
-		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
 	}
 	if !math.IsNaN(h.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, h.cfg.analyticsRate))

--- a/contrib/go-pg/pg.v10/pg_go_test.go
+++ b/contrib/go-pg/pg.v10/pg_go_test.go
@@ -68,8 +68,6 @@ func TestSelect(t *testing.T) {
 	assert.Equal("go-pg", spans[0].OperationName())
 	assert.Equal("http.request", spans[1].OperationName())
 	assert.Equal("go-pg/pg.v10", spans[0].Tags()[ext.Component])
-	assert.Equal(ext.SpanKindClient, spans[0].Tags()[ext.SpanKind])
-
 }
 
 func TestServiceName(t *testing.T) {
@@ -109,7 +107,6 @@ func TestServiceName(t *testing.T) {
 		assert.Equal("gopg.db", spans[0].Tag(ext.ServiceName))
 		assert.Equal("fake-http-server", spans[1].Tag(ext.ServiceName))
 		assert.Equal("go-pg/pg.v10", spans[0].Tags()[ext.Component])
-		assert.Equal(ext.SpanKindClient, spans[0].Tags()[ext.SpanKind])
 	})
 
 	t.Run("global", func(t *testing.T) {
@@ -151,7 +148,6 @@ func TestServiceName(t *testing.T) {
 		assert.Equal("global-service", spans[0].Tag(ext.ServiceName))
 		assert.Equal("fake-http-server", spans[1].Tag(ext.ServiceName))
 		assert.Equal("go-pg/pg.v10", spans[0].Tags()[ext.Component])
-		assert.Equal(ext.SpanKindClient, spans[0].Tags()[ext.SpanKind])
 	})
 
 	t.Run("custom", func(t *testing.T) {
@@ -190,7 +186,6 @@ func TestServiceName(t *testing.T) {
 		assert.Equal("my-service-name", spans[0].Tag(ext.ServiceName))
 		assert.Equal("fake-http-server", spans[1].Tag(ext.ServiceName))
 		assert.Equal("go-pg/pg.v10", spans[0].Tags()[ext.Component])
-		assert.Equal(ext.SpanKindClient, spans[0].Tags()[ext.SpanKind])
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?

ORMs by nature are internal spankind values which go-pg mistakenly was not.
Removes the spankind tag and updates tests such that it follows the theme of ORMs being internal