### PR TITLE
ddtrace/tracer: capture more span creation time in execution trace tasks

### DIFF
--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -449,9 +449,6 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		noDebugStack: t.config.noDebugStack,
 	}
 	pprofContext, span.taskEnd = startExecutionTracerTask(pprofContext, span)
-	if t.config.profilerHotspots || t.config.profilerEndpoints {
-		t.applyPPROFLabels(pprofContext, span)
-	}
 	// Generate span ID after execution trace task creation (if it's
 	// enabled) so that the task includes possible contention during span ID
 	// generation.
@@ -524,6 +521,9 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 	if _, ok := span.context.samplingPriority(); !ok {
 		// if not already sampled or a brand new trace, sample it
 		t.sample(span)
+	}
+	if t.config.profilerHotspots || t.config.profilerEndpoints {
+		t.applyPPROFLabels(pprofContext, span)
 	}
 	if t.config.serviceMappings != nil {
 		if newSvc, ok := t.config.serviceMappings[span.Service]; ok {


### PR DESCRIPTION
### What does this PR do?

Moves execution trace task creation (if it's enabled) earlier in the span
creation function so that the task covers any delay during span creation, which
is also included in the span time.

### Motivation

In very busy programs, span creation can be a non-trivial source of
latency, e.g. from lock contention on the root trace object during
newSpanContext. Currently we create an execution tracer task at the very
end of span creation. However, the start span time is set at the very
beginning of span creation. This means the task will capture the span
work, but the task's duration can sometimes significantly disagree with
the span time when there is a large delay during span creaiton.

### Describe how to test/QA your changes

TODO

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.
