### PR TITLE
[CONTINT-3554] Fix build on linux and do not send cgroup node inode if in host cgroup namespace

### DIFF
--- a/internal/container_linux.go
+++ b/internal/container_linux.go
@@ -56,7 +56,7 @@ var (
 
 func init() {
 	containerID = readContainerID(cgroupPath)
-	entityID = readEntityID(defaultCgroupMountPath, cgroupPath)
+	entityID = readEntityID(defaultCgroupMountPath, cgroupPath, isHostCgroupNamespace())
 }
 
 // parseContainerID finds the first container ID reading from r and returns it.
@@ -147,14 +147,14 @@ func inodeForPath(path string) string {
 }
 
 // readEntityID attempts to return the cgroup node inode or empty on failure.
-func readEntityID(mountPath, cgroupPath string) string {
+func readEntityID(mountPath, cgroupPath string, isHostCgroupNamespace bool) string {
 	// First try to emit the containerID if available. It will be retrieved if the container is
 	// running in the host cgroup namespace, independently of the cgroup version.
 	if containerID != "" {
 		return "cid-" + containerID
 	}
 	// Rely on the inode if we're not running in the host cgroup namespace.
-	if isHostCgroupNamespace() {
+	if isHostCgroupNamespace {
 		return ""
 	}
 	return getCgroupInode(mountPath, cgroupPath)

--- a/internal/container_linux.go
+++ b/internal/container_linux.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build linux
+
 package internal
 
 import (
@@ -20,20 +22,20 @@ const (
 	// cgroupPath is the path to the cgroup file where we can find the container id if one exists.
 	cgroupPath = "/proc/self/cgroup"
 
-	// cgroupV2Key is the key used to store the cgroup v2 identify the cgroupv2 mount point in the cgroupMounts map.
-	cgroupV2Key = "cgroupv2"
-
 	// cgroupV1BaseController is the base controller used to identify the cgroup v1 mount point in the cgroupMounts map.
 	cgroupV1BaseController = "memory"
 
 	// defaultCgroupMountPath is the path to the cgroup mount point.
 	defaultCgroupMountPath = "/sys/fs/cgroup"
-)
 
-const (
 	uuidSource      = "[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}|[0-9a-f]{8}(?:-[0-9a-f]{4}){4}$"
 	containerSource = "[0-9a-f]{64}"
 	taskSource      = "[0-9a-f]{32}-\\d+"
+
+	// From https://github.com/torvalds/linux/blob/5859a2b1991101d6b978f3feb5325dad39421f29/include/linux/proc_ns.h#L41-L49
+	// Currently, host namespace inode number are hardcoded, which can be used to detect
+	// if we're running in host namespace or not (does not work when running in DinD)
+	hostCgroupNamespaceInode = 0xEFFFFFFB
 )
 
 var (
@@ -47,9 +49,8 @@ var (
 	containerID string
 
 	// entityID is the entityID to use for the container. It is the `cid-<containerID>` if the container id available,
-	// otherwise the cgroup v2 node inode prefixed with `in-` or an empty string on cgroup v1 or incompatible OS.
-	// It is retrieved by finding cgroup2 mounts in /proc/mounts, finding the cgroup v2 node path in /proc/self/cgroup and
-	// calling stat on mountPath+nodePath to get the inode.
+	// otherwise the cgroup node controller's inode prefixed with `in-` or an empty string on incompatible OS.
+	// We use the memory controller on cgroupv1 and the root cgroup on cgroupv2.
 	entityID string
 )
 
@@ -145,16 +146,37 @@ func inodeForPath(path string) string {
 	return fmt.Sprintf("in-%d", stats.Ino)
 }
 
-// readEntityID attempts to return the cgroup v2 node inode or empty on failure.
+// readEntityID attempts to return the cgroup node inode or empty on failure.
 func readEntityID(mountPath, cgroupPath string) string {
+	// First try to emit the containerID if available. It will be retrieved if the container is
+	// running in the host cgroup namespace, independently of the cgroup version.
 	if containerID != "" {
 		return "cid-" + containerID
+	}
+	// Rely on the inode if we're not running in the host cgroup namespace.
+	if isHostCgroupNamespace() {
+		return ""
 	}
 	return getCgroupInode(mountPath, cgroupPath)
 }
 
-// EntityID attempts to return the container ID or the cgroup v2 node inode if the container ID is not available.
-// The cid is prefixed with `cid-` and the inode with `in-`.
+// EntityID attempts to return the container ID or the cgroup node controller's inode if the container ID
+// is not available. The cid is prefixed with `cid-` and the inode with `in-`.
 func EntityID() string {
 	return entityID
+}
+
+// isHostCgroupNamespace checks if the agent is running in the host cgroup namespace.
+func isHostCgroupNamespace() bool {
+	fi, err := os.Stat("/proc/self/ns/cgroup")
+	if err != nil {
+		return false
+	}
+
+	stat, ok := fi.Sys().(*syscall.Stat_t)
+	if ok {
+		return stat.Ino == hostCgroupNamespaceInode
+	}
+
+	return false
 }

--- a/internal/container_linux_test.go
+++ b/internal/container_linux_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
-//go:build test && linux
+//go:build linux
 
 package internal
 

--- a/internal/container_linux_test.go
+++ b/internal/container_linux_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build test && linux
+
 package internal
 
 import (

--- a/internal/container_linux_test.go
+++ b/internal/container_linux_test.go
@@ -92,7 +92,7 @@ func TestReadEntityIDPrioritizeCID(t *testing.T) {
 	defer func(cid string) { containerID = cid }(containerID)
 
 	containerID = "fakeContainerID"
-	eid := readEntityID("", "")
+	eid := readEntityID("", "", true)
 	assert.Equal(t, "cid-fakeContainerID", eid)
 }
 
@@ -119,8 +119,11 @@ func TestReadEntityIDFallbackOnInode(t *testing.T) {
 	err = procSelfCgroup.Close()
 	require.NoError(t, err)
 
-	eid := readEntityID(sysFsCgroupPath, procSelfCgroup.Name())
+	eid := readEntityID(sysFsCgroupPath, procSelfCgroup.Name(), false)
 	assert.Equal(t, expectedInode, eid)
+
+	emptyEid := readEntityID(sysFsCgroupPath, procSelfCgroup.Name(), true)
+	assert.Equal(t, "", emptyEid)
 }
 
 func TestParsegroupControllerPath(t *testing.T) {

--- a/internal/container_stub.go
+++ b/internal/container_stub.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+//go:build !linux
+
+package internal
+
+// ContainerID attempts to return the container ID from /proc/self/cgroup or empty on failure.
+func ContainerID() string {
+	return ""
+}
+
+// EntityID attempts to return the container ID or the cgroup v2 node inode if the container ID is not available.
+// The cid is prefixed with `cid-` and the inode with `in-`.
+func EntityID() string {
+	return ""
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
This PR adds build flags in the logic that retrieves the container id since it only works on linux.
It also only retrieves the cgroup node inode if the sender not in the host cgroup namespace. Indeed it would mean either that:
- We're not in a container and the inode we're sending is not related to a container
- We already have access to the container-id and it will be retrieved in the previous logic
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Fix build and do not emit data if not necessary (limit perf impact)
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
