### PR TITLE
appsec: fix IsSecurityError

### DIFF
--- a/appsec/events/block.go
+++ b/appsec/events/block.go
@@ -11,8 +11,6 @@ import "errors"
 
 var _ error = (*BlockingSecurityEvent)(nil)
 
-var securityError = &BlockingSecurityEvent{}
-
 // BlockingSecurityEvent is the error type returned by function calls blocked by appsec.
 // Even though appsec takes care of responding automatically to the blocked requests, it
 // is your duty to abort the request handlers that are calling functions blocked by appsec.
@@ -29,5 +27,6 @@ func (*BlockingSecurityEvent) Error() string {
 
 // IsSecurityError returns true if the error is a security event.
 func IsSecurityError(err error) bool {
-	return errors.Is(err, securityError)
+	var secErr *BlockingSecurityEvent
+	return errors.As(err, &secErr)
 }

--- a/contrib/net/http/roundtripper_test.go
+++ b/contrib/net/http/roundtripper_test.go
@@ -662,7 +662,7 @@ func TestAppsec(t *testing.T) {
 				resp, err := client.RoundTrip(req.WithContext(r.Context()))
 
 				if enabled {
-					require.ErrorIs(t, err, &events.BlockingSecurityEvent{})
+					require.True(t, events.IsSecurityError(err))
 				} else {
 					require.NoError(t, err)
 				}
@@ -690,6 +690,7 @@ func TestAppsec(t *testing.T) {
 			require.Contains(t, appsecJSON, httpsec.ServerIoNetURLAddr)
 
 			require.Contains(t, serviceSpan.Tags(), "_dd.stack")
+			require.NotContains(t, serviceSpan.Tags(), "error.message")
 
 			// This is a nested event so it should contain the child span id in the service entry span
 			// TODO(eliott.bouhana): uncomment this once we have the child span id in the service entry span


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR fix `IsSecurityError` which did not have the right behaviour and was always returning false in go 1.20

### Impact

This function has 2 current uses:
* It should be used by customers to check whether the WAF blocked a ˋnet/http` outgoing request.
* It is used in the ˋnet/http` contrib to not report the error as one in the current span.

Both usages are void in go 1.20 without this PR.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
