### PR TITLE
internal/exectracetest: fix TestExecutionTraceSpans flakes

### DIFF
--- a/internal/exectracetest/exectrace_test.go
+++ b/internal/exectracetest/exectrace_test.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 	"runtime/pprof"
 	"runtime/trace"
+	"sort"
 	"testing"
 	"time"
 
@@ -185,13 +186,14 @@ func TestExecutionTraceSpans(t *testing.T) {
 	}
 
 	want := []traceSpan{
-		{name: "root", spanID: root.Context().SpanID()},
 		{name: "child", parent: "root", spanID: child.Context().SpanID()},
+		{name: "root", spanID: root.Context().SpanID()},
 	}
 	var got []traceSpan
 	for _, v := range spans {
 		got = append(got, *v)
 	}
+	sort.Slice(got, func(i, j int) bool { return got[i].name < got[j].name })
 
 	if !reflect.DeepEqual(want, got) {
 		t.Errorf("wanted spans %+v, got %+v", want, got)


### PR DESCRIPTION
This test was sensitive to the order of map iteration, making it flaky.
Whoops!

Example flake: https://github.com/DataDog/dd-trace-go/actions/runs/9778155930/job/26994378106#step:5:362
