### PR TITLE
contrib/internal/httptrace: improve performance of span starts (cherry-pick #2128)

### DIFF
--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -31,28 +31,34 @@ var (
 func StartRequestSpan(r *http.Request, opts ...ddtrace.StartSpanOption) (tracer.Span, context.Context) {
 	// Append our span options before the given ones so that the caller can "overwrite" them.
 	// TODO(): rework span start option handling (https://github.com/DataDog/dd-trace-go/issues/1352)
-	opts = append([]ddtrace.StartSpanOption{
-		tracer.SpanType(ext.SpanTypeWeb),
-		tracer.Tag(ext.HTTPMethod, r.Method),
-		tracer.Tag(ext.HTTPURL, urlFromRequest(r)),
-		tracer.Tag(ext.HTTPUserAgent, r.UserAgent()),
-		tracer.Measured(),
-	}, opts...)
-	if r.Host != "" {
-		opts = append([]ddtrace.StartSpanOption{
-			tracer.Tag("http.host", r.Host),
-		}, opts...)
-	}
-	if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(r.Header)); err == nil {
-		opts = append(opts, tracer.ChildOf(spanctx))
-	}
+
+	var ipTags map[string]string
 	if cfg.traceClientIP {
-		ipTags, _ := httpsec.ClientIPTags(r.Header, true, r.RemoteAddr)
-		for k, v := range ipTags {
-			opts = append(opts, tracer.Tag(k, v))
-		}
+		ipTags, _ = httpsec.ClientIPTags(r.Header, true, r.RemoteAddr)
 	}
-	return tracer.StartSpanFromContext(r.Context(), namingschema.NewHTTPServerOp().GetName(), opts...)
+	nopts := make([]ddtrace.StartSpanOption, 0, len(opts)+1+len(ipTags))
+	nopts = append(nopts,
+		func(cfg *ddtrace.StartSpanConfig) {
+			if cfg.Tags == nil {
+				cfg.Tags = make(map[string]interface{})
+			}
+			cfg.Tags[ext.SpanType] = ext.SpanTypeWeb
+			cfg.Tags[ext.HTTPMethod] = r.Method
+			cfg.Tags[ext.HTTPURL] = urlFromRequest(r)
+			cfg.Tags[ext.HTTPUserAgent] = r.UserAgent()
+			cfg.Tags["_dd.measured"] = 1
+			if r.Host != "" {
+				cfg.Tags["http.host"] = r.Host
+			}
+			if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(r.Header)); err == nil {
+				cfg.Parent = spanctx
+			}
+			for k, v := range ipTags {
+				cfg.Tags[k] = v
+			}
+		})
+	nopts = append(nopts, opts...)
+	return tracer.StartSpanFromContext(r.Context(), namingschema.NewHTTPServerOp().GetName(), nopts...)
 }
 
 // FinishRequestSpan finishes the given HTTP request span and sets the expected response-related tags such as the status


### PR DESCRIPTION
This commit improves the performance of starting a span by reducing work done, especially allocations.

Cherry-pick of #2128 

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.