### PR TITLE
ddtrace/tracer: Fix TestSpanTracePushSeveral

### DIFF
--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -176,19 +176,19 @@ func TestSpanTracePushSeveral(t *testing.T) {
 
 	assert := assert.New(t)
 
-	_, transport, flush, stop := startTestTracer(t)
+	trc, transport, flush, stop := startTestTracer(t)
 	defer stop()
 	buffer := newTrace()
 	assert.NotNil(buffer)
 	assert.Len(buffer.spans, 0)
 
 	traceID := random.Uint64()
-	root := newSpan("name1", "a-service", "a-resource", traceID, traceID, 0)
-	span2 := newSpan("name2", "a-service", "a-resource", random.Uint64(), traceID, root.SpanID)
-	span3 := newSpan("name3", "a-service", "a-resource", random.Uint64(), traceID, root.SpanID)
-	span3a := newSpan("name3", "a-service", "a-resource", random.Uint64(), traceID, span3.SpanID)
+	root := trc.StartSpan("name1", WithSpanID(traceID))
+	span2 := trc.StartSpan("name2", ChildOf(root.Context()))
+	span3 := trc.StartSpan("name3", ChildOf(root.Context()))
+	span3a := trc.StartSpan("name3", ChildOf(span3.Context()))
 
-	trace := []*span{root, span2, span3, span3a}
+	trace := []*span{root.(*span), span2.(*span), span3.(*span), span3a.(*span)}
 
 	for i, span := range trace {
 		span.context.trace = buffer


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Start spans in this test instead of creating them manually.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
While working on partial flushing this test failed in weird and interesting ways because it calls finish on spans that never actually started. To avoid this, this PR actually calls start span instead of relying on the weird test function that allows creating a span directly.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes
the test should continue to pass
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.