### PR TITLE
internal/appsec: refactor simple WAF run operations

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,8 +4,8 @@ stages:
   - test-apps
 
 variables:
-  # This base image is created here: https://gitlab.ddbuild.io/DataDog/apm-reliability/benchmarking-platform/-/pipelines/30723596
-  BASE_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dd-trace-go-30723596
+  # This base image is created here: https://gitlab.ddbuild.io/DataDog/apm-reliability/benchmarking-platform/-/pipelines/38806487
+  BASE_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dd-trace-go-38806487
   INDEX_FILE: index.txt
   KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-go
   FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"

--- a/internal/appsec/listener/graphqlsec/graphql.go
+++ b/internal/appsec/listener/graphqlsec/graphql.go
@@ -45,7 +45,7 @@ func Install(wafHandle *waf.Handle, cfg *config.Config, lim limiter.Limiter, roo
 type wafEventListener struct {
 	wafHandle *waf.Handle
 	config    *config.Config
-	addresses map[string]struct{}
+	addresses listener.AddressSet
 	limiter   limiter.Limiter
 	wafDiags  waf.Diagnostics
 	once      sync.Once

--- a/internal/appsec/listener/httpsec/roundtripper.go
+++ b/internal/appsec/listener/httpsec/roundtripper.go
@@ -10,7 +10,6 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/emitter/httpsec/types"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/listener/sharedsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/trace"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 
 	"github.com/DataDog/appsec-internal-go/limiter"
 	"github.com/DataDog/go-libddwaf/v3"
@@ -18,15 +17,7 @@ import (
 
 // RegisterRoundTripperListener registers a listener on outgoing HTTP client requests to run the WAF.
 func RegisterRoundTripperListener(op dyngo.Operation, events *trace.SecurityEventsHolder, wafCtx *waf.Context, limiter limiter.Limiter) {
-	dyngo.On(op, func(op *types.RoundTripOperation, args types.RoundTripOperationArgs) {
-		wafResult := sharedsec.RunWAF(wafCtx, waf.RunAddressData{Ephemeral: map[string]any{ServerIoNetURLAddr: args.URL}})
-		if !wafResult.HasEvents() {
-			return
-		}
-
-		log.Debug("appsec: WAF detected a suspicious outgoing request URL: %s", args.URL)
-
-		sharedsec.ProcessActions(op, wafResult.Actions)
-		sharedsec.AddSecurityEvents(events, limiter, wafResult.Events)
-	})
+	dyngo.On(op, sharedsec.MakeWAFRunListener(events, wafCtx, limiter, func(args types.RoundTripOperationArgs) waf.RunAddressData {
+		return waf.RunAddressData{Ephemeral: map[string]any{ServerIoNetURLAddr: args.URL}}
+	}))
 }

--- a/internal/appsec/listener/sharedsec/shared.go
+++ b/internal/appsec/listener/sharedsec/shared.go
@@ -8,6 +8,7 @@ package sharedsec
 import (
 	"encoding/json"
 	"errors"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/appsec/events"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/emitter/sharedsec"
@@ -37,7 +38,12 @@ func RunWAF(wafCtx *waf.Context, values waf.RunAddressData) waf.Result {
 	return result
 }
 
-func MakeWAFRunListener[O dyngo.Operation, T dyngo.ArgOf[O]](events *trace.SecurityEventsHolder, wafCtx *waf.Context, limiter limiter.Limiter, toRunAddressData func(T) waf.RunAddressData) func(O, T) {
+func MakeWAFRunListener[O dyngo.Operation, T dyngo.ArgOf[O]](
+	events *trace.SecurityEventsHolder,
+	wafCtx *waf.Context,
+	limiter limiter.Limiter,
+	toRunAddressData func(T) waf.RunAddressData,
+) func(O, T) {
 	return func(op O, args T) {
 		wafResult := RunWAF(wafCtx, toRunAddressData(args))
 		if !wafResult.HasEvents() {

--- a/internal/appsec/listener/sharedsec/shared.go
+++ b/internal/appsec/listener/sharedsec/shared.go
@@ -44,7 +44,7 @@ func MakeWAFRunListener[O dyngo.Operation, T dyngo.ArgOf[O]](events *trace.Secur
 			return
 		}
 
-		log.Debug("appsec: WAF detected a suspicious RASP event")
+		log.Debug("appsec: WAF detected a suspicious WAF event")
 
 		ProcessActions(op, wafResult.Actions)
 		AddSecurityEvents(events, limiter, wafResult.Events)

--- a/internal/appsec/listener/sqlsec/sql.go
+++ b/internal/appsec/listener/sqlsec/sql.go
@@ -6,12 +6,13 @@
 package sqlsec
 
 import (
-	"github.com/DataDog/appsec-internal-go/limiter"
-	waf "github.com/DataDog/go-libddwaf/v3"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/emitter/sqlsec/types"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/listener/sharedsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/trace"
+
+	"github.com/DataDog/appsec-internal-go/limiter"
+	waf "github.com/DataDog/go-libddwaf/v3"
 )
 
 const (

--- a/internal/appsec/listener/sqlsec/sql.go
+++ b/internal/appsec/listener/sqlsec/sql.go
@@ -6,14 +6,12 @@
 package sqlsec
 
 import (
+	"github.com/DataDog/appsec-internal-go/limiter"
+	waf "github.com/DataDog/go-libddwaf/v3"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/emitter/sqlsec/types"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/listener/sharedsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/trace"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
-
-	"github.com/DataDog/appsec-internal-go/limiter"
-	waf "github.com/DataDog/go-libddwaf/v3"
 )
 
 const (
@@ -22,18 +20,15 @@ const (
 )
 
 func RegisterSQLListener(op dyngo.Operation, events *trace.SecurityEventsHolder, wafCtx *waf.Context, limiter limiter.Limiter) {
-	dyngo.On(op, func(op *types.SQLOperation, args types.SQLOperationArgs) {
-		wafResult := sharedsec.RunWAF(wafCtx, waf.RunAddressData{Ephemeral: map[string]any{
-			ServerDBStatementAddr: args.Query,
-			ServerDBTypeAddr:      args.Driver,
-		}})
-		if !wafResult.HasEvents() {
-			return
-		}
+	dyngo.On(op, sharedsec.MakeWAFRunListener(events, wafCtx, limiter, func(args types.SQLOperationArgs) waf.RunAddressData {
+		return waf.RunAddressData{Ephemeral: map[string]any{ServerDBStatementAddr: args.Query, ServerDBTypeAddr: args.Driver}}
+	}))
+}
 
-		log.Debug("appsec: WAF detected a suspicious SQL operation")
+func SQLAddressesPresent(addresses map[string]struct{}) bool {
+	_, queryAddr := addresses[ServerDBStatementAddr]
+	_, driverAddr := addresses[ServerDBTypeAddr]
 
-		sharedsec.ProcessActions(op, wafResult.Actions)
-		sharedsec.AddSecurityEvents(events, limiter, wafResult.Events)
-	})
+	return queryAddr || driverAddr
+
 }

--- a/internal/appsec/listener/sqlsec/sql.go
+++ b/internal/appsec/listener/sqlsec/sql.go
@@ -8,6 +8,7 @@ package sqlsec
 import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/emitter/sqlsec/types"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/listener"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/listener/sharedsec"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/trace"
 
@@ -26,7 +27,7 @@ func RegisterSQLListener(op dyngo.Operation, events *trace.SecurityEventsHolder,
 	}))
 }
 
-func SQLAddressesPresent(addresses map[string]struct{}) bool {
+func SQLAddressesPresent(addresses listener.AddressSet) bool {
 	_, queryAddr := addresses[ServerDBStatementAddr]
 	_, driverAddr := addresses[ServerDBTypeAddr]
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR does a simple refactor of `internal/appsec/listener` packages. Including the following:

- [x] Make a new `MakeWAFRunListener` func that simplify adding new simple addresses to call the WAF
- [x] Stop trying to register Derivatives at each WAF run.
- [x] Register RASP SQLi in gRPC   

### Motivation

Doing less copy-pastes

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
