### PR TITLE
appsec: Attacker Fingerprinting

### DIFF
--- a/appsec/appsec.go
+++ b/appsec/appsec.go
@@ -84,7 +84,7 @@ func SetUser(ctx context.Context, id string, opts ...tracer.UserMonitoringOption
 // Take-Over (ATO) monitoring, ultimately blocking the IP address and/or user id
 // associated to them.
 func TrackUserLoginSuccessEvent(ctx context.Context, uid string, md map[string]string, opts ...tracer.UserMonitoringOption) error {
-	TrackCustomEvent(ctx, "users.login", md)
+	TrackCustomEvent(ctx, "users.login.success", md)
 	return SetUser(ctx, uid, opts...)
 }
 

--- a/appsec/appsec.go
+++ b/appsec/appsec.go
@@ -154,7 +154,9 @@ func getRootSpan(ctx context.Context) tracer.Span {
 }
 
 func getSessionID(opts ...tracer.UserMonitoringOption) string {
-	cfg := new(tracer.UserMonitoringConfig)
+	cfg := &tracer.UserMonitoringConfig{
+		Metadata: make(map[string]string),
+	}
 	for _, opt := range opts {
 		opt(cfg)
 	}

--- a/appsec/appsec.go
+++ b/appsec/appsec.go
@@ -60,8 +60,14 @@ func SetUser(ctx context.Context, id string, opts ...tracer.UserMonitoringOption
 		appsecDisabledLog.Do(func() { log.Warn("appsec: not enabled. User blocking checks won't be performed.") })
 		return nil
 	}
+
 	op, errPtr := usersec.StartUserLoginOperation(ctx, usersec.UserLoginOperationArgs{})
-	op.Finish(usersec.UserLoginOperationRes{UserID: id, Success: true})
+	op.Finish(usersec.UserLoginOperationRes{
+		UserID:    id,
+		SessionID: getSessionID(opts...),
+		Success:   true,
+	})
+
 	return *errPtr
 }
 
@@ -145,4 +151,12 @@ func getRootSpan(ctx context.Context) tracer.Span {
 	}
 	log.Error("appsec: could not access the root span")
 	return nil
+}
+
+func getSessionID(opts ...tracer.UserMonitoringOption) string {
+	cfg := new(tracer.UserMonitoringConfig)
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return cfg.SessionID
 }

--- a/appsec/appsec.go
+++ b/appsec/appsec.go
@@ -33,7 +33,7 @@ var appsecDisabledLog sync.Once
 // Note that passing the raw bytes of the HTTP request body is not expected and would
 // result in inaccurate attack detection.
 // This function always returns nil when appsec is disabled.
-func MonitorParsedHTTPBody(ctx context.Context, body interface{}) error {
+func MonitorParsedHTTPBody(ctx context.Context, body any) error {
 	if !appsec.Enabled() {
 		appsecDisabledLog.Do(func() { log.Warn("appsec: not enabled. Body blocking checks won't be performed.") })
 		return nil
@@ -60,7 +60,9 @@ func SetUser(ctx context.Context, id string, opts ...tracer.UserMonitoringOption
 		appsecDisabledLog.Do(func() { log.Warn("appsec: not enabled. User blocking checks won't be performed.") })
 		return nil
 	}
-	return usersec.MonitorUser(ctx, id)
+	op, errPtr := usersec.StartUserLoginOperation(ctx, usersec.UserLoginOperationArgs{})
+	op.Finish(usersec.UserLoginOperationRes{UserID: id, Success: true})
+	return *errPtr
 }
 
 // TrackUserLoginSuccessEvent sets a successful user login event, with the given
@@ -76,17 +78,7 @@ func SetUser(ctx context.Context, id string, opts ...tracer.UserMonitoringOption
 // Take-Over (ATO) monitoring, ultimately blocking the IP address and/or user id
 // associated to them.
 func TrackUserLoginSuccessEvent(ctx context.Context, uid string, md map[string]string, opts ...tracer.UserMonitoringOption) error {
-	span := getRootSpan(ctx)
-	if span == nil {
-		return nil
-	}
-
-	const tagPrefix = "appsec.events.users.login.success."
-	span.SetTag(tagPrefix+"track", true)
-	for k, v := range md {
-		span.SetTag(tagPrefix+k, v)
-	}
-	span.SetTag(ext.SamplingPriority, ext.PriorityUserKeep)
+	TrackCustomEvent(ctx, "users.login", md)
 	return SetUser(ctx, uid, opts...)
 }
 
@@ -106,14 +98,15 @@ func TrackUserLoginFailureEvent(ctx context.Context, uid string, exists bool, md
 		return
 	}
 
-	const tagPrefix = "appsec.events.users.login.failure."
-	span.SetTag(tagPrefix+"track", true)
-	span.SetTag(tagPrefix+"usr.id", uid)
-	span.SetTag(tagPrefix+"usr.exists", exists)
-	for k, v := range md {
-		span.SetTag(tagPrefix+k, v)
-	}
-	span.SetTag(ext.SamplingPriority, ext.PriorityUserKeep)
+	// We need to do the first call to SetTag ourselves because the map taken by TrackCustomEvent is map[string]string
+	// and not map [string]any, so the `exists` boolean variable does not fit int
+	span.SetTag("appsec.events.users.login.failure.usr.exists", exists)
+	span.SetTag("appsec.events.users.login.failure.usr.id", uid)
+
+	TrackCustomEvent(ctx, "users.login.failure", md)
+
+	op, _ := usersec.StartUserLoginOperation(ctx, usersec.UserLoginOperationArgs{})
+	op.Finish(usersec.UserLoginOperationRes{UserID: uid, Success: false})
 }
 
 // TrackCustomEvent sets a custom event as service entry span tags. This span is

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	cloud.google.com/go/pubsub v1.33.0
 	github.com/99designs/gqlgen v0.17.36
-	github.com/DataDog/appsec-internal-go v1.7.0
+	github.com/DataDog/appsec-internal-go v1.8.0
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.57.0
 	github.com/DataDog/datadog-go/v5 v5.3.0

--- a/go.sum
+++ b/go.sum
@@ -625,8 +625,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v0.5.1/go.mod h1:Vt9s
 github.com/AzureAD/microsoft-authentication-library-for-go v0.8.1/go.mod h1:4qFor3D/HDsvBME35Xy9rwW9DecL+M2sNw1ybjPtwA0=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DataDog/appsec-internal-go v1.7.0 h1:iKRNLih83dJeVya3IoUfK+6HLD/hQsIbyBlfvLmAeb0=
-github.com/DataDog/appsec-internal-go v1.7.0/go.mod h1:wW0cRfWBo4C044jHGwYiyh5moQV2x0AhnwqMuiX7O/g=
+github.com/DataDog/appsec-internal-go v1.8.0 h1:1Tfn3LEogntRqZtf88twSApOCAAO3V+NILYhuQIo4J4=
+github.com/DataDog/appsec-internal-go v1.8.0/go.mod h1:wW0cRfWBo4C044jHGwYiyh5moQV2x0AhnwqMuiX7O/g=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0 h1:bUMSNsw1iofWiju9yc1f+kBd33E3hMJtq9GuU602Iy8=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0/go.mod h1:HzySONXnAgSmIQfL6gOv9hWprKJkx8CicuXuUbmgWfo=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.57.0 h1:LplNAmMgZvGU7kKA0+4c1xWOjz828xweW5TCi8Mw9Q0=

--- a/internal/apps/go.mod
+++ b/internal/apps/go.mod
@@ -8,7 +8,7 @@ require (
 )
 
 require (
-	github.com/DataDog/appsec-internal-go v1.7.0 // indirect
+	github.com/DataDog/appsec-internal-go v1.8.0 // indirect
 	github.com/DataDog/go-libddwaf/v3 v3.4.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/eapache/queue/v2 v2.0.0-20230407133247-75960ed334e4 // indirect

--- a/internal/apps/go.sum
+++ b/internal/apps/go.sum
@@ -1,5 +1,5 @@
-github.com/DataDog/appsec-internal-go v1.7.0 h1:iKRNLih83dJeVya3IoUfK+6HLD/hQsIbyBlfvLmAeb0=
-github.com/DataDog/appsec-internal-go v1.7.0/go.mod h1:wW0cRfWBo4C044jHGwYiyh5moQV2x0AhnwqMuiX7O/g=
+github.com/DataDog/appsec-internal-go v1.8.0 h1:1Tfn3LEogntRqZtf88twSApOCAAO3V+NILYhuQIo4J4=
+github.com/DataDog/appsec-internal-go v1.8.0/go.mod h1:wW0cRfWBo4C044jHGwYiyh5moQV2x0AhnwqMuiX7O/g=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0 h1:bUMSNsw1iofWiju9yc1f+kBd33E3hMJtq9GuU602Iy8=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0/go.mod h1:HzySONXnAgSmIQfL6gOv9hWprKJkx8CicuXuUbmgWfo=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.57.0 h1:LplNAmMgZvGU7kKA0+4c1xWOjz828xweW5TCi8Mw9Q0=

--- a/internal/appsec/emitter/usersec/user.go
+++ b/internal/appsec/emitter/usersec/user.go
@@ -28,8 +28,9 @@ type (
 
 	// UserLoginOperationRes is the user ID operation results.
 	UserLoginOperationRes struct {
-		UserID  string
-		Success bool
+		UserID    string
+		SessionID string
+		Success   bool
 	}
 )
 

--- a/internal/appsec/emitter/waf/addresses/addresses.go
+++ b/internal/appsec/emitter/waf/addresses/addresses.go
@@ -17,7 +17,10 @@ const (
 	ServerResponseHeadersNoCookiesAddr = "server.response.headers.no_cookies"
 
 	ClientIPAddr = "http.client_ip"
-	UserIDAddr   = "usr.id"
+
+	UserIDAddr           = "usr.id"
+	UserLoginSuccessAddr = "server.business_logic.users.login.success"
+	UserLoginFailureAddr = "server.business_logic.users.login.failure"
 
 	ServerIoNetURLAddr    = "server.io.net.url"
 	ServerIOFSFileAddr    = "server.io.fs.file"

--- a/internal/appsec/emitter/waf/addresses/addresses.go
+++ b/internal/appsec/emitter/waf/addresses/addresses.go
@@ -19,7 +19,7 @@ const (
 	ClientIPAddr = "http.client_ip"
 
 	UserIDAddr           = "usr.id"
-	UserSessionIDAddr    = "usr.session.id"
+	UserSessionIDAddr    = "usr.session_id"
 	UserLoginSuccessAddr = "server.business_logic.users.login.success"
 	UserLoginFailureAddr = "server.business_logic.users.login.failure"
 

--- a/internal/appsec/emitter/waf/addresses/addresses.go
+++ b/internal/appsec/emitter/waf/addresses/addresses.go
@@ -19,6 +19,7 @@ const (
 	ClientIPAddr = "http.client_ip"
 
 	UserIDAddr           = "usr.id"
+	UserSessionIDAddr    = "usr.session.id"
 	UserLoginSuccessAddr = "server.business_logic.users.login.success"
 	UserLoginFailureAddr = "server.business_logic.users.login.failure"
 

--- a/internal/appsec/emitter/waf/addresses/builder.go
+++ b/internal/appsec/emitter/waf/addresses/builder.go
@@ -115,6 +115,16 @@ func (b *RunAddressDataBuilder) WithUserID(id string) *RunAddressDataBuilder {
 	return b
 }
 
+func (b *RunAddressDataBuilder) WithUserLoginSuccess() *RunAddressDataBuilder {
+	b.Persistent[UserLoginSuccessAddr] = nil
+	return b
+}
+
+func (b *RunAddressDataBuilder) WithUserLoginFailure() *RunAddressDataBuilder {
+	b.Persistent[UserLoginFailureAddr] = nil
+	return b
+}
+
 func (b *RunAddressDataBuilder) WithFilePath(file string) *RunAddressDataBuilder {
 	if file == "" {
 		return b

--- a/internal/appsec/emitter/waf/addresses/builder.go
+++ b/internal/appsec/emitter/waf/addresses/builder.go
@@ -28,24 +28,18 @@ func NewAddressesBuilder() *RunAddressDataBuilder {
 }
 
 func (b *RunAddressDataBuilder) WithMethod(method string) *RunAddressDataBuilder {
-	if method == "" {
-		return b
-	}
 	b.Persistent[ServerRequestMethodAddr] = method
 	return b
 }
 
 func (b *RunAddressDataBuilder) WithRawURI(uri string) *RunAddressDataBuilder {
-	if uri == "" {
-		return b
-	}
 	b.Persistent[ServerRequestRawURIAddr] = uri
 	return b
 }
 
 func (b *RunAddressDataBuilder) WithHeadersNoCookies(headers map[string][]string) *RunAddressDataBuilder {
 	if len(headers) == 0 {
-		return b
+		headers = nil
 	}
 	b.Persistent[ServerRequestHeadersNoCookiesAddr] = headers
 	return b
@@ -53,7 +47,7 @@ func (b *RunAddressDataBuilder) WithHeadersNoCookies(headers map[string][]string
 
 func (b *RunAddressDataBuilder) WithCookies(cookies map[string][]string) *RunAddressDataBuilder {
 	if len(cookies) == 0 {
-		return b
+		cookies = nil
 	}
 	b.Persistent[ServerRequestCookiesAddr] = cookies
 	return b
@@ -61,7 +55,7 @@ func (b *RunAddressDataBuilder) WithCookies(cookies map[string][]string) *RunAdd
 
 func (b *RunAddressDataBuilder) WithQuery(query map[string][]string) *RunAddressDataBuilder {
 	if len(query) == 0 {
-		return b
+		query = nil
 	}
 	b.Persistent[ServerRequestQueryAddr] = query
 	return b
@@ -121,6 +115,7 @@ func (b *RunAddressDataBuilder) WithUserSessionID(id string) *RunAddressDataBuil
 	}
 	b.Persistent[UserSessionIDAddr] = id
 	return b
+
 }
 
 func (b *RunAddressDataBuilder) WithUserLoginSuccess() *RunAddressDataBuilder {

--- a/internal/appsec/emitter/waf/addresses/builder.go
+++ b/internal/appsec/emitter/waf/addresses/builder.go
@@ -115,6 +115,14 @@ func (b *RunAddressDataBuilder) WithUserID(id string) *RunAddressDataBuilder {
 	return b
 }
 
+func (b *RunAddressDataBuilder) WithUserSessionID(id string) *RunAddressDataBuilder {
+	if id == "" {
+		return b
+	}
+	b.Persistent[UserSessionIDAddr] = id
+	return b
+}
+
 func (b *RunAddressDataBuilder) WithUserLoginSuccess() *RunAddressDataBuilder {
 	b.Persistent[UserLoginSuccessAddr] = nil
 	return b

--- a/internal/appsec/listener/usersec/usec.go
+++ b/internal/appsec/listener/usersec/usec.go
@@ -25,6 +25,7 @@ func (*Feature) Stop() {}
 func NewUserSecFeature(cfg *config.Config, rootOp dyngo.Operation) (listener.Feature, error) {
 	if !cfg.SupportedAddresses.AnyOf(
 		addresses.UserIDAddr,
+		addresses.UserSessionIDAddr,
 		addresses.UserLoginSuccessAddr,
 		addresses.UserLoginFailureAddr) {
 		return nil, nil
@@ -35,11 +36,12 @@ func NewUserSecFeature(cfg *config.Config, rootOp dyngo.Operation) (listener.Fea
 	return feature, nil
 }
 
-func (*Feature) OnFinish(op *usersec.UserLoginOperation, args usersec.UserLoginOperationRes) {
+func (*Feature) OnFinish(op *usersec.UserLoginOperation, res usersec.UserLoginOperationRes) {
 	builder := addresses.NewAddressesBuilder().
-		WithUserID(args.UserID)
+		WithUserID(res.UserID).
+		WithUserSessionID(res.SessionID)
 
-	if args.Success {
+	if res.Success {
 		builder = builder.WithUserLoginSuccess()
 	} else {
 		builder = builder.WithUserLoginFailure()

--- a/internal/appsec/remoteconfig.go
+++ b/internal/appsec/remoteconfig.go
@@ -392,6 +392,10 @@ var blockingCapabilities = [...]remoteconfig.Capability{
 	remoteconfig.ASMCustomBlockingResponse,
 	remoteconfig.ASMTrustedIPs,
 	remoteconfig.ASMExclusionData,
+	remoteconfig.ASMEndpointFingerprinting,
+	remoteconfig.ASMSessionFingerprinting,
+	remoteconfig.ASMNetworkFingerprinting,
+	remoteconfig.ASMHeaderFingerprinting,
 }
 
 func (a *appsec) enableRCBlocking() {

--- a/internal/appsec/testdata/fp.json
+++ b/internal/appsec/testdata/fp.json
@@ -1,0 +1,207 @@
+{
+    "version": "2.2",
+    "metadata": {
+        "rules_version": "1.4.2"
+    },
+    "rules": [
+        {
+            "id": "crs-933-130-block",
+            "name": "PHP Injection Attack: Global Variables Found",
+            "tags": {
+                "type": "php_code_injection",
+                "crs_id": "933130",
+                "category": "attack_attempt",
+                "confidence": "1"
+            },
+            "conditions": [
+                {
+                    "parameters": {
+                        "inputs": [
+                            {
+                                "address": "server.request.query"
+                            }
+                        ],
+                        "list": [
+                            "$globals"
+                        ]
+                    },
+                    "operator": "phrase_match"
+                }
+            ],
+            "transformers": [
+                "lowercase"
+            ]
+        }
+    ],
+    "processors": [
+        {
+            "id": "http-endpoint-fingerprint",
+            "generator": "http_endpoint_fingerprint",
+            "conditions": [
+                {
+                    "operator": "exists",
+                    "parameters": {
+                        "inputs": [
+                            {
+                                "address": "waf.context.event"
+                            },
+                            {
+                                "address": "server.business_logic.users.login.failure"
+                            },
+                            {
+                                "address": "server.business_logic.users.login.success"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "parameters": {
+                "mappings": [
+                    {
+                        "method": [
+                            {
+                                "address": "server.request.method"
+                            }
+                        ],
+                        "uri_raw": [
+                            {
+                                "address": "server.request.uri.raw"
+                            }
+                        ],
+                        "body": [
+                            {
+                                "address": "server.request.body"
+                            }
+                        ],
+                        "query": [
+                            {
+                                "address": "server.request.query"
+                            }
+                        ],
+                        "output": "_dd.appsec.fp.http.endpoint"
+                    }
+                ]
+            },
+            "evaluate": false,
+            "output": true
+        },
+        {
+            "id": "http-header-fingerprint",
+            "generator": "http_header_fingerprint",
+            "conditions": [
+                {
+                    "operator": "exists",
+                    "parameters": {
+                        "inputs": [
+                            {
+                                "address": "waf.context.event"
+                            },
+                            {
+                                "address": "server.business_logic.users.login.failure"
+                            },
+                            {
+                                "address": "server.business_logic.users.login.success"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "parameters": {
+                "mappings": [
+                    {
+                        "headers": [
+                            {
+                                "address": "server.request.headers.no_cookies"
+                            }
+                        ],
+                        "output": "_dd.appsec.fp.http.header"
+                    }
+                ]
+            },
+            "evaluate": false,
+            "output": true
+        },
+        {
+            "id": "http-network-fingerprint",
+            "generator": "http_network_fingerprint",
+            "conditions": [
+                {
+                    "operator": "exists",
+                    "parameters": {
+                        "inputs": [
+                            {
+                                "address": "waf.context.event"
+                            },
+                            {
+                                "address": "server.business_logic.users.login.failure"
+                            },
+                            {
+                                "address": "server.business_logic.users.login.success"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "parameters": {
+                "mappings": [
+                    {
+                        "headers": [
+                            {
+                                "address": "server.request.headers.no_cookies"
+                            }
+                        ],
+                        "output": "_dd.appsec.fp.http.network"
+                    }
+                ]
+            },
+            "evaluate": false,
+            "output": true
+        },
+        {
+            "id": "session-fingerprint",
+            "generator": "session_fingerprint",
+            "conditions": [
+                {
+                    "operator": "exists",
+                    "parameters": {
+                        "inputs": [
+                            {
+                                "address": "waf.context.event"
+                            },
+                            {
+                                "address": "server.business_logic.users.login.failure"
+                            },
+                            {
+                                "address": "server.business_logic.users.login.success"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "parameters": {
+                "mappings": [
+                    {
+                        "cookies": [
+                            {
+                                "address": "server.request.cookies"
+                            }
+                        ],
+                        "session_id": [
+                            {
+                                "address": "usr.session_id"
+                            }
+                        ],
+                        "user_id": [
+                            {
+                                "address": "usr.id"
+                            }
+                        ],
+                        "output": "_dd.appsec.fp.session"
+                    }
+                ]
+            },
+            "evaluate": false,
+            "output": true
+        }
+    ]
+}

--- a/internal/exectracetest/go.mod
+++ b/internal/exectracetest/go.mod
@@ -10,7 +10,7 @@ require (
 )
 
 require (
-	github.com/DataDog/appsec-internal-go v1.7.0 // indirect
+	github.com/DataDog/appsec-internal-go v1.8.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.57.0 // indirect
 	github.com/DataDog/datadog-go/v5 v5.3.0 // indirect

--- a/internal/exectracetest/go.sum
+++ b/internal/exectracetest/go.sum
@@ -1,5 +1,5 @@
-github.com/DataDog/appsec-internal-go v1.7.0 h1:iKRNLih83dJeVya3IoUfK+6HLD/hQsIbyBlfvLmAeb0=
-github.com/DataDog/appsec-internal-go v1.7.0/go.mod h1:wW0cRfWBo4C044jHGwYiyh5moQV2x0AhnwqMuiX7O/g=
+github.com/DataDog/appsec-internal-go v1.8.0 h1:1Tfn3LEogntRqZtf88twSApOCAAO3V+NILYhuQIo4J4=
+github.com/DataDog/appsec-internal-go v1.8.0/go.mod h1:wW0cRfWBo4C044jHGwYiyh5moQV2x0AhnwqMuiX7O/g=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0 h1:bUMSNsw1iofWiju9yc1f+kBd33E3hMJtq9GuU602Iy8=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0/go.mod h1:HzySONXnAgSmIQfL6gOv9hWprKJkx8CicuXuUbmgWfo=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.57.0 h1:LplNAmMgZvGU7kKA0+4c1xWOjz828xweW5TCi8Mw9Q0=

--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -86,12 +86,32 @@ const (
 	ASMRASPLFI
 	// ASMRASPSSRF enables ASM support for runtime protection against SSRF attacks
 	ASMRASPSSRF
-)
-
-// Additional capability bit index values that are non-consecutive from above.
-const (
+	// ASMRASPSHI enables ASM support for runtime protection against XSS attacks
+	ASMRASPSHI
+	// ASMRASPXXE enables ASM support for runtime protection against XXE attacks
+	ASMRASPXXE
+	// ASMRASPRCE enables ASM support for runtime protection against Remote Code Execution
+	ASMRASPRCE
+	// ASMRASPNOSQLI enables ASM support for runtime protection against NoSQL Injection attacks
+	ASMRASPNOSQLI
+	// ASMRASPXSS enables ASM support for runtime protection against Cross Site Scripting attacks
+	ASMRASPXSS
 	// APMTracingSampleRules represents the sampling rate using matching rules from APM client libraries
-	APMTracingSampleRules = 29
+	APMTracingSampleRules
+	// CSMActivation represents the capability to activate CSM through remote configuration
+	CSMActivation
+	// ASMAutoUserInstrumMode represents the capability to enable the automatic user instrumentation mode
+	ASMAutoUserInstrumMode
+	// ASMEndpointFingerprinting represents the capability to enable endpoint fingerprinting
+	ASMEndpointFingerprinting
+	// ASMSessionFingerprinting represents the capability to enable session fingerprinting
+	ASMSessionFingerprinting
+	// ASMNetworkFingerprinting represents the capability to enable network fingerprinting
+	ASMNetworkFingerprinting
+	// ASMHeaderFingerprinting represents the capability to enable header fingerprinting
+	ASMHeaderFingerprinting
+	// ASMTruncationRules is the support for truncation payload rules
+	ASMTruncationRules
 )
 
 // ErrClientNotStarted is returned when the remote config client is not started.


### PR DESCRIPTION
### What does this PR do?

This PR finishing to setup Attacker fingerprinting:

- [x] Support for `server.business_logic.users.login.success` address
- [x] Support for `server.business_logic.users.login.failure` address
- [x] Support for `usr.session_id` address
- [x] Add all missing capabilities from the remoteconfig client
- [x] Register fingerprinting capabilities at appsec start
- [x] Upgrade the default ruleset to include fingerprinting preprocessors  

System-tests job: https://github.com/DataDog/dd-trace-go/actions/runs/11127586022

### Motivation

Implementation of the Attacker Fingerprinting [RFC](https://docs.google.com/document/d/1DivOa9XsCggmZVzMI57vyxH2_EBJ0-qqIkRHm_sEvSs/edit?pli=1)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
