### PR TITLE
contrib/emicklei/go-restful.v3: fix componentName (cherry-pick #2132)

### DIFF
--- a/contrib/emicklei/go-restful.v3/restful.go
+++ b/contrib/emicklei/go-restful.v3/restful.go
@@ -19,7 +19,7 @@ import (
 	"github.com/emicklei/go-restful/v3"
 )
 
-const componentName = "emicklei/go-restful/v3"
+const componentName = "emicklei/go-restful.v3"
 
 func init() {
 	telemetry.LoadIntegration(componentName)

--- a/contrib/emicklei/go-restful.v3/restful_test.go
+++ b/contrib/emicklei/go-restful.v3/restful_test.go
@@ -160,7 +160,7 @@ func TestTrace200(t *testing.T) {
 	assert.Equal("GET", span.Tag(ext.HTTPMethod))
 	assert.Equal("http://example.com/user/123", span.Tag(ext.HTTPURL))
 	assert.Equal(ext.SpanKindServer, span.Tag(ext.SpanKind))
-	assert.Equal("emicklei/go-restful/v3", span.Tag(ext.Component))
+	assert.Equal("emicklei/go-restful.v3", span.Tag(ext.Component))
 }
 
 func TestError(t *testing.T) {
@@ -194,7 +194,7 @@ func TestError(t *testing.T) {
 	assert.Equal("500", span.Tag(ext.HTTPCode))
 	assert.Equal(wantErr.Error(), span.Tag(ext.Error).(error).Error())
 	assert.Equal(ext.SpanKindServer, span.Tag(ext.SpanKind))
-	assert.Equal("emicklei/go-restful/v3", span.Tag(ext.Component))
+	assert.Equal("emicklei/go-restful.v3", span.Tag(ext.Component))
 }
 
 func TestPropagation(t *testing.T) {


### PR DESCRIPTION
After #2092, where the integration was moved to the correct folder, I forgot to update the componentName as well.

This is a cherry-pick of #2132 onto the v1.53.x release branch.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.