### PR TITLE
tracer: verify that hostname reporting is honored regardless of stats calculation

### DIFF
--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1717,6 +1717,23 @@ func TestTracerReportsHostname(t *testing.T) {
 		assert.True(ok)
 		assert.Equal(got, hostname)
 	})
+
+	t.Run("DD_TRACE_SOURCE_HOSTNAME/unset", func(t *testing.T) {
+		tracer, _, _, stop := startTestTracer(t)
+		defer stop()
+
+		root := tracer.StartSpan("root").(*span)
+		child := tracer.StartSpan("child", ChildOf(root.Context())).(*span)
+		child.Finish()
+		root.Finish()
+
+		assert := assert.New(t)
+
+		_, ok := root.Meta[keyHostname]
+		assert.False(ok)
+		_, ok = child.Meta[keyHostname]
+		assert.False(ok)
+	})
 }
 
 func TestVersion(t *testing.T) {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1627,87 +1627,6 @@ func TestTracerFlush(t *testing.T) {
 func TestTracerReportsHostname(t *testing.T) {
 	const hostname = "hostname-test"
 
-	t.Run("DD_TRACE_REPORT_HOSTNAME/set", func(t *testing.T) {
-		t.Setenv("DD_TRACE_REPORT_HOSTNAME", "true")
-
-		tracer, _, _, stop := startTestTracer(t)
-		defer stop()
-
-		root := tracer.StartSpan("root").(*span)
-		child := tracer.StartSpan("child", ChildOf(root.Context())).(*span)
-		child.Finish()
-		root.Finish()
-
-		assert := assert.New(t)
-
-		name, ok := root.Meta[keyHostname]
-		assert.True(ok)
-		assert.Equal(name, tracer.config.hostname)
-
-		name, ok = child.Meta[keyHostname]
-		assert.True(ok)
-		assert.Equal(name, tracer.config.hostname)
-	})
-
-	t.Run("DD_TRACE_REPORT_HOSTNAME/unset", func(t *testing.T) {
-		tracer, _, _, stop := startTestTracer(t)
-		defer stop()
-
-		root := tracer.StartSpan("root").(*span)
-		child := tracer.StartSpan("child", ChildOf(root.Context())).(*span)
-		child.Finish()
-		root.Finish()
-
-		assert := assert.New(t)
-
-		_, ok := root.Meta[keyHostname]
-		assert.False(ok)
-		_, ok = child.Meta[keyHostname]
-		assert.False(ok)
-	})
-
-	t.Run("WithHostname", func(t *testing.T) {
-		tracer, _, _, stop := startTestTracer(t, WithHostname(hostname))
-		defer stop()
-
-		root := tracer.StartSpan("root").(*span)
-		child := tracer.StartSpan("child", ChildOf(root.Context())).(*span)
-		child.Finish()
-		root.Finish()
-
-		assert := assert.New(t)
-
-		got, ok := root.Meta[keyHostname]
-		assert.True(ok)
-		assert.Equal(got, hostname)
-
-		got, ok = child.Meta[keyHostname]
-		assert.True(ok)
-		assert.Equal(got, hostname)
-	})
-
-	t.Run("DD_TRACE_SOURCE_HOSTNAME/set", func(t *testing.T) {
-		t.Setenv("DD_TRACE_SOURCE_HOSTNAME", "hostname-test")
-
-		tracer, _, _, stop := startTestTracer(t)
-		defer stop()
-
-		root := tracer.StartSpan("root").(*span)
-		child := tracer.StartSpan("child", ChildOf(root.Context())).(*span)
-		child.Finish()
-		root.Finish()
-
-		assert := assert.New(t)
-
-		got, ok := root.Meta[keyHostname]
-		assert.True(ok)
-		assert.Equal(got, hostname)
-
-		got, ok = child.Meta[keyHostname]
-		assert.True(ok)
-		assert.Equal(got, hostname)
-	})
-
 	testReportHostnameEnabled := func(t *testing.T, name string, withComputeStats bool) {
 		t.Run(name, func(t *testing.T) {
 			t.Setenv("DD_TRACE_REPORT_HOSTNAME", "true")
@@ -1756,6 +1675,48 @@ func TestTracerReportsHostname(t *testing.T) {
 	}
 	testReportHostnameDisabled(t, "DD_TRACE_REPORT_HOSTNAME/unset,DD_TRACE_COMPUTE_STATS/true", true)
 	testReportHostnameDisabled(t, "DD_TRACE_REPORT_HOSTNAME/unset,DD_TRACE_COMPUTE_STATS/false", false)
+
+	t.Run("WithHostname", func(t *testing.T) {
+		tracer, _, _, stop := startTestTracer(t, WithHostname(hostname))
+		defer stop()
+
+		root := tracer.StartSpan("root").(*span)
+		child := tracer.StartSpan("child", ChildOf(root.Context())).(*span)
+		child.Finish()
+		root.Finish()
+
+		assert := assert.New(t)
+
+		got, ok := root.Meta[keyHostname]
+		assert.True(ok)
+		assert.Equal(got, hostname)
+
+		got, ok = child.Meta[keyHostname]
+		assert.True(ok)
+		assert.Equal(got, hostname)
+	})
+
+	t.Run("DD_TRACE_SOURCE_HOSTNAME/set", func(t *testing.T) {
+		t.Setenv("DD_TRACE_SOURCE_HOSTNAME", "hostname-test")
+
+		tracer, _, _, stop := startTestTracer(t)
+		defer stop()
+
+		root := tracer.StartSpan("root").(*span)
+		child := tracer.StartSpan("child", ChildOf(root.Context())).(*span)
+		child.Finish()
+		root.Finish()
+
+		assert := assert.New(t)
+
+		got, ok := root.Meta[keyHostname]
+		assert.True(ok)
+		assert.Equal(got, hostname)
+
+		got, ok = child.Meta[keyHostname]
+		assert.True(ok)
+		assert.Equal(got, hostname)
+	})
 }
 
 func TestVersion(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Expands the current tests to verify that regardless of the value of `DD_TRACE_COMPUTE_STATS`, the `DD_TRACE_REPORT_HOSTNAME` variable is always respected.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

This is important to prevent an unintentional cardinality increase when tracer stats are enabled, and would maintain inheritance of host tags. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
