### PR TITLE
Update benchmarks CI image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,8 +3,8 @@ stages:
   - test-apps
 
 variables:
-  # This base image is created here: https://gitlab.ddbuild.io/DataDog/apm-reliability/benchmarking-platform/-/pipelines/16323186
-  BASE_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dd-trace-go-16323186
+  # This base image is created here: https://gitlab.ddbuild.io/DataDog/apm-reliability/benchmarking-platform/-/pipelines/17228699
+  BASE_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dd-trace-go-17228699
   INDEX_FILE: index.txt
   KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-go
   FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"


### PR DESCRIPTION
### What does this PR do?

Includes fixes and improvements in benchmark analyzer and PR commenter, in particular:
* Fixes timeout in PR commenter due to Github GraphQL API changes;
* Fixes unit of measurement rounding in benchmark analyzer;
* Fixes incorrect display of instructions count.

### Motivation

Ensure that benchmarking pipeline is running smoothly and has latest updates.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.