### PR TITLE
internal/telemetry: fix flaky agentless retry test

### DIFF
--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -247,8 +247,7 @@ func TestConcurrentClient(t *testing.T) {
 func fakeAgentless(ctx context.Context, t *testing.T) (wait func(), cleanup func()) {
 	received := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		h := r.Header.Get("DD-Telemetry-Request-Type")
-		if len(h) > 0 {
+		if r.Header.Get("DD-Telemetry-Request-Type") == string(telemetry.RequestTypeAppStarted) {
 			received <- struct{}{}
 		}
 	}))

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -245,10 +245,13 @@ func TestConcurrentClient(t *testing.T) {
 //  2. a cleanup function that closes the server and resets the agentless endpoint to
 //     its original value
 func fakeAgentless(ctx context.Context, t *testing.T) (wait func(), cleanup func()) {
-	received := make(chan struct{})
+	received := make(chan struct{}, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("DD-Telemetry-Request-Type") == string(telemetry.RequestTypeAppStarted) {
-			received <- struct{}{}
+			select {
+			case received <- struct{}{}:
+			default:
+			}
 		}
 	}))
 	prevEndpoint := telemetry.SetAgentlessEndpoint(server.URL)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Fix a flaky `TestAgentlessRetry` test. 

This test creates a server that acts as a fake agentless endpoint and waits for a request to verify telemetry is being sent to the agentless endpoint. The handler runs `received <- struct{}{}` when it receives the first request, which verifies agentless retry is working and the test then tries to close the server.

Sometimes, a second telemetry message triggers `received <- struct{}{}` before the server closes, but now there is no one waiting on the other side of the channel. This then causes `server.Close()` to be blocked.

Fix by 
1) ignoring all messages except for `app-started` in the server handler 
2) making the received channel buffered and have sending to the channel be non-blocking (thanks to @nsrip-dd)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes
In the `internal/telemetry` directory:

`go test -run=TestAgentlessRetry -count=100`

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.