### PR TITLE
Fix windows CI

### DIFF
--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -577,6 +577,10 @@ func TestEndpointCounts(t *testing.T) {
 			// Configure endpoint counting
 			t.Setenv(traceprof.EndpointCountEnvVar, fmt.Sprintf("%v", enabled))
 
+			// Start the tracer (before profiler to avoid race in case of slow tracer start)
+			tracer.Start()
+			defer tracer.Stop()
+
 			// Start profiler
 			err := Start(
 				WithAgentAddr(server.Listener.Addr().String()),
@@ -585,10 +589,6 @@ func TestEndpointCounts(t *testing.T) {
 			)
 			require.NoError(t, err)
 			defer Stop()
-
-			// Start the tracer
-			tracer.Start()
-			defer tracer.Stop()
 
 			// Create spans until the first profile is finished
 			var m profileMeta


### PR DESCRIPTION
### What does this PR do?

Fixes the [windows ci tests](https://github.com/DataDog/dd-trace-go/actions/runs/3994308804) broken by 0d7ea332e47bd82f4d84110ad14e5f179c989a47.

The problem was caused by the tracer starting up very slowly on windows due to slow network timeouts (see https://github.com/DataDog/dd-trace-go/commit/0013a52f2ded06043c29d8393c2519273dc25ec5).

![image](https://user-images.githubusercontent.com/15000/214272441-375192d7-6bf3-4586-b750-5f08da46edba.png)

This patch does not attempt to speed up the network timeout. This would require access to `withStatsdClient(&statsd.NoOpClient{})` which is a refactoring I don't have time for right now. But if we decide that we need faster windows tests at some point I'm happy to do this.

### Motivation

Green is good, red is bad.

### Describe how to test/QA your changes

I've tested this on Windows Server 2022, see screenshot.

![CleanShot 2023-01-24 at 11 47 35@2x](https://user-images.githubusercontent.com/15000/214272383-17830a66-16e3-41ab-83d5-86ae0f1f9ced.png)


### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.