### PR TITLE
CODEOWNERS: rename appsec-go to asm-go

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,16 +12,16 @@
 /internal/traceprof             @DataDog/profiling-go
 
 # appsec
-/appsec                         @DataDog/appsec-go
-/internal/appsec                @DataDog/appsec-go
-/contrib/**/*appsec*.go         @DataDog/appsec-go
-/.github/workflows/appsec.yml   @DataDog/appsec-go
+/appsec                         @DataDog/asm-go
+/internal/appsec                @DataDog/asm-go
+/contrib/**/*appsec*.go         @DataDog/asm-go
+/.github/workflows/appsec.yml   @DataDog/asm-go
 
 # telemetry
 /internal/telemetry             @DataDog/apm-go
 
 # linter rules
-.golangci.yml                   @DataDog/tracing-go @DataDog/profiling-go @DataDog/appsec-go
+.golangci.yml                   @DataDog/tracing-go @DataDog/profiling-go @DataDog/asm-go
 
 # Gitlab configuration
 .gitlab-ci.yml                  @DataDog/apm-go @DataDog/apm-core-reliability-and-performance


### PR DESCRIPTION
### What does this PR do?

Transfer ownership of code owned by appsec-go to asm-go to account for team renaming.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.