### PR TITLE
Revert "AIT-9184: update gotraceui to v0.3.0."

### DIFF
--- a/contrib/database/sql/exec_trace_test.go
+++ b/contrib/database/sql/exec_trace_test.go
@@ -3,15 +3,15 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023 Datadog, Inc.
 
-// Each gotraceui release does not handle next Go versions execution tracer changes,
-// so we need to skip this test for future versions. We still have coverage for
-// older Go versions due to our support policy, and Go 1.22 shouldn't fundamentally
-// change the behavior this test is covering. Update this build constraint
-// once gotraceui supports next Go version supported in our support policy.
+// TODO: gotraceui does not currently handle Go 1.21 execution tracer changes,
+// so we need to skip this test for that version. We still have coverage for
+// older Go versions due to our support policy, and Go 1.21 shouldn't fundamentally
+// change the behavior this test is covering. Remove this build constraint
+// once gotraceui supports Go 1.21
 //
 //go:build !go1.21
 
-package sql_test
+package sql
 
 import (
 	"bytes"
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	sqltrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql"
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/httpmem"
@@ -54,12 +53,12 @@ func TestExecutionTraceAnnotations(t *testing.T) {
 	// jitter, etc., but we know that they should be at least this long.
 	const sleepDuration = 10 * time.Millisecond
 
-	sqltrace.Register("mock", &internal.MockDriver{
+	Register("mock", &internal.MockDriver{
 		Hook: func() {
 			time.Sleep(sleepDuration)
 		},
 	})
-	db, err := sqltrace.Open("mock", "")
+	db, err := Open("mock", "")
 	require.NoError(t, err, "opening mock db")
 
 	span, ctx := tracer.StartSpanFromContext(context.Background(), "parent")

--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	gorm.io/driver/postgres v1.4.6
 	gorm.io/driver/sqlserver v1.4.2
 	gorm.io/gorm v1.25.3
-	honnef.co/go/gotraceui v0.3.0
+	honnef.co/go/gotraceui v0.2.0
 	k8s.io/apimachinery v0.23.17
 	k8s.io/client-go v0.23.17
 )

--- a/go.sum
+++ b/go.sum
@@ -3025,8 +3025,8 @@ gotest.tools/gotestsum v1.8.2/go.mod h1:6JHCiN6TEjA7Kaz23q1bH0e2Dc3YJjDUZ0DmctFZ
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 gotest.tools/v3 v3.3.0/go.mod h1:Mcr9QNxkg0uMvy/YElmo4SpXgJKWgQvYrT7Kw5RzJ1A=
-honnef.co/go/gotraceui v0.3.0 h1:+AAnS8W70Zg5LPNFprv0Vp47T1+n6wrHdUi3HFiLLGM=
-honnef.co/go/gotraceui v0.3.0/go.mod h1:NSZZ7eph/Pw7oML0LB7bURivs55YCwgFPwU6fDsMR4A=
+honnef.co/go/gotraceui v0.2.0 h1:dmNsfQ9Vl3GwbiVD7Z8d/osC6WtGGrasyrC2suc4ZIQ=
+honnef.co/go/gotraceui v0.2.0/go.mod h1:qHo4/W75cA3bX0QQoSvDjbJa4R8mAyyFjbWAj63XElc=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
Reverts DataDog/dd-trace-go#2443 It was merged accidentally.