### PR TITLE
remoteconfig: remove empty products and don't override appsec rules data

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -73,6 +73,13 @@ jobs:
           DD_SITE: "datadoghq.com"
         run: ./run.sh APM_TRACING_E2E_SINGLE_SPAN
 
+      - name: Run ASM IP blocking scenario
+        env:
+          DD_API_KEY: ${{ secrets.SYSTEM_TESTS_E2E_DD_API_KEY }}
+          DD_APPLICATION_KEY: ${{ secrets.SYSTEM_TESTS_E2E_DD_APP_KEY }}
+          DD_SITE: "datadoghq.com"
+        run: ./run.sh APPSEC_IP_BLOCKING
+
       - name: Run ASM blocking scenario
         env:
           DD_API_KEY: ${{ secrets.SYSTEM_TESTS_E2E_DD_API_KEY }}

--- a/internal/appsec/ruleset_builder.go
+++ b/internal/appsec/ruleset_builder.go
@@ -166,6 +166,7 @@ func (r *rulesManager) compile() {
 		r.latest.Overrides = append(r.latest.Overrides, v.Overrides...)
 		r.latest.Exclusions = append(r.latest.Exclusions, v.Exclusions...)
 		r.latest.Actions = append(r.latest.Actions, v.Actions...)
+		r.latest.RulesData = append(r.latest.RulesData, v.RulesData...)
 		// TODO (Francois): process more fields once we expose the adequate capabilities (custom actions, custom rules, etc...)
 	}
 }

--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -212,10 +212,12 @@ func (c *Client) UnregisterCapability(cap Capability) {
 func (c *Client) applyUpdate(pbUpdate *clientGetConfigsResponse) error {
 	fileMap := make(map[string][]byte, len(pbUpdate.TargetFiles))
 	productUpdates := make(map[string]ProductUpdate, len(c.Products))
+	for p := range c.Products {
+		productUpdates[p] = make(ProductUpdate)
+	}
 	for _, f := range pbUpdate.TargetFiles {
 		fileMap[f.Path] = f.Raw
 		for p := range c.Products {
-			productUpdates[p] = make(ProductUpdate)
 			// Check the config file path to make sure it belongs to the right product
 			if strings.Contains(f.Path, "/"+p+"/") {
 				productUpdates[p][f.Path] = f.Raw
@@ -350,7 +352,7 @@ func (c *Client) newUpdateRequest() (bytes.Buffer, error) {
 	for i := range c.Capabilities {
 		capa.SetBit(capa, int(i), 1)
 	}
-	products := make([]string, len(c.Products))
+	products := make([]string, 0, len(c.Products))
 	for p := range c.Products {
 		products = append(products, p)
 	}


### PR DESCRIPTION
### What does this PR do?

This change fixes 2 things:
- remove empty products from the remote config client products slice
- prevent rules data from being overwritten with an empty set when rulesManager compiles the rules

### Motivation

This is a bugfix.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.