### PR TITLE
internal/version: bump to v1.57.0-dev

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -13,7 +13,7 @@ import (
 // Tag specifies the current release tag. It needs to be manually
 // updated. A test checks that the value of Tag never points to a
 // git tag that is older than HEAD.
-const Tag = "v1.56.0-dev"
+const Tag = "v1.57.0-dev"
 
 // Dissected version number. Filled during init()
 var (


### PR DESCRIPTION
### What does this PR do?

Bump tag to `1.57.0-dev`.

### Motivation

`v1.56.0` release.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!