### PR TITLE
internal/telemetry: do not send empty container and entity headers

### DIFF
--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -472,8 +472,12 @@ func (c *client) newRequest(t RequestType) *Request {
 		"DD-Client-Library-Version":  {version.Tag},
 		"DD-Agent-Env":               {c.Env},
 		"DD-Agent-Hostname":          {hostname},
-		"Datadog-Container-ID":       {internal.ContainerID()},
-		"Datadog-Entity-ID":          {internal.EntityID()},
+	}
+	if cid := internal.ContainerID(); cid != "" {
+		header.Set("Datadog-Container-ID", cid)
+	}
+	if eid := internal.EntityID(); eid != "" {
+		header.Set("Datadog-Entity-ID", eid)
 	}
 	if c.URL == getAgentlessURL() {
 		header.Set("DD-API-KEY", c.APIKey)

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -435,3 +435,17 @@ func Test_heartbeatInterval(t *testing.T) {
 		})
 	}
 }
+
+func TestNoEmptyHeaders(t *testing.T) {
+	c := &client{}
+	req := c.newRequest(RequestTypeAppStarted)
+	assertNotEmpty := func(header string) {
+		headers := *req.Header
+		vals := headers[header]
+		for _, v := range vals {
+			assert.NotEmpty(t, v, "%s header should not be empty", header)
+		}
+	}
+	assertNotEmpty("Datadog-Container-ID")
+	assertNotEmpty("Datadog-Entity-ID")
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Do not send container and entity ID headers if empty. It's already the case for profiling, dsm and tracing transport but the telemetry client was an anomaly.

Ideally, we should have a shared transport code that takes care of this.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fixes https://github.com/DataDog/system-tests/pull/2021

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
