### PR TITLE
ddtrace/mocktracer: reset mock tracer on stop & don't add finished spans if not present

### DIFF
--- a/ddtrace/mocktracer/mocktracer.go
+++ b/ddtrace/mocktracer/mocktracer.go
@@ -13,12 +13,13 @@
 package mocktracer
 
 import (
-	"github.com/DataDog/dd-trace-go/v2/ddtrace"
-	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
-	"github.com/DataDog/dd-trace-go/v2/internal/datastreams"
 	"net/http"
 	"net/url"
 	"sync"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	"github.com/DataDog/dd-trace-go/v2/internal/datastreams"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 )

--- a/ddtrace/mocktracer/mocktracer.go
+++ b/ddtrace/mocktracer/mocktracer.go
@@ -156,6 +156,12 @@ func (t *mocktracer) Reset() {
 func (t *mocktracer) addFinishedSpan(s *tracer.Span) {
 	t.Lock()
 	defer t.Unlock()
+	// If the span is not in the open spans, we may be finishing a span that was started
+	// before the mock tracer was started. In this case, we don't want to add it to the
+	// finished spans.
+	if _, ok := t.openSpans[s.Context().SpanID()]; !ok {
+		return
+	}
 	delete(t.openSpans, s.Context().SpanID())
 	if t.finishedSpans == nil {
 		t.finishedSpans = make([]*Span, 0, 1)

--- a/ddtrace/mocktracer/mocktracer.go
+++ b/ddtrace/mocktracer/mocktracer.go
@@ -13,13 +13,12 @@
 package mocktracer
 
 import (
-	"net/http"
-	"net/url"
-	"sync"
-
 	"github.com/DataDog/dd-trace-go/v2/ddtrace"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/internal/datastreams"
+	"net/http"
+	"net/url"
+	"sync"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 )
@@ -79,7 +78,8 @@ func (t *mocktracer) FinishSpan(s *tracer.Span) {
 }
 
 // Stop deactivates the mock tracer and sets the active tracer to a no-op.
-func (*mocktracer) Stop() {
+func (t *mocktracer) Stop() {
+	t.Reset()
 	tracer.StopTestTracer()
 }
 

--- a/internal/contrib/sqltest/sqltest.go
+++ b/internal/contrib/sqltest/sqltest.go
@@ -240,11 +240,11 @@ func testExec(cfg *Config) func(*testing.T) {
 		)
 
 		cfg.mockTracer.Reset()
-		tx, err := cfg.DB.BeginTx(ctx, nil)
+		tx, err := cfg.DB.BeginTx(ctx, nil) // Generates 2 spans with `sql.query_type` Connect & Begin
 		assert.Equal(nil, err)
-		_, err = tx.ExecContext(ctx, query)
+		_, err = tx.ExecContext(ctx, query) // Generates 1 span with `sql.query_type` Exec
 		assert.Equal(nil, err)
-		err = tx.Commit()
+		err = tx.Commit() // Generates 1 span with `sql.query_type` Commit
 		assert.Equal(nil, err)
 
 		parent.Finish() // flush children
@@ -267,7 +267,7 @@ func testExec(cfg *Config) func(*testing.T) {
 				assert.Equal(v, span.Tag(k), "Value mismatch on tag %s", k)
 			}
 		} else {
-			assert.Len(spans, 5)
+			assert.Len(spans, 4)
 		}
 
 		var span *mocktracer.Span

--- a/internal/contrib/sqltest/sqltest.go
+++ b/internal/contrib/sqltest/sqltest.go
@@ -242,7 +242,8 @@ func testExec(cfg *Config) func(*testing.T) {
 		cfg.mockTracer.Reset()
 		tx, err := cfg.DB.BeginTx(ctx, nil) // Generates 2 spans with `sql.query_type` Connect & Begin
 		assert.Equal(nil, err)
-		_, err = tx.ExecContext(ctx, query) // Generates 1 span with `sql.query_type` Exec
+		// Generates 1 span with `sql.query_type` Exec, but 3 spans for the mssql driver (Prepare, Exec, Close)
+		_, err = tx.ExecContext(ctx, query)
 		assert.Equal(nil, err)
 		err = tx.Commit() // Generates 1 span with `sql.query_type` Commit
 		assert.Equal(nil, err)
@@ -253,7 +254,7 @@ func testExec(cfg *Config) func(*testing.T) {
 		if cfg.DriverName == "sqlserver" {
 			//The mssql driver doesn't support non-prepared exec so there are 2 extra spans for the exec:
 			//prepare, exec, and then a close
-			assert.Len(spans, 7)
+			assert.Len(spans, 6)
 			span := spans[2]
 			cfg.ExpectTags["sql.query_type"] = "Prepare"
 			assert.Equal(cfg.ExpectName, span.OperationName())


### PR DESCRIPTION
### What does this PR do?

Tries to fix flaky test [TestAnalyticsSettings/defaults](https://github.com/DataDog/dd-trace-go/actions/runs/7441549595/job/20243802029) in v2-dev.

The issue is that sometimes an extra span appears. It usually belongs to a previous test, as if the span was finished after the test where it was generated itself.

### Motivation

Another flaky test biting the dust. Also, making sure that any extraneous span finished after the lifetime of its corresponding mock tracer won't interfere with the active test.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
