### PR TITLE
tracer: always propagate the tracestate header

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -279,7 +279,6 @@ func (p *chainedPropagator) Extract(carrier interface{}) (ddtrace.SpanContext, e
 			// A valid trace context has already been extracted. We should now extract
 			// and propagate the W3C tracestate header if the trace-id matches.
 			p.propagateTracestate(ctx.(*spanContext), carrier)
-			sctx := ctx.(*spanContext)
 			break
 		}
 		var err error

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -309,8 +309,7 @@ func (p *propagatorW3c) propagateTracestate(ctx *spanContext, carrier interface{
 		return // The trace-ids must match.
 	}
 	if w3cCtx.(*spanContext).trace == nil {
-		// extractors initialize a new spanContext, so the trace might be nil
-		w3cCtx.(*spanContext).trace = newTrace()
+		return // this shouldn't happen, since it should have a propagating tag already
 	}
 	// Get the tracestate header from extracted w3C context, and propagate
 	// it to the span context that will be returned.

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -276,7 +276,6 @@ func (p *chainedPropagator) Extract(carrier interface{}) (ddtrace.SpanContext, e
 	var ctx ddtrace.SpanContext
 	for _, v := range p.extractors {
 		if p, isW3C := v.(*propagatorW3c); isW3C && ctx != nil {
-			fmt.Println("HERE")
 			// A valid trace context has already been extracted. We should now extract
 			// and propagate the W3C tracestate header if the trace-id matches.
 			p.propagateTracestate(ctx.(*spanContext), carrier)

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -280,7 +280,6 @@ func (p *chainedPropagator) Extract(carrier interface{}) (ddtrace.SpanContext, e
 			// and propagate the W3C tracestate header if the trace-id matches.
 			p.propagateTracestate(ctx.(*spanContext), carrier)
 			sctx := ctx.(*spanContext)
-			fmt.Println(sctx)
 			break
 		}
 		var err error

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -284,18 +284,20 @@ func (p *chainedPropagator) Extract(carrier interface{}) (ddtrace.SpanContext, e
 		var err error
 		ctx, err = v.Extract(carrier)
 		if ctx != nil {
-			if internal.BoolEnv("DD_TRACE_PROPAGATION_EXTRACT_FIRST", false) {
+			if p.onlyExtractFirst {
+				// Return early if the customer configured that only the first successful
+				// extraction should occur.
 				return ctx, nil
 			}
 		} else if err != ErrSpanContextNotFound {
 			return nil, err
 		}
 	}
-	if ctx != nil {
-		log.Debug("Extracted span context: %#v", ctx)
-		return ctx, nil
+	if ctx == nil {
+		return nil, ErrSpanContextNotFound
 	}
-	return nil, ErrSpanContextNotFound
+	log.Debug("Extracted span context: %#v", ctx)
+	return ctx, nil
 }
 
 // propagateTracestate will add the tracestate propagating tag to the given

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -147,7 +147,7 @@ func TestTextMapExtractTracestatePropagation(t *testing.T) {
 		{
 			/*
 				With Datadog AND w3c propagation set, but mismatching trace-ids,
-				the tracestate header should be ignored, and not propagated to
+				the tracestate header should be ignored and not propagated to
 				the returned trace context.
 			*/
 			name:                      "datadog-and-w3c-mismatching-ids",
@@ -157,8 +157,8 @@ func TestTextMapExtractTracestatePropagation(t *testing.T) {
 		},
 		{
 			/*
-				With Datadog AND w3c propagation set, but mismatching trace-ids,
-				the tracestate header should be ignored, and not propagated to
+				With Datadog AND w3c propagation set, but the traceparent is malformed,
+				the tracestate header should be ignored and not propagated to
 				the returned trace context.
 			*/
 			name:                      "datadog-and-w3c-malformed",
@@ -168,8 +168,18 @@ func TestTextMapExtractTracestatePropagation(t *testing.T) {
 		},
 		{
 			/*
+				With Datadog AND w3c propagation set, but there is no traceparent,
+				the tracestate header should be ignored and not propagated to
+				the returned trace context.
+			*/
+			name:                      "datadog-and-w3c-no-traceparent",
+			propagationStyle:          "datadog,tracecontext",
+			wantTracestatePropagation: false,
+		},
+		{
+			/*
 				With Datadog AND w3c propagation set, but DD_TRACE_PROPAGATION_EXTRACT_FIRST
-				is true, so the tracestate header should be ignored, and not propagated to
+				is true, the tracestate header should be ignored and not propagated to
 				the returned trace context.
 			*/
 			name:                      "datadog-and-w3c-only-extract-first",

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -161,7 +161,7 @@ func TestTextMapExtractTracestatePropagation(t *testing.T) {
 			*/
 			name:             "datadog-and-w3c-malformed",
 			propagationStyle: "datadog,tracecontext",
-			traceparent:      "00-00000000000000000000000000000004-22asdf!2-01", // malformed
+			traceparent:      "00-00000000000000000000000000000004-22asdf!2-01",
 		},
 		{
 			/*
@@ -180,7 +180,7 @@ func TestTextMapExtractTracestatePropagation(t *testing.T) {
 			*/
 			name:             "datadog-and-w3c-only-extract-first",
 			propagationStyle: "datadog,tracecontext",
-			traceparent:      "00-00000000000000000000000000000004-2222222222222222-01", // malformed
+			traceparent:      "00-00000000000000000000000000000004-2222222222222222-01",
 			onlyExtractFirst: true,
 		},
 	}
@@ -207,14 +207,13 @@ func TestTextMapExtractTracestatePropagation(t *testing.T) {
 			sctx, ok := ctx.(*spanContext)
 			assert.True(ok)
 			assert.Equal("00000000000000000000000000000004", sctx.traceID.HexEncoded())
-			assert.Equal(uint64(1), sctx.spanID)
+			assert.Equal(uint64(1), sctx.spanID)    // should use x-datadog-parent-id, not the id in the tracestate
+			assert.Equal("synthetics", sctx.origin) // should use x-datadog-origin, not the origin in the tracestate
 			if tc.wantTracestatePropagation {
 				assert.Equal("dd=s:0;o:synthetics,othervendor=t61rcWkgMzE", sctx.trace.propagatingTag(tracestateHeader))
 			} else if sctx.trace != nil {
 				assert.False(sctx.trace.hasPropagatingTag(tracestateHeader))
 			}
-			// TODO: This could still benefit from some tests verifying that other fields are not changed,
-			// and only the tracestate header was propagated.
 		})
 	}
 }

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -118,10 +118,9 @@ func TestTextMapExtractTracestatePropagation(t *testing.T) {
 				With only Datadog propagation set, the tracestate header should
 				be ignored, and not propagated to the returned trace context.
 			*/
-			name:                      "datadog-only",
-			propagationStyle:          "datadog",
-			traceparent:               "00-00000000000000000000000000000004-2222222222222222-01",
-			wantTracestatePropagation: false,
+			name:             "datadog-only",
+			propagationStyle: "datadog",
+			traceparent:      "00-00000000000000000000000000000004-2222222222222222-01",
 		},
 		{
 			/*
@@ -150,10 +149,9 @@ func TestTextMapExtractTracestatePropagation(t *testing.T) {
 				the tracestate header should be ignored and not propagated to
 				the returned trace context.
 			*/
-			name:                      "datadog-and-w3c-mismatching-ids",
-			propagationStyle:          "datadog,tracecontext",
-			traceparent:               "00-00000000000000000000000000000088-2222222222222222-01",
-			wantTracestatePropagation: false,
+			name:             "datadog-and-w3c-mismatching-ids",
+			propagationStyle: "datadog,tracecontext",
+			traceparent:      "00-00000000000000000000000000000088-2222222222222222-01",
 		},
 		{
 			/*
@@ -161,10 +159,9 @@ func TestTextMapExtractTracestatePropagation(t *testing.T) {
 				the tracestate header should be ignored and not propagated to
 				the returned trace context.
 			*/
-			name:                      "datadog-and-w3c-malformed",
-			propagationStyle:          "datadog,tracecontext",
-			traceparent:               "00-00000000000000000000000000000004-22asdf!2-01", // malformed
-			wantTracestatePropagation: false,
+			name:             "datadog-and-w3c-malformed",
+			propagationStyle: "datadog,tracecontext",
+			traceparent:      "00-00000000000000000000000000000004-22asdf!2-01", // malformed
 		},
 		{
 			/*
@@ -172,9 +169,8 @@ func TestTextMapExtractTracestatePropagation(t *testing.T) {
 				the tracestate header should be ignored and not propagated to
 				the returned trace context.
 			*/
-			name:                      "datadog-and-w3c-no-traceparent",
-			propagationStyle:          "datadog,tracecontext",
-			wantTracestatePropagation: false,
+			name:             "datadog-and-w3c-no-traceparent",
+			propagationStyle: "datadog,tracecontext",
 		},
 		{
 			/*
@@ -182,11 +178,10 @@ func TestTextMapExtractTracestatePropagation(t *testing.T) {
 				is true, the tracestate header should be ignored and not propagated to
 				the returned trace context.
 			*/
-			name:                      "datadog-and-w3c-only-extract-first",
-			propagationStyle:          "datadog,tracecontext",
-			traceparent:               "00-00000000000000000000000000000004-2222222222222222-01", // malformed
-			onlyExtractFirst:          true,
-			wantTracestatePropagation: false,
+			name:             "datadog-and-w3c-only-extract-first",
+			propagationStyle: "datadog,tracecontext",
+			traceparent:      "00-00000000000000000000000000000004-2222222222222222-01", // malformed
+			onlyExtractFirst: true,
 		},
 	}
 	for _, tc := range tests {
@@ -201,6 +196,7 @@ func TestTextMapExtractTracestatePropagation(t *testing.T) {
 			headers := TextMapCarrier(map[string]string{
 				DefaultTraceIDHeader:  "4",
 				DefaultParentIDHeader: "1",
+				originHeader:          "synthetics",
 				b3TraceIDHeader:       "0021dc1807524785",
 				traceparentHeader:     tc.traceparent,
 				tracestateHeader:      "dd=s:2;o:rum;t.tid:1230000000000000~~,othervendor=t61rcWkgMzE",
@@ -213,7 +209,7 @@ func TestTextMapExtractTracestatePropagation(t *testing.T) {
 			assert.Equal("00000000000000000000000000000004", sctx.traceID.HexEncoded())
 			assert.Equal(uint64(1), sctx.spanID)
 			if tc.wantTracestatePropagation {
-				assert.Equal("dd=s:2;o:rum;t.tid:1230000000000000~~,othervendor=t61rcWkgMzE", sctx.trace.propagatingTag(tracestateHeader))
+				assert.Equal("dd=s:0;o:synthetics,othervendor=t61rcWkgMzE", sctx.trace.propagatingTag(tracestateHeader))
 			} else if sctx.trace != nil {
 				assert.False(sctx.trace.hasPropagatingTag(tracestateHeader))
 			}

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -125,6 +125,17 @@ func TestTextMapExtractTracestatePropagation(t *testing.T) {
 		},
 		{
 			/*
+				With Datadog, B3, AND w3c propagation set, the tracestate header should
+				be propagated to the returned trace context. This test also verifies that
+				b3 extraction doesn't override the local context value.
+			*/
+			name:                      "datadog-b3-w3c",
+			propagationStyle:          "datadog,b3,tracecontext",
+			traceparent:               "00-00000000000000000000000000000004-2222222222222222-01",
+			wantTracestatePropagation: true,
+		},
+		{
+			/*
 				With Datadog AND w3c propagation set, the tracestate header should
 				be propagated to the returned trace context.
 			*/
@@ -180,6 +191,7 @@ func TestTextMapExtractTracestatePropagation(t *testing.T) {
 			headers := TextMapCarrier(map[string]string{
 				DefaultTraceIDHeader:  "4",
 				DefaultParentIDHeader: "1",
+				b3TraceIDHeader:       "0021dc1807524785",
 				traceparentHeader:     tc.traceparent,
 				tracestateHeader:      "dd=s:2;o:rum;t.tid:1230000000000000~~,othervendor=t61rcWkgMzE",
 			})


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Always forwards the `tracestate` from other vendors, regardless of whether the w3c trace context is during extraction.

Extraction will now iterate through the propagators in precedence order and for each propagator apply the following logic:

1. Attempt to extract a trace context from the incoming request headers. If there is no valid trace context, continue to the next propagator.
2. If this is the first propagator to extract a valid trace context, use this for the local trace context. Additionally, if the configuration is set to `DD_TRACE_PROPAGATION_EXTRACT_FIRST=true`, immediately return the local trace context as the result of the trace context extraction.
3. If this is not the first propagator to extract a valid span context (i.e. a local trace context has already been created), AND this is a W3C propagator:
  a. Verify that the  trace-id of the `traceparent` matches the trace-id of the local trace context
  b. Extract the `tracestate` header value and (if present) store the `tracestate` in the local trace context
  c. Note: Do not update any other trace context fields like sampling priority, propagated tags, or origin.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

This will improve the migration path for customers using a combination of different trace context propagation styles across multiple systems.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
AIT-8849