### PR TITLE
Faster CI: Optimize APM Parametric Tests

### DIFF
--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -47,7 +47,8 @@ jobs:
         with:
           python-version: '3.9'
 
-      - uses: actions/cache@v3
+      - name: Cache venv
+        uses: actions/cache@v3
         with:
           path: ./venv
           key: ${{ runner.os }}-venv-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -34,7 +34,7 @@ jobs:
           path: system-tests/golang
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18.7'
+          go-version: '1.18'
       - name: Patch dd-trace-go version
         run: |
           cd system-tests/utils/build/docker/golang/parametric/
@@ -55,4 +55,5 @@ jobs:
         run: |
           cd system-tests
           pip install -r requirements.txt
+          time TEST_LIBRARY=golang ./build.sh -i runner
           time TEST_LIBRARY=golang ./run.sh

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -53,6 +53,6 @@ jobs:
           pip install wheel
       - name: Run
         run: |
-          pip install -r system-tests/requirements.txt
-          cd system-tests/parametric
-          CLIENTS_ENABLED=golang ./run.sh
+          cd system-tests
+          pip install -r requirements.txt
+          time TEST_LIBRARY=golang ./run.sh

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -55,5 +55,5 @@ jobs:
         run: |
           cd system-tests
           pip install -r requirements.txt
-          time TEST_LIBRARY=golang ./build.sh -i runner
-          time TEST_LIBRARY=golang ./run.sh
+          time export TEST_LIBRARY=golang && ./build.sh -i runner
+          time export TEST_LIBRARY=golang && ./run.sh

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -18,9 +18,9 @@ on:
 jobs:
   parametric-tests:
     if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'DataDog/dd-trace-go')
-    runs-on: ubuntu-latest
+    runs-on:
+      group: "APM Larger Runners"
     env:
-      COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }} 
       TEST_LIBRARY: golang
     steps:
       - name: Checkout system tests

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -39,8 +39,9 @@ jobs:
 
       - name: Patch dd-trace-go version
         run: |
+          ddtg="$(pwd)/dd-trace-go"
           cd utils/build/docker/golang/parametric/
-          echo "replace gopkg.in/DataDog/dd-trace-go.v1 => $(pwd)/dd-trace-go" >> go.mod
+          echo "replace gopkg.in/DataDog/dd-trace-go.v1 => ${ddtg}" >> go.mod
           go mod tidy
 
       - uses: actions/setup-python@v4

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -18,8 +18,7 @@ on:
 jobs:
   parametric-tests:
     if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'DataDog/dd-trace-go')
-    runs-on:
-      group: "APM Larger Runners"
+    runs-on: ubuntu-latest
     env:
       TEST_LIBRARY: golang
     steps:

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Patch dd-trace-go version
         run: |
           cd utils/build/docker/golang/parametric/
-          echo "replace gopkg.in/DataDog/dd-trace-go.v1 => ./dd-trace-go" >> go.mod
+          echo "replace gopkg.in/DataDog/dd-trace-go.v1 => $(pwd)/dd-trace-go" >> go.mod
           go mod tidy
 
       - uses: actions/setup-python@v4

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -49,7 +49,7 @@ jobs:
           python-version: '3.9'
 
       - name: Build
-        run: cd system-tests && ./build.sh -i runner
+        run: ./build.sh -i runner
 
       - name: Run
-        run: cd system-tests && ./run.sh PARAMETRIC
+        run: ./run.sh PARAMETRIC

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }} 
+      TEST_LIBRARY: golang
     steps:
       - name: Checkout system tests
         uses: actions/checkout@v3
@@ -28,32 +29,22 @@ jobs:
           repository: 'DataDog/system-tests'
           path: system-tests
 
-      - name: Checkout Go
-        uses: actions/checkout@v3
-        with:
-          path: system-tests/golang
       - uses: actions/setup-go@v3
         with:
           go-version: '1.18'
+
       - name: Patch dd-trace-go version
         run: |
           cd system-tests/utils/build/docker/golang/parametric/
           go get gopkg.in/DataDog/dd-trace-go.v1@$COMMIT_SHA
           go mod tidy
 
-      - name: Checkout Python
-        uses: actions/checkout@v3
-        with:
-          path: system-tests/python
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-      - name: Install
-        run: |
-          pip install wheel
+
+      - name: Build
+        run: cd system-tests && ./build.sh -i runner
+
       - name: Run
-        run: |
-          cd system-tests
-          pip install -r requirements.txt
-          time export TEST_LIBRARY=golang && ./build.sh -i runner
-          time export TEST_LIBRARY=golang && ./run.sh
+        run: cd system-tests && ./run.sh PARAMETRIC

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -48,6 +48,13 @@ jobs:
         with:
           python-version: '3.9'
 
+      - uses: actions/cache@v3
+        with:
+          path: ./venv
+          key: ${{ runner.os }}-venv-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-venv-
+
       - name: Build
         run: ./build.sh -i runner
 

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -27,7 +27,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'DataDog/system-tests'
-          path: system-tests
+
+      - name: Checkout dd-trace-go
+        uses: actions/checkout@v3
+        with:
+          path: dd-trace-go
 
       - uses: actions/setup-go@v3
         with:
@@ -35,8 +39,8 @@ jobs:
 
       - name: Patch dd-trace-go version
         run: |
-          cd system-tests/utils/build/docker/golang/parametric/
-          go get gopkg.in/DataDog/dd-trace-go.v1@$COMMIT_SHA
+          cd utils/build/docker/golang/parametric/
+          echo "replace gopkg.in/DataDog/dd-trace-go.v1 => ./dd-trace-go" >> go.mod
           go mod tidy
 
       - uses: actions/setup-python@v4

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout dd-trace-go
         uses: actions/checkout@v3
         with:
-          path: dd-trace-go
+          path: utils/build/docker/golang/parametric/dd-trace-go
 
       - uses: actions/setup-go@v3
         with:
@@ -39,9 +39,8 @@ jobs:
 
       - name: Patch dd-trace-go version
         run: |
-          ddtg="$(pwd)/dd-trace-go"
           cd utils/build/docker/golang/parametric/
-          echo "replace gopkg.in/DataDog/dd-trace-go.v1 => ${ddtg}" >> go.mod
+          echo "replace gopkg.in/DataDog/dd-trace-go.v1 => ./dd-trace-go" >> go.mod
           go mod tidy
 
       - uses: actions/setup-python@v4


### PR DESCRIPTION
### What does this PR do?

1. Speed up "Patch dd-trace-go version" step from 30s to 10s by using a replace directive in go.mod instead of using `go get`.
1. Split "Run" step into "Build" and "Run" step and by moving away from the [legacy parametric/run.sh](https://github.com/DataDog/system-tests/blob/0e8f0a8bf815e522c7f033296408a7a5e81736b2/parametric/run.sh#L8) script.
1. Add "Cache venv" step to speedup build step from ~1m to ~10s 
1. Remove "Checkout Go" step that served no apparent purpose.

Together with #2068 this will allow running this pipeline as fast as [3min45s](https://github.com/DataDog/dd-trace-go/actions/runs/5371460197/jobs/9744234220) 🚀.

### Motivation

See `RFC: Faster CI for dd-trace-go 🚀` google doc.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.