### PR TITLE
test.sh: add support for running on Apple Silicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ dd-trace-go.iml
 vendor
 
 /contrib/google.golang.org/grpc.v12/vendor/
+/contrib_coverage.txt
+/core_coverage.txt
+/gotestsum-report.xml

--- a/test.sh
+++ b/test.sh
@@ -11,6 +11,11 @@ if [[ $# -eq 0 ]]; then
 	echo "Use the -h flag for help"
 fi
 
+if [[ "$(uname -s)" = 'Darwin' && "$(uname -m)" = 'arm64' ]]; then
+  # Needed to run integration tests on Apple Silicon
+  export DOCKER_DEFAULT_PLATFORM=linux/amd64
+fi
+
 while [[ $# -gt 0 ]]; do
 	case $1 in
 		-a|--appsec)


### PR DESCRIPTION
### What does this PR do?

Adds support for Apple Silicon by setting the appropriate environment variable to force Docker images' platform to be x86 64 (`amd64`).

### Motivation

Easily run integration tests locally.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!