### PR TITLE
tracer: Refactor span context's TraceID to be a full [16]byte

### DIFF
--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -52,8 +52,8 @@ func TestStartSpanFromContext(t *testing.T) {
 	_, _, _, stop := startTestTracer(t)
 	defer stop()
 
-	parent := &span{context: &spanContext{spanID: 123, traceID: 456}}
-	parent2 := &span{context: &spanContext{spanID: 789, traceID: 456}}
+	parent := &span{context: &spanContext{spanID: 123, traceID: traceIDFromLowerUint64(456)}}
+	parent2 := &span{context: &spanContext{spanID: 789, traceID: traceIDFromLowerUint64(456)}}
 	pctx := ContextWithSpan(context.Background(), parent)
 	child, ctx := StartSpanFromContext(
 		pctx,

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -52,8 +52,8 @@ func TestStartSpanFromContext(t *testing.T) {
 	_, _, _, stop := startTestTracer(t)
 	defer stop()
 
-	parent := &span{context: &spanContext{spanID: 123, traceID: traceIDFromLowerUint64(456)}}
-	parent2 := &span{context: &spanContext{spanID: 789, traceID: traceIDFromLowerUint64(456)}}
+	parent := &span{context: &spanContext{spanID: 123, traceID: traceIDFrom64Bits(456)}}
+	parent2 := &span{context: &spanContext{spanID: 789, traceID: traceIDFrom64Bits(456)}}
 	pctx := ContextWithSpan(context.Background(), parent)
 	child, ctx := StartSpanFromContext(
 		pctx,

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -627,7 +627,7 @@ func (s *span) Format(f fmt.State, c rune) {
 			}
 		}
 		var traceID string
-		if sharedinternal.BoolEnv("DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED", false) && strings.TrimLeft(s.context.traceID128, "0") != "" {
+		if sharedinternal.BoolEnv("DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED", false) && s.context.traceID.HasUpper() {
 			traceID = s.context.TraceID128()
 		} else {
 			traceID = fmt.Sprintf("%d", s.TraceID)

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -375,7 +375,7 @@ func TestTraceManualKeepAndManualDrop(t *testing.T) {
 		t.Run(fmt.Sprintf("%s/non-local", scenario.tag), func(t *testing.T) {
 			tracer := newTracer()
 			defer tracer.Stop()
-			spanCtx := &spanContext{traceID: 42, spanID: 42}
+			spanCtx := &spanContext{traceID: traceIDFromLowerUint64(42), spanID: 42}
 			spanCtx.setSamplingPriority(scenario.p, samplernames.RemoteRate)
 			span := tracer.StartSpan("non-local root span", ChildOf(spanCtx)).(*span)
 			span.SetTag(scenario.tag, true)
@@ -765,7 +765,7 @@ func TestSpanLog(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithEnv("testenv"))
 		defer stop()
 		span := tracer.StartSpan("test.request", WithSpanID(87654321)).(*span)
-		span.context.traceID128 = "01"
+		span.context.traceID.SetUpper(1)
 		span.Finish()
 		assert.Equal(`dd.service=tracer.test dd.env=testenv dd.trace_id="00000000000000010000000005397fb1" dd.span_id="87654321"`, fmt.Sprintf("%v", span))
 		v, _ := span.context.meta(keyTraceID128)

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -375,7 +375,7 @@ func TestTraceManualKeepAndManualDrop(t *testing.T) {
 		t.Run(fmt.Sprintf("%s/non-local", scenario.tag), func(t *testing.T) {
 			tracer := newTracer()
 			defer tracer.Stop()
-			spanCtx := &spanContext{traceID: traceIDFromLowerUint64(42), spanID: 42}
+			spanCtx := &spanContext{traceID: traceIDFrom64Bits(42), spanID: 42}
 			spanCtx.setSamplingPriority(scenario.p, samplernames.RemoteRate)
 			span := tracer.StartSpan("non-local root span", ChildOf(spanCtx)).(*span)
 			span.SetTag(scenario.tag, true)

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -8,9 +8,7 @@ package tracer
 import (
 	"encoding/binary"
 	"encoding/hex"
-	"fmt"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -22,6 +20,60 @@ import (
 )
 
 var _ ddtrace.SpanContext = (*spanContext)(nil)
+
+type traceID [16]byte // TraceID in big endian
+
+var emptyTraceID traceID
+
+func (t *traceID) HexEncoded() string {
+	return hex.EncodeToString(t[:])
+}
+
+func (t *traceID) Lower() uint64 {
+	return binary.BigEndian.Uint64(t[8:])
+}
+
+func (t *traceID) Upper() uint64 {
+	return binary.BigEndian.Uint64(t[:9])
+}
+
+func (t *traceID) SetLower(i uint64) {
+	binary.BigEndian.PutUint64(t[8:], i)
+}
+
+func (t *traceID) SetUpper(i uint64) {
+	binary.BigEndian.PutUint64(t[:9], i)
+}
+
+func (t *traceID) SetUpperFromHex(s string) {
+	bs, err := hex.DecodeString(s)
+	if err != nil {
+		log.Debug("Attempted to decode an invalid hex traceID %s", s)
+		return
+	}
+	n := copy(t[:9], bs)
+	if n > 8 {
+		log.Debug("More than 8 bytes received from hex trace ID %s", s)
+	}
+}
+
+func (t *traceID) Empty() bool {
+	return *t == emptyTraceID
+}
+
+func (t *traceID) HasUpper() bool {
+	//TODO: in go 1.20 we can simplify this
+	for _, b := range t[:9] {
+		if b != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (t *traceID) UpperHex() string {
+	return hex.EncodeToString(t[:9])
+}
 
 // SpanContext represents a span state that can propagate to descendant spans
 // and across process boundaries. It contains all the information needed to
@@ -38,9 +90,8 @@ type spanContext struct {
 
 	// the below group should propagate cross-process
 
-	traceID    uint64
-	traceID128 string // high order 64 bits of a 128 bit trace id, hex encoded into 16 bytes
-	spanID     uint64
+	traceID traceID
+	spanID  uint64
 
 	mu         sync.RWMutex // guards below fields
 	baggage    map[string]string
@@ -55,12 +106,12 @@ type spanContext struct {
 // for the same span.
 func newSpanContext(span *span, parent *spanContext) *spanContext {
 	context := &spanContext{
-		traceID: span.TraceID,
-		spanID:  span.SpanID,
-		span:    span,
+		spanID: span.SpanID,
+		span:   span,
 	}
+	context.traceID.SetLower(span.TraceID) // TODO: look in the incoming span for the upper bits?
 	if parent != nil {
-		context.traceID128 = parent.traceID128
+		context.traceID = parent.traceID
 		context.trace = parent.trace
 		context.origin = parent.origin
 		context.errors = parent.errors
@@ -89,28 +140,11 @@ func newSpanContext(span *span, parent *spanContext) *spanContext {
 func (c *spanContext) SpanID() uint64 { return c.spanID }
 
 // TraceID implements ddtrace.SpanContext.
-func (c *spanContext) TraceID() uint64 { return c.traceID }
+func (c *spanContext) TraceID() uint64 { return c.traceID.Lower() }
 
 // TraceID128 implements ddtrace.SpanContextW3C.
 func (c *spanContext) TraceID128() string {
-	var hi []byte
-	if c.traceID128 != "" {
-		// 128 bit trace ids is enabled, so fill the higher order bits
-		var err error
-		hi, err = hex.DecodeString(c.traceID128)
-		if err != nil {
-			log.Debug("failed to decode upper 64 bits of 128-bit trace id %q", c.traceID128)
-			return "" // this would be our fault, and means we have a bug
-		}
-		if len(hi) > 8 {
-			log.Debug("invalid 128-bit trace id %q", c.traceID128)
-			return "" // this would be our fault, and means we have a bug
-		}
-	}
-	buf := make([]byte, 16)
-	copy(buf[8-len(hi):], hi)
-	binary.BigEndian.PutUint64(buf[8:], c.traceID)
-	return hex.EncodeToString(buf)
+	return c.traceID.HexEncoded()
 }
 
 // ForeachBaggageItem implements ddtrace.SpanContext.
@@ -367,8 +401,8 @@ func (t *trace) finishedOne(s *span) {
 			s.setMeta(k, v)
 		}
 	}
-	if s.context != nil && strings.Trim(s.context.traceID128, "0") != "" {
-		s.setMeta(keyTraceID128, fmt.Sprintf("%016s", s.context.traceID128))
+	if s.context != nil && s.context.traceID.HasUpper() {
+		s.setMeta(keyTraceID128, s.context.traceID.UpperHex())
 	}
 	if len(t.spans) != t.finished {
 		return

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -46,15 +46,12 @@ func (t *traceID) SetUpper(i uint64) {
 }
 
 func (t *traceID) SetUpperFromHex(s string) {
-	bs, err := hex.DecodeString(s)
+	u, err := strconv.ParseUint(s, 16, 64)
 	if err != nil {
 		log.Debug("Attempted to decode an invalid hex traceID %s", s)
 		return
 	}
-	n := copy(t[:8], bs)
-	if n > 8 {
-		log.Debug("More than 8 bytes received from hex trace ID %s", s)
-	}
+	t.SetUpper(u)
 }
 
 func (t *traceID) Empty() bool {

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -21,7 +21,7 @@ import (
 
 var _ ddtrace.SpanContext = (*spanContext)(nil)
 
-type traceID [16]byte // TraceID in big endian
+type traceID [16]byte // traceID in big endian, i.e. <upper><lower>
 
 var emptyTraceID traceID
 

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -34,7 +34,7 @@ func (t *traceID) Lower() uint64 {
 }
 
 func (t *traceID) Upper() uint64 {
-	return binary.BigEndian.Uint64(t[:9])
+	return binary.BigEndian.Uint64(t[:8])
 }
 
 func (t *traceID) SetLower(i uint64) {
@@ -42,7 +42,7 @@ func (t *traceID) SetLower(i uint64) {
 }
 
 func (t *traceID) SetUpper(i uint64) {
-	binary.BigEndian.PutUint64(t[:9], i)
+	binary.BigEndian.PutUint64(t[:8], i)
 }
 
 func (t *traceID) SetUpperFromHex(s string) {
@@ -51,7 +51,7 @@ func (t *traceID) SetUpperFromHex(s string) {
 		log.Debug("Attempted to decode an invalid hex traceID %s", s)
 		return
 	}
-	n := copy(t[:9], bs)
+	n := copy(t[:8], bs)
 	if n > 8 {
 		log.Debug("More than 8 bytes received from hex trace ID %s", s)
 	}
@@ -63,7 +63,7 @@ func (t *traceID) Empty() bool {
 
 func (t *traceID) HasUpper() bool {
 	//TODO: in go 1.20 we can simplify this
-	for _, b := range t[:9] {
+	for _, b := range t[:8] {
 		if b != 0 {
 			return true
 		}
@@ -72,7 +72,7 @@ func (t *traceID) HasUpper() bool {
 }
 
 func (t *traceID) UpperHex() string {
-	return hex.EncodeToString(t[:9])
+	return hex.EncodeToString(t[:8])
 }
 
 // SpanContext represents a span state that can propagate to descendant spans
@@ -109,9 +109,9 @@ func newSpanContext(span *span, parent *spanContext) *spanContext {
 		spanID: span.SpanID,
 		span:   span,
 	}
-	context.traceID.SetLower(span.TraceID) // TODO: look in the incoming span for the upper bits?
+	context.traceID.SetLower(span.TraceID)
 	if parent != nil {
-		context.traceID = parent.traceID
+		context.traceID.SetUpper(parent.traceID.Upper())
 		context.trace = parent.trace
 		context.origin = parent.origin
 		context.errors = parent.errors

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -250,7 +250,7 @@ func TestNewSpanContext(t *testing.T) {
 		}
 		ctx := newSpanContext(span, nil)
 		assert := assert.New(t)
-		assert.Equal(ctx.traceID, span.TraceID)
+		assert.Equal(ctx.traceID.Lower(), span.TraceID)
 		assert.Equal(ctx.spanID, span.SpanID)
 		assert.NotNil(ctx.trace)
 		assert.Nil(ctx.trace.priority)
@@ -267,7 +267,7 @@ func TestNewSpanContext(t *testing.T) {
 		}
 		ctx := newSpanContext(span, nil)
 		assert := assert.New(t)
-		assert.Equal(ctx.traceID, span.TraceID)
+		assert.Equal(ctx.traceID.Lower(), span.TraceID)
 		assert.Equal(ctx.spanID, span.SpanID)
 		assert.Equal(ctx.TraceID(), span.TraceID)
 		assert.Equal(ctx.SpanID(), span.SpanID)
@@ -334,7 +334,7 @@ func TestSpanContextParent(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := newSpanContext(s, parentCtx)
 			assert := assert.New(t)
-			assert.Equal(ctx.traceID, s.TraceID)
+			assert.Equal(ctx.traceID.Lower(), s.TraceID)
 			assert.Equal(ctx.spanID, s.SpanID)
 			if parentCtx.trace != nil {
 				assert.Equal(len(ctx.trace.spans), len(parentCtx.trace.spans))

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -290,9 +290,9 @@ func TestNewSpanContext(t *testing.T) {
 		sctx, ok := ctx.(*spanContext)
 		assert.True(ok)
 		span := StartSpan("some-span", ChildOf(ctx))
-		assert.EqualValues(sctx.traceID, 1)
-		assert.EqualValues(sctx.spanID, 2)
-		assert.EqualValues(*sctx.trace.priority, 3)
+		assert.EqualValues(uint64(1), sctx.traceID.Lower())
+		assert.EqualValues(2, sctx.spanID)
+		assert.EqualValues(3, *sctx.trace.priority)
 		assert.Equal(sctx.trace.root, span)
 	})
 }
@@ -493,4 +493,16 @@ func TestSetSamplingPriorityLocked(t *testing.T) {
 		tr.setSamplingPriorityLocked(1, samplernames.RemoteRate)
 		assert.Equal(t, "-1", tr.propagatingTags[keyDecisionMaker])
 	})
+}
+
+func TestTraceIDHexEncoded(t *testing.T) {
+	tid := traceID([16]byte{})
+	tid[15] = 5
+	assert.Equal(t, "00000000000000000000000000000005", tid.HexEncoded())
+}
+
+func TestTraceIDEmpty(t *testing.T) {
+	tid := traceID([16]byte{})
+	tid[15] = 5
+	assert.False(t, tid.Empty())
 }

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -285,16 +285,16 @@ func (p *propagator) Inject(spanCtx ddtrace.SpanContext, carrier interface{}) er
 
 func (p *propagator) injectTextMap(spanCtx ddtrace.SpanContext, writer TextMapWriter) error {
 	ctx, ok := spanCtx.(*spanContext)
-	if !ok || ctx.traceID == 0 || ctx.spanID == 0 {
+	if !ok || ctx.traceID.Empty() || ctx.spanID == 0 {
 		return ErrInvalidSpanContext
 	}
 	// propagate the TraceID and the current active SpanID
-	if strings.Trim(ctx.traceID128, "0") != "" {
-		setPropagatingTag(ctx, keyTraceID128, ctx.traceID128)
+	if ctx.traceID.HasUpper() {
+		setPropagatingTag(ctx, keyTraceID128, ctx.traceID.UpperHex())
 	} else if ctx.trace != nil {
 		ctx.trace.unsetPropagatingTag(keyTraceID128)
 	}
-	writer.Set(p.cfg.TraceHeader, strconv.FormatUint(ctx.traceID, 10))
+	writer.Set(p.cfg.TraceHeader, strconv.FormatUint(ctx.traceID.Lower(), 10))
 	writer.Set(p.cfg.ParentHeader, strconv.FormatUint(ctx.spanID, 10))
 	if sp, ok := ctx.samplingPriority(); ok {
 		writer.Set(p.cfg.PriorityHeader, strconv.Itoa(sp))
@@ -361,10 +361,12 @@ func (p *propagator) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 		key := strings.ToLower(k)
 		switch key {
 		case p.cfg.TraceHeader:
-			ctx.traceID, err = parseUint64(v)
+			var lowerTid uint64
+			lowerTid, err = parseUint64(v)
 			if err != nil {
 				return ErrSpanContextCorrupted
 			}
+			ctx.traceID.SetLower(lowerTid)
 		case p.cfg.ParentHeader:
 			ctx.spanID, err = parseUint64(v)
 			if err != nil {
@@ -391,9 +393,10 @@ func (p *propagator) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 		return nil, err
 	}
 	if ctx.trace != nil {
-		ctx.traceID128 = ctx.trace.propagatingTags[keyTraceID128]
+		// TODO: this always assumed it was valid so I copied that logic here, maybe we shouldn't
+		ctx.traceID.SetUpperFromHex(ctx.trace.propagatingTags[keyTraceID128])
 	}
-	if ctx.traceID == 0 || (ctx.spanID == 0 && ctx.origin != "synthetics") {
+	if ctx.traceID.Empty() || (ctx.spanID == 0 && ctx.origin != "synthetics") {
 		return nil, ErrSpanContextNotFound
 	}
 	return &ctx, nil
@@ -451,10 +454,10 @@ func (p *propagatorB3) Inject(spanCtx ddtrace.SpanContext, carrier interface{}) 
 
 func (*propagatorB3) injectTextMap(spanCtx ddtrace.SpanContext, writer TextMapWriter) error {
 	ctx, ok := spanCtx.(*spanContext)
-	if !ok || ctx.traceID == 0 || ctx.spanID == 0 {
+	if !ok || ctx.traceID.Empty() || ctx.spanID == 0 {
 		return ErrInvalidSpanContext
 	}
-	if strings.Trim(ctx.traceID128, "0") == "" { // 64-bit trace id
+	if ctx.traceID.HasUpper() { // 64-bit trace id
 		writer.Set(b3TraceIDHeader, fmt.Sprintf("%016x", ctx.traceID))
 	} else { // 128-bit trace id
 		var w3Cctx ddtrace.SpanContextW3C
@@ -511,7 +514,7 @@ func (*propagatorB3) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 	if err != nil {
 		return nil, err
 	}
-	if ctx.traceID == 0 || ctx.spanID == 0 {
+	if ctx.traceID.Empty() || ctx.spanID == 0 {
 		return nil, ErrSpanContextNotFound
 	}
 	return &ctx, nil
@@ -532,13 +535,13 @@ func (p *propagatorB3SingleHeader) Inject(spanCtx ddtrace.SpanContext, carrier i
 
 func (*propagatorB3SingleHeader) injectTextMap(spanCtx ddtrace.SpanContext, writer TextMapWriter) error {
 	ctx, ok := spanCtx.(*spanContext)
-	if !ok || ctx.traceID == 0 || ctx.spanID == 0 {
+	if !ok || ctx.traceID.Empty() || ctx.spanID == 0 {
 		return ErrInvalidSpanContext
 	}
 	sb := strings.Builder{}
 	var traceID string
-	if strings.Trim(ctx.traceID128, "0") == "" { // 64-bit trace id
-		traceID = fmt.Sprintf("%016x", ctx.traceID)
+	if !ctx.traceID.HasUpper() { // 64-bit trace id
+		traceID = fmt.Sprintf("%016x", ctx.traceID.Lower())
 	} else { // 128-bit trace id
 		var w3Cctx ddtrace.SpanContextW3C
 		if w3Cctx, ok = spanCtx.(ddtrace.SpanContextW3C); !ok {
@@ -605,7 +608,7 @@ func (*propagatorB3SingleHeader) extractTextMap(reader TextMapReader) (ddtrace.S
 	if err != nil {
 		return nil, err
 	}
-	if ctx.traceID == 0 || ctx.spanID == 0 {
+	if ctx.traceID.Empty() || ctx.spanID == 0 {
 		return nil, ErrSpanContextNotFound
 	}
 	return &ctx, nil
@@ -640,7 +643,7 @@ func (p *propagatorW3c) Inject(spanCtx ddtrace.SpanContext, carrier interface{})
 // where each list-member is managed by a vendor or instrumentation library.
 func (*propagatorW3c) injectTextMap(spanCtx ddtrace.SpanContext, writer TextMapWriter) error {
 	ctx, ok := spanCtx.(*spanContext)
-	if !ok || ctx.traceID == 0 || ctx.spanID == 0 {
+	if !ok || ctx.traceID.Empty() || ctx.spanID == 0 {
 		return ErrInvalidSpanContext
 	}
 	flags := ""
@@ -652,8 +655,8 @@ func (*propagatorW3c) injectTextMap(spanCtx ddtrace.SpanContext, writer TextMapW
 	}
 
 	var traceID string
-	if strings.Trim(ctx.traceID128, "0") != "" {
-		setPropagatingTag(ctx, keyTraceID128, ctx.traceID128)
+	if ctx.traceID.HasUpper() {
+		setPropagatingTag(ctx, keyTraceID128, ctx.traceID.UpperHex())
 		if w3Cctx, ok := spanCtx.(ddtrace.SpanContextW3C); ok {
 			traceID = w3Cctx.TraceID128()
 		}
@@ -926,12 +929,15 @@ func extractTraceID128(ctx *spanContext, v string) error {
 	v = strings.TrimLeft(v, "0")
 	var err error
 	if len(v) <= 16 { // 64-bit trace id
-		ctx.traceID, err = strconv.ParseUint(v, 16, 64)
+		var tid uint64
+		tid, err = strconv.ParseUint(v, 16, 64)
+		ctx.traceID.SetLower(tid)
 	} else { // 128-bit trace id
-		id128 := v[:len(v)-16]
-		// pad ctx.traceID128 with zeroes to ensure length of 16
-		ctx.traceID128 = fmt.Sprintf("%016s", id128)
-		ctx.traceID, err = strconv.ParseUint(v[len(id128):], 16, 64)
+		idUpper := v[:len(v)-16]
+		ctx.traceID.SetUpperFromHex(idUpper)
+		var l uint64
+		l, err = strconv.ParseUint(v[len(idUpper):], 16, 64)
+		ctx.traceID.SetLower(l)
 	}
 	if err != nil {
 		return ErrSpanContextCorrupted

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -457,8 +457,8 @@ func (*propagatorB3) injectTextMap(spanCtx ddtrace.SpanContext, writer TextMapWr
 	if !ok || ctx.traceID.Empty() || ctx.spanID == 0 {
 		return ErrInvalidSpanContext
 	}
-	if ctx.traceID.HasUpper() { // 64-bit trace id
-		writer.Set(b3TraceIDHeader, fmt.Sprintf("%016x", ctx.traceID))
+	if !ctx.traceID.HasUpper() { // 64-bit trace id
+		writer.Set(b3TraceIDHeader, fmt.Sprintf("%016x", ctx.traceID.Lower()))
 	} else { // 128-bit trace id
 		var w3Cctx ddtrace.SpanContextW3C
 		if w3Cctx, ok = spanCtx.(ddtrace.SpanContextW3C); !ok {

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -475,9 +475,9 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		// casting from int64 -> uint32 should be safe since the start time won't be
 		// negative, and the seconds should fit within 32-bits for the foreseeable future.
 		// (We only want 32 bits of time, then the rest is zero)
+		tUp := uint64(uint32(id128)) << 32 // We need the time at the upper 32 bits of the uint
 
-		//TODO: I think I messed this up and need to to bit twiddling
-		span.context.traceID.SetUpper(uint64(uint32(id128)))
+		span.context.traceID.SetUpper(tUp)
 	}
 
 	// add tags from options

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -854,7 +854,7 @@ func TestTracerSamplingPriorityEmptySpanCtx(t *testing.T) {
 	defer stop()
 	root := newBasicSpan("web.request")
 	spanCtx := &spanContext{
-		traceID: traceIDFromLowerUint64(root.context.TraceID()),
+		traceID: traceIDFrom64Bits(root.context.TraceID()),
 		spanID:  root.context.SpanID(),
 		trace:   &trace{},
 	}
@@ -869,7 +869,7 @@ func TestTracerDDUpstreamServicesManualKeep(t *testing.T) {
 	defer tracer.Stop()
 	root := newBasicSpan("web.request")
 	spanCtx := &spanContext{
-		traceID: traceIDFromLowerUint64(root.context.TraceID()),
+		traceID: traceIDFrom64Bits(root.context.TraceID()),
 		spanID:  root.context.SpanID(),
 		trace:   &trace{},
 	}

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -854,7 +854,7 @@ func TestTracerSamplingPriorityEmptySpanCtx(t *testing.T) {
 	defer stop()
 	root := newBasicSpan("web.request")
 	spanCtx := &spanContext{
-		traceID: root.context.TraceID(),
+		traceID: traceIDFromLowerUint64(root.context.TraceID()),
 		spanID:  root.context.SpanID(),
 		trace:   &trace{},
 	}
@@ -869,7 +869,7 @@ func TestTracerDDUpstreamServicesManualKeep(t *testing.T) {
 	defer tracer.Stop()
 	root := newBasicSpan("web.request")
 	spanCtx := &spanContext{
-		traceID: root.context.TraceID(),
+		traceID: traceIDFromLowerUint64(root.context.TraceID()),
 		spanID:  root.context.SpanID(),
 		trace:   &trace{},
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Refactor the spancontext `traceID` to be a `[16]byte` instead of a `uint64`. This is a marginal memory gain over storing the upper bits as a hex string at a slight cost of possibly needing to hex-encode more frequently. 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
It's confusing to have the trace id split up across fields and as different types, it led to odd looking code occasionally where some bits of the ID would need to be encoded or decoded for the use-case at hand. I _believe_ this refactor is an improvement in readability, although admittedly this code is still a bit confusing. Notably `newContext` as the `span` type can't be changed as it's exactly marshalled to the agent in its current form.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes
The unit tests, system tests, parametric tests should sufficiently cover this refactor I believe, but given this touches a critical component of the tracer we may want to be extra diligent during release testing to ensure there's no breakages here.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.