### PR TITLE
ddtrace/tracer/textmap: Add support for b3 single header propagation

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -509,7 +509,8 @@ func (*propagatorB3) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 type propagatorB3SingleHeader struct{}
 
 func (p *propagatorB3SingleHeader) Inject(spanCtx ddtrace.SpanContext, carrier interface{}) error {
-	panic("NO IMPL")
+	return nil
+	// TODO IMPL ME
 }
 
 func (*propagatorB3SingleHeader) injectTextMap(spanCtx ddtrace.SpanContext, writer TextMapWriter) error {

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -560,23 +560,20 @@ func (*propagatorB3SingleHeader) extractTextMap(reader TextMapReader) (ddtrace.S
 				if err != nil {
 					return ErrSpanContextCorrupted
 				}
-
 				ctx.spanID, err = strconv.ParseUint(b3Parts[1], 16, 64)
 				if err != nil {
 					return ErrSpanContextCorrupted
 				}
 				if len(b3Parts) >= 3 {
-					if b3Parts[2] != "" {
-						switch b3Parts[2] {
-						case "1":
-							ctx.setSamplingPriority(1, samplernames.Unknown)
-						case "0":
-							ctx.setSamplingPriority(0, samplernames.Unknown)
-						case "d": // Treat 'debug' traces as priority 1
-							ctx.setSamplingPriority(1, samplernames.Unknown)
-						default:
-							return ErrSpanContextCorrupted
-						}
+					switch b3Parts[2] {
+					case "":
+						break
+					case "1", "d": // Treat 'debug' traces as priority 1
+						ctx.setSamplingPriority(1, samplernames.Unknown)
+					case "0":
+						ctx.setSamplingPriority(0, samplernames.Unknown)
+					default:
+						return ErrSpanContextCorrupted
 					}
 				}
 			} else {

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -821,7 +821,7 @@ func TestEnvVars(t *testing.T) {
 			var tests = []struct {
 				in              TextMapCarrier
 				traceID         uint64
-				fullTraceId     string
+				fullTraceID     string
 				spanID          uint64
 				priority        int
 				origin          string
@@ -832,7 +832,7 @@ func TestEnvVars(t *testing.T) {
 						traceparentHeader: "00-00000000000000001111111111111111-2222222222222222-01",
 						tracestateHeader:  "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64~~,othervendor=t61rcWkgMzE",
 					},
-					fullTraceId: "00000000000000001111111111111111",
+					fullTraceID: "00000000000000001111111111111111",
 					traceID:     1229782938247303441,
 					spanID:      2459565876494606882,
 					priority:    2,
@@ -849,7 +849,7 @@ func TestEnvVars(t *testing.T) {
 						traceparentHeader: "00-10000000000000000000000000000000-2222222222222222-01",
 						tracestateHeader:  "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64~~,othervendor=t61rcWkgMzE",
 					},
-					fullTraceId: "10000000000000000000000000000000",
+					fullTraceID: "10000000000000000000000000000000",
 					traceID:     0x0,
 					spanID:      2459565876494606882,
 					priority:    2,
@@ -866,7 +866,7 @@ func TestEnvVars(t *testing.T) {
 						traceparentHeader: "00-00000000000000001111111111111111-2222222222222222-03",
 						tracestateHeader:  "dd=s:0;o:rum;t.dm:-2;t.usr.id:baz64~~,othervendor=t61rcWkgMzE",
 					},
-					fullTraceId: "00000000000000001111111111111111",
+					fullTraceID: "00000000000000001111111111111111",
 					traceID:     1229782938247303441,
 					spanID:      2459565876494606882,
 					priority:    1,
@@ -882,7 +882,7 @@ func TestEnvVars(t *testing.T) {
 						traceparentHeader: "00-00000000000000001111111111111111-2222222222222222-01",
 						tracestateHeader:  "dd=s:2;o:rum:rum;t.dm:-4;t.usr.id:baz64~~,othervendor=t61rcWkgMzE",
 					},
-					fullTraceId: "00000000000000001111111111111111",
+					fullTraceID: "00000000000000001111111111111111",
 					traceID:     1229782938247303441,
 					spanID:      2459565876494606882,
 					priority:    2, // tracestate priority takes precedence
@@ -899,7 +899,7 @@ func TestEnvVars(t *testing.T) {
 						traceparentHeader: "00-00000000000000001111111111111111-2222222222222222-01",
 						tracestateHeader:  "dd=s:;o:rum:rum;t.dm:-4;t.usr.id:baz64~~,othervendor=t61rcWkgMzE",
 					},
-					fullTraceId: "00000000000000001111111111111111",
+					fullTraceID: "00000000000000001111111111111111",
 					traceID:     1229782938247303441,
 					spanID:      2459565876494606882,
 					priority:    1, // traceparent priority takes precedence
@@ -916,7 +916,7 @@ func TestEnvVars(t *testing.T) {
 						traceparentHeader: " \t-00-00000000000000001111111111111111-2222222222222222-01 \t-",
 						tracestateHeader:  "othervendor=t61rcWkgMzE,dd=o:rum:rum;s:;t.dm:-4;t.usr.id:baz64~~",
 					},
-					fullTraceId: "00000000000000001111111111111111",
+					fullTraceID: "00000000000000001111111111111111",
 					traceID:     1229782938247303441,
 					spanID:      2459565876494606882,
 					priority:    1, // traceparent priority takes precedence
@@ -933,7 +933,7 @@ func TestEnvVars(t *testing.T) {
 						traceparentHeader: "00-00000000000000001111111111111111-2222222222222222-01",
 						tracestateHeader:  "othervendor=t61rcWkgMzE,dd=o:2;s:fake_origin;t.dm:-4;t.usr.id:baz64~~,",
 					},
-					fullTraceId: "00000000000000001111111111111111",
+					fullTraceID: "00000000000000001111111111111111",
 					traceID:     1229782938247303441,
 					spanID:      2459565876494606882,
 					priority:    1,
@@ -965,7 +965,7 @@ func TestEnvVars(t *testing.T) {
 					assert.True(ok)
 					assert.Equal(test.priority, p)
 
-					assert.Equal(test.fullTraceId, sctx.trace.propagatingTags[w3cTraceIDTag])
+					assert.Equal(test.fullTraceID, sctx.trace.propagatingTags[w3cTraceIDTag])
 					assert.Equal(test.propagatingTags, sctx.trace.propagatingTags)
 				})
 			}


### PR DESCRIPTION
### What does this PR do?
This PR adds support for B3 Single header propagation via the `b3` header.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The multi-header approach is considered "old". The new single header is more compact which can free up additional headers in environments where the total number of headers is restricted.

### Describe how to test/QA your changes
The Unit tests here are pretty thorough. If desired, a test with two apps both using only `b3` to propagate trace info and verifying those traces appear in the datadog UI can be done.
There are also system tests however, they are currently broken due to a possible bug that is being resolved here: https://github.com/DataDog/system-tests/pull/753
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.