### PR TITLE
tracer: remove WithTraceID128

### DIFF
--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -139,10 +139,6 @@ type StartSpanConfig struct {
 	// TraceID to the same value.
 	SpanID uint64
 
-	// TraceID128High will be the upper 64 bits of a 128-bit trace id of the span if no
-	// Parent SpanContext is present, overriding the random number that would be generated.
-	TraceID128High uint64
-
 	// Context is the parent context where the span should be stored.
 	Context context.Context
 }

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -813,15 +813,6 @@ func WithSpanID(id uint64) StartSpanOption {
 	}
 }
 
-// WithTraceID128High sets the higher-order 64 bits of a 128-bit trace id
-// of the started span if no Parent SpanContext is present,
-// overriding the random number that would be generated.
-func WithTraceID128High(id uint64) StartSpanOption {
-	return func(cfg *ddtrace.StartSpanConfig) {
-		cfg.TraceID128High = id
-	}
-}
-
 // ChildOf tells StartSpan to use the given span context as a parent for the
 // created span.
 func ChildOf(ctx ddtrace.SpanContext) StartSpanOption {

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -470,10 +470,7 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 
 	// add 128 bit trace id, if enabled.
 	if os.Getenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED") == "true" {
-		id128 := opts.TraceID128High
-		if id128 == 0 {
-			id128 = generateSpanID(startTime)
-		}
+		id128 := generateSpanID(startTime)
 		buf := make([]byte, 8)
 		binary.BigEndian.PutUint64(buf, id128)
 		span.setMeta(keyTraceID128, hex.EncodeToString(buf))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Remove the `WithTraceID128` API that was added to this feature branch (not currently in a dd-trace-go release or in main).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

There isn't enough evidence that we need this API at this time, and the UX is confusing as it is. Currently, the only way to set the trace id programmatically is for root spans using `WithSpanID`, which then applies the trace id. Adding a separate API just to set the higher bits is likely to lead to confusion, and we should redesign this for v2 anyway.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.