### PR TITLE
internal/remoteconfig: add ASMUserBlocking capability

### DIFF
--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -40,6 +40,8 @@ const (
 	ASMIPBlocking
 	// ASMDDRules represents the capability to update the rules used by the ASM WAF for threat detection
 	ASMDDRules
+	// ASMUserBlocking represents the capability for ASM to block requests based on user ID
+	ASMUserBlocking = 7
 )
 
 // ProductUpdate represents an update for a specific product.


### PR DESCRIPTION

### What does this PR do?

Add a new capability to the list of capabilities handled by the remote configuration client.
This capability, `ASMUserBlocking`, can be registered for apps that are capable of blocking requests based on the user
ID.

### Motivation
This is needed as part of the AppSec user blocking feature (see https://github.com/DataDog/dd-trace-go/pull/1706)
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.