### PR TITLE
internal/remoteconfig/: Fixes capability APM_TRACING_SAMPLING_RULES to use the correct reserved number 29.

### DIFF
--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -71,7 +71,7 @@ const (
 	// APMTracingCustomTags enables APM client to set custom tags on all spans
 	APMTracingCustomTags
 	// APMTracingSampleRules represents the sampling rate using matching rules from APM client libraries
-	APMTracingSampleRules
+	APMTracingSampleRules = 29
 )
 
 // APMTracingEnabled enables APM tracing

--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -70,12 +70,15 @@ const (
 	APMTracingHTTPHeaderTags
 	// APMTracingCustomTags enables APM client to set custom tags on all spans
 	APMTracingCustomTags
+)
+
+// Additional capability bit index values that are non-consecutive from above.
+const (
+	// APMTracingEnabled enables APM tracing
+	APMTracingEnabled Capability = 19
 	// APMTracingSampleRules represents the sampling rate using matching rules from APM client libraries
 	APMTracingSampleRules = 29
 )
-
-// APMTracingEnabled enables APM tracing
-const APMTracingEnabled Capability = 19
 
 // ErrClientNotStarted is returned when the remote config client is not started.
 var ErrClientNotStarted = errors.New("remote config client not started")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Explicitly setting the APM_TRACING_SAMPLING_RULES to use the correct number 29 that is reserved across all languages.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
