### PR TITLE
ci: set GOTOOLCHAIN=local for unit tests

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -70,6 +70,13 @@ jobs:
     # Run go mod tidy to ensure that all go.mod and go.sum files are up-to-date.
     name: 'go mod tidy smoke test'
     runs-on: ubuntu-latest
+    env:
+      # Users may build our library with GOTOOLCHAIN=local. If they do, and our
+      # go.mod file specifies a newer Go version than their local toolchain, their
+      # build will break. Run our tests with GOTOOLCHAIN=local to ensure that
+      # our library builds with all of the Go versions we claim to support,
+      # without having to download a newer one.
+      GOTOOLCHAIN: local
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -13,6 +13,12 @@ on:
 
 env:
   DD_APPSEC_WAF_TIMEOUT: 1m # Increase time WAF time budget to reduce CI flakiness
+  # Users may build our library with GOTOOLCHAIN=local. If they do, and our
+  # go.mod file specifies a newer Go version than their local toolchain, their
+  # build will break. Run our tests with GOTOOLCHAIN=local to ensure that
+  # our library builds with all of the Go versions we claim to support,
+  # without having to download a newer one.
+  GOTOOLCHAIN: local
 
 jobs:
   copyright:

--- a/internal/exectracetest/go.mod
+++ b/internal/exectracetest/go.mod
@@ -2,8 +2,6 @@ module gopkg.in/DataDog/dd-trace-go.v1/internal/exectracetest
 
 go 1.21
 
-toolchain go1.21.0
-
 require (
 	github.com/google/pprof v0.0.0-20230817174616-7a8ec2ada47b
 	github.com/mattn/go-sqlite3 v1.14.18


### PR DESCRIPTION
### What does this PR do?

Set `GOTOOLCHAIN=local` for our unit tests.

I didn't change the `go get -u` smoke tests. Those tests are inherently
incompatible with `GOTOOLCHAIN=local`. We could perhaps make them
work with `GOTOOLCHAIN=local` by adding `go@1.xyz` to the `go get -u`
commands, like [Orhcestrion does](https://github.com/DataDog/orchestrion/blob/aee181b5ec8ac51cee000d32ecd555c35340eb08/.github/workflows/deps-update.yml#L37-L38).

### Motivation

Users may build our library with `GOTOOLCHAIN=local`. If they do, and our
go.mod file specifies a newer Go version than their local toolchain, their
build will break. Run our tests with `GOTOOLCHAIN=local` to ensure that
our library builds with all of the Go versions we claim to support,
without having to download a newer one.
