### PR TITLE
contrib/labstack/echo: Add warning and deprecation notice

### DIFF
--- a/contrib/labstack/echo/echotrace.go
+++ b/contrib/labstack/echo/echotrace.go
@@ -4,6 +4,9 @@
 // Copyright 2016 Datadog, Inc.
 
 // Package echo provides functions to trace the labstack/echo package (https://github.com/labstack/echo).
+// WARNING: The underlying v3 version of labstack/echo has known security vulnerabilities that have been resolved in v4
+// and is no longer under active development. As such consider this package deprecated.
+// It is highly recommended that you update to the latest version available at labstack/echo.v4.
 package echo
 
 import (


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Add a warning and deprecation notice for contrib/labstack/echo v3. The old version is no longer under development it seems and has active security vulnerabilities that were addressed in the newer "v4" version that supports go modules. Customers should migrate off the v3 version to v4, and when we release dd-trace-go v2 we should remove support for v3. 

### Motivation
Customers who are interested in using labstack/echo might not know which version they should prefer when viewing our docs. This warning should help new implementors avoid relying on insecure / outdated software as well as notifying current users that support is deprecated.

### Describe how to test/QA your changes
no QA needed 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.