### PR TITLE
profiler: remove TestTryUpload

### DIFF
--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -25,9 +25,11 @@ import (
 	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/httpmem"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/traceprof"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/version"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -381,6 +383,11 @@ func TestAllUploaded(t *testing.T) {
 		assert.ElementsMatch(t, customLabelKeys[:customProfileLabelLimit], profile.event.CustomAttributes)
 
 		assert.Contains(t, profile.tags, fmt.Sprintf("profile_seq:%d", seq))
+
+		assert.Equal(t, profile.event.Version, "4")
+		assert.Equal(t, profile.event.Family, "go")
+		assert.NotNil(t, profile.event.Start)
+		assert.NotNil(t, profile.event.End)
 	}
 
 	validateProfile(<-profiles, 0)
@@ -402,6 +409,14 @@ func TestCorrectTags(t *testing.T) {
 		"foo:bar",
 		"service:xyz",
 		"host:example",
+		"runtime:go",
+		fmt.Sprintf("process_id:%d", os.Getpid()),
+		fmt.Sprintf("profiler_version:%s", version.Tag),
+		fmt.Sprintf("runtime_version:%s", strings.TrimPrefix(runtime.Version(), "go")),
+		fmt.Sprintf("runtime_compiler:%s", runtime.Compiler),
+		fmt.Sprintf("runtime_arch:%s", runtime.GOARCH),
+		fmt.Sprintf("runtime_os:%s", runtime.GOOS),
+		fmt.Sprintf("runtime-id:%s", globalconfig.RuntimeID()),
 	}
 	for i := 0; i < 20; i++ {
 		// We check the tags we get several times to try to have a

--- a/profiler/upload_test.go
+++ b/profiler/upload_test.go
@@ -6,19 +6,14 @@
 package profiler
 
 import (
-	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 
 	maininternal "gopkg.in/DataDog/dd-trace-go.v1/internal"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/version"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,57 +34,6 @@ var testBatch = batch{
 			data: []byte("my-heap-profile"),
 		},
 	},
-}
-
-func TestTryUpload(t *testing.T) {
-	// Force an empty containerid and entityID on this test.
-	defer func(cid, eid string) { containerID = cid; entityID = eid }(containerID, entityID)
-	containerID = ""
-	entityID = ""
-
-	profiles := make(chan profileMeta, 1)
-	server := httptest.NewServer(&mockBackend{t: t, profiles: profiles})
-	defer server.Close()
-	p, err := unstartedProfiler(
-		WithAgentAddr(server.Listener.Addr().String()),
-		WithService("my-service"),
-		WithEnv("my-env"),
-		WithTags("tag1:1", "tag2:2"),
-	)
-	require.NoError(t, err)
-	err = p.doRequest(testBatch)
-	require.NoError(t, err)
-	profile := <-profiles
-
-	assert := assert.New(t)
-	assert.Empty(profile.headers.Get("Datadog-Container-ID"))
-	assert.Empty(profile.headers.Get("Datadog-Entity-ID"))
-	assert.Subset(profile.tags, []string{
-		"host:my-host",
-		"runtime:go",
-		"service:my-service",
-		"env:my-env",
-		"profile_seq:23",
-		"tag1:1",
-		"tag2:2",
-		fmt.Sprintf("process_id:%d", os.Getpid()),
-		fmt.Sprintf("profiler_version:%s", version.Tag),
-		fmt.Sprintf("runtime_version:%s", strings.TrimPrefix(runtime.Version(), "go")),
-		fmt.Sprintf("runtime_compiler:%s", runtime.Compiler),
-		fmt.Sprintf("runtime_arch:%s", runtime.GOARCH),
-		fmt.Sprintf("runtime_os:%s", runtime.GOOS),
-		fmt.Sprintf("runtime-id:%s", globalconfig.RuntimeID()),
-	})
-	assert.Equal(profile.event.Version, "4")
-	assert.Equal(profile.event.Family, "go")
-	assert.NotNil(profile.event.Start)
-	assert.NotNil(profile.event.End)
-	for k, v := range map[string][]byte{
-		"cpu.pprof":  []byte("my-cpu-profile"),
-		"heap.pprof": []byte("my-heap-profile"),
-	} {
-		assert.Equal(v, profile.attachments[k])
-	}
 }
 
 func TestTryUploadUDS(t *testing.T) {
@@ -155,35 +99,24 @@ func TestOldAgent(t *testing.T) {
 	assert.Equal(t, errOldAgent, err)
 }
 
-func TestContainerIDHeader(t *testing.T) {
-	// Force a non-empty containerid on this test.
-	defer func(cid string) { containerID = cid }(containerID)
-	containerID = "fakeContainerID"
-
-	profile := doOneShortProfileUpload(t)
-	assert.Equal(t, containerID, profile.headers.Get("Datadog-Container-Id"))
-}
-
-func TestEntityIDHeader(t *testing.T) {
-	// Force a non-empty entityID on this test.
-	defer func(eid string) { entityID = eid }(entityID)
-	entityID = "fakeEntityID"
-
-	profiles := make(chan profileMeta, 1)
-	server := httptest.NewServer(&mockBackend{t: t, profiles: profiles})
-	defer server.Close()
-	p, err := unstartedProfiler(
-		WithAgentAddr(server.Listener.Addr().String()),
-		WithService("my-service"),
-		WithEnv("my-env"),
-		WithTags("tag1:1", "tag2:2"),
-	)
-	require.NoError(t, err)
-	err = p.doRequest(testBatch)
-	require.NoError(t, err)
-
-	profile := <-profiles
-	assert.Equal(t, entityID, profile.headers.Get("Datadog-Entity-Id"))
+func TestEntityContainerIDHeaders(t *testing.T) {
+	t.Run("set", func(t *testing.T) {
+		defer func(cid, eid string) { containerID = cid; entityID = eid }(containerID, entityID)
+		entityID = "fakeEntityID"
+		containerID = "fakeContainerID"
+		profile := doOneShortProfileUpload(t)
+		assert.Equal(t, containerID, profile.headers.Get("Datadog-Container-Id"))
+		assert.Equal(t, entityID, profile.headers.Get("Datadog-Entity-Id"))
+	})
+	t.Run("unset", func(t *testing.T) {
+		// Force an empty containerid and entityID on this test.
+		defer func(cid, eid string) { containerID = cid; entityID = eid }(containerID, entityID)
+		entityID = ""
+		containerID = ""
+		profile := doOneShortProfileUpload(t)
+		assert.Empty(t, profile.headers.Get("Datadog-Container-ID"))
+		assert.Empty(t, profile.headers.Get("Datadog-Entity-ID"))
+	})
 }
 
 func TestGitMetadata(t *testing.T) {


### PR DESCRIPTION
This is yet another test that hooks into internal implementation details
of the profiler. It's been mostly superseded by TestAllUploaded. The
bits that are unique to this test (asserting some of the default tags
and a few details of the event payload) can be folded into tests that
aren't (as) dependent on implementation details.
