### PR TITLE
remote configuration: fix deadlock when using client API during a configuration update (#2458)

### DIFF
--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -90,10 +90,15 @@ type Client struct {
 	repository *rc.Repository
 	stop       chan struct{}
 
-	callbacks             []Callback
-	products              map[string]struct{}
-	productsWithCallbacks map[string]ProductCallback
-	capabilities          map[Capability]struct{}
+	// When acquiring several locks and using defer to release them, make sure to acquire the locks in the following order:
+	callbacks                []Callback
+	_callbacksMu             sync.RWMutex
+	products                 map[string]struct{}
+	_productsMu              sync.RWMutex
+	productsWithCallbacks    map[string]ProductCallback
+	_productsWithCallbacksMu sync.RWMutex
+	capabilities             map[Capability]struct{}
+	_capabilitiesMu          sync.RWMutex
 
 	lastError error
 }
@@ -243,12 +248,18 @@ func Subscribe(product string, callback ProductCallback, capabilities ...Capabil
 	if client == nil {
 		return ErrClientNotStarted
 	}
-	client.Lock()
-	defer client.Unlock()
+	client._productsMu.RLock()
+	defer client._productsMu.RUnlock()
 	if _, found := client.products[product]; found {
 		return fmt.Errorf("product %s already registered via RegisterProduct", product)
 	}
+
+	client._productsWithCallbacksMu.Lock()
+	defer client._productsWithCallbacksMu.Unlock()
 	client.productsWithCallbacks[product] = callback
+
+	client._capabilitiesMu.Lock()
+	defer client._capabilitiesMu.Unlock()
 	for _, cap := range capabilities {
 		client.capabilities[cap] = struct{}{}
 	}
@@ -262,8 +273,8 @@ func RegisterCallback(f Callback) error {
 	if client == nil {
 		return ErrClientNotStarted
 	}
-	client.Lock()
-	defer client.Unlock()
+	client._callbacksMu.Lock()
+	defer client._callbacksMu.Unlock()
 	client.callbacks = append(client.callbacks, f)
 	return nil
 }
@@ -274,12 +285,13 @@ func UnregisterCallback(f Callback) error {
 	if client == nil {
 		return ErrClientNotStarted
 	}
-	client.Lock()
-	defer client.Unlock()
+	client._callbacksMu.Lock()
+	defer client._callbacksMu.Unlock()
 	fValue := reflect.ValueOf(f)
 	for i, callback := range client.callbacks {
 		if reflect.ValueOf(callback) == fValue {
 			client.callbacks = append(client.callbacks[:i], client.callbacks[i+1:]...)
+			break
 		}
 	}
 	return nil
@@ -290,8 +302,10 @@ func RegisterProduct(p string) error {
 	if client == nil {
 		return ErrClientNotStarted
 	}
-	client.Lock()
-	defer client.Unlock()
+	client._productsMu.Lock()
+	defer client._productsMu.Unlock()
+	client._productsWithCallbacksMu.RLock()
+	defer client._productsWithCallbacksMu.RUnlock()
 	if _, found := client.productsWithCallbacks[p]; found {
 		return fmt.Errorf("product %s already registered via Subscribe", p)
 	}
@@ -304,8 +318,8 @@ func UnregisterProduct(p string) error {
 	if client == nil {
 		return ErrClientNotStarted
 	}
-	client.Lock()
-	defer client.Unlock()
+	client._productsMu.Lock()
+	defer client._productsMu.Unlock()
 	delete(client.products, p)
 	return nil
 }
@@ -315,8 +329,10 @@ func HasProduct(p string) (bool, error) {
 	if client == nil {
 		return false, ErrClientNotStarted
 	}
-	client.RLock()
-	defer client.RUnlock()
+	client._productsMu.RLock()
+	defer client._productsMu.RUnlock()
+	client._productsWithCallbacksMu.RLock()
+	defer client._productsWithCallbacksMu.RUnlock()
 	_, found := client.products[p]
 	_, foundWithCallback := client.productsWithCallbacks[p]
 	return found || foundWithCallback, nil
@@ -328,8 +344,8 @@ func RegisterCapability(cap Capability) error {
 	if client == nil {
 		return ErrClientNotStarted
 	}
-	client.Lock()
-	defer client.Unlock()
+	client._capabilitiesMu.Lock()
+	defer client._capabilitiesMu.Unlock()
 	client.capabilities[cap] = struct{}{}
 	return nil
 }
@@ -340,8 +356,8 @@ func UnregisterCapability(cap Capability) error {
 	if client == nil {
 		return ErrClientNotStarted
 	}
-	client.Lock()
-	defer client.Unlock()
+	client._capabilitiesMu.Lock()
+	defer client._capabilitiesMu.Unlock()
 	delete(client.capabilities, cap)
 	return nil
 }
@@ -351,13 +367,35 @@ func HasCapability(cap Capability) (bool, error) {
 	if client == nil {
 		return false, ErrClientNotStarted
 	}
-	client.RLock()
-	defer client.RUnlock()
+	client._capabilitiesMu.RLock()
+	defer client._capabilitiesMu.RUnlock()
 	_, found := client.capabilities[cap]
 	return found, nil
 }
 
+func (c *Client) globalCallbacks() []Callback {
+	c._callbacksMu.RLock()
+	defer c._callbacksMu.RUnlock()
+	callbacks := make([]Callback, len(c.callbacks))
+	copy(callbacks, c.callbacks)
+	return callbacks
+}
+
+func (c *Client) productCallbacks() map[string]ProductCallback {
+	c._productsWithCallbacksMu.RLock()
+	defer c._productsWithCallbacksMu.RUnlock()
+	callbacks := make(map[string]ProductCallback, len(c.productsWithCallbacks))
+	for k, v := range c.productsWithCallbacks {
+		callbacks[k] = v
+	}
+	return callbacks
+}
+
 func (c *Client) allProducts() []string {
+	c._productsMu.RLock()
+	defer c._productsMu.RUnlock()
+	c._productsWithCallbacksMu.RLock()
+	defer c._productsWithCallbacksMu.RUnlock()
 	products := make([]string, 0, len(c.products)+len(c.productsWithCallbacks))
 	for p := range c.products {
 		products = append(products, p)
@@ -447,7 +485,7 @@ func (c *Client) applyUpdate(pbUpdate *clientGetConfigsResponse) error {
 	// 3 - ApplyStateAcknowledged
 	// This makes sure that any product that would need to re-receive the config in a subsequent update will be allowed to
 	statuses := make(map[string]rc.ApplyStatus)
-	for _, fn := range c.callbacks {
+	for _, fn := range c.globalCallbacks() {
 		for path, status := range fn(productUpdates) {
 			if s, ok := statuses[path]; !ok || status.State == rc.ApplyStateError ||
 				s.State == rc.ApplyStateAcknowledged && status.State == rc.ApplyStateUnacknowledged {
@@ -456,8 +494,9 @@ func (c *Client) applyUpdate(pbUpdate *clientGetConfigsResponse) error {
 		}
 	}
 	// Call the product-specific callbacks registered via Subscribe
+	productCallbacks := c.productCallbacks()
 	for product, update := range productUpdates {
-		if fn, ok := c.productsWithCallbacks[product]; ok {
+		if fn, ok := productCallbacks[product]; ok {
 			for path, status := range fn(update) {
 				statuses[path] = status
 			}


### PR DESCRIPTION
[BACKPORT] main -> release-v1.59.x
JIRA: APPSEC-18227

A deadlock occurred when trying to modify the remote configuration client using its public API while a configuration update was happening. This was due to the global lock performed in the update goroutine. This change introduces several new RWLocks for various data structures in order to avoid the global lock, and allow updating data in the client while the client is updating its configurations.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
