### PR TITLE
internal/civisibility: add support for the test.source.end tag

### DIFF
--- a/internal/civisibility/constants/test_tags.go
+++ b/internal/civisibility/constants/test_tags.go
@@ -46,6 +46,10 @@ const (
 	// This constant is used to tag traces with the line number in the source file where the test starts.
 	TestSourceStartLine = "test.source.start"
 
+	// TestSourceEndLine indicates the line of the source file where the test ends.
+	// This constant is used to tag traces with the line number in the source file where the test ends.
+	TestSourceEndLine = "test.source.end"
+
 	// TestCodeOwners indicates the test code owners.
 	// This constant is used to tag traces with the code owners responsible for the test.
 	TestCodeOwners = "test.codeowners"

--- a/internal/civisibility/integrations/manual_api_ddtest.go
+++ b/internal/civisibility/integrations/manual_api_ddtest.go
@@ -8,6 +8,9 @@ package integrations
 import (
 	"context"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"runtime"
 	"strings"
 	"time"
@@ -134,11 +137,58 @@ func (t *tslvTest) SetTestFunc(fn *runtime.Func) {
 		return
 	}
 
-	file, line := fn.FileLine(fn.Entry())
-	file = utils.GetRelativePathFromCITagsSourceRoot(file)
+	// let's get the file path and the start line of the function
+	absolutePath, startLine := fn.FileLine(fn.Entry())
+	file := utils.GetRelativePathFromCITagsSourceRoot(absolutePath)
 	t.SetTag(constants.TestSourceFile, file)
-	t.SetTag(constants.TestSourceStartLine, line)
+	t.SetTag(constants.TestSourceStartLine, startLine)
 
+	// now, let's try to get the end line of the function using ast
+	// parse the entire file where the function is defined to create an abstract syntax tree (AST)
+	// if we can't parse the file (source code is not available) we silently bail out
+	fset := token.NewFileSet()
+	fileNode, err := parser.ParseFile(fset, absolutePath, nil, parser.AllErrors)
+	if err == nil {
+		// get the function name without the package name
+		fullName := fn.Name()
+		firstDot := strings.LastIndex(fullName, ".") + 1
+		name := fullName[firstDot:]
+
+		// variable to store the ending line of the function
+		var endLine int
+		// traverse the AST to find the function declaration for targetFunction
+		ast.Inspect(fileNode, func(n ast.Node) bool {
+			// check if the current node is a function declaration
+			if funcDecl, ok := n.(*ast.FuncDecl); ok {
+				// if the function name matches "targetFunction"
+				if funcDecl.Name.Name == name {
+					// get the line number of the end of the function body
+					endLine = fset.Position(funcDecl.Body.End()).Line
+					// stop further inspection since we have found the target function
+					return false
+				}
+			}
+			// check if the current node is a function literal (FuncLit)
+			if funcLit, ok := n.(*ast.FuncLit); ok {
+				// get the line number of the start of the function literal
+				funcStartLine := fset.Position(funcLit.Body.Pos()).Line
+				// if the start line matches the known start line, record the end line
+				if funcStartLine == startLine {
+					endLine = fset.Position(funcLit.Body.End()).Line
+					return false // Stop further inspection since we have found the function
+				}
+			}
+			// continue inspecting other nodes
+			return true
+		})
+
+		// if we found an endLine we check is greater than the calculated startLine
+		if endLine > startLine {
+			t.SetTag(constants.TestSourceEndLine, endLine)
+		}
+	}
+
+	// get the codeowner of the function
 	codeOwners := utils.GetCodeOwners()
 	if codeOwners != nil {
 		match, found := codeOwners.Match("/" + file)

--- a/internal/civisibility/integrations/manual_api_ddtest.go
+++ b/internal/civisibility/integrations/manual_api_ddtest.go
@@ -156,11 +156,11 @@ func (t *tslvTest) SetTestFunc(fn *runtime.Func) {
 
 		// variable to store the ending line of the function
 		var endLine int
-		// traverse the AST to find the function declaration for targetFunction
+		// traverse the AST to find the function declaration for the target function
 		ast.Inspect(fileNode, func(n ast.Node) bool {
 			// check if the current node is a function declaration
 			if funcDecl, ok := n.(*ast.FuncDecl); ok {
-				// if the function name matches "targetFunction"
+				// if the function name matches the target function name
 				if funcDecl.Name.Name == name {
 					// get the line number of the end of the function body
 					endLine = fset.Position(funcDecl.Body.End()).Line
@@ -175,7 +175,7 @@ func (t *tslvTest) SetTestFunc(fn *runtime.Func) {
 				// if the start line matches the known start line, record the end line
 				if funcStartLine == startLine {
 					endLine = fset.Position(funcLit.Body.End()).Line
-					return false // Stop further inspection since we have found the function
+					return false // stop further inspection since we have found the function
 				}
 			}
 			// continue inspecting other nodes

--- a/internal/civisibility/integrations/manual_api_mocktracer_test.go
+++ b/internal/civisibility/integrations/manual_api_mocktracer_test.go
@@ -273,5 +273,6 @@ func testAssertions(assert *assert.Assertions, now time.Time, testSpan mocktrace
 	assert.Contains(spanTags, constants.TestSuiteIDTag)
 	assert.Contains(spanTags, constants.TestSourceFile)
 	assert.Contains(spanTags, constants.TestSourceStartLine)
+	assert.Contains(spanTags, constants.TestSourceEndLine)
 	commonAssertions(assert, testSpan)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds a logic to calcule the `test.source.end` tag with the end line number of a test function using the ast parser. It's a best effort approach, in case we cannot extract it (eg: no source code is available) then we silently bail out.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This part of the CI Visibility specs.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
