### PR TITLE
v2: remove samplingpriority

### DIFF
--- a/appsec/appsec.go
+++ b/appsec/appsec.go
@@ -87,6 +87,7 @@ func TrackUserLoginSuccessEvent(ctx context.Context, uid string, md map[string]s
 		span.SetTag(tagPrefix+k, v)
 	}
 	span.SetTag(ext.SamplingPriority, ext.PriorityUserKeep)
+	span.SetTag(ext.ManualKeep, true)
 	return SetUser(ctx, uid, opts...)
 }
 
@@ -114,6 +115,7 @@ func TrackUserLoginFailureEvent(ctx context.Context, uid string, exists bool, md
 		span.SetTag(tagPrefix+k, v)
 	}
 	span.SetTag(ext.SamplingPriority, ext.PriorityUserKeep)
+	span.SetTag(ext.ManualKeep, true)
 }
 
 // TrackCustomEvent sets a custom event as service entry span tags. This span is
@@ -131,6 +133,7 @@ func TrackCustomEvent(ctx context.Context, name string, md map[string]string) {
 	tagPrefix := "appsec.events." + name + "."
 	span.SetTag(tagPrefix+"track", true)
 	span.SetTag(ext.SamplingPriority, ext.PriorityUserKeep)
+	span.SetTag(ext.ManualKeep, true)
 	for k, v := range md {
 		span.SetTag(tagPrefix+k, v)
 	}

--- a/contrib/dimfeld/httptreemux.v5/example_test.go
+++ b/contrib/dimfeld/httptreemux.v5/example_test.go
@@ -44,6 +44,7 @@ func Example_withSpanOpts() {
 		httptrace.WithService("http.router"),
 		httptrace.WithSpanOptions(
 			tracer.Tag(ext.SamplingPriority, ext.PriorityUserKeep),
+			tracer.Tag(ext.ManualKeep, true),
 		),
 	)
 

--- a/contrib/gorilla/mux/mux_test.go
+++ b/contrib/gorilla/mux/mux_test.go
@@ -224,7 +224,7 @@ func TestSpanOptions(t *testing.T) {
 	assert := assert.New(t)
 	mt := mocktracer.Start()
 	defer mt.Stop()
-	mux := NewRouter(WithSpanOptions(tracer.Tag(ext.SamplingPriority, 2)))
+	mux := NewRouter(WithSpanOptions(tracer.Tag(ext.SamplingPriority, 2), tracer.Tag(ext.ManualKeep, true)))
 	mux.Handle("/200", okHandler()).Host("localhost")
 	r := httptest.NewRequest("GET", "http://localhost/200", nil)
 	w := httptest.NewRecorder()

--- a/contrib/julienschmidt/httprouter/example_test.go
+++ b/contrib/julienschmidt/httprouter/example_test.go
@@ -46,6 +46,7 @@ func Example_withSpanOpts() {
 		httptrace.WithService("http.router"),
 		httptrace.WithSpanOptions(
 			tracer.Tag(ext.SamplingPriority, ext.PriorityUserKeep),
+			tracer.Tag(ext.ManualKeep, true),
 		),
 	)
 

--- a/ddtrace/tracer/rules_sampler.go
+++ b/ddtrace/tracer/rules_sampler.go
@@ -488,14 +488,17 @@ func (rs *traceRulesSampler) applyRate(span *Span, rate float64, now time.Time, 
 	delete(span.metrics, keySamplingPriorityRate)
 	if !sampledByRate(span.traceID, rate) {
 		span.setSamplingPriorityLocked(ext.PriorityUserReject, sampler)
+		span.setKeptDecisionLocked(false)
 		return
 	}
 
 	sampled, rate := rs.limiter.allowOne(now)
 	if sampled {
 		span.setSamplingPriorityLocked(ext.PriorityUserKeep, sampler)
+		span.setKeptDecisionLocked(true)
 	} else {
 		span.setSamplingPriorityLocked(ext.PriorityUserReject, sampler)
+		span.setKeptDecisionLocked(false)
 	}
 	span.setMetric(keyRulesSamplerLimiterRate, rate)
 }

--- a/ddtrace/tracer/sampler.go
+++ b/ddtrace/tracer/sampler.go
@@ -165,8 +165,10 @@ func (ps *prioritySampler) apply(spn *Span) {
 	rate := ps.getRate(spn)
 	if sampledByRate(spn.traceID, rate) {
 		spn.setSamplingPriority(ext.PriorityAutoKeep, samplernames.AgentRate)
+		spn.setKeptDecisionLocked(true)
 	} else {
 		spn.setSamplingPriority(ext.PriorityAutoReject, samplernames.AgentRate)
+		spn.setKeptDecisionLocked(false)
 	}
 	spn.SetTag(keySamplingPriorityRate, rate)
 }

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -287,11 +287,13 @@ func (s *Span) setSamplingPriority(priority int, sampler samplernames.SamplerNam
 
 // setSamplingDecision locks the span and updates the sampling decision.
 // It should also update the trace's sampling decision.
-func (s *Span) setSamplingDecision(decision samplingDecision) {
+func (s *Span) setKeptDecision(decision bool) {
 	if s == nil {
 		return
 	}
-	if decision == decisionKeep {
+	s.Lock()
+	defer s.Unlock()
+	if decision {
 		s.SetTag(ext.ManualKeep, true)
 	} else {
 		s.SetTag(ext.ManualDrop, true)

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -215,6 +215,8 @@ func TestShouldDrop(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			s := newSpan("", "", "", 1, 1, 0)
 			s.SetTag(ext.SamplingPriority, tt.prio)
+			s.SetTag(ext.ManualKeep, tt.prio > 0)
+			s.SetTag(ext.ManualDrop, tt.prio <= 0)
 			s.SetTag(ext.EventSampleRate, tt.rate)
 			atomic.StoreInt32(&s.context.errors, tt.errors)
 			assert.Equal(t, shouldKeep(s), tt.want)
@@ -727,9 +729,10 @@ func TestSpanError(t *testing.T) {
 	span.SetTag(ext.Error, err)
 	assert.Equal(int32(0), span.error)
 
-	// '+3' is `_dd.p.dm` + `_dd.base_service`, `_dd.p.tid`
+	// '+6' is `_dd.p.dm` + `_dd.kept` + `_dd.base_service`, `_dd.p.tid`
+	// + `manual.drop` + `manual.keep`
 	t.Logf("%q\n", span.meta)
-	assert.Equal(nMeta+3, len(span.meta))
+	assert.Equal(nMeta+6, len(span.meta))
 	assert.Equal("", span.meta[ext.ErrorMsg])
 	assert.Equal("", span.meta[ext.ErrorType])
 	assert.Equal("", span.meta[ext.ErrorStack])

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -394,6 +394,7 @@ func (t *trace) setSamplingPriority(p int, sampler samplernames.SamplerName) boo
 func (t *trace) setKeptDecision(decision bool) {
 	t.setTag(ext.ManualDrop, fmt.Sprintf("%t", !decision))
 	t.setTag(ext.ManualKeep, fmt.Sprintf("%t", decision))
+	t.setTag(keyKeptDecision, fmt.Sprintf("%t", decision))
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.setKeptDecisionLocked(decision)
@@ -459,7 +460,7 @@ func (t *trace) setSamplingPriorityLocked(p int, sampler samplernames.SamplerNam
 }
 
 func (t *trace) setKeptDecisionLocked(decision bool) {
-	// t.setPropagatingTagLocked(keyKeptDecision, fmt.Sprintf("%t", decision))
+	t.setPropagatingTagLocked(keyKeptDecision, fmt.Sprintf("%t", decision))
 	t.kept = decision
 }
 

--- a/ddtrace/tracer/sqlcomment_test.go
+++ b/ddtrace/tracer/sqlcomment_test.go
@@ -181,6 +181,8 @@ func TestSQLCommentCarrier(t *testing.T) {
 				traceID = uint64(10)
 				root := tracer.StartSpan("service.calling.db", WithSpanID(traceID))
 				root.SetTag(ext.SamplingPriority, tc.samplingPriority)
+				root.SetTag(ext.ManualKeep, tc.samplingPriority > 0)
+				root.SetTag(ext.ManualDrop, tc.samplingPriority <= 0)
 				spanCtx = root.Context()
 			}
 
@@ -347,6 +349,7 @@ func setupBenchmark() (*tracer, *SpanContext, SQLCommentCarrier) {
 	tracer, _ := newTracer(WithService("whiskey-service !#$%&'()*+,/:;=?@[]"), WithEnv("test-env"), WithServiceVersion("1.0.0"))
 	root := tracer.StartSpan("service.calling.db", WithSpanID(10))
 	root.SetTag(ext.SamplingPriority, 2)
+	root.SetTag(ext.ManualKeep, true)
 	spanCtx := root.Context()
 	carrier := SQLCommentCarrier{Query: "SELECT 1 FROM dual", Mode: DBMPropagationModeFull, DBServiceName: "whiskey-db"}
 	return tracer, spanCtx, carrier

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -1578,8 +1578,6 @@ func TestEnvVars(t *testing.T) {
 					assert.Nil(err)
 					root := tracer.StartSpan("web.request")
 					root.SetTag(ext.SamplingPriority, tc.priority)
-					root.SetTag(ext.ManualKeep, tc.priority > 0)
-					root.SetTag(ext.ManualDrop, tc.priority <= 0)
 					ctx := root.Context()
 					ctx.origin = tc.origin
 					ctx.traceID = tc.tid

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -372,6 +372,7 @@ func TestTextMapPropagatorTraceTagsWithoutPriority(t *testing.T) {
 	childSpanID := child.Context().spanID
 	assert.Equal(t, map[string]string{
 		"hello":    "world",
+		"_dd.kept": "true",
 		"_dd.p.dm": "-1",
 	}, ctx.trace.propagatingTags)
 	dst := map[string]string{}
@@ -381,7 +382,7 @@ func TestTextMapPropagatorTraceTagsWithoutPriority(t *testing.T) {
 	assert.Equal(t, strconv.Itoa(int(childSpanID)), dst["x-datadog-parent-id"])
 	assert.Equal(t, "1", dst["x-datadog-trace-id"])
 	assert.Equal(t, "1", dst["x-datadog-sampling-priority"])
-	assertTraceTags(t, "hello=world,_dd.p.dm=-1", dst["x-datadog-tags"])
+	assertTraceTags(t, "hello=world,_dd.p.dm=-1,_dd.kept=true", dst["x-datadog-tags"])
 }
 
 func TestExtractOriginSynthetics(t *testing.T) {
@@ -412,6 +413,7 @@ func Test257CharacterDDTracestateLengh(t *testing.T) {
 	assert := assert.New(t)
 	root := tracer.StartSpan("web.request")
 	root.SetTag(ext.SamplingPriority, ext.PriorityUserKeep)
+	root.SetTag(ext.ManualKeep, true)
 	ctx := root.Context()
 	ctx.origin = "rum"
 	ctx.traceID = traceIDFrom64Bits(1)
@@ -575,6 +577,7 @@ func TestTextMapPropagator(t *testing.T) {
 		assert.NoError(t, err)
 		root := tracer.StartSpan("web.request")
 		root.SetTag(ext.SamplingPriority, -1)
+		root.SetTag(ext.ManualDrop, true)
 		root.SetBaggageItem("item", "x")
 		ctx := root.Context()
 		headers := TextMapCarrier(map[string]string{})
@@ -1054,6 +1057,7 @@ func TestEnvVars(t *testing.T) {
 					assert.NoError(t, err)
 					root := tracer.StartSpan("web.request")
 					root.SetTag(ext.SamplingPriority, -1)
+					root.SetTag(ext.ManualDrop, true)
 					root.SetBaggageItem("item", "x")
 					ctx := root.Context()
 					ctx.traceID = traceIDFrom64Bits(tc.in[0])
@@ -1574,6 +1578,8 @@ func TestEnvVars(t *testing.T) {
 					assert.Nil(err)
 					root := tracer.StartSpan("web.request")
 					root.SetTag(ext.SamplingPriority, tc.priority)
+					root.SetTag(ext.ManualKeep, tc.priority > 0)
+					root.SetTag(ext.ManualDrop, tc.priority <= 0)
 					ctx := root.Context()
 					ctx.origin = tc.origin
 					ctx.traceID = tc.tid
@@ -1604,6 +1610,7 @@ func TestEnvVars(t *testing.T) {
 					assert.Nil(err)
 					root := tracer.StartSpan("web.request")
 					root.SetTag(ext.SamplingPriority, ext.PriorityUserKeep)
+					root.SetTag(ext.ManualKeep, true)
 					ctx := root.Context()
 					ctx.origin = "old_tracestate"
 					ctx.traceID = traceIDFrom64Bits(1229782938247303442)
@@ -1963,6 +1970,7 @@ func TestNonePropagator(t *testing.T) {
 		assert.NoError(t, err)
 		root := tracer.StartSpan("web.request")
 		root.SetTag(ext.SamplingPriority, -1)
+		root.SetTag(ext.ManualDrop, true)
 		root.SetBaggageItem("item", "x")
 		ctx := root.Context()
 		ctx.traceID = traceIDFrom64Bits(1)
@@ -1986,6 +1994,7 @@ func TestNonePropagator(t *testing.T) {
 		tracer.config.propagator = NewPropagator(&PropagatorConfig{})
 		root := tracer.StartSpan("web.request")
 		root.SetTag(ext.SamplingPriority, -1)
+		root.SetTag(ext.ManualDrop, true)
 		root.SetBaggageItem("item", "x")
 		ctx := root.Context()
 		ctx.traceID = traceIDFrom64Bits(1)
@@ -2009,6 +2018,7 @@ func TestNonePropagator(t *testing.T) {
 		assert.NoError(err)
 		root := tracer.StartSpan("web.request")
 		root.SetTag(ext.SamplingPriority, -1)
+		root.SetTag(ext.ManualDrop, true)
 		root.SetBaggageItem("item", "x")
 		headers := TextMapCarrier(map[string]string{})
 
@@ -2026,6 +2036,7 @@ func TestNonePropagator(t *testing.T) {
 			assert.NoError(t, err)
 			root := tracer.StartSpan("web.request")
 			root.SetTag(ext.SamplingPriority, -1)
+			root.SetTag(ext.ManualDrop, true)
 			root.SetBaggageItem("item", "x")
 			ctx := root.Context()
 			ctx.traceID = traceIDFrom64Bits(1)
@@ -2047,6 +2058,7 @@ func TestNonePropagator(t *testing.T) {
 			defer tracer.Stop()
 			root := tracer.StartSpan("web.request")
 			root.SetTag(ext.SamplingPriority, -1)
+			root.SetTag(ext.ManualDrop, true)
 			root.SetBaggageItem("item", "x")
 			ctx := root.Context()
 			ctx.traceID = traceIDFrom64Bits(1)
@@ -2071,6 +2083,7 @@ func TestNonePropagator(t *testing.T) {
 			assert.NoError(t, err)
 			root := tracer.StartSpan("web.request")
 			root.SetTag(ext.SamplingPriority, -1)
+			root.SetTag(ext.ManualDrop, true)
 			root.SetBaggageItem("item", "x")
 			ctx := root.Context()
 			ctx.traceID = traceIDFrom64Bits(1)

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -893,6 +893,7 @@ func TestPropagationDefaults(t *testing.T) {
 	root := tracer.StartSpan("web.request")
 	root.SetBaggageItem("x", "y")
 	root.SetTag(ext.SamplingPriority, -1)
+	root.SetTag(ext.ManualDrop, true)
 	ctx := root.Context()
 	headers := http.Header{}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

* Increase use of `ManualKeep` and `ManualDrop` to properly imitate the behavior of `SamplingPriority`.
* Remove `deprecated` label on `SamplingPriority`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

Although `SamplingPriority` was deprecated several years ago, support for it remained for backwards compatibility. This PR removes the `deprecated` label, as removing it entirely is not feasible at this point in time. Customers should still be encouraged to use `ManualKeep` and `ManualDrop` instead. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
