### PR TITLE
tracer: add support for span.StartChild

### DIFF
--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -100,6 +100,9 @@ type Span interface {
 
 	// Context returns the SpanContext of this Span.
 	Context() SpanContext
+
+	// StartChild starts a new child span with the given operation name and options.
+	StartChild(operationName string, opts ...StartSpanOption) Span
 }
 
 // SpanContext represents a span state that can propagate to descendant spans

--- a/ddtrace/example_test.go
+++ b/ddtrace/example_test.go
@@ -29,7 +29,7 @@ func Example_datadog() {
 	defer span.Finish()
 
 	// Create a child of it, computing the time needed to read a file.
-	child := tracer.StartSpan("read.file", tracer.ChildOf(span.Context()))
+	child := span.StartChild("read.file")
 	child.SetTag(ext.ResourceName, "test.json")
 
 	// If you are using 128 bit trace ids and want to generate the high

--- a/ddtrace/internal/globaltracer.go
+++ b/ddtrace/internal/globaltracer.go
@@ -100,6 +100,11 @@ func (NoopSpan) Tracer() ddtrace.Tracer { return NoopTracer{} }
 // Context implements ddtrace.Span.
 func (NoopSpan) Context() ddtrace.SpanContext { return NoopSpanContext{} }
 
+// StartSpan implements ddtrace.Span.
+func (NoopSpan) StartChild(_ string, _ ...ddtrace.StartSpanOption) ddtrace.Span {
+	return NoopSpan{}
+}
+
 var _ ddtrace.SpanContext = (*NoopSpanContext)(nil)
 
 // NoopSpanContext is an implementation of ddtrace.SpanContext that is a no-op.

--- a/ddtrace/mocktracer/mockspan.go
+++ b/ddtrace/mocktracer/mockspan.go
@@ -47,6 +47,9 @@ type Span interface {
 	// Context returns the span's SpanContext.
 	Context() ddtrace.SpanContext
 
+	// StartChild starts a new child span with the given operation name and options.
+	StartChild(operationName string, opts ...ddtrace.StartSpanOption) ddtrace.Span
+
 	// Stringer allows pretty-printing the span's fields for debugging.
 	fmt.Stringer
 }
@@ -276,4 +279,10 @@ func (s *mockspan) Root() tracer.Span {
 	}
 	root, _ := current.(*mockspan)
 	return root
+}
+
+// StartChild starts a new child span with the given operation name and options.
+func (s *mockspan) StartChild(operationName string, opts ...ddtrace.StartSpanOption) ddtrace.Span {
+	opts = append(opts, tracer.ChildOf(s.Context()))
+	return s.tracer.StartSpan(operationName, opts...)
 }

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -1140,8 +1140,8 @@ func WithSpanID(id uint64) StartSpanOption {
 	}
 }
 
-// ChildOf tells StartSpan to use the given span context as a parent for the
-// created span.
+// ChildOf tells StartSpan to use the given span context as a parent for the created span.
+// ChildOf is deprecated, use span.StartChild instead.
 func ChildOf(ctx ddtrace.SpanContext) StartSpanOption {
 	return func(cfg *ddtrace.StartSpanConfig) {
 		cfg.Parent = ctx

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -1141,7 +1141,8 @@ func WithSpanID(id uint64) StartSpanOption {
 }
 
 // ChildOf tells StartSpan to use the given span context as a parent for the created span.
-// ChildOf is deprecated, use span.StartChild instead.
+//
+// Deprecated: Use span.StartChild instead.
 func ChildOf(ctx ddtrace.SpanContext) StartSpanOption {
 	return func(cfg *ddtrace.StartSpanConfig) {
 		cfg.Parent = ctx

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -269,6 +269,12 @@ func (s *span) SetUser(id string, opts ...UserMonitoringOption) {
 	}
 }
 
+// StartChild starts a new child span with the given operation name and options.
+func (s *span) StartChild(operationName string, opts ...ddtrace.StartSpanOption) ddtrace.Span {
+	opts = append(opts, ChildOf(s.Context()))
+	return internal.GetGlobalTracer().StartSpan(operationName, opts...)
+}
+
 // setSamplingPriorityLocked updates the sampling priority.
 // It also updates the trace's sampling priority.
 func (s *span) setSamplingPriorityLocked(priority int, sampler samplernames.SamplerName) {

--- a/internal/appsec/_testlib/mockspan.go
+++ b/internal/appsec/_testlib/mockspan.go
@@ -48,3 +48,7 @@ func (m *MockSpan) Finish(_ ...ddtrace.FinishOption) {
 func (m *MockSpan) Context() ddtrace.SpanContext {
 	panic("unused")
 }
+
+func (m *MockSpan) StartChild(op string, opts ...ddtrace.StartSpanOption) ddtrace.Span {
+	panic("unused")
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

AIT-8746

Add support for `span.StartChild`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

fixes https://github.com/DataDog/dd-trace-go/issues/427

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
