### PR TITLE
internal/gitmetadata: log failed read build info as debug

### DIFF
--- a/internal/gitmetadatabinary.go
+++ b/internal/gitmetadatabinary.go
@@ -19,7 +19,7 @@ func getTagsFromBinary() map[string]string {
 	res := make(map[string]string)
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
-		log.Warn("ReadBuildInfo failed, skip source code metadata extracting")
+		log.Debug("ReadBuildInfo failed, skip source code metadata extracting")
 		return res
 	}
 	goPath := info.Path


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Log failed read build info as debug

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

- There are other sources to collect build info from (e.g env vars) - `debug.ReadBuildInfo()` is allowed to fail.
- The warning can be confusing and spammy, the error itself doesn't affect the product beyond version control information not being available in the traces
- Similar to https://github.com/DataDog/dd-trace-go/pull/1875

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.