### PR TITLE
ddtrace/tracer: reset decision maker during fallback behavior of w3c header extraction

### DIFF
--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -330,6 +330,14 @@ func (t *trace) unsetPropagatingTag(key string) {
 	delete(t.propagatingTags, key)
 }
 
+// hasPropagatingTag performs a thread-safe lookup for propagating tags.
+func (t *trace) hasPropagatingTag(key string) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	_, found := t.propagatingTags[key]
+	return found
+}
+
 func (t *trace) setSamplingPriorityLocked(p int, sampler samplernames.SamplerName) {
 	if t.locked {
 		return

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -942,14 +942,37 @@ func TestEnvVars(t *testing.T) {
 						traceparentHeader: "00-00000000000000001111111111111111-2222222222222222-03",
 						tracestateHeader:  "dd=s:0;o:rum;t.dm:-2;t.usr.id:baz64~~,othervendor=t61rcWkgMzE",
 					},
-					out: []uint64{2459565876494606882, 1},
-					tid: traceIDFrom64Bits(1229782938247303441),
-
+					out:    []uint64{2459565876494606882, 1},
+					tid:    traceIDFrom64Bits(1229782938247303441),
 					origin: "rum",
 					propagatingTags: map[string]string{
-						"_dd.p.dm":     "-2",
+						"_dd.p.dm":     "-0",
 						"_dd.p.usr.id": "baz64==",
 						"tracestate":   "dd=s:0;o:rum;t.dm:-2;t.usr.id:baz64~~,othervendor=t61rcWkgMzE"},
+				},
+				{
+					in: TextMapCarrier{
+						traceparentHeader: "00-00000000000000001111111111111111-2222222222222222-00",
+						tracestateHeader:  "dd=s:1;o:rum;t.usr.id:baz64~~,othervendor=t61rcWkgMzE",
+					},
+					out:    []uint64{2459565876494606882, 0},
+					tid:    traceIDFrom64Bits(1229782938247303441),
+					origin: "rum",
+					propagatingTags: map[string]string{
+						"_dd.p.usr.id": "baz64==",
+						"tracestate":   "dd=s:1;o:rum;t.usr.id:baz64~~,othervendor=t61rcWkgMzE"},
+				},
+				{
+					in: TextMapCarrier{
+						traceparentHeader: "00-00000000000000001111111111111111-2222222222222222-00",
+						tracestateHeader:  "dd=s:1;o:rum;t.dm:-2;t.usr.id:baz64~~,othervendor=t61rcWkgMzE",
+					},
+					out:    []uint64{2459565876494606882, 0},
+					tid:    traceIDFrom64Bits(1229782938247303441),
+					origin: "rum",
+					propagatingTags: map[string]string{
+						"_dd.p.usr.id": "baz64==",
+						"tracestate":   "dd=s:1;o:rum;t.dm:-2;t.usr.id:baz64~~,othervendor=t61rcWkgMzE"},
 				},
 				{
 					in: TextMapCarrier{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Fix sampling priority and decision maker values extracted from tracestate (align with the spec)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Bug fix

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

- Unit tests
- [This test](https://github.com/DataDog/system-tests/blob/21687fc490bf326863fee1b738af3671da72bc97/parametric/test_headers_tracestate_dd.py#L509) in system-test passes (will remove the skip once this PR is merged).

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.