### PR TITLE
tracer: don't log a warning if tracestate is present when propagating DD tags

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -324,6 +324,9 @@ func (p *propagator) marshalPropagatingTags(ctx *spanContext) string {
 
 	var properr string
 	ctx.trace.iteratePropagatingTags(func(k, v string) bool {
+		if k == tracestateHeader || k == traceparentHeader {
+			return true // don't propagate W3C headers with the DD propagator
+		}
 		if err := isValidPropagatableTag(k, v); err != nil {
 			log.Warn("Won't propagate tag '%s': %v", k, err.Error())
 			properr = "encoding_error"
@@ -703,7 +706,7 @@ var (
 	// equals (reserved for list-member key-value separator),
 	// space and characters outside the ASCII range 0x20 to 0x7E.
 	// Disallowed characters must be replaced with the underscore.
-	keyRgx = regexp.MustCompile(",|=|[^\\x20-\\x7E]+")
+	keyRgx = regexp.MustCompile(`,|=|[^\\x20-\\x7E]+`)
 
 	// valueRgx is used to sanitize the values of the datadog propagating tags.
 	// Disallowed characters are comma (reserved as a list-member separator),
@@ -712,7 +715,7 @@ var (
 	// and characters outside the ASCII range 0x20 to 0x7E.
 	// Equals character must be encoded with a tilde.
 	// Other disallowed characters must be replaced with the underscore.
-	valueRgx = regexp.MustCompile(",|;|~|[^\\x20-\\x7E]+")
+	valueRgx = regexp.MustCompile(`,|;|~|[^\\x20-\\x7E]+`)
 
 	// originRgx is used to sanitize the value of the datadog origin tag.
 	// Disallowed characters are comma (reserved as a list-member separator),
@@ -721,12 +724,12 @@ var (
 	// and characters outside the ASCII range 0x21 to 0x7E.
 	// Equals character must be encoded with a tilde.
 	// Other disallowed characters must be replaced with the underscore.
-	originRgx = regexp.MustCompile(",|~|;|[^\\x21-\\x7E]+")
+	originRgx = regexp.MustCompile(`,|~|;|[^\\x21-\\x7E]+`)
 
 	// validIDRgx is used to verify that the input is a valid hex string.
 	// The input must match the pattern from start to end.
 	// validIDRgx is applicable for both trace and span IDs.
-	validIDRgx = regexp.MustCompile("^[a-f0-9]+$")
+	validIDRgx = regexp.MustCompile(`^[a-f0-9]+$`)
 )
 
 // composeTracestate creates a tracestateHeader from the spancontext.

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -720,30 +720,26 @@ var (
 	// equals (reserved for list-member key-value separator),
 	// space and characters outside the ASCII range 0x20 to 0x7E.
 	// Disallowed characters must be replaced with the underscore.
-	keyRgx = regexp.MustCompile(`,|=|[^\\x20-\\x7E]+`)
+	keyRgx = regexp.MustCompile(",|=|[^\\x20-\\x7E]+")
 
 	// valueRgx is used to sanitize the values of the datadog propagating tags.
 	// Disallowed characters are comma (reserved as a list-member separator),
-	// semi-colon (reserved for separator between entries in the dd list-member),
-	// tilde (reserved, will represent 0x3D (equals) in the encoded tag value,
 	// and characters outside the ASCII range 0x20 to 0x7E.
 	// Equals character must be encoded with a tilde.
 	// Other disallowed characters must be replaced with the underscore.
-	valueRgx = regexp.MustCompile(`,|;|~|[^\\x20-\\x7E]+`)
+	valueRgx = regexp.MustCompile(",|;|~|[^\\x20-\\x7E]+")
 
 	// originRgx is used to sanitize the value of the datadog origin tag.
 	// Disallowed characters are comma (reserved as a list-member separator),
-	// semi-colon (reserved for separator between entries in the dd list-member),
-	// equals (reserved for list-member key-value separator),
 	// and characters outside the ASCII range 0x21 to 0x7E.
 	// Equals character must be encoded with a tilde.
 	// Other disallowed characters must be replaced with the underscore.
-	originRgx = regexp.MustCompile(`,|~|;|[^\\x21-\\x7E]+`)
+	originRgx = regexp.MustCompile(",|~|;|[^\\x21-\\x7E]+")
 
 	// validIDRgx is used to verify that the input is a valid hex string.
 	// The input must match the pattern from start to end.
 	// validIDRgx is applicable for both trace and span IDs.
-	validIDRgx = regexp.MustCompile(`^[a-f0-9]+$`)
+	validIDRgx = regexp.MustCompile("^[a-f0-9]+$")
 )
 
 // composeTracestate creates a tracestateHeader from the spancontext.
@@ -948,6 +944,7 @@ func parseTracestate(ctx *spanContext, header string) {
 			}
 			key, val := keyVal[0], keyVal[1]
 			if key == "o" {
+				// ctx.origin could be empty here, so shouldn't we use the origin in the key??
 				ctx.origin = strings.ReplaceAll(val, "~", "=")
 			} else if key == "s" {
 				stateP, err := strconv.Atoi(val)

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -948,7 +948,6 @@ func parseTracestate(ctx *spanContext, header string) {
 			}
 			key, val := keyVal[0], keyVal[1]
 			if key == "o" {
-				// ctx.origin could be empty here, so shouldn't we use the origin in the key??
 				ctx.origin = strings.ReplaceAll(val, "~", "=")
 			} else if key == "s" {
 				stateP, err := strconv.Atoi(val)

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -724,6 +724,8 @@ var (
 
 	// valueRgx is used to sanitize the values of the datadog propagating tags.
 	// Disallowed characters are comma (reserved as a list-member separator),
+	// semi-colon (reserved for separator between entries in the dd list-member),
+	// tilde (reserved, will represent 0x3D (equals) in the encoded tag value,
 	// and characters outside the ASCII range 0x20 to 0x7E.
 	// Equals character must be encoded with a tilde.
 	// Other disallowed characters must be replaced with the underscore.
@@ -731,6 +733,8 @@ var (
 
 	// originRgx is used to sanitize the value of the datadog origin tag.
 	// Disallowed characters are comma (reserved as a list-member separator),
+	// semi-colon (reserved for separator between entries in the dd list-member),
+	// equals (reserved for list-member key-value separator),
 	// and characters outside the ASCII range 0x21 to 0x7E.
 	// Equals character must be encoded with a tilde.
 	// Other disallowed characters must be replaced with the underscore.

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -306,36 +306,36 @@ func TestTextMapPropagator(t *testing.T) {
 			tags:        bigMap,
 			errStr:      "inject_max_size",
 		}, {
-			name:               "InjectInvalidComma",
+			name:               "InvalidComma",
 			injectStyle:        "datadog",
 			tags:               map[string]string{"_dd.p.hello1": "world", "_dd.p.hello2": "malformed,"},
 			xDatadogTagsHeader: "_dd.p.dm=-1,_dd.p.hello1=world",
 			errStr:             "encoding_error",
 		}, {
-			name:               "InjectInvalidChar",
+			name:               "InvalidChar",
 			injectStyle:        "datadog",
 			tags:               map[string]string{"_dd.p.hello": "ÜwÜ"},
 			xDatadogTagsHeader: "_dd.p.dm=-1",
 			errStr:             "encoding_error",
 		}, {
-			name:               "InjectTracestate-Datadog",
+			name:               "Tracestate-Datadog",
 			injectStyle:        "datadog",
 			tags:               map[string]string{"_dd.p.hello1": "world", tracestateHeader: "shouldbe=ignored"},
 			xDatadogTagsHeader: "_dd.p.dm=-1,_dd.p.hello1=world",
 		}, {
-			name:               "InjectTraceparent-Datadog",
+			name:               "Traceparent-Datadog",
 			injectStyle:        "datadog",
 			tags:               map[string]string{"_dd.p.hello1": "world", traceparentHeader: "00-00000000000000001111111111111111-2222222222222222-01"},
 			xDatadogTagsHeader: "_dd.p.dm=-1,_dd.p.hello1=world",
 		}, {
-			name:               "InjectTracestate-Datadog",
+			name:               "Tracestate-Datadog",
 			injectStyle:        "tracecontext,datadog",
 			tags:               map[string]string{"_dd.p.hello1": "world", tracestateHeader: "shouldbe=kept"},
 			xDatadogTagsHeader: "_dd.p.dm=-1,_dd.p.hello1=world",
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run("Inject-"+tc.name, func(t *testing.T) {
 			t.Setenv(headerPropagationStyleInject, tc.injectStyle)
 			tracer := newTracer()
 			defer tracer.Stop()

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -291,7 +291,84 @@ func TestExtractOriginSynthetics(t *testing.T) {
 }
 
 func TestTextMapPropagator(t *testing.T) {
-	t.Run("InvalidTraceTagsHeader", func(t *testing.T) {
+	bigMap := make(map[string]string)
+	for i := 0; i < 100; i++ {
+		bigMap[fmt.Sprintf("someKey%d", i)] = fmt.Sprintf("someValue%d", i)
+	}
+	tests := []struct {
+		name, injectStyle          string
+		tags                       map[string]string
+		xDatadogTagsHeader, errStr string
+	}{
+		{
+			name:        "InjectTooManyTags",
+			injectStyle: "datadog",
+			tags:        bigMap,
+			errStr:      "inject_max_size",
+		}, {
+			name:               "InjectInvalidComma",
+			injectStyle:        "datadog",
+			tags:               map[string]string{"_dd.p.hello1": "world", "_dd.p.hello2": "malformed,"},
+			xDatadogTagsHeader: "_dd.p.dm=-1,_dd.p.hello1=world",
+			errStr:             "encoding_error",
+		}, {
+			name:               "InjectInvalidChar",
+			injectStyle:        "datadog",
+			tags:               map[string]string{"_dd.p.hello": "ÜwÜ"},
+			xDatadogTagsHeader: "_dd.p.dm=-1",
+			errStr:             "encoding_error",
+		}, {
+			name:               "InjectTracestate-Datadog",
+			injectStyle:        "datadog",
+			tags:               map[string]string{"_dd.p.hello1": "world", tracestateHeader: "shouldbe=ignored"},
+			xDatadogTagsHeader: "_dd.p.dm=-1,_dd.p.hello1=world",
+		}, {
+			name:               "InjectTraceparent-Datadog",
+			injectStyle:        "datadog",
+			tags:               map[string]string{"_dd.p.hello1": "world", traceparentHeader: "00-00000000000000001111111111111111-2222222222222222-01"},
+			xDatadogTagsHeader: "_dd.p.dm=-1,_dd.p.hello1=world",
+		}, {
+			name:               "InjectTracestate-Datadog",
+			injectStyle:        "tracecontext,datadog",
+			tags:               map[string]string{"_dd.p.hello1": "world", tracestateHeader: "shouldbe=kept"},
+			xDatadogTagsHeader: "_dd.p.dm=-1,_dd.p.hello1=world",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(headerPropagationStyleInject, tc.injectStyle)
+			tracer := newTracer()
+			defer tracer.Stop()
+			internal.SetGlobalTracer(tracer)
+			child := tracer.StartSpan("test")
+			for k, v := range tc.tags {
+				child.Context().(*spanContext).trace.setPropagatingTag(k, v)
+			}
+			childSpanID := child.Context().(*spanContext).spanID
+			dst := map[string]string{}
+			err := tracer.Inject(child.Context(), TextMapCarrier(dst))
+			assert.Nil(t, err)
+			ddHeadersLen := 3 // x-datadog-parent-id, x-datadog-trace-id, x-datadog-sampling-priority
+			if tc.xDatadogTagsHeader != "" {
+				ddHeadersLen++ // x-datadog-tags
+			}
+			if strings.Contains(tc.injectStyle, "tracecontext") {
+				ddHeadersLen += 2 // tracestate, traceparent
+			}
+			assert.Len(t, dst, ddHeadersLen) // ensure that no extra headers exist that shouldn't
+			assert.Equal(t, strconv.Itoa(int(childSpanID)), dst["x-datadog-parent-id"])
+			assert.Equal(t, strconv.Itoa(int(childSpanID)), dst["x-datadog-trace-id"])
+			assert.Equal(t, "1", dst["x-datadog-sampling-priority"])
+			assertTraceTags(t, tc.xDatadogTagsHeader, dst["x-datadog-tags"])
+			if strings.Contains(tc.injectStyle, "tracecontext") {
+				// other unit tests check the value of these W3C headers, so just make sure they're present
+				assert.NotEmpty(t, dst[tracestateHeader])
+				assert.NotEmpty(t, dst[traceparentHeader])
+			}
+			assert.Equal(t, tc.errStr, child.Context().(*spanContext).trace.tags["_dd.propagation_error"])
+		})
+	}
+	t.Run("Extract-InvalidTraceTagsHeader", func(t *testing.T) {
 		t.Setenv(headerPropagationStyleExtract, "datadog")
 		src := TextMapCarrier(map[string]string{
 			DefaultTraceIDHeader:  "1",
@@ -307,17 +384,12 @@ func TestTextMapPropagator(t *testing.T) {
 		assert.Equal(t, "decoding_error", sctx.trace.tags["_dd.propagation_error"])
 	})
 
-	t.Run("ExtractTraceTagsTooLong", func(t *testing.T) {
+	t.Run("Extract-TooManyTags", func(t *testing.T) {
 		t.Setenv(headerPropagationStyleExtract, "datadog")
-		tags := make([]string, 0)
-		for i := 0; i < 100; i++ {
-			tags = append(tags, fmt.Sprintf("_dd.p.tag%d=value%d", i, i))
-		}
-		traceTags := strings.Join(tags, ",")
 		src := TextMapCarrier(map[string]string{
 			DefaultTraceIDHeader:  "1",
 			DefaultParentIDHeader: "1",
-			traceTagsHeader:       traceTags,
+			traceTagsHeader:       fmt.Sprintf("%s", bigMap),
 		})
 		tracer := newTracer()
 		defer tracer.Stop()
@@ -326,65 +398,6 @@ func TestTextMapPropagator(t *testing.T) {
 		sctx, ok := ctx.(*spanContext)
 		assert.True(t, ok)
 		assert.Equal(t, "extract_max_size", sctx.trace.tags["_dd.propagation_error"])
-	})
-
-	t.Run("InjectTraceTagsTooLong", func(t *testing.T) {
-		t.Setenv(headerPropagationStyleInject, "datadog")
-		tracer := newTracer()
-		defer tracer.Stop()
-		child := tracer.StartSpan("test")
-		for i := 0; i < 100; i++ {
-			child.Context().(*spanContext).trace.setPropagatingTag(fmt.Sprintf("someKey%d", i), fmt.Sprintf("someValue%d", i))
-		}
-		childSpanID := child.Context().(*spanContext).spanID
-		dst := map[string]string{}
-		err := tracer.Inject(child.Context(), TextMapCarrier(dst))
-		assert.Nil(t, err)
-		assert.Equal(t, map[string]string{
-			"x-datadog-parent-id":         strconv.Itoa(int(childSpanID)),
-			"x-datadog-trace-id":          strconv.Itoa(int(childSpanID)),
-			"x-datadog-sampling-priority": "1",
-		}, dst)
-		assert.Equal(t, "inject_max_size", child.Context().(*spanContext).trace.tags["_dd.propagation_error"])
-	})
-
-	t.Run("TracestateWithCommas", func(t *testing.T) {
-		t.Setenv(headerPropagationStyleInject, "datadog")
-		tracer := newTracer()
-		defer tracer.Stop()
-		internal.SetGlobalTracer(tracer)
-		child := tracer.StartSpan("test")
-		child.Context().(*spanContext).trace.setPropagatingTag("_dd.p.hello1", "world")
-		child.Context().(*spanContext).trace.setPropagatingTag("tracestate", "rojo=00f067aa0ba902b7,congo=t61rcWkgMzE")
-		childSpanID := child.Context().(*spanContext).spanID
-		dst := map[string]string{}
-		err := tracer.Inject(child.Context(), TextMapCarrier(dst))
-		assert.Nil(t, err)
-		assert.Len(t, dst, 4)
-		assert.Equal(t, strconv.Itoa(int(childSpanID)), dst["x-datadog-parent-id"])
-		assert.Equal(t, strconv.Itoa(int(childSpanID)), dst["x-datadog-trace-id"])
-		assert.Equal(t, "1", dst["x-datadog-sampling-priority"])
-		assertTraceTags(t, "_dd.p.dm=-1,_dd.p.hello1=world,tracestate=rojo=00f067aa0ba902b7,congo=t61rcWkgMzE", dst["x-datadog-tags"])
-		assert.Empty(t, child.Context().(*spanContext).trace.tags["_dd.propagation_error"])
-	})
-
-	t.Run("InvalidTraceTag", func(t *testing.T) {
-		t.Setenv(headerPropagationStyleInject, "datadog")
-		tracer := newTracer()
-		defer tracer.Stop()
-		internal.SetGlobalTracer(tracer)
-		child := tracer.StartSpan("test")
-		child.Context().(*spanContext).trace.setPropagatingTag("bad", "ÜwÜ")
-		childSpanID := child.Context().(*spanContext).spanID
-		dst := map[string]string{}
-		err := tracer.Inject(child.Context(), TextMapCarrier(dst))
-		assert.Nil(t, err)
-		assert.Len(t, dst, 4)
-		assert.Equal(t, strconv.Itoa(int(childSpanID)), dst["x-datadog-parent-id"])
-		assert.Equal(t, strconv.Itoa(int(childSpanID)), dst["x-datadog-trace-id"])
-		assert.Equal(t, "1", dst["x-datadog-sampling-priority"])
-		assertTraceTags(t, "_dd.p.dm=-1", dst["x-datadog-tags"])
-		assert.Equal(t, "encoding_error", child.Context().(*spanContext).trace.tags["_dd.propagation_error"])
 	})
 
 	t.Run("InjectExtract", func(t *testing.T) {

--- a/ddtrace/tracer/util.go
+++ b/ddtrace/tracer/util.go
@@ -84,7 +84,7 @@ func isValidPropagatableTag(k, v string) error {
 		return fmt.Errorf("value length must be greater than zero")
 	}
 	for _, ch := range v {
-		if ch < 32 || ch > 126 || ch == ',' {
+		if ch < 32 || ch > 126 {
 			return fmt.Errorf("value contains an invalid character %d", ch)
 		}
 	}

--- a/ddtrace/tracer/util.go
+++ b/ddtrace/tracer/util.go
@@ -84,7 +84,7 @@ func isValidPropagatableTag(k, v string) error {
 		return fmt.Errorf("value length must be greater than zero")
 	}
 	for _, ch := range v {
-		if ch < 32 || ch > 126 {
+		if ch < 32 || ch > 126 || ch == ',' {
 			return fmt.Errorf("value contains an invalid character %d", ch)
 		}
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Ensures that `tracestate` and `traceparent` headers will not be injected by DD context propagation, and that a warning won't be emitted if those are present in the propagating tags (they'll just be skipped instead).

This PR also refactors some tests to avoid repetition. If it's just more confusing, I can refactor it back, so feedback is welcome.

Fixes #2112

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

There is no need to marshal W3C headers during the DD context propagation injection. If those headers are present, and someone wants to propagate them, then they should instead ensure that `tracecontext` is in their list of propagation styles.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.