### PR TITLE
internal/telemetry: support v2 telemetry

### DIFF
--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -15,8 +15,6 @@ import (
 	"net/http"
 	"os"
 	"runtime"
-	"runtime/debug"
-	"strings"
 	"sync"
 	"time"
 
@@ -28,8 +26,11 @@ import (
 )
 
 var (
+	// GlobalClient acts as a global telemetry client that the
+	// tracer, profiler, and appsec products will use
+	GlobalClient *Client
 	// copied from dd-trace-go/profiler
-	defaultClient = &http.Client{
+	defaultHTTPClient = &http.Client{
 		// We copy the transport to avoid using the default one, as it might be
 		// augmented with tracing and we don't want these calls to be recorded.
 		// See https://golang.org/pkg/net/http/#DefaultTransport .
@@ -47,10 +48,18 @@ var (
 		},
 		Timeout: 5 * time.Second,
 	}
-	// TODO: Default telemetry URL?
 	hostname string
 
+	// protects agentlessURL, which may be changed for testing purposes
+	agentlessEndpointLock sync.RWMutex
+	// agentlessURL is the endpoint used to send telemetry in an agentless environment. It is
+	// also the default URL in case connecting to the agent URL fails.
+	agentlessURL = "https://instrumentation-telemetry-intake.datadoghq.com/api/v2/apmtelemetry"
+
 	defaultHeartbeatInterval = 60 // seconds
+
+	// LogPrefix specifies the prefix for all telemetry logging
+	LogPrefix = "Instrumentation telemetry: "
 )
 
 func init() {
@@ -58,6 +67,8 @@ func init() {
 	if err == nil {
 		hostname = h
 	}
+	GlobalClient = new(Client)
+	GlobalClient.applyFallbackOps()
 }
 
 // Client buffers and sends telemetry messages to Datadog (possibly through an
@@ -73,9 +84,6 @@ type Client struct {
 	// APIKey should be supplied if the endpoint is not a Datadog agent,
 	// i.e. you are sending telemetry directly to Datadog
 	APIKey string
-	// How often to send batched requests. Defaults to 60s
-	SubmissionInterval time.Duration
-
 	// The interval for sending a heartbeat signal to the backend.
 	// Configurable with DD_TELEMETRY_HEARTBEAT_INTERVAL. Default 60s.
 	heartbeatInterval time.Duration
@@ -87,21 +95,6 @@ type Client struct {
 	Service string
 	Env     string
 	Version string
-
-	// Determines whether telemetry should actually run.
-	// Defaults to false, but will be overridden by the environment variable
-	// DD_INSTRUMENTATION_TELEMETRY_ENABLED is set to 0 or false
-	Disabled bool
-
-	// debug enables the debug flag for all requests, see
-	// https://dtdg.co/3bv2MMv If set, the DD_INSTRUMENTATION_TELEMETRY_DEBUG
-	// takes precedence over this field.
-	debug bool
-
-	// Optional destination to record submission-related logging events
-	Logger interface {
-		Printf(msg string, args ...interface{})
-	}
 
 	// Client will be used for telemetry uploads. This http.Client, if
 	// provided, should be the same as would be used for any other
@@ -115,193 +108,41 @@ type Client struct {
 
 	// mu guards all of the following fields
 	mu sync.Mutex
+
+	// debug enables the debug flag for all requests, see
+	// https://dtdg.co/3bv2MMv.
+	// DD_INSTRUMENTATION_TELEMETRY_DEBUG configures this field.
+	debug bool
 	// started is true in between when Start() returns and the next call to
 	// Stop()
 	started bool
 	// seqID is a sequence number used to order telemetry messages by
 	// the back end.
 	seqID int64
-	// flushT is used to schedule flushing outstanding messages
-	flushT *time.Timer
 	// heartbeatT is used to schedule heartbeat messages
 	heartbeatT *time.Timer
 	// requests hold all messages which don't need to be immediately sent
 	requests []*Request
 	// metrics holds un-sent metrics that will be aggregated the next time
 	// metrics are sent
-	metrics    map[string]*metric
+	metrics    map[Namespace]map[string]*metric
 	newMetrics bool
 }
 
 func (c *Client) log(msg string, args ...interface{}) {
-	if c.Logger == nil {
-		return
-	}
-	c.Logger.Printf(msg, args...)
+	// Debug level so users aren't spammed with telemetry info.
+	log.Debug(fmt.Sprintf(LogPrefix+msg, args...))
 }
 
-// Start registers that the app has begun running with the given integrations
-// and configuration.
-func (c *Client) Start(integrations []Integration, configuration []Configuration) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.Disabled || !internal.BoolEnv("DD_INSTRUMENTATION_TELEMETRY_ENABLED", true) {
-		return
-	}
-	if c.started {
-		return
-	}
-	c.debug = internal.BoolEnv("DD_INSTRUMENTATION_TELEMETRY_DEBUG", c.debug)
-
-	c.started = true
-
-	// XXX: Should we let metrics persist between starting and stopping?
-	c.metrics = make(map[string]*metric)
-
-	payload := &AppStarted{
-		Integrations:  append([]Integration{}, integrations...),
-		Configuration: append([]Configuration{}, configuration...),
-	}
-	deps, ok := debug.ReadBuildInfo()
-	if ok {
-		for _, dep := range deps.Deps {
-			payload.Dependencies = append(payload.Dependencies,
-				Dependency{
-					Name:    dep.Path,
-					Version: dep.Version,
-				},
-			)
-		}
-	}
-
-	// configEnvFallback returns the value of environment variable with the
-	// given key if def == ""
-	configEnvFallback := func(key, def string) string {
-		if def != "" {
-			return def
-		}
-		return os.Getenv(key)
-	}
-	c.Service = configEnvFallback("DD_SERVICE", c.Service)
-	if len(c.Service) == 0 {
-		if name := globalconfig.ServiceName(); len(name) != 0 {
-			c.Service = name
-		} else {
-			// I think service *has* to be something?
-			c.Service = "unnamed-go-service"
-		}
-	}
-	c.Env = configEnvFallback("DD_ENV", c.Env)
-	c.Version = configEnvFallback("DD_VERSION", c.Version)
-
-	c.APIKey = configEnvFallback("DD_API_KEY", c.APIKey)
-
-	r := c.newRequest(RequestTypeAppStarted)
-	r.Payload = payload
-	c.scheduleSubmit(r)
-	c.flush()
-
-	if c.SubmissionInterval == 0 {
-		c.SubmissionInterval = 60 * time.Second
-	}
-	c.flushT = time.AfterFunc(c.SubmissionInterval, c.backgroundFlush)
-
-	heartbeat := internal.IntEnv("DD_TELEMETRY_HEARTBEAT_INTERVAL", defaultHeartbeatInterval)
-	if heartbeat < 1 || heartbeat > 3600 {
-		log.Warn("DD_TELEMETRY_HEARTBEAT_INTERVAL=%d not in [1,3600] range, setting to default of %d", heartbeat, defaultHeartbeatInterval)
-		heartbeat = defaultHeartbeatInterval
-	}
-	c.heartbeatInterval = time.Duration(heartbeat) * time.Second
-	c.heartbeatT = time.AfterFunc(c.heartbeatInterval, c.backgroundHeartbeat)
+// Disabled returns whether instrumentation telemetry is disabled
+// according to the DD_INSTRUMENTATION_TELEMETRY_ENABLED env var
+func Disabled() bool {
+	return !internal.BoolEnv("DD_INSTRUMENTATION_TELEMETRY_ENABLED", true)
 }
 
-// Stop notifies the telemetry endpoint that the app is closing. All outstanding
-// messages will also be sent. No further messages will be sent until the client
-// is started again
-func (c *Client) Stop() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if !c.started {
-		return
-	}
-	c.started = false
-	c.flushT.Stop()
-	c.heartbeatT.Stop()
-	// close request types have no body
-	r := c.newRequest(RequestTypeAppClosing)
-	c.scheduleSubmit(r)
-	c.flush()
-}
-
-type metricKind string
-
-var (
-	metricKindGauge metricKind = "gauge"
-	metricKindCount metricKind = "count"
-)
-
-type metric struct {
-	name  string
-	kind  metricKind
-	value float64
-	// Unix timestamp
-	ts     float64
-	tags   []string
-	common bool
-}
-
-// TODO: Can there be identically named/tagged metrics with a "common" and "not
-// common" variant?
-
-func newmetric(name string, kind metricKind, tags []string, common bool) *metric {
-	return &metric{
-		name:   name,
-		kind:   kind,
-		tags:   append([]string{}, tags...),
-		common: common,
-	}
-}
-
-func metricKey(name string, tags []string) string {
-	return name + strings.Join(tags, "-")
-}
-
-// Gauge sets the value for a gauge with the given name and tags. If the metric
-// is not language-specific, common should be set to true
-func (c *Client) Gauge(name string, value float64, tags []string, common bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if !c.started {
-		return
-	}
-	key := metricKey(name, tags)
-	m, ok := c.metrics[key]
-	if !ok {
-		m = newmetric(name, metricKindGauge, tags, common)
-		c.metrics[key] = m
-	}
-	m.value = value
-	m.ts = float64(time.Now().Unix())
-	c.newMetrics = true
-}
-
-// Count adds the value to a count with the given name and tags. If the metric
-// is not language-specific, common should be set to true
-func (c *Client) Count(name string, value float64, tags []string, common bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if !c.started {
-		return
-	}
-	key := metricKey(name, tags)
-	m, ok := c.metrics[key]
-	if !ok {
-		m = newmetric(name, metricKindCount, tags, common)
-		c.metrics[key] = m
-	}
-	m.value += value
-	m.ts = float64(time.Now().Unix())
-	c.newMetrics = true
+// collectDependencies returns whether dependencies telemetry information is sent
+func collectDependencies() bool {
+	return internal.BoolEnv("DD_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED", true)
 }
 
 // flush sends any outstanding telemetry messages and aggregated metrics to be
@@ -312,25 +153,24 @@ func (c *Client) flush() {
 	if c.newMetrics {
 		c.newMetrics = false
 		r := c.newRequest(RequestTypeGenerateMetrics)
-		payload := &Metrics{
-			Namespace:   c.Namespace,
-			LibLanguage: "go",
-			LibVersion:  version.Tag,
-		}
-		for _, m := range c.metrics {
-			s := Series{
-				Metric: m.name,
-				Type:   string(m.kind),
-				Tags:   m.tags,
-				Common: m.common,
+		for namespace := range c.metrics {
+			payload := &Metrics{
+				Namespace: namespace,
 			}
-			s.Points = [][2]float64{{m.ts, m.value}}
-			payload.Series = append(payload.Series, s)
+			for _, m := range c.metrics[namespace] {
+				s := Series{
+					Metric: m.name,
+					Type:   string(m.kind),
+					Tags:   m.tags,
+					Common: m.common,
+				}
+				s.Points = [][2]float64{{m.ts, m.value}}
+				payload.Series = append(payload.Series, s)
+			}
+			r.Body.Payload = payload
+			submissions = append(submissions, r)
 		}
-		r.Payload = payload
-		submissions = append(submissions, r)
 	}
-
 	// copy over requests so we can do the actual submission without holding
 	// the lock. Zero out the old stuff so we don't leak references
 	for i, r := range c.requests {
@@ -341,9 +181,9 @@ func (c *Client) flush() {
 
 	go func() {
 		for _, r := range submissions {
-			err := c.submit(r)
+			err := r.submit()
 			if err != nil {
-				c.log("telemetry submission failed: %s", err)
+				c.log("submission error: %s", err.Error())
 			}
 		}
 	}()
@@ -373,8 +213,8 @@ func getOSVersion() string {
 // sent through this Client
 func (c *Client) newRequest(t RequestType) *Request {
 	c.seqID++
-	return &Request{
-		APIVersion:  "v1",
+	body := &Body{
+		APIVersion:  "v2",
 		RequestType: t,
 		TracerTime:  time.Now().Unix(),
 		RuntimeID:   globalconfig.RuntimeID(),
@@ -389,48 +229,114 @@ func (c *Client) newRequest(t RequestType) *Request {
 			LanguageVersion: runtime.Version(),
 		},
 		Host: Host{
-			Hostname:    hostname,
-			ContainerID: internal.ContainerID(),
-			OS:          getOSName(),
-			OSVersion:   getOSVersion(),
+			Hostname:     hostname,
+			OS:           getOSName(),
+			OSVersion:    getOSVersion(),
+			Architecture: runtime.GOARCH,
+			// TODO (lievan): getting kernel name, release, version TBD
 		},
 	}
-}
 
-// submit posts a telemetry request to the backend
-func (c *Client) submit(r *Request) error {
-	b, err := json.Marshal(r)
-	if err != nil {
-		return err
+	header := &http.Header{
+		"Content-Type":               {"application/json"},
+		"DD-Telemetry-API-Version":   {"v2"},
+		"DD-Telemetry-Request-Type":  {string(t)},
+		"DD-Client-Library-Language": {"go"},
+		"DD-Client-Library-Version":  {version.Tag},
+		"DD-Agent-Env":               {c.Env},
+		"DD-Agent-Hostname":          {hostname},
+		"Datadog-Container-ID":       {internal.ContainerID()},
 	}
-
-	req, err := http.NewRequest(http.MethodPost, c.URL, bytes.NewReader(b))
-	if err != nil {
-		return err
+	if c.URL == getAgentlessURL() && isAPIKeyValid(c.APIKey) {
+		header.Set("DD-API-KEY", c.APIKey)
 	}
-	req.Header = http.Header{
-		"Content-Type":              {"application/json"},
-		"DD-Telemetry-API-Version":  {"v1"},
-		"DD-Telemetry-Request-Type": {string(r.RequestType)},
-	}
-	if len(c.APIKey) > 0 {
-		req.Header.Add("DD-API-Key", c.APIKey)
-	}
-	req.ContentLength = int64(len(b))
-
 	client := c.Client
 	if client == nil {
-		client = defaultClient
+		client = defaultHTTPClient
+	}
+	return &Request{Body: body,
+		Header:          header,
+		HTTPClient:      client,
+		URL:             c.URL,
+		TelemetryClient: c}
+}
+
+// submit sends a telemetry request
+func (r *Request) submit() error {
+	if r.TelemetryClient == nil {
+		return fmt.Errorf("all telemetry requests must be associated with a telemetry client")
+	}
+	retry, err := r.trySubmit()
+	if retry {
+		// retry telemetry submissions in instances where the telemetry client has trouble
+		// connecting with the agent
+		r.TelemetryClient.log("telemetry submission failed, retrying with agentless: %s", err)
+		r.URL = getAgentlessURL()
+		r.Header.Set("DD-API-KEY", defaultAPIKey())
+		_, err := r.trySubmit()
+		if err != nil {
+			r.TelemetryClient.log("retrying with agentless telemetry failed: %s", err)
+		}
+	}
+	return err
+}
+
+// agentlessRetry determines if we should retry a failed a request with
+// by submitting to the agentless endpoint
+func agentlessRetry(req *Request, resp *http.Response, err error) bool {
+	if req.URL == getAgentlessURL() {
+		// no need to retry with agentless endpoint if it already failed
+		return false
+	}
+	if err != nil {
+		// we didn't get a response which might signal a connectivity problem with
+		// agent - retry with agentless
+		return true
+	}
+	// Do not retry with the following status codes:
+	// 400 - client side error
+	// 429 - too many requests
+	// TODO - add more
+	doNotRetry := []int{400, 429}
+	for status := range doNotRetry {
+		if resp.StatusCode == status {
+			return false
+		}
+	}
+	return true
+}
+
+// trySubmit submits a telemetry request to the specified URL
+// in the Request struct. If submission fails, return whether or not
+// this submission should be re-tried with the agentless endpoint
+// as well as the error that occurred
+func (r *Request) trySubmit() (retry bool, err error) {
+	b, err := json.Marshal(r.Body)
+	if err != nil {
+		return false, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, r.URL, bytes.NewReader(b))
+	if err != nil {
+		return false, err
+	}
+	req.Header = *r.Header
+
+	req.ContentLength = int64(len(b))
+
+	client := r.HTTPClient
+	if client == nil {
+		client = defaultHTTPClient
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		return agentlessRetry(r, resp, err), err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
-		return errBadStatus(resp.StatusCode)
+		return agentlessRetry(r, resp, err), errBadStatus(resp.StatusCode)
 	}
-	return nil
+	return false, nil
 }
 
 type errBadStatus int
@@ -441,27 +347,4 @@ func (e errBadStatus) Error() string { return fmt.Sprintf("bad HTTP response sta
 // with c.mu locked
 func (c *Client) scheduleSubmit(r *Request) {
 	c.requests = append(c.requests, r)
-}
-
-func (c *Client) backgroundHeartbeat() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if !c.started {
-		return
-	}
-	err := c.submit(c.newRequest(RequestTypeAppHeartbeat))
-	if err != nil {
-		c.log("heartbeat failed: %s", err)
-	}
-	c.heartbeatT.Reset(c.heartbeatInterval)
-}
-
-func (c *Client) backgroundFlush() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if !c.started {
-		return
-	}
-	c.flush()
-	c.flushT.Reset(c.SubmissionInterval)
 }

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -3,26 +3,24 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022 Datadog, Inc.
 
-package telemetry_test
+package telemetry
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"reflect"
 	"sort"
 	"sync"
 	"testing"
 	"time"
 
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient(t *testing.T) {
-	os.Setenv("DD_TELEMETRY_HEARTBEAT_INTERVAL", "1")
-	defer os.Unsetenv("DD_TELEMETRY_HEARTBEAT_INTERVAL")
-
+	t.Setenv("DD_TELEMETRY_HEARTBEAT_INTERVAL", "1")
 	heartbeat := make(chan struct{})
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -30,7 +28,7 @@ func TestClient(t *testing.T) {
 		if len(h) == 0 {
 			t.Fatal("didn't get telemetry request type header")
 		}
-		if telemetry.RequestType(h) == telemetry.RequestTypeAppHeartbeat {
+		if RequestType(h) == RequestTypeAppHeartbeat {
 			select {
 			case heartbeat <- struct{}{}:
 			default:
@@ -39,12 +37,11 @@ func TestClient(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := &telemetry.Client{
-		URL:                server.URL,
-		SubmissionInterval: time.Millisecond,
+	client := &Client{
+		URL: server.URL,
 	}
-	client.Start(nil, nil)
-	client.Start(nil, nil) // test idempotence
+	client.Start(nil)
+	client.Start(nil) // test idempotence
 	defer client.Stop()
 
 	timeout := time.After(30 * time.Second)
@@ -57,32 +54,33 @@ func TestClient(t *testing.T) {
 }
 
 func TestMetrics(t *testing.T) {
+	t.Setenv("DD_TELEMETRY_HEARTBEAT_INTERVAL", "1")
 	var (
 		mu  sync.Mutex
-		got []telemetry.Series
+		got []Series
 	)
 	closed := make(chan struct{}, 1)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("DD-Telemetry-Request-Type") == string(telemetry.RequestTypeAppClosing) {
+		if r.Header.Get("DD-Telemetry-Request-Type") == string(RequestTypeAppClosing) {
 			select {
 			case closed <- struct{}{}:
 			default:
 			}
 			return
 		}
-		req := telemetry.Request{
-			Payload: new(telemetry.Metrics),
+		req := Body{
+			Payload: new(Metrics),
 		}
 		dec := json.NewDecoder(r.Body)
 		err := dec.Decode(&req)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if req.RequestType != telemetry.RequestTypeGenerateMetrics {
+		if req.RequestType != RequestTypeGenerateMetrics {
 			return
 		}
-		v, ok := req.Payload.(*telemetry.Metrics)
+		v, ok := req.Payload.(*Metrics)
 		if !ok {
 			t.Fatal("payload set metrics but didn't get metrics")
 		}
@@ -99,25 +97,25 @@ func TestMetrics(t *testing.T) {
 	defer server.Close()
 
 	go func() {
-		client := &telemetry.Client{
+		client := &Client{
 			URL: server.URL,
 		}
-		client.Start(nil, nil)
+		client.Start(nil)
 
 		// Gauges should have the most recent value
-		client.Gauge("foobar", 1, nil, false)
-		client.Gauge("foobar", 2, nil, false)
+		client.Gauge(NamespaceTracers, "foobar", 1, nil, false)
+		client.Gauge(NamespaceTracers, "foobar", 2, nil, false)
 		// Counts should be aggregated
-		client.Count("baz", 3, nil, true)
-		client.Count("baz", 1, nil, true)
+		client.Count(NamespaceTracers, "baz", 3, nil, true)
+		client.Count(NamespaceTracers, "baz", 1, nil, true)
 		// Tags should be passed through
-		client.Count("bonk", 4, []string{"org:1"}, false)
+		client.Count(NamespaceTracers, "bonk", 4, []string{"org:1"}, false)
 		client.Stop()
 	}()
 
 	<-closed
 
-	want := []telemetry.Series{
+	want := []Series{
 		{Metric: "baz", Type: "count", Points: [][2]float64{{0, 4}}, Tags: []string{}, Common: true},
 		{Metric: "bonk", Type: "count", Points: [][2]float64{{0, 4}}, Tags: []string{"org:1"}},
 		{Metric: "foobar", Type: "gauge", Points: [][2]float64{{0, 2}}, Tags: []string{}},
@@ -131,64 +129,66 @@ func TestMetrics(t *testing.T) {
 }
 
 func TestDisabledClient(t *testing.T) {
+	t.Setenv("DD_TELEMETRY_HEARTBEAT_INTERVAL", "1")
+	t.Setenv("DD_INSTRUMENTATION_TELEMETRY_ENABLED", "0")
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("shouldn't have got any requests")
 	}))
 	defer server.Close()
-	t.Setenv("DD_INSTRUMENTATION_TELEMETRY_ENABLED", "0")
 
-	client := &telemetry.Client{
-		URL:                server.URL,
-		SubmissionInterval: time.Millisecond,
+	client := &Client{
+		URL: server.URL,
 	}
-	client.Start(nil, nil)
-	client.Gauge("foobar", 1, nil, false)
-	client.Count("bonk", 4, []string{"org:1"}, false)
+	client.Start(nil)
+	client.Gauge(NamespaceTracers, "foobar", 1, nil, false)
+	client.Count(NamespaceTracers, "bonk", 4, []string{"org:1"}, false)
 	client.Stop()
 }
 
 func TestNonStartedClient(t *testing.T) {
+	t.Setenv("DD_TELEMETRY_HEARTBEAT_INTERVAL", "1")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("shouldn't have got any requests")
 	}))
 	defer server.Close()
 
-	client := &telemetry.Client{
-		URL:                server.URL,
-		SubmissionInterval: time.Millisecond,
+	client := &Client{
+		URL: server.URL,
 	}
-	client.Gauge("foobar", 1, nil, false)
-	client.Count("bonk", 4, []string{"org:1"}, false)
+	client.Gauge(NamespaceTracers, "foobar", 1, nil, false)
+	client.Count(NamespaceTracers, "bonk", 4, []string{"org:1"}, false)
 	client.Stop()
 }
 
 func TestConcurrentClient(t *testing.T) {
+	t.Setenv("DD_TELEMETRY_HEARTBEAT_INTERVAL", "1")
 	var (
 		mu  sync.Mutex
-		got []telemetry.Series
+		got []Series
 	)
 	closed := make(chan struct{}, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Log("foo")
-		if r.Header.Get("DD-Telemetry-Request-Type") == string(telemetry.RequestTypeAppClosing) {
+		if r.Header.Get("DD-Telemetry-Request-Type") == string(RequestTypeAppClosing) {
 			select {
 			case closed <- struct{}{}:
 			default:
 				return
 			}
 		}
-		req := telemetry.Request{
-			Payload: new(telemetry.Metrics),
+		req := Body{
+			Payload: new(Metrics),
 		}
 		dec := json.NewDecoder(r.Body)
 		err := dec.Decode(&req)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if req.RequestType != telemetry.RequestTypeGenerateMetrics {
+		if req.RequestType != RequestTypeGenerateMetrics {
 			return
 		}
-		v, ok := req.Payload.(*telemetry.Metrics)
+		v, ok := req.Payload.(*Metrics)
 		if !ok {
 			t.Fatal("payload set metrics but didn't get metrics")
 		}
@@ -205,10 +205,10 @@ func TestConcurrentClient(t *testing.T) {
 	defer server.Close()
 
 	go func() {
-		client := &telemetry.Client{
-			URL: server.URL,
-		}
-		client.Start(nil, nil)
+		client := new(Client)
+		client.ApplyOps(WithURL(false, server.URL))
+
+		client.Start(nil)
 		defer client.Stop()
 
 		var wg sync.WaitGroup
@@ -217,7 +217,7 @@ func TestConcurrentClient(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				for j := 0; j < 10; j++ {
-					client.Count("foobar", 1, []string{"tag"}, false)
+					client.Count(NamespaceTracers, "foobar", 1, []string{"tag"}, false)
 				}
 			}()
 		}
@@ -226,7 +226,7 @@ func TestConcurrentClient(t *testing.T) {
 
 	<-closed
 
-	want := []telemetry.Series{
+	want := []Series{
 		{Metric: "foobar", Type: "count", Points: [][2]float64{{0, 80}}, Tags: []string{"tag"}},
 	}
 	sort.Slice(got, func(i, j int) bool {
@@ -235,4 +235,139 @@ func TestConcurrentClient(t *testing.T) {
 	if !reflect.DeepEqual(want, got) {
 		t.Fatalf("want %+v, got %+v", want, got)
 	}
+}
+
+// fakeAgentless is a helper function for TestAgentlessRetry. It replaces the agentless
+// endpoint in the telemetry package with a custom server URL and returns
+//  1. a function that waits for a telemetry request to that server
+//  2. a cleanup function that closes the server and resets the agentless endpoint to
+//     its original value
+func fakeAgentless(ctx context.Context, t *testing.T) (wait func(), cleanup func()) {
+	received := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := r.Header.Get("DD-Telemetry-Request-Type")
+		if len(h) > 0 {
+			received <- struct{}{}
+		}
+	}))
+	prevEndpoint := SetAgentlessEndpoint(server.URL)
+	return func() {
+			select {
+			case <-ctx.Done():
+				t.Fatalf("fake agentless endpoint timed out waiting for telemetry")
+			case <-received:
+				return
+			}
+		}, func() {
+			server.Close()
+			SetAgentlessEndpoint(prevEndpoint)
+		}
+}
+
+// TestAgentlessRetry tests the behavior of the telemetry client in the case where
+// the client cannot connect to the agent. The client should re-try the request
+// with the agentless endpoint.
+func TestAgentlessRetry(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	waitAgentlessEndpoint, cleanup := fakeAgentless(ctx, t)
+	defer cleanup()
+
+	brokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	}))
+	brokenServer.Close()
+
+	client := &Client{
+		URL: brokenServer.URL,
+	}
+	client.Start([]Configuration{})
+	waitAgentlessEndpoint()
+}
+
+func TestCollectDependencies(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	received := make(chan *Dependencies)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("DD-Telemetry-Request-Type") == string(RequestTypeDependenciesLoaded) {
+			var body Body
+			body.Payload = new(Dependencies)
+			err := json.NewDecoder(r.Body).Decode(&body)
+			if err != nil {
+				t.Errorf("bad body: %s", err)
+			}
+			select {
+			case received <- body.Payload.(*Dependencies):
+			default:
+			}
+		}
+	}))
+	defer server.Close()
+	client := &Client{
+		URL: server.URL,
+	}
+	client.Start([]Configuration{})
+	select {
+	case <-received:
+	case <-ctx.Done():
+		t.Fatalf("Timed out waiting for dependency payload")
+	}
+}
+
+func TestProductChange(t *testing.T) {
+	t.Setenv("DD_TELEMETRY_HEARTBEAT_INTERVAL", "1")
+	receivedProducts := make(chan *Products, 1)
+	receivedConfigs := make(chan *ConfigurationChange, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("DD-Telemetry-Request-Type") == string(RequestTypeAppProductChange) {
+			var body Body
+			body.Payload = new(Products)
+			err := json.NewDecoder(r.Body).Decode(&body)
+			if err != nil {
+				t.Errorf("bad body: %s", err)
+			}
+			select {
+			case receivedProducts <- body.Payload.(*Products):
+			default:
+			}
+		}
+		if r.Header.Get("DD-Telemetry-Request-Type") == string(RequestTypeAppClientConfigurationChange) {
+			var body Body
+			body.Payload = new(ConfigurationChange)
+			err := json.NewDecoder(r.Body).Decode(&body)
+			if err != nil {
+				t.Errorf("bad body: %s", err)
+			}
+			select {
+			case receivedConfigs <- body.Payload.(*ConfigurationChange):
+			default:
+			}
+		}
+	}))
+	defer server.Close()
+	client := &Client{
+		URL: server.URL,
+	}
+	client.Start(nil)
+	client.ProductChange(NamespaceProfilers, true,
+		[]Configuration{{Name: "delta_profiles", Value: true}})
+
+	var productsPayload *Products = <-receivedProducts
+	assert.Equal(t, productsPayload.Profiler.Enabled, true)
+
+	var configPayload *ConfigurationChange = <-receivedConfigs
+	check := func(key string, expected interface{}) {
+		for _, kv := range configPayload.Configuration {
+			if kv.Name == key {
+				if kv.Value != expected {
+					t.Errorf("configuration %s: wanted %v, got %v", key, expected, kv.Value)
+				}
+				return
+			}
+		}
+		t.Errorf("missing configuration %s", key)
+	}
+	check("delta_profiles", true)
 }

--- a/internal/telemetry/message.go
+++ b/internal/telemetry/message.go
@@ -5,8 +5,22 @@
 
 package telemetry
 
-// Request is the common high-level structure encapsulating a telemetry request
+import "net/http"
+
+// Request captures all necessary information for a telemetry event submission
+// so we do not need to read directly from our telemetry client when submitting
+// asynchronously
 type Request struct {
+	Body       *Body
+	Header     *http.Header
+	HTTPClient *http.Client
+	URL        string
+	// still store pointer to origin telemetry client for logging and error handling
+	TelemetryClient *Client
+}
+
+// Body is the common high-level structure encapsulating a telemetry request body
+type Body struct {
 	APIVersion  string      `json:"api_version"`
 	RequestType RequestType `json:"request_type"`
 	TracerTime  int64       `json:"tracer_time"`
@@ -34,6 +48,14 @@ const (
 	RequestTypeGenerateMetrics RequestType = "generate-metrics"
 	// RequestTypeAppClosing is sent when the telemetry client is stopped
 	RequestTypeAppClosing RequestType = "app-closing"
+	// RequestTypeDependenciesLoaded is sent if DD_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED
+	// is enabled. Still sent when Start is called for the telemetry client.
+	RequestTypeDependenciesLoaded RequestType = "app-dependencies-loaded"
+	// RequestTypeAppClientConfigurationChange is sent if there are changes
+	// to the client library configuration
+	RequestTypeAppClientConfigurationChange RequestType = "app-client-configuration-change"
+	// RequestTypeAppProductChange is sent when products are enabled/disabled
+	RequestTypeAppProductChange RequestType = "app-product-change"
 )
 
 // Namespace describes an APM product to distinguish telemetry coming from
@@ -51,16 +73,54 @@ const (
 
 // Application is identifying information about the app itself
 type Application struct {
-	ServiceName     string   `json:"service_name"`
-	Env             string   `json:"env,omitempty"`
-	ServiceVersion  string   `json:"service_version,omitempty"`
-	TracerVersion   string   `json:"tracer_version"`
-	LanguageName    string   `json:"language_name"`
-	LanguageVersion string   `json:"language_version"`
-	RuntimeName     string   `json:"runtime_name,omitempty"`
-	RuntimeVersion  string   `json:"runtime_version,omitempty"`
-	RuntimePatches  string   `json:"runtime_patches,omitempty"`
-	Products        Products `json:"products,omitempty"`
+	ServiceName     string `json:"service_name"`
+	Env             string `json:"env"`
+	ServiceVersion  string `json:"service_version"`
+	TracerVersion   string `json:"tracer_version"`
+	LanguageName    string `json:"language_name"`
+	LanguageVersion string `json:"language_version"`
+	RuntimeName     string `json:"runtime_name"`
+	RuntimeVersion  string `json:"runtime_version"`
+	RuntimePatches  string `json:"runtime_patches,omitempty"`
+}
+
+// Host is identifying information about the host on which the app
+// is running
+type Host struct {
+	Hostname  string `json:"hostname"`
+	OS        string `json:"os"`
+	OSVersion string `json:"os_version,omitempty"`
+	// TODO: Do we care about the kernel stuff? internal/osinfo gets most of
+	// this information in OSName/OSVersion
+	Architecture  string `json:"architecture"`
+	KernelName    string `json:"kernel_name"`
+	KernelRelease string `json:"kernel_release"`
+	KernelVersion string `json:"kernel_version"`
+}
+
+// AppStarted corresponds to the "app-started" request type
+type AppStarted struct {
+	Configuration     []Configuration     `json:"configuration,omitempty"`
+	Products          Products            `json:"products,omitempty"`
+	AdditionalPayload []AdditionalPayload `json:"additional_payload,omitempty"`
+	Error             Error               `json:"error,omitempty"`
+}
+
+// ConfigurationChange corresponds to the `AppClientConfigurationChange` event
+// that contains information about configuration changes since the app-started event
+type ConfigurationChange struct {
+	Configuration []Configuration `json:"conf_key_values"`
+	RemoteConfig  RemoteConfig    `json:"remote_config"`
+}
+
+// Configuration is a library-specific configuration value
+type Configuration struct {
+	Name string `json:"name"`
+	// Value should have a type that can be marshaled to JSON
+	Value       interface{} `json:"value"`
+	Origin      string      `json:"origin"` // source of config?
+	Error       Error       `json:"error"`
+	IsOverriden bool        `json:"is_overridden"`
 }
 
 // Products specifies information about available products.
@@ -71,28 +131,9 @@ type Products struct {
 
 // ProductDetails specifies details about a product.
 type ProductDetails struct {
-	Version string `json:"version"`
-}
-
-// Host is identifying information about the host on which the app
-// is running
-type Host struct {
-	ContainerID string `json:"container_id,omitempty"`
-	Hostname    string `json:"hostname,omitempty"`
-	OS          string `json:"os,omitempty"`
-	OSVersion   string `json:"os_version,omitempty"`
-	// TODO: Do we care about the kernel stuff? internal/osinfo gets most of
-	// this information in OSName/OSVersion
-	KernelName    string `json:"kernel_name,omitempty"`
-	KernelRelease string `json:"kernel_release,omitempty"`
-	KernelVersion string `json:"kernel_version,omitempty"`
-}
-
-// AppStarted corresponds to the "app-started" request type
-type AppStarted struct {
-	Integrations  []Integration   `json:"integrations"`
-	Dependencies  []Dependency    `json:"dependencies"`
-	Configuration []Configuration `json:"configuration"`
+	Enabled bool   `json:"enabled"`
+	Version string `json:"version,omitempty"`
+	Error   Error  `json:"error,omitempty"`
 }
 
 // Integration is an integration that is available within the app and applicable
@@ -106,27 +147,42 @@ type Integration struct {
 	Error       string `json:"error,omitempty"`
 }
 
-// Dependency is a Go module on which the applciation depends. This information
+// Dependencies stores a list of dependencies
+type Dependencies struct {
+	Dependencies []Dependency `json:"dependencies"`
+}
+
+// Dependency is a Go module on which the application depends. This information
 // can be accesed at run-time through the runtime/debug.ReadBuildInfo API.
 type Dependency struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
-	Type    string `json:"type"`
 }
 
-// Configuration is a library-specific configuration value
-type Configuration struct {
-	Name string `json:"name"`
-	// Value should have a type that can be marshaled to JSON
+// RemoteConfig contains information about remote-config
+type RemoteConfig struct {
+	UserEnabled     string `json:"user_enabled"`     // whether the library has made a request to fetch remote-config
+	ConfigsRecieved bool   `json:"configs_received"` // whether the library recieves a valid config response
+	Error           Error  `json:"error"`
+}
+
+// Error stores error information about various tracer events
+type Error struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// AdditionalPayload can be used to add extra information to the app-started
+// event
+type AdditionalPayload struct {
+	Name  string      `json:"name"`
 	Value interface{} `json:"value"`
 }
 
 // Metrics corresponds to the "generate-metrics" request type
 type Metrics struct {
-	Namespace   Namespace `json:"namespace"`
-	LibLanguage string    `json:"lib_language"`
-	LibVersion  string    `json:"lib_version"`
-	Series      []Series  `json:"series"`
+	Namespace Namespace `json:"namespace"`
+	Series    []Series  `json:"series"`
 }
 
 // Series is a sequence of observations for a single named metric
@@ -144,5 +200,5 @@ type Series struct {
 	Common bool `json:"common"`
 }
 
-// TODO: app-dependencies-loaded and app-integrations-change? Does this really
+// TODO: app-integrations-change? Does this really
 // apply to Go?


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

- Migrates instrumentation telemetry to v2 (support agentless telemetry, support new v2 instrumentation telemetry events) and enables instrumentation telemetry by default to send library configuration data.
- Implements a global instrumentation telemetry client that the tracer, profiler, and appsec can use to send telemetry info.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.