### PR TITLE
contrib/log/slog: implement handler.WithAttrs

### DIFF
--- a/contrib/log/slog/slog.go
+++ b/contrib/log/slog/slog.go
@@ -49,3 +49,9 @@ func (h *handler) Handle(ctx context.Context, rec slog.Record) error {
 	}
 	return h.Handler.Handle(ctx, rec)
 }
+
+// WithAttrs returns a new Handler whose attributes consist of
+// both the receiver's attributes and the arguments.
+func (h *handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return WrapHandler(h.Handler.WithAttrs(attrs))
+}

--- a/contrib/log/slog/slog_test.go
+++ b/contrib/log/slog/slog_test.go
@@ -74,3 +74,9 @@ func TestWrapHandler(t *testing.T) {
 		return WrapHandler(slog.NewJSONHandler(b, nil))
 	})
 }
+
+func TestWithAttrs(t *testing.T) {
+	testLogger(t, func(b *bytes.Buffer) slog.Handler {
+		return NewJSONHandler(b, nil).WithAttrs([]slog.Attr{slog.String("key", "value")})
+	})
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

implement contrib/log/slog.handler.WithAttrs
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

resolve https://github.com/DataDog/dd-trace-go/issues/2838

### Note
In the issue, I mentioned that the handler is replaced by Logger.WithGroup call as well. But I'm not sure if it is fine to implement handler.WithGroup in this case.

If you implement logger.WithGruop like 
```
func (h *handler) WithGroup(name string) slog.Handler {
	return WrapHandler(h.Handler.WithGroup(string))
}
```

the logger will produce the log with grouped dd attributes.

```
logger := slog.New(NewJSONHandler(b, nil))
logger := logger.WithGruop("group")
```

```
{"time":"2024-08-31T13:14:16.583178+09:00","level":"INFO","msg":"this is an info log with tracing information","group":{"dd.trace_id":1371324856057376362,"dd.span_id":1371324856057376362}}
```

But I think it is not what [datadog expected](https://docs.datadoghq.com/ja/tracing/other_telemetry/connect_logs_and_traces/).

I would like some advice on this.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
