### PR TITLE
internal/civisibility: fixes the test parent status when the auto-retry feature ended up with a failed test and then a successful test.

### DIFF
--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -571,7 +571,11 @@ func applyAdditionalFeaturesToTestFunc(f func(*testing.T)) func(*testing.T) {
 						tCommonPrivates := getTestPrivateFields(t)
 						tCommonPrivates.SetFailed(ptrToLocalT.Failed())
 						tCommonPrivates.SetSkipped(ptrToLocalT.Skipped())
-						tParentCommonPrivates.SetFailed(ptrToLocalT.Failed())
+
+						// Only change the parent status to failing if the current test failed
+						if ptrToLocalT.Failed() {
+							tParentCommonPrivates.SetFailed(ptrToLocalT.Failed())
+						}
 						break
 					}
 				}

--- a/internal/civisibility/integrations/gotesting/testing_test.go
+++ b/internal/civisibility/integrations/gotesting/testing_test.go
@@ -93,7 +93,7 @@ func TestMain(m *testing.M) {
 	// 2 benchmark spans (optional - require the -bench option)
 	fmt.Printf("Number of spans received: %d\n", len(finishedSpans))
 	if len(finishedSpans) < 37 {
-		panic("expected at least 36 finished spans, got " + strconv.Itoa(len(finishedSpans)))
+		panic("expected at least 37 finished spans, got " + strconv.Itoa(len(finishedSpans)))
 	}
 
 	sessionSpans := getSpansWithType(finishedSpans, constants.SpanTypeTestSession)
@@ -121,7 +121,7 @@ func TestMain(m *testing.M) {
 	fmt.Printf("Number of tests received: %d\n", len(testSpans))
 	showResourcesNameFromSpans(testSpans)
 	if len(testSpans) != 37 {
-		panic("expected exactly 36 test spans, got " + strconv.Itoa(len(testSpans)))
+		panic("expected exactly 37 test spans, got " + strconv.Itoa(len(testSpans)))
 	}
 
 	httpSpans := getSpansWithType(finishedSpans, ext.SpanTypeHTTP)

--- a/internal/civisibility/integrations/gotesting/testing_test.go
+++ b/internal/civisibility/integrations/gotesting/testing_test.go
@@ -72,7 +72,10 @@ func TestMain(m *testing.M) {
 
 	// execute the tests, because we are expecting some tests to fail and check the assertion later
 	// we don't store the exit code from the test runner
-	RunM(m)
+	exitCode := RunM(m)
+	if exitCode != 1 {
+		panic("expected the exit code to be 1. We have a failing test on purpose.")
+	}
 
 	// get all finished spans
 	finishedSpans := mTracer.FinishedSpans()
@@ -80,7 +83,7 @@ func TestMain(m *testing.M) {
 	// 1 session span
 	// 1 module span
 	// 2 suite span (testing_test.go and reflections_test.go)
-	// 5 tests spans from testing_test.go
+	// 6 tests spans from testing_test.go
 	// 7 sub stest spans from testing_test.go
 	// 1 TestRetryWithPanic + 3 retry tests from testing_test.go
 	// 1 TestRetryWithFail + 3 retry tests from testing_test.go
@@ -89,7 +92,7 @@ func TestMain(m *testing.M) {
 	// 5 tests from reflections_test.go
 	// 2 benchmark spans (optional - require the -bench option)
 	fmt.Printf("Number of spans received: %d\n", len(finishedSpans))
-	if len(finishedSpans) < 36 {
+	if len(finishedSpans) < 37 {
 		panic("expected at least 36 finished spans, got " + strconv.Itoa(len(finishedSpans)))
 	}
 
@@ -117,7 +120,7 @@ func TestMain(m *testing.M) {
 	testSpans := getSpansWithType(finishedSpans, constants.SpanTypeTest)
 	fmt.Printf("Number of tests received: %d\n", len(testSpans))
 	showResourcesNameFromSpans(testSpans)
-	if len(testSpans) != 36 {
+	if len(testSpans) != 37 {
 		panic("expected exactly 36 test spans, got " + strconv.Itoa(len(testSpans)))
 	}
 
@@ -310,6 +313,8 @@ func TestRetryAlwaysFail(t *testing.T) {
 	t.Parallel()
 	t.Fatal("Always fail")
 }
+
+func TestNormalPassingAfterRetryAlwaysFail(t *testing.T) {}
 
 // BenchmarkFirst demonstrates benchmark instrumentation with sub-benchmarks.
 func BenchmarkFirst(gb *testing.B) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR fixes the scenario when a test fail after retrying and then a test passes, before the PR we were always setting the test parent status according the current test status, so a previous failure status gets overwrote by a test passing status.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This is fix on an actual bug in the implementation.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
