### PR TITLE
internal/log: allow RecordLogger to ignore certain logs

### DIFF
--- a/ddtrace/tracer/log_test.go
+++ b/ddtrace/tracer/log_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,20 +20,20 @@ import (
 func TestStartupLog(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
 		assert := assert.New(t)
-		tp := new(testLogger)
+		tp := new(log.RecordLogger)
 		tracer, _, _, stop := startTestTracer(t, WithLogger(tp))
 		defer stop()
 
 		tp.Reset()
 		logStartup(tracer)
-		lines := removeAppSec(tp.Lines())
+		lines := removeAppSec(tp.Logs())
 		require.Len(t, lines, 2)
 		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)? INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test(\.exe)?","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sample_rate_limit":"disabled","sampling_rules":null,"sampling_rules_error":"","service_mappings":null,"tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"profiler_code_hotspots_enabled":((false)|(true)),"profiler_endpoints_enabled":((false)|(true)),"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"false","appsec":((true)|(false)),"agent_features":{"DropP0s":((true)|(false)),"Stats":((true)|(false)),"StatsdPort":0}}`, lines[1])
 	})
 
 	t.Run("configured", func(t *testing.T) {
 		assert := assert.New(t)
-		tp := new(testLogger)
+		tp := new(log.RecordLogger)
 		os.Setenv("DD_TRACE_SAMPLE_RATE", "0.123")
 		defer os.Unsetenv("DD_TRACE_SAMPLE_RATE")
 		tracer, _, _, stop := startTestTracer(t,
@@ -55,13 +56,13 @@ func TestStartupLog(t *testing.T) {
 
 		tp.Reset()
 		logStartup(tracer)
-		require.Len(t, tp.Lines(), 2)
-		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)? INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"configuredEnv","service":"configured.service","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":true,"analytics_enabled":true,"sample_rate":"0\.123000","sample_rate_limit":"100","sampling_rules":\[{"service":"mysql","name":"","sample_rate":0\.75,"type":"trace\(0\)"}\],"sampling_rules_error":"","service_mappings":{"initial_service":"new_service"},"tags":{"runtime-id":"[^"]*","tag":"value","tag2":"NaN"},"runtime_metrics_enabled":true,"health_metrics_enabled":true,"profiler_code_hotspots_enabled":((false)|(true)),"profiler_endpoints_enabled":((false)|(true)),"dd_version":"2.3.4","architecture":"[^"]*","global_service":"configured.service","lambda_mode":"false","appsec":((true)|(false)),"agent_features":{"DropP0s":false,"Stats":false,"StatsdPort":0}}`, tp.Lines()[1])
+		require.Len(t, tp.Logs(), 2)
+		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)? INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"configuredEnv","service":"configured.service","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":true,"analytics_enabled":true,"sample_rate":"0\.123000","sample_rate_limit":"100","sampling_rules":\[{"service":"mysql","name":"","sample_rate":0\.75,"type":"trace\(0\)"}\],"sampling_rules_error":"","service_mappings":{"initial_service":"new_service"},"tags":{"runtime-id":"[^"]*","tag":"value","tag2":"NaN"},"runtime_metrics_enabled":true,"health_metrics_enabled":true,"profiler_code_hotspots_enabled":((false)|(true)),"profiler_endpoints_enabled":((false)|(true)),"dd_version":"2.3.4","architecture":"[^"]*","global_service":"configured.service","lambda_mode":"false","appsec":((true)|(false)),"agent_features":{"DropP0s":false,"Stats":false,"StatsdPort":0}}`, tp.Logs()[1])
 	})
 
 	t.Run("limit", func(t *testing.T) {
 		assert := assert.New(t)
-		tp := new(testLogger)
+		tp := new(log.RecordLogger)
 		os.Setenv("DD_TRACE_SAMPLE_RATE", "0.123")
 		defer os.Unsetenv("DD_TRACE_SAMPLE_RATE")
 		os.Setenv("DD_TRACE_RATE_LIMIT", "1000.001")
@@ -86,13 +87,13 @@ func TestStartupLog(t *testing.T) {
 
 		tp.Reset()
 		logStartup(tracer)
-		require.Len(t, tp.Lines(), 2)
-		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)? INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"configuredEnv","service":"configured.service","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":true,"analytics_enabled":true,"sample_rate":"0\.123000","sample_rate_limit":"1000.001","sampling_rules":\[{"service":"mysql","name":"","sample_rate":0\.75,"type":"trace\(0\)"}\],"sampling_rules_error":"","service_mappings":{"initial_service":"new_service"},"tags":{"runtime-id":"[^"]*","tag":"value","tag2":"NaN"},"runtime_metrics_enabled":true,"health_metrics_enabled":true,"profiler_code_hotspots_enabled":((false)|(true)),"profiler_endpoints_enabled":((false)|(true)),"dd_version":"2.3.4","architecture":"[^"]*","global_service":"configured.service","lambda_mode":"false","appsec":((true)|(false)),"agent_features":{"DropP0s":false,"Stats":false,"StatsdPort":0}}`, tp.Lines()[1])
+		require.Len(t, tp.Logs(), 2)
+		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)? INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"configuredEnv","service":"configured.service","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":true,"analytics_enabled":true,"sample_rate":"0\.123000","sample_rate_limit":"1000.001","sampling_rules":\[{"service":"mysql","name":"","sample_rate":0\.75,"type":"trace\(0\)"}\],"sampling_rules_error":"","service_mappings":{"initial_service":"new_service"},"tags":{"runtime-id":"[^"]*","tag":"value","tag2":"NaN"},"runtime_metrics_enabled":true,"health_metrics_enabled":true,"profiler_code_hotspots_enabled":((false)|(true)),"profiler_endpoints_enabled":((false)|(true)),"dd_version":"2.3.4","architecture":"[^"]*","global_service":"configured.service","lambda_mode":"false","appsec":((true)|(false)),"agent_features":{"DropP0s":false,"Stats":false,"StatsdPort":0}}`, tp.Logs()[1])
 	})
 
 	t.Run("errors", func(t *testing.T) {
 		assert := assert.New(t)
-		tp := new(testLogger)
+		tp := new(log.RecordLogger)
 		os.Setenv("DD_TRACE_SAMPLING_RULES", `[{"service": "some.service", "sample_rate": 0.234}, {"service": "other.service"}]`)
 		defer os.Unsetenv("DD_TRACE_SAMPLING_RULES")
 		tracer, _, _, stop := startTestTracer(t, WithLogger(tp))
@@ -100,54 +101,54 @@ func TestStartupLog(t *testing.T) {
 
 		tp.Reset()
 		logStartup(tracer)
-		require.Len(t, tp.Lines(), 2)
-		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)? INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test(\.exe)?","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sample_rate_limit":"100","sampling_rules":\[{"service":"some.service","name":"","sample_rate":0\.234,"type":"trace\(0\)"}\],"sampling_rules_error":"\\n\\tat index 1: rate not provided","service_mappings":null,"tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"profiler_code_hotspots_enabled":((false)|(true)),"profiler_endpoints_enabled":((false)|(true)),"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"false","appsec":((true)|(false)),"agent_features":{"DropP0s":((true)|(false)),"Stats":((true)|(false)),"StatsdPort":0}}`, tp.Lines()[1])
+		require.Len(t, tp.Logs(), 2)
+		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)? INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test(\.exe)?","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sample_rate_limit":"100","sampling_rules":\[{"service":"some.service","name":"","sample_rate":0\.234,"type":"trace\(0\)"}\],"sampling_rules_error":"\\n\\tat index 1: rate not provided","service_mappings":null,"tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"profiler_code_hotspots_enabled":((false)|(true)),"profiler_endpoints_enabled":((false)|(true)),"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"false","appsec":((true)|(false)),"agent_features":{"DropP0s":((true)|(false)),"Stats":((true)|(false)),"StatsdPort":0}}`, tp.Logs()[1])
 	})
 
 	t.Run("lambda", func(t *testing.T) {
 		assert := assert.New(t)
-		tp := new(testLogger)
+		tp := new(log.RecordLogger)
 		tracer, _, _, stop := startTestTracer(t, WithLogger(tp), WithLambdaMode(true))
 		defer stop()
 
 		tp.Reset()
 		logStartup(tracer)
-		assert.Len(tp.Lines(), 1)
-		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)? INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test(\.exe)?","agent_url":"http://localhost:9/v0.4/traces","agent_error":"","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sample_rate_limit":"disabled","sampling_rules":null,"sampling_rules_error":"","service_mappings":null,"tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"profiler_code_hotspots_enabled":((false)|(true)),"profiler_endpoints_enabled":((false)|(true)),"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"true","appsec":((true)|(false)),"agent_features":{"DropP0s":false,"Stats":false,"StatsdPort":0}}`, tp.Lines()[0])
+		assert.Len(tp.Logs(), 1)
+		assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)? INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test(\.exe)?","agent_url":"http://localhost:9/v0.4/traces","agent_error":"","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sample_rate_limit":"disabled","sampling_rules":null,"sampling_rules_error":"","service_mappings":null,"tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"profiler_code_hotspots_enabled":((false)|(true)),"profiler_endpoints_enabled":((false)|(true)),"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"true","appsec":((true)|(false)),"agent_features":{"DropP0s":false,"Stats":false,"StatsdPort":0}}`, tp.Logs()[0])
 	})
 }
 
 func TestLogSamplingRules(t *testing.T) {
 	assert := assert.New(t)
-	tp := new(testLogger)
+	tp := new(log.RecordLogger)
 	os.Setenv("DD_TRACE_SAMPLING_RULES", `[{"service": "some.service", "sample_rate": 0.234}, {"service": "other.service"}, {"service": "last.service", "sample_rate": 0.56}, {"odd": "pairs"}, {"sample_rate": 9.10}]`)
 	defer os.Unsetenv("DD_TRACE_SAMPLING_RULES")
 	_, _, _, stop := startTestTracer(t, WithLogger(tp))
 	defer stop()
 
-	lines := removeAppSec(tp.Lines())
+	lines := removeAppSec(tp.Logs())
 	assert.Len(lines, 1)
 	assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)? WARN: DIAGNOSTICS Error\(s\) parsing sampling rules: found errors:\n\tat index 1: rate not provided\n\tat index 3: rate not provided\n\tat index 4: ignoring rule {Service: Name: Rate:9\.10 MaxPerSecond:0}: rate is out of \[0\.0, 1\.0] range$`, lines[0])
 }
 
 func TestLogAgentReachable(t *testing.T) {
 	assert := assert.New(t)
-	tp := new(testLogger)
+	tp := new(log.RecordLogger)
 	tracer, _, _, stop := startTestTracer(t, WithLogger(tp))
 	defer stop()
 	tp.Reset()
 	logStartup(tracer)
-	require.Len(t, tp.Lines(), 2)
-	assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)? WARN: DIAGNOSTICS Unable to reach agent intake: Post`, tp.Lines()[0])
+	require.Len(t, tp.Logs(), 2)
+	assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)? WARN: DIAGNOSTICS Unable to reach agent intake: Post`, tp.Logs()[0])
 }
 
 func TestLogFormat(t *testing.T) {
 	assert := assert.New(t)
-	tp := new(testLogger)
+	tp := new(log.RecordLogger)
 	tracer := newTracer(WithLogger(tp), WithRuntimeMetrics(), WithDebugMode(true))
 	defer tracer.Stop()
 	tp.Reset()
 	tracer.StartSpan("test", ServiceName("test-service"), ResourceName("/"), WithSpanID(12345))
-	assert.Len(tp.Lines(), 1)
-	assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)? DEBUG: Started Span: dd.trace_id="12345" dd.span_id="12345", Operation: test, Resource: /, Tags: map.*, map.*`, tp.Lines()[0])
+	assert.Len(tp.Logs(), 1)
+	assert.Regexp(`Datadog Tracer v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)? DEBUG: Started Span: dd.trace_id="12345" dd.span_id="12345", Operation: test, Resource: /, Tags: map.*, map.*`, tp.Logs()[0])
 }

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -33,7 +33,7 @@ func setupteardown(start, max int) func() {
 func TestNewSpanContextPushError(t *testing.T) {
 	defer setupteardown(2, 2)()
 
-	tp := new(testLogger)
+	tp := new(log.RecordLogger)
 	_, _, _, stop := startTestTracer(t, WithLogger(tp), WithLambdaMode(true))
 	defer stop()
 	parent := newBasicSpan("test1")                  // 1st span in trace
@@ -45,7 +45,7 @@ func TestNewSpanContextPushError(t *testing.T) {
 	child.context = newSpanContext(child, parent.context)
 
 	log.Flush()
-	assert.Contains(t, removeAppSec(tp.Lines())[0], "ERROR: trace buffer full (2)")
+	assert.Contains(t, removeAppSec(tp.Logs())[0], "ERROR: trace buffer full (2)")
 }
 
 func TestAsyncSpanRace(t *testing.T) {
@@ -144,7 +144,7 @@ func TestSpanTracePushNoFinish(t *testing.T) {
 
 	assert := assert.New(t)
 
-	tp := new(testLogger)
+	tp := new(log.RecordLogger)
 	_, _, _, stop := startTestTracer(t, WithLogger(tp), WithLambdaMode(true))
 	defer stop()
 
@@ -162,7 +162,7 @@ func TestSpanTracePushNoFinish(t *testing.T) {
 
 	<-time.After(time.Second / 10)
 	log.Flush()
-	assert.Len(removeAppSec(tp.Lines()), 0)
+	assert.Len(removeAppSec(tp.Logs()), 0)
 	t.Logf("expected timeout, nothing should show up in buffer as the trace is not finished")
 }
 
@@ -354,7 +354,7 @@ func TestSpanContextParent(t *testing.T) {
 func TestSpanContextPushFull(t *testing.T) {
 	defer func(old int) { traceMaxSize = old }(traceMaxSize)
 	traceMaxSize = 2
-	tp := new(testLogger)
+	tp := new(log.RecordLogger)
 	_, _, _, stop := startTestTracer(t, WithLogger(tp), WithLambdaMode(true))
 	defer stop()
 
@@ -366,13 +366,13 @@ func TestSpanContextPushFull(t *testing.T) {
 	assert := assert.New(t)
 	buffer.push(span1)
 	log.Flush()
-	assert.Len(removeAppSec(tp.Lines()), 0)
+	assert.Len(removeAppSec(tp.Logs()), 0)
 	buffer.push(span2)
 	log.Flush()
-	assert.Len(removeAppSec(tp.Lines()), 0)
+	assert.Len(removeAppSec(tp.Logs()), 0)
 	buffer.push(span3)
 	log.Flush()
-	assert.Contains(removeAppSec(tp.Lines())[0], "ERROR: trace buffer full (2)")
+	assert.Contains(removeAppSec(tp.Logs())[0], "ERROR: trace buffer full (2)")
 }
 
 func TestSpanContextBaggage(t *testing.T) {
@@ -405,33 +405,6 @@ func TestSpanContextIteratorBreak(t *testing.T) {
 	})
 
 	assert.Len(t, got, 0)
-}
-
-// testLogger implements a mock Printer.
-type testLogger struct {
-	mu    sync.RWMutex
-	lines []string
-}
-
-// Print implements log.Printer.
-func (tp *testLogger) Log(msg string) {
-	tp.mu.Lock()
-	defer tp.mu.Unlock()
-	tp.lines = append(tp.lines, msg)
-}
-
-// Lines returns the lines that were printed using this printer.
-func (tp *testLogger) Lines() []string {
-	tp.mu.RLock()
-	defer tp.mu.RUnlock()
-	return tp.lines
-}
-
-// Reset resets the printer's internal buffer.
-func (tp *testLogger) Reset() {
-	tp.mu.Lock()
-	defer tp.mu.Unlock()
-	tp.lines = tp.lines[:0]
 }
 
 func BenchmarkBaggageItemPresent(b *testing.B) {

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -22,6 +22,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/httpmem"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/samplernames"
 )
 
@@ -1571,7 +1572,7 @@ func TestNonePropagator(t *testing.T) {
 
 	t.Run("inject/none,b3", func(t *testing.T) {
 		t.Setenv(headerPropagationStyleInject, "none,b3")
-		tp := new(testLogger)
+		tp := new(log.RecordLogger)
 		tracer := newTracer(WithLogger(tp))
 		defer tracer.Stop()
 		// reinitializing to capture log output, since propagators are parsed before logger is set
@@ -1590,7 +1591,7 @@ func TestNonePropagator(t *testing.T) {
 		assert.Nil(err)
 		assert.Equal("0000000000000001", headers[b3TraceIDHeader])
 		assert.Equal("0000000000000001", headers[b3SpanIDHeader])
-		assert.Contains(tp.lines[0], "Propagator \"none\" has no effect when combined with other propagators. "+
+		assert.Contains(tp.Logs()[0], "Propagator \"none\" has no effect when combined with other propagators. "+
 			"To disable the propagator, set to `none`")
 	})
 

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -611,28 +611,28 @@ func TestSamplingDecision(t *testing.T) {
 
 func TestTracerRuntimeMetrics(t *testing.T) {
 	t.Run("on", func(t *testing.T) {
-		tp := new(testLogger)
+		tp := new(log.RecordLogger)
 		tracer := newTracer(WithRuntimeMetrics(), WithLogger(tp), WithDebugMode(true))
 		defer tracer.Stop()
-		assert.Contains(t, tp.Lines()[0], "DEBUG: Runtime metrics enabled")
+		assert.Contains(t, tp.Logs()[0], "DEBUG: Runtime metrics enabled")
 	})
 
 	t.Run("env", func(t *testing.T) {
 		os.Setenv("DD_RUNTIME_METRICS_ENABLED", "true")
 		defer os.Unsetenv("DD_RUNTIME_METRICS_ENABLED")
-		tp := new(testLogger)
+		tp := new(log.RecordLogger)
 		tracer := newTracer(WithLogger(tp), WithDebugMode(true))
 		defer tracer.Stop()
-		assert.Contains(t, tp.Lines()[0], "DEBUG: Runtime metrics enabled")
+		assert.Contains(t, tp.Logs()[0], "DEBUG: Runtime metrics enabled")
 	})
 
 	t.Run("overrideEnv", func(t *testing.T) {
 		os.Setenv("DD_RUNTIME_METRICS_ENABLED", "false")
 		defer os.Unsetenv("DD_RUNTIME_METRICS_ENABLED")
-		tp := new(testLogger)
+		tp := new(log.RecordLogger)
 		tracer := newTracer(WithRuntimeMetrics(), WithLogger(tp), WithDebugMode(true))
 		defer tracer.Stop()
-		assert.Contains(t, tp.Lines()[0], "DEBUG: Runtime metrics enabled")
+		assert.Contains(t, tp.Logs()[0], "DEBUG: Runtime metrics enabled")
 	})
 }
 
@@ -1429,7 +1429,7 @@ func TestPushPayload(t *testing.T) {
 func TestPushTrace(t *testing.T) {
 	assert := assert.New(t)
 
-	tp := new(testLogger)
+	tp := new(log.RecordLogger)
 	log.UseLogger(tp)
 	tracer := newUnstartedTracer()
 	defer tracer.statsd.Close()
@@ -1458,7 +1458,7 @@ func TestPushTrace(t *testing.T) {
 	}
 	assert.Len(tracer.out, payloadQueueSize)
 	log.Flush()
-	assert.True(len(tp.Lines()) >= 1)
+	assert.True(len(tp.Logs()) >= 1)
 }
 
 func TestTracerFlush(t *testing.T) {

--- a/ddtrace/tracer/writer_test.go
+++ b/ddtrace/tracer/writer_test.go
@@ -239,7 +239,7 @@ func TestLogWriter(t *testing.T) {
 }
 
 func TestLogWriterOverflow(t *testing.T) {
-	log.UseLogger(new(testLogger))
+	log.UseLogger(new(log.RecordLogger))
 	t.Run("single-too-big", func(t *testing.T) {
 		assert := assert.New(t)
 		var buf bytes.Buffer

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -199,14 +200,28 @@ func (d DiscardLogger) Log(msg string) {}
 
 // RecordLogger records every call to Log() and makes it available via Logs().
 type RecordLogger struct {
-	m    sync.Mutex
-	logs []string
+	m      sync.Mutex
+	logs   []string
+	ignore []string // a log is ignored if it contains a string in ignored
+}
+
+// Ignore adds substrings to the ignore field of RecordLogger, allowing
+// the RecordLogger to ignore attempts to log strings with certain substrings.
+func (r *RecordLogger) Ignore(substrings ...string) {
+	r.m.Lock()
+	defer r.m.Unlock()
+	r.ignore = append(r.ignore, substrings...)
 }
 
 // Log implements Logger.
 func (r *RecordLogger) Log(msg string) {
 	r.m.Lock()
 	defer r.m.Unlock()
+	for _, ignored := range r.ignore {
+		if strings.Contains(msg, ignored) {
+			return
+		}
+	}
 	r.logs = append(r.logs, msg)
 }
 

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -239,4 +239,5 @@ func (r *RecordLogger) Reset() {
 	r.m.Lock()
 	defer r.m.Unlock()
 	r.logs = r.logs[:0]
+	r.ignore = r.ignore[:0]
 }

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -127,6 +127,15 @@ func TestLog(t *testing.T) {
 	})
 }
 
+func TestRecordLoggerIgnore(t *testing.T) {
+	tp := new(RecordLogger)
+	tp.Ignore("appsec")
+	tp.Log("this is an appsec log")
+	tp.Log("this is a tracer log")
+	assert.Len(t, tp.Logs(), 1)
+	assert.NotContains(t, tp.Logs()[0], "appsec")
+}
+
 func BenchmarkError(b *testing.B) {
 	Error("k %s", "a") // warm up cache
 	for i := 0; i < b.N; i++ {

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -134,6 +134,10 @@ func TestRecordLoggerIgnore(t *testing.T) {
 	tp.Log("this is a tracer log")
 	assert.Len(t, tp.Logs(), 1)
 	assert.NotContains(t, tp.Logs()[0], "appsec")
+	tp.Reset()
+	tp.Log("this is an appsec log")
+	assert.Len(t, tp.Logs(), 1)
+	assert.Contains(t, tp.Logs()[0], "appsec")
 }
 
 func BenchmarkError(b *testing.B) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Some unit tests in the tracer assert based on the content or positioning of log messages ([example](https://github.com/DataDog/dd-trace-go/blob/68bff5f324e762ce8b7dce14411554a0423f2f24/ddtrace/tracer/log_test.go#LL28-L29C27)). When new log messages are added (e.g. by appsec) these tests will fail. To workaround this, we've previously introduced a `removeAppsec` method that removes strings which contain `appsec: ` from recorded logs. This PR introduces an alternate solution to directly ignore certain substrings using `RecordLogger` while logging.

More specifically, this PR:

- removes `testLogger` from the tracer package. `testLogger` has a near identical implementation to `RecordLogger` in the `internal/log` package, so we can just use `RecordLogger` instead.
- adds a `Ignore` method to `RecordLogger` that allows us to ignore logs which contain certain substrings.
- edits unit tests in the tracer package to use `RecordLogger` and `Ignore` to ignore appsec logs

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Introduces a slightly friendlier interface for ignoring logs in comparison to creating custom functions that remove log messages, which may be useful when new features that use logging (e.g. instrumentation telemetry) are introduced.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.