### PR TITLE
internal/version: bump to v1.47.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -13,7 +13,7 @@ import (
 // Tag specifies the current release tag. It needs to be manually
 // updated. A test checks that the value of Tag never points to a
 // git tag that is older than HEAD.
-const Tag = "v1.46.0"
+const Tag = "v1.47.0"
 
 // Dissected version number. Filled during init()
 var (


### PR DESCRIPTION
Bump the version constant to 1.47.0, following the 1.46.0 release.
