### PR TITLE
workflows: do not run the smoke-tests on forks

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -34,6 +34,7 @@ jobs:
     #  Related to issue https://github.com/DataDog/dd-trace-go/issues/1607
     name: 'go get -u smoke test'
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'DataDog' # only run on DataDog's repository, not in forks
     env:
       PACKAGES: ./internal/... ./ddtrace/... ./profiler/... ./appsec/...
     steps:
@@ -75,6 +76,7 @@ jobs:
     # must be considered breaking changes.
     name: 'Build and deployment requirements smoke tests'
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'DataDog' # only run on DataDog's repository, not in forks
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This adds a if in the workflows that will fail on forks. The issue is that `go get` on dd-trace-go and go-libddwaf fails when a fork is used to run the workflow.

### Motivation

We received a contribution in appsec code that triggered this workflow and failed it.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
