### PR TITLE
profiler: make execution trace tag match the span tag

### DIFF
--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -554,7 +554,7 @@ func TestExecutionTrace(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		m := <-got
 		t.Log(m.event.Attachments, m.tags)
-		if contains(m.event.Attachments, "go.trace") && contains(m.tags, "profile_has_go_execution_trace:yes") {
+		if contains(m.event.Attachments, "go.trace") && contains(m.tags, "go_execution_traced:yes") {
 			seenTraces++
 		}
 	}

--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -88,7 +88,7 @@ func (p *profiler) doRequest(bat batch) error {
 	// that the uploads are more easily discoverable in the UI.
 	for _, b := range bat.profiles {
 		if b.pt == executionTrace {
-			tags = append(tags, "profile_has_go_execution_trace:yes")
+			tags = append(tags, "go_execution_traced:yes")
 		}
 	}
 	contentType, body, err := encode(bat, tags)


### PR DESCRIPTION
### What does this PR do?

Change the tag for profile uploads with execution trace data to
`go_execution_traced:yes`.

### Motivation

It's shorter and matches the tag we added for traced spans.

### Describe how to test/QA your changes

Unit test updated.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Changed code has unit tests for its functionality.
- [x] If this interacts with the agent in a new way, a system test has been added.
