### PR TITLE
.github: Introduce stale PR action to auto close old stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,17 @@
+name: 'Close stale PRs'
+# Docs: https://github.com/marketplace/actions/close-stale-issues
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-pr-message: 'This PR is stale because it has been open 20 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-pr-message: 'This PR was closed because it has been open for 30 days with no activity.'
+          start-date: '2023-08-20T00:00:00Z' #PRs before stale bot introduced should be ignored
+          days-before-pr-close: 30
+          days-before-pr-stale: 20


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Introduce a github action to autoclose PRs with no activity for 30 days (A warning message and stale label will be applied after 20 days of inactivity)
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We have a number of very old stale PRs that aren't being worked on. To reduce the manual burden on cleaning these out and encourage a smaller number of "open" PRs (read: we should close or merge PRs faster) let's close old stale PRs automatically.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.