### PR TITLE
contrib/database/sql: use correct context for trace tasks in statemen…

### DIFF
--- a/contrib/database/sql/stmt.go
+++ b/contrib/database/sql/stmt.go
@@ -36,7 +36,7 @@ func (s *tracedStmt) Close() (err error) {
 func (s *tracedStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (res driver.Result, err error) {
 	start := time.Now()
 	if stmtExecContext, ok := s.Stmt.(driver.StmtExecContext); ok {
-		ctx, end := startTraceTask(s.ctx, QueryTypeExec)
+		ctx, end := startTraceTask(ctx, QueryTypeExec)
 		defer end()
 		res, err := stmtExecContext.ExecContext(ctx, args)
 		s.tryTrace(ctx, QueryTypeExec, s.query, start, err)
@@ -51,7 +51,7 @@ func (s *tracedStmt) ExecContext(ctx context.Context, args []driver.NamedValue) 
 		return nil, ctx.Err()
 	default:
 	}
-	ctx, end := startTraceTask(s.ctx, QueryTypeExec)
+	ctx, end := startTraceTask(ctx, QueryTypeExec)
 	defer end()
 	res, err = s.Exec(dargs)
 	s.tryTrace(ctx, QueryTypeExec, s.query, start, err)
@@ -62,7 +62,7 @@ func (s *tracedStmt) ExecContext(ctx context.Context, args []driver.NamedValue) 
 func (s *tracedStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (rows driver.Rows, err error) {
 	start := time.Now()
 	if stmtQueryContext, ok := s.Stmt.(driver.StmtQueryContext); ok {
-		ctx, end := startTraceTask(s.ctx, QueryTypeQuery)
+		ctx, end := startTraceTask(ctx, QueryTypeQuery)
 		defer end()
 		rows, err := stmtQueryContext.QueryContext(ctx, args)
 		s.tryTrace(ctx, QueryTypeQuery, s.query, start, err)
@@ -77,7 +77,7 @@ func (s *tracedStmt) QueryContext(ctx context.Context, args []driver.NamedValue)
 		return nil, ctx.Err()
 	default:
 	}
-	ctx, end := startTraceTask(s.ctx, QueryTypeQuery)
+	ctx, end := startTraceTask(ctx, QueryTypeQuery)
 	defer end()
 	rows, err = s.Query(dargs)
 	s.tryTrace(ctx, QueryTypeQuery, s.query, start, err)

--- a/contrib/database/sql/stmt_test.go
+++ b/contrib/database/sql/stmt_test.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package sql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUseStatementContext(t *testing.T) {
+	Register("sqlite3", &sqlite3.SQLiteDriver{})
+	db, err := Open("sqlite3", "file::memory:?cache=shared")
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Prepare using ctx1
+	ctx1, cancel := context.WithCancel(context.Background())
+	stmt, err := db.PrepareContext(ctx1, "SELECT 1")
+	require.NoError(t, err)
+	defer stmt.Close()
+	cancel()
+
+	// Query stmt using ctx2
+	ctx2 := context.Background()
+	var result int
+	require.NoError(t, stmt.QueryRowContext(ctx2).Scan(&result))
+}


### PR DESCRIPTION
…ts (#2173)

The context used to prepare a statement and the context used to execute a statement need not be the same (see
https://pkg.go.dev/database/sql#DB.PrepareContext)

The execution trace task changes added in #2060 incorrectly used the statement's context from preparation to derive the execution trace task. We should be using the context provided for executing the statement instead.

Fixes #2172

(cherry-picked from main)

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!