### PR TITLE
ddtrace/tracer: fix race condition in abandonedspans_test.go

### DIFF
--- a/ddtrace/tracer/abandonedspans.go
+++ b/ddtrace/tracer/abandonedspans.go
@@ -196,12 +196,11 @@ func (d *abandonedSpansDebugger) add(s *abandonedSpanCandidate, interval time.Du
 		d.buckets[btime] = b
 	}
 
-	atomic.AddUint32(&d.addedSpans, 1)
 	b.add(s.SpanID, s)
+	atomic.AddUint32(&d.addedSpans, 1)
 }
 
 func (d *abandonedSpansDebugger) remove(s *abandonedSpanCandidate, interval time.Duration) {
-	atomic.AddUint32(&d.removedSpans, 1)
 	bucketSize := interval.Nanoseconds()
 	btime := alignTs(s.Start, bucketSize)
 	b, ok := d.buckets[btime]
@@ -213,6 +212,7 @@ func (d *abandonedSpansDebugger) remove(s *abandonedSpanCandidate, interval time
 	// If a bucket becomes empty, also remove that bucket from the
 	// abandoned spans list.
 	b.remove(s.SpanID)
+	atomic.AddUint32(&d.removedSpans, 1)
 	if b.Len() > 0 {
 		return
 	}
@@ -272,13 +272,13 @@ func (d *abandonedSpansDebugger) log(interval *time.Duration) {
 		return
 	}
 
-	atomic.SwapUint32(&d.logged, 1)
 	log.Warn("%d abandoned spans:", spanCount)
 	if truncated {
 		log.Warn("Too many abandoned spans. Truncating message.")
 		sb.WriteString("...")
 	}
 	log.Warn(sb.String())
+	atomic.SwapUint32(&d.logged, 1)
 }
 
 // formatAbandonedSpans takes a bucket and returns a human-readable string representing

--- a/ddtrace/tracer/abandonedspans_test.go
+++ b/ddtrace/tracer/abandonedspans_test.go
@@ -24,7 +24,7 @@ var spanStart = time.Date(2023, time.August, 18, 0, 0, 0, 0, time.UTC)
 // setTestTime() sets the current time, which will be used to calculate the
 // duration of abandoned spans.
 func setTestTime() func() {
-	current := spanStart.UnixNano() + 10*time.Minute.Nanoseconds() //use a fixed time instead of now
+	current := spanStart.UnixNano() + 10*time.Minute.Nanoseconds() // use a fixed time instead of now
 	now = func() int64 { return current }
 
 	return func() {
@@ -44,7 +44,7 @@ func assertProcessedSpans(assert *assert.Assertions, t *tracer, startedSpans, fi
 		return atomic.LoadUint32(&d.addedSpans) >= uint32(startedSpans) &&
 			atomic.LoadUint32(&d.removedSpans) >= uint32(finishedSpans)
 	}
-	assert.Eventually(cond, 300*time.Millisecond, 50*time.Millisecond)
+	assert.Eventually(cond, 500*time.Millisecond, 50*time.Millisecond)
 	// We expect logs to be generated when startedSpans and finishedSpans are different.
 	if startedSpans == finishedSpans {
 		return


### PR DESCRIPTION
### What does this PR do?

This PR fixes some flaky tests due to misplaced atomic variables' updates in internal counters that were used to avoid using `time.Sleep` in unit tests.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!