### PR TITLE
chore: make the smoke-test workflow usable as go-libddwaf integ test

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -4,8 +4,12 @@ on:
   workflow_call: # allows to reuse this workflow
     inputs:
       ref:
-        description: 'The branch to run the workflow on'
+        description: The branch or tag to run the workflow on
         required: true
+        type: string
+      go-libddwaf-ref:
+        description: A git ref to update github.com/DataDog/go-libddwaf/v2 to. No-op if empty.
+        required: false
         type: string
   push:
     branches:
@@ -41,8 +45,13 @@ jobs:
           go-version: "stable"
           cache: true
       - name: go get -u
-        run: |
+        run: |-
           go get -u -t $PACKAGES
+          go mod tidy
+      - name: Install requested go-libddwaf version
+        if: github.event_name == 'workflow_call' && inputs.go-libddwaf-ref != ''
+        run: |-
+          go get -u -t github.com/DataDog/go-libddwaf/v2@${{ inputs.go-libddwaf-ref }}
           go mod tidy
       - name: Compile dd-trace-go
         run: go build $PACKAGES
@@ -142,5 +151,6 @@ jobs:
             build_with_vendoring=${{ matrix.build-with-vendoring }}
             build_with_cgo=${{ matrix.build-with-cgo }}
             deployment_env=${{ matrix.deployment-env }}
+            go_libddwaf_ref=${{ inputs.go-libddwaf-ref }}
       - name: Test
         run: docker run -p7777:7777 --rm smoke-test

--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -42,6 +42,12 @@ RUN set -ex; if [ "$build_env" = "alpine" ] && [ "$build_with_cgo" = "1" ]; then
       apk update && apk add gcc libc-dev; \
     fi
 
+# If requested, upgrade go-libddwaf to the desired release.
+ARG go_libddwaf_ref=""
+RUN if [ "${go_libddwaf_ref}" != "" ]; then \
+    go get -u github.com/DataDog/go-libddwaf/v2@${go_libddwaf_ref}; \
+  fi
+
 RUN go mod tidy
 
 ARG build_with_vendoring


### PR DESCRIPTION

### What does this PR do?

In order to prevent reoccurrences of issues where non-go files are located in places incompatible with `go mod vendor`, which the smoke test accurately detects, we are going to run the smoke tests as part of the CI suite in go-libddwaf itself. This requires being able to pin the go-libddwaf version to the commit being CI'd.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
