### PR TITLE
statsdtest: Move mock statsd client for testing into its own package

### DIFF
--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -30,6 +30,7 @@ import (
 	maininternal "gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/statsdtest"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 
 	"github.com/stretchr/testify/assert"
@@ -2240,7 +2241,7 @@ func TestFlush(t *testing.T) {
 	tw := newTestTraceWriter()
 	tr.traceWriter = tw
 
-	ts := &testStatsdClient{}
+	ts := &statsdtest.TestStatsdClient{}
 	tr.statsd = ts
 
 	transport := newDummyTransport()
@@ -2275,11 +2276,11 @@ loop:
 	c.add(as)
 
 	assert.Len(t, tw.Flushed(), 0)
-	assert.Zero(t, ts.flushed)
+	assert.Zero(t, ts.Flushed())
 	assert.Len(t, transport.Stats(), 0)
 	tr.flushSync()
 	assert.Len(t, tw.Flushed(), 1)
-	assert.Equal(t, 1, ts.flushed)
+	assert.Equal(t, 1, ts.Flushed())
 	assert.Len(t, transport.Stats(), 1)
 }
 

--- a/ddtrace/tracer/writer_test.go
+++ b/ddtrace/tracer/writer_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/statsdtest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -243,7 +244,7 @@ func TestLogWriterOverflow(t *testing.T) {
 	t.Run("single-too-big", func(t *testing.T) {
 		assert := assert.New(t)
 		var buf bytes.Buffer
-		var tg testStatsdClient
+		var tg statsdtest.TestStatsdClient
 		cfg := newConfig(withStatsdClient(&tg))
 		statsd, err := newStatsdClient(cfg)
 		require.NoError(t, err)
@@ -263,7 +264,7 @@ func TestLogWriterOverflow(t *testing.T) {
 	t.Run("split", func(t *testing.T) {
 		assert := assert.New(t)
 		var buf bytes.Buffer
-		var tg testStatsdClient
+		var tg statsdtest.TestStatsdClient
 		cfg := newConfig(withStatsdClient(&tg))
 		statsd, err := newStatsdClient(cfg)
 		require.NoError(t, err)
@@ -393,7 +394,7 @@ func TestTraceWriterFlushRetries(t *testing.T) {
 				c.transport = p
 				c.sendRetries = test.configRetries
 			})
-			var statsd testStatsdClient
+			var statsd statsdtest.TestStatsdClient
 
 			h := newAgentTraceWriter(c, nil, &statsd)
 			h.add(ss)
@@ -404,14 +405,12 @@ func TestTraceWriterFlushRetries(t *testing.T) {
 			assert.Equal(test.expAttempts, p.sendAttempts)
 			assert.Equal(test.tracesSent, p.tracesSent)
 
-			statsd.mu.Lock()
-			assert.Equal(1, len(statsd.timingCalls))
+			assert.Equal(1, len(statsd.TimingCalls()))
 			if test.tracesSent {
-				assert.Equal(sentCounts, statsd.counts)
+				assert.Equal(sentCounts, statsd.Counts())
 			} else {
-				assert.Equal(droppedCounts, statsd.counts)
+				assert.Equal(droppedCounts, statsd.Counts())
 			}
-			statsd.mu.Unlock()
 		})
 	}
 }

--- a/internal/statsdtest/statsdtest.go
+++ b/internal/statsdtest/statsdtest.go
@@ -1,0 +1,246 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package statsdtest // import "gopkg.in/DataDog/dd-trace-go.v1/internal/statsdtest"
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type callType int64
+
+const (
+	callTypeGauge callType = iota
+	callTypeIncr
+	callTypeCount
+	callTypeTiming
+)
+
+type TestStatsdClient struct {
+	mu          sync.RWMutex
+	gaugeCalls  []testStatsdCall
+	incrCalls   []testStatsdCall
+	countCalls  []testStatsdCall
+	timingCalls []testStatsdCall
+	counts      map[string]int64
+	tags        []string
+	n           int
+	closed      bool
+	flushed     int
+}
+
+type testStatsdCall struct {
+	name     string
+	floatVal float64
+	intVal   int64
+	timeVal  time.Duration
+	tags     []string
+	rate     float64
+}
+
+func (tg *TestStatsdClient) addCount(name string, value int64) {
+	tg.mu.Lock()
+	defer tg.mu.Unlock()
+	if tg.counts == nil {
+		tg.counts = make(map[string]int64)
+	}
+	tg.counts[name] += value
+}
+
+func (tg *TestStatsdClient) Gauge(name string, value float64, tags []string, rate float64) error {
+	return tg.addMetric(callTypeGauge, tags, testStatsdCall{
+		name:     name,
+		floatVal: value,
+		tags:     make([]string, len(tags)),
+		rate:     rate,
+	})
+}
+
+func (tg *TestStatsdClient) Incr(name string, tags []string, rate float64) error {
+	tg.addCount(name, 1)
+	return tg.addMetric(callTypeIncr, tags, testStatsdCall{
+		name: name,
+		tags: make([]string, len(tags)),
+		rate: rate,
+	})
+}
+
+func (tg *TestStatsdClient) Count(name string, value int64, tags []string, rate float64) error {
+	tg.addCount(name, value)
+	return tg.addMetric(callTypeCount, tags, testStatsdCall{
+		name:   name,
+		intVal: value,
+		tags:   make([]string, len(tags)),
+		rate:   rate,
+	})
+}
+
+func (tg *TestStatsdClient) Timing(name string, value time.Duration, tags []string, rate float64) error {
+	return tg.addMetric(callTypeTiming, tags, testStatsdCall{
+		name:    name,
+		timeVal: value,
+		tags:    make([]string, len(tags)),
+		rate:    rate,
+	})
+}
+
+func (tg *TestStatsdClient) addMetric(ct callType, tags []string, c testStatsdCall) error {
+	tg.mu.Lock()
+	defer tg.mu.Unlock()
+	copy(c.tags, tags)
+	switch ct {
+	case callTypeGauge:
+		tg.gaugeCalls = append(tg.gaugeCalls, c)
+	case callTypeIncr:
+		tg.incrCalls = append(tg.incrCalls, c)
+	case callTypeCount:
+		tg.countCalls = append(tg.countCalls, c)
+	case callTypeTiming:
+		tg.timingCalls = append(tg.timingCalls, c)
+	}
+	tg.tags = tags
+	tg.n++
+	return nil
+}
+
+func (tg *TestStatsdClient) Flush() error {
+	tg.mu.Lock()
+	defer tg.mu.Unlock()
+	tg.flushed++
+	return nil
+}
+
+func (tg *TestStatsdClient) Close() error {
+	tg.closed = true
+	return nil
+}
+
+func (tg *TestStatsdClient) GaugeCalls() []testStatsdCall {
+	tg.mu.RLock()
+	defer tg.mu.RUnlock()
+	c := make([]testStatsdCall, len(tg.gaugeCalls))
+	copy(c, tg.gaugeCalls)
+	return c
+}
+
+func (tg *TestStatsdClient) IncrCalls() []testStatsdCall {
+	tg.mu.RLock()
+	defer tg.mu.RUnlock()
+	c := make([]testStatsdCall, len(tg.incrCalls))
+	copy(c, tg.incrCalls)
+	return c
+}
+
+func (tg *TestStatsdClient) CountCalls() []testStatsdCall {
+	tg.mu.RLock()
+	defer tg.mu.RUnlock()
+	c := make([]testStatsdCall, len(tg.countCalls))
+	copy(c, tg.countCalls)
+	return c
+}
+
+func (tg *TestStatsdClient) TimingCalls() []testStatsdCall {
+	tg.mu.RLock()
+	defer tg.mu.RUnlock()
+	c := make([]testStatsdCall, len(tg.timingCalls))
+	copy(c, tg.countCalls)
+	return c
+}
+
+func (tg *TestStatsdClient) CallNames() []string {
+	tg.mu.RLock()
+	defer tg.mu.RUnlock()
+	var n []string
+	for _, c := range tg.gaugeCalls {
+		n = append(n, c.name)
+	}
+	for _, c := range tg.incrCalls {
+		n = append(n, c.name)
+	}
+	for _, c := range tg.countCalls {
+		n = append(n, c.name)
+	}
+	for _, c := range tg.timingCalls {
+		n = append(n, c.name)
+	}
+	return n
+}
+
+func (tg *TestStatsdClient) CallsByName() map[string]int {
+	tg.mu.RLock()
+	defer tg.mu.RUnlock()
+	counts := make(map[string]int)
+	for _, c := range tg.gaugeCalls {
+		counts[c.name]++
+	}
+	for _, c := range tg.incrCalls {
+		counts[c.name]++
+	}
+	for _, c := range tg.countCalls {
+		counts[c.name]++
+	}
+	for _, c := range tg.timingCalls {
+		counts[c.name]++
+	}
+	return counts
+}
+
+func (tg *TestStatsdClient) Counts() map[string]int64 {
+	tg.mu.RLock()
+	defer tg.mu.RUnlock()
+	c := make(map[string]int64)
+	for key, value := range tg.counts {
+		c[key] = value
+	}
+	return c
+}
+
+func (tg *TestStatsdClient) Tags() []string {
+	tg.mu.RLock()
+	defer tg.mu.RUnlock()
+	t := make([]string, len(tg.tags))
+	copy(t, tg.tags)
+	return t
+}
+
+func (tg *TestStatsdClient) Reset() {
+	tg.mu.Lock()
+	defer tg.mu.Unlock()
+	tg.gaugeCalls = tg.gaugeCalls[:0]
+	tg.incrCalls = tg.incrCalls[:0]
+	tg.countCalls = tg.countCalls[:0]
+	tg.timingCalls = tg.timingCalls[:0]
+	tg.counts = make(map[string]int64)
+	tg.tags = tg.tags[:0]
+	tg.n = 0
+}
+
+// Wait blocks until n metrics have been reported using the statsdtest.TestStatsdClient or until duration d passes.
+// If d passes, or a wait is already active, an error is returned.
+func (tg *TestStatsdClient) Wait(asserts *assert.Assertions, n int, d time.Duration) error {
+	c := func() bool {
+		tg.mu.RLock()
+		defer tg.mu.RUnlock()
+
+		return tg.n >= n
+	}
+	if !asserts.Eventually(c, d, 50*time.Millisecond) {
+		return fmt.Errorf("timed out after waiting %s for gauge events", d)
+	}
+
+	return nil
+}
+
+func (tg *TestStatsdClient) Closed() bool {
+	return tg.closed
+}
+
+func (tg *TestStatsdClient) Flushed() int {
+	return tg.flushed
+}

--- a/internal/statsdtest/statsdtest.go
+++ b/internal/statsdtest/statsdtest.go
@@ -24,10 +24,10 @@ const (
 
 type TestStatsdClient struct {
 	mu          sync.RWMutex
-	gaugeCalls  []testStatsdCall
-	incrCalls   []testStatsdCall
-	countCalls  []testStatsdCall
-	timingCalls []testStatsdCall
+	gaugeCalls  []TestStatsdCall
+	incrCalls   []TestStatsdCall
+	countCalls  []TestStatsdCall
+	timingCalls []TestStatsdCall
 	counts      map[string]int64
 	tags        []string
 	n           int
@@ -35,7 +35,7 @@ type TestStatsdClient struct {
 	flushed     int
 }
 
-type testStatsdCall struct {
+type TestStatsdCall struct {
 	name     string
 	floatVal float64
 	intVal   int64
@@ -54,7 +54,7 @@ func (tg *TestStatsdClient) addCount(name string, value int64) {
 }
 
 func (tg *TestStatsdClient) Gauge(name string, value float64, tags []string, rate float64) error {
-	return tg.addMetric(callTypeGauge, tags, testStatsdCall{
+	return tg.addMetric(callTypeGauge, tags, TestStatsdCall{
 		name:     name,
 		floatVal: value,
 		tags:     make([]string, len(tags)),
@@ -64,7 +64,7 @@ func (tg *TestStatsdClient) Gauge(name string, value float64, tags []string, rat
 
 func (tg *TestStatsdClient) Incr(name string, tags []string, rate float64) error {
 	tg.addCount(name, 1)
-	return tg.addMetric(callTypeIncr, tags, testStatsdCall{
+	return tg.addMetric(callTypeIncr, tags, TestStatsdCall{
 		name: name,
 		tags: make([]string, len(tags)),
 		rate: rate,
@@ -73,7 +73,7 @@ func (tg *TestStatsdClient) Incr(name string, tags []string, rate float64) error
 
 func (tg *TestStatsdClient) Count(name string, value int64, tags []string, rate float64) error {
 	tg.addCount(name, value)
-	return tg.addMetric(callTypeCount, tags, testStatsdCall{
+	return tg.addMetric(callTypeCount, tags, TestStatsdCall{
 		name:   name,
 		intVal: value,
 		tags:   make([]string, len(tags)),
@@ -82,7 +82,7 @@ func (tg *TestStatsdClient) Count(name string, value int64, tags []string, rate 
 }
 
 func (tg *TestStatsdClient) Timing(name string, value time.Duration, tags []string, rate float64) error {
-	return tg.addMetric(callTypeTiming, tags, testStatsdCall{
+	return tg.addMetric(callTypeTiming, tags, TestStatsdCall{
 		name:    name,
 		timeVal: value,
 		tags:    make([]string, len(tags)),
@@ -90,7 +90,7 @@ func (tg *TestStatsdClient) Timing(name string, value time.Duration, tags []stri
 	})
 }
 
-func (tg *TestStatsdClient) addMetric(ct callType, tags []string, c testStatsdCall) error {
+func (tg *TestStatsdClient) addMetric(ct callType, tags []string, c TestStatsdCall) error {
 	tg.mu.Lock()
 	defer tg.mu.Unlock()
 	copy(c.tags, tags)
@@ -121,34 +121,34 @@ func (tg *TestStatsdClient) Close() error {
 	return nil
 }
 
-func (tg *TestStatsdClient) GaugeCalls() []testStatsdCall {
+func (tg *TestStatsdClient) GaugeCalls() []TestStatsdCall {
 	tg.mu.RLock()
 	defer tg.mu.RUnlock()
-	c := make([]testStatsdCall, len(tg.gaugeCalls))
+	c := make([]TestStatsdCall, len(tg.gaugeCalls))
 	copy(c, tg.gaugeCalls)
 	return c
 }
 
-func (tg *TestStatsdClient) IncrCalls() []testStatsdCall {
+func (tg *TestStatsdClient) IncrCalls() []TestStatsdCall {
 	tg.mu.RLock()
 	defer tg.mu.RUnlock()
-	c := make([]testStatsdCall, len(tg.incrCalls))
+	c := make([]TestStatsdCall, len(tg.incrCalls))
 	copy(c, tg.incrCalls)
 	return c
 }
 
-func (tg *TestStatsdClient) CountCalls() []testStatsdCall {
+func (tg *TestStatsdClient) CountCalls() []TestStatsdCall {
 	tg.mu.RLock()
 	defer tg.mu.RUnlock()
-	c := make([]testStatsdCall, len(tg.countCalls))
+	c := make([]TestStatsdCall, len(tg.countCalls))
 	copy(c, tg.countCalls)
 	return c
 }
 
-func (tg *TestStatsdClient) TimingCalls() []testStatsdCall {
+func (tg *TestStatsdClient) TimingCalls() []TestStatsdCall {
 	tg.mu.RLock()
 	defer tg.mu.RUnlock()
-	c := make([]testStatsdCall, len(tg.timingCalls))
+	c := make([]TestStatsdCall, len(tg.timingCalls))
 	copy(c, tg.countCalls)
 	return c
 }


### PR DESCRIPTION
### What does this PR do?
Moves the mock statsd client for testing out of the `tracer` package and into its own internal `statsdtest` package.

### Motivation
The infrastructure for testing statsd metric submission / statsd client successes was internal and lived within the `tracer` package, in the ddtrace/tracer/metrics_test.go file. In developing valuable tests for the new `StatsCarrier` type ([PR](https://github.com/DataDog/dd-trace-go/pull/2543)), which supports the "sharing" of statsd metrics between contrib packages and `tracer` package, we realized we needed access to this mock statsd client in non-tracer packages. Thus, the mock statsd client was made accessible to all packages within the repo by moving into its own internal package.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
