### PR TITLE
tracer: introduce dynamic configuration

### DIFF
--- a/ddtrace/tracer/dynamic_config.go
+++ b/ddtrace/tracer/dynamic_config.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package tracer
+
+import (
+	"sync"
+)
+
+// dynamicConfig is a thread-safe generic data structure to represent configuration fields.
+// It's designed to satisfy the dynamic configuration semantics (i.e reset, update, apply configuration changes).
+// This structure will be extended to track the origin of configuration values as well (e.g remote_config, env_var).
+type dynamicConfig[T any] struct {
+	sync.RWMutex
+	current T       // holds the current configuration value
+	startup T       // holds the startup configuration value
+	apply   func(T) // applies a configuration value
+	isReset bool    // internal boolean to avoid unnecessary resets
+}
+
+func newDynamicConfig[T any](val T, apply func(T)) dynamicConfig[T] {
+	return dynamicConfig[T]{
+		current: val,
+		startup: val,
+		apply:   apply,
+		isReset: true,
+	}
+}
+
+// update applies a new configuration value
+func (dc *dynamicConfig[T]) update(val T) {
+	dc.Lock()
+	defer dc.Unlock()
+	dc.current = val
+	dc.apply(val)
+	dc.isReset = false
+}
+
+// reset re-applies the startup configuration value
+func (dc *dynamicConfig[T]) reset() {
+	dc.Lock()
+	defer dc.Unlock()
+	if dc.isReset {
+		return
+	}
+	dc.current = dc.startup
+	dc.apply(dc.startup)
+	dc.isReset = true
+}
+
+// handleRC processes a new configuration value from remote config
+func (dc *dynamicConfig[T]) handleRC(val *T) {
+	if val != nil {
+		dc.update(*val)
+		return
+	}
+	dc.reset()
+}

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -253,6 +253,12 @@ type config struct {
 	// orchestrionCfg holds Orchestrion (aka auto-instrumentation) configuration.
 	// Only used for telemetry currently.
 	orchestrionCfg orchestrionConfig
+
+	// traceSampleRate holds the trace sample rate.
+	traceSampleRate dynamicConfig[float64]
+
+	// headerAsTags holds the header as tags configuration.
+	headerAsTags dynamicConfig[[]string]
 }
 
 // orchestrionConfig contains Orchestrion configuration.
@@ -316,6 +322,7 @@ func newConfig(opts ...StartOption) *config {
 	if v := os.Getenv("DD_SERVICE_MAPPING"); v != "" {
 		internal.ForEachStringTag(v, func(key, val string) { WithServiceMapping(key, val)(c) })
 	}
+	c.headerAsTags = newDynamicConfig(nil, setHeaderTags)
 	if v := os.Getenv("DD_TRACE_HEADER_TAGS"); v != "" {
 		WithHeaderTags(strings.Split(v, ","))(c)
 	}
@@ -1212,14 +1219,19 @@ func StackFrames(n, skip uint) FinishOption {
 // Special headers can not be sub-selected. E.g., an entire Cookie header would be transmitted, without the ability to choose specific Cookies.
 func WithHeaderTags(headerAsTags []string) StartOption {
 	return func(c *config) {
-		globalconfig.ClearHeaderTags()
-		for _, h := range headerAsTags {
-			if strings.HasPrefix(h, "x-datadog-") {
-				continue
-			}
-			header, tag := normalizer.HeaderTag(h)
-			globalconfig.SetHeaderTag(header, tag)
+		c.headerAsTags = newDynamicConfig(headerAsTags, setHeaderTags)
+		setHeaderTags(headerAsTags)
+	}
+}
+
+func setHeaderTags(headerAsTags []string) {
+	globalconfig.ClearHeaderTags()
+	for _, h := range headerAsTags {
+		if strings.HasPrefix(h, "x-datadog-") {
+			continue
 		}
+		header, tag := normalizer.HeaderTag(h)
+		globalconfig.SetHeaderTag(header, tag)
 	}
 }
 

--- a/ddtrace/tracer/remote_config.go
+++ b/ddtrace/tracer/remote_config.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package tracer
+
+import (
+	"encoding/json"
+	"strings"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/remoteconfig"
+
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+)
+
+type configData struct {
+	Action        string    `json:"action"`
+	ServiceTarget target    `json:"service_target"`
+	LibConfig     libConfig `json:"lib_config"`
+}
+
+type target struct {
+	Service string `json:"service"`
+	Env     string `json:"env"`
+}
+
+type libConfig struct {
+	SamplingRate *float64    `json:"tracing_sampling_rate,omitempty"`
+	HeaderTags   *headerTags `json:"tracing_header_tags,omitempty"`
+}
+
+type headerTags []headerTag
+
+type headerTag struct {
+	Header  string `json:"header"`
+	TagName string `json:"tag_name"`
+}
+
+func (hts *headerTags) toSlice() *[]string {
+	if hts == nil {
+		return nil
+	}
+	s := make([]string, len(*hts))
+	for i, ht := range *hts {
+		s[i] = ht.toString()
+	}
+	return &s
+}
+
+func (ht headerTag) toString() string {
+	var sb strings.Builder
+	sb.WriteString(ht.Header)
+	sb.WriteString(":")
+	sb.WriteString(ht.TagName)
+	return sb.String()
+}
+
+// onRemoteConfigUpdate is a remote config callaback responsible for processing APM_TRACING RC-product updates.
+func (t *tracer) onRemoteConfigUpdate(updates map[string]remoteconfig.ProductUpdate) map[string]state.ApplyStatus {
+	statuses := map[string]state.ApplyStatus{}
+	u, found := updates[state.ProductAPMTracing]
+	if !found {
+		return statuses
+	}
+	for path, raw := range u {
+		if raw == nil {
+			continue
+		}
+		log.Debug("Processing config from RC. Path: %s. Raw: %s", path, raw)
+		var c configData
+		if err := json.Unmarshal(raw, &c); err != nil {
+			log.Debug("Error while unmarshalling payload for %s: %v. Configuration won't be applied.", path, err)
+			statuses[path] = state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()}
+			continue
+		}
+		statuses[path] = state.ApplyStatus{State: state.ApplyStateAcknowledged}
+		t.config.traceSampleRate.handleRC(c.LibConfig.SamplingRate)
+		t.config.headerAsTags.handleRC(c.LibConfig.HeaderTags.toSlice())
+	}
+	return statuses
+}

--- a/ddtrace/tracer/remote_config_test.go
+++ b/ddtrace/tracer/remote_config_test.go
@@ -1,0 +1,140 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package tracer
+
+import (
+	"testing"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/remoteconfig"
+
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOnRemoteConfigUpdate(t *testing.T) {
+	t.Run("RC sampling rate = 0.5 is applied and can be reverted", func(t *testing.T) {
+		tracer, _, _, stop := startTestTracer(t)
+		defer stop()
+
+		// Apply RC. Assert _dd.rule_psr shows the RC sampling rate (0.2) is applied
+		input := map[string]remoteconfig.ProductUpdate{
+			"APM_TRACING": {"path": []byte(`{"lib_config": {"tracing_sampling_rate": 0.5}}`)},
+		}
+		applyStatus := tracer.onRemoteConfigUpdate(input)
+		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
+		s := tracer.StartSpan("web.request").(*span)
+		s.Finish()
+		require.Equal(t, 0.5, s.Metrics[keyRulesSamplerAppliedRate])
+
+		// Unset RC. Assert _dd.rule_psr is not set
+		input["APM_TRACING"] = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}}`)}
+		applyStatus = tracer.onRemoteConfigUpdate(input)
+		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
+		s = tracer.StartSpan("web.request").(*span)
+		s.Finish()
+		require.NotContains(t, keyRulesSamplerAppliedRate, s.Metrics)
+	})
+
+	t.Run("DD_TRACE_SAMPLE_RATE=0.1 and RC sampling rate = 0.2", func(t *testing.T) {
+		t.Setenv("DD_TRACE_SAMPLE_RATE", "0.1")
+		tracer, _, _, stop := startTestTracer(t)
+		defer stop()
+
+		// Apply RC. Assert _dd.rule_psr shows the RC sampling rate (0.2) is applied
+		input := map[string]remoteconfig.ProductUpdate{
+			"APM_TRACING": {"path": []byte(`{"lib_config": {"tracing_sampling_rate": 0.2}}`)},
+		}
+		applyStatus := tracer.onRemoteConfigUpdate(input)
+		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
+		s := tracer.StartSpan("web.request").(*span)
+		s.Finish()
+		require.Equal(t, 0.2, s.Metrics[keyRulesSamplerAppliedRate])
+
+		// Unset RC. Assert _dd.rule_psr shows the previous sampling rate (0.1) is applied
+		input["APM_TRACING"] = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}}`)}
+		applyStatus = tracer.onRemoteConfigUpdate(input)
+		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
+		s = tracer.StartSpan("web.request").(*span)
+		s.Finish()
+		require.Equal(t, 0.1, s.Metrics[keyRulesSamplerAppliedRate])
+	})
+
+	t.Run("RC header tags = X-Test-Header:my-tag-name is applied and can be reverted", func(t *testing.T) {
+		tracer, _, _, stop := startTestTracer(t)
+		defer stop()
+
+		// Apply RC. Assert global config shows the RC header tag is applied
+		input := map[string]remoteconfig.ProductUpdate{
+			"APM_TRACING": {"path": []byte(`{"lib_config": {"tracing_header_tags": [{"header": "X-Test-Header", "tag_name": "my-tag-name"}]}}`)},
+		}
+		applyStatus := tracer.onRemoteConfigUpdate(input)
+		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
+		require.Equal(t, 1, globalconfig.HeaderTagsLen())
+		require.Equal(t, "my-tag-name", globalconfig.HeaderTag("X-Test-Header"))
+
+		// Unset RC. Assert header tags are not set
+		input["APM_TRACING"] = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}}`)}
+		applyStatus = tracer.onRemoteConfigUpdate(input)
+		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
+		require.Equal(t, 0, globalconfig.HeaderTagsLen())
+	})
+
+	t.Run("DD_TRACE_HEADER_TAGS=X-Test-Header:my-tag-name-from-env and RC header tags = X-Test-Header:my-tag-name-from-rc", func(t *testing.T) {
+		t.Setenv("DD_TRACE_HEADER_TAGS", "X-Test-Header:my-tag-name-from-env")
+		tracer, _, _, stop := startTestTracer(t)
+		defer stop()
+
+		// Apply RC. Assert global config shows the RC header tag is applied
+		input := map[string]remoteconfig.ProductUpdate{
+			"APM_TRACING": {"path": []byte(`{"lib_config": {"tracing_header_tags": [{"header": "X-Test-Header", "tag_name": "my-tag-name-from-rc"}]}}`)},
+		}
+		applyStatus := tracer.onRemoteConfigUpdate(input)
+		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
+		require.Equal(t, 1, globalconfig.HeaderTagsLen())
+		require.Equal(t, "my-tag-name-from-rc", globalconfig.HeaderTag("X-Test-Header"))
+
+		// Unset RC. Assert global config shows the DD_TRACE_HEADER_TAGS header tag
+		input["APM_TRACING"] = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}}`)}
+		applyStatus = tracer.onRemoteConfigUpdate(input)
+		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
+		require.Equal(t, 1, globalconfig.HeaderTagsLen())
+		require.Equal(t, "my-tag-name-from-env", globalconfig.HeaderTag("X-Test-Header"))
+	})
+
+	t.Run("In code header tags = X-Test-Header:my-tag-name-in-code and RC header tags = X-Test-Header:my-tag-name-from-rc", func(t *testing.T) {
+		tracer, _, _, stop := startTestTracer(t, WithHeaderTags([]string{"X-Test-Header:my-tag-name-in-code"}))
+		defer stop()
+
+		// Apply RC. Assert global config shows the RC header tag is applied
+		input := map[string]remoteconfig.ProductUpdate{
+			"APM_TRACING": {"path": []byte(`{"lib_config": {"tracing_header_tags": [{"header": "X-Test-Header", "tag_name": "my-tag-name-from-rc"}]}}`)},
+		}
+		applyStatus := tracer.onRemoteConfigUpdate(input)
+		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
+		require.Equal(t, 1, globalconfig.HeaderTagsLen())
+		require.Equal(t, "my-tag-name-from-rc", globalconfig.HeaderTag("X-Test-Header"))
+
+		// Unset RC. Assert global config shows the in-code header tag
+		input["APM_TRACING"] = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}}`)}
+		applyStatus = tracer.onRemoteConfigUpdate(input)
+		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
+		require.Equal(t, 1, globalconfig.HeaderTagsLen())
+		require.Equal(t, "my-tag-name-in-code", globalconfig.HeaderTag("X-Test-Header"))
+	})
+
+	t.Run("Invalid payload", func(t *testing.T) {
+		tracer, _, _, stop := startTestTracer(t)
+		defer stop()
+
+		input := map[string]remoteconfig.ProductUpdate{
+			"APM_TRACING": {"path": []byte(`{"lib_config": {"tracing_sampling_rate": "string value"}}`)},
+		}
+		applyStatus := tracer.onRemoteConfigUpdate(input)
+		require.Equal(t, state.ApplyStateError, applyStatus["path"].State)
+		require.NotEmpty(t, applyStatus["path"].Error)
+	})
+}

--- a/ddtrace/tracer/rules_sampler.go
+++ b/ddtrace/tracer/rules_sampler.go
@@ -37,9 +37,9 @@ type rulesSampler struct {
 // Rules are split between trace and single span sampling rules according to their type.
 // Such rules are user-defined through environment variable or WithSamplingRules option.
 // Invalid rules or environment variable values are tolerated, by logging warnings and then ignoring them.
-func newRulesSampler(traceRules, spanRules []SamplingRule) *rulesSampler {
+func newRulesSampler(traceRules, spanRules []SamplingRule, traceSampleRate float64) *rulesSampler {
 	return &rulesSampler{
-		traces: newTraceRulesSampler(traceRules),
+		traces: newTraceRulesSampler(traceRules, traceSampleRate),
 		spans:  newSingleSpanRulesSampler(spanRules),
 	}
 }
@@ -199,6 +199,7 @@ func SpanNameServiceMPSRule(name, service string, rate, limit float64) SamplingR
 // Its value is the number of spans to sample per second.
 // Spans that matched the rules but exceeded the rate limit are not sampled.
 type traceRulesSampler struct {
+	m          sync.RWMutex
 	rules      []SamplingRule // the rules to match spans with
 	globalRate float64        // a rate to apply when no rules match a span
 	limiter    *rateLimiter   // used to limit the volume of spans sampled
@@ -206,10 +207,10 @@ type traceRulesSampler struct {
 
 // newTraceRulesSampler configures a *traceRulesSampler instance using the given set of rules.
 // Invalid rules or environment variable values are tolerated, by logging warnings and then ignoring them.
-func newTraceRulesSampler(rules []SamplingRule) *traceRulesSampler {
+func newTraceRulesSampler(rules []SamplingRule, traceSampleRate float64) *traceRulesSampler {
 	return &traceRulesSampler{
 		rules:      rules,
-		globalRate: globalSampleRate(),
+		globalRate: traceSampleRate,
 		limiter:    newRateLimiter(),
 	}
 }
@@ -235,7 +236,15 @@ func globalSampleRate() float64 {
 }
 
 func (rs *traceRulesSampler) enabled() bool {
+	rs.m.RLock()
+	defer rs.m.RUnlock()
 	return len(rs.rules) > 0 || !math.IsNaN(rs.globalRate)
+}
+
+func (rs *traceRulesSampler) setGlobalSampleRate(rate float64) {
+	rs.m.Lock()
+	defer rs.m.Unlock()
+	rs.globalRate = rate
 }
 
 // apply uses the sampling rules to determine the sampling rate for the
@@ -249,7 +258,9 @@ func (rs *traceRulesSampler) apply(span *span) bool {
 	}
 
 	var matched bool
+	rs.m.RLock()
 	rate := rs.globalRate
+	rs.m.RUnlock()
 	for _, rule := range rs.rules {
 		if rule.match(span) {
 			matched = true

--- a/ddtrace/tracer/sampler_test.go
+++ b/ddtrace/tracer/sampler_test.go
@@ -392,7 +392,7 @@ func TestRulesSampler(t *testing.T) {
 	}
 	t.Run("no-rules", func(t *testing.T) {
 		assert := assert.New(t)
-		rs := newRulesSampler(nil, nil)
+		rs := newRulesSampler(nil, nil, globalSampleRate())
 
 		span := makeSpan("http.request", "test-service")
 		result := rs.SampleTrace(span)
@@ -410,7 +410,7 @@ func TestRulesSampler(t *testing.T) {
 		for _, v := range traceRules {
 			t.Run("", func(t *testing.T) {
 				assert := assert.New(t)
-				rs := newRulesSampler(v, nil)
+				rs := newRulesSampler(v, nil, globalSampleRate())
 
 				span := makeSpan("http.request", "test-service")
 				result := rs.SampleTrace(span)
@@ -433,7 +433,7 @@ func TestRulesSampler(t *testing.T) {
 		for _, v := range traceRules {
 			t.Run("", func(t *testing.T) {
 				assert := assert.New(t)
-				rs := newRulesSampler(v, nil)
+				rs := newRulesSampler(v, nil, globalSampleRate())
 
 				span := makeSpan("http.request", "test-service")
 				result := rs.SampleTrace(span)
@@ -470,7 +470,7 @@ func TestRulesSampler(t *testing.T) {
 				_, rules, _ := samplingRulesFromEnv()
 
 				assert := assert.New(t)
-				rs := newRulesSampler(nil, rules)
+				rs := newRulesSampler(nil, rules, globalSampleRate())
 
 				span := makeFinishedSpan(tt.spanName, tt.spanSrv)
 				result := rs.SampleSpan(span)
@@ -510,7 +510,7 @@ func TestRulesSampler(t *testing.T) {
 				_, rules, _ := samplingRulesFromEnv()
 
 				assert := assert.New(t)
-				rs := newRulesSampler(nil, rules)
+				rs := newRulesSampler(nil, rules, globalSampleRate())
 
 				span := makeFinishedSpan(tt.spanName, tt.spanSrv)
 				result := rs.SampleSpan(span)
@@ -551,7 +551,7 @@ func TestRulesSampler(t *testing.T) {
 				_, rules, _ := samplingRulesFromEnv()
 
 				assert := assert.New(t)
-				rs := newRulesSampler(nil, rules)
+				rs := newRulesSampler(nil, rules, globalSampleRate())
 
 				span := makeFinishedSpan(tt.spanName, tt.spanSrv)
 				result := rs.SampleSpan(span)
@@ -593,7 +593,7 @@ func TestRulesSampler(t *testing.T) {
 			t.Run("", func(t *testing.T) {
 				assert := assert.New(t)
 				c := newConfig(WithSamplingRules(tt.rules))
-				rs := newRulesSampler(nil, c.spanRules)
+				rs := newRulesSampler(nil, c.spanRules, globalSampleRate())
 
 				span := makeFinishedSpan(tt.spanName, tt.spanSrv)
 				result := rs.SampleSpan(span)
@@ -621,7 +621,7 @@ func TestRulesSampler(t *testing.T) {
 					assert := assert.New(t)
 					os.Setenv("DD_TRACE_SAMPLE_RATE", fmt.Sprint(rate))
 					defer os.Unsetenv("DD_TRACE_SAMPLE_RATE")
-					rs := newRulesSampler(nil, rules)
+					rs := newRulesSampler(nil, rules, globalSampleRate())
 
 					span := makeSpan("http.request", "test-service")
 					result := rs.SampleTrace(span)
@@ -678,7 +678,7 @@ func TestRulesSamplerInternals(t *testing.T) {
 	t.Run("full-rate", func(t *testing.T) {
 		assert := assert.New(t)
 		now := time.Now()
-		rs := newRulesSampler(nil, nil)
+		rs := newRulesSampler(nil, nil, globalSampleRate())
 		// set samplingLimiter to specific state
 		rs.traces.limiter.prevTime = now.Add(-1 * time.Second)
 		rs.traces.limiter.allowed = 1
@@ -693,7 +693,7 @@ func TestRulesSamplerInternals(t *testing.T) {
 	t.Run("limited-rate", func(t *testing.T) {
 		assert := assert.New(t)
 		now := time.Now()
-		rs := newRulesSampler(nil, nil)
+		rs := newRulesSampler(nil, nil, globalSampleRate())
 		// force sampling limiter to 1.0 spans/sec
 		rs.traces.limiter.limiter = rate.NewLimiter(rate.Limit(1.0), 1)
 		rs.traces.limiter.prevTime = now.Add(-1 * time.Second)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

AIT-8577

The PR introduces internal mechanisms to support dynamic configuration in the tracer. The targeted configs are trace sampling rate and header tags but the design is meant to be extended to support other configs in the near future.

The PR also implements a Remote Config callback function. Although the Remote Config work is incomplete will be done in subsequent PRs to keep the size of the current PR reasonable + it would require reviews from ASM and profiling.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

New feature.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!