### PR TITLE
all: add reminder to get security review when needed

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,3 +29,10 @@
 - [ ] Changed code has unit tests for its functionality at or near 100% coverage.
 - [ ] There is a benchmark for any new code, or changes to existing code.
 - [ ] If this interacts with the agent in a new way, a system test has been added.
+
+For Datadog employees:
+
+- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
+- [ ] This PR doesn't touch any of that.
+
+Unsure? Have a question? Request a review!


### PR DESCRIPTION
### What does this PR do?

Add a reminder to ask for security review when needed to our PR checklist.

### Motivation

We sometimes make changes to our CI which involve handling Datadog API keys or
otherwise interacting with Datadog infrastructure. Such changes should get a
review from our security team to ensure that we aren't exposing ourself to
risk, such as via leaking credentials.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] There is a benchmark for any new code, or changes to existing code.
- [x] If this interacts with the agent in a new way, a system test has been added.
