### PR TITLE
Faster CI: Use Larger Runners

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,7 +11,8 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on:
+      group: "APM Larger Runners"
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,8 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on:
-      group: "APM Larger Runners"
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -18,7 +18,8 @@ on:
 jobs:
   parametric-tests:
     if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'DataDog/dd-trace-go')
-    runs-on: ubuntu-latest
+    runs-on:
+      group: "APM Larger Runners"
     env:
       COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }} 
     steps:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -24,8 +24,9 @@ on:
 jobs:
   system-tests:
     if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'DataDog/dd-trace-go')
-    runs-on:
-      group: "APM Larger Runners"
+    # Note: Not using large runners because the jobs spawned by this pipeline
+    # don't seem to get a noticable speedup from using larger runners.
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         weblog-variant:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -24,7 +24,8 @@ on:
 jobs:
   system-tests:
     if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'DataDog/dd-trace-go')
-    runs-on: ubuntu-latest
+    runs-on:
+      group: "APM Larger Runners"
     strategy:
       matrix:
         weblog-variant:

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -37,7 +37,8 @@ jobs:
           reporter: github-pr-review
 
   test-core:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: "APM Larger Runners"
     env:
        TEST_RESULTS: /tmp/test-results # path to where test results will be saved
        INTEGRATION: true
@@ -89,7 +90,8 @@ jobs:
         run: bash <(curl -s https://codecov.io/bash)
 
   test-contrib:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: "APM Larger Runners"
     env:
        TEST_RESULTS: /tmp/test-results # path to where test results will be saved
        INTEGRATION: true

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -20,6 +20,7 @@ jobs:
           go run checkcopyright.go
 
   lint:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v4
         with:

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -20,8 +20,6 @@ jobs:
           go run checkcopyright.go
 
   lint:
-    runs-on:
-      group: "APM Larger Runners"
     steps:
       - uses: actions/setup-go@v4
         with:
@@ -36,59 +34,6 @@ jobs:
           golangci_lint_version: v1.52.2
           fail_on_error: true
           reporter: github-pr-review
-
-  test-core:
-    runs-on:
-      group: "APM Larger Runners"
-    env:
-       TEST_RESULTS: /tmp/test-results # path to where test results will be saved
-       INTEGRATION: true
-    services:
-      datadog-agent:
-        image: datadog/agent:latest
-        env:
-          DD_HOSTNAME: "github-actions-worker"
-          DD_APM_ENABLED: true
-          DD_BIND_HOST: "0.0.0.0"
-          DD_API_KEY: "invalid_key_but_this_is_fine"
-        # We need to specify a custom health-check. By default, this container will remain "unhealthy" since
-        # we don't fully configure it with a valid API key (and possibly other reasons)
-        # This command just checks for our ability to connect to port 8126
-        options: >-
-          --health-cmd "bash -c '</dev/tcp/127.0.0.1/8126'"
-        ports:
-          - 8125:8125/udp
-          - 8126:8126
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          repository: 'DataDog/dd-trace-go'
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ inputs.go-version }}
-          check-latest: true
-          cache: true
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@latest
-      - name: Test Core
-        run: |
-            mkdir -p $TEST_RESULTS
-            PACKAGE_NAMES=$(go list ./... | grep -v /contrib/)
-            gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- $PACKAGE_NAMES -v -race -coverprofile=coverage.txt -covermode=atomic
-
-      - name: Upload the results to Datadog CI App
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/dd-ci-upload
-        with:
-          dd-api-key: ${{ secrets.DD_CI_API_KEY }}
-          files: ${{ env.TEST_RESULTS }}/gotestsum-report.xml
-          tags: go:${{ inputs.go-version }}},arch:${{ runner.arch }},os:${{ runner.os }},distribution:${{ runner.distribution }}
-      - name: Upload Coverage
-        if: always()
-        shell: bash
-        run: bash <(curl -s https://codecov.io/bash)
 
   test-contrib:
     runs-on:
@@ -267,3 +212,56 @@ jobs:
               git fetch origin && git checkout v1.0.0 && cd ../..
 
               go test -mod=vendor -v ./contrib/google.golang.org/grpc.v12/...
+
+  test-core:
+    runs-on:
+      group: "APM Larger Runners"
+    env:
+       TEST_RESULTS: /tmp/test-results # path to where test results will be saved
+       INTEGRATION: true
+    services:
+      datadog-agent:
+        image: datadog/agent:latest
+        env:
+          DD_HOSTNAME: "github-actions-worker"
+          DD_APM_ENABLED: true
+          DD_BIND_HOST: "0.0.0.0"
+          DD_API_KEY: "invalid_key_but_this_is_fine"
+        # We need to specify a custom health-check. By default, this container will remain "unhealthy" since
+        # we don't fully configure it with a valid API key (and possibly other reasons)
+        # This command just checks for our ability to connect to port 8126
+        options: >-
+          --health-cmd "bash -c '</dev/tcp/127.0.0.1/8126'"
+        ports:
+          - 8125:8125/udp
+          - 8126:8126
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: 'DataDog/dd-trace-go'
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ inputs.go-version }}
+          check-latest: true
+          cache: true
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+      - name: Test Core
+        run: |
+            mkdir -p $TEST_RESULTS
+            PACKAGE_NAMES=$(go list ./... | grep -v /contrib/)
+            gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- $PACKAGE_NAMES -v -race -coverprofile=coverage.txt -covermode=atomic
+
+      - name: Upload the results to Datadog CI App
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/dd-ci-upload
+        with:
+          dd-api-key: ${{ secrets.DD_CI_API_KEY }}
+          files: ${{ env.TEST_RESULTS }}/gotestsum-report.xml
+          tags: go:${{ inputs.go-version }}},arch:${{ runner.arch }},os:${{ runner.os }},distribution:${{ runner.distribution }}
+      - name: Upload Coverage
+        if: always()
+        shell: bash
+        run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -20,7 +20,8 @@ jobs:
           go run checkcopyright.go
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: "APM Larger Runners"
     steps:
       - uses: actions/setup-go@v4
         with:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

1. Use large runners for the `test-core`, `test-contrib` and `parametric-tests` CI jobs.
2. Enqueue `test-contrib` before `test-core` by relocating it in the YAML file.
3. Add a comment indicating that using large runners for "System Tests" didn't provide a noticeable benefit. We'll have to investigate other approaches for speeding up that pipeline.

As a result median CI time should be reduced from ~13.5 minutes to ~7.5 minutes (rough guess based on a few runs). We'll have to wait for a couple weeks before we can analyze the new P95 latency (I don't feel like writing a script to trigger hundreds of CI jobs now 😅).

<table>
<tr>
	<td>Before</td>
	<td>After</td>
</tr>
<tr>
	<td>

<img width="1272" alt="CleanShot 2023-06-25 at 16 27 47@2x" src="https://github.com/DataDog/dd-trace-go/assets/15000/b824e4b9-3e74-4642-a93a-64a14cfa6e8c">


</td>
	<td>

<img width="1276" alt="CleanShot 2023-06-25 at 16 27 13@2x" src="https://github.com/DataDog/dd-trace-go/assets/15000/41ffad4a-a4c1-4da4-b45e-f856911ad50f">

</td>
</tr>
</table> 


### Motivation

Using larger runners allows our tests to run faster because we're testing many packages, and `go test` automatically builds and executes packages in parallel. The larger runners we use have 16 vCPUs vs the default of 2 vCPUs provided by GitHub.

Enqueuing `test-contrib` before `test-core` achieves optimal scheduling when our standby runner is available. In that case `test-contrib` starts executing right away, while `test-core` has to wait for another runner to spin up. But since `test-core` is much faster, it ends up finishing at roughly the same time as `test-contrib` 🥳. We could also consider assigning a large runner to our `lint` job, but based on the current timing this wouldn't provide a significant latency benefit. See example below.

<img width="1616" alt="CleanShot 2023-06-25 at 16 19 21@2x" src="https://github.com/DataDog/dd-trace-go/assets/15000/d3ef3475-7255-4118-b63e-696a60fc3723">

See internal `Faster CI for dd-trace-go 🚀` google doc for more information.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.