### PR TITLE
internal/telemetry: uniformize language name with other ways it's reported

### DIFF
--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -314,7 +314,7 @@ func (c *Client) flush() {
 		r := c.newRequest(RequestTypeGenerateMetrics)
 		payload := &Metrics{
 			Namespace:   c.Namespace,
-			LibLanguage: "golang",
+			LibLanguage: "go",
 			LibVersion:  version.Tag,
 		}
 		for _, m := range c.metrics {
@@ -385,7 +385,7 @@ func (c *Client) newRequest(t RequestType) *Request {
 			Env:             c.Env,
 			ServiceVersion:  c.Version,
 			TracerVersion:   version.Tag,
-			LanguageName:    "golang",
+			LanguageName:    "go",
 			LanguageVersion: runtime.Version(),
 		},
 		Host: Host{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

rename the language name from `golang` to `go` in the instrumentation telemetry client.

### Motivation

The documentation for instrumentation-telemetry specified the value `golang` as the reported language name but this is not  uniform with the existing ways it's reported. Since this feature is not GAed in dd-trace-go, let's fix it before we have to care about backward compatibility.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.