### PR TITLE
ddtrace/tracer: fix race condition with RecordLogger in abandonedspans_test.go

### DIFF
--- a/ddtrace/tracer/abandonedspans.go
+++ b/ddtrace/tracer/abandonedspans.go
@@ -119,10 +119,6 @@ type abandonedSpansDebugger struct {
 	// addedSpans and removedSpans are internal counters, mainly for testing
 	// purposes
 	addedSpans, removedSpans uint32
-
-	// logged reports if the debugger has logged abandoned spans at least once
-	// (when non-zero).
-	logged uint32
 }
 
 // newAbandonedSpansDebugger creates a new abandonedSpansDebugger debugger
@@ -278,7 +274,6 @@ func (d *abandonedSpansDebugger) log(interval *time.Duration) {
 		sb.WriteString("...")
 	}
 	log.Warn(sb.String())
-	atomic.SwapUint32(&d.logged, 1)
 }
 
 // formatAbandonedSpans takes a bucket and returns a human-readable string representing

--- a/ddtrace/tracer/abandonedspans_test.go
+++ b/ddtrace/tracer/abandonedspans_test.go
@@ -44,15 +44,16 @@ func assertProcessedSpans(assert *assert.Assertions, t *tracer, startedSpans, fi
 		return atomic.LoadUint32(&d.addedSpans) >= uint32(startedSpans) &&
 			atomic.LoadUint32(&d.removedSpans) >= uint32(finishedSpans)
 	}
-	assert.Eventually(cond, 500*time.Millisecond, 50*time.Millisecond)
+	assert.Eventually(cond, 1*time.Second, 75*time.Millisecond)
 	// We expect logs to be generated when startedSpans and finishedSpans are different.
+	// At least there should be 3 lines: 1. debugger activation, 2. detected spans warn, and 3. the details.
 	if startedSpans == finishedSpans {
 		return
 	}
 	cond = func() bool {
-		return atomic.LoadUint32(&d.logged) == 1
+		return len(t.config.logger.(*log.RecordLogger).Logs()) > 2
 	}
-	assert.Eventually(cond, 300*time.Millisecond, 50*time.Millisecond)
+	assert.Eventually(cond, 1*time.Second, 75*time.Millisecond)
 }
 
 func formatSpanString(s *span) string {


### PR DESCRIPTION
### What does this PR do?

Finally, a last fix to the `abandonedspans_test.go`, as the last race condition was found while checking if logs have been generated.

It was tested over 50K+ iterations over 2 days without reproducing again the error in the flaky test that failed yesterday: 

**Test execution link**: [TestReportAbandonedSpans](https://app.datadoghq.com/ci/test/AgAAAYpMGEY4oNocrgAAAAAAAAAYAAAAAEFZcE1HRVk0QUFCT2lHc2IzLXlGTTB1SgAAACQAAAAAMDE4YTRjMWItYjk3Zi00YTA4LTkyNDItMzQxZDM2ZjRlZGYy)  
**Service**: dd-trace-go  
**Branch**: [main](https://app.datadoghq.com/ci/test-branch/github.com%2FDataDog%2Fdd-trace-go/dd-trace-go/main?env=none)  
**First Flaked**: [283c0ac0ef4488df84a1d5ef9d6e940811fdc433](https://app.datadoghq.com/ci/test-commit/github.com%2FDataDog%2Fdd-trace-go/dd-trace-go/main/283c0ac0ef4488df84a1d5ef9d6e940811fdc433?env=none) 
**Last Flaked**:  [52975ed5d9683b061d1be4f9ced798096cbecba1](https://app.datadoghq.com/ci/test-commit/github.com%2FDataDog%2Fdd-trace-go/dd-trace-go/main/283c0ac0ef4488df84a1d5ef9d6e940811fdc433?env=none)   
**Last flaked author**: Dario Castañé  

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!