### PR TITLE
CI: Simplify System Tests

### DIFF
--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -43,20 +43,8 @@ jobs:
           echo "replace gopkg.in/DataDog/dd-trace-go.v1 => ./dd-trace-go" >> go.mod
           go mod tidy
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-
-      - name: Cache venv
-        uses: actions/cache@v3
-        with:
-          path: ./venv
-          key: ${{ runner.os }}-venv-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-venv-
-
-      - name: Build
-        run: ./build.sh -i runner
+      - name: Install runner
+        uses: ./.github/actions/install_runner
 
       - name: Run
         run: ./run.sh PARAMETRIC

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -43,7 +43,7 @@ jobs:
           echo "replace gopkg.in/DataDog/dd-trace-go.v1 => ./dd-trace-go" >> go.mod
           go mod tidy
 
-      - name: Install runner
+      - name: Build runner
         uses: ./.github/actions/install_runner
 
       - name: Run

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -84,7 +84,7 @@ jobs:
     name: Test (${{ matrix.weblog-variant }}, ${{ matrix.scenario }})
     steps:
       - name: Checkout system tests
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'DataDog/system-tests'
           ref: ${{ inputs.ref }}
@@ -95,13 +95,13 @@ jobs:
           path: 'binaries/dd-trace-go'
 
       - name: Build weblog
-        uses: ./build.sh -i weblog
+        run: ./build.sh -i weblog
 
       - name: Build runner
         uses: ./.github/actions/install_runner
 
       - name: Build agent
-        uses: ./build.sh -i agent
+        run: ./build.sh -i agent
 
       - name: Run
         run: env ${{ matrix.env }} ./run.sh ${{ matrix.scenario }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -83,11 +83,6 @@ jobs:
       SYSTEM_TESTS_E2E_DD_APP_KEY: ${{ secrets.SYSTEM_TESTS_E2E_DD_APP_KEY }}
     name: Test (${{ matrix.weblog-variant }}, ${{ matrix.scenario }})
     steps:
-      - name: Setup python 3.9
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-
       - name: Checkout system tests
         uses: actions/checkout@v2
         with:
@@ -95,20 +90,18 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Checkout dd-trace-go
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: 'binaries/dd-trace-go'
 
-      - name: Cache venv
-        uses: actions/cache@v3
-        with:
-          path: ./venv
-          key: ${{ runner.os }}-venv-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-venv-
+      - name: Build weblog
+        uses: ./build.sh -i weblog
 
-      - name: Build
-        run: ./build.sh
+      - name: Build runner
+        uses: ./.github/actions/install_runner
+
+      - name: Build agent
+        uses: ./build.sh -i agent
 
       - name: Run
         run: env ${{ matrix.env }} ./run.sh ${{ matrix.scenario }}


### PR DESCRIPTION
### What does this PR do?

1. Reuse [install_runner](https://github.com/DataDog/system-tests/blob/main/.github/actions/install_runner/action.yaml) action from the system tests repo. This reduces code duplication.
1. Use explicit build steps for runner, weblog and agent. This helps debugging performance.
1. Update to checkout v3. This is just house keeping.

### Motivation

Reduce duplication and make it easier to debug performance issues.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.