### PR TITLE
tracer: support 128-bit propagation of B3 multi header

### DIFF
--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -497,8 +497,8 @@ func TestSpanError(t *testing.T) {
 	span.SetTag(ext.Error, err)
 	assert.Equal(int32(0), span.Error)
 
-	// '+1' is `_dd.p.dm`
-	assert.Equal(nMeta+1, len(span.Meta))
+	// '+2' is `_dd.p.dm` and `"_dd.p.tid"`
+	assert.Equal(nMeta+2, len(span.Meta))
 	assert.Equal("", span.Meta[ext.ErrorMsg])
 	assert.Equal("", span.Meta[ext.ErrorType])
 	assert.Equal("", span.Meta[ext.ErrorStack])

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -497,7 +497,7 @@ func TestSpanError(t *testing.T) {
 	span.SetTag(ext.Error, err)
 	assert.Equal(int32(0), span.Error)
 
-	// '+2' is `_dd.p.dm` and `"_dd.p.tid"`
+	// '+2' is `_dd.p.dm` and `_dd.p.tid`
 	assert.Equal(nMeta+2, len(span.Meta))
 	assert.Equal("", span.Meta[ext.ErrorMsg])
 	assert.Equal("", span.Meta[ext.ErrorType])

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -56,8 +56,8 @@ func newSpanContext(span *span, parent *spanContext) *spanContext {
 		spanID:  span.SpanID,
 		span:    span,
 	}
-	if span.Meta != nil {
-		context.traceID128 = span.Meta[keyTraceID128]
+	if span.context != nil {
+		context.traceID128 = span.context.traceID128
 	}
 	if parent != nil {
 		context.trace = parent.trace
@@ -362,6 +362,9 @@ func (t *trace) finishedOne(s *span) {
 		for k, v := range t.propagatingTags {
 			s.setMeta(k, v)
 		}
+	}
+	if s.context != nil {
+		s.setMeta(keyTraceID128, s.context.traceID128)
 	}
 	if len(t.spans) != t.finished {
 		return

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -93,16 +93,16 @@ func (c *spanContext) TraceID() uint64 { return c.traceID }
 // TraceID128 implements ddtrace.SpanContextW3C.
 func (c *spanContext) TraceID128() string {
 	var hi []byte
-	if hiStr := c.traceID128; hiStr != "" {
+	if c.traceID128 != "" {
 		// 128 bit trace ids is enabled, so fill the higher order bits
 		var err error
-		hi, err = hex.DecodeString(hiStr)
+		hi, err = hex.DecodeString(c.traceID128)
 		if err != nil {
-			log.Debug("failed to decode upper 64 bits of 128-bit trace id %q", hiStr)
+			log.Debug("failed to decode upper 64 bits of 128-bit trace id %q", c.traceID128)
 			return "" // this would be our fault, and means we have a bug
 		}
 		if len(hi) > 8 {
-			log.Debug("invalid 128-bit trace id %q", hiStr)
+			log.Debug("invalid 128-bit trace id %q", c.traceID128)
 			return "" // this would be our fault, and means we have a bug
 		}
 	}

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -350,6 +350,7 @@ func (p *propagator) Extract(carrier interface{}) (ddtrace.SpanContext, error) {
 }
 
 func (p *propagator) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, error) {
+	// TODO: support 128-bit propagation
 	var ctx spanContext
 	err := reader.ForeachKey(func(k, v string) error {
 		var err error
@@ -566,6 +567,7 @@ func (p *propagatorB3SingleHeader) Extract(carrier interface{}) (ddtrace.SpanCon
 }
 
 func (*propagatorB3SingleHeader) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, error) {
+	// TODO: support 128-bit propagation
 	var ctx spanContext
 	err := reader.ForeachKey(func(k, v string) error {
 		var err error
@@ -765,6 +767,7 @@ func (p *propagatorW3c) Extract(carrier interface{}) (ddtrace.SpanContext, error
 }
 
 func (*propagatorW3c) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, error) {
+	// TODO: support 128-bit propagation
 	var parentHeader string
 	var stateHeader string
 	// to avoid parsing tracestate header(s) if traceparent is invalid

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -493,7 +493,7 @@ func (*propagatorB3) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 			} else { // 128-bit trace id
 				id128 := v[:len(v)-16]
 				// pad ctx.traceID128 with zeroes to ensure length of 16
-				ctx.traceID128 = fmt.Sprintf("%0*s", 16, id128)
+				ctx.traceID128 = fmt.Sprintf("%016s", id128)
 				if ctx.span != nil {
 					ctx.span.setMeta(keyTraceID128, ctx.traceID128)
 				}

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -494,9 +494,6 @@ func (*propagatorB3) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 				id128 := v[:len(v)-16]
 				// pad ctx.traceID128 with zeroes to ensure length of 16
 				ctx.traceID128 = fmt.Sprintf("%016s", id128)
-				if ctx.span != nil {
-					ctx.span.setMeta(keyTraceID128, ctx.traceID128)
-				}
 				ctx.traceID, err = strconv.ParseUint(v[len(id128):], 16, 64)
 			}
 			if err != nil {

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -446,10 +446,13 @@ func (*propagatorB3) injectTextMap(spanCtx ddtrace.SpanContext, writer TextMapWr
 	if !ok || ctx.traceID == 0 || ctx.spanID == 0 {
 		return ErrInvalidSpanContext
 	}
-	if w3Cctx, ok := spanCtx.(ddtrace.SpanContextW3C); !ok {
-		return ErrInvalidSpanContext
-	} else {
-		fmt.Printf("%q\n", w3Cctx.TraceID128())
+	if strings.Trim(ctx.traceID128, "0") == "" { // 64-bit trace id
+		writer.Set(b3TraceIDHeader, fmt.Sprintf("%016x", ctx.traceID))
+	} else { // 128-bit trace id
+		var w3Cctx ddtrace.SpanContextW3C
+		if w3Cctx, ok = spanCtx.(ddtrace.SpanContextW3C); !ok {
+			return ErrInvalidSpanContext
+		}
 		writer.Set(b3TraceIDHeader, w3Cctx.TraceID128())
 	}
 	writer.Set(b3SpanIDHeader, fmt.Sprintf("%016x", ctx.spanID))
@@ -483,14 +486,16 @@ func (*propagatorB3) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 				v = v[len(v)-32:]
 			}
 			var err error
-			if len(v) > 16 { // 128 bit trace id
-				ctx.traceID128 = v[:len(v)-16]
-				if ctx.span != nil {
-					ctx.span.setMeta(keyTraceID128, v[:len(v)-16])
-				}
-				ctx.traceID, err = strconv.ParseUint(v[:16], 16, 64)
-			} else { // 64 bit trace id
+			if len(v) < 32 { // 64-bit trace id
 				ctx.traceID, err = strconv.ParseUint(v, 16, 64)
+			} else if len(v) == 32 { // 128-bit trace id
+				ctx.traceID128 = v[:16]
+				if ctx.span != nil {
+					ctx.span.setMeta(keyTraceID128, ctx.traceID128)
+				}
+				ctx.traceID, err = strconv.ParseUint(v[16:], 16, 64)
+			} else { // invalid trace id length
+				return ErrSpanContextCorrupted
 			}
 			if err != nil {
 				return ErrSpanContextCorrupted

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -421,7 +421,7 @@ func TestEnvVars(t *testing.T) {
 					traceID128High: 0,
 					spanID:         1842642739201064,
 					out: map[string]string{
-						b3TraceIDHeader: "0000000000000000000504ab30404b09",
+						b3TraceIDHeader: "000504ab30404b09",
 						b3SpanIDHeader:  "00068bdfb1eb0428",
 					},
 				},
@@ -430,7 +430,7 @@ func TestEnvVars(t *testing.T) {
 					traceID128High: 0,
 					spanID:         9455715668862222,
 					out: map[string]string{
-						b3TraceIDHeader: "00000000000000000021dc1807524785",
+						b3TraceIDHeader: "0021dc1807524785",
 						b3SpanIDHeader:  "002197ec5d8a250e",
 					},
 				},

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -493,10 +493,10 @@ func TestEnvVars(t *testing.T) {
 				},
 				{
 					TextMapCarrier{
-						b3TraceIDHeader: "10000000000000001",
+						b3TraceIDHeader: "20000000000000001",
 						b3SpanIDHeader:  "1",
 					},
-					"0000000000000001",
+					"0000000000000002",
 					[]uint64{1, 1},
 				},
 				{

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -481,7 +481,7 @@ func TestEnvVars(t *testing.T) {
 			var tests = []struct {
 				in        TextMapCarrier
 				traceID18 string
-				out       []uint64 // contains [<trace_id>, <trace_id_128>, <span_id>]
+				out       []uint64 // contains [<trace_id>, <span_id>]
 			}{
 				{
 					TextMapCarrier{

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -465,7 +465,8 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 				span.setMeta(keyOrigin, context.origin)
 			}
 		}
-	} else if sharedinternal.BoolEnv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", false) {
+	}
+	if span.Meta[keyTraceID128] != "" && sharedinternal.BoolEnv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", false) {
 		id128 := startTime.Unix()
 		b := make([]byte, 8)
 		// casting from int64 -> uint32 should be safe since the start time won't be

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -449,7 +449,6 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		// this is a child span
 		span.TraceID = context.traceID
 		span.ParentID = context.spanID
-		span.setMeta(keyTraceID128, context.traceID128)
 		if p, ok := context.samplingPriority(); ok {
 			span.setMetric(keySamplingPriority, float64(p))
 		}
@@ -466,19 +465,20 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 			}
 		}
 	}
+	span.context = newSpanContext(span, context)
+	span.setMetric(ext.Pid, float64(t.pid))
+	span.setMeta("language", "go")
+
 	// add 128 bit trace id, if enabled, formatted as big-endian:
 	// <32-bit unix seconds> <32 bits of zero> <64 random bits>
-	if span.Meta[keyTraceID128] != "" && sharedinternal.BoolEnv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", false) {
+	if span.context.traceID128 == "" && sharedinternal.BoolEnv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", false) {
 		id128 := startTime.Unix()
 		b := make([]byte, 8)
 		// casting from int64 -> uint32 should be safe since the start time won't be
 		// negative, and the seconds should fit within 32-bits for the forseeable future.
 		binary.BigEndian.PutUint32(b, uint32(id128))
-		span.setMeta(keyTraceID128, hex.EncodeToString(b))
+		span.context.traceID128 = hex.EncodeToString(b)
 	}
-	span.context = newSpanContext(span, context)
-	span.setMetric(ext.Pid, float64(t.pid))
-	span.setMeta("language", "go")
 
 	// add tags from options
 	for k, v := range opts.Tags {

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -466,6 +466,8 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 			}
 		}
 	}
+	// add 128 bit trace id, if enabled, formatted as big-endian:
+	// <32-bit unix seconds> <32 bits of zero> <64 random bits>
 	if span.Meta[keyTraceID128] != "" && sharedinternal.BoolEnv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", false) {
 		id128 := startTime.Unix()
 		b := make([]byte, 8)

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -449,6 +449,7 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		// this is a child span
 		span.TraceID = context.traceID
 		span.ParentID = context.spanID
+		span.setMeta(keyTraceID128, context.traceID128)
 		if p, ok := context.samplingPriority(); ok {
 			span.setMetric(keySamplingPriority, float64(p))
 		}
@@ -464,14 +465,7 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 				span.setMeta(keyOrigin, context.origin)
 			}
 		}
-	}
-	span.context = newSpanContext(span, context)
-	span.setMetric(ext.Pid, float64(t.pid))
-	span.setMeta("language", "go")
-
-	// add 128 bit trace id, if enabled, formatted as big-endian:
-	// <32-bit unix seconds> <32 bits of zero> <64 random bits>
-	if sharedinternal.BoolEnv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", false) {
+	} else if sharedinternal.BoolEnv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", false) {
 		id128 := startTime.Unix()
 		b := make([]byte, 8)
 		// casting from int64 -> uint32 should be safe since the start time won't be
@@ -479,6 +473,9 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		binary.BigEndian.PutUint32(b, uint32(id128))
 		span.setMeta(keyTraceID128, hex.EncodeToString(b))
 	}
+	span.context = newSpanContext(span, context)
+	span.setMetric(ext.Pid, float64(t.pid))
+	span.setMeta("language", "go")
 
 	// add tags from options
 	for k, v := range opts.Tags {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Supports 128-bit trace id propagation in B3 multi headers. Other carriers will be supported in future PRs, and TODOs have been added in the code where it is needed.

Also fixes the issue where a `spanContext` needed to have an associated span to access and store 128-bit trace ids. It is now a separate field of the `spanContext`. Now, the `_dd.p.tid` tag in the `Meta` map (upper 64 bits of 128-bit trace ID) is populated from the `spanContext` upon span finish.

Updates #909

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.