### PR TITLE
profiler: reduce TestExecutionTraceRandom by increasing trials

### DIFF
--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -531,8 +531,6 @@ func TestExecutionTraceMisconfiguration(t *testing.T) {
 }
 
 func TestExecutionTraceRandom(t *testing.T) {
-	t.Skip("flaky test, see: https://github.com/DataDog/dd-trace-go/issues/2529")
-
 	collectTraces := func(t *testing.T, profilePeriod, tracePeriod time.Duration, count int) int {
 		t.Setenv("DD_PROFILING_EXECUTION_TRACE_ENABLED", "true")
 		t.Setenv("DD_PROFILING_EXECUTION_TRACE_PERIOD", tracePeriod.String())
@@ -585,12 +583,12 @@ func TestExecutionTraceRandom(t *testing.T) {
 		name := fmt.Sprintf("rate-%f", rate)
 		t.Run(name, func(t *testing.T) {
 			// We should be within 2 standard deviations ~95% of the time
-			// with a correct implementation. If we do this twice, then
+			// with a correct implementation. If we do this four times, then
 			// we have a ~99.999% chance of succeeding with a correct
 			// implementation. We keep a reasonably tight tolerance
 			// to ensure that an incorrect implementation is more likely
-			// to fail both times
-			for i := 0; i < 2; i++ {
+			// to fail each time
+			for i := 0; i < 4; i++ {
 				if doTrial(t, rate, 2.0) {
 					return
 				}


### PR DESCRIPTION
Due to a bit of math sloppiness, we were getting a ~1/500 failure rate
for TestExecutionTraceRandom, which was often enough to be irritating to
dd-trace-go developers. Each trial has a 95% success rate given a
correct implementation. We were doing 2 trials. The comment in the test
incorrectly states that 2 trials should have a 99.999% success rate.
But, actuall we should expect a ~99.75% success rate for 2 trials, or a
1/400 failure rate, roughly matching what we saw.

Increase the number of trials to 4. This actually gives the desired
99.999% success rate. We should expect roughly 1 failure for every
160000 runs. This is a tolerable failure rate, and lets the test remain
somewhat robust, rather than use a fixed seed as considered in #2642.
I have manually tested this by breaking the implementation (multiplying
by an extra rand.Float64() draw) and confirmed that the test still fails
reliably.

Confirmation of the 95% success rate for each trial:

```R
> rates <- c(1/15, 0.5, 1)
> means <- 100*rates
> stddevs <- sqrt(100*rates*(1-rates))
> lo <- means - 2*stddevs
> hi <- means + 2*stddevs
> 1 - (1 - pbinom(hi, size=100, prob=rates) + pbinom(lo, size=100, prob=rates))
[1] 0.9574683 0.9539559 0.0000000
```

(here, `pbinom` is the cumulative distribution function, and I'm computing the
probability around the mean by getting the size of the tail ends and
subtracting them. The `0` for probability 1 is just because lo and hi are the
same, but really we're testing that probability 1 gets exactly 100 each time)

Fixes #2529
