### PR TITLE
tracer: never set an empty tracestate header

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -634,13 +634,15 @@ func (*propagatorW3c) injectTextMap(spanCtx ddtrace.SpanContext, writer TextMapW
 	}
 
 	var traceID string
-	// if previous traceparent is valid, do NOT update the trace ID
+	var tracestate string
 	if ctx.trace != nil && ctx.trace.propagatingTags != nil {
-		tag := ctx.trace.propagatingTags[w3cTraceIDTag]
-		if len(tag) == 32 {
-			id, err := strconv.ParseUint(tag[16:], 16, 64)
+		tracestate = ctx.trace.propagatingTags[tracestateHeader]
+		idTag := ctx.trace.propagatingTags[w3cTraceIDTag]
+		// if previous traceparent is valid, do NOT update the trace ID
+		if len(idTag) == 32 {
+			id, err := strconv.ParseUint(idTag[16:], 16, 64)
 			if err == nil && id != 0 {
-				traceID = tag
+				traceID = idTag
 			}
 		}
 	}
@@ -648,15 +650,13 @@ func (*propagatorW3c) injectTextMap(spanCtx ddtrace.SpanContext, writer TextMapW
 		traceID = fmt.Sprintf("%032x", ctx.traceID)
 	}
 	writer.Set(traceparentHeader, fmt.Sprintf("00-%s-%016x-%v", traceID, ctx.spanID, flags))
-	// if context priority / origin / tags were updated after extraction,
-	// or the tracestateHeader doesn't start with `dd=`
-	// we need to recreate tracestate
-	if ctx.updated ||
-		(ctx.trace != nil && ctx.trace.propagatingTags != nil && !strings.HasPrefix(ctx.trace.propagatingTags[tracestateHeader], "dd=")) ||
-		len(ctx.trace.propagatingTags[tracestateHeader]) == 0 {
-		writer.Set(tracestateHeader, composeTracestate(ctx, p, ctx.trace.propagatingTags[tracestateHeader]))
-	} else {
-		writer.Set(tracestateHeader, ctx.trace.propagatingTags[tracestateHeader])
+	// re-generate the tracestate if the context priority / origin / tags
+	// were updated after extraction, or the header is not prefixed with "dd="
+	if ctx.updated || !strings.HasPrefix(tracestate, "dd=") {
+		tracestate = composeTracestate(ctx, p, tracestate)
+	}
+	if tracestate != "" {
+		writer.Set(tracestateHeader, tracestate)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Refactors the injection of the `tracestate` header for W3C.

Fixes #1776

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

The code may have set an empty `tracestate` previously, which would cause incorrect warnings to be logged later.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

No QA needed

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.