### PR TITLE
tracer: pre-size payload buffer to optimize memory allocations

### DIFF
--- a/ddtrace/tracer/payload.go
+++ b/ddtrace/tracer/payload.go
@@ -72,6 +72,7 @@ func newPayload() *payload {
 
 // push pushes a new item into the stream.
 func (p *payload) push(t spanList) error {
+	p.buf.Grow(t.Msgsize())
 	if err := msgp.Encode(&p.buf, t); err != nil {
 		return err
 	}

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1938,6 +1938,13 @@ func BenchmarkPartialFlushing(b *testing.B) {
 	})
 }
 
+// BenchmarkBigTraces tests the performance of creating a lot of spans in a single thread
+func BenchmarkBigTraces(b *testing.B) {
+	b.Run("Big traces", func(b *testing.B) {
+		genBigTraces(b)
+	})
+}
+
 func genBigTraces(b *testing.B) {
 	tracer, transport, flush, stop := startTestTracer(b, WithLogger(log.DiscardLogger{}))
 	defer stop()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Pre-size the payload buffer before encoding payloads.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Performance improvements.

```
goos: darwin
goarch: arm64
pkg: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer
                        │   old.txt   │              new.txt               │
                        │   sec/op    │   sec/op     vs base               │
BigTraces/Big_traces-10   115.1m ± 1%   114.0m ± 1%  -0.99% (p=0.019 n=10)

                        │     old.txt      │              new.txt               │
                        │ avgHeapInUse(Mb) │ avgHeapInUse(Mb)  vs base          │
BigTraces/Big_traces-10         78.71 ± 4%        77.80 ± 10%  ~ (p=0.436 n=10)

                        │   old.txt    │               new.txt                │
                        │     B/op     │     B/op      vs base                │
BigTraces/Big_traces-10   326.6Mi ± 0%   286.8Mi ± 0%  -12.18% (p=0.000 n=10)

                        │   old.txt   │              new.txt               │
                        │  allocs/op  │  allocs/op   vs base               │
BigTraces/Big_traces-10   2.983M ± 0%   2.981M ± 0%  -0.05% (p=0.043 n=10)
```

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!