### PR TITLE
contrib/miekg/dns: fix span kind for dns server traces

### DIFF
--- a/contrib/miekg/dns/dns_test.go
+++ b/contrib/miekg/dns/dns_test.go
@@ -160,7 +160,7 @@ func assertSpans(t *testing.T, spans []mocktracer.Span) {
 	}
 
 	// the server span should be the first one
-	assert.Equal(t, ext.SpanKindClient, spans[0].Tag(ext.SpanKind))
+	assert.Equal(t, ext.SpanKindServer, spans[0].Tag(ext.SpanKind))
 	assert.Equal(t, ext.SpanKindClient, spans[1].Tag(ext.SpanKind))
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Fixes span kind for dns server traces - this library is used both for DNS client and server and we were setting type client for both.

Also refactored tests and increased test coverage for some functions not covered by existing tests.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->
We want to set correct span kind for DNS server traces.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->
Updated existing tests.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Changed code has unit tests for its functionality.
- [x] If this interacts with the agent in a new way, a system test has been added.