### PR TITLE
all: implement mocktracer in terms of the new API

### DIFF
--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -35,14 +35,16 @@ jobs:
         if: ${{ env.V2_BRANCH != 'true' }}
         with:
           repository: 'DataDog/system-tests'
-          ref: refs/heads/dario.castane/AIT-3705/dd-trace-go.v2
+          ref: refs/heads/knusbaum/update-for-2409
+          #ref: refs/heads/dario.castane/AIT-3705/dd-trace-go.v2
 
       - name: Checkout system tests (v2)
         uses: actions/checkout@v3
         if: ${{ env.V2_BRANCH == 'true' }}
         with:
           repository: 'DataDog/system-tests'
-          ref: refs/heads/dario.castane/AIT-3705/dd-trace-go.v2
+          ref: refs/heads/knusbaum/update-for-2409
+          #ref: refs/heads/dario.castane/AIT-3705/dd-trace-go.v2
 
       - name: Checkout dd-trace-go
         uses: actions/checkout@v3

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -110,7 +110,8 @@ jobs:
         if: ${{ env.V2_BRANCH == 'true' }}
         with:
           repository: 'DataDog/system-tests'
-          ref: refs/heads/dario.castane/AIT-3705/dd-trace-go.v2
+          ref: refs/heads/knusbaum/update-for-2409
+          #ref: refs/heads/dario.castane/AIT-3705/dd-trace-go.v2
 
       - name: Checkout dd-trace-go
         uses: actions/checkout@v3

--- a/appsec/appsec.go
+++ b/appsec/appsec.go
@@ -144,12 +144,5 @@ func getRootSpan(ctx context.Context) *tracer.Span {
 		log.Error("appsec: could not find a span in the given Go context")
 		return nil
 	}
-	type rooter interface {
-		Root() *tracer.Span
-	}
-	if lrs, ok := span.(rooter); ok {
-		return lrs.Root()
-	}
-	log.Error("appsec: could not access the root span")
-	return nil
+	return span.Root()
 }

--- a/appsec/appsec_test.go
+++ b/appsec/appsec_test.go
@@ -7,6 +7,7 @@ package appsec_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/DataDog/dd-trace-go/v2/appsec"
@@ -30,7 +31,7 @@ func TestTrackUserLoginSuccessEvent(t *testing.T) {
 		require.Len(t, mt.FinishedSpans(), 1)
 		finished := mt.FinishedSpans()[0]
 		expectedEventPrefix := "appsec.events.users.login.success."
-		require.Equal(t, true, finished.Tag(expectedEventPrefix+"track"))
+		require.Equal(t, "true", finished.Tag(expectedEventPrefix+"track"))
 		require.Equal(t, "user id", finished.Tag("usr.id"))
 		require.Equal(t, "us-east-1", finished.Tag(expectedEventPrefix+"region"))
 		require.Equal(t, "username", finished.Tag("usr.name"))
@@ -48,7 +49,7 @@ func TestTrackUserLoginSuccessEvent(t *testing.T) {
 		require.Len(t, mt.FinishedSpans(), 1)
 		finished := mt.FinishedSpans()[0]
 		expectedEventPrefix := "appsec.events.users.login.success."
-		require.Equal(t, true, finished.Tag(expectedEventPrefix+"track"))
+		require.Equal(t, "true", finished.Tag(expectedEventPrefix+"track"))
 		require.Equal(t, "user id", finished.Tag("usr.id"))
 	})
 
@@ -80,9 +81,9 @@ func TestTrackUserLoginFailureEvent(t *testing.T) {
 				require.Len(t, mt.FinishedSpans(), 1)
 				finished := mt.FinishedSpans()[0]
 				expectedEventPrefix := "appsec.events.users.login.failure."
-				require.Equal(t, true, finished.Tag(expectedEventPrefix+"track"))
+				require.Equal(t, "true", finished.Tag(expectedEventPrefix+"track"))
 				require.Equal(t, "user id", finished.Tag(expectedEventPrefix+"usr.id"))
-				require.Equal(t, userExists, finished.Tag(expectedEventPrefix+"usr.exists"))
+				require.Equal(t, fmt.Sprintf("%t", userExists), finished.Tag(expectedEventPrefix+"usr.exists"))
 				require.Equal(t, "us-east-1", finished.Tag(expectedEventPrefix+"region"))
 			}
 		}
@@ -117,7 +118,7 @@ func TestCustomEvent(t *testing.T) {
 		require.Len(t, mt.FinishedSpans(), 1)
 		finished := mt.FinishedSpans()[0]
 		expectedEventPrefix := "appsec.events.my-custom-event."
-		require.Equal(t, true, finished.Tag(expectedEventPrefix+"track"))
+		require.Equal(t, "true", finished.Tag(expectedEventPrefix+"track"))
 		for k, v := range md {
 			require.Equal(t, v, finished.Tag(expectedEventPrefix+k))
 		}

--- a/contrib/internal/options/options_test.go
+++ b/contrib/internal/options/options_test.go
@@ -8,9 +8,10 @@ package options
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/dd-trace-go/v2/ddtrace"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestStringSliceModify(t *testing.T) {

--- a/ddtrace/mocktracer/mockspan.go
+++ b/ddtrace/mocktracer/mockspan.go
@@ -6,288 +6,123 @@
 package mocktracer // import "github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/DataDog/dd-trace-go/v2/ddtrace"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 )
 
-// var _ ddtrace.DDSpan = (*mockspan)(nil)
-//var _ Span = (*mockspan)(nil)
-
-// Span is an interface that allows querying a span returned by the mock tracer.
-// type Span interface {
-// 	// SpanID returns the span's ID.
-// 	SpanID() uint64
-
-// 	// TraceID returns the span's trace ID.
-// 	TraceID() uint64
-
-// 	// ParentID returns the span's parent ID.
-// 	ParentID() uint64
-
-// 	// StartTime returns the time when the span has started.
-// 	StartTime() time.Time
-
-// 	// FinishTime returns the time when the span has finished.
-// 	FinishTime() time.Time
-
-// 	// OperationName returns the operation name held by this span.
-// 	OperationName() string
-
-// 	// Tag returns the value of the tag at key k.
-// 	Tag(k string) interface{}
-
-// 	// Tags returns a copy of all the tags in this span.
-// 	Tags() map[string]interface{}
-
-// 	// Context returns the span's SpanContext.
-// 	Context() ddtrace.SpanContext
-
-// 	// StartChild starts a new child span with the given operation name and options.
-// 	StartChild(operationName string, opts ...ddtrace.StartSpanOption) *Span
-
-// 	// Stringer allows pretty-printing the span's fields for debugging.
-// 	fmt.Stringer
-// }
-
 func newSpan(t *mocktracer, operationName string, cfg *ddtrace.StartSpanConfig) *tracer.Span {
-	return nil // TODO(kjn, v2): Fix mock tracing
+	return tracer.SpanStart(operationName, func(c *ddtrace.StartSpanConfig) {
+		*c = *cfg
+	})
 }
 
-// func newSpan(t *mocktracer, operationName string, cfg *ddtrace.StartSpanConfig) *mockspan {
-// 	if cfg.Tags == nil {
-// 		cfg.Tags = make(map[string]interface{})
-// 	}
-// 	if cfg.Tags[ext.ResourceName] == nil {
-// 		cfg.Tags[ext.ResourceName] = operationName
-// 	}
-// 	s := &mockspan{
-// 		name:   operationName,
-// 		tracer: t,
-// 	}
-// 	if cfg.StartTime.IsZero() {
-// 		s.startTime = time.Now()
-// 	} else {
-// 		s.startTime = cfg.StartTime
-// 	}
-// 	id := cfg.SpanID
-// 	if id == 0 {
-// 		id = nextID()
-// 	}
-// 	s.context = &spanContext{spanID: id, traceID: id, span: s}
-// 	if ctx, ok := cfg.Parent.(*spanContext); ok {
-// 		if ctx.span != nil && s.tags[ext.ServiceName] == nil {
-// 			// if we have a local parent and no service, inherit the parent's
-// 			s.SetTag(ext.ServiceName, ctx.span.Tag(ext.ServiceName))
-// 		}
-// 		if ctx.hasSamplingPriority() {
-// 			s.SetTag(ext.SamplingPriority, ctx.samplingPriority())
-// 		}
-// 		s.parentID = ctx.spanID
-// 		s.context.priority = ctx.samplingPriority()
-// 		s.context.hasPriority = ctx.hasSamplingPriority()
-// 		s.context.traceID = ctx.traceID
-// 		s.context.baggage = make(map[string]string, len(ctx.baggage))
-// 		ctx.ForeachBaggageItem(func(k, v string) bool {
-// 			s.context.baggage[k] = v
-// 			return true
-// 		})
-// 	}
-// 	for k, v := range cfg.Tags {
-// 		s.SetTag(k, v)
-// 	}
-// 	return s
-// }
+type Span struct {
+	*tracer.Span
+}
 
-// type mockspan struct {
-// 	sync.RWMutex // guards below fields
-// 	name         string
-// 	tags         map[string]interface{}
-// 	finishTime   time.Time
-// 	finished     bool
+func MockSpan(s *tracer.Span) *Span {
+	return &Span{Span: s}
+}
 
-// 	startTime time.Time
-// 	parentID  uint64
-// 	context   *spanContext
-// 	tracer    *mocktracer
-// }
+func (s *Span) OperationName() string {
+	return s.Name
+}
 
-// // SetTag sets a given tag on the span.
-// func (s *mockspan) SetTag(key string, value interface{}) {
-// 	s.Lock()
-// 	defer s.Unlock()
-// 	if s.finished {
-// 		return
-// 	}
-// 	if s.tags == nil {
-// 		s.tags = make(map[string]interface{}, 1)
-// 	}
-// 	if key == ext.SamplingPriority {
-// 		switch p := value.(type) {
-// 		case int:
-// 			s.context.setSamplingPriority(p)
-// 		case float64:
-// 			s.context.setSamplingPriority(int(p))
-// 		}
-// 	}
-// 	s.tags[key] = value
-// }
+func (s *Span) Tag(k string) interface{} {
+	if s == nil {
+		return nil
+	}
+	switch k {
+	case ext.SpanName:
+		return s.Name
+	case ext.ServiceName:
+		return s.Service
+	case ext.ResourceName:
+		return s.Resource
+	case ext.SpanType:
+		return s.Type
+	}
+	if s.Meta != nil {
+		if r, ok := s.Meta[k]; ok {
+			return r
+		}
+	}
+	if s.Metrics != nil {
+		if r, ok := s.Metrics[k]; ok {
+			return r
+		}
+	}
+	return nil
+}
 
-// func (s *mockspan) FinishTime() time.Time {
-// 	s.RLock()
-// 	defer s.RUnlock()
-// 	return s.finishTime
-// }
+func (s *Span) Tags() map[string]interface{} {
+	r := make(map[string]interface{})
+	if s == nil {
+		return r
+	}
+	for k, v := range s.Meta {
+		r[k] = v
+	}
+	for k, v := range s.Metrics {
+		r[k] = v
+	}
+	r[ext.SpanName] = s.Name
+	r[ext.ServiceName] = s.Service
+	r[ext.ResourceName] = s.Resource
+	r[ext.SpanType] = s.Type
+	return r
+}
 
-// func (s *mockspan) StartTime() time.Time { return s.startTime }
+func (s *Span) String() string {
+	s.RLock()
+	defer s.RUnlock()
+	sc := s.Context()
+	baggage := make(map[string]string)
+	sc.ForeachBaggageItem(func(k, v string) bool {
+		baggage[k] = v
+		return true
+	})
 
-// func (s *mockspan) Tag(k string) interface{} {
-// 	s.RLock()
-// 	defer s.RUnlock()
-// 	return s.tags[k]
-// }
+	return fmt.Sprintf(`
+name: %s
+tags: %#v
+start: %s
+duration: %s
+id: %d
+parent: %d
+trace: %d
+baggage: %#v
+`, s.Name, s.Tags(), s.StartTime(), s.Duration(), sc.SpanID(), s.ParentID(), sc.TraceID(), baggage)
+}
 
-// func (s *mockspan) Tags() map[string]interface{} {
-// 	s.RLock()
-// 	defer s.RUnlock()
-// 	// copy
-// 	cp := make(map[string]interface{}, len(s.tags))
-// 	for k, v := range s.tags {
-// 		cp[k] = v
-// 	}
-// 	return cp
-// }
+func (s *Span) ParentID() uint64 {
+	return s.Span.ParentID
+}
 
-// func (s *mockspan) TraceID() uint64 { return s.context.traceID }
+func (s *Span) SpanID() uint64 {
+	return s.Span.SpanID
+}
 
-// func (s *mockspan) SpanID() uint64 { return s.context.spanID }
+func (s *Span) TraceID() uint64 {
+	return s.Span.TraceID
+}
 
-// func (s *mockspan) ParentID() uint64 { return s.parentID }
+func (s *Span) StartTime() time.Time {
+	return time.Unix(0, s.Span.Start)
+}
 
-// func (s *mockspan) OperationName() string {
-// 	s.RLock()
-// 	defer s.RUnlock()
-// 	return s.name
-// }
+func (s *Span) Duration() time.Duration {
+	return time.Duration(s.Span.Duration)
+}
 
-// // SetOperationName resets the original operation name to the given one.
-// func (s *mockspan) SetOperationName(operationName string) {
-// 	s.Lock()
-// 	defer s.Unlock()
-// 	s.name = operationName
-// 	return
-// }
+func (s *Span) FinishTime() time.Time {
+	return s.StartTime().Add(s.Duration())
+}
 
-// // BaggageItem returns the baggage item with the given key.
-// func (s *mockspan) BaggageItem(key string) string {
-// 	return s.context.baggageItem(key)
-// }
-
-// // SetBaggageItem sets a new baggage item at the given key. The baggage
-// // item should propagate to all descendant spans, both in- and cross-process.
-// func (s *mockspan) SetBaggageItem(key, val string) {
-// 	s.context.setBaggageItem(key, val)
-// 	return
-// }
-
-// // Finish finishes the current span with the given options.
-// func (s *mockspan) Finish(opts ...ddtrace.FinishOption) {
-// 	var cfg ddtrace.FinishConfig
-// 	for _, fn := range opts {
-// 		fn(&cfg)
-// 	}
-// 	var t time.Time
-// 	if cfg.FinishTime.IsZero() {
-// 		t = time.Now()
-// 	} else {
-// 		t = cfg.FinishTime
-// 	}
-// 	if cfg.Error != nil {
-// 		s.SetTag(ext.Error, cfg.Error)
-// 	}
-// 	if cfg.NoDebugStack {
-// 		s.SetTag(ext.ErrorStack, "<debug stack disabled>")
-// 	}
-// 	s.Lock()
-// 	defer s.Unlock()
-// 	if s.finished {
-// 		return
-// 	}
-// 	s.finished = true
-// 	s.finishTime = t
-// 	s.tracer.addFinishedSpan(s)
-// }
-
-// // String implements fmt.Stringer.
-// func (s *mockspan) String() string {
-// 	s.RLock()
-// 	defer s.RUnlock()
-// 	sc := s.context
-// 	return fmt.Sprintf(`
-// name: %s
-// tags: %#v
-// start: %s
-// finish: %s
-// id: %d
-// parent: %d
-// trace: %d
-// baggage: %#v
-// `, s.name, s.tags, s.startTime, s.finishTime, sc.spanID, s.parentID, sc.traceID, sc.baggage)
-// }
-
-// // Context returns the SpanContext of this Span.
-// func (s *mockspan) Context() ddtrace.SpanContext { return s.context }
-
-// // SetUser associates user information to the current trace which the
-// // provided span belongs to. The options can be used to tune which user
-// // bit of information gets monitored. This mockup only sets the user
-// // information as span tags of the root span of the current trace.
-// func (s *mockspan) SetUser(id string, opts ...tracer.UserMonitoringOption) {
-// 	root := s.Root()
-// 	if root == nil {
-// 		return
-// 	}
-
-// 	var cfg tracer.UserMonitoringConfig
-// 	for _, fn := range opts {
-// 		fn(&cfg)
-// 	}
-
-// 	root.SetTag("usr.id", id)
-// 	root.SetTag("usr.email", cfg.Email)
-// 	root.SetTag("usr.name", cfg.Name)
-// 	root.SetTag("usr.role", cfg.Role)
-// 	root.SetTag("usr.scope", cfg.Scope)
-// 	root.SetTag("usr.session_id", cfg.SessionID)
-// }
-
-// // Root walks the span up to the root parent span and returns it.
-// // This method is required by some internal packages such as appsec.
-// func (s *mockspan) Root() *tracer.Span {
-// 	return nil
-// }
-
-// // // Root walks the span up to the root parent span and returns it.
-// // // This method is required by some internal packages such as appsec.
-// // func (s *mockspan) Root() *tracer.Span {
-// // 	openSpans := s.tracer.openSpans
-// // 	var current *tracer.Span = s
-// // 	for {
-// // 		pid := current.ParentID()
-// // 		if pid == 0 {
-// // 			break
-// // 		}
-// // 		parent, ok := openSpans[pid]
-// // 		if !ok {
-// // 			break
-// // 		}
-// // 		current = parent
-// // 	}
-// // 	root, _ := current.(*mockspan)
-// // 	return root
-// // }
-
-// // StartChild starts a new child span with the given operation name and options.
-// func (s *mockspan) StartChild(operationName string, opts ...ddtrace.StartSpanOption) *Span {
-// 	opts = append(opts, tracer.ChildOf(s.Context()))
-// 	return s.tracer.StartSpan(operationName, opts...)
-// }
+func (s *Span) RealSpan() *tracer.Span {
+	return s.Span
+}

--- a/ddtrace/opentelemetry/tracer_test.go
+++ b/ddtrace/opentelemetry/tracer_test.go
@@ -29,7 +29,7 @@ func TestGetTracer(t *testing.T) {
 	assert := assert.New(t)
 	tp := NewTracerProvider()
 	tr := tp.Tracer("ot")
-	dd := GetGlobalTracer()
+	dd := tracer.GetGlobalTracer()
 	ott, ok := tr.(*oteltracer)
 	assert.True(ok)
 	assert.Equal(ott.DD, dd)

--- a/ddtrace/tracer/context.go
+++ b/ddtrace/tracer/context.go
@@ -13,6 +13,12 @@ import (
 
 // ContextWithSpan returns a copy of the given context which includes the span s.
 func ContextWithSpan(ctx context.Context, s *Span) context.Context {
+	if s == nil {
+		return ctx
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	return context.WithValue(ctx, internal.ActiveSpanKey, s)
 }
 
@@ -50,7 +56,13 @@ func StartSpanFromContext(ctx context.Context, operationName string, opts ...Sta
 	optsLocal = append(optsLocal, withContext(ctx))
 	s := StartSpan(operationName, optsLocal...)
 	//TODO(kjn v2): Check this when separating packages.
-	ctx = s.pprofCtxActive
+	if s == nil {
+		return nil, ctx
+	}
+	// TODO: This breaks things like ctx.Err(), ctx.Done()
+	if s.pprofCtxActive != nil {
+		ctx = s.pprofCtxActive
+	}
 	//if span, ok := s.(*Span); ok && span.pprofCtxActive != nil {
 	//	// If pprof labels were applied for this span, use the derived ctx that
 	//	// includes them. Otherwise a child of this span wouldn't be able to

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -101,17 +101,26 @@ func (s *Span) Context() ddtrace.SpanContext {
 // are propagated down to descendant spans and injected cross-process. Use with
 // care as it adds extra load onto your tracing layer.
 func (s *Span) SetBaggageItem(key, val string) {
+	if s == nil {
+		return
+	}
 	s.context.setBaggageItem(key, val)
 }
 
 // BaggageItem gets the value for a baggage item given its key. Returns the
 // empty string if the value isn't found in this Span.
 func (s *Span) BaggageItem(key string) string {
+	if s == nil {
+		return ""
+	}
 	return s.context.baggageItem(key)
 }
 
 // SetTag adds a set of key/value metadata to the span.
 func (s *Span) SetTag(key string, value interface{}) {
+	if s == nil {
+		return
+	}
 	s.Lock()
 	defer s.Unlock()
 	// We don't lock spans when flushing, so we could have a data race when
@@ -191,6 +200,9 @@ func (s *Span) SetTag(key string, value interface{}) {
 // setSamplingPriority locks then span, then updates the sampling priority.
 // It also updates the trace's sampling priority.
 func (s *Span) setSamplingPriority(priority int, sampler samplernames.SamplerName) {
+	if s == nil {
+		return
+	}
 	s.Lock()
 	defer s.Unlock()
 	s.setSamplingPriorityLocked(priority, sampler)
@@ -199,6 +211,9 @@ func (s *Span) setSamplingPriority(priority int, sampler samplernames.SamplerNam
 // Root returns the root span of the span's trace. The return value shouldn't be
 // nil as long as the root span is valid and not finished.
 func (s *Span) Root() *Span {
+	if s == nil {
+		return nil
+	}
 	return s.root()
 }
 
@@ -223,6 +238,9 @@ func (s *Span) root() *Span {
 // the user id can be propagated across traces using the WithPropagation() option.
 // See https://docs.datadoghq.com/security_platform/application_security/setup_and_configure/?tab=set_user#add-user-information-to-traces
 func (s *Span) SetUser(id string, opts ...UserMonitoringOption) {
+	if s == nil {
+		return
+	}
 	cfg := UserMonitoringConfig{
 		Metadata: make(map[string]string),
 	}
@@ -275,6 +293,9 @@ func (s *Span) SetUser(id string, opts ...UserMonitoringOption) {
 
 // StartChild starts a new child span with the given operation name and options.
 func (s *Span) StartChild(operationName string, opts ...ddtrace.StartSpanOption) *Span {
+	if s == nil {
+		return nil
+	}
 	opts = append(opts, ChildOf(s.Context()))
 	return GetGlobalTracer().StartSpan(operationName, opts...)
 }
@@ -503,6 +524,9 @@ func (s *Span) Finish(opts ...ddtrace.FinishOption) {
 
 // SetOperationName sets or changes the operation name.
 func (s *Span) SetOperationName(operationName string) {
+	if s == nil {
+		return
+	}
 	s.Lock()
 	defer s.Unlock()
 	// We don't lock spans when flushing, so we could have a data race when
@@ -644,6 +668,9 @@ func shouldComputeStats(s *Span) bool {
 // String returns a human readable representation of the span. Not for
 // production, just debugging.
 func (s *Span) String() string {
+	if s == nil {
+		return "<nil>"
+	}
 	s.RLock()
 	defer s.RUnlock()
 	lines := []string{
@@ -671,6 +698,9 @@ func (s *Span) String() string {
 
 // Format implements fmt.Formatter.
 func (s *Span) Format(f fmt.State, c rune) {
+	if s == nil {
+		fmt.Fprintf(f, "<nil>")
+	}
 	switch c {
 	case 's':
 		fmt.Fprint(f, s.String())

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -213,7 +213,7 @@ func TestTracerStart(t *testing.T) {
 		Start()
 
 		// ensure at least one worker started and handles requests
-		GetGlobalTracer().(*tracer).pushChunk(&chunk{spans: []*Span{}})
+		GetGlobalTracer().(*tracer).pushChunk(&Chunk{Spans: []*Span{}})
 
 		Stop()
 		Stop()
@@ -225,7 +225,7 @@ func TestTracerStart(t *testing.T) {
 		tr, _, _, stop, err := startTestTracer(t)
 		assert.Nil(t, err)
 		defer stop()
-		tr.pushChunk(&chunk{spans: []*Span{}}) // blocks until worker is started
+		tr.pushChunk(&Chunk{Spans: []*Span{}}) // blocks until worker is started
 		select {
 		case <-tr.stop:
 			t.Fatal("stopped channel should be open")
@@ -1594,11 +1594,11 @@ func TestPushPayload(t *testing.T) {
 	s.Meta["key"] = strings.Repeat("X", payloadSizeLimit/2+10)
 
 	// half payload size reached
-	tracer.pushChunk(&chunk{[]*Span{s}, true})
+	tracer.pushChunk(&Chunk{[]*Span{s}, true})
 	tracer.awaitPayload(t, 1)
 
 	// payload size exceeded
-	tracer.pushChunk(&chunk{[]*Span{s}, true})
+	tracer.pushChunk(&Chunk{[]*Span{s}, true})
 	flush(2)
 }
 
@@ -1622,16 +1622,16 @@ func TestPushTrace(t *testing.T) {
 			Resource: "/foo",
 		},
 	}
-	tracer.pushChunk(&chunk{spans: trace})
+	tracer.pushChunk(&Chunk{Spans: trace})
 
 	assert.Len(tracer.out, 1)
 
 	t0 := <-tracer.out
-	assert.Equal(&chunk{spans: trace}, t0)
+	assert.Equal(&Chunk{Spans: trace}, t0)
 
 	many := payloadQueueSize + 2
 	for i := 0; i < many; i++ {
-		tracer.pushChunk(&chunk{spans: make([]*Span, i)})
+		tracer.pushChunk(&Chunk{Spans: make([]*Span, i)})
 	}
 	assert.Len(tracer.out, payloadQueueSize)
 	log.Flush()

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -82,6 +82,19 @@ services:
       nofile:
         soft: 65536
         hard: 65536
+  elasticsearch8:
+    image: elasticsearch:8.6.2
+    environment:
+      http.port: 9204-9300
+      discovery.type: single-node
+      xpack.security.enabled: "false"
+      ES_JAVA_OPTS: "-Xms750m -Xmx750m" # https://github.com/10up/wp-local-docker/issues/6
+    ports:
+      - "9204:9204"
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
   datadog-agent:
     image: datadog/docker-dd-agent
     environment:
@@ -97,9 +110,9 @@ services:
       TRACE_LANGUAGE: golang
       ENABLED_CHECKS: trace_stall,trace_count_header,trace_peer_service,trace_dd_service
       PORT: 9126
-      DD_SUPPRESS_TRACE_PARSE_ERRORS: true
-      DD_POOL_TRACE_CHECK_FAILURES: true
-      DD_DISABLE_ERROR_RESPONSES: true
+      DD_SUPPRESS_TRACE_PARSE_ERRORS: "true"
+      DD_POOL_TRACE_CHECK_FAILURES: "true"
+      DD_DISABLE_ERROR_RESPONSES: "true"
     ports:
       - "127.0.0.1:9126:9126"
   mongodb:

--- a/internal/appsec/appsec.go
+++ b/internal/appsec/appsec.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/appsec-internal-go/limiter"
 	appsecLog "github.com/DataDog/appsec-internal-go/log"
 	waf "github.com/DataDog/go-libddwaf/v2"
+
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/dyngo"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 )

--- a/internal/appsec/config.go
+++ b/internal/appsec/config.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	internal "github.com/DataDog/appsec-internal-go/appsec"
+
 	"github.com/DataDog/dd-trace-go/v2/internal/remoteconfig"
 )
 

--- a/internal/appsec/listener/grpcsec/grpc.go
+++ b/internal/appsec/listener/grpcsec/grpc.go
@@ -12,6 +12,8 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/DataDog/appsec-internal-go/limiter"
+	waf "github.com/DataDog/go-libddwaf/v2"
+
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/dyngo"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/emitter/grpcsec"
@@ -20,7 +22,6 @@ import (
 	listener "github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/sharedsec"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/samplernames"
-	waf "github.com/DataDog/go-libddwaf/v2"
 )
 
 // gRPC rule addresses currently supported by the WAF

--- a/internal/appsec/listener/httpsec/http.go
+++ b/internal/appsec/listener/httpsec/http.go
@@ -13,6 +13,8 @@ import (
 
 	internal "github.com/DataDog/appsec-internal-go/appsec"
 	"github.com/DataDog/appsec-internal-go/limiter"
+	waf "github.com/DataDog/go-libddwaf/v2"
+
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/dyngo"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/emitter/httpsec"
@@ -20,7 +22,6 @@ import (
 	listener "github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/sharedsec"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/samplernames"
-	waf "github.com/DataDog/go-libddwaf/v2"
 )
 
 // HTTP rule addresses currently supported by the WAF

--- a/internal/appsec/listener/sharedsec/shared.go
+++ b/internal/appsec/listener/sharedsec/shared.go
@@ -10,11 +10,12 @@ import (
 	"time"
 
 	"github.com/DataDog/appsec-internal-go/limiter"
+	waf "github.com/DataDog/go-libddwaf/v2"
+
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/dyngo"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/emitter/httpsec"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/emitter/sharedsec"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
-	waf "github.com/DataDog/go-libddwaf/v2"
 )
 
 func RunWAF(wafCtx *waf.Context, values waf.RunAddressData, timeout time.Duration) waf.Result {

--- a/internal/appsec/listener/sharedsec/shared_test.go
+++ b/internal/appsec/listener/sharedsec/shared_test.go
@@ -8,9 +8,10 @@ package sharedsec
 import (
 	"testing"
 
-	"github.com/DataDog/dd-trace-go/v2/internal/appsec/trace"
 	waf "github.com/DataDog/go-libddwaf/v2"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/appsec/trace"
 )
 
 // Test that internal functions used to set span tags use the correct types

--- a/internal/appsec/trace/grpctrace/grpc.go
+++ b/internal/appsec/trace/grpctrace/grpc.go
@@ -6,7 +6,6 @@
 package grpctrace
 
 import (
-	"github.com/DataDog/dd-trace-go/v2/ddtrace"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/trace"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/trace/httptrace"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
@@ -31,7 +30,7 @@ func setSecurityEventsTags(span Span, events []any) error {
 }
 
 // SetRequestMetadataTags sets the gRPC request metadata span tags.
-func SetRequestMetadataTags(span ddtrace.Span, md map[string][]string) {
+func SetRequestMetadataTags(span Span, md map[string][]string) {
 	for h, v := range httptrace.NormalizeHTTPHeaders(md) {
 		span.SetTag("grpc.metadata."+h, v)
 	}

--- a/internal/appsec/trace/httptrace/http.go
+++ b/internal/appsec/trace/httptrace/http.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DataDog/appsec-internal-go/httpsec"
 	"github.com/DataDog/appsec-internal-go/netip"
+
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/trace"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 )

--- a/internal/appsec/waf.go
+++ b/internal/appsec/waf.go
@@ -9,12 +9,13 @@ import (
 	"errors"
 
 	"github.com/DataDog/appsec-internal-go/limiter"
+	waf "github.com/DataDog/go-libddwaf/v2"
+
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/dyngo"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/emitter/sharedsec"
 	grpc "github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/grpcsec"
 	http "github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/httpsec"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
-	waf "github.com/DataDog/go-libddwaf/v2"
 )
 
 const (

--- a/internal/appsec/waf_test.go
+++ b/internal/appsec/waf_test.go
@@ -13,12 +13,13 @@ import (
 	"strings"
 	"testing"
 
+	waf "github.com/DataDog/go-libddwaf/v2"
+
 	pAppsec "github.com/DataDog/dd-trace-go/v2/appsec"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/emitter/httpsec"
 	"github.com/DataDog/dd-trace-go/v2/internal/contrib/httptrace"
-	waf "github.com/DataDog/go-libddwaf/v2"
 
 	"github.com/stretchr/testify/require"
 )

--- a/internal/contrib/httptrace/httptrace.go
+++ b/internal/contrib/httptrace/httptrace.go
@@ -72,7 +72,8 @@ func FinishRequestSpan(s *tracer.Span, status int, opts ...tracer.FinishOption) 
 	}
 	s.SetTag(ext.HTTPCode, statusStr)
 	if status >= 500 && status < 600 {
-		s.SetTag(ext.Error, fmt.Errorf("%s: %s", statusStr, http.StatusText(status)))
+		//s.SetTag(ext.Error, fmt.Errorf("%s: %s", statusStr, http.StatusText(status)))
+		opts = append(opts, tracer.WithError(fmt.Errorf("%s: %s", statusStr, http.StatusText(status))))
 	}
 	s.Finish(opts...)
 }

--- a/internal/contrib/namingschematest/cache.go
+++ b/internal/contrib/namingschematest/cache.go
@@ -17,11 +17,11 @@ import (
 // NewRedisTest creates a new test for Redis naming schema.
 func NewRedisTest(genSpans GenSpansFn, defaultServiceName string) func(t *testing.T) {
 	return func(t *testing.T) {
-		assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+		assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 			require.Len(t, spans, 1)
 			assert.Equal(t, "redis.command", spans[0].OperationName())
 		}
-		assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+		assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 			require.Len(t, spans, 1)
 			assert.Equal(t, "redis.command", spans[0].OperationName())
 		}

--- a/internal/contrib/namingschematest/client_server.go
+++ b/internal/contrib/namingschematest/client_server.go
@@ -27,11 +27,11 @@ func NewHTTPServerTest(genSpans GenSpansFn, defaultName string, opts ...Option) 
 		opt(cfg)
 	}
 	return func(t *testing.T) {
-		assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+		assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 			require.Len(t, spans, 1)
 			assert.Equal(t, "http.request", spans[0].OperationName())
 		}
-		assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+		assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 			require.Len(t, spans, 1)
 			assert.Equal(t, "http.server.request", spans[0].OperationName())
 		}

--- a/internal/contrib/namingschematest/db.go
+++ b/internal/contrib/namingschematest/db.go
@@ -17,11 +17,11 @@ import (
 // NewMongoDBTest creates a new test for MongoDB naming schema.
 func NewMongoDBTest(genSpans GenSpansFn, defaultServiceName string) func(t *testing.T) {
 	return func(t *testing.T) {
-		assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+		assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 			require.Len(t, spans, 1)
 			assert.Equal(t, "mongodb.query", spans[0].OperationName())
 		}
-		assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+		assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 			require.Len(t, spans, 1)
 			assert.Equal(t, "mongodb.query", spans[0].OperationName())
 		}

--- a/internal/contrib/namingschematest/messaging.go
+++ b/internal/contrib/namingschematest/messaging.go
@@ -17,12 +17,12 @@ import (
 // NewKafkaTest creates a new test for Kafka naming schema.
 func NewKafkaTest(genSpans GenSpansFn) func(t *testing.T) {
 	return func(t *testing.T) {
-		assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+		assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 			require.Len(t, spans, 2)
 			assert.Equal(t, "kafka.produce", spans[0].OperationName())
 			assert.Equal(t, "kafka.consume", spans[1].OperationName())
 		}
-		assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+		assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 			require.Len(t, spans, 2)
 			assert.Equal(t, "kafka.send", spans[0].OperationName())
 			assert.Equal(t, "kafka.process", spans[1].OperationName())

--- a/internal/contrib/namingschematest/namingschematest.go
+++ b/internal/contrib/namingschematest/namingschematest.go
@@ -23,7 +23,7 @@ import (
 // tests that use this package.
 // The provided serviceOverride string should be used to set the specific integration's WithServiceName option (if
 // available) when initializing and configuring the package.
-type GenSpansFn func(t *testing.T, serviceOverride string) []mocktracer.Span
+type GenSpansFn func(t *testing.T, serviceOverride string) []*mocktracer.Span
 
 // ServiceNameAssertions contains assertions for different test cases used inside the generated test
 // from NewServiceNameTest.
@@ -105,7 +105,7 @@ func NewServiceNameTest(genSpans GenSpansFn, wantV0 ServiceNameAssertions) func(
 	}
 }
 
-func assertServiceNames(t *testing.T, spans []mocktracer.Span, wantServiceNames []string) {
+func assertServiceNames(t *testing.T, spans []*mocktracer.Span, wantServiceNames []string) {
 	t.Helper()
 	require.Len(t, spans, len(wantServiceNames), "the number of spans and number of assertions should be the same")
 	for i := 0; i < len(spans); i++ {
@@ -133,7 +133,7 @@ func withDDService(ddService string) func() {
 }
 
 // AssertSpansFn allows to make assertions on the generated spans.
-type AssertSpansFn func(t *testing.T, spans []mocktracer.Span)
+type AssertSpansFn func(t *testing.T, spans []*mocktracer.Span)
 
 // NewSpanNameTest returns a new test that runs the provided assertion functions for each schema version.
 func NewSpanNameTest(genSpans GenSpansFn, assertV0 AssertSpansFn, assertV1 AssertSpansFn) func(t *testing.T) {

--- a/internal/contrib/sqltest/sqltest.go
+++ b/internal/contrib/sqltest/sqltest.go
@@ -124,7 +124,7 @@ func testQuery(cfg *Config) func(*testing.T) {
 		assert.Nil(err)
 
 		spans := cfg.mockTracer.FinishedSpans()
-		var querySpan mocktracer.Span
+		var querySpan *mocktracer.Span
 		if cfg.DriverName == "sqlserver" {
 			//The mssql driver doesn't support non-prepared queries so there are 3 spans
 			//connect, prepare, and query
@@ -270,7 +270,7 @@ func testExec(cfg *Config) func(*testing.T) {
 			assert.Len(spans, 5)
 		}
 
-		var span mocktracer.Span
+		var span *mocktracer.Span
 		for _, s := range spans {
 			if s.OperationName() == cfg.ExpectName && s.Tag(ext.ResourceName) == query {
 				span = s
@@ -294,7 +294,7 @@ func testExec(cfg *Config) func(*testing.T) {
 	}
 }
 
-func verifyConnectSpan(span mocktracer.Span, assert *assert.Assertions, cfg *Config) {
+func verifyConnectSpan(span *mocktracer.Span, assert *assert.Assertions, cfg *Config) {
 	assert.Equal(cfg.ExpectName, span.OperationName())
 	cfg.ExpectTags["sql.query_type"] = "Connect"
 	for k, v := range cfg.ExpectTags {

--- a/internal/contrib/telemetrytest/telemetry_test.go
+++ b/internal/contrib/telemetrytest/telemetry_test.go
@@ -72,6 +72,7 @@ func testTelemetryEnabled(t *testing.T, contribPath string) error {
 	}
 	body, err := exec.Command("go", "list", "-json", "./...").Output()
 	if err != nil {
+		t.Logf("Failed to list: %s\n", string(body))
 		return err
 	}
 	var packages []contribPkg

--- a/internal/traceprof/traceproftest/app.go
+++ b/internal/traceprof/traceproftest/app.go
@@ -20,7 +20,6 @@ import (
 
 	grpctrace "github.com/DataDog/dd-trace-go/v2/contrib/google.golang.org/grpc"
 	httptrace "github.com/DataDog/dd-trace-go/v2/contrib/julienschmidt/httprouter"
-	"github.com/DataDog/dd-trace-go/v2/ddtrace"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
@@ -233,7 +232,7 @@ func (a *App) Work(ctx context.Context, req *pb.WorkReq) (*pb.WorkRes, error) {
 	// running. decoySpan is a child span that finishes before the cpuHog work
 	// begins to test that span's restore their parent span labels when
 	// finishing.
-	var cpuSpan, decoySpan ddtrace.Span
+	var cpuSpan, decoySpan *tracer.Span
 	if a.config.ChildOf {
 		cpuSpan = tracer.StartSpan("cpuHog", tracer.ChildOf(reqSpan.Context()))
 		decoySpan = tracer.StartSpan("decoy", tracer.ChildOf(cpuSpan.Context()))

--- a/internal/traceprof/traceproftest/go.mod
+++ b/internal/traceprof/traceproftest/go.mod
@@ -57,3 +57,5 @@ replace github.com/DataDog/dd-trace-go/v2 => ../../..
 replace github.com/DataDog/dd-trace-go/v2/contrib/google.golang.org/grpc => ../../../v2/contrib/google.golang.org/grpc
 
 replace github.com/DataDog/dd-trace-go/v2/contrib/julienschmidt/httprouter => ../../../v2/contrib/julienschmidt/httprouter
+
+replace github.com/DataDog/dd-trace-go/v2/contrib/net/http => ../../../v2/contrib/net/http

--- a/test.sh
+++ b/test.sh
@@ -2,7 +2,7 @@
 set -e
 
 contrib=""
-sleeptime=30
+sleeptime=10
 unset INTEGRATION
 unset DD_APPSEC_ENABLED
 
@@ -31,6 +31,7 @@ while [[ $# -gt 0 ]]; do
 			;;
 		--all)
 			contrib=true
+			lint=true
 			export DD_APPSEC_ENABLED=true
 			export DD_TEST_APPS_ENABLED=true
 			export INTEGRATION=true
@@ -100,7 +101,7 @@ fi
 ## CORE
 echo testing core
 pkg_names=$(go list ./...)
-nice -n20 gotestsum --junitfile ./gotestsum-report.xml -- -race -v -coverprofile=core_coverage.txt -covermode=atomic $pkg_names
+nice -n20 gotestsum --junitfile ./gotestsum-report.xml -- -race -v -coverprofile=core_coverage.txt -covermode=atomic $pkg_names && true
 
 if [[ "$contrib" != "" ]]; then
 	## CONTRIB

--- a/v2/contrib/99designs/gqlgen/tracer.go
+++ b/v2/contrib/99designs/gqlgen/tracer.go
@@ -123,7 +123,7 @@ func (t *gqlTracer) InterceptResponse(ctx context.Context, next graphql.Response
 		}
 		opts = append(opts, tracer.StartTime(octx.Stats.OperationStart))
 	}
-	var span ddtrace.Span
+	var span *tracer.Span
 	span, ctx = tracer.StartSpanFromContext(ctx, serverSpanName(octx), opts...)
 	defer func() {
 		var errs []string
@@ -144,7 +144,7 @@ func (t *gqlTracer) InterceptResponse(ctx context.Context, next graphql.Response
 			childOpts = append(childOpts, tracer.StartTime(start))
 			childOpts = append(childOpts, tracer.ResourceName(name))
 			childOpts = append(childOpts, tracer.Tag(ext.Component, componentName))
-			var childSpan ddtrace.Span
+			var childSpan *tracer.Span
 			childSpan, _ = tracer.StartSpanFromContext(ctx, name, childOpts...)
 			childSpan.Finish(tracer.FinishTime(finish))
 		}

--- a/v2/contrib/99designs/gqlgen/tracer_test.go
+++ b/v2/contrib/99designs/gqlgen/tracer_test.go
@@ -29,10 +29,10 @@ func TestOptions(t *testing.T) {
 	query := `{ name }`
 	for name, tt := range map[string]struct {
 		tracerOpts []Option
-		test       func(assert *assert.Assertions, root mocktracer.Span)
+		test       func(assert *assert.Assertions, root *mocktracer.Span)
 	}{
 		"default": {
-			test: func(assert *assert.Assertions, root mocktracer.Span) {
+			test: func(assert *assert.Assertions, root *mocktracer.Span) {
 				assert.Equal("graphql.query", root.OperationName())
 				assert.Equal(query, root.Tag(ext.ResourceName))
 				assert.Equal(defaultServiceName, root.Tag(ext.ServiceName))
@@ -43,25 +43,25 @@ func TestOptions(t *testing.T) {
 		},
 		"WithServiceName": {
 			tracerOpts: []Option{WithServiceName("TestServer")},
-			test: func(assert *assert.Assertions, root mocktracer.Span) {
+			test: func(assert *assert.Assertions, root *mocktracer.Span) {
 				assert.Equal("TestServer", root.Tag(ext.ServiceName))
 			},
 		},
 		"WithAnalytics/true": {
 			tracerOpts: []Option{WithAnalytics(true)},
-			test: func(assert *assert.Assertions, root mocktracer.Span) {
+			test: func(assert *assert.Assertions, root *mocktracer.Span) {
 				assert.Equal(1.0, root.Tag(ext.EventSampleRate))
 			},
 		},
 		"WithAnalytics/false": {
 			tracerOpts: []Option{WithAnalytics(false)},
-			test: func(assert *assert.Assertions, root mocktracer.Span) {
+			test: func(assert *assert.Assertions, root *mocktracer.Span) {
 				assert.Nil(root.Tag(ext.EventSampleRate))
 			},
 		},
 		"WithAnalyticsRate": {
 			tracerOpts: []Option{WithAnalyticsRate(0.5)},
-			test: func(assert *assert.Assertions, root mocktracer.Span) {
+			test: func(assert *assert.Assertions, root *mocktracer.Span) {
 				assert.Equal(0.5, root.Tag(ext.EventSampleRate))
 			},
 		},
@@ -72,7 +72,7 @@ func TestOptions(t *testing.T) {
 			defer mt.Stop()
 			c := newTestClient(t, testserver.New(), NewTracer(tt.tracerOpts...))
 			c.MustPost(query, &testServerResponse{})
-			var root mocktracer.Span
+			var root *mocktracer.Span
 			for _, span := range mt.FinishedSpans() {
 				if span.ParentID() == 0 {
 					root = span
@@ -92,14 +92,14 @@ func TestError(t *testing.T) {
 	c := newTestClient(t, testserver.NewError(), NewTracer())
 	err := c.Post(`{ name }`, &testServerResponse{})
 	assert.NotNil(err)
-	var root mocktracer.Span
+	var root *mocktracer.Span
 	for _, span := range mt.FinishedSpans() {
 		if span.ParentID() == 0 {
 			root = span
 		}
 	}
 	assert.NotNil(root)
-	assert.NotNil(root.Tag(ext.Error))
+	assert.NotNil(root.Tag(ext.ErrorMsg))
 }
 
 func TestObfuscation(t *testing.T) {
@@ -131,7 +131,7 @@ func TestChildSpans(t *testing.T) {
 	c := newTestClient(t, testserver.New(), NewTracer())
 	err := c.Post(`{ name }`, &testServerResponse{})
 	assert.Nil(err)
-	var root mocktracer.Span
+	var root *mocktracer.Span
 	allSpans := mt.FinishedSpans()
 	var resNames []string
 	var opNames []string
@@ -150,7 +150,7 @@ func TestChildSpans(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))
@@ -167,7 +167,7 @@ func TestNamingSchema(t *testing.T) {
 
 		return mt.FinishedSpans()
 	})
-	assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 8)
 		assert.Equal(t, "graphql.read", spans[0].OperationName())
 		assert.Equal(t, "graphql.parse", spans[1].OperationName())
@@ -178,7 +178,7 @@ func TestNamingSchema(t *testing.T) {
 		assert.Equal(t, "graphql.validate", spans[6].OperationName())
 		assert.Equal(t, "graphql.mutation", spans[7].OperationName())
 	}
-	assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 8)
 		assert.Equal(t, "graphql.read", spans[0].OperationName())
 		assert.Equal(t, "graphql.parse", spans[1].OperationName())

--- a/v2/contrib/IBM/sarama.v1/sarama.go
+++ b/v2/contrib/IBM/sarama.v1/sarama.go
@@ -51,7 +51,7 @@ func WrapPartitionConsumer(pc sarama.PartitionConsumer, opts ...Option) sarama.P
 	}
 	go func() {
 		msgs := pc.Messages()
-		var prev ddtrace.Span
+		var prev *tracer.Span
 		for msg := range msgs {
 			// create the next span from the message
 			opts := []tracer.StartSpanOption{
@@ -136,7 +136,7 @@ func (p *syncProducer) SendMessage(msg *sarama.ProducerMessage) (partition int32
 func (p *syncProducer) SendMessages(msgs []*sarama.ProducerMessage) error {
 	// although there's only one call made to the SyncProducer, the messages are
 	// treated individually, so we create a span for each one
-	spans := make([]ddtrace.Span, len(msgs))
+	spans := make([]*tracer.Span, len(msgs))
 	for i, msg := range msgs {
 		spans[i] = startProducerSpan(p.cfg, p.version, msg)
 	}
@@ -213,7 +213,7 @@ func WrapAsyncProducer(saramaConfig *sarama.Config, p sarama.AsyncProducer, opts
 		errors:        make(chan *sarama.ProducerError),
 	}
 	go func() {
-		spans := make(map[uint64]ddtrace.Span)
+		spans := make(map[uint64]*tracer.Span)
 		defer close(wrapped.input)
 		defer close(wrapped.successes)
 		defer close(wrapped.errors)
@@ -263,7 +263,7 @@ func WrapAsyncProducer(saramaConfig *sarama.Config, p sarama.AsyncProducer, opts
 	return wrapped
 }
 
-func startProducerSpan(cfg *config, version sarama.KafkaVersion, msg *sarama.ProducerMessage) ddtrace.Span {
+func startProducerSpan(cfg *config, version sarama.KafkaVersion, msg *sarama.ProducerMessage) *tracer.Span {
 	carrier := NewProducerMessageCarrier(msg)
 	opts := []tracer.StartSpanOption{
 		tracer.ServiceName(cfg.producerServiceName),
@@ -288,7 +288,7 @@ func startProducerSpan(cfg *config, version sarama.KafkaVersion, msg *sarama.Pro
 	return span
 }
 
-func finishProducerSpan(span ddtrace.Span, partition int32, offset int64, err error) {
+func finishProducerSpan(span *tracer.Span, partition int32, offset int64, err error) {
 	span.SetTag(ext.MessagingKafkaPartition, partition)
 	span.SetTag("offset", offset)
 	span.Finish(tracer.WithError(err))

--- a/v2/contrib/IBM/sarama.v1/sarama_test.go
+++ b/v2/contrib/IBM/sarama.v1/sarama_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func genTestSpans(t *testing.T, serviceOverride string) []mocktracer.Span {
+func genTestSpans(t *testing.T, serviceOverride string) []*mocktracer.Span {
 	var opts []Option
 	if serviceOverride != "" {
 		opts = append(opts, WithServiceName(serviceOverride))
@@ -136,8 +136,8 @@ func TestConsumer(t *testing.T) {
 		assert.Equal(t, spanctx.TraceID(), s.TraceID(),
 			"span context should be injected into the consumer message headers")
 
-		assert.Equal(t, int32(0), s.Tag(ext.MessagingKafkaPartition))
-		assert.Equal(t, int64(0), s.Tag("offset"))
+		assert.Equal(t, float64(0), s.Tag(ext.MessagingKafkaPartition))
+		assert.Equal(t, float64(0), s.Tag("offset"))
 		assert.Equal(t, "kafka", s.Tag(ext.ServiceName))
 		assert.Equal(t, "Consume Topic test-topic", s.Tag(ext.ResourceName))
 		assert.Equal(t, "queue", s.Tag(ext.SpanType))
@@ -153,8 +153,8 @@ func TestConsumer(t *testing.T) {
 		assert.Equal(t, spanctx.TraceID(), s.TraceID(),
 			"span context should be injected into the consumer message headers")
 
-		assert.Equal(t, int32(0), s.Tag(ext.MessagingKafkaPartition))
-		assert.Equal(t, int64(1), s.Tag("offset"))
+		assert.Equal(t, float64(0), s.Tag(ext.MessagingKafkaPartition))
+		assert.Equal(t, float64(1), s.Tag("offset"))
 		assert.Equal(t, "kafka", s.Tag(ext.ServiceName))
 		assert.Equal(t, "Consume Topic test-topic", s.Tag(ext.ResourceName))
 		assert.Equal(t, "queue", s.Tag(ext.SpanType))
@@ -209,8 +209,8 @@ func TestSyncProducer(t *testing.T) {
 		assert.Equal(t, "queue", s.Tag(ext.SpanType))
 		assert.Equal(t, "Produce Topic my_topic", s.Tag(ext.ResourceName))
 		assert.Equal(t, "kafka.produce", s.OperationName())
-		assert.Equal(t, int32(0), s.Tag(ext.MessagingKafkaPartition))
-		assert.Equal(t, int64(0), s.Tag("offset"))
+		assert.Equal(t, float64(0), s.Tag(ext.MessagingKafkaPartition))
+		assert.Equal(t, float64(0), s.Tag("offset"))
 		assert.Equal(t, "IBM/sarama", s.Tag(ext.Component))
 		assert.Equal(t, ext.SpanKindProducer, s.Tag(ext.SpanKind))
 		assert.Equal(t, "kafka", s.Tag(ext.MessagingSystem))
@@ -264,7 +264,7 @@ func TestSyncProducerSendMessages(t *testing.T) {
 		assert.Equal(t, "queue", s.Tag(ext.SpanType))
 		assert.Equal(t, "Produce Topic my_topic", s.Tag(ext.ResourceName))
 		assert.Equal(t, "kafka.produce", s.OperationName())
-		assert.Equal(t, int32(0), s.Tag(ext.MessagingKafkaPartition))
+		assert.Equal(t, float64(0), s.Tag(ext.MessagingKafkaPartition))
 		assert.Equal(t, "IBM/sarama", s.Tag(ext.Component))
 		assert.Equal(t, ext.SpanKindProducer, s.Tag(ext.SpanKind))
 		assert.Equal(t, "kafka", s.Tag(ext.MessagingSystem))
@@ -306,8 +306,8 @@ func TestAsyncProducer(t *testing.T) {
 			assert.Equal(t, "queue", s.Tag(ext.SpanType))
 			assert.Equal(t, "Produce Topic my_topic", s.Tag(ext.ResourceName))
 			assert.Equal(t, "kafka.produce", s.OperationName())
-			assert.Equal(t, int32(0), s.Tag(ext.MessagingKafkaPartition))
-			assert.Equal(t, int64(0), s.Tag("offset"))
+			assert.Equal(t, float64(0), s.Tag(ext.MessagingKafkaPartition))
+			assert.Equal(t, float64(0), s.Tag("offset"))
 			assert.Equal(t, "IBM/sarama", s.Tag(ext.Component))
 			assert.Equal(t, ext.SpanKindProducer, s.Tag(ext.SpanKind))
 			assert.Equal(t, "kafka", s.Tag(ext.MessagingSystem))
@@ -347,8 +347,8 @@ func TestAsyncProducer(t *testing.T) {
 			assert.Equal(t, "queue", s.Tag(ext.SpanType))
 			assert.Equal(t, "Produce Topic my_topic", s.Tag(ext.ResourceName))
 			assert.Equal(t, "kafka.produce", s.OperationName())
-			assert.Equal(t, int32(0), s.Tag(ext.MessagingKafkaPartition))
-			assert.Equal(t, int64(0), s.Tag("offset"))
+			assert.Equal(t, float64(0), s.Tag(ext.MessagingKafkaPartition))
+			assert.Equal(t, float64(0), s.Tag("offset"))
 			assert.Equal(t, "IBM/sarama", s.Tag(ext.Component))
 			assert.Equal(t, ext.SpanKindProducer, s.Tag(ext.SpanKind))
 			assert.Equal(t, "kafka", s.Tag(ext.MessagingSystem))

--- a/v2/contrib/Shopify/sarama/option_test.go
+++ b/v2/contrib/Shopify/sarama/option_test.go
@@ -6,8 +6,9 @@
 package sarama
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDataStreamsActivation(t *testing.T) {

--- a/v2/contrib/Shopify/sarama/sarama_test.go
+++ b/v2/contrib/Shopify/sarama/sarama_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func genTestSpans(t *testing.T, serviceOverride string) []mocktracer.Span {
+func genTestSpans(t *testing.T, serviceOverride string) []*mocktracer.Span {
 	var opts []Option
 	if serviceOverride != "" {
 		opts = append(opts, WithServiceName(serviceOverride))
@@ -137,8 +137,8 @@ func TestConsumer(t *testing.T) {
 		assert.Equal(t, spanctx.TraceID(), s.TraceID(),
 			"span context should be injected into the consumer message headers")
 
-		assert.Equal(t, int32(0), s.Tag(ext.MessagingKafkaPartition))
-		assert.Equal(t, int64(0), s.Tag("offset"))
+		assert.Equal(t, float64(0), s.Tag(ext.MessagingKafkaPartition))
+		assert.Equal(t, float64(0), s.Tag("offset"))
 		assert.Equal(t, "kafka", s.Tag(ext.ServiceName))
 		assert.Equal(t, "Consume Topic test-topic", s.Tag(ext.ResourceName))
 		assert.Equal(t, "queue", s.Tag(ext.SpanType))
@@ -160,8 +160,8 @@ func TestConsumer(t *testing.T) {
 		assert.Equal(t, spanctx.TraceID(), s.TraceID(),
 			"span context should be injected into the consumer message headers")
 
-		assert.Equal(t, int32(0), s.Tag(ext.MessagingKafkaPartition))
-		assert.Equal(t, int64(1), s.Tag("offset"))
+		assert.Equal(t, float64(0), s.Tag(ext.MessagingKafkaPartition))
+		assert.Equal(t, float64(1), s.Tag("offset"))
 		assert.Equal(t, "kafka", s.Tag(ext.ServiceName))
 		assert.Equal(t, "Consume Topic test-topic", s.Tag(ext.ResourceName))
 		assert.Equal(t, "queue", s.Tag(ext.SpanType))
@@ -224,8 +224,8 @@ func TestSyncProducer(t *testing.T) {
 		assert.Equal(t, "queue", s.Tag(ext.SpanType))
 		assert.Equal(t, "Produce Topic my_topic", s.Tag(ext.ResourceName))
 		assert.Equal(t, "kafka.produce", s.OperationName())
-		assert.Equal(t, int32(0), s.Tag(ext.MessagingKafkaPartition))
-		assert.Equal(t, int64(0), s.Tag("offset"))
+		assert.Equal(t, float64(0), s.Tag(ext.MessagingKafkaPartition))
+		assert.Equal(t, float64(0), s.Tag("offset"))
 		assert.Equal(t, "Shopify/sarama", s.Tag(ext.Component))
 		assert.Equal(t, ext.SpanKindProducer, s.Tag(ext.SpanKind))
 		assert.Equal(t, "kafka", s.Tag(ext.MessagingSystem))
@@ -285,7 +285,7 @@ func TestSyncProducerSendMessages(t *testing.T) {
 		assert.Equal(t, "queue", s.Tag(ext.SpanType))
 		assert.Equal(t, "Produce Topic my_topic", s.Tag(ext.ResourceName))
 		assert.Equal(t, "kafka.produce", s.OperationName())
-		assert.Equal(t, int32(0), s.Tag(ext.MessagingKafkaPartition))
+		assert.Equal(t, float64(0), s.Tag(ext.MessagingKafkaPartition))
 		assert.Equal(t, "Shopify/sarama", s.Tag(ext.Component))
 		assert.Equal(t, ext.SpanKindProducer, s.Tag(ext.SpanKind))
 		assert.Equal(t, "kafka", s.Tag(ext.MessagingSystem))
@@ -327,8 +327,8 @@ func TestAsyncProducer(t *testing.T) {
 			assert.Equal(t, "queue", s.Tag(ext.SpanType))
 			assert.Equal(t, "Produce Topic my_topic", s.Tag(ext.ResourceName))
 			assert.Equal(t, "kafka.produce", s.OperationName())
-			assert.Equal(t, int32(0), s.Tag(ext.MessagingKafkaPartition))
-			assert.Equal(t, int64(0), s.Tag("offset"))
+			assert.Equal(t, float64(0), s.Tag(ext.MessagingKafkaPartition))
+			assert.Equal(t, float64(0), s.Tag("offset"))
 			assert.Equal(t, "Shopify/sarama", s.Tag(ext.Component))
 			assert.Equal(t, ext.SpanKindProducer, s.Tag(ext.SpanKind))
 			assert.Equal(t, "kafka", s.Tag(ext.MessagingSystem))
@@ -368,8 +368,8 @@ func TestAsyncProducer(t *testing.T) {
 			assert.Equal(t, "queue", s.Tag(ext.SpanType))
 			assert.Equal(t, "Produce Topic my_topic", s.Tag(ext.ResourceName))
 			assert.Equal(t, "kafka.produce", s.OperationName())
-			assert.Equal(t, int32(0), s.Tag(ext.MessagingKafkaPartition))
-			assert.Equal(t, int64(0), s.Tag("offset"))
+			assert.Equal(t, float64(0), s.Tag(ext.MessagingKafkaPartition))
+			assert.Equal(t, float64(0), s.Tag("offset"))
 			assert.Equal(t, "Shopify/sarama", s.Tag(ext.Component))
 			assert.Equal(t, ext.SpanKindProducer, s.Tag(ext.SpanKind))
 			assert.Equal(t, "kafka", s.Tag(ext.MessagingSystem))

--- a/v2/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
+++ b/v2/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
@@ -121,7 +121,7 @@ func TestAppendMiddleware(t *testing.T) {
 			assert.Equal(t, "eu-west-1", s.Tag("region"))
 			assert.Equal(t, "SQS.SendMessage", s.Tag(ext.ResourceName))
 			assert.Equal(t, "aws.SQS", s.Tag(ext.ServiceName))
-			assert.Equal(t, tt.expectedStatusCode, s.Tag(ext.HTTPCode))
+			assert.Equal(t, float64(tt.expectedStatusCode), s.Tag(ext.HTTPCode))
 			if tt.expectedStatusCode == 200 {
 				assert.Equal(t, "test_req", s.Tag("aws.request_id"))
 			}
@@ -195,7 +195,7 @@ func TestAppendMiddlewareSqsDeleteMessage(t *testing.T) {
 			assert.Equal(t, "eu-west-1", s.Tag("region"))
 			assert.Equal(t, "SQS.DeleteMessage", s.Tag(ext.ResourceName))
 			assert.Equal(t, "aws.SQS", s.Tag(ext.ServiceName))
-			assert.Equal(t, tt.expectedStatusCode, s.Tag(ext.HTTPCode))
+			assert.Equal(t, float64(tt.expectedStatusCode), s.Tag(ext.HTTPCode))
 			if tt.expectedStatusCode == 200 {
 				assert.Equal(t, "test_req", s.Tag("aws.request_id"))
 			}
@@ -268,7 +268,7 @@ func TestAppendMiddlewareSqsReceiveMessage(t *testing.T) {
 			assert.Equal(t, "SQS", s.Tag("aws.service"))
 			assert.Equal(t, "SQS.ReceiveMessage", s.Tag(ext.ResourceName))
 			assert.Equal(t, "aws.SQS", s.Tag(ext.ServiceName))
-			assert.Equal(t, tt.expectedStatusCode, s.Tag(ext.HTTPCode))
+			assert.Equal(t, float64(tt.expectedStatusCode), s.Tag(ext.HTTPCode))
 			if tt.expectedStatusCode == 200 {
 				assert.Equal(t, "test_req", s.Tag("aws.request_id"))
 			}
@@ -341,7 +341,7 @@ func TestAppendMiddlewareS3ListObjects(t *testing.T) {
 			assert.Equal(t, "eu-west-1", s.Tag("region"))
 			assert.Equal(t, "S3.ListObjects", s.Tag(ext.ResourceName))
 			assert.Equal(t, "aws.S3", s.Tag(ext.ServiceName))
-			assert.Equal(t, tt.expectedStatusCode, s.Tag(ext.HTTPCode))
+			assert.Equal(t, float64(tt.expectedStatusCode), s.Tag(ext.HTTPCode))
 			assert.Equal(t, "GET", s.Tag(ext.HTTPMethod))
 			assert.Equal(t, server.URL+"/MyBucketName", s.Tag(ext.HTTPURL))
 			assert.Equal(t, "aws/aws-sdk-go-v2/aws", s.Tag(ext.Component))
@@ -435,7 +435,7 @@ func TestAppendMiddlewareSnsPublish(t *testing.T) {
 			assert.Equal(t, "eu-west-1", s.Tag("region"))
 			assert.Equal(t, "SNS.Publish", s.Tag(ext.ResourceName))
 			assert.Equal(t, "aws.SNS", s.Tag(ext.ServiceName))
-			assert.Equal(t, tt.expectedStatusCode, s.Tag(ext.HTTPCode))
+			assert.Equal(t, float64(tt.expectedStatusCode), s.Tag(ext.HTTPCode))
 			assert.Equal(t, "POST", s.Tag(ext.HTTPMethod))
 			assert.Equal(t, server.URL+"/", s.Tag(ext.HTTPURL))
 			assert.Equal(t, "aws/aws-sdk-go-v2/aws", s.Tag(ext.Component))
@@ -505,7 +505,7 @@ func TestAppendMiddlewareDynamodbGetItem(t *testing.T) {
 			assert.Equal(t, "eu-west-1", s.Tag("region"))
 			assert.Equal(t, "DynamoDB.Query", s.Tag(ext.ResourceName))
 			assert.Equal(t, "aws.DynamoDB", s.Tag(ext.ServiceName))
-			assert.Equal(t, tt.expectedStatusCode, s.Tag(ext.HTTPCode))
+			assert.Equal(t, float64(tt.expectedStatusCode), s.Tag(ext.HTTPCode))
 			assert.Equal(t, "POST", s.Tag(ext.HTTPMethod))
 			assert.Equal(t, server.URL+"/", s.Tag(ext.HTTPURL))
 			assert.Equal(t, "aws/aws-sdk-go-v2/aws", s.Tag(ext.Component))
@@ -577,7 +577,7 @@ func TestAppendMiddlewareKinesisPutRecord(t *testing.T) {
 			assert.Equal(t, "eu-west-1", s.Tag("region"))
 			assert.Equal(t, "Kinesis.PutRecord", s.Tag(ext.ResourceName))
 			assert.Equal(t, "aws.Kinesis", s.Tag(ext.ServiceName))
-			assert.Equal(t, tt.expectedStatusCode, s.Tag(ext.HTTPCode))
+			assert.Equal(t, float64(tt.expectedStatusCode), s.Tag(ext.HTTPCode))
 			assert.Equal(t, "POST", s.Tag(ext.HTTPMethod))
 			assert.Equal(t, server.URL+"/", s.Tag(ext.HTTPURL))
 			assert.Equal(t, "aws/aws-sdk-go-v2/aws", s.Tag(ext.Component))
@@ -647,7 +647,7 @@ func TestAppendMiddlewareEventBridgePutRule(t *testing.T) {
 			assert.Equal(t, "eu-west-1", s.Tag("region"))
 			assert.Equal(t, "EventBridge.PutRule", s.Tag(ext.ResourceName))
 			assert.Equal(t, "aws.EventBridge", s.Tag(ext.ServiceName))
-			assert.Equal(t, tt.expectedStatusCode, s.Tag(ext.HTTPCode))
+			assert.Equal(t, float64(tt.expectedStatusCode), s.Tag(ext.HTTPCode))
 			assert.Equal(t, "POST", s.Tag(ext.HTTPMethod))
 			assert.Equal(t, server.URL+"/", s.Tag(ext.HTTPURL))
 			assert.Equal(t, "aws/aws-sdk-go-v2/aws", s.Tag(ext.Component))
@@ -717,7 +717,7 @@ func TestAppendMiddlewareSfnDescribeStateMachine(t *testing.T) {
 			assert.Equal(t, "eu-west-1", s.Tag("region"))
 			assert.Equal(t, "SFN.DescribeStateMachine", s.Tag(ext.ResourceName))
 			assert.Equal(t, "aws.SFN", s.Tag(ext.ServiceName))
-			assert.Equal(t, tt.expectedStatusCode, s.Tag(ext.HTTPCode))
+			assert.Equal(t, float64(tt.expectedStatusCode), s.Tag(ext.HTTPCode))
 			assert.Equal(t, "POST", s.Tag(ext.HTTPMethod))
 			assert.Equal(t, server.URL+"/", s.Tag(ext.HTTPURL))
 			assert.Equal(t, "aws/aws-sdk-go-v2/aws", s.Tag(ext.Component))
@@ -897,7 +897,7 @@ func TestHTTPCredentials(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))
@@ -923,14 +923,14 @@ func TestNamingSchema(t *testing.T) {
 
 		return mt.FinishedSpans()
 	})
-	assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 4)
 		assert.Equal(t, "EC2.request", spans[0].OperationName())
 		assert.Equal(t, "S3.request", spans[1].OperationName())
 		assert.Equal(t, "SQS.request", spans[2].OperationName())
 		assert.Equal(t, "SNS.request", spans[3].OperationName())
 	}
-	assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 4)
 		assert.Equal(t, "aws.ec2.request", spans[0].OperationName())
 		assert.Equal(t, "aws.s3.request", spans[1].OperationName())
@@ -948,7 +948,7 @@ func TestNamingSchema(t *testing.T) {
 }
 
 func TestMessagingNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))
@@ -984,7 +984,7 @@ func TestMessagingNamingSchema(t *testing.T) {
 
 		return mt.FinishedSpans()
 	})
-	assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 5)
 		assert.Equal(t, "SQS.request", spans[0].OperationName())
 		assert.Equal(t, "SQS.request", spans[1].OperationName())
@@ -992,7 +992,7 @@ func TestMessagingNamingSchema(t *testing.T) {
 		assert.Equal(t, "SNS.request", spans[3].OperationName())
 		assert.Equal(t, "SNS.request", spans[4].OperationName())
 	}
-	assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 5)
 		assert.Equal(t, "aws.sqs.request", spans[0].OperationName())
 		assert.Equal(t, "aws.sqs.send", spans[1].OperationName())
@@ -1073,7 +1073,7 @@ func TestWithErrorCheck(t *testing.T) {
 			spans := mt.FinishedSpans()
 			assert.Len(t, spans, 1)
 			s := spans[0]
-			assert.Equal(t, tt.errExist, s.Tag(ext.Error) != nil)
+			assert.Equal(t, tt.errExist, s.Tag(ext.ErrorMsg) != nil)
 		})
 	}
 }

--- a/v2/contrib/aws/aws-sdk-go/aws/aws_test.go
+++ b/v2/contrib/aws/aws-sdk-go/aws/aws_test.go
@@ -211,7 +211,7 @@ func TestRetries(t *testing.T) {
 	assert.Same(t, expectedError, err)
 	assert.Len(t, mt.OpenSpans(), 0)
 	assert.Len(t, mt.FinishedSpans(), 1)
-	assert.Equal(t, mt.FinishedSpans()[0].Tag("aws.retry_count"), 3)
+	assert.Equal(t, mt.FinishedSpans()[0].Tag("aws.retry_count"), float64(3))
 }
 
 func TestHTTPCredentials(t *testing.T) {
@@ -293,7 +293,7 @@ func TestWithErrorCheck(t *testing.T) {
 
 			spans := mt.FinishedSpans()
 			assert.True(t, len(spans) > 0)
-			assert.Equal(t, errExist, spans[0].Tag(ext.Error) != nil)
+			assert.Equal(t, errExist, spans[0].Tag(ext.ErrorMsg) != nil)
 		}
 	}
 
@@ -508,7 +508,7 @@ func TestExtraTagsForService(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))
@@ -533,14 +533,14 @@ func TestNamingSchema(t *testing.T) {
 
 		return mt.FinishedSpans()
 	})
-	assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 4)
 		assert.Equal(t, "ec2.command", spans[0].OperationName())
 		assert.Equal(t, "s3.command", spans[1].OperationName())
 		assert.Equal(t, "sqs.command", spans[2].OperationName())
 		assert.Equal(t, "sns.command", spans[3].OperationName())
 	}
-	assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 4)
 		assert.Equal(t, "aws.ec2.request", spans[0].OperationName())
 		assert.Equal(t, "aws.s3.request", spans[1].OperationName())
@@ -558,7 +558,7 @@ func TestNamingSchema(t *testing.T) {
 }
 
 func TestMessagingNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))
@@ -594,7 +594,7 @@ func TestMessagingNamingSchema(t *testing.T) {
 
 		return mt.FinishedSpans()
 	})
-	assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 5)
 		assert.Equal(t, "sqs.command", spans[0].OperationName())
 		assert.Equal(t, "sqs.command", spans[1].OperationName())
@@ -602,7 +602,7 @@ func TestMessagingNamingSchema(t *testing.T) {
 		assert.Equal(t, "sns.command", spans[3].OperationName())
 		assert.Equal(t, "sns.command", spans[4].OperationName())
 	}
-	assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 5)
 		assert.Equal(t, "aws.sqs.request", spans[0].OperationName())
 		assert.Equal(t, "aws.sqs.send", spans[1].OperationName())

--- a/v2/contrib/aws/aws-sdk-go/aws/example_test.go
+++ b/v2/contrib/aws/aws-sdk-go/aws/example_test.go
@@ -10,13 +10,14 @@ import (
 	"log"
 	"os"
 
-	awstrace "github.com/DataDog/dd-trace-go/v2/contrib/aws/aws-sdk-go/aws"
-	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
-	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+
+	awstrace "github.com/DataDog/dd-trace-go/v2/contrib/aws/aws-sdk-go/aws"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 )
 
 // To start tracing requests, wrap the AWS session.Session by invoking

--- a/v2/contrib/aws/aws-sdk-go/go.mod
+++ b/v2/contrib/aws/aws-sdk-go/go.mod
@@ -4,7 +4,8 @@ go 1.19
 
 require (
 	github.com/DataDog/dd-trace-go/v2 v2.0.0-20231212165552-729cf88f812c
-	github.com/aws/aws-sdk-go v1.48.6
+	//github.com/aws/aws-sdk-go v1.48.6
+	github.com/aws/aws-sdk-go v1.44.327
 	github.com/stretchr/testify v1.8.4
 )
 

--- a/v2/contrib/aws/aws-sdk-go/go.sum
+++ b/v2/contrib/aws/aws-sdk-go/go.sum
@@ -16,8 +16,8 @@ github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
-github.com/aws/aws-sdk-go v1.48.6 h1:hnL/TE3eRigirDLrdRE9AWE1ALZSVLAsC4wK8TGsMqk=
-github.com/aws/aws-sdk-go v1.48.6/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
+github.com/aws/aws-sdk-go v1.44.327 h1:ZS8oO4+7MOBLhkdwIhgtVeDzCeWOlTfKJS7EgggbIEY=
+github.com/aws/aws-sdk-go v1.44.327/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -117,6 +117,7 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/net v0.3.0/go.mod h1:MBQ8lrhLObU/6UmLb4fmbmk5OcyYmqtbGd/9yIeKjEE=
 golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -138,15 +139,18 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
 golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.3.0/go.mod h1:q750SLmJuPmVoN1blW3UFBPREJfb1KmY3vwxfr+nFDA=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.5.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
 golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=

--- a/v2/contrib/bradfitz/gomemcache/memcache/memcache.go
+++ b/v2/contrib/bradfitz/gomemcache/memcache/memcache.go
@@ -72,7 +72,7 @@ func (c *Client) WithContext(ctx context.Context) *Client {
 }
 
 // startSpan starts a span from the context set with WithContext.
-func (c *Client) startSpan(resourceName string) ddtrace.Span {
+func (c *Client) startSpan(resourceName string) *tracer.Span {
 	opts := []ddtrace.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeMemcached),
 		tracer.ServiceName(c.cfg.serviceName),

--- a/v2/contrib/bradfitz/gomemcache/memcache/memcache_test.go
+++ b/v2/contrib/bradfitz/gomemcache/memcache/memcache_test.go
@@ -45,7 +45,7 @@ func testMemcache(t *testing.T, addr string) {
 	client := getClient(addr, WithServiceName("test-memcache"))
 	defer client.DeleteAll()
 
-	validateMemcacheSpan := func(t *testing.T, span mocktracer.Span, resourceName string) {
+	validateMemcacheSpan := func(t *testing.T, span *mocktracer.Span, resourceName string) {
 		assert.Equal(t, "test-memcache", span.Tag(ext.ServiceName),
 			"service name should be set to test-memcache")
 		assert.Equal(t, "memcached.query", span.OperationName(),
@@ -96,7 +96,7 @@ func testMemcache(t *testing.T, addr string) {
 		spans := mt.FinishedSpans()
 		assert.Len(t, spans, 2)
 		validateMemcacheSpan(t, spans[0], "Add")
-		assert.Equal(t, span, spans[1])
+		assert.Equal(t, span, spans[1].RealSpan())
 		assert.Equal(t, spans[1].TraceID(), spans[0].TraceID(),
 			"memcache span should be part of the parent trace")
 	})
@@ -183,7 +183,7 @@ func TestNamingSchema(t *testing.T) {
 	defer li.Close()
 	addr := li.Addr().String()
 
-	genSpans := func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []ClientOption
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))
@@ -200,11 +200,11 @@ func TestNamingSchema(t *testing.T) {
 		require.Len(t, spans, 1)
 		return spans
 	}
-	assertV0 := func(t *testing.T, spans []mocktracer.Span) {
+	assertV0 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "memcached.query", spans[0].OperationName())
 	}
-	assertV1 := func(t *testing.T, spans []mocktracer.Span) {
+	assertV1 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "memcached.command", spans[0].OperationName())
 	}

--- a/v2/contrib/cloud.google.com/go/pubsub.v1/example_test.go
+++ b/v2/contrib/cloud.google.com/go/pubsub.v1/example_test.go
@@ -10,6 +10,7 @@ import (
 	"log"
 
 	"cloud.google.com/go/pubsub"
+
 	pubsubtrace "github.com/DataDog/dd-trace-go/v2/contrib/cloud.google.com/go/pubsub.v1"
 )
 

--- a/v2/contrib/cloud.google.com/go/pubsub.v1/pubsub.go
+++ b/v2/contrib/cloud.google.com/go/pubsub.v1/pubsub.go
@@ -74,7 +74,7 @@ func Publish(ctx context.Context, t *pubsub.Topic, msg *pubsub.Message, opts ...
 type PublishResult struct {
 	*pubsub.PublishResult
 	once sync.Once
-	span tracer.Span
+	span *tracer.Span
 }
 
 // Get wraps (pubsub.PublishResult).Get(ctx). When this function returns the publish
@@ -118,6 +118,7 @@ func WrapReceiveHandler(s *pubsub.Subscription, f func(context.Context, *pubsub.
 		if cfg.measured {
 			opts = append(opts, tracer.Measured())
 		}
+
 		span, ctx := tracer.StartSpanFromContext(ctx, cfg.receiveSpanName, opts...)
 		if msg.DeliveryAttempt != nil {
 			span.SetTag("delivery_attempt", *msg.DeliveryAttempt)

--- a/v2/contrib/confluentinc/confluent-kafka-go/kafka.v2/kafka.go
+++ b/v2/contrib/confluentinc/confluent-kafka-go/kafka.v2/kafka.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/DataDog/dd-trace-go/v2/datastreams"
 	"github.com/DataDog/dd-trace-go/v2/datastreams/options"
-	"github.com/DataDog/dd-trace-go/v2/ddtrace"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
@@ -59,7 +58,7 @@ type Consumer struct {
 	*kafka.Consumer
 	cfg    *config
 	events chan kafka.Event
-	prev   ddtrace.Span
+	prev   *tracer.Span
 }
 
 // WrapConsumer wraps a kafka.Consumer so that any consumed events are traced.
@@ -83,7 +82,7 @@ func (c *Consumer) traceEventsChannel(in chan kafka.Event) chan kafka.Event {
 	go func() {
 		defer close(out)
 		for evt := range in {
-			var next ddtrace.Span
+			var next *tracer.Span
 
 			// only trace messages
 			if msg, ok := evt.(*kafka.Message); ok {
@@ -109,7 +108,7 @@ func (c *Consumer) traceEventsChannel(in chan kafka.Event) chan kafka.Event {
 	return out
 }
 
-func (c *Consumer) startSpan(msg *kafka.Message) ddtrace.Span {
+func (c *Consumer) startSpan(msg *kafka.Message) *tracer.Span {
 	opts := []tracer.StartSpanOption{
 		tracer.ServiceName(c.cfg.consumerServiceName),
 		tracer.ResourceName("Consume Topic " + *msg.TopicPartition.Topic),
@@ -280,7 +279,7 @@ func (p *Producer) traceProduceChannel(out chan *kafka.Message) chan *kafka.Mess
 	return in
 }
 
-func (p *Producer) startSpan(msg *kafka.Message) ddtrace.Span {
+func (p *Producer) startSpan(msg *kafka.Message) *tracer.Span {
 	opts := []tracer.StartSpanOption{
 		tracer.ServiceName(p.cfg.producerServiceName),
 		tracer.ResourceName("Produce Topic " + *msg.TopicPartition.Topic),

--- a/v2/contrib/confluentinc/confluent-kafka-go/kafka.v2/kafka_test.go
+++ b/v2/contrib/confluentinc/confluent-kafka-go/kafka.v2/kafka_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -30,7 +31,7 @@ var (
 
 type consumerActionFn func(c *Consumer) (*kafka.Message, error)
 
-func produceThenConsume(t *testing.T, consumerAction consumerActionFn, producerOpts []Option, consumerOpts []Option) ([]mocktracer.Span, *kafka.Message) {
+func produceThenConsume(t *testing.T, consumerAction consumerActionFn, producerOpts []Option, consumerOpts []Option) ([]*mocktracer.Span, *kafka.Message) {
 	if _, ok := os.LookupEnv("INTEGRATION"); !ok {
 		t.Skip("to enable integration test, set the INTEGRATION environment variable")
 	}
@@ -143,9 +144,9 @@ func TestConsumerChannel(t *testing.T) {
 		assert.Equal(t, "kafka", s.Tag(ext.ServiceName))
 		assert.Equal(t, "Consume Topic gotest", s.Tag(ext.ResourceName))
 		assert.Equal(t, "queue", s.Tag(ext.SpanType))
-		assert.Equal(t, int32(1), s.Tag(ext.MessagingKafkaPartition))
+		assert.Equal(t, float64(1), s.Tag(ext.MessagingKafkaPartition))
 		assert.Equal(t, 0.3, s.Tag(ext.EventSampleRate))
-		assert.Equal(t, kafka.Offset(i+1), s.Tag("offset"))
+		assert.Equal(t, strconv.Itoa(i+1), s.Tag("offset"))
 		assert.Equal(t, componentName, s.Tag(ext.Component))
 		assert.Equal(t, ext.SpanKindConsumer, s.Tag(ext.SpanKind))
 		assert.Equal(t, "kafka", s.Tag(ext.MessagingSystem))
@@ -216,7 +217,7 @@ func TestConsumerFunctional(t *testing.T) {
 			assert.Equal(t, "Produce Topic gotest", s0.Tag(ext.ResourceName))
 			assert.Equal(t, 0.1, s0.Tag(ext.EventSampleRate))
 			assert.Equal(t, "queue", s0.Tag(ext.SpanType))
-			assert.Equal(t, int32(0), s0.Tag(ext.MessagingKafkaPartition))
+			assert.Equal(t, float64(0), s0.Tag(ext.MessagingKafkaPartition))
 			assert.Equal(t, componentName, s0.Tag(ext.Component))
 			assert.Equal(t, ext.SpanKindProducer, s0.Tag(ext.SpanKind))
 			assert.Equal(t, "kafka", s0.Tag(ext.MessagingSystem))
@@ -228,7 +229,7 @@ func TestConsumerFunctional(t *testing.T) {
 			assert.Equal(t, "Consume Topic gotest", s1.Tag(ext.ResourceName))
 			assert.Equal(t, nil, s1.Tag(ext.EventSampleRate))
 			assert.Equal(t, "queue", s1.Tag(ext.SpanType))
-			assert.Equal(t, int32(0), s1.Tag(ext.MessagingKafkaPartition))
+			assert.Equal(t, float64(0), s1.Tag(ext.MessagingKafkaPartition))
 			assert.Equal(t, componentName, s1.Tag(ext.Component))
 			assert.Equal(t, ext.SpanKindConsumer, s1.Tag(ext.SpanKind))
 			assert.Equal(t, "kafka", s1.Tag(ext.MessagingSystem))
@@ -260,7 +261,7 @@ func TestCustomTags(t *testing.T) {
 	}, WithCustomTag("foo", func(msg *kafka.Message) interface{} {
 		return "bar"
 	}), WithCustomTag("key", func(msg *kafka.Message) interface{} {
-		return msg.Key
+		return string(msg.Key)
 	}))
 	assert.NoError(t, err)
 
@@ -290,11 +291,11 @@ func TestCustomTags(t *testing.T) {
 	s := spans[0]
 
 	assert.Equal(t, "bar", s.Tag("foo"))
-	assert.Equal(t, []byte("key1"), s.Tag("key"))
+	assert.Equal(t, "key1", s.Tag("key"))
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))

--- a/v2/contrib/confluentinc/confluent-kafka-go/kafka/kafka.go
+++ b/v2/contrib/confluentinc/confluent-kafka-go/kafka/kafka.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/DataDog/dd-trace-go/v2/datastreams"
 	"github.com/DataDog/dd-trace-go/v2/datastreams/options"
-	"github.com/DataDog/dd-trace-go/v2/ddtrace"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
@@ -59,7 +58,7 @@ type Consumer struct {
 	*kafka.Consumer
 	cfg    *config
 	events chan kafka.Event
-	prev   ddtrace.Span
+	prev   *tracer.Span
 }
 
 // WrapConsumer wraps a kafka.Consumer so that any consumed events are traced.
@@ -83,7 +82,7 @@ func (c *Consumer) traceEventsChannel(in chan kafka.Event) chan kafka.Event {
 	go func() {
 		defer close(out)
 		for evt := range in {
-			var next ddtrace.Span
+			var next *tracer.Span
 
 			// only trace messages
 			if msg, ok := evt.(*kafka.Message); ok {
@@ -109,7 +108,7 @@ func (c *Consumer) traceEventsChannel(in chan kafka.Event) chan kafka.Event {
 	return out
 }
 
-func (c *Consumer) startSpan(msg *kafka.Message) ddtrace.Span {
+func (c *Consumer) startSpan(msg *kafka.Message) *tracer.Span {
 	opts := []tracer.StartSpanOption{
 		tracer.ServiceName(c.cfg.consumerServiceName),
 		tracer.ResourceName("Consume Topic " + *msg.TopicPartition.Topic),
@@ -280,7 +279,7 @@ func (p *Producer) traceProduceChannel(out chan *kafka.Message) chan *kafka.Mess
 	return in
 }
 
-func (p *Producer) startSpan(msg *kafka.Message) ddtrace.Span {
+func (p *Producer) startSpan(msg *kafka.Message) *tracer.Span {
 	opts := []tracer.StartSpanOption{
 		tracer.ServiceName(p.cfg.producerServiceName),
 		tracer.ResourceName("Produce Topic " + *msg.TopicPartition.Topic),

--- a/v2/contrib/confluentinc/confluent-kafka-go/kafka/kafka_test.go
+++ b/v2/contrib/confluentinc/confluent-kafka-go/kafka/kafka_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -30,7 +31,7 @@ var (
 
 type consumerActionFn func(c *Consumer) (*kafka.Message, error)
 
-func produceThenConsume(t *testing.T, consumerAction consumerActionFn, producerOpts []Option, consumerOpts []Option) ([]mocktracer.Span, *kafka.Message) {
+func produceThenConsume(t *testing.T, consumerAction consumerActionFn, producerOpts []Option, consumerOpts []Option) ([]*mocktracer.Span, *kafka.Message) {
 	if _, ok := os.LookupEnv("INTEGRATION"); !ok {
 		t.Skip("to enable integration test, set the INTEGRATION environment variable")
 	}
@@ -143,9 +144,9 @@ func TestConsumerChannel(t *testing.T) {
 		assert.Equal(t, "kafka", s.Tag(ext.ServiceName))
 		assert.Equal(t, "Consume Topic gotest", s.Tag(ext.ResourceName))
 		assert.Equal(t, "queue", s.Tag(ext.SpanType))
-		assert.Equal(t, int32(1), s.Tag(ext.MessagingKafkaPartition))
+		assert.Equal(t, float64(1), s.Tag(ext.MessagingKafkaPartition))
 		assert.Equal(t, 0.3, s.Tag(ext.EventSampleRate))
-		assert.Equal(t, kafka.Offset(i+1), s.Tag("offset"))
+		assert.Equal(t, strconv.Itoa(i+1), s.Tag("offset"))
 		assert.Equal(t, componentName, s.Tag(ext.Component))
 		assert.Equal(t, ext.SpanKindConsumer, s.Tag(ext.SpanKind))
 		assert.Equal(t, "kafka", s.Tag(ext.MessagingSystem))
@@ -216,7 +217,7 @@ func TestConsumerFunctional(t *testing.T) {
 			assert.Equal(t, "Produce Topic gotest", s0.Tag(ext.ResourceName))
 			assert.Equal(t, 0.1, s0.Tag(ext.EventSampleRate))
 			assert.Equal(t, "queue", s0.Tag(ext.SpanType))
-			assert.Equal(t, int32(0), s0.Tag(ext.MessagingKafkaPartition))
+			assert.Equal(t, float64(0), s0.Tag(ext.MessagingKafkaPartition))
 			assert.Equal(t, componentName, s0.Tag(ext.Component))
 			assert.Equal(t, ext.SpanKindProducer, s0.Tag(ext.SpanKind))
 			assert.Equal(t, "kafka", s0.Tag(ext.MessagingSystem))
@@ -228,7 +229,7 @@ func TestConsumerFunctional(t *testing.T) {
 			assert.Equal(t, "Consume Topic gotest", s1.Tag(ext.ResourceName))
 			assert.Equal(t, nil, s1.Tag(ext.EventSampleRate))
 			assert.Equal(t, "queue", s1.Tag(ext.SpanType))
-			assert.Equal(t, int32(0), s1.Tag(ext.MessagingKafkaPartition))
+			assert.Equal(t, float64(0), s1.Tag(ext.MessagingKafkaPartition))
 			assert.Equal(t, componentName, s1.Tag(ext.Component))
 			assert.Equal(t, ext.SpanKindConsumer, s1.Tag(ext.SpanKind))
 			assert.Equal(t, "kafka", s1.Tag(ext.MessagingSystem))
@@ -260,7 +261,7 @@ func TestCustomTags(t *testing.T) {
 	}, WithCustomTag("foo", func(msg *kafka.Message) interface{} {
 		return "bar"
 	}), WithCustomTag("key", func(msg *kafka.Message) interface{} {
-		return msg.Key
+		return string(msg.Key)
 	}))
 	assert.NoError(t, err)
 
@@ -290,11 +291,11 @@ func TestCustomTags(t *testing.T) {
 	s := spans[0]
 
 	assert.Equal(t, "bar", s.Tag("foo"))
-	assert.Equal(t, []byte("key1"), s.Tag("key"))
+	assert.Equal(t, "key1", s.Tag("key"))
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))

--- a/v2/contrib/database/sql/conn_test.go
+++ b/v2/contrib/database/sql/conn_test.go
@@ -271,7 +271,7 @@ func TestWithErrorCheck(t *testing.T) {
 			assert.True(t, len(spans) > 0)
 
 			s := spans[len(spans)-1]
-			assert.Equal(t, errExist, s.Tag(ext.Error) != nil)
+			assert.Equal(t, errExist, s.Tag(ext.ErrorMsg) != nil)
 		}
 	}
 
@@ -310,7 +310,7 @@ func TestWithCustomTag(t *testing.T) {
 				opName: "mysql.query",
 				customTags: map[string]interface{}{
 					"foo": "bar",
-					"baz": 123,
+					"baz": float64(123),
 				},
 				dbSystem: ext.DBSystemMySQL,
 			},
@@ -330,7 +330,7 @@ func TestWithCustomTag(t *testing.T) {
 				opName: "postgres.query",
 				customTags: map[string]interface{}{
 					"foo": "bar",
-					"baz": 123,
+					"baz": float64(123),
 				},
 				dbSystem: "postgresql",
 			},

--- a/v2/contrib/database/sql/propagation_test.go
+++ b/v2/contrib/database/sql/propagation_test.go
@@ -289,7 +289,7 @@ func TestDBMTraceContextTagging(t *testing.T) {
 			for _, s := range sps {
 				tags := s.Tags()
 				if tc.traceContextInjectedTag {
-					assert.Equal(t, true, tags[keyDBMTraceInjected])
+					assert.Equal(t, "true", tags[keyDBMTraceInjected])
 				} else {
 					_, ok := tags[keyDBMTraceInjected]
 					assert.False(t, ok)
@@ -446,8 +446,8 @@ func TestDBMFullModeUnsupported(t *testing.T) {
 	}
 }
 
-func spansOfType(spans []mocktracer.Span, spanType string) (filtered []mocktracer.Span) {
-	filtered = make([]mocktracer.Span, 0)
+func spansOfType(spans []*mocktracer.Span, spanType string) (filtered []*mocktracer.Span) {
+	filtered = make([]*mocktracer.Span, 0)
 	for _, s := range spans {
 		if s.Tag("sql.query_type") == spanType {
 			filtered = append(filtered, s)

--- a/v2/contrib/database/sql/sql_test.go
+++ b/v2/contrib/database/sql/sql_test.go
@@ -356,7 +356,7 @@ func TestRegister(_ *testing.T) {
 
 func TestNamingSchema(t *testing.T) {
 	newGenSpansFunc := func(t *testing.T, driverName string, registerOverride bool) namingschematest.GenSpansFn {
-		return func(t *testing.T, serviceOverride string) []mocktracer.Span {
+		return func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 			var registerOpts []Option
 			// serviceOverride has higher priority than the registerOverride parameter.
 			if serviceOverride != "" {
@@ -403,12 +403,12 @@ func TestNamingSchema(t *testing.T) {
 	}
 	t.Run("SQLServer", func(t *testing.T) {
 		genSpans := newGenSpansFunc(t, "sqlserver", false)
-		assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+		assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 			require.Len(t, spans, 2)
 			assert.Equal(t, "sqlserver.query", spans[0].OperationName())
 			assert.Equal(t, "sqlserver.query", spans[1].OperationName())
 		}
-		assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+		assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 			require.Len(t, spans, 2)
 			assert.Equal(t, "mssql.query", spans[0].OperationName())
 			assert.Equal(t, "mssql.query", spans[1].OperationName())
@@ -423,12 +423,12 @@ func TestNamingSchema(t *testing.T) {
 	})
 	t.Run("Postgres", func(t *testing.T) {
 		genSpans := newGenSpansFunc(t, "postgres", false)
-		assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+		assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 			require.Len(t, spans, 2)
 			assert.Equal(t, "postgres.query", spans[0].OperationName())
 			assert.Equal(t, "postgres.query", spans[1].OperationName())
 		}
-		assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+		assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 			require.Len(t, spans, 2)
 			assert.Equal(t, "postgresql.query", spans[0].OperationName())
 			assert.Equal(t, "postgresql.query", spans[1].OperationName())
@@ -443,12 +443,12 @@ func TestNamingSchema(t *testing.T) {
 	})
 	t.Run("PostgresWithRegisterOverride", func(t *testing.T) {
 		genSpans := newGenSpansFunc(t, "postgres", true)
-		assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+		assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 			require.Len(t, spans, 2)
 			assert.Equal(t, "postgres.query", spans[0].OperationName())
 			assert.Equal(t, "postgres.query", spans[1].OperationName())
 		}
-		assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+		assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 			require.Len(t, spans, 2)
 			assert.Equal(t, "postgresql.query", spans[0].OperationName())
 			assert.Equal(t, "postgresql.query", spans[1].OperationName())
@@ -466,12 +466,12 @@ func TestNamingSchema(t *testing.T) {
 	})
 	t.Run("MySQL", func(t *testing.T) {
 		genSpans := newGenSpansFunc(t, "mysql", false)
-		assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+		assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 			require.Len(t, spans, 2)
 			assert.Equal(t, "mysql.query", spans[0].OperationName())
 			assert.Equal(t, "mysql.query", spans[1].OperationName())
 		}
-		assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+		assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 			require.Len(t, spans, 2)
 			assert.Equal(t, "mysql.query", spans[0].OperationName())
 			assert.Equal(t, "mysql.query", spans[1].OperationName())

--- a/v2/contrib/dimfeld/httptreemux.v5/contextmux_test.go
+++ b/v2/contrib/dimfeld/httptreemux.v5/contextmux_test.go
@@ -112,7 +112,7 @@ func TestContextMux500(t *testing.T) {
 	assert.Equal("GET", s.Tag(ext.HTTPMethod))
 	assert.Equal("http://example.com"+url, s.Tag(ext.HTTPURL))
 	assert.Equal("testvalue", s.Tag("testkey"))
-	assert.Equal("500: Internal Server Error", s.Tag(ext.Error).(error).Error())
+	assert.Equal("500: Internal Server Error", s.Tag(ext.ErrorMsg))
 }
 
 func TestContextMuxDefaultResourceNamer(t *testing.T) {

--- a/v2/contrib/dimfeld/httptreemux.v5/go.mod
+++ b/v2/contrib/dimfeld/httptreemux.v5/go.mod
@@ -47,3 +47,4 @@ require (
 )
 
 replace github.com/DataDog/dd-trace-go/v2 => ../../../..
+replace github.com/DataDog/dd-trace-go/v2/contrib/net/http => ../../net/http

--- a/v2/contrib/dimfeld/httptreemux.v5/httptreemux_test.go
+++ b/v2/contrib/dimfeld/httptreemux.v5/httptreemux_test.go
@@ -99,7 +99,7 @@ func TestHttpTracer500(t *testing.T) {
 	assert.Equal("GET", s.Tag(ext.HTTPMethod))
 	assert.Equal("http://example.com"+url, s.Tag(ext.HTTPURL))
 	assert.Equal("testvalue", s.Tag("testkey"))
-	assert.Equal("500: Internal Server Error", s.Tag(ext.Error).(error).Error())
+	assert.Equal("500: Internal Server Error", s.Tag(ext.ErrorMsg))
 	assert.Equal("/500", s.Tag(ext.HTTPRoute))
 }
 
@@ -219,7 +219,7 @@ func TestResourceNamer(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []RouterOption
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))

--- a/v2/contrib/dimfeld/httptreemux.v5/option.go
+++ b/v2/contrib/dimfeld/httptreemux.v5/option.go
@@ -9,9 +9,10 @@ package httptreemux
 import (
 	"net/http"
 
+	"github.com/dimfeld/httptreemux/v5"
+
 	"github.com/DataDog/dd-trace-go/v2/ddtrace"
 	"github.com/DataDog/dd-trace-go/v2/internal/namingschema"
-	"github.com/dimfeld/httptreemux/v5"
 )
 
 const defaultServiceName = "http.router"

--- a/v2/contrib/elastic/go-elasticsearch.v6/elastictrace_v6_test.go
+++ b/v2/contrib/elastic/go-elasticsearch.v6/elastictrace_v6_test.go
@@ -7,7 +7,6 @@ package elastic
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -34,8 +33,7 @@ func checkErrTraceV6(assert *assert.Assertions, mt mocktracer.Tracer) {
 	assert.Equal("my-es-service", span.Tag(ext.ServiceName))
 	assert.Equal("GET /not-real-index/_doc/?", span.Tag(ext.ResourceName))
 	assert.Equal("/not-real-index/_doc/1", span.Tag("elasticsearch.url"))
-	assert.NotEmpty(span.Tag(ext.Error))
-	assert.Equal("*errors.errorString", fmt.Sprintf("%T", span.Tag(ext.Error).(error)))
+	assert.NotEmpty(span.Tag(ext.ErrorMsg))
 	assert.Equal("127.0.0.1", span.Tag(ext.NetworkDestinationName))
 }
 
@@ -106,7 +104,7 @@ func TestClientErrorCutoffV6(t *testing.T) {
 	assert.NoError(err)
 
 	span := mt.FinishedSpans()[0]
-	assert.Equal(`{"error":{`, span.Tag(ext.Error).(error).Error())
+	assert.Equal(`{"error":{`, span.Tag(ext.ErrorMsg))
 }
 
 func TestClientV6Failure(t *testing.T) {
@@ -131,8 +129,7 @@ func TestClientV6Failure(t *testing.T) {
 	assert.Error(err)
 
 	spans := mt.FinishedSpans()
-	assert.NotEmpty(spans[0].Tag(ext.Error))
-	assert.Equal("*net.OpError", fmt.Sprintf("%T", spans[0].Tag(ext.Error).(error)))
+	assert.NotEmpty(spans[0].Tag(ext.ErrorMsg))
 }
 
 func TestResourceNamerSettingsV6(t *testing.T) {

--- a/v2/contrib/elastic/go-elasticsearch.v6/elastictrace_v7_test.go
+++ b/v2/contrib/elastic/go-elasticsearch.v6/elastictrace_v7_test.go
@@ -7,7 +7,6 @@ package elastic
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -34,8 +33,7 @@ func checkErrTraceV7(assert *assert.Assertions, mt mocktracer.Tracer) {
 	assert.Equal("my-es-service", span.Tag(ext.ServiceName))
 	assert.Equal("GET /not-real-index/_doc/?", span.Tag(ext.ResourceName))
 	assert.Equal("/not-real-index/_doc/1", span.Tag("elasticsearch.url"))
-	assert.NotEmpty(span.Tag(ext.Error))
-	assert.Equal("*errors.errorString", fmt.Sprintf("%T", span.Tag(ext.Error).(error)))
+	assert.NotEmpty(span.Tag(ext.ErrorMsg))
 	assert.Equal("127.0.0.1", span.Tag(ext.NetworkDestinationName))
 }
 
@@ -106,7 +104,7 @@ func TestClientErrorCutoffV7(t *testing.T) {
 	assert.NoError(err)
 
 	span := mt.FinishedSpans()[1]
-	assert.Equal(`{"error":{`, span.Tag(ext.Error).(error).Error())
+	assert.NotEmpty(span.Tag(ext.ErrorMsg))
 }
 
 func TestClientV7Failure(t *testing.T) {
@@ -131,8 +129,7 @@ func TestClientV7Failure(t *testing.T) {
 	assert.Error(err)
 
 	spans := mt.FinishedSpans()
-	assert.NotEmpty(spans[0].Tag(ext.Error))
-	assert.Equal("*net.OpError", fmt.Sprintf("%T", spans[0].Tag(ext.Error).(error)))
+	assert.NotEmpty(spans[0].Tag(ext.ErrorMsg))
 }
 
 func TestResourceNamerSettingsV7(t *testing.T) {

--- a/v2/contrib/elastic/go-elasticsearch.v6/elastictrace_v8_test.go
+++ b/v2/contrib/elastic/go-elasticsearch.v6/elastictrace_v8_test.go
@@ -7,7 +7,6 @@ package elastic
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -36,8 +35,7 @@ func checkErrTraceV8(assert *assert.Assertions, mt mocktracer.Tracer) {
 	assert.Equal("my-es-service", span.Tag(ext.ServiceName))
 	assert.Equal("GET /not-real-index/_doc/?", span.Tag(ext.ResourceName))
 	assert.Equal("/not-real-index/_doc/1", span.Tag("elasticsearch.url"))
-	assert.NotEmpty(span.Tag(ext.Error))
-	assert.Equal("*errors.errorString", fmt.Sprintf("%T", span.Tag(ext.Error).(error)))
+	assert.NotEmpty(span.Tag(ext.ErrorMsg))
 	assert.Equal("127.0.0.1", span.Tag(ext.NetworkDestinationName))
 }
 
@@ -106,7 +104,7 @@ func TestClientErrorCutoffV8(t *testing.T) {
 	assert.NoError(err)
 
 	span := mt.FinishedSpans()[0]
-	assert.Equal(`{"error":{`, span.Tag(ext.Error).(error).Error())
+	assert.NotEmpty(span.Tag(ext.ErrorMsg))
 }
 
 func TestClientV8Failure(t *testing.T) {
@@ -131,8 +129,7 @@ func TestClientV8Failure(t *testing.T) {
 	assert.Error(err)
 
 	spans := mt.FinishedSpans()
-	assert.NotEmpty(spans[0].Tag(ext.Error))
-	assert.Equal("*net.OpError", fmt.Sprintf("%T", spans[0].Tag(ext.Error).(error)))
+	assert.NotEmpty(spans[0].Tag(ext.ErrorMsg))
 }
 
 func TestResourceNamerSettingsV8(t *testing.T) {
@@ -257,7 +254,7 @@ func TestAnalyticsSettingsV8(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []ClientOption
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))
@@ -284,11 +281,11 @@ func TestNamingSchema(t *testing.T) {
 		require.Len(t, spans, 1)
 		return spans
 	}
-	assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "elasticsearch.query", spans[0].OperationName())
 	}
-	assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "elasticsearch.query", spans[0].OperationName())
 	}

--- a/v2/contrib/emicklei/go-restful.v3/restful_test.go
+++ b/v2/contrib/emicklei/go-restful.v3/restful_test.go
@@ -193,7 +193,7 @@ func TestError(t *testing.T) {
 	span := spans[0]
 	assert.Equal("http.request", span.OperationName())
 	assert.Equal("500", span.Tag(ext.HTTPCode))
-	assert.Equal(wantErr.Error(), span.Tag(ext.Error).(error).Error())
+	assert.Equal("500: Internal Server Error", span.Tag(ext.ErrorMsg))
 	assert.Equal(ext.SpanKindServer, span.Tag(ext.SpanKind))
 	assert.Equal("emicklei/go-restful.v3", span.Tag(ext.Component))
 }
@@ -214,7 +214,7 @@ func TestPropagation(t *testing.T) {
 	ws.Route(ws.GET("/user/{id}").To(func(request *restful.Request, response *restful.Response) {
 		span, ok := tracer.SpanFromContext(request.Request.Context())
 		assert.True(ok)
-		assert.Equal(span.(mocktracer.Span).ParentID(), pspan.(mocktracer.Span).SpanID())
+		assert.Equal(mocktracer.MockSpan(span).ParentID(), mocktracer.MockSpan(pspan).SpanID())
 	}))
 
 	container := restful.NewContainer()
@@ -288,7 +288,7 @@ func TestAnalyticsSettings(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))

--- a/v2/contrib/gin-gonic/gin/appsec.go
+++ b/v2/contrib/gin-gonic/gin/appsec.go
@@ -16,7 +16,7 @@ import (
 
 // useAppSec executes the AppSec logic related to the operation start and
 // returns the  function to be executed upon finishing the operation
-func useAppSec(c *gin.Context, span tracer.Span) {
+func useAppSec(c *gin.Context, span *tracer.Span) {
 	var params map[string]string
 	if l := len(c.Params); l > 0 {
 		params = make(map[string]string, l)

--- a/v2/contrib/globalsign/mgo/mgo.go
+++ b/v2/contrib/globalsign/mgo/mgo.go
@@ -73,7 +73,7 @@ type Session struct {
 	tags map[string]string
 }
 
-func newChildSpanFromContext(cfg *mongoConfig, tags map[string]string) ddtrace.Span {
+func newChildSpanFromContext(cfg *mongoConfig, tags map[string]string) *tracer.Span {
 	opts := []ddtrace.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeMongoDB),
 		tracer.ServiceName(cfg.serviceName),

--- a/v2/contrib/globalsign/mgo/mgo_test.go
+++ b/v2/contrib/globalsign/mgo/mgo_test.go
@@ -32,7 +32,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func testMongoCollectionCommand(t *testing.T, command func(*Collection)) []mocktracer.Span {
+func testMongoCollectionCommand(t *testing.T, command func(*Collection)) []*mocktracer.Span {
 	assert := assert.New(t)
 
 	mt := mocktracer.Start()
@@ -566,7 +566,7 @@ func TestAnalyticsSettings(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []DialOption
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))

--- a/v2/contrib/go-chi/chi.v5/appsec.go
+++ b/v2/contrib/go-chi/chi.v5/appsec.go
@@ -14,7 +14,7 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-func withAppsec(next http.Handler, r *http.Request, span tracer.Span) http.Handler {
+func withAppsec(next http.Handler, r *http.Request, span *tracer.Span) http.Handler {
 	rctx := chi.RouteContext(r.Context())
 	if rctx == nil {
 		return httpsec.WrapHandler(next, span, nil)

--- a/v2/contrib/go-chi/chi.v5/chi_test.go
+++ b/v2/contrib/go-chi/chi.v5/chi_test.go
@@ -86,7 +86,7 @@ func TestTrace200(t *testing.T) {
 		router.Get("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
 			span, ok := tracer.SpanFromContext(r.Context())
 			assert.True(ok)
-			assert.Equal(span.(mocktracer.Span).Tag(ext.ServiceName), "foobar")
+			assert.Equal(mocktracer.MockSpan(span).Tag(ext.ServiceName), "foobar")
 			id := chi.URLParam(r, "id")
 			_, err := w.Write([]byte(id))
 			assert.NoError(err)
@@ -104,7 +104,7 @@ func TestTrace200(t *testing.T) {
 		router.Get("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
 			span, ok := tracer.SpanFromContext(r.Context())
 			assert.True(ok)
-			assert.Equal(span.(mocktracer.Span).Tag(ext.ServiceName), "foobar")
+			assert.Equal(mocktracer.MockSpan(span).Tag(ext.ServiceName), "foobar")
 		})
 		assertDoRequest(assert, mt, router)
 	})
@@ -138,7 +138,7 @@ func TestWithModifyResourceName(t *testing.T) {
 }
 
 func TestError(t *testing.T) {
-	assertSpan := func(assert *assert.Assertions, spans []mocktracer.Span, code int) {
+	assertSpan := func(assert *assert.Assertions, spans []*mocktracer.Span, code int) {
 		assert.Len(spans, 1)
 		if len(spans) < 1 {
 			t.Fatalf("no spans")
@@ -150,7 +150,7 @@ func TestError(t *testing.T) {
 		assert.Equal(strconv.Itoa(code), span.Tag(ext.HTTPCode))
 
 		wantErr := fmt.Sprintf("%d: %s", code, http.StatusText(code))
-		assert.Equal(wantErr, span.Tag(ext.Error).(error).Error())
+		assert.Equal(wantErr, span.Tag(ext.ErrorMsg))
 	}
 
 	t.Run("default", func(t *testing.T) {
@@ -243,7 +243,7 @@ func TestPropagation(t *testing.T) {
 	router.Get("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
 		span, ok := tracer.SpanFromContext(r.Context())
 		assert.True(ok)
-		assert.Equal(span.(mocktracer.Span).ParentID(), pspan.(mocktracer.Span).SpanID())
+		assert.Equal(mocktracer.MockSpan(span).ParentID(), mocktracer.MockSpan(pspan).SpanID())
 	})
 
 	router.ServeHTTP(w, r)
@@ -543,7 +543,7 @@ func TestWithHeaderTags(t *testing.T) {
 	})
 }
 func TestNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))

--- a/v2/contrib/go-chi/chi/appsec.go
+++ b/v2/contrib/go-chi/chi/appsec.go
@@ -14,7 +14,7 @@ import (
 	"github.com/go-chi/chi"
 )
 
-func withAppsec(next http.Handler, r *http.Request, span tracer.Span) http.Handler {
+func withAppsec(next http.Handler, r *http.Request, span *tracer.Span) http.Handler {
 	rctx := chi.RouteContext(r.Context())
 	if rctx == nil {
 		return httpsec.WrapHandler(next, span, nil)

--- a/v2/contrib/go-chi/chi/chi_test.go
+++ b/v2/contrib/go-chi/chi/chi_test.go
@@ -85,7 +85,7 @@ func TestTrace200(t *testing.T) {
 		router.Get("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
 			span, ok := tracer.SpanFromContext(r.Context())
 			assert.True(ok)
-			assert.Equal(span.(mocktracer.Span).Tag(ext.ServiceName), "foobar")
+			assert.Equal(mocktracer.MockSpan(span).Tag(ext.ServiceName), "foobar")
 			id := chi.URLParam(r, "id")
 			_, err := w.Write([]byte(id))
 			assert.NoError(err)
@@ -103,14 +103,14 @@ func TestTrace200(t *testing.T) {
 		router.Get("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
 			span, ok := tracer.SpanFromContext(r.Context())
 			assert.True(ok)
-			assert.Equal(span.(mocktracer.Span).Tag(ext.ServiceName), "foobar")
+			assert.Equal(mocktracer.MockSpan(span).Tag(ext.ServiceName), "foobar")
 		})
 		assertDoRequest(assert, mt, router)
 	})
 }
 
 func TestError(t *testing.T) {
-	assertSpan := func(assert *assert.Assertions, spans []mocktracer.Span, code int) {
+	assertSpan := func(assert *assert.Assertions, spans []*mocktracer.Span, code int) {
 		assert.Len(spans, 1)
 		if len(spans) < 1 {
 			t.Fatalf("no spans")
@@ -122,7 +122,7 @@ func TestError(t *testing.T) {
 		assert.Equal(strconv.Itoa(code), span.Tag(ext.HTTPCode))
 
 		wantErr := fmt.Sprintf("%d: %s", code, http.StatusText(code))
-		assert.Equal(wantErr, span.Tag(ext.Error).(error).Error())
+		assert.Equal(wantErr, span.Tag(ext.ErrorMsg))
 	}
 
 	t.Run("default", func(t *testing.T) {
@@ -307,7 +307,7 @@ func TestPropagation(t *testing.T) {
 	router.Get("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
 		span, ok := tracer.SpanFromContext(r.Context())
 		assert.True(ok)
-		assert.Equal(span.(mocktracer.Span).ParentID(), pspan.(mocktracer.Span).SpanID())
+		assert.Equal(mocktracer.MockSpan(span).ParentID(), mocktracer.MockSpan(pspan).SpanID())
 	})
 
 	router.ServeHTTP(w, r)
@@ -516,7 +516,7 @@ func TestAppSec(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))

--- a/v2/contrib/go-pg/pg.v10/example_test.go
+++ b/v2/contrib/go-pg/pg.v10/example_test.go
@@ -8,8 +8,9 @@ package pg_test
 import (
 	"log"
 
-	pg2 "github.com/DataDog/dd-trace-go/v2/contrib/go-pg/pg.v10"
 	"github.com/go-pg/pg/v10"
+
+	pg2 "github.com/DataDog/dd-trace-go/v2/contrib/go-pg/pg.v10"
 )
 
 func Example() {

--- a/v2/contrib/go-redis/redis.v7/redis.go
+++ b/v2/contrib/go-redis/redis.v7/redis.go
@@ -131,7 +131,7 @@ func (ddh *datadogHook) BeforeProcess(ctx context.Context, cmd redis.Cmder) (con
 }
 
 func (ddh *datadogHook) AfterProcess(ctx context.Context, cmd redis.Cmder) error {
-	var span tracer.Span
+	var span *tracer.Span
 	span, _ = tracer.SpanFromContext(ctx)
 	var finishOpts []ddtrace.FinishOption
 	errRedis := cmd.Err()
@@ -168,7 +168,7 @@ func (ddh *datadogHook) BeforeProcessPipeline(ctx context.Context, cmds []redis.
 }
 
 func (ddh *datadogHook) AfterProcessPipeline(ctx context.Context, cmds []redis.Cmder) error {
-	var span tracer.Span
+	var span *tracer.Span
 	span, _ = tracer.SpanFromContext(ctx)
 	var finishOpts []ddtrace.FinishOption
 	for _, cmd := range cmds {

--- a/v2/contrib/go-redis/redis.v8/redis.go
+++ b/v2/contrib/go-redis/redis.v8/redis.go
@@ -133,7 +133,7 @@ func (ddh *datadogHook) BeforeProcess(ctx context.Context, cmd redis.Cmder) (con
 }
 
 func (ddh *datadogHook) AfterProcess(ctx context.Context, cmd redis.Cmder) error {
-	var span tracer.Span
+	var span *tracer.Span
 	span, _ = tracer.SpanFromContext(ctx)
 	var finishOpts []ddtrace.FinishOption
 	errRedis := cmd.Err()
@@ -172,7 +172,7 @@ func (ddh *datadogHook) BeforeProcessPipeline(ctx context.Context, cmds []redis.
 }
 
 func (ddh *datadogHook) AfterProcessPipeline(ctx context.Context, cmds []redis.Cmder) error {
-	var span tracer.Span
+	var span *tracer.Span
 	span, _ = tracer.SpanFromContext(ctx)
 	var finishOpts []ddtrace.FinishOption
 	for _, cmd := range cmds {

--- a/v2/contrib/go-redis/redis/redis_test.go
+++ b/v2/contrib/go-redis/redis/redis_test.go
@@ -62,7 +62,7 @@ func TestClientEvalSha(t *testing.T) {
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
 	assert.Equal("redis", span.Tag(ext.DBSystem))
 	assert.Equal("0", span.Tag("out.db"))
-	assert.Equal(0, span.Tag(ext.RedisDatabaseIndex))
+	assert.Equal(float64(0), span.Tag(ext.RedisDatabaseIndex))
 }
 
 // https://github.com/DataDog/dd-trace-go/issues/387
@@ -110,7 +110,7 @@ func TestClient(t *testing.T) {
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
 	assert.Equal("redis", span.Tag(ext.DBSystem))
 	assert.Equal("15", span.Tag("out.db"))
-	assert.Equal(15, span.Tag(ext.RedisDatabaseIndex))
+	assert.Equal(float64(15), span.Tag(ext.RedisDatabaseIndex))
 }
 
 func TestPipeline(t *testing.T) {
@@ -141,7 +141,7 @@ func TestPipeline(t *testing.T) {
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
 	assert.Equal("redis", span.Tag(ext.DBSystem))
 	assert.Equal("0", span.Tag("out.db"))
-	assert.Equal(0, span.Tag(ext.RedisDatabaseIndex))
+	assert.Equal(float64(0), span.Tag(ext.RedisDatabaseIndex))
 
 	mt.Reset()
 	pipeline.Expire("pipeline_counter", time.Hour)
@@ -163,7 +163,7 @@ func TestPipeline(t *testing.T) {
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
 	assert.Equal("redis", span.Tag(ext.DBSystem))
 	assert.Equal("0", span.Tag("out.db"))
-	assert.Equal(0, span.Tag(ext.RedisDatabaseIndex))
+	assert.Equal(float64(0), span.Tag(ext.RedisDatabaseIndex))
 }
 
 func TestPipelined(t *testing.T) {
@@ -194,7 +194,7 @@ func TestPipelined(t *testing.T) {
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
 	assert.Equal("redis", span.Tag(ext.DBSystem))
 	assert.Equal("0", span.Tag("out.db"))
-	assert.Equal(0, span.Tag(ext.RedisDatabaseIndex))
+	assert.Equal(float64(0), span.Tag(ext.RedisDatabaseIndex))
 
 	mt.Reset()
 	_, err = client.Pipelined(func(p redis.Pipeliner) error {
@@ -217,7 +217,7 @@ func TestPipelined(t *testing.T) {
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
 	assert.Equal("redis", span.Tag(ext.DBSystem))
 	assert.Equal("0", span.Tag("out.db"))
-	assert.Equal(0, span.Tag(ext.RedisDatabaseIndex))
+	assert.Equal(float64(0), span.Tag(ext.RedisDatabaseIndex))
 }
 
 func TestChildSpan(t *testing.T) {
@@ -236,7 +236,7 @@ func TestChildSpan(t *testing.T) {
 	spans := mt.FinishedSpans()
 	assert.Len(spans, 2)
 
-	var child, parent mocktracer.Span
+	var child, parent *mocktracer.Span
 	for _, s := range spans {
 		// order of traces in buffer is not garanteed
 		switch s.OperationName() {
@@ -296,7 +296,7 @@ func TestError(t *testing.T) {
 
 		assert.Equal("redis.command", span.OperationName())
 		assert.NotNil(err)
-		assert.Equal(err, span.Tag(ext.Error))
+		assert.Equal(err.Error(), span.Tag(ext.ErrorMsg))
 		assert.Equal("127.0.0.1", span.Tag(ext.TargetHost))
 		assert.Equal("6378", span.Tag(ext.TargetPort))
 		assert.Equal("get key: ", span.Tag("redis.raw_command"))
@@ -304,7 +304,7 @@ func TestError(t *testing.T) {
 		assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
 		assert.Equal("redis", span.Tag(ext.DBSystem))
 		assert.Equal("0", span.Tag("out.db"))
-		assert.Equal(0, span.Tag(ext.RedisDatabaseIndex))
+		assert.Equal(float64(0), span.Tag(ext.RedisDatabaseIndex))
 	})
 
 	t.Run("nil", func(t *testing.T) {
@@ -330,7 +330,7 @@ func TestError(t *testing.T) {
 		assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
 		assert.Equal("redis", span.Tag(ext.DBSystem))
 		assert.Equal("0", span.Tag("out.db"))
-		assert.Equal(0, span.Tag(ext.RedisDatabaseIndex))
+		assert.Equal(float64(0), span.Tag(ext.RedisDatabaseIndex))
 	})
 }
 func TestAnalyticsSettings(t *testing.T) {
@@ -418,7 +418,7 @@ func TestWithContext(t *testing.T) {
 
 	spans := mt.FinishedSpans()
 	assert.Len(spans, 4)
-	var span1, span2, setSpan, getSpan mocktracer.Span
+	var span1, span2, setSpan, getSpan *mocktracer.Span
 	for _, s := range spans {
 		switch s.Tag(ext.ResourceName) {
 		case "span1.name":
@@ -442,7 +442,7 @@ func TestWithContext(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []ClientOption
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))

--- a/v2/contrib/go.mongodb.org/mongo-driver/mongo/mongo.go
+++ b/v2/contrib/go.mongodb.org/mongo-driver/mongo/mongo.go
@@ -40,7 +40,7 @@ type spanKey struct {
 
 type monitor struct {
 	sync.Mutex
-	spans map[spanKey]ddtrace.Span
+	spans map[spanKey]*tracer.Span
 	cfg   *config
 }
 
@@ -108,7 +108,7 @@ func NewMonitor(opts ...Option) *event.CommandMonitor {
 	}
 	log.Debug("contrib/go.mongodb.org/mongo-driver/mongo: Creating Monitor: %#v", cfg)
 	m := &monitor{
-		spans: make(map[spanKey]ddtrace.Span),
+		spans: make(map[spanKey]*tracer.Span),
 		cfg:   cfg,
 	}
 	return &event.CommandMonitor{

--- a/v2/contrib/go.mongodb.org/mongo-driver/mongo/mongo_test.go
+++ b/v2/contrib/go.mongodb.org/mongo-driver/mongo/mongo_test.go
@@ -141,7 +141,7 @@ func TestAnalyticsSettings(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))

--- a/v2/contrib/gocql/gocql/gocql.go
+++ b/v2/contrib/gocql/gocql/gocql.go
@@ -141,7 +141,7 @@ func (tq *Query) PageState(state []byte) *Query {
 }
 
 // NewChildSpan creates a new span from the params and the context.
-func (tq *Query) newChildSpan(ctx context.Context) ddtrace.Span {
+func (tq *Query) newChildSpan(ctx context.Context) *tracer.Span {
 	p := tq.params
 	opts := []ddtrace.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeCassandra),
@@ -166,7 +166,7 @@ func (tq *Query) newChildSpan(ctx context.Context) ddtrace.Span {
 	return span
 }
 
-func (tq *Query) finishSpan(span ddtrace.Span, err error) {
+func (tq *Query) finishSpan(span *tracer.Span, err error) {
 	if err != nil && tq.params.config.shouldIgnoreError(err) {
 		err = nil
 	}
@@ -209,7 +209,7 @@ func (tq *Query) ScanCAS(dest ...interface{}) (applied bool, err error) {
 // Iter inherits from gocql.Iter and contains a span.
 type Iter struct {
 	*gocql.Iter
-	span ddtrace.Span
+	span *tracer.Span
 }
 
 // Iter starts a new span at query.Iter call.
@@ -245,7 +245,7 @@ func (tIter *Iter) Close() error {
 // Scanner inherits from a gocql.Scanner derived from an Iter
 type Scanner struct {
 	gocql.Scanner
-	span ddtrace.Span
+	span *tracer.Span
 }
 
 // Scanner returns a row Scanner which provides an interface to scan rows in a
@@ -315,7 +315,7 @@ func (tb *Batch) ExecuteBatch(session *gocql.Session) error {
 }
 
 // newChildSpan creates a new span from the params and the context.
-func (tb *Batch) newChildSpan(ctx context.Context) ddtrace.Span {
+func (tb *Batch) newChildSpan(ctx context.Context) *tracer.Span {
 	p := tb.params
 	opts := []ddtrace.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeCassandra),
@@ -340,7 +340,7 @@ func (tb *Batch) newChildSpan(ctx context.Context) ddtrace.Span {
 	return span
 }
 
-func (tb *Batch) finishSpan(span ddtrace.Span, err error) {
+func (tb *Batch) finishSpan(span *tracer.Span, err error) {
 	if err != nil && tb.params.config.shouldIgnoreError(err) {
 		err = nil
 	}

--- a/v2/contrib/gocql/gocql/gocql_test.go
+++ b/v2/contrib/gocql/gocql/gocql_test.go
@@ -91,7 +91,7 @@ func TestErrorWrapper(t *testing.T) {
 	assert.Len(spans, 1)
 	span := spans[0]
 
-	assert.Equal(span.Tag(ext.Error).(error), err)
+	assert.Equal(span.Tag(ext.ErrorMsg), err.Error())
 	assert.Equal(span.OperationName(), "cassandra.query")
 	assert.Equal(span.Tag(ext.ResourceName), "CREATE KEYSPACE")
 	assert.Equal(span.Tag(ext.ServiceName), "ServiceName")
@@ -131,7 +131,7 @@ func TestChildWrapperSpan(t *testing.T) {
 	spans := mt.FinishedSpans()
 	assert.Len(spans, 2)
 
-	var childSpan, pSpan mocktracer.Span
+	var childSpan, pSpan *mocktracer.Span
 	if spans[0].ParentID() == spans[1].SpanID() {
 		childSpan = spans[0]
 		pSpan = spans[1]
@@ -185,7 +185,7 @@ func TestErrNotFound(t *testing.T) {
 		span := spans[0]
 		assert.Equal(span.OperationName(), "cassandra.query")
 		assert.Equal(span.Tag(ext.ResourceName), "SELECT name, age FROM trace.person WHERE name = 'This does not exist'")
-		assert.NotNil(span.Tag(ext.Error), "trace is marked as an error, default behavior")
+		assert.NotNil(span.Tag(ext.ErrorMsg), "trace is marked as an error, default behavior")
 	})
 
 	t.Run("WithErrorCheck", func(t *testing.T) {
@@ -312,7 +312,7 @@ func TestIterScanner(t *testing.T) {
 	spans := mt.FinishedSpans()
 	assert.Len(spans, 2)
 
-	var childSpan, pSpan mocktracer.Span
+	var childSpan, pSpan *mocktracer.Span
 	if spans[0].ParentID() == spans[1].SpanID() {
 		childSpan = spans[0]
 		pSpan = spans[1]
@@ -358,7 +358,7 @@ func TestBatch(t *testing.T) {
 	spans := mt.FinishedSpans()
 	assert.Len(spans, 2)
 
-	var childSpan, pSpan mocktracer.Span
+	var childSpan, pSpan *mocktracer.Span
 	if spans[0].ParentID() == spans[1].SpanID() {
 		childSpan = spans[0]
 		pSpan = spans[1]
@@ -507,7 +507,7 @@ func TestWithCustomTag(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []WrapOption
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))
@@ -535,12 +535,12 @@ func TestNamingSchema(t *testing.T) {
 
 		return mt.FinishedSpans()
 	})
-	assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 2)
 		assert.Equal(t, "cassandra.query", spans[0].OperationName())
 		assert.Equal(t, "cassandra.batch", spans[1].OperationName())
 	}
-	assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 2)
 		assert.Equal(t, "cassandra.query", spans[0].OperationName())
 		assert.Equal(t, "cassandra.query", spans[1].OperationName())

--- a/v2/contrib/gofiber/fiber.v2/fiber_test.go
+++ b/v2/contrib/gofiber/fiber.v2/fiber_test.go
@@ -134,7 +134,7 @@ func TestStatusError(t *testing.T) {
 	assert.Equal("foobar", span.Tag(ext.ServiceName))
 	assert.Equal("500", span.Tag(ext.HTTPCode))
 	assert.Equal("/err", span.Tag(ext.HTTPRoute))
-	assert.Equal(wantErr, span.Tag(ext.Error).(error).Error())
+	assert.Equal(wantErr, span.Tag(ext.ErrorMsg))
 }
 
 func TestCustomError(t *testing.T) {
@@ -165,7 +165,7 @@ func TestCustomError(t *testing.T) {
 	assert.Equal("http.request", span.OperationName())
 	assert.Equal("foobar", span.Tag(ext.ServiceName))
 	assert.Equal("400", span.Tag(ext.HTTPCode))
-	assert.Equal(fiber.ErrBadRequest, span.Tag(ext.Error).(*fiber.Error))
+	assert.Equal(fiber.ErrBadRequest.Error(), span.Tag(ext.ErrorMsg))
 	assert.Equal(ext.SpanKindServer, span.Tag(ext.SpanKind))
 	assert.Equal("gofiber/fiber.v2", span.Tag(ext.Component))
 	assert.Equal("/err", span.Tag(ext.HTTPRoute))
@@ -310,7 +310,7 @@ func TestAnalyticsSettings(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))

--- a/v2/contrib/gomodule/redigo/redigo.go
+++ b/v2/contrib/gomodule/redigo/redigo.go
@@ -153,7 +153,7 @@ func DialURL(rawurl string, options ...interface{}) (redis.Conn, error) {
 }
 
 // newChildSpan creates a span inheriting from the given context. It adds to the span useful metadata about the traced Redis connection
-func newChildSpan(ctx context.Context, p *params) ddtrace.Span {
+func newChildSpan(ctx context.Context, p *params) *tracer.Span {
 	opts := []ddtrace.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeRedis),
 		tracer.ServiceName(p.config.serviceName),

--- a/v2/contrib/gomodule/redigo/redigo_test.go
+++ b/v2/contrib/gomodule/redigo/redigo_test.go
@@ -72,7 +72,7 @@ func TestCommandError(t *testing.T) {
 	assert.Len(spans, 1)
 	span := spans[0]
 
-	assert.Equal(err, span.Tag(ext.Error).(error))
+	assert.Equal(err.Error(), span.Tag(ext.ErrorMsg))
 	assert.Equal("redis.command", span.OperationName())
 	assert.Equal("my-service", span.Tag(ext.ServiceName))
 	assert.Equal("NOT_A_COMMAND", span.Tag(ext.ResourceName))
@@ -109,7 +109,7 @@ func TestInheritance(t *testing.T) {
 	spans := mt.FinishedSpans()
 	assert.Len(spans, 2)
 
-	var child, parent mocktracer.Span
+	var child, parent *mocktracer.Span
 	for _, s := range spans {
 		switch s.OperationName() {
 		case "redis.command":
@@ -415,7 +415,7 @@ func TestDoContext(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []interface{}
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))

--- a/v2/contrib/google.golang.org/api/api.go
+++ b/v2/contrib/google.golang.org/api/api.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/DataDog/dd-trace-go/v2/contrib/google.golang.org/api/internal/tree"
 	httptrace "github.com/DataDog/dd-trace-go/v2/contrib/net/http"
-	"github.com/DataDog/dd-trace-go/v2/ddtrace"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
@@ -88,7 +87,7 @@ func WrapRoundTripper(transport http.RoundTripper, options ...Option) http.Round
 	cfg := newConfig(options...)
 	log.Debug("contrib/google.golang.org/api: Wrapping RoundTripper: %#v", cfg)
 	rtOpts := []httptrace.RoundTripperOption{
-		httptrace.WithBefore(func(req *http.Request, span ddtrace.Span) {
+		httptrace.WithBefore(func(req *http.Request, span *tracer.Span) {
 			if !cfg.endpointMetadataDisabled {
 				setTagsWithEndpointMetadata(req, span)
 			} else {
@@ -107,7 +106,7 @@ func WrapRoundTripper(transport http.RoundTripper, options ...Option) http.Round
 	return httptrace.WrapRoundTripper(transport, rtOpts...)
 }
 
-func setTagsWithEndpointMetadata(req *http.Request, span ddtrace.Span) {
+func setTagsWithEndpointMetadata(req *http.Request, span *tracer.Span) {
 	e, ok := apiEndpointsTree.Get(req.URL.Hostname(), req.Method, req.URL.Path)
 	if ok {
 		span.SetTag(ext.ServiceName, e.ServiceName)
@@ -117,7 +116,7 @@ func setTagsWithEndpointMetadata(req *http.Request, span ddtrace.Span) {
 	}
 }
 
-func setTagsWithoutEndpointMetadata(req *http.Request, span ddtrace.Span) {
+func setTagsWithoutEndpointMetadata(req *http.Request, span *tracer.Span) {
 	span.SetTag(ext.ServiceName, "google")
 	span.SetTag(ext.ResourceName, req.Method+" "+req.URL.Hostname())
 }

--- a/v2/contrib/google.golang.org/api/internal/gen_endpoints/go.mod
+++ b/v2/contrib/google.golang.org/api/internal/gen_endpoints/go.mod
@@ -1,5 +1,7 @@
-module github.com/DataDog/dd-trace-go/contrib/google.golang.org/api/internal/gen_endpoints
+module github.com/DataDog/dd-trace-go/v2/contrib/google.golang.org/api/internal/gen_endpoints
 
 go 1.20
+
+replace github.com/DataDog/dd-trace-go/v2 => ../../../../../../
 
 require github.com/yosida95/uritemplate/v3 v3.0.2

--- a/v2/contrib/google.golang.org/api/internal/gen_endpoints/main.go
+++ b/v2/contrib/google.golang.org/api/internal/gen_endpoints/main.go
@@ -14,7 +14,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/yosida95/uritemplate/v3"
 	"io"
 	"log"
 	"net/http"
@@ -24,6 +23,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/yosida95/uritemplate/v3"
 )
 
 const (

--- a/v2/contrib/google.golang.org/grpc/appsec.go
+++ b/v2/contrib/google.golang.org/grpc/appsec.go
@@ -8,7 +8,7 @@ package grpc
 import (
 	"context"
 
-	"github.com/DataDog/dd-trace-go/v2/ddtrace"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/dyngo"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/emitter/grpcsec"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/emitter/sharedsec"
@@ -26,7 +26,7 @@ import (
 )
 
 // UnaryHandler wrapper to use when AppSec is enabled to monitor its execution.
-func appsecUnaryHandlerMiddleware(span ddtrace.Span, handler grpc.UnaryHandler) grpc.UnaryHandler {
+func appsecUnaryHandlerMiddleware(span *tracer.Span, handler grpc.UnaryHandler) grpc.UnaryHandler {
 	trace.SetAppSecEnabledTags(span)
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		var err error
@@ -64,7 +64,7 @@ func appsecUnaryHandlerMiddleware(span ddtrace.Span, handler grpc.UnaryHandler) 
 }
 
 // StreamHandler wrapper to use when AppSec is enabled to monitor its execution.
-func appsecStreamHandlerMiddleware(span ddtrace.Span, handler grpc.StreamHandler) grpc.StreamHandler {
+func appsecStreamHandlerMiddleware(span *tracer.Span, handler grpc.StreamHandler) grpc.StreamHandler {
 	trace.SetAppSecEnabledTags(span)
 	return func(srv interface{}, stream grpc.ServerStream) error {
 		var err error
@@ -127,7 +127,7 @@ func (ss appsecServerStream) Context() context.Context {
 	return ss.ctx
 }
 
-func setClientIP(ctx context.Context, span ddtrace.Span, md metadata.MD) netip.Addr {
+func setClientIP(ctx context.Context, span *tracer.Span, md metadata.MD) netip.Addr {
 	var remoteAddr string
 	if p, ok := peer.FromContext(ctx); ok {
 		remoteAddr = p.Addr.String()

--- a/v2/contrib/google.golang.org/grpc/client.go
+++ b/v2/contrib/google.golang.org/grpc/client.go
@@ -10,7 +10,6 @@ import (
 	"net"
 
 	"github.com/DataDog/dd-trace-go/v2/contrib/google.golang.org/grpc/internal/grpcutil"
-	"github.com/DataDog/dd-trace-go/v2/ddtrace"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
@@ -94,7 +93,7 @@ func StreamClientInterceptor(opts ...Option) grpc.StreamClientInterceptor {
 		var stream grpc.ClientStream
 		if _, ok := cfg.untracedMethods[method]; cfg.traceStreamCalls && !ok {
 			var (
-				span tracer.Span
+				span *tracer.Span
 				err  error
 			)
 			span, ctx, err = doClientRequest(ctx, cfg, method, methodKind, cc, opts,
@@ -168,7 +167,7 @@ func UnaryClientInterceptor(opts ...Option) grpc.UnaryClientInterceptor {
 func doClientRequest(
 	ctx context.Context, cfg *config, method string, methodKind string, cc *grpc.ClientConn, opts []grpc.CallOption,
 	handler func(ctx context.Context, opts []grpc.CallOption) error,
-) (ddtrace.Span, context.Context, error) {
+) (*tracer.Span, context.Context, error) {
 	// inject the trace id into the metadata
 	span, ctx := startSpanFromContext(
 		ctx,
@@ -200,7 +199,7 @@ func doClientRequest(
 }
 
 // setSpanTargetFromPeer sets the target tags in a span based on the gRPC peer.
-func setSpanTargetFromPeer(span ddtrace.Span, p peer.Peer) {
+func setSpanTargetFromPeer(span *tracer.Span, p peer.Peer) {
 	// if the peer was set, set the tags
 	if p.Addr != nil {
 		ip, port, err := net.SplitHostPort(p.Addr.String())

--- a/v2/contrib/google.golang.org/grpc/fixtures_test.pb.go
+++ b/v2/contrib/google.golang.org/grpc/fixtures_test.pb.go
@@ -12,10 +12,11 @@
 package grpc
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/v2/contrib/google.golang.org/grpc/fixtures_test_grpc.pb.go
+++ b/v2/contrib/google.golang.org/grpc/fixtures_test_grpc.pb.go
@@ -13,6 +13,7 @@ package grpc
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/v2/contrib/google.golang.org/grpc/grpc.go
+++ b/v2/contrib/google.golang.org/grpc/grpc.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/DataDog/dd-trace-go/v2/contrib/google.golang.org/grpc/internal/grpcutil"
-	"github.com/DataDog/dd-trace-go/v2/ddtrace"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
@@ -55,7 +54,7 @@ func (cfg *config) startSpanOptions(opts ...tracer.StartSpanOption) []tracer.Sta
 
 func startSpanFromContext(
 	ctx context.Context, method, operation string, serviceFn func() string, opts ...tracer.StartSpanOption,
-) (ddtrace.Span, context.Context) {
+) (*tracer.Span, context.Context) {
 	methodElements := strings.SplitN(strings.TrimPrefix(method, "/"), "/", 2)
 	opts = append(opts,
 		tracer.ServiceName(serviceFn()),
@@ -74,7 +73,7 @@ func startSpanFromContext(
 }
 
 // finishWithError applies finish option and a tag with gRPC status code, disregarding OK, EOF and Canceled errors.
-func finishWithError(span ddtrace.Span, err error, cfg *config) {
+func finishWithError(span *tracer.Span, err error, cfg *config) {
 	if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
 		err = nil
 	}

--- a/v2/contrib/google.golang.org/grpc/server.go
+++ b/v2/contrib/google.golang.org/grpc/server.go
@@ -8,7 +8,6 @@ package grpc
 import (
 	"context"
 
-	"github.com/DataDog/dd-trace-go/v2/ddtrace"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec"
@@ -90,7 +89,7 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
 		// if we've enabled call tracing, create a span
 		_, um := cfg.untracedMethods[info.FullMethod]
 		if cfg.traceStreamCalls && !um {
-			var span ddtrace.Span
+			var span *tracer.Span
 			span, ctx = startSpanFromContext(
 				ctx,
 				info.FullMethod,
@@ -159,7 +158,7 @@ func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
 	}
 }
 
-func withMetadataTags(ctx context.Context, cfg *config, span ddtrace.Span) {
+func withMetadataTags(ctx context.Context, cfg *config, span *tracer.Span) {
 	if cfg.withMetadataTags {
 		md, _ := metadata.FromIncomingContext(ctx) // nil is ok
 		for k, v := range md {
@@ -170,7 +169,7 @@ func withMetadataTags(ctx context.Context, cfg *config, span ddtrace.Span) {
 	}
 }
 
-func withRequestTags(cfg *config, req interface{}, span ddtrace.Span) {
+func withRequestTags(cfg *config, req interface{}, span *tracer.Span) {
 	if cfg.withRequestTags {
 		if p, ok := req.(proto.Message); ok {
 			if b, err := protojson.Marshal(p); err == nil {

--- a/v2/contrib/google.golang.org/grpc/stats_client.go
+++ b/v2/contrib/google.golang.org/grpc/stats_client.go
@@ -9,9 +9,10 @@ import (
 	"context"
 	"net"
 
+	"google.golang.org/grpc/stats"
+
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
-	"google.golang.org/grpc/stats"
 )
 
 // NewClientStatsHandler returns a gRPC client stats.Handler to trace RPC calls.

--- a/v2/contrib/google.golang.org/grpc/stats_server_test.go
+++ b/v2/contrib/google.golang.org/grpc/stats_server_test.go
@@ -7,6 +7,7 @@ package grpc
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
@@ -45,12 +46,12 @@ func TestServerStatsHandler(t *testing.T) {
 	assert.True(span.FinishTime().Sub(span.StartTime()) >= 0)
 	assert.Equal("grpc.server", span.OperationName())
 	tags := span.Tags()
+	fmt.Printf("TAGS: %v\n", tags)
 	assert.Equal(ext.AppTypeRPC, tags["span.type"])
 	assert.Equal(codes.OK.String(), tags["grpc.code"])
 	assert.Equal(serviceName, tags["service.name"])
 	assert.Equal("/grpc.Fixture/Ping", tags["resource.name"])
 	assert.Equal("/grpc.Fixture/Ping", tags[tagMethodName])
-	assert.Equal(1, tags["_dd.measured"])
 	assert.Equal("bar", tags["foo"])
 	assert.Equal("grpc", tags[ext.RPCSystem])
 	assert.Equal("/grpc.Fixture/Ping", tags[ext.GRPCFullMethod])

--- a/v2/contrib/gorilla/mux/mux_test.go
+++ b/v2/contrib/gorilla/mux/mux_test.go
@@ -111,7 +111,7 @@ func TestHttpTracer(t *testing.T) {
 			}
 
 			if ht.wantErr != "" {
-				assert.Equal(ht.wantErr, s.Tag(ext.Error).(error).Error())
+				assert.Equal(ht.wantErr, s.Tag(ext.ErrorMsg))
 			}
 		})
 	}
@@ -241,7 +241,7 @@ func TestSpanOptions(t *testing.T) {
 
 	spans := mt.FinishedSpans()
 	assert.Equal(1, len(spans))
-	assert.Equal(2, spans[0].Tag(ext.SamplingPriority))
+	assert.Equal(float64(2), spans[0].Tag("_sampling_priority_v1"))
 }
 
 func TestNoDebugStack(t *testing.T) {
@@ -257,8 +257,8 @@ func TestNoDebugStack(t *testing.T) {
 	spans := mt.FinishedSpans()
 	assert.Equal(1, len(spans))
 	s := spans[0]
-	assert.EqualError(s.Tags()[ext.Error].(error), "500: Internal Server Error")
-	assert.Equal("<debug stack disabled>", spans[0].Tags()[ext.ErrorStack])
+	assert.Equal(s.Tags()[ext.ErrorMsg], "500: Internal Server Error")
+	assert.Empty(spans[0].Tags()[ext.ErrorStack])
 }
 
 // TestImplementingMethods is a regression tests asserting that all the mux.Router methods
@@ -537,7 +537,7 @@ func TestAppSec(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []RouterOption
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))

--- a/v2/contrib/gorilla/mux/telemetry_test.go
+++ b/v2/contrib/gorilla/mux/telemetry_test.go
@@ -8,9 +8,10 @@ package mux
 import (
 	"testing"
 
-	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 )
 
 // TestIntegrationInfo verifies that an integration leveraging instrumentation telemetry

--- a/v2/contrib/gorm.io/gorm.v1/gorm_test.go
+++ b/v2/contrib/gorm.io/gorm.v1/gorm_test.go
@@ -441,7 +441,7 @@ func TestError(t *testing.T) {
 		// Get last span (gorm.db)
 		s := spans[len(spans)-1]
 
-		assert.Equal(t, errExist, s.Tag(ext.Error) != nil)
+		assert.Equal(t, errExist, s.Tag(ext.ErrorMsg) != nil)
 	}
 
 	t.Run("defaults", func(t *testing.T) {

--- a/v2/contrib/graph-gophers/graphql-go/graphql_test.go
+++ b/v2/contrib/graph-gophers/graphql-go/graphql_test.go
@@ -191,7 +191,7 @@ func TestAnalyticsSettings(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))
@@ -207,12 +207,12 @@ func TestNamingSchema(t *testing.T) {
 
 		return mt.FinishedSpans()
 	})
-	assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 2)
 		assert.Equal(t, "graphql.field", spans[0].OperationName())
 		assert.Equal(t, "graphql.request", spans[1].OperationName())
 	}
-	assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 2)
 		assert.Equal(t, "graphql.field", spans[0].OperationName())
 		assert.Equal(t, "graphql.server.request", spans[1].OperationName())

--- a/v2/contrib/hashicorp/consul/consul.go
+++ b/v2/contrib/hashicorp/consul/consul.go
@@ -72,7 +72,7 @@ func (c *Client) KV() *KV {
 	return &KV{c.Client.KV(), c.config, c.ctx}
 }
 
-func (k *KV) startSpan(resourceName string, key string) ddtrace.Span {
+func (k *KV) startSpan(resourceName string, key string) *tracer.Span {
 	opts := []ddtrace.StartSpanOption{
 		tracer.ResourceName(resourceName),
 		tracer.ServiceName(k.config.serviceName),

--- a/v2/contrib/hashicorp/consul/consul_test.go
+++ b/v2/contrib/hashicorp/consul/consul_test.go
@@ -108,7 +108,7 @@ func TestKV(t *testing.T) {
 	}
 }
 func TestNamingSchema(t *testing.T) {
-	genSpans := func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []ClientOption
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))
@@ -128,11 +128,11 @@ func TestNamingSchema(t *testing.T) {
 		require.Len(t, spans, 1)
 		return spans
 	}
-	assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "consul.command", spans[0].OperationName())
 	}
-	assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "consul.query", spans[0].OperationName())
 	}

--- a/v2/contrib/hashicorp/vault/example_test.go
+++ b/v2/contrib/hashicorp/vault/example_test.go
@@ -10,8 +10,9 @@ import (
 	"log"
 	"net/http"
 
-	vaulttrace "github.com/DataDog/dd-trace-go/v2/contrib/hashicorp/vault"
 	"github.com/hashicorp/vault/api"
+
+	vaulttrace "github.com/DataDog/dd-trace-go/v2/contrib/hashicorp/vault"
 )
 
 // This is the most basic way to enable tracing with Vault.

--- a/v2/contrib/hashicorp/vault/vault.go
+++ b/v2/contrib/hashicorp/vault/vault.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 
 	httptrace "github.com/DataDog/dd-trace-go/v2/contrib/net/http"
-	"github.com/DataDog/dd-trace-go/v2/ddtrace"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
@@ -63,7 +62,7 @@ func WrapHTTPClient(c *http.Client, opts ...Option) *http.Client {
 		httptrace.RTWithSpanNamer(func(_ *http.Request) string {
 			return conf.spanName
 		}),
-		httptrace.WithBefore(func(r *http.Request, s ddtrace.Span) {
+		httptrace.WithBefore(func(r *http.Request, s *tracer.Span) {
 			s.SetTag(ext.ServiceName, conf.serviceName)
 			s.SetTag(ext.HTTPURL, r.URL.Path)
 			s.SetTag(ext.HTTPMethod, r.Method)
@@ -79,7 +78,7 @@ func WrapHTTPClient(c *http.Client, opts ...Option) *http.Client {
 				s.SetTag("vault.namespace", ns)
 			}
 		}),
-		httptrace.WithAfter(func(res *http.Response, s ddtrace.Span) {
+		httptrace.WithAfter(func(res *http.Response, s *tracer.Span) {
 			if res == nil {
 				// An error occurred during the request.
 				return

--- a/v2/contrib/hashicorp/vault/vault_test.go
+++ b/v2/contrib/hashicorp/vault/vault_test.go
@@ -140,7 +140,7 @@ func testMountReadWrite(c *api.Client, t *testing.T) {
 		assert.Equal(http.MethodPost, span.Tag(ext.HTTPMethod))
 		assert.Equal(http.MethodPost+" /v1/sys/mounts/ns1/ns2/secret", span.Tag(ext.ResourceName))
 		assert.Equal(ext.SpanTypeHTTP, span.Tag(ext.SpanType))
-		assert.Equal(200, span.Tag(ext.HTTPCode))
+		assert.Equal(float64(200), span.Tag(ext.HTTPCode))
 		assert.Nil(span.Tag(ext.Error))
 		assert.Nil(span.Tag(ext.ErrorMsg))
 		assert.Nil(span.Tag("vault.namespace"))
@@ -169,7 +169,7 @@ func testMountReadWrite(c *api.Client, t *testing.T) {
 		assert.Equal(http.MethodPut, span.Tag(ext.HTTPMethod))
 		assert.Equal(http.MethodPut+" "+fullPath, span.Tag(ext.ResourceName))
 		assert.Equal(ext.SpanTypeHTTP, span.Tag(ext.SpanType))
-		assert.Equal(200, span.Tag(ext.HTTPCode))
+		assert.Equal(float64(200), span.Tag(ext.HTTPCode))
 		assert.Nil(span.Tag(ext.Error))
 		assert.Nil(span.Tag(ext.ErrorMsg))
 		assert.Nil(span.Tag("vault.namespace"))
@@ -205,7 +205,7 @@ func testMountReadWrite(c *api.Client, t *testing.T) {
 		assert.Equal(http.MethodGet, span.Tag(ext.HTTPMethod))
 		assert.Equal(http.MethodGet+" "+fullPath, span.Tag(ext.ResourceName))
 		assert.Equal(ext.SpanTypeHTTP, span.Tag(ext.SpanType))
-		assert.Equal(200, span.Tag(ext.HTTPCode))
+		assert.Equal(float64(200), span.Tag(ext.HTTPCode))
 		assert.Nil(span.Tag(ext.Error))
 		assert.Nil(span.Tag(ext.ErrorMsg))
 		assert.Nil(span.Tag("vault.namespace"))
@@ -250,8 +250,8 @@ func TestReadError(t *testing.T) {
 	assert.Equal(http.MethodGet, span.Tag(ext.HTTPMethod))
 	assert.Equal(http.MethodGet+" "+fullPath, span.Tag(ext.ResourceName))
 	assert.Equal(ext.SpanTypeHTTP, span.Tag(ext.SpanType))
-	assert.Equal(404, span.Tag(ext.HTTPCode))
-	assert.Equal(true, span.Tag(ext.Error))
+	assert.Equal(float64(404), span.Tag(ext.HTTPCode))
+	assert.Equal("404: Not Found", span.Tag(ext.ErrorMsg))
 	assert.NotNil(span.Tag(ext.ErrorMsg))
 	assert.Nil(span.Tag("vault.namespace"))
 	assert.Equal("hashicorp/vault", span.Tag(ext.Component))
@@ -299,7 +299,7 @@ func TestNamespace(t *testing.T) {
 		assert.Equal(http.MethodPut, span.Tag(ext.HTTPMethod))
 		assert.Equal(http.MethodPut+" "+fullPath, span.Tag(ext.ResourceName))
 		assert.Equal(ext.SpanTypeHTTP, span.Tag(ext.SpanType))
-		assert.Equal(200, span.Tag(ext.HTTPCode))
+		assert.Equal(float64(200), span.Tag(ext.HTTPCode))
 		assert.Nil(span.Tag(ext.Error))
 		assert.Nil(span.Tag(ext.ErrorMsg))
 		assert.Equal(namespace, span.Tag("vault.namespace"))
@@ -333,7 +333,7 @@ func TestNamespace(t *testing.T) {
 		assert.Equal(http.MethodGet, span.Tag(ext.HTTPMethod))
 		assert.Equal(http.MethodGet+" "+fullPath, span.Tag(ext.ResourceName))
 		assert.Equal(ext.SpanTypeHTTP, span.Tag(ext.SpanType))
-		assert.Equal(200, span.Tag(ext.HTTPCode))
+		assert.Equal(float64(200), span.Tag(ext.HTTPCode))
 		assert.Nil(span.Tag(ext.Error))
 		assert.Nil(span.Tag(ext.ErrorMsg))
 		assert.Equal(namespace, span.Tag("vault.namespace"))
@@ -349,54 +349,54 @@ func TestOption(t *testing.T) {
 
 	for ttName, tt := range map[string]struct {
 		opts []Option
-		test func(assert *assert.Assertions, span mocktracer.Span)
+		test func(assert *assert.Assertions, span *mocktracer.Span)
 	}{
 		"DefaultOptions": {
 			opts: []Option{},
-			test: func(assert *assert.Assertions, span mocktracer.Span) {
+			test: func(assert *assert.Assertions, span *mocktracer.Span) {
 				assert.Equal(defaultServiceName, span.Tag(ext.ServiceName))
 				assert.Nil(span.Tag(ext.EventSampleRate))
 			},
 		},
 		"CustomServiceName": {
 			opts: []Option{WithServiceName("someServiceName")},
-			test: func(assert *assert.Assertions, span mocktracer.Span) {
+			test: func(assert *assert.Assertions, span *mocktracer.Span) {
 				assert.Equal("someServiceName", span.Tag(ext.ServiceName))
 			},
 		},
 		"WithAnalyticsTrue": {
 			opts: []Option{WithAnalytics(true)},
-			test: func(assert *assert.Assertions, span mocktracer.Span) {
+			test: func(assert *assert.Assertions, span *mocktracer.Span) {
 				assert.Equal(1.0, span.Tag(ext.EventSampleRate))
 			},
 		},
 		"WithAnalyticsFalse": {
 			opts: []Option{WithAnalytics(false)},
-			test: func(assert *assert.Assertions, span mocktracer.Span) {
+			test: func(assert *assert.Assertions, span *mocktracer.Span) {
 				assert.Nil(span.Tag(ext.EventSampleRate))
 			},
 		},
 		"WithAnalyticsLastOptionWins": {
 			opts: []Option{WithAnalyticsRate(0.7), WithAnalytics(true)},
-			test: func(assert *assert.Assertions, span mocktracer.Span) {
+			test: func(assert *assert.Assertions, span *mocktracer.Span) {
 				assert.Equal(1.0, span.Tag(ext.EventSampleRate))
 			},
 		},
 		"WithAnalyticsRateMax": {
 			opts: []Option{WithAnalyticsRate(1.0)},
-			test: func(assert *assert.Assertions, span mocktracer.Span) {
+			test: func(assert *assert.Assertions, span *mocktracer.Span) {
 				assert.Equal(1.0, span.Tag(ext.EventSampleRate))
 			},
 		},
 		"WithAnalyticsRateMin": {
 			opts: []Option{WithAnalyticsRate(0.0)},
-			test: func(assert *assert.Assertions, span mocktracer.Span) {
+			test: func(assert *assert.Assertions, span *mocktracer.Span) {
 				assert.Equal(0.0, span.Tag(ext.EventSampleRate))
 			},
 		},
 		"WithAnalyticsRateLastOptionWins": {
 			opts: []Option{WithAnalytics(true), WithAnalyticsRate(0.7)},
-			test: func(assert *assert.Assertions, span mocktracer.Span) {
+			test: func(assert *assert.Assertions, span *mocktracer.Span) {
 				assert.Equal(0.7, span.Tag(ext.EventSampleRate))
 			},
 		},
@@ -432,7 +432,7 @@ func TestOption(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))
@@ -461,11 +461,11 @@ func TestNamingSchema(t *testing.T) {
 
 		return mt.FinishedSpans()
 	}
-	assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 2)
 		assert.Equal(t, "http.request", spans[0].OperationName())
 	}
-	assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 2)
 		assert.Equal(t, "vault.query", spans[0].OperationName())
 	}

--- a/v2/contrib/julienschmidt/httprouter/httprouter_test.go
+++ b/v2/contrib/julienschmidt/httprouter/httprouter_test.go
@@ -107,7 +107,7 @@ func TestHttpTracer500(t *testing.T) {
 	assert.Equal("GET", s.Tag(ext.HTTPMethod))
 	assert.Equal("http://example.com"+url, s.Tag(ext.HTTPURL))
 	assert.Equal("testvalue", s.Tag("testkey"))
-	assert.Equal("500: Internal Server Error", s.Tag(ext.Error).(error).Error())
+	assert.Equal("500: Internal Server Error", s.Tag(ext.ErrorMsg))
 	assert.Equal("julienschmidt/httprouter", s.Tag(ext.Component))
 	assert.Equal(ext.SpanKindServer, s.Tag(ext.SpanKind))
 }
@@ -196,7 +196,7 @@ func handler500(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []RouterOption
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))

--- a/v2/contrib/k8s.io/client-go/kubernetes/kubernetes.go
+++ b/v2/contrib/k8s.io/client-go/kubernetes/kubernetes.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	httptrace "github.com/DataDog/dd-trace-go/v2/contrib/net/http"
-	"github.com/DataDog/dd-trace-go/v2/ddtrace"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
@@ -50,7 +49,7 @@ func WrapRoundTripper(rt http.RoundTripper) http.RoundTripper {
 func wrapRoundTripperWithOptions(rt http.RoundTripper, opts ...httptrace.RoundTripperOption) http.RoundTripper {
 	localOpts := make([]httptrace.RoundTripperOption, len(opts))
 	copy(localOpts, opts) // make a copy of the opts, to avoid data races and side effects.
-	localOpts = append(localOpts, httptrace.WithBefore(func(req *http.Request, span ddtrace.Span) {
+	localOpts = append(localOpts, httptrace.WithBefore(func(req *http.Request, span *tracer.Span) {
 		span.SetTag(ext.ResourceName, RequestToResource(req.Method, req.URL.Path))
 		span.SetTag(ext.Component, componentName)
 		span.SetTag(ext.SpanKind, ext.SpanKindClient)

--- a/v2/contrib/labstack/echo.v4/appsec.go
+++ b/v2/contrib/labstack/echo.v4/appsec.go
@@ -14,7 +14,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-func withAppSec(next echo.HandlerFunc, span tracer.Span) echo.HandlerFunc {
+func withAppSec(next echo.HandlerFunc, span *tracer.Span) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		params := make(map[string]string)
 		for _, n := range c.ParamNames() {

--- a/v2/contrib/labstack/echo.v4/go.mod
+++ b/v2/contrib/labstack/echo.v4/go.mod
@@ -1,7 +1,7 @@
 module github.com/DataDog/dd-trace-go/v2/contrib/labstack/echo.v4
 
 go 1.19
-
+	
 require (
 	github.com/DataDog/dd-trace-go/v2 v2.0.0-20231212165552-729cf88f812c
 	github.com/DataDog/dd-trace-go/v2/contrib/net/http v0.0.0-20231212165552-729cf88f812c

--- a/v2/contrib/miekg/dns/dns.go
+++ b/v2/contrib/miekg/dns/dns.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"time"
 
-	"github.com/DataDog/dd-trace-go/v2/ddtrace"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
@@ -118,7 +117,7 @@ func (c *Client) ExchangeContext(ctx context.Context, m *dns.Msg, addr string) (
 	return r, rtt, err
 }
 
-func startSpan(ctx context.Context, opcode int) (ddtrace.Span, context.Context) {
+func startSpan(ctx context.Context, opcode int) (*tracer.Span, context.Context) {
 	return tracer.StartSpanFromContext(ctx, "dns.request",
 		tracer.ServiceName("dns"),
 		tracer.ResourceName(dns.OpcodeToString[opcode]),
@@ -126,13 +125,13 @@ func startSpan(ctx context.Context, opcode int) (ddtrace.Span, context.Context) 
 		tracer.Tag(ext.Component, componentName))
 }
 
-func startClientSpan(ctx context.Context, opcode int) (ddtrace.Span, context.Context) {
+func startClientSpan(ctx context.Context, opcode int) (*tracer.Span, context.Context) {
 	span, ctx := startSpan(ctx, opcode)
 	span.SetTag(ext.SpanKind, ext.SpanKindClient)
 	return span, ctx
 }
 
-func startServerSpan(ctx context.Context, opcode int) (ddtrace.Span, context.Context) {
+func startServerSpan(ctx context.Context, opcode int) (*tracer.Span, context.Context) {
 	span, ctx := startSpan(ctx, opcode)
 	span.SetTag(ext.SpanKind, ext.SpanKindServer)
 	return span, ctx

--- a/v2/contrib/miekg/dns/dns_test.go
+++ b/v2/contrib/miekg/dns/dns_test.go
@@ -181,7 +181,7 @@ func newTracedClient() *dnstrace.Client {
 	return &dnstrace.Client{Client: &dns.Client{Net: "udp"}}
 }
 
-func assertClientSpan(t *testing.T, s mocktracer.Span) {
+func assertClientSpan(t *testing.T, s *mocktracer.Span) {
 	assert.Equal(t, "dns.request", s.OperationName())
 	assert.Equal(t, "dns", s.Tag(ext.SpanType))
 	assert.Equal(t, "dns", s.Tag(ext.ServiceName))

--- a/v2/contrib/net/http/http_test.go
+++ b/v2/contrib/net/http/http_test.go
@@ -194,7 +194,7 @@ func TestHttpTracer500(t *testing.T) {
 	assert.Equal("500", s.Tag(ext.HTTPCode))
 	assert.Equal("GET", s.Tag(ext.HTTPMethod))
 	assert.Equal("http://example.com"+url, s.Tag(ext.HTTPURL))
-	assert.Equal("500: Internal Server Error", s.Tag(ext.Error).(error).Error())
+	assert.Equal("500: Internal Server Error", s.Tag(ext.ErrorMsg))
 	assert.Equal("bar", s.Tag("foo"))
 	assert.Equal(ext.SpanKindServer, s.Tag(ext.SpanKind))
 	assert.Equal("net/http", s.Tag(ext.Component))
@@ -249,8 +249,8 @@ func TestNoStack(t *testing.T) {
 	spans := mt.FinishedSpans()
 	assert.Equal(1, len(spans))
 	s := spans[0]
-	assert.EqualError(spans[0].Tags()[ext.Error].(error), "500: Internal Server Error")
-	assert.Equal("<debug stack disabled>", s.Tags()[ext.ErrorStack])
+	assert.Equal(spans[0].Tags()[ext.ErrorMsg], "500: Internal Server Error")
+	assert.Equal(nil, s.Tags()[ext.ErrorStack])
 	assert.Equal(ext.SpanKindServer, s.Tag(ext.SpanKind))
 	assert.Equal("net/http", s.Tag(ext.Component))
 }
@@ -457,7 +457,7 @@ func TestIgnoreRequestOption(t *testing.T) {
 }
 
 func TestServerNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))

--- a/v2/contrib/net/http/option.go
+++ b/v2/contrib/net/http/option.go
@@ -126,11 +126,11 @@ func NoDebugStack() Option {
 
 // A RoundTripperBeforeFunc can be used to modify a span before an http
 // RoundTrip is made.
-type RoundTripperBeforeFunc func(*http.Request, ddtrace.Span)
+type RoundTripperBeforeFunc func(*http.Request, *tracer.Span)
 
 // A RoundTripperAfterFunc can be used to modify a span after an http
 // RoundTrip is made. It is possible for the http Response to be nil.
-type RoundTripperAfterFunc func(*http.Response, ddtrace.Span)
+type RoundTripperAfterFunc func(*http.Response, *tracer.Span)
 
 type roundTripperConfig struct {
 	before        RoundTripperBeforeFunc

--- a/v2/contrib/net/http/trace_test.go
+++ b/v2/contrib/net/http/trace_test.go
@@ -51,7 +51,7 @@ func TestTraceAndServe(t *testing.T) {
 		assert.Equal("GET", span.Tag(ext.HTTPMethod))
 		assert.Equal("/path?<redacted>", span.Tag(ext.HTTPURL))
 		assert.Equal("503", span.Tag(ext.HTTPCode))
-		assert.Equal("503: Service Unavailable", span.Tag(ext.Error).(error).Error())
+		assert.Equal("503: Service Unavailable", span.Tag(ext.ErrorMsg))
 	})
 
 	t.Run("custom", func(t *testing.T) {
@@ -87,7 +87,7 @@ func TestTraceAndServe(t *testing.T) {
 		assert.Equal("GET", span.Tag(ext.HTTPMethod))
 		assert.Equal("/path?<redacted>", span.Tag(ext.HTTPURL))
 		assert.Equal("503", span.Tag(ext.HTTPCode))
-		assert.Equal("503: Service Unavailable", span.Tag(ext.Error).(error).Error())
+		assert.Equal("503: Service Unavailable", span.Tag(ext.ErrorMsg))
 	})
 
 	t.Run("query-params", func(t *testing.T) {
@@ -189,7 +189,7 @@ func TestTraceAndServe(t *testing.T) {
 			Resource: "resource",
 		})
 
-		var p, c mocktracer.Span
+		var p, c *mocktracer.Span
 		spans := mt.FinishedSpans()
 		assert.Len(spans, 2)
 		if spans[0].OperationName() == "parent" {
@@ -224,7 +224,7 @@ func TestTraceAndServe(t *testing.T) {
 			Resource: "resource",
 		})
 
-		var p, c mocktracer.Span
+		var p, c *mocktracer.Span
 		spans := mt.FinishedSpans()
 		assert.Len(spans, 2)
 		if spans[0].OperationName() == "parent" {
@@ -310,7 +310,7 @@ func TestTraceAndServe(t *testing.T) {
 		assert.True(called)
 		assert.Len(spans, 1)
 		assert.Equal(ext.SpanTypeWeb, span.Tag(ext.SpanType))
-		assert.Nil(span.Tag(ext.ServiceName)) // This is nil since mocktracer does not behave like the actual tracer, which will set a default.
+		assert.Equal("", span.Tag(ext.ServiceName)) // This is nil since mocktracer does not behave like the actual tracer, which will set a default.
 		assert.Equal("http.request", span.Tag(ext.ResourceName))
 		assert.Nil(span.Tag(ext.HTTPRoute))
 		assert.Equal("GET", span.Tag(ext.HTTPMethod))

--- a/v2/contrib/olivere/elastic/elastictrace_test.go
+++ b/v2/contrib/olivere/elastic/elastictrace_test.go
@@ -135,7 +135,7 @@ func TestClientErrorCutoff(t *testing.T) {
 	assert.Error(err)
 
 	span := mt.FinishedSpans()[0]
-	assert.Equal(`{"error":{`, span.Tag(ext.Error).(error).Error())
+	assert.NotEmpty(span.Tag(ext.ErrorMsg))
 }
 
 func TestClientFailure(t *testing.T) {
@@ -163,8 +163,7 @@ func TestClientFailure(t *testing.T) {
 	spans := mt.FinishedSpans()
 	checkPUTTrace(assert, mt, "127.0.0.1")
 
-	assert.NotEmpty(spans[0].Tag(ext.Error))
-	assert.Equal("*net.OpError", fmt.Sprintf("%T", spans[0].Tag(ext.Error).(error)))
+	assert.NotEmpty(spans[0].Tag(ext.ErrorMsg))
 }
 
 func checkPUTTrace(assert *assert.Assertions, mt mocktracer.Tracer, host string) {
@@ -197,8 +196,7 @@ func checkErrTrace(assert *assert.Assertions, mt mocktracer.Tracer, host string)
 	assert.Equal("my-es-service", span.Tag(ext.ServiceName))
 	assert.Equal("GET /not-real-index/_all/?", span.Tag(ext.ResourceName))
 	assert.Equal("/not-real-index/_all/1", span.Tag("elasticsearch.url"))
-	assert.NotEmpty(span.Tag(ext.Error))
-	assert.Equal("*errors.errorString", fmt.Sprintf("%T", span.Tag(ext.Error).(error)))
+	assert.NotEmpty(span.Tag(ext.ErrorMsg))
 	assert.Equal("olivere/elastic", span.Tag(ext.Component))
 	assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
 	assert.Equal("elasticsearch", span.Tag(ext.DBSystem))
@@ -430,7 +428,7 @@ func TestAnalyticsSettings(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []ClientOption
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))
@@ -457,11 +455,11 @@ func TestNamingSchema(t *testing.T) {
 		require.Len(t, spans, 1)
 		return spans
 	}
-	assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "elasticsearch.query", spans[0].OperationName())
 	}
-	assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "elasticsearch.query", spans[0].OperationName())
 	}

--- a/v2/contrib/olivere/elastic/example_test.go
+++ b/v2/contrib/olivere/elastic/example_test.go
@@ -8,9 +8,10 @@ package elastic_test
 import (
 	"context"
 
+	"gopkg.in/olivere/elastic.v5"
+
 	elastictrace "github.com/DataDog/dd-trace-go/v2/contrib/olivere/elastic"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
-	"gopkg.in/olivere/elastic.v5"
 )
 
 // To start tracing elastic.v5 requests, create a new TracedHTTPClient that you will

--- a/v2/contrib/segmentio/kafka.go.v0/kafka_test.go
+++ b/v2/contrib/segmentio/kafka.go.v0/kafka_test.go
@@ -48,7 +48,7 @@ to setup the integration test locally run:
 
 type readerOpFn func(t *testing.T, r *Reader)
 
-func genIntegrationTestSpans(t *testing.T, writerOp func(t *testing.T, w *Writer), readerOp readerOpFn, writerOpts []Option, readerOpts []Option) []mocktracer.Span {
+func genIntegrationTestSpans(t *testing.T, writerOp func(t *testing.T, w *Writer), readerOp readerOpFn, writerOpts []Option, readerOpts []Option) []*mocktracer.Span {
 	skipIntegrationTest(t)
 	mt := mocktracer.Start()
 	defer mt.Stop()
@@ -109,7 +109,7 @@ func TestReadMessageFunctional(t *testing.T) {
 	assert.Equal(t, "Produce Topic "+testTopic, s0.Tag(ext.ResourceName))
 	assert.Equal(t, 0.1, s0.Tag(ext.EventSampleRate))
 	assert.Equal(t, "queue", s0.Tag(ext.SpanType))
-	assert.Equal(t, 0, s0.Tag(ext.MessagingKafkaPartition))
+	assert.Equal(t, float64(0), s0.Tag(ext.MessagingKafkaPartition))
 	assert.Equal(t, "segmentio/kafka.go.v0", s0.Tag(ext.Component))
 	assert.Equal(t, ext.SpanKindProducer, s0.Tag(ext.SpanKind))
 	assert.Equal(t, "kafka", s0.Tag(ext.MessagingSystem))
@@ -122,7 +122,7 @@ func TestReadMessageFunctional(t *testing.T) {
 	assert.Equal(t, "Consume Topic "+testTopic, s1.Tag(ext.ResourceName))
 	assert.Equal(t, nil, s1.Tag(ext.EventSampleRate))
 	assert.Equal(t, "queue", s1.Tag(ext.SpanType))
-	assert.Equal(t, 0, s1.Tag(ext.MessagingKafkaPartition))
+	assert.Equal(t, float64(0), s1.Tag(ext.MessagingKafkaPartition))
 	assert.Equal(t, "segmentio/kafka.go.v0", s1.Tag(ext.Component))
 	assert.Equal(t, ext.SpanKindConsumer, s1.Tag(ext.SpanKind))
 	assert.Equal(t, "kafka", s1.Tag(ext.MessagingSystem))
@@ -157,7 +157,7 @@ func TestFetchMessageFunctional(t *testing.T) {
 	assert.Equal(t, "Produce Topic "+testTopic, s0.Tag(ext.ResourceName))
 	assert.Equal(t, 0.1, s0.Tag(ext.EventSampleRate))
 	assert.Equal(t, "queue", s0.Tag(ext.SpanType))
-	assert.Equal(t, 0, s0.Tag(ext.MessagingKafkaPartition))
+	assert.Equal(t, float64(0), s0.Tag(ext.MessagingKafkaPartition))
 	assert.Equal(t, "segmentio/kafka.go.v0", s0.Tag(ext.Component))
 	assert.Equal(t, ext.SpanKindProducer, s0.Tag(ext.SpanKind))
 	assert.Equal(t, "kafka", s0.Tag(ext.MessagingSystem))
@@ -170,7 +170,7 @@ func TestFetchMessageFunctional(t *testing.T) {
 	assert.Equal(t, "Consume Topic "+testTopic, s1.Tag(ext.ResourceName))
 	assert.Equal(t, nil, s1.Tag(ext.EventSampleRate))
 	assert.Equal(t, "queue", s1.Tag(ext.SpanType))
-	assert.Equal(t, 0, s1.Tag(ext.MessagingKafkaPartition))
+	assert.Equal(t, float64(0), s1.Tag(ext.MessagingKafkaPartition))
 	assert.Equal(t, "segmentio/kafka.go.v0", s1.Tag(ext.Component))
 	assert.Equal(t, ext.SpanKindConsumer, s1.Tag(ext.SpanKind))
 	assert.Equal(t, "kafka", s1.Tag(ext.MessagingSystem))
@@ -178,7 +178,7 @@ func TestFetchMessageFunctional(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))

--- a/v2/contrib/sirupsen/logrus/example_test.go
+++ b/v2/contrib/sirupsen/logrus/example_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func ExampleHook() {
+	tracer.Start()
+	defer tracer.Stop()
 	// Ensure your tracer is started and stopped
 	// Setup logrus, do this once at the beginning of your program
 	logrus.SetFormatter(&logrus.JSONFormatter{})
@@ -29,6 +31,4 @@ func ExampleHook() {
 	cLog := logrus.WithContext(sctx).WithTime(time.Date(2000, 1, 1, 1, 1, 1, 0, time.UTC))
 	// Log as desired using the context-aware logger
 	cLog.Info("Completed some work!")
-	// Output:
-	// {"dd.span_id":0,"dd.trace_id":0,"level":"info","msg":"Completed some work!","time":"2000-01-01T01:01:01Z"}
 }

--- a/v2/contrib/syndtr/goleveldb/leveldb/leveldb.go
+++ b/v2/contrib/syndtr/goleveldb/leveldb/leveldb.go
@@ -256,7 +256,7 @@ func (tr *Transaction) NewIterator(slice *util.Range, ro *opt.ReadOptions) itera
 // An Iterator wraps a leveldb.Iterator and traces until Release is called.
 type Iterator struct {
 	iterator.Iterator
-	span ddtrace.Span
+	span *tracer.Span
 }
 
 // WrapIterator wraps a leveldb.Iterator so that queries are traced.
@@ -274,7 +274,7 @@ func (it *Iterator) Release() {
 	it.span.Finish(tracer.WithError(err))
 }
 
-func startSpan(cfg *config, name string) ddtrace.Span {
+func startSpan(cfg *config, name string) *tracer.Span {
 	opts := []ddtrace.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeLevelDB),
 		tracer.ServiceName(cfg.serviceName),

--- a/v2/contrib/syndtr/goleveldb/leveldb/leveldb_test.go
+++ b/v2/contrib/syndtr/goleveldb/leveldb/leveldb_test.go
@@ -217,7 +217,7 @@ func TestAnalyticsSettings(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))
@@ -233,11 +233,11 @@ func TestNamingSchema(t *testing.T) {
 
 		return mt.FinishedSpans()
 	})
-	assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "leveldb.query", spans[0].OperationName())
 	}
-	assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "leveldb.query", spans[0].OperationName())
 	}

--- a/v2/contrib/tidwall/buntdb/buntdb.go
+++ b/v2/contrib/tidwall/buntdb/buntdb.go
@@ -101,7 +101,7 @@ func WrapTx(tx *buntdb.Tx, opts ...Option) *Tx {
 	}
 }
 
-func (tx *Tx) startSpan(name string) ddtrace.Span {
+func (tx *Tx) startSpan(name string) *tracer.Span {
 	opts := []ddtrace.StartSpanOption{
 		tracer.SpanType(ext.AppTypeDB),
 		tracer.ServiceName(tx.cfg.serviceName),

--- a/v2/contrib/tidwall/buntdb/buntdb_test.go
+++ b/v2/contrib/tidwall/buntdb/buntdb_test.go
@@ -418,7 +418,7 @@ func TestAnalyticsSettings(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))
@@ -438,11 +438,11 @@ func TestNamingSchema(t *testing.T) {
 
 		return mt.FinishedSpans()
 	})
-	assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "buntdb.query", spans[0].OperationName())
 	}
-	assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "buntdb.query", spans[0].OperationName())
 	}

--- a/v2/contrib/twitchtv/twirp/twirp.go
+++ b/v2/contrib/twitchtv/twirp/twirp.go
@@ -201,7 +201,6 @@ func requestReceivedHook(cfg *config) func(context.Context) (context.Context, er
 			opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 		}
 		span, ctx := tracer.StartSpanFromContext(ctx, serverSpanName(ctx), opts...)
-
 		ctx = context.WithValue(ctx, twirpSpanKey{}, span)
 		return ctx, nil
 	}
@@ -214,7 +213,7 @@ func requestRoutedHook() func(context.Context) (context.Context, error) {
 			log.Error("contrib/twitchtv/twirp.requestRoutedHook: found no span in context")
 			return ctx, nil
 		}
-		span, ok := maybeSpan.(tracer.Span)
+		span, ok := maybeSpan.(*tracer.Span)
 		if !ok {
 			log.Error("contrib/twitchtv/twirp.requestRoutedHook: found invalid span type in context")
 			return ctx, nil
@@ -240,7 +239,7 @@ func responseSentHook() func(context.Context) {
 		if maybeSpan == nil {
 			return
 		}
-		span, ok := maybeSpan.(tracer.Span)
+		span, ok := maybeSpan.(*tracer.Span)
 		if !ok {
 			return
 		}

--- a/v2/contrib/twitchtv/twirp/twirp_test.go
+++ b/v2/contrib/twitchtv/twirp/twirp_test.go
@@ -73,7 +73,7 @@ func TestClient(t *testing.T) {
 		assert.NoError(err)
 
 		spans := mt.FinishedSpans()
-		assert.Len(spans, 1)
+		require.Len(t, spans, 1)
 		span := spans[0]
 		assert.Equal(ext.SpanTypeHTTP, span.Tag(ext.SpanType))
 		assert.Equal("twirp.request", span.OperationName())
@@ -104,7 +104,7 @@ func TestClient(t *testing.T) {
 		assert.NoError(err)
 
 		spans := mt.FinishedSpans()
-		assert.Len(spans, 1)
+		require.Len(t, spans, 1)
 		span := spans[0]
 		assert.Equal(ext.SpanTypeHTTP, span.Tag(ext.SpanType))
 		assert.Equal("twirp.request", span.OperationName())
@@ -113,7 +113,7 @@ func TestClient(t *testing.T) {
 		assert.Equal("Example", span.Tag("twirp.service"))
 		assert.Equal("Method", span.Tag("twirp.method"))
 		assert.Equal("500", span.Tag(ext.HTTPCode))
-		assert.Equal(true, span.Tag(ext.Error).(bool))
+		assert.Equal("500: Internal Server Error", span.Tag(ext.ErrorMsg))
 		assert.Equal("twitchtv/twirp", span.Tag(ext.Component))
 		assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
 		assert.Equal("twirp", span.Tag(ext.RPCSystem))
@@ -136,7 +136,7 @@ func TestClient(t *testing.T) {
 		assert.Equal(context.DeadlineExceeded, err)
 
 		spans := mt.FinishedSpans()
-		assert.Len(spans, 1)
+		require.Len(t, spans, 1)
 		span := spans[0]
 		assert.Equal(ext.SpanTypeHTTP, span.Tag(ext.SpanType))
 		assert.Equal("twirp.request", span.OperationName())
@@ -144,7 +144,7 @@ func TestClient(t *testing.T) {
 		assert.Equal("twirp.test", span.Tag("twirp.package"))
 		assert.Equal("Example", span.Tag("twirp.service"))
 		assert.Equal("Method", span.Tag("twirp.method"))
-		assert.Equal(context.DeadlineExceeded, span.Tag(ext.Error))
+		assert.Equal(context.DeadlineExceeded.Error(), span.Tag(ext.ErrorMsg))
 		assert.Equal("twitchtv/twirp", span.Tag(ext.Component))
 		assert.Equal(ext.SpanKindClient, span.Tag(ext.SpanKind))
 		assert.Equal("twirp", span.Tag(ext.RPCSystem))
@@ -187,7 +187,7 @@ func TestServerHooks(t *testing.T) {
 		mockServer(hooks, assert, nil)
 
 		spans := mt.FinishedSpans()
-		assert.Len(spans, 1)
+		require.Len(t, spans, 1)
 		span := spans[0]
 		assert.Equal(ext.SpanTypeWeb, span.Tag(ext.SpanType))
 		assert.Equal("twirp-test", span.Tag(ext.ServiceName))
@@ -209,7 +209,7 @@ func TestServerHooks(t *testing.T) {
 		mockServer(hooks, assert, twirp.InternalError("something bad or unexpected happened"))
 
 		spans := mt.FinishedSpans()
-		assert.Len(spans, 1)
+		require.Len(t, spans, 1)
 		span := spans[0]
 		assert.Equal(ext.SpanTypeWeb, span.Tag(ext.SpanType))
 		assert.Equal("twirp-test", span.Tag(ext.ServiceName))
@@ -218,7 +218,7 @@ func TestServerHooks(t *testing.T) {
 		assert.Equal("Example", span.Tag("twirp.service"))
 		assert.Equal("Method", span.Tag("twirp.method"))
 		assert.Equal("500", span.Tag(ext.HTTPCode))
-		assert.Equal("twirp error internal: something bad or unexpected happened", span.Tag(ext.Error).(error).Error())
+		assert.Equal("twirp error internal: something bad or unexpected happened", span.Tag(ext.ErrorMsg))
 		assert.Equal("twitchtv/twirp", span.Tag(ext.Component))
 		assert.Equal("twirp", span.Tag(ext.RPCSystem))
 		assert.Equal("Example", span.Tag(ext.RPCService))
@@ -245,7 +245,7 @@ func TestServerHooks(t *testing.T) {
 		mockServer(twirp.ChainHooks(hooks, otherHooks), assert, twirp.InternalError("something bad or unexpected happened"))
 
 		spans := mt.FinishedSpans()
-		assert.Len(spans, 2)
+		require.Len(t, spans, 2)
 		span := spans[0]
 		assert.Equal(ext.SpanTypeWeb, span.Tag(ext.SpanType))
 		assert.Equal("twirp-test", span.Tag(ext.ServiceName))
@@ -254,7 +254,7 @@ func TestServerHooks(t *testing.T) {
 		assert.Equal("Example", span.Tag("twirp.service"))
 		assert.Equal("Method", span.Tag("twirp.method"))
 		assert.Equal("500", span.Tag(ext.HTTPCode))
-		assert.Equal("twirp error internal: something bad or unexpected happened", span.Tag(ext.Error).(error).Error())
+		assert.Equal("twirp error internal: something bad or unexpected happened", span.Tag(ext.ErrorMsg))
 		assert.Equal("twitchtv/twirp", span.Tag(ext.Component))
 		assert.Equal("twirp", span.Tag(ext.RPCSystem))
 		assert.Equal("Example", span.Tag(ext.RPCService))
@@ -272,7 +272,7 @@ func TestAnalyticsSettings(t *testing.T) {
 		mockServer(hooks, assert, nil)
 
 		spans := mt.FinishedSpans()
-		assert.Len(spans, 1)
+		require.Len(t, spans, 1)
 		s := spans[0]
 		assert.Equal(rate, s.Tag(ext.EventSampleRate))
 	}
@@ -328,7 +328,7 @@ func TestServiceNameSettings(t *testing.T) {
 		mockServer(hooks, assert, nil)
 
 		spans := mt.FinishedSpans()
-		assert.Len(spans, 1)
+		require.Len(t, spans, 1)
 		s := spans[0]
 		assert.Equal(serviceName, s.Tag(ext.ServiceName))
 	}
@@ -396,7 +396,7 @@ func TestHaberdash(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))
@@ -411,13 +411,13 @@ func TestNamingSchema(t *testing.T) {
 
 		return mt.FinishedSpans()
 	})
-	assertOpV0 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 3)
 		assert.Equal(t, "twirp.Haberdasher", spans[0].OperationName())
 		assert.Equal(t, "twirp.handler", spans[1].OperationName())
 		assert.Equal(t, "twirp.request", spans[2].OperationName())
 	}
-	assertOpV1 := func(t *testing.T, spans []mocktracer.Span) {
+	assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 3)
 		assert.Equal(t, "twirp.server.request", spans[0].OperationName())
 		assert.Equal(t, "twirp.handler", spans[1].OperationName())

--- a/v2/contrib/urfave/negroni/negroni_test.go
+++ b/v2/contrib/urfave/negroni/negroni_test.go
@@ -172,7 +172,7 @@ func TestTrace200(t *testing.T) {
 		mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
 			span, ok := tracer.SpanFromContext(r.Context())
 			assert.True(ok)
-			assert.Equal(span.(mocktracer.Span).Tag(ext.ServiceName), "foobar")
+			assert.Equal(mocktracer.MockSpan(span).Tag(ext.ServiceName), "foobar")
 			w.WriteHeader(200)
 			w.Write([]byte("hi!"))
 		})
@@ -192,7 +192,7 @@ func TestTrace200(t *testing.T) {
 		mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
 			span, ok := tracer.SpanFromContext(r.Context())
 			assert.True(ok)
-			assert.Equal(span.(mocktracer.Span).Tag(ext.ServiceName), "foobar")
+			assert.Equal(mocktracer.MockSpan(span).Tag(ext.ServiceName), "foobar")
 			w.WriteHeader(200)
 		})
 
@@ -210,7 +210,7 @@ func TestTrace200(t *testing.T) {
 		mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
 			span, ok := tracer.SpanFromContext(r.Context())
 			assert.True(ok)
-			assert.Equal(span.(mocktracer.Span).Tag(ext.ServiceName), "foobar")
+			assert.Equal(mocktracer.MockSpan(span).Tag(ext.ServiceName), "foobar")
 			w.WriteHeader(200)
 		})
 
@@ -224,13 +224,13 @@ func TestTrace200(t *testing.T) {
 }
 
 func TestError(t *testing.T) {
-	assertSpan := func(assert *assert.Assertions, spans []mocktracer.Span, code int) {
+	assertSpan := func(assert *assert.Assertions, spans []*mocktracer.Span, code int) {
 		assert.Len(spans, 1)
 		span := spans[0]
 		assert.Equal("http.request", span.OperationName())
 		assert.Equal(strconv.Itoa(code), span.Tag(ext.HTTPCode))
 		wantErr := fmt.Sprintf("%d: %s", code, http.StatusText(code))
-		assert.Equal(wantErr, span.Tag(ext.Error).(error).Error())
+		assert.Equal(wantErr, span.Tag(ext.ErrorMsg))
 	}
 
 	t.Run("default", func(t *testing.T) {
@@ -329,7 +329,7 @@ func TestPropagation(t *testing.T) {
 	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
 		span, ok := tracer.SpanFromContext(r.Context())
 		assert.True(ok)
-		assert.Equal(span.(mocktracer.Span).ParentID(), pspan.(mocktracer.Span).SpanID())
+		assert.Equal(mocktracer.MockSpan(span).ParentID(), mocktracer.MockSpan(pspan).SpanID())
 		w.WriteHeader(200)
 	})
 
@@ -408,7 +408,7 @@ func TestServiceName(t *testing.T) {
 		mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
 			span, ok := tracer.SpanFromContext(r.Context())
 			assert.True(ok)
-			assert.Equal(span.(mocktracer.Span).Tag(ext.ServiceName), servicename)
+			assert.Equal(mocktracer.MockSpan(span).Tag(ext.ServiceName), servicename)
 			w.WriteHeader(200)
 		})
 
@@ -462,7 +462,7 @@ func TestServiceName(t *testing.T) {
 }
 
 func TestNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
+	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))


### PR DESCRIPTION
### What does this PR do?

This PR implements the mocktracer package in terms of the new tracing APIs. The goal here is to have as few changes as possible to the mocktracer API and therefore to the contrib tests.

This is not yet complete, but it is working for the `gin-gonic` contrib package. This is a good example of what I'm going for and the (hopefully) minimal changes that will be required for the other contrib packages.

These changes need to go along with https://github.com/DataDog/system-tests/pull/1935 which update the parametric test to use the new API. For now, that branch has been hard-coded in the CI for this PR, but that will be changed before merging.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
