### PR TITLE
profiler: return copy of delta profile data to avoid race

### DIFF
--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -57,6 +57,11 @@ func (p *profiler) upload(bat batch) error {
 			}
 			statsd.Count("datadog.profiling.go.uploaded_profile_bytes", b, nil, 1)
 		}
+		// If the error isn't retriable, we're done with the byte buffers and
+		// they can be reused.
+		for _, p := range bat.profiles {
+			bufPool.Put(p.data[:0])
+		}
 		return err
 	}
 	return fmt.Errorf("failed after %d retries, last error was: %v", maxRetries, err)

--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -57,11 +57,6 @@ func (p *profiler) upload(bat batch) error {
 			}
 			statsd.Count("datadog.profiling.go.uploaded_profile_bytes", b, nil, 1)
 		}
-		// If the error isn't retriable, we're done with the byte buffers and
-		// they can be reused.
-		for _, p := range bat.profiles {
-			bufPool.Put(p.data[:0])
-		}
 		return err
 	}
 	return fmt.Errorf("failed after %d retries, last error was: %v", maxRetries, err)


### PR DESCRIPTION
### What does this PR do?

Returns a copy of the fast delta profile bytes.

### Motivation

To fix a data race. The fast delta profiler re-uses
a bytes.Buffer for each profile computation. The underlying byte slice
from that buffer is passed on to be uploaded. This is flagged as a race
by the race detector. While delta profile computation and uploading
_shouldn't_ generally happen at the same time, this is still a logical
race. It could be a real problem if the upload fails a bunch, causing the
buffer to be corrupted when delta computation and uploading overlap.

The simplest fix for this race is to just allocate a new bytes.Buffer
for each delta computation.

### Describe how to test/QA your changes

This passes all the existing unit tests under the race detector, including the
ones which failed previously.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Changed code has unit tests for its functionality.
- [x] If this interacts with the agent in a new way, a system test has been added.
