### PR TITLE
appsec: don't enable blocking-related RC features when using local security rules

### DIFF
--- a/internal/appsec/remoteconfig.go
+++ b/internal/appsec/remoteconfig.go
@@ -382,7 +382,6 @@ func (a *appsec) enableRCBlocking() {
 	if _, isSet := os.LookupEnv(internal.EnvRules); isSet {
 		log.Debug("appsec: Remote config: using rules from %s, blocking capabilities won't be enabled", a.cfg.RulesManager.BasePath)
 		return
-
 	}
 
 	products := []string{rc.ProductASM, rc.ProductASMDD, rc.ProductASMData}

--- a/internal/appsec/remoteconfig.go
+++ b/internal/appsec/remoteconfig.go
@@ -379,6 +379,11 @@ func (a *appsec) enableRCBlocking() {
 		log.Debug("appsec: Remote config: no valid remote configuration client")
 		return
 	}
+	if _, isSet := os.LookupEnv(internal.EnvRules); isSet {
+		log.Debug("appsec: Remote config: using rules from %s, blocking capabilities won't be enabled", a.cfg.RulesManager.BasePath)
+		return
+
+	}
 
 	products := []string{rc.ProductASM, rc.ProductASMDD, rc.ProductASMData}
 	for _, p := range products {
@@ -391,11 +396,9 @@ func (a *appsec) enableRCBlocking() {
 		log.Debug("appsec: Remote config: couldn't register callback: %v", err)
 	}
 
-	if _, isSet := os.LookupEnv(internal.EnvRules); !isSet {
-		for _, c := range blockingCapabilities {
-			if err := a.registerRCCapability(c); err != nil {
-				log.Debug("appsec: Remote config: couldn't register capability %v: %v", c, err)
-			}
+	for _, c := range blockingCapabilities {
+		if err := a.registerRCCapability(c); err != nil {
+			log.Debug("appsec: Remote config: couldn't register capability %v: %v", c, err)
 		}
 	}
 }

--- a/internal/appsec/remoteconfig_test.go
+++ b/internal/appsec/remoteconfig_test.go
@@ -754,7 +754,7 @@ func TestOnRCUpdateStatuses(t *testing.T) {
 				}
 			} else {
 				require.Len(t, statuses, len(tc.expected))
-				require.True(t, reflect.DeepEqual(tc.expected, statuses), "expectedC: %#v\nactual:   %#v", tc.expected, statuses)
+				require.True(t, reflect.DeepEqual(tc.expected, statuses), "expected: %#v\nactual:   %#v", tc.expected, statuses)
 			}
 		})
 	}
@@ -788,7 +788,7 @@ func TestWafRCUpdate(t *testing.T) {
 		values := map[string]interface{}{
 			httpsec.ServerRequestPathParamsAddr: "/rfiinc.txt",
 		}
-		// Make sure the rule matches as expectedC
+		// Make sure the rule matches as expected
 		result := sharedsec.RunWAF(wafCtx, waf.RunAddressData{Persistent: values}, cfg.WAFTimeout)
 		require.Contains(t, jsonString(t, result.Events), "crs-913-120")
 		require.Empty(t, result.Actions)


### PR DESCRIPTION
### What does this PR do?

Stop registering RC products, callbacks and capabilities related to blocking when DD_APPSEC_RULES is set.
This behaviour is RFC specified.

### Motivation

This aligns ASM's behaviour with that of the RFC specification, as well as fixes a bug where rules get
instantaneously overwritten by those received through ASM_DD even when using DD_APPSEC_RULES.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
