### PR TITLE
contrib/database/sql: temporarily disable DB stats feature

### DIFF
--- a/contrib/database/sql/example_test.go
+++ b/contrib/database/sql/example_test.go
@@ -108,7 +108,7 @@ func Example_dbmPropagation() {
 }
 
 func Example_dbStats() {
-	sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithDBStats())
+	sqltrace.Register("postgres", &pq.Driver{})
 	db, err := sqltrace.Open("postgres", "postgres://pqgotest:password@localhost/pqgotest?sslmode=disable")
 
 	if err != nil {

--- a/contrib/database/sql/option.go
+++ b/contrib/database/sql/option.go
@@ -264,12 +264,3 @@ func WithDBMPropagation(mode tracer.DBMPropagationMode) Option {
 		cfg.dbmPropagationMode = mode
 	}
 }
-
-// WithDBStats enables polling of DBStats metrics
-// ref: https://pkg.go.dev/database/sql#DBStats
-// These metrics are submitted to Datadog and are not billed as custom metrics
-func WithDBStats() Option {
-	return func(cfg *config) {
-		cfg.dbStats = true
-	}
-}

--- a/contrib/database/sql/option_test.go
+++ b/contrib/database/sql/option_test.go
@@ -43,17 +43,3 @@ func TestAnalyticsSettings(t *testing.T) {
 		assert.Equal(t, 0.2, cfg.analyticsRate)
 	})
 }
-
-func TestWithDBStats(t *testing.T) {
-	t.Run("default off", func(t *testing.T) {
-		cfg := new(config)
-		defaults(cfg, "", nil)
-		assert.False(t, cfg.dbStats)
-	})
-	t.Run("on", func(t *testing.T) {
-		cfg := new(config)
-		defaults(cfg, "", nil)
-		WithDBStats()(cfg)
-		assert.True(t, cfg.dbStats)
-	})
-}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This feature disables the user-facing part of the DB stats feature until the tests are passing and all memory-related bugs are fixed. This PR can be reverted to add the feature back to the `database/sql` contrib.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

There were some test failures related to a deadlock that are being investigated in https://github.com/DataDog/dd-trace-go/pull/2593

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
