### PR TITLE
fix and cleanup the `Content-Length` handling in transport

### DIFF
--- a/ddtrace/tracer/civisibility_transport.go
+++ b/ddtrace/tracer/civisibility_transport.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"os"
 	"runtime"
-	"strconv"
 	"strings"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal"
@@ -154,7 +153,6 @@ func (t *ciVisibilityTransport) send(p *payload) (body io.ReadCloser, err error)
 	for header, value := range t.headers {
 		req.Header.Set(header, value)
 	}
-	req.Header.Set("Content-Length", strconv.Itoa(buffer.Len()))
 	if t.agentless {
 		req.Header.Set("Content-Encoding", "gzip")
 	}

--- a/ddtrace/tracer/transport.go
+++ b/ddtrace/tracer/transport.go
@@ -143,11 +143,11 @@ func (t *httpTransport) send(p *payload) (body io.ReadCloser, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot create http request: %v", err)
 	}
+	req.ContentLength = int64(p.size())
 	for header, value := range t.headers {
 		req.Header.Set(header, value)
 	}
 	req.Header.Set(traceCountHeader, strconv.Itoa(p.itemCount()))
-	req.Header.Set("Content-Length", strconv.Itoa(p.size()))
 	req.Header.Set(headerComputedTopLevel, "yes")
 	if t, ok := traceinternal.GetGlobalTracer().(*tracer); ok {
 		if t.config.canComputeStats() {

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -249,6 +249,11 @@ func TestWithHTTPClient(t *testing.T) {
 	var hits int
 	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		hits++
+		if r.Method == http.MethodGet {
+			return
+		}
+		cl := r.Header.Get("Content-Length")
+		assert.NotZero(cl)
 	}))
 	defer srv.Close()
 
@@ -266,6 +271,7 @@ func TestWithHTTPClient(t *testing.T) {
 	assert.Len(rt.reqs, 2)
 	assert.Contains(rt.reqs[0].URL.Path, "/info")
 	assert.Contains(rt.reqs[1].URL.Path, "/traces")
+	assert.NotZero(rt.reqs[1].ContentLength)
 	assert.Equal(hits, 2)
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR cleans up the `Content-Length` header in the request made to the agent. In the case of civisibility the request is made with a `*bytes.Buffer` and as indicated in the documentation the content length is computed automatically here ([cf doc](https://pkg.go.dev/net/http#NewRequestWithContext)).

In the case of the default/regular trace transport, the `Content-Length` was set manually through the header. My investigation from the agent side is that we receive a fair amount of traces from dd-trace-go without `Content-Length`, so this PR moves the content length back to the actual request field, [as suggested in the documentation](https://pkg.go.dev/net/http#Client.Do:~:text=For%20client%20requests%2C%20certain%20headers%20such%20as%20Content%2DLength%0A%09//%20and%20Connection%20are%20automatically%20written%20when%20needed%20and%0A%09//%20values%20in%20Header%20may%20be%20ignored.%20See%20the%20documentation%0A%09//%20for%20the%20Request.Write%20method). 

Here is a playground example showing how setting the header manually is not working as expected https://go.dev/play/p/AGdBGGZ7IgY

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
