### PR TITLE
.github/workflows: fixes apm:ecosystem label for issues and PRs

### DIFF
--- a/.github/workflows/ecosystems-label-issue copy.yml
+++ b/.github/workflows/ecosystems-label-issue copy.yml
@@ -7,7 +7,7 @@ on:
       - edited
 jobs:
   label_issues:
-    if: contains(github.event.pull_request.title, 'contrib')
+    if: contains(github.event.issue.title, 'contrib')
     runs-on: ubuntu-latest
     steps:
       # https://github.com/marketplace/actions/actions-ecosystem-add-labels

--- a/.github/workflows/ecosystems-label-issue copy.yml
+++ b/.github/workflows/ecosystems-label-issue copy.yml
@@ -1,0 +1,17 @@
+name: Label APM Ecosystems issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+      - edited
+jobs:
+  label_issues:
+    if: contains(github.event.pull_request.title, 'contrib')
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/marketplace/actions/actions-ecosystem-add-labels
+      - name: add label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: apm:ecosystem

--- a/.github/workflows/ecosystems-label-pr.yml
+++ b/.github/workflows/ecosystems-label-pr.yml
@@ -1,4 +1,4 @@
-name: Label APM Ecosystems issues
+name: Label APM Ecosystems Pull Requests
 on:
   pull_request:
     paths:

--- a/.github/workflows/ecosystems-label-pr.yml
+++ b/.github/workflows/ecosystems-label-pr.yml
@@ -1,12 +1,5 @@
 name: Label APM Ecosystems issues
 on:
-  issues:
-    paths:
-      - "contrib/**"
-    types:
-      - reopened
-      - opened
-      - edited
   pull_request:
     paths:
       - "contrib/**"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Separates the workflows for PRs and issues to add the `apm:ecosystem` label. We now have two workflows to add the label:
  1. Looks for PRs with files in any `contrib/*` directory
  2. Looks for issues with `contrib` in the title

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

It's broken today, and adding the labels on _every_ issue, which we don't want. For example: https://github.com/DataDog/dd-trace-go/issues/2516.

This broke when https://github.com/DataDog/dd-trace-go/pull/2496/files# was merged, because it stopped filtering the issues based on the title, and started relying on path instead (which in hindsight, won't work). Separating the workflows allows the job to use the `if: contains(github.event.issue.title, 'contrib')` constraint for issues, and allows a check on the files with `contrib/**` in the path for pull requests.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
