### PR TITLE
ASEC-131:Remove reference to SDG as the team no longer exists

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,9 +33,5 @@
 - [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
 - [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
 
-For Datadog employees:
-
-- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
-- [ ] This PR doesn't touch any of that.
 
 Unsure? Have a question? Request a review!


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Removing reference of Security Design and Guidance team in PR review template as the team no longer exists. We will work with the trace team to understand the requirements of review.


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->
