### PR TITLE
contrib/net/http: Support go1.22 ServeMux patterns

### DIFF
--- a/contrib/net/http/http.go
+++ b/contrib/net/http/http.go
@@ -8,6 +8,7 @@ package http // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
 
 import (
 	"net/http"
+	"strings"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
@@ -49,7 +50,8 @@ func (mux *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// get the resource associated to this request
-	_, route := mux.Handler(r)
+	_, pattern := mux.Handler(r)
+	route := patternRoute(pattern)
 	resource := mux.cfg.resourceNamer(r)
 	if resource == "" {
 		resource = r.Method + " " + route
@@ -63,6 +65,19 @@ func (mux *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		SpanOpts: so,
 		Route:    route,
 	})
+}
+
+// patternRoute returns the route part of a go1.22 style ServeMux pattern. I.e.
+// it returns "/foo" for the pattern "/foo" as well as the pattern "GET /foo".
+func patternRoute(s string) string {
+	// Support go1.22 serve mux patterns: [METHOD ][HOST]/[PATH]
+	// Consider any text before a space or tab to be the method of the pattern.
+	// See net/http.parsePattern and the link below for more information.
+	// https://pkg.go.dev/net/http#hdr-Patterns
+	if i := strings.IndexAny(s, " \t"); i > 0 && len(s) >= i+1 {
+		return strings.TrimLeft(s[i+1:], " \t")
+	}
+	return s
 }
 
 // WrapHandler wraps an http.Handler with tracing using the given service and resource.

--- a/contrib/net/http/http_test.go
+++ b/contrib/net/http/http_test.go
@@ -290,6 +290,52 @@ func TestServeMuxUsesResourceNamer(t *testing.T) {
 	assert.Equal("net/http", s.Tag(ext.Component))
 }
 
+func TestServeMuxGo122Patterns(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	// A mux with go1.21 patterns ("/bar") and go1.22 patterns ("GET /foo")
+	mux := NewServeMux()
+	mux.HandleFunc("/bar", func(w http.ResponseWriter, r *http.Request) {})
+	mux.HandleFunc("GET /foo", func(w http.ResponseWriter, r *http.Request) {})
+
+	// Try to hit both routes
+	barW := httptest.NewRecorder()
+	mux.ServeHTTP(barW, httptest.NewRequest("GET", "/bar", nil))
+	fooW := httptest.NewRecorder()
+	mux.ServeHTTP(fooW, httptest.NewRequest("GET", "/foo", nil))
+
+	// Assert the number of spans
+	assert := assert.New(t)
+	spans := mt.FinishedSpans()
+	assert.Equal(2, len(spans))
+
+	// Check the /bar span
+	barSpan := spans[0]
+	assert.Equal(http.StatusOK, barW.Code)
+	assert.Equal("/bar", barSpan.Tag(ext.HTTPRoute))
+	assert.Equal("GET /bar", barSpan.Tag(ext.ResourceName))
+
+	// Check the /foo span
+	fooSpan := spans[1]
+	if fooW.Code == http.StatusOK {
+		assert.Equal("/foo", fooSpan.Tag(ext.HTTPRoute))
+		assert.Equal("GET /foo", fooSpan.Tag(ext.ResourceName))
+	} else {
+		// Until our go.mod version is go1.22 or greater, the mux will not
+		// understand the "GET /foo" pattern, causing the request to be handled
+		// by the 404 handler. Let's assert what we can, and mark the test as
+		// skipped to highlight the issue.
+		assert.Equal(http.StatusNotFound, fooW.Code)
+		assert.Equal(nil, fooSpan.Tag(ext.HTTPRoute))
+		// Using "GET " as a resource name doesn't seem ideal, but that's how
+		// the mux instrumentation deals with 404s right now.
+		assert.Equal("GET ", fooSpan.Tag(ext.ResourceName))
+		t.Skip("run `go mod edit -go=1.22` to run the full test")
+	}
+
+}
+
 func TestWrapHandlerWithResourceNameNoRace(_ *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()


### PR DESCRIPTION
### What does this PR do?

Let's assume you want to instrument a `http.ServeMux` using the [new routing patterns in go1.22](https://tip.golang.org/doc/go1.22#enhanced_routing_patterns):

```go
mux := httptrace.NewServeMux()
mux.HandleFunc("GET /", home.HomeHandler(d))
return mux
```

Before this patch, you'll see the http methods being reported twice:

![2024-05-29 APM Trace Queries  Datadog at 20 23 36@2x](https://github.com/DataDog/dd-trace-go/assets/15000/382033eb-5824-4bd6-b1e3-6b23006fb195)

After this patch, this problem is fixed:

![2024-05-29 APM Trace Queries  Datadog at 20 25 39@2x](https://github.com/DataDog/dd-trace-go/assets/15000/e024a0c6-bac4-4017-b2c1-3caa52dc0a5e)

### Motivation

I'm building a little toy app which may or may not serve my blog one day, and I'm using it to compare the usability of our existing contrib instrumentations against orchestrion. While doing this I noticed the problem above and figured I should submit a fix.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
