### PR TITLE
CODEOWNERS: remove IDM as owner of /ddtrace path

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,7 +12,7 @@ go.sum
 
 # tracing
 /contrib                        @DataDog/apm-go @Datadog/apm-idm-go
-/ddtrace                        @DataDog/apm-go @Datadog/apm-idm-go
+/ddtrace                        @DataDog/apm-go
 
 # profiling
 /profiler                       @DataDog/profiling-go


### PR DESCRIPTION
### What does this PR do?

Removes IDM as owner of `/ddtrace`.

### Motivation

IDM focuses on contribs, while `/ddtrace` is under `apm-go` scope.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
