### PR TITLE
internal/apps: make ref in workflow optional

### DIFF
--- a/.github/workflows/test-apps.cue
+++ b/.github/workflows/test-apps.cue
@@ -92,7 +92,7 @@ on: {
             [=~ "scenario:"]: {default: true},
             ref: {
                 description: "The branch to run the workflow on",
-                required: true,
+                required: false,
                 type: "string",
             },
         } 

--- a/.github/workflows/test-apps.yml
+++ b/.github/workflows/test-apps.yml
@@ -5,7 +5,7 @@ name: Test Apps
     inputs:
       ref:
         description: The branch to run the workflow on
-        required: true
+        required: false
         type: string
       'env: prod':
         type: boolean


### PR DESCRIPTION
### What does this PR do?

Makes the ref input optional so we (should) default to the triggering ref.

This is a small follow-up fix for https://github.com/DataDog/dd-trace-go/pull/2420

### Motivation

Fix scheduled workflow: https://github.com/DataDog/dd-trace-go/actions/runs/7167025415

<img width="2157" alt="CleanShot 2023-12-11 at 12 58 40@2x" src="https://github.com/DataDog/dd-trace-go/assets/15000/3ed71146-8498-48a5-8f90-555d4c7de235">

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
