### PR TITLE
ci: pin system tests until opentelemetry changes are merged

### DIFF
--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -27,6 +27,10 @@ jobs:
         with:
           repository: 'DataDog/system-tests'
           path: system-tests
+          # TODO: this pins the tests to a commit which doesn't use the
+          # opentelemetry package, which hasn't yet been merged to main. Unpin
+          # when those changes are merged.
+          ref: 9edeb7e92dcf4576cad27b6af6fee2f05836d245
 
       - name: Checkout Go
         uses: actions/checkout@v3

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -47,6 +47,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'DataDog/system-tests'
+          # TODO: this pins the tests to a commit which doesn't use the
+          # opentelemetry package, which hasn't yet been merged to main. Unpin
+          # when those changes are merged.
+          ref: 9edeb7e92dcf4576cad27b6af6fee2f05836d245
 
       - name: Checkout dd-trace-go
         uses: actions/checkout@v2

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -47,10 +47,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'DataDog/system-tests'
-          # TODO: this pins the tests to a commit which doesn't use the
-          # opentelemetry package, which hasn't yet been merged to main. Unpin
-          # when those changes are merged.
-          ref: 9edeb7e92dcf4576cad27b6af6fee2f05836d245
 
       - name: Checkout dd-trace-go
         uses: actions/checkout@v2


### PR DESCRIPTION
### What does this PR do?

The parametric tests app uses the opentelemetry package, which hasn't
been merged. This means it can't build on branches against main, so CI
is broken. Pin to before the tests were changed.

### Motivation

Fix CI.

