### PR TITLE
contrib/dimfeld/httptreemux.v5: default resource namer incorrectly replaces path variables

### DIFF
--- a/contrib/dimfeld/httptreemux.v5/httptreemux.go
+++ b/contrib/dimfeld/httptreemux.v5/httptreemux.go
@@ -145,7 +145,10 @@ func getRoute(router *httptreemux.TreeMux, w http.ResponseWriter, req *http.Requ
 		// replace parameter at end of the path, i.e. "../:param"
 		oldP = "/" + v
 		newP = "/:" + k
-		route = strings.Replace(route, oldP, newP, 1)
+		if strings.HasSuffix(route, oldP) {
+			endPos := strings.LastIndex(route, oldP)
+			route = route[:endPos] + newP
+		}
 	}
 	return route, true
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR fixes a case where the path variable replacement fails under certain conditions. The current implementation "end of path replacement" isn't actually bound to the end of the path and can do a replacement anywhere in the string. E.x. a parameters value is `he` and the url is `/hey/he` it will be replaced as `/:?y/he` (which obviously isn't intended behaviour).

https://github.com/DataDog/dd-trace-go/blob/054d19dbcec79cf5b2a584d12b461e65b8ea24a7/contrib/dimfeld/httptreemux.v5/httptreemux.go#L145-L148

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

Fixes https://github.com/DataDog/dd-trace-go/issues/2812

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!