### PR TITLE
contrib/segmentio/kafka.go.v0: add DSM support

### DIFF
--- a/contrib/segmentio/kafka.go.v0/kafka.go
+++ b/contrib/segmentio/kafka.go.v0/kafka.go
@@ -10,6 +10,8 @@ import (
 	"math"
 	"strings"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/datastreams"
+	"gopkg.in/DataDog/dd-trace-go.v1/datastreams/options"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -46,6 +48,11 @@ func WrapReader(c *kafka.Reader, opts ...Option) *Reader {
 	if c.Config().Brokers != nil {
 		wrapped.bootstrapServers = strings.Join(c.Config().Brokers, ",")
 	}
+
+	if c.Config().GroupID != "" {
+		wrapped.groupID = c.Config().GroupID
+	}
+
 	log.Debug("contrib/segmentio/kafka-go.v0/kafka: Wrapping Reader: %#v", wrapped.cfg)
 	return wrapped
 }
@@ -53,6 +60,7 @@ func WrapReader(c *kafka.Reader, opts ...Option) *Reader {
 // A kafkaConfig struct holds information from the kafka config for span tags
 type kafkaConfig struct {
 	bootstrapServers string
+	groupID          string
 }
 
 // A Reader wraps a kafka.Reader.
@@ -115,6 +123,7 @@ func (r *Reader) ReadMessage(ctx context.Context) (kafka.Message, error) {
 		return kafka.Message{}, err
 	}
 	r.prev = r.startSpan(ctx, &msg)
+	setConsumeCheckpoint(r.cfg.dataStreamsEnabled, r.groupID, &msg)
 	return msg, nil
 }
 
@@ -129,7 +138,33 @@ func (r *Reader) FetchMessage(ctx context.Context) (kafka.Message, error) {
 		return msg, err
 	}
 	r.prev = r.startSpan(ctx, &msg)
+	setConsumeCheckpoint(r.cfg.dataStreamsEnabled, r.groupID, &msg)
 	return msg, nil
+}
+
+func setConsumeCheckpoint(enabled bool, groupID string, msg *kafka.Message) {
+	if !enabled || msg == nil {
+		return
+	}
+	edges := []string{"direction:in", "topic:" + msg.Topic, "type:kafka"}
+	if groupID != "" {
+		edges = append(edges, "group:"+groupID)
+	}
+	carrier := messageCarrier{msg}
+	ctx, ok := tracer.SetDataStreamsCheckpointWithParams(
+		datastreams.ExtractFromBase64Carrier(context.Background(), carrier),
+		options.CheckpointParams{PayloadSize: getConsumerMsgSize(msg)},
+		edges...,
+	)
+	if !ok {
+		return
+	}
+	datastreams.InjectToBase64Carrier(ctx, carrier)
+	if groupID != "" {
+		// only track Kafka lag if a consumer group is set.
+		// since there is no ack mechanism, we consider that messages read are committed right away.
+		tracer.TrackKafkaCommitOffset(groupID, msg.Topic, int32(msg.Partition), msg.Offset)
+	}
 }
 
 // WrapWriter wraps a kafka.Writer so requests are traced.
@@ -191,10 +226,58 @@ func (w *Writer) WriteMessages(ctx context.Context, msgs ...kafka.Message) error
 	spans := make([]ddtrace.Span, len(msgs))
 	for i := range msgs {
 		spans[i] = w.startSpan(ctx, &msgs[i])
+		setProduceCheckpoint(w.cfg.dataStreamsEnabled, &msgs[i], w.Writer)
 	}
 	err := w.Writer.WriteMessages(ctx, msgs...)
 	for i, span := range spans {
 		finishSpan(span, msgs[i].Partition, msgs[i].Offset, err)
 	}
 	return err
+}
+
+func setProduceCheckpoint(enabled bool, msg *kafka.Message, writer *kafka.Writer) {
+	if !enabled || msg == nil {
+		return
+	}
+
+	var topic string
+	if writer.Topic != "" {
+		topic = writer.Topic
+	} else {
+		topic = msg.Topic
+	}
+
+	edges := []string{"direction:out", "topic:" + topic, "type:kafka"}
+	carrier := messageCarrier{msg}
+	ctx, ok := tracer.SetDataStreamsCheckpointWithParams(
+		datastreams.ExtractFromBase64Carrier(context.Background(), carrier),
+		options.CheckpointParams{PayloadSize: getProducerMsgSize(msg)},
+		edges...,
+	)
+	if !ok {
+		return
+	}
+
+	// Headers will be dropped if the current protocol does not support them
+	datastreams.InjectToBase64Carrier(ctx, carrier)
+}
+
+func getProducerMsgSize(msg *kafka.Message) (size int64) {
+	for _, header := range msg.Headers {
+		size += int64(len(header.Key) + len(header.Value))
+	}
+	if msg.Value != nil {
+		size += int64(len(msg.Value))
+	}
+	if msg.Key != nil {
+		size += int64(len(msg.Key))
+	}
+	return size
+}
+
+func getConsumerMsgSize(msg *kafka.Message) (size int64) {
+	for _, header := range msg.Headers {
+		size += int64(len(header.Key) + len(header.Value))
+	}
+	return size + int64(len(msg.Value)+len(msg.Key))
 }

--- a/contrib/segmentio/kafka.go.v0/kafka_test.go
+++ b/contrib/segmentio/kafka.go.v0/kafka_test.go
@@ -12,8 +12,10 @@ import (
 	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/namingschematest"
+	"gopkg.in/DataDog/dd-trace-go.v1/datastreams"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	kafka "github.com/segmentio/kafka-go"
 	"github.com/stretchr/testify/assert"
@@ -24,15 +26,6 @@ const (
 	testGroupID       = "gosegtest"
 	testTopic         = "gosegtest"
 	testReaderMaxWait = 10 * time.Millisecond
-)
-
-var (
-	testMessages = []kafka.Message{
-		{
-			Key:   []byte("key1"),
-			Value: []byte("value1"),
-		},
-	}
 )
 
 func skipIntegrationTest(t *testing.T) {
@@ -48,16 +41,19 @@ to setup the integration test locally run:
 
 type readerOpFn func(t *testing.T, r *Reader)
 
-func genIntegrationTestSpans(t *testing.T, writerOp func(t *testing.T, w *Writer), readerOp readerOpFn, writerOpts []Option, readerOpts []Option) []mocktracer.Span {
+func genIntegrationTestSpans(t *testing.T, mt mocktracer.Tracer, writerOp func(t *testing.T, w *Writer), readerOp readerOpFn, writerOpts []Option, readerOpts []Option) ([]mocktracer.Span, []kafka.Message) {
 	skipIntegrationTest(t)
-	mt := mocktracer.Start()
-	defer mt.Stop()
+
+	writtenMessages := []kafka.Message{}
 
 	// add some dummy values to broker/addr to test bootstrap servers.
 	kw := &kafka.Writer{
 		Addr:         kafka.TCP("localhost:9092", "localhost:9093", "localhost:9094"),
 		Topic:        testTopic,
 		RequiredAcks: kafka.RequireOne,
+		Completion: func(messages []kafka.Message, err error) {
+			writtenMessages = append(writtenMessages, messages...)
+		},
 	}
 	w := WrapWriter(kw, writerOpts...)
 	writerOp(t, w)
@@ -78,14 +74,28 @@ func genIntegrationTestSpans(t *testing.T, writerOp func(t *testing.T, w *Writer
 	require.Len(t, spans, 2)
 	// they should be linked via headers
 	assert.Equal(t, spans[0].TraceID(), spans[1].TraceID(), "Trace IDs should match")
-	return spans
+	return spans, writtenMessages
 }
 
 func TestReadMessageFunctional(t *testing.T) {
-	spans := genIntegrationTestSpans(
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	var (
+		messagesToWrite = []kafka.Message{
+			{
+				Key:   []byte("key1"),
+				Value: []byte("value1"),
+			},
+		}
+		readMessages []kafka.Message
+	)
+
+	spans, writtenMessages := genIntegrationTestSpans(
 		t,
+		mt,
 		func(t *testing.T, w *Writer) {
-			err := w.WriteMessages(context.Background(), testMessages...)
+			err := w.WriteMessages(context.Background(), messagesToWrite...)
 			require.NoError(t, err, "Expected to write message to topic")
 		},
 		func(t *testing.T, r *Reader) {
@@ -93,14 +103,18 @@ func TestReadMessageFunctional(t *testing.T) {
 			defer cancel()
 			readMsg, err := r.ReadMessage(ctx)
 			require.NoError(t, err, "Expected to consume message")
-			assert.Equal(t, testMessages[0].Value, readMsg.Value, "Values should be equal")
+			assert.Equal(t, messagesToWrite[0].Value, readMsg.Value, "Values should be equal")
 
+			readMessages = append(readMessages, readMsg)
 			err = r.CommitMessages(context.Background(), readMsg)
 			assert.NoError(t, err, "Expected CommitMessages to not return an error")
 		},
-		[]Option{WithAnalyticsRate(0.1)},
-		[]Option{},
+		[]Option{WithAnalyticsRate(0.1), WithDataStreams()},
+		[]Option{WithDataStreams()},
 	)
+
+	assert.Len(t, writtenMessages, len(messagesToWrite))
+	assert.Len(t, readMessages, len(messagesToWrite))
 
 	// producer span
 	s0 := spans[0]
@@ -115,6 +129,13 @@ func TestReadMessageFunctional(t *testing.T) {
 	assert.Equal(t, "kafka", s0.Tag(ext.MessagingSystem))
 	assert.Equal(t, "localhost:9092,localhost:9093,localhost:9094", s0.Tag(ext.KafkaBootstrapServers))
 
+	p, ok := datastreams.PathwayFromContext(datastreams.ExtractFromBase64Carrier(context.Background(), messageCarrier{&writtenMessages[0]}))
+	assert.True(t, ok)
+	expectedCtx, _ := tracer.SetDataStreamsCheckpoint(context.Background(), "direction:out", "topic:"+testTopic, "type:kafka")
+	expected, _ := datastreams.PathwayFromContext(expectedCtx)
+	assert.NotEqual(t, expected.GetHash(), 0)
+	assert.Equal(t, expected.GetHash(), p.GetHash())
+
 	// consumer span
 	s1 := spans[1]
 	assert.Equal(t, "kafka.consume", s1.OperationName())
@@ -127,13 +148,37 @@ func TestReadMessageFunctional(t *testing.T) {
 	assert.Equal(t, ext.SpanKindConsumer, s1.Tag(ext.SpanKind))
 	assert.Equal(t, "kafka", s1.Tag(ext.MessagingSystem))
 	assert.Equal(t, "localhost:9092,localhost:9093,localhost:9094", s1.Tag(ext.KafkaBootstrapServers))
+
+	p, ok = datastreams.PathwayFromContext(datastreams.ExtractFromBase64Carrier(context.Background(), messageCarrier{&readMessages[0]}))
+	assert.True(t, ok)
+	expectedCtx, _ = tracer.SetDataStreamsCheckpoint(
+		datastreams.ExtractFromBase64Carrier(context.Background(), messageCarrier{&writtenMessages[0]}),
+		"direction:in", "topic:"+testTopic, "type:kafka", "group:"+testGroupID,
+	)
+	expected, _ = datastreams.PathwayFromContext(expectedCtx)
+	assert.NotEqual(t, expected.GetHash(), 0)
+	assert.Equal(t, expected.GetHash(), p.GetHash())
 }
 
 func TestFetchMessageFunctional(t *testing.T) {
-	spans := genIntegrationTestSpans(
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	var (
+		messagesToWrite = []kafka.Message{
+			{
+				Key:   []byte("key1"),
+				Value: []byte("value1"),
+			},
+		}
+		readMessages []kafka.Message
+	)
+
+	spans, writtenMessages := genIntegrationTestSpans(
 		t,
+		mt,
 		func(t *testing.T, w *Writer) {
-			err := w.WriteMessages(context.Background(), testMessages...)
+			err := w.WriteMessages(context.Background(), messagesToWrite...)
 			require.NoError(t, err, "Expected to write message to topic")
 		},
 		func(t *testing.T, r *Reader) {
@@ -141,13 +186,14 @@ func TestFetchMessageFunctional(t *testing.T) {
 			defer cancel()
 			readMsg, err := r.FetchMessage(ctx)
 			require.NoError(t, err, "Expected to consume message")
-			assert.Equal(t, testMessages[0].Value, readMsg.Value, "Values should be equal")
+			assert.Equal(t, messagesToWrite[0].Value, readMsg.Value, "Values should be equal")
 
+			readMessages = append(readMessages, readMsg)
 			err = r.CommitMessages(context.Background(), readMsg)
 			assert.NoError(t, err, "Expected CommitMessages to not return an error")
 		},
-		[]Option{WithAnalyticsRate(0.1)},
-		[]Option{},
+		[]Option{WithAnalyticsRate(0.1), WithDataStreams()},
+		[]Option{WithDataStreams()},
 	)
 
 	// producer span
@@ -163,6 +209,13 @@ func TestFetchMessageFunctional(t *testing.T) {
 	assert.Equal(t, "kafka", s0.Tag(ext.MessagingSystem))
 	assert.Equal(t, "localhost:9092,localhost:9093,localhost:9094", s0.Tag(ext.KafkaBootstrapServers))
 
+	p, ok := datastreams.PathwayFromContext(datastreams.ExtractFromBase64Carrier(context.Background(), messageCarrier{&writtenMessages[0]}))
+	assert.True(t, ok)
+	expectedCtx, _ := tracer.SetDataStreamsCheckpoint(context.Background(), "direction:out", "topic:"+testTopic, "type:kafka")
+	expected, _ := datastreams.PathwayFromContext(expectedCtx)
+	assert.NotEqual(t, expected.GetHash(), 0)
+	assert.Equal(t, expected.GetHash(), p.GetHash())
+
 	// consumer span
 	s1 := spans[1]
 	assert.Equal(t, "kafka.consume", s1.OperationName())
@@ -175,6 +228,16 @@ func TestFetchMessageFunctional(t *testing.T) {
 	assert.Equal(t, ext.SpanKindConsumer, s1.Tag(ext.SpanKind))
 	assert.Equal(t, "kafka", s1.Tag(ext.MessagingSystem))
 	assert.Equal(t, "localhost:9092,localhost:9093,localhost:9094", s1.Tag(ext.KafkaBootstrapServers))
+
+	p, ok = datastreams.PathwayFromContext(datastreams.ExtractFromBase64Carrier(context.Background(), messageCarrier{&readMessages[0]}))
+	assert.True(t, ok)
+	expectedCtx, _ = tracer.SetDataStreamsCheckpoint(
+		datastreams.ExtractFromBase64Carrier(context.Background(), messageCarrier{&writtenMessages[0]}),
+		"direction:in", "topic:"+testTopic, "type:kafka", "group:"+testGroupID,
+	)
+	expected, _ = datastreams.PathwayFromContext(expectedCtx)
+	assert.NotEqual(t, expected.GetHash(), 0)
+	assert.Equal(t, expected.GetHash(), p.GetHash())
 }
 
 func TestNamingSchema(t *testing.T) {
@@ -183,10 +246,22 @@ func TestNamingSchema(t *testing.T) {
 		if serviceOverride != "" {
 			opts = append(opts, WithServiceName(serviceOverride))
 		}
-		return genIntegrationTestSpans(
+
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		messagesToWrite := []kafka.Message{
+			{
+				Key:   []byte("key1"),
+				Value: []byte("value1"),
+			},
+		}
+
+		spans, _ := genIntegrationTestSpans(
 			t,
+			mt,
 			func(t *testing.T, w *Writer) {
-				err := w.WriteMessages(context.Background(), testMessages...)
+				err := w.WriteMessages(context.Background(), messagesToWrite...)
 				require.NoError(t, err, "Expected to write message to topic")
 			},
 			func(t *testing.T, r *Reader) {
@@ -194,7 +269,7 @@ func TestNamingSchema(t *testing.T) {
 				defer cancel()
 				readMsg, err := r.FetchMessage(ctx)
 				require.NoError(t, err, "Expected to consume message")
-				assert.Equal(t, testMessages[0].Value, readMsg.Value, "Values should be equal")
+				assert.Equal(t, messagesToWrite[0].Value, readMsg.Value, "Values should be equal")
 
 				err = r.CommitMessages(context.Background(), readMsg)
 				assert.NoError(t, err, "Expected CommitMessages to not return an error")
@@ -202,6 +277,7 @@ func TestNamingSchema(t *testing.T) {
 			opts,
 			opts,
 		)
+		return spans
 	}
 	namingschematest.NewKafkaTest(genSpans)(t)
 }
@@ -214,9 +290,14 @@ func BenchmarkReaderStartSpan(b *testing.B) {
 		MaxWait: testReaderMaxWait,
 	})
 
+	msg := kafka.Message{
+		Key:   []byte("key1"),
+		Value: []byte("value1"),
+	}
+
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		r.startSpan(nil, &testMessages[0])
+		r.startSpan(nil, &msg)
 	}
 }
 
@@ -228,8 +309,13 @@ func BenchmarkWriterStartSpan(b *testing.B) {
 	}
 	w := WrapWriter(kw)
 
+	msg := kafka.Message{
+		Key:   []byte("key1"),
+		Value: []byte("value1"),
+	}
+
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		w.startSpan(nil, &testMessages[0])
+		w.startSpan(nil, &msg)
 	}
 }

--- a/contrib/segmentio/kafka.go.v0/option.go
+++ b/contrib/segmentio/kafka.go.v0/option.go
@@ -20,6 +20,7 @@ type config struct {
 	consumerSpanName    string
 	producerSpanName    string
 	analyticsRate       float64
+	dataStreamsEnabled  bool
 }
 
 // An Option customizes the config.
@@ -33,6 +34,8 @@ func newConfig(opts ...Option) *config {
 	if internal.BoolEnv("DD_TRACE_KAFKA_ANALYTICS_ENABLED", false) {
 		cfg.analyticsRate = 1.0
 	}
+
+	cfg.dataStreamsEnabled = internal.BoolEnv("DD_DATA_STREAMS_ENABLED", false)
 
 	cfg.consumerServiceName = namingschema.ServiceName(defaultServiceName)
 	cfg.producerServiceName = namingschema.ServiceNameOverrideV0(defaultServiceName, defaultServiceName)
@@ -73,5 +76,12 @@ func WithAnalyticsRate(rate float64) Option {
 		} else {
 			cfg.analyticsRate = math.NaN()
 		}
+	}
+}
+
+// WithDataStreams enables the Data Streams monitoring product features: https://www.datadoghq.com/product/data-streams-monitoring/
+func WithDataStreams() Option {
+	return func(cfg *config) {
+		cfg.dataStreamsEnabled = true
 	}
 }

--- a/contrib/segmentio/kafka.go.v0/option_test.go
+++ b/contrib/segmentio/kafka.go.v0/option_test.go
@@ -43,4 +43,17 @@ func TestAnalyticsSettings(t *testing.T) {
 		cfg := newConfig(WithAnalyticsRate(0.2))
 		assert.Equal(t, 0.2, cfg.analyticsRate)
 	})
+
+	t.Run("withEnv", func(t *testing.T) {
+		t.Setenv("DD_DATA_STREAMS_ENABLED", "true")
+		cfg := newConfig()
+		assert.True(t, cfg.dataStreamsEnabled)
+	})
+
+	t.Run("optionOverridesEnv", func(t *testing.T) {
+		t.Setenv("DD_DATA_STREAMS_ENABLED", "false")
+		cfg := newConfig()
+		WithDataStreams()(cfg)
+		assert.True(t, cfg.dataStreamsEnabled)
+	})
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add Data Streams Monitoring support to segmentio/kafka integration

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

We currently use segmentio/kafka for our Go projects and it was easier to update the integration than change library.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
