### PR TITLE
contrib/net/http: Add header tags support to WrapHandler

### DIFF
--- a/contrib/net/http/http.go
+++ b/contrib/net/http/http.go
@@ -87,6 +87,7 @@ func WrapHandler(h http.Handler, service, resource string, opts ...Option) http.
 		}
 		so := make([]ddtrace.StartSpanOption, len(cfg.spanOpts))
 		copy(so, cfg.spanOpts)
+		so = append(so, httptrace.HeaderTagsFromRequest(req, cfg.headerTags))
 		TraceAndServe(h, w, req, &ServeConfig{
 			Service:    service,
 			Resource:   resc,

--- a/contrib/net/http/http_test.go
+++ b/contrib/net/http/http_test.go
@@ -485,3 +485,37 @@ func BenchmarkHttpServeTrace(b *testing.B) {
 		rtr.ServeHTTP(w, r)
 	}
 }
+
+func TestWrapHandlerWithHeaderTags(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	assert := assert.New(t)
+
+	htArgs := []string{"h!e@a-d.e*r", "2header:tag"}
+	handler := WrapHandler(http.HandlerFunc(handler200), "my-service", "my-resource",
+		WithHeaderTags(htArgs),
+	)
+
+	url := "/"
+	r := httptest.NewRequest("GET", url, nil)
+	r.Header.Set("h!e@a-d.e*r", "val")
+	r.Header.Add("h!e@a-d.e*r", "val2")
+	r.Header.Set("2header", "2val")
+	r.Header.Set("x-datadog-header", "value")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+	assert.Equal(200, w.Code)
+	assert.Equal("OK\n", w.Body.String())
+
+	spans := mt.FinishedSpans()
+	assert.Equal(1, len(spans))
+
+	s := spans[0]
+
+	for _, arg := range htArgs {
+		header, tag := normalizer.HeaderTag(arg)
+		assert.Equal(strings.Join(r.Header.Values(header), ","), s.Tags()[tag])
+	}
+	assert.NotContains(s.Tags(), "http.headers.x-datadog-header")
+}


### PR DESCRIPTION
### What does this PR do?

Add support for header tags when using `net/http`'s `WrapHandler`.

### Motivation

I was using `WrapHandler` and noticed that adding header tags with `WithHeaderTags` did nothing. After some investigation, I realized that `WrapHandler` was not calling `HeaderTagsFromRequest`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!