### PR TITLE
ci: use older Windows for Go 1.19 tests

### DIFF
--- a/.github/workflows/multios-unit-tests.yml
+++ b/.github/workflows/multios-unit-tests.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   test-multi-os:
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: "${{ (inputs.go-version == '1.19' && inputs.runs-on == 'windows-latest') && 'windows-2019' || inputs.runs-on }}"
     env:
       REPORT: gotestsum-report.xml # path to where test results will be saved
     steps:


### PR DESCRIPTION
### What does this PR do?

Use windows-2019 runner when testing Go 1.19, since the windows-2022 image
has an incompatible C toolchain which breaks some of our tests.

This is a known issue, fixed in Go 1.20: https://github.com/golang/go/issues/51007

### Motivation

Keep CI green for Go 1.19.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
