### PR TITLE
database/sql: Export TracedConn, as we need it when using the db.Conn Raw() API call.

### DIFF
--- a/contrib/database/sql/conn.go
+++ b/contrib/database/sql/conn.go
@@ -38,6 +38,7 @@ const (
 	keyDBMTraceInjected = "_dd.dbm_trace_injected"
 )
 
+// TracedConn holds a traced connection with tracing parameters.
 type TracedConn struct {
 	driver.Conn
 	*traceParams

--- a/contrib/database/sql/conn.go
+++ b/contrib/database/sql/conn.go
@@ -43,6 +43,7 @@ type TracedConn struct {
 	*traceParams
 }
 
+// WrappedConn returns the wrapped connection object.
 func (tc *TracedConn) WrappedConn() driver.Conn {
 	return tc.Conn
 }
@@ -135,7 +136,7 @@ func (tc *TracedConn) ExecContext(ctx context.Context, query string, args []driv
 	return nil, driver.ErrSkip
 }
 
-// PingContext verifies the connection to the database is still alive.
+// Ping verifies the connection to the database is still alive.
 func (tc *TracedConn) Ping(ctx context.Context) (err error) {
 	start := time.Now()
 	if pinger, ok := tc.Conn.(driver.Pinger); ok {

--- a/contrib/database/sql/sql.go
+++ b/contrib/database/sql/sql.go
@@ -160,7 +160,7 @@ func (t *tracedConnector) Connect(ctx context.Context) (driver.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &tracedConn{conn, tp}, err
+	return &TracedConn{conn, tp}, err
 }
 
 func (t *tracedConnector) Driver() driver.Driver {


### PR DESCRIPTION
We would prefer to be able to type assert to this interface type, but we cannot type assert without the type being exported. The alternative would be to use reflection here.

In addition, we want to be able to, on occasion, access the underlying connection object, hence the addition of the WrappedConn() function.

This is an up-to-date-version of https://github.com/DataDog/dd-trace-go/pull/1566 , you can read this change  there.