### PR TITLE
appsec: differentiate user login and user set event

### DIFF
--- a/internal/appsec/emitter/usersec/user.go
+++ b/internal/appsec/emitter/usersec/user.go
@@ -7,36 +7,58 @@ package usersec
 
 import (
 	"context"
+	"sync"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/appsec/events"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/dyngo"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 )
 
 const errorLog = `
 appsec: user login monitoring ignored: could not find the http handler instrumentation metadata in the request context:
-	the request handler is not being monitored by a middleware function or the provided context is not the expected request context
+	the request handler is not being monitored by a middleware function or the provided context is not the expected request context.
+	If the user has been blocked using remote rules, blocking will still be enforced but it will not be reported.
 `
 
+var errorLogOnce sync.Once
+
 type (
+	// UserEventType is the type of user event, such as a successful login or a failed login or any other authenticated request.
+	UserEventType int
+
 	// UserLoginOperation type representing a call to appsec.SetUser(). It gets both created and destroyed in a single
 	// call to ExecuteUserIDOperation
 	UserLoginOperation struct {
 		dyngo.Operation
+		EventType UserEventType
 	}
 	// UserLoginOperationArgs is the user ID operation arguments.
-	UserLoginOperationArgs struct{}
+	UserLoginOperationArgs struct {
+	}
 
 	// UserLoginOperationRes is the user ID operation results.
 	UserLoginOperationRes struct {
 		UserID    string
 		SessionID string
-		Success   bool
 	}
 )
 
-func StartUserLoginOperation(ctx context.Context, args UserLoginOperationArgs) (*UserLoginOperation, *error) {
-	parent, _ := dyngo.FromContext(ctx)
-	op := &UserLoginOperation{Operation: dyngo.NewOperation(parent)}
+const (
+	// UserLoginSuccess is the event type for a successful user login, when a new session or JWT is created.
+	UserLoginSuccess UserEventType = iota
+	// UserLoginFailure is the event type for a failed user login, when the user ID is not found or the password is incorrect.
+	UserLoginFailure
+	// UserSet is the event type for a user ID operation that is not a login, such as any authenticated request made by the user.
+	UserSet
+)
+
+func StartUserLoginOperation(ctx context.Context, eventType UserEventType, args UserLoginOperationArgs) (*UserLoginOperation, *error) {
+	parent, ok := dyngo.FromContext(ctx)
+	if !ok { // Nothing will be reported in this case, but we can still block so we don't return
+		errorLogOnce.Do(func() { log.Error(errorLog) })
+	}
+
+	op := &UserLoginOperation{Operation: dyngo.NewOperation(parent), EventType: eventType}
 	var err error
 	dyngo.OnData(op, func(e *events.BlockingSecurityEvent) { err = e })
 	dyngo.StartOperation(op, args)

--- a/internal/appsec/listener/usersec/usec.go
+++ b/internal/appsec/listener/usersec/usec.go
@@ -37,14 +37,19 @@ func NewUserSecFeature(cfg *config.Config, rootOp dyngo.Operation) (listener.Fea
 }
 
 func (*Feature) OnFinish(op *usersec.UserLoginOperation, res usersec.UserLoginOperationRes) {
-	builder := addresses.NewAddressesBuilder().
-		WithUserID(res.UserID).
-		WithUserSessionID(res.SessionID)
+	builder := addresses.NewAddressesBuilder()
 
-	if res.Success {
-		builder = builder.WithUserLoginSuccess()
-	} else {
-		builder = builder.WithUserLoginFailure()
+	switch op.EventType {
+	case usersec.UserLoginSuccess:
+		builder = builder.WithUserLoginSuccess().
+			WithUserID(res.UserID).
+			WithUserSessionID(res.SessionID)
+	case usersec.UserLoginFailure:
+		builder = builder.WithUserLoginFailure().
+			WithUserID(res.UserID)
+	case usersec.UserSet:
+		builder = builder.WithUserID(res.UserID).
+			WithUserSessionID(res.SessionID)
 	}
 
 	dyngo.EmitData(op, waf.RunEvent{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Rework user login WAF addresses passing by differentiating a simple authenticated request and a user login request

### Motivation

Better ATO detection

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
