### PR TITLE
ddtrace/opentelemetry: Fixed setting a wrong span field (span.kind)

### DIFF
--- a/ddtrace/opentelemetry/span_test.go
+++ b/ddtrace/opentelemetry/span_test.go
@@ -269,7 +269,7 @@ func TestSpanContextWithStartOptions(t *testing.T) {
 	}
 	assert.Contains(p, "persisted_ctx_rsc")
 	assert.Contains(p, "persisted_srv")
-	assert.Contains(p, `"type":"producer"`)
+	assert.Contains(p, `"span.kind":"producer"`)
 	assert.Contains(p, fmt.Sprint(spanID))
 	assert.Contains(p, fmt.Sprint(startTime.UnixNano()))
 	assert.Contains(p, fmt.Sprint(duration.Nanoseconds()))
@@ -303,7 +303,7 @@ func TestSpanContextWithStartOptionsPriorityOrder(t *testing.T) {
 	}
 	assert.Contains(p, "persisted_ctx_rsc")
 	assert.Contains(p, "persisted_srv")
-	assert.Contains(p, `"type":"producer"`)
+	assert.Contains(p, `"span.kind":"producer"`)
 	assert.NotContains(p, "discarded")
 }
 

--- a/ddtrace/opentelemetry/tracer.go
+++ b/ddtrace/opentelemetry/tracer.go
@@ -9,9 +9,9 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 

--- a/ddtrace/opentelemetry/tracer.go
+++ b/ddtrace/opentelemetry/tracer.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -47,7 +48,7 @@ func (t *oteltracer) Start(ctx context.Context, spanName string, opts ...oteltra
 		ddopts = append(ddopts, tracer.Tag(string(attr.Key), attr.Value.AsInterface()))
 	}
 	if k := ssConfig.SpanKind(); k != 0 {
-		ddopts = append(ddopts, tracer.SpanType(k.String()))
+		ddopts = append(ddopts, tracer.Tag(ext.SpanKind, k.String()))
 	}
 	if opts, ok := spanOptionsFromContext(ctx); ok {
 		ddopts = append(ddopts, opts...)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Previously, we were setting `span.type` based on the `span.kind` attribute. Now, `span.kind` will map to `span.kind`.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!