### PR TITLE
internal/appsec: make blocking response configurable

### DIFF
--- a/internal/appsec/remoteconfig.go
+++ b/internal/appsec/remoteconfig.go
@@ -61,6 +61,9 @@ func combineRCRulesUpdates(r *rulesManager, updates map[string]remoteconfig.Prod
 updateLoop:
 	// Process rules related updates
 	for p, u := range updates {
+		if u != nil && len(u) == 0 {
+			continue
+		}
 		switch p {
 		case rc.ProductASMData:
 			// Merge all rules data entries together and store them as a rulesManager edit entry
@@ -371,6 +374,7 @@ func (a *appsec) enableRCBlocking() {
 		a.registerRCCapability(remoteconfig.ASMDDRules)
 		a.registerRCCapability(remoteconfig.ASMExclusions)
 		a.registerRCCapability(remoteconfig.ASMCustomRules)
+		a.registerRCCapability(remoteconfig.ASMCustomBlockingResponse)
 	}
 }
 

--- a/internal/appsec/remoteconfig_test.go
+++ b/internal/appsec/remoteconfig_test.go
@@ -376,6 +376,7 @@ func TestCapabilities(t *testing.T) {
 			expected: []remoteconfig.Capability{
 				remoteconfig.ASMRequestBlocking, remoteconfig.ASMUserBlocking, remoteconfig.ASMExclusions,
 				remoteconfig.ASMDDRules, remoteconfig.ASMIPBlocking, remoteconfig.ASMCustomRules,
+				remoteconfig.ASMCustomBlockingResponse,
 			},
 		},
 		{

--- a/internal/appsec/rules_manager.go
+++ b/internal/appsec/rules_manager.go
@@ -70,7 +70,8 @@ type (
 		Parameters struct {
 			StatusCode     int    `json:"status_code"`
 			GRPCStatusCode int    `json:"grpc_status_code,omitempty"`
-			StrParam       string `json:"-"`
+			Type           string `json:"type,omitempty"`
+			Location       string `json:"location,omitempty"`
 		} `json:"parameters,omitempty"`
 	}
 )
@@ -179,7 +180,6 @@ func (r *rulesManager) compile() {
 		r.latest.Actions = append(r.latest.Actions, v.Actions...)
 		r.latest.RulesData = append(r.latest.RulesData, v.RulesData...)
 		r.latest.CustomRules = append(r.latest.CustomRules, v.CustomRules...)
-		// TODO (Francois): process more fields once we expose the adequate capabilities (custom actions, custom rules, etc...)
 	}
 }
 

--- a/internal/appsec/waf.go
+++ b/internal/appsec/waf.go
@@ -46,17 +46,6 @@ type wafHandle struct {
 	actions map[string]*sharedsec.Action
 }
 
-// RegisterAction registers a specific action to the handler. If the action kind is unknown
-// the action will not be registered
-func (h *wafHandle) RegisterAction(id string, a *sharedsec.Action) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	if h.actions == nil {
-		h.actions = make(map[string]*sharedsec.Action)
-	}
-	h.actions[id] = a
-}
-
 func (a *appsec) swapWAF(rules rulesFragment) (err error) {
 	// Instantiate a new WAF handle and verify its state
 	newHandle, err := newWAFHandle(rules, a.cfg)
@@ -104,9 +93,9 @@ func (a *appsec) swapWAF(rules rulesFragment) (err error) {
 func actionFromEntry(e *actionEntry) *sharedsec.Action {
 	switch e.Type {
 	case "block_request":
-		return sharedsec.NewBlockRequestAction(e.Parameters.StatusCode, e.Parameters.GRPCStatusCode, e.Parameters.StrParam)
+		return sharedsec.NewBlockRequestAction(e.Parameters.StatusCode, e.Parameters.GRPCStatusCode, e.Parameters.Type)
 	case "redirect_request":
-		return sharedsec.NewRedirectRequestAction(e.Parameters.StatusCode, e.Parameters.StrParam)
+		return sharedsec.NewRedirectRequestAction(e.Parameters.StatusCode, e.Parameters.Location)
 	default:
 		return nil
 	}

--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -51,6 +51,8 @@ const (
 	ASMUserBlocking
 	// ASMCustomRules represents the capability for ASM to receive and use user-defined security rules
 	ASMCustomRules
+	// ASMCustomRules represents the capability for ASM to receive and use user-defined blocking responses
+	ASMCustomBlockingResponse
 )
 
 // ProductUpdate represents an update for a specific product.


### PR DESCRIPTION
### What does this PR do?

This change:

- fixes a bug in RC updates processing where empty updates would override existing configs instead
of being ignore
- makes appsec export the custom blocking response RC capability
- updates the json representation of action entries to account for custom actions

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.