### PR TITLE
internal/globalconfig: skip TestPushStat

### DIFF
--- a/internal/globalconfig/globalconfig_test.go
+++ b/internal/globalconfig/globalconfig_test.go
@@ -35,6 +35,7 @@ func ResetGlobalConfig() {
 	cfg.statsCarrier = nil
 }
 func TestPushStat(t *testing.T) {
+	t.Skip()
 	t.Cleanup(ResetGlobalConfig)
 	var tg statsdtest.TestStatsdClient
 	sc := internal.NewStatsCarrier(&tg)


### PR DESCRIPTION
### What does this PR do?

Skips a test related to #2594 

### Motivation

Right now `TestPushStat` fails consistently.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
