### PR TITLE
[DSMS-19] Fix SNS topic format issue

### DIFF
--- a/internal/datastreams/pathway.go
+++ b/internal/datastreams/pathway.go
@@ -21,9 +21,8 @@ func isValidArn(arn string) bool {
 	parts := strings.Split(arn, ":")
 	if len(parts) > 0 && parts[0] == "arn" && len(parts) > 5 {
 		return true
-	} else {
-		return false
 	}
+	return false
 }
 
 func isWellFormedEdgeTag(t string) bool {

--- a/internal/datastreams/pathway.go
+++ b/internal/datastreams/pathway.go
@@ -17,6 +17,15 @@ import (
 
 var hashableEdgeTags = map[string]struct{}{"event_type": {}, "exchange": {}, "group": {}, "topic": {}, "type": {}, "direction": {}}
 
+func isValidArn(arn string) bool {
+	parts := strings.Split(arn, ":")
+	if len(parts) > 0 && parts[0] == "arn" && len(parts) > 5 {
+		return true
+	} else {
+		return false
+	}
+}
+
 func isWellFormedEdgeTag(t string) bool {
 	if i := strings.IndexByte(t, ':'); i != -1 {
 		if j := strings.LastIndexByte(t, ':'); j == i {
@@ -24,7 +33,7 @@ func isWellFormedEdgeTag(t string) bool {
 				return true
 			}
 		}
-		if t[:i] == "topic" && strings.Contains(t, "arn") {
+		if t[:i] == "topic" && isValidArn(t) {
 			return true
 		}
 	}

--- a/internal/datastreams/pathway.go
+++ b/internal/datastreams/pathway.go
@@ -18,8 +18,11 @@ import (
 var hashableEdgeTags = map[string]struct{}{"event_type": {}, "exchange": {}, "group": {}, "topic": {}, "type": {}, "direction": {}}
 
 func isValidArn(arn string) bool {
-	parts := strings.Split(arn, ":")
-	if len(parts) > 0 && parts[0] == "arn" && len(parts) > 5 {
+	separators := strings.Count(arn, ":")
+	if separators < 5 {
+		return false
+	}
+	if strings.HasPrefix(arn, "arn:") {
 		return true
 	}
 	return false

--- a/internal/datastreams/pathway.go
+++ b/internal/datastreams/pathway.go
@@ -24,6 +24,9 @@ func isWellFormedEdgeTag(t string) bool {
 				return true
 			}
 		}
+		if t[:i] == "topic" && strings.Contains(t, "arn") {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR fixes the SNS topic format issue raised in the [support ticket](https://datadoghq.atlassian.net/browse/DSMS-19) where SNS topics aren't detected as data streams. The customer traced the issue to the `nodeHash` function where it checks for correctly formatted tags and returned them. 

However, in the `isWellFormedEdgeTag` check, it will return false for any cases where the tag is a topic that is a full arn (such as `topic:arn:aws:sns:eu-west-1:474060719897:sre-spec-api-ops-dev-slo-consumers` in the customer's case) because the condition check (`j == i`) will return `true` only if there is **one** colon in the edge tag. 

The fix will check that 1) there is a colon, 2) the tag is a topic, and that 3) the tag string contains "arn", then return `true` for this case so that full arn topic tags are not excluded as well-formed tags. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

[See support ticket](https://datadoghq.atlassian.net/browse/DSMS-19) 


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
