### PR TITLE
ddtrace/tracer: 128-bit support

### DIFF
--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -20,6 +20,13 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 )
 
+type SpanContextW3C interface {
+	SpanContext
+
+	// TraceID128 returns the hex-encoded 128-bit trace ID that this context is carrying.
+	TraceID128() string
+}
+
 // Tracer specifies an implementation of the Datadog tracer which allows starting
 // and propagating spans. The official implementation if exposed as functions
 // within the "tracer" package.
@@ -124,9 +131,15 @@ type StartSpanConfig struct {
 	// new span.
 	Tags map[string]interface{}
 
-	// Force-set the SpanID, rather than use a random number. If no Parent SpanContext is present,
-	// then this will also set the TraceID to the same value.
+	// SpanID will be the SpanID of the Span, overriding the random number that would
+	// be generated. If no Parent SpanContext is present, then this will also set the
+	// TraceID to the same value.
 	SpanID uint64
+
+	// TraceIDHigh128 will be the TraceIDHigh128 of the Span (the higher-order 64 bits of
+	// a 128-bit trace id) if no Parent SpanContext is present, overring the random number
+	// that would be generated.
+	TraceIDHigh128 uint64
 
 	// Context is the parent context where the span should be stored.
 	Context context.Context

--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -136,10 +136,10 @@ type StartSpanConfig struct {
 	// TraceID to the same value.
 	SpanID uint64
 
-	// TraceIDHigh128 will be the TraceIDHigh128 of the Span (the higher-order 64 bits of
-	// a 128-bit trace id) if no Parent SpanContext is present, overring the random number
-	// that would be generated.
-	TraceIDHigh128 uint64
+	// TraceID128 will be the 128-bit trace id of the span if no Parent SpanContext is
+	// present, overriding the random number that would be generated, or any trace id
+	// that would be taken from a provided SpanID.
+	TraceID128 string
 
 	// Context is the parent context where the span should be stored.
 	Context context.Context

--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -26,6 +26,7 @@ type SpanContextW3C interface {
 	SpanContext
 
 	// TraceID128 returns the hex-encoded 128-bit trace ID that this context is carrying.
+	// The string will be exactly 32 bytes and may include leading zeroes.
 	TraceID128() string
 }
 

--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -136,10 +136,9 @@ type StartSpanConfig struct {
 	// TraceID to the same value.
 	SpanID uint64
 
-	// TraceID128 will be the 128-bit trace id of the span if no Parent SpanContext is
-	// present, overriding the random number that would be generated, or any trace id
-	// that would be taken from a provided SpanID.
-	TraceID128 string
+	// TraceID128High will be the upper 64 bits of a 128-bit trace id of the span if no
+	// Parent SpanContext is present, overriding the random number that would be generated.
+	TraceID128High uint64
 
 	// Context is the parent context where the span should be stored.
 	Context context.Context

--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -20,6 +20,8 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 )
 
+// SpanContextW3C represents a SpanContext with an additional method to allow
+// access of the 128-bit trace id of the span, if present.
 type SpanContextW3C interface {
 	SpanContext
 

--- a/ddtrace/example_test.go
+++ b/ddtrace/example_test.go
@@ -6,11 +6,13 @@
 package ddtrace_test
 
 import (
+	"fmt"
 	"log"
 	"os"
 
 	opentracing "github.com/opentracing/opentracing-go"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer"
@@ -32,6 +34,13 @@ func Example_datadog() {
 	// Create a child of it, computing the time needed to read a file.
 	child := tracer.StartSpan("read.file", tracer.ChildOf(span.Context()))
 	child.SetTag(ext.ResourceName, "test.json")
+
+	// If you are using 128 bit trace ids and want to generate the high
+	// order bits, cast the span's context to ddtrace.SpanContextW3C.
+	// See #XXXX (TODO: link to GH issue for v2 API change)
+	if w3Cctx, ok := child.Context().(ddtrace.SpanContextW3C); ok {
+		fmt.Printf("128 bit trace id = %s\n", w3Cctx.TraceID128())
+	}
 
 	// Perform an operation.
 	_, err := os.ReadFile("~/test.json")

--- a/ddtrace/example_test.go
+++ b/ddtrace/example_test.go
@@ -37,7 +37,7 @@ func Example_datadog() {
 
 	// If you are using 128 bit trace ids and want to generate the high
 	// order bits, cast the span's context to ddtrace.SpanContextW3C.
-	// See #XXXX (TODO: link to GH issue for v2 API change)
+	// See Issue #1677
 	if w3Cctx, ok := child.Context().(ddtrace.SpanContextW3C); ok {
 		fmt.Printf("128 bit trace id = %s\n", w3Cctx.TraceID128())
 	}

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -110,7 +110,7 @@ func TestStartSpanFromContextRace(t *testing.T) {
 	assert.ElementsMatch(t, outputs, expectedTraceIDs)
 }
 
-func Test128Bit(t *testing.T) {
+func Test128(t *testing.T) {
 	_, _, _, stop := startTestTracer(t)
 	defer stop()
 

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -123,7 +123,7 @@ func Test128(t *testing.T) {
 	}
 
 	// Enable 128 bit trace ids
-	t.Setenv("DD_TRACE_128_BIT_TRACEID_ENABLED", "true")
+	t.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "true")
 	span128, _ := StartSpanFromContext(context.Background(), "http.request")
 	assert.NotZero(t, span128.Context().TraceID())
 	if w3cCtx, ok := span128.Context().(ddtrace.SpanContextW3C); ok {

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -116,32 +116,32 @@ func Test128(t *testing.T) {
 
 	span, _ := StartSpanFromContext(context.Background(), "http.request")
 	assert.NotZero(t, span.Context().TraceID())
-	if w3cCtx, ok := span.Context().(ddtrace.SpanContextW3C); ok {
-		id128 := w3cCtx.TraceID128()
-		assert.Len(t, id128, 32) // ensure there are enough leading zeros
-		idBytes, err := hex.DecodeString(id128)
-		assert.NoError(t, err)
-		assert.Equal(t, uint64(0), binary.BigEndian.Uint64(idBytes[:8])) // high 64 bits should be 0
-		assert.Equal(t, span.Context().TraceID(), binary.BigEndian.Uint64(idBytes[8:]))
-	} else {
-		assert.Fail(t, "should be castable to SpanContextW3C")
+	w3cCtx, ok := span.Context().(ddtrace.SpanContextW3C)
+	if !ok {
+		assert.Fail(t, "couldn't cast to ddtrace.SpanContextW3C")
 	}
+	id128 := w3cCtx.TraceID128()
+	assert.Len(t, id128, 32) // ensure there are enough leading zeros
+	idBytes, err := hex.DecodeString(id128)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(0), binary.BigEndian.Uint64(idBytes[:8])) // high 64 bits should be 0
+	assert.Equal(t, span.Context().TraceID(), binary.BigEndian.Uint64(idBytes[8:]))
 
 	// Enable 128 bit trace ids
 	t.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "true")
 	span128, _ := StartSpanFromContext(context.Background(), "http.request")
 	assert.NotZero(t, span128.Context().TraceID())
-	if w3cCtx, ok := span128.Context().(ddtrace.SpanContextW3C); ok {
-		id128bit := w3cCtx.TraceID128()
-		assert.NotEmpty(t, id128bit)
-		assert.Len(t, id128bit, 32)
-		// Ensure that the lower order bits match the span's 64-bit trace id
-		b, err := hex.DecodeString(id128bit)
-		assert.NoError(t, err)
-		assert.Equal(t, span128.Context().TraceID(), binary.BigEndian.Uint64(b[8:]))
-	} else {
-		assert.Fail(t, "should be castable to SpanContextW3C")
+	w3cCtx, ok = span128.Context().(ddtrace.SpanContextW3C)
+	if !ok {
+		assert.Fail(t, "couldn't cast to ddtrace.SpanContextW3C")
 	}
+	id128bit := w3cCtx.TraceID128()
+	assert.NotEmpty(t, id128bit)
+	assert.Len(t, id128bit, 32)
+	// Ensure that the lower order bits match the span's 64-bit trace id
+	b, err := hex.DecodeString(id128bit)
+	assert.NoError(t, err)
+	assert.Equal(t, span128.Context().TraceID(), binary.BigEndian.Uint64(b[8:]))
 }
 
 func TestStartSpanFromNilContext(t *testing.T) {

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -813,6 +813,15 @@ func WithSpanID(id uint64) StartSpanOption {
 	}
 }
 
+// WithTraceIDHigh128 sets the TraceIDHigh128 (the higher-order 64 bits of
+// a 128-bit trace id) of the started span if no Parent SpanContext is present,
+// overriding the random number that would be generated.
+func WithTraceID128(id string) StartSpanOption {
+	return func(cfg *ddtrace.StartSpanConfig) {
+		cfg.TraceID128 = id
+	}
+}
+
 // ChildOf tells StartSpan to use the given span context as a parent for the
 // created span.
 func ChildOf(ctx ddtrace.SpanContext) StartSpanOption {

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -813,12 +813,12 @@ func WithSpanID(id uint64) StartSpanOption {
 	}
 }
 
-// WithTraceIDHigh128 sets the TraceIDHigh128 (the higher-order 64 bits of
-// a 128-bit trace id) of the started span if no Parent SpanContext is present,
+// WithTraceID128High sets the higher-order 64 bits of a 128-bit trace id
+// of the started span if no Parent SpanContext is present,
 // overriding the random number that would be generated.
-func WithTraceID128(id string) StartSpanOption {
+func WithTraceID128High(id uint64) StartSpanOption {
 	return func(cfg *ddtrace.StartSpanConfig) {
-		cfg.TraceID128 = id
+		cfg.TraceID128High = id
 	}
 }
 

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -655,6 +655,8 @@ const (
 	keySingleSpanSamplingMPS = "_dd.span_sampling.max_per_second"
 	// keyPropagatedUserID holds the propagated user identifier, if user id propagation is enabled.
 	keyPropagatedUserID = "_dd.p.usr.id"
+	// keyTraceId128 is the 128-bit trace id, if applicable.
+	keyTraceId128 = "_dd.p.tid"
 )
 
 // The following set of tags is used for user monitoring and set through calls to span.SetUser().

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -62,18 +62,19 @@ type errorConfig struct {
 type span struct {
 	sync.RWMutex `msg:"-"` // all fields are protected by this RWMutex
 
-	Name     string             `msg:"name"`              // operation name
-	Service  string             `msg:"service"`           // service name (i.e. "grpc.server", "http.request")
-	Resource string             `msg:"resource"`          // resource name (i.e. "/user?id=123", "SELECT * FROM users")
-	Type     string             `msg:"type"`              // protocol associated with the span (i.e. "web", "db", "cache")
-	Start    int64              `msg:"start"`             // span start time expressed in nanoseconds since epoch
-	Duration int64              `msg:"duration"`          // duration of the span expressed in nanoseconds
-	Meta     map[string]string  `msg:"meta,omitempty"`    // arbitrary map of metadata
-	Metrics  map[string]float64 `msg:"metrics,omitempty"` // arbitrary map of numeric metrics
-	SpanID   uint64             `msg:"span_id"`           // identifier of this span
-	TraceID  uint64             `msg:"trace_id"`          // identifier of the root span
-	ParentID uint64             `msg:"parent_id"`         // identifier of the span's direct parent
-	Error    int32              `msg:"error"`             // error status of the span; 0 means no errors
+	Name           string             `msg:"name"`              // operation name
+	Service        string             `msg:"service"`           // service name (i.e. "grpc.server", "http.request")
+	Resource       string             `msg:"resource"`          // resource name (i.e. "/user?id=123", "SELECT * FROM users")
+	Type           string             `msg:"type"`              // protocol associated with the span (i.e. "web", "db", "cache")
+	Start          int64              `msg:"start"`             // span start time expressed in nanoseconds since epoch
+	Duration       int64              `msg:"duration"`          // duration of the span expressed in nanoseconds
+	Meta           map[string]string  `msg:"meta,omitempty"`    // arbitrary map of metadata
+	Metrics        map[string]float64 `msg:"metrics,omitempty"` // arbitrary map of numeric metrics
+	SpanID         uint64             `msg:"span_id"`           // identifier of this span
+	TraceID        uint64             `msg:"trace_id"`          // lower 64-bits of the root span identifier
+	TraceIDHigh128 uint64             `msg:"trace_id_high_128"` // upper 64-bits of the root span identifier
+	ParentID       uint64             `msg:"parent_id"`         // identifier of the span's direct parent
+	Error          int32              `msg:"error"`             // error status of the span; 0 means no errors
 
 	noDebugStack bool         `msg:"-"` // disables debug stack traces
 	finished     bool         `msg:"-"` // true if the span has been submitted to a tracer.

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -654,7 +654,7 @@ const (
 	keySingleSpanSamplingMPS = "_dd.span_sampling.max_per_second"
 	// keyPropagatedUserID holds the propagated user identifier, if user id propagation is enabled.
 	keyPropagatedUserID = "_dd.p.usr.id"
-	// keyTraceId128 is the 128-bit trace id, if applicable.
+	// keyTraceId128 is the lowercase, hex encoded upper 64 bits of a 128-bit trace id, if present.
 	keyTraceId128 = "_dd.p.tid"
 )
 

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -654,8 +654,8 @@ const (
 	keySingleSpanSamplingMPS = "_dd.span_sampling.max_per_second"
 	// keyPropagatedUserID holds the propagated user identifier, if user id propagation is enabled.
 	keyPropagatedUserID = "_dd.p.usr.id"
-	// keyTraceId128 is the lowercase, hex encoded upper 64 bits of a 128-bit trace id, if present.
-	keyTraceId128 = "_dd.p.tid"
+	// keyTraceID128 is the lowercase, hex encoded upper 64 bits of a 128-bit trace id, if present.
+	keyTraceID128 = "_dd.p.tid"
 )
 
 // The following set of tags is used for user monitoring and set through calls to span.SetUser().

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -62,19 +62,18 @@ type errorConfig struct {
 type span struct {
 	sync.RWMutex `msg:"-"` // all fields are protected by this RWMutex
 
-	Name           string             `msg:"name"`              // operation name
-	Service        string             `msg:"service"`           // service name (i.e. "grpc.server", "http.request")
-	Resource       string             `msg:"resource"`          // resource name (i.e. "/user?id=123", "SELECT * FROM users")
-	Type           string             `msg:"type"`              // protocol associated with the span (i.e. "web", "db", "cache")
-	Start          int64              `msg:"start"`             // span start time expressed in nanoseconds since epoch
-	Duration       int64              `msg:"duration"`          // duration of the span expressed in nanoseconds
-	Meta           map[string]string  `msg:"meta,omitempty"`    // arbitrary map of metadata
-	Metrics        map[string]float64 `msg:"metrics,omitempty"` // arbitrary map of numeric metrics
-	SpanID         uint64             `msg:"span_id"`           // identifier of this span
-	TraceID        uint64             `msg:"trace_id"`          // lower 64-bits of the root span identifier
-	TraceIDHigh128 uint64             `msg:"trace_id_high_128"` // upper 64-bits of the root span identifier
-	ParentID       uint64             `msg:"parent_id"`         // identifier of the span's direct parent
-	Error          int32              `msg:"error"`             // error status of the span; 0 means no errors
+	Name     string             `msg:"name"`              // operation name
+	Service  string             `msg:"service"`           // service name (i.e. "grpc.server", "http.request")
+	Resource string             `msg:"resource"`          // resource name (i.e. "/user?id=123", "SELECT * FROM users")
+	Type     string             `msg:"type"`              // protocol associated with the span (i.e. "web", "db", "cache")
+	Start    int64              `msg:"start"`             // span start time expressed in nanoseconds since epoch
+	Duration int64              `msg:"duration"`          // duration of the span expressed in nanoseconds
+	Meta     map[string]string  `msg:"meta,omitempty"`    // arbitrary map of metadata
+	Metrics  map[string]float64 `msg:"metrics,omitempty"` // arbitrary map of numeric metrics
+	SpanID   uint64             `msg:"span_id"`           // identifier of this span
+	TraceID  uint64             `msg:"trace_id"`          // lower 64-bits of the root span identifier
+	ParentID uint64             `msg:"parent_id"`         // identifier of the span's direct parent
+	Error    int32              `msg:"error"`             // error status of the span; 0 means no errors
 
 	noDebugStack bool         `msg:"-"` // disables debug stack traces
 	finished     bool         `msg:"-"` // true if the span has been submitted to a tracer.

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -6,8 +6,6 @@
 package tracer
 
 import (
-	"encoding/binary"
-	"encoding/hex"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -90,15 +88,7 @@ func (c *spanContext) TraceID() uint64 { return c.traceID }
 
 // TraceID128 implements ddtrace.SpanContextW3C.
 func (c *spanContext) TraceID128() string {
-	if c.traceIDHigh128 == 0 {
-		return "" // using 64-bit trace ids
-	}
-	// TODO: maybe store this somewhere so we don't have
-	// to make an allocation and encode it every time?
-	buf := make([]byte, 16)
-	binary.BigEndian.PutUint64(buf[:8], c.traceIDHigh128)
-	binary.BigEndian.PutUint64(buf[8:], c.traceID)
-	return hex.EncodeToString(buf)
+	return c.span.Meta[keyTraceId128]
 }
 
 // ForeachBaggageItem implements ddtrace.SpanContext.

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -50,10 +50,9 @@ type spanContext struct {
 // for the same span.
 func newSpanContext(span *span, parent *spanContext) *spanContext {
 	context := &spanContext{
-		traceID:        span.TraceID,
-		traceIDHigh128: span.TraceIDHigh128,
-		spanID:         span.SpanID,
-		span:           span,
+		traceID: span.TraceID,
+		spanID:  span.SpanID,
+		span:    span,
 	}
 	if parent != nil {
 		context.trace = parent.trace

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -33,9 +33,8 @@ type spanContext struct {
 
 	// the below group should propagate cross-process
 
-	traceID        uint64
-	traceIDHigh128 uint64
-	spanID         uint64
+	traceID uint64
+	spanID  uint64
 
 	mu         sync.RWMutex // guards below fields
 	baggage    map[string]string

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -89,7 +89,7 @@ func (c *spanContext) TraceID() uint64 { return c.traceID }
 
 // TraceID128 implements ddtrace.SpanContextW3C.
 func (c *spanContext) TraceID128() string {
-	hiBits := c.span.Meta[keyTraceId128]
+	hiBits := c.span.Meta[keyTraceID128]
 	if hiBits == "" {
 		return "" // 128 bit trace ids not enabled
 	}

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -470,14 +470,14 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 
 	// add 128 bit trace id, if enabled.
 	if os.Getenv("DD_TRACE_128_BIT_TRACEID_ENABLED") == "true" {
-		var traceIdHigh64 uint64
+		var idHigh uint64
 		if opts.TraceIDHigh128 != 0 {
-			traceIdHigh64 = opts.TraceIDHigh128
+			idHigh = opts.TraceIDHigh128
 		} else {
-			traceIdHigh64 = generateSpanID(startTime)
+			idHigh = generateSpanID(startTime)
 		}
 		buf := make([]byte, 16)
-		binary.BigEndian.PutUint64(buf[:8], traceIdHigh64)
+		binary.BigEndian.PutUint64(buf[:8], idHigh)
 		binary.BigEndian.PutUint64(buf[8:], id)
 		span.setMeta(keyTraceId128, hex.EncodeToString(buf))
 	}

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -439,6 +439,11 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		taskEnd:      startExecutionTracerTask(operationName),
 		noDebugStack: t.config.noDebugStack,
 	}
+	if opts.TraceIDHigh128 != 0 {
+		span.TraceIDHigh128 = opts.TraceIDHigh128
+	} else if os.Getenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED") == "true" {
+		span.TraceIDHigh128 = generateSpanID(startTime)
+	}
 	if t.config.hostname != "" {
 		span.setMeta(keyHostname, t.config.hostname)
 	}

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -472,7 +472,7 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		if id128 == 0 {
 			id128 = generateSpanID(startTime)
 		}
-		span.setMeta(keyTraceId128, strconv.FormatUint(id128, 16))
+		span.setMeta(keyTraceID128, strconv.FormatUint(id128, 16))
 	}
 
 	// add tags from options

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -467,7 +467,7 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 	span.setMeta("language", "go")
 
 	// add 128 bit trace id, if enabled.
-	if os.Getenv("DD_TRACE_128_BIT_TRACEID_ENABLED") == "true" {
+	if os.Getenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED") == "true" {
 		id128 := opts.TraceID128High
 		if id128 == 0 {
 			id128 = generateSpanID(startTime)

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -7,6 +7,8 @@ package tracer
 
 import (
 	gocontext "context"
+	"encoding/binary"
+	"encoding/hex"
 	"os"
 	"runtime/pprof"
 	rt "runtime/trace"
@@ -472,7 +474,9 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		if id128 == 0 {
 			id128 = generateSpanID(startTime)
 		}
-		span.setMeta(keyTraceID128, strconv.FormatUint(id128, 16))
+		buf := make([]byte, 8)
+		binary.BigEndian.PutUint64(buf, id128)
+		span.setMeta(keyTraceID128, hex.EncodeToString(buf))
 	}
 
 	// add tags from options

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -675,7 +675,7 @@ func TestTracerStartSpanOptions128(t *testing.T) {
 	}
 
 	// Enable 128 bit trace ids
-	t.Setenv("DD_TRACE_128_BIT_TRACEID_ENABLED", "true")
+	t.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "true")
 	opts128 := []StartSpanOption{
 		WithSpanID(420),
 		WithTraceID128High(123), // 123420 hex encoded

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -662,7 +662,7 @@ func TestTracerStartSpanOptions128(t *testing.T) {
 	defer tracer.Stop()
 	opts := []StartSpanOption{
 		WithSpanID(420),
-		WithTraceID128("1E21C"), // 123420 hex encoded
+		WithTraceID128High(123), // 123 hex encoded
 	}
 	s := tracer.StartSpan("web.request", opts...).(*span)
 	assert := assert.New(t)
@@ -678,13 +678,13 @@ func TestTracerStartSpanOptions128(t *testing.T) {
 	t.Setenv("DD_TRACE_128_BIT_TRACEID_ENABLED", "true")
 	opts128 := []StartSpanOption{
 		WithSpanID(420),
-		WithTraceID128("1E21C"), // 123420 hex encoded
+		WithTraceID128High(123), // 123420 hex encoded
 	}
 	s128 := tracer.StartSpan("web.request", opts128...).(*span)
 	assert.Equal(uint64(420), s128.SpanID)
 	assert.Equal(uint64(420), s128.TraceID)
 	if w3cCtx, ok := s128.Context().(ddtrace.SpanContextW3C); ok {
-		assert.Equal("1E21C", w3cCtx.TraceID128())
+		assert.Equal("7b0000000000000000000000000001a4", w3cCtx.TraceID128())
 	} else {
 		assert.Fail("couldn't cast to ddtrace.SpanContextW3C")
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Adds support for generating 128 bit trace ids and exposing them from the Datadog API via a new `SpanContextW3C`. Future PRs will propagate this id for distributed tracing.

The downside of this approach is that if clients want to access the 128 bit trace ids in their code, they must type-cast (as shown in `example_test.go`). However, there is no other feasible approach while still maintaining backwards compatibility for the API. This can be cleaned up in v2.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Describe how to test/QA your changes
Toggle `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED` to generate 128 bit trace ids and ensure that you can access them programmatically in your tracer example.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.