### PR TITLE
ci: increase multi-OS test timeout from 10 minutes to 15 minutes

### DIFF
--- a/.github/workflows/multios-unit-tests.yml
+++ b/.github/workflows/multios-unit-tests.yml
@@ -42,7 +42,7 @@ jobs:
         shell: bash
         run: |
             go list ./... | grep -v -e grpc.v12 -e google.golang.org/api -e sarama -e confluent-kafka-go -e cmemprof | sort >packages.txt
-            gotestsum --junitfile ${REPORT} -- $(cat packages.txt) -v -coverprofile=coverage.txt -covermode=atomic
+            gotestsum --junitfile ${REPORT} -- $(cat packages.txt) -v -coverprofile=coverage.txt -covermode=atomic -timeout=15m
 
       - name: Upload the results to Datadog CI App
         if: always()


### PR DESCRIPTION
### What does this PR do?

Increase the timeout for multi-OS unit tests to 15 minutes.

### Motivation

The ddtrace/tracer tests take longer than 10 minutes to run on the
GitHub Windows runners. Since 10 minutes is the default Go test timeout,
that means the tests are now failing to complete. Increase the timeout
to 15 minutes to give more headroom until we can figure out why the
tests are taking so long.

### Describe how to test/QA your changes

Run the unit tests on Windows with this increased timeout, see if they pass.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.
