### PR TITLE
chore: fix smoke test workflow_call situation

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -40,6 +40,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+          # Manually specify the repository, which is necessary in the workflow_call situation, as the default is
+          # otherwise the repository where the caller workflow started from. In this case, we need to check out the
+          # repository where the called workflow is (i.e, this repository); but I don't know of a more elegant way to
+          # obtain its name than hard-coding it.
+          repository: DataDog/dd-trace-go
       - uses: actions/setup-go@v3
         with:
           go-version: "stable"
@@ -135,6 +140,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+          # Manually specify the repository, which is necessary in the workflow_call situation, as the default is
+          # otherwise the repository where the caller workflow started from. In this case, we need to check out the
+          # repository where the called workflow is (i.e, this repository); but I don't know of a more elegant way to
+          # obtain its name than hard-coding it.
+          repository: DataDog/dd-trace-go
       - uses: docker/setup-buildx-action@v3
       - name: Build
         uses: docker/build-push-action@v5


### PR DESCRIPTION
### What does this PR do?

The default repository being checked out by `actions/checkout` is the one designated by `${{ github.repository }}`, which is the repository where the original event (at the root of the workflow call tree) started.

We however must check out the source to `dd-trace-go` and not that of the caller workflow. This requires hard-coding the repository name here.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
