### PR TITLE
tracer: limit the scope of setting the priority when auto dropped

### DIFF
--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -23,7 +23,6 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/hostname"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/remoteconfig"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/samplernames"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/traceprof"
 
@@ -624,7 +623,7 @@ func (t *tracer) sample(span *span) {
 	sampler := t.config.sampler
 	if !sampler.Sample(span) {
 		span.context.trace.drop()
-		span.setSamplingPriority(ext.PriorityAutoReject, samplernames.RuleRate)
+		span.context.trace.setSamplingPriority(ext.PriorityAutoReject, SamplingRuleSpan)
 		return
 	}
 	if rs, ok := sampler.(RateSampler); ok && rs.Rate() < 1 {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Only change the priority of the trace, not the individual span, if it's dropped upon creation. This is a follow up of https://github.com/DataDog/dd-trace-go/pull/2067

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

We only need this because a sampling decision must be made before a chunk is partially flushed. Even though this will create 1 additional allocation, and a ~5% execution time degradation from the current code on main, it will only affect a single span in a trace. Once the decision has been made for the first span in the trace, then that decision will just be used for the remaining spans, so this code won't be reached. Typical use cases wouldn't notice any change in performance. It's also worth noting that this allocation likely would have been created anyway, just later down the line, because the trace priority will be finalized before flushing. Also note that this only creates one more allocation for this benchmark *per trace*, even though the benchmark makes it look like it's *per span*, because there is only a single pointer to a float for the entire trace.

```
pkg: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer
                  │   old.txt   │              new4.txt              │
                  │   sec/op    │   sec/op     vs base               │
TracerAddSpans-10   1.633µ ± 2%   1.710µ ± 2%  +4.72% (p=0.000 n=10)

                  │   old.txt    │              new4.txt               │
                  │     B/op     │     B/op      vs base               │
TracerAddSpans-10   2.124Ki ± 0%   2.132Ki ± 0%  +0.37% (p=0.000 n=10)

                  │  old.txt   │             new4.txt              │
                  │ allocs/op  │ allocs/op   vs base               │
TracerAddSpans-10   22.00 ± 0%   23.00 ± 0%  +4.55% (p=0.000 n=10)
```

Note that this is still better than [the original PR](https://github.com/DataDog/dd-trace-go/pull/2067), which had a ~10% performance time hit. Though this still probably would have been negligible for users:

```
pkg: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer
                  │   old.txt   │              new.txt               │
                  │   sec/op    │   sec/op     vs base               │
TracerAddSpans-10   1.633µ ± 2%   1.788µ ± 4%  +9.49% (p=0.000 n=10)

                  │   old.txt    │               new.txt               │
                  │     B/op     │     B/op      vs base               │
TracerAddSpans-10   2.124Ki ± 0%   2.132Ki ± 0%  +0.37% (p=0.000 n=10)

                  │  old.txt   │              new.txt              │
                  │ allocs/op  │ allocs/op   vs base               │
TracerAddSpans-10   22.00 ± 0%   23.00 ± 0%  +4.55% (p=0.000 n=10)
```

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
* Ideally your changes have automated unit and/or integration tests which are run in CI.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.