### PR TITLE
profiler: support user-triggered trace collection

### DIFF
--- a/profiler/limiter.go
+++ b/profiler/limiter.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023 Datadog, Inc.
+
+package profiler
+
+import (
+	"time"
+)
+
+// rateLimiter limits the number of actions that can be taken in
+// a time period, which can be conditionally activated
+type rateLimiter struct {
+	active     bool
+	tokens     int
+	capacity   int
+	period     time.Duration
+	activation time.Time
+}
+
+// newRateLimiter returns a limiter which allows up to count actions
+// to be taken in the given time period, once activated
+func newRateLimiter(count int, period time.Duration) *rateLimiter {
+	return &rateLimiter{
+		capacity: count,
+		period:   period,
+	}
+}
+
+// activate activates the rate limiter if it is not already active
+func (l *rateLimiter) activate() {
+	if l.active {
+		return
+	}
+	l.activation = time.Now()
+	l.tokens = l.capacity
+	l.active = true
+}
+
+// allow requests to take an action and returns whether the action can be taken
+// given the configured limit, if the limiter is active
+func (l *rateLimiter) allow() bool {
+	if !l.active {
+		return true
+	}
+	if time.Since(l.activation) > l.period {
+		l.active = false
+		return true
+	}
+	l.tokens--
+	return l.tokens >= 0
+}

--- a/profiler/telemetry.go
+++ b/profiler/telemetry.go
@@ -51,6 +51,7 @@ func startTelemetry(c *config) {
 			{Name: "execution_trace_enabled", Value: c.traceConfig.Enabled},
 			{Name: "execution_trace_period", Value: c.traceConfig.Period.String()},
 			{Name: "execution_trace_size_limit", Value: c.traceConfig.Limit},
+			{Name: "execution_trace_trigger_enabled", Value: c.traceConfig.userTriger != nil},
 			{Name: "endpoint_count_enabled", Value: c.endpointCountEnabled},
 		},
 	)


### PR DESCRIPTION
### What does this PR do?

Due to the high data volume produced by the execution traces, we collect
execution traces infrequently by default. This means our data collection
won't always align with activity the user is interested in. Add support
for a user-provided trace collection trigger. This mechanism can be
wired up to whatever mechanism is convenient to the user (such as a flag
that is set via a debug endpoint) to trigger targeted data collection.

To prevent accidentally incurring massive data transfer bills, we
rate-limit user-triggered collection on the client. The rate limiting
allows for burst of consecutive traces, while overall respecting the
configured trace period so we maintain the same average data rate. The
limit is 5 traces per 5 trace periods (5 is the "burst size" and is
subject to change). Limiting is enabled when we first see a
user-triggered trace which we otherwise would not have collected, i.e.
not randomly, and not the first profiling cycle. Limiting is disabled
again after 5 trace periods have passed. The motivations of
conditionally enabling the limiter are 1) to not penalize the user for
traces we would have already been willing to collect, and 2) to not
unduly skew the distribution of traces we normally collect randomly.

While here, we remove support for run-time reconfiguration of execution
trace collection. It is [not generally safe](https://www.evanjones.ca/setenv-is-not-thread-safe.html) for a user to modify
environment variables at run-time, and also probably not desirable to
allow the user to completely change the collection frequency or size
limits at runtime (will they be reliably set back to lower values?).
With the new trigger mechanism, users will have a safer and more
flexible way to target collection.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
