### PR TITLE
checkmilestone.go: do not allow merging into triage milestone

### DIFF
--- a/checkmilestone.go
+++ b/checkmilestone.go
@@ -43,5 +43,5 @@ func main() {
 	} else if data.Milestone == "Triage" {
 		exit(errors.New("Cannot merge PR's in 'Triage' milestone."))
 	}
-	fmt.Println("Milestone check passed.")
+	fmt.Println("Milestone check passed for [%s].", data.Milestone)
 }

--- a/checkmilestone.go
+++ b/checkmilestone.go
@@ -52,5 +52,5 @@ func main() {
 	} else {
 		exit(errors.New("Could not resolve milestone. checkmilestone.go likely needs to be updated."))
 	}
-	fmt.Printf("Milestone check passed for [%v].", data.Milestone)
+	fmt.Println("Milestone check passed.")
 }

--- a/checkmilestone.go
+++ b/checkmilestone.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 )
 
 func main() {
@@ -40,8 +41,16 @@ func main() {
 	resp.Body.Close()
 	if data.Milestone == nil {
 		exit(errors.New("Milestone not set."))
-	} else if data.Milestone == "Triage" {
-		exit(errors.New("Cannot merge PR's in 'Triage' milestone."))
+	} else if m, ok := data.Milestone.(map[string]interface{}); ok {
+		title, ok := m["title"].(string)
+		if !ok {
+			exit(errors.New("Could not find milestone \"title\" in milestone map."))
+		}
+		if strings.ToLower(title) == "triage" {
+			exit(errors.New("PR's in the Triage milestone cannot be merged."))
+		}
+	} else {
+		exit(errors.New("Could not resolve milestone. checkmilestone.go likely needs to be updated."))
 	}
-	fmt.Println("Milestone check passed for [%s].", data.Milestone)
+	fmt.Printf("Milestone check passed for [%v].", data.Milestone)
 }

--- a/checkmilestone.go
+++ b/checkmilestone.go
@@ -40,6 +40,8 @@ func main() {
 	resp.Body.Close()
 	if data.Milestone == nil {
 		exit(errors.New("Milestone not set."))
+	} else if data.Milestone == "Triage" {
+		exit(errors.New("Cannot merge PR's in 'Triage' milestone."))
 	}
 	fmt.Println("Milestone check passed.")
 }


### PR DESCRIPTION
### What does this PR do?

This commit changes the `checkmilestone.go` program so that it does not allow merging when Milestone is `Triage`. 



### Motivation

This is to prevent PR's from being merged but not being associated with a release, and not showing up in release notes.

### Describe how to test/QA your changes

This PR is in milestone Triage. The milestone test should fail. Before merging, I will move it to the correct milestone and ensure that the CI passes.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.