### PR TITLE
ddtrace/tracer: optimize textmap.composeTracestate

### DIFF
--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -609,7 +609,7 @@ func setPeerServiceFromSource(s *span) string {
 
 const hexEncodingDigits = "0123456789abcdef"
 
-// spanIDHexEncoded returns the hex encoded string of the span ID
+// spanIDHexEncoded returns the hex encoded string of the given span ID `u`
 // with the given padding.
 //
 // Code is borrowed from `fmt.fmtInteger` in the standard library.

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -606,3 +606,26 @@ func setPeerServiceFromSource(s *span) string {
 	}
 	return ""
 }
+
+const hexEncodingDigits = "0123456789abcdef"
+
+func spanIDHexEncoded(u uint64, padding int) string {
+	var intbuf [68]byte
+	buf := intbuf[0:]
+	if padding > 68 {
+		buf = make([]byte, padding)
+	}
+	i := len(buf)
+	for u >= 16 {
+		i--
+		buf[i] = hexEncodingDigits[u&0xF]
+		u >>= 4
+	}
+	i--
+	buf[i] = hexEncodingDigits[u]
+	for i > 0 && padding > len(buf)-i {
+		i--
+		buf[i] = '0'
+	}
+	return string(buf[i:])
+}

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -609,12 +609,19 @@ func setPeerServiceFromSource(s *span) string {
 
 const hexEncodingDigits = "0123456789abcdef"
 
+// spanIDHexEncoded returns the hex encoded string of the span ID
+// with the given padding.
+//
+// Code is borrowed from `fmt.fmtInteger` in the standard library.
 func spanIDHexEncoded(u uint64, padding int) string {
+	// The allocated intbuf with a capacity of 68 bytes
+	// is large enough for integer formatting.
 	var intbuf [68]byte
 	buf := intbuf[0:]
 	if padding > 68 {
 		buf = make([]byte, padding)
 	}
+	// Because printing is easier right-to-left: format u into buf, ending at buf[i].
 	i := len(buf)
 	for u >= 16 {
 		i--

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -869,6 +869,11 @@ func TestSpanIDHexEncoded(t *testing.T) {
 
 	sid = spanIDHexEncoded(math.MaxInt64, 128)
 	assert.Equal(t, fmt.Sprintf("%0128x", math.MaxInt64), sid)
+
+	sid = spanIDHexEncoded(math.MaxUint64, -16)
+	assert.Equal(t, "ffffffffffffffff", sid)
+	assert.Equal(t, spanIDHexEncoded(math.MaxUint64, 0), sid)
+	assert.Equal(t, spanIDHexEncoded(math.MaxUint64, 16), sid)
 }
 
 func BenchmarkSpanIDHexEncoded(b *testing.B) {
@@ -884,7 +889,15 @@ func BenchmarkSpanIDSprintf(b *testing.B) {
 }
 
 func FuzzSpanIDHexEncoded(f *testing.F) {
+	f.Add(-99, uint64(0))
+	f.Add(16, uint64(1))
+	f.Add(32, uint64(16))
+	f.Add(0, uint64(math.MaxUint64))
 	f.Fuzz(func(t *testing.T, p int, v uint64) {
+		// We don't support negative padding nor right-padding.
+		if p < 0 {
+			return
+		}
 		expected := fmt.Sprintf(
 			fmt.Sprintf("%%0%dx", p),
 			v,

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -8,6 +8,7 @@ package tracer
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -854,4 +855,43 @@ func TestTraceIDEmpty(t *testing.T) {
 	tid := traceID([16]byte{})
 	tid[15] = 5
 	assert.False(t, tid.Empty())
+}
+
+func TestSpanIDHexEncoded(t *testing.T) {
+	sid := spanIDHexEncoded(5, 16)
+	assert.Equal(t, fmt.Sprintf("%016x", 5), sid)
+
+	sid = spanIDHexEncoded(5, 32)
+	assert.Equal(t, fmt.Sprintf("%032x", 5), sid)
+
+	sid = spanIDHexEncoded(math.MaxInt64, 68)
+	assert.Equal(t, fmt.Sprintf("%068x", math.MaxInt64), sid)
+
+	sid = spanIDHexEncoded(math.MaxInt64, 128)
+	assert.Equal(t, fmt.Sprintf("%0128x", math.MaxInt64), sid)
+}
+
+func BenchmarkSpanIDHexEncoded(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		_ = spanIDHexEncoded(32, 16)
+	}
+}
+
+func BenchmarkSpanIDSprintf(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		_ = fmt.Sprintf("%016x", 32)
+	}
+}
+
+func FuzzSpanIDHexEncoded(f *testing.F) {
+	f.Fuzz(func(t *testing.T, p int, v uint64) {
+		expected := fmt.Sprintf(
+			fmt.Sprintf("%%0%dx", p),
+			v,
+		)
+		actual := spanIDHexEncoded(v, p)
+		if actual != expected {
+			t.Fatalf("expected %s, got %s", expected, actual)
+		}
+	})
 }

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -949,7 +949,7 @@ func composeTracestate(ctx *spanContext, priority int, oldState string) string {
 	// to allow the backend to reparent orphaned spans if necessary
 	if !ctx.isRemote {
 		b.WriteString(";p:")
-		b.WriteString(fmt.Sprintf("%016x", ctx.SpanID()))
+		b.WriteString(spanIDHexEncoded(ctx.SpanID(), 16))
 	} else if ctx.reparentID != "" && ctx.reparentID != "0000000000000000" {
 		b.WriteString(";p:")
 		b.WriteString(ctx.reparentID)

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -2429,3 +2429,17 @@ func TestMalformedTID(t *testing.T) {
 		assert.Equal(t, "640cfd8d00000000", root.Meta[keyTraceID128])
 	})
 }
+
+func BenchmarkComposeTracestate(b *testing.B) {
+	ctx := new(spanContext)
+	ctx.trace = newTrace()
+	ctx.origin = "synthetics"
+	ctx.trace.setPropagatingTag("_dd.p.keyOne", "json")
+	ctx.trace.setPropagatingTag("_dd.p.KeyTwo", "123123")
+	ctx.trace.setPropagatingTag("_dd.p.table", "chair")
+	ctx.isRemote = false
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		composeTracestate(ctx, 1, "s:-2;o:synthetics___web")
+	}
+}

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -2271,8 +2271,8 @@ func FuzzComposeTracestate(f *testing.F) {
 		tags := map[string]string{key1: val1, key2: val2, key3: val3}
 		totalLen := 0
 		for key, val := range tags {
-			k := "_dd.p." + keyRgx.ReplaceAllString(key, "_")
-			v := valueRgx.ReplaceAllString(val, "_")
+			k := "_dd.p." + strings.Map(keyDisallowedFn, key)
+			v := strings.Map(valueDisallowedFn, val)
 			if strings.ContainsAny(k, ":;") {
 				t.Skipf("Skipping invalid tags")
 			}

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -2482,9 +2482,10 @@ func FuzzStringMutator(f *testing.F) {
 	rx := regexp.MustCompile(",|~|;|[^\\x21-\\x7E]+")
 	f.Add("a,b;c~~~~d;")
 	f.Add("a,b👍👍👍;c~d👍;")
+	f.Add("=")
 	f.Fuzz(func(t *testing.T, input string) {
 		sm := &stringMutator{}
-		expected := rx.ReplaceAllString(input, "_")
+		expected := strings.ReplaceAll(rx.ReplaceAllString(input, "_"), "=", "~")
 		actual := sm.Mutate(originDisallowedFn, input)
 		if expected != actual {
 			t.Fatalf("expected: %s, actual: %s", expected, actual)

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -2268,11 +2268,12 @@ func FuzzComposeTracestate(f *testing.F) {
 		recvCtx := new(spanContext)
 		recvCtx.trace = newTrace()
 
+		sm := &stringMutator{}
 		tags := map[string]string{key1: val1, key2: val2, key3: val3}
 		totalLen := 0
 		for key, val := range tags {
-			k := "_dd.p." + strings.Map(keyDisallowedFn, key)
-			v := strings.Map(valueDisallowedFn, val)
+			k := "_dd.p." + sm.Mutate(keyDisallowedFn, key)
+			v := sm.Mutate(valueDisallowedFn, val)
 			if strings.ContainsAny(k, ":;") {
 				t.Skipf("Skipping invalid tags")
 			}

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -2476,6 +2476,11 @@ func TestStringMutator(t *testing.T) {
 			assert.Equal(t, expected, actual)
 		})
 	}
+	t.Run("raw string", func(t *testing.T) {
+		expected := "a_b_c____d_~"
+		actual := sm.Mutate(originDisallowedFn, "a,b;c~~~~d;=")
+		assert.Equal(t, expected, actual)
+	})
 }
 
 func FuzzStringMutator(f *testing.F) {


### PR DESCRIPTION
### What does this PR do?

Replaces the usage of `fmt.Sprintf` and `regex` calls in `textmap.composeTracestate` to reduce allocations and CPU consumption.

### Motivation

This function has been reported as a significant contributor of tracer overhead.

Original benchmark results for the worst scenario:

```
BenchmarkComposeTracestate-10       448386          2429 ns/op         589 B/op         36 allocs/op
```

Benchmark results after removing all `fmt.Sprintf` usages:

```
BenchmarkComposeTracestate-10       508797          1976 ns/op         403 B/op         24 allocs/op
```

Benchmark results after replacing `regex` usages with tailored code:

```
BenchmarkComposeTracestate-10      1749620           675.3 ns/op       240 B/op         10 allocs/op
```

Benchmark results evolving the tailored code to a reusable state machine wrapped in a struct:

```
BenchmarkComposeTracestate-10    	 2625484	       444.6 ns/op	     160 B/op	       3 allocs/op
```

Benchmark results after replacing `fmt.Sprintf("%016x", spanID)` with a zero-allocation hand-coded hex encoding function:

```
BenchmarkComposeTracestate-10    	 3060886	       401.3 ns/op	     144 B/op	       2 allocs/op
```

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
