### PR TITLE
internal/civisibility/integrations/gotesting: fixes for orchestrion autoinstrumentation

### DIFF
--- a/ddtrace/tracer/civisibility_payload.go
+++ b/ddtrace/tracer/civisibility_payload.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/tinylib/msgp/msgp"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/version"
 )
 
@@ -46,6 +47,7 @@ func (p *ciVisibilityPayload) push(event *ciVisibilityEvent) error {
 //
 //	A pointer to a newly initialized civisibilitypayload instance.
 func newCiVisibilityPayload() *ciVisibilityPayload {
+	log.Debug("ciVisibilityPayload: creating payload instance")
 	return &ciVisibilityPayload{newPayload()}
 }
 
@@ -61,6 +63,7 @@ func newCiVisibilityPayload() *ciVisibilityPayload {
 //	A pointer to a bytes.Buffer containing the encoded CI Visibility payload.
 //	An error if reading from the buffer or encoding the payload fails.
 func (p *ciVisibilityPayload) getBuffer(config *config) (*bytes.Buffer, error) {
+	log.Debug("ciVisibilityPayload: .getBuffer (count: %v)", p.itemCount())
 
 	/*
 			The Payload format in the CI Visibility protocol is like this:

--- a/ddtrace/tracer/civisibility_transport.go
+++ b/ddtrace/tracer/civisibility_transport.go
@@ -105,6 +105,8 @@ func newCiVisibilityTransport(config *config) *ciVisibilityTransport {
 		testCycleURL = fmt.Sprintf("%s/%s/%s", config.agentURL.String(), EvpProxyPath, TestCyclePath)
 	}
 
+	log.Debug("ciVisibilityTransport: creating transport instance [agentless: %v, testcycleurl: %v]", agentlessEnabled, testCycleURL)
+
 	return &ciVisibilityTransport{
 		config:           config,
 		testCycleURLPath: testCycleURL,
@@ -157,6 +159,7 @@ func (t *ciVisibilityTransport) send(p *payload) (body io.ReadCloser, err error)
 		req.Header.Set("Content-Encoding", "gzip")
 	}
 
+	log.Debug("ciVisibilityTransport: sending transport request: %v bytes", buffer.Len())
 	response, err := t.config.httpClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/ddtrace/tracer/civisibility_tslv.go
+++ b/ddtrace/tracer/civisibility_tslv.go
@@ -273,6 +273,7 @@ func getCiVisibilityEvent(span *span) *ciVisibilityEvent {
 //	A pointer to the created ciVisibilityEvent.
 func createTestEventFromSpan(span *span) *ciVisibilityEvent {
 	tSpan := createTslvSpan(span)
+	tSpan.ParentID = 0
 	tSpan.SessionID = getAndRemoveMetaToUInt64(span, constants.TestSessionIDTag)
 	tSpan.ModuleID = getAndRemoveMetaToUInt64(span, constants.TestModuleIDTag)
 	tSpan.SuiteID = getAndRemoveMetaToUInt64(span, constants.TestSuiteIDTag)
@@ -298,6 +299,7 @@ func createTestEventFromSpan(span *span) *ciVisibilityEvent {
 //	A pointer to the created ciVisibilityEvent.
 func createTestSuiteEventFromSpan(span *span) *ciVisibilityEvent {
 	tSpan := createTslvSpan(span)
+	tSpan.ParentID = 0
 	tSpan.SessionID = getAndRemoveMetaToUInt64(span, constants.TestSessionIDTag)
 	tSpan.ModuleID = getAndRemoveMetaToUInt64(span, constants.TestModuleIDTag)
 	tSpan.SuiteID = getAndRemoveMetaToUInt64(span, constants.TestSuiteIDTag)
@@ -320,6 +322,7 @@ func createTestSuiteEventFromSpan(span *span) *ciVisibilityEvent {
 //	A pointer to the created ciVisibilityEvent.
 func createTestModuleEventFromSpan(span *span) *ciVisibilityEvent {
 	tSpan := createTslvSpan(span)
+	tSpan.ParentID = 0
 	tSpan.SessionID = getAndRemoveMetaToUInt64(span, constants.TestSessionIDTag)
 	tSpan.ModuleID = getAndRemoveMetaToUInt64(span, constants.TestModuleIDTag)
 	return &ciVisibilityEvent{
@@ -341,6 +344,7 @@ func createTestModuleEventFromSpan(span *span) *ciVisibilityEvent {
 //	A pointer to the created ciVisibilityEvent.
 func createTestSessionEventFromSpan(span *span) *ciVisibilityEvent {
 	tSpan := createTslvSpan(span)
+	tSpan.ParentID = 0
 	tSpan.SessionID = getAndRemoveMetaToUInt64(span, constants.TestSessionIDTag)
 	return &ciVisibilityEvent{
 		span:    span,

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -68,7 +68,7 @@ func setInstrumentationMetadata(fn *runtime.Func, metadata *instrumentationMetad
 	instrumentationMap[fn] = metadata
 }
 
-// getCiVisibilityTest retrieves the CI visibility test associated with a given *testing.T or *testing.B
+// getCiVisibilityTest retrieves the CI visibility test associated with a given *testing.T, *testing.B, *testing.common
 func getCiVisibilityTest(tb testing.TB) *ddTestItem {
 	ciVisibilityTestsMutex.RLock()
 	defer ciVisibilityTestsMutex.RUnlock()
@@ -78,7 +78,7 @@ func getCiVisibilityTest(tb testing.TB) *ddTestItem {
 	return nil
 }
 
-// setCiVisibilityTest associates a CI visibility test with a given *testing.T or *testing.B
+// setCiVisibilityTest associates a CI visibility test with a given *testing.T, *testing.B, *testing.common
 func setCiVisibilityTest(tb testing.TB, ciTest integrations.DdTest) {
 	ciVisibilityTestsMutex.Lock()
 	defer ciVisibilityTestsMutex.Unlock()
@@ -184,7 +184,7 @@ func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
 	return instrumentedFn
 }
 
-// instrumentSetErrorInfo helper function to set an error in the `testing.T or testing.B` CI Visibility span
+// instrumentSetErrorInfo helper function to set an error in the `*testing.T, *testing.B, *testing.common` CI Visibility span
 func instrumentSetErrorInfo(tb testing.TB, errType string, errMessage string, skip int) {
 	ciTestItem := getCiVisibilityTest(tb)
 	if ciTestItem != nil && ciTestItem.error.CompareAndSwap(0, 1) && ciTestItem.test != nil {
@@ -192,7 +192,7 @@ func instrumentSetErrorInfo(tb testing.TB, errType string, errMessage string, sk
 	}
 }
 
-// instrumentCloseAndSkip helper function to close and skip with a reason a `testing.T or testing.B` CI Visibility span
+// instrumentCloseAndSkip helper function to close and skip with a reason a `*testing.T, *testing.B, *testing.common` CI Visibility span
 func instrumentCloseAndSkip(tb testing.TB, skipReason string) {
 	ciTestItem := getCiVisibilityTest(tb)
 	if ciTestItem != nil && ciTestItem.skipped.CompareAndSwap(0, 1) && ciTestItem.test != nil {
@@ -200,7 +200,7 @@ func instrumentCloseAndSkip(tb testing.TB, skipReason string) {
 	}
 }
 
-// instrumentSkipNow helper function to close and skip a `testing.T or testing.B` CI Visibility span
+// instrumentSkipNow helper function to close and skip a `*testing.T, *testing.B, *testing.common` CI Visibility span
 func instrumentSkipNow(tb testing.TB) {
 	ciTestItem := getCiVisibilityTest(tb)
 	if ciTestItem != nil && ciTestItem.skipped.CompareAndSwap(0, 1) && ciTestItem.test != nil {

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -166,14 +166,7 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo) func(*testing.T) {
 		testInfo.originalFunc(t)
 	}
 
-	metadata := &instrumentationMetadata{
-		IsInternal:       true,
-		OriginalTest:     &testInfo.originalFunc,
-		InstrumentedTest: &instrumentedFunc,
-	}
-
-	setInstrumentationMetadata(originalFunc, metadata)
-	setInstrumentationMetadata(runtime.FuncForPC(reflect.Indirect(reflect.ValueOf(instrumentedFunc)).Pointer()), metadata)
+	setInstrumentationMetadata(runtime.FuncForPC(reflect.Indirect(reflect.ValueOf(instrumentedFunc)).Pointer()), &instrumentationMetadata{IsInternal: true})
 	return instrumentedFunc
 }
 

--- a/internal/civisibility/integrations/gotesting/testingB.go
+++ b/internal/civisibility/integrations/gotesting/testingB.go
@@ -24,7 +24,7 @@ var (
 	// subBenchmarkAutoNameRegex is a regex pattern to match the sub-benchmark auto name.
 	subBenchmarkAutoNameRegex = regexp.MustCompile(`(?si)\/\[DD:TestVisibility\].*`)
 
-	// civisibilityBenchmarksFuncs holds a map of *func(*testing.B) for tracking instrumented functions
+	// civisibilityBenchmarksFuncs holds a map of *runtime.Func for tracking instrumented functions
 	civisibilityBenchmarksFuncs = map[*runtime.Func]struct{}{}
 
 	// civisibilityBenchmarksFuncsMutex is a read-write mutex for synchronizing access to civisibilityBenchmarksFuncs.
@@ -184,7 +184,7 @@ func (ddb *B) getBWithSkip(skipReason string) *testing.B {
 	return b
 }
 
-// hasCiVisibilityBenchmarkFunc gets if a func(*testing.B) is being instrumented.
+// hasCiVisibilityBenchmarkFunc gets if a *runtime.Func is being instrumented.
 func hasCiVisibilityBenchmarkFunc(fn *runtime.Func) bool {
 	civisibilityBenchmarksFuncsMutex.RLock()
 	defer civisibilityBenchmarksFuncsMutex.RUnlock()
@@ -196,7 +196,7 @@ func hasCiVisibilityBenchmarkFunc(fn *runtime.Func) bool {
 	return false
 }
 
-// setCiVisibilityBenchmarkFunc tracks a func(*testing.B) as instrumented benchmark.
+// setCiVisibilityBenchmarkFunc tracks a *runtime.Func as instrumented benchmark.
 func setCiVisibilityBenchmarkFunc(fn *runtime.Func) {
 	civisibilityBenchmarksFuncsMutex.RLock()
 	defer civisibilityBenchmarksFuncsMutex.RUnlock()

--- a/internal/civisibility/integrations/gotesting/testingB.go
+++ b/internal/civisibility/integrations/gotesting/testingB.go
@@ -54,9 +54,9 @@ func (ddb *B) Run(name string, f func(*testing.B)) bool {
 // integration tests.
 func (ddb *B) Context() context.Context {
 	b := (*testing.B)(ddb)
-	ciTest := getCiVisibilityTest(b)
-	if ciTest != nil {
-		return ciTest.Context()
+	ciTestItem := getCiVisibilityTest(b)
+	if ciTestItem != nil && ciTestItem.test != nil {
+		return ciTestItem.test.Context()
 	}
 
 	return context.Background()

--- a/internal/civisibility/integrations/gotesting/testingB.go
+++ b/internal/civisibility/integrations/gotesting/testingB.go
@@ -226,10 +226,3 @@ func setCiVisibilityBenchmarkFunc(fn *func(*testing.B)) {
 	defer civisibilityBenchmarksFuncsMutex.RUnlock()
 	civisibilityBenchmarksFuncs[fn] = struct{}{}
 }
-
-// deleteCiVisibilityBenchmarkFunc untracks a func(*testing.B) as instrumented benchmark.
-func deleteCiVisibilityBenchmarkFunc(fn *func(*testing.B)) {
-	civisibilityBenchmarksFuncsMutex.RLock()
-	defer civisibilityBenchmarksFuncsMutex.RUnlock()
-	delete(civisibilityBenchmarksFuncs, fn)
-}

--- a/internal/civisibility/integrations/gotesting/testingB.go
+++ b/internal/civisibility/integrations/gotesting/testingB.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -30,7 +31,7 @@ var (
 	subBenchmarkAutoNameRegex = regexp.MustCompile(`(?si)\/\[DD:TestVisibility\].*`)
 
 	// civisibilityBenchmarksFuncs holds a map of *func(*testing.B) for tracking instrumented functions
-	civisibilityBenchmarksFuncs = map[*func(*testing.B)]struct{}{}
+	civisibilityBenchmarksFuncs = map[*runtime.Func]struct{}{}
 
 	// civisibilityBenchmarksFuncsMutex is a read-write mutex for synchronizing access to civisibilityBenchmarksFuncs.
 	civisibilityBenchmarksFuncsMutex sync.RWMutex
@@ -209,7 +210,7 @@ func setCiVisibilityBenchmark(b *testing.B, ciTest integrations.DdTest) {
 }
 
 // hasCiVisibilityBenchmarkFunc gets if a func(*testing.B) is being instrumented.
-func hasCiVisibilityBenchmarkFunc(fn *func(*testing.B)) bool {
+func hasCiVisibilityBenchmarkFunc(fn *runtime.Func) bool {
 	civisibilityBenchmarksFuncsMutex.RLock()
 	defer civisibilityBenchmarksFuncsMutex.RUnlock()
 
@@ -221,7 +222,7 @@ func hasCiVisibilityBenchmarkFunc(fn *func(*testing.B)) bool {
 }
 
 // setCiVisibilityBenchmarkFunc tracks a func(*testing.B) as instrumented benchmark.
-func setCiVisibilityBenchmarkFunc(fn *func(*testing.B)) {
+func setCiVisibilityBenchmarkFunc(fn *runtime.Func) {
 	civisibilityBenchmarksFuncsMutex.RLock()
 	defer civisibilityBenchmarksFuncsMutex.RUnlock()
 	civisibilityBenchmarksFuncs[fn] = struct{}{}

--- a/internal/civisibility/integrations/gotesting/testingT.go
+++ b/internal/civisibility/integrations/gotesting/testingT.go
@@ -40,9 +40,9 @@ func (ddt *T) Run(name string, f func(*testing.T)) bool {
 // integration tests.
 func (ddt *T) Context() context.Context {
 	t := (*testing.T)(ddt)
-	ciTest := getCiVisibilityTest(t)
-	if ciTest != nil {
-		return ciTest.Context()
+	ciTestItem := getCiVisibilityTest(t)
+	if ciTestItem != nil && ciTestItem.test != nil {
+		return ciTestItem.test.Context()
 	}
 
 	return context.Background()

--- a/internal/civisibility/integrations/gotesting/testingT.go
+++ b/internal/civisibility/integrations/gotesting/testingT.go
@@ -8,6 +8,7 @@ package gotesting
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -23,7 +24,7 @@ var (
 	ciVisibilityTestsMutex sync.RWMutex
 
 	// civisibilityTestsFuncs holds a map of *func(*testing.T) for tracking instrumented functions
-	civisibilityTestsFuncs = map[*func(*testing.T)]struct{}{}
+	civisibilityTestsFuncs = map[*runtime.Func]struct{}{}
 
 	// civisibilityTestsFuncsMutex is a read-write mutex for synchronizing access to civisibilityTestsFuncs.
 	civisibilityTestsFuncsMutex sync.RWMutex
@@ -164,7 +165,7 @@ func setCiVisibilityTest(t *testing.T, ciTest integrations.DdTest) {
 }
 
 // hasCiVisibilityTestFunc gets if a func(*testing.T) is being instrumented.
-func hasCiVisibilityTestFunc(fn *func(*testing.T)) bool {
+func hasCiVisibilityTestFunc(fn *runtime.Func) bool {
 	civisibilityTestsFuncsMutex.RLock()
 	defer civisibilityTestsFuncsMutex.RUnlock()
 
@@ -176,7 +177,7 @@ func hasCiVisibilityTestFunc(fn *func(*testing.T)) bool {
 }
 
 // setCiVisibilityTestFunc tracks a func(*testing.T) as instrumented benchmark.
-func setCiVisibilityTestFunc(fn *func(*testing.T)) {
+func setCiVisibilityTestFunc(fn *runtime.Func) {
 	civisibilityTestsFuncsMutex.RLock()
 	defer civisibilityTestsFuncsMutex.RUnlock()
 	civisibilityTestsFuncs[fn] = struct{}{}

--- a/internal/civisibility/integrations/gotesting/testingT.go
+++ b/internal/civisibility/integrations/gotesting/testingT.go
@@ -8,26 +8,10 @@ package gotesting
 import (
 	"context"
 	"fmt"
-	"runtime"
-	"sync"
 	"testing"
 	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations"
-)
-
-var (
-	// ciVisibilityTests holds a map of *testing.T to civisibility.DdTest for tracking tests.
-	ciVisibilityTests = map[*testing.T]integrations.DdTest{}
-
-	// ciVisibilityTestsMutex is a read-write mutex for synchronizing access to ciVisibilityTests.
-	ciVisibilityTestsMutex sync.RWMutex
-
-	// civisibilityTestsFuncs holds a map of *func(*testing.T) for tracking instrumented functions
-	civisibilityTestsFuncs = map[*runtime.Func]struct{}{}
-
-	// civisibilityTestsFuncsMutex is a read-write mutex for synchronizing access to civisibilityTestsFuncs.
-	civisibilityTestsFuncsMutex sync.RWMutex
 )
 
 // T is a type alias for testing.T to provide additional methods for CI visibility.
@@ -110,7 +94,7 @@ func (ddt *T) Skipf(format string, args ...any) {
 // during the test. Calling SkipNow does not stop those other goroutines.
 func (ddt *T) SkipNow() {
 	t := (*testing.T)(ddt)
-	instrumentTestingTSkipNow(t)
+	instrumentSkipNow(t)
 	t.SkipNow()
 }
 
@@ -135,50 +119,12 @@ func (ddt *T) Setenv(key, value string) { (*testing.T)(ddt).Setenv(key, value) }
 
 func (ddt *T) getTWithError(errType string, errMessage string) *testing.T {
 	t := (*testing.T)(ddt)
-	instrumentTestingTSetErrorInfo(t, errType, errMessage, 1)
+	instrumentSetErrorInfo(t, errType, errMessage, 1)
 	return t
 }
 
 func (ddt *T) getTWithSkip(skipReason string) *testing.T {
 	t := (*testing.T)(ddt)
-	instrumentTestingTCloseAndSkip(t, skipReason)
+	instrumentCloseAndSkip(t, skipReason)
 	return t
-}
-
-// getCiVisibilityTest retrieves the CI visibility test associated with a given *testing.T.
-func getCiVisibilityTest(t *testing.T) integrations.DdTest {
-	ciVisibilityTestsMutex.RLock()
-	defer ciVisibilityTestsMutex.RUnlock()
-
-	if v, ok := ciVisibilityTests[t]; ok {
-		return v
-	}
-
-	return nil
-}
-
-// setCiVisibilityTest associates a CI visibility test with a given *testing.T.
-func setCiVisibilityTest(t *testing.T, ciTest integrations.DdTest) {
-	ciVisibilityTestsMutex.Lock()
-	defer ciVisibilityTestsMutex.Unlock()
-	ciVisibilityTests[t] = ciTest
-}
-
-// hasCiVisibilityTestFunc gets if a func(*testing.T) is being instrumented.
-func hasCiVisibilityTestFunc(fn *runtime.Func) bool {
-	civisibilityTestsFuncsMutex.RLock()
-	defer civisibilityTestsFuncsMutex.RUnlock()
-
-	if _, ok := civisibilityTestsFuncs[fn]; ok {
-		return true
-	}
-
-	return false
-}
-
-// setCiVisibilityTestFunc tracks a func(*testing.T) as instrumented benchmark.
-func setCiVisibilityTestFunc(fn *runtime.Func) {
-	civisibilityTestsFuncsMutex.RLock()
-	defer civisibilityTestsFuncsMutex.RUnlock()
-	civisibilityTestsFuncs[fn] = struct{}{}
 }

--- a/internal/civisibility/integrations/gotesting/testing_test.go
+++ b/internal/civisibility/integrations/gotesting/testing_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"slices"
 	"strconv"
 	"testing"
 
@@ -35,7 +36,10 @@ func TestMain(m *testing.M) {
 	// or use a helper method gotesting.RunM(m)
 
 	// os.Exit((*M)(m).Run())
-	_ = RunM(m)
+	exit := RunM(m)
+	if exit != 0 {
+		os.Exit(exit)
+	}
 
 	finishedSpans := mTracer.FinishedSpans()
 	// 1 session span
@@ -107,18 +111,27 @@ func Test_Foo(gt *testing.T) {
 	assertTest(gt)
 	t := (*T)(gt)
 	var tests = []struct {
+		index byte
 		name  string
 		input string
 		want  string
 	}{
-		{"yellow should return color", "yellow", "color"},
-		{"banana should return fruit", "banana", "fruit"},
-		{"duck should return animal", "duck", "animal"},
+		{1, "yellow should return color", "yellow", "color"},
+		{2, "banana should return fruit", "banana", "fruit"},
+		{3, "duck should return animal", "duck", "animal"},
 	}
+	buf := []byte{}
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Log(test.name)
+			buf = append(buf, test.index)
 		})
+	}
+
+	expected := []byte{1, 2, 3}
+	if !slices.Equal(buf, expected) {
+		t.Error("error in subtests closure")
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

For orchestrion we are going to instrument `testing.M.Run()`, `testing.T.Run()` and `testing.B.Run()` methods, for that we need to make some fixes and add some checks to avoid multiple instrumentation over the same Func

This PR also fixes an issue found with orchestrion about Test Suite Level Visibility (tslv) objects having `ParentId != 0` this breaks the backend json schema. Now we make sure that structs like `Test`, `TestSuite`,  `TestModule` and `TestSession` never set the ParentId value (Only normal spans are allowed to have it).


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

While working with the orchestrion autoinstrumentation I'm hitting this issues. This PR fixes those issues.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
