### PR TITLE
contrib/emicklei/go-restful: drain and close response bodies in tests

### DIFF
--- a/contrib/emicklei/go-restful/restful_test.go
+++ b/contrib/emicklei/go-restful/restful_test.go
@@ -7,6 +7,7 @@ package restful
 
 import (
 	"errors"
+	"io"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -146,6 +147,8 @@ func TestTrace200(t *testing.T) {
 
 	container.ServeHTTP(w, r)
 	response := w.Result()
+	defer response.Body.Close()
+	io.Copy(io.Discard, response.Body)
 	assert.Equal(response.StatusCode, 200)
 
 	spans := mt.FinishedSpans()
@@ -183,6 +186,8 @@ func TestError(t *testing.T) {
 
 	container.ServeHTTP(w, r)
 	response := w.Result()
+	defer response.Body.Close()
+	io.Copy(io.Discard, response.Body)
 	assert.Equal(response.StatusCode, 500)
 
 	spans := mt.FinishedSpans()


### PR DESCRIPTION
### What does this PR do?

Drains the response body and closes it in the go-restful tests.

### Motivation

The Go standard library docs for net/http.Response state that the Body must be
read to completion and closed, or else TCP connections may not be reused.

One of our linters complains about the lack of closing, adding comments to
every single PR. This PR fixes that. The linter doesn't catch that we also
don't read the request bodies to completion, but we still need to do it
according to the API.

### Describe how to test/QA your changes

The existing tests still pass, and the linter doesn't complain any more.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality.
- [x] If this interacts with the agent in a new way, a system test has been added.
