### PR TITLE
ddtrace/tracer: fix concurrent map writes when applying trace sampling rules and setting tags concurrently

### DIFF
--- a/ddtrace/tracer/rules_sampler.go
+++ b/ddtrace/tracer/rules_sampler.go
@@ -498,20 +498,23 @@ func (rs *traceRulesSampler) sampleRules(span *span) bool {
 }
 
 func (rs *traceRulesSampler) applyRate(span *span, rate float64, now time.Time, sampler samplernames.SamplerName) {
+	span.Lock()
+	defer span.Unlock()
+
 	span.setMetric(keyRulesSamplerAppliedRate, rate)
 	delete(span.Metrics, keySamplingPriorityRate)
 	if !sampledByRate(span.TraceID, rate) {
-		span.setSamplingPriority(ext.PriorityUserReject, sampler)
+		span.setSamplingPriorityLocked(ext.PriorityUserReject, sampler)
 		return
 	}
 
 	sampled, rate := rs.limiter.allowOne(now)
 	if sampled {
-		span.setSamplingPriority(ext.PriorityUserKeep, sampler)
+		span.setSamplingPriorityLocked(ext.PriorityUserKeep, sampler)
 	} else {
-		span.setSamplingPriority(ext.PriorityUserReject, sampler)
+		span.setSamplingPriorityLocked(ext.PriorityUserReject, sampler)
 	}
-	span.SetTag(keyRulesSamplerLimiterRate, rate)
+	span.setMetric(keyRulesSamplerLimiterRate, rate)
 }
 
 // limit returns the rate limit set in the rules sampler, controlled by DD_TRACE_RATE_LIMIT, and

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -1082,6 +1082,11 @@ func (s *stringer) String() string {
 // concurrent map writes. It seems to only be consistently reproduced with the -count=100
 // flag when running go test, but it's a good test to have.
 func TestConcurrentSpanSetTag(t *testing.T) {
+	testConcurrentSpanSetTag(t)
+	testConcurrentSpanSetTag(t)
+}
+
+func testConcurrentSpanSetTag(t *testing.T) {
 	tracer, _, _, stop := startTestTracer(t, WithSamplingRules([]SamplingRule{NameRule("root", 1.0)}))
 	defer stop()
 
@@ -1093,11 +1098,11 @@ func TestConcurrentSpanSetTag(t *testing.T) {
 	wg.Add(n * 2)
 	for i := 0; i < n; i++ {
 		go func() {
-			span.SetTag("key", "value")
+			tracer.Inject(span.Context(), TextMapCarrier(map[string]string{}))
 			wg.Done()
 		}()
 		go func() {
-			tracer.Inject(span.Context(), TextMapCarrier(map[string]string{}))
+			span.SetTag("key", "value")
 			wg.Done()
 		}()
 	}


### PR DESCRIPTION
### What does this PR do?

Fixes a race condition bug reported by TEE, where a span was being modified concurrently to inject context and to set tags and trace sampling rules are in place.

### Motivation

Avoid race conditions in our code and improve reliability of our tracer.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
