### PR TITLE
contrib/net/http: don't set empty string values as span tags

### DIFF
--- a/contrib/net/http/trace.go
+++ b/contrib/net/http/trace.go
@@ -52,12 +52,12 @@ func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, cfg *
 	if cfg == nil {
 		cfg = new(ServeConfig)
 	}
-	var opts []tracer.StartSpanOption
+	opts := cfg.SpanOpts
 	if cfg.Service != "" {
-		opts = append(cfg.SpanOpts, tracer.ServiceName(cfg.Service))
+		opts = append(opts, tracer.ServiceName(cfg.Service))
 	}
 	if cfg.Resource != "" {
-		opts = append(cfg.SpanOpts, tracer.ResourceName(cfg.Resource))
+		opts = append(opts, tracer.ResourceName(cfg.Resource))
 	}
 	if cfg.Route != "" {
 		opts = append(opts, tracer.Tag(ext.HTTPRoute, cfg.Route))

--- a/contrib/net/http/trace.go
+++ b/contrib/net/http/trace.go
@@ -52,8 +52,16 @@ func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, cfg *
 	if cfg == nil {
 		cfg = new(ServeConfig)
 	}
-	opts := append(cfg.SpanOpts, tracer.ServiceName(cfg.Service), tracer.ResourceName(cfg.Resource))
-	opts = append(opts, tracer.Tag(ext.HTTPRoute, cfg.Route))
+	var opts []tracer.StartSpanOption
+	if cfg.Service != "" {
+		opts = append(cfg.SpanOpts, tracer.ServiceName(cfg.Service))
+	}
+	if cfg.Resource != "" {
+		opts = append(cfg.SpanOpts, tracer.ResourceName(cfg.Resource))
+	}
+	if cfg.Route != "" {
+		opts = append(opts, tracer.Tag(ext.HTTPRoute, cfg.Route))
+	}
 	span, ctx := httptrace.StartRequestSpan(r, opts...)
 	rw, ddrw := wrapResponseWriter(w)
 	defer func() {

--- a/contrib/net/http/trace_test.go
+++ b/contrib/net/http/trace_test.go
@@ -310,7 +310,7 @@ func TestTraceAndServe(t *testing.T) {
 		assert.True(called)
 		assert.Len(spans, 1)
 		assert.Equal(ext.SpanTypeWeb, span.Tag(ext.SpanType))
-		assert.Nil(span.Tag(ext.ServiceName))
+		assert.Nil(span.Tag(ext.ServiceName)) // This is nil since mocktracer does not behave like the actual tracer, which will set a default.
 		assert.Equal("http.server.request", span.Tag(ext.ResourceName))
 		assert.Equal("GET", span.Tag(ext.HTTPMethod))
 		assert.Equal("/path?<redacted>", span.Tag(ext.HTTPURL))

--- a/contrib/net/http/trace_test.go
+++ b/contrib/net/http/trace_test.go
@@ -312,6 +312,7 @@ func TestTraceAndServe(t *testing.T) {
 		assert.Equal(ext.SpanTypeWeb, span.Tag(ext.SpanType))
 		assert.Nil(span.Tag(ext.ServiceName)) // This is nil since mocktracer does not behave like the actual tracer, which will set a default.
 		assert.Equal("http.server.request", span.Tag(ext.ResourceName))
+		assert.Nil(span.Tag(ext.HTTPRoute))
 		assert.Equal("GET", span.Tag(ext.HTTPMethod))
 		assert.Equal("/path?<redacted>", span.Tag(ext.HTTPURL))
 		assert.Equal("200", span.Tag(ext.HTTPCode))


### PR DESCRIPTION



<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Do not set span fields when they are not configured so the tracer can `put` the defaults in.

### Motivation

Currently the TraceAndServe function sets service, resource, etc. whether or not they are configured, meaning we can easily end up with spans with service "unnamed-go-service" and blank tags/resource. 

This is becoming relevant for the autoinstrumentation, where the service, etc is not readily available, and we want sane defaults.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.