### PR TITLE
internal/apps: better tagging

### DIFF
--- a/.github/workflows/test-apps-schedule.yml
+++ b/.github/workflows/test-apps-schedule.yml
@@ -13,6 +13,7 @@ jobs:
     secrets: inherit
     with:
       "arg: scenario_duration": "10m"
+      "arg: tags": "trigger:nightly"
 
   weekly:
     if: github.event.schedule == '0 0 * * 2'
@@ -20,3 +21,4 @@ jobs:
     secrets: inherit
     with:
       "arg: scenario_duration": "1h"
+      "arg: tags": "trigger:weekly"

--- a/.github/workflows/test-apps.cue
+++ b/.github/workflows/test-apps.cue
@@ -24,21 +24,18 @@
         type: "number",
         description: "Requests per second",
         default: 5,
-        pr_default: default,
     },
     scenario_duration: {
         env: "DD_TEST_APPS_TOTAL_DURATION",
         type: "string",
         description: "Scenario duration",
         default: "10m",
-        pr_default: "60s",
     },
     profile_period: {
         env: "DD_TEST_APPS_PROFILE_PERIOD",
         type: "string",
         description: "Profile period",
         default: "60s",
-        pr_default: "10s",
     },
 }
 
@@ -147,7 +144,7 @@ jobs: {
                         name: "Run Scenario"
                         env: {
                             for name, arg in #args {
-                                "\(arg.env)": "${{ inputs['arg: \(name)'] || '\(arg.pr_default)' }}",
+                                "\(arg.env)": "${{ inputs['arg: \(name)'] }}",
                             }
                         },
                         run: "cd ./internal/apps && ./run-scenario.bash '\(scenario.name)'"

--- a/.github/workflows/test-apps.cue
+++ b/.github/workflows/test-apps.cue
@@ -37,6 +37,12 @@
         description: "Profile period",
         default: "60s",
     },
+    tags: {
+        env: false,
+        type: "string",
+        description: "Extra DD_TAGS",
+        default: "trigger:manual",
+    },
 }
 
 #envs: [
@@ -103,7 +109,7 @@ on: {
 
 env: {
   DD_ENV: "github",
-  DD_TAGS: "github_run_id:${{ github.run_id }} github_run_number:${{ github.run_number }}",
+  DD_TAGS: "github_run_id:${{ github.run_id }} github_run_number:${{ github.run_number }} $${{ inputs['arg: tags'] }}",
 }
 
 jobs: {
@@ -143,7 +149,8 @@ jobs: {
                     {
                         name: "Run Scenario"
                         env: {
-                            for name, arg in #args {
+                            // args.env is (string|false), so we use null coalescing to type cast to string
+                            for name, arg in #args if (*(arg.env&string) | "") != "" {
                                 "\(arg.env)": "${{ inputs['arg: \(name)'] }}",
                             }
                         },

--- a/.github/workflows/test-apps.cue
+++ b/.github/workflows/test-apps.cue
@@ -1,4 +1,5 @@
 // See /internal/apps/README.md for more information.
+import "encoding/json"
 
 #scenarios: [
     {
@@ -77,13 +78,15 @@
             },
         }
 
-        for scenario in #scenarios {
-            "scenario: \(scenario.name)": {
-                type: "boolean",
-                default: true | false,
-            }
-        }
-
+        scenarios: {
+            type: "string",
+            default: json.Marshal([
+                for scenario in #scenarios {
+                    scenario.name
+                }
+            ]),
+            description: "Scenarios to run"
+        },
     }
 }
 
@@ -109,7 +112,7 @@ on: {
 
 env: {
   DD_ENV: "github",
-  DD_TAGS: "github_run_id:${{ github.run_id }} github_run_number:${{ github.run_number }} $${{ inputs['arg: tags'] }}",
+  DD_TAGS: "github_run_id:${{ github.run_id }} github_run_number:${{ github.run_number }} ${{ inputs['arg: tags'] }}",
 }
 
 jobs: {
@@ -119,7 +122,7 @@ jobs: {
                 name: "\(scenario.name) (\(env.name))",
                 "runs-on": "ubuntu-latest",
 
-                #if_scenario: "inputs['scenario: \(scenario.name)']",
+                #if_scenario: "contains(fromJSON(inputs['scenarios']), '\(scenario.name)')",
                 #if_env: "inputs['env: \(env.name)']",
                 
                 if: "\(#if_scenario) && \(#if_env)"

--- a/.github/workflows/test-apps.yml
+++ b/.github/workflows/test-apps.yml
@@ -101,9 +101,9 @@ jobs:
           cache: true
       - name: Run Scenario
         env:
-          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] || ''5'' }}'
-          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] || ''60s'' }}'
-          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] || ''10s'' }}'
+          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] }}'
+          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] }}'
+          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] }}'
         run: cd ./internal/apps && ./run-scenario.bash 'unit-of-work/v1'
   job-0-1:
     name: unit-of-work/v1 (staging)
@@ -127,9 +127,9 @@ jobs:
           cache: true
       - name: Run Scenario
         env:
-          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] || ''5'' }}'
-          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] || ''60s'' }}'
-          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] || ''10s'' }}'
+          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] }}'
+          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] }}'
+          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] }}'
         run: cd ./internal/apps && ./run-scenario.bash 'unit-of-work/v1'
   job-1-0:
     name: unit-of-work/v2 (prod)
@@ -153,9 +153,9 @@ jobs:
           cache: true
       - name: Run Scenario
         env:
-          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] || ''5'' }}'
-          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] || ''60s'' }}'
-          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] || ''10s'' }}'
+          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] }}'
+          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] }}'
+          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] }}'
         run: cd ./internal/apps && ./run-scenario.bash 'unit-of-work/v2'
   job-1-1:
     name: unit-of-work/v2 (staging)
@@ -179,9 +179,9 @@ jobs:
           cache: true
       - name: Run Scenario
         env:
-          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] || ''5'' }}'
-          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] || ''60s'' }}'
-          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] || ''10s'' }}'
+          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] }}'
+          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] }}'
+          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] }}'
         run: cd ./internal/apps && ./run-scenario.bash 'unit-of-work/v2'
   job-2-0:
     name: memory-leak/goroutine (prod)
@@ -205,9 +205,9 @@ jobs:
           cache: true
       - name: Run Scenario
         env:
-          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] || ''5'' }}'
-          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] || ''60s'' }}'
-          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] || ''10s'' }}'
+          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] }}'
+          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] }}'
+          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] }}'
         run: cd ./internal/apps && ./run-scenario.bash 'memory-leak/goroutine'
   job-2-1:
     name: memory-leak/goroutine (staging)
@@ -231,9 +231,9 @@ jobs:
           cache: true
       - name: Run Scenario
         env:
-          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] || ''5'' }}'
-          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] || ''60s'' }}'
-          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] || ''10s'' }}'
+          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] }}'
+          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] }}'
+          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] }}'
         run: cd ./internal/apps && ./run-scenario.bash 'memory-leak/goroutine'
   job-3-0:
     name: memory-leak/heap (prod)
@@ -257,9 +257,9 @@ jobs:
           cache: true
       - name: Run Scenario
         env:
-          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] || ''5'' }}'
-          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] || ''60s'' }}'
-          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] || ''10s'' }}'
+          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] }}'
+          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] }}'
+          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] }}'
         run: cd ./internal/apps && ./run-scenario.bash 'memory-leak/heap'
   job-3-1:
     name: memory-leak/heap (staging)
@@ -283,9 +283,9 @@ jobs:
           cache: true
       - name: Run Scenario
         env:
-          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] || ''5'' }}'
-          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] || ''60s'' }}'
-          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] || ''10s'' }}'
+          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] }}'
+          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] }}'
+          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] }}'
         run: cd ./internal/apps && ./run-scenario.bash 'memory-leak/heap'
   job-4-0:
     name: memory-leak/goroutine-heap (prod)
@@ -309,9 +309,9 @@ jobs:
           cache: true
       - name: Run Scenario
         env:
-          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] || ''5'' }}'
-          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] || ''60s'' }}'
-          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] || ''10s'' }}'
+          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] }}'
+          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] }}'
+          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] }}'
         run: cd ./internal/apps && ./run-scenario.bash 'memory-leak/goroutine-heap'
   job-4-1:
     name: memory-leak/goroutine-heap (staging)
@@ -335,7 +335,7 @@ jobs:
           cache: true
       - name: Run Scenario
         env:
-          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] || ''5'' }}'
-          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] || ''60s'' }}'
-          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] || ''10s'' }}'
+          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] }}'
+          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] }}'
+          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] }}'
         run: cd ./internal/apps && ./run-scenario.bash 'memory-leak/goroutine-heap'

--- a/.github/workflows/test-apps.yml
+++ b/.github/workflows/test-apps.yml
@@ -3,6 +3,10 @@ name: Test Apps
 "on":
   workflow_call:
     inputs:
+      scenarios:
+        type: string
+        default: '["unit-of-work/v1","unit-of-work/v2","memory-leak/goroutine","memory-leak/heap","memory-leak/goroutine-heap"]'
+        description: Scenarios to run
       ref:
         description: The branch to run the workflow on
         required: false
@@ -29,23 +33,12 @@ name: Test Apps
         type: string
         default: trigger:manual
         description: Extra DD_TAGS
-      'scenario: unit-of-work/v1':
-        type: boolean
-        default: true
-      'scenario: unit-of-work/v2':
-        type: boolean
-        default: true
-      'scenario: memory-leak/goroutine':
-        type: boolean
-        default: true
-      'scenario: memory-leak/heap':
-        type: boolean
-        default: true
-      'scenario: memory-leak/goroutine-heap':
-        type: boolean
-        default: true
   workflow_dispatch:
     inputs:
+      scenarios:
+        type: string
+        default: '["unit-of-work/v1","unit-of-work/v2","memory-leak/goroutine","memory-leak/heap","memory-leak/goroutine-heap"]'
+        description: Scenarios to run
       'env: prod':
         type: boolean
         default: true
@@ -68,29 +61,14 @@ name: Test Apps
         type: string
         default: trigger:manual
         description: Extra DD_TAGS
-      'scenario: unit-of-work/v1':
-        type: boolean
-        default: false
-      'scenario: unit-of-work/v2':
-        type: boolean
-        default: false
-      'scenario: memory-leak/goroutine':
-        type: boolean
-        default: false
-      'scenario: memory-leak/heap':
-        type: boolean
-        default: false
-      'scenario: memory-leak/goroutine-heap':
-        type: boolean
-        default: false
 env:
   DD_ENV: github
-  DD_TAGS: 'github_run_id:${{ github.run_id }} github_run_number:${{ github.run_number }} $${{ inputs[''arg: tags''] }}'
+  DD_TAGS: 'github_run_id:${{ github.run_id }} github_run_number:${{ github.run_number }} ${{ inputs[''arg: tags''] }}'
 jobs:
   job-0-0:
     name: unit-of-work/v1 (prod)
     runs-on: ubuntu-latest
-    if: 'inputs[''scenario: unit-of-work/v1''] && inputs[''env: prod'']'
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''unit-of-work/v1'') && inputs[''env: prod'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -116,7 +94,7 @@ jobs:
   job-0-1:
     name: unit-of-work/v1 (staging)
     runs-on: ubuntu-latest
-    if: 'inputs[''scenario: unit-of-work/v1''] && inputs[''env: staging'']'
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''unit-of-work/v1'') && inputs[''env: staging'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -142,7 +120,7 @@ jobs:
   job-1-0:
     name: unit-of-work/v2 (prod)
     runs-on: ubuntu-latest
-    if: 'inputs[''scenario: unit-of-work/v2''] && inputs[''env: prod'']'
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''unit-of-work/v2'') && inputs[''env: prod'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -168,7 +146,7 @@ jobs:
   job-1-1:
     name: unit-of-work/v2 (staging)
     runs-on: ubuntu-latest
-    if: 'inputs[''scenario: unit-of-work/v2''] && inputs[''env: staging'']'
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''unit-of-work/v2'') && inputs[''env: staging'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -194,7 +172,7 @@ jobs:
   job-2-0:
     name: memory-leak/goroutine (prod)
     runs-on: ubuntu-latest
-    if: 'inputs[''scenario: memory-leak/goroutine''] && inputs[''env: prod'']'
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''memory-leak/goroutine'') && inputs[''env: prod'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -220,7 +198,7 @@ jobs:
   job-2-1:
     name: memory-leak/goroutine (staging)
     runs-on: ubuntu-latest
-    if: 'inputs[''scenario: memory-leak/goroutine''] && inputs[''env: staging'']'
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''memory-leak/goroutine'') && inputs[''env: staging'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -246,7 +224,7 @@ jobs:
   job-3-0:
     name: memory-leak/heap (prod)
     runs-on: ubuntu-latest
-    if: 'inputs[''scenario: memory-leak/heap''] && inputs[''env: prod'']'
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''memory-leak/heap'') && inputs[''env: prod'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -272,7 +250,7 @@ jobs:
   job-3-1:
     name: memory-leak/heap (staging)
     runs-on: ubuntu-latest
-    if: 'inputs[''scenario: memory-leak/heap''] && inputs[''env: staging'']'
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''memory-leak/heap'') && inputs[''env: staging'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -298,7 +276,7 @@ jobs:
   job-4-0:
     name: memory-leak/goroutine-heap (prod)
     runs-on: ubuntu-latest
-    if: 'inputs[''scenario: memory-leak/goroutine-heap''] && inputs[''env: prod'']'
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''memory-leak/goroutine-heap'') && inputs[''env: prod'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -324,7 +302,7 @@ jobs:
   job-4-1:
     name: memory-leak/goroutine-heap (staging)
     runs-on: ubuntu-latest
-    if: 'inputs[''scenario: memory-leak/goroutine-heap''] && inputs[''env: staging'']'
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''memory-leak/goroutine-heap'') && inputs[''env: staging'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/test-apps.yml
+++ b/.github/workflows/test-apps.yml
@@ -25,6 +25,10 @@ name: Test Apps
         type: string
         default: 60s
         description: Profile period
+      'arg: tags':
+        type: string
+        default: trigger:manual
+        description: Extra DD_TAGS
       'scenario: unit-of-work/v1':
         type: boolean
         default: true
@@ -60,6 +64,10 @@ name: Test Apps
         type: string
         default: 60s
         description: Profile period
+      'arg: tags':
+        type: string
+        default: trigger:manual
+        description: Extra DD_TAGS
       'scenario: unit-of-work/v1':
         type: boolean
         default: false
@@ -77,7 +85,7 @@ name: Test Apps
         default: false
 env:
   DD_ENV: github
-  DD_TAGS: github_run_id:${{ github.run_id }} github_run_number:${{ github.run_number }}
+  DD_TAGS: 'github_run_id:${{ github.run_id }} github_run_number:${{ github.run_number }} $${{ inputs[''arg: tags''] }}'
 jobs:
   job-0-0:
     name: unit-of-work/v1 (prod)


### PR DESCRIPTION
### What does this PR do?

* Automatically add a `trigger:weekly` or `trigger:nightly` tag to scheduled test-app runs
* Allow specifying custom `DD_TAGS` when manually triggering test-app runs
* Switch from using individual bool inputs for selecting the scenarios to supplying them via JSON (because I ran into a GH Actions limitation, see commit message 😠)
* Clean up some unrelated stuff (pr_default option)

<table>
<tr>
	<td>Before</td>
	<td>After</td>
</tr>
<tr>
	<td>
<img alt="CleanShot 2023-12-12 at 11 41 06@2x" src="https://github.com/DataDog/dd-trace-go/assets/15000/0efcf48d-0200-4c13-b901-5aaa7c41965e">
</td>
	<td>

![CleanShot 2023-12-12 at 11 41 53@2x](https://github.com/DataDog/dd-trace-go/assets/15000/4e48bba9-6d09-43f7-a994-ba4b742dc10f)

</td>
</tr>
</table> 

### Motivation

Make it easier to find the data for nightly, weekly and manually triggered test-app runs in the trace explorer and profile search.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
