### PR TITLE
internal/telemetry: skip TestProductChange/profiler_start,_tracer_start

### DIFF
--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -112,6 +112,7 @@ func TestProductChange(t *testing.T) {
 				GlobalClient.ProductChange(NamespaceProfilers, true, []Configuration{{Name: "key", Value: "value"}})
 			},
 		},
+		/* This case is flaky (see #2688)
 		{
 			name:           "profiler start, tracer start",
 			wantedMessages: []RequestType{RequestTypeAppStarted, RequestTypeDependenciesLoaded, RequestTypeAppClientConfigurationChange},
@@ -120,6 +121,7 @@ func TestProductChange(t *testing.T) {
 				GlobalClient.ProductChange(NamespaceTracers, true, []Configuration{{Name: "key", Value: "value"}})
 			},
 		},
+		*/
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
### What does this PR do?

This test case is has been flaky for a long time. Per our policy, skip it until
we find a way to fix it.

For #2688

### Motivation

We don't want flaky tests.
