### PR TITLE
ddtrace/tracer: adding support of tags in remote sampling rules.

### DIFF
--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -166,7 +166,7 @@ jobs:
         ports:
           - 2181:2181
       kafka:
-        image: bitnami/kafka:latest
+        image: darccio/kafka:latest  # temporary workaround for the missing wurstmeister image
         env:
           KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
           KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -166,7 +166,7 @@ jobs:
         ports:
           - 2181:2181
       kafka:
-        image: darccio/kafka:latest  # temporary workaround for the missing wurstmeister image
+        image: darccio/kafka::2.13-2.8.1  # temporary workaround for the missing wurstmeister image
         env:
           KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
           KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -166,7 +166,7 @@ jobs:
         ports:
           - 2181:2181
       kafka:
-        image: darccio/kafka::2.13-2.8.1  # temporary workaround for the missing wurstmeister image
+        image: darccio/kafka:2.13-2.8.1  # temporary workaround for the missing wurstmeister image
         env:
           KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
           KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -166,7 +166,7 @@ jobs:
         ports:
           - 2181:2181
       kafka:
-        image: wurstmeister/kafka:2.13-2.8.1
+        image: bitnami/kafka:latest
         env:
           KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
           KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092

--- a/ddtrace/tracer/remote_config_test.go
+++ b/ddtrace/tracer/remote_config_test.go
@@ -32,7 +32,9 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 
 		// Apply RC. Assert _dd.rule_psr shows the RC sampling rate (0.5) is applied
 		input := remoteconfig.ProductUpdate{
-			"path": []byte(`{"lib_config": {"tracing_sampling_rate": 0.5}, "service_target": {"service": "my-service", "env": "my-env"}}`),
+			"path": []byte(
+				`{"lib_config": {"tracing_sampling_rate": 0.5}, "service_target": {"service": "my-service", "env": "my-env"}}`,
+			),
 		}
 		applyStatus := tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
@@ -42,7 +44,11 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 
 		// Telemetry
 		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 1)
-		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_sample_rate", Value: 0.5, Origin: "remote_config"}})
+		telemetryClient.AssertCalled(
+			t,
+			"ConfigChange",
+			[]telemetry.Configuration{{Name: "trace_sample_rate", Value: 0.5, Origin: "remote_config"}},
+		)
 
 		//Apply RC with sampling rules. Assert _dd.rule_psr shows the corresponding rule matched rate.
 		input = remoteconfig.ProductUpdate{
@@ -71,7 +77,9 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		}
 
 		// Unset RC. Assert _dd.rule_psr is not set
-		input = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`)}
+		input = remoteconfig.ProductUpdate{
+			"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`),
+		}
 		applyStatus = tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
 		s = tracer.StartSpan("web.request").(*span)
@@ -94,7 +102,9 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 
 		// Apply RC. Assert _dd.rule_psr shows the RC sampling rate (0.2) is applied
 		input := remoteconfig.ProductUpdate{
-			"path": []byte(`{"lib_config": {"tracing_sampling_rate": 0.2}, "service_target": {"service": "my-service", "env": "my-env"}}`),
+			"path": []byte(
+				`{"lib_config": {"tracing_sampling_rate": 0.2}, "service_target": {"service": "my-service", "env": "my-env"}}`,
+			),
 		}
 		applyStatus := tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
@@ -104,10 +114,16 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 
 		// Telemetry
 		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 1)
-		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_sample_rate", Value: 0.2, Origin: "remote_config"}})
+		telemetryClient.AssertCalled(
+			t,
+			"ConfigChange",
+			[]telemetry.Configuration{{Name: "trace_sample_rate", Value: 0.2, Origin: "remote_config"}},
+		)
 
 		// Unset RC. Assert _dd.rule_psr shows the previous sampling rate (0.1) is applied
-		input = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`)}
+		input = remoteconfig.ProductUpdate{
+			"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`),
+		}
 		applyStatus = tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
 		s = tracer.StartSpan("web.request").(*span)
@@ -116,7 +132,11 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 
 		// Telemetry
 		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 2)
-		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_sample_rate", Value: 0.1, Origin: ""}})
+		telemetryClient.AssertCalled(
+			t,
+			"ConfigChange",
+			[]telemetry.Configuration{{Name: "trace_sample_rate", Value: 0.1, Origin: ""}},
+		)
 	})
 
 	t.Run("DD_TRACE_SAMPLING_RULES rate=0.1 and RC trace sampling rules rate = 1.0", func(t *testing.T) {
@@ -169,7 +189,11 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 1)
 		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{
 			{Name: "trace_sample_rate", Value: 0.5, Origin: "remote_config"},
-			{Name: "trace_sample_rules", Value: `[{"service":"my-service","name":"web.request","resource":"abc","sample_rate":1,"type":"1","provenance":"customer"}]`, Origin: "remote_config"}})
+			{
+				Name:   "trace_sample_rules",
+				Value:  `[{"service":"my-service","name":"web.request","resource":"abc","sample_rate":1,"provenance":"customer"}]`,
+				Origin: "remote_config",
+			}})
 	})
 
 	t.Run("DD_TRACE_SAMPLING_RULES=0.1 and RC rule rate=1.0 and revert", func(t *testing.T) {
@@ -221,7 +245,11 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		s.Finish()
 		require.Equal(t, 0.3, s.Metrics[keyRulesSamplerAppliedRate])
 		if p, ok := s.context.trace.samplingPriority(); ok && p > 0 {
-			require.Equal(t, samplerToDM(samplernames.RemoteDynamicRule), s.context.trace.propagatingTags[keyDecisionMaker])
+			require.Equal(
+				t,
+				samplerToDM(samplernames.RemoteDynamicRule),
+				s.context.trace.propagatingTags[keyDecisionMaker],
+			)
 		}
 
 		// Reset restores local rules
@@ -239,12 +267,15 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{
 			{Name: "trace_sample_rate", Value: 0.5, Origin: "remote_config"},
 			{Name: "trace_sample_rules",
-				Value: `[{"service":"my-service","name":"web.request","resource":"abc","sample_rate":1,"type":"1","provenance":"customer"} {"service":"my-service","name":"web.request","resource":"*","sample_rate":0.3,"type":"1","provenance":"dynamic"}]`, Origin: "remote_config"},
+				Value: `[{"service":"my-service","name":"web.request","resource":"abc","sample_rate":1,"provenance":"customer"} {"service":"my-service","name":"web.request","resource":"*","sample_rate":0.3,"provenance":"dynamic"}]`, Origin: "remote_config"},
 		})
 		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{
 			{Name: "trace_sample_rate", Value: nil, Origin: ""},
-			{Name: "trace_sample_rules", Value: `[{"service":"my-service","name":"web.request","resource":"*","sample_rate":0.1,"type":"1"}]`,
-				Origin: ""},
+			{
+				Name:   "trace_sample_rules",
+				Value:  `[{"service":"my-service","name":"web.request","resource":"*","sample_rate":0.1,"type":"1"}]`,
+				Origin: "",
+			},
 		})
 	})
 
@@ -279,14 +310,17 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		// A span with non-matching tags gets the global rate
 		s = tracer.StartSpan("web.request").(*span)
 		s.SetTag("tag-a", "not-matching")
-		s.Resource = "abc"
 		s.Finish()
 		require.Equal(t, 0.5, s.Metrics[keyRulesSamplerAppliedRate])
 
 		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 1)
 		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{
 			{Name: "trace_sample_rate", Value: 0.5, Origin: "remote_config"},
-			{Name: "trace_sample_rules", Value: `[{"service":"my-service","name":"web.request","resource":"*","sample_rate":1,"tags":{"tag-a":"tv-a??"},"type":"1","provenance":"customer"}]`, Origin: "remote_config"},
+			{
+				Name:   "trace_sample_rules",
+				Value:  `[{"service":"my-service","name":"web.request","resource":"*","sample_rate":1,"tags":{"tag-a":"tv-a??"},"provenance":"customer"}]`,
+				Origin: "remote_config",
+			},
 		})
 	})
 
@@ -300,7 +334,9 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 
 		// Apply RC. Assert global config shows the RC header tag is applied
 		input := remoteconfig.ProductUpdate{
-			"path": []byte(`{"lib_config": {"tracing_header_tags": [{"header": "X-Test-Header", "tag_name": "my-tag-name"}]}, "service_target": {"service": "my-service", "env": "my-env"}}`),
+			"path": []byte(
+				`{"lib_config": {"tracing_header_tags": [{"header": "X-Test-Header", "tag_name": "my-tag-name"}]}, "service_target": {"service": "my-service", "env": "my-env"}}`,
+			),
 		}
 		applyStatus := tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
@@ -308,17 +344,29 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.Equal(t, "my-tag-name", globalconfig.HeaderTag("X-Test-Header"))
 
 		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 1)
-		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name", Origin: "remote_config"}})
+		telemetryClient.AssertCalled(
+			t,
+			"ConfigChange",
+			[]telemetry.Configuration{
+				{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name", Origin: "remote_config"},
+			},
+		)
 
 		// Unset RC. Assert header tags are not set
-		input = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`)}
+		input = remoteconfig.ProductUpdate{
+			"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`),
+		}
 		applyStatus = tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
 		require.Equal(t, 0, globalconfig.HeaderTagsLen())
 
 		// Telemetry
 		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 2)
-		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: "", Origin: ""}})
+		telemetryClient.AssertCalled(
+			t,
+			"ConfigChange",
+			[]telemetry.Configuration{{Name: "trace_header_tags", Value: "", Origin: ""}},
+		)
 	})
 
 	t.Run("RC tracing_enabled = false is applied", func(t *testing.T) {
@@ -329,7 +377,9 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		defer Stop()
 
 		input := remoteconfig.ProductUpdate{
-			"path": []byte(`{"lib_config": {"tracing_enabled": false}, "service_target": {"service": "my-service", "env": "my-env"}}`),
+			"path": []byte(
+				`{"lib_config": {"tracing_enabled": false}, "service_target": {"service": "my-service", "env": "my-env"}}`,
+			),
 		}
 
 		tr, ok := internal.GetGlobalTracer().(*tracer)
@@ -362,7 +412,9 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 
 		// turning tracing back explicitly is not allowed
 		input = remoteconfig.ProductUpdate{
-			"path": []byte(`{"lib_config": {"tracing_enabled": true}, "service_target": {"service": "my-service", "env": "my-env"}}`),
+			"path": []byte(
+				`{"lib_config": {"tracing_enabled": true}, "service_target": {"service": "my-service", "env": "my-env"}}`,
+			),
 		}
 		applyStatus = tr.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
@@ -371,72 +423,115 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 1)
 	})
 
-	t.Run("DD_TRACE_HEADER_TAGS=X-Test-Header:my-tag-name-from-env and RC header tags = X-Test-Header:my-tag-name-from-rc", func(t *testing.T) {
-		defer globalconfig.ClearHeaderTags()
-		telemetryClient := new(telemetrytest.MockClient)
-		defer telemetry.MockGlobalClient(telemetryClient)()
+	t.Run(
+		"DD_TRACE_HEADER_TAGS=X-Test-Header:my-tag-name-from-env and RC header tags = X-Test-Header:my-tag-name-from-rc",
+		func(t *testing.T) {
+			defer globalconfig.ClearHeaderTags()
+			telemetryClient := new(telemetrytest.MockClient)
+			defer telemetry.MockGlobalClient(telemetryClient)()
 
-		t.Setenv("DD_TRACE_HEADER_TAGS", "X-Test-Header:my-tag-name-from-env")
-		tracer, _, _, stop := startTestTracer(t, WithService("my-service"), WithEnv("my-env"))
-		defer stop()
+			t.Setenv("DD_TRACE_HEADER_TAGS", "X-Test-Header:my-tag-name-from-env")
+			tracer, _, _, stop := startTestTracer(t, WithService("my-service"), WithEnv("my-env"))
+			defer stop()
 
-		// Apply RC. Assert global config shows the RC header tag is applied
-		input := remoteconfig.ProductUpdate{
-			"path": []byte(`{"lib_config": {"tracing_header_tags": [{"header": "X-Test-Header", "tag_name": "my-tag-name-from-rc"}]}, "service_target": {"service": "my-service", "env": "my-env"}}`),
-		}
-		applyStatus := tracer.onRemoteConfigUpdate(input)
-		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
-		require.Equal(t, 1, globalconfig.HeaderTagsLen())
-		require.Equal(t, "my-tag-name-from-rc", globalconfig.HeaderTag("X-Test-Header"))
+			// Apply RC. Assert global config shows the RC header tag is applied
+			input := remoteconfig.ProductUpdate{
+				"path": []byte(
+					`{"lib_config": {"tracing_header_tags": [{"header": "X-Test-Header", "tag_name": "my-tag-name-from-rc"}]}, "service_target": {"service": "my-service", "env": "my-env"}}`,
+				),
+			}
+			applyStatus := tracer.onRemoteConfigUpdate(input)
+			require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
+			require.Equal(t, 1, globalconfig.HeaderTagsLen())
+			require.Equal(t, "my-tag-name-from-rc", globalconfig.HeaderTag("X-Test-Header"))
 
-		// Telemetry
-		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 1)
-		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name-from-rc", Origin: "remote_config"}})
+			// Telemetry
+			telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 1)
+			telemetryClient.AssertCalled(
+				t,
+				"ConfigChange",
+				[]telemetry.Configuration{
+					{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name-from-rc", Origin: "remote_config"},
+				},
+			)
 
-		// Unset RC. Assert global config shows the DD_TRACE_HEADER_TAGS header tag
-		input = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`)}
-		applyStatus = tracer.onRemoteConfigUpdate(input)
-		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
-		require.Equal(t, 1, globalconfig.HeaderTagsLen())
-		require.Equal(t, "my-tag-name-from-env", globalconfig.HeaderTag("X-Test-Header"))
+			// Unset RC. Assert global config shows the DD_TRACE_HEADER_TAGS header tag
+			input = remoteconfig.ProductUpdate{
+				"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`),
+			}
+			applyStatus = tracer.onRemoteConfigUpdate(input)
+			require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
+			require.Equal(t, 1, globalconfig.HeaderTagsLen())
+			require.Equal(t, "my-tag-name-from-env", globalconfig.HeaderTag("X-Test-Header"))
 
-		// Telemetry
-		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 2)
-		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name-from-env", Origin: ""}})
-	})
+			// Telemetry
+			telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 2)
+			telemetryClient.AssertCalled(
+				t,
+				"ConfigChange",
+				[]telemetry.Configuration{
+					{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name-from-env", Origin: ""},
+				},
+			)
+		},
+	)
 
-	t.Run("In code header tags = X-Test-Header:my-tag-name-in-code and RC header tags = X-Test-Header:my-tag-name-from-rc", func(t *testing.T) {
-		defer globalconfig.ClearHeaderTags()
-		telemetryClient := new(telemetrytest.MockClient)
-		defer telemetry.MockGlobalClient(telemetryClient)()
+	t.Run(
+		"In code header tags = X-Test-Header:my-tag-name-in-code and RC header tags = X-Test-Header:my-tag-name-from-rc",
+		func(t *testing.T) {
+			defer globalconfig.ClearHeaderTags()
+			telemetryClient := new(telemetrytest.MockClient)
+			defer telemetry.MockGlobalClient(telemetryClient)()
 
-		tracer, _, _, stop := startTestTracer(t, WithService("my-service"), WithEnv("my-env"), WithHeaderTags([]string{"X-Test-Header:my-tag-name-in-code"}))
-		defer stop()
+			tracer, _, _, stop := startTestTracer(
+				t,
+				WithService("my-service"),
+				WithEnv("my-env"),
+				WithHeaderTags([]string{"X-Test-Header:my-tag-name-in-code"}),
+			)
+			defer stop()
 
-		// Apply RC. Assert global config shows the RC header tag is applied
-		input := remoteconfig.ProductUpdate{
-			"path": []byte(`{"lib_config": {"tracing_header_tags": [{"header": "X-Test-Header", "tag_name": "my-tag-name-from-rc"}]}, "service_target": {"service": "my-service", "env": "my-env"}}`),
-		}
-		applyStatus := tracer.onRemoteConfigUpdate(input)
-		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
-		require.Equal(t, 1, globalconfig.HeaderTagsLen())
-		require.Equal(t, "my-tag-name-from-rc", globalconfig.HeaderTag("X-Test-Header"))
+			// Apply RC. Assert global config shows the RC header tag is applied
+			input := remoteconfig.ProductUpdate{
+				"path": []byte(
+					`{"lib_config": {"tracing_header_tags": [{"header": "X-Test-Header", "tag_name": "my-tag-name-from-rc"}]}, "service_target": {"service": "my-service", "env": "my-env"}}`,
+				),
+			}
+			applyStatus := tracer.onRemoteConfigUpdate(input)
+			require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
+			require.Equal(t, 1, globalconfig.HeaderTagsLen())
+			require.Equal(t, "my-tag-name-from-rc", globalconfig.HeaderTag("X-Test-Header"))
 
-		// Telemetry
-		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 1)
-		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name-from-rc", Origin: "remote_config"}})
+			// Telemetry
+			telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 1)
+			telemetryClient.AssertCalled(
+				t,
+				"ConfigChange",
+				[]telemetry.Configuration{
+					{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name-from-rc", Origin: "remote_config"},
+				},
+			)
 
-		// Unset RC. Assert global config shows the in-code header tag
-		input = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`)}
-		applyStatus = tracer.onRemoteConfigUpdate(input)
-		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
-		require.Equal(t, 1, globalconfig.HeaderTagsLen())
-		require.Equal(t, "my-tag-name-in-code", globalconfig.HeaderTag("X-Test-Header"))
+			// Unset RC. Assert global config shows the in-code header tag
+			input = remoteconfig.ProductUpdate{
+				"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`),
+			}
+			applyStatus = tracer.onRemoteConfigUpdate(input)
+			require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
+			require.Equal(t, 1, globalconfig.HeaderTagsLen())
+			require.Equal(t, "my-tag-name-in-code", globalconfig.HeaderTag("X-Test-Header"))
 
-		// Telemetry
-		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 2)
-		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name-in-code", Origin: ""}})
-	})
+			// Telemetry
+			telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 2)
+			telemetryClient.AssertCalled(
+				t,
+				"ConfigChange",
+				[]telemetry.Configuration{
+					{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name-in-code", Origin: ""},
+				},
+			)
+		},
+	)
 
 	t.Run("Invalid payload", func(t *testing.T) {
 		telemetryClient := new(telemetrytest.MockClient)
@@ -446,7 +541,9 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		defer stop()
 
 		input := remoteconfig.ProductUpdate{
-			"path": []byte(`{"lib_config": {"tracing_sampling_rate": "string value", "service_target": {"service": "my-service", "env": "my-env"}}}`),
+			"path": []byte(
+				`{"lib_config": {"tracing_sampling_rate": "string value", "service_target": {"service": "my-service", "env": "my-env"}}}`,
+			),
 		}
 		applyStatus := tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateError, applyStatus["path"].State)
@@ -497,12 +594,19 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		defer telemetry.MockGlobalClient(telemetryClient)()
 
 		t.Setenv("DD_TAGS", "key0:val0,key1:val1")
-		tracer, _, _, stop := startTestTracer(t, WithService("my-service"), WithEnv("my-env"), WithGlobalTag("key2", "val2"))
+		tracer, _, _, stop := startTestTracer(
+			t,
+			WithService("my-service"),
+			WithEnv("my-env"),
+			WithGlobalTag("key2", "val2"),
+		)
 		defer stop()
 
 		// Apply RC. Assert global tags have the RC tags key3:val3,key4:val4 applied + runtime ID
 		input := remoteconfig.ProductUpdate{
-			"path": []byte(`{"lib_config": {"tracing_tags": ["key3:val3","key4:val4"]}, "service_target": {"service": "my-service", "env": "my-env"}}`),
+			"path": []byte(
+				`{"lib_config": {"tracing_tags": ["key3:val3","key4:val4"]}, "service_target": {"service": "my-service", "env": "my-env"}}`,
+			),
 		}
 		applyStatus := tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
@@ -518,10 +622,18 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 
 		// Telemetry
 		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 1)
-		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_tags", Value: "key3:val3,key4:val4," + runtimeIDTag, Origin: "remote_config"}})
+		telemetryClient.AssertCalled(
+			t,
+			"ConfigChange",
+			[]telemetry.Configuration{
+				{Name: "trace_tags", Value: "key3:val3,key4:val4," + runtimeIDTag, Origin: "remote_config"},
+			},
+		)
 
 		// Unset RC. Assert config shows the original DD_TAGS + WithGlobalTag + runtime ID
-		input = remoteconfig.ProductUpdate{"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`)}
+		input = remoteconfig.ProductUpdate{
+			"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "my-env"}}`),
+		}
 		applyStatus = tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
 		s = tracer.StartSpan("web.request").(*span)
@@ -535,7 +647,13 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 
 		// Telemetry
 		telemetryClient.AssertNumberOfCalls(t, "ConfigChange", 2)
-		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{{Name: "trace_tags", Value: "key0:val0,key1:val1,key2:val2," + runtimeIDTag, Origin: ""}})
+		telemetryClient.AssertCalled(
+			t,
+			"ConfigChange",
+			[]telemetry.Configuration{
+				{Name: "trace_tags", Value: "key0:val0,key1:val1,key2:val2," + runtimeIDTag, Origin: ""},
+			},
+		)
 	})
 
 	t.Run("Deleted config", func(t *testing.T) {
@@ -551,7 +669,9 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 
 		// Apply RC. Assert configuration is updated to the RC values.
 		input := remoteconfig.ProductUpdate{
-			"path": []byte(`{"lib_config": {"tracing_sampling_rate": 0.2,"tracing_header_tags": [{"header": "X-Test-Header", "tag_name": "my-tag-from-rc"}],"tracing_tags": ["ddtag:from-rc"]}, "service_target": {"service": "my-service", "env": "my-env"}}`),
+			"path": []byte(
+				`{"lib_config": {"tracing_sampling_rate": 0.2,"tracing_header_tags": [{"header": "X-Test-Header", "tag_name": "my-tag-from-rc"}],"tracing_tags": ["ddtag:from-rc"]}, "service_target": {"service": "my-service", "env": "my-env"}}`,
+			),
 		}
 		applyStatus := tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
@@ -566,7 +686,11 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		telemetryClient.AssertCalled(t, "ConfigChange", []telemetry.Configuration{
 			{Name: "trace_sample_rate", Value: 0.2, Origin: "remote_config"},
 			{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-from-rc", Origin: "remote_config"},
-			{Name: "trace_tags", Value: "ddtag:from-rc," + ext.RuntimeID + ":" + globalconfig.RuntimeID(), Origin: "remote_config"},
+			{
+				Name:   "trace_tags",
+				Value:  "ddtag:from-rc," + ext.RuntimeID + ":" + globalconfig.RuntimeID(),
+				Origin: "remote_config",
+			},
 		})
 
 		// Remove RC. Assert configuration is reset to the original values.

--- a/ddtrace/tracer/rules_sampler.go
+++ b/ddtrace/tracer/rules_sampler.go
@@ -271,6 +271,17 @@ func NameServiceRule(name string, service string, rate float64) SamplingRule {
 	}
 }
 
+func NameServiceResourceRule(name, service, resource string, rate float64) SamplingRule {
+	return SamplingRule{
+		Service:  globMatch(service),
+		Name:     globMatch(name),
+		Resource: globMatch(resource),
+		Rate:     rate,
+		ruleType: SamplingRuleTrace,
+		globRule: &jsonRule{Name: name, Service: service, Resource: resource},
+	}
+}
+
 // RateRule returns a SamplingRule that applies the provided sampling rate to all spans.
 func RateRule(rate float64) SamplingRule {
 	return SamplingRule{

--- a/ddtrace/tracer/rules_sampler.go
+++ b/ddtrace/tracer/rules_sampler.go
@@ -271,17 +271,6 @@ func NameServiceRule(name string, service string, rate float64) SamplingRule {
 	}
 }
 
-func NameServiceResourceRule(name, service, resource string, rate float64) SamplingRule {
-	return SamplingRule{
-		Service:  globMatch(service),
-		Name:     globMatch(name),
-		Resource: globMatch(resource),
-		Rate:     rate,
-		ruleType: SamplingRuleTrace,
-		globRule: &jsonRule{Name: name, Service: service, Resource: resource},
-	}
-}
-
 // RateRule returns a SamplingRule that applies the provided sampling rate to all spans.
 func RateRule(rate float64) SamplingRule {
 	return SamplingRule{
@@ -846,7 +835,10 @@ func validateRules(jsonRules []jsonRule, spanType SamplingRuleType) ([]SamplingR
 			continue
 		}
 		if rate < 0.0 || rate > 1.0 {
-			errs = append(errs, fmt.Sprintf("at index %d: ignoring rule %s: rate is out of [0.0, 1.0] range", i, v.String()))
+			errs = append(
+				errs,
+				fmt.Sprintf("at index %d: ignoring rule %s: rate is out of [0.0, 1.0] range", i, v.String()),
+			)
 			continue
 		}
 		tagGlobs := make(map[string]*regexp.Regexp, len(v.Tags))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Supporting sampling rules with tags matching from remote config.

A companion system test is added in https://github.com/DataDog/system-tests/pull/2409

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [X] Changed code has unit tests for its functionality at or near 100% coverage.
- [X] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [X] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
