### PR TITLE
tracer: Reduce flakiness of tests

### DIFF
--- a/contrib/database/sql/sql_test.go
+++ b/contrib/database/sql/sql_test.go
@@ -38,8 +38,10 @@ func TestMain(m *testing.M) {
 		fmt.Println("--- SKIP: to enable integration test, set the INTEGRATION environment variable")
 		os.Exit(0)
 	}
-	defer sqltest.Prepare(tableName)()
-	os.Exit(m.Run())
+	cleanup := sqltest.Prepare(tableName)
+	testResult := m.Run()
+	cleanup()
+	os.Exit(testResult)
 }
 
 func TestSqlServer(t *testing.T) {

--- a/contrib/gopkg.in/jinzhu/gorm.v1/gorm_test.go
+++ b/contrib/gopkg.in/jinzhu/gorm.v1/gorm_test.go
@@ -35,8 +35,10 @@ func TestMain(m *testing.M) {
 		fmt.Println("--- SKIP: to enable integration test, set the INTEGRATION environment variable")
 		os.Exit(0)
 	}
-	defer sqltest.Prepare(tableName)()
-	os.Exit(m.Run())
+	cleanup := sqltest.Prepare(tableName)
+	testResult := m.Run()
+	cleanup()
+	os.Exit(testResult)
 }
 
 func TestMySQL(t *testing.T) {

--- a/contrib/gorm.io/gorm.v1/gorm_test.go
+++ b/contrib/gorm.io/gorm.v1/gorm_test.go
@@ -44,8 +44,10 @@ func TestMain(m *testing.M) {
 		fmt.Println("--- SKIP: to enable integration test, set the INTEGRATION environment variable")
 		os.Exit(0)
 	}
-	defer sqltest.Prepare(tableName)()
-	os.Exit(m.Run())
+	cleanup := sqltest.Prepare(tableName)
+	testResult := m.Run()
+	cleanup()
+	os.Exit(testResult)
 }
 
 func TestMySQL(t *testing.T) {

--- a/contrib/jinzhu/gorm/gorm_test.go
+++ b/contrib/jinzhu/gorm/gorm_test.go
@@ -35,8 +35,10 @@ func TestMain(m *testing.M) {
 		fmt.Println("--- SKIP: to enable integration test, set the INTEGRATION environment variable")
 		os.Exit(0)
 	}
-	defer sqltest.Prepare(tableName)()
-	os.Exit(m.Run())
+	cleanup := sqltest.Prepare(tableName)
+	testResult := m.Run()
+	cleanup()
+	os.Exit(testResult)
 }
 
 func TestSqlServer(t *testing.T) {

--- a/contrib/jmoiron/sqlx/sql_test.go
+++ b/contrib/jmoiron/sqlx/sql_test.go
@@ -29,8 +29,10 @@ func TestMain(m *testing.M) {
 		fmt.Println("--- SKIP: to enable integration test, set the INTEGRATION environment variable")
 		os.Exit(0)
 	}
-	defer sqltest.Prepare(tableName)()
-	os.Exit(m.Run())
+	cleanup := sqltest.Prepare(tableName)
+	testResult := m.Run()
+	cleanup()
+	os.Exit(testResult)
 }
 
 func TestMySQL(t *testing.T) {

--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -286,7 +286,7 @@ func TestReportHealthMetrics(t *testing.T) {
 
 	tracer.StartSpan("operation").Finish()
 	flush(1)
-	tg.Wait(3, 1*time.Second)
+	tg.Wait(3, 10*time.Second)
 
 	counts := tg.Counts()
 	assert.Equal(int64(1), counts["datadog.tracer.spans_started"])

--- a/ddtrace/tracer/writer.go
+++ b/ddtrace/tracer/writer.go
@@ -97,8 +97,8 @@ func (h *agentTraceWriter) flush() {
 			p.clear()
 
 			<-h.climit
-			h.wg.Done()
 			h.statsd.Timing("datadog.tracer.flush_duration", time.Since(start), nil, 1)
+			h.wg.Done()
 		}(time.Now())
 
 		var count, size int


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Closes #2411 
Closes #2412 
Closes #2413

- 2411 I just increase the timeout here since I don't see a great way to make this not flaky at all (and 1 second seems a bit fast for the sometime slow CI, running locally I was totally unable to get this to flake at all)
- 2412 revealed a more widespread issue where we tried to use `defer` in TestMain. This fails because the normal pattern for TestMain is to provide success/fail by calling `os.Exit` with the result of running the tests (otherwise the exit code is ALWAYS `0`). Calling os.Exit exits IMMEDIATELY meaning none of the deferred code is run. I did a search for this pattern and found a few places doing it so I altered them to not use defer.
- 2413 I just moved the timing call to BEFORE marking the go routine as done, this closes a race condition where the wait group would be "done" before all the stats calls had been made making the test fail as it expected `Timing` to have been called.

For ease of review each test fix is in its own commit (if that helps)
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Flaky tests are no fun and slow us down and stuff.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
