### PR TITLE
ddtracer/tracer: update TestStartupLog/errors & TestLogSamplingRules to new sampling rules implementation in v2

### DIFF
--- a/ddtrace/tracer/log_test.go
+++ b/ddtrace/tracer/log_test.go
@@ -105,17 +105,15 @@ func TestStartupLog(t *testing.T) {
 	t.Run("errors", func(t *testing.T) {
 		assert := assert.New(t)
 		tp := new(log.RecordLogger)
+		tp.Ignore("appsec: ", telemetry.LogPrefix)
 		os.Setenv("DD_TRACE_SAMPLING_RULES", `[{"service": "some.service","sample_rate": 0.234}, {"service": "other.service"}]`)
 		defer os.Unsetenv("DD_TRACE_SAMPLING_RULES")
-		tracer, _, _, stop, err := startTestTracer(t, WithLogger(tp))
-		assert.Nil(err)
-		defer stop()
+		tracer, _, _, _, err := startTestTracer(t, WithLogger(tp))
+		assert.Nil(tracer)
+		assert.Error(err)
 
-		tp.Reset()
-		tp.Ignore("appsec: ", telemetry.LogPrefix)
-		logStartup(tracer)
-		require.Len(t, tp.Logs(), 2)
-		assert.Regexp(logPrefixRegexp+` INFO: DATADOG TRACER CONFIGURATION {"date":"[^"]*","os_name":"[^"]*","os_version":"[^"]*","version":"[^"]*","lang":"Go","lang_version":"[^"]*","env":"","service":"tracer\.test(\.exe)?","agent_url":"http://localhost:9/v0.4/traces","agent_error":"Post .*","debug":false,"analytics_enabled":false,"sample_rate":"NaN","sample_rate_limit":"100","sampling_rules":\[{"service":"\^some\\\\\.service\$","sample_rate":0\.234,"type":"trace\(0\)"}\],"sampling_rules_error":"\\n\\tat index 1: rate not provided","service_mappings":null,"tags":{"runtime-id":"[^"]*"},"runtime_metrics_enabled":false,"health_metrics_enabled":false,"profiler_code_hotspots_enabled":((false)|(true)),"profiler_endpoints_enabled":((false)|(true)),"dd_version":"","architecture":"[^"]*","global_service":"","lambda_mode":"false","appsec":((true)|(false)),"agent_features":{"DropP0s":((true)|(false)),"Stats":((true)|(false)),"DataStreams":((true)|(false)),"StatsdPort":0},"integrations":{.*},"partial_flush_enabled":false,"partial_flush_min_spans":1000,"orchestrion":{"enabled":false}}`, tp.Logs()[1])
+		require.Len(t, tp.Logs(), 1)
+		assert.Contains(tp.Logs()[0], "WARN: DIAGNOSTICS Error(s) parsing sampling rules: found errors:\n\tat index 1: rate not provided")
 	})
 
 	t.Run("lambda", func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Updates `TestStartupLog/errors` to handle the way that sampling rules work in #2448, as in v2 it causes to return an error when creating the tracer. The error is logged as before, but we don't need to run the tracer to create it.

### Motivation

Keeping v2 green.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
