### PR TITLE
profiler/internal/pprofutils: work around breaking pprof change (#2515 backport)

### DIFF
--- a/profiler/internal/pprofutils/protobuf.go
+++ b/profiler/internal/pprofutils/protobuf.go
@@ -33,8 +33,21 @@ func (p Protobuf) Convert(protobuf *profile.Profile, text io.Writer) error {
 		}
 		w.WriteString(strings.Join(sampleTypes, " ") + "\n")
 	}
-	if err := protobuf.Aggregate(true, true, false, false, false); err != nil {
-		return err
+	// This is a workaround for a breaking change in the pprof library
+	// when it added columns as an additional attribute for aggregation.
+	if pb, ok := any(protobuf).(interface {
+		Aggregate(bool, bool, bool, bool, bool) error
+	}); ok {
+		if err := pb.Aggregate(true, true, false, false, false); err != nil {
+			return err
+		}
+	}
+	if pb, ok := any(protobuf).(interface {
+		Aggregate(bool, bool, bool, bool, bool, bool) error
+	}); ok {
+		if err := pb.Aggregate(true, true, false, false, false, false); err != nil {
+			return err
+		}
 	}
 	protobuf = protobuf.Compact()
 	sort.Slice(protobuf.Sample, func(i, j int) bool {


### PR DESCRIPTION
This backports #2515. If a user upgrades the github.com/google/pprof to the
latest version, the profiler client won't compile.
