### PR TITLE
ci: switch Orchestrion workflow back to main

### DIFF
--- a/.github/workflows/orchestrion.yml
+++ b/.github/workflows/orchestrion.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   test:
     name: 'Run Tests'
-    uses: DataDog/orchestrion/.github/workflows/workflow_call.yml@eliott.bouhana/APPSEC-53773 # we don't want to pin our own action
+    uses: DataDog/orchestrion/.github/workflows/workflow_call.yml@main # we don't want to pin our own action
     with:
       dd-trace-go-ref: ${{ github.sha }}
       runs-on: ubuntu-latest-16-cores


### PR DESCRIPTION
With https://github.com/DataDog/orchestrion/pull/219 merged, the branch
we pinned to for the Orchestrion test is gone. Switch back to main so
the workflow can run again.

See https://github.com/DataDog/dd-trace-go/actions/runs/10617402656/workflow
