### PR TITLE
ddtrace/mocktracer: fix SetUser & WithUserMetadata

### DIFF
--- a/ddtrace/mocktracer/mockspan.go
+++ b/ddtrace/mocktracer/mockspan.go
@@ -246,7 +246,9 @@ func (s *mockspan) SetUser(id string, opts ...tracer.UserMonitoringOption) {
 		return
 	}
 
-	var cfg tracer.UserMonitoringConfig
+	cfg := tracer.UserMonitoringConfig{
+		Metadata: make(map[string]string),
+	}
 	for _, fn := range opts {
 		fn(&cfg)
 	}
@@ -257,6 +259,10 @@ func (s *mockspan) SetUser(id string, opts ...tracer.UserMonitoringOption) {
 	root.SetTag("usr.role", cfg.Role)
 	root.SetTag("usr.scope", cfg.Scope)
 	root.SetTag("usr.session_id", cfg.SessionID)
+
+	for k, v := range cfg.Metadata {
+		root.SetTag(fmt.Sprintf("usr.%s", k), v)
+	}
 }
 
 // Root walks the span up to the root parent span and returns it.

--- a/ddtrace/mocktracer/mocktracer_test.go
+++ b/ddtrace/mocktracer/mocktracer_test.go
@@ -112,6 +112,30 @@ func TestTracerOpenSpans(t *testing.T) {
 	assert.Empty(t, mt.OpenSpans())
 }
 
+func TestTracerSetUser(t *testing.T) {
+	mt := newMockTracer()
+	span := mt.StartSpan("http.request")
+	tracer.SetUser(span, "test-user",
+		tracer.WithUserEmail("email"),
+		tracer.WithUserName("name"),
+		tracer.WithUserRole("role"),
+		tracer.WithUserScope("scope"),
+		tracer.WithUserSessionID("session"),
+		tracer.WithUserMetadata("key", "value"),
+	)
+
+	span.Finish()
+
+	finishedSpan := mt.FinishedSpans()[0]
+	assert.Equal(t, "test-user", finishedSpan.Tag("usr.id"))
+	assert.Equal(t, "email", finishedSpan.Tag("usr.email"))
+	assert.Equal(t, "name", finishedSpan.Tag("usr.name"))
+	assert.Equal(t, "role", finishedSpan.Tag("usr.role"))
+	assert.Equal(t, "scope", finishedSpan.Tag("usr.scope"))
+	assert.Equal(t, "session", finishedSpan.Tag("usr.session_id"))
+	assert.Equal(t, "value", finishedSpan.Tag("usr.key"))
+}
+
 func TestTracerReset(t *testing.T) {
 	assert := assert.New(t)
 	mt := newMockTracer()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR fixes a panic happening when using `tracer.SetUser` with the option `WithUserMetadata` on a instance of a mocktracer.

Stacktrace:
<details>

```
panic: assignment to entry in nil map [recovered]
	panic: assignment to entry in nil map

goroutine 5 [running]:
testing.tRunner.func1.2({0x10487e640, 0x104965140})
	/opt/homebrew/Cellar/go/1.22.3/libexec/src/testing/testing.go:1631 +0x1c4
testing.tRunner.func1()
	/opt/homebrew/Cellar/go/1.22.3/libexec/src/testing/testing.go:1634 +0x33c
panic({0x10487e640?, 0x104965140?})
	/opt/homebrew/Cellar/go/1.22.3/libexec/src/runtime/panic.go:770 +0x124
github.com/DataDog/dd-source/domains/aaa/shared/libs/go/authctxhttp.Authenticate.func1.1.WithUserMetadata.4(0x1400008db18?)
	/Users/kaitlyn.paglia/go/pkg/mod/gopkg.in/!data!dog/dd-trace-go.v1@v1.66.0-rc.1/ddtrace/tracer/option.go:1326 +0x40
gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer.(*mockspan).SetUser(0x104de8fb0?, {0x14000354154, 0x4}, {0x1400007c2e0, 0x3, 0x14000358000?})
	/Users/kaitlyn.paglia/go/pkg/mod/gopkg.in/!data!dog/dd-trace-go.v1@v1.66.0-rc.1/ddtrace/mocktracer/mockspan.go:251 +0x70
gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.SetUser({0x104971c98?, 0x14000358000?}, {0x14000354154?, 0x4?}, {0x1400007c2e0?, 0x3?, 0x4?})
	/Users/kaitlyn.paglia/go/pkg/mod/gopkg.in/!data!dog/dd-trace-go.v1@v1.66.0-rc.1/ddtrace/tracer/tracer.go:224 +0x7c
gopkg.in/DataDog/dd-trace-go.v1/appsec.SetUser({0x10496f0c8, 0x1400035d050}, {0x14000354154, 0x4}, {0x1400007c2e0, 0x3, 0x4})
	/Users/kaitlyn.paglia/go/pkg/mod/gopkg.in/!data!dog/dd-trace-go.v1@v1.66.0-rc.1/appsec/appsec.go:58 +0x54
github.com/DataDog/dd-source/domains/aaa/shared/libs/go/authctxhttp.Authenticate.func1.1({0x10496d6c8, 0x14000346040}, 0x14000422120)
	/Users/kaitlyn.paglia/go/src/github.com/DataDog/dd-source/domains/aaa/shared/libs/go/authctxhttp/authctxhttp.go:337 +0xc18
net/http.HandlerFunc.ServeHTTP(0x104967bd8?, {0x10496d6c8?, 0x14000346040?}, 0x1046c8f17?)
	/opt/homebrew/Cellar/go/1.22.3/libexec/src/net/http/server.go:2166 +0x38
github.com/DataDog/dd-source/domains/aaa/shared/libs/go/authctxhttp.TestAppSecBlocking(0x14000111ba0)
	/Users/kaitlyn.paglia/go/src/github.com/DataDog/dd-source/domains/aaa/shared/libs/go/authctxhttp/authctxhttp_test.go:290 +0x3a4
testing.tRunner(0x14000111ba0, 0x104961ec0)
	/opt/homebrew/Cellar/go/1.22.3/libexec/src/testing/testing.go:1689 +0xec
created by testing.(*T).Run in goroutine 1
	/opt/homebrew/Cellar/go/1.22.3/libexec/src/testing/testing.go:1742 +0x318
FAIL	github.com/DataDog/dd-source/domains/aaa/shared/libs/go/authctxhttp	0.642s
FAIL
```

</details>

### Motivation

Happened in dd-source on a rapid service testing `appsec.SetUser`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
