### PR TITLE
internal/civisibility: add handshake linkname to orchestrion api to address linkname lock down

### DIFF
--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	_ "unsafe"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/constants"
@@ -29,6 +30,8 @@ import (
 // ******************************************************************************************************************
 
 // instrumentTestingM helper function to instrument internalTests and internalBenchmarks in a `*testing.M` instance.
+//
+//go:linkname instrumentTestingM
 func instrumentTestingM(m *testing.M) func(exitCode int) {
 	// Check if CI Visibility was disabled using the kill switch before trying to initialize it
 	atomic.StoreInt32(&ciVisibilityEnabledValue, -1)
@@ -72,6 +75,8 @@ func instrumentTestingM(m *testing.M) func(exitCode int) {
 }
 
 // instrumentTestingTFunc helper function to instrument a testing function func(*testing.T)
+//
+//go:linkname instrumentTestingTFunc
 func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
 	// Check if CI Visibility was disabled using the kill switch before instrumenting
 	if !isCiVisibilityEnabled() {
@@ -188,6 +193,8 @@ func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
 }
 
 // instrumentSetErrorInfo helper function to set an error in the `*testing.T, *testing.B, *testing.common` CI Visibility span
+//
+//go:linkname instrumentSetErrorInfo
 func instrumentSetErrorInfo(tb testing.TB, errType string, errMessage string, skip int) {
 	// Check if CI Visibility was disabled using the kill switch before
 	if !isCiVisibilityEnabled() {
@@ -202,6 +209,8 @@ func instrumentSetErrorInfo(tb testing.TB, errType string, errMessage string, sk
 }
 
 // instrumentCloseAndSkip helper function to close and skip with a reason a `*testing.T, *testing.B, *testing.common` CI Visibility span
+//
+//go:linkname instrumentCloseAndSkip
 func instrumentCloseAndSkip(tb testing.TB, skipReason string) {
 	// Check if CI Visibility was disabled using the kill switch before
 	if !isCiVisibilityEnabled() {
@@ -216,6 +225,8 @@ func instrumentCloseAndSkip(tb testing.TB, skipReason string) {
 }
 
 // instrumentSkipNow helper function to close and skip a `*testing.T, *testing.B, *testing.common` CI Visibility span
+//
+//go:linkname instrumentSkipNow
 func instrumentSkipNow(tb testing.TB) {
 	// Check if CI Visibility was disabled using the kill switch before
 	if !isCiVisibilityEnabled() {
@@ -230,6 +241,8 @@ func instrumentSkipNow(tb testing.TB) {
 }
 
 // instrumentTestingBFunc helper function to instrument a benchmark function func(*testing.B)
+//
+//go:linkname instrumentTestingBFunc
 func instrumentTestingBFunc(pb *testing.B, name string, f func(*testing.B)) (string, func(*testing.B)) {
 	// Check if CI Visibility was disabled using the kill switch before instrumenting
 	if !isCiVisibilityEnabled() {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

In go 1.23, a change was made in the //go:linkname by locking down the usage, and the recommended way of doing it now is in handshake mode.

https://github.com/golang/go/issues/67401

Because the orchestrion integration uses the api using //go:linkname we are adding here the handshake support.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

I want to avoid any future issue of //go:linkname missusage 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
