### PR TITLE
[V2 experimentation]profiler: remove WithAPIKey and WithAgentlessUpload

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -248,9 +248,7 @@ func defaultConfig() (*config, error) {
 	if v := os.Getenv("DD_API_KEY"); v != "" {
 		c.apiKey = v
 	}
-	if internal.BoolEnv("DD_PROFILING_AGENTLESS", false) {
-		c.agentless = true
-	}
+	c.agentless = internal.BoolEnv("DD_PROFILING_AGENTLESS", false)
 	if v := os.Getenv("DD_SITE"); v != "" {
 		WithSite(v)(&c)
 	}

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -249,7 +249,7 @@ func defaultConfig() (*config, error) {
 		c.apiKey = v
 	}
 	if internal.BoolEnv("DD_PROFILING_AGENTLESS", false) {
-		WithAgentlessUpload()(&c)
+		c.agentless = true
 	}
 	if v := os.Getenv("DD_SITE"); v != "" {
 		WithSite(v)(&c)
@@ -316,16 +316,6 @@ type Option func(*config)
 func WithAgentAddr(hostport string) Option {
 	return func(cfg *config) {
 		cfg.agentURL = "http://" + hostport + "/profiling/v1/input"
-	}
-}
-
-// WithAgentlessUpload is currently for internal usage only and not officially
-// supported. You should not enable it unless somebody at Datadog instructed
-// you to do so. It allows to skip the agent and talk to the Datadog API
-// directly using the provided API key.
-func WithAgentlessUpload() Option {
-	return func(cfg *config) {
-		cfg.agentless = true
 	}
 }
 

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -246,7 +246,7 @@ func defaultConfig() (*config, error) {
 		WithUploadTimeout(d)(&c)
 	}
 	if v := os.Getenv("DD_API_KEY"); v != "" {
-		WithAPIKey(v)(&c)
+		c.apiKey = v
 	}
 	if internal.BoolEnv("DD_PROFILING_AGENTLESS", false) {
 		WithAgentlessUpload()(&c)
@@ -316,19 +316,6 @@ type Option func(*config)
 func WithAgentAddr(hostport string) Option {
 	return func(cfg *config) {
 		cfg.agentURL = "http://" + hostport + "/profiling/v1/input"
-	}
-}
-
-// WithAPIKey sets the Datadog API Key and takes precedence over the DD_API_KEY
-// env variable. Historically this option was used to enable agentless
-// uploading, but as of dd-trace-go v1.30.0 the behavior has changed to always
-// default to agent based uploading which doesn't require an API key. So if you
-// currently don't have an agent running on the default localhost:8126 hostport
-// you need to set it up, or use WithAgentAddr to specify the hostport location
-// of the agent. See WithAgentlessUpload for more information.
-func WithAPIKey(key string) Option {
-	return func(cfg *config) {
-		cfg.apiKey = key
 	}
 }
 

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -95,21 +95,6 @@ func TestOptions(t *testing.T) {
 		assert.Equal(t, 5*time.Second, cfg.uploadTimeout)
 	})
 
-	t.Run("WithAPIKey", func(t *testing.T) {
-		var cfg config
-		WithAPIKey(testAPIKey)(&cfg)
-		assert.Equal(t, testAPIKey, cfg.apiKey)
-		assert.Equal(t, cfg.apiURL, cfg.targetURL)
-	})
-
-	t.Run("WithAPIKey/override", func(t *testing.T) {
-		t.Setenv("DD_API_KEY", "apikey")
-		var testAPIKey = "12345678901234567890123456789012"
-		var cfg config
-		WithAPIKey(testAPIKey)(&cfg)
-		assert.Equal(t, testAPIKey, cfg.apiKey)
-	})
-
 	t.Run("WithURL", func(t *testing.T) {
 		var cfg config
 		WithURL("my-url")(&cfg)

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -33,8 +33,7 @@ var (
 // Start starts the profiler. If the profiler is already running, it will be
 // stopped and restarted with the given options.
 //
-// It may return an error if an API key is not provided by means of the
-// WithAPIKey option, or if a hostname is not found.
+// It may return an error if a hostname is not found.
 func Start(opts ...Option) error {
 	mu.Lock()
 	defer mu.Unlock()
@@ -143,7 +142,7 @@ func newProfiler(opts ...Option) (*profiler, error) {
 	// WithAgentlessUpload can be used to enable it for testing and debugging.
 	if cfg.agentless {
 		if !isAPIKeyValid(cfg.apiKey) {
-			return nil, errors.New("profiler.WithAgentlessUpload requires a valid API key. Use profiler.WithAPIKey or the DD_API_KEY env variable to set it")
+			return nil, errors.New("profiler.WithAgentlessUpload requires a valid API key. Use the DD_API_KEY env variable to set it")
 		}
 		// Always warn people against using this mode for now. All customers should
 		// use agent based uploading at this point.
@@ -156,7 +155,7 @@ func newProfiler(opts ...Option) (*profiler, error) {
 		// key configured, we warn the customers that this is probably a
 		// misconfiguration.
 		if cfg.apiKey != "" {
-			log.Warn("You are currently setting profiler.WithAPIKey or the DD_API_KEY env variable, but as of dd-trace-go v1.30.0 this value is getting ignored by the profiler. Please see the profiler.WithAPIKey go docs and verify that your integration is still working. If you can't remove DD_API_KEY from your environment, you can use WithAPIKey(\"\") to silence this warning.")
+			log.Warn("You are currently setting the DD_API_KEY env variable, but as of dd-trace-go v1.30.0 this value is getting ignored by the profiler. Please verify that your integration is still working.")
 		}
 		cfg.targetURL = cfg.agentURL
 	}

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -139,14 +139,14 @@ func newProfiler(opts ...Option) (*profiler, error) {
 		cfg.addProfileType(expGoroutineWaitProfile)
 	}
 	// Agentless upload is disabled by default as of v1.30.0, but
-	// WithAgentlessUpload can be used to enable it for testing and debugging.
+	// DD_PROFILING_AGENTLESS can be set to enable it for testing and debugging.
 	if cfg.agentless {
 		if !isAPIKeyValid(cfg.apiKey) {
-			return nil, errors.New("profiler.WithAgentlessUpload requires a valid API key. Use the DD_API_KEY env variable to set it")
+			return nil, errors.New("Agentless upload requires a valid API key. Use the DD_API_KEY env variable to set it")
 		}
 		// Always warn people against using this mode for now. All customers should
 		// use agent based uploading at this point.
-		log.Warn("profiler.WithAgentlessUpload is currently for internal usage only and not officially supported.")
+		log.Warn("Agentless upload is currently for internal usage only and not officially supported.")
 		cfg.targetURL = cfg.apiURL
 	} else {
 		// Historically people could use an API Key to enable agentless uploading.

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -87,27 +87,26 @@ func TestStart(t *testing.T) {
 	})
 
 	t.Run("options/GoodAPIKey/Agent", func(t *testing.T) {
+		t.Setenv("DD_API_KEY", "12345678901234567890123456789012")
 		rl := &log.RecordLogger{}
 		defer log.UseLogger(rl)()
 
-		err := Start(WithAPIKey("12345678901234567890123456789012"))
+		err := Start()
 		defer Stop()
 		assert.Nil(t, err)
 		assert.Equal(t, activeProfiler.cfg.agentURL, activeProfiler.cfg.targetURL)
 		// The package should log a warning that using an API has no
 		// effect unless uploading directly to Datadog (i.e. agentless)
 		assert.LessOrEqual(t, 1, len(rl.Logs()))
-		assert.Contains(t, strings.Join(rl.Logs(), " "), "profiler.WithAPIKey")
+		assert.Contains(t, strings.Join(rl.Logs(), " "), "DD_API_KEY")
 	})
 
 	t.Run("options/GoodAPIKey/Agentless", func(t *testing.T) {
+		t.Setenv("DD_API_KEY", "12345678901234567890123456789012")
 		rl := &log.RecordLogger{}
 		defer log.UseLogger(rl)()
 
-		err := Start(
-			WithAPIKey("12345678901234567890123456789012"),
-			WithAgentlessUpload(),
-		)
+		err := Start(WithAgentlessUpload())
 		defer Stop()
 		assert.Nil(t, err)
 		assert.Equal(t, activeProfiler.cfg.apiURL, activeProfiler.cfg.targetURL)
@@ -117,10 +116,23 @@ func TestStart(t *testing.T) {
 		assert.Contains(t, strings.Join(rl.Logs(), " "), "profiler.WithAgentlessUpload")
 	})
 
-	t.Run("options/BadAPIKey", func(t *testing.T) {
-		err := Start(WithAPIKey("aaaa"), WithAgentlessUpload())
+	t.Run("options/NoAPIKey/Agentless", func(t *testing.T) {
+		err := Start(WithAgentlessUpload())
 		defer Stop()
 		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "profiler.WithAgentlessUpload requires a valid API key")
+
+		// Check that mu gets unlocked, even if newProfiler() returns an error.
+		mu.Lock()
+		mu.Unlock()
+	})
+
+	t.Run("options/BadAPIKey/Agentless", func(t *testing.T) {
+		t.Setenv("DD_API_KEY", "aaaa")
+		err := Start(WithAgentlessUpload())
+		defer Stop()
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "profiler.WithAgentlessUpload requires a valid API key")
 
 		// Check that mu gets unlocked, even if newProfiler() returns an error.
 		mu.Lock()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Remove `WithAPIKey` option 
https://github.com/DataDog/dd-trace-go/issues/866


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
TLDR: 
Agentless uploading is originally supported if customer set `DD_API_KEY` env variable, or use `WithAPIKey` option. [`WithAgentlessUpload` was introduced for debugging purpose](https://github.com/DataDog/dd-trace-go/pull/906/) when agentless mode is disabled for `WithAPIKey` option.

Due to business reasons we want to deprecate agentless support for public uses, only allow internal usage by explicitly set `DD_PROFILING_AGENTLESS` and `DD_API_KEY` env variable. 

This PR is to remove `WithAPIKey` and `WithAgentlessUpload` option.

More context: [Agentless vs Agent Uploading](https://docs.google.com/document/d/172cmlRA_GTSu2OjC_FL5PzO6EjCpRH5ddU1nP08-yF0/edit)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!