### PR TITLE
tracer: call SetServiceName("") from tests to reset globals

### DIFF
--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -904,6 +904,7 @@ func TestServiceName(t *testing.T) {
 		c = newConfig(WithGlobalTag("service", "testService2"), WithService("testService4"))
 		assert.Equal(c.serviceName, "testService4")
 		assert.Equal("testService4", globalconfig.ServiceName())
+		defer globalconfig.SetServiceName("")
 	})
 }
 
@@ -1118,6 +1119,7 @@ func TestEnvConfig(t *testing.T) {
 func TestStatsTags(t *testing.T) {
 	assert := assert.New(t)
 	c := newConfig(WithService("serviceName"), WithEnv("envName"))
+	defer globalconfig.SetServiceName("")
 	c.hostname = "hostName"
 	tags := statsTags(c)
 

--- a/ddtrace/tracer/sqlcomment_test.go
+++ b/ddtrace/tracer/sqlcomment_test.go
@@ -13,6 +13,7 @@ import (
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -101,6 +102,7 @@ func TestSQLCommentCarrier(t *testing.T) {
 			// the test service name includes all RFC3986 reserved characters to make sure all of them are url encoded
 			// as per the sqlcommenter spec
 			tracer := newTracer(WithService("whiskey-service !#$%&'()*+,/:;=?@[]"), WithEnv("test-env"), WithServiceVersion("1.0.0"))
+			defer globalconfig.SetServiceName("")
 			defer tracer.Stop()
 
 			var spanCtx ddtrace.SpanContext

--- a/ddtrace/tracer/telemetry_test.go
+++ b/ddtrace/tracer/telemetry_test.go
@@ -8,6 +8,7 @@ package tracer
 import (
 	"testing"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/telemetrytest"
 	"gopkg.in/DataDog/dd-trace-go.v1/profiler"
@@ -28,6 +29,7 @@ func TestTelemetryEnabled(t *testing.T) {
 			WithPeerServiceMapping("key", "val"),
 			WithPeerServiceDefaults(true),
 		)
+		defer globalconfig.SetServiceName("")
 		defer Stop()
 
 		assert.True(t, telemetryClient.Started)
@@ -59,6 +61,7 @@ func TestTelemetryEnabled(t *testing.T) {
 		Start(
 			WithService("test-serv"),
 		)
+		defer globalconfig.SetServiceName("")
 		defer Stop()
 		telemetry.Check(t, telemetryClient.Configuration, "service", "test-serv")
 		telemetryClient.AssertNumberOfCalls(t, "ApplyOps", 2)


### PR DESCRIPTION
### What does this PR do?

This fixes tests with run with -shuffle=on. I am not sure if I caught all of them, since I just verified this experimentally by running the following command, rather than by trying to check all uses.

for i in $(seq 10); do
  go test -shuffle=on -failfast -count=2 ./ddtrace/tracer || break
done


### Motivation

I was running the tests with this flag with the race detector to check for any other races on my fix I'm about to send separately.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!