### PR TITLE
 contrib: `peer.service` precursors for confluentinc/segmentio integrations 

### DIFF
--- a/contrib/confluentinc/confluent-kafka-go/kafka/kafka_test.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/kafka_test.go
@@ -211,6 +211,7 @@ func TestConsumerFunctional(t *testing.T) {
 			assert.Equal(t, "confluentinc/confluent-kafka-go/kafka", s0.Tag(ext.Component))
 			assert.Equal(t, ext.SpanKindProducer, s0.Tag(ext.SpanKind))
 			assert.Equal(t, "kafka", s0.Tag(ext.MessagingSystem))
+			assert.Equal(t, "127.0.0.1:9092", s0.Tag(ext.KafkaBootstrapServers))
 
 			s1 := spans[1] // consume
 			assert.Equal(t, "kafka.consume", s1.OperationName())
@@ -222,6 +223,7 @@ func TestConsumerFunctional(t *testing.T) {
 			assert.Equal(t, "confluentinc/confluent-kafka-go/kafka", s1.Tag(ext.Component))
 			assert.Equal(t, ext.SpanKindConsumer, s1.Tag(ext.SpanKind))
 			assert.Equal(t, "kafka", s1.Tag(ext.MessagingSystem))
+			assert.Equal(t, "127.0.0.1:9092", s1.Tag(ext.KafkaBootstrapServers))
 		})
 	}
 }

--- a/contrib/segmentio/kafka.go.v0/kafka.go
+++ b/contrib/segmentio/kafka.go.v0/kafka.go
@@ -8,6 +8,7 @@ package kafka // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/segmentio/kafka
 import (
 	"context"
 	"math"
+	"strings"
 
 	"github.com/segmentio/kafka-go"
 
@@ -61,8 +62,10 @@ func (r *Reader) startSpan(ctx context.Context, msg *kafka.Message) ddtrace.Span
 		tracer.Tag(ext.Component, componentName),
 		tracer.Tag(ext.SpanKind, ext.SpanKindConsumer),
 		tracer.Tag(ext.MessagingSystem, "kafka"),
+		tracer.Tag(ext.KafkaBootstrapServers, strings.Join(r.Config().Brokers, ",")),
 		tracer.Measured(),
 	}
+
 	if !math.IsNaN(r.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, r.cfg.analyticsRate))
 	}
@@ -141,6 +144,7 @@ func (w *Writer) startSpan(ctx context.Context, msg *kafka.Message) ddtrace.Span
 		tracer.Tag(ext.Component, componentName),
 		tracer.Tag(ext.SpanKind, ext.SpanKindProducer),
 		tracer.Tag(ext.MessagingSystem, "kafka"),
+		tracer.Tag(ext.KafkaBootstrapServers, w.Addr.String()),
 	}
 	if w.Writer.Topic != "" {
 		opts = append(opts, tracer.ResourceName("Produce Topic "+w.Writer.Topic))

--- a/contrib/segmentio/kafka.go.v0/kafka_test.go
+++ b/contrib/segmentio/kafka.go.v0/kafka_test.go
@@ -205,3 +205,33 @@ func TestNamingSchema(t *testing.T) {
 	}
 	namingschematest.NewKafkaTest(genSpans)(t)
 }
+
+func BenchmarkReaderStartSpan(b *testing.B) {
+
+	r := NewReader(kafka.ReaderConfig{
+		Brokers: []string{"localhost:9092", "localhost:9093", "localhost:9094"},
+		GroupID: testGroupID,
+		Topic:   testTopic,
+		MaxWait: testReaderMaxWait,
+	})
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		r.startSpan(nil, &testMessages[0])
+	}
+}
+
+func BenchmarkWriterStartSpan(b *testing.B) {
+
+	kw := &kafka.Writer{
+		Addr:         kafka.TCP("localhost:9092", "localhost:9093", "localhost:9094"),
+		Topic:        testTopic,
+		RequiredAcks: kafka.RequireOne,
+	}
+	w := WrapWriter(kw)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		w.startSpan(nil, &testMessages[0])
+	}
+}

--- a/contrib/segmentio/kafka.go.v0/kafka_test.go
+++ b/contrib/segmentio/kafka.go.v0/kafka_test.go
@@ -53,8 +53,9 @@ func genIntegrationTestSpans(t *testing.T, writerOp func(t *testing.T, w *Writer
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
+	//add some dummy values to broker/addr to test bootstrap servers
 	kw := &kafka.Writer{
-		Addr:         kafka.TCP("localhost:9092"),
+		Addr:         kafka.TCP("localhost:9092", "localhost:9093", "localhost:9094"),
 		Topic:        testTopic,
 		RequiredAcks: kafka.RequireOne,
 	}
@@ -64,7 +65,7 @@ func genIntegrationTestSpans(t *testing.T, writerOp func(t *testing.T, w *Writer
 	require.NoError(t, err)
 
 	r := NewReader(kafka.ReaderConfig{
-		Brokers: []string{"localhost:9092"},
+		Brokers: []string{"localhost:9092", "localhost:9093", "localhost:9094"},
 		GroupID: testGroupID,
 		Topic:   testTopic,
 		MaxWait: testReaderMaxWait,
@@ -112,6 +113,7 @@ func TestReadMessageFunctional(t *testing.T) {
 	assert.Equal(t, "segmentio/kafka.go.v0", s0.Tag(ext.Component))
 	assert.Equal(t, ext.SpanKindProducer, s0.Tag(ext.SpanKind))
 	assert.Equal(t, "kafka", s0.Tag(ext.MessagingSystem))
+	assert.Equal(t, "localhost:9092,localhost:9093,localhost:9094", s0.Tag(ext.KafkaBootstrapServers))
 
 	// consumer span
 	s1 := spans[1]
@@ -124,6 +126,7 @@ func TestReadMessageFunctional(t *testing.T) {
 	assert.Equal(t, "segmentio/kafka.go.v0", s1.Tag(ext.Component))
 	assert.Equal(t, ext.SpanKindConsumer, s1.Tag(ext.SpanKind))
 	assert.Equal(t, "kafka", s1.Tag(ext.MessagingSystem))
+	assert.Equal(t, "localhost:9092,localhost:9093,localhost:9094", s1.Tag(ext.KafkaBootstrapServers))
 }
 
 func TestFetchMessageFunctional(t *testing.T) {
@@ -158,6 +161,7 @@ func TestFetchMessageFunctional(t *testing.T) {
 	assert.Equal(t, "segmentio/kafka.go.v0", s0.Tag(ext.Component))
 	assert.Equal(t, ext.SpanKindProducer, s0.Tag(ext.SpanKind))
 	assert.Equal(t, "kafka", s0.Tag(ext.MessagingSystem))
+	assert.Equal(t, "localhost:9092,localhost:9093,localhost:9094", s0.Tag(ext.KafkaBootstrapServers))
 
 	// consumer span
 	s1 := spans[1]
@@ -170,6 +174,7 @@ func TestFetchMessageFunctional(t *testing.T) {
 	assert.Equal(t, "segmentio/kafka.go.v0", s1.Tag(ext.Component))
 	assert.Equal(t, ext.SpanKindConsumer, s1.Tag(ext.SpanKind))
 	assert.Equal(t, "kafka", s1.Tag(ext.MessagingSystem))
+	assert.Equal(t, "localhost:9092,localhost:9093,localhost:9094", s1.Tag(ext.KafkaBootstrapServers))
 }
 
 func TestNamingSchema(t *testing.T) {

--- a/contrib/segmentio/kafka.go.v0/kafka_test.go
+++ b/contrib/segmentio/kafka.go.v0/kafka_test.go
@@ -207,7 +207,6 @@ func TestNamingSchema(t *testing.T) {
 }
 
 func BenchmarkReaderStartSpan(b *testing.B) {
-
 	r := NewReader(kafka.ReaderConfig{
 		Brokers: []string{"localhost:9092", "localhost:9093", "localhost:9094"},
 		GroupID: testGroupID,
@@ -222,7 +221,6 @@ func BenchmarkReaderStartSpan(b *testing.B) {
 }
 
 func BenchmarkWriterStartSpan(b *testing.B) {
-
 	kw := &kafka.Writer{
 		Addr:         kafka.TCP("localhost:9092", "localhost:9093", "localhost:9094"),
 		Topic:        testTopic,

--- a/contrib/segmentio/kafka.go.v0/kafka_test.go
+++ b/contrib/segmentio/kafka.go.v0/kafka_test.go
@@ -53,7 +53,7 @@ func genIntegrationTestSpans(t *testing.T, writerOp func(t *testing.T, w *Writer
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	//add some dummy values to broker/addr to test bootstrap servers
+	// add some dummy values to broker/addr to test bootstrap servers.
 	kw := &kafka.Writer{
 		Addr:         kafka.TCP("localhost:9092", "localhost:9093", "localhost:9094"),
 		Topic:        testTopic,

--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -109,6 +109,9 @@ const (
 
 	// MessagingSystem identifies which messaging system created this span (kafka, rabbitmq, amazonsqs, googlepubsub...)
 	MessagingSystem = "messaging.system"
+
+	//KafkaBootstrapServers lists bootstrap servers as defined in producer or consumer config
+	KafkaBootstrapServers = "messaging.kafka.bootstrap.servers"
 )
 
 // Messaging tags.

--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -110,7 +110,7 @@ const (
 	// MessagingSystem identifies which messaging system created this span (kafka, rabbitmq, amazonsqs, googlepubsub...)
 	MessagingSystem = "messaging.system"
 
-	//KafkaBootstrapServers lists bootstrap servers as defined in producer or consumer config
+	//KafkaBootstrapServers holds a comma separated list bootstrap servers as defined in producer or consumer config
 	KafkaBootstrapServers = "messaging.kafka.bootstrap.servers"
 )
 

--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -110,7 +110,7 @@ const (
 	// MessagingSystem identifies which messaging system created this span (kafka, rabbitmq, amazonsqs, googlepubsub...)
 	MessagingSystem = "messaging.system"
 
-	//KafkaBootstrapServers holds a comma separated list bootstrap servers as defined in producer or consumer config
+	// KafkaBootstrapServers holds a comma separated list bootstrap servers as defined in producer or consumer config.
 	KafkaBootstrapServers = "messaging.kafka.bootstrap.servers"
 )
 

--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -110,7 +110,7 @@ const (
 	// MessagingSystem identifies which messaging system created this span (kafka, rabbitmq, amazonsqs, googlepubsub...)
 	MessagingSystem = "messaging.system"
 
-	// KafkaBootstrapServers holds a comma separated list bootstrap servers as defined in producer or consumer config.
+	// KafkaBootstrapServers holds a comma separated list of bootstrap servers as defined in producer or consumer config.
 	KafkaBootstrapServers = "messaging.kafka.bootstrap.servers"
 )
 


### PR DESCRIPTION
### What does this PR do?

-This PR sets the `peer.service` precursor for confluentinc and segementio kafka integration spans which is the `messaging.kafka.bootstrap.servers` tag.
-Adds according testing and other modifications to meet requirements