### PR TITLE
profiler: deprecate PprofDiff

### DIFF
--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -523,7 +523,7 @@ func (cdp *comparingDeltaProfiler) Delta(data []byte) (res []byte, err error) {
 		return res, nil
 	}
 
-	pprofDiff, err := pprofDiff(pprofSut, pprofGolden)
+	pprofDiff, err := PprofDiff(pprofSut, pprofGolden)
 	if err != nil {
 		cdp.reportError(err.Error())
 		return res, nil
@@ -572,11 +572,18 @@ func (cdp *comparingDeltaProfiler) reportError(error string, extraTags ...string
 	_ = cdp.statsd.Count("datadog.profiling.go.delta_compare.error", 1, tags, 1)
 }
 
-// pprofDiff computes the delta between all values b-a and returns them as a new
+// PprofDiff computes the delta between all values b-a and returns them as a new
 // profile. Samples that end up with a delta of 0 are dropped. WARNING: Profile
 // a will be mutated by this function. You should pass a copy if that's
 // undesirable.
-func pprofDiff(a, b *pprofile.Profile) (*pprofile.Profile, error) {
+//
+// Deprecated: This function was introduced into our public API unintentionally.
+// It will be removed in the next release. If you need this functionality,
+// it can be implemented in two lines:
+//
+//	a.Scale(-1)
+//	return pprofile.Merge([]*pprofile.Profile{a, b})
+func PprofDiff(a, b *pprofile.Profile) (*pprofile.Profile, error) {
 	a.Scale(-1)
 	return pprofile.Merge([]*pprofile.Profile{a, b})
 }

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -523,7 +523,7 @@ func (cdp *comparingDeltaProfiler) Delta(data []byte) (res []byte, err error) {
 		return res, nil
 	}
 
-	pprofDiff, err := PprofDiff(pprofSut, pprofGolden)
+	pprofDiff, err := pprofDiff(pprofSut, pprofGolden)
 	if err != nil {
 		cdp.reportError(err.Error())
 		return res, nil
@@ -572,11 +572,11 @@ func (cdp *comparingDeltaProfiler) reportError(error string, extraTags ...string
 	_ = cdp.statsd.Count("datadog.profiling.go.delta_compare.error", 1, tags, 1)
 }
 
-// PprofDiff computes the delta between all values b-a and returns them as a new
+// pprofDiff computes the delta between all values b-a and returns them as a new
 // profile. Samples that end up with a delta of 0 are dropped. WARNING: Profile
 // a will be mutated by this function. You should pass a copy if that's
 // undesirable.
-func PprofDiff(a, b *pprofile.Profile) (*pprofile.Profile, error) {
+func pprofDiff(a, b *pprofile.Profile) (*pprofile.Profile, error) {
 	a.Scale(-1)
 	return pprofile.Merge([]*pprofile.Profile{a, b})
 }

--- a/profiler/profile_test.go
+++ b/profiler/profile_test.go
@@ -430,7 +430,7 @@ func requirePprofEqual(t *testing.T, a, b []byte) {
 	require.NoError(t, err)
 	pprofB, err := pprofile.ParseData(b)
 	require.NoError(t, err)
-	pprofDiff, err := pprofDiff(pprofA, pprofB)
+	pprofDiff, err := PprofDiff(pprofA, pprofB)
 	require.NoError(t, err)
 	require.Len(t, pprofDiff.Sample, 0)
 }

--- a/profiler/profile_test.go
+++ b/profiler/profile_test.go
@@ -430,7 +430,7 @@ func requirePprofEqual(t *testing.T, a, b []byte) {
 	require.NoError(t, err)
 	pprofB, err := pprofile.ParseData(b)
 	require.NoError(t, err)
-	pprofDiff, err := PprofDiff(pprofA, pprofB)
+	pprofDiff, err := pprofDiff(pprofA, pprofB)
 	require.NoError(t, err)
 	require.Len(t, pprofDiff.Sample, 0)
 }


### PR DESCRIPTION
### What does this PR do?

Deprecates the PprofDiff function. It will be removed in v1.50.0.

### Motivation

The PprofDiff function was added to our public API unintentionally as
part of #1511. The function is only meant for internal use. This was
missed during code review, likely due to the size of the change and the
fact that most of our attention was devoted to making sure the core
parts of the change were implemented correctly.

This is an exception to our normal v1 compatibility guarantees. It is
very unlikely that any of our users depend on this function. It serves
no purpose in the context of the profiler's public API, and anybody who
might have a reason to use this function would probably have already
found a way to do what they want using the
github.com/google/pprof/profile package.

### Describe how to test/QA your changes

N/A

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Changed code has unit tests for its functionality.
- [x] If this interacts with the agent in a new way, a system test has been added.
