### PR TITLE
contrib/internal/httptrace: improve performance of span starts

### DIFF
--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	cfg      = newConfig()
-	serverOp = namingschema.NewHTTPServerOp()
+	serverOp = namingschema.NewHTTPServerOp().GetName()
 )
 
 // StartRequestSpan starts an HTTP request span with the standard list of HTTP request span tags (http.method, http.url,
@@ -38,13 +38,6 @@ func StartRequestSpan(r *http.Request, opts ...ddtrace.StartSpanOption) (tracer.
 		ipTags, _ = httpsec.ClientIPTags(r.Header, true, r.RemoteAddr)
 	}
 	nopts := make([]ddtrace.StartSpanOption, 0, len(opts)+7+len(ipTags))
-	// nopts = append(nopts,
-	// 	tracer.SpanType(ext.SpanTypeWeb),
-	// 	tracer.Tag(ext.HTTPMethod, r.Method),
-	// 	tracer.Tag(ext.HTTPURL, urlFromRequest(r)),
-	// 	tracer.Tag(ext.HTTPUserAgent, r.UserAgent()),
-	// 	tracer.Measured())
-
 	nopts = append(nopts,
 		func(cfg *ddtrace.StartSpanConfig) {
 			if cfg.Tags == nil {
@@ -66,7 +59,7 @@ func StartRequestSpan(r *http.Request, opts ...ddtrace.StartSpanOption) (tracer.
 			}
 		})
 	nopts = append(nopts, opts...)
-	return tracer.StartSpanFromContext(r.Context(), serverOp.Name(), nopts...)
+	return tracer.StartSpanFromContext(r.Context(), serverOp, nopts...)
 }
 
 // FinishRequestSpan finishes the given HTTP request span and sets the expected response-related tags such as the status

--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -23,7 +23,8 @@ import (
 )
 
 var (
-	cfg = newConfig()
+	cfg      = newConfig()
+	serverOp = namingschema.NewHTTPServerOp()
 )
 
 // StartRequestSpan starts an HTTP request span with the standard list of HTTP request span tags (http.method, http.url,
@@ -31,28 +32,41 @@ var (
 func StartRequestSpan(r *http.Request, opts ...ddtrace.StartSpanOption) (tracer.Span, context.Context) {
 	// Append our span options before the given ones so that the caller can "overwrite" them.
 	// TODO(): rework span start option handling (https://github.com/DataDog/dd-trace-go/issues/1352)
-	opts = append([]ddtrace.StartSpanOption{
-		tracer.SpanType(ext.SpanTypeWeb),
-		tracer.Tag(ext.HTTPMethod, r.Method),
-		tracer.Tag(ext.HTTPURL, urlFromRequest(r)),
-		tracer.Tag(ext.HTTPUserAgent, r.UserAgent()),
-		tracer.Measured(),
-	}, opts...)
-	if r.Host != "" {
-		opts = append([]ddtrace.StartSpanOption{
-			tracer.Tag("http.host", r.Host),
-		}, opts...)
-	}
-	if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(r.Header)); err == nil {
-		opts = append(opts, tracer.ChildOf(spanctx))
-	}
+
+	var ipTags map[string]string
 	if cfg.traceClientIP {
-		ipTags, _ := httpsec.ClientIPTags(r.Header, true, r.RemoteAddr)
-		for k, v := range ipTags {
-			opts = append(opts, tracer.Tag(k, v))
-		}
+		ipTags, _ = httpsec.ClientIPTags(r.Header, true, r.RemoteAddr)
 	}
-	return tracer.StartSpanFromContext(r.Context(), namingschema.NewHTTPServerOp().GetName(), opts...)
+	nopts := make([]ddtrace.StartSpanOption, 0, len(opts)+7+len(ipTags))
+	// nopts = append(nopts,
+	// 	tracer.SpanType(ext.SpanTypeWeb),
+	// 	tracer.Tag(ext.HTTPMethod, r.Method),
+	// 	tracer.Tag(ext.HTTPURL, urlFromRequest(r)),
+	// 	tracer.Tag(ext.HTTPUserAgent, r.UserAgent()),
+	// 	tracer.Measured())
+
+	nopts = append(nopts,
+		func(cfg *ddtrace.StartSpanConfig) {
+			if cfg.Tags == nil {
+				cfg.Tags = make(map[string]interface{})
+			}
+			cfg.Tags[ext.SpanType] = ext.SpanTypeWeb
+			cfg.Tags[ext.HTTPMethod] = r.Method
+			cfg.Tags[ext.HTTPURL] = urlFromRequest(r)
+			cfg.Tags[ext.HTTPUserAgent] = r.UserAgent()
+			cfg.Tags["_dd.measured"] = 1
+			if r.Host != "" {
+				cfg.Tags["http.host"] = r.Host
+			}
+			if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(r.Header)); err == nil {
+				cfg.Parent = spanctx
+			}
+			for k, v := range ipTags {
+				cfg.Tags[k] = v
+			}
+		})
+	nopts = append(nopts, opts...)
+	return tracer.StartSpanFromContext(r.Context(), serverOp.Name(), nopts...)
 }
 
 // FinishRequestSpan finishes the given HTTP request span and sets the expected response-related tags such as the status

--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -37,7 +37,7 @@ func StartRequestSpan(r *http.Request, opts ...ddtrace.StartSpanOption) (tracer.
 	if cfg.traceClientIP {
 		ipTags, _ = httpsec.ClientIPTags(r.Header, true, r.RemoteAddr)
 	}
-	nopts := make([]ddtrace.StartSpanOption, 0, len(opts)+7+len(ipTags))
+	nopts := make([]ddtrace.StartSpanOption, 0, len(opts)+1+len(ipTags))
 	nopts = append(nopts,
 		func(cfg *ddtrace.StartSpanConfig) {
 			if cfg.Tags == nil {

--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -23,8 +23,7 @@ import (
 )
 
 var (
-	cfg      = newConfig()
-	serverOp = namingschema.NewHTTPServerOp().GetName()
+	cfg = newConfig()
 )
 
 // StartRequestSpan starts an HTTP request span with the standard list of HTTP request span tags (http.method, http.url,
@@ -59,7 +58,7 @@ func StartRequestSpan(r *http.Request, opts ...ddtrace.StartSpanOption) (tracer.
 			}
 		})
 	nopts = append(nopts, opts...)
-	return tracer.StartSpanFromContext(r.Context(), serverOp, nopts...)
+	return tracer.StartSpanFromContext(r.Context(), namingschema.NewHTTPServerOp().GetName(), nopts...)
 }
 
 // FinishRequestSpan finishes the given HTTP request span and sets the expected response-related tags such as the status

--- a/contrib/internal/httptrace/httptrace_test.go
+++ b/contrib/internal/httptrace/httptrace_test.go
@@ -252,6 +252,7 @@ func BenchmarkStartRequestSpan(b *testing.B) {
 		tracer.ResourceName("SomeResource"),
 		tracer.Tag(ext.HTTPRoute, "/some/route/?"),
 	}
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		StartRequestSpan(r, opts...)
 	}

--- a/contrib/internal/httptrace/httptrace_test.go
+++ b/contrib/internal/httptrace/httptrace_test.go
@@ -12,8 +12,10 @@ import (
 	"strconv"
 	"testing"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/normalizer"
@@ -235,5 +237,22 @@ func TestURLTag(t *testing.T) {
 			url := urlFromRequest(&r)
 			require.Equal(t, tc.expectedURL, url)
 		})
+	}
+}
+
+func BenchmarkStartRequestSpan(b *testing.B) {
+	b.ReportAllocs()
+	r, err := http.NewRequest("GET", "http://example.com", nil)
+	if err != nil {
+		b.Errorf("Failed to create request: %v", err)
+		return
+	}
+	opts := []ddtrace.StartSpanOption{
+		tracer.ServiceName("SomeService"),
+		tracer.ResourceName("SomeResource"),
+		tracer.Tag(ext.HTTPRoute, "/some/route/?"),
+	}
+	for i := 0; i < b.N; i++ {
+		StartRequestSpan(r, opts...)
 	}
 }

--- a/internal/namingschema/op_client_server.go
+++ b/internal/namingschema/op_client_server.go
@@ -37,13 +37,32 @@ type serverInboundOp struct {
 	system string
 }
 
+type SimpleSchema func() string
+
+func (s SimpleSchema) Name() string { return s() }
+
+type Namer interface {
+	Name() string
+}
+
 // NewServerInboundOp creates a new naming schema for server inbound operations.
-func NewServerInboundOp(system string, opts ...Option) *Schema {
+func NewServerInboundOp(system string, opts ...Option) Namer {
 	cfg := &config{}
 	for _, opt := range opts {
 		opt(cfg)
 	}
-	return New(&serverInboundOp{cfg: cfg, system: system})
+	switch GetVersion() {
+	case SchemaV1:
+		s := fmt.Sprintf("%s.server.request", system)
+		return SimpleSchema(func() string { return s })
+	default:
+		if cfg.overrideV0 != nil {
+			return SimpleSchema(func() string { return *cfg.overrideV0 })
+		}
+		s := fmt.Sprintf("%s.request", system)
+		return SimpleSchema(func() string { return s })
+
+	}
 }
 
 func (s *serverInboundOp) V0() string {
@@ -63,7 +82,7 @@ func NewHTTPClientOp(opts ...Option) *Schema {
 }
 
 // NewHTTPServerOp creates a new schema for HTTP server inbound operations.
-func NewHTTPServerOp(opts ...Option) *Schema {
+func NewHTTPServerOp(opts ...Option) Namer {
 	return NewServerInboundOp("http", opts...)
 }
 
@@ -74,12 +93,12 @@ func NewGRPCClientOp(opts ...Option) *Schema {
 }
 
 // NewGRPCServerOp creates a new schema for gRPC server inbound operations.
-func NewGRPCServerOp(opts ...Option) *Schema {
+func NewGRPCServerOp(opts ...Option) Namer {
 	newOpts := append([]Option{WithOverrideV0("grpc.server")}, opts...)
 	return NewServerInboundOp("grpc", newOpts...)
 }
 
 // NewGraphqlServerOp creates a new schema for GraphQL server inbound operations.
-func NewGraphqlServerOp(opts ...Option) *Schema {
+func NewGraphqlServerOp(opts ...Option) Namer {
 	return NewServerInboundOp("graphql", opts...)
 }

--- a/internal/namingschema/op_client_server.go
+++ b/internal/namingschema/op_client_server.go
@@ -37,32 +37,13 @@ type serverInboundOp struct {
 	system string
 }
 
-type SimpleSchema func() string
-
-func (s SimpleSchema) Name() string { return s() }
-
-type Namer interface {
-	Name() string
-}
-
 // NewServerInboundOp creates a new naming schema for server inbound operations.
-func NewServerInboundOp(system string, opts ...Option) Namer {
+func NewServerInboundOp(system string, opts ...Option) *Schema {
 	cfg := &config{}
 	for _, opt := range opts {
 		opt(cfg)
 	}
-	switch GetVersion() {
-	case SchemaV1:
-		s := fmt.Sprintf("%s.server.request", system)
-		return SimpleSchema(func() string { return s })
-	default:
-		if cfg.overrideV0 != nil {
-			return SimpleSchema(func() string { return *cfg.overrideV0 })
-		}
-		s := fmt.Sprintf("%s.request", system)
-		return SimpleSchema(func() string { return s })
-
-	}
+	return New(&serverInboundOp{cfg: cfg, system: system})
 }
 
 func (s *serverInboundOp) V0() string {
@@ -82,7 +63,7 @@ func NewHTTPClientOp(opts ...Option) *Schema {
 }
 
 // NewHTTPServerOp creates a new schema for HTTP server inbound operations.
-func NewHTTPServerOp(opts ...Option) Namer {
+func NewHTTPServerOp(opts ...Option) *Schema {
 	return NewServerInboundOp("http", opts...)
 }
 
@@ -93,12 +74,12 @@ func NewGRPCClientOp(opts ...Option) *Schema {
 }
 
 // NewGRPCServerOp creates a new schema for gRPC server inbound operations.
-func NewGRPCServerOp(opts ...Option) Namer {
+func NewGRPCServerOp(opts ...Option) *Schema {
 	newOpts := append([]Option{WithOverrideV0("grpc.server")}, opts...)
 	return NewServerInboundOp("grpc", newOpts...)
 }
 
 // NewGraphqlServerOp creates a new schema for GraphQL server inbound operations.
-func NewGraphqlServerOp(opts ...Option) Namer {
+func NewGraphqlServerOp(opts ...Option) *Schema {
 	return NewServerInboundOp("graphql", opts...)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This commit improves the performance of starting a span by reducing work
done, especially allocations.

### Motivation

We were seeing a large increase in memory and CPU usage while starting spans compared to previous versions.


### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.