### PR TITLE
ddtrace/tracer: replace Windows path characters in fake UDS host

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -230,7 +230,7 @@ func newConfig(opts ...StartOption) *config {
 		c.httpClient = udsClient(c.agentURL.Path)
 		c.agentURL = &url.URL{
 			Scheme: "http",
-			Host:   fmt.Sprintf("UDS_%s", strings.ReplaceAll(c.agentURL.Path, "/", "_")),
+			Host:   fmt.Sprintf("UDS_%s", strings.NewReplacer(":", "_", "/", "_", `\`, "_").Replace(c.agentURL.Path)),
 		}
 	} else if c.httpClient == nil {
 		c.httpClient = defaultClient


### PR DESCRIPTION
### What does this PR do?

Tries to make `TestWithUDS` pass on Windows.

### Motivation

We still need to give a full URL to the HTTP client, with the "http"
scheme, but we want the URL to somewhat resemble the UDS path. Windows
paths contain colons and back-slashes. Colons in particular cause
trouble because they're usually followed by a port. See this failure
for example:

https://github.com/DataDog/dd-trace-go/actions/runs/4068558554/jobs/7007255118#step:6:169
```
=== FAIL: ddtrace/tracer TestWithUDS (0.00s)
    transport_test.go:299: 
        	Error Trace:	D:\a\dd-trace-go\dd-trace-go\ddtrace\tracer\transport_test.go:299
        	Error:      	Received unexpected error:
        	            	cannot create http request: parse "http://UDS_C:%5CUsers%5CRUNNER~1%5CAppData%5CLocal%5CTemp%5Csocket3746974948%5Capm.socket/v0.4/traces": invalid port ":%5CUsers%5CRUNNER~1%5CAppData%5CLocal%5CTemp%5Csocket3746974948%5Capm.socket" after host
        	Test:       	TestWithUDS
```

### Describe how to test/QA your changes

I'll try manually dispatching a Windows CI run.

EDIT: passed run on this branch: https://github.com/DataDog/dd-trace-go/actions/runs/4078254716/jobs/7028254198

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Changed code has unit tests for its functionality.
- [x] If this interacts with the agent in a new way, a system test has been added.
