### PR TITLE
appsec: update API Security config through remote configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/99designs/gqlgen v0.17.36
 	github.com/DataDog/appsec-internal-go v1.4.0
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0
-	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.1
+	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.51.0-devel.0.20231207091214-c1dd16b339ab
 	github.com/DataDog/datadog-go/v5 v5.3.0
 	github.com/DataDog/go-libddwaf/v2 v2.2.3
 	github.com/DataDog/gostackparse v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -628,8 +628,8 @@ github.com/DataDog/appsec-internal-go v1.4.0 h1:KFI8ElxkJOgpw+cUm9TXK/jh5EZvRaWM
 github.com/DataDog/appsec-internal-go v1.4.0/go.mod h1:ONW8aV6R7Thgb4g0bB9ZQCm+oRgyz5eWiW7XoQ19wIc=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0 h1:bUMSNsw1iofWiju9yc1f+kBd33E3hMJtq9GuU602Iy8=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0/go.mod h1:HzySONXnAgSmIQfL6gOv9hWprKJkx8CicuXuUbmgWfo=
-github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.1 h1:5nE6N3JSs2IG3xzMthNFhXfOaXlrsdgqmJ73lndFf8c=
-github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.1/go.mod h1:Vc+snp0Bey4MrrJyiV2tVxxJb6BmLomPvN1RgAvjGaQ=
+github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.51.0-devel.0.20231207091214-c1dd16b339ab h1:JkXo8V2DLW/SC8HPx40fRwZSi7BL+kkfGDxeJJbNAas=
+github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.51.0-devel.0.20231207091214-c1dd16b339ab/go.mod h1:Vc+snp0Bey4MrrJyiV2tVxxJb6BmLomPvN1RgAvjGaQ=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go/v5 v5.3.0 h1:2q2qjFOb3RwAZNU+ez27ZVDwErJv5/VpbBPprz7Z+s8=
 github.com/DataDog/datadog-go/v5 v5.3.0/go.mod h1:XRDJk1pTc00gm+ZDiBKsjh7oOOtJfYfglVCmFb8C2+Q=

--- a/internal/apps/go.mod
+++ b/internal/apps/go.mod
@@ -27,7 +27,7 @@ require (
 
 require (
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.1 // indirect
+	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.51.0-devel.0.20231207091214-c1dd16b339ab // indirect
 	github.com/DataDog/datadog-go/v5 v5.3.0 // indirect
 	github.com/DataDog/go-tuf v1.0.2-0.5.2 // indirect
 	github.com/DataDog/gostackparse v0.7.0 // indirect

--- a/internal/apps/go.sum
+++ b/internal/apps/go.sum
@@ -2,8 +2,8 @@ github.com/DataDog/appsec-internal-go v1.4.0 h1:KFI8ElxkJOgpw+cUm9TXK/jh5EZvRaWM
 github.com/DataDog/appsec-internal-go v1.4.0/go.mod h1:ONW8aV6R7Thgb4g0bB9ZQCm+oRgyz5eWiW7XoQ19wIc=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0 h1:bUMSNsw1iofWiju9yc1f+kBd33E3hMJtq9GuU602Iy8=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0/go.mod h1:HzySONXnAgSmIQfL6gOv9hWprKJkx8CicuXuUbmgWfo=
-github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.1 h1:5nE6N3JSs2IG3xzMthNFhXfOaXlrsdgqmJ73lndFf8c=
-github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.1/go.mod h1:Vc+snp0Bey4MrrJyiV2tVxxJb6BmLomPvN1RgAvjGaQ=
+github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.51.0-devel.0.20231207091214-c1dd16b339ab h1:JkXo8V2DLW/SC8HPx40fRwZSi7BL+kkfGDxeJJbNAas=
+github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.51.0-devel.0.20231207091214-c1dd16b339ab/go.mod h1:Vc+snp0Bey4MrrJyiV2tVxxJb6BmLomPvN1RgAvjGaQ=
 github.com/DataDog/datadog-go/v5 v5.3.0 h1:2q2qjFOb3RwAZNU+ez27ZVDwErJv5/VpbBPprz7Z+s8=
 github.com/DataDog/datadog-go/v5 v5.3.0/go.mod h1:XRDJk1pTc00gm+ZDiBKsjh7oOOtJfYfglVCmFb8C2+Q=
 github.com/DataDog/go-libddwaf/v2 v2.2.3 h1:LpKE8AYhVrEhlmlw6FGD41udtDf7zW/aMdLNbCXpegQ=

--- a/internal/appsec/appsec.go
+++ b/internal/appsec/appsec.go
@@ -153,6 +153,9 @@ func (a *appsec) start() error {
 		return err
 	}
 	a.enableRCBlocking()
+	if a.cfg.APISec.Enabled {
+		a.enableAPISecurity()
+	}
 	a.started = true
 	log.Info("appsec: up and running")
 	// TODO: log the config like the APM tracer does but we first need to define
@@ -168,6 +171,7 @@ func (a *appsec) stop() {
 	a.started = false
 	// Disable RC blocking first so that the following is guaranteed not to be concurrent anymore.
 	a.disableRCBlocking()
+	a.disableAPISecurity()
 
 	// Disable the currently applied instrumentation
 	dyngo.SwapRootOperation(nil)


### PR DESCRIPTION
### What does this PR do?

JIRA: APPSEC-16868

Add a new RC product callback (ASM_FEATURES) to handle updates to API Security configuration through RC.

Details:

- Replace ASM_FEATURES single callback by two callbacks:
  - `onRemoteActivation()` handles remote activation
  - `onAPISecConfigUpdate()` handles updates to API security configuration (sampling rate)
- Use `remoteconfig.Subscribe()` to register single product callbacks (ASM FEATURES)
- Add related tests
- Upgrade the agent to \<TDB\>
- Add RWMutex to APISecConfig to safely update the API Security sampling rate through RC


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
