### PR TITLE
opentelemetry: refactor span links code for clarity

### DIFF
--- a/ddtrace/opentelemetry/span_test.go
+++ b/ddtrace/opentelemetry/span_test.go
@@ -135,59 +135,54 @@ func TestSpanSetName(t *testing.T) {
 
 func TestSpanLink(t *testing.T) {
 	assert := assert.New(t)
-
-	_, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	_, payloads, cleanup := mockTracerProvider(t)
+	tr := otel.Tracer("")
+	defer cleanup()
 
 	// Use traceID, spanID, and traceflags that can be unmarshalled from unint64 to float64 without loss of precision
 	traceID, _ := oteltrace.TraceIDFromHex("00000000000001c8000000000000007b")
 	spanID, _ := oteltrace.SpanIDFromHex("000000000000000f")
-	traceState, _ := oteltrace.ParseTraceState("dd_origin=ci")
+	traceStateVal := "dd_origin=ci"
+	traceState, _ := oteltrace.ParseTraceState(traceStateVal)
 	remoteSpanContext := oteltrace.NewSpanContext(
 		oteltrace.SpanContextConfig{
 			TraceID:    traceID,
 			SpanID:     spanID,
-			TraceFlags: 0x0,
+			TraceFlags: oteltrace.FlagsSampled,
 			TraceState: traceState,
 			Remote:     true,
 		},
 	)
 
-	_, payloads, cleanup := mockTracerProvider(t)
-	tr := otel.Tracer("")
-	defer cleanup()
-
 	// Create a span with a link to a remote span
-	_, decoratedSpan := tr.Start(context.Background(), "span_with_link",
+	_, span := tr.Start(context.Background(), "span_with_link",
 		oteltrace.WithLinks(oteltrace.Link{
 			SpanContext: remoteSpanContext,
 			Attributes:  []attribute.KeyValue{attribute.String("link.name", "alpha_transaction")},
 		}))
-	decoratedSpan.End()
+	span.End()
 
-	// Flush span with link and unmarshal the payload to a map
 	tracer.Flush()
 	payload, err := waitForPayload(payloads)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
 	assert.NotNil(payload)
-	// Ensure payload contains one trace and one span
-	assert.Len(payload[0], 1)
+	assert.Len(payload, 1)    // only one trace
+	assert.Len(payload[0], 1) // only one span
 
-	// Convert the span_links field from type []map[string]interface{} to a struct
 	var spanLinks []ddtrace.SpanLink
 	spanLinkBytes, _ := json.Marshal(payload[0][0]["span_links"])
 	json.Unmarshal(spanLinkBytes, &spanLinks)
-	assert.Len(spanLinks, 1)
+	assert.Len(spanLinks, 1) // only one span link
 
 	// Ensure the span link has the correct values
-	assert.Equal(spanLinks[0].TraceID, uint64(123))
-	assert.Equal(spanLinks[0].TraceIDHigh, uint64(456))
-	assert.Equal(spanLinks[0].SpanID, uint64(15))
-	assert.Equal(spanLinks[0].Attributes, map[string]string{"link.name": "alpha_transaction"})
-	assert.Equal(spanLinks[0].Tracestate, "dd_origin=ci")
-	assert.Equal(spanLinks[0].Flags, uint32(0x80000000))
+	assert.Equal(uint64(123), spanLinks[0].TraceID)
+	assert.Equal(uint64(456), spanLinks[0].TraceIDHigh)
+	assert.Equal(uint64(15), spanLinks[0].SpanID)
+	assert.Equal(map[string]string{"link.name": "alpha_transaction"}, spanLinks[0].Attributes)
+	assert.Equal(traceStateVal, spanLinks[0].Tracestate)
+	assert.Equal(uint32(oteltrace.FlagsSampled), spanLinks[0].Flags)
 }
 
 func TestSpanEnd(t *testing.T) {

--- a/ddtrace/opentelemetry/span_test.go
+++ b/ddtrace/opentelemetry/span_test.go
@@ -182,7 +182,7 @@ func TestSpanLink(t *testing.T) {
 	assert.Equal(uint64(15), spanLinks[0].SpanID)
 	assert.Equal(map[string]string{"link.name": "alpha_transaction"}, spanLinks[0].Attributes)
 	assert.Equal(traceStateVal, spanLinks[0].Tracestate)
-	assert.Equal(uint32(oteltrace.FlagsSampled), spanLinks[0].Flags)
+	assert.Equal(uint32(0x80000001), spanLinks[0].Flags) // sampled and set
 }
 
 func TestSpanEnd(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This change also includes a number of refactors, including some additional information about the trace flags.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

We should maintain some of the logic in the original PR when creating the DD span link: https://github.com/DataDog/dd-trace-go/pull/2396/files#diff-328a045c801a15647d453336c495d31dcd8016d29df86de478c77769d6792567

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
