### PR TITLE
[data streams] Track high watermark offsets

### DIFF
--- a/contrib/confluentinc/confluent-kafka-go/kafka.v2/kafka.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka.v2/kafka.go
@@ -91,6 +91,7 @@ func (c *Consumer) traceEventsChannel(in chan kafka.Event) chan kafka.Event {
 				setConsumeCheckpoint(c.cfg.dataStreamsEnabled, c.cfg.groupID, msg)
 			} else if offset, ok := evt.(kafka.OffsetsCommitted); ok {
 				commitOffsets(c.cfg.dataStreamsEnabled, c.cfg.groupID, offset.Offsets, offset.Error)
+				c.trackHighWatermark(c.cfg.dataStreamsEnabled, offset.Offsets)
 			}
 
 			out <- evt
@@ -176,8 +177,20 @@ func (c *Consumer) Poll(timeoutMS int) (event kafka.Event) {
 		c.prev = c.startSpan(msg)
 	} else if offset, ok := evt.(kafka.OffsetsCommitted); ok {
 		commitOffsets(c.cfg.dataStreamsEnabled, c.cfg.groupID, offset.Offsets, offset.Error)
+		c.trackHighWatermark(c.cfg.dataStreamsEnabled, offset.Offsets)
 	}
 	return evt
+}
+
+func (c *Consumer) trackHighWatermark(dataStreamsEnabled bool, offsets []kafka.TopicPartition) {
+	if !dataStreamsEnabled {
+		return
+	}
+	for _, tp := range offsets {
+		if _, high, err := c.Consumer.GetWatermarkOffsets(*tp.Topic, tp.Partition); err == nil {
+			tracer.TrackKafkaHighWatermarkOffset("", *tp.Topic, tp.Partition, high)
+		}
+	}
 }
 
 // ReadMessage polls the consumer for a message. Message will be traced.
@@ -199,6 +212,7 @@ func (c *Consumer) ReadMessage(timeout time.Duration) (*kafka.Message, error) {
 func (c *Consumer) Commit() ([]kafka.TopicPartition, error) {
 	tps, err := c.Consumer.Commit()
 	commitOffsets(c.cfg.dataStreamsEnabled, c.cfg.groupID, tps, err)
+	c.trackHighWatermark(c.cfg.dataStreamsEnabled, tps)
 	return tps, err
 }
 
@@ -206,6 +220,7 @@ func (c *Consumer) Commit() ([]kafka.TopicPartition, error) {
 func (c *Consumer) CommitMessage(msg *kafka.Message) ([]kafka.TopicPartition, error) {
 	tps, err := c.Consumer.CommitMessage(msg)
 	commitOffsets(c.cfg.dataStreamsEnabled, c.cfg.groupID, tps, err)
+	c.trackHighWatermark(c.cfg.dataStreamsEnabled, tps)
 	return tps, err
 }
 
@@ -213,6 +228,7 @@ func (c *Consumer) CommitMessage(msg *kafka.Message) ([]kafka.TopicPartition, er
 func (c *Consumer) CommitOffsets(offsets []kafka.TopicPartition) ([]kafka.TopicPartition, error) {
 	tps, err := c.Consumer.CommitOffsets(offsets)
 	commitOffsets(c.cfg.dataStreamsEnabled, c.cfg.groupID, tps, err)
+	c.trackHighWatermark(c.cfg.dataStreamsEnabled, tps)
 	return tps, err
 }
 

--- a/contrib/confluentinc/confluent-kafka-go/kafka.v2/kafka_test.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka.v2/kafka_test.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"errors"
 	"os"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +19,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	internaldsm "gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/stretchr/testify/assert"
@@ -76,6 +79,8 @@ func produceThenConsume(t *testing.T, consumerAction consumerActionFn, producerO
 
 	msg2, err := consumerAction(c)
 	require.NoError(t, err)
+	commits, err := c.CommitMessage(msg2)
+	require.NoError(t, err)
 	assert.Equal(t, msg1.String(), msg2.String())
 	err = c.Close()
 	require.NoError(t, err)
@@ -84,6 +89,22 @@ func produceThenConsume(t *testing.T, consumerAction consumerActionFn, producerO
 	require.Len(t, spans, 2)
 	// they should be linked via headers
 	assert.Equal(t, spans[0].TraceID(), spans[1].TraceID())
+
+	if c.cfg.dataStreamsEnabled {
+		backlogs := mt.SentDSMBacklogs()
+		sort.Slice(backlogs, func(i, j int) bool {
+			// it will sort the backlogs in the order: commit, high watermark, produce
+			return strings.Join(backlogs[i].Tags, "") < strings.Join(backlogs[j].Tags, "")
+		})
+		require.Len(t, commits, 1)
+		highWatermark := int64(commits[0].Offset)
+		expectedBacklogs := []internaldsm.Backlog{
+			{Tags: []string{"consumer_group:" + testGroupID, "partition:0", "topic:" + testTopic, "type:kafka_commit"}, Value: highWatermark},
+			{Tags: []string{"partition:0", "topic:" + testTopic, "type:kafka_high_watermark"}, Value: highWatermark},
+			{Tags: []string{"partition:0", "topic:" + testTopic, "type:kafka_produce"}, Value: highWatermark - 1},
+		}
+		assert.Equal(t, expectedBacklogs, backlogs)
+	}
 	return spans, msg2
 }
 

--- a/contrib/confluentinc/confluent-kafka-go/kafka/kafka.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/kafka.go
@@ -91,6 +91,7 @@ func (c *Consumer) traceEventsChannel(in chan kafka.Event) chan kafka.Event {
 				setConsumeCheckpoint(c.cfg.dataStreamsEnabled, c.cfg.groupID, msg)
 			} else if offset, ok := evt.(kafka.OffsetsCommitted); ok {
 				commitOffsets(c.cfg.dataStreamsEnabled, c.cfg.groupID, offset.Offsets, offset.Error)
+				c.trackHighWatermark(c.cfg.dataStreamsEnabled, offset.Offsets)
 			}
 
 			out <- evt
@@ -176,8 +177,20 @@ func (c *Consumer) Poll(timeoutMS int) (event kafka.Event) {
 		c.prev = c.startSpan(msg)
 	} else if offset, ok := evt.(kafka.OffsetsCommitted); ok {
 		commitOffsets(c.cfg.dataStreamsEnabled, c.cfg.groupID, offset.Offsets, offset.Error)
+		c.trackHighWatermark(c.cfg.dataStreamsEnabled, offset.Offsets)
 	}
 	return evt
+}
+
+func (c *Consumer) trackHighWatermark(dataStreamsEnabled bool, offsets []kafka.TopicPartition) {
+	if !dataStreamsEnabled {
+		return
+	}
+	for _, tp := range offsets {
+		if _, high, err := c.Consumer.GetWatermarkOffsets(*tp.Topic, tp.Partition); err == nil {
+			tracer.TrackKafkaHighWatermarkOffset("", *tp.Topic, tp.Partition, high)
+		}
+	}
 }
 
 // ReadMessage polls the consumer for a message. Message will be traced.
@@ -199,6 +212,7 @@ func (c *Consumer) ReadMessage(timeout time.Duration) (*kafka.Message, error) {
 func (c *Consumer) Commit() ([]kafka.TopicPartition, error) {
 	tps, err := c.Consumer.Commit()
 	commitOffsets(c.cfg.dataStreamsEnabled, c.cfg.groupID, tps, err)
+	c.trackHighWatermark(c.cfg.dataStreamsEnabled, tps)
 	return tps, err
 }
 
@@ -206,6 +220,7 @@ func (c *Consumer) Commit() ([]kafka.TopicPartition, error) {
 func (c *Consumer) CommitMessage(msg *kafka.Message) ([]kafka.TopicPartition, error) {
 	tps, err := c.Consumer.CommitMessage(msg)
 	commitOffsets(c.cfg.dataStreamsEnabled, c.cfg.groupID, tps, err)
+	c.trackHighWatermark(c.cfg.dataStreamsEnabled, tps)
 	return tps, err
 }
 
@@ -213,6 +228,7 @@ func (c *Consumer) CommitMessage(msg *kafka.Message) ([]kafka.TopicPartition, er
 func (c *Consumer) CommitOffsets(offsets []kafka.TopicPartition) ([]kafka.TopicPartition, error) {
 	tps, err := c.Consumer.CommitOffsets(offsets)
 	commitOffsets(c.cfg.dataStreamsEnabled, c.cfg.groupID, tps, err)
+	c.trackHighWatermark(c.cfg.dataStreamsEnabled, tps)
 	return tps, err
 }
 

--- a/ddtrace/mocktracer/data_streams.go
+++ b/ddtrace/mocktracer/data_streams.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package mocktracer
+
+import (
+	"compress/gzip"
+	"net/http"
+
+	"github.com/tinylib/msgp/msgp"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams"
+)
+
+type mockDSMTransport struct {
+	backlogs []datastreams.Backlog
+}
+
+// RoundTrip does nothing and returns a dummy response.
+func (t *mockDSMTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// You can customize the dummy response if needed.
+	gzipReader, err := gzip.NewReader(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	var p datastreams.StatsPayload
+	err = msgp.Decode(gzipReader, &p)
+	if err != nil {
+		return nil, err
+	}
+	for _, bucket := range p.Stats {
+		t.backlogs = append(t.backlogs, bucket.Backlogs...)
+	}
+	return &http.Response{
+		StatusCode:    200,
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Request:       req,
+		ContentLength: -1,
+		Body:          http.NoBody,
+	}, nil
+}

--- a/ddtrace/mocktracer/mocktracer.go
+++ b/ddtrace/mocktracer/mocktracer.go
@@ -37,6 +37,7 @@ type Tracer interface {
 
 	// FinishedSpans returns the set of finished spans.
 	FinishedSpans() []Span
+	SentDSMBacklogs() []datastreams.Backlog
 
 	// Reset resets the spans and services recorded in the tracer. This is
 	// especially useful when running tests in a loop, where a clean start
@@ -63,11 +64,25 @@ type mocktracer struct {
 	sync.RWMutex  // guards below spans
 	finishedSpans []Span
 	openSpans     map[uint64]Span
+	dsmTransport  *mockDSMTransport
+	dsmProcessor  *datastreams.Processor
+}
+
+func (t *mocktracer) SentDSMBacklogs() []datastreams.Backlog {
+	t.dsmProcessor.Flush()
+	return t.dsmTransport.backlogs
 }
 
 func newMockTracer() *mocktracer {
 	var t mocktracer
 	t.openSpans = make(map[uint64]Span)
+	t.dsmTransport = &mockDSMTransport{}
+	client := &http.Client{
+		Transport: t.dsmTransport,
+	}
+	t.dsmProcessor = datastreams.NewProcessor(&statsd.NoOpClient{}, "env", "service", "v1", &url.URL{Scheme: "http", Host: "agent-address"}, client, func() bool { return true })
+	t.dsmProcessor.Start()
+	t.dsmProcessor.Flush()
 	return &t
 }
 
@@ -91,27 +106,8 @@ func (t *mocktracer) StartSpan(operationName string, opts ...ddtrace.StartSpanOp
 	return span
 }
 
-type noOpTransport struct{}
-
-// RoundTrip does nothing and returns a dummy response.
-func (t *noOpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	// You can customize the dummy response if needed.
-	return &http.Response{
-		StatusCode:    200,
-		Proto:         "HTTP/1.1",
-		ProtoMajor:    1,
-		ProtoMinor:    1,
-		Request:       req,
-		ContentLength: -1,
-		Body:          http.NoBody,
-	}, nil
-}
-
 func (t *mocktracer) GetDataStreamsProcessor() *datastreams.Processor {
-	client := &http.Client{
-		Transport: &noOpTransport{},
-	}
-	return datastreams.NewProcessor(&statsd.NoOpClient{}, "env", "service", "v1", &url.URL{Scheme: "http", Host: "agent-address"}, client, func() bool { return true })
+	return t.dsmProcessor
 }
 
 func (t *mocktracer) OpenSpans() []Span {

--- a/ddtrace/tracer/data_streams.go
+++ b/ddtrace/tracer/data_streams.go
@@ -62,3 +62,13 @@ func TrackKafkaProduceOffset(topic string, partition int32, offset int64) {
 		}
 	}
 }
+
+// TrackKafkaHighWatermarkOffset should be used in the producer, to track when it produces a message.
+// if used together with TrackKafkaCommitOffset it can generate a Kafka lag in seconds metric.
+func TrackKafkaHighWatermarkOffset(cluster string, topic string, partition int32, offset int64) {
+	if t, ok := internal.GetGlobalTracer().(dataStreamsContainer); ok {
+		if p := t.GetDataStreamsProcessor(); p != nil {
+			p.TrackKafkaHighWatermarkOffset(cluster, topic, partition, offset)
+		}
+	}
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Track high watermark offsets along with produce and commit offsets.
This information can be used to determine Kafka lag of consumers.
So we can now get the Kafka lag by only instrumenting the consumer service, with no instrumentation on the producer side.
This also makes the Kafka lag more reliable, since we don't rely on stitching commit & produce offsets later on, but are doing it directly in the application.

### Motivation

The main motivation is improving the accuracy and reliability of the `data_streams.kafka.lag_seconds` metric.
Right now, the metric has edge cases in which it doesn't work great. For example when multiple Kafka topics have the same name.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
