### PR TITLE
contrib/database/sql: fix bug where options were always overwritten by register options

### DIFF
--- a/contrib/database/sql/option.go
+++ b/contrib/database/sql/option.go
@@ -36,7 +36,6 @@ type registerConfig = config
 type RegisterOption = Option
 
 func defaults(cfg *config, driverName string, rc *registerConfig) {
-	// default cfg.serviceName set in Register based on driver name
 	// cfg.analyticsRate = globalconfig.AnalyticsRate()
 	if internal.BoolEnv("DD_TRACE_SQL_ANALYTICS_ENABLED", false) {
 		cfg.analyticsRate = 1.0
@@ -50,19 +49,31 @@ func defaults(cfg *config, driverName string, rc *registerConfig) {
 	cfg.dbmPropagationMode = tracer.DBMPropagationMode(mode)
 	cfg.serviceName = getServiceName(driverName, rc)
 	cfg.spanName = getSpanName(driverName)
+	if rc != nil {
+		// use registered config as the default value for some options
+		if math.IsNaN(cfg.analyticsRate) {
+			cfg.analyticsRate = rc.analyticsRate
+		}
+		if cfg.dbmPropagationMode == tracer.DBMPropagationModeUndefined {
+			cfg.dbmPropagationMode = rc.dbmPropagationMode
+		}
+		cfg.errCheck = rc.errCheck
+		cfg.ignoreQueryTypes = rc.ignoreQueryTypes
+		cfg.childSpansOnly = rc.childSpansOnly
+	}
 }
 
 func getServiceName(driverName string, rc *registerConfig) string {
 	defaultServiceName := fmt.Sprintf("%s.db", driverName)
-	serviceNameV0 := defaultServiceName
 	if rc != nil {
-		// for v0, if service name was set during Register, we use that value as default
-		serviceNameV0 = rc.serviceName
+		// if service name was set during Register, we use that value as default instead of
+		// the one calculated above.
+		defaultServiceName = rc.serviceName
 	}
 	return namingschema.NewServiceNameSchema(
 		"",
 		defaultServiceName,
-		namingschema.WithVersionOverride(namingschema.SchemaV0, serviceNameV0),
+		namingschema.WithVersionOverride(namingschema.SchemaV0, defaultServiceName),
 	).GetName()
 }
 

--- a/contrib/database/sql/sql.go
+++ b/contrib/database/sql/sql.go
@@ -20,13 +20,11 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
-	"math"
 	"reflect"
 	"sync"
 	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql/internal"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 )
@@ -198,18 +196,6 @@ func OpenDB(c driver.Connector, opts ...Option) *sql.DB {
 	for _, fn := range opts {
 		fn(cfg)
 	}
-	// use registered config for unset options
-	if math.IsNaN(cfg.analyticsRate) {
-		cfg.analyticsRate = rc.analyticsRate
-	}
-	if cfg.errCheck == nil {
-		cfg.errCheck = rc.errCheck
-	}
-	if cfg.dbmPropagationMode == tracer.DBMPropagationModeUndefined {
-		cfg.dbmPropagationMode = rc.dbmPropagationMode
-	}
-	cfg.ignoreQueryTypes = rc.ignoreQueryTypes
-	cfg.childSpansOnly = rc.childSpansOnly
 	tc := &tracedConnector{
 		connector:  c,
 		driverName: driverName,

--- a/contrib/database/sql/sql_test.go
+++ b/contrib/database/sql/sql_test.go
@@ -10,7 +10,6 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
-	"log"
 	"math"
 	"os"
 	"strconv"
@@ -126,17 +125,13 @@ func TestPostgres(t *testing.T) {
 
 func TestOpenOptions(t *testing.T) {
 	driverName := "postgres"
-	Register(driverName, &pq.Driver{}, WithServiceName("postgres-test"), WithAnalyticsRate(0.2))
-	defer unregister(driverName)
+	dsn := "postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable"
 
 	t.Run("Open", func(t *testing.T) {
-		db, err := Open(driverName, "postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable",
-			WithServiceName("override-test"),
-			WithAnalytics(true),
-		)
-		if err != nil {
-			log.Fatal(err)
-		}
+		Register(driverName, &pq.Driver{}, WithServiceName("postgres-test"), WithAnalyticsRate(0.2))
+		defer unregister(driverName)
+		db, err := Open(driverName, dsn, WithServiceName("override-test"), WithAnalytics(true))
+		require.NoError(t, err)
 		defer db.Close()
 
 		testConfig := &sqltest.Config{
@@ -157,12 +152,11 @@ func TestOpenOptions(t *testing.T) {
 		}
 		sqltest.RunAll(t, testConfig)
 	})
-
 	t.Run("OpenDB", func(t *testing.T) {
-		c, err := pq.NewConnector("postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable")
-		if err != nil {
-			log.Fatal(err)
-		}
+		Register(driverName, &pq.Driver{}, WithServiceName("postgres-test"), WithAnalyticsRate(0.2))
+		defer unregister(driverName)
+		c, err := pq.NewConnector(dsn)
+		require.NoError(t, err)
 		db := OpenDB(c)
 		defer db.Close()
 
@@ -184,13 +178,11 @@ func TestOpenOptions(t *testing.T) {
 		}
 		sqltest.RunAll(t, testConfig)
 	})
-
 	t.Run("WithDSN", func(t *testing.T) {
-		dsn := "postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable"
+		Register(driverName, &pq.Driver{}, WithServiceName("postgres-test"), WithAnalyticsRate(0.2))
+		defer unregister(driverName)
 		c, err := pq.NewConnector(dsn)
-		if err != nil {
-			log.Fatal(err)
-		}
+		require.NoError(t, err)
 		db := OpenDB(c, WithDSN(dsn))
 		defer db.Close()
 
@@ -211,6 +203,67 @@ func TestOpenOptions(t *testing.T) {
 			},
 		}
 		sqltest.RunAll(t, testConfig)
+	})
+	t.Run("WithChildSpansOnly", func(t *testing.T) {
+		Register(driverName, &pq.Driver{})
+		defer unregister(driverName)
+		db, err := Open(driverName, dsn, WithChildSpansOnly())
+		require.NoError(t, err)
+
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		err = db.Ping()
+		require.NoError(t, err)
+
+		spans := mt.FinishedSpans()
+		// the number of spans should be 0 since we specified the WithChildSpansOnly option
+		assert.Len(t, spans, 0)
+	})
+	t.Run("WithIgnoreQueryTypes", func(t *testing.T) {
+		registerOpts := []RegisterOption{
+			WithIgnoreQueryTypes(QueryTypeConnect),
+		}
+		openDBOpts := []Option{
+			WithIgnoreQueryTypes(QueryTypeConnect, QueryTypePing),
+		}
+		Register(driverName, &pq.Driver{}, registerOpts...)
+		defer unregister(driverName)
+		db, err := Open(driverName, dsn, openDBOpts...)
+		require.NoError(t, err)
+
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		err = db.Ping()
+		require.NoError(t, err)
+
+		spans := mt.FinishedSpans()
+		// the number of spans should be 0 since we are ignoring Connect and Ping spans.
+		assert.Len(t, spans, 0)
+	})
+	t.Run("RegisterOptionsAsDefault", func(t *testing.T) {
+		registerOpts := []RegisterOption{
+			WithServiceName("register-override"),
+			WithIgnoreQueryTypes(QueryTypeConnect),
+		}
+		Register(driverName, &pq.Driver{}, registerOpts...)
+		defer unregister(driverName)
+		db, err := Open(driverName, dsn)
+		require.NoError(t, err)
+
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		err = db.Ping()
+		require.NoError(t, err)
+
+		spans := mt.FinishedSpans()
+		// the number of spans should be 1 since we are ignoring Connect spans from the Register options.
+		require.Len(t, spans, 1)
+
+		s0 := spans[0]
+		assert.Equal(t, "register-override", s0.Tag(ext.ServiceName))
 	})
 }
 
@@ -295,11 +348,14 @@ func TestRegister(_ *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	newGenSpansFunc := func(t *testing.T, driverName string) namingschematest.GenSpansFn {
+	newGenSpansFunc := func(t *testing.T, driverName string, registerOverride string) namingschematest.GenSpansFn {
 		return func(t *testing.T, serviceOverride string) []mocktracer.Span {
 			var registerOpts []RegisterOption
+			// serviceOverride has higher priority than the registerOverride parameter.
 			if serviceOverride != "" {
 				registerOpts = append(registerOpts, WithServiceName(serviceOverride))
+			} else if registerOverride != "" {
+				registerOpts = append(registerOpts, WithServiceName(registerOverride))
 			}
 			var openOpts []Option
 			if serviceOverride != "" {
@@ -339,7 +395,7 @@ func TestNamingSchema(t *testing.T) {
 		}
 	}
 	t.Run("SQLServer", func(t *testing.T) {
-		genSpans := newGenSpansFunc(t, "sqlserver")
+		genSpans := newGenSpansFunc(t, "sqlserver", "")
 		assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
 			require.Len(t, spans, 2)
 			assert.Equal(t, "sqlserver.query", spans[0].OperationName())
@@ -359,7 +415,7 @@ func TestNamingSchema(t *testing.T) {
 		t.Run("SpanName", namingschematest.NewOpNameTest(genSpans, assertOpV0, assertOpV1))
 	})
 	t.Run("Postgres", func(t *testing.T) {
-		genSpans := newGenSpansFunc(t, "postgres")
+		genSpans := newGenSpansFunc(t, "postgres", "")
 		assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
 			require.Len(t, spans, 2)
 			assert.Equal(t, "postgres.query", spans[0].OperationName())
@@ -378,8 +434,31 @@ func TestNamingSchema(t *testing.T) {
 		t.Run("ServiceName", namingschematest.NewServiceNameTest(genSpans, "postgres.db", wantServiceNameV0))
 		t.Run("SpanName", namingschematest.NewOpNameTest(genSpans, assertOpV0, assertOpV1))
 	})
+	t.Run("PostgresWithRegisterOverride", func(t *testing.T) {
+		genSpans := newGenSpansFunc(t, "postgres", "register-override")
+		assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+			require.Len(t, spans, 2)
+			assert.Equal(t, "postgres.query", spans[0].OperationName())
+			assert.Equal(t, "postgres.query", spans[1].OperationName())
+		}
+		assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+			require.Len(t, spans, 2)
+			assert.Equal(t, "postgresql.query", spans[0].OperationName())
+			assert.Equal(t, "postgresql.query", spans[1].OperationName())
+		}
+		wantServiceNameV0 := namingschematest.ServiceNameAssertions{
+			// when the WithServiceName option is set during Register and not providing a service name when opening
+			// the DB connection, that value is used as default instead of postgres.db.
+			WithDefaults: []string{"register-override", "register-override"},
+			// in v0, DD_SERVICE is ignored for this integration.
+			WithDDService:            []string{"register-override", "register-override"},
+			WithDDServiceAndOverride: []string{namingschematest.TestServiceOverride, namingschematest.TestServiceOverride},
+		}
+		t.Run("ServiceName", namingschematest.NewServiceNameTest(genSpans, "register-override", wantServiceNameV0))
+		t.Run("SpanName", namingschematest.NewOpNameTest(genSpans, assertOpV0, assertOpV1))
+	})
 	t.Run("MySQL", func(t *testing.T) {
-		genSpans := newGenSpansFunc(t, "mysql")
+		genSpans := newGenSpansFunc(t, "mysql", "")
 		assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
 			require.Len(t, spans, 2)
 			assert.Equal(t, "mysql.query", spans[0].OperationName())


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
- Fix a bug where some options passed to `Open` or `OpenDB` functions were always ignored and replaced by the value provided during the `Register` driver call (tested in the new `TestOpenOptions` test cases).
- Also includes a small behavior change from https://github.com/DataDog/dd-trace-go/pull/1895 naming schema changes: the logic of defaulting to the service name set in `Register` instead of the default `<driverName>.db` is also used in naming schema v1 (tested in the new `TestNamingSchema/PostgresWithRegisterOverride` test case).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->
Bug fixes.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.