### PR TITLE
appsec: enable API Security by default

### DIFF
--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -15,12 +15,14 @@ on:
       - 'internal/appsec/**'
       - 'appsec/**'
       - 'contrib/**/appsec.go'
+      - '**/go.mod'
   merge_group: # on merge groups touching appsec files
     paths:
       - '.github/workflows/appsec.yml'
       - 'internal/appsec/**'
       - 'appsec/**'
       - 'contrib/**/appsec.go'
+      - '**/go.mod'
   push:
     branches: release-v*
 env:

--- a/internal/appsec/waf_test.go
+++ b/internal/appsec/waf_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	internal "github.com/DataDog/appsec-internal-go/appsec"
 	waf "github.com/DataDog/go-libddwaf/v2"
 	pAppsec "gopkg.in/DataDog/dd-trace-go.v1/appsec"
 	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
@@ -448,8 +449,8 @@ func TestAPISecurity(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("enabled", func(t *testing.T) {
-		t.Setenv("DD_EXPERIMENTAL_API_SECURITY_ENABLED", "true")
-		t.Setenv("DD_API_SECURITY_REQUEST_SAMPLE_RATE", "1.0")
+		t.Setenv(internal.EnvAPISecEnabled, "true")
+		t.Setenv(internal.EnvAPISecSampleRate, "1.0")
 		appsec.Start()
 		require.True(t, appsec.Enabled())
 		defer appsec.Stop()
@@ -470,7 +471,7 @@ func TestAPISecurity(t *testing.T) {
 	})
 
 	t.Run("disabled", func(t *testing.T) {
-		t.Setenv("DD_EXPERIMENTAL_API_SECURITY_ENABLED", "false")
+		t.Setenv(internal.EnvAPISecEnabled, "false")
 		appsec.Start()
 		require.True(t, appsec.Enabled())
 		defer appsec.Stop()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Rename DD_EXPERIMENTAL_API_SECURITY_ENABLED to DD_API_SECURITY_ENABLED
and make API Security enable by default (actually done here #2553 as an incident response)

This PR fixes a test that failed during the previous PR and also enables the good workflow to run in case the go.mod files are modified.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
