### PR TITLE
internal/telemetry: don't send app-dependencies-loaded in the absence of Go deps

### DIFF
--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -211,6 +211,18 @@ func (c *client) start(configuration []Configuration, namespace Namespace, flush
 	cfg = append(cfg, c.globalAppConfig...)
 	cfg = append(cfg, configuration...)
 
+	// State whether the app has its Go dependencies available or not
+	deps, ok := debug.ReadBuildInfo()
+	if !ok {
+		deps = nil // because not guaranteed to be nil by the public doc when !ok
+	}
+	cfg = append(cfg, BoolConfig("dependencies_available", ok))
+	collectDependenciesEnabled := collectDependencies()
+	cfg = append(cfg, BoolConfig("DD_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED", collectDependenciesEnabled)) // TODO: report all the possible telemetry config option automatically
+	if !collectDependenciesEnabled {
+		deps = nil // to simplify the condition below to `deps != nil`
+	}
+
 	payload := &AppStarted{
 		Configuration: cfg,
 		Products:      productInfo,
@@ -219,18 +231,19 @@ func (c *client) start(configuration []Configuration, namespace Namespace, flush
 	appStarted.Body.Payload = payload
 	c.scheduleSubmit(appStarted)
 
-	if collectDependencies() {
+	if deps != nil {
 		var depPayload Dependencies
-		if deps, ok := debug.ReadBuildInfo(); ok {
-			for _, dep := range deps.Deps {
-				depPayload.Dependencies = append(depPayload.Dependencies,
-					Dependency{
-						Name:    dep.Path,
-						Version: strings.TrimPrefix(dep.Version, "v"),
-					},
-				)
-			}
+		for _, dep := range deps.Deps {
+			depPayload.Dependencies = append(depPayload.Dependencies,
+				Dependency{
+					Name:    dep.Path,
+					Version: strings.TrimPrefix(dep.Version, "v"),
+				},
+			)
 		}
+		// Send the telemetry request if and only if the dependencies are actually present in the binary.
+		// For instance, bazel doesn't include them out of the box (cf. https://github.com/bazelbuild/rules_go/issues/3090),
+		// which would result in an empty list of dependencies.
 		dep := c.newRequest(RequestTypeDependenciesLoaded)
 		dep.Body.Payload = depPayload
 		c.scheduleSubmit(dep)

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -151,7 +151,6 @@ func TestRegisterAppConfig(t *testing.T) {
 	require.Equal(t, RequestTypeAppStarted, req.RequestType)
 	appStarted := req.Payload.(*AppStarted)
 	cfg := appStarted.Configuration
-	require.Len(t, cfg, 2)
 	require.Contains(t, cfg, Configuration{Name: "key1", Value: "val1", Origin: OriginDefault})
 	require.Contains(t, cfg, Configuration{Name: "key2", Value: "val2", Origin: OriginDDConfig})
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Avoid sending the telemetry request `app-dependencies-loaded` when there is no Go build info available in the running Go program.
 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Datadog's Software Composition Analysis (SCA) relies on program deps, sent over `app-dependencies-loaded`, which must not be sent when they are missing.
This issue appeared with Bazel which doesn't seem to include Go build info (https://github.com/bazelbuild/rules_go/issues/3090).

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
