### PR TITLE
internal: Improve the Iter performance of LockMap on empty maps

### DIFF
--- a/internal/utils.go
+++ b/internal/utils.go
@@ -5,21 +5,29 @@
 
 package internal
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
 // LockMap uses an RWMutex to synchronize map access to allow for concurrent access.
 // This should not be used for cases with heavy write load and performance concerns.
 type LockMap struct {
 	sync.RWMutex
+	c uint32
 	m map[string]string
 }
 
 func NewLockMap(m map[string]string) *LockMap {
-	return &LockMap{m: m}
+	return &LockMap{m: m, c: uint32(len(m))}
 }
 
 // Iter iterates over all the map entries passing in keys and values to provided func f. Note this is READ ONLY.
 func (l *LockMap) Iter(f func(key string, val string)) {
+	c := atomic.LoadUint32(&l.c)
+	if c == 0 { //Fast exit to avoid the cost of RLock/RUnlock for empty maps
+		return
+	}
 	l.RLock()
 	defer l.RUnlock()
 	for k, v := range l.m {
@@ -37,11 +45,15 @@ func (l *LockMap) Clear() {
 	l.Lock()
 	defer l.Unlock()
 	l.m = map[string]string{}
+	atomic.StoreUint32(&l.c, 0)
 }
 
 func (l *LockMap) Set(k, v string) {
 	l.Lock()
 	defer l.Unlock()
+	if _, ok := l.m[k]; !ok {
+		atomic.AddUint32(&l.c, 1)
+	}
 	l.m[k] = v
 }
 

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package internal
+
+import (
+	"context"
+	"math/rand"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func BenchmarkIter(b *testing.B) {
+	m := NewLockMap(nil)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Iter(func(key string, val string) {})
+	}
+}
+
+func TestLockMapThrash(t *testing.T) {
+	wg := sync.WaitGroup{}
+	ctx, _ := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	lm := NewLockMap(map[string]string{})
+	wg.Add(6)
+	for i := 0; i < 3; i++ {
+		// Readers
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					lm.Iter(func(key string, val string) {
+						_ = key + val //fake work
+					})
+				}
+			}
+		}()
+		// Writers
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					lm.Set(strings.Repeat("a", rand.Int()%10), "val")
+					if rand.Int()%3 == 0 {
+						lm.Clear()
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, len(lm.m), int(lm.c))
+}


### PR DESCRIPTION
Turns out doing RLock and RUnlock can still be slow especially when this code is in a HOT path. For most users this map will be empty. Therefore it's worth speeding up that case at the cost of a tiny bit of extra memory and a bit of complexity.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Cherry-picks across #2127 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.