### PR TITLE
ci: use correct path for Windows datadog-ci release

### DIFF
--- a/.github/actions/dd-ci-upload/action.yml
+++ b/.github/actions/dd-ci-upload/action.yml
@@ -20,7 +20,7 @@ runs:
   steps:
     - if: runner.os == 'Windows'
       shell: bash
-      run: echo "DD_CI_CLI_BUILD=win-x64.exe" >> $GITHUB_ENV
+      run: echo "DD_CI_CLI_BUILD=win-x64" >> $GITHUB_ENV
     - if: runner.os == 'macOS'
       shell: bash
       run: echo "DD_CI_CLI_BUILD=darwin-x64" >> $GITHUB_ENV


### PR DESCRIPTION
The datadog-ci Windows release is now just 'datadog-ci_win-x64', without the '.exe' extension at the end. This means our CI no longer works for Windows on main.

Here's a failure, before this PR: https://github.com/DataDog/dd-trace-go/actions/runs/9162301098/job/25190768068#step:7:34. We can see right above the failure that fetching from the cache failed. We're already well over our cache limit so things are being bumped from the cache:

<img width="513" alt="Screenshot 2024-05-20 at 15 03 23" src="https://github.com/DataDog/dd-trace-go/assets/97066770/64292b75-32c4-4834-9a21-916393e93a63">

Here's a Windows CI run showing the "Upload Results to Datadog CI App" stage working with the change in this PR: https://github.com/DataDog/dd-trace-go/actions/runs/9163305530/job/25192097278
