### PR TITLE
profiler: use only one service version value

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -92,6 +92,7 @@ type config struct {
 	apiURL               string // apiURL is the Datadog intake API URL
 	agentURL             string // agentURL is the Datadog agent profiling URL
 	service, env         string
+	version              string
 	hostname             string
 	statsd               StatsdClient
 	httpClient           *http.Client
@@ -417,7 +418,9 @@ func WithEnv(env string) Option {
 
 // WithVersion specifies the service version tag to attach to profiles
 func WithVersion(version string) Option {
-	return WithTags("version:" + version)
+	return func(cfg *config) {
+		cfg.version = version
+	}
 }
 
 // WithTags specifies a set of tags to be attached to the profiler. These may help

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -201,7 +201,7 @@ func TestOptions(t *testing.T) {
 	t.Run("WithVersion", func(t *testing.T) {
 		var cfg config
 		WithVersion("1.2.3")(&cfg)
-		assert.Contains(t, cfg.tags.Slice(), "version:1.2.3")
+		assert.Equal(t, cfg.version, "1.2.3")
 	})
 
 	t.Run("WithVersion/override", func(t *testing.T) {
@@ -209,7 +209,7 @@ func TestOptions(t *testing.T) {
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
 		WithVersion("1.2.3")(cfg)
-		assert.Contains(t, cfg.tags.Slice(), "version:1.2.3")
+		assert.Equal(t, cfg.version, "1.2.3")
 	})
 
 	t.Run("WithTags", func(t *testing.T) {
@@ -311,7 +311,7 @@ func TestEnvVars(t *testing.T) {
 		t.Setenv("DD_VERSION", "1.2.3")
 		cfg, err := defaultConfig()
 		require.NoError(t, err)
-		assert.Contains(t, cfg.tags.Slice(), "version:1.2.3")
+		assert.Equal(t, cfg.version, "1.2.3")
 	})
 
 	t.Run("DD_TAGS", func(t *testing.T) {

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -195,13 +195,18 @@ func newProfiler(opts ...Option) (*profiler, error) {
 		logStartup(cfg)
 	}
 	var tags []string
+	var seenVersionTag bool
 	for _, tag := range cfg.tags.Slice() {
 		// If the user configured a tag via DD_VERSION or WithVersion,
 		// override any version tags the user provided via WithTags,
 		// since having more than one version tag breaks the comparison
-		// UI
-		if cfg.version != "" && strings.HasPrefix(tag, "version:") {
-			continue
+		// UI. If a version is only supplied by WithTags, keep only the
+		// first one.
+		if strings.HasPrefix(strings.ToLower(tag), "version:") {
+			if cfg.version != "" || seenVersionTag {
+				continue
+			}
+			seenVersionTag = true
 		}
 		tags = append(tags, tag)
 	}

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -655,8 +655,9 @@ func TestVersionResolution(t *testing.T) {
 	}
 
 	t.Run("tags only", func(t *testing.T) {
-		data := doOneProfileUpload(WithTags("version:4.5.6"))
+		data := doOneProfileUpload(WithTags("version:4.5.6", "version:7.8.9"))
 		assert.Contains(t, data.tags, "version:4.5.6")
+		assert.NotContains(t, data.tags, "version:7.8.9")
 	})
 
 	t.Run("env", func(t *testing.T) {
@@ -674,5 +675,11 @@ func TestVersionResolution(t *testing.T) {
 		assert.NotContains(t, data.tags, "version:1.2.3")
 		assert.NotContains(t, data.tags, "version:4.5.6")
 		assert.Contains(t, data.tags, "version:7.8.9")
+	})
+
+	t.Run("case insensitive", func(t *testing.T) {
+		data := doOneProfileUpload(WithTags("Version:4.5.6", "version:7.8.9"))
+		assert.Contains(t, data.tags, "Version:4.5.6")
+		assert.NotContains(t, data.tags, "version:7.8.9")
 	})
 }


### PR DESCRIPTION
### What does this PR do?

Users can set the version tag for profiles in three ways: via
`WithVersion`, the `DD_VERSION` environment variable, or via `WithTags`. A
service should only have one version tag at a time for profile
comparison with a "recent" version to work properly in the UI. Today,
all of these options can be used at once and the profiles for a service
can have multiple version tags.

To be consistent with the tracer, we should supply a single version and
it should be configured with the following priority order: first,
`WithVersion` is used. If that option is not set, then `DD_VERSION` will be
used. If either of those are used, then they get priority over any
version tags supplied via `WithTags`. That is, version tags are removed if
the version is explicity set.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] There is a benchmark for any new code, or changes to existing code.
- [x] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
