### PR TITLE
internal/civisibility/integrations/gotesting: add the `DD_CIVISIBILITY_ENABLED` kill switch environment variable

### DIFF
--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -116,6 +116,7 @@ func setCiVisibilityTest(tb testing.TB, ciTest integrations.DdTest) {
 // instrumentTestingM helper function to instrument internalTests and internalBenchmarks in a `*testing.M` instance.
 func instrumentTestingM(m *testing.M) func(exitCode int) {
 	// Check if CI Visibility was disabled using the kill switch before trying to initialize it
+	ciVisibilityEnabledValue = nil
 	if !isCiVisibilityEnabled() {
 		return func(exitCode int) {}
 	}

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -60,7 +60,7 @@ var (
 func isCiVisibilityEnabled() bool {
 	// let's check if the value has already been loaded from the env-vars
 	if ciVisibilityEnabledValue == nil {
-		// Get the DD_CIVISIBILITY_ENABLED env var, if not present we default to true. This is because if we are here means
+		// Get the DD_CIVISIBILITY_ENABLED env var, if not present we default to true. This is because if we are here, it means
 		// that the process was instrumented for ci visibility or by using orchestrion.
 		// So effectively this env-var will act as a kill switch for cases where the code is instrumented, but
 		// we don't want the civisibility instrumentation to be enabled.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds a mechanism to use the existing `DD_CIVISIBILITY_ENABLED` environment variable as a kill switch to avoid enabling CI Visibility on an instrumented process.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
This is useful for `orchestrion` instrumentation to allow us control when we want ci visibility to be enabled or not.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
