### PR TITLE
tracer TestUserMonitoring: Wait for goroutines before test completes

### DIFF
--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -2319,9 +2319,10 @@ func TestUserMonitoring(t *testing.T) {
 
 	// This tests data races for trace.propagatingTags reads/writes through public API.
 	// The Go data race detector should not complain when running the test with '-race'.
-	wg := &sync.WaitGroup{}
-	wg.Add(2)
 	t.Run("data-race", func(t *testing.T) {
+		wg := &sync.WaitGroup{}
+		wg.Add(2)
+
 		root := tr.newRootSpan("root", "test", "test")
 
 		go func() {
@@ -2336,9 +2337,10 @@ func TestUserMonitoring(t *testing.T) {
 				tr.StartSpan("test", ChildOf(root.Context())).Finish()
 			}
 		}()
+
 		root.Finish()
+		wg.Wait()
 	})
-	wg.Wait()
 }
 
 // BenchmarkTracerStackFrames tests the performance of taking stack trace.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This test starts a set of goroutines which do things to spans after they have finished. Wait for these goroutines to complete before ending the test function. This ensures these goroutines are not running when other tests run. This avoids these tests accidentally capturing the logs from these goroutines, and avoids the race detector triggering on things they are doing.

This fixes a problem when running tests with -shuffle=on, and also fixes a race detector warning:

```
==================
WARNING: DATA RACE
Write at 0x000103d80470 by goroutine 74703:
  gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.setTestTime()
      /Users/evan.jones/dd/dd-trace-go/ddtrace/tracer/abandonedspans_test.go:28 +0xf8
  gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.TestReportAbandonedSpans.func2()
      /Users/evan.jones/dd/dd-trace-go/ddtrace/tracer/abandonedspans_test.go:81 +0x44
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.2/libexec/src/testing/testing.go:1595 +0x194
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.2/libexec/src/testing/testing.go:1648 +0x40

Previous read at 0x000103d80470 by goroutine 74356:
  gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.(*span).Finish()
      /Users/evan.jones/dd/dd-trace-go/ddtrace/tracer/span.go:423 +0x3c
  gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.TestUserMonitoring.func5.2()
      /Users/evan.jones/dd/dd-trace-go/ddtrace/tracer/tracer_test.go:2331 +0xc4

Goroutine 74703 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.21.2/libexec/src/testing/testing.go:1648 +0x5d8
  gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.TestReportAbandonedSpans()
      /Users/evan.jones/dd/dd-trace-go/ddtrace/tracer/abandonedspans_test.go:79 +0x204
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.2/libexec/src/testing/testing.go:1595 +0x194
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.2/libexec/src/testing/testing.go:1648 +0x40

Goroutine 74356 (running) created at:
  gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.TestUserMonitoring.func5()
      /Users/evan.jones/dd/dd-trace-go/ddtrace/tracer/tracer_test.go:2329 +0x154
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.2/libexec/src/testing/testing.go:1595 +0x194
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.2/libexec/src/testing/testing.go:1648 +0x40
==================
```

### Motivation

I'm trying to add a test and bug fix for a race detector bug, and I also found this race detector bug in the main branch tests.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!