### PR TITLE
CODEOWNERS: give internal/ default ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,6 @@
 # tracing
 /contrib                        @DataDog/tracing-go
 /ddtrace                        @DataDog/tracing-go
-/internal                       @DataDog/tracing-go
 
 # profiling
 /profiler                       @DataDog/profiling-go


### PR DESCRIPTION
### What does this PR do?

Changes CODEOWNERS so that `internal/` gets the default ownership.

### Motivation

The stuff in `internal/` is shared across the different products, so `apm-go` seems like the appropriate ownership rather than just `tracing-go`.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Changed code has unit tests for its functionality.
- [x] If this interacts with the agent in a new way, a system test has been added.
