### PR TITLE
telemetry: add service naming and peer service configurations to payload

### DIFF
--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -7,6 +7,7 @@ package tracer
 
 import (
 	"fmt"
+	"strings"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 )
@@ -51,7 +52,18 @@ func startTelemetry(c *config) {
 		{Name: "profiling_hotspots_enabled", Value: c.profilerHotspots},
 		{Name: "profiling_endpoints_enabled", Value: c.profilerEndpoints},
 		{Name: "trace_enabled", Value: c.enabled},
+		{Name: "trace_span_attribute_schema", Value: c.spanAttributeSchemaVersion},
+		{Name: "trace_peer_service_defaults_enabled", Value: c.peerServiceDefaultsEnabled},
 	}
+	if len(c.peerServiceMappings) != 0 {
+		var result []string
+		for key, value := range c.peerServiceMappings {
+			result = append(result, fmt.Sprintf("%s:%s", key, value))
+		}
+		telemetryConfigs = append(telemetryConfigs,
+			telemetry.Configuration{Name: "trace_peer_service_mapping", Value: strings.Join(result, ",")})
+	}
+
 	if chained, ok := c.propagator.(*chainedPropagator); ok {
 		telemetryConfigs = append(telemetryConfigs,
 			telemetry.Configuration{Name: "trace_propagation_style_inject", Value: chained.injectorNames})

--- a/ddtrace/tracer/telemetry_test.go
+++ b/ddtrace/tracer/telemetry_test.go
@@ -25,6 +25,8 @@ func TestTelemetryEnabled(t *testing.T) {
 			WithService("test-serv"),
 			WithEnv("test-env"),
 			WithRuntimeMetrics(),
+			WithPeerServiceMapping("key", "val"),
+			WithPeerServiceDefaults(true),
 		)
 		defer Stop()
 
@@ -35,6 +37,9 @@ func TestTelemetryEnabled(t *testing.T) {
 		telemetry.Check(t, telemetryClient.Configuration, "env", "test-env")
 		telemetry.Check(t, telemetryClient.Configuration, "runtime_metrics_enabled", true)
 		telemetry.Check(t, telemetryClient.Configuration, "stats_computation_enabled", false)
+		telemetry.Check(t, telemetryClient.Configuration, "trace_span_attribute_schema", 0)
+		telemetry.Check(t, telemetryClient.Configuration, "trace_peer_service_defaults_enabled", true)
+		telemetry.Check(t, telemetryClient.Configuration, "trace_peer_service_mapping", "key:val")
 		if metrics, ok := telemetryClient.Metrics[telemetry.NamespaceGeneral]; ok {
 			if initTime, ok := metrics["init_time"]; ok {
 				assert.True(t, initTime > 0)


### PR DESCRIPTION
### What does this PR do?

adds new peer service and service naming telemetry configurations


- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.