### PR TITLE
v2/contrib: replace WithServiceName with WithService everywhere

### DIFF
--- a/internal/contrib/namingschematest/namingschematest.go
+++ b/internal/contrib/namingschematest/namingschematest.go
@@ -21,7 +21,7 @@ import (
 
 // GenSpansFn is used across different functions from this package to generate spans. It should be implemented in the
 // tests that use this package.
-// The provided serviceOverride string should be used to set the specific integration's WithServiceName option (if
+// The provided serviceOverride string should be used to set the specific integration's WithService option (if
 // available) when initializing and configuring the package.
 type GenSpansFn func(t *testing.T, serviceOverride string) []mocktracer.Span
 
@@ -36,7 +36,7 @@ type ServiceNameAssertions struct {
 	// value to TestDDService from this package).
 	WithDDService []string
 	// WithDDServiceAndOverride is used for the test case where the global DD_SERVICE configuration is enabled and the
-	// contrib specific `WithServiceName` option is used (in this case, the test will set DD_SERVICE and serviceOverride
+	// contrib specific `WithService` option is used (in this case, the test will set DD_SERVICE and serviceOverride
 	// to the TestDDService and TestServiceOverride constants from this package, respectively).
 	WithDDServiceAndOverride []string
 }
@@ -45,7 +45,7 @@ const (
 	// TestDDService is a constant used in the test returned by NewServiceNameTest to set the value of DD_SERVICE.
 	TestDDService = "dd-service"
 	// TestServiceOverride is a constant used in the test returned by NewServiceNameTest to set the value of
-	// the integration's WithServiceName option.
+	// the integration's WithService option.
 	TestServiceOverride = "service-override"
 )
 

--- a/internal/contrib/validationtest/contrib/bradfitz_memcache.go
+++ b/internal/contrib/validationtest/contrib/bradfitz_memcache.go
@@ -48,6 +48,6 @@ func (i *Memcache) NumSpans() int {
 	return i.numSpans
 }
 
-func (i *Memcache) WithServiceName(name string) {
-	i.opts = append(i.opts, memcachetrace.WithServiceName(name))
+func (i *Memcache) WithService(name string) {
+	i.opts = append(i.opts, memcachetrace.WithService(name))
 }

--- a/internal/contrib/validationtest/contrib/miekg_dns.go
+++ b/internal/contrib/validationtest/contrib/miekg_dns.go
@@ -72,7 +72,7 @@ func (i *DNS) NumSpans() int {
 	return i.numSpans
 }
 
-func (i *DNS) WithServiceName(_ string) {
+func (i *DNS) WithService(_ string) {
 	return
 }
 

--- a/internal/contrib/validationtest/validation_test.go
+++ b/internal/contrib/validationtest/validation_test.go
@@ -40,8 +40,8 @@ type Integration interface {
 	// NumSpans returns the number of spans that should have been generated during the test.
 	NumSpans() int
 
-	// WithServiceName configures the integration to use the given service name.
-	WithServiceName(name string)
+	// WithService configures the integration to use the given service name.
+	WithService(name string)
 }
 
 // tracerEnv gets the current tracer configuration variables needed for Test Agent testing and places
@@ -158,7 +158,7 @@ func TestIntegrations(t *testing.T) {
 				if tc.integrationServiceName != "" {
 					componentName := ig.Name()
 					t.Setenv(fmt.Sprintf("DD_%s_SERVICE", strings.ToUpper(componentName)), tc.integrationServiceName)
-					ig.WithServiceName(tc.integrationServiceName)
+					ig.WithService(tc.integrationServiceName)
 				}
 
 				ig.Init(t)

--- a/internal/traceprof/traceproftest/app.go
+++ b/internal/traceprof/traceproftest/app.go
@@ -118,8 +118,8 @@ func (a *App) start(t testing.TB) {
 	case GRPC:
 		l, err := net.Listen("tcp", "127.0.0.1:0")
 		require.NoError(t, err)
-		si := grpctrace.StreamServerInterceptor(grpctrace.WithServiceName("my-grpc-client"))
-		ui := grpctrace.UnaryServerInterceptor(grpctrace.WithServiceName("my-grpc-client"))
+		si := grpctrace.StreamServerInterceptor(grpctrace.WithService("my-grpc-client"))
+		ui := grpctrace.UnaryServerInterceptor(grpctrace.WithService("my-grpc-client"))
 		a.grpcServer = grpc.NewServer(grpc.StreamInterceptor(si), grpc.UnaryInterceptor(ui))
 		pb.RegisterTestAppServer(a.grpcServer, a)
 		go a.grpcServer.Serve(l)

--- a/v2/contrib/99designs/gqlgen/option.go
+++ b/v2/contrib/99designs/gqlgen/option.go
@@ -54,8 +54,8 @@ func WithAnalyticsRate(rate float64) OptionFn {
 	}
 }
 
-// WithServiceName sets the given service name for the gqlgen server.
-func WithServiceName(name string) OptionFn {
+// WithService sets the given service name for the gqlgen server.
+func WithService(name string) OptionFn {
 	return func(t *config) {
 		t.serviceName = name
 	}

--- a/v2/contrib/99designs/gqlgen/tracer.go
+++ b/v2/contrib/99designs/gqlgen/tracer.go
@@ -31,7 +31,7 @@
 //
 //		t := gqlgentrace.NewTracer(
 //			gqlgentrace.WithAnalytics(true),
-//			gqlgentrace.WithServiceName("todo.server"),
+//			gqlgentrace.WithService("todo.server"),
 //		)
 //		h := handler.NewDefaultServer(todo.NewExecutableSchema(todo.New()))
 //		h.Use(t)

--- a/v2/contrib/99designs/gqlgen/tracer_test.go
+++ b/v2/contrib/99designs/gqlgen/tracer_test.go
@@ -41,8 +41,8 @@ func TestOptions(t *testing.T) {
 				assert.Nil(root.Tag(ext.EventSampleRate))
 			},
 		},
-		"WithServiceName": {
-			tracerOpts: []Option{WithServiceName("TestServer")},
+		"WithService": {
+			tracerOpts: []Option{WithService("TestServer")},
 			test: func(assert *assert.Assertions, root mocktracer.Span) {
 				assert.Equal("TestServer", root.Tag(ext.ServiceName))
 			},
@@ -153,7 +153,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/IBM/sarama.v1/option.go
+++ b/v2/contrib/IBM/sarama.v1/option.go
@@ -52,8 +52,8 @@ func (fn OptionFn) apply(cfg *config) {
 	fn(cfg)
 }
 
-// WithServiceName sets the given service name for the intercepted client.
-func WithServiceName(name string) OptionFn {
+// WithService sets the given service name for the intercepted client.
+func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.consumerServiceName = name
 		cfg.producerServiceName = name

--- a/v2/contrib/IBM/sarama.v1/sarama_test.go
+++ b/v2/contrib/IBM/sarama.v1/sarama_test.go
@@ -23,7 +23,7 @@ import (
 func genTestSpans(t *testing.T, serviceOverride string) []mocktracer.Span {
 	var opts []Option
 	if serviceOverride != "" {
-		opts = append(opts, WithServiceName(serviceOverride))
+		opts = append(opts, WithService(serviceOverride))
 	}
 	mt := mocktracer.Start()
 	defer mt.Stop()

--- a/v2/contrib/README.md
+++ b/v2/contrib/README.md
@@ -2,7 +2,7 @@
 
 The purpose of these packages is to provide tracing on top of commonly used packages from the standard library as well as the 
 community in a "plug-and-play" manner. This means that by simply importing the appropriate path, functions are exposed having
- the same signature as the original package. These functions return structures which embed the original return value, allowing 
+ the same signature as the original package. These functions return structures that embed the original return value, allowing 
 them to be used as they normally would with tracing activated out of the box.
 
 All of these libraries are supported by our [APM product](https://www.datadoghq.com/apm/).
@@ -20,12 +20,16 @@ First, find the library which you'd like to integrate with. The naming conventio
 * The package itself should retain its un-versioned name. For example, the integration under `user/repo.v2` stays as `package repo`, and does not become `package repo.v2`
 
 Second, there are a few tags that should be found in all integration spans:
+
 * The `span.kind` tag should be set in root spans with either a `client`, `server`, `producer`, or `consumer` value according to the [definitions](../../ddtrace/ext/span_kind.go) found in the repository.
 If the value is determined to be `internal`, then omit the tag as that is the assumed default value. Otherwise, explicitly set it with a value from above.
 * The `component` tag should be set in all spans with the value equivalent to full naming convention of the integration package explained in the previous step.
 
-Each integration comes with thorough documentation and usage examples. A good overview can be seen on our 
-[godoc](https://godoc.org/github.com/DataDog/dd-trace-go/v2/contrib) page.
+Third, some guidelines to follow on naming functions:
+
+* Use `WithService` instead of `WithServiceName` when setting the service name.
+
+Each integration comes with a thorough documentation and usage examples. A good overview can be seen on our [godoc](https://godoc.org/github.com/DataDog/dd-trace-go/v2/contrib) page.
 
 ### Instrumentation telemetry
 

--- a/v2/contrib/Shopify/sarama/option.go
+++ b/v2/contrib/Shopify/sarama/option.go
@@ -56,8 +56,8 @@ func (fn OptionFn) apply(cfg *config) {
 	fn(cfg)
 }
 
-// WithServiceName sets the given service name for the intercepted client.
-func WithServiceName(name string) OptionFn {
+// WithService sets the given service name for the intercepted client.
+func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.consumerServiceName = name
 		cfg.producerServiceName = name

--- a/v2/contrib/Shopify/sarama/sarama_test.go
+++ b/v2/contrib/Shopify/sarama/sarama_test.go
@@ -24,7 +24,7 @@ import (
 func genTestSpans(t *testing.T, serviceOverride string) []mocktracer.Span {
 	var opts []Option
 	if serviceOverride != "" {
-		opts = append(opts, WithServiceName(serviceOverride))
+		opts = append(opts, WithService(serviceOverride))
 	}
 	mt := mocktracer.Start()
 	defer mt.Stop()

--- a/v2/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
+++ b/v2/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
@@ -788,7 +788,7 @@ func TestAppendMiddleware_WithOpts(t *testing.T) {
 		},
 		{
 			name:                "with service name",
-			opts:                []Option{WithServiceName("TestName")},
+			opts:                []Option{WithService("TestName")},
 			expectedServiceName: "TestName",
 			expectedRate:        nil,
 		},
@@ -900,7 +900,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()
@@ -951,7 +951,7 @@ func TestMessagingNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/aws/aws-sdk-go-v2/aws/option.go
+++ b/v2/contrib/aws/aws-sdk-go-v2/aws/option.go
@@ -37,10 +37,10 @@ func defaults(cfg *config) {
 	}
 }
 
-// WithServiceName sets the given service name for the dialled connection.
+// WithService sets the given service name for the dialled connection.
 // When the service name is not explicitly set it will be inferred based on the
 // request to AWS.
-func WithServiceName(name string) OptionFn {
+func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/aws/aws-sdk-go/aws/aws_test.go
+++ b/v2/contrib/aws/aws-sdk-go/aws/aws_test.go
@@ -511,7 +511,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()
@@ -561,7 +561,7 @@ func TestMessagingNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/aws/aws-sdk-go/aws/option.go
+++ b/v2/contrib/aws/aws-sdk-go/aws/option.go
@@ -38,10 +38,10 @@ func defaults(cfg *config) {
 	}
 }
 
-// WithServiceName sets the given service name for the dialled connection.
+// WithService sets the given service name for the dialled connection.
 // When the service name is not explicitly set it will be inferred based on the
 // request to AWS.
-func WithServiceName(name string) OptionFn {
+func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/bradfitz/gomemcache/memcache/memcache_test.go
+++ b/v2/contrib/bradfitz/gomemcache/memcache/memcache_test.go
@@ -42,7 +42,7 @@ func TestMemcacheIntegration(t *testing.T) {
 }
 
 func testMemcache(t *testing.T, addr string) {
-	client := getClient(addr, WithServiceName("test-memcache"))
+	client := getClient(addr, WithService("test-memcache"))
 	defer client.DeleteAll()
 
 	validateMemcacheSpan := func(t *testing.T, span mocktracer.Span, resourceName string) {
@@ -186,7 +186,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []ClientOption
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/bradfitz/gomemcache/memcache/option.go
+++ b/v2/contrib/bradfitz/gomemcache/memcache/option.go
@@ -49,8 +49,8 @@ func defaults(cfg *clientConfig) {
 	}
 }
 
-// WithServiceName sets the given service name for the dialled connection.
-func WithServiceName(name string) ClientOptionFn {
+// WithService sets the given service name for the dialled connection.
+func WithService(name string) ClientOptionFn {
 	return func(cfg *clientConfig) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/cloud.google.com/go/pubsub.v1/option.go
+++ b/v2/contrib/cloud.google.com/go/pubsub.v1/option.go
@@ -40,8 +40,8 @@ func (fn OptionFn) apply(cfg *config) {
 	fn(cfg)
 }
 
-// WithServiceName sets the service name tag for traces started by WrapReceiveHandler or Publish.
-func WithServiceName(serviceName string) OptionFn {
+// WithService sets the service name tag for traces started by WrapReceiveHandler or Publish.
+func WithService(serviceName string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = serviceName
 	}

--- a/v2/contrib/cloud.google.com/go/pubsub.v1/pubsub_test.go
+++ b/v2/contrib/cloud.google.com/go/pubsub.v1/pubsub_test.go
@@ -108,7 +108,7 @@ func TestPropagationWithServiceName(t *testing.T) {
 	err = sub.Receive(ctx, WrapReceiveHandler(sub, func(ctx context.Context, msg *pubsub.Message) {
 		msg.Ack()
 		cancel()
-	}, WithServiceName("example.service")))
+	}, WithService("example.service")))
 	assert.NoError(err)
 
 	spans := mt.FinishedSpans()
@@ -242,7 +242,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		ctx, cancel, mt, topic, sub := setup(t)
 

--- a/v2/contrib/confluentinc/confluent-kafka-go/kafka.v2/kafka_test.go
+++ b/v2/contrib/confluentinc/confluent-kafka-go/kafka.v2/kafka_test.go
@@ -297,7 +297,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		consumerAction := consumerActionFn(func(c *Consumer) (*kafka.Message, error) {
 			return c.ReadMessage(3000 * time.Millisecond)

--- a/v2/contrib/confluentinc/confluent-kafka-go/kafka.v2/option.go
+++ b/v2/contrib/confluentinc/confluent-kafka-go/kafka.v2/option.go
@@ -69,8 +69,8 @@ func newConfig(opts ...Option) *config {
 	return cfg
 }
 
-// WithServiceName sets the config service name to serviceName.
-func WithServiceName(serviceName string) OptionFn {
+// WithService sets the config service name to serviceName.
+func WithService(serviceName string) OptionFn {
 	return func(cfg *config) {
 		cfg.consumerServiceName = serviceName
 		cfg.producerServiceName = serviceName

--- a/v2/contrib/confluentinc/confluent-kafka-go/kafka/kafka_test.go
+++ b/v2/contrib/confluentinc/confluent-kafka-go/kafka/kafka_test.go
@@ -297,7 +297,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		consumerAction := consumerActionFn(func(c *Consumer) (*kafka.Message, error) {
 			return c.ReadMessage(3000 * time.Millisecond)

--- a/v2/contrib/confluentinc/confluent-kafka-go/kafka/option.go
+++ b/v2/contrib/confluentinc/confluent-kafka-go/kafka/option.go
@@ -69,8 +69,8 @@ func newConfig(opts ...Option) *config {
 	return cfg
 }
 
-// WithServiceName sets the config service name to serviceName.
-func WithServiceName(serviceName string) OptionFn {
+// WithService sets the config service name to serviceName.
+func WithService(serviceName string) OptionFn {
 	return func(cfg *config) {
 		cfg.consumerServiceName = serviceName
 		cfg.producerServiceName = serviceName

--- a/v2/contrib/database/sql/conn_test.go
+++ b/v2/contrib/database/sql/conn_test.go
@@ -64,7 +64,7 @@ func TestWithSpanTags(t *testing.T) {
 				dsn:    "postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable",
 				driver: &pq.Driver{},
 				opts: []Option{
-					WithServiceName("postgres-test"),
+					WithService("postgres-test"),
 					WithAnalyticsRate(0.2),
 				},
 			},
@@ -221,7 +221,7 @@ func TestWithChildSpansOnly(t *testing.T) {
 				driver: &pq.Driver{},
 				opts: []Option{
 					WithChildSpansOnly(),
-					WithServiceName("postgres-test"),
+					WithService("postgres-test"),
 					WithAnalyticsRate(0.2),
 				},
 			},

--- a/v2/contrib/database/sql/example_test.go
+++ b/v2/contrib/database/sql/example_test.go
@@ -38,7 +38,7 @@ func Example() {
 
 func Example_context() {
 	// Register the driver that we will be using (in this case mysql) under a custom service name.
-	sqltrace.Register("mysql", &mysql.MySQLDriver{}, sqltrace.WithServiceName("my-db"))
+	sqltrace.Register("mysql", &mysql.MySQLDriver{}, sqltrace.WithService("my-db"))
 
 	// Open a connection to the DB using the driver we've just registered with tracing.
 	db, err := sqltrace.Open("mysql", "user:password@/dbname")
@@ -64,7 +64,7 @@ func Example_context() {
 
 func Example_sqlite() {
 	// Register the driver that we will be using (in this case Sqlite) under a custom service name.
-	sqltrace.Register("sqlite", &sqlite.SQLiteDriver{}, sqltrace.WithServiceName("sqlite-example"))
+	sqltrace.Register("sqlite", &sqlite.SQLiteDriver{}, sqltrace.WithService("sqlite-example"))
 
 	// Open a connection to the DB using the driver we've just registered with tracing.
 	db, err := sqltrace.Open("sqlite", "./test.db")

--- a/v2/contrib/database/sql/option.go
+++ b/v2/contrib/database/sql/option.go
@@ -173,9 +173,9 @@ func getSpanName(driverName string) string {
 	).GetName()
 }
 
-// WithServiceName sets the given service name when registering a driver,
+// WithService sets the given service name when registering a driver,
 // or opening a database connection.
-func WithServiceName(name string) OptionFn {
+func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/database/sql/sql_test.go
+++ b/v2/contrib/database/sql/sql_test.go
@@ -100,7 +100,7 @@ func TestMySQL(t *testing.T) {
 
 func TestPostgres(t *testing.T) {
 	driverName := "postgres"
-	Register(driverName, &pq.Driver{}, WithServiceName("postgres-test"), WithAnalyticsRate(0.2))
+	Register(driverName, &pq.Driver{}, WithService("postgres-test"), WithAnalyticsRate(0.2))
 	defer unregister(driverName)
 	db, err := Open(driverName, "postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable")
 	require.NoError(t, err)
@@ -130,9 +130,9 @@ func TestOpenOptions(t *testing.T) {
 	dsn := "postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable"
 
 	t.Run("Open", func(t *testing.T) {
-		Register(driverName, &pq.Driver{}, WithServiceName("postgres-test"), WithAnalyticsRate(0.2))
+		Register(driverName, &pq.Driver{}, WithService("postgres-test"), WithAnalyticsRate(0.2))
 		defer unregister(driverName)
-		db, err := Open(driverName, dsn, WithServiceName("override-test"), WithAnalytics(true))
+		db, err := Open(driverName, dsn, WithService("override-test"), WithAnalytics(true))
 		require.NoError(t, err)
 		defer db.Close()
 
@@ -156,7 +156,7 @@ func TestOpenOptions(t *testing.T) {
 	})
 
 	t.Run("OpenDB", func(t *testing.T) {
-		Register(driverName, &pq.Driver{}, WithServiceName("postgres-test"), WithAnalyticsRate(0.2))
+		Register(driverName, &pq.Driver{}, WithService("postgres-test"), WithAnalyticsRate(0.2))
 		defer unregister(driverName)
 		c, err := pq.NewConnector(dsn)
 		require.NoError(t, err)
@@ -183,7 +183,7 @@ func TestOpenOptions(t *testing.T) {
 	})
 
 	t.Run("WithDSN", func(t *testing.T) {
-		Register(driverName, &pq.Driver{}, WithServiceName("postgres-test"), WithAnalyticsRate(0.2))
+		Register(driverName, &pq.Driver{}, WithService("postgres-test"), WithAnalyticsRate(0.2))
 		defer unregister(driverName)
 		c, err := pq.NewConnector(dsn)
 		require.NoError(t, err)
@@ -247,7 +247,7 @@ func TestOpenOptions(t *testing.T) {
 
 	t.Run("RegisterOptionsAsDefault", func(t *testing.T) {
 		registerOpts := []Option{
-			WithServiceName("register-override"),
+			WithService("register-override"),
 			WithIgnoreQueryTypes(QueryTypeConnect),
 		}
 		Register(driverName, &pq.Driver{}, registerOpts...)
@@ -360,13 +360,13 @@ func TestNamingSchema(t *testing.T) {
 			var registerOpts []Option
 			// serviceOverride has higher priority than the registerOverride parameter.
 			if serviceOverride != "" {
-				registerOpts = append(registerOpts, WithServiceName(serviceOverride))
+				registerOpts = append(registerOpts, WithService(serviceOverride))
 			} else if registerOverride {
-				registerOpts = append(registerOpts, WithServiceName("register-override"))
+				registerOpts = append(registerOpts, WithService("register-override"))
 			}
 			var openOpts []Option
 			if serviceOverride != "" {
-				openOpts = append(openOpts, WithServiceName(serviceOverride))
+				openOpts = append(openOpts, WithService(serviceOverride))
 			}
 			mt := mocktracer.Start()
 			defer mt.Stop()
@@ -454,7 +454,7 @@ func TestNamingSchema(t *testing.T) {
 			assert.Equal(t, "postgresql.query", spans[1].OperationName())
 		}
 		wantServiceNameV0 := namingschematest.ServiceNameAssertions{
-			// when the WithServiceName option is set during Register and not providing a service name when opening
+			// when the WithService option is set during Register and not providing a service name when opening
 			// the DB connection, that value is used as default instead of postgres.db.
 			WithDefaults: []string{"register-override", "register-override"},
 			// in v0, DD_SERVICE is ignored for this integration.

--- a/v2/contrib/dimfeld/httptreemux.v5/contextmux_test.go
+++ b/v2/contrib/dimfeld/httptreemux.v5/contextmux_test.go
@@ -24,7 +24,7 @@ func TestContextMux200(t *testing.T) {
 	defer mt.Stop()
 
 	router := NewWithContext(
-		WithServiceName("my-service"),
+		WithService("my-service"),
 		WithSpanOptions(tracer.Tag("testkey", "testvalue")),
 	)
 
@@ -62,7 +62,7 @@ func TestContextMux404(t *testing.T) {
 	r := httptest.NewRequest("GET", url, nil)
 	w := httptest.NewRecorder()
 	NewWithContext(
-		WithServiceName("my-service"),
+		WithService("my-service"),
 		WithSpanOptions(tracer.Tag("testkey", "testvalue")),
 	).ServeHTTP(w, r)
 	assert.Equal(404, w.Code)
@@ -88,7 +88,7 @@ func TestContextMux500(t *testing.T) {
 	defer mt.Stop()
 
 	router := NewWithContext(
-		WithServiceName("my-service"),
+		WithService("my-service"),
 		WithSpanOptions(tracer.Tag("testkey", "testvalue")),
 	)
 
@@ -217,7 +217,7 @@ func TestContextMuxResourceNamer(t *testing.T) {
 	defer mt.Stop()
 
 	router := NewWithContext(
-		WithServiceName("my-service"),
+		WithService("my-service"),
 		WithSpanOptions(tracer.Tag("testkey", "testvalue")),
 		WithResourceNamer(staticNamer),
 	)

--- a/v2/contrib/dimfeld/httptreemux.v5/example_test.go
+++ b/v2/contrib/dimfeld/httptreemux.v5/example_test.go
@@ -32,7 +32,7 @@ func Example() {
 }
 
 func Example_withServiceName() {
-	router := httptrace.New(httptrace.WithServiceName("http.router"))
+	router := httptrace.New(httptrace.WithService("http.router"))
 	router.GET("/", Index)
 	router.GET("/hello/:name", Hello)
 
@@ -41,7 +41,7 @@ func Example_withServiceName() {
 
 func Example_withSpanOpts() {
 	router := httptrace.New(
-		httptrace.WithServiceName("http.router"),
+		httptrace.WithService("http.router"),
 		httptrace.WithSpanOptions(
 			tracer.Tag(ext.SamplingPriority, ext.PriorityUserKeep),
 		),

--- a/v2/contrib/dimfeld/httptreemux.v5/httptreemux_test.go
+++ b/v2/contrib/dimfeld/httptreemux.v5/httptreemux_test.go
@@ -189,7 +189,7 @@ func TestResourceNamer(t *testing.T) {
 	defer mt.Stop()
 
 	router := New(
-		WithServiceName("my-service"),
+		WithService("my-service"),
 		WithSpanOptions(tracer.Tag("testkey", "testvalue")),
 		WithResourceNamer(staticNamer),
 	)
@@ -222,7 +222,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []RouterOption
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()
@@ -296,7 +296,7 @@ func TestTrailingSlashRoutes(t *testing.T) {
 
 func router() http.Handler {
 	router := New(
-		WithServiceName("my-service"),
+		WithService("my-service"),
 		WithSpanOptions(tracer.Tag("testkey", "testvalue")),
 	)
 

--- a/v2/contrib/dimfeld/httptreemux.v5/option.go
+++ b/v2/contrib/dimfeld/httptreemux.v5/option.go
@@ -39,8 +39,8 @@ func defaults(cfg *routerConfig) {
 	cfg.resourceNamer = defaultResourceNamer
 }
 
-// WithServiceName sets the given service name for the returned router.
-func WithServiceName(name string) RouterOptionFn {
+// WithService sets the given service name for the returned router.
+func WithService(name string) RouterOptionFn {
 	return func(cfg *routerConfig) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/elastic/go-elasticsearch.v6/elastictrace_v6_test.go
+++ b/v2/contrib/elastic/go-elasticsearch.v6/elastictrace_v6_test.go
@@ -45,7 +45,7 @@ func TestClientV6(t *testing.T) {
 	defer mt.Stop()
 
 	cfg := elasticsearch6.Config{
-		Transport: NewRoundTripper(WithServiceName("my-es-service")),
+		Transport: NewRoundTripper(WithService("my-es-service")),
 		Addresses: []string{
 			elasticV6URL,
 		},
@@ -91,7 +91,7 @@ func TestClientErrorCutoffV6(t *testing.T) {
 	bodyCutoff = 10
 
 	cfg := elasticsearch6.Config{
-		Transport: NewRoundTripper(WithServiceName("my-es-service")),
+		Transport: NewRoundTripper(WithService("my-es-service")),
 		Addresses: []string{
 			elasticV6URL,
 		},
@@ -115,7 +115,7 @@ func TestClientV6Failure(t *testing.T) {
 	defer mt.Stop()
 
 	cfg := elasticsearch6.Config{
-		Transport: NewRoundTripper(WithServiceName("my-es-service")),
+		Transport: NewRoundTripper(WithService("my-es-service")),
 		Addresses: []string{
 			"http://127.0.0.1:9207", // inexistent service, it must fail
 		},

--- a/v2/contrib/elastic/go-elasticsearch.v6/elastictrace_v7_test.go
+++ b/v2/contrib/elastic/go-elasticsearch.v6/elastictrace_v7_test.go
@@ -45,7 +45,7 @@ func TestClientV7(t *testing.T) {
 	defer mt.Stop()
 
 	cfg := elasticsearch7.Config{
-		Transport: NewRoundTripper(WithServiceName("my-es-service")),
+		Transport: NewRoundTripper(WithService("my-es-service")),
 		Addresses: []string{
 			elasticV7URL,
 		},
@@ -91,7 +91,7 @@ func TestClientErrorCutoffV7(t *testing.T) {
 	bodyCutoff = 10
 
 	cfg := elasticsearch7.Config{
-		Transport: NewRoundTripper(WithServiceName("my-es-service")),
+		Transport: NewRoundTripper(WithService("my-es-service")),
 		Addresses: []string{
 			elasticV7URL,
 		},
@@ -115,7 +115,7 @@ func TestClientV7Failure(t *testing.T) {
 	defer mt.Stop()
 
 	cfg := elasticsearch7.Config{
-		Transport: NewRoundTripper(WithServiceName("my-es-service")),
+		Transport: NewRoundTripper(WithService("my-es-service")),
 		Addresses: []string{
 			"http://127.0.0.1:9207", // inexistent service, it must fail
 		},

--- a/v2/contrib/elastic/go-elasticsearch.v6/elastictrace_v8_test.go
+++ b/v2/contrib/elastic/go-elasticsearch.v6/elastictrace_v8_test.go
@@ -47,7 +47,7 @@ func TestClientV8(t *testing.T) {
 	defer mt.Stop()
 
 	cfg := elasticsearch8.Config{
-		Transport: NewRoundTripper(WithServiceName("my-es-service")),
+		Transport: NewRoundTripper(WithService("my-es-service")),
 		Addresses: []string{
 			elasticV8URL,
 		},
@@ -91,7 +91,7 @@ func TestClientErrorCutoffV8(t *testing.T) {
 	bodyCutoff = 10
 
 	cfg := elasticsearch8.Config{
-		Transport: NewRoundTripper(WithServiceName("my-es-service")),
+		Transport: NewRoundTripper(WithService("my-es-service")),
 		Addresses: []string{
 			elasticV8URL,
 		},
@@ -115,7 +115,7 @@ func TestClientV8Failure(t *testing.T) {
 	defer mt.Stop()
 
 	cfg := elasticsearch8.Config{
-		Transport: NewRoundTripper(WithServiceName("my-es-service")),
+		Transport: NewRoundTripper(WithService("my-es-service")),
 		Addresses: []string{
 			"http://127.0.0.1:9207", // inexistent service, it must fail
 		},
@@ -260,7 +260,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []ClientOption
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/elastic/go-elasticsearch.v6/example_test.go
+++ b/v2/contrib/elastic/go-elasticsearch.v6/example_test.go
@@ -18,7 +18,7 @@ import (
 
 func Example_v8() {
 	cfg := elasticsearch.Config{
-		Transport: elastictrace.NewRoundTripper(elastictrace.WithServiceName("my-es-service")),
+		Transport: elastictrace.NewRoundTripper(elastictrace.WithService("my-es-service")),
 		Addresses: []string{
 			"http://127.0.0.1:9200",
 		},

--- a/v2/contrib/elastic/go-elasticsearch.v6/option.go
+++ b/v2/contrib/elastic/go-elasticsearch.v6/option.go
@@ -57,8 +57,8 @@ func WithTransport(t http.RoundTripper) ClientOptionFn {
 	}
 }
 
-// WithServiceName sets the given service name for the client.
-func WithServiceName(name string) ClientOptionFn {
+// WithService sets the given service name for the client.
+func WithService(name string) ClientOptionFn {
 	return func(cfg *clientConfig) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/emicklei/go-restful.v3/example_test.go
+++ b/v2/contrib/emicklei/go-restful.v3/example_test.go
@@ -23,7 +23,7 @@ func Example() {
 
 	// create the Datadog filter
 	filter := restfultrace.FilterFunc(
-		restfultrace.WithServiceName("my-service"),
+		restfultrace.WithService("my-service"),
 	)
 
 	// use it
@@ -43,7 +43,7 @@ func Example() {
 func Example_spanFromContext() {
 	ws := new(restful.WebService)
 	ws.Filter(restfultrace.FilterFunc(
-		restfultrace.WithServiceName("my-service"),
+		restfultrace.WithService("my-service"),
 	))
 
 	ws.Route(ws.GET("/image/encode").To(

--- a/v2/contrib/emicklei/go-restful.v3/option.go
+++ b/v2/contrib/emicklei/go-restful.v3/option.go
@@ -50,8 +50,8 @@ func (fn OptionFn) apply(cfg *config) {
 	fn(cfg)
 }
 
-// WithServiceName sets the service name to by used by the filter.
-func WithServiceName(name string) OptionFn {
+// WithService sets the service name to by used by the filter.
+func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/emicklei/go-restful.v3/restful_test.go
+++ b/v2/contrib/emicklei/go-restful.v3/restful_test.go
@@ -129,7 +129,7 @@ func TestTrace200(t *testing.T) {
 	defer mt.Stop()
 
 	ws := new(restful.WebService)
-	ws.Filter(FilterFunc(WithServiceName("my-service")))
+	ws.Filter(FilterFunc(WithService("my-service")))
 	ws.Route(ws.GET("/user/{id}").Param(restful.PathParameter("id", "user ID")).
 		To(func(request *restful.Request, response *restful.Response) {
 			_, ok := tracer.SpanFromContext(request.Request.Context())
@@ -291,7 +291,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/globalsign/mgo/mgo_test.go
+++ b/v2/contrib/globalsign/mgo/mgo_test.go
@@ -45,7 +45,7 @@ func testMongoCollectionCommand(t *testing.T, command func(*Collection)) []mockt
 		tracer.ResourceName("insert-test"),
 	)
 
-	session, err := Dial("localhost:27017", WithServiceName("unit-tests"), WithContext(ctx))
+	session, err := Dial("localhost:27017", WithService("unit-tests"), WithContext(ctx))
 	require.NoError(t, err)
 
 	defer session.Close()
@@ -569,7 +569,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []DialOption
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/globalsign/mgo/option.go
+++ b/v2/contrib/globalsign/mgo/option.go
@@ -50,8 +50,8 @@ func (fn DialOptionFn) apply(cfg *mongoConfig) {
 	fn(cfg)
 }
 
-// WithServiceName sets the service name for a given MongoDB context.
-func WithServiceName(name string) DialOptionFn {
+// WithService sets the service name for a given MongoDB context.
+func WithService(name string) DialOptionFn {
 	return func(cfg *mongoConfig) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/go-chi/chi.v5/chi_test.go
+++ b/v2/contrib/go-chi/chi.v5/chi_test.go
@@ -35,7 +35,7 @@ func TestChildSpan(t *testing.T) {
 	defer mt.Stop()
 
 	router := chi.NewRouter()
-	router.Use(Middleware(WithServiceName("foobar")))
+	router.Use(Middleware(WithService("foobar")))
 	router.Get("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
 		_, ok := tracer.SpanFromContext(r.Context())
 		assert.True(ok)
@@ -82,7 +82,7 @@ func TestTrace200(t *testing.T) {
 		defer mt.Stop()
 
 		router := chi.NewRouter()
-		router.Use(Middleware(WithServiceName("foobar")))
+		router.Use(Middleware(WithService("foobar")))
 		router.Get("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
 			span, ok := tracer.SpanFromContext(r.Context())
 			assert.True(ok)
@@ -100,7 +100,7 @@ func TestTrace200(t *testing.T) {
 		defer mt.Stop()
 
 		router := chi.NewRouter()
-		router.Use(Middleware(WithServiceName("foobar")))
+		router.Use(Middleware(WithService("foobar")))
 		router.Get("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
 			span, ok := tracer.SpanFromContext(r.Context())
 			assert.True(ok)
@@ -160,7 +160,7 @@ func TestError(t *testing.T) {
 
 		// setup
 		router := chi.NewRouter()
-		router.Use(Middleware(WithServiceName("foobar")))
+		router.Use(Middleware(WithService("foobar")))
 		code := 500
 
 		// a handler with an error and make the requests
@@ -187,7 +187,7 @@ func TestError(t *testing.T) {
 		// setup
 		router := chi.NewRouter()
 		router.Use(Middleware(
-			WithServiceName("foobar"),
+			WithService("foobar"),
 			WithStatusCheck(func(statusCode int) bool {
 				return statusCode >= 400
 			}),
@@ -239,7 +239,7 @@ func TestPropagation(t *testing.T) {
 	tracer.Inject(pspan.Context(), tracer.HTTPHeadersCarrier(r.Header))
 
 	router := chi.NewRouter()
-	router.Use(Middleware(WithServiceName("foobar")))
+	router.Use(Middleware(WithService("foobar")))
 	router.Get("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
 		span, ok := tracer.SpanFromContext(r.Context())
 		assert.True(ok)
@@ -546,7 +546,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()
@@ -571,7 +571,7 @@ func TestCustomResourceName(t *testing.T) {
 	defer mt.Stop()
 
 	router := chi.NewRouter()
-	router.Use(Middleware(WithServiceName("service-name"), WithResourceNamer(func(r *http.Request) string {
+	router.Use(Middleware(WithService("service-name"), WithResourceNamer(func(r *http.Request) string {
 		return "custom-resource-name"
 	})))
 	router.Get("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
@@ -595,7 +595,7 @@ func TestUnknownResourceName(t *testing.T) {
 	defer mt.Stop()
 
 	router := chi.NewRouter()
-	router.Use(Middleware(WithServiceName("service-name")))
+	router.Use(Middleware(WithService("service-name")))
 	router.Get("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
 		_, ok := tracer.SpanFromContext(r.Context())
 		assert.True(ok)
@@ -620,7 +620,7 @@ func TestConcurrency(t *testing.T) {
 	expectedCap := 10
 	opts := make([]Option, 0, expectedCap)
 	opts = append(opts, []Option{
-		WithServiceName("foobar"),
+		WithService("foobar"),
 		WithSpanOptions(tracer.Tag("tag1", "value1")),
 	}...)
 	expectedLen := 2

--- a/v2/contrib/go-chi/chi.v5/example_test.go
+++ b/v2/contrib/go-chi/chi.v5/example_test.go
@@ -45,7 +45,7 @@ func Example_withServiceName() {
 	router := chi.NewRouter()
 
 	// Use the tracer middleware with your desired service name.
-	router.Use(chitrace.Middleware(chitrace.WithServiceName("chi-server")))
+	router.Use(chitrace.Middleware(chitrace.WithService("chi-server")))
 
 	// Set up some endpoints.
 	router.Get("/", handler)

--- a/v2/contrib/go-chi/chi.v5/option.go
+++ b/v2/contrib/go-chi/chi.v5/option.go
@@ -56,8 +56,8 @@ func defaults(cfg *config) {
 	cfg.resourceNamer = nil
 }
 
-// WithServiceName sets the given service name for the router.
-func WithServiceName(name string) OptionFn {
+// WithService sets the given service name for the router.
+func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/go-chi/chi/chi_test.go
+++ b/v2/contrib/go-chi/chi/chi_test.go
@@ -34,7 +34,7 @@ func TestChildSpan(t *testing.T) {
 	defer mt.Stop()
 
 	router := chi.NewRouter()
-	router.Use(Middleware(WithServiceName("foobar")))
+	router.Use(Middleware(WithService("foobar")))
 	router.Get("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
 		_, ok := tracer.SpanFromContext(r.Context())
 		assert.True(ok)
@@ -81,7 +81,7 @@ func TestTrace200(t *testing.T) {
 		defer mt.Stop()
 
 		router := chi.NewRouter()
-		router.Use(Middleware(WithServiceName("foobar")))
+		router.Use(Middleware(WithService("foobar")))
 		router.Get("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
 			span, ok := tracer.SpanFromContext(r.Context())
 			assert.True(ok)
@@ -99,7 +99,7 @@ func TestTrace200(t *testing.T) {
 		defer mt.Stop()
 
 		router := chi.NewRouter()
-		router.Use(Middleware(WithServiceName("foobar")))
+		router.Use(Middleware(WithService("foobar")))
 		router.Get("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
 			span, ok := tracer.SpanFromContext(r.Context())
 			assert.True(ok)
@@ -132,7 +132,7 @@ func TestError(t *testing.T) {
 
 		// setup
 		router := chi.NewRouter()
-		router.Use(Middleware(WithServiceName("foobar")))
+		router.Use(Middleware(WithService("foobar")))
 		code := 500
 
 		// a handler with an error and make the requests
@@ -159,7 +159,7 @@ func TestError(t *testing.T) {
 		// setup
 		router := chi.NewRouter()
 		router.Use(Middleware(
-			WithServiceName("foobar"),
+			WithService("foobar"),
 			WithStatusCheck(func(statusCode int) bool {
 				return statusCode >= 400
 			}),
@@ -303,7 +303,7 @@ func TestPropagation(t *testing.T) {
 	tracer.Inject(pspan.Context(), tracer.HTTPHeadersCarrier(r.Header))
 
 	router := chi.NewRouter()
-	router.Use(Middleware(WithServiceName("foobar")))
+	router.Use(Middleware(WithService("foobar")))
 	router.Get("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
 		span, ok := tracer.SpanFromContext(r.Context())
 		assert.True(ok)
@@ -519,7 +519,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()
@@ -544,7 +544,7 @@ func TestCustomResourceName(t *testing.T) {
 	defer mt.Stop()
 
 	router := chi.NewRouter()
-	router.Use(Middleware(WithServiceName("service-name"), WithResourceNamer(func(r *http.Request) string {
+	router.Use(Middleware(WithService("service-name"), WithResourceNamer(func(r *http.Request) string {
 		return "custom-resource-name"
 	})))
 	router.Get("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
@@ -568,7 +568,7 @@ func TestUnknownResourceName(t *testing.T) {
 	defer mt.Stop()
 
 	router := chi.NewRouter()
-	router.Use(Middleware(WithServiceName("service-name")))
+	router.Use(Middleware(WithService("service-name")))
 	router.Get("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
 		_, ok := tracer.SpanFromContext(r.Context())
 		assert.True(ok)

--- a/v2/contrib/go-chi/chi/example_test.go
+++ b/v2/contrib/go-chi/chi/example_test.go
@@ -45,7 +45,7 @@ func Example_withServiceName() {
 	router := chi.NewRouter()
 
 	// Use the tracer middleware with your desired service name.
-	router.Use(chitrace.Middleware(chitrace.WithServiceName("chi-server")))
+	router.Use(chitrace.Middleware(chitrace.WithService("chi-server")))
 
 	// Set up some endpoints.
 	router.Get("/", handler)

--- a/v2/contrib/go-chi/chi/option.go
+++ b/v2/contrib/go-chi/chi/option.go
@@ -62,8 +62,8 @@ func defaults(cfg *config) {
 	}
 }
 
-// WithServiceName sets the given service name for the router.
-func WithServiceName(name string) OptionFn {
+// WithService sets the given service name for the router.
+func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/go-pg/pg.v10/option.go
+++ b/v2/contrib/go-pg/pg.v10/option.go
@@ -43,8 +43,8 @@ func defaults(cfg *config) {
 	}
 }
 
-// WithServiceName sets the given service name for the client.
-func WithServiceName(name string) OptionFn {
+// WithService sets the given service name for the client.
+func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/go-pg/pg.v10/pg_go_test.go
+++ b/v2/contrib/go-pg/pg.v10/pg_go_test.go
@@ -164,7 +164,7 @@ func TestServiceName(t *testing.T) {
 			Database: "postgres",
 		})
 
-		Wrap(conn, WithServiceName("my-service-name"))
+		Wrap(conn, WithService("my-service-name"))
 
 		parentSpan, ctx := tracer.StartSpanFromContext(context.Background(), "http.request",
 			tracer.ServiceName("fake-http-server"),

--- a/v2/contrib/go-redis/redis.v7/example_test.go
+++ b/v2/contrib/go-redis/redis.v7/example_test.go
@@ -46,7 +46,7 @@ func Example() {
 func Example_pipeliner() {
 	// create a client
 	opts := &redis.Options{Addr: "127.0.0.1", Password: "", DB: 0}
-	c := redistrace.NewClient(opts, redistrace.WithServiceName("my-redis-service"))
+	c := redistrace.NewClient(opts, redistrace.WithService("my-redis-service"))
 
 	// open the pipeline
 	pipe := c.Pipeline()

--- a/v2/contrib/go-redis/redis.v7/option.go
+++ b/v2/contrib/go-redis/redis.v7/option.go
@@ -48,8 +48,8 @@ func defaults(cfg *clientConfig) {
 	cfg.errCheck = func(error) bool { return true }
 }
 
-// WithServiceName sets the given service name for the client.
-func WithServiceName(name string) ClientOptionFn {
+// WithService sets the given service name for the client.
+func WithService(name string) ClientOptionFn {
 	return func(cfg *clientConfig) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/go-redis/redis.v7/redis_test.go
+++ b/v2/contrib/go-redis/redis.v7/redis_test.go
@@ -45,7 +45,7 @@ func TestClientEvalSha(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 
 	sha1 := client.ScriptLoad("return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}").Val()
 	mt.Reset()
@@ -75,7 +75,7 @@ func TestClient(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 	client.Set("test_key", "test_value", 0)
 
 	spans := mt.FinishedSpans()
@@ -139,7 +139,7 @@ func TestWrapClient(t *testing.T) {
 			mt := mocktracer.Start()
 			defer mt.Stop()
 
-			WrapClient(tc.client, WithServiceName("my-redis"))
+			WrapClient(tc.client, WithService("my-redis"))
 			tc.client.Set("test_key", "test_value", 0)
 
 			spans := mt.FinishedSpans()
@@ -225,7 +225,7 @@ func TestPipeline(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 	pipeline := client.Pipeline()
 	pipeline.Expire("pipeline_counter", time.Hour)
 
@@ -279,7 +279,7 @@ func TestChildSpan(t *testing.T) {
 	defer mt.Stop()
 
 	// Parent span
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 	root, ctx := tracer.StartSpanFromContext(context.Background(), "parent.span")
 	client = client.WithContext(ctx)
 	client.Set("test_key", "test_value", 0)
@@ -311,7 +311,7 @@ func TestMultipleCommands(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 	client.Set("test_key", "test_value", 0)
 	client.Get("test_key")
 	client.Incr("int_key")
@@ -338,7 +338,7 @@ func TestError(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		client := NewClient(opts, WithServiceName("my-redis"))
+		client := NewClient(opts, WithService("my-redis"))
 		_, err := client.Get("key").Result()
 
 		spans := mt.FinishedSpans()
@@ -364,7 +364,7 @@ func TestError(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		client := NewClient(opts, WithServiceName("my-redis"))
+		client := NewClient(opts, WithService("my-redis"))
 		_, err := client.Get("non_existent_key").Result()
 
 		spans := mt.FinishedSpans()
@@ -396,7 +396,7 @@ func TestError(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		client := NewClient(opts, WithServiceName("my-redis"), WithErrorCheck(errCheckFn))
+		client := NewClient(opts, WithService("my-redis"), WithErrorCheck(errCheckFn))
 		client = client.WithContext(ctx)
 
 		_, err := client.Get("test_key").Result()
@@ -491,11 +491,11 @@ func TestWithContext(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client1 := NewClient(opts, WithServiceName("my-redis"))
+	client1 := NewClient(opts, WithService("my-redis"))
 	s1, ctx1 := tracer.StartSpanFromContext(context.Background(), "span1.name")
 	client1 = client1.WithContext(ctx1)
 	s2, ctx2 := tracer.StartSpanFromContext(context.Background(), "span2.name")
-	client2 := NewClient(opts, WithServiceName("my-redis"))
+	client2 := NewClient(opts, WithService("my-redis"))
 	client2 = client2.WithContext(ctx2)
 	client1.Set("test_key", "test_value", 0)
 	client2.Get("test_key")
@@ -529,7 +529,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []ClientOption
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/go-redis/redis.v8/example_test.go
+++ b/v2/contrib/go-redis/redis.v8/example_test.go
@@ -45,7 +45,7 @@ func Example_pipeliner() {
 	ctx := context.Background()
 	// create a client
 	opts := &redis.Options{Addr: "127.0.0.1", Password: "", DB: 0}
-	c := redistrace.NewClient(opts, redistrace.WithServiceName("my-redis-service"))
+	c := redistrace.NewClient(opts, redistrace.WithService("my-redis-service"))
 
 	// open the pipeline
 	pipe := c.Pipeline()

--- a/v2/contrib/go-redis/redis.v8/option.go
+++ b/v2/contrib/go-redis/redis.v8/option.go
@@ -58,8 +58,8 @@ func WithSkipRawCommand(skip bool) ClientOptionFn {
 	}
 }
 
-// WithServiceName sets the given service name for the client.
-func WithServiceName(name string) ClientOptionFn {
+// WithService sets the given service name for the client.
+func WithService(name string) ClientOptionFn {
 	return func(cfg *clientConfig) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/go-redis/redis.v8/redis_test.go
+++ b/v2/contrib/go-redis/redis.v8/redis_test.go
@@ -91,7 +91,7 @@ func TestClientEvalSha(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 
 	sha1 := client.ScriptLoad(ctx, "return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}").Val()
 	mt.Reset()
@@ -122,7 +122,7 @@ func TestPing(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 	_, err := client.Do(ctx, "PING").Result()
 	require.NoError(t, err)
 
@@ -149,7 +149,7 @@ func TestClient(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 	client.Set(ctx, "test_key", "test_value", 0)
 
 	spans := mt.FinishedSpans()
@@ -214,7 +214,7 @@ func TestWrapClient(t *testing.T) {
 			mt := mocktracer.Start()
 			defer mt.Stop()
 
-			WrapClient(tc.client, WithServiceName("my-redis"))
+			WrapClient(tc.client, WithService("my-redis"))
 			tc.client.Set(ctx, "test_key", "test_value", 0)
 
 			spans := mt.FinishedSpans()
@@ -301,7 +301,7 @@ func TestPipeline(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 	pipeline := client.Pipeline()
 	pipeline.Expire(ctx, "pipeline_counter", time.Hour)
 
@@ -356,7 +356,7 @@ func TestChildSpan(t *testing.T) {
 	defer mt.Stop()
 
 	// Parent span
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 	root, ctx := tracer.StartSpanFromContext(ctx, "parent.span")
 
 	client.Set(ctx, "test_key", "test_value", 0)
@@ -390,7 +390,7 @@ func TestMultipleCommands(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 	client.Set(ctx, "test_key", "test_value", 0)
 	client.Get(ctx, "test_key")
 	client.Incr(ctx, "int_key")
@@ -418,7 +418,7 @@ func TestError(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		client := NewClient(opts, WithServiceName("my-redis"))
+		client := NewClient(opts, WithService("my-redis"))
 		_, err := client.Get(ctx, "key").Result()
 
 		spans := mt.FinishedSpans()
@@ -445,7 +445,7 @@ func TestError(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		client := NewClient(opts, WithServiceName("my-redis"))
+		client := NewClient(opts, WithService("my-redis"))
 		_, err := client.Get(ctx, "non_existent_key").Result()
 
 		spans := mt.FinishedSpans()
@@ -477,7 +477,7 @@ func TestError(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		client := NewClient(opts, WithServiceName("my-redis"), WithErrorCheck(errCheckFn))
+		client := NewClient(opts, WithService("my-redis"), WithErrorCheck(errCheckFn))
 		_, err := client.Get(ctx, "test_key").Result()
 
 		spans := mt.FinishedSpans()
@@ -573,11 +573,11 @@ func TestWithContext(t *testing.T) {
 
 	ctx1 := context.Background()
 	ctx2 := context.Background()
-	client1 := NewClient(opts, WithServiceName("my-redis"))
+	client1 := NewClient(opts, WithService("my-redis"))
 	s1, ctx1 := tracer.StartSpanFromContext(ctx1, "span1.name")
 
 	s2, ctx2 := tracer.StartSpanFromContext(ctx2, "span2.name")
-	client2 := NewClient(opts, WithServiceName("my-redis"))
+	client2 := NewClient(opts, WithService("my-redis"))
 	client1.Set(ctx1, "test_key", "test_value", 0)
 	client2.Get(ctx2, "test_key")
 	s1.Finish()
@@ -611,7 +611,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []ClientOption
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/go-redis/redis/example_test.go
+++ b/v2/contrib/go-redis/redis/example_test.go
@@ -46,7 +46,7 @@ func Example() {
 func Example_pipeliner() {
 	// create a client
 	opts := &redis.Options{Addr: "127.0.0.1", Password: "", DB: 0}
-	c := redistrace.NewClient(opts, redistrace.WithServiceName("my-redis-service"))
+	c := redistrace.NewClient(opts, redistrace.WithService("my-redis-service"))
 
 	// open the pipeline
 	pipe := c.Pipeline()

--- a/v2/contrib/go-redis/redis/option.go
+++ b/v2/contrib/go-redis/redis/option.go
@@ -46,8 +46,8 @@ func defaults(cfg *clientConfig) {
 	}
 }
 
-// WithServiceName sets the given service name for the client.
-func WithServiceName(name string) ClientOptionFn {
+// WithService sets the given service name for the client.
+func WithService(name string) ClientOptionFn {
 	return func(cfg *clientConfig) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/go-redis/redis/redis_test.go
+++ b/v2/contrib/go-redis/redis/redis_test.go
@@ -41,7 +41,7 @@ func TestClientEvalSha(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 
 	sha1 := client.ScriptLoad("return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}").Val()
 	mt.Reset()
@@ -68,7 +68,7 @@ func TestClientEvalSha(t *testing.T) {
 // https://github.com/DataDog/dd-trace-go/issues/387
 func TestIssue387(_ *testing.T) {
 	opts := &redis.Options{Addr: "127.0.0.1:6379"}
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 	n := 1000
 
 	client.Set("test_key", "test_value", 0)
@@ -92,7 +92,7 @@ func TestClient(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 	client.Set("test_key", "test_value", 0)
 
 	spans := mt.FinishedSpans()
@@ -119,7 +119,7 @@ func TestPipeline(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 	pipeline := client.Pipeline()
 	pipeline.Expire("pipeline_counter", time.Hour)
 
@@ -172,7 +172,7 @@ func TestPipelined(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 	_, err := client.Pipelined(func(p redis.Pipeliner) error {
 		p.Expire("pipeline_counter", time.Hour)
 		return nil
@@ -227,7 +227,7 @@ func TestChildSpan(t *testing.T) {
 	defer mt.Stop()
 
 	// Parent span
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 	root, ctx := tracer.StartSpanFromContext(context.Background(), "parent.span")
 	client = client.WithContext(ctx)
 	client.Set("test_key", "test_value", 0)
@@ -260,7 +260,7 @@ func TestMultipleCommands(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 	client.Set("test_key", "test_value", 0)
 	client.Get("test_key")
 	client.Incr("int_key")
@@ -287,7 +287,7 @@ func TestError(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		client := NewClient(opts, WithServiceName("my-redis"))
+		client := NewClient(opts, WithService("my-redis"))
 		_, err := client.Get("key").Result()
 
 		spans := mt.FinishedSpans()
@@ -313,7 +313,7 @@ func TestError(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		client := NewClient(opts, WithServiceName("my-redis"))
+		client := NewClient(opts, WithService("my-redis"))
 		_, err := client.Get("non_existent_key").Result()
 
 		spans := mt.FinishedSpans()
@@ -406,7 +406,7 @@ func TestWithContext(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client1 := NewClient(opts, WithServiceName("my-redis"))
+	client1 := NewClient(opts, WithService("my-redis"))
 	s1, ctx1 := tracer.StartSpanFromContext(context.Background(), "span1.name")
 	client1 = client1.WithContext(ctx1)
 	s2, ctx2 := tracer.StartSpanFromContext(context.Background(), "span2.name")
@@ -445,7 +445,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []ClientOption
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/go.mongodb.org/mongo-driver/mongo/mongo_test.go
+++ b/v2/contrib/go.mongodb.org/mongo-driver/mongo/mongo_test.go
@@ -144,7 +144,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/go.mongodb.org/mongo-driver/mongo/option.go
+++ b/v2/contrib/go.mongodb.org/mongo-driver/mongo/option.go
@@ -46,10 +46,10 @@ func defaults(cfg *config) {
 	}
 }
 
-// WithServiceName sets the given service name for the dialled connection.
+// WithService sets the given service name for the dialled connection.
 // When the service name is not explicitly set it will be inferred based on the
 // request to AWS.
-func WithServiceName(name string) OptionFn {
+func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/gocql/gocql/example_test.go
+++ b/v2/contrib/gocql/gocql/example_test.go
@@ -15,7 +15,7 @@ import (
 
 func Example() {
 	// Initialise a wrapped Cassandra session and create a query.
-	cluster := gocqltrace.NewCluster([]string{"127.0.0.1"}, gocqltrace.WithServiceName("ServiceName"))
+	cluster := gocqltrace.NewCluster([]string{"127.0.0.1"}, gocqltrace.WithService("ServiceName"))
 	session, _ := cluster.CreateSession()
 	query := session.Query("CREATE KEYSPACE if not exists trace WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor': 1}")
 

--- a/v2/contrib/gocql/gocql/option.go
+++ b/v2/contrib/gocql/gocql/option.go
@@ -55,8 +55,8 @@ func defaultConfig() *queryConfig {
 	return cfg
 }
 
-// WithServiceName sets the given service name for the returned query.
-func WithServiceName(name string) WrapOptionFn {
+// WithService sets the given service name for the returned query.
+func WithService(name string) WrapOptionFn {
 	return func(cfg *queryConfig) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/gofiber/fiber.v2/example_test.go
+++ b/v2/contrib/gofiber/fiber.v2/example_test.go
@@ -41,7 +41,7 @@ func Example_withServiceName() {
 	router := fiber.New()
 
 	// Use the tracer middleware with your desired service name.
-	router.Use(fibertrace.Middleware(fibertrace.WithServiceName("fiber")))
+	router.Use(fibertrace.Middleware(fibertrace.WithService("fiber")))
 
 	// Set up some endpoints.
 	router.Get("/", func(c *fiber.Ctx) error {

--- a/v2/contrib/gofiber/fiber.v2/fiber_test.go
+++ b/v2/contrib/gofiber/fiber.v2/fiber_test.go
@@ -28,7 +28,7 @@ func TestChildSpan(t *testing.T) {
 	defer mt.Stop()
 
 	router := fiber.New()
-	router.Use(Middleware(WithServiceName("foobar")))
+	router.Use(Middleware(WithService("foobar")))
 	router.Get("/user/:id", func(c *fiber.Ctx) error {
 		return c.SendString(c.Params("id"))
 	})
@@ -79,7 +79,7 @@ func TestTrace200(t *testing.T) {
 		defer mt.Stop()
 
 		router := fiber.New()
-		router.Use(Middleware(WithServiceName("foobar")))
+		router.Use(Middleware(WithService("foobar")))
 		router.Get("/user/:id", func(c *fiber.Ctx) error {
 			return c.SendString(c.Params("id"))
 		})
@@ -93,7 +93,7 @@ func TestTrace200(t *testing.T) {
 		defer mt.Stop()
 
 		router := fiber.New()
-		router.Use(Middleware(WithServiceName("foobar")))
+		router.Use(Middleware(WithService("foobar")))
 		router.Get("/user/:id", func(c *fiber.Ctx) error {
 			return c.SendString(c.Params("id"))
 		})
@@ -108,7 +108,7 @@ func TestStatusError(t *testing.T) {
 
 	// setup
 	router := fiber.New()
-	router.Use(Middleware(WithServiceName("foobar")))
+	router.Use(Middleware(WithService("foobar")))
 	code := 500
 	wantErr := fmt.Sprintf("%d: %s", code, http.StatusText(code))
 
@@ -143,7 +143,7 @@ func TestCustomError(t *testing.T) {
 	defer mt.Stop()
 
 	router := fiber.New()
-	router.Use(Middleware(WithServiceName("foobar")))
+	router.Use(Middleware(WithService("foobar")))
 
 	router.Get("/err", func(c *fiber.Ctx) error {
 		c.SendStatus(400)
@@ -178,7 +178,7 @@ func TestUserContext(t *testing.T) {
 
 	// setup
 	router := fiber.New()
-	router.Use(Middleware(WithServiceName("foobar")))
+	router.Use(Middleware(WithService("foobar")))
 
 	router.Get("/", func(c *fiber.Ctx) error {
 		// check if not default empty context
@@ -225,7 +225,7 @@ func TestPropagation(t *testing.T) {
 	requestWithoutSpan := httptest.NewRequest("GET", "/span/exists/false", nil)
 
 	router := fiber.New()
-	router.Use(Middleware(WithServiceName("foobar")))
+	router.Use(Middleware(WithService("foobar")))
 	router.Get("/span/exists/true", func(c *fiber.Ctx) error {
 		s, _ := tracer.SpanFromContext(c.UserContext())
 		assert.Equal(s.Context().TraceID() == pspan.Context().TraceID(), true)
@@ -313,7 +313,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/gofiber/fiber.v2/option.go
+++ b/v2/contrib/gofiber/fiber.v2/option.go
@@ -52,8 +52,8 @@ func defaults(cfg *config) {
 	}
 }
 
-// WithServiceName sets the given service name for the router.
-func WithServiceName(name string) OptionFn {
+// WithService sets the given service name for the router.
+func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/gomodule/redigo/example_test.go
+++ b/v2/contrib/gomodule/redigo/example_test.go
@@ -40,7 +40,7 @@ func Example() {
 
 func Example_tracedConn() {
 	c, err := redigotrace.Dial("tcp", "127.0.0.1:6379",
-		redigotrace.WithServiceName("my-redis-backend"),
+		redigotrace.WithService("my-redis-backend"),
 		redis.DialKeepAlive(time.Minute),
 	)
 	if err != nil {
@@ -75,7 +75,7 @@ func Example_pool() {
 	pool := &redis.Pool{
 		Dial: func() (redis.Conn, error) {
 			return redigotrace.Dial("tcp", "127.0.0.1:6379",
-				redigotrace.WithServiceName("my-redis-backend"),
+				redigotrace.WithService("my-redis-backend"),
 			)
 		},
 	}

--- a/v2/contrib/gomodule/redigo/option.go
+++ b/v2/contrib/gomodule/redigo/option.go
@@ -56,8 +56,8 @@ func defaults(cfg *dialConfig) {
 	cfg.connectionType = connectionTypeWithTimeout
 }
 
-// WithServiceName sets the given service name for the dialled connection.
-func WithServiceName(name string) DialOptionFn {
+// WithService sets the given service name for the dialled connection.
+func WithService(name string) DialOptionFn {
 	return func(cfg *dialConfig) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/gomodule/redigo/redigo_test.go
+++ b/v2/contrib/gomodule/redigo/redigo_test.go
@@ -37,7 +37,7 @@ func TestClient(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	c, err := Dial("tcp", "127.0.0.1:6379", WithServiceName("my-service"))
+	c, err := Dial("tcp", "127.0.0.1:6379", WithService("my-service"))
 	assert.Nil(err)
 	c.Do("SET", 1, "truck")
 
@@ -63,7 +63,7 @@ func TestCommandError(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	c, err := Dial("tcp", "127.0.0.1:6379", WithServiceName("my-service"))
+	c, err := Dial("tcp", "127.0.0.1:6379", WithService("my-service"))
 	assert.Nil(err)
 	_, err = c.Do("NOT_A_COMMAND", context.Background())
 	assert.NotNil(err)
@@ -89,7 +89,7 @@ func TestConnectionError(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	_, err := Dial("tcp", "127.0.0.1:1000", WithServiceName("redis-service"))
+	_, err := Dial("tcp", "127.0.0.1:1000", WithService("redis-service"))
 
 	assert.NotNil(err)
 	assert.Contains(err.Error(), "dial tcp 127.0.0.1:1000")
@@ -101,7 +101,7 @@ func TestInheritance(t *testing.T) {
 	defer mt.Stop()
 
 	root, ctx := tracer.StartSpanFromContext(context.Background(), "parent.span")
-	client, err := Dial("tcp", "127.0.0.1:6379", WithServiceName("redis-service"))
+	client, err := Dial("tcp", "127.0.0.1:6379", WithService("redis-service"))
 	assert.Nil(err)
 	client.Do("SET", "water", "bottle", ctx)
 	root.Finish()
@@ -139,7 +139,7 @@ func TestCommandsToSring(t *testing.T) {
 	defer mt.Stop()
 
 	str := stringifyTest{A: 57, B: 8}
-	c, err := Dial("tcp", "127.0.0.1:6379", WithServiceName("my-service"))
+	c, err := Dial("tcp", "127.0.0.1:6379", WithService("my-service"))
 	assert.Nil(err)
 	c.Do("SADD", "testSet", "a", int(0), int32(1), int64(2), str, context.Background())
 
@@ -169,7 +169,7 @@ func TestPool(t *testing.T) {
 		IdleTimeout: 23,
 		Wait:        true,
 		Dial: func() (redis.Conn, error) {
-			return Dial("tcp", "127.0.0.1:6379", WithServiceName("my-service"))
+			return Dial("tcp", "127.0.0.1:6379", WithService("my-service"))
 		},
 	}
 
@@ -188,7 +188,7 @@ func TestTracingDialUrl(t *testing.T) {
 	defer mt.Stop()
 
 	url := "redis://127.0.0.1:6379"
-	client, err := DialURL(url, WithServiceName("redis-service"))
+	client, err := DialURL(url, WithService("redis-service"))
 	assert.Nil(err)
 	client.Do("SET", "ONE", " TWO", context.Background())
 
@@ -202,7 +202,7 @@ func TestTracingDialContext(t *testing.T) {
 	defer mt.Stop()
 
 	ctx := context.Background()
-	client, err := DialContext(ctx, "tcp", "127.0.0.1:6379", WithServiceName("my-service"))
+	client, err := DialContext(ctx, "tcp", "127.0.0.1:6379", WithService("my-service"))
 	assert.Nil(err)
 
 	_, _ = client.Do("SET", "ONE", " TWO", ctx)
@@ -285,7 +285,7 @@ func TestDoWithTimeout(t *testing.T) {
 	defer mt.Stop()
 
 	url := "redis://127.0.0.1:6379"
-	client, err := DialURL(url, WithServiceName("redis-service"), WithTimeoutConnection())
+	client, err := DialURL(url, WithService("redis-service"), WithTimeoutConnection())
 	assert.Nil(err)
 	_, err = redis.DoWithTimeout(client, time.Second, "SET", "ONE", " TWO")
 	assert.NoError(err)
@@ -301,7 +301,7 @@ func TestDo(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		client, err := Dial("tcp", "127.0.0.1:6379", WithServiceName("my-service"), WithContextConnection())
+		client, err := Dial("tcp", "127.0.0.1:6379", WithService("my-service"), WithContextConnection())
 		assert.Nil(err)
 		_, err = client.Do("SET", "ONE", " TWO")
 		assert.NoError(err)
@@ -314,7 +314,7 @@ func TestDo(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		client, err := Dial("tcp", "127.0.0.1:6379", WithServiceName("my-service"), WithDefaultConnection())
+		client, err := Dial("tcp", "127.0.0.1:6379", WithService("my-service"), WithDefaultConnection())
 		assert.Nil(err)
 		_, err = client.Do("SET", "ONE", " TWO")
 		assert.NoError(err)
@@ -331,7 +331,7 @@ func TestDoContext(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		client, err := Dial("tcp", "127.0.0.1:6379", WithServiceName("my-service"), WithContextConnection())
+		client, err := Dial("tcp", "127.0.0.1:6379", WithService("my-service"), WithContextConnection())
 		assert.Nil(err)
 		_, err = redis.DoContext(client, context.Background(), "SET", "ONE", " TWO")
 		assert.NoError(err)
@@ -349,7 +349,7 @@ func TestDoContext(t *testing.T) {
 		span, ctx := tracer.StartSpanFromContext(context.Background(), "test", tracer.WithSpanID(parentSpanID))
 		defer span.Finish()
 
-		client, err := Dial("tcp", "127.0.0.1:6379", WithServiceName("my-service"), WithContextConnection())
+		client, err := Dial("tcp", "127.0.0.1:6379", WithService("my-service"), WithContextConnection())
 		assert.Nil(err)
 		_, err = redis.DoContext(client, ctx, "SET", "ONE", " TWO")
 		assert.NoError(err)
@@ -365,7 +365,7 @@ func TestDoContext(t *testing.T) {
 		defer mt.Stop()
 
 		url := "redis://127.0.0.1:6379"
-		client, err := DialURL(url, WithServiceName("redis-service"), WithContextConnection())
+		client, err := DialURL(url, WithService("redis-service"), WithContextConnection())
 		assert.Nil(err)
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
@@ -383,7 +383,7 @@ func TestDoContext(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		client, err := DialContext(context.Background(), "tcp", "127.0.0.1:6379", WithServiceName("my-service"), WithContextConnection())
+		client, err := DialContext(context.Background(), "tcp", "127.0.0.1:6379", WithService("my-service"), WithContextConnection())
 		assert.Nil(err)
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
@@ -400,7 +400,7 @@ func TestDoContext(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		client, err := DialContext(context.Background(), "tcp", "127.0.0.1:6379", WithServiceName("my-service"), WithContextConnection())
+		client, err := DialContext(context.Background(), "tcp", "127.0.0.1:6379", WithService("my-service"), WithContextConnection())
 		assert.Nil(err)
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
@@ -418,7 +418,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []interface{}
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/google.golang.org/api/option.go
+++ b/v2/contrib/google.golang.org/api/option.go
@@ -64,9 +64,9 @@ func WithScopes(scopes ...string) OptionFn {
 	}
 }
 
-// WithServiceName sets the service name in the config. The default service
+// WithService sets the service name in the config. The default service
 // name is inferred from the API definitions based on the http request route.
-func WithServiceName(serviceName string) OptionFn {
+func WithService(serviceName string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = serviceName
 	}

--- a/v2/contrib/google.golang.org/grpc/appsec_test.go
+++ b/v2/contrib/google.golang.org/grpc/appsec_test.go
@@ -356,7 +356,7 @@ func TestUserBlocking(t *testing.T) {
 }
 
 func newAppsecRig(traceClient bool, interceptorOpts ...Option) (*appsecRig, error) {
-	interceptorOpts = append([]Option{WithServiceName("grpc")}, interceptorOpts...)
+	interceptorOpts = append([]Option{WithService("grpc")}, interceptorOpts...)
 
 	server := grpc.NewServer(
 		grpc.UnaryInterceptor(UnaryServerInterceptor(interceptorOpts...)),

--- a/v2/contrib/google.golang.org/grpc/example_test.go
+++ b/v2/contrib/google.golang.org/grpc/example_test.go
@@ -16,8 +16,8 @@ import (
 
 func Example_client() {
 	// Create the client interceptor using the grpc trace package.
-	si := grpctrace.StreamClientInterceptor(grpctrace.WithServiceName("my-grpc-client"))
-	ui := grpctrace.UnaryClientInterceptor(grpctrace.WithServiceName("my-grpc-client"))
+	si := grpctrace.StreamClientInterceptor(grpctrace.WithService("my-grpc-client"))
+	ui := grpctrace.UnaryClientInterceptor(grpctrace.WithService("my-grpc-client"))
 
 	// Dial in using the created interceptor.
 	// Note: To use multiple UnaryInterceptors with grpc.Dial, you must use
@@ -40,8 +40,8 @@ func Example_server() {
 	}
 
 	// Create the server interceptor using the grpc trace package.
-	si := grpctrace.StreamServerInterceptor(grpctrace.WithServiceName("my-grpc-server"))
-	ui := grpctrace.UnaryServerInterceptor(grpctrace.WithServiceName("my-grpc-server"))
+	si := grpctrace.StreamServerInterceptor(grpctrace.WithService("my-grpc-server"))
+	ui := grpctrace.UnaryServerInterceptor(grpctrace.WithService("my-grpc-server"))
 
 	// Initialize the grpc server as normal, using the tracing interceptor.
 	s := grpc.NewServer(grpc.StreamInterceptor(si), grpc.UnaryInterceptor(ui))

--- a/v2/contrib/google.golang.org/grpc/grpc_test.go
+++ b/v2/contrib/google.golang.org/grpc/grpc_test.go
@@ -62,7 +62,7 @@ func TestUnary(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			rig, err := newRig(true, WithServiceName("grpc"), WithRequestTags())
+			rig, err := newRig(true, WithService("grpc"), WithRequestTags())
 			require.NoError(t, err, "error setting up rig")
 			defer rig.Close()
 			client := rig.client
@@ -224,7 +224,7 @@ func TestStreaming(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		rig, err := newRig(true, WithServiceName("grpc"))
+		rig, err := newRig(true, WithService("grpc"))
 		require.NoError(t, err, "error setting up rig")
 		defer rig.Close()
 
@@ -249,7 +249,7 @@ func TestStreaming(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		rig, err := newRig(true, WithServiceName("grpc"), WithStreamMessages(false))
+		rig, err := newRig(true, WithService("grpc"), WithStreamMessages(false))
 		require.NoError(t, err, "error setting up rig")
 		defer rig.Close()
 
@@ -274,7 +274,7 @@ func TestStreaming(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		rig, err := newRig(true, WithServiceName("grpc"), WithStreamCalls(false))
+		rig, err := newRig(true, WithService("grpc"), WithStreamCalls(false))
 		require.NoError(t, err, "error setting up rig")
 		defer rig.Close()
 
@@ -316,7 +316,7 @@ func TestSpanTree(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		rig, err := newRig(true, WithServiceName("grpc"))
+		rig, err := newRig(true, WithService("grpc"))
 		require.NoError(t, err, "error setting up rig")
 		defer rig.Close()
 
@@ -351,7 +351,7 @@ func TestSpanTree(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		rig, err := newRig(true, WithServiceName("grpc"), WithRequestTags(), WithMetadataTags())
+		rig, err := newRig(true, WithService("grpc"), WithRequestTags(), WithMetadataTags())
 		require.NoError(t, err, "error setting up rig")
 		defer rig.Close()
 		client := rig.client
@@ -436,7 +436,7 @@ func TestPass(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	rig, err := newRig(false, WithServiceName("grpc"))
+	rig, err := newRig(false, WithService("grpc"))
 	require.NoError(t, err, "error setting up rig")
 	defer rig.Close()
 	client := rig.client
@@ -1011,7 +1011,7 @@ func getGenSpansFn(traceClient, traceServer bool) namingschematest.GenSpansFn {
 	return func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		// exclude the grpc.message spans as they are not affected by naming schema
 		opts = append(opts, WithStreamMessages(false))

--- a/v2/contrib/google.golang.org/grpc/option.go
+++ b/v2/contrib/google.golang.org/grpc/option.go
@@ -94,8 +94,8 @@ func serverDefaults(cfg *config) {
 	defaults(cfg)
 }
 
-// WithServiceName sets the given service name for the intercepted client.
-func WithServiceName(name string) OptionFn {
+// WithService sets the given service name for the intercepted client.
+func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = func() string { return name }
 	}

--- a/v2/contrib/google.golang.org/grpc/stats_client_test.go
+++ b/v2/contrib/google.golang.org/grpc/stats_client_test.go
@@ -23,7 +23,7 @@ func TestClientStatsHandler(t *testing.T) {
 	assert := assert.New(t)
 
 	serviceName := "grpc-service"
-	statsHandler := NewClientStatsHandler(WithServiceName(serviceName), WithSpanOptions(tracer.Tag("foo", "bar")))
+	statsHandler := NewClientStatsHandler(WithService(serviceName), WithSpanOptions(tracer.Tag("foo", "bar")))
 	server, err := newClientStatsHandlerTestServer(statsHandler)
 	if err != nil {
 		t.Fatalf("failed to start test server: %s", err)

--- a/v2/contrib/google.golang.org/grpc/stats_server_test.go
+++ b/v2/contrib/google.golang.org/grpc/stats_server_test.go
@@ -23,7 +23,7 @@ func TestServerStatsHandler(t *testing.T) {
 	assert := assert.New(t)
 
 	serviceName := "grpc-service"
-	statsHandler := NewServerStatsHandler(WithServiceName(serviceName), WithSpanOptions(tracer.Tag("foo", "bar")))
+	statsHandler := NewServerStatsHandler(WithService(serviceName), WithSpanOptions(tracer.Tag("foo", "bar")))
 	server, err := newServerStatsHandlerTestServer(statsHandler)
 	if err != nil {
 		t.Fatalf("failed to start test server: %s", err)

--- a/v2/contrib/gorilla/mux/example_test.go
+++ b/v2/contrib/gorilla/mux/example_test.go
@@ -22,7 +22,7 @@ func Example() {
 }
 
 func Example_withServiceName() {
-	mux := muxtrace.NewRouter(muxtrace.WithServiceName("mux.route"))
+	mux := muxtrace.NewRouter(muxtrace.WithService("mux.route"))
 	mux.HandleFunc("/", handler)
 	http.ListenAndServe(":8080", mux)
 }

--- a/v2/contrib/gorilla/mux/mux_test.go
+++ b/v2/contrib/gorilla/mux/mux_test.go
@@ -121,7 +121,7 @@ func TestDomain(t *testing.T) {
 	assert := assert.New(t)
 	mt := mocktracer.Start()
 	defer mt.Stop()
-	mux := NewRouter(WithServiceName("my-service"))
+	mux := NewRouter(WithService("my-service"))
 	mux.Handle("/200", okHandler()).Host("localhost")
 	r := httptest.NewRequest("GET", "http://localhost/200", nil)
 	w := httptest.NewRecorder()
@@ -384,7 +384,7 @@ func TestResourceNamer(t *testing.T) {
 }
 
 func router() http.Handler {
-	mux := NewRouter(WithServiceName("my-service"))
+	mux := NewRouter(WithService("my-service"))
 	mux.Handle("/200", okHandler())
 	mux.Handle("/500", errorHandler(http.StatusInternalServerError))
 	mux.Handle("/405", okHandler()).Methods("GET")
@@ -540,7 +540,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []RouterOption
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/gorilla/mux/option.go
+++ b/v2/contrib/gorilla/mux/option.go
@@ -75,8 +75,8 @@ func WithIgnoreRequest(f func(*http.Request) bool) RouterOptionFn {
 	}
 }
 
-// WithServiceName sets the given service name for the router.
-func WithServiceName(name string) RouterOptionFn {
+// WithService sets the given service name for the router.
+func WithService(name string) RouterOptionFn {
 	return func(cfg *routerConfig) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/gorm.io/gorm.v1/example_test.go
+++ b/v2/contrib/gorm.io/gorm.v1/example_test.go
@@ -26,7 +26,7 @@ type User struct {
 
 func ExampleOpen() {
 	// Register augments the provided driver with tracing, enabling it to be loaded by gormtrace.Open.
-	sqltrace.Register("pgx", &stdlib.Driver{}, sqltrace.WithServiceName("my-service"))
+	sqltrace.Register("pgx", &stdlib.Driver{}, sqltrace.WithService("my-service"))
 	sqlDb, err := sqltrace.Open("pgx", "postgres://pqgotest:password@localhost/pqgotest?sslmode=disable")
 	if err != nil {
 		log.Fatal(err)
@@ -43,7 +43,7 @@ func ExampleOpen() {
 
 func ExampleContext() {
 	// Register augments the provided driver with tracing, enabling it to be loaded by gormtrace.Open.
-	sqltrace.Register("pgx", &stdlib.Driver{}, sqltrace.WithServiceName("my-service"))
+	sqltrace.Register("pgx", &stdlib.Driver{}, sqltrace.WithService("my-service"))
 	sqlDb, err := sqltrace.Open("pgx", "postgres://pqgotest:password@localhost/pqgotest?sslmode=disable")
 	if err != nil {
 		log.Fatal(err)

--- a/v2/contrib/gorm.io/gorm.v1/gorm_test.go
+++ b/v2/contrib/gorm.io/gorm.v1/gorm_test.go
@@ -51,7 +51,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestMySQL(t *testing.T) {
-	sqltrace.Register("mysql", &mysql.MySQLDriver{}, sqltrace.WithServiceName("mysql-test"))
+	sqltrace.Register("mysql", &mysql.MySQLDriver{}, sqltrace.WithService("mysql-test"))
 	sqlDb, err := sqltrace.Open("mysql", mysqlConnString)
 	if err != nil {
 		log.Fatal(err)

--- a/v2/contrib/gorm.io/gorm.v1/option.go
+++ b/v2/contrib/gorm.io/gorm.v1/option.go
@@ -45,9 +45,9 @@ func defaults(cfg *config) {
 	cfg.tagFns = make(map[string]func(db *gorm.DB) interface{})
 }
 
-// WithServiceName sets the given service name when registering a driver,
+// WithService sets the given service name when registering a driver,
 // or opening a database connection.
-func WithServiceName(name string) OptionFn {
+func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/graph-gophers/graphql-go/graphql_test.go
+++ b/v2/contrib/graph-gophers/graphql-go/graphql_test.go
@@ -45,7 +45,7 @@ func newTestServer(opts ...Option) *httptest.Server {
 
 func Test(t *testing.T) {
 	makeRequest := func(opts ...Option) {
-		opts = append([]Option{WithServiceName("test-graphql-service")}, opts...)
+		opts = append([]Option{WithService("test-graphql-service")}, opts...)
 		srv := newTestServer(opts...)
 		defer srv.Close()
 		q := `{"query": "query TestQuery() { hello, helloNonTrivial }", "operationName": "TestQuery"}`
@@ -194,7 +194,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/graph-gophers/graphql-go/option.go
+++ b/v2/contrib/graph-gophers/graphql-go/option.go
@@ -45,8 +45,8 @@ func defaults(cfg *config) {
 	}
 }
 
-// WithServiceName sets the given service name for the client.
-func WithServiceName(name string) OptionFn {
+// WithService sets the given service name for the client.
+func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/graphql-go/graphql/appsec_test.go
+++ b/v2/contrib/graphql-go/graphql/appsec_test.go
@@ -78,7 +78,7 @@ func TestAppSec(t *testing.T) {
 			},
 		},
 	})
-	opts := []Option{WithServiceName("test-graphql-service")}
+	opts := []Option{WithService("test-graphql-service")}
 	schema, err := NewSchema(graphql.SchemaConfig{Query: rootQuery}, opts...)
 	require.NoError(t, err)
 	restore := enableAppSec(t)

--- a/v2/contrib/graphql-go/graphql/bench_test.go
+++ b/v2/contrib/graphql-go/graphql/bench_test.go
@@ -152,7 +152,7 @@ func BenchmarkGraphQL(b *testing.B) {
 			b.Run(fmt.Sprintf("scenario=%s", name), func(b *testing.B) {
 				b.StopTimer()
 				b.ReportAllocs()
-				opts := []Option{WithServiceName("test-graphql-service")}
+				opts := []Option{WithService("test-graphql-service")}
 				schema, err := NewSchema(
 					graphql.SchemaConfig{
 						Query: rootQuery,

--- a/v2/contrib/graphql-go/graphql/graphql_test.go
+++ b/v2/contrib/graphql-go/graphql/graphql_test.go
@@ -35,7 +35,7 @@ func Test(t *testing.T) {
 			},
 		},
 	})
-	opts := []Option{WithServiceName("test-graphql-service")}
+	opts := []Option{WithService("test-graphql-service")}
 	schema, err := NewSchema(
 		graphql.SchemaConfig{
 			Query: rootQuery,

--- a/v2/contrib/graphql-go/graphql/option.go
+++ b/v2/contrib/graphql-go/graphql/option.go
@@ -63,8 +63,8 @@ func WithAnalyticsRate(rate float64) OptionFn {
 	}
 }
 
-// WithServiceName sets the given service name for the client.
-func WithServiceName(name string) OptionFn {
+// WithService sets the given service name for the client.
+func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/hashicorp/consul/consul_test.go
+++ b/v2/contrib/hashicorp/consul/consul_test.go
@@ -111,7 +111,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []ClientOption
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 
 		mt := mocktracer.Start()

--- a/v2/contrib/hashicorp/consul/example_test.go
+++ b/v2/contrib/hashicorp/consul/example_test.go
@@ -19,7 +19,7 @@ import (
 // Here's an example illustrating a simple use case for interacting with consul with tracing enabled.
 func Example() {
 	// Get a new Consul client
-	client, err := NewClient(consul.DefaultConfig(), WithServiceName("consul.example"))
+	client, err := NewClient(consul.DefaultConfig(), WithService("consul.example"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/v2/contrib/hashicorp/consul/option.go
+++ b/v2/contrib/hashicorp/consul/option.go
@@ -55,8 +55,8 @@ func defaults(cfg *clientConfig) {
 	}
 }
 
-// WithServiceName sets the given service name for the client.
-func WithServiceName(name string) ClientOptionFn {
+// WithService sets the given service name for the client.
+func WithService(name string) ClientOptionFn {
 	return func(cfg *clientConfig) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/hashicorp/vault/example_test.go
+++ b/v2/contrib/hashicorp/vault/example_test.go
@@ -31,7 +31,7 @@ func ExampleNewHTTPClient() {
 func ExampleNewHTTPClient_withOptions() {
 	c, err := api.NewClient(&api.Config{
 		HttpClient: vaulttrace.NewHTTPClient(
-			vaulttrace.WithServiceName("my.vault"),
+			vaulttrace.WithService("my.vault"),
 			vaulttrace.WithAnalytics(true),
 		),
 		Address: "http://vault.mydomain.com:8200",
@@ -81,7 +81,7 @@ func ExampleWrapHTTPClient_withOptions() {
 	client, err := api.NewClient(&api.Config{
 		HttpClient: vaulttrace.WrapHTTPClient(
 			c,
-			vaulttrace.WithServiceName("my.vault"),
+			vaulttrace.WithService("my.vault"),
 			vaulttrace.WithAnalytics(true),
 		),
 		Address: "http://vault.mydomain.com:8200",

--- a/v2/contrib/hashicorp/vault/option.go
+++ b/v2/contrib/hashicorp/vault/option.go
@@ -65,8 +65,8 @@ func WithAnalyticsRate(rate float64) OptionFn {
 	}
 }
 
-// WithServiceName sets the given service name for the http.Client.
-func WithServiceName(name string) OptionFn {
+// WithService sets the given service name for the http.Client.
+func WithService(name string) OptionFn {
 	return func(c *config) {
 		c.serviceName = name
 	}

--- a/v2/contrib/hashicorp/vault/vault_test.go
+++ b/v2/contrib/hashicorp/vault/vault_test.go
@@ -359,7 +359,7 @@ func TestOption(t *testing.T) {
 			},
 		},
 		"CustomServiceName": {
-			opts: []Option{WithServiceName("someServiceName")},
+			opts: []Option{WithService("someServiceName")},
 			test: func(assert *assert.Assertions, span mocktracer.Span) {
 				assert.Equal("someServiceName", span.Tag(ext.ServiceName))
 			},
@@ -435,7 +435,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 
 		mt := mocktracer.Start()

--- a/v2/contrib/jmoiron/sqlx/example_test.go
+++ b/v2/contrib/jmoiron/sqlx/example_test.go
@@ -19,7 +19,7 @@ func ExampleOpen() {
 	// Register informs the sqlxtrace package of the driver that we will be using in our program.
 	// It uses a default service name, in the below case "postgres.db". To use a custom service
 	// name use RegisterWithServiceName.
-	sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithServiceName("my-service"))
+	sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithService("my-service"))
 	db, err := sqlxtrace.Open("postgres", "postgres://pqgotest:password@localhost/pqgotest?sslmode=disable")
 	if err != nil {
 		log.Fatal(err)

--- a/v2/contrib/jmoiron/sqlx/sql_test.go
+++ b/v2/contrib/jmoiron/sqlx/sql_test.go
@@ -36,7 +36,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestMySQL(t *testing.T) {
-	sqltrace.Register("mysql", &mysql.MySQLDriver{}, sqltrace.WithServiceName("mysql-test"))
+	sqltrace.Register("mysql", &mysql.MySQLDriver{}, sqltrace.WithService("mysql-test"))
 	dbx, err := Open("mysql", "test:test@tcp(127.0.0.1:3306)/test")
 	if err != nil {
 		log.Fatal(err)
@@ -111,8 +111,8 @@ func TestSQLServer(t *testing.T) {
 }
 
 func TestOpenWithOptions(t *testing.T) {
-	sqltrace.Register("mysql", &mysql.MySQLDriver{}, sqltrace.WithServiceName("mysql-test"))
-	dbx, err := Open("mysql", "test:test@tcp(127.0.0.1:3306)/test", sqltrace.WithServiceName("other-service"))
+	sqltrace.Register("mysql", &mysql.MySQLDriver{}, sqltrace.WithService("mysql-test"))
+	dbx, err := Open("mysql", "test:test@tcp(127.0.0.1:3306)/test", sqltrace.WithService("other-service"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/v2/contrib/julienschmidt/httprouter/example_test.go
+++ b/v2/contrib/julienschmidt/httprouter/example_test.go
@@ -34,7 +34,7 @@ func Example() {
 }
 
 func Example_withServiceName() {
-	router := httptrace.New(httptrace.WithServiceName("http.router"))
+	router := httptrace.New(httptrace.WithService("http.router"))
 	router.GET("/", Index)
 	router.GET("/hello/:name", Hello)
 
@@ -43,7 +43,7 @@ func Example_withServiceName() {
 
 func Example_withSpanOpts() {
 	router := httptrace.New(
-		httptrace.WithServiceName("http.router"),
+		httptrace.WithService("http.router"),
 		httptrace.WithSpanOptions(
 			tracer.Tag(ext.SamplingPriority, ext.PriorityUserKeep),
 		),

--- a/v2/contrib/julienschmidt/httprouter/httprouter_test.go
+++ b/v2/contrib/julienschmidt/httprouter/httprouter_test.go
@@ -172,7 +172,7 @@ func TestAnalyticsSettings(t *testing.T) {
 
 func router() http.Handler {
 	router := New(
-		WithServiceName("my-service"),
+		WithService("my-service"),
 		WithSpanOptions(tracer.Tag("testkey", "testvalue")),
 	)
 
@@ -199,7 +199,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []RouterOption
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/julienschmidt/httprouter/option.go
+++ b/v2/contrib/julienschmidt/httprouter/option.go
@@ -46,8 +46,8 @@ func defaults(cfg *routerConfig) {
 	cfg.headerTags = globalconfig.HeaderTagMap()
 }
 
-// WithServiceName sets the given service name for the returned router.
-func WithServiceName(name string) RouterOptionFn {
+// WithService sets the given service name for the returned router.
+func WithService(name string) RouterOptionFn {
 	return func(cfg *routerConfig) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/labstack/echo.v4/echotrace_test.go
+++ b/v2/contrib/labstack/echo.v4/echotrace_test.go
@@ -32,7 +32,7 @@ func TestChildSpan(t *testing.T) {
 	var called, traced bool
 
 	router := echo.New()
-	router.Use(Middleware(WithServiceName("foobar")))
+	router.Use(Middleware(WithService("foobar")))
 	router.GET("/user/:id", func(c echo.Context) error {
 		called = true
 		_, traced = tracer.SpanFromContext(c.Request().Context())
@@ -55,7 +55,7 @@ func TestTrace200(t *testing.T) {
 	var called, traced bool
 
 	router := echo.New()
-	router.Use(Middleware(WithServiceName("foobar"), WithAnalytics(false)))
+	router.Use(Middleware(WithService("foobar"), WithAnalytics(false)))
 	router.GET("/user/:id", func(c echo.Context) error {
 		called = true
 		var span tracer.Span
@@ -104,7 +104,7 @@ func TestTraceAnalytics(t *testing.T) {
 	var called, traced bool
 
 	router := echo.New()
-	router.Use(Middleware(WithServiceName("foobar"), WithAnalytics(true)))
+	router.Use(Middleware(WithService("foobar"), WithAnalytics(true)))
 	router.GET("/user/:id", func(c echo.Context) error {
 		called = true
 		var span tracer.Span
@@ -154,7 +154,7 @@ func TestError(t *testing.T) {
 
 	// setup
 	router := echo.New()
-	router.Use(Middleware(WithServiceName("foobar")))
+	router.Use(Middleware(WithService("foobar")))
 	wantErr := errors.New("oh no")
 
 	// a handler with an error and make the requests
@@ -197,7 +197,7 @@ func TestErrorHandling(t *testing.T) {
 	router.HTTPErrorHandler = func(err error, ctx echo.Context) {
 		ctx.Response().WriteHeader(http.StatusInternalServerError)
 	}
-	router.Use(Middleware(WithServiceName("foobar")))
+	router.Use(Middleware(WithService("foobar")))
 	wantErr := errors.New("oh no")
 
 	// a handler with an error and make the requests
@@ -304,7 +304,7 @@ func TestStatusError(t *testing.T) {
 			defer mt.Stop()
 
 			router := echo.New()
-			opts := []Option{WithServiceName("foobar")}
+			opts := []Option{WithService("foobar")}
 			if tt.isStatusError != nil {
 				opts = append(opts, WithStatusCheck(tt.isStatusError))
 			}
@@ -480,7 +480,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()
@@ -598,7 +598,7 @@ func TestWithCustomTags(t *testing.T) {
 	// setup
 	router := echo.New()
 	router.Use(Middleware(
-		WithServiceName("foobar"),
+		WithService("foobar"),
 		WithCustomTag("customTag1", "customValue1"),
 		WithCustomTag("customTag2", "customValue2"),
 		WithCustomTag(ext.SpanKind, "replace me"),

--- a/v2/contrib/labstack/echo.v4/example_test.go
+++ b/v2/contrib/labstack/echo.v4/example_test.go
@@ -23,7 +23,7 @@ func Example() {
 	r := echo.New()
 
 	// Use the tracer middleware with your desired service name.
-	r.Use(echotrace.Middleware(echotrace.WithServiceName("my-web-app")))
+	r.Use(echotrace.Middleware(echotrace.WithService("my-web-app")))
 
 	// Set up an endpoint.
 	r.GET("/hello", func(c echo.Context) error {
@@ -40,7 +40,7 @@ func Example_spanFromContext() {
 	r := echo.New()
 
 	// Use the tracer middleware with your desired service name.
-	r.Use(echotrace.Middleware(echotrace.WithServiceName("image-encoder")))
+	r.Use(echotrace.Middleware(echotrace.WithService("image-encoder")))
 
 	// Set up some endpoints.
 	r.GET("/image/encode", func(c echo.Context) error {

--- a/v2/contrib/labstack/echo.v4/option.go
+++ b/v2/contrib/labstack/echo.v4/option.go
@@ -60,8 +60,8 @@ func defaults(cfg *config) {
 	}
 }
 
-// WithServiceName sets the given service name for the system.
-func WithServiceName(name string) OptionFn {
+// WithService sets the given service name for the system.
+func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/net/http/example_test.go
+++ b/v2/contrib/net/http/example_test.go
@@ -20,7 +20,7 @@ func Example() {
 }
 
 func Example_withServiceName() {
-	mux := httptrace.NewServeMux(httptrace.WithServiceName("my-service"))
+	mux := httptrace.NewServeMux(httptrace.WithService("my-service"))
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("Hello World!\n"))
 	})

--- a/v2/contrib/net/http/http_test.go
+++ b/v2/contrib/net/http/http_test.go
@@ -460,7 +460,7 @@ func TestServerNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()
@@ -478,7 +478,7 @@ func TestServerNamingSchema(t *testing.T) {
 
 func router(muxOpts ...Option) http.Handler {
 	defaultOpts := []Option{
-		WithServiceName("my-service"),
+		WithService("my-service"),
 		WithSpanOptions(tracer.Tag("foo", "bar")),
 	}
 	mux := NewServeMux(append(defaultOpts, muxOpts...)...)

--- a/v2/contrib/net/http/option.go
+++ b/v2/contrib/net/http/option.go
@@ -81,8 +81,8 @@ func WithIgnoreRequest(f func(*http.Request) bool) OptionFn {
 	}
 }
 
-// WithServiceName sets the given service name for the returned ServeMux.
-func WithServiceName(name string) OptionFn {
+// WithService sets the given service name for the returned ServeMux.
+func WithService(name string) OptionFn {
 	return func(cfg *commonConfig) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/net/http/roundtripper_test.go
+++ b/v2/contrib/net/http/roundtripper_test.go
@@ -458,7 +458,7 @@ func TestServiceName(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 		serviceName := "testServer"
-		rt := WrapRoundTripper(http.DefaultTransport, WithServiceName(serviceName))
+		rt := WrapRoundTripper(http.DefaultTransport, WithService(serviceName))
 		client := &http.Client{
 			Transport: rt,
 		}
@@ -475,7 +475,7 @@ func TestServiceName(t *testing.T) {
 		defer mt.Stop()
 		serviceName := "testServer"
 		rt := WrapRoundTripper(http.DefaultTransport,
-			WithServiceName("wrongServiceName"),
+			WithService("wrongServiceName"),
 			WithBefore(func(_ *http.Request, span ddtrace.Span) {
 				span.SetTag(ext.ServiceName, serviceName)
 			}),
@@ -586,7 +586,7 @@ func TestClientNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []RoundTripperOption
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/olivere/elastic/elastictrace_test.go
+++ b/v2/contrib/olivere/elastic/elastictrace_test.go
@@ -45,7 +45,7 @@ func TestClient(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	tc := NewHTTPClient(WithServiceName("my-es-service"))
+	tc := NewHTTPClient(WithService("my-es-service"))
 	client, err := elastic.NewClient(
 		elastic.SetURL(elasticURL),
 		elastic.SetHttpClient(tc),
@@ -80,7 +80,7 @@ func TestClientGzip(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	tc := NewHTTPClient(WithServiceName("my-es-service"))
+	tc := NewHTTPClient(WithService("my-es-service"))
 	client, err := elastic.NewClient(
 		elastic.SetURL(elasticURL),
 		elastic.SetHttpClient(tc),
@@ -121,7 +121,7 @@ func TestClientErrorCutoff(t *testing.T) {
 	}()
 	bodyCutoff = 10
 
-	tc := NewHTTPClient(WithServiceName("my-es-service"))
+	tc := NewHTTPClient(WithService("my-es-service"))
 	client, err := elastic.NewClient(
 		elastic.SetURL(elasticURL),
 		elastic.SetHttpClient(tc),
@@ -143,7 +143,7 @@ func TestClientFailure(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	tc := NewHTTPClient(WithServiceName("my-es-service"))
+	tc := NewHTTPClient(WithService("my-es-service"))
 	client, err := elastic.NewClient(
 		// inexistent service, it must fail
 		elastic.SetURL(elasticFakeURL),
@@ -433,7 +433,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []ClientOption
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/olivere/elastic/example_test.go
+++ b/v2/contrib/olivere/elastic/example_test.go
@@ -16,7 +16,7 @@ import (
 // To start tracing elastic.v5 requests, create a new TracedHTTPClient that you will
 // use when initializing the elastic.Client.
 func Example() {
-	tc := elastictrace.NewHTTPClient(elastictrace.WithServiceName("my-es-service"))
+	tc := elastictrace.NewHTTPClient(elastictrace.WithService("my-es-service"))
 	client, _ := elastic.NewClient(
 		elastic.SetURL("http://127.0.0.1:9200"),
 		elastic.SetHttpClient(tc),

--- a/v2/contrib/olivere/elastic/option.go
+++ b/v2/contrib/olivere/elastic/option.go
@@ -51,8 +51,8 @@ func defaults(cfg *clientConfig) {
 	}
 }
 
-// WithServiceName sets the given service name for the client.
-func WithServiceName(name string) ClientOptionFn {
+// WithService sets the given service name for the client.
+func WithService(name string) ClientOptionFn {
 	return func(cfg *clientConfig) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/redis/go-redis.v9/example_test.go
+++ b/v2/contrib/redis/go-redis.v9/example_test.go
@@ -45,7 +45,7 @@ func Example_pipeliner() {
 	ctx := context.Background()
 	// create a client
 	opts := &redis.Options{Addr: "127.0.0.1", Password: "", DB: 0}
-	c := redistrace.NewClient(opts, redistrace.WithServiceName("my-redis-service"))
+	c := redistrace.NewClient(opts, redistrace.WithService("my-redis-service"))
 
 	// open the pipeline
 	pipe := c.Pipeline()

--- a/v2/contrib/redis/go-redis.v9/option.go
+++ b/v2/contrib/redis/go-redis.v9/option.go
@@ -58,8 +58,8 @@ func WithSkipRawCommand(skip bool) ClientOptionFn {
 	}
 }
 
-// WithServiceName sets the given service name for the client.
-func WithServiceName(name string) ClientOptionFn {
+// WithService sets the given service name for the client.
+func WithService(name string) ClientOptionFn {
 	return func(cfg *clientConfig) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/redis/go-redis.v9/redis_test.go
+++ b/v2/contrib/redis/go-redis.v9/redis_test.go
@@ -103,7 +103,7 @@ func TestClientEvalSha(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 
 	sha1 := client.ScriptLoad(ctx, "return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}").Val()
 	mt.Reset()
@@ -132,7 +132,7 @@ func TestClient(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 	client.Set(ctx, "test_key", "test_value", 0)
 
 	spans := mt.FinishedSpans()
@@ -200,7 +200,7 @@ func TestWrapClient(t *testing.T) {
 			mt := mocktracer.Start()
 			defer mt.Stop()
 
-			WrapClient(tc.client, WithServiceName("my-redis"))
+			WrapClient(tc.client, WithService("my-redis"))
 			tc.client.Set(ctx, "test_key", "test_value", 0)
 
 			spans := mt.FinishedSpans()
@@ -308,7 +308,7 @@ func TestPipeline(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 	pipeline := client.Pipeline()
 	pipeline.Expire(ctx, "pipeline_counter", time.Hour)
 
@@ -364,7 +364,7 @@ func TestChildSpan(t *testing.T) {
 	defer mt.Stop()
 
 	// Parent span
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 	root, ctx := tracer.StartSpanFromContext(ctx, "parent.span")
 
 	client.Set(ctx, "test_key", "test_value", 0)
@@ -401,7 +401,7 @@ func TestMultipleCommands(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 	client.Set(ctx, "test_key", "test_value", 0)
 	client.Get(ctx, "test_key")
 	client.Incr(ctx, "int_key")
@@ -431,7 +431,7 @@ func TestError(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		client := NewClient(opts, WithServiceName("my-redis"))
+		client := NewClient(opts, WithService("my-redis"))
 		_, err := client.Get(ctx, "key").Result()
 
 		spans := mt.FinishedSpans()
@@ -461,7 +461,7 @@ func TestError(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		client := NewClient(opts, WithServiceName("my-redis"))
+		client := NewClient(opts, WithService("my-redis"))
 		_, err := client.Get(ctx, "non_existent_key").Result()
 
 		spans := mt.FinishedSpans()
@@ -490,7 +490,7 @@ func TestError(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		client := NewClient(opts, WithServiceName("my-redis"))
+		client := NewClient(opts, WithService("my-redis"))
 		pipeline := client.Pipeline()
 		pipeline.Get(ctx, "key")
 
@@ -532,7 +532,7 @@ func TestError(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		client := NewClient(opts, WithServiceName("my-redis"), WithErrorCheck(errCheckFn))
+		client := NewClient(opts, WithService("my-redis"), WithErrorCheck(errCheckFn))
 		_, err := client.Get(ctx, "test_key").Result()
 
 		spans := mt.FinishedSpans()
@@ -626,11 +626,11 @@ func TestWithContext(t *testing.T) {
 
 	ctx1 := context.Background()
 	ctx2 := context.Background()
-	client1 := NewClient(opts, WithServiceName("my-redis"))
+	client1 := NewClient(opts, WithService("my-redis"))
 	s1, ctx1 := tracer.StartSpanFromContext(ctx1, "span1.name")
 
 	s2, ctx2 := tracer.StartSpanFromContext(ctx2, "span2.name")
-	client2 := NewClient(opts, WithServiceName("my-redis"))
+	client2 := NewClient(opts, WithService("my-redis"))
 	client1.Set(ctx1, "test_key", "test_value", 0)
 	client2.Get(ctx2, "test_key")
 	s1.Finish()
@@ -667,7 +667,7 @@ func TestDial(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	client := NewClient(opts, WithServiceName("my-redis"))
+	client := NewClient(opts, WithService("my-redis"))
 	client.Ping(ctx)
 
 	spans := mt.FinishedSpans()
@@ -693,7 +693,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []ClientOption
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/segmentio/kafka.go.v0/kafka_test.go
+++ b/v2/contrib/segmentio/kafka.go.v0/kafka_test.go
@@ -181,7 +181,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		return genIntegrationTestSpans(
 			t,

--- a/v2/contrib/segmentio/kafka.go.v0/option.go
+++ b/v2/contrib/segmentio/kafka.go.v0/option.go
@@ -57,8 +57,8 @@ func newConfig(opts ...Option) *config {
 	return cfg
 }
 
-// WithServiceName sets the config service name to serviceName.
-func WithServiceName(serviceName string) OptionFn {
+// WithService sets the config service name to serviceName.
+func WithService(serviceName string) OptionFn {
 	return func(cfg *config) {
 		cfg.consumerServiceName = serviceName
 		cfg.producerServiceName = serviceName

--- a/v2/contrib/syndtr/goleveldb/leveldb/leveldb_test.go
+++ b/v2/contrib/syndtr/goleveldb/leveldb/leveldb_test.go
@@ -139,7 +139,7 @@ func testAction(t *testing.T, name string, f func(mt mocktracer.Tracer, db *DB))
 		defer mt.Stop()
 
 		db, err := Open(storage.NewMemStorage(), &opt.Options{},
-			WithServiceName("my-database"))
+			WithService("my-database"))
 		assert.NoError(t, err)
 		defer db.Close()
 
@@ -220,7 +220,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/syndtr/goleveldb/leveldb/option.go
+++ b/v2/contrib/syndtr/goleveldb/leveldb/option.go
@@ -61,8 +61,8 @@ func WithContext(ctx context.Context) OptionFn {
 	}
 }
 
-// WithServiceName sets the given service name for the db.
-func WithServiceName(serviceName string) OptionFn {
+// WithService sets the given service name for the db.
+func WithService(serviceName string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = serviceName
 	}

--- a/v2/contrib/tidwall/buntdb/buntdb_test.go
+++ b/v2/contrib/tidwall/buntdb/buntdb_test.go
@@ -421,7 +421,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/tidwall/buntdb/option.go
+++ b/v2/contrib/tidwall/buntdb/option.go
@@ -56,8 +56,8 @@ func WithContext(ctx context.Context) OptionFn {
 	}
 }
 
-// WithServiceName sets the given service name for the transaction.
-func WithServiceName(serviceName string) OptionFn {
+// WithService sets the given service name for the transaction.
+func WithService(serviceName string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = serviceName
 	}

--- a/v2/contrib/twitchtv/twirp/option.go
+++ b/v2/contrib/twitchtv/twirp/option.go
@@ -56,10 +56,10 @@ func serverDefaults(cfg *config) {
 	defaults(cfg)
 }
 
-// WithServiceName sets the given service name for the dialled connection.
+// WithService sets the given service name for the dialled connection.
 // When the service name is not explicitly set, it will be inferred based on the
 // request to the twirp service.
-func WithServiceName(name string) OptionFn {
+func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/twitchtv/twirp/twirp_test.go
+++ b/v2/contrib/twitchtv/twirp/twirp_test.go
@@ -178,7 +178,7 @@ func mockServer(hooks *twirp.ServerHooks, assert *assert.Assertions, twerr twirp
 func TestServerHooks(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
-	hooks := NewServerHooks(WithServiceName("twirp-test"), WithAnalytics(true))
+	hooks := NewServerHooks(WithService("twirp-test"), WithAnalytics(true))
 
 	t.Run("success", func(t *testing.T) {
 		defer mt.Reset()
@@ -359,7 +359,7 @@ func TestServiceNameSettings(t *testing.T) {
 		defer globalconfig.SetServiceName(svc)
 		globalconfig.SetServiceName("service.global")
 
-		assertServiceName(t, mt, "service.local", WithServiceName("service.local"))
+		assertServiceName(t, mt, "service.local", WithService("service.local"))
 	})
 }
 
@@ -399,7 +399,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/urfave/negroni/example_test.go
+++ b/v2/contrib/urfave/negroni/example_test.go
@@ -47,7 +47,7 @@ func Example_withServiceName() {
 	n := negroni.New()
 
 	// Use the tracer middleware with your desired service name.
-	n.Use(negronitrace.Middleware(negronitrace.WithServiceName("negroni-server")))
+	n.Use(negronitrace.Middleware(negronitrace.WithService("negroni-server")))
 
 	// Set up some endpoints.
 	mux := http.NewServeMux()

--- a/v2/contrib/urfave/negroni/negroni_test.go
+++ b/v2/contrib/urfave/negroni/negroni_test.go
@@ -178,7 +178,7 @@ func TestTrace200(t *testing.T) {
 		})
 
 		router := negroni.New()
-		router.Use(Middleware(WithServiceName("foobar")))
+		router.Use(Middleware(WithService("foobar")))
 		router.UseHandler(mux)
 		assertDoRequest(assert, mt, router, "")
 	})
@@ -197,7 +197,7 @@ func TestTrace200(t *testing.T) {
 		})
 
 		router := negroni.New()
-		router.Use(Middleware(WithServiceName("foobar")))
+		router.Use(Middleware(WithService("foobar")))
 		router.UseHandler(mux)
 		assertDoRequest(assert, mt, router, "")
 	})
@@ -215,7 +215,7 @@ func TestTrace200(t *testing.T) {
 		})
 
 		router := negroni.New()
-		router.Use(Middleware(WithServiceName("foobar"), WithResourceNamer(func(r *http.Request) string {
+		router.Use(Middleware(WithService("foobar"), WithResourceNamer(func(r *http.Request) string {
 			return fmt.Sprintf("%s %s", r.Method, r.URL.Path)
 		})))
 		router.UseHandler(mux)
@@ -456,7 +456,7 @@ func TestServiceName(t *testing.T) {
 		defer mt.Stop()
 
 		router := negroni.New()
-		router.Use(Middleware(WithServiceName("my-service")))
+		router.Use(Middleware(WithService("my-service")))
 		assertServiceName(t, mt, router, "my-service")
 	})
 }
@@ -465,7 +465,7 @@ func TestNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
 		if serviceOverride != "" {
-			opts = append(opts, WithServiceName(serviceOverride))
+			opts = append(opts, WithService(serviceOverride))
 		}
 		mt := mocktracer.Start()
 		defer mt.Stop()

--- a/v2/contrib/urfave/negroni/option.go
+++ b/v2/contrib/urfave/negroni/option.go
@@ -52,8 +52,8 @@ func defaults(cfg *config) {
 	cfg.resourceNamer = defaultResourceNamer
 }
 
-// WithServiceName sets the given service name for the router.
-func WithServiceName(name string) OptionFn {
+// WithService sets the given service name for the router.
+func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
 	}

--- a/v2/contrib/valyala/fasthttp.v1/example_test.go
+++ b/v2/contrib/valyala/fasthttp.v1/example_test.go
@@ -33,5 +33,5 @@ func Example_withServiceName() {
 	defer tracer.Stop()
 
 	// Start fasthttp server
-	fasthttp.ListenAndServe(":8081", fasthttptrace.WrapHandler(fastHTTPHandler, fasthttptrace.WithServiceName("fasthttp-server")))
+	fasthttp.ListenAndServe(":8081", fasthttptrace.WrapHandler(fastHTTPHandler, fasthttptrace.WithService("fasthttp-server")))
 }

--- a/v2/contrib/valyala/fasthttp.v1/option.go
+++ b/v2/contrib/valyala/fasthttp.v1/option.go
@@ -44,8 +44,8 @@ func newConfig() *config {
 	}
 }
 
-// WithServiceName sets the given service name for the router.
-func WithServiceName(name string) OptionFn {
+// WithService sets the given service name for the router.
+func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
 	}


### PR DESCRIPTION
### What does this PR do?

[WithService](https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#WithService) and [WithServiceName](https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#WithServiceName) (which is deprecated) serve the same purpose in the tracer.

Additionally, all the contribs have their own WithServiceName option, while we prefer WithService. We need to make all contribs consistent with the tracer option.

### Motivation

Consistency across all contribs.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
