### PR TITLE
ddtrace/mocktracer: use lock in String method

### DIFF
--- a/ddtrace/mocktracer/mockspan.go
+++ b/ddtrace/mocktracer/mockspan.go
@@ -217,6 +217,8 @@ func (s *mockspan) Finish(opts ...ddtrace.FinishOption) {
 
 // String implements fmt.Stringer.
 func (s *mockspan) String() string {
+	s.RLock()
+	defer s.RUnlock()
 	sc := s.context
 	return fmt.Sprintf(`
 name: %s

--- a/ddtrace/mocktracer/mockspan_test.go
+++ b/ddtrace/mocktracer/mockspan_test.go
@@ -192,6 +192,14 @@ func TestSpanFinishTwice(t *testing.T) {
 	assert.Equal(len(s.tracer.finishedSpans), 1)
 }
 
+func TestSpanString(t *testing.T) {
+	s := basicSpan("http.request")
+	s.Finish(tracer.WithError(errors.New("some error")))
+
+	assert := assert.New(t)
+	assert.NotEmpty(s.String())
+}
+
 func TestSpanWithID(t *testing.T) {
 	spanID := uint64(123456789)
 	span := newMockTracer().StartSpan("", tracer.WithSpanID(spanID))


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Use RLock in the mockspan String method to fix the "data race" error when running tests with -race flag. All other methods do use lock so this seems to be an oversight.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
```
WARNING: DATA RACE
Write at 0x00c00039b650 by goroutine 16:
  runtime.mapassign_faststr()
      /usr/local/go/src/runtime/map_faststr.go:203 +0x0
  gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer.(*mockspan).SetTag()
      /home/circleci/project/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer/mockspan.go:130 +0x304
```
```
Previous read at 0x00c00039b650 by goroutine 28:
  reflect.maplen()
      /usr/local/go/src/runtime/map.go:1394 +0x0
  reflect.Value.lenNonSlice()
      /usr/local/go/src/reflect/value.go:1630 +0x26d
  reflect.Value.Len()
      /usr/local/go/src/reflect/value.go:1619 +0x11a
  internal/fmtsort.Sort()
      /usr/local/go/src/internal/fmtsort/sort.go:58 +0x101
  fmt.(*pp).printValue()
      /usr/local/go/src/fmt/print.go:800 +0x1164
  fmt.(*pp).printArg()
      /usr/local/go/src/fmt/print.go:743 +0xe17
  fmt.(*pp).doPrintf()
      /usr/local/go/src/fmt/print.go:1057 +0x499
  fmt.Sprintf()
      /usr/local/go/src/fmt/print.go:219 +0x67
  gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer.(*mockspan).String()
      /home/circleci/project/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer/mockspan.go:221 +0x22a
```
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!