### PR TITLE
test: use `t.Setenv` to set env vars in tests

### DIFF
--- a/contrib/internal/httptrace/config_test.go
+++ b/contrib/internal/httptrace/config_test.go
@@ -6,7 +6,6 @@
 package httptrace
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -50,28 +49,12 @@ func TestConfig(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			defer cleanEnv()()
 			for k, v := range tc.env {
-				os.Setenv(k, v)
+				t.Setenv(k, v)
 			}
 			c := newConfig()
 			require.Equal(t, tc.cfg.queryStringRegexp, c.queryStringRegexp)
 			require.Equal(t, tc.cfg.queryString, c.queryString)
 		})
-	}
-}
-
-func cleanEnv() func() {
-	env := map[string]string{
-		envQueryStringDisabled: os.Getenv(envQueryStringDisabled),
-		envQueryStringRegexp:   os.Getenv(envQueryStringRegexp),
-	}
-	for k := range env {
-		os.Unsetenv(k)
-	}
-	return func() {
-		for k, v := range env {
-			os.Setenv(k, v)
-		}
 	}
 }

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -116,35 +116,38 @@ func Test128(t *testing.T) {
 	_, _, _, stop := startTestTracer(t)
 	defer stop()
 
-	t.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "false")
-	span, _ := StartSpanFromContext(context.Background(), "http.request")
-	assert.NotZero(t, span.Context().TraceID())
-	w3cCtx, ok := span.Context().(ddtrace.SpanContextW3C)
-	if !ok {
-		assert.Fail(t, "couldn't cast to ddtrace.SpanContextW3C")
-	}
-	id128 := w3cCtx.TraceID128()
-	assert.Len(t, id128, 32) // ensure there are enough leading zeros
-	idBytes, err := hex.DecodeString(id128)
-	assert.NoError(t, err)
-	assert.Equal(t, uint64(0), binary.BigEndian.Uint64(idBytes[:8])) // high 64 bits should be 0
-	assert.Equal(t, span.Context().TraceID(), binary.BigEndian.Uint64(idBytes[8:]))
+	t.Run("disable 128 bit trace ids", func(t *testing.T) {
+		t.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "false")
+		span, _ := StartSpanFromContext(context.Background(), "http.request")
+		assert.NotZero(t, span.Context().TraceID())
+		w3cCtx, ok := span.Context().(ddtrace.SpanContextW3C)
+		if !ok {
+			assert.Fail(t, "couldn't cast to ddtrace.SpanContextW3C")
+		}
+		id128 := w3cCtx.TraceID128()
+		assert.Len(t, id128, 32) // ensure there are enough leading zeros
+		idBytes, err := hex.DecodeString(id128)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(0), binary.BigEndian.Uint64(idBytes[:8])) // high 64 bits should be 0
+		assert.Equal(t, span.Context().TraceID(), binary.BigEndian.Uint64(idBytes[8:]))
+	})
 
-	// Enable 128 bit trace ids
-	os.Unsetenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED")
-	span128, _ := StartSpanFromContext(context.Background(), "http.request")
-	assert.NotZero(t, span128.Context().TraceID())
-	w3cCtx, ok = span128.Context().(ddtrace.SpanContextW3C)
-	if !ok {
-		assert.Fail(t, "couldn't cast to ddtrace.SpanContextW3C")
-	}
-	id128bit := w3cCtx.TraceID128()
-	assert.NotEmpty(t, id128bit)
-	assert.Len(t, id128bit, 32)
-	// Ensure that the lower order bits match the span's 64-bit trace id
-	b, err := hex.DecodeString(id128bit)
-	assert.NoError(t, err)
-	assert.Equal(t, span128.Context().TraceID(), binary.BigEndian.Uint64(b[8:]))
+	t.Run("enable 128 bit trace ids", func(t *testing.T) {
+		os.Unsetenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED")
+		span128, _ := StartSpanFromContext(context.Background(), "http.request")
+		assert.NotZero(t, span128.Context().TraceID())
+		w3cCtx, ok := span128.Context().(ddtrace.SpanContextW3C)
+		if !ok {
+			assert.Fail(t, "couldn't cast to ddtrace.SpanContextW3C")
+		}
+		id128bit := w3cCtx.TraceID128()
+		assert.NotEmpty(t, id128bit)
+		assert.Len(t, id128bit, 32)
+		// Ensure that the lower order bits match the span's 64-bit trace id
+		b, err := hex.DecodeString(id128bit)
+		assert.NoError(t, err)
+		assert.Equal(t, span128.Context().TraceID(), binary.BigEndian.Uint64(b[8:]))
+	})
 }
 
 func TestStartSpanFromNilContext(t *testing.T) {

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -116,7 +116,7 @@ func Test128(t *testing.T) {
 	_, _, _, stop := startTestTracer(t)
 	defer stop()
 
-	os.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "false")
+	t.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "false")
 	span, _ := StartSpanFromContext(context.Background(), "http.request")
 	assert.NotZero(t, span.Context().TraceID())
 	w3cCtx, ok := span.Context().(ddtrace.SpanContextW3C)

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
-	"os"
 	"testing"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
@@ -133,7 +132,7 @@ func Test128(t *testing.T) {
 	})
 
 	t.Run("enable 128 bit trace ids", func(t *testing.T) {
-		os.Unsetenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED")
+		// DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED is true by default
 		span128, _ := StartSpanFromContext(context.Background(), "http.request")
 		assert.NotZero(t, span128.Context().TraceID())
 		w3cCtx, ok := span128.Context().(ddtrace.SpanContextW3C)

--- a/ddtrace/tracer/log_test.go
+++ b/ddtrace/tracer/log_test.go
@@ -8,7 +8,6 @@ package tracer
 import (
 	"fmt"
 	"math"
-	"os"
 	"testing"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
@@ -39,8 +38,7 @@ func TestStartupLog(t *testing.T) {
 		assert := assert.New(t)
 		tp := new(log.RecordLogger)
 
-		os.Setenv("DD_TRACE_SAMPLE_RATE", "0.123")
-		defer os.Unsetenv("DD_TRACE_SAMPLE_RATE")
+		t.Setenv("DD_TRACE_SAMPLE_RATE", "0.123")
 		tracer, _, _, stop := startTestTracer(t,
 			WithLogger(tp),
 			WithService("configured.service"),
@@ -71,10 +69,8 @@ func TestStartupLog(t *testing.T) {
 	t.Run("limit", func(t *testing.T) {
 		assert := assert.New(t)
 		tp := new(log.RecordLogger)
-		os.Setenv("DD_TRACE_SAMPLE_RATE", "0.123")
-		defer os.Unsetenv("DD_TRACE_SAMPLE_RATE")
-		os.Setenv("DD_TRACE_RATE_LIMIT", "1000.001")
-		defer os.Unsetenv("DD_TRACE_RATE_LIMIT")
+		t.Setenv("DD_TRACE_SAMPLE_RATE", "0.123")
+		t.Setenv("DD_TRACE_RATE_LIMIT", "1000.001")
 		tracer, _, _, stop := startTestTracer(t,
 			WithLogger(tp),
 			WithService("configured.service"),
@@ -103,8 +99,7 @@ func TestStartupLog(t *testing.T) {
 	t.Run("errors", func(t *testing.T) {
 		assert := assert.New(t)
 		tp := new(log.RecordLogger)
-		os.Setenv("DD_TRACE_SAMPLING_RULES", `[{"service": "some.service","sample_rate": 0.234}, {"service": "other.service"}]`)
-		defer os.Unsetenv("DD_TRACE_SAMPLING_RULES")
+		t.Setenv("DD_TRACE_SAMPLING_RULES", `[{"service": "some.service","sample_rate": 0.234}, {"service": "other.service"}]`)
 		tracer, _, _, stop := startTestTracer(t, WithLogger(tp))
 		defer stop()
 
@@ -149,8 +144,7 @@ func TestLogSamplingRules(t *testing.T) {
 	assert := assert.New(t)
 	tp := new(log.RecordLogger)
 	tp.Ignore("appsec: ", telemetry.LogPrefix)
-	os.Setenv("DD_TRACE_SAMPLING_RULES", `[{"service": "some.service", "sample_rate": 0.234}, {"service": "other.service"}, {"service": "last.service", "sample_rate": 0.56}, {"odd": "pairs"}, {"sample_rate": 9.10}]`)
-	defer os.Unsetenv("DD_TRACE_SAMPLING_RULES")
+	t.Setenv("DD_TRACE_SAMPLING_RULES", `[{"service": "some.service", "sample_rate": 0.234}, {"service": "other.service"}, {"service": "last.service", "sample_rate": 0.56}, {"odd": "pairs"}, {"sample_rate": 9.10}]`)
 	_, _, _, stop := startTestTracer(t, WithLogger(tp))
 	defer stop()
 

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -60,8 +60,7 @@ func testStatsd(t *testing.T, cfg *config, addr string) {
 }
 
 func TestStatsdUDPConnect(t *testing.T) {
-	defer func(old string) { os.Setenv("DD_DOGSTATSD_PORT", old) }(os.Getenv("DD_DOGSTATSD_PORT"))
-	os.Setenv("DD_DOGSTATSD_PORT", "8111")
+	t.Setenv("DD_DOGSTATSD_PORT", "8111")
 	testStatsd(t, newConfig(), net.JoinHostPort(defaultHostname, "8111"))
 	cfg := newConfig()
 	addr := net.JoinHostPort(defaultHostname, "8111")
@@ -144,8 +143,7 @@ func TestAutoDetectStatsd(t *testing.T) {
 	})
 
 	t.Run("env", func(t *testing.T) {
-		defer func(old string) { os.Setenv("DD_DOGSTATSD_PORT", old) }(os.Getenv("DD_DOGSTATSD_PORT"))
-		os.Setenv("DD_DOGSTATSD_PORT", "8111")
+		t.Setenv("DD_DOGSTATSD_PORT", "8111")
 		testStatsd(t, newConfig(), net.JoinHostPort(defaultHostname, "8111"))
 	})
 
@@ -222,8 +220,7 @@ func TestLoadAgentFeatures(t *testing.T) {
 	})
 
 	t.Run("discovery", func(t *testing.T) {
-		defer func(old string) { os.Setenv("DD_TRACE_FEATURES", old) }(os.Getenv("DD_TRACE_FEATURES"))
-		os.Setenv("DD_TRACE_FEATURES", "discovery")
+		t.Setenv("DD_TRACE_FEATURES", "discovery")
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Write([]byte(`{"endpoints":["/v0.6/stats"],"client_drop_p0s":true,"statsd_port":8999}`))
 		}))
@@ -410,16 +407,14 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		})
 
 		t.Run("env/on", func(t *testing.T) {
-			os.Setenv("DD_TRACE_ANALYTICS_ENABLED", "true")
-			defer os.Unsetenv("DD_TRACE_ANALYTICS_ENABLED")
+			t.Setenv("DD_TRACE_ANALYTICS_ENABLED", "true")
 			defer globalconfig.SetAnalyticsRate(math.NaN())
 			newConfig()
 			assert.Equal(t, 1.0, globalconfig.AnalyticsRate())
 		})
 
 		t.Run("env/off", func(t *testing.T) {
-			os.Setenv("DD_TRACE_ANALYTICS_ENABLED", "kj12")
-			defer os.Unsetenv("DD_TRACE_ANALYTICS_ENABLED")
+			t.Setenv("DD_TRACE_ANALYTICS_ENABLED", "kj12")
 			defer globalconfig.SetAnalyticsRate(math.NaN())
 			newConfig()
 			assert.True(t, math.IsNaN(globalconfig.AnalyticsRate()))
@@ -435,8 +430,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		})
 
 		t.Run("env-host", func(t *testing.T) {
-			os.Setenv("DD_AGENT_HOST", "my-host")
-			defer os.Unsetenv("DD_AGENT_HOST")
+			t.Setenv("DD_AGENT_HOST", "my-host")
 			tracer := newTracer()
 			defer tracer.Stop()
 			c := tracer.config
@@ -444,8 +438,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		})
 
 		t.Run("env-port", func(t *testing.T) {
-			os.Setenv("DD_DOGSTATSD_PORT", "123")
-			defer os.Unsetenv("DD_DOGSTATSD_PORT")
+			t.Setenv("DD_DOGSTATSD_PORT", "123")
 			tracer := newTracer()
 			defer tracer.Stop()
 			c := tracer.config
@@ -453,10 +446,8 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		})
 
 		t.Run("env-both", func(t *testing.T) {
-			os.Setenv("DD_AGENT_HOST", "my-host")
-			os.Setenv("DD_DOGSTATSD_PORT", "123")
-			defer os.Unsetenv("DD_AGENT_HOST")
-			defer os.Unsetenv("DD_DOGSTATSD_PORT")
+			t.Setenv("DD_AGENT_HOST", "my-host")
+			t.Setenv("DD_DOGSTATSD_PORT", "123")
 			tracer := newTracer()
 			defer tracer.Stop()
 			c := tracer.config
@@ -464,8 +455,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		})
 
 		t.Run("env-env", func(t *testing.T) {
-			os.Setenv("DD_ENV", "testEnv")
-			defer os.Unsetenv("DD_ENV")
+			t.Setenv("DD_ENV", "testEnv")
 			tracer := newTracer()
 			defer tracer.Stop()
 			c := tracer.config
@@ -481,8 +471,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 	})
 
 	t.Run("env-agentAddr", func(t *testing.T) {
-		os.Setenv("DD_AGENT_HOST", "trace-agent")
-		defer os.Unsetenv("DD_AGENT_HOST")
+		t.Setenv("DD_AGENT_HOST", "trace-agent")
 		tracer := newTracer()
 		defer tracer.Stop()
 		c := tracer.config
@@ -518,8 +507,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 	})
 
 	t.Run("override", func(t *testing.T) {
-		os.Setenv("DD_ENV", "dev")
-		defer os.Unsetenv("DD_ENV")
+		t.Setenv("DD_ENV", "dev")
 		assert := assert.New(t)
 		env := "production"
 		tracer := newTracer(WithEnv(env))
@@ -537,8 +525,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		})
 
 		t.Run("override", func(t *testing.T) {
-			os.Setenv("DD_TRACE_ENABLED", "false")
-			defer os.Unsetenv("DD_TRACE_ENABLED")
+			t.Setenv("DD_TRACE_ENABLED", "false")
 			tracer := newTracer()
 			defer tracer.Stop()
 			c := tracer.config
@@ -566,8 +553,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 	})
 
 	t.Run("env-tags", func(t *testing.T) {
-		os.Setenv("DD_TAGS", "env:test, aKey:aVal,bKey:bVal, cKey:")
-		defer os.Unsetenv("DD_TAGS")
+		t.Setenv("DD_TAGS", "env:test, aKey:aVal,bKey:bVal, cKey:")
 
 		assert := assert.New(t)
 		c := newConfig()
@@ -590,8 +576,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		})
 
 		t.Run("override", func(t *testing.T) {
-			os.Setenv(traceprof.EndpointEnvVar, "false")
-			defer os.Unsetenv(traceprof.EndpointEnvVar)
+			t.Setenv(traceprof.EndpointEnvVar, "false")
 			c := newConfig()
 			assert.False(t, c.profilerEndpoints)
 		})
@@ -604,16 +589,14 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		})
 
 		t.Run("override", func(t *testing.T) {
-			os.Setenv(traceprof.CodeHotspotsEnvVar, "false")
-			defer os.Unsetenv(traceprof.CodeHotspotsEnvVar)
+			t.Setenv(traceprof.CodeHotspotsEnvVar, "false")
 			c := newConfig()
 			assert.False(t, c.profilerHotspots)
 		})
 	})
 
 	t.Run("env-mapping", func(t *testing.T) {
-		os.Setenv("DD_SERVICE_MAPPING", "tracer.test:test2, svc:Newsvc,http.router:myRouter, noval:")
-		defer os.Unsetenv("DD_SERVICE_MAPPING")
+		t.Setenv("DD_SERVICE_MAPPING", "tracer.test:test2, svc:Newsvc,http.router:myRouter, noval:")
 
 		assert := assert.New(t)
 		c := newConfig()
@@ -626,8 +609,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 
 	t.Run("datadog-tags", func(t *testing.T) {
 		t.Run("can-set-value", func(t *testing.T) {
-			os.Setenv("DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH", "200")
-			defer os.Unsetenv("DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH")
+			t.Setenv("DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH", "200")
 			assert := assert.New(t)
 			c := newConfig()
 			p := c.propagator.(*chainedPropagator).injectors[1].(*propagator)
@@ -642,8 +624,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		})
 
 		t.Run("clamped-to-zero", func(t *testing.T) {
-			os.Setenv("DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH", "-520")
-			defer os.Unsetenv("DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH")
+			t.Setenv("DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH", "-520")
 			assert := assert.New(t)
 			c := newConfig()
 			p := c.propagator.(*chainedPropagator).injectors[1].(*propagator)
@@ -651,8 +632,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		})
 
 		t.Run("upper-clamp", func(t *testing.T) {
-			os.Setenv("DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH", "1000")
-			defer os.Unsetenv("DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH")
+			t.Setenv("DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH", "1000")
 			assert := assert.New(t)
 			c := newConfig()
 			p := c.propagator.(*chainedPropagator).injectors[1].(*propagator)
@@ -782,14 +762,12 @@ func TestDefaultDogstatsdAddr(t *testing.T) {
 	})
 
 	t.Run("env", func(t *testing.T) {
-		defer func(old string) { os.Setenv("DD_DOGSTATSD_PORT", old) }(os.Getenv("DD_DOGSTATSD_PORT"))
-		os.Setenv("DD_DOGSTATSD_PORT", "8111")
+		t.Setenv("DD_DOGSTATSD_PORT", "8111")
 		assert.Equal(t, defaultDogstatsdAddr(), "localhost:8111")
 	})
 
 	t.Run("env+socket", func(t *testing.T) {
-		defer func(old string) { os.Setenv("DD_DOGSTATSD_PORT", old) }(os.Getenv("DD_DOGSTATSD_PORT"))
-		os.Setenv("DD_DOGSTATSD_PORT", "8111")
+		t.Setenv("DD_DOGSTATSD_PORT", "8111")
 		assert.Equal(t, defaultDogstatsdAddr(), "localhost:8111")
 		f, err := ioutil.TempFile("", "dsd.socket")
 		if err != nil {
@@ -847,8 +825,7 @@ func TestServiceName(t *testing.T) {
 
 	t.Run("env", func(t *testing.T) {
 		defer globalconfig.SetServiceName("")
-		os.Setenv("DD_SERVICE", "api-intake")
-		defer os.Unsetenv("DD_SERVICE")
+		t.Setenv("DD_SERVICE", "api-intake")
 		assert := assert.New(t)
 		c := newConfig()
 
@@ -866,8 +843,7 @@ func TestServiceName(t *testing.T) {
 
 	t.Run("DD_TAGS", func(t *testing.T) {
 		defer globalconfig.SetServiceName("")
-		os.Setenv("DD_TAGS", "service:api-intake")
-		defer os.Unsetenv("DD_TAGS")
+		t.Setenv("DD_TAGS", "service:api-intake")
 		assert := assert.New(t)
 		c := newConfig()
 
@@ -882,8 +858,7 @@ func TestServiceName(t *testing.T) {
 		assert.Equal(c.serviceName, filepath.Base(os.Args[0]))
 		assert.Equal("", globalconfig.ServiceName())
 
-		os.Setenv("DD_TAGS", "service:testService")
-		defer os.Unsetenv("DD_TAGS")
+		t.Setenv("DD_TAGS", "service:testService")
 		globalconfig.SetServiceName("")
 		c = newConfig()
 		assert.Equal(c.serviceName, "testService")
@@ -894,8 +869,7 @@ func TestServiceName(t *testing.T) {
 		assert.Equal(c.serviceName, "testService2")
 		assert.Equal("testService2", globalconfig.ServiceName())
 
-		os.Setenv("DD_SERVICE", "testService3")
-		defer os.Unsetenv("DD_SERVICE")
+		t.Setenv("DD_SERVICE", "testService3")
 		globalconfig.SetServiceName("")
 		c = newConfig(WithGlobalTag("service", "testService2"))
 		assert.Equal(c.serviceName, "testService3")
@@ -993,8 +967,7 @@ func TestTagSeparators(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-			os.Setenv("DD_TAGS", tag.in)
-			defer os.Unsetenv("DD_TAGS")
+			t.Setenv("DD_TAGS", tag.in)
 			c := newConfig()
 			globalTags := c.globalTags.get()
 			for key, expected := range tag.out {
@@ -1016,8 +989,7 @@ func TestVersionConfig(t *testing.T) {
 	})
 
 	t.Run("env", func(t *testing.T) {
-		os.Setenv("DD_VERSION", "1.2.3")
-		defer os.Unsetenv("DD_VERSION")
+		t.Setenv("DD_VERSION", "1.2.3")
 		assert := assert.New(t)
 		c := newConfig()
 
@@ -1031,8 +1003,7 @@ func TestVersionConfig(t *testing.T) {
 	})
 
 	t.Run("DD_TAGS", func(t *testing.T) {
-		os.Setenv("DD_TAGS", "version:1.2.3")
-		defer os.Unsetenv("DD_TAGS")
+		t.Setenv("DD_TAGS", "version:1.2.3")
 		assert := assert.New(t)
 		c := newConfig()
 
@@ -1044,16 +1015,14 @@ func TestVersionConfig(t *testing.T) {
 		c := newConfig()
 		assert.Equal(c.version, "")
 
-		os.Setenv("DD_TAGS", "version:1.1.1")
-		defer os.Unsetenv("DD_TAGS")
+		t.Setenv("DD_TAGS", "version:1.1.1")
 		c = newConfig()
 		assert.Equal("1.1.1", c.version)
 
 		c = newConfig(WithGlobalTag("version", "1.1.2"))
 		assert.Equal("1.1.2", c.version)
 
-		os.Setenv("DD_VERSION", "1.1.3")
-		defer os.Unsetenv("DD_VERSION")
+		t.Setenv("DD_VERSION", "1.1.3")
 		c = newConfig(WithGlobalTag("version", "1.1.2"))
 		assert.Equal("1.1.3", c.version)
 
@@ -1072,8 +1041,7 @@ func TestEnvConfig(t *testing.T) {
 	})
 
 	t.Run("env", func(t *testing.T) {
-		os.Setenv("DD_ENV", "testing")
-		defer os.Unsetenv("DD_ENV")
+		t.Setenv("DD_ENV", "testing")
 		assert := assert.New(t)
 		c := newConfig()
 
@@ -1087,8 +1055,7 @@ func TestEnvConfig(t *testing.T) {
 	})
 
 	t.Run("DD_TAGS", func(t *testing.T) {
-		os.Setenv("DD_TAGS", "env:testing")
-		defer os.Unsetenv("DD_TAGS")
+		t.Setenv("DD_TAGS", "env:testing")
 		assert := assert.New(t)
 		c := newConfig()
 
@@ -1100,16 +1067,14 @@ func TestEnvConfig(t *testing.T) {
 		c := newConfig()
 		assert.Equal(c.env, "")
 
-		os.Setenv("DD_TAGS", "env:testing1")
-		defer os.Unsetenv("DD_TAGS")
+		t.Setenv("DD_TAGS", "env:testing1")
 		c = newConfig()
 		assert.Equal("testing1", c.env)
 
 		c = newConfig(WithGlobalTag("env", "testing2"))
 		assert.Equal("testing2", c.env)
 
-		os.Setenv("DD_ENV", "testing3")
-		defer os.Unsetenv("DD_ENV")
+		t.Setenv("DD_ENV", "testing3")
 		c = newConfig(WithGlobalTag("env", "testing2"))
 		assert.Equal("testing3", c.env)
 
@@ -1145,8 +1110,7 @@ func TestWithHostname(t *testing.T) {
 
 	t.Run("env", func(t *testing.T) {
 		assert := assert.New(t)
-		os.Setenv("DD_TRACE_SOURCE_HOSTNAME", "hostname-env")
-		defer os.Unsetenv("DD_TRACE_SOURCE_HOSTNAME")
+		t.Setenv("DD_TRACE_SOURCE_HOSTNAME", "hostname-env")
 		c := newConfig()
 		assert.Equal("hostname-env", c.hostname)
 	})
@@ -1154,8 +1118,7 @@ func TestWithHostname(t *testing.T) {
 	t.Run("env-override", func(t *testing.T) {
 		assert := assert.New(t)
 
-		os.Setenv("DD_TRACE_SOURCE_HOSTNAME", "hostname-env")
-		defer os.Unsetenv("DD_TRACE_SOURCE_HOSTNAME")
+		t.Setenv("DD_TRACE_SOURCE_HOSTNAME", "hostname-env")
 		c := newConfig(WithHostname("hostname-middleware"))
 		assert.Equal("hostname-middleware", c.hostname)
 	})
@@ -1170,16 +1133,14 @@ func TestWithTraceEnabled(t *testing.T) {
 
 	t.Run("env", func(t *testing.T) {
 		assert := assert.New(t)
-		os.Setenv("DD_TRACE_ENABLED", "false")
-		defer os.Unsetenv("DD_TRACE_ENABLED")
+		t.Setenv("DD_TRACE_ENABLED", "false")
 		c := newConfig()
 		assert.False(c.enabled)
 	})
 
 	t.Run("env-override", func(t *testing.T) {
 		assert := assert.New(t)
-		os.Setenv("DD_TRACE_ENABLED", "false")
-		defer os.Unsetenv("DD_TRACE_ENABLED")
+		t.Setenv("DD_TRACE_ENABLED", "false")
 		c := newConfig(WithTraceEnabled(true))
 		assert.True(c.enabled)
 	})
@@ -1238,8 +1199,7 @@ func TestWithHeaderTags(t *testing.T) {
 
 	t.Run("envvar-only", func(t *testing.T) {
 		defer globalconfig.ClearHeaderTags()
-		os.Setenv("DD_TRACE_HEADER_TAGS", "  1header:1tag,2.h.e.a.d.e.r  ")
-		defer os.Unsetenv("DD_TRACE_HEADER_TAGS")
+		t.Setenv("DD_TRACE_HEADER_TAGS", "  1header:1tag,2.h.e.a.d.e.r  ")
 
 		assert := assert.New(t)
 		newConfig()
@@ -1251,8 +1211,7 @@ func TestWithHeaderTags(t *testing.T) {
 	t.Run("env-override", func(t *testing.T) {
 		defer globalconfig.ClearHeaderTags()
 		assert := assert.New(t)
-		os.Setenv("DD_TRACE_HEADER_TAGS", "unexpected")
-		defer os.Unsetenv("DD_TRACE_HEADER_TAGS")
+		t.Setenv("DD_TRACE_HEADER_TAGS", "unexpected")
 		newConfig(WithHeaderTags([]string{"expected"}))
 		assert.Equal(ext.HTTPRequestHeaders+".expected", globalconfig.HeaderTag("Expected"))
 		assert.Equal(1, globalconfig.HeaderTagsLen())

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -8,7 +8,6 @@ package tracer
 import (
 	"errors"
 	"fmt"
-	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -567,7 +566,6 @@ func TestSpanProfilingTags(t *testing.T) {
 			require.Equal(t, false, ok)
 		})
 	}
-
 }
 
 func TestSpanError(t *testing.T) {
@@ -775,12 +773,9 @@ func TestSpanLog(t *testing.T) {
 	})
 
 	t.Run("env", func(t *testing.T) {
-		os.Setenv("DD_SERVICE", "tracer.test")
-		defer os.Unsetenv("DD_SERVICE")
-		os.Setenv("DD_VERSION", "1.2.3")
-		defer os.Unsetenv("DD_VERSION")
-		os.Setenv("DD_ENV", "testenv")
-		defer os.Unsetenv("DD_ENV")
+		t.Setenv("DD_SERVICE", "tracer.test")
+		t.Setenv("DD_VERSION", "1.2.3")
+		t.Setenv("DD_ENV", "testenv")
 		assert := assert.New(t)
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
@@ -809,12 +804,9 @@ func TestSpanLog(t *testing.T) {
 	})
 
 	t.Run("notracer/env", func(t *testing.T) {
-		os.Setenv("DD_SERVICE", "tracer.test")
-		defer os.Unsetenv("DD_SERVICE")
-		os.Setenv("DD_VERSION", "1.2.3")
-		defer os.Unsetenv("DD_VERSION")
-		os.Setenv("DD_ENV", "testenv")
-		defer os.Unsetenv("DD_ENV")
+		t.Setenv("DD_SERVICE", "tracer.test")
+		t.Setenv("DD_VERSION", "1.2.3")
+		t.Setenv("DD_ENV", "testenv")
 		assert := assert.New(t)
 		tracer, _, _, stop := startTestTracer(t)
 		span := tracer.StartSpan("test.request").(*span)

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -188,8 +187,7 @@ func TestTextMapExtractTracestatePropagation(t *testing.T) {
 		t.Run(fmt.Sprintf("TestTextMapExtractTracestatePropagation-%s", tc.name), func(t *testing.T) {
 			t.Setenv(headerPropagationStyle, tc.propagationStyle)
 			if tc.onlyExtractFirst {
-				os.Setenv("DD_TRACE_PROPAGATION_EXTRACT_FIRST", "true")
-				defer os.Unsetenv("DD_TRACE_PROPAGATION_EXTRACT_FIRST")
+				t.Setenv("DD_TRACE_PROPAGATION_EXTRACT_FIRST", "true")
 			}
 			tracer := newTracer()
 			assert := assert.New(t)
@@ -517,8 +515,7 @@ func TestTextMapPropagator(t *testing.T) {
 	})
 
 	t.Run("InjectExtract", func(t *testing.T) {
-		os.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "true")
-		defer os.Unsetenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED")
+		t.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "true")
 		t.Setenv(headerPropagationStyleExtract, "datadog")
 		t.Setenv(headerPropagationStyleInject, "datadog")
 		propagator := NewPropagator(&PropagatorConfig{

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -192,8 +192,7 @@ func TestTracerStart(t *testing.T) {
 	})
 
 	t.Run("tracing_not_enabled", func(t *testing.T) {
-		os.Setenv("DD_TRACE_ENABLED", "false")
-		defer os.Unsetenv("DD_TRACE_ENABLED")
+		t.Setenv("DD_TRACE_ENABLED", "false")
 		Start()
 		defer Stop()
 		if _, ok := internal.GetGlobalTracer().(*tracer); ok {
@@ -427,8 +426,7 @@ func TestSamplingDecision(t *testing.T) {
 	})
 
 	t.Run("client_dropped_with_single_spans:stats_enabled", func(t *testing.T) {
-		os.Setenv("DD_SPAN_SAMPLING_RULES", `[{"service": "test_*","name":"*_1", "sample_rate": 1.0, "max_per_second": 15.0}]`)
-		defer os.Unsetenv("DD_SPAN_SAMPLING_RULES")
+		t.Setenv("DD_SPAN_SAMPLING_RULES", `[{"service": "test_*","name":"*_1", "sample_rate": 1.0, "max_per_second": 15.0}]`)
 		// Stats are enabled, rules are available. Trace sample rate equals 0.
 		// Span sample rate equals 1. The trace should be dropped. One single span is extracted.
 		tracer, _, _, stop := startTestTracer(t)
@@ -457,8 +455,7 @@ func TestSamplingDecision(t *testing.T) {
 	})
 
 	t.Run("client_dropped_with_single_spans:stats_disabled", func(t *testing.T) {
-		os.Setenv("DD_SPAN_SAMPLING_RULES", `[{"service": "test_*","name":"*_1", "sample_rate": 1.0, "max_per_second": 15.0}]`)
-		defer os.Unsetenv("DD_SPAN_SAMPLING_RULES")
+		t.Setenv("DD_SPAN_SAMPLING_RULES", `[{"service": "test_*","name":"*_1", "sample_rate": 1.0, "max_per_second": 15.0}]`)
 		// Stats are disabled, rules are available. Trace sample rate equals 0.
 		// Span sample rate equals 1. The trace should be dropped. One span has single span tags set.
 		tracer, _, _, stop := startTestTracer(t)
@@ -485,8 +482,7 @@ func TestSamplingDecision(t *testing.T) {
 	})
 
 	t.Run("client_dropped_with_single_span_rules", func(t *testing.T) {
-		os.Setenv("DD_SPAN_SAMPLING_RULES", `[{"service": "match","name":"nothing", "sample_rate": 1.0, "max_per_second": 15.0}]`)
-		defer os.Unsetenv("DD_SPAN_SAMPLING_RULES")
+		t.Setenv("DD_SPAN_SAMPLING_RULES", `[{"service": "match","name":"nothing", "sample_rate": 1.0, "max_per_second": 15.0}]`)
 		// Rules are available, but match nothing. Trace sample rate equals 0.
 		// The trace should be dropped. No single spans extracted.
 		tracer, _, _, stop := startTestTracer(t)
@@ -513,8 +509,7 @@ func TestSamplingDecision(t *testing.T) {
 	})
 
 	t.Run("client_kept_with_single_spans", func(t *testing.T) {
-		os.Setenv("DD_SPAN_SAMPLING_RULES", `[{"service": "test_*","name":"*", "sample_rate": 1.0}]`)
-		defer os.Unsetenv("DD_SPAN_SAMPLING_RULES")
+		t.Setenv("DD_SPAN_SAMPLING_RULES", `[{"service": "test_*","name":"*", "sample_rate": 1.0}]`)
 		// Rules are available. Trace sample rate equals 1. Span sample rate equals 1.
 		// The trace should be kept. No single spans extracted.
 		tracer, _, _, stop := startTestTracer(t)
@@ -538,11 +533,9 @@ func TestSamplingDecision(t *testing.T) {
 	})
 
 	t.Run("single_spans_with_max_per_second:rate_1.0", func(t *testing.T) {
-		os.Setenv("DD_SPAN_SAMPLING_RULES",
+		t.Setenv("DD_SPAN_SAMPLING_RULES",
 			`[{"service": "test_*","name":"name_*", "sample_rate": 1.0,"max_per_second":50}]`)
-		defer os.Unsetenv("DD_SPAN_SAMPLING_RULES")
-		os.Setenv("DD_TRACE_SAMPLE_RATE", "0.8")
-		defer os.Unsetenv("DD_TRACE_SAMPLE_RATE")
+		t.Setenv("DD_TRACE_SAMPLE_RATE", "0.8")
 		tracer, _, _, stop := startTestTracer(t)
 		// Don't allow the rate limiter to reset while the test is running.
 		current := time.Now()
@@ -582,10 +575,8 @@ func TestSamplingDecision(t *testing.T) {
 	})
 
 	t.Run("single_spans_without_max_per_second:rate_1.0", func(t *testing.T) {
-		os.Setenv("DD_SPAN_SAMPLING_RULES", `[{"service": "test_*","name":"name_*", "sample_rate": 1.0}]`)
-		defer os.Unsetenv("DD_SPAN_SAMPLING_RULES")
-		os.Setenv("DD_TRACE_SAMPLE_RATE", "0.8")
-		defer os.Unsetenv("DD_TRACE_SAMPLE_RATE")
+		t.Setenv("DD_SPAN_SAMPLING_RULES", `[{"service": "test_*","name":"name_*", "sample_rate": 1.0}]`)
+		t.Setenv("DD_TRACE_SAMPLE_RATE", "0.8")
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
 		tracer.config.featureFlags = make(map[string]struct{})
@@ -618,10 +609,8 @@ func TestSamplingDecision(t *testing.T) {
 	})
 
 	t.Run("single_spans_without_max_per_second:rate_0.5", func(t *testing.T) {
-		os.Setenv("DD_SPAN_SAMPLING_RULES", `[{"service": "test_*","name":"name_2", "sample_rate": 0.5}]`)
-		defer os.Unsetenv("DD_SPAN_SAMPLING_RULES")
-		os.Setenv("DD_TRACE_SAMPLE_RATE", "0.8")
-		defer os.Unsetenv("DD_TRACE_SAMPLE_RATE")
+		t.Setenv("DD_SPAN_SAMPLING_RULES", `[{"service": "test_*","name":"name_2", "sample_rate": 0.5}]`)
+		t.Setenv("DD_TRACE_SAMPLE_RATE", "0.8")
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
 		tracer.config.featureFlags = make(map[string]struct{})
@@ -666,8 +655,7 @@ func TestTracerRuntimeMetrics(t *testing.T) {
 	})
 
 	t.Run("env", func(t *testing.T) {
-		os.Setenv("DD_RUNTIME_METRICS_ENABLED", "true")
-		defer os.Unsetenv("DD_RUNTIME_METRICS_ENABLED")
+		t.Setenv("DD_RUNTIME_METRICS_ENABLED", "true")
 		tp := new(log.RecordLogger)
 		tp.Ignore("appsec: ", telemetry.LogPrefix)
 		tracer := newTracer(WithLogger(tp), WithDebugMode(true))
@@ -676,8 +664,7 @@ func TestTracerRuntimeMetrics(t *testing.T) {
 	})
 
 	t.Run("overrideEnv", func(t *testing.T) {
-		os.Setenv("DD_RUNTIME_METRICS_ENABLED", "false")
-		defer os.Unsetenv("DD_RUNTIME_METRICS_ENABLED")
+		t.Setenv("DD_RUNTIME_METRICS_ENABLED", "false")
 		tp := new(log.RecordLogger)
 		tp.Ignore("appsec: ", telemetry.LogPrefix)
 		tracer := newTracer(WithRuntimeMetrics(), WithLogger(tp), WithDebugMode(true))
@@ -715,8 +702,7 @@ func TestTracerStartSpanOptions128(t *testing.T) {
 	defer internal.SetGlobalTracer(&internal.NoopTracer{})
 	t.Run("64-bit-trace-id", func(t *testing.T) {
 		assert := assert.New(t)
-		os.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "false")
-		defer os.Unsetenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED")
+		t.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "false")
 		opts := []StartSpanOption{
 			WithSpanID(987654),
 		}
@@ -1044,10 +1030,9 @@ func TestNewSpanChild(t *testing.T) {
 }
 
 func testNewSpanChild(t *testing.T, is128 bool) {
-	t.Run(fmt.Sprintf("TestNewChildSpan(is128=%t)", is128), func(*testing.T) {
+	t.Run(fmt.Sprintf("TestNewChildSpan(is128=%t)", is128), func(t *testing.T) {
 		if !is128 {
-			os.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "false")
-			defer os.Unsetenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED")
+			t.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "false")
 		}
 		assert := assert.New(t)
 
@@ -1621,8 +1606,7 @@ func TestTracerReportsHostname(t *testing.T) {
 	const hostname = "hostname-test"
 
 	t.Run("DD_TRACE_REPORT_HOSTNAME/set", func(t *testing.T) {
-		os.Setenv("DD_TRACE_REPORT_HOSTNAME", "true")
-		defer os.Unsetenv("DD_TRACE_REPORT_HOSTNAME")
+		t.Setenv("DD_TRACE_REPORT_HOSTNAME", "true")
 
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
@@ -1681,8 +1665,7 @@ func TestTracerReportsHostname(t *testing.T) {
 	})
 
 	t.Run("DD_TRACE_SOURCE_HOSTNAME/set", func(t *testing.T) {
-		os.Setenv("DD_TRACE_SOURCE_HOSTNAME", "hostname-test")
-		defer os.Unsetenv("DD_TRACE_SOURCE_HOSTNAME")
+		t.Setenv("DD_TRACE_SOURCE_HOSTNAME", "hostname-test")
 
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
@@ -2421,8 +2404,7 @@ func BenchmarkSingleSpanRetention(b *testing.B) {
 	})
 
 	b.Run("with-rules/match-half", func(b *testing.B) {
-		os.Setenv("DD_SPAN_SAMPLING_RULES", `[{"service": "test_*","name":"*_1", "sample_rate": 1.0, "max_per_second": 15.0}]`)
-		defer os.Unsetenv("DD_SPAN_SAMPLING_RULES")
+		b.Setenv("DD_SPAN_SAMPLING_RULES", `[{"service": "test_*","name":"*_1", "sample_rate": 1.0, "max_per_second": 15.0}]`)
 		tracer, _, _, stop := startTestTracer(b)
 		defer stop()
 		tracer.config.agent.DropP0s = true
@@ -2447,8 +2429,7 @@ func BenchmarkSingleSpanRetention(b *testing.B) {
 	})
 
 	b.Run("with-rules/match-all", func(b *testing.B) {
-		os.Setenv("DD_SPAN_SAMPLING_RULES", `[{"service": "test_*","name":"*_1", "sample_rate": 1.0, "max_per_second": 15.0}]`)
-		defer os.Unsetenv("DD_SPAN_SAMPLING_RULES")
+		b.Setenv("DD_SPAN_SAMPLING_RULES", `[{"service": "test_*","name":"*_1", "sample_rate": 1.0, "max_per_second": 15.0}]`)
 		tracer, _, _, stop := startTestTracer(b)
 		defer stop()
 		tracer.config.agent.DropP0s = true

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -96,12 +96,10 @@ func TestResolveAgentAddr(t *testing.T) {
 	} {
 		t.Run("", func(t *testing.T) {
 			if tt.envHost != "" {
-				os.Setenv("DD_AGENT_HOST", tt.envHost)
-				defer os.Unsetenv("DD_AGENT_HOST")
+				t.Setenv("DD_AGENT_HOST", tt.envHost)
 			}
 			if tt.envPort != "" {
-				os.Setenv("DD_TRACE_AGENT_PORT", tt.envPort)
-				defer os.Unsetenv("DD_TRACE_AGENT_PORT")
+				t.Setenv("DD_TRACE_AGENT_PORT", tt.envPort)
 			}
 			c.agentURL = resolveAgentAddr()
 			if tt.inOpt != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

Reference: https://pkg.go.dev/testing#T.Setenv

```go
func TestFoo(t *testing.T) {
	// before
	os.Setenv(key, "new value")
	defer os.Unsetenv(key)
	
	// after
	t.Setenv(key, "new value")
}
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
