### PR TITLE
chore: make git available in smoke-test docker image

### DIFF
--- a/internal/apps/setup-smoke-test/Dockerfile
+++ b/internal/apps/setup-smoke-test/Dockerfile
@@ -37,7 +37,7 @@ RUN go env -w CGO_ENABLED=$build_with_cgo
 
 # GCC and the C library headers are needed for compilation of runtime/cgo with
 # CGO_ENABLED=1 - but the golang:alpine image doesn't provide them out of the box.
-ARG build_env
+ARG build_env="bookworm"
 RUN set -ex; if [ "$build_env" = "alpine" ] && [ "$build_with_cgo" = "1" ]; then \
       apk update && apk add gcc libc-dev; \
     fi
@@ -45,7 +45,11 @@ RUN set -ex; if [ "$build_env" = "alpine" ] && [ "$build_with_cgo" = "1" ]; then
 # If requested, upgrade go-libddwaf to the desired release.
 ARG go_libddwaf_ref=""
 RUN if [ "${go_libddwaf_ref}" != "" ]; then \
-    go get -u github.com/DataDog/go-libddwaf/v2@${go_libddwaf_ref}; \
+  case "${build_env}" in \
+  alpine) apk update && apk add git;; \
+  *) apt update && apt install -y git ;; \
+  esac; \
+  go get -u github.com/DataDog/go-libddwaf/v2@${go_libddwaf_ref}; \
   fi
 
 RUN go mod tidy


### PR DESCRIPTION
### What does this PR do?

When installing go-libddwaf from a Git ref that is not available from the go module proxy, the build fails upon trying to use git to check out the requested source. This is always the case when requesting a particular git SHA.


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
