### PR TITLE
ci: run smoke-test with the latest stable Go release

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "stable"
           cache: true
       - name: go get -u
         run: |


### PR DESCRIPTION
### What does this PR do?

Runs the smoke test with the latest stable Go release.

### Motivation

The smoke test asserts that our packages still build and pass their unit
tests when all of the dependencies are upgraded to their latest
compatible versions. Sometimes dependencies can drop support for older
Go versions and will no longer compile if we're running the tests using
the unsupported Go version. This can happen, for example, if we are
doing a patch release for a release which supported an older Go version,
and a new Go version comes out. If a user does what this test does, this
they should expect to sometimes need to upgrade their Go toolchain for
this reason. So let's run the test using the latest toolchain.


### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] There is a benchmark for any new code, or changes to existing code.
- [x] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
