### PR TITLE
ddtrace/tracer: Separate trace/span types from the tracer struct

### DIFF
--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -50,7 +50,42 @@ type Tracer interface {
 
 	// Stop stops the tracer. Calls to Stop should be idempotent.
 	Stop()
+
+	// TODO(kjn v2): These can be removed / consolidated. These are
+	// here temporarily as we figure out a sensible API.
+	TracerConf() TracerConf
+
+	SubmitStats(Span)
+	SubmitAbandonedSpan(Span, bool)
+	SubmitChunk(any) // This is a horrible signature. This will eventually become SubmitChunk(Chunk)
+	Flush()          // Synchronous flushing
+
+	// TODO(kjn v2): Not sure if this belongs in the tracer.
+	// May be better to have a separate stats counting package / type.
+	Signal(Event)
 }
+
+type TracerConf struct {
+	CanComputeStats      bool
+	CanDropP0s           bool
+	DebugAbandonedSpans  bool
+	PartialFlush         bool
+	PartialFlushMinSpans int
+	PeerServiceDefaults  bool
+	PeerServiceMappings  map[string]string
+	EnvTag               string
+	VersionTag           string
+	ServiceTag           string
+}
+
+// Events are things that happen in the tracer such as a trace being dropped or
+// a span being started. These are counted and submitted as metrics.
+type Event int
+
+const (
+	TraceDropped Event = iota
+	SpanStarted
+)
 
 // Span represents a chunk of computation time. Spans have names, durations,
 // timestamps and other metadata. A Tracer is used to create hierarchies of

--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -62,7 +62,7 @@ type Tracer interface {
 
 	// TODO(kjn v2): Not sure if this belongs in the tracer.
 	// May be better to have a separate stats counting package / type.
-	Signal(Event)
+	//	Signal(Event)
 }
 
 type TracerConf struct {
@@ -77,15 +77,6 @@ type TracerConf struct {
 	VersionTag           string
 	ServiceTag           string
 }
-
-// Events are things that happen in the tracer such as a trace being dropped or
-// a span being started. These are counted and submitted as metrics.
-type Event int
-
-const (
-	TraceDropped Event = iota
-	SpanStarted
-)
 
 // Span represents a chunk of computation time. Spans have names, durations,
 // timestamps and other metadata. A Tracer is used to create hierarchies of

--- a/ddtrace/internal/globaltracer.go
+++ b/ddtrace/internal/globaltracer.go
@@ -73,7 +73,6 @@ func (NoopTracer) SubmitStats(ddtrace.Span)               {}
 func (NoopTracer) SubmitAbandonedSpan(ddtrace.Span, bool) {}
 func (NoopTracer) SubmitChunk(any)                        {}
 func (NoopTracer) Flush()                                 {}
-func (NoopTracer) Signal(ddtrace.Event)                   {}
 
 var _ ddtrace.Span = (*NoopSpan)(nil)
 

--- a/ddtrace/internal/globaltracer.go
+++ b/ddtrace/internal/globaltracer.go
@@ -63,6 +63,18 @@ func (NoopTracer) Inject(_ ddtrace.SpanContext, _ interface{}) error { return ni
 // Stop implements ddtrace.Tracer.
 func (NoopTracer) Stop() {}
 
+// TODO(kjn v2): These should be removed. They are here temporarily to facilitate
+// the shift to the v2 API.
+func (NoopTracer) TracerConf() ddtrace.TracerConf {
+	return ddtrace.TracerConf{}
+}
+
+func (NoopTracer) SubmitStats(ddtrace.Span)               {}
+func (NoopTracer) SubmitAbandonedSpan(ddtrace.Span, bool) {}
+func (NoopTracer) SubmitChunk(any)                        {}
+func (NoopTracer) Flush()                                 {}
+func (NoopTracer) Signal(ddtrace.Event)                   {}
+
 var _ ddtrace.Span = (*NoopSpan)(nil)
 
 // NoopSpan is an implementation of ddtrace.Span that is a no-op.

--- a/ddtrace/internal/globaltracer_test.go
+++ b/ddtrace/internal/globaltracer_test.go
@@ -28,14 +28,14 @@ func (r *raceTestTracer) Stop() {
 	r.stopped = true
 }
 
-func (t *raceTestTracer) TracerConf() ddtrace.TracerConf {
+func (*raceTestTracer) TracerConf() ddtrace.TracerConf {
 	return ddtrace.TracerConf{}
 }
 
-func (t *raceTestTracer) SubmitStats(ddtrace.Span)               {}
-func (t *raceTestTracer) SubmitAbandonedSpan(ddtrace.Span, bool) {}
-func (t *raceTestTracer) SubmitChunk(any)                        {}
-func (t *raceTestTracer) Flush()                                 {}
+func (*raceTestTracer) SubmitStats(ddtrace.Span)               {}
+func (*raceTestTracer) SubmitAbandonedSpan(ddtrace.Span, bool) {}
+func (*raceTestTracer) SubmitChunk(any)                        {}
+func (*raceTestTracer) Flush()                                 {}
 
 func TestGlobalTracer(t *testing.T) {
 	// at module initialization, the tracer must be seet

--- a/ddtrace/internal/globaltracer_test.go
+++ b/ddtrace/internal/globaltracer_test.go
@@ -28,6 +28,16 @@ func (r *raceTestTracer) Stop() {
 	r.stopped = true
 }
 
+func (t *raceTestTracer) TracerConf() ddtrace.TracerConf {
+	return ddtrace.TracerConf{}
+}
+
+func (t *raceTestTracer) SubmitStats(ddtrace.Span)               {}
+func (t *raceTestTracer) SubmitAbandonedSpan(ddtrace.Span, bool) {}
+func (t *raceTestTracer) SubmitChunk(any)                        {}
+func (t *raceTestTracer) Flush()                                 {}
+func (t *raceTestTracer) Signal(ddtrace.Event)                   {}
+
 func TestGlobalTracer(t *testing.T) {
 	// at module initialization, the tracer must be seet
 	if GetGlobalTracer() == nil {

--- a/ddtrace/internal/globaltracer_test.go
+++ b/ddtrace/internal/globaltracer_test.go
@@ -36,7 +36,6 @@ func (t *raceTestTracer) SubmitStats(ddtrace.Span)               {}
 func (t *raceTestTracer) SubmitAbandonedSpan(ddtrace.Span, bool) {}
 func (t *raceTestTracer) SubmitChunk(any)                        {}
 func (t *raceTestTracer) Flush()                                 {}
-func (t *raceTestTracer) Signal(ddtrace.Event)                   {}
 
 func TestGlobalTracer(t *testing.T) {
 	// at module initialization, the tracer must be seet

--- a/ddtrace/internal/tracerstats/stats.go
+++ b/ddtrace/internal/tracerstats/stats.go
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package tracerstats
+
+import "sync/atomic"
+
+// Events are things that happen in the tracer such as a trace being dropped or
+// a span being started. These are counted and submitted as metrics.
+type Event int
+
+const (
+	SpanStarted Event = iota
+	SpansFinished
+	TracesDropped
+	DroppedP0Traces
+	DroppedP0Spans
+	PartialTraces
+)
+
+// These integers track metrics about spans and traces as they are started,
+// finished, and dropped
+var spansStarted, spansFinished, tracesDropped uint32
+
+// Records the number of dropped P0 traces and spans.
+var droppedP0Traces, droppedP0Spans uint32
+
+// partialTrace the number of partially dropped traces.
+var partialTraces uint32
+
+func Signal(e Event, count uint32) {
+	switch e {
+	case SpanStarted:
+		atomic.AddUint32(&spansStarted, count)
+	case SpansFinished:
+		atomic.AddUint32(&spansFinished, count)
+	case TracesDropped:
+		atomic.AddUint32(&tracesDropped, count)
+	case DroppedP0Traces:
+		atomic.AddUint32(&droppedP0Traces, count)
+	case DroppedP0Spans:
+		atomic.AddUint32(&droppedP0Spans, count)
+	case PartialTraces:
+		atomic.AddUint32(&partialTraces, count)
+	}
+}
+
+func Count(e Event) uint32 {
+	switch e {
+	case SpanStarted:
+		return atomic.SwapUint32(&spansStarted, 0)
+	case SpansFinished:
+		return atomic.SwapUint32(&spansFinished, 0)
+	case TracesDropped:
+		return atomic.SwapUint32(&tracesDropped, 0)
+	case DroppedP0Traces:
+		return atomic.SwapUint32(&droppedP0Traces, 0)
+	case DroppedP0Spans:
+		return atomic.SwapUint32(&droppedP0Spans, 0)
+	case PartialTraces:
+		return atomic.SwapUint32(&partialTraces, 0)
+	}
+	return 0
+}
+
+func Reset() {
+	atomic.StoreUint32(&spansStarted, 0)
+	atomic.StoreUint32(&spansFinished, 0)
+	atomic.StoreUint32(&tracesDropped, 0)
+	atomic.StoreUint32(&droppedP0Traces, 0)
+	atomic.StoreUint32(&droppedP0Spans, 0)
+	atomic.StoreUint32(&partialTraces, 0)
+}

--- a/ddtrace/internal/tracerstats/stats.go
+++ b/ddtrace/internal/tracerstats/stats.go
@@ -18,6 +18,11 @@ const (
 	DroppedP0Traces
 	DroppedP0Spans
 	PartialTraces
+
+	// Read-only. We duplicate some of the stats so that we can send them to the
+	// agent in headers as well as counting them with statsd.
+	AgentDroppedP0Traces
+	AgentDroppedP0Spans
 )
 
 // These integers track metrics about spans and traces as they are started,
@@ -30,6 +35,9 @@ var droppedP0Traces, droppedP0Spans uint32
 // partialTrace the number of partially dropped traces.
 var partialTraces uint32
 
+// Copies of the stats to be sent to the agent.
+var agentDroppedP0Traces, agentDroppedP0Spans uint32
+
 func Signal(e Event, count uint32) {
 	switch e {
 	case SpanStarted:
@@ -40,8 +48,10 @@ func Signal(e Event, count uint32) {
 		atomic.AddUint32(&tracesDropped, count)
 	case DroppedP0Traces:
 		atomic.AddUint32(&droppedP0Traces, count)
+		atomic.AddUint32(&agentDroppedP0Traces, count)
 	case DroppedP0Spans:
 		atomic.AddUint32(&droppedP0Spans, count)
+		atomic.AddUint32(&agentDroppedP0Spans, count)
 	case PartialTraces:
 		atomic.AddUint32(&partialTraces, count)
 	}
@@ -61,6 +71,10 @@ func Count(e Event) uint32 {
 		return atomic.SwapUint32(&droppedP0Spans, 0)
 	case PartialTraces:
 		return atomic.SwapUint32(&partialTraces, 0)
+	case AgentDroppedP0Traces:
+		return atomic.SwapUint32(&agentDroppedP0Traces, 0)
+	case AgentDroppedP0Spans:
+		return atomic.SwapUint32(&agentDroppedP0Spans, 0)
 	}
 	return 0
 }
@@ -72,4 +86,6 @@ func Reset() {
 	atomic.StoreUint32(&droppedP0Traces, 0)
 	atomic.StoreUint32(&droppedP0Spans, 0)
 	atomic.StoreUint32(&partialTraces, 0)
+	atomic.StoreUint32(&agentDroppedP0Traces, 0)
+	atomic.StoreUint32(&agentDroppedP0Spans, 0)
 }

--- a/ddtrace/mocktracer/mocktracer.go
+++ b/ddtrace/mocktracer/mocktracer.go
@@ -197,3 +197,13 @@ func (t *mocktracer) Inject(context ddtrace.SpanContext, carrier interface{}) er
 	})
 	return nil
 }
+
+func (t *mocktracer) TracerConf() ddtrace.TracerConf {
+	return ddtrace.TracerConf{}
+}
+
+func (t *mocktracer) SubmitStats(ddtrace.Span)               {}
+func (t *mocktracer) SubmitAbandonedSpan(ddtrace.Span, bool) {}
+func (t *mocktracer) SubmitChunk(any)                        {}
+func (t *mocktracer) Flush()                                 {}
+func (t *mocktracer) Signal(ddtrace.Event)                   {}

--- a/ddtrace/mocktracer/mocktracer.go
+++ b/ddtrace/mocktracer/mocktracer.go
@@ -206,4 +206,3 @@ func (t *mocktracer) SubmitStats(ddtrace.Span)               {}
 func (t *mocktracer) SubmitAbandonedSpan(ddtrace.Span, bool) {}
 func (t *mocktracer) SubmitChunk(any)                        {}
 func (t *mocktracer) Flush()                                 {}
-func (t *mocktracer) Signal(ddtrace.Event)                   {}

--- a/ddtrace/tracer/metrics.go
+++ b/ddtrace/tracer/metrics.go
@@ -6,8 +6,10 @@
 package tracer
 
 import (
+	"fmt"
 	"runtime"
 	"runtime/debug"
+	"strconv"
 	"time"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/internal/tracerstats"
@@ -91,6 +93,10 @@ func (t *tracer) reportHealthMetrics(interval time.Duration) {
 	for {
 		select {
 		case <-ticker.C:
+			t.statsd.Count("datadog.tracer.dropped_p0_traces", int64(tracerstats.Count(tracerstats.AgentDroppedP0Traces)),
+				[]string{fmt.Sprintf("partial:%s", strconv.FormatBool(tracerstats.Count(tracerstats.PartialTraces) > 0))}, 1)
+			t.statsd.Count("datadog.tracer.dropped_p0_spans", int64(tracerstats.Count(tracerstats.AgentDroppedP0Spans)), nil, 1)
+
 			t.statsd.Count("datadog.tracer.spans_started", int64(tracerstats.Count(tracerstats.SpanStarted)), nil, 1)
 			t.statsd.Count("datadog.tracer.spans_finished", int64(tracerstats.Count(tracerstats.SpansFinished)), nil, 1)
 			t.statsd.Count("datadog.tracer.traces_dropped", int64(tracerstats.Count(tracerstats.TracesDropped)), []string{"reason:trace_too_large"}, 1)

--- a/ddtrace/tracer/metrics.go
+++ b/ddtrace/tracer/metrics.go
@@ -8,9 +8,9 @@ package tracer
 import (
 	"runtime"
 	"runtime/debug"
-	"sync/atomic"
 	"time"
 
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/internal/tracerstats"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 )
 
@@ -91,9 +91,9 @@ func (t *tracer) reportHealthMetrics(interval time.Duration) {
 	for {
 		select {
 		case <-ticker.C:
-			t.statsd.Count("datadog.tracer.spans_started", int64(atomic.SwapUint32(&t.spansStarted, 0)), nil, 1)
-			t.statsd.Count("datadog.tracer.spans_finished", int64(atomic.SwapUint32(&t.spansFinished, 0)), nil, 1)
-			t.statsd.Count("datadog.tracer.traces_dropped", int64(atomic.SwapUint32(&t.tracesDropped, 0)), []string{"reason:trace_too_large"}, 1)
+			t.statsd.Count("datadog.tracer.spans_started", int64(tracerstats.Count(tracerstats.SpanStarted)), nil, 1)
+			t.statsd.Count("datadog.tracer.spans_finished", int64(tracerstats.Count(tracerstats.SpansFinished)), nil, 1)
+			t.statsd.Count("datadog.tracer.traces_dropped", int64(tracerstats.Count(tracerstats.TracesDropped)), []string{"reason:trace_too_large"}, 1)
 		case <-t.stop:
 			return
 		}

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/internal"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/internal/tracerstats"
 	ginternal "github.com/DataDog/dd-trace-go/v2/internal"
 	sharedinternal "github.com/DataDog/dd-trace-go/v2/internal"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
@@ -351,7 +352,7 @@ func (t *trace) push(sp *span) {
 		t.spans = nil // allow our spans to be collected by GC.
 		log.Error("trace buffer full (%d spans), dropping trace", traceMaxSize)
 		if tr != nil {
-			tr.Signal(ddtrace.TraceDropped)
+			tracerstats.Signal(tracerstats.TracesDropped, 1)
 		}
 		return
 	}
@@ -360,7 +361,7 @@ func (t *trace) push(sp *span) {
 	}
 	t.spans = append(t.spans, sp)
 	if tr != nil {
-		tr.Signal(ddtrace.SpanStarted)
+		tracerstats.Signal(tracerstats.SpanStarted, 1)
 	}
 }
 

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -50,7 +50,7 @@ func TestNewSpanContextPushError(t *testing.T) {
 	child.context = newSpanContext(child, parent.context)
 
 	log.Flush()
-	assert.Contains(t, tp.Logs()[0], "ERROR: trace buffer full (2)")
+	assert.Contains(t, tp.Logs()[0], "ERROR: trace buffer full (2 spans)")
 }
 
 func TestAsyncSpanRace(t *testing.T) {
@@ -762,7 +762,7 @@ func TestSpanContextPushFull(t *testing.T) {
 	assert.Len(tp.Logs(), 0)
 	buffer.push(span3)
 	log.Flush()
-	assert.Contains(tp.Logs()[0], "ERROR: trace buffer full (2)")
+	assert.Contains(tp.Logs()[0], "ERROR: trace buffer full (2 spans)")
 }
 
 func TestSpanContextBaggage(t *testing.T) {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -2100,7 +2100,7 @@ func BenchmarkStartSpan(b *testing.B) {
 
 // startTestTracer returns a Tracer with a DummyTransport
 func startTestTracer(t testing.TB, opts ...StartOption) (trc *tracer, transport *dummyTransport, flush func(n int), stop func(), err error) {
-  tracerstats.Reset()
+	tracerstats.Reset()
 	transport = newDummyTransport()
 	tick := make(chan time.Time)
 	o := append([]StartOption{

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -2253,7 +2253,7 @@ loop:
 	assert.Len(t, tw.Flushed(), 0)
 	assert.Zero(t, ts.flushed)
 	assert.Len(t, transport.Stats(), 0)
-	tr.flushSync()
+	tr.Flush()
 	assert.Len(t, tw.Flushed(), 1)
 	assert.Equal(t, 1, ts.flushed)
 	assert.Len(t, transport.Stats(), 1)

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/internal"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/internal/tracerstats"
 	maininternal "github.com/DataDog/dd-trace-go/v2/internal"
 	"github.com/DataDog/dd-trace-go/v2/internal/globalconfig"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
@@ -404,8 +405,8 @@ func TestSamplingDecision(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t)
 		defer func() {
 			// Must check these after tracer is stopped to avoid flakiness
-			assert.Equal(t, uint32(1), tracer.droppedP0Traces)
-			assert.Equal(t, uint32(2), tracer.droppedP0Spans)
+			assert.Equal(t, uint32(1), tracerstats.Count(tracerstats.DroppedP0Traces))
+			assert.Equal(t, uint32(2), tracerstats.Count(tracerstats.DroppedP0Spans))
 		}()
 		defer stop()
 		tracer.config.sampler = NewRateSampler(0)
@@ -434,8 +435,8 @@ func TestSamplingDecision(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t)
 		defer func() {
 			// Must check these after tracer is stopped to avoid flakiness
-			assert.Equal(t, uint32(0), tracer.droppedP0Traces)
-			assert.Equal(t, uint32(1), tracer.droppedP0Spans)
+			assert.Equal(t, uint32(0), tracerstats.Count(tracerstats.DroppedP0Traces))
+			assert.Equal(t, uint32(1), tracerstats.Count(tracerstats.DroppedP0Spans))
 		}()
 		defer stop()
 		tracer.config.agent.DropP0s = true
@@ -464,8 +465,8 @@ func TestSamplingDecision(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t)
 		defer func() {
 			// Must check these after tracer is stopped to avoid flakiness
-			assert.Equal(t, uint32(0), tracer.droppedP0Traces)
-			assert.Equal(t, uint32(1), tracer.droppedP0Spans)
+			assert.Equal(t, uint32(0), tracerstats.Count(tracerstats.DroppedP0Traces))
+			assert.Equal(t, uint32(1), tracerstats.Count(tracerstats.DroppedP0Spans))
 		}()
 		defer stop()
 		tracer.config.featureFlags = make(map[string]struct{})
@@ -492,8 +493,8 @@ func TestSamplingDecision(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t)
 		defer func() {
 			// Must check these after tracer is stopped to avoid flakiness
-			assert.Equal(t, uint32(1), tracer.droppedP0Traces)
-			assert.Equal(t, uint32(2), tracer.droppedP0Spans)
+			assert.Equal(t, uint32(1), tracerstats.Count(tracerstats.DroppedP0Traces))
+			assert.Equal(t, uint32(2), tracerstats.Count(tracerstats.DroppedP0Spans))
 		}()
 		defer stop()
 		tracer.config.featureFlags = make(map[string]struct{})
@@ -2015,6 +2016,7 @@ func BenchmarkStartSpan(b *testing.B) {
 
 // startTestTracer returns a Tracer with a DummyTransport
 func startTestTracer(t testing.TB, opts ...StartOption) (trc *tracer, transport *dummyTransport, flush func(n int), stop func()) {
+	tracerstats.Reset()
 	transport = newDummyTransport()
 	tick := make(chan time.Time)
 	o := append([]StartOption{

--- a/ddtrace/tracer/transport.go
+++ b/ddtrace/tracer/transport.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"time"
 
+	traceinternal "github.com/DataDog/dd-trace-go/v2/ddtrace/internal"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/internal/tracerstats"
 	"github.com/DataDog/dd-trace-go/v2/internal"
 	"github.com/DataDog/dd-trace-go/v2/internal/version"
 
@@ -146,21 +148,21 @@ func (t *httpTransport) send(p *payload) (body io.ReadCloser, err error) {
 	req.Header.Set(headerComputedTopLevel, "yes")
 	// TODO(kjn v2): Figure out the stats. They probably don't belong in the Tracer interface?
 	// Looking for input from other engineers.
-	// if t, ok := traceinternal.GetGlobalTracer().(*tracer); ok {
-	// 	if t.config.canComputeStats() {
-	// 		req.Header.Set("Datadog-Client-Computed-Stats", "yes")
-	// 	}
-	// 	droppedTraces := int(atomic.SwapUint32(&t.droppedP0Traces, 0))
-	// 	partialTraces := int(atomic.SwapUint32(&t.partialTraces, 0))
-	// 	droppedSpans := int(atomic.SwapUint32(&t.droppedP0Spans, 0))
-	// 	if stats := t.statsd; stats != nil {
-	// 		stats.Count("datadog.tracer.dropped_p0_traces", int64(droppedTraces),
-	// 			[]string{fmt.Sprintf("partial:%s", strconv.FormatBool(partialTraces > 0))}, 1)
-	// 		stats.Count("datadog.tracer.dropped_p0_spans", int64(droppedSpans), nil, 1)
-	// 	}
-	// 	req.Header.Set("Datadog-Client-Dropped-P0-Traces", strconv.Itoa(droppedTraces))
-	// 	req.Header.Set("Datadog-Client-Dropped-P0-Spans", strconv.Itoa(droppedSpans))
-	// }
+	if t, ok := traceinternal.GetGlobalTracer().(*tracer); ok {
+		if t.config.canComputeStats() {
+			req.Header.Set("Datadog-Client-Computed-Stats", "yes")
+		}
+		droppedTraces := int(tracerstats.Count(tracerstats.DroppedP0Traces))
+		partialTraces := int(tracerstats.Count(tracerstats.PartialTraces))
+		droppedSpans := int(tracerstats.Count(tracerstats.DroppedP0Spans))
+		if stats := t.statsd; stats != nil {
+			stats.Count("datadog.tracer.dropped_p0_traces", int64(droppedTraces),
+				[]string{fmt.Sprintf("partial:%s", strconv.FormatBool(partialTraces > 0))}, 1)
+			stats.Count("datadog.tracer.dropped_p0_spans", int64(droppedSpans), nil, 1)
+		}
+		req.Header.Set("Datadog-Client-Dropped-P0-Traces", strconv.Itoa(droppedTraces))
+		req.Header.Set("Datadog-Client-Dropped-P0-Spans", strconv.Itoa(droppedSpans))
+	}
 	response, err := t.client.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION

### What does this PR do?

This commit modifies the trace, span, and spancontext types to be independent of the `ddtrace/tracer.tracer` type. Previously this code would cast to the `*tracer` type and interact with its internals. Now, they communicate with a `ddtrace.Tracer` type through an established interface.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!