### PR TITLE
datastreams: Add version tag

### DIFF
--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -241,7 +241,7 @@ func newUnstartedTracer(opts ...StartOption) *tracer {
 	}
 	var dataStreamsProcessor *datastreams.Processor
 	if c.dataStreamsMonitoringEnabled {
-		dataStreamsProcessor = datastreams.NewProcessor(statsd, c.env, c.serviceName, c.agentURL, c.httpClient, func() bool {
+		dataStreamsProcessor = datastreams.NewProcessor(statsd, c.env, c.serviceName, c.version, c.agentURL, c.httpClient, func() bool {
 			f := loadAgentFeatures(c.logToStdout, c.agentURL, c.httpClient)
 			return f.DataStreams
 		})

--- a/internal/datastreams/payload.go
+++ b/internal/datastreams/payload.go
@@ -19,6 +19,8 @@ type StatsPayload struct {
 	TracerVersion string
 	// Lang is the language of the tracer
 	Lang string
+	// Version is the version of the service
+	Version string
 }
 
 type ProduceOffset struct {

--- a/internal/datastreams/payload_msgp.go
+++ b/internal/datastreams/payload_msgp.go
@@ -579,6 +579,12 @@ func (z *StatsPayload) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "Lang")
 				return
 			}
+		case "Version":
+			z.Version, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "Version")
+				return
+			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -592,9 +598,9 @@ func (z *StatsPayload) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *StatsPayload) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 5
+	// map header, size 6
 	// write "Env"
-	err = en.Append(0x85, 0xa3, 0x45, 0x6e, 0x76)
+	err = en.Append(0x86, 0xa3, 0x45, 0x6e, 0x76)
 	if err != nil {
 		return
 	}
@@ -650,6 +656,16 @@ func (z *StatsPayload) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "Lang")
 		return
 	}
+	// write "Version"
+	err = en.Append(0xa7, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.Version)
+	if err != nil {
+		err = msgp.WrapError(err, "Version")
+		return
+	}
 	return
 }
 
@@ -659,7 +675,7 @@ func (z *StatsPayload) Msgsize() (s int) {
 	for za0001 := range z.Stats {
 		s += z.Stats[za0001].Msgsize()
 	}
-	s += 14 + msgp.StringPrefixSize + len(z.TracerVersion) + 5 + msgp.StringPrefixSize + len(z.Lang)
+	s += 14 + msgp.StringPrefixSize + len(z.TracerVersion) + 5 + msgp.StringPrefixSize + len(z.Lang) + 8 + msgp.StringPrefixSize + len(z.Version)
 	return
 }
 

--- a/internal/datastreams/processor.go
+++ b/internal/datastreams/processor.go
@@ -166,6 +166,7 @@ type Processor struct {
 	env                  string
 	primaryTag           string
 	service              string
+	version              string
 	// used for tests
 	timeSource                  func() time.Time
 	disableStatsFlushing        uint32
@@ -179,7 +180,7 @@ func (p *Processor) time() time.Time {
 	return time.Now()
 }
 
-func NewProcessor(statsd internal.StatsdClient, env, service string, agentURL *url.URL, httpClient *http.Client, getAgentSupportsDataStreams func() bool) *Processor {
+func NewProcessor(statsd internal.StatsdClient, env, service, version string, agentURL *url.URL, httpClient *http.Client, getAgentSupportsDataStreams func() bool) *Processor {
 	if service == "" {
 		service = defaultServiceName
 	}
@@ -192,6 +193,7 @@ func NewProcessor(statsd internal.StatsdClient, env, service string, agentURL *u
 		statsd:                      statsd,
 		env:                         env,
 		service:                     service,
+		version:                     version,
 		transport:                   newHTTPTransport(agentURL, httpClient),
 		timeSource:                  time.Now,
 		getAgentSupportsDataStreams: getAgentSupportsDataStreams,
@@ -348,6 +350,7 @@ func (p *Processor) flush(now time.Time) StatsPayload {
 	nowNano := now.UnixNano()
 	sp := StatsPayload{
 		Service:       p.service,
+		Version:       p.version,
 		Env:           p.env,
 		Lang:          "go",
 		TracerVersion: version.Tag,

--- a/internal/datastreams/processor_test.go
+++ b/internal/datastreams/processor_test.go
@@ -31,7 +31,7 @@ func buildSketch(values ...float64) []byte {
 }
 
 func TestProcessor(t *testing.T) {
-	p := NewProcessor(nil, "env", "service", &url.URL{Scheme: "http", Host: "agent-address"}, nil, func() bool { return true })
+	p := NewProcessor(nil, "env", "service", "v1", &url.URL{Scheme: "http", Host: "agent-address"}, nil, func() bool { return true })
 	tp1 := time.Now().Truncate(bucketDuration)
 	tp2 := tp1.Add(time.Minute)
 
@@ -79,6 +79,7 @@ func TestProcessor(t *testing.T) {
 	assert.Equal(t, StatsPayload{
 		Env:     "env",
 		Service: "service",
+		Version: "v1",
 		Stats: []StatsBucket{
 			{
 				Start:    uint64(tp1.Add(-10 * time.Second).UnixNano()),
@@ -125,6 +126,7 @@ func TestProcessor(t *testing.T) {
 	assert.Equal(t, StatsPayload{
 		Env:     "env",
 		Service: "service",
+		Version: "v1",
 		Stats: []StatsBucket{
 			{
 				Start:    uint64(tp2.Add(-time.Second * 10).UnixNano()),
@@ -211,7 +213,7 @@ func TestSetCheckpoint(t *testing.T) {
 }
 
 func TestKafkaLag(t *testing.T) {
-	p := NewProcessor(nil, "env", "service", &url.URL{Scheme: "http", Host: "agent-address"}, nil, func() bool { return true })
+	p := NewProcessor(nil, "env", "service", "v1", &url.URL{Scheme: "http", Host: "agent-address"}, nil, func() bool { return true })
 	tp1 := time.Now()
 	p.addKafkaOffset(kafkaOffset{offset: 1, topic: "topic1", partition: 1, group: "group1", offsetType: commitOffset})
 	p.addKafkaOffset(kafkaOffset{offset: 10, topic: "topic2", partition: 1, group: "group1", offsetType: commitOffset})


### PR DESCRIPTION
### What does this PR do?

Add a version tag to stats produced for data streams monitoring.
This will help detect when deployments happen.

### Motivation

When there is a sudden increase in latency, it is useful to understand if it's due to a new version being rolled out.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!