### PR TITLE
contrib/valyala/fasthttp.v1: fix memory leak of spanOpts

### DIFF
--- a/contrib/valyala/fasthttp.v1/fasthttp.go
+++ b/contrib/valyala/fasthttp.v1/fasthttp.go
@@ -33,13 +33,13 @@ func WrapHandler(h fasthttp.RequestHandler, opts ...Option) fasthttp.RequestHand
 		fn(cfg)
 	}
 	log.Debug("contrib/valyala/fasthttp.v1: Configuring Middleware: cfg: %#v", cfg)
-	spanOpts := []tracer.StartSpanOption{
-		tracer.ServiceName(cfg.serviceName),
-	}
 	return func(fctx *fasthttp.RequestCtx) {
 		if cfg.ignoreRequest(fctx) {
 			h(fctx)
 			return
+		}
+		spanOpts := []tracer.StartSpanOption{
+			tracer.ServiceName(cfg.serviceName),
 		}
 		spanOpts = append(spanOpts, defaultSpanOptions(fctx)...)
 		fcc := &fasthttptrace.HTTPHeadersCarrier{


### PR DESCRIPTION
### What does this PR do?

This PR fixes the memory leak of contrib/valyala/fasthttp.v1 WrapHandler function by moving the initialization of `spanOpts` to be in the closure anonymous function that will return as a fasthttp.RequestHandler instead of WrapHandler function. So it will be garbage collected every time the request handler end.

### Motivation

Fixes #2961 

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
