### PR TITLE
internal/globalconfig: make statsTags un-changeable from outside of the globalconfig package

### DIFF
--- a/internal/globalconfig/globalconfig.go
+++ b/internal/globalconfig/globalconfig.go
@@ -91,7 +91,7 @@ func StatsTags() []string {
 func SetStatsTags(tags []string) {
 	cfg.mu.Lock()
 	defer cfg.mu.Unlock()
-	// Copy the slice before setting it, so that any changes to tags cannot pollute the underlying array of statsTags
+	// Copy the slice before setting it, so that any changes to the slice provided to SetStatsTags does not pollute the underlying array of statsTags
 	statsTags := make([]string, len(tags))
 	copy(statsTags, tags)
 	cfg.statsTags = statsTags

--- a/internal/globalconfig/globalconfig.go
+++ b/internal/globalconfig/globalconfig.go
@@ -80,7 +80,10 @@ func SetDogstatsdAddr(addr string) {
 func StatsTags() []string {
 	cfg.mu.RLock()
 	defer cfg.mu.RUnlock()
-	return cfg.statsTags
+	// Copy the slice before returning it, so that callers cannot pollute the underlying array
+	tags := make([]string, len(cfg.statsTags))
+	copy(tags, cfg.statsTags)
+	return tags
 }
 
 // SetStatsTags configures the list of tags that should be applied to contribs' statsd.Client as global tags
@@ -88,7 +91,10 @@ func StatsTags() []string {
 func SetStatsTags(tags []string) {
 	cfg.mu.Lock()
 	defer cfg.mu.Unlock()
-	cfg.statsTags = tags
+	// Copy the slice before setting it, so that any changes to tags cannot pollute the underlying array of statsTags
+	statsTags := make([]string, len(tags))
+	copy(statsTags, tags)
+	cfg.statsTags = statsTags
 }
 
 // RuntimeID returns this process's unique runtime id.

--- a/internal/globalconfig/globalconfig_test.go
+++ b/internal/globalconfig/globalconfig_test.go
@@ -18,3 +18,17 @@ func TestHeaderTag(t *testing.T) {
 	assert.Equal(t, "tag1", cfg.headersAsTags.Get("header1"))
 	assert.Equal(t, "tag2", cfg.headersAsTags.Get("header2"))
 }
+
+// Asserts that APIs to access cfg.statsTags protect against pollution from external changes
+func TestStatsTags(t *testing.T) {
+	array := [6]string{"aaa", "bbb", "ccc"}
+	slice1 := array[:]
+	SetStatsTags(slice1)
+	slice1 = append(slice1, []string{"ddd", "eee", "fff"}...)
+	slice1[0] = "zzz"
+	assert.Equal(t, cfg.statsTags[:3], []string{"aaa", "bbb", "ccc"})
+
+	tags := StatsTags()
+	tags[1] = "yyy"
+	assert.Equal(t, cfg.statsTags[1], "bbb")
+}

--- a/internal/globalconfig/globalconfig_test.go
+++ b/internal/globalconfig/globalconfig_test.go
@@ -19,7 +19,7 @@ func TestHeaderTag(t *testing.T) {
 	assert.Equal(t, "tag2", cfg.headersAsTags.Get("header2"))
 }
 
-// Asserts that APIs to access cfg.statsTags protect against pollution from external changes
+// Assert that APIs to access cfg.statsTags protect against pollution from external changes
 func TestStatsTags(t *testing.T) {
 	array := [6]string{"aaa", "bbb", "ccc"}
 	slice1 := array[:]


### PR DESCRIPTION
### What does this PR do?
- `globalconfig.SetStatsTags(tags []string)` now makes a copy of `tags` before setting it as the value of `cfg.statsTags` 
- `globalconfig.StatsTags()` now returns a copy of `cfg.statsTags`

### Motivation
Failure to perform the copying specified above resulted in pollution of the globalconfig statsTags.
https://github.com/DataDog/dd-trace-go/issues/2836 

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
