### PR TITLE
contrib/net/http: Copy span options and resource name to avoid data race (#2204)

### DIFF
--- a/contrib/net/http/http.go
+++ b/contrib/net/http/http.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
@@ -53,11 +54,13 @@ func (mux *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if resource == "" {
 		resource = r.Method + " " + route
 	}
-	spanOpts := append(mux.cfg.spanOpts, httptrace.HeaderTagsFromRequest(r, mux.cfg.headerTags))
+	so := make([]ddtrace.StartSpanOption, len(mux.cfg.spanOpts), len(mux.cfg.spanOpts)+1)
+	copy(so, mux.cfg.spanOpts)
+	so = append(so, httptrace.HeaderTagsFromRequest(r, mux.cfg.headerTags))
 	TraceAndServe(mux.ServeMux, w, r, &ServeConfig{
 		Service:  mux.cfg.serviceName,
 		Resource: resource,
-		SpanOpts: spanOpts,
+		SpanOpts: so,
 		Route:    route,
 	})
 }
@@ -78,15 +81,17 @@ func WrapHandler(h http.Handler, service, resource string, opts ...Option) http.
 			h.ServeHTTP(w, req)
 			return
 		}
+		resc := resource
 		if r := cfg.resourceNamer(req); r != "" {
-			resource = r
+			resc = r
 		}
-
+		so := make([]ddtrace.StartSpanOption, len(cfg.spanOpts))
+		copy(so, cfg.spanOpts)
 		TraceAndServe(h, w, req, &ServeConfig{
 			Service:    service,
-			Resource:   resource,
+			Resource:   resc,
 			FinishOpts: cfg.finishOpts,
-			SpanOpts:   cfg.spanOpts,
+			SpanOpts:   so,
 		})
 	})
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
cherry pick fix across for v1.54.1 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!