### PR TITLE
contrib/emicklei/go-restful/v3: add integration for newest version

### DIFF
--- a/contrib/emicklei/go-restful/v3/example_test.go
+++ b/contrib/emicklei/go-restful/v3/example_test.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package restful_test
+
+import (
+	"io"
+	"log"
+	"net/http"
+
+	restfultrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/emicklei/go-restful/v3"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+
+	"github.com/emicklei/go-restful/v3"
+)
+
+// To start tracing requests, add the trace filter to your go-restful router.
+func Example() {
+	// create new go-restful service
+	ws := new(restful.WebService)
+
+	// create the Datadog filter
+	filter := restfultrace.FilterFunc(
+		restfultrace.WithServiceName("my-service"),
+	)
+
+	// use it
+	ws.Filter(filter)
+
+	// set endpoint
+	ws.Route(ws.GET("/hello").To(
+		func(request *restful.Request, response *restful.Response) {
+			io.WriteString(response, "world")
+		}))
+	restful.Add(ws)
+
+	// serve request
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func Example_spanFromContext() {
+	ws := new(restful.WebService)
+	ws.Filter(restfultrace.FilterFunc(
+		restfultrace.WithServiceName("my-service"),
+	))
+
+	ws.Route(ws.GET("/image/encode").To(
+		func(request *restful.Request, response *restful.Response) {
+			// create a child span to track operation timing.
+			encodeSpan, _ := tracer.StartSpanFromContext(request.Request.Context(), "image.encode")
+			// encode a image
+			encodeSpan.Finish()
+		}))
+}

--- a/contrib/emicklei/go-restful/v3/option.go
+++ b/contrib/emicklei/go-restful/v3/option.go
@@ -1,0 +1,90 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package restful
+
+import (
+	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/namingschema"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/normalizer"
+)
+
+const defaultServiceName = "go-restful"
+
+type config struct {
+	serviceName   string
+	analyticsRate float64
+	headerTags    func(string) (string, bool)
+}
+
+func newConfig() *config {
+	rate := globalconfig.AnalyticsRate()
+	if internal.BoolEnv("DD_TRACE_RESTFUL_ANALYTICS_ENABLED", false) {
+		rate = 1.0
+	}
+	serviceName := namingschema.NewDefaultServiceName(
+		defaultServiceName,
+		namingschema.WithOverrideV0(defaultServiceName),
+	).GetName()
+	return &config{
+		serviceName:   serviceName,
+		analyticsRate: rate,
+		headerTags:    globalconfig.HeaderTag,
+	}
+}
+
+// Option specifies instrumentation configuration options.
+type Option func(*config)
+
+// WithServiceName sets the service name to by used by the filter.
+func WithServiceName(name string) Option {
+	return func(cfg *config) {
+		cfg.serviceName = name
+	}
+}
+
+// WithAnalytics enables Trace Analytics for all started spans.
+func WithAnalytics(on bool) Option {
+	return func(cfg *config) {
+		if on {
+			cfg.analyticsRate = 1.0
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
+	}
+}
+
+// WithAnalyticsRate sets the sampling rate for Trace Analytics events
+// correlated to started spans.
+func WithAnalyticsRate(rate float64) Option {
+	return func(cfg *config) {
+		if rate >= 0.0 && rate <= 1.0 {
+			cfg.analyticsRate = rate
+		} else {
+			cfg.analyticsRate = math.NaN()
+		}
+	}
+}
+
+// WithHeaderTags enables the integration to attach HTTP request headers as span tags.
+// Warning:
+// Using this feature can risk exposing sensitive data such as authorization tokens to Datadog.
+// Special headers can not be sub-selected. E.g., an entire Cookie header would be transmitted, without the ability to choose specific Cookies.
+func WithHeaderTags(headers []string) Option {
+	headerAsTags := make(map[string]string)
+	for _, h := range headers {
+		header, tag := normalizer.NormalizeHeaderTag(h)
+		headerAsTags[header] = tag
+	}
+	return func(cfg *config) {
+		cfg.headerTags = func(k string) (string, bool) {
+			tag, ok := headerAsTags[k]
+			return tag, ok
+		}
+	}
+}

--- a/contrib/emicklei/go-restful/v3/restful.go
+++ b/contrib/emicklei/go-restful/v3/restful.go
@@ -19,7 +19,7 @@ import (
 	"github.com/emicklei/go-restful/v3"
 )
 
-const componentName = "emicklei/go-restful"
+const componentName = "emicklei/go-restful/v3"
 
 func init() {
 	telemetry.LoadIntegration(componentName)

--- a/contrib/emicklei/go-restful/v3/restful.go
+++ b/contrib/emicklei/go-restful/v3/restful.go
@@ -31,7 +31,7 @@ func FilterFunc(configOpts ...Option) restful.FilterFunction {
 	for _, opt := range configOpts {
 		opt(cfg)
 	}
-	log.Debug("contrib/emicklei/go-restful: Creating tracing filter: %#v", cfg)
+	log.Debug("contrib/emicklei/go-restful/v3: Creating tracing filter: %#v", cfg)
 	spanOpts := []ddtrace.StartSpanOption{tracer.ServiceName(cfg.serviceName)}
 	return func(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
 		spanOpts := append(spanOpts, tracer.ResourceName(req.SelectedRoutePath()))

--- a/contrib/emicklei/go-restful/v3/restful.go
+++ b/contrib/emicklei/go-restful/v3/restful.go
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+// Package restful provides functions to trace the emicklei/go-restful package (https://github.com/emicklei/go-restful).
+package restful
+
+import (
+	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
+
+	"github.com/emicklei/go-restful/v3"
+)
+
+const componentName = "emicklei/go-restful"
+
+func init() {
+	telemetry.LoadIntegration(componentName)
+}
+
+// FilterFunc returns a restful.FilterFunction which will automatically trace incoming request.
+func FilterFunc(configOpts ...Option) restful.FilterFunction {
+	cfg := newConfig()
+	for _, opt := range configOpts {
+		opt(cfg)
+	}
+	log.Debug("contrib/emicklei/go-restful: Creating tracing filter: %#v", cfg)
+	spanOpts := []ddtrace.StartSpanOption{tracer.ServiceName(cfg.serviceName)}
+	return func(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+		spanOpts := append(spanOpts, tracer.ResourceName(req.SelectedRoutePath()))
+		spanOpts = append(spanOpts, tracer.Tag(ext.Component, componentName))
+		spanOpts = append(spanOpts, tracer.Tag(ext.SpanKind, ext.SpanKindServer))
+
+		if !math.IsNaN(cfg.analyticsRate) {
+			spanOpts = append(spanOpts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
+		}
+		spanOpts = append(spanOpts, httptrace.HeaderTagsFromRequest(req.Request, cfg.headerTags))
+		span, ctx := httptrace.StartRequestSpan(req.Request, spanOpts...)
+		defer func() {
+			httptrace.FinishRequestSpan(span, resp.StatusCode(), tracer.WithError(resp.Error()))
+		}()
+
+		// pass the span through the request context
+		req.Request = req.Request.WithContext(ctx)
+		chain.ProcessFilter(req, resp)
+	}
+}

--- a/contrib/emicklei/go-restful/v3/restful_test.go
+++ b/contrib/emicklei/go-restful/v3/restful_test.go
@@ -159,7 +159,7 @@ func TestTrace200(t *testing.T) {
 	assert.Equal("GET", span.Tag(ext.HTTPMethod))
 	assert.Equal("http://example.com/user/123", span.Tag(ext.HTTPURL))
 	assert.Equal(ext.SpanKindServer, span.Tag(ext.SpanKind))
-	assert.Equal("emicklei/go-restful", span.Tag(ext.Component))
+	assert.Equal("emicklei/go-restful/v3", span.Tag(ext.Component))
 }
 
 func TestError(t *testing.T) {
@@ -192,7 +192,7 @@ func TestError(t *testing.T) {
 	assert.Equal("500", span.Tag(ext.HTTPCode))
 	assert.Equal(wantErr.Error(), span.Tag(ext.Error).(error).Error())
 	assert.Equal(ext.SpanKindServer, span.Tag(ext.SpanKind))
-	assert.Equal("emicklei/go-restful", span.Tag(ext.Component))
+	assert.Equal("emicklei/go-restful/v3", span.Tag(ext.Component))
 }
 
 func TestPropagation(t *testing.T) {

--- a/contrib/emicklei/go-restful/v3/restful_test.go
+++ b/contrib/emicklei/go-restful/v3/restful_test.go
@@ -146,6 +146,7 @@ func TestTrace200(t *testing.T) {
 
 	container.ServeHTTP(w, r)
 	response := w.Result()
+	defer response.Body.Close()
 	assert.Equal(response.StatusCode, 200)
 
 	spans := mt.FinishedSpans()
@@ -183,6 +184,7 @@ func TestError(t *testing.T) {
 
 	container.ServeHTTP(w, r)
 	response := w.Result()
+	defer response.Body.Close()
 	assert.Equal(response.StatusCode, 500)
 
 	spans := mt.FinishedSpans()

--- a/contrib/emicklei/go-restful/v3/restful_test.go
+++ b/contrib/emicklei/go-restful/v3/restful_test.go
@@ -1,0 +1,322 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package restful
+
+import (
+	"errors"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/namingschematest"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/namingschema"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/normalizer"
+
+	"github.com/emicklei/go-restful/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithHeaderTags(t *testing.T) {
+	setupReq := func(opts ...Option) *http.Request {
+		ws := new(restful.WebService)
+		ws.Filter(FilterFunc(opts...))
+		ws.Route(ws.GET("/test").To(func(request *restful.Request, response *restful.Response) {
+			response.Write([]byte("test"))
+		}))
+
+		container := restful.NewContainer()
+		container.Add(ws)
+
+		r := httptest.NewRequest("GET", "/test", nil)
+		r.Header.Set("h!e@a-d.e*r", "val")
+		r.Header.Add("h!e@a-d.e*r", "val2")
+		r.Header.Set("2header", "2val")
+		r.Header.Set("3header", "3val")
+		r.Header.Set("x-datadog-header", "value")
+		w := httptest.NewRecorder()
+
+		container.ServeHTTP(w, r)
+		return r
+	}
+
+	t.Run("default-off", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+		htArgs := []string{"h!e@a-d.e*r", "2header", "3header", "x-datadog-header"}
+		setupReq()
+		spans := mt.FinishedSpans()
+		assert := assert.New(t)
+		assert.Equal(len(spans), 1)
+		s := spans[0]
+		for _, arg := range htArgs {
+			_, tag := normalizer.NormalizeHeaderTag(arg)
+			assert.NotContains(s.Tags(), tag)
+		}
+	})
+
+	t.Run("integration", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		htArgs := []string{"h!e@a-d.e*r", "2header:tag"}
+		r := setupReq(WithHeaderTags(htArgs))
+		spans := mt.FinishedSpans()
+		assert := assert.New(t)
+		assert.Equal(len(spans), 1)
+		s := spans[0]
+
+		for _, arg := range htArgs {
+			header, tag := normalizer.NormalizeHeaderTag(arg)
+			assert.Equal(strings.Join(r.Header.Values(header), ","), s.Tags()[tag])
+		}
+		assert.NotContains(s.Tags(), "http.headers.x-datadog-header")
+	})
+
+	t.Run("global", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		header, tag := normalizer.NormalizeHeaderTag("3header")
+		globalconfig.SetHeaderTag(header, tag)
+		globalconfig.SetHeaderTag("other", tag)
+
+		r := setupReq()
+		spans := mt.FinishedSpans()
+		assert := assert.New(t)
+		assert.Equal(len(spans), 1)
+		s := spans[0]
+
+		assert.Equal(strings.Join(r.Header.Values(header), ","), s.Tags()[tag])
+		assert.NotContains(s.Tags(), "http.headers.x-datadog-header")
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		globalH, globalT := normalizer.NormalizeHeaderTag("3header")
+		globalconfig.SetHeaderTag(globalH, globalT)
+
+		htArgs := []string{"h!e@a-d.e*r", "2header:tag"}
+		r := setupReq(WithHeaderTags(htArgs))
+		spans := mt.FinishedSpans()
+		assert := assert.New(t)
+		assert.Equal(len(spans), 1)
+		s := spans[0]
+
+		for _, arg := range htArgs {
+			header, tag := normalizer.NormalizeHeaderTag(arg)
+			assert.Equal(strings.Join(r.Header.Values(header), ","), s.Tags()[tag])
+		}
+		assert.NotContains(s.Tags(), "http.headers.x-datadog-header")
+		assert.NotContains(s.Tags(), globalT)
+	})
+}
+
+func TestTrace200(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	ws := new(restful.WebService)
+	ws.Filter(FilterFunc(WithServiceName("my-service")))
+	ws.Route(ws.GET("/user/{id}").Param(restful.PathParameter("id", "user ID")).
+		To(func(request *restful.Request, response *restful.Response) {
+			_, ok := tracer.SpanFromContext(request.Request.Context())
+			assert.True(ok)
+			id := request.PathParameter("id")
+			response.Write([]byte(id))
+		}))
+
+	container := restful.NewContainer()
+	container.Add(ws)
+
+	r := httptest.NewRequest("GET", "/user/123", nil)
+	w := httptest.NewRecorder()
+
+	container.ServeHTTP(w, r)
+	response := w.Result()
+	assert.Equal(response.StatusCode, 200)
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 1)
+	span := spans[0]
+	assert.Equal("http.request", span.OperationName())
+	assert.Equal(ext.SpanTypeWeb, span.Tag(ext.SpanType))
+	assert.Contains(span.Tag(ext.ResourceName), "/user/{id}")
+	assert.Equal("my-service", span.Tag(ext.ServiceName))
+	assert.Equal("200", span.Tag(ext.HTTPCode))
+	assert.Equal("GET", span.Tag(ext.HTTPMethod))
+	assert.Equal("http://example.com/user/123", span.Tag(ext.HTTPURL))
+	assert.Equal(ext.SpanKindServer, span.Tag(ext.SpanKind))
+	assert.Equal("emicklei/go-restful", span.Tag(ext.Component))
+}
+
+func TestError(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	wantErr := errors.New("oh no")
+
+	ws := new(restful.WebService)
+	ws.Filter(FilterFunc())
+	ws.Route(ws.GET("/err").To(func(request *restful.Request, response *restful.Response) {
+		response.WriteError(500, wantErr)
+	}))
+
+	container := restful.NewContainer()
+	container.Add(ws)
+
+	r := httptest.NewRequest("GET", "/err", nil)
+	w := httptest.NewRecorder()
+
+	container.ServeHTTP(w, r)
+	response := w.Result()
+	assert.Equal(response.StatusCode, 500)
+
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 1)
+	span := spans[0]
+	assert.Equal("http.request", span.OperationName())
+	assert.Equal("500", span.Tag(ext.HTTPCode))
+	assert.Equal(wantErr.Error(), span.Tag(ext.Error).(error).Error())
+	assert.Equal(ext.SpanKindServer, span.Tag(ext.SpanKind))
+	assert.Equal("emicklei/go-restful", span.Tag(ext.Component))
+}
+
+func TestPropagation(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	r := httptest.NewRequest("GET", "/user/123", nil)
+	w := httptest.NewRecorder()
+
+	pspan := tracer.StartSpan("test")
+	tracer.Inject(pspan.Context(), tracer.HTTPHeadersCarrier(r.Header))
+
+	ws := new(restful.WebService)
+	ws.Filter(FilterFunc())
+	ws.Route(ws.GET("/user/{id}").To(func(request *restful.Request, response *restful.Response) {
+		span, ok := tracer.SpanFromContext(request.Request.Context())
+		assert.True(ok)
+		assert.Equal(span.(mocktracer.Span).ParentID(), pspan.(mocktracer.Span).SpanID())
+	}))
+
+	container := restful.NewContainer()
+	container.Add(ws)
+
+	container.ServeHTTP(w, r)
+}
+
+func TestAnalyticsSettings(t *testing.T) {
+	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate float64, opts ...Option) {
+		ws := new(restful.WebService)
+		ws.Filter(FilterFunc(opts...))
+		ws.Route(ws.GET("/user/{id}").To(func(request *restful.Request, response *restful.Response) {}))
+
+		container := restful.NewContainer()
+		container.Add(ws)
+		r := httptest.NewRequest("GET", "/user/123", nil)
+		w := httptest.NewRecorder()
+		container.ServeHTTP(w, r)
+
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+		s := spans[0]
+		if !math.IsNaN(rate) {
+			assert.Equal(t, rate, s.Tag(ext.EventSampleRate))
+		}
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, globalconfig.AnalyticsRate())
+	})
+
+	t.Run("global", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.4)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, 1.0, WithAnalytics(true))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		assertRate(t, mt, math.NaN(), WithAnalytics(false))
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		rate := globalconfig.AnalyticsRate()
+		defer globalconfig.SetAnalyticsRate(rate)
+		globalconfig.SetAnalyticsRate(0.4)
+
+		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
+	})
+}
+
+func TestNamingSchema(t *testing.T) {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+		var opts []Option
+		if serviceOverride != "" {
+			opts = append(opts, WithServiceName(serviceOverride))
+		}
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		ws := new(restful.WebService)
+		ws.Filter(FilterFunc(opts...))
+		ws.Route(ws.GET("/user/{id}").Param(restful.PathParameter("id", "user ID")).
+			To(func(request *restful.Request, response *restful.Response) {
+				_, err := response.Write([]byte(request.PathParameter("id")))
+				require.NoError(t, err)
+			}))
+		container := restful.NewContainer()
+		container.Add(ws)
+
+		r := httptest.NewRequest("GET", "/user/200", nil)
+		w := httptest.NewRecorder()
+		container.ServeHTTP(w, r)
+
+		return mt.FinishedSpans()
+	})
+	wantServiceNameV0 := namingschematest.ServiceNameAssertions{
+		WithDefaults:             []string{"go-restful"},
+		WithDDService:            []string{"go-restful"},
+		WithDDServiceAndOverride: []string{namingschematest.TestServiceOverride},
+	}
+	namingschematest.NewHTTPServerTest(
+		genSpans,
+		"go-restful",
+		namingschematest.WithServiceNameAssertions(namingschema.SchemaV0, wantServiceNameV0),
+	)(t)
+}

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/elastic/go-elasticsearch/v7 v7.17.1
 	github.com/elastic/go-elasticsearch/v8 v8.4.0
 	github.com/emicklei/go-restful v2.16.0+incompatible
+	github.com/emicklei/go-restful/v3 v3.10.2
 	github.com/garyburd/redigo v1.6.3
 	github.com/gin-gonic/gin v1.9.1
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8

--- a/go.sum
+++ b/go.sum
@@ -1059,6 +1059,8 @@ github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.16.0+incompatible h1:rgqiKNjTnFQA6kkhFe16D8epTksy9HQ1MyrbDXSdYhM=
 github.com/emicklei/go-restful v2.16.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/go-restful/v3 v3.10.2 h1:hIovbnmBTLjHXkqEBUz3HGpXZdM7ZrE9fJIZIqlJLqE=
+github.com/emicklei/go-restful/v3 v3.10.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=


### PR DESCRIPTION
### What does this PR do?

Adds support for the [latest version of `go-restful`](https://github.com/emicklei/go-restful#using-go-modules).

### Motivation

The integration for previous versions can't be used with `v3`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.