### PR TITLE
internal/apps: fix argument types

### DIFF
--- a/.github/workflows/test-apps.cue
+++ b/.github/workflows/test-apps.cue
@@ -28,14 +28,14 @@
     },
     scenario_duration: {
         env: "DD_TEST_APPS_TOTAL_DURATION",
-        type: "number",
+        type: "string",
         description: "Scenario duration",
         default: "10m",
         pr_default: "60s",
     },
     profile_period: {
         env: "DD_TEST_APPS_PROFILE_PERIOD",
-        type: "number",
+        type: "string",
         description: "Profile period",
         default: "60s",
         pr_default: "10s",

--- a/.github/workflows/test-apps.yml
+++ b/.github/workflows/test-apps.yml
@@ -18,11 +18,11 @@ name: Test Apps
         default: 5
         description: Requests per second
       'arg: scenario_duration':
-        type: number
+        type: string
         default: 10m
         description: Scenario duration
       'arg: profile_period':
-        type: number
+        type: string
         default: 60s
         description: Profile period
       'scenario: unit-of-work/v1':
@@ -53,11 +53,11 @@ name: Test Apps
         default: 5
         description: Requests per second
       'arg: scenario_duration':
-        type: number
+        type: string
         default: 10m
         description: Scenario duration
       'arg: profile_period':
-        type: number
+        type: string
         default: 60s
         description: Profile period
       'scenario: unit-of-work/v1':


### PR DESCRIPTION
### What does this PR do?

Fix the argument types.

This is a small follow-up fix for https://github.com/DataDog/dd-trace-go/pull/2420

Note: This wasn't caught by my previous testing because GitHub Actions seems to ignore argument types for the default values of inputs as well as when manually triggering workflows. But if you call a workflow from another workflow, apparently it gets validated. Sigh.

### Motivation

Fix the scheduled workflow: https://github.com/DataDog/dd-trace-go/actions/runs/7167137526

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
