### PR TITLE
ddtrace/tracer: add JSON logging workaround for tracer logs in WithLogger docs

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -738,6 +738,9 @@ func WithFeatureFlags(feats ...string) StartOption {
 }
 
 // WithLogger sets logger as the tracer's error printer.
+// Diagnostic and startup tracer logs are prefixed to simplify the search within logs.
+// If JSON logging format is required, it's possible to wrap tracer logs using an existing JSON logger with this
+// function. To learn more about this possibility, please visit: https://github.com/DataDog/dd-trace-go/issues/2152#issuecomment-1790586933
 func WithLogger(logger ddtrace.Logger) StartOption {
 	return func(c *config) {
 		c.logger = logger


### PR DESCRIPTION
### What does this PR do?

Adds a comment with link to the workaround in the WithLogger, as detailed in https://github.com/DataDog/dd-trace-go/issues/2152#issuecomment-1790586933

Closes #2152 

### Motivation

Some [customers](https://github.com/DataDog/dd-trace-go/issues/2295) and [projects](https://github.com/DataDog/dd-trace-go/issues/2152) want to have all logs generated as JSON, including the tracer diagnostic and startup logs.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
