### PR TITLE
profiler: record timestamp at the start execution tracing

### DIFF
--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -191,9 +191,7 @@ var profileTypes = map[ProfileType]profileType{
 			if !p.shouldTrace() {
 				return nil, errors.New("started tracing erroneously, indicating a bug in the profiler")
 			}
-			defer func() {
-				p.lastTrace = time.Now()
-			}()
+			p.lastTrace = time.Now()
 			buf := new(bytes.Buffer)
 			lt := &limitedTraceCollector{
 				w:     buf,

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -551,7 +551,7 @@ func TestExecutionTrace(t *testing.T) {
 		return false
 	}
 	seenTraces := 0
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 4; i++ {
 		m := <-got
 		t.Log(m.event.Attachments, m.tags)
 		if contains(m.event.Attachments, "go.trace") && contains(m.tags, "go_execution_traced:yes") {
@@ -559,7 +559,7 @@ func TestExecutionTrace(t *testing.T) {
 		}
 	}
 	// With a trace frequency of 3 seconds and a profiling period of 1
-	// second, we should see 2 traces after 5 profile collections: one at
+	// second, we should see 2 traces after 4 profile collections: one at
 	// the start, and one 3 seconds later.
 	if seenTraces != 2 {
 		t.Errorf("wanted %d traces, got %d", 2, seenTraces)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Sets the timestamp for the last execution trace recording at the beginning,
rather than the end, of recording.

### Motivation

Setting a tracing period matching the profile period will do the expected thing
of sending a trace with every profile upload, rather than every _other_ profile
upload.

### Describe how to test/QA your changes

The unit test has been updated. Previously, with a profile period of 1 second
and a trace period of 3 seconds, it took 5 uploads to see the expected 2
traces. But really it should only have taken 4.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Changed code has unit tests for its functionality.
- [x] If this interacts with the agent in a new way, a system test has been added.
