### PR TITLE
contrib/hashicorp/vault: add NewClient function for Orchestrion integration

### DIFF
--- a/contrib/hashicorp/vault/vault.go
+++ b/contrib/hashicorp/vault/vault.go
@@ -94,6 +94,8 @@ func WrapHTTPClient(c *http.Client, opts ...Option) *http.Client {
 	return c
 }
 
+// NewClient returns an api.Client for the Vault API. A set of options
+// can be passed in for further configuration.
 func NewClient(c *api.Config, opts ...Option) (*api.Client, error) {
 	if c.HttpClient == nil {
 		c.HttpClient = NewHTTPClient(opts...)

--- a/contrib/hashicorp/vault/vault.go
+++ b/contrib/hashicorp/vault/vault.go
@@ -93,3 +93,13 @@ func WrapHTTPClient(c *http.Client, opts ...Option) *http.Client {
 	)
 	return c
 }
+
+func NewClient(c *api.Config, opts ...Option) (*api.Client, error) {
+	if c.HttpClient == nil {
+		c.HttpClient = NewHTTPClient(opts...)
+	} else {
+
+		c.HttpClient = WrapHTTPClient(c.HttpClient, opts...)
+	}
+	return api.NewClient(c)
+}

--- a/contrib/hashicorp/vault/vault.go
+++ b/contrib/hashicorp/vault/vault.go
@@ -100,7 +100,6 @@ func NewClient(c *api.Config, opts ...Option) (*api.Client, error) {
 	if c.HttpClient == nil {
 		c.HttpClient = NewHTTPClient(opts...)
 	} else {
-
 		c.HttpClient = WrapHTTPClient(c.HttpClient, opts...)
 	}
 	return api.NewClient(c)

--- a/contrib/hashicorp/vault/vault_test.go
+++ b/contrib/hashicorp/vault/vault_test.go
@@ -97,6 +97,46 @@ func TestWrapHTTPClient(t *testing.T) {
 	testMountReadWrite(client, t)
 }
 
+func TestNewClient(t *testing.T) {
+	ts, cleanup := setupServer(t)
+	defer cleanup()
+
+	testCases := []struct {
+		name   string
+		client *http.Client
+	}{
+		{
+			name:   "nil HTTP client",
+			client: nil,
+		},
+		{
+			name:   "present HTTP client",
+			client: http.DefaultClient,
+		},
+		{
+			name:   "already instrumented HTTP client",
+			client: NewHTTPClient(),
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			config := &api.Config{
+				HttpClient: tc.client,
+				Address:    ts.URL,
+			}
+			client, err := NewClient(config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			testMountReadWrite(client, t)
+		})
+	}
+}
+
 // mountKV mounts the K/V engine on secretMountPath and returns a function to unmount it.
 // See: https://www.vaultproject.io/docs/secrets/
 func mountKV(c *api.Client, t *testing.T) func() {


### PR DESCRIPTION
### What does this PR do?

Adds a new function `NewClient` that acts as a entrypoint for Orchestrion instrumentation. It's the simpler way to detect if the provided `api.Config` has a given HTTP client or not.

The underlying `httptrace` instrumentation detects if the HTTP client's transport is already instrumented.

### Motivation

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
