### PR TITLE
ddtrace/tracer: add usr.id even with propagation

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -218,10 +218,9 @@ func (s *span) SetUser(id string, opts ...UserMonitoringOption) {
 			s.context.updated = true
 		}
 		delete(root.Meta, keyPropagatedUserID)
-		// setMeta is used since the span is already locked
-		root.setMeta(keyUserID, id)
 	}
 	for k, v := range map[string]string{
+		keyUserID:        id,
 		keyUserEmail:     cfg.Email,
 		keyUserName:      cfg.Name,
 		keyUserScope:     cfg.Scope,
@@ -229,6 +228,7 @@ func (s *span) SetUser(id string, opts ...UserMonitoringOption) {
 		keyUserSessionID: cfg.SessionID,
 	} {
 		if v != "" {
+			// setMeta is used since the span is already locked
 			root.setMeta(k, v)
 		}
 	}

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -2054,8 +2054,7 @@ func TestUserMonitoring(t *testing.T) {
 		s := tr.newRootSpan("root", "test", "test")
 		SetUser(s, id, WithPropagation())
 		s.Finish()
-		_, ok := s.Meta[keyUserID]
-		assert.False(t, ok)
+		assert.Equal(t, id, s.Meta[keyUserID])
 		encoded := base64.StdEncoding.EncodeToString([]byte(id))
 		assert.Equal(t, encoded, s.context.trace.propagatingTags[keyPropagatedUserID])
 		assert.Equal(t, encoded, s.Meta[keyPropagatedUserID])


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Add the `usr.id` span tag even when the user id propagation is enabled.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

At first, we thought the backend would enrich this span tag based on the propagated `_dd.p.usr.id` one, but having `usr.id` present is part of the feature:
1. `_dd.p.usr.id` is set alone when it was found in the HTTP header for propagated tags (note how anyone can set it)
2. `usr.id` must always be set when using the `SetUser()` function, so that we can know that the user id has been programmatically set.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

- Go test from this PR
- System tests: https://github.com/DataDog/system-tests/blob/main/tests/test_identify.py (opening a PR to update them)

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.