### PR TITLE
.gitlab/scripts: Benchmark against common ancestor, not latest in main

### DIFF
--- a/.gitlab/scripts/run-benchmarks.sh
+++ b/.gitlab/scripts/run-benchmarks.sh
@@ -10,6 +10,7 @@ git clone --branch ${CI_COMMIT_REF_NAME} https://github.com/DataDog/dd-trace-go
 cd dd-trace-go/ddtrace/tracer/
 go test -run=XXX -bench "BenchmarkConcurrentTracing|BenchmarkStartSpan" -benchmem -count 10 -benchtime 2s ./... | tee ${ARTIFACTS_DIR}/pr_bench.txt
 
+CANDIDATE_BRANCH=$CI_COMMIT_REF_NAME
 BASELINE_BRANCH=$(github-find-merge-into-branch --for-repo="$CI_PROJECT_NAME" --for-pr="$CANDIDATE_BRANCH" || :)
 BASELINE_COMMIT_SHA=$(git merge-base "origin/$BASELINE_BRANCH" "origin/$UPSTREAM_BRANCH")
 

--- a/.gitlab/scripts/run-benchmarks.sh
+++ b/.gitlab/scripts/run-benchmarks.sh
@@ -10,7 +10,7 @@ git clone --branch ${CI_COMMIT_REF_NAME} https://github.com/DataDog/dd-trace-go
 cd dd-trace-go/ddtrace/tracer/
 go test -run=XXX -bench "BenchmarkConcurrentTracing|BenchmarkStartSpan" -benchmem -count 10 -benchtime 2s ./... | tee ${ARTIFACTS_DIR}/pr_bench.txt
 
-BASELINE_BRANCH=$(github-find-merge-into-branch --for-repo="$UPSTREAM_PROJECT_NAME" --for-pr="$UPSTREAM_BRANCH" || :)
+BASELINE_BRANCH=$(github-find-merge-into-branch --for-repo="$CI_PROJECT_NAME" --for-pr="$CANDIDATE_BRANCH" || :)
 BASELINE_COMMIT_SHA=$(git merge-base "origin/$BASELINE_BRANCH" "origin/$UPSTREAM_BRANCH")
 
 git checkout "$BASELINE_COMMIT_SHA"

--- a/.gitlab/scripts/run-benchmarks.sh
+++ b/.gitlab/scripts/run-benchmarks.sh
@@ -12,7 +12,7 @@ go test -run=XXX -bench "BenchmarkConcurrentTracing|BenchmarkStartSpan" -benchme
 
 CANDIDATE_BRANCH="$CI_COMMIT_REF_NAME"
 BASELINE_BRANCH=$(github-find-merge-into-branch --for-repo="$CI_PROJECT_NAME" --for-pr="$CANDIDATE_BRANCH" || :)
-BASELINE_COMMIT_SHA=$(git merge-base "origin/$BASELINE_BRANCH" "origin/$UPSTREAM_BRANCH")
+BASELINE_COMMIT_SHA=$(git merge-base "origin/$BASELINE_BRANCH" "origin/$CANDIDATE_BRANCH")
 
 git checkout "$BASELINE_COMMIT_SHA"
 go test -run=XXX -bench "BenchmarkConcurrentTracing|BenchmarkStartSpan" -benchmem -count 10 -benchtime 2s ./... | tee ${ARTIFACTS_DIR}/main_bench.txt

--- a/.gitlab/scripts/run-benchmarks.sh
+++ b/.gitlab/scripts/run-benchmarks.sh
@@ -5,12 +5,12 @@ set -x
 ARTIFACTS_DIR="/artifacts/${CI_JOB_ID}"
 mkdir -p "${ARTIFACTS_DIR}"
 
-git clone --branch ${CI_COMMIT_REF_NAME} https://github.com/DataDog/dd-trace-go
+git clone --branch "${CI_COMMIT_REF_NAME}" https://github.com/DataDog/dd-trace-go
 
 cd dd-trace-go/ddtrace/tracer/
 go test -run=XXX -bench "BenchmarkConcurrentTracing|BenchmarkStartSpan" -benchmem -count 10 -benchtime 2s ./... | tee ${ARTIFACTS_DIR}/pr_bench.txt
 
-CANDIDATE_BRANCH=$CI_COMMIT_REF_NAME
+CANDIDATE_BRANCH="$CI_COMMIT_REF_NAME"
 BASELINE_BRANCH=$(github-find-merge-into-branch --for-repo="$CI_PROJECT_NAME" --for-pr="$CANDIDATE_BRANCH" || :)
 BASELINE_COMMIT_SHA=$(git merge-base "origin/$BASELINE_BRANCH" "origin/$UPSTREAM_BRANCH")
 

--- a/.gitlab/scripts/run-benchmarks.sh
+++ b/.gitlab/scripts/run-benchmarks.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -x
+
 ARTIFACTS_DIR="/artifacts/${CI_JOB_ID}"
 mkdir -p "${ARTIFACTS_DIR}"
 

--- a/.gitlab/scripts/run-benchmarks.sh
+++ b/.gitlab/scripts/run-benchmarks.sh
@@ -8,5 +8,8 @@ git clone --branch ${CI_COMMIT_REF_NAME} https://github.com/DataDog/dd-trace-go
 cd dd-trace-go/ddtrace/tracer/
 go test -run=XXX -bench "BenchmarkConcurrentTracing|BenchmarkStartSpan" -benchmem -count 10 -benchtime 2s ./... | tee ${ARTIFACTS_DIR}/pr_bench.txt
 
-git checkout main
+BASELINE_BRANCH=$(github-find-merge-into-branch --for-repo="$UPSTREAM_PROJECT_NAME" --for-pr="$UPSTREAM_BRANCH" || :)
+BASELINE_COMMIT_SHA=$(git merge-base "origin/$BASELINE_BRANCH" "origin/$UPSTREAM_BRANCH")
+
+git checkout "$BASELINE_COMMIT_SHA"
 go test -run=XXX -bench "BenchmarkConcurrentTracing|BenchmarkStartSpan" -benchmem -count 10 -benchtime 2s ./... | tee ${ARTIFACTS_DIR}/main_bench.txt


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Updates the benchmarking scripts so that we evaluate against our common ancestor with main.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Currently we baseline against `main`, this can cause confusion where the PR branch hasn't merged the latest changes from `main` in. This change was recommended by @ddyurchenko who shared this is how the JS team handles it.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes
no QA needed
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.