### PR TITLE
tracer: small refactor for single span sampling

### DIFF
--- a/ddtrace/tracer/rules_sampler.go
+++ b/ddtrace/tracer/rules_sampler.go
@@ -364,7 +364,7 @@ func (rs *singleSpanRulesSampler) apply(span *span) bool {
 					return false
 				}
 			}
-			span.setMetric(keySpanSamplingMechanism, samplingMechanismSingleSpan)
+			span.setMetric(keySpanSamplingMechanism, float64(samplernames.SingleSpan))
 			span.setMetric(keySingleSpanSamplingRuleRate, rate)
 			if rule.MaxPerSecond != 0 {
 				span.setMetric(keySingleSpanSamplingMPS, rule.MaxPerSecond)

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -665,9 +665,3 @@ const (
 	keyUserScope     = "usr.scope"
 	keyUserSessionID = "usr.session_id"
 )
-
-const (
-	// samplingMechanismSingleSpan specifies value reserved to indicate that a span was kept
-	// on account of a single span sampling rule.
-	samplingMechanismSingleSpan = 8
-)

--- a/internal/samplernames/samplernames.go
+++ b/internal/samplernames/samplernames.go
@@ -31,7 +31,6 @@ const (
 	// RemoteUserRate specifies that the span was sampled
 	// with a user specified remote rate.
 	RemoteUserRate SamplerName = 6
-
 	// SingleSpan specifies that the span was sampled by single
 	// span sampling rules.
 	SingleSpan SamplerName = 8

--- a/internal/samplernames/samplernames.go
+++ b/internal/samplernames/samplernames.go
@@ -31,4 +31,8 @@ const (
 	// RemoteUserRate specifies that the span was sampled
 	// with a user specified remote rate.
 	RemoteUserRate SamplerName = 6
+
+	// SingleSpan specifies that the span was sampled by single
+	// span sampling rules.
+	SingleSpan SamplerName = 8
 )


### PR DESCRIPTION
Move `SamplerName` to meet the conventions of the rest of the repo.