### PR TITLE
ddtrace/tracer: return non-nil Span from NoopTracer.StartSpan

### DIFF
--- a/ddtrace/tracer/noop.go
+++ b/ddtrace/tracer/noop.go
@@ -5,7 +5,9 @@
 
 package tracer
 
-import "github.com/DataDog/dd-trace-go/v2/ddtrace"
+import (
+	"github.com/DataDog/dd-trace-go/v2/ddtrace"
+)
 
 var _ Tracer = (*NoopTracer)(nil)
 
@@ -14,7 +16,10 @@ type NoopTracer struct{}
 
 // StartSpan implements Tracer.
 func (NoopTracer) StartSpan(_ string, _ ...ddtrace.StartSpanOption) *Span {
-	return nil
+	// Create a bare minimum span to avoid panics in tests.
+	s := &Span{}
+	s.context = newSpanContext(s, nil)
+	return s
 }
 
 // SetServiceInfo implements Tracer.


### PR DESCRIPTION
### What does this PR do?

This PR modifiers `NoopTracer.StartSpan` to return a non-nil `Span` because `dd-source` test panick when a nil value is returned.

### Motivation

Upgrade `dd-source` & `dd-go` to use `dd-trace-go` v2 and start internal dogfooding.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
