### PR TITLE
tracer: enable stats flushing when Flush() is called

### DIFF
--- a/ddtrace/tracer/metrics.go
+++ b/ddtrace/tracer/metrics.go
@@ -23,6 +23,7 @@ type statsdClient interface {
 	Count(name string, value int64, tags []string, rate float64) error
 	Gauge(name string, value float64, tags []string, rate float64) error
 	Timing(name string, value time.Duration, tags []string, rate float64) error
+	Flush() error
 	Close() error
 }
 

--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -35,6 +35,7 @@ type testStatsdClient struct {
 	waitCh      chan struct{}
 	n           int
 	closed      bool
+	flushed     int
 }
 
 type testStatsdCall struct {
@@ -123,6 +124,9 @@ func (tg *testStatsdClient) addMetric(ct callType, tags []string, c testStatsdCa
 }
 
 func (tg *testStatsdClient) Flush() error {
+	tg.mu.Lock()
+	defer tg.mu.Unlock()
+	tg.flushed += 1
 	return nil
 }
 

--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -122,6 +122,10 @@ func (tg *testStatsdClient) addMetric(ct callType, tags []string, c testStatsdCa
 	return nil
 }
 
+func (tg *testStatsdClient) Flush() error {
+	return nil
+}
+
 func (tg *testStatsdClient) Close() error {
 	tg.closed = true
 	return nil

--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -126,7 +126,7 @@ func (tg *testStatsdClient) addMetric(ct callType, tags []string, c testStatsdCa
 func (tg *testStatsdClient) Flush() error {
 	tg.mu.Lock()
 	defer tg.mu.Unlock()
-	tg.flushed += 1
+	tg.flushed++
 	return nil
 }
 

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -312,7 +312,7 @@ func (t *tracer) worker(tick <-chan time.Time) {
 			t.statsd.Incr("datadog.tracer.flush_triggered", []string{"reason:invoked"}, 1)
 			t.traceWriter.flush()
 			t.statsd.Flush()
-			t.stats.flushAndSend(time.Now(), withoutCurrentBucket)
+			t.stats.flushAndSend(time.Now(), withCurrentBucket)
 			// TODO(x): In reality, the traceWriter.flush() call is not synchronous
 			// when using the agent traceWriter. However, this functionnality is used
 			// in Lambda so for that purpose this mechanism should suffice.

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -312,6 +312,7 @@ func (t *tracer) worker(tick <-chan time.Time) {
 			t.statsd.Incr("datadog.tracer.flush_triggered", []string{"reason:invoked"}, 1)
 			t.traceWriter.flush()
 			t.statsd.Flush()
+			t.stats.flushAndSend(time.Now(), withoutCurrentBucket)
 			// TODO(x): In reality, the traceWriter.flush() call is not synchronous
 			// when using the agent traceWriter. However, this functionnality is used
 			// in Lambda so for that purpose this mechanism should suffice.

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -311,6 +311,7 @@ func (t *tracer) worker(tick <-chan time.Time) {
 		case done := <-t.flush:
 			t.statsd.Incr("datadog.tracer.flush_triggered", []string{"reason:invoked"}, 1)
 			t.traceWriter.flush()
+			t.statsd.Flush()
 			// TODO(x): In reality, the traceWriter.flush() call is not synchronous
 			// when using the agent traceWriter. However, this functionnality is used
 			// in Lambda so for that purpose this mechanism should suffice.

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1976,7 +1976,7 @@ loop:
 	assert.Len(t, transport.Stats(), 0)
 	tr.flushSync()
 	assert.Len(t, tw.Flushed(), 1)
-	assert.Equal(t, ts.flushed, 1)
+	assert.Equal(t, 1, ts.flushed)
 	assert.Len(t, transport.Stats(), 1)
 }
 

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1966,7 +1966,7 @@ loop:
 			Name: "http.request",
 		},
 		// Start must be older than latest bucket to get flushed
-		Start:    time.Now().UnixNano() - 3*500000,
+		Start:    time.Now().UnixNano() - 3*defaultStatsBucketSize,
 		Duration: 1,
 	}
 	c.add(as)
@@ -1977,7 +1977,7 @@ loop:
 	tr.flushSync()
 	assert.Len(t, tw.Flushed(), 1)
 	assert.Equal(t, ts.flushed, 1)
-	assert.NotZero(t, transport.Stats())
+	assert.Len(t, transport.Stats(), 1)
 }
 
 func TestTakeStackTrace(t *testing.T) {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1934,6 +1934,8 @@ func TestFlush(t *testing.T) {
 	tr, _, _, stop := startTestTracer(t)
 	tw := newTestTraceWriter()
 	tr.traceWriter = tw
+	ts := &testStatsdClient{}
+	tr.statsd = ts
 	defer stop()
 	tr.StartSpan("op").Finish()
 	timeout := time.After(time.Second)
@@ -1951,8 +1953,10 @@ loop:
 		}
 	}
 	assert.Len(t, tw.Flushed(), 0)
+	assert.Equal(t, ts.flushed, 0)
 	tr.flushSync()
 	assert.Len(t, tw.Flushed(), 1)
+	assert.Equal(t, ts.flushed, 1)
 }
 
 func TestTakeStackTrace(t *testing.T) {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1941,7 +1941,7 @@ func TestFlush(t *testing.T) {
 	tr.statsd = ts
 
 	transport := newDummyTransport()
-	c := newConcentrator(&config{transport: transport}, 500000)
+	c := newConcentrator(&config{transport: transport}, defaultStatsBucketSize)
 	tr.stats = c
 	c.Start()
 	defer c.Stop()

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1972,7 +1972,7 @@ loop:
 	c.add(as)
 
 	assert.Len(t, tw.Flushed(), 0)
-	assert.Equal(t, ts.flushed, 0)
+	assert.Zero(t, ts.flushed)
 	assert.Len(t, transport.Stats(), 0)
 	tr.flushSync()
 	assert.Len(t, tw.Flushed(), 1)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Flush() flushed buffered traces, but it did not flush stats. We added flushing for both the stats concentrator and the statsdClient when Flush() is called.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

There were issues in parametric tests because Flush() did not flush stats. Fixes #1547 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.