### PR TITLE
go.mod: retract experimental versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -289,3 +289,15 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
+
+// Retract experimental versions
+retract (
+	v1.999.0-rc.8
+	v1.999.0-rc.7
+	v1.999.0-rc.6
+	v1.999.0-rc.5
+	v1.999.0-rc.4
+	v1.999.0-rc.3
+	v1.999.0-rc.2
+	v1.999.0-rc.1
+)


### PR DESCRIPTION
### What does this PR do?

Retracts some tagged versions created to dogfood our v1 shim for v2.

### Motivation

Keep public docs clean and let users to use release candidates if they want without `go get` pulling the experimental versions accidentally.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
