### PR TITLE
internal/civisibility: add more nil checks to increase resilience

### DIFF
--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -79,7 +79,7 @@ func instrumentTestingM(m *testing.M) func(exitCode int) {
 //go:linkname instrumentTestingTFunc
 func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
 	// Check if CI Visibility was disabled using the kill switch before instrumenting
-	if !isCiVisibilityEnabled() {
+	if !isCiVisibilityEnabled() || !testing.Testing() {
 		return f
 	}
 

--- a/internal/civisibility/integrations/gotesting/reflections.go
+++ b/internal/civisibility/integrations/gotesting/reflections.go
@@ -44,6 +44,22 @@ func copyFieldUsingPointers[V any](source any, target any, fieldName string) err
 		return err
 	}
 
+	if targetPtr == nil {
+		return errors.New("target pointer is nil")
+	}
+
+	if sourcePtr == nil {
+		return errors.New("source pointer is nil")
+	}
+
+	if (*V)(targetPtr) == nil {
+		return errors.New("target pointer value is nil")
+	}
+
+	if (*V)(sourcePtr) == nil {
+		return errors.New("source pointer value is nil")
+	}
+
 	*(*V)(targetPtr) = *(*V)(sourcePtr)
 	return nil
 }
@@ -65,23 +81,41 @@ type commonPrivateFields struct {
 // AddLevel increase or decrease the testing.common.level field value, used by
 // testing.B to create the name of the benchmark test
 func (c *commonPrivateFields) AddLevel(delta int) int {
+	if c.mu == nil {
+		return 0
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.level == nil {
+		return 0
+	}
 	*c.level = *c.level + delta
 	return *c.level
 }
 
 // SetFailed set the boolean value in testing.common.failed field value
 func (c *commonPrivateFields) SetFailed(value bool) {
+	if c.mu == nil {
+		return
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.failed == nil {
+		return
+	}
 	*c.failed = value
 }
 
 // SetSkipped set the boolean value in testing.common.skipped field value
 func (c *commonPrivateFields) SetSkipped(value bool) {
+	if c.mu == nil {
+		return
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.skipped == nil {
+		return
+	}
 	*c.skipped = value
 }
 
@@ -92,7 +126,7 @@ func (c *commonPrivateFields) SetSkipped(value bool) {
 // getInternalTestArray gets the pointer to the testing.InternalTest array inside a
 // testing.M instance containing all the "root" tests
 func getInternalTestArray(m *testing.M) *[]testing.InternalTest {
-	if ptr, err := getFieldPointerFrom(m, "tests"); err == nil {
+	if ptr, err := getFieldPointerFrom(m, "tests"); err == nil && ptr != nil {
 		return (*[]testing.InternalTest)(ptr)
 	}
 	return nil
@@ -104,22 +138,22 @@ func getTestPrivateFields(t *testing.T) *commonPrivateFields {
 	testFields := &commonPrivateFields{}
 
 	// testing.common
-	if ptr, err := getFieldPointerFrom(t, "mu"); err == nil {
+	if ptr, err := getFieldPointerFrom(t, "mu"); err == nil && ptr != nil {
 		testFields.mu = (*sync.RWMutex)(ptr)
 	}
-	if ptr, err := getFieldPointerFrom(t, "level"); err == nil {
+	if ptr, err := getFieldPointerFrom(t, "level"); err == nil && ptr != nil {
 		testFields.level = (*int)(ptr)
 	}
-	if ptr, err := getFieldPointerFrom(t, "name"); err == nil {
+	if ptr, err := getFieldPointerFrom(t, "name"); err == nil && ptr != nil {
 		testFields.name = (*string)(ptr)
 	}
-	if ptr, err := getFieldPointerFrom(t, "failed"); err == nil {
+	if ptr, err := getFieldPointerFrom(t, "failed"); err == nil && ptr != nil {
 		testFields.failed = (*bool)(ptr)
 	}
-	if ptr, err := getFieldPointerFrom(t, "skipped"); err == nil {
+	if ptr, err := getFieldPointerFrom(t, "skipped"); err == nil && ptr != nil {
 		testFields.skipped = (*bool)(ptr)
 	}
-	if ptr, err := getFieldPointerFrom(t, "parent"); err == nil {
+	if ptr, err := getFieldPointerFrom(t, "parent"); err == nil && ptr != nil {
 		testFields.parent = (*unsafe.Pointer)(ptr)
 	}
 
@@ -136,19 +170,19 @@ func getTestParentPrivateFields(t *testing.T) *commonPrivateFields {
 		testFields := &commonPrivateFields{}
 
 		// testing.common
-		if ptr, err := getFieldPointerFromValue(value, "mu"); err == nil {
+		if ptr, err := getFieldPointerFromValue(value, "mu"); err == nil && ptr != nil {
 			testFields.mu = (*sync.RWMutex)(ptr)
 		}
-		if ptr, err := getFieldPointerFromValue(value, "level"); err == nil {
+		if ptr, err := getFieldPointerFromValue(value, "level"); err == nil && ptr != nil {
 			testFields.level = (*int)(ptr)
 		}
-		if ptr, err := getFieldPointerFromValue(value, "name"); err == nil {
+		if ptr, err := getFieldPointerFromValue(value, "name"); err == nil && ptr != nil {
 			testFields.name = (*string)(ptr)
 		}
-		if ptr, err := getFieldPointerFromValue(value, "failed"); err == nil {
+		if ptr, err := getFieldPointerFromValue(value, "failed"); err == nil && ptr != nil {
 			testFields.failed = (*bool)(ptr)
 		}
-		if ptr, err := getFieldPointerFromValue(value, "skipped"); err == nil {
+		if ptr, err := getFieldPointerFromValue(value, "skipped"); err == nil && ptr != nil {
 			testFields.skipped = (*bool)(ptr)
 		}
 
@@ -165,8 +199,14 @@ type contextMatcher struct {
 
 // ClearSubNames clears the subname map used for creating unique names for subtests
 func (c *contextMatcher) ClearSubNames() {
+	if c.mu == nil {
+		return
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.subNames == nil {
+		return
+	}
 	*c.subNames = map[string]int32{}
 }
 
@@ -186,10 +226,10 @@ func getTestContextMatcherPrivateFields(t *testing.T) *contextMatcher {
 	matchMember = matchMember.Elem()
 
 	fields := &contextMatcher{}
-	if ptr, err := getFieldPointerFromValue(matchMember, "mu"); err == nil {
+	if ptr, err := getFieldPointerFromValue(matchMember, "mu"); err == nil && ptr != nil {
 		fields.mu = (*sync.RWMutex)(ptr)
 	}
-	if ptr, err := getFieldPointerFromValue(matchMember, "subNames"); err == nil {
+	if ptr, err := getFieldPointerFromValue(matchMember, "subNames"); err == nil && ptr != nil {
 		fields.subNames = (*map[string]int32)(ptr)
 	}
 
@@ -244,7 +284,7 @@ func copyTestWithoutParent(source *testing.T, target *testing.T) {
 // getInternalBenchmarkArray gets the pointer to the testing.InternalBenchmark array inside
 // a testing.M instance containing all the "root" benchmarks
 func getInternalBenchmarkArray(m *testing.M) *[]testing.InternalBenchmark {
-	if ptr, err := getFieldPointerFrom(m, "benchmarks"); err == nil {
+	if ptr, err := getFieldPointerFrom(m, "benchmarks"); err == nil && ptr != nil {
 		return (*[]testing.InternalBenchmark)(ptr)
 	}
 	return nil
@@ -267,30 +307,30 @@ func getBenchmarkPrivateFields(b *testing.B) *benchmarkPrivateFields {
 	}
 
 	// testing.common
-	if ptr, err := getFieldPointerFrom(b, "mu"); err == nil {
+	if ptr, err := getFieldPointerFrom(b, "mu"); err == nil && ptr != nil {
 		benchFields.mu = (*sync.RWMutex)(ptr)
 	}
-	if ptr, err := getFieldPointerFrom(b, "level"); err == nil {
+	if ptr, err := getFieldPointerFrom(b, "level"); err == nil && ptr != nil {
 		benchFields.level = (*int)(ptr)
 	}
-	if ptr, err := getFieldPointerFrom(b, "name"); err == nil {
+	if ptr, err := getFieldPointerFrom(b, "name"); err == nil && ptr != nil {
 		benchFields.name = (*string)(ptr)
 	}
-	if ptr, err := getFieldPointerFrom(b, "failed"); err == nil {
+	if ptr, err := getFieldPointerFrom(b, "failed"); err == nil && ptr != nil {
 		benchFields.failed = (*bool)(ptr)
 	}
-	if ptr, err := getFieldPointerFrom(b, "skipped"); err == nil {
+	if ptr, err := getFieldPointerFrom(b, "skipped"); err == nil && ptr != nil {
 		benchFields.skipped = (*bool)(ptr)
 	}
-	if ptr, err := getFieldPointerFrom(b, "parent"); err == nil {
+	if ptr, err := getFieldPointerFrom(b, "parent"); err == nil && ptr != nil {
 		benchFields.parent = (*unsafe.Pointer)(ptr)
 	}
 
 	// testing.B
-	if ptr, err := getFieldPointerFrom(b, "benchFunc"); err == nil {
+	if ptr, err := getFieldPointerFrom(b, "benchFunc"); err == nil && ptr != nil {
 		benchFields.benchFunc = (*func(b *testing.B))(ptr)
 	}
-	if ptr, err := getFieldPointerFrom(b, "result"); err == nil {
+	if ptr, err := getFieldPointerFrom(b, "result"); err == nil && ptr != nil {
 		benchFields.result = (*testing.BenchmarkResult)(ptr)
 	}
 

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -82,48 +82,50 @@ func (ddm *M) Run() int {
 
 // instrumentInternalTests instruments the internal tests for CI visibility.
 func (ddm *M) instrumentInternalTests(internalTests *[]testing.InternalTest) {
-	if internalTests != nil {
-		// Extract info from internal tests
-		testInfos = make([]*testingTInfo, len(*internalTests))
-		for idx, test := range *internalTests {
-			moduleName, suiteName := utils.GetModuleAndSuiteName(reflect.Indirect(reflect.ValueOf(test.F)).Pointer())
-			testInfo := &testingTInfo{
-				originalFunc: test.F,
-				commonInfo: commonInfo{
-					moduleName: moduleName,
-					suiteName:  suiteName,
-					testName:   test.Name,
-				},
-			}
-
-			// Initialize module and suite counters if not already present.
-			if _, ok := modulesCounters[moduleName]; !ok {
-				var v int32
-				modulesCounters[moduleName] = &v
-			}
-			// Increment the test count in the module.
-			atomic.AddInt32(modulesCounters[moduleName], 1)
-
-			if _, ok := suitesCounters[suiteName]; !ok {
-				var v int32
-				suitesCounters[suiteName] = &v
-			}
-			// Increment the test count in the suite.
-			atomic.AddInt32(suitesCounters[suiteName], 1)
-
-			testInfos[idx] = testInfo
-		}
-
-		// Create new instrumented internal tests
-		newTestArray := make([]testing.InternalTest, len(*internalTests))
-		for idx, testInfo := range testInfos {
-			newTestArray[idx] = testing.InternalTest{
-				Name: testInfo.testName,
-				F:    ddm.executeInternalTest(testInfo),
-			}
-		}
-		*internalTests = newTestArray
+	if internalTests == nil {
+		return
 	}
+
+	// Extract info from internal tests
+	testInfos = make([]*testingTInfo, len(*internalTests))
+	for idx, test := range *internalTests {
+		moduleName, suiteName := utils.GetModuleAndSuiteName(reflect.Indirect(reflect.ValueOf(test.F)).Pointer())
+		testInfo := &testingTInfo{
+			originalFunc: test.F,
+			commonInfo: commonInfo{
+				moduleName: moduleName,
+				suiteName:  suiteName,
+				testName:   test.Name,
+			},
+		}
+
+		// Initialize module and suite counters if not already present.
+		if _, ok := modulesCounters[moduleName]; !ok {
+			var v int32
+			modulesCounters[moduleName] = &v
+		}
+		// Increment the test count in the module.
+		atomic.AddInt32(modulesCounters[moduleName], 1)
+
+		if _, ok := suitesCounters[suiteName]; !ok {
+			var v int32
+			suitesCounters[suiteName] = &v
+		}
+		// Increment the test count in the suite.
+		atomic.AddInt32(suitesCounters[suiteName], 1)
+
+		testInfos[idx] = testInfo
+	}
+
+	// Create new instrumented internal tests
+	newTestArray := make([]testing.InternalTest, len(*internalTests))
+	for idx, testInfo := range testInfos {
+		newTestArray[idx] = testing.InternalTest{
+			Name: testInfo.testName,
+			F:    ddm.executeInternalTest(testInfo),
+		}
+	}
+	*internalTests = newTestArray
 }
 
 // executeInternalTest wraps the original test function to include CI visibility instrumentation.
@@ -217,49 +219,51 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo) func(*testing.T) {
 
 // instrumentInternalBenchmarks instruments the internal benchmarks for CI visibility.
 func (ddm *M) instrumentInternalBenchmarks(internalBenchmarks *[]testing.InternalBenchmark) {
-	if internalBenchmarks != nil {
-		// Extract info from internal benchmarks
-		benchmarkInfos = make([]*testingBInfo, len(*internalBenchmarks))
-		for idx, benchmark := range *internalBenchmarks {
-			moduleName, suiteName := utils.GetModuleAndSuiteName(reflect.Indirect(reflect.ValueOf(benchmark.F)).Pointer())
-			benchmarkInfo := &testingBInfo{
-				originalFunc: benchmark.F,
-				commonInfo: commonInfo{
-					moduleName: moduleName,
-					suiteName:  suiteName,
-					testName:   benchmark.Name,
-				},
-			}
-
-			// Initialize module and suite counters if not already present.
-			if _, ok := modulesCounters[moduleName]; !ok {
-				var v int32
-				modulesCounters[moduleName] = &v
-			}
-			// Increment the test count in the module.
-			atomic.AddInt32(modulesCounters[moduleName], 1)
-
-			if _, ok := suitesCounters[suiteName]; !ok {
-				var v int32
-				suitesCounters[suiteName] = &v
-			}
-			// Increment the test count in the suite.
-			atomic.AddInt32(suitesCounters[suiteName], 1)
-
-			benchmarkInfos[idx] = benchmarkInfo
-		}
-
-		// Create a new instrumented internal benchmarks
-		newBenchmarkArray := make([]testing.InternalBenchmark, len(*internalBenchmarks))
-		for idx, benchmarkInfo := range benchmarkInfos {
-			newBenchmarkArray[idx] = testing.InternalBenchmark{
-				Name: benchmarkInfo.testName,
-				F:    ddm.executeInternalBenchmark(benchmarkInfo),
-			}
-		}
-
-		*internalBenchmarks = newBenchmarkArray
+	if internalBenchmarks == nil {
+		return
 	}
+
+	// Extract info from internal benchmarks
+	benchmarkInfos = make([]*testingBInfo, len(*internalBenchmarks))
+	for idx, benchmark := range *internalBenchmarks {
+		moduleName, suiteName := utils.GetModuleAndSuiteName(reflect.Indirect(reflect.ValueOf(benchmark.F)).Pointer())
+		benchmarkInfo := &testingBInfo{
+			originalFunc: benchmark.F,
+			commonInfo: commonInfo{
+				moduleName: moduleName,
+				suiteName:  suiteName,
+				testName:   benchmark.Name,
+			},
+		}
+
+		// Initialize module and suite counters if not already present.
+		if _, ok := modulesCounters[moduleName]; !ok {
+			var v int32
+			modulesCounters[moduleName] = &v
+		}
+		// Increment the test count in the module.
+		atomic.AddInt32(modulesCounters[moduleName], 1)
+
+		if _, ok := suitesCounters[suiteName]; !ok {
+			var v int32
+			suitesCounters[suiteName] = &v
+		}
+		// Increment the test count in the suite.
+		atomic.AddInt32(suitesCounters[suiteName], 1)
+
+		benchmarkInfos[idx] = benchmarkInfo
+	}
+
+	// Create a new instrumented internal benchmarks
+	newBenchmarkArray := make([]testing.InternalBenchmark, len(*internalBenchmarks))
+	for idx, benchmarkInfo := range benchmarkInfos {
+		newBenchmarkArray[idx] = testing.InternalBenchmark{
+			Name: benchmarkInfo.testName,
+			F:    ddm.executeInternalBenchmark(benchmarkInfo),
+		}
+	}
+
+	*internalBenchmarks = newBenchmarkArray
 }
 
 // executeInternalBenchmark wraps the original benchmark function to include CI visibility instrumentation.
@@ -268,7 +272,10 @@ func (ddm *M) executeInternalBenchmark(benchmarkInfo *testingBInfo) func(*testin
 	instrumentedInternalFunc := func(b *testing.B) {
 
 		// decrement level
-		getBenchmarkPrivateFields(b).AddLevel(-1)
+		pBench := getBenchmarkPrivateFields(b)
+		if pBench != nil {
+			pBench.AddLevel(-1)
+		}
 
 		startTime := time.Now()
 		module := session.GetOrCreateModuleWithFrameworkAndStartTime(benchmarkInfo.moduleName, testFramework, runtime.Version(), startTime)
@@ -296,9 +303,17 @@ func (ddm *M) executeInternalBenchmark(benchmarkInfo *testingBInfo) func(*testin
 
 			// Enable allocation reporting.
 			b.ReportAllocs()
+
 			// Retrieve the private fields of the inner testing.B.
 			iPfOfB = getBenchmarkPrivateFields(b)
+			if iPfOfB == nil {
+				panic("failed to get private fields of the inner testing.B")
+			}
+
 			// Replace the benchmark function with the original one (this must be executed only once - the first iteration[b.run1]).
+			if iPfOfB.benchFunc == nil {
+				panic("failed to get the original benchmark function")
+			}
 			*iPfOfB.benchFunc = benchmarkInfo.originalFunc
 
 			// Get the metadata regarding the execution (in case is already created from the additional features)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Add more nil checks on the CI Visibility library to either workaround possible crash, or panic with a better error message.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Try to increase library resilience

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
