### PR TITLE
ddtrace/tracer: clean up resources in tests

### DIFF
--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -61,7 +61,7 @@ jobs:
           ./bin/gometalinter --disable-all --vendor --deadline=120s --enable=golint ./...
 
   test-core:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     env:
        TEST_RESULTS: /tmp/test-results # path to where test results will be saved
        INTEGRATION: true

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -61,7 +61,7 @@ jobs:
           ./bin/gometalinter --disable-all --vendor --deadline=120s --enable=golint ./...
 
   test-core:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
        TEST_RESULTS: /tmp/test-results # path to where test results will be saved
        INTEGRATION: true

--- a/ddtrace/tracer/metrics.go
+++ b/ddtrace/tracer/metrics.go
@@ -46,7 +46,7 @@ func (t *tracer) reportRuntimeMetrics(interval time.Duration) {
 			runtime.ReadMemStats(&ms)
 			debug.ReadGCStats(&gc)
 
-			statsd := t.config.statsd
+			statsd := t.statsd
 			// CPU statistics
 			statsd.Gauge("runtime.go.num_cpu", float64(runtime.NumCPU()), nil, 1)
 			statsd.Gauge("runtime.go.num_goroutine", float64(runtime.NumGoroutine()), nil, 1)
@@ -99,9 +99,9 @@ func (t *tracer) reportHealthMetrics(interval time.Duration) {
 	for {
 		select {
 		case <-ticker.C:
-			t.config.statsd.Count("datadog.tracer.spans_started", int64(atomic.SwapUint32(&t.spansStarted, 0)), nil, 1)
-			t.config.statsd.Count("datadog.tracer.spans_finished", int64(atomic.SwapUint32(&t.spansFinished, 0)), nil, 1)
-			t.config.statsd.Count("datadog.tracer.traces_dropped", int64(atomic.SwapUint32(&t.tracesDropped, 0)), []string{"reason:trace_too_large"}, 1)
+			t.statsd.Count("datadog.tracer.spans_started", int64(atomic.SwapUint32(&t.spansStarted, 0)), nil, 1)
+			t.statsd.Count("datadog.tracer.spans_finished", int64(atomic.SwapUint32(&t.spansFinished, 0)), nil, 1)
+			t.statsd.Count("datadog.tracer.traces_dropped", int64(atomic.SwapUint32(&t.tracesDropped, 0)), []string{"reason:trace_too_large"}, 1)
 		case <-t.stop:
 			return
 		}

--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -246,7 +246,6 @@ func (tg *testStatsdClient) Wait(n int, d time.Duration) error {
 func TestReportRuntimeMetrics(t *testing.T) {
 	var tg testStatsdClient
 	trc := newUnstartedTracer(withStatsdClient(&tg))
-	trc.startStatsd()
 	defer trc.statsd.Close()
 
 	trc.wg.Add(1)

--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -48,7 +48,7 @@ type testStatsdCall struct {
 
 func withStatsdClient(s statsdClient) StartOption {
 	return func(c *config) {
-		c.statsClient = s
+		c.statsdClient = s
 	}
 }
 

--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -48,7 +48,7 @@ type testStatsdCall struct {
 
 func withStatsdClient(s statsdClient) StartOption {
 	return func(c *config) {
-		c.statsd = s
+		c.statsClient = s
 	}
 }
 
@@ -246,6 +246,8 @@ func (tg *testStatsdClient) Wait(n int, d time.Duration) error {
 func TestReportRuntimeMetrics(t *testing.T) {
 	var tg testStatsdClient
 	trc := newUnstartedTracer(withStatsdClient(&tg))
+	trc.startStatsd()
+	defer trc.statsd.Close()
 
 	trc.wg.Add(1)
 	go func() {

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -114,9 +114,9 @@ type config struct {
 	// combination of the environment variables DD_AGENT_HOST and DD_DOGSTATSD_PORT.
 	dogstatsdAddr string
 
-	// statsClient is set when a user provides a custom statsd client for tracking metrics
+	// statsdClient is set when a user provides a custom statsd client for tracking metrics
 	// associated with the runtime and the tracer.
-	statsClient statsdClient
+	statsdClient statsdClient
 
 	// spanRules contains user-defined rules to determine the sampling rate to apply
 	// to trace spans.
@@ -296,7 +296,7 @@ func newConfig(opts ...StartOption) *config {
 		log.SetLevel(log.LevelDebug)
 	}
 	c.loadAgentFeatures()
-	if c.statsClient == nil {
+	if c.statsdClient == nil {
 		// configure statsd client
 		addr := c.dogstatsdAddr
 		if addr == "" {
@@ -323,8 +323,8 @@ func newConfig(opts ...StartOption) *config {
 }
 
 func newStatsdClient(c *config) (statsdClient, error) {
-	if c.statsClient != nil {
-		return c.statsClient, nil
+	if c.statsdClient != nil {
+		return c.statsdClient, nil
 	}
 
 	client, err := statsd.New(c.dogstatsdAddr, statsd.WithMaxMessagesPerPayload(40), statsd.WithTags(statsTags(c)))
@@ -483,7 +483,7 @@ func statsTags(c *config) []string {
 // withNoopStats is used for testing to disable statsd client
 func withNoopStats() StartOption {
 	return func(c *config) {
-		c.statsClient = &statsd.NoOpClient{}
+		c.statsdClient = &statsd.NoOpClient{}
 	}
 }
 

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -41,9 +41,11 @@ func withTickChan(ch <-chan time.Time) StartOption {
 // testStatsd asserts that the given statsd.Client can successfully send metrics
 // to a UDP listener located at addr.
 func testStatsd(t *testing.T, cfg *config, addr string) {
-	client := cfg.statsd
+	client, err := newStatsdClient(cfg)
+	require.NoError(t, err)
+	defer client.Close()
 	require.Equal(t, addr, cfg.dogstatsdAddr)
-	_, err := net.ResolveUDPAddr("udp", addr)
+	_, err = net.ResolveUDPAddr("udp", addr)
 	require.NoError(t, err)
 
 	client.Count("name", 1, []string{"tag"}, 1)
@@ -57,7 +59,9 @@ func TestStatsdUDPConnect(t *testing.T) {
 	cfg := newConfig()
 	addr := net.JoinHostPort(defaultHostname, "8111")
 
-	client := cfg.statsd
+	client, err := newStatsdClient(cfg)
+	require.NoError(t, err)
+	defer client.Close()
 	require.Equal(t, addr, cfg.dogstatsdAddr)
 	udpaddr, err := net.ResolveUDPAddr("udp", addr)
 	require.NoError(t, err)
@@ -118,8 +122,11 @@ func TestAutoDetectStatsd(t *testing.T) {
 		conn.SetDeadline(time.Now().Add(5 * time.Second))
 
 		cfg := newConfig()
+		statsd, err := newStatsdClient(cfg)
+		require.NoError(t, err)
+		defer statsd.Close()
 		require.Equal(t, cfg.dogstatsdAddr, "unix://"+addr)
-		cfg.statsd.Count("name", 1, []string{"tag"}, 1)
+		statsd.Count("name", 1, []string{"tag"}, 1)
 
 		buf := make([]byte, 17)
 		n, err := conn.Read(buf)
@@ -246,11 +253,14 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			defer globalconfig.SetAnalyticsRate(math.NaN())
 			assert := assert.New(t)
 			assert.True(math.IsNaN(globalconfig.AnalyticsRate()))
-			newTracer(WithAnalyticsRate(0.5))
+			tracer := newTracer(WithAnalyticsRate(0.5))
+			defer tracer.Stop()
 			assert.Equal(0.5, globalconfig.AnalyticsRate())
-			newTracer(WithAnalytics(false))
+			tracer = newTracer(WithAnalytics(false))
+			defer tracer.Stop()
 			assert.True(math.IsNaN(globalconfig.AnalyticsRate()))
-			newTracer(WithAnalytics(true))
+			tracer = newTracer(WithAnalytics(true))
+			defer tracer.Stop()
 			assert.Equal(1., globalconfig.AnalyticsRate())
 		})
 
@@ -274,6 +284,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 	t.Run("dogstatsd", func(t *testing.T) {
 		t.Run("default", func(t *testing.T) {
 			tracer := newTracer()
+			defer tracer.Stop()
 			c := tracer.config
 			assert.Equal(t, c.dogstatsdAddr, "localhost:8125")
 		})
@@ -282,6 +293,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			os.Setenv("DD_AGENT_HOST", "my-host")
 			defer os.Unsetenv("DD_AGENT_HOST")
 			tracer := newTracer()
+			defer tracer.Stop()
 			c := tracer.config
 			assert.Equal(t, c.dogstatsdAddr, "my-host:8125")
 		})
@@ -290,6 +302,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			os.Setenv("DD_DOGSTATSD_PORT", "123")
 			defer os.Unsetenv("DD_DOGSTATSD_PORT")
 			tracer := newTracer()
+			defer tracer.Stop()
 			c := tracer.config
 			assert.Equal(t, c.dogstatsdAddr, "localhost:123")
 		})
@@ -300,6 +313,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			defer os.Unsetenv("DD_AGENT_HOST")
 			defer os.Unsetenv("DD_DOGSTATSD_PORT")
 			tracer := newTracer()
+			defer tracer.Stop()
 			c := tracer.config
 			assert.Equal(t, c.dogstatsdAddr, "my-host:123")
 		})
@@ -308,12 +322,14 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			os.Setenv("DD_ENV", "testEnv")
 			defer os.Unsetenv("DD_ENV")
 			tracer := newTracer()
+			defer tracer.Stop()
 			c := tracer.config
 			assert.Equal(t, "testEnv", c.env)
 		})
 
 		t.Run("option", func(t *testing.T) {
 			tracer := newTracer(WithDogstatsdAddress("10.1.0.12:4002"))
+			defer tracer.Stop()
 			c := tracer.config
 			assert.Equal(t, c.dogstatsdAddr, "10.1.0.12:4002")
 		})
@@ -323,6 +339,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		os.Setenv("DD_AGENT_HOST", "trace-agent")
 		defer os.Unsetenv("DD_AGENT_HOST")
 		tracer := newTracer()
+		defer tracer.Stop()
 		c := tracer.config
 		assert.Equal(t, "http://trace-agent:8126", c.agentURL)
 	})
@@ -331,6 +348,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		t.Run("env", func(t *testing.T) {
 			t.Setenv("DD_TRACE_AGENT_URL", "https://custom:1234")
 			tracer := newTracer()
+			defer tracer.Stop()
 			c := tracer.config
 			assert.Equal(t, "https://custom:1234", c.agentURL)
 		})
@@ -340,6 +358,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			t.Setenv("DD_TRACE_AGENT_PORT", "3333")
 			t.Setenv("DD_TRACE_AGENT_URL", "https://custom:1234")
 			tracer := newTracer()
+			defer tracer.Stop()
 			c := tracer.config
 			assert.Equal(t, "https://custom:1234", c.agentURL)
 		})
@@ -347,6 +366,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		t.Run("code-override", func(t *testing.T) {
 			t.Setenv("DD_TRACE_AGENT_URL", "https://custom:1234")
 			tracer := newTracer(WithAgentAddr("testhost:3333"))
+			defer tracer.Stop()
 			c := tracer.config
 			assert.Equal(t, "http://testhost:3333", c.agentURL)
 		})
@@ -358,6 +378,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		assert := assert.New(t)
 		env := "production"
 		tracer := newTracer(WithEnv(env))
+		defer tracer.Stop()
 		c := tracer.config
 		assert.Equal(env, c.env)
 	})
@@ -365,6 +386,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 	t.Run("trace_enabled", func(t *testing.T) {
 		t.Run("default", func(t *testing.T) {
 			tracer := newTracer()
+			defer tracer.Stop()
 			c := tracer.config
 			assert.True(t, c.enabled)
 		})
@@ -373,6 +395,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			os.Setenv("DD_TRACE_ENABLED", "false")
 			defer os.Unsetenv("DD_TRACE_ENABLED")
 			tracer := newTracer()
+			defer tracer.Stop()
 			c := tracer.config
 			assert.False(t, c.enabled)
 		})
@@ -387,6 +410,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			WithDebugMode(true),
 			WithEnv("testEnv"),
 		)
+		defer tracer.Stop()
 		c := tracer.config
 		assert.Equal(float64(0.5), c.sampler.(RateSampler).Rate())
 		assert.Equal("http://ddagent.consul.local:58126", c.agentURL)

--- a/ddtrace/tracer/sampler_test.go
+++ b/ddtrace/tracer/sampler_test.go
@@ -643,6 +643,7 @@ func TestRulesSamplerConcurrency(t *testing.T) {
 		NameRule("notweb.request", 1.0),
 	}
 	tracer := newTracer(WithSamplingRules(rules))
+	defer tracer.Stop()
 	span := func(wg *sync.WaitGroup) {
 		defer wg.Done()
 		tracer.StartSpan("db.query", ServiceName("postgres.db")).Finish()

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -76,6 +76,7 @@ func TestSpanFinish(t *testing.T) {
 	assert := assert.New(t)
 	wait := time.Millisecond * 2
 	tracer := newTracer(withTransport(newDefaultTransport()))
+	defer tracer.Stop()
 	span := tracer.newRootSpan("pylons.request", "pylons", "/")
 
 	// the finish should set finished and the duration
@@ -364,6 +365,7 @@ func TestTraceManualKeepAndManualDrop(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%s/local", scenario.tag), func(t *testing.T) {
 			tracer := newTracer()
+			defer tracer.Stop()
 			span := tracer.newRootSpan("root span", "my service", "my resource")
 			span.SetTag(scenario.tag, true)
 			assert.Equal(t, scenario.keep, shouldKeep(span))
@@ -371,6 +373,7 @@ func TestTraceManualKeepAndManualDrop(t *testing.T) {
 
 		t.Run(fmt.Sprintf("%s/non-local", scenario.tag), func(t *testing.T) {
 			tracer := newTracer()
+			defer tracer.Stop()
 			spanCtx := &spanContext{traceID: 42, spanID: 42}
 			spanCtx.setSamplingPriority(scenario.p, samplernames.RemoteRate)
 			span := tracer.StartSpan("non-local root span", ChildOf(spanCtx)).(*span)
@@ -396,6 +399,7 @@ func TestSpanSetDatadogTags(t *testing.T) {
 func TestSpanStart(t *testing.T) {
 	assert := assert.New(t)
 	tracer := newTracer(withTransport(newDefaultTransport()))
+	defer tracer.Stop()
 	span := tracer.newRootSpan("pylons.request", "pylons", "/")
 
 	// a new span sets the Start after the initialization
@@ -405,6 +409,7 @@ func TestSpanStart(t *testing.T) {
 func TestSpanString(t *testing.T) {
 	assert := assert.New(t)
 	tracer := newTracer(withTransport(newDefaultTransport()))
+	defer tracer.Stop()
 	span := tracer.newRootSpan("pylons.request", "pylons", "/")
 	// don't bother checking the contents, just make sure it works.
 	assert.NotEqual("", span.String())
@@ -463,6 +468,7 @@ func TestSpanSetMetric(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 			tracer := newTracer(withTransport(newDefaultTransport()))
+			defer tracer.Stop()
 			span := tracer.newRootSpan("http.request", "mux.router", "/")
 			tt(assert, span)
 		})
@@ -472,6 +478,7 @@ func TestSpanSetMetric(t *testing.T) {
 func TestSpanError(t *testing.T) {
 	assert := assert.New(t)
 	tracer := newTracer(withTransport(newDefaultTransport()))
+	defer tracer.Stop()
 	span := tracer.newRootSpan("pylons.request", "pylons", "/")
 
 	// check the error is set in the default meta
@@ -499,6 +506,7 @@ func TestSpanError(t *testing.T) {
 func TestSpanError_Typed(t *testing.T) {
 	assert := assert.New(t)
 	tracer := newTracer(withTransport(newDefaultTransport()))
+	defer tracer.Stop()
 	span := tracer.newRootSpan("pylons.request", "pylons", "/")
 
 	// check the error is set in the default meta
@@ -513,6 +521,7 @@ func TestSpanError_Typed(t *testing.T) {
 func TestSpanErrorNil(t *testing.T) {
 	assert := assert.New(t)
 	tracer := newTracer(withTransport(newDefaultTransport()))
+	defer tracer.Stop()
 	span := tracer.newRootSpan("pylons.request", "pylons", "/")
 
 	// don't set the error if it's nil
@@ -574,6 +583,7 @@ func TestSpanModifyWhileFlushing(t *testing.T) {
 func TestSpanSamplingPriority(t *testing.T) {
 	assert := assert.New(t)
 	tracer := newTracer(withTransport(newDefaultTransport()))
+	defer tracer.Stop()
 
 	span := tracer.newRootSpan("my.name", "my.service", "my.resource")
 	_, ok := span.Metrics[keySamplingPriority]

--- a/ddtrace/tracer/stats.go
+++ b/ddtrace/tracer/stats.go
@@ -54,11 +54,11 @@ type concentrator struct {
 	// stopped reports whether the concentrator is stopped (when non-zero)
 	stopped uint32
 
-	wg          sync.WaitGroup // waits for any active goroutines
-	bucketSize  int64          // the size of a bucket in nanoseconds
-	stop        chan struct{}  // closing this channel triggers shutdown
-	cfg         *config        // tracer startup configuration
-	statsClient statsdClient   // statsd client for sending stats.
+	wg           sync.WaitGroup // waits for any active goroutines
+	bucketSize   int64          // the size of a bucket in nanoseconds
+	stop         chan struct{}  // closing this channel triggers shutdown
+	cfg          *config        // tracer startup configuration
+	statsdClient statsdClient   // statsd client for sending metrics.
 }
 
 // newConcentrator creates a new concentrator using the given tracer
@@ -114,10 +114,10 @@ func (c *concentrator) runFlusher(tick <-chan time.Time) {
 
 // statsd returns any tracer configured statsd client, or a no-op.
 func (c *concentrator) statsd() statsdClient {
-	if c.statsClient == nil {
+	if c.statsdClient == nil {
 		return &statsd.NoOpClient{}
 	}
-	return c.statsClient
+	return c.statsdClient
 }
 
 // runIngester runs the loop which accepts incoming data on the concentrator's In

--- a/ddtrace/tracer/stats.go
+++ b/ddtrace/tracer/stats.go
@@ -54,10 +54,11 @@ type concentrator struct {
 	// stopped reports whether the concentrator is stopped (when non-zero)
 	stopped uint32
 
-	wg         sync.WaitGroup // waits for any active goroutines
-	bucketSize int64          // the size of a bucket in nanoseconds
-	stop       chan struct{}  // closing this channel triggers shutdown
-	cfg        *config        // tracer startup configuration
+	wg          sync.WaitGroup // waits for any active goroutines
+	bucketSize  int64          // the size of a bucket in nanoseconds
+	stop        chan struct{}  // closing this channel triggers shutdown
+	cfg         *config        // tracer startup configuration
+	statsClient statsdClient   // statsd client for sending stats.
 }
 
 // newConcentrator creates a new concentrator using the given tracer
@@ -113,10 +114,10 @@ func (c *concentrator) runFlusher(tick <-chan time.Time) {
 
 // statsd returns any tracer configured statsd client, or a no-op.
 func (c *concentrator) statsd() statsdClient {
-	if c.cfg.statsd == nil {
+	if c.statsClient == nil {
 		return &statsd.NoOpClient{}
 	}
-	return c.cfg.statsd
+	return c.statsClient
 }
 
 // runIngester runs the loop which accepts incoming data on the concentrator's In

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -88,6 +88,9 @@ type tracer struct {
 	// obfuscator holds the obfuscator used to obfuscate resources in aggregated stats.
 	// obfuscator may be nil if disabled.
 	obfuscator *obfuscate.Obfuscator
+
+	// statsd is used for tracking metrics associated with the runtime and the tracer.
+	statsd statsdClient
 }
 
 const (
@@ -231,10 +234,20 @@ func newUnstartedTracer(opts ...StartOption) *tracer {
 	return t
 }
 
+func (t *tracer) startStatsd() {
+	statsd, err := newStatsdClient(t.config)
+	if err != nil {
+		log.Warn("Runtime and health metrics disabled: %v", err)
+	}
+	t.statsd = statsd
+	t.traceWriter.sendStats(t.statsd)
+}
+
 func newTracer(opts ...StartOption) *tracer {
 	t := newUnstartedTracer(opts...)
 	c := t.config
-	t.config.statsd.Incr("datadog.tracer.started", nil, 1)
+	t.startStatsd()
+	t.statsd.Incr("datadog.tracer.started", nil, 1)
 	if c.runtimeMetrics {
 		log.Debug("Runtime metrics enabled.")
 		t.wg.Add(1)
@@ -297,11 +310,11 @@ func (t *tracer) worker(tick <-chan time.Time) {
 				t.traceWriter.add(trace.spans)
 			}
 		case <-tick:
-			t.config.statsd.Incr("datadog.tracer.flush_triggered", []string{"reason:scheduled"}, 1)
+			t.statsd.Incr("datadog.tracer.flush_triggered", []string{"reason:scheduled"}, 1)
 			t.traceWriter.flush()
 
 		case done := <-t.flush:
-			t.config.statsd.Incr("datadog.tracer.flush_triggered", []string{"reason:invoked"}, 1)
+			t.statsd.Incr("datadog.tracer.flush_triggered", []string{"reason:invoked"}, 1)
 			t.traceWriter.flush()
 			// TODO(x): In reality, the traceWriter.flush() call is not synchronous
 			// when using the agent traceWriter. However, this functionnality is used
@@ -547,12 +560,12 @@ func spanResourcePIISafe(s *span) bool {
 func (t *tracer) Stop() {
 	t.stopOnce.Do(func() {
 		close(t.stop)
-		t.config.statsd.Incr("datadog.tracer.stopped", nil, 1)
+		t.statsd.Incr("datadog.tracer.stopped", nil, 1)
 	})
 	t.stats.Stop()
 	t.wg.Wait()
 	t.traceWriter.stop()
-	t.config.statsd.Close()
+	t.statsd.Close()
 	appsec.Stop()
 }
 

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1427,7 +1427,6 @@ func TestPushTrace(t *testing.T) {
 	tp := new(testLogger)
 	log.UseLogger(tp)
 	tracer := newUnstartedTracer()
-	tracer.startStatsd()
 	defer tracer.statsd.Close()
 	trace := []*span{
 		&span{
@@ -1912,8 +1911,6 @@ func (w *testTraceWriter) reset() {
 	w.buf = w.buf[:0]
 	w.mu.Unlock()
 }
-
-func (w *testTraceWriter) sendStats(statsd statsdClient) {}
 
 // Buffered returns the spans buffered by the writer.
 func (w *testTraceWriter) Buffered() []*span {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1427,6 +1427,8 @@ func TestPushTrace(t *testing.T) {
 	tp := new(testLogger)
 	log.UseLogger(tp)
 	tracer := newUnstartedTracer()
+	tracer.startStatsd()
+	defer tracer.statsd.Close()
 	trace := []*span{
 		&span{
 			Name:     "pylons.request",
@@ -1910,6 +1912,8 @@ func (w *testTraceWriter) reset() {
 	w.buf = w.buf[:0]
 	w.mu.Unlock()
 }
+
+func (w *testTraceWriter) sendStats(statsd statsdClient) {}
 
 // Buffered returns the spans buffered by the writer.
 func (w *testTraceWriter) Buffered() []*span {

--- a/ddtrace/tracer/transport.go
+++ b/ddtrace/tracer/transport.go
@@ -152,7 +152,7 @@ func (t *httpTransport) send(p *payload) (body io.ReadCloser, err error) {
 		droppedTraces := int(atomic.SwapUint32(&t.droppedP0Traces, 0))
 		partialTraces := int(atomic.SwapUint32(&t.partialTraces, 0))
 		droppedSpans := int(atomic.SwapUint32(&t.droppedP0Spans, 0))
-		if stats := t.config.statsd; stats != nil {
+		if stats := t.statsd; stats != nil {
 			stats.Count("datadog.tracer.dropped_p0_traces", int64(droppedTraces),
 				[]string{fmt.Sprintf("partial:%s", strconv.FormatBool(partialTraces > 0))}, 1)
 			stats.Count("datadog.tracer.dropped_p0_spans", int64(droppedSpans), nil, 1)

--- a/ddtrace/tracer/writer.go
+++ b/ddtrace/tracer/writer.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 )
 

--- a/ddtrace/tracer/writer.go
+++ b/ddtrace/tracer/writer.go
@@ -114,8 +114,8 @@ func (h *agentTraceWriter) flush() {
 	}(oldp)
 }
 
-func (a *agentTraceWriter) sendStats(statsd statsdClient) {
-	a.statsd = statsd
+func (h *agentTraceWriter) sendStats(statsd statsdClient) {
+	h.statsd = statsd
 }
 
 // logWriter specifies the output target of the logTraceWriter; replaced in tests.

--- a/ddtrace/tracer/writer_test.go
+++ b/ddtrace/tracer/writer_test.go
@@ -230,6 +230,7 @@ func TestLogWriterOverflow(t *testing.T) {
 		var buf bytes.Buffer
 		var tg testStatsdClient
 		h := newLogTraceWriter(newConfig(withStatsdClient(&tg)))
+		h.sendStats(&tg)
 		h.w = &buf
 		s := makeSpan(10000)
 		h.add([]*span{s})


### PR DESCRIPTION
Tests have been failing to clean up after themselves and causing memory usage issues during unit test runs.

One cause of this is failing to shut down a tracer after starting it, which is solved simply by defering tracer.Close() for those tests.

Other tests use newConfig() to generate a tracer config, which they use for various purposes. Unfortunately newConfig() actually creates a statsd client for the new config, which needs to be Close()'d in order to release its resources. It doesn't make much sense to need to Close() a config, or have to Close() something *in* a config, so this problem requires a more complicated solution. Instead, the config still calculates the statsd address, but the actual instantiation of the statsd client is moved into newTracer, where the worker routines and other things that require cleanup are started.

This unfortunately requires several other pieces of code to keep a new reference to the statsd client, rather than just to the config as they did previously.

This brings peak memory usage on my system down from 10GiB to 3GiB. It also appears to cut the CI time for core tests down from 3 min to 2 mins. 


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### Describe how to test/QA your changes

We want to make sure:
1. Traces can still make it to the agent and to the backend.
    1. Send some traces with a few spans to an agent and check in the UI that they show up correctly
2. Metrics still make it to the backend
    1. Enable runtime metrics in a traced application and ensure metrics are still appearing in the UI.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.