### PR TITLE
contrib: stop caching appsec.Enabled() value for gin/echo

### DIFF
--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -22,7 +22,6 @@ import (
 // Middleware returns middleware that will trace incoming requests. If service is empty then the
 // default service name will be used.
 func Middleware(service string, opts ...Option) gin.HandlerFunc {
-	appsecEnabled := appsec.Enabled()
 	cfg := newConfig(service)
 	for _, opt := range opts {
 		opt(cfg)
@@ -52,7 +51,7 @@ func Middleware(service string, opts ...Option) gin.HandlerFunc {
 		c.Request = c.Request.WithContext(ctx)
 
 		// Use AppSec if enabled by user
-		if appsecEnabled {
+		if appsec.Enabled() {
 			useAppSec(c, span)
 		}
 

--- a/contrib/labstack/echo.v4/echotrace.go
+++ b/contrib/labstack/echo.v4/echotrace.go
@@ -25,7 +25,6 @@ import (
 
 // Middleware returns echo middleware which will trace incoming requests.
 func Middleware(opts ...Option) echo.MiddlewareFunc {
-	appsecEnabled := appsec.Enabled()
 	cfg := new(config)
 	defaults(cfg)
 	for _, fn := range opts {
@@ -70,7 +69,7 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 			// pass the span through the request context
 			c.SetRequest(request.WithContext(ctx))
 
-			if appsecEnabled {
+			if appsec.Enabled() {
 				next = withAppSec(next, span)
 			}
 			// serve the request to the next middleware


### PR DESCRIPTION
### What does this PR do?

Explicitely call `appsec.Enabled()` every time we want to check that appsec is enabled, instead of calling
it once and only using the cached value.

### Motivation

Appsec can now be enabled at runtime through remote configuration meaning that the value returned by `appsec.Enabled()`
can change during execution. Explicitely calling `appsec.Enabled()` makes sure the actual value used in our conditions is accurate.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.