### PR TITLE
Added nightly/manual CI jobs for dd-trace-go macrobenchmarks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 stages:
   - benchmarks
+  - macrobenchmarks
   - test-apps
 
 variables:
@@ -12,4 +13,5 @@ variables:
 
 include:
   - ".gitlab/benchmarks.yml"
+  - ".gitlab/macrobenchmarks.yml"
   - ".gitlab/test-apps.yml"

--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -31,15 +31,13 @@ variables:
   # By marking the benchmarks as allow_failure, this should go away. (This workaround should be removed once the
   # benchmarks get changed to run on every PR)
   allow_failure: true
-    
+
 go118-baseline-macrobenchmark:
   extends: .dd-trace-go-macrobenchmarks
   variables:
-    DD_BENCHMARKS_CONFIGURATION: go118-baseline
     K6_RUN_ID_PREFIX: ci
-    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_BENCHMARKS_CONFIGURATION: go118-baseline
     ENABLE_DDPROF: "false"
-    DD_TRACE_GO_VERSION: latest
     ENABLE_TRACING: "false"
     ENABLE_PROFILING: "false"
     ENABLE_APPSEC: "false"
@@ -47,16 +45,19 @@ go118-baseline-macrobenchmark:
     DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
     GO_VERSION: "1.18"
-    SCENARIO: go118-baseline
-
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_TRACE_GO_VERSION: latest
+    K6_RATE_: 15
+    K6_DURATION_: 20m
+    K6_GRACEFUL_STOP_: 1m
+    K6_PRE_ALLOCATED_VUS_: 4
+    K6_MAX_VUS_: 4
 go118-only-trace-macrobenchmark:
   extends: .dd-trace-go-macrobenchmarks
   variables:
-    DD_BENCHMARKS_CONFIGURATION: go118-only-trace
     K6_RUN_ID_PREFIX: ci
-    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_BENCHMARKS_CONFIGURATION: go118-only-trace
     ENABLE_DDPROF: "false"
-    DD_TRACE_GO_VERSION: latest
     ENABLE_TRACING: "true"
     ENABLE_PROFILING: "false"
     ENABLE_APPSEC: "false"
@@ -64,16 +65,19 @@ go118-only-trace-macrobenchmark:
     DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
     GO_VERSION: "1.18"
-    SCENARIO: go118-only-trace
-
-go118-only-ddprofile-macrobenchmark:
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_TRACE_GO_VERSION: latest
+    K6_RATE_: 15
+    K6_DURATION_: 20m
+    K6_GRACEFUL_STOP_: 1m
+    K6_PRE_ALLOCATED_VUS_: 4
+    K6_MAX_VUS_: 4
+go118-only-profile-macrobenchmark:
   extends: .dd-trace-go-macrobenchmarks
   variables:
-    DD_BENCHMARKS_CONFIGURATION: go118-only-ddprofile
     K6_RUN_ID_PREFIX: ci
-    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_BENCHMARKS_CONFIGURATION: go118-only-profile
     ENABLE_DDPROF: "false"
-    DD_TRACE_GO_VERSION: latest
     ENABLE_TRACING: "false"
     ENABLE_PROFILING: "true"
     ENABLE_APPSEC: "false"
@@ -81,16 +85,19 @@ go118-only-ddprofile-macrobenchmark:
     DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
     GO_VERSION: "1.18"
-    SCENARIO: go118-only-ddprofile
-
-go118-ddprofile-trace-macrobenchmark:
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_TRACE_GO_VERSION: latest
+    K6_RATE_: 15
+    K6_DURATION_: 20m
+    K6_GRACEFUL_STOP_: 1m
+    K6_PRE_ALLOCATED_VUS_: 4
+    K6_MAX_VUS_: 4
+go118-profile-trace-macrobenchmark:
   extends: .dd-trace-go-macrobenchmarks
   variables:
-    DD_BENCHMARKS_CONFIGURATION: go118-ddprofile-trace
     K6_RUN_ID_PREFIX: ci
-    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_BENCHMARKS_CONFIGURATION: go118-profile-trace
     ENABLE_DDPROF: "false"
-    DD_TRACE_GO_VERSION: latest
     ENABLE_TRACING: "true"
     ENABLE_PROFILING: "true"
     ENABLE_APPSEC: "false"
@@ -98,16 +105,19 @@ go118-ddprofile-trace-macrobenchmark:
     DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
     GO_VERSION: "1.18"
-    SCENARIO: go118-ddprofile-trace
-
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_TRACE_GO_VERSION: latest
+    K6_RATE_: 15
+    K6_DURATION_: 20m
+    K6_GRACEFUL_STOP_: 1m
+    K6_PRE_ALLOCATED_VUS_: 4
+    K6_MAX_VUS_: 4
 go118-trace-asm-macrobenchmark:
   extends: .dd-trace-go-macrobenchmarks
   variables:
-    DD_BENCHMARKS_CONFIGURATION: go118-trace-asm
     K6_RUN_ID_PREFIX: ci
-    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_BENCHMARKS_CONFIGURATION: go118-trace-asm
     ENABLE_DDPROF: "false"
-    DD_TRACE_GO_VERSION: latest
     ENABLE_TRACING: "true"
     ENABLE_PROFILING: "false"
     ENABLE_APPSEC: "true"
@@ -115,16 +125,19 @@ go118-trace-asm-macrobenchmark:
     DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
     GO_VERSION: "1.18"
-    SCENARIO: go118-trace-asm
-    
-go118-ddprofile-trace-asm-macrobenchmark:
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_TRACE_GO_VERSION: latest
+    K6_RATE_: 15
+    K6_DURATION_: 20m
+    K6_GRACEFUL_STOP_: 1m
+    K6_PRE_ALLOCATED_VUS_: 4
+    K6_MAX_VUS_: 4
+go118-profile-trace-asm-macrobenchmark:
   extends: .dd-trace-go-macrobenchmarks
   variables:
-    DD_BENCHMARKS_CONFIGURATION: go118-profile-trace-asm
     K6_RUN_ID_PREFIX: ci
-    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_BENCHMARKS_CONFIGURATION: go118-profile-trace-asm
     ENABLE_DDPROF: "false"
-    DD_TRACE_GO_VERSION: latest
     ENABLE_TRACING: "true"
     ENABLE_PROFILING: "true"
     ENABLE_APPSEC: "true"
@@ -132,16 +145,19 @@ go118-ddprofile-trace-asm-macrobenchmark:
     DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
     GO_VERSION: "1.18"
-    SCENARIO: go118-profile-trace-asm
-
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_TRACE_GO_VERSION: latest
+    K6_RATE_: 15
+    K6_DURATION_: 20m
+    K6_GRACEFUL_STOP_: 1m
+    K6_PRE_ALLOCATED_VUS_: 4
+    K6_MAX_VUS_: 4
 go119-baseline-macrobenchmark:
   extends: .dd-trace-go-macrobenchmarks
   variables:
-    DD_BENCHMARKS_CONFIGURATION: go119-baseline
     K6_RUN_ID_PREFIX: ci
-    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_BENCHMARKS_CONFIGURATION: go119-baseline
     ENABLE_DDPROF: "false"
-    DD_TRACE_GO_VERSION: latest
     ENABLE_TRACING: "false"
     ENABLE_PROFILING: "false"
     ENABLE_APPSEC: "false"
@@ -149,16 +165,19 @@ go119-baseline-macrobenchmark:
     DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
     GO_VERSION: "1.19"
-    SCENARIO: go119-baseline
-
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_TRACE_GO_VERSION: latest
+    K6_RATE_: 15
+    K6_DURATION_: 20m
+    K6_GRACEFUL_STOP_: 1m
+    K6_PRE_ALLOCATED_VUS_: 4
+    K6_MAX_VUS_: 4
 go119-only-trace-macrobenchmark:
   extends: .dd-trace-go-macrobenchmarks
   variables:
-    DD_BENCHMARKS_CONFIGURATION: go119-only-trace
     K6_RUN_ID_PREFIX: ci
-    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_BENCHMARKS_CONFIGURATION: go119-only-trace
     ENABLE_DDPROF: "false"
-    DD_TRACE_GO_VERSION: latest
     ENABLE_TRACING: "true"
     ENABLE_PROFILING: "false"
     ENABLE_APPSEC: "false"
@@ -166,16 +185,19 @@ go119-only-trace-macrobenchmark:
     DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
     GO_VERSION: "1.19"
-    SCENARIO: go119-only-trace
-
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_TRACE_GO_VERSION: latest
+    K6_RATE_: 15
+    K6_DURATION_: 20m
+    K6_GRACEFUL_STOP_: 1m
+    K6_PRE_ALLOCATED_VUS_: 4
+    K6_MAX_VUS_: 4
 go119-only-profile-macrobenchmark:
   extends: .dd-trace-go-macrobenchmarks
   variables:
-    DD_BENCHMARKS_CONFIGURATION: go119-only-profile
     K6_RUN_ID_PREFIX: ci
-    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_BENCHMARKS_CONFIGURATION: go119-only-profile
     ENABLE_DDPROF: "false"
-    DD_TRACE_GO_VERSION: latest
     ENABLE_TRACING: "false"
     ENABLE_PROFILING: "true"
     ENABLE_APPSEC: "false"
@@ -183,16 +205,19 @@ go119-only-profile-macrobenchmark:
     DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
     GO_VERSION: "1.19"
-    SCENARIO: go119-only-profile
-
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_TRACE_GO_VERSION: latest
+    K6_RATE_: 15
+    K6_DURATION_: 20m
+    K6_GRACEFUL_STOP_: 1m
+    K6_PRE_ALLOCATED_VUS_: 4
+    K6_MAX_VUS_: 4
 go119-profile-trace-macrobenchmark:
   extends: .dd-trace-go-macrobenchmarks
   variables:
-    DD_BENCHMARKS_CONFIGURATION: go119-profile-trace
     K6_RUN_ID_PREFIX: ci
-    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_BENCHMARKS_CONFIGURATION: go119-profile-trace
     ENABLE_DDPROF: "false"
-    DD_TRACE_GO_VERSION: latest
     ENABLE_TRACING: "true"
     ENABLE_PROFILING: "true"
     ENABLE_APPSEC: "false"
@@ -200,16 +225,19 @@ go119-profile-trace-macrobenchmark:
     DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
     GO_VERSION: "1.19"
-    SCENARIO: go119-profile-trace
-
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_TRACE_GO_VERSION: latest
+    K6_RATE_: 15
+    K6_DURATION_: 20m
+    K6_GRACEFUL_STOP_: 1m
+    K6_PRE_ALLOCATED_VUS_: 4
+    K6_MAX_VUS_: 4
 go119-trace-asm-macrobenchmark:
   extends: .dd-trace-go-macrobenchmarks
   variables:
-    DD_BENCHMARKS_CONFIGURATION: go119-trace-asm
     K6_RUN_ID_PREFIX: ci
-    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_BENCHMARKS_CONFIGURATION: go119-trace-asm
     ENABLE_DDPROF: "false"
-    DD_TRACE_GO_VERSION: latest
     ENABLE_TRACING: "true"
     ENABLE_PROFILING: "false"
     ENABLE_APPSEC: "true"
@@ -217,16 +245,19 @@ go119-trace-asm-macrobenchmark:
     DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
     GO_VERSION: "1.19"
-    SCENARIO: go119-trace-asm
-
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_TRACE_GO_VERSION: latest
+    K6_RATE_: 15
+    K6_DURATION_: 20m
+    K6_GRACEFUL_STOP_: 1m
+    K6_PRE_ALLOCATED_VUS_: 4
+    K6_MAX_VUS_: 4
 go119-profile-trace-asm-macrobenchmark:
   extends: .dd-trace-go-macrobenchmarks
   variables:
-    DD_BENCHMARKS_CONFIGURATION: go119-profile-trace-asm
     K6_RUN_ID_PREFIX: ci
-    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_BENCHMARKS_CONFIGURATION: go119-profile-trace-asm
     ENABLE_DDPROF: "false"
-    DD_TRACE_GO_VERSION: latest
     ENABLE_TRACING: "true"
     ENABLE_PROFILING: "true"
     ENABLE_APPSEC: "true"
@@ -234,5 +265,11 @@ go119-profile-trace-asm-macrobenchmark:
     DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
     GO_VERSION: "1.19"
-    SCENARIO: go119-profile-trace-asm
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    DD_TRACE_GO_VERSION: latest
+    K6_RATE_: 15
+    K6_DURATION_: 20m
+    K6_GRACEFUL_STOP_: 1m
+    K6_PRE_ALLOCATED_VUS_: 4
+    K6_MAX_VUS_: 4   
 

--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -6,8 +6,8 @@ variables:
   tags: ["runner:apm-k8s-same-cpu"]
   timeout: 1h
   rules:
-    #- if: $CI_PIPELINE_SOURCE == "schedule"
-    #  when: always
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: always
     - when: manual
   # If you have a problem with Gitlab cache, see Troubleshooting section in Benchmarking Platform docs
   image: $BENCHMARKS_CI_IMAGE

--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -1,0 +1,238 @@
+variables:
+  BENCHMARKS_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dd-trace-go-macrobenchmarks
+
+.dd-trace-go-macrobenchmarks:
+  stage: macrobenchmarks
+  tags: ["runner:apm-k8s-same-cpu"]
+  timeout: 1h
+  rules:
+    #- if: $CI_PIPELINE_SOURCE == "schedule"
+    #  when: always
+    - when: manual
+  # If you have a problem with Gitlab cache, see Troubleshooting section in Benchmarking Platform docs
+  image: $BENCHMARKS_CI_IMAGE
+  script:
+    - export ARTIFACTS_DIR="$(pwd)/reports" && (mkdir "${ARTIFACTS_DIR}" || :)
+    - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-go.dd_api_key --with-decryption --query "Parameter.Value" --out text)
+    - git clone --branch igoragoli/migrate_go_macrobenchmark_from_ktg https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform /platform && cd /platform
+    - ./steps/capture-hardware-software-info.sh
+    - ./steps/run-benchmarks.sh
+    - "./steps/upload-results-to-s3.sh || :"
+  artifacts:
+    name: "reports"
+    paths:
+      - reports/
+    expire_in: 3 months
+  variables:
+    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true" # Important tweak for stability of benchmarks
+    K6_RUN_ID_PREFIX: ci
+    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-go
+  # Workaround: Currently we're not running the benchmarks on every PR, but GitHub still shows them as pending.
+  # By marking the benchmarks as allow_failure, this should go away. (This workaround should be removed once the
+  # benchmarks get changed to run on every PR)
+  allow_failure: true
+    
+go118-baseline-macrobenchmark:
+  extends: .dd-trace-go-macrobenchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: go118-baseline
+    K6_RUN_ID_PREFIX: ci
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    ENABLE_DDPROF: "false"
+    DD_TRACE_GO_VERSION: latest
+    ENABLE_TRACING: "false"
+    ENABLE_PROFILING: "false"
+    ENABLE_APPSEC: "false"
+    DD_INSTRUMENTATION_TELEMETRY_ENABLED: "true"
+    DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
+    GO_VERSION: "1.18"
+    SCENARIO: go118-baseline
+
+go118-only-trace-macrobenchmark:
+  extends: .dd-trace-go-macrobenchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: go118-only-trace
+    K6_RUN_ID_PREFIX: ci
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    ENABLE_DDPROF: "false"
+    DD_TRACE_GO_VERSION: latest
+    ENABLE_TRACING: "true"
+    ENABLE_PROFILING: "false"
+    ENABLE_APPSEC: "false"
+    DD_INSTRUMENTATION_TELEMETRY_ENABLED: "true"
+    DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
+    GO_VERSION: "1.18"
+    SCENARIO: go118-only-trace
+
+go118-only-ddprofile-macrobenchmark:
+  extends: .dd-trace-go-macrobenchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: go118-only-ddprofile
+    K6_RUN_ID_PREFIX: ci
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    ENABLE_DDPROF: "false"
+    DD_TRACE_GO_VERSION: latest
+    ENABLE_TRACING: "false"
+    ENABLE_PROFILING: "true"
+    ENABLE_APPSEC: "false"
+    DD_INSTRUMENTATION_TELEMETRY_ENABLED: "true"
+    DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
+    GO_VERSION: "1.18"
+    SCENARIO: go118-only-ddprofile
+
+go118-ddprofile-trace-macrobenchmark:
+  extends: .dd-trace-go-macrobenchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: go118-ddprofile-trace
+    K6_RUN_ID_PREFIX: ci
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    ENABLE_DDPROF: "false"
+    DD_TRACE_GO_VERSION: latest
+    ENABLE_TRACING: "true"
+    ENABLE_PROFILING: "true"
+    ENABLE_APPSEC: "false"
+    DD_INSTRUMENTATION_TELEMETRY_ENABLED: "true"
+    DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
+    GO_VERSION: "1.18"
+    SCENARIO: go118-ddprofile-trace
+
+go118-trace-asm-macrobenchmark:
+  extends: .dd-trace-go-macrobenchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: go118-trace-asm
+    K6_RUN_ID_PREFIX: ci
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    ENABLE_DDPROF: "false"
+    DD_TRACE_GO_VERSION: latest
+    ENABLE_TRACING: "true"
+    ENABLE_PROFILING: "false"
+    ENABLE_APPSEC: "true"
+    DD_INSTRUMENTATION_TELEMETRY_ENABLED: "true"
+    DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
+    GO_VERSION: "1.18"
+    SCENARIO: go118-trace-asm
+    
+go118-ddprofile-trace-asm-macrobenchmark:
+  extends: .dd-trace-go-macrobenchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: go118-profile-trace-asm
+    K6_RUN_ID_PREFIX: ci
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    ENABLE_DDPROF: "false"
+    DD_TRACE_GO_VERSION: latest
+    ENABLE_TRACING: "true"
+    ENABLE_PROFILING: "true"
+    ENABLE_APPSEC: "true"
+    DD_INSTRUMENTATION_TELEMETRY_ENABLED: "true"
+    DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
+    GO_VERSION: "1.18"
+    SCENARIO: go118-profile-trace-asm
+
+go119-baseline-macrobenchmark:
+  extends: .dd-trace-go-macrobenchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: go119-baseline
+    K6_RUN_ID_PREFIX: ci
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    ENABLE_DDPROF: "false"
+    DD_TRACE_GO_VERSION: latest
+    ENABLE_TRACING: "false"
+    ENABLE_PROFILING: "false"
+    ENABLE_APPSEC: "false"
+    DD_INSTRUMENTATION_TELEMETRY_ENABLED: "true"
+    DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
+    GO_VERSION: "1.19"
+    SCENARIO: go119-baseline
+
+go119-only-trace-macrobenchmark:
+  extends: .dd-trace-go-macrobenchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: go119-only-trace
+    K6_RUN_ID_PREFIX: ci
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    ENABLE_DDPROF: "false"
+    DD_TRACE_GO_VERSION: latest
+    ENABLE_TRACING: "true"
+    ENABLE_PROFILING: "false"
+    ENABLE_APPSEC: "false"
+    DD_INSTRUMENTATION_TELEMETRY_ENABLED: "true"
+    DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
+    GO_VERSION: "1.19"
+    SCENARIO: go119-only-trace
+
+go119-only-profile-macrobenchmark:
+  extends: .dd-trace-go-macrobenchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: go119-only-profile
+    K6_RUN_ID_PREFIX: ci
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    ENABLE_DDPROF: "false"
+    DD_TRACE_GO_VERSION: latest
+    ENABLE_TRACING: "false"
+    ENABLE_PROFILING: "true"
+    ENABLE_APPSEC: "false"
+    DD_INSTRUMENTATION_TELEMETRY_ENABLED: "true"
+    DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
+    GO_VERSION: "1.19"
+    SCENARIO: go119-only-profile
+
+go119-profile-trace-macrobenchmark:
+  extends: .dd-trace-go-macrobenchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: go119-profile-trace
+    K6_RUN_ID_PREFIX: ci
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    ENABLE_DDPROF: "false"
+    DD_TRACE_GO_VERSION: latest
+    ENABLE_TRACING: "true"
+    ENABLE_PROFILING: "true"
+    ENABLE_APPSEC: "false"
+    DD_INSTRUMENTATION_TELEMETRY_ENABLED: "true"
+    DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
+    GO_VERSION: "1.19"
+    SCENARIO: go119-profile-trace
+
+go119-trace-asm-macrobenchmark:
+  extends: .dd-trace-go-macrobenchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: go119-trace-asm
+    K6_RUN_ID_PREFIX: ci
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    ENABLE_DDPROF: "false"
+    DD_TRACE_GO_VERSION: latest
+    ENABLE_TRACING: "true"
+    ENABLE_PROFILING: "false"
+    ENABLE_APPSEC: "true"
+    DD_INSTRUMENTATION_TELEMETRY_ENABLED: "true"
+    DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
+    GO_VERSION: "1.19"
+    SCENARIO: go119-trace-asm
+
+go119-profile-trace-asm-macrobenchmark:
+  extends: .dd-trace-go-macrobenchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: go119-profile-trace-asm
+    K6_RUN_ID_PREFIX: ci
+    GO_PROF_APP_BUILD_VARIANT: candidate
+    ENABLE_DDPROF: "false"
+    DD_TRACE_GO_VERSION: latest
+    ENABLE_TRACING: "true"
+    ENABLE_PROFILING: "true"
+    ENABLE_APPSEC: "true"
+    DD_INSTRUMENTATION_TELEMETRY_ENABLED: "true"
+    DD_INSTRUMENTATION_TELEMETRY_DEBUG: "true"
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
+    GO_VERSION: "1.19"
+    SCENARIO: go119-profile-trace-asm
+


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
This PR sets up nightly/manual CI jobs for running `dd-trace-go` macrobenchmarks, in order to migrate the Go Macrobenchmark from the KTG/Reliability Environment (see [datadog-reliability-env/apps/go/prof-app](https://github.com/DataDog/datadog-reliability-env/tree/master/apps/go/prof-app)) to the Benchmarking Platform.
* The benchmarks are described and explained in [DataDog/benchmarking-platform@igoragoli/migrate_go_macrobenchmark_from_ktg PR](https://github.com/DataDog/benchmarking-platform/pull/8).
* All 12 scenarios are scheduled to run in parallel across different GitLab runners on a nightly basis, and they take 20 minutes to run.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
[Related issue](https://datadoghq.atlassian.net/browse/AIT-7737)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes
The adequate execution of the added CI jobs can be verified in the following pipeline:
[#17672789](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-go/-/pipelines/17672789)

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.