### PR TITLE
workflows: increase timeout of WAF time budget in contrib CI tests

### DIFF
--- a/.github/workflows/multios-unit-tests.yml
+++ b/.github/workflows/multios-unit-tests.yml
@@ -26,6 +26,9 @@ on:
         required: true
         type: string
 
+env:
+  DD_APPSEC_WAF_TIMEOUT: 1m # Increase time WAF time budget to reduce CI flakiness
+
 jobs:
   test-multi-os:
     runs-on: "${{ (inputs.go-version == '1.20' && inputs.runs-on == 'windows-latest') && 'windows-2019' || inputs.runs-on }}"

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -11,6 +11,9 @@ on:
         required: true
         type: string
 
+env:
+  DD_APPSEC_WAF_TIMEOUT: 1m # Increase time WAF time budget to reduce CI flakiness
+
 jobs:
   copyright:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds the `DD_APPSEC_WAF_TIMEOUT=1m` env var to more CI jobs to reduce CI flakiness.

### Motivation

ASM can take up a lot of each customer's app requests time of left unchecked, so multiple safe guard are baked into dd-trace-go to make sure we stop ourselves before taking too much time. This env var change the timeout from the default, 1ms, to 1. minute. Cases like [this one](https://github.com/DataDog/dd-trace-go/actions/runs/8647087390/job/23707810560#step:5:313) where only half of the security rules that should trigger have triggered should disappear. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
