### PR TITLE
profiler: document/test that Start restarts the profiler

### DIFF
--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -32,8 +32,11 @@ var (
 	containerID    = internal.ContainerID() // replaced in tests
 )
 
-// Start starts the profiler. It may return an error if an API key is not provided by means of
-// the WithAPIKey option, or if a hostname is not found.
+// Start starts the profiler. If the profiler is already running, it will be
+// stopped and restarted with the given options.
+//
+// It may return an error if an API key is not provided by means of the
+// WithAPIKey option, or if a hostname is not found.
 func Start(opts ...Option) error {
 	mu.Lock()
 	defer mu.Unlock()


### PR DESCRIPTION
### What does this PR do?

Document that Start will restart the profiler with the given configuration if
the profiler was already running. Add a test to lock in this behavior.

This PR also removes the TestStartStopIdempotent test. This test made no
assertions, and at any rate Start was not idempotent to begin with.

### Motivation

Start will first stop the profiler if it is already running, and the
re-start it with the given configuration. This behavior is not
documented. It is also not tested--the current test suite passes if
Start is changed to return early when the profiler is already active.
It is possible that there are apps out there which rely on this behavior
(some of our internal apps do), and it would be a breaking change for
these apps to make Start do nothing if the profiler is already started.
Given that there isn't a strong reason to change the behavior otherwise,
we should document it and make sure it's actually tested.

### Describe how to test/QA your changes

See the unit test.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Changed code has unit tests for its functionality.
- [x] If this interacts with the agent in a new way, a system test has been added.
