### PR TITLE
contrib/internal/httptrace: optionally omit http.url and http.host tags

### DIFF
--- a/contrib/internal/httptrace/config.go
+++ b/contrib/internal/httptrace/config.go
@@ -24,6 +24,8 @@ const (
 	envTraceClientIPEnabled = "DD_TRACE_CLIENT_IP_ENABLED"
 	// envTraceHTTPURLDisabled is the name of the env var used to disable HTTP URL collection.
 	envTraceHTTPURLDisabled = "DD_TRACE_HTTP_URL_DISABLED"
+	// envTraceHTTPHostDisabled is the name of the env var used to disable HTTP host collection.
+	envTraceHTTPHostDisabled = "DD_TRACE_HTTP_HOST_DISABLED"
 )
 
 // defaultQueryStringRegexp is the regexp used for query string obfuscation if `envQueryStringRegexp` is empty.
@@ -34,6 +36,7 @@ type config struct {
 	queryString       bool           // queryString reports whether the query string should be included in the URL span tag.
 	traceClientIP     bool           // traceClientIP represents whether the client IP tags should be included in the trace span tags.
 	httpURL           bool           // httpURL represents whether the HTTP URL tag is included in the trace span tags.
+	httpHost          bool           // httpHost whether the HTTP host tag is included in the trace span information.
 }
 
 func newConfig() config {
@@ -42,6 +45,7 @@ func newConfig() config {
 		queryStringRegexp: defaultQueryStringRegexp,
 		traceClientIP:     internal.BoolEnv(envTraceClientIPEnabled, false),
 		httpURL:           !internal.BoolEnv(envTraceHTTPURLDisabled, false),
+		httpHost:          !internal.BoolEnv(envTraceHTTPHostDisabled, false),
 	}
 	if s, ok := os.LookupEnv(envQueryStringRegexp); !ok {
 		return c

--- a/contrib/internal/httptrace/config.go
+++ b/contrib/internal/httptrace/config.go
@@ -22,6 +22,8 @@ const (
 	envQueryStringRegexp = "DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP"
 	// envTraceClientIPEnabled is the name of the env var used to specify whether or not to collect client ip in span tags.
 	envTraceClientIPEnabled = "DD_TRACE_CLIENT_IP_ENABLED"
+	// envTraceHTTPURLDisabled is the name of the env var used to disable HTTP URL collection.
+	envTraceHTTPURLDisabled = "DD_TRACE_HTTP_URL_DISABLED"
 )
 
 // defaultQueryStringRegexp is the regexp used for query string obfuscation if `envQueryStringRegexp` is empty.
@@ -31,6 +33,7 @@ type config struct {
 	queryStringRegexp *regexp.Regexp // queryStringRegexp specifies the regexp to use for query string obfuscation.
 	queryString       bool           // queryString reports whether the query string should be included in the URL span tag.
 	traceClientIP     bool           // traceClientIP represents whether the client IP tags should be included in the trace span tags.
+	httpURL           bool           // httpURL represents whether the HTTP URL tag is included in the trace span tags.
 }
 
 func newConfig() config {
@@ -38,6 +41,7 @@ func newConfig() config {
 		queryString:       !internal.BoolEnv(envQueryStringDisabled, false),
 		queryStringRegexp: defaultQueryStringRegexp,
 		traceClientIP:     internal.BoolEnv(envTraceClientIPEnabled, false),
+		httpURL:           !internal.BoolEnv(envTraceHTTPURLDisabled, false),
 	}
 	if s, ok := os.LookupEnv(envQueryStringRegexp); !ok {
 		return c

--- a/contrib/internal/httptrace/config.go
+++ b/contrib/internal/httptrace/config.go
@@ -16,11 +16,11 @@ import (
 // The env vars described below are used to configure the http security tags collection.
 // See https://docs.datadoghq.com/tracing/setup_overview/configure_data_security to learn how to use those properly.
 const (
-	// envQueryStringDisabled is the name of the env var used to disabled query string collection.
+	// envQueryStringDisabled is the name of the env var used to disable query string collection.
 	envQueryStringDisabled = "DD_TRACE_HTTP_URL_QUERY_STRING_DISABLED"
 	// envQueryStringRegexp is the name of the env var used to specify the regexp to use for query string obfuscation.
 	envQueryStringRegexp = "DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP"
-	// envTraceClientIPEnabled is the name of the env var used to specify whether or not to collect client ip in span tags
+	// envTraceClientIPEnabled is the name of the env var used to specify whether or not to collect client ip in span tags.
 	envTraceClientIPEnabled = "DD_TRACE_CLIENT_IP_ENABLED"
 )
 
@@ -28,9 +28,9 @@ const (
 var defaultQueryStringRegexp = regexp.MustCompile("(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:(?:\\s|%20)*(?:=|%3D)[^&]+|(?:\"|%22)(?:\\s|%20)*(?::|%3A)(?:\\s|%20)*(?:\"|%22)(?:%2[^2]|%[^2]|[^\"%])+(?:\"|%22))|bearer(?:\\s|%20)+[a-z0-9\\._\\-]|token(?::|%3A)[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L](?:[\\w=-]|%3D)+\\.ey[I-L](?:[\\w=-]|%3D)+(?:\\.(?:[\\w.+\\/=-]|%3D|%2F|%2B)+)?|[\\-]{5}BEGIN(?:[a-z\\s]|%20)+PRIVATE(?:\\s|%20)KEY[\\-]{5}[^\\-]+[\\-]{5}END(?:[a-z\\s]|%20)+PRIVATE(?:\\s|%20)KEY|ssh-rsa(?:\\s|%20)*(?:[a-z0-9\\/\\.+]|%2F|%5C|%2B){100,}")
 
 type config struct {
-	queryStringRegexp *regexp.Regexp // specifies the regexp to use for query string obfuscation.
-	queryString       bool           // reports whether the query string should be included in the URL span tag.
-	traceClientIP     bool
+	queryStringRegexp *regexp.Regexp // queryStringRegexp specifies the regexp to use for query string obfuscation.
+	queryString       bool           // queryString reports whether the query string should be included in the URL span tag.
+	traceClientIP     bool           // traceClientIP represents whether the client IP tags should be included in the trace span tags.
 }
 
 func newConfig() config {

--- a/contrib/internal/httptrace/config_test.go
+++ b/contrib/internal/httptrace/config_test.go
@@ -61,6 +61,45 @@ func TestConfigQueryString(t *testing.T) {
 	}
 }
 
+func TestConfigHTTPURL(t *testing.T) {
+	defaultCfg := config{
+		httpURL: true,
+	}
+	for _, tc := range []struct {
+		name string
+		env  map[string]string
+		cfg  config // cfg is the expected output config
+	}{
+		{
+			name: "empty-env",
+			cfg:  defaultCfg,
+		},
+		{
+			name: "bad-value",
+			env: map[string]string{
+				envTraceHTTPURLDisabled: "invalid",
+			},
+			cfg: defaultCfg,
+		},
+		{
+			name: "disable-http-url",
+			env:  map[string]string{envTraceHTTPURLDisabled: "true"},
+			cfg: config{
+				httpURL: false,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer cleanEnv()()
+			for k, v := range tc.env {
+				os.Setenv(k, v)
+			}
+			c := newConfig()
+			require.Equal(t, tc.cfg.httpURL, c.httpURL)
+		})
+	}
+}
+
 func cleanEnv() func() {
 	env := map[string]string{
 		envQueryStringDisabled: os.Getenv(envQueryStringDisabled),

--- a/contrib/internal/httptrace/config_test.go
+++ b/contrib/internal/httptrace/config_test.go
@@ -100,6 +100,45 @@ func TestConfigHTTPURL(t *testing.T) {
 	}
 }
 
+func TestConfigHTTPHost(t *testing.T) {
+	defaultCfg := config{
+		httpHost: true,
+	}
+	for _, tc := range []struct {
+		name string
+		env  map[string]string
+		cfg  config // cfg is the expected output config
+	}{
+		{
+			name: "empty-env",
+			cfg:  defaultCfg,
+		},
+		{
+			name: "bad-value",
+			env: map[string]string{
+				envTraceHTTPHostDisabled: "invalid",
+			},
+			cfg: defaultCfg,
+		},
+		{
+			name: "disable-http-url",
+			env:  map[string]string{envTraceHTTPHostDisabled: "true"},
+			cfg: config{
+				httpHost: false,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer cleanEnv()()
+			for k, v := range tc.env {
+				os.Setenv(k, v)
+			}
+			c := newConfig()
+			require.Equal(t, tc.cfg.httpHost, c.httpHost)
+		})
+	}
+}
+
 func cleanEnv() func() {
 	env := map[string]string{
 		envQueryStringDisabled: os.Getenv(envQueryStringDisabled),

--- a/contrib/internal/httptrace/config_test.go
+++ b/contrib/internal/httptrace/config_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfig(t *testing.T) {
+func TestConfigQueryString(t *testing.T) {
 	defaultCfg := config{
 		queryString:       true,
 		queryStringRegexp: defaultQueryStringRegexp,

--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -38,23 +38,23 @@ func StartRequestSpan(r *http.Request, opts ...ddtrace.StartSpanOption) (tracer.
 	}
 	nopts := make([]ddtrace.StartSpanOption, 0, len(opts)+1+len(ipTags))
 	nopts = append(nopts,
-		func(cfg *ddtrace.StartSpanConfig) {
-			if cfg.Tags == nil {
-				cfg.Tags = make(map[string]interface{})
+		func(c *ddtrace.StartSpanConfig) {
+			if c.Tags == nil {
+				c.Tags = make(map[string]interface{})
 			}
-			cfg.Tags[ext.SpanType] = ext.SpanTypeWeb
-			cfg.Tags[ext.HTTPMethod] = r.Method
-			cfg.Tags[ext.HTTPURL] = urlFromRequest(r)
-			cfg.Tags[ext.HTTPUserAgent] = r.UserAgent()
-			cfg.Tags["_dd.measured"] = 1
+			c.Tags[ext.SpanType] = ext.SpanTypeWeb
+			c.Tags[ext.HTTPMethod] = r.Method
+			c.Tags[ext.HTTPURL] = urlFromRequest(r)
+			c.Tags[ext.HTTPUserAgent] = r.UserAgent()
+			c.Tags["_dd.measured"] = 1
 			if r.Host != "" {
-				cfg.Tags["http.host"] = r.Host
+				c.Tags["http.host"] = r.Host
 			}
 			if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(r.Header)); err == nil {
-				cfg.Parent = spanctx
+				c.Parent = spanctx
 			}
 			for k, v := range ipTags {
-				cfg.Tags[k] = v
+				c.Tags[k] = v
 			}
 		})
 	nopts = append(nopts, opts...)

--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -49,8 +49,8 @@ func StartRequestSpan(r *http.Request, opts ...ddtrace.StartSpanOption) (tracer.
 			}
 			c.Tags[ext.HTTPUserAgent] = r.UserAgent()
 			c.Tags["_dd.measured"] = 1
-			if r.Host != "" {
-				c.Tags["http.host"] = r.Host
+			if cfg.httpHost && r.Host != "" {
+				c.Tags[ext.HTTPHost] = r.Host
 			}
 			if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(r.Header)); err == nil {
 				c.Parent = spanctx

--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -44,7 +44,9 @@ func StartRequestSpan(r *http.Request, opts ...ddtrace.StartSpanOption) (tracer.
 			}
 			c.Tags[ext.SpanType] = ext.SpanTypeWeb
 			c.Tags[ext.HTTPMethod] = r.Method
-			c.Tags[ext.HTTPURL] = urlFromRequest(r)
+			if cfg.httpURL {
+				c.Tags[ext.HTTPURL] = urlFromRequest(r)
+			}
 			c.Tags[ext.HTTPUserAgent] = r.UserAgent()
 			c.Tags["_dd.measured"] = 1
 			if r.Host != "" {

--- a/ddtrace/ext/ext_test.go
+++ b/ddtrace/ext/ext_test.go
@@ -28,6 +28,7 @@ func TestSpec(t *testing.T) {
 		SpanTypeElasticSearch, "elasticsearch",
 		SQLQuery, "sql.query",
 		HTTPURL, "http.url",
+		HTTPHost, "http.host",
 		Environment, "env",
 	}
 	if len(tests)%2 != 0 {

--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -58,6 +58,9 @@ const (
 	// See https://docs.datadoghq.com/tracing/trace_collection/tracing_naming_convention/#http-requests
 	HTTPRequestHeaders = "http.request.headers"
 
+	// HTTPHost sets the HTTP host tag.
+	HTTPHost = "http.host"
+
 	// SpanName is a pseudo-key for setting a span's operation name by means of
 	// a tag. It is mostly here to facilitate vendor-agnostic frameworks like Opentracing
 	// and OpenCensus.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR introduces two configuration options that can be set via environment variables:

- `DD_TRACE_HTTP_URL_DISABLED`: Controls whether the `http.url` tag is omitted from trace span tags.
- `DD_TRACE_HTTP_HOST_DISABLED`: Controls whether the `http.host` tag is omitted from trace span tags.

A note to reviewers: I would recommend looking at the changes on a per commit basis. I tried to keep the related changes scoped to each commit to make it easier to distinguish the individual changes from the bigger picture. Thank you for your time and I look forward to your feedback.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

We already have the option to remove the query string from the collected span tags, the changes in this PR introduce the ability to do the same with the `http.url` and `http.host` tag. These tags could potentially contain information that the user would prefer to exclude from traces sent to Datadog APM.

Resolves #2178.
Resolves #2179.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.