### PR TITLE
ddtrace/tracer: Switch default context propagation order

### DIFF
--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -245,26 +245,6 @@ jobs:
               go get google.golang.org/api@v0.121.0 # version used to generate code
               go mod tidy # Go1.16 doesn't update the sum file correctly after the go get, this tidy fixes it
               go test -v ./contrib/google.golang.org/api/...
-
-      - name: Testing outlier gRPC v1.2
-        if: inputs.ref != 'refs/heads/v2-dev'
-        run: |
-              # This hacky approach is necessary because running the tests regularly
-              # do not allow using grpc-go@v1.2.0 alongside sketches-go@v1.0.0
-              go mod vendor
-
-              # Checkout grpc-go@v1.2.0
-              cd vendor/google.golang.org && rm -rf grpc
-              git clone https://github.com/grpc/grpc-go grpc && cd grpc
-              git fetch origin && git checkout v1.2.0 && cd ../..
-
-              # Checkout sketches-go@v1.0.0
-              cd vendor/github.com/DataDog && rm -rf sketches-go
-              git clone https://github.com/DataDog/sketches-go && cd sketches-go
-              git fetch origin && git checkout v1.0.0 && cd ../..
-
-              go test -mod=vendor -v ./contrib/google.golang.org/grpc.v12/...
-
   test-core:
     runs-on:
       group: "APM Larger Runners"

--- a/ddtrace/opentelemetry/telemetry_test.go
+++ b/ddtrace/opentelemetry/telemetry_test.go
@@ -22,30 +22,30 @@ func TestTelemetry(t *testing.T) {
 		expectedExtract string
 	}{
 		{
-			// if nothing is set, DD_TRACE_PROPAGATION_STYLE will be set to tracecontext,datadog
-			expectedInject:  "tracecontext,datadog",
-			expectedExtract: "tracecontext,datadog",
+			// if nothing is set, DD_TRACE_PROPAGATION_STYLE will be set to datadog,tracecontext
+			expectedInject:  "datadog,tracecontext",
+			expectedExtract: "datadog,tracecontext",
 		},
 		{
 			env: map[string]string{
 				"DD_TRACE_PROPAGATION_STYLE_EXTRACT": "datadog",
 			},
-			expectedInject:  "tracecontext,datadog",
+			expectedInject:  "datadog,tracecontext",
 			expectedExtract: "datadog",
 		},
 		{
 			env: map[string]string{
 				"DD_TRACE_PROPAGATION_STYLE_EXTRACT": "none",
 			},
-			expectedInject:  "tracecontext,datadog",
+			expectedInject:  "datadog,tracecontext",
 			expectedExtract: "",
 		},
 		{
 			env: map[string]string{
-				"DD_TRACE_PROPAGATION_STYLE":         "tracecontext,datadog",
+				"DD_TRACE_PROPAGATION_STYLE":         "datadog,tracecontext",
 				"DD_TRACE_PROPAGATION_STYLE_EXTRACT": "none",
 			},
-			expectedInject:  "tracecontext,datadog",
+			expectedInject:  "datadog,tracecontext",
 			expectedExtract: "",
 		},
 		{
@@ -55,15 +55,15 @@ func TestTelemetry(t *testing.T) {
 				"DD_TRACE_PROPAGATION_STYLE_EXTRACT": "",
 			},
 			expectedInject:  "tracecontext",
-			expectedExtract: "tracecontext,datadog",
+			expectedExtract: "datadog,tracecontext",
 		},
 		{
 			env: map[string]string{
 				// deprecated environment variable
-				"DD_PROPAGATION_STYLE_INJECT":        "tracecontext,datadog",
+				"DD_PROPAGATION_STYLE_INJECT":        "datadog,tracecontext",
 				"DD_TRACE_PROPAGATION_STYLE_EXTRACT": "b3",
 			},
-			expectedInject:  "tracecontext,datadog",
+			expectedInject:  "datadog,tracecontext",
 			expectedExtract: "b3",
 		},
 	}

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -198,7 +198,7 @@ type chainedPropagator struct {
 func getPropagators(cfg *PropagatorConfig, ps string) ([]Propagator, string) {
 	dd := &propagator{cfg}
 	defaultPs := []Propagator{&propagatorW3c{}, dd}
-	defaultPsName := "tracecontext,datadog"
+	defaultPsName := "datadog,tracecontext"
 	if cfg.B3 {
 		defaultPs = append(defaultPs, &propagatorB3{})
 		defaultPsName += ",b3"

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -448,7 +448,7 @@ func TestTextMapPropagator(t *testing.T) {
 			xDatadogTagsHeader: "_dd.p.dm=-1,_dd.p.hello1=world",
 		}, {
 			name:               "Tracestate-Datadog",
-			injectStyle:        "tracecontext,datadog",
+			injectStyle:        "datadog,tracecontext",
 			tags:               map[string]string{"_dd.p.hello1": "world", tracestateHeader: "shouldbe=kept"},
 			xDatadogTagsHeader: "_dd.p.dm=-1,_dd.p.hello1=world",
 		},
@@ -1595,7 +1595,7 @@ func TestEnvVars(t *testing.T) {
 	})
 
 	t.Run("datadog extract / w3c,datadog inject", func(t *testing.T) {
-		t.Setenv(headerPropagationStyleInject, "tracecontext,datadog")
+		t.Setenv(headerPropagationStyleInject, "datadog,tracecontext")
 		t.Setenv(headerPropagationStyleExtract, "datadog")
 		var tests = []struct {
 			outHeaders TextMapCarrier


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR switch default context propagation order from `tracecontext,datadog` to datadog,tracecontext
System test change: https://github.com/DataDog/system-tests/pull/1853

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!