### PR TITLE
contrib/elasticsearch: use naming schema

### DIFF
--- a/contrib/elastic/go-elasticsearch.v6/elastictrace.go
+++ b/contrib/elastic/go-elasticsearch.v6/elastictrace.go
@@ -71,7 +71,7 @@ func (t *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if !math.IsNaN(t.config.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, t.config.analyticsRate))
 	}
-	span, _ := tracer.StartSpanFromContext(req.Context(), "elasticsearch.query", opts...)
+	span, _ := tracer.StartSpanFromContext(req.Context(), t.config.operationName, opts...)
 	defer span.Finish()
 
 	contentEncoding := req.Header.Get("Content-Encoding")

--- a/contrib/elastic/go-elasticsearch.v6/option.go
+++ b/contrib/elastic/go-elasticsearch.v6/option.go
@@ -10,10 +10,14 @@ import (
 	"net/http"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/namingschema"
 )
+
+const defaultServiceName = "elastic.client"
 
 type clientConfig struct {
 	serviceName   string
+	operationName string
 	transport     http.RoundTripper
 	analyticsRate float64
 	resourceNamer func(url, method string) string
@@ -23,7 +27,12 @@ type clientConfig struct {
 type ClientOption func(*clientConfig)
 
 func defaults(cfg *clientConfig) {
-	cfg.serviceName = "elastic.client"
+	cfg.serviceName = namingschema.NewServiceNameSchema(
+		"",
+		defaultServiceName,
+		namingschema.WithVersionOverride(namingschema.SchemaV0, defaultServiceName),
+	).GetName()
+	cfg.operationName = namingschema.NewElasticsearchOutboundOp().GetName()
 	cfg.transport = http.DefaultTransport
 	cfg.resourceNamer = quantize
 	if internal.BoolEnv("DD_TRACE_ELASTIC_ANALYTICS_ENABLED", false) {

--- a/contrib/olivere/elastic/elastictrace.go
+++ b/contrib/olivere/elastic/elastictrace.go
@@ -69,7 +69,7 @@ func (t *httpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if !math.IsNaN(t.config.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, t.config.analyticsRate))
 	}
-	span, _ := tracer.StartSpanFromContext(req.Context(), "elasticsearch.query", opts...)
+	span, _ := tracer.StartSpanFromContext(req.Context(), t.config.operationName, opts...)
 	defer span.Finish()
 
 	contentEncoding := req.Header.Get("Content-Encoding")

--- a/contrib/olivere/elastic/option.go
+++ b/contrib/olivere/elastic/option.go
@@ -10,10 +10,14 @@ import (
 	"net/http"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/namingschema"
 )
+
+const defaultServiceName = "elastic.client"
 
 type clientConfig struct {
 	serviceName   string
+	operationName string
 	transport     *http.Transport
 	analyticsRate float64
 	resourceNamer func(url, method string) string
@@ -23,7 +27,12 @@ type clientConfig struct {
 type ClientOption func(*clientConfig)
 
 func defaults(cfg *clientConfig) {
-	cfg.serviceName = "elastic.client"
+	cfg.serviceName = namingschema.NewServiceNameSchema(
+		"",
+		defaultServiceName,
+		namingschema.WithVersionOverride(namingschema.SchemaV0, defaultServiceName),
+	).GetName()
+	cfg.operationName = namingschema.NewElasticsearchOutboundOp().GetName()
 	cfg.transport = http.DefaultTransport.(*http.Transport)
 	cfg.resourceNamer = quantize
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Implements naming schema versioning for all kafka integrations:
- `olivere/elastic`
- `elastic/go-elasticsearch.v6`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->
Improve service and span names.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.