### PR TITLE
remoteconfig: make rc client a singleton

### DIFF
--- a/internal/appsec/appsec.go
+++ b/internal/appsec/appsec.go
@@ -15,7 +15,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 
-	"github.com/DataDog/go-libddwaf"
+	waf "github.com/DataDog/go-libddwaf"
 )
 
 // Enabled returns true when AppSec is up and running. Meaning that the appsec build tag is enabled, the env var
@@ -61,10 +61,7 @@ func Start(opts ...StartOption) {
 	for _, opt := range opts {
 		opt(cfg)
 	}
-
-	appsec := &appsec{
-		cfg: cfg,
-	}
+	appsec := newAppSec(cfg)
 
 	// Start the remote configuration client
 	log.Debug("appsec: starting the remote configuration client")
@@ -120,6 +117,12 @@ type appsec struct {
 	limiter   *TokenTicker
 	wafHandle *wafHandle
 	started   bool
+}
+
+func newAppSec(cfg *Config) *appsec {
+	return &appsec{
+		cfg: cfg,
+	}
 }
 
 // Start AppSec by registering its security protections according to the configured the security rules.

--- a/internal/appsec/remoteconfig.go
+++ b/internal/appsec/remoteconfig.go
@@ -304,7 +304,6 @@ func (a *appsec) registerRCProduct(p string) error {
 	if a.cfg.rc == nil {
 		return fmt.Errorf("no valid remote configuration client")
 	}
-	a.cfg.rc.Products[p] = struct{}{}
 	remoteconfig.RegisterProduct(p)
 	return nil
 }
@@ -313,13 +312,11 @@ func (a *appsec) unregisterRCProduct(p string) error {
 	if a.cfg.rc == nil {
 		return fmt.Errorf("no valid remote configuration client")
 	}
-	delete(a.cfg.rc.Products, p)
 	remoteconfig.UnregisterProduct(p)
 	return nil
 }
 
 func (a *appsec) registerRCCapability(c remoteconfig.Capability) error {
-	a.cfg.rc.Capabilities[c] = struct{}{}
 	if a.cfg.rc == nil {
 		return fmt.Errorf("no valid remote configuration client")
 	}
@@ -332,7 +329,6 @@ func (a *appsec) unregisterRCCapability(c remoteconfig.Capability) {
 		log.Debug("appsec: Remote config: no valid remote configuration client")
 		return
 	}
-	delete(a.cfg.rc.Capabilities, c)
 	remoteconfig.UnregisterCapability(c)
 }
 

--- a/internal/appsec/remoteconfig_test.go
+++ b/internal/appsec/remoteconfig_test.go
@@ -32,7 +32,7 @@ func TestASMFeaturesCallback(t *testing.T) {
 	disabledPayload := []byte(`{"asm":{"enabled":false}}`)
 	cfg, err := newConfig()
 	require.NoError(t, err)
-	a := &appsec{cfg: cfg}
+	a := newAppSec(cfg)
 	err = a.startRC()
 	require.NoError(t, err)
 

--- a/internal/appsec/remoteconfig_test.go
+++ b/internal/appsec/remoteconfig_test.go
@@ -335,8 +335,12 @@ func TestRemoteActivationScenarios(t *testing.T) {
 
 		require.NotNil(t, activeAppSec)
 		require.False(t, Enabled())
-		require.True(t, remoteconfig.HasCapability(remoteconfig.ASMActivation))
-		require.True(t, remoteconfig.HasProduct(rc.ProductASMFeatures))
+		found, err := remoteconfig.HasCapability(remoteconfig.ASMActivation)
+		require.NoError(t, err)
+		require.True(t, found)
+		found, err = remoteconfig.HasProduct(rc.ProductASMFeatures)
+		require.NoError(t, err)
+		require.True(t, found)
 	})
 
 	t.Run("DD_APPSEC_ENABLED=true", func(t *testing.T) {
@@ -346,8 +350,12 @@ func TestRemoteActivationScenarios(t *testing.T) {
 		defer Stop()
 
 		require.True(t, Enabled())
-		require.False(t, remoteconfig.HasCapability(remoteconfig.ASMActivation))
-		require.False(t, remoteconfig.HasProduct(rc.ProductASMFeatures))
+		found, err := remoteconfig.HasCapability(remoteconfig.ASMActivation)
+		require.NoError(t, err)
+		require.False(t, found)
+		found, err = remoteconfig.HasProduct(rc.ProductASMFeatures)
+		require.NoError(t, err)
+		require.False(t, found)
 	})
 
 	t.Run("DD_APPSEC_ENABLED=false", func(t *testing.T) {
@@ -397,7 +405,9 @@ func TestCapabilities(t *testing.T) {
 				t.Skip()
 			}
 			for _, cap := range tc.expected {
-				require.True(t, remoteconfig.HasCapability(cap))
+				found, err := remoteconfig.HasCapability(cap)
+				require.NoError(t, err)
+				require.True(t, found)
 			}
 		})
 	}

--- a/internal/remoteconfig/config.go
+++ b/internal/remoteconfig/config.go
@@ -30,8 +30,6 @@ type ClientConfig struct {
 	Env string
 	// The time interval between two client polls to the agent for updates
 	PollInterval time.Duration
-	// The products this client is interested in
-	Products map[string]struct{}
 	// The tracer's runtime id
 	RuntimeID string
 	// The name of the user's application
@@ -40,8 +38,6 @@ type ClientConfig struct {
 	TracerVersion string
 	// The base TUF root metadata file
 	TUFRoot string
-	// The capabilities of the client
-	Capabilities map[Capability]struct{}
 	// HTTP is the HTTP client used to receive config updates
 	HTTP *http.Client
 }
@@ -49,8 +45,6 @@ type ClientConfig struct {
 // DefaultClientConfig returns the default remote config client configuration
 func DefaultClientConfig() ClientConfig {
 	return ClientConfig{
-		Capabilities:  map[Capability]struct{}{},
-		Products:      map[string]struct{}{},
 		Env:           os.Getenv("DD_ENV"),
 		HTTP:          &http.Client{Timeout: 10 * time.Second},
 		PollInterval:  pollIntervalFromEnv(),

--- a/internal/remoteconfig/remoteconfig_test.go
+++ b/internal/remoteconfig/remoteconfig_test.go
@@ -37,18 +37,21 @@ func TestRCClient(t *testing.T) {
 		nilCallback := func(map[string]ProductUpdate) map[string]rc.ApplyStatus { return nil }
 		defer func() { client.callbacks = []Callback{} }()
 		require.Equal(t, 0, len(client.callbacks))
-		RegisterCallback(nilCallback)
+		err = RegisterCallback(nilCallback)
+		require.NoError(t, err)
 		require.Equal(t, 1, len(client.callbacks))
 		require.Equal(t, 1, len(client.callbacks))
-		RegisterCallback(nilCallback)
+		err = RegisterCallback(nilCallback)
+		require.NoError(t, err)
 		require.Equal(t, 2, len(client.callbacks))
 	})
 
 	t.Run("apply-update", func(t *testing.T) {
 		client.callbacks = []Callback{}
 		cfgPath := "datadog/2/ASM_FEATURES/asm_features_activation/config"
-		RegisterProduct(rc.ProductASMFeatures)
-		RegisterCallback(func(updates map[string]ProductUpdate) map[string]rc.ApplyStatus {
+		err = RegisterProduct(rc.ProductASMFeatures)
+		require.NoError(t, err)
+		err = RegisterCallback(func(updates map[string]ProductUpdate) map[string]rc.ApplyStatus {
 			statuses := map[string]rc.ApplyStatus{}
 			for p, u := range updates {
 				if p == rc.ProductASMFeatures {
@@ -60,6 +63,7 @@ func TestRCClient(t *testing.T) {
 			}
 			return statuses
 		})
+		require.NoError(t, err)
 
 		resp := genUpdateResponse([]byte("test"), cfgPath)
 		err := client.applyUpdate(resp)
@@ -253,24 +257,32 @@ func TestRegistration(t *testing.T) {
 		client, err = newClient(DefaultClientConfig())
 		require.NoError(t, err)
 
-		RegisterCallback(dummyCallback1)
+		err = RegisterCallback(dummyCallback1)
+		require.NoError(t, err)
 		require.Len(t, client.callbacks, 1)
-		UnregisterCallback(dummyCallback1)
+		err = UnregisterCallback(dummyCallback1)
+		require.NoError(t, err)
 		require.Empty(t, client.callbacks)
 
-		RegisterCallback(dummyCallback2)
-		RegisterCallback(dummyCallback3)
-		RegisterCallback(dummyCallback1)
-		RegisterCallback(dummyCallback4)
+		err = RegisterCallback(dummyCallback2)
+		require.NoError(t, err)
+		err = RegisterCallback(dummyCallback3)
+		require.NoError(t, err)
+		err = RegisterCallback(dummyCallback1)
+		require.NoError(t, err)
+		err = RegisterCallback(dummyCallback4)
+		require.NoError(t, err)
 		require.Len(t, client.callbacks, 4)
 
-		UnregisterCallback(dummyCallback1)
+		err = UnregisterCallback(dummyCallback1)
+		require.NoError(t, err)
 		require.Len(t, client.callbacks, 3)
 		for _, c := range client.callbacks {
 			require.NotEqual(t, reflect.ValueOf(dummyCallback1), reflect.ValueOf(c))
 		}
 
-		UnregisterCallback(dummyCallback3)
+		err = UnregisterCallback(dummyCallback3)
+		require.NoError(t, err)
 		require.Len(t, client.callbacks, 2)
 		for _, c := range client.callbacks {
 			require.NotEqual(t, reflect.ValueOf(dummyCallback3), reflect.ValueOf(c))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

AIT-8578
Make the remote config client a singleton. Tracing and profiling will then be able to use it in addition to ASM.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

It's a requirement to have a single shared instance of the remote config client per tracer.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!