### PR TITLE
contrib/gofiber/fiber.v2: add possibility to exclude spans generation for specific requests

### DIFF
--- a/contrib/gofiber/fiber.v2/fiber.go
+++ b/contrib/gofiber/fiber.v2/fiber.go
@@ -37,6 +37,10 @@ func Middleware(opts ...Option) func(c *fiber.Ctx) error {
 	}
 	log.Debug("gofiber/fiber.v2: Middleware: %#v", cfg)
 	return func(c *fiber.Ctx) error {
+		if cfg.ignoreRequest(c) {
+			return c.Next()
+		}
+
 		opts := []ddtrace.StartSpanOption{
 			tracer.SpanType(ext.SpanTypeWeb),
 			tracer.ServiceName(cfg.serviceName),


### PR DESCRIPTION
### What does this PR do?
Thi PR is about adding functionality to gofiber trace Middleware to avoid span generation for a specific requests.

### Motivation
Exclude spans generation for unneeded endpoints, like `/healthcheck`, `/`, `/version` etc. and to be able to do it on an application level rather than DD Agent.

[Issue](https://github.com/DataDog/dd-trace-go/issues/2582)

### Reviewer's Checklist
- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
