### PR TITLE
contrib/database/sql: Fix sample code in document to prevent panic on OpenDB

### DIFF
--- a/contrib/database/sql/sql.go
+++ b/contrib/database/sql/sql.go
@@ -9,7 +9,7 @@
 // We start by telling the package which driver we will be using. For example, if we are using "github.com/lib/pq",
 // we would do as follows:
 //
-//	sqltrace.Register("pq", pq.Driver{})
+//	sqltrace.Register("pq", &pq.Driver{})
 //	db, err := sqltrace.Open("pq", "postgres://pqgotest:password@localhost...")
 //
 // The rest of our application would continue as usual, but with tracing enabled.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Fix document to prevent to misuse Register function.
Issue: #1634

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
In the example below, driver.Driver is passed as struct, and `reflect.TypeOf(driver)` is added to map.
https://github.com/DataDog/dd-trace-go/blob/2d259577c708a035e4ca6346230c55192a16e4b1/contrib/database/sql/sql.go#L12-L13

Later when user call OpenDB, `reflect.TypeOf(driver)` is looked up in d.keys, therefore driver added and looked up must have same type. For example, if added type is struct, looked up by struct. And if added type is pointer of struct, looked up by pointer of struct.
https://github.com/DataDog/dd-trace-go/blob/2d259577c708a035e4ca6346230c55192a16e4b1/contrib/database/sql/sql.go#L76

This behavior is not a problem when driver doesn't implement driver.DriverContext interface, because in this case driver get from map `driver` is used when lookup and type of these always same.
https://github.com/DataDog/dd-trace-go/blob/2d259577c708a035e4ca6346230c55192a16e4b1/contrib/database/sql/sql.go#L236

However when driver implement driver.DriverContext, user must care whether type is pointer or not when calling `Register`.

Driver in `lib/pq` currently not implement `driver.DriverContext` but soon it will implement. see: https://github.com/lib/pq/pull/900

Ideally the way look up should be better, but at least document should be fixed.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes
The problem can be reproduced by code below.
```
	sqltrace.Register("mysql", mysql.MySQLDriver{})
	_, err := sqltrace.Open("mysql", "user:password@tcp(localhost:3306)/db")
	fmt.Printf("err with mysql.MySQLDriver{} %v\n", err)
```
This print `panic: sqltrace.OpenDB: driver is not registered via sqltrace.Register` with stacktrace.

The error can be avoided by passing by pointer like below. 
```
	sqltrace.Register("mysql", &mysql.MySQLDriver{})
	_, err2 := sqltrace.Open("mysql", "user:password@tcp(localhost:3306)/dbe")
	fmt.Printf("err with &mysql.MySQLDriver{} %v\n", err2)
```
This print `err with &mysql.MySQLDriver{} <nil>`.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.