### PR TITLE
contrib/jackc/pgx.v5: wrap previous tracer

### DIFF
--- a/contrib/jackc/pgx.v5/pgx.go
+++ b/contrib/jackc/pgx.v5/pgx.go
@@ -23,22 +23,33 @@ func init() {
 	tracer.MarkIntegrationImported("github.com/jackc/pgx.v5")
 }
 
+// Deprecated: this type is unused internally so it will be removed in a future release, please use pgx.Batch instead.
 type Batch = pgx.Batch
 
+// Connect is equivalent to pgx.Connect providing a connection augmented with tracing.
 func Connect(ctx context.Context, connString string, opts ...Option) (*pgx.Conn, error) {
 	connConfig, err := pgx.ParseConfig(connString)
 	if err != nil {
 		return nil, err
 	}
-
 	return ConnectConfig(ctx, connConfig, opts...)
 }
 
+// ConnectConfig is equivalent to pgx.ConnectConfig providing a connection augmented with tracing.
 func ConnectConfig(ctx context.Context, connConfig *pgx.ConnConfig, opts ...Option) (*pgx.Conn, error) {
 	// The tracer must be set in the config before calling connect
 	// as pgx takes ownership of the config. QueryTracer traces
 	// may work, but none of the others will, as they're set in
 	// unexported fields in the config in the pgx.connect function.
-	connConfig.Tracer = newPgxTracer(opts...)
+	connConfig.Tracer = wrapPgxTracer(connConfig.Tracer, opts...)
 	return pgx.ConnectConfig(ctx, connConfig)
+}
+
+// ConnectWithOptions is equivalent to pgx.ConnectWithOptions providing a connection augmented with tracing.
+func ConnectWithOptions(ctx context.Context, connString string, options pgx.ParseConfigOptions, tracerOpts ...Option) (*pgx.Conn, error) {
+	connConfig, err := pgx.ParseConfigWithOptions(connString, options)
+	if err != nil {
+		return nil, err
+	}
+	return ConnectConfig(ctx, connConfig, tracerOpts...)
 }

--- a/contrib/jackc/pgx.v5/pgxpool.go
+++ b/contrib/jackc/pgx.v5/pgxpool.go
@@ -20,7 +20,10 @@ func NewPool(ctx context.Context, connString string, opts ...Option) (*pgxpool.P
 }
 
 func NewPoolWithConfig(ctx context.Context, config *pgxpool.Config, opts ...Option) (*pgxpool.Pool, error) {
-	tracer := newPgxTracer(opts...)
+	// pgxpool.NewWithConfig panics if the config was not created using pgxpool.ParseConfig, which should ensure everything
+	// is properly initialized, so it doesn't make sense to check for a nil config here.
+
+	tracer := wrapPgxTracer(config.ConnConfig.Tracer, opts...)
 	config.ConnConfig.Tracer = tracer
 	pool, err := pgxpool.NewWithConfig(ctx, config)
 	if err != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Fixes https://github.com/DataDog/dd-trace-go/issues/2908

Wrap the previous tracer if there was one instead of replacing it.

Additionally, it adds `ConnectWithOptions` which is the traced version of the original `pgx.ConnectWithOptions`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
