### PR TITLE
[CI Visibility] Refactor gotesting integration to be used by orchestrion

### DIFF
--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -1,0 +1,280 @@
+package gotesting
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils"
+)
+
+// The following functions are being used by the gotesting package for manual instrumentation and the orchestrion
+// automatic instrumentation
+
+// instrumentTestingM helper function to instrument internalTests and internalBenchmarks in a `*testing.M` instance.
+func instrumentTestingM(m *testing.M) func(exitCode int) {
+	// Initialize CI Visibility
+	integrations.EnsureCiVisibilityInitialization()
+
+	// Create a new test session for CI visibility.
+	session = integrations.CreateTestSession()
+
+	ddm := (*M)(m)
+
+	// Instrument the internal tests for CI visibility.
+	ddm.instrumentInternalTests(getInternalTestArray(m))
+
+	// Instrument the internal benchmarks for CI visibility.
+	for _, v := range os.Args {
+		// check if benchmarking is enabled to instrument
+		if strings.Contains(v, "-bench") || strings.Contains(v, "test.bench") {
+			ddm.instrumentInternalBenchmarks(getInternalBenchmarkArray(m))
+			break
+		}
+	}
+
+	return func(exitCode int) {
+		// Close the session and return the exit code.
+		session.Close(exitCode)
+
+		// Finalize CI Visibility
+		integrations.ExitCiVisibility()
+	}
+}
+
+// instrumentTestingTFunc helper function to instrument a testing function func(*testing.T)
+func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
+	// Reflect the function to obtain its pointer.
+	fReflect := reflect.Indirect(reflect.ValueOf(f))
+	moduleName, suiteName := utils.GetModuleAndSuiteName(fReflect.Pointer())
+	originalFunc := runtime.FuncForPC(fReflect.Pointer())
+
+	// Increment the test count in the module.
+	atomic.AddInt32(modulesCounters[moduleName], 1)
+
+	// Increment the test count in the suite.
+	atomic.AddInt32(suitesCounters[suiteName], 1)
+
+	return func(t *testing.T) {
+		// Create or retrieve the module, suite, and test for CI visibility.
+		module := session.GetOrCreateModuleWithFramework(moduleName, testFramework, runtime.Version())
+		suite := module.GetOrCreateSuite(suiteName)
+		test := suite.CreateTest(t.Name())
+		test.SetTestFunc(originalFunc)
+		setCiVisibilityTest(t, test)
+		defer func() {
+			if r := recover(); r != nil {
+				// Handle panic and set error information.
+				test.SetErrorInfo("panic", fmt.Sprint(r), utils.GetStacktrace(1))
+				test.Close(integrations.ResultStatusFail)
+				checkModuleAndSuite(module, suite)
+				integrations.ExitCiVisibility()
+				panic(r)
+			} else {
+				// Normal finalization: determine the test result based on its state.
+				if t.Failed() {
+					test.SetTag(ext.Error, true)
+					suite.SetTag(ext.Error, true)
+					module.SetTag(ext.Error, true)
+					test.Close(integrations.ResultStatusFail)
+				} else if t.Skipped() {
+					test.Close(integrations.ResultStatusSkip)
+				} else {
+					test.Close(integrations.ResultStatusPass)
+				}
+				checkModuleAndSuite(module, suite)
+			}
+		}()
+
+		// Execute the original test function.
+		f(t)
+	}
+}
+
+// instrumentTestingTSetErrorInfo helper function to set an error in the `testing.T` CI Visibility span
+func instrumentTestingTSetErrorInfo(t *testing.T, errType string, errMessage string, skip int) {
+	ciTest := getCiVisibilityTest(t)
+	if ciTest != nil {
+		ciTest.SetErrorInfo(errType, errMessage, utils.GetStacktrace(2+skip))
+	}
+}
+
+// instrumentTestingTCloseAndSkip helper function to close and skip with a reason a `testing.T` CI Visibility span
+func instrumentTestingTCloseAndSkip(t *testing.T, skipReason string) {
+	ciTest := getCiVisibilityTest(t)
+	if ciTest != nil {
+		ciTest.CloseWithFinishTimeAndSkipReason(integrations.ResultStatusSkip, time.Now(), skipReason)
+	}
+}
+
+// instrumentTestingTSkipNow helper function to close and skip a `testing.T` CI Visibility span
+func instrumentTestingTSkipNow(t *testing.T) {
+	ciTest := getCiVisibilityTest(t)
+	if ciTest != nil {
+		ciTest.Close(integrations.ResultStatusSkip)
+	}
+}
+
+// instrumentTestingBFunc helper function to instrument a benchmark function func(*testing.B)
+func instrumentTestingBFunc(pb *testing.B, name string, f func(*testing.B)) (string, func(*testing.B)) {
+	// Avoid instrumenting twice
+	if hasCiVisibilityBenchmarkFunc(&f) {
+		return name, f
+	}
+
+	// Reflect the function to obtain its pointer.
+	fReflect := reflect.Indirect(reflect.ValueOf(f))
+	moduleName, suiteName := utils.GetModuleAndSuiteName(fReflect.Pointer())
+	originalFunc := runtime.FuncForPC(fReflect.Pointer())
+
+	// Increment the test count in the module.
+	atomic.AddInt32(modulesCounters[moduleName], 1)
+
+	// Increment the test count in the suite.
+	atomic.AddInt32(suitesCounters[suiteName], 1)
+
+	return subBenchmarkAutoName, func(b *testing.B) {
+		// The sub-benchmark implementation relies on creating a dummy sub benchmark (called [DD:TestVisibility]) with
+		// a Run over the original sub benchmark function to get the child results without interfering measurements
+		// By doing this the name of the sub-benchmark are changed
+		// from:
+		// 		benchmark/child
+		// to:
+		//		benchmark/[DD:TestVisibility]/child
+		// We use regex and decrement the depth level of the benchmark to restore the original name
+
+		// Decrement level.
+		bpf := getBenchmarkPrivateFields(b)
+		bpf.AddLevel(-1)
+
+		startTime := time.Now()
+		module := session.GetOrCreateModuleWithFrameworkAndStartTime(moduleName, testFramework, runtime.Version(), startTime)
+		suite := module.GetOrCreateSuiteWithStartTime(suiteName, startTime)
+		test := suite.CreateTestWithStartTime(fmt.Sprintf("%s/%s", pb.Name(), name), startTime)
+		test.SetTestFunc(originalFunc)
+
+		// Restore the original name without the sub-benchmark auto name.
+		*bpf.name = subBenchmarkAutoNameRegex.ReplaceAllString(*bpf.name, "")
+
+		// Run original benchmark.
+		var iPfOfB *benchmarkPrivateFields
+		var recoverFunc *func(r any)
+		instrumentedFunc := func(b *testing.B) {
+			// Stop the timer to do the initialization and replacements.
+			b.StopTimer()
+
+			defer func() {
+				if r := recover(); r != nil {
+					if recoverFunc != nil {
+						fn := *recoverFunc
+						fn(r)
+					}
+					panic(r)
+				}
+			}()
+
+			// First time we get the private fields of the inner testing.B.
+			iPfOfB = getBenchmarkPrivateFields(b)
+			// Replace this function with the original one (executed only once - the first iteration[b.run1]).
+			*iPfOfB.benchFunc = f
+			// Set b to the CI visibility test.
+			setCiVisibilityBenchmark(b, test)
+
+			// Enable the timer again.
+			b.ResetTimer()
+			b.StartTimer()
+
+			// Execute original func
+			f(b)
+		}
+
+		setCiVisibilityBenchmarkFunc(&instrumentedFunc)
+		defer deleteCiVisibilityBenchmarkFunc(&instrumentedFunc)
+		b.Run(name, instrumentedFunc)
+
+		endTime := time.Now()
+		results := iPfOfB.result
+
+		// Set benchmark data for CI visibility.
+		test.SetBenchmarkData("duration", map[string]any{
+			"run":  results.N,
+			"mean": results.NsPerOp(),
+		})
+		test.SetBenchmarkData("memory_total_operations", map[string]any{
+			"run":            results.N,
+			"mean":           results.AllocsPerOp(),
+			"statistics.max": results.MemAllocs,
+		})
+		test.SetBenchmarkData("mean_heap_allocations", map[string]any{
+			"run":  results.N,
+			"mean": results.AllocedBytesPerOp(),
+		})
+		test.SetBenchmarkData("total_heap_allocations", map[string]any{
+			"run":  results.N,
+			"mean": iPfOfB.result.MemBytes,
+		})
+		if len(results.Extra) > 0 {
+			mapConverted := map[string]any{}
+			for k, v := range results.Extra {
+				mapConverted[k] = v
+			}
+			test.SetBenchmarkData("extra", mapConverted)
+		}
+
+		// Define a function to handle panic during benchmark finalization.
+		panicFunc := func(r any) {
+			test.SetErrorInfo("panic", fmt.Sprint(r), utils.GetStacktrace(1))
+			suite.SetTag(ext.Error, true)
+			module.SetTag(ext.Error, true)
+			test.Close(integrations.ResultStatusFail)
+			checkModuleAndSuite(module, suite)
+			integrations.ExitCiVisibility()
+		}
+		recoverFunc = &panicFunc
+
+		// Normal finalization: determine the benchmark result based on its state.
+		if iPfOfB.B.Failed() {
+			test.SetTag(ext.Error, true)
+			suite.SetTag(ext.Error, true)
+			module.SetTag(ext.Error, true)
+			test.CloseWithFinishTime(integrations.ResultStatusFail, endTime)
+		} else if iPfOfB.B.Skipped() {
+			test.CloseWithFinishTime(integrations.ResultStatusSkip, endTime)
+		} else {
+			test.CloseWithFinishTime(integrations.ResultStatusPass, endTime)
+		}
+
+		checkModuleAndSuite(module, suite)
+	}
+}
+
+// instrumentTestingBSetErrorInfo helper function to set an error in the `testing.B` CI Visibility span
+func instrumentTestingBSetErrorInfo(b *testing.B, errType string, errMessage string, skip int) {
+	ciTest := getCiVisibilityBenchmark(b)
+	if ciTest != nil {
+		ciTest.SetErrorInfo(errType, errMessage, utils.GetStacktrace(2+skip))
+	}
+}
+
+// instrumentTestingBCloseAndSkip helper function to close and skip with a reason a `testing.B` CI Visibility span
+func instrumentTestingBCloseAndSkip(b *testing.B, skipReason string) {
+	ciTest := getCiVisibilityBenchmark(b)
+	if ciTest != nil {
+		ciTest.CloseWithFinishTimeAndSkipReason(integrations.ResultStatusSkip, time.Now(), skipReason)
+	}
+}
+
+// instrumentTestingBSkipNow helper function to close and skip a `testing.B` CI Visibility span
+func instrumentTestingBSkipNow(b *testing.B) {
+	ciTest := getCiVisibilityBenchmark(b)
+	if ciTest != nil {
+		ciTest.Close(integrations.ResultStatusSkip)
+	}
+}

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
 package gotesting
 
 import (

--- a/internal/civisibility/integrations/gotesting/testingB.go
+++ b/internal/civisibility/integrations/gotesting/testingB.go
@@ -30,7 +30,7 @@ var (
 	subBenchmarkAutoNameRegex = regexp.MustCompile(`(?si)\/\[DD:TestVisibility\].*`)
 
 	// civisibilityBenchmarksFuncs holds a map of *func(*testing.B) for tracking instrumented functions
-	civisibilityBenchmarksFuncs = map[*func(*testing.B)]bool{}
+	civisibilityBenchmarksFuncs = map[*func(*testing.B)]struct{}{}
 
 	// civisibilityBenchmarksFuncsMutex is a read-write mutex for synchronizing access to civisibilityBenchmarksFuncs.
 	civisibilityBenchmarksFuncsMutex sync.RWMutex
@@ -224,7 +224,7 @@ func hasCiVisibilityBenchmarkFunc(fn *func(*testing.B)) bool {
 func setCiVisibilityBenchmarkFunc(fn *func(*testing.B)) {
 	civisibilityBenchmarksFuncsMutex.RLock()
 	defer civisibilityBenchmarksFuncsMutex.RUnlock()
-	civisibilityBenchmarksFuncs[fn] = true
+	civisibilityBenchmarksFuncs[fn] = struct{}{}
 }
 
 // deleteCiVisibilityBenchmarkFunc untracks a func(*testing.B) as instrumented benchmark.

--- a/internal/civisibility/integrations/gotesting/testingB.go
+++ b/internal/civisibility/integrations/gotesting/testingB.go
@@ -8,17 +8,12 @@ package gotesting
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"regexp"
-	"runtime"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils"
 )
 
 var (
@@ -33,6 +28,12 @@ var (
 
 	// subBenchmarkAutoNameRegex is a regex pattern to match the sub-benchmark auto name.
 	subBenchmarkAutoNameRegex = regexp.MustCompile(`(?si)\/\[DD:TestVisibility\].*`)
+
+	// civisibilityBenchmarksFuncs holds a map of *func(*testing.B) for tracking instrumented functions
+	civisibilityBenchmarksFuncs = map[*func(*testing.B)]bool{}
+
+	// civisibilityBenchmarksFuncsMutex is a read-write mutex for synchronizing access to civisibilityBenchmarksFuncs.
+	civisibilityBenchmarksFuncsMutex sync.RWMutex
 )
 
 // B is a type alias for testing.B to provide additional methods for CI visibility.
@@ -48,127 +49,9 @@ func GetBenchmark(t *testing.B) *B { return (*B)(t) }
 // A subbenchmark is like any other benchmark. A benchmark that calls Run at
 // least once will not be measured itself and will be called once with N=1.
 func (ddb *B) Run(name string, f func(*testing.B)) bool {
-	// Reflect the function to obtain its pointer.
-	fReflect := reflect.Indirect(reflect.ValueOf(f))
-	moduleName, suiteName := utils.GetModuleAndSuiteName(fReflect.Pointer())
-	originalFunc := runtime.FuncForPC(fReflect.Pointer())
-
-	// Increment the test count in the module.
-	atomic.AddInt32(modulesCounters[moduleName], 1)
-
-	// Increment the test count in the suite.
-	atomic.AddInt32(suitesCounters[suiteName], 1)
-
 	pb := (*testing.B)(ddb)
-	return pb.Run(subBenchmarkAutoName, func(b *testing.B) {
-		// The sub-benchmark implementation relies on creating a dummy sub benchmark (called [DD:TestVisibility]) with
-		// a Run over the original sub benchmark function to get the child results without interfering measurements
-		// By doing this the name of the sub-benchmark are changed
-		// from:
-		// 		benchmark/child
-		// to:
-		//		benchmark/[DD:TestVisibility]/child
-		// We use regex and decrement the depth level of the benchmark to restore the original name
-
-		// Decrement level.
-		bpf := getBenchmarkPrivateFields(b)
-		bpf.AddLevel(-1)
-
-		startTime := time.Now()
-		module := session.GetOrCreateModuleWithFrameworkAndStartTime(moduleName, testFramework, runtime.Version(), startTime)
-		suite := module.GetOrCreateSuiteWithStartTime(suiteName, startTime)
-		test := suite.CreateTestWithStartTime(fmt.Sprintf("%s/%s", pb.Name(), name), startTime)
-		test.SetTestFunc(originalFunc)
-
-		// Restore the original name without the sub-benchmark auto name.
-		*bpf.name = subBenchmarkAutoNameRegex.ReplaceAllString(*bpf.name, "")
-
-		// Run original benchmark.
-		var iPfOfB *benchmarkPrivateFields
-		var recoverFunc *func(r any)
-		b.Run(name, func(b *testing.B) {
-			// Stop the timer to do the initialization and replacements.
-			b.StopTimer()
-
-			defer func() {
-				if r := recover(); r != nil {
-					if recoverFunc != nil {
-						fn := *recoverFunc
-						fn(r)
-					}
-					panic(r)
-				}
-			}()
-
-			// First time we get the private fields of the inner testing.B.
-			iPfOfB = getBenchmarkPrivateFields(b)
-			// Replace this function with the original one (executed only once - the first iteration[b.run1]).
-			*iPfOfB.benchFunc = f
-			// Set b to the CI visibility test.
-			setCiVisibilityBenchmark(b, test)
-
-			// Enable the timer again.
-			b.ResetTimer()
-			b.StartTimer()
-
-			// Execute original func
-			f(b)
-		})
-
-		endTime := time.Now()
-		results := iPfOfB.result
-
-		// Set benchmark data for CI visibility.
-		test.SetBenchmarkData("duration", map[string]any{
-			"run":  results.N,
-			"mean": results.NsPerOp(),
-		})
-		test.SetBenchmarkData("memory_total_operations", map[string]any{
-			"run":            results.N,
-			"mean":           results.AllocsPerOp(),
-			"statistics.max": results.MemAllocs,
-		})
-		test.SetBenchmarkData("mean_heap_allocations", map[string]any{
-			"run":  results.N,
-			"mean": results.AllocedBytesPerOp(),
-		})
-		test.SetBenchmarkData("total_heap_allocations", map[string]any{
-			"run":  results.N,
-			"mean": iPfOfB.result.MemBytes,
-		})
-		if len(results.Extra) > 0 {
-			mapConverted := map[string]any{}
-			for k, v := range results.Extra {
-				mapConverted[k] = v
-			}
-			test.SetBenchmarkData("extra", mapConverted)
-		}
-
-		// Define a function to handle panic during benchmark finalization.
-		panicFunc := func(r any) {
-			test.SetErrorInfo("panic", fmt.Sprint(r), utils.GetStacktrace(1))
-			suite.SetTag(ext.Error, true)
-			module.SetTag(ext.Error, true)
-			test.Close(integrations.ResultStatusFail)
-			checkModuleAndSuite(module, suite)
-			integrations.ExitCiVisibility()
-		}
-		recoverFunc = &panicFunc
-
-		// Normal finalization: determine the benchmark result based on its state.
-		if iPfOfB.B.Failed() {
-			test.SetTag(ext.Error, true)
-			suite.SetTag(ext.Error, true)
-			module.SetTag(ext.Error, true)
-			test.CloseWithFinishTime(integrations.ResultStatusFail, endTime)
-		} else if iPfOfB.B.Skipped() {
-			test.CloseWithFinishTime(integrations.ResultStatusSkip, endTime)
-		} else {
-			test.CloseWithFinishTime(integrations.ResultStatusPass, endTime)
-		}
-
-		checkModuleAndSuite(module, suite)
-	})
+	name, f = instrumentTestingBFunc(pb, name, f)
+	return pb.Run(name, f)
 }
 
 // Context returns the CI Visibility context of the Test span.
@@ -230,11 +113,7 @@ func (ddb *B) Skipf(format string, args ...any) {
 // during the test. Calling SkipNow does not stop those other goroutines.
 func (ddb *B) SkipNow() {
 	b := (*testing.B)(ddb)
-	ciTest := getCiVisibilityBenchmark(b)
-	if ciTest != nil {
-		ciTest.Close(integrations.ResultStatusSkip)
-	}
-
+	instrumentTestingBSkipNow(b)
 	b.SkipNow()
 }
 
@@ -300,19 +179,13 @@ func (ddb *B) SetParallelism(p int) { (*testing.B)(ddb).SetParallelism(p) }
 
 func (ddb *B) getBWithError(errType string, errMessage string) *testing.B {
 	b := (*testing.B)(ddb)
-	ciTest := getCiVisibilityBenchmark(b)
-	if ciTest != nil {
-		ciTest.SetErrorInfo(errType, errMessage, utils.GetStacktrace(2))
-	}
+	instrumentTestingBSetErrorInfo(b, errType, errMessage, 1)
 	return b
 }
 
 func (ddb *B) getBWithSkip(skipReason string) *testing.B {
 	b := (*testing.B)(ddb)
-	ciTest := getCiVisibilityBenchmark(b)
-	if ciTest != nil {
-		ciTest.CloseWithFinishTimeAndSkipReason(integrations.ResultStatusSkip, time.Now(), skipReason)
-	}
+	instrumentTestingBCloseAndSkip(b, skipReason)
 	return b
 }
 
@@ -333,4 +206,30 @@ func setCiVisibilityBenchmark(b *testing.B, ciTest integrations.DdTest) {
 	ciVisibilityBenchmarksMutex.Lock()
 	defer ciVisibilityBenchmarksMutex.Unlock()
 	ciVisibilityBenchmarks[b] = ciTest
+}
+
+// hasCiVisibilityBenchmarkFunc gets if a func(*testing.B) is being instrumented.
+func hasCiVisibilityBenchmarkFunc(fn *func(*testing.B)) bool {
+	civisibilityBenchmarksFuncsMutex.RLock()
+	defer civisibilityBenchmarksFuncsMutex.RUnlock()
+
+	if _, ok := civisibilityBenchmarksFuncs[fn]; ok {
+		return true
+	}
+
+	return false
+}
+
+// setCiVisibilityBenchmarkFunc tracks a func(*testing.B) as instrumented benchmark.
+func setCiVisibilityBenchmarkFunc(fn *func(*testing.B)) {
+	civisibilityBenchmarksFuncsMutex.RLock()
+	defer civisibilityBenchmarksFuncsMutex.RUnlock()
+	civisibilityBenchmarksFuncs[fn] = true
+}
+
+// deleteCiVisibilityBenchmarkFunc untracks a func(*testing.B) as instrumented benchmark.
+func deleteCiVisibilityBenchmarkFunc(fn *func(*testing.B)) {
+	civisibilityBenchmarksFuncsMutex.RLock()
+	defer civisibilityBenchmarksFuncsMutex.RUnlock()
+	delete(civisibilityBenchmarksFuncs, fn)
 }

--- a/internal/civisibility/integrations/gotesting/testingT.go
+++ b/internal/civisibility/integrations/gotesting/testingT.go
@@ -8,16 +8,11 @@ package gotesting
 import (
 	"context"
 	"fmt"
-	"reflect"
-	"runtime"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils"
 )
 
 var (
@@ -44,52 +39,9 @@ func GetTest(t *testing.T) *T {
 // Run may be called simultaneously from multiple goroutines, but all such calls
 // must return before the outer test function for t returns.
 func (ddt *T) Run(name string, f func(*testing.T)) bool {
-	// Reflect the function to obtain its pointer.
-	fReflect := reflect.Indirect(reflect.ValueOf(f))
-	moduleName, suiteName := utils.GetModuleAndSuiteName(fReflect.Pointer())
-	originalFunc := runtime.FuncForPC(fReflect.Pointer())
-
-	// Increment the test count in the module.
-	atomic.AddInt32(modulesCounters[moduleName], 1)
-
-	// Increment the test count in the suite.
-	atomic.AddInt32(suitesCounters[suiteName], 1)
-
+	f = instrumentTestingTFunc(f)
 	t := (*testing.T)(ddt)
-	return t.Run(name, func(t *testing.T) {
-		// Create or retrieve the module, suite, and test for CI visibility.
-		module := session.GetOrCreateModuleWithFramework(moduleName, testFramework, runtime.Version())
-		suite := module.GetOrCreateSuite(suiteName)
-		test := suite.CreateTest(t.Name())
-		test.SetTestFunc(originalFunc)
-		setCiVisibilityTest(t, test)
-		defer func() {
-			if r := recover(); r != nil {
-				// Handle panic and set error information.
-				test.SetErrorInfo("panic", fmt.Sprint(r), utils.GetStacktrace(1))
-				test.Close(integrations.ResultStatusFail)
-				checkModuleAndSuite(module, suite)
-				integrations.ExitCiVisibility()
-				panic(r)
-			} else {
-				// Normal finalization: determine the test result based on its state.
-				if t.Failed() {
-					test.SetTag(ext.Error, true)
-					suite.SetTag(ext.Error, true)
-					module.SetTag(ext.Error, true)
-					test.Close(integrations.ResultStatusFail)
-				} else if t.Skipped() {
-					test.Close(integrations.ResultStatusSkip)
-				} else {
-					test.Close(integrations.ResultStatusPass)
-				}
-				checkModuleAndSuite(module, suite)
-			}
-		}()
-
-		// Execute the original test function.
-		f(t)
-	})
+	return t.Run(name, f)
 }
 
 // Context returns the CI Visibility context of the Test span.
@@ -151,11 +103,7 @@ func (ddt *T) Skipf(format string, args ...any) {
 // during the test. Calling SkipNow does not stop those other goroutines.
 func (ddt *T) SkipNow() {
 	t := (*testing.T)(ddt)
-	ciTest := getCiVisibilityTest(t)
-	if ciTest != nil {
-		ciTest.Close(integrations.ResultStatusSkip)
-	}
-
+	instrumentTestingTSkipNow(t)
 	t.SkipNow()
 }
 
@@ -180,19 +128,13 @@ func (ddt *T) Setenv(key, value string) { (*testing.T)(ddt).Setenv(key, value) }
 
 func (ddt *T) getTWithError(errType string, errMessage string) *testing.T {
 	t := (*testing.T)(ddt)
-	ciTest := getCiVisibilityTest(t)
-	if ciTest != nil {
-		ciTest.SetErrorInfo(errType, errMessage, utils.GetStacktrace(2))
-	}
+	instrumentTestingTSetErrorInfo(t, errType, errMessage, 1)
 	return t
 }
 
 func (ddt *T) getTWithSkip(skipReason string) *testing.T {
 	t := (*testing.T)(ddt)
-	ciTest := getCiVisibilityTest(t)
-	if ciTest != nil {
-		ciTest.CloseWithFinishTimeAndSkipReason(integrations.ResultStatusSkip, time.Now(), skipReason)
-	}
+	instrumentTestingTCloseAndSkip(t, skipReason)
 	return t
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR is a refactor of the existing code so the new methods can be used by the orchestrion instrumentation. It doesn't introduce any new functionality and the existing tests are enough for testing the refactored code.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Playing with orchestrion I realised that the current internal apis are really hard to call from an orchestrion integration, the refactor creates a new set of methods that can be easily called from methods prepend code kind of integrations. 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
