### PR TITLE
ddtrace/opentelemetry,opentracing: fixed the format of telemetry tags 

### DIFF
--- a/ddtrace/opentelemetry/tracer.go
+++ b/ddtrace/opentelemetry/tracer.go
@@ -21,7 +21,7 @@ import (
 
 var _ oteltrace.Tracer = (*oteltracer)(nil)
 
-var telemetryTags = []string{`"integration_name":"otel"`}
+var telemetryTags = []string{"integration_name:otel"}
 
 type oteltracer struct {
 	noop.Tracer // https://pkg.go.dev/go.opentelemetry.io/otel/trace#hdr-API_Implementations

--- a/ddtrace/opentelemetry/tracer_provider.go
+++ b/ddtrace/opentelemetry/tracer_provider.go
@@ -29,6 +29,7 @@
 package opentelemetry
 
 import (
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -83,6 +84,7 @@ func (p *TracerProvider) Tracer(_ string, _ ...oteltrace.TracerOption) oteltrace
 func (p *TracerProvider) Shutdown() error {
 	p.Once.Do(func() {
 		tracer.Stop()
+		telemetry.GlobalClient.Stop()
 		atomic.StoreUint32(&p.stopped, 1)
 	})
 	return nil

--- a/ddtrace/opentelemetry/tracer_provider.go
+++ b/ddtrace/opentelemetry/tracer_provider.go
@@ -29,7 +29,6 @@
 package opentelemetry
 
 import (
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -84,7 +83,6 @@ func (p *TracerProvider) Tracer(_ string, _ ...oteltrace.TracerOption) oteltrace
 func (p *TracerProvider) Shutdown() error {
 	p.Once.Do(func() {
 		tracer.Stop()
-		telemetry.GlobalClient.Stop()
 		atomic.StoreUint32(&p.stopped, 1)
 	})
 	return nil

--- a/ddtrace/opentracer/tracer.go
+++ b/ddtrace/opentracer/tracer.go
@@ -44,7 +44,7 @@ func New(opts ...tracer.StartOption) opentracing.Tracer {
 
 var _ opentracing.Tracer = (*opentracer)(nil)
 
-var telemetryTags = []string{`"integration_name":"opentracing"`}
+var telemetryTags = []string{"integration_name:opentracing"}
 
 // opentracer implements opentracing.Tracer on top of ddtrace.Tracer.
 type opentracer struct{ ddtrace.Tracer }

--- a/internal/apps/unit-of-work/go.mod
+++ b/internal/apps/unit-of-work/go.mod
@@ -8,10 +8,10 @@ require (
 )
 
 require (
-	github.com/DataDog/appsec-internal-go v1.0.1 // indirect
+	github.com/DataDog/appsec-internal-go v1.0.2 // indirect
 	github.com/DataDog/go-libddwaf v1.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/ebitengine/purego v0.5.0-alpha.1 // indirect
+	github.com/ebitengine/purego v0.5.0 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/outcaste-io/ristretto v0.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
@@ -43,7 +43,7 @@ require (
 	github.com/tinylib/msgp v1.1.8 // indirect
 	go4.org/intern v0.0.0-20230525184215-6c62f75575cb // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2 // indirect
-	golang.org/x/sys v0.13.0 // indirect
+	golang.org/x/sys v0.14.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect

--- a/internal/apps/unit-of-work/go.sum
+++ b/internal/apps/unit-of-work/go.sum
@@ -1,6 +1,7 @@
 github.com/DataDog/appsec-internal-go v1.0.0 h1:2u5IkF4DBj3KVeQn5Vg2vjPUtt513zxEYglcqnd500U=
 github.com/DataDog/appsec-internal-go v1.0.0/go.mod h1:+Y+4klVWKPOnZx6XESG7QHydOaUGEXyH2j/vSg9JiNM=
 github.com/DataDog/appsec-internal-go v1.0.1/go.mod h1:+Y+4klVWKPOnZx6XESG7QHydOaUGEXyH2j/vSg9JiNM=
+github.com/DataDog/appsec-internal-go v1.0.2/go.mod h1:+Y+4klVWKPOnZx6XESG7QHydOaUGEXyH2j/vSg9JiNM=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.46.0 h1:rUNnUcHC4AlxoImuXmZeOfi6H80BDBHzeagWXWCVhnA=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.46.0/go.mod h1:e933RWa4kAWuHi5jpzEuOiULlv21HcCFEVIYegmaB5c=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0/go.mod h1:HzySONXnAgSmIQfL6gOv9hWprKJkx8CicuXuUbmgWfo=
@@ -39,6 +40,7 @@ github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+m
 github.com/dvyukov/go-fuzz v0.0.0-20210103155950-6a8e9d1f2415/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
 github.com/ebitengine/purego v0.5.0-alpha.1 h1:0gVgWGb8GjKYs7cufvfNSleJAD00m2xWC26FMwOjNrw=
 github.com/ebitengine/purego v0.5.0-alpha.1/go.mod h1:ah1In8AOtksoNK6yk5z1HTJeUkC1Ez4Wk2idgGslMwQ=
+github.com/ebitengine/purego v0.5.0/go.mod h1:ah1In8AOtksoNK6yk5z1HTJeUkC1Ez4Wk2idgGslMwQ=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
@@ -153,6 +155,7 @@ golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.3.0/go.mod h1:q750SLmJuPmVoN1blW3UFBPREJfb1KmY3vwxfr+nFDA=


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
This PR fixes the format of telemetry tags in opentracing and opentelemetry packages. Previously, the string with `integration_type` had redundant quotes, which were causing the telemetry processing to not recognise the integration type and mark it as `N/A`.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Missing metrics on the usage of opentelemetry package
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
