### PR TITLE
ci: setup smoke tests

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -42,3 +42,41 @@ jobs:
         run: go build $PACKAGES
       - name: Test dd-trace-go
         run: go test $PACKAGES
+
+  setup-requirements:
+    name: 'Compilation and deployment requirements follow Go standards'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ "1.21", "1.20", "1.19" ]
+        build-env: [ latest, bookworm, bullseye ]
+        buildmode: [ base, go-mod-vendor ]
+        build-with-cgo: [ 0, 1 ]
+        deployment-env: [ alpine, debian-bullseye, debian-bookworm ]
+        include:
+          # alpine as build env is only compatible with alpine deployment envs
+          # they indeed name their libc libmusl.so instead of libc.so
+          - build-env: alpine
+            deployment-env: alpine
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: DataDog/appsec-go-test-app
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./internal/apps/setup-smoke-test/Dockerfile
+          push: false
+          load: true
+          tags: smoke-test
+          target: ${{ matrix.distrib }}
+          build-args: |
+            build-env=${{ matrix.build-env }}
+            build-mode=${{ matrix.build-mode }}
+            build-with-cgo=${{ inputs.build-with-cgo }}
+            deployment-env=${{ inputs.deployment-env }}
+      - name: Test
+        run: |
+          docker run -p7777:7777 --rm smoke-test

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -70,6 +70,9 @@ jobs:
           - build-env: alpine
             build-with-cgo: 1
             deployment-env: busybox
+            # 2. Too old glibc on the deployment environment than on the build env
+          - build-env: bookworm
+            deployment-env: redhat
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -15,7 +15,7 @@ on:
       - '**'
   schedule: # nightly
     - cron: "0 0 * * *"
-  workflow_dispatch: {} #manually
+  workflow_dispatch: {} # manually
 
 jobs:
   go-get-u:
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: DataDog/appsec-go-test-app
+          ref: ${{ inputs.ref || github.ref }}
       - uses: docker/setup-buildx-action@v3
       - uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -25,7 +25,7 @@ jobs:
     #  Run go get -u to upgrade dd-trace-go dependencies to their
     #  latest minor version and see if dd-trace-go still compiles.
     #  Related to issue https://github.com/DataDog/dd-trace-go/issues/1607
-    name: 'dd-trace-go still works after go get -u'
+    name: 'go get -u smoke test'
     runs-on: ubuntu-latest
     env:
       PACKAGES: ./internal/... ./ddtrace/... ./profiler/... ./appsec/...
@@ -47,7 +47,13 @@ jobs:
         run: go test $PACKAGES
 
   setup-requirements-linux:
-    name: 'Compilation and deployment requirements follow Go standards'
+    # Build and deployment setup smoke test of linux containers built from the
+    # golang docker image to test that dd-trace-go doesn't need more than the
+    # "out-of-the-box" images. It is expected require a few more tools when CGO
+    # is enabled, but nothing more than gcc and the C library, but nothing more.
+    # Anything more than this "standard Go build and deployment requirements"
+    # must be considered breaking changes.
+    name: 'Build and deployment requirements smoke tests'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -95,6 +101,8 @@ jobs:
           # 2. Too old glibc on the deployment environment than on the build env
           - build-env: bookworm
             deployment-env: al2
+          - build-env: bookworm
+            deployment-debian-version: 11
           # 3. Build with CGO enabled and deploying to a scratch docker image
           #    requires copying the dynamic lib dependencies (full example
           #    provided at https://github.com/DataDog/appsec-go-test-app/blob/main/examples/docker/scratch/Dockerfile)

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Test dd-trace-go
         run: go test $PACKAGES
 
+  # TODO: macos setup requirements (xcode tools installation, etc.)
   setup-requirements-linux:
     # Build and deployment setup smoke test of linux containers built from the
     # golang docker image to test that dd-trace-go doesn't need more than the

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -46,18 +46,32 @@ jobs:
       - name: Test dd-trace-go
         run: go test $PACKAGES
 
-  setup-requirements:
+  setup-requirements-linux:
     name: 'Compilation and deployment requirements follow Go standards'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        # TODO: cross-compilation
         go: [ "1.21", "1.20", "1.19" ]
         build-env: [ alpine, bookworm, bullseye ]
-        build-with-vendoring: [ y, n ]
         build-with-cgo: [ 0, 1 ]
-        deployment-env: [ alpine, debian, redhat-ubi8, busybox, scratch ]
-        deployment-debian-version: [ 11, 12 ]
+        deployment-env: [ alpine, debian, al2, al2023, busybox, scratch ]
+        deployment-debian-version: [ 12 ]
+        include:
+          # GitHub limits the number of matrix jobs to 256, so we need to reduce
+          # it a bit, and we can reduce redundant tests.
+          # 1. Building with `go mod vendoring` is not worth it on all the
+          #    possible build and deployment envs.
+          - build-env: alpine
+            build-with-vendoring: y
+            build-with-cgo: 1 # cgo's build tag can impact the vendored files
+            deployment-env: alpine
+          - build-env: alpine
+            build-with-vendoring: y
+            build-with-cgo: 0 # cgo's build tag can impact the vendored files
+            deployment-env: alpine
+
         exclude:
           # Exclude "out of the box" cases requiring extra setup:
           # 1. Building with CGO enabled on alpine but deploying to a non-alpine
@@ -79,7 +93,6 @@ jobs:
           #    provided at https://github.com/DataDog/appsec-go-test-app/blob/main/examples/docker/scratch/Dockerfile)
           - build-with-cgo: 1
             deployment-env: scratch
-
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -16,6 +16,9 @@ on:
   schedule: # nightly
     - cron: "0 0 * * *"
   workflow_dispatch: {} # manually
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   go-get-u:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -93,7 +93,7 @@ jobs:
             deployment-env: scratch
           # 2. Too old glibc on the deployment environment than on the build env
           - build-env: bookworm
-            deployment-env: redhat-ubi8
+            deployment-env: al2
           # 3. Build with CGO enabled and deploying to a scratch docker image
           #    requires copying the dynamic lib dependencies (full example
           #    provided at https://github.com/DataDog/appsec-go-test-app/blob/main/examples/docker/scratch/Dockerfile)

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -56,7 +56,7 @@ jobs:
         build-env: [ alpine, bookworm, bullseye ]
         build-with-vendoring: [ y, n ]
         build-with-cgo: [ 0, 1 ]
-        deployment-env: [ alpine, debian, redhat, busybox, scratch ]
+        deployment-env: [ alpine, debian, redhat-ubi8, busybox, scratch ]
         deployment-debian-version: [ 11, 12 ]
         exclude:
           # Exclude "out of the box" cases requiring extra setup:
@@ -67,13 +67,13 @@ jobs:
             deployment-env: debian
           - build-env: alpine
             build-with-cgo: 1
-            deployment-env: redhat
+            deployment-env: redhat-ubi8
           - build-env: alpine
             build-with-cgo: 1
             deployment-env: busybox
           # 2. Too old glibc on the deployment environment than on the build env
           - build-env: bookworm
-            deployment-env: redhat
+            deployment-env: redhat-ubi8
           # 3. Build with CGO enabled and deploying to a scratch docker image
           #    requires copying the dynamic lib dependencies (full example
           #    provided at https://github.com/DataDog/appsec-go-test-app/blob/main/examples/docker/scratch/Dockerfile)

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -52,12 +52,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: cross-compilation
+        # TODO: cross-compilation from/to different hardware architectures once
+        #       github provides native ARM runners.
         go: [ "1.21", "1.20", "1.19" ]
         build-env: [ alpine, bookworm, bullseye ]
         build-with-cgo: [ 0, 1 ]
         deployment-env: [ alpine, debian, al2, al2023, busybox, scratch ]
-        deployment-debian-version: [ 12 ]
+        deployment-debian-version: [ 11, 12 ]
         include:
           # GitHub limits the number of matrix jobs to 256, so we need to reduce
           # it a bit, and we can reduce redundant tests.

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -81,10 +81,16 @@ jobs:
             deployment-env: debian
           - build-env: alpine
             build-with-cgo: 1
-            deployment-env: redhat-ubi8
+            deployment-env: al2
+          - build-env: alpine
+            build-with-cgo: 1
+            deployment-env: al2023
           - build-env: alpine
             build-with-cgo: 1
             deployment-env: busybox
+          - build-env: alpine
+            build-with-cgo: 1
+            deployment-env: scratch
           # 2. Too old glibc on the deployment environment than on the build env
           - build-env: bookworm
             deployment-env: redhat-ubi8

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -64,7 +64,7 @@ jobs:
         go: [ "1.21", "1.20", "1.19" ]
         build-env: [ alpine, bookworm, bullseye ]
         build-with-cgo: [ 0, 1 ]
-        deployment-env: [ alpine, debian, al2, al2023, busybox, scratch ]
+        deployment-env: [ alpine, debian11, debian12, al2, al2023, busybox, scratch ]
         include:
           # GitHub limits the number of matrix jobs to 256, so we need to reduce
           # it a bit, and we can reduce redundant tests.
@@ -78,11 +78,6 @@ jobs:
             build-with-vendoring: y
             build-with-cgo: 0 # cgo's build tag can impact the vendored files
             deployment-env: alpine
-        # 2. Test on all the stable debian versions
-          - deployment-env: debian
-            deployment-debian-version: 11
-          - deployment-env: debian
-            deployment-debian-version: 12
 
         exclude:
           # Exclude "out of the box" cases requiring extra setup:
@@ -90,7 +85,10 @@ jobs:
           #    environment: the C library isn't located at the same place.
           - build-env: alpine
             build-with-cgo: 1
-            deployment-env: debian
+            deployment-env: debian11
+          - build-env: alpine
+            build-with-cgo: 1
+            deployment-env: debian12
           - build-env: alpine
             build-with-cgo: 1
             deployment-env: al2
@@ -107,7 +105,7 @@ jobs:
           - build-env: bookworm
             deployment-env: al2
           - build-env: bookworm
-            deployment-debian-version: 11
+            deployment-env: debian11
           # 3. Build with CGO enabled and deploying to a scratch docker image
           #    requires copying the dynamic lib dependencies (full example
           #    provided at https://github.com/DataDog/appsec-go-test-app/blob/main/examples/docker/scratch/Dockerfile)
@@ -133,6 +131,5 @@ jobs:
             build_with_vendoring=${{ matrix.build-with-vendoring }}
             build_with_cgo=${{ matrix.build-with-cgo }}
             deployment_env=${{ matrix.deployment-env }}
-            deployment_debian_env_version=${{ matrix.deployment-debian-version }}
       - name: Test
         run: docker run -p7777:7777 --rm smoke-test

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -55,13 +55,13 @@ jobs:
         go: [ "1.21", "1.20", "1.19" ]
         build-env: [ bookworm, bullseye ]
         build-with-vendoring: [ y, n ]
-        build-with-cgo: [ 0 ]
+        build-with-cgo: [ 0, 1 ]
         deployment-env: [ alpine, debian, redhat, busybox ]
         include:
           # alpine as build env is only compatible with alpine deployment envs
           # they indeed name their libc libmusl.so instead of libc.so
-          - build-env: alpine
-            deployment-env: alpine
+          # - build-env: alpine
+          #  deployment-env: alpine
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -50,6 +50,7 @@ jobs:
     name: 'Compilation and deployment requirements follow Go standards'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         go: [ "1.21", "1.20", "1.19" ]
         build-env: [ bookworm, bullseye ]

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         go: [ "1.21", "1.20", "1.19" ]
-        build-env: [ latest, bookworm, bullseye ]
+        build-env: [ bookworm, bullseye ]
         build-with-vendoring: [ y, n ]
         build-with-cgo: [ 0 ]
         deployment-env: [ alpine, debian, redhat, busybox ]
@@ -75,11 +75,11 @@ jobs:
           push: false
           load: true
           tags: smoke-test
-          target: ${{ matrix.deployment-env }}
           build-args: |
             go=${{ matrix.go }}
             build_env=${{ matrix.build-env }}
             build_with_vendoring=${{ matrix.build-with-vendoring }}
             build_with_cgo=${{ matrix.build-with-cgo }}
+            deployment_env=${{ matrix.deployment-env }}
       - name: Test
         run: docker run -p7777:7777 --rm smoke-test

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -57,7 +57,7 @@ jobs:
         build-with-vendoring: [ y, n ]
         build-with-cgo: [ 0, 1 ]
         deployment-env: [ alpine, debian, redhat, busybox ]
-        include:
+        #include:
           # alpine as build env is only compatible with alpine deployment envs
           # they indeed name their libc libmusl.so instead of libc.so
           # - build-env: alpine

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -65,7 +65,6 @@ jobs:
         build-env: [ alpine, bookworm, bullseye ]
         build-with-cgo: [ 0, 1 ]
         deployment-env: [ alpine, debian, al2, al2023, busybox, scratch ]
-        deployment-debian-version: [ 11, 12 ]
         include:
           # GitHub limits the number of matrix jobs to 256, so we need to reduce
           # it a bit, and we can reduce redundant tests.
@@ -79,6 +78,11 @@ jobs:
             build-with-vendoring: y
             build-with-cgo: 0 # cgo's build tag can impact the vendored files
             deployment-env: alpine
+        # 2. Test on all the stable debian versions
+          - deployment-env: debian
+            deployment-debian-version: 11
+          - deployment-env: debian
+            deployment-debian-version: 12
 
         exclude:
           # Exclude "out of the box" cases requiring extra setup:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -53,15 +53,29 @@ jobs:
       fail-fast: false
       matrix:
         go: [ "1.21", "1.20", "1.19" ]
-        build-env: [ bookworm, bullseye ]
+        build-env: [ alpine, bookworm, bullseye ]
         build-with-vendoring: [ y, n ]
         build-with-cgo: [ 0, 1 ]
         deployment-env: [ alpine, debian, redhat, busybox ]
-        #include:
-          # alpine as build env is only compatible with alpine deployment envs
-          # they indeed name their libc libmusl.so instead of libc.so
-          # - build-env: alpine
-          #  deployment-env: alpine
+        include:
+          # Building with CGO enabled and deploying to alpine requires
+          # installing libc6-compat
+          - build-with-cgo: 1
+            deployment-env: alpine
+            deployment-alpine-with-libc6-compat: y
+        exclude:
+          # Exclude incompatible cases:
+          # 1. Building wih CGO enabled on alpine but deploying to a non-alpine
+          #    environment: the C library isn't located at the same place.
+          - build-env: alpine
+            build-with-cgo: 1
+            deployment-env: debian
+          - build-env: alpine
+            build-with-cgo: 1
+            deployment-env: redhat
+          - build-env: alpine
+            build-with-cgo: 1
+            deployment-env: busybox
 
     steps:
       - uses: actions/checkout@v4
@@ -82,5 +96,6 @@ jobs:
             build_with_vendoring=${{ matrix.build-with-vendoring }}
             build_with_cgo=${{ matrix.build-with-cgo }}
             deployment_env=${{ matrix.deployment-env }}
+            deployment_alpine_with_libc6compat=${{ matrix.deployment-alpine-with-libc6-compat }}
       - name: Test
         run: docker run -p7777:7777 --rm smoke-test

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -57,15 +57,9 @@ jobs:
         build-with-vendoring: [ y, n ]
         build-with-cgo: [ 0, 1 ]
         deployment-env: [ alpine, debian, redhat, busybox ]
-        include:
-          # Building with CGO enabled and deploying to alpine requires
-          # installing libc6-compat
-          - build-with-cgo: 1
-            deployment-env: alpine
-            deployment-alpine-with-libc6-compat: y
         exclude:
           # Exclude incompatible cases:
-          # 1. Building wih CGO enabled on alpine but deploying to a non-alpine
+          # 1. Building with CGO enabled on alpine but deploying to a non-alpine
           #    environment: the C library isn't located at the same place.
           - build-env: alpine
             build-with-cgo: 1
@@ -96,6 +90,5 @@ jobs:
             build_with_vendoring=${{ matrix.build-with-vendoring }}
             build_with_cgo=${{ matrix.build-with-cgo }}
             deployment_env=${{ matrix.deployment-env }}
-            deployment_alpine_with_libc6compat=${{ matrix.deployment-alpine-with-libc6-compat }}
       - name: Test
         run: docker run -p7777:7777 --rm smoke-test

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -53,9 +53,9 @@ jobs:
       matrix:
         go: [ "1.21", "1.20", "1.19" ]
         build-env: [ latest, bookworm, bullseye ]
-        buildmode: [ base, go-mod-vendor ]
-        build-with-cgo: [ 0, 1 ]
-        deployment-env: [ alpine, debian-bullseye, debian-bookworm ]
+        build-with-vendoring: [ y, n ]
+        build-with-cgo: [ 0 ]
+        deployment-env: [ alpine, debian, redhat, busybox ]
         include:
           # alpine as build env is only compatible with alpine deployment envs
           # they indeed name their libc libmusl.so instead of libc.so
@@ -67,19 +67,19 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
       - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v5
+      - name: Build
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./internal/apps/setup-smoke-test/Dockerfile
           push: false
           load: true
           tags: smoke-test
-          target: ${{ matrix.distrib }}
+          target: ${{ matrix.deployment-env }}
           build-args: |
-            build-env=${{ matrix.build-env }}
-            build-mode=${{ matrix.build-mode }}
-            build-with-cgo=${{ inputs.build-with-cgo }}
-            deployment-env=${{ inputs.deployment-env }}
+            go=${{ matrix.go }}
+            build_env=${{ matrix.build-env }}
+            build_with_vendoring=${{ matrix.build-with-vendoring }}
+            build_with_cgo=${{ matrix.build-with-cgo }}
       - name: Test
-        run: |
-          docker run -p7777:7777 --rm smoke-test
+        run: docker run -p7777:7777 --rm smoke-test

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -30,7 +30,7 @@ jobs:
     env:
       PACKAGES: ./internal/... ./ddtrace/... ./profiler/... ./appsec/...
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
       - uses: actions/setup-go@v3
@@ -56,9 +56,10 @@ jobs:
         build-env: [ alpine, bookworm, bullseye ]
         build-with-vendoring: [ y, n ]
         build-with-cgo: [ 0, 1 ]
-        deployment-env: [ alpine, debian, redhat, busybox ]
+        deployment-env: [ alpine, debian, redhat, busybox, scratch ]
+        deployment-debian-version: [ 11, 12 ]
         exclude:
-          # Exclude incompatible cases:
+          # Exclude "out of the box" cases requiring extra setup:
           # 1. Building with CGO enabled on alpine but deploying to a non-alpine
           #    environment: the C library isn't located at the same place.
           - build-env: alpine
@@ -70,9 +71,15 @@ jobs:
           - build-env: alpine
             build-with-cgo: 1
             deployment-env: busybox
-            # 2. Too old glibc on the deployment environment than on the build env
+          # 2. Too old glibc on the deployment environment than on the build env
           - build-env: bookworm
             deployment-env: redhat
+          # 3. Build with CGO enabled and deploying to a scratch docker image
+          #    requires copying the dynamic lib dependencies (full example
+          #    provided at https://github.com/DataDog/appsec-go-test-app/blob/main/examples/docker/scratch/Dockerfile)
+          - build-with-cgo: 1
+            deployment-env: scratch
+
 
     steps:
       - uses: actions/checkout@v4
@@ -93,5 +100,6 @@ jobs:
             build_with_vendoring=${{ matrix.build-with-vendoring }}
             build_with_cgo=${{ matrix.build-with-cgo }}
             deployment_env=${{ matrix.deployment-env }}
+            deployment_debian_env_version=${{ matrix.deployment-debian-version }}
       - name: Test
         run: docker run -p7777:7777 --rm smoke-test

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -1,0 +1,35 @@
+# FROM golang:{go}-{buildenv}
+ARG go="1.21"
+ARG buildenv="alpine"
+
+ARG buildmode="base" # base or go-mod-vendor
+ARG debianversion="12" # FROM debian:{debianversion}-slim
+
+FROM golang:$go-$buildenv AS base-build-env
+
+WORKDIR /src
+COPY . .
+WORKDIR /src/internal/apps/setup-smoke-test
+
+ARG build-with-cgo="0"
+ENV CGO_ENABLED=$build-with-cgo
+
+# Aternative base-build-env with vendoring (selected with ARG build-mode)
+FROM base-build-env AS go-mod-vendor-build-env
+RUN go mod vendor
+
+# $build-mode defaults to base and allows to be changed into go-mod-vendor to
+# test this alternative
+FROM $buildmode-build-env AS build-env
+RUN go build -v -o smoke-test .
+RUN pwd && ls -l
+
+# debian deployment environment
+FROM debian:$debianversion-slim AS debian
+COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
+CMD /usr/local/bin/smoke-test
+
+# alpine target
+FROM alpine AS alpine
+COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
+CMD /usr/local/bin/smoke-test

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -1,8 +1,29 @@
+# This Dockerfile is used to showcase the onboarding experience of our users
+# who leverage docker for their build and deployments.
+# It covers both the build requirements and deployment requirements, and it is
+# parametrized to allow to covering all the possible combinations we are aware
+# of that our users do, with:
+# - build environment, made of the following docker build args:
+#    - go: the Go version to use, , following their docker image tagging
+#      convention `golang:{go}-{buildenv}`.
+#    - build_env: the golang build image "environment" to use, following their
+#      docker image tagging convention `golang:{go}-{buildenv}`.
+#    - build_with_cgo: whether to enable CGO or not (0 or 1).
+#    - build_with_vendoring: whether to vendor the Go dependencies with
+#      `go mod vendor` or not (y or empty).
+# - deployment environment, made of the following docker build args:
+#    - deployment_debian_env_version: the debian version to use, following their
+#      docker image tagging convention `debian:{debianversion}-slim`.
+#    - deployment_env: the deployment environment to use. Since multiple targets
+#      are possible in this multi-stage dockerfile, this parameter allows to
+#      select one by default, but also allows to provide a --build-arg option
+#      too instead of relying on the --target option. This way, the CI matrix
+#      can systematically use --build-arg for all of the parameters.
 ARG go="1.21" # golang docker image parameter in `golang:{go}-{buildenv}`
 ARG build_env="bookworm" # golang docker image parameter in `golang:{go}-{buildenv}`
 ARG build_with_cgo="0" # 0 or 1
 ARG build_with_vendoring="" # y or empty
-ARG debian_version="12" # debian docker image versio in `debian:{debianversion}-slim`
+ARG deployment_debian_env_version="12" # debian docker image version in `debian:{debianversion}-slim`
 ARG deployment_env="debian"
 
 FROM golang:$go-$build_env AS build-env
@@ -31,7 +52,7 @@ RUN go env && go build -v -tags datadog.no_waf -o smoke-test .
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.
-FROM debian:$debian_version-slim AS debian
+FROM debian:$deployment_debian_env_version-slim AS debian
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 
@@ -70,7 +91,7 @@ CMD /usr/local/bin/smoke-test
 # out of the box in it without any further installation.
 FROM scratch AS scratch
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /
-CMD /smoke-test
+ENTRYPOINT [ "/smoke-test" ]
 
 # Final deployment environment - helper target to end up a single one
 FROM $deployment_env AS deployment-env

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -15,7 +15,7 @@ ARG build_with_vendoring="" # y or empty
 RUN set -ex; if [ "$build_with_vendoring" = "y" ]; then \
       go mod vendor; \
     fi
-RUN go env && go build -v -o smoke-test .
+RUN go env && go build -v -tags datadog.no_waf -o smoke-test .
 
 # debian deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -30,6 +30,10 @@ CMD /usr/local/bin/smoke-test
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.
 FROM alpine AS alpine
+ARG deployment_alpine_with_libc6compat="" # y or empty
+RUN set -ex; if [ "$deployment_alpine_with_libc6compat" = "y" ]; then \
+      apk update && apk add libc6-compat; \
+    fi
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -21,7 +21,7 @@ ARG go="1.21" # golang docker image parameter in `golang:{go}-{buildenv}`
 ARG build_env="bookworm" # golang docker image parameter in `golang:{go}-{buildenv}`
 ARG build_with_cgo="0" # 0 or 1
 ARG build_with_vendoring="" # y or empty
-ARG deployment_env="debian"
+ARG deployment_env="debian12"
 
 # Build stage compiling the test app in the golang image, along with sub-options
 # to possibly enable CGO and vendoring.

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -59,7 +59,7 @@ CMD /usr/local/bin/smoke-test
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.
-FROM debian:12 AS debian11
+FROM debian:12 AS debian12
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -26,6 +26,8 @@ ARG build_with_vendoring="" # y or empty
 ARG deployment_debian_env_version="12" # debian docker image version in `debian:{debianversion}-slim`
 ARG deployment_env="debian"
 
+# Build stage compiling the test app in the golang image, along with sub-options
+# to possibly enable CGO and vendoring.
 FROM golang:$go-$build_env AS build-env
 
 WORKDIR /src
@@ -35,9 +37,9 @@ WORKDIR /src/internal/apps/setup-smoke-test
 ARG build_with_cgo
 RUN go env -w CGO_ENABLED=$build_with_cgo
 
-ARG build_env
 # GCC and the C library headers are needed for compilation of runtime/cgo with
 # CGO_ENABLED=1 - but the golang:alpine image doesn't provide them out of the box.
+ARG build_env
 RUN set -ex; if [ "$build_env" = "alpine" ] && [ "$build_with_cgo" = "1" ]; then \
       apk update && apk add gcc libc-dev; \
     fi
@@ -56,7 +58,7 @@ FROM debian:$deployment_debian_env_version-slim AS debian
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 
-# alpine target
+# alpine deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.
@@ -68,15 +70,15 @@ RUN set -ex; if [ "$build_with_cgo" = "1" ]; then \
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 
-# redhat target
+# redhat deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.
-FROM redhat/ubi8 AS redhat
+FROM redhat/ubi8 AS redhat-ubi8
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 
-# busybox target
+# busybox deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.
@@ -85,7 +87,7 @@ RUN mkdir -p /usr/local/bin
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 
-# scratch target - meant to be used with CGO_ENABLED=0
+# scratch deployment environment - meant to be used with CGO_ENABLED=0
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -1,34 +1,26 @@
-# FROM golang:{go}-{buildenv}
-ARG go="1.21"
-ARG buildenv="alpine"
+ARG go="1.21" # golang docker image parameter in `golang:{go}-{buildenv}`
+ARG build_env="bookworm" # golang docker image parameter in `golang:{go}-{buildenv}`
+ARG debian_version="12" # debian docker image versio in `debian:{debianversion}-slim`
 
-ARG buildmode="base" # base or go-mod-vendor
-ARG debianversion="12" # FROM debian:{debianversion}-slim
-
-FROM golang:$go-$buildenv AS base-build-env
+FROM golang:$go-$build_env AS build-env
 
 WORKDIR /src
 COPY . .
 WORKDIR /src/internal/apps/setup-smoke-test
 
-ARG build-with-cgo="0"
-ENV CGO_ENABLED=$build-with-cgo
-
-# Aternative base-build-env with vendoring (selected with ARG build-mode)
-FROM base-build-env AS go-mod-vendor-build-env
-RUN go mod vendor
-
-# $build-mode defaults to base and allows to be changed into go-mod-vendor to
-# test this alternative
-FROM $buildmode-build-env AS build-env
-RUN go build -v -o smoke-test .
-RUN pwd && ls -l
+ARG build_with_cgo="0" # base or go-mod-vendor
+RUN go env -w CGO_ENABLED=$build_with_cgo
+ARG build_with_vendoring="" # y or empty
+RUN set -ex; if [ "$build_with_vendoring" = "y" ]; then \
+      go mod vendor; \
+    fi
+RUN go env && go build -v -o smoke-test .
 
 # debian deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.
-FROM debian:$debianversion-slim AS debian
+FROM debian:$debian_version-slim AS debian
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 
@@ -39,3 +31,28 @@ CMD /usr/local/bin/smoke-test
 FROM alpine AS alpine
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
+
+# redhat target
+# IMPORTANT NOTE: Nothing else than the compiled program must be copied into
+# this image to preperly highlight the fact that the compiled program is running
+# out of the box in it without any further installation.
+FROM redhat/ubi8 AS redhat
+COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
+CMD /usr/local/bin/smoke-test
+
+# busybox target
+# IMPORTANT NOTE: Nothing else than the compiled program must be copied into
+# this image to preperly highlight the fact that the compiled program is running
+# out of the box in it without any further installation.
+FROM busybox AS busybox
+RUN mkdir -p /usr/local/bin
+COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
+CMD /usr/local/bin/smoke-test
+
+# scratch target - meant to be used with CGO_ENABLED=0
+# IMPORTANT NOTE: Nothing else than the compiled program must be copied into
+# this image to preperly highlight the fact that the compiled program is running
+# out of the box in it without any further installation.
+FROM scratch AS scratch
+COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /
+CMD /smoke-test

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -16,7 +16,7 @@ RUN go env -w CGO_ENABLED=$build_with_cgo
 
 ARG build_env
 RUN set -ex; if [ "$build_env" = "alpine" ] && [ "$build_with_cgo" = "1" ]; then \
-      apk update && apk add gcc; \
+      apk update && apk add gcc libc-dev; \ # needed for cgo and the compilation of runtime/cgo
     fi
 
 ARG build_with_vendoring

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -70,11 +70,19 @@ RUN set -ex; if [ "$build_with_cgo" = "1" ]; then \
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 
-# redhat deployment environment
+# amazonlinux:2 deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.
-FROM redhat/ubi8 AS redhat-ubi8
+FROM amazonlinux:2 AS al2
+COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
+CMD /usr/local/bin/smoke-test
+
+# amazonlinux:2023 deployment environment
+# IMPORTANT NOTE: Nothing else than the compiled program must be copied into
+# this image to preperly highlight the fact that the compiled program is running
+# out of the box in it without any further installation.
+FROM amazonlinux:2023 AS al2023
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -15,8 +15,10 @@ ARG build_with_cgo
 RUN go env -w CGO_ENABLED=$build_with_cgo
 
 ARG build_env
+# GCC and the C library headers are needed for compilation of runtime/cgo with
+# CGO_ENABLED=1 - but the golang:alpine image doesn't provide them out of the box.
 RUN set -ex; if [ "$build_env" = "alpine" ] && [ "$build_with_cgo" = "1" ]; then \
-      apk update && apk add gcc libc-dev; \ # needed for cgo and the compilation of runtime/cgo
+      apk update && apk add gcc libc-dev; \
     fi
 
 ARG build_with_vendoring

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -25,11 +25,17 @@ RUN go build -v -o smoke-test .
 RUN pwd && ls -l
 
 # debian deployment environment
+# IMPORTANT NOTE: Nothing else than the compiled program must be copied into
+# this image to preperly highlight the fact that the compiled program is running
+# out of the box in it without any further installation.
 FROM debian:$debianversion-slim AS debian
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 
 # alpine target
+# IMPORTANT NOTE: Nothing else than the compiled program must be copied into
+# this image to preperly highlight the fact that the compiled program is running
+# out of the box in it without any further installation.
 FROM alpine AS alpine
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -12,8 +12,6 @@
 #    - build_with_vendoring: whether to vendor the Go dependencies with
 #      `go mod vendor` or not (y or empty).
 # - deployment environment, made of the following docker build args:
-#    - deployment_debian_env_version: the debian version to use, following their
-#      docker image tagging convention `debian:{debianversion}-slim`.
 #    - deployment_env: the deployment environment to use. Since multiple targets
 #      are possible in this multi-stage dockerfile, this parameter allows to
 #      select one by default, but also allows to provide a --build-arg option
@@ -23,7 +21,6 @@ ARG go="1.21" # golang docker image parameter in `golang:{go}-{buildenv}`
 ARG build_env="bookworm" # golang docker image parameter in `golang:{go}-{buildenv}`
 ARG build_with_cgo="0" # 0 or 1
 ARG build_with_vendoring="" # y or empty
-ARG deployment_debian_env_version="12" # debian docker image version in `debian:{debianversion}-slim`
 ARG deployment_env="debian"
 
 # Build stage compiling the test app in the golang image, along with sub-options
@@ -50,11 +47,19 @@ RUN set -ex; if [ "$build_with_vendoring" = "y" ]; then \
     fi
 RUN go env && go build -v -tags datadog.no_waf -o smoke-test .
 
-# debian deployment environment
+# debian11 deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.
-FROM debian:$deployment_debian_env_version-slim AS debian
+FROM debian:11 AS debian11
+COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
+CMD /usr/local/bin/smoke-test
+
+# debian12 deployment environment
+# IMPORTANT NOTE: Nothing else than the compiled program must be copied into
+# this image to preperly highlight the fact that the compiled program is running
+# out of the box in it without any further installation.
+FROM debian:12 AS debian11
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -1,5 +1,7 @@
 ARG go="1.21" # golang docker image parameter in `golang:{go}-{buildenv}`
 ARG build_env="bookworm" # golang docker image parameter in `golang:{go}-{buildenv}`
+ARG build_with_cgo="0" # 0 or 1
+ARG build_with_vendoring="" # y or empty
 ARG debian_version="12" # debian docker image versio in `debian:{debianversion}-slim`
 ARG deployment_env="debian"
 
@@ -9,9 +11,15 @@ WORKDIR /src
 COPY . .
 WORKDIR /src/internal/apps/setup-smoke-test
 
-ARG build_with_cgo="0"
+ARG build_with_cgo
 RUN go env -w CGO_ENABLED=$build_with_cgo
-ARG build_with_vendoring="" # y or empty
+
+ARG build_env
+RUN set -ex; if [ "$build_env" = "alpine" ] && [ "$build_with_cgo" = "1" ]; then \
+      apk update && apk add gcc; \
+    fi
+
+ARG build_with_vendoring
 RUN set -ex; if [ "$build_with_vendoring" = "y" ]; then \
       go mod vendor; \
     fi
@@ -30,8 +38,8 @@ CMD /usr/local/bin/smoke-test
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.
 FROM alpine AS alpine
-ARG deployment_alpine_with_libc6compat="" # y or empty
-RUN set -ex; if [ "$deployment_alpine_with_libc6compat" = "y" ]; then \
+ARG build_with_cgo
+RUN set -ex; if [ "$build_with_cgo" = "1" ]; then \
       apk update && apk add libc6-compat; \
     fi
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -1,6 +1,7 @@
 ARG go="1.21" # golang docker image parameter in `golang:{go}-{buildenv}`
 ARG build_env="bookworm" # golang docker image parameter in `golang:{go}-{buildenv}`
 ARG debian_version="12" # debian docker image versio in `debian:{debianversion}-slim`
+ARG deployment_env="debian"
 
 FROM golang:$go-$build_env AS build-env
 
@@ -8,7 +9,7 @@ WORKDIR /src
 COPY . .
 WORKDIR /src/internal/apps/setup-smoke-test
 
-ARG build_with_cgo="0" # base or go-mod-vendor
+ARG build_with_cgo="0"
 RUN go env -w CGO_ENABLED=$build_with_cgo
 ARG build_with_vendoring="" # y or empty
 RUN set -ex; if [ "$build_with_vendoring" = "y" ]; then \
@@ -56,3 +57,6 @@ CMD /usr/local/bin/smoke-test
 FROM scratch AS scratch
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /
 CMD /smoke-test
+
+# Final deployment environment - helper target to end up a single one
+FROM $deployment_env AS deployment-env

--- a/internal/apps/setup-smoke-test/main.go
+++ b/internal/apps/setup-smoke-test/main.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023 Datadog, Inc.
+
 package main
 
 import (

--- a/internal/apps/setup-smoke-test/main.go
+++ b/internal/apps/setup-smoke-test/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+
+	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/profiler"
+)
+
+func main() {
+	os.Setenv("DD_APPSEC_ENABLED", "true")
+	tracer.Start(tracer.WithDebugMode(true))
+	defer tracer.Stop()
+	profiler.Start()
+	defer profiler.Stop()
+
+	mux := httptrace.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := io.WriteString(w, "ok"); err != nil {
+			panic(err)
+		}
+	})
+
+	l, err := net.Listen("tcp", ":8080")
+	if err != nil {
+		panic(err)
+	}
+	go http.Serve(l, mux)
+
+	res, err := http.Get("http://localhost:8080")
+	if err != nil {
+		panic(err)
+	}
+	defer res.Body.Close()
+	if sc := res.StatusCode; sc != http.StatusOK {
+		panic(fmt.Errorf("unexpected status code: %d", sc))
+	}
+	buf, err := io.ReadAll(res.Body)
+	if err != nil {
+		panic(err)
+	}
+	if str := string(buf); str != "ok" {
+		panic(fmt.Errorf("unexpected response body: %s", str))
+	}
+
+	fmt.Println("smoke test passed")
+	os.Exit(0)
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This makes sure that the "standard and most common" way of compiling and deploying Go apps is working when using dd-trace-go.

Add a new test app called `setup-smoke-test` which sets up dd-trace-go and all its products on a basic net/http server.
The Dockerfile is a parameterized multi-stage Dockerfile with docker args and multiple targets allowing us to cover the main setup of our users we do not want to ever break:
- `golang` docker image being used, with a matrix of:
    - go version
    - distribution: alpine or debian.
    - with or without `go mod vendor`
    - with or without CGO
    - alpine with gcc and the C librray headers
- deployment docker image with a matrix of:
   - bare alpine (musl-based distrib)
   - bare docker (glibc-based distrib)
   - alpine with libc6-compat
   - amazonlinux
   - docker's scratch image

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Avoid compilation and/or deployment breaking changes. This makes sure that the "standard and most common" way of compiling and deploying Go apps is working when using dd-trace-go.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
