### PR TITLE
contrib/google.golang.org/grpc: add tag for grpc target

### DIFF
--- a/contrib/google.golang.org/grpc/client.go
+++ b/contrib/google.golang.org/grpc/client.go
@@ -183,8 +183,8 @@ func doClientRequest(
 		span.SetTag(tagMethodKind, methodKind)
 	}
 	// check the old ctx, because it's smaller & less expensive to check
-	if v := ctx.Value("grpc.target"); v != nil {
-		span.SetTag("grpc.target", v)
+	if v := ctx.Value(tagTarget); v != nil {
+		span.SetTag(tagTarget, v)
 	}
 
 	// fill in the peer so we can add it to the tags

--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -66,6 +66,7 @@ func TestUnary(t *testing.T) {
 			defer mt.Stop()
 
 			span, ctx := tracer.StartSpanFromContext(context.Background(), "a", tracer.ServiceName("b"), tracer.ResourceName("c"))
+			ctx = context.WithValue(ctx, tagTarget, "dns:///127:0:0:1:8080")
 
 			resp, err := client.Ping(ctx, &FixtureRequest{Name: tt.message})
 			span.Finish()
@@ -102,6 +103,7 @@ func TestUnary(t *testing.T) {
 			assert.Equal(clientSpan.Tag(tagCode), tt.wantCode.String())
 			assert.Equal(clientSpan.TraceID(), rootSpan.TraceID())
 			assert.Equal(clientSpan.Tag(tagMethodKind), methodKindUnary)
+			assert.Equal(clientSpan.Tag(tagTarget), "dns:///127:0:0:1:8080")
 			assert.Equal(clientSpan.Tag(ext.Component), "google.golang.org/grpc")
 			assert.Equal(clientSpan.Tag(ext.SpanKind), ext.SpanKindClient)
 			assert.Equal(serverSpan.Tag(ext.ServiceName), "grpc")
@@ -162,6 +164,8 @@ func TestStreaming(t *testing.T) {
 					"expected target host tag to be set in span: %v", span)
 				assert.Equal(t, rig.port, span.Tag(ext.TargetPort),
 					"expected target host port to be set in span: %v", span)
+				assert.Equal(t, "dns:///127:0:0:1:8080", span.Tag(tagTarget),
+					"expected target to be set in span: %v", span)
 				fallthrough
 			case "grpc.server":
 				assert.Equal(t, methodKindBidiStream, span.Tag(tagMethodKind),
@@ -217,6 +221,7 @@ func TestStreaming(t *testing.T) {
 		span, ctx := tracer.StartSpanFromContext(context.Background(), "a",
 			tracer.ServiceName("b"),
 			tracer.ResourceName("c"))
+		ctx = context.WithValue(ctx, tagTarget, "dns:///127:0:0:1:8080")
 
 		runPings(t, ctx, rig.client)
 
@@ -244,6 +249,7 @@ func TestStreaming(t *testing.T) {
 		span, ctx := tracer.StartSpanFromContext(context.Background(), "a",
 			tracer.ServiceName("b"),
 			tracer.ResourceName("c"))
+		ctx = context.WithValue(ctx, tagTarget, "dns:///127:0:0:1:8080")
 
 		runPings(t, ctx, rig.client)
 
@@ -271,6 +277,7 @@ func TestStreaming(t *testing.T) {
 		span, ctx := tracer.StartSpanFromContext(context.Background(), "a",
 			tracer.ServiceName("b"),
 			tracer.ResourceName("c"))
+		ctx = context.WithValue(ctx, tagTarget, "dns:///127:0:0:1:8080")
 
 		runPings(t, ctx, rig.client)
 

--- a/contrib/google.golang.org/grpc/tags.go
+++ b/contrib/google.golang.org/grpc/tags.go
@@ -9,6 +9,7 @@ package grpc
 const (
 	tagMethodName     = "grpc.method.name"
 	tagMethodKind     = "grpc.method.kind"
+	tagTarget         = "grpc.target"
 	tagCode           = "grpc.code"
 	tagMetadataPrefix = "grpc.metadata."
 	tagRequest        = "grpc.request"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds a tag `grpc.target` to client unary and stream traces. This is one of two changes, the [other](https://github.com/DataDog/dd-source/pull/30427/files) in dd-source

### Motivation

Fabric is looking to gain more information on who is using fabric-dns versus other solutions. Having the full target, complete with the resolver, in traces will allow us to understand the fleet better and provide better support when folks ask us for help. 

### Describe how to test/QA your changes

Apart from the unit tests, I've also run a few integration tests via publishing this fork and directing the targets in `dd-source/domains/rpc/*` to the fork. 

You can see a resulting span [here](https://ddstaging.datadoghq.com/apm/trace/7551520533901175660?colorBy=service&env=staging&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=7551520533901175660&spanViewType=metadata&timeHint=1680804065813.24)

<img width="578" alt="Screenshot 2023-04-05 at 3 56 27 PM" src="https://user-images.githubusercontent.com/32601978/230671565-08c4ff58-e488-4f13-aa53-27ec432478f2.png">

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.