### PR TITLE
ddtrace/tracer: noDebugStack config reports to telemetry under distinct key debug_stack_enabled

### DIFF
--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -48,7 +48,7 @@ func startTelemetry(c *config) {
 		{Name: "agent_hostname", Value: c.hostname},
 		{Name: "runtime_metrics_enabled", Value: c.runtimeMetrics},
 		{Name: "dogstatsd_addr", Value: c.dogstatsdAddr},
-		{Name: "trace_debug_enabled", Value: !c.noDebugStack},
+		{Name: "debug_stack_disabled", Value: c.noDebugStack},
 		{Name: "profiling_hotspots_enabled", Value: c.profilerHotspots},
 		{Name: "profiling_endpoints_enabled", Value: c.profilerEndpoints},
 		{Name: "trace_span_attribute_schema", Value: c.spanAttributeSchemaVersion},

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -48,7 +48,7 @@ func startTelemetry(c *config) {
 		{Name: "agent_hostname", Value: c.hostname},
 		{Name: "runtime_metrics_enabled", Value: c.runtimeMetrics},
 		{Name: "dogstatsd_addr", Value: c.dogstatsdAddr},
-		{Name: "debug_stack_disabled", Value: c.noDebugStack},
+		{Name: "debug_stack_enabled", Value: !c.noDebugStack},
 		{Name: "profiling_hotspots_enabled", Value: c.profilerHotspots},
 		{Name: "profiling_endpoints_enabled", Value: c.profilerEndpoints},
 		{Name: "trace_span_attribute_schema", Value: c.spanAttributeSchemaVersion},

--- a/ddtrace/tracer/telemetry_test.go
+++ b/ddtrace/tracer/telemetry_test.go
@@ -44,7 +44,6 @@ func TestTelemetryEnabled(t *testing.T) {
 		assert.True(t, telemetryClient.Started)
 		telemetryClient.AssertNumberOfCalls(t, "ApplyOps", 1)
 		telemetry.Check(t, telemetryClient.Configuration, "trace_debug_enabled", true)
-		telemetry.Check(t, telemetryClient.Configuration, "trace_debug_enabled", true)
 		telemetry.Check(t, telemetryClient.Configuration, "service", "test-serv")
 		telemetry.Check(t, telemetryClient.Configuration, "env", "test-env")
 		telemetry.Check(t, telemetryClient.Configuration, "runtime_metrics_enabled", true)

--- a/ddtrace/tracer/telemetry_test.go
+++ b/ddtrace/tracer/telemetry_test.go
@@ -23,12 +23,13 @@ func TestTelemetryEnabled(t *testing.T) {
 		defer telemetry.MockGlobalClient(telemetryClient)()
 
 		Start(
-			WithDebugStack(false),
+			WithDebugMode(true),
 			WithService("test-serv"),
 			WithEnv("test-env"),
 			WithRuntimeMetrics(),
 			WithPeerServiceMapping("key", "val"),
 			WithPeerServiceDefaults(true),
+			WithDebugStack(false),
 			WithHeaderTags([]string{"key:val", "key2:val2"}),
 			WithSamplingRules(
 				[]SamplingRule{TagsResourceRule(
@@ -42,7 +43,8 @@ func TestTelemetryEnabled(t *testing.T) {
 
 		assert.True(t, telemetryClient.Started)
 		telemetryClient.AssertNumberOfCalls(t, "ApplyOps", 1)
-		telemetry.Check(t, telemetryClient.Configuration, "trace_debug_enabled", false)
+		telemetry.Check(t, telemetryClient.Configuration, "trace_debug_enabled", true)
+		telemetry.Check(t, telemetryClient.Configuration, "trace_debug_enabled", true)
 		telemetry.Check(t, telemetryClient.Configuration, "service", "test-serv")
 		telemetry.Check(t, telemetryClient.Configuration, "env", "test-env")
 		telemetry.Check(t, telemetryClient.Configuration, "runtime_metrics_enabled", true)
@@ -51,6 +53,7 @@ func TestTelemetryEnabled(t *testing.T) {
 		telemetry.Check(t, telemetryClient.Configuration, "trace_span_attribute_schema", 0)
 		telemetry.Check(t, telemetryClient.Configuration, "trace_peer_service_defaults_enabled", true)
 		telemetry.Check(t, telemetryClient.Configuration, "trace_peer_service_mapping", "key:val")
+		telemetry.Check(t, telemetryClient.Configuration, "debug_stack_enabled", false)
 		telemetry.Check(t, telemetryClient.Configuration, "orchestrion_enabled", false)
 		telemetry.Check(t, telemetryClient.Configuration, "trace_sample_rate", nil) // default value is NaN which is sanitized to nil
 		telemetry.Check(t, telemetryClient.Configuration, "trace_header_tags", "key:val,key2:val2")


### PR DESCRIPTION
### What does this PR do?
The `noDebugStack` tracer configuration now reports telemetry under the key `debug_stack_enabled`.
Note: New `debug_stack_enabled` field added to telemetry backend here: https://github.com/DataDog/dd-go/pull/143865

### Motivation
Prior to this change, the `noDebugStack` config was incorrectly reporting telemetry under the key `trace_debug_enabled`.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [n/a] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [n/a] There is a benchmark for any new code, or changes to existing code.
- [n/a ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [n/a] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
