### PR TITLE
appsec: support server.response.headers.no_cookies WAF address

### DIFF
--- a/internal/appsec/dyngo/instrumentation/httpsec/http.go
+++ b/internal/appsec/dyngo/instrumentation/httpsec/http.go
@@ -51,7 +51,8 @@ type (
 	// HandlerOperationRes is the HTTP handler operation results.
 	HandlerOperationRes struct {
 		// Status corresponds to the address `server.response.status`.
-		Status int
+		Status  int
+		Headers map[string][]string
 	}
 
 	// SDKBodyOperationArgs is the SDK body operation arguments.
@@ -132,12 +133,7 @@ func WrapHandler(handler http.Handler, span ddtrace.Span, pathParams map[string]
 		r = r.WithContext(ctx)
 
 		defer func() {
-			var status int
-			if mw, ok := w.(interface{ Status() int }); ok {
-				status = mw.Status()
-			}
-
-			events := op.Finish(HandlerOperationRes{Status: status})
+			events := op.Finish(MakeHandlerOperationRes(w))
 
 			// Execute the onBlock functions to make sure blocking works properly
 			// in case we are instrumenting the Gin framework
@@ -173,16 +169,8 @@ func WrapHandler(handler http.Handler, span ddtrace.Span, pathParams map[string]
 
 // MakeHandlerOperationArgs creates the HandlerOperationArgs value.
 func MakeHandlerOperationArgs(r *http.Request, clientIP netip.Addr, pathParams map[string]string) HandlerOperationArgs {
-	headers := make(http.Header, len(r.Header))
-	for k, v := range r.Header {
-		k := strings.ToLower(k)
-		if k == "cookie" {
-			// Do not include cookies in the request headers
-			continue
-		}
-		headers[k] = v
-	}
 	cookies := makeCookies(r) // TODO(Julio-Guerra): avoid actively parsing the cookies thanks to dynamic instrumentation
+	headers := headersRemoveCookies(r.Header)
 	headers["host"] = []string{r.Host}
 	return HandlerOperationArgs{
 		Method:     r.Method,
@@ -201,7 +189,21 @@ func MakeHandlerOperationRes(w http.ResponseWriter) HandlerOperationRes {
 	if mw, ok := w.(interface{ Status() int }); ok {
 		status = mw.Status()
 	}
-	return HandlerOperationRes{Status: status}
+	return HandlerOperationRes{Status: status, Headers: headersRemoveCookies(w.Header())}
+}
+
+// Remove cookies from the request headers and return the map of headers
+// Used from `server.request.headers.no_cookies` and server.response.headers.no_cookies` addresses for the WAF
+func headersRemoveCookies(headers http.Header) map[string][]string {
+	headersNoCookies := make(http.Header, len(headers))
+	for k, v := range headers {
+		k := strings.ToLower(k)
+		if k == "cookie" {
+			continue
+		}
+		headersNoCookies[k] = v
+	}
+	return headersNoCookies
 }
 
 // Return the map of parsed cookies if any and following the specification of

--- a/internal/appsec/testdata/user_rules.json
+++ b/internal/appsec/testdata/user_rules.json
@@ -43,7 +43,33 @@
                                 "address": "server.request.query"
                             }
                         ],
-                        "regex": "^match$"
+                        "regex": "^match-request-query$"
+                    },
+                    "operator": "match_regex"
+                }
+            ],
+            "transformers": [],
+            "on_match": [
+                "block"
+            ]
+        },
+        {
+            "id": "headers-003",
+            "name": "query match",
+            "tags": {
+                "type": "security_scanner",
+                "category": "attack_attempt",
+                "confidence": "1"
+            },
+            "conditions": [
+                {
+                    "parameters": {
+                        "inputs": [
+                            {
+                                "address": "server.response.headers.no_cookies"
+                            }
+                        ],
+                        "regex": "match-response-header"
                     },
                     "operator": "match_regex"
                 }

--- a/internal/appsec/waf.go
+++ b/internal/appsec/waf.go
@@ -243,6 +243,10 @@ func newHTTPWAFEventListener(handle *wafHandle, addresses map[string]struct{}, t
 				values[serverResponseStatusAddr] = fmt.Sprintf("%d", res.Status)
 			}
 
+			if _, ok := addresses[serverResponseHeadersNoCookiesAddr]; ok && res.Headers != nil {
+				values[serverResponseHeadersNoCookiesAddr] = res.Headers
+			}
+
 			// Run the WAF, ignoring the returned actions - if any - since blocking after the request handler's
 			// response is not supported at the moment.
 			wafResult := runWAF(wafCtx, waf.RunAddressData{Persistent: values}, timeout)
@@ -391,16 +395,17 @@ func runWAF(wafCtx *waf.Context, values waf.RunAddressData, timeout time.Duratio
 
 // HTTP rule addresses currently supported by the WAF
 const (
-	serverRequestMethodAddr           = "server.request.method"
-	serverRequestRawURIAddr           = "server.request.uri.raw"
-	serverRequestHeadersNoCookiesAddr = "server.request.headers.no_cookies"
-	serverRequestCookiesAddr          = "server.request.cookies"
-	serverRequestQueryAddr            = "server.request.query"
-	serverRequestPathParamsAddr       = "server.request.path_params"
-	serverRequestBodyAddr             = "server.request.body"
-	serverResponseStatusAddr          = "server.response.status"
-	httpClientIPAddr                  = "http.client_ip"
-	userIDAddr                        = "usr.id"
+	serverRequestMethodAddr            = "server.request.method"
+	serverRequestRawURIAddr            = "server.request.uri.raw"
+	serverRequestHeadersNoCookiesAddr  = "server.request.headers.no_cookies"
+	serverRequestCookiesAddr           = "server.request.cookies"
+	serverRequestQueryAddr             = "server.request.query"
+	serverRequestPathParamsAddr        = "server.request.path_params"
+	serverRequestBodyAddr              = "server.request.body"
+	serverResponseStatusAddr           = "server.response.status"
+	serverResponseHeadersNoCookiesAddr = "server.response.headers.no_cookies"
+	httpClientIPAddr                   = "http.client_ip"
+	userIDAddr                         = "usr.id"
 )
 
 // List of HTTP rule addresses currently supported by the WAF
@@ -413,6 +418,7 @@ var httpAddresses = []string{
 	serverRequestPathParamsAddr,
 	serverRequestBodyAddr,
 	serverResponseStatusAddr,
+	serverResponseHeadersNoCookiesAddr,
 	httpClientIPAddr,
 	userIDAddr,
 }

--- a/internal/appsec/waf_test.go
+++ b/internal/appsec/waf_test.go
@@ -92,10 +92,12 @@ func TestUserRules(t *testing.T) {
 
 	// Start and trace an HTTP server
 	mux := httptrace.NewServeMux()
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("match-response-header", "match-response-header")
-		w.WriteHeader(200)
+	mux.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("Hello World!\n"))
+	})
+	mux.HandleFunc("/response-header", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("match-response-header", "match-response-header")
+		w.WriteHeader(204)
 	})
 
 	srv := httptest.NewServer(mux)
@@ -108,16 +110,17 @@ func TestUserRules(t *testing.T) {
 	}{
 		{
 			name: "custom-001",
+			url:  "/hello",
 			rule: "custom-001",
 		},
 		{
 			name: "custom-action",
-			url:  "?match=match-request-query",
+			url:  "/hello?match=match-request-query",
 			rule: "query-002",
 		},
 		{
 			name: "response-headers",
-			url:  "",
+			url:  "/response-header",
 			rule: "headers-003",
 		},
 	} {

--- a/internal/appsec/waf_test.go
+++ b/internal/appsec/waf_test.go
@@ -93,6 +93,8 @@ func TestUserRules(t *testing.T) {
 	// Start and trace an HTTP server
 	mux := httptrace.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("match-response-header", "match-response-header")
+		w.WriteHeader(200)
 		w.Write([]byte("Hello World!\n"))
 	})
 
@@ -110,8 +112,13 @@ func TestUserRules(t *testing.T) {
 		},
 		{
 			name: "custom-action",
-			url:  "?match=match",
+			url:  "?match=match-request-query",
 			rule: "query-002",
+		},
+		{
+			name: "response-headers",
+			url:  "",
+			rule: "headers-003",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Adds a field to `HandlerOperationRes` in `appsec/internal/dyngo/instrumentation/httpsec/http.go` for response headers and send them to the WAF in `appsec/internal/waf.go`

### Motivation

API Security is around the corner and we need to build support schemas for user responses. As such, two new addresses were created:
- `server.response.headers.no_cookies`
- `server.response.body`

This PR does half the job since the second address will be tricker to implement.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!