### PR TITLE
internal/civisibility: adds the new vcpu_count metric for tslv events

### DIFF
--- a/internal/civisibility/constants/tags.go
+++ b/internal/civisibility/constants/tags.go
@@ -10,6 +10,10 @@ const (
 	// This tag helps in identifying the source of the trace data.
 	Origin = "_dd.origin"
 
+	// LogicalCPUCores is a tag used to indicate the number of logical cpu cores
+	// This tag is used by the backend to perform calculations
+	LogicalCPUCores = "_dd.host.vcpu_count"
+
 	// CIAppTestOrigin defines the CIApp test origin value.
 	// This constant is used to tag traces that originate from CIApp test executions.
 	CIAppTestOrigin = "ciapp-test"

--- a/internal/civisibility/integrations/civisibility.go
+++ b/internal/civisibility/integrations/civisibility.go
@@ -66,6 +66,7 @@ func internalCiVisibilityInitialization(tracerInitializer func([]tracer.StartOpt
 
 		// Preload all CI, Git, and CodeOwners tags.
 		ciTags := utils.GetCITags()
+		_ = utils.GetCIMetrics()
 
 		// Check if DD_SERVICE has been set; otherwise default to the repo name (from the spec).
 		var opts []tracer.StartOption

--- a/internal/civisibility/integrations/gotesting/testing_test.go
+++ b/internal/civisibility/integrations/gotesting/testing_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"runtime"
 	"slices"
 	"strconv"
 	"testing"
@@ -328,8 +329,9 @@ func assertCommon(assert *assert.Assertions, span mocktracer.Span) {
 	spanTags := span.Tags()
 
 	assert.Subset(spanTags, map[string]interface{}{
-		constants.Origin:   constants.CIAppTestOrigin,
-		constants.TestType: constants.TestTypeTest,
+		constants.Origin:          constants.CIAppTestOrigin,
+		constants.TestType:        constants.TestTypeTest,
+		constants.LogicalCPUCores: float64(runtime.NumCPU()),
 	})
 
 	assert.Contains(spanTags, ext.ResourceName)

--- a/internal/civisibility/integrations/manual_api.go
+++ b/internal/civisibility/integrations/manual_api.go
@@ -214,5 +214,10 @@ func fillCommonTags(opts []tracer.StartSpanOption) []tracer.StartSpanOption {
 		opts = append(opts, tracer.Tag(k, v))
 	}
 
+	// Apply CI metrics
+	for k, v := range utils.GetCIMetrics() {
+		opts = append(opts, tracer.Tag(k, v))
+	}
+
 	return opts
 }

--- a/internal/civisibility/utils/environmentTags.go
+++ b/internal/civisibility/utils/environmentTags.go
@@ -18,6 +18,10 @@ var (
 	// ciTags holds the CI/CD environment variable information.
 	ciTags      map[string]string
 	ciTagsMutex sync.Mutex
+
+	// ciMetrics holds the CI/CD environment numeric variable information
+	ciMetrics      map[string]float64
+	ciMetricsMutex sync.Mutex
 )
 
 // GetCITags retrieves and caches the CI/CD tags from environment variables.
@@ -36,6 +40,24 @@ func GetCITags() map[string]string {
 	}
 
 	return ciTags
+}
+
+// GetCIMetrics retrieves and caches the CI/CD metrics from environment variables.
+// It initializes the ciMetrics map if it is not already initialized.
+// This function is thread-safe due to the use of a mutex.
+//
+// Returns:
+//
+//	A map[string]float64 containing the CI/CD metrics.
+func GetCIMetrics() map[string]float64 {
+	ciMetricsMutex.Lock()
+	defer ciMetricsMutex.Unlock()
+
+	if ciMetrics == nil {
+		ciMetrics = createCIMetricsMap()
+	}
+
+	return ciMetrics
 }
 
 // GetRelativePathFromCITagsSourceRoot calculates the relative path from the CI workspace root to the specified path.
@@ -116,4 +138,16 @@ func createCITagsMap() map[string]string {
 	}
 
 	return localTags
+}
+
+// createCIMetricsMap creates a map of CI/CD tags by extracting information from environment variables and runtime information.
+//
+// Returns:
+//
+//	A map[string]float64 containing the metrics extracted
+func createCIMetricsMap() map[string]float64 {
+	localMetrics := make(map[string]float64)
+	localMetrics[constants.LogicalCPUCores] = float64(runtime.NumCPU())
+
+	return localMetrics
 }

--- a/internal/civisibility/utils/environmentTags_test.go
+++ b/internal/civisibility/utils/environmentTags_test.go
@@ -25,6 +25,18 @@ func TestGetCITagsCache(t *testing.T) {
 	assert.Equal(t, "newvalue", tags["key"])
 }
 
+func TestGetCIMetricsCache(t *testing.T) {
+	ciMetrics = map[string]float64{"key": float64(1)}
+
+	// First call to initialize ciMetrics
+	tags := GetCIMetrics()
+	assert.Equal(t, float64(1), tags["key"])
+
+	tags["key"] = float64(42)
+	tags = GetCIMetrics()
+	assert.Equal(t, float64(42), tags["key"])
+}
+
 func TestGetRelativePathFromCITagsSourceRoot(t *testing.T) {
 	ciTags = map[string]string{constants.CIWorkspacePath: "/ci/workspace"}
 	absPath := "/ci/workspace/subdir/file.txt"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds the new `_dd.host.vcpu_count` metric to all test suite level visibility events.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This new tag will be used by the backend to do some calculations.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
