### PR TITLE
profiler: use size as the bound for execution trace recording

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -140,7 +140,7 @@ func logStartup(c *config) {
 		UploadTimeout        string   `json:"upload_timeout"`
 		TraceEnabled         bool     `json:"execution_trace_enabled"`
 		TracePeriod          string   `json:"execution_trace_period"`
-		TraceDuration        string   `json:"execution_trace_duration"`
+		TraceSizeLimit       int      `json:"execution_trace_size_limit"`
 		EndpointCountEnabled bool     `json:"endpoint_count_enabled"`
 	}{
 		Date:                 time.Now().Format(time.RFC3339),
@@ -166,7 +166,7 @@ func logStartup(c *config) {
 		UploadTimeout:        c.uploadTimeout.String(),
 		TraceEnabled:         c.traceEnabled,
 		TracePeriod:          c.traceConfig.Period.String(),
-		TraceDuration:        c.traceConfig.Duration.String(),
+		TraceSizeLimit:       c.traceConfig.Limit,
 		EndpointCountEnabled: c.endpointCountEnabled,
 	}
 	for t := range c.types {
@@ -312,10 +312,9 @@ func defaultConfig() (*config, error) {
 	// Experimental feature: Go execution trace (runtime/trace) recording.
 	c.traceEnabled = internal.BoolEnv("DD_PROFILING_EXECUTION_TRACE_ENABLED", false)
 	c.traceConfig.Period = internal.DurationEnv("DD_PROFILING_EXECUTION_TRACE_PERIOD", 5000*time.Second)
-	c.traceConfig.Duration = internal.DurationEnv("DD_PROFILING_EXECUTION_TRACE_DURATION", 1*time.Second)
 	c.traceConfig.Limit = internal.IntEnv("DD_PROFILING_EXECUTION_TRACE_LIMIT_BYTES", defaultExecutionTraceSizeLimit)
-	if c.traceEnabled && (c.traceConfig.Period == 0 || c.traceConfig.Duration == 0) {
-		log.Warn("Invalid execution trace config, enabled is true but duration or frequency is 0. Disabling execution trace.")
+	if c.traceEnabled && (c.traceConfig.Period == 0 || c.traceConfig.Limit == 0) {
+		log.Warn("Invalid execution trace config, enabled is true but size limit or frequency is 0. Disabling execution trace.")
 		c.traceEnabled = false
 	}
 	return &c, nil
@@ -545,12 +544,15 @@ func WithHostname(hostname string) Option {
 // executionTraceConfig controls how often, and for how long, runtime execution
 // traces are collected, see defaultConfig() for more details.
 type executionTraceConfig struct {
-	// Duration is how long the execution trace will run.
-	Duration time.Duration
 	// Period is the amount of time between traces.
 	Period time.Duration
-	// Limit is the desired upper bound, in bytes, of a collected trace. If
-	// zero, there is no size limit. Traces may be slightly larger than this
-	// limit due to flushing pending buffers at the end of tracing.
+	// Limit is the desired upper bound, in bytes, of a collected trace.
+	// Traces may be slightly larger than this limit due to flushing pending
+	// buffers at the end of tracing.
+	//
+	// We attempt to record for a full profiling period. The size limit of
+	// the trace is a better proxy for overhead (it scales with the number
+	// of events recorded) than duration, so we use that to decide when to
+	// stop tracing.
 	Limit int
 }

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -313,6 +313,7 @@ func defaultConfig() (*config, error) {
 	c.traceEnabled = internal.BoolEnv("DD_PROFILING_EXECUTION_TRACE_ENABLED", false)
 	c.traceConfig.Period = internal.DurationEnv("DD_PROFILING_EXECUTION_TRACE_PERIOD", 5000*time.Second)
 	c.traceConfig.Duration = internal.DurationEnv("DD_PROFILING_EXECUTION_TRACE_DURATION", 1*time.Second)
+	c.traceConfig.Limit = internal.IntEnv("DD_PROFILING_EXECUTION_TRACE_LIMIT_BYTES", defaultExecutionTraceSizeLimit)
 	if c.traceEnabled && (c.traceConfig.Period == 0 || c.traceConfig.Duration == 0) {
 		log.Warn("Invalid execution trace config, enabled is true but duration or frequency is 0. Disabling execution trace.")
 		c.traceEnabled = false
@@ -548,4 +549,8 @@ type executionTraceConfig struct {
 	Duration time.Duration
 	// Period is the amount of time between traces.
 	Period time.Duration
+	// Limit is the desired upper bound, in bytes, of a collected trace. If
+	// zero, there is no size limit. Traces may be slightly larger than this
+	// limit due to flushing pending buffers at the end of tracing.
+	Limit int
 }

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -215,7 +215,7 @@ var profileTypes = map[ProfileType]profileType{
 // 5MB was selected to give reasonable latency for processing, both online and
 // using offline tools. This is a conservative estimate--we could possibly get
 // away with 10MB and still have a tolerable experience.
-const defaultExecutionTraceSizeLimit = 5 << 20
+const defaultExecutionTraceSizeLimit = 5 * 1024 * 1024
 
 type limitedTraceCollector struct {
 	w       io.Writer

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -6,6 +6,7 @@
 package profiler
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,6 +15,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"runtime"
+	"runtime/trace"
 	"strings"
 	"sync"
 	"testing"
@@ -23,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/httpmem"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/traceprof"
@@ -610,4 +613,53 @@ func TestEndpointCounts(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExecutionTraceSizeLimit(t *testing.T) {
+	got := make(chan profileMeta)
+	server, client := httpmem.ServerAndClient(&mockBackend{t: t, profiles: got})
+	defer server.Close()
+
+	done := make(chan struct{})
+	// bigMessage just forces a bunch of data to be written to the trace buffer.
+	// We'll write ~300k bytes per second, and try to stop at ~100k bytes with
+	// a trace duration of 1 second, so we should stop early.
+	bigMessage := string(make([]byte, 1024))
+	tick := time.NewTicker(3 * time.Millisecond)
+	defer tick.Stop()
+	go func() {
+		for {
+			select {
+			case <-tick.C:
+				trace.Log(context.Background(), "msg", bigMessage)
+			case <-done:
+				return
+			}
+		}
+	}()
+	defer close(done)
+
+	t.Setenv("DD_PROFILING_EXECUTION_TRACE_ENABLED", "true")
+	t.Setenv("DD_PROFILING_EXECUTION_TRACE_PERIOD", "3s")
+	t.Setenv("DD_PROFILING_EXECUTION_TRACE_DURATION", "1s")
+	t.Setenv("DD_PROFILING_EXECUTION_TRACE_LIMIT_BYTES", "100000")
+	err := Start(
+		WithHTTPClient(client),
+		WithProfileTypes(), // just want the execution trace
+		WithPeriod(1*time.Second),
+	)
+	require.NoError(t, err)
+	defer Stop()
+
+	const expectedSize = 200 * 1024
+	for i := 0; i < 5; i++ {
+		m := <-got
+		if p, ok := m.attachments["go.trace"]; ok {
+			if len(p) > expectedSize {
+				t.Fatalf("profile was too large: want %d, got %d", expectedSize, len(p))
+			}
+			return
+		}
+	}
+	t.Errorf("did not see an execution trace")
 }

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -534,7 +534,6 @@ func TestExecutionTrace(t *testing.T) {
 
 	t.Setenv("DD_PROFILING_EXECUTION_TRACE_ENABLED", "true")
 	t.Setenv("DD_PROFILING_EXECUTION_TRACE_PERIOD", "3s")
-	t.Setenv("DD_PROFILING_EXECUTION_TRACE_DURATION", "50ms")
 	err := Start(
 		WithAgentAddr(server.Listener.Addr().String()),
 		WithProfileTypes(CPUProfile),
@@ -641,7 +640,6 @@ func TestExecutionTraceSizeLimit(t *testing.T) {
 
 	t.Setenv("DD_PROFILING_EXECUTION_TRACE_ENABLED", "true")
 	t.Setenv("DD_PROFILING_EXECUTION_TRACE_PERIOD", "3s")
-	t.Setenv("DD_PROFILING_EXECUTION_TRACE_DURATION", "1s")
 	t.Setenv("DD_PROFILING_EXECUTION_TRACE_LIMIT_BYTES", "100000")
 	err := Start(
 		WithHTTPClient(client),

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -623,7 +623,7 @@ func TestExecutionTraceSizeLimit(t *testing.T) {
 	done := make(chan struct{})
 	// bigMessage just forces a bunch of data to be written to the trace buffer.
 	// We'll write ~300k bytes per second, and try to stop at ~100k bytes with
-	// a trace duration of 1 second, so we should stop early.
+	// a trace duration of 2 seconds, so we should stop early.
 	bigMessage := string(make([]byte, 1024))
 	tick := time.NewTicker(3 * time.Millisecond)
 	defer tick.Stop()
@@ -646,12 +646,12 @@ func TestExecutionTraceSizeLimit(t *testing.T) {
 	err := Start(
 		WithHTTPClient(client),
 		WithProfileTypes(), // just want the execution trace
-		WithPeriod(1*time.Second),
+		WithPeriod(2*time.Second),
 	)
 	require.NoError(t, err)
 	defer Stop()
 
-	const expectedSize = 200 * 1024
+	const expectedSize = 300 * 1024
 	for i := 0; i < 5; i++ {
 		m := <-got
 		if p, ok := m.attachments["go.trace"]; ok {


### PR DESCRIPTION
### What does this PR do?

Adds a size limit for controlling execution trace recording. The size limit can
be configured using the `DD_PROFILING_EXECUTION_TRACE_LIMIT_BYTES` environment
variable, and defaults to 5MB (discussion below).

The execution trace duration configuration is removed, and the profiler will
attempt to record for the full profiling period, until the size limit is
reached.

### Motivation

Size is a better proxy for tracer overhead than duration. Overhead comes from
recording events, and execution trace size scales with the number of events
recorded. By using size, we can get larger traces for lightly-loaded services,
and maintain reasonable processing latencies and bandwidth usage.

The 5MB default limit still deserves some discussion. I picked this after
locally testing and seeing a tolerable latency for trace processing. It's a
conservative estimate, though, and "tolerable" varies from user to user. We
could do 10MB? It's worth experimenting.

### Describe how to test/QA your changes

This change includes a unit test. It's a bit tricky to test, because we'll
naturally overshoot the size limit a bit as pending events are flushed at the
end of tracing. I originally had the test emitting events in a tight loop, but
I found that the limit was frequently significantly exceeded before tracing
could stop. This might be an issue for real services which are extremely heavy
on scheduling activity, which could be an argument for keeping the default
limit smaller.

We should also run this in the reliability environment to make sure traces come
out to the expected size.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.
