### PR TITLE
Setup python 3.9 for system tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -38,6 +38,11 @@ jobs:
       WEBLOG_VARIANT: ${{ matrix.weblog-variant }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
     steps:
+      - name: Setup python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
       - name: Checkout system tests
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION

### What does this PR do?

This PR installs python 3.9 for system tests jobs.

### Motivation

System test executor will run on the host rather than inside a container (see https://github.com/DataDog/system-tests/pull/958). It will allow users to do step-by-step debugging, and will allow to unify architecture with parametric tests.

Side note, As now, the change will do nothing but installing python 3.9 on system tests job. Once the PR on system repo will be merge, it'll work silently (and we'll be able to remove the installation of docker compose, not required anymore).

### Describe how to test/QA your changes

N/A

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.