### PR TITLE
contrib/{internal/httptrace, net/http}: fix memory leak and request closure (cherry-pick #2138)

### DIFF
--- a/contrib/net/http/http.go
+++ b/contrib/net/http/http.go
@@ -53,11 +53,11 @@ func (mux *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if resource == "" {
 		resource = r.Method + " " + route
 	}
-	mux.cfg.spanOpts = append(mux.cfg.spanOpts, httptrace.HeaderTagsFromRequest(r, mux.cfg.headerTags))
+	spanOpts := append(mux.cfg.spanOpts, httptrace.HeaderTagsFromRequest(r, mux.cfg.headerTags))
 	TraceAndServe(mux.ServeMux, w, r, &ServeConfig{
 		Service:  mux.cfg.serviceName,
 		Resource: resource,
-		SpanOpts: mux.cfg.spanOpts,
+		SpanOpts: spanOpts,
 		Route:    route,
 	})
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
This pull request addresses one major and one minor performance issue.

The major issue is in contrib/net/http, where (*ServeMux).ServeHTTP adds
an element to it's spanOpts slice every time a request is served. This is
both a race, and it grows the slice unbounded resulting in a memory leak,
and a huge amount of CPU time spent copying the slice.

The second, smaller issues is in contrib/internal/httptrace's
HeaderTagsFromRequest. This function created a closure which captured the
request including all of its headers. This may keep the request alive
longer than necessary. Instead we build the list of required headers and
return a function closing over just that list.

This cherry-picks #2138 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.