### PR TITLE
contrib/confluentinc/confluent-kafka-go: fix goroutine leak in Produce

### DIFF
--- a/contrib/confluentinc/confluent-kafka-go/kafka.v2/kafka_test.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka.v2/kafka_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 )
 
 var (
@@ -393,4 +394,42 @@ func TestNamingSchema(t *testing.T) {
 		return spans
 	}
 	namingschematest.NewKafkaTest(genSpans)(t)
+}
+
+// Test we don't leak goroutines and properly close the span when Produce returns an error.
+func TestProduceError(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	// first write a message to the topic
+	p, err := NewProducer(&kafka.ConfigMap{
+		"bootstrap.servers":   "127.0.0.1:9092",
+		"go.delivery.reports": true,
+	})
+	require.NoError(t, err)
+	defer p.Close()
+
+	// this empty message should cause an error in the Produce call.
+	topic := ""
+	msg := &kafka.Message{
+		TopicPartition: kafka.TopicPartition{
+			Topic: &topic,
+		},
+	}
+	deliveryChan := make(chan kafka.Event, 1)
+	err = p.Produce(msg, deliveryChan)
+	require.Error(t, err)
+	require.EqualError(t, err, "Local: Invalid argument or configuration")
+
+	select {
+	case <-deliveryChan:
+		assert.Fail(t, "there should be no events in the deliveryChan")
+	case <-time.After(1 * time.Second):
+		// assume there is no event
+	}
+
+	spans := mt.FinishedSpans()
+	assert.Len(t, spans, 1)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
(Thanks to @majorgreys that reported this issue).

Fix a goroutine leak in `producer.Produce` when the actual Produce call was returning an error and a `deliveryChan` is provided.
In this case, goroutine "wrapping" the original channel gets stuck waiting for a message in the channel, but no event is ever sent to that channel. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->
Fix goroutine leak.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
