### PR TITLE
[CI VIsibility] Fix the source path for windows

### DIFF
--- a/internal/civisibility/integrations/gotesting/testing_test.go
+++ b/internal/civisibility/integrations/gotesting/testing_test.go
@@ -329,12 +329,15 @@ func assertCommon(assert *assert.Assertions, span mocktracer.Span) {
 	assert.Contains(spanTags, constants.RuntimeName)
 	assert.Contains(spanTags, constants.GitRepositoryURL)
 	assert.Contains(spanTags, constants.GitCommitSHA)
-	assert.Contains(spanTags, constants.GitCommitMessage)
-	assert.Contains(spanTags, constants.GitCommitAuthorEmail)
-	assert.Contains(spanTags, constants.GitCommitAuthorDate)
-	assert.Contains(spanTags, constants.GitCommitCommitterEmail)
-	assert.Contains(spanTags, constants.GitCommitCommitterDate)
-	assert.Contains(spanTags, constants.GitCommitCommitterName)
+	// GitHub CI does not provide commit details
+	if spanTags[constants.CIProviderName] != "github" {
+		assert.Contains(spanTags, constants.GitCommitMessage)
+		assert.Contains(spanTags, constants.GitCommitAuthorEmail)
+		assert.Contains(spanTags, constants.GitCommitAuthorDate)
+		assert.Contains(spanTags, constants.GitCommitCommitterEmail)
+		assert.Contains(spanTags, constants.GitCommitCommitterDate)
+		assert.Contains(spanTags, constants.GitCommitCommitterName)
+	}
 	assert.Contains(spanTags, constants.CIWorkspacePath)
 }
 

--- a/internal/civisibility/utils/environmentTags.go
+++ b/internal/civisibility/utils/environmentTags.go
@@ -53,9 +53,8 @@ func GetRelativePathFromCITagsSourceRoot(path string) string {
 	if v, ok := tags[constants.CIWorkspacePath]; ok {
 		relPath, err := filepath.Rel(v, path)
 		if err == nil {
-			return relPath
+			return filepath.ToSlash(relPath)
 		}
-		relPath = filepath.ToSlash(path)
 	}
 
 	return path

--- a/internal/civisibility/utils/environmentTags.go
+++ b/internal/civisibility/utils/environmentTags.go
@@ -55,6 +55,7 @@ func GetRelativePathFromCITagsSourceRoot(path string) string {
 		if err == nil {
 			return relPath
 		}
+		relPath = filepath.ToSlash(path)
 	}
 
 	return path


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Transform the source path from the windows represantion to the unix representation.

Implications:
- Codeowners are defined in the unix represantation, and we want to match the source files with codeowners: https://github.com/DataDog/dd-trace-go/blob/0ee003663a921b30bd2f4af6b463b17fb0261145/internal/civisibility/integrations/manual_api_ddtest.go#L144
- The working directory tag in test session event for Windows will be in the unix representation: https://github.com/DataDog/dd-trace-go/blob/0ee003663a921b30bd2f4af6b463b17fb0261145/internal/civisibility/integrations/manual_api_ddtestsession.go#L54

Also, don't assert git commit details if the provider is github, because github doesn't provide those tags, example job:
https://github.com/DataDog/dd-trace-go/actions/runs/9853630340/job/27204586043

The final test for Windows: https://github.com/DataDog/dd-trace-go/actions/runs/9853630340

### Motivation
- The unit tests on Windows are failing: https://github.com/DataDog/dd-trace-go/actions/runs/9842614267/job/27172427652

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
