### PR TITLE
internal: stacktrace: skip internal packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/confluentinc/confluent-kafka-go/v2 v2.2.0
 	github.com/denisenkom/go-mssqldb v0.11.0
 	github.com/dimfeld/httptreemux/v5 v5.5.0
+	github.com/eapache/queue/v2 v2.0.0-20230407133247-75960ed334e4
 	github.com/elastic/go-elasticsearch/v6 v6.8.5
 	github.com/elastic/go-elasticsearch/v7 v7.17.1
 	github.com/elastic/go-elasticsearch/v8 v8.4.0

--- a/go.sum
+++ b/go.sum
@@ -1062,6 +1062,8 @@ github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3 h1:Oy0F4A
 github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3/go.mod h1:YvSRo5mw33fLEx1+DlK6L2VV43tJt5Eyel9n9XBcR+0=
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
+github.com/eapache/queue/v2 v2.0.0-20230407133247-75960ed334e4 h1:8EXxF+tCLqaVk8AOC29zl2mnhQjwyLxxOTuhUazWRsg=
+github.com/eapache/queue/v2 v2.0.0-20230407133247-75960ed334e4/go.mod h1:I5sHm0Y0T1u5YjlyqC5GVArM7aNZRUYtTjmJ8mPJFds=
 github.com/ebitengine/purego v0.6.0-alpha.5 h1:EYID3JOAdmQ4SNZYJHu9V6IqOeRQDBYxqKAg9PyoHFY=
 github.com/ebitengine/purego v0.6.0-alpha.5/go.mod h1:ah1In8AOtksoNK6yk5z1HTJeUkC1Ez4Wk2idgGslMwQ=
 github.com/elastic/elastic-transport-go/v8 v8.1.0 h1:NeqEz1ty4RQz+TVbUrpSU7pZ48XkzGWQj02k5koahIE=

--- a/internal/stacktrace/event_test.go
+++ b/internal/stacktrace/event_test.go
@@ -20,8 +20,7 @@ func TestNewEvent(t *testing.T) {
 	require.Equal(t, ExceptionEvent, event.Category)
 	require.Equal(t, "go", event.Language)
 	require.Equal(t, "message", event.Message)
-	require.GreaterOrEqual(t, len(event.Frames), 3)
-	require.Equal(t, "TestNewEvent", event.Frames[0].Function)
+	require.GreaterOrEqual(t, len(event.Frames), 2)
 }
 
 func TestEventToSpan(t *testing.T) {

--- a/internal/stacktrace/event_test.go
+++ b/internal/stacktrace/event_test.go
@@ -16,10 +16,12 @@ import (
 )
 
 func TestNewEvent(t *testing.T) {
-	event := NewEvent(ExceptionEvent, "", "message")
+	event := NewEvent(ExceptionEvent, WithMessage("message"), WithType("type"), WithID("id"))
 	require.Equal(t, ExceptionEvent, event.Category)
 	require.Equal(t, "go", event.Language)
 	require.Equal(t, "message", event.Message)
+	require.Equal(t, "type", event.Type)
+	require.Equal(t, "id", event.ID)
 	require.GreaterOrEqual(t, len(event.Frames), 2)
 }
 
@@ -28,7 +30,7 @@ func TestEventToSpan(t *testing.T) {
 	defer mt.Stop()
 
 	span := ddtracer.StartSpan("op")
-	event := NewEvent(ExceptionEvent, "", "message")
+	event := NewEvent(ExceptionEvent, WithMessage("message"))
 	AddToSpan(span, event)
 	span.Finish()
 

--- a/internal/stacktrace/stacktrace_test.go
+++ b/internal/stacktrace/stacktrace_test.go
@@ -137,10 +137,15 @@ func TestParseSymbol(t *testing.T) {
 			"*Test",
 			"Method",
 		}},
-		{"main-receiver-templated", "test.(*toto).templatedFunc[...]", symbol{
+		{"main-receiver-templated-func", "test.(*toto).templatedFunc[...]", symbol{
 			"test",
 			"*toto",
 			"templatedFunc[...]",
+		}},
+		{"main-templated-receiver", "test.(*toto[...]).func", symbol{
+			"test",
+			"*toto[...]",
+			"func",
 		}},
 		{"main-lambda", "test.main.func1", symbol{
 			"test",

--- a/internal/stacktrace/stacktrace_test.go
+++ b/internal/stacktrace/stacktrace_test.go
@@ -7,13 +7,14 @@ package stacktrace
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewStackTrace(t *testing.T) {
-	stack := Capture()
+	stack := skipAndCapture(defaultCallerSkip, defaultMaxDepth, nil)
 	if len(stack) == 0 {
 		t.Error("stacktrace should not be empty")
 	}
@@ -21,7 +22,7 @@ func TestNewStackTrace(t *testing.T) {
 
 func TestStackTraceCurrentFrame(t *testing.T) {
 	// Check last frame for the values of the current function
-	stack := Capture()
+	stack := skipAndCapture(defaultCallerSkip, defaultMaxDepth, nil)
 	require.GreaterOrEqual(t, len(stack), 3)
 
 	frame := stack[0]
@@ -35,7 +36,7 @@ func TestStackTraceCurrentFrame(t *testing.T) {
 type Test struct{}
 
 func (t *Test) Method() StackTrace {
-	return Capture()
+	return skipAndCapture(defaultCallerSkip, defaultMaxDepth, nil)
 }
 
 func TestStackMethodReceiver(t *testing.T) {
@@ -53,7 +54,7 @@ func TestStackMethodReceiver(t *testing.T) {
 
 func recursive(i int) StackTrace {
 	if i == 0 {
-		return Capture()
+		return skipAndCapture(defaultCallerSkip, defaultMaxDepth, nil)
 	}
 
 	return recursive(i - 1)
@@ -153,15 +154,15 @@ func TestParseSymbol(t *testing.T) {
 	}
 }
 
-func recursiveBench(i int, b *testing.B) StackTrace {
+func recursiveBench(i int, depth int, b *testing.B) StackTrace {
 	if i == 0 {
 		b.StartTimer()
-		stack := Capture()
+		stack := skipAndCapture(defaultCallerSkip, depth*2, nil)
 		b.StopTimer()
 		return stack
 	}
 
-	return recursiveBench(i-1, b)
+	return recursiveBench(i-1, depth, b)
 }
 
 func BenchmarkCaptureStackTrace(b *testing.B) {
@@ -169,7 +170,7 @@ func BenchmarkCaptureStackTrace(b *testing.B) {
 		b.Run(fmt.Sprintf("%v", depth), func(b *testing.B) {
 			defaultMaxDepth = depth * 2 // Making sure we are capturing the full stack
 			for n := 0; n < b.N; n++ {
-				runtime.KeepAlive(recursiveBench(depth, b))
+				runtime.KeepAlive(recursiveBench(depth, depth, b))
 			}
 		})
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR refactors the `internal/stacktrace` package to skip modules managed by the tracer to provide a cleaner stacktrace to users.

### Motivation

The default stack size is 32 and is bloated with internal code that the user does not care about

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
