### PR TITLE
ddtrace/tracer: use the configured HTTP client during startup logging

### DIFF
--- a/ddtrace/tracer/log.go
+++ b/ddtrace/tracer/log.go
@@ -56,14 +56,14 @@ type startupInfo struct {
 // checkEndpoint tries to connect to the URL specified by endpoint.
 // If the endpoint is not reachable, checkEndpoint returns an error
 // explaining why.
-func checkEndpoint(endpoint string) error {
+func checkEndpoint(client *http.Client, endpoint string) error {
 	req, err := http.NewRequest("POST", endpoint, bytes.NewReader([]byte{0x90}))
 	if err != nil {
 		return fmt.Errorf("cannot create http request: %v", err)
 	}
 	req.Header.Set(traceCountHeader, "0")
 	req.Header.Set("Content-Type", "application/msgpack")
-	_, err = defaultClient.Do(req)
+	_, err = client.Do(req)
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ func logStartup(t *tracer) {
 		info.SampleRateLimit = fmt.Sprintf("%v", limit)
 	}
 	if !t.config.logToStdout {
-		if err := checkEndpoint(t.config.transport.endpoint()); err != nil {
+		if err := checkEndpoint(t.config.httpClient, t.config.transport.endpoint()); err != nil {
 			info.AgentError = fmt.Sprintf("%s", err)
 			log.Warn("DIAGNOSTICS Unable to reach agent intake: %s", err)
 		}


### PR DESCRIPTION
### What does this PR do?

During startup logging, the tracer attempts to connect to the trace
agent. However, this is done using the default client and not the one
the user may have configured. This leads to a spurious diagnostic error
when the user connects to the agent over UDS. This PR connects using
the configured client, and adds a test to connect to an "agent" over UDS
during the startup log.

For #1621

### Motivation

Reduce confusion.

### Describe how to test/QA your changes

This PR has a a unit test.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.
