### PR TITLE
profiler: allow human-readable values for trace size limit

### DIFF
--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -424,3 +424,33 @@ func TestWith_outputDir(t *testing.T) {
 	want := map[string]string{"foo.pprof": "foo", "bar.pprof": "bar"}
 	require.Equal(t, want, fileData)
 }
+
+func TestParseDataSize(t *testing.T) {
+	cases := []struct {
+		Input      string
+		Output     int
+		ShouldFail bool
+	}{
+		{Input: "1000", Output: 1000},
+		{Input: "123B", Output: 123},
+		{Input: "5MiB", Output: 5 * 1024 * 1024},
+		{Input: "10MB", Output: 10 * 1024 * 1024},
+		{Input: "512KB", Output: 512 * 1024},
+		{Input: "256KiB", Output: 256 * 1024},
+		{Input: "MB", ShouldFail: true},
+		{Input: "1GiB", ShouldFail: true},
+		{Input: "foobar", ShouldFail: true},
+	}
+
+	for _, tc := range cases {
+		n, err := parseDataSize(tc.Input)
+		switch {
+		case err != nil && !tc.ShouldFail:
+			t.Errorf("input: %s, failed with error: %s", tc.Input, err)
+		case err == nil && tc.ShouldFail:
+			t.Errorf("input: %s, unexpectedly succeded with output %d", tc.Input, n)
+		case err == nil && tc.Output != n:
+			t.Errorf("input: %s, want %d, got %d", tc.Input, tc.Output, n)
+		}
+	}
+}

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -559,7 +559,7 @@ func TestExecutionTraceSizeLimit(t *testing.T) {
 
 	t.Setenv("DD_PROFILING_EXECUTION_TRACE_ENABLED", "true")
 	t.Setenv("DD_PROFILING_EXECUTION_TRACE_PERIOD", "3s")
-	t.Setenv("DD_PROFILING_EXECUTION_TRACE_LIMIT_BYTES", "100000")
+	t.Setenv("DD_PROFILING_EXECUTION_TRACE_LIMIT_BYTES", "100KiB")
 	err := Start(
 		WithHTTPClient(client),
 		WithProfileTypes(), // just want the execution trace


### PR DESCRIPTION
### What does this PR do?

Allow using human-readable suffixes for the execution trace size limit value,
e.g. 5MiB instead of 5242880.

### Motivation

It's more clear what the value is meant to be at a glance. Matches in spirit
what we do for the duration, where we allow 15m/5000s/1h values rather than
requiring the duration to be a single unit like seconds or minutes.

### Describe how to test/QA your changes

This PR adds a unit test for the value parsing.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.
