### PR TITLE
ddtrace/tracer: annotate execution trace with span IDs

### DIFF
--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -6,7 +6,6 @@
 package tracer
 
 import (
-	"context"
 	gocontext "context"
 	"os"
 	"runtime/pprof"
@@ -598,7 +597,7 @@ func (t *tracer) sample(span *span) {
 	t.prioritySampling.apply(span)
 }
 
-func startExecutionTracerTask(ctx context.Context, name string, spanID uint64) (context.Context, func()) {
+func startExecutionTracerTask(ctx gocontext.Context, name string, spanID uint64) (gocontext.Context, func()) {
 	if !rt.IsEnabled() {
 		return ctx, func() {}
 	}


### PR DESCRIPTION
### What does this PR do?

Using the execution tracer's Log functionality, annotate execution trace tasks
corresponding to APM spans with their span IDs.

This PR also arranges for the pprof context.Context to hold execution trace
task info, so that there is a proper parent/child relationship between tasks
corresponding to the same relationship between APM spans.

Logs are the most efficient way to capture span IDs in the
execution trace right now, since we don't get any benefit from interning
what's effectively going to be a new value for each span. We do pay a
roughly 1 microsecond cost for collecting another stack trace (give or take 
depending on stack depth) plus another allocation to serialize the span ID.
We only pay that price if execution tracing is actually enabled, though.

### Motivation

Provide a mechanism for a trace consumer to associate execution trace
data with APM-level spans using the facilities available today (i.e.
not relying on anything else being added to the execution tracer).

Here's what you can see in the trace UI when you focus on tasks:

<img width="733" alt="Screen Shot 2023-01-22 at 4 26 58 PM" src="https://user-images.githubusercontent.com/97066770/213941513-eb5e44b2-acc8-469d-8ff0-9d8d3be0d4a9.png">

The logs show up under the task where they were created. You can
also see instantaneous events in the UI, and parent & child tasks are properly
displayed:

<img width="942" alt="Screen Shot 2023-01-22 at 4 26 31 PM" src="https://user-images.githubusercontent.com/97066770/213941557-16882630-d943-4def-b972-544372775d3d.png">

### Reviewing/Testing

I've manually tested this, and it looks OK (see screenshots above). There's
unfortunately no stable Go execution trace parser library so it would be a bit
hairy to write nicer unit tests for this right now.

Here's a simple test case I tried:

```go
func TestParentChildIDsExecTrace(t *testing.T) {
	tracer, _, _, stop := startTestTracer(t)
	defer stop()
	parent := tracer.StartSpan("parent.test")
	t.Log("parent ID", parent.Context().SpanID())
	defer parent.Finish()
	child := tracer.StartSpan("child.test", ChildOf(parent.Context()))
	defer child.Finish()
	t.Log("child ID", child.Context().SpanID())
}
```

I ran this:

```
go test -v -run=ParentChildIDsExecTrace -trace=trace.out ./ddtrace/tracer
=== RUN   TestParentChildIDsExecTrace
    tracer_test.go:2155: parent ID 3295123603864800625
    tracer_test.go:2159: child ID 3998406317951193332
--- PASS: TestParentChildIDsExecTrace (0.01s)
PASS
ok  	gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer	0.242s
```

Then I looked at the trace output:

<img width="691" alt="Screen Shot 2023-01-23 at 10 11 21 AM" src="https://user-images.githubusercontent.com/97066770/214075149-85988f61-6d72-40e3-969c-19d3c7ea03a5.png">
<img width="683" alt="Screen Shot 2023-01-23 at 10 11 28 AM" src="https://user-images.githubusercontent.com/97066770/214075173-232faa27-697c-477a-833f-cd6b637998a5.png">
<img width="925" alt="Screen Shot 2023-01-23 at 10 11 44 AM" src="https://user-images.githubusercontent.com/97066770/214075186-455166ca-9413-421e-99ac-aaff96a64d0b.png">
