### PR TITLE
ddtrace/tracer: Set Priority on rate dropped spans

### DIFF
--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -431,7 +431,7 @@ func (t *trace) finishedOne(s *span) {
 		return // The trace hasn't completed and partial flushing will not occur
 	}
 	log.Debug("Partial flush triggered with %d finished spans", t.finished)
-	//TODO: is there a metric we should bump when doing this?
+	// TODO: is there a metric we should bump when doing this?
 	finishedSpans := make([]*span, 0, t.finished)
 	leftoverSpans := make([]*span, 0, len(t.spans)-t.finished)
 	for _, s2 := range t.spans {

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -441,8 +441,6 @@ func (t *trace) finishedOne(s *span) {
 			leftoverSpans = append(leftoverSpans, s2)
 		}
 	}
-	// TODO(partialFlush): This isn't going to work if the root span hasn't
-	// finished yet. (And in fact can panic in some situations, as repro'd by TestSpanTracePushSeveral)
 	finishedSpans[0].setMetric(keySamplingPriority, *t.priority)
 	if s != t.spans[0] {
 		// Make sure the first span in the chunk has the trace-level tags

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -156,40 +156,58 @@ func TestSpanTracePushOne(t *testing.T) {
 
 func TestPartialFlush(t *testing.T) {
 	t.Setenv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", "2")
-	tracer, transport, flush, stop := startTestTracer(t)
-	defer stop()
+	t.Run("WithFlush", func(t *testing.T) {
+		tracer, transport, flush, stop := startTestTracer(t)
+		defer stop()
 
-	root := tracer.StartSpan("root")
-	root.(*span).context.trace.setTag("someTraceTag", "someValue")
-	var children []*span
-	for i := 0; i < 3; i++ { // create 3 child spans
-		child := tracer.StartSpan(fmt.Sprintf("child%d", i), ChildOf(root.Context()))
-		children = append(children, child.(*span))
-		child.Finish()
-	}
-	flush(1)
+		root := tracer.StartSpan("root")
+		root.(*span).context.trace.setTag("someTraceTag", "someValue")
+		var children []*span
+		for i := 0; i < 3; i++ { // create 3 child spans
+			child := tracer.StartSpan(fmt.Sprintf("child%d", i), ChildOf(root.Context()))
+			children = append(children, child.(*span))
+			child.Finish()
+		}
+		flush(1)
 
-	ts := transport.Traces()
-	require.Len(t, ts, 1)
-	require.Len(t, ts[0], 2)
-	assert.Equal(t, "someValue", ts[0][0].Meta["someTraceTag"])
-	assert.Equal(t, 1.0, ts[0][0].Metrics[keySamplingPriority])
-	assert.Empty(t, ts[0][1].Meta["someTraceTag"])              // the tag should only be on the first span in the chunk
-	assert.Equal(t, 1.0, ts[0][1].Metrics[keySamplingPriority]) // the tag should only be on the first span in the chunk
-	comparePayloadSpans(t, children[0], ts[0][0])
-	comparePayloadSpans(t, children[1], ts[0][1])
+		ts := transport.Traces()
+		require.Len(t, ts, 1)
+		require.Len(t, ts[0], 2)
+		assert.Equal(t, "someValue", ts[0][0].Meta["someTraceTag"])
+		assert.Equal(t, 1.0, ts[0][0].Metrics[keySamplingPriority])
+		assert.Empty(t, ts[0][1].Meta["someTraceTag"])              // the tag should only be on the first span in the chunk
+		assert.Equal(t, 1.0, ts[0][1].Metrics[keySamplingPriority]) // the tag should only be on the first span in the chunk
+		comparePayloadSpans(t, children[0], ts[0][0])
+		comparePayloadSpans(t, children[1], ts[0][1])
 
-	root.Finish()
-	flush(1)
-	tsRoot := transport.Traces()
-	require.Len(t, tsRoot, 1)
-	require.Len(t, tsRoot[0], 2)
-	assert.Equal(t, "someValue", ts[0][0].Meta["someTraceTag"])
-	assert.Equal(t, 1.0, ts[0][0].Metrics[keySamplingPriority])
-	assert.Empty(t, ts[0][1].Meta["someTraceTag"])              // the tag should only be on the first span in the chunk
-	assert.Equal(t, 1.0, ts[0][1].Metrics[keySamplingPriority]) // the tag should only be on the first span in the chunk
-	comparePayloadSpans(t, root.(*span), tsRoot[0][0])
-	comparePayloadSpans(t, children[2], tsRoot[0][1])
+		root.Finish()
+		flush(1)
+		tsRoot := transport.Traces()
+		require.Len(t, tsRoot, 1)
+		require.Len(t, tsRoot[0], 2)
+		assert.Equal(t, "someValue", ts[0][0].Meta["someTraceTag"])
+		assert.Equal(t, 1.0, ts[0][0].Metrics[keySamplingPriority])
+		assert.Empty(t, ts[0][1].Meta["someTraceTag"])              // the tag should only be on the first span in the chunk
+		assert.Equal(t, 1.0, ts[0][1].Metrics[keySamplingPriority]) // the tag should only be on the first span in the chunk
+		comparePayloadSpans(t, root.(*span), tsRoot[0][0])
+		comparePayloadSpans(t, children[2], tsRoot[0][1])
+	})
+
+	// This test covers an issue where partial flushing + a rate sampler would panic
+	t.Run("WithRateSamplerNoPanic", func(t *testing.T) {
+		tracer, _, _, stop := startTestTracer(t, WithSampler(NewRateSampler(0.000001)))
+		defer stop()
+
+		root := tracer.StartSpan("root")
+		root.(*span).context.trace.setTag("someTraceTag", "someValue")
+		var children []*span
+		for i := 0; i < 10; i++ { // create 10 child spans to ensure some aren't sampled
+			child := tracer.StartSpan(fmt.Sprintf("child%d", i), ChildOf(root.Context()))
+			children = append(children, child.(*span))
+			child.Finish()
+		}
+	})
+
 }
 
 func TestSpanTracePushNoFinish(t *testing.T) {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
@@ -413,6 +415,9 @@ func TestSamplingDecision(t *testing.T) {
 		span := tracer.StartSpan("name_1").(*span)
 		child := tracer.StartSpan("name_2", ChildOf(span.context))
 		child.SetTag(ext.EventSampleRate, 1)
+		p, ok := span.context.samplingPriority()
+		require.True(t, ok)
+		assert.Equal(t, ext.PriorityAutoReject, p)
 		child.Finish()
 		span.Finish()
 		assert.Equal(t, float64(ext.PriorityAutoReject), span.Metrics[keySamplingPriority])

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -13,7 +13,7 @@ import (
 // Tag specifies the current release tag. It needs to be manually
 // updated. A test checks that the value of Tag never points to a
 // git tag that is older than HEAD.
-const Tag = "v1.52.0"
+const Tag = "v1.53.0"
 
 // Dissected version number. Filled during init()
 var (


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Set the sampling priority of dropped spans by the tracer rate sampler. Previously an unset priority would cause the new partial flushing code to panic as it expected that a sampling decision would have already been made (and therefore that `trace.SamplingPriority` would be non-nil.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Not panic
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes
Unit tests :) 
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.