### PR TITLE
contrib/database/sql: use correct context for trace tasks in statements

### DIFF
--- a/contrib/database/sql/stmt.go
+++ b/contrib/database/sql/stmt.go
@@ -36,7 +36,7 @@ func (s *tracedStmt) Close() (err error) {
 func (s *tracedStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (res driver.Result, err error) {
 	start := time.Now()
 	if stmtExecContext, ok := s.Stmt.(driver.StmtExecContext); ok {
-		ctx, end := startTraceTask(s.ctx, QueryTypeExec)
+		ctx, end := startTraceTask(ctx, QueryTypeExec)
 		defer end()
 		res, err := stmtExecContext.ExecContext(ctx, args)
 		s.tryTrace(ctx, QueryTypeExec, s.query, start, err)
@@ -51,7 +51,7 @@ func (s *tracedStmt) ExecContext(ctx context.Context, args []driver.NamedValue) 
 		return nil, ctx.Err()
 	default:
 	}
-	ctx, end := startTraceTask(s.ctx, QueryTypeExec)
+	ctx, end := startTraceTask(ctx, QueryTypeExec)
 	defer end()
 	res, err = s.Exec(dargs)
 	s.tryTrace(ctx, QueryTypeExec, s.query, start, err)
@@ -62,7 +62,7 @@ func (s *tracedStmt) ExecContext(ctx context.Context, args []driver.NamedValue) 
 func (s *tracedStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (rows driver.Rows, err error) {
 	start := time.Now()
 	if stmtQueryContext, ok := s.Stmt.(driver.StmtQueryContext); ok {
-		ctx, end := startTraceTask(s.ctx, QueryTypeQuery)
+		ctx, end := startTraceTask(ctx, QueryTypeQuery)
 		defer end()
 		rows, err := stmtQueryContext.QueryContext(ctx, args)
 		s.tryTrace(ctx, QueryTypeQuery, s.query, start, err)
@@ -77,7 +77,7 @@ func (s *tracedStmt) QueryContext(ctx context.Context, args []driver.NamedValue)
 		return nil, ctx.Err()
 	default:
 	}
-	ctx, end := startTraceTask(s.ctx, QueryTypeQuery)
+	ctx, end := startTraceTask(ctx, QueryTypeQuery)
 	defer end()
 	rows, err = s.Query(dargs)
 	s.tryTrace(ctx, QueryTypeQuery, s.query, start, err)

--- a/contrib/database/sql/stmt_test.go
+++ b/contrib/database/sql/stmt_test.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package sql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUseStatementContext(t *testing.T) {
+	Register("sqlite3", &sqlite3.SQLiteDriver{})
+	db, err := Open("sqlite3", "file::memory:?cache=shared")
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Prepare using ctx1
+	ctx1, cancel := context.WithCancel(context.Background())
+	stmt, err := db.PrepareContext(ctx1, "SELECT 1")
+	require.NoError(t, err)
+	defer stmt.Close()
+	cancel()
+
+	// Query stmt using ctx2
+	ctx2 := context.Background()
+	var result int
+	require.NoError(t, stmt.QueryRowContext(ctx2).Scan(&result))
+}


### PR DESCRIPTION
### What does this PR do?

Uses the context passed to the execute/query call for a prepared statment,
rather than the context provided for _preparing_ the statement.

Fixes #2172

### Motivation

The context used to prepare a statement and the context used to execute
a statement need not be the same (see
https://pkg.go.dev/database/sql#DB.PrepareContext)

The execution trace task changes added in #2060 incorrectly used the
statement's context from preparation to derive the execution trace task. This
can lead to a statement unexpectedly failing with a "context canceled" error
when the context used to prepare the statement is canceled, but the context
passed to execute the statement isn't. We should be using the context provided
for executing the statement instead.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] There is a benchmark for any new code, or changes to existing code.
- [x] If this interacts with the agent in a new way, a system test has been added.
