### PR TITLE
internal/appsec: request blocking based on user ID

### DIFF
--- a/appsec/appsec.go
+++ b/appsec/appsec.go
@@ -84,7 +84,7 @@ func SetUser(ctx context.Context, id string, opts ...tracer.UserMonitoringOption
 	tracer.SetUser(s, id, opts...)
 	if sharedsec.MonitorUser(ctx, id) {
 		return &userMonitoringError{
-			err: errors.New("Suspicious user detected. Associated requests should be blocked."),
+			err: errors.New("Suspicious user detected. Associated requests should be blocked"),
 			status: struct {
 				grpc codes.Code
 				http int

--- a/appsec/appsec.go
+++ b/appsec/appsec.go
@@ -83,6 +83,9 @@ func SetUser(ctx context.Context, id string, opts ...tracer.UserMonitoringOption
 	}
 	tracer.SetUser(s, id, opts...)
 	if sharedsec.MonitorUser(ctx, id) {
+		if s, ok := tracer.SpanFromContext(ctx); ok {
+			s.SetTag("appsec.blocked", true)
+		}
 		return &userMonitoringError{
 			err: errors.New("Suspicious user detected. Associated requests should be blocked"),
 			status: struct {

--- a/appsec/appsec.go
+++ b/appsec/appsec.go
@@ -81,9 +81,6 @@ func SetUser(ctx context.Context, id string, opts ...tracer.UserMonitoringOption
 		return nil
 	}
 	if sharedsec.MonitorUser(ctx, id) {
-		if s, ok := tracer.SpanFromContext(ctx); ok {
-			s.SetTag("appsec.blocked", true)
-		}
 		return &userMonitoringError{
 			err: errors.New("Suspicious user detected. Associated requests should be blocked"),
 			status: struct {

--- a/appsec/appsec.go
+++ b/appsec/appsec.go
@@ -63,13 +63,13 @@ func (err *userMonitoringError) Error() string {
 	return err.err.Error()
 }
 
-// SetUser associates user information to the current trace which the
-// provided context belongs to. The options can be used to tune which user
-// bit of information gets monitored. In case of distributed traces,
-// the user id can be propagated across traces using the WithPropagation() option.
-// See https://docs.datadoghq.com/security_platform/application_security/setup_and_configure/?tab=set_user#add-user-information-to-traces
-// A nil returned error means everything went well. A not nil error can be used to know whether the user should be blocked or not.
-func SetUser(ctx context.Context, id string, opts ...tracer.UserMonitoringOption) *userMonitoringError {
+// SetUser wraps tracer.SetUser().
+// On top of associating user information to spans, it performs a WAF check
+// and returns an error in case `id` matches a blocked user ID in the AppSec
+// WAF security rules. It is recommended to use this SDK whenever dealing with
+// authenticated user requests and block that request's execution in case this function
+// returns an error. See the examples for more information.
+func SetUser(ctx context.Context, id string, opts ...tracer.UserMonitoringOption) error {
 	if !appsec.Enabled() {
 		return &userMonitoringError{
 			err: errors.New("AppSec is not enabled"),

--- a/appsec/appsec_test.go
+++ b/appsec/appsec_test.go
@@ -7,7 +7,6 @@ package appsec_test
 
 import (
 	"context"
-	privateAppsec "gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,6 +14,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/appsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	privateAppsec "gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
 )
 
 func TestTrackUserLoginSuccessEvent(t *testing.T) {
@@ -146,6 +146,9 @@ func TestSetUser(t *testing.T) {
 
 	privateAppsec.Start()
 	defer privateAppsec.Stop()
+	if !privateAppsec.Enabled() {
+		t.Skip("AppSec needs to be enabled for this test")
+	}
 
 	t.Run("error/nil-ctx", func(t *testing.T) {
 		err := appsec.SetUser(nil, "usr.id")

--- a/appsec/appsec_test.go
+++ b/appsec/appsec_test.go
@@ -140,7 +140,6 @@ func TestSetUser(t *testing.T) {
 	t.Run("error/appsec-disabled", func(t *testing.T) {
 		err := appsec.SetUser(nil, "usr.id")
 		require.NotNil(t, err)
-		require.False(t, err.ShouldBlock())
 		require.Equal(t, "AppSec is not enabled", err.Error())
 	})
 
@@ -153,7 +152,6 @@ func TestSetUser(t *testing.T) {
 	t.Run("error/nil-ctx", func(t *testing.T) {
 		err := appsec.SetUser(nil, "usr.id")
 		require.NotNil(t, err)
-		require.False(t, err.ShouldBlock())
 		require.Equal(t, "Could not retrieve span from context", err.Error())
 	})
 

--- a/appsec/appsec_test.go
+++ b/appsec/appsec_test.go
@@ -137,10 +137,13 @@ func TestCustomEvent(t *testing.T) {
 }
 
 func TestSetUser(t *testing.T) {
-	t.Run("error/appsec-disabled", func(t *testing.T) {
-		err := appsec.SetUser(nil, "usr.id")
-		require.NotNil(t, err)
-		require.Equal(t, "AppSec is not enabled", err.Error())
+	t.Run("early-return/appsec-disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+		span, ctx := tracer.StartSpanFromContext(context.Background(), "example")
+		defer span.Finish()
+		err := appsec.SetUser(ctx, "usr.id")
+		require.NoError(t, err)
 	})
 
 	privateAppsec.Start()
@@ -149,13 +152,12 @@ func TestSetUser(t *testing.T) {
 		t.Skip("AppSec needs to be enabled for this test")
 	}
 
-	t.Run("error/nil-ctx", func(t *testing.T) {
+	t.Run("early-return/nil-ctx", func(t *testing.T) {
 		err := appsec.SetUser(nil, "usr.id")
-		require.NotNil(t, err)
-		require.Equal(t, "Could not retrieve span from context", err.Error())
+		require.NoError(t, err)
 	})
 
-	t.Run("no-error", func(t *testing.T) {
+	t.Run("no-early-return", func(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 		span, ctx := tracer.StartSpanFromContext(context.Background(), "example")

--- a/appsec/example_test.go
+++ b/appsec/example_test.go
@@ -60,3 +60,21 @@ func ExampleMonitorParsedHTTPBody_customContext() {
 
 	r.Start(":8080")
 }
+
+func userIDFromRequest(r *http.Request) string {
+	return r.Header.Get("user-id")
+}
+
+// Monitor and block requests depending on user ID
+func ExampleSetUser() {
+	mux := httptrace.NewServeMux()
+	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
+		// Check for error on SetUser() to know if the request should be blocked or not.
+		// If it should, early exit from the handler.
+		if err := appsec.SetUser(r.Context(), userIDFromRequest(r)); err != nil && err.ShouldBlock() {
+			return
+		}
+
+		w.Write([]byte("User monitored using AppSec SetUser SDK\n"))
+	})
+}

--- a/appsec/example_test.go
+++ b/appsec/example_test.go
@@ -69,8 +69,9 @@ func userIDFromRequest(r *http.Request) string {
 func ExampleSetUser() {
 	mux := httptrace.NewServeMux()
 	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
-		// Check for error on SetUser() to know if the request should be blocked or not.
-		// If it should, early exit from the handler.
+		// We use SetUser() here to associate the user ID to the request's span. The return value
+		// can then be checked to decide whether to block the request or not.
+		// If it should be blocked, early exit from the handler.
 		if err := appsec.SetUser(r.Context(), userIDFromRequest(r)); err != nil {
 			return
 		}

--- a/appsec/example_test.go
+++ b/appsec/example_test.go
@@ -71,7 +71,7 @@ func ExampleSetUser() {
 	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
 		// Check for error on SetUser() to know if the request should be blocked or not.
 		// If it should, early exit from the handler.
-		if err := appsec.SetUser(r.Context(), userIDFromRequest(r)); err != nil && err.ShouldBlock() {
+		if err := appsec.SetUser(r.Context(), userIDFromRequest(r)); err != nil {
 			return
 		}
 

--- a/contrib/google.golang.org/grpc/appsec.go
+++ b/contrib/google.golang.org/grpc/appsec.go
@@ -43,7 +43,6 @@ func appsecUnaryHandlerMiddleware(span ddtrace.Span, handler grpc.UnaryHandler) 
 		}()
 
 		if op.BlockedCode != nil {
-			op.AddTag(httpsec.BlockedRequestTag, true)
 			return nil, status.Errorf(*op.BlockedCode, "Request blocked")
 		}
 
@@ -80,7 +79,6 @@ func appsecStreamHandlerMiddleware(span ddtrace.Span, handler grpc.StreamHandler
 		}()
 
 		if op.BlockedCode != nil {
-			op.AddTag(httpsec.BlockedRequestTag, true)
 			return status.Error(*op.BlockedCode, "Request blocked")
 		}
 

--- a/contrib/google.golang.org/grpc/appsec_test.go
+++ b/contrib/google.golang.org/grpc/appsec_test.go
@@ -7,13 +7,17 @@ package grpc
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"strings"
 	"testing"
 
+	pappsec "gopkg.in/DataDog/dd-trace-go.v1/appsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -182,4 +186,137 @@ func TestBlocking(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+}
+
+// Test that user blocking works by using custom rules/rules data
+func TestUserBlocking(t *testing.T) {
+	t.Setenv("DD_APPSEC_RULES", "../../../internal/appsec/testdata/blocking.json")
+	appsec.Start()
+	defer appsec.Stop()
+	if !appsec.Enabled() {
+		t.Skip("appsec disabled")
+	}
+
+	rig, err := newAppsecRig(false)
+	require.NoError(t, err)
+	defer rig.Close()
+	client := rig.client
+
+	t.Run("unary-block", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		// Send a XSS attack in the payload along with the canary value in the RPC metadata
+		ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("user-id", "blocked-user-1"))
+		reply, err := client.Ping(ctx, &FixtureRequest{Name: "<script>alert('xss');</script>"})
+
+		require.Nil(t, reply)
+		require.Equal(t, codes.Aborted, status.Code(err))
+
+		finished := mt.FinishedSpans()
+		require.Len(t, finished, 1)
+		// The request should have the attack attempts
+		event, _ := finished[0].Tag("_dd.appsec.json").(string)
+		require.NotNil(t, event)
+		require.True(t, strings.Contains(event, "blk-001-002"))
+	})
+
+	t.Run("stream-block", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("user-id", "blocked-user-1"))
+		stream, err := client.StreamPing(ctx)
+		require.NoError(t, err)
+		reply, err := stream.Recv()
+
+		require.Equal(t, codes.Aborted, status.Code(err))
+		require.Nil(t, reply)
+
+		finished := mt.FinishedSpans()
+		require.Len(t, finished, 1)
+		// The request should have the attack attempts
+		event, _ := finished[0].Tag("_dd.appsec.json").(string)
+		require.NotNil(t, event)
+		require.True(t, strings.Contains(event, "blk-001-002"))
+	})
+}
+
+func newAppsecRig(traceClient bool, interceptorOpts ...Option) (*appsecRig, error) {
+	interceptorOpts = append([]InterceptorOption{WithServiceName("grpc")}, interceptorOpts...)
+
+	server := grpc.NewServer(
+		grpc.UnaryInterceptor(UnaryServerInterceptor(interceptorOpts...)),
+		grpc.StreamInterceptor(StreamServerInterceptor(interceptorOpts...)),
+	)
+
+	fixtureServer := new(appsecFixtureServer)
+	RegisterFixtureServer(server, fixtureServer)
+
+	li, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	_, port, _ := net.SplitHostPort(li.Addr().String())
+	// start our test fixtureServer.
+	go server.Serve(li)
+
+	opts := []grpc.DialOption{grpc.WithInsecure()}
+	if traceClient {
+		opts = append(opts,
+			grpc.WithUnaryInterceptor(UnaryClientInterceptor(interceptorOpts...)),
+			grpc.WithStreamInterceptor(StreamClientInterceptor(interceptorOpts...)),
+		)
+	}
+	conn, err := grpc.Dial(li.Addr().String(), opts...)
+	if err != nil {
+		return nil, fmt.Errorf("error dialing: %s", err)
+	}
+	return &appsecRig{
+		fixtureServer: fixtureServer,
+		listener:      li,
+		port:          port,
+		server:        server,
+		conn:          conn,
+		client:        NewFixtureClient(conn),
+	}, err
+}
+
+// rig contains all of the servers and connections we'd need for a
+// grpc integration test
+type appsecRig struct {
+	fixtureServer *appsecFixtureServer
+	server        *grpc.Server
+	port          string
+	listener      net.Listener
+	conn          *grpc.ClientConn
+	client        FixtureClient
+}
+
+func (r *appsecRig) Close() {
+	r.server.Stop()
+	r.conn.Close()
+}
+
+type appsecFixtureServer struct {
+	s fixtureServer
+}
+
+func (s *appsecFixtureServer) StreamPing(stream Fixture_StreamPingServer) (err error) {
+	ctx := stream.Context()
+	md, _ := metadata.FromIncomingContext(ctx)
+	ids := md.Get("user-id")
+	if err := pappsec.SetUser(ctx, ids[0]); err != nil && err.ShouldBlock() {
+		return err
+	}
+	return s.s.StreamPing(stream)
+}
+func (s *appsecFixtureServer) Ping(ctx context.Context, in *FixtureRequest) (*FixtureReply, error) {
+	md, _ := metadata.FromIncomingContext(ctx)
+	ids := md.Get("user-id")
+	if err := pappsec.SetUser(ctx, ids[0]); err != nil && err.ShouldBlock() {
+		return nil, err.GRPCStatus().Err()
+	}
+
+	return s.s.Ping(ctx, in)
 }

--- a/internal/appsec/dyngo/instrumentation/common.go
+++ b/internal/appsec/dyngo/instrumentation/common.go
@@ -15,6 +15,9 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/samplernames"
 )
 
+// BlockedRequestTag used to convey whether a request is blocked
+const BlockedRequestTag = "appsec.blocked"
+
 type (
 	// TagSetter is the interface needed to set a span tag.
 	TagSetter interface {

--- a/internal/appsec/dyngo/instrumentation/common.go
+++ b/internal/appsec/dyngo/instrumentation/common.go
@@ -15,17 +15,27 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/samplernames"
 )
 
-// TagSetter is the interface needed to set a span tag.
-type TagSetter interface {
-	SetTag(string, interface{})
-}
-
-// TagsHolder wraps a map holding tags. The purpose of this struct is to be used by composition in an Operation
-// to allow said operation to handle tags addition/retrieval. See httpsec/http.go and grpcsec/grpc.go.
-type TagsHolder struct {
-	tags map[string]interface{}
-	mu   sync.Mutex
-}
+type (
+	// TagSetter is the interface needed to set a span tag.
+	TagSetter interface {
+		SetTag(string, interface{})
+	}
+	// TagsHolder wraps a map holding tags. The purpose of this struct is to be used by composition in an Operation
+	// to allow said operation to handle tags addition/retrieval. See httpsec/http.go and grpcsec/grpc.go.
+	TagsHolder struct {
+		tags map[string]interface{}
+		mu   sync.Mutex
+	}
+	// SecurityEventsHolder is a wrapper around a thread safe security events slice. The purpose of this struct is to be
+	// used by composition in an Operation to allow said operation to handle security events addition/retrieval.
+	// See httpsec/http.go and grpcsec/grpc.go.
+	SecurityEventsHolder struct {
+		events []json.RawMessage
+		mu     sync.RWMutex
+	}
+	// ContextKey is used as a key to store operations in the request's context (gRPC/HTTP)
+	ContextKey struct{}
+)
 
 // NewTagsHolder returns a new instance of a TagsHolder struct.
 func NewTagsHolder() TagsHolder {
@@ -42,14 +52,6 @@ func (m *TagsHolder) AddTag(k string, v interface{}) {
 // Tags returns the tags map
 func (m *TagsHolder) Tags() map[string]interface{} {
 	return m.tags
-}
-
-// SecurityEventsHolder is a wrapper around a thread safe security events slice. The purpose of this struct is to be
-// used by composition in an Operation to allow said operation to handle security events addition/retrieval.
-// See httpsec/http.go and grpcsec/grpc.go.
-type SecurityEventsHolder struct {
-	events []json.RawMessage
-	mu     sync.RWMutex
 }
 
 // AddSecurityEvents adds the security events to the collected events list.

--- a/internal/appsec/dyngo/instrumentation/grpcsec/actions.go
+++ b/internal/appsec/dyngo/instrumentation/grpcsec/actions.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation"
 )
@@ -56,7 +57,7 @@ func (h *ActionsHandler) Apply(id string, op *HandlerOperation) bool {
 	}
 	// Currently, only the "block_request" type is supported, so we only need to check for blockRequestParams
 	if p, ok := a.(*BlockRequestAction); ok {
-		op.BlockedCode = &p.Status
+		op.Error = status.Error(p.Status, "Request blocked")
 		op.AddTag(instrumentation.BlockedRequestTag, true)
 		return true
 	}

--- a/internal/appsec/dyngo/instrumentation/grpcsec/actions.go
+++ b/internal/appsec/dyngo/instrumentation/grpcsec/actions.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 
 	"google.golang.org/grpc/codes"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation"
 )
 
 // Action is used to identify any action kind
@@ -55,6 +57,7 @@ func (h *ActionsHandler) Apply(id string, op *HandlerOperation) bool {
 	// Currently, only the "block_request" type is supported, so we only need to check for blockRequestParams
 	if p, ok := a.(*BlockRequestAction); ok {
 		op.BlockedCode = &p.Status
+		op.AddTag(instrumentation.BlockedRequestTag, true)
 		return true
 	}
 	return false

--- a/internal/appsec/dyngo/instrumentation/grpcsec/grpc.go
+++ b/internal/appsec/dyngo/instrumentation/grpcsec/grpc.go
@@ -69,7 +69,6 @@ type (
 		// Corresponds to the address `grpc.server.request.message`.
 		Message interface{}
 	}
-	contextKey struct{}
 )
 
 // TODO(Julio-Guerra): create a go-generate tool to generate the types, vars and methods below
@@ -83,7 +82,7 @@ func StartHandlerOperation(ctx context.Context, args HandlerOperationArgs, paren
 		Operation:  dyngo.NewOperation(parent),
 		TagsHolder: instrumentation.NewTagsHolder(),
 	}
-	newCtx := context.WithValue(ctx, contextKey{}, op)
+	newCtx := context.WithValue(ctx, instrumentation.ContextKey{}, op)
 	dyngo.StartOperation(op, args)
 	return newCtx, op
 }
@@ -179,10 +178,4 @@ func (OnReceiveOperationFinish) ListenedType() reflect.Type { return receiveOper
 // on v whose type is the one returned by ListenedType().
 func (f OnReceiveOperationFinish) Call(op dyngo.Operation, v interface{}) {
 	f(op.(ReceiveOperation), v.(ReceiveOperationRes))
-}
-
-// FromContext returns the HandlerOperation object stored in the context, if any
-func FromContext(ctx context.Context) *HandlerOperation {
-	op, _ := ctx.Value(contextKey{}).(*HandlerOperation)
-	return op
 }

--- a/internal/appsec/dyngo/instrumentation/grpcsec/grpc.go
+++ b/internal/appsec/dyngo/instrumentation/grpcsec/grpc.go
@@ -16,8 +16,6 @@ import (
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation"
-
-	"google.golang.org/grpc/codes"
 )
 
 // Abstract gRPC server handler operation definitions. It is based on two
@@ -42,7 +40,7 @@ type (
 		dyngo.Operation
 		instrumentation.TagsHolder
 		instrumentation.SecurityEventsHolder
-		BlockedCode *codes.Code
+		Error error
 	}
 	// HandlerOperationArgs is the grpc handler arguments.
 	HandlerOperationArgs struct {

--- a/internal/appsec/dyngo/instrumentation/grpcsec/grpc_test.go
+++ b/internal/appsec/dyngo/instrumentation/grpcsec/grpc_test.go
@@ -6,6 +6,7 @@
 package grpcsec_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -57,7 +58,7 @@ func TestUsage(t *testing.T) {
 				}))
 			}))
 
-			rpcOp := grpcsec.StartHandlerOperation(grpcsec.HandlerOperationArgs{}, localRootOp)
+			_, rpcOp := grpcsec.StartHandlerOperation(context.Background(), grpcsec.HandlerOperationArgs{}, localRootOp)
 
 			for i := 1; i <= expectedRecvOperation; i++ {
 				recvOp := grpcsec.StartReceiveOperation(grpcsec.ReceiveOperationArgs{}, rpcOp)

--- a/internal/appsec/dyngo/instrumentation/httpsec/http.go
+++ b/internal/appsec/dyngo/instrumentation/httpsec/http.go
@@ -60,38 +60,19 @@ type (
 	// SDKBodyOperationRes is the SDK body operation results.
 	SDKBodyOperationRes struct{}
 
-	// UserIDOperationArgs is the user ID operation arguments.
-	UserIDOperationArgs struct {
-		UserID string
-	}
-
-	// UserIDOperationRes is the user ID operation results.
-	UserIDOperationRes struct{}
+	contextKey struct{}
 )
 
 // MonitorParsedBody starts and finishes the SDK body operation.
 // This function should not be called when AppSec is disabled in order to
 // get preciser error logs.
 func MonitorParsedBody(ctx context.Context, body interface{}) {
-	if parent := fromContext(ctx); parent != nil {
+	if parent := FromContext(ctx); parent != nil {
 		op := StartSDKBodyOperation(parent, SDKBodyOperationArgs{Body: body})
 		op.Finish()
 	} else {
 		log.Error("appsec: parsed http body monitoring ignored: could not find the http handler instrumentation metadata in the request context: the request handler is not being monitored by a middleware function or the provided context is not the expected request context")
 	}
-}
-
-// MonitorUser starts and finishes a UserID operation.
-// A call to the WAF is made to check the user ID and the returned value
-// indicates whether the user should be blocked or not.
-func MonitorUser(ctx context.Context, userID string) bool {
-	if parent := fromContext(ctx); parent != nil {
-		op := StartUserIDOperation(parent, UserIDOperationArgs{UserID: userID})
-		op.Finish()
-		return op.Block
-	}
-	log.Error("appsec: user ID monitoring ignored: could not find the http handler instrumentation metadata in the request context: the request handler is not being monitored by a middleware function or the provided context is not the expected request context")
-	return false
 }
 
 // applyActions executes the operation's actions and returns the resulting http handler
@@ -204,14 +185,6 @@ type (
 	SDKBodyOperation struct {
 		dyngo.Operation
 	}
-
-	// UserIDOperation type representing a call to appsec.SetUser(). It must be created with
-	// StartUserIDOperation() and finished with its Finish() method.
-	UserIDOperation struct {
-		dyngo.Operation
-		Block bool
-	}
-	contextKey struct{}
 )
 
 // StartOperation starts an HTTP handler operation, along with the given
@@ -228,7 +201,8 @@ func StartOperation(ctx context.Context, args HandlerOperationArgs) (context.Con
 	return newCtx, op
 }
 
-func fromContext(ctx context.Context) *Operation {
+// FromContext returns the Operation object stored in the context, if any
+func FromContext(ctx context.Context) *Operation {
 	// Avoid a runtime panic in case of type-assertion error by collecting the 2 return values
 	op, _ := ctx.Value(contextKey{}).(*Operation)
 	return op
@@ -274,16 +248,6 @@ func (op *SDKBodyOperation) Finish() {
 	dyngo.FinishOperation(op, SDKBodyOperationRes{})
 }
 
-func StartUserIDOperation(parent *Operation, args UserIDOperationArgs) *UserIDOperation {
-	op := &UserIDOperation{Operation: dyngo.NewOperation(parent)}
-	dyngo.StartOperation(op, args)
-	return op
-}
-
-func (op *UserIDOperation) Finish() {
-	dyngo.FinishOperation(op, UserIDOperationRes{})
-}
-
 // HTTP handler operation's start and finish event callback function types.
 type (
 	// OnHandlerOperationStart function type, called when an HTTP handler
@@ -298,9 +262,6 @@ type (
 	// OnSDKBodyOperationFinish function type, called when an SDK body
 	// operation finishes.
 	OnSDKBodyOperationFinish func(*SDKBodyOperation, SDKBodyOperationRes)
-	// OnUserIDOperationStart function type, called when a user ID
-	// operation starts.
-	OnUserIDOperationStart func(operation *UserIDOperation, args UserIDOperationArgs)
 )
 
 var (
@@ -308,7 +269,6 @@ var (
 	handlerOperationResType  = reflect.TypeOf((*HandlerOperationRes)(nil)).Elem()
 	sdkBodyOperationArgsType = reflect.TypeOf((*SDKBodyOperationArgs)(nil)).Elem()
 	sdkBodyOperationResType  = reflect.TypeOf((*SDKBodyOperationRes)(nil)).Elem()
-	userIDOperationArgsType  = reflect.TypeOf((*UserIDOperationArgs)(nil)).Elem()
 )
 
 // ListenedType returns the type a OnHandlerOperationStart event listener
@@ -349,13 +309,6 @@ func (OnSDKBodyOperationFinish) ListenedType() reflect.Type { return sdkBodyOper
 // type-assertion on v whose type is the one returned by ListenedType().
 func (f OnSDKBodyOperationFinish) Call(op dyngo.Operation, v interface{}) {
 	f(op.(*SDKBodyOperation), v.(SDKBodyOperationRes))
-}
-
-// ListenedType returns the type a OnUserIDOperationStart event listener
-// listens to, which is the UserIDOperationStartArgs type.
-func (OnUserIDOperationStart) ListenedType() reflect.Type { return userIDOperationArgsType }
-func (f OnUserIDOperationStart) Call(op dyngo.Operation, v interface{}) {
-	f(op.(*UserIDOperation), v.(UserIDOperationArgs))
 }
 
 // blockedTemplateJSON is the default JSON template used to write responses for blocked requests

--- a/internal/appsec/dyngo/instrumentation/httpsec/http.go
+++ b/internal/appsec/dyngo/instrumentation/httpsec/http.go
@@ -59,15 +59,13 @@ type (
 
 	// SDKBodyOperationRes is the SDK body operation results.
 	SDKBodyOperationRes struct{}
-
-	contextKey struct{}
 )
 
 // MonitorParsedBody starts and finishes the SDK body operation.
 // This function should not be called when AppSec is disabled in order to
 // get preciser error logs.
 func MonitorParsedBody(ctx context.Context, body interface{}) {
-	if parent := FromContext(ctx); parent != nil {
+	if parent := fromContext(ctx); parent != nil {
 		op := StartSDKBodyOperation(parent, SDKBodyOperationArgs{Body: body})
 		op.Finish()
 	} else {
@@ -196,15 +194,15 @@ func StartOperation(ctx context.Context, args HandlerOperationArgs) (context.Con
 		Operation:  dyngo.NewOperation(nil),
 		TagsHolder: instrumentation.NewTagsHolder(),
 	}
-	newCtx := context.WithValue(ctx, contextKey{}, op)
+	newCtx := context.WithValue(ctx, instrumentation.ContextKey{}, op)
 	dyngo.StartOperation(op, args)
 	return newCtx, op
 }
 
-// FromContext returns the Operation object stored in the context, if any
-func FromContext(ctx context.Context) *Operation {
+// fromContext returns the Operation object stored in the context, if any
+func fromContext(ctx context.Context) *Operation {
 	// Avoid a runtime panic in case of type-assertion error by collecting the 2 return values
-	op, _ := ctx.Value(contextKey{}).(*Operation)
+	op, _ := ctx.Value(instrumentation.ContextKey{}).(*Operation)
 	return op
 }
 

--- a/internal/appsec/dyngo/instrumentation/httpsec/tags.go
+++ b/internal/appsec/dyngo/instrumentation/httpsec/tags.go
@@ -24,9 +24,6 @@ const (
 	// multipleIPHeadersTag sets the multiple ip header tag used internally to tell the backend an error occurred when
 	// retrieving an HTTP request client IP.
 	multipleIPHeadersTag = "_dd.multiple-ip-headers"
-
-	// BlockedRequestTag used to convey whether a request is blocked
-	BlockedRequestTag = "appsec.blocked"
 )
 
 var (

--- a/internal/appsec/dyngo/instrumentation/sharedsec/shared.go
+++ b/internal/appsec/dyngo/instrumentation/sharedsec/shared.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023 Datadog, Inc.
+
+package sharedsec
+
+import (
+	"context"
+	"reflect"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation/grpcsec"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation/httpsec"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+)
+
+type (
+	// UserIDOperation type representing a call to appsec.SetUser(). It must be created with
+	// StartUserIDOperation() and finished with its Finish() method.
+	UserIDOperation struct {
+		dyngo.Operation
+		Block bool
+	}
+	// UserIDOperationArgs is the user ID operation arguments.
+	UserIDOperationArgs struct {
+		UserID string
+	}
+	// UserIDOperationRes is the user ID operation results.
+	UserIDOperationRes struct{}
+
+	// OnUserIDOperationStart function type, called when a user ID
+	// operation starts.
+	OnUserIDOperationStart func(operation *UserIDOperation, args UserIDOperationArgs)
+)
+
+var userIDOperationArgsType = reflect.TypeOf((*UserIDOperationArgs)(nil)).Elem()
+
+func StartUserIDOperation(parent dyngo.Operation, args UserIDOperationArgs) *UserIDOperation {
+	op := &UserIDOperation{Operation: dyngo.NewOperation(parent)}
+	dyngo.StartOperation(op, args)
+	return op
+}
+
+func (op *UserIDOperation) Finish() {
+	dyngo.FinishOperation(op, UserIDOperationRes{})
+}
+
+// ListenedType returns the type a OnUserIDOperationStart event listener
+// listens to, which is the UserIDOperationStartArgs type.
+func (OnUserIDOperationStart) ListenedType() reflect.Type { return userIDOperationArgsType }
+
+// OnUserIDOperationStart function type, called when a user ID
+// operation starts.
+func (f OnUserIDOperationStart) Call(op dyngo.Operation, v interface{}) {
+	f(op.(*UserIDOperation), v.(UserIDOperationArgs))
+}
+
+// MonitorUser starts and finishes a UserID operation.
+// A call to the WAF is made to check the user ID and the returned value
+// indicates whether the user should be blocked or not.
+func MonitorUser(ctx context.Context, userID string) bool {
+	if parent := fromContext(ctx); parent != nil {
+		op := StartUserIDOperation(parent, UserIDOperationArgs{UserID: userID})
+		op.Finish()
+		return op.Block
+	}
+	log.Error("appsec: user ID monitoring ignored: could not find the http handler instrumentation metadata in the request context: the request handler is not being monitored by a middleware function or the provided context is not the expected request context")
+	return false
+
+}
+
+func fromContext(ctx context.Context) dyngo.Operation {
+	// Avoid a runtime panic in case of type-assertion error by collecting the 2 return values
+	// HTTP context
+	if op := httpsec.FromContext(ctx); op != nil {
+		return op
+	}
+	return grpcsec.FromContext(ctx)
+}

--- a/internal/appsec/dyngo/instrumentation/sharedsec/shared.go
+++ b/internal/appsec/dyngo/instrumentation/sharedsec/shared.go
@@ -50,8 +50,8 @@ func (op *UserIDOperation) Finish() {
 // listens to, which is the UserIDOperationStartArgs type.
 func (OnUserIDOperationStart) ListenedType() reflect.Type { return userIDOperationArgsType }
 
-// OnUserIDOperationStart function type, called when a user ID
-// operation starts.
+// Call the underlying event listener function by performing the type-assertion
+// on v whose type is the one returned by ListenedType().
 func (f OnUserIDOperationStart) Call(op dyngo.Operation, v interface{}) {
 	f(op.(*UserIDOperation), v.(UserIDOperationArgs))
 }

--- a/internal/appsec/dyngo/instrumentation/sharedsec/shared.go
+++ b/internal/appsec/dyngo/instrumentation/sharedsec/shared.go
@@ -36,12 +36,14 @@ type (
 
 var userIDOperationArgsType = reflect.TypeOf((*UserIDOperationArgs)(nil)).Elem()
 
+// StartUserIDOperation starts the UserID operation and emits a dyngo start event
 func StartUserIDOperation(parent dyngo.Operation, args UserIDOperationArgs) *UserIDOperation {
 	op := &UserIDOperation{Operation: dyngo.NewOperation(parent)}
 	dyngo.StartOperation(op, args)
 	return op
 }
 
+// Finish finishes the UserID operation and emits a dyngo finish event
 func (op *UserIDOperation) Finish() {
 	dyngo.FinishOperation(op, UserIDOperationRes{})
 }

--- a/internal/appsec/dyngo/instrumentation/sharedsec/shared.go
+++ b/internal/appsec/dyngo/instrumentation/sharedsec/shared.go
@@ -10,8 +10,7 @@ import (
 	"reflect"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation/grpcsec"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation/httpsec"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 )
 
@@ -62,7 +61,7 @@ func (f OnUserIDOperationStart) Call(op dyngo.Operation, v interface{}) {
 // A call to the WAF is made to check the user ID and the returned value
 // indicates whether the user should be blocked or not.
 func MonitorUser(ctx context.Context, userID string) bool {
-	if parent := fromContext(ctx); parent != nil {
+	if parent, ok := ctx.Value(instrumentation.ContextKey{}).(dyngo.Operation); ok {
 		op := StartUserIDOperation(parent, UserIDOperationArgs{UserID: userID})
 		op.Finish()
 		return op.Block
@@ -70,13 +69,4 @@ func MonitorUser(ctx context.Context, userID string) bool {
 	log.Error("appsec: user ID monitoring ignored: could not find the http handler instrumentation metadata in the request context: the request handler is not being monitored by a middleware function or the provided context is not the expected request context")
 	return false
 
-}
-
-func fromContext(ctx context.Context) dyngo.Operation {
-	// Avoid a runtime panic in case of type-assertion error by collecting the 2 return values
-	// HTTP context
-	if op := httpsec.FromContext(ctx); op != nil {
-		return op
-	}
-	return grpcsec.FromContext(ctx)
 }

--- a/internal/appsec/dyngo/operation.go
+++ b/internal/appsec/dyngo/operation.go
@@ -101,23 +101,24 @@ type operation struct {
 // and finish functions. The following example shows how to wrap an operation
 // so that its functions are statically typed (instead of dyngo's interface{}
 // values):
-//   package mypackage
-//   import "dyngo"
-//   type (
-//     MyOperation struct {
-//       dyngo.Operation
-//     }
-//     MyOperationArgs { /* ... */ }
-//     MyOperationRes { /* ... */ }
-//   )
-//   func StartOperation(args MyOperationArgs, parent dyngo.Operation) MyOperation {
-//     op := MyOperation{Operation: dyngo.NewOperation(parent)}
-//     dyngo.StartOperation(op, args)
-//     return op
-//   }
-//   func (op MyOperation) Finish(res MyOperationRes) {
-//       dyngo.FinishOperation(op, res)
-//     }
+//
+//	package mypackage
+//	import "dyngo"
+//	type (
+//	  MyOperation struct {
+//	    dyngo.Operation
+//	  }
+//	  MyOperationArgs { /* ... */ }
+//	  MyOperationRes { /* ... */ }
+//	)
+//	func StartOperation(args MyOperationArgs, parent dyngo.Operation) MyOperation {
+//	  op := MyOperation{Operation: dyngo.NewOperation(parent)}
+//	  dyngo.StartOperation(op, args)
+//	  return op
+//	}
+//	func (op MyOperation) Finish(res MyOperationRes) {
+//	    dyngo.FinishOperation(op, res)
+//	  }
 func NewOperation(parent Operation) Operation {
 	if parent == nil {
 		parent = rootOperation
@@ -213,9 +214,10 @@ func (o *operation) register(l ...EventListener) UnregisterFunc {
 // On registers the event listener. The difference with the Register() is that
 // it doesn't return a function closure, which avoids unnecessary allocations
 // For example:
-//     op.On(MyOperationStart(func (op MyOperation, args MyOperationArgs) {
-//         // ...
-//     }))
+//
+//	op.On(MyOperationStart(func (op MyOperation, args MyOperationArgs) {
+//	    // ...
+//	}))
 func (o *operation) On(l EventListener) {
 	o.mu.RLock()
 	defer o.mu.RUnlock()

--- a/internal/appsec/remoteconfig.go
+++ b/internal/appsec/remoteconfig.go
@@ -238,6 +238,7 @@ func (a *appsec) enableRCBlocking(handle wafHandleWrapper) error {
 	}
 	a.registerRCProduct(rc.ProductASMData)
 	a.registerRCCapability(remoteconfig.ASMIPBlocking)
+	a.registerRCCapability(remoteconfig.ASMUserBlocking)
 	a.registerRCCallback(handle.asmDataCallback, rc.ProductASMData)
 	return nil
 }

--- a/internal/appsec/testdata/blocking.json
+++ b/internal/appsec/testdata/blocking.json
@@ -28,6 +28,31 @@
             "on_match": [
                 "block"
             ]
+        },
+        {
+            "id": "blk-001-002",
+            "name": "Block User Addresses",
+            "tags": {
+                "type": "block_user",
+                "category": "security_response"
+            },
+            "conditions": [
+                {
+                    "parameters": {
+                        "inputs": [
+                            {
+                                "address": "usr.id"
+                            }
+                        ],
+                        "data": "blocked_users"
+                    },
+                    "operator": "exact_match"
+                }
+            ],
+            "transformers": [],
+            "on_match": [
+                "block"
+            ]
         }
     ],
     "rules_data": [
@@ -36,6 +61,13 @@
             "type": "ip_with_expiration",
             "data": [
                 { "value": "1.2.3.4" }
+            ]
+        },
+        {
+            "id": "blocked_users",
+            "type": "data_with_expiration",
+            "data": [
+                { "value": "blocked-user-1" }
             ]
         }
     ]

--- a/internal/appsec/testdata/blocking.json
+++ b/internal/appsec/testdata/blocking.json
@@ -53,6 +53,56 @@
             "on_match": [
                 "block"
             ]
+        },
+        {
+            "id": "crs-941-110",
+            "name": "XSS Filter - Category 1: Script Tag Vector",
+            "tags": {
+                "type": "xss",
+                "crs_id": "941110",
+                "category": "attack_attempt",
+                "confidence": "1"
+            },
+            "conditions": [
+                {
+                    "parameters": {
+                        "inputs": [
+                            {
+                                "address": "server.request.headers.no_cookies",
+                                "key_path": [
+                                    "user-agent"
+                                ]
+                            },
+                            {
+                                "address": "server.request.headers.no_cookies",
+                                "key_path": [
+                                    "referer"
+                                ]
+                            },
+                            {
+                                "address": "server.request.query"
+                            },
+                            {
+                                "address": "server.request.body"
+                            },
+                            {
+                                "address": "server.request.path_params"
+                            },
+                            {
+                                "address": "grpc.server.request.message"
+                            }
+                        ],
+                        "regex": "<script[^>]*>[\\s\\S]*?",
+                        "options": {
+                            "min_length": 8
+                        }
+                    },
+                    "operator": "match_regex"
+                }
+            ],
+            "transformers": [
+                "removeNulls"
+            ]
         }
     ],
     "rules_data": [

--- a/internal/appsec/waf.go
+++ b/internal/appsec/waf.go
@@ -114,6 +114,7 @@ func newHTTPWAFEventListener(handle *waf.Handle, addresses []string, timeout tim
 		// see if the associated user should be blocked. Since we don't control the execution flow in this case
 		// (SetUser is SDK), we delegate the responsibility of interrupting the handler to the user.
 		op.On(httpsec.OnUserIDOperationStart(func(operation *httpsec.UserIDOperation, args httpsec.UserIDOperationArgs) {
+			values := map[string]interface{}{}
 			for _, addr := range addresses {
 				if addr == userIDAddr {
 					values[userIDAddr] = args.UserID

--- a/internal/appsec/waf.go
+++ b/internal/appsec/waf.go
@@ -337,6 +337,7 @@ const (
 	serverRequestBodyAddr             = "server.request.body"
 	serverResponseStatusAddr          = "server.response.status"
 	httpClientIPAddr                  = "http.client_ip"
+	userID                            = "usr.id"
 )
 
 // List of HTTP rule addresses currently supported by the WAF
@@ -349,6 +350,7 @@ var httpAddresses = []string{
 	serverRequestBodyAddr,
 	serverResponseStatusAddr,
 	httpClientIPAddr,
+	userID,
 }
 
 // gRPC rule addresses currently supported by the WAF
@@ -362,6 +364,7 @@ var grpcAddresses = []string{
 	grpcServerRequestMessage,
 	grpcServerRequestMetadata,
 	httpClientIPAddr,
+	userID,
 }
 
 func init() {

--- a/internal/appsec/waf.go
+++ b/internal/appsec/waf.go
@@ -104,7 +104,6 @@ func newHTTPWAFEventListener(handle *waf.Handle, addresses []string, timeout tim
 
 	return httpsec.OnHandlerOperationStart(func(op *httpsec.Operation, args httpsec.HandlerOperationArgs) {
 		var body interface{}
-		values := map[string]interface{}{}
 		wafCtx := waf.NewContext(handle)
 		if wafCtx == nil {
 			// The WAF event listener got concurrently released
@@ -131,6 +130,7 @@ func newHTTPWAFEventListener(handle *waf.Handle, addresses []string, timeout tim
 			}
 		}))
 
+		values := map[string]interface{}{}
 		for _, addr := range addresses {
 			switch addr {
 			case httpClientIPAddr:
@@ -263,7 +263,7 @@ func newGRPCWAFEventListener(handle *waf.Handle, addresses []string, timeout tim
 					operation.Block = actionHandler.Apply(id, op) || operation.Block
 				}
 				op.AddSecurityEvents(matches)
-				log.Debug("appsec: WAF detected a suspicious user: %s", args.UserID)
+				log.Debug("appsec: WAF detected an authenticated user attack: %s", args.UserID)
 			}
 		}))
 

--- a/internal/appsec/waf_test.go
+++ b/internal/appsec/waf_test.go
@@ -173,10 +173,9 @@ func TestWAF(t *testing.T) {
 	})
 }
 
-// Test that http blocking works by using custom rules/rules data
+// Test that request blocking works by using custom rules/rules data
 func TestBlocking(t *testing.T) {
 	t.Setenv("DD_APPSEC_RULES", "testdata/blocking.json")
-
 	appsec.Start()
 	defer appsec.Stop()
 	if !appsec.Enabled() {
@@ -185,54 +184,80 @@ func TestBlocking(t *testing.T) {
 
 	// Start and trace an HTTP server
 	mux := httptrace.NewServeMux()
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/ip", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Hello World!\n"))
+	})
+	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
+		if err := pAppsec.SetUser(r.Context(), r.Header.Get("test-usr")); err != nil && err.ShouldBlock() {
+			return
+		}
 		w.Write([]byte("Hello World!\n"))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	t.Run("block", func(t *testing.T) {
-		mt := mocktracer.Start()
-		defer mt.Stop()
-
-		req, err := http.NewRequest("POST", srv.URL, nil)
-		if err != nil {
-			panic(err)
-		}
-		// Hardcoded IP header holding an IP that is blocked
-		req.Header.Set("x-forwarded-for", "1.2.3.4")
-		res, err := srv.Client().Do(req)
-		require.NoError(t, err)
-
-		// Check that the request was blocked
-		b, err := io.ReadAll(res.Body)
-		require.NoError(t, err)
-		require.NotEqual(t, "Hello World!\n", string(b))
-		require.Equal(t, 403, res.StatusCode)
-	})
-
-	t.Run("no-block", func(t *testing.T) {
-		mt := mocktracer.Start()
-		defer mt.Stop()
-
-		req1, err := http.NewRequest("POST", srv.URL, nil)
-		if err != nil {
-			panic(err)
-		}
-		req2, err := http.NewRequest("POST", srv.URL, nil)
-		if err != nil {
-			panic(err)
-		}
-		req2.Header.Set("x-forwarded-for", "1.2.3.5")
-
-		for _, r := range []*http.Request{req1, req2} {
-			res, err := srv.Client().Do(r)
+	for _, tc := range []struct {
+		name     string
+		headers  map[string]string
+		endpoint string
+		status   int
+	}{
+		{
+			name:     "ip/no-block/no-ip",
+			endpoint: "/ip",
+			status:   200,
+		},
+		{
+			name:     "ip/no-block/good-ip",
+			endpoint: "/ip",
+			headers:  map[string]string{"x-forwarded-for": "1.2.3.5"},
+			status:   200,
+		},
+		{
+			name:     "ip/block",
+			headers:  map[string]string{"x-forwarded-for": "1.2.3.4"},
+			endpoint: "/ip",
+			status:   403,
+		},
+		{
+			name:     "user/no-block/no-user",
+			endpoint: "/user",
+			status:   200,
+		},
+		{
+			name:     "user/no-block/legit-user",
+			headers:  map[string]string{"test-usr": "legit-user"},
+			endpoint: "/user",
+			status:   200,
+		},
+		{
+			name:     "user/block",
+			headers:  map[string]string{"test-usr": "blocked-user-1"},
+			endpoint: "/user",
+			status:   403,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mt := mocktracer.Start()
+			defer mt.Stop()
+			req, err := http.NewRequest("POST", srv.URL+tc.endpoint, nil)
+			if err != nil {
+				panic(err)
+			}
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+			res, err := srv.Client().Do(req)
 			require.NoError(t, err)
-			// Check that the request was not blocked
+			require.Equal(t, tc.status, res.StatusCode)
 			b, err := io.ReadAll(res.Body)
 			require.NoError(t, err)
-			require.Equal(t, "Hello World!\n", string(b))
+			if tc.status == 200 {
+				require.Equal(t, "Hello World!\n", string(b))
+			} else {
+				require.NotEqual(t, "Hello World!\n", string(b))
+			}
 
-		}
-	})
+		})
+	}
 }

--- a/internal/appsec/waf_test.go
+++ b/internal/appsec/waf_test.go
@@ -188,7 +188,7 @@ func TestBlocking(t *testing.T) {
 		w.Write([]byte("Hello World!\n"))
 	})
 	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
-		if err := pAppsec.SetUser(r.Context(), r.Header.Get("test-usr")); err != nil && err.ShouldBlock() {
+		if err := pAppsec.SetUser(r.Context(), r.Header.Get("test-usr")); err != nil {
 			return
 		}
 		w.Write([]byte("Hello World!\n"))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.
-->
### What does this PR do?

This change adds a new SDK to the appsec top level package, `SetUser()`. `SetUser()` wraps the existing `tracer.SetUser()`
and performs a WAF call to check if the user ID passed to `SetUser` is on a block list, in which case an error is returned,
instructing the SDK user to block the request execution as soon as possible.

Additionally:
- A new remote configuration capability is added - `ASMUserBlocking`, and registered during remote config initialization by appsec
- `TrackUserLoginSuccessEvent()` now uses `appsec.SetUser()` and returns an error if the user should be blocked

### Motivation

This is a planned feature.

### Describe how to test/QA your changes

The change includes integration tests to test both the high level API usage (in the appsec package) and
the internal mechanics (internal/appsec), as well as the gRPC integration (contrib/google.golang.org/grpc).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.