### PR TITLE
contrib/net/http: harmonize benchmarks for v2

### DIFF
--- a/contrib/net/http/http_test.go
+++ b/contrib/net/http/http_test.go
@@ -17,6 +17,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/normalizer"
 
 	"github.com/stretchr/testify/assert"
@@ -496,8 +497,8 @@ func handler500(w http.ResponseWriter, _ *http.Request) {
 }
 
 func BenchmarkHttpServeTrace(b *testing.B) {
-	mt := mocktracer.Start()
-	defer mt.Stop()
+	tracer.Start(tracer.WithLogger(log.DiscardLogger{}))
+	defer tracer.Stop()
 	header, tag := normalizer.HeaderTag("3header")
 	globalconfig.SetHeaderTag(header, tag)
 

--- a/contrib/net/http/trace_test.go
+++ b/contrib/net/http/trace_test.go
@@ -373,14 +373,15 @@ func BenchmarkTraceAndServe(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+	cfg := ServeConfig{
+		Service:     "service-name",
+		Resource:    "resource-name",
+		FinishOpts:  []ddtrace.FinishOption{},
+		SpanOpts:    []ddtrace.StartSpanOption{},
+		QueryParams: false,
+	}
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		cfg := ServeConfig{
-			Service:     "service-name",
-			Resource:    "resource-name",
-			FinishOpts:  []ddtrace.FinishOption{},
-			SpanOpts:    []ddtrace.StartSpanOption{},
-			QueryParams: false,
-		}
 		TraceAndServe(handler, noopWriter{}, req, &cfg)
 	}
 }

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -2046,6 +2046,7 @@ func BenchmarkTracerAddSpans(b *testing.B) {
 	tracer, _, _, stop := startTestTracer(b, WithLogger(log.DiscardLogger{}), WithSampler(NewRateSampler(0)))
 	defer stop()
 
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		span := tracer.StartSpan("pylons.request", ServiceName("pylons"), ResourceName("/"))
 		span.Finish()


### PR DESCRIPTION
### What does this PR do?

`BenchmarkHttpServeTrace` used the `mocktracer` instead of the real tracer.

### Motivation

As in v2 we prefer to use the real tracer, although not completely applied, we found that we were measuring different implementations.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
