### PR TITLE
go.mod: rotate go 1.19 from supported versions

### DIFF
--- a/.github/workflows/main-branch-tests.yml
+++ b/.github/workflows/main-branch-tests.yml
@@ -14,7 +14,7 @@ on:
     tags:
       - "**"
 
-concurrency: 
+concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
@@ -22,7 +22,7 @@ jobs:
   unit-integration-tests:
     strategy:
       matrix:
-        go-version: ["1.19", "1.20", "1.21"]
+        go-version: ["1.20", "1.21", "1.22"]
       fail-fast: false
     uses: ./.github/workflows/unit-integration-tests.yml
     with:
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         runs-on: [ macos-latest, windows-latest, ubuntu-latest ]
-        go-version: ["1.19", "1.20", "1.21"]
+        go-version: ["1.20", "1.21", "1.22"]
       fail-fast: false
     uses: ./.github/workflows/multios-unit-tests.yml
     with:

--- a/.github/workflows/multios-unit-tests.yml
+++ b/.github/workflows/multios-unit-tests.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   test-multi-os:
-    runs-on: "${{ (inputs.go-version == '1.19' && inputs.runs-on == 'windows-latest') && 'windows-2019' || inputs.runs-on }}"
+    runs-on: "${{ (inputs.go-version == '1.20' && inputs.runs-on == 'windows-latest') && 'windows-2019' || inputs.runs-on }}"
     env:
       REPORT: gotestsum-report.xml # path to where test results will be saved
       DD_APPSEC_WAF_TIMEOUT: 1h

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
 
       - name: Build runner
         uses: ./.github/actions/install_runner

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - 'mq-working-branch-**'
 
-concurrency: 
+concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
@@ -18,6 +18,6 @@ jobs:
     name: PR Unit and Integration Tests
     uses: ./.github/workflows/unit-integration-tests.yml
     with:
-      go-version: "1.19"
+      go-version: "1.20"
       ref: ${{ github.ref }}
     secrets: inherit

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -80,7 +80,7 @@ jobs:
       matrix:
         # TODO: cross-compilation from/to different hardware architectures once
         #       github provides native ARM runners.
-        go: [ "1.21", "1.20", "1.19" ]
+        go: [ "1.20", "1.21", "1.22" ]
         build-env: [ alpine, bookworm, bullseye ]
         build-with-cgo: [ 0, 1 ]
         deployment-env: [ alpine, debian11, debian12, al2, al2023, busybox, scratch ]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,8 +4,8 @@ stages:
   - test-apps
 
 variables:
-  # This base image is created here: https://gitlab.ddbuild.io/DataDog/apm-reliability/benchmarking-platform/-/pipelines/18455613
-  BASE_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dd-trace-go-18455613
+  # This base image is created here: https://gitlab.ddbuild.io/DataDog/apm-reliability/benchmarking-platform/-/pipelines/30087677
+  BASE_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dd-trace-go-30087677
   INDEX_FILE: index.txt
   KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-go
   FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"

--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -43,7 +43,7 @@ go122-baseline:
     ENABLE_PROFILING: "false"
     ENABLE_APPSEC: "false"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.22.0"
+    GO_VERSION: "1.22.1"
     LOAD_TESTS: normal_operation_io-bound,high_load_io-bound|normal_operation_cpu-bound,high_load_cpu-bound|normal_operation_cgo-cpu-bound,high_load_cgo-cpu-bound|normal_operation_cpu-bound-x-client-ip-enabled,high_load_cpu-bound-x-client-ip-enabled
     PARALLELIZE: "true"
 go122-only-trace:
@@ -54,7 +54,7 @@ go122-only-trace:
     ENABLE_PROFILING: "false"
     ENABLE_APPSEC: "false"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.22.0"
+    GO_VERSION: "1.22.1"
     LOAD_TESTS: normal_operation_io-bound,high_load_io-bound|normal_operation_cpu-bound,high_load_cpu-bound|normal_operation_cgo-cpu-bound,high_load_cgo-cpu-bound|normal_operation_cpu-bound-x-client-ip-enabled,high_load_cpu-bound-x-client-ip-enabled
     PARALLELIZE: "true"
 go122-only-profile:
@@ -65,7 +65,7 @@ go122-only-profile:
     ENABLE_PROFILING: "true"
     ENABLE_APPSEC: "false"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.22.0"
+    GO_VERSION: "1.22.1"
     LOAD_TESTS: normal_operation_io-bound,high_load_io-bound|normal_operation_cpu-bound,high_load_cpu-bound|normal_operation_cgo-cpu-bound,high_load_cgo-cpu-bound|normal_operation_cpu-bound-x-client-ip-enabled,high_load_cpu-bound-x-client-ip-enabled
     PARALLELIZE: "true"
 go122-profile-trace:
@@ -76,7 +76,7 @@ go122-profile-trace:
     ENABLE_PROFILING: "true"
     ENABLE_APPSEC: "false"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.22.0"
+    GO_VERSION: "1.22.1"
     LOAD_TESTS: normal_operation_io-bound,high_load_io-bound|normal_operation_cpu-bound,high_load_cpu-bound|normal_operation_cgo-cpu-bound,high_load_cgo-cpu-bound|normal_operation_cpu-bound-x-client-ip-enabled,high_load_cpu-bound-x-client-ip-enabled
     PARALLELIZE: "true"
 go122-trace-asm:
@@ -87,7 +87,7 @@ go122-trace-asm:
     ENABLE_PROFILING: "false"
     ENABLE_APPSEC: "true"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.22.0"
+    GO_VERSION: "1.22.1"
     LOAD_TESTS: normal_operation_io-bound,high_load_io-bound|normal_operation_cpu-bound,high_load_cpu-bound|normal_operation_cgo-cpu-bound,high_load_cgo-cpu-bound|normal_operation_cpu-bound-x-client-ip-enabled,high_load_cpu-bound-x-client-ip-enabled
     PARALLELIZE: "true"
 go122-profile-trace-asm:
@@ -98,10 +98,10 @@ go122-profile-trace-asm:
     ENABLE_PROFILING: "true"
     ENABLE_APPSEC: "true"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.22.0"
+    GO_VERSION: "1.22.1"
     LOAD_TESTS: normal_operation_io-bound,high_load_io-bound|normal_operation_cpu-bound,high_load_cpu-bound|normal_operation_cgo-cpu-bound,high_load_cgo-cpu-bound|normal_operation_cpu-bound-x-client-ip-enabled,high_load_cpu-bound-x-client-ip-enabled
     PARALLELIZE: "true"
-go119-baseline:
+go120-baseline:
   extends: .benchmarks
   variables:
     ENABLE_DDPROF: "false"
@@ -109,10 +109,10 @@ go119-baseline:
     ENABLE_PROFILING: "false"
     ENABLE_APPSEC: "false"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.19.13"
+    GO_VERSION: "1.20.14"
     LOAD_TESTS: normal_operation_io-bound,high_load_io-bound|normal_operation_cpu-bound,high_load_cpu-bound|normal_operation_cgo-cpu-bound,high_load_cgo-cpu-bound|normal_operation_cpu-bound-x-client-ip-enabled,high_load_cpu-bound-x-client-ip-enabled
     PARALLELIZE: "true"
-go119-only-trace:
+go120-only-trace:
   extends: .benchmarks
   variables:
     ENABLE_DDPROF: "false"
@@ -120,10 +120,10 @@ go119-only-trace:
     ENABLE_PROFILING: "false"
     ENABLE_APPSEC: "false"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.19.13"
+    GO_VERSION: "1.20.14"
     LOAD_TESTS: normal_operation_io-bound,high_load_io-bound|normal_operation_cpu-bound,high_load_cpu-bound|normal_operation_cgo-cpu-bound,high_load_cgo-cpu-bound|normal_operation_cpu-bound-x-client-ip-enabled,high_load_cpu-bound-x-client-ip-enabled
     PARALLELIZE: "true"
-go119-only-profile:
+go120-only-profile:
   extends: .benchmarks
   variables:
     ENABLE_DDPROF: "false"
@@ -131,10 +131,10 @@ go119-only-profile:
     ENABLE_PROFILING: "true"
     ENABLE_APPSEC: "false"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.19.13"
+    GO_VERSION: "1.20.14"
     LOAD_TESTS: normal_operation_io-bound,high_load_io-bound|normal_operation_cpu-bound,high_load_cpu-bound|normal_operation_cgo-cpu-bound,high_load_cgo-cpu-bound|normal_operation_cpu-bound-x-client-ip-enabled,high_load_cpu-bound-x-client-ip-enabled
     PARALLELIZE: "true"
-go119-profile-trace:
+go120-profile-trace:
   extends: .benchmarks
   variables:
     ENABLE_DDPROF: "false"
@@ -142,10 +142,10 @@ go119-profile-trace:
     ENABLE_PROFILING: "true"
     ENABLE_APPSEC: "false"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.19.13"
+    GO_VERSION: "1.20.14"
     LOAD_TESTS: normal_operation_io-bound,high_load_io-bound|normal_operation_cpu-bound,high_load_cpu-bound|normal_operation_cgo-cpu-bound,high_load_cgo-cpu-bound|normal_operation_cpu-bound-x-client-ip-enabled,high_load_cpu-bound-x-client-ip-enabled
     PARALLELIZE: "true"
-go119-trace-asm:
+go120-trace-asm:
   extends: .benchmarks
   variables:
     ENABLE_DDPROF: "false"
@@ -153,10 +153,10 @@ go119-trace-asm:
     ENABLE_PROFILING: "false"
     ENABLE_APPSEC: "true"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.19.13"
+    GO_VERSION: "1.20.14"
     LOAD_TESTS: normal_operation_io-bound,high_load_io-bound|normal_operation_cpu-bound,high_load_cpu-bound|normal_operation_cgo-cpu-bound,high_load_cgo-cpu-bound|normal_operation_cpu-bound-x-client-ip-enabled,high_load_cpu-bound-x-client-ip-enabled
     PARALLELIZE: "true"
-go119-profile-trace-asm:
+go120-profile-trace-asm:
   extends: .benchmarks
   variables:
     ENABLE_DDPROF: "false"
@@ -164,6 +164,6 @@ go119-profile-trace-asm:
     ENABLE_PROFILING: "true"
     ENABLE_APPSEC: "true"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.19.13"
+    GO_VERSION: "1.20.14"
     LOAD_TESTS: normal_operation_io-bound,high_load_io-bound|normal_operation_cpu-bound,high_load_cpu-bound|normal_operation_cgo-cpu-bound,high_load_cgo-cpu-bound|normal_operation_cpu-bound-x-client-ip-enabled,high_load_cpu-bound-x-client-ip-enabled
     PARALLELIZE: "true"

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
 
 This repository contains Go packages for the client-side components of the Datadog product suite for Application Performance Monitoring, Continuous Profiling and Application Security Monitoring of Go applications.
 
-- [Datadog Application Performance Monitoring (APM)](https://docs.datadoghq.com/tracing/): Trace requests as they flow across web servers, databases and microservices so that developers have great visiblity into bottlenecks and troublesome requests.  
+- [Datadog Application Performance Monitoring (APM)](https://docs.datadoghq.com/tracing/): Trace requests as they flow across web servers, databases and microservices so that developers have great visiblity into bottlenecks and troublesome requests.
 The package [`gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer`](https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer) allows you to trace any piece of your Go code, and commonly used Go libraries can be automatically traced thanks to our out-of-the-box integrations which can be found in the package [`gopkg.in/DataDog/dd-trace-go.v1/ddtrace/contrib`](https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/contrib).
 
-- [Datadog Go Continuous Profiler](https://docs.datadoghq.com/profiler/): Continuously profile your Go apps to find CPU, memory, and synchronization bottlenecks, broken down by function name, and line number, to significantly reduce end-user latency and infrastructure costs.  
+- [Datadog Go Continuous Profiler](https://docs.datadoghq.com/profiler/): Continuously profile your Go apps to find CPU, memory, and synchronization bottlenecks, broken down by function name, and line number, to significantly reduce end-user latency and infrastructure costs.
 The package [`gopkg.in/DataDog/dd-trace-go.v1/profiler`](https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/profiler) allows you to periodically collect and send Go profiles to the Datadog API.
 
 - [Datadog Application Security Management (ASM)](https://docs.datadoghq.com/security_platform/application_security/) provides in-app monitoring and protection against application-level attacks that aim to exploit code-level vulnerabilities, such as a Server-Side-Request-Forgery (SSRF), a SQL injection (SQLi), or Reflected Cross-Site-Scripting (XSS). ASM identifies services exposed to application attacks and leverages in-app security rules to detect and protect against threats in your application environment. ASM is not a standalone Go package and is transparently integrated into the APM tracer. You can simply enable it with [`DD_APPSEC_ENABLED=true`](https://docs.datadoghq.com/security/application_security/enabling/go).
@@ -57,10 +57,10 @@ Datadog APM for Go is built upon dependencies defined in specific versions of th
 <!-- NOTE: When updating the below section ensure you update the minimum supported version listed in the public docs here: https://docs.datadoghq.com/tracing/setup_overview/setup/go/?tab=containers#compatibility-requirements -->
 | **Go Version** | **Support level**                   |
 |----------------|-------------------------------------|
+| 1.22           | [GA](#support-ga)                   |
 | 1.21           | [GA](#support-ga)                   |
-| 1.20           | [GA](#support-ga)                   |
-| 1.19           | [Maintenance](#support-maintenance) |
-| 1.18           | [Legacy](#support-legacy)           |
+| 1.20           | [Maintenance](#support-maintenance) |
+| 1.19           | [Legacy](#support-legacy)           |
 
 * Datadog's Trace Agent >= 5.21.1
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gopkg.in/DataDog/dd-trace-go.v1
 
-go 1.19
+go 1.20
 
 require (
 	cloud.google.com/go/pubsub v1.33.0

--- a/internal/apps/go.mod
+++ b/internal/apps/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/dd-trace-go/internal/apps
 
-go 1.19
+go 1.20
 
 require (
 	golang.org/x/sync v0.3.0


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

As per the [go supported version policy](https://github.com/DataDog/dd-trace-go#supported-versions). We are rotating go 1.19 from the supported versions in favor of go 1.22.

- [x] Replace go 1.19 with go 1.20 for job running the oldest supported version
- [x] Rotate go 1.19 in favor of go 1.22 for jobs running all supported versions via a matrix
- [x] Modify the README to declare that go 1.19 is now legacy
- [x] Upgrade go mod version
- [x] Upgrade benchmarking platform to 1.20 (https://github.com/DataDog/benchmarking-platform/pull/45) and use the new image built by the CI

Fixes #2595 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
