### PR TITLE
docs: fix dbStats example in contrib/database/sql

### DIFF
--- a/contrib/database/sql/example_test.go
+++ b/contrib/database/sql/example_test.go
@@ -108,14 +108,16 @@ func Example_dbmPropagation() {
 }
 
 func Example_dbStats() {
-	sqltrace.Register("postgres", &pq.Driver{})
+	// Register the driver with the WithDBStats option to enable DBStats metric polling
+	sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithDBStats())
+	// Followed by a call to Open.
 	db, err := sqltrace.Open("postgres", "postgres://pqgotest:password@localhost/pqgotest?sslmode=disable")
 
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// Tracing is now enabled. Continue to use the database/sql package as usual
+	// Tracing and metric polling is now enabled. Metrics  will be submitted to Datadog with the prefix `datadog.tracer.sql`
 	rows, err := db.Query("SELECT name FROM users WHERE age=?", 27)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
### What does this PR do?
The WithDBStats example on the contrib/database/sql go docs is inaccurate: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1@v1.63.0/contrib/database/sql#example-package-DbStats
It's missing WithDBStats in the register function call. This PR updates the code snippet to an accurate example 

### Motivation
Clarity and usability for the feature

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
