### PR TITLE
ddtrace/tracer: locking sampling decision after context propagation

### DIFF
--- a/ddtrace/tracer/sampler_test.go
+++ b/ddtrace/tracer/sampler_test.go
@@ -946,11 +946,11 @@ func TestRulesSampler(t *testing.T) {
 		assert.EqualValues(t, 2, originSpan.(*span).Metrics[keySamplingPriority])
 		assert.EqualValues(t, 1, originSpan.(*span).Metrics[keyRulesSamplerAppliedRate])
 
-		// context already injected / propagated, but the sampling decision can still be changed
+		// context already injected / propagated, and the sampling decision can no longer be changed
 		originSpan.SetTag("tag2", "val2")
 		originSpan.Finish()
-		assert.EqualValues(t, -1, originSpan.(*span).Metrics[keySamplingPriority])
-		assert.EqualValues(t, 0, originSpan.(*span).Metrics[keyRulesSamplerAppliedRate])
+		assert.EqualValues(t, 2, originSpan.(*span).Metrics[keySamplingPriority])
+		assert.EqualValues(t, 1, originSpan.(*span).Metrics[keyRulesSamplerAppliedRate])
 
 		w3cCtx, err := tr.Extract(headers)
 		assert.Nil(t, err)

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -481,7 +481,12 @@ func (s *span) Finish(opts ...ddtrace.FinishOption) {
 	}
 
 	if tr, ok := internal.GetGlobalTracer().(*tracer); ok && tr.rulesSampling.traces.enabled() {
-		tr.rulesSampling.SampleTrace(s)
+		s.context.trace.mu.RLock()
+		locked := s.context.trace.locked
+		s.context.trace.mu.RUnlock()
+		if !locked {
+			tr.rulesSampling.SampleTrace(s)
+		}
 	}
 
 	s.finish(t)

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -481,10 +481,7 @@ func (s *span) Finish(opts ...ddtrace.FinishOption) {
 	}
 
 	if tr, ok := internal.GetGlobalTracer().(*tracer); ok && tr.rulesSampling.traces.enabled() {
-		s.context.trace.mu.RLock()
-		locked := s.context.trace.locked
-		s.context.trace.mu.RUnlock()
-		if !locked {
+		if !s.context.trace.isLocked() {
 			tr.rulesSampling.SampleTrace(s)
 		}
 	}

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -345,6 +345,18 @@ func (t *trace) setSamplingPriorityLocked(p int, sampler samplernames.SamplerNam
 	return updatedPriority
 }
 
+func (t *trace) isTraceLocked() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.locked
+}
+
+func (t *trace) setTraceLocked(locked bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.locked = locked
+}
+
 // push pushes a new span into the trace. If the buffer is full, it returns
 // a errBufferFull error.
 func (t *trace) push(sp *span) {

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -345,13 +345,13 @@ func (t *trace) setSamplingPriorityLocked(p int, sampler samplernames.SamplerNam
 	return updatedPriority
 }
 
-func (t *trace) isTraceLocked() bool {
+func (t *trace) isLocked() bool {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return t.locked
 }
 
-func (t *trace) setTraceLocked(locked bool) {
+func (t *trace) setLocked(locked bool) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.locked = locked

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -670,14 +670,14 @@ func (t *tracer) updateSampling(ctx ddtrace.SpanContext) {
 	// if SampleTrace successfully samples the trace,
 	// it will lock the span and the trace mutexes in span.setSamplingPriorityLocked
 	// and trace.setSamplingPriority respectively, so we can't rely on those mutexes.
-	if sctx.trace.isTraceLocked() {
+	if sctx.trace.isLocked() {
 		// trace sampling decision already taken and locked, no re-sampling shall occur
 		return
 	}
 
 	// if sampling was successful, need to lock the trace to prevent further re-sampling
 	if t.rulesSampling.SampleTrace(sctx.trace.root) {
-		sctx.trace.setTraceLocked(true)
+		sctx.trace.setLocked(true)
 	}
 }
 

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -666,7 +666,14 @@ func (t *tracer) updateSampling(ctx ddtrace.SpanContext) {
 	if t.rulesSampling == nil || sctx.trace == nil || sctx.trace.root == nil {
 		return
 	}
+	sctx.mu.Lock()
+	defer sctx.mu.Unlock()
+	if sctx.trace.locked {
+		// trace sampling decision already taken and locked, no re-sampling shall occur
+		return
+	}
 	t.rulesSampling.SampleTrace(sctx.trace.root)
+	sctx.trace.locked = true
 }
 
 // Extract uses the configured or default TextMap Propagator.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Previously, the sampling decision of the span could be updated if new tags were set or a resource name updated. Now, this is onlyu possible up to a moment where a context is injected / propagated to preserve the connections between spans and avoid broken traces with different sampling priorities. 


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
