### PR TITLE
maitenance: new GitHub Triage Badger

### DIFF
--- a/.github/workflows/needs-triage.yml
+++ b/.github/workflows/needs-triage.yml
@@ -1,0 +1,93 @@
+name: Needs Triage
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+  schedule:
+    - cron: '0 8 * * 1-5' # Every Mon-Fri at 8am UTC
+  workflow_dispatch: # Manually trigger a run
+
+run-name: ${{ github.event_name == 'issues' && format('Label issue \#{0} as needs-triage', github.event.issue.number) || 'Report old un-triaged issues' }}
+
+jobs:
+  add-label:
+    name: Label Issue
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Create needs-triage label if needed
+        run: |-
+          gh label create                                                       \
+            'needs-triage'                                                      \
+            --repo='${{ github.repository }}'                                   \
+            --color='#0E8A16'                                                   \
+            --description='New issues that have not yet been triaged'           \
+            --force
+      - name: Add needs-triage label
+        run: |-
+          gh issue edit ${{ github.event.issue.number }}                        \
+            --repo='${{ github.repository }}'                                   \
+            --add-label='needs-triage'
+
+  find-old-issues:
+    name: Find issues in need of attention
+    # Schedule or workflow dispatch
+    if: github.event_name != 'issues'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+    outputs:
+      count: ${{ steps.find-issues.outputs.count }}
+      json: ${{ steps.find-issues.outputs.json }}
+    steps:
+      - name: Find un-triaged issues older than 3 days
+        id: find-issues
+        run: |-
+          gh issue list                                                         \
+            --repo='${{ github.repository }}'                                   \
+            --state=open                                                        \
+            --label='needs-triage'                                              \
+            --search="created:<$(date --date='today - 3 days' +'%Y-%m-%d')"     \
+            --limit=10                                                          \
+            --json='number,title,body,createdAt'                                \
+            | tee issues.json
+
+          echo "count=$(jq -r '. | length' < issues.json)" >> "${GITHUB_OUTPUT}"
+          echo "json<<EOJSON"                              >> "${GITHUB_OUTPUT}"
+          cat issues.json                                  >> "${GITHUB_OUTPUT}"
+          echo "EOJSON"                                    >> "${GITHUB_OUTPUT}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  notify-slack:
+    needs: find-old-issues
+    # Schedule or workflow dispatch
+    if: github.event_name != 'issues' && fromJson(needs.find-old-issues.outputs.count) > 0
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.find-old-issues.outputs.json) }}
+
+    name: 'Notify Slack about #${{ matrix.number }}'
+
+    steps:
+      - name: Notify about ${{ matrix.number }}
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |-
+            {
+              "issue_number": ${{ toJson(matrix.number) }},
+              "issue_title": ${{ toJson(matrix.title) }},
+              "issue_url": ${{ toJson(format('github.com/{0}/issues/{1}', github.repository, matrix.number)) }},
+              "issue_body": ${{ toJson(matrix.body) }},
+              "created_at": ${{ toJson(matrix.createdAt) }}
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.NEEDS_TRIAGE_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
### What does this PR do?

Adds a new GitHub workflow which automatically adds a `needs-triage` label to issues that are opened or re-opened, which is to be removed whenever triage is performed.

Every weekday (at 8am UTC, per the current configuration), the workflow lists up to 10 issues that have the `needs-triage` label and are more than 3 days old, and sends messages to Slack via a configrued WebHook to pester maintainers to triage them. The Slack message includes a link to the issue as well as the issue's ID, title, body, and creation timestamp.

### Motivation

Per the last guild meeting, we agreed it would be helpful to have some automation help us make sure new issues are looked at at least in a cursory manner, so we (for example) catch sensitive content (which should not be in GitHub issues) earlier rather than later.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
