### PR TITLE
Disable profiling when run in AWS Lambda.

### DIFF
--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -125,6 +125,9 @@ func (p *profiler) lookupProfile(name string, w io.Writer, debug int) error {
 
 // newProfiler creates a new, unstarted profiler.
 func newProfiler(opts ...Option) (*profiler, error) {
+	if os.Getenv("AWS_LAMBDA_FUNCTION_NAME") != "" {
+		return nil, errors.New("profiling not supported in AWS Lambda runtimes")
+	}
 	cfg, err := defaultConfig()
 	if err != nil {
 		return nil, err

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -126,6 +126,13 @@ func TestStart(t *testing.T) {
 		mu.Lock()
 		mu.Unlock()
 	})
+
+	t.Run("aws-lambda", func(t *testing.T) {
+		t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "my-function-name")
+		err := Start()
+		defer Stop()
+		assert.NotNil(t, err)
+	})
 }
 
 // TestStartWithoutStopReconfigures verifies that calling Start while the


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
When aws lambda runtime is detected, refuse to start profiler.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->
Profiling is not currently supported in aws lambda. Node and Python are currently in public beta. Because Go is not included in this, customers would get charged for profiles that are potentially inaccurate.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!