### PR TITLE
internal: make container ID logic Linux-only

### DIFF
--- a/internal/container_default.go
+++ b/internal/container_default.go
@@ -1,0 +1,14 @@
+//go:build !linux
+
+package internal
+
+// ContainerID attempts to return the container ID from /proc/self/cgroup or empty on failure.
+func ContainerID() string {
+	return ""
+}
+
+// EntityID attempts to return the container ID or the cgroup v2 node inode if the container ID is not available.
+// The cid is prefixed with `cid-` and the inode with `in-`.
+func EntityID() string {
+	return ""
+}

--- a/internal/container_linux.go
+++ b/internal/container_linux.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build linux
+
 package internal
 
 import (

--- a/internal/container_test.go
+++ b/internal/container_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build linux
+
 package internal
 
 import (


### PR DESCRIPTION
### What does this PR do?

cgroups are a Linux feature and all of our container ID logic is also
Linux-only. Move all of this behind a linux build tag.

### Motivation

Fix the broken Windows build

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
