### PR TITLE
.github/workflows: integrate v2 CI nightly to run from main

### DIFF
--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -27,7 +27,6 @@ env:
   DD_APPSEC_WAF_TIMEOUT: 5s
   JUNIT_REPORT: gotestsum-report.xml
   TO_TEST: ./appsec/... ./internal/appsec/... ./contrib/google.golang.org/grpc/... ./contrib/net/http/... ./contrib/gorilla/mux/... ./contrib/go-chi/... ./contrib/labstack/echo.v4/... ./contrib/gin-gonic/gin/...
-  V2_BRANCH: ${{ inputs.ref == 'refs/heads/v2-dev' }}
 jobs:
   native:
     strategy:
@@ -163,23 +162,15 @@ jobs:
           platforms: arm64
       - run: docker run --platform=linux/arm64 -v $PWD:$PWD -w $PWD -eCGO_ENABLED=${{ matrix.cgo_enabled }} -eDD_APPSEC_ENABLED=${{ matrix.appsec_enabled }} -eDD_APPSEC_WAF_TIMEOUT=$DD_APPSEC_WAF_TIMEOUT golang go test -v -tags appsec $TO_TEST
 
-  v2_switch:
-    runs-on: ubuntu-latest
-    outputs:
-      v2_branch: ${{ steps.eval_v2_branch.outputs.v2_branch }}
-    steps:
-      - id: eval_v2_branch
-        run: echo "::set-output name=v2_branch::$V2_BRANCH"
-
   smoke-tests:
     uses: DataDog/appsec-go-test-app/.github/workflows/smoke-tests.yml@main
-    if: ${{ needs.v2_switch.outputs.v2_branch != 'true' }}
+    if: inputs.ref != 'refs/heads/v2-dev'
     with:
       dd-trace-go-version: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
   smoke-tests-v2:
     # TODO(darccio): change to main branch on v2 release
     uses: DataDog/appsec-go-test-app/.github/workflows/smoke-tests.yml@dario.castane/AIT-3705/dd-trace-go.v2
-    if: ${{ needs.v2_switch.outputs.v2_branch == 'true' }}
+    if: inputs.ref == 'refs/heads/v2-dev'
     with:
       dd-trace-go-version: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -27,6 +27,7 @@ env:
   DD_APPSEC_WAF_TIMEOUT: 5s
   JUNIT_REPORT: gotestsum-report.xml
   TO_TEST: ./appsec/... ./internal/appsec/... ./contrib/google.golang.org/grpc/... ./contrib/net/http/... ./contrib/gorilla/mux/... ./contrib/go-chi/... ./contrib/labstack/echo.v4/... ./contrib/gin-gonic/gin/...
+  V2_BRANCH: false
 jobs:
   native:
     strategy:
@@ -164,5 +165,13 @@ jobs:
 
   smoke-tests:
     uses: DataDog/appsec-go-test-app/.github/workflows/smoke-tests.yml@main
+    if: ${{ env.V2_BRANCH != 'true' }}
+    with:
+      dd-trace-go-version: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+  smoke-tests-v2:
+    # TODO(darccio): change to main branch on v2 release
+    uses: DataDog/appsec-go-test-app/.github/workflows/smoke-tests.yml@dario.castane/AIT-3705/dd-trace-go.v2
+    if: ${{ env.V2_BRANCH == 'true' }}
     with:
       dd-trace-go-version: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -27,6 +27,7 @@ env:
   DD_APPSEC_WAF_TIMEOUT: 5s
   JUNIT_REPORT: gotestsum-report.xml
   TO_TEST: ./appsec/... ./internal/appsec/... ./contrib/google.golang.org/grpc/... ./contrib/net/http/... ./contrib/gorilla/mux/... ./contrib/go-chi/... ./contrib/labstack/echo.v4/... ./contrib/gin-gonic/gin/...
+  V2_BRANCH: false
 jobs:
   native:
     strategy:

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -27,7 +27,7 @@ env:
   DD_APPSEC_WAF_TIMEOUT: 5s
   JUNIT_REPORT: gotestsum-report.xml
   TO_TEST: ./appsec/... ./internal/appsec/... ./contrib/google.golang.org/grpc/... ./contrib/net/http/... ./contrib/gorilla/mux/... ./contrib/go-chi/... ./contrib/labstack/echo.v4/... ./contrib/gin-gonic/gin/...
-  V2_BRANCH: false
+  V2_BRANCH: ${{ inputs.ref == 'refs/heads/v2-dev' }}
 jobs:
   native:
     strategy:

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -27,7 +27,6 @@ env:
   DD_APPSEC_WAF_TIMEOUT: 5s
   JUNIT_REPORT: gotestsum-report.xml
   TO_TEST: ./appsec/... ./internal/appsec/... ./contrib/google.golang.org/grpc/... ./contrib/net/http/... ./contrib/gorilla/mux/... ./contrib/go-chi/... ./contrib/labstack/echo.v4/... ./contrib/gin-gonic/gin/...
-  V2_BRANCH: false
 jobs:
   native:
     strategy:
@@ -163,15 +162,23 @@ jobs:
           platforms: arm64
       - run: docker run --platform=linux/arm64 -v $PWD:$PWD -w $PWD -eCGO_ENABLED=${{ matrix.cgo_enabled }} -eDD_APPSEC_ENABLED=${{ matrix.appsec_enabled }} -eDD_APPSEC_WAF_TIMEOUT=$DD_APPSEC_WAF_TIMEOUT golang go test -v -tags appsec $TO_TEST
 
+  v2_switch:
+    runs-on: ubuntu-latest
+    outputs:
+      v2_branch: ${{ steps.eval_v2_branch.outputs.v2_branch }}
+    steps:
+      - id: eval_v2_branch
+        run: echo "v2_branch=$V2_BRANCH" >> "$GITHUB_OUTPUT"
+
   smoke-tests:
     uses: DataDog/appsec-go-test-app/.github/workflows/smoke-tests.yml@main
-    if: env.V2_BRANCH != 'true'
+    if: ${{ needs.v2_switch.outputs.v2_branch != 'true' }}
     with:
       dd-trace-go-version: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
   smoke-tests-v2:
     # TODO(darccio): change to main branch on v2 release
     uses: DataDog/appsec-go-test-app/.github/workflows/smoke-tests.yml@dario.castane/AIT-3705/dd-trace-go.v2
-    if: env.V2_BRANCH == 'true'
+    if: ${{ needs.v2_switch.outputs.v2_branch == 'true' }}
     with:
       dd-trace-go-version: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -169,7 +169,7 @@ jobs:
       v2_branch: ${{ steps.eval_v2_branch.outputs.v2_branch }}
     steps:
       - id: eval_v2_branch
-        run: echo "v2_branch=$V2_BRANCH" >> "$GITHUB_OUTPUT"
+        run: echo "::set-output name=v2_branch::$V2_BRANCH"
 
   smoke-tests:
     uses: DataDog/appsec-go-test-app/.github/workflows/smoke-tests.yml@main

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -165,13 +165,13 @@ jobs:
 
   smoke-tests:
     uses: DataDog/appsec-go-test-app/.github/workflows/smoke-tests.yml@main
-    if: ${{ env.V2_BRANCH != 'true' }}
+    if: env.V2_BRANCH != 'true'
     with:
       dd-trace-go-version: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
   smoke-tests-v2:
     # TODO(darccio): change to main branch on v2 release
     uses: DataDog/appsec-go-test-app/.github/workflows/smoke-tests.yml@dario.castane/AIT-3705/dd-trace-go.v2
-    if: ${{ env.V2_BRANCH == 'true' }}
+    if: env.V2_BRANCH == 'true'
     with:
       dd-trace-go-version: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 env:
-  V2_BRANCH: false
+  V2_BRANCH: ${{ inputs.ref == 'refs/heads/v2-dev' }}
 
 jobs:
   govulncheck-tests:

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -14,6 +14,9 @@ on:
     - cron: '00 00 * * *'
   workflow_dispatch:
 
+env:
+  V2_BRANCH: false
+
 jobs:
   govulncheck-tests:
     runs-on: ubuntu-latest
@@ -31,8 +34,15 @@ jobs:
       - name: Run govulncheck
         run: govulncheck -tags appsec ./ddtrace/... ./appsec/... ./profiler/... ./internal/... 
       - name: Run govulncheck-contribs
+        if: ${{ env.V2_BRANCH != 'true' }}
         run: |
           # Excluding legacy contrib grpc.v12
           go list -f '{{.Dir}}' ./contrib/... | grep -v -e grpc.v12 | while read dir ; do
+            govulncheck -C $dir .
+          done
+      - name: Run govulncheck-contribs (v2)
+        if: ${{ env.V2_BRANCH == 'true' }}
+        run: |
+          go list -f '{{.Dir}}' ./contrib/... | while read dir ; do
             govulncheck -C $dir .
           done

--- a/.github/workflows/multios-unit-tests.yml
+++ b/.github/workflows/multios-unit-tests.yml
@@ -26,6 +26,9 @@ on:
         required: true
         type: string
 
+env:
+  V2_BRANCH: false
+
 jobs:
   test-multi-os:
     runs-on: "${{ (inputs.go-version == '1.19' && inputs.runs-on == 'windows-latest') && 'windows-2019' || inputs.runs-on }}"
@@ -47,9 +50,16 @@ jobs:
         if: inputs.runs-on == 'macos-latest'
         run: brew install coreutils
       - name: "Runner ${{ matrix.runner-index }}: Test Core and Contrib (No Integration Tests)"
+        if: ${{ env.V2_BRANCH != 'true' }}
         shell: bash
         run: |
           go list ./... | grep -v -e grpc.v12 -e google.golang.org/api -e sarama -e confluent-kafka-go -e cmemprof | sort >packages.txt
+          gotestsum --junitfile ${REPORT} -- $(cat packages.txt) -v -coverprofile=coverage.txt -covermode=atomic -timeout 15m
+      - name: "Runner ${{ matrix.runner-index }}: Test Core and Contrib (No Integration Tests) v2"
+        if: ${{ env.V2_BRANCH == 'true' }}
+        shell: bash
+        run: |
+          go list ./... | grep -v -e google.golang.org/api -e sarama -e confluent-kafka-go -e cmemprof | sort >packages.txt
           gotestsum --junitfile ${REPORT} -- $(cat packages.txt) -v -coverprofile=coverage.txt -covermode=atomic -timeout 15m
       - name: Upload the results to Datadog CI App
         if: always()

--- a/.github/workflows/multios-unit-tests.yml
+++ b/.github/workflows/multios-unit-tests.yml
@@ -27,7 +27,7 @@ on:
         type: string
 
 env:
-  V2_BRANCH: false
+  V2_BRANCH: ${{ inputs.ref == 'refs/heads/v2-dev' }}
 
 jobs:
   test-multi-os:

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -28,6 +28,7 @@ jobs:
       group: "APM Larger Runners"
     env:
       TEST_LIBRARY: golang
+      V2_BRANCH: false
     steps:
       - name: Checkout system tests
         uses: actions/checkout@v3
@@ -45,14 +46,14 @@ jobs:
           go-version: "1.19"
 
       - name: Patch dd-trace-go version
-        if: inputs.ref != 'refs/heads/v2-dev'
+        if: ${{ env.V2_BRANCH != 'true' }}
         run: |
           cd utils/build/docker/golang/parametric/
           echo "replace gopkg.in/DataDog/dd-trace-go.v1 => ./dd-trace-go" >> go.mod
           go mod tidy
 
       - name: Patch dd-trace-go version (v2)
-        if: inputs.ref == 'refs/heads/v2-dev'
+        if: ${{ env.V2_BRANCH == 'true' }}
         run: |
           cd utils/build/docker/golang/parametric/
           echo "replace github.com/DataDog/dd-trace-go/v2 => ./dd-trace-go" >> go.mod

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -28,7 +28,7 @@ jobs:
       group: "APM Larger Runners"
     env:
       TEST_LIBRARY: golang
-      V2_BRANCH: false
+      V2_BRANCH: ${{ inputs.ref == 'refs/heads/v2-dev' }}
     steps:
       - name: Checkout system tests
         uses: actions/checkout@v3

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -93,7 +93,7 @@ jobs:
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
       SYSTEM_TESTS_E2E_DD_API_KEY: ${{ secrets.SYSTEM_TESTS_E2E_DD_API_KEY }}
       SYSTEM_TESTS_E2E_DD_APP_KEY: ${{ secrets.SYSTEM_TESTS_E2E_DD_APP_KEY }}
-      V2_BRANCH: ${{ inputs.ref == 'refs/heads/v2-dev' }}
+      V2_BRANCH: ${{ inputs.branch_ref == 'refs/heads/v2-dev' }}
     name: Test (${{ matrix.weblog-variant }}, ${{ matrix.scenario }})
     steps:
       - name: Checkout system tests

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -93,7 +93,7 @@ jobs:
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
       SYSTEM_TESTS_E2E_DD_API_KEY: ${{ secrets.SYSTEM_TESTS_E2E_DD_API_KEY }}
       SYSTEM_TESTS_E2E_DD_APP_KEY: ${{ secrets.SYSTEM_TESTS_E2E_DD_APP_KEY }}
-      V2_BRANCH: false
+      V2_BRANCH: ${{ inputs.ref == 'refs/heads/v2-dev' }}
     name: Test (${{ matrix.weblog-variant }}, ${{ matrix.scenario }})
     steps:
       - name: Checkout system tests

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -93,27 +93,28 @@ jobs:
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
       SYSTEM_TESTS_E2E_DD_API_KEY: ${{ secrets.SYSTEM_TESTS_E2E_DD_API_KEY }}
       SYSTEM_TESTS_E2E_DD_APP_KEY: ${{ secrets.SYSTEM_TESTS_E2E_DD_APP_KEY }}
+      V2_BRANCH: false
     name: Test (${{ matrix.weblog-variant }}, ${{ matrix.scenario }})
     steps:
       - name: Checkout system tests
         uses: actions/checkout@v3
+        if: ${{ env.V2_BRANCH != 'true' }}
         with:
           repository: 'DataDog/system-tests'
           ref: ${{ inputs.ref }}
+
+      - name: Checkout system tests (v2)
+        uses: actions/checkout@v3
+        if: ${{ env.V2_BRANCH == 'true' }}
+        with:
+          repository: 'DataDog/system-tests'
+          ref: refs/heads/dario.castane/AIT-3705/dd-trace-go.v2
 
       - name: Checkout dd-trace-go
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.branch_ref || github.ref }}
           path: 'binaries/dd-trace-go'
-
-      - name: Patch dd-trace-go version
-        if: ${{ inputs.branch_ref == 'refs/heads/v2-dev' }}
-        run: |
-          cd utils/build/docker/golang/app
-          find -type f -name '*.go' -exec sed -i 's#gopkg.in/DataDog/dd-trace-go.v1#github.com/DataDog/dd-trace-go/v2#g' {} \;
-          echo "replace github.com/DataDog/dd-trace-go/v2 => /home/runner/work/dd-trace-go/dd-trace-go/binaries/dd-trace-go" >> go.mod
-          go mod tidy
 
       - name: Build weblog
         run: ./build.sh -i weblog

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -51,6 +51,7 @@ jobs:
     env:
        TEST_RESULTS: /tmp/test-results # path to where test results will be saved
        INTEGRATION: true
+       V2_BRANCH: false
     services:
       datadog-agent:
         image: datadog/agent:latest
@@ -192,10 +193,18 @@ jobs:
           go-version: ${{ inputs.go-version }}
 
       - name: Test Contrib
+        if: ${{ env.V2_BRANCH != 'true' }}
         run: |
             mkdir -p $TEST_RESULTS
             PACKAGE_NAMES=$(go list ./contrib/... | grep -v -e grpc.v12 -e google.golang.org/api)
             gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- $PACKAGE_NAMES -v -race -coverprofile=coverage.txt -covermode=atomic
+
+      - name: Test Contrib (v2)
+        if: ${{ env.V2_BRANCH == 'true' }}
+        run: |
+          mkdir -p $TEST_RESULTS
+          PACKAGE_NAMES=$(go list ./contrib/... | grep -v -e google.golang.org/api)
+          gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- $PACKAGE_NAMES -v -race -coverprofile=coverage.txt -covermode=atomic
 
       - name: Upload the results to Datadog CI App
         if: always()
@@ -247,7 +256,7 @@ jobs:
               go test -v ./contrib/google.golang.org/api/...
 
       - name: Testing outlier gRPC v1.2
-        if: inputs.ref != 'refs/heads/v2-dev'
+        if: ${{ env.V2_BRANCH != 'true' }}
         run: |
               # This hacky approach is necessary because running the tests regularly
               # do not allow using grpc-go@v1.2.0 alongside sketches-go@v1.0.0

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -51,7 +51,7 @@ jobs:
     env:
        TEST_RESULTS: /tmp/test-results # path to where test results will be saved
        INTEGRATION: true
-       V2_BRANCH: false
+       V2_BRANCH: ${{ inputs.ref == 'refs/heads/v2-dev' }}
     services:
       datadog-agent:
         image: datadog/agent:latest


### PR DESCRIPTION
### What does this PR do?

Completes the implementation of nightly CI runs for v2. Builds upon #2348 #2359 #2360. 

### Motivation

We want to catch any regression during v2 development. Running this nightly will allow to detect them easily.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!