### PR TITLE
profiler: support periodic execution trace collection

### DIFF
--- a/internal/env.go
+++ b/internal/env.go
@@ -8,6 +8,7 @@ package internal
 import (
 	"os"
 	"strconv"
+	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 )
@@ -37,6 +38,21 @@ func IntEnv(key string, def int) int {
 	v, err := strconv.Atoi(vv)
 	if err != nil {
 		log.Warn("Non-integer value for env var %s, defaulting to %d. Parse failed with error: %v", key, def, err)
+		return def
+	}
+	return v
+}
+
+// DurationEnv returns the parsed duration value of an environment variable, or
+// def otherwise.
+func DurationEnv(key string, def time.Duration) time.Duration {
+	vv, ok := os.LookupEnv(key)
+	if !ok {
+		return def
+	}
+	v, err := time.ParseDuration(vv)
+	if err != nil {
+		log.Warn("Non-duration value for env var %s, defaulting to %d. Parse failed with error: %v", key, def, err)
 		return def
 	}
 	return v

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -297,9 +297,9 @@ func defaultConfig() (*config, error) {
 
 	// Experimental feature: Go execution trace (runtime/trace) recording.
 	c.traceEnabled = internal.BoolEnv("DD_PROFILING_EXECUTION_TRACE_ENABLED", false)
-	c.traceConfig.Frequency = internal.DurationEnv("DD_PROFILING_EXECUTION_TRACE_FREQUENCY", 5000*time.Second)
+	c.traceConfig.Period = internal.DurationEnv("DD_PROFILING_EXECUTION_TRACE_PERIOD", 5000*time.Second)
 	c.traceConfig.Duration = internal.DurationEnv("DD_PROFILING_EXECUTION_TRACE_DURATION", 1*time.Second)
-	if c.traceEnabled && (c.traceConfig.Frequency == 0 || c.traceConfig.Duration == 0) {
+	if c.traceEnabled && (c.traceConfig.Period == 0 || c.traceConfig.Duration == 0) {
 		log.Warn("Invalid execution trace config, enabled is true but duration or frequency is 0. Disabling execution trace.")
 		c.traceEnabled = false
 	}
@@ -532,6 +532,6 @@ func WithHostname(hostname string) Option {
 type executionTraceConfig struct {
 	// Duration is how long the execution trace will run.
 	Duration time.Duration
-	// Frequency is the amount of time between traces.
-	Frequency time.Duration
+	// Period is the amount of time between traces.
+	Period time.Duration
 }

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -189,9 +189,6 @@ var profileTypes = map[ProfileType]profileType{
 				return nil, errors.New("started tracing erroneously, indicating a bug in the profiler")
 			}
 			defer func() {
-				// TODO: this updates the last trace time
-				// regardless of whether tracing suceeds or not.
-				// Should we only update it if tracing succeeds?
 				p.lastTrace = time.Now()
 			}()
 			buf := new(bytes.Buffer)

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -183,10 +183,10 @@ var profileTypes = map[ProfileType]profileType{
 	},
 	executionTrace: {
 		Name:     "execution-trace",
-		Filename: "trace.gotrace", // TODO: pick a good name
+		Filename: "go.trace",
 		Collect: func(p *profiler) ([]byte, error) {
 			if !p.shouldTrace() {
-				return nil, errors.New("execution trace collection is disabled")
+				return nil, errors.New("started tracing erroneously. This is a bug, please report it!")
 			}
 			defer func() {
 				// TODO: this updates the last trace time
@@ -198,6 +198,9 @@ var profileTypes = map[ProfileType]profileType{
 			if err := trace.Start(buf); err != nil {
 				return nil, err
 			}
+			// TODO: randomize where we collect within the current
+			// profile collection cycle, so we're not biased toward
+			// stuff that happens at the start of the cycle.
 			p.interruptibleSleep(p.cfg.traceConfig.Duration)
 			trace.Stop()
 			return buf.Bytes(), nil

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -186,7 +186,7 @@ var profileTypes = map[ProfileType]profileType{
 		Filename: "go.trace",
 		Collect: func(p *profiler) ([]byte, error) {
 			if !p.shouldTrace() {
-				return nil, errors.New("started tracing erroneously. This is a bug, please report it!")
+				return nil, errors.New("started tracing erroneously, indicating a bug in the profiler")
 			}
 			defer func() {
 				// TODO: this updates the last trace time

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+	"runtime/trace"
 	"time"
 
 	"github.com/DataDog/gostackparse"
@@ -50,6 +51,11 @@ const (
 	expGoroutineWaitProfile
 	// MetricsProfile reports top-line metrics associated with user-specified profiles
 	MetricsProfile
+
+	// executionTrace is the runtime/trace execution tracer.
+	// This is private, as this trace requires special explicit configuration and
+	// shouldn't just be added to WithProfileTypes
+	executionTrace
 )
 
 // profileType holds the implementation details of a ProfileType.
@@ -175,6 +181,28 @@ var profileTypes = map[ProfileType]profileType{
 			return buf.Bytes(), err
 		},
 	},
+	executionTrace: {
+		Name:     "execution-trace",
+		Filename: "trace.gotrace", // TODO: pick a good name
+		Collect: func(p *profiler) ([]byte, error) {
+			if !p.shouldTrace() {
+				return nil, errors.New("execution trace collection is disabled")
+			}
+			defer func() {
+				// TODO: this updates the last trace time
+				// regardless of whether tracing suceeds or not.
+				// Should we only update it if tracing succeeds?
+				p.lastTrace = time.Now()
+			}()
+			buf := new(bytes.Buffer)
+			if err := trace.Start(buf); err != nil {
+				return nil, err
+			}
+			p.interruptibleSleep(p.cfg.traceConfig.Duration)
+			trace.Stop()
+			return buf.Bytes(), nil
+		},
+	},
 }
 
 func collectGenericProfile(name string, pt ProfileType) func(p *profiler) ([]byte, error) {
@@ -236,6 +264,7 @@ func (t ProfileType) Tag() string {
 type profile struct {
 	// name indicates profile type and format (e.g. cpu.pprof, metrics.json)
 	name string
+	pt   ProfileType
 	data []byte
 }
 
@@ -267,7 +296,7 @@ func (p *profiler) runProfile(pt ProfileType) ([]*profile, error) {
 		filename = "delta-" + filename
 	}
 	p.cfg.statsd.Timing("datadog.profiling.go.collect_time", end.Sub(start), tags, 1)
-	return []*profile{{name: filename, data: data}}, nil
+	return []*profile{{name: filename, pt: pt, data: data}}, nil
 }
 
 type deltaProfiler interface {

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -81,7 +81,7 @@ type profiler struct {
 }
 
 func (p *profiler) shouldTrace() bool {
-	return p.cfg.traceEnabled && time.Since(p.lastTrace) > p.cfg.traceConfig.Frequency
+	return p.cfg.traceEnabled && time.Since(p.lastTrace) > p.cfg.traceConfig.Period
 }
 
 // testHooks are functions that are replaced during testing which would normally

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -75,6 +75,13 @@ type profiler struct {
 	pendingProfiles sync.WaitGroup // signal that profile collection is done, for stopping CPU profiling
 
 	testHooks testHooks
+
+	// lastTrace is the last time an execution trace was collected
+	lastTrace time.Time
+}
+
+func (p *profiler) shouldTrace() bool {
+	return p.cfg.traceEnabled && time.Since(p.lastTrace) > p.cfg.traceConfig.Frequency
 }
 
 // testHooks are functions that are replaced during testing which would normally
@@ -315,12 +322,16 @@ func (p *profiler) collect(ticker <-chan time.Time) {
 		// finished (because p.pendingProfiles will have been
 		// incremented to count every non-CPU profile before CPU
 		// profiling starts)
-		for _, t := range p.enabledProfileTypes() {
+		profileTypes := p.enabledProfileTypes()
+		if p.shouldTrace() {
+			profileTypes = append(profileTypes, executionTrace)
+		}
+		for _, t := range profileTypes {
 			if t != CPUProfile {
 				p.pendingProfiles.Add(1)
 			}
 		}
-		for _, t := range p.enabledProfileTypes() {
+		for _, t := range profileTypes {
 			wg.Add(1)
 			go func(t ProfileType) {
 				defer wg.Done()
@@ -365,6 +376,7 @@ func (p *profiler) enabledProfileTypes() []ProfileType {
 		GoroutineProfile,
 		expGoroutineWaitProfile,
 		MetricsProfile,
+		executionTrace,
 	}
 	enabled := []ProfileType{}
 	for _, t := range order {

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -528,7 +528,7 @@ func TestExecutionTrace(t *testing.T) {
 	defer server.Close()
 
 	t.Setenv("DD_PROFILING_EXECUTION_TRACE_ENABLED", "true")
-	t.Setenv("DD_PROFILING_EXECUTION_TRACE_FREQUENCY", "3s")
+	t.Setenv("DD_PROFILING_EXECUTION_TRACE_PERIOD", "3s")
 	t.Setenv("DD_PROFILING_EXECUTION_TRACE_DURATION", "50ms")
 	err := Start(
 		WithAgentAddr(server.Listener.Addr().String()),
@@ -550,7 +550,7 @@ func TestExecutionTrace(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		m := <-got
 		t.Log(m.event.Attachments, m.tags)
-		if contains(m.event.Attachments, "trace.gotrace") && contains(m.tags, "profile_has_go_execution_trace:yes") {
+		if contains(m.event.Attachments, "go.trace") && contains(m.tags, "profile_has_go_execution_trace:yes") {
 			seenTraces++
 		}
 	}

--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -84,6 +84,13 @@ func (p *profiler) doRequest(bat batch) error {
 	if p.cfg.env != "" {
 		tags = append(tags, fmt.Sprintf("env:%s", p.cfg.env))
 	}
+	// If the profile batch includes a runtime execution trace, add a tag so
+	// that the uploads are more easily discoverable in the UI.
+	for _, b := range bat.profiles {
+		if b.pt == executionTrace {
+			tags = append(tags, "profile_has_go_execution_trace:yes")
+		}
+	}
 	contentType, body, err := encode(bat, tags)
 	if err != nil {
 		return err


### PR DESCRIPTION
### What does this PR do?

Add support for periodically collection runtime execution traces through runtime/trace. To manage the overhead, traces are collected for short durations and with lots of time between collections.

Collection is enabled by setting the `DD_PROFILING_EXECUTION_TRACE_ENABLED` environment variable to "true". By default, a 1-second trace will be collected roughly every 5000 seconds. The collection duration and period can be configured with the `DD_PROFILING_EXECUTION_TRACE_DURATION` and `DD_PROFILING_EXECUTION_TRACE_PERIOD` environment variables, respectively.

### Motivation

The execution tracer is an incredibly rich data source for understanding latency in Go programs.

### Describe how to test/QA your changes

This PR includes a small unit test, but we'll also want to try it out in our internal reliability environment.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.
