### PR TITLE
internal/globalconfig: move mutex un/lock from PushStat to StatsCarrier

### DIFF
--- a/internal/globalconfig/globalconfig.go
+++ b/internal/globalconfig/globalconfig.go
@@ -109,6 +109,8 @@ func PushStat(stat internal.Stat) {
 		log.Debug("No stats carrier found; dropping stat %v", stat.Name())
 		return
 	}
+	cfg.mu.Lock()
+	defer cfg.mu.Unlock()
 	cfg.statsCarrier.Add(stat)
 }
 

--- a/internal/globalconfig/globalconfig.go
+++ b/internal/globalconfig/globalconfig.go
@@ -105,18 +105,13 @@ func SetStatsCarrier(sc *internal.StatsCarrier) {
 
 // PushStat pushes the stat onto the StatsCarrier's stats channel, via the Add method
 func PushStat(stat internal.Stat) {
-	if !StatsCarrier() {
+	cfg.mu.RLock()
+	sc := cfg.statsCarrier
+	cfg.mu.RUnlock()
+
+	if sc == nil {
 		log.Debug("No stats carrier found; dropping stat %v", stat.Name())
 		return
 	}
-	cfg.mu.Lock()
-	defer cfg.mu.Unlock()
-	cfg.statsCarrier.Add(stat)
-}
-
-// StatsCarrier returns true if there is a StatsCarrier on the globalconfig, else false
-func StatsCarrier() bool {
-	cfg.mu.RLock()
-	defer cfg.mu.RUnlock()
-	return cfg.statsCarrier != nil
+	sc.Add(stat)
 }

--- a/internal/globalconfig/globalconfig.go
+++ b/internal/globalconfig/globalconfig.go
@@ -105,8 +105,6 @@ func SetStatsCarrier(sc *internal.StatsCarrier) {
 
 // PushStat pushes the stat onto the StatsCarrier's stats channel, via the Add method
 func PushStat(stat internal.Stat) {
-	cfg.mu.RLock()
-	defer cfg.mu.RUnlock()
 	if !StatsCarrier() {
 		log.Debug("No stats carrier found; dropping stat %v", stat.Name())
 		return
@@ -116,5 +114,7 @@ func PushStat(stat internal.Stat) {
 
 // StatsCarrier returns true if there is a StatsCarrier on the globalconfig, else false
 func StatsCarrier() bool {
+	cfg.mu.RLock()
+	defer cfg.mu.RUnlock()
 	return cfg.statsCarrier != nil
 }

--- a/internal/globalconfig/globalconfig_test.go
+++ b/internal/globalconfig/globalconfig_test.go
@@ -47,15 +47,3 @@ func TestPushStat(t *testing.T) {
 	assert.Len(t, calls, 1)
 	assert.Contains(t, calls, "name")
 }
-
-func TestStatsCarrier(t *testing.T) {
-	t.Run("default none", func(t *testing.T) {
-		assert.False(t, StatsCarrier())
-	})
-	t.Run("exists", func(t *testing.T) {
-		t.Cleanup(ResetGlobalConfig)
-		sc := internal.NewStatsCarrier(&statsd.NoOpClient{})
-		cfg.statsCarrier = sc
-		assert.True(t, StatsCarrier())
-	})
-}

--- a/internal/statsd.go
+++ b/internal/statsd.go
@@ -139,7 +139,7 @@ type StatsCarrier struct {
 
 func NewStatsCarrier(statsd StatsdClient) *StatsCarrier {
 	return &StatsCarrier{
-		contribStats: make(chan Stat, 10),
+		contribStats: make(chan Stat),
 		statsd:       statsd,
 		stopped:      1,
 	}
@@ -216,9 +216,5 @@ func (sc *StatsCarrier) push(s Stat) {
 
 // Add pushes the Stat, s, onto the StatsCarrier's contribStats channel
 func (sc *StatsCarrier) Add(s Stat) {
-	select {
-	case sc.contribStats <- s:
-	default:
-		log.Debug("Stats carrier channel is full; dropping stat %v", s.Name())
-	}
+	sc.contribStats <- s
 }

--- a/internal/statsd.go
+++ b/internal/statsd.go
@@ -219,6 +219,6 @@ func (sc *StatsCarrier) Add(s Stat) {
 	select {
 	case sc.contribStats <- s:
 	default:
-		log.Debug("StatsCarrier's contribStats channel is full; dropping stat %v", s.Name())
+		log.Debug("Stats carrier channel is full; dropping stat %v", s.Name())
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Rearranges `globalconfig` locking operations in `PushStat`, that only calls a function that pushes into a channel, to avoid deadlocks with `SetStatsCarrier`. If `PushStat` locks while adding a stat into StatsCarrier's channel, it locks any further function using the same `globalconfig` mutex.

It's been tested locally. It no longer fails.

### Motivation

Avoid failing tests due to deadlocks:

```
goroutine 738 [sync.RWMutex.Lock]:
sync.runtime_SemacquireRWMutex(0x12addca40?, 0x18?, 0x18?)
	/Users/dario.castane/sdk/go1.21.5/src/runtime/sema.go:87 +0x28
sync.(*RWMutex).Lock(0x14000481eb8?)
	/Users/dario.castane/sdk/go1.21.5/src/sync/rwmutex.go:152 +0xf8
gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig.SetServiceName({0x1050f2c11, 0xa})
	/Users/dario.castane/go/src/github.com/DataDog/dd-trace-go/internal/globalconfig/globalconfig.go:60 +0x3c
gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/namingschematest.withDDService({0x1050f2c11, 0xa})
	/Users/dario.castane/go/src/github.com/DataDog/dd-trace-go/contrib/internal/namingschematest/namingschematest.go:131 +0x80
gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql.TestNamingSchema.func4.NewServiceNameTest.func3.1(0x0?)
	/Users/dario.castane/go/src/github.com/DataDog/dd-trace-go/contrib/internal/namingschematest/namingschematest.go:88 +0x4c
testing.tRunner(0x14000c501a0, 0x14001db8ac8)
	/Users/dario.castane/sdk/go1.21.5/src/testing/testing.go:1595 +0xe8
created by testing.(*T).Run in goroutine 702
	/Users/dario.castane/sdk/go1.21.5/src/testing/testing.go:1648 +0x33c

[...]

goroutine 566 [chan send]:
gopkg.in/DataDog/dd-trace-go.v1/internal.(*StatsCarrier).Add(...)
	/Users/dario.castane/go/src/github.com/DataDog/dd-trace-go/internal/statsd.go:219
gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig.PushStat({0x10543fea8?, 0x14001a0a7c0?})
	/Users/dario.castane/go/src/github.com/DataDog/dd-trace-go/internal/globalconfig/globalconfig.go:114 +0xe0
gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql.pollDBStats(0x140000af040, {0x14000ae1140, 0x1, 0x1})
	/Users/dario.castane/go/src/github.com/DataDog/dd-trace-go/contrib/database/sql/metrics.go:44 +0x194
created by gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql.OpenDB in goroutine 564
	/Users/dario.castane/go/src/github.com/DataDog/dd-trace-go/contrib/database/sql/sql.go:215 +0x2dc
```

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
