### PR TITLE
ddtrace/tracer: set a global service name when defaulting to binary name (AIT-8312)

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -420,11 +420,11 @@ func newConfig(opts ...StartOption) *config {
 		if v, ok := c.globalTags["service"]; ok {
 			if s, ok := v.(string); ok {
 				c.serviceName = s
-				globalconfig.SetServiceName(s)
 			}
 		} else {
 			c.serviceName = filepath.Base(os.Args[0])
 		}
+		globalconfig.SetServiceName(c.serviceName)
 	}
 	if c.transport == nil {
 		c.transport = newHTTPTransport(c.agentURL.String(), c.httpClient)

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -902,7 +902,7 @@ func TestServiceName(t *testing.T) {
 		globalconfig.SetServiceName("")
 		c := newConfig()
 		assert.Equal(c.serviceName, filepath.Base(os.Args[0]))
-		assert.Equal("", globalconfig.ServiceName())
+		assert.Equal(c.serviceName, globalconfig.ServiceName())
 
 		os.Setenv("DD_TAGS", "service:testService")
 		defer os.Unsetenv("DD_TAGS")

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -888,6 +888,15 @@ func TestServiceName(t *testing.T) {
 		assert.Equal("api-intake", globalconfig.ServiceName())
 	})
 
+	t.Run("default to binary name", func(t *testing.T) {
+		defer globalconfig.SetServiceName("")
+		assert := assert.New(t)
+		c := newConfig()
+
+		assert.Regexp(`tracer\.test(\.exe)?`, c.serviceName)
+		assert.Regexp(`tracer\.test(\.exe)?`, globalconfig.ServiceName())
+	})
+
 	t.Run("override-chain", func(t *testing.T) {
 		assert := assert.New(t)
 		globalconfig.SetServiceName("")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Fixes a bug where the global service name is not set when defaulting to binary name as service name.

### Motivation

This was discovered while investigating gRPC contrib warnings. This PR fixes these warnings.

```
Datadog Tracer v1.55.0 WARN: No global service name was detected. GRPC Server may have been created before calling tracer.Start(). Will dynamically fetch service name for every span. Note this may have a slight performance cost, it is always recommended to start the tracer before initializing any traced packages.
```

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!