### PR TITLE
tracer: discard invalid _dd.p.tid in the datadog propagator

### DIFF
--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -8,6 +8,7 @@ package tracer
 import (
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -48,13 +49,13 @@ func (t *traceID) SetUpper(i uint64) {
 	binary.BigEndian.PutUint64(t[:8], i)
 }
 
-func (t *traceID) SetUpperFromHex(s string) {
+func (t *traceID) SetUpperFromHex(s string) error {
 	u, err := strconv.ParseUint(s, 16, 64)
 	if err != nil {
-		log.Debug("Attempted to decode an invalid hex traceID %s", s)
-		return
+		return fmt.Errorf("malformed %q: %s", s, err)
 	}
 	t.SetUpper(u)
+	return nil
 }
 
 func (t *traceID) Empty() bool {

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -397,13 +397,29 @@ func (p *propagator) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 		return nil, err
 	}
 	if ctx.trace != nil {
-		// TODO: this always assumed it was valid so I copied that logic here, maybe we shouldn't
-		ctx.traceID.SetUpperFromHex(ctx.trace.propagatingTag(keyTraceID128))
+		tid := ctx.trace.propagatingTag(keyTraceID128)
+		if err := validateTID(tid); err != nil {
+			log.Debug("Invalid hex traceID: %s", err)
+			ctx.trace.unsetPropagatingTag(keyTraceID128)
+		} else if err := ctx.traceID.SetUpperFromHex(tid); err != nil {
+			log.Debug("Attempted to set an invalid hex traceID: %s", err)
+			ctx.trace.unsetPropagatingTag(keyTraceID128)
+		}
 	}
 	if ctx.traceID.Empty() || (ctx.spanID == 0 && ctx.origin != "synthetics") {
 		return nil, ErrSpanContextNotFound
 	}
 	return &ctx, nil
+}
+
+func validateTID(tid string) error {
+	if len(tid) != 16 {
+		return fmt.Errorf("invalid length: %q", tid)
+	}
+	if !validIDRgx.MatchString(tid) {
+		return fmt.Errorf("malformed: %q", tid)
+	}
+	return nil
 }
 
 // unmarshalPropagatingTags unmarshals tags from v into ctx


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

- Do not set `_dd.p.tid` in the `datadog` propagator if the value isn't valid
- Inspired by https://github.com/DataDog/dd-trace-go/pull/1969
- This doesn't cover malformed `tid` in the `tracecontext` propagator: keep sending the malformed `tid` seems to be the expected behavior in that case, based on the parametric tests
- This doesn't cover sending the optional `_dd.propagation_error` tag

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Enable test case `test_datadog_128_bit_propagation_tid_short` in parametric tests https://github.com/DataDog/system-tests/blob/main/tests/parametric/test_128_bit_traceids.py#L76

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

Unit tests + test case in parametric tests is enabled once this PR is merged

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.