### PR TITLE
remoteconfig: add Subscribe function

### DIFF
--- a/ddtrace/tracer/remote_config.go
+++ b/ddtrace/tracer/remote_config.go
@@ -75,10 +75,9 @@ func (t *tags) toMap() *map[string]interface{} {
 }
 
 // onRemoteConfigUpdate is a remote config callaback responsible for processing APM_TRACING RC-product updates.
-func (t *tracer) onRemoteConfigUpdate(updates map[string]remoteconfig.ProductUpdate) map[string]state.ApplyStatus {
+func (t *tracer) onRemoteConfigUpdate(u remoteconfig.ProductUpdate) map[string]state.ApplyStatus {
 	statuses := map[string]state.ApplyStatus{}
-	u, found := updates[state.ProductAPMTracing]
-	if !found {
+	if u == nil {
 		return statuses
 	}
 	var telemConfigs []telemetry.Configuration
@@ -131,21 +130,11 @@ func (t *tracer) startRemoteConfig(rcConfig remoteconfig.ClientConfig) error {
 	if err != nil {
 		return err
 	}
-	err = remoteconfig.RegisterProduct(state.ProductAPMTracing)
-	if err != nil {
-		return err
-	}
-	err = remoteconfig.RegisterCapability(remoteconfig.APMTracingSampleRate)
-	if err != nil {
-		return err
-	}
-	err = remoteconfig.RegisterCapability(remoteconfig.APMTracingHTTPHeaderTags)
-	if err != nil {
-		return err
-	}
-	err = remoteconfig.RegisterCapability(remoteconfig.APMTracingCustomTags)
-	if err != nil {
-		return err
-	}
-	return remoteconfig.RegisterCallback(t.onRemoteConfigUpdate)
+	return remoteconfig.Subscribe(
+		state.ProductAPMTracing,
+		t.onRemoteConfigUpdate,
+		remoteconfig.APMTracingSampleRate,
+		remoteconfig.APMTracingHTTPHeaderTags,
+		remoteconfig.APMTracingCustomTags,
+	)
 }

--- a/ddtrace/tracer/remote_config_test.go
+++ b/ddtrace/tracer/remote_config_test.go
@@ -27,8 +27,8 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		defer stop()
 
 		// Apply RC. Assert _dd.rule_psr shows the RC sampling rate (0.2) is applied
-		input := map[string]remoteconfig.ProductUpdate{
-			"APM_TRACING": {"path": []byte(`{"lib_config": {"tracing_sampling_rate": 0.5}, "service_target": {"service": "my-service", "env": "my-env"}}`)},
+		input := remoteconfig.ProductUpdate{
+			"path": []byte(`{"lib_config": {"tracing_sampling_rate": 0.5}, "service_target": {"service": "my-service", "env": "my-env"}}`),
 		}
 		applyStatus := tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
@@ -41,7 +41,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_sample_rate", Value: 0.5, Origin: "remote_config"}})
 
 		// Unset RC. Assert _dd.rule_psr is not set
-		input["APM_TRACING"] = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`)}
+		input = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`)}
 		applyStatus = tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
 		s = tracer.StartSpan("web.request").(*span)
@@ -63,8 +63,8 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		defer stop()
 
 		// Apply RC. Assert _dd.rule_psr shows the RC sampling rate (0.2) is applied
-		input := map[string]remoteconfig.ProductUpdate{
-			"APM_TRACING": {"path": []byte(`{"lib_config": {"tracing_sampling_rate": 0.2}, "service_target": {"service": "my-service", "env": "my-env"}}`)},
+		input := remoteconfig.ProductUpdate{
+			"path": []byte(`{"lib_config": {"tracing_sampling_rate": 0.2}, "service_target": {"service": "my-service", "env": "my-env"}}`),
 		}
 		applyStatus := tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
@@ -77,7 +77,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_sample_rate", Value: 0.2, Origin: "remote_config"}})
 
 		// Unset RC. Assert _dd.rule_psr shows the previous sampling rate (0.1) is applied
-		input["APM_TRACING"] = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`)}
+		input = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`)}
 		applyStatus = tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
 		s = tracer.StartSpan("web.request").(*span)
@@ -97,8 +97,8 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		defer stop()
 
 		// Apply RC. Assert global config shows the RC header tag is applied
-		input := map[string]remoteconfig.ProductUpdate{
-			"APM_TRACING": {"path": []byte(`{"lib_config": {"tracing_header_tags": [{"header": "X-Test-Header", "tag_name": "my-tag-name"}]}, "service_target": {"service": "my-service", "env": "my-env"}}`)},
+		input := remoteconfig.ProductUpdate{
+			"path": []byte(`{"lib_config": {"tracing_header_tags": [{"header": "X-Test-Header", "tag_name": "my-tag-name"}]}, "service_target": {"service": "my-service", "env": "my-env"}}`),
 		}
 		applyStatus := tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
@@ -109,7 +109,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name", Origin: "remote_config"}})
 
 		// Unset RC. Assert header tags are not set
-		input["APM_TRACING"] = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`)}
+		input = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`)}
 		applyStatus = tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
 		require.Equal(t, 0, globalconfig.HeaderTagsLen())
@@ -128,8 +128,8 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		defer stop()
 
 		// Apply RC. Assert global config shows the RC header tag is applied
-		input := map[string]remoteconfig.ProductUpdate{
-			"APM_TRACING": {"path": []byte(`{"lib_config": {"tracing_header_tags": [{"header": "X-Test-Header", "tag_name": "my-tag-name-from-rc"}]}, "service_target": {"service": "my-service", "env": "my-env"}}`)},
+		input := remoteconfig.ProductUpdate{
+			"path": []byte(`{"lib_config": {"tracing_header_tags": [{"header": "X-Test-Header", "tag_name": "my-tag-name-from-rc"}]}, "service_target": {"service": "my-service", "env": "my-env"}}`),
 		}
 		applyStatus := tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
@@ -141,7 +141,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name-from-rc", Origin: "remote_config"}})
 
 		// Unset RC. Assert global config shows the DD_TRACE_HEADER_TAGS header tag
-		input["APM_TRACING"] = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`)}
+		input = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`)}
 		applyStatus = tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
 		require.Equal(t, 1, globalconfig.HeaderTagsLen())
@@ -160,8 +160,8 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		defer stop()
 
 		// Apply RC. Assert global config shows the RC header tag is applied
-		input := map[string]remoteconfig.ProductUpdate{
-			"APM_TRACING": {"path": []byte(`{"lib_config": {"tracing_header_tags": [{"header": "X-Test-Header", "tag_name": "my-tag-name-from-rc"}]}, "service_target": {"service": "my-service", "env": "my-env"}}`)},
+		input := remoteconfig.ProductUpdate{
+			"path": []byte(`{"lib_config": {"tracing_header_tags": [{"header": "X-Test-Header", "tag_name": "my-tag-name-from-rc"}]}, "service_target": {"service": "my-service", "env": "my-env"}}`),
 		}
 		applyStatus := tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
@@ -173,7 +173,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name-from-rc", Origin: "remote_config"}})
 
 		// Unset RC. Assert global config shows the in-code header tag
-		input["APM_TRACING"] = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`)}
+		input = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`)}
 		applyStatus = tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
 		require.Equal(t, 1, globalconfig.HeaderTagsLen())
@@ -191,8 +191,8 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t, WithService("my-service"), WithEnv("my-env"))
 		defer stop()
 
-		input := map[string]remoteconfig.ProductUpdate{
-			"APM_TRACING": {"path": []byte(`{"lib_config": {"tracing_sampling_rate": "string value", "service_target": {"service": "my-service", "env": "my-env"}}}`)},
+		input := remoteconfig.ProductUpdate{
+			"path": []byte(`{"lib_config": {"tracing_sampling_rate": "string value", "service_target": {"service": "my-service", "env": "my-env"}}}`),
 		}
 		applyStatus := tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateError, applyStatus["path"].State)
@@ -209,8 +209,8 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t, WithServiceName("my-service"), WithEnv("my-env"))
 		defer stop()
 
-		input := map[string]remoteconfig.ProductUpdate{
-			"APM_TRACING": {"path": []byte(`{"lib_config": {}, "service_target": {"service": "other-service", "env": "my-env"}}`)},
+		input := remoteconfig.ProductUpdate{
+			"path": []byte(`{"lib_config": {}, "service_target": {"service": "other-service", "env": "my-env"}}`),
 		}
 		applyStatus := tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateError, applyStatus["path"].State)
@@ -227,8 +227,8 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t, WithServiceName("my-service"), WithEnv("my-env"))
 		defer stop()
 
-		input := map[string]remoteconfig.ProductUpdate{
-			"APM_TRACING": {"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "other-env"}}`)},
+		input := remoteconfig.ProductUpdate{
+			"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "other-env"}}`),
 		}
 		applyStatus := tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateError, applyStatus["path"].State)
@@ -247,8 +247,8 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		defer stop()
 
 		// Apply RC. Assert global tags have the RC tags key3:val3,key4:val4 applied + runtime ID
-		input := map[string]remoteconfig.ProductUpdate{
-			"APM_TRACING": {"path": []byte(`{"lib_config": {"tracing_tags": ["key3:val3","key4:val4"]}, "service_target": {"service": "my-service", "env": "my-env"}}`)},
+		input := remoteconfig.ProductUpdate{
+			"path": []byte(`{"lib_config": {"tracing_tags": ["key3:val3","key4:val4"]}, "service_target": {"service": "my-service", "env": "my-env"}}`),
 		}
 		applyStatus := tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
@@ -267,7 +267,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_tags", Value: "key3:val3,key4:val4," + runtimeIDTag, Origin: "remote_config"}})
 
 		// Unset RC. Assert config shows the original DD_TAGS + WithGlobalTag + runtime ID
-		input["APM_TRACING"] = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`)}
+		input = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`)}
 		applyStatus = tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
 		s = tracer.StartSpan("web.request").(*span)

--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -31,6 +31,9 @@ import (
 // for each config file received through the update.
 type Callback func(updates map[string]ProductUpdate) map[string]rc.ApplyStatus
 
+// ProductCallback is like Callback but for a specific product.
+type ProductCallback func(update ProductUpdate) map[string]rc.ApplyStatus
+
 // Capability represents a bit index to be set in clientData.Capabilites in order to register a client
 // for a specific capability
 type Capability uint
@@ -87,9 +90,10 @@ type Client struct {
 	repository *rc.Repository
 	stop       chan struct{}
 
-	callbacks    []Callback
-	products     map[string]struct{}
-	capabilities map[Capability]struct{}
+	callbacks             []Callback
+	products              map[string]struct{}
+	productsWithCallbacks map[string]ProductCallback
+	capabilities          map[Capability]struct{}
 
 	lastError error
 }
@@ -114,15 +118,16 @@ func newClient(config ClientConfig) (*Client, error) {
 	}
 
 	return &Client{
-		ClientConfig: config,
-		clientID:     generateID(),
-		endpoint:     fmt.Sprintf("%s/v0.7/config", config.AgentURL),
-		repository:   repo,
-		stop:         make(chan struct{}),
-		lastError:    nil,
-		callbacks:    []Callback{},
-		capabilities: map[Capability]struct{}{},
-		products:     map[string]struct{}{},
+		ClientConfig:          config,
+		clientID:              generateID(),
+		endpoint:              fmt.Sprintf("%s/v0.7/config", config.AgentURL),
+		repository:            repo,
+		stop:                  make(chan struct{}),
+		lastError:             nil,
+		callbacks:             []Callback{},
+		capabilities:          map[Capability]struct{}{},
+		products:              map[string]struct{}{},
+		productsWithCallbacks: make(map[string]ProductCallback),
 	}, nil
 }
 
@@ -232,6 +237,24 @@ func (c *Client) updateState() {
 	c.lastError = c.applyUpdate(&update)
 }
 
+// Subscribe registers a product and its callback to be invoked when the client receives configuration updates.
+// Subscribe should be preferred over RegisterProduct and RegisterCallback if your callback only handles a single product.
+func Subscribe(product string, callback ProductCallback, capabilities ...Capability) error {
+	if client == nil {
+		return ErrClientNotStarted
+	}
+	client.Lock()
+	defer client.Unlock()
+	if _, found := client.products[product]; found {
+		return fmt.Errorf("product %s already registered via RegisterProduct", product)
+	}
+	client.productsWithCallbacks[product] = callback
+	for _, cap := range capabilities {
+		client.capabilities[cap] = struct{}{}
+	}
+	return nil
+}
+
 // RegisterCallback allows registering a callback that will be invoked when the client
 // receives configuration updates. It is up to that callback to then decide what to do
 // depending on the product related to the configuration update.
@@ -269,6 +292,9 @@ func RegisterProduct(p string) error {
 	}
 	client.Lock()
 	defer client.Unlock()
+	if _, found := client.productsWithCallbacks[p]; found {
+		return fmt.Errorf("product %s already registered via Subscribe", p)
+	}
 	client.products[p] = struct{}{}
 	return nil
 }
@@ -292,7 +318,8 @@ func HasProduct(p string) (bool, error) {
 	client.RLock()
 	defer client.RUnlock()
 	_, found := client.products[p]
-	return found, nil
+	_, foundWithCallback := client.productsWithCallbacks[p]
+	return found || foundWithCallback, nil
 }
 
 // RegisterCapability adds a capability to the list of capabilities exposed by the client when requesting
@@ -330,15 +357,27 @@ func HasCapability(cap Capability) (bool, error) {
 	return found, nil
 }
 
+func (c *Client) allProducts() []string {
+	products := make([]string, 0, len(c.products)+len(c.productsWithCallbacks))
+	for p := range c.products {
+		products = append(products, p)
+	}
+	for p := range c.productsWithCallbacks {
+		products = append(products, p)
+	}
+	return products
+}
+
 func (c *Client) applyUpdate(pbUpdate *clientGetConfigsResponse) error {
 	fileMap := make(map[string][]byte, len(pbUpdate.TargetFiles))
-	productUpdates := make(map[string]ProductUpdate, len(c.products))
-	for p := range c.products {
+	allProducts := c.allProducts()
+	productUpdates := make(map[string]ProductUpdate, len(allProducts))
+	for _, p := range allProducts {
 		productUpdates[p] = make(ProductUpdate)
 	}
 	for _, f := range pbUpdate.TargetFiles {
 		fileMap[f.Path] = f.Raw
-		for p := range c.products {
+		for _, p := range allProducts {
 			// Check the config file path to make sure it belongs to the right product
 			if strings.Contains(f.Path, "/"+p+"/") {
 				productUpdates[p][f.Path] = f.Raw
@@ -412,6 +451,14 @@ func (c *Client) applyUpdate(pbUpdate *clientGetConfigsResponse) error {
 		for path, status := range fn(productUpdates) {
 			if s, ok := statuses[path]; !ok || status.State == rc.ApplyStateError ||
 				s.State == rc.ApplyStateAcknowledged && status.State == rc.ApplyStateUnacknowledged {
+				statuses[path] = status
+			}
+		}
+	}
+	// Call the product-specific callbacks registered via Subscribe
+	for product, update := range productUpdates {
+		if fn, ok := c.productsWithCallbacks[product]; ok {
+			for path, status := range fn(update) {
 				statuses[path] = status
 			}
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Add a remote-config Subscribe function to register a product and its callback in a single call. This guarantees that the callback only receives updates for the corresponding product.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Make the API more ergonomic and easier to use.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
