### PR TITLE
contrib: add db.system tag for all db integrations

### DIFF
--- a/contrib/bradfitz/gomemcache/memcache/memcache.go
+++ b/contrib/bradfitz/gomemcache/memcache/memcache.go
@@ -71,6 +71,7 @@ func (c *Client) startSpan(resourceName string) ddtrace.Span {
 		tracer.ResourceName(resourceName),
 		tracer.Tag(ext.Component, "bradfitz/gomemcache/memcache"),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
+		tracer.Tag(ext.DBSystem, ext.DBSystemMemcached),
 	}
 	if !math.IsNaN(c.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, c.cfg.analyticsRate))

--- a/contrib/bradfitz/gomemcache/memcache/memcache_test.go
+++ b/contrib/bradfitz/gomemcache/memcache/memcache_test.go
@@ -54,6 +54,8 @@ func testMemcache(t *testing.T, addr string) {
 			"component should be set to gomemcache")
 		assert.Equal(t, ext.SpanKindClient, span.Tag(ext.SpanKind),
 			"span.kind should be set to client")
+		assert.Equal(t, "memcached", span.Tag(ext.DBSystem),
+			"db.system should be set to memcached")
 	}
 
 	t.Run("default", func(t *testing.T) {

--- a/contrib/database/sql/conn.go
+++ b/contrib/database/sql/conn.go
@@ -228,6 +228,8 @@ func (tp *traceParams) tryTrace(ctx context.Context, qtype queryType, query stri
 		tracer.StartTime(startTime),
 		tracer.Tag(ext.Component, "database/sql"),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
+		// set a default value for this tag which will be overwritten later if set in the metadata.
+		tracer.Tag(ext.DBSystem, ext.DBSystemOtherSQL),
 	)
 	if tp.cfg.tags != nil {
 		for key, tag := range tp.cfg.tags {

--- a/contrib/database/sql/conn_test.go
+++ b/contrib/database/sql/conn_test.go
@@ -29,8 +29,9 @@ func TestWithSpanTags(t *testing.T) {
 		opts   []RegisterOption
 	}
 	type want struct {
-		opName  string
-		ctxTags map[string]string
+		opName   string
+		ctxTags  map[string]string
+		dbSystem string
 	}
 	testcases := []struct {
 		name        string
@@ -52,6 +53,7 @@ func TestWithSpanTags(t *testing.T) {
 					"mysql_tag2": "mysql_value2",
 					"mysql_tag3": "mysql_value3",
 				},
+				dbSystem: "mysql",
 			},
 		},
 		{
@@ -71,6 +73,7 @@ func TestWithSpanTags(t *testing.T) {
 					"pg_tag1": "pg_value1",
 					"pg_tag2": "pg_value2",
 				},
+				dbSystem: "postgresql",
 			},
 		},
 	}
@@ -104,6 +107,7 @@ func TestWithSpanTags(t *testing.T) {
 			}
 			assert.Equal(t, ext.SpanKindClient, connectSpan.Tag(ext.SpanKind))
 			assert.Equal(t, "database/sql", connectSpan.Tag(ext.Component))
+			assert.Equal(t, tt.want.dbSystem, connectSpan.Tag(ext.DBSystem))
 
 			span := spans[1]
 			assert.Equal(t, tt.want.opName, span.OperationName())
@@ -112,6 +116,7 @@ func TestWithSpanTags(t *testing.T) {
 			}
 			assert.Equal(t, ext.SpanKindClient, span.Tag(ext.SpanKind))
 			assert.Equal(t, "database/sql", span.Tag(ext.Component))
+			assert.Equal(t, tt.want.dbSystem, connectSpan.Tag(ext.DBSystem))
 		})
 	}
 }
@@ -216,6 +221,7 @@ func TestWithCustomTag(t *testing.T) {
 	type want struct {
 		opName     string
 		customTags map[string]interface{}
+		dbSystem   string
 	}
 	testcases := []struct {
 		name        string
@@ -236,6 +242,7 @@ func TestWithCustomTag(t *testing.T) {
 					"foo": "bar",
 					"baz": 123,
 				},
+				dbSystem: ext.DBSystemMySQL,
 			},
 			options: []Option{
 				WithCustomTag("foo", "bar"),
@@ -255,6 +262,7 @@ func TestWithCustomTag(t *testing.T) {
 					"foo": "bar",
 					"baz": 123,
 				},
+				dbSystem: "postgresql",
 			},
 			options: []Option{
 				WithCustomTag("foo", "bar"),
@@ -290,6 +298,7 @@ func TestWithCustomTag(t *testing.T) {
 			}
 			assert.Equal(t, ext.SpanKindClient, connectSpan.Tag(ext.SpanKind))
 			assert.Equal(t, "database/sql", connectSpan.Tag(ext.Component))
+			assert.Equal(t, tt.want.dbSystem, connectSpan.Tag(ext.DBSystem))
 
 			span := spans[1]
 			assert.Equal(t, tt.want.opName, span.OperationName())
@@ -298,6 +307,7 @@ func TestWithCustomTag(t *testing.T) {
 			}
 			assert.Equal(t, ext.SpanKindClient, connectSpan.Tag(ext.SpanKind))
 			assert.Equal(t, "database/sql", connectSpan.Tag(ext.Component))
+			assert.Equal(t, tt.want.dbSystem, connectSpan.Tag(ext.DBSystem))
 		})
 	}
 }

--- a/contrib/database/sql/internal/dsn.go
+++ b/contrib/database/sql/internal/dsn.go
@@ -12,8 +12,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 )
 
-// ParseDSN parses various supported DSN types (currently mysql and postgres) into a
-// map of key/value pairs which can be used as valid tags.
+// ParseDSN parses various supported DSN types into a map of key/value pairs which can be used as valid tags.
 func ParseDSN(driverName, dsn string) (meta map[string]string, err error) {
 	meta = make(map[string]string)
 	switch driverName {
@@ -22,16 +21,19 @@ func ParseDSN(driverName, dsn string) (meta map[string]string, err error) {
 		if err != nil {
 			return
 		}
+		meta[ext.DBSystem] = ext.DBSystemMySQL
 	case "postgres", "pgx":
 		meta, err = parsePostgresDSN(dsn)
 		if err != nil {
 			return
 		}
+		meta[ext.DBSystem] = ext.DBSystemPostgreSQL
 	case "sqlserver":
 		meta, err = parseSQLServerDSN(dsn)
 		if err != nil {
 			return
 		}
+		meta[ext.DBSystem] = ext.DBSystemMicrosoftSQLServer
 	default:
 		// not supported
 	}
@@ -47,6 +49,7 @@ func reduceKeys(meta map[string]string) map[string]string {
 		"dbname":           ext.DBName,
 		"host":             ext.TargetHost,
 		"port":             ext.TargetPort,
+		ext.DBSystem:       ext.DBSystem,
 	}
 	m := make(map[string]string)
 	for k, v := range meta {

--- a/contrib/database/sql/internal/dsn_test.go
+++ b/contrib/database/sql/internal/dsn_test.go
@@ -28,6 +28,7 @@ func TestParseDSN(t *testing.T) {
 				ext.TargetHost: "1.2.3.4",
 				ext.TargetPort: "5432",
 				ext.DBName:     "mydb",
+				ext.DBSystem:   "postgresql",
 			},
 		},
 		{
@@ -38,6 +39,7 @@ func TestParseDSN(t *testing.T) {
 				ext.DBUser:     "bob",
 				ext.TargetHost: "1.2.3.4",
 				ext.TargetPort: "5432",
+				ext.DBSystem:   "mysql",
 			},
 		},
 		{
@@ -49,6 +51,7 @@ func TestParseDSN(t *testing.T) {
 				ext.DBName:        "dogdatastaging",
 				ext.DBApplication: "trace-api",
 				ext.DBUser:        "dog",
+				ext.DBSystem:      "postgresql",
 			},
 		},
 		{
@@ -59,6 +62,7 @@ func TestParseDSN(t *testing.T) {
 				ext.TargetHost: "1.2.3.4",
 				ext.TargetPort: "1433",
 				ext.DBName:     "mydb",
+				ext.DBSystem:   "mssql",
 			},
 		},
 	} {

--- a/contrib/database/sql/sql_test.go
+++ b/contrib/database/sql/sql_test.go
@@ -62,6 +62,7 @@ func TestSqlServer(t *testing.T) {
 			ext.DBUser:          "sa",
 			ext.DBName:          "master",
 			ext.EventSampleRate: nil,
+			ext.DBSystem:        "mssql",
 		},
 	}
 	sqltest.RunAll(t, testConfig)
@@ -88,6 +89,7 @@ func TestMySQL(t *testing.T) {
 			ext.DBUser:          "test",
 			ext.DBName:          "test",
 			ext.EventSampleRate: nil,
+			ext.DBSystem:        "mysql",
 		},
 	}
 	sqltest.RunAll(t, testConfig)
@@ -114,6 +116,7 @@ func TestPostgres(t *testing.T) {
 			ext.DBUser:          "postgres",
 			ext.DBName:          "postgres",
 			ext.EventSampleRate: 0.2,
+			ext.DBSystem:        "postgresql",
 		},
 	}
 	sqltest.RunAll(t, testConfig)
@@ -145,6 +148,7 @@ func TestOpenOptions(t *testing.T) {
 				ext.DBUser:          "postgres",
 				ext.DBName:          "postgres",
 				ext.EventSampleRate: 1.0,
+				ext.DBSystem:        "postgresql",
 			},
 		}
 		sqltest.RunAll(t, testConfig)
@@ -171,6 +175,7 @@ func TestOpenOptions(t *testing.T) {
 				ext.DBUser:          nil,
 				ext.DBName:          nil,
 				ext.EventSampleRate: 0.2,
+				ext.DBSystem:        "other_sql",
 			},
 		}
 		sqltest.RunAll(t, testConfig)
@@ -198,6 +203,7 @@ func TestOpenOptions(t *testing.T) {
 				ext.DBUser:          "postgres",
 				ext.DBName:          "postgres",
 				ext.EventSampleRate: 0.2,
+				ext.DBSystem:        "postgresql",
 			},
 		}
 		sqltest.RunAll(t, testConfig)

--- a/contrib/elastic/go-elasticsearch.v6/elastictrace.go
+++ b/contrib/elastic/go-elasticsearch.v6/elastictrace.go
@@ -59,6 +59,7 @@ func (t *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		tracer.Tag("elasticsearch.params", req.URL.Query().Encode()),
 		tracer.Tag(ext.Component, "elastic/go-elasticsearch.v6"),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
+		tracer.Tag(ext.DBSystem, ext.DBSystemElasticsearch),
 	}
 	if !math.IsNaN(t.config.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, t.config.analyticsRate))

--- a/contrib/elastic/go-elasticsearch.v6/elastictrace_test.go
+++ b/contrib/elastic/go-elasticsearch.v6/elastictrace_test.go
@@ -44,6 +44,7 @@ func checkPUTTrace(assert *assert.Assertions, mt mocktracer.Tracer) {
 	assert.Equal(`{"user": "test", "message": "hello"}`, span.Tag("elasticsearch.body"))
 	assert.Equal("elastic/go-elasticsearch.v6", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+	assert.Equal("elasticsearch", span.Tag(ext.DBSystem))
 }
 
 func checkGETTrace(assert *assert.Assertions, mt mocktracer.Tracer) {
@@ -54,6 +55,7 @@ func checkGETTrace(assert *assert.Assertions, mt mocktracer.Tracer) {
 	assert.Equal("GET", span.Tag("elasticsearch.method"))
 	assert.Equal("elastic/go-elasticsearch.v6", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+	assert.Equal("elasticsearch", span.Tag(ext.DBSystem))
 }
 
 func checkErrTrace(assert *assert.Assertions, mt mocktracer.Tracer) {
@@ -65,6 +67,7 @@ func checkErrTrace(assert *assert.Assertions, mt mocktracer.Tracer) {
 	assert.Equal("*errors.errorString", fmt.Sprintf("%T", span.Tag(ext.Error).(error)))
 	assert.Equal("elastic/go-elasticsearch.v6", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+	assert.Equal("elasticsearch", span.Tag(ext.DBSystem))
 }
 
 func TestQuantize(t *testing.T) {

--- a/contrib/garyburd/redigo/redigo.go
+++ b/contrib/garyburd/redigo/redigo.go
@@ -105,6 +105,7 @@ func (tc Conn) newChildSpan(ctx context.Context) ddtrace.Span {
 		tracer.ServiceName(p.config.serviceName),
 		tracer.Tag(ext.Component, "garyburd/redigo"),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
+		tracer.Tag(ext.DBSystem, ext.DBSystemRedis),
 	}
 	if !math.IsNaN(p.config.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, p.config.analyticsRate))

--- a/contrib/garyburd/redigo/redigo_test.go
+++ b/contrib/garyburd/redigo/redigo_test.go
@@ -51,6 +51,7 @@ func TestClient(t *testing.T) {
 	assert.Equal("2", span.Tag("redis.args_length"))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
 	assert.Equal("garyburd/redigo", span.Tag(ext.Component))
+	assert.Equal("redis", span.Tag(ext.DBSystem))
 }
 
 func TestCommandError(t *testing.T) {
@@ -76,6 +77,7 @@ func TestCommandError(t *testing.T) {
 	assert.Equal("NOT_A_COMMAND", span.Tag("redis.raw_command"))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
 	assert.Equal("garyburd/redigo", span.Tag(ext.Component))
+	assert.Equal("redis", span.Tag(ext.DBSystem))
 }
 
 func TestConnectionError(t *testing.T) {
@@ -120,6 +122,7 @@ func TestInheritance(t *testing.T) {
 	assert.Equal(child.Tag(ext.TargetPort), "6379")
 	assert.Equal(ext.SpanKindClient, child.Tag(ext.SpanKind))
 	assert.Equal("garyburd/redigo", child.Tag(ext.Component))
+	assert.Equal("redis", child.Tag(ext.DBSystem))
 }
 
 type stringifyTest struct{ A, B int }
@@ -148,6 +151,7 @@ func TestCommandsToSring(t *testing.T) {
 	assert.Equal("SADD testSet a 0 1 2 [57, 8]", span.Tag("redis.raw_command"))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
 	assert.Equal("garyburd/redigo", span.Tag(ext.Component))
+	assert.Equal("redis", span.Tag(ext.DBSystem))
 }
 
 func TestPool(t *testing.T) {

--- a/contrib/globalsign/mgo/mgo.go
+++ b/contrib/globalsign/mgo/mgo.go
@@ -57,6 +57,7 @@ func newChildSpanFromContext(cfg *mongoConfig, tags map[string]string) ddtrace.S
 		tracer.ServiceName(cfg.serviceName),
 		tracer.ResourceName("mongodb.query"),
 		tracer.Tag(ext.Component, "globalsign/mgo"),
+		tracer.Tag(ext.DBSystem, ext.DBSystemMongoDB),
 	}
 
 	if _, ok := tags["createChild"]; !ok {

--- a/contrib/globalsign/mgo/mgo_test.go
+++ b/contrib/globalsign/mgo/mgo_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
@@ -30,7 +31,9 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func testMongoCollectionCommand(assert *assert.Assertions, command func(*Collection)) []mocktracer.Span {
+func testMongoCollectionCommand(t *testing.T, command func(*Collection)) []mocktracer.Span {
+	assert := assert.New(t)
+
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
@@ -42,10 +45,9 @@ func testMongoCollectionCommand(assert *assert.Assertions, command func(*Collect
 	)
 
 	session, err := Dial("localhost:27017", WithServiceName("unit-tests"), WithContext(ctx))
-	defer session.Close()
+	require.NoError(t, err)
 
-	assert.NotNil(session)
-	assert.Nil(err)
+	defer session.Close()
 
 	db := session.DB("my_db")
 	collection := db.C("MyCollection")
@@ -82,12 +84,13 @@ func TestIter_NoSpanKind(t *testing.T) {
 		collection.UpdateId(r.Map()["_id"], entity)
 	}
 
-	spans := testMongoCollectionCommand(assert, insert)
+	spans := testMongoCollectionCommand(t, insert)
 	assert.Equal(5, len(spans))
 
 	numSpanKindClient := 0
 	for _, val := range spans {
 		if val.OperationName() != "mgo-unittest" {
+			assert.Equal("mongodb", val.Tag(ext.DBSystem))
 			if val, ok := val.Tags()[ext.SpanKind]; ok && val == ext.SpanKindClient {
 				numSpanKindClient++
 			}
@@ -111,10 +114,11 @@ func TestCollection_Insert(t *testing.T) {
 		collection.Insert(entity)
 	}
 
-	spans := testMongoCollectionCommand(assert, insert)
+	spans := testMongoCollectionCommand(t, insert)
 	assert.Equal(2, len(spans))
 	assert.Equal("mongodb.query", spans[0].OperationName())
 	assert.Equal(ext.SpanKindClient, spans[0].Tag(ext.SpanKind))
+	assert.Equal("mongodb", spans[0].Tag(ext.DBSystem))
 }
 
 func TestCollection_Update(t *testing.T) {
@@ -132,10 +136,11 @@ func TestCollection_Update(t *testing.T) {
 		collection.Update(entity, entity)
 	}
 
-	spans := testMongoCollectionCommand(assert, insert)
+	spans := testMongoCollectionCommand(t, insert)
 	assert.Equal(3, len(spans))
 	assert.Equal("mongodb.query", spans[1].OperationName())
 	assert.Equal(ext.SpanKindClient, spans[1].Tag(ext.SpanKind))
+	assert.Equal("mongodb", spans[1].Tag(ext.DBSystem))
 }
 
 func TestCollection_UpdateId(t *testing.T) {
@@ -155,9 +160,10 @@ func TestCollection_UpdateId(t *testing.T) {
 		collection.UpdateId(r.Map()["_id"], entity)
 	}
 
-	spans := testMongoCollectionCommand(assert, insert)
+	spans := testMongoCollectionCommand(t, insert)
 	assert.Equal(5, len(spans))
 	assert.Equal("mongodb.query", spans[3].OperationName())
+	assert.Equal("mongodb", spans[3].Tag(ext.DBSystem))
 }
 
 func TestIssue874(t *testing.T) {
@@ -183,7 +189,7 @@ func TestIssue874(t *testing.T) {
 		collection.UpdateId(r.Map()["_id"], entity)
 	}
 
-	spans := testMongoCollectionCommand(assert, insert)
+	spans := testMongoCollectionCommand(t, insert)
 	assert.Equal(9, len(spans))
 }
 
@@ -205,10 +211,12 @@ func TestCollection_Upsert(t *testing.T) {
 		collection.UpsertId(r.Map()["_id"], entity)
 	}
 
-	spans := testMongoCollectionCommand(assert, insert)
+	spans := testMongoCollectionCommand(t, insert)
 	assert.Equal(6, len(spans))
 	assert.Equal("mongodb.query", spans[1].OperationName())
+	assert.Equal("mongodb", spans[1].Tag(ext.DBSystem))
 	assert.Equal("mongodb.query", spans[4].OperationName())
+	assert.Equal("mongodb", spans[4].Tag(ext.DBSystem))
 }
 
 func TestCollection_UpdateAll(t *testing.T) {
@@ -226,9 +234,10 @@ func TestCollection_UpdateAll(t *testing.T) {
 		collection.UpdateAll(entity, entity)
 	}
 
-	spans := testMongoCollectionCommand(assert, insert)
+	spans := testMongoCollectionCommand(t, insert)
 	assert.Equal(3, len(spans))
 	assert.Equal("mongodb.query", spans[1].OperationName())
+	assert.Equal("mongodb", spans[1].Tag(ext.DBSystem))
 }
 
 func TestCollection_FindId(t *testing.T) {
@@ -249,7 +258,7 @@ func TestCollection_FindId(t *testing.T) {
 		collection.FindId(r.Map()["_id"]).Iter().Next(&r2)
 	}
 
-	spans := testMongoCollectionCommand(assert, insert)
+	spans := testMongoCollectionCommand(t, insert)
 	assert.Equal(6, len(spans))
 }
 
@@ -268,9 +277,10 @@ func TestCollection_Remove(t *testing.T) {
 		collection.Remove(entity)
 	}
 
-	spans := testMongoCollectionCommand(assert, insert)
+	spans := testMongoCollectionCommand(t, insert)
 	assert.Equal(3, len(spans))
 	assert.Equal("mongodb.query", spans[1].OperationName())
+	assert.Equal("mongodb", spans[1].Tag(ext.DBSystem))
 }
 
 func TestCollection_RemoveId(t *testing.T) {
@@ -294,9 +304,10 @@ func TestCollection_RemoveId(t *testing.T) {
 		assert.NoError(err)
 	}
 
-	spans := testMongoCollectionCommand(assert, removeByID)
+	spans := testMongoCollectionCommand(t, removeByID)
 	assert.Equal(5, len(spans))
 	assert.Equal("mongodb.query", spans[3].OperationName())
+	assert.Equal("mongodb", spans[3].Tag(ext.DBSystem))
 }
 
 func TestCollection_RemoveAll(t *testing.T) {
@@ -314,9 +325,10 @@ func TestCollection_RemoveAll(t *testing.T) {
 		collection.RemoveAll(entity)
 	}
 
-	spans := testMongoCollectionCommand(assert, insert)
+	spans := testMongoCollectionCommand(t, insert)
 	assert.Equal(3, len(spans))
 	assert.Equal("mongodb.query", spans[1].OperationName())
+	assert.Equal("mongodb", spans[1].Tag(ext.DBSystem))
 }
 
 func TestCollection_DropCollection(t *testing.T) {
@@ -326,9 +338,10 @@ func TestCollection_DropCollection(t *testing.T) {
 		collection.DropCollection()
 	}
 
-	spans := testMongoCollectionCommand(assert, insert)
+	spans := testMongoCollectionCommand(t, insert)
 	assert.Equal(2, len(spans))
 	assert.Equal("mongodb.query", spans[0].OperationName())
+	assert.Equal("mongodb", spans[0].Tag(ext.DBSystem))
 }
 
 func TestCollection_Create(t *testing.T) {
@@ -338,9 +351,10 @@ func TestCollection_Create(t *testing.T) {
 		collection.Create(&mgo.CollectionInfo{})
 	}
 
-	spans := testMongoCollectionCommand(assert, insert)
+	spans := testMongoCollectionCommand(t, insert)
 	assert.Equal(2, len(spans))
 	assert.Equal("mongodb.query", spans[0].OperationName())
+	assert.Equal("mongodb", spans[0].Tag(ext.DBSystem))
 }
 
 func TestCollection_Count(t *testing.T) {
@@ -350,7 +364,7 @@ func TestCollection_Count(t *testing.T) {
 		collection.Count()
 	}
 
-	spans := testMongoCollectionCommand(assert, insert)
+	spans := testMongoCollectionCommand(t, insert)
 	assert.Equal(2, len(spans))
 	assert.Equal("mongodb.query", spans[0].OperationName())
 }
@@ -366,13 +380,13 @@ func TestCollection_IndexCommands(t *testing.T) {
 		collection.EnsureIndexKey("_id_")
 	}
 
-	spans := testMongoCollectionCommand(assert, indexTest)
-	assert.Equal(6, len(spans))
-	assert.Equal("mongodb.query", spans[0].OperationName())
-	assert.Equal("mongodb.query", spans[1].OperationName())
-	assert.Equal("mongodb.query", spans[2].OperationName())
-	assert.Equal("mongodb.query", spans[3].OperationName())
-	assert.Equal("mongodb.query", spans[4].OperationName())
+	spans := testMongoCollectionCommand(t, indexTest)
+	require.Equal(t, 6, len(spans))
+	for i := 0; i <= 4; i++ {
+		span := spans[i]
+		assert.Equal("mongodb.query", span.OperationName())
+		assert.Equal("mongodb", span.Tag(ext.DBSystem))
+	}
 	assert.Equal("mgo-unittest", spans[5].OperationName())
 }
 
@@ -400,12 +414,13 @@ func TestCollection_FindAndIter(t *testing.T) {
 		iter.Close()
 	}
 
-	spans := testMongoCollectionCommand(assert, insert)
-	assert.Equal(8, len(spans))
-	assert.Equal("mongodb.query", spans[3].OperationName())
-	assert.Equal("mongodb.query", spans[4].OperationName())
-	assert.Equal("mongodb.query", spans[5].OperationName())
-	assert.Equal("mongodb.query", spans[6].OperationName())
+	spans := testMongoCollectionCommand(t, insert)
+	require.Equal(t, 8, len(spans))
+	for i := 3; i <= 6; i++ {
+		span := spans[i]
+		assert.Equal("mongodb.query", span.OperationName())
+		assert.Equal("mongodb", span.Tag(ext.DBSystem))
+	}
 }
 
 func TestCollection_Bulk(t *testing.T) {
@@ -424,9 +439,10 @@ func TestCollection_Bulk(t *testing.T) {
 		bulk.Run()
 	}
 
-	spans := testMongoCollectionCommand(assert, insert)
+	spans := testMongoCollectionCommand(t, insert)
 	assert.Equal(2, len(spans))
 	assert.Equal("mongodb.query", spans[0].OperationName())
+	assert.Equal("mongodb", spans[0].Tag(ext.DBSystem))
 }
 
 func TestBadDial(t *testing.T) {

--- a/contrib/go-pg/pg.v10/pg_go.go
+++ b/contrib/go-pg/pg.v10/pg_go.go
@@ -44,6 +44,7 @@ func (h *queryHook) BeforeQuery(ctx context.Context, qe *pg.QueryEvent) (context
 		tracer.ResourceName(string(query)),
 		tracer.ServiceName(h.cfg.serviceName),
 		tracer.Tag(ext.Component, "go-pg/pg.v10"),
+		tracer.Tag(ext.DBSystem, ext.DBSystemPostgreSQL),
 	}
 	if !math.IsNaN(h.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, h.cfg.analyticsRate))

--- a/contrib/go-pg/pg.v10/pg_go_test.go
+++ b/contrib/go-pg/pg.v10/pg_go_test.go
@@ -67,7 +67,8 @@ func TestSelect(t *testing.T) {
 	assert.Equal(1, n)
 	assert.Equal("go-pg", spans[0].OperationName())
 	assert.Equal("http.request", spans[1].OperationName())
-	assert.Equal("go-pg/pg.v10", spans[0].Tags()[ext.Component])
+	assert.Equal("go-pg/pg.v10", spans[0].Tag(ext.Component))
+	assert.Equal("postgresql", spans[0].Tag(ext.DBSystem))
 }
 
 func TestServiceName(t *testing.T) {
@@ -106,7 +107,8 @@ func TestServiceName(t *testing.T) {
 		assert.Equal("http.request", spans[1].OperationName())
 		assert.Equal("gopg.db", spans[0].Tag(ext.ServiceName))
 		assert.Equal("fake-http-server", spans[1].Tag(ext.ServiceName))
-		assert.Equal("go-pg/pg.v10", spans[0].Tags()[ext.Component])
+		assert.Equal("go-pg/pg.v10", spans[0].Tag(ext.Component))
+		assert.Equal("postgresql", spans[0].Tag(ext.DBSystem))
 	})
 
 	t.Run("global", func(t *testing.T) {
@@ -147,7 +149,8 @@ func TestServiceName(t *testing.T) {
 		assert.Equal("http.request", spans[1].OperationName())
 		assert.Equal("global-service", spans[0].Tag(ext.ServiceName))
 		assert.Equal("fake-http-server", spans[1].Tag(ext.ServiceName))
-		assert.Equal("go-pg/pg.v10", spans[0].Tags()[ext.Component])
+		assert.Equal("go-pg/pg.v10", spans[0].Tag(ext.Component))
+		assert.Equal("postgresql", spans[0].Tag(ext.DBSystem))
 	})
 
 	t.Run("custom", func(t *testing.T) {
@@ -185,7 +188,8 @@ func TestServiceName(t *testing.T) {
 		assert.Equal("http.request", spans[1].OperationName())
 		assert.Equal("my-service-name", spans[0].Tag(ext.ServiceName))
 		assert.Equal("fake-http-server", spans[1].Tag(ext.ServiceName))
-		assert.Equal("go-pg/pg.v10", spans[0].Tags()[ext.Component])
+		assert.Equal("go-pg/pg.v10", spans[0].Tag(ext.Component))
+		assert.Equal("postgresql", spans[0].Tag(ext.DBSystem))
 	})
 }
 

--- a/contrib/go-redis/redis.v7/redis.go
+++ b/contrib/go-redis/redis.v7/redis.go
@@ -110,6 +110,7 @@ func (ddh *datadogHook) BeforeProcess(ctx context.Context, cmd redis.Cmder) (con
 		tracer.Tag("redis.args_length", strconv.Itoa(length)),
 		tracer.Tag(ext.Component, "go-redis/redis.v7"),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
+		tracer.Tag(ext.DBSystem, ext.DBSystemRedis),
 	}
 	opts = append(opts, ddh.additionalTags...)
 	if !math.IsNaN(p.config.analyticsRate) {
@@ -146,6 +147,7 @@ func (ddh *datadogHook) BeforeProcessPipeline(ctx context.Context, cmds []redis.
 		tracer.Tag("redis.pipeline_length", strconv.Itoa(len(cmds))),
 		tracer.Tag(ext.Component, "go-redis/redis.v7"),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
+		tracer.Tag(ext.DBSystem, ext.DBSystemRedis),
 	}
 	opts = append(opts, ddh.additionalTags...)
 	if !math.IsNaN(p.config.analyticsRate) {

--- a/contrib/go-redis/redis.v7/redis_test.go
+++ b/contrib/go-redis/redis.v7/redis_test.go
@@ -61,6 +61,7 @@ func TestClientEvalSha(t *testing.T) {
 	assert.Equal("evalsha", span.Tag(ext.ResourceName))
 	assert.Equal("go-redis/redis.v7", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+	assert.Equal("redis", span.Tag(ext.DBSystem))
 }
 
 func TestClient(t *testing.T) {
@@ -85,6 +86,7 @@ func TestClient(t *testing.T) {
 	assert.Equal("3", span.Tag("redis.args_length"))
 	assert.Equal("go-redis/redis.v7", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+	assert.Equal("redis", span.Tag(ext.DBSystem))
 }
 
 func TestWrapClient(t *testing.T) {
@@ -144,6 +146,7 @@ func TestWrapClient(t *testing.T) {
 			assert.Equal("3", span.Tag("redis.args_length"))
 			assert.Equal("go-redis/redis.v7", span.Tag(ext.Component))
 			assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+			assert.Equal("redis", span.Tag(ext.DBSystem))
 		})
 	}
 }
@@ -233,6 +236,7 @@ func TestPipeline(t *testing.T) {
 	assert.Equal("1", span.Tag("redis.pipeline_length"))
 	assert.Equal("go-redis/redis.v7", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+	assert.Equal("redis", span.Tag(ext.DBSystem))
 
 	mt.Reset()
 	pipeline.Expire("pipeline_counter", time.Hour)
@@ -252,6 +256,7 @@ func TestPipeline(t *testing.T) {
 	assert.Equal("2", span.Tag("redis.pipeline_length"))
 	assert.Equal("go-redis/redis.v7", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+	assert.Equal("redis", span.Tag(ext.DBSystem))
 }
 
 func TestChildSpan(t *testing.T) {
@@ -335,6 +340,7 @@ func TestError(t *testing.T) {
 		assert.Equal("get key: ", span.Tag("redis.raw_command"))
 		assert.Equal("go-redis/redis.v7", span.Tag(ext.Component))
 		assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+		assert.Equal("redis", span.Tag(ext.DBSystem))
 	})
 
 	t.Run("nil", func(t *testing.T) {
@@ -358,6 +364,7 @@ func TestError(t *testing.T) {
 		assert.Equal("get non_existent_key: ", span.Tag("redis.raw_command"))
 		assert.Equal("go-redis/redis.v7", span.Tag(ext.Component))
 		assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+		assert.Equal("redis", span.Tag(ext.DBSystem))
 	})
 }
 func TestAnalyticsSettings(t *testing.T) {

--- a/contrib/go-redis/redis.v8/redis.go
+++ b/contrib/go-redis/redis.v8/redis.go
@@ -110,6 +110,7 @@ func (ddh *datadogHook) BeforeProcess(ctx context.Context, cmd redis.Cmder) (con
 		tracer.Tag("redis.args_length", strconv.Itoa(length)),
 		tracer.Tag(ext.Component, "go-redis/redis.v8"),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
+		tracer.Tag(ext.DBSystem, ext.DBSystemRedis),
 	)
 	if !p.config.skipRaw {
 		opts = append(opts, tracer.Tag("redis.raw_command", raw))
@@ -147,6 +148,7 @@ func (ddh *datadogHook) BeforeProcessPipeline(ctx context.Context, cmds []redis.
 		tracer.Tag("redis.pipeline_length", strconv.Itoa(len(cmds))),
 		tracer.Tag(ext.Component, "go-redis/redis.v8"),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
+		tracer.Tag(ext.DBSystem, ext.DBSystemRedis),
 	)
 	if !p.config.skipRaw {
 		opts = append(opts, tracer.Tag("redis.raw_command", raw))

--- a/contrib/go-redis/redis.v8/redis_test.go
+++ b/contrib/go-redis/redis.v8/redis_test.go
@@ -107,6 +107,7 @@ func TestClientEvalSha(t *testing.T) {
 	assert.Equal("evalsha", span.Tag(ext.ResourceName))
 	assert.Equal("go-redis/redis.v8", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+	assert.Equal("redis", span.Tag(ext.DBSystem))
 }
 
 func TestClient(t *testing.T) {
@@ -132,6 +133,7 @@ func TestClient(t *testing.T) {
 	assert.Equal("3", span.Tag("redis.args_length"))
 	assert.Equal("go-redis/redis.v8", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+	assert.Equal("redis", span.Tag(ext.DBSystem))
 }
 
 func TestWrapClient(t *testing.T) {
@@ -192,6 +194,7 @@ func TestWrapClient(t *testing.T) {
 			assert.Equal("3", span.Tag("redis.args_length"))
 			assert.Equal("go-redis/redis.v8", span.Tag(ext.Component))
 			assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+			assert.Equal("redis", span.Tag(ext.DBSystem))
 		})
 	}
 }
@@ -282,6 +285,7 @@ func TestPipeline(t *testing.T) {
 	assert.Equal("1", span.Tag("redis.pipeline_length"))
 	assert.Equal("go-redis/redis.v8", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+	assert.Equal("redis", span.Tag(ext.DBSystem))
 
 	mt.Reset()
 	pipeline.Expire(ctx, "pipeline_counter", time.Hour)
@@ -301,6 +305,7 @@ func TestPipeline(t *testing.T) {
 	assert.Equal("2", span.Tag("redis.pipeline_length"))
 	assert.Equal("go-redis/redis.v8", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+	assert.Equal("redis", span.Tag(ext.DBSystem))
 }
 
 func TestChildSpan(t *testing.T) {
@@ -388,6 +393,7 @@ func TestError(t *testing.T) {
 		assert.Equal("get key: ", span.Tag("redis.raw_command"))
 		assert.Equal("go-redis/redis.v8", span.Tag(ext.Component))
 		assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+		assert.Equal("redis", span.Tag(ext.DBSystem))
 	})
 
 	t.Run("nil", func(t *testing.T) {
@@ -412,6 +418,7 @@ func TestError(t *testing.T) {
 		assert.Equal("get non_existent_key: ", span.Tag("redis.raw_command"))
 		assert.Equal("go-redis/redis.v8", span.Tag(ext.Component))
 		assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+		assert.Equal("redis", span.Tag(ext.DBSystem))
 	})
 }
 func TestAnalyticsSettings(t *testing.T) {

--- a/contrib/go-redis/redis/redis.go
+++ b/contrib/go-redis/redis/redis.go
@@ -125,6 +125,7 @@ func (c *Pipeliner) execWithContext(ctx context.Context) ([]redis.Cmder, error) 
 		tracer.Tag("out.db", p.db),
 		tracer.Tag(ext.Component, "go-redis/redis"),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
+		tracer.Tag(ext.DBSystem, ext.DBSystemRedis),
 	}
 	if !math.IsNaN(p.config.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, p.config.analyticsRate))
@@ -197,6 +198,7 @@ func createWrapperFromClient(tc *Client) func(oldProcess func(cmd redis.Cmder) e
 				tracer.Tag("redis.args_length", strconv.Itoa(length)),
 				tracer.Tag(ext.Component, "go-redis/redis"),
 				tracer.Tag(ext.SpanKind, ext.SpanKindClient),
+				tracer.Tag(ext.DBSystem, ext.DBSystemRedis),
 			}
 			if !math.IsNaN(p.config.analyticsRate) {
 				opts = append(opts, tracer.Tag(ext.EventSampleRate, p.config.analyticsRate))

--- a/contrib/go-redis/redis/redis_test.go
+++ b/contrib/go-redis/redis/redis_test.go
@@ -58,6 +58,7 @@ func TestClientEvalSha(t *testing.T) {
 	assert.Equal("evalsha", span.Tag(ext.ResourceName))
 	assert.Equal("go-redis/redis", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+	assert.Equal("redis", span.Tag(ext.DBSystem))
 }
 
 // https://github.com/DataDog/dd-trace-go/issues/387
@@ -103,6 +104,7 @@ func TestClient(t *testing.T) {
 	assert.Equal("3", span.Tag("redis.args_length"))
 	assert.Equal("go-redis/redis", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+	assert.Equal("redis", span.Tag(ext.DBSystem))
 }
 
 func TestPipeline(t *testing.T) {
@@ -131,6 +133,7 @@ func TestPipeline(t *testing.T) {
 	assert.Equal("1", span.Tag("redis.pipeline_length"))
 	assert.Equal("go-redis/redis", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+	assert.Equal("redis", span.Tag(ext.DBSystem))
 
 	mt.Reset()
 	pipeline.Expire("pipeline_counter", time.Hour)
@@ -150,6 +153,7 @@ func TestPipeline(t *testing.T) {
 	assert.Equal("2", span.Tag("redis.pipeline_length"))
 	assert.Equal("go-redis/redis", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+	assert.Equal("redis", span.Tag(ext.DBSystem))
 }
 
 func TestPipelined(t *testing.T) {
@@ -178,6 +182,7 @@ func TestPipelined(t *testing.T) {
 	assert.Equal("1", span.Tag("redis.pipeline_length"))
 	assert.Equal("go-redis/redis", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+	assert.Equal("redis", span.Tag(ext.DBSystem))
 
 	mt.Reset()
 	_, err = client.Pipelined(func(p redis.Pipeliner) error {
@@ -198,6 +203,7 @@ func TestPipelined(t *testing.T) {
 	assert.Equal("2", span.Tag("redis.pipeline_length"))
 	assert.Equal("go-redis/redis", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+	assert.Equal("redis", span.Tag(ext.DBSystem))
 }
 
 func TestChildSpan(t *testing.T) {
@@ -282,6 +288,7 @@ func TestError(t *testing.T) {
 		assert.Equal("get key: ", span.Tag("redis.raw_command"))
 		assert.Equal("go-redis/redis", span.Tag(ext.Component))
 		assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+		assert.Equal("redis", span.Tag(ext.DBSystem))
 	})
 
 	t.Run("nil", func(t *testing.T) {
@@ -305,6 +312,7 @@ func TestError(t *testing.T) {
 		assert.Equal("get non_existent_key: ", span.Tag("redis.raw_command"))
 		assert.Equal("go-redis/redis", span.Tag(ext.Component))
 		assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+		assert.Equal("redis", span.Tag(ext.DBSystem))
 	})
 }
 func TestAnalyticsSettings(t *testing.T) {

--- a/contrib/go.mongodb.org/mongo-driver/mongo/mongo.go
+++ b/contrib/go.mongodb.org/mongo-driver/mongo/mongo.go
@@ -50,6 +50,7 @@ func (m *monitor) Started(ctx context.Context, evt *event.CommandStartedEvent) {
 		tracer.Tag(ext.PeerPort, port),
 		tracer.Tag(ext.Component, "go.mongodb.org/mongo-driver/mongo"),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
+		tracer.Tag(ext.DBSystem, ext.DBSystemMongoDB),
 	}
 	if !math.IsNaN(m.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, m.cfg.analyticsRate))

--- a/contrib/go.mongodb.org/mongo-driver/mongo/mongo_test.go
+++ b/contrib/go.mongodb.org/mongo-driver/mongo/mongo_test.go
@@ -78,6 +78,7 @@ func Test(t *testing.T) {
 	assert.Equal(t, "mongo", s.Tag(ext.DBType))
 	assert.Equal(t, "go.mongodb.org/mongo-driver/mongo", s.Tag(ext.Component))
 	assert.Equal(t, ext.SpanKindClient, s.Tag(ext.SpanKind))
+	assert.Equal(t, "mongodb", s.Tag(ext.DBSystem))
 }
 
 func TestAnalyticsSettings(t *testing.T) {

--- a/contrib/gocql/gocql/gocql.go
+++ b/contrib/gocql/gocql/gocql.go
@@ -104,6 +104,7 @@ func (tq *Query) newChildSpan(ctx context.Context) ddtrace.Span {
 		tracer.Tag(ext.CassandraKeyspace, p.keyspace),
 		tracer.Tag(ext.Component, "gocql/gocql"),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
+		tracer.Tag(ext.DBSystem, ext.DBSystemCassandra),
 	}
 	if !math.IsNaN(p.config.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, p.config.analyticsRate))
@@ -257,6 +258,7 @@ func (tb *Batch) newChildSpan(ctx context.Context) ddtrace.Span {
 		tracer.Tag(ext.CassandraKeyspace, tb.Keyspace()),
 		tracer.Tag(ext.Component, "gocql/gocql"),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
+		tracer.Tag(ext.DBSystem, ext.DBSystemCassandra),
 	}
 	if !math.IsNaN(p.config.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, p.config.analyticsRate))

--- a/contrib/gocql/gocql/gocql_test.go
+++ b/contrib/gocql/gocql/gocql_test.go
@@ -87,6 +87,7 @@ func TestErrorWrapper(t *testing.T) {
 	assert.Equal(span.Tag(ext.CassandraPaginated), "false")
 	assert.Equal(span.Tag(ext.Component), "gocql/gocql")
 	assert.Equal(span.Tag(ext.SpanKind), ext.SpanKindClient)
+	assert.Equal(span.Tag(ext.DBSystem), "cassandra")
 
 	if iter.Host() != nil {
 		assert.Equal(span.Tag(ext.TargetPort), "9042")
@@ -132,6 +133,8 @@ func TestChildWrapperSpan(t *testing.T) {
 	assert.Equal(childSpan.Tag(ext.CassandraKeyspace), "trace")
 	assert.Equal(childSpan.Tag(ext.Component), "gocql/gocql")
 	assert.Equal(childSpan.Tag(ext.SpanKind), ext.SpanKindClient)
+	assert.Equal(childSpan.Tag(ext.DBSystem), "cassandra")
+
 	if iter.Host() != nil {
 		assert.Equal(childSpan.Tag(ext.TargetPort), "9042")
 		assert.Equal(childSpan.Tag(ext.TargetHost), iter.Host().HostID())
@@ -311,7 +314,7 @@ func TestIterScanner(t *testing.T) {
 	assert.Equal(childSpan.Tag(ext.CassandraKeyspace), "trace")
 	assert.Equal(childSpan.Tag(ext.Component), "gocql/gocql")
 	assert.Equal(childSpan.Tag(ext.SpanKind), ext.SpanKindClient)
-
+	assert.Equal(childSpan.Tag(ext.DBSystem), "cassandra")
 }
 
 func TestBatch(t *testing.T) {
@@ -356,4 +359,5 @@ func TestBatch(t *testing.T) {
 	assert.Equal(childSpan.Tag(ext.CassandraKeyspace), "trace")
 	assert.Equal(childSpan.Tag(ext.Component), "gocql/gocql")
 	assert.Equal(childSpan.Tag(ext.SpanKind), ext.SpanKindClient)
+	assert.Equal(childSpan.Tag(ext.DBSystem), "cassandra")
 }

--- a/contrib/gomodule/redigo/redigo.go
+++ b/contrib/gomodule/redigo/redigo.go
@@ -151,6 +151,7 @@ func newChildSpan(ctx context.Context, p *params) ddtrace.Span {
 		tracer.ServiceName(p.config.serviceName),
 		tracer.Tag(ext.Component, "gomodule/redigo"),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
+		tracer.Tag(ext.DBSystem, ext.DBSystemRedis),
 	}
 	if !math.IsNaN(p.config.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, p.config.analyticsRate))

--- a/contrib/gomodule/redigo/redigo_test.go
+++ b/contrib/gomodule/redigo/redigo_test.go
@@ -53,6 +53,7 @@ func TestClient(t *testing.T) {
 	assert.Equal("2", span.Tag("redis.args_length"))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
 	assert.Equal("gomodule/redigo", span.Tag(ext.Component))
+	assert.Equal("redis", span.Tag(ext.DBSystem))
 }
 
 func TestCommandError(t *testing.T) {
@@ -78,6 +79,7 @@ func TestCommandError(t *testing.T) {
 	assert.Equal("NOT_A_COMMAND", span.Tag("redis.raw_command"))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
 	assert.Equal("gomodule/redigo", span.Tag(ext.Component))
+	assert.Equal("redis", span.Tag(ext.DBSystem))
 }
 
 func TestConnectionError(t *testing.T) {
@@ -122,6 +124,7 @@ func TestInheritance(t *testing.T) {
 	assert.Equal(child.Tag(ext.TargetPort), "6379")
 	assert.Equal(ext.SpanKindClient, child.Tag(ext.SpanKind))
 	assert.Equal("gomodule/redigo", child.Tag(ext.Component))
+	assert.Equal("redis", child.Tag(ext.DBSystem))
 }
 
 type stringifyTest struct{ A, B int }
@@ -150,6 +153,7 @@ func TestCommandsToSring(t *testing.T) {
 	assert.Equal("SADD testSet a 0 1 2 [57, 8]", span.Tag("redis.raw_command"))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
 	assert.Equal("gomodule/redigo", span.Tag(ext.Component))
+	assert.Equal("redis", span.Tag(ext.DBSystem))
 }
 
 func TestPool(t *testing.T) {

--- a/contrib/hashicorp/consul/consul.go
+++ b/contrib/hashicorp/consul/consul.go
@@ -72,6 +72,7 @@ func (k *KV) startSpan(resourceName string, key string) ddtrace.Span {
 		tracer.Tag("consul.key", key),
 		tracer.Tag(ext.Component, "hashicorp/consul"),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
+		tracer.Tag(ext.DBSystem, ext.DBSystemConsulKV),
 	}
 	if !math.IsNaN(k.config.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, k.config.analyticsRate))

--- a/contrib/hashicorp/consul/consul_test.go
+++ b/contrib/hashicorp/consul/consul_test.go
@@ -100,6 +100,7 @@ func TestKV(t *testing.T) {
 			assert.Equal(key, span.Tag("consul.key"))
 			assert.Equal("hashicorp/consul", span.Tag(ext.Component))
 			assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+			assert.Equal(ext.DBSystemConsulKV, span.Tag(ext.DBSystem))
 		})
 	}
 }

--- a/contrib/olivere/elastic/elastictrace.go
+++ b/contrib/olivere/elastic/elastictrace.go
@@ -57,6 +57,7 @@ func (t *httpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		tracer.Tag("elasticsearch.params", req.URL.Query().Encode()),
 		tracer.Tag(ext.Component, "olivere/elastic"),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
+		tracer.Tag(ext.DBSystem, ext.DBSystemElasticsearch),
 	}
 	if !math.IsNaN(t.config.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, t.config.analyticsRate))

--- a/contrib/olivere/elastic/elastictrace_test.go
+++ b/contrib/olivere/elastic/elastictrace_test.go
@@ -265,6 +265,7 @@ func checkPUTTrace(assert *assert.Assertions, mt mocktracer.Tracer) {
 	assert.Equal(`{"user": "test", "message": "hello"}`, span.Tag("elasticsearch.body"))
 	assert.Equal("olivere/elastic", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+	assert.Equal("elasticsearch", span.Tag(ext.DBSystem))
 }
 
 func checkGETTrace(assert *assert.Assertions, mt mocktracer.Tracer) {
@@ -275,6 +276,7 @@ func checkGETTrace(assert *assert.Assertions, mt mocktracer.Tracer) {
 	assert.Equal("GET", span.Tag("elasticsearch.method"))
 	assert.Equal("olivere/elastic", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+	assert.Equal("elasticsearch", span.Tag(ext.DBSystem))
 }
 
 func checkErrTrace(assert *assert.Assertions, mt mocktracer.Tracer) {
@@ -286,6 +288,7 @@ func checkErrTrace(assert *assert.Assertions, mt mocktracer.Tracer) {
 	assert.Equal("*errors.errorString", fmt.Sprintf("%T", span.Tag(ext.Error).(error)))
 	assert.Equal("olivere/elastic", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
+	assert.Equal("elasticsearch", span.Tag(ext.DBSystem))
 }
 
 func TestQuantize(t *testing.T) {

--- a/contrib/syndtr/goleveldb/leveldb/leveldb.go
+++ b/contrib/syndtr/goleveldb/leveldb/leveldb.go
@@ -273,6 +273,7 @@ func startSpan(cfg *config, name string) ddtrace.Span {
 		tracer.ResourceName(name),
 		tracer.Tag(ext.Component, "syndtr/goleveldb/leveldb"),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
+		tracer.Tag(ext.DBSystem, ext.DBSystemLevelDB),
 	}
 	if !math.IsNaN(cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))

--- a/contrib/syndtr/goleveldb/leveldb/leveldb_test.go
+++ b/contrib/syndtr/goleveldb/leveldb/leveldb_test.go
@@ -150,6 +150,7 @@ func testAction(t *testing.T, name string, f func(mt mocktracer.Tracer, db *DB))
 		assert.Equal(t, name, spans[0].Tag(ext.ResourceName))
 		assert.Equal(t, "syndtr/goleveldb/leveldb", spans[0].Tag(ext.Component))
 		assert.Equal(t, ext.SpanKindClient, spans[0].Tag(ext.SpanKind))
+		assert.Equal(t, "leveldb", spans[0].Tag(ext.DBSystem))
 	})
 }
 

--- a/contrib/tidwall/buntdb/buntdb.go
+++ b/contrib/tidwall/buntdb/buntdb.go
@@ -100,6 +100,7 @@ func (tx *Tx) startSpan(name string) ddtrace.Span {
 		tracer.ResourceName(name),
 		tracer.Tag(ext.Component, "tidwall/buntdb"),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
+		tracer.Tag(ext.DBSystem, ext.DBSystemBuntDB),
 	}
 	if !math.IsNaN(tx.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, tx.cfg.analyticsRate))

--- a/contrib/tidwall/buntdb/buntdb_test.go
+++ b/contrib/tidwall/buntdb/buntdb_test.go
@@ -437,6 +437,7 @@ func testUpdate(t *testing.T, name string, f func(tx *Tx) error) {
 	assert.Equal(t, "buntdb.query", spans[0].OperationName())
 	assert.Equal(t, "tidwall/buntdb", spans[0].Tag(ext.Component))
 	assert.Equal(t, ext.SpanKindClient, spans[0].Tag(ext.SpanKind))
+	assert.Equal(t, "buntdb", spans[0].Tag(ext.DBSystem))
 }
 
 func testView(t *testing.T, name string, f func(tx *Tx) error) {
@@ -457,6 +458,7 @@ func testView(t *testing.T, name string, f func(tx *Tx) error) {
 	assert.Equal(t, "buntdb.query", spans[0].OperationName())
 	assert.Equal(t, "tidwall/buntdb", spans[0].Tag(ext.Component))
 	assert.Equal(t, ext.SpanKindClient, spans[0].Tag(ext.SpanKind))
+	assert.Equal(t, "buntdb", spans[0].Tag(ext.DBSystem))
 }
 
 func getDatabase(t *testing.T, opts ...Option) *DB {

--- a/ddtrace/ext/db.go
+++ b/ddtrace/ext/db.go
@@ -19,3 +19,22 @@ const (
 	// DBStatement records a database statement for the given database type.
 	DBStatement = "db.statement"
 )
+
+// DBSystem indicates the database management system (DBMS) product being used.
+// The following list includes the tag name and all the available values for it.
+const (
+	DBSystem                   = "db.system"
+	DBSystemMemcached          = "memcached"
+	DBSystemMySQL              = "mysql"
+	DBSystemPostgreSQL         = "postgresql"
+	DBSystemMicrosoftSQLServer = "mssql"
+	// DBSystemOtherSQL is used for other SQL databases not listed above.
+	DBSystemOtherSQL      = "other_sql"
+	DBSystemElasticsearch = "elasticsearch"
+	DBSystemRedis         = "redis"
+	DBSystemMongoDB       = "mongodb"
+	DBSystemCassandra     = "cassandra"
+	DBSystemConsulKV      = "consul"
+	DBSystemLevelDB       = "leveldb"
+	DBSystemBuntDB        = "buntdb"
+)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Add db.system tag for all db integrations.

 | Integration   | db.system
 | ------------- | ----------------
 | `bradfitz/gomemcache`         | `memcached`           
 | `database/sql`     | `mysql`/`postgresql`/`mssql`/`other_sql`         
 | `elastic/go-elasticsearch.v6`      | `elasticsearch`        
 | `garyburd/redigo`   | `redis`     
 | `globalsign/mgo`    | `mongodb`      
 | `go-pg/pg.v10`       | `postgresql`         
 | `go-redis/redis` | `redis`   
 | `go-redis/redis.v7`       | `redis`         
 | `go-redis/redis.v8`     | `redis`
 | `go.mongodb.org/mongo-driver/mongo` | `mongodb`
 | `gocql/gocql` | `cassandra`
 | `gomodule/redigo` | `redis`
 | `hashicorp/consul` (KV only) | `consul`
 | `oliviere/elastic` | `elasticsearch`
 | `syndtr/goleveldb/leveldb` | `leveldb`
 | `tidwall/buntdb` | `buntdb`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Part of the unified naming changes to standardize span tags across tracers.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes
Updated existing tests.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Changed code has unit tests for its functionality.
- [x] If this interacts with the agent in a new way, a system test has been added.