### PR TITLE
ddtrace/tracer: ensure access to trace tags is concurrency-safe

### DIFF
--- a/ddtrace/tracer/propagating_tags.go
+++ b/ddtrace/tracer/propagating_tags.go
@@ -41,14 +41,28 @@ func (t *trace) unsetPropagatingTag(key string) {
 	delete(t.propagatingTags, key)
 }
 
-func (t *trace) allPropagatingTags() map[string]string {
+// func (t *trace) allPropagatingTags() map[string]string {
+// 	t.mu.RLock()
+// 	defer t.mu.RUnlock()
+// 	m := make(map[string]string)
+// 	for k, v := range t.propagatingTags {
+// 		m[k] = v
+// 	}
+// 	return m
+// }
+
+// iteratePropagatingTags allows safe iteration through the propagating tags of a trace.
+// the trace must not be modified during this call, as it is locked for reading.
+//
+// f should return whether or not the iteration should continue.
+func (t *trace) iteratePropagatingTags(f func(k, v string) bool) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	m := make(map[string]string)
 	for k, v := range t.propagatingTags {
-		m[k] = v
+		if !f(k, v) {
+			break
+		}
 	}
-	return m
 }
 
 func (t *trace) replacePropagatingTags(tags map[string]string) {

--- a/ddtrace/tracer/propagating_tags.go
+++ b/ddtrace/tracer/propagating_tags.go
@@ -41,16 +41,6 @@ func (t *trace) unsetPropagatingTag(key string) {
 	delete(t.propagatingTags, key)
 }
 
-// func (t *trace) allPropagatingTags() map[string]string {
-// 	t.mu.RLock()
-// 	defer t.mu.RUnlock()
-// 	m := make(map[string]string)
-// 	for k, v := range t.propagatingTags {
-// 		m[k] = v
-// 	}
-// 	return m
-// }
-
 // iteratePropagatingTags allows safe iteration through the propagating tags of a trace.
 // the trace must not be modified during this call, as it is locked for reading.
 //

--- a/ddtrace/tracer/propagating_tags.go
+++ b/ddtrace/tracer/propagating_tags.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package tracer
+
+func (t *trace) hasPropagatingTag(k string) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	_, ok := t.propagatingTags[k]
+	return ok
+}
+
+func (t *trace) propagatingTag(k string) string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.propagatingTags[k]
+}
+
+// setPropagatingTag sets the key/value pair as a trace propagating tag.
+func (t *trace) setPropagatingTag(key, value string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.setPropagatingTagLocked(key, value)
+}
+
+// setPropagatingTagLocked sets the key/value pair as a trace propagating tag.
+// Not safe for concurrent use, setPropagatingTag should be used instead in that case.
+func (t *trace) setPropagatingTagLocked(key, value string) {
+	if t.propagatingTags == nil {
+		t.propagatingTags = make(map[string]string, 1)
+	}
+	t.propagatingTags[key] = value
+}
+
+// unsetPropagatingTag deletes the key/value pair from the trace's propagated tags.
+func (t *trace) unsetPropagatingTag(key string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.propagatingTags, key)
+}
+
+func (t *trace) allPropagatingTags() map[string]string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	m := make(map[string]string)
+	for k, v := range t.propagatingTags {
+		m[k] = v
+	}
+	return m
+}
+
+func (t *trace) replacePropagatingTags(tags map[string]string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.propagatingTags = tags
+}
+
+func (t *trace) propagatingTagsLen() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return len(t.propagatingTags)
+}

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -221,7 +221,7 @@ func (s *span) SetUser(id string, opts ...UserMonitoringOption) {
 	} else {
 		// Unset the propagated user ID so that a propagated user ID coming from upstream won't be propagated anymore.
 		trace.unsetPropagatingTag(keyPropagatedUserID)
-		if _, ok := trace.propagatingTags[keyPropagatedUserID]; ok {
+		if trace.hasPropagatingTag(keyPropagatedUserID) {
 			s.context.updated = true
 		}
 		delete(root.Meta, keyPropagatedUserID)

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -321,14 +321,14 @@ func (t *trace) setSamplingPriorityLocked(p int, sampler samplernames.SamplerNam
 		t.priority = new(float64)
 	}
 	*t.priority = float64(p)
-	_, ok := t.propagatingTags[keyDecisionMaker] // Safe to access propagatingTags here since we hold t.mu
+	_, ok := t.propagatingTags[keyDecisionMaker]
 	if p > 0 && !ok && sampler != samplernames.Unknown {
 		// We have a positive priority and the sampling mechanism isn't set.
 		// Send nothing when sampler is `Unknown` for RFC compliance.
 		t.setPropagatingTagLocked(keyDecisionMaker, "-"+strconv.Itoa(int(sampler)))
 	}
 	if p <= 0 && ok {
-		delete(t.propagatingTags, keyDecisionMaker) // Safe to access propagatingTags here since we hold t.mu
+		delete(t.propagatingTags, keyDecisionMaker)
 	}
 }
 
@@ -390,7 +390,7 @@ func (t *trace) finishedOne(s *span) {
 		for k, v := range t.tags {
 			s.setMeta(k, v)
 		}
-		for k, v := range t.propagatingTags { // Safe to access propagatingTags here because we hold t.mu
+		for k, v := range t.propagatingTags {
 			s.setMeta(k, v)
 		}
 		for k, v := range ginternal.GetTracerGitMetadataTags() {

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -1972,7 +1972,7 @@ func TestPropagatingTagsConcurrency(t *testing.T) {
 	defer trc.Stop()
 
 	var wg sync.WaitGroup
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 1_000; i++ {
 		root := trc.StartSpan("test")
 		wg.Add(5)
 		for i := 0; i < 5; i++ {

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -1967,7 +1967,8 @@ func FuzzExtractTraceID128(f *testing.F) {
 }
 
 // Regression test for https://github.com/DataDog/dd-trace-go/issues/1944
-func TestPropagatingTagsConcurrency(t *testing.T) {
+func TestPropagatingTagsConcurrency(_ *testing.T) {
+	// This test ensures Injection can be done concurrently.
 	trc := newTracer()
 	defer trc.Stop()
 

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -1972,7 +1972,7 @@ func TestPropagatingTagsConcurrency(t *testing.T) {
 	defer trc.Stop()
 
 	var wg sync.WaitGroup
-	for i := 0; i < 10000; i++ {
+	for i := 0; i < 1000; i++ {
 		root := trc.StartSpan("test")
 		wg.Add(5)
 		for i := 0; i < 5; i++ {


### PR DESCRIPTION

### What does this PR do?

This commit adds a few methods to trace to allow safe access to the tags and propagatingTags members of trace to the marshaling code.

Fixes #1944 

### Motivation

Spancontext marshaling was accessing tracer internal structures without a lock, resulting in a data race and panic.
### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.