### PR TITLE
ddtrace/opentelemetry: fix flaky TestSpanResourceNameDefault

### DIFF
--- a/ddtrace/opentelemetry/span_test.go
+++ b/ddtrace/opentelemetry/span_test.go
@@ -43,6 +43,14 @@ func mockTracerProvider(t *testing.T, opts ...tracer.StartOption) (tp *TracerPro
 			var js bytes.Buffer
 			msgp.UnmarshalAsJSON(&js, buf)
 			payloads <- js.String()
+		default:
+			if r.Method == "GET" {
+				// Write an empty JSON object to the output, to avoid spurious decoding
+				// errors to be reported in the logs, which may lead someone
+				// investigating a test failure into the wrong direction.
+				_, _ = w.Write([]byte("{}"))
+				return
+			}
 		}
 		w.WriteHeader(200)
 	}))


### PR DESCRIPTION
### What does this PR do?

(Tries to) fix TestSpanResourceNameDefault. A different take from #2503.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
