### PR TITLE
profiler: add DD_PROFILING_FLUSH_ON_EXIT to upload current profiles before exiting

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -112,6 +112,7 @@ type config struct {
 	traceConfig          executionTraceConfig
 	endpointCountEnabled bool
 	enabled              bool
+	flushOnExit          bool
 }
 
 // logStartup records the configuration to the configured logger in JSON format
@@ -241,6 +242,9 @@ func defaultConfig() (*config, error) {
 	}
 	if v := os.Getenv("DD_VERSION"); v != "" {
 		WithVersion(v)(&c)
+	}
+	if internal.BoolEnv("DD_PROFILING_FLUSH_ON_EXIT", false) {
+		c.flushOnExit = true
 	}
 
 	tags := make(map[string]string)

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -149,6 +149,7 @@ func logStartup(c *config) {
 		"endpoint_count_enabled":     c.endpointCountEnabled,
 		"custom_profiler_label_keys": c.customProfilerLabels,
 		"enabled":                    c.enabled,
+		"flush_on_exit":              c.flushOnExit,
 	}
 	b, err := json.Marshal(info)
 	if err != nil {
@@ -243,9 +244,7 @@ func defaultConfig() (*config, error) {
 	if v := os.Getenv("DD_VERSION"); v != "" {
 		WithVersion(v)(&c)
 	}
-	if internal.BoolEnv("DD_PROFILING_FLUSH_ON_EXIT", false) {
-		c.flushOnExit = true
-	}
+	c.flushOnExit = internal.BoolEnv("DD_PROFILING_FLUSH_ON_EXIT", false)
 
 	tags := make(map[string]string)
 	if v := os.Getenv("DD_TAGS"); v != "" {

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -236,8 +236,7 @@ func TestStopLatency(t *testing.T) {
 
 func TestFlushAndStop(t *testing.T) {
 	start := time.Now()
-	os.Setenv("DD_PROFILING_FLUSH_ON_EXIT", "1")
-	defer os.Unsetenv("DD_PROFILING_FLUSH_ON_EXIT")
+	t.Setenv("DD_PROFILING_FLUSH_ON_EXIT", "1")
 	received := startTestProfiler(t, 1,
 		WithProfileTypes(CPUProfile, HeapProfile),
 		WithPeriod(time.Hour),
@@ -279,8 +278,7 @@ func TestFlushAndStopTimeout(t *testing.T) {
 	}))
 	defer server.Close()
 
-	os.Setenv("DD_PROFILING_FLUSH_ON_EXIT", "1")
-	defer os.Unsetenv("DD_PROFILING_FLUSH_ON_EXIT")
+	t.Setenv("DD_PROFILING_FLUSH_ON_EXIT", "1")
 	Start(
 		WithAgentAddr(server.Listener.Addr().String()),
 		WithPeriod(time.Hour),

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -243,7 +243,6 @@ func TestFlushAndStop(t *testing.T) {
 		WithPeriod(time.Hour),
 		WithUploadTimeout(time.Hour))
 
-	time.Sleep(1 * time.Second)
 	end := time.Now()
 	Stop()
 
@@ -288,7 +287,6 @@ func TestFlushAndStopTimeout(t *testing.T) {
 		WithUploadTimeout(uploadTimeout),
 	)
 
-	time.Sleep(500 * time.Millisecond)
 	start := time.Now()
 	Stop()
 

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -236,6 +236,8 @@ func TestStopLatency(t *testing.T) {
 
 func TestFlushAndStop(t *testing.T) {
 	start := time.Now()
+	os.Setenv("DD_PROFILING_FLUSH_ON_EXIT", "1")
+	defer os.Unsetenv("DD_PROFILING_FLUSH_ON_EXIT")
 	received := startTestProfiler(t, 1,
 		WithProfileTypes(CPUProfile, HeapProfile),
 		WithPeriod(time.Hour),
@@ -243,7 +245,7 @@ func TestFlushAndStop(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 	end := time.Now()
-	FlushAndStop()
+	Stop()
 
 	select {
 	case prof := <-received:
@@ -278,6 +280,8 @@ func TestFlushAndStopTimeout(t *testing.T) {
 	}))
 	defer server.Close()
 
+	os.Setenv("DD_PROFILING_FLUSH_ON_EXIT", "1")
+	defer os.Unsetenv("DD_PROFILING_FLUSH_ON_EXIT")
 	Start(
 		WithAgentAddr(server.Listener.Addr().String()),
 		WithPeriod(time.Hour),
@@ -286,7 +290,7 @@ func TestFlushAndStopTimeout(t *testing.T) {
 
 	time.Sleep(500 * time.Millisecond)
 	start := time.Now()
-	FlushAndStop()
+	Stop()
 
 	elapsed := time.Since(start)
 	if elapsed > (maxRetries*uploadTimeout)+1*time.Second {
@@ -304,7 +308,7 @@ func TestSetProfileFraction(t *testing.T) {
 		p, err := unstartedProfiler(WithProfileTypes(MutexProfile))
 		require.NoError(t, err)
 		p.run()
-		p.stop(false)
+		p.stop()
 		assert.Equal(t, DefaultMutexFraction, runtime.SetMutexProfileFraction(-1))
 	})
 
@@ -314,7 +318,7 @@ func TestSetProfileFraction(t *testing.T) {
 		p, err := unstartedProfiler()
 		require.NoError(t, err)
 		p.run()
-		p.stop(false)
+		p.stop()
 		assert.Zero(t, runtime.SetMutexProfileFraction(-1))
 	})
 }

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -235,26 +235,16 @@ func TestStopLatency(t *testing.T) {
 }
 
 func TestFlushAndStop(t *testing.T) {
-	start := time.Now()
 	t.Setenv("DD_PROFILING_FLUSH_ON_EXIT", "1")
 	received := startTestProfiler(t, 1,
 		WithProfileTypes(CPUProfile, HeapProfile),
 		WithPeriod(time.Hour),
 		WithUploadTimeout(time.Hour))
 
-	end := time.Now()
 	Stop()
 
 	select {
 	case prof := <-received:
-		evtStart, _ := time.Parse(time.RFC3339Nano, prof.event.Start)
-		evtEnd, _ := time.Parse(time.RFC3339Nano, prof.event.End)
-		if s := evtStart.Sub(start); s < 0 || s > 1*time.Second {
-			t.Errorf("profiler started %v after expected", evtStart.Sub(start))
-		}
-		if s := evtEnd.Sub(end); s < 0 || s > 1*time.Second {
-			t.Errorf("profiler ended %v after expected", evtEnd.Sub(end))
-		}
 		if len(prof.attachments["cpu.pprof"]) == 0 {
 			t.Errorf("expected CPU profile, got none")
 		}

--- a/profiler/telemetry.go
+++ b/profiler/telemetry.go
@@ -55,6 +55,7 @@ func startTelemetry(c *config) {
 			{Name: "endpoint_count_enabled", Value: c.endpointCountEnabled},
 			{Name: "num_custom_profiler_label_keys", Value: len(c.customProfilerLabels)},
 			{Name: "enabled", Value: c.enabled},
+			{Name: "flush_on_exit", Value: c.flushOnExit},
 		},
 	)
 }

--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -37,7 +37,7 @@ func (p *profiler) upload(bat batch) error {
 	for i := 0; i < maxRetries; i++ {
 		select {
 		case <-p.exit:
-			if !p.flush {
+			if !p.cfg.flushOnExit {
 				return nil
 			}
 		default:
@@ -100,7 +100,7 @@ func (p *profiler) doRequest(bat batch) error {
 	go func() {
 		select {
 		case <-p.exit:
-			if p.flush {
+			if p.cfg.flushOnExit {
 				return
 			}
 		case <-funcExit:

--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -37,7 +37,9 @@ func (p *profiler) upload(bat batch) error {
 	for i := 0; i < maxRetries; i++ {
 		select {
 		case <-p.exit:
-			return nil
+			if !p.flush {
+				return nil
+			}
 		default:
 		}
 
@@ -98,6 +100,9 @@ func (p *profiler) doRequest(bat batch) error {
 	go func() {
 		select {
 		case <-p.exit:
+			if p.flush {
+				return
+			}
 		case <-funcExit:
 		}
 		cancel()


### PR DESCRIPTION
### What does this PR do?

This PR adds a new bool env `DD_PROFILING_FLUSH_ON_EXIT` in order to abort and upload the current profiling sessions before exiting.

### Motivation

- profiling short lived processes without fine-tuning the period
- profile visibility on the "exit section" of processes and applications

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
