### PR TITLE
ddtrace/opentelemetry: adds http status code remapping for otel trace metrics

### DIFF
--- a/ddtrace/opentelemetry/span.go
+++ b/ddtrace/opentelemetry/span.go
@@ -212,6 +212,8 @@ func toReservedAttributes(k string, v attribute.Value) (string, interface{}) {
 			rate = 0
 		}
 		return ext.EventSampleRate, rate
+	case "http.response.status_code":
+		return "http.status_code", v.AsString()
 	default:
 		return k, v.AsInterface()
 	}

--- a/ddtrace/opentelemetry/span_test.go
+++ b/ddtrace/opentelemetry/span_test.go
@@ -725,6 +725,7 @@ func TestRemapWithMultipleSetAttributes(t *testing.T) {
 	sp.SetAttributes(attribute.String("service.name", "new.service.name"))
 	sp.SetAttributes(attribute.String("span.type", "new.span.type"))
 	sp.SetAttributes(attribute.String("analytics.event", "true"))
+	sp.SetAttributes(attribute.String("http.response.status_code", "200"))
 	sp.End()
 
 	tracer.Flush()
@@ -739,4 +740,6 @@ func TestRemapWithMultipleSetAttributes(t *testing.T) {
 	assert.Equal("new.span.type", p[0]["type"])
 	metrics := fmt.Sprintf("%v", p[0]["metrics"])
 	assert.Contains(metrics, fmt.Sprintf("%s:%s", "_dd1.sr.eausr", "1"))
+	meta := fmt.Sprintf("%v", p[0]["meta"])
+	assert.Contains(meta, fmt.Sprintf("%s:%s", "http.status_code", "200"))
 }


### PR DESCRIPTION




In order for Otel spans to be compliant with the DD backend, `http.response.status_code` needs to be remapped to `http.status_code` for trace metrics compliance.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [x] There is a benchmark for any new code, or changes to existing code.
- [x] If this interacts with the agent in a new way, a system test has been added.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
