### PR TITLE
[V2 experimentation] ddtrace/tracer: add WithAgentURL option

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -830,7 +830,7 @@ func WithAgentURL(agentURL string) StartOption {
 	return func(c *config) {
 		u, err := url.Parse(agentURL)
 		if err != nil {
-			log.Error("Fail to parse Agent URL: %v", err)
+			log.Warn("Fail to parse Agent URL: %v", err)
 			return
 		}
 		switch u.Scheme {
@@ -840,7 +840,7 @@ func WithAgentURL(agentURL string) StartOption {
 				Host:   u.Host,
 			}
 		default:
-			log.Error("Unsupported protocol %q in Agent URL %q. Must be one of: http, https, unix.", u.Scheme, agentURL)
+			log.Warn("Unsupported protocol %q in Agent URL %q. Must be one of: http, https, unix.", u.Scheme, agentURL)
 		}
 	}
 }

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -825,6 +825,26 @@ func WithAgentAddr(addr string) StartOption {
 	}
 }
 
+// WithAgentURL sets the full trace agent URL
+func WithAgentURL(agentURL string) StartOption {
+	return func(c *config) {
+		u, err := url.Parse(agentURL)
+		if err != nil {
+			log.Error("Fail to parse Agent URL: %v", err)
+			return
+		}
+		switch u.Scheme {
+		case "unix", "http", "https":
+			c.agentURL = &url.URL{
+				Scheme: u.Scheme,
+				Host:   u.Host,
+			}
+		default:
+			log.Error("Unsupported protocol %q in Agent URL %q. Must be one of: http, https, unix.", u.Scheme, agentURL)
+		}
+	}
+}
+
 // WithEnv sets the environment to which all traces started by the tracer will be submitted.
 // The default value is the environment variable DD_ENV, if it is set.
 func WithEnv(env string) StartOption {

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -529,6 +529,14 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			c := tracer.config
 			assert.Equal(t, &url.URL{Scheme: "http", Host: "testhost:3333"}, c.agentURL)
 		})
+
+		t.Run("code-override-full-URL", func(t *testing.T) {
+			t.Setenv("DD_TRACE_AGENT_URL", "https://custom:1234")
+			tracer := newTracer(WithAgentURL("http://testhost:3333"))
+			defer tracer.Stop()
+			c := tracer.config
+			assert.Equal(t, &url.URL{Scheme: "http", Host: "testhost:3333"}, c.agentURL)
+		})
 	})
 
 	t.Run("override", func(t *testing.T) {

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -26,6 +26,7 @@ import (
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/namingschema"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/traceprof"
 
@@ -536,6 +537,21 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			defer tracer.Stop()
 			c := tracer.config
 			assert.Equal(t, &url.URL{Scheme: "http", Host: "testhost:3333"}, c.agentURL)
+		})
+
+		t.Run("code-override-full-URL-error", func(t *testing.T) {
+			tp := new(log.RecordLogger)
+			// Have to use UseLogger directly before tracer logger is set
+			defer log.UseLogger(tp)()
+			t.Setenv("DD_TRACE_AGENT_URL", "https://localhost:1234")
+			tracer := newTracer(WithAgentURL("go://testhost:3333"))
+			defer tracer.Stop()
+			c := tracer.config
+			assert.Equal(t, &url.URL{Scheme: "https", Host: "localhost:1234"}, c.agentURL)
+			cond := func() bool {
+				return strings.Contains(strings.Join(tp.Logs(), ""), "Unsupported protocol")
+			}
+			assert.Eventually(t, cond, 1*time.Second, 75*time.Millisecond)
 		})
 	})
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Added `WithAgentURL` option 
Proposal: https://github.com/DataDog/dd-trace-go/issues/368
Jira: https://datadoghq.atlassian.net/browse/AIT-8435

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Have an option to supply full URL in `StartOption` in addition to the existing `WithAgentAddr`option.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!