### PR TITLE
profiler: support reconfiguring execution tracing at runtime

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -560,11 +560,11 @@ type executionTraceConfig struct {
 // changes to the configuration environment variables, applying defaults as
 // needed.
 func (e *executionTraceConfig) Refresh() {
-	enabled := internal.BoolEnv("DD_PROFILING_EXECUTION_TRACE_ENABLED", false)
-	period := internal.DurationEnv("DD_PROFILING_EXECUTION_TRACE_PERIOD", 5000*time.Second)
-	limit := internal.IntEnv("DD_PROFILING_EXECUTION_TRACE_LIMIT_BYTES", defaultExecutionTraceSizeLimit)
+	e.Enabled = internal.BoolEnv("DD_PROFILING_EXECUTION_TRACE_ENABLED", false)
+	e.Period = internal.DurationEnv("DD_PROFILING_EXECUTION_TRACE_PERIOD", 5000*time.Second)
+	e.Limit = internal.IntEnv("DD_PROFILING_EXECUTION_TRACE_LIMIT_BYTES", defaultExecutionTraceSizeLimit)
 
-	if enabled && (period == 0 || limit == 0) {
+	if e.Enabled && (e.Period == 0 || e.Limit == 0) {
 		if !e.warned {
 			e.warned = true
 			log.Warn("Invalid execution trace config, enabled is true but size limit or frequency is 0. Disabling execution trace.")
@@ -575,8 +575,4 @@ func (e *executionTraceConfig) Refresh() {
 	// If the config is valid, reset e.warned so we'll print another warning
 	// if it's udpated to be invalid
 	e.warned = false
-
-	e.Enabled = enabled
-	e.Period = period
-	e.Limit = limit
 }

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -108,7 +108,6 @@ type config struct {
 	deltaProfiles        bool
 	deltaMethod          string
 	logStartup           bool
-	traceEnabled         bool
 	traceConfig          executionTraceConfig
 	endpointCountEnabled bool
 }
@@ -164,7 +163,7 @@ func logStartup(c *config) {
 		MutexProfileFraction: c.mutexFraction,
 		MaxGoroutinesWait:    c.maxGoroutinesWait,
 		UploadTimeout:        c.uploadTimeout.String(),
-		TraceEnabled:         c.traceEnabled,
+		TraceEnabled:         c.traceConfig.Enabled,
 		TracePeriod:          c.traceConfig.Period.String(),
 		TraceSizeLimit:       c.traceConfig.Limit,
 		EndpointCountEnabled: c.endpointCountEnabled,
@@ -310,13 +309,7 @@ func defaultConfig() (*config, error) {
 	}
 
 	// Experimental feature: Go execution trace (runtime/trace) recording.
-	c.traceEnabled = internal.BoolEnv("DD_PROFILING_EXECUTION_TRACE_ENABLED", false)
-	c.traceConfig.Period = internal.DurationEnv("DD_PROFILING_EXECUTION_TRACE_PERIOD", 5000*time.Second)
-	c.traceConfig.Limit = internal.IntEnv("DD_PROFILING_EXECUTION_TRACE_LIMIT_BYTES", defaultExecutionTraceSizeLimit)
-	if c.traceEnabled && (c.traceConfig.Period == 0 || c.traceConfig.Limit == 0) {
-		log.Warn("Invalid execution trace config, enabled is true but size limit or frequency is 0. Disabling execution trace.")
-		c.traceEnabled = false
-	}
+	c.traceConfig.Refresh()
 	return &c, nil
 }
 
@@ -542,8 +535,10 @@ func WithHostname(hostname string) Option {
 }
 
 // executionTraceConfig controls how often, and for how long, runtime execution
-// traces are collected, see defaultConfig() for more details.
+// traces are collected.
 type executionTraceConfig struct {
+	// Enabled indicates whether execution tracing is enabled.
+	Enabled bool
 	// Period is the amount of time between traces.
 	Period time.Duration
 	// Limit is the desired upper bound, in bytes, of a collected trace.
@@ -555,4 +550,33 @@ type executionTraceConfig struct {
 	// of events recorded) than duration, so we use that to decide when to
 	// stop tracing.
 	Limit int
+
+	// warned is checked to prevent spamming a log every minute if the trace
+	// config is invalid
+	warned bool
+}
+
+// Refresh updates the execution trace configuration to reflect any run-time
+// changes to the configuration environment variables, applying defaults as
+// needed.
+func (e *executionTraceConfig) Refresh() {
+	enabled := internal.BoolEnv("DD_PROFILING_EXECUTION_TRACE_ENABLED", false)
+	period := internal.DurationEnv("DD_PROFILING_EXECUTION_TRACE_PERIOD", 5000*time.Second)
+	limit := internal.IntEnv("DD_PROFILING_EXECUTION_TRACE_LIMIT_BYTES", defaultExecutionTraceSizeLimit)
+
+	if enabled && (period == 0 || limit == 0) {
+		if !e.warned {
+			e.warned = true
+			log.Warn("Invalid execution trace config, enabled is true but size limit or frequency is 0. Disabling execution trace.")
+		}
+		e.Enabled = false
+		return
+	}
+	// If the config is valid, reset e.warned so we'll print another warning
+	// if it's udpated to be invalid
+	e.warned = false
+
+	e.Enabled = enabled
+	e.Period = period
+	e.Limit = limit
 }

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -83,7 +83,8 @@ type profiler struct {
 }
 
 func (p *profiler) shouldTrace() bool {
-	return p.cfg.traceEnabled && time.Since(p.lastTrace) > p.cfg.traceConfig.Period
+	p.cfg.traceConfig.Refresh()
+	return p.cfg.traceConfig.Enabled && time.Since(p.lastTrace) > p.cfg.traceConfig.Period
 }
 
 // testHooks are functions that are replaced during testing which would normally

--- a/profiler/telemetry.go
+++ b/profiler/telemetry.go
@@ -42,7 +42,7 @@ func startTelemetry(c *config) {
 			{Name: "goroutine_profile_enabled", Value: profileEnabled(GoroutineProfile)},
 			{Name: "goroutine_wait_profile_enabled", Value: profileEnabled(expGoroutineWaitProfile)},
 			{Name: "upload_timeout", Value: c.uploadTimeout.String()},
-			{Name: "execution_trace_enabled", Value: c.traceEnabled},
+			{Name: "execution_trace_enabled", Value: c.traceConfig.Enabled},
 			{Name: "execution_trace_period", Value: c.traceConfig.Period.String()},
 			{Name: "execution_trace_size_limit", Value: c.traceConfig.Limit},
 			{Name: "endpoint_count_enabled", Value: c.endpointCountEnabled},


### PR DESCRIPTION
### What does this PR do?
Have the profiler check the execution tracing configuration environment
variables at the beginning of each profiling cycle. That way, the environment
variables can be updated at run-time.

### Motivation

Give initial users the flexibility to, for example, increase collection
frequency during periods where they suspect a performance issue is happening,
without requiring us to commit to a public interface for triggering or
reconfiguring trace collection.

### Describe how to test/QA your changes

TODO. The existing tests pass. Perhaps worth adding an additional test to see
if updating the configuration works.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality.
- [x] If this interacts with the agent in a new way, a system test has been added.
