### PR TITLE
github: better initial generated notes with release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+# Reference: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    labels:
+      - no-changelog
+  categories:
+    - title: "Application Performance Monitoring (APM)"
+      labels:
+        - apm:core
+        - apm:ecosystem
+    - title: "Application Security Management (ASM)"
+      labels:
+        - appsec
+    - title: "Profiling"
+      labels:
+        - profiler
+    - title: "General"
+      labels:
+        - "*"


### PR DESCRIPTION
Generate the release notes with a better state than GitHub's default where PRs are split by Datadog product according to the PR labels:
- no-changelog: do not include this PR in the changelog
- appsec: appsec-related change
- profiler: profiler-related change
- apm:core and apm:ecosystem: APM-related change

Note that GitHub doesn't allow to further customize the exact template, but only this list of top-level categories for now.