### PR TITLE
tracer: ensure trace-level tags are always set correctly

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -79,7 +79,7 @@ type span struct {
 
 	goExecTraced bool         `msg:"-"`
 	noDebugStack bool         `msg:"-"` // disables debug stack traces
-	finished     bool         `msg:"-"` // true if the span has been submitted to a tracer.
+	finished     bool         `msg:"-"` // true if the span has been submitted to a tracer. Can only be read/modified if the trace is locked.
 	context      *spanContext `msg:"-"` // span propagation context
 
 	pprofCtxActive  context.Context `msg:"-"` // contains pprof.WithLabel labels to tell the profiler more about this span
@@ -492,7 +492,6 @@ func (s *span) finish(finishTime int64) {
 	if s.Duration < 0 {
 		s.Duration = 0
 	}
-	s.finished = true
 
 	keep := true
 	if t, ok := internal.GetGlobalTracer().(*tracer); ok {

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/samplernames"
 
@@ -480,6 +481,7 @@ func TestSpanSetMetric(t *testing.T) {
 func TestSpanError(t *testing.T) {
 	assert := assert.New(t)
 	tracer := newTracer(withTransport(newDefaultTransport()))
+	internal.SetGlobalTracer(tracer)
 	defer tracer.Stop()
 	span := tracer.newRootSpan("pylons.request", "pylons", "/")
 
@@ -508,6 +510,7 @@ func TestSpanError(t *testing.T) {
 func TestSpanError_Typed(t *testing.T) {
 	assert := assert.New(t)
 	tracer := newTracer(withTransport(newDefaultTransport()))
+	internal.SetGlobalTracer(tracer)
 	defer tracer.Stop()
 	span := tracer.newRootSpan("pylons.request", "pylons", "/")
 
@@ -523,6 +526,7 @@ func TestSpanError_Typed(t *testing.T) {
 func TestSpanErrorNil(t *testing.T) {
 	assert := assert.New(t)
 	tracer := newTracer(withTransport(newDefaultTransport()))
+	internal.SetGlobalTracer(tracer)
 	defer tracer.Stop()
 	span := tracer.newRootSpan("pylons.request", "pylons", "/")
 

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -444,6 +444,8 @@ func (t *trace) finishedOne(s *span) {
 			leftoverSpans = append(leftoverSpans, s2)
 		}
 	}
+	// TODO(partialFlush): This isn't going to work if the root span hasn't
+	// finished yet. (And in fact can panic in some situations, as repro'd by TestSpanTracePushSeveral)
 	finishedSpans[0].setMetric(keySamplingPriority, *t.priority)
 	if s != t.spans[0] {
 		// Make sure the first span in the chunk has the trace-level tags

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -410,7 +410,6 @@ func (t *trace) finishedOne(s *span) {
 		t.root.setMetric(keySamplingPriority, *t.priority)
 		t.locked = true
 	}
-
 	if len(t.spans) > 0 && s == t.spans[0] {
 		// first span in chunk finished, lock down the tags
 		//

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -384,6 +384,7 @@ func (t *trace) setTraceTags(s *span) {
 func (t *trace) finishedOne(s *span) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	s.finished = true
 	if t.full {
 		// capacity has been reached, the buffer is no longer tracking
 		// all the spans in the trace, so the below conditions will not

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -394,8 +394,6 @@ func (t *trace) finishedOne(s *span) {
 		// all the spans in the trace, so the below conditions will not
 		// be accurate and would trigger a pre-mature flush, exposing us
 		// to a race condition where spans can be modified while flushing.
-		//
-		// TODO(partialFlush): should we do a partial flush in this scenario?
 		return
 	}
 	t.finished++

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -52,6 +52,15 @@ func TestNewSpanContextPushError(t *testing.T) {
 }
 
 func TestAsyncSpanRace(t *testing.T) {
+	testAsyncSpanRace(t)
+}
+
+func TestAsyncSpanRacePartialFlush(t *testing.T) {
+	t.Setenv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", "1")
+	testAsyncSpanRace(t)
+}
+
+func testAsyncSpanRace(t *testing.T) {
 	// This tests a regression where asynchronously finishing spans would
 	// modify a flushing root's sampling priority.
 	_, _, _, stop := startTestTracer(t)

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -7,6 +7,7 @@ package tracer
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -154,31 +155,41 @@ func TestSpanTracePushOne(t *testing.T) {
 }
 
 func TestPartialFlush(t *testing.T) {
-	t.Setenv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", "1")
+	t.Setenv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", "2")
 	tracer, transport, flush, stop := startTestTracer(t)
 	defer stop()
 
 	root := tracer.StartSpan("root")
 	root.(*span).context.trace.setTag("someTraceTag", "someValue")
-	child := tracer.StartSpan("child", ChildOf(root.Context()))
-	child.Finish()
-
+	var children []*span
+	for i := 0; i < 3; i++ { // create 3 child spans
+		child := tracer.StartSpan(fmt.Sprintf("child%d", i), ChildOf(root.Context()))
+		children = append(children, child.(*span))
+		child.Finish()
+	}
 	flush(1)
 
 	ts := transport.Traces()
 	require.Len(t, ts, 1)
-	require.Len(t, ts[0], 1)
-	fs := ts[0][0]
-	assert.Equal(t, "someValue", fs.Meta["someTraceTag"])
-	assert.Equal(t, 1.0, fs.Metrics[keySamplingPriority])
-	comparePayloadSpans(t, child.(*span), fs)
+	require.Len(t, ts[0], 2)
+	assert.Equal(t, "someValue", ts[0][0].Meta["someTraceTag"])
+	assert.Equal(t, 1.0, ts[0][0].Metrics[keySamplingPriority])
+	assert.Empty(t, ts[0][1].Meta["someTraceTag"])              // the tag should only be on the first span in the chunk
+	assert.Equal(t, 1.0, ts[0][1].Metrics[keySamplingPriority]) // the tag should only be on the first span in the chunk
+	comparePayloadSpans(t, children[0], ts[0][0])
+	comparePayloadSpans(t, children[1], ts[0][1])
 
 	root.Finish()
 	flush(1)
 	tsRoot := transport.Traces()
 	require.Len(t, tsRoot, 1)
-	require.Len(t, tsRoot[0], 1)
+	require.Len(t, tsRoot[0], 2)
+	assert.Equal(t, "someValue", ts[0][0].Meta["someTraceTag"])
+	assert.Equal(t, 1.0, ts[0][0].Metrics[keySamplingPriority])
+	assert.Empty(t, ts[0][1].Meta["someTraceTag"])              // the tag should only be on the first span in the chunk
+	assert.Equal(t, 1.0, ts[0][1].Metrics[keySamplingPriority]) // the tag should only be on the first span in the chunk
 	comparePayloadSpans(t, root.(*span), tsRoot[0][0])
+	comparePayloadSpans(t, children[2], tsRoot[0][1])
 }
 
 func TestSpanTracePushNoFinish(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Fixes and adds to the failing `TestPartialFlush` test by ensuring that the trace-level tags are always set on the first span in the chunk, regardless of whether partial flushing is used. 

Also does some refactoring of `finishedOne` to eliminate the need for multiple defer functions.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

The refactors were done to make the code less ambiguous, since the defers had side effects that were unclear at first glance.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

Unit tests cover this.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality.
- [x] If this interacts with the agent in a new way, a system test has been added.