### PR TITLE
Fix http remapping to account for int values

### DIFF
--- a/ddtrace/opentelemetry/span.go
+++ b/ddtrace/opentelemetry/span.go
@@ -213,7 +213,7 @@ func toReservedAttributes(k string, v attribute.Value) (string, interface{}) {
 		}
 		return ext.EventSampleRate, rate
 	case "http.response.status_code":
-		return "http.status_code", v.AsString()
+		return "http.status_code", strconv.FormatInt(v.AsInt64(), 10)
 	default:
 		return k, v.AsInterface()
 	}

--- a/ddtrace/opentelemetry/span_test.go
+++ b/ddtrace/opentelemetry/span_test.go
@@ -725,7 +725,7 @@ func TestRemapWithMultipleSetAttributes(t *testing.T) {
 	sp.SetAttributes(attribute.String("service.name", "new.service.name"))
 	sp.SetAttributes(attribute.String("span.type", "new.span.type"))
 	sp.SetAttributes(attribute.String("analytics.event", "true"))
-	sp.SetAttributes(attribute.String("http.response.status_code", "200"))
+	sp.SetAttributes(attribute.Int("http.response.status_code", 200))
 	sp.End()
 
 	tracer.Flush()


### PR DESCRIPTION
### What does this PR do?

Changes code due to the unforeseen circumstance that otel values for `http.response.status_code` are int values while Datadog uses `http.status_code` as a string value

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [x] There is a benchmark for any new code, or changes to existing code.
- [x] If this interacts with the agent in a new way, a system test has been added.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
