### PR TITLE
ddtrace/opentelemetry: added support for special attributes mapping

### DIFF
--- a/ddtrace/opentelemetry/span.go
+++ b/ddtrace/opentelemetry/span.go
@@ -143,26 +143,31 @@ func (s *span) SetStatus(code otelcodes.Code, description string) {
 // Every value is propagated as an interface.
 func (s *span) SetAttributes(kv ...attribute.KeyValue) {
 	for _, attr := range kv {
-		k, v := string(attr.Key), attr.Value
-		switch k {
-		case "operation.name":
-			s.SetName(v.AsString())
-		case "service.name":
-			s.SetTag(ext.ServiceName, v.AsString())
-		case "resource.name":
-			s.SetTag(ext.ResourceName, v.AsString())
-		case "span.type":
-			s.SetTag(ext.SpanType, v.AsString())
-		case "analytics.event":
-			var rate int
-			if v.AsBool() {
-				rate = 1
-			} else {
-				rate = 0
-			}
-			s.SetTag(ext.EventSampleRate, rate)
-		default:
-			s.SetTag(string(attr.Key), attr.Value.AsInterface())
+		s.SetTag(toSpecialAttributes(string(attr.Key), attr.Value))
+	}
+}
+
+// toSpecialAttributes recognizes a set of span attributes that have a special meaning.
+// These tags should supersede other values.
+func toSpecialAttributes(k string, v attribute.Value) (string, interface{}) {
+	switch k {
+	case "operation.name":
+		return ext.SpanName, v.AsString()
+	case "service.name":
+		return ext.ServiceName, v.AsString()
+	case "resource.name":
+		return ext.ResourceName, v.AsString()
+	case "span.type":
+		return ext.SpanType, v.AsString()
+	case "analytics.event":
+		var rate int
+		if v.AsBool() {
+			rate = 1
+		} else {
+			rate = 0
 		}
+		return ext.EventSampleRate, rate
+	default:
+		return k, v.AsInterface()
 	}
 }

--- a/ddtrace/opentelemetry/span.go
+++ b/ddtrace/opentelemetry/span.go
@@ -143,6 +143,26 @@ func (s *span) SetStatus(code otelcodes.Code, description string) {
 // Every value is propagated as an interface.
 func (s *span) SetAttributes(kv ...attribute.KeyValue) {
 	for _, attr := range kv {
-		s.SetTag(string(attr.Key), attr.Value.AsInterface())
+		k, v := string(attr.Key), attr.Value
+		switch k {
+		case "operation.name":
+			s.SetName(v.AsString())
+		case "service.name":
+			s.SetTag(ext.ServiceName, v.AsString())
+		case "resource.name":
+			s.SetTag(ext.ResourceName, v.AsString())
+		case "span.type":
+			s.SetTag(ext.SpanType, v.AsString())
+		case "analytics.event":
+			var rate int
+			if v.AsBool() {
+				rate = 1
+			} else {
+				rate = 0
+			}
+			s.SetTag(ext.EventSampleRate, rate)
+		default:
+			s.SetTag(string(attr.Key), attr.Value.AsInterface())
+		}
 	}
 }

--- a/ddtrace/opentelemetry/span_test.go
+++ b/ddtrace/opentelemetry/span_test.go
@@ -389,23 +389,40 @@ func TestSpanSetAttributes(t *testing.T) {
 
 	attributes := [][]string{{"k1", "v1_old"},
 		{"k2", "v2"},
-		{"k1", "v1_new"}}
+		{"k1", "v1_new"},
+		// maps to 'name'
+		{"operation.name", "ops"},
+		// maps to 'service'
+		{"service.name", "srv"},
+		// maps to 'resource'
+		{"resource.name", "rsr"},
+		// maps to 'type'
+		{"span.type", "db"},
+	}
 
 	_, sp := tr.Start(context.Background(), "test")
 	for _, tag := range attributes {
 		sp.SetAttributes(attribute.String(tag[0], tag[1]))
 	}
+	// maps to '_dd1.sr.eausr'
+	sp.SetAttributes(attribute.Int("analytics.event", 1))
+
 	sp.End()
 	tracer.Flush()
 	payload, err := waitForPayload(ctx, payloads)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	assert.Contains(payload, "k1")
-	assert.Contains(payload, "k2")
-	assert.Contains(payload, "v1_new")
-	assert.Contains(payload, "v2")
+	assert.Contains(payload, `"k1":"v1_new"`)
+	assert.Contains(payload, `"k2":"v2"`)
 	assert.NotContains(payload, "v1_old")
+
+	// reserved attributes
+	assert.Contains(payload, `"name":"ops"`)
+	assert.Contains(payload, `"service":"srv"`)
+	assert.Contains(payload, `"resource":"rsr"`)
+	assert.Contains(payload, `"type":"db"`)
+	assert.Contains(payload, `"_dd1.sr.eausr":1`)
 }
 
 func TestTracerStartOptions(t *testing.T) {

--- a/ddtrace/opentelemetry/span_test.go
+++ b/ddtrace/opentelemetry/span_test.go
@@ -269,7 +269,7 @@ func TestSpanContextWithStartOptions(t *testing.T) {
 	}
 	assert.Contains(p, "persisted_ctx_rsc")
 	assert.Contains(p, "persisted_srv")
-	assert.Contains(p, `"type":"producer"`)
+	assert.Contains(p, `"span.kind":"producer"`)
 	assert.Contains(p, fmt.Sprint(spanID))
 	assert.Contains(p, fmt.Sprint(startTime.UnixNano()))
 	assert.Contains(p, fmt.Sprint(duration.Nanoseconds()))
@@ -303,7 +303,7 @@ func TestSpanContextWithStartOptionsPriorityOrder(t *testing.T) {
 	}
 	assert.Contains(p, "persisted_ctx_rsc")
 	assert.Contains(p, "persisted_srv")
-	assert.Contains(p, `"type":"producer"`)
+	assert.Contains(p, `"span.kind":"producer"`)
 	assert.NotContains(p, "discarded")
 }
 

--- a/ddtrace/opentelemetry/span_test.go
+++ b/ddtrace/opentelemetry/span_test.go
@@ -269,7 +269,7 @@ func TestSpanContextWithStartOptions(t *testing.T) {
 	}
 	assert.Contains(p, "persisted_ctx_rsc")
 	assert.Contains(p, "persisted_srv")
-	assert.Contains(p, `"span.kind":"producer"`)
+	assert.Contains(p, `"type":"producer"`)
 	assert.Contains(p, fmt.Sprint(spanID))
 	assert.Contains(p, fmt.Sprint(startTime.UnixNano()))
 	assert.Contains(p, fmt.Sprint(duration.Nanoseconds()))
@@ -303,7 +303,7 @@ func TestSpanContextWithStartOptionsPriorityOrder(t *testing.T) {
 	}
 	assert.Contains(p, "persisted_ctx_rsc")
 	assert.Contains(p, "persisted_srv")
-	assert.Contains(p, `"span.kind":"producer"`)
+	assert.Contains(p, `"type":"producer"`)
 	assert.NotContains(p, "discarded")
 }
 

--- a/ddtrace/opentelemetry/tracer.go
+++ b/ddtrace/opentelemetry/tracer.go
@@ -9,9 +9,9 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 

--- a/ddtrace/opentelemetry/tracer.go
+++ b/ddtrace/opentelemetry/tracer.go
@@ -11,7 +11,6 @@ import (
 	"encoding/hex"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 
@@ -48,7 +47,7 @@ func (t *oteltracer) Start(ctx context.Context, spanName string, opts ...oteltra
 		ddopts = append(ddopts, tracer.Tag(toSpecialAttributes(string(attr.Key), attr.Value)))
 	}
 	if k := ssConfig.SpanKind(); k != 0 {
-		ddopts = append(ddopts, tracer.Tag(ext.SpanKind, k.String()))
+		ddopts = append(ddopts, tracer.SpanType(k.String()))
 	}
 	if opts, ok := spanOptionsFromContext(ctx); ok {
 		ddopts = append(ddopts, opts...)

--- a/ddtrace/opentelemetry/tracer.go
+++ b/ddtrace/opentelemetry/tracer.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -44,10 +45,10 @@ func (t *oteltracer) Start(ctx context.Context, spanName string, opts ...oteltra
 		ddopts = append(ddopts, tracer.StartTime(ssConfig.Timestamp()))
 	}
 	for _, attr := range ssConfig.Attributes() {
-		ddopts = append(ddopts, tracer.Tag(string(attr.Key), attr.Value.AsInterface()))
+		ddopts = append(ddopts, tracer.Tag(toSpecialAttributes(string(attr.Key), attr.Value)))
 	}
 	if k := ssConfig.SpanKind(); k != 0 {
-		ddopts = append(ddopts, tracer.SpanType(k.String()))
+		ddopts = append(ddopts, tracer.Tag(ext.SpanKind, k.String()))
 	}
 	if opts, ok := spanOptionsFromContext(ctx); ok {
 		ddopts = append(ddopts, opts...)

--- a/go.sum
+++ b/go.sum
@@ -624,8 +624,6 @@ github.com/AzureAD/microsoft-authentication-library-for-go v0.5.1/go.mod h1:Vt9s
 github.com/AzureAD/microsoft-authentication-library-for-go v0.8.1/go.mod h1:4qFor3D/HDsvBME35Xy9rwW9DecL+M2sNw1ybjPtwA0=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DataDog/appsec-internal-go v1.0.0 h1:2u5IkF4DBj3KVeQn5Vg2vjPUtt513zxEYglcqnd500U=
-github.com/DataDog/appsec-internal-go v1.0.0/go.mod h1:+Y+4klVWKPOnZx6XESG7QHydOaUGEXyH2j/vSg9JiNM=
 github.com/DataDog/appsec-internal-go v1.0.1 h1:j60HUtXEQ2uRIm8SsNnLp1Ummx/EU8iV9IFvEYmSdUM=
 github.com/DataDog/appsec-internal-go v1.0.1/go.mod h1:+Y+4klVWKPOnZx6XESG7QHydOaUGEXyH2j/vSg9JiNM=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0 h1:bUMSNsw1iofWiju9yc1f+kBd33E3hMJtq9GuU602Iy8=


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
This PR adds support special span attributes, to match OTLP behavior. 
Specifically, name, service, resource, type and analytics.event.

For example:
- if `service.name` attribute is set on the span, it will be remapped to Datadog's `service` tag.
- if `analytics.event` attribute is set on the span, it will be remapped to Datadog's `_dd1.sr.eausr` tag.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Matching OTLP support behaviour.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!