### PR TITLE
ci: restore automatic benchmark runs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,5 +9,6 @@ variables:
   KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-go
   FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
 
-include: ".gitlab/benchmarks.yml"
-include: ".gitlab/test-apps.yml"
+include:
+  - ".gitlab/benchmarks.yml"
+  - ".gitlab/test-apps.yml"

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -1,6 +1,7 @@
 benchmark:
   stage: benchmarks
   image: $BASE_CI_IMAGE
+  when: on_success
   timeout: 1h
   only:
     refs:


### PR DESCRIPTION
### What does this PR do?

Fixes the bug in .gitlab-ci.yml due to duplicate `include` key (and yet - it is valid yaml!)

### Motivation

Benchmarks should be run automatically for each branch again.