### PR TITLE
google.golang.org/grpc: revert behaviour of calculating service names when spans are created

### DIFF
--- a/contrib/google.golang.org/grpc/client.go
+++ b/contrib/google.golang.org/grpc/client.go
@@ -38,7 +38,7 @@ func (cs *clientStream) RecvMsg(m interface{}) (err error) {
 			cs.Context(),
 			cs.method,
 			"grpc.message",
-			cs.cfg.serviceName,
+			cs.cfg.serviceName(),
 			cs.cfg.startSpanOptions()...,
 		)
 		span.SetTag(ext.Component, componentName)
@@ -57,7 +57,7 @@ func (cs *clientStream) SendMsg(m interface{}) (err error) {
 			cs.Context(),
 			cs.method,
 			"grpc.message",
-			cs.cfg.serviceName,
+			cs.cfg.serviceName(),
 			cs.cfg.startSpanOptions()...,
 		)
 		span.SetTag(ext.Component, componentName)
@@ -174,7 +174,7 @@ func doClientRequest(
 		ctx,
 		method,
 		cfg.spanName,
-		cfg.serviceName,
+		cfg.serviceName(),
 		cfg.startSpanOptions(
 			tracer.Tag(ext.Component, componentName),
 			tracer.Tag(ext.SpanKind, ext.SpanKindClient))...,

--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -1260,9 +1260,6 @@ func TestRegressionServiceNames(t *testing.T) {
 			},
 		},
 	}
-	tracer.Start(tracer.WithHTTPClient(httpClient))
-	defer tracer.Stop()
-
 	serverInterceptors := []grpc.ServerOption{
 		grpc.UnaryInterceptor(UnaryServerInterceptor()),
 		grpc.StreamInterceptor(StreamServerInterceptor()),
@@ -1275,6 +1272,10 @@ func TestRegressionServiceNames(t *testing.T) {
 	rig, err := newRigWithInterceptors(serverInterceptors, clientInterceptors)
 	require.NoError(t, err)
 	defer rig.Close()
+
+	// call tracer.Start after integration is initialized, to reproduce the issue
+	tracer.Start(tracer.WithHTTPClient(httpClient))
+	defer tracer.Stop()
 
 	_, err = rig.client.Ping(context.Background(), &FixtureRequest{Name: "pass"})
 	require.NoError(t, err)

--- a/contrib/google.golang.org/grpc/option.go
+++ b/contrib/google.golang.org/grpc/option.go
@@ -24,7 +24,7 @@ const (
 type Option func(*config)
 
 type config struct {
-	serviceName         string
+	serviceName         func() string
 	spanName            string
 	nonErrorCodes       map[codes.Code]bool
 	traceStreamCalls    bool
@@ -60,16 +60,20 @@ func defaults(cfg *config) {
 }
 
 func clientDefaults(cfg *config) {
-	cfg.serviceName = namingschema.NewDefaultServiceName(
-		defaultClientServiceName,
-		namingschema.WithOverrideV0(defaultClientServiceName),
-	).GetName()
+	cfg.serviceName = func() string {
+		return namingschema.NewDefaultServiceName(
+			defaultClientServiceName,
+			namingschema.WithOverrideV0(defaultClientServiceName),
+		).GetName()
+	}
 	cfg.spanName = namingschema.NewGRPCClientOp().GetName()
 	defaults(cfg)
 }
 
 func serverDefaults(cfg *config) {
-	cfg.serviceName = namingschema.NewDefaultServiceName(defaultServerServiceName).GetName()
+	cfg.serviceName = func() string {
+		return namingschema.NewDefaultServiceName(defaultServerServiceName).GetName()
+	}
 	cfg.spanName = namingschema.NewGRPCServerOp().GetName()
 	defaults(cfg)
 }
@@ -77,7 +81,7 @@ func serverDefaults(cfg *config) {
 // WithServiceName sets the given service name for the intercepted client.
 func WithServiceName(name string) Option {
 	return func(cfg *config) {
-		cfg.serviceName = name
+		cfg.serviceName = func() string { return name }
 	}
 }
 

--- a/contrib/google.golang.org/grpc/server.go
+++ b/contrib/google.golang.org/grpc/server.go
@@ -46,7 +46,7 @@ func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 			ss.ctx,
 			ss.method,
 			"grpc.message",
-			ss.cfg.serviceName,
+			ss.cfg.serviceName(),
 			ss.cfg.startSpanOptions(tracer.Measured())...,
 		)
 		span.SetTag(ext.Component, componentName)
@@ -68,7 +68,7 @@ func (ss *serverStream) SendMsg(m interface{}) (err error) {
 			ss.ctx,
 			ss.method,
 			"grpc.message",
-			ss.cfg.serviceName,
+			ss.cfg.serviceName(),
 			ss.cfg.startSpanOptions(tracer.Measured())...,
 		)
 		span.SetTag(ext.Component, componentName)
@@ -97,7 +97,7 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
 				ctx,
 				info.FullMethod,
 				cfg.spanName,
-				cfg.serviceName,
+				cfg.serviceName(),
 				cfg.startSpanOptions(tracer.Measured(),
 					tracer.Tag(ext.Component, componentName),
 					tracer.Tag(ext.SpanKind, ext.SpanKindServer))...,
@@ -145,7 +145,7 @@ func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
 			ctx,
 			info.FullMethod,
 			cfg.spanName,
-			cfg.serviceName,
+			cfg.serviceName(),
 			cfg.startSpanOptions(tracer.Measured(),
 				tracer.Tag(ext.Component, componentName),
 				tracer.Tag(ext.SpanKind, ext.SpanKindServer))...,

--- a/contrib/google.golang.org/grpc/stats_client.go
+++ b/contrib/google.golang.org/grpc/stats_client.go
@@ -36,7 +36,7 @@ func (h *clientStatsHandler) TagRPC(ctx context.Context, rti *stats.RPCTagInfo) 
 		ctx,
 		rti.FullMethodName,
 		h.cfg.spanName,
-		h.cfg.serviceName,
+		h.cfg.serviceName(),
 		spanOpts...,
 	)
 	ctx = injectSpanIntoContext(ctx)

--- a/contrib/google.golang.org/grpc/stats_server.go
+++ b/contrib/google.golang.org/grpc/stats_server.go
@@ -40,7 +40,7 @@ func (h *serverStatsHandler) TagRPC(ctx context.Context, rti *stats.RPCTagInfo) 
 		ctx,
 		rti.FullMethodName,
 		h.cfg.spanName,
-		h.cfg.serviceName,
+		h.cfg.serviceName(),
 		spanOpts...,
 	)
 	return ctx


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Revert behaviour of calculating service names when spans are created instead of when the integration is initialized (this behaviour was introduced in https://github.com/DataDog/dd-trace-go/pull/1919)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->
Fix regression issue.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality.
- [x] If this interacts with the agent in a new way, a system test has been added.