### PR TITLE
appsec: fix macos native tests

### DIFF
--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -90,11 +90,11 @@ jobs:
 
   macos:
     name: ${{ matrix.runs-on }} go${{ matrix.go-version }}
-    runs-on: macos-11 # oldest macos runner available - the full macOS matrix is in go-libddwaf
+    runs-on: ${{ matrix.runs-on }}
     needs: go-mod-caching
     strategy:
       matrix:
-        runs-on: [ macos-11, macos-14 ] # oldest and newest macos runners available - macos-14 mainly is here to cover the fact it is an ARM machine
+        runs-on: [ macos-12, macos-14 ] # oldest and newest macos runners available - macos-14 mainly is here to cover the fact it is an ARM machine
         go-version: [ "1.22", "1.21", "1.20" ]
       fail-fast: true # saving some CI time - macos runners too long to get
     steps:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

- [x] Replace `macos-11` runners by `macos-12` because they are deprecated and fewer in number which makes the CI slower
- [x] Fix missing template parameter in `runs-on`  

### Motivation

Make CI faster and run on ARM

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!

[APPSEC-53468](https://datadoghq.atlassian.net/browse/APPSEC-53468)


[APPSEC-53468]: https://datadoghq.atlassian.net/browse/APPSEC-53468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ