### PR TITLE
tracer: fix telemetry metrics to align with spec

### DIFF
--- a/ddtrace/opentelemetry/tracer.go
+++ b/ddtrace/opentelemetry/tracer.go
@@ -19,7 +19,7 @@ import (
 
 var _ oteltrace.Tracer = (*oteltracer)(nil)
 
-var telemetryTags = []string{"otel"}
+var telemetryTags = []string{`"integration_name":"otel"`}
 
 type oteltracer struct {
 	provider *TracerProvider

--- a/ddtrace/opentelemetry/tracer.go
+++ b/ddtrace/opentelemetry/tracer.go
@@ -50,7 +50,7 @@ func (t *oteltracer) Start(ctx context.Context, spanName string, opts ...oteltra
 	if opts, ok := spanOptionsFromContext(ctx); ok {
 		ddopts = append(ddopts, opts...)
 	}
-	telemetry.GlobalClient.Count(telemetry.NamespaceTracers, "spans_created", 1.0, []string{"otel"}, true)
+	telemetry.GlobalClient.Count(telemetry.NamespaceTracers, "spans_created", 1.0, telemetryTags, true)
 	s := tracer.StartSpan(spanName, ddopts...)
 	os := oteltrace.Span(&span{
 		Span:       s,
@@ -95,3 +95,5 @@ type noopOteltracer struct{}
 func (n *noopOteltracer) Start(_ context.Context, _ string, _ ...oteltrace.SpanStartOption) (context.Context, oteltrace.Span) {
 	return nil, nil
 }
+
+var telemetryTags = []string{"otel"}

--- a/ddtrace/opentelemetry/tracer.go
+++ b/ddtrace/opentelemetry/tracer.go
@@ -19,6 +19,8 @@ import (
 
 var _ oteltrace.Tracer = (*oteltracer)(nil)
 
+var telemetryTags = []string{"otel"}
+
 type oteltracer struct {
 	provider *TracerProvider
 	ddtrace.Tracer
@@ -95,5 +97,3 @@ type noopOteltracer struct{}
 func (n *noopOteltracer) Start(_ context.Context, _ string, _ ...oteltrace.SpanStartOption) (context.Context, oteltrace.Span) {
 	return nil, nil
 }
-
-var telemetryTags = []string{"otel"}

--- a/ddtrace/opentelemetry/tracer.go
+++ b/ddtrace/opentelemetry/tracer.go
@@ -50,7 +50,7 @@ func (t *oteltracer) Start(ctx context.Context, spanName string, opts ...oteltra
 	if opts, ok := spanOptionsFromContext(ctx); ok {
 		ddopts = append(ddopts, opts...)
 	}
-	telemetry.GlobalClient.Count(telemetry.NamespaceTracers, "span_created", 1.0, []string{"otel"}, true)
+	telemetry.GlobalClient.Count(telemetry.NamespaceTracers, "spans_created", 1.0, []string{"otel"}, true)
 	s := tracer.StartSpan(spanName, ddopts...)
 	os := oteltrace.Span(&span{
 		Span:       s,

--- a/ddtrace/opentelemetry/tracer.go
+++ b/ddtrace/opentelemetry/tracer.go
@@ -50,7 +50,7 @@ func (t *oteltracer) Start(ctx context.Context, spanName string, opts ...oteltra
 	if opts, ok := spanOptionsFromContext(ctx); ok {
 		ddopts = append(ddopts, opts...)
 	}
-	telemetry.GlobalClient.Count(telemetry.NamespaceTracers, "otel.spans_created", 1.0, nil, true)
+	telemetry.GlobalClient.Count(telemetry.NamespaceTracers, "span_created", 1.0, []string{"otel"}, true)
 	s := tracer.StartSpan(spanName, ddopts...)
 	os := oteltrace.Span(&span{
 		Span:       s,

--- a/ddtrace/opentelemetry/tracer_test.go
+++ b/ddtrace/opentelemetry/tracer_test.go
@@ -197,7 +197,7 @@ func TestSpanTelemetry(t *testing.T) {
 	otel.SetTracerProvider(tp)
 	tr := otel.Tracer("")
 	_, _ = tr.Start(context.Background(), "otel.span")
-	telemetryClient.AssertCalled(t, "Count", telemetry.NamespaceTracers, "otel.spans_created", 1.0, *new([]string), true)
+	telemetryClient.AssertCalled(t, "Count", telemetry.NamespaceTracers, "span_created", 1.0, []string{"otel"}, true)
 	telemetryClient.AssertNumberOfCalls(t, "Count", 1)
 }
 

--- a/ddtrace/opentelemetry/tracer_test.go
+++ b/ddtrace/opentelemetry/tracer_test.go
@@ -197,7 +197,7 @@ func TestSpanTelemetry(t *testing.T) {
 	otel.SetTracerProvider(tp)
 	tr := otel.Tracer("")
 	_, _ = tr.Start(context.Background(), "otel.span")
-	telemetryClient.AssertCalled(t, "Count", telemetry.NamespaceTracers, "spans_created", 1.0, []string{"otel"}, true)
+	telemetryClient.AssertCalled(t, "Count", telemetry.NamespaceTracers, "spans_created", 1.0, telemetryTags, true)
 	telemetryClient.AssertNumberOfCalls(t, "Count", 1)
 }
 

--- a/ddtrace/opentelemetry/tracer_test.go
+++ b/ddtrace/opentelemetry/tracer_test.go
@@ -197,7 +197,7 @@ func TestSpanTelemetry(t *testing.T) {
 	otel.SetTracerProvider(tp)
 	tr := otel.Tracer("")
 	_, _ = tr.Start(context.Background(), "otel.span")
-	telemetryClient.AssertCalled(t, "Count", telemetry.NamespaceTracers, "span_created", 1.0, []string{"otel"}, true)
+	telemetryClient.AssertCalled(t, "Count", telemetry.NamespaceTracers, "spans_created", 1.0, []string{"otel"}, true)
 	telemetryClient.AssertNumberOfCalls(t, "Count", 1)
 }
 

--- a/ddtrace/opentracer/tracer.go
+++ b/ddtrace/opentracer/tracer.go
@@ -44,6 +44,8 @@ func New(opts ...tracer.StartOption) opentracing.Tracer {
 
 var _ opentracing.Tracer = (*opentracer)(nil)
 
+var telemetryTags = []string{"opentracing"}
+
 // opentracer implements opentracing.Tracer on top of ddtrace.Tracer.
 type opentracer struct{ ddtrace.Tracer }
 
@@ -122,5 +124,3 @@ func translateError(err error) error {
 		return err
 	}
 }
-
-var telemetryTags = []string{"opentracing"}

--- a/ddtrace/opentracer/tracer.go
+++ b/ddtrace/opentracer/tracer.go
@@ -44,7 +44,7 @@ func New(opts ...tracer.StartOption) opentracing.Tracer {
 
 var _ opentracing.Tracer = (*opentracer)(nil)
 
-var telemetryTags = []string{"opentracing"}
+var telemetryTags = []string{`"integration_name":"opentracing"`}
 
 // opentracer implements opentracing.Tracer on top of ddtrace.Tracer.
 type opentracer struct{ ddtrace.Tracer }

--- a/ddtrace/opentracer/tracer.go
+++ b/ddtrace/opentracer/tracer.go
@@ -65,7 +65,7 @@ func (t *opentracer) StartSpan(operationName string, options ...opentracing.Star
 	for k, v := range sso.Tags {
 		opts = append(opts, tracer.Tag(k, v))
 	}
-	telemetry.GlobalClient.Count(telemetry.NamespaceTracers, "opentracing.spans_created", 1.0, nil, true)
+	telemetry.GlobalClient.Count(telemetry.NamespaceTracers, "span_created", 1.0, []string{"opentracing"}, true)
 	return &span{
 		Span:       t.Tracer.StartSpan(operationName, opts...),
 		opentracer: t,

--- a/ddtrace/opentracer/tracer.go
+++ b/ddtrace/opentracer/tracer.go
@@ -65,7 +65,7 @@ func (t *opentracer) StartSpan(operationName string, options ...opentracing.Star
 	for k, v := range sso.Tags {
 		opts = append(opts, tracer.Tag(k, v))
 	}
-	telemetry.GlobalClient.Count(telemetry.NamespaceTracers, "spans_created", 1.0, []string{"opentracing"}, true)
+	telemetry.GlobalClient.Count(telemetry.NamespaceTracers, "spans_created", 1.0, telemetryTags, true)
 	return &span{
 		Span:       t.Tracer.StartSpan(operationName, opts...),
 		opentracer: t,
@@ -122,3 +122,5 @@ func translateError(err error) error {
 		return err
 	}
 }
+
+var telemetryTags = []string{"opentracing"}

--- a/ddtrace/opentracer/tracer.go
+++ b/ddtrace/opentracer/tracer.go
@@ -65,7 +65,7 @@ func (t *opentracer) StartSpan(operationName string, options ...opentracing.Star
 	for k, v := range sso.Tags {
 		opts = append(opts, tracer.Tag(k, v))
 	}
-	telemetry.GlobalClient.Count(telemetry.NamespaceTracers, "span_created", 1.0, []string{"opentracing"}, true)
+	telemetry.GlobalClient.Count(telemetry.NamespaceTracers, "spans_created", 1.0, []string{"opentracing"}, true)
 	return &span{
 		Span:       t.Tracer.StartSpan(operationName, opts...),
 		opentracer: t,

--- a/ddtrace/opentracer/tracer_test.go
+++ b/ddtrace/opentracer/tracer_test.go
@@ -119,6 +119,6 @@ func TestSpanTelemetry(t *testing.T) {
 	defer telemetry.MockGlobalClient(telemetryClient)()
 	opentracing.SetGlobalTracer(New())
 	_ = opentracing.StartSpan("opentracing.span")
-	telemetryClient.AssertCalled(t, "Count", telemetry.NamespaceTracers, "spans_created", 1.0, []string{"opentracing"}, true)
+	telemetryClient.AssertCalled(t, "Count", telemetry.NamespaceTracers, "spans_created", 1.0, telemetryTags, true)
 	telemetryClient.AssertNumberOfCalls(t, "Count", 1)
 }

--- a/ddtrace/opentracer/tracer_test.go
+++ b/ddtrace/opentracer/tracer_test.go
@@ -119,6 +119,6 @@ func TestSpanTelemetry(t *testing.T) {
 	defer telemetry.MockGlobalClient(telemetryClient)()
 	opentracing.SetGlobalTracer(New())
 	_ = opentracing.StartSpan("opentracing.span")
-	telemetryClient.AssertCalled(t, "Count", telemetry.NamespaceTracers, "span_created", 1.0, []string{"opentracing"}, true)
+	telemetryClient.AssertCalled(t, "Count", telemetry.NamespaceTracers, "spans_created", 1.0, []string{"opentracing"}, true)
 	telemetryClient.AssertNumberOfCalls(t, "Count", 1)
 }

--- a/ddtrace/opentracer/tracer_test.go
+++ b/ddtrace/opentracer/tracer_test.go
@@ -119,6 +119,6 @@ func TestSpanTelemetry(t *testing.T) {
 	defer telemetry.MockGlobalClient(telemetryClient)()
 	opentracing.SetGlobalTracer(New())
 	_ = opentracing.StartSpan("opentracing.span")
-	telemetryClient.AssertCalled(t, "Count", telemetry.NamespaceTracers, "opentracing.spans_created", 1.0, *new([]string), true)
+	telemetryClient.AssertCalled(t, "Count", telemetry.NamespaceTracers, "span_created", 1.0, []string{"opentracing"}, true)
 	telemetryClient.AssertNumberOfCalls(t, "Count", 1)
 }

--- a/ddtrace/tracer/telemetry_test.go
+++ b/ddtrace/tracer/telemetry_test.go
@@ -35,7 +35,7 @@ func TestTelemetryEnabled(t *testing.T) {
 		telemetry.Check(t, telemetryClient.Configuration, "env", "test-env")
 		telemetry.Check(t, telemetryClient.Configuration, "runtime_metrics_enabled", true)
 		if metrics, ok := telemetryClient.Metrics[telemetry.NamespaceTracers]; ok {
-			if initTime, ok := metrics["tracer_init_time"]; ok {
+			if initTime, ok := metrics["init_time"]; ok {
 				assert.True(t, initTime > 0)
 				return
 			}

--- a/ddtrace/tracer/telemetry_test.go
+++ b/ddtrace/tracer/telemetry_test.go
@@ -34,12 +34,12 @@ func TestTelemetryEnabled(t *testing.T) {
 		telemetry.Check(t, telemetryClient.Configuration, "service", "test-serv")
 		telemetry.Check(t, telemetryClient.Configuration, "env", "test-env")
 		telemetry.Check(t, telemetryClient.Configuration, "runtime_metrics_enabled", true)
-		if metrics, ok := telemetryClient.Metrics[telemetry.NamespaceTracers]; ok {
+		if metrics, ok := telemetryClient.Metrics[telemetry.NamespaceGeneral]; ok {
 			if initTime, ok := metrics["init_time"]; ok {
 				assert.True(t, initTime > 0)
 				return
 			}
-			t.Fatalf("could not find tracer init time in telemetry client metrics")
+			t.Fatalf("could not find general init time in telemetry client metrics")
 		}
 		t.Fatalf("could not find tracer namespace in telemetry client metrics")
 	})

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -124,7 +124,7 @@ func Start(opts ...StartOption) {
 	if internal.Testing {
 		return // mock tracer active
 	}
-	defer telemetry.Time(telemetry.NamespaceTracers, "tracer_init_time", nil, true)()
+	defer telemetry.Time(telemetry.NamespaceTracers, "init_time", nil, true)()
 	t := newTracer(opts...)
 	if !t.config.enabled {
 		// TODO: instrumentation telemetry client won't get started

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -124,7 +124,7 @@ func Start(opts ...StartOption) {
 	if internal.Testing {
 		return // mock tracer active
 	}
-	defer telemetry.Time(telemetry.NamespaceTracers, "init_time", nil, true)()
+	defer telemetry.Time(telemetry.NamespaceGeneral, "init_time", nil, true)()
 	t := newTracer(opts...)
 	if !t.config.enabled {
 		// TODO: instrumentation telemetry client won't get started

--- a/internal/telemetry/message.go
+++ b/internal/telemetry/message.go
@@ -64,6 +64,8 @@ const (
 type Namespace string
 
 const (
+	// NamespaceGeneral is for general use
+	NamespaceGeneral Namespace = "general"
 	// NamespaceTracers is for distributed tracing
 	NamespaceTracers Namespace = "tracers"
 	// NamespaceProfilers is for continuous profiling

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -103,7 +103,7 @@ func LoadIntegration(name string) {
 // of some portion of code. It returns a function that should be called when
 // the desired code finishes executing.
 // For example, by adding:
-// defer Time(namespace, "tracer_init_time", nil, true)()
+// defer Time(namespace, "init_time", nil, true)()
 // at the beginning of the tracer Start function, the tracer start time is measured
 // and stored as a metric to be flushed by the global telemetry client.
 func Time(namespace Namespace, name string, tags []string, common bool) (finish func()) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Changes the metrics `otel.spans_created` and `tracer_init_time` to meet the telemetry naming specification.
- `otel.spans_created` changes to `spans_created` with `otel` as a tag instead
- `tracer_init_time` changes to `init_time`, and moves to a new "general" namespace

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

This is causing internal errors and triggering issues with monitors.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.