### PR TITLE
internal/remoteconfig: fixes data race when accessing capabilities

### DIFF
--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -381,6 +381,16 @@ func HasCapability(cap Capability) (bool, error) {
 	return found, nil
 }
 
+func (c *Client) allCapabilities() *big.Int {
+	client.capabilitiesMu.Lock()
+	defer client.capabilitiesMu.Unlock()
+	capa := big.NewInt(0)
+	for i := range c.capabilities {
+		capa.SetBit(capa, int(i), 1)
+	}
+	return capa
+}
+
 func (c *Client) globalCallbacks() []Callback {
 	c._callbacksMu.RLock()
 	defer c._callbacksMu.RUnlock()
@@ -563,10 +573,7 @@ func (c *Client) newUpdateRequest() (bytes.Buffer, error) {
 		}
 	}
 
-	capa := big.NewInt(0)
-	for i := range c.capabilities {
-		capa.SetBit(capa, int(i), 1)
-	}
+	capa := c.allCapabilities()
 	req := clientGetConfigsRequest{
 		Client: &clientData{
 			State: &clientState{


### PR DESCRIPTION
### What does this PR do?

Fixes a data race when accessing capabilities by using the corresponding mutex :)

### Motivation

Fixes #2648

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

For Datadog employees:

- [ ] If this PR touches code that handles credentials of any kind, such as Datadog API keys, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
