### PR TITLE
internal/appsec: fix missing ResponseHeaderCopier call

### DIFF
--- a/internal/appsec/emitter/httpsec/http.go
+++ b/internal/appsec/emitter/httpsec/http.go
@@ -93,7 +93,7 @@ func WrapHandler(handler http.Handler, span ddtrace.Span, pathParams map[string]
 		r = r.WithContext(ctx)
 
 		defer func() {
-			events := op.Finish(MakeHandlerOperationRes(w))
+			events := op.Finish(MakeHandlerOperationRes(w, opts.ResponseHeaderCopier))
 
 			// Execute the onBlock functions to make sure blocking works properly
 			// in case we are instrumenting the Gin framework
@@ -149,12 +149,12 @@ func MakeHandlerOperationArgs(r *http.Request, clientIP netip.Addr, pathParams m
 }
 
 // MakeHandlerOperationRes creates the HandlerOperationRes value.
-func MakeHandlerOperationRes(w http.ResponseWriter) types.HandlerOperationRes {
+func MakeHandlerOperationRes(w http.ResponseWriter, responseHeadersCopier func(http.ResponseWriter) http.Header) types.HandlerOperationRes {
 	var status int
 	if mw, ok := w.(interface{ Status() int }); ok {
 		status = mw.Status()
 	}
-	return types.HandlerOperationRes{Status: status, Headers: headersRemoveCookies(w.Header())}
+	return types.HandlerOperationRes{Status: status, Headers: headersRemoveCookies(responseHeadersCopier(w))}
 }
 
 // Remove cookies from the request headers and return the map of headers


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR fixes a case where we were supposed to call the `ResponseHeaderCopier` func but we did not

### Motivation

Fix cases where concurrently reading the response header map would can a panic. This fixes the fix done in #2640 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
