### PR TITLE
contrib/gorm.io/gorm.v1: do not panic on open

### DIFF
--- a/contrib/gorm.io/gorm.v1/gorm.go
+++ b/contrib/gorm.io/gorm.v1/gorm.go
@@ -36,7 +36,13 @@ const (
 // Open opens a new (traced) database connection. The used driver must be formerly registered
 // using (gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql).Register.
 func Open(dialector gorm.Dialector, cfg *gorm.Config, opts ...Option) (*gorm.DB, error) {
-	db, err := gorm.Open(dialector, cfg)
+	var db *gorm.DB
+	var err error
+	if cfg != nil {
+		db, err = gorm.Open(dialector, cfg)
+	} else {
+		db, err = gorm.Open(dialector)
+	}
 	if err != nil {
 		return db, err
 	}

--- a/contrib/gorm.io/gorm.v1/gorm_test.go
+++ b/contrib/gorm.io/gorm.v1/gorm_test.go
@@ -50,6 +50,19 @@ func TestMain(m *testing.M) {
 	os.Exit(testResult)
 }
 
+func TestOpenDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			assert.Fail(t, "Opening connection panicked", r)
+		}
+	}()
+	// None of the following calls should end up in a panic.
+	_, _ = gorm.Open(nil, &gorm.Config{})
+	_, _ = gorm.Open(nil, nil)
+	_, _ = Open(nil, &gorm.Config{})
+	_, _ = Open(nil, nil)
+}
+
 func TestMySQL(t *testing.T) {
 	sqltrace.Register("mysql", &mysql.MySQLDriver{}, sqltrace.WithServiceName("mysql-test"))
 	sqlDb, err := sqltrace.Open("mysql", mysqlConnString)


### PR DESCRIPTION
If passing a nil `*gorm.Config` to `Open`, we should not panic, but instead pass nothing on to `gorm`.

Fixes https://github.com/DataDog/dd-trace-go/issues/2559

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
This PR fixes a panic when calling `Open` with a nil-config.
Calling the original `gorm` library with a nil-config is valid (although no-op),
so we should mimic that behavior in dd-trace-go.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Fixes #2559
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
