### PR TITLE
contrib/go-chi: Apply DD_TRACE_HTTP_SERVER_ERROR_STATUSES 

### DIFF
--- a/contrib/go-chi/chi.v5/chi_test.go
+++ b/contrib/go-chi/chi.v5/chi_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	pappsec "gopkg.in/DataDog/dd-trace-go.v1/appsec"
+	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/namingschematest"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
@@ -206,6 +207,40 @@ func TestError(t *testing.T) {
 		assertSpan(assert, span, code)
 		wantErr := fmt.Sprintf("%d: %s", code, http.StatusText(code))
 		assert.Equal(wantErr, span.Tag(ext.Error).(error).Error())
+	})
+	t.Run("envvar", func(t *testing.T) {
+		assert := assert.New(t)
+		t.Setenv("DD_TRACE_HTTP_SERVER_ERROR_STATUSES", "200")
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		httptrace.Temp()
+
+		router := chi.NewRouter()
+		router.Use(Middleware(
+			WithServiceName("foobar")))
+		code := 200
+		// a handler with an error and make the requests
+		router.Get("/err", func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, fmt.Sprintf("%d!", code), code)
+		})
+		r := httptest.NewRequest("GET", "/err", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, r)
+		response := w.Result()
+		defer response.Body.Close()
+		assert.Equal(response.StatusCode, code)
+
+		spans := mt.FinishedSpans()
+		assert.Len(spans, 1)
+		span := spans[0]
+		if span.Tag(ext.Error) == nil {
+			t.Fatal("Span missing error tags")
+		}
+		assertSpan(assert, span, code)
+		wantErr := fmt.Sprintf("%d: %s", code, http.StatusText(code))
+		assert.Equal(wantErr, span.Tag(ext.Error).(error).Error())
+
 	})
 	t.Run("integration overrides global", func(t *testing.T) {
 		assert := assert.New(t)

--- a/contrib/go-chi/chi.v5/chi_test.go
+++ b/contrib/go-chi/chi.v5/chi_test.go
@@ -214,7 +214,7 @@ func TestError(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		httptrace.Temp()
+		httptrace.ResetCfg()
 
 		router := chi.NewRouter()
 		router.Use(Middleware(

--- a/contrib/go-chi/chi.v5/chi_test.go
+++ b/contrib/go-chi/chi.v5/chi_test.go
@@ -214,6 +214,7 @@ func TestError(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
+		// re-run config defaults based on new DD_TRACE_HTTP_SERVER_ERROR_STATUSES value
 		httptrace.ResetCfg()
 
 		router := chi.NewRouter()

--- a/contrib/go-chi/chi.v5/option.go
+++ b/contrib/go-chi/chi.v5/option.go
@@ -96,10 +96,6 @@ func WithStatusCheck(fn func(statusCode int) bool) Option {
 	}
 }
 
-func isServerError(statusCode int) bool {
-	return statusCode >= 500 && statusCode < 600
-}
-
 // WithIgnoreRequest specifies a function to use for determining if the
 // incoming HTTP request tracing should be skipped.
 func WithIgnoreRequest(fn func(r *http.Request) bool) Option {

--- a/contrib/go-chi/chi.v5/option.go
+++ b/contrib/go-chi/chi.v5/option.go
@@ -43,7 +43,6 @@ func defaults(cfg *config) {
 		cfg.analyticsRate = globalconfig.AnalyticsRate()
 	}
 	cfg.headerTags = globalconfig.HeaderTagMap()
-	cfg.isStatusError = isServerError
 	cfg.ignoreRequest = func(_ *http.Request) bool { return false }
 	cfg.modifyResourceName = func(s string) string { return s }
 	// for backward compatibility with modifyResourceName, initialize resourceName as nil.

--- a/contrib/go-chi/chi/chi_test.go
+++ b/contrib/go-chi/chi/chi_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	pappsec "gopkg.in/DataDog/dd-trace-go.v1/appsec"
+	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/namingschematest"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
@@ -175,6 +176,39 @@ func TestError(t *testing.T) {
 		spans := mt.FinishedSpans()
 		assert.Len(spans, 1)
 		span := spans[0]
+		assertSpan(assert, span, code)
+		wantErr := fmt.Sprintf("%d: %s", code, http.StatusText(code))
+		assert.Equal(wantErr, span.Tag(ext.Error).(error).Error())
+	})
+	t.Run("envvar", func(t *testing.T) {
+		assert := assert.New(t)
+		t.Setenv("DD_TRACE_HTTP_SERVER_ERROR_STATUSES", "200")
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		httptrace.ResetCfg()
+
+		router := chi.NewRouter()
+		router.Use(Middleware(
+			WithServiceName("foobar")))
+		code := 200
+		// a handler with an error and make the requests
+		router.Get("/err", func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, fmt.Sprintf("%d!", code), code)
+		})
+		r := httptest.NewRequest("GET", "/err", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, r)
+		response := w.Result()
+		defer response.Body.Close()
+		assert.Equal(response.StatusCode, code)
+
+		spans := mt.FinishedSpans()
+		assert.Len(spans, 1)
+		span := spans[0]
+		if span.Tag(ext.Error) == nil {
+			t.Fatal("Span missing error tags")
+		}
 		assertSpan(assert, span, code)
 		wantErr := fmt.Sprintf("%d: %s", code, http.StatusText(code))
 		assert.Equal(wantErr, span.Tag(ext.Error).(error).Error())

--- a/contrib/go-chi/chi/chi_test.go
+++ b/contrib/go-chi/chi/chi_test.go
@@ -186,6 +186,7 @@ func TestError(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
+		// re-run config defaults based on new DD_TRACE_HTTP_SERVER_ERROR_STATUSES value
 		httptrace.ResetCfg()
 
 		router := chi.NewRouter()

--- a/contrib/go-chi/chi/option.go
+++ b/contrib/go-chi/chi/option.go
@@ -41,7 +41,6 @@ func defaults(cfg *config) {
 		cfg.analyticsRate = globalconfig.AnalyticsRate()
 	}
 	cfg.headerTags = globalconfig.HeaderTagMap()
-	cfg.isStatusError = isServerError
 	cfg.ignoreRequest = func(_ *http.Request) bool { return false }
 	cfg.resourceNamer = func(r *http.Request) string {
 		resourceName := chi.RouteContext(r.Context()).RoutePattern()
@@ -97,10 +96,6 @@ func WithStatusCheck(fn func(statusCode int) bool) Option {
 	return func(cfg *config) {
 		cfg.isStatusError = fn
 	}
-}
-
-func isServerError(statusCode int) bool {
-	return statusCode >= 500 && statusCode < 600
 }
 
 // WithHeaderTags enables the integration to attach HTTP request headers as span tags.

--- a/contrib/internal/httptrace/config.go
+++ b/contrib/internal/httptrace/config.go
@@ -6,7 +6,6 @@
 package httptrace
 
 import (
-	"fmt"
 	"os"
 	"regexp"
 	"strconv"
@@ -39,10 +38,8 @@ type config struct {
 	isStatusError     func(statusCode int) bool
 }
 
-func ResetCfg() config {
-	oldCfg := cfg
+func ResetCfg() {
 	cfg = newConfig()
-	return oldCfg
 }
 
 func newConfig() config {
@@ -54,7 +51,6 @@ func newConfig() config {
 	}
 	v := os.Getenv(envServerErrorStatuses)
 	if fn := GetErrorCodesFromInput(v); fn != nil {
-		fmt.Println("MTOFF: is 200 error?", fn(200))
 		c.isStatusError = fn
 	}
 	if s, ok := os.LookupEnv(envQueryStringRegexp); !ok {

--- a/contrib/internal/httptrace/config.go
+++ b/contrib/internal/httptrace/config.go
@@ -6,6 +6,7 @@
 package httptrace
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"strconv"
@@ -38,6 +39,10 @@ type config struct {
 	isStatusError     func(statusCode int) bool
 }
 
+func Temp() {
+	cfg = newConfig()
+}
+
 func newConfig() config {
 	c := config{
 		queryString:       !internal.BoolEnv(envQueryStringDisabled, false),
@@ -47,6 +52,7 @@ func newConfig() config {
 	}
 	v := os.Getenv(envServerErrorStatuses)
 	if fn := GetErrorCodesFromInput(v); fn != nil {
+		fmt.Println("MTOFF: is 200 error?", fn(200))
 		c.isStatusError = fn
 	}
 	if s, ok := os.LookupEnv(envQueryStringRegexp); !ok {

--- a/contrib/internal/httptrace/config.go
+++ b/contrib/internal/httptrace/config.go
@@ -39,8 +39,10 @@ type config struct {
 	isStatusError     func(statusCode int) bool
 }
 
-func Temp() {
+func ResetCfg() config {
+	oldCfg := cfg
 	cfg = newConfig()
+	return oldCfg
 }
 
 func newConfig() config {

--- a/contrib/internal/httptrace/config.go
+++ b/contrib/internal/httptrace/config.go
@@ -38,6 +38,7 @@ type config struct {
 	isStatusError     func(statusCode int) bool
 }
 
+// ResetCfg sets local variable cfg back to its defaults (mainly useful for testing)
 func ResetCfg() {
 	cfg = newConfig()
 }

--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -67,10 +67,8 @@ func FinishRequestSpan(s tracer.Span, status int, errorFn func(int) bool, opts .
 	var statusStr string
 	var fn func(int) bool
 	if errorFn == nil {
-		fmt.Println("MTOFF: errorFn is nil")
 		fn = cfg.isStatusError
 	} else {
-		fmt.Println("MTOFF: errorFn is not nil")
 		fn = errorFn
 	}
 	// if status is 0, treat it like 200 unless 0 was called out in DD_TRACE_HTTP_SERVER_ERROR_STATUSES
@@ -84,7 +82,6 @@ func FinishRequestSpan(s tracer.Span, status int, errorFn func(int) bool, opts .
 	} else {
 		statusStr = strconv.Itoa(status)
 		if fn(status) {
-			fmt.Println("MTOFF: FN 200 IS ERR")
 			s.SetTag(ext.Error, fmt.Errorf("%s: %s", statusStr, http.StatusText(status)))
 		}
 	}

--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -67,8 +67,10 @@ func FinishRequestSpan(s tracer.Span, status int, errorFn func(int) bool, opts .
 	var statusStr string
 	var fn func(int) bool
 	if errorFn == nil {
+		fmt.Println("MTOFF: errorFn is nil")
 		fn = cfg.isStatusError
 	} else {
+		fmt.Println("MTOFF: errorFn is not nil")
 		fn = errorFn
 	}
 	// if status is 0, treat it like 200 unless 0 was called out in DD_TRACE_HTTP_SERVER_ERROR_STATUSES
@@ -82,6 +84,7 @@ func FinishRequestSpan(s tracer.Span, status int, errorFn func(int) bool, opts .
 	} else {
 		statusStr = strconv.Itoa(status)
 		if fn(status) {
+			fmt.Println("MTOFF: FN 200 IS ERR")
 			s.SetTag(ext.Error, fmt.Errorf("%s: %s", statusStr, http.StatusText(status)))
 		}
 	}

--- a/contrib/internal/httptrace/httptrace_test.go
+++ b/contrib/internal/httptrace/httptrace_test.go
@@ -91,10 +91,8 @@ func TestConfiguredErrorStatuses(t *testing.T) {
 
 		os.Setenv("DD_TRACE_HTTP_SERVER_ERROR_STATUSES", "199-399,400,501")
 
-		// reset config based on new DD_TRACE_HTTP_SERVER_ERROR_STATUSES value
+		// re-run config defaults based on new DD_TRACE_HTTP_SERVER_ERROR_STATUSES value
 		ResetCfg()
-		// oldConfig := ResetCfg()
-		// defer func() { cfg = oldConfig }()
 
 		statuses := []int{0, 200, 400, 500}
 		r := httptest.NewRequest(http.MethodGet, "/test", nil)
@@ -123,10 +121,8 @@ func TestConfiguredErrorStatuses(t *testing.T) {
 
 		os.Setenv("DD_TRACE_HTTP_SERVER_ERROR_STATUSES", "0")
 
-		// reset config based on new DD_TRACE_HTTP_SERVER_ERROR_STATUSES value
+		// re-run config defaults based on new DD_TRACE_HTTP_SERVER_ERROR_STATUSES value
 		ResetCfg()
-		// oldConfig := ResetCfg()
-		// defer func() { cfg = oldConfig }()
 
 		r := httptest.NewRequest(http.MethodGet, "/test", nil)
 		sp, _ := StartRequestSpan(r)

--- a/contrib/internal/httptrace/httptrace_test.go
+++ b/contrib/internal/httptrace/httptrace_test.go
@@ -92,9 +92,8 @@ func TestConfiguredErrorStatuses(t *testing.T) {
 		os.Setenv("DD_TRACE_HTTP_SERVER_ERROR_STATUSES", "199-399,400,501")
 
 		// reset config based on new DD_TRACE_HTTP_SERVER_ERROR_STATUSES value
-		oldConfig := cfg
+		oldConfig := ResetCfg()
 		defer func() { cfg = oldConfig }()
-		cfg = newConfig()
 
 		statuses := []int{0, 200, 400, 500}
 		r := httptest.NewRequest(http.MethodGet, "/test", nil)
@@ -124,9 +123,8 @@ func TestConfiguredErrorStatuses(t *testing.T) {
 		os.Setenv("DD_TRACE_HTTP_SERVER_ERROR_STATUSES", "0")
 
 		// reset config based on new DD_TRACE_HTTP_SERVER_ERROR_STATUSES value
-		oldConfig := cfg
+		oldConfig := ResetCfg()
 		defer func() { cfg = oldConfig }()
-		cfg = newConfig()
 
 		r := httptest.NewRequest(http.MethodGet, "/test", nil)
 		sp, _ := StartRequestSpan(r)

--- a/contrib/internal/httptrace/httptrace_test.go
+++ b/contrib/internal/httptrace/httptrace_test.go
@@ -92,8 +92,9 @@ func TestConfiguredErrorStatuses(t *testing.T) {
 		os.Setenv("DD_TRACE_HTTP_SERVER_ERROR_STATUSES", "199-399,400,501")
 
 		// reset config based on new DD_TRACE_HTTP_SERVER_ERROR_STATUSES value
-		oldConfig := ResetCfg()
-		defer func() { cfg = oldConfig }()
+		ResetCfg()
+		// oldConfig := ResetCfg()
+		// defer func() { cfg = oldConfig }()
 
 		statuses := []int{0, 200, 400, 500}
 		r := httptest.NewRequest(http.MethodGet, "/test", nil)
@@ -123,8 +124,9 @@ func TestConfiguredErrorStatuses(t *testing.T) {
 		os.Setenv("DD_TRACE_HTTP_SERVER_ERROR_STATUSES", "0")
 
 		// reset config based on new DD_TRACE_HTTP_SERVER_ERROR_STATUSES value
-		oldConfig := ResetCfg()
-		defer func() { cfg = oldConfig }()
+		ResetCfg()
+		// oldConfig := ResetCfg()
+		// defer func() { cfg = oldConfig }()
 
 		r := httptest.NewRequest(http.MethodGet, "/test", nil)
 		sp, _ := StartRequestSpan(r)


### PR DESCRIPTION
### What does this PR do?
Removes `isServerError` function from go-chi and go-chi.v5 integrations. In the case that the contribs have not been initialized with a custom error checker via `WithStatusError`, they will rely on the error checker from httptrace.
This allows go-chi and go-chi.v5 integrations to be impacted by DD_TRACE_HTTP_SERVER_ERROR_STATUSES.

### Motivation
Noticed the `Test_Config_HttpServerErrorStatuses_FeatureFlagCustom` system test was failing for go-chi ([link](https://github.com/DataDog/system-tests/blob/main/tests/test_config_consistency.py#L45-L60))

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
