### PR TITLE
ci: trigger on merge queue branch pushes

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - "**"
   merge_group:
+  push:
+    branches:
+      - 'mq-working-branch-**'
 
 concurrency: 
   group: ${{ github.ref }}


### PR DESCRIPTION
### What does this PR do?

Trigger required GitHub Actions checks on merge queue branch pushes (`mq-working-branch-**`).

### Motivation

Use our internal devflow `/merge` command on PRs to reduce waiting times.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!