### PR TITLE
internal/log: fix potential integer conversion issue from parsed value

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -99,16 +99,22 @@ var (
 )
 
 func init() {
-	if v := os.Getenv("DD_LOGGING_RATE"); v != "" {
-		if sec, err := strconv.ParseInt(v, 10, 64); err != nil {
-			Warn("Invalid value for DD_LOGGING_RATE: %v", err)
+	v := os.Getenv("DD_LOGGING_RATE")
+	setLoggingRate(v)
+}
+
+func setLoggingRate(v string) {
+	if v == "" {
+		return
+	}
+	if sec, err := strconv.ParseInt(v, 10, 64); err != nil {
+		Warn("Invalid value for DD_LOGGING_RATE: %v", err)
+	} else {
+		if sec < 0 {
+			Warn("Invalid value for DD_LOGGING_RATE: negative value")
 		} else {
-			if sec < 0 {
-				Warn("Invalid value for DD_LOGGING_RATE: negative value")
-			} else {
-				// DD_LOGGING_RATE = 0 allows to log errors immediately.
-				errrate = time.Duration(sec) * time.Second
-			}
+			// DD_LOGGING_RATE = 0 allows to log errors immediately.
+			errrate = time.Duration(sec) * time.Second
 		}
 	}
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -100,10 +100,15 @@ var (
 
 func init() {
 	if v := os.Getenv("DD_LOGGING_RATE"); v != "" {
-		if sec, err := strconv.ParseUint(v, 10, 64); err != nil {
+		if sec, err := strconv.ParseInt(v, 10, 64); err != nil {
 			Warn("Invalid value for DD_LOGGING_RATE: %v", err)
 		} else {
-			errrate = time.Duration(sec) * time.Second
+			if sec < 0 {
+				Warn("Invalid value for DD_LOGGING_RATE: negative value")
+			} else {
+				// DD_LOGGING_RATE = 0 allows to log errors immediately.
+				errrate = time.Duration(sec) * time.Second
+			}
 		}
 	}
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -99,14 +99,12 @@ var (
 )
 
 func init() {
-	v := os.Getenv("DD_LOGGING_RATE")
-	setLoggingRate(v)
+	if v := os.Getenv("DD_LOGGING_RATE"); v != "" {
+		setLoggingRate(v)
+	}
 }
 
 func setLoggingRate(v string) {
-	if v == "" {
-		return
-	}
 	if sec, err := strconv.ParseInt(v, 10, 64); err != nil {
 		Warn("Invalid value for DD_LOGGING_RATE: %v", err)
 	} else {

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -141,57 +141,37 @@ func TestRecordLoggerIgnore(t *testing.T) {
 }
 
 func TestSetLoggingRate(t *testing.T) {
-	defer func(old Logger) {
-		UseLogger(old)
-		errrate = time.Minute
-	}(logger)
-	tp := new(RecordLogger)
-	UseLogger(tp)
-
 	testCases := []struct {
-		input       string
-		expectedLog string
-		result      time.Duration
+		input  string
+		result time.Duration
 	}{
 		{
-			input:       "",
-			expectedLog: "",
-			result:      time.Minute,
+			input:  "",
+			result: time.Minute,
 		},
 		{
-			input:       "0",
-			expectedLog: "",
-			result:      0 * time.Second,
+			input:  "0",
+			result: 0 * time.Second,
 		},
 		{
-			input:       "10",
-			expectedLog: "",
-			result:      10 * time.Second,
+			input:  "10",
+			result: 10 * time.Second,
 		},
 		{
-			input:       "-1",
-			expectedLog: "Invalid value for DD_LOGGING_RATE: negative value",
-			result:      time.Minute,
+			input:  "-1",
+			result: time.Minute,
 		},
 		{
-			input:       "this is not a number",
-			expectedLog: "Invalid value for DD_LOGGING_RATE: strconv.ParseInt: parsing \"this is not a number\": invalid syntax",
-			result:      time.Minute,
+			input:  "this is not a number",
+			result: time.Minute,
 		},
 	}
 	for _, tC := range testCases {
 		tC := tC
-		tp.Reset()
 		errrate = time.Minute // reset global variable
 		t.Run(tC.input, func(t *testing.T) {
 			setLoggingRate(tC.input)
-			lines := tp.Logs()
 			assert.Equal(t, tC.result, errrate)
-			if tC.expectedLog == "" {
-				assert.Empty(t, lines)
-			} else {
-				assert.Contains(t, lines[0], tC.expectedLog)
-			}
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Parses `DD_LOGGING_RATE` as `int64` instead of `uint64` to make sure, although it should contain a big value to happen, it doesn't yield unexpected results when converted to `time.Duration`.

Respects the current behaviour by taking into account that a zero value means to log immediately.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!