### PR TITLE
ddtrace/opentelemetry: add RWMutex to handle concurrent calls to setters

### DIFF
--- a/ddtrace/opentelemetry/span.go
+++ b/ddtrace/opentelemetry/span.go
@@ -46,6 +46,8 @@ func (s *span) SetName(name string) {
 }
 
 func (s *span) End(options ...oteltrace.SpanEndOption) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.finished {
 		return
 	}

--- a/ddtrace/opentelemetry/span.go
+++ b/ddtrace/opentelemetry/span.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"strconv"
 	"strings"
+	"sync"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
@@ -25,7 +26,8 @@ import (
 var _ oteltrace.Span = (*span)(nil)
 
 type span struct {
-	noop.Span  // https://pkg.go.dev/go.opentelemetry.io/otel/trace#hdr-API_Implementations
+	noop.Span               // https://pkg.go.dev/go.opentelemetry.io/otel/trace#hdr-API_Implementations
+	mu         sync.RWMutex `msg:"-"` // all fields are protected by this RWMutex
 	DD         tracer.Span
 	finished   bool
 	attributes map[string]interface{}
@@ -38,6 +40,8 @@ type span struct {
 func (s *span) TracerProvider() oteltrace.TracerProvider { return s.oteltracer.provider }
 
 func (s *span) SetName(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.attributes[ext.SpanName] = strings.ToLower(name)
 }
 
@@ -157,6 +161,8 @@ type statusInfo struct {
 // value before (OK > Error > Unset), the code will not be changed.
 // The code and description are set once when the span is finished.
 func (s *span) SetStatus(code otelcodes.Code, description string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if code >= s.statusInfo.code {
 		s.statusInfo = statusInfo{code, description}
 	}
@@ -175,6 +181,8 @@ func (s *span) SetStatus(code otelcodes.Code, description string) {
 // The list of reserved tags might be extended in the future.
 // Any other non-reserved tags will be set as provided.
 func (s *span) SetAttributes(kv ...attribute.KeyValue) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	for _, kv := range kv {
 		if k, v := toReservedAttributes(string(kv.Key), kv.Value); k != "" {
 			s.attributes[k] = v

--- a/ddtrace/opentelemetry/tracer_test.go
+++ b/ddtrace/opentelemetry/tracer_test.go
@@ -207,6 +207,25 @@ func TestSpanTelemetry(t *testing.T) {
 	telemetryClient.AssertNumberOfCalls(t, "Count", 1)
 }
 
+func TestConcurrentSetAttributes(t *testing.T) {
+	tp := NewTracerProvider()
+	otel.SetTracerProvider(tp)
+	tr := otel.Tracer("")
+
+	_, span := tr.Start(context.Background(), "test")
+	defer span.End()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		i := i
+		go func(val int) {
+			defer wg.Done()
+			span.SetAttributes(attribute.Float64("workerID", float64(i)))
+		}(i)
+	}
+}
+
 func BenchmarkOTelApiWithNoTags(b *testing.B) {
 	testData := struct {
 		env, srv, op string

--- a/ddtrace/opentelemetry/tracer_test.go
+++ b/ddtrace/opentelemetry/tracer_test.go
@@ -207,7 +207,7 @@ func TestSpanTelemetry(t *testing.T) {
 	telemetryClient.AssertNumberOfCalls(t, "Count", 1)
 }
 
-func TestConcurrentSetAttributes(t *testing.T) {
+func TestConcurrentSetAttributes(_ *testing.T) {
 	tp := NewTracerProvider()
 	otel.SetTracerProvider(tp)
 	tr := otel.Tracer("")

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -349,6 +349,8 @@ func (p *propagator) injectTextMap(spanCtx ddtrace.SpanContext, writer TextMapWr
 	if !ok || ctx.traceID.Empty() || ctx.spanID == 0 {
 		return ErrInvalidSpanContext
 	}
+	ctx.mu.Lock()
+	defer ctx.mu.Unlock()
 	// propagate the TraceID and the current active SpanID
 	if ctx.traceID.HasUpper() {
 		setPropagatingTag(ctx, keyTraceID128, ctx.traceID.UpperHex())

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -922,7 +922,7 @@ func TestTracerBaggageImmutability(t *testing.T) {
 	assert.Equal("changed!", childContext.baggage["key"])
 }
 
-func TestTracerBaggageConcurrency(_ *testing.T) {
+func TestTracerInjectConcurrency(_ *testing.T) {
 	tr := newTracer()
 	defer tr.Stop()
 	span, _ := StartSpanFromContext(context.Background(), "main")

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -922,6 +922,28 @@ func TestTracerBaggageImmutability(t *testing.T) {
 	assert.Equal("changed!", childContext.baggage["key"])
 }
 
+func TestTracerBaggageConcurrency(_ *testing.T) {
+	tr := newTracer()
+	defer tr.Stop()
+	span, _ := StartSpanFromContext(context.Background(), "main")
+	defer span.Finish()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 500; i++ {
+		wg.Add(1)
+		i := i
+		go func(val int) {
+			defer wg.Done()
+			span.SetBaggageItem("val", fmt.Sprintf("%d", val))
+
+			traceContext := map[string]string{}
+			_ = tr.Inject(span.Context(), TextMapCarrier(traceContext))
+		}(i)
+	}
+
+	wg.Wait()
+}
+
 func TestTracerSpanTags(t *testing.T) {
 	tracer := newTracer()
 	defer tracer.Stop()

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -922,9 +922,9 @@ func TestTracerBaggageImmutability(t *testing.T) {
 	assert.Equal("changed!", childContext.baggage["key"])
 }
 
-func TestTracerInjectConcurrency(_ *testing.T) {
-	tr := newTracer()
-	defer tr.Stop()
+func TestTracerInjectConcurrency(t *testing.T) {
+	tracer, _, _, stop := startTestTracer(t)
+	defer stop()
 	span, _ := StartSpanFromContext(context.Background(), "main")
 	defer span.Finish()
 
@@ -937,7 +937,7 @@ func TestTracerInjectConcurrency(_ *testing.T) {
 			span.SetBaggageItem("val", fmt.Sprintf("%d", val))
 
 			traceContext := map[string]string{}
-			_ = tr.Inject(span.Context(), TextMapCarrier(traceContext))
+			_ = tracer.Inject(span.Context(), TextMapCarrier(traceContext))
 		}(i)
 	}
 


### PR DESCRIPTION
### What does this PR do?

Fixes #2518.

### Motivation

Making sure OTel spans can be used concurrently, as our `tracer.Span`.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
