### PR TITLE
profiler: enable execution traces by default for go1.21+

### DIFF
--- a/profiler/go_lt_1_21.go
+++ b/profiler/go_lt_1_21.go
@@ -1,0 +1,7 @@
+//go:build !go1.21
+
+package profiler
+
+func init() {
+	executionTraceEnabledDefault = false
+}

--- a/profiler/go_lt_1_21.go
+++ b/profiler/go_lt_1_21.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023 Datadog, Inc.
+
 //go:build !go1.21
 
 package profiler

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -552,11 +552,17 @@ type executionTraceConfig struct {
 	warned bool
 }
 
+// executionTraceEnabledDefault depends on the Go version and CPU architecture,
+// see go_lt_1_21.go and this [article][] for more details.
+//
+// [article]: https://blog.felixge.de/waiting-for-go1-21-execution-tracing-with-less-than-one-percent-overhead/
+var executionTraceEnabledDefault = runtime.GOARCH == "arm64" || runtime.GOARCH == "amd64"
+
 // Refresh updates the execution trace configuration to reflect any run-time
 // changes to the configuration environment variables, applying defaults as
 // needed.
 func (e *executionTraceConfig) Refresh() {
-	e.Enabled = internal.BoolEnv("DD_PROFILING_EXECUTION_TRACE_ENABLED", false)
+	e.Enabled = internal.BoolEnv("DD_PROFILING_EXECUTION_TRACE_ENABLED", executionTraceEnabledDefault)
 	e.Period = internal.DurationEnv("DD_PROFILING_EXECUTION_TRACE_PERIOD", 15*time.Minute)
 	e.Limit = internal.IntEnv("DD_PROFILING_EXECUTION_TRACE_LIMIT_BYTES", defaultExecutionTraceSizeLimit)
 

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -236,6 +236,10 @@ func TestProfilerPassthrough(t *testing.T) {
 	if testing.Short() {
 		return
 	}
+	beforeExecutionTraceEnabledDefault := executionTraceEnabledDefault
+	executionTraceEnabledDefault = false
+	defer func() { executionTraceEnabledDefault = beforeExecutionTraceEnabledDefault }()
+
 	out := make(chan batch)
 	p, err := newProfiler()
 	require.NoError(t, err)
@@ -377,6 +381,9 @@ func TestAllUploaded(t *testing.T) {
 			"delta-mutex.pprof",
 			"goroutines.pprof",
 			"goroutineswait.pprof",
+		}
+		if executionTraceEnabledDefault && seq == 0 {
+			expected = append(expected, "go.trace")
 		}
 		assert.ElementsMatch(t, expected, profile.event.Attachments)
 


### PR DESCRIPTION
### What does this PR do?

Enable execution traces by default for go1.21+

### Motivation

We've verified that this is safe and has no performance impact on our internal fleet. Let's allow all customers to enjoy this feature without having to figure out how to turn it on.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!