### PR TITLE
AIT-9184: update gotraceui to v0.3.0.

### DIFF
--- a/contrib/database/sql/exec_trace_test.go
+++ b/contrib/database/sql/exec_trace_test.go
@@ -3,6 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023 Datadog, Inc.
 
+// Each gotraceui does not handle next Go versions execution tracer changes,
+// so we need to skip this test for future versions. We still have coverage for
+// older Go versions due to our support policy, and Go 1.22 shouldn't fundamentally
+// change the behavior this test is covering. Update this build constraint
+// once gotraceui supports next Go version supported in our support policy.
+//
+//go:build !go1.22
+
 package sql
 
 import (

--- a/contrib/database/sql/exec_trace_test.go
+++ b/contrib/database/sql/exec_trace_test.go
@@ -9,7 +9,7 @@
 // change the behavior this test is covering. Update this build constraint
 // once gotraceui supports next Go version supported in our support policy.
 //
-//go:build !go1.22
+//go:build !go1.21
 
 package sql_test
 

--- a/contrib/database/sql/exec_trace_test.go
+++ b/contrib/database/sql/exec_trace_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023 Datadog, Inc.
 
-// Each gotraceui does not handle next Go versions execution tracer changes,
+// Each gotraceui release does not handle next Go versions execution tracer changes,
 // so we need to skip this test for future versions. We still have coverage for
 // older Go versions due to our support policy, and Go 1.22 shouldn't fundamentally
 // change the behavior this test is covering. Update this build constraint

--- a/contrib/database/sql/exec_trace_test.go
+++ b/contrib/database/sql/exec_trace_test.go
@@ -3,14 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023 Datadog, Inc.
 
-// TODO: gotraceui does not currently handle Go 1.21 execution tracer changes,
-// so we need to skip this test for that version. We still have coverage for
-// older Go versions due to our support policy, and Go 1.21 shouldn't fundamentally
-// change the behavior this test is covering. Remove this build constraint
-// once gotraceui supports Go 1.21
-//
-//go:build !go1.21
-
 package sql
 
 import (

--- a/contrib/database/sql/exec_trace_test.go
+++ b/contrib/database/sql/exec_trace_test.go
@@ -11,7 +11,7 @@
 //
 //go:build !go1.22
 
-package sql
+package sql_test
 
 import (
 	"bytes"
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	sqltrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql"
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/httpmem"
@@ -53,12 +54,12 @@ func TestExecutionTraceAnnotations(t *testing.T) {
 	// jitter, etc., but we know that they should be at least this long.
 	const sleepDuration = 10 * time.Millisecond
 
-	Register("mock", &internal.MockDriver{
+	sqltrace.Register("mock", &internal.MockDriver{
 		Hook: func() {
 			time.Sleep(sleepDuration)
 		},
 	})
-	db, err := Open("mock", "")
+	db, err := sqltrace.Open("mock", "")
 	require.NoError(t, err, "opening mock db")
 
 	span, ctx := tracer.StartSpanFromContext(context.Background(), "parent")

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	gorm.io/driver/postgres v1.4.6
 	gorm.io/driver/sqlserver v1.4.2
 	gorm.io/gorm v1.25.3
-	honnef.co/go/gotraceui v0.2.0
+	honnef.co/go/gotraceui v0.3.0
 	k8s.io/apimachinery v0.23.17
 	k8s.io/client-go v0.23.17
 )

--- a/go.sum
+++ b/go.sum
@@ -3021,8 +3021,8 @@ gotest.tools/gotestsum v1.8.2/go.mod h1:6JHCiN6TEjA7Kaz23q1bH0e2Dc3YJjDUZ0DmctFZ
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 gotest.tools/v3 v3.3.0/go.mod h1:Mcr9QNxkg0uMvy/YElmo4SpXgJKWgQvYrT7Kw5RzJ1A=
-honnef.co/go/gotraceui v0.2.0 h1:dmNsfQ9Vl3GwbiVD7Z8d/osC6WtGGrasyrC2suc4ZIQ=
-honnef.co/go/gotraceui v0.2.0/go.mod h1:qHo4/W75cA3bX0QQoSvDjbJa4R8mAyyFjbWAj63XElc=
+honnef.co/go/gotraceui v0.3.0 h1:+AAnS8W70Zg5LPNFprv0Vp47T1+n6wrHdUi3HFiLLGM=
+honnef.co/go/gotraceui v0.3.0/go.mod h1:NSZZ7eph/Pw7oML0LB7bURivs55YCwgFPwU6fDsMR4A=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
### What does this PR do?

Upgrades `gotraceui` to [v0.3.0](https://github.com/dominikh/gotraceui/releases/tag/v0.3.0), that supports Go 1.21 traces.

### Motivation

Review and act on TODO comments as part of the cleanup for v2 release. 

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
