### PR TITLE
ci: run pull request workflows for merge groups

### DIFF
--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -9,6 +9,12 @@ on:
       - 'internal/appsec/**'
       - 'appsec/**'
       - 'contrib/**/appsec.go'
+  merge_group: # on merge groups touching appsec files
+    paths:
+      - '.github/workflows/appsec.yml'
+      - 'internal/appsec/**'
+      - 'appsec/**'
+      - 'contrib/**/appsec.go'
   push:
     branches: release-v*
 env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]
+  merge_group:
 
 jobs:
   analyze:

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - "**"
+  merge_group:
   workflow_dispatch: {}
   schedule:
     - cron:  '00 04 * * 2-6'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - "**"
+  merge_group:
 
 concurrency: 
   group: ${{ github.ref }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - "**"
+  merge_group:
   workflow_dispatch: {}
   schedule:
     - cron:  '00 04 * * 2-6'


### PR DESCRIPTION
### What does this PR do?

Enables our pull request CI checks to also run on "merge groups", which are
what GitHub does to implement a merge queue.

See [the official docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions)

### Motivation

If we want to enable a merge queue, we should have our CI also run on PR
that get added to the queue. If CI fails, the PR will be removed from
the queue. Right now we require a PR to be up-to-date with main, and
have green CI, before merging into main. This basically replicates that
requirement for merge queues.

### Describe how to test/QA your changes

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.
