### PR TITLE
contrib/redigo: add redis db index tag

### DIFF
--- a/contrib/gomodule/redigo/redigo.go
+++ b/contrib/gomodule/redigo/redigo.go
@@ -16,12 +16,13 @@ import (
 	"strconv"
 	"time"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/redigo"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 
-	redis "github.com/gomodule/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 // Conn is an implementation of the redis.Conn interface that supports tracing
@@ -48,6 +49,7 @@ type params struct {
 	network string
 	host    string
 	port    string
+	db      int
 }
 
 // parseOptions parses a set of arbitrary options (which can be of type redis.DialOption
@@ -98,7 +100,12 @@ func Dial(network, address string, options ...interface{}) (redis.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	tc := wrapConn(c, &params{cfg, network, host, port})
+	db := 0
+	dialCfg, ok := redigo.ResolveDialOpts(dialOpts)
+	if ok {
+		db = dialCfg.DB
+	}
+	tc := wrapConn(c, &params{cfg, network, host, port, db})
 	return tc, nil
 }
 
@@ -115,7 +122,12 @@ func DialContext(ctx context.Context, network, address string, options ...interf
 	if err != nil {
 		return nil, err
 	}
-	tc := wrapConn(c, &params{cfg, network, host, port})
+	db := 0
+	dialCfg, ok := redigo.ResolveDialOpts(dialOpts)
+	if ok {
+		db = dialCfg.DB
+	}
+	tc := wrapConn(c, &params{cfg, network, host, port, db})
 	return tc, nil
 }
 
@@ -139,8 +151,9 @@ func DialURL(rawurl string, options ...interface{}) (redis.Conn, error) {
 		host = "localhost"
 	}
 	network := "tcp"
+	db, _ := redigo.GetDBIndexFromURL(rawurl)
 	c, err := redis.DialURL(rawurl, dialOpts...)
-	tc := wrapConn(c, &params{cfg, network, host, port})
+	tc := wrapConn(c, &params{cfg, network, host, port, db})
 	return tc, err
 }
 
@@ -152,6 +165,7 @@ func newChildSpan(ctx context.Context, p *params) ddtrace.Span {
 		tracer.Tag(ext.Component, "gomodule/redigo"),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
 		tracer.Tag(ext.DBSystem, ext.DBSystemRedis),
+		tracer.Tag(ext.RedisDatabaseIndex, p.db),
 	}
 	if !math.IsNaN(p.config.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, p.config.analyticsRate))

--- a/contrib/internal/redigo/redigo.go
+++ b/contrib/internal/redigo/redigo.go
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023 Datadog, Inc.
+
+package redigo
+
+import (
+	"net/url"
+	"reflect"
+	"regexp"
+	"strconv"
+	"unsafe"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+
+	garyburdredis "github.com/garyburd/redigo/redis"
+	gomoduleredis "github.com/gomodule/redigo/redis"
+)
+
+// RedisDialConfig contains the configurable parameters for the Redis connection.
+type RedisDialConfig struct {
+	DB int
+}
+
+const (
+	structFieldNameDialOptionFunc = "f"
+	structFieldNameConfigDBIndex  = "db"
+)
+
+// DialOption is a type constraint for the redis.DialOption struct from both redigo integrations.
+type DialOption interface {
+	garyburdredis.DialOption | gomoduleredis.DialOption
+}
+
+// ResolveDialOpts resolves the config from the given []redis.DialOption.
+// Since both the config struct (redis.dialOption) and the redis.DialOption.f struct field are unexported,
+// this function uses reflection to initialize and access the struct fields.
+func ResolveDialOpts[T DialOption](opts []T) (*RedisDialConfig, bool) {
+	if len(opts) == 0 {
+		return &RedisDialConfig{}, true
+	}
+	defer func() {
+		if err := recover(); err != nil {
+			log.Debug("contrib/internal/redigo: Failed to resolve dial options")
+		}
+	}()
+	cfg := &RedisDialConfig{}
+	redisDoVal := newRedisDialOptionValue(opts[0])
+	for _, opt := range opts {
+		funcVal := reflect.ValueOf(&opt).Elem().FieldByName(structFieldNameDialOptionFunc)
+		callableFuncVal := reflect.NewAt(funcVal.Type(), unsafe.Pointer(funcVal.UnsafeAddr())).Elem()
+		callArgs := []reflect.Value{redisDoVal}
+		_ = callableFuncVal.Call(callArgs)
+	}
+	cfg.DB = int(redisDoVal.Elem().FieldByName(structFieldNameConfigDBIndex).Int())
+	return cfg, true
+}
+
+// newRedisDialOptionValue initializes the unexported *redis.dialOptions struct from redigo/redis.
+// This is equivalent to doing the following: return &redis.dialOptions{}
+func newRedisDialOptionValue[T DialOption](opt T) reflect.Value {
+	fVal := reflect.ValueOf(&opt).Elem().FieldByName(structFieldNameDialOptionFunc)
+	firstArgType := fVal.Type().In(0)
+	firstArgPtrVal := reflect.New(firstArgType).Elem()
+	s := firstArgPtrVal.Type().Elem()
+	return reflect.New(s)
+}
+
+var pathDBRegexp = regexp.MustCompile(`/(\d*)\z`)
+
+// GetDBIndexFromURL extracts the DB Index from the given Redis connection URL. The URLs should follow the draft IANA
+// specification for the scheme (https://www.iana.org/assignments/uri-schemes/prov/redis).
+// Example: redis://user:secret@localhost:6379/0?foo=bar&qux=baz
+func GetDBIndexFromURL(rawURL string) (int, bool) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return 0, false
+	}
+	if u.Path == "" {
+		return 0, true
+	}
+	match := pathDBRegexp.FindStringSubmatch(u.Path)
+	if len(match) == 2 {
+		if len(match[1]) > 0 {
+			if db, err := strconv.Atoi(match[1]); err == nil {
+				return db, true
+			}
+		}
+	}
+	return 0, false
+}

--- a/ddtrace/ext/db.go
+++ b/ddtrace/ext/db.go
@@ -50,3 +50,9 @@ const (
 	// MongoDBCollection indicates the collection being accessed.
 	MongoDBCollection = "db.mongodb.collection"
 )
+
+// Redis tags.
+const (
+	// RedisDatabaseIndex indicates the Redis database index connected to.
+	RedisDatabaseIndex = "db.redis.database_index"
+)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Adds `db.redis.database_index` tag to the following integrations:
- `contrib/gomodule/redigo`
- `contrib/garyburd/redigo`

It also adds a new internal package with helper functions reused in both `redigo` integrations under `contrib/internal/redigo`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->
Unify span tags across tracers.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Changed code has unit tests for its functionality.
- [x] If this interacts with the agent in a new way, a system test has been added.