### PR TITLE
internal/appsec: add server.request.method address

### DIFF
--- a/internal/appsec/dyngo/instrumentation/httpsec/http.go
+++ b/internal/appsec/dyngo/instrumentation/httpsec/http.go
@@ -33,6 +33,8 @@ import (
 type (
 	// HandlerOperationArgs is the HTTP handler operation arguments.
 	HandlerOperationArgs struct {
+		// Method is the http method verb of the request, address is `server.request.method`
+		Method string
 		// RequestURI corresponds to the address `server.request.uri.raw`
 		RequestURI string
 		// Headers corresponds to the address `server.request.headers.no_cookies`
@@ -143,6 +145,7 @@ func MakeHandlerOperationArgs(r *http.Request, clientIP netip.Addr, pathParams m
 	cookies := makeCookies(r) // TODO(Julio-Guerra): avoid actively parsing the cookies thanks to dynamic instrumentation
 	headers["host"] = []string{r.Host}
 	return HandlerOperationArgs{
+		Method:     r.Method,
 		RequestURI: r.RequestURI,
 		Headers:    headers,
 		Cookies:    cookies,

--- a/internal/appsec/testdata/custom_rules.json
+++ b/internal/appsec/testdata/custom_rules.json
@@ -1,0 +1,31 @@
+{
+    "version": "2.2",
+    "metadata": {
+        "rules_version": "1.4.2"
+    },
+    "rules": [
+        {
+            "id": "custom-001",
+            "name": "Custom Rule",
+            "tags": {
+                "type": "security_scanner",
+                "category": "attack_attempt",
+                "confidence": "1"
+            },
+            "conditions": [
+                {
+                    "parameters": {
+                        "inputs": [
+                            {
+                                "address": "server.request.method"
+                            }
+                        ],
+                        "regex": "^POST$"
+                    },
+                    "operator": "match_regex"
+                }
+            ],
+            "transformers": []
+        }
+    ]
+}

--- a/internal/appsec/waf.go
+++ b/internal/appsec/waf.go
@@ -127,7 +127,7 @@ func newHTTPWAFEventListener(handle *waf.Handle, addresses []string, timeout tim
 	actionHandler := httpsec.NewActionsHandler()
 
 	return httpsec.OnHandlerOperationStart(func(op *httpsec.Operation, args httpsec.HandlerOperationArgs) {
-		var body interface{}
+		var body any
 		wafCtx := waf.NewContext(handle)
 		if wafCtx == nil {
 			// The WAF event listener got concurrently released
@@ -163,6 +163,8 @@ func newHTTPWAFEventListener(handle *waf.Handle, addresses []string, timeout tim
 				if args.ClientIP.IsValid() {
 					values[httpClientIPAddr] = args.ClientIP.String()
 				}
+			case serverRequestMethodAddr:
+				values[serverRequestMethodAddr] = args.Method
 			case serverRequestRawURIAddr:
 				values[serverRequestRawURIAddr] = args.RequestURI
 			case serverRequestHeadersNoCookiesAddr:
@@ -400,6 +402,7 @@ func runWAF(wafCtx *waf.Context, values map[string]interface{}, timeout time.Dur
 
 // HTTP rule addresses currently supported by the WAF
 const (
+	serverRequestMethodAddr           = "server.request.method"
 	serverRequestRawURIAddr           = "server.request.uri.raw"
 	serverRequestHeadersNoCookiesAddr = "server.request.headers.no_cookies"
 	serverRequestCookiesAddr          = "server.request.cookies"
@@ -413,6 +416,7 @@ const (
 
 // List of HTTP rule addresses currently supported by the WAF
 var httpAddresses = []string{
+	serverRequestMethodAddr,
 	serverRequestRawURIAddr,
 	serverRequestHeadersNoCookiesAddr,
 	serverRequestCookiesAddr,


### PR DESCRIPTION
### What does this PR do?

This address is now sent to the WAF for further examination.

### Motivation

This address is not used by all the recommended ruleset, but with custom rules we will need to support it.

### Describe how to test/QA your changes

I added a test about a custom rule using this address.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.