### PR TITLE
internal/samplernames: fixes a colliding sampler name

### DIFF
--- a/internal/samplernames/samplernames.go
+++ b/internal/samplernames/samplernames.go
@@ -34,10 +34,11 @@ const (
 	// SingleSpan specifies that the span was sampled by single
 	// span sampling rules.
 	SingleSpan SamplerName = 8
+	// Sampler name 9 is reserved/used by OTel ingestion.
 	// RemoteUserRule specifies that the span was sampled by a rule the user configured remotely
 	// through Datadog UI.
-	RemoteUserRule SamplerName = 9
+	RemoteUserRule SamplerName = 10
 	// RemoteDynamicRule specifies that the span was sampled by a rule configured by Datadog
 	// Dynamic Sampling.
-	RemoteDynamicRule SamplerName = 10
+	RemoteDynamicRule SamplerName = 11
 )


### PR DESCRIPTION
sampler name `9` was reserved for OTel ingestion but not documented. 
The new sampler for remote user rule also uses `9`. This fixes the collide.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
