### PR TITLE
Add instruction how to update Go version for macrobenchmarks

### DIFF
--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -38,122 +38,132 @@ variables:
   # benchmarks get changed to run on every PR)
   allow_failure: true
 
-go122-baseline:
+
+#
+# Please read next before updating Go version in this file!
+#
+# In order to update Go version, you need to include it in benchmarks Docker image first:
+# 1. Update version in Dockerfile https://github.com/DataDog/benchmarking-platform/blob/go/go-prof-app/container/Dockerfile#L5
+# 2. Rebuild image in Gitlab CI (build-images CI job in https://gitlab.ddbuild.io/DataDog/apm-reliability/benchmarking-platform/-/pipelines?page=1&scope=all&ref=go%2Fgo-prof-app)
+#
+
+.go121-benchmarks:
   extends: .benchmarks
+  variables:
+    GO_VERSION: "1.21.12"
+
+.go122-benchmarks:
+  extends: .benchmarks
+  variables:
+    GO_VERSION: "1.22.5"
+
+#
+# Specific macrobenchmark configurations are below
+
+go122-baseline:
+  extends: .go122-benchmarks
   variables:
     ENABLE_DDPROF: "false"
     ENABLE_TRACING: "false"
     ENABLE_PROFILING: "false"
     ENABLE_APPSEC: "false"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.22.5"
 
 go122-only-trace:
-  extends: .benchmarks
+  extends: .go122-benchmarks
   variables:
     ENABLE_DDPROF: "false"
     ENABLE_TRACING: "true"
     ENABLE_PROFILING: "false"
     ENABLE_APPSEC: "false"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.22.5"
 
 go122-only-profile:
-  extends: .benchmarks
+  extends: .go122-benchmarks
   variables:
     ENABLE_DDPROF: "false"
     ENABLE_TRACING: "false"
     ENABLE_PROFILING: "true"
     ENABLE_APPSEC: "false"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.22.5"
 
 go122-profile-trace:
-  extends: .benchmarks
+  extends: .go122-benchmarks
   variables:
     ENABLE_DDPROF: "false"
     ENABLE_TRACING: "true"
     ENABLE_PROFILING: "true"
     ENABLE_APPSEC: "false"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.22.5"
 
 go122-trace-asm:
-  extends: .benchmarks
+  extends: .go122-benchmarks
   variables:
     ENABLE_DDPROF: "false"
     ENABLE_TRACING: "true"
     ENABLE_PROFILING: "false"
     ENABLE_APPSEC: "true"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.22.5"
 
 go122-profile-trace-asm:
-  extends: .benchmarks
+  extends: .go122-benchmarks
   variables:
     ENABLE_DDPROF: "false"
     ENABLE_TRACING: "true"
     ENABLE_PROFILING: "true"
     ENABLE_APPSEC: "true"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.22.5"
 
 go121-baseline:
-  extends: .benchmarks
+  extends: .go121-benchmarks
   variables:
     ENABLE_DDPROF: "false"
     ENABLE_TRACING: "false"
     ENABLE_PROFILING: "false"
     ENABLE_APPSEC: "false"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.21.12"
 
 go121-only-trace:
-  extends: .benchmarks
+  extends: .go121-benchmarks
   variables:
     ENABLE_DDPROF: "false"
     ENABLE_TRACING: "true"
     ENABLE_PROFILING: "false"
     ENABLE_APPSEC: "false"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.21.12"
 
 go121-only-profile:
-  extends: .benchmarks
+  extends: .go121-benchmarks
   variables:
     ENABLE_DDPROF: "false"
     ENABLE_TRACING: "false"
     ENABLE_PROFILING: "true"
     ENABLE_APPSEC: "false"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.21.12"
 
 go121-profile-trace:
-  extends: .benchmarks
+  extends: .go121-benchmarks
   variables:
     ENABLE_DDPROF: "false"
     ENABLE_TRACING: "true"
     ENABLE_PROFILING: "true"
     ENABLE_APPSEC: "false"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.21.12"
 
 go121-trace-asm:
-  extends: .benchmarks
+  extends: .go121-benchmarks
   variables:
     ENABLE_DDPROF: "false"
     ENABLE_TRACING: "true"
     ENABLE_PROFILING: "false"
     ENABLE_APPSEC: "true"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.21.12"
 
 go121-profile-trace-asm:
-  extends: .benchmarks
+  extends: .go121-benchmarks
   variables:
     ENABLE_DDPROF: "false"
     ENABLE_TRACING: "true"
     ENABLE_PROFILING: "true"
     ENABLE_APPSEC: "true"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
-    GO_VERSION: "1.21.12"

--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -38,6 +38,15 @@ variables:
   # benchmarks get changed to run on every PR)
   allow_failure: true
 
+  retry:
+    max: 2
+    when:
+      - unknown_failure
+      - data_integrity_failure
+      - runner_system_failure
+      - scheduler_failure
+      - api_failure
+
 
 #
 # Please read next before updating Go version in this file!


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

1. Adds instruction how to update Go version for macrobenchmarks.
2. Adds retries for macrobenchmarks that failed due to internal Gitlab errors (which are expected to happen 1 in ca. 900 runs on avg).

### Motivation

Go macrobenchmarks were broken since last Thursday due to https://github.com/DataDog/dd-trace-go/commit/e8dc9746d65d857fe557a7bc438939d110373c15, because Docker image was not updated  with newer Go versions.

I've already updated the image in background, so now the pipeline is fixed.

This PR adds more specific instructions on updating Go versions.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
