### PR TITLE
profiler: randomize when execution traces are collected

### DIFF
--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -88,7 +89,15 @@ type profiler struct {
 
 func (p *profiler) shouldTrace() bool {
 	p.cfg.traceConfig.Refresh()
-	return p.cfg.traceConfig.Enabled && time.Since(p.lastTrace) > p.cfg.traceConfig.Period
+	if !p.cfg.traceConfig.Enabled {
+		return false
+	}
+	if p.cfg.traceConfig.Period < p.cfg.period {
+		return true
+	}
+	// Randomly record a trace with probability (profile period) / (trace period)
+	prob := float64(p.cfg.period) / float64(p.cfg.traceConfig.Period)
+	return rand.Float64() < prob
 }
 
 // testHooks are functions that are replaced during testing which would normally


### PR DESCRIPTION
### What does this PR do?

Randomize execution trace collection. Each profiling cycle we record an
execution trace with probability `(profiling period) / (trace period)`. This
way we still maintain the same desired avarage data rate of one trace every 15
minutes by default.

### Motivation

We currently record execution traces at a fixed interval. This means
that apps which are deployed across several instances simulatenously
will have time periods where no instances have execution trace data.
This also biases us against activity which occurs with a frequency which
is harmonic with the trace collection frequency. To fully address this
we would need to decouple execution trace collection from the normal
profiling cycle. But as a first step, we should give every profiling
cycle a chance of recording data.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
