### PR TITLE
Use PAT to read team member list

### DIFF
--- a/.github/workflows/needs-triage.yml
+++ b/.github/workflows/needs-triage.yml
@@ -41,6 +41,8 @@ jobs:
             fi
           done
           echo "result=${result}" >> "${GITHUB_OUTPUT}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.NEEDS_TRIAGE_GITHUB_TOKEN }}
       - name: Add needs-triage label
         if: steps.is-author-guild-member.outputs.result == 'false'
         run: |-


### PR DESCRIPTION
### Motivation

An appropriately authorized PAT is required to read group members of DataDog teams.
