### PR TITLE
contrib/go-chi/chi.v5: add WithResourceNamer option

### DIFF
--- a/contrib/go-chi/chi.v5/chi.go
+++ b/contrib/go-chi/chi.v5/chi.go
@@ -73,13 +73,18 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 			// pass the span through the request context and serve the request to the next middleware
 			next.ServeHTTP(ww, r)
 
-			// set the resource name as we get it only once the handler is executed
-			resourceName := cfg.modifyResourceName(chi.RouteContext(r.Context()).RoutePattern())
-			span.SetTag(ext.HTTPRoute, resourceName)
-			if resourceName == "" {
-				resourceName = "unknown"
+			routePattern := cfg.modifyResourceName(chi.RouteContext(r.Context()).RoutePattern())
+			span.SetTag(ext.HTTPRoute, routePattern)
+			var resourceName string
+			if cfg.resourceNamer != nil {
+				resourceName = cfg.resourceNamer(r)
+			} else {
+				resourceName = routePattern
+				if resourceName == "" {
+					resourceName = "unknown"
+				}
+				resourceName = r.Method + " " + resourceName
 			}
-			resourceName = r.Method + " " + resourceName
 			span.SetTag(ext.ResourceName, resourceName)
 		})
 	}

--- a/contrib/go-chi/chi.v5/chi_test.go
+++ b/contrib/go-chi/chi.v5/chi_test.go
@@ -471,3 +471,49 @@ func TestNamingSchema(t *testing.T) {
 	})
 	namingschematest.NewHTTPServerTest(genSpans, "chi.router")(t)
 }
+
+func TestCustomResourceName(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	router := chi.NewRouter()
+	router.Use(Middleware(WithServiceName("service-name"), WithResourceNamer(func(r *http.Request) string {
+		return "custom-resource-name"
+	})))
+	router.Get("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
+		_, ok := tracer.SpanFromContext(r.Context())
+		assert.True(ok)
+	})
+
+	r := httptest.NewRequest("GET", "/user/123", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+	spans := mt.FinishedSpans()
+	require.Equal(t, "/user/{id}", spans[0].Tag(ext.HTTPRoute))
+	require.Equal(t, "service-name", spans[0].Tag(ext.ServiceName))
+	require.Equal(t, "custom-resource-name", spans[0].Tag(ext.ResourceName))
+}
+
+func TestUnknownResourceName(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	router := chi.NewRouter()
+	router.Use(Middleware(WithServiceName("service-name")))
+	router.Get("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
+		_, ok := tracer.SpanFromContext(r.Context())
+		assert.True(ok)
+	})
+
+	r := httptest.NewRequest("GET", "/other/123", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+	spans := mt.FinishedSpans()
+	require.Equal(t, "", spans[0].Tag(ext.HTTPRoute))
+	require.Equal(t, "service-name", spans[0].Tag(ext.ServiceName))
+	require.Equal(t, "GET unknown", spans[0].Tag(ext.ResourceName))
+}

--- a/contrib/go-chi/chi.v5/option.go
+++ b/contrib/go-chi/chi.v5/option.go
@@ -24,6 +24,7 @@ type config struct {
 	isStatusError      func(statusCode int) bool
 	ignoreRequest      func(r *http.Request) bool
 	modifyResourceName func(resourceName string) string
+	resourceNamer      func(r *http.Request) string
 }
 
 // Option represents an option that can be passed to NewRouter.
@@ -39,6 +40,8 @@ func defaults(cfg *config) {
 	cfg.isStatusError = isServerError
 	cfg.ignoreRequest = func(_ *http.Request) bool { return false }
 	cfg.modifyResourceName = func(s string) string { return s }
+	// for backward compatibility with modifyResourceName, initialize resourceName as nil.
+	cfg.resourceNamer = nil
 }
 
 // WithServiceName sets the given service name for the router.
@@ -103,5 +106,13 @@ func WithIgnoreRequest(fn func(r *http.Request) bool) Option {
 func WithModifyResourceName(fn func(resourceName string) string) Option {
 	return func(cfg *config) {
 		cfg.modifyResourceName = fn
+	}
+}
+
+// WithResourceNamer specifies a function to use for determining the resource
+// name of the span.
+func WithResourceNamer(fn func(r *http.Request) string) Option {
+	return func(cfg *config) {
+		cfg.resourceNamer = fn
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR introduces the WithResourceNamer option to chi.v5, which allows customizing span resource names.
The implementation is similar to #1950.

### Motivation

Improve span resource names and provide a generic solution for Issue #1198.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

New unit tests, similar to those added in PR #1950, have been implemented to verify the new functionality.
- `TestCustomResourceName()` checks if the custom resource name is properly applied
- `TestUnknownResourceName()` ensures the default naming is used in case of unknown resource names.

And, the existing test, `TestWithModifyResourceName()`, guarantees backward compatibility.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.