### PR TITLE
version: v1.65.0-dev

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -13,7 +13,7 @@ import (
 // Tag specifies the current release tag. It needs to be manually
 // updated. A test checks that the value of Tag never points to a
 // git tag that is older than HEAD.
-const Tag = "v1.64.0-dev"
+const Tag = "v1.65.0-dev"
 
 // Dissected version number. Filled during init()
 var (


### PR DESCRIPTION
Bump the development version tag now that the v1.64.0 release process has started.
