### PR TITLE
.github/workflows: integrate APM E2E tests in Github Actions CI

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Compress artifact
         if: ${{ always() }}
-        run: tar -czvf artifact.tar.gz $(ls | grep -e "logs*")
+        run: tar -czvf artifact.tar.gz $(ls | grep logs)
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -53,9 +53,23 @@ jobs:
       - name: Run
         run: ./run.sh
 
+      - name: Run APM E2E default tests
+        env:
+          DD_API_KEY: ${{ secrets.SYSTEM_TESTS_E2E_DD_API_KEY }}
+          DD_APPLICATION_KEY: ${{ secrets.SYSTEM_TESTS_E2E_DD_APP_KEY }}
+          DD_SITE: "datadoghq.com"
+        run: ./run.sh APM_TRACING_E2E
+
+      - name: Run APM E2E Single Span tests
+        env:
+          DD_API_KEY: ${{ secrets.SYSTEM_TESTS_E2E_DD_API_KEY }}
+          DD_APPLICATION_KEY: ${{ secrets.SYSTEM_TESTS_E2E_DD_APP_KEY }}
+          DD_SITE: "datadoghq.com"
+        run: ./run.sh APM_TRACING_E2E_SINGLE_SPAN
+
       - name: Compress artifact
         if: ${{ always() }}
-        run: tar -czvf artifact.tar.gz $(ls | grep logs)
+        run: tar -czvf artifact.tar.gz $(ls | grep -e "logs*")
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR enables the APM end-to-end (E2E) tests in Github Actions CI.

At the moment, the default test is enabled for all variants, but the [Single Spans test is only implemented for the `chi` variant](https://github.com/DataDog/system-tests/blob/3a028228a56671e7fb10ff85cb6039f0efb45ec1/utils/build/docker/golang/app/chi.go#L136-L160). All other variants will still run the jobs, but are skipped (in system-tests terms they are expectedly failing).

Once we verify that this works well, we can implement the rest variants too, in follow-up PRs.

Examples of successful jobs:
- `chi`: https://github.com/DataDog/dd-trace-go/actions/runs/4366904885/jobs/7651749363
  - Single Spans test runs and passes.
- `echo`: https://github.com/DataDog/dd-trace-go/actions/runs/4366904885/jobs/7651749157
  - Single Spans test is expectedly skipped.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

We had several incidents with features not working correctly due to incorrect assumptions, and bugs, in some component of the whole APM tracing pipeline (tracer, agent, backend). 

We want to enable end-to-end tests for key use-cases to avoid regressions in the future.
See ATI-2419 for more details.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.