### PR TITLE
tracer: report config-change telemetry in dynamic config

### DIFF
--- a/ddtrace/tracer/dynamic_config.go
+++ b/ddtrace/tracer/dynamic_config.go
@@ -7,6 +7,8 @@ package tracer
 
 import (
 	"sync"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 )
 
 // dynamicConfig is a thread-safe generic data structure to represent configuration fields.
@@ -14,47 +16,80 @@ import (
 // This structure will be extended to track the origin of configuration values as well (e.g remote_config, env_var).
 type dynamicConfig[T any] struct {
 	sync.RWMutex
-	current T       // holds the current configuration value
-	startup T       // holds the startup configuration value
-	apply   func(T) // applies a configuration value
-	isReset bool    // internal boolean to avoid unnecessary resets
+	current   T                 // holds the current configuration value
+	startup   T                 // holds the startup configuration value
+	cfgName   string            // holds the name of the configuration, has to be compatible with telemetry.Configuration.Name
+	cfgOrigin string            // holds the origin of the current configuration value (currently only supports remote_config, empty otherwise)
+	apply     func(T) bool      // applies a configuration value
+	equal     func(x, y T) bool // compares two configuration values
 }
 
-func newDynamicConfig[T any](val T, apply func(T)) dynamicConfig[T] {
+func newDynamicConfig[T any](name string, val T, apply func(T) bool, equal func(x, y T) bool) dynamicConfig[T] {
 	return dynamicConfig[T]{
+		cfgName: name,
 		current: val,
 		startup: val,
 		apply:   apply,
-		isReset: true,
+		equal:   equal,
 	}
 }
 
 // update applies a new configuration value
-func (dc *dynamicConfig[T]) update(val T) {
+func (dc *dynamicConfig[T]) update(val T, origin string) bool {
 	dc.Lock()
 	defer dc.Unlock()
+	if dc.equal(dc.current, val) {
+		return false
+	}
 	dc.current = val
-	dc.apply(val)
-	dc.isReset = false
+	dc.cfgOrigin = origin
+	return dc.apply(val)
 }
 
 // reset re-applies the startup configuration value
-func (dc *dynamicConfig[T]) reset() {
+func (dc *dynamicConfig[T]) reset() bool {
 	dc.Lock()
 	defer dc.Unlock()
-	if dc.isReset {
-		return
+	if dc.equal(dc.current, dc.startup) {
+		return false
 	}
 	dc.current = dc.startup
-	dc.apply(dc.startup)
-	dc.isReset = true
+	dc.cfgOrigin = ""
+	return dc.apply(dc.startup)
 }
 
 // handleRC processes a new configuration value from remote config
-func (dc *dynamicConfig[T]) handleRC(val *T) {
+// Returns whether the configuration value has been updated or not
+func (dc *dynamicConfig[T]) handleRC(val *T) bool {
 	if val != nil {
-		dc.update(*val)
-		return
+		return dc.update(*val, "remote_config")
 	}
-	dc.reset()
+	return dc.reset()
+}
+
+// telemetry returns the current configuration value as telemetry.Configuration
+func (dc *dynamicConfig[T]) telemetry() telemetry.Configuration {
+	dc.RLock()
+	defer dc.RUnlock()
+	return telemetry.Configuration{
+		Name:   dc.cfgName,
+		Value:  dc.current,
+		Origin: dc.cfgOrigin,
+	}
+}
+
+func equal[T comparable](x, y T) bool {
+	return x == y
+}
+
+func equalSlice[T comparable](x, y []T) bool {
+	if len(x) != len(y) {
+		return false
+	}
+	for i, v := range x {
+		if v != y[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/ddtrace/tracer/dynamic_config.go
+++ b/ddtrace/tracer/dynamic_config.go
@@ -71,11 +71,11 @@ func (dc *dynamicConfig[T]) handleRC(val *T) bool {
 func (dc *dynamicConfig[T]) telemetry() telemetry.Configuration {
 	dc.RLock()
 	defer dc.RUnlock()
-	return telemetry.Configuration{
+	return telemetry.Sanitize(telemetry.Configuration{
 		Name:   dc.cfgName,
 		Value:  dc.current,
 		Origin: dc.cfgOrigin,
-	}
+	})
 }
 
 func equal[T comparable](x, y T) bool {

--- a/ddtrace/tracer/dynamic_config.go
+++ b/ddtrace/tracer/dynamic_config.go
@@ -82,6 +82,8 @@ func equal[T comparable](x, y T) bool {
 	return x == y
 }
 
+// equalSlice compares two slices of comparable values
+// The comparison takes into account the order of the elements
 func equalSlice[T comparable](x, y []T) bool {
 	if len(x) != len(y) {
 		return false

--- a/ddtrace/tracer/dynamic_config.go
+++ b/ddtrace/tracer/dynamic_config.go
@@ -67,8 +67,8 @@ func (dc *dynamicConfig[T]) handleRC(val *T) bool {
 	return dc.reset()
 }
 
-// telemetry returns the current configuration value as telemetry.Configuration
-func (dc *dynamicConfig[T]) telemetry() telemetry.Configuration {
+// toTelemetry returns the current configuration value as telemetry.Configuration
+func (dc *dynamicConfig[T]) toTelemetry() telemetry.Configuration {
 	dc.RLock()
 	defer dc.RUnlock()
 	return telemetry.Sanitize(telemetry.Configuration{

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -322,7 +322,7 @@ func newConfig(opts ...StartOption) *config {
 	if v := os.Getenv("DD_SERVICE_MAPPING"); v != "" {
 		internal.ForEachStringTag(v, func(key, val string) { WithServiceMapping(key, val)(c) })
 	}
-	c.headerAsTags = newDynamicConfig(nil, setHeaderTags)
+	c.headerAsTags = newDynamicConfig("trace_header_tags", nil, setHeaderTags, equalSlice[string])
 	if v := os.Getenv("DD_TRACE_HEADER_TAGS"); v != "" {
 		WithHeaderTags(strings.Split(v, ","))(c)
 	}
@@ -1219,12 +1219,14 @@ func StackFrames(n, skip uint) FinishOption {
 // Special headers can not be sub-selected. E.g., an entire Cookie header would be transmitted, without the ability to choose specific Cookies.
 func WithHeaderTags(headerAsTags []string) StartOption {
 	return func(c *config) {
-		c.headerAsTags = newDynamicConfig(headerAsTags, setHeaderTags)
+		c.headerAsTags = newDynamicConfig("trace_header_tags", headerAsTags, setHeaderTags, equalSlice[string])
 		setHeaderTags(headerAsTags)
 	}
 }
 
-func setHeaderTags(headerAsTags []string) {
+// setHeaderTags sets the global header tags.
+// Always resets the global value and returns true.
+func setHeaderTags(headerAsTags []string) bool {
 	globalconfig.ClearHeaderTags()
 	for _, h := range headerAsTags {
 		if strings.HasPrefix(h, "x-datadog-") {
@@ -1233,6 +1235,7 @@ func setHeaderTags(headerAsTags []string) {
 		header, tag := normalizer.HeaderTag(h)
 		globalconfig.SetHeaderTag(header, tag)
 	}
+	return true
 }
 
 // UserMonitoringConfig is used to configure what is used to identify a user.

--- a/ddtrace/tracer/remote_config.go
+++ b/ddtrace/tracer/remote_config.go
@@ -80,7 +80,7 @@ func (t *tracer) onRemoteConfigUpdate(updates map[string]remoteconfig.ProductUpd
 		statuses[path] = state.ApplyStatus{State: state.ApplyStateAcknowledged}
 		updated := t.config.traceSampleRate.handleRC(c.LibConfig.SamplingRate)
 		if updated {
-			telemConfigs = append(telemConfigs, telemetry.Sanitize(t.config.traceSampleRate.telemetry()))
+			telemConfigs = append(telemConfigs, t.config.traceSampleRate.telemetry())
 		}
 		updated = t.config.headerAsTags.handleRC(c.LibConfig.HeaderTags.toSlice())
 		if updated {

--- a/ddtrace/tracer/remote_config.go
+++ b/ddtrace/tracer/remote_config.go
@@ -80,11 +80,11 @@ func (t *tracer) onRemoteConfigUpdate(updates map[string]remoteconfig.ProductUpd
 		statuses[path] = state.ApplyStatus{State: state.ApplyStateAcknowledged}
 		updated := t.config.traceSampleRate.handleRC(c.LibConfig.SamplingRate)
 		if updated {
-			telemConfigs = append(telemConfigs, t.config.traceSampleRate.telemetry())
+			telemConfigs = append(telemConfigs, t.config.traceSampleRate.toTelemetry())
 		}
 		updated = t.config.headerAsTags.handleRC(c.LibConfig.HeaderTags.toSlice())
 		if updated {
-			telemConfigs = append(telemConfigs, t.config.headerAsTags.telemetry())
+			telemConfigs = append(telemConfigs, t.config.headerAsTags.toTelemetry())
 		}
 	}
 	if len(telemConfigs) > 0 {

--- a/ddtrace/tracer/remote_config_test.go
+++ b/ddtrace/tracer/remote_config_test.go
@@ -10,6 +10,8 @@ import (
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/remoteconfig"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/telemetrytest"
 
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/stretchr/testify/require"
@@ -17,6 +19,9 @@ import (
 
 func TestOnRemoteConfigUpdate(t *testing.T) {
 	t.Run("RC sampling rate = 0.5 is applied and can be reverted", func(t *testing.T) {
+		telemetryClient := new(telemetrytest.MockClient)
+		defer telemetry.MockGlobalClient(telemetryClient)()
+
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
 
@@ -30,6 +35,10 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		s.Finish()
 		require.Equal(t, 0.5, s.Metrics[keyRulesSamplerAppliedRate])
 
+		// Telemetry
+		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 1)
+		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_sample_rate", Value: 0.5, Origin: "remote_config"}})
+
 		// Unset RC. Assert _dd.rule_psr is not set
 		input["APM_TRACING"] = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}}`)}
 		applyStatus = tracer.onRemoteConfigUpdate(input)
@@ -37,9 +46,17 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		s = tracer.StartSpan("web.request").(*span)
 		s.Finish()
 		require.NotContains(t, keyRulesSamplerAppliedRate, s.Metrics)
+
+		// Telemetry
+		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 2)
+		// Not calling AssertCalled because the configuration contains a math.NaN()
+		// as value which cannot be asserted see https://github.com/stretchr/testify/issues/624
 	})
 
 	t.Run("DD_TRACE_SAMPLE_RATE=0.1 and RC sampling rate = 0.2", func(t *testing.T) {
+		telemetryClient := new(telemetrytest.MockClient)
+		defer telemetry.MockGlobalClient(telemetryClient)()
+
 		t.Setenv("DD_TRACE_SAMPLE_RATE", "0.1")
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
@@ -54,6 +71,10 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		s.Finish()
 		require.Equal(t, 0.2, s.Metrics[keyRulesSamplerAppliedRate])
 
+		// Telemetry
+		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 1)
+		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_sample_rate", Value: 0.2, Origin: "remote_config"}})
+
 		// Unset RC. Assert _dd.rule_psr shows the previous sampling rate (0.1) is applied
 		input["APM_TRACING"] = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}}`)}
 		applyStatus = tracer.onRemoteConfigUpdate(input)
@@ -61,9 +82,16 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		s = tracer.StartSpan("web.request").(*span)
 		s.Finish()
 		require.Equal(t, 0.1, s.Metrics[keyRulesSamplerAppliedRate])
+
+		// Telemetry
+		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 2)
+		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_sample_rate", Value: 0.1, Origin: ""}})
 	})
 
 	t.Run("RC header tags = X-Test-Header:my-tag-name is applied and can be reverted", func(t *testing.T) {
+		telemetryClient := new(telemetrytest.MockClient)
+		defer telemetry.MockGlobalClient(telemetryClient)()
+
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
 
@@ -76,14 +104,25 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.Equal(t, 1, globalconfig.HeaderTagsLen())
 		require.Equal(t, "my-tag-name", globalconfig.HeaderTag("X-Test-Header"))
 
+		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 1)
+		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: []string{"X-Test-Header:my-tag-name"}, Origin: "remote_config"}})
+
 		// Unset RC. Assert header tags are not set
 		input["APM_TRACING"] = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}}`)}
 		applyStatus = tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
 		require.Equal(t, 0, globalconfig.HeaderTagsLen())
+
+		// Telemetry
+		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 2)
+		var val []string
+		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: val, Origin: ""}})
 	})
 
 	t.Run("DD_TRACE_HEADER_TAGS=X-Test-Header:my-tag-name-from-env and RC header tags = X-Test-Header:my-tag-name-from-rc", func(t *testing.T) {
+		telemetryClient := new(telemetrytest.MockClient)
+		defer telemetry.MockGlobalClient(telemetryClient)()
+
 		t.Setenv("DD_TRACE_HEADER_TAGS", "X-Test-Header:my-tag-name-from-env")
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
@@ -97,15 +136,26 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.Equal(t, 1, globalconfig.HeaderTagsLen())
 		require.Equal(t, "my-tag-name-from-rc", globalconfig.HeaderTag("X-Test-Header"))
 
+		// Telemetry
+		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 1)
+		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: []string{"X-Test-Header:my-tag-name-from-rc"}, Origin: "remote_config"}})
+
 		// Unset RC. Assert global config shows the DD_TRACE_HEADER_TAGS header tag
 		input["APM_TRACING"] = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}}`)}
 		applyStatus = tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
 		require.Equal(t, 1, globalconfig.HeaderTagsLen())
 		require.Equal(t, "my-tag-name-from-env", globalconfig.HeaderTag("X-Test-Header"))
+
+		// Telemetry
+		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 2)
+		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: []string{"X-Test-Header:my-tag-name-from-env"}, Origin: ""}})
 	})
 
 	t.Run("In code header tags = X-Test-Header:my-tag-name-in-code and RC header tags = X-Test-Header:my-tag-name-from-rc", func(t *testing.T) {
+		telemetryClient := new(telemetrytest.MockClient)
+		defer telemetry.MockGlobalClient(telemetryClient)()
+
 		tracer, _, _, stop := startTestTracer(t, WithHeaderTags([]string{"X-Test-Header:my-tag-name-in-code"}))
 		defer stop()
 
@@ -118,15 +168,26 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.Equal(t, 1, globalconfig.HeaderTagsLen())
 		require.Equal(t, "my-tag-name-from-rc", globalconfig.HeaderTag("X-Test-Header"))
 
+		// Telemetry
+		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 1)
+		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: []string{"X-Test-Header:my-tag-name-from-rc"}, Origin: "remote_config"}})
+
 		// Unset RC. Assert global config shows the in-code header tag
 		input["APM_TRACING"] = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}}`)}
 		applyStatus = tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
 		require.Equal(t, 1, globalconfig.HeaderTagsLen())
 		require.Equal(t, "my-tag-name-in-code", globalconfig.HeaderTag("X-Test-Header"))
+
+		// Telemetry
+		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 2)
+		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: []string{"X-Test-Header:my-tag-name-in-code"}, Origin: ""}})
 	})
 
 	t.Run("Invalid payload", func(t *testing.T) {
+		telemetryClient := new(telemetrytest.MockClient)
+		defer telemetry.MockGlobalClient(telemetryClient)()
+
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
 
@@ -136,5 +197,8 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		applyStatus := tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateError, applyStatus["path"].State)
 		require.NotEmpty(t, applyStatus["path"].Error)
+
+		// Telemetry
+		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 0)
 	})
 }

--- a/ddtrace/tracer/remote_config_test.go
+++ b/ddtrace/tracer/remote_config_test.go
@@ -105,7 +105,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.Equal(t, "my-tag-name", globalconfig.HeaderTag("X-Test-Header"))
 
 		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 1)
-		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: []string{"X-Test-Header:my-tag-name"}, Origin: "remote_config"}})
+		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name", Origin: "remote_config"}})
 
 		// Unset RC. Assert header tags are not set
 		input["APM_TRACING"] = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}}`)}
@@ -115,8 +115,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 
 		// Telemetry
 		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 2)
-		var val []string
-		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: val, Origin: ""}})
+		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: "", Origin: ""}})
 	})
 
 	t.Run("DD_TRACE_HEADER_TAGS=X-Test-Header:my-tag-name-from-env and RC header tags = X-Test-Header:my-tag-name-from-rc", func(t *testing.T) {
@@ -138,7 +137,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 
 		// Telemetry
 		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 1)
-		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: []string{"X-Test-Header:my-tag-name-from-rc"}, Origin: "remote_config"}})
+		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name-from-rc", Origin: "remote_config"}})
 
 		// Unset RC. Assert global config shows the DD_TRACE_HEADER_TAGS header tag
 		input["APM_TRACING"] = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}}`)}
@@ -149,7 +148,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 
 		// Telemetry
 		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 2)
-		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: []string{"X-Test-Header:my-tag-name-from-env"}, Origin: ""}})
+		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name-from-env", Origin: ""}})
 	})
 
 	t.Run("In code header tags = X-Test-Header:my-tag-name-in-code and RC header tags = X-Test-Header:my-tag-name-from-rc", func(t *testing.T) {
@@ -170,7 +169,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 
 		// Telemetry
 		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 1)
-		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: []string{"X-Test-Header:my-tag-name-from-rc"}, Origin: "remote_config"}})
+		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name-from-rc", Origin: "remote_config"}})
 
 		// Unset RC. Assert global config shows the in-code header tag
 		input["APM_TRACING"] = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}}`)}
@@ -181,7 +180,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 
 		// Telemetry
 		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 2)
-		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: []string{"X-Test-Header:my-tag-name-in-code"}, Origin: ""}})
+		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name-in-code", Origin: ""}})
 	})
 
 	t.Run("Invalid payload", func(t *testing.T) {

--- a/ddtrace/tracer/rules_sampler.go
+++ b/ddtrace/tracer/rules_sampler.go
@@ -241,14 +241,23 @@ func (rs *traceRulesSampler) enabled() bool {
 	return len(rs.rules) > 0 || !math.IsNaN(rs.globalRate)
 }
 
-func (rs *traceRulesSampler) setGlobalSampleRate(rate float64) {
+// setGlobalSampleRate sets the global sample rate to the given value.
+// Returns whether the value was changed or not.
+func (rs *traceRulesSampler) setGlobalSampleRate(rate float64) bool {
 	if rate < 0.0 || rate > 1.0 {
 		log.Warn("Ignoring trace sample rate %f: value out of range [0,1]", rate)
-		return
+		return false
 	}
 	rs.m.Lock()
 	defer rs.m.Unlock()
+	if math.IsNaN(rs.globalRate) && math.IsNaN(rate) {
+		return false
+	}
+	if rs.globalRate == rate {
+		return false
+	}
 	rs.globalRate = rate
+	return true
 }
 
 // apply uses the sampling rules to determine the sampling rate for the

--- a/ddtrace/tracer/rules_sampler.go
+++ b/ddtrace/tracer/rules_sampler.go
@@ -251,6 +251,8 @@ func (rs *traceRulesSampler) setGlobalSampleRate(rate float64) bool {
 	rs.m.Lock()
 	defer rs.m.Unlock()
 	if math.IsNaN(rs.globalRate) && math.IsNaN(rate) {
+		// NaN is not considered equal to any number, including itself.
+		// It should be compared with math.IsNaN
 		return false
 	}
 	if rs.globalRate == rate {

--- a/ddtrace/tracer/sampler_test.go
+++ b/ddtrace/tracer/sampler_test.go
@@ -1004,18 +1004,26 @@ func BenchmarkGlobMatchSpan(b *testing.B) {
 }
 
 func TestSetGlobalSampleRate(t *testing.T) {
-	rs := newTraceRulesSampler([]SamplingRule{ServiceRule("test-service", 1.0)}, 1.0)
-	assert.Equal(t, 1.0, rs.globalRate)
+	rs := newTraceRulesSampler(nil, math.NaN())
+	assert.True(t, math.IsNaN(rs.globalRate))
+
+	// Comparing NaN values
+	b := rs.setGlobalSampleRate(math.NaN())
+	assert.True(t, math.IsNaN(rs.globalRate))
+	assert.False(t, b)
 
 	// valid
-	rs.setGlobalSampleRate(0.5)
+	b = rs.setGlobalSampleRate(0.5)
 	assert.Equal(t, 0.5, rs.globalRate)
+	assert.True(t, b)
 
 	// valid
-	rs.setGlobalSampleRate(0.0)
+	b = rs.setGlobalSampleRate(0.0)
 	assert.Equal(t, 0.0, rs.globalRate)
+	assert.True(t, b)
 
 	// ignore out of bound value
-	rs.setGlobalSampleRate(2)
+	b = rs.setGlobalSampleRate(2)
 	assert.Equal(t, 0.0, rs.globalRate)
+	assert.False(t, b)
 }

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -55,8 +55,8 @@ func startTelemetry(c *config) {
 		{Name: "trace_span_attribute_schema", Value: c.spanAttributeSchemaVersion},
 		{Name: "trace_peer_service_defaults_enabled", Value: c.peerServiceDefaultsEnabled},
 		{Name: "orchestrion_enabled", Value: c.orchestrionCfg.Enabled},
-		{Name: c.traceSampleRate.name(), Value: c.traceSampleRate.value(), Origin: c.traceSampleRate.origin()},
-		{Name: c.headerAsTags.name(), Value: c.headerAsTags.value(), Origin: c.headerAsTags.origin()},
+		c.traceSampleRate.telemetry(),
+		c.headerAsTags.telemetry(),
 	}
 	var peerServiceMapping []string
 	for key, value := range c.peerServiceMappings {

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -55,8 +55,8 @@ func startTelemetry(c *config) {
 		{Name: "trace_span_attribute_schema", Value: c.spanAttributeSchemaVersion},
 		{Name: "trace_peer_service_defaults_enabled", Value: c.peerServiceDefaultsEnabled},
 		{Name: "orchestrion_enabled", Value: c.orchestrionCfg.Enabled},
-		c.traceSampleRate.telemetry(),
-		c.headerAsTags.telemetry(),
+		c.traceSampleRate.toTelemetry(),
+		c.headerAsTags.toTelemetry(),
 	}
 	var peerServiceMapping []string
 	for key, value := range c.peerServiceMappings {

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -55,6 +55,8 @@ func startTelemetry(c *config) {
 		{Name: "trace_span_attribute_schema", Value: c.spanAttributeSchemaVersion},
 		{Name: "trace_peer_service_defaults_enabled", Value: c.peerServiceDefaultsEnabled},
 		{Name: "orchestrion_enabled", Value: c.orchestrionCfg.Enabled},
+		{Name: c.traceSampleRate.name(), Value: c.traceSampleRate.value(), Origin: c.traceSampleRate.origin()},
+		{Name: c.headerAsTags.name(), Value: c.headerAsTags.value(), Origin: c.headerAsTags.origin()},
 	}
 	var peerServiceMapping []string
 	for key, value := range c.peerServiceMappings {

--- a/ddtrace/tracer/telemetry_test.go
+++ b/ddtrace/tracer/telemetry_test.go
@@ -28,6 +28,7 @@ func TestTelemetryEnabled(t *testing.T) {
 			WithRuntimeMetrics(),
 			WithPeerServiceMapping("key", "val"),
 			WithPeerServiceDefaults(true),
+			WithHeaderTags([]string{"key:val", "key2:val2"}),
 		)
 		defer globalconfig.SetServiceName("")
 		defer Stop()
@@ -44,6 +45,8 @@ func TestTelemetryEnabled(t *testing.T) {
 		telemetry.Check(t, telemetryClient.Configuration, "trace_peer_service_defaults_enabled", true)
 		telemetry.Check(t, telemetryClient.Configuration, "trace_peer_service_mapping", "key:val")
 		telemetry.Check(t, telemetryClient.Configuration, "orchestrion_enabled", false)
+		telemetry.Check(t, telemetryClient.Configuration, "trace_sample_rate", nil) // default value is NaN which is sanitized to nil
+		telemetry.Check(t, telemetryClient.Configuration, "trace_header_tags", "key:val,key2:val2")
 		if metrics, ok := telemetryClient.Metrics[telemetry.NamespaceGeneral]; ok {
 			if initTime, ok := metrics["init_time"]; ok {
 				assert.True(t, initTime > 0)

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -245,7 +245,7 @@ func newUnstartedTracer(opts ...StartOption) *tracer {
 	}
 	globalRate := globalSampleRate()
 	rulesSampler := newRulesSampler(c.traceRules, c.spanRules, globalRate)
-	c.traceSampleRate = newDynamicConfig(globalRate, rulesSampler.traces.setGlobalSampleRate)
+	c.traceSampleRate = newDynamicConfig("trace_sample_rate", globalRate, rulesSampler.traces.setGlobalSampleRate, equal[float64])
 	var dataStreamsProcessor *datastreams.Processor
 	if c.dataStreamsMonitoringEnabled {
 		dataStreamsProcessor = datastreams.NewProcessor(statsd, c.env, c.serviceName, c.version, c.agentURL, c.httpClient, func() bool {

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -32,6 +32,7 @@ import (
 // agent).
 type Client interface {
 	ProductStart(namespace Namespace, configuration []Configuration)
+	ConfigChange(configuration []Configuration)
 	Record(namespace Namespace, metric MetricKind, name string, value float64, tags []string, common bool)
 	Count(namespace Namespace, name string, value float64, tags []string, common bool)
 	ApplyOps(opts ...Option)

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -42,6 +42,13 @@ func (c *client) ProductStart(namespace Namespace, configuration []Configuration
 	}
 }
 
+// ConfigChange is a thread-safe method to enqueue an app-client-configuration-change event.
+func (c *client) ConfigChange(configuration []Configuration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.configChange(configuration)
+}
+
 // configChange enqueues an app-client-configuration-change event to be flushed.
 // Must be called with c.mu locked.
 func (c *client) configChange(configuration []Configuration) {

--- a/internal/telemetry/telemetrytest/telemetrytest.go
+++ b/internal/telemetry/telemetrytest/telemetrytest.go
@@ -94,3 +94,9 @@ func (c *MockClient) ApplyOps(args ...telemetry.Option) {
 	c.On("ApplyOps", args).Return()
 	_ = c.Called(args)
 }
+
+// ConfigChange is a mock for the ConfigChange method.
+func (c *MockClient) ConfigChange(args []telemetry.Configuration) {
+	c.On("ConfigChange", args).Return()
+	_ = c.Called(args)
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

AIT-8580

Report configuration changes applied via dynamic configuration. This required some refactoring of the current dynamicConfig implementation with an intent to keep it as generic as possible.
More logic was added to avoid unnecessary reconfigurations and unnecessary (or inaccurate) config change telemetry events in case of an attempt to reconfigure the same value.

This what an example payload looks like
```
{"api_version":"v2","request_type":"app-client-configuration-change","tracer_time":1699955789,"runtime_id":"9d6b96e5-6d6f-4d33-92e8-756b31d69776","seq_id":3,"debug":false,"payload":{"configuration":[{"name":"trace_sample_rate","value":0.7,"origin":"remote_config","error":{"code":0,"message":""},"is_overridden":false}]},"application":{"service_name":"my.go.service","env":"staging","service_version":"v1","tracer_version":"v1.57.0-dev","language_name":"go","language_version":"go1.20.5","runtime_name":"","runtime_version":""},"host":{"hostname":"REDACTED","os":"darwin","os_version":"13.6","architecture":"arm64","kernel_name":"","kernel_release":"","kernel_version":""}}
```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation


Bette UX for dynamic config: the reported active configuration will be shown on the UI.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!