### PR TITLE
[fix] Remove superfluous WriteHeader call

### DIFF
--- a/contrib/net/http/trace.go
+++ b/contrib/net/http/trace.go
@@ -96,9 +96,7 @@ func (w *responseWriter) Status() int {
 // We explicitly call WriteHeader with the 200 status code
 // in order to get it reported into the span.
 func (w *responseWriter) Write(b []byte) (int, error) {
-	if w.status == 0 {
-		w.WriteHeader(http.StatusOK)
-	}
+	w.status = 200
 	return w.ResponseWriter.Write(b)
 }
 

--- a/contrib/net/http/trace.go
+++ b/contrib/net/http/trace.go
@@ -92,9 +92,8 @@ func (w *responseWriter) Status() int {
 	return w.status
 }
 
-// Write writes the data to the connection as part of an HTTP reply.
-// We explicitly call WriteHeader with the 200 status code
-// in order to get it reported into the span.
+// Write sets the status code and writes the data to
+// the connection as part of an HTTP reply.
 func (w *responseWriter) Write(b []byte) (int, error) {
 	w.status = 200
 	return w.ResponseWriter.Write(b)


### PR DESCRIPTION
### What does this PR do?

This PR addresses a bug where the net/http contrib package is explicitly calling `WriteHeader(200)` and `Write(...)` in succession via a wrapped `http.ResponseWriter`, however the second call to `Write(...)` already performs the first call implicitly, which results in an extra unnecessary call to `WriteHeader` and net/http writes a complaint to stdout. I've instead updated the code to instead just update the wrapper `responseWriter`'s status code and perform the call to write.

### Motivation

An issue describing this bug was opened in #2859

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
