### PR TITLE
profiler: enable fastdelta by default

### DIFF
--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -327,8 +327,6 @@ func newDeltaProfiler(cfg *config, v ...pprofutils.ValueType) deltaProfiler {
 			cfg,
 			&pprofileDeltaProfiler{delta: pprofutils.Delta{SampleTypes: v}},
 			newFastDeltaProfiler(v...))
-	case "fastdelta":
-		fallthrough
 	default:
 		return newFastDeltaProfiler(v...)
 	}

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -321,7 +321,7 @@ func newDeltaProfiler(cfg *config, v ...pprofutils.ValueType) deltaProfiler {
 	switch cfg.deltaMethod {
 	// TODO: slowdelta and comparing implementation can be removed after 2022-04-11.
 	case "slowdelta":
-		return newFastDeltaProfiler(v...)
+		return &pprofileDeltaProfiler{delta: pprofutils.Delta{SampleTypes: v}}
 	case "comparing":
 		return newComparingDeltaProfiler(
 			cfg,
@@ -330,7 +330,7 @@ func newDeltaProfiler(cfg *config, v ...pprofutils.ValueType) deltaProfiler {
 	case "fastdelta":
 		fallthrough
 	default:
-		return &pprofileDeltaProfiler{delta: pprofutils.Delta{SampleTypes: v}}
+		return newFastDeltaProfiler(v...)
 	}
 }
 

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -319,7 +319,7 @@ type pprofileDeltaProfiler struct {
 // Otherwise, deltas will be computed for every value.
 func newDeltaProfiler(cfg *config, v ...pprofutils.ValueType) deltaProfiler {
 	switch cfg.deltaMethod {
-	// TODO: slowdelta and comparing implementation can be removed after 2022-04-11.
+	// TODO: slowdelta and comparing implementation can be removed after 2023-04-11.
 	case "slowdelta":
 		return &pprofileDeltaProfiler{delta: pprofutils.Delta{SampleTypes: v}}
 	case "comparing":

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -319,13 +319,16 @@ type pprofileDeltaProfiler struct {
 // Otherwise, deltas will be computed for every value.
 func newDeltaProfiler(cfg *config, v ...pprofutils.ValueType) deltaProfiler {
 	switch cfg.deltaMethod {
-	case "fastdelta":
+	// TODO: slowdelta and comparing implementation can be removed after 2022-04-11.
+	case "slowdelta":
 		return newFastDeltaProfiler(v...)
 	case "comparing":
 		return newComparingDeltaProfiler(
 			cfg,
 			&pprofileDeltaProfiler{delta: pprofutils.Delta{SampleTypes: v}},
 			newFastDeltaProfiler(v...))
+	case "fastdelta":
+		fallthrough
 	default:
 		return &pprofileDeltaProfiler{delta: pprofutils.Delta{SampleTypes: v}}
 	}

--- a/profiler/profile_test.go
+++ b/profiler/profile_test.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -25,11 +24,9 @@ import (
 // This test should be removed When the DD_PROFILING_DELTA_METHOD env var is removed
 // This is to exercise delta profiles using the alternate delta computation methods
 func TestRunDeltaProfileAlternateImpls(t *testing.T) {
-	old := os.Getenv("DD_PROFILING_DELTA_METHOD")
-	defer os.Setenv("DD_PROFILING_DELTA_METHOD", old)
-	for _, deltaMethod := range []string{"fastdelta", "comparing"} {
+	for _, deltaMethod := range []string{"slowdelta", "comparing"} {
 		// nb: we are not running under t.Parallel(); this would yield inconsistent results otherwise
-		os.Setenv("DD_PROFILING_DELTA_METHOD", deltaMethod)
+		t.Setenv("DD_PROFILING_DELTA_METHOD", deltaMethod)
 		t.Run(deltaMethod, func(t *testing.T) {
 			testRunDeltaProfile(t)
 		})


### PR DESCRIPTION
This should significantly reduce the profiler overhead when memory profiling is enabled.

If needed, the previous implementation is still available behind an environment variable:

  DD_PROFILING_DELTA_METHOD=slowdelta

This option will be removed in a future release.