### PR TITLE
httpsec/client-ip: stop walking the headers as soon as a global ip is found

### DIFF
--- a/internal/appsec/dyngo/instrumentation/httpsec/tags.go
+++ b/internal/appsec/dyngo/instrumentation/httpsec/tags.go
@@ -142,6 +142,7 @@ func ClientIP(hdrs map[string][]string, hasCanonicalMIMEHeaderKeys bool, remoteA
 
 	// Walk IP-related headers
 	var foundIP instrumentation.NetaddrIP
+headersLoop:
 	for _, headerName := range monitoredHeaders {
 		if hasCanonicalMIMEHeaderKeys {
 			headerName = textproto.CanonicalMIMEHeaderKey(headerName)
@@ -171,7 +172,7 @@ func ClientIP(hdrs map[string][]string, hasCanonicalMIMEHeaderKeys bool, remoteA
 			}
 			if isGlobal(ip) {
 				foundIP = ip
-				break
+				break headersLoop
 			}
 		}
 	}

--- a/internal/appsec/dyngo/instrumentation/httpsec/tags_test.go
+++ b/internal/appsec/dyngo/instrumentation/httpsec/tags_test.go
@@ -209,6 +209,16 @@ func genIPTestCases() []ipTestCase {
 			expectedIP: instrumentation.NetaddrMustParseIP(ipv4Global),
 		},
 		{
+			name:       "ip-multi-header-order-0",
+			headers:    map[string]string{"forwarded-for": ipv6Global, "cf-connecting-ip": ipv4Global},
+			expectedIP: instrumentation.NetaddrMustParseIP(ipv6Global),
+		},
+		{
+			name:       "ip-multi-header-order-1",
+			headers:    map[string]string{"forwarded-for": ipv6Global, "x-client-ip": ipv4Global},
+			expectedIP: instrumentation.NetaddrMustParseIP(ipv4Global),
+		},
+		{
 			name:       "ipv4-multi-header-0",
 			headers:    map[string]string{"x-forwarded-for": ipv4Private, "forwarded-for": ipv4Global},
 			expectedIP: instrumentation.NetaddrMustParseIP(ipv4Global),


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Fix the new `ClientIP()` algorithm so that it properly stops as soon as a global IP address is found in the HTTP headers. This patch fixes the `break` statement that was performed on the inner for loop instead of the outter, and therefore continuing to look at the next HTTP headers, therefore returning the last global IP address found.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.