### PR TITLE
refactor(contrib/confluent-kafka-go/kafka): extract tracing code

### DIFF
--- a/contrib/confluentinc/confluent-kafka-go/kafka/headers.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/headers.go
@@ -6,48 +6,13 @@
 package kafka
 
 import (
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/contrib/confluentinc/confluent-kafka-go/kafka/internal/tracing"
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 )
 
-// A MessageCarrier injects and extracts traces from a sarama.ProducerMessage.
-type MessageCarrier struct {
-	msg *kafka.Message
-}
+type MessageCarrier = tracing.MessageCarrier
 
-var _ interface {
-	tracer.TextMapReader
-	tracer.TextMapWriter
-} = (*MessageCarrier)(nil)
-
-// ForeachKey iterates over every header.
-func (c MessageCarrier) ForeachKey(handler func(key, val string) error) error {
-	for _, h := range c.msg.Headers {
-		err := handler(string(h.Key), string(h.Value))
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// Set sets a header.
-func (c MessageCarrier) Set(key, val string) {
-	// ensure uniqueness of keys
-	for i := 0; i < len(c.msg.Headers); i++ {
-		if string(c.msg.Headers[i].Key) == key {
-			c.msg.Headers = append(c.msg.Headers[:i], c.msg.Headers[i+1:]...)
-			i--
-		}
-	}
-	c.msg.Headers = append(c.msg.Headers, kafka.Header{
-		Key:   key,
-		Value: []byte(val),
-	})
-}
-
-// NewMessageCarrier creates a new MessageCarrier.
 func NewMessageCarrier(msg *kafka.Message) MessageCarrier {
-	return MessageCarrier{msg}
+	return tracing.NewMessageCarrier(msg)
 }

--- a/contrib/confluentinc/confluent-kafka-go/kafka/internal/option.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/internal/option.go
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package internal
+
+import (
+	"context"
+	"math"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/namingschema"
+)
+
+const defaultServiceName = "kafka"
+
+type Config struct {
+	Ctx                 context.Context
+	ConsumerServiceName string
+	ProducerServiceName string
+	ConsumerSpanName    string
+	ProducerSpanName    string
+	AnalyticsRate       float64
+	BootstrapServers    string
+	GroupID             string
+	TagFns              map[string]func(msg *kafka.Message) interface{}
+	DataStreamsEnabled  bool
+}
+
+type Option func(cfg *Config)
+
+func NewConfig(opts ...Option) *Config {
+	cfg := &Config{
+		Ctx: context.Background(),
+		// analyticsRate: globalconfig.AnalyticsRate(),
+		AnalyticsRate: math.NaN(),
+	}
+	cfg.DataStreamsEnabled = internal.BoolEnv("DD_DATA_STREAMS_ENABLED", false)
+	if internal.BoolEnv("DD_TRACE_KAFKA_ANALYTICS_ENABLED", false) {
+		cfg.AnalyticsRate = 1.0
+	}
+
+	cfg.ConsumerServiceName = namingschema.ServiceName(defaultServiceName)
+	cfg.ProducerServiceName = namingschema.ServiceNameOverrideV0(defaultServiceName, defaultServiceName)
+	cfg.ConsumerSpanName = namingschema.OpName(namingschema.KafkaInbound)
+	cfg.ProducerSpanName = namingschema.OpName(namingschema.KafkaOutbound)
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return cfg
+}

--- a/contrib/confluentinc/confluent-kafka-go/kafka/internal/tracing/common.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/internal/tracing/common.go
@@ -1,0 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package tracing
+
+const (
+	ComponentName = "confluentinc/confluent-kafka-go/kafka"
+)

--- a/contrib/confluentinc/confluent-kafka-go/kafka/internal/tracing/consumer.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/internal/tracing/consumer.go
@@ -1,0 +1,206 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package tracing
+
+import (
+	"context"
+	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/datastreams"
+	"gopkg.in/DataDog/dd-trace-go.v1/datastreams/options"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+)
+
+type ConsumerTracer struct {
+	Ctx                context.Context
+	DataStreamsEnabled bool
+	GroupID            string
+	Prev               ddtrace.Span
+	Events             chan kafka.Event
+	StartSpanConfig    StartSpanConfig
+	WatermarkOffsets   watermarkOffsetsFn
+}
+
+type watermarkOffsetsFn func(topic string, partition int32) (int64, int64, error)
+
+func NewConsumerTracer(ctx context.Context, c *kafka.Consumer, groupID string, startSpanConfig StartSpanConfig) *ConsumerTracer {
+	tracer := &ConsumerTracer{
+		Ctx:             ctx,
+		GroupID:         groupID,
+		StartSpanConfig: startSpanConfig,
+	}
+	tracer.traceEventsChannel(c.Events())
+	return tracer
+}
+
+func (ct *ConsumerTracer) traceEventsChannel(in chan kafka.Event) {
+	// in will be nil when consuming via the events channel is not enabled
+	if in == nil {
+		ct.Events = in
+		return
+	}
+	out := make(chan kafka.Event, 1)
+	go func() {
+		defer close(out)
+		for evt := range in {
+			var next ddtrace.Span
+
+			// only trace messages
+			if msg, ok := evt.(*kafka.Message); ok {
+				next = startConsumerSpan(ct.Ctx, msg, ct.StartSpanConfig)
+				setConsumeCheckpoint(ct.DataStreamsEnabled, ct.GroupID, msg)
+			} else if offset, ok := evt.(kafka.OffsetsCommitted); ok {
+				commitOffsets(ct.DataStreamsEnabled, ct.GroupID, offset.Offsets, offset.Error)
+				trackHighWatermark(ct.WatermarkOffsets, ct.DataStreamsEnabled, offset.Offsets)
+			}
+
+			out <- evt
+
+			if ct.Prev != nil {
+				ct.Prev.Finish()
+			}
+			ct.Prev = next
+		}
+		// finish any remaining span
+		if ct.Prev != nil {
+			ct.Prev.Finish()
+			ct.Prev = nil
+		}
+	}()
+	ct.Events = out
+}
+
+func (ct *ConsumerTracer) WrapPoll(p func() kafka.Event) kafka.Event {
+	if ct.Prev != nil {
+		ct.Prev.Finish()
+		ct.Prev = nil
+	}
+	evt := p()
+	if msg, ok := evt.(*kafka.Message); ok {
+		setConsumeCheckpoint(ct.DataStreamsEnabled, ct.GroupID, msg)
+		ct.Prev = ct.startSpan(msg)
+	} else if offset, ok := evt.(kafka.OffsetsCommitted); ok {
+		commitOffsets(ct.DataStreamsEnabled, ct.GroupID, offset.Offsets, offset.Error)
+		trackHighWatermark(ct.WatermarkOffsets, ct.DataStreamsEnabled, offset.Offsets)
+	}
+	return evt
+}
+
+func (ct *ConsumerTracer) WrapReadMessage(rm func() (*kafka.Message, error)) (*kafka.Message, error) {
+	if ct.Prev != nil {
+		ct.Prev.Finish()
+		ct.Prev = nil
+	}
+	msg, err := rm()
+	if err != nil {
+		return nil, err
+	}
+	setConsumeCheckpoint(ct.DataStreamsEnabled, ct.GroupID, msg)
+	ct.Prev = ct.startSpan(msg)
+	return msg, err
+}
+
+func (ct *ConsumerTracer) startSpan(msg *kafka.Message) ddtrace.Span {
+	return startConsumerSpan(ct.Ctx, msg, ct.StartSpanConfig)
+}
+
+func (ct *ConsumerTracer) WrapCommit(c func() ([]kafka.TopicPartition, error)) ([]kafka.TopicPartition, error) {
+	tps, err := c()
+	commitOffsets(ct.DataStreamsEnabled, ct.GroupID, tps, err)
+	trackHighWatermark(ct.WatermarkOffsets, ct.DataStreamsEnabled, tps)
+	return tps, err
+}
+
+func (ct *ConsumerTracer) Close() {
+	// we only close the previous span if consuming via the events channel is
+	// not enabled, because otherwise there would be a data race from the
+	// consuming goroutine.
+	if ct.Events == nil && ct.Prev != nil {
+		ct.Prev.Finish()
+		ct.Prev = nil
+	}
+}
+
+func startConsumerSpan(ctx context.Context, msg *kafka.Message, cfg StartSpanConfig) ddtrace.Span {
+	opts := []tracer.StartSpanOption{
+		tracer.ServiceName(cfg.Service),
+		tracer.ResourceName("Consume Topic " + *msg.TopicPartition.Topic),
+		tracer.SpanType(ext.SpanTypeMessageConsumer),
+		tracer.Tag(ext.MessagingKafkaPartition, msg.TopicPartition.Partition),
+		tracer.Tag("offset", msg.TopicPartition.Offset),
+		tracer.Tag(ext.Component, ComponentName),
+		tracer.Tag(ext.SpanKind, ext.SpanKindConsumer),
+		tracer.Tag(ext.MessagingSystem, ext.MessagingSystemKafka),
+		tracer.Measured(),
+	}
+	if cfg.BootstrapServers != "" {
+		opts = append(opts, tracer.Tag(ext.KafkaBootstrapServers, cfg.BootstrapServers))
+	}
+	if cfg.TagFns != nil {
+		for key, tagFn := range cfg.TagFns {
+			opts = append(opts, tracer.Tag(key, tagFn(msg)))
+		}
+	}
+	if !math.IsNaN(cfg.AnalyticsRate) {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.AnalyticsRate))
+	}
+	// kafka supports headers, so try to extract a span context
+	carrier := NewMessageCarrier(msg)
+	if spanctx, err := tracer.Extract(carrier); err == nil {
+		opts = append(opts, tracer.ChildOf(spanctx))
+	}
+	span, _ := tracer.StartSpanFromContext(ctx, cfg.Operation, opts...)
+	// reinject the span context so consumers can pick it up
+	tracer.Inject(span.Context(), carrier)
+	return span
+}
+
+func setConsumeCheckpoint(dataStreamsEnabled bool, groupID string, msg *kafka.Message) {
+	if !dataStreamsEnabled || msg == nil {
+		return
+	}
+	edges := []string{"direction:in", "topic:" + *msg.TopicPartition.Topic, "type:kafka"}
+	if groupID != "" {
+		edges = append(edges, "group:"+groupID)
+	}
+	carrier := NewMessageCarrier(msg)
+	ctx, ok := tracer.SetDataStreamsCheckpointWithParams(datastreams.ExtractFromBase64Carrier(context.Background(), carrier), options.CheckpointParams{PayloadSize: getMsgSize(msg)}, edges...)
+	if !ok {
+		return
+	}
+	datastreams.InjectToBase64Carrier(ctx, carrier)
+}
+
+func getMsgSize(msg *kafka.Message) (size int64) {
+	for _, header := range msg.Headers {
+		size += int64(len(header.Key) + len(header.Value))
+	}
+	return size + int64(len(msg.Value)+len(msg.Key))
+}
+
+func commitOffsets(dataStreamsEnabled bool, groupID string, tps []kafka.TopicPartition, err error) {
+	if err != nil || groupID == "" || !dataStreamsEnabled {
+		return
+	}
+	for _, tp := range tps {
+		tracer.TrackKafkaCommitOffset(groupID, *tp.Topic, tp.Partition, int64(tp.Offset))
+	}
+}
+
+func trackHighWatermark(watermarkOffsets watermarkOffsetsFn, dataStreamsEnabled bool, offsets []kafka.TopicPartition) {
+	if !dataStreamsEnabled {
+		return
+	}
+	for _, tp := range offsets {
+		if _, high, err := watermarkOffsets(*tp.Topic, tp.Partition); err == nil {
+			tracer.TrackKafkaHighWatermarkOffset("", *tp.Topic, tp.Partition, high)
+		}
+	}
+}

--- a/contrib/confluentinc/confluent-kafka-go/kafka/internal/tracing/consumer.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/internal/tracing/consumer.go
@@ -30,11 +30,13 @@ type ConsumerTracer struct {
 
 type watermarkOffsetsFn func(topic string, partition int32) (int64, int64, error)
 
-func NewConsumerTracer(ctx context.Context, c *kafka.Consumer, groupID string, startSpanConfig StartSpanConfig) *ConsumerTracer {
+func NewConsumerTracer(ctx context.Context, c *kafka.Consumer, dataStreamsEnabled bool, groupID string, startSpanConfig StartSpanConfig) *ConsumerTracer {
 	tracer := &ConsumerTracer{
-		Ctx:             ctx,
-		GroupID:         groupID,
-		StartSpanConfig: startSpanConfig,
+		Ctx:                ctx,
+		DataStreamsEnabled: dataStreamsEnabled,
+		GroupID:            groupID,
+		StartSpanConfig:    startSpanConfig,
+		WatermarkOffsets:   c.GetWatermarkOffsets,
 	}
 	tracer.traceEventsChannel(c.Events())
 	return tracer

--- a/contrib/confluentinc/confluent-kafka-go/kafka/internal/tracing/headers.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/internal/tracing/headers.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package tracing
+
+import (
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+)
+
+// A MessageCarrier injects and extracts traces from a sarama.ProducerMessage.
+type MessageCarrier struct {
+	msg *kafka.Message
+}
+
+var _ interface {
+	tracer.TextMapReader
+	tracer.TextMapWriter
+} = (*MessageCarrier)(nil)
+
+// ForeachKey iterates over every header.
+func (c MessageCarrier) ForeachKey(handler func(key, val string) error) error {
+	for _, h := range c.msg.Headers {
+		err := handler(string(h.Key), string(h.Value))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Set sets a header.
+func (c MessageCarrier) Set(key, val string) {
+	// ensure uniqueness of keys
+	for i := 0; i < len(c.msg.Headers); i++ {
+		if string(c.msg.Headers[i].Key) == key {
+			c.msg.Headers = append(c.msg.Headers[:i], c.msg.Headers[i+1:]...)
+			i--
+		}
+	}
+	c.msg.Headers = append(c.msg.Headers, kafka.Header{
+		Key:   key,
+		Value: []byte(val),
+	})
+}
+
+// NewMessageCarrier creates a new MessageCarrier.
+func NewMessageCarrier(msg *kafka.Message) MessageCarrier {
+	return MessageCarrier{msg}
+}

--- a/contrib/confluentinc/confluent-kafka-go/kafka/internal/tracing/producer.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/internal/tracing/producer.go
@@ -1,0 +1,167 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package tracing
+
+import (
+	"context"
+	"math"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/datastreams"
+	"gopkg.in/DataDog/dd-trace-go.v1/datastreams/options"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+)
+
+type ProducerTracer struct {
+	Ctx                context.Context
+	DataStreamsEnabled bool
+	LibraryVersion     int
+	ProduceChannel     chan *kafka.Message
+	Events             chan kafka.Event
+	StartSpanConfig    StartSpanConfig
+}
+
+func NewProducerTracer(ctx context.Context, p *kafka.Producer, dataStreamsEnabled bool, startSpanConfig StartSpanConfig) *ProducerTracer {
+	version, _ := kafka.LibraryVersion()
+	tracer := &ProducerTracer{
+		Ctx:                ctx,
+		DataStreamsEnabled: dataStreamsEnabled,
+		LibraryVersion:     version,
+		StartSpanConfig:    startSpanConfig,
+	}
+	tracer.traceProduceChannel(p.ProduceChannel())
+	tracer.traceEventsChannel(p.Events())
+	return tracer
+}
+
+func (pt *ProducerTracer) traceProduceChannel(out chan *kafka.Message) {
+	if out == nil {
+		pt.ProduceChannel = out
+		return
+	}
+	in := make(chan *kafka.Message, 1)
+	go func() {
+		for msg := range in {
+			span := pt.startSpan(msg)
+			setProduceCheckpoint(pt.DataStreamsEnabled, pt.LibraryVersion, msg)
+			out <- msg
+			span.Finish()
+		}
+	}()
+	pt.ProduceChannel = in
+}
+
+func (pt *ProducerTracer) traceEventsChannel(in chan kafka.Event) {
+	pt.Events = in
+	if !pt.DataStreamsEnabled || in == nil {
+		return
+	}
+	out := make(chan kafka.Event, 1)
+	go func() {
+		defer close(out)
+		for evt := range in {
+			if msg, ok := evt.(*kafka.Message); ok {
+				trackProduceOffsets(pt.DataStreamsEnabled, msg, msg.TopicPartition.Error)
+			}
+			out <- evt
+		}
+	}()
+	pt.Events = out
+}
+
+func (pt *ProducerTracer) AroundProduce(msg *kafka.Message, deliveryChan chan kafka.Event) func(error) {
+	span := pt.startSpan(msg)
+
+	// if the user has selected a delivery channel, we will wrap it and
+	// wait for the delivery event to finish the span
+	if deliveryChan != nil {
+		oldDeliveryChan := deliveryChan
+		deliveryChan = make(chan kafka.Event)
+		go func() {
+			var err error
+			evt := <-deliveryChan
+			if msg, ok := evt.(*kafka.Message); ok {
+				// delivery errors are returned via TopicPartition.Error
+				err = msg.TopicPartition.Error
+				trackProduceOffsets(pt.DataStreamsEnabled, msg, err)
+			}
+			span.Finish(tracer.WithError(err))
+			oldDeliveryChan <- evt
+		}()
+	}
+
+	setProduceCheckpoint(pt.DataStreamsEnabled, pt.LibraryVersion, msg)
+
+	return func(err error) {
+		// with no delivery channel or enqueue error, finish immediately
+		if err != nil || deliveryChan == nil {
+			span.Finish(tracer.WithError(err))
+		}
+	}
+}
+
+func (pt *ProducerTracer) startSpan(msg *kafka.Message) ddtrace.Span {
+	cfg := pt.StartSpanConfig
+	opts := []tracer.StartSpanOption{
+		tracer.ServiceName(cfg.Service),
+		tracer.ResourceName("Produce Topic " + *msg.TopicPartition.Topic),
+		tracer.SpanType(ext.SpanTypeMessageProducer),
+		tracer.Tag(ext.Component, ComponentName),
+		tracer.Tag(ext.SpanKind, ext.SpanKindProducer),
+		tracer.Tag(ext.MessagingSystem, ext.MessagingSystemKafka),
+		tracer.Tag(ext.MessagingKafkaPartition, msg.TopicPartition.Partition),
+	}
+	if cfg.BootstrapServers != "" {
+		opts = append(opts, tracer.Tag(ext.KafkaBootstrapServers, cfg.BootstrapServers))
+	}
+	if !math.IsNaN(cfg.AnalyticsRate) {
+		opts = append(opts, tracer.Tag(ext.EventSampleRate, cfg.AnalyticsRate))
+	}
+	carrier := NewMessageCarrier(msg)
+	if spanctx, err := tracer.Extract(carrier); err == nil {
+		opts = append(opts, tracer.ChildOf(spanctx))
+	}
+	span, _ := tracer.StartSpanFromContext(pt.Ctx, cfg.Operation, opts...)
+	// inject the span context so consumers can pick it up
+	tracer.Inject(span.Context(), carrier)
+	return span
+}
+
+func (pt *ProducerTracer) Close() {
+	close(pt.ProduceChannel)
+}
+
+type StartSpanConfig struct {
+	Service          string
+	Operation        string
+	BootstrapServers string
+	AnalyticsRate    float64
+	TagFns           map[string]func(msg *kafka.Message) interface{}
+}
+
+func setProduceCheckpoint(dataStreamsEnabled bool, version int, msg *kafka.Message) {
+	if !dataStreamsEnabled || msg == nil {
+		return
+	}
+	edges := []string{"direction:out", "topic:" + *msg.TopicPartition.Topic, "type:kafka"}
+	carrier := NewMessageCarrier(msg)
+	ctx, ok := tracer.SetDataStreamsCheckpointWithParams(datastreams.ExtractFromBase64Carrier(context.Background(), carrier), options.CheckpointParams{PayloadSize: getMsgSize(msg)}, edges...)
+	if !ok || version < 0x000b0400 {
+		// headers not supported before librdkafka >=0.11.4
+		return
+	}
+	datastreams.InjectToBase64Carrier(ctx, carrier)
+}
+
+func trackProduceOffsets(dataStreamsEnabled bool, msg *kafka.Message, err error) {
+	if err != nil || !dataStreamsEnabled || msg.TopicPartition.Topic == nil {
+		return
+	}
+	tracer.TrackKafkaProduceOffset(*msg.TopicPartition.Topic, msg.TopicPartition.Partition, int64(msg.TopicPartition.Offset))
+}

--- a/contrib/confluentinc/confluent-kafka-go/kafka/internal/tracing/producer.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/internal/tracing/producer.go
@@ -75,7 +75,7 @@ func (pt *ProducerTracer) traceEventsChannel(in chan kafka.Event) {
 	pt.Events = out
 }
 
-func (pt *ProducerTracer) WrapProduce(produceFn func(*kafka.Message, chan kafka.Event) error, msg *kafka.Message, deliveryChan chan kafka.Event) error {
+func (pt *ProducerTracer) AroundProduce(msg *kafka.Message, deliveryChan chan kafka.Event) func(error) {
 	span := pt.startSpan(msg)
 
 	// if the user has selected a delivery channel, we will wrap it and
@@ -98,12 +98,12 @@ func (pt *ProducerTracer) WrapProduce(produceFn func(*kafka.Message, chan kafka.
 
 	setProduceCheckpoint(pt.DataStreamsEnabled, pt.LibraryVersion, msg)
 
-	err := produceFn(msg, deliveryChan)
-	// with no delivery channel or enqueue error, finish immediately
-	if err != nil || deliveryChan == nil {
-		span.Finish(tracer.WithError(err))
+	return func(err error) {
+		// with no delivery channel or enqueue error, finish immediately
+		if err != nil || deliveryChan == nil {
+			span.Finish(tracer.WithError(err))
+		}
 	}
-	return err
 }
 
 func (pt *ProducerTracer) startSpan(msg *kafka.Message) ddtrace.Span {

--- a/contrib/confluentinc/confluent-kafka-go/kafka/kafka.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/kafka.go
@@ -7,14 +7,9 @@
 package kafka // import "gopkg.in/DataDog/dd-trace-go.v1/contrib/confluentinc/confluent-kafka-go/kafka"
 
 import (
-	"context"
-	"math"
 	"time"
 
-	"gopkg.in/DataDog/dd-trace-go.v1/datastreams"
-	"gopkg.in/DataDog/dd-trace-go.v1/datastreams/options"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/contrib/confluentinc/confluent-kafka-go/kafka/internal/tracing"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
@@ -24,7 +19,7 @@ import (
 
 const (
 	// make sure these 3 are updated to V2 for the V2 version.
-	componentName   = "confluentinc/confluent-kafka-go/kafka"
+	componentName   = tracing.ComponentName
 	packageName     = "contrib/confluentinc/confluent-kafka-go/kafka"
 	integrationName = "github.com/confluentinc/confluent-kafka-go"
 )
@@ -58,306 +53,118 @@ func NewProducer(conf *kafka.ConfigMap, opts ...Option) (*Producer, error) {
 type Consumer struct {
 	*kafka.Consumer
 	cfg    *config
-	events chan kafka.Event
-	prev   ddtrace.Span
+	tracer *tracing.ConsumerTracer
 }
 
 // WrapConsumer wraps a kafka.Consumer so that any consumed events are traced.
 func WrapConsumer(c *kafka.Consumer, opts ...Option) *Consumer {
+	cfg := newConfig(opts...)
 	wrapped := &Consumer{
 		Consumer: c,
-		cfg:      newConfig(opts...),
+		cfg:      cfg,
+		tracer: tracing.NewConsumerTracer(cfg.ctx, c, cfg.groupID, tracing.StartSpanConfig{
+			Service:          cfg.consumerServiceName,
+			Operation:        cfg.consumerSpanName,
+			BootstrapServers: cfg.bootstrapServers,
+			AnalyticsRate:    cfg.analyticsRate,
+			TagFns:           cfg.tagFns,
+		}),
 	}
 	log.Debug("%s: Wrapping Consumer: %#v", packageName, wrapped.cfg)
-	wrapped.events = wrapped.traceEventsChannel(c.Events())
 	return wrapped
-}
-
-func (c *Consumer) traceEventsChannel(in chan kafka.Event) chan kafka.Event {
-	// in will be nil when consuming via the events channel is not enabled
-	if in == nil {
-		return nil
-	}
-
-	out := make(chan kafka.Event, 1)
-	go func() {
-		defer close(out)
-		for evt := range in {
-			var next ddtrace.Span
-
-			// only trace messages
-			if msg, ok := evt.(*kafka.Message); ok {
-				next = c.startSpan(msg)
-				setConsumeCheckpoint(c.cfg.dataStreamsEnabled, c.cfg.groupID, msg)
-			} else if offset, ok := evt.(kafka.OffsetsCommitted); ok {
-				commitOffsets(c.cfg.dataStreamsEnabled, c.cfg.groupID, offset.Offsets, offset.Error)
-				c.trackHighWatermark(c.cfg.dataStreamsEnabled, offset.Offsets)
-			}
-
-			out <- evt
-
-			if c.prev != nil {
-				c.prev.Finish()
-			}
-			c.prev = next
-		}
-		// finish any remaining span
-		if c.prev != nil {
-			c.prev.Finish()
-			c.prev = nil
-		}
-	}()
-	return out
-}
-
-func (c *Consumer) startSpan(msg *kafka.Message) ddtrace.Span {
-	opts := []tracer.StartSpanOption{
-		tracer.ServiceName(c.cfg.consumerServiceName),
-		tracer.ResourceName("Consume Topic " + *msg.TopicPartition.Topic),
-		tracer.SpanType(ext.SpanTypeMessageConsumer),
-		tracer.Tag(ext.MessagingKafkaPartition, msg.TopicPartition.Partition),
-		tracer.Tag("offset", msg.TopicPartition.Offset),
-		tracer.Tag(ext.Component, componentName),
-		tracer.Tag(ext.SpanKind, ext.SpanKindConsumer),
-		tracer.Tag(ext.MessagingSystem, ext.MessagingSystemKafka),
-		tracer.Measured(),
-	}
-	if c.cfg.bootstrapServers != "" {
-		opts = append(opts, tracer.Tag(ext.KafkaBootstrapServers, c.cfg.bootstrapServers))
-	}
-	if c.cfg.tagFns != nil {
-		for key, tagFn := range c.cfg.tagFns {
-			opts = append(opts, tracer.Tag(key, tagFn(msg)))
-		}
-	}
-	if !math.IsNaN(c.cfg.analyticsRate) {
-		opts = append(opts, tracer.Tag(ext.EventSampleRate, c.cfg.analyticsRate))
-	}
-	// kafka supports headers, so try to extract a span context
-	carrier := NewMessageCarrier(msg)
-	if spanctx, err := tracer.Extract(carrier); err == nil {
-		opts = append(opts, tracer.ChildOf(spanctx))
-	}
-	span, _ := tracer.StartSpanFromContext(c.cfg.ctx, c.cfg.consumerSpanName, opts...)
-	// reinject the span context so consumers can pick it up
-	tracer.Inject(span.Context(), carrier)
-	return span
 }
 
 // Close calls the underlying Consumer.Close and if polling is enabled, finishes
 // any remaining span.
 func (c *Consumer) Close() error {
-	err := c.Consumer.Close()
-	// we only close the previous span if consuming via the events channel is
-	// not enabled, because otherwise there would be a data race from the
-	// consuming goroutine.
-	if c.events == nil && c.prev != nil {
-		c.prev.Finish()
-		c.prev = nil
-	}
-	return err
+	c.tracer.Close()
+	return c.Consumer.Close()
 }
 
 // Events returns the kafka Events channel (if enabled). Message events will be
 // traced.
 func (c *Consumer) Events() chan kafka.Event {
-	return c.events
+	return c.tracer.Events
 }
 
 // Poll polls the consumer for messages or events. Message will be
 // traced.
 func (c *Consumer) Poll(timeoutMS int) (event kafka.Event) {
-	if c.prev != nil {
-		c.prev.Finish()
-		c.prev = nil
-	}
-	evt := c.Consumer.Poll(timeoutMS)
-	if msg, ok := evt.(*kafka.Message); ok {
-		setConsumeCheckpoint(c.cfg.dataStreamsEnabled, c.cfg.groupID, msg)
-		c.prev = c.startSpan(msg)
-	} else if offset, ok := evt.(kafka.OffsetsCommitted); ok {
-		commitOffsets(c.cfg.dataStreamsEnabled, c.cfg.groupID, offset.Offsets, offset.Error)
-		c.trackHighWatermark(c.cfg.dataStreamsEnabled, offset.Offsets)
-	}
-	return evt
-}
-
-func (c *Consumer) trackHighWatermark(dataStreamsEnabled bool, offsets []kafka.TopicPartition) {
-	if !dataStreamsEnabled {
-		return
-	}
-	for _, tp := range offsets {
-		if _, high, err := c.Consumer.GetWatermarkOffsets(*tp.Topic, tp.Partition); err == nil {
-			tracer.TrackKafkaHighWatermarkOffset("", *tp.Topic, tp.Partition, high)
-		}
-	}
+	return c.tracer.WrapPoll(func() kafka.Event {
+		return c.Consumer.Poll(timeoutMS)
+	})
 }
 
 // ReadMessage polls the consumer for a message. Message will be traced.
 func (c *Consumer) ReadMessage(timeout time.Duration) (*kafka.Message, error) {
-	if c.prev != nil {
-		c.prev.Finish()
-		c.prev = nil
-	}
-	msg, err := c.Consumer.ReadMessage(timeout)
-	if err != nil {
-		return nil, err
-	}
-	setConsumeCheckpoint(c.cfg.dataStreamsEnabled, c.cfg.groupID, msg)
-	c.prev = c.startSpan(msg)
-	return msg, nil
+	return c.tracer.WrapReadMessage(func() (*kafka.Message, error) {
+		return c.Consumer.ReadMessage(timeout)
+	})
 }
 
 // Commit commits current offsets and tracks the commit offsets if data streams is enabled.
 func (c *Consumer) Commit() ([]kafka.TopicPartition, error) {
-	tps, err := c.Consumer.Commit()
-	commitOffsets(c.cfg.dataStreamsEnabled, c.cfg.groupID, tps, err)
-	c.trackHighWatermark(c.cfg.dataStreamsEnabled, tps)
-	return tps, err
+	return c.tracer.WrapCommit(func() ([]kafka.TopicPartition, error) {
+		return c.Consumer.Commit()
+	})
 }
 
 // CommitMessage commits a message and tracks the commit offsets if data streams is enabled.
 func (c *Consumer) CommitMessage(msg *kafka.Message) ([]kafka.TopicPartition, error) {
-	tps, err := c.Consumer.CommitMessage(msg)
-	commitOffsets(c.cfg.dataStreamsEnabled, c.cfg.groupID, tps, err)
-	c.trackHighWatermark(c.cfg.dataStreamsEnabled, tps)
-	return tps, err
+	return c.tracer.WrapCommit(func() ([]kafka.TopicPartition, error) {
+		return c.Consumer.CommitMessage(msg)
+	})
 }
 
 // CommitOffsets commits provided offsets and tracks the commit offsets if data streams is enabled.
 func (c *Consumer) CommitOffsets(offsets []kafka.TopicPartition) ([]kafka.TopicPartition, error) {
-	tps, err := c.Consumer.CommitOffsets(offsets)
-	commitOffsets(c.cfg.dataStreamsEnabled, c.cfg.groupID, tps, err)
-	c.trackHighWatermark(c.cfg.dataStreamsEnabled, tps)
-	return tps, err
-}
-
-func commitOffsets(dataStreamsEnabled bool, groupID string, tps []kafka.TopicPartition, err error) {
-	if err != nil || groupID == "" || !dataStreamsEnabled {
-		return
-	}
-	for _, tp := range tps {
-		tracer.TrackKafkaCommitOffset(groupID, *tp.Topic, tp.Partition, int64(tp.Offset))
-	}
-}
-
-func trackProduceOffsets(dataStreamsEnabled bool, msg *kafka.Message, err error) {
-	if err != nil || !dataStreamsEnabled || msg.TopicPartition.Topic == nil {
-		return
-	}
-	tracer.TrackKafkaProduceOffset(*msg.TopicPartition.Topic, msg.TopicPartition.Partition, int64(msg.TopicPartition.Offset))
+	return c.tracer.WrapCommit(func() ([]kafka.TopicPartition, error) {
+		return c.Consumer.CommitOffsets(offsets)
+	})
 }
 
 // A Producer wraps a kafka.Producer.
 type Producer struct {
 	*kafka.Producer
-	cfg            *config
-	produceChannel chan *kafka.Message
-	events         chan kafka.Event
-	libraryVersion int
+	cfg    *config
+	tracer *tracing.ProducerTracer
 }
 
 // WrapProducer wraps a kafka.Producer so requests are traced.
 func WrapProducer(p *kafka.Producer, opts ...Option) *Producer {
-	version, _ := kafka.LibraryVersion()
+	cfg := newConfig(opts...)
 	wrapped := &Producer{
-		Producer:       p,
-		cfg:            newConfig(opts...),
-		events:         p.Events(),
-		libraryVersion: version,
+		Producer: p,
+		cfg:      cfg,
+		tracer: tracing.NewProducerTracer(cfg.ctx, p, cfg.dataStreamsEnabled, tracing.StartSpanConfig{
+			Service:          cfg.producerServiceName,
+			Operation:        cfg.producerSpanName,
+			BootstrapServers: cfg.bootstrapServers,
+			AnalyticsRate:    cfg.analyticsRate,
+		}),
 	}
 	log.Debug("%s: Wrapping Producer: %#v", packageName, wrapped.cfg)
-	wrapped.produceChannel = wrapped.traceProduceChannel(p.ProduceChannel())
-	if wrapped.cfg.dataStreamsEnabled {
-		wrapped.events = wrapped.traceEventsChannel(p.Events())
-	}
 	return wrapped
 }
 
 // Events returns the kafka Events channel (if enabled). Message events will be monitored
 // with data streams monitoring (if enabled)
 func (p *Producer) Events() chan kafka.Event {
-	return p.events
-}
-
-func (p *Producer) traceProduceChannel(out chan *kafka.Message) chan *kafka.Message {
-	if out == nil {
-		return out
-	}
-	in := make(chan *kafka.Message, 1)
-	go func() {
-		for msg := range in {
-			span := p.startSpan(msg)
-			setProduceCheckpoint(p.cfg.dataStreamsEnabled, p.libraryVersion, msg)
-			out <- msg
-			span.Finish()
-		}
-	}()
-	return in
-}
-
-func (p *Producer) startSpan(msg *kafka.Message) ddtrace.Span {
-	opts := []tracer.StartSpanOption{
-		tracer.ServiceName(p.cfg.producerServiceName),
-		tracer.ResourceName("Produce Topic " + *msg.TopicPartition.Topic),
-		tracer.SpanType(ext.SpanTypeMessageProducer),
-		tracer.Tag(ext.Component, componentName),
-		tracer.Tag(ext.SpanKind, ext.SpanKindProducer),
-		tracer.Tag(ext.MessagingSystem, ext.MessagingSystemKafka),
-		tracer.Tag(ext.MessagingKafkaPartition, msg.TopicPartition.Partition),
-	}
-	if p.cfg.bootstrapServers != "" {
-		opts = append(opts, tracer.Tag(ext.KafkaBootstrapServers, p.cfg.bootstrapServers))
-	}
-	if !math.IsNaN(p.cfg.analyticsRate) {
-		opts = append(opts, tracer.Tag(ext.EventSampleRate, p.cfg.analyticsRate))
-	}
-	// if there's a span context in the headers, use that as the parent
-	carrier := NewMessageCarrier(msg)
-	if spanctx, err := tracer.Extract(carrier); err == nil {
-		opts = append(opts, tracer.ChildOf(spanctx))
-	}
-	span, _ := tracer.StartSpanFromContext(p.cfg.ctx, p.cfg.producerSpanName, opts...)
-	// inject the span context so consumers can pick it up
-	tracer.Inject(span.Context(), carrier)
-	return span
+	return p.tracer.Events
 }
 
 // Close calls the underlying Producer.Close and also closes the internal
 // wrapping producer channel.
 func (p *Producer) Close() {
-	close(p.produceChannel)
+	p.tracer.Close()
 	p.Producer.Close()
 }
 
 // Produce calls the underlying Producer.Produce and traces the request.
 func (p *Producer) Produce(msg *kafka.Message, deliveryChan chan kafka.Event) error {
-	span := p.startSpan(msg)
-
-	// if the user has selected a delivery channel, we will wrap it and
-	// wait for the delivery event to finish the span
-	if deliveryChan != nil {
-		oldDeliveryChan := deliveryChan
-		deliveryChan = make(chan kafka.Event)
-		go func() {
-			var err error
-			evt := <-deliveryChan
-			if msg, ok := evt.(*kafka.Message); ok {
-				// delivery errors are returned via TopicPartition.Error
-				err = msg.TopicPartition.Error
-				trackProduceOffsets(p.cfg.dataStreamsEnabled, msg, err)
-			}
-			span.Finish(tracer.WithError(err))
-			oldDeliveryChan <- evt
-		}()
-	}
-
-	setProduceCheckpoint(p.cfg.dataStreamsEnabled, p.libraryVersion, msg)
+	finish := p.tracer.AroundProduce(msg, deliveryChan)
 	err := p.Producer.Produce(msg, deliveryChan)
-	// with no delivery channel or enqueue error, finish immediately
-	if err != nil || deliveryChan == nil {
-		span.Finish(tracer.WithError(err))
-	}
+	finish(err)
 
 	return err
 }
@@ -365,59 +172,5 @@ func (p *Producer) Produce(msg *kafka.Message, deliveryChan chan kafka.Event) er
 // ProduceChannel returns a channel which can receive kafka Messages and will
 // send them to the underlying producer channel.
 func (p *Producer) ProduceChannel() chan *kafka.Message {
-	return p.produceChannel
-}
-
-func (p *Producer) traceEventsChannel(in chan kafka.Event) chan kafka.Event {
-	if in == nil {
-		return nil
-	}
-	out := make(chan kafka.Event, 1)
-	go func() {
-		defer close(out)
-		for evt := range in {
-			if msg, ok := evt.(*kafka.Message); ok {
-				trackProduceOffsets(p.cfg.dataStreamsEnabled, msg, msg.TopicPartition.Error)
-			}
-			out <- evt
-		}
-	}()
-	return out
-}
-
-func setConsumeCheckpoint(dataStreamsEnabled bool, groupID string, msg *kafka.Message) {
-	if !dataStreamsEnabled || msg == nil {
-		return
-	}
-	edges := []string{"direction:in", "topic:" + *msg.TopicPartition.Topic, "type:kafka"}
-	if groupID != "" {
-		edges = append(edges, "group:"+groupID)
-	}
-	carrier := NewMessageCarrier(msg)
-	ctx, ok := tracer.SetDataStreamsCheckpointWithParams(datastreams.ExtractFromBase64Carrier(context.Background(), carrier), options.CheckpointParams{PayloadSize: getMsgSize(msg)}, edges...)
-	if !ok {
-		return
-	}
-	datastreams.InjectToBase64Carrier(ctx, carrier)
-}
-
-func setProduceCheckpoint(dataStreamsEnabled bool, version int, msg *kafka.Message) {
-	if !dataStreamsEnabled || msg == nil {
-		return
-	}
-	edges := []string{"direction:out", "topic:" + *msg.TopicPartition.Topic, "type:kafka"}
-	carrier := NewMessageCarrier(msg)
-	ctx, ok := tracer.SetDataStreamsCheckpointWithParams(datastreams.ExtractFromBase64Carrier(context.Background(), carrier), options.CheckpointParams{PayloadSize: getMsgSize(msg)}, edges...)
-	if !ok || version < 0x000b0400 {
-		// headers not supported before librdkafka >=0.11.4
-		return
-	}
-	datastreams.InjectToBase64Carrier(ctx, carrier)
-}
-
-func getMsgSize(msg *kafka.Message) (size int64) {
-	for _, header := range msg.Headers {
-		size += int64(len(header.Key) + len(header.Value))
-	}
-	return size + int64(len(msg.Value)+len(msg.Key))
+	return p.tracer.ProduceChannel
 }

--- a/contrib/confluentinc/confluent-kafka-go/kafka/kafka.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/kafka.go
@@ -168,6 +168,7 @@ func (p *Producer) Produce(msg *kafka.Message, deliveryChan chan kafka.Event) er
 	defer stop(err)
 
 	err = p.Producer.Produce(msg, deliveryChan)
+	return err
 }
 
 // ProduceChannel returns a channel which can receive kafka Messages and will

--- a/contrib/confluentinc/confluent-kafka-go/kafka/kafka_test.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/kafka_test.go
@@ -89,7 +89,7 @@ func produceThenConsume(t *testing.T, consumerAction consumerActionFn, producerO
 	// they should be linked via headers
 	assert.Equal(t, spans[0].TraceID(), spans[1].TraceID())
 
-	if c.cfg.dataStreamsEnabled {
+	if c.cfg.DataStreamsEnabled {
 		backlogs := mt.SentDSMBacklogs()
 		toMap := func(b []internaldsm.Backlog) map[string]struct{} {
 			m := make(map[string]struct{})

--- a/contrib/confluentinc/confluent-kafka-go/kafka/option.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/option.go
@@ -11,76 +11,38 @@ import (
 	"net"
 	"strings"
 
-	"gopkg.in/DataDog/dd-trace-go.v1/internal"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/namingschema"
-
 	"github.com/confluentinc/confluent-kafka-go/kafka"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/contrib/confluentinc/confluent-kafka-go/kafka/internal"
 )
 
-const defaultServiceName = "kafka"
+// An Option customizes the Config.
+type Option = internal.Option
 
-type config struct {
-	ctx                 context.Context
-	consumerServiceName string
-	producerServiceName string
-	consumerSpanName    string
-	producerSpanName    string
-	analyticsRate       float64
-	bootstrapServers    string
-	groupID             string
-	tagFns              map[string]func(msg *kafka.Message) interface{}
-	dataStreamsEnabled  bool
-}
-
-// An Option customizes the config.
-type Option func(cfg *config)
-
-func newConfig(opts ...Option) *config {
-	cfg := &config{
-		ctx: context.Background(),
-		// analyticsRate: globalconfig.AnalyticsRate(),
-		analyticsRate: math.NaN(),
-	}
-	cfg.dataStreamsEnabled = internal.BoolEnv("DD_DATA_STREAMS_ENABLED", false)
-	if internal.BoolEnv("DD_TRACE_KAFKA_ANALYTICS_ENABLED", false) {
-		cfg.analyticsRate = 1.0
-	}
-
-	cfg.consumerServiceName = namingschema.ServiceName(defaultServiceName)
-	cfg.producerServiceName = namingschema.ServiceNameOverrideV0(defaultServiceName, defaultServiceName)
-	cfg.consumerSpanName = namingschema.OpName(namingschema.KafkaInbound)
-	cfg.producerSpanName = namingschema.OpName(namingschema.KafkaOutbound)
-
-	for _, opt := range opts {
-		opt(cfg)
-	}
-	return cfg
-}
-
-// WithContext sets the config context to ctx.
+// WithContext sets the internal.Config context to ctx.
 // Deprecated: This is deprecated in favor of passing the context
 // via the message headers
 func WithContext(ctx context.Context) Option {
-	return func(cfg *config) {
-		cfg.ctx = ctx
+	return func(cfg *internal.Config) {
+		cfg.Ctx = ctx
 	}
 }
 
-// WithServiceName sets the config service name to serviceName.
+// WithServiceName sets the internal.Config service name to serviceName.
 func WithServiceName(serviceName string) Option {
-	return func(cfg *config) {
-		cfg.consumerServiceName = serviceName
-		cfg.producerServiceName = serviceName
+	return func(cfg *internal.Config) {
+		cfg.ConsumerServiceName = serviceName
+		cfg.ProducerServiceName = serviceName
 	}
 }
 
 // WithAnalytics enables Trace Analytics for all started spans.
 func WithAnalytics(on bool) Option {
-	return func(cfg *config) {
+	return func(cfg *internal.Config) {
 		if on {
-			cfg.analyticsRate = 1.0
+			cfg.AnalyticsRate = 1.0
 		} else {
-			cfg.analyticsRate = math.NaN()
+			cfg.AnalyticsRate = math.NaN()
 		}
 	}
 }
@@ -88,11 +50,11 @@ func WithAnalytics(on bool) Option {
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
 func WithAnalyticsRate(rate float64) Option {
-	return func(cfg *config) {
+	return func(cfg *internal.Config) {
 		if rate >= 0.0 && rate <= 1.0 {
-			cfg.analyticsRate = rate
+			cfg.AnalyticsRate = rate
 		} else {
-			cfg.analyticsRate = math.NaN()
+			cfg.AnalyticsRate = math.NaN()
 		}
 	}
 }
@@ -100,25 +62,25 @@ func WithAnalyticsRate(rate float64) Option {
 // WithCustomTag will cause the given tagFn to be evaluated after executing
 // a query and attach the result to the span tagged by the key.
 func WithCustomTag(tag string, tagFn func(msg *kafka.Message) interface{}) Option {
-	return func(cfg *config) {
-		if cfg.tagFns == nil {
-			cfg.tagFns = make(map[string]func(msg *kafka.Message) interface{})
+	return func(cfg *internal.Config) {
+		if cfg.TagFns == nil {
+			cfg.TagFns = make(map[string]func(msg *kafka.Message) interface{})
 		}
-		cfg.tagFns[tag] = tagFn
+		cfg.TagFns[tag] = tagFn
 	}
 }
 
-// WithConfig extracts the config information for the client to be tagged
+// WithConfig extracts the internal.Config information for the client to be tagged
 func WithConfig(cg *kafka.ConfigMap) Option {
-	return func(cfg *config) {
+	return func(cfg *internal.Config) {
 		if groupID, err := cg.Get("group.id", ""); err == nil {
-			cfg.groupID = groupID.(string)
+			cfg.GroupID = groupID.(string)
 		}
 		if bs, err := cg.Get("bootstrap.servers", ""); err == nil && bs != "" {
 			for _, addr := range strings.Split(bs.(string), ",") {
 				host, _, err := net.SplitHostPort(addr)
 				if err == nil {
-					cfg.bootstrapServers = host
+					cfg.BootstrapServers = host
 					return
 				}
 			}
@@ -128,7 +90,7 @@ func WithConfig(cg *kafka.ConfigMap) Option {
 
 // WithDataStreams enables the Data Streams monitoring product features: https://www.datadoghq.com/product/data-streams-monitoring/
 func WithDataStreams() Option {
-	return func(cfg *config) {
-		cfg.dataStreamsEnabled = true
+	return func(cfg *internal.Config) {
+		cfg.DataStreamsEnabled = true
 	}
 }

--- a/contrib/confluentinc/confluent-kafka-go/kafka/option_test.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka/option_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"testing"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/contrib/confluentinc/confluent-kafka-go/kafka/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 
 	"github.com/stretchr/testify/assert"
@@ -16,29 +17,29 @@ import (
 
 func TestDataStreamsActivation(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
-		cfg := newConfig()
-		assert.False(t, cfg.dataStreamsEnabled)
+		cfg := internal.NewConfig()
+		assert.False(t, cfg.DataStreamsEnabled)
 	})
 	t.Run("withOption", func(t *testing.T) {
-		cfg := newConfig(WithDataStreams())
-		assert.True(t, cfg.dataStreamsEnabled)
+		cfg := internal.NewConfig(WithDataStreams())
+		assert.True(t, cfg.DataStreamsEnabled)
 	})
 	t.Run("withEnv", func(t *testing.T) {
 		t.Setenv("DD_DATA_STREAMS_ENABLED", "true")
-		cfg := newConfig()
-		assert.True(t, cfg.dataStreamsEnabled)
+		cfg := internal.NewConfig()
+		assert.True(t, cfg.DataStreamsEnabled)
 	})
 	t.Run("optionOverridesEnv", func(t *testing.T) {
 		t.Setenv("DD_DATA_STREAMS_ENABLED", "false")
-		cfg := newConfig(WithDataStreams())
-		assert.True(t, cfg.dataStreamsEnabled)
+		cfg := internal.NewConfig(WithDataStreams())
+		assert.True(t, cfg.DataStreamsEnabled)
 	})
 }
 
 func TestAnalyticsSettings(t *testing.T) {
 	t.Run("defaults", func(t *testing.T) {
-		cfg := newConfig()
-		assert.True(t, math.IsNaN(cfg.analyticsRate))
+		cfg := internal.NewConfig()
+		assert.True(t, math.IsNaN(cfg.AnalyticsRate))
 	})
 
 	t.Run("global", func(t *testing.T) {
@@ -47,13 +48,13 @@ func TestAnalyticsSettings(t *testing.T) {
 		defer globalconfig.SetAnalyticsRate(rate)
 		globalconfig.SetAnalyticsRate(0.4)
 
-		cfg := newConfig()
-		assert.Equal(t, 0.4, cfg.analyticsRate)
+		cfg := internal.NewConfig()
+		assert.Equal(t, 0.4, cfg.AnalyticsRate)
 	})
 
 	t.Run("enabled", func(t *testing.T) {
-		cfg := newConfig(WithAnalytics(true))
-		assert.Equal(t, 1.0, cfg.analyticsRate)
+		cfg := internal.NewConfig(WithAnalytics(true))
+		assert.Equal(t, 1.0, cfg.AnalyticsRate)
 	})
 
 	t.Run("override", func(t *testing.T) {
@@ -61,7 +62,7 @@ func TestAnalyticsSettings(t *testing.T) {
 		defer globalconfig.SetAnalyticsRate(rate)
 		globalconfig.SetAnalyticsRate(0.4)
 
-		cfg := newConfig(WithAnalyticsRate(0.2))
-		assert.Equal(t, 0.2, cfg.analyticsRate)
+		cfg := internal.NewConfig(WithAnalyticsRate(0.2))
+		assert.Equal(t, 0.2, cfg.AnalyticsRate)
 	})
 }


### PR DESCRIPTION
### What does this PR do?

Refactoring tracing code for `contrib/confluent-kafka-go/kafka` to have an internal implementation usable by Orchestrion.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
