### PR TITLE
contrib/database/sql: statsTags function must not polute globalconfig.StatTags()

### DIFF
--- a/contrib/database/sql/metrics.go
+++ b/contrib/database/sql/metrics.go
@@ -51,7 +51,7 @@ func pollDBStats(statsd internal.StatsdClient, db *sql.DB) {
 }
 
 func statsTags(c *config) []string {
-	tags := globalconfig.StatsTags()
+	tags := append([]string{}, globalconfig.StatsTags()...)
 	if c.serviceName != "" {
 		tags = append(tags, "service:"+c.serviceName)
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our.
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Ensure that statsTags function does not polute globalconfig.StatTags(). Fix https://github.com/DataDog/dd-trace-go/issues/2836
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The original implementation
```go
tags := globalconfig.StatsTags()
...
tags = append(tags, ...)
```

Every call of `statsTags` shares the same initial `globalconfig.StatTags()` slice. Even thought the `append` function will assign new slice, the array behind the slice will be the same one if `append` function determine that it does not necessary to allocate new array. And when this happen `statsTags` will effectively pollute the array behind `globalconfig.StatTags()` slice.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
