### PR TITLE
chore(w3c): ensure last parent id is never set to 16 zeros

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -507,7 +507,7 @@ func getDatadogPropagator(cp *chainedPropagator) *propagator {
 // if the reparenting ID is not set on the context, the span ID from datadog headers is used.
 func overrideDatadogParentID(ctx, w3cCtx, ddCtx *spanContext) {
 	ctx.spanID = w3cCtx.spanID
-	if w3cCtx.reparentID != "" && w3cCtx.reparentID != "0000000000000000" {
+	if w3cCtx.reparentID != "" {
 		ctx.reparentID = w3cCtx.reparentID
 	} else if ddCtx != nil {
 		// NIT: could be done without using fmt.Sprintf? Is it worth it?
@@ -967,7 +967,7 @@ func composeTracestate(ctx *spanContext, priority int, oldState string) string {
 	if !ctx.isRemote {
 		b.WriteString(";p:")
 		b.WriteString(spanIDHexEncoded(ctx.SpanID(), 16))
-	} else if ctx.reparentID != "" && ctx.reparentID != "0000000000000000" {
+	} else if ctx.reparentID != "" {
 		b.WriteString(";p:")
 		b.WriteString(ctx.reparentID)
 	}
@@ -1201,10 +1201,6 @@ func parseTracestate(ctx *spanContext, header string) {
 				val = strings.ReplaceAll(val, "~", "=")
 				setPropagatingTag(ctx, "_dd.p."+keySuffix, val)
 			}
-		}
-		// if dd list-member is present and last parent is not set, set it to zeros
-		if ctx.reparentID == "" {
-			ctx.reparentID = "0000000000000000"
 		}
 	}
 }

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -1756,7 +1756,7 @@ func TestEnvVars(t *testing.T) {
 					},
 					out:        []uint64{8687463697196027922, 1311768467284833366},
 					priority:   1,
-					lastParent: "0000000000000000",
+					lastParent: "",
 				},
 			}
 			for i, tc := range tests {
@@ -1839,7 +1839,13 @@ func TestEnvVars(t *testing.T) {
 					if tc.priority != 0 {
 						sctx.setSamplingPriority(int(tc.priority), samplernames.Unknown)
 					}
-					assert.Equal(s.(*span).Meta["_dd.parent_id"], tc.lastParent)
+
+					if tc.lastParent == "" {
+						assert.Empty(s.(*span).Meta["_dd.parent_id"])
+					} else {
+						assert.Equal(s.(*span).Meta["_dd.parent_id"], tc.lastParent)
+					}
+
 					assert.Equal(true, sctx.updated)
 
 					headers := TextMapCarrier(map[string]string{})


### PR DESCRIPTION
### What does this PR do?

Currently when w3c tracestate headers are extracted by Datadog W3C Propagators:
1) The `p` value in the tracestate is stored in `SpanContext.reparentID`.
2) If the `p` value is not found in the tracestate then SpanContext.reparentID (which will be used to set `Span.meta["_dd.parent_id"]`) is set to `0000000000000000`.

The second condition is no longer required. Datadog internal services no longer handle the case where `Span.meta["_dd.parent_id"] == 0000000000000000`. `0000000000000000` is treated as an invalid value and ignored. We should avoid setting this value in client libraries.

### Motivation

- Simplify the extraction logic for w3c tracecontext headers. 
- Avoids unnecessary tags to the Datadog agent.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
