### PR TITLE
appsec: refactor remoteconfig facility a little

### DIFF
--- a/internal/appsec/remoteconfig.go
+++ b/internal/appsec/remoteconfig.go
@@ -48,13 +48,13 @@ func mergeMaps[K comparable, V any](m1 map[K]V, m2 map[K]V) map[K]V {
 }
 
 // combineRCRulesUpdates updates the state of the given rulesManager with the combination of all the provided rules updates
-func combineRCRulesUpdates(r *rulesManager, updates map[string]remoteconfig.ProductUpdate) (map[string]rc.ApplyStatus, error) {
-	statuses := map[string]rc.ApplyStatus{}
+func (r *rulesManager) combineRCRulesUpdates(updates map[string]remoteconfig.ProductUpdate) (statuses map[string]rc.ApplyStatus, err error) {
+	statuses = make(map[string]rc.ApplyStatus, len(updates))
 	// Set the default statuses for all updates to unacknowledged
 	for _, u := range updates {
 		statuses = mergeMaps(statuses, statusesFromUpdate(u, false, nil))
 	}
-	var err error
+
 updateLoop:
 	// Process rules related updates
 	for p, u := range updates {
@@ -72,7 +72,7 @@ updateLoop:
 			// If the config was removed, switch back to the static recommended rules
 			if len(u) > 1 { // Don't process configs if more than one is received for ASM_DD
 				log.Debug("appsec: Remote config: more than one config received for ASM_DD. Updates won't be applied")
-				err = errors.New("More than one config received for ASM_DD")
+				err = errors.New("more than one config received for ASM_DD")
 				statuses = mergeMaps(statuses, statusesFromUpdate(u, true, err))
 				break updateLoop
 			}
@@ -145,7 +145,7 @@ func (a *appsec) onRCRulesUpdate(updates map[string]remoteconfig.ProductUpdate) 
 
 	// Create a new local rulesManager
 	r := a.cfg.rulesManager.clone()
-	statuses, err := combineRCRulesUpdates(r, updates)
+	statuses, err := r.combineRCRulesUpdates(updates)
 	if err != nil {
 		log.Debug("appsec: Remote config: not applying any updates because of error: %v", err)
 		return statuses
@@ -263,7 +263,11 @@ func mergeRulesData(u remoteconfig.ProductUpdate) ([]ruleDataEntry, map[string]r
 // mergeRulesDataEntries merges two slices of rules data entries together, removing duplicates and
 // only keeping the longest expiration values for similar entries.
 func mergeRulesDataEntries(entries1, entries2 []rc.ASMDataRuleDataEntry) []rc.ASMDataRuleDataEntry {
-	mergeMap := map[string]int64{}
+	cap := len(entries1)
+	if cap2 := len(entries2); cap2 > cap {
+		cap = cap2
+	}
+	mergeMap := make(map[string]int64, cap)
 
 	for _, entry := range entries1 {
 		mergeMap[entry.Value] = entry.Expiration
@@ -278,10 +282,7 @@ func mergeRulesDataEntries(entries1, entries2 []rc.ASMDataRuleDataEntry) []rc.AS
 	// Create the final slice and return it
 	entries := make([]rc.ASMDataRuleDataEntry, 0, len(mergeMap))
 	for val, exp := range mergeMap {
-		entries = append(entries, rc.ASMDataRuleDataEntry{
-			Value:      val,
-			Expiration: exp,
-		})
+		entries = append(entries, rc.ASMDataRuleDataEntry{Value: val, Expiration: exp})
 	}
 	return entries
 }
@@ -336,6 +337,16 @@ func (a *appsec) enableRemoteActivation() error {
 	return remoteconfig.RegisterCallback(a.onRemoteActivation)
 }
 
+var blockingCapabilities = [...]remoteconfig.Capability{
+	remoteconfig.ASMUserBlocking,
+	remoteconfig.ASMRequestBlocking,
+	remoteconfig.ASMIPBlocking,
+	remoteconfig.ASMDDRules,
+	remoteconfig.ASMExclusions,
+	remoteconfig.ASMCustomRules,
+	remoteconfig.ASMCustomBlockingResponse,
+}
+
 func (a *appsec) enableRCBlocking() {
 	if a.cfg.rc == nil {
 		log.Debug("appsec: Remote config: no valid remote configuration client")
@@ -354,16 +365,7 @@ func (a *appsec) enableRCBlocking() {
 	}
 
 	if _, isSet := os.LookupEnv(internal.EnvRules); !isSet {
-		caps := []remoteconfig.Capability{
-			remoteconfig.ASMUserBlocking,
-			remoteconfig.ASMRequestBlocking,
-			remoteconfig.ASMIPBlocking,
-			remoteconfig.ASMDDRules,
-			remoteconfig.ASMExclusions,
-			remoteconfig.ASMCustomRules,
-			remoteconfig.ASMCustomBlockingResponse,
-		}
-		for _, c := range caps {
+		for _, c := range blockingCapabilities {
 			if err := a.registerRCCapability(c); err != nil {
 				log.Debug("appsec: Remote config: couldn't register capability %v: %v", c, err)
 			}
@@ -375,15 +377,7 @@ func (a *appsec) disableRCBlocking() {
 	if a.cfg.rc == nil {
 		return
 	}
-	caps := []remoteconfig.Capability{
-		remoteconfig.ASMDDRules,
-		remoteconfig.ASMExclusions,
-		remoteconfig.ASMIPBlocking,
-		remoteconfig.ASMRequestBlocking,
-		remoteconfig.ASMUserBlocking,
-		remoteconfig.ASMCustomRules,
-	}
-	for _, c := range caps {
+	for _, c := range blockingCapabilities {
 		if err := a.unregisterRCCapability(c); err != nil {
 			log.Debug("appsec: Remote config: couldn't unregister capability %v: %v", c, err)
 		}

--- a/internal/appsec/remoteconfig_test.go
+++ b/internal/appsec/remoteconfig_test.go
@@ -377,13 +377,9 @@ func TestCapabilities(t *testing.T) {
 			expected: []remoteconfig.Capability{remoteconfig.ASMActivation},
 		},
 		{
-			name: "appsec-enabled/default-rulesManager",
-			env:  map[string]string{EnvEnabled: "1"},
-			expected: []remoteconfig.Capability{
-				remoteconfig.ASMRequestBlocking, remoteconfig.ASMUserBlocking, remoteconfig.ASMExclusions,
-				remoteconfig.ASMDDRules, remoteconfig.ASMIPBlocking, remoteconfig.ASMCustomRules,
-				remoteconfig.ASMCustomBlockingResponse,
-			},
+			name:     "appsec-enabled/default-rulesManager",
+			env:      map[string]string{EnvEnabled: "1"},
+			expected: blockingCapabilities[:],
 		},
 		{
 			name:     "appsec-enabled/rulesManager-from-env",
@@ -708,7 +704,8 @@ func TestWafRCUpdate(t *testing.T) {
 		require.Contains(t, jsonString(t, result.Events), "crs-913-120")
 		require.Empty(t, result.Actions)
 		// Simulate an RC update that disables the rule
-		statuses, err := combineRCRulesUpdates(cfg.rulesManager, craftRCUpdates(map[string]rulesFragment{"override": override}))
+		statuses, err := cfg.rulesManager.combineRCRulesUpdates(craftRCUpdates(map[string]rulesFragment{"override": override}))
+		require.NoError(t, err)
 		for _, status := range statuses {
 			require.Equal(t, status.State, rc.ApplyStateAcknowledged)
 		}


### PR DESCRIPTION

### What does this PR do?

- Pre-allocating certain maps & slices for more efficient processing
- Making `combineRCRulesUpdates` a method of `*rulesManager`
- Extracting a duplicated []Capabilities slice into a shared variable

### Motivation

Somewhat improves readability & performance.

### Reviewer's Checklist

- [X] Changed code has unit tests for its functionality at or near 100% coverage.
- [X] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
