### PR TITLE
internal/civisibility: removes importing contrib packages from tests

### DIFF
--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -96,14 +96,12 @@ func runFlakyTestRetriesTests(m *testing.M) {
 	// 1 TestMyTest01
 	// 1 TestMyTest02 + 2 subtests
 	// 1 Test_Foo + 3 subtests
-	// 1 TestWithExternalCalls + 2 subtests
 	// 1 TestSkip
 	// 1 TestRetryWithPanic + 3 retry tests from testing_test.go
 	// 1 TestRetryWithFail + 3 retry tests from testing_test.go
 	// 1 TestRetryAlwaysFail + 10 retry tests from testing_test.go
 	// 1 TestNormalPassingAfterRetryAlwaysFail
 	// 1 TestEarlyFlakeDetection
-	// 2 normal spans from testing_test.go
 
 	// check spans by resource name
 	checkSpansByResourceName(finishedSpans, "gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations/gotesting", 1)
@@ -117,9 +115,6 @@ func runFlakyTestRetriesTests(m *testing.M) {
 	checkSpansByResourceName(finishedSpans, "testing_test.go.Test_Foo/yellow_should_return_color", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.Test_Foo/banana_should_return_fruit", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.Test_Foo/duck_should_return_animal", 1)
-	checkSpansByResourceName(finishedSpans, "testing_test.go.TestWithExternalCalls", 1)
-	checkSpansByResourceName(finishedSpans, "testing_test.go.TestWithExternalCalls/default", 1)
-	checkSpansByResourceName(finishedSpans, "testing_test.go.TestWithExternalCalls/custom-name", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestSkip", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestRetryWithPanic", 4)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestRetryWithFail", 4)
@@ -132,12 +127,12 @@ func runFlakyTestRetriesTests(m *testing.M) {
 
 	// check spans by type
 	checkSpansByType(finishedSpans,
-		44,
+		39,
 		1,
 		1,
 		2,
-		38,
-		2)
+		35,
+		0)
 
 	os.Exit(0)
 }
@@ -179,7 +174,6 @@ func runEarlyFlakyTestDetectionTests(m *testing.M) {
 	// 11 TestMyTest01
 	// 11 TestMyTest02 + 22 subtests
 	// 11 Test_Foo + 33 subtests
-	// 11 TestWithExternalCalls + 22 subtests
 	// 11 TestSkip
 	// 11 TestRetryWithPanic
 	// 11 TestRetryWithFail
@@ -200,9 +194,6 @@ func runEarlyFlakyTestDetectionTests(m *testing.M) {
 	checkSpansByResourceName(finishedSpans, "testing_test.go.Test_Foo/yellow_should_return_color", 11)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.Test_Foo/banana_should_return_fruit", 11)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.Test_Foo/duck_should_return_animal", 11)
-	checkSpansByResourceName(finishedSpans, "testing_test.go.TestWithExternalCalls", 11)
-	checkSpansByResourceName(finishedSpans, "testing_test.go.TestWithExternalCalls/default", 11)
-	checkSpansByResourceName(finishedSpans, "testing_test.go.TestWithExternalCalls/custom-name", 11)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestSkip", 11)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestRetryWithPanic", 11)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestRetryWithFail", 11)
@@ -211,17 +202,17 @@ func runEarlyFlakyTestDetectionTests(m *testing.M) {
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestEarlyFlakeDetection", 11)
 
 	// check spans by tag
-	checkSpansByTagName(finishedSpans, constants.TestIsNew, 187)
-	checkSpansByTagName(finishedSpans, constants.TestIsRetry, 170)
+	checkSpansByTagName(finishedSpans, constants.TestIsNew, 154)
+	checkSpansByTagName(finishedSpans, constants.TestIsRetry, 140)
 
 	// check spans by type
 	checkSpansByType(finishedSpans,
-		218,
+		163,
 		1,
 		1,
 		2,
-		192,
-		22)
+		159,
+		0)
 
 	os.Exit(0)
 }
@@ -298,9 +289,6 @@ func runFlakyTestRetriesWithEarlyFlakyTestDetectionTests(m *testing.M) {
 	checkSpansByResourceName(finishedSpans, "testing_test.go.Test_Foo/yellow_should_return_color", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.Test_Foo/banana_should_return_fruit", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.Test_Foo/duck_should_return_animal", 1)
-	checkSpansByResourceName(finishedSpans, "testing_test.go.TestWithExternalCalls", 1)
-	checkSpansByResourceName(finishedSpans, "testing_test.go.TestWithExternalCalls/default", 1)
-	checkSpansByResourceName(finishedSpans, "testing_test.go.TestWithExternalCalls/custom-name", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestSkip", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestRetryWithPanic", 4)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestRetryWithFail", 4)
@@ -314,12 +302,12 @@ func runFlakyTestRetriesWithEarlyFlakyTestDetectionTests(m *testing.M) {
 
 	// check spans by type
 	checkSpansByType(finishedSpans,
-		64,
+		59,
 		1,
 		1,
 		2,
-		58,
-		2)
+		55,
+		0)
 
 	os.Exit(0)
 }

--- a/internal/civisibility/integrations/gotesting/testing_test.go
+++ b/internal/civisibility/integrations/gotesting/testing_test.go
@@ -7,16 +7,12 @@ package gotesting
 
 import (
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"runtime"
 	"slices"
 	"testing"
 
-	ddhttp "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
-	ddtracer "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/constants"
 
 	"github.com/stretchr/testify/assert"
@@ -74,82 +70,6 @@ func Test_Foo(gt *testing.T) {
 	if !slices.Equal(buf, expected) {
 		t.Error("error in subtests closure")
 	}
-}
-
-// TestWithExternalCalls demonstrates testing with external HTTP calls.
-func TestWithExternalCalls(gt *testing.T) {
-	assertTest(gt)
-	t := (*T)(gt)
-
-	// Create a new HTTP test server
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte("Hello World"))
-	}))
-	defer s.Close()
-
-	t.Run("default", func(t *testing.T) {
-
-		// if we want to use the test span as a parent of a child span
-		// we can extract the SpanContext and use it in other integrations
-		ctx := (*T)(t).Context()
-
-		// Wrap the default HTTP transport for tracing
-		rt := ddhttp.WrapRoundTripper(http.DefaultTransport)
-		client := &http.Client{
-			Transport: rt,
-		}
-
-		// Create a new HTTP request
-		req, err := http.NewRequest("GET", s.URL+"/hello/world", nil)
-		if err != nil {
-			t.FailNow()
-		}
-
-		// Use the span context here so the http span will appear as a child of the test
-		req = req.WithContext(ctx)
-
-		res, err := client.Do(req)
-		if err != nil {
-			t.FailNow()
-		}
-		_ = res.Body.Close()
-	})
-
-	t.Run("custom-name", func(t *testing.T) {
-
-		// we can also add custom tags to the test span by retrieving the
-		// context and call the `ddtracer.SpanFromContext` api
-		ctx := (*T)(t).Context()
-		span, _ := ddtracer.SpanFromContext(ctx)
-
-		// Custom namer function for the HTTP request
-		customNamer := func(req *http.Request) string {
-			value := fmt.Sprintf("%s %s", req.Method, req.URL.Path)
-
-			// Then we can set custom tags to that test span
-			span.SetTag("customNamer.Value", value)
-			return value
-		}
-
-		rt := ddhttp.WrapRoundTripper(http.DefaultTransport, ddhttp.RTWithResourceNamer(customNamer))
-		client := &http.Client{
-			Transport: rt,
-		}
-
-		req, err := http.NewRequest("GET", s.URL+"/hello/world", nil)
-		if err != nil {
-			t.FailNow()
-		}
-
-		// Use the span context here so the http span will appear as a child of the test
-		req = req.WithContext(ctx)
-
-		res, err := client.Do(req)
-		if err != nil {
-			t.FailNow()
-		}
-		_ = res.Body.Close()
-	})
 }
 
 // TestSkip demonstrates skipping a test with a message.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR removes tests that imports contrib packages.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This required for v2 works.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
