### PR TITLE
tracer: configure global tags via remote-config

### DIFF
--- a/ddtrace/tracer/log.go
+++ b/ddtrace/tracer/log.go
@@ -79,7 +79,7 @@ func checkEndpoint(c *http.Client, endpoint string) error {
 // JSON format.
 func logStartup(t *tracer) {
 	tags := make(map[string]string)
-	for k, v := range t.config.globalTags {
+	for k, v := range t.config.globalTags.get() {
 		tags[k] = fmt.Sprintf("%v", v)
 	}
 

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -160,7 +160,7 @@ type config struct {
 
 	// globalTags holds a set of tags that will be automatically applied to
 	// all spans.
-	globalTags map[string]interface{}
+	globalTags dynamicConfig[map[string]interface{}]
 
 	// transport specifies the Transport interface which will be used to send data to the agent.
 	transport transport
@@ -409,22 +409,23 @@ func newConfig(opts ...StartOption) *config {
 		c.httpClient = defaultClient
 	}
 	WithGlobalTag(ext.RuntimeID, globalconfig.RuntimeID())(c)
+	globalTags := c.globalTags.get()
 	if c.env == "" {
-		if v, ok := c.globalTags["env"]; ok {
+		if v, ok := globalTags["env"]; ok {
 			if e, ok := v.(string); ok {
 				c.env = e
 			}
 		}
 	}
 	if c.version == "" {
-		if v, ok := c.globalTags["version"]; ok {
+		if v, ok := globalTags["version"]; ok {
 			if ver, ok := v.(string); ok {
 				c.version = ver
 			}
 		}
 	}
 	if c.serviceName == "" {
-		if v, ok := c.globalTags["service"]; ok {
+		if v, ok := globalTags["service"]; ok {
 			if s, ok := v.(string); ok {
 				c.serviceName = s
 				globalconfig.SetServiceName(s)
@@ -488,6 +489,9 @@ func newConfig(opts ...StartOption) *config {
 		}
 		c.dogstatsdAddr = addr
 	}
+	// Re-initialize the globalTags config with the value constructed from the environment and start options
+	// This allows persisting the initial value of globalTags for future resets and updates.
+	c.initGlobalTags(c.globalTags.get())
 
 	return c
 }
@@ -703,7 +707,7 @@ func statsTags(c *config) []string {
 	if c.hostname != "" {
 		tags = append(tags, "host:"+c.hostname)
 	}
-	for k, v := range c.globalTags {
+	for k, v := range c.globalTags.get() {
 		if vstr, ok := v.(string); ok {
 			tags = append(tags, k+":"+vstr)
 		}
@@ -875,11 +879,23 @@ func WithPeerServiceMapping(from, to string) StartOption {
 // created by tracer. This option may be used multiple times.
 func WithGlobalTag(k string, v interface{}) StartOption {
 	return func(c *config) {
-		if c.globalTags == nil {
-			c.globalTags = make(map[string]interface{})
+		if c.globalTags.get() == nil {
+			c.initGlobalTags(map[string]interface{}{})
 		}
-		c.globalTags[k] = v
+		c.globalTags.Lock()
+		defer c.globalTags.Unlock()
+		c.globalTags.current[k] = v
 	}
+}
+
+// initGlobalTags initializes the globalTags config with the provided init value
+func (c *config) initGlobalTags(init map[string]interface{}) {
+	apply := func(map[string]interface{}) bool {
+		// always set the runtime ID on updates
+		c.globalTags.current[ext.RuntimeID] = globalconfig.RuntimeID()
+		return true
+	}
+	c.globalTags = newDynamicConfig[map[string]interface{}]("trace_tags", init, apply, equalMap[string])
 }
 
 // WithSampler sets the given sampler to be used with the tracer. By default

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -559,8 +559,8 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		c := tracer.config
 		assert.Equal(float64(0.5), c.sampler.(RateSampler).Rate())
 		assert.Equal(&url.URL{Scheme: "http", Host: "ddagent.consul.local:58126"}, c.agentURL)
-		assert.NotNil(c.globalTags)
-		assert.Equal("v", c.globalTags["k"])
+		assert.NotNil(c.globalTags.get())
+		assert.Equal("v", c.globalTags.get()["k"])
 		assert.Equal("testEnv", c.env)
 		assert.True(c.debug)
 	})
@@ -572,12 +572,13 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		assert := assert.New(t)
 		c := newConfig()
 
-		assert.Equal("test", c.globalTags["env"])
-		assert.Equal("aVal", c.globalTags["aKey"])
-		assert.Equal("bVal", c.globalTags["bKey"])
-		assert.Equal("", c.globalTags["cKey"])
+		globalTags := c.globalTags.get()
+		assert.Equal("test", globalTags["env"])
+		assert.Equal("aVal", globalTags["aKey"])
+		assert.Equal("bVal", globalTags["bKey"])
+		assert.Equal("", globalTags["cKey"])
 
-		dVal, ok := c.globalTags["dKey"]
+		dVal, ok := globalTags["dKey"]
 		assert.False(ok)
 		assert.Equal(nil, dVal)
 	})
@@ -995,8 +996,9 @@ func TestTagSeparators(t *testing.T) {
 			os.Setenv("DD_TAGS", tag.in)
 			defer os.Unsetenv("DD_TAGS")
 			c := newConfig()
+			globalTags := c.globalTags.get()
 			for key, expected := range tag.out {
-				got, ok := c.globalTags[key]
+				got, ok := globalTags[key]
 				assert.True(ok, "tag not found")
 				assert.Equal(expected, got)
 			}

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -57,6 +57,7 @@ func startTelemetry(c *config) {
 		{Name: "orchestrion_enabled", Value: c.orchestrionCfg.Enabled},
 		c.traceSampleRate.toTelemetry(),
 		c.headerAsTags.toTelemetry(),
+		c.globalTags.toTelemetry(),
 	}
 	var peerServiceMapping []string
 	for key, value := range c.peerServiceMappings {
@@ -77,7 +78,7 @@ func startTelemetry(c *config) {
 	for k, v := range c.serviceMappings {
 		telemetryConfigs = append(telemetryConfigs, telemetry.Configuration{Name: "service_mapping_" + k, Value: v})
 	}
-	for k, v := range c.globalTags {
+	for k, v := range c.globalTags.get() {
 		telemetryConfigs = append(telemetryConfigs, telemetry.Configuration{Name: "global_tag_" + k, Value: v})
 	}
 	rules := append(c.spanRules, c.traceRules...)

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -529,7 +529,7 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		span.SetTag(k, v)
 	}
 	// add global tags
-	for k, v := range t.config.globalTags {
+	for k, v := range t.config.globalTags.get() {
 		span.SetTag(k, v)
 	}
 	if t.config.serviceMappings != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

AIT-8977

- Make global tags dynamic: support custom global tags via remote config
- Report RC capabilities for custom tags 
- Report telemetry events on custom tag updates

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Better onboarding UX

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
