### PR TITLE
contrib/google.golang.org/grpc: statshandler respects untraced and ignored methods config

### DIFF
--- a/contrib/google.golang.org/grpc/stats_server.go
+++ b/contrib/google.golang.org/grpc/stats_server.go
@@ -32,6 +32,12 @@ type serverStatsHandler struct {
 
 // TagRPC starts a new span for the initiated RPC request.
 func (h *serverStatsHandler) TagRPC(ctx context.Context, rti *stats.RPCTagInfo) context.Context {
+	_, im := h.cfg.ignoredMethods[rti.FullMethodName]
+	_, um := h.cfg.untracedMethods[rti.FullMethodName]
+	if im || um {
+		return ctx
+	}
+
 	spanOpts := append([]tracer.StartSpanOption{
 		tracer.Measured(),
 		tracer.Tag(ext.SpanKind, ext.SpanKindServer)},

--- a/contrib/google.golang.org/grpc/stats_server_test.go
+++ b/contrib/google.golang.org/grpc/stats_server_test.go
@@ -57,6 +57,65 @@ func TestServerStatsHandler(t *testing.T) {
 	assert.Equal(ext.SpanKindServer, tags[ext.SpanKind])
 }
 
+func TestServerStatsHandlerWithUntracedMethod(t *testing.T) {
+	assert := assert.New(t)
+
+	serviceName := "grpc-service"
+	statsHandler := NewServerStatsHandler(WithServiceName(serviceName), WithUntracedMethods("/grpc.Fixture/Ping"))
+	server, err := newServerStatsHandlerTestServer(statsHandler)
+	if err != nil {
+		t.Fatalf("failed to start test server: %s", err)
+	}
+	defer server.Close()
+
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	_, err = server.client.Ping(context.Background(), &FixtureRequest{Name: "name"})
+	assert.NoError(err)
+
+	waitForSpans(mt, 1)
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 0)
+}
+
+func TestServerStatsHandlerWithUntracedMethodEmpty(t *testing.T) {
+	assert := assert.New(t)
+
+	serviceName := "grpc-service"
+	statsHandler := NewServerStatsHandler(WithServiceName(serviceName), WithUntracedMethods())
+	server, err := newServerStatsHandlerTestServer(statsHandler)
+	if err != nil {
+		t.Fatalf("failed to start test server: %s", err)
+	}
+	defer server.Close()
+
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	_, err = server.client.Ping(context.Background(), &FixtureRequest{Name: "name"})
+	assert.NoError(err)
+
+	waitForSpans(mt, 1)
+	spans := mt.FinishedSpans()
+	assert.Len(spans, 1)
+
+	span := spans[0]
+	assert.Zero(span.ParentID())
+	assert.NotZero(span.StartTime())
+	assert.True(span.FinishTime().Sub(span.StartTime()) >= 0)
+	assert.Equal("grpc.server", span.OperationName())
+	tags := span.Tags()
+	assert.Equal(ext.AppTypeRPC, tags["span.type"])
+	assert.Equal(codes.OK.String(), tags["grpc.code"])
+	assert.Equal(serviceName, tags["service.name"])
+	assert.Equal("/grpc.Fixture/Ping", tags["resource.name"])
+	assert.Equal("/grpc.Fixture/Ping", tags[tagMethodName])
+	assert.Equal(1, tags["_dd.measured"])
+	assert.Equal("bar", tags["foo"])
+	assert.Equal("grpc", tags[ext.RPCSystem])
+	assert.Equal("/grpc.Fixture/Ping", tags[ext.GRPCFullMethod])
+	assert.Equal(ext.SpanKindServer, tags[ext.SpanKind])
+}
+
 func newServerStatsHandlerTestServer(statsHandler stats.Handler) (*rig, error) {
 	return newRigWithInterceptors(
 		[]grpc.ServerOption{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Have the grpc stats handler respec untraced methods.

### Motivation

I shifted from using the interceptors to using the stats handler and it surprised me that the options that the interceptors use are not considered in the stats handler path. The health checks became too noisy for us so that's what motivated me to submit this patch.

### Describe how to test/QA your changes

Pass in `WithUntracedMethods` to `NewServerStatsHandler`. The ignored methods won't show up in the traces in DataDog.com.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Changed code has unit tests for its functionality.
- [ ] If this interacts with the agent in a new way, a system test has been added.
