### PR TITLE
contrib/gocql/gocql: implement observer api based tracing

### DIFF
--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -85,6 +85,9 @@ jobs:
         image: cassandra:3.11
         env:
           JVM_OPTS: "-Xms750m -Xmx750m"
+          CASSANDRA_CLUSTER_NAME: "dd-trace-go-test-cluster"
+          CASSANDRA_DC: "dd-trace-go-test-datacenter"
+          CASSANDRA_ENDPOINT_SNITCH: "GossipingPropertyFileSnitch"
         ports:
           - 9042:9042
       mysql:

--- a/contrib/gocql/gocql/example_test.go
+++ b/contrib/gocql/gocql/example_test.go
@@ -7,15 +7,18 @@ package gocql_test
 
 import (
 	"context"
+	"log"
+
+	"github.com/gocql/gocql"
 
 	gocqltrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/gocql/gocql"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
-func Example() {
+func ExampleNewCluster() {
 	// Initialise a wrapped Cassandra session and create a query.
-	cluster := gocqltrace.NewCluster([]string{"127.0.0.1"}, gocqltrace.WithServiceName("ServiceName"))
+	cluster := gocqltrace.NewCluster([]string{"127.0.0.1:9043"}, gocqltrace.WithServiceName("ServiceName"))
 	session, _ := cluster.CreateSession()
 	query := session.Query("CREATE KEYSPACE if not exists trace WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor': 1}")
 
@@ -33,4 +36,90 @@ func Example() {
 
 	// Execute your query as usual
 	query.Exec()
+}
+
+func ExampleNewTracedSession() {
+	cluster := gocql.NewCluster("127.0.0.1:9042")
+	cluster.Keyspace = "my-keyspace"
+
+	// Create a new traced session using any number of options
+	session, err := gocqltrace.NewTracedSession(cluster, gocqltrace.WithServiceName("ServiceName"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	query := session.Query("CREATE KEYSPACE if not exists trace WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor': 1}")
+
+	// Use context to pass information down the call chain
+	_, ctx := tracer.StartSpanFromContext(context.Background(), "parent.request",
+		tracer.SpanType(ext.SpanTypeCassandra),
+		tracer.ServiceName("web"),
+		tracer.ResourceName("/home"),
+	)
+	query.WithContext(ctx)
+
+	// Finally, execute the query
+	if err := query.Exec(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func ExampleTraceQuery() {
+	cluster := gocql.NewCluster("127.0.0.1:9042")
+	cluster.Keyspace = "my-keyspace"
+
+	// Create a new regular gocql session
+	session, err := cluster.CreateSession()
+	if err != nil {
+		log.Fatal(err)
+	}
+	query := session.Query("CREATE KEYSPACE if not exists trace WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor': 1}")
+
+	// Use context to pass information down the call chain
+	_, ctx := tracer.StartSpanFromContext(context.Background(), "parent.request",
+		tracer.SpanType(ext.SpanTypeCassandra),
+		tracer.ServiceName("web"),
+		tracer.ResourceName("/home"),
+	)
+	query.WithContext(ctx)
+
+	// Enable tracing this query only.
+	query = gocqltrace.TraceQuery(query, cluster, gocqltrace.WithServiceName("ServiceName"))
+
+	// Finally, execute the query
+	if err := query.Exec(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func ExampleTraceBatch() {
+	cluster := gocql.NewCluster("127.0.0.1:9042")
+	cluster.Keyspace = "my-keyspace"
+
+	// Create a new regular gocql session
+	session, err := cluster.CreateSession()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create a new regular gocql batch and add some queries to it
+	stmt := "INSERT INTO trace.person (name, age, description) VALUES (?, ?, ?)"
+	batch := session.NewBatch(gocql.UnloggedBatch)
+	batch.Query(stmt, "Kate", 80, "Cassandra's sister running in kubernetes")
+	batch.Query(stmt, "Lucas", 60, "Another person")
+
+	// Use context to pass information down the call chain
+	_, ctx := tracer.StartSpanFromContext(context.Background(), "parent.request",
+		tracer.SpanType(ext.SpanTypeCassandra),
+		tracer.ServiceName("web"),
+		tracer.ResourceName("/home"),
+	)
+	batch.WithContext(ctx)
+
+	// Enable tracing this batch only
+	batch = gocqltrace.TraceBatch(batch, cluster, gocqltrace.WithServiceName("ServiceName"))
+
+	// Finally, execute the batch
+	if err := session.ExecuteBatch(batch); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/contrib/gocql/gocql/gocql.go
+++ b/contrib/gocql/gocql/gocql.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
@@ -30,6 +31,9 @@ func init() {
 }
 
 // ClusterConfig embeds gocql.ClusterConfig and keeps information relevant to tracing.
+//
+// Deprecated: use the Observer based methods NewTracedSession, TraceQuery or TraceBatch instead, which returns
+// native gocql types instead of wrapped types.
 type ClusterConfig struct {
 	*gocql.ClusterConfig
 	hosts []string
@@ -37,6 +41,9 @@ type ClusterConfig struct {
 }
 
 // NewCluster calls gocql.NewCluster and returns a wrapped instrumented version of it.
+//
+// Deprecated: use the Observer based methods NewTracedSession, TraceQuery or TraceBatch instead, which returns
+// native gocql types instead of wrapped types.
 func NewCluster(hosts []string, opts ...WrapOption) *ClusterConfig {
 	return &ClusterConfig{
 		ClusterConfig: gocql.NewCluster(hosts...),
@@ -46,6 +53,9 @@ func NewCluster(hosts []string, opts ...WrapOption) *ClusterConfig {
 }
 
 // Session embeds gocql.Session and keeps information relevant to tracing.
+//
+// Deprecated: use the Observer based methods NewTracedSession, TraceQuery or TraceBatch instead, which returns
+// native gocql types instead of wrapped types.
 type Session struct {
 	*gocql.Session
 	hosts []string
@@ -66,10 +76,13 @@ func (c *ClusterConfig) CreateSession() (*Session, error) {
 }
 
 // Query inherits from gocql.Query, it keeps the tracer and the context.
+//
+// Deprecated: use the Observer based methods NewTracedSession, TraceQuery or TraceBatch instead, which returns
+// native gocql types instead of wrapped types.
 type Query struct {
 	*gocql.Query
-	*params
-	ctx context.Context
+	params params
+	ctx    context.Context
 }
 
 // Query calls the underlying gocql.Session's Query method and returns a new Query augmented with tracing.
@@ -79,13 +92,19 @@ func (s *Session) Query(stmt string, values ...interface{}) *Query {
 }
 
 // Batch inherits from gocql.Batch, it keeps the tracer and the context.
+//
+// Deprecated: use the Observer based methods NewTracedSession, TraceQuery or TraceBatch instead, which returns
+// native gocql types instead of wrapped types.
 type Batch struct {
 	*gocql.Batch
-	*params
-	ctx context.Context
+	params params
+	ctx    context.Context
 }
 
 // NewBatch calls the underlying gocql.Session's NewBatch method and returns a new Batch augmented with tracing.
+//
+// Deprecated: use the Observer based methods NewTracedSession, TraceQuery or TraceBatch instead, which returns
+// native gocql types instead of wrapped types.
 func (s *Session) NewBatch(typ gocql.BatchType) *Batch {
 	b := s.Session.NewBatch(typ)
 	return wrapBatch(b, s.hosts, s.opts...)
@@ -93,10 +112,15 @@ func (s *Session) NewBatch(typ gocql.BatchType) *Batch {
 
 // params contains fields and metadata useful for command tracing
 type params struct {
-	config               *queryConfig
+	config               *config
 	keyspace             string
 	paginated            bool
+	skipPaginated        bool
 	clusterContactPoints string
+	consistency          string
+	hostInfo             *gocql.HostInfo
+	startTime            time.Time
+	finishTime           time.Time
 }
 
 // WrapQuery wraps a gocql.Query into a traced Query under the given service name.
@@ -109,7 +133,8 @@ type params struct {
 // of `WithContext` and `PageState` but not that of `Consistency`, `Trace`,
 // `Observer`, etc.
 //
-// Deprecated: initialize your ClusterConfig with NewCluster instead.
+// Deprecated: use the Observer based methods NewTracedSession, TraceQuery or TraceBatch instead, which returns
+// native gocql types instead of wrapped types.
 func WrapQuery(q *gocql.Query, opts ...WrapOption) *Query {
 	return wrapQuery(q, nil, opts...)
 }
@@ -124,7 +149,7 @@ func wrapQuery(q *gocql.Query, hosts []string, opts ...WrapOption) *Query {
 			cfg.resourceName = parts[1]
 		}
 	}
-	p := &params{config: cfg}
+	p := params{config: cfg}
 	if len(hosts) > 0 {
 		p.clusterContactPoints = strings.Join(hosts, ",")
 	}
@@ -155,43 +180,6 @@ func (tq *Query) PageState(state []byte) *Query {
 	return tq
 }
 
-// NewChildSpan creates a new span from the params and the context.
-func (tq *Query) newChildSpan(ctx context.Context) ddtrace.Span {
-	p := tq.params
-	opts := []ddtrace.StartSpanOption{
-		tracer.SpanType(ext.SpanTypeCassandra),
-		tracer.ServiceName(p.config.serviceName),
-		tracer.ResourceName(p.config.resourceName),
-		tracer.Tag(ext.CassandraPaginated, fmt.Sprintf("%t", p.paginated)),
-		tracer.Tag(ext.CassandraKeyspace, p.keyspace),
-		tracer.Tag(ext.Component, componentName),
-		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
-		tracer.Tag(ext.DBSystem, ext.DBSystemCassandra),
-	}
-	if !math.IsNaN(p.config.analyticsRate) {
-		opts = append(opts, tracer.Tag(ext.EventSampleRate, p.config.analyticsRate))
-	}
-	if tq.clusterContactPoints != "" {
-		opts = append(opts, tracer.Tag(ext.CassandraContactPoints, tq.clusterContactPoints))
-	}
-	for k, v := range tq.config.customTags {
-		opts = append(opts, tracer.Tag(k, v))
-	}
-	span, _ := tracer.StartSpanFromContext(ctx, p.config.querySpanName, opts...)
-	return span
-}
-
-func (tq *Query) finishSpan(span ddtrace.Span, err error) {
-	if err != nil && tq.params.config.shouldIgnoreError(err) {
-		err = nil
-	}
-	if tq.params.config.noDebugStack {
-		span.Finish(tracer.WithError(err), tracer.NoDebugStack())
-	} else {
-		span.Finish(tracer.WithError(err))
-	}
-}
-
 // Exec is rewritten so that it passes by our custom Iter
 func (tq *Query) Exec() error {
 	return tq.Iter().Close()
@@ -199,37 +187,40 @@ func (tq *Query) Exec() error {
 
 // MapScan wraps in a span query.MapScan call.
 func (tq *Query) MapScan(m map[string]interface{}) error {
-	span := tq.newChildSpan(tq.ctx)
+	span := startQuerySpan(tq.ctx, tq.params)
 	err := tq.Query.MapScan(m)
-	tq.finishSpan(span, err)
+	finishSpan(span, err, tq.params)
 	return err
 }
 
 // MapScanCAS wraps in a span query.MapScanCAS call.
 func (tq *Query) MapScanCAS(m map[string]interface{}) (applied bool, err error) {
-	span := tq.newChildSpan(tq.ctx)
+	span := startQuerySpan(tq.ctx, tq.params)
 	applied, err = tq.Query.MapScanCAS(m)
-	tq.finishSpan(span, err)
+	finishSpan(span, err, tq.params)
 	return applied, err
 }
 
 // Scan wraps in a span query.Scan call.
 func (tq *Query) Scan(dest ...interface{}) error {
-	span := tq.newChildSpan(tq.ctx)
+	span := startQuerySpan(tq.ctx, tq.params)
 	err := tq.Query.Scan(dest...)
-	tq.finishSpan(span, err)
+	finishSpan(span, err, tq.params)
 	return err
 }
 
 // ScanCAS wraps in a span query.ScanCAS call.
 func (tq *Query) ScanCAS(dest ...interface{}) (applied bool, err error) {
-	span := tq.newChildSpan(tq.ctx)
+	span := startQuerySpan(tq.ctx, tq.params)
 	applied, err = tq.Query.ScanCAS(dest...)
-	tq.finishSpan(span, err)
+	finishSpan(span, err, tq.params)
 	return applied, err
 }
 
 // Iter inherits from gocql.Iter and contains a span.
+//
+// Deprecated: use the Observer based methods NewTracedSession, TraceQuery or TraceBatch instead, which returns
+// native gocql types instead of wrapped types.
 type Iter struct {
 	*gocql.Iter
 	span ddtrace.Span
@@ -237,7 +228,7 @@ type Iter struct {
 
 // Iter starts a new span at query.Iter call.
 func (tq *Query) Iter() *Iter {
-	span := tq.newChildSpan(tq.ctx)
+	span := startQuerySpan(tq.ctx, tq.params)
 	iter := tq.Query.Iter()
 	span.SetTag(ext.CassandraRowCount, strconv.Itoa(iter.NumRows()))
 	span.SetTag(ext.CassandraConsistencyLevel, tq.GetConsistency().String())
@@ -253,7 +244,7 @@ func (tq *Query) Iter() *Iter {
 
 		cluster := tIter.Iter.Host().ClusterName()
 		dc := tIter.Iter.Host().DataCenter()
-		if tq.config.clusterTagLegacyMode {
+		if tq.params.config.clusterTagLegacyMode {
 			tIter.span.SetTag(ext.CassandraCluster, dc)
 		} else {
 			tIter.span.SetTag(ext.CassandraCluster, cluster)
@@ -273,7 +264,10 @@ func (tIter *Iter) Close() error {
 	return err
 }
 
-// Scanner inherits from a gocql.Scanner derived from an Iter
+// Scanner inherits from a gocql.Scanner derived from an Iter.
+//
+// Deprecated: use the Observer based methods NewTracedSession, TraceQuery or TraceBatch instead, which returns
+// native gocql types instead of wrapped types.
 type Scanner struct {
 	gocql.Scanner
 	span ddtrace.Span
@@ -309,7 +303,8 @@ func (s *Scanner) Err() error {
 // of `WithContext` and `WithTimestamp` but not that of `SerialConsistency`, `Trace`,
 // `Observer`, etc.
 //
-// Deprecated: initialize your ClusterConfig with NewCluster instead.
+// Deprecated: use the Observer based methods NewTracedSession, TraceQuery or TraceBatch instead, which returns
+// native gocql types instead of wrapped types.
 func WrapBatch(b *gocql.Batch, opts ...WrapOption) *Batch {
 	return wrapBatch(b, nil, opts...)
 }
@@ -319,7 +314,7 @@ func wrapBatch(b *gocql.Batch, hosts []string, opts ...WrapOption) *Batch {
 	for _, fn := range opts {
 		fn(cfg)
 	}
-	p := &params{config: cfg}
+	p := params{config: cfg}
 	if len(hosts) > 0 {
 		p.clusterContactPoints = strings.Join(hosts, ",")
 	}
@@ -354,45 +349,102 @@ func (tb *Batch) WithTimestamp(timestamp int64) *Batch {
 
 // ExecuteBatch calls session.ExecuteBatch on the Batch, tracing the execution.
 func (tb *Batch) ExecuteBatch(session *gocql.Session) error {
-	span := tb.newChildSpan(tb.ctx)
+	p := params{
+		config:               tb.params.config,
+		keyspace:             tb.Batch.Keyspace(),
+		paginated:            tb.params.paginated,
+		clusterContactPoints: tb.params.clusterContactPoints,
+		consistency:          tb.Batch.GetConsistency().String(),
+	}
+	span := startBatchSpan(tb.ctx, p)
 	err := session.ExecuteBatch(tb.Batch)
-	tb.finishSpan(span, err)
+	finishSpan(span, err, tb.params)
 	return err
 }
 
+func startQuerySpan(ctx context.Context, p params) ddtrace.Span {
+	opts := commonStartSpanOptions(p)
+	if p.keyspace != "" {
+		opts = append(opts, tracer.Tag(ext.CassandraKeyspace, p.keyspace))
+	}
+	if !p.skipPaginated {
+		opts = append(opts, tracer.Tag(ext.CassandraPaginated, fmt.Sprintf("%t", p.paginated)))
+	}
+	for k, v := range p.config.customTags {
+		opts = append(opts, tracer.Tag(k, v))
+	}
+	span, _ := tracer.StartSpanFromContext(ctx, p.config.querySpanName, opts...)
+	return span
+}
+
 // newChildSpan creates a new span from the params and the context.
-func (tb *Batch) newChildSpan(ctx context.Context) ddtrace.Span {
-	p := tb.params
+func startBatchSpan(ctx context.Context, p params) ddtrace.Span {
+	cfg := p.config
+	opts := commonStartSpanOptions(p)
+	if p.keyspace != "" {
+		opts = append(opts, tracer.Tag(ext.CassandraKeyspace, p.keyspace))
+	}
+	if p.consistency != "" {
+		opts = append(opts, tracer.Tag(ext.CassandraConsistencyLevel, p.consistency))
+	}
+	for k, v := range cfg.customTags {
+		opts = append(opts, tracer.Tag(k, v))
+	}
+	span, _ := tracer.StartSpanFromContext(ctx, cfg.batchSpanName, opts...)
+	return span
+}
+
+func commonStartSpanOptions(p params) []tracer.StartSpanOption {
+	cfg := p.config
 	opts := []ddtrace.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeCassandra),
-		tracer.ServiceName(p.config.serviceName),
-		tracer.ResourceName(p.config.resourceName),
-		tracer.Tag(ext.CassandraConsistencyLevel, tb.Cons.String()),
-		tracer.Tag(ext.CassandraKeyspace, tb.Keyspace()),
+		tracer.ServiceName(cfg.serviceName),
 		tracer.Tag(ext.Component, componentName),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
 		tracer.Tag(ext.DBSystem, ext.DBSystemCassandra),
 	}
-	if !math.IsNaN(p.config.analyticsRate) {
-		opts = append(opts, tracer.Tag(ext.EventSampleRate, p.config.analyticsRate))
+	if p.config.resourceName != "" {
+		opts = append(opts, tracer.ResourceName(p.config.resourceName))
 	}
-	if tb.clusterContactPoints != "" {
-		opts = append(opts, tracer.Tag(ext.CassandraContactPoints, tb.clusterContactPoints))
+	if !p.startTime.IsZero() {
+		opts = append(opts, tracer.StartTime(p.startTime))
 	}
-	for k, v := range tb.config.customTags {
-		opts = append(opts, tracer.Tag(k, v))
+	if !math.IsNaN(cfg.analyticsRate) {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.analyticsRate))
 	}
-	span, _ := tracer.StartSpanFromContext(ctx, p.config.batchSpanName, opts...)
-	return span
+	if p.clusterContactPoints != "" {
+		opts = append(opts, tracer.Tag(ext.CassandraContactPoints, p.clusterContactPoints))
+	}
+	if p.hostInfo != nil {
+		opts = append(opts,
+			tracer.Tag(ext.TargetHost, p.hostInfo.ConnectAddress().String()),
+			tracer.Tag(ext.TargetPort, strconv.Itoa(p.hostInfo.Port())),
+		)
+		if p.hostInfo.HostID() != "" {
+			opts = append(opts, tracer.Tag(ext.CassandraHostID, p.hostInfo.HostID()))
+		}
+		if p.hostInfo.ClusterName() != "" {
+			opts = append(opts, tracer.Tag(ext.CassandraCluster, p.hostInfo.ClusterName()))
+		}
+		if p.hostInfo.DataCenter() != "" {
+			opts = append(opts, tracer.Tag(ext.CassandraDatacenter, p.hostInfo.DataCenter()))
+		}
+	}
+	return opts
 }
 
-func (tb *Batch) finishSpan(span ddtrace.Span, err error) {
-	if err != nil && tb.params.config.shouldIgnoreError(err) {
+func finishSpan(span ddtrace.Span, err error, p params) {
+	if err != nil && p.config.shouldIgnoreError(err) {
 		err = nil
 	}
-	if tb.params.config.noDebugStack {
-		span.Finish(tracer.WithError(err), tracer.NoDebugStack())
-	} else {
-		span.Finish(tracer.WithError(err))
+	opts := []ddtrace.FinishOption{
+		tracer.WithError(err),
 	}
+	if !p.finishTime.IsZero() {
+		opts = append(opts, tracer.FinishTime(p.finishTime))
+	}
+	if p.config.noDebugStack {
+		opts = append(opts, tracer.NoDebugStack())
+	}
+	span.Finish(opts...)
 }

--- a/contrib/gocql/gocql/gocql.go
+++ b/contrib/gocql/gocql/gocql.go
@@ -32,7 +32,7 @@ func init() {
 
 // ClusterConfig embeds gocql.ClusterConfig and keeps information relevant to tracing.
 //
-// Deprecated: use the Observer based methods NewTracedSession, TraceQuery or TraceBatch instead, which returns
+// Deprecated: use the Observer based method CreateTracedSession instead, which allows to use
 // native gocql types instead of wrapped types.
 type ClusterConfig struct {
 	*gocql.ClusterConfig
@@ -42,7 +42,7 @@ type ClusterConfig struct {
 
 // NewCluster calls gocql.NewCluster and returns a wrapped instrumented version of it.
 //
-// Deprecated: use the Observer based methods NewTracedSession, TraceQuery or TraceBatch instead, which returns
+// Deprecated: use the Observer based method CreateTracedSession instead, which allows to use
 // native gocql types instead of wrapped types.
 func NewCluster(hosts []string, opts ...WrapOption) *ClusterConfig {
 	return &ClusterConfig{
@@ -54,7 +54,7 @@ func NewCluster(hosts []string, opts ...WrapOption) *ClusterConfig {
 
 // Session embeds gocql.Session and keeps information relevant to tracing.
 //
-// Deprecated: use the Observer based methods NewTracedSession, TraceQuery or TraceBatch instead, which returns
+// Deprecated: use the Observer based method CreateTracedSession instead, which allows to use
 // native gocql types instead of wrapped types.
 type Session struct {
 	*gocql.Session
@@ -77,7 +77,7 @@ func (c *ClusterConfig) CreateSession() (*Session, error) {
 
 // Query inherits from gocql.Query, it keeps the tracer and the context.
 //
-// Deprecated: use the Observer based methods NewTracedSession, TraceQuery or TraceBatch instead, which returns
+// Deprecated: use the Observer based method CreateTracedSession instead, which allows to use
 // native gocql types instead of wrapped types.
 type Query struct {
 	*gocql.Query
@@ -93,7 +93,7 @@ func (s *Session) Query(stmt string, values ...interface{}) *Query {
 
 // Batch inherits from gocql.Batch, it keeps the tracer and the context.
 //
-// Deprecated: use the Observer based methods NewTracedSession, TraceQuery or TraceBatch instead, which returns
+// Deprecated: use the Observer based method CreateTracedSession instead, which allows to use
 // native gocql types instead of wrapped types.
 type Batch struct {
 	*gocql.Batch
@@ -103,7 +103,7 @@ type Batch struct {
 
 // NewBatch calls the underlying gocql.Session's NewBatch method and returns a new Batch augmented with tracing.
 //
-// Deprecated: use the Observer based methods NewTracedSession, TraceQuery or TraceBatch instead, which returns
+// Deprecated: use the Observer based method CreateTracedSession instead, which allows to use
 // native gocql types instead of wrapped types.
 func (s *Session) NewBatch(typ gocql.BatchType) *Batch {
 	b := s.Session.NewBatch(typ)
@@ -133,7 +133,7 @@ type params struct {
 // of `WithContext` and `PageState` but not that of `Consistency`, `Trace`,
 // `Observer`, etc.
 //
-// Deprecated: use the Observer based methods NewTracedSession, TraceQuery or TraceBatch instead, which returns
+// Deprecated: use the Observer based method CreateTracedSession instead, which allows to use
 // native gocql types instead of wrapped types.
 func WrapQuery(q *gocql.Query, opts ...WrapOption) *Query {
 	return wrapQuery(q, nil, opts...)
@@ -219,7 +219,7 @@ func (tq *Query) ScanCAS(dest ...interface{}) (applied bool, err error) {
 
 // Iter inherits from gocql.Iter and contains a span.
 //
-// Deprecated: use the Observer based methods NewTracedSession, TraceQuery or TraceBatch instead, which returns
+// Deprecated: use the Observer based method CreateTracedSession instead, which allows to use
 // native gocql types instead of wrapped types.
 type Iter struct {
 	*gocql.Iter
@@ -266,7 +266,7 @@ func (tIter *Iter) Close() error {
 
 // Scanner inherits from a gocql.Scanner derived from an Iter.
 //
-// Deprecated: use the Observer based methods NewTracedSession, TraceQuery or TraceBatch instead, which returns
+// Deprecated: use the Observer based method CreateTracedSession instead, which allows to use
 // native gocql types instead of wrapped types.
 type Scanner struct {
 	gocql.Scanner
@@ -303,7 +303,7 @@ func (s *Scanner) Err() error {
 // of `WithContext` and `WithTimestamp` but not that of `SerialConsistency`, `Trace`,
 // `Observer`, etc.
 //
-// Deprecated: use the Observer based methods NewTracedSession, TraceQuery or TraceBatch instead, which returns
+// Deprecated: use the Observer based method CreateTracedSession instead, which allows to use
 // native gocql types instead of wrapped types.
 func WrapBatch(b *gocql.Batch, opts ...WrapOption) *Batch {
 	return wrapBatch(b, nil, opts...)

--- a/contrib/gocql/gocql/observer.go
+++ b/contrib/gocql/gocql/observer.go
@@ -1,0 +1,123 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package gocql
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/gocql/gocql"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+// NewTracedSession returns a new session augmented with tracing.
+func NewTracedSession(cluster *gocql.ClusterConfig, opts ...WrapOption) (*gocql.Session, error) {
+	obs := NewObserver(cluster, opts...)
+	cfg := obs.cfg
+
+	if cfg.traceQuery {
+		cluster.QueryObserver = obs
+	}
+	if cfg.traceBatch {
+		cluster.BatchObserver = obs
+	}
+	if cfg.traceConnect {
+		cluster.ConnectObserver = obs
+	}
+	return cluster.CreateSession()
+}
+
+// TraceQuery can be used to enable tracing an individual *gocql.Query.
+func TraceQuery(q *gocql.Query, cluster *gocql.ClusterConfig, opts ...WrapOption) *gocql.Query {
+	obs := NewObserver(cluster, opts...)
+	return q.Observer(obs)
+}
+
+// TraceBatch can be used to enable tracing for an individual *gocql.Batch.
+func TraceBatch(b *gocql.Batch, cluster *gocql.ClusterConfig, opts ...WrapOption) *gocql.Batch {
+	obs := NewObserver(cluster, opts...)
+	return b.Observer(obs)
+}
+
+// NewObserver creates a new Observer to trace gocql.
+func NewObserver(cluster *gocql.ClusterConfig, opts ...WrapOption) *Observer {
+	cfg := defaultConfig()
+	for _, fn := range opts {
+		fn(cfg)
+	}
+	return &Observer{
+		cfg:                  cfg,
+		clusterContactPoints: strings.Join(cluster.Hosts, ","),
+	}
+}
+
+var (
+	_ gocql.QueryObserver   = (*Observer)(nil)
+	_ gocql.BatchObserver   = (*Observer)(nil)
+	_ gocql.ConnectObserver = (*Observer)(nil)
+)
+
+// Observer implements gocql observer interfaces to support tracing.
+type Observer struct {
+	cfg                  *config
+	clusterContactPoints string
+}
+
+// ObserveQuery implements gocql.QueryObserver.
+func (o *Observer) ObserveQuery(ctx context.Context, query gocql.ObservedQuery) {
+	p := params{
+		config:               o.cfg,
+		keyspace:             query.Keyspace,
+		skipPaginated:        true,
+		clusterContactPoints: o.clusterContactPoints,
+		hostInfo:             query.Host,
+		startTime:            query.Start,
+		finishTime:           query.End,
+	}
+	span := startQuerySpan(ctx, p)
+	resource := o.cfg.resourceName
+	if resource == "" {
+		resource = query.Statement
+	}
+	span.SetTag(ext.ResourceName, resource)
+	span.SetTag(ext.CassandraRowCount, strconv.Itoa(query.Rows))
+	finishSpan(span, query.Err, p)
+}
+
+// ObserveBatch implements gocql.BatchObserver.
+func (o *Observer) ObserveBatch(ctx context.Context, batch gocql.ObservedBatch) {
+	p := params{
+		config:               o.cfg,
+		keyspace:             batch.Keyspace,
+		skipPaginated:        true,
+		clusterContactPoints: o.clusterContactPoints,
+		hostInfo:             batch.Host,
+		startTime:            batch.Start,
+		finishTime:           batch.End,
+	}
+	span := startBatchSpan(ctx, p)
+	finishSpan(span, batch.Err, p)
+}
+
+// ObserveConnect implements gocql.ConnectObserver.
+func (o *Observer) ObserveConnect(connect gocql.ObservedConnect) {
+	p := params{
+		config:               o.cfg,
+		clusterContactPoints: o.clusterContactPoints,
+		hostInfo:             connect.Host,
+		startTime:            connect.Start,
+		finishTime:           connect.End,
+	}
+	opts := commonStartSpanOptions(p)
+	for k, v := range o.cfg.customTags {
+		opts = append(opts, tracer.Tag(k, v))
+	}
+	span := tracer.StartSpan("cassandra.connect", opts...)
+	finishSpan(span, connect.Err, p)
+}

--- a/contrib/gocql/gocql/observer_test.go
+++ b/contrib/gocql/gocql/observer_test.go
@@ -187,7 +187,7 @@ func TestObserver_Batch(t *testing.T) {
 		{
 			name: "error",
 			opts: nil,
-			updateBatch: func(cluster *gocql.ClusterConfig, sess *gocql.Session, _ *gocql.Batch) *gocql.Batch {
+			updateBatch: func(_ *gocql.ClusterConfig, sess *gocql.Session, _ *gocql.Batch) *gocql.Batch {
 				stmt := "SELECT name, age FRM trace.person WHERE name = 'This does not exist'"
 				b := sess.NewBatch(gocql.UnloggedBatch)
 				b.Query(stmt)
@@ -205,7 +205,7 @@ func TestObserver_Batch(t *testing.T) {
 					return false
 				}),
 			},
-			updateBatch: func(cluster *gocql.ClusterConfig, sess *gocql.Session, _ *gocql.Batch) *gocql.Batch {
+			updateBatch: func(_ *gocql.ClusterConfig, sess *gocql.Session, _ *gocql.Batch) *gocql.Batch {
 				stmt := "SELECT name, age FRM trace.person WHERE name = 'This does not exist'"
 				b := sess.NewBatch(gocql.UnloggedBatch)
 				b.Query(stmt)

--- a/contrib/gocql/gocql/observer_test.go
+++ b/contrib/gocql/gocql/observer_test.go
@@ -1,0 +1,442 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package gocql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gocql/gocql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+func TestObserver_Query(t *testing.T) {
+	testCases := []struct {
+		name             string
+		opts             []WrapOption
+		updateQuery      func(cluster *gocql.ClusterConfig, sess *gocql.Session, q *gocql.Query) *gocql.Query
+		wantServiceName  string
+		wantResourceName string
+		wantRowCount     string
+		wantErr          bool
+		wantErrTag       bool
+	}{
+		{
+			name: "default",
+			opts: nil,
+		},
+		{
+			name: "service_and_resource_name",
+			opts: []WrapOption{
+				WithServiceName("test-service"),
+				WithResourceName("test-resource"),
+			},
+			wantServiceName:  "test-service",
+			wantResourceName: "test-resource",
+		},
+		{
+			name: "error",
+			opts: nil,
+			updateQuery: func(_ *gocql.ClusterConfig, sess *gocql.Session, _ *gocql.Query) *gocql.Query {
+				stmt := "SELECT name, age FRM trace.person WHERE name = 'This does not exist'"
+				return sess.Query(stmt)
+			},
+			wantServiceName:  "",
+			wantResourceName: "SELECT name, age FRM trace.person WHERE name = 'This does not exist'",
+			wantRowCount:     "0",
+			wantErr:          true,
+			wantErrTag:       true,
+		},
+		{
+			name: "error_ignore",
+			opts: []WrapOption{
+				WithErrorCheck(func(_ error) bool {
+					return false
+				}),
+			},
+			updateQuery: func(_ *gocql.ClusterConfig, sess *gocql.Session, _ *gocql.Query) *gocql.Query {
+				stmt := "SELECT name, age FRM trace.person WHERE name = 'This does not exist'"
+				return sess.Query(stmt)
+			},
+			wantServiceName:  "",
+			wantResourceName: "SELECT name, age FRM trace.person WHERE name = 'This does not exist'",
+			wantRowCount:     "0",
+			wantErr:          true,
+			wantErrTag:       false,
+		},
+		{
+			name: "individual_query_trace",
+			opts: []WrapOption{
+				WithTraceQuery(false),
+			},
+			updateQuery: func(cluster *gocql.ClusterConfig, _ *gocql.Session, q *gocql.Query) *gocql.Query {
+				return TraceQuery(q, cluster, WithResourceName("test resource"), WithServiceName("test service"))
+			},
+			wantServiceName:  "test service",
+			wantResourceName: "test resource",
+			wantErr:          false,
+			wantErrTag:       false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mt := mocktracer.Start()
+			defer mt.Stop()
+
+			cluster := newCassandraCluster()
+			cluster.Hosts = []string{cassandraHost, "127.0.0.1:9043"}
+			cluster.Keyspace = "trace"
+
+			opts := []WrapOption{
+				WithTraceQuery(true),
+				WithTraceBatch(false),
+				WithTraceConnect(false),
+			}
+			opts = append(opts, tc.opts...)
+			sess, err := NewTracedSession(cluster, opts...)
+			require.NoError(t, err)
+
+			p, ctx := tracer.StartSpanFromContext(context.Background(), "parentSpan")
+
+			stmt := "SELECT * FROM trace.person WHERE name = 'Cassandra'"
+			q := sess.Query(stmt)
+			if tc.updateQuery != nil {
+				q = tc.updateQuery(cluster, sess, q)
+			}
+			q = q.WithContext(ctx)
+
+			err = q.Exec()
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			p.Finish()
+
+			spans := mt.FinishedSpans()
+			require.Len(t, spans, 2)
+
+			wantService := tc.wantServiceName
+			if wantService == "" {
+				wantService = "gocql.query"
+			}
+			wantResource := tc.wantResourceName
+			if wantResource == "" {
+				wantResource = stmt
+			}
+			wantRowCount := tc.wantRowCount
+			if wantRowCount == "" {
+				wantRowCount = "1"
+			}
+
+			parentSpan := spans[1]
+			querySpan := spans[0]
+
+			assert.Equal(t, "parentSpan", parentSpan.OperationName())
+			assert.Equal(t, querySpan.ParentID(), parentSpan.SpanID())
+
+			assertCommonTags(t, querySpan)
+
+			assert.Equal(t, "cassandra.query", querySpan.OperationName())
+			assert.Equal(t, wantResource, querySpan.Tag(ext.ResourceName))
+			assert.Equal(t, wantService, querySpan.Tag(ext.ServiceName))
+			assert.Equal(t, wantRowCount, querySpan.Tag(ext.CassandraRowCount))
+
+			if tc.wantErrTag {
+				assert.NotNil(t, querySpan.Tag(ext.Error))
+			} else {
+				assert.Nil(t, querySpan.Tag(ext.Error))
+			}
+		})
+	}
+}
+
+func TestObserver_Batch(t *testing.T) {
+	testCases := []struct {
+		name             string
+		opts             []WrapOption
+		updateBatch      func(cluster *gocql.ClusterConfig, sess *gocql.Session, b *gocql.Batch) *gocql.Batch
+		wantServiceName  string
+		wantResourceName string
+		wantErr          bool
+		wantErrTag       bool
+	}{
+		{
+			name: "default",
+			opts: nil,
+		},
+		{
+			name: "service_and_resource_name",
+			opts: []WrapOption{
+				WithServiceName("test-service"),
+				WithResourceName("test-resource"),
+			},
+			wantServiceName:  "test-service",
+			wantResourceName: "test-resource",
+		},
+		{
+			name: "error",
+			opts: nil,
+			updateBatch: func(cluster *gocql.ClusterConfig, sess *gocql.Session, _ *gocql.Batch) *gocql.Batch {
+				stmt := "SELECT name, age FRM trace.person WHERE name = 'This does not exist'"
+				b := sess.NewBatch(gocql.UnloggedBatch)
+				b.Query(stmt)
+				return b
+			},
+			wantServiceName:  "",
+			wantResourceName: "",
+			wantErr:          true,
+			wantErrTag:       true,
+		},
+		{
+			name: "error_ignore",
+			opts: []WrapOption{
+				WithErrorCheck(func(_ error) bool {
+					return false
+				}),
+			},
+			updateBatch: func(cluster *gocql.ClusterConfig, sess *gocql.Session, _ *gocql.Batch) *gocql.Batch {
+				stmt := "SELECT name, age FRM trace.person WHERE name = 'This does not exist'"
+				b := sess.NewBatch(gocql.UnloggedBatch)
+				b.Query(stmt)
+				return b
+			},
+			wantServiceName:  "",
+			wantResourceName: "",
+			wantErr:          true,
+			wantErrTag:       false,
+		},
+		{
+			name: "individual_batch_trace",
+			opts: []WrapOption{
+				WithTraceBatch(false),
+			},
+			updateBatch: func(cluster *gocql.ClusterConfig, _ *gocql.Session, b *gocql.Batch) *gocql.Batch {
+				return TraceBatch(b, cluster, WithResourceName("test resource"), WithServiceName("test service"))
+			},
+			wantServiceName:  "test service",
+			wantResourceName: "test resource",
+			wantErr:          false,
+			wantErrTag:       false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mt := mocktracer.Start()
+			defer mt.Stop()
+
+			cluster := newCassandraCluster()
+			cluster.Hosts = []string{cassandraHost, "127.0.0.1:9043"}
+			cluster.Keyspace = "trace"
+
+			opts := []WrapOption{
+				WithTraceQuery(true),
+				WithTraceBatch(true),
+				WithTraceConnect(false),
+			}
+			opts = append(opts, tc.opts...)
+			sess, err := NewTracedSession(cluster, opts...)
+			require.NoError(t, err)
+
+			p, ctx := tracer.StartSpanFromContext(context.Background(), "parentSpan")
+
+			stmt := "INSERT INTO trace.person (name, age, description) VALUES (?, ?, ?)"
+			b := sess.NewBatch(gocql.UnloggedBatch)
+			b.Query(stmt, "Kate", 80, "Cassandra's sister running in kubernetes")
+			b.Query(stmt, "Lucas", 60, "Another person")
+
+			if tc.updateBatch != nil {
+				b = tc.updateBatch(cluster, sess, b)
+			}
+			b = b.WithContext(ctx)
+
+			err = sess.ExecuteBatch(b)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			p.Finish()
+
+			spans := mt.FinishedSpans()
+			require.Len(t, spans, 2)
+
+			wantService := tc.wantServiceName
+			if wantService == "" {
+				wantService = "gocql.query"
+			}
+			wantResource := tc.wantResourceName
+			if wantResource == "" {
+				wantResource = "cassandra.batch"
+			}
+
+			parentSpan := spans[1]
+			batchSpan := spans[0]
+
+			assert.Equal(t, "parentSpan", parentSpan.OperationName())
+			assert.Equal(t, batchSpan.ParentID(), parentSpan.SpanID())
+
+			assertCommonTags(t, batchSpan)
+
+			assert.Equal(t, "cassandra.batch", batchSpan.OperationName())
+			assert.Equal(t, wantResource, batchSpan.Tag(ext.ResourceName))
+			assert.Equal(t, wantService, batchSpan.Tag(ext.ServiceName))
+			assert.Nil(t, batchSpan.Tag(ext.CassandraRowCount))
+
+			if tc.wantErrTag {
+				assert.NotNil(t, batchSpan.Tag(ext.Error))
+			} else {
+				assert.Nil(t, batchSpan.Tag(ext.Error))
+			}
+		})
+	}
+}
+
+func TestObserver_Connect(t *testing.T) {
+	testCases := []struct {
+		name             string
+		opts             []WrapOption
+		wantServiceName  string
+		wantResourceName string
+		wantErr          bool
+		wantErrTag       bool
+	}{
+		{
+			name: "default",
+			opts: nil,
+		},
+		{
+			name: "service_and_resource_name",
+			opts: []WrapOption{
+				WithServiceName("test-service"),
+				WithResourceName("test-resource"),
+			},
+			wantServiceName:  "test-service",
+			wantResourceName: "test-resource",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mt := mocktracer.Start()
+			defer mt.Stop()
+
+			cluster := newCassandraCluster()
+			cluster.Hosts = []string{cassandraHost, "127.0.0.1:9043"}
+			cluster.Keyspace = "trace"
+
+			opts := []WrapOption{
+				WithTraceQuery(false),
+				WithTraceBatch(false),
+				WithTraceConnect(true),
+			}
+			opts = append(opts, tc.opts...)
+			sess, err := NewTracedSession(cluster, opts...)
+			require.NoError(t, err)
+
+			err = sess.Query("SELECT * FROM trace.person WHERE name = 'Cassandra'").Exec()
+			require.NoError(t, err)
+
+			wantService := tc.wantServiceName
+			if wantService == "" {
+				wantService = "gocql.query"
+			}
+			wantResource := tc.wantResourceName
+			if wantResource == "" {
+				wantResource = "cassandra.connect"
+			}
+
+			spans := mt.FinishedSpans()
+
+			var okSpans []mocktracer.Span
+			var okSpansHostInfo []mocktracer.Span
+			var errSpans []mocktracer.Span
+
+			for _, span := range spans {
+				port := span.Tag(ext.TargetPort)
+				require.NotEmpty(t, port)
+				switch port {
+				case "9042":
+					okSpans = append(okSpans, span)
+
+				case "9043":
+					errSpans = append(errSpans, span)
+
+				default:
+					assert.FailNow(t, "unexpected port: "+port.(string))
+				}
+			}
+			assert.NotEmpty(t, okSpans)
+			assert.NotEmpty(t, errSpans)
+
+			for _, span := range spans {
+				// this information should be present in all spans.
+				assert.Equal(t, "cassandra.connect", span.OperationName())
+				assert.Equal(t, wantResource, span.Tag(ext.ResourceName))
+				assert.Equal(t, wantService, span.Tag(ext.ServiceName))
+
+				assert.Equal(t, "gocql/gocql", span.Tag(ext.Component))
+				assert.Equal(t, ext.SpanKindClient, span.Tag(ext.SpanKind))
+				assert.Equal(t, "cassandra", span.Tag(ext.DBSystem))
+				assert.Equal(t, "127.0.0.1:9042,127.0.0.1:9043", span.Tag(ext.CassandraContactPoints))
+				assert.Equal(t, "127.0.0.1", span.Tag(ext.TargetHost))
+			}
+			for _, span := range okSpans {
+				assert.Equal(t, "9042", span.Tag(ext.TargetPort))
+				assert.Nil(t, span.Tag(ext.Error))
+
+				if span.Tag(ext.CassandraHostID) != nil {
+					okSpansHostInfo = append(okSpansHostInfo, span)
+				}
+			}
+			assert.NotEmpty(t, okSpansHostInfo, "should have found at least one non-error connect span with additional host info")
+
+			for _, span := range okSpansHostInfo {
+				// this information is not present in all the spans for some reason.
+				assert.Equal(t, "dd-trace-go-test-cluster", span.Tag(ext.CassandraCluster))
+				assert.Equal(t, "dd-trace-go-test-datacenter", span.Tag(ext.CassandraDatacenter))
+				assert.NotEmpty(t, span.Tag(ext.CassandraHostID))
+			}
+			for _, span := range errSpans {
+				assert.Equal(t, "9043", span.Tag(ext.TargetPort))
+				assert.NotNil(t, span.Tag(ext.Error))
+
+				// since this node does not exist, this information should not be present.
+				assert.Nil(t, span.Tag(ext.CassandraCluster))
+				assert.Nil(t, span.Tag(ext.CassandraDatacenter))
+				assert.Nil(t, span.Tag(ext.CassandraHostID))
+			}
+		})
+	}
+}
+
+func assertCommonTags(t *testing.T, span mocktracer.Span) {
+	t.Helper()
+
+	assert.Equal(t, "trace", span.Tag(ext.CassandraKeyspace))
+	assert.Equal(t, "gocql/gocql", span.Tag(ext.Component))
+	assert.Equal(t, ext.SpanKindClient, span.Tag(ext.SpanKind))
+	assert.Equal(t, "cassandra", span.Tag(ext.DBSystem))
+	assert.Equal(t, "127.0.0.1:9042,127.0.0.1:9043", span.Tag(ext.CassandraContactPoints))
+	assert.Equal(t, "9042", span.Tag(ext.TargetPort))
+	assert.Equal(t, "127.0.0.1", span.Tag(ext.TargetHost))
+	assert.Equal(t, "dd-trace-go-test-cluster", span.Tag(ext.CassandraCluster))
+	assert.Equal(t, "dd-trace-go-test-datacenter", span.Tag(ext.CassandraDatacenter))
+	assert.NotEmpty(t, span.Tag(ext.CassandraHostID))
+
+	// These tags can't be obtained with the Observer API.
+	assert.Nil(t, span.Tag(ext.CassandraPaginated))
+	assert.Nil(t, span.Tag(ext.CassandraConsistencyLevel))
+}

--- a/contrib/gocql/gocql/observer_test.go
+++ b/contrib/gocql/gocql/observer_test.go
@@ -379,7 +379,7 @@ func TestObserver_Connect(t *testing.T) {
 				}
 			}
 			assert.NotEmpty(t, okSpans)
-			assert.NotEmpty(t, errSpans)
+			// the errSpans slice might be empty or not, so we don't assert any length to avoid flakiness.
 
 			for _, span := range spans {
 				// this information should be present in all spans.

--- a/contrib/gocql/gocql/option.go
+++ b/contrib/gocql/gocql/option.go
@@ -18,21 +18,26 @@ import (
 
 const defaultServiceName = "gocql.query"
 
-type queryConfig struct {
-	serviceName, resourceName    string
-	querySpanName, batchSpanName string
-	noDebugStack                 bool
-	analyticsRate                float64
-	errCheck                     func(err error) bool
-	customTags                   map[string]interface{}
-	clusterTagLegacyMode         bool
+type config struct {
+	serviceName, resourceName            string
+	querySpanName, batchSpanName         string
+	noDebugStack                         bool
+	analyticsRate                        float64
+	errCheck                             func(err error) bool
+	customTags                           map[string]interface{}
+	clusterTagLegacyMode                 bool
+	traceQuery, traceBatch, traceConnect bool
 }
 
 // WrapOption represents an option that can be passed to WrapQuery.
-type WrapOption func(*queryConfig)
+type WrapOption func(*config)
 
-func defaultConfig() *queryConfig {
-	cfg := &queryConfig{}
+func defaultConfig() *config {
+	cfg := &config{
+		traceQuery:   true,
+		traceBatch:   true,
+		traceConnect: true,
+	}
 	cfg.serviceName = namingschema.ServiceNameOverrideV0(defaultServiceName, defaultServiceName)
 	cfg.querySpanName = namingschema.OpName(namingschema.CassandraOutbound)
 	cfg.batchSpanName = namingschema.OpNameOverrideV0(namingschema.CassandraOutbound, "cassandra.batch")
@@ -55,7 +60,7 @@ func defaultConfig() *queryConfig {
 
 // WithServiceName sets the given service name for the returned query.
 func WithServiceName(name string) WrapOption {
-	return func(cfg *queryConfig) {
+	return func(cfg *config) {
 		cfg.serviceName = name
 	}
 }
@@ -67,14 +72,14 @@ func WithServiceName(name string) WrapOption {
 // call, which can be costly when called repeatedly. Using WithResourceName will
 // avoid that call. Under normal circumstances, it is safe to rely on the default.
 func WithResourceName(name string) WrapOption {
-	return func(cfg *queryConfig) {
+	return func(cfg *config) {
 		cfg.resourceName = name
 	}
 }
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) WrapOption {
-	return func(cfg *queryConfig) {
+	return func(cfg *config) {
 		if on {
 			cfg.analyticsRate = 1.0
 		} else {
@@ -86,7 +91,7 @@ func WithAnalytics(on bool) WrapOption {
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) WrapOption {
-	return func(cfg *queryConfig) {
+	return func(cfg *config) {
 		if rate >= 0.0 && rate <= 1.0 {
 			cfg.analyticsRate = rate
 		} else {
@@ -99,12 +104,12 @@ func WithAnalyticsRate(rate float64) WrapOption {
 // with an error. This is useful in situations where errors are frequent and
 // performance is critical.
 func NoDebugStack() WrapOption {
-	return func(cfg *queryConfig) {
+	return func(cfg *config) {
 		cfg.noDebugStack = true
 	}
 }
 
-func (c *queryConfig) shouldIgnoreError(err error) bool {
+func (c *config) shouldIgnoreError(err error) bool {
 	return c != nil && c.errCheck != nil && !c.errCheck(err)
 }
 
@@ -112,7 +117,7 @@ func (c *queryConfig) shouldIgnoreError(err error) bool {
 // error should be marked as an error. The fn is called whenever a CQL request
 // finishes with an error.
 func WithErrorCheck(fn func(err error) bool) WrapOption {
-	return func(cfg *queryConfig) {
+	return func(cfg *config) {
 		// When the error is explicitly marked as not-an-error, that is
 		// when this errCheck function returns false, the APM code will
 		// just skip the error and pretend the span was successful.
@@ -128,10 +133,31 @@ func WithErrorCheck(fn func(err error) bool) WrapOption {
 
 // WithCustomTag will attach the value to the span tagged by the key.
 func WithCustomTag(key string, value interface{}) WrapOption {
-	return func(cfg *queryConfig) {
+	return func(cfg *config) {
 		if cfg.customTags == nil {
 			cfg.customTags = make(map[string]interface{})
 		}
 		cfg.customTags[key] = value
+	}
+}
+
+// WithTraceQuery will enable tracing for queries. This option only takes effect in the NewTracedSession function.
+func WithTraceQuery(enabled bool) WrapOption {
+	return func(cfg *config) {
+		cfg.traceQuery = enabled
+	}
+}
+
+// WithTraceBatch will enable tracing for batches. This option only takes effect in the NewTracedSession function.
+func WithTraceBatch(enabled bool) WrapOption {
+	return func(cfg *config) {
+		cfg.traceBatch = enabled
+	}
+}
+
+// WithTraceConnect will enable tracing for connections. This option only takes effect in the NewTracedSession function.
+func WithTraceConnect(enabled bool) WrapOption {
+	return func(cfg *config) {
+		cfg.traceConnect = enabled
 	}
 }

--- a/contrib/gocql/gocql/option.go
+++ b/contrib/gocql/gocql/option.go
@@ -141,21 +141,21 @@ func WithCustomTag(key string, value interface{}) WrapOption {
 	}
 }
 
-// WithTraceQuery will enable tracing for queries. This option only takes effect in the NewTracedSession function.
+// WithTraceQuery will enable tracing for queries. This option only takes effect in the CreateTracedSession function.
 func WithTraceQuery(enabled bool) WrapOption {
 	return func(cfg *config) {
 		cfg.traceQuery = enabled
 	}
 }
 
-// WithTraceBatch will enable tracing for batches. This option only takes effect in the NewTracedSession function.
+// WithTraceBatch will enable tracing for batches. This option only takes effect in the CreateTracedSession function.
 func WithTraceBatch(enabled bool) WrapOption {
 	return func(cfg *config) {
 		cfg.traceBatch = enabled
 	}
 }
 
-// WithTraceConnect will enable tracing for connections. This option only takes effect in the NewTracedSession function.
+// WithTraceConnect will enable tracing for connections. This option only takes effect in the CreateTracedSession function.
 func WithTraceConnect(enabled bool) WrapOption {
 	return func(cfg *config) {
 		cfg.traceConnect = enabled

--- a/contrib/gocql/gocql/option.go
+++ b/contrib/gocql/gocql/option.go
@@ -141,21 +141,24 @@ func WithCustomTag(key string, value interface{}) WrapOption {
 	}
 }
 
-// WithTraceQuery will enable tracing for queries. This option only takes effect in the CreateTracedSession function.
+// WithTraceQuery will enable tracing for queries (default is true).
+// This option only takes effect in CreateTracedSession and NewObserver.
 func WithTraceQuery(enabled bool) WrapOption {
 	return func(cfg *config) {
 		cfg.traceQuery = enabled
 	}
 }
 
-// WithTraceBatch will enable tracing for batches. This option only takes effect in the CreateTracedSession function.
+// WithTraceBatch will enable tracing for batches (default is true).
+// This option only takes effect in CreateTracedSession and NewObserver.
 func WithTraceBatch(enabled bool) WrapOption {
 	return func(cfg *config) {
 		cfg.traceBatch = enabled
 	}
 }
 
-// WithTraceConnect will enable tracing for connections. This option only takes effect in the CreateTracedSession function.
+// WithTraceConnect will enable tracing for connections (default is true).
+// This option only takes effect in CreateTracedSession and NewObserver.
 func WithTraceConnect(enabled bool) WrapOption {
 	return func(cfg *config) {
 		cfg.traceConnect = enabled

--- a/ddtrace/ext/db.go
+++ b/ddtrace/ext/db.go
@@ -87,4 +87,7 @@ const (
 
 	// CassandraContactPoints holds the list of cassandra initial seed nodes used to discover the cluster.
 	CassandraContactPoints = "db.cassandra.contact.points"
+
+	// CassandraHostID represents the host ID for this operation.
+	CassandraHostID = "db.cassandra.host.id"
 )

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,9 @@ services:
     image: cassandra:3.11
     environment:
       JVM_OPTS: "-Xms750m -Xmx750m"
+      CASSANDRA_CLUSTER_NAME: "dd-trace-go-test-cluster"
+      CASSANDRA_DC: "dd-trace-go-test-datacenter"
+      CASSANDRA_ENDPOINT_SNITCH: "GossipingPropertyFileSnitch"
     ports:
       - "9042:9042"
   mysql:

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/go-redis/redis/v7 v7.4.1
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/go-sql-driver/mysql v1.6.0
-	github.com/gocql/gocql v0.0.0-20220224095938-0eacd3183625
+	github.com/gocql/gocql v1.6.0
 	github.com/gofiber/fiber/v2 v2.52.5
 	github.com/golang/protobuf v1.5.3
 	github.com/gomodule/redigo v1.8.9

--- a/go.sum
+++ b/go.sum
@@ -1224,8 +1224,8 @@ github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncV
 github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
-github.com/gocql/gocql v0.0.0-20220224095938-0eacd3183625 h1:6ImvI6U901e1ezn/8u2z3bh1DZIvMOia0yTSBxhy4Ao=
-github.com/gocql/gocql v0.0.0-20220224095938-0eacd3183625/go.mod h1:3gM2c4D3AnkISwBxGnMMsS8Oy4y2lhbPRsH4xnJrHG8=
+github.com/gocql/gocql v1.6.0 h1:IdFdOTbnpbd0pDhl4REKQDM+Q0SzKXQ1Yh+YZZ8T/qU=
+github.com/gocql/gocql v1.6.0/go.mod h1:3gM2c4D3AnkISwBxGnMMsS8Oy4y2lhbPRsH4xnJrHG8=
 github.com/godbus/dbus v0.0.0-20151105175453-c7fdd8b5cd55/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
- Adds `CreateTracedSession`, and `NewObserver` functions that make use of the gocql [observer apis](https://pkg.go.dev/github.com/gocql/gocql#hdr-Metrics_and_tracing):  (it only implements the query, batch and connect observers for now).
- Adds new options `WithTraceQuery`, `WithTraceBatch` and `WithTraceConnect` to enable/disable these observers individually (all are enabled by default).
- Mark the existing wrapping functions and types as deprecated.

Differences with the existing tracing method:
- The tags `cassandra.paginated` and `cassandra.consistency_level` are not set, since the required information is not available in the observer api.
- The new observer based functions set `out.host` to the actual host name instead of the cassandra host ID. The host ID is set to a new tag called `db.cassandra.host.id`.
- The new observer based functions ignore the `DD_TRACE_GOCQL_COMPAT` env variable introduced in  https://github.com/DataDog/dd-trace-go/pull/2577 and instead directly set the correct values for the `cassandra.cluster` and `cassandra.datacenter` tags.
- `cassandra.row_count` is a number value instead of a string.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->
Using the observer apis makes this instrumentation easier to use and maintain. It also allows to use the native gocql types instead of our custom wrapper types.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
