### PR TITLE
ddtrace/tracer: update the expected telemetry tags for OTel env-var mapping

### DIFF
--- a/ddtrace/tracer/otel_dd_mappings.go
+++ b/ddtrace/tracer/otel_dd_mappings.go
@@ -89,16 +89,18 @@ func getDDorOtelConfig(configName string) string {
 
 	val := os.Getenv(config.dd)
 	if otVal := os.Getenv(config.ot); otVal != "" {
-		ddPrefix := "config.datadog:"
-		otelPrefix := "config.opentelemetry:"
+		ddPrefix := "config_datadog:"
+		otelPrefix := "config_opentelemetry:"
 		if val != "" {
 			log.Warn("Both %v and %v are set, using %v=%v", config.ot, config.dd, config.dd, val)
-			telemetry.GlobalClient.Count(telemetry.NamespaceTracers, "otel.env.hiding", 1.0, []string{ddPrefix + config.dd, otelPrefix + config.ot}, true)
+			telemetryTags := []string{ddPrefix + strings.ToLower(config.dd), otelPrefix + strings.ToLower(config.ot)}
+			telemetry.GlobalClient.Count(telemetry.NamespaceTracers, "otel.env.hiding", 1.0, telemetryTags, true)
 		} else {
 			v, err := config.remapper(otVal)
 			if err != nil {
 				log.Warn(err.Error())
-				telemetry.GlobalClient.Count(telemetry.NamespaceTracers, "otel.env.invalid", 1.0, []string{ddPrefix + config.dd, otelPrefix + config.ot}, true)
+				telemetryTags := []string{ddPrefix + strings.ToLower(config.dd), otelPrefix + strings.ToLower(config.ot)}
+				telemetry.GlobalClient.Count(telemetry.NamespaceTracers, "otel.env.invalid", 1.0, telemetryTags, true)
 			}
 			val = v
 		}

--- a/ddtrace/tracer/otel_dd_mappings_test.go
+++ b/ddtrace/tracer/otel_dd_mappings_test.go
@@ -36,7 +36,7 @@ func TestAssessSource(t *testing.T) {
 		t.Setenv("OTEL_SERVICE_NAME", "123")
 		v := getDDorOtelConfig("service")
 		assert.Equal(t, "abc", v)
-		telemetryClient.AssertCalled(t, "Count", telemetry.NamespaceTracers, "otel.env.hiding", 1.0, []string{"config.datadog:DD_SERVICE", "config.opentelemetry:OTEL_SERVICE_NAME"}, true)
+		telemetryClient.AssertCalled(t, "Count", telemetry.NamespaceTracers, "otel.env.hiding", 1.0, []string{"config_datadog:dd_service", "config_opentelemetry:otel_service_name"}, true)
 	})
 	t.Run("invalid-ot", func(t *testing.T) {
 		telemetryClient := new(telemetrytest.MockClient)
@@ -44,6 +44,6 @@ func TestAssessSource(t *testing.T) {
 		t.Setenv("OTEL_LOG_LEVEL", "nonesense")
 		v := getDDorOtelConfig("debugMode")
 		assert.Equal(t, "", v)
-		telemetryClient.AssertCalled(t, "Count", telemetry.NamespaceTracers, "otel.env.invalid", 1.0, []string{"config.datadog:DD_TRACE_DEBUG", "config.opentelemetry:OTEL_LOG_LEVEL"}, true)
+		telemetryClient.AssertCalled(t, "Count", telemetry.NamespaceTracers, "otel.env.invalid", 1.0, []string{"config_datadog:dd_trace_debug", "config_opentelemetry:otel_log_level"}, true)
 	})
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

The expected telemetry tags when reporting OTel env-var mapping issues now use snake-case:
```
 config.datadog       -> config_datadog
 config.opentelemetry -> config_opentelemetry
```
The expected tag values should also be lower-case.

### Motivation

The [RFC](https://docs.google.com/document/d/1gtdjhsMSIvuTnM9E4EreI7oZ-bAUoAxkhXX0-fBvdDY/edit?usp=sharing) has been revised since #2715

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
