### PR TITLE
ddtrace/tracer: encode span IDs in execution traces efficiently

### DIFF
--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -7,6 +7,7 @@ package tracer
 
 import (
 	gocontext "context"
+	"encoding/binary"
 	"os"
 	"runtime/pprof"
 	rt "runtime/trace"
@@ -702,7 +703,12 @@ func startExecutionTracerTask(ctx gocontext.Context, span *span) (gocontext.Cont
 		// skipped.
 		ctx = globalinternal.WithExecutionNotTraced(ctx)
 	}
-	rt.Log(ctx, "span id", strconv.FormatUint(span.SpanID, 10))
+	var b [8]byte
+	binary.LittleEndian.PutUint64(b[:], span.SpanID)
+	// TODO: can we make string(b[:]) not allocate? e.g. with unsafe
+	// shenanigans? rt.Log won't retain the message string, though perhaps
+	// we can't assume that will always be the case.
+	rt.Log(ctx, "datadog.packed_span_id", string(b[:]))
 	return ctx, end
 }
 


### PR DESCRIPTION
### What does this PR do?

Encode span IDs directly as 8-byte unsigned integers in the execution trace log
message.

*TODO*: There aren't any automated tests for this. Would be nice to have at
least one.

### Motivation

We were previously encoding span IDs into execution traces as base-10
strings. This is wasteful, in terms of CPU time to encode the ID and
more importantly in terms of how much of the limited execution trace
data the profiler collects will be taken up by span IDs. They can be
encoded directly as 8-byte unsigned integers.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [x] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
