### PR TITLE
internal/telemetry: track tracer init time metric

### DIFF
--- a/ddtrace/tracer/telemetry_test.go
+++ b/ddtrace/tracer/telemetry_test.go
@@ -31,4 +31,12 @@ func TestTelemetryEnabled(t *testing.T) {
 	telemetry.Check(t, telemetryClient.Configuration, "service", "test-serv")
 	telemetry.Check(t, telemetryClient.Configuration, "env", "test-env")
 	telemetry.Check(t, telemetryClient.Configuration, "runtime_metrics_enabled", true)
+	if metrics, ok := telemetryClient.Metrics[telemetry.NamespaceTracers]; ok {
+		if initTime, ok := metrics["tracer_init_time"]; ok {
+			assert.True(t, initTime > 0)
+			return
+		}
+		t.Fatalf("could not find tracer init time in telemetry client metrics")
+	}
+	t.Fatalf("could not find tracer namespace in telemetry client metrics")
 }

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -22,6 +22,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/hostname"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/remoteconfig"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/traceprof"
 
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
@@ -123,6 +124,7 @@ func Start(opts ...StartOption) {
 	if internal.Testing {
 		return // mock tracer active
 	}
+	defer telemetry.TimeGauge(telemetry.NamespaceTracers, "tracer_init_time", nil, true)()
 	t := newTracer(opts...)
 	if !t.config.enabled {
 		// TODO: instrumentation telemetry client won't get started

--- a/internal/telemetry/telemetrytest/telemetrytest.go
+++ b/internal/telemetry/telemetrytest/telemetrytest.go
@@ -19,6 +19,7 @@ type MockClient struct {
 	Configuration   []telemetry.Configuration
 	ProfilerEnabled bool
 	AsmEnabled      bool
+	Metrics         map[telemetry.Namespace]map[string]float64
 }
 
 // Start starts and adds configuration data to the mock client.
@@ -27,6 +28,7 @@ func (c *MockClient) Start(configuration []telemetry.Configuration) {
 	defer c.mu.Unlock()
 	c.Started = true
 	c.Configuration = append(c.Configuration, configuration...)
+	c.Metrics = make(map[telemetry.Namespace]map[string]float64)
 }
 
 // ProductChange signals that a certain product is enabled or disabled for the mock client.
@@ -44,8 +46,12 @@ func (c *MockClient) ProductChange(namespace telemetry.Namespace, enabled bool, 
 	c.Configuration = append(c.Configuration, configuration...)
 }
 
-// Gauge is NOOP for the mock client.
+// stores the value for the given namespace and metric name
 func (c *MockClient) Gauge(namespace telemetry.Namespace, name string, value float64, tags []string, common bool) {
+	if _, ok := c.Metrics[namespace]; !ok {
+		c.Metrics[namespace] = map[string]float64{}
+	}
+	c.Metrics[namespace][name] = value
 }
 
 // Count is NOOP for the mock client.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Implements `TimeGauge` telemetry function and uses it to track tracer init time. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.