### PR TITLE
feat(contrib/net/http): add option to wrap a provided *http.ServeMux

### DIFF
--- a/contrib/net/http/example_test.go
+++ b/contrib/net/http/example_test.go
@@ -6,6 +6,7 @@
 package http_test
 
 import (
+	"log"
 	"net/http"
 	"net/http/httptest"
 
@@ -34,6 +35,33 @@ func Example_withServiceName() {
 		w.Write([]byte("Hello World!\n"))
 	})
 	http.ListenAndServe(":8080", mux)
+}
+
+// Example_withServeMux shows how to make the traced ServeMux the outermost handler in a
+// chain of wrapped handlers, by having it wrap a *http.ServeMux that was already configured
+// elsewhere (here, with its own logging middleware). Since the traced mux runs first, it has
+// already added trace context to the request by the time logMiddleware runs, so the logger
+// can include dd.trace_id and dd.span_id.
+func Example_withServeMux() {
+	tracer.Start()
+	defer tracer.Stop()
+
+	appMux := http.NewServeMux()
+	appMux.Handle("/", logMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("Hello World!\n"))
+	})))
+
+	mux := httptrace.NewServeMux(httptrace.WithServeMux(appMux))
+	http.ListenAndServe(":8080", mux)
+}
+
+func logMiddleware(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if span, ok := tracer.SpanFromContext(r.Context()); ok {
+			log.Printf("dd.trace_id=%s dd.span_id=%d", span.Context().TraceID(), span.Context().SpanID())
+		}
+		h.ServeHTTP(w, r)
+	})
 }
 
 func ExampleTraceAndServe() {

--- a/contrib/net/http/http_test.go
+++ b/contrib/net/http/http_test.go
@@ -335,6 +335,40 @@ func TestServeMuxGo122Patterns(t *testing.T) {
 	assert.Equal("GET /foo", fooSpan.Tag(ext.ResourceName))
 }
 
+func TestWithServeMux(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	assert := assert.New(t)
+
+	underlying := http.NewServeMux()
+	mux := NewServeMux(WithServeMux(underlying))
+	mux.HandleFunc("/200", handler200)
+
+	// registering routes on the traced mux also registers them on the
+	// underlying mux, since it wraps it rather than replacing it
+	assert.Same(underlying, mux.ServeMux)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/200", nil)
+	mux.ServeHTTP(w, r)
+
+	assert.Equal(200, w.Code)
+	assert.Equal("OK\n", w.Body.String())
+
+	spans := mt.FinishedSpans()
+	assert.Equal(1, len(spans))
+	s := spans[0]
+	assert.Equal("GET /200", s.Tag(ext.ResourceName))
+	assert.Equal(ext.SpanKindServer, s.Tag(ext.SpanKind))
+	assert.Equal("net/http", s.Tag(ext.Component))
+
+	// the underlying mux itself dispatches to the same handler
+	underlyingW := httptest.NewRecorder()
+	underlying.ServeHTTP(underlyingW, httptest.NewRequest("GET", "/200", nil))
+	assert.Equal(200, underlyingW.Code)
+	assert.Equal("OK\n", underlyingW.Body.String())
+}
+
 func TestWrapHandlerWithResourceNameNoRace(_ *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()

--- a/contrib/net/http/http_test.go
+++ b/contrib/net/http/http_test.go
@@ -369,6 +369,34 @@ func TestWithServeMux(t *testing.T) {
 	assert.Equal("OK\n", underlyingW.Body.String())
 }
 
+// TestWithServeMuxPreConfigured covers the motivating use case from the PR: wrapping a
+// *http.ServeMux that already has routes registered on it, rather than registering routes
+// through the traced wrapper. Requests to those routes must still be traced.
+func TestWithServeMuxPreConfigured(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	assert := assert.New(t)
+
+	underlying := http.NewServeMux()
+	underlying.HandleFunc("/200", handler200)
+
+	mux := NewServeMux(WithServeMux(underlying))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/200", nil)
+	mux.ServeHTTP(w, r)
+
+	assert.Equal(200, w.Code)
+	assert.Equal("OK\n", w.Body.String())
+
+	spans := mt.FinishedSpans()
+	assert.Equal(1, len(spans))
+	s := spans[0]
+	assert.Equal("GET /200", s.Tag(ext.ResourceName))
+	assert.Equal(ext.SpanKindServer, s.Tag(ext.SpanKind))
+	assert.Equal("net/http", s.Tag(ext.Component))
+}
+
 func TestWrapHandlerWithResourceNameNoRace(_ *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()

--- a/contrib/net/http/internal/config/config.go
+++ b/contrib/net/http/internal/config/config.go
@@ -53,6 +53,10 @@ type Config struct {
 	CommonConfig
 	FinishOpts []tracer.FinishOption
 	HeaderTags instrumentation.HeaderTags
+	// Mux, if set, is used as the underlying *http.ServeMux instead of
+	// allocating a new one, so the traced ServeMux can wrap a mux that
+	// was already configured elsewhere.
+	Mux *http.ServeMux
 }
 
 func (c *Config) ApplyOpts(opts ...Option) {

--- a/contrib/net/http/internal/wrap/mux.go
+++ b/contrib/net/http/internal/wrap/mux.go
@@ -37,6 +37,14 @@ func NewServeMux(opts ...internal.Option) *ServeMux {
 	mux := cfg.Mux
 	if mux == nil {
 		mux = http.NewServeMux()
+	} else if internal.Instrumentation.AppSecEnabled() {
+		// Routes registered directly on a caller-provided *http.ServeMux (e.g. before it
+		// was passed to WithServeMux) never go through this package's Handle/HandleFunc,
+		// so they never call httpsec.RouteMatched: the WAF never sees the resolved path
+		// parameters for those routes, and can't block on rules that key off of them.
+		instr.Logger().Warn("contrib/net/http: WithServeMux was used while AppSec is enabled; " +
+			"path-parameter WAF rules only apply to routes registered via ServeMux.Handle or " +
+			"ServeMux.HandleFunc, not to routes already registered on the wrapped *http.ServeMux")
 	}
 
 	return &ServeMux{

--- a/contrib/net/http/internal/wrap/mux.go
+++ b/contrib/net/http/internal/wrap/mux.go
@@ -32,8 +32,15 @@ func NewServeMux(opts ...internal.Option) *ServeMux {
 	cfg.SpanOpts = append(cfg.SpanOpts, tracer.Tag(ext.SpanKind, ext.SpanKindServer))
 	cfg.SpanOpts = append(cfg.SpanOpts, tracer.Tag(ext.Component, internal.ComponentName))
 	instr.Logger().Debug("contrib/net/http: Configuring ServeMux: %#v", cfg)
+
+	// wrap the provided ServeMux, if any, otherwise create a new one
+	mux := cfg.Mux
+	if mux == nil {
+		mux = http.NewServeMux()
+	}
+
 	return &ServeMux{
-		ServeMux: http.NewServeMux(),
+		ServeMux: mux,
 		cfg:      cfg,
 	}
 }

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -32,6 +32,7 @@ type HandlerOptionFn = internal.HandlerOptionFn
 // of allocating a new one. This is useful when the traced ServeMux needs to wrap
 // a ServeMux that was already configured elsewhere, or when it needs to be the
 // outermost handler in a chain of wrapped handlers.
+// This option only affects NewServeMux; it has no effect when passed to WrapHandler.
 func WithServeMux(mux *http.ServeMux) HandlerOptionFn {
 	return func(cfg *internal.Config) {
 		cfg.Mux = mux

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -28,6 +28,16 @@ type OptionFn = internal.OptionFn
 // HandlerOptionFn represents options applicable to NewServeMux and WrapHandler.
 type HandlerOptionFn = internal.HandlerOptionFn
 
+// WithServeMux sets the given *http.ServeMux as the underlying ServeMux instead
+// of allocating a new one. This is useful when the traced ServeMux needs to wrap
+// a ServeMux that was already configured elsewhere, or when it needs to be the
+// outermost handler in a chain of wrapped handlers.
+func WithServeMux(mux *http.ServeMux) HandlerOptionFn {
+	return func(cfg *internal.Config) {
+		cfg.Mux = mux
+	}
+}
+
 // WithIgnoreRequest holds the function to use for determining if the
 // incoming HTTP request should not be traced.
 func WithIgnoreRequest(f func(*http.Request) bool) OptionFn {


### PR DESCRIPTION
There are many cases where the traced serve mux should be the 'outer' most http handler in a chain of wrapped handlers. For example, if one wanted to write a middleware which logged all requests by wrapping a http.Handler and they wanted this logger to log dd.trace_id and dd.span_id, that logger would have to execute after the traced http.Handler. One could achieve this using the
contrib/net/http#WrapHandler function, but this loses the nice capability of naming the resource using the http.ServeMux#Handler method because the resourceNamer config does not have access to the mux itself.

Another approach, would be to have the contrib/net/http.ServeMux take another ServeMux as an option, and use that as its mux if provided. This way, the first 'handler' in a chain of request handlers would be the contrib/net/http.ServeMux. This traced mux would add trace context to the http request. This traced request would then be passed to the e.g. logging middleare mux, and so on, and so forth.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
