### PR TITLE
ddtrace/tracer: update sample rate configuration parsing to avoid logging a warning when empty

### DIFF
--- a/ddtrace/tracer/log_test.go
+++ b/ddtrace/tracer/log_test.go
@@ -152,6 +152,18 @@ func TestLogSamplingRules(t *testing.T) {
 	assert.Regexp(logPrefixRegexp+` WARN: DIAGNOSTICS Error\(s\) parsing sampling rules: found errors:\n\tat index 4: ignoring rule {Rate:9\.10}: rate is out of \[0\.0, 1\.0] range$`, tp.Logs()[0])
 }
 
+func TestLogDefaultSamplingRules(t *testing.T) {
+	assert := assert.New(t)
+	tp := new(log.RecordLogger)
+	tp.Ignore("appsec: ", telemetry.LogPrefix)
+	log.UseLogger(tp)
+	t.Setenv("DD_TRACE_SAMPLING_RULES", ``)
+	_, _, _, stop := startTestTracer(t, WithLogger(tp))
+	defer stop()
+
+	assert.Len(tp.Logs(), 0)
+}
+
 func TestLogAgentReachable(t *testing.T) {
 	assert := assert.New(t)
 	tp := new(log.RecordLogger)

--- a/ddtrace/tracer/log_test.go
+++ b/ddtrace/tracer/log_test.go
@@ -152,12 +152,12 @@ func TestLogSamplingRules(t *testing.T) {
 	assert.Regexp(logPrefixRegexp+` WARN: DIAGNOSTICS Error\(s\) parsing sampling rules: found errors:\n\tat index 4: ignoring rule {Rate:9\.10}: rate is out of \[0\.0, 1\.0] range$`, tp.Logs()[0])
 }
 
-func TestLogDefaultSamplingRules(t *testing.T) {
+func TestLogDefaultSampleRate(t *testing.T) {
 	assert := assert.New(t)
 	tp := new(log.RecordLogger)
 	tp.Ignore("appsec: ", telemetry.LogPrefix)
 	log.UseLogger(tp)
-	t.Setenv("DD_TRACE_SAMPLING_RULES", ``)
+	t.Setenv("DD_TRACE_SAMPLE_RATE", ``)
 	_, _, _, stop := startTestTracer(t, WithLogger(tp))
 	defer stop()
 

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -305,15 +305,19 @@ const partialFlushMinSpansDefault = 1000
 func newConfig(opts ...StartOption) *config {
 	c := new(config)
 	c.sampler = NewAllSampler()
-	defaultRate, err := strconv.ParseFloat(getDDorOtelConfig("sampleRate"), 64)
-	if err != nil {
-		log.Warn("ignoring DD_TRACE_SAMPLE_RATE, error: %v", err)
-		defaultRate = math.NaN()
-	} else if defaultRate < 0.0 || defaultRate > 1.0 {
-		log.Warn("ignoring DD_TRACE_SAMPLE_RATE: out of range %f", defaultRate)
-		defaultRate = math.NaN()
+	sampleRate := math.NaN()
+	if r := getDDorOtelConfig("sampleRate"); r != "" {
+		var err error
+		sampleRate, err = strconv.ParseFloat(r, 64)
+		if err != nil {
+			log.Warn("ignoring DD_TRACE_SAMPLE_RATE, error: %v", err)
+			sampleRate = math.NaN()
+		} else if sampleRate < 0.0 || sampleRate > 1.0 {
+			log.Warn("ignoring DD_TRACE_SAMPLE_RATE: out of range %f", sampleRate)
+			sampleRate = math.NaN()
+		}
 	}
-	c.globalSampleRate = defaultRate
+	c.globalSampleRate = sampleRate
 	c.httpClientTimeout = time.Second * 10 // 10 seconds
 
 	if v := os.Getenv("OTEL_LOGS_EXPORTER"); v != "" {


### PR DESCRIPTION
### What does this PR do?
This PR adds a small rewrite to the parsing of the DD / OTEL Sample Rate configuration so that we do not log a warning when the sample rate is empty. This also adds a regression test for the scenario.

### Motivation
Fixes #2749 

### Reviewer's Checklist
- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
