### PR TITLE
telemetry: fix profiler not passing config and align data model with spec AIT-7935

### DIFF
--- a/ddtrace/tracer/telemetry_test.go
+++ b/ddtrace/tracer/telemetry_test.go
@@ -32,6 +32,7 @@ func TestTelemetryEnabled(t *testing.T) {
 
 		assert.True(t, telemetryClient.Started)
 		assert.True(t, telemetryClient.AsmEnabled)
+		telemetryClient.AssertNumberOfCalls(t, "ApplyOps", 1)
 		telemetry.Check(t, telemetryClient.Configuration, "trace_debug_enabled", false)
 		telemetry.Check(t, telemetryClient.Configuration, "service", "test-serv")
 		telemetry.Check(t, telemetryClient.Configuration, "env", "test-env")
@@ -60,6 +61,7 @@ func TestTelemetryEnabled(t *testing.T) {
 		)
 		defer Stop()
 		telemetry.Check(t, telemetryClient.Configuration, "service", "test-serv")
+		telemetryClient.AssertNumberOfCalls(t, "ApplyOps", 2)
 	})
 	t.Run("orchestrion telemetry", func(t *testing.T) {
 		telemetryClient := new(telemetrytest.MockClient)

--- a/internal/telemetry/message.go
+++ b/internal/telemetry/message.go
@@ -107,6 +107,7 @@ type AppStarted struct {
 	Products          Products            `json:"products,omitempty"`
 	AdditionalPayload []AdditionalPayload `json:"additional_payload,omitempty"`
 	Error             Error               `json:"error,omitempty"`
+	RemoteConfig      *RemoteConfig       `json:"remote_config,omitempty"`
 }
 
 // IntegrationsChange corresponds to the app-integrations-change requesty type
@@ -127,8 +128,8 @@ type Integration struct {
 // ConfigurationChange corresponds to the `AppClientConfigurationChange` event
 // that contains information about configuration changes since the app-started event
 type ConfigurationChange struct {
-	Configuration []Configuration `json:"conf_key_values"`
-	RemoteConfig  RemoteConfig    `json:"remote_config"`
+	Configuration []Configuration `json:"configuration"`
+	RemoteConfig  *RemoteConfig   `json:"remote_config,omitempty"`
 }
 
 // Configuration is a library-specific configuration value
@@ -194,7 +195,10 @@ type Dependency struct {
 type RemoteConfig struct {
 	UserEnabled     string `json:"user_enabled"`     // whether the library has made a request to fetch remote-config
 	ConfigsRecieved bool   `json:"configs_received"` // whether the library receives a valid config response
-	Error           Error  `json:"error"`
+	RcID            string `json:"rc_id,omitempty"`
+	RcRevision      string `json:"rc_revision,omitempty"`
+	RcVersion       string `json:"rc_version,omitempty"`
+	Error           Error  `json:"error,omitempty"`
 }
 
 // Error stores error information about various tracer events

--- a/internal/telemetry/option.go
+++ b/internal/telemetry/option.go
@@ -18,7 +18,8 @@ import (
 // An Option is used to configure the telemetry client's settings
 type Option func(*client)
 
-// ApplyOps sets various fields of the client
+// ApplyOps sets various fields of the client.
+// To be called before starting any product.
 func (c *client) ApplyOps(opts ...Option) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -15,31 +15,30 @@ import (
 
 // ProductStart signals that the product has started with some configuration
 // information. It will start the telemetry client if it is not already started.
+// ProductStart assumes that the telemetry client has been configured already by the caller using the ApplyOps method.
 // If the client is already started, it will send any necessary app-product-change
 // events to indicate whether the product is enabled, as well as an app-client-configuration-change
 // event in case any new configuration information is available.
 func (c *client) ProductStart(namespace Namespace, configuration []Configuration) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.started {
-		c.configChange(configuration)
-		switch namespace {
-		case NamespaceProfilers:
-			c.productEnabled(NamespaceProfilers)
-		case NamespaceTracers:
-			// Since appsec is integrated with the tracer, we sent an app-product-change
-			// update about appsec when the tracer starts. Any tracer-related configuration
-			// information can be passed along here as well.
-			if appsec.Enabled() {
-				c.productEnabled(NamespaceASM)
-			}
-		case NamespaceASM:
-			c.productEnabled(NamespaceASM)
-		default:
-			log("unknown product namespace provided to ProductStart")
-		}
-	} else {
+	if !c.started {
 		c.start(configuration, namespace)
+		return
+	}
+	c.configChange(configuration)
+	switch namespace {
+	case NamespaceProfilers, NamespaceASM:
+		c.productEnabled(namespace)
+	case NamespaceTracers:
+		// Since appsec is integrated with the tracer, we sent an app-product-change
+		// update about appsec when the tracer starts. Any tracer-related configuration
+		// information can be passed along here as well.
+		if appsec.Enabled() {
+			c.productEnabled(NamespaceASM)
+		}
+	default:
+		log("unknown product namespace provided to ProductStart")
 	}
 }
 

--- a/internal/telemetry/telemetrytest/telemetrytest.go
+++ b/internal/telemetry/telemetrytest/telemetrytest.go
@@ -89,6 +89,8 @@ func (c *MockClient) Count(ns telemetry.Namespace, name string, val float64, tag
 func (c *MockClient) Stop() {
 }
 
-// ApplyOps is NOOP for the mock client.
-func (c *MockClient) ApplyOps(_ ...telemetry.Option) {
+// ApplyOps is used to record the number of ApplyOps method calls.
+func (c *MockClient) ApplyOps(args ...telemetry.Option) {
+	c.On("ApplyOps", args).Return()
+	_ = c.Called(args)
 }

--- a/profiler/telemetry.go
+++ b/profiler/telemetry.go
@@ -24,9 +24,15 @@ func startTelemetry(c *config) {
 		_, ok := c.types[t]
 		return ok
 	}
-	configs := []telemetry.Configuration{}
-	telemetry.GlobalClient.ProductStart(telemetry.NamespaceProfilers,
-		append(configs, []telemetry.Configuration{
+	telemetry.GlobalClient.ApplyOps(
+		telemetry.WithService(c.service),
+		telemetry.WithEnv(c.env),
+		telemetry.WithHTTPClient(c.httpClient),
+		telemetry.WithURL(c.agentless, c.agentURL),
+	)
+	telemetry.GlobalClient.ProductStart(
+		telemetry.NamespaceProfilers,
+		[]telemetry.Configuration{
 			{Name: "delta_profiles", Value: c.deltaProfiles},
 			{Name: "agentless", Value: c.agentless},
 			{Name: "profile_period", Value: c.period.String()},
@@ -46,5 +52,6 @@ func startTelemetry(c *config) {
 			{Name: "execution_trace_period", Value: c.traceConfig.Period.String()},
 			{Name: "execution_trace_size_limit", Value: c.traceConfig.Limit},
 			{Name: "endpoint_count_enabled", Value: c.endpointCountEnabled},
-		}...))
+		},
+	)
 }

--- a/profiler/telemetry_test.go
+++ b/profiler/telemetry_test.go
@@ -17,7 +17,6 @@ import (
 
 // Test that the profiler sends the correct telemetry information
 func TestTelemetryEnabled(t *testing.T) {
-
 	t.Run("tracer start, profiler start", func(t *testing.T) {
 		telemetryClient := new(telemetrytest.MockClient)
 		defer telemetry.MockGlobalClient(telemetryClient)()
@@ -34,6 +33,7 @@ func TestTelemetryEnabled(t *testing.T) {
 
 		assert.True(t, telemetryClient.ProfilerEnabled)
 		telemetry.Check(t, telemetryClient.Configuration, "heap_profile_enabled", true)
+		telemetryClient.AssertNumberOfCalls(t, "ApplyOps", 2)
 	})
 	t.Run("only profiler start", func(t *testing.T) {
 		telemetryClient := new(telemetrytest.MockClient)
@@ -47,5 +47,6 @@ func TestTelemetryEnabled(t *testing.T) {
 
 		assert.True(t, telemetryClient.ProfilerEnabled)
 		telemetry.Check(t, telemetryClient.Configuration, "heap_profile_enabled", true)
+		telemetryClient.AssertNumberOfCalls(t, "ApplyOps", 1)
 	})
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

The PR fixes 2 bugs
- The profiler starts the telemetry client without passing any config so we end up without a valid agent url for telemetry. This is problematic typically when the profiler is used alone or if it starts before the tracer. The first 2 commits address this issue.
- The `app-client-configuration-change` requests contain invalid payloads, i.e used `conf_key_values` instead of `configuration`. This seemed to be [an inconsistency in the api docs that have been fixed](https://github.com/DataDog/instrumentation-telemetry-api-docs/commit/3067196e0175e5fe2aa1f971c02f182b3087c5c1#diff-fc5c86287b453d12d2fbb6b4e56c351add9831b1b54cd1fba88530348c5b173b) after telemetry was implemented in the tracer. Also took the opportunity to align the `remote_config` field with the spec. This is done in the 3rd and 4th commits.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Bug fixes.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!