### PR TITLE
internal/appsec/dyngo: atomic instrumentation swapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -215,6 +215,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.40.0
 	go.opentelemetry.io/otel v1.14.0
 	go.opentelemetry.io/otel/trace v1.14.0
+	go.uber.org/atomic v1.10.0
 )
 
 require (
@@ -225,7 +226,6 @@ require (
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/outcaste-io/ristretto v0.2.1 // indirect
 	go.opentelemetry.io/otel/metric v0.37.0 // indirect
-	go.uber.org/atomic v1.10.0 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect

--- a/internal/appsec/appsec.go
+++ b/internal/appsec/appsec.go
@@ -87,7 +87,6 @@ func setActiveAppSec(a *appsec) {
 	mu.Lock()
 	defer mu.Unlock()
 	if activeAppSec != nil {
-		activeAppSec.stopRC()
 		activeAppSec.stop()
 	}
 	activeAppSec = a
@@ -131,10 +130,12 @@ func (a *appsec) start() error {
 
 // Stop AppSec by unregistering the security protections.
 func (a *appsec) stop() {
-	if a.started {
-		a.started = false
-		dyngo.SwapRootOperation(nil)
-		a.limiter.Stop()
-		a.disableRCBlocking()
+	if !a.started {
+		return
 	}
+	a.started = false
+	a.stopRC()
+	dyngo.SwapRootOperation(nil)
+	a.limiter.Stop()
+	a.disableRCBlocking()
 }

--- a/internal/appsec/appsec.go
+++ b/internal/appsec/appsec.go
@@ -87,6 +87,7 @@ func setActiveAppSec(a *appsec) {
 	mu.Lock()
 	defer mu.Unlock()
 	if activeAppSec != nil {
+		activeAppSec.stopRC()
 		activeAppSec.stop()
 	}
 	activeAppSec = a
@@ -134,10 +135,7 @@ func (a *appsec) stop() {
 		return
 	}
 	a.started = false
-
-	// Stop RC first so that the following is guaranteed not to be concurrent
-	// anymore.
-	a.stopRC()
+	// Disable RC blocking first so that the following is guaranteed not to be concurrent anymore.
 	a.disableRCBlocking()
 
 	// Disable the currently applied instrumentation

--- a/internal/appsec/config.go
+++ b/internal/appsec/config.go
@@ -85,8 +85,13 @@ func newConfig() (*Config, error) {
 		return nil, err
 	}
 
+	r, err := newRulesManager(rules)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Config{
-		rulesManager:   newRulesManager(rules),
+		rulesManager:   r,
 		wafTimeout:     readWAFTimeoutConfig(),
 		traceRateLimit: readRateLimitConfig(),
 		obfuscator:     readObfuscatorConfig(),

--- a/internal/appsec/config_test.go
+++ b/internal/appsec/config_test.go
@@ -17,8 +17,10 @@ import (
 )
 
 func TestConfig(t *testing.T) {
+	r, err := newRulesManager(nil)
+	require.NoError(t, err)
 	expectedDefaultConfig := &Config{
-		rulesManager:   newRulesManager(nil),
+		rulesManager:   r,
 		wafTimeout:     defaultWAFTimeout,
 		traceRateLimit: defaultTraceRate,
 		obfuscator: ObfuscatorConfig{
@@ -124,7 +126,8 @@ func TestConfig(t *testing.T) {
 				os.Remove(file.Name())
 			}()
 			expCfg := *expectedDefaultConfig
-			expCfg.rulesManager = newRulesManager([]byte(staticRecommendedRules))
+			expCfg.rulesManager, err = newRulesManager([]byte(staticRecommendedRules))
+			require.NoError(t, err)
 			_, err = file.WriteString(staticRecommendedRules)
 			require.NoError(t, err)
 			os.Setenv(rulesEnvVar, file.Name())

--- a/internal/appsec/dyngo/operation_test.go
+++ b/internal/appsec/dyngo/operation_test.go
@@ -552,106 +552,38 @@ func TestUsage(t *testing.T) {
 		// The number of calls should be equal to the expected number of events
 		require.Equal(t, uint32(nbGoroutines*2*nbGoroutines), atomic.LoadUint32(&calls))
 	})
-
-	t.Run("concurrency", func(t *testing.T) {
-		// Create nbGoroutines registering event listeners concurrently
-		nbGoroutines := 1000
-		// The concurrency is maximized by using start barriers to sync the goroutine launches
-		var done, startBarrier sync.WaitGroup
-
-		done.Add(nbGoroutines)
-		startBarrier.Add(nbGoroutines + 1)
-
-		var calls uint32
-		for g := 0; g < nbGoroutines; g++ {
-			// Start a goroutine that registers its event listeners to root, emits those events with a new operation, and
-			// finally unregisters them. This allows to test the thread-safety of the underlying list of listeners.
-			// To make the number of calls predictable, the event listener increases the number of calls only when it
-			// comes from the goroutine emitting the event.
-			go func(g int) {
-				startBarrier.Done()
-				startBarrier.Wait()
-				defer done.Done()
-
-				unregister := dyngo.Register(OnMyOperationStart(func(_ dyngo.Operation, a MyOperationArgs) {
-					if a.n == g {
-						atomic.AddUint32(&calls, 1)
-					}
-				}))
-				defer unregister()
-				unregister = dyngo.Register(OnMyOperationFinish(func(_ dyngo.Operation, r MyOperationRes) {
-					if r.n == g {
-						atomic.AddUint32(&calls, 1)
-					}
-				}))
-				defer unregister()
-
-				// Emit events by passing the goroutine number g
-				op := startOperation(MyOperationArgs{g}, nil)
-				defer op.Finish(MyOperationRes{g})
-			}(g)
-		}
-
-		// Wait for all the goroutines to be started
-		startBarrier.Done()
-		startBarrier.Wait()
-		// Wait for the goroutines to be done
-		done.Wait()
-
-		// The number of calls should be equal to the expected number of events
-		require.Equal(t, uint32(nbGoroutines*2), calls)
-	})
 }
 
-func TestRegisterUnregister(t *testing.T) {
-	t.Run("single-listener", func(t *testing.T) {
-		var called int
-		unregister := dyngo.Register(OnMyOperationStart(func(dyngo.Operation, MyOperationArgs) {
-			called++
-		}))
+func TestSwapRootOperation(t *testing.T) {
+	var onStartCalled, onFinishCalled int
 
-		op := startOperation(MyOperationArgs{}, nil)
-		require.Equal(t, 1, called)
-		dyngo.FinishOperation(op, MyOperationRes{})
+	root := dyngo.NewRootOperation()
+	root.On(OnMyOperationStart(func(dyngo.Operation, MyOperationArgs) {
+		onStartCalled++
+	}))
+	root.On(OnMyOperationFinish(func(dyngo.Operation, MyOperationRes) {
+		onFinishCalled++
+	}))
 
-		unregister()
-		op = startOperation(MyOperationArgs{}, nil)
-		require.Equal(t, 1, called)
-		dyngo.FinishOperation(op, MyOperationRes{})
+	dyngo.SwapRootOperation(root)
+	runOperation(nil, MyOperationArgs{}, MyOperationRes{}, func(op dyngo.Operation) {})
+	require.Equal(t, 1, onStartCalled)
+	require.Equal(t, 1, onFinishCalled)
 
-		require.NotPanics(t, func() {
-			unregister()
-		})
-		op = startOperation(MyOperationArgs{}, nil)
-		require.Equal(t, 1, called)
-		dyngo.FinishOperation(op, MyOperationRes{})
-	})
+	dyngo.SwapRootOperation(dyngo.NewRootOperation())
+	runOperation(nil, MyOperationArgs{}, MyOperationRes{}, func(op dyngo.Operation) {})
+	require.Equal(t, 1, onStartCalled)
+	require.Equal(t, 1, onFinishCalled)
 
-	t.Run("multiple-listeners", func(t *testing.T) {
-		var onStartCalled, onFinishCalled int
+	dyngo.SwapRootOperation(nil)
+	runOperation(nil, MyOperationArgs{}, MyOperationRes{}, func(op dyngo.Operation) {})
+	require.Equal(t, 1, onStartCalled)
+	require.Equal(t, 1, onFinishCalled)
 
-		unregister := dyngo.Register(
-			OnMyOperationStart(func(dyngo.Operation, MyOperationArgs) {
-				onStartCalled++
-			}),
-			OnMyOperationFinish(func(dyngo.Operation, MyOperationRes) {
-				onFinishCalled++
-			}),
-		)
-
-		runOperation(nil, MyOperationArgs{}, MyOperationRes{}, func(op dyngo.Operation) {})
-		require.Equal(t, 1, onStartCalled)
-		require.Equal(t, 1, onFinishCalled)
-
-		unregister()
-		runOperation(nil, MyOperationArgs{}, MyOperationRes{}, func(op dyngo.Operation) {})
-		require.Equal(t, 1, onStartCalled)
-		require.Equal(t, 1, onFinishCalled)
-
-		require.NotPanics(t, func() {
-			unregister()
-		})
-	})
+	dyngo.SwapRootOperation(root)
+	runOperation(nil, MyOperationArgs{}, MyOperationRes{}, func(op dyngo.Operation) {})
+	require.Equal(t, 2, onStartCalled)
+	require.Equal(t, 2, onFinishCalled)
 }
 
 // Helper type wrapping a dyngo.Operation to provide some helper function and

--- a/internal/appsec/limiter_test.go
+++ b/internal/appsec/limiter_test.go
@@ -19,6 +19,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAllowAfterStop(t *testing.T) {
+	l := NewTokenTicker(0, 100)
+	l.Start()
+	l.Stop()
+	require.False(t, l.Allow())
+	require.False(t, l.Allow())
+	require.False(t, l.Allow())
+	require.False(t, l.Allow())
+	require.False(t, l.Allow())
+	require.False(t, l.Allow())
+}
+
 func TestLimiterUnit(t *testing.T) {
 	startTime := time.Now()
 

--- a/internal/appsec/limiter_test.go
+++ b/internal/appsec/limiter_test.go
@@ -19,18 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAllowAfterStop(t *testing.T) {
-	l := NewTokenTicker(0, 100)
-	l.Start()
-	l.Stop()
-	require.False(t, l.Allow())
-	require.False(t, l.Allow())
-	require.False(t, l.Allow())
-	require.False(t, l.Allow())
-	require.False(t, l.Allow())
-	require.False(t, l.Allow())
-}
-
 func TestLimiterUnit(t *testing.T) {
 	startTime := time.Now()
 

--- a/internal/appsec/remoteconfig.go
+++ b/internal/appsec/remoteconfig.go
@@ -146,6 +146,7 @@ func (a *appsec) onRCRulesUpdate(updates map[string]remoteconfig.ProductUpdate) 
 		return map[string]rc.ApplyStatus{}
 	}
 
+	// Create a new local rulesManager
 	r := a.cfg.rulesManager.clone()
 	statuses, err := combineRCRulesUpdates(r, updates)
 	if err != nil {
@@ -156,6 +157,7 @@ func (a *appsec) onRCRulesUpdate(updates map[string]remoteconfig.ProductUpdate) 
 	// Compile the final rules once all updates have been processed and no error occurred
 	r.compile()
 	log.Debug("appsec: Remote config: final compiled rules: %s", r)
+
 	// If an error occurs while updating the WAF handle, don't swap the rulesManager and propagate the error
 	// to all config statuses since we can't know which config is the faulty one
 	if err = a.swapWAF(r.latest); err != nil {
@@ -164,6 +166,7 @@ func (a *appsec) onRCRulesUpdate(updates map[string]remoteconfig.ProductUpdate) 
 			statuses[k] = genApplyStatus(true, err)
 		}
 	} else {
+		// Replace the rulesManager with the new one holding the new state
 		a.cfg.rulesManager = r
 	}
 	return statuses

--- a/internal/appsec/remoteconfig.go
+++ b/internal/appsec/remoteconfig.go
@@ -155,11 +155,10 @@ func (a *appsec) onRCRulesUpdate(updates map[string]remoteconfig.ProductUpdate) 
 
 	// Compile the final rules once all updates have been processed and no error occurred
 	r.compile()
-	data := r.raw()
-	log.Debug("appsec: Remote config: final compiled rules: %s", data)
+	log.Debug("appsec: Remote config: final compiled rules: %s", r)
 	// If an error occurs while updating the WAF handle, don't swap the rulesManager and propagate the error
 	// to all config statuses since we can't know which config is the faulty one
-	if err = a.swapWAF(data); err != nil {
+	if err = a.swapWAF(r.latest); err != nil {
 		log.Error("appsec: Remote config: could not apply the new security rules: %v", err)
 		for k := range statuses {
 			statuses[k] = genApplyStatus(true, err)

--- a/internal/appsec/remoteconfig.go
+++ b/internal/appsec/remoteconfig.go
@@ -290,8 +290,6 @@ func mergeRulesDataEntries(entries1, entries2 []rc.ASMDataRuleDataEntry) []rc.AS
 
 func (a *appsec) startRC() {
 	if a.rc != nil {
-		a.rc.RegisterCallback(a.onRemoteActivation)
-		a.rc.RegisterCallback(a.onRCRulesUpdate)
 		a.rc.Start()
 	}
 }
@@ -351,6 +349,7 @@ func (a *appsec) enableRemoteActivation() error {
 	}
 	a.registerRCProduct(rc.ProductASMFeatures)
 	a.registerRCCapability(remoteconfig.ASMActivation)
+	a.rc.RegisterCallback(a.onRemoteActivation)
 	return nil
 }
 
@@ -363,6 +362,7 @@ func (a *appsec) enableRCBlocking() {
 	a.registerRCProduct(rc.ProductASM)
 	a.registerRCProduct(rc.ProductASMDD)
 	a.registerRCProduct(rc.ProductASMData)
+	a.rc.RegisterCallback(a.onRCRulesUpdate)
 
 	if _, isSet := os.LookupEnv(rulesEnvVar); !isSet {
 		a.registerRCCapability(remoteconfig.ASMUserBlocking)
@@ -382,4 +382,5 @@ func (a *appsec) disableRCBlocking() {
 	a.unregisterRCCapability(remoteconfig.ASMIPBlocking)
 	a.unregisterRCCapability(remoteconfig.ASMRequestBlocking)
 	a.unregisterRCCapability(remoteconfig.ASMUserBlocking)
+	a.rc.UnregisterCallback(a.onRCRulesUpdate)
 }

--- a/internal/appsec/remoteconfig_test.go
+++ b/internal/appsec/remoteconfig_test.go
@@ -435,7 +435,8 @@ func craftRCUpdates(fragments map[string]rulesFragment) map[string]remoteconfig.
 }
 
 func TestOnRCUpdate(t *testing.T) {
-	baseRuleset := newRulesManager(nil)
+	baseRuleset, err := newRulesManager(nil)
+	require.NoError(t, err)
 	baseRuleset.compile()
 
 	rules := rulesFragment{
@@ -574,7 +575,8 @@ func TestOnRCUpdate(t *testing.T) {
 }
 
 func TestOnRCUpdateStatuses(t *testing.T) {
-	invalidRuleset := newRulesManager([]byte(`{"version": "2.2", "metadata": {"rules_version": "1.4.2"}, "rules": [{"id": "id","name":"name","tags":{},"conditions":[],"transformers":[],"on_match":[]}]}`))
+	invalidRuleset, err := newRulesManager([]byte(`{"version": "2.2", "metadata": {"rules_version": "1.4.2"}, "rules": [{"id": "id","name":"name","tags":{},"conditions":[],"transformers":[],"on_match":[]}]}`))
+	require.NoError(t, err)
 	invalidRules := invalidRuleset.base
 	overrides := rulesFragment{
 		Overrides: []rulesOverrideEntry{

--- a/internal/appsec/ruleset_builder.go
+++ b/internal/appsec/ruleset_builder.go
@@ -176,7 +176,7 @@ func (r *rulesManager) raw() []byte {
 	return data
 }
 
-// String returns the string representation of the json rules.
+// String returns the string representation of the latest compiled json rules.
 func (r *rulesManager) String() string {
 	return fmt.Sprintf("%+v", r.latest)
 }

--- a/internal/appsec/ruleset_builder.go
+++ b/internal/appsec/ruleset_builder.go
@@ -170,3 +170,9 @@ func (r *rulesManager) raw() []byte {
 	data, _ := json.Marshal(r.latest)
 	return data
 }
+
+// String returns the string representation of the json rules.
+func (r *rulesManager) String() string {
+	data, _ := json.Marshal(r.latest)
+	return string(data)
+}

--- a/internal/appsec/ruleset_builder.go
+++ b/internal/appsec/ruleset_builder.go
@@ -112,18 +112,22 @@ func (r_ *rulesFragment) clone() rulesFragment {
 }
 
 // newRulesManager initializes and returns a new rulesManager using the provided rules.
-// If no rules are provided (nil), or the provided rules are invalid, the default rules are used instead
-func newRulesManager(rules []byte) *rulesManager {
+// If no rules are provided (nil), the default rules are used instead.
+// If the provided rules are invalid, an error is returned
+func newRulesManager(rules []byte) (*rulesManager, error) {
 	var f rulesFragment
-	if err := json.Unmarshal(rules, &f); err != nil {
+	if rules == nil {
 		f = defaultRulesFragment()
-		log.Debug("appsec: cannot create rulesManager from specified rules. Using default rules instead")
+		log.Debug("appsec: rulesManager: using default rules configuration")
+	} else if err := json.Unmarshal(rules, &f); err != nil {
+		log.Debug("appsec: cannot create rulesManager from specified rules")
+		return nil, err
 	}
 	return &rulesManager{
 		latest: f,
 		base:   f,
 		edits:  map[string]rulesFragment{},
-	}
+	}, nil
 }
 
 func (r *rulesManager) clone() *rulesManager {

--- a/internal/appsec/ruleset_builder.go
+++ b/internal/appsec/ruleset_builder.go
@@ -7,6 +7,7 @@ package appsec
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 
@@ -173,6 +174,5 @@ func (r *rulesManager) raw() []byte {
 
 // String returns the string representation of the json rules.
 func (r *rulesManager) String() string {
-	data, _ := json.Marshal(r.latest)
-	return string(data)
+	return fmt.Sprintf("%+v", r.latest)
 }

--- a/internal/appsec/waf.go
+++ b/internal/appsec/waf.go
@@ -67,7 +67,9 @@ func (a *appsec) swapWAF(rules []byte) error {
 	oldHandle := a.wafHandle
 	a.wafHandle = newHandle
 	dyngo.SwapRootOperation(root)
-	oldHandle.Close()
+	if oldHandle != nil {
+		oldHandle.Close()
+	}
 
 	return nil
 }

--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"math/big"
 	"net/http"
+	"reflect"
 	"strings"
 	"time"
 
@@ -173,6 +174,17 @@ func (c *Client) updateState() {
 // depending on the product related to the configuration update.
 func (c *Client) RegisterCallback(f Callback) {
 	c.callbacks = append(c.callbacks, f)
+}
+
+// UnregisterCallback removes a previously registered callback from the active callbacks list
+// This remove operation preserves ordering
+func (c *Client) UnregisterCallback(f Callback) {
+	fValue := reflect.ValueOf(f)
+	for i, callback := range c.callbacks {
+		if reflect.ValueOf(callback) == fValue {
+			c.callbacks = append(c.callbacks[:i], c.callbacks[i+1:]...)
+		}
+	}
 }
 
 // RegisterProduct adds a product to the list of products listened by the client


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Atomic swapping of AppSec's instrumentations (currently HTTP WAF and gRPC WAF) by reviewing the way dyngo event listeners should be managed. Instead of allowing registering and unregistering event listeners, we rather simplified it so that we can simply atomically swap the root operation instead. This allows a cleaner approach where a root operation can be created async, along with the new set of event listeners, and later on live-swapped, with no more need to deal with concurrent event listeners swapping. The current implementation simply is an atomic pointer swapping.

Overall, this allows a cleaner "pure programming" approach, where an operation is no longer modified once running (assuming all its event listeners are registered on the start events, which is not enforced today), which gives new guarantees on the state of our instrumentation now where new security rules can no longer be partially applied. This PR rather ensures that N security rules updates can safely concurrently live all together.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

By making the appsec instrumentation modification atomic, we avoid:
- Partial instrumentation states while new rules get applied
- Partial security rules updates while new rules get applied

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.