### PR TITLE
tracer: fixes race condition with partial flushing

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -79,7 +79,7 @@ type span struct {
 
 	goExecTraced bool         `msg:"-"`
 	noDebugStack bool         `msg:"-"` // disables debug stack traces
-	finished     bool         `msg:"-"` // true if the span has been submitted to a tracer.
+	finished     bool         `msg:"-"` // true if the span has been submitted to a tracer. Can only be read/modified if the trace is locked.
 	context      *spanContext `msg:"-"` // span propagation context
 
 	pprofCtxActive  context.Context `msg:"-"` // contains pprof.WithLabel labels to tell the profiler more about this span
@@ -492,7 +492,6 @@ func (s *span) finish(finishTime int64) {
 	if s.Duration < 0 {
 		s.Duration = 0
 	}
-	s.finished = true
 
 	keep := true
 	if t, ok := internal.GetGlobalTracer().(*tracer); ok {

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -384,6 +384,7 @@ func (t *trace) setTraceTags(s *span) {
 func (t *trace) finishedOne(s *span) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	s.finished = true
 	if t.full {
 		// capacity has been reached, the buffer is no longer tracking
 		// all the spans in the trace, so the below conditions will not

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -52,6 +52,15 @@ func TestNewSpanContextPushError(t *testing.T) {
 }
 
 func TestAsyncSpanRace(t *testing.T) {
+	testAsyncSpanRace(t)
+}
+
+func TestAsyncSpanRacePartialFlush(t *testing.T) {
+	t.Setenv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", "1")
+	testAsyncSpanRace(t)
+}
+
+func testAsyncSpanRace(t *testing.T) {
 	// This tests a regression where asynchronously finishing spans would
 	// modify a flushing root's sampling priority.
 	_, _, _, stop := startTestTracer(t)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Fixes race condition that can occur when `t.finished` and the `span.finished` state can become out of sync.

This wasn't an issue before because all spans in a trace had to have been finished before flushing would occur. Plus, the `span.finished` state was never actually looked at in `finishedOne` to know whether a span was safe to flush. With partial flushing, we need to know if a span is finished or not before flushing it and currently the only way to do that is to check the `finished` state of each span in a trace.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

There was another way we could have solved this, which would be to lock the trace earlier up the call stack, e.g. in `(*span).finish`. However, that is going to increase the hold time on a write lock for no real benefit, further increasing contention. None of the code prior to `finishedOne` needs to have the `(*span).finished` state be `true` in order to function properly, so this should be safe.

Yet another alternative would be to maintain a separate list of only finished spans. However, this could double the amount of memory necessary for holding all of the span pointers. Since it would just be holding the pointers, maybe that's okay, but I fear that it could also lead to some nasty bugs where spans in the two lists get out of sync.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

There's a new unit test that consistently fails if the race is reproduced, simply because the map capacity allocation `leftoverSpans := make([]*span, 0, len(t.spans)-t.finished)` will end up trying to create a map with negative capacity when `len(t.spans) < t.finished`. That does mean that if we stop initializing the map with a defined capacity in this way, that the bug could hide in the future, since tests may otherwise pass, so there could be work here to improve the test a bit.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.