### PR TITLE
contrib/grpc: simplify appsec test attack patterns

### DIFF
--- a/contrib/google.golang.org/grpc/appsec_test.go
+++ b/contrib/google.golang.org/grpc/appsec_test.go
@@ -42,7 +42,7 @@ func TestAppSec(t *testing.T) {
 
 		// Send a XSS attack in the payload along with the canary value in the RPC metadata
 		ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("dd-canary", "dd-test-scanner-log"))
-		res, err := client.Ping(ctx, &FixtureRequest{Name: "<script>alert('xss');</script>"})
+		res, err := client.Ping(ctx, &FixtureRequest{Name: "<script>evilJSCode;</script>"})
 		// Check that the handler was properly called
 		require.NoError(t, err)
 		require.Equal(t, "passed", res.Message)
@@ -67,7 +67,7 @@ func TestAppSec(t *testing.T) {
 		require.NoError(t, err)
 
 		// Send a XSS attack
-		err = stream.Send(&FixtureRequest{Name: "<script>alert('xss');</script>"})
+		err = stream.Send(&FixtureRequest{Name: "<script>evilJSCode;</script>"})
 		require.NoError(t, err)
 
 		// Check that the handler was properly called
@@ -76,7 +76,7 @@ func TestAppSec(t *testing.T) {
 		require.NoError(t, err)
 
 		// Send a SQLi attack
-		err = stream.Send(&FixtureRequest{Name: "-1' and 1=1 union/* foo */select load_file('/etc/passwd')--"})
+		err = stream.Send(&FixtureRequest{Name: "-1' and 1=1 union select * from users--"})
 		require.NoError(t, err)
 
 		// Check that the handler was properly called


### PR DESCRIPTION
Appsec tests were failing because of unspecified security rules matching order. Because the attacks were complex they could be matched by several rules and it was not possible to know which would match first. This change simplifies the attack patterns to ensure that only one specific rule will match.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.