### PR TITLE
readme: drop go 1.19 from support table

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Datadog APM for Go is built upon dependencies defined in specific versions of th
 | 1.22           | [GA](#support-ga)                   |
 | 1.21           | [GA](#support-ga)                   |
 | 1.20           | [Maintenance](#support-maintenance) |
-| 1.19           | [Legacy](#support-legacy)           |
 
 * Datadog's Trace Agent >= 5.21.1
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Remove 1.19 from supported versions

Fixes #2750

### Motivation

Confusing for readers of the README since dd-trace-go does not compile with it anymore

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
