### PR TITLE
internal/remoteconfig: configure poll interval through an env var

### DIFF
--- a/internal/remoteconfig/config.go
+++ b/internal/remoteconfig/config.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023 Datadog, Inc.
+
+package remoteconfig
+
+import (
+	"net/http"
+	"os"
+	"time"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/version"
+)
+
+const (
+	envPollIntervalSec = "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS"
+)
+
+// ClientConfig contains the required values to configure a remoteconfig client
+type ClientConfig struct {
+	// The address at which the agent is listening for remoteconfig update requests on
+	AgentURL string
+	// The semantic version of the user's application
+	AppVersion string
+	// The env this tracer is running in
+	Env string
+	// The time interval between two client polls to the agent for updates
+	PollInterval time.Duration
+	// A list of remote config products this client is interested in
+	Products []string
+	// The tracer's runtime id
+	RuntimeID string
+	// The name of the user's application
+	ServiceName string
+	// The semantic version of the tracer
+	TracerVersion string
+	// The base TUF root metadata file
+	TUFRoot string
+	// The capabilities of the client
+	Capabilities []Capability
+	// HTTP is the HTTP client used to receive config updates
+	HTTP *http.Client
+}
+
+// DefaultClientConfig returns the default remote config client configuration
+func DefaultClientConfig() ClientConfig {
+	return ClientConfig{
+		Env:           os.Getenv("DD_ENV"),
+		HTTP:          &http.Client{Timeout: 10 * time.Second},
+		PollInterval:  pollIntervalFromEnv(),
+		RuntimeID:     globalconfig.RuntimeID(),
+		ServiceName:   globalconfig.ServiceName(),
+		TracerVersion: version.Tag,
+		TUFRoot:       os.Getenv("DD_RC_TUF_ROOT"),
+	}
+}
+
+func pollIntervalFromEnv() time.Duration {
+	interval := internal.IntEnv(envPollIntervalSec, 5)
+	if interval < 0 {
+		log.Debug("Remote config: cannot use a negative poll interval: %s = %d. Defaulting to 5s.", envPollIntervalSec, interval)
+		return 5 * time.Second
+	} else if interval == 0 {
+		log.Debug("Remote config: poll interval set to 0. Polling will be continuous.")
+		return time.Nanosecond
+	}
+
+	return time.Duration(interval) * time.Second
+}

--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -14,15 +14,12 @@ import (
 	"io"
 	"math/big"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
 	rc "github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/version"
 )
 
 // Callback represents a function that can process a remote config update.
@@ -45,48 +42,9 @@ const (
 	ASMDDRules
 )
 
-// DefaultClientConfig returns the default remote config client configuration
-func DefaultClientConfig() ClientConfig {
-	return ClientConfig{
-		Env:           os.Getenv("DD_ENV"),
-		HTTP:          &http.Client{Timeout: 10 * time.Second},
-		PollInterval:  time.Second * 1,
-		RuntimeID:     globalconfig.RuntimeID(),
-		ServiceName:   globalconfig.ServiceName(),
-		TracerVersion: version.Tag,
-		TUFRoot:       os.Getenv("DD_RC_TUF_ROOT"),
-	}
-}
-
 // ProductUpdate represents an update for a specific product.
 // It is a map of file path to raw file content
 type ProductUpdate map[string][]byte
-
-// ClientConfig contains the required values to configure a remoteconfig client
-type ClientConfig struct {
-	// The address at which the agent is listening for remoteconfig update requests on
-	AgentURL string
-	// The semantic version of the user's application
-	AppVersion string
-	// The env this tracer is running in
-	Env string
-	// The time interval between two client polls to the agent for updates
-	PollInterval time.Duration
-	// A list of remote config products this client is interested in
-	Products []string
-	// The tracer's runtime id
-	RuntimeID string
-	// The name of the user's application
-	ServiceName string
-	// The semantic version of the tracer
-	TracerVersion string
-	// The base TUF root metadata file
-	TUFRoot string
-	// The capabilities of the client
-	Capabilities []Capability
-	// HTTP is the HTTP client used to receive config updates
-	HTTP *http.Client
-}
 
 // A Client interacts with an Agent to update and track the state of remote
 // configuration


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
- Set the default polling interval to 5s
- Read the polling interval from the `DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS` env var
- Use the default value if reading the above env var fails
- Add testing for the new env var
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Comply with the global RC specs
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.