### PR TITLE
{telemetry,remoteconfig}: support fraction of second intervals

### DIFF
--- a/internal/env.go
+++ b/internal/env.go
@@ -92,3 +92,18 @@ func ParseTagString(str string) map[string]string {
 	ForEachStringTag(str, func(key, val string) { res[key] = val })
 	return res
 }
+
+// FloatEnv returns the parsed float64 value of an environment variable,
+// or def otherwise.
+func FloatEnv(key string, def float64) float64 {
+	env, ok := os.LookupEnv(key)
+	if !ok {
+		return def
+	}
+	v, err := strconv.ParseFloat(env, 64)
+	if err != nil {
+		log.Warn("Non-float value for env var %s, defaulting to %f. Parse failed with error: %v", key, def, err)
+		return def
+	}
+	return v
+}

--- a/internal/remoteconfig/config.go
+++ b/internal/remoteconfig/config.go
@@ -56,14 +56,13 @@ func DefaultClientConfig() ClientConfig {
 }
 
 func pollIntervalFromEnv() time.Duration {
-	interval := internal.IntEnv(envPollIntervalSec, 5)
+	interval := internal.FloatEnv(envPollIntervalSec, 5.0)
 	if interval < 0 {
-		log.Debug("Remote config: cannot use a negative poll interval: %s = %d. Defaulting to 5s.", envPollIntervalSec, interval)
-		return 5 * time.Second
+		log.Debug("Remote config: cannot use a negative poll interval: %s = %f. Defaulting to 5s.", envPollIntervalSec, interval)
+		interval = 5.0
 	} else if interval == 0 {
 		log.Debug("Remote config: poll interval set to 0. Polling will be continuous.")
 		return time.Nanosecond
 	}
-
-	return time.Duration(interval) * time.Second
+	return time.Duration(interval * float64(time.Second))
 }

--- a/internal/remoteconfig/config_test.go
+++ b/internal/remoteconfig/config_test.go
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023 Datadog, Inc.
+
+package remoteconfig
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_pollIntervalFromEnv(t *testing.T) {
+	defaultInterval := time.Second * time.Duration(5.0)
+	tests := []struct {
+		name  string
+		setup func(t *testing.T)
+		want  time.Duration
+	}{
+		{
+			name:  "default",
+			setup: func(t *testing.T) {},
+			want:  defaultInterval,
+		},
+		{
+			name:  "float",
+			setup: func(t *testing.T) { t.Setenv("DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS", "0.2") },
+			want:  time.Millisecond * 200,
+		},
+		{
+			name:  "integer",
+			setup: func(t *testing.T) { t.Setenv("DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS", "2") },
+			want:  time.Second * 2,
+		},
+		{
+			name:  "negative",
+			setup: func(t *testing.T) { t.Setenv("DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS", "-1") },
+			want:  defaultInterval,
+		},
+		{
+			name:  "zero",
+			setup: func(t *testing.T) { t.Setenv("DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS", "0") },
+			want:  time.Nanosecond,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup(t)
+			assert.Equal(t, tt.want, pollIntervalFromEnv())
+		})
+	}
+}

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -76,7 +76,7 @@ var (
 	// also the default URL in case connecting to the agent URL fails.
 	agentlessURL = "https://instrumentation-telemetry-intake.datadoghq.com/api/v2/apmtelemetry"
 
-	defaultHeartbeatInterval = 60 // seconds
+	defaultHeartbeatInterval = 60.0 // seconds
 
 	// LogPrefix specifies the prefix for all telemetry logging
 	LogPrefix = "Instrumentation telemetry: "
@@ -222,14 +222,17 @@ func (c *client) start(configuration []Configuration, namespace Namespace) {
 	}
 
 	c.flush()
+	c.heartbeatInterval = heartbeatInterval()
+	c.heartbeatT = time.AfterFunc(c.heartbeatInterval, c.backgroundHeartbeat)
+}
 
-	heartbeat := internal.IntEnv("DD_TELEMETRY_HEARTBEAT_INTERVAL", defaultHeartbeatInterval)
-	if heartbeat < 1 || heartbeat > 3600 {
-		log("DD_TELEMETRY_HEARTBEAT_INTERVAL=%d not in [1,3600] range, setting to default of %d", heartbeat, defaultHeartbeatInterval)
+func heartbeatInterval() time.Duration {
+	heartbeat := internal.FloatEnv("DD_TELEMETRY_HEARTBEAT_INTERVAL", defaultHeartbeatInterval)
+	if heartbeat <= 0 || heartbeat > 3600 {
+		log("DD_TELEMETRY_HEARTBEAT_INTERVAL=%d not in [1,3600] range, setting to default of %f", heartbeat, defaultHeartbeatInterval)
 		heartbeat = defaultHeartbeatInterval
 	}
-	c.heartbeatInterval = time.Duration(heartbeat) * time.Second
-	c.heartbeatT = time.AfterFunc(c.heartbeatInterval, c.backgroundHeartbeat)
+	return time.Duration(heartbeat * float64(time.Second))
 }
 
 // Stop notifies the telemetry endpoint that the app is closing. All outstanding


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Support float values for `DD_TELEMETRY_HEARTBEAT_INTERVAL` and `DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

These options are set to 0.2 in parametric tests to speed up the execution time.
https://github.com/DataDog/system-tests/blob/7cbb0153babff6b80cde7a6425ab41adcdffe014/tests/parametric/test_dynamic_configuration.py#L31-L32

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!