### PR TITLE
ddtrace/tracer: add attribute schema version config variable and tag

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -25,6 +25,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/namingschema"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/traceprof"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/version"
 
@@ -150,6 +151,9 @@ type config struct {
 
 	// disableHostnameDetection specifies whether the tracer should disable hostname detection.
 	disableHostnameDetection bool
+
+	// spanAttributeSchemaVersion holds the selected DD_TRACE_SPAN_ATTRIBUTE_SCHEMA version.
+	spanAttributeSchemaVersion int
 }
 
 // HasFeature reports whether feature f is enabled.
@@ -219,6 +223,17 @@ func newConfig(opts ...StartOption) *config {
 	c.enabled = internal.BoolEnv("DD_TRACE_ENABLED", true)
 	c.profilerEndpoints = internal.BoolEnv(traceprof.EndpointEnvVar, true)
 	c.profilerHotspots = internal.BoolEnv(traceprof.CodeHotspotsEnvVar, true)
+
+	schemaVersionStr := os.Getenv(namingschema.SpanAttributeSchemaEnvVar)
+	if v, ok := namingschema.ParseVersion(schemaVersionStr); ok {
+		namingschema.SetVersion(v)
+		c.spanAttributeSchemaVersion = int(v)
+	} else {
+		namingschema.SetDefaultVersion()
+		v := namingschema.GetVersion()
+		c.spanAttributeSchemaVersion = int(v)
+		log.Warn("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA=%s is not a valid value, setting to default of v%d", schemaVersionStr, v)
+	}
 
 	for _, fn := range opts {
 		fn(c)

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -665,6 +665,8 @@ const (
 
 	//keyTracerHostname holds the tracer detected hostname, only present when not connected over UDS to agent.
 	keyTracerHostname = "_dd.tracer_hostname"
+	// keySpanAttributeSchemaVersion holds the selected DD_TRACE_SPAN_ATTRIBUTE_SCHEMA version.
+	keySpanAttributeSchemaVersion = "_dd.trace_span_attribute_schema"
 )
 
 // The following set of tags is used for user monitoring and set through calls to span.SetUser().

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -426,7 +426,7 @@ const (
 func TestSpanSetMetric(t *testing.T) {
 	for name, tt := range map[string]func(assert *assert.Assertions, span *span){
 		"init": func(assert *assert.Assertions, span *span) {
-			assert.Equal(4, len(span.Metrics))
+			assert.Equal(5, len(span.Metrics))
 			_, ok := span.Metrics[keySamplingPriority]
 			assert.True(ok)
 			_, ok = span.Metrics[keySamplingPriorityRate]
@@ -461,7 +461,7 @@ func TestSpanSetMetric(t *testing.T) {
 		"finished": func(assert *assert.Assertions, span *span) {
 			span.Finish()
 			span.SetTag("finished.test", 1337)
-			assert.Equal(4, len(span.Metrics))
+			assert.Equal(5, len(span.Metrics))
 			_, ok := span.Metrics["finished.test"]
 			assert.False(ok)
 		},

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -487,6 +487,10 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 			span.Service = newSvc
 		}
 	}
+	// root span
+	if context == nil || context.span == nil {
+		span.setMetric(keySpanAttributeSchemaVersion, float64(t.config.spanAttributeSchemaVersion))
+	}
 	if context == nil || context.span == nil || context.span.Service != span.Service {
 		span.setMetric(keyTopLevel, 1)
 		// all top level spans are measured. So the measured tag is redundant.

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -285,6 +285,39 @@ func TestTracerStartSpan(t *testing.T) {
 		child := tracer.StartSpan("home/user", Measured(), ChildOf(parent.context)).(*span)
 		assert.Equal(t, 1.0, child.Metrics[keyMeasured])
 	})
+
+	t.Run("attribute_schema_is_set_v0", func(t *testing.T) {
+		t.Setenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", "v0")
+		tracer := newTracer()
+		defer tracer.Stop()
+		parent := tracer.StartSpan("/home/user").(*span)
+		child := tracer.StartSpan("home/user", ChildOf(parent.context)).(*span)
+		assert.Contains(t, parent.Metrics, "_dd.trace_span_attribute_schema")
+		assert.Equal(t, 0.0, parent.Metrics["_dd.trace_span_attribute_schema"])
+		assert.NotContains(t, child.Metrics, "_dd.trace_span_attribute_schema")
+	})
+
+	t.Run("attribute_schema_is_set_v1", func(t *testing.T) {
+		t.Setenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", "v1")
+		tracer := newTracer()
+		defer tracer.Stop()
+		parent := tracer.StartSpan("/home/user").(*span)
+		child := tracer.StartSpan("home/user", ChildOf(parent.context)).(*span)
+		assert.Contains(t, parent.Metrics, "_dd.trace_span_attribute_schema")
+		assert.Equal(t, 1.0, parent.Metrics["_dd.trace_span_attribute_schema"])
+		assert.NotContains(t, child.Metrics, "_dd.trace_span_attribute_schema")
+	})
+
+	t.Run("attribute_schema_is_set_wrong_value", func(t *testing.T) {
+		t.Setenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", "bad-version")
+		tracer := newTracer()
+		defer tracer.Stop()
+		parent := tracer.StartSpan("/home/user").(*span)
+		child := tracer.StartSpan("home/user", ChildOf(parent.context)).(*span)
+		assert.Contains(t, parent.Metrics, "_dd.trace_span_attribute_schema")
+		assert.Equal(t, 0.0, parent.Metrics["_dd.trace_span_attribute_schema"])
+		assert.NotContains(t, child.Metrics, "_dd.trace_span_attribute_schema")
+	})
 }
 
 func TestSamplingDecision(t *testing.T) {

--- a/internal/namingschema/namingschema.go
+++ b/internal/namingschema/namingschema.go
@@ -14,15 +14,13 @@
 package namingschema
 
 import (
-	"os"
 	"strings"
 	"sync"
-
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 )
 
 const (
-	envSpanAttributeSchema = "DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"
+	// SpanAttributeSchemaEnvVar is used to specify the span attribute schema (aka naming schema) version to use.
+	SpanAttributeSchemaEnvVar = "DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"
 )
 
 // Version represents the available naming schema versions.
@@ -40,17 +38,15 @@ var (
 	sv Version
 )
 
-func init() {
-	mu.Lock()
-	defer mu.Unlock()
-	switch version := strings.ToLower(os.Getenv(envSpanAttributeSchema)); version {
+// ParseVersion attempts to parse the version string.
+func ParseVersion(v string) (Version, bool) {
+	switch strings.ToLower(v) {
 	case "", "v0":
-		sv = SchemaV0
+		return SchemaV0, true
 	case "v1":
-		sv = SchemaV1
+		return SchemaV1, true
 	default:
-		log.Warn("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA=%s is not a valid value, setting to default of v0", version)
-		sv = SchemaV0
+		return SchemaV0, false
 	}
 }
 

--- a/internal/namingschema/namingschema.go
+++ b/internal/namingschema/namingschema.go
@@ -64,6 +64,11 @@ func SetVersion(v Version) {
 	sv = v
 }
 
+// SetDefaultVersion sets the default global naming schema version.
+func SetDefaultVersion() {
+	SetVersion(SchemaV0)
+}
+
 // VersionSupportSchema is an interface that ensures all the available naming schema versions are implemented by the caller.
 type VersionSupportSchema interface {
 	V0() string


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
- Move `DD_TRACE_SPAN_ATTRIBUTE_SCHEMA` env variable read and parsing to `ddtrace/trace` package.
- Set `_dd.trace_span_attribute_schema` metric tag to the value of the selected `DD_TRACE_SPAN_ATTRIBUTE_SCHEMA` version (`0` or `1` currently). This tag is only set for root spans.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->
This tag is necessary so we can track the used schema version.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Changed code has unit tests for its functionality.
- [x] If this interacts with the agent in a new way, a system test has been added.