### PR TITLE
tracer: refactor tests to support 128-bit trace id propagation

### DIFF
--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -421,7 +421,7 @@ func TestEnvVars(t *testing.T) {
 					traceID128High: 0,
 					spanID:         1842642739201064,
 					out: map[string]string{
-						b3TraceIDHeader: "0000000000000000000504ab30404b09",
+						b3TraceIDHeader: "000504ab30404b09",
 						b3SpanIDHeader:  "00068bdfb1eb0428",
 					},
 				},
@@ -430,7 +430,7 @@ func TestEnvVars(t *testing.T) {
 					traceID128High: 0,
 					spanID:         9455715668862222,
 					out: map[string]string{
-						b3TraceIDHeader: "00000000000000000021dc1807524785",
+						b3TraceIDHeader: "0021dc1807524785",
 						b3SpanIDHeader:  "002197ec5d8a250e",
 					},
 				},

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -479,9 +479,9 @@ func TestEnvVars(t *testing.T) {
 				t.Setenv(k, v)
 			}
 			var tests = []struct {
-				in        TextMapCarrier
-				traceID18 string
-				out       []uint64 // contains [<trace_id>, <span_id>]
+				in         TextMapCarrier
+				traceID128 string
+				out        []uint64 // contains [<trace_id>, <span_id>]
 			}{
 				{
 					TextMapCarrier{

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -421,7 +421,7 @@ func TestEnvVars(t *testing.T) {
 					traceID128High: 0,
 					spanID:         1842642739201064,
 					out: map[string]string{
-						b3TraceIDHeader: "000504ab30404b09",
+						b3TraceIDHeader: "0000000000000000000504ab30404b09",
 						b3SpanIDHeader:  "00068bdfb1eb0428",
 					},
 				},
@@ -430,7 +430,7 @@ func TestEnvVars(t *testing.T) {
 					traceID128High: 0,
 					spanID:         9455715668862222,
 					out: map[string]string{
-						b3TraceIDHeader: "0021dc1807524785",
+						b3TraceIDHeader: "00000000000000000021dc1807524785",
 						b3SpanIDHeader:  "002197ec5d8a250e",
 					},
 				},

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -449,7 +449,6 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		// this is a child span
 		span.TraceID = context.traceID
 		span.ParentID = context.spanID
-		span.setMeta(keyTraceID128, context.traceID128)
 		if p, ok := context.samplingPriority(); ok {
 			span.setMetric(keySamplingPriority, float64(p))
 		}
@@ -466,6 +465,10 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 			}
 		}
 	}
+	span.context = newSpanContext(span, context)
+	span.setMetric(ext.Pid, float64(t.pid))
+	span.setMeta("language", "go")
+
 	// add 128 bit trace id, if enabled, formatted as big-endian:
 	// <32-bit unix seconds> <32 bits of zero> <64 random bits>
 	if span.context.traceID128 == "" && sharedinternal.BoolEnv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", false) {
@@ -476,9 +479,6 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		binary.BigEndian.PutUint32(b, uint32(id128))
 		span.context.traceID128 = hex.EncodeToString(b)
 	}
-	span.context = newSpanContext(span, context)
-	span.setMetric(ext.Pid, float64(t.pid))
-	span.setMeta("language", "go")
 
 	// add tags from options
 	for k, v := range opts.Tags {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -697,7 +697,7 @@ func TestTracerStartSpanOptions128(t *testing.T) {
 		s := tracer.StartSpan("web.request", opts128...).(*span)
 		assert.Equal(uint64(987654), s.SpanID)
 		assert.Equal(uint64(987654), s.TraceID)
-		id := id128FromSpan(assert, s)
+		id := id128FromSpan(assert, s.Context())
 		// hex_encoded(<32-bit unix seconds> <32 bits of zero> <64 random bits>)
 		// 0001e240 (123456) + 00000000 (zeros) + 00000000000f1206 (987654)
 		assert.Equal("0001e2400000000000000000000f1206", id)
@@ -1015,8 +1015,8 @@ func testNewSpanChild(t *testing.T, is128 bool) {
 		// ids and services are inherited
 		assert.Equal(parent.SpanID, child.ParentID)
 		assert.Equal(parent.TraceID, child.TraceID)
-		id := id128FromSpan(assert, child)
-		assert.Equal(id128FromSpan(assert, parent), id)
+		id := id128FromSpan(assert, child.Context())
+		assert.Equal(id128FromSpan(assert, parent.Context()), id)
 		assert.Equal(parent.Service, child.Service)
 		// the resource is not inherited and defaults to the name
 		assert.Equal("redis.command", child.Resource)

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -49,10 +49,10 @@ func (t *tracer) newChildSpan(name string, parent *span) *span {
 	return t.StartSpan(name, ChildOf(parent.Context())).(*span)
 }
 
-func id128FromSpan(assert *assert.Assertions, span *span) string {
+func id128FromSpan(assert *assert.Assertions, ctx ddtrace.SpanContext) string {
 	var w3Cctx ddtrace.SpanContextW3C
 	var ok bool
-	w3Cctx, ok = span.Context().(ddtrace.SpanContextW3C)
+	w3Cctx, ok = ctx.(ddtrace.SpanContextW3C)
 	assert.True(ok)
 	id := w3Cctx.TraceID128()
 	assert.Len(id, 32)
@@ -680,7 +680,7 @@ func TestTracerStartSpanOptions128(t *testing.T) {
 		s := tracer.StartSpan("web.request", opts...).(*span)
 		assert.Equal(uint64(987654), s.SpanID)
 		assert.Equal(uint64(987654), s.TraceID)
-		id := id128FromSpan(assert, s)
+		id := id128FromSpan(assert, s.Context())
 		assert.Empty(s.Meta[keyTraceID128])
 		idBytes, err := hex.DecodeString(id)
 		assert.NoError(err)


### PR DESCRIPTION
Small refactor to tests to make it easier to test with 128-bit trace ids for other carriers.

These tests could probably be refactored even further to have less repetition, but for now, it's just extending them to support 128-bit trace ids.