### PR TITLE
[godfathering] contrib/dimfeld/httptreemux.v5: failing tests for path variable replacement

### DIFF
--- a/contrib/dimfeld/httptreemux.v5/httptreemux.go
+++ b/contrib/dimfeld/httptreemux.v5/httptreemux.go
@@ -145,7 +145,10 @@ func getRoute(router *httptreemux.TreeMux, w http.ResponseWriter, req *http.Requ
 		// replace parameter at end of the path, i.e. "../:param"
 		oldP = "/" + v
 		newP = "/:" + k
-		route = strings.Replace(route, oldP, newP, 1)
+		if strings.HasSuffix(route, oldP) {
+			endPos := strings.LastIndex(route, oldP)
+			route = route[:endPos] + newP
+		}
 	}
 	return route, true
 }


### PR DESCRIPTION
### What does this PR do?

Replicates and closes #2881 #2812 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
