### PR TITLE
ddtrace/tracer/textmap: always extract baggage when using w3c for compat

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -750,6 +750,7 @@ func (p *propagatorW3c) Extract(carrier interface{}) (ddtrace.SpanContext, error
 func (*propagatorW3c) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, error) {
 	var parentHeader string
 	var stateHeader string
+	var ctx spanContext
 	// to avoid parsing tracestate header(s) if traceparent is invalid
 	if err := reader.ForeachKey(func(k, v string) error {
 		key := strings.ToLower(k)
@@ -761,18 +762,23 @@ func (*propagatorW3c) extractTextMap(reader TextMapReader) (ddtrace.SpanContext,
 			parentHeader = v
 		case tracestateHeader:
 			stateHeader = v
+		default:
+			if strings.HasPrefix(key, DefaultBaggageHeaderPrefix) {
+				ctx.setBaggageItem(strings.TrimPrefix(key, DefaultBaggageHeaderPrefix), v)
+			}
 		}
 		return nil
 	}); err != nil {
 		return nil, err
 	}
-	var ctx spanContext
+
 	if err := parseTraceparent(&ctx, parentHeader); err != nil {
 		return nil, err
 	}
 	if err := parseTracestate(&ctx, stateHeader); err != nil {
 		return nil, err
 	}
+
 	return &ctx, nil
 }
 

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -1528,6 +1528,27 @@ func TestEnvVars(t *testing.T) {
 	})
 }
 
+func TestW3CExtractsBaggage(t *testing.T) {
+	tracer := newTracer()
+	defer tracer.Stop()
+	headers := TextMapCarrier{
+		traceparentHeader:      "00-12345678901234567890123456789012-1234567890123456-01",
+		tracestateHeader:       "dd=s:2;o:rum;t.usr.id:baz64~~",
+		"ot-baggage-something": "someVal",
+	}
+	s, err := tracer.Extract(headers)
+	assert.NoError(t, err)
+	found := false
+	s.ForeachBaggageItem(func(k, v string) bool {
+		if k == "something" {
+			found = true
+			return false
+		}
+		return true
+	})
+	assert.True(t, found)
+}
+
 func TestNonePropagator(t *testing.T) {
 	t.Run("inject/none", func(t *testing.T) {
 		t.Setenv(headerPropagationStyleInject, "none")


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
This cherry-picks across the change made in #1759 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes
tested in unit test
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.