### PR TITLE
Don't ask for triage of issues from @DataDog/dd-trace-go-guild

### DIFF
--- a/.github/workflows/needs-triage.yml
+++ b/.github/workflows/needs-triage.yml
@@ -29,7 +29,20 @@ jobs:
             --color='#0E8A16'                                                   \
             --description='New issues that have not yet been triaged'           \
             --force
+      - name: Is author a guild member?
+        id: is-author-guild-member
+        run: |-
+          members=$(gh api /orgs/DataDog/teams/dd-trace-go-guild/members --jq='.[].id')
+          result='false'
+          for member in ${members}; do
+            if [ "${member}" = "${{ github.event.issue.user.id }}" ]; then
+              result='true'
+              break
+            fi
+          done
+          echo "result=${result}" >> "${GITHUB_OUTPUT}"
       - name: Add needs-triage label
+        if: steps.is-author-guild-member.outputs.result == 'false'
         run: |-
           gh issue edit ${{ github.event.issue.number }}                        \
             --repo='${{ github.repository }}'                                   \


### PR DESCRIPTION
### What does this PR do?

Stops adding the `needs-triage` label on issues created by members of the @DataDog/dd-trace-go-guild team.

### Motivation

We don't need someone from the guild reviewing issues by members of the guild.
