### PR TITLE
contrib/google.golang.org/grpc: Fallback to dynamic service names if no global is found

### DIFF
--- a/contrib/google.golang.org/grpc/grpc.go
+++ b/contrib/google.golang.org/grpc/grpc.go
@@ -53,11 +53,11 @@ func (cfg *config) startSpanOptions(opts ...tracer.StartSpanOption) []tracer.Sta
 }
 
 func startSpanFromContext(
-	ctx context.Context, method, operation, service string, opts ...tracer.StartSpanOption,
+	ctx context.Context, method, operation string, serviceFn func() string, opts ...tracer.StartSpanOption,
 ) (ddtrace.Span, context.Context) {
 	methodElements := strings.SplitN(strings.TrimPrefix(method, "/"), "/", 2)
 	opts = append(opts,
-		tracer.ServiceName(service),
+		tracer.ServiceName(serviceFn()),
 		tracer.ResourceName(method),
 		tracer.Tag(tagMethodName, method),
 		spanTypeRPC,

--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -1219,7 +1219,8 @@ func (rt *roundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	return http.DefaultTransport.RoundTrip(r)
 }
 
-func TestRegressionServiceNames(t *testing.T) {
+func TestIssue2050(t *testing.T) {
+	// https://github.com/DataDog/dd-trace-go/issues/2050
 	t.Setenv("DD_SERVICE", "some-dd-service")
 
 	spansFound := make(chan bool, 1)

--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -17,6 +17,14 @@ import (
 	"testing"
 	"time"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/lists"
+	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/namingschematest"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tinylib/msgp/msgp"
@@ -26,14 +34,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-
-	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/lists"
-	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/namingschematest"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 )
 
 func TestUnary(t *testing.T) {

--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -17,8 +17,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tinylib/msgp/msgp"
+	context "golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/lists"
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/namingschematest"
@@ -27,14 +34,6 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	context "golang.org/x/net/context"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
 )
 
 func TestUnary(t *testing.T) {

--- a/contrib/google.golang.org/grpc/option.go
+++ b/contrib/google.golang.org/grpc/option.go
@@ -72,7 +72,7 @@ func clientDefaults(cfg *config) {
 }
 
 func serverDefaults(cfg *config) {
-	// We check for a configured service name, so we don't break users who are accidentally creating their server
+	// We check for a configured service name, so we don't break users who are incorrectly creating their server
 	// before the call `tracer.Start()`
 	if globalconfig.ServiceName() != "" {
 		sn := namingschema.NewDefaultServiceName(defaultServerServiceName).GetName()

--- a/contrib/google.golang.org/grpc/option.go
+++ b/contrib/google.golang.org/grpc/option.go
@@ -78,7 +78,7 @@ func serverDefaults(cfg *config) {
 		sn := namingschema.NewDefaultServiceName(defaultServerServiceName).GetName()
 		cfg.serviceName = func() string { return sn }
 	} else {
-		log.Warn("No service name was detected. GRPC Server may have been created before calling tracer.Start(). Will dynamically fetch service name per span. " +
+		log.Warn("No global service name was detected. GRPC Server may have been created before calling tracer.Start(). Will dynamically fetch service name for every span. " +
 			"Note this may have a slight performance cost, it is always recommended to start the tracer before initializing any traced packages.\n")
 		ns := namingschema.NewDefaultServiceName(defaultServerServiceName)
 		cfg.serviceName = ns.GetName

--- a/contrib/google.golang.org/grpc/option.go
+++ b/contrib/google.golang.org/grpc/option.go
@@ -81,9 +81,7 @@ func serverDefaults(cfg *config) {
 		log.Warn("No service name was detected. GRPC Server may have been created before calling tracer.Start(). Will dynamically fetch service name per span. " +
 			"Note this may have a slight performance cost, it is always recommended to start the tracer before initializing any traced packages.\n")
 		ns := namingschema.NewDefaultServiceName(defaultServerServiceName)
-		cfg.serviceName = func() string {
-			return ns.GetName()
-		}
+		cfg.serviceName = ns.GetName
 	}
 	cfg.spanName = namingschema.NewGRPCServerOp().GetName()
 	defaults(cfg)

--- a/contrib/google.golang.org/grpc/option.go
+++ b/contrib/google.golang.org/grpc/option.go
@@ -9,6 +9,8 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/namingschema"
 
 	"google.golang.org/grpc/codes"
@@ -24,7 +26,7 @@ const (
 type Option func(*config)
 
 type config struct {
-	serviceName         string
+	serviceName         func() string
 	spanName            string
 	nonErrorCodes       map[codes.Code]bool
 	traceStreamCalls    bool
@@ -60,16 +62,29 @@ func defaults(cfg *config) {
 }
 
 func clientDefaults(cfg *config) {
-	cfg.serviceName = namingschema.NewDefaultServiceName(
+	sn := namingschema.NewDefaultServiceName(
 		defaultClientServiceName,
 		namingschema.WithOverrideV0(defaultClientServiceName),
 	).GetName()
+	cfg.serviceName = func() string { return sn }
 	cfg.spanName = namingschema.NewGRPCClientOp().GetName()
 	defaults(cfg)
 }
 
 func serverDefaults(cfg *config) {
-	cfg.serviceName = namingschema.NewDefaultServiceName(defaultServerServiceName).GetName()
+	// We check for a configured service name, so we don't break users who are accidentally creating their server
+	// before the call `tracer.Start()`
+	if globalconfig.ServiceName() != "" {
+		sn := namingschema.NewDefaultServiceName(defaultServerServiceName).GetName()
+		cfg.serviceName = func() string { return sn }
+	} else {
+		log.Warn("No service name was detected. GRPC Server may have been created before calling tracer.Start(). Will dynamically fetch service name per span. " +
+			"Note this may have a slight performance cost, it is always recommended to start the tracer before initializing any traced packages.\n")
+		ns := namingschema.NewDefaultServiceName(defaultServerServiceName)
+		cfg.serviceName = func() string {
+			return ns.GetName()
+		}
+	}
 	cfg.spanName = namingschema.NewGRPCServerOp().GetName()
 	defaults(cfg)
 }
@@ -77,7 +92,7 @@ func serverDefaults(cfg *config) {
 // WithServiceName sets the given service name for the intercepted client.
 func WithServiceName(name string) Option {
 	return func(cfg *config) {
-		cfg.serviceName = name
+		cfg.serviceName = func() string { return name }
 	}
 }
 

--- a/internal/namingschema/service_name.go
+++ b/internal/namingschema/service_name.go
@@ -22,10 +22,6 @@ func NewDefaultServiceName(fallbackName string, opts ...Option) *Schema {
 	})
 }
 
-func HasConfiguredServiceName() bool {
-	return globalconfig.ServiceName() != ""
-}
-
 type standardServiceNameSchema struct {
 	fallbackName         string
 	useGlobalServiceName bool

--- a/internal/namingschema/service_name.go
+++ b/internal/namingschema/service_name.go
@@ -22,6 +22,10 @@ func NewDefaultServiceName(fallbackName string, opts ...Option) *Schema {
 	})
 }
 
+func HasConfiguredServiceName() bool {
+	return globalconfig.ServiceName() != ""
+}
+
 type standardServiceNameSchema struct {
 	fallbackName         string
 	useGlobalServiceName bool


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
To protect users who may be accidentally creating their GRPC server before calling `tracer.Start()` this PR falls back to dynamically fetching the service name for every span (as before), but if a service name is found it is cached (for a slight performance benefit).

GRPC is the only contrib here that is important as it previously did NOT cache the service name, unlike many of the other contribs where the caching was already occurring (meaning that those contribs would have had this same issue in the past, but because the behavior is changing here for grpc it can cause breakages for customers who did not know they needed to start the tracer first)
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We found several applications that are creating their GRPC server before calling `tracer.Start()`. These applications would suddenly have a new service name due to the new caching of service name as part of the `namingschema` changes. While it is highly recommended to call `tracer.Start()` before initializing any traced libraries, to try and avoid impacting users of the library we should try to detect this situation and fallback to the old behavior while logging a warning so that users know they should update their code.

Closes #2050 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes
Unit tested
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.