### PR TITLE
v2: feat(contrib): migrate twitchtv/twirp, tidwall/buntdb, syndtr/goleveldb/leveldb, Shopify/sarama, sirupsen/logrus

### DIFF
--- a/contrib/Shopify/sarama/option.go
+++ b/contrib/Shopify/sarama/option.go
@@ -8,8 +8,7 @@ package sarama
 import (
 	"math"
 
-	"github.com/DataDog/dd-trace-go/v2/internal"
-	"github.com/DataDog/dd-trace-go/v2/internal/namingschema"
+	"github.com/DataDog/dd-trace-go/v2/instrumentation"
 )
 
 const defaultServiceName = "kafka"
@@ -25,20 +24,15 @@ type config struct {
 }
 
 func defaults(cfg *config) {
-	cfg.consumerServiceName = namingschema.ServiceName(defaultServiceName)
-	cfg.producerServiceName = namingschema.ServiceNameOverrideV0(defaultServiceName, defaultServiceName)
+	cfg.consumerServiceName = instr.ServiceName(instrumentation.ComponentConsumer, nil)
+	cfg.producerServiceName = instr.ServiceName(instrumentation.ComponentProducer, nil)
 
-	cfg.consumerSpanName = namingschema.OpName(namingschema.KafkaInbound)
-	cfg.producerSpanName = namingschema.OpName(namingschema.KafkaOutbound)
+	cfg.consumerSpanName = instr.OperationName(instrumentation.ComponentConsumer, nil)
+	cfg.producerSpanName = instr.OperationName(instrumentation.ComponentProducer, nil)
 
-	cfg.dataStreamsEnabled = internal.BoolEnv("DD_DATA_STREAMS_ENABLED", false)
+	cfg.dataStreamsEnabled = instr.DataStreamsEnabled()
 
-	// cfg.analyticsRate = globalconfig.AnalyticsRate()
-	if internal.BoolEnv("DD_TRACE_SARAMA_ANALYTICS_ENABLED", false) {
-		cfg.analyticsRate = 1.0
-	} else {
-		cfg.analyticsRate = math.NaN()
-	}
+	cfg.analyticsRate = instr.AnalyticsRate(false)
 }
 
 // Option describes options for the Sarama integration.

--- a/contrib/Shopify/sarama/sarama.go
+++ b/contrib/Shopify/sarama/sarama.go
@@ -15,17 +15,15 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
-	"github.com/DataDog/dd-trace-go/v2/internal/log"
-	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
+	"github.com/DataDog/dd-trace-go/v2/instrumentation"
 
 	"github.com/Shopify/sarama"
 )
 
-const componentName = "Shopify/sarama"
+var instr *instrumentation.Instrumentation
 
 func init() {
-	telemetry.LoadIntegration(componentName)
-	tracer.MarkIntegrationImported("github.com/Shopify/sarama")
+	instr = instrumentation.Load(instrumentation.PackageShopifySarama)
 }
 
 type partitionConsumer struct {
@@ -47,7 +45,7 @@ func WrapPartitionConsumer(pc sarama.PartitionConsumer, opts ...Option) sarama.P
 	for _, opt := range opts {
 		opt.apply(cfg)
 	}
-	log.Debug("contrib/Shopify/sarama: Wrapping Partition Consumer: %#v", cfg)
+	instr.Logger().Debug("contrib/Shopify/sarama: Wrapping Partition Consumer: %#v", cfg)
 	wrapped := &partitionConsumer{
 		PartitionConsumer: pc,
 		messages:          make(chan *sarama.ConsumerMessage),
@@ -63,7 +61,7 @@ func WrapPartitionConsumer(pc sarama.PartitionConsumer, opts ...Option) sarama.P
 				tracer.SpanType(ext.SpanTypeMessageConsumer),
 				tracer.Tag(ext.MessagingKafkaPartition, msg.Partition),
 				tracer.Tag("offset", msg.Offset),
-				tracer.Tag(ext.Component, componentName),
+				tracer.Tag(ext.Component, instrumentation.PackageShopifySarama),
 				tracer.Tag(ext.SpanKind, ext.SpanKindConsumer),
 				tracer.Tag(ext.MessagingSystem, ext.MessagingSystemKafka),
 				tracer.Measured(),
@@ -170,7 +168,7 @@ func WrapSyncProducer(saramaConfig *sarama.Config, producer sarama.SyncProducer,
 	for _, opt := range opts {
 		opt.apply(cfg)
 	}
-	log.Debug("contrib/Shopify/sarama: Wrapping Sync Producer: %#v", cfg)
+	instr.Logger().Debug("contrib/Shopify/sarama: Wrapping Sync Producer: %#v", cfg)
 	if saramaConfig == nil {
 		saramaConfig = sarama.NewConfig()
 	}
@@ -214,12 +212,12 @@ func WrapAsyncProducer(saramaConfig *sarama.Config, p sarama.AsyncProducer, opts
 	for _, opt := range opts {
 		opt.apply(cfg)
 	}
-	log.Debug("contrib/Shopify/sarama: Wrapping Async Producer: %#v", cfg)
+	instr.Logger().Debug("contrib/Shopify/sarama: Wrapping Async Producer: %#v", cfg)
 	if saramaConfig == nil {
 		saramaConfig = sarama.NewConfig()
 		saramaConfig.Version = sarama.V0_11_0_0
 	} else if !saramaConfig.Version.IsAtLeast(sarama.V0_11_0_0) {
-		log.Error("Tracing Sarama async producer requires at least sarama.V0_11_0_0 version")
+		instr.Logger().Error("Tracing Sarama async producer requires at least sarama.V0_11_0_0 version")
 	}
 	wrapped := &asyncProducer{
 		AsyncProducer: p,
@@ -289,7 +287,7 @@ func startProducerSpan(cfg *config, version sarama.KafkaVersion, msg *sarama.Pro
 		tracer.ServiceName(cfg.producerServiceName),
 		tracer.ResourceName("Produce Topic " + msg.Topic),
 		tracer.SpanType(ext.SpanTypeMessageProducer),
-		tracer.Tag(ext.Component, componentName),
+		tracer.Tag(ext.Component, instrumentation.PackageShopifySarama),
 		tracer.Tag(ext.SpanKind, ext.SpanKindProducer),
 		tracer.Tag(ext.MessagingSystem, ext.MessagingSystemKafka),
 	}

--- a/contrib/Shopify/sarama/sarama_test.go
+++ b/contrib/Shopify/sarama/sarama_test.go
@@ -14,75 +14,10 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
-	"github.com/DataDog/dd-trace-go/v2/internal/contrib/namingschematest"
 
 	"github.com/Shopify/sarama"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func genTestSpans(t *testing.T, serviceOverride string) []*mocktracer.Span {
-	var opts []Option
-	if serviceOverride != "" {
-		opts = append(opts, WithService(serviceOverride))
-	}
-	mt := mocktracer.Start()
-	defer mt.Stop()
-
-	broker := sarama.NewMockBroker(t, 1)
-	defer broker.Close()
-
-	broker.SetHandlerByMap(map[string]sarama.MockResponse{
-		"MetadataRequest": sarama.NewMockMetadataResponse(t).
-			SetBroker(broker.Addr(), broker.BrokerID()).
-			SetLeader("test-topic", 0, broker.BrokerID()),
-		"OffsetRequest": sarama.NewMockOffsetResponse(t).
-			SetOffset("test-topic", 0, sarama.OffsetOldest, 0).
-			SetOffset("test-topic", 0, sarama.OffsetNewest, 1),
-		"FetchRequest": sarama.NewMockFetchResponse(t, 1).
-			SetMessage("test-topic", 0, 0, sarama.StringEncoder("hello")),
-		"ProduceRequest": sarama.NewMockProduceResponse(t).
-			SetError("test-topic", 0, sarama.ErrNoError),
-	})
-	cfg := sarama.NewConfig()
-	cfg.Version = sarama.MinVersion
-	cfg.Producer.Return.Successes = true
-	cfg.Producer.Flush.Messages = 1
-
-	producer, err := sarama.NewSyncProducer([]string{broker.Addr()}, cfg)
-	require.NoError(t, err)
-	producer = WrapSyncProducer(cfg, producer, opts...)
-
-	c, err := sarama.NewConsumer([]string{broker.Addr()}, cfg)
-	require.NoError(t, err)
-	defer func(c sarama.Consumer) {
-		err := c.Close()
-		require.NoError(t, err)
-	}(c)
-	c = WrapConsumer(c, opts...)
-
-	msg1 := &sarama.ProducerMessage{
-		Topic:    "test-topic",
-		Value:    sarama.StringEncoder("test 1"),
-		Metadata: "test",
-	}
-	_, _, err = producer.SendMessage(msg1)
-	require.NoError(t, err)
-
-	pc, err := c.ConsumePartition("test-topic", 0, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_ = <-pc.Messages()
-	err = pc.Close()
-	require.NoError(t, err)
-	// wait for the channel to be closed
-	<-pc.Messages()
-
-	spans := mt.FinishedSpans()
-	require.Len(t, spans, 2)
-	return spans
-}
 
 func TestConsumer(t *testing.T) {
 	mt := mocktracer.Start()
@@ -375,10 +310,6 @@ func TestAsyncProducer(t *testing.T) {
 			assert.Equal(t, "kafka", s.Tag(ext.MessagingSystem))
 		}
 	})
-}
-
-func TestNamingSchema(t *testing.T) {
-	namingschematest.NewKafkaTest(genTestSpans)(t)
 }
 
 func newMockBroker(t *testing.T) *sarama.MockBroker {

--- a/contrib/sirupsen/logrus/logrus.go
+++ b/contrib/sirupsen/logrus/logrus.go
@@ -8,16 +8,15 @@ package logrus
 
 import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
-	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
+	"github.com/DataDog/dd-trace-go/v2/instrumentation"
 
 	"github.com/sirupsen/logrus"
 )
 
-const componentName = "sirupsen/logrus"
+var instr *instrumentation.Instrumentation
 
 func init() {
-	telemetry.LoadIntegration(componentName)
-	tracer.MarkIntegrationImported("github.com/sirupsen/logrus")
+	instr = instrumentation.Load(instrumentation.PackageSirupsenLogrus)
 }
 
 // DDContextLogHook ensures that any span in the log context is correlated to log output.

--- a/contrib/syndtr/goleveldb/leveldb/leveldb.go
+++ b/contrib/syndtr/goleveldb/leveldb/leveldb.go
@@ -12,8 +12,7 @@ import (
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
-	"github.com/DataDog/dd-trace-go/v2/internal/log"
-	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
+	"github.com/DataDog/dd-trace-go/v2/instrumentation"
 
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/iterator"
@@ -24,9 +23,10 @@ import (
 
 const componentName = "syndtr/goleveldb/leveldb"
 
+var instr *instrumentation.Instrumentation
+
 func init() {
-	telemetry.LoadIntegration(componentName)
-	tracer.MarkIntegrationImported("github.com/syndtr/goleveldb")
+	instr = instrumentation.Load(instrumentation.PackageSyndtrGoLevelDB)
 }
 
 // A DB wraps a leveldb.DB and traces all queries.
@@ -56,7 +56,7 @@ func OpenFile(path string, o *opt.Options, opts ...Option) (*DB, error) {
 // WrapDB wraps a leveldb.DB so that queries are traced.
 func WrapDB(db *leveldb.DB, opts ...Option) *DB {
 	cfg := newConfig(opts...)
-	log.Debug("contrib/syndtr/goleveldb/leveldb: Wrapping DB: %#v", cfg)
+	instr.Logger().Debug("contrib/syndtr/goleveldb/leveldb: Wrapping DB: %#v", cfg)
 	return &DB{
 		DB:  db,
 		cfg: cfg,

--- a/contrib/syndtr/goleveldb/leveldb/leveldb_test.go
+++ b/contrib/syndtr/goleveldb/leveldb/leveldb_test.go
@@ -12,11 +12,9 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
-	"github.com/DataDog/dd-trace-go/v2/internal/contrib/namingschematest"
-	"github.com/DataDog/dd-trace-go/v2/internal/globalconfig"
+	"github.com/DataDog/dd-trace-go/v2/instrumentation/testutils"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/storage"
@@ -183,9 +181,7 @@ func TestAnalyticsSettings(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		rate := globalconfig.AnalyticsRate()
-		defer globalconfig.SetAnalyticsRate(rate)
-		globalconfig.SetAnalyticsRate(0.4)
+		testutils.SetGlobalAnalyticsRate(t, 0.4)
 
 		assertRate(t, mt, 0.4)
 	})
@@ -208,44 +204,8 @@ func TestAnalyticsSettings(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		rate := globalconfig.AnalyticsRate()
-		defer globalconfig.SetAnalyticsRate(rate)
-		globalconfig.SetAnalyticsRate(0.4)
+		testutils.SetGlobalAnalyticsRate(t, 0.4)
 
 		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
 	})
-}
-
-func TestNamingSchema(t *testing.T) {
-	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []*mocktracer.Span {
-		var opts []Option
-		if serviceOverride != "" {
-			opts = append(opts, WithService(serviceOverride))
-		}
-		mt := mocktracer.Start()
-		defer mt.Stop()
-
-		db, err := Open(storage.NewMemStorage(), &opt.Options{}, opts...)
-		require.NoError(t, err)
-		defer db.Close()
-		err = db.Put([]byte("key"), []byte("value"), nil)
-		require.NoError(t, err)
-
-		return mt.FinishedSpans()
-	})
-	assertOpV0 := func(t *testing.T, spans []*mocktracer.Span) {
-		require.Len(t, spans, 1)
-		assert.Equal(t, "leveldb.query", spans[0].OperationName())
-	}
-	assertOpV1 := func(t *testing.T, spans []*mocktracer.Span) {
-		require.Len(t, spans, 1)
-		assert.Equal(t, "leveldb.query", spans[0].OperationName())
-	}
-	wantServiceNameV0 := namingschematest.ServiceNameAssertions{
-		WithDefaults:             []string{"leveldb"},
-		WithDDService:            []string{"leveldb"},
-		WithDDServiceAndOverride: []string{namingschematest.TestServiceOverride},
-	}
-	t.Run("ServiceName", namingschematest.NewServiceNameTest(genSpans, wantServiceNameV0))
-	t.Run("SpanName", namingschematest.NewSpanNameTest(genSpans, assertOpV0, assertOpV1))
 }

--- a/contrib/syndtr/goleveldb/leveldb/option.go
+++ b/contrib/syndtr/goleveldb/leveldb/option.go
@@ -9,11 +9,8 @@ import (
 	"context"
 	"math"
 
-	"github.com/DataDog/dd-trace-go/v2/internal"
-	"github.com/DataDog/dd-trace-go/v2/internal/namingschema"
+	"github.com/DataDog/dd-trace-go/v2/instrumentation"
 )
-
-const defaultServiceName = "leveldb"
 
 type config struct {
 	ctx           context.Context
@@ -24,14 +21,10 @@ type config struct {
 
 func newConfig(opts ...Option) *config {
 	cfg := &config{
-		serviceName: namingschema.ServiceNameOverrideV0(defaultServiceName, defaultServiceName),
-		spanName:    namingschema.OpName(namingschema.LevelDBOutbound),
-		ctx:         context.Background(),
-		// cfg.analyticsRate: globalconfig.AnalyticsRate(),
-		analyticsRate: math.NaN(),
-	}
-	if internal.BoolEnv("DD_TRACE_LEVELDB_ANALYTICS_ENABLED", false) {
-		cfg.analyticsRate = 1.0
+		serviceName:   instr.ServiceName(instrumentation.ComponentDefault, nil),
+		spanName:      instr.OperationName(instrumentation.ComponentDefault, nil),
+		ctx:           context.Background(),
+		analyticsRate: instr.AnalyticsRate(false),
 	}
 	for _, opt := range opts {
 		opt.apply(cfg)

--- a/contrib/tidwall/buntdb/buntdb.go
+++ b/contrib/tidwall/buntdb/buntdb.go
@@ -12,17 +12,17 @@ import (
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
-	"github.com/DataDog/dd-trace-go/v2/internal/log"
-	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
+	"github.com/DataDog/dd-trace-go/v2/instrumentation"
 
 	"github.com/tidwall/buntdb"
 )
 
 const componentName = "tidwall/buntdb"
 
+var instr *instrumentation.Instrumentation
+
 func init() {
-	telemetry.LoadIntegration(componentName)
-	tracer.MarkIntegrationImported("github.com/tidwall/buntdb")
+	instr = instrumentation.Load(instrumentation.PackageTidwallBuntDB)
 }
 
 // A DB wraps a buntdb.DB, automatically tracing any transactions.
@@ -93,7 +93,7 @@ func WrapTx(tx *buntdb.Tx, opts ...Option) *Tx {
 	for _, opt := range opts {
 		opt.apply(cfg)
 	}
-	log.Debug("contrib/tidwall/buntdb: Wrapping Transaction: %#v", cfg)
+	instr.Logger().Debug("contrib/tidwall/buntdb: Wrapping Transaction: %#v", cfg)
 	return &Tx{
 		Tx:  tx,
 		cfg: cfg,

--- a/contrib/tidwall/buntdb/option.go
+++ b/contrib/tidwall/buntdb/option.go
@@ -9,11 +9,8 @@ import (
 	"context"
 	"math"
 
-	"github.com/DataDog/dd-trace-go/v2/internal"
-	"github.com/DataDog/dd-trace-go/v2/internal/namingschema"
+	"github.com/DataDog/dd-trace-go/v2/instrumentation"
 )
-
-const defaultServiceName = "buntdb"
 
 type config struct {
 	ctx           context.Context
@@ -23,15 +20,10 @@ type config struct {
 }
 
 func defaults(cfg *config) {
-	cfg.serviceName = namingschema.ServiceNameOverrideV0(defaultServiceName, defaultServiceName)
-	cfg.spanName = namingschema.OpName(namingschema.BuntDBOutbound)
+	cfg.serviceName = instr.ServiceName(instrumentation.ComponentDefault, nil)
+	cfg.spanName = instr.OperationName(instrumentation.ComponentDefault, nil)
+	cfg.analyticsRate = instr.AnalyticsRate(false)
 	cfg.ctx = context.Background()
-	// cfg.analyticsRate = globalconfig.AnalyticsRate()
-	if internal.BoolEnv("DD_TRACE_BUNTDB_ANALYTICS_ENABLED", false) {
-		cfg.analyticsRate = 1.0
-	} else {
-		cfg.analyticsRate = math.NaN()
-	}
 }
 
 // Option describes options for the BuntDB integration.

--- a/contrib/twitchtv/twirp/option.go
+++ b/contrib/twitchtv/twirp/option.go
@@ -8,14 +8,7 @@ package twirp
 import (
 	"math"
 
-	"github.com/DataDog/dd-trace-go/v2/internal"
-	"github.com/DataDog/dd-trace-go/v2/internal/globalconfig"
-	"github.com/DataDog/dd-trace-go/v2/internal/namingschema"
-)
-
-const (
-	defaultClientServiceName = "twirp-client"
-	defaultServerServiceName = "twirp-server"
+	"github.com/DataDog/dd-trace-go/v2/instrumentation"
 )
 
 type config struct {
@@ -37,21 +30,17 @@ func (fn OptionFn) apply(cfg *config) {
 }
 
 func defaults(cfg *config) {
-	if internal.BoolEnv("DD_TRACE_TWIRP_ANALYTICS_ENABLED", false) {
-		cfg.analyticsRate = 1.0
-	} else {
-		cfg.analyticsRate = globalconfig.AnalyticsRate()
-	}
+	cfg.analyticsRate = instr.AnalyticsRate(true)
 }
 
 func clientDefaults(cfg *config) {
-	cfg.serviceName = namingschema.ServiceName(defaultClientServiceName)
-	cfg.spanName = namingschema.OpName(namingschema.TwirpClient)
+	cfg.serviceName = instr.ServiceName(instrumentation.ComponentClient, nil)
+	cfg.spanName = instr.OperationName(instrumentation.ComponentClient, nil)
 	defaults(cfg)
 }
 
 func serverDefaults(cfg *config) {
-	cfg.serviceName = namingschema.ServiceName(defaultServerServiceName)
+	cfg.serviceName = instr.ServiceName(instrumentation.ComponentServer, nil)
 	// spanName is calculated dynamically since V0 span names are based on the twirp service name.
 	defaults(cfg)
 }

--- a/go.work.sum
+++ b/go.work.sum
@@ -1167,6 +1167,7 @@ github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
+github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
@@ -1198,6 +1199,7 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4 h1:WtGNWLvXpe
 github.com/go-ini/ini v1.25.4 h1:Mujh4R/dH6YL8bxuISne3xX2+qcQ9p0IxKAP6ExWoUo=
 github.com/go-jose/go-jose/v3 v3.0.1 h1:pWmKFVtt+Jl0vBZTIpz/eAKwsm6LkIxDVVbFHKkchhA=
 github.com/go-jose/go-jose/v3 v3.0.1/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
+github.com/go-jose/go-jose/v3 v3.0.3 h1:fFKWeig/irsp7XD2zBxvnmA/XaRWp5V3CBsZXJF7G7k=
 github.com/go-jose/go-jose/v3 v3.0.3/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-kit/kit v0.9.0 h1:wDJmvq38kDhkVxi50ni9ykkdUr1PKgqKOoi01fa0Mdk=
 github.com/go-kit/log v0.1.0 h1:DGJh0Sm43HbOeYDNnVZFl8BvcYVvjD5bqYJvp0REbwQ=
@@ -1312,6 +1314,7 @@ github.com/hashicorp/go-kms-wrapping/v2 v2.0.8/go.mod h1:qTCjxGig/kjuj3hk1z8pOUr
 github.com/hashicorp/go-plugin v1.4.8 h1:CHGwpxYDOttQOY7HOWgETU9dyVjOXzniXDqJcYJE1zM=
 github.com/hashicorp/go-plugin v1.4.8/go.mod h1:viDMjcLJuDui6pXb8U4HVfb8AamCWhHGUjr2IrTF67s=
 github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-retryablehttp v0.7.5 h1:bJj+Pj19UZMIweq/iie+1u5YCdGrnxCT9yvm0e+Nd5M=
 github.com/hashicorp/go-retryablehttp v0.7.5/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/go-secure-stdlib/base62 v0.1.2 h1:ET4pqyjiGmY09R5y+rSd70J2w45CtbWDNvGqWp/R3Ng=
 github.com/hashicorp/go-secure-stdlib/base62 v0.1.2/go.mod h1:EdWO6czbmthiwZ3/PUsDV+UD1D5IRU4ActiaWGwt0Yw=
@@ -1329,6 +1332,7 @@ github.com/hashicorp/go.net v0.0.1 h1:sNCoNyDEvN1xa+X0baata4RdcpKwcMS6DH+xwfqPgj
 github.com/hashicorp/hcl/v2 v2.20.1/go.mod h1:TZDqQ4kNKCbh1iJp99FdPiUaVDDUPivbqxZulxDYqL4=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/mdns v1.0.4 h1:sY0CMhFmjIPDMlTB+HfymFHCaYLhgifZ0QhjaYKD/UQ=
+github.com/hashicorp/vault/api v1.12.1 h1:WzGN4X5jrJdNO39g6Sa55djNio3I9DxEBOTmCZE7tm0=
 github.com/hashicorp/vault/api v1.12.1/go.mod h1:1pqP/sErScodde+ybJCyP+ONC4jzEg7Dmawg/QLWo1k=
 github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87 h1:xixZ2bWeofWV68J+x6AzmKuVM/JWCQwkWm6GW/MUR6I=
 github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=

--- a/instrumentation/internal/namingschematest/main_test.go
+++ b/instrumentation/internal/namingschematest/main_test.go
@@ -37,6 +37,7 @@ func TestNamingSchema(t *testing.T) {
 		urfaveNegroni,
 		twitchTVTwirp,
 		tidwallBuntDB,
+		syndtrGoLevelDB,
 	}
 	for _, tc := range testCases {
 		harness.RunTest(t, tc)

--- a/instrumentation/internal/namingschematest/main_test.go
+++ b/instrumentation/internal/namingschematest/main_test.go
@@ -36,6 +36,7 @@ func TestNamingSchema(t *testing.T) {
 		gcpPubsub,
 		urfaveNegroni,
 		twitchTVTwirp,
+		tidwallBuntDB,
 	}
 	for _, tc := range testCases {
 		harness.RunTest(t, tc)

--- a/instrumentation/internal/namingschematest/main_test.go
+++ b/instrumentation/internal/namingschematest/main_test.go
@@ -38,6 +38,7 @@ func TestNamingSchema(t *testing.T) {
 		twitchTVTwirp,
 		tidwallBuntDB,
 		syndtrGoLevelDB,
+		shopifySarama,
 	}
 	for _, tc := range testCases {
 		harness.RunTest(t, tc)

--- a/instrumentation/internal/namingschematest/main_test.go
+++ b/instrumentation/internal/namingschematest/main_test.go
@@ -35,6 +35,7 @@ func TestNamingSchema(t *testing.T) {
 		gomemcache,
 		gcpPubsub,
 		urfaveNegroni,
+		twitchTVTwirp,
 	}
 	for _, tc := range testCases {
 		harness.RunTest(t, tc)

--- a/instrumentation/internal/namingschematest/shopify_sarama.go
+++ b/instrumentation/internal/namingschematest/shopify_sarama.go
@@ -1,0 +1,98 @@
+package namingschematest
+
+import (
+	"testing"
+
+	saramatrace "github.com/DataDog/dd-trace-go/contrib/Shopify/sarama/v2"
+	"github.com/DataDog/dd-trace-go/instrumentation/internal/namingschematest/harness"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
+	"github.com/DataDog/dd-trace-go/v2/instrumentation"
+	"github.com/Shopify/sarama"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func shopifySaramaGenSpans() harness.GenSpansFn {
+	return func(t *testing.T, serviceOverride string) []*mocktracer.Span {
+		var opts []saramatrace.Option
+		if serviceOverride != "" {
+			opts = append(opts, saramatrace.WithService(serviceOverride))
+		}
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		broker := sarama.NewMockBroker(t, 1)
+		defer broker.Close()
+
+		broker.SetHandlerByMap(map[string]sarama.MockResponse{
+			"MetadataRequest": sarama.NewMockMetadataResponse(t).
+				SetBroker(broker.Addr(), broker.BrokerID()).
+				SetLeader("test-topic", 0, broker.BrokerID()),
+			"OffsetRequest": sarama.NewMockOffsetResponse(t).
+				SetOffset("test-topic", 0, sarama.OffsetOldest, 0).
+				SetOffset("test-topic", 0, sarama.OffsetNewest, 1),
+			"FetchRequest": sarama.NewMockFetchResponse(t, 1).
+				SetMessage("test-topic", 0, 0, sarama.StringEncoder("hello")),
+			"ProduceRequest": sarama.NewMockProduceResponse(t).
+				SetError("test-topic", 0, sarama.ErrNoError),
+		})
+		cfg := sarama.NewConfig()
+		cfg.Version = sarama.MinVersion
+		cfg.Producer.Return.Successes = true
+		cfg.Producer.Flush.Messages = 1
+
+		producer, err := sarama.NewSyncProducer([]string{broker.Addr()}, cfg)
+		require.NoError(t, err)
+		producer = saramatrace.WrapSyncProducer(cfg, producer, opts...)
+
+		c, err := sarama.NewConsumer([]string{broker.Addr()}, cfg)
+		require.NoError(t, err)
+		defer func(c sarama.Consumer) {
+			err := c.Close()
+			require.NoError(t, err)
+		}(c)
+		c = saramatrace.WrapConsumer(c, opts...)
+
+		msg1 := &sarama.ProducerMessage{
+			Topic:    "test-topic",
+			Value:    sarama.StringEncoder("test 1"),
+			Metadata: "test",
+		}
+		_, _, err = producer.SendMessage(msg1)
+		require.NoError(t, err)
+
+		pc, err := c.ConsumePartition("test-topic", 0, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = <-pc.Messages()
+		err = pc.Close()
+		require.NoError(t, err)
+		// wait for the channel to be closed
+		<-pc.Messages()
+
+		spans := mt.FinishedSpans()
+		require.Len(t, spans, 2)
+		return spans
+	}
+}
+
+var shopifySarama = harness.TestCase{
+	Name:     instrumentation.PackageShopifySarama,
+	GenSpans: shopifySaramaGenSpans(),
+	WantServiceNameV0: harness.ServiceNameAssertions{
+		Defaults:        harness.RepeatString("kafka", 2),
+		DDService:       []string{"kafka", harness.TestDDService},
+		ServiceOverride: harness.RepeatString(harness.TestServiceOverride, 2),
+	},
+	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
+		require.Len(t, spans, 2)
+		assert.Equal(t, "kafka.produce", spans[0].OperationName())
+		assert.Equal(t, "kafka.consume", spans[1].OperationName())
+	},
+	AssertOpV1: func(t *testing.T, spans []*mocktracer.Span) {
+		require.Len(t, spans, 2)
+		assert.Equal(t, "kafka.send", spans[0].OperationName())
+		assert.Equal(t, "kafka.process", spans[1].OperationName())
+	},
+}

--- a/instrumentation/internal/namingschematest/syndtr_goleveldb.go
+++ b/instrumentation/internal/namingschematest/syndtr_goleveldb.go
@@ -1,0 +1,51 @@
+package namingschematest
+
+import (
+	"testing"
+
+	leveldbtrace "github.com/DataDog/dd-trace-go/contrib/syndtr/goleveldb/v2/leveldb"
+	"github.com/DataDog/dd-trace-go/instrumentation/internal/namingschematest/harness"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
+	"github.com/DataDog/dd-trace-go/v2/instrumentation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/syndtr/goleveldb/leveldb/storage"
+)
+
+func syndtrGoLevelDBGenSpans() harness.GenSpansFn {
+	return func(t *testing.T, serviceOverride string) []*mocktracer.Span {
+		var opts []leveldbtrace.Option
+		if serviceOverride != "" {
+			opts = append(opts, leveldbtrace.WithService(serviceOverride))
+		}
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		db, err := leveldbtrace.Open(storage.NewMemStorage(), &opt.Options{}, opts...)
+		require.NoError(t, err)
+		defer db.Close()
+		err = db.Put([]byte("key"), []byte("value"), nil)
+		require.NoError(t, err)
+
+		return mt.FinishedSpans()
+	}
+}
+
+var syndtrGoLevelDB = harness.TestCase{
+	Name:     instrumentation.PackageSyndtrGoLevelDB,
+	GenSpans: syndtrGoLevelDBGenSpans(),
+	WantServiceNameV0: harness.ServiceNameAssertions{
+		Defaults:        []string{"leveldb"},
+		DDService:       []string{"leveldb"},
+		ServiceOverride: []string{harness.TestServiceOverride},
+	},
+	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
+		require.Len(t, spans, 1)
+		assert.Equal(t, "leveldb.query", spans[0].OperationName())
+	},
+	AssertOpV1: func(t *testing.T, spans []*mocktracer.Span) {
+		require.Len(t, spans, 1)
+		assert.Equal(t, "leveldb.query", spans[0].OperationName())
+	},
+}

--- a/instrumentation/internal/namingschematest/tidwall_buntdb.go
+++ b/instrumentation/internal/namingschematest/tidwall_buntdb.go
@@ -1,0 +1,53 @@
+package namingschematest
+
+import (
+	"testing"
+
+	buntdbtrace "github.com/DataDog/dd-trace-go/contrib/tidwall/buntdb/v2"
+	"github.com/DataDog/dd-trace-go/instrumentation/internal/namingschematest/harness"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
+	"github.com/DataDog/dd-trace-go/v2/instrumentation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func buntDBGenSpans() harness.GenSpansFn {
+	return func(t *testing.T, serviceOverride string) []*mocktracer.Span {
+		var opts []buntdbtrace.Option
+		if serviceOverride != "" {
+			opts = append(opts, buntdbtrace.WithService(serviceOverride))
+		}
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		db, err := buntdbtrace.Open(":memory:", opts...)
+		require.NoError(t, err)
+		defer db.Close()
+
+		err = db.Update(func(tx *buntdbtrace.Tx) error {
+			_, _, err := tx.Set("key", "value", nil)
+			return err
+		})
+		require.NoError(t, err)
+
+		return mt.FinishedSpans()
+	}
+}
+
+var tidwallBuntDB = harness.TestCase{
+	Name:     instrumentation.PackageTidwallBuntDB,
+	GenSpans: buntDBGenSpans(),
+	WantServiceNameV0: harness.ServiceNameAssertions{
+		Defaults:        []string{"buntdb"},
+		DDService:       []string{"buntdb"},
+		ServiceOverride: []string{harness.TestServiceOverride},
+	},
+	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
+		require.Len(t, spans, 1)
+		assert.Equal(t, "buntdb.query", spans[0].OperationName())
+	},
+	AssertOpV1: func(t *testing.T, spans []*mocktracer.Span) {
+		require.Len(t, spans, 1)
+		assert.Equal(t, "buntdb.query", spans[0].OperationName())
+	},
+}

--- a/instrumentation/internal/namingschematest/twirp_test.go
+++ b/instrumentation/internal/namingschematest/twirp_test.go
@@ -1,0 +1,116 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package namingschematest
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+
+	twitchtvtrace "github.com/DataDog/dd-trace-go/contrib/twitchtv/twirp/v2"
+	"github.com/DataDog/dd-trace-go/instrumentation/internal/namingschematest/harness"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
+	"github.com/DataDog/dd-trace-go/v2/instrumentation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twitchtv/twirp"
+	"github.com/twitchtv/twirp/example"
+)
+
+var twitchTVTwirp = harness.TestCase{
+	Name: instrumentation.PackageTwitchTVTwirp,
+	GenSpans: func(t *testing.T, serviceOverride string) []*mocktracer.Span {
+		var opts []twitchtvtrace.Option
+		if serviceOverride != "" {
+			opts = append(opts, twitchtvtrace.WithService(serviceOverride))
+		}
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		client, cleanup := startIntegrationTestServer(t, opts...)
+		defer cleanup()
+		_, err := client.MakeHat(context.Background(), &example.Size{Inches: 6})
+		require.NoError(t, err)
+
+		return mt.FinishedSpans()
+	},
+	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
+		require.Len(t, spans, 3)
+		assert.Equal(t, "twirp.Haberdasher", spans[0].OperationName())
+		assert.Equal(t, "twirp.handler", spans[1].OperationName())
+		assert.Equal(t, "twirp.request", spans[2].OperationName())
+	},
+	AssertOpV1: func(t *testing.T, spans []*mocktracer.Span) {
+		require.Len(t, spans, 3)
+		assert.Equal(t, "twirp.server.request", spans[0].OperationName())
+		assert.Equal(t, "twirp.handler", spans[1].OperationName())
+		assert.Equal(t, "twirp.client.request", spans[2].OperationName())
+	},
+	WantServiceNameV0: harness.ServiceNameAssertions{
+		Defaults:        []string{"twirp-server", "twirp-server", "twirp-client"},
+		DDService:       harness.RepeatString(harness.TestDDService, 3),
+		ServiceOverride: harness.RepeatString(harness.TestServiceOverride, 3),
+	},
+}
+
+// Copied from contrib/twitchtv/twirp/twirp_test.go
+type notifyListener struct {
+	net.Listener
+	ch chan<- struct{}
+}
+
+func (n *notifyListener) Accept() (c net.Conn, err error) {
+	if n.ch != nil {
+		close(n.ch)
+		n.ch = nil
+	}
+	return n.Listener.Accept()
+}
+
+type haberdasher int32
+
+func (h haberdasher) MakeHat(_ context.Context, size *example.Size) (*example.Hat, error) {
+	if size.Inches != int32(h) {
+		return nil, twirp.InvalidArgumentError("Inches", "Only size of %d is allowed")
+	}
+	hat := &example.Hat{
+		Size:  size.Inches,
+		Color: "purple",
+		Name:  "doggie beanie",
+	}
+	return hat, nil
+}
+
+func startIntegrationTestServer(t *testing.T, opts ...twitchtvtrace.Option) (example.Haberdasher, func()) {
+	l, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	readyCh := make(chan struct{})
+	nl := &notifyListener{Listener: l, ch: readyCh}
+
+	hooks := twitchtvtrace.NewServerHooks(opts...)
+	server := twitchtvtrace.WrapServer(example.NewHaberdasherServer(haberdasher(6), hooks), opts...)
+	errCh := make(chan error)
+	go func() {
+		err := http.Serve(nl, server)
+		if err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+		close(errCh)
+	}()
+	select {
+	case <-readyCh:
+		break
+	case err := <-errCh:
+		l.Close()
+		assert.FailNow(t, "server not started", err)
+	}
+	client := example.NewHaberdasherJSONClient("http://"+nl.Addr().String(), twitchtvtrace.WrapClient(http.DefaultClient, opts...))
+	return client, func() {
+		assert.NoError(t, l.Close())
+	}
+}

--- a/instrumentation/packages.go
+++ b/instrumentation/packages.go
@@ -38,6 +38,7 @@ const (
 	PackageUrfaveNegroni   Package = "urfave/negroni"
 	PackageTwitchTVTwirp   Package = "twitchtv/twirp"
 	PackageTidwallBuntDB   Package = "tidwall/buntdb"
+	PackageSyndtrGoLevelDB Package = "syndtr/goleveldb/leveldb"
 )
 
 type Component int
@@ -352,6 +353,18 @@ var packages = map[Package]PackageInfo{
 				buildServiceNameV0: staticName("buntdb"),
 				buildOpNameV0:      staticName("buntdb.query"),
 				buildOpNameV1:      staticName("buntdb.query"),
+			},
+		},
+	},
+	PackageSyndtrGoLevelDB: {
+		TracedPackage: "syndtr/goleveldb/leveldb",
+		EnvVarPrefix:  "LEVELDB",
+		naming: map[Component]componentNames{
+			ComponentDefault: {
+				useDDServiceV0:     false,
+				buildServiceNameV0: staticName("leveldb"),
+				buildOpNameV0:      staticName("leveldb.query"),
+				buildOpNameV1:      staticName("leveldb.query"),
 			},
 		},
 	},

--- a/instrumentation/packages.go
+++ b/instrumentation/packages.go
@@ -40,6 +40,7 @@ const (
 	PackageTidwallBuntDB   Package = "tidwall/buntdb"
 	PackageSyndtrGoLevelDB Package = "syndtr/goleveldb/leveldb"
 	PackageSirupsenLogrus  Package = "sirupsen/logrus"
+	PackageShopifySarama   Package = "Shopify/sarama"
 )
 
 type Component int
@@ -372,6 +373,24 @@ var packages = map[Package]PackageInfo{
 	PackageSirupsenLogrus: {
 		TracedPackage: "github.com/sirupsen/logrus",
 		EnvVarPrefix:  "LOGRUS",
+	},
+	PackageShopifySarama: {
+		TracedPackage: "github.com/Shopify/sarama",
+		EnvVarPrefix:  "SARAMA",
+		naming: map[Component]componentNames{
+			ComponentConsumer: {
+				useDDServiceV0:     true,
+				buildServiceNameV0: staticName("kafka"),
+				buildOpNameV0:      staticName("kafka.consume"),
+				buildOpNameV1:      staticName("kafka.process"),
+			},
+			ComponentProducer: {
+				useDDServiceV0:     false,
+				buildServiceNameV0: staticName("kafka"),
+				buildOpNameV0:      staticName("kafka.produce"),
+				buildOpNameV1:      staticName("kafka.send"),
+			},
+		},
 	},
 }
 

--- a/instrumentation/packages.go
+++ b/instrumentation/packages.go
@@ -36,6 +36,7 @@ const (
 
 	PackageValyalaFastHTTP Package = "valyala/fasthttp"
 	PackageUrfaveNegroni   Package = "urfave/negroni"
+	PackageTwitchTVTwirp   Package = "twitchtv/twirp"
 )
 
 type Component int
@@ -314,6 +315,30 @@ var packages = map[Package]PackageInfo{
 				buildServiceNameV0: staticName("negroni.router"),
 				buildOpNameV0:      staticName("http.request"),
 				buildOpNameV1:      staticName("http.server.request"),
+			},
+		},
+	},
+	PackageTwitchTVTwirp: {
+		TracedPackage: "github.com/twitchtv/twirp",
+		EnvVarPrefix:  "TWIRP",
+		naming: map[Component]componentNames{
+			ComponentServer: {
+				useDDServiceV0:     true,
+				buildServiceNameV0: staticName("twirp-server"),
+				buildOpNameV0: func(opCtx OperationContext) string {
+					rpcService, ok := opCtx[ext.RPCService]
+					if rpcService == "" || !ok {
+						return "twirp.service"
+					}
+					return fmt.Sprintf("twirp.%s", rpcService)
+				},
+				buildOpNameV1: staticName("twirp.server.request"),
+			},
+			ComponentClient: {
+				useDDServiceV0:     true,
+				buildServiceNameV0: staticName("twirp-client"),
+				buildOpNameV0:      staticName("twirp.request"),
+				buildOpNameV1:      staticName("twirp.client.request"),
 			},
 		},
 	},

--- a/instrumentation/packages.go
+++ b/instrumentation/packages.go
@@ -39,6 +39,7 @@ const (
 	PackageTwitchTVTwirp   Package = "twitchtv/twirp"
 	PackageTidwallBuntDB   Package = "tidwall/buntdb"
 	PackageSyndtrGoLevelDB Package = "syndtr/goleveldb/leveldb"
+	PackageSirupsenLogrus  Package = "sirupsen/logrus"
 )
 
 type Component int
@@ -367,6 +368,10 @@ var packages = map[Package]PackageInfo{
 				buildOpNameV1:      staticName("leveldb.query"),
 			},
 		},
+	},
+	PackageSirupsenLogrus: {
+		TracedPackage: "github.com/sirupsen/logrus",
+		EnvVarPrefix:  "LOGRUS",
 	},
 }
 

--- a/instrumentation/packages.go
+++ b/instrumentation/packages.go
@@ -37,6 +37,7 @@ const (
 	PackageValyalaFastHTTP Package = "valyala/fasthttp"
 	PackageUrfaveNegroni   Package = "urfave/negroni"
 	PackageTwitchTVTwirp   Package = "twitchtv/twirp"
+	PackageTidwallBuntDB   Package = "tidwall/buntdb"
 )
 
 type Component int
@@ -339,6 +340,18 @@ var packages = map[Package]PackageInfo{
 				buildServiceNameV0: staticName("twirp-client"),
 				buildOpNameV0:      staticName("twirp.request"),
 				buildOpNameV1:      staticName("twirp.client.request"),
+			},
+		},
+	},
+	PackageTidwallBuntDB: {
+		TracedPackage: "tidwall/buntdb",
+		EnvVarPrefix:  "BUNTDB",
+		naming: map[Component]componentNames{
+			ComponentDefault: {
+				useDDServiceV0:     false,
+				buildServiceNameV0: staticName("buntdb"),
+				buildOpNameV0:      staticName("buntdb.query"),
+				buildOpNameV1:      staticName("buntdb.query"),
 			},
 		},
 	},


### PR DESCRIPTION
### What does this PR do?

Migrates a subset of the contribs to use the new contrib API. Each commit is a contrib, to simplify code review.

### Motivation

Contrib API was created to split contribs as nested modules: see #2768 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
