### PR TITLE
appsec: add Start() and Stop() to API

### DIFF
--- a/appsec/appsec_test.go
+++ b/appsec/appsec_test.go
@@ -7,6 +7,7 @@ package appsec_test
 
 import (
 	"context"
+	"gopkg.in/DataDog/dd-trace-go.v1/appsec/options"
 	"testing"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/appsec"
@@ -146,7 +147,7 @@ func TestSetUser(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	privateAppsec.Start()
+	privateAppsec.Start(options.WithCodeActivation(true))
 	defer privateAppsec.Stop()
 	if !privateAppsec.Enabled() {
 		t.Skip("AppSec needs to be enabled for this test")

--- a/appsec/options/options.go
+++ b/appsec/options/options.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022 Datadog, Inc.
+
+package options
+
+import (
+	internalConfig "gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/config"
+	"time"
+)
+
+type StartOption func(c *internalConfig.Config)
+
+// WithWafTimeout sets the maximum WAF execution time. Can also be set using `DD_APPSEC_WAF_TIMEOUT`.
+func WithWafTimeout(timeout time.Duration) StartOption {
+	return func(c *internalConfig.Config) {
+		c.WAFTimeout = timeout
+	}
+}
+
+// WithTraceRateLimit sets the AppSec trace rate limit (traces per second). Can also be set using `DD_APPSEC_TRACE_RATE_LIMIT`.
+func WithTraceRateLimit(limit int64) StartOption {
+	return func(c *internalConfig.Config) {
+		c.TraceRateLimit = limit
+	}
+}
+
+// WithObfuscatorKeyRegex sets the obfuscator regex for all keys in. Can also be set using `DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP`.
+func WithObfuscatorKeyRegex(cfg string) StartOption {
+	return func(c *internalConfig.Config) {
+		c.Obfuscator.KeyRegex = cfg
+	}
+}
+
+// WithObfuscatorValueRegex sets the obfuscator regex for all values in. Can also be set using `DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP`.
+func WithObfuscatorValueRegex(cfg string) StartOption {
+	return func(c *internalConfig.Config) {
+		c.Obfuscator.ValueRegex = cfg
+	}
+}
+
+// WithAPISecEnabled enables the APISec feature. Can also be set using `DD_EXPERIMENTAL_API_SECURITY_ENABLED`.
+func WithAPISecEnabled() StartOption {
+	return func(c *internalConfig.Config) {
+		c.APISec.Enabled = true
+	}
+}
+
+// WithAPISecSampleRate sets the APISec sample rate. Can also be set using `DD_API_SECURITY_REQUEST_SAMPLE_RATE`.
+func WithAPISecSampleRate(rate float64) StartOption {
+	return func(c *internalConfig.Config) {
+		c.APISec.SampleRate = rate
+	}
+}
+
+// WithRCActive enable or disable Remote Configuration for Appsec Datadog feature.
+func WithRCActive(enable bool) StartOption {
+	return func(c *internalConfig.Config) {
+		c.RCEnabled = enable
+	}
+}
+
+// WithCodeActivation enable or disable Appsec. Can also be set using `DD_APPSEC_ENABLED`.
+func WithCodeActivation(enable bool) StartOption {
+	return func(c *internalConfig.Config) {
+		c.CodeActivation = &enable
+	}
+}

--- a/contrib/99designs/gqlgen/appsec_test.go
+++ b/contrib/99designs/gqlgen/appsec_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"gopkg.in/DataDog/dd-trace-go.v1/appsec/options"
 	"os"
 	"path"
 	"testing"
@@ -258,9 +259,8 @@ func enableAppSec(t *testing.T) func() {
 	rulesFile := path.Join(tmpDir, "rules.json")
 	err = os.WriteFile(rulesFile, []byte(rules), 0644)
 	require.NoError(t, err)
-	t.Setenv("DD_APPSEC_ENABLED", "1")
 	t.Setenv("DD_APPSEC_RULES", rulesFile)
-	appsec.Start()
+	appsec.Start(options.WithCodeActivation(true))
 	cleanup := func() {
 		appsec.Stop()
 		_ = os.RemoveAll(tmpDir)

--- a/contrib/gin-gonic/gin/appsec_test.go
+++ b/contrib/gin-gonic/gin/appsec_test.go
@@ -7,6 +7,7 @@ package gin
 
 import (
 	"fmt"
+	"gopkg.in/DataDog/dd-trace-go.v1/appsec/options"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -23,7 +24,7 @@ import (
 )
 
 func TestAppSec(t *testing.T) {
-	appsec.Start()
+	appsec.Start(options.WithCodeActivation(true))
 	defer appsec.Stop()
 	if !appsec.Enabled() {
 		t.Skip("appsec disabled")
@@ -149,7 +150,7 @@ func TestAppSec(t *testing.T) {
 }
 
 func TestControlFlow(t *testing.T) {
-	appsec.Start()
+	appsec.Start(options.WithCodeActivation(true))
 	defer appsec.Stop()
 	middlewareResponseBody := "Hello Middleware"
 	middlewareResponseStatus := 433
@@ -373,7 +374,7 @@ func TestControlFlow(t *testing.T) {
 func TestBlocking(t *testing.T) {
 	t.Setenv("DD_APPSEC_RULES", "../../../internal/appsec/testdata/blocking.json")
 
-	appsec.Start()
+	appsec.Start(options.WithCodeActivation(true))
 	defer appsec.Stop()
 	if !appsec.Enabled() {
 		t.Skip("AppSec needs to be enabled for this test")

--- a/contrib/go-chi/chi.v5/chi_test.go
+++ b/contrib/go-chi/chi.v5/chi_test.go
@@ -7,6 +7,7 @@ package chi
 
 import (
 	"fmt"
+	"gopkg.in/DataDog/dd-trace-go.v1/appsec/options"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -343,7 +344,7 @@ func TestIgnoreRequest(t *testing.T) {
 }
 
 func TestAppSec(t *testing.T) {
-	appsec.Start()
+	appsec.Start(options.WithCodeActivation(true))
 	defer appsec.Stop()
 
 	if !appsec.Enabled() {

--- a/contrib/go-chi/chi/chi_test.go
+++ b/contrib/go-chi/chi/chi_test.go
@@ -7,6 +7,7 @@ package chi
 
 import (
 	"fmt"
+	"gopkg.in/DataDog/dd-trace-go.v1/appsec/options"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -407,7 +408,7 @@ func TestIgnoreRequest(t *testing.T) {
 }
 
 func TestAppSec(t *testing.T) {
-	appsec.Start()
+	appsec.Start(options.WithCodeActivation(true))
 	defer appsec.Stop()
 
 	if !appsec.Enabled() {

--- a/contrib/google.golang.org/grpc/appsec_test.go
+++ b/contrib/google.golang.org/grpc/appsec_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"gopkg.in/DataDog/dd-trace-go.v1/appsec/options"
 	"net"
 	"strings"
 	"testing"
@@ -25,7 +26,7 @@ import (
 )
 
 func TestAppSec(t *testing.T) {
-	appsec.Start()
+	appsec.Start(options.WithCodeActivation(true))
 	defer appsec.Stop()
 	if !appsec.Enabled() {
 		t.Skip("appsec disabled")
@@ -133,7 +134,7 @@ func TestAppSec(t *testing.T) {
 // Test that http blocking works by using custom rules/rules data
 func TestBlocking(t *testing.T) {
 	t.Setenv("DD_APPSEC_RULES", "../../../internal/appsec/testdata/blocking.json")
-	appsec.Start()
+	appsec.Start(options.WithCodeActivation(true))
 	defer appsec.Stop()
 	if !appsec.Enabled() {
 		t.Skip("appsec disabled")
@@ -226,7 +227,7 @@ func TestBlocking(t *testing.T) {
 // Test that user blocking works by using custom rules/rules data
 func TestUserBlocking(t *testing.T) {
 	t.Setenv("DD_APPSEC_RULES", "../../../internal/appsec/testdata/blocking.json")
-	appsec.Start()
+	appsec.Start(options.WithCodeActivation(true))
 	defer appsec.Stop()
 	if !appsec.Enabled() {
 		t.Skip("appsec disabled")

--- a/contrib/gorilla/mux/mux_test.go
+++ b/contrib/gorilla/mux/mux_test.go
@@ -7,6 +7,7 @@ package mux
 
 import (
 	"fmt"
+	"gopkg.in/DataDog/dd-trace-go.v1/appsec/options"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -407,7 +408,7 @@ func okHandler() http.Handler {
 }
 
 func TestAppSec(t *testing.T) {
-	appsec.Start()
+	appsec.Start(options.WithCodeActivation(true))
 	defer appsec.Stop()
 
 	if !appsec.Enabled() {

--- a/contrib/graph-gophers/graphql-go/appsec_test.go
+++ b/contrib/graph-gophers/graphql-go/appsec_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"gopkg.in/DataDog/dd-trace-go.v1/appsec/options"
 	"os"
 	"path"
 	"testing"
@@ -240,12 +241,10 @@ func enableAppSec(t *testing.T) func() {
 	rulesFile := path.Join(tmpDir, "rules.json")
 	err = os.WriteFile(rulesFile, []byte(rules), 0644)
 	require.NoError(t, err)
-	restoreDdAppsecEnabled := setEnv("DD_APPSEC_ENABLED", "1")
 	restoreDdAppsecRules := setEnv("DD_APPSEC_RULES", rulesFile)
-	appsec.Start()
+	appsec.Start(options.WithCodeActivation(true))
 	restore := func() {
 		appsec.Stop()
-		restoreDdAppsecEnabled()
 		restoreDdAppsecRules()
 		_ = os.RemoveAll(tmpDir)
 	}

--- a/contrib/graphql-go/graphql/appsec_test.go
+++ b/contrib/graphql-go/graphql/appsec_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"gopkg.in/DataDog/dd-trace-go.v1/appsec/options"
 	"os"
 	"path"
 	"testing"
@@ -260,12 +261,10 @@ func enableAppSec(t *testing.T) func() {
 	rulesFile := path.Join(tmpDir, "rules.json")
 	err = os.WriteFile(rulesFile, []byte(rules), 0644)
 	require.NoError(t, err)
-	restoreDdAppsecEnabled := setEnv("DD_APPSEC_ENABLED", "1")
 	restoreDdAppsecRules := setEnv("DD_APPSEC_RULES", rulesFile)
-	appsec.Start()
+	appsec.Start(options.WithCodeActivation(true))
 	restore := func() {
 		appsec.Stop()
-		restoreDdAppsecEnabled()
 		restoreDdAppsecRules()
 		_ = os.RemoveAll(tmpDir)
 	}

--- a/contrib/graphql-go/graphql/bench_test.go
+++ b/contrib/graphql-go/graphql/bench_test.go
@@ -7,6 +7,7 @@ package graphql
 
 import (
 	"fmt"
+	"gopkg.in/DataDog/dd-trace-go.v1/appsec/options"
 	"os"
 	"path"
 	"testing"
@@ -247,9 +248,8 @@ func enableAppSecBench(b *testing.B) func() {
 	rulesFile := path.Join(tmpDir, "rules.json")
 	err = os.WriteFile(rulesFile, []byte(rules), 0644)
 	require.NoError(b, err)
-	b.Setenv("DD_APPSEC_ENABLED", "1")
 	b.Setenv("DD_APPSEC_RULES", rulesFile)
-	appsec.Start()
+	appsec.Start(options.WithCodeActivation(true))
 	restore := func() {
 		appsec.Stop()
 		_ = os.RemoveAll(tmpDir)

--- a/contrib/labstack/echo.v4/appsec_test.go
+++ b/contrib/labstack/echo.v4/appsec_test.go
@@ -8,6 +8,7 @@ package echo
 import (
 	"errors"
 	"fmt"
+	"gopkg.in/DataDog/dd-trace-go.v1/appsec/options"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -24,7 +25,7 @@ import (
 )
 
 func TestAppSec(t *testing.T) {
-	appsec.Start()
+	appsec.Start(options.WithCodeActivation(true))
 	defer appsec.Stop()
 
 	if !appsec.Enabled() {
@@ -239,7 +240,7 @@ func TestAppSec(t *testing.T) {
 // TestControlFlow ensures that the AppSec middleware behaves correctly in various execution flows and wrapping
 // scenarios.
 func TestControlFlow(t *testing.T) {
-	appsec.Start()
+	appsec.Start(options.WithCodeActivation(true))
 	defer appsec.Stop()
 	if !appsec.Enabled() {
 		t.Skip("AppSec needs to be enabled for this test")
@@ -551,7 +552,7 @@ func TestControlFlow(t *testing.T) {
 func TestBlocking(t *testing.T) {
 	t.Setenv("DD_APPSEC_RULES", "../../../internal/appsec/testdata/blocking.json")
 
-	appsec.Start()
+	appsec.Start(options.WithCodeActivation(true))
 	defer appsec.Stop()
 	if !appsec.Enabled() {
 		t.Skip("AppSec needs to be enabled for this test")

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -21,7 +21,6 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
 	globalinternal "gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
-	appsecConfig "gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/config"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/hostname"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
@@ -169,9 +168,15 @@ func Start(opts ...StartOption) {
 
 	// appsec.Start() may use the telemetry client to report activation, so it is
 	// important this happens _AFTER_ startTelemetry() has been called, so the
-	// client is appropriately configured.
-	appsec.Start(appsecConfig.WithRCConfig(cfg))
+	// client is appropriately configured. Same for remote config with startRemoteConfig().
+	appsec.Start()
 	_ = t.hostname() // Prime the hostname cache
+}
+
+// IsUpAndRunning returns true if the tracer is started and is not a noop tracer, false otherwise
+func IsUpAndRunning() bool {
+	_, ok := internal.GetGlobalTracer().(*internal.NoopTracer)
+	return !ok
 }
 
 // Stop stops the started tracer. Subsequent calls are valid but become no-op.

--- a/internal/apps/go.mod
+++ b/internal/apps/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/DataDog/appsec-internal-go v1.4.0 // indirect
 	github.com/DataDog/go-libddwaf/v2 v2.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/ebitengine/purego v0.5.1 // indirect
+	github.com/ebitengine/purego v0.5.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/internal/apps/go.sum
+++ b/internal/apps/go.sum
@@ -31,8 +31,8 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvyukov/go-fuzz v0.0.0-20210103155950-6a8e9d1f2415/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
-github.com/ebitengine/purego v0.5.1 h1:hNunhThpOf1vzKl49v6YxIsXLhl92vbBEv1/2Ez3ZrY=
-github.com/ebitengine/purego v0.5.1/go.mod h1:ah1In8AOtksoNK6yk5z1HTJeUkC1Ez4Wk2idgGslMwQ=
+github.com/ebitengine/purego v0.5.2 h1:r2MQEtkGzZ4LRtFZVAg5bjYKnUbxxloaeuGxH0t7qfs=
+github.com/ebitengine/purego v0.5.2/go.mod h1:ah1In8AOtksoNK6yk5z1HTJeUkC1Ez4Wk2idgGslMwQ=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
@@ -40,7 +40,6 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -61,7 +60,6 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
-github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/outcaste-io/ristretto v0.2.3 h1:AK4zt/fJ76kjlYObOeNwh4T3asEuaCmp26pOvUOL9w0=
 github.com/outcaste-io/ristretto v0.2.3/go.mod h1:W8HywhmtlopSB1jeMg3JtdIhf+DYkLAr0VN/s4+MHac=
 github.com/philhofer/fwd v1.1.2 h1:bnDivRJ1EWPjUIRXV5KfORO897HTbpFAQddBdE8t7Gw=
@@ -86,7 +84,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/objx v0.5.1 h1:4VhoImhV/Bm0ToFkXFi8hXNXwpDRZ/ynw3amt82mzq0=
-github.com/stretchr/objx v0.5.1/go.mod h1:/iHQpkQwBD6DLUmQ4pE+s1TXdob1mORJ4/UFdrifcy0=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
@@ -116,8 +113,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
-golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
+golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
@@ -178,7 +174,6 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 google.golang.org/grpc v1.57.1 h1:upNTNqv0ES+2ZOOqACwVtS3Il8M12/+Hz41RCPzAjQg=
-google.golang.org/grpc v1.57.1/go.mod h1:Sd+9RMTACXwmub0zcNY2c4arhtrbBYD1AUHI/dt16Mo=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
@@ -188,7 +183,6 @@ google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
@@ -196,6 +190,5 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/gotraceui v0.2.0 h1:dmNsfQ9Vl3GwbiVD7Z8d/osC6WtGGrasyrC2suc4ZIQ=
-honnef.co/go/gotraceui v0.2.0/go.mod h1:qHo4/W75cA3bX0QQoSvDjbJa4R8mAyyFjbWAj63XElc=
 inet.af/netaddr v0.0.0-20230525184311-b8eac61e914a h1:1XCVEdxrvL6c0TGOhecLuB7U9zYNdxZEjvOqJreKZiM=
 inet.af/netaddr v0.0.0-20230525184311-b8eac61e914a/go.mod h1:e83i32mAQOW1LAqEIweALsuK2Uw4mhQadA5r7b0Wobo=

--- a/internal/appsec/appsec_test.go
+++ b/internal/appsec/appsec_test.go
@@ -6,17 +6,16 @@
 package appsec_test
 
 import (
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/config"
 	"os"
 	"strconv"
 	"testing"
 
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/config"
-
 	waf "github.com/DataDog/go-libddwaf/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
 )
 
 func TestEnabled(t *testing.T) {

--- a/internal/appsec/remoteconfig.go
+++ b/internal/appsec/remoteconfig.go
@@ -288,35 +288,22 @@ func mergeRulesDataEntries(entries1, entries2 []rc.ASMDataRuleDataEntry) []rc.AS
 	return entries
 }
 
-func (a *appsec) startRC() error {
-	if a.cfg.RC != nil {
-		return remoteconfig.Start(*a.cfg.RC)
-	}
-	return nil
-}
-
-func (a *appsec) stopRC() {
-	if a.cfg.RC != nil {
-		remoteconfig.Stop()
-	}
-}
-
 func (a *appsec) registerRCProduct(p string) error {
-	if a.cfg.RC == nil {
+	if !a.cfg.RCEnabled {
 		return fmt.Errorf("no valid remote configuration client")
 	}
 	return remoteconfig.RegisterProduct(p)
 }
 
 func (a *appsec) registerRCCapability(c remoteconfig.Capability) error {
-	if a.cfg.RC == nil {
+	if !a.cfg.RCEnabled {
 		return fmt.Errorf("no valid remote configuration client")
 	}
 	return remoteconfig.RegisterCapability(c)
 }
 
 func (a *appsec) unregisterRCCapability(c remoteconfig.Capability) error {
-	if a.cfg.RC == nil {
+	if !a.cfg.RCEnabled {
 		log.Debug("appsec: Remote config: no valid remote configuration client")
 		return nil
 	}
@@ -324,7 +311,7 @@ func (a *appsec) unregisterRCCapability(c remoteconfig.Capability) error {
 }
 
 func (a *appsec) enableRemoteActivation() error {
-	if a.cfg.RC == nil {
+	if !a.cfg.RCEnabled {
 		return fmt.Errorf("no valid remote configuration client")
 	}
 	err := a.registerRCProduct(rc.ProductASMFeatures)
@@ -350,7 +337,7 @@ var blockingCapabilities = [...]remoteconfig.Capability{
 }
 
 func (a *appsec) enableRCBlocking() {
-	if a.cfg.RC == nil {
+	if !a.cfg.RCEnabled {
 		log.Debug("appsec: Remote config: no valid remote configuration client")
 		return
 	}
@@ -376,7 +363,7 @@ func (a *appsec) enableRCBlocking() {
 }
 
 func (a *appsec) disableRCBlocking() {
-	if a.cfg.RC == nil {
+	if !a.cfg.RCEnabled {
 		return
 	}
 	for _, c := range blockingCapabilities {

--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -165,6 +165,11 @@ func Start(config ClientConfig) error {
 	return err
 }
 
+// IsUpAndRunning returns whether RC client has started and is running.
+func IsUpAndRunning() bool {
+	return client != nil
+}
+
 // Stop stops the client's update poll loop.
 // Noop if the client has already been stopped.
 // The remote config client is supposed to have the same lifecycle as the tracer.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds `Start` and `Stop` and options to it on the appsec public API for a programmatic access to enabling ASM Threats.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We would like to have a way to enable and configure ASM directly in consul internally in Datadog. A Version 1 of this works already but requires to redeploy everything which can be slow and cannot be done by us. A way to dynamically activate ASM but more granularly than Remote Activation is required to make this happen.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
