### PR TITLE
ddtrace/opentelemetry: improve TestSpanContextWithStartOptions

### DIFF
--- a/ddtrace/opentelemetry/span_test.go
+++ b/ddtrace/opentelemetry/span_test.go
@@ -242,6 +242,7 @@ func TestSpanContextWithStartOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
+	assert.Contains(p, "},{") // check that there are two spans in the payload
 	assert.Contains(p, "persisted_ctx_rsc")
 	assert.Contains(p, "persisted_srv")
 	assert.Contains(p, `"type":"producer"`)

--- a/ddtrace/opentelemetry/span_test.go
+++ b/ddtrace/opentelemetry/span_test.go
@@ -242,7 +242,9 @@ func TestSpanContextWithStartOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	assert.Contains(p, "},{") // check that there are two spans in the payload
+	if strings.Count(p, "span_id") != 2 {
+		t.Fatalf("payload does not contain two spans\n%s", p)
+	}
 	assert.Contains(p, "persisted_ctx_rsc")
 	assert.Contains(p, "persisted_srv")
 	assert.Contains(p, `"type":"producer"`)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Adds a check to the `TestSpanContextWithStartOptions` OTel test which verifies that the payload contains two spans.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

This test started failing while we were implementing partial flushing. We found that partial flushing was being triggered when it shouldn't have been, which led to the payload at the end only containing a single span, instead of 2 spans as would be expected. It took longer than necessary to realize that's why the test was failing though, so this just makes it easier to spot the root cause if this test fails in that way again.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.