### PR TITLE
ci: remove the deprecated ubuntu-18.04 runners

### DIFF
--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -26,7 +26,7 @@ jobs:
   native:
     strategy:
       matrix:
-        runs-on: [ macos-12, macos-11, macos-10.15, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, windows-latest ]
+        runs-on: [ macos-12, macos-11, macos-10.15, ubuntu-22.04, ubuntu-20.04, windows-latest ]
         go-version: [ "1.20", "1.19", "1.18" ]
         cgo_enabled: # test it compiles with and without cgo
           - 0


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

ubuntu-18.04 runners have been deprecated and are no longer available.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.