### PR TITLE
ci: don't send issue body in triager

### DIFF
--- a/.github/workflows/needs-triage.yml
+++ b/.github/workflows/needs-triage.yml
@@ -86,7 +86,6 @@ jobs:
               "issue_number": ${{ toJson(matrix.number) }},
               "issue_title": ${{ toJson(matrix.title) }},
               "issue_url": ${{ toJson(format('github.com/{0}/issues/{1}', github.repository, matrix.number)) }},
-              "issue_body": ${{ toJson(matrix.body) }},
               "created_at": ${{ toJson(matrix.createdAt) }}
             }
         env:


### PR DESCRIPTION
### What does this PR do?

Remove the issue body from the triager bot Slack payload.

### Motivation

The full issue body can be quite long. The title and a link to the issue are
sufficient.
