### PR TITLE
ddtracer/tracer: fix appending 'tracer_version' to the statsd tags

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -750,7 +750,7 @@ func statsTags(c *config) []string {
 		}
 	}
 	globalconfig.SetStatsTags(tags)
-	tags = append(tags, version.Tag)
+	tags = append(tags, "tracer_version:"+version.Tag)
 	if c.serviceName != "" {
 		tags = append(tags, "service:"+c.serviceName)
 	}

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -1287,6 +1287,7 @@ func TestStatsTags(t *testing.T) {
 	assert.Contains(tags, "service:serviceName")
 	assert.Contains(tags, "env:envName")
 	assert.Contains(tags, "host:hostName")
+	assert.Contains(tags, "tracer_version:"+version.Tag)
 
 	st := globalconfig.StatsTags()
 	// all of the tracer tags except `service` and `version` should be on `st`
@@ -1295,7 +1296,7 @@ func TestStatsTags(t *testing.T) {
 	assert.Contains(st, "host:hostName")
 	assert.Contains(st, "lang:go")
 	assert.Contains(st, "lang_version:"+runtime.Version())
-	assert.NotContains(st, "version:"+version.Tag)
+	assert.NotContains(st, "tracer_version:"+version.Tag)
 	assert.NotContains(st, "service:serviceName")
 }
 


### PR DESCRIPTION
### What does this PR do?

Cherry-picks #2784 from release-v1.66.x to main. That PR fixed the tracer's
statsd configuration to properly tag internal metrics with the tracer version.

### Motivation

We use these metrics to track release candidate behavior for internal services
during release dogfooding.
