### PR TITLE
Implement DD_TRACE_LOG_DIRECTORY

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -276,6 +276,9 @@ type config struct {
 
 	// ciVisibilityEnabled controls if the tracer is loaded with CI Visibility mode. default false
 	ciVisibilityEnabled bool
+
+	// logDirectory is directory specified by user-setting DD_TRACE_LOG_DIRECTORY
+	logDirectory string
 }
 
 // orchestrionConfig contains Orchestrion configuration.
@@ -379,6 +382,7 @@ func newConfig(opts ...StartOption) *config {
 	c.logStartup = internal.BoolEnv("DD_TRACE_STARTUP_LOGS", true)
 	c.runtimeMetrics = internal.BoolVal(getDDorOtelConfig("metrics"), false)
 	c.debug = internal.BoolVal(getDDorOtelConfig("debugMode"), false)
+	c.logDirectory = os.Getenv("DD_TRACE_LOG_DIRECTORY")
 	c.enabled = newDynamicConfig("tracing_enabled", internal.BoolVal(getDDorOtelConfig("enabled"), true), func(b bool) bool { return true }, equal[bool])
 	if _, ok := os.LookupEnv("DD_TRACE_ENABLED"); ok {
 		c.enabled.cfgOrigin = telemetry.OriginEnvVar
@@ -505,7 +509,6 @@ func newConfig(opts ...StartOption) *config {
 	if c.debug {
 		log.SetLevel(log.LevelDebug)
 	}
-
 	// if using stdout or traces are disabled, agent is disabled
 	agentDisabled := c.logToStdout || !c.enabled.current
 	c.agent = loadAgentFeatures(agentDisabled, c.agentURL, c.httpClient)

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -277,7 +277,7 @@ type config struct {
 	// ciVisibilityEnabled controls if the tracer is loaded with CI Visibility mode. default false
 	ciVisibilityEnabled bool
 
-	// logDirectory is directory specified by user-setting DD_TRACE_LOG_DIRECTORY
+	// logDirectory is directory for tracer logs specified by user-setting DD_TRACE_LOG_DIRECTORY. default empty/unused
 	logDirectory string
 }
 

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -55,6 +55,7 @@ func startTelemetry(c *config) {
 		{Name: "trace_peer_service_defaults_enabled", Value: c.peerServiceDefaultsEnabled},
 		{Name: "orchestrion_enabled", Value: c.orchestrionCfg.Enabled},
 		{Name: "trace_enabled", Value: c.enabled.current, Origin: c.enabled.cfgOrigin},
+		{Name: "trace_log_directory", Value: c.logDirectory},
 		c.traceSampleRate.toTelemetry(),
 		c.headerAsTags.toTelemetry(),
 		c.globalTags.toTelemetry(),

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -112,6 +112,9 @@ type tracer struct {
 	// when abandoned spans debugging is enabled.
 	abandonedSpansDebugger *abandonedSpansDebugger
 
+	// logFile contains a pointer to the file for writing tracer logs along with helper functionality for closing the file
+	// logFile is closed when tracer stops
+	// by default, tracer logs to stderr and this setting is unused
 	logFile *log.ManagedFile
 }
 

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -8,7 +8,6 @@ package tracer
 import (
 	gocontext "context"
 	"encoding/binary"
-	"fmt"
 	"math"
 	"os"
 	"runtime/pprof"
@@ -677,7 +676,6 @@ func spanResourcePIISafe(s *span) bool {
 
 // Stop stops the tracer.
 func (t *tracer) Stop() {
-	fmt.Println("Hallo?")
 	t.stopOnce.Do(func() {
 		close(t.stop)
 		t.statsd.Incr("datadog.tracer.stopped", nil, 1)

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -257,14 +257,15 @@ func TestTracerStart(t *testing.T) {
 
 func TestTracerLogFile(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
-		f, err := os.MkdirTemp("", "example")
+		dir, err := os.MkdirTemp("", "example")
 		if err != nil {
 			t.Fatalf("Failure to make temp dir: %v", err)
 		}
-		t.Setenv("DD_TRACE_LOG_DIRECTORY", f)
+		t.Setenv("DD_TRACE_LOG_DIRECTORY", dir)
 		tracer := newTracer()
-		assert.Equal(t, f, tracer.config.logDirectory)
+		assert.Equal(t, dir, tracer.config.logDirectory)
 		assert.NotNil(t, tracer.logFile)
+		assert.Equal(t, dir+"/"+log.LoggerFile, tracer.logFile.Name())
 	})
 	t.Run("invalid", func(t *testing.T) {
 		t.Setenv("DD_TRACE_LOG_DIRECTORY", "some/nonexistent/path")

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -255,6 +255,26 @@ func TestTracerStart(t *testing.T) {
 	})
 }
 
+func TestTracerLogFile(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		f, err := os.MkdirTemp("", "example")
+		if err != nil {
+			t.Fatalf("Failure to make temp dir: %v", err)
+		}
+		t.Setenv("DD_TRACE_LOG_DIRECTORY", f)
+		tracer := newTracer()
+		assert.Equal(t, f, tracer.config.logDirectory)
+		assert.NotNil(t, tracer.logFile)
+	})
+	t.Run("invalid", func(t *testing.T) {
+		t.Setenv("DD_TRACE_LOG_DIRECTORY", "some/nonexistent/path")
+		tracer := newTracer()
+		defer Stop()
+		assert.Empty(t, tracer.config.logDirectory)
+		assert.Nil(t, tracer.logFile)
+	})
+}
+
 func TestTracerStartSpan(t *testing.T) {
 	t.Run("generic", func(t *testing.T) {
 		tracer := newTracer()

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -60,7 +60,6 @@ func (m *ManagedFile) Close() error {
 		return err
 	}
 	m.closed = true
-	fmt.Println("It's closed now", m.closed)
 	return nil
 }
 

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -52,13 +52,13 @@ func TestLogDirectory(t *testing.T) {
 	})
 	t.Run("valid", func(t *testing.T) {
 		// ensure File is created successfully
-		p, err := os.MkdirTemp("", "example")
+		dir, err := os.MkdirTemp("", "example")
 		if err != nil {
 			t.Fatalf("Failure creating directory %v", err)
 		}
-		f, err := OpenFileAtPath(p)
+		f, err := OpenFileAtPath(dir)
 		assert.Nil(t, err)
-		fp := p + "/" + LoggerFile
+		fp := dir + "/" + LoggerFile
 		assert.NotNil(t, f.file)
 		assert.Equal(t, fp, f.file.Name())
 		assert.False(t, f.closed)

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -6,7 +6,9 @@
 package log
 
 import (
+	"bytes"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -40,6 +42,76 @@ func (tp *testLogger) Reset() {
 	tp.mu.Lock()
 	tp.lines = tp.lines[:0]
 	tp.mu.Unlock()
+}
+
+func TestLogDirectory(t *testing.T) {
+	t.Run("invalid", func(t *testing.T) {
+		f, err := OpenFileAtPath("/some/nonexistent/path")
+		assert.Nil(t, f)
+		assert.Error(t, err)
+	})
+	t.Run("valid", func(t *testing.T) {
+		// ensure File is created successfully
+		p, err := os.MkdirTemp("", "example")
+		if err != nil {
+			t.Fatalf("Failure creating directory %v", err)
+		}
+		f, err := OpenFileAtPath(p)
+		assert.Nil(t, err)
+		fp := p + "/" + LoggerFile
+		assert.NotNil(t, f.file)
+		assert.Equal(t, fp, f.file.Name())
+		assert.False(t, f.closed)
+
+		// ensure this setting plays nicely with other log features
+		oldLvl := level
+		SetLevel(LevelDebug)
+		defer func() {
+			SetLevel(oldLvl)
+		}()
+		Info("info!")
+		Warn("warn!")
+		Debug("debug!")
+		// shorten errrate to test Error() behavior in a reasonable amount of time
+		oldRate := errrate
+		errrate = time.Microsecond
+		defer func() {
+			errrate = oldRate
+		}()
+		Error("error!")
+		time.Sleep(1 * time.Second)
+
+		b, err := os.ReadFile(fp)
+		if err != nil {
+			t.Fatalf("Failure reading file: %v", err)
+		}
+		// convert file content to []string{}, split by \n, to easily check its contents
+		lines := bytes.Split(b, []byte{'\n'})
+		var logs []string
+		for _, line := range lines {
+			logs = append(logs, string(line))
+		}
+
+		assert.True(t, containsMessage("INFO", "info!", logs))
+		assert.True(t, containsMessage("WARN", "warn!", logs))
+		assert.True(t, containsMessage("DEBUG", "debug!", logs))
+		assert.True(t, containsMessage("ERROR", "error!", logs))
+
+		f.Close()
+		assert.True(t, f.closed)
+
+		//ensure f.Close() is concurrent-safe and free of deadlocks
+		var wg sync.WaitGroup
+		for i := 0; i < 100; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				f.Close()
+			}()
+		}
+		wg.Wait()
+		assert.True(t, f.closed)
+	})
 }
 
 func TestLog(t *testing.T) {
@@ -194,4 +266,13 @@ func hasMsg(lvl, m string, lines []string) bool {
 
 func msg(lvl, msg string) string {
 	return fmt.Sprintf("%s %s: %s", prefixMsg, lvl, msg)
+}
+
+func containsMessage(lvl, m string, lines []string) bool {
+	for _, line := range lines {
+		if strings.Contains(line, msg(lvl, m)) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Supports specifying a log directory for tracer logs via `DD_TRACE_LOG_DIRECTORY` env var. If directory exists on the underlying os, tracer creates log file `ddtrace.log` at specified path and all tracer logs are routed to said file. Tracer maintains default behavior (log to stdout) if directory is invalid or does not exist.

### Motivation
Bring dd-trace-go up to speed on feature parity (other tracing libs support this). [RFC](https://docs.google.com/document/d/1kI-gTAKghfcwI7YzKhqRv2ExUstcHqADIWA4-TZ387o/edit#heading=h.okio0dm2m6n0)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
