### PR TITLE
internal/telemetry: refactor telemetry unit tests

### DIFF
--- a/ddtrace/tracer/telemetry_test.go
+++ b/ddtrace/tracer/telemetry_test.go
@@ -6,44 +6,19 @@
 package tracer
 
 import (
-	"context"
-	"encoding/json"
-	"net/http"
 	"testing"
-	"time"
 
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/httpmem"
+	"github.com/stretchr/testify/assert"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/telemetrytest"
 )
 
 func TestTelemetryEnabled(t *testing.T) {
-	t.Setenv("DD_TRACE_STARTUP_LOGS", "0")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	received := make(chan *telemetry.AppStarted, 1)
-	server, client := httpmem.ServerAndClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/telemetry/proxy/api/v2/apmtelemetry" {
-			return
-		}
-		if r.Header.Get("DD-Telemetry-Request-Type") != string(telemetry.RequestTypeAppStarted) {
-			return
-		}
-		var body telemetry.Body
-		body.Payload = new(telemetry.AppStarted)
-		err := json.NewDecoder(r.Body).Decode(&body)
-		if err != nil {
-			t.Errorf("bad body: %s", err)
-		}
-		select {
-		case received <- body.Payload.(*telemetry.AppStarted):
-		default:
-		}
-	}))
-	defer server.Close()
+	telemetryClient := new(telemetrytest.MockClient)
+	defer telemetry.MockGlobalClient(telemetryClient)()
 
 	Start(
-		WithHTTPClient(client),
 		WithDebugStack(false),
 		WithService("test-serv"),
 		WithEnv("test-env"),
@@ -51,27 +26,9 @@ func TestTelemetryEnabled(t *testing.T) {
 	)
 	defer Stop()
 
-	var payload *telemetry.AppStarted
-	select {
-	case <-ctx.Done():
-		t.Fatalf("Time out: waiting for telemetry payload")
-	case payload = <-received:
-	}
-
-	check := func(key string, expected interface{}) {
-		for _, kv := range payload.Configuration {
-			if kv.Name == key {
-				if kv.Value != expected {
-					t.Errorf("configuration %s: wanted %v, got %v", key, expected, kv.Value)
-				}
-				return
-			}
-		}
-		t.Errorf("missing configuration %s", key)
-	}
-
-	check("trace_debug_enabled", false)
-	check("service", "test-serv")
-	check("env", "test-env")
-	check("runtime_metrics_enabled", true)
+	assert.True(t, telemetryClient.Started)
+	telemetry.Check(t, telemetryClient.Configuration, "trace_debug_enabled", false)
+	telemetry.Check(t, telemetryClient.Configuration, "service", "test-serv")
+	telemetry.Check(t, telemetryClient.Configuration, "env", "test-env")
+	telemetry.Check(t, telemetryClient.Configuration, "runtime_metrics_enabled", true)
 }

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022 Datadog, Inc.
 
-package telemetry_test
+package telemetry
 
 import (
 	"context"
@@ -15,10 +15,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 )
 
 func TestClient(t *testing.T) {
@@ -30,7 +26,7 @@ func TestClient(t *testing.T) {
 		if len(h) == 0 {
 			t.Fatal("didn't get telemetry request type header")
 		}
-		if telemetry.RequestType(h) == telemetry.RequestTypeAppHeartbeat {
+		if RequestType(h) == RequestTypeAppHeartbeat {
 			select {
 			case heartbeat <- struct{}{}:
 			default:
@@ -39,7 +35,7 @@ func TestClient(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := &telemetry.Client{
+	client := &Client{
 		URL: server.URL,
 	}
 	client.Start(nil)
@@ -59,30 +55,30 @@ func TestMetrics(t *testing.T) {
 	t.Setenv("DD_TELEMETRY_HEARTBEAT_INTERVAL", "1")
 	var (
 		mu  sync.Mutex
-		got []telemetry.Series
+		got []Series
 	)
 	closed := make(chan struct{}, 1)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("DD-Telemetry-Request-Type") == string(telemetry.RequestTypeAppClosing) {
+		if r.Header.Get("DD-Telemetry-Request-Type") == string(RequestTypeAppClosing) {
 			select {
 			case closed <- struct{}{}:
 			default:
 			}
 			return
 		}
-		req := telemetry.Body{
-			Payload: new(telemetry.Metrics),
+		req := Body{
+			Payload: new(Metrics),
 		}
 		dec := json.NewDecoder(r.Body)
 		err := dec.Decode(&req)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if req.RequestType != telemetry.RequestTypeGenerateMetrics {
+		if req.RequestType != RequestTypeGenerateMetrics {
 			return
 		}
-		v, ok := req.Payload.(*telemetry.Metrics)
+		v, ok := req.Payload.(*Metrics)
 		if !ok {
 			t.Fatal("payload set metrics but didn't get metrics")
 		}
@@ -99,25 +95,25 @@ func TestMetrics(t *testing.T) {
 	defer server.Close()
 
 	go func() {
-		client := &telemetry.Client{
+		client := &Client{
 			URL: server.URL,
 		}
 		client.Start(nil)
 
 		// Gauges should have the most recent value
-		client.Gauge(telemetry.NamespaceTracers, "foobar", 1, nil, false)
-		client.Gauge(telemetry.NamespaceTracers, "foobar", 2, nil, false)
+		client.Gauge(NamespaceTracers, "foobar", 1, nil, false)
+		client.Gauge(NamespaceTracers, "foobar", 2, nil, false)
 		// Counts should be aggregated
-		client.Count(telemetry.NamespaceTracers, "baz", 3, nil, true)
-		client.Count(telemetry.NamespaceTracers, "baz", 1, nil, true)
+		client.Count(NamespaceTracers, "baz", 3, nil, true)
+		client.Count(NamespaceTracers, "baz", 1, nil, true)
 		// Tags should be passed through
-		client.Count(telemetry.NamespaceTracers, "bonk", 4, []string{"org:1"}, false)
+		client.Count(NamespaceTracers, "bonk", 4, []string{"org:1"}, false)
 		client.Stop()
 	}()
 
 	<-closed
 
-	want := []telemetry.Series{
+	want := []Series{
 		{Metric: "baz", Type: "count", Points: [][2]float64{{0, 4}}, Tags: []string{}, Common: true},
 		{Metric: "bonk", Type: "count", Points: [][2]float64{{0, 4}}, Tags: []string{"org:1"}},
 		{Metric: "foobar", Type: "gauge", Points: [][2]float64{{0, 2}}, Tags: []string{}},
@@ -139,12 +135,12 @@ func TestDisabledClient(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := &telemetry.Client{
+	client := &Client{
 		URL: server.URL,
 	}
 	client.Start(nil)
-	client.Gauge(telemetry.NamespaceTracers, "foobar", 1, nil, false)
-	client.Count(telemetry.NamespaceTracers, "bonk", 4, []string{"org:1"}, false)
+	client.Gauge(NamespaceTracers, "foobar", 1, nil, false)
+	client.Count(NamespaceTracers, "bonk", 4, []string{"org:1"}, false)
 	client.Stop()
 }
 
@@ -155,11 +151,11 @@ func TestNonStartedClient(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := &telemetry.Client{
+	client := &Client{
 		URL: server.URL,
 	}
-	client.Gauge(telemetry.NamespaceTracers, "foobar", 1, nil, false)
-	client.Count(telemetry.NamespaceTracers, "bonk", 4, []string{"org:1"}, false)
+	client.Gauge(NamespaceTracers, "foobar", 1, nil, false)
+	client.Count(NamespaceTracers, "bonk", 4, []string{"org:1"}, false)
 	client.Stop()
 }
 
@@ -167,30 +163,30 @@ func TestConcurrentClient(t *testing.T) {
 	t.Setenv("DD_TELEMETRY_HEARTBEAT_INTERVAL", "1")
 	var (
 		mu  sync.Mutex
-		got []telemetry.Series
+		got []Series
 	)
 	closed := make(chan struct{}, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Log("foo")
-		if r.Header.Get("DD-Telemetry-Request-Type") == string(telemetry.RequestTypeAppClosing) {
+		if r.Header.Get("DD-Telemetry-Request-Type") == string(RequestTypeAppClosing) {
 			select {
 			case closed <- struct{}{}:
 			default:
 				return
 			}
 		}
-		req := telemetry.Body{
-			Payload: new(telemetry.Metrics),
+		req := Body{
+			Payload: new(Metrics),
 		}
 		dec := json.NewDecoder(r.Body)
 		err := dec.Decode(&req)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if req.RequestType != telemetry.RequestTypeGenerateMetrics {
+		if req.RequestType != RequestTypeGenerateMetrics {
 			return
 		}
-		v, ok := req.Payload.(*telemetry.Metrics)
+		v, ok := req.Payload.(*Metrics)
 		if !ok {
 			t.Fatal("payload set metrics but didn't get metrics")
 		}
@@ -207,7 +203,7 @@ func TestConcurrentClient(t *testing.T) {
 	defer server.Close()
 
 	go func() {
-		client := &telemetry.Client{
+		client := &Client{
 			URL: server.URL,
 		}
 		client.Start(nil)
@@ -219,7 +215,7 @@ func TestConcurrentClient(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				for j := 0; j < 10; j++ {
-					client.Count(telemetry.NamespaceTracers, "foobar", 1, []string{"tag"}, false)
+					client.Count(NamespaceTracers, "foobar", 1, []string{"tag"}, false)
 				}
 			}()
 		}
@@ -228,7 +224,7 @@ func TestConcurrentClient(t *testing.T) {
 
 	<-closed
 
-	want := []telemetry.Series{
+	want := []Series{
 		{Metric: "foobar", Type: "count", Points: [][2]float64{{0, 80}}, Tags: []string{"tag"}},
 	}
 	sort.Slice(got, func(i, j int) bool {
@@ -245,16 +241,14 @@ func TestConcurrentClient(t *testing.T) {
 //  2. a cleanup function that closes the server and resets the agentless endpoint to
 //     its original value
 func fakeAgentless(ctx context.Context, t *testing.T) (wait func(), cleanup func()) {
-	received := make(chan struct{}, 1)
+	received := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("DD-Telemetry-Request-Type") == string(telemetry.RequestTypeAppStarted) {
-			select {
-			case received <- struct{}{}:
-			default:
-			}
+		h := r.Header.Get("DD-Telemetry-Request-Type")
+		if len(h) > 0 {
+			received <- struct{}{}
 		}
 	}))
-	prevEndpoint := telemetry.SetAgentlessEndpoint(server.URL)
+	prevEndpoint := SetAgentlessEndpoint(server.URL)
 	return func() {
 			select {
 			case <-ctx.Done():
@@ -264,7 +258,7 @@ func fakeAgentless(ctx context.Context, t *testing.T) (wait func(), cleanup func
 			}
 		}, func() {
 			server.Close()
-			telemetry.SetAgentlessEndpoint(prevEndpoint)
+			SetAgentlessEndpoint(prevEndpoint)
 		}
 }
 
@@ -282,96 +276,40 @@ func TestAgentlessRetry(t *testing.T) {
 	}))
 	brokenServer.Close()
 
-	client := &telemetry.Client{
+	client := &Client{
 		URL: brokenServer.URL,
 	}
-	client.Start([]telemetry.Configuration{})
+	client.Start(nil)
 	waitAgentlessEndpoint()
 }
 
 func TestCollectDependencies(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	received := make(chan *telemetry.Dependencies)
+	received := make(chan *Dependencies)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("DD-Telemetry-Request-Type") == string(telemetry.RequestTypeDependenciesLoaded) {
-			var body telemetry.Body
-			body.Payload = new(telemetry.Dependencies)
+		if r.Header.Get("DD-Telemetry-Request-Type") == string(RequestTypeDependenciesLoaded) {
+			var body Body
+			body.Payload = new(Dependencies)
 			err := json.NewDecoder(r.Body).Decode(&body)
 			if err != nil {
 				t.Errorf("bad body: %s", err)
 			}
 			select {
-			case received <- body.Payload.(*telemetry.Dependencies):
+			case received <- body.Payload.(*Dependencies):
 			default:
 			}
 		}
 	}))
 	defer server.Close()
-	client := &telemetry.Client{
+	client := &Client{
 		URL: server.URL,
 	}
-	client.Start([]telemetry.Configuration{})
+	client.Start(nil)
 	select {
 	case <-received:
 	case <-ctx.Done():
 		t.Fatalf("Timed out waiting for dependency payload")
 	}
-}
-
-func TestProductChange(t *testing.T) {
-	t.Setenv("DD_TELEMETRY_HEARTBEAT_INTERVAL", "1")
-	receivedProducts := make(chan *telemetry.Products, 1)
-	receivedConfigs := make(chan *telemetry.ConfigurationChange, 1)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("DD-Telemetry-Request-Type") == string(telemetry.RequestTypeAppProductChange) {
-			var body telemetry.Body
-			body.Payload = new(telemetry.Products)
-			err := json.NewDecoder(r.Body).Decode(&body)
-			if err != nil {
-				t.Errorf("bad body: %s", err)
-			}
-			select {
-			case receivedProducts <- body.Payload.(*telemetry.Products):
-			default:
-			}
-		}
-		if r.Header.Get("DD-Telemetry-Request-Type") == string(telemetry.RequestTypeAppClientConfigurationChange) {
-			var body telemetry.Body
-			body.Payload = new(telemetry.ConfigurationChange)
-			err := json.NewDecoder(r.Body).Decode(&body)
-			if err != nil {
-				t.Errorf("bad body: %s", err)
-			}
-			select {
-			case receivedConfigs <- body.Payload.(*telemetry.ConfigurationChange):
-			default:
-			}
-		}
-	}))
-	defer server.Close()
-	client := &telemetry.Client{
-		URL: server.URL,
-	}
-	client.Start(nil)
-	client.ProductChange(telemetry.NamespaceProfilers, true,
-		[]telemetry.Configuration{telemetry.BoolConfig("delta_profiles", true)})
-
-	var productsPayload *telemetry.Products = <-receivedProducts
-	assert.Equal(t, productsPayload.Profiler.Enabled, true)
-
-	var configPayload *telemetry.ConfigurationChange = <-receivedConfigs
-	check := func(key string, expected interface{}) {
-		for _, kv := range configPayload.Configuration {
-			if kv.Name == key {
-				if kv.Value != expected {
-					t.Errorf("configuration %s: wanted %v, got %v", key, expected, kv.Value)
-				}
-				return
-			}
-		}
-		t.Errorf("missing configuration %s", key)
-	}
-	check("delta_profiles", true)
 }

--- a/internal/telemetry/option.go
+++ b/internal/telemetry/option.go
@@ -133,19 +133,10 @@ func (c *Client) fallbackOps() error {
 			c.Service = name
 		} else {
 			c.Service = filepath.Base(os.Args[0])
+
 		}
 	}
 	c.Env = configEnvFallback("DD_ENV", c.Env)
 	c.Version = configEnvFallback("DD_VERSION", c.Version)
 	return nil
-}
-
-// SetAgentlessEndpoint is used for testing purposes to replace the real agentless
-// endpoint with a custom one
-func SetAgentlessEndpoint(endpoint string) string {
-	agentlessEndpointLock.Lock()
-	defer agentlessEndpointLock.Unlock()
-	prev := agentlessURL
-	agentlessURL = endpoint
-	return prev
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -20,7 +20,6 @@ func (c *Client) ProductChange(namespace Namespace, enabled bool, configuration 
 	defer c.mu.Unlock()
 	if !c.started {
 		log("attempted to send product change event, but telemetry client has not started")
-		return
 	}
 	products := new(Products)
 	switch namespace {
@@ -30,7 +29,6 @@ func (c *Client) ProductChange(namespace Namespace, enabled bool, configuration 
 		products.AppSec = ProductDetails{Enabled: enabled}
 	default:
 		log("unknown product namespace, app-product-change telemetry event will not send")
-		return
 	}
 	productReq := c.newRequest(RequestTypeAppProductChange)
 	productReq.Body.Payload = products

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023 Datadog, Inc.
+
+// Package telemetry implements a client for sending telemetry information to
+// Datadog regarding usage of an APM library such as tracing or profiling.
+
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProductChange(t *testing.T) {
+	client := new(Client)
+	client.Start(nil)
+	client.ProductChange(NamespaceProfilers, true,
+		[]Configuration{BoolConfig("delta_profiles", true)})
+
+	// should contain app-client-configuration-change and app-product-change
+	assert.Len(t, client.requests, 2)
+
+	firstBody := client.requests[0].Body
+	assert.Equal(t, RequestTypeAppClientConfigurationChange, firstBody.RequestType)
+	var configPayload *ConfigurationChange = client.requests[0].Body.Payload.(*ConfigurationChange)
+	assert.Len(t, configPayload.Configuration, 1)
+
+	Check(t, configPayload.Configuration, "delta_profiles", true)
+
+	secondBody := client.requests[1].Body
+	assert.Equal(t, RequestTypeAppProductChange, secondBody.RequestType)
+
+	var productsPayload *Products = secondBody.Payload.(*Products)
+	assert.Equal(t, productsPayload.Profiler.Enabled, true)
+}

--- a/internal/telemetry/utils.go
+++ b/internal/telemetry/utils.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023 Datadog, Inc.
+
+// Package telemetry implements a client for sending telemetry information to
+// Datadog regarding usage of an APM library such as tracing or profiling.
+package telemetry
+
+import (
+	"testing"
+)
+
+// MockGlobalClient replaces the global telemetry client with a custom
+// implementation of TelemetryClient. It returns a function that can be deferred
+// to reset the global telemetry client to its previous value.
+func MockGlobalClient(client TelemetryClient) func() {
+	globalClient.Lock()
+	defer globalClient.Unlock()
+	oldClient := GlobalClient
+	GlobalClient = client
+	return func() {
+		globalClient.Lock()
+		defer globalClient.Unlock()
+		GlobalClient = oldClient
+	}
+}
+
+// Check is a testing utility to assert that a target key value pair
+// exists in an array of Configuration
+func Check(t *testing.T, configuration []Configuration, key string, expected interface{}) {
+	for _, kv := range configuration {
+		if kv.Name == key {
+			if kv.Value != expected {
+				t.Errorf("configuration %s: wanted %v, got %v", key, expected, kv.Value)
+			}
+			return
+		}
+	}
+	t.Errorf("missing configuration %s", key)
+}
+
+// SetAgentlessEndpoint is used for testing purposes to replace the real agentless
+// endpoint with a custom one
+func SetAgentlessEndpoint(endpoint string) string {
+	agentlessEndpointLock.Lock()
+	defer agentlessEndpointLock.Unlock()
+	prev := agentlessURL
+	agentlessURL = endpoint
+	return prev
+}

--- a/profiler/telemetry.go
+++ b/profiler/telemetry.go
@@ -14,7 +14,6 @@ import (
 func startTelemetry(c *config) {
 	if telemetry.Disabled() {
 		// Do not do extra work populating config data if instrumentation telemetry is disabled.
-		return
 	}
 	profileEnabled := func(t ProfileType) bool {
 		_, ok := c.types[t]

--- a/profiler/telemetry_test.go
+++ b/profiler/telemetry_test.go
@@ -6,89 +6,30 @@
 package profiler
 
 import (
-	"encoding/json"
-	"net/http"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/httpmem"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/telemetrytest"
 )
 
-// Test that telemetry is enabled by default for the profiler. Turning on the profiler should send two telemetry events:
-// `app-product-change` to inform that the profiler has been enabled
-// `app-client-configuration-change` to send profiler-related configuration information
+// Test that the profiler sends the correct telemetry information
 func TestTelemetryEnabled(t *testing.T) {
-	t.Setenv("DD_TELEMETRY_HEARTBEAT_INTERVAL", "1")
-	receivedProducts := make(chan *telemetry.Products, 1)
-	configChanges := make(chan *telemetry.ConfigurationChange, 1)
-	server, client := httpmem.ServerAndClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/telemetry/proxy/api/v2/apmtelemetry" {
-			return
-		}
-		if r.Header.Get("DD-Telemetry-Request-Type") == string(telemetry.RequestTypeAppProductChange) {
-			var body telemetry.Body
-			body.Payload = new(telemetry.Products)
-			err := json.NewDecoder(r.Body).Decode(&body)
-			if err != nil {
-				t.Errorf("bad body: %s", err)
-			}
-			select {
-			case receivedProducts <- body.Payload.(*telemetry.Products):
-			default:
-			}
-		}
-		if r.Header.Get("DD-Telemetry-Request-Type") == string(telemetry.RequestTypeAppClientConfigurationChange) {
-			var body telemetry.Body
-			body.Payload = new(telemetry.ConfigurationChange)
-			err := json.NewDecoder(r.Body).Decode(&body)
-			if err != nil {
-				t.Errorf("bad body: %s", err)
-			}
-			select {
-			case configChanges <- body.Payload.(*telemetry.ConfigurationChange):
-			default:
-			}
-		}
-	}))
-	defer server.Close()
-	tracer.Start(tracer.WithHTTPClient(client))
+	telemetryClient := new(telemetrytest.MockClient)
+	defer telemetry.MockGlobalClient(telemetryClient)()
+
+	tracer.Start()
 	defer tracer.Stop()
+
 	Start(
-		WithHTTPClient(client),
 		WithProfileTypes(
-			BlockProfile,
 			HeapProfile,
-			MutexProfile,
 		),
-		WithPeriod(10*time.Millisecond),
-		CPUDuration(1*time.Millisecond),
 	)
 	defer Stop()
 
-	var productsPayload *telemetry.Products = <-receivedProducts
-	assert.Equal(t, productsPayload.Profiler.Enabled, true)
-
-	var configPayload *telemetry.ConfigurationChange = <-configChanges
-	check := func(key string, expected interface{}) {
-		for _, kv := range configPayload.Configuration {
-			if kv.Name == key {
-				if kv.Value != expected {
-					t.Errorf("configuration %s: wanted %v, got %T", key, expected, kv.Value)
-				}
-				return
-			}
-		}
-		t.Errorf("missing configuration %s", key)
-	}
-
-	check("heap_profile_enabled", true)
-	check("block_profile_enabled", true)
-	check("goroutine_profile_enabled", false)
-	check("mutex_profile_enabled", true)
-	check("profile_period", time.Duration(10*time.Millisecond).String())
-	check("cpu_duration", time.Duration(1*time.Millisecond).String())
+	assert.True(t, telemetryClient.ProfilerEnabled)
+	telemetry.Check(t, telemetryClient.Configuration, "heap_profile_enabled", true)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
This PR refactors unit testing related to instrumentation telemetry.

- remove black box testing `internal/telemetry` for more granular testing
- add a `utils.go` for testing helper functions
- add a `internal/telemetry/telemetrytest` package that implements a mock telemetry client
- creates the `TelemetryClient` interface

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Previous unit tests in the tracer and profiler used a mock server to receive telemetry requests. However, this testing style relies on connecting all the telemetry functionality (heartbeat, flushing, sending requests) to send requests. The only obligation of `TestTelemetryEnabled` in the tracer and profiler package should be to verify that the tracer/profiler has sent data to the telemetry client. To reflect this, we implement a mock client that can be used in tracer and profiler unit tests.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.