### PR TITLE
contrib/{internal/httptrace, net/http}: fix memory leak and request closure

### DIFF
--- a/contrib/net/http/http.go
+++ b/contrib/net/http/http.go
@@ -53,11 +53,11 @@ func (mux *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if resource == "" {
 		resource = r.Method + " " + route
 	}
-	mux.cfg.spanOpts = append(mux.cfg.spanOpts, httptrace.HeaderTagsFromRequest(r, mux.cfg.headerTags))
+	spanOpts := append(mux.cfg.spanOpts, httptrace.HeaderTagsFromRequest(r, mux.cfg.headerTags))
 	TraceAndServe(mux.ServeMux, w, r, &ServeConfig{
 		Service:  mux.cfg.serviceName,
 		Resource: resource,
-		SpanOpts: mux.cfg.spanOpts,
+		SpanOpts: spanOpts,
 		Route:    route,
 	})
 }


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
This pull request addresses one major and one minor performance issue.

The major issue is in contrib/net/http, where (*ServeMux).ServeHTTP adds an element to it's spanOpts slice every time a request is served. This is both a race, and it grows the slice unbounded resulting in a memory leak, and a huge amount of CPU time spent copying the slice.


<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.