### PR TITLE
[WIP] ddtrace/tracer: create debug mode for old, open spans

### DIFF
--- a/ddtrace/tracer/open_spans.go
+++ b/ddtrace/tracer/open_spans.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package tracer
+
+import (
+	"time"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+)
+
+// reportOpenSpans periodically finds and reports old, open spans at
+// the given interval.
+func (t *tracer) reportOpenSpans(interval time.Duration) {
+	tick := time.NewTicker(1 * time.Second)
+	defer tick.Stop()
+	for {
+		select {
+		case <-tick.C:
+			// check for open spans
+			for e := t.openSpans.Front(); e != nil; e = e.Next() {
+				sp := e.Value.(*span)
+				life := now() - sp.Start
+				if life >= interval.Nanoseconds() {
+					log.Debug("Trace %v waiting on span %v", sp.Context().TraceID(), sp.Context().SpanID())
+				}
+			}
+		case s := <-t.cIn:
+			t.openSpans.PushBack(s)
+		case s := <-t.cOut:
+			for e := t.openSpans.Front(); e != nil; e = e.Next() {
+				if e.Value == s {
+					t.openSpans.Remove(e)
+					break
+				}
+			}
+		case <-t.stop:
+			return
+		}
+	}
+}

--- a/ddtrace/tracer/open_spans.go
+++ b/ddtrace/tracer/open_spans.go
@@ -14,7 +14,7 @@ import (
 // reportOpenSpans periodically finds and reports old, open spans at
 // the given interval.
 func (t *tracer) reportOpenSpans(interval time.Duration) {
-	tick := time.NewTicker(1 * time.Second)
+	tick := time.NewTicker(interval)
 	defer tick.Stop()
 	for {
 		select {

--- a/ddtrace/tracer/open_spans_test.go
+++ b/ddtrace/tracer/open_spans_test.go
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package tracer
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/version"
+)
+
+func TestReportOpenSpans(t *testing.T) {
+	assert := assert.New(t)
+	tp := new(log.RecordLogger)
+
+	tracer, _, _, stop := startTestTracer(t, WithLogger(tp), WithDebugSpansMode(true), WithDebugMode(true))
+	defer stop()
+
+	tp.Reset()
+	tp.Ignore("appsec: ", telemetry.LogPrefix)
+
+	t.Run("finished", func(t *testing.T) {
+		s := tracer.StartSpan("operation")
+		s.Finish()
+		time.Sleep(3 * time.Second)
+		expected := fmt.Sprintf("Datadog Tracer %v DEBUG: Trace %v waiting on span %v", version.Tag, s.Context().TraceID(), s.Context().SpanID())
+		assert.NotContains(tp.Logs(), expected)
+	})
+
+	t.Run("open", func(t *testing.T) {
+		s := tracer.StartSpan("operation")
+		time.Sleep(3 * time.Second)
+		expected := fmt.Sprintf("Datadog Tracer %v DEBUG: Trace %v waiting on span %v", version.Tag, s.Context().TraceID(), s.Context().SpanID())
+		assert.Contains(tp.Logs(), expected)
+		s.Finish()
+	})
+
+	t.Run("both", func(t *testing.T) {
+		sf := tracer.StartSpan("op")
+		sf.Finish()
+		s := tracer.StartSpan("op2")
+		time.Sleep(3 * time.Second)
+		notExpected := fmt.Sprintf("Datadog Tracer %v DEBUG: Trace %v waiting on span %v", version.Tag, sf.Context().TraceID(), sf.Context().SpanID())
+		expected := fmt.Sprintf("Datadog Tracer %v DEBUG: Trace %v waiting on span %v", version.Tag, s.Context().TraceID(), s.Context().SpanID())
+		assert.NotContains(tp.Logs(), notExpected)
+		assert.Contains(tp.Logs(), expected)
+		s.Finish()
+	})
+}
+
+func TestDebugOpenSpansOff(t *testing.T) {
+	assert := assert.New(t)
+	tp := new(log.RecordLogger)
+	tracer, _, _, stop := startTestTracer(t, WithLogger(tp), WithDebugMode(true))
+	defer stop()
+
+	tp.Reset()
+	tp.Ignore("appsec: ", telemetry.LogPrefix)
+
+	t.Run("default", func(t *testing.T) {
+		assert.False(tracer.config.debugOpenSpans)
+		assert.Empty(tracer.openSpans)
+		s := tracer.StartSpan("operation")
+		time.Sleep(3 * time.Second)
+		expected := fmt.Sprintf("Datadog Tracer %v DEBUG: Trace %v waiting on span %v", version.Tag, s.Context().TraceID(), s.Context().SpanID())
+		assert.NotContains(tp.Logs(), expected)
+		s.Finish()
+	})
+}

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -517,6 +517,9 @@ func (s *span) finish(finishTime int64) {
 			// the agent supports dropping p0's in the client
 			keep = shouldKeep(s)
 		}
+		if t.config.debugOpenSpans {
+			t.cOut <- s
+		}
 	}
 	if keep {
 		// a single kept span keeps the whole trace.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR introduces a debugging mode that the user can configure for finding and logging old, unfinished spans. Traces/Spans older than some configured `X` amount of time will be printed to the debug logs.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Traces with unfinished spans may never finish but never error, which causes confusion when data goes missing.

Fixes #2064

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

New and old unit tests should pass. For manual testing, turn on the debug mode with `WithDebugSpansMode(true)`. Create spans older than the configured amount of time (default value: 1 second) and check that they are printed out in the tracer logs.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.