### PR TITLE
internal: appsec: switch appsec event tag from json to messagepack using meta_struct

### DIFF
--- a/contrib/graph-gophers/graphql-go/appsec_test.go
+++ b/contrib/graph-gophers/graphql-go/appsec_test.go
@@ -105,24 +105,17 @@ func TestAppSec(t *testing.T) {
 				// The last finished span (which is GraphQL entry) should have the "_dd.appsec.enabled" tag.
 				require.Equal(t, 1, spans[len(spans)-1].Tag("_dd.appsec.enabled"))
 				events := make(map[string]string)
-				type ddAppsecJSON struct {
-					Triggers []struct {
-						Rule struct {
-							ID string `json:"id"`
-						} `json:"rule"`
-					} `json:"triggers"`
-				}
+
 				// Search for AppSec events in the set of spans
 				for _, span := range spans {
-					jsonText, ok := span.Tag("_dd.appsec.json").(string)
-					if !ok || jsonText == "" {
+					if span.Tag("_dd.appsec.json") == nil {
 						continue
 					}
-					var parsed ddAppsecJSON
-					err := json.Unmarshal([]byte(jsonText), &parsed)
-					require.NoError(t, err)
-					require.Len(t, parsed.Triggers, 1, "expected exactly 1 trigger on %s span", span.OperationName())
-					ruleID := parsed.Triggers[0].Rule.ID
+
+					tag := span.Tag("_dd.appsec.json").(map[string][]any)
+
+					require.Len(t, tag["triggers"], 1, "expected exactly 1 trigger on %s span", span.OperationName())
+					ruleID := tag["triggers"][0].(map[string]any)["rule"].(map[string]any)["id"].(string)
 					_, duplicate := events[ruleID]
 					require.False(t, duplicate, "found duplicated hit for rule %s", ruleID)
 					var origin string

--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -57,6 +57,10 @@ type Tracer interface {
 // spans in a request, buffer and submit them to the server.
 type Span interface {
 	// SetTag sets a key/value pair as metadata on the span.
+	// The value can be of any trivial type that can be encoded as a string or support the fmt.Stringer interface.
+	// Structs implementing the msgp.Marshaler interface are also supported using msgp.AppendIntf.
+	// It can also be a map[string]any composed recursively of trivial types or msgp.Encodable types.
+	// Cf. https://pkg.go.dev/github.com/tinylib/msgp/msgp#AppendIntf
 	SetTag(key string, value interface{})
 
 	// SetOperationName sets the operation name for this span. An operation name should be

--- a/ddtrace/tracer/meta_struct.go
+++ b/ddtrace/tracer/meta_struct.go
@@ -1,0 +1,101 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package tracer
+
+import (
+	"github.com/tinylib/msgp/msgp"
+)
+
+var (
+	_ msgp.Encodable = (*metaStructMap)(nil)
+	_ msgp.Decodable = (*metaStructMap)(nil)
+	_ msgp.Sizer     = (*metaStructMap)(nil)
+)
+
+// metaStructMap is a map of string to any of metadata embedded in each span
+// We export special messagepack methods to handle the encoding and decoding of the map
+// Because the agent expects the metadata to be a map of string to byte array, we have to create sub-messages of messagepack for each value
+type metaStructMap map[string]any
+
+// EncodeMsg transforms the map[string]any into a map[string][]byte agent-side (which is parsed back into a map[string]any in the backend)
+func (m *metaStructMap) EncodeMsg(en *msgp.Writer) error {
+	if m == nil {
+		return en.WriteNil()
+	}
+
+	err := en.WriteMapHeader(uint32(len(*m)))
+	if err != nil {
+		return msgp.WrapError(err, "MetaStruct")
+	}
+
+	for key, value := range *m {
+		err = en.WriteString(key)
+		if err != nil {
+			return msgp.WrapError(err, "MetaStruct")
+		}
+
+		// Wrap the encoded value in a byte array that will not be parsed by the agent
+		msg, err := msgp.AppendIntf(nil, value)
+		if err != nil {
+			return err
+		}
+		if err != nil {
+			return msgp.WrapError(err, "MetaStruct", key)
+		}
+
+		err = en.WriteBytes(msg)
+		if err != nil {
+			return msgp.WrapError(err, "MetaStruct", key)
+		}
+	}
+
+	return nil
+}
+
+// DecodeMsg transforms the map[string][]byte agent-side into a map[string]any where values are sub-messages in messagepack
+func (m *metaStructMap) DecodeMsg(de *msgp.Reader) error {
+	err := de.ReadNil()
+	if err == nil {
+		*m = nil
+		return nil
+	}
+
+	header, err := de.ReadMapHeader()
+	if err != nil {
+		return msgp.WrapError(err, "MetaStruct")
+	}
+
+	*m = make(metaStructMap, header)
+	for i := uint32(0); i < header; i++ {
+		var key string
+		key, err = de.ReadString()
+		if err != nil {
+			return msgp.WrapError(err, "MetaStruct")
+		}
+
+		subMsg, err := de.ReadBytes(nil)
+		if err != nil {
+			return msgp.WrapError(err, "MetaStruct", key)
+		}
+
+		(*m)[key], _, err = msgp.ReadIntfBytes(subMsg)
+		if err != nil {
+			return msgp.WrapError(err, "MetaStruct", key)
+		}
+	}
+
+	return nil
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (m *metaStructMap) Msgsize() int {
+	size := msgp.MapHeaderSize
+	for key, value := range *m {
+		size += msgp.StringPrefixSize + len(key)
+		size += msgp.BytesPrefixSize + msgp.GuessSize(value)
+	}
+	return size
+}

--- a/ddtrace/tracer/meta_struct_test.go
+++ b/ddtrace/tracer/meta_struct_test.go
@@ -1,0 +1,138 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package tracer
+
+import (
+	"bytes"
+	"errors"
+	"github.com/stretchr/testify/require"
+	"reflect"
+	"testing"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestMetaStructMap_EncodeDecode(t *testing.T) {
+	// Create a sample metaStructMap
+	meta := map[string]any{
+		"key1": "value1",
+		"key2": "value2",
+	}
+
+	for _, tc := range []struct {
+		name          string
+		input         metaStructMap
+		encodingError error
+		output        map[string]any
+		decodingError error
+	}{
+		{
+			name:   "empty",
+			input:  metaStructMap{},
+			output: map[string]any{},
+		},
+		{
+			name:   "non-empty",
+			input:  meta,
+			output: meta,
+		},
+		{
+			name:   "nil",
+			input:  nil,
+			output: nil,
+		},
+		{
+			name: "nested-map",
+			input: metaStructMap{
+				"key": map[string]any{
+					"nested-key": "nested-value",
+				},
+			},
+			output: map[string]any{
+				"key": map[string]any{
+					"nested-key": "nested-value",
+				},
+			},
+		},
+		{
+			name: "nested-slice",
+			input: metaStructMap{
+				"key": []any{
+					"nested-value",
+				},
+			},
+			output: map[string]any{
+				"key": []any{
+					"nested-value",
+				},
+			},
+		},
+		{
+			name: "encoding-error/nested-chan",
+			input: metaStructMap{
+				"key": map[string]any{
+					"nested-key": make(chan struct{}),
+				},
+			},
+			encodingError: errors.New("msgp: type \"chan struct {}\" not supported"),
+		},
+		{
+			name: "encoding-error/channel",
+			input: metaStructMap{
+				"key": make(chan struct{}),
+			},
+			encodingError: errors.New("msgp: type \"chan struct {}\" not supported"),
+		},
+		{
+			name: "encoding-error/func",
+			input: metaStructMap{
+				"key": func() {},
+			},
+			encodingError: errors.New("msgp: type \"func()\" not supported"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Encode the metaStructMap
+			var buf bytes.Buffer
+			enc := msgp.NewWriter(&buf)
+			err := tc.input.EncodeMsg(enc)
+			if tc.encodingError != nil {
+				require.EqualError(t, err, tc.encodingError.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			require.NoError(t, enc.Flush())
+
+			// Decode the encoded metaStructMap
+			dec := msgp.NewReader(bytes.NewReader(buf.Bytes()))
+			var decodedMeta metaStructMap
+			err = decodedMeta.DecodeMsg(dec)
+			if tc.decodingError != nil {
+				require.EqualError(t, err, tc.decodingError.Error())
+				return
+			}
+
+			require.NoError(t, err)
+
+			// Compare the original and decoded metaStructMap
+			compareMetaStructMaps(t, tc.output, decodedMeta)
+		})
+	}
+}
+
+func compareMetaStructMaps(t *testing.T, m1, m2 metaStructMap) {
+	require.Equal(t, len(m1), len(m2), "mismatched map lengths: %d != %d", len(m1), len(m2))
+
+	for k, v := range m1 {
+		m2v, ok := m2[k]
+		require.Truef(t, ok, "missing key %s", k)
+
+		if !reflect.DeepEqual(v, m2v) {
+			require.Fail(t, "compareMetaStructMaps", "mismatched key %s: expected '%v' but got '%v'", k, v, m2v)
+		}
+	}
+}

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -64,19 +64,20 @@ type errorConfig struct {
 type span struct {
 	sync.RWMutex `msg:"-"` // all fields are protected by this RWMutex
 
-	Name      string             `msg:"name"`              // operation name
-	Service   string             `msg:"service"`           // service name (i.e. "grpc.server", "http.request")
-	Resource  string             `msg:"resource"`          // resource name (i.e. "/user?id=123", "SELECT * FROM users")
-	Type      string             `msg:"type"`              // protocol associated with the span (i.e. "web", "db", "cache")
-	Start     int64              `msg:"start"`             // span start time expressed in nanoseconds since epoch
-	Duration  int64              `msg:"duration"`          // duration of the span expressed in nanoseconds
-	Meta      map[string]string  `msg:"meta,omitempty"`    // arbitrary map of metadata
-	Metrics   map[string]float64 `msg:"metrics,omitempty"` // arbitrary map of numeric metrics
-	SpanID    uint64             `msg:"span_id"`           // identifier of this span
-	TraceID   uint64             `msg:"trace_id"`          // lower 64-bits of the root span identifier
-	ParentID  uint64             `msg:"parent_id"`         // identifier of the span's direct parent
-	Error     int32              `msg:"error"`             // error status of the span; 0 means no errors
-	SpanLinks []ddtrace.SpanLink `msg:"span_links"`        // links to other spans
+	Name       string             `msg:"name"`                  // operation name
+	Service    string             `msg:"service"`               // service name (i.e. "grpc.server", "http.request")
+	Resource   string             `msg:"resource"`              // resource name (i.e. "/user?id=123", "SELECT * FROM users")
+	Type       string             `msg:"type"`                  // protocol associated with the span (i.e. "web", "db", "cache")
+	Start      int64              `msg:"start"`                 // span start time expressed in nanoseconds since epoch
+	Duration   int64              `msg:"duration"`              // duration of the span expressed in nanoseconds
+	Meta       map[string]string  `msg:"meta,omitempty"`        // arbitrary map of metadata
+	MetaStruct metaStructMap      `msg:"meta_struct,omitempty"` // arbitrary map of metadata with structured values
+	Metrics    map[string]float64 `msg:"metrics,omitempty"`     // arbitrary map of numeric metrics
+	SpanID     uint64             `msg:"span_id"`               // identifier of this span
+	TraceID    uint64             `msg:"trace_id"`              // lower 64-bits of the root span identifier
+	ParentID   uint64             `msg:"parent_id"`             // identifier of the span's direct parent
+	Error      int32              `msg:"error"`                 // error status of the span; 0 means no errors
+	SpanLinks  []ddtrace.SpanLink `msg:"span_links"`            // links to other spans
 
 	goExecTraced bool         `msg:"-"`
 	noDebugStack bool         `msg:"-"` // disables debug stack traces
@@ -162,6 +163,13 @@ func (s *span) SetTag(key string, value interface{}) {
 		s.setMeta(key, v.String())
 		return
 	}
+
+	// Can be sent as messagepack in `meta_struct` instead of `meta`
+	if _, ok := value.(msgp.Marshaler); ok {
+		s.setMetaStruct(key, value)
+		return
+	}
+
 	if value != nil {
 		// Arrays will be translated to dot notation. e.g.
 		// {"myarr.0": "foo", "myarr.1": "bar"}
@@ -178,6 +186,10 @@ func (s *span) SetTag(key string, value interface{}) {
 					s.setMeta(key, fmt.Sprintf("%v", v))
 				}
 			}
+			return
+		case reflect.Map:
+			// `meta_struct` does not support slice as a top-level value.
+			s.setMetaStruct(key, value)
 			return
 		}
 	}
@@ -388,6 +400,13 @@ func (s *span) setMeta(key, v string) {
 	default:
 		s.Meta[key] = v
 	}
+}
+
+func (s *span) setMetaStruct(key string, v any) {
+	if s.MetaStruct == nil {
+		s.MetaStruct = make(metaStructMap, 1)
+	}
+	s.MetaStruct[key] = v
 }
 
 // setTagBool sets a boolean tag on the span.

--- a/ddtrace/tracer/span_msgp.go
+++ b/ddtrace/tracer/span_msgp.go
@@ -180,6 +180,12 @@ func (z *span) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 				z.Meta[za0001] = za0002
 			}
+		case "meta_struct":
+			err = z.MetaStruct.DecodeMsg(dc)
+			if err != nil {
+				err = msgp.WrapError(err, "MetaStruct")
+				return
+			}
 		case "metrics":
 			var zb0003 uint32
 			zb0003, err = dc.ReadMapHeader()
@@ -267,15 +273,16 @@ func (z *span) DecodeMsg(dc *msgp.Reader) (err error) {
 // EncodeMsg implements msgp.Encodable
 func (z *span) EncodeMsg(en *msgp.Writer) (err error) {
 	// omitempty: check for empty values
-	zb0001Len := uint32(13)
-	var zb0001Mask uint16 /* 13 bits */
+	zb0001Len := uint32(14)
+	var zb0001Mask uint16 /* 14 bits */
+	_ = zb0001Mask
 	if z.Meta == nil {
 		zb0001Len--
 		zb0001Mask |= 0x40
 	}
 	if z.Metrics == nil {
 		zb0001Len--
-		zb0001Mask |= 0x80
+		zb0001Mask |= 0x100
 	}
 	// variable map header, size zb0001Len
 	err = en.Append(0x80 | uint8(zb0001Len))
@@ -369,7 +376,17 @@ func (z *span) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 	}
-	if (zb0001Mask & 0x80) == 0 { // if not empty
+	// write "meta_struct"
+	err = en.Append(0xab, 0x6d, 0x65, 0x74, 0x61, 0x5f, 0x73, 0x74, 0x72, 0x75, 0x63, 0x74)
+	if err != nil {
+		return
+	}
+	err = z.MetaStruct.EncodeMsg(en)
+	if err != nil {
+		err = msgp.WrapError(err, "MetaStruct")
+		return
+	}
+	if (zb0001Mask & 0x100) == 0 { // if not empty
 		// write "metrics"
 		err = en.Append(0xa7, 0x6d, 0x65, 0x74, 0x72, 0x69, 0x63, 0x73)
 		if err != nil {
@@ -462,7 +479,7 @@ func (z *span) Msgsize() (s int) {
 			s += msgp.StringPrefixSize + len(za0001) + msgp.StringPrefixSize + len(za0002)
 		}
 	}
-	s += 8 + msgp.MapHeaderSize
+	s += 12 + z.MetaStruct.Msgsize() + 8 + msgp.MapHeaderSize
 	if z.Metrics != nil {
 		for za0003, za0004 := range z.Metrics {
 			_ = za0004

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -356,9 +356,30 @@ func TestSpanSetTag(t *testing.T) {
 	assert.Equal("[]", span.Meta["someslices.2"])
 	assert.Equal("[e, f]", span.Meta["someslices.3"])
 
+	mapStrStr := map[string]string{"b": "c"}
+	span.SetTag("map", map[string]string{"b": "c"})
+	assert.Equal(mapStrStr, span.MetaStruct["map"])
+
+	mapOfMap := map[string]map[string]any{"a": {"b": "c"}}
+	span.SetTag("mapOfMap", mapOfMap)
+	assert.Equal(mapOfMap, span.MetaStruct["mapOfMap"])
+
+	// groupedStats is a struct that implements the msgp.Marshaler interface
+	testValue := &testMsgpStruct{A: "test"}
+	span.SetTag("struct", testValue)
+	require.Equal(t, testValue, span.MetaStruct["struct"])
+
 	assert.Panics(func() {
 		span.SetTag("panicStringer", &panicStringer{})
 	})
+}
+
+type testMsgpStruct struct {
+	A string
+}
+
+func (t *testMsgpStruct) MarshalMsg(b []byte) ([]byte, error) {
+	return nil, nil
 }
 
 func TestSpanSetTagError(t *testing.T) {

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -364,7 +364,7 @@ func TestSpanSetTag(t *testing.T) {
 	span.SetTag("mapOfMap", mapOfMap)
 	assert.Equal(mapOfMap, span.MetaStruct["mapOfMap"])
 
-	// groupedStats is a struct that implements the msgp.Marshaler interface
+	// testMsgpStruct is a struct that implements the msgp.Marshaler interface
 	testValue := &testMsgpStruct{A: "test"}
 	span.SetTag("struct", testValue)
 	require.Equal(t, testValue, span.MetaStruct["struct"])
@@ -378,7 +378,7 @@ type testMsgpStruct struct {
 	A string
 }
 
-func (t *testMsgpStruct) MarshalMsg(b []byte) ([]byte, error) {
+func (t *testMsgpStruct) MarshalMsg(_ []byte) ([]byte, error) {
 	return nil, nil
 }
 

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -25,17 +25,18 @@ import (
 // getTestSpan returns a Span with different fields set
 func getTestSpan() *span {
 	return &span{
-		TraceID:  42,
-		SpanID:   52,
-		ParentID: 42,
-		Type:     "web",
-		Service:  "high.throughput",
-		Name:     "sending.events",
-		Resource: "SEND /data",
-		Start:    1481215590883401105,
-		Duration: 1000000000,
-		Meta:     map[string]string{"http.host": "192.168.0.1"},
-		Metrics:  map[string]float64{"http.monitor": 41.99},
+		TraceID:    42,
+		SpanID:     52,
+		ParentID:   42,
+		Type:       "web",
+		Service:    "high.throughput",
+		Name:       "sending.events",
+		Resource:   "SEND /data",
+		Start:      1481215590883401105,
+		Duration:   1000000000,
+		Meta:       map[string]string{"http.host": "192.168.0.1"},
+		MetaStruct: map[string]any{"_dd.appsec.json": map[string]any{"triggers": []any{map[string]any{"id": "1"}}}},
+		Metrics:    map[string]float64{"http.monitor": 41.99},
 	}
 }
 

--- a/ddtrace/tracer/writer.go
+++ b/ddtrace/tracer/writer.go
@@ -219,6 +219,23 @@ func (h *logTraceWriter) encodeSpan(s *span) {
 		h.buf.WriteString(":")
 		h.marshalString(v)
 	}
+	h.buf.WriteString(`},"meta_struct":{`)
+	first = true
+	for k, v := range s.MetaStruct {
+		if first {
+			first = false
+		} else {
+			h.buf.WriteString(`,`)
+		}
+		h.marshalString(k)
+		h.buf.WriteString(":")
+		jsonValue, err := json.Marshal(v)
+		if err != nil {
+			log.Error("Error marshaling value %q: %v", v, err)
+			continue
+		}
+		h.marshalString(string(jsonValue))
+	}
 	h.buf.WriteString(`},"metrics":{`)
 	first = true
 	for k, v := range s.Metrics {

--- a/ddtrace/tracer/writer.go
+++ b/ddtrace/tracer/writer.go
@@ -219,8 +219,7 @@ func (h *logTraceWriter) encodeSpan(s *span) {
 		h.buf.WriteString(":")
 		h.marshalString(v)
 	}
-	h.buf.WriteString(`},"meta_struct":{`)
-	first = true
+	// We cannot pack messagepack into JSON, so we need to marshal the meta struct as JSON, and send them through the `meta` field
 	for k, v := range s.MetaStruct {
 		if first {
 			first = false

--- a/ddtrace/tracer/writer_test.go
+++ b/ddtrace/tracer/writer_test.go
@@ -203,12 +203,11 @@ func TestLogWriter(t *testing.T) {
 			Service:  "basicService",
 			Resource: "basicResource",
 			Meta: map[string]string{
-				"env":     "prod",
-				"version": "1.26.0",
-			},
-			MetaStruct: map[string]any{
+				"env":       "prod",
+				"version":   "1.26.0",
 				"_dd.stack": "{\"0\":\"github.com/DataDog/dd-trace-go/v1/internal/tracer.TestLogWriter\"}",
 			},
+			MetaStruct: nil,
 			Metrics: map[string]float64{
 				"widgets": 1e26,
 				"zero":    0.0,
@@ -242,7 +241,7 @@ func TestLogWriter(t *testing.T) {
 		w.encodeSpan(s)
 
 		str := w.buf.String()
-		assert.Equal(`{"trace_id":"1","span_id":"2","parent_id":"3","name":"name\n","resource":"\"res\"","error":0,"meta":{"query\n":"Select * from \n Where\nvalue"},"meta_struct":{},"metrics":{"version\n":3},"start":12,"duration":0,"service":"srv\t"}`, str)
+		assert.Equal(`{"trace_id":"1","span_id":"2","parent_id":"3","name":"name\n","resource":"\"res\"","error":0,"meta":{"query\n":"Select * from \n Where\nvalue"},"metrics":{"version\n":3},"start":12,"duration":0,"service":"srv\t"}`, str)
 		assert.NotContains(str, "\n")
 		assert.Contains(str, "\\n")
 	})

--- a/internal/appsec/trace/trace.go
+++ b/internal/appsec/trace/trace.go
@@ -8,9 +8,6 @@
 package trace
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/samplernames"
 )
@@ -45,11 +42,7 @@ func SetEventSpanTags(span TagSetter, events []any) error {
 	}
 
 	// Set the appsec event span tag
-	val, err := makeEventTagValue(events)
-	if err != nil {
-		return err
-	}
-	span.SetTag("_dd.appsec.json", string(val))
+	span.SetTag("_dd.appsec.json", map[string][]any{"triggers": events})
 	// Keep this span due to the security event
 	//
 	// This is a workaround to tell the tracer that the trace was kept by AppSec.
@@ -68,18 +61,4 @@ func SetTags[V any](span TagSetter, tags map[string]V) {
 	for k, v := range tags {
 		span.SetTag(k, v)
 	}
-}
-
-// Create the value of the security event tag.
-func makeEventTagValue(events []any) (json.RawMessage, error) {
-	type eventTagValue struct {
-		Triggers []any `json:"triggers"`
-	}
-
-	tag, err := json.Marshal(eventTagValue{events})
-	if err != nil {
-		return nil, fmt.Errorf("unexpected error while serializing the appsec event span tag: %v", err)
-	}
-
-	return tag, nil
 }

--- a/internal/appsec/trace/trace.go
+++ b/internal/appsec/trace/trace.go
@@ -42,7 +42,7 @@ func SetEventSpanTags(span TagSetter, events []any) error {
 	}
 
 	// Set the appsec event span tag
-	span.SetTag("_dd.appsec.json", map[string][]any{"triggers": events})
+	span.SetTag("_dd.appsec.json", map[string]any{"triggers": events})
 	// Keep this span due to the security event
 	//
 	// This is a workaround to tell the tracer that the trace was kept by AppSec.

--- a/internal/appsec/trace/trace.go
+++ b/internal/appsec/trace/trace.go
@@ -42,7 +42,7 @@ func SetEventSpanTags(span TagSetter, events []any) error {
 	}
 
 	// Set the appsec event span tag
-	span.SetTag("_dd.appsec.json", map[string]any{"triggers": events})
+	span.SetTag("appsec", map[string]any{"triggers": events})
 	// Keep this span due to the security event
 	//
 	// This is a workaround to tell the tracer that the trace was kept by AppSec.


### PR DESCRIPTION
### What does this PR do?

This PR optimize the was appsec events are sent to the backend by using the new `meta_struct` span field to sent structured data to the backend without resorting to json in a string.

### Motivation

Marshaling json values directly in the customer hot path adds overhead to ASM that can now be avoided using this method that moves serializing to the agent writer goroutine.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
APPSEC-51698

Signed-off-by: Eliott Bouhana <eliott.bouhana@datadoghq.com>