### PR TITLE
tracer: use DD_TRACE_PARTIAL_FLUSH_ENABLED

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -236,9 +236,7 @@ func newConfig(opts ...StartOption) *config {
 	c.profilerEndpoints = internal.BoolEnv(traceprof.EndpointEnvVar, true)
 	c.profilerHotspots = internal.BoolEnv(traceprof.CodeHotspotsEnvVar, true)
 	c.enableHostnameDetection = internal.BoolEnv("DD_CLIENT_HOSTNAME_ENABLED", true)
-	if internal.BoolEnv("DD_TRACE_PARTIAL_FLUSH_ENABLED", false) {
-		c.partialFlushEnabled = true
-	}
+	c.partialFlushEnabled = internal.BoolEnv("DD_TRACE_PARTIAL_FLUSH_ENABLED", false)
 	c.partialFlushMinSpans = internal.IntEnv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", partialFlushMinSpansDefault)
 	if c.partialFlushMinSpans <= 0 {
 		log.Warn("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS=%d is not a valid value, setting to default %d", c.partialFlushMinSpans, partialFlushMinSpansDefault)

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -239,8 +239,12 @@ func newConfig(opts ...StartOption) *config {
 	if internal.BoolEnv("DD_TRACE_PARTIAL_FLUSH_ENABLED", false) {
 		c.partialFlushEnabled = true
 		c.partialFlushMinSpans = internal.IntEnv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", partialFlushMinSpansDefault)
+		// TODO(partialFlush): add a test for the below two cases
 		if c.partialFlushMinSpans <= 0 {
 			log.Warn("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS=%d is not a valid value, setting to default %d", c.partialFlushMinSpans, partialFlushMinSpansDefault)
+			c.partialFlushMinSpans = partialFlushMinSpansDefault
+		} else if c.partialFlushMinSpans >= traceMaxSize {
+			log.Warn("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS=%d is above the max number of spans that can be kept in memory for a single trace (%d spans), so partial flushing will never trigger, setting to default %d", c.partialFlushMinSpans, traceMaxSize, partialFlushMinSpansDefault)
 			c.partialFlushMinSpans = partialFlushMinSpansDefault
 		}
 	}

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -826,6 +826,7 @@ func WithProfilerEndpoints(enabled bool) StartOption {
 // is disabled by default.
 func WithPartialFlushing(numSpans int) StartOption {
 	return func(c *config) {
+		c.partialFlushEnabled = true
 		c.partialFlushMinSpans = numSpans
 	}
 }

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -155,9 +155,14 @@ type config struct {
 	// spanAttributeSchemaVersion holds the selected DD_TRACE_SPAN_ATTRIBUTE_SCHEMA version.
 	spanAttributeSchemaVersion int
 
-	// partialFlushMinSpans the number of finished spans in a single trace to flush at. Disabled when 0.
-	// Value from DD_TRACE_PARTIAL_FLUSH_MIN_SPANS, currently defaults to 0 but may be enabled by default in the future.
+	// partialFlushMinSpans is the number of finished spans in a single trace to trigger a
+	// partial flush, or 0 if partial flushing is disabled.
+	// Value from DD_TRACE_PARTIAL_FLUSH_MIN_SPANS, default 1000.
 	partialFlushMinSpans int
+
+	// partialFlushEnabled specifices whether the tracer should enable partial flushing. Value
+	// from DD_TRACE_PARTIAL_FLUSH_ENABLED, default false.
+	partialFlushEnabled bool
 }
 
 // HasFeature reports whether feature f is enabled.
@@ -171,6 +176,9 @@ type StartOption func(*config)
 
 // maxPropagatedTagsLength limits the size of DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH to prevent HTTP 413 responses.
 const maxPropagatedTagsLength = 512
+
+// partialFlushMinSpansDefault is the default number of spans for partial flushing, if enabled.
+const partialFlushMinSpansDefault = 1000
 
 // newConfig renders the tracer configuration based on defaults, environment variables
 // and passed user opts.
@@ -228,7 +236,17 @@ func newConfig(opts ...StartOption) *config {
 	c.profilerEndpoints = internal.BoolEnv(traceprof.EndpointEnvVar, true)
 	c.profilerHotspots = internal.BoolEnv(traceprof.CodeHotspotsEnvVar, true)
 	c.enableHostnameDetection = internal.BoolEnv("DD_CLIENT_HOSTNAME_ENABLED", true)
-	c.partialFlushMinSpans = internal.IntEnv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", 0)
+	if internal.BoolEnv("DD_TRACE_PARTIAL_FLUSH_ENABLED", false) {
+		c.partialFlushEnabled = true
+		c.partialFlushMinSpans = internal.IntEnv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", partialFlushMinSpansDefault)
+		if c.partialFlushMinSpans <= 0 {
+			log.Warn("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS=%d is not a valid value, setting to default %d", c.partialFlushMinSpans, partialFlushMinSpansDefault)
+			c.partialFlushMinSpans = partialFlushMinSpansDefault
+		}
+	}
+	// TODO(partialFlush): consider logging a warning here if DD_TRACE_PARTIAL_FLUSH_MIN_SPANS
+	// is set, but DD_TRACE_PARTIAL_FLUSH_ENABLED is not true. Or just assume it should be enabled
+	// if it's explicitly set, and don't require both variables to be configured.
 
 	schemaVersionStr := os.Getenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA")
 	if v, ok := namingschema.ParseVersion(schemaVersionStr); ok {
@@ -801,8 +819,10 @@ func WithProfilerEndpoints(enabled bool) StartOption {
 // WithPartialFlushing enables flushing of partially finished traces.
 // This is done after "numSpans" have finished in a single local trace at
 // which point all finished spans in that trace will be flushed, freeing up
-// any memory they were consuming. This feature is currently disabled by
-// default but may be enabled in the future.
+// any memory they were consuming. This can also be configured by setting
+// DD_TRACE_PARTIAL_FLUSH_ENABLED to true, which will default to 1000 spans
+// unless overriden with DD_TRACE_PARTIAL_FLUSH_MIN_SPANS. Parital flushing
+// is disabled by default.
 func WithPartialFlushing(numSpans int) StartOption {
 	return func(c *config) {
 		c.partialFlushMinSpans = numSpans

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -238,17 +238,16 @@ func newConfig(opts ...StartOption) *config {
 	c.enableHostnameDetection = internal.BoolEnv("DD_CLIENT_HOSTNAME_ENABLED", true)
 	if internal.BoolEnv("DD_TRACE_PARTIAL_FLUSH_ENABLED", false) {
 		c.partialFlushEnabled = true
-		c.partialFlushMinSpans = internal.IntEnv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", partialFlushMinSpansDefault)
-		// TODO(partialFlush): add a test for the below two cases
-		if c.partialFlushMinSpans <= 0 {
-			log.Warn("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS=%d is not a valid value, setting to default %d", c.partialFlushMinSpans, partialFlushMinSpansDefault)
-			c.partialFlushMinSpans = partialFlushMinSpansDefault
-		} else if c.partialFlushMinSpans >= traceMaxSize {
-			log.Warn("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS=%d is above the max number of spans that can be kept in memory for a single trace (%d spans), so partial flushing will never trigger, setting to default %d", c.partialFlushMinSpans, traceMaxSize, partialFlushMinSpansDefault)
-			c.partialFlushMinSpans = partialFlushMinSpansDefault
-		}
 	}
-	// TODO(partialFlush): consider logging a warning here if DD_TRACE_PARTIAL_FLUSH_MIN_SPANS
+	c.partialFlushMinSpans = internal.IntEnv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", partialFlushMinSpansDefault)
+	if c.partialFlushMinSpans <= 0 {
+		log.Warn("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS=%d is not a valid value, setting to default %d", c.partialFlushMinSpans, partialFlushMinSpansDefault)
+		c.partialFlushMinSpans = partialFlushMinSpansDefault
+	} else if c.partialFlushMinSpans >= traceMaxSize {
+		log.Warn("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS=%d is above the max number of spans that can be kept in memory for a single trace (%d spans), so partial flushing will never trigger, setting to default %d", c.partialFlushMinSpans, traceMaxSize, partialFlushMinSpansDefault)
+		c.partialFlushMinSpans = partialFlushMinSpansDefault
+	}
+	// TODO(partialFlush): consider logging a warning if DD_TRACE_PARTIAL_FLUSH_MIN_SPANS
 	// is set, but DD_TRACE_PARTIAL_FLUSH_ENABLED is not true. Or just assume it should be enabled
 	// if it's explicitly set, and don't require both variables to be configured.
 

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -1002,4 +1002,5 @@ func TestPartialFlushing(t *testing.T) {
 		assert.True(t, c.partialFlushEnabled)
 		assert.Equal(t, 10, c.partialFlushMinSpans)
 	})
+	// TODO: add tests here for WithPartialFlush
 }

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -1002,5 +1002,10 @@ func TestPartialFlushing(t *testing.T) {
 		assert.True(t, c.partialFlushEnabled)
 		assert.Equal(t, 10, c.partialFlushMinSpans)
 	})
-	// TODO: add tests here for WithPartialFlush
+	t.Run("WithPartialFlushOption", func(t *testing.T) {
+		c := newConfig()
+		WithPartialFlushing(20)(c)
+		assert.True(t, c.partialFlushEnabled)
+		assert.Equal(t, 20, c.partialFlushMinSpans)
+	})
 }

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -970,3 +970,36 @@ func TestHostnameDisabled(t *testing.T) {
 		assert.False(t, c.enableHostnameDetection)
 	})
 }
+
+func TestPartialFlushing(t *testing.T) {
+	t.Run("None", func(t *testing.T) {
+		c := newConfig()
+		assert.False(t, c.partialFlushEnabled)
+		assert.Equal(t, partialFlushMinSpansDefault, c.partialFlushMinSpans)
+	})
+	t.Run("Disabled-DefaultMinSpans", func(t *testing.T) {
+		t.Setenv("DD_TRACE_PARTIAL_FLUSH_ENABLED", "false")
+		c := newConfig()
+		assert.False(t, c.partialFlushEnabled)
+		assert.Equal(t, partialFlushMinSpansDefault, c.partialFlushMinSpans)
+	})
+	t.Run("Default-SetMinSpans", func(t *testing.T) {
+		t.Setenv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", "10")
+		c := newConfig()
+		assert.False(t, c.partialFlushEnabled)
+		assert.Equal(t, 10, c.partialFlushMinSpans)
+	})
+	t.Run("Enabled-DefaultMinSpans", func(t *testing.T) {
+		t.Setenv("DD_TRACE_PARTIAL_FLUSH_ENABLED", "true")
+		c := newConfig()
+		assert.True(t, c.partialFlushEnabled)
+		assert.Equal(t, partialFlushMinSpansDefault, c.partialFlushMinSpans)
+	})
+	t.Run("Enabled-SetMinSpans", func(t *testing.T) {
+		t.Setenv("DD_TRACE_PARTIAL_FLUSH_ENABLED", "true")
+		t.Setenv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", "10")
+		c := newConfig()
+		assert.True(t, c.partialFlushEnabled)
+		assert.Equal(t, 10, c.partialFlushMinSpans)
+	})
+}

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -514,7 +514,6 @@ func TestSpanError(t *testing.T) {
 func TestSpanError_Typed(t *testing.T) {
 	assert := assert.New(t)
 	tracer := newTracer(withTransport(newDefaultTransport()))
-	internal.SetGlobalTracer(tracer)
 	defer tracer.Stop()
 	span := tracer.newRootSpan("pylons.request", "pylons", "/")
 

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -514,6 +514,7 @@ func TestSpanError(t *testing.T) {
 func TestSpanError_Typed(t *testing.T) {
 	assert := assert.New(t)
 	tracer := newTracer(withTransport(newDefaultTransport()))
+	internal.SetGlobalTracer(tracer)
 	defer tracer.Stop()
 	span := tracer.newRootSpan("pylons.request", "pylons", "/")
 

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -444,6 +444,8 @@ func (t *trace) finishedOne(s *span) {
 			leftoverSpans = append(leftoverSpans, s2)
 		}
 	}
+	// TODO(partialFlush): This isn't going to work if the root span hasn't
+	// finished yet. (And in fact can panic in some situations, as repro'd by TestSpanTracePushSeveral)
 	finishedSpans[0].setMetric(keySamplingPriority, *t.priority)
 	if s != t.spans[0] {
 		// Make sure the first span in the chunk has the trace-level tags

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -410,7 +410,6 @@ func (t *trace) finishedOne(s *span) {
 		t.root.setMetric(keySamplingPriority, *t.priority)
 		t.locked = true
 	}
-
 	if len(t.spans) > 0 && s == t.spans[0] {
 		// first span in chunk finished, lock down the tags
 		//

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -429,7 +429,7 @@ func (t *trace) finishedOne(s *span) {
 		return
 	}
 
-	doPartialFlush := t.finished >= tr.config.partialFlushMinSpans
+	doPartialFlush := tr.config.partialFlushEnabled && t.finished >= tr.config.partialFlushMinSpans
 	if !doPartialFlush {
 		return // The trace hasn't completed and partial flushing will not occur
 	}

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -394,6 +394,8 @@ func (t *trace) finishedOne(s *span) {
 		// all the spans in the trace, so the below conditions will not
 		// be accurate and would trigger a pre-mature flush, exposing us
 		// to a race condition where spans can be modified while flushing.
+		//
+		// TODO(partialFlush): should we do a partial flush in this scenario?
 		return
 	}
 	t.finished++
@@ -408,6 +410,7 @@ func (t *trace) finishedOne(s *span) {
 		t.root.setMetric(keySamplingPriority, *t.priority)
 		t.locked = true
 	}
+
 	if len(t.spans) > 0 && s == t.spans[0] {
 		// first span in chunk finished, lock down the tags
 		//
@@ -441,8 +444,6 @@ func (t *trace) finishedOne(s *span) {
 			leftoverSpans = append(leftoverSpans, s2)
 		}
 	}
-	// TODO(partialFlush): This isn't going to work if the root span hasn't
-	// finished yet. (And in fact can panic in some situations, as repro'd by TestSpanTracePushSeveral)
 	finishedSpans[0].setMetric(keySamplingPriority, *t.priority)
 	if s != t.spans[0] {
 		// Make sure the first span in the chunk has the trace-level tags

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -57,6 +57,7 @@ func TestAsyncSpanRace(t *testing.T) {
 }
 
 func TestAsyncSpanRacePartialFlush(t *testing.T) {
+	t.Setenv("DD_TRACE_PARTIAL_FLUSH_ENABLED", "true")
 	t.Setenv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", "1")
 	testAsyncSpanRace(t)
 }

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -155,6 +155,7 @@ func TestSpanTracePushOne(t *testing.T) {
 }
 
 func TestPartialFlush(t *testing.T) {
+	t.Setenv("DD_TRACE_PARTIAL_FLUSH_ENABLED", "true")
 	t.Setenv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", "2")
 	tracer, transport, flush, stop := startTestTracer(t)
 	defer stop()

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -250,6 +250,11 @@ func newUnstartedTracer(opts ...StartOption) *tracer {
 	return t
 }
 
+// newTracer creates a new no-op tracer for testing.
+// NOTE: This function does NOT set the global tracer, which is required for
+// most finish span/flushing operations to work as expected. If you are calling
+// span.Finish and/or expecting flushing to work, you must call
+// internal.SetGlobalTracer(...) with the tracer provided by this function.
 func newTracer(opts ...StartOption) *tracer {
 	t := newUnstartedTracer(opts...)
 	c := t.config

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1045,6 +1045,7 @@ func testNewSpanChild(t *testing.T, is128 bool) {
 
 		// the tracer must create child spans
 		tracer := newTracer(withTransport(newDefaultTransport()))
+		internal.SetGlobalTracer(tracer)
 		defer tracer.Stop()
 		parent := tracer.newRootSpan("pylons.request", "pylons", "/")
 		child := tracer.newChildSpan("redis.command", parent)
@@ -2244,6 +2245,7 @@ func TestUserMonitoring(t *testing.T) {
 	}
 	tr := newTracer()
 	defer tr.Stop()
+	internal.SetGlobalTracer(tr)
 
 	t.Run("root", func(t *testing.T) {
 		s := tr.newRootSpan("root", "test", "test")

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -706,6 +706,7 @@ func TestTracerStartSpanOptions(t *testing.T) {
 
 func TestTracerStartSpanOptions128(t *testing.T) {
 	tracer := newTracer()
+	internal.SetGlobalTracer(tracer)
 	defer tracer.Stop()
 	assert := assert.New(t)
 	t.Run("64-bit-trace-id", func(t *testing.T) {
@@ -1889,6 +1890,7 @@ func BenchmarkConcurrentTracing(b *testing.B) {
 // while partial flushing is enabled.
 func BenchmarkPartialFlushing(b *testing.B) {
 	b.Run("Enabled", func(b *testing.B) {
+		b.Setenv("DD_TRACE_PARTIAL_FLUSH_ENABLED", "true")
 		b.Setenv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", "500")
 		genBigTraces(b)
 	})


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Requires `DD_TRACE_PARTIAL_FLUSH_ENABLED` to be "true" in order to enable partial flushing. This changes the behavior where previously if a customer set `DD_TRACE_PARTIAL_FLUSH_MIN_SPANS` it would automatically assume that partial flushing was enabled.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

There are pros and cons to this approach. The benefit is that now a customer can just set `DD_TRACE_PARTIAL_FLUSH_ENABLED` and it will automatically use a default number of spans, so a customer doesn't have to decide on a reasonable default in order to use partial flushing. It also makes it very clear when it's enabled and disabled.
The downside is that a customer could be confused if they set `DD_TRACE_PARTIAL_FLUSH_MIN_SPANS` and partial flushing doesn't actually occur. We could get around this in a few ways. One approach would be to log a warning if `DD_TRACE_PARTIAL_FLUSH_MIN_SPANS` is set, but `DD_TRACE_PARTIAL_FLUSH_ENABLED` is either false or not set (this PR adds a TODO to consider that). Another approach would be to assume that if `DD_TRACE_PARTIAL_FLUSH_MIN_SPANS` is set, that partial flushing should be considered enabled unless `DD_TRACE_PARTIAL_FLUSH_ENABLED` is explicitly set to false. This creates some implied behavior, and might be a bit tougher to document, but could make for a better UX. In this PR, neither of those approaches are taken.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

Covered by unit tests

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.