### PR TITLE
v2: remove sampling priority

### DIFF
--- a/appsec/appsec.go
+++ b/appsec/appsec.go
@@ -86,7 +86,7 @@ func TrackUserLoginSuccessEvent(ctx context.Context, uid string, md map[string]s
 	for k, v := range md {
 		span.SetTag(tagPrefix+k, v)
 	}
-	span.SetTag(ext.SamplingPriority, ext.PriorityUserKeep)
+	span.SetTag(ext.ManualKeep, true)
 	return SetUser(ctx, uid, opts...)
 }
 
@@ -113,7 +113,7 @@ func TrackUserLoginFailureEvent(ctx context.Context, uid string, exists bool, md
 	for k, v := range md {
 		span.SetTag(tagPrefix+k, v)
 	}
-	span.SetTag(ext.SamplingPriority, ext.PriorityUserKeep)
+	span.SetTag(ext.ManualKeep, true)
 }
 
 // TrackCustomEvent sets a custom event as service entry span tags. This span is
@@ -130,7 +130,7 @@ func TrackCustomEvent(ctx context.Context, name string, md map[string]string) {
 
 	tagPrefix := "appsec.events." + name + "."
 	span.SetTag(tagPrefix+"track", true)
-	span.SetTag(ext.SamplingPriority, ext.PriorityUserKeep)
+	span.SetTag(ext.ManualKeep, true)
 	for k, v := range md {
 		span.SetTag(tagPrefix+k, v)
 	}

--- a/contrib/dimfeld/httptreemux.v5/example_test.go
+++ b/contrib/dimfeld/httptreemux.v5/example_test.go
@@ -43,7 +43,7 @@ func Example_withSpanOpts() {
 	router := httptrace.New(
 		httptrace.WithService("http.router"),
 		httptrace.WithSpanOptions(
-			tracer.Tag(ext.SamplingPriority, ext.PriorityUserKeep),
+			tracer.Tag(ext.ManualKeep, true),
 		),
 	)
 

--- a/contrib/gorilla/mux/mux_test.go
+++ b/contrib/gorilla/mux/mux_test.go
@@ -224,7 +224,7 @@ func TestSpanOptions(t *testing.T) {
 	assert := assert.New(t)
 	mt := mocktracer.Start()
 	defer mt.Stop()
-	mux := NewRouter(WithSpanOptions(tracer.Tag(ext.SamplingPriority, 2)))
+	mux := NewRouter(WithSpanOptions(tracer.Tag(ext.ManualKeep, true)))
 	mux.Handle("/200", okHandler()).Host("localhost")
 	r := httptest.NewRequest("GET", "http://localhost/200", nil)
 	w := httptest.NewRecorder()

--- a/contrib/julienschmidt/httprouter/example_test.go
+++ b/contrib/julienschmidt/httprouter/example_test.go
@@ -45,7 +45,7 @@ func Example_withSpanOpts() {
 	router := httptrace.New(
 		httptrace.WithService("http.router"),
 		httptrace.WithSpanOptions(
-			tracer.Tag(ext.SamplingPriority, ext.PriorityUserKeep),
+			tracer.Tag(ext.ManualKeep, true),
 		),
 	)
 

--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -25,10 +25,6 @@ const (
 	// NetworkDestinationPort is the remote port number of the outbound connection.
 	NetworkDestinationPort = "network.destination.port"
 
-	// SamplingPriority is the tag that marks the sampling priority of a span.
-	// Deprecated in favor of ManualKeep and ManualDrop.
-	SamplingPriority = "sampling.priority"
-
 	// SQLType sets the sql type tag.
 	SQLType = "sql"
 

--- a/ddtrace/mocktracer/mocktracer_test.go
+++ b/ddtrace/mocktracer/mocktracer_test.go
@@ -30,7 +30,7 @@ func TestTracerStop(t *testing.T) {
 }
 
 func TestTracerStartSpan(t *testing.T) {
-	parentTags := map[string]interface{}{ext.ServiceName: "root-service", ext.SamplingPriority: -1}
+	parentTags := map[string]interface{}{ext.ServiceName: "root-service", ext.ManualDrop: true}
 	// Need to round the monotonic clock so parsed UnixNano values are equal.
 	// See time.Time documentation for details:
 	// https://pkg.go.dev/time#Time

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -530,10 +530,10 @@ func (s *Span) setMetric(key string, v float64) {
 		if v == float64(samplernames.AppSec) {
 			s.setSamplingPriorityLocked(ext.PriorityUserKeep, samplernames.AppSec)
 		}
-	case ext.SamplingPriority:
-		// ext.SamplingPriority is deprecated in favor of ext.ManualKeep and ext.ManualDrop.
-		// We have it here for backward compatibility.
-		s.setSamplingPriorityLocked(int(v), samplernames.Manual)
+	case ext.ManualDrop:
+		if v == float64(samplernames.AppSec) {
+			s.setSamplingPriorityLocked(ext.PriorityUserReject, samplernames.AppSec)
+		}
 	default:
 		s.metrics[key] = v
 	}

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -530,10 +530,6 @@ func (s *Span) setMetric(key string, v float64) {
 		if v == float64(samplernames.AppSec) {
 			s.setSamplingPriorityLocked(ext.PriorityUserKeep, samplernames.AppSec)
 		}
-	case ext.ManualDrop:
-		if v == float64(samplernames.AppSec) {
-			s.setSamplingPriorityLocked(ext.PriorityUserReject, samplernames.AppSec)
-		}
 	default:
 		s.metrics[key] = v
 	}

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -214,7 +214,7 @@ func TestShouldDrop(t *testing.T) {
 	} {
 		t.Run("", func(t *testing.T) {
 			s := newSpan("", "", "", 1, 1, 0)
-			s.SetTag(ext.SamplingPriority, tt.prio)
+			s.setSamplingPriority(tt.prio, samplernames.Default)
 			s.SetTag(ext.EventSampleRate, tt.rate)
 			atomic.StoreInt32(&s.context.errors, tt.errors)
 			assert.Equal(t, shouldKeep(s), tt.want)
@@ -836,7 +836,7 @@ func TestSpanSamplingPriority(t *testing.T) {
 		ext.PriorityUserKeep,
 		999, // not used, but we should allow it
 	} {
-		span.SetTag(ext.SamplingPriority, priority)
+		span.setSamplingPriority(priority, samplernames.Default)
 		v, ok := span.metrics[keySamplingPriority]
 		assert.True(ok)
 		assert.EqualValues(priority, v)

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -138,7 +138,7 @@ func TestAddSpanLink(t *testing.T) {
 
 	// Test adding a link with a sampling decision
 	linkedSpanSampled := newSpan("linked_sampled", "service", "res", 3, 4, 0)
-	linkedSpanSampled.Context().setSamplingPriority(2, samplernames.Manual)
+	linkedSpanSampled.Context().setSamplingPriority(ext.PriorityUserKeep, samplernames.Manual)
 	rootSpan.AddLink(linkedSpanSampled.Context(), map[string]string{})
 	assert.Equal(len(rootSpan.spanLinks), 2)
 	spanLinkSampled := rootSpan.spanLinks[1]

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -80,7 +80,7 @@ func testAsyncSpanRace(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		// The test has 100 iterations because it is not easy to reproduce the race.
 		t.Run("", func(t *testing.T) {
-			root, ctx := StartSpanFromContext(context.Background(), "root", Tag(ext.SamplingPriority, ext.PriorityUserKeep))
+			root, ctx := StartSpanFromContext(context.Background(), "root", Tag(ext.ManualKeep, true))
 			var wg sync.WaitGroup
 			done := make(chan struct{})
 			wg.Add(1)
@@ -116,7 +116,7 @@ func testAsyncSpanRace(t *testing.T) {
 				for i := 0; i < 50; i++ {
 					// to trigger the bug, the child should be created after the root was finished,
 					// as its being flushed
-					child, _ := StartSpanFromContext(ctx, "child", Tag(ext.SamplingPriority, ext.PriorityUserKeep))
+					child, _ := StartSpanFromContext(ctx, "child", Tag(ext.ManualKeep, true))
 					child.Finish()
 				}
 			}()
@@ -306,12 +306,12 @@ func TestSpanFinishPriority(t *testing.T) {
 
 	root := tracer.StartSpan(
 		"root",
-		Tag(ext.SamplingPriority, 1),
 	)
+	root.setSamplingPriority(ext.PriorityAutoKeep, samplernames.Manual)
 	child := tracer.StartSpan(
 		"child",
 		ChildOf(root.Context()),
-		Tag(ext.SamplingPriority, 2),
+		Tag(ext.ManualKeep, true),
 	)
 	child.Finish()
 	root.Finish()

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -837,35 +837,35 @@ func TestSetSamplingPriorityLocked(t *testing.T) {
 		tr := trace{
 			propagatingTags: map[string]string{},
 		}
-		tr.setSamplingPriorityLocked(0, samplernames.RemoteRate)
+		tr.setSamplingPriorityLocked(ext.PriorityAutoReject, samplernames.RemoteRate)
 		assert.Empty(t, tr.propagatingTags[keyDecisionMaker])
 	})
 	t.Run("UnknownSamplerIsIgnored", func(t *testing.T) {
 		tr := trace{
 			propagatingTags: map[string]string{},
 		}
-		tr.setSamplingPriorityLocked(0, samplernames.Unknown)
+		tr.setSamplingPriorityLocked(ext.PriorityAutoReject, samplernames.Unknown)
 		assert.Empty(t, tr.propagatingTags[keyDecisionMaker])
 	})
 	t.Run("NoPriorAndP1IsAccepted", func(t *testing.T) {
 		tr := trace{
 			propagatingTags: map[string]string{},
 		}
-		tr.setSamplingPriorityLocked(1, samplernames.RemoteRate)
+		tr.setSamplingPriorityLocked(ext.PriorityAutoKeep, samplernames.RemoteRate)
 		assert.Equal(t, "-2", tr.propagatingTags[keyDecisionMaker])
 	})
 	t.Run("PriorAndP1AndSameDMIsIgnored", func(t *testing.T) {
 		tr := trace{
 			propagatingTags: map[string]string{keyDecisionMaker: "-1"},
 		}
-		tr.setSamplingPriorityLocked(1, samplernames.AgentRate)
+		tr.setSamplingPriorityLocked(ext.PriorityAutoKeep, samplernames.AgentRate)
 		assert.Equal(t, "-1", tr.propagatingTags[keyDecisionMaker])
 	})
 	t.Run("PriorAndP1DifferentDMAccepted", func(t *testing.T) {
 		tr := trace{
 			propagatingTags: map[string]string{keyDecisionMaker: "-1"},
 		}
-		tr.setSamplingPriorityLocked(1, samplernames.RemoteRate)
+		tr.setSamplingPriorityLocked(ext.PriorityAutoKeep, samplernames.RemoteRate)
 		assert.Equal(t, "-2", tr.propagatingTags[keyDecisionMaker])
 	})
 }

--- a/ddtrace/tracer/sqlcomment_test.go
+++ b/ddtrace/tracer/sqlcomment_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/internal/globalconfig"
+	"github.com/DataDog/dd-trace-go/v2/internal/samplernames"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -180,7 +181,7 @@ func TestSQLCommentCarrier(t *testing.T) {
 			if tc.injectSpan {
 				traceID = uint64(10)
 				root := tracer.StartSpan("service.calling.db", WithSpanID(traceID))
-				root.SetTag(ext.SamplingPriority, tc.samplingPriority)
+				root.setSamplingPriority(tc.samplingPriority, samplernames.Default)
 				spanCtx = root.Context()
 			}
 
@@ -346,7 +347,7 @@ func BenchmarkSQLCommentExtraction(b *testing.B) {
 func setupBenchmark() (*tracer, *SpanContext, SQLCommentCarrier) {
 	tracer, _ := newTracer(WithService("whiskey-service !#$%&'()*+,/:;=?@[]"), WithEnv("test-env"), WithServiceVersion("1.0.0"))
 	root := tracer.StartSpan("service.calling.db", WithSpanID(10))
-	root.SetTag(ext.SamplingPriority, 2)
+	root.SetTag(ext.ManualKeep, true)
 	spanCtx := root.Context()
 	carrier := SQLCommentCarrier{Query: "SELECT 1 FROM dual", Mode: DBMPropagationModeFull, DBServiceName: "whiskey-db"}
 	return tracer, spanCtx, carrier

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -717,9 +717,9 @@ func (*propagatorB3SingleHeader) extractTextMap(reader TextMapReader) (*SpanCont
 					case "":
 						break
 					case "1", "d": // Treat 'debug' traces as priority 1
-						ctx.setSamplingPriority(1, samplernames.Unknown)
+						ctx.setSamplingPriority(ext.PriorityAutoKeep, samplernames.Unknown)
 					case "0":
-						ctx.setSamplingPriority(0, samplernames.Unknown)
+						ctx.setSamplingPriority(ext.PriorityAutoReject, samplernames.Unknown)
 					default:
 						return ErrSpanContextCorrupted
 					}
@@ -1201,11 +1201,11 @@ func parseTracestate(ctx *SpanContext, header string) {
 				}
 				if parentP == 1 && stateP <= 0 {
 					// Auto keep (1) and set the decision maker to default
-					ctx.setSamplingPriority(1, samplernames.Default)
+					ctx.setSamplingPriority(ext.PriorityAutoKeep, samplernames.Default)
 				}
 				if parentP == 0 && stateP > 0 {
 					// Auto drop (0) and drop the decision maker
-					ctx.setSamplingPriority(0, samplernames.Unknown)
+					ctx.setSamplingPriority(ext.PriorityAutoReject, samplernames.Unknown)
 					dropDM = true
 				}
 			} else if key == "p" {

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -281,7 +281,7 @@ func TestTextMapPropagatorInjectHeader(t *testing.T) {
 
 	root := tracer.StartSpan("web.request")
 	root.SetBaggageItem("item", "x")
-	root.SetTag(ext.SamplingPriority, 0)
+	root.setSamplingPriority(ext.PriorityAutoReject, samplernames.Default)
 	ctx := root.Context()
 	headers := http.Header{}
 
@@ -411,7 +411,7 @@ func Test257CharacterDDTracestateLengh(t *testing.T) {
 	defer tracer.Stop()
 	assert := assert.New(t)
 	root := tracer.StartSpan("web.request")
-	root.SetTag(ext.SamplingPriority, ext.PriorityUserKeep)
+	root.SetTag(ext.ManualKeep, true)
 	ctx := root.Context()
 	ctx.origin = "rum"
 	ctx.traceID = traceIDFrom64Bits(1)
@@ -574,7 +574,7 @@ func TestTextMapPropagator(t *testing.T) {
 		defer tracer.Stop()
 		assert.NoError(t, err)
 		root := tracer.StartSpan("web.request")
-		root.SetTag(ext.SamplingPriority, -1)
+		root.SetTag(ext.ManualDrop, true)
 		root.SetBaggageItem("item", "x")
 		ctx := root.Context()
 		headers := TextMapCarrier(map[string]string{})
@@ -1053,7 +1053,7 @@ func TestEnvVars(t *testing.T) {
 					defer tracer.Stop()
 					assert.NoError(t, err)
 					root := tracer.StartSpan("web.request")
-					root.SetTag(ext.SamplingPriority, -1)
+					root.SetTag(ext.ManualDrop, true)
 					root.SetBaggageItem("item", "x")
 					ctx := root.Context()
 					ctx.traceID = traceIDFrom64Bits(tc.in[0])
@@ -1573,7 +1573,7 @@ func TestEnvVars(t *testing.T) {
 					assert := assert.New(t)
 					assert.Nil(err)
 					root := tracer.StartSpan("web.request")
-					root.SetTag(ext.SamplingPriority, tc.priority)
+					root.setSamplingPriority(tc.priority, samplernames.Default)
 					ctx := root.Context()
 					ctx.origin = tc.origin
 					ctx.traceID = tc.tid
@@ -1603,7 +1603,7 @@ func TestEnvVars(t *testing.T) {
 					assert := assert.New(t)
 					assert.Nil(err)
 					root := tracer.StartSpan("web.request")
-					root.SetTag(ext.SamplingPriority, ext.PriorityUserKeep)
+					root.SetTag(ext.ManualKeep, true)
 					ctx := root.Context()
 					ctx.origin = "old_tracestate"
 					ctx.traceID = traceIDFrom64Bits(1229782938247303442)
@@ -1962,7 +1962,7 @@ func TestNonePropagator(t *testing.T) {
 		defer tracer.Stop()
 		assert.NoError(t, err)
 		root := tracer.StartSpan("web.request")
-		root.SetTag(ext.SamplingPriority, -1)
+		root.SetTag(ext.ManualDrop, true)
 		root.SetBaggageItem("item", "x")
 		ctx := root.Context()
 		ctx.traceID = traceIDFrom64Bits(1)
@@ -1985,7 +1985,7 @@ func TestNonePropagator(t *testing.T) {
 		// reinitializing to capture log output, since propagators are parsed before logger is set
 		tracer.config.propagator = NewPropagator(&PropagatorConfig{})
 		root := tracer.StartSpan("web.request")
-		root.SetTag(ext.SamplingPriority, -1)
+		root.SetTag(ext.ManualDrop, true)
 		root.SetBaggageItem("item", "x")
 		ctx := root.Context()
 		ctx.traceID = traceIDFrom64Bits(1)
@@ -2008,7 +2008,7 @@ func TestNonePropagator(t *testing.T) {
 		defer tracer.Stop()
 		assert.NoError(err)
 		root := tracer.StartSpan("web.request")
-		root.SetTag(ext.SamplingPriority, -1)
+		root.SetTag(ext.ManualDrop, true)
 		root.SetBaggageItem("item", "x")
 		headers := TextMapCarrier(map[string]string{})
 
@@ -2025,7 +2025,7 @@ func TestNonePropagator(t *testing.T) {
 			defer tracer.Stop()
 			assert.NoError(t, err)
 			root := tracer.StartSpan("web.request")
-			root.SetTag(ext.SamplingPriority, -1)
+			root.SetTag(ext.ManualDrop, true)
 			root.SetBaggageItem("item", "x")
 			ctx := root.Context()
 			ctx.traceID = traceIDFrom64Bits(1)
@@ -2046,7 +2046,7 @@ func TestNonePropagator(t *testing.T) {
 			assert.NoError(t, err)
 			defer tracer.Stop()
 			root := tracer.StartSpan("web.request")
-			root.SetTag(ext.SamplingPriority, -1)
+			root.SetTag(ext.ManualDrop, true)
 			root.SetBaggageItem("item", "x")
 			ctx := root.Context()
 			ctx.traceID = traceIDFrom64Bits(1)
@@ -2070,7 +2070,7 @@ func TestNonePropagator(t *testing.T) {
 			defer tracer.Stop()
 			assert.NoError(t, err)
 			root := tracer.StartSpan("web.request")
-			root.SetTag(ext.SamplingPriority, -1)
+			root.SetTag(ext.ManualDrop, true)
 			root.SetBaggageItem("item", "x")
 			ctx := root.Context()
 			ctx.traceID = traceIDFrom64Bits(1)

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -267,7 +267,7 @@ func TestTracerStartSpan(t *testing.T) {
 		tracer, err := newTracer()
 		defer tracer.Stop()
 		assert.NoError(t, err)
-		span := tracer.StartSpan("web.request", Tag(ext.SamplingPriority, ext.PriorityUserKeep))
+		span := tracer.StartSpan("web.request", Tag(ext.ManualKeep, true))
 		assert.Equal(t, float64(ext.PriorityUserKeep), span.metrics[keySamplingPriority])
 		assert.Equal(t, "-4", span.context.trace.propagatingTags[keyDecisionMaker])
 	})
@@ -892,7 +892,7 @@ func TestPropagationDefaults(t *testing.T) {
 	assert.Nil(err)
 	root := tracer.StartSpan("web.request")
 	root.SetBaggageItem("x", "y")
-	root.SetTag(ext.SamplingPriority, -1)
+	root.SetTag(ext.ManualDrop, true)
 	ctx := root.Context()
 	headers := http.Header{}
 
@@ -935,7 +935,7 @@ func TestTracerSamplingPriorityPropagation(t *testing.T) {
 	tracer, err := newTracer()
 	defer tracer.Stop()
 	assert.Nil(err)
-	root := tracer.StartSpan("web.request", Tag(ext.SamplingPriority, 2))
+	root := tracer.StartSpan("web.request", Tag(ext.ManualKeep, true))
 	child := tracer.StartSpan("db.query", ChildOf(root.Context()))
 	assert.EqualValues(2, root.metrics[keySamplingPriority])
 	assert.Equal("-4", root.context.trace.propagatingTags[keyDecisionMaker])


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Removes support for `ext.SamplingPriority`. Users should opt to use `span.SetTag(ext.ManualKeep, true)` for keeping spans/traces, and `span.SetTag(ext.ManualDrop, true)` for dropping spans/traces.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

Re: PR #1082 , `ext.SamplingPriority` has been deprecated. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
