### PR TITLE
tracer: make high 64 bits of 128-bit trace id a timestamp

### DIFF
--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -396,11 +396,11 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 	for _, fn := range options {
 		fn(&opts)
 	}
-	var startTime int64
+	var startTime time.Time
 	if opts.StartTime.IsZero() {
-		startTime = now()
+		startTime = nowTime()
 	} else {
-		startTime = opts.StartTime.UnixNano()
+		startTime = opts.StartTime
 	}
 	var context *spanContext
 	// The default pprof context is taken from the start options and is
@@ -429,7 +429,7 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 	}
 	id := opts.SpanID
 	if id == 0 {
-		id = generateSpanID(startTime)
+		id = generateSpanID(startTime.UnixNano())
 	}
 	// span defaults
 	span := &span{
@@ -438,7 +438,7 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		Resource:     operationName,
 		SpanID:       id,
 		TraceID:      id,
-		Start:        startTime,
+		Start:        startTime.UnixNano(),
 		taskEnd:      startExecutionTracerTask(operationName),
 		noDebugStack: t.config.noDebugStack,
 	}
@@ -469,12 +469,15 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 	span.setMetric(ext.Pid, float64(t.pid))
 	span.setMeta("language", "go")
 
-	// add 128 bit trace id, if enabled.
+	// add 128 bit trace id, if enabled, formatted as:
+	// <32-bit unix seconds> <32 bits of zero> <64 random bits>
 	if sharedinternal.BoolEnv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", false) {
-		id128 := generateSpanID(startTime)
-		buf := make([]byte, 8)
-		binary.BigEndian.PutUint64(buf, id128)
-		span.setMeta(keyTraceID128, hex.EncodeToString(buf))
+		id128 := startTime.Unix()
+		b := make([]byte, 8)
+		// casting from int64 -> uint32 should be safe since the start time won't be
+		// negative, and the seconds should fit within 32-bits for the forseeable future.
+		binary.BigEndian.PutUint32(b, uint32(id128))
+		span.setMeta(keyTraceID128, hex.EncodeToString(b))
 	}
 
 	// add tags from options

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -686,6 +686,7 @@ func TestTracerStartSpanOptions128(t *testing.T) {
 		t.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "true")
 		opts128 := []StartSpanOption{
 			WithSpanID(987654),
+			StartTime(time.Unix(123456, 0)),
 		}
 		s := tracer.StartSpan("web.request", opts128...).(*span)
 		assert.Equal(uint64(987654), s.SpanID)
@@ -694,12 +695,9 @@ func TestTracerStartSpanOptions128(t *testing.T) {
 		if !ok {
 			assert.Fail("couldn't cast to ddtrace.SpanContextW3C")
 		}
-		id := w3cCtx.TraceID128()
-		assert.Len(id, 32) // ensure there are enough leading zeros
-		idBytes, err := hex.DecodeString(id)
-		assert.NoError(err)
-		assert.NotEqual(uint64(0), binary.BigEndian.Uint64(idBytes[:8])) // high 64 bits should not be 0
-		assert.Equal(s.Context().TraceID(), binary.BigEndian.Uint64(idBytes[8:]))
+		// hex_encoded(<32-bit unix seconds> <32 bits of zero> <64 random bits>)
+		// 0001e240 (123456 hex encoded) + 00000000 (zeros) + 00000000000f1206 (987654 hex encoded)
+		assert.Equal("0001e2400000000000000000000f1206", w3cCtx.TraceID128())
 	})
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Rather than generate a random 64 bits for the upper half of a 128-bit trace id, use the first 32 bits as a timestamp, and the remaining 32 bits padded with zeroes.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

This is allowed per the W3C spec, and it prevents the additional propagation overhead of a timestamp beyond that needed to convey a 128-bit trace ID, which we will be doing anyway.

</div></b>

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.