### PR TITLE
contrib/gomodule/redigo: don't ignore the context given as first argument (#1935)

### DIFF
--- a/contrib/gomodule/redigo/redigo.go
+++ b/contrib/gomodule/redigo/redigo.go
@@ -172,10 +172,9 @@ func newChildSpan(ctx context.Context, p *params) ddtrace.Span {
 
 func withSpan(ctx context.Context, do func(commandName string, args ...interface{}) (interface{}, error), p *params, commandName string, args ...interface{}) (reply interface{}, err error) {
 	// When a context exists in the args, it takes precedence over the passed ctx.
-	var ok bool
 	if n := len(args); n > 0 {
-		ctx, ok = args[n-1].(context.Context)
-		if ok {
+		if argCtx, ok := args[n-1].(context.Context); ok {
+			ctx = argCtx
 			args = args[:n-1]
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

These changes stop to override the given context given as first argument to `DoContext()` when the last given argument is not a context.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.