### PR TITLE
CODEOWNERS: Reduce go.mod/go.sum related pings

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,6 +31,7 @@
 - [ ] There is a benchmark for any new code, or changes to existing code.
 - [ ] If this interacts with the agent in a new way, a system test has been added.
 - [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
+- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
 
 For Datadog employees:
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,6 +3,13 @@
 # default owner
 *                               @DataDog/dd-trace-go-guild
 
+# no owner: changes to these files will not automatically ping any particular
+# team and can be reviewed by anybody with the appropriate permissions. This is
+# meant to avoid pinging all of @DataDog/dd-trace-go-guild for every PR that
+# changes one of these files.
+go.mod
+go.sum
+
 # tracing
 /contrib                        @DataDog/apm-go
 /ddtrace                        @DataDog/apm-go


### PR DESCRIPTION
### What does this PR do?

* Remove @DataDog/dd-trace-go-guild as the CODEOWNER for `go.mod` and `go.sum`.

### Motivation

Most PRs that touch go.mod or go.sum are only relevant for the team working on it. For example: https://github.com/DataDog/dd-trace-go/pull/2410

This change will avoid the @DataDog/dd-trace-go-guild team to be added to such PRs by default and allow anybody with review permissions on dd-trace-go to approve the PR.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
