### PR TITLE
opentelemetry: finish a span with an error if one is provided

### DIFF
--- a/ddtrace/opentelemetry/span.go
+++ b/ddtrace/opentelemetry/span.go
@@ -7,6 +7,7 @@ package opentelemetry
 
 import (
 	"encoding/binary"
+	"errors"
 	"strconv"
 	"strings"
 
@@ -45,6 +46,7 @@ func (s *span) End(options ...oteltrace.SpanEndOption) {
 	var opts []tracer.FinishOption
 	if s.statusInfo.code == otelcodes.Error {
 		s.SetTag(ext.ErrorMsg, s.statusInfo.description)
+		opts = append(opts, tracer.WithError(errors.New(s.statusInfo.description)))
 	}
 	if t := finishCfg.Timestamp(); !t.IsZero() {
 		opts = append(opts, tracer.FinishTime(t))

--- a/ddtrace/opentelemetry/span_test.go
+++ b/ddtrace/opentelemetry/span_test.go
@@ -148,6 +148,7 @@ func TestSpanEnd(t *testing.T) {
 	assert.NotContains(payload, ignoredName)
 	assert.Contains(payload, msg)
 	assert.NotContains(payload, ignoredMsg)
+	assert.Contains(payload, `"error":1`) // this should be an error span
 
 	for k, v := range attributes {
 		assert.Contains(payload, fmt.Sprintf("\"%s\":\"%s\"", k, v))
@@ -374,6 +375,7 @@ func TestSpanEndOptions(t *testing.T) {
 	assert.Contains(p, fmt.Sprint(startTime.UnixNano()))
 	assert.Contains(p, `"duration":5000000000,`)
 	assert.Contains(p, `persisted_option`)
+	assert.Contains(p, `"error":1`)
 }
 
 func TestSpanSetAttributes(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Passes a finish option to end a span as an error span if an error was provided.

Note that this won't have *all* of the information, since we don't support span events right now, so `RecordError` is a no-op. So all we have is the description, instead of the original error from the application.

Fixes #2272

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!