### PR TITLE
ddtrace/{.,tracer}: expose tracer structs and refactor interfaces & api

### DIFF
--- a/ddtrace/tracer/abandonedspans.go
+++ b/ddtrace/tracer/abandonedspans.go
@@ -79,7 +79,7 @@ type abandonedSpanCandidate struct {
 	Finished        bool
 }
 
-func newAbandonedSpanCandidate(s *span, finished bool) *abandonedSpanCandidate {
+func newAbandonedSpanCandidate(s *Span, finished bool) *abandonedSpanCandidate {
 	// finished is explicit instead of implicit as s.finished may be not set
 	// at the moment of calling this method.
 	// Also, locking is not required as it's called while the span is already locked or it's

--- a/ddtrace/tracer/abandonedspans_test.go
+++ b/ddtrace/tracer/abandonedspans_test.go
@@ -34,7 +34,7 @@ func setTestTime() func() {
 
 // spanAge takes in a span and returns the current test duration of the
 // span in seconds as a string
-func spanAge(s *span) string {
+func spanAge(s *Span) string {
 	return fmt.Sprintf("%d sec", (now()-s.Start)/int64(time.Second))
 }
 
@@ -56,7 +56,7 @@ func assertProcessedSpans(assert *assert.Assertions, t *tracer, startedSpans, fi
 	assert.Eventually(cond, 1*time.Second, 75*time.Millisecond)
 }
 
-func formatSpanString(s *span) string {
+func formatSpanString(s *Span) string {
 	s.Lock()
 	msg := fmt.Sprintf("[name: %s, span_id: %d, trace_id: %d, age: %s],", s.Name, s.SpanID, s.TraceID, spanAge(s))
 	s.Unlock()
@@ -81,7 +81,7 @@ func TestReportAbandonedSpans(t *testing.T) {
 		defer setTestTime()()
 		tracer, _, _, stop := startTestTracer(t, WithLogger(tp), WithDebugSpansMode(500*time.Millisecond))
 		defer stop()
-		s := tracer.StartSpan("operation", StartTime(spanStart)).(*span)
+		s := tracer.StartSpan("operation", StartTime(spanStart)).(*Span)
 		s.Finish()
 		assertProcessedSpans(assert, tracer, 1, 1)
 		expected := fmt.Sprintf("%s%s", warnPrefix, formatSpanString(s))
@@ -93,7 +93,7 @@ func TestReportAbandonedSpans(t *testing.T) {
 		defer setTestTime()()
 		tracer, _, _, stop := startTestTracer(t, WithLogger(tp), WithDebugSpansMode(500*time.Millisecond))
 		defer stop()
-		s := tracer.StartSpan("operation", StartTime(spanStart)).(*span)
+		s := tracer.StartSpan("operation", StartTime(spanStart)).(*Span)
 		assertProcessedSpans(assert, tracer, 1, 0)
 		assert.Contains(tp.Logs(), fmt.Sprintf("%s%d abandoned spans:", warnPrefix, 1))
 		assert.Contains(tp.Logs(), fmt.Sprintf("%s%s", warnPrefix, formatSpanString(s)))
@@ -104,9 +104,9 @@ func TestReportAbandonedSpans(t *testing.T) {
 		defer setTestTime()()
 		tracer, _, _, stop := startTestTracer(t, WithLogger(tp), WithDebugSpansMode(500*time.Millisecond))
 		defer stop()
-		sf := tracer.StartSpan("op", StartTime(spanStart)).(*span)
+		sf := tracer.StartSpan("op", StartTime(spanStart)).(*Span)
 		sf.Finish()
-		s := tracer.StartSpan("op2", StartTime(spanStart)).(*span)
+		s := tracer.StartSpan("op2", StartTime(spanStart)).(*Span)
 		notExpected := fmt.Sprintf("%s%s,%s,", warnPrefix, formatSpanString(sf), formatSpanString(s))
 		expected := fmt.Sprintf("%s%s", warnPrefix, formatSpanString(s))
 		assertProcessedSpans(assert, tracer, 2, 1)
@@ -121,9 +121,9 @@ func TestReportAbandonedSpans(t *testing.T) {
 		defer setTestTime()()
 		tracer, _, _, stop := startTestTracer(t, WithLogger(tp), WithDebugSpansMode(3*time.Minute))
 		defer stop()
-		s1 := tracer.StartSpan("op", StartTime(spanStart)).(*span)
+		s1 := tracer.StartSpan("op", StartTime(spanStart)).(*Span)
 		delayedStart := spanStart.Add(8 * time.Minute)
-		s2 := tracer.StartSpan("op2", StartTime(delayedStart)).(*span)
+		s2 := tracer.StartSpan("op2", StartTime(delayedStart)).(*Span)
 		notExpected := fmt.Sprintf("%s%s,%s,", warnPrefix, formatSpanString(s1), formatSpanString(s2))
 		expected := fmt.Sprintf("%s%s", warnPrefix, formatSpanString(s1))
 		assertProcessedSpans(assert, tracer, 2, 0)
@@ -140,8 +140,8 @@ func TestReportAbandonedSpans(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t, WithLogger(tp), WithDebugSpansMode(10*time.Minute))
 		defer stop()
 		delayedStart := spanStart.Add(1 * time.Minute)
-		s1 := tracer.StartSpan("op", StartTime(delayedStart)).(*span)
-		s2 := tracer.StartSpan("op2", StartTime(spanStart)).(*span)
+		s1 := tracer.StartSpan("op", StartTime(delayedStart)).(*Span)
+		s2 := tracer.StartSpan("op2", StartTime(spanStart)).(*Span)
 		notExpected := fmt.Sprintf("%s%s,%s,", warnPrefix, formatSpanString(s1), formatSpanString(s2))
 		notExpected2 := fmt.Sprintf("%s%s,%s,", warnPrefix, formatSpanString(s1), formatSpanString(s2))
 		assertProcessedSpans(assert, tracer, 2, 0)
@@ -157,7 +157,7 @@ func TestReportAbandonedSpans(t *testing.T) {
 		var sb strings.Builder
 		sb.WriteString(warnPrefix)
 		for i := 0; i < 10; i++ {
-			s := tracer.StartSpan(fmt.Sprintf("operation%d", i), StartTime(spanStart)).(*span)
+			s := tracer.StartSpan(fmt.Sprintf("operation%d", i), StartTime(spanStart)).(*Span)
 			if i%2 == 0 {
 				s.Finish()
 			} else {
@@ -182,7 +182,7 @@ func TestReportAbandonedSpans(t *testing.T) {
 			time.Sleep(15 * time.Millisecond)
 		}
 		for i := 0; i < 5; i++ {
-			s := tracer.StartSpan(fmt.Sprintf("operation2-%d", i), StartTime(spanStart)).(*span)
+			s := tracer.StartSpan(fmt.Sprintf("operation2-%d", i), StartTime(spanStart)).(*Span)
 			sb.WriteString(formatSpanString(s))
 			time.Sleep(15 * time.Millisecond)
 		}
@@ -199,7 +199,7 @@ func TestReportAbandonedSpans(t *testing.T) {
 		sb.WriteString(warnPrefix)
 
 		for i := 0; i < 5; i++ {
-			s := tracer.StartSpan(fmt.Sprintf("operation%d", i), StartTime(spanStart)).(*span)
+			s := tracer.StartSpan(fmt.Sprintf("operation%d", i), StartTime(spanStart)).(*Span)
 			sb.WriteString(formatSpanString(s))
 		}
 		assertProcessedSpans(assert, tracer, 5, 0)
@@ -214,7 +214,7 @@ func TestReportAbandonedSpans(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t, WithLogger(tp), WithDebugSpansMode(500*time.Millisecond))
 		defer stop()
 
-		s := tracer.StartSpan("operation", StartTime(spanStart)).(*span)
+		s := tracer.StartSpan("operation", StartTime(spanStart)).(*Span)
 		expected := fmt.Sprintf("%s%s", warnPrefix, formatSpanString(s))
 
 		assert.NotContains(tp.Logs(), expected)
@@ -233,7 +233,7 @@ func TestReportAbandonedSpans(t *testing.T) {
 			logSize = 9000
 		}()
 
-		s := tracer.StartSpan("operation", StartTime(spanStart)).(*span)
+		s := tracer.StartSpan("operation", StartTime(spanStart)).(*Span)
 		msg := formatSpanString(s)
 		assertProcessedSpans(assert, tracer, 1, 0)
 		stop()

--- a/ddtrace/tracer/context.go
+++ b/ddtrace/tracer/context.go
@@ -14,14 +14,14 @@ import (
 )
 
 // ContextWithSpan returns a copy of the given context which includes the span s.
-func ContextWithSpan(ctx context.Context, s Span) context.Context {
+func ContextWithSpan(ctx context.Context, s ddtrace.Span) context.Context {
 	return context.WithValue(ctx, internal.ActiveSpanKey, s)
 }
 
 // SpanFromContext returns the span contained in the given context. A second return
 // value indicates if a span was found in the context. If no span is found, a no-op
 // span is returned.
-func SpanFromContext(ctx context.Context) (Span, bool) {
+func SpanFromContext(ctx context.Context) (ddtrace.Span, bool) {
 	if ctx == nil {
 		return &traceinternal.NoopSpan{}, false
 	}
@@ -35,7 +35,7 @@ func SpanFromContext(ctx context.Context) (Span, bool) {
 // StartSpanFromContext returns a new span with the given operation name and options. If a span
 // is found in the context, it will be used as the parent of the resulting span. If the ChildOf
 // option is passed, it will only be used as the parent if there is no span found in `ctx`.
-func StartSpanFromContext(ctx context.Context, operationName string, opts ...StartSpanOption) (Span, context.Context) {
+func StartSpanFromContext(ctx context.Context, operationName string, opts ...StartSpanOption) (ddtrace.Span, context.Context) {
 	// copy opts in case the caller reuses the slice in parallel
 	// we will add at least 1, at most 2 items
 	optsLocal := make([]StartSpanOption, len(opts), len(opts)+2)
@@ -49,7 +49,7 @@ func StartSpanFromContext(ctx context.Context, operationName string, opts ...Sta
 	}
 	optsLocal = append(optsLocal, withContext(ctx))
 	s := StartSpan(operationName, optsLocal...)
-	if span, ok := s.(*span); ok && span.pprofCtxActive != nil {
+	if span, ok := s.(*Span); ok && span.pprofCtxActive != nil {
 		// If pprof labels were applied for this span, use the derived ctx that
 		// includes them. Otherwise a child of this span wouldn't be able to
 		// correctly restore the labels of its parent when it finishes.

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -19,9 +19,9 @@ import (
 )
 
 func TestContextWithSpan(t *testing.T) {
-	want := &span{SpanID: 123}
+	want := &Span{SpanID: 123}
 	ctx := ContextWithSpan(context.Background(), want)
-	got, ok := ctx.Value(internal.ActiveSpanKey).(*span)
+	got, ok := ctx.Value(internal.ActiveSpanKey).(*Span)
 	assert := assert.New(t)
 	assert.True(ok)
 	assert.Equal(got, want)
@@ -30,7 +30,7 @@ func TestContextWithSpan(t *testing.T) {
 func TestSpanFromContext(t *testing.T) {
 	t.Run("regular", func(t *testing.T) {
 		assert := assert.New(t)
-		want := &span{SpanID: 123}
+		want := &Span{SpanID: 123}
 		ctx := ContextWithSpan(context.Background(), want)
 		got, ok := SpanFromContext(ctx)
 		assert.True(ok)
@@ -53,8 +53,8 @@ func TestStartSpanFromContext(t *testing.T) {
 	_, _, _, stop := startTestTracer(t)
 	defer stop()
 
-	parent := &span{context: &spanContext{spanID: 123, traceID: traceIDFrom64Bits(456)}}
-	parent2 := &span{context: &spanContext{spanID: 789, traceID: traceIDFrom64Bits(456)}}
+	parent := &Span{context: &spanContext{spanID: 123, traceID: traceIDFrom64Bits(456)}}
+	parent2 := &Span{context: &spanContext{spanID: 789, traceID: traceIDFrom64Bits(456)}}
 	pctx := ContextWithSpan(context.Background(), parent)
 	child, ctx := StartSpanFromContext(
 		pctx,
@@ -65,7 +65,7 @@ func TestStartSpanFromContext(t *testing.T) {
 	)
 	assert := assert.New(t)
 
-	got, ok := child.(*span)
+	got, ok := child.(*Span)
 	assert.True(ok)
 	gotctx, ok := SpanFromContext(ctx)
 	assert.True(ok)
@@ -154,7 +154,7 @@ func TestStartSpanFromNilContext(t *testing.T) {
 	// ensure the returned context works
 	assert.Nil(ctx.Value("not_found_key"))
 
-	internalSpan, ok := child.(*span)
+	internalSpan, ok := child.(*Span)
 	assert.True(ok)
 	assert.Equal("http.request", internalSpan.Name)
 

--- a/ddtrace/tracer/payload_test.go
+++ b/ddtrace/tracer/payload_test.go
@@ -21,7 +21,7 @@ var fixedTime = now()
 
 func newSpanList(n int) spanList {
 	itoa := map[int]string{0: "0", 1: "1", 2: "2", 3: "3", 4: "4", 5: "5"}
-	list := make([]*span, n)
+	list := make([]*Span, n)
 	for i := 0; i < n; i++ {
 		list[i] = newBasicSpan("span.list." + itoa[i%5+1])
 		list[i].Start = fixedTime

--- a/ddtrace/tracer/remote_config_test.go
+++ b/ddtrace/tracer/remote_config_test.go
@@ -26,7 +26,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		}
 		applyStatus := tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
-		s := tracer.StartSpan("web.request").(*span)
+		s := tracer.StartSpan("web.request").(*Span)
 		s.Finish()
 		require.Equal(t, 0.5, s.Metrics[keyRulesSamplerAppliedRate])
 
@@ -34,7 +34,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		input["APM_TRACING"] = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}}`)}
 		applyStatus = tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
-		s = tracer.StartSpan("web.request").(*span)
+		s = tracer.StartSpan("web.request").(*Span)
 		s.Finish()
 		require.NotContains(t, keyRulesSamplerAppliedRate, s.Metrics)
 	})
@@ -50,7 +50,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		}
 		applyStatus := tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
-		s := tracer.StartSpan("web.request").(*span)
+		s := tracer.StartSpan("web.request").(*Span)
 		s.Finish()
 		require.Equal(t, 0.2, s.Metrics[keyRulesSamplerAppliedRate])
 
@@ -58,7 +58,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		input["APM_TRACING"] = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}}`)}
 		applyStatus = tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
-		s = tracer.StartSpan("web.request").(*span)
+		s = tracer.StartSpan("web.request").(*Span)
 		s.Finish()
 		require.Equal(t, 0.1, s.Metrics[keyRulesSamplerAppliedRate])
 	})

--- a/ddtrace/tracer/rules_sampler.go
+++ b/ddtrace/tracer/rules_sampler.go
@@ -44,9 +44,9 @@ func newRulesSampler(traceRules, spanRules []SamplingRule, traceSampleRate float
 	}
 }
 
-func (r *rulesSampler) SampleTrace(s *span) bool { return r.traces.apply(s) }
+func (r *rulesSampler) SampleTrace(s *Span) bool { return r.traces.apply(s) }
 
-func (r *rulesSampler) SampleSpan(s *span) bool { return r.spans.apply(s) }
+func (r *rulesSampler) SampleSpan(s *Span) bool { return r.spans.apply(s) }
 
 func (r *rulesSampler) HasSpanRules() bool { return r.spans.enabled() }
 
@@ -77,7 +77,7 @@ type SamplingRule struct {
 }
 
 // match returns true when the span's details match all the expected values in the rule.
-func (sr *SamplingRule) match(s *span) bool {
+func (sr *SamplingRule) match(s *Span) bool {
 	if sr.Service != nil && !sr.Service.MatchString(s.Service) {
 		return false
 	} else if sr.exactService != "" && sr.exactService != s.Service {
@@ -251,7 +251,7 @@ func (rs *traceRulesSampler) setGlobalSampleRate(rate float64) {
 // provided span. If the rules don't match, and a default rate hasn't been
 // set using DD_TRACE_SAMPLE_RATE, then it returns false and the span is not
 // modified.
-func (rs *traceRulesSampler) apply(span *span) bool {
+func (rs *traceRulesSampler) apply(span *Span) bool {
 	if !rs.enabled() {
 		// short path when disabled
 		return false
@@ -278,7 +278,7 @@ func (rs *traceRulesSampler) apply(span *span) bool {
 	return true
 }
 
-func (rs *traceRulesSampler) applyRule(span *span, rate float64, now time.Time) {
+func (rs *traceRulesSampler) applyRule(span *Span, rate float64, now time.Time) {
 	span.SetTag(keyRulesSamplerAppliedRate, rate)
 	if !sampledByRate(span.TraceID, rate) {
 		span.setSamplingPriority(ext.PriorityUserReject, samplernames.RuleRate)
@@ -360,7 +360,7 @@ func (rs *singleSpanRulesSampler) enabled() bool {
 // apply uses the sampling rules to determine the sampling rate for the
 // provided span. If the rules don't match, then it returns false and the span is not
 // modified.
-func (rs *singleSpanRulesSampler) apply(span *span) bool {
+func (rs *singleSpanRulesSampler) apply(span *Span) bool {
 	for _, rule := range rs.rules {
 		if rule.match(span) {
 			rate := rule.Rate

--- a/ddtrace/tracer/sampler.go
+++ b/ddtrace/tracer/sampler.go
@@ -19,7 +19,7 @@ import (
 // Sampler is the generic interface of any sampler. It must be safe for concurrent use.
 type Sampler interface {
 	// Sample returns true if the given span should be sampled.
-	Sample(span Span) bool
+	Sample(span ddtrace.Span) bool
 }
 
 // RateSampler is a sampler implementation which randomly selects spans using a
@@ -72,7 +72,7 @@ func (r *rateSampler) Sample(spn ddtrace.Span) bool {
 		// fast path
 		return true
 	}
-	s, ok := spn.(*span)
+	s, ok := spn.(*Span)
 	if !ok {
 		return false
 	}
@@ -127,7 +127,7 @@ func (ps *prioritySampler) readRatesJSON(rc io.ReadCloser) error {
 
 // getRate returns the sampling rate to be used for the given span. Callers must
 // guard the span.
-func (ps *prioritySampler) getRate(spn *span) float64 {
+func (ps *prioritySampler) getRate(spn *Span) float64 {
 	key := "service:" + spn.Service + ",env:" + spn.Meta[ext.Environment]
 	ps.mu.RLock()
 	defer ps.mu.RUnlock()
@@ -139,7 +139,7 @@ func (ps *prioritySampler) getRate(spn *span) float64 {
 
 // apply applies sampling priority to the given span. Caller must ensure it is safe
 // to modify the span.
-func (ps *prioritySampler) apply(spn *span) {
+func (ps *prioritySampler) apply(spn *Span) {
 	rate := ps.getRate(spn)
 	if sampledByRate(spn.TraceID, rate) {
 		spn.setSamplingPriority(ext.PriorityAutoKeep, samplernames.AgentRate)

--- a/ddtrace/tracer/sampler_test.go
+++ b/ddtrace/tracer/sampler_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/dd-trace-go/v2/ddtrace"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/internal"
 
@@ -25,8 +26,8 @@ import (
 
 func TestPrioritySampler(t *testing.T) {
 	// create a new span with given service/env
-	mkSpan := func(svc, env string) *span {
-		s := &span{Service: svc, Meta: map[string]string{}}
+	mkSpan := func(svc, env string) *Span {
+		s := &Span{Service: svc, Meta: map[string]string{}}
 		if env != "" {
 			s.Meta["env"] = env
 		}
@@ -382,10 +383,10 @@ func TestRuleEnvVars(t *testing.T) {
 }
 
 func TestRulesSampler(t *testing.T) {
-	makeSpan := func(op string, svc string) *span {
+	makeSpan := func(op string, svc string) *Span {
 		return newSpan(op, svc, "", random.Uint64(), random.Uint64(), 0)
 	}
-	makeFinishedSpan := func(op string, svc string) *span {
+	makeFinishedSpan := func(op string, svc string) *Span {
 		s := newSpan(op, svc, "", random.Uint64(), random.Uint64(), 0)
 		s.finished = true
 		return s
@@ -658,7 +659,7 @@ func TestRulesSamplerConcurrency(_ *testing.T) {
 }
 
 func TestRulesSamplerInternals(t *testing.T) {
-	makeSpanAt := func(op string, svc string, ts time.Time) *span {
+	makeSpanAt := func(op string, svc string, ts time.Time) *Span {
 		s := newSpan(op, svc, "", 0, 0, 0)
 		s.Start = ts.UnixNano()
 		return s
@@ -789,7 +790,7 @@ func BenchmarkRulesSampler(b *testing.B) {
                                 }`,
 		)),
 		)
-		spans := make([]Span, batchSize)
+		spans := make([]ddtrace.Span, batchSize)
 		b.StopTimer()
 		b.ResetTimer()
 		for i := 0; i < b.N; i += batchSize {
@@ -953,7 +954,7 @@ func TestSamplingRuleMarshall(t *testing.T) {
 	}
 }
 func BenchmarkGlobMatchSpan(b *testing.B) {
-	var spans []*span
+	var spans []*Span
 	for i := 0; i < 1000; i++ {
 		spans = append(spans, newSpan("name.ops.date", "srv.name.ops.date", "", 0, 0, 0))
 	}

--- a/ddtrace/tracer/span_msgp.go
+++ b/ddtrace/tracer/span_msgp.go
@@ -14,7 +14,7 @@ import (
 )
 
 // DecodeMsg implements msgp.Decodable
-func (z *span) DecodeMsg(dc *msgp.Reader) (err error) {
+func (z *Span) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
 	var zb0001 uint32
@@ -144,7 +144,7 @@ func (z *span) DecodeMsg(dc *msgp.Reader) (err error) {
 }
 
 // EncodeMsg implements msgp.Encodable
-func (z *span) EncodeMsg(en *msgp.Writer) (err error) {
+func (z *Span) EncodeMsg(en *msgp.Writer) (err error) {
 	// map header, size 12
 	// write "name"
 	err = en.Append(0x8c, 0xa4, 0x6e, 0x61, 0x6d, 0x65)
@@ -278,7 +278,7 @@ func (z *span) EncodeMsg(en *msgp.Writer) (err error) {
 }
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
-func (z *span) Msgsize() (s int) {
+func (z *Span) Msgsize() (s int) {
 	s = 1 + 5 + msgp.StringPrefixSize + len(z.Name) + 8 + msgp.StringPrefixSize + len(z.Service) + 9 + msgp.StringPrefixSize + len(z.Resource) + 5 + msgp.StringPrefixSize + len(z.Type) + 6 + msgp.Int64Size + 9 + msgp.Int64Size + 5 + msgp.MapHeaderSize
 	if z.Meta != nil {
 		for za0001, za0002 := range z.Meta {
@@ -318,7 +318,7 @@ func (z *spanList) DecodeMsg(dc *msgp.Reader) (err error) {
 			(*z)[zb0001] = nil
 		} else {
 			if (*z)[zb0001] == nil {
-				(*z)[zb0001] = new(span)
+				(*z)[zb0001] = new(Span)
 			}
 			err = (*z)[zb0001].DecodeMsg(dc)
 			if err != nil {
@@ -396,7 +396,7 @@ func (z *spanLists) DecodeMsg(dc *msgp.Reader) (err error) {
 				(*z)[zb0001][zb0002] = nil
 			} else {
 				if (*z)[zb0001][zb0002] == nil {
-					(*z)[zb0001][zb0002] = new(span)
+					(*z)[zb0001][zb0002] = new(Span)
 				}
 				err = (*z)[zb0001][zb0002].DecodeMsg(dc)
 				if err != nil {

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -28,8 +28,8 @@ import (
 
 // newSpan creates a new span. This is a low-level function, required for testing and advanced usage.
 // Most of the time one should prefer the Tracer NewRootSpan or NewChildSpan methods.
-func newSpan(name, service, resource string, spanID, traceID, parentID uint64) *span {
-	span := &span{
+func newSpan(name, service, resource string, spanID, traceID, parentID uint64) *Span {
+	span := &Span{
 		Name:     name,
 		Service:  service,
 		Resource: resource,
@@ -45,7 +45,7 @@ func newSpan(name, service, resource string, spanID, traceID, parentID uint64) *
 }
 
 // newBasicSpan is the OpenTracing Span constructor
-func newBasicSpan(operationName string) *span {
+func newBasicSpan(operationName string) *Span {
 	return newSpan(operationName, "", "", 0, 0, 0)
 }
 
@@ -159,7 +159,7 @@ func TestShouldComputeStats(t *testing.T) {
 		{map[string]float64{}, false},
 	} {
 		t.Run("", func(t *testing.T) {
-			assert.Equal(t, shouldComputeStats(&span{Metrics: tt.metrics}), tt.want)
+			assert.Equal(t, shouldComputeStats(&Span{Metrics: tt.metrics}), tt.want)
 		})
 	}
 }
@@ -167,7 +167,7 @@ func TestShouldComputeStats(t *testing.T) {
 func TestNewAggregableSpan(t *testing.T) {
 	t.Run("obfuscating", func(t *testing.T) {
 		o := obfuscate.NewObfuscator(obfuscate.Config{})
-		aggspan := newAggregableSpan(&span{
+		aggspan := newAggregableSpan(&Span{
 			Name:     "name",
 			Resource: "SELECT * FROM table WHERE password='secret'",
 			Service:  "service",
@@ -182,7 +182,7 @@ func TestNewAggregableSpan(t *testing.T) {
 	})
 
 	t.Run("nil-obfuscator", func(t *testing.T) {
-		aggspan := newAggregableSpan(&span{
+		aggspan := newAggregableSpan(&Span{
 			Name:     "name",
 			Resource: "SELECT * FROM table WHERE password='secret'",
 			Service:  "service",
@@ -255,7 +255,7 @@ func TestSpanFinishWithErrorStackFrames(t *testing.T) {
 	assert.Equal("test error", span.Meta[ext.ErrorMsg])
 	assert.Equal("*errors.errorString", span.Meta[ext.ErrorType])
 	assert.Contains(span.Meta[ext.ErrorStack], "tracer.TestSpanFinishWithErrorStackFrames")
-	assert.Contains(span.Meta[ext.ErrorStack], "tracer.(*span).Finish")
+	assert.Contains(span.Meta[ext.ErrorStack], "tracer.(*Span).Finish")
 	assert.Equal(strings.Count(span.Meta[ext.ErrorStack], "\n\t"), 2)
 }
 
@@ -380,7 +380,7 @@ func TestTraceManualKeepAndManualDrop(t *testing.T) {
 			defer tracer.Stop()
 			spanCtx := &spanContext{traceID: traceIDFrom64Bits(42), spanID: 42}
 			spanCtx.setSamplingPriority(scenario.p, samplernames.RemoteRate)
-			span := tracer.StartSpan("non-local root span", ChildOf(spanCtx)).(*span)
+			span := tracer.StartSpan("non-local root span", ChildOf(spanCtx)).(*Span)
 			span.SetTag(scenario.tag, true)
 			assert.Equal(t, scenario.keep, shouldKeep(span))
 		})
@@ -428,41 +428,41 @@ const (
 )
 
 func TestSpanSetMetric(t *testing.T) {
-	for name, tt := range map[string]func(assert *assert.Assertions, span *span){
-		"init": func(assert *assert.Assertions, span *span) {
+	for name, tt := range map[string]func(assert *assert.Assertions, span *Span){
+		"init": func(assert *assert.Assertions, span *Span) {
 			assert.Equal(6, len(span.Metrics))
 			_, ok := span.Metrics[keySamplingPriority]
 			assert.True(ok)
 			_, ok = span.Metrics[keySamplingPriorityRate]
 			assert.True(ok)
 		},
-		"float": func(assert *assert.Assertions, span *span) {
+		"float": func(assert *assert.Assertions, span *Span) {
 			span.SetTag("temp", 72.42)
 			assert.Equal(72.42, span.Metrics["temp"])
 		},
-		"int": func(assert *assert.Assertions, span *span) {
+		"int": func(assert *assert.Assertions, span *Span) {
 			span.SetTag("bytes", 1024)
 			assert.Equal(1024.0, span.Metrics["bytes"])
 		},
-		"max": func(assert *assert.Assertions, span *span) {
+		"max": func(assert *assert.Assertions, span *Span) {
 			span.SetTag("bytes", intUpperLimit-1)
 			assert.Equal(float64(intUpperLimit-1), span.Metrics["bytes"])
 		},
-		"min": func(assert *assert.Assertions, span *span) {
+		"min": func(assert *assert.Assertions, span *Span) {
 			span.SetTag("bytes", intLowerLimit+1)
 			assert.Equal(float64(intLowerLimit+1), span.Metrics["bytes"])
 		},
-		"toobig": func(assert *assert.Assertions, span *span) {
+		"toobig": func(assert *assert.Assertions, span *Span) {
 			span.SetTag("bytes", intUpperLimit)
 			assert.Equal(0.0, span.Metrics["bytes"])
 			assert.Equal(fmt.Sprint(intUpperLimit), span.Meta["bytes"])
 		},
-		"toosmall": func(assert *assert.Assertions, span *span) {
+		"toosmall": func(assert *assert.Assertions, span *Span) {
 			span.SetTag("bytes", intLowerLimit)
 			assert.Equal(0.0, span.Metrics["bytes"])
 			assert.Equal(fmt.Sprint(intLowerLimit), span.Meta["bytes"])
 		},
-		"finished": func(assert *assert.Assertions, span *span) {
+		"finished": func(assert *assert.Assertions, span *Span) {
 			span.Finish()
 			span.SetTag("finished.test", 1337)
 			assert.Equal(6, len(span.Metrics))
@@ -653,7 +653,7 @@ func TestSpanLog(t *testing.T) {
 		assert := assert.New(t)
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
-		span := tracer.StartSpan("test.request").(*span)
+		span := tracer.StartSpan("test.request").(*Span)
 		expect := fmt.Sprintf(`dd.trace_id="%d" dd.span_id="%d" dd.parent_id="0"`, span.TraceID, span.SpanID)
 		assert.Equal(expect, fmt.Sprintf("%v", span))
 	}
@@ -663,7 +663,7 @@ func TestSpanLog(t *testing.T) {
 		assert := assert.New(t)
 		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"))
 		defer stop()
-		span := tracer.StartSpan("test.request").(*span)
+		span := tracer.StartSpan("test.request").(*Span)
 		expect := fmt.Sprintf(`dd.service=tracer.test dd.trace_id="%d" dd.span_id="%d" dd.parent_id="0"`, span.TraceID, span.SpanID)
 		assert.Equal(expect, fmt.Sprintf("%v", span))
 	})
@@ -672,7 +672,7 @@ func TestSpanLog(t *testing.T) {
 		assert := assert.New(t)
 		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithEnv("testenv"))
 		defer stop()
-		span := tracer.StartSpan("test.request").(*span)
+		span := tracer.StartSpan("test.request").(*Span)
 		expect := fmt.Sprintf(`dd.service=tracer.test dd.env=testenv dd.trace_id="%d" dd.span_id="%d" dd.parent_id="0"`, span.TraceID, span.SpanID)
 		assert.Equal(expect, fmt.Sprintf("%v", span))
 	})
@@ -681,7 +681,7 @@ func TestSpanLog(t *testing.T) {
 		assert := assert.New(t)
 		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithServiceVersion("1.2.3"))
 		defer stop()
-		span := tracer.StartSpan("test.request").(*span)
+		span := tracer.StartSpan("test.request").(*Span)
 		expect := fmt.Sprintf(`dd.service=tracer.test dd.version=1.2.3 dd.trace_id="%d" dd.span_id="%d" dd.parent_id="0"`, span.TraceID, span.SpanID)
 		assert.Equal(expect, fmt.Sprintf("%v", span))
 	})
@@ -690,7 +690,7 @@ func TestSpanLog(t *testing.T) {
 		assert := assert.New(t)
 		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithServiceVersion("1.2.3"), WithEnv("testenv"))
 		defer stop()
-		span := tracer.StartSpan("test.request").(*span)
+		span := tracer.StartSpan("test.request").(*Span)
 		expect := fmt.Sprintf(`dd.service=tracer.test dd.env=testenv dd.version=1.2.3 dd.trace_id="%d" dd.span_id="%d" dd.parent_id="0"`, span.TraceID, span.SpanID)
 		assert.Equal(expect, fmt.Sprintf("%v", span))
 	})
@@ -702,7 +702,7 @@ func TestSpanLog(t *testing.T) {
 		assert := assert.New(t)
 		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithServiceVersion("1.2.3"), WithEnv("testenv"))
 		defer stop()
-		span := tracer.StartSpan("test.request", ServiceName("subservice name")).(*span)
+		span := tracer.StartSpan("test.request", ServiceName("subservice name")).(*Span)
 		expect := fmt.Sprintf(`dd.service=tracer.test dd.env=testenv dd.version=1.2.3 dd.trace_id="%d" dd.span_id="%d" dd.parent_id="0"`, span.TraceID, span.SpanID)
 		assert.Equal(expect, fmt.Sprintf("%v", span))
 	})
@@ -717,7 +717,7 @@ func TestSpanLog(t *testing.T) {
 		assert := assert.New(t)
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
-		span := tracer.StartSpan("test.request").(*span)
+		span := tracer.StartSpan("test.request").(*Span)
 		expect := fmt.Sprintf(`dd.service=tracer.test dd.env=testenv dd.version=1.2.3 dd.trace_id="%d" dd.span_id="%d" dd.parent_id="0"`, span.TraceID, span.SpanID)
 		assert.Equal(expect, fmt.Sprintf("%v", span))
 	})
@@ -726,7 +726,7 @@ func TestSpanLog(t *testing.T) {
 		assert := assert.New(t)
 		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithServiceVersion("1.2.3"))
 		defer stop()
-		span := tracer.StartSpan("test.request").(*span)
+		span := tracer.StartSpan("test.request").(*Span)
 		expect := fmt.Sprintf(`%%!b(ddtrace.Span=dd.service=tracer.test dd.version=1.2.3 dd.trace_id="%d" dd.span_id="%d" dd.parent_id="0")`, span.TraceID, span.SpanID)
 		assert.Equal(expect, fmt.Sprintf("%b", span))
 	})
@@ -734,7 +734,7 @@ func TestSpanLog(t *testing.T) {
 	t.Run("notracer/options", func(t *testing.T) {
 		assert := assert.New(t)
 		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithServiceVersion("1.2.3"), WithEnv("testenv"))
-		span := tracer.StartSpan("test.request").(*span)
+		span := tracer.StartSpan("test.request").(*Span)
 		stop()
 		// no service, env, or version after the tracer is stopped
 		expect := fmt.Sprintf(`dd.trace_id="%d" dd.span_id="%d" dd.parent_id="0"`, span.TraceID, span.SpanID)
@@ -750,7 +750,7 @@ func TestSpanLog(t *testing.T) {
 		defer os.Unsetenv("DD_ENV")
 		assert := assert.New(t)
 		tracer, _, _, stop := startTestTracer(t)
-		span := tracer.StartSpan("test.request").(*span)
+		span := tracer.StartSpan("test.request").(*Span)
 		stop()
 		// service is not included: it is cleared when we stop the tracer
 		// env, version are included: it reads the environment variable when there is no tracer
@@ -766,7 +766,7 @@ func TestSpanLog(t *testing.T) {
 		assert := assert.New(t)
 		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithEnv("testenv"))
 		defer stop()
-		span := tracer.StartSpan("test.request").(*span)
+		span := tracer.StartSpan("test.request").(*Span)
 		span.TraceID = 12345678
 		span.SpanID = 87654321
 		span.Finish()
@@ -782,7 +782,7 @@ func TestSpanLog(t *testing.T) {
 		assert := assert.New(t)
 		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithEnv("testenv"))
 		defer stop()
-		span := tracer.StartSpan("test.request").(*span)
+		span := tracer.StartSpan("test.request").(*Span)
 		span.TraceID = 12345678
 		span.SpanID = 87654321
 		span.Finish()
@@ -798,7 +798,7 @@ func TestSpanLog(t *testing.T) {
 		assert := assert.New(t)
 		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithEnv("testenv"))
 		defer stop()
-		span := tracer.StartSpan("test.request").(*span)
+		span := tracer.StartSpan("test.request").(*Span)
 		span.SpanID = 87654321
 		span.Finish()
 		expect := fmt.Sprintf(`dd.service=tracer.test dd.env=testenv dd.trace_id=%q dd.span_id="87654321" dd.parent_id="0"`, span.context.TraceID128())
@@ -814,7 +814,7 @@ func TestSpanLog(t *testing.T) {
 		assert := assert.New(t)
 		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithEnv("testenv"))
 		defer stop()
-		span := tracer.StartSpan("test.request", WithSpanID(87654321)).(*span)
+		span := tracer.StartSpan("test.request", WithSpanID(87654321)).(*Span)
 		span.context.traceID.SetUpper(1)
 		span.Finish()
 		assert.Equal(`dd.service=tracer.test dd.env=testenv dd.trace_id="00000000000000010000000005397fb1" dd.span_id="87654321" dd.parent_id="0"`, fmt.Sprintf("%v", span))
@@ -829,7 +829,7 @@ func TestSpanLog(t *testing.T) {
 		assert := assert.New(t)
 		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithEnv("testenv"))
 		defer stop()
-		span := tracer.StartSpan("test.request", WithSpanID(87654321)).(*span)
+		span := tracer.StartSpan("test.request", WithSpanID(87654321)).(*Span)
 		span.Finish()
 		assert.False(span.context.traceID.HasUpper()) // it should not have generated upper bits
 		assert.Equal(`dd.service=tracer.test dd.env=testenv dd.trace_id="87654321" dd.span_id="87654321" dd.parent_id="0"`, fmt.Sprintf("%v", span))
@@ -843,20 +843,20 @@ func TestRootSpanAccessor(t *testing.T) {
 	defer stop()
 
 	t.Run("nil-span", func(t *testing.T) {
-		var s *span
+		var s *Span
 		require.Nil(t, s.Root())
 	})
 
 	t.Run("single-span", func(t *testing.T) {
 		sp := tracer.StartSpan("root")
-		require.Equal(t, sp, sp.(*span).Root())
+		require.Equal(t, sp, sp.(*Span).Root())
 		sp.Finish()
 	})
 
 	t.Run("single-span-finished", func(t *testing.T) {
 		sp := tracer.StartSpan("root")
 		sp.Finish()
-		require.Equal(t, sp, sp.(*span).Root())
+		require.Equal(t, sp, sp.(*Span).Root())
 	})
 
 	t.Run("root-with-children", func(t *testing.T) {
@@ -871,11 +871,11 @@ func TestRootSpanAccessor(t *testing.T) {
 		child211 := tracer.StartSpan("child2.1.1", ChildOf(child21.Context()))
 		defer child211.Finish()
 
-		require.Equal(t, root, root.(*span).Root())
-		require.Equal(t, root, child1.(*span).Root())
-		require.Equal(t, root, child2.(*span).Root())
-		require.Equal(t, root, child21.(*span).Root())
-		require.Equal(t, root, child211.(*span).Root())
+		require.Equal(t, root, root.(*Span).Root())
+		require.Equal(t, root, child1.(*Span).Root())
+		require.Equal(t, root, child2.(*Span).Root())
+		require.Equal(t, root, child21.(*Span).Root())
+		require.Equal(t, root, child211.(*Span).Root())
 	})
 
 	t.Run("root-finished-with-children", func(t *testing.T) {
@@ -890,11 +890,11 @@ func TestRootSpanAccessor(t *testing.T) {
 		child211 := tracer.StartSpan("child2.1.1", ChildOf(child21.Context()))
 		defer child211.Finish()
 
-		require.Equal(t, root, root.(*span).Root())
-		require.Equal(t, root, child1.(*span).Root())
-		require.Equal(t, root, child2.(*span).Root())
-		require.Equal(t, root, child21.(*span).Root())
-		require.Equal(t, root, child211.(*span).Root())
+		require.Equal(t, root, root.(*Span).Root())
+		require.Equal(t, root, child1.(*Span).Root())
+		require.Equal(t, root, child2.(*Span).Root())
+		require.Equal(t, root, child21.(*Span).Root())
+		require.Equal(t, root, child211.(*Span).Root())
 	})
 }
 
@@ -928,7 +928,7 @@ func TestSetUserPropagatedUserID(t *testing.T) {
 
 	// Service 1, create span with propagated user
 	s := tracer.StartSpan("op")
-	s.(*span).SetUser("userino", WithPropagation())
+	s.(*Span).SetUser("userino", WithPropagation())
 	m := make(map[string]string)
 	err := tracer.Inject(s.Context(), TextMapCarrier(m))
 	require.NoError(t, err)
@@ -937,8 +937,8 @@ func TestSetUserPropagatedUserID(t *testing.T) {
 	c, err := tracer.Extract(TextMapCarrier(m))
 	require.NoError(t, err)
 	s = tracer.StartSpan("op", ChildOf(c))
-	s.(*span).SetUser("userino")
-	assert.True(t, s.(*span).context.updated)
+	s.(*Span).SetUser("userino")
+	assert.True(t, s.(*Span).context.updated)
 }
 
 func BenchmarkSetTagMetric(b *testing.B) {

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -82,7 +82,7 @@ func testAsyncSpanRace(t *testing.T) {
 				case <-done:
 					root.Finish()
 					for i := 0; i < 500; i++ {
-						for range root.(*span).Metrics {
+						for range root.(*Span).Metrics {
 							// this range simulates iterating over the metrics map
 							// as we do when encoding msgpack upon flushing.
 							continue
@@ -98,7 +98,7 @@ func testAsyncSpanRace(t *testing.T) {
 				case <-done:
 					root.Finish()
 					for i := 0; i < 500; i++ {
-						for range root.(*span).Meta {
+						for range root.(*Span).Meta {
 							// this range simulates iterating over the meta map
 							// as we do when encoding msgpack upon flushing.
 							continue
@@ -167,11 +167,11 @@ func TestPartialFlush(t *testing.T) {
 		defer stop()
 
 		root := tracer.StartSpan("root")
-		root.(*span).context.trace.setTag("someTraceTag", "someValue")
-		var children []*span
+		root.(*Span).context.trace.setTag("someTraceTag", "someValue")
+		var children []*Span
 		for i := 0; i < 3; i++ { // create 3 child spans
 			child := tracer.StartSpan(fmt.Sprintf("child%d", i), ChildOf(root.Context()))
-			children = append(children, child.(*span))
+			children = append(children, child.(*Span))
 			child.Finish()
 		}
 		flush(1)
@@ -200,7 +200,7 @@ func TestPartialFlush(t *testing.T) {
 		assert.Equal(t, 1.0, ts[0][0].Metrics[keySamplingPriority])
 		assert.Empty(t, ts[0][1].Meta["someTraceTag"])              // the tag should only be on the first span in the chunk
 		assert.Equal(t, 1.0, ts[0][1].Metrics[keySamplingPriority]) // the tag should only be on the first span in the chunk
-		comparePayloadSpans(t, root.(*span), tsRoot[0][0])
+		comparePayloadSpans(t, root.(*Span), tsRoot[0][0])
 		comparePayloadSpans(t, children[2], tsRoot[0][1])
 		telemetryClient.AssertNumberOfCalls(t, "Count", 1)
 		// TODO: (Support MetricKindDist) Re-enable this when we actually support `MetricKindDist`
@@ -213,11 +213,11 @@ func TestPartialFlush(t *testing.T) {
 		defer stop()
 
 		root := tracer.StartSpan("root")
-		root.(*span).context.trace.setTag("someTraceTag", "someValue")
-		var children []*span
+		root.(*Span).context.trace.setTag("someTraceTag", "someValue")
+		var children []*Span
 		for i := 0; i < 10; i++ { // create 10 child spans to ensure some aren't sampled
 			child := tracer.StartSpan(fmt.Sprintf("child%d", i), ChildOf(root.Context()))
-			children = append(children, child.(*span))
+			children = append(children, child.(*Span))
 			child.Finish()
 		}
 	})
@@ -269,7 +269,7 @@ func TestSpanTracePushSeveral(t *testing.T) {
 	span3 := trc.StartSpan("name3", ChildOf(root.Context()))
 	span3a := trc.StartSpan("name3", ChildOf(span3.Context()))
 
-	trace := []*span{root.(*span), span2.(*span), span3.(*span), span3a.(*span)}
+	trace := []*Span{root.(*Span), span2.(*Span), span3.(*Span), span3a.(*Span)}
 
 	for i, span := range trace {
 		span.context.trace = buffer
@@ -498,7 +498,7 @@ func TestSpanPeerService(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		assertSpan := func(t *testing.T, s *span) {
+		assertSpan := func(t *testing.T, s *Span) {
 			if tc.wantPeerService == "" {
 				assert.NotContains(t, s.Meta, "peer.service")
 			} else {
@@ -544,7 +544,7 @@ func TestSpanPeerService(t *testing.T) {
 }
 
 func TestSpanDDBaseService(t *testing.T) {
-	run := func(t *testing.T, tracerOpts []StartOption, spanOpts []StartSpanOption) []*span {
+	run := func(t *testing.T, tracerOpts []StartOption, spanOpts []StartSpanOption) []*Span {
 		prevSvc := globalconfig.ServiceName()
 		t.Cleanup(func() { globalconfig.SetServiceName(prevSvc) })
 
@@ -632,7 +632,7 @@ func TestSpanDDBaseService(t *testing.T) {
 
 func TestNewSpanContext(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
-		span := &span{
+		span := &Span{
 			TraceID:  1,
 			SpanID:   2,
 			ParentID: 3,
@@ -648,7 +648,7 @@ func TestNewSpanContext(t *testing.T) {
 	})
 
 	t.Run("priority", func(t *testing.T) {
-		span := &span{
+		span := &Span{
 			TraceID:  1,
 			SpanID:   2,
 			ParentID: 3,
@@ -687,7 +687,7 @@ func TestNewSpanContext(t *testing.T) {
 }
 
 func TestSpanContextParent(t *testing.T) {
-	s := &span{
+	s := &Span{
 		TraceID:  1,
 		SpanID:   2,
 		ParentID: 3,
@@ -703,7 +703,7 @@ func TestSpanContextParent(t *testing.T) {
 			baggage:    map[string]string{"A": "A", "B": "B"},
 			hasBaggage: 1,
 			trace: &trace{
-				spans:    []*span{newBasicSpan("abc")},
+				spans:    []*Span{newBasicSpan("abc")},
 				priority: func() *float64 { v := new(float64); *v = 2; return v }(),
 			},
 		},
@@ -711,12 +711,12 @@ func TestSpanContextParent(t *testing.T) {
 			baggage:    map[string]string{"A": "A", "B": "B"},
 			hasBaggage: 1,
 			trace: &trace{
-				spans:            []*span{newBasicSpan("abc")},
+				spans:            []*Span{newBasicSpan("abc")},
 				samplingDecision: decisionKeep,
 			},
 		},
 		"origin": {
-			trace:  &trace{spans: []*span{newBasicSpan("abc")}},
+			trace:  &trace{spans: []*Span{newBasicSpan("abc")}},
 			origin: "synthetics",
 		},
 	} {

--- a/ddtrace/tracer/sqlcomment_test.go
+++ b/ddtrace/tracer/sqlcomment_test.go
@@ -109,7 +109,7 @@ func TestSQLCommentCarrier(t *testing.T) {
 			var traceID uint64
 			if tc.injectSpan {
 				traceID = uint64(10)
-				root := tracer.StartSpan("service.calling.db", WithSpanID(traceID)).(*span)
+				root := tracer.StartSpan("service.calling.db", WithSpanID(traceID)).(*Span)
 				root.SetTag(ext.SamplingPriority, tc.samplingPriority)
 				spanCtx = root.Context()
 			}
@@ -281,7 +281,7 @@ func BenchmarkSQLCommentExtraction(b *testing.B) {
 
 func setupBenchmark() (*tracer, ddtrace.SpanContext, SQLCommentCarrier) {
 	tracer := newTracer(WithService("whiskey-service !#$%&'()*+,/:;=?@[]"), WithEnv("test-env"), WithServiceVersion("1.0.0"))
-	root := tracer.StartSpan("service.calling.db", WithSpanID(10)).(*span)
+	root := tracer.StartSpan("service.calling.db", WithSpanID(10)).(*Span)
 	root.SetTag(ext.SamplingPriority, 2)
 	spanCtx := root.Context()
 	carrier := SQLCommentCarrier{Query: "SELECT 1 FROM dual", Mode: DBMPropagationModeFull, DBServiceName: "whiskey-db"}

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -158,7 +158,7 @@ func TestTextMapPropagatorInjectHeader(t *testing.T) {
 	tracer := newTracer(WithPropagator(propagator))
 	defer tracer.Stop()
 
-	root := tracer.StartSpan("web.request").(*span)
+	root := tracer.StartSpan("web.request").(*Span)
 	root.SetBaggageItem("item", "x")
 	root.SetTag(ext.SamplingPriority, 0)
 	ctx := root.Context()
@@ -410,7 +410,7 @@ func TestTextMapPropagator(t *testing.T) {
 		})
 		tracer := newTracer(WithPropagator(propagator))
 		defer tracer.Stop()
-		root := tracer.StartSpan("web.request").(*span)
+		root := tracer.StartSpan("web.request").(*Span)
 		root.SetTag(ext.SamplingPriority, -1)
 		root.SetBaggageItem("item", "x")
 		ctx := root.Context().(*spanContext)
@@ -494,7 +494,7 @@ func TestEnvVars(t *testing.T) {
 				t.Run(fmt.Sprintf("inject with env=%q", testEnv), func(t *testing.T) {
 					tracer := newTracer(WithHTTPClient(c), withStatsdClient(&statsd.NoOpClient{}))
 					defer tracer.Stop()
-					root := tracer.StartSpan("web.request").(*span)
+					root := tracer.StartSpan("web.request").(*Span)
 					ctx, ok := root.Context().(*spanContext)
 					ctx.traceID = test.tid
 					ctx.spanID = test.spanID
@@ -696,7 +696,7 @@ func TestEnvVars(t *testing.T) {
 			t.Run(fmt.Sprintf("b3 single header inject #%d", i), func(t *testing.T) {
 				tracer := newTracer(WithHTTPClient(c), withStatsdClient(&statsd.NoOpClient{}))
 				defer tracer.Stop()
-				root := tracer.StartSpan("myrequest").(*span)
+				root := tracer.StartSpan("myrequest").(*Span)
 				ctx, ok := root.Context().(*spanContext)
 				require.True(t, ok)
 				ctx.traceID = traceIDFrom64Bits(tc.in[0])
@@ -753,7 +753,7 @@ func TestEnvVars(t *testing.T) {
 				t.Run(fmt.Sprintf("inject with env=%q", testEnv), func(t *testing.T) {
 					tracer := newTracer(WithPropagator(NewPropagator(&PropagatorConfig{B3: true})), WithHTTPClient(c), withStatsdClient(&statsd.NoOpClient{}))
 					defer tracer.Stop()
-					root := tracer.StartSpan("web.request").(*span)
+					root := tracer.StartSpan("web.request").(*Span)
 					ctx, ok := root.Context().(*spanContext)
 					ctx.traceID = traceIDFrom64Bits(tc.in[0])
 					ctx.spanID = tc.in[1]
@@ -886,7 +886,7 @@ func TestEnvVars(t *testing.T) {
 				t.Run(fmt.Sprintf("inject and extract with env=%q", testEnv), func(t *testing.T) {
 					tracer := newTracer(WithHTTPClient(c), withStatsdClient(&statsd.NoOpClient{}))
 					defer tracer.Stop()
-					root := tracer.StartSpan("web.request").(*span)
+					root := tracer.StartSpan("web.request").(*Span)
 					root.SetTag(ext.SamplingPriority, -1)
 					root.SetBaggageItem("item", "x")
 					ctx, ok := root.Context().(*spanContext)
@@ -1209,7 +1209,7 @@ func TestEnvVars(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					root := tracer.StartSpan("web.request", ChildOf(ctx)).(*span)
+					root := tracer.StartSpan("web.request", ChildOf(ctx)).(*Span)
 					defer root.Finish()
 					sctx, ok := ctx.(*spanContext)
 					sctx.origin = tc.origin
@@ -1395,7 +1395,7 @@ func TestEnvVars(t *testing.T) {
 					tracer := newTracer(WithHTTPClient(c), withStatsdClient(&statsd.NoOpClient{}))
 					defer tracer.Stop()
 					assert := assert.New(t)
-					root := tracer.StartSpan("web.request").(*span)
+					root := tracer.StartSpan("web.request").(*Span)
 					root.SetTag(ext.SamplingPriority, tc.priority)
 					ctx, ok := root.Context().(*spanContext)
 					ctx.origin = tc.origin
@@ -1423,7 +1423,7 @@ func TestEnvVars(t *testing.T) {
 					tracer := newTracer(WithHTTPClient(c), withStatsdClient(&statsd.NoOpClient{}))
 					defer tracer.Stop()
 					assert := assert.New(t)
-					root := tracer.StartSpan("web.request").(*span)
+					root := tracer.StartSpan("web.request").(*Span)
 					root.SetTag(ext.SamplingPriority, ext.PriorityUserKeep)
 					ctx, ok := root.Context().(*spanContext)
 					ctx.origin = "old_tracestate"
@@ -1494,7 +1494,7 @@ func TestEnvVars(t *testing.T) {
 				ctx, err := tracer.Extract(tc.inHeaders)
 				assert.Nil(err)
 
-				root := tracer.StartSpan("web.request", ChildOf(ctx)).(*span)
+				root := tracer.StartSpan("web.request", ChildOf(ctx)).(*Span)
 				defer root.Finish()
 				sctx, ok := ctx.(*spanContext)
 				headers := TextMapCarrier(map[string]string{})
@@ -1744,7 +1744,7 @@ func TestNonePropagator(t *testing.T) {
 		t.Setenv(headerPropagationStyleInject, "none")
 		tracer := newTracer()
 		defer tracer.Stop()
-		root := tracer.StartSpan("web.request").(*span)
+		root := tracer.StartSpan("web.request").(*Span)
 		root.SetTag(ext.SamplingPriority, -1)
 		root.SetBaggageItem("item", "x")
 		ctx, ok := root.Context().(*spanContext)
@@ -1767,7 +1767,7 @@ func TestNonePropagator(t *testing.T) {
 		defer tracer.Stop()
 		// reinitializing to capture log output, since propagators are parsed before logger is set
 		tracer.config.propagator = NewPropagator(&PropagatorConfig{})
-		root := tracer.StartSpan("web.request").(*span)
+		root := tracer.StartSpan("web.request").(*Span)
 		root.SetTag(ext.SamplingPriority, -1)
 		root.SetBaggageItem("item", "x")
 		ctx, ok := root.Context().(*spanContext)
@@ -1790,7 +1790,7 @@ func TestNonePropagator(t *testing.T) {
 		assert := assert.New(t)
 		tracer := newTracer()
 		defer tracer.Stop()
-		root := tracer.StartSpan("web.request").(*span)
+		root := tracer.StartSpan("web.request").(*Span)
 		root.SetTag(ext.SamplingPriority, -1)
 		root.SetBaggageItem("item", "x")
 		headers := TextMapCarrier(map[string]string{})
@@ -1806,7 +1806,7 @@ func TestNonePropagator(t *testing.T) {
 			t.Setenv(headerPropagationStyle, "NoNe")
 			tracer := newTracer()
 			defer tracer.Stop()
-			root := tracer.StartSpan("web.request").(*span)
+			root := tracer.StartSpan("web.request").(*Span)
 			root.SetTag(ext.SamplingPriority, -1)
 			root.SetBaggageItem("item", "x")
 			ctx, ok := root.Context().(*spanContext)
@@ -1830,7 +1830,7 @@ func TestNonePropagator(t *testing.T) {
 			t.Setenv(headerPropagationStyleInject, "NoNe")
 			tracer := newTracer()
 			defer tracer.Stop()
-			root := tracer.StartSpan("web.request").(*span)
+			root := tracer.StartSpan("web.request").(*Span)
 			root.SetTag(ext.SamplingPriority, -1)
 			root.SetBaggageItem("item", "x")
 			ctx, ok := root.Context().(*spanContext)
@@ -2106,7 +2106,7 @@ func TestMalformedTID(t *testing.T) {
 		})
 		sctx, err := tracer.Extract(headers)
 		assert.Nil(t, err)
-		root := tracer.StartSpan("web.request", ChildOf(sctx)).(*span)
+		root := tracer.StartSpan("web.request", ChildOf(sctx)).(*Span)
 		root.Finish()
 		assert.NotContains(t, root.Meta, keyTraceID128)
 	})
@@ -2119,7 +2119,7 @@ func TestMalformedTID(t *testing.T) {
 		})
 		sctx, err := tracer.Extract(headers)
 		assert.Nil(t, err)
-		root := tracer.StartSpan("web.request", ChildOf(sctx)).(*span)
+		root := tracer.StartSpan("web.request", ChildOf(sctx)).(*Span)
 		root.Finish()
 		assert.NotContains(t, root.Meta, keyTraceID128)
 	})
@@ -2132,7 +2132,7 @@ func TestMalformedTID(t *testing.T) {
 		})
 		sctx, err := tracer.Extract(headers)
 		assert.Nil(t, err)
-		root := tracer.StartSpan("web.request", ChildOf(sctx)).(*span)
+		root := tracer.StartSpan("web.request", ChildOf(sctx)).(*Span)
 		root.Finish()
 		assert.Equal(t, "640cfd8d00000000", root.Meta[keyTraceID128])
 	})

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -37,19 +37,19 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
-func (t *tracer) newEnvSpan(service, env string) *span {
-	return t.StartSpan("test.op", SpanType("test"), ServiceName(service), ResourceName("/"), Tag(ext.Environment, env)).(*span)
+func (t *tracer) newEnvSpan(service, env string) *Span {
+	return t.StartSpan("test.op", SpanType("test"), ServiceName(service), ResourceName("/"), Tag(ext.Environment, env)).(*Span)
 }
 
-func (t *tracer) newRootSpan(name, service, resource string) *span {
-	return t.StartSpan(name, SpanType("test"), ServiceName(service), ResourceName(resource)).(*span)
+func (t *tracer) newRootSpan(name, service, resource string) *Span {
+	return t.StartSpan(name, SpanType("test"), ServiceName(service), ResourceName(resource)).(*Span)
 }
 
-func (t *tracer) newChildSpan(name string, parent *span) *span {
+func (t *tracer) newChildSpan(name string, parent *Span) *Span {
 	if parent == nil {
-		return t.StartSpan(name).(*span)
+		return t.StartSpan(name).(*Span)
 	}
-	return t.StartSpan(name, ChildOf(parent.Context())).(*span)
+	return t.StartSpan(name, ChildOf(parent.Context())).(*Span)
 }
 
 func id128FromSpan(assert *assert.Assertions, ctx ddtrace.SpanContext) string {
@@ -213,7 +213,7 @@ func TestTracerStart(t *testing.T) {
 		Start()
 
 		// ensure at least one worker started and handles requests
-		internal.GetGlobalTracer().(*tracer).pushChunk(&chunk{spans: []*span{}})
+		internal.GetGlobalTracer().(*tracer).pushChunk(&chunk{spans: []*Span{}})
 
 		Stop()
 		Stop()
@@ -224,7 +224,7 @@ func TestTracerStart(t *testing.T) {
 	t.Run("deadlock/direct", func(t *testing.T) {
 		tr, _, _, stop := startTestTracer(t)
 		defer stop()
-		tr.pushChunk(&chunk{spans: []*span{}}) // blocks until worker is started
+		tr.pushChunk(&chunk{spans: []*Span{}}) // blocks until worker is started
 		select {
 		case <-tr.stop:
 			t.Fatal("stopped channel should be open")
@@ -247,7 +247,7 @@ func TestTracerStartSpan(t *testing.T) {
 	t.Run("generic", func(t *testing.T) {
 		tracer := newTracer()
 		defer tracer.Stop()
-		span := tracer.StartSpan("web.request").(*span)
+		span := tracer.StartSpan("web.request").(*Span)
 		assert := assert.New(t)
 		assert.NotEqual(uint64(0), span.TraceID)
 		assert.NotEqual(uint64(0), span.SpanID)
@@ -269,7 +269,7 @@ func TestTracerStartSpan(t *testing.T) {
 	t.Run("priority", func(t *testing.T) {
 		tracer := newTracer()
 		defer tracer.Stop()
-		span := tracer.StartSpan("web.request", Tag(ext.SamplingPriority, ext.PriorityUserKeep)).(*span)
+		span := tracer.StartSpan("web.request", Tag(ext.SamplingPriority, ext.PriorityUserKeep)).(*Span)
 		assert.Equal(t, float64(ext.PriorityUserKeep), span.Metrics[keySamplingPriority])
 		assert.Equal(t, "-4", span.context.trace.propagatingTags[keyDecisionMaker])
 	})
@@ -277,7 +277,7 @@ func TestTracerStartSpan(t *testing.T) {
 	t.Run("name", func(t *testing.T) {
 		tracer := newTracer()
 		defer tracer.Stop()
-		span := tracer.StartSpan("/home/user", Tag(ext.SpanName, "db.query")).(*span)
+		span := tracer.StartSpan("/home/user", Tag(ext.SpanName, "db.query")).(*Span)
 		assert.Equal(t, "db.query", span.Name)
 		assert.Equal(t, "/home/user", span.Resource)
 	})
@@ -285,7 +285,7 @@ func TestTracerStartSpan(t *testing.T) {
 	t.Run("measured_top_level", func(t *testing.T) {
 		tracer := newTracer()
 		defer tracer.Stop()
-		span := tracer.StartSpan("/home/user", Measured()).(*span)
+		span := tracer.StartSpan("/home/user", Measured()).(*Span)
 		_, ok := span.Metrics[keyMeasured]
 		assert.False(t, ok)
 		assert.Equal(t, 1.0, span.Metrics[keyTopLevel])
@@ -294,8 +294,8 @@ func TestTracerStartSpan(t *testing.T) {
 	t.Run("measured_non_top_level", func(t *testing.T) {
 		tracer := newTracer()
 		defer tracer.Stop()
-		parent := tracer.StartSpan("/home/user").(*span)
-		child := tracer.StartSpan("home/user", Measured(), ChildOf(parent.context)).(*span)
+		parent := tracer.StartSpan("/home/user").(*Span)
+		child := tracer.StartSpan("home/user", Measured(), ChildOf(parent.context)).(*Span)
 		assert.Equal(t, 1.0, child.Metrics[keyMeasured])
 	})
 
@@ -303,8 +303,8 @@ func TestTracerStartSpan(t *testing.T) {
 		t.Setenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", "v0")
 		tracer := newTracer()
 		defer tracer.Stop()
-		parent := tracer.StartSpan("/home/user").(*span)
-		child := tracer.StartSpan("home/user", ChildOf(parent.context)).(*span)
+		parent := tracer.StartSpan("/home/user").(*Span)
+		child := tracer.StartSpan("home/user", ChildOf(parent.context)).(*Span)
 		assert.Contains(t, parent.Metrics, "_dd.trace_span_attribute_schema")
 		assert.Equal(t, 0.0, parent.Metrics["_dd.trace_span_attribute_schema"])
 		assert.NotContains(t, child.Metrics, "_dd.trace_span_attribute_schema")
@@ -314,8 +314,8 @@ func TestTracerStartSpan(t *testing.T) {
 		t.Setenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", "v1")
 		tracer := newTracer()
 		defer tracer.Stop()
-		parent := tracer.StartSpan("/home/user").(*span)
-		child := tracer.StartSpan("home/user", ChildOf(parent.context)).(*span)
+		parent := tracer.StartSpan("/home/user").(*Span)
+		child := tracer.StartSpan("home/user", ChildOf(parent.context)).(*Span)
 		assert.Contains(t, parent.Metrics, "_dd.trace_span_attribute_schema")
 		assert.Equal(t, 1.0, parent.Metrics["_dd.trace_span_attribute_schema"])
 		assert.NotContains(t, child.Metrics, "_dd.trace_span_attribute_schema")
@@ -325,8 +325,8 @@ func TestTracerStartSpan(t *testing.T) {
 		t.Setenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", "bad-version")
 		tracer := newTracer()
 		defer tracer.Stop()
-		parent := tracer.StartSpan("/home/user").(*span)
-		child := tracer.StartSpan("home/user", ChildOf(parent.context)).(*span)
+		parent := tracer.StartSpan("/home/user").(*Span)
+		child := tracer.StartSpan("home/user", ChildOf(parent.context)).(*Span)
 		assert.Contains(t, parent.Metrics, "_dd.trace_span_attribute_schema")
 		assert.Equal(t, 0.0, parent.Metrics["_dd.trace_span_attribute_schema"])
 		assert.NotContains(t, child.Metrics, "_dd.trace_span_attribute_schema")
@@ -340,7 +340,7 @@ func TestSamplingDecision(t *testing.T) {
 		defer stop()
 		tracer.prioritySampling.defaultRate = 0
 		tracer.config.serviceName = "test_service"
-		span := tracer.StartSpan("name_1").(*span)
+		span := tracer.StartSpan("name_1").(*Span)
 		child := tracer.StartSpan("name_2", ChildOf(span.context))
 		child.Finish()
 		span.Finish()
@@ -357,7 +357,7 @@ func TestSamplingDecision(t *testing.T) {
 		tracer.config.agent.DropP0s = true
 		tracer.prioritySampling.defaultRate = 0
 		tracer.config.serviceName = "test_service"
-		span := tracer.StartSpan("name_1").(*span)
+		span := tracer.StartSpan("name_1").(*Span)
 		child := tracer.StartSpan("name_2", ChildOf(span.context))
 		child.Finish()
 		span.Finish()
@@ -375,7 +375,7 @@ func TestSamplingDecision(t *testing.T) {
 		tracer.config.agent.Stats = true
 		tracer.prioritySampling.defaultRate = 0
 		tracer.config.serviceName = "test_service"
-		span := tracer.StartSpan("name_1").(*span)
+		span := tracer.StartSpan("name_1").(*Span)
 		child := tracer.StartSpan("name_2", ChildOf(span.context))
 		child.Finish()
 		span.Finish()
@@ -390,7 +390,7 @@ func TestSamplingDecision(t *testing.T) {
 		tracer.config.agent.DropP0s = true
 		tracer.prioritySampling.defaultRate = 0
 		tracer.config.serviceName = "test_service"
-		span := tracer.StartSpan("name_1").(*span)
+		span := tracer.StartSpan("name_1").(*Span)
 		child := tracer.StartSpan("name_2", ChildOf(span.context))
 		child.SetTag(ext.EventSampleRate, 1)
 		child.Finish()
@@ -411,7 +411,7 @@ func TestSamplingDecision(t *testing.T) {
 		tracer.config.sampler = NewRateSampler(0)
 		tracer.prioritySampling.defaultRate = 0
 		tracer.config.serviceName = "test_service"
-		span := tracer.StartSpan("name_1").(*span)
+		span := tracer.StartSpan("name_1").(*Span)
 		child := tracer.StartSpan("name_2", ChildOf(span.context))
 		child.SetTag(ext.EventSampleRate, 1)
 		p, ok := span.context.samplingPriority()
@@ -444,8 +444,8 @@ func TestSamplingDecision(t *testing.T) {
 		tracer.config.sampler = NewRateSampler(0)
 		tracer.prioritySampling.defaultRate = 0
 		tracer.config.serviceName = "test_service"
-		parent := tracer.StartSpan("name_1").(*span)
-		child := tracer.StartSpan("name_2", ChildOf(parent.context)).(*span)
+		parent := tracer.StartSpan("name_1").(*Span)
+		child := tracer.StartSpan("name_2", ChildOf(parent.context)).(*Span)
 		child.Finish()
 		parent.Finish()
 		tracer.Stop()
@@ -472,8 +472,8 @@ func TestSamplingDecision(t *testing.T) {
 		tracer.config.sampler = NewRateSampler(0)
 		tracer.prioritySampling.defaultRate = 0
 		tracer.config.serviceName = "test_service"
-		parent := tracer.StartSpan("name_1").(*span)
-		child := tracer.StartSpan("name_2", ChildOf(parent.context)).(*span)
+		parent := tracer.StartSpan("name_1").(*Span)
+		child := tracer.StartSpan("name_2", ChildOf(parent.context)).(*Span)
 		child.Finish()
 		parent.Finish()
 		tracer.Stop()
@@ -500,8 +500,8 @@ func TestSamplingDecision(t *testing.T) {
 		tracer.config.sampler = NewRateSampler(0)
 		tracer.prioritySampling.defaultRate = 0
 		tracer.config.serviceName = "test_service"
-		parent := tracer.StartSpan("name_1").(*span)
-		child := tracer.StartSpan("name_2", ChildOf(parent.context)).(*span)
+		parent := tracer.StartSpan("name_1").(*Span)
+		child := tracer.StartSpan("name_2", ChildOf(parent.context)).(*Span)
 		child.Finish()
 		parent.Finish()
 		tracer.Stop()
@@ -524,8 +524,8 @@ func TestSamplingDecision(t *testing.T) {
 		tracer.config.sampler = NewRateSampler(1)
 		tracer.prioritySampling.defaultRate = 1
 		tracer.config.serviceName = "test_service"
-		parent := tracer.StartSpan("name_1").(*span)
-		child := tracer.StartSpan("name_2", ChildOf(parent.context)).(*span)
+		parent := tracer.StartSpan("name_1").(*Span)
+		child := tracer.StartSpan("name_2", ChildOf(parent.context)).(*Span)
 		child.Finish()
 		parent.Finish()
 		tracer.Stop()
@@ -553,9 +553,9 @@ func TestSamplingDecision(t *testing.T) {
 		defer stop()
 		tracer.config.featureFlags = make(map[string]struct{})
 		tracer.config.serviceName = "test_service"
-		var spans []*span
+		var spans []*Span
 		for i := 0; i < 100; i++ {
-			s := tracer.StartSpan(fmt.Sprintf("name_%d", i)).(*span)
+			s := tracer.StartSpan(fmt.Sprintf("name_%d", i)).(*Span)
 			for j := 0; j < 9; j++ {
 				child := tracer.newChildSpan(fmt.Sprintf("name_%d_%d", i, j), s)
 				child.Finish()
@@ -590,13 +590,13 @@ func TestSamplingDecision(t *testing.T) {
 		defer stop()
 		tracer.config.featureFlags = make(map[string]struct{})
 		tracer.config.serviceName = "test_service"
-		spans := []*span{}
+		spans := []*Span{}
 		for i := 0; i < 100; i++ {
-			s := tracer.StartSpan("name_1").(*span)
+			s := tracer.StartSpan("name_1").(*Span)
 			for i := 0; i < 9; i++ {
 				child := tracer.StartSpan("name_2", ChildOf(s.context))
 				child.Finish()
-				spans = append(spans, child.(*span))
+				spans = append(spans, child.(*Span))
 			}
 			spans = append(spans, s)
 			s.Finish()
@@ -626,13 +626,13 @@ func TestSamplingDecision(t *testing.T) {
 		defer stop()
 		tracer.config.featureFlags = make(map[string]struct{})
 		tracer.config.serviceName = "test_service"
-		spans := []*span{}
+		spans := []*Span{}
 		for i := 0; i < 100; i++ {
-			s := tracer.StartSpan("name_1").(*span)
+			s := tracer.StartSpan("name_1").(*Span)
 			for i := 0; i < 9; i++ {
 				child := tracer.StartSpan("name_2", ChildOf(s.context))
 				child.Finish()
-				spans = append(spans, child.(*span))
+				spans = append(spans, child.(*Span))
 			}
 			spans = append(spans, s)
 			s.Finish()
@@ -697,7 +697,7 @@ func TestTracerStartSpanOptions(t *testing.T) {
 		StartTime(now),
 		WithSpanID(420),
 	}
-	span := tracer.StartSpan("web.request", opts...).(*span)
+	span := tracer.StartSpan("web.request", opts...).(*Span)
 	assert := assert.New(t)
 	assert.Equal("test", span.Type)
 	assert.Equal("test.service", span.Service)
@@ -718,7 +718,7 @@ func TestTracerStartSpanOptions128(t *testing.T) {
 		opts := []StartSpanOption{
 			WithSpanID(987654),
 		}
-		s := tracer.StartSpan("web.request", opts...).(*span)
+		s := tracer.StartSpan("web.request", opts...).(*Span)
 		assert.Equal(uint64(987654), s.SpanID)
 		assert.Equal(uint64(987654), s.TraceID)
 		id := id128FromSpan(assert, s.Context())
@@ -736,7 +736,7 @@ func TestTracerStartSpanOptions128(t *testing.T) {
 			WithSpanID(987654),
 			StartTime(time.Unix(123456, 0)),
 		}
-		s := tracer.StartSpan("web.request", opts128...).(*span)
+		s := tracer.StartSpan("web.request", opts128...).(*Span)
 		assert.Equal(uint64(987654), s.SpanID)
 		assert.Equal(uint64(987654), s.TraceID)
 		id := id128FromSpan(assert, s.Context())
@@ -753,11 +753,11 @@ func TestTracerStartChildSpan(t *testing.T) {
 		assert := assert.New(t)
 		tracer := newTracer()
 		defer tracer.Stop()
-		root := tracer.StartSpan("web.request", ServiceName("root-service")).(*span)
+		root := tracer.StartSpan("web.request", ServiceName("root-service")).(*Span)
 		child := tracer.StartSpan("db.query",
 			ChildOf(root.Context()),
 			ServiceName("child-service"),
-			WithSpanID(69)).(*span)
+			WithSpanID(69)).(*Span)
 
 		assert.NotEqual(uint64(0), child.TraceID)
 		assert.NotEqual(uint64(0), child.SpanID)
@@ -776,8 +776,8 @@ func TestTracerStartChildSpan(t *testing.T) {
 		assert := assert.New(t)
 		tracer := newTracer()
 		defer tracer.Stop()
-		root := tracer.StartSpan("web.request", ServiceName("root-service")).(*span)
-		child := tracer.StartSpan("db.query", ChildOf(root.Context())).(*span)
+		root := tracer.StartSpan("web.request", ServiceName("root-service")).(*Span)
+		child := tracer.StartSpan("db.query", ChildOf(root.Context())).(*Span)
 
 		assert.Equal("root-service", child.Service)
 		// the root is marked as "top level", but the child is not
@@ -790,9 +790,9 @@ func TestTracerBaggagePropagation(t *testing.T) {
 	assert := assert.New(t)
 	tracer := newTracer()
 	defer tracer.Stop()
-	root := tracer.StartSpan("web.request").(*span)
+	root := tracer.StartSpan("web.request").(*Span)
 	root.SetBaggageItem("key", "value")
-	child := tracer.StartSpan("db.query", ChildOf(root.Context())).(*span)
+	child := tracer.StartSpan("db.query", ChildOf(root.Context())).(*Span)
 	context := child.Context().(*spanContext)
 
 	assert.Equal("value", context.baggage["key"])
@@ -816,11 +816,11 @@ func TestStartSpanOrigin(t *testing.T) {
 
 	// first child contains tag
 	child := tracer.StartSpan("child", ChildOf(ctx))
-	assert.Equal("synthetics", child.(*span).Meta[keyOrigin])
+	assert.Equal("synthetics", child.(*Span).Meta[keyOrigin])
 
 	// secondary child doesn't
 	child2 := tracer.StartSpan("child2", ChildOf(child.Context()))
-	assert.Empty(child2.(*span).Meta[keyOrigin])
+	assert.Empty(child2.(*Span).Meta[keyOrigin])
 
 	// but injecting its context marks origin
 	carrier2 := TextMapCarrier(map[string]string{})
@@ -836,7 +836,7 @@ func TestPropagationDefaults(t *testing.T) {
 
 	tracer := newTracer()
 	defer tracer.Stop()
-	root := tracer.StartSpan("web.request").(*span)
+	root := tracer.StartSpan("web.request").(*Span)
 	root.SetBaggageItem("x", "y")
 	root.SetTag(ext.SamplingPriority, -1)
 	ctx := root.Context().(*spanContext)
@@ -867,7 +867,7 @@ func TestPropagationDefaults(t *testing.T) {
 	assert.Equal(*ctx.trace.priority, -1.)
 
 	// ensure a child can be created
-	child := tracer.StartSpan("db.query", ChildOf(propagated)).(*span)
+	child := tracer.StartSpan("db.query", ChildOf(propagated)).(*Span)
 
 	assert.NotEqual(uint64(0), child.TraceID)
 	assert.NotEqual(uint64(0), child.SpanID)
@@ -880,8 +880,8 @@ func TestTracerSamplingPriorityPropagation(t *testing.T) {
 	assert := assert.New(t)
 	tracer := newTracer()
 	defer tracer.Stop()
-	root := tracer.StartSpan("web.request", Tag(ext.SamplingPriority, 2)).(*span)
-	child := tracer.StartSpan("db.query", ChildOf(root.Context())).(*span)
+	root := tracer.StartSpan("web.request", Tag(ext.SamplingPriority, 2)).(*Span)
+	child := tracer.StartSpan("db.query", ChildOf(root.Context())).(*Span)
 	assert.EqualValues(2, root.Metrics[keySamplingPriority])
 	assert.Equal("-4", root.context.trace.propagatingTags[keyDecisionMaker])
 	assert.EqualValues(2, child.Metrics[keySamplingPriority])
@@ -899,7 +899,7 @@ func TestTracerSamplingPriorityEmptySpanCtx(t *testing.T) {
 		spanID:  root.context.SpanID(),
 		trace:   &trace{},
 	}
-	child := tracer.StartSpan("db.query", ChildOf(spanCtx)).(*span)
+	child := tracer.StartSpan("db.query", ChildOf(spanCtx)).(*Span)
 	assert.EqualValues(1, child.Metrics[keySamplingPriority])
 	assert.Equal("-1", child.context.trace.propagatingTags[keyDecisionMaker])
 }
@@ -914,8 +914,8 @@ func TestTracerDDUpstreamServicesManualKeep(t *testing.T) {
 		spanID:  root.context.SpanID(),
 		trace:   &trace{},
 	}
-	child := tracer.StartSpan("db.query", ChildOf(spanCtx)).(*span)
-	grandChild := tracer.StartSpan("db.query", ChildOf(child.Context())).(*span)
+	child := tracer.StartSpan("db.query", ChildOf(spanCtx)).(*Span)
+	grandChild := tracer.StartSpan("db.query", ChildOf(child.Context())).(*Span)
 	grandChild.SetTag(ext.ManualDrop, true)
 	grandChild.SetTag(ext.ManualKeep, true)
 	assert.Equal("-4", grandChild.context.trace.propagatingTags[keyDecisionMaker])
@@ -925,9 +925,9 @@ func TestTracerBaggageImmutability(t *testing.T) {
 	assert := assert.New(t)
 	tracer := newTracer()
 	defer tracer.Stop()
-	root := tracer.StartSpan("web.request").(*span)
+	root := tracer.StartSpan("web.request").(*Span)
 	root.SetBaggageItem("key", "value")
-	child := tracer.StartSpan("db.query", ChildOf(root.Context())).(*span)
+	child := tracer.StartSpan("db.query", ChildOf(root.Context())).(*Span)
 	child.SetBaggageItem("key", "changed!")
 	parentContext := root.Context().(*spanContext)
 	childContext := child.Context().(*spanContext)
@@ -939,7 +939,7 @@ func TestTracerSpanTags(t *testing.T) {
 	tracer := newTracer()
 	defer tracer.Stop()
 	tag := Tag("key", "value")
-	span := tracer.StartSpan("web.request", tag).(*span)
+	span := tracer.StartSpan("web.request", tag).(*Span)
 	assert := assert.New(t)
 	assert.Equal("value", span.Meta["key"])
 }
@@ -948,9 +948,9 @@ func TestTracerSpanGlobalTags(t *testing.T) {
 	assert := assert.New(t)
 	tracer := newTracer(WithGlobalTag("key", "value"))
 	defer tracer.Stop()
-	s := tracer.StartSpan("web.request").(*span)
+	s := tracer.StartSpan("web.request").(*Span)
 	assert.Equal("value", s.Meta["key"])
-	child := tracer.StartSpan("db.query", ChildOf(s.Context())).(*span)
+	child := tracer.StartSpan("db.query", ChildOf(s.Context())).(*Span)
 	assert.Equal("value", child.Meta["key"])
 }
 
@@ -960,7 +960,7 @@ func TestTracerSpanServiceMappings(t *testing.T) {
 	t.Run("WithServiceMapping", func(t *testing.T) {
 		tracer := newTracer(WithServiceName("initial_service"), WithServiceMapping("initial_service", "new_service"))
 		defer tracer.Stop()
-		s := tracer.StartSpan("web.request").(*span)
+		s := tracer.StartSpan("web.request").(*Span)
 		assert.Equal("new_service", s.Service)
 
 	})
@@ -968,8 +968,8 @@ func TestTracerSpanServiceMappings(t *testing.T) {
 	t.Run("child", func(t *testing.T) {
 		tracer := newTracer(WithServiceMapping("initial_service", "new_service"))
 		defer tracer.Stop()
-		s := tracer.StartSpan("web.request", ServiceName("initial_service")).(*span)
-		child := tracer.StartSpan("db.query", ChildOf(s.Context())).(*span)
+		s := tracer.StartSpan("web.request", ServiceName("initial_service")).(*Span)
+		child := tracer.StartSpan("db.query", ChildOf(s.Context())).(*Span)
 		assert.Equal("new_service", child.Service)
 
 	})
@@ -977,7 +977,7 @@ func TestTracerSpanServiceMappings(t *testing.T) {
 	t.Run("StartSpanOption", func(t *testing.T) {
 		tracer := newTracer(WithServiceMapping("initial_service", "new_service"))
 		defer tracer.Stop()
-		s := tracer.StartSpan("web.request", ServiceName("initial_service")).(*span)
+		s := tracer.StartSpan("web.request", ServiceName("initial_service")).(*Span)
 		assert.Equal("new_service", s.Service)
 
 	})
@@ -985,14 +985,14 @@ func TestTracerSpanServiceMappings(t *testing.T) {
 	t.Run("tag", func(t *testing.T) {
 		tracer := newTracer(WithServiceMapping("initial_service", "new_service"))
 		defer tracer.Stop()
-		s := tracer.StartSpan("web.request", Tag("service.name", "initial_service")).(*span)
+		s := tracer.StartSpan("web.request", Tag("service.name", "initial_service")).(*Span)
 		assert.Equal("new_service", s.Service)
 	})
 
 	t.Run("globalTags", func(t *testing.T) {
 		tracer := newTracer(WithGlobalTag("service.name", "initial_service"), WithServiceMapping("initial_service", "new_service"))
 		defer tracer.Stop()
-		s := tracer.StartSpan("web.request").(*span)
+		s := tracer.StartSpan("web.request").(*Span)
 		assert.Equal("new_service", s.Service)
 	})
 }
@@ -1003,7 +1003,7 @@ func TestTracerNoDebugStack(t *testing.T) {
 	t.Run("Finish", func(t *testing.T) {
 		tracer := newTracer(WithDebugStack(false))
 		defer tracer.Stop()
-		s := tracer.StartSpan("web.request").(*span)
+		s := tracer.StartSpan("web.request").(*Span)
 		err := errors.New("test error")
 		s.Finish(WithError(err))
 		assert.Empty(s.Meta[ext.ErrorStack])
@@ -1012,7 +1012,7 @@ func TestTracerNoDebugStack(t *testing.T) {
 	t.Run("SetTag", func(t *testing.T) {
 		tracer := newTracer(WithDebugStack(false))
 		defer tracer.Stop()
-		s := tracer.StartSpan("web.request").(*span)
+		s := tracer.StartSpan("web.request").(*Span)
 		err := errors.New("error value with no trace")
 		s.SetTag(ext.Error, err)
 		assert.Empty(s.Meta[ext.ErrorStack])
@@ -1464,7 +1464,7 @@ func TestTracerRace(t *testing.T) {
 	assert.Len(traces, total, "we should have exactly as many traces as expected")
 	for _, trace := range traces {
 		assert.Len(trace, 3, "each trace should have exactly 3 spans")
-		var parent, child, redis *span
+		var parent, child, redis *Span
 		for _, span := range trace {
 			switch span.Name {
 			case "pylons.request":
@@ -1532,11 +1532,11 @@ func TestPushPayload(t *testing.T) {
 	s.Meta["key"] = strings.Repeat("X", payloadSizeLimit/2+10)
 
 	// half payload size reached
-	tracer.pushChunk(&chunk{[]*span{s}, true})
+	tracer.pushChunk(&chunk{[]*Span{s}, true})
 	tracer.awaitPayload(t, 1)
 
 	// payload size exceeded
-	tracer.pushChunk(&chunk{[]*span{s}, true})
+	tracer.pushChunk(&chunk{[]*Span{s}, true})
 	flush(2)
 }
 
@@ -1547,7 +1547,7 @@ func TestPushTrace(t *testing.T) {
 	log.UseLogger(tp)
 	tracer := newUnstartedTracer()
 	defer tracer.statsd.Close()
-	trace := []*span{
+	trace := []*Span{
 		{
 			Name:     "pylons.request",
 			Service:  "pylons",
@@ -1568,7 +1568,7 @@ func TestPushTrace(t *testing.T) {
 
 	many := payloadQueueSize + 2
 	for i := 0; i < many; i++ {
-		tracer.pushChunk(&chunk{spans: make([]*span, i)})
+		tracer.pushChunk(&chunk{spans: make([]*Span, i)})
 	}
 	assert.Len(tracer.out, payloadQueueSize)
 	log.Flush()
@@ -1625,8 +1625,8 @@ func TestTracerReportsHostname(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
 
-		root := tracer.StartSpan("root").(*span)
-		child := tracer.StartSpan("child", ChildOf(root.Context())).(*span)
+		root := tracer.StartSpan("root").(*Span)
+		child := tracer.StartSpan("child", ChildOf(root.Context())).(*Span)
 		child.Finish()
 		root.Finish()
 
@@ -1645,8 +1645,8 @@ func TestTracerReportsHostname(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
 
-		root := tracer.StartSpan("root").(*span)
-		child := tracer.StartSpan("child", ChildOf(root.Context())).(*span)
+		root := tracer.StartSpan("root").(*Span)
+		child := tracer.StartSpan("child", ChildOf(root.Context())).(*Span)
 		child.Finish()
 		root.Finish()
 
@@ -1662,8 +1662,8 @@ func TestTracerReportsHostname(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t, WithHostname(hostname))
 		defer stop()
 
-		root := tracer.StartSpan("root").(*span)
-		child := tracer.StartSpan("child", ChildOf(root.Context())).(*span)
+		root := tracer.StartSpan("root").(*Span)
+		child := tracer.StartSpan("child", ChildOf(root.Context())).(*Span)
 		child.Finish()
 		root.Finish()
 
@@ -1685,8 +1685,8 @@ func TestTracerReportsHostname(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
 
-		root := tracer.StartSpan("root").(*span)
-		child := tracer.StartSpan("child", ChildOf(root.Context())).(*span)
+		root := tracer.StartSpan("root").(*Span)
+		child := tracer.StartSpan("child", ChildOf(root.Context())).(*Span)
 		child.Finish()
 		root.Finish()
 
@@ -1705,8 +1705,8 @@ func TestTracerReportsHostname(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
 
-		root := tracer.StartSpan("root").(*span)
-		child := tracer.StartSpan("child", ChildOf(root.Context())).(*span)
+		root := tracer.StartSpan("root").(*Span)
+		child := tracer.StartSpan("child", ChildOf(root.Context())).(*Span)
 		child.Finish()
 		root.Finish()
 
@@ -1725,7 +1725,7 @@ func TestVersion(t *testing.T) {
 		defer stop()
 
 		assert := assert.New(t)
-		sp := tracer.StartSpan("http.request").(*span)
+		sp := tracer.StartSpan("http.request").(*Span)
 		v := sp.Meta[ext.Version]
 		assert.Equal("4.5.6", v)
 	})
@@ -1735,7 +1735,7 @@ func TestVersion(t *testing.T) {
 		defer stop()
 
 		assert := assert.New(t)
-		sp := tracer.StartSpan("http.request", ServiceName("otherservenv")).(*span)
+		sp := tracer.StartSpan("http.request", ServiceName("otherservenv")).(*Span)
 		_, ok := sp.Meta[ext.Version]
 		assert.False(ok)
 	})
@@ -1744,7 +1744,7 @@ func TestVersion(t *testing.T) {
 		defer stop()
 
 		assert := assert.New(t)
-		sp := tracer.StartSpan("http.request", ServiceName("otherservenv")).(*span)
+		sp := tracer.StartSpan("http.request", ServiceName("otherservenv")).(*Span)
 		v, ok := sp.Meta[ext.Version]
 		assert.True(ok)
 		assert.Equal("4.5.6", v)
@@ -1755,7 +1755,7 @@ func TestVersion(t *testing.T) {
 		defer stop()
 
 		assert := assert.New(t)
-		sp := tracer.StartSpan("http.request", ServiceName("otherservenv")).(*span)
+		sp := tracer.StartSpan("http.request", ServiceName("otherservenv")).(*Span)
 		v, ok := sp.Meta[ext.Version]
 		assert.True(ok)
 		assert.Equal("1.2.3", v)
@@ -1766,7 +1766,7 @@ func TestVersion(t *testing.T) {
 		defer stop()
 
 		assert := assert.New(t)
-		sp := tracer.StartSpan("http.request", ServiceName("otherservenv")).(*span)
+		sp := tracer.StartSpan("http.request", ServiceName("otherservenv")).(*Span)
 		_, ok := sp.Meta[ext.Version]
 		assert.False(ok)
 	})
@@ -1778,7 +1778,7 @@ func TestEnvironment(t *testing.T) {
 		defer stop()
 
 		assert := assert.New(t)
-		sp := tracer.StartSpan("http.request").(*span)
+		sp := tracer.StartSpan("http.request").(*Span)
 		v := sp.Meta[ext.Environment]
 		assert.Equal("test", v)
 	})
@@ -1788,7 +1788,7 @@ func TestEnvironment(t *testing.T) {
 		defer stop()
 
 		assert := assert.New(t)
-		sp := tracer.StartSpan("http.request").(*span)
+		sp := tracer.StartSpan("http.request").(*Span)
 		_, ok := sp.Meta[ext.Environment]
 		assert.False(ok)
 	})
@@ -1805,7 +1805,7 @@ func TestGitMetadata(t *testing.T) {
 		defer maininternal.ResetGitMetadataTags()
 
 		assert := assert.New(t)
-		sp := tracer.StartSpan("http.request").(*span)
+		sp := tracer.StartSpan("http.request").(*Span)
 		sp.context.finish()
 
 		assert.Equal("123456789ABCD", sp.Meta[maininternal.TraceTagCommitSha])
@@ -1821,7 +1821,7 @@ func TestGitMetadata(t *testing.T) {
 		defer maininternal.ResetGitMetadataTags()
 
 		assert := assert.New(t)
-		sp := tracer.StartSpan("http.request").(*span)
+		sp := tracer.StartSpan("http.request").(*Span)
 		sp.context.finish()
 
 		assert.Equal("123456789ABCD", sp.Meta[maininternal.TraceTagCommitSha])
@@ -1841,7 +1841,7 @@ func TestGitMetadata(t *testing.T) {
 		defer maininternal.ResetGitMetadataTags()
 
 		assert := assert.New(t)
-		sp := tracer.StartSpan("http.request").(*span)
+		sp := tracer.StartSpan("http.request").(*Span)
 		sp.context.finish()
 
 		assert.Equal("123456789ABCDE", sp.Meta[maininternal.TraceTagCommitSha])
@@ -1857,7 +1857,7 @@ func TestGitMetadata(t *testing.T) {
 		defer maininternal.ResetGitMetadataTags()
 
 		assert := assert.New(t)
-		sp := tracer.StartSpan("http.request").(*span)
+		sp := tracer.StartSpan("http.request").(*Span)
 		sp.context.finish()
 
 		assert.Equal("123456789ABCDE", sp.Meta[maininternal.TraceTagCommitSha])
@@ -1873,7 +1873,7 @@ func TestGitMetadata(t *testing.T) {
 		defer maininternal.ResetGitMetadataTags()
 
 		assert := assert.New(t)
-		sp := tracer.StartSpan("http.request").(*span)
+		sp := tracer.StartSpan("http.request").(*Span)
 		sp.context.finish()
 
 		assert.Equal("123456789ABCD", sp.Meta[maininternal.TraceTagCommitSha])
@@ -1892,7 +1892,7 @@ func TestGitMetadata(t *testing.T) {
 		defer maininternal.ResetGitMetadataTags()
 
 		assert := assert.New(t)
-		sp := tracer.StartSpan("http.request").(*span)
+		sp := tracer.StartSpan("http.request").(*Span)
 		sp.context.finish()
 
 		assert.Equal("", sp.Meta[maininternal.TraceTagCommitSha])
@@ -2104,7 +2104,7 @@ func decode(p *payload) (spanLists, error) {
 	return traces, err
 }
 
-func encode(traces [][]*span) (*payload, error) {
+func encode(traces [][]*Span) (*payload, error) {
 	p := newPayload()
 	for _, t := range traces {
 		if err := p.push(t); err != nil {
@@ -2133,18 +2133,18 @@ func (t *dummyTransport) Traces() spanLists {
 // read from the msgpack payload. In that case the private fields will
 // not be available and the maps (meta & metrics will be nil for lengths
 // of 0). This function covers for those cases and correctly compares.
-func comparePayloadSpans(t *testing.T, a, b *span) {
+func comparePayloadSpans(t *testing.T, a, b *Span) {
 	assert.Equal(t, cpspan(a), cpspan(b))
 }
 
-func cpspan(s *span) *span {
+func cpspan(s *Span) *Span {
 	if len(s.Metrics) == 0 {
 		s.Metrics = nil
 	}
 	if len(s.Meta) == 0 {
 		s.Meta = nil
 	}
-	return &span{
+	return &Span{
 		Name:     s.Name,
 		Service:  s.Service,
 		Resource: s.Resource,
@@ -2162,18 +2162,18 @@ func cpspan(s *span) *span {
 
 type testTraceWriter struct {
 	mu      sync.RWMutex
-	buf     []*span
-	flushed []*span
+	buf     []*Span
+	flushed []*Span
 }
 
 func newTestTraceWriter() *testTraceWriter {
 	return &testTraceWriter{
-		buf:     []*span{},
-		flushed: []*span{},
+		buf:     []*Span{},
+		flushed: []*Span{},
 	}
 }
 
-func (w *testTraceWriter) add(spans []*span) {
+func (w *testTraceWriter) add(spans []*Span) {
 	w.mu.Lock()
 	w.buf = append(w.buf, spans...)
 	w.mu.Unlock()
@@ -2196,14 +2196,14 @@ func (w *testTraceWriter) reset() {
 }
 
 // Buffered returns the spans buffered by the writer.
-func (w *testTraceWriter) Buffered() []*span {
+func (w *testTraceWriter) Buffered() []*Span {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 	return w.buf
 }
 
 // Flushed returns the spans flushed by the writer.
-func (w *testTraceWriter) Flushed() []*span {
+func (w *testTraceWriter) Flushed() []*Span {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 	return w.flushed
@@ -2402,7 +2402,7 @@ func BenchmarkSingleSpanRetention(b *testing.B) {
 		tracer.config.serviceName = "test_service"
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			span := tracer.StartSpan("name_1").(*span)
+			span := tracer.StartSpan("name_1").(*Span)
 			for i := 0; i < 100; i++ {
 				child := tracer.StartSpan("name_2", ChildOf(span.context))
 				child.Finish()
@@ -2424,7 +2424,7 @@ func BenchmarkSingleSpanRetention(b *testing.B) {
 		tracer.config.serviceName = "test_service"
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			span := tracer.StartSpan("name_1").(*span)
+			span := tracer.StartSpan("name_1").(*Span)
 			for i := 0; i < 50; i++ {
 				child := tracer.StartSpan("name_2", ChildOf(span.context))
 				child.Finish()
@@ -2450,7 +2450,7 @@ func BenchmarkSingleSpanRetention(b *testing.B) {
 		tracer.config.serviceName = "test_service"
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			span := tracer.StartSpan("name_1").(*span)
+			span := tracer.StartSpan("name_1").(*Span)
 			for i := 0; i < 100; i++ {
 				child := tracer.StartSpan("name_2", ChildOf(span.context))
 				child.Finish()
@@ -2475,16 +2475,16 @@ func TestExecutionTraceSpanTagged(t *testing.T) {
 	tracer, _, _, stop := startTestTracer(t)
 	defer stop()
 
-	tracedSpan := tracer.StartSpan("traced").(*span)
+	tracedSpan := tracer.StartSpan("traced").(*Span)
 	tracedSpan.Finish()
 
-	partialSpan := tracer.StartSpan("partial").(*span)
+	partialSpan := tracer.StartSpan("partial").(*Span)
 
 	rt.Stop()
 
 	partialSpan.Finish()
 
-	untracedSpan := tracer.StartSpan("untraced").(*span)
+	untracedSpan := tracer.StartSpan("untraced").(*Span)
 	untracedSpan.Finish()
 
 	assert.Equal(t, tracedSpan.Meta["go_execution_traced"], "yes")

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -23,8 +23,8 @@ import (
 )
 
 // getTestSpan returns a Span with different fields set
-func getTestSpan() *span {
-	return &span{
+func getTestSpan() *Span {
+	return &Span{
 		TraceID:  42,
 		SpanID:   52,
 		ParentID: 42,
@@ -41,11 +41,11 @@ func getTestSpan() *span {
 
 // getTestTrace returns a list of traces that is composed by “traceN“ number
 // of traces, each one composed by “size“ number of spans.
-func getTestTrace(traceN, size int) [][]*span {
-	var traces [][]*span
+func getTestTrace(traceN, size int) [][]*Span {
+	var traces [][]*Span
 
 	for i := 0; i < traceN; i++ {
-		trace := []*span{}
+		trace := []*Span{}
 		for j := 0; j < size; j++ {
 			trace = append(trace, getTestSpan())
 		}
@@ -61,7 +61,7 @@ func TestTracesAgentIntegration(t *testing.T) {
 	assert := assert.New(t)
 
 	testCases := []struct {
-		payload [][]*span
+		payload [][]*Span
 	}{
 		{getTestTrace(1, 1)},
 		{getTestTrace(10, 1)},
@@ -167,7 +167,7 @@ func TestTraceCountHeader(t *testing.T) {
 	assert := assert.New(t)
 
 	testCases := []struct {
-		payload [][]*span
+		payload [][]*Span
 	}{
 		{getTestTrace(1, 1)},
 		{getTestTrace(10, 1)},

--- a/ddtrace/tracer/writer_test.go
+++ b/ddtrace/tracer/writer_test.go
@@ -27,7 +27,7 @@ func TestImplementsTraceWriter(t *testing.T) {
 }
 
 // makeSpan returns a span, adding n entries to meta and metrics each.
-func makeSpan(n int) *span {
+func makeSpan(n int) *Span {
 	s := newSpan("encodeName", "encodeService", "encodeResource", random.Uint64(), random.Uint64(), random.Uint64())
 	for i := 0; i < n; i++ {
 		istr := fmt.Sprintf("%0.10d", i)
@@ -106,7 +106,7 @@ func TestLogWriter(t *testing.T) {
 		h.w = &buf
 		s := makeSpan(0)
 		for i := 0; i < 20; i++ {
-			h.add([]*span{s, s})
+			h.add([]*Span{s, s})
 		}
 		h.flush()
 		v := struct{ Traces [][]map[string]interface{} }{}
@@ -134,7 +134,7 @@ func TestLogWriter(t *testing.T) {
 		s.Metrics["nan"] = math.NaN()
 		s.Metrics["+inf"] = math.Inf(1)
 		s.Metrics["-inf"] = math.Inf(-1)
-		h.add([]*span{s})
+		h.add([]*Span{s})
 		h.flush()
 		json := string(buf.Bytes())
 		assert.NotContains(json, `"nan":`)
@@ -167,7 +167,7 @@ func TestLogWriter(t *testing.T) {
 		type jsonPayload struct {
 			Traces [][]jsonSpan `json:"traces"`
 		}
-		s := &span{
+		s := &Span{
 			Name:     "basicName",
 			Service:  "basicService",
 			Resource: "basicResource",
@@ -212,7 +212,7 @@ func TestLogWriter(t *testing.T) {
 			Duration: 456,
 			Error:    789,
 		}
-		h.add([]*span{s})
+		h.add([]*Span{s})
 		h.flush()
 		d := json.NewDecoder(&buf)
 		var payload jsonPayload
@@ -251,7 +251,7 @@ func TestLogWriterOverflow(t *testing.T) {
 		h := newLogTraceWriter(cfg, statsd)
 		h.w = &buf
 		s := makeSpan(10000)
-		h.add([]*span{s})
+		h.add([]*Span{s})
 		h.flush()
 		v := struct{ Traces [][]map[string]interface{} }{}
 		d := json.NewDecoder(&buf)
@@ -271,7 +271,7 @@ func TestLogWriterOverflow(t *testing.T) {
 		h := newLogTraceWriter(cfg, statsd)
 		h.w = &buf
 		s := makeSpan(10)
-		var trace []*span
+		var trace []*Span
 		for i := 0; i < 500; i++ {
 			trace = append(trace, s)
 		}
@@ -302,8 +302,8 @@ func TestLogWriterOverflow(t *testing.T) {
 		h := newLogTraceWriter(cfg, statsd)
 		h.w = &buf
 		s := makeSpan(4000)
-		h.add([]*span{s})
-		h.add([]*span{s})
+		h.add([]*Span{s})
+		h.add([]*Span{s})
 		h.flush()
 		v := struct{ Traces [][]map[string]interface{} }{}
 		d := json.NewDecoder(&buf)
@@ -380,7 +380,7 @@ func TestTraceWriterFlushRetries(t *testing.T) {
 		"datadog.tracer.traces_dropped": 1,
 	}
 
-	ss := []*span{makeSpan(0)}
+	ss := []*Span{makeSpan(0)}
 	for _, test := range testcases {
 		name := fmt.Sprintf("%d-%d-%t-%d", test.configRetries, test.failCount, test.tracesSent, test.expAttempts)
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Draft PR working to expose the tracer and span structs from ddtrace/tracer, remove references to ddtrace.Tracer and ddtrace.Span where possible, and refactor or remove those interfaces.


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!