### PR TITLE
v2: contrib/README: add versioning and deprecation policies for contribs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.52.2 golangci-l
 
 ### Integrations
 
-Please view our contrib [README.md](v2/contrib/README.md) for information on new integrations. If you need support for a new integration, please file an issue to discuss before opening a PR.
+Please view our contrib [README.md](v2/contrib/README.md) for information on integrations. If you need support for a new integration, please file an issue to discuss before opening a PR.
 
 ### Go Modules
 

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -39,7 +39,21 @@ Each integration comes with a thorough documentation and usage examples. A good 
 ### Instrumentation telemetry
 
 Every integration is expected to import instrumentation telemetry to gather integration usage (more info [here](https://docs.datadoghq.com/tracing/configure_data_security/#telemetry-collection)). Instrumentation telemetry can be enabled by adding the following `init` function to the new contrib package:
+
 ```golang
 func init() {
     telemetry.LoadIntegration("package/import/path")
 }
+```
+
+### Version pinning
+
+We aim to keep all integrated packages to their minimum working version without known vulnerabilities (based on reported CVEs). As integrated packages have different versioning policies regarding breaking changes,
+there is no guarantee that previously pinned versions will work with next `dd-trace-go` versions.
+
+### Deprecation
+
+Integrations can be deprecated if all the following conditions are true:
+
+* The integrated package is deprecated or archived (no longer maintained).
+* A vulnerability is reported in the latest available version as CVE.


### PR DESCRIPTION
### What does this PR do?

Updates our policy on how we deprecate our contribs when upstream deprecates and there is a CVE.

### Motivation

Setting clear expectations on how we manage the contribs when the integrated package are deprecated.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
