### PR TITLE
.github/workflows: cherrypick changes from v2-dev for v2 nightly CI

### DIFF
--- a/.github/workflows/apps/test-contrib-submodules.sh
+++ b/.github/workflows/apps/test-contrib-submodules.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+# This script is used to test the contrib submodules in the apps directory.
+# It is run by the GitHub Actions CI workflow defined in
+# .github/workflows/unit-integration-tests.yml.
+
+CONTRIBS=$(find ./v2/contrib -mindepth 2 -maxdepth 5 -type f -name go.mod -exec dirname {} \;)
+
+for contrib in $CONTRIBS; do
+  echo "Testing contrib module: $contrib"
+  contrib_id=$(echo $contrib | sed 's/^\.\///g;s/[\/\.]/_/g')
+  cd $contrib
+  gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report-$contrib_id.xml -- ./... -v -race -coverprofile=coverage-$contrib_id.txt -covermode=atomic
+  cd -
+done

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -25,7 +25,7 @@ on:
     branches: release-v*
 env:
   DD_APPSEC_WAF_TIMEOUT: 5s
-  JUNIT_REPORT: gotestsum-report.xml
+  JUNIT_REPORT: /tmp/gotestsum-report
   TO_TEST: ./appsec/... ./internal/appsec/... ./contrib/google.golang.org/grpc/... ./contrib/net/http/... ./contrib/gorilla/mux/... ./contrib/go-chi/... ./contrib/labstack/echo.v4/... ./contrib/gin-gonic/gin/...
 jobs:
   native:
@@ -64,15 +64,15 @@ jobs:
       - name: go test
         shell: bash
         run: |
-          env GOBIN=$PWD go install gotest.tools/gotestsum@latest
+          go install gotest.tools/gotestsum@latest
           # Run the tests with gotestsum
-          env ${{ matrix.cgocheck }} CGO_ENABLED=${{ matrix.cgo_enabled }} ${{ matrix.appsec_enabled }} ./gotestsum --junitfile $JUNIT_REPORT -- -v $TO_TEST
+          env ${{ matrix.cgocheck }} CGO_ENABLED=${{ matrix.cgo_enabled }} ${{ matrix.appsec_enabled }} gotestsum --junitfile $JUNIT_REPORT.xml -- -v $TO_TEST
 
       - name: Upload the results to Datadog CI App
         uses: ./.github/actions/dd-ci-upload
         with:
           dd-api-key: ${{ secrets.DD_CI_API_KEY }}
-          files: ${{ env.JUNIT_REPORT }}
+          files: ${{ env.JUNIT_REPORT }}*.xml
           tags: go:${{ matrix.go-version }},arch:${{ runner.arch }},os:${{ runner.os }}
 
   # Tests cases were appsec end up being disable
@@ -105,15 +105,15 @@ jobs:
       - name: go test
         shell: bash
         run: |
-          env GOBIN=$PWD go install gotest.tools/gotestsum@latest
+          go install gotest.tools/gotestsum@latest
           # Run the tests with gotestsum
-          env ${{ matrix.appsec_enabled }} ./gotestsum --junitfile $JUNIT_REPORT -- -v $TO_TEST
+          env ${{ matrix.appsec_enabled }} gotestsum --junitfile $JUNIT_REPORT.xml -- -v $TO_TEST
 
       - name: Upload the results to Datadog CI App
         uses: ./.github/actions/dd-ci-upload
         with:
           dd-api-key: ${{ secrets.DD_CI_API_KEY }}
-          files: ${{ env.JUNIT_REPORT }}
+          files: ${{ env.JUNIT_REPORT }}*.xml
           tags: go:${{ matrix.go-version }},arch:${{ runner.arch }},os:${{ runner.os }}
 
 
@@ -156,16 +156,16 @@ jobs:
       - name: go test
         run: |
           # Install gotestsum to get the results in a junit file
-          env GOBIN=$PWD go install gotest.tools/gotestsum@latest
+          go install gotest.tools/gotestsum@latest
           # Run the tests with gotestsum
-          env CGO_ENABLED=${{ matrix.cgo_enabled }} ${{ matrix.appsec_enabled }} ./gotestsum --junitfile $JUNIT_REPORT -- -v $TO_TEST
+          env CGO_ENABLED=${{ matrix.cgo_enabled }} ${{ matrix.appsec_enabled }} gotestsum --junitfile $JUNIT_REPORT.xml -- -v $TO_TEST
 
       - name: Upload the results to Datadog CI App
         if: matrix.distribution != 'alpine' # datadog-ci CLI doesn't work on alpine
         uses: ./.github/actions/dd-ci-upload
         with:
           dd-api-key: ${{ secrets.DD_CI_API_KEY }}
-          files: ${{ env.JUNIT_REPORT }}
+          files: ${{ env.JUNIT_REPORT }}*.xml
           tags: go:${{ matrix.go-version }},arch:${{ runner.arch }},os:${{ runner.os }},distribution:${{ matrix.distribution }}
 
   linux-arm64:

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 env:
-  V2_BRANCH: ${{ inputs.ref == 'refs/heads/v2-dev' }}
+  V2_BRANCH: false
 
 jobs:
   govulncheck-tests:

--- a/.github/workflows/multios-unit-tests.yml
+++ b/.github/workflows/multios-unit-tests.yml
@@ -27,7 +27,7 @@ on:
         type: string
 
 env:
-  V2_BRANCH: ${{ inputs.ref == 'refs/heads/v2-dev' }}
+  V2_BRANCH: false
 
 jobs:
   test-multi-os:

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -28,7 +28,7 @@ jobs:
       group: "APM Larger Runners"
     env:
       TEST_LIBRARY: golang
-      V2_BRANCH: ${{ inputs.ref == 'refs/heads/v2-dev' }}
+      V2_BRANCH: false
     steps:
       - name: Checkout system tests
         uses: actions/checkout@v3

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -93,7 +93,7 @@ jobs:
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
       SYSTEM_TESTS_E2E_DD_API_KEY: ${{ secrets.SYSTEM_TESTS_E2E_DD_API_KEY }}
       SYSTEM_TESTS_E2E_DD_APP_KEY: ${{ secrets.SYSTEM_TESTS_E2E_DD_APP_KEY }}
-      V2_BRANCH: ${{ inputs.branch_ref == 'refs/heads/v2-dev' }}
+      V2_BRANCH: false
     name: Test (${{ matrix.weblog-variant }}, ${{ matrix.scenario }})
     steps:
       - name: Checkout system tests
@@ -103,6 +103,7 @@ jobs:
           repository: 'DataDog/system-tests'
           ref: ${{ inputs.ref }}
 
+      # TODO(darccio): remove ref on v2 release
       - name: Checkout system tests (v2)
         uses: actions/checkout@v3
         if: ${{ env.V2_BRANCH == 'true' }}

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -51,7 +51,7 @@ jobs:
     env:
        TEST_RESULTS: /tmp/test-results # path to where test results will be saved
        INTEGRATION: true
-       V2_BRANCH: ${{ inputs.ref == 'refs/heads/v2-dev' }}
+       V2_BRANCH: false
     services:
       datadog-agent:
         image: datadog/agent:latest
@@ -206,13 +206,17 @@ jobs:
           PACKAGE_NAMES=$(go list ./contrib/... | grep -v -e google.golang.org/api)
           gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- $PACKAGE_NAMES -v -race -coverprofile=coverage.txt -covermode=atomic
 
+      - name: Test Contrib Submodules (v2)
+        if: ${{ env.V2_BRANCH == 'true' }} && always()
+        run: ./.github/workflows/apps/test-contrib-submodules.sh
+
       - name: Upload the results to Datadog CI App
         if: always()
         continue-on-error: true
         uses: ./.github/actions/dd-ci-upload
         with:
           dd-api-key: ${{ secrets.DD_CI_API_KEY }}
-          files: ${{ env.TEST_RESULTS }}/gotestsum-report.xml
+          files: ${{ env.TEST_RESULTS }}/gotestsum-report*.xml
           tags: go:${{ inputs.go-version }},arch:${{ runner.arch }},os:${{ runner.os }},distribution:${{ runner.distribution }}
 
       - name: Upload Coverage


### PR DESCRIPTION
### What does this PR do?

Adds some last changes for running scheduled v2 nightly CI from main.

### Motivation

Ensure that the nightly CI runs without errors, except for flaky tests.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
