### PR TITLE
.github/workflows: improve nightly v2 CI workflows

### DIFF
--- a/.github/workflows/multios-unit-tests.yml
+++ b/.github/workflows/multios-unit-tests.yml
@@ -21,6 +21,10 @@ on:
       runs-on:
         required: true
         type: string
+      ref:
+        description: 'The branch to run the workflow on'
+        required: true
+        type: string
 
 jobs:
   test-multi-os:

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Patch dd-trace-go version
         run: |
           cd utils/build/docker/golang/parametric/
-          echo "replace gopkg.in/DataDog/dd-trace-go.v1 => ./dd-trace-go" >> go.mod
+          echo "replace github.com/DataDog/dd-trace-go/v2 => ./dd-trace-go" >> go.mod
           go mod tidy
 
       - name: Build runner

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -45,6 +45,14 @@ jobs:
           go-version: "1.19"
 
       - name: Patch dd-trace-go version
+        if: inputs.ref != 'refs/heads/v2-dev'
+        run: |
+          cd utils/build/docker/golang/parametric/
+          echo "replace gopkg.in/DataDog/dd-trace-go.v1 => ./dd-trace-go" >> go.mod
+          go mod tidy
+
+      - name: Patch dd-trace-go version (v2)
+        if: inputs.ref == 'refs/heads/v2-dev'
         run: |
           cd utils/build/docker/golang/parametric/
           echo "replace github.com/DataDog/dd-trace-go/v2 => ./dd-trace-go" >> go.mod

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           cd utils/build/docker/golang/app
           find -type f -name '*.go' -exec sed -i 's#gopkg.in/DataDog/dd-trace-go.v1#github.com/DataDog/dd-trace-go/v2#g' {} \;
-          echo "replace github.com/DataDog/dd-trace-go/v2 => ../../../../binaries/dd-trace-go" >> go.mod
+          echo "replace github.com/DataDog/dd-trace-go/v2 => /home/runner/work/dd-trace-go/dd-trace-go/binaries/dd-trace-go" >> go.mod
           go mod tidy
 
       - name: Build weblog

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -107,6 +107,13 @@ jobs:
           ref: ${{ inputs.branch_ref || github.ref }}
           path: 'binaries/dd-trace-go'
 
+      - name: Patch dd-trace-go version
+        if: ${{ inputs.branch_ref == 'refs/heads/v2-dev' }}
+        run: |
+          cd utils/build/docker/golang/app
+          echo "replace github.com/DataDog/dd-trace-go/v2 => ../../../../binaries/dd-trace-go" >> go.mod
+          go mod tidy
+
       - name: Build weblog
         run: ./build.sh -i weblog
 

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -3,7 +3,7 @@ name: System Tests
 on:
   workflow_call: # allows to reuse this workflow
     inputs:
-      wfc_ref:
+      branch_ref:
         description: 'The branch to run the workflow on'
         required: true
         type: string
@@ -19,7 +19,7 @@ on:
   merge_group:
   workflow_dispatch:
       inputs:
-          wfd_ref:
+          ref:
               description: 'System Tests ref/tag/branch'
               required: true
               default: main
@@ -99,12 +99,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'DataDog/system-tests'
-          ref: ${{ inputs.wfc_ref || inputs.wfd_ref }}
+          ref: ${{ inputs.ref }}
 
       - name: Checkout dd-trace-go
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ inputs.branch_ref || github.ref }}
           path: 'binaries/dd-trace-go'
 
       - name: Build weblog

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -111,6 +111,7 @@ jobs:
         if: ${{ inputs.branch_ref == 'refs/heads/v2-dev' }}
         run: |
           cd utils/build/docker/golang/app
+          find -type f -name '*.go' -exec sed -i 's#gopkg.in/DataDog/dd-trace-go.v1#github.com/DataDog/dd-trace-go/v2#g' {} \;
           echo "replace github.com/DataDog/dd-trace-go/v2 => ../../../../binaries/dd-trace-go" >> go.mod
           go mod tidy
 

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -247,6 +247,7 @@ jobs:
               go test -v ./contrib/google.golang.org/api/...
 
       - name: Testing outlier gRPC v1.2
+        if: inputs.ref != 'refs/heads/v2-dev'
         run: |
               # This hacky approach is necessary because running the tests regularly
               # do not allow using grpc-go@v1.2.0 alongside sketches-go@v1.0.0

--- a/.github/workflows/v2-nightly.yml
+++ b/.github/workflows/v2-nightly.yml
@@ -38,7 +38,7 @@ jobs:
     uses: ./.github/workflows/system-tests.yml
     secrets: inherit
     with:
-      ref: refs/heads/v2-dev
+      branch_ref: refs/heads/v2-dev
 
   test-apps-v2:
     uses: ./.github/workflows/test-apps.yml

--- a/.github/workflows/v2-nightly.yml
+++ b/.github/workflows/v2-nightly.yml
@@ -8,40 +8,40 @@ jobs:
     uses: ./.github/workflows/appsec.yml
     secrets: inherit
     with:
-      ref: refs/remotes/origin/v2-dev
+      ref: refs/heads/v2-dev
 
   codeql-v2:
     uses: ./.github/workflows/codeql-analysis.yml
     secrets: inherit
     with:
-      ref: refs/remotes/origin/v2-dev
+      ref: refs/heads/v2-dev
 
   govulncheck-v2:
     uses: ./.github/workflows/govulncheck.yml
     secrets: inherit
     with:
-      ref: refs/remotes/origin/v2-dev
+      ref: refs/heads/v2-dev
 
   parametric-v2:
     uses: ./.github/workflows/parametric-tests.yml
     secrets: inherit
     with:
-      ref: refs/remotes/origin/v2-dev
+      ref: refs/heads/v2-dev
 
   smoke-v2:
     uses: ./.github/workflows/smoke-tests.yml
     secrets: inherit
     with:
-      ref: refs/remotes/origin/v2-dev
+      ref: refs/heads/v2-dev
 
   system-v2:
     uses: ./.github/workflows/system-tests.yml
     secrets: inherit
     with:
-      branch_ref: refs/remotes/origin/v2-dev
+      branch_ref: refs/heads/v2-dev
 
   test-apps-v2:
     uses: ./.github/workflows/test-apps.yml
     secrets: inherit
     with:
-      ref: refs/remotes/origin/v2-dev
+      ref: refs/heads/v2-dev

--- a/.github/workflows/v2-nightly.yml
+++ b/.github/workflows/v2-nightly.yml
@@ -8,40 +8,40 @@ jobs:
     uses: ./.github/workflows/appsec.yml
     secrets: inherit
     with:
-      ref: refs/heads/v2-dev
+      ref: refs/remotes/origin/v2-dev
 
   codeql-v2:
     uses: ./.github/workflows/codeql-analysis.yml
     secrets: inherit
     with:
-      ref: refs/heads/v2-dev
+      ref: refs/remotes/origin/v2-dev
 
   govulncheck-v2:
     uses: ./.github/workflows/govulncheck.yml
     secrets: inherit
     with:
-      ref: refs/heads/v2-dev
+      ref: refs/remotes/origin/v2-dev
 
   parametric-v2:
     uses: ./.github/workflows/parametric-tests.yml
     secrets: inherit
     with:
-      ref: refs/heads/v2-dev
+      ref: refs/remotes/origin/v2-dev
 
   smoke-v2:
     uses: ./.github/workflows/smoke-tests.yml
     secrets: inherit
     with:
-      ref: refs/heads/v2-dev
+      ref: refs/remotes/origin/v2-dev
 
   system-v2:
     uses: ./.github/workflows/system-tests.yml
     secrets: inherit
     with:
-      branch_ref: refs/heads/v2-dev
+      branch_ref: refs/remotes/origin/v2-dev
 
   test-apps-v2:
     uses: ./.github/workflows/test-apps.yml
     secrets: inherit
     with:
-      ref: refs/heads/v2-dev
+      ref: refs/remotes/origin/v2-dev

--- a/.github/workflows/v2-nightly.yml
+++ b/.github/workflows/v2-nightly.yml
@@ -22,6 +22,12 @@ jobs:
     with:
       ref: refs/heads/v2-dev
 
+  main-branch-tests-v2:
+    uses: ./.github/workflows/main-branch-tests.yml
+    secrets: inherit
+    with:
+      ref: refs/heads/v2-dev
+
   parametric-v2:
     uses: ./.github/workflows/parametric-tests.yml
     secrets: inherit


### PR DESCRIPTION
### What does this PR do?

Builds upon #2348 & #2359 to ensure nightly CI is run on `v2-dev`. Fixes for smoke and system tests on v2 will be done in a separate PR.

### Motivation

We need to catch any possible issue early, as we aim to dogfood dd-trace-go/v2 in around a month.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!