### PR TITLE
golangci lint for appsec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,8 @@ run:
   skip-dirs:
     # This package is an exception and has its own test job (Testing outlier gRPC v1.2).
     - contrib/google.golang.org/grpc.v12
+  build-tags:
+    - appsec
 linters:
   disable-all: true
   enable:

--- a/internal/appsec/config_test.go
+++ b/internal/appsec/config_test.go
@@ -259,7 +259,7 @@ func cleanEnv() func() {
 		obfuscatorKeyEnvVar:   os.Getenv(obfuscatorKeyEnvVar),
 		obfuscatorValueEnvVar: os.Getenv(obfuscatorValueEnvVar),
 	}
-	for k, _ := range env {
+	for k := range env {
 		if err := os.Unsetenv(k); err != nil {
 			panic(err)
 		}

--- a/internal/appsec/dyngo/instrumentation/grpcsec/actions.go
+++ b/internal/appsec/dyngo/instrumentation/grpcsec/actions.go
@@ -11,10 +11,10 @@ package grpcsec
 import (
 	"sync"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo/instrumentation"
 )
 
 // Action is used to identify any action kind

--- a/internal/appsec/remoteconfig_test.go
+++ b/internal/appsec/remoteconfig_test.go
@@ -17,11 +17,11 @@ import (
 	"strings"
 	"testing"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/remoteconfig"
+
 	rc "github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	waf "github.com/DataDog/go-libddwaf"
 	"github.com/stretchr/testify/require"
-
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/remoteconfig"
 )
 
 func TestASMFeaturesCallback(t *testing.T) {

--- a/internal/appsec/waf.go
+++ b/internal/appsec/waf.go
@@ -149,7 +149,7 @@ func newHTTPWAFEventListener(handle *waf.Handle, addresses map[string]struct{}, 
 		}
 
 		values := map[string]interface{}{}
-		for addr, _ := range addresses {
+		for addr := range addresses {
 			switch addr {
 			case httpClientIPAddr:
 				if args.ClientIP.IsValid() {
@@ -272,7 +272,7 @@ func newGRPCWAFEventListener(handle *waf.Handle, addresses map[string]struct{}, 
 		// (SetUser is SDK), we delegate the responsibility of interrupting the handler to the user.
 		op.On(sharedsec.OnUserIDOperationStart(func(operation *sharedsec.UserIDOperation, args sharedsec.UserIDOperationArgs) {
 			values := map[string]interface{}{}
-			for addr, _ := range addresses {
+			for addr := range addresses {
 				if addr == userIDAddr {
 					values[userIDAddr] = args.UserID
 				}
@@ -290,7 +290,7 @@ func newGRPCWAFEventListener(handle *waf.Handle, addresses map[string]struct{}, 
 
 		// The same address is used for gRPC and http when it comes to client ip
 		values := map[string]interface{}{}
-		for addr, _ := range addresses {
+		for addr := range addresses {
 			if addr == httpClientIPAddr && handlerArgs.ClientIP.IsValid() {
 				values[httpClientIPAddr] = handlerArgs.ClientIP.String()
 			}

--- a/internal/appsec/waf_test.go
+++ b/internal/appsec/waf_test.go
@@ -64,8 +64,9 @@ func TestCustomRules(t *testing.T) {
 			req, err := http.NewRequest(tc.method, srv.URL, nil)
 			require.NoError(t, err)
 
-			_, err = srv.Client().Do(req)
+			res, err := srv.Client().Do(req)
 			require.NoError(t, err)
+			defer res.Body.Close()
 
 			spans := mt.FinishedSpans()
 			require.Len(t, spans, 1)
@@ -105,8 +106,9 @@ func TestUserRules(t *testing.T) {
 		req, err := http.NewRequest("GET", srv.URL, nil)
 		require.NoError(t, err)
 
-		_, err = srv.Client().Do(req)
+		res, err := srv.Client().Do(req)
 		require.NoError(t, err)
+		defer res.Body.Close()
 
 		spans := mt.FinishedSpans()
 		require.Len(t, spans, 1)
@@ -151,6 +153,7 @@ func TestWAF(t *testing.T) {
 		}
 		res, err := srv.Client().Do(req)
 		require.NoError(t, err)
+		defer res.Body.Close()
 
 		// Check that the handler was properly called
 		b, err := io.ReadAll(res.Body)
@@ -182,6 +185,7 @@ func TestWAF(t *testing.T) {
 		}
 		res, err := srv.Client().Do(req)
 		require.NoError(t, err)
+		defer res.Body.Close()
 
 		// Check that the handler was properly called
 		b, err := io.ReadAll(res.Body)
@@ -247,6 +251,7 @@ func TestWAF(t *testing.T) {
 		}
 		res, err := srv.Client().Do(req)
 		require.NoError(t, err)
+		defer res.Body.Close()
 
 		// Check that the handler was properly called
 		b, err := io.ReadAll(res.Body)
@@ -380,6 +385,7 @@ func TestBlocking(t *testing.T) {
 			}
 			res, err := srv.Client().Do(req)
 			require.NoError(t, err)
+			defer res.Body.Close()
 			require.Equal(t, tc.status, res.StatusCode)
 			b, err := io.ReadAll(res.Body)
 			require.NoError(t, err)


### PR DESCRIPTION
### What does this PR do?

This PR enables golangci-lint on the files with the `appsec` build tag

### Motivation

By removing the `appsec` build tag for testing purposes. We realized that the linter was skipping the files marked with the `appsec` build tag. This PR fixes this.

### Reviewer's Checklist

- [ ] Review the `.golangci.yml` file
- [ ] Review the linter-requested changes 