### PR TITLE
internal/appsec: use interface{} for rulesOverrideEntry.Enabled

### DIFF
--- a/internal/appsec/remoteconfig_test.go
+++ b/internal/appsec/remoteconfig_test.go
@@ -679,7 +679,6 @@ func TestWafRCUpdate(t *testing.T) {
 		Overrides: []rulesOverrideEntry{
 			{
 				ID:      "crs-913-120",
-				Enabled: true,
 				OnMatch: []string{"block"},
 			},
 		},

--- a/internal/appsec/ruleset_builder.go
+++ b/internal/appsec/ruleset_builder.go
@@ -48,7 +48,7 @@ type (
 	rulesOverrideEntry struct {
 		ID          string        `json:"id,omitempty"`
 		RulesTarget []interface{} `json:"rules_target,omitempty"`
-		Enabled     bool          `json:"enabled,omitempty"`
+		Enabled     interface{}   `json:"enabled,omitempty"`
 		OnMatch     interface{}   `json:"on_match,omitempty"`
 	}
 


### PR DESCRIPTION
### What does this PR do?
This changes the field rulesOverrideEntry.Enabled from bool to interface{}.
This fixes the default case for which the entry should be missing, not the default bool value (false).

### Motivation

Bugfix during release
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.