### PR TITLE
ci: set a large enough appsec timeout value

### DIFF
--- a/.github/workflows/multios-unit-tests.yml
+++ b/.github/workflows/multios-unit-tests.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: "${{ (inputs.go-version == '1.19' && inputs.runs-on == 'windows-latest') && 'windows-2019' || inputs.runs-on }}"
     env:
       REPORT: gotestsum-report.xml # path to where test results will be saved
+      DD_APPSEC_WAF_TIMEOUT: 1h
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -294,6 +294,8 @@ jobs:
           go-version: ${{ inputs.go-version }}
 
       - name: Test Core
+        env:
+          DD_APPSEC_WAF_TIMEOUT: 1h
         run: |
             mkdir -p $TEST_RESULTS
             PACKAGE_NAMES=$(go list ./... | grep -v /contrib/)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Avoid using the default value of `DD_APPSEC_WAF_TIMEOUT` (1ms) in CI and rather use an "infinite" value, large enough for our CI runs.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Avoid getting flaky test results.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
