### PR TITLE
contrib/99designs/gqlgen: add WithCustomTag option

### DIFF
--- a/contrib/99designs/gqlgen/option.go
+++ b/contrib/99designs/gqlgen/option.go
@@ -17,14 +17,16 @@ const defaultServiceName = "graphql"
 type config struct {
 	serviceName   string
 	analyticsRate float64
+	tags          map[string]interface{}
 }
 
 // An Option configures the gqlgen integration.
-type Option func(t *config)
+type Option func(cfg *config)
 
-func defaults(t *config) {
-	t.serviceName = namingschema.ServiceNameOverrideV0(defaultServiceName, defaultServiceName)
-	t.analyticsRate = globalconfig.AnalyticsRate()
+func defaults(cfg *config) {
+	cfg.serviceName = namingschema.ServiceNameOverrideV0(defaultServiceName, defaultServiceName)
+	cfg.analyticsRate = globalconfig.AnalyticsRate()
+	cfg.tags = make(map[string]interface{})
 }
 
 // WithAnalytics enables or disables Trace Analytics for all started spans.
@@ -37,14 +39,24 @@ func WithAnalytics(on bool) Option {
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events correlated to started spans.
 func WithAnalyticsRate(rate float64) Option {
-	return func(t *config) {
-		t.analyticsRate = rate
+	return func(cfg *config) {
+		cfg.analyticsRate = rate
 	}
 }
 
 // WithServiceName sets the given service name for the gqlgen server.
 func WithServiceName(name string) Option {
-	return func(t *config) {
-		t.serviceName = name
+	return func(cfg *config) {
+		cfg.serviceName = name
+	}
+}
+
+// WithCustomTag will attach the value to the span tagged by the key.
+func WithCustomTag(key string, value interface{}) Option {
+	return func(cfg *config) {
+		if cfg.tags == nil {
+			cfg.tags = make(map[string]interface{})
+		}
+		cfg.tags[key] = value
 	}
 }

--- a/contrib/99designs/gqlgen/tracer.go
+++ b/contrib/99designs/gqlgen/tracer.go
@@ -139,13 +139,17 @@ func (t *gqlTracer) InterceptOperation(ctx context.Context, next graphql.Operati
 func (t *gqlTracer) InterceptField(ctx context.Context, next graphql.Resolver) (res any, err error) {
 	opCtx := graphql.GetOperationContext(ctx)
 	fieldCtx := graphql.GetFieldContext(ctx)
-	opts := []tracer.StartSpanOption{
+	opts := make([]tracer.StartSpanOption, 0, 6+len(t.cfg.tags))
+	for k, v := range t.cfg.tags {
+		opts = append(opts, tracer.Tag(k, v))
+	}
+	opts = append(opts,
 		tracer.Tag(tagGraphqlField, fieldCtx.Field.Name),
 		tracer.Tag(tagGraphqlOperationType, opCtx.Operation.Operation),
 		tracer.Tag(ext.Component, componentName),
 		tracer.ResourceName(fmt.Sprintf("%s.%s", fieldCtx.Object, fieldCtx.Field.Name)),
 		tracer.Measured(),
-	}
+	)
 	if !math.IsNaN(t.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, t.cfg.analyticsRate))
 	}
@@ -172,14 +176,18 @@ func (*gqlTracer) InterceptResponse(ctx context.Context, next graphql.ResponseHa
 // also creates child spans (orphans in the case of a subscription) for the
 // read, parsing and validation phases of the operation.
 func (t *gqlTracer) createRootSpan(ctx context.Context, opCtx *graphql.OperationContext) (ddtrace.Span, context.Context) {
-	opts := []tracer.StartSpanOption{
+	opts := make([]tracer.StartSpanOption, 0, 7+len(t.cfg.tags))
+	for k, v := range t.cfg.tags {
+		opts = append(opts, tracer.Tag(k, v))
+	}
+	opts = append(opts,
 		tracer.SpanType(ext.SpanTypeGraphQL),
 		tracer.Tag(ext.SpanKind, ext.SpanKindServer),
 		tracer.ServiceName(t.cfg.serviceName),
 		tracer.Tag(ext.Component, componentName),
 		tracer.ResourceName(opCtx.RawQuery),
 		tracer.StartTime(opCtx.Stats.OperationStart),
-	}
+	)
 	if !math.IsNaN(t.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, t.cfg.analyticsRate))
 	}

--- a/contrib/99designs/gqlgen/tracer_test.go
+++ b/contrib/99designs/gqlgen/tracer_test.go
@@ -65,6 +65,16 @@ func TestOptions(t *testing.T) {
 				assert.Equal(0.5, root.Tag(ext.EventSampleRate))
 			},
 		},
+		"WithCustomTag": {
+			tracerOpts: []Option{
+				WithCustomTag("customTag1", "customValue1"),
+				WithCustomTag("customTag2", "customValue2"),
+			},
+			test: func(assert *assert.Assertions, root mocktracer.Span) {
+				assert.Equal("customValue1", root.Tag("customTag1"))
+				assert.Equal("customValue2", root.Tag("customTag2"))
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)


### PR DESCRIPTION
### What does this PR do?

The `gqlgen` middleware was missing the ability to customize tags on the created spans. Implement a `WithCustomTag` option that follows the pattern of other similar packages.

I also renamed variable names for the `config` struct as `cfg`, instead of `t`, to match every other contrib package.

### Motivation

Fixes #2597; supports the ability to use additional tagging with `gqlgen` traces.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
