### PR TITLE
appsec: support for SSRF Exploit Prevention

### DIFF
--- a/appsec/events/block.go
+++ b/appsec/events/block.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022 Datadog, Inc.
+
+// Package events provides the types and interfaces for the appsec event system.
+// User-facing events can be returned by the appsec package to signal that a request was blocked.
+// Handling these events differently than other errors is crucial to not leak information to an attacker.
+package events
+
+var _ error = (*SecurityBlockingEvent)(nil)
+
+// SecurityBlockingEvent is an event that signals that a request was blocked by the WAF.
+// It should be handled differently than other errors to avoid leaking information to an attacker.
+// If this error was returned by native types wrapped by dd-trace-go, it means that a 403 response will be written
+// by appsec middleware (or any other status code defined in DataDog's UI). Therefore, the user should not write a
+// response in the handler.
+type SecurityBlockingEvent struct{}
+
+func (*SecurityBlockingEvent) Error() string {
+	return "request blocked by WAF"
+}

--- a/appsec/events/block.go
+++ b/appsec/events/block.go
@@ -8,15 +8,15 @@
 // Handling these events differently than other errors is crucial to not leak information to an attacker.
 package events
 
-var _ error = (*SecurityBlockingEvent)(nil)
+var _ error = (*BlockingSecurityEvent)(nil)
 
-// SecurityBlockingEvent is an event that signals that a request was blocked by the WAF.
+// BlockingSecurityEvent is an event that signals that a request was blocked by the WAF.
 // It should be handled differently than other errors to avoid leaking information to an attacker.
 // If this error was returned by native types wrapped by dd-trace-go, it means that a 403 response will be written
 // by appsec middleware (or any other status code defined in DataDog's UI). Therefore, the user should not write a
 // response in the handler.
-type SecurityBlockingEvent struct{}
+type BlockingSecurityEvent struct{}
 
-func (*SecurityBlockingEvent) Error() string {
+func (*BlockingSecurityEvent) Error() string {
 	return "request blocked by WAF"
 }

--- a/appsec/events/block.go
+++ b/appsec/events/block.go
@@ -7,7 +7,11 @@
 // It allows finer-grained integrations of appsec into your Go errors' management logic.
 package events
 
+import "errors"
+
 var _ error = (*BlockingSecurityEvent)(nil)
+
+var securityError = &BlockingSecurityEvent{}
 
 // BlockingSecurityEvent is the error type returned by function calls blocked by appsec.
 // Even though appsec takes care of responding automatically to the blocked requests, it
@@ -21,4 +25,9 @@ type BlockingSecurityEvent struct{}
 
 func (*BlockingSecurityEvent) Error() string {
 	return "request blocked by WAF"
+}
+
+// IsSecurityError returns true if the error is a security event.
+func IsSecurityError(err error) bool {
+	return errors.Is(err, securityError)
 }

--- a/contrib/google.golang.org/grpc/appsec.go
+++ b/contrib/google.golang.org/grpc/appsec.go
@@ -7,6 +7,7 @@ package grpc
 
 import (
 	"context"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/emitter/grpcsec"

--- a/contrib/labstack/echo.v4/appsec.go
+++ b/contrib/labstack/echo.v4/appsec.go
@@ -6,13 +6,12 @@
 package echo
 
 import (
+	"gopkg.in/DataDog/dd-trace-go.v1/appsec/events"
 	"net/http"
 
+	"github.com/labstack/echo/v4"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/emitter/httpsec"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/emitter/httpsec/types"
-
-	"github.com/labstack/echo/v4"
 )
 
 func withAppSec(next echo.HandlerFunc, span tracer.Span) echo.HandlerFunc {
@@ -27,7 +26,7 @@ func withAppSec(next echo.HandlerFunc, span tracer.Span) echo.HandlerFunc {
 			err = next(c)
 			// If the error is a monitoring one, it means appsec actions will take care of writing the response
 			// and handling the error. Don't call the echo error handler in this case
-			if _, ok := err.(*types.MonitoringError); !ok && err != nil {
+			if _, ok := err.(*events.SecurityBlockingEvent); !ok && err != nil {
 				c.Error(err)
 			}
 		})

--- a/contrib/labstack/echo.v4/appsec.go
+++ b/contrib/labstack/echo.v4/appsec.go
@@ -26,7 +26,7 @@ func withAppSec(next echo.HandlerFunc, span tracer.Span) echo.HandlerFunc {
 			err = next(c)
 			// If the error is a monitoring one, it means appsec actions will take care of writing the response
 			// and handling the error. Don't call the echo error handler in this case
-			if _, ok := err.(*events.SecurityBlockingEvent); !ok && err != nil {
+			if _, ok := err.(*events.BlockingSecurityEvent); !ok && err != nil {
 				c.Error(err)
 			}
 		})

--- a/contrib/labstack/echo.v4/appsec.go
+++ b/contrib/labstack/echo.v4/appsec.go
@@ -6,12 +6,13 @@
 package echo
 
 import (
-	"gopkg.in/DataDog/dd-trace-go.v1/appsec/events"
 	"net/http"
 
-	"github.com/labstack/echo/v4"
+	"gopkg.in/DataDog/dd-trace-go.v1/appsec/events"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/emitter/httpsec"
+
+	"github.com/labstack/echo/v4"
 )
 
 func withAppSec(next echo.HandlerFunc, span tracer.Span) echo.HandlerFunc {

--- a/contrib/net/http/roundtripper.go
+++ b/contrib/net/http/roundtripper.go
@@ -78,11 +78,7 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (res *http.Response, err er
 		}
 	}
 	if appsec.Enabled() {
-		res, err = httpsec.RoundTrip(httpsec.RoundTripArgs{
-			Ctx: ctx,
-			Req: r2,
-			Rt:  rt.base,
-		})
+		res, err = httpsec.RoundTrip(ctx, r2, rt.base)
 	} else {
 		res, err = rt.base.RoundTrip(r2)
 	}

--- a/contrib/net/http/roundtripper.go
+++ b/contrib/net/http/roundtripper.go
@@ -78,7 +78,6 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (res *http.Response, err er
 		}
 	}
 	if appsec.Enabled() {
-		span.SetTag("_dd.appsec.rasp", "1")
 		res, err = httpsec.RoundTrip(httpsec.RoundTripArgs{
 			Ctx: ctx,
 			Req: r2,

--- a/contrib/net/http/roundtripper.go
+++ b/contrib/net/http/roundtripper.go
@@ -7,8 +7,6 @@ package http
 
 import (
 	"fmt"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/emitter/httpsec"
 	"math"
 	"net/http"
 	"os"
@@ -17,6 +15,8 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/emitter/httpsec"
 )
 
 type roundTripper struct {

--- a/contrib/net/http/roundtripper.go
+++ b/contrib/net/http/roundtripper.go
@@ -10,7 +10,6 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/emitter/httpsec"
 	"math"
-	"math/rand"
 	"net/http"
 	"os"
 	"strconv"
@@ -42,11 +41,6 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (res *http.Response, err er
 		tracer.Tag(ext.Component, componentName),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
 		tracer.Tag(ext.NetworkDestinationName, url.Hostname()),
-	}
-	var appsecSpanID uint64
-	if appsec.Enabled() {
-		appsecSpanID = rand.Uint64()
-		opts = append(opts, tracer.WithSpanID(appsecSpanID))
 	}
 	if !math.IsNaN(rt.cfg.analyticsRate) {
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, rt.cfg.analyticsRate))
@@ -85,11 +79,9 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (res *http.Response, err er
 	}
 	if appsec.Enabled() {
 		res, err = httpsec.RoundTrip(httpsec.RoundTripArgs{
-			SpanID: appsecSpanID,
-			Span:   span,
-			Ctx:    ctx,
-			Req:    r2,
-			Rt:     rt.base,
+			Ctx: ctx,
+			Req: r2,
+			Rt:  rt.base,
 		})
 	} else {
 		res, err = rt.base.RoundTrip(r2)

--- a/contrib/net/http/roundtripper.go
+++ b/contrib/net/http/roundtripper.go
@@ -61,7 +61,7 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (res *http.Response, err er
 		if rt.cfg.after != nil {
 			rt.cfg.after(res, span)
 		}
-		if !errors.Is(err, &events.SecurityBlockingEvent{}) && (rt.cfg.errCheck == nil || rt.cfg.errCheck(err)) {
+		if !errors.Is(err, &events.BlockingSecurityEvent{}) && (rt.cfg.errCheck == nil || rt.cfg.errCheck(err)) {
 			span.Finish(tracer.WithError(err))
 		} else {
 			span.Finish()

--- a/contrib/net/http/roundtripper.go
+++ b/contrib/net/http/roundtripper.go
@@ -78,6 +78,7 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (res *http.Response, err er
 		}
 	}
 	if appsec.Enabled() {
+		span.SetTag("_dd.appsec.rasp", "1")
 		res, err = httpsec.RoundTrip(httpsec.RoundTripArgs{
 			Ctx: ctx,
 			Req: r2,

--- a/contrib/net/http/roundtripper_test.go
+++ b/contrib/net/http/roundtripper_test.go
@@ -654,7 +654,7 @@ func TestAppsec(t *testing.T) {
 			require.NoError(t, err)
 
 			resp, err := client.RoundTrip(req.WithContext(r.Context()))
-			require.ErrorIs(t, err, &events.SecurityBlockingEvent{})
+			require.ErrorIs(t, err, &events.BlockingSecurityEvent{})
 			if resp != nil {
 				defer resp.Body.Close()
 			}

--- a/contrib/net/http/roundtripper_test.go
+++ b/contrib/net/http/roundtripper_test.go
@@ -8,6 +8,8 @@ package http
 import (
 	"encoding/base64"
 	"fmt"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/listener/sharedsec"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -618,4 +620,57 @@ func TestClientNamingSchema(t *testing.T) {
 	}
 	t.Run("ServiceName", namingschematest.NewServiceNameTest(genSpans, wantServiceNameV0))
 	t.Run("SpanName", namingschematest.NewSpanNameTest(genSpans, assertOpV0, assertOpV1))
+}
+
+type emptyRoundTripper struct{}
+
+func (rt *emptyRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	recorder := httptest.NewRecorder()
+	recorder.WriteHeader(200)
+	return recorder.Result(), nil
+}
+
+func TestAppsec(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	t.Setenv("DD_APPSEC_RULES", "../../../internal/appsec/testdata/rasp.json")
+
+	appsec.Start()
+	if !appsec.Enabled() {
+		t.Skip("appsec not enabled")
+	}
+
+	client := WrapRoundTripper(&emptyRoundTripper{})
+
+	t.Run("event", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r, err := http.NewRequest("GET", "?value=169.254.169.254", nil)
+		require.NoError(t, err)
+
+		TraceAndServe(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			req, err := http.NewRequest("GET", "http://169.254.169.254", nil)
+			require.NoError(t, err)
+
+			resp, err := client.RoundTrip(req.WithContext(r.Context()))
+			defer require.NoError(t, err)
+			defer resp.Body.Close()
+		}), w, r, &ServeConfig{
+			Service:  "service",
+			Resource: "resource",
+		})
+
+		spans := mt.FinishedSpans()
+		require.Len(t, spans, 2) // service entry serviceSpan & http request serviceSpan
+		serviceSpan := spans[1]
+
+		require.Contains(t, serviceSpan.Tags(), "_dd.appsec.json")
+
+		appsecJSON := serviceSpan.Tag("_dd.appsec.json")
+		require.Contains(t, appsecJSON, sharedsec.ServerIoNetURLAddr)
+
+		// This is a nested event so it should contain the child span id in the service entry span
+		// TODO(eliott.bouhana): uncomment this once we have the child span id in the service entry span
+		// require.Contains(t, appsecJSON, `"span_id":`+strconv.FormatUint(requestSpan.SpanID(), 10))
+	})
 }

--- a/contrib/net/http/roundtripper_test.go
+++ b/contrib/net/http/roundtripper_test.go
@@ -8,8 +8,6 @@ package http
 import (
 	"encoding/base64"
 	"fmt"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/listener/sharedsec"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -23,6 +21,8 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/listener/sharedsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 
 	"github.com/stretchr/testify/assert"

--- a/contrib/net/http/roundtripper_test.go
+++ b/contrib/net/http/roundtripper_test.go
@@ -8,6 +8,7 @@ package http
 import (
 	"encoding/base64"
 	"fmt"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/listener/httpsec"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -22,7 +23,6 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/listener/sharedsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 
 	"github.com/stretchr/testify/assert"
@@ -667,7 +667,7 @@ func TestAppsec(t *testing.T) {
 		require.Contains(t, serviceSpan.Tags(), "_dd.appsec.json")
 
 		appsecJSON := serviceSpan.Tag("_dd.appsec.json")
-		require.Contains(t, appsecJSON, sharedsec.ServerIoNetURLAddr)
+		require.Contains(t, appsecJSON, httpsec.ServerIoNetURLAddr)
 
 		// This is a nested event so it should contain the child span id in the service entry span
 		// TODO(eliott.bouhana): uncomment this once we have the child span id in the service entry span

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	cloud.google.com/go/pubsub v1.33.0
 	github.com/99designs/gqlgen v0.17.36
-	github.com/DataDog/appsec-internal-go v1.5.0
+	github.com/DataDog/appsec-internal-go v1.6.0
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.1
 	github.com/DataDog/datadog-go/v5 v5.3.0

--- a/go.sum
+++ b/go.sum
@@ -624,8 +624,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v0.5.1/go.mod h1:Vt9s
 github.com/AzureAD/microsoft-authentication-library-for-go v0.8.1/go.mod h1:4qFor3D/HDsvBME35Xy9rwW9DecL+M2sNw1ybjPtwA0=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DataDog/appsec-internal-go v1.5.0 h1:8kS5zSx5T49uZ8dZTdT19QVAvC/B8ByyZdhQKYQWHno=
-github.com/DataDog/appsec-internal-go v1.5.0/go.mod h1:pEp8gjfNLtEOmz+iZqC8bXhu0h4k7NUsW/qiQb34k1U=
+github.com/DataDog/appsec-internal-go v1.6.0 h1:QHvPOv/O0s2fSI/BraZJNpRDAtdlrRm5APJFZNBxjAw=
+github.com/DataDog/appsec-internal-go v1.6.0/go.mod h1:pEp8gjfNLtEOmz+iZqC8bXhu0h4k7NUsW/qiQb34k1U=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0 h1:bUMSNsw1iofWiju9yc1f+kBd33E3hMJtq9GuU602Iy8=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0/go.mod h1:HzySONXnAgSmIQfL6gOv9hWprKJkx8CicuXuUbmgWfo=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.1 h1:5nE6N3JSs2IG3xzMthNFhXfOaXlrsdgqmJ73lndFf8c=

--- a/internal/apps/go.mod
+++ b/internal/apps/go.mod
@@ -8,7 +8,7 @@ require (
 )
 
 require (
-	github.com/DataDog/appsec-internal-go v1.5.0 // indirect
+	github.com/DataDog/appsec-internal-go v1.6.0 // indirect
 	github.com/DataDog/go-libddwaf/v3 v3.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/eapache/queue/v2 v2.0.0-20230407133247-75960ed334e4 // indirect

--- a/internal/apps/go.sum
+++ b/internal/apps/go.sum
@@ -1,5 +1,5 @@
-github.com/DataDog/appsec-internal-go v1.5.0 h1:8kS5zSx5T49uZ8dZTdT19QVAvC/B8ByyZdhQKYQWHno=
-github.com/DataDog/appsec-internal-go v1.5.0/go.mod h1:pEp8gjfNLtEOmz+iZqC8bXhu0h4k7NUsW/qiQb34k1U=
+github.com/DataDog/appsec-internal-go v1.6.0 h1:QHvPOv/O0s2fSI/BraZJNpRDAtdlrRm5APJFZNBxjAw=
+github.com/DataDog/appsec-internal-go v1.6.0/go.mod h1:pEp8gjfNLtEOmz+iZqC8bXhu0h4k7NUsW/qiQb34k1U=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0 h1:bUMSNsw1iofWiju9yc1f+kBd33E3hMJtq9GuU602Iy8=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0/go.mod h1:HzySONXnAgSmIQfL6gOv9hWprKJkx8CicuXuUbmgWfo=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.1 h1:5nE6N3JSs2IG3xzMthNFhXfOaXlrsdgqmJ73lndFf8c=

--- a/internal/appsec/appsec.go
+++ b/internal/appsec/appsec.go
@@ -26,6 +26,13 @@ func Enabled() bool {
 	return activeAppSec != nil && activeAppSec.started
 }
 
+// RASPEnabled returns true when DD_APPSEC_RASP_ENABLED=true or is unset. Granted that AppSec is enabled.
+func RASPEnabled() bool {
+	mu.RLock()
+	defer mu.RUnlock()
+	return activeAppSec != nil && activeAppSec.started && activeAppSec.cfg.RASP
+}
+
 // Start AppSec when enabled is enabled by both using the appsec build tag and
 // setting the environment variable DD_APPSEC_ENABLED to true.
 func Start(opts ...config.StartOption) {

--- a/internal/appsec/appsec.go
+++ b/internal/appsec/appsec.go
@@ -162,6 +162,7 @@ func (a *appsec) start(telemetry *appsecTelemetry) error {
 	}
 
 	a.enableRCBlocking()
+	a.enableRASP()
 
 	a.started = true
 	log.Info("appsec: up and running")

--- a/internal/appsec/config/config.go
+++ b/internal/appsec/config/config.go
@@ -11,8 +11,9 @@ import (
 	"strconv"
 	"time"
 
-	internal "github.com/DataDog/appsec-internal-go/appsec"
+	appsecInternal "github.com/DataDog/appsec-internal-go/appsec"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/remoteconfig"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
@@ -62,11 +63,12 @@ type Config struct {
 	// AppSec trace rate limit (traces per second).
 	TraceRateLimit int64
 	// Obfuscator configuration
-	Obfuscator internal.ObfuscatorConfig
+	Obfuscator appsecInternal.ObfuscatorConfig
 	// APISec configuration
-	APISec internal.APISecConfig
+	APISec appsecInternal.APISecConfig
 	// RC is the remote configuration client used to receive product configuration updates. Nil if RC is disabled (default)
-	RC *remoteconfig.ClientConfig
+	RC   *remoteconfig.ClientConfig
+	RASP bool
 }
 
 // WithRCConfig sets the AppSec remote config client configuration to the specified cfg
@@ -99,7 +101,7 @@ func parseBoolEnvVar(env string) (enabled bool, set bool, err error) {
 
 // NewConfig returns a fresh appsec configuration read from the env
 func NewConfig() (*Config, error) {
-	rules, err := internal.RulesFromEnv()
+	rules, err := appsecInternal.RulesFromEnv()
 	if err != nil {
 		return nil, err
 	}
@@ -111,9 +113,11 @@ func NewConfig() (*Config, error) {
 
 	return &Config{
 		RulesManager:   r,
-		WAFTimeout:     internal.WAFTimeoutFromEnv(),
-		TraceRateLimit: int64(internal.RateLimitFromEnv()),
-		Obfuscator:     internal.NewObfuscatorConfig(),
-		APISec:         internal.NewAPISecConfig(),
+		WAFTimeout:     appsecInternal.WAFTimeoutFromEnv(),
+		TraceRateLimit: int64(appsecInternal.RateLimitFromEnv()),
+		Obfuscator:     appsecInternal.NewObfuscatorConfig(),
+		APISec:         appsecInternal.NewAPISecConfig(),
+		// TODO: use appsecInternal.RASPENabled() when merged and released
+		RASP: internal.BoolEnv("DD_APPSEC_RASP_ENABLED", true),
 	}, nil
 }

--- a/internal/appsec/config/config.go
+++ b/internal/appsec/config/config.go
@@ -117,7 +117,6 @@ func NewConfig() (*Config, error) {
 		TraceRateLimit: int64(appsecInternal.RateLimitFromEnv()),
 		Obfuscator:     appsecInternal.NewObfuscatorConfig(),
 		APISec:         appsecInternal.NewAPISecConfig(),
-		// TODO: use appsecInternal.RASPENabled() when merged and released
-		RASP: internal.BoolEnv("DD_APPSEC_RASP_ENABLED", true),
+		RASP:           internal.BoolEnv("DD_APPSEC_RASP_ENABLED", true),
 	}, nil
 }

--- a/internal/appsec/config/config.go
+++ b/internal/appsec/config/config.go
@@ -11,9 +11,8 @@ import (
 	"strconv"
 	"time"
 
-	appsecInternal "github.com/DataDog/appsec-internal-go/appsec"
+	internal "github.com/DataDog/appsec-internal-go/appsec"
 
-	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/remoteconfig"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
@@ -63,9 +62,9 @@ type Config struct {
 	// AppSec trace rate limit (traces per second).
 	TraceRateLimit int64
 	// Obfuscator configuration
-	Obfuscator appsecInternal.ObfuscatorConfig
+	Obfuscator internal.ObfuscatorConfig
 	// APISec configuration
-	APISec appsecInternal.APISecConfig
+	APISec internal.APISecConfig
 	// RC is the remote configuration client used to receive product configuration updates. Nil if RC is disabled (default)
 	RC   *remoteconfig.ClientConfig
 	RASP bool
@@ -101,7 +100,7 @@ func parseBoolEnvVar(env string) (enabled bool, set bool, err error) {
 
 // NewConfig returns a fresh appsec configuration read from the env
 func NewConfig() (*Config, error) {
-	rules, err := appsecInternal.RulesFromEnv()
+	rules, err := internal.RulesFromEnv()
 	if err != nil {
 		return nil, err
 	}
@@ -113,10 +112,10 @@ func NewConfig() (*Config, error) {
 
 	return &Config{
 		RulesManager:   r,
-		WAFTimeout:     appsecInternal.WAFTimeoutFromEnv(),
-		TraceRateLimit: int64(appsecInternal.RateLimitFromEnv()),
-		Obfuscator:     appsecInternal.NewObfuscatorConfig(),
-		APISec:         appsecInternal.NewAPISecConfig(),
-		RASP:           internal.BoolEnv("DD_APPSEC_RASP_ENABLED", true),
+		WAFTimeout:     internal.WAFTimeoutFromEnv(),
+		TraceRateLimit: int64(internal.RateLimitFromEnv()),
+		Obfuscator:     internal.NewObfuscatorConfig(),
+		APISec:         internal.NewAPISecConfig(),
+		RASP:           internal.RASPEnabled(),
 	}, nil
 }

--- a/internal/appsec/emitter/grpcsec/types/types.go
+++ b/internal/appsec/emitter/grpcsec/types/types.go
@@ -72,32 +72,7 @@ type (
 		// Corresponds to the address `grpc.server.request.message`.
 		Message interface{}
 	}
-
-	// MonitoringError is used to vehicle a gRPC error that also embeds a request status code
-	MonitoringError struct {
-		msg    string
-		status uint32
-	}
 )
-
-// NewMonitoringError creates and returns a new gRPC monitoring error, wrapped under
-// sharedesec.MonitoringError
-func NewMonitoringError(msg string, code uint32) error {
-	return &MonitoringError{
-		msg:    msg,
-		status: code,
-	}
-}
-
-// GRPCStatus returns the gRPC status code embedded in the error
-func (e *MonitoringError) GRPCStatus() uint32 {
-	return e.status
-}
-
-// Error implements the error interface
-func (e *MonitoringError) Error() string {
-	return e.msg
-}
 
 // Finish the gRPC handler operation, along with the given results, and emit a
 // finish event up in the operation stack.

--- a/internal/appsec/emitter/httpsec/http.go
+++ b/internal/appsec/emitter/httpsec/http.go
@@ -50,7 +50,7 @@ func MonitorParsedBody(ctx context.Context, body any) error {
 func ExecuteSDKBodyOperation(parent dyngo.Operation, args types.SDKBodyOperationArgs) error {
 	var err error
 	op := &types.SDKBodyOperation{Operation: dyngo.NewOperation(parent)}
-	dyngo.OnData(op, func(e *events.SecurityBlockingEvent) {
+	dyngo.OnData(op, func(e *events.BlockingSecurityEvent) {
 		err = e
 	})
 	dyngo.StartOperation(op, args)

--- a/internal/appsec/emitter/httpsec/http.go
+++ b/internal/appsec/emitter/httpsec/http.go
@@ -78,7 +78,7 @@ func WrapHandler(handler http.Handler, span ddtrace.Span, pathParams map[string]
 
 		var bypassHandler http.Handler
 		var blocking bool
-		var stackTrace stacktrace.Event
+		var stackTrace *stacktrace.Event
 		args := MakeHandlerOperationArgs(r, clientIP, pathParams)
 		ctx, op := StartOperation(r.Context(), args, func(op *types.Operation) {
 			dyngo.OnData(op, func(a *sharedsec.HTTPAction) {
@@ -86,7 +86,7 @@ func WrapHandler(handler http.Handler, span ddtrace.Span, pathParams map[string]
 				bypassHandler = a.Handler
 			})
 			dyngo.OnData(op, func(a *sharedsec.StackTraceAction) {
-				stackTrace = a.Event
+				stackTrace = &a.Event
 			})
 		})
 		r = r.WithContext(ctx)
@@ -104,7 +104,9 @@ func WrapHandler(handler http.Handler, span ddtrace.Span, pathParams map[string]
 			}
 
 			// Add stacktraces to the span, if any
-			stacktrace.AddToSpan(span, &stackTrace)
+			if stackTrace != nil {
+				stacktrace.AddToSpan(span, stackTrace)
+			}
 
 			if bypassHandler != nil {
 				bypassHandler.ServeHTTP(w, r)

--- a/internal/appsec/emitter/httpsec/roundtripper.go
+++ b/internal/appsec/emitter/httpsec/roundtripper.go
@@ -7,7 +7,6 @@ package httpsec
 
 import (
 	"context"
-	"net/http"
 	"sync"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/appsec/events"
@@ -19,8 +18,7 @@ import (
 
 var badInputContextOnce sync.Once
 
-func RoundTrip(ctx context.Context, request *http.Request, rt http.RoundTripper) (*http.Response, error) {
-	url := request.URL.String()
+func ProtectRoundTrip(ctx context.Context, url string) error {
 	opArgs := types.RoundTripOperationArgs{
 		URL: url,
 	}
@@ -32,7 +30,7 @@ func RoundTrip(ctx context.Context, request *http.Request, rt http.RoundTripper)
 				"instrumentation metadata in the request context: the request handler is not being monitored by a " +
 				"middleware function or the incoming request context has not be forwarded correctly to the roundtripper")
 		})
-		return rt.RoundTrip(request)
+		return nil
 	}
 
 	op := &types.RoundTripOperation{
@@ -49,8 +47,8 @@ func RoundTrip(ctx context.Context, request *http.Request, rt http.RoundTripper)
 
 	if err != nil {
 		log.Debug("appsec: outgoing http request blocked by the WAF on URL: %s", url)
-		return nil, err
+		return err
 	}
 
-	return rt.RoundTrip(request)
+	return nil
 }

--- a/internal/appsec/emitter/httpsec/roundtripper.go
+++ b/internal/appsec/emitter/httpsec/roundtripper.go
@@ -38,6 +38,7 @@ func ProtectRoundTrip(ctx context.Context, url string) error {
 	}
 
 	var err *events.BlockingSecurityEvent
+	// TODO: move the data listener as a setup function of httpsec.StartRoundTripperOperation(ars, <setup>) 
 	dyngo.OnData(op, func(e *events.BlockingSecurityEvent) {
 		err = e
 	})

--- a/internal/appsec/emitter/httpsec/roundtripper.go
+++ b/internal/appsec/emitter/httpsec/roundtripper.go
@@ -26,7 +26,7 @@ func ProtectRoundTrip(ctx context.Context, url string) error {
 	parent, _ := ctx.Value(listener.ContextKey{}).(dyngo.Operation)
 	if parent == nil { // No parent operation => we can't monitor the request
 		badInputContextOnce.Do(func() {
-			log.Debug("appsec: outgoing http request monitoring ignored: could not find the http handler " +
+			log.Debug("appsec: outgoing http request monitoring ignored: could not find the handler " +
 				"instrumentation metadata in the request context: the request handler is not being monitored by a " +
 				"middleware function or the incoming request context has not be forwarded correctly to the roundtripper")
 		})

--- a/internal/appsec/emitter/httpsec/roundtripper.go
+++ b/internal/appsec/emitter/httpsec/roundtripper.go
@@ -38,7 +38,7 @@ func ProtectRoundTrip(ctx context.Context, url string) error {
 	}
 
 	var err *events.BlockingSecurityEvent
-	// TODO: move the data listener as a setup function of httpsec.StartRoundTripperOperation(ars, <setup>) 
+	// TODO: move the data listener as a setup function of httpsec.StartRoundTripperOperation(ars, <setup>)
 	dyngo.OnData(op, func(e *events.BlockingSecurityEvent) {
 		err = e
 	})

--- a/internal/appsec/emitter/httpsec/roundtripper.go
+++ b/internal/appsec/emitter/httpsec/roundtripper.go
@@ -37,8 +37,8 @@ func ProtectRoundTrip(ctx context.Context, url string) error {
 		Operation: dyngo.NewOperation(parent),
 	}
 
-	var err *events.SecurityBlockingEvent
-	dyngo.OnData(op, func(e *events.SecurityBlockingEvent) {
+	var err *events.BlockingSecurityEvent
+	dyngo.OnData(op, func(e *events.BlockingSecurityEvent) {
 		err = e
 	})
 

--- a/internal/appsec/emitter/httpsec/roundtripper.go
+++ b/internal/appsec/emitter/httpsec/roundtripper.go
@@ -7,10 +7,11 @@ package httpsec
 
 import (
 	"context"
+	"net/http"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/emitter/httpsec/types"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
-	"net/http"
 )
 
 type RoundTripArgs struct {
@@ -34,10 +35,11 @@ func RoundTrip(args RoundTripArgs) (*http.Response, error) {
 	op := &types.RoundTripOperation{Operation: dyngo.NewOperation(parent)}
 
 	var err error
+
+	// Listen for errors in case the request gets blocked
 	dyngo.OnData(op, func(e error) {
 		err = e
 	})
-
 	dyngo.StartOperation(op, opArgs)
 	dyngo.FinishOperation(op, types.RoundTripOperationRes{})
 

--- a/internal/appsec/emitter/httpsec/roundtripper.go
+++ b/internal/appsec/emitter/httpsec/roundtripper.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package httpsec
+
+import (
+	"context"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/emitter/httpsec/types"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+	"net/http"
+)
+
+type RoundTripArgs struct {
+	Ctx context.Context
+	Req *http.Request
+	Rt  http.RoundTripper
+}
+
+func RoundTrip(args RoundTripArgs) (*http.Response, error) {
+	url := args.Req.URL.String()
+	opArgs := types.RoundTripOperationArgs{
+		URL:    url,
+		SpanID: args.SpanID,
+	}
+
+	parent := fromContext(args.Ctx)
+	if parent == nil { // No parent operation => we can't monitor the request
+		log.Error("appsec: outgoing http request monitoring ignored: could not find the http handler instrumentation metadata in the request context: the request handler is not being monitored by a middleware function or the provided context has not be forwarded correctly")
+		return args.Rt.RoundTrip(args.Req)
+	}
+
+	op := &types.RoundTripOperation{Operation: dyngo.NewOperation(parent)}
+
+	var err error
+	dyngo.OnData(op, func(e error) {
+		err = e
+	})
+
+	dyngo.StartOperation(op, opArgs)
+	dyngo.FinishOperation(op, types.RoundTripOperationRes{})
+
+	if err != nil {
+		log.Error("appsec: outgoing http request blocked by the WAF on URL: %s", url)
+		return nil, err
+	}
+
+	return args.Rt.RoundTrip(args.Req)
+}

--- a/internal/appsec/emitter/httpsec/roundtripper.go
+++ b/internal/appsec/emitter/httpsec/roundtripper.go
@@ -22,8 +22,7 @@ type RoundTripArgs struct {
 func RoundTrip(args RoundTripArgs) (*http.Response, error) {
 	url := args.Req.URL.String()
 	opArgs := types.RoundTripOperationArgs{
-		URL:    url,
-		SpanID: args.SpanID,
+		URL: url,
 	}
 
 	parent := fromContext(args.Ctx)

--- a/internal/appsec/emitter/httpsec/types/types.go
+++ b/internal/appsec/emitter/httpsec/types/types.go
@@ -76,10 +76,13 @@ type (
 	// SDKBodyOperationRes is the SDK body operation results.
 	SDKBodyOperationRes struct{}
 
+	// RoundTripOperationArgs is the round trip operation arguments.
 	RoundTripOperationArgs struct {
+		// URL corresponds to the address `server.io.net.url`.
 		URL string
 	}
 
+	// RoundTripOperationRes is the round trip operation results.
 	RoundTripOperationRes struct{}
 )
 

--- a/internal/appsec/emitter/httpsec/types/types.go
+++ b/internal/appsec/emitter/httpsec/types/types.go
@@ -77,8 +77,7 @@ type (
 	SDKBodyOperationRes struct{}
 
 	RoundTripOperationArgs struct {
-		URL    string
-		SpanID uint64
+		URL string
 	}
 
 	RoundTripOperationRes struct{}

--- a/internal/appsec/emitter/httpsec/types/types.go
+++ b/internal/appsec/emitter/httpsec/types/types.go
@@ -70,7 +70,7 @@ type (
 	// SDKBodyOperationArgs is the SDK body operation arguments.
 	SDKBodyOperationArgs struct {
 		// Body corresponds to the address `server.request.body`.
-		Body interface{}
+		Body any
 	}
 
 	// SDKBodyOperationRes is the SDK body operation results.
@@ -81,29 +81,11 @@ type (
 	}
 
 	RoundTripOperationRes struct{}
-
-	// MonitoringError is used to vehicle an HTTP error, usually resurfaced through Appsec SDKs.
-	MonitoringError struct {
-		msg string
-	}
 )
 
 // Finish finishes the SDKBody operation and emits a finish event
 func (op *SDKBodyOperation) Finish() {
 	dyngo.FinishOperation(op, SDKBodyOperationRes{})
-}
-
-// Error implements the Error interface
-func (e *MonitoringError) Error() string {
-	return e.msg
-}
-
-// NewMonitoringError creates and returns a new HTTP monitoring error, wrapped under
-// sharedesec.MonitoringError
-func NewMonitoringError(msg string) error {
-	return &MonitoringError{
-		msg: msg,
-	}
 }
 
 func (SDKBodyOperationArgs) IsArgOf(*SDKBodyOperation)   {}

--- a/internal/appsec/emitter/httpsec/types/types.go
+++ b/internal/appsec/emitter/httpsec/types/types.go
@@ -27,6 +27,10 @@ type (
 	SDKBodyOperation struct {
 		dyngo.Operation
 	}
+
+	RoundTripOperation struct {
+		dyngo.Operation
+	}
 )
 
 // Finish the HTTP handler operation, along with the given results and emits a
@@ -72,6 +76,13 @@ type (
 	// SDKBodyOperationRes is the SDK body operation results.
 	SDKBodyOperationRes struct{}
 
+	RoundTripOperationArgs struct {
+		URL    string
+		SpanID uint64
+	}
+
+	RoundTripOperationRes struct{}
+
 	// MonitoringError is used to vehicle an HTTP error, usually resurfaced through Appsec SDKs.
 	MonitoringError struct {
 		msg string
@@ -101,3 +112,6 @@ func (SDKBodyOperationRes) IsResultOf(*SDKBodyOperation) {}
 
 func (HandlerOperationArgs) IsArgOf(*Operation)   {}
 func (HandlerOperationRes) IsResultOf(*Operation) {}
+
+func (RoundTripOperationArgs) IsArgOf(*RoundTripOperation)   {}
+func (RoundTripOperationRes) IsResultOf(*RoundTripOperation) {}

--- a/internal/appsec/emitter/sharedsec/actions.go
+++ b/internal/appsec/emitter/sharedsec/actions.go
@@ -197,7 +197,7 @@ func newBlockRequestHandler(status int, ct string, payload []byte) http.Handler 
 
 func newGRPCBlockHandler(status int) GRPCWrapper {
 	return func(_ map[string][]string) (uint32, error) {
-		return uint32(status), &events.SecurityBlockingEvent{}
+		return uint32(status), &events.BlockingSecurityEvent{}
 	}
 }
 

--- a/internal/appsec/emitter/sharedsec/actions.go
+++ b/internal/appsec/emitter/sharedsec/actions.go
@@ -103,7 +103,7 @@ func (a *StackTraceAction) EmitData(op dyngo.Operation) { dyngo.EmitData(op, a) 
 func NewStackTraceAction(params map[string]any) Action {
 	id, ok := params["stack_id"]
 	if !ok {
-		log.Debug("appsec: could not read stack_id parameter for stack_trace action")
+		log.Debug("appsec: could not read stack_id parameter for generate_stack action")
 		return nil
 	}
 

--- a/internal/appsec/emitter/sharedsec/actions.go
+++ b/internal/appsec/emitter/sharedsec/actions.go
@@ -7,11 +7,11 @@ package sharedsec
 
 import (
 	_ "embed" // Blank import
-	"errors"
 	"net/http"
 	"os"
 	"strings"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/appsec/events"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/stacktrace"
@@ -197,7 +197,7 @@ func newBlockRequestHandler(status int, ct string, payload []byte) http.Handler 
 
 func newGRPCBlockHandler(status int) GRPCWrapper {
 	return func(_ map[string][]string) (uint32, error) {
-		return uint32(status), errors.New("Request blocked")
+		return uint32(status), &events.SecurityBlockingEvent{}
 	}
 }
 

--- a/internal/appsec/emitter/sharedsec/shared.go
+++ b/internal/appsec/emitter/sharedsec/shared.go
@@ -7,6 +7,7 @@ package sharedsec
 
 import (
 	"context"
+	"gopkg.in/DataDog/dd-trace-go.v1/appsec/events"
 	"reflect"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo"
@@ -39,7 +40,7 @@ var userIDOperationArgsType = reflect.TypeOf((*UserIDOperationArgs)(nil)).Elem()
 func ExecuteUserIDOperation(parent dyngo.Operation, args UserIDOperationArgs) error {
 	var err error
 	op := &UserIDOperation{Operation: dyngo.NewOperation(parent)}
-	dyngo.OnData(op, func(e error) { err = e })
+	dyngo.OnData(op, func(e *events.SecurityBlockingEvent) { err = e })
 	dyngo.StartOperation(op, args)
 	dyngo.FinishOperation(op, UserIDOperationRes{})
 	return err

--- a/internal/appsec/emitter/sharedsec/shared.go
+++ b/internal/appsec/emitter/sharedsec/shared.go
@@ -40,7 +40,7 @@ var userIDOperationArgsType = reflect.TypeOf((*UserIDOperationArgs)(nil)).Elem()
 func ExecuteUserIDOperation(parent dyngo.Operation, args UserIDOperationArgs) error {
 	var err error
 	op := &UserIDOperation{Operation: dyngo.NewOperation(parent)}
-	dyngo.OnData(op, func(e *events.SecurityBlockingEvent) { err = e })
+	dyngo.OnData(op, func(e *events.BlockingSecurityEvent) { err = e })
 	dyngo.StartOperation(op, args)
 	dyngo.FinishOperation(op, UserIDOperationRes{})
 	return err

--- a/internal/appsec/listener/graphqlsec/graphql.go
+++ b/internal/appsec/listener/graphqlsec/graphql.go
@@ -29,6 +29,7 @@ const (
 // List of GraphQL rule addresses currently supported by the WAF
 var supportedAddresses = listener.AddressSet{
 	graphQLServerResolverAddr: {},
+	shared.ServerIoNetURLAddr: {},
 }
 
 // Install registers the GraphQL WAF Event Listener on the given root operation.
@@ -81,6 +82,10 @@ func (l *wafEventListener) onEvent(request *types.RequestOperation, _ types.Requ
 	// - err is not nil, meaning context creation failed
 	if wafCtx == nil || err != nil {
 		return
+	}
+
+	if _, ok := l.addresses[shared.ServerIoNetURLAddr]; ok {
+		shared.RegisterRoundTripper(request, wafCtx, l.limiter, l.config.WAFTimeout)
 	}
 
 	// Add span tags notifying this trace is AppSec-enabled

--- a/internal/appsec/listener/graphqlsec/graphql.go
+++ b/internal/appsec/listener/graphqlsec/graphql.go
@@ -85,7 +85,7 @@ func (l *wafEventListener) onEvent(request *types.RequestOperation, _ types.Requ
 	}
 
 	if _, ok := l.addresses[shared.ServerIoNetURLAddr]; ok {
-		shared.RegisterRoundTripper(request, wafCtx, l.limiter, l.config.WAFTimeout)
+		shared.RegisterRoundTripper(request, wafCtx, l.limiter)
 	}
 
 	// Add span tags notifying this trace is AppSec-enabled

--- a/internal/appsec/listener/grpcsec/grpc.go
+++ b/internal/appsec/listener/grpcsec/grpc.go
@@ -120,14 +120,7 @@ func (l *wafEventListener) onEvent(op *types.HandlerOperation, handlerArgs types
 			}
 			wafResult := shared.RunWAF(wafCtx, waf.RunAddressData{Persistent: values})
 			if wafResult.HasActions() || wafResult.HasEvents() {
-				for aType, params := range wafResult.Actions {
-					for _, action := range shared.ActionsFromEntry(aType, params) {
-						if grpcAction, ok := action.(*sharedsec.GRPCAction); ok {
-							code, err := grpcAction.GRPCWrapper(map[string][]string{})
-							dyngo.EmitData(userIDOp, types.NewMonitoringError(err.Error(), code))
-						}
-					}
-				}
+				shared.ProcessActions(userIDOp, wafResult.Actions)
 				shared.AddSecurityEvents(&op.SecurityEventsHolder, l.limiter, wafResult.Events)
 				log.Debug("appsec: WAF detected an authenticated user attack: %s", args.UserID)
 			}

--- a/internal/appsec/listener/grpcsec/grpc.go
+++ b/internal/appsec/listener/grpcsec/grpc.go
@@ -105,7 +105,7 @@ func (l *wafEventListener) onEvent(op *types.HandlerOperation, handlerArgs types
 	}
 
 	if _, ok := l.addresses[shared.ServerIoNetURLAddr]; ok {
-		shared.RegisterRoundTripper(op, wafCtx, l.limiter, l.config.WAFTimeout)
+		shared.RegisterRoundTripper(op, wafCtx, l.limiter)
 	}
 
 	// Listen to the UserID address if the WAF rules are using it

--- a/internal/appsec/listener/grpcsec/grpc.go
+++ b/internal/appsec/listener/grpcsec/grpc.go
@@ -19,7 +19,6 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/emitter/grpcsec/types"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/emitter/sharedsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/listener"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/listener/httpsec"
 	shared "gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/listener/sharedsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/samplernames"
@@ -30,8 +29,6 @@ const (
 	GRPCServerMethodAddr          = "grpc.server.method"
 	GRPCServerRequestMessageAddr  = "grpc.server.request.message"
 	GRPCServerRequestMetadataAddr = "grpc.server.request.metadata"
-	HTTPClientIPAddr              = httpsec.HTTPClientIPAddr
-	UserIDAddr                    = httpsec.UserIDAddr
 )
 
 // List of gRPC rule addresses currently supported by the WAF
@@ -39,8 +36,9 @@ var supportedAddresses = listener.AddressSet{
 	GRPCServerMethodAddr:          {},
 	GRPCServerRequestMessageAddr:  {},
 	GRPCServerRequestMetadataAddr: {},
-	HTTPClientIPAddr:              {},
-	UserIDAddr:                    {},
+	shared.HTTPClientIPAddr:       {},
+	shared.UserIDAddr:             {},
+	shared.ServerIoNetURLAddr:     {},
 }
 
 // Install registers the gRPC WAF Event Listener on the given root operation.
@@ -106,14 +104,18 @@ func (l *wafEventListener) onEvent(op *types.HandlerOperation, handlerArgs types
 		return
 	}
 
+	if _, ok := l.addresses[shared.ServerIoNetURLAddr]; ok {
+		shared.RegisterRoundTripper(op, wafCtx, l.limiter, l.config.WAFTimeout)
+	}
+
 	// Listen to the UserID address if the WAF rules are using it
-	if l.isSecAddressListened(UserIDAddr) {
+	if l.isSecAddressListened(shared.UserIDAddr) {
 		// UserIDOperation happens when appsec.SetUser() is called. We run the WAF and apply actions to
 		// see if the associated user should be blocked. Since we don't control the execution flow in this case
 		// (SetUser is SDK), we delegate the responsibility of interrupting the handler to the user.
 		dyngo.On(op, func(userIDOp *sharedsec.UserIDOperation, args sharedsec.UserIDOperationArgs) {
 			values := map[string]any{
-				UserIDAddr: args.UserID,
+				shared.UserIDAddr: args.UserID,
 			}
 			wafResult := shared.RunWAF(wafCtx, waf.RunAddressData{Persistent: values})
 			if wafResult.HasActions() || wafResult.HasEvents() {
@@ -136,8 +138,8 @@ func (l *wafEventListener) onEvent(op *types.HandlerOperation, handlerArgs types
 		// Note that this address is passed asap for the passlist, which are created per grpc method
 		values[GRPCServerMethodAddr] = handlerArgs.Method
 	}
-	if l.isSecAddressListened(HTTPClientIPAddr) && handlerArgs.ClientIP.IsValid() {
-		values[HTTPClientIPAddr] = handlerArgs.ClientIP.String()
+	if l.isSecAddressListened(shared.HTTPClientIPAddr) && handlerArgs.ClientIP.IsValid() {
+		values[shared.HTTPClientIPAddr] = handlerArgs.ClientIP.String()
 	}
 
 	wafResult := shared.RunWAF(wafCtx, waf.RunAddressData{Persistent: values})

--- a/internal/appsec/listener/httpsec/http.go
+++ b/internal/appsec/listener/httpsec/http.go
@@ -69,6 +69,7 @@ type wafEventListener struct {
 	once      sync.Once
 }
 
+// newWAFEventListener returns the WAF event listener to register in order to enable it.
 func newWafEventListener(wafHandle *waf.Handle, cfg *config.Config, limiter limiter.Limiter) *wafEventListener {
 	if wafHandle == nil {
 		log.Debug("appsec: no WAF Handle available, the HTTP WAF Event Listener will not be registered")
@@ -90,7 +91,6 @@ func newWafEventListener(wafHandle *waf.Handle, cfg *config.Config, limiter limi
 	}
 }
 
-// NewWAFEventListener returns the WAF event listener to register in order to enable it.
 func (l *wafEventListener) onEvent(op *types.Operation, args types.HandlerOperationArgs) {
 	wafCtx, err := l.wafHandle.NewContextWithBudget(l.config.WAFTimeout)
 	if err != nil {

--- a/internal/appsec/listener/httpsec/roundtripper.go
+++ b/internal/appsec/listener/httpsec/roundtripper.go
@@ -17,7 +17,7 @@ import (
 
 // RegisterRoundTripperListener registers a listener on outgoing requests to run the WAF.
 func RegisterRoundTripperListener(op dyngo.Operation, events *trace.SecurityEventsHolder, wafCtx *waf.Context, limiter limiter.Limiter) {
-	dyngo.On(op, func(operation *types.RoundTripOperation, args types.RoundTripOperationArgs) {
+	dyngo.On(op, func(op *types.RoundTripOperation, args types.RoundTripOperationArgs) {
 		wafResult := sharedsec.RunWAF(wafCtx, waf.RunAddressData{Persistent: map[string]any{ServerIoNetURLAddr: args.URL}})
 		if !wafResult.HasEvents() {
 			return

--- a/internal/appsec/listener/httpsec/roundtripper.go
+++ b/internal/appsec/listener/httpsec/roundtripper.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package httpsec
+
+import (
+	"github.com/DataDog/appsec-internal-go/limiter"
+	"github.com/DataDog/go-libddwaf/v3"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/emitter/httpsec/types"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/listener/sharedsec"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/trace"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+)
+
+// RegisterRoundTripperListener registers a listener on outgoing requests to run the WAF.
+func RegisterRoundTripperListener(op dyngo.Operation, events *trace.SecurityEventsHolder, wafCtx *waf.Context, limiter limiter.Limiter) {
+	dyngo.On(op, func(operation *types.RoundTripOperation, args types.RoundTripOperationArgs) {
+		wafResult := sharedsec.RunWAF(wafCtx, waf.RunAddressData{Persistent: map[string]any{ServerIoNetURLAddr: args.URL}})
+		if !wafResult.HasEvents() {
+			return
+		}
+
+		log.Debug("appsec: WAF detected a suspicious outgoing request URL: %s", args.URL)
+
+		sharedsec.ProcessActions(op, wafResult.Actions)
+		sharedsec.AddSecurityEvents(events, limiter, wafResult.Events)
+	})
+}

--- a/internal/appsec/listener/httpsec/roundtripper.go
+++ b/internal/appsec/listener/httpsec/roundtripper.go
@@ -6,13 +6,14 @@
 package httpsec
 
 import (
-	"github.com/DataDog/appsec-internal-go/limiter"
-	"github.com/DataDog/go-libddwaf/v3"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/emitter/httpsec/types"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/listener/sharedsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/trace"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+
+	"github.com/DataDog/appsec-internal-go/limiter"
+	"github.com/DataDog/go-libddwaf/v3"
 )
 
 // RegisterRoundTripperListener registers a listener on outgoing HTTP client requests to run the WAF.

--- a/internal/appsec/listener/httpsec/roundtripper.go
+++ b/internal/appsec/listener/httpsec/roundtripper.go
@@ -15,7 +15,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 )
 
-// RegisterRoundTripperListener registers a listener on outgoing requests to run the WAF.
+// RegisterRoundTripperListener registers a listener on outgoing HTTP client requests to run the WAF.
 func RegisterRoundTripperListener(op dyngo.Operation, events *trace.SecurityEventsHolder, wafCtx *waf.Context, limiter limiter.Limiter) {
 	dyngo.On(op, func(op *types.RoundTripOperation, args types.RoundTripOperationArgs) {
 		wafResult := sharedsec.RunWAF(wafCtx, waf.RunAddressData{Persistent: map[string]any{ServerIoNetURLAddr: args.URL}})

--- a/internal/appsec/listener/sharedsec/shared.go
+++ b/internal/appsec/listener/sharedsec/shared.go
@@ -8,14 +8,16 @@ package sharedsec
 import (
 	"encoding/json"
 	"errors"
-	"github.com/DataDog/appsec-internal-go/limiter"
-	waf "github.com/DataDog/go-libddwaf/v3"
-	wafErrors "github.com/DataDog/go-libddwaf/v3/errors"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/appsec/events"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/emitter/sharedsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/trace"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+
+	"github.com/DataDog/appsec-internal-go/limiter"
+	waf "github.com/DataDog/go-libddwaf/v3"
+	wafErrors "github.com/DataDog/go-libddwaf/v3/errors"
 )
 
 const (

--- a/internal/appsec/listener/sharedsec/shared.go
+++ b/internal/appsec/listener/sharedsec/shared.go
@@ -94,7 +94,7 @@ func ProcessActions(op dyngo.Operation, actions map[string]any) (interrupt bool)
 	// If any of the actions are supposed to interrupt the request, emit a blocking event for the SDK operations
 	// to return an error.
 	if interrupt {
-		dyngo.EmitData(op, &events.SecurityBlockingEvent{})
+		dyngo.EmitData(op, &events.BlockingSecurityEvent{})
 	}
 
 	return interrupt

--- a/internal/appsec/listener/sharedsec/shared.go
+++ b/internal/appsec/listener/sharedsec/shared.go
@@ -107,7 +107,7 @@ func ActionsFromEntry(actionType string, params any) []sharedsec.Action {
 		return sharedsec.NewBlockAction(p)
 	case "redirect_request":
 		return []sharedsec.Action{sharedsec.NewRedirectAction(p)}
-	case "stack_trace":
+	case "generate_stack":
 		return []sharedsec.Action{sharedsec.NewStackTraceAction(p)}
 
 	default:

--- a/internal/appsec/remoteconfig.go
+++ b/internal/appsec/remoteconfig.go
@@ -402,6 +402,16 @@ func (a *appsec) enableRCBlocking() {
 	}
 }
 
+func (a *appsec) enableRASP() {
+	if !a.cfg.RASP {
+		return
+	}
+	if err := remoteconfig.RegisterCapability(remoteconfig.ASMRASPSSRF); err != nil {
+		log.Debug("appsec: Remote config: couldn't register RASP SSRF: %v", err)
+	}
+	// TODO: register other RASP capabilities when supported
+}
+
 func (a *appsec) disableRCBlocking() {
 	if a.cfg.RC == nil {
 		return

--- a/internal/appsec/testdata/rasp.json
+++ b/internal/appsec/testdata/rasp.json
@@ -1,0 +1,155 @@
+{
+    "version": "2.2",
+    "metadata": {
+        "rules_version": "1.4.2"
+    },
+    "rules": [
+        {
+            "id": "rasp-930-100",
+            "name": "Local file inclusion exploit",
+            "tags": {
+                "type": "lfi",
+                "category": "vulnerability_trigger",
+                "cwe": "22",
+                "capec": "1000/255/153/126",
+                "confidence": "0",
+                "module": "rasp"
+            },
+            "conditions": [
+                {
+                    "parameters": {
+                        "resource": [
+                            {
+                                "address": "server.io.fs.file"
+                            }
+                        ],
+                        "params": [
+                            {
+                                "address": "server.request.query"
+                            },
+                            {
+                                "address": "server.request.body"
+                            },
+                            {
+                                "address": "server.request.path_params"
+                            },
+                            {
+                                "address": "grpc.server.request.message"
+                            },
+                            {
+                                "address": "graphql.server.all_resolvers"
+                            },
+                            {
+                                "address": "graphql.server.resolver"
+                            }
+                        ]
+                    },
+                    "operator": "lfi_detector"
+                }
+            ],
+            "transformers": [],
+            "on_match": [
+                "stack_trace"
+            ]
+        },
+        {
+            "id": "rasp-934-100",
+            "name": "Server-side request forgery exploit",
+            "tags": {
+                "type": "ssrf",
+                "category": "vulnerability_trigger",
+                "cwe": "918",
+                "capec": "1000/225/115/664",
+                "confidence": "0",
+                "module": "rasp"
+            },
+            "conditions": [
+                {
+                    "parameters": {
+                        "resource": [
+                            {
+                                "address": "server.io.net.url"
+                            }
+                        ],
+                        "params": [
+                            {
+                                "address": "server.request.query"
+                            },
+                            {
+                                "address": "server.request.body"
+                            },
+                            {
+                                "address": "server.request.path_params"
+                            },
+                            {
+                                "address": "grpc.server.request.message"
+                            },
+                            {
+                                "address": "graphql.server.all_resolvers"
+                            },
+                            {
+                                "address": "graphql.server.resolver"
+                            }
+                        ]
+                    },
+                    "operator": "ssrf_detector"
+                }
+            ],
+            "transformers": [],
+            "on_match": [
+                "stack_trace"
+            ]
+        },
+        {
+            "id": "rasp-942-100",
+            "name": "SQL injection exploit",
+            "tags": {
+                "type": "sql_injection",
+                "category": "vulnerability_trigger",
+                "cwe": "89",
+                "capec": "1000/152/248/66",
+                "confidence": "0",
+                "module": "rasp"
+            },
+            "conditions": [
+                {
+                    "parameters": {
+                        "resource": [
+                            {
+                                "address": "server.db.statement"
+                            }
+                        ],
+                        "params": [
+                            {
+                                "address": "server.request.query"
+                            },
+                            {
+                                "address": "server.request.body"
+                            },
+                            {
+                                "address": "server.request.path_params"
+                            },
+                            {
+                                "address": "graphql.server.all_resolvers"
+                            },
+                            {
+                                "address": "graphql.server.resolver"
+                            }
+                        ],
+                        "db_type": [
+                            {
+                                "address": "server.db.system"
+                            }
+                        ]
+                    },
+                    "operator": "sqli_detector"
+                }
+            ],
+            "transformers": [],
+            "on_match": [
+                "stack_trace"
+            ]
+        }
+    ],
+    "rules_data": []
+}

--- a/internal/appsec/testdata/rasp.json
+++ b/internal/appsec/testdata/rasp.json
@@ -49,7 +49,8 @@
             ],
             "transformers": [],
             "on_match": [
-                "stack_trace"
+                "stack_trace",
+                "block"
             ]
         },
         {
@@ -97,7 +98,8 @@
             ],
             "transformers": [],
             "on_match": [
-                "stack_trace"
+                "stack_trace",
+                "block"
             ]
         },
         {
@@ -147,7 +149,8 @@
             ],
             "transformers": [],
             "on_match": [
-                "stack_trace"
+                "stack_trace",
+                "block"
             ]
         }
     ],

--- a/internal/appsec/waf.go
+++ b/internal/appsec/waf.go
@@ -50,57 +50,6 @@ func (a *appsec) swapWAF(rules config.RulesFragment) (err error) {
 	return nil
 }
 
-const raspSSRFRule = `
-{
-	"id": "rasp-934-100",
-	"name": "Server-side request forgery exploit",
-	"tags": {
-		"type": "ssrf",
-		"category": "vulnerability_trigger",
-		"cwe": "918",
-		"capec": "1000/225/115/664",
-		"confidence": "0",
-		"module": "rasp"
-	},
-	"conditions": [
-		{
-			"parameters": {
-				"resource": [
-					{
-						"address": "server.io.net.url"
-					}
-				],
-				"params": [
-					{
-						"address": "server.request.query"
-					},
-					{
-						"address": "server.request.body"
-					},
-					{
-						"address": "server.request.path_params"
-					},
-					{
-						"address": "grpc.server.request.message"
-					},
-					{
-						"address": "graphql.server.all_resolvers"
-					},
-					{
-						"address": "graphql.server.resolver"
-					}
-				]
-			},
-			"operator": "ssrf_detector"
-		}
-	],
-	"transformers": [],
-	"on_match": [
-		"stack_trace"
-	]
-}
-`
-
 type wafEventListener func(*waf.Handle, *config.Config, limiter.Limiter, dyngo.Operation)
 
 // wafEventListeners is the global list of event listeners registered by contribs at init time. This

--- a/internal/appsec/waf.go
+++ b/internal/appsec/waf.go
@@ -50,6 +50,57 @@ func (a *appsec) swapWAF(rules config.RulesFragment) (err error) {
 	return nil
 }
 
+const raspSSRFRule = `
+{
+	"id": "rasp-934-100",
+	"name": "Server-side request forgery exploit",
+	"tags": {
+		"type": "ssrf",
+		"category": "vulnerability_trigger",
+		"cwe": "918",
+		"capec": "1000/225/115/664",
+		"confidence": "0",
+		"module": "rasp"
+	},
+	"conditions": [
+		{
+			"parameters": {
+				"resource": [
+					{
+						"address": "server.io.net.url"
+					}
+				],
+				"params": [
+					{
+						"address": "server.request.query"
+					},
+					{
+						"address": "server.request.body"
+					},
+					{
+						"address": "server.request.path_params"
+					},
+					{
+						"address": "grpc.server.request.message"
+					},
+					{
+						"address": "graphql.server.all_resolvers"
+					},
+					{
+						"address": "graphql.server.resolver"
+					}
+				]
+			},
+			"operator": "ssrf_detector"
+		}
+	],
+	"transformers": [],
+	"on_match": [
+		"stack_trace"
+	]
+}
+`
+
 type wafEventListener func(*waf.Handle, *config.Config, limiter.Limiter, dyngo.Operation)
 
 // wafEventListeners is the global list of event listeners registered by contribs at init time. This

--- a/internal/appsec/waf_test.go
+++ b/internal/appsec/waf_test.go
@@ -15,16 +15,15 @@ import (
 	"strings"
 	"testing"
 
-	internal "github.com/DataDog/appsec-internal-go/appsec"
-	waf "github.com/DataDog/go-libddwaf/v3"
 	pAppsec "gopkg.in/DataDog/dd-trace-go.v1/appsec"
 	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/config"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/listener/httpsec"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/listener/sharedsec"
 
+	internal "github.com/DataDog/appsec-internal-go/appsec"
+	waf "github.com/DataDog/go-libddwaf/v3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -521,7 +520,7 @@ func BenchmarkSampleWAFContext(b *testing.B) {
 		_, err = ctx.Run(
 			waf.RunAddressData{
 				Persistent: map[string]any{
-					sharedsec.HTTPClientIPAddr:      "1.1.1.1",
+					httpsec.HTTPClientIPAddr:        "1.1.1.1",
 					httpsec.ServerRequestMethodAddr: "GET",
 					httpsec.ServerRequestRawURIAddr: "/",
 					httpsec.ServerRequestHeadersNoCookiesAddr: map[string][]string{

--- a/internal/appsec/waf_test.go
+++ b/internal/appsec/waf_test.go
@@ -23,6 +23,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/config"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/listener/httpsec"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/listener/sharedsec"
 
 	"github.com/stretchr/testify/require"
 )
@@ -520,7 +521,7 @@ func BenchmarkSampleWAFContext(b *testing.B) {
 		_, err = ctx.Run(
 			waf.RunAddressData{
 				Persistent: map[string]any{
-					httpsec.HTTPClientIPAddr:        "1.1.1.1",
+					sharedsec.HTTPClientIPAddr:      "1.1.1.1",
 					httpsec.ServerRequestMethodAddr: "GET",
 					httpsec.ServerRequestRawURIAddr: "/",
 					httpsec.ServerRequestHeadersNoCookiesAddr: map[string][]string{

--- a/internal/exectracetest/go.mod
+++ b/internal/exectracetest/go.mod
@@ -9,7 +9,7 @@ require (
 )
 
 require (
-	github.com/DataDog/appsec-internal-go v1.5.0 // indirect
+	github.com/DataDog/appsec-internal-go v1.6.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.1 // indirect
 	github.com/DataDog/datadog-go/v5 v5.3.0 // indirect

--- a/internal/exectracetest/go.sum
+++ b/internal/exectracetest/go.sum
@@ -1,5 +1,5 @@
-github.com/DataDog/appsec-internal-go v1.5.0 h1:8kS5zSx5T49uZ8dZTdT19QVAvC/B8ByyZdhQKYQWHno=
-github.com/DataDog/appsec-internal-go v1.5.0/go.mod h1:pEp8gjfNLtEOmz+iZqC8bXhu0h4k7NUsW/qiQb34k1U=
+github.com/DataDog/appsec-internal-go v1.6.0 h1:QHvPOv/O0s2fSI/BraZJNpRDAtdlrRm5APJFZNBxjAw=
+github.com/DataDog/appsec-internal-go v1.6.0/go.mod h1:pEp8gjfNLtEOmz+iZqC8bXhu0h4k7NUsW/qiQb34k1U=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0 h1:bUMSNsw1iofWiju9yc1f+kBd33E3hMJtq9GuU602Iy8=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0/go.mod h1:HzySONXnAgSmIQfL6gOv9hWprKJkx8CicuXuUbmgWfo=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.1 h1:5nE6N3JSs2IG3xzMthNFhXfOaXlrsdgqmJ73lndFf8c=

--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -70,6 +70,8 @@ const (
 	APMTracingHTTPHeaderTags
 	// APMTracingCustomTags enables APM client to set custom tags on all spans
 	APMTracingCustomTags
+	// ASMRASPSSRF enables ASM support for runtime protection against SSRF attacks
+	ASMRASPSSRF = 23
 )
 
 // Additional capability bit index values that are non-consecutive from above.

--- a/internal/stacktrace/event.go
+++ b/internal/stacktrace/event.go
@@ -88,14 +88,16 @@ func AddToSpan(span ddtrace.Span, events ...*Event) {
 		return
 	}
 
-	groupByCategory := map[EventCategory][]*Event{
-		ExceptionEvent:     {},
-		VulnerabilityEvent: {},
-		ExploitEvent:       {},
-	}
+	// TODO(eliott.bouhana): switch to a map[EventCategory][]*Event type when the tinylib/msgp@1.1.10 is out
+	groupByCategory := make(map[string]any, 3)
 
 	for _, event := range events {
-		groupByCategory[event.Category] = append(groupByCategory[event.Category], event)
+		if _, ok := groupByCategory[string(event.Category)]; !ok {
+			groupByCategory[string(event.Category)] = []*Event{event}
+			continue
+		}
+
+		groupByCategory[string(event.Category)] = append(groupByCategory[string(event.Category)].([]*Event), event)
 	}
 
 	type rooter interface {

--- a/internal/stacktrace/event_test.go
+++ b/internal/stacktrace/event_test.go
@@ -6,7 +6,6 @@
 package stacktrace
 
 import (
-	"github.com/tinylib/msgp/msgp"
 	"testing"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
@@ -14,6 +13,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 
 	"github.com/stretchr/testify/require"
+	"github.com/tinylib/msgp/msgp"
 )
 
 func TestNewEvent(t *testing.T) {


### PR DESCRIPTION
JIRA: APPSEC-52492

This change adds support for SSRF exploit prevention.

### What does this PR do?

- Add appsec to net/http/roundtripper
- Add a new dyngo roundtripper operation
- Add a new listener for stacktrace actions
- Add stacktraces to meta_struct, if generated
- Add RC capability for RASP SSRF and register it for appsec

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
