### PR TITLE
Configure parametric test to get the golang tracer in same way as system-tests

### DIFF
--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -32,10 +32,27 @@ jobs:
     steps:
       - name: Checkout system tests
         uses: actions/checkout@v3
+        if: ${{ env.V2_BRANCH != 'true' }}
         with:
           repository: 'DataDog/system-tests'
+          ref: ${{ inputs.ref }}
+
+      # TODO(darccio): remove ref on v2 release
+      - name: Checkout system tests (v2)
+        uses: actions/checkout@v3
+        if: ${{ env.V2_BRANCH == 'true' }}
+        with:
+          repository: 'DataDog/system-tests'
+          ref: refs/heads/dario.castane/AIT-3705/dd-trace-go.v2
 
       - name: Checkout dd-trace-go
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch_ref || github.ref }}
+          path: 'binaries/dd-trace-go'        
+
+      #This It will be removed after merge the system-tests PR: https://github.com/DataDog/system-tests/pull/1948
+      - name: Checkout dd-trace-go (Deprecated.)
         uses: actions/checkout@v3
         with:
           path: utils/build/docker/golang/parametric/dd-trace-go
@@ -45,14 +62,16 @@ jobs:
         with:
           go-version: "1.19"
 
-      - name: Patch dd-trace-go version
+      #This It will be removed after merge the system-tests PR: https://github.com/DataDog/system-tests/pull/1948
+      - name: Patch dd-trace-go version (Deprecated)
         if: ${{ env.V2_BRANCH != 'true' }}
         run: |
           cd utils/build/docker/golang/parametric/
           echo "replace gopkg.in/DataDog/dd-trace-go.v1 => ./dd-trace-go" >> go.mod
           go mod tidy
-
-      - name: Patch dd-trace-go version (v2)
+      
+      #This It will be removed after merge the system-tests PR: https://github.com/DataDog/system-tests/pull/1948
+      - name: Patch dd-trace-go version (v2)(Deprecated)
         if: ${{ env.V2_BRANCH == 'true' }}
         run: |
           cd utils/build/docker/golang/parametric/


### PR DESCRIPTION
Currently Parametric only executes tests using latest tracer release. We add support to run snapshot version of the golang tracer (dev).

The idea behind this is to use the same approach to install dd-trace-go as is used by system-tests (maintainability reasons).

We are using the previously existing script to install the tracer: utils/build/docker/golang/install_ddtrace.sh.

This PR is a intermediate steps to avoid conflicts on the tracer pipelines during the "migration process".

I will create a new PR to clean the obsolete code after merge the system-tests PR: https://github.com/DataDog/system-tests/pull/1948

(Sorry for the msg of the first commit...copy-paste...)

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
