### PR TITLE
tracer: ease configuring client-side stats computation

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -1010,8 +1010,11 @@ func WithPartialFlushing(numSpans int) StartOption {
 	}
 }
 
-// WithStatsComputation enables client-side stats computation.
+// WithStatsComputation enables client-side stats computation, allowing
+// the tracer to compute stats from traces. This can reduce network traffic
+// to the Datadog Agent, and produce more accurate stats data.
 // This can also be configured by setting DD_TRACE_STATS_COMPUTATION_ENABLED to true.
+// Client-side stats is off by default.
 func WithStatsComputation(enabled bool) StartOption {
 	return func(c *config) {
 		c.statsComputationEnabled = enabled

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -235,6 +235,9 @@ type config struct {
 	// partialFlushEnabled specifices whether the tracer should enable partial flushing. Value
 	// from DD_TRACE_PARTIAL_FLUSH_ENABLED, default false.
 	partialFlushEnabled bool
+
+	// statsComputationEnabled enables client-side stats computation (aka trace metrics).
+	statsComputationEnabled bool
 }
 
 // HasFeature reports whether feature f is enabled.
@@ -311,6 +314,7 @@ func newConfig(opts ...StartOption) *config {
 	c.profilerEndpoints = internal.BoolEnv(traceprof.EndpointEnvVar, true)
 	c.profilerHotspots = internal.BoolEnv(traceprof.CodeHotspotsEnvVar, true)
 	c.enableHostnameDetection = internal.BoolEnv("DD_CLIENT_HOSTNAME_ENABLED", true)
+	c.statsComputationEnabled = internal.BoolEnv("DD_TRACE_STATS_COMPUTATION_ENABLED", false)
 	c.partialFlushEnabled = internal.BoolEnv("DD_TRACE_PARTIAL_FLUSH_ENABLED", false)
 	c.partialFlushMinSpans = internal.IntEnv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", partialFlushMinSpansDefault)
 	if c.partialFlushMinSpans <= 0 {
@@ -633,7 +637,7 @@ func (c *config) loadContribIntegrations(deps []*debug.Module) {
 }
 
 func (c *config) canComputeStats() bool {
-	return c.agent.Stats && c.HasFeature("discovery")
+	return c.agent.Stats && (c.HasFeature("discovery") || c.statsComputationEnabled)
 }
 
 func (c *config) canDropP0s() bool {
@@ -1003,6 +1007,14 @@ func WithPartialFlushing(numSpans int) StartOption {
 	return func(c *config) {
 		c.partialFlushEnabled = true
 		c.partialFlushMinSpans = numSpans
+	}
+}
+
+// WithStatsComputation enables client-side stats computation.
+// This can also be configured by setting DD_TRACE_STATS_COMPUTATION_ENABLED to true.
+func WithStatsComputation(enabled bool) StartOption {
+	return func(c *config) {
+		c.statsComputationEnabled = enabled
 	}
 }
 

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -1292,3 +1292,33 @@ func TestPartialFlushing(t *testing.T) {
 		assert.Equal(t, 20, c.partialFlushMinSpans)
 	})
 }
+
+func TestWithStatsComputation(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		assert := assert.New(t)
+		c := newConfig()
+		assert.False(c.statsComputationEnabled)
+	})
+	t.Run("enabled-via-option", func(t *testing.T) {
+		assert := assert.New(t)
+		c := newConfig(WithStatsComputation(true))
+		assert.True(c.statsComputationEnabled)
+	})
+	t.Run("disabled-via-option", func(t *testing.T) {
+		assert := assert.New(t)
+		c := newConfig(WithStatsComputation(false))
+		assert.False(c.statsComputationEnabled)
+	})
+	t.Run("enabled-via-env", func(t *testing.T) {
+		assert := assert.New(t)
+		t.Setenv("DD_TRACE_STATS_COMPUTATION_ENABLED", "true")
+		c := newConfig()
+		assert.True(c.statsComputationEnabled)
+	})
+	t.Run("env-override", func(t *testing.T) {
+		assert := assert.New(t)
+		t.Setenv("DD_TRACE_STATS_COMPUTATION_ENABLED", "false")
+		c := newConfig(WithStatsComputation(true))
+		assert.True(c.statsComputationEnabled)
+	})
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Allow controlling client-side stats via
- `WithStatsComputation` 
- `DD_TRACE_STATS_COMPUTATION_ENABLED`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

- Before this PR, the only way to enable client-side stats is to configure `DD_APM_FEATURES=discovery`. This PR makes it easier and more intuitive to enable client-side stats.
- Client-side stats reduce the load on the agent as it enables dropping P0s in the tracer, this PR is a step toward enabling them by default in the Go tracer.
- [[Internal doc](https://docs.google.com/document/d/1xEJzAW_z4H4slBC4E0rafadX69lHuCHJ43c60eSgWr0/edit) with more context on client-side stats]

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.