### PR TITLE
contrib/database/sql: add in ddh, dddb propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ might be running versions different from the vendored one, creating hard to debu
 To run integration tests locally, you should set the `INTEGRATION` environment variable. The dependencies of the integration tests are best run via Docker. To get an
 idea about the versions and the set-up take a look at our [docker-compose config](./docker-compose.yaml).
 
-The best way to run the entire test suite is using the [test.sh](./test.sh) script. You'll need Docker and docker-compose installed. Run `./test.sh --all` to run all of the integration tests through the docker-compose environment. Run `./test.sh --help` for more options.
+The best way to run the entire test suite is using the [test.sh](./test.sh) script. You'll need Docker and docker-compose installed. If this is your first time running the tests, you should run `./test.sh -t` to install any missing test tools/dependencies. Run `./test.sh --all` to run all of the integration tests through the docker-compose environment. Run `./test.sh --help` for more options.
 
 If you're only interested in the tests for a specific integration it can be useful to spin up just the required containers via docker-compose.
 For example if you're running tests that need the `mysql` database container to be up:

--- a/contrib/database/sql/conn.go
+++ b/contrib/database/sql/conn.go
@@ -253,7 +253,7 @@ func (tc *TracedConn) injectComments(ctx context.Context, query string, mode tra
 	if span, ok := tracer.SpanFromContext(ctx); ok {
 		spanCtx = span.Context()
 	}
-	carrier := tracer.SQLCommentCarrier{Query: query, Mode: mode, DBServiceName: tc.cfg.serviceName}
+	carrier := tracer.SQLCommentCarrier{Query: query, Mode: mode, DBServiceName: tc.cfg.serviceName, PeerDBHostname: tc.meta[ext.TargetHost], PeerDBName: tc.meta[ext.DBName]}
 	if err := carrier.Inject(spanCtx); err != nil {
 		// this should never happen
 		log.Warn("contrib/database/sql: failed to inject query comments: %v", err)

--- a/contrib/database/sql/internal/dsn.go
+++ b/contrib/database/sql/internal/dsn.go
@@ -7,6 +7,7 @@ package internal // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql
 
 import (
 	"net"
+	"net/url"
 	"strings"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
@@ -32,7 +33,15 @@ func ParseDSN(driverName, dsn string) (meta map[string]string, err error) {
 			return
 		}
 	default:
-		// not supported
+		// Try to parse the DSN and see if the scheme contains a known driver name.
+		u, err := url.Parse(dsn)
+		if err != nil {
+			// dsn is not a valid URL, so just ignore
+			break
+		}
+		if driverName != u.Scheme {
+			return ParseDSN(u.Scheme, dsn)
+		}
 	}
 	return reduceKeys(meta), nil
 }

--- a/contrib/database/sql/propagation_test.go
+++ b/contrib/database/sql/propagation_test.go
@@ -37,6 +37,7 @@ func TestDBMPropagation(t *testing.T) {
 		opts     []RegisterOption
 		callDB   func(ctx context.Context, db *sql.DB) error
 		prepared []string
+		dsn      string
 		executed []*regexp.Regexp
 	}{
 		{
@@ -73,7 +74,8 @@ func TestDBMPropagation(t *testing.T) {
 				_, err := db.PrepareContext(ctx, "SELECT 1 from DUAL")
 				return err
 			},
-			prepared: []string{"/*dddbs='test.db',dde='test-env',ddps='test-service',ddpv='1.0.0'*/ SELECT 1 from DUAL"},
+			dsn:      "postgres://postgres:postgres@127.0.0.1:5432/fakepreparedb?sslmode=disable",
+			prepared: []string{"/*dddbs='test.db',dde='test-env',ddps='test-service',ddpv='1.0.0',ddh='127.0.0.1',dddb='fakepreparedb'*/ SELECT 1 from DUAL"},
 		},
 		{
 			name: "query",
@@ -109,7 +111,8 @@ func TestDBMPropagation(t *testing.T) {
 				_, err := db.QueryContext(ctx, "SELECT 1 from DUAL")
 				return err
 			},
-			executed: []*regexp.Regexp{regexp.MustCompile("/\\*dddbs='test.db',dde='test-env',ddps='test-service',ddpv='1.0.0',traceparent='00-00000000000000000000000000000001-[\\da-f]{16}-01'\\*/ SELECT 1 from DUAL")},
+			dsn:      "postgres://postgres:postgres@127.0.0.1:5432/fakequerydb?sslmode=disable",
+			executed: []*regexp.Regexp{regexp.MustCompile("/\\*dddbs='test.db',dde='test-env',ddps='test-service',ddpv='1.0.0',traceparent='00-00000000000000000000000000000001-[\\da-f]{16}-01',ddh='127.0.0.1',dddb='fakequerydb'\\*/ SELECT 1 from DUAL")},
 		},
 		{
 			name: "exec",
@@ -145,7 +148,8 @@ func TestDBMPropagation(t *testing.T) {
 				_, err := db.ExecContext(ctx, "SELECT 1 from DUAL")
 				return err
 			},
-			executed: []*regexp.Regexp{regexp.MustCompile("/\\*dddbs='test.db',dde='test-env',ddps='test-service',ddpv='1.0.0',traceparent='00-00000000000000000000000000000001-[\\da-f]{16}-01'\\*/ SELECT 1 from DUAL")},
+			dsn:      "postgres://postgres:postgres@127.0.0.1:5432/fakeexecdb?sslmode=disable",
+			executed: []*regexp.Regexp{regexp.MustCompile("/\\*dddbs='test.db',dde='test-env',ddps='test-service',ddpv='1.0.0',traceparent='00-00000000000000000000000000000001-[\\da-f]{16}-01',ddh='127.0.0.1',dddb='fakeexecdb'\\*/ SELECT 1 from DUAL")},
 		},
 	}
 
@@ -163,9 +167,12 @@ func TestDBMPropagation(t *testing.T) {
 			Register("test", d, tc.opts...)
 			defer unregister("test")
 
-			db, err := Open("test", "dn")
+			dsn := "dn"
+			if tc.dsn != "" {
+				dsn = tc.dsn
+			}
+			db, err := Open("test", dsn)
 			require.NoError(t, err)
-
 			s, ctx := tracer.StartSpanFromContext(context.Background(), "test.call", tracer.WithSpanID(1))
 			err = tc.callDB(ctx, db)
 			s.Finish()

--- a/ddtrace/tracer/sqlcomment.go
+++ b/ddtrace/tracer/sqlcomment.go
@@ -57,8 +57,10 @@ const (
 	sqlCommentDBService     = "dddbs"
 	sqlCommentParentVersion = "ddpv"
 	sqlCommentEnv           = "dde"
-	sqlCommentPeerHostname  = "ddh"
-	sqlCommentPeerDBName    = "dddb"
+	// These keys are for the database we are connecting to, instead of the service we are running in.
+	// "Peer" is the OpenTelemetry nomenclature for "thing I am talking to"
+	sqlCommentPeerHostname = "ddh"
+	sqlCommentPeerDBName   = "dddb"
 )
 
 // Current trace context version (see https://www.w3.org/TR/trace-context/#version)

--- a/ddtrace/tracer/sqlcomment_test.go
+++ b/ddtrace/tracer/sqlcomment_test.go
@@ -26,6 +26,8 @@ func TestSQLCommentCarrier(t *testing.T) {
 		mode               DBMPropagationMode
 		injectSpan         bool
 		samplingPriority   int
+		peerDBHostname     string
+		peerDBName         string
 		expectedQuery      string
 		expectedSpanIDGen  bool
 		expectedExtractErr error
@@ -35,6 +37,8 @@ func TestSQLCommentCarrier(t *testing.T) {
 			query:              "SELECT * from FOO",
 			mode:               DBMPropagationModeFull,
 			injectSpan:         true,
+			peerDBHostname:     "",
+			peerDBName:         "",
 			expectedQuery:      "/*dddbs='whiskey-db',dde='test-env',ddps='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddpv='1.0.0',traceparent='00-0000000000000000000000000000000a-<span_id>-00'*/ SELECT * from FOO",
 			expectedSpanIDGen:  true,
 			expectedExtractErr: nil,
@@ -44,6 +48,8 @@ func TestSQLCommentCarrier(t *testing.T) {
 			query:              "SELECT * from FOO",
 			mode:               DBMPropagationModeService,
 			injectSpan:         true,
+			peerDBHostname:     "",
+			peerDBName:         "",
 			expectedQuery:      "/*dddbs='whiskey-db',dde='test-env',ddps='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddpv='1.0.0'*/ SELECT * from FOO",
 			expectedSpanIDGen:  false,
 			expectedExtractErr: ErrSpanContextNotFound,
@@ -52,6 +58,8 @@ func TestSQLCommentCarrier(t *testing.T) {
 			name:               "no-trace",
 			query:              "SELECT * from FOO",
 			mode:               DBMPropagationModeFull,
+			peerDBHostname:     "",
+			peerDBName:         "",
 			expectedQuery:      "/*dddbs='whiskey-db',ddps='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',traceparent='00-0000000000000000<span_id>-<span_id>-00'*/ SELECT * from FOO",
 			expectedSpanIDGen:  true,
 			expectedExtractErr: nil,
@@ -61,6 +69,8 @@ func TestSQLCommentCarrier(t *testing.T) {
 			query:              "",
 			mode:               DBMPropagationModeFull,
 			injectSpan:         true,
+			peerDBHostname:     "",
+			peerDBName:         "",
 			expectedQuery:      "/*dddbs='whiskey-db',dde='test-env',ddps='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddpv='1.0.0',traceparent='00-0000000000000000000000000000000a-<span_id>-00'*/",
 			expectedSpanIDGen:  true,
 			expectedExtractErr: nil,
@@ -91,7 +101,45 @@ func TestSQLCommentCarrier(t *testing.T) {
 			mode:               DBMPropagationModeFull,
 			injectSpan:         true,
 			samplingPriority:   1,
+			peerDBHostname:     "",
+			peerDBName:         "",
 			expectedQuery:      "/*dddbs='whiskey-db',dde='test-env',ddps='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddpv='1.0.0',traceparent='00-0000000000000000000000000000000a-<span_id>-01'*/ /* c */ SELECT * from FOO /**/",
+			expectedSpanIDGen:  true,
+			expectedExtractErr: nil,
+		},
+		{
+			name:               "peer_entity_tags_dddb",
+			query:              "/* c */ SELECT * from FOO /**/",
+			mode:               DBMPropagationModeFull,
+			injectSpan:         true,
+			samplingPriority:   1,
+			peerDBName:         "fake-database",
+			peerDBHostname:     "",
+			expectedQuery:      "/*dddbs='whiskey-db',dde='test-env',ddps='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddpv='1.0.0',traceparent='00-0000000000000000000000000000000a-<span_id>-01',dddb='fake-database'*/ /* c */ SELECT * from FOO /**/",
+			expectedSpanIDGen:  true,
+			expectedExtractErr: nil,
+		},
+		{
+			name:               "peer_entity_tags_ddh",
+			query:              "/* c */ SELECT * from FOO /**/",
+			mode:               DBMPropagationModeFull,
+			injectSpan:         true,
+			samplingPriority:   1,
+			peerDBHostname:     "fake-hostname",
+			peerDBName:         "",
+			expectedQuery:      "/*dddbs='whiskey-db',dde='test-env',ddps='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddpv='1.0.0',traceparent='00-0000000000000000000000000000000a-<span_id>-01',ddh='fake-hostname'*/ /* c */ SELECT * from FOO /**/",
+			expectedSpanIDGen:  true,
+			expectedExtractErr: nil,
+		},
+		{
+			name:               "peer_entity_tags_dddb_and_ddh",
+			query:              "/* c */ SELECT * from FOO /**/",
+			mode:               DBMPropagationModeFull,
+			injectSpan:         true,
+			samplingPriority:   1,
+			peerDBHostname:     "fake-hostname",
+			peerDBName:         "fake-database",
+			expectedQuery:      "/*dddbs='whiskey-db',dde='test-env',ddps='whiskey-service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddpv='1.0.0',traceparent='00-0000000000000000000000000000000a-<span_id>-01',ddh='fake-hostname',dddb='fake-database'*/ /* c */ SELECT * from FOO /**/",
 			expectedSpanIDGen:  true,
 			expectedExtractErr: nil,
 		},
@@ -114,7 +162,7 @@ func TestSQLCommentCarrier(t *testing.T) {
 				spanCtx = root.Context()
 			}
 
-			carrier := SQLCommentCarrier{Query: tc.query, Mode: tc.mode, DBServiceName: "whiskey-db"}
+			carrier := SQLCommentCarrier{Query: tc.query, Mode: tc.mode, DBServiceName: "whiskey-db", PeerDBHostname: tc.peerDBHostname, PeerDBName: tc.peerDBName}
 			err := carrier.Inject(spanCtx)
 			require.NoError(t, err)
 			expected := strings.ReplaceAll(tc.expectedQuery, "<span_id>", fmt.Sprintf("%016s", strconv.FormatUint(carrier.SpanID, 16)))


### PR DESCRIPTION
### What does this PR do?
This PR adds in the `ddh` and `dddb` peer service tags to SQL comments.


### Motivation
This change allows the DBM product to propagate service name information which maps with the inferred entities/services used by APM.  

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [x] There is a benchmark for any new code, or changes to existing code.
- [x] If this interacts with the agent in a new way, a system test has been added.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [x] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
