### PR TITLE
contrib/google.golang.org/grpc: fix flaky tests by removing arbitrary sleeps

### DIFF
--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -658,15 +658,7 @@ func newRig(traceClient bool, opts ...Option) (*rig, error) {
 // waitForSpans polls the mock tracer until the expected number of spans
 // appears
 func waitForSpans(mt mocktracer.Tracer, sz int) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-
 	for len(mt.FinishedSpans()) < sz {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
 		time.Sleep(time.Millisecond * 100)
 	}
 }
@@ -1332,8 +1324,5 @@ func TestIssue2050(t *testing.T) {
 	select {
 	case <-spansFound:
 		return
-
-	case <-time.After(5 * time.Second):
-		assert.Fail(t, "spans not found")
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Remove arbitrary calls to `time.Sleep`.
The test timeout will be enough to gate their exec time if they happen to fail.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

gRPC tests are extremely flaky on qemu arm64.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
