### PR TITLE
chore(otel): adds an API for generating span links

### DIFF
--- a/ddtrace/mocktracer/mockspan.go
+++ b/ddtrace/mocktracer/mockspan.go
@@ -47,28 +47,7 @@ func (s *Span) SetTag(k string, v interface{}) {
 }
 
 func (s *Span) AddLink(spanContext *tracer.SpanContext, attributes map[string]string) {
-	//  traceIDUpper uint64
-	traceIDHex := spanContext.TraceID()
-	traceIDHigh, _ := strconv.ParseUint(traceIDHex[:8], 16, 64)
-
-	samplingDecision, hasSamplingDecision := spanContext.SamplingPriority()
-	var flags uint32
-	if hasSamplingDecision && samplingDecision >= ext.PriorityAutoKeep {
-		flags = uint32(1<<31 | 1)
-	} else if hasSamplingDecision {
-		flags = uint32(1<<31 | 0)
-	} else {
-		flags = uint32(0)
-	}
-
-	// TODO: Add support for setting tracestate
-	s.sp.spanLinks = append(s.sp.spanLinks, SpanLink{
-		TraceID:     spanContext.TraceIDLower(),
-		TraceIDHigh: traceIDHigh,
-		SpanID:      spanContext.SpanID(),
-		Attributes:  attributes,
-		Flags:       flags,
-	})
+	s.sp.AddLink(spanContext, attributes)
 }
 
 func (s *Span) Tag(k string) interface{} {

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -242,7 +242,7 @@ func (s *Span) AddLink(spanContext *SpanContext, attributes map[string]string) {
 		flags = uint32(1<<31 | samplingDecision)
 	}
 
-	// TODO: Add support for setting tracestate and traceflags
+	// TODO: Add support for setting tracestate
 	s.spanLinks = append(s.spanLinks, SpanLink{
 		TraceID:     spanContext.TraceIDLower(),
 		TraceIDHigh: traceIDHigh,

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -229,7 +229,6 @@ func (s *Span) SetTag(key string, value interface{}) {
 // AddLink sets a casuality link to another span via a spanContext. It also
 // stores details about the link in an attributes map.
 func (s *Span) AddLink(spanContext *SpanContext, attributes map[string]string) {
-	//  traceIDUpper uint64
 	traceIDHex := spanContext.TraceID()
 	traceIDHigh, _ := strconv.ParseUint(traceIDHex[:8], 16, 64)
 
@@ -243,7 +242,6 @@ func (s *Span) AddLink(spanContext *SpanContext, attributes map[string]string) {
 		flags = uint32(0)
 	}
 
-	// TODO: Add support for setting tracestate
 	s.spanLinks = append(s.spanLinks, SpanLink{
 		TraceID:     spanContext.TraceIDLower(),
 		TraceIDHigh: traceIDHigh,

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -234,12 +234,13 @@ func (s *Span) AddLink(spanContext *SpanContext, attributes map[string]string) {
 	traceIDHigh, _ := strconv.ParseUint(traceIDHighHex, 16, 64)
 
 	samplingDecision, hasSamplingDecision := spanContext.SamplingPriority()
-	flags := uint32(0)
-	if hasSamplingDecision {
-		// To distinguish between "not sampled" and "not set", Datadog
-		// will rely on the highest bit being set. The OTel API doesn't
-		// differentiate this, so we will just always mark it as set.
-		flags = uint32(1<<31 | samplingDecision)
+	var flags uint32
+	if hasSamplingDecision && samplingDecision >= ext.PriorityAutoKeep {
+		flags = uint32(1<<31 | 1)
+	} else if hasSamplingDecision {
+		flags = uint32(1<<31 | 0)
+	} else {
+		flags = uint32(0)
 	}
 
 	// TODO: Add support for setting tracestate

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -230,8 +230,8 @@ func (s *Span) SetTag(key string, value interface{}) {
 // stores details about the link in an attributes map.
 func (s *Span) AddLink(spanContext *SpanContext, attributes map[string]string) {
 	//  traceIDUpper uint64
-	traceIDHighHex := spanContext.TraceID()[:16]
-	traceIDHigh, _ := strconv.ParseUint(traceIDHighHex, 16, 64)
+	traceIDHex := spanContext.TraceID()
+	traceIDHigh, _ := strconv.ParseUint(traceIDHex[:8], 16, 64)
 
 	samplingDecision, hasSamplingDecision := spanContext.SamplingPriority()
 	var flags uint32

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -117,6 +117,35 @@ func TestSpanContext(t *testing.T) {
 	assert.NotNil(span.Context())
 }
 
+func TestAddSpanLink(t *testing.T) {
+	assert := assert.New(t)
+
+	rootSpan := newSpan("root", "service", "res", 123, 456, 0)
+	linkedSpan := newSpan("linked", "service", "res", 1, 2, 0)
+
+	attrs := map[string]string{"key1": "val1"}
+	rootSpan.AddLink(linkedSpan.Context(), attrs)
+
+	assert.Equal(len(rootSpan.spanLinks), 1)
+	// Test adding a link with attributes
+	spanLink := rootSpan.spanLinks[0]
+	assert.Equal(spanLink.TraceID, uint64(0x2))
+	assert.Equal(spanLink.SpanID, uint64(0x1))
+	assert.Equal(spanLink.Attributes["key1"], "val1")
+	assert.Equal(spanLink.Tracestate, "")
+	assert.Equal(spanLink.Flags, uint32(0))
+
+	// Test adding a link with a sampling decision
+	linkedSpanSampled := newSpan("linked_sampled", "service", "res", 3, 4, 0)
+	linkedSpanSampled.Context().setSamplingPriority(2, samplernames.Manual)
+	rootSpan.AddLink(linkedSpanSampled.Context(), map[string]string{})
+	assert.Equal(len(rootSpan.spanLinks), 2)
+	spanLinkSampled := rootSpan.spanLinks[1]
+	assert.Equal(spanLink.TraceID, uint64(0x3))
+	assert.Equal(spanLink.SpanID, uint64(0x4))
+	assert.Equal(spanLinkSampled.Flags, uint32(2147483649))
+}
+
 func TestSpanOperationName(t *testing.T) {
 	assert := assert.New(t)
 

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -141,8 +141,8 @@ func TestAddSpanLink(t *testing.T) {
 	rootSpan.AddLink(linkedSpanSampled.Context(), map[string]string{})
 	assert.Equal(len(rootSpan.spanLinks), 2)
 	spanLinkSampled := rootSpan.spanLinks[1]
-	assert.Equal(spanLink.TraceID, uint64(0x3))
-	assert.Equal(spanLink.SpanID, uint64(0x4))
+	assert.Equal(spanLinkSampled.TraceID, uint64(0x4))
+	assert.Equal(spanLinkSampled.SpanID, uint64(0x3))
 	assert.Equal(spanLinkSampled.Flags, uint32(2147483649))
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds `AddLink` to the span struct.

### Motivation

Currently span links can only be set on spans on span creation (via [WithSpanLinks](https://github.com/DataDog/dd-trace-go/blob/v1.999.0-rc.8/ddtrace/tracer/option.go#L414) option). To support many use cases we need the ability to add SpanLinks after a span has been created.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
