### PR TITLE
Revert "ddtrace/tracer: changed default tracecontext propagation order"

### DIFF
--- a/ddtrace/opentelemetry/tracer_provider.go
+++ b/ddtrace/opentelemetry/tracer_provider.go
@@ -27,9 +27,6 @@
 package opentelemetry
 
 import (
-	"fmt"
-	"os"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -60,46 +57,16 @@ func NewTracerProvider(opts ...tracer.StartOption) *TracerProvider {
 	return &TracerProvider{ddopts: opts}
 }
 
-const (
-	w3cPropagator                 = "tracecontext"
-	genericHeaderPropagationStyle = "DD_TRACE_PROPAGATION_STYLE"
-)
-
 // Tracer returns an instance of OpenTelemetry Tracer and initializes Datadog Tracer.
 // If the TracerProvider has already been shut down, this will return a no-op tracer.
 func (p *TracerProvider) Tracer(_ string, _ ...oteltrace.TracerOption) oteltrace.Tracer {
 	if atomic.LoadUint32(&p.stopped) != 0 {
 		return &noopOteltracer{}
 	}
-	setW3CPropagationStyle("DD_TRACE_PROPAGATION_STYLE_INJECT",
-		"DD_PROPAGATION_STYLE_INJECT", genericHeaderPropagationStyle)
-	setW3CPropagationStyle("DD_TRACE_PROPAGATION_STYLE_EXTRACT",
-		"DD_PROPAGATION_STYLE_EXTRACT", genericHeaderPropagationStyle)
 	tracer.Start(p.ddopts...)
 	return &oteltracer{
 		Tracer:   internal.GetGlobalTracer(),
 		provider: p,
-	}
-}
-
-func setW3CPropagationStyle(env ...string) {
-	for _, key := range env {
-		// if trace context propagation style was set but does not contain w3c propagator,
-		// append the w3c propagator
-		if v := os.Getenv(key); v != "" && !strings.Contains(v, w3cPropagator) {
-			style := fmt.Sprintf("%s,%s", v, w3cPropagator)
-			os.Setenv(key, style)
-			log.Info(fmt.Sprintf("W3C context propagation not enabled. "+
-				"Updating '%s' from '%s' to '%s'.", key, v, style))
-			return
-		}
-	}
-	// trace context propagation was not configured through environment variable,
-	// setting propagation style to tracecontext
-	if v := os.Getenv(genericHeaderPropagationStyle); v == "" {
-		log.Info(fmt.Sprintf("Trace context propagation style not configured. "+
-			"Setting '%s' to '%s'.", genericHeaderPropagationStyle, w3cPropagator))
-		os.Setenv(genericHeaderPropagationStyle, w3cPropagator)
 	}
 }
 

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -487,14 +487,14 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			defer os.Unsetenv("DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH")
 			assert := assert.New(t)
 			c := newConfig()
-			p := c.propagator.(*chainedPropagator).injectors[0].(*propagator)
+			p := c.propagator.(*chainedPropagator).injectors[1].(*propagator)
 			assert.Equal(200, p.cfg.MaxTagsHeaderLen)
 		})
 
 		t.Run("default", func(t *testing.T) {
 			assert := assert.New(t)
 			c := newConfig()
-			p := c.propagator.(*chainedPropagator).injectors[0].(*propagator)
+			p := c.propagator.(*chainedPropagator).injectors[1].(*propagator)
 			assert.Equal(128, p.cfg.MaxTagsHeaderLen)
 		})
 
@@ -503,7 +503,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			defer os.Unsetenv("DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH")
 			assert := assert.New(t)
 			c := newConfig()
-			p := c.propagator.(*chainedPropagator).injectors[0].(*propagator)
+			p := c.propagator.(*chainedPropagator).injectors[1].(*propagator)
 			assert.Equal(0, p.cfg.MaxTagsHeaderLen)
 		})
 
@@ -512,7 +512,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			defer os.Unsetenv("DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH")
 			assert := assert.New(t)
 			c := newConfig()
-			p := c.propagator.(*chainedPropagator).injectors[0].(*propagator)
+			p := c.propagator.(*chainedPropagator).injectors[1].(*propagator)
 			assert.Equal(512, p.cfg.MaxTagsHeaderLen)
 		})
 	})

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -193,7 +193,7 @@ type chainedPropagator struct {
 // a warning and be ignored.
 func getPropagators(cfg *PropagatorConfig, ps string) []Propagator {
 	dd := &propagator{cfg}
-	defaultPs := []Propagator{dd}
+	defaultPs := []Propagator{&propagatorW3c{}, dd}
 	if cfg.B3 {
 		defaultPs = append(defaultPs, &propagatorB3{})
 	}
@@ -217,7 +217,7 @@ func getPropagators(cfg *PropagatorConfig, ps string) []Propagator {
 		case "datadog":
 			list = append(list, dd)
 		case "tracecontext":
-			list = append(list, &propagatorW3c{})
+			list = append([]Propagator{&propagatorW3c{}}, list...)
 		case "b3", "b3multi":
 			if !cfg.B3 {
 				// propagatorB3 hasn't already been added, add a new one.

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -819,7 +819,6 @@ func TestEnvVars(t *testing.T) {
 			{headerPropagationStyleInjectDeprecated: "datadog", headerPropagationStyleExtractDeprecated: "datadog"},
 			{headerPropagationStyleInject: "datadog", headerPropagationStyle: "datadog"},
 			{headerPropagationStyle: "datadog"},
-			{headerPropagationStyle: ""},
 		}
 		for _, testEnv := range testEnvs {
 			for k, v := range testEnv {
@@ -1131,10 +1130,11 @@ func TestEnvVars(t *testing.T) {
 		}
 	})
 
-	t.Run("w3c extract / datadog inject", func(t *testing.T) {
+	t.Run("w3c extract / w3c,datadog inject", func(t *testing.T) {
 		testEnvs = []map[string]string{
 			{headerPropagationStyleExtract: "traceContext"},
 			{headerPropagationStyleExtractDeprecated: "traceContext,none" /* none should have no affect */},
+			{headerPropagationStyle: "traceContext"},
 		}
 		for _, testEnv := range testEnvs {
 			for k, v := range testEnv {
@@ -1155,6 +1155,8 @@ func TestEnvVars(t *testing.T) {
 						tracestateHeader:  "foo=1,dd=s:-1",
 					},
 					outHeaders: TextMapCarrier{
+						traceparentHeader:     "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00",
+						tracestateHeader:      "dd=s:-1;o:synthetics;t.tid:4bf92f3577b34da6,foo=1",
 						DefaultPriorityHeader: "-1",
 						DefaultTraceIDHeader:  "4bf92f3577b34da6a3ce929d0e0e4736",
 						DefaultParentIDHeader: "00f067aa0ba902b7",
@@ -1622,7 +1624,6 @@ func checkSameElements(assert *assert.Assertions, want, got string) {
 }
 
 func TestW3CExtractsBaggage(t *testing.T) {
-	t.Setenv(headerPropagationStyle, "tracecontext")
 	tracer := newTracer()
 	defer tracer.Stop()
 	headers := TextMapCarrier{


### PR DESCRIPTION
Reverts DataDog/dd-trace-go#2072

We do not want to change the default context propagation at this time.