### PR TITLE
appsec: reintroduce the appsec build tag when cgo is disabled

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -42,3 +42,41 @@ jobs:
         run: go build $PACKAGES
       - name: Test dd-trace-go
         run: go test $PACKAGES
+
+  setup-requirements:
+    name: 'Compilation and deployment requirements follow Go standards'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ "1.21", "1.20", "1.19" ]
+        build-env: [ latest, bookworm, bullseye ]
+        buildmode: [ base, go-mod-vendor ]
+        build-with-cgo: [ 0, 1 ]
+        deployment-env: [ alpine, debian-bullseye, debian-bookworm ]
+        include:
+          # alpine as build env is only compatible with alpine deployment envs
+          # they indeed name their libc libmusl.so instead of libc.so
+          - build-env: alpine
+            deployment-env: alpine
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: DataDog/appsec-go-test-app
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./internal/apps/setup-smoke-test/Dockerfile
+          push: false
+          load: true
+          tags: smoke-test
+          target: ${{ matrix.distrib }}
+          build-args: |
+            build-env=${{ matrix.build-env }}
+            build-mode=${{ matrix.build-mode }}
+            build-with-cgo=${{ inputs.build-with-cgo }}
+            deployment-env=${{ inputs.deployment-env }}
+      - name: Test
+        run: |
+          docker run -p7777:7777 --rm smoke-test

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -64,6 +64,8 @@ jobs:
         go: [ "1.21", "1.20", "1.19" ]
         build-env: [ alpine, bookworm, bullseye ]
         build-with-cgo: [ 0, 1 ]
+        build-tags: [ "" ]
+        build-with-vendoring: [ n ]
         deployment-env: [ alpine, debian11, debian12, al2, al2023, busybox, scratch ]
         include:
           # GitHub limits the number of matrix jobs to 256, so we need to reduce
@@ -78,6 +80,10 @@ jobs:
             build-with-vendoring: y
             build-with-cgo: 0 # cgo's build tag can impact the vendored files
             deployment-env: alpine
+          # 2. <Describe me>
+          - deployment-env: busybox
+            build-with-cgo: 1
+            build-tags: "datadog.no_waf"
 
         exclude:
           # Exclude "out of the box" cases requiring extra setup:
@@ -106,11 +112,14 @@ jobs:
             deployment-env: al2
           - build-env: bookworm
             deployment-env: debian11
-          # 3. Build with CGO enabled and deploying to a scratch docker image
-          #    requires copying the dynamic lib dependencies (full example
+          # 3. Build with CGO enabled and deploying to a scratch/busybox docker
+          #    image requires copying the dynamic lib dependencies (full example
           #    provided at https://github.com/DataDog/appsec-go-test-app/blob/main/examples/docker/scratch/Dockerfile)
           - build-with-cgo: 1
             deployment-env: scratch
+          - build-with-cgo: 1
+            build-tags: ""
+            deployment-env: busybox
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -70,6 +70,9 @@ jobs:
           - build-env: alpine
             build-with-cgo: 1
             deployment-env: busybox
+            # 2. Too old glibc on the deployment environment than on the build env
+          - build-env: bookworm
+            deployment-env: redhat
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -15,7 +15,7 @@ on:
       - '**'
   schedule: # nightly
     - cron: "0 0 * * *"
-  workflow_dispatch: {} #manually
+  workflow_dispatch: {} # manually
 
 jobs:
   go-get-u:
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: DataDog/appsec-go-test-app
+          ref: ${{ inputs.ref || github.ref }}
       - uses: docker/setup-buildx-action@v3
       - uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -25,7 +25,7 @@ jobs:
     #  Run go get -u to upgrade dd-trace-go dependencies to their
     #  latest minor version and see if dd-trace-go still compiles.
     #  Related to issue https://github.com/DataDog/dd-trace-go/issues/1607
-    name: 'dd-trace-go still works after go get -u'
+    name: 'go get -u smoke test'
     runs-on: ubuntu-latest
     env:
       PACKAGES: ./internal/... ./ddtrace/... ./profiler/... ./appsec/...
@@ -47,7 +47,13 @@ jobs:
         run: go test $PACKAGES
 
   setup-requirements-linux:
-    name: 'Compilation and deployment requirements follow Go standards'
+    # Build and deployment setup smoke test of linux containers built from the
+    # golang docker image to test that dd-trace-go doesn't need more than the
+    # "out-of-the-box" images. It is expected require a few more tools when CGO
+    # is enabled, but nothing more than gcc and the C library, but nothing more.
+    # Anything more than this "standard Go build and deployment requirements"
+    # must be considered breaking changes.
+    name: 'Build and deployment requirements smoke tests'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -95,6 +101,8 @@ jobs:
           # 2. Too old glibc on the deployment environment than on the build env
           - build-env: bookworm
             deployment-env: al2
+          - build-env: bookworm
+            deployment-debian-version: 11
           # 3. Build with CGO enabled and deploying to a scratch docker image
           #    requires copying the dynamic lib dependencies (full example
           #    provided at https://github.com/DataDog/appsec-go-test-app/blob/main/examples/docker/scratch/Dockerfile)

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -73,10 +73,12 @@ jobs:
           # 1. Building with `go mod vendoring` is not worth it on all the
           #    possible build and deployment envs.
           - build-env: alpine
+            go: 1.21
             build-with-vendoring: y
             build-with-cgo: 1 # cgo's build tag can impact the vendored files
             deployment-env: alpine
           - build-env: alpine
+            go: 1.21
             build-with-vendoring: y
             build-with-cgo: 0 # cgo's build tag can impact the vendored files
             deployment-env: alpine

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -80,7 +80,10 @@ jobs:
             build-with-vendoring: y
             build-with-cgo: 0 # cgo's build tag can impact the vendored files
             deployment-env: alpine
-          # 2. <Describe me>
+          # 2. Given the low blast radius of the busybox deployment environment
+          #    this is the only one where we accept the libdl.so.2 requirement.
+          #    For this reason, we add the datadog.no_waf build tag in this only
+          #    case to avoid the libdl.so.2 dependency.
           - deployment-env: busybox
             build-with-cgo: 1
             build-tags: "datadog.no_waf"

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -135,6 +135,7 @@ jobs:
           build-args: |
             go=${{ matrix.go }}
             build_env=${{ matrix.build-env }}
+            build_tags=${{ matrix.build-tags }}
             build_with_vendoring=${{ matrix.build-with-vendoring }}
             build_with_cgo=${{ matrix.build-with-cgo }}
             deployment_env=${{ matrix.deployment-env }}

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -64,8 +64,6 @@ jobs:
         go: [ "1.21", "1.20", "1.19" ]
         build-env: [ alpine, bookworm, bullseye ]
         build-with-cgo: [ 0, 1 ]
-        build-tags: [ "" ]
-        build-with-vendoring: [ n ]
         deployment-env: [ alpine, debian11, debian12, al2, al2023, busybox, scratch ]
         include:
           # GitHub limits the number of matrix jobs to 256, so we need to reduce
@@ -73,12 +71,10 @@ jobs:
           # 1. Building with `go mod vendoring` is not worth it on all the
           #    possible build and deployment envs.
           - build-env: alpine
-            go: 1.21
             build-with-vendoring: y
             build-with-cgo: 1 # cgo's build tag can impact the vendored files
             deployment-env: alpine
           - build-env: alpine
-            go: 1.21
             build-with-vendoring: y
             build-with-cgo: 0 # cgo's build tag can impact the vendored files
             deployment-env: alpine

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -85,6 +85,9 @@ jobs:
           - deployment-env: busybox
             build-with-cgo: 1
             build-tags: "datadog.no_waf"
+          - build-with-cgo: 0
+            build-tags: ""
+            deployment-env: busybox
 
         exclude:
           # Exclude "out of the box" cases requiring extra setup:
@@ -118,9 +121,6 @@ jobs:
           #    provided at https://github.com/DataDog/appsec-go-test-app/blob/main/examples/docker/scratch/Dockerfile)
           - build-with-cgo: 1
             deployment-env: scratch
-          - build-with-cgo: 1
-            build-tags: ""
-            deployment-env: busybox
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -46,18 +46,32 @@ jobs:
       - name: Test dd-trace-go
         run: go test $PACKAGES
 
-  setup-requirements:
+  setup-requirements-linux:
     name: 'Compilation and deployment requirements follow Go standards'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        # TODO: cross-compilation
         go: [ "1.21", "1.20", "1.19" ]
         build-env: [ alpine, bookworm, bullseye ]
-        build-with-vendoring: [ y, n ]
         build-with-cgo: [ 0, 1 ]
-        deployment-env: [ alpine, debian, redhat-ubi8, busybox, scratch ]
-        deployment-debian-version: [ 11, 12 ]
+        deployment-env: [ alpine, debian, al2, al2023, busybox, scratch ]
+        deployment-debian-version: [ 12 ]
+        include:
+          # GitHub limits the number of matrix jobs to 256, so we need to reduce
+          # it a bit, and we can reduce redundant tests.
+          # 1. Building with `go mod vendoring` is not worth it on all the
+          #    possible build and deployment envs.
+          - build-env: alpine
+            build-with-vendoring: y
+            build-with-cgo: 1 # cgo's build tag can impact the vendored files
+            deployment-env: alpine
+          - build-env: alpine
+            build-with-vendoring: y
+            build-with-cgo: 0 # cgo's build tag can impact the vendored files
+            deployment-env: alpine
+
         exclude:
           # Exclude "out of the box" cases requiring extra setup:
           # 1. Building with CGO enabled on alpine but deploying to a non-alpine
@@ -79,7 +93,6 @@ jobs:
           #    provided at https://github.com/DataDog/appsec-go-test-app/blob/main/examples/docker/scratch/Dockerfile)
           - build-with-cgo: 1
             deployment-env: scratch
-
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -16,6 +16,9 @@ on:
   schedule: # nightly
     - cron: "0 0 * * *"
   workflow_dispatch: {} # manually
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   go-get-u:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -93,7 +93,7 @@ jobs:
             deployment-env: scratch
           # 2. Too old glibc on the deployment environment than on the build env
           - build-env: bookworm
-            deployment-env: redhat-ubi8
+            deployment-env: al2
           # 3. Build with CGO enabled and deploying to a scratch docker image
           #    requires copying the dynamic lib dependencies (full example
           #    provided at https://github.com/DataDog/appsec-go-test-app/blob/main/examples/docker/scratch/Dockerfile)

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -56,7 +56,7 @@ jobs:
         build-env: [ alpine, bookworm, bullseye ]
         build-with-vendoring: [ y, n ]
         build-with-cgo: [ 0, 1 ]
-        deployment-env: [ alpine, debian, redhat, busybox, scratch ]
+        deployment-env: [ alpine, debian, redhat-ubi8, busybox, scratch ]
         deployment-debian-version: [ 11, 12 ]
         exclude:
           # Exclude "out of the box" cases requiring extra setup:
@@ -67,13 +67,13 @@ jobs:
             deployment-env: debian
           - build-env: alpine
             build-with-cgo: 1
-            deployment-env: redhat
+            deployment-env: redhat-ubi8
           - build-env: alpine
             build-with-cgo: 1
             deployment-env: busybox
           # 2. Too old glibc on the deployment environment than on the build env
           - build-env: bookworm
-            deployment-env: redhat
+            deployment-env: redhat-ubi8
           # 3. Build with CGO enabled and deploying to a scratch docker image
           #    requires copying the dynamic lib dependencies (full example
           #    provided at https://github.com/DataDog/appsec-go-test-app/blob/main/examples/docker/scratch/Dockerfile)

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -52,12 +52,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: cross-compilation
+        # TODO: cross-compilation from/to different hardware architectures once
+        #       github provides native ARM runners.
         go: [ "1.21", "1.20", "1.19" ]
         build-env: [ alpine, bookworm, bullseye ]
         build-with-cgo: [ 0, 1 ]
         deployment-env: [ alpine, debian, al2, al2023, busybox, scratch ]
-        deployment-debian-version: [ 12 ]
+        deployment-debian-version: [ 11, 12 ]
         include:
           # GitHub limits the number of matrix jobs to 256, so we need to reduce
           # it a bit, and we can reduce redundant tests.

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -81,10 +81,16 @@ jobs:
             deployment-env: debian
           - build-env: alpine
             build-with-cgo: 1
-            deployment-env: redhat-ubi8
+            deployment-env: al2
+          - build-env: alpine
+            build-with-cgo: 1
+            deployment-env: al2023
           - build-env: alpine
             build-with-cgo: 1
             deployment-env: busybox
+          - build-env: alpine
+            build-with-cgo: 1
+            deployment-env: scratch
           # 2. Too old glibc on the deployment environment than on the build env
           - build-env: bookworm
             deployment-env: redhat-ubi8

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -55,13 +55,13 @@ jobs:
         go: [ "1.21", "1.20", "1.19" ]
         build-env: [ bookworm, bullseye ]
         build-with-vendoring: [ y, n ]
-        build-with-cgo: [ 0 ]
+        build-with-cgo: [ 0, 1 ]
         deployment-env: [ alpine, debian, redhat, busybox ]
         include:
           # alpine as build env is only compatible with alpine deployment envs
           # they indeed name their libc libmusl.so instead of libc.so
-          - build-env: alpine
-            deployment-env: alpine
+          # - build-env: alpine
+          #  deployment-env: alpine
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -50,6 +50,7 @@ jobs:
     name: 'Compilation and deployment requirements follow Go standards'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         go: [ "1.21", "1.20", "1.19" ]
         build-env: [ bookworm, bullseye ]

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -63,7 +63,6 @@ jobs:
         go: [ "1.21", "1.20", "1.19" ]
         build-env: [ alpine, bookworm, bullseye ]
         build-with-cgo: [ 0, 1 ]
-        build-tags: [ "" ]
         deployment-env: [ alpine, debian, al2, al2023, busybox, scratch ]
         deployment-debian-version: [ 11, 12 ]
         include:
@@ -109,9 +108,6 @@ jobs:
           #    provided at https://github.com/DataDog/appsec-go-test-app/blob/main/examples/docker/scratch/Dockerfile)
           - build-with-cgo: 1
             deployment-env: scratch
-          # 4. Having CGO enabled and appsec build tag is repetitive
-          - build-with-cgo: 1
-            build-tags: "appsec"
 
     steps:
       - uses: actions/checkout@v4
@@ -129,7 +125,6 @@ jobs:
           build-args: |
             go=${{ matrix.go }}
             build_env=${{ matrix.build-env }}
-            build_tags=${{ matrix.build-tags }}
             build_with_vendoring=${{ matrix.build-with-vendoring }}
             build_with_cgo=${{ matrix.build-with-cgo }}
             deployment_env=${{ matrix.deployment-env }}

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         go: [ "1.21", "1.20", "1.19" ]
-        build-env: [ latest, bookworm, bullseye ]
+        build-env: [ bookworm, bullseye ]
         build-with-vendoring: [ y, n ]
         build-with-cgo: [ 0 ]
         deployment-env: [ alpine, debian, redhat, busybox ]
@@ -75,11 +75,11 @@ jobs:
           push: false
           load: true
           tags: smoke-test
-          target: ${{ matrix.deployment-env }}
           build-args: |
             go=${{ matrix.go }}
             build_env=${{ matrix.build-env }}
             build_with_vendoring=${{ matrix.build-with-vendoring }}
             build_with_cgo=${{ matrix.build-with-cgo }}
+            deployment_env=${{ matrix.deployment-env }}
       - name: Test
         run: docker run -p7777:7777 --rm smoke-test

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -57,7 +57,7 @@ jobs:
         build-with-vendoring: [ y, n ]
         build-with-cgo: [ 0, 1 ]
         deployment-env: [ alpine, debian, redhat, busybox ]
-        include:
+        #include:
           # alpine as build env is only compatible with alpine deployment envs
           # they indeed name their libc libmusl.so instead of libc.so
           # - build-env: alpine

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -63,6 +63,7 @@ jobs:
         go: [ "1.21", "1.20", "1.19" ]
         build-env: [ alpine, bookworm, bullseye ]
         build-with-cgo: [ 0, 1 ]
+        build-tags: [ "" ]
         deployment-env: [ alpine, debian, al2, al2023, busybox, scratch ]
         deployment-debian-version: [ 11, 12 ]
         include:
@@ -108,6 +109,9 @@ jobs:
           #    provided at https://github.com/DataDog/appsec-go-test-app/blob/main/examples/docker/scratch/Dockerfile)
           - build-with-cgo: 1
             deployment-env: scratch
+          # 4. Having CGO enabled and appsec build tag is repetitive
+          - build-with-cgo: 1
+            build-tags: "appsec"
 
     steps:
       - uses: actions/checkout@v4
@@ -125,6 +129,7 @@ jobs:
           build-args: |
             go=${{ matrix.go }}
             build_env=${{ matrix.build-env }}
+            build_tags=${{ matrix.build-tags }}
             build_with_vendoring=${{ matrix.build-with-vendoring }}
             build_with_cgo=${{ matrix.build-with-cgo }}
             deployment_env=${{ matrix.deployment-env }}

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -85,9 +85,6 @@ jobs:
           - deployment-env: busybox
             build-with-cgo: 1
             build-tags: "datadog.no_waf"
-          - build-with-cgo: 0
-            build-tags: ""
-            deployment-env: busybox
 
         exclude:
           # Exclude "out of the box" cases requiring extra setup:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -53,15 +53,29 @@ jobs:
       fail-fast: false
       matrix:
         go: [ "1.21", "1.20", "1.19" ]
-        build-env: [ bookworm, bullseye ]
+        build-env: [ alpine, bookworm, bullseye ]
         build-with-vendoring: [ y, n ]
         build-with-cgo: [ 0, 1 ]
         deployment-env: [ alpine, debian, redhat, busybox ]
-        #include:
-          # alpine as build env is only compatible with alpine deployment envs
-          # they indeed name their libc libmusl.so instead of libc.so
-          # - build-env: alpine
-          #  deployment-env: alpine
+        include:
+          # Building with CGO enabled and deploying to alpine requires
+          # installing libc6-compat
+          - build-with-cgo: 1
+            deployment-env: alpine
+            deployment-alpine-with-libc6-compat: y
+        exclude:
+          # Exclude incompatible cases:
+          # 1. Building wih CGO enabled on alpine but deploying to a non-alpine
+          #    environment: the C library isn't located at the same place.
+          - build-env: alpine
+            build-with-cgo: 1
+            deployment-env: debian
+          - build-env: alpine
+            build-with-cgo: 1
+            deployment-env: redhat
+          - build-env: alpine
+            build-with-cgo: 1
+            deployment-env: busybox
 
     steps:
       - uses: actions/checkout@v4
@@ -82,5 +96,6 @@ jobs:
             build_with_vendoring=${{ matrix.build-with-vendoring }}
             build_with_cgo=${{ matrix.build-with-cgo }}
             deployment_env=${{ matrix.deployment-env }}
+            deployment_alpine_with_libc6compat=${{ matrix.deployment-alpine-with-libc6-compat }}
       - name: Test
         run: docker run -p7777:7777 --rm smoke-test

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -57,15 +57,9 @@ jobs:
         build-with-vendoring: [ y, n ]
         build-with-cgo: [ 0, 1 ]
         deployment-env: [ alpine, debian, redhat, busybox ]
-        include:
-          # Building with CGO enabled and deploying to alpine requires
-          # installing libc6-compat
-          - build-with-cgo: 1
-            deployment-env: alpine
-            deployment-alpine-with-libc6-compat: y
         exclude:
           # Exclude incompatible cases:
-          # 1. Building wih CGO enabled on alpine but deploying to a non-alpine
+          # 1. Building with CGO enabled on alpine but deploying to a non-alpine
           #    environment: the C library isn't located at the same place.
           - build-env: alpine
             build-with-cgo: 1
@@ -96,6 +90,5 @@ jobs:
             build_with_vendoring=${{ matrix.build-with-vendoring }}
             build_with_cgo=${{ matrix.build-with-cgo }}
             deployment_env=${{ matrix.deployment-env }}
-            deployment_alpine_with_libc6compat=${{ matrix.deployment-alpine-with-libc6-compat }}
       - name: Test
         run: docker run -p7777:7777 --rm smoke-test

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -53,9 +53,9 @@ jobs:
       matrix:
         go: [ "1.21", "1.20", "1.19" ]
         build-env: [ latest, bookworm, bullseye ]
-        buildmode: [ base, go-mod-vendor ]
-        build-with-cgo: [ 0, 1 ]
-        deployment-env: [ alpine, debian-bullseye, debian-bookworm ]
+        build-with-vendoring: [ y, n ]
+        build-with-cgo: [ 0 ]
+        deployment-env: [ alpine, debian, redhat, busybox ]
         include:
           # alpine as build env is only compatible with alpine deployment envs
           # they indeed name their libc libmusl.so instead of libc.so
@@ -67,19 +67,19 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
       - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v5
+      - name: Build
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./internal/apps/setup-smoke-test/Dockerfile
           push: false
           load: true
           tags: smoke-test
-          target: ${{ matrix.distrib }}
+          target: ${{ matrix.deployment-env }}
           build-args: |
-            build-env=${{ matrix.build-env }}
-            build-mode=${{ matrix.build-mode }}
-            build-with-cgo=${{ inputs.build-with-cgo }}
-            deployment-env=${{ inputs.deployment-env }}
+            go=${{ matrix.go }}
+            build_env=${{ matrix.build-env }}
+            build_with_vendoring=${{ matrix.build-with-vendoring }}
+            build_with_cgo=${{ matrix.build-with-cgo }}
       - name: Test
-        run: |
-          docker run -p7777:7777 --rm smoke-test
+        run: docker run -p7777:7777 --rm smoke-test

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -30,7 +30,7 @@ jobs:
     env:
       PACKAGES: ./internal/... ./ddtrace/... ./profiler/... ./appsec/...
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
       - uses: actions/setup-go@v3
@@ -56,9 +56,10 @@ jobs:
         build-env: [ alpine, bookworm, bullseye ]
         build-with-vendoring: [ y, n ]
         build-with-cgo: [ 0, 1 ]
-        deployment-env: [ alpine, debian, redhat, busybox ]
+        deployment-env: [ alpine, debian, redhat, busybox, scratch ]
+        deployment-debian-version: [ 11, 12 ]
         exclude:
-          # Exclude incompatible cases:
+          # Exclude "out of the box" cases requiring extra setup:
           # 1. Building with CGO enabled on alpine but deploying to a non-alpine
           #    environment: the C library isn't located at the same place.
           - build-env: alpine
@@ -70,9 +71,15 @@ jobs:
           - build-env: alpine
             build-with-cgo: 1
             deployment-env: busybox
-            # 2. Too old glibc on the deployment environment than on the build env
+          # 2. Too old glibc on the deployment environment than on the build env
           - build-env: bookworm
             deployment-env: redhat
+          # 3. Build with CGO enabled and deploying to a scratch docker image
+          #    requires copying the dynamic lib dependencies (full example
+          #    provided at https://github.com/DataDog/appsec-go-test-app/blob/main/examples/docker/scratch/Dockerfile)
+          - build-with-cgo: 1
+            deployment-env: scratch
+
 
     steps:
       - uses: actions/checkout@v4
@@ -93,5 +100,6 @@ jobs:
             build_with_vendoring=${{ matrix.build-with-vendoring }}
             build_with_cgo=${{ matrix.build-with-cgo }}
             deployment_env=${{ matrix.deployment-env }}
+            deployment_debian_env_version=${{ matrix.deployment-debian-version }}
       - name: Test
         run: docker run -p7777:7777 --rm smoke-test

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.1
 	github.com/DataDog/datadog-go/v5 v5.3.0
-	github.com/DataDog/go-libddwaf/v2 v2.2.2
+	github.com/DataDog/go-libddwaf/v2 v2.2.3-0.20231218105916-75a7fde5c0d3
 	github.com/DataDog/gostackparse v0.7.0
 	github.com/DataDog/sketches-go v1.4.2
 	github.com/IBM/sarama v1.40.0

--- a/go.sum
+++ b/go.sum
@@ -633,8 +633,8 @@ github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.1/go.mod h1:Vc+snp
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go/v5 v5.3.0 h1:2q2qjFOb3RwAZNU+ez27ZVDwErJv5/VpbBPprz7Z+s8=
 github.com/DataDog/datadog-go/v5 v5.3.0/go.mod h1:XRDJk1pTc00gm+ZDiBKsjh7oOOtJfYfglVCmFb8C2+Q=
-github.com/DataDog/go-libddwaf/v2 v2.2.2 h1:WS0l3qcPju2U4Ot+vr02f525YfW9RcoQfvpoV1410ac=
-github.com/DataDog/go-libddwaf/v2 v2.2.2/go.mod h1:UH7CLwSL++Ij9U7LmdZRH+71hzD+AfH28lF7pTTpWhs=
+github.com/DataDog/go-libddwaf/v2 v2.2.3-0.20231218105916-75a7fde5c0d3 h1:i1U3u0pS5mvXRFLTHx2WB7b6JxPuAe10gFzZMsKXDT4=
+github.com/DataDog/go-libddwaf/v2 v2.2.3-0.20231218105916-75a7fde5c0d3/go.mod h1:8nX0SYJMB62+fbwYmx5J7zuCGEjiC/RxAo3+AuYJuFE=
 github.com/DataDog/go-tuf v1.0.2-0.5.2 h1:EeZr937eKAWPxJ26IykAdWA4A0jQXJgkhUjqEI/w7+I=
 github.com/DataDog/go-tuf v1.0.2-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gostackparse v0.7.0 h1:i7dLkXHvYzHV308hnkvVGDL3BR4FWl7IsXNPz/IGQh4=

--- a/internal/apps/go.mod
+++ b/internal/apps/go.mod
@@ -9,7 +9,7 @@ require (
 
 require (
 	github.com/DataDog/appsec-internal-go v1.4.0 // indirect
-	github.com/DataDog/go-libddwaf/v2 v2.2.2 // indirect
+	github.com/DataDog/go-libddwaf/v2 v2.2.3-0.20231218105916-75a7fde5c0d3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/ebitengine/purego v0.5.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/internal/apps/go.mod
+++ b/internal/apps/go.mod
@@ -9,9 +9,9 @@ require (
 
 require (
 	github.com/DataDog/appsec-internal-go v1.4.0 // indirect
-	github.com/DataDog/go-libddwaf/v2 v2.2.3-0.20231218105916-75a7fde5c0d3 // indirect
+	github.com/DataDog/go-libddwaf/v2 v2.2.3-0.20231218131635-86b3b5555ae0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/ebitengine/purego v0.5.0 // indirect
+	github.com/ebitengine/purego v0.5.1 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
@@ -46,7 +46,7 @@ require (
 	github.com/tinylib/msgp v1.1.8 // indirect
 	go4.org/intern v0.0.0-20230525184215-6c62f75575cb // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20231121144256-b99613f794b6 // indirect
-	golang.org/x/sys v0.14.0 // indirect
+	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect

--- a/internal/apps/go.sum
+++ b/internal/apps/go.sum
@@ -6,8 +6,8 @@ github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.1 h1:5nE6N3JSs2IG3
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.1/go.mod h1:Vc+snp0Bey4MrrJyiV2tVxxJb6BmLomPvN1RgAvjGaQ=
 github.com/DataDog/datadog-go/v5 v5.3.0 h1:2q2qjFOb3RwAZNU+ez27ZVDwErJv5/VpbBPprz7Z+s8=
 github.com/DataDog/datadog-go/v5 v5.3.0/go.mod h1:XRDJk1pTc00gm+ZDiBKsjh7oOOtJfYfglVCmFb8C2+Q=
-github.com/DataDog/go-libddwaf/v2 v2.2.2 h1:WS0l3qcPju2U4Ot+vr02f525YfW9RcoQfvpoV1410ac=
-github.com/DataDog/go-libddwaf/v2 v2.2.2/go.mod h1:UH7CLwSL++Ij9U7LmdZRH+71hzD+AfH28lF7pTTpWhs=
+github.com/DataDog/go-libddwaf/v2 v2.2.3-0.20231218105916-75a7fde5c0d3 h1:i1U3u0pS5mvXRFLTHx2WB7b6JxPuAe10gFzZMsKXDT4=
+github.com/DataDog/go-libddwaf/v2 v2.2.3-0.20231218105916-75a7fde5c0d3/go.mod h1:8nX0SYJMB62+fbwYmx5J7zuCGEjiC/RxAo3+AuYJuFE=
 github.com/DataDog/go-tuf v1.0.2-0.5.2 h1:EeZr937eKAWPxJ26IykAdWA4A0jQXJgkhUjqEI/w7+I=
 github.com/DataDog/go-tuf v1.0.2-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gostackparse v0.7.0 h1:i7dLkXHvYzHV308hnkvVGDL3BR4FWl7IsXNPz/IGQh4=

--- a/internal/apps/go.sum
+++ b/internal/apps/go.sum
@@ -6,8 +6,8 @@ github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.1 h1:5nE6N3JSs2IG3
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.1/go.mod h1:Vc+snp0Bey4MrrJyiV2tVxxJb6BmLomPvN1RgAvjGaQ=
 github.com/DataDog/datadog-go/v5 v5.3.0 h1:2q2qjFOb3RwAZNU+ez27ZVDwErJv5/VpbBPprz7Z+s8=
 github.com/DataDog/datadog-go/v5 v5.3.0/go.mod h1:XRDJk1pTc00gm+ZDiBKsjh7oOOtJfYfglVCmFb8C2+Q=
-github.com/DataDog/go-libddwaf/v2 v2.2.3-0.20231218105916-75a7fde5c0d3 h1:i1U3u0pS5mvXRFLTHx2WB7b6JxPuAe10gFzZMsKXDT4=
-github.com/DataDog/go-libddwaf/v2 v2.2.3-0.20231218105916-75a7fde5c0d3/go.mod h1:8nX0SYJMB62+fbwYmx5J7zuCGEjiC/RxAo3+AuYJuFE=
+github.com/DataDog/go-libddwaf/v2 v2.2.3-0.20231218131635-86b3b5555ae0 h1:ZztjSafTh2Mlx08MClenoM1fmGBZ2Kql7JtwjrxzNFg=
+github.com/DataDog/go-libddwaf/v2 v2.2.3-0.20231218131635-86b3b5555ae0/go.mod h1:8nX0SYJMB62+fbwYmx5J7zuCGEjiC/RxAo3+AuYJuFE=
 github.com/DataDog/go-tuf v1.0.2-0.5.2 h1:EeZr937eKAWPxJ26IykAdWA4A0jQXJgkhUjqEI/w7+I=
 github.com/DataDog/go-tuf v1.0.2-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gostackparse v0.7.0 h1:i7dLkXHvYzHV308hnkvVGDL3BR4FWl7IsXNPz/IGQh4=
@@ -31,8 +31,8 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvyukov/go-fuzz v0.0.0-20210103155950-6a8e9d1f2415/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
-github.com/ebitengine/purego v0.5.0 h1:JrMGKfRIAM4/QVKaesIIT7m/UVjTj5GYhRSQYwfVdpo=
-github.com/ebitengine/purego v0.5.0/go.mod h1:ah1In8AOtksoNK6yk5z1HTJeUkC1Ez4Wk2idgGslMwQ=
+github.com/ebitengine/purego v0.5.1 h1:hNunhThpOf1vzKl49v6YxIsXLhl92vbBEv1/2Ez3ZrY=
+github.com/ebitengine/purego v0.5.1/go.mod h1:ah1In8AOtksoNK6yk5z1HTJeUkC1Ez4Wk2idgGslMwQ=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
@@ -152,8 +152,8 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
-golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
+golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.3.0/go.mod h1:q750SLmJuPmVoN1blW3UFBPREJfb1KmY3vwxfr+nFDA=

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -1,0 +1,35 @@
+# FROM golang:{go}-{buildenv}
+ARG go="1.21"
+ARG buildenv="alpine"
+
+ARG buildmode="base" # base or go-mod-vendor
+ARG debianversion="12" # FROM debian:{debianversion}-slim
+
+FROM golang:$go-$buildenv AS base-build-env
+
+WORKDIR /src
+COPY . .
+WORKDIR /src/internal/apps/setup-smoke-test
+
+ARG build-with-cgo="0"
+ENV CGO_ENABLED=$build-with-cgo
+
+# Aternative base-build-env with vendoring (selected with ARG build-mode)
+FROM base-build-env AS go-mod-vendor-build-env
+RUN go mod vendor
+
+# $build-mode defaults to base and allows to be changed into go-mod-vendor to
+# test this alternative
+FROM $buildmode-build-env AS build-env
+RUN go build -v -o smoke-test .
+RUN pwd && ls -l
+
+# debian deployment environment
+FROM debian:$debianversion-slim AS debian
+COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
+CMD /usr/local/bin/smoke-test
+
+# alpine target
+FROM alpine AS alpine
+COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
+CMD /usr/local/bin/smoke-test

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -1,8 +1,29 @@
+# This Dockerfile is used to showcase the onboarding experience of our users
+# who leverage docker for their build and deployments.
+# It covers both the build requirements and deployment requirements, and it is
+# parametrized to allow to covering all the possible combinations we are aware
+# of that our users do, with:
+# - build environment, made of the following docker build args:
+#    - go: the Go version to use, , following their docker image tagging
+#      convention `golang:{go}-{buildenv}`.
+#    - build_env: the golang build image "environment" to use, following their
+#      docker image tagging convention `golang:{go}-{buildenv}`.
+#    - build_with_cgo: whether to enable CGO or not (0 or 1).
+#    - build_with_vendoring: whether to vendor the Go dependencies with
+#      `go mod vendor` or not (y or empty).
+# - deployment environment, made of the following docker build args:
+#    - deployment_debian_env_version: the debian version to use, following their
+#      docker image tagging convention `debian:{debianversion}-slim`.
+#    - deployment_env: the deployment environment to use. Since multiple targets
+#      are possible in this multi-stage dockerfile, this parameter allows to
+#      select one by default, but also allows to provide a --build-arg option
+#      too instead of relying on the --target option. This way, the CI matrix
+#      can systematically use --build-arg for all of the parameters.
 ARG go="1.21" # golang docker image parameter in `golang:{go}-{buildenv}`
 ARG build_env="bookworm" # golang docker image parameter in `golang:{go}-{buildenv}`
 ARG build_with_cgo="0" # 0 or 1
 ARG build_with_vendoring="" # y or empty
-ARG debian_version="12" # debian docker image versio in `debian:{debianversion}-slim`
+ARG deployment_debian_env_version="12" # debian docker image version in `debian:{debianversion}-slim`
 ARG deployment_env="debian"
 
 FROM golang:$go-$build_env AS build-env
@@ -31,7 +52,7 @@ RUN go env && go build -v -tags datadog.no_waf -o smoke-test .
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.
-FROM debian:$debian_version-slim AS debian
+FROM debian:$deployment_debian_env_version-slim AS debian
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 
@@ -70,7 +91,7 @@ CMD /usr/local/bin/smoke-test
 # out of the box in it without any further installation.
 FROM scratch AS scratch
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /
-CMD /smoke-test
+ENTRYPOINT [ "/smoke-test" ]
 
 # Final deployment environment - helper target to end up a single one
 FROM $deployment_env AS deployment-env

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -21,6 +21,7 @@
 #      can systematically use --build-arg for all of the parameters.
 ARG go="1.21" # golang docker image parameter in `golang:{go}-{buildenv}`
 ARG build_env="bookworm" # golang docker image parameter in `golang:{go}-{buildenv}`
+ARG build_tags=""
 ARG build_with_cgo="0" # 0 or 1
 ARG build_with_vendoring="" # y or empty
 ARG deployment_debian_env_version="12" # debian docker image version in `debian:{debianversion}-slim`
@@ -48,7 +49,7 @@ ARG build_with_vendoring
 RUN set -ex; if [ "$build_with_vendoring" = "y" ]; then \
       go mod vendor; \
     fi
-RUN go env && go build -v -tags datadog.no_waf -o smoke-test .
+RUN go env && go build -v -tags=$build_tags -o smoke-test .
 
 # debian deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -15,7 +15,7 @@ ARG build_with_vendoring="" # y or empty
 RUN set -ex; if [ "$build_with_vendoring" = "y" ]; then \
       go mod vendor; \
     fi
-RUN go env && go build -v -o smoke-test .
+RUN go env && go build -v -tags datadog.no_waf -o smoke-test .
 
 # debian deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -46,7 +46,7 @@ RUN set -ex; if [ "$build_with_vendoring" = "y" ]; then \
       go mod vendor; \
     fi
 RUN go env && go build -v -o smoke-test .
-RUN ldd smoke-test
+RUN ldd smoke-test || true
 
 # debian11 deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -30,6 +30,10 @@ CMD /usr/local/bin/smoke-test
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.
 FROM alpine AS alpine
+ARG deployment_alpine_with_libc6compat="" # y or empty
+RUN set -ex; if [ "$deployment_alpine_with_libc6compat" = "y" ]; then \
+      apk update && apk add libc6-compat; \
+    fi
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -26,6 +26,8 @@ ARG build_with_vendoring="" # y or empty
 ARG deployment_debian_env_version="12" # debian docker image version in `debian:{debianversion}-slim`
 ARG deployment_env="debian"
 
+# Build stage compiling the test app in the golang image, along with sub-options
+# to possibly enable CGO and vendoring.
 FROM golang:$go-$build_env AS build-env
 
 WORKDIR /src
@@ -35,9 +37,9 @@ WORKDIR /src/internal/apps/setup-smoke-test
 ARG build_with_cgo
 RUN go env -w CGO_ENABLED=$build_with_cgo
 
-ARG build_env
 # GCC and the C library headers are needed for compilation of runtime/cgo with
 # CGO_ENABLED=1 - but the golang:alpine image doesn't provide them out of the box.
+ARG build_env
 RUN set -ex; if [ "$build_env" = "alpine" ] && [ "$build_with_cgo" = "1" ]; then \
       apk update && apk add gcc libc-dev; \
     fi
@@ -56,7 +58,7 @@ FROM debian:$deployment_debian_env_version-slim AS debian
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 
-# alpine target
+# alpine deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.
@@ -68,15 +70,15 @@ RUN set -ex; if [ "$build_with_cgo" = "1" ]; then \
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 
-# redhat target
+# redhat deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.
-FROM redhat/ubi8 AS redhat
+FROM redhat/ubi8 AS redhat-ubi8
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 
-# busybox target
+# busybox deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.
@@ -85,7 +87,7 @@ RUN mkdir -p /usr/local/bin
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 
-# scratch target - meant to be used with CGO_ENABLED=0
+# scratch deployment environment - meant to be used with CGO_ENABLED=0
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -46,7 +46,8 @@ ARG build_with_vendoring
 RUN set -ex; if [ "$build_with_vendoring" = "y" ]; then \
       go mod vendor; \
     fi
-RUN go env && go build -v -o smoke-test .
+ARG build_tags
+RUN go env && go build -v -tags "$build_tags" -o smoke-test .
 RUN ldd smoke-test || true
 
 # debian11 deployment environment

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -1,34 +1,26 @@
-# FROM golang:{go}-{buildenv}
-ARG go="1.21"
-ARG buildenv="alpine"
+ARG go="1.21" # golang docker image parameter in `golang:{go}-{buildenv}`
+ARG build_env="bookworm" # golang docker image parameter in `golang:{go}-{buildenv}`
+ARG debian_version="12" # debian docker image versio in `debian:{debianversion}-slim`
 
-ARG buildmode="base" # base or go-mod-vendor
-ARG debianversion="12" # FROM debian:{debianversion}-slim
-
-FROM golang:$go-$buildenv AS base-build-env
+FROM golang:$go-$build_env AS build-env
 
 WORKDIR /src
 COPY . .
 WORKDIR /src/internal/apps/setup-smoke-test
 
-ARG build-with-cgo="0"
-ENV CGO_ENABLED=$build-with-cgo
-
-# Aternative base-build-env with vendoring (selected with ARG build-mode)
-FROM base-build-env AS go-mod-vendor-build-env
-RUN go mod vendor
-
-# $build-mode defaults to base and allows to be changed into go-mod-vendor to
-# test this alternative
-FROM $buildmode-build-env AS build-env
-RUN go build -v -o smoke-test .
-RUN pwd && ls -l
+ARG build_with_cgo="0" # base or go-mod-vendor
+RUN go env -w CGO_ENABLED=$build_with_cgo
+ARG build_with_vendoring="" # y or empty
+RUN set -ex; if [ "$build_with_vendoring" = "y" ]; then \
+      go mod vendor; \
+    fi
+RUN go env && go build -v -o smoke-test .
 
 # debian deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.
-FROM debian:$debianversion-slim AS debian
+FROM debian:$debian_version-slim AS debian
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 
@@ -39,3 +31,28 @@ CMD /usr/local/bin/smoke-test
 FROM alpine AS alpine
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
+
+# redhat target
+# IMPORTANT NOTE: Nothing else than the compiled program must be copied into
+# this image to preperly highlight the fact that the compiled program is running
+# out of the box in it without any further installation.
+FROM redhat/ubi8 AS redhat
+COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
+CMD /usr/local/bin/smoke-test
+
+# busybox target
+# IMPORTANT NOTE: Nothing else than the compiled program must be copied into
+# this image to preperly highlight the fact that the compiled program is running
+# out of the box in it without any further installation.
+FROM busybox AS busybox
+RUN mkdir -p /usr/local/bin
+COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
+CMD /usr/local/bin/smoke-test
+
+# scratch target - meant to be used with CGO_ENABLED=0
+# IMPORTANT NOTE: Nothing else than the compiled program must be copied into
+# this image to preperly highlight the fact that the compiled program is running
+# out of the box in it without any further installation.
+FROM scratch AS scratch
+COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /
+CMD /smoke-test

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -45,7 +45,7 @@ ARG build_with_vendoring
 RUN set -ex; if [ "$build_with_vendoring" = "y" ]; then \
       go mod vendor; \
     fi
-RUN go env && go build -v -tags datadog.no_waf -o smoke-test .
+RUN go env && go build -v -o smoke-test .
 
 # debian11 deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -16,7 +16,7 @@ RUN go env -w CGO_ENABLED=$build_with_cgo
 
 ARG build_env
 RUN set -ex; if [ "$build_env" = "alpine" ] && [ "$build_with_cgo" = "1" ]; then \
-      apk update && apk add gcc; \
+      apk update && apk add gcc libc-dev; \ # needed for cgo and the compilation of runtime/cgo
     fi
 
 ARG build_with_vendoring

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -21,6 +21,7 @@ ARG go="1.21" # golang docker image parameter in `golang:{go}-{buildenv}`
 ARG build_env="bookworm" # golang docker image parameter in `golang:{go}-{buildenv}`
 ARG build_with_cgo="0" # 0 or 1
 ARG build_with_vendoring="" # y or empty
+ARG build_tags=""
 ARG deployment_env="debian12"
 
 # Build stage compiling the test app in the golang image, along with sub-options

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -70,11 +70,19 @@ RUN set -ex; if [ "$build_with_cgo" = "1" ]; then \
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 
-# redhat deployment environment
+# amazonlinux:2 deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.
-FROM redhat/ubi8 AS redhat-ubi8
+FROM amazonlinux:2 AS al2
+COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
+CMD /usr/local/bin/smoke-test
+
+# amazonlinux:2023 deployment environment
+# IMPORTANT NOTE: Nothing else than the compiled program must be copied into
+# this image to preperly highlight the fact that the compiled program is running
+# out of the box in it without any further installation.
+FROM amazonlinux:2023 AS al2023
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -21,7 +21,6 @@
 #      can systematically use --build-arg for all of the parameters.
 ARG go="1.21" # golang docker image parameter in `golang:{go}-{buildenv}`
 ARG build_env="bookworm" # golang docker image parameter in `golang:{go}-{buildenv}`
-ARG build_tags=""
 ARG build_with_cgo="0" # 0 or 1
 ARG build_with_vendoring="" # y or empty
 ARG deployment_debian_env_version="12" # debian docker image version in `debian:{debianversion}-slim`

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -15,8 +15,10 @@ ARG build_with_cgo
 RUN go env -w CGO_ENABLED=$build_with_cgo
 
 ARG build_env
+# GCC and the C library headers are needed for compilation of runtime/cgo with
+# CGO_ENABLED=1 - but the golang:alpine image doesn't provide them out of the box.
 RUN set -ex; if [ "$build_env" = "alpine" ] && [ "$build_with_cgo" = "1" ]; then \
-      apk update && apk add gcc libc-dev; \ # needed for cgo and the compilation of runtime/cgo
+      apk update && apk add gcc libc-dev; \
     fi
 
 ARG build_with_vendoring

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -25,11 +25,17 @@ RUN go build -v -o smoke-test .
 RUN pwd && ls -l
 
 # debian deployment environment
+# IMPORTANT NOTE: Nothing else than the compiled program must be copied into
+# this image to preperly highlight the fact that the compiled program is running
+# out of the box in it without any further installation.
 FROM debian:$debianversion-slim AS debian
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test
 
 # alpine target
+# IMPORTANT NOTE: Nothing else than the compiled program must be copied into
+# this image to preperly highlight the fact that the compiled program is running
+# out of the box in it without any further installation.
 FROM alpine AS alpine
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin
 CMD /usr/local/bin/smoke-test

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -1,5 +1,7 @@
 ARG go="1.21" # golang docker image parameter in `golang:{go}-{buildenv}`
 ARG build_env="bookworm" # golang docker image parameter in `golang:{go}-{buildenv}`
+ARG build_with_cgo="0" # 0 or 1
+ARG build_with_vendoring="" # y or empty
 ARG debian_version="12" # debian docker image versio in `debian:{debianversion}-slim`
 ARG deployment_env="debian"
 
@@ -9,9 +11,15 @@ WORKDIR /src
 COPY . .
 WORKDIR /src/internal/apps/setup-smoke-test
 
-ARG build_with_cgo="0"
+ARG build_with_cgo
 RUN go env -w CGO_ENABLED=$build_with_cgo
-ARG build_with_vendoring="" # y or empty
+
+ARG build_env
+RUN set -ex; if [ "$build_env" = "alpine" ] && [ "$build_with_cgo" = "1" ]; then \
+      apk update && apk add gcc; \
+    fi
+
+ARG build_with_vendoring
 RUN set -ex; if [ "$build_with_vendoring" = "y" ]; then \
       go mod vendor; \
     fi
@@ -30,8 +38,8 @@ CMD /usr/local/bin/smoke-test
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.
 FROM alpine AS alpine
-ARG deployment_alpine_with_libc6compat="" # y or empty
-RUN set -ex; if [ "$deployment_alpine_with_libc6compat" = "y" ]; then \
+ARG build_with_cgo
+RUN set -ex; if [ "$build_with_cgo" = "1" ]; then \
       apk update && apk add libc6-compat; \
     fi
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /usr/local/bin

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -46,6 +46,7 @@ RUN set -ex; if [ "$build_with_vendoring" = "y" ]; then \
       go mod vendor; \
     fi
 RUN go env && go build -v -o smoke-test .
+RUN ldd smoke-test
 
 # debian11 deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -1,6 +1,7 @@
 ARG go="1.21" # golang docker image parameter in `golang:{go}-{buildenv}`
 ARG build_env="bookworm" # golang docker image parameter in `golang:{go}-{buildenv}`
 ARG debian_version="12" # debian docker image versio in `debian:{debianversion}-slim`
+ARG deployment_env="debian"
 
 FROM golang:$go-$build_env AS build-env
 
@@ -8,7 +9,7 @@ WORKDIR /src
 COPY . .
 WORKDIR /src/internal/apps/setup-smoke-test
 
-ARG build_with_cgo="0" # base or go-mod-vendor
+ARG build_with_cgo="0"
 RUN go env -w CGO_ENABLED=$build_with_cgo
 ARG build_with_vendoring="" # y or empty
 RUN set -ex; if [ "$build_with_vendoring" = "y" ]; then \
@@ -56,3 +57,6 @@ CMD /usr/local/bin/smoke-test
 FROM scratch AS scratch
 COPY --from=build-env /src/internal/apps/setup-smoke-test/smoke-test /
 CMD /smoke-test
+
+# Final deployment environment - helper target to end up a single one
+FROM $deployment_env AS deployment-env

--- a/internal/apps/setup-smoke-test/main.go
+++ b/internal/apps/setup-smoke-test/main.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023 Datadog, Inc.
+
 package main
 
 import (

--- a/internal/apps/setup-smoke-test/main.go
+++ b/internal/apps/setup-smoke-test/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+
+	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/profiler"
+)
+
+func main() {
+	os.Setenv("DD_APPSEC_ENABLED", "true")
+	tracer.Start(tracer.WithDebugMode(true))
+	defer tracer.Stop()
+	profiler.Start()
+	defer profiler.Stop()
+
+	mux := httptrace.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := io.WriteString(w, "ok"); err != nil {
+			panic(err)
+		}
+	})
+
+	l, err := net.Listen("tcp", ":8080")
+	if err != nil {
+		panic(err)
+	}
+	go http.Serve(l, mux)
+
+	res, err := http.Get("http://localhost:8080")
+	if err != nil {
+		panic(err)
+	}
+	defer res.Body.Close()
+	if sc := res.StatusCode; sc != http.StatusOK {
+		panic(fmt.Errorf("unexpected status code: %d", sc))
+	}
+	buf, err := io.ReadAll(res.Body)
+	if err != nil {
+		panic(err)
+	}
+	if str := string(buf); str != "ok" {
+		panic(fmt.Errorf("unexpected response body: %s", str))
+	}
+
+	fmt.Println("smoke test passed")
+	os.Exit(0)
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Reintroduce the `appsec` build tag when CGO is not enabled (`CGO_ENABLED=0`).
AppSec is indeed depending on `libdl.so.2` which is not available on commonly found golang deployment envs such as `alpine`, `scratch`, etc.

The only case impacted by this change is when deploying to `busybox` with `CGO_ENABLED=1`, where `libdl.so.2` isn't available. Such users can either:
1. Add the `datadog.no_waf` go build tag
2. Or disable CGO by recompiling with `CGO_ENABLED=0`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Avoid deployments breaking changes due to libdl's dependency from appsec when `CGO_ENABLED=1`.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
