### PR TITLE
.github/workflows: use GCR instead of Docker Hub to pull datadog-agent

### DIFF
--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -54,7 +54,7 @@ jobs:
        V2_BRANCH: ${{ inputs.ref == 'refs/heads/v2-dev' }}
     services:
       datadog-agent:
-        image: datadog/agent:latest
+        image: us.gcr.io/cloud-containers-mirror/datadog/agent:latest
         env:
           DD_HOSTNAME: "github-actions-worker"
           DD_APM_ENABLED: true
@@ -282,7 +282,7 @@ jobs:
        INTEGRATION: true
     services:
       datadog-agent:
-        image: datadog/agent:latest
+        image: us.gcr.io/cloud-containers-mirror/datadog/agent:latest
         env:
           DD_HOSTNAME: "github-actions-worker"
           DD_APM_ENABLED: true


### PR DESCRIPTION
### What does this PR do?

Avoids using Docker Hub's rate limits.

### Motivation

Sometimes CI fails due to rate limits from Docker Hub.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
