### PR TITLE
internal/civisibility: api refactor and support for telemetry metrics

### DIFF
--- a/ddtrace/tracer/civisibility_payload.go
+++ b/ddtrace/tracer/civisibility_payload.go
@@ -92,7 +92,7 @@ func (p *ciVisibilityPayload) getBuffer(config *config) (*bytes.Buffer, error) {
 
 	telemetry.EndpointPayloadEventsCount(telemetry.TestCycleEndpointType, float64(p.itemCount()))
 	telemetry.EndpointPayloadBytes(telemetry.TestCycleEndpointType, float64(encodedBuf.Len()))
-	telemetry.EndpointEventsSerializationMs(telemetry.TestCycleEndpointType, float64(p.serializationTime.Milliseconds()+time.Since(startTime).Milliseconds()))
+	telemetry.EndpointEventsSerializationMs(telemetry.TestCycleEndpointType, float64((p.serializationTime + time.Since(startTime)).Milliseconds()))
 	return encodedBuf, nil
 }
 

--- a/ddtrace/tracer/civisibility_transport.go
+++ b/ddtrace/tracer/civisibility_transport.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils/telemetry"
 	"io"
 	"net/http"
 	"os"
@@ -170,6 +171,7 @@ func (t *ciVisibilityTransport) send(p *payload) (body io.ReadCloser, err error)
 		n, _ := response.Body.Read(msg)
 		_ = response.Body.Close()
 		txt := http.StatusText(code)
+		telemetry.EndpointPayloadRequestsErrors(telemetry.TestCycleEndpointType, telemetry.GetErrorTypeFromStatusCode(code))
 		if n > 0 {
 			return nil, fmt.Errorf("%s (Status: %s)", msg[:n], txt)
 		}

--- a/ddtrace/tracer/civisibility_writer.go
+++ b/ddtrace/tracer/civisibility_writer.go
@@ -105,15 +105,12 @@ func (w *ciVisibilityTraceWriter) flush() {
 
 		var count, size int
 		var err error
-		if ciTransport, ok := w.config.transport.(*ciVisibilityTransport); ok {
-			if ciTransport.agentless {
-				telemetry.EndpointPayloadRequests(telemetry.TestCycleRequestCompressedEndpointType)
-			} else {
-				telemetry.EndpointPayloadRequests(telemetry.TestCycleUncompressedEndpointType)
-			}
-		} else {
-			telemetry.EndpointPayloadRequests(telemetry.TestCycleUncompressedEndpointType)
+
+		requestCompressedType := telemetry.UncompressedRequestCompressedType
+		if ciTransport, ok := w.config.transport.(*ciVisibilityTransport); ok && ciTransport.agentless {
+			requestCompressedType = telemetry.CompressedRequestCompressedType
 		}
+		telemetry.EndpointPayloadRequests(telemetry.TestCycleEndpointType, requestCompressedType)
 
 		for attempt := 0; attempt <= w.config.sendRetries; attempt++ {
 			size, count = p.size(), p.itemCount()

--- a/ddtrace/tracer/civisibility_writer_test.go
+++ b/ddtrace/tracer/civisibility_writer_test.go
@@ -32,7 +32,7 @@ type failingCiVisibilityTransport struct {
 func (t *failingCiVisibilityTransport) send(p *payload) (io.ReadCloser, error) {
 	t.sendAttempts++
 
-	ciVisibilityPayload := &ciVisibilityPayload{p}
+	ciVisibilityPayload := &ciVisibilityPayload{p, 0}
 
 	var events ciVisibilityEvents
 	err := msgp.Decode(ciVisibilityPayload, &events)

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -284,6 +284,9 @@ type config struct {
 	// ciVisibilityEnabled controls if the tracer is loaded with CI Visibility mode. default false
 	ciVisibilityEnabled bool
 
+	// ciVisibilityAgentless controls if the tracer is loaded with CI Visibility agentless mode. default false
+	ciVisibilityAgentless bool
+
 	// logDirectory is directory for tracer logs specified by user-setting DD_TRACE_LOG_DIRECTORY. default empty/unused
 	logDirectory string
 }
@@ -558,10 +561,12 @@ func newConfig(opts ...StartOption) *config {
 
 	// Check if CI Visibility mode is enabled
 	if internal.BoolEnv(constants.CIVisibilityEnabledEnvironmentVariable, false) {
-		c.ciVisibilityEnabled = true              // Enable CI Visibility mode
-		c.httpClientTimeout = time.Second * 45    // Increase timeout up to 45 seconds (same as other tracers in CIVis mode)
-		c.logStartup = false                      // If we are in CI Visibility mode we don't want to log the startup to stdout to avoid polluting the output
-		c.transport = newCiVisibilityTransport(c) // Replace the default transport with the CI Visibility transport
+		c.ciVisibilityEnabled = true               // Enable CI Visibility mode
+		c.httpClientTimeout = time.Second * 45     // Increase timeout up to 45 seconds (same as other tracers in CIVis mode)
+		c.logStartup = false                       // If we are in CI Visibility mode we don't want to log the startup to stdout to avoid polluting the output
+		ciTransport := newCiVisibilityTransport(c) // Create a default CI Visibility Transport
+		c.transport = ciTransport                  // Replace the default transport with the CI Visibility transport
+		c.ciVisibilityAgentless = ciTransport.agentless
 	}
 
 	return c

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -36,7 +36,8 @@ func startTelemetry(c *config) {
 		telemetry.WithEnv(c.env),
 		telemetry.WithHTTPClient(c.httpClient),
 		// c.logToStdout is true if serverless is turned on
-		telemetry.WithURL(c.logToStdout, c.agentURL.String()),
+		// c.ciVisibilityAgentless is true if ci visibility mode is turned on and agentless writer is configured
+		telemetry.WithURL(c.logToStdout || c.ciVisibilityAgentless, c.agentURL.String()),
 		telemetry.WithVersion(c.version),
 	)
 	telemetryConfigs := []telemetry.Configuration{

--- a/internal/civisibility/integrations/civisibility.go
+++ b/internal/civisibility/integrations/civisibility.go
@@ -19,6 +19,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/constants"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 )
 
 // ciVisibilityCloseAction defines an action to be executed when CI visibility is closing.
@@ -130,6 +131,7 @@ func ExitCiVisibility() {
 		log.Debug("civisibility: flushing and stopping tracer")
 		tracer.Flush()
 		tracer.Stop()
+		telemetry.GlobalClient.Stop()
 		log.Debug("civisibility: done.")
 	}()
 	for _, v := range closeActions {

--- a/internal/civisibility/integrations/gotesting/coverage/coverage_payload.go
+++ b/internal/civisibility/integrations/gotesting/coverage/coverage_payload.go
@@ -169,6 +169,6 @@ func (p *coveragePayload) getBuffer() (*bytes.Buffer, error) {
 
 	telemetry.EndpointPayloadBytes(telemetry.CodeCoverageEndpointType, float64(encodedBuf.Len()))
 	telemetry.EndpointPayloadEventsCount(telemetry.CodeCoverageEndpointType, float64(p.itemCount()))
-	telemetry.EndpointEventsSerializationMs(telemetry.CodeCoverageEndpointType, float64(p.serializationTime.Milliseconds()+time.Since(startTime).Milliseconds()))
+	telemetry.EndpointEventsSerializationMs(telemetry.CodeCoverageEndpointType, float64((p.serializationTime + time.Since(startTime)).Milliseconds()))
 	return encodedBuf, nil
 }

--- a/internal/civisibility/integrations/gotesting/coverage/coverage_writer.go
+++ b/internal/civisibility/integrations/gotesting/coverage/coverage_writer.go
@@ -6,10 +6,10 @@
 package coverage
 
 import (
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils/telemetry"
 	"sync"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils/net"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils/telemetry"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 )
 
@@ -92,6 +92,7 @@ func (w *coverageWriter) flush() {
 			return
 		}
 
+		telemetry.CodeCoverageFiles(float64(p.itemCount()))
 		err = w.client.SendCoveragePayload(buf)
 		if err != nil {
 			log.Error("coverageWriter: failure sending coverage data: %v", err)

--- a/internal/civisibility/integrations/gotesting/coverage/coverage_writer.go
+++ b/internal/civisibility/integrations/gotesting/coverage/coverage_writer.go
@@ -6,6 +6,7 @@
 package coverage
 
 import (
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils/telemetry"
 	"sync"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils/net"
@@ -44,6 +45,7 @@ func newCoverageWriter() *coverageWriter {
 }
 
 func (w *coverageWriter) add(coverage *testCoverage) {
+	telemetry.EventsEnqueueForSerialization()
 	ciTestCoverage := newCiTestCoverageData(coverage)
 	if err := w.payload.push(ciTestCoverage); err != nil {
 		log.Error("coverageWriter: Error encoding msgpack: %v", err)

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -30,14 +30,14 @@ type (
 
 	// testExecutionMetadata contains metadata regarding an unique *testing.T or *testing.B execution
 	testExecutionMetadata struct {
-		test                        integrations.DdTest // internal CI Visibility test event
-		error                       atomic.Int32        // flag to check if the test event has error data already
-		skipped                     atomic.Int32        // flag to check if the test event has skipped data already
-		panicData                   any                 // panic data recovered from an internal test execution when using an additional feature wrapper
-		panicStacktrace             string              // stacktrace from the panic recovered from an internal test
-		isARetry                    bool                // flag to tag if a current test execution is a retry
-		isANewTest                  bool                // flag to tag if a current test execution is part of a new test (EFD not known test)
-		hasAdditionalFeatureWrapper bool                // flag to check if the current execution is part of an additional feature wrapper
+		test                        integrations.Test // internal CI Visibility test event
+		error                       atomic.Int32      // flag to check if the test event has error data already
+		skipped                     atomic.Int32      // flag to check if the test event has skipped data already
+		panicData                   any               // panic data recovered from an internal test execution when using an additional feature wrapper
+		panicStacktrace             string            // stacktrace from the panic recovered from an internal test
+		isARetry                    bool              // flag to tag if a current test execution is a retry
+		isANewTest                  bool              // flag to tag if a current test execution is part of a new test (EFD not known test)
+		hasAdditionalFeatureWrapper bool              // flag to check if the current execution is part of an additional feature wrapper
 	}
 
 	// runTestWithRetryOptions contains the options for calling runTestWithRetry function
@@ -341,8 +341,8 @@ func runTestWithRetry(options *runTestWithRetryOptions) {
 	var lastPtrToLocalT *testing.T
 
 	// Module and suite for this test
-	var module integrations.DdTestModule
-	var suite integrations.DdTestSuite
+	var module integrations.TestModule
+	var suite integrations.TestSuite
 
 	// Check if we have execution metadata to propagate
 	originalExecMeta := getTestMetadata(options.t)

--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -238,7 +238,7 @@ func instrumentCloseAndSkip(tb testing.TB, skipReason string) {
 	// Get the CI Visibility span and check if we can mark it as skipped and close it
 	ciTestItem := getTestMetadata(tb)
 	if ciTestItem != nil && ciTestItem.test != nil && ciTestItem.skipped.CompareAndSwap(0, 1) {
-		ciTestItem.test.CloseWithFinishTimeAndSkipReason(integrations.ResultStatusSkip, time.Now(), skipReason)
+		ciTestItem.test.Close(integrations.ResultStatusSkip, integrations.WithTestSkipReason(skipReason))
 	}
 }
 
@@ -417,11 +417,11 @@ func instrumentTestingBFunc(pb *testing.B, name string, f func(*testing.B)) (str
 			test.SetTag(ext.Error, true)
 			suite.SetTag(ext.Error, true)
 			module.SetTag(ext.Error, true)
-			test.CloseWithFinishTime(integrations.ResultStatusFail, endTime)
+			test.Close(integrations.ResultStatusFail, integrations.WithTestFinishTime(endTime))
 		} else if iPfOfB.B.Skipped() {
-			test.CloseWithFinishTime(integrations.ResultStatusSkip, endTime)
+			test.Close(integrations.ResultStatusSkip, integrations.WithTestFinishTime(endTime))
 		} else {
-			test.CloseWithFinishTime(integrations.ResultStatusPass, endTime)
+			test.Close(integrations.ResultStatusPass, integrations.WithTestFinishTime(endTime))
 		}
 
 		checkModuleAndSuite(module, suite)

--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -176,7 +176,7 @@ func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
 		defer func() {
 			if r := recover(); r != nil {
 				// Handle panic and set error information.
-				test.SetErrorInfo("panic", fmt.Sprint(r), utils.GetStacktrace(1))
+				test.SetError(integrations.WithErrorInfo("panic", fmt.Sprint(r), utils.GetStacktrace(1)))
 				test.Close(integrations.ResultStatusFail)
 				checkModuleAndSuite(module, suite)
 				// this is not an internal test. Retries are not applied to subtest (because the parent internal test is going to be retried)
@@ -222,7 +222,7 @@ func instrumentSetErrorInfo(tb testing.TB, errType string, errMessage string, sk
 	// Get the CI Visibility span and check if we can set the error type, message and stack
 	ciTestItem := getTestMetadata(tb)
 	if ciTestItem != nil && ciTestItem.test != nil && ciTestItem.error.CompareAndSwap(0, 1) {
-		ciTestItem.test.SetErrorInfo(errType, errMessage, utils.GetStacktrace(2+skip))
+		ciTestItem.test.SetError(integrations.WithErrorInfo(errType, errMessage, utils.GetStacktrace(2+skip)))
 	}
 }
 
@@ -403,7 +403,7 @@ func instrumentTestingBFunc(pb *testing.B, name string, f func(*testing.B)) (str
 
 		// Define a function to handle panic during benchmark finalization.
 		panicFunc := func(r any) {
-			test.SetErrorInfo("panic", fmt.Sprint(r), utils.GetStacktrace(1))
+			test.SetError(integrations.WithErrorInfo("panic", fmt.Sprint(r), utils.GetStacktrace(1)))
 			suite.SetTag(ext.Error, true)
 			module.SetTag(ext.Error, true)
 			test.Close(integrations.ResultStatusFail)

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -222,11 +222,11 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo) func(*testing.T) {
 			if test.Context().Value(constants.TestUnskippable) != true {
 				test.SetTag(constants.TestSkippedByITR, "true")
 				test.Close(integrations.ResultStatusSkip, integrations.WithTestSkipReason(constants.SkippedByITRReason))
+				telemetry.ITRSkipped(telemetry.TestEventType)
 				session.SetTag(constants.ITRTestsSkipped, "true")
 				session.SetTag(constants.ITRTestsSkippingCount, numOfTestsSkipped.Add(1))
 				checkModuleAndSuite(module, suite)
 				t.Skip(constants.SkippedByITRReason)
-				telemetry.ITRSkipped(telemetry.TestEventType)
 				return
 			} else {
 				test.SetTag(constants.TestForcedToRun, "true")

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -277,7 +277,7 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo) func(*testing.T) {
 				// Handle panic and set error information.
 				execMeta.panicData = r
 				execMeta.panicStacktrace = utils.GetStacktrace(1)
-				test.SetErrorInfo("panic", fmt.Sprint(r), execMeta.panicStacktrace)
+				test.SetError(integrations.WithErrorInfo("panic", fmt.Sprint(r), execMeta.panicStacktrace))
 				suite.SetTag(ext.Error, true)
 				module.SetTag(ext.Error, true)
 				test.Close(integrations.ResultStatusFail)
@@ -480,7 +480,7 @@ func (ddm *M) executeInternalBenchmark(benchmarkInfo *testingBInfo) func(*testin
 
 		// Define a function to handle panic during benchmark finalization.
 		panicFunc := func(r any) {
-			test.SetErrorInfo("panic", fmt.Sprint(r), utils.GetStacktrace(1))
+			test.SetError(integrations.WithErrorInfo("panic", fmt.Sprint(r), utils.GetStacktrace(1)))
 			suite.SetTag(ext.Error, true)
 			module.SetTag(ext.Error, true)
 			test.Close(integrations.ResultStatusFail)

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -195,7 +195,7 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo) func(*testing.T) {
 		}
 
 		// Create or retrieve the module, suite, and test for CI visibility.
-		module := session.GetOrCreateModuleWithFramework(testInfo.moduleName, testFramework, runtime.Version())
+		module := session.GetOrCreateModule(testInfo.moduleName)
 		suite := module.GetOrCreateSuite(testInfo.suiteName)
 		test := suite.CreateTest(testInfo.testName)
 		test.SetTestFunc(originalFunc)
@@ -391,9 +391,9 @@ func (ddm *M) executeInternalBenchmark(benchmarkInfo *testingBInfo) func(*testin
 		}
 
 		startTime := time.Now()
-		module := session.GetOrCreateModuleWithFrameworkAndStartTime(benchmarkInfo.moduleName, testFramework, runtime.Version(), startTime)
-		suite := module.GetOrCreateSuiteWithStartTime(benchmarkInfo.suiteName, startTime)
-		test := suite.CreateTestWithStartTime(benchmarkInfo.testName, startTime)
+		module := session.GetOrCreateModule(benchmarkInfo.moduleName, integrations.WithTestModuleStartTime(startTime))
+		suite := module.GetOrCreateSuite(benchmarkInfo.suiteName, integrations.WithTestSuiteStartTime(startTime))
+		test := suite.CreateTest(benchmarkInfo.testName, integrations.WithTestStartTime(startTime))
 		test.SetTestFunc(originalFunc)
 
 		// Run the original benchmark function.

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -220,7 +220,7 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo) func(*testing.T) {
 			// check if the test was marked as unskippable
 			if test.Context().Value(constants.TestUnskippable) != true {
 				test.SetTag(constants.TestSkippedByITR, "true")
-				test.CloseWithFinishTimeAndSkipReason(integrations.ResultStatusSkip, time.Now(), constants.SkippedByITRReason)
+				test.Close(integrations.ResultStatusSkip, integrations.WithTestSkipReason(constants.SkippedByITRReason))
 				session.SetTag(constants.ITRTestsSkipped, "true")
 				session.SetTag(constants.ITRTestsSkippingCount, numOfTestsSkipped.Add(1))
 				checkModuleAndSuite(module, suite)
@@ -494,11 +494,11 @@ func (ddm *M) executeInternalBenchmark(benchmarkInfo *testingBInfo) func(*testin
 			test.SetTag(ext.Error, true)
 			suite.SetTag(ext.Error, true)
 			module.SetTag(ext.Error, true)
-			test.CloseWithFinishTime(integrations.ResultStatusFail, endTime)
+			test.Close(integrations.ResultStatusFail, integrations.WithTestFinishTime(endTime))
 		} else if iPfOfB.B.Skipped() {
-			test.CloseWithFinishTime(integrations.ResultStatusSkip, endTime)
+			test.Close(integrations.ResultStatusSkip, integrations.WithTestFinishTime(endTime))
 		} else {
-			test.CloseWithFinishTime(integrations.ResultStatusPass, endTime)
+			test.Close(integrations.ResultStatusPass, integrations.WithTestFinishTime(endTime))
 		}
 
 		checkModuleAndSuite(module, suite)

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations/gotesting/coverage"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils/telemetry"
 )
 
 const (
@@ -225,9 +226,11 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo) func(*testing.T) {
 				session.SetTag(constants.ITRTestsSkippingCount, numOfTestsSkipped.Add(1))
 				checkModuleAndSuite(module, suite)
 				t.Skip(constants.SkippedByITRReason)
+				telemetry.ITRSkipped(telemetry.TestEventType)
 				return
 			} else {
 				test.SetTag(constants.TestForcedToRun, "true")
+				telemetry.ITRForcedRun(telemetry.TestEventType)
 			}
 		}
 

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	// session represents the CI visibility test session.
-	session integrations.DdTestSession
+	session integrations.TestSession
 
 	// testInfos holds information about the instrumented tests.
 	testInfos []*testingTInfo
@@ -514,7 +514,7 @@ func RunM(m *testing.M) int {
 }
 
 // checkModuleAndSuite checks and closes the modules and suites if all tests are executed.
-func checkModuleAndSuite(module integrations.DdTestModule, suite integrations.DdTestSuite) {
+func checkModuleAndSuite(module integrations.TestModule, suite integrations.TestSuite) {
 	// If all tests in a suite has been executed we can close the suite
 	if atomic.AddInt32(suitesCounters[suite.Name()], -1) <= 0 {
 		suite.Close()

--- a/internal/civisibility/integrations/gotesting/testing_test.go
+++ b/internal/civisibility/integrations/gotesting/testing_test.go
@@ -175,6 +175,9 @@ func assertTest(t *testing.T) {
 
 		// Assert Session
 		if span.Tag(ext.SpanType) == constants.SpanTypeTestSession {
+			assert.Subset(spanTags, map[string]interface{}{
+				constants.TestFramework: "golang.org/pkg/testing",
+			})
 			assert.Contains(spanTags, constants.TestSessionIDTag)
 			assertCommon(assert, span)
 			hasSession = true

--- a/internal/civisibility/integrations/manual_api.go
+++ b/internal/civisibility/integrations/manual_api.go
@@ -66,19 +66,10 @@ type DdTestSession interface {
 	WorkingDirectory() string
 
 	// Close closes the test session with the given exit code.
-	Close(exitCode int)
-
-	// CloseWithFinishTime closes the test session with the given exit code and finish time.
-	CloseWithFinishTime(exitCode int, finishTime time.Time)
+	Close(exitCode int, options ...DdTestSessionCloseOption)
 
 	// GetOrCreateModule returns an existing module or creates a new one with the given name.
-	GetOrCreateModule(name string) DdTestModule
-
-	// GetOrCreateModuleWithFramework returns an existing module or creates a new one with the given name, framework, and framework version.
-	GetOrCreateModuleWithFramework(name string, framework string, frameworkVersion string) DdTestModule
-
-	// GetOrCreateModuleWithFrameworkAndStartTime returns an existing module or creates a new one with the given name, framework, framework version, and start time.
-	GetOrCreateModuleWithFrameworkAndStartTime(name string, framework string, frameworkVersion string, startTime time.Time) DdTestModule
+	GetOrCreateModule(name string, options ...DdTestModuleStartOption) DdTestModule
 }
 
 // DdTestModule represents a module within a test session.
@@ -98,16 +89,10 @@ type DdTestModule interface {
 	Name() string
 
 	// Close closes the test module.
-	Close()
-
-	// CloseWithFinishTime closes the test module with the given finish time.
-	CloseWithFinishTime(finishTime time.Time)
+	Close(options ...DdTestModuleCloseOption)
 
 	// GetOrCreateSuite returns an existing suite or creates a new one with the given name.
-	GetOrCreateSuite(name string) DdTestSuite
-
-	// GetOrCreateSuiteWithStartTime returns an existing suite or creates a new one with the given name and start time.
-	GetOrCreateSuiteWithStartTime(name string, startTime time.Time) DdTestSuite
+	GetOrCreateSuite(name string, options ...DdTestSuiteStartOption) DdTestSuite
 }
 
 // DdTestSuite represents a suite of tests within a module.
@@ -124,16 +109,10 @@ type DdTestSuite interface {
 	Name() string
 
 	// Close closes the test suite.
-	Close()
+	Close(options ...DdTestSuiteCloseOption)
 
-	// CloseWithFinishTime closes the test suite with the given finish time.
-	CloseWithFinishTime(finishTime time.Time)
-
-	// CreateTest creates a new test with the given name.
-	CreateTest(name string) DdTest
-
-	// CreateTestWithStartTime creates a new test with the given name and start time.
-	CreateTestWithStartTime(name string, startTime time.Time) DdTest
+	// CreateTest creates a new test with the given name and options.
+	CreateTest(name string, options ...DdTestStartOption) DdTest
 }
 
 // DdTest represents an individual test within a suite.

--- a/internal/civisibility/integrations/manual_api.go
+++ b/internal/civisibility/integrations/manual_api.go
@@ -25,8 +25,8 @@ const (
 	ResultStatusSkip TestResultStatus = 2
 )
 
-// DdErrorOption is a function that sets an option for creating an error.
-type DdErrorOption func(*tslvErrorOptions)
+// ErrorOption is a function that sets an option for creating an error.
+type ErrorOption func(*tslvErrorOptions)
 
 // tslvErrorOptions is a struct that holds options for creating an error.
 type tslvErrorOptions struct {
@@ -37,12 +37,12 @@ type tslvErrorOptions struct {
 }
 
 // WithError sets the error on the options.
-func WithError(err error) DdErrorOption {
+func WithError(err error) ErrorOption {
 	return func(o *tslvErrorOptions) { o.err = err }
 }
 
 // WithErrorInfo sets detailed error information on the options.
-func WithErrorInfo(errType string, message string, callstack string) DdErrorOption {
+func WithErrorInfo(errType string, message string, callstack string) ErrorOption {
 	return func(o *tslvErrorOptions) {
 		o.errType = errType
 		o.message = message
@@ -59,14 +59,14 @@ type ddTslvEvent interface {
 	StartTime() time.Time
 
 	// SetError sets an error on the event.
-	SetError(options ...DdErrorOption)
+	SetError(options ...ErrorOption)
 
 	// SetTag sets a tag on the event.
 	SetTag(key string, value interface{})
 }
 
-// DdTestSessionStartOption represents an option that can be passed to CreateTestSession.
-type DdTestSessionStartOption func(*tslvTestSessionStartOptions)
+// TestSessionStartOption represents an option that can be passed to CreateTestSession.
+type TestSessionStartOption func(*tslvTestSessionStartOptions)
 
 // tslvTestSessionStartOptions contains the options for creating a new test session.
 type tslvTestSessionStartOptions struct {
@@ -78,17 +78,17 @@ type tslvTestSessionStartOptions struct {
 }
 
 // WithTestSessionCommand sets the command used to run the test session.
-func WithTestSessionCommand(command string) DdTestSessionStartOption {
+func WithTestSessionCommand(command string) TestSessionStartOption {
 	return func(o *tslvTestSessionStartOptions) { o.command = command }
 }
 
 // WithTestSessionWorkingDirectory sets the working directory of the test session.
-func WithTestSessionWorkingDirectory(workingDirectory string) DdTestSessionStartOption {
+func WithTestSessionWorkingDirectory(workingDirectory string) TestSessionStartOption {
 	return func(o *tslvTestSessionStartOptions) { o.workingDirectory = workingDirectory }
 }
 
 // WithTestSessionFramework sets the testing framework used in the test session.
-func WithTestSessionFramework(framework, frameworkVersion string) DdTestSessionStartOption {
+func WithTestSessionFramework(framework, frameworkVersion string) TestSessionStartOption {
 	return func(o *tslvTestSessionStartOptions) {
 		o.framework = framework
 		o.frameworkVersion = frameworkVersion
@@ -96,12 +96,12 @@ func WithTestSessionFramework(framework, frameworkVersion string) DdTestSessionS
 }
 
 // WithTestSessionStartTime sets the start time of the test session.
-func WithTestSessionStartTime(startTime time.Time) DdTestSessionStartOption {
+func WithTestSessionStartTime(startTime time.Time) TestSessionStartOption {
 	return func(o *tslvTestSessionStartOptions) { o.startTime = startTime }
 }
 
-// DdTestSessionCloseOption represents an option that can be passed to Close.
-type DdTestSessionCloseOption func(*tslvTestSessionCloseOptions)
+// TestSessionCloseOption represents an option that can be passed to Close.
+type TestSessionCloseOption func(*tslvTestSessionCloseOptions)
 
 // tslvTestSessionCloseOptions contains the options for closing a test session.
 type tslvTestSessionCloseOptions struct {
@@ -109,12 +109,12 @@ type tslvTestSessionCloseOptions struct {
 }
 
 // WithTestSessionFinishTime sets the finish time of the test session.
-func WithTestSessionFinishTime(finishTime time.Time) DdTestSessionCloseOption {
+func WithTestSessionFinishTime(finishTime time.Time) TestSessionCloseOption {
 	return func(o *tslvTestSessionCloseOptions) { o.finishTime = finishTime }
 }
 
-// DdTestModuleStartOption represents an option that can be passed to GetOrCreateModule.
-type DdTestModuleStartOption func(*tslvTestModuleStartOptions)
+// TestModuleStartOption represents an option that can be passed to GetOrCreateModule.
+type TestModuleStartOption func(*tslvTestModuleStartOptions)
 
 // tslvTestModuleOptions contains the options for creating a new test module.
 type tslvTestModuleStartOptions struct {
@@ -124,7 +124,7 @@ type tslvTestModuleStartOptions struct {
 }
 
 // WithTestModuleFramework sets the testing framework used by the test module.
-func WithTestModuleFramework(framework, frameworkVersion string) DdTestModuleStartOption {
+func WithTestModuleFramework(framework, frameworkVersion string) TestModuleStartOption {
 	return func(o *tslvTestModuleStartOptions) {
 		o.framework = framework
 		o.frameworkVersion = frameworkVersion
@@ -132,12 +132,12 @@ func WithTestModuleFramework(framework, frameworkVersion string) DdTestModuleSta
 }
 
 // WithTestModuleStartTime sets the start time of the test module.
-func WithTestModuleStartTime(startTime time.Time) DdTestModuleStartOption {
+func WithTestModuleStartTime(startTime time.Time) TestModuleStartOption {
 	return func(o *tslvTestModuleStartOptions) { o.startTime = startTime }
 }
 
-// DdTestSession represents a session for a set of tests.
-type DdTestSession interface {
+// TestSession represents a session for a set of tests.
+type TestSession interface {
 	ddTslvEvent
 
 	// SessionID returns the ID of the session.
@@ -153,14 +153,14 @@ type DdTestSession interface {
 	WorkingDirectory() string
 
 	// Close closes the test session with the given exit code.
-	Close(exitCode int, options ...DdTestSessionCloseOption)
+	Close(exitCode int, options ...TestSessionCloseOption)
 
 	// GetOrCreateModule returns an existing module or creates a new one with the given name.
-	GetOrCreateModule(name string, options ...DdTestModuleStartOption) DdTestModule
+	GetOrCreateModule(name string, options ...TestModuleStartOption) TestModule
 }
 
-// DdTestModuleCloseOption represents an option for closing a test module.
-type DdTestModuleCloseOption func(*tslvTestModuleCloseOptions)
+// TestModuleCloseOption represents an option for closing a test module.
+type TestModuleCloseOption func(*tslvTestModuleCloseOptions)
 
 // tslvTestModuleCloseOptions represents the options for closing a test module.
 type tslvTestModuleCloseOptions struct {
@@ -168,12 +168,12 @@ type tslvTestModuleCloseOptions struct {
 }
 
 // WithTestModuleFinishTime sets the finish time for closing the test module.
-func WithTestModuleFinishTime(finishTime time.Time) DdTestModuleCloseOption {
+func WithTestModuleFinishTime(finishTime time.Time) TestModuleCloseOption {
 	return func(o *tslvTestModuleCloseOptions) { o.finishTime = finishTime }
 }
 
-// DdTestSuiteStartOption represents an option for starting a test suite.
-type DdTestSuiteStartOption func(*tslvTestSuiteStartOptions)
+// TestSuiteStartOption represents an option for starting a test suite.
+type TestSuiteStartOption func(*tslvTestSuiteStartOptions)
 
 // tslvTestSuiteStartOptions represents the options for starting a test suite.
 type tslvTestSuiteStartOptions struct {
@@ -181,19 +181,19 @@ type tslvTestSuiteStartOptions struct {
 }
 
 // WithTestSuiteStartTime sets the start time for starting a test suite.
-func WithTestSuiteStartTime(startTime time.Time) DdTestSuiteStartOption {
+func WithTestSuiteStartTime(startTime time.Time) TestSuiteStartOption {
 	return func(o *tslvTestSuiteStartOptions) { o.startTime = startTime }
 }
 
-// DdTestModule represents a module within a test session.
-type DdTestModule interface {
+// TestModule represents a module within a test session.
+type TestModule interface {
 	ddTslvEvent
 
 	// ModuleID returns the ID of the module.
 	ModuleID() uint64
 
 	// Session returns the test session to which the module belongs.
-	Session() DdTestSession
+	Session() TestSession
 
 	// Framework returns the testing framework used by the module.
 	Framework() string
@@ -202,14 +202,14 @@ type DdTestModule interface {
 	Name() string
 
 	// Close closes the test module.
-	Close(options ...DdTestModuleCloseOption)
+	Close(options ...TestModuleCloseOption)
 
 	// GetOrCreateSuite returns an existing suite or creates a new one with the given name.
-	GetOrCreateSuite(name string, options ...DdTestSuiteStartOption) DdTestSuite
+	GetOrCreateSuite(name string, options ...TestSuiteStartOption) TestSuite
 }
 
-// DdTestSuiteCloseOption represents an option for closing a test suite.
-type DdTestSuiteCloseOption func(*tslvTestSuiteCloseOptions)
+// TestSuiteCloseOption represents an option for closing a test suite.
+type TestSuiteCloseOption func(*tslvTestSuiteCloseOptions)
 
 // tslvTestSuiteCloseOptions represents the options for closing a test suite.
 type tslvTestSuiteCloseOptions struct {
@@ -217,12 +217,12 @@ type tslvTestSuiteCloseOptions struct {
 }
 
 // WithTestSuiteFinishTime sets the finish time for closing the test suite.
-func WithTestSuiteFinishTime(finishTime time.Time) DdTestSuiteCloseOption {
+func WithTestSuiteFinishTime(finishTime time.Time) TestSuiteCloseOption {
 	return func(o *tslvTestSuiteCloseOptions) { o.finishTime = finishTime }
 }
 
-// DdTestStartOption represents an option for starting a test.
-type DdTestStartOption func(*tslvTestStartOptions)
+// TestStartOption represents an option for starting a test.
+type TestStartOption func(*tslvTestStartOptions)
 
 // tslvTestStartOptions represents the options for starting a test.
 type tslvTestStartOptions struct {
@@ -230,32 +230,32 @@ type tslvTestStartOptions struct {
 }
 
 // WithTestStartTime sets the start time for starting a test.
-func WithTestStartTime(startTime time.Time) DdTestStartOption {
+func WithTestStartTime(startTime time.Time) TestStartOption {
 	return func(o *tslvTestStartOptions) { o.startTime = startTime }
 }
 
-// DdTestSuite represents a suite of tests within a module.
-type DdTestSuite interface {
+// TestSuite represents a suite of tests within a module.
+type TestSuite interface {
 	ddTslvEvent
 
 	// SuiteID returns the ID of the suite.
 	SuiteID() uint64
 
 	// Module returns the module to which the suite belongs.
-	Module() DdTestModule
+	Module() TestModule
 
 	// Name returns the name of the suite.
 	Name() string
 
 	// Close closes the test suite.
-	Close(options ...DdTestSuiteCloseOption)
+	Close(options ...TestSuiteCloseOption)
 
 	// CreateTest creates a new test with the given name and options.
-	CreateTest(name string, options ...DdTestStartOption) DdTest
+	CreateTest(name string, options ...TestStartOption) Test
 }
 
-// DdTestCloseOption represents an option for closing a test.
-type DdTestCloseOption func(*tslvTestCloseOptions)
+// TestCloseOption represents an option for closing a test.
+type TestCloseOption func(*tslvTestCloseOptions)
 
 // tslvTestCloseOptions represents the options for closing a test.
 type tslvTestCloseOptions struct {
@@ -264,17 +264,17 @@ type tslvTestCloseOptions struct {
 }
 
 // WithTestFinishTime sets the finish time of the test.
-func WithTestFinishTime(finishTime time.Time) DdTestCloseOption {
+func WithTestFinishTime(finishTime time.Time) TestCloseOption {
 	return func(o *tslvTestCloseOptions) { o.finishTime = finishTime }
 }
 
 // WithTestSkipReason sets the skip reason of the test.
-func WithTestSkipReason(skipReason string) DdTestCloseOption {
+func WithTestSkipReason(skipReason string) TestCloseOption {
 	return func(o *tslvTestCloseOptions) { o.skipReason = skipReason }
 }
 
-// DdTest represents an individual test within a suite.
-type DdTest interface {
+// Test represents an individual test within a suite.
+type Test interface {
 	ddTslvEvent
 
 	// TestID returns the ID of the test.
@@ -284,10 +284,10 @@ type DdTest interface {
 	Name() string
 
 	// Suite returns the suite to which the test belongs.
-	Suite() DdTestSuite
+	Suite() TestSuite
 
 	// Close closes the test with the given status.
-	Close(status TestResultStatus, options ...DdTestCloseOption)
+	Close(status TestResultStatus, options ...TestCloseOption)
 
 	// SetTestFunc sets the function to be tested. (Sets the test.source tags and test.codeowners)
 	SetTestFunc(fn *runtime.Func)

--- a/internal/civisibility/integrations/manual_api.go
+++ b/internal/civisibility/integrations/manual_api.go
@@ -129,13 +129,7 @@ type DdTest interface {
 	Suite() DdTestSuite
 
 	// Close closes the test with the given status.
-	Close(status TestResultStatus)
-
-	// CloseWithFinishTime closes the test with the given status and finish time.
-	CloseWithFinishTime(status TestResultStatus, finishTime time.Time)
-
-	// CloseWithFinishTimeAndSkipReason closes the test with the given status, finish time, and skip reason.
-	CloseWithFinishTimeAndSkipReason(status TestResultStatus, finishTime time.Time, skipReason string)
+	Close(status TestResultStatus, options ...DdTestCloseOption)
 
 	// SetTestFunc sets the function to be tested. (Sets the test.source tags and test.codeowners)
 	SetTestFunc(fn *runtime.Func)

--- a/internal/civisibility/integrations/manual_api_common.go
+++ b/internal/civisibility/integrations/manual_api_common.go
@@ -37,7 +37,7 @@ func (c *ciVisibilityCommon) Context() context.Context { return c.ctx }
 func (c *ciVisibilityCommon) StartTime() time.Time { return c.startTime }
 
 // SetError sets an error on the event.
-func (c *ciVisibilityCommon) SetError(options ...DdErrorOption) {
+func (c *ciVisibilityCommon) SetError(options ...ErrorOption) {
 	defaults := &tslvErrorOptions{}
 	for _, o := range options {
 		o(defaults)

--- a/internal/civisibility/integrations/manual_api_common.go
+++ b/internal/civisibility/integrations/manual_api_common.go
@@ -1,0 +1,98 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package integrations
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/constants"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils"
+)
+
+// common
+var _ ddTslvEvent = (*ciVisibilityCommon)(nil)
+
+// ciVisibilityCommon is a struct that implements the ddTslvEvent interface and provides common functionality for CI visibility.
+type ciVisibilityCommon struct {
+	startTime time.Time
+
+	tags   []tracer.StartSpanOption
+	span   tracer.Span
+	ctx    context.Context
+	mutex  sync.Mutex
+	closed bool
+}
+
+// Context returns the context of the event.
+func (c *ciVisibilityCommon) Context() context.Context { return c.ctx }
+
+// StartTime returns the start time of the event.
+func (c *ciVisibilityCommon) StartTime() time.Time { return c.startTime }
+
+// SetError sets an error on the event.
+func (c *ciVisibilityCommon) SetError(options ...DdErrorOption) {
+	defaults := &tslvErrorOptions{}
+	for _, o := range options {
+		o(defaults)
+	}
+
+	// if there is an error, set the span with the error
+	if defaults.err != nil {
+		c.span.SetTag(ext.Error, defaults.err)
+		return
+	}
+
+	// if there is no error, set the span with error the error info
+
+	// set the span with error:1
+	c.span.SetTag(ext.Error, true)
+
+	// set the error type
+	if defaults.errType != "" {
+		c.span.SetTag(ext.ErrorType, defaults.errType)
+	}
+
+	// set the error message
+	if defaults.message != "" {
+		c.span.SetTag(ext.ErrorMsg, defaults.message)
+	}
+
+	// set the error stacktrace
+	if defaults.callstack != "" {
+		c.span.SetTag(ext.ErrorStack, defaults.callstack)
+	}
+}
+
+// SetTag sets a tag on the event.
+func (c *ciVisibilityCommon) SetTag(key string, value interface{}) { c.span.SetTag(key, value) }
+
+// fillCommonTags adds common tags to the span options for CI visibility.
+func fillCommonTags(opts []tracer.StartSpanOption) []tracer.StartSpanOption {
+	opts = append(opts, []tracer.StartSpanOption{
+		tracer.Tag(constants.Origin, constants.CIAppTestOrigin),
+		tracer.Tag(ext.ManualKeep, true),
+	}...)
+
+	// Apply CI tags
+	for k, v := range utils.GetCITags() {
+		// Ignore the test session name (sent at the payload metadata level, see `civisibility_payload.go`)
+		if k == constants.TestSessionName {
+			continue
+		}
+		opts = append(opts, tracer.Tag(k, v))
+	}
+
+	// Apply CI metrics
+	for k, v := range utils.GetCIMetrics() {
+		opts = append(opts, tracer.Tag(k, v))
+	}
+
+	return opts
+}

--- a/internal/civisibility/integrations/manual_api_ddtest.go
+++ b/internal/civisibility/integrations/manual_api_ddtest.go
@@ -150,15 +150,8 @@ func (t *tslvTest) Close(status TestResultStatus, options ...DdTestCloseOption) 
 }
 
 // SetError sets an error on the test and marks the suite and module as having an error.
-func (t *tslvTest) SetError(err error) {
-	t.ciVisibilityCommon.SetError(err)
-	t.Suite().SetTag(ext.Error, true)
-	t.Suite().Module().SetTag(ext.Error, true)
-}
-
-// SetErrorInfo sets detailed error information on the test and marks the suite and module as having an error.
-func (t *tslvTest) SetErrorInfo(errType string, message string, callstack string) {
-	t.ciVisibilityCommon.SetErrorInfo(errType, message, callstack)
+func (t *tslvTest) SetError(options ...DdErrorOption) {
+	t.ciVisibilityCommon.SetError(options...)
 	t.Suite().SetTag(ext.Error, true)
 	t.Suite().Module().SetTag(ext.Error, true)
 }

--- a/internal/civisibility/integrations/manual_api_ddtest.go
+++ b/internal/civisibility/integrations/manual_api_ddtest.go
@@ -23,8 +23,8 @@ import (
 
 // Test
 
-// Ensures that tslvTest implements the DdTest interface.
-var _ DdTest = (*tslvTest)(nil)
+// Ensures that tslvTest implements the Test interface.
+var _ Test = (*tslvTest)(nil)
 
 // tslvTest implements the DdTest interface and represents an individual test within a suite.
 type tslvTest struct {
@@ -35,7 +35,7 @@ type tslvTest struct {
 }
 
 // createTest initializes a new test within a given suite.
-func createTest(suite *tslvTestSuite, name string, startTime time.Time) DdTest {
+func createTest(suite *tslvTestSuite, name string, startTime time.Time) Test {
 	if suite == nil {
 		return nil
 	}
@@ -90,10 +90,10 @@ func (t *tslvTest) TestID() uint64 {
 func (t *tslvTest) Name() string { return t.name }
 
 // Suite returns the suite to which the test belongs.
-func (t *tslvTest) Suite() DdTestSuite { return t.suite }
+func (t *tslvTest) Suite() TestSuite { return t.suite }
 
 // Close closes the test with the given status.
-func (t *tslvTest) Close(status TestResultStatus, options ...DdTestCloseOption) {
+func (t *tslvTest) Close(status TestResultStatus, options ...TestCloseOption) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 	if t.closed {
@@ -127,7 +127,7 @@ func (t *tslvTest) Close(status TestResultStatus, options ...DdTestCloseOption) 
 }
 
 // SetError sets an error on the test and marks the suite and module as having an error.
-func (t *tslvTest) SetError(options ...DdErrorOption) {
+func (t *tslvTest) SetError(options ...ErrorOption) {
 	t.ciVisibilityCommon.SetError(options...)
 	t.Suite().SetTag(ext.Error, true)
 	t.Suite().Module().SetTag(ext.Error, true)

--- a/internal/civisibility/integrations/manual_api_ddtest.go
+++ b/internal/civisibility/integrations/manual_api_ddtest.go
@@ -19,6 +19,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/constants"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils/telemetry"
 )
 
 // Test
@@ -78,6 +79,8 @@ func createTest(suite *tslvTestSuite, name string, startTime time.Time) Test {
 	// Note: if the process is killed some tests will not be closed and will be lost. This is a known limitation.
 	// We will not close it because there's no a good test status to report in this case, and we don't want to report a false positive (pass, fail, or skip).
 
+	// Creating telemetry event created
+	telemetry.EventCreated(t.suite.module.framework, telemetry.TestEventType)
 	return t
 }
 
@@ -124,6 +127,9 @@ func (t *tslvTest) Close(status TestResultStatus, options ...TestCloseOption) {
 
 	t.span.Finish(tracer.FinishTime(defaults.finishTime))
 	t.closed = true
+
+	// Creating telemetry event finished
+	telemetry.EventFinished(t.suite.module.framework, telemetry.TestEventType)
 }
 
 // SetError sets an error on the test and marks the suite and module as having an error.

--- a/internal/civisibility/integrations/manual_api_ddtest.go
+++ b/internal/civisibility/integrations/manual_api_ddtest.go
@@ -92,29 +92,6 @@ func (t *tslvTest) Name() string { return t.name }
 // Suite returns the suite to which the test belongs.
 func (t *tslvTest) Suite() DdTestSuite { return t.suite }
 
-// DdTestCloseOption represents an option for closing a test.
-type DdTestCloseOption func(*tslvTestCloseOptions)
-
-// tslvTestCloseOptions represents the options for closing a test.
-type tslvTestCloseOptions struct {
-	finishTime time.Time
-	skipReason string
-}
-
-// WithTestFinishTime sets the finish time of the test.
-func WithTestFinishTime(finishTime time.Time) DdTestCloseOption {
-	return func(o *tslvTestCloseOptions) {
-		o.finishTime = finishTime
-	}
-}
-
-// WithTestSkipReason sets the skip reason of the test.
-func WithTestSkipReason(skipReason string) DdTestCloseOption {
-	return func(o *tslvTestCloseOptions) {
-		o.skipReason = skipReason
-	}
-}
-
 // Close closes the test with the given status.
 func (t *tslvTest) Close(status TestResultStatus, options ...DdTestCloseOption) {
 	t.mutex.Lock()

--- a/internal/civisibility/integrations/manual_api_ddtest.go
+++ b/internal/civisibility/integrations/manual_api_ddtest.go
@@ -229,6 +229,7 @@ func (t *tslvTest) SetTestFunc(fn *runtime.Func) {
 		// if the function is marked as unskippable, set the appropriate tag
 		if isUnskippable {
 			t.SetTag(constants.TestUnskippable, "true")
+			telemetry.ITRUnskippable(telemetry.TestEventType)
 			t.ctx = context.WithValue(t.ctx, constants.TestUnskippable, true)
 		}
 	}

--- a/internal/civisibility/integrations/manual_api_ddtestmodule.go
+++ b/internal/civisibility/integrations/manual_api_ddtestmodule.go
@@ -18,8 +18,8 @@ import (
 
 // Test Module
 
-// Ensures that tslvTestModule implements the DdTestModule interface.
-var _ DdTestModule = (*tslvTestModule)(nil)
+// Ensures that tslvTestModule implements the TestModule interface.
+var _ TestModule = (*tslvTestModule)(nil)
 
 // tslvTestModule implements the DdTestModule interface and represents a module within a test session.
 type tslvTestModule struct {
@@ -29,11 +29,11 @@ type tslvTestModule struct {
 	name      string
 	framework string
 
-	suites map[string]DdTestSuite
+	suites map[string]TestSuite
 }
 
 // createTestModule initializes a new test module within a given session.
-func createTestModule(session *tslvTestSession, name string, framework string, frameworkVersion string, startTime time.Time) DdTestModule {
+func createTestModule(session *tslvTestSession, name string, framework string, frameworkVersion string, startTime time.Time) TestModule {
 	// Ensure CI visibility is properly configured.
 	EnsureCiVisibilityInitialization()
 
@@ -75,7 +75,7 @@ func createTestModule(session *tslvTestSession, name string, framework string, f
 		moduleID:  moduleID,
 		name:      name,
 		framework: framework,
-		suites:    map[string]DdTestSuite{},
+		suites:    map[string]TestSuite{},
 		ciVisibilityCommon: ciVisibilityCommon{
 			startTime: startTime,
 			tags:      moduleTags,
@@ -104,10 +104,10 @@ func (t *tslvTestModule) Name() string { return t.name }
 func (t *tslvTestModule) Framework() string { return t.framework }
 
 // Session returns the test session to which the test module belongs.
-func (t *tslvTestModule) Session() DdTestSession { return t.session }
+func (t *tslvTestModule) Session() TestSession { return t.session }
 
 // Close closes the test module.
-func (t *tslvTestModule) Close(options ...DdTestModuleCloseOption) {
+func (t *tslvTestModule) Close(options ...TestModuleCloseOption) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 	if t.closed {
@@ -126,7 +126,7 @@ func (t *tslvTestModule) Close(options ...DdTestModuleCloseOption) {
 	for _, suite := range t.suites {
 		suite.Close()
 	}
-	t.suites = map[string]DdTestSuite{}
+	t.suites = map[string]TestSuite{}
 
 	t.span.Finish(tracer.FinishTime(defaults.finishTime))
 	t.closed = true
@@ -136,7 +136,7 @@ func (t *tslvTestModule) Close(options ...DdTestModuleCloseOption) {
 }
 
 // GetOrCreateSuite returns an existing suite or creates a new one with the given name.
-func (t *tslvTestModule) GetOrCreateSuite(name string, options ...DdTestSuiteStartOption) DdTestSuite {
+func (t *tslvTestModule) GetOrCreateSuite(name string, options ...TestSuiteStartOption) TestSuite {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
@@ -149,7 +149,7 @@ func (t *tslvTestModule) GetOrCreateSuite(name string, options ...DdTestSuiteSta
 		defaults.startTime = time.Now()
 	}
 
-	var suite DdTestSuite
+	var suite TestSuite
 	if v, ok := t.suites[name]; ok {
 		suite = v
 	} else {

--- a/internal/civisibility/integrations/manual_api_ddtestmodule.go
+++ b/internal/civisibility/integrations/manual_api_ddtestmodule.go
@@ -8,12 +8,12 @@ package integrations
 import (
 	"context"
 	"fmt"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils/telemetry"
 	"strings"
 	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/constants"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils/telemetry"
 )
 
 // Test Module
@@ -106,21 +106,6 @@ func (t *tslvTestModule) Framework() string { return t.framework }
 // Session returns the test session to which the test module belongs.
 func (t *tslvTestModule) Session() DdTestSession { return t.session }
 
-// DdTestModuleCloseOption represents an option for closing a test module.
-type DdTestModuleCloseOption func(*tslvTestModuleCloseOptions)
-
-// tslvTestModuleCloseOptions represents the options for closing a test module.
-type tslvTestModuleCloseOptions struct {
-	finishTime time.Time
-}
-
-// WithTestModuleFinishTime sets the finish time for closing the test module.
-func WithTestModuleFinishTime(finishTime time.Time) DdTestModuleCloseOption {
-	return func(o *tslvTestModuleCloseOptions) {
-		o.finishTime = finishTime
-	}
-}
-
 // Close closes the test module.
 func (t *tslvTestModule) Close(options ...DdTestModuleCloseOption) {
 	t.mutex.Lock()
@@ -148,21 +133,6 @@ func (t *tslvTestModule) Close(options ...DdTestModuleCloseOption) {
 
 	// Creating telemetry event finished
 	telemetry.EventFinished(t.framework, telemetry.ModuleEventType)
-}
-
-// DdTestSuiteStartOption represents an option for starting a test suite.
-type DdTestSuiteStartOption func(*tslvTestSuiteStartOptions)
-
-// tslvTestSuiteStartOptions represents the options for starting a test suite.
-type tslvTestSuiteStartOptions struct {
-	startTime time.Time
-}
-
-// WithTestSuiteStartTime sets the start time for starting a test suite.
-func WithTestSuiteStartTime(startTime time.Time) DdTestSuiteStartOption {
-	return func(o *tslvTestSuiteStartOptions) {
-		o.startTime = startTime
-	}
 }
 
 // GetOrCreateSuite returns an existing suite or creates a new one with the given name.

--- a/internal/civisibility/integrations/manual_api_ddtestsession.go
+++ b/internal/civisibility/integrations/manual_api_ddtestsession.go
@@ -20,8 +20,8 @@ import (
 
 // Test Session
 
-// Ensures that tslvTestSession implements the DdTestSession interface.
-var _ DdTestSession = (*tslvTestSession)(nil)
+// Ensures that tslvTestSession implements the TestSession interface.
+var _ TestSession = (*tslvTestSession)(nil)
 
 // tslvTestSession implements the DdTestSession interface and represents a session for a set of tests.
 type tslvTestSession struct {
@@ -32,11 +32,11 @@ type tslvTestSession struct {
 	framework        string
 	frameworkVersion string
 
-	modules map[string]DdTestModule
+	modules map[string]TestModule
 }
 
 // CreateTestSession initializes a new test session with the given command and working directory.
-func CreateTestSession(options ...DdTestSessionStartOption) DdTestSession {
+func CreateTestSession(options ...TestSessionStartOption) TestSession {
 	defaults := &tslvTestSessionStartOptions{}
 	for _, f := range options {
 		f(defaults)
@@ -91,7 +91,7 @@ func CreateTestSession(options ...DdTestSessionStartOption) DdTestSession {
 		workingDirectory: defaults.workingDirectory,
 		framework:        defaults.framework,
 		frameworkVersion: defaults.frameworkVersion,
-		modules:          map[string]DdTestModule{},
+		modules:          map[string]TestModule{},
 		ciVisibilityCommon: ciVisibilityCommon{
 			startTime: defaults.startTime,
 			tags:      sessionTags,
@@ -123,7 +123,7 @@ func (t *tslvTestSession) Framework() string { return t.framework }
 func (t *tslvTestSession) WorkingDirectory() string { return t.workingDirectory }
 
 // Close closes the test session with the given exit code.
-func (t *tslvTestSession) Close(exitCode int, options ...DdTestSessionCloseOption) {
+func (t *tslvTestSession) Close(exitCode int, options ...TestSessionCloseOption) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 	if t.closed {
@@ -142,7 +142,7 @@ func (t *tslvTestSession) Close(exitCode int, options ...DdTestSessionCloseOptio
 	for _, m := range t.modules {
 		m.Close()
 	}
-	t.modules = map[string]DdTestModule{}
+	t.modules = map[string]TestModule{}
 
 	t.span.SetTag(constants.TestCommandExitCode, exitCode)
 	if exitCode == 0 {
@@ -161,7 +161,7 @@ func (t *tslvTestSession) Close(exitCode int, options ...DdTestSessionCloseOptio
 }
 
 // GetOrCreateModule returns an existing module or creates a new one with the given name, framework, framework version, and start time.
-func (t *tslvTestSession) GetOrCreateModule(name string, options ...DdTestModuleStartOption) DdTestModule {
+func (t *tslvTestSession) GetOrCreateModule(name string, options ...TestModuleStartOption) TestModule {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
@@ -178,7 +178,7 @@ func (t *tslvTestSession) GetOrCreateModule(name string, options ...DdTestModule
 		defaults.startTime = time.Now()
 	}
 
-	var mod DdTestModule
+	var mod TestModule
 	if v, ok := t.modules[name]; ok {
 		mod = v
 	} else {

--- a/internal/civisibility/integrations/manual_api_ddtestsession.go
+++ b/internal/civisibility/integrations/manual_api_ddtestsession.go
@@ -35,47 +35,6 @@ type tslvTestSession struct {
 	modules map[string]DdTestModule
 }
 
-// DdTestSessionStartOption represents an option that can be passed to CreateTestSession.
-type DdTestSessionStartOption func(*tslvTestSessionStartOptions)
-
-// tslvTestSessionStartOptions contains the options for creating a new test session.
-type tslvTestSessionStartOptions struct {
-	command          string
-	workingDirectory string
-	framework        string
-	frameworkVersion string
-	startTime        time.Time
-}
-
-// WithTestSessionCommand sets the command used to run the test session.
-func WithTestSessionCommand(command string) DdTestSessionStartOption {
-	return func(o *tslvTestSessionStartOptions) {
-		o.command = command
-	}
-}
-
-// WithTestSessionWorkingDirectory sets the working directory of the test session.
-func WithTestSessionWorkingDirectory(workingDirectory string) DdTestSessionStartOption {
-	return func(o *tslvTestSessionStartOptions) {
-		o.workingDirectory = workingDirectory
-	}
-}
-
-// WithTestSessionFramework sets the testing framework used in the test session.
-func WithTestSessionFramework(framework, frameworkVersion string) DdTestSessionStartOption {
-	return func(o *tslvTestSessionStartOptions) {
-		o.framework = framework
-		o.frameworkVersion = frameworkVersion
-	}
-}
-
-// WithTestSessionStartTime sets the start time of the test session.
-func WithTestSessionStartTime(startTime time.Time) DdTestSessionStartOption {
-	return func(o *tslvTestSessionStartOptions) {
-		o.startTime = startTime
-	}
-}
-
 // CreateTestSession initializes a new test session with the given command and working directory.
 func CreateTestSession(options ...DdTestSessionStartOption) DdTestSession {
 	defaults := &tslvTestSessionStartOptions{}
@@ -163,21 +122,6 @@ func (t *tslvTestSession) Framework() string { return t.framework }
 // WorkingDirectory returns the working directory of the test session.
 func (t *tslvTestSession) WorkingDirectory() string { return t.workingDirectory }
 
-// DdTestSessionCloseOption represents an option that can be passed to Close.
-type DdTestSessionCloseOption func(*tslvTestSessionCloseOptions)
-
-// tslvTestSessionCloseOptions contains the options for closing a test session.
-type tslvTestSessionCloseOptions struct {
-	finishTime time.Time
-}
-
-// WithTestSessionFinishTime sets the finish time of the test session.
-func WithTestSessionFinishTime(finishTime time.Time) DdTestSessionCloseOption {
-	return func(o *tslvTestSessionCloseOptions) {
-		o.finishTime = finishTime
-	}
-}
-
 // Close closes the test session with the given exit code.
 func (t *tslvTestSession) Close(exitCode int, options ...DdTestSessionCloseOption) {
 	t.mutex.Lock()
@@ -214,31 +158,6 @@ func (t *tslvTestSession) Close(exitCode int, options ...DdTestSessionCloseOptio
 	// Creating telemetry event finished
 	telemetry.EventFinished(t.framework, telemetry.GetSessionTestingEventType())
 	tracer.Flush()
-}
-
-// DdTestModuleStartOption represents an option that can be passed to GetOrCreateModule.
-type DdTestModuleStartOption func(*tslvTestModuleStartOptions)
-
-// tslvTestModuleOptions contains the options for creating a new test module.
-type tslvTestModuleStartOptions struct {
-	framework        string
-	frameworkVersion string
-	startTime        time.Time
-}
-
-// WithTestModuleFramework sets the testing framework used by the test module.
-func WithTestModuleFramework(framework, frameworkVersion string) DdTestModuleStartOption {
-	return func(o *tslvTestModuleStartOptions) {
-		o.framework = framework
-		o.frameworkVersion = frameworkVersion
-	}
-}
-
-// WithTestModuleStartTime sets the start time of the test module.
-func WithTestModuleStartTime(startTime time.Time) DdTestModuleStartOption {
-	return func(o *tslvTestModuleStartOptions) {
-		o.startTime = startTime
-	}
 }
 
 // GetOrCreateModule returns an existing module or creates a new one with the given name, framework, framework version, and start time.

--- a/internal/civisibility/integrations/manual_api_ddtestsession.go
+++ b/internal/civisibility/integrations/manual_api_ddtestsession.go
@@ -104,7 +104,9 @@ func CreateTestSession(options ...TestSessionStartOption) TestSession {
 	PushCiVisibilityCloseAction(func() { s.Close(1) })
 
 	// Creating telemetry event created
-	telemetry.EventCreated(s.framework, telemetry.GetSessionTestingEventType())
+	hasCodeOwners := utils.GetCodeOwners() != nil
+	_, hasCiProvider := utils.GetCITags()[constants.CIProviderName]
+	telemetry.EventCreated(s.framework, telemetry.GetSessionTestingEventType(hasCodeOwners, hasCiProvider))
 	return s
 }
 
@@ -156,7 +158,9 @@ func (t *tslvTestSession) Close(exitCode int, options ...TestSessionCloseOption)
 	t.closed = true
 
 	// Creating telemetry event finished
-	telemetry.EventFinished(t.framework, telemetry.GetSessionTestingEventType())
+	hasCodeOwners := utils.GetCodeOwners() != nil
+	_, hasCiProvider := utils.GetCITags()[constants.CIProviderName]
+	telemetry.EventFinished(t.framework, telemetry.GetSessionTestingEventType(hasCodeOwners, hasCiProvider))
 	tracer.Flush()
 }
 

--- a/internal/civisibility/integrations/manual_api_ddtestsession.go
+++ b/internal/civisibility/integrations/manual_api_ddtestsession.go
@@ -204,7 +204,7 @@ func (t *tslvTestSession) Close(exitCode int, options ...DdTestSessionCloseOptio
 	if exitCode == 0 {
 		t.span.SetTag(constants.TestStatus, constants.TestStatusPass)
 	} else {
-		t.SetErrorInfo("ExitCode", "exit code is not zero.", "")
+		t.SetError(WithErrorInfo("ExitCode", "exit code is not zero.", ""))
 		t.span.SetTag(constants.TestStatus, constants.TestStatusFail)
 	}
 

--- a/internal/civisibility/integrations/manual_api_ddtestsession.go
+++ b/internal/civisibility/integrations/manual_api_ddtestsession.go
@@ -104,9 +104,14 @@ func CreateTestSession(options ...TestSessionStartOption) TestSession {
 	PushCiVisibilityCloseAction(func() { s.Close(1) })
 
 	// Creating telemetry event created
-	hasCodeOwners := utils.GetCodeOwners() != nil
-	_, hasCiProvider := utils.GetCITags()[constants.CIProviderName]
-	telemetry.EventCreated(s.framework, telemetry.GetSessionTestingEventType(hasCodeOwners, hasCiProvider))
+	testingEventType := telemetry.SessionEventType
+	if utils.GetCodeOwners() != nil {
+		testingEventType = append(testingEventType, telemetry.HasCodeOwnerEventType...)
+	}
+	if _, hasCiProvider := utils.GetCITags()[constants.CIProviderName]; !hasCiProvider {
+		testingEventType = append(testingEventType, telemetry.UnsupportedCiEventType...)
+	}
+	telemetry.EventCreated(s.framework, testingEventType)
 	return s
 }
 
@@ -158,9 +163,14 @@ func (t *tslvTestSession) Close(exitCode int, options ...TestSessionCloseOption)
 	t.closed = true
 
 	// Creating telemetry event finished
-	hasCodeOwners := utils.GetCodeOwners() != nil
-	_, hasCiProvider := utils.GetCITags()[constants.CIProviderName]
-	telemetry.EventFinished(t.framework, telemetry.GetSessionTestingEventType(hasCodeOwners, hasCiProvider))
+	testingEventType := telemetry.SessionEventType
+	if utils.GetCodeOwners() != nil {
+		testingEventType = append(testingEventType, telemetry.HasCodeOwnerEventType...)
+	}
+	if _, hasCiProvider := utils.GetCITags()[constants.CIProviderName]; !hasCiProvider {
+		testingEventType = append(testingEventType, telemetry.UnsupportedCiEventType...)
+	}
+	telemetry.EventFinished(t.framework, testingEventType)
 	tracer.Flush()
 }
 

--- a/internal/civisibility/integrations/manual_api_ddtestsuite.go
+++ b/internal/civisibility/integrations/manual_api_ddtestsuite.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/constants"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils/telemetry"
 )
 
 // Test Suite
@@ -73,6 +74,8 @@ func createTestSuite(module *tslvTestModule, name string, startTime time.Time) T
 	// Ensure to close everything before CI visibility exits. In CI visibility mode, we try to never lose data.
 	PushCiVisibilityCloseAction(func() { suite.Close() })
 
+	// Creating telemetry event created
+	telemetry.EventCreated(module.framework, telemetry.SuiteEventType)
 	return suite
 }
 
@@ -106,6 +109,9 @@ func (t *tslvTestSuite) Close(options ...TestSuiteCloseOption) {
 
 	t.span.Finish(tracer.FinishTime(defaults.finishTime))
 	t.closed = true
+
+	// Creating telemetry event finished
+	telemetry.EventFinished(t.module.framework, telemetry.ModuleEventType)
 }
 
 // SetError sets an error on the test suite and marks the module as having an error.

--- a/internal/civisibility/integrations/manual_api_ddtestsuite.go
+++ b/internal/civisibility/integrations/manual_api_ddtestsuite.go
@@ -111,7 +111,7 @@ func (t *tslvTestSuite) Close(options ...TestSuiteCloseOption) {
 	t.closed = true
 
 	// Creating telemetry event finished
-	telemetry.EventFinished(t.module.framework, telemetry.ModuleEventType)
+	telemetry.EventFinished(t.module.framework, telemetry.SuiteEventType)
 }
 
 // SetError sets an error on the test suite and marks the module as having an error.

--- a/internal/civisibility/integrations/manual_api_ddtestsuite.go
+++ b/internal/civisibility/integrations/manual_api_ddtestsuite.go
@@ -124,14 +124,8 @@ func (t *tslvTestSuite) Close(options ...DdTestSuiteCloseOption) {
 }
 
 // SetError sets an error on the test suite and marks the module as having an error.
-func (t *tslvTestSuite) SetError(err error) {
-	t.ciVisibilityCommon.SetError(err)
-	t.Module().SetTag(ext.Error, true)
-}
-
-// SetErrorInfo sets detailed error information on the test suite and marks the module as having an error.
-func (t *tslvTestSuite) SetErrorInfo(errType string, message string, callstack string) {
-	t.ciVisibilityCommon.SetErrorInfo(errType, message, callstack)
+func (t *tslvTestSuite) SetError(options ...DdErrorOption) {
+	t.ciVisibilityCommon.SetError(options...)
 	t.Module().SetTag(ext.Error, true)
 }
 

--- a/internal/civisibility/integrations/manual_api_ddtestsuite.go
+++ b/internal/civisibility/integrations/manual_api_ddtestsuite.go
@@ -87,21 +87,6 @@ func (t *tslvTestSuite) Name() string { return t.name }
 // Module returns the module to which the test suite belongs.
 func (t *tslvTestSuite) Module() DdTestModule { return t.module }
 
-// DdTestSuiteCloseOption represents an option for closing a test suite.
-type DdTestSuiteCloseOption func(*tslvTestSuiteCloseOptions)
-
-// tslvTestSuiteCloseOptions represents the options for closing a test suite.
-type tslvTestSuiteCloseOptions struct {
-	finishTime time.Time
-}
-
-// WithTestSuiteFinishTime sets the finish time for closing the test suite.
-func WithTestSuiteFinishTime(finishTime time.Time) DdTestSuiteCloseOption {
-	return func(o *tslvTestSuiteCloseOptions) {
-		o.finishTime = finishTime
-	}
-}
-
 // Close closes the test suite with the given finish time.
 func (t *tslvTestSuite) Close(options ...DdTestSuiteCloseOption) {
 	t.mutex.Lock()
@@ -127,21 +112,6 @@ func (t *tslvTestSuite) Close(options ...DdTestSuiteCloseOption) {
 func (t *tslvTestSuite) SetError(options ...DdErrorOption) {
 	t.ciVisibilityCommon.SetError(options...)
 	t.Module().SetTag(ext.Error, true)
-}
-
-// DdTestStartOption represents an option for starting a test.
-type DdTestStartOption func(*tslvTestStartOptions)
-
-// tslvTestStartOptions represents the options for starting a test.
-type tslvTestStartOptions struct {
-	startTime time.Time
-}
-
-// WithTestStartTime sets the start time for starting a test.
-func WithTestStartTime(startTime time.Time) DdTestStartOption {
-	return func(o *tslvTestStartOptions) {
-		o.startTime = startTime
-	}
 }
 
 // CreateTest creates a new test within the suite.

--- a/internal/civisibility/integrations/manual_api_ddtestsuite.go
+++ b/internal/civisibility/integrations/manual_api_ddtestsuite.go
@@ -18,8 +18,8 @@ import (
 
 // Test Suite
 
-// Ensures that tslvTestSuite implements the DdTestSuite interface.
-var _ DdTestSuite = (*tslvTestSuite)(nil)
+// Ensures that tslvTestSuite implements the TestSuite interface.
+var _ TestSuite = (*tslvTestSuite)(nil)
 
 // tslvTestSuite implements the DdTestSuite interface and represents a suite of tests within a module.
 type tslvTestSuite struct {
@@ -30,7 +30,7 @@ type tslvTestSuite struct {
 }
 
 // createTestSuite initializes a new test suite within a given module.
-func createTestSuite(module *tslvTestModule, name string, startTime time.Time) DdTestSuite {
+func createTestSuite(module *tslvTestModule, name string, startTime time.Time) TestSuite {
 	if module == nil {
 		return nil
 	}
@@ -85,10 +85,10 @@ func (t *tslvTestSuite) SuiteID() uint64 {
 func (t *tslvTestSuite) Name() string { return t.name }
 
 // Module returns the module to which the test suite belongs.
-func (t *tslvTestSuite) Module() DdTestModule { return t.module }
+func (t *tslvTestSuite) Module() TestModule { return t.module }
 
 // Close closes the test suite with the given finish time.
-func (t *tslvTestSuite) Close(options ...DdTestSuiteCloseOption) {
+func (t *tslvTestSuite) Close(options ...TestSuiteCloseOption) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 	if t.closed {
@@ -109,13 +109,13 @@ func (t *tslvTestSuite) Close(options ...DdTestSuiteCloseOption) {
 }
 
 // SetError sets an error on the test suite and marks the module as having an error.
-func (t *tslvTestSuite) SetError(options ...DdErrorOption) {
+func (t *tslvTestSuite) SetError(options ...ErrorOption) {
 	t.ciVisibilityCommon.SetError(options...)
 	t.Module().SetTag(ext.Error, true)
 }
 
 // CreateTest creates a new test within the suite.
-func (t *tslvTestSuite) CreateTest(name string, options ...DdTestStartOption) DdTest {
+func (t *tslvTestSuite) CreateTest(name string, options ...TestStartOption) Test {
 	defaults := &tslvTestStartOptions{}
 	for _, opt := range options {
 		opt(defaults)

--- a/internal/civisibility/integrations/manual_api_mocktracer_test.go
+++ b/internal/civisibility/integrations/manual_api_mocktracer_test.go
@@ -126,7 +126,7 @@ func TestModule(t *testing.T) {
 	now := time.Now()
 	session, module := createDDTestModule(now)
 	defer func() { session.Close(0) }()
-	module.SetErrorInfo("my-type", "my-message", "my-stack")
+	module.SetError(WithErrorInfo("my-type", "my-message", "my-stack"))
 
 	assert.NotNil(module.Context())
 	assert.Equal("my-module", module.Name())
@@ -176,7 +176,7 @@ func TestSuite(t *testing.T) {
 		session.Close(0)
 		module.Close()
 	}()
-	suite.SetErrorInfo("my-type", "my-message", "my-stack")
+	suite.SetError(WithErrorInfo("my-type", "my-message", "my-stack"))
 
 	assert.NotNil(suite.Context())
 	assert.Equal("my-suite", suite.Name())
@@ -228,8 +228,8 @@ func Test(t *testing.T) {
 		module.Close()
 		suite.Close()
 	}()
-	test.SetError(errors.New("we keep the last error"))
-	test.SetErrorInfo("my-type", "my-message", "my-stack")
+	test.SetError(WithError(errors.New("we keep the last error")))
+	test.SetError(WithErrorInfo("my-type", "my-message", "my-stack"))
 	pc, _, _, _ := runtime.Caller(0)
 	test.SetTestFunc(runtime.FuncForPC(pc))
 
@@ -259,8 +259,8 @@ func TestWithInnerFunc(t *testing.T) {
 		module.Close()
 		suite.Close()
 	}()
-	test.SetError(errors.New("we keep the last error"))
-	test.SetErrorInfo("my-type", "my-message", "my-stack")
+	test.SetError(WithError(errors.New("we keep the last error")))
+	test.SetError(WithErrorInfo("my-type", "my-message", "my-stack"))
 	func() {
 		pc, _, _, _ := runtime.Caller(0)
 		test.SetTestFunc(runtime.FuncForPC(pc))

--- a/internal/civisibility/integrations/manual_api_mocktracer_test.go
+++ b/internal/civisibility/integrations/manual_api_mocktracer_test.go
@@ -30,28 +30,28 @@ func TestMain(m *testing.M) {
 }
 
 func createDDTestSession(now time.Time) DdTestSession {
-	session := CreateTestSessionWith("my-command", "/tmp/wd", "my-testing-framework", now)
+	session := CreateTestSession(WithTestSessionCommand("my-command"), WithTestSessionWorkingDirectory("/tmp/wd"), WithTestSessionFramework("my-testing-framework", "framework-version"), WithTestSessionStartTime(now))
 	session.SetTag("my-tag", "my-value")
 	return session
 }
 
 func createDDTestModule(now time.Time) (DdTestSession, DdTestModule) {
 	session := createDDTestSession(now)
-	module := session.GetOrCreateModuleWithFrameworkAndStartTime("my-module", "my-module-framework", "framework-version", now)
+	module := session.GetOrCreateModule("my-module", WithTestModuleFramework("my-module-framework", "framework-version"), WithTestModuleStartTime(now))
 	module.SetTag("my-tag", "my-value")
 	return session, module
 }
 
 func createDDTestSuite(now time.Time) (DdTestSession, DdTestModule, DdTestSuite) {
 	session, module := createDDTestModule(now)
-	suite := module.GetOrCreateSuiteWithStartTime("my-suite", now)
+	suite := module.GetOrCreateSuite("my-suite", WithTestSuiteStartTime(now))
 	suite.SetTag("my-tag", "my-value")
 	return session, module, suite
 }
 
 func createDDTest(now time.Time) (DdTestSession, DdTestModule, DdTestSuite, DdTest) {
 	session, module, suite := createDDTestSuite(now)
-	test := suite.CreateTestWithStartTime("my-test", now)
+	test := suite.CreateTest("my-test", WithTestStartTime(now))
 	test.SetTag("my-tag", "my-value")
 	return session, module, suite, test
 }

--- a/internal/civisibility/integrations/manual_api_mocktracer_test.go
+++ b/internal/civisibility/integrations/manual_api_mocktracer_test.go
@@ -29,27 +29,27 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func createDDTestSession(now time.Time) DdTestSession {
+func createDDTestSession(now time.Time) TestSession {
 	session := CreateTestSession(WithTestSessionCommand("my-command"), WithTestSessionWorkingDirectory("/tmp/wd"), WithTestSessionFramework("my-testing-framework", "framework-version"), WithTestSessionStartTime(now))
 	session.SetTag("my-tag", "my-value")
 	return session
 }
 
-func createDDTestModule(now time.Time) (DdTestSession, DdTestModule) {
+func createDDTestModule(now time.Time) (TestSession, TestModule) {
 	session := createDDTestSession(now)
 	module := session.GetOrCreateModule("my-module", WithTestModuleFramework("my-module-framework", "framework-version"), WithTestModuleStartTime(now))
 	module.SetTag("my-tag", "my-value")
 	return session, module
 }
 
-func createDDTestSuite(now time.Time) (DdTestSession, DdTestModule, DdTestSuite) {
+func createDDTestSuite(now time.Time) (TestSession, TestModule, TestSuite) {
 	session, module := createDDTestModule(now)
 	suite := module.GetOrCreateSuite("my-suite", WithTestSuiteStartTime(now))
 	suite.SetTag("my-tag", "my-value")
 	return session, module, suite
 }
 
-func createDDTest(now time.Time) (DdTestSession, DdTestModule, DdTestSuite, DdTest) {
+func createDDTest(now time.Time) (TestSession, TestModule, TestSuite, Test) {
 	session, module, suite := createDDTestSuite(now)
 	test := suite.CreateTest("my-test", WithTestStartTime(now))
 	test.SetTag("my-tag", "my-value")
@@ -76,7 +76,7 @@ func commonAssertions(assert *assert.Assertions, sessionSpan mocktracer.Span) {
 	assert.Contains(spanTags, constants.GitCommitSHA)
 }
 
-func TestSession(t *testing.T) {
+func TestTestSession(t *testing.T) {
 	mockTracer.Reset()
 	assert := assert.New(t)
 
@@ -119,7 +119,7 @@ func sessionAssertions(assert *assert.Assertions, now time.Time, sessionSpan moc
 	commonAssertions(assert, sessionSpan)
 }
 
-func TestModule(t *testing.T) {
+func TestTestModule(t *testing.T) {
 	mockTracer.Reset()
 	assert := assert.New(t)
 
@@ -166,7 +166,7 @@ func moduleAssertions(assert *assert.Assertions, now time.Time, moduleSpan mockt
 	commonAssertions(assert, moduleSpan)
 }
 
-func TestSuite(t *testing.T) {
+func TestTestSuite(t *testing.T) {
 	mockTracer.Reset()
 	assert := assert.New(t)
 
@@ -217,7 +217,7 @@ func suiteAssertions(assert *assert.Assertions, now time.Time, suiteSpan mocktra
 	commonAssertions(assert, suiteSpan)
 }
 
-func Test(t *testing.T) {
+func TestTest(t *testing.T) {
 	mockTracer.Reset()
 	assert := assert.New(t)
 

--- a/internal/civisibility/integrations/manual_api_test.go
+++ b/internal/civisibility/integrations/manual_api_test.go
@@ -30,12 +30,8 @@ func (m *MockDdTslvEvent) StartTime() time.Time {
 	return args.Get(0).(time.Time)
 }
 
-func (m *MockDdTslvEvent) SetError(err error) {
-	m.Called(err)
-}
-
-func (m *MockDdTslvEvent) SetErrorInfo(errType string, message string, callstack string) {
-	m.Called(errType, message, callstack)
+func (m *MockDdTslvEvent) SetError(options ...DdErrorOption) {
+	m.Called(options)
 }
 
 func (m *MockDdTslvEvent) SetTag(key string, value interface{}) {

--- a/internal/civisibility/integrations/manual_api_test.go
+++ b/internal/civisibility/integrations/manual_api_test.go
@@ -30,7 +30,7 @@ func (m *MockDdTslvEvent) StartTime() time.Time {
 	return args.Get(0).(time.Time)
 }
 
-func (m *MockDdTslvEvent) SetError(options ...DdErrorOption) {
+func (m *MockDdTslvEvent) SetError(options ...ErrorOption) {
 	m.Called(options)
 }
 
@@ -54,12 +54,12 @@ func (m *MockDdTest) Name() string {
 	return args.String(0)
 }
 
-func (m *MockDdTest) Suite() DdTestSuite {
+func (m *MockDdTest) Suite() TestSuite {
 	args := m.Called()
-	return args.Get(0).(DdTestSuite)
+	return args.Get(0).(TestSuite)
 }
 
-func (m *MockDdTest) Close(status TestResultStatus, options ...DdTestCloseOption) {
+func (m *MockDdTest) Close(status TestResultStatus, options ...TestCloseOption) {
 	m.Called(status, options)
 }
 
@@ -97,13 +97,13 @@ func (m *MockDdTestSession) WorkingDirectory() string {
 	return args.String(0)
 }
 
-func (m *MockDdTestSession) Close(exitCode int, options ...DdTestSessionCloseOption) {
+func (m *MockDdTestSession) Close(exitCode int, options ...TestSessionCloseOption) {
 	m.Called(exitCode, options)
 }
 
-func (m *MockDdTestSession) GetOrCreateModule(name string, options ...DdTestModuleStartOption) DdTestModule {
+func (m *MockDdTestSession) GetOrCreateModule(name string, options ...TestModuleStartOption) TestModule {
 	args := m.Called(name, options)
-	return args.Get(0).(DdTestModule)
+	return args.Get(0).(TestModule)
 }
 
 // Mocking the DdTestModule interface
@@ -117,9 +117,9 @@ func (m *MockDdTestModule) ModuleID() uint64 {
 	return args.Get(0).(uint64)
 }
 
-func (m *MockDdTestModule) Session() DdTestSession {
+func (m *MockDdTestModule) Session() TestSession {
 	args := m.Called()
-	return args.Get(0).(DdTestSession)
+	return args.Get(0).(TestSession)
 }
 
 func (m *MockDdTestModule) Framework() string {
@@ -132,18 +132,18 @@ func (m *MockDdTestModule) Name() string {
 	return args.String(0)
 }
 
-func (m *MockDdTestModule) Close(options ...DdTestModuleCloseOption) {
+func (m *MockDdTestModule) Close(options ...TestModuleCloseOption) {
 	m.Called(options)
 }
 
-func (m *MockDdTestModule) GetOrCreateSuite(name string, options ...DdTestSuiteStartOption) DdTestSuite {
+func (m *MockDdTestModule) GetOrCreateSuite(name string, options ...TestSuiteStartOption) TestSuite {
 	args := m.Called(name, options)
-	return args.Get(0).(DdTestSuite)
+	return args.Get(0).(TestSuite)
 }
 
-func (m *MockDdTestModule) GetOrCreateSuiteWithStartTime(name string, startTime time.Time) DdTestSuite {
+func (m *MockDdTestModule) GetOrCreateSuiteWithStartTime(name string, startTime time.Time) TestSuite {
 	args := m.Called(name, startTime)
-	return args.Get(0).(DdTestSuite)
+	return args.Get(0).(TestSuite)
 }
 
 // Mocking the DdTestSuite interface
@@ -157,9 +157,9 @@ func (m *MockDdTestSuite) SuiteID() uint64 {
 	return args.Get(0).(uint64)
 }
 
-func (m *MockDdTestSuite) Module() DdTestModule {
+func (m *MockDdTestSuite) Module() TestModule {
 	args := m.Called()
-	return args.Get(0).(DdTestModule)
+	return args.Get(0).(TestModule)
 }
 
 func (m *MockDdTestSuite) Name() string {
@@ -167,13 +167,13 @@ func (m *MockDdTestSuite) Name() string {
 	return args.String(0)
 }
 
-func (m *MockDdTestSuite) Close(options ...DdTestSuiteCloseOption) {
+func (m *MockDdTestSuite) Close(options ...TestSuiteCloseOption) {
 	m.Called(options)
 }
 
-func (m *MockDdTestSuite) CreateTest(name string, options ...DdTestStartOption) DdTest {
+func (m *MockDdTestSuite) CreateTest(name string, options ...TestStartOption) Test {
 	args := m.Called(name, options)
-	return args.Get(0).(DdTest)
+	return args.Get(0).(Test)
 }
 
 // Unit tests
@@ -185,7 +185,7 @@ func TestDdTestSession(t *testing.T) {
 	mockSession.On("Close", 0, mock.Anything).Return()
 	mockSession.On("GetOrCreateModule", "test-module", mock.Anything).Return(new(MockDdTestModule))
 
-	session := (DdTestSession)(mockSession)
+	session := (TestSession)(mockSession)
 	assert.Equal(t, "test-command", session.Command())
 	assert.Equal(t, "test-framework", session.Framework())
 	assert.Equal(t, "/path/to/working/dir", session.WorkingDirectory())
@@ -218,7 +218,7 @@ func TestDdTestModule(t *testing.T) {
 	mockModule.On("Close", mock.Anything).Return()
 	mockModule.On("GetOrCreateSuite", "test-suite", mock.Anything).Return(new(MockDdTestSuite))
 
-	module := (DdTestModule)(mockModule)
+	module := (TestModule)(mockModule)
 
 	assert.Equal(t, "test-framework", module.Framework())
 	assert.Equal(t, "test-module", module.Name())
@@ -246,7 +246,7 @@ func TestDdTestSuite(t *testing.T) {
 	mockSuite.On("Close", mock.Anything).Return()
 	mockSuite.On("CreateTest", "test-name", mock.Anything).Return(new(MockDdTest))
 
-	suite := (DdTestSuite)(mockSuite)
+	suite := (TestSuite)(mockSuite)
 
 	assert.Equal(t, "test-suite", suite.Name())
 
@@ -274,7 +274,7 @@ func TestDdTest(t *testing.T) {
 	mockTest.On("SetTestFunc", mock.Anything).Return()
 	mockTest.On("SetBenchmarkData", "measure-type", mock.Anything).Return()
 
-	test := (DdTest)(mockTest)
+	test := (Test)(mockTest)
 
 	assert.Equal(t, "test-name", test.Name())
 

--- a/internal/civisibility/utils/git.go
+++ b/internal/civisibility/utils/git.go
@@ -66,8 +66,10 @@ func isGitFound() bool {
 // execGit executes a Git command with the given arguments.
 func execGit(commandType telemetry.CommandType, args ...string) (val []byte, err error) {
 	if commandType != telemetry.NotSpecifiedCommandsType {
+		startTime := time.Now()
 		telemetry.GitCommand(commandType)
 		defer func() {
+			telemetry.GitCommandMs(commandType, float64(time.Since(startTime).Milliseconds()))
 			var exitErr *exec.ExitError
 			if errors.As(err, &exitErr) {
 				switch exitErr.ExitCode() {

--- a/internal/civisibility/utils/net/client.go
+++ b/internal/civisibility/utils/net/client.go
@@ -23,6 +23,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/constants"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 )
 
 const (
@@ -194,6 +195,16 @@ func NewClientWithServiceNameAndSubdomain(serviceName, subdomain string) Client 
 
 	log.Debug("ciVisibilityHttpClient: new client created [id: %v, agentless: %v, url: %v, env: %v, serviceName: %v, subdomain: %v]",
 		id, agentlessEnabled, baseURL, environment, serviceName, subdomain)
+
+	if !telemetry.Disabled() {
+		telemetry.GlobalClient.ApplyOps(
+			telemetry.WithService(serviceName),
+			telemetry.WithEnv(environment),
+			telemetry.WithHTTPClient(requestHandler.Client),
+			telemetry.WithURL(agentlessEnabled, baseURL),
+		)
+	}
+
 	return &client{
 		id:               id,
 		agentless:        agentlessEnabled,

--- a/internal/civisibility/utils/net/client.go
+++ b/internal/civisibility/utils/net/client.go
@@ -209,6 +209,7 @@ func NewClientWithServiceNameAndSubdomain(serviceName, subdomain string) Client 
 				telemetry.WithEnv(environment),
 				telemetry.WithHTTPClient(requestHandler.Client),
 				telemetry.WithURL(agentlessEnabled, baseURL),
+				telemetry.SyncFlushOnStop(),
 			)
 			telemetry.GlobalClient.ProductChange(telemetry.NamespaceCiVisibility, true, []telemetry.Configuration{
 				telemetry.StringConfig("service", serviceName),

--- a/internal/civisibility/utils/net/coverage.go
+++ b/internal/civisibility/utils/net/coverage.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils/telemetry"
 	"io"
+	"time"
 )
 
 const (
@@ -60,7 +61,10 @@ func (c *client) SendCoveragePayload(ciTestCovPayload io.Reader) error {
 		telemetry.EndpointPayloadRequests(telemetry.CodeCoverageUncompressedEndpointType)
 	}
 
+	startTime := time.Now()
 	response, responseErr := c.handler.SendRequest(request)
+	telemetry.EndpointPayloadRequestsMs(telemetry.CodeCoverageEndpointType, float64(time.Since(startTime).Milliseconds()))
+
 	if responseErr != nil {
 		telemetry.EndpointPayloadRequestsErrors(telemetry.CodeCoverageEndpointType, telemetry.NetworkErrorType)
 		telemetry.EndpointPayloadDropped(telemetry.CodeCoverageEndpointType)

--- a/internal/civisibility/utils/net/coverage.go
+++ b/internal/civisibility/utils/net/coverage.go
@@ -56,9 +56,9 @@ func (c *client) SendCoveragePayload(ciTestCovPayload io.Reader) error {
 	}
 
 	if request.Compressed {
-		telemetry.EndpointPayloadRequests(telemetry.CodeCoverageRequestCompressedEndpointType)
+		telemetry.EndpointPayloadRequests(telemetry.CodeCoverageEndpointType, telemetry.CompressedRequestCompressedType)
 	} else {
-		telemetry.EndpointPayloadRequests(telemetry.CodeCoverageUncompressedEndpointType)
+		telemetry.EndpointPayloadRequests(telemetry.CodeCoverageEndpointType, telemetry.UncompressedRequestCompressedType)
 	}
 
 	startTime := time.Now()

--- a/internal/civisibility/utils/net/efd_api.go
+++ b/internal/civisibility/utils/net/efd_api.go
@@ -7,6 +7,7 @@ package net
 
 import (
 	"fmt"
+	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils/telemetry"
 )
@@ -71,7 +72,10 @@ func (c *client) GetEarlyFlakeDetectionData() (*EfdResponseData, error) {
 		telemetry.EarlyFlakeDetectionRequest(telemetry.UncompressedRequestCompressedType)
 	}
 
+	startTime := time.Now()
 	response, err := c.handler.SendRequest(*request)
+	telemetry.EarlyFlakeDetectionRequestMs(float64(time.Since(startTime).Milliseconds()))
+
 	if err != nil {
 		telemetry.EarlyFlakeDetectionRequestErrors(telemetry.NetworkErrorType)
 		return nil, fmt.Errorf("sending early flake detection request: %s", err.Error())
@@ -80,6 +84,11 @@ func (c *client) GetEarlyFlakeDetectionData() (*EfdResponseData, error) {
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		telemetry.EarlyFlakeDetectionRequestErrors(telemetry.GetErrorTypeFromStatusCode(response.StatusCode))
 	}
+	if response.Compressed {
+		telemetry.EarlyFlakeDetectionResponseBytes(telemetry.CompressedResponseCompressedType, float64(len(response.Body)))
+	} else {
+		telemetry.EarlyFlakeDetectionResponseBytes(telemetry.UncompressedResponseCompressedType, float64(len(response.Body)))
+	}
 
 	var responseObject efdResponse
 	err = response.Unmarshal(&responseObject)
@@ -87,5 +96,17 @@ func (c *client) GetEarlyFlakeDetectionData() (*EfdResponseData, error) {
 		return nil, fmt.Errorf("unmarshalling early flake detection data response: %s", err.Error())
 	}
 
+	testCount := 0
+	if responseObject.Data.Attributes.Tests != nil {
+		for _, suites := range responseObject.Data.Attributes.Tests {
+			if suites == nil {
+				continue
+			}
+			for _, tests := range suites {
+				testCount += len(tests)
+			}
+		}
+	}
+	telemetry.EarlyFlakeDetectionResponseTests(float64(testCount))
 	return &responseObject.Data.Attributes, nil
 }

--- a/internal/civisibility/utils/net/http.go
+++ b/internal/civisibility/utils/net/http.go
@@ -66,6 +66,7 @@ type Response struct {
 	Format       string // Format of the response (json or msgpack)
 	StatusCode   int    // HTTP status code
 	CanUnmarshal bool   // Whether the response body can be unmarshalled
+	Compressed   bool   // Whether to use gzip compression
 }
 
 // Unmarshal deserializes the response body into the provided target based on the response format.
@@ -269,7 +270,9 @@ func (rh *RequestHandler) internalSendRequest(config *RequestConfig, attempt int
 	}
 
 	// Decompress response if it is gzip compressed
+	compressedResponse := false
 	if resp.Header.Get(HeaderContentEncoding) == ContentEncodingGzip {
+		compressedResponse = true
 		responseBody, err = decompressData(responseBody)
 		if err != nil {
 			return true, nil, err
@@ -294,7 +297,7 @@ func (rh *RequestHandler) internalSendRequest(config *RequestConfig, attempt int
 	canUnmarshal := statusCode >= 200 && statusCode < 300
 
 	// Return the successful response with status code and unmarshal capability
-	return true, &Response{Body: responseBody, Format: responseFormat, StatusCode: statusCode, CanUnmarshal: canUnmarshal}, nil
+	return true, &Response{Body: responseBody, Format: responseFormat, StatusCode: statusCode, CanUnmarshal: canUnmarshal, Compressed: compressedResponse}, nil
 }
 
 // Helper functions for data serialization, compression, and handling multipart form data

--- a/internal/civisibility/utils/net/sendpackfiles_api.go
+++ b/internal/civisibility/utils/net/sendpackfiles_api.go
@@ -8,6 +8,7 @@ package net
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils/telemetry"
 )
@@ -82,7 +83,10 @@ func (c *client) SendPackFiles(commitSha string, packFiles []string) (bytes int6
 			telemetry.GitRequestsObjectsPack(telemetry.UncompressedRequestCompressedType)
 		}
 
+		startTime := time.Now()
 		response, responseErr := c.handler.SendRequest(request)
+		telemetry.GitRequestsObjectsPackMs(float64(time.Since(startTime).Milliseconds()))
+
 		if responseErr != nil {
 			telemetry.GitRequestsObjectsPackErrors(telemetry.NetworkErrorType)
 			err = fmt.Errorf("failed to send packfile request: %s", responseErr.Error())
@@ -97,5 +101,7 @@ func (c *client) SendPackFiles(commitSha string, packFiles []string) (bytes int6
 		bytes += int64(len(fileContent))
 	}
 
+	telemetry.GitRequestsObjectsPackFiles(float64(len(packFiles)))
+	telemetry.GitRequestsObjectsPackBytes(float64(bytes))
 	return
 }

--- a/internal/civisibility/utils/net/settings_api.go
+++ b/internal/civisibility/utils/net/settings_api.go
@@ -7,6 +7,7 @@ package net
 
 import (
 	"fmt"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 )
 
 const (
@@ -88,5 +89,8 @@ func (c *client) GetSettings() (*SettingsResponseData, error) {
 		return nil, fmt.Errorf("unmarshalling settings response: %s", err.Error())
 	}
 
+	if log.DebugEnabled() {
+		log.Debug("civisibility.settings: %s", string(response.Body))
+	}
 	return &responseObject.Data.Attributes, nil
 }

--- a/internal/civisibility/utils/net/settings_api.go
+++ b/internal/civisibility/utils/net/settings_api.go
@@ -7,6 +7,9 @@ package net
 
 import (
 	"fmt"
+	"time"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils/telemetry"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 )
 
@@ -78,9 +81,23 @@ func (c *client) GetSettings() (*SettingsResponseData, error) {
 		},
 	}
 
-	response, err := c.handler.SendRequest(*c.getPostRequestConfig(settingsURLPath, body))
+	request := c.getPostRequestConfig(settingsURLPath, body)
+	if request.Compressed {
+		telemetry.GitRequestsSettings(telemetry.CompressedRequestCompressedType)
+	} else {
+		telemetry.GitRequestsSettings(telemetry.UncompressedRequestCompressedType)
+	}
+
+	startTime := time.Now()
+	response, err := c.handler.SendRequest(*request)
+	telemetry.GitRequestsSettingsMs(float64(time.Since(startTime).Milliseconds()))
 	if err != nil {
+		telemetry.GitRequestsSettingsErrors(telemetry.NetworkErrorType)
 		return nil, fmt.Errorf("sending get settings request: %s", err.Error())
+	}
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		telemetry.GitRequestsSettingsErrors(telemetry.GetErrorTypeFromStatusCode(response.StatusCode))
 	}
 
 	var responseObject settingsResponse
@@ -92,5 +109,17 @@ func (c *client) GetSettings() (*SettingsResponseData, error) {
 	if log.DebugEnabled() {
 		log.Debug("civisibility.settings: %s", string(response.Body))
 	}
+
+	var settingsResponseType telemetry.SettingsResponseType
+	if responseObject.Data.Attributes.CodeCoverage {
+		settingsResponseType = append(settingsResponseType, telemetry.CoverageEnabledSettingsResponseType...)
+	}
+	if responseObject.Data.Attributes.TestsSkipping {
+		settingsResponseType = append(settingsResponseType, telemetry.ItrSkipEnabledSettingsResponseType...)
+	}
+	if responseObject.Data.Attributes.EarlyFlakeDetection.Enabled {
+		settingsResponseType = append(settingsResponseType, telemetry.EfdEnabledSettingsResponseType...)
+	}
+	telemetry.GitRequestsSettingsResponse(settingsResponseType)
 	return &responseObject.Data.Attributes, nil
 }

--- a/internal/civisibility/utils/net/skippable.go
+++ b/internal/civisibility/utils/net/skippable.go
@@ -7,6 +7,8 @@ package net
 
 import (
 	"fmt"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils/telemetry"
 )
 
 const (
@@ -72,9 +74,21 @@ func (c *client) GetSkippableTests() (correlationID string, skippables map[strin
 		},
 	}
 
-	response, err := c.handler.SendRequest(*c.getPostRequestConfig(skippableURLPath, body))
+	request := c.getPostRequestConfig(skippableURLPath, body)
+	if request.Compressed {
+		telemetry.ITRSkippableTestsRequest(telemetry.CompressedRequestCompressedType)
+	} else {
+		telemetry.ITRSkippableTestsRequest(telemetry.UncompressedRequestCompressedType)
+	}
+
+	response, err := c.handler.SendRequest(*request)
 	if err != nil {
+		telemetry.ITRSkippableTestsRequestErrors(telemetry.NetworkErrorType)
 		return "", nil, fmt.Errorf("sending skippable tests request: %s", err.Error())
+	}
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		telemetry.ITRSkippableTestsRequestErrors(telemetry.GetErrorTypeFromStatusCode(response.StatusCode))
 	}
 
 	var responseObject skippableResponse
@@ -83,6 +97,7 @@ func (c *client) GetSkippableTests() (correlationID string, skippables map[strin
 		return "", nil, fmt.Errorf("unmarshalling skippable tests response: %s", err.Error())
 	}
 
+	telemetry.ITRSkippableTestsResponseTests(float64(len(responseObject.Data)))
 	skippableTestsMap := map[string]map[string][]SkippableResponseDataAttributes{}
 	for _, data := range responseObject.Data {
 

--- a/internal/civisibility/utils/telemetry.go
+++ b/internal/civisibility/utils/telemetry.go
@@ -1,0 +1,162 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package utils
+
+// TestingFramework is a type for testing frameworks
+type TestingFramework string
+
+const (
+	GoTestingFramework TestingFramework = "test_framework:testing"
+	UnknownFramework   TestingFramework = "test_framework:unknown"
+)
+
+// TestingEventType is a type for testing event types
+type TestingEventType string
+
+const (
+	TestEventType                                                   TestingEventType = "event_type:test"
+	BenchmarkTestEventType                                          TestingEventType = "event_type:test;is_benchmark"
+	SuiteEventType                                                  TestingEventType = "event_type:suite"
+	ModuleEventType                                                 TestingEventType = "event_type:module"
+	SessionNoCodeOwnerIsSupportedCiEventType                        TestingEventType = "event_type:session"
+	SessionNoCodeOwnerUnsupportedCiEventType                        TestingEventType = "event_type:session;is_unsupported_ci"
+	SessionHasCodeOwnerIsSupportedCiEventType                       TestingEventType = "event_type:session;has_codeowner"
+	SessionHasCodeOwnerUnsupportedCiEventType                       TestingEventType = "event_type:session;has_codeowner;is_unsupported_ci"
+	TestEfdTestIsNewEventType                                       TestingEventType = "event_type:test;is_new:true"
+	TestEfdTestIsNewEfdAbortSlowEventType                           TestingEventType = "event_type:test;is_new:true;early_flake_detection_abort_reason:slow"
+	TestBrowserDriverSeleniumEventType                              TestingEventType = "event_type:test;browser_driver:selenium"
+	TestEfdTestIsNewBrowserDriverSeleniumEventType                  TestingEventType = "event_type:test;is_new:true;browser_driver:selenium"
+	TestEfdTestIsNewEfdAbortSlowBrowserDriverSeleniumEventType      TestingEventType = "event_type:test;is_new:true;early_flake_detection_abort_reason:slow;browser_driver:selenium"
+	TestBrowserDriverSeleniumIsRumEventType                         TestingEventType = "event_type:test;browser_driver:selenium;is_rum:true"
+	TestEfdTestIsNewBrowserDriverSeleniumIsRumEventType             TestingEventType = "event_type:test;is_new:true;browser_driver:selenium;is_rum:true"
+	TestEfdTestIsNewEfdAbortSlowBrowserDriverSeleniumIsRumEventType TestingEventType = "event_type:test;is_new:true;early_flake_detection_abort_reason:slow;browser_driver:selenium;is_rum:true"
+)
+
+// CoverageLibraryType is a type for coverage library types
+type CoverageLibraryType string
+
+const (
+	DefaultCoverageLibraryType CoverageLibraryType = "library:default"
+	UnknownCoverageLibraryType CoverageLibraryType = "library:unknown"
+)
+
+// EndpointAndCompressionType is a type for endpoint and compression types
+type EndpointAndCompressionType string
+
+const (
+	TestCycleUncompressedEndpointType         EndpointAndCompressionType = "endpoint:test_cycle"
+	TestCycleRequestCompressedEndpointType    EndpointAndCompressionType = "endpoint:test_cycle;rq_compressed:true"
+	CodeCoverageUncompressedEndpointType      EndpointAndCompressionType = "endpoint:code_coverage"
+	CodeCoverageRequestCompressedEndpointType EndpointAndCompressionType = "endpoint:code_coverage;rq_compressed:true"
+)
+
+// EndpointType is a type for endpoint types
+type EndpointType string
+
+const (
+	TestCycleEndpointType    EndpointType = "endpoint:test_cycle"
+	CodeCoverageEndpointType EndpointType = "endpoint:code_coverage"
+)
+
+// ErrorType is a type for error types
+type ErrorType string
+
+const (
+	TimeoutErrorType       ErrorType = "error_type:timeout"
+	NetworkErrorType       ErrorType = "error_type:network"
+	StatusCodeErrorType    ErrorType = "error_type:status_code"
+	StatusCode4xxErrorType ErrorType = "error_type:status_code_4xx_response"
+	StatusCode5xxErrorType ErrorType = "error_type:status_code_5xx_response"
+	StatusCode400ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:400"
+	StatusCode401ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:401"
+	StatusCode403ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:403"
+	StatusCode404ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:404"
+	StatusCode408ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:408"
+	StatusCode429ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:429"
+)
+
+// CommandType is a type for commands types
+type CommandType string
+
+const (
+	GetRepositoryCommandsType   CommandType = "command:get_repository"
+	GetBranchCommandsType       CommandType = "command:get_branch"
+	GetRemoteCommandsType       CommandType = "command:get_remote"
+	GetHeadCommandsType         CommandType = "command:get_head"
+	CheckShallowCommandsType    CommandType = "command:check_shallow"
+	UnshallowCommandsType       CommandType = "command:unshallow"
+	GetLocalCommitsCommandsType CommandType = "command:get_local_commits"
+	GetObjectsCommandsType      CommandType = "command:get_objects"
+	PackObjectsCommandsType     CommandType = "command:pack_objects"
+)
+
+// CommandExitCodeType is a type for command exit codes
+type CommandExitCodeType string
+
+const (
+	MissingCommandExitCode  CommandExitCodeType = "exit_code:missing"
+	UnknownCommandExitCode  CommandExitCodeType = "exit_code:unknown"
+	ECMinus1CommandExitCode CommandExitCodeType = "exit_code:-1"
+	EC1CommandExitCode      CommandExitCodeType = "exit_code:1"
+	EC2CommandExitCode      CommandExitCodeType = "exit_code:2"
+	EC127CommandExitCode    CommandExitCodeType = "exit_code:127"
+	EC128CommandExitCode    CommandExitCodeType = "exit_code:128"
+	EC129CommandExitCode    CommandExitCodeType = "exit_code:129"
+)
+
+// RequestCompressedType is a type for request compressed types
+type RequestCompressedType string
+
+const (
+	UncompressedRequestCompressedType RequestCompressedType = ""
+	CompressedRequestCompressedType   RequestCompressedType = "rq_compressed:true"
+)
+
+// ResponseCompressedType is a type for response compressed types
+type ResponseCompressedType string
+
+const (
+	UncompressedResponseCompressedType ResponseCompressedType = ""
+	CompressedResponseCompressedType   ResponseCompressedType = "rs_compressed:true"
+)
+
+// SettingsResponseType is a type for settings response types
+type SettingsResponseType string
+
+const (
+	CoverageDisabledItrSkipDisabledSettingsResponseType           SettingsResponseType = ""
+	CoverageEnabledItrSkipDisabledSettingsResponseType            SettingsResponseType = "coverage_enabled"
+	CoverageDisabledItrSkipEnabledSettingsResponseType            SettingsResponseType = "itrskip_enabled"
+	CoverageEnabledItrSkipEnabledSettingsResponseType             SettingsResponseType = "coverage_enabled;itrskip_enabled"
+	CoverageDisabledItrSkipDisabledEfdEnabledSettingsResponseType SettingsResponseType = "early_flake_detection_enabled:true"
+	CoverageEnabledItrSkipDisabledEfdEnabledSettingsResponseType  SettingsResponseType = "coverage_enabled;early_flake_detection_enabled:true"
+	CoverageDisabledItrSkipEnabledEfdEnabledSettingsResponseType  SettingsResponseType = "itrskip_enabled;early_flake_detection_enabled:true"
+	CoverageEnabledItrSkipEnabledEfdEnabledSettingsResponseType   SettingsResponseType = "coverage_enabled;itrskip_enabled;early_flake_detection_enabled:true"
+)
+
+// removeEmptyStrings removes empty string values inside an array or use the same if not empty string is found.
+func removeEmptyStrings(s []string) []string {
+	var r []string
+	hasSpace := false
+	for i, str := range s {
+		if str == "" && r == nil {
+			if i > 0 {
+				r = s[:i]
+			}
+			hasSpace = true
+			continue
+		}
+		if hasSpace {
+			r = append(r, str)
+		}
+	}
+
+	if r == nil {
+		r = s
+	}
+
+	return r
+}

--- a/internal/civisibility/utils/telemetry/telemetry.go
+++ b/internal/civisibility/utils/telemetry/telemetry.go
@@ -128,14 +128,9 @@ const (
 type SettingsResponseType []string
 
 var (
-	CoverageDisabledItrSkipDisabledSettingsResponseType           SettingsResponseType = []string{}
-	CoverageEnabledItrSkipDisabledSettingsResponseType            SettingsResponseType = []string{"coverage_enabled"}
-	CoverageDisabledItrSkipEnabledSettingsResponseType            SettingsResponseType = []string{"itrskip_enabled"}
-	CoverageEnabledItrSkipEnabledSettingsResponseType             SettingsResponseType = []string{"coverage_enabled", "itrskip_enabled"}
-	CoverageDisabledItrSkipDisabledEfdEnabledSettingsResponseType SettingsResponseType = []string{"early_flake_detection_enabled:true"}
-	CoverageEnabledItrSkipDisabledEfdEnabledSettingsResponseType  SettingsResponseType = []string{"coverage_enabled", "early_flake_detection_enabled:true"}
-	CoverageDisabledItrSkipEnabledEfdEnabledSettingsResponseType  SettingsResponseType = []string{"itrskip_enabled", "early_flake_detection_enabled:true"}
-	CoverageEnabledItrSkipEnabledEfdEnabledSettingsResponseType   SettingsResponseType = []string{"coverage_enabled", "itrskip_enabled", "early_flake_detection_enabled:true"}
+	CoverageEnabledSettingsResponseType SettingsResponseType = []string{"coverage_enabled"}
+	ItrSkipEnabledSettingsResponseType  SettingsResponseType = []string{"itrskip_enabled"}
+	EfdEnabledSettingsResponseType      SettingsResponseType = []string{"early_flake_detection_enabled:true"}
 )
 
 // removeEmptyStrings removes empty string values inside an array or use the same if not empty string is found.

--- a/internal/civisibility/utils/telemetry/telemetry.go
+++ b/internal/civisibility/utils/telemetry/telemetry.go
@@ -17,22 +17,17 @@ const (
 type TestingEventType []string
 
 var (
-	TestEventType                                                   TestingEventType = []string{"event_type:test"}
-	BenchmarkTestEventType                                          TestingEventType = []string{"event_type:test", "is_benchmark"}
-	SuiteEventType                                                  TestingEventType = []string{"event_type:suite"}
-	ModuleEventType                                                 TestingEventType = []string{"event_type:module"}
-	SessionNoCodeOwnerIsSupportedCiEventType                        TestingEventType = []string{"event_type:session"}
-	SessionNoCodeOwnerUnsupportedCiEventType                        TestingEventType = []string{"event_type:session", "is_unsupported_ci"}
-	SessionHasCodeOwnerIsSupportedCiEventType                       TestingEventType = []string{"event_type:session", "has_codeowner"}
-	SessionHasCodeOwnerUnsupportedCiEventType                       TestingEventType = []string{"event_type:session", "has_codeowner", "is_unsupported_ci"}
-	TestEfdTestIsNewEventType                                       TestingEventType = []string{"event_type:test", "is_new:true"}
-	TestEfdTestIsNewEfdAbortSlowEventType                           TestingEventType = []string{"event_type:test", "is_new:true", "early_flake_detection_abort_reason:slow"}
-	TestBrowserDriverSeleniumEventType                              TestingEventType = []string{"event_type:test", "browser_driver:selenium"}
-	TestEfdTestIsNewBrowserDriverSeleniumEventType                  TestingEventType = []string{"event_type:test", "is_new:true", "browser_driver:selenium"}
-	TestEfdTestIsNewEfdAbortSlowBrowserDriverSeleniumEventType      TestingEventType = []string{"event_type:test", "is_new:true", "early_flake_detection_abort_reason:slow", "browser_driver:selenium"}
-	TestBrowserDriverSeleniumIsRumEventType                         TestingEventType = []string{"event_type:test", "browser_driver:selenium", "is_rum:true"}
-	TestEfdTestIsNewBrowserDriverSeleniumIsRumEventType             TestingEventType = []string{"event_type:test", "is_new:true", "browser_driver:selenium", "is_rum:true"}
-	TestEfdTestIsNewEfdAbortSlowBrowserDriverSeleniumIsRumEventType TestingEventType = []string{"event_type:test", "is_new:true", "early_flake_detection_abort_reason:slow", "browser_driver:selenium", "is_rum:true"}
+	TestEventType    TestingEventType = []string{"event_type:test"}
+	SuiteEventType   TestingEventType = []string{"event_type:suite"}
+	ModuleEventType  TestingEventType = []string{"event_type:module"}
+	SessionEventType TestingEventType = []string{"event_type:session"}
+
+	UnsupportedCiEventType TestingEventType = []string{"is_unsupported_ci"}
+	HasCodeOwnerEventType  TestingEventType = []string{"has_codeowner"}
+	IsNewEventType         TestingEventType = []string{"is_new:true"}
+	IsRetryEventType       TestingEventType = []string{"is_retry:true"}
+	EfdAbortSlowEventType  TestingEventType = []string{"early_flake_detection_abort_reason:slow"}
+	IsBenchmarkEventType   TestingEventType = []string{"is_benchmark"}
 )
 
 // CoverageLibraryType is a type for coverage library types
@@ -41,16 +36,6 @@ type CoverageLibraryType string
 const (
 	DefaultCoverageLibraryType CoverageLibraryType = "library:default"
 	UnknownCoverageLibraryType CoverageLibraryType = "library:unknown"
-)
-
-// EndpointAndCompressionType is a type for endpoint and compression types
-type EndpointAndCompressionType []string
-
-var (
-	TestCycleUncompressedEndpointType         EndpointAndCompressionType = []string{"endpoint:test_cycle"}
-	TestCycleRequestCompressedEndpointType    EndpointAndCompressionType = []string{"endpoint:test_cycle", "rq_compressed:true"}
-	CodeCoverageUncompressedEndpointType      EndpointAndCompressionType = []string{"endpoint:code_coverage"}
-	CodeCoverageRequestCompressedEndpointType EndpointAndCompressionType = []string{"endpoint:code_coverage", "rq_compressed:true"}
 )
 
 // EndpointType is a type for endpoint types

--- a/internal/civisibility/utils/telemetry/telemetry.go
+++ b/internal/civisibility/utils/telemetry/telemetry.go
@@ -14,25 +14,25 @@ const (
 )
 
 // TestingEventType is a type for testing event types
-type TestingEventType string
+type TestingEventType []string
 
-const (
-	TestEventType                                                   TestingEventType = "event_type:test"
-	BenchmarkTestEventType                                          TestingEventType = "event_type:test;is_benchmark"
-	SuiteEventType                                                  TestingEventType = "event_type:suite"
-	ModuleEventType                                                 TestingEventType = "event_type:module"
-	SessionNoCodeOwnerIsSupportedCiEventType                        TestingEventType = "event_type:session"
-	SessionNoCodeOwnerUnsupportedCiEventType                        TestingEventType = "event_type:session;is_unsupported_ci"
-	SessionHasCodeOwnerIsSupportedCiEventType                       TestingEventType = "event_type:session;has_codeowner"
-	SessionHasCodeOwnerUnsupportedCiEventType                       TestingEventType = "event_type:session;has_codeowner;is_unsupported_ci"
-	TestEfdTestIsNewEventType                                       TestingEventType = "event_type:test;is_new:true"
-	TestEfdTestIsNewEfdAbortSlowEventType                           TestingEventType = "event_type:test;is_new:true;early_flake_detection_abort_reason:slow"
-	TestBrowserDriverSeleniumEventType                              TestingEventType = "event_type:test;browser_driver:selenium"
-	TestEfdTestIsNewBrowserDriverSeleniumEventType                  TestingEventType = "event_type:test;is_new:true;browser_driver:selenium"
-	TestEfdTestIsNewEfdAbortSlowBrowserDriverSeleniumEventType      TestingEventType = "event_type:test;is_new:true;early_flake_detection_abort_reason:slow;browser_driver:selenium"
-	TestBrowserDriverSeleniumIsRumEventType                         TestingEventType = "event_type:test;browser_driver:selenium;is_rum:true"
-	TestEfdTestIsNewBrowserDriverSeleniumIsRumEventType             TestingEventType = "event_type:test;is_new:true;browser_driver:selenium;is_rum:true"
-	TestEfdTestIsNewEfdAbortSlowBrowserDriverSeleniumIsRumEventType TestingEventType = "event_type:test;is_new:true;early_flake_detection_abort_reason:slow;browser_driver:selenium;is_rum:true"
+var (
+	TestEventType                                                   TestingEventType = []string{"event_type:test"}
+	BenchmarkTestEventType                                          TestingEventType = []string{"event_type:test", "is_benchmark"}
+	SuiteEventType                                                  TestingEventType = []string{"event_type:suite"}
+	ModuleEventType                                                 TestingEventType = []string{"event_type:module"}
+	SessionNoCodeOwnerIsSupportedCiEventType                        TestingEventType = []string{"event_type:session"}
+	SessionNoCodeOwnerUnsupportedCiEventType                        TestingEventType = []string{"event_type:session", "is_unsupported_ci"}
+	SessionHasCodeOwnerIsSupportedCiEventType                       TestingEventType = []string{"event_type:session", "has_codeowner"}
+	SessionHasCodeOwnerUnsupportedCiEventType                       TestingEventType = []string{"event_type:session", "has_codeowner", "is_unsupported_ci"}
+	TestEfdTestIsNewEventType                                       TestingEventType = []string{"event_type:test", "is_new:true"}
+	TestEfdTestIsNewEfdAbortSlowEventType                           TestingEventType = []string{"event_type:test", "is_new:true", "early_flake_detection_abort_reason:slow"}
+	TestBrowserDriverSeleniumEventType                              TestingEventType = []string{"event_type:test", "browser_driver:selenium"}
+	TestEfdTestIsNewBrowserDriverSeleniumEventType                  TestingEventType = []string{"event_type:test", "is_new:true", "browser_driver:selenium"}
+	TestEfdTestIsNewEfdAbortSlowBrowserDriverSeleniumEventType      TestingEventType = []string{"event_type:test", "is_new:true", "early_flake_detection_abort_reason:slow", "browser_driver:selenium"}
+	TestBrowserDriverSeleniumIsRumEventType                         TestingEventType = []string{"event_type:test", "browser_driver:selenium", "is_rum:true"}
+	TestEfdTestIsNewBrowserDriverSeleniumIsRumEventType             TestingEventType = []string{"event_type:test", "is_new:true", "browser_driver:selenium", "is_rum:true"}
+	TestEfdTestIsNewEfdAbortSlowBrowserDriverSeleniumIsRumEventType TestingEventType = []string{"event_type:test", "is_new:true", "early_flake_detection_abort_reason:slow", "browser_driver:selenium", "is_rum:true"}
 )
 
 // CoverageLibraryType is a type for coverage library types
@@ -44,13 +44,13 @@ const (
 )
 
 // EndpointAndCompressionType is a type for endpoint and compression types
-type EndpointAndCompressionType string
+type EndpointAndCompressionType []string
 
-const (
-	TestCycleUncompressedEndpointType         EndpointAndCompressionType = "endpoint:test_cycle"
-	TestCycleRequestCompressedEndpointType    EndpointAndCompressionType = "endpoint:test_cycle;rq_compressed:true"
-	CodeCoverageUncompressedEndpointType      EndpointAndCompressionType = "endpoint:code_coverage"
-	CodeCoverageRequestCompressedEndpointType EndpointAndCompressionType = "endpoint:code_coverage;rq_compressed:true"
+var (
+	TestCycleUncompressedEndpointType         EndpointAndCompressionType = []string{"endpoint:test_cycle"}
+	TestCycleRequestCompressedEndpointType    EndpointAndCompressionType = []string{"endpoint:test_cycle", "rq_compressed:true"}
+	CodeCoverageUncompressedEndpointType      EndpointAndCompressionType = []string{"endpoint:code_coverage"}
+	CodeCoverageRequestCompressedEndpointType EndpointAndCompressionType = []string{"endpoint:code_coverage", "rq_compressed:true"}
 )
 
 // EndpointType is a type for endpoint types
@@ -62,26 +62,27 @@ const (
 )
 
 // ErrorType is a type for error types
-type ErrorType string
+type ErrorType []string
 
-const (
-	TimeoutErrorType       ErrorType = "error_type:timeout"
-	NetworkErrorType       ErrorType = "error_type:network"
-	StatusCodeErrorType    ErrorType = "error_type:status_code"
-	StatusCode4xxErrorType ErrorType = "error_type:status_code_4xx_response"
-	StatusCode5xxErrorType ErrorType = "error_type:status_code_5xx_response"
-	StatusCode400ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:400"
-	StatusCode401ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:401"
-	StatusCode403ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:403"
-	StatusCode404ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:404"
-	StatusCode408ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:408"
-	StatusCode429ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:429"
+var (
+	TimeoutErrorType       ErrorType = []string{"error_type:timeout"}
+	NetworkErrorType       ErrorType = []string{"error_type:network"}
+	StatusCodeErrorType    ErrorType = []string{"error_type:status_code"}
+	StatusCode4xxErrorType ErrorType = []string{"error_type:status_code_4xx_response"}
+	StatusCode5xxErrorType ErrorType = []string{"error_type:status_code_5xx_response"}
+	StatusCode400ErrorType ErrorType = []string{"error_type:status_code_4xx_response", "status_code:400"}
+	StatusCode401ErrorType ErrorType = []string{"error_type:status_code_4xx_response", "status_code:401"}
+	StatusCode403ErrorType ErrorType = []string{"error_type:status_code_4xx_response", "status_code:403"}
+	StatusCode404ErrorType ErrorType = []string{"error_type:status_code_4xx_response", "status_code:404"}
+	StatusCode408ErrorType ErrorType = []string{"error_type:status_code_4xx_response", "status_code:408"}
+	StatusCode429ErrorType ErrorType = []string{"error_type:status_code_4xx_response", "status_code:429"}
 )
 
 // CommandType is a type for commands types
 type CommandType string
 
 const (
+	NotSpecifiedCommandsType    CommandType = ""
 	GetRepositoryCommandsType   CommandType = "command:get_repository"
 	GetBranchCommandsType       CommandType = "command:get_branch"
 	GetRemoteCommandsType       CommandType = "command:get_remote"
@@ -124,17 +125,17 @@ const (
 )
 
 // SettingsResponseType is a type for settings response types
-type SettingsResponseType string
+type SettingsResponseType []string
 
-const (
-	CoverageDisabledItrSkipDisabledSettingsResponseType           SettingsResponseType = ""
-	CoverageEnabledItrSkipDisabledSettingsResponseType            SettingsResponseType = "coverage_enabled"
-	CoverageDisabledItrSkipEnabledSettingsResponseType            SettingsResponseType = "itrskip_enabled"
-	CoverageEnabledItrSkipEnabledSettingsResponseType             SettingsResponseType = "coverage_enabled;itrskip_enabled"
-	CoverageDisabledItrSkipDisabledEfdEnabledSettingsResponseType SettingsResponseType = "early_flake_detection_enabled:true"
-	CoverageEnabledItrSkipDisabledEfdEnabledSettingsResponseType  SettingsResponseType = "coverage_enabled;early_flake_detection_enabled:true"
-	CoverageDisabledItrSkipEnabledEfdEnabledSettingsResponseType  SettingsResponseType = "itrskip_enabled;early_flake_detection_enabled:true"
-	CoverageEnabledItrSkipEnabledEfdEnabledSettingsResponseType   SettingsResponseType = "coverage_enabled;itrskip_enabled;early_flake_detection_enabled:true"
+var (
+	CoverageDisabledItrSkipDisabledSettingsResponseType           SettingsResponseType = []string{}
+	CoverageEnabledItrSkipDisabledSettingsResponseType            SettingsResponseType = []string{"coverage_enabled"}
+	CoverageDisabledItrSkipEnabledSettingsResponseType            SettingsResponseType = []string{"itrskip_enabled"}
+	CoverageEnabledItrSkipEnabledSettingsResponseType             SettingsResponseType = []string{"coverage_enabled", "itrskip_enabled"}
+	CoverageDisabledItrSkipDisabledEfdEnabledSettingsResponseType SettingsResponseType = []string{"early_flake_detection_enabled:true"}
+	CoverageEnabledItrSkipDisabledEfdEnabledSettingsResponseType  SettingsResponseType = []string{"coverage_enabled", "early_flake_detection_enabled:true"}
+	CoverageDisabledItrSkipEnabledEfdEnabledSettingsResponseType  SettingsResponseType = []string{"itrskip_enabled", "early_flake_detection_enabled:true"}
+	CoverageEnabledItrSkipEnabledEfdEnabledSettingsResponseType   SettingsResponseType = []string{"coverage_enabled", "itrskip_enabled", "early_flake_detection_enabled:true"}
 )
 
 // removeEmptyStrings removes empty string values inside an array or use the same if not empty string is found.

--- a/internal/civisibility/utils/telemetry/telemetry.go
+++ b/internal/civisibility/utils/telemetry/telemetry.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
-package utils
+package telemetry
 
 // TestingFramework is a type for testing frameworks
 type TestingFramework string

--- a/internal/civisibility/utils/telemetry/telemetry_count.go
+++ b/internal/civisibility/utils/telemetry/telemetry_count.go
@@ -178,13 +178,8 @@ func ITRSkippableTestsRequestErrors(errorType ErrorType) {
 }
 
 // ITRSkippableTestsResponseTests the number of tests received in the ITR skippable tests response by CI Visibility.
-func ITRSkippableTestsResponseTests() {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skippable_tests.response_tests", 1.0, nil, true)
-}
-
-// ITRSkippableTestsResponseSuites the number of suites received in the ITR skippable tests response by CI Visibility.
-func ITRSkippableTestsResponseSuites() {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skippable_tests.response_suites", 1.0, nil, true)
+func ITRSkippableTestsResponseTests(value float64) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skippable_tests.response_tests", value, nil, true)
 }
 
 // ITRSkipped the number of ITR tests skipped by CI Visibility, tagged by the event type.

--- a/internal/civisibility/utils/telemetry/telemetry_count.go
+++ b/internal/civisibility/utils/telemetry/telemetry_count.go
@@ -18,6 +18,7 @@ func getTestingFramework(testingFramework string) TestingFramework {
 	}
 	return telemetryFramework
 }
+
 func GetSessionTestingEventType() TestingEventType {
 	hasCodeOwners := utils.GetCodeOwners() != nil
 	_, hasCiProvider := utils.GetCITags()[constants.CIProviderName]
@@ -29,6 +30,33 @@ func GetSessionTestingEventType() TestingEventType {
 		return SessionNoCodeOwnerIsSupportedCiEventType
 	}
 	return SessionNoCodeOwnerUnsupportedCiEventType
+}
+
+func GetErrorTypeFromStatusCode(statusCode int) ErrorType {
+	switch statusCode {
+	case 0:
+		return NetworkErrorType
+	case 400:
+		return StatusCode400ErrorType
+	case 401:
+		return StatusCode401ErrorType
+	case 403:
+		return StatusCode403ErrorType
+	case 404:
+		return StatusCode404ErrorType
+	case 408:
+		return StatusCode408ErrorType
+	case 429:
+		return StatusCode429ErrorType
+	default:
+		if statusCode >= 500 && statusCode < 600 {
+			return StatusCode5xxErrorType
+		} else if statusCode >= 400 && statusCode < 500 {
+			return StatusCode4xxErrorType
+		} else {
+			return StatusCodeErrorType
+		}
+	}
 }
 
 // EventCreated the number of events created by CI Visibility

--- a/internal/civisibility/utils/telemetry/telemetry_count.go
+++ b/internal/civisibility/utils/telemetry/telemetry_count.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
-package utils
+package telemetry
 
 import "gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 

--- a/internal/civisibility/utils/telemetry/telemetry_count.go
+++ b/internal/civisibility/utils/telemetry/telemetry_count.go
@@ -6,8 +6,6 @@
 package telemetry
 
 import (
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/constants"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 )
 
@@ -19,9 +17,7 @@ func getTestingFramework(testingFramework string) TestingFramework {
 	return telemetryFramework
 }
 
-func GetSessionTestingEventType() TestingEventType {
-	hasCodeOwners := utils.GetCodeOwners() != nil
-	_, hasCiProvider := utils.GetCITags()[constants.CIProviderName]
+func GetSessionTestingEventType(hasCodeOwners, hasCiProvider bool) TestingEventType {
 	if hasCodeOwners && hasCiProvider {
 		return SessionHasCodeOwnerIsSupportedCiEventType
 	} else if hasCodeOwners {
@@ -61,18 +57,16 @@ func GetErrorTypeFromStatusCode(statusCode int) ErrorType {
 
 // EventCreated the number of events created by CI Visibility
 func EventCreated(testingFramework string, eventType TestingEventType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "event_created", 1.0, removeEmptyStrings([]string{
-		(string)(getTestingFramework(testingFramework)),
-		(string)(eventType),
-	}), true)
+	tags := []string{(string)(getTestingFramework(testingFramework))}
+	tags = append(tags, eventType...)
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "event_created", 1.0, removeEmptyStrings(tags), true)
 }
 
 // EventFinished the number of events finished by CI Visibility
 func EventFinished(testingFramework string, eventType TestingEventType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "event_finished", 1.0, removeEmptyStrings([]string{
-		(string)(getTestingFramework(testingFramework)),
-		(string)(eventType),
-	}), true)
+	tags := []string{(string)(getTestingFramework(testingFramework))}
+	tags = append(tags, eventType...)
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "event_finished", 1.0, removeEmptyStrings(tags), true)
 }
 
 // CodeCoverageStarted the number of code coverage start calls by CI Visibility
@@ -98,17 +92,14 @@ func EventsEnqueueForSerialization() {
 
 // EndpointPayloadRequests the number of requests sent to the endpoint, regardless of success, tagged by endpoint type
 func EndpointPayloadRequests(endpointAndCompressionType EndpointAndCompressionType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "endpoint_payload.requests", 1.0, removeEmptyStrings([]string{
-		(string)(endpointAndCompressionType),
-	}), true)
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "endpoint_payload.requests", 1.0, removeEmptyStrings(endpointAndCompressionType), true)
 }
 
 // EndpointPayloadRequestsErrors the number of requests sent to the endpoint that errored, tagget by the error type and endpoint type and status code
 func EndpointPayloadRequestsErrors(endpointType EndpointType, errorType ErrorType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "endpoint_payload.requests_errors", 1.0, removeEmptyStrings([]string{
-		(string)(endpointType),
-		(string)(errorType),
-	}), true)
+	tags := []string{(string)(endpointType)}
+	tags = append(tags, errorType...)
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "endpoint_payload.requests_errors", 1.0, removeEmptyStrings(tags), true)
 }
 
 // EndpointPayloadDropped the number of payloads dropped after all retries by CI Visibility
@@ -142,9 +133,7 @@ func GitRequestsSearchCommits(requestCompressed RequestCompressedType) {
 
 // GitRequestsSearchCommitsErrors the number of requests sent to the search commit endpoint that errored, tagged by the error type.
 func GitRequestsSearchCommitsErrors(errorType ErrorType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.search_commits_errors", 1.0, removeEmptyStrings([]string{
-		(string)(errorType),
-	}), true)
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.search_commits_errors", 1.0, removeEmptyStrings(errorType), true)
 }
 
 // GitRequestsObjectsPack the number of requests sent to the objects pack endpoint, tagged by the request compressed type.
@@ -156,9 +145,7 @@ func GitRequestsObjectsPack(requestCompressed RequestCompressedType) {
 
 // GitRequestsObjectsPackErrors the number of requests sent to the objects pack endpoint that errored, tagged by the error type.
 func GitRequestsObjectsPackErrors(errorType ErrorType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.objects_pack_errors", 1.0, removeEmptyStrings([]string{
-		(string)(errorType),
-	}), true)
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.objects_pack_errors", 1.0, removeEmptyStrings(errorType), true)
 }
 
 // GitRequestsSettings the number of requests sent to the settings endpoint, tagged by the request compressed type.
@@ -170,16 +157,12 @@ func GitRequestsSettings(requestCompressed RequestCompressedType) {
 
 // GitRequestsSettingsErrors the number of requests sent to the settings endpoint that errored, tagged by the error type.
 func GitRequestsSettingsErrors(errorType ErrorType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.settings_errors", 1.0, removeEmptyStrings([]string{
-		(string)(errorType),
-	}), true)
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.settings_errors", 1.0, removeEmptyStrings(errorType), true)
 }
 
 // GitRequestsSettingsResponse the number of settings responses received by CI Visibility, tagged by the settings response type.
 func GitRequestsSettingsResponse(settingsResponseType SettingsResponseType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.settings_response", 1.0, removeEmptyStrings([]string{
-		(string)(settingsResponseType),
-	}), true)
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.settings_response", 1.0, removeEmptyStrings(settingsResponseType), true)
 }
 
 // ITRSkippableTestsRequest the number of requests sent to the ITR skippable tests endpoint, tagged by the request compressed type.
@@ -191,9 +174,7 @@ func ITRSkippableTestsRequest(requestCompressed RequestCompressedType) {
 
 // ITRSkippableTestsRequestErrors the number of requests sent to the ITR skippable tests endpoint that errored, tagged by the error type.
 func ITRSkippableTestsRequestErrors(errorType ErrorType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skippable_tests.request_errors", 1.0, removeEmptyStrings([]string{
-		(string)(errorType),
-	}), true)
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skippable_tests.request_errors", 1.0, removeEmptyStrings(errorType), true)
 }
 
 // ITRSkippableTestsResponseTests the number of tests received in the ITR skippable tests response by CI Visibility.
@@ -208,23 +189,17 @@ func ITRSkippableTestsResponseSuites() {
 
 // ITRSkipped the number of ITR tests skipped by CI Visibility, tagged by the event type.
 func ITRSkipped(eventType TestingEventType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skipped", 1.0, removeEmptyStrings([]string{
-		(string)(eventType),
-	}), true)
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skipped", 1.0, removeEmptyStrings(eventType), true)
 }
 
 // ITRUnskippable the number of ITR tests unskippable by CI Visibility, tagged by the event type.
 func ITRUnskippable(eventType TestingEventType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_unskippable", 1.0, removeEmptyStrings([]string{
-		(string)(eventType),
-	}), true)
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_unskippable", 1.0, removeEmptyStrings(eventType), true)
 }
 
 // ITRForcedRun the number of tests or test suites that would've been skipped by ITR but were forced to run because of their unskippable status by CI Visibility.
 func ITRForcedRun(eventType TestingEventType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_forced_run", 1.0, removeEmptyStrings([]string{
-		(string)(eventType),
-	}), true)
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_forced_run", 1.0, removeEmptyStrings(eventType), true)
 }
 
 // CodeCoverageIsEmpty the number of code coverage payloads that are empty by CI Visibility.
@@ -246,7 +221,5 @@ func EarlyFlakeDetectionRequest(requestCompressed RequestCompressedType) {
 
 // EarlyFlakeDetectionRequestErrors the number of requests sent to the early flake detection endpoint that errored, tagged by the error type.
 func EarlyFlakeDetectionRequestErrors(errorType ErrorType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "early_flake_detection.request_errors", 1.0, removeEmptyStrings([]string{
-		(string)(errorType),
-	}), true)
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "early_flake_detection.request_errors", 1.0, removeEmptyStrings(errorType), true)
 }

--- a/internal/civisibility/utils/telemetry/telemetry_count.go
+++ b/internal/civisibility/utils/telemetry/telemetry_count.go
@@ -5,36 +5,61 @@
 
 package telemetry
 
-import "gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
+import (
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/constants"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
+)
+
+func getTestingFramework(testingFramework string) TestingFramework {
+	telemetryFramework := UnknownFramework
+	if testingFramework == "golang.org/pkg/testing" {
+		telemetryFramework = GoTestingFramework
+	}
+	return telemetryFramework
+}
+func GetSessionTestingEventType() TestingEventType {
+	hasCodeOwners := utils.GetCodeOwners() != nil
+	_, hasCiProvider := utils.GetCITags()[constants.CIProviderName]
+	if hasCodeOwners && hasCiProvider {
+		return SessionHasCodeOwnerIsSupportedCiEventType
+	} else if hasCodeOwners {
+		return SessionHasCodeOwnerUnsupportedCiEventType
+	} else if hasCiProvider {
+		return SessionNoCodeOwnerIsSupportedCiEventType
+	} else {
+		return SessionNoCodeOwnerUnsupportedCiEventType
+	}
+}
 
 // EventCreated the number of events created by CI Visibility
-func EventCreated(testingFramework TestingFramework, eventType TestingEventType) {
+func EventCreated(testingFramework string, eventType TestingEventType) {
 	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "event_created", 1.0, removeEmptyStrings([]string{
-		(string)(testingFramework),
+		(string)(getTestingFramework(testingFramework)),
 		(string)(eventType),
 	}), true)
 }
 
 // EventFinished the number of events finished by CI Visibility
-func EventFinished(testingFramework TestingFramework, eventType TestingEventType) {
+func EventFinished(testingFramework string, eventType TestingEventType) {
 	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "event_finished", 1.0, removeEmptyStrings([]string{
-		(string)(testingFramework),
+		(string)(getTestingFramework(testingFramework)),
 		(string)(eventType),
 	}), true)
 }
 
 // CodeCoverageStarted the number of code coverage start calls by CI Visibility
-func CodeCoverageStarted(testingFramework TestingFramework, coverageLibraryType CoverageLibraryType) {
+func CodeCoverageStarted(testingFramework string, coverageLibraryType CoverageLibraryType) {
 	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "code_coverage_started", 1.0, removeEmptyStrings([]string{
-		(string)(testingFramework),
+		(string)(getTestingFramework(testingFramework)),
 		(string)(coverageLibraryType),
 	}), true)
 }
 
 // CodeCoverageFinished the number of code coverage finished calls by CI Visibility
-func CodeCoverageFinished(testingFramework TestingFramework, coverageLibraryType CoverageLibraryType) {
+func CodeCoverageFinished(testingFramework string, coverageLibraryType CoverageLibraryType) {
 	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "code_coverage_finished", 1.0, removeEmptyStrings([]string{
-		(string)(testingFramework),
+		(string)(getTestingFramework(testingFramework)),
 		(string)(coverageLibraryType),
 	}), true)
 }

--- a/internal/civisibility/utils/telemetry/telemetry_count.go
+++ b/internal/civisibility/utils/telemetry/telemetry_count.go
@@ -17,17 +17,6 @@ func getTestingFramework(testingFramework string) TestingFramework {
 	return telemetryFramework
 }
 
-func GetSessionTestingEventType(hasCodeOwners, hasCiProvider bool) TestingEventType {
-	if hasCodeOwners && hasCiProvider {
-		return SessionHasCodeOwnerIsSupportedCiEventType
-	} else if hasCodeOwners {
-		return SessionHasCodeOwnerUnsupportedCiEventType
-	} else if hasCiProvider {
-		return SessionNoCodeOwnerIsSupportedCiEventType
-	}
-	return SessionNoCodeOwnerUnsupportedCiEventType
-}
-
 func GetErrorTypeFromStatusCode(statusCode int) ErrorType {
 	switch statusCode {
 	case 0:
@@ -57,14 +46,14 @@ func GetErrorTypeFromStatusCode(statusCode int) ErrorType {
 
 // EventCreated the number of events created by CI Visibility
 func EventCreated(testingFramework string, eventType TestingEventType) {
-	tags := []string{(string)(getTestingFramework(testingFramework))}
+	tags := []string{string(getTestingFramework(testingFramework))}
 	tags = append(tags, eventType...)
 	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "event_created", 1.0, removeEmptyStrings(tags), true)
 }
 
 // EventFinished the number of events finished by CI Visibility
 func EventFinished(testingFramework string, eventType TestingEventType) {
-	tags := []string{(string)(getTestingFramework(testingFramework))}
+	tags := []string{string(getTestingFramework(testingFramework))}
 	tags = append(tags, eventType...)
 	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "event_finished", 1.0, removeEmptyStrings(tags), true)
 }
@@ -72,16 +61,16 @@ func EventFinished(testingFramework string, eventType TestingEventType) {
 // CodeCoverageStarted the number of code coverage start calls by CI Visibility
 func CodeCoverageStarted(testingFramework string, coverageLibraryType CoverageLibraryType) {
 	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "code_coverage_started", 1.0, removeEmptyStrings([]string{
-		(string)(getTestingFramework(testingFramework)),
-		(string)(coverageLibraryType),
+		string(getTestingFramework(testingFramework)),
+		string(coverageLibraryType),
 	}), true)
 }
 
 // CodeCoverageFinished the number of code coverage finished calls by CI Visibility
 func CodeCoverageFinished(testingFramework string, coverageLibraryType CoverageLibraryType) {
 	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "code_coverage_finished", 1.0, removeEmptyStrings([]string{
-		(string)(getTestingFramework(testingFramework)),
-		(string)(coverageLibraryType),
+		string(getTestingFramework(testingFramework)),
+		string(coverageLibraryType),
 	}), true)
 }
 
@@ -91,13 +80,16 @@ func EventsEnqueueForSerialization() {
 }
 
 // EndpointPayloadRequests the number of requests sent to the endpoint, regardless of success, tagged by endpoint type
-func EndpointPayloadRequests(endpointAndCompressionType EndpointAndCompressionType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "endpoint_payload.requests", 1.0, removeEmptyStrings(endpointAndCompressionType), true)
+func EndpointPayloadRequests(endpointType EndpointType, requestCompressedType RequestCompressedType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "endpoint_payload.requests", 1.0, removeEmptyStrings([]string{
+		string(endpointType),
+		string(requestCompressedType),
+	}), true)
 }
 
 // EndpointPayloadRequestsErrors the number of requests sent to the endpoint that errored, tagget by the error type and endpoint type and status code
 func EndpointPayloadRequestsErrors(endpointType EndpointType, errorType ErrorType) {
-	tags := []string{(string)(endpointType)}
+	tags := []string{string(endpointType)}
 	tags = append(tags, errorType...)
 	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "endpoint_payload.requests_errors", 1.0, removeEmptyStrings(tags), true)
 }
@@ -105,29 +97,29 @@ func EndpointPayloadRequestsErrors(endpointType EndpointType, errorType ErrorTyp
 // EndpointPayloadDropped the number of payloads dropped after all retries by CI Visibility
 func EndpointPayloadDropped(endpointType EndpointType) {
 	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "endpoint_payload.dropped", 1.0, removeEmptyStrings([]string{
-		(string)(endpointType),
+		string(endpointType),
 	}), true)
 }
 
 // GitCommand the number of git commands executed by CI Visibility
 func GitCommand(commandType CommandType) {
 	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git.command", 1.0, removeEmptyStrings([]string{
-		(string)(commandType),
+		string(commandType),
 	}), true)
 }
 
 // GitCommandErrors the number of git command that errored by CI Visibility
 func GitCommandErrors(commandType CommandType, exitCode CommandExitCodeType) {
 	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git.command_errors", 1.0, removeEmptyStrings([]string{
-		(string)(commandType),
-		(string)(exitCode),
+		string(commandType),
+		string(exitCode),
 	}), true)
 }
 
 // GitRequestsSearchCommits the number of requests sent to the search commit endpoint, regardless of success.
 func GitRequestsSearchCommits(requestCompressed RequestCompressedType) {
 	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.search_commits", 1.0, removeEmptyStrings([]string{
-		(string)(requestCompressed),
+		string(requestCompressed),
 	}), true)
 }
 
@@ -139,7 +131,7 @@ func GitRequestsSearchCommitsErrors(errorType ErrorType) {
 // GitRequestsObjectsPack the number of requests sent to the objects pack endpoint, tagged by the request compressed type.
 func GitRequestsObjectsPack(requestCompressed RequestCompressedType) {
 	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.objects_pack", 1.0, removeEmptyStrings([]string{
-		(string)(requestCompressed),
+		string(requestCompressed),
 	}), true)
 }
 
@@ -151,7 +143,7 @@ func GitRequestsObjectsPackErrors(errorType ErrorType) {
 // GitRequestsSettings the number of requests sent to the settings endpoint, tagged by the request compressed type.
 func GitRequestsSettings(requestCompressed RequestCompressedType) {
 	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.settings", 1.0, removeEmptyStrings([]string{
-		(string)(requestCompressed),
+		string(requestCompressed),
 	}), true)
 }
 
@@ -168,7 +160,7 @@ func GitRequestsSettingsResponse(settingsResponseType SettingsResponseType) {
 // ITRSkippableTestsRequest the number of requests sent to the ITR skippable tests endpoint, tagged by the request compressed type.
 func ITRSkippableTestsRequest(requestCompressed RequestCompressedType) {
 	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skippable_tests.request", 1.0, removeEmptyStrings([]string{
-		(string)(requestCompressed),
+		string(requestCompressed),
 	}), true)
 }
 
@@ -210,7 +202,7 @@ func CodeCoverageErrors() {
 // EarlyFlakeDetectionRequest the number of requests sent to the early flake detection endpoint, tagged by the request compressed type.
 func EarlyFlakeDetectionRequest(requestCompressed RequestCompressedType) {
 	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "early_flake_detection.request", 1.0, removeEmptyStrings([]string{
-		(string)(requestCompressed),
+		string(requestCompressed),
 	}), true)
 }
 

--- a/internal/civisibility/utils/telemetry/telemetry_count.go
+++ b/internal/civisibility/utils/telemetry/telemetry_count.go
@@ -27,9 +27,8 @@ func GetSessionTestingEventType() TestingEventType {
 		return SessionHasCodeOwnerUnsupportedCiEventType
 	} else if hasCiProvider {
 		return SessionNoCodeOwnerIsSupportedCiEventType
-	} else {
-		return SessionNoCodeOwnerUnsupportedCiEventType
 	}
+	return SessionNoCodeOwnerUnsupportedCiEventType
 }
 
 // EventCreated the number of events created by CI Visibility

--- a/internal/civisibility/utils/telemetry/telemetry_distribution.go
+++ b/internal/civisibility/utils/telemetry/telemetry_distribution.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
-package utils
+package telemetry
 
 import "gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 

--- a/internal/civisibility/utils/telemetry_count.go
+++ b/internal/civisibility/utils/telemetry_count.go
@@ -1,0 +1,332 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package utils
+
+import "gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
+
+// TestingFramework is a type for testing frameworks
+type TestingFramework string
+
+const (
+	GoTestingFramework TestingFramework = "test_framework:testing"
+	UnknownFramework   TestingFramework = "test_framework:unknown"
+)
+
+// TestingEventType is a type for testing event types
+type TestingEventType string
+
+const (
+	TestEventType                                                   TestingEventType = "event_type:test"
+	BenchmarkTestEventType                                          TestingEventType = "event_type:test;is_benchmark"
+	SuiteEventType                                                  TestingEventType = "event_type:suite"
+	ModuleEventType                                                 TestingEventType = "event_type:module"
+	SessionNoCodeOwnerIsSupportedCiEventType                        TestingEventType = "event_type:session"
+	SessionNoCodeOwnerUnsupportedCiEventType                        TestingEventType = "event_type:session;is_unsupported_ci"
+	SessionHasCodeOwnerIsSupportedCiEventType                       TestingEventType = "event_type:session;has_codeowner"
+	SessionHasCodeOwnerUnsupportedCiEventType                       TestingEventType = "event_type:session;has_codeowner;is_unsupported_ci"
+	TestEfdTestIsNewEventType                                       TestingEventType = "event_type:test;is_new:true"
+	TestEfdTestIsNewEfdAbortSlowEventType                           TestingEventType = "event_type:test;is_new:true;early_flake_detection_abort_reason:slow"
+	TestBrowserDriverSeleniumEventType                              TestingEventType = "event_type:test;browser_driver:selenium"
+	TestEfdTestIsNewBrowserDriverSeleniumEventType                  TestingEventType = "event_type:test;is_new:true;browser_driver:selenium"
+	TestEfdTestIsNewEfdAbortSlowBrowserDriverSeleniumEventType      TestingEventType = "event_type:test;is_new:true;early_flake_detection_abort_reason:slow;browser_driver:selenium"
+	TestBrowserDriverSeleniumIsRumEventType                         TestingEventType = "event_type:test;browser_driver:selenium;is_rum:true"
+	TestEfdTestIsNewBrowserDriverSeleniumIsRumEventType             TestingEventType = "event_type:test;is_new:true;browser_driver:selenium;is_rum:true"
+	TestEfdTestIsNewEfdAbortSlowBrowserDriverSeleniumIsRumEventType TestingEventType = "event_type:test;is_new:true;early_flake_detection_abort_reason:slow;browser_driver:selenium;is_rum:true"
+)
+
+// CoverageLibraryType is a type for coverage library types
+type CoverageLibraryType string
+
+const (
+	DefaultCoverageLibraryType CoverageLibraryType = "library:default"
+	UnknownCoverageLibraryType CoverageLibraryType = "library:unknown"
+)
+
+// EndpointAndCompressionType is a type for endpoint and compression types
+type EndpointAndCompressionType string
+
+const (
+	TestCycleUncompressedEndpointType         EndpointAndCompressionType = "endpoint:test_cycle"
+	TestCycleRequestCompressedEndpointType    EndpointAndCompressionType = "endpoint:test_cycle;rq_compressed:true"
+	CodeCoverageUncompressedEndpointType      EndpointAndCompressionType = "endpoint:code_coverage"
+	CodeCoverageRequestCompressedEndpointType EndpointAndCompressionType = "endpoint:code_coverage;rq_compressed:true"
+)
+
+// EndpointType is a type for endpoint types
+type EndpointType string
+
+const (
+	TestCycleEndpointType    EndpointType = "endpoint:test_cycle"
+	CodeCoverageEndpointType EndpointType = "endpoint:code_coverage"
+)
+
+// ErrorType is a type for error types
+type ErrorType string
+
+const (
+	TimeoutErrorType       ErrorType = "error_type:timeout"
+	NetworkErrorType       ErrorType = "error_type:network"
+	StatusCodeErrorType    ErrorType = "error_type:status_code"
+	StatusCode4xxErrorType ErrorType = "error_type:status_code_4xx_response"
+	StatusCode5xxErrorType ErrorType = "error_type:status_code_5xx_response"
+	StatusCode400ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:400"
+	StatusCode401ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:401"
+	StatusCode403ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:403"
+	StatusCode404ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:404"
+	StatusCode408ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:408"
+	StatusCode429ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:429"
+)
+
+// CommandType is a type for commands types
+type CommandType string
+
+const (
+	GetRepositoryCommandsType   CommandType = "command:get_repository"
+	GetBranchCommandsType       CommandType = "command:get_branch"
+	GetRemoteCommandsType       CommandType = "command:get_remote"
+	GetHeadCommandsType         CommandType = "command:get_head"
+	CheckShallowCommandsType    CommandType = "command:check_shallow"
+	UnshallowCommandsType       CommandType = "command:unshallow"
+	GetLocalCommitsCommandsType CommandType = "command:get_local_commits"
+	GetObjectsCommandsType      CommandType = "command:get_objects"
+	PackObjectsCommandsType     CommandType = "command:pack_objects"
+)
+
+// CommandExitCodeType is a type for command exit codes
+type CommandExitCodeType string
+
+const (
+	MissingCommandExitCode  CommandExitCodeType = "exit_code:missing"
+	UnknownCommandExitCode  CommandExitCodeType = "exit_code:unknown"
+	ECMinus1CommandExitCode CommandExitCodeType = "exit_code:-1"
+	EC1CommandExitCode      CommandExitCodeType = "exit_code:1"
+	EC2CommandExitCode      CommandExitCodeType = "exit_code:2"
+	EC127CommandExitCode    CommandExitCodeType = "exit_code:127"
+	EC128CommandExitCode    CommandExitCodeType = "exit_code:128"
+	EC129CommandExitCode    CommandExitCodeType = "exit_code:129"
+)
+
+// RequestCompressedType is a type for request compressed types
+type RequestCompressedType string
+
+const (
+	UncompressedRequestCompressedType RequestCompressedType = ""
+	CompressedRequestCompressedType   RequestCompressedType = "rq_compressed:true"
+)
+
+// ResponseCompressedType is a type for response compressed types
+type ResponseCompressedType string
+
+const (
+	UncompressedResponseCompressedType ResponseCompressedType = ""
+	CompressedResponseCompressedType   ResponseCompressedType = "rs_compressed:true"
+)
+
+// SettingsResponseType is a type for settings response types
+type SettingsResponseType string
+
+const (
+	CoverageDisabledItrSkipDisabledSettingsResponseType           SettingsResponseType = ""
+	CoverageEnabledItrSkipDisabledSettingsResponseType            SettingsResponseType = "coverage_enabled"
+	CoverageDisabledItrSkipEnabledSettingsResponseType            SettingsResponseType = "itrskip_enabled"
+	CoverageEnabledItrSkipEnabledSettingsResponseType             SettingsResponseType = "coverage_enabled;itrskip_enabled"
+	CoverageDisabledItrSkipDisabledEfdEnabledSettingsResponseType SettingsResponseType = "early_flake_detection_enabled:true"
+	CoverageEnabledItrSkipDisabledEfdEnabledSettingsResponseType  SettingsResponseType = "coverage_enabled;early_flake_detection_enabled:true"
+	CoverageDisabledItrSkipEnabledEfdEnabledSettingsResponseType  SettingsResponseType = "itrskip_enabled;early_flake_detection_enabled:true"
+	CoverageEnabledItrSkipEnabledEfdEnabledSettingsResponseType   SettingsResponseType = "coverage_enabled;itrskip_enabled;early_flake_detection_enabled:true"
+)
+
+// EventCreated the number of events created by CI Visibility
+func EventCreated(testingFramework TestingFramework, eventType TestingEventType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "event_created", 1.0, []string{
+		(string)(testingFramework),
+		(string)(eventType),
+	}, true)
+}
+
+// EventFinished the number of events finished by CI Visibility
+func EventFinished(testingFramework TestingFramework, eventType TestingEventType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "event_finished", 1.0, []string{
+		(string)(testingFramework),
+		(string)(eventType),
+	}, true)
+}
+
+// CodeCoverageStarted the number of code coverage start calls by CI Visibility
+func CodeCoverageStarted(testingFramework TestingFramework, coverageLibraryType CoverageLibraryType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "code_coverage_started", 1.0, []string{
+		(string)(testingFramework),
+		(string)(coverageLibraryType),
+	}, true)
+}
+
+// CodeCoverageFinished the number of code coverage finished calls by CI Visibility
+func CodeCoverageFinished(testingFramework TestingFramework, coverageLibraryType CoverageLibraryType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "code_coverage_finished", 1.0, []string{
+		(string)(testingFramework),
+		(string)(coverageLibraryType),
+	}, true)
+}
+
+// EventsEnqueueForSerialization the number of events enqueued for serialization by CI Visibility
+func EventsEnqueueForSerialization() {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "events_enqueued_for_serialization", 1.0, []string{}, true)
+}
+
+// EndpointPayloadRequests the number of requests sent to the endpoint, regardless of success, tagged by endpoint type
+func EndpointPayloadRequests(endpointAndCompressionType EndpointAndCompressionType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "endpoint_payload.requests", 1.0, []string{
+		(string)(endpointAndCompressionType),
+	}, true)
+}
+
+// EndpointPayloadRequestsErrors the number of requests sent to the endpoint that errored, tagget by the error type and endpoint type and status code
+func EndpointPayloadRequestsErrors(endpointType EndpointType, errorType ErrorType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "endpoint_payload.requests_errors", 1.0, []string{
+		(string)(endpointType),
+		(string)(errorType),
+	}, true)
+}
+
+// EndpointPayloadDropped the number of payloads dropped after all retries by CI Visibility
+func EndpointPayloadDropped(endpointType EndpointType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "endpoint_payload.dropped", 1.0, []string{
+		(string)(endpointType),
+	}, true)
+}
+
+// GitCommand the number of git commands executed by CI Visibility
+func GitCommand(commandType CommandType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git.command", 1.0, []string{
+		(string)(commandType),
+	}, true)
+}
+
+// GitCommandErrors the number of git command that errored by CI Visibility
+func GitCommandErrors(commandType CommandType, exitCode CommandExitCodeType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git.command_errors", 1.0, []string{
+		(string)(commandType),
+		(string)(exitCode),
+	}, true)
+}
+
+// GitRequestsSearchCommits the number of requests sent to the search commit endpoint, regardless of success.
+func GitRequestsSearchCommits(requestCompressed RequestCompressedType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.search_commits", 1.0, []string{
+		(string)(requestCompressed),
+	}, true)
+}
+
+// GitRequestsSearchCommitsErrors the number of requests sent to the search commit endpoint that errored, tagged by the error type.
+func GitRequestsSearchCommitsErrors(errorType ErrorType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.search_commits_errors", 1.0, []string{
+		(string)(errorType),
+	}, true)
+}
+
+// GitRequestsObjectsPack the number of requests sent to the objects pack endpoint, tagged by the request compressed type.
+func GitRequestsObjectsPack(requestCompressed RequestCompressedType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.objects_pack", 1.0, []string{
+		(string)(requestCompressed),
+	}, true)
+}
+
+// GitRequestsObjectsPackErrors the number of requests sent to the objects pack endpoint that errored, tagged by the error type.
+func GitRequestsObjectsPackErrors(errorType ErrorType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.objects_pack_errors", 1.0, []string{
+		(string)(errorType),
+	}, true)
+}
+
+// GitRequestsSettings the number of requests sent to the settings endpoint, tagged by the request compressed type.
+func GitRequestsSettings(requestCompressed RequestCompressedType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.settings", 1.0, []string{
+		(string)(requestCompressed),
+	}, true)
+}
+
+// GitRequestsSettingsErrors the number of requests sent to the settings endpoint that errored, tagged by the error type.
+func GitRequestsSettingsErrors(errorType ErrorType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.settings_errors", 1.0, []string{
+		(string)(errorType),
+	}, true)
+}
+
+// GitRequestsSettingsResponse the number of settings responses received by CI Visibility, tagged by the settings response type.
+func GitRequestsSettingsResponse(settingsResponseType SettingsResponseType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.settings_response", 1.0, []string{
+		(string)(settingsResponseType),
+	}, true)
+}
+
+// ITRSkippableTestsRequest the number of requests sent to the ITR skippable tests endpoint, tagged by the request compressed type.
+func ITRSkippableTestsRequest(requestCompressed RequestCompressedType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skippable_tests.request", 1.0, []string{
+		(string)(requestCompressed),
+	}, true)
+}
+
+// ITRSkippableTestsRequestErrors the number of requests sent to the ITR skippable tests endpoint that errored, tagged by the error type.
+func ITRSkippableTestsRequestErrors(errorType ErrorType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skippable_tests.request_errors", 1.0, []string{
+		(string)(errorType),
+	}, true)
+}
+
+// ITRSkippableTestsResponseTests the number of tests received in the ITR skippable tests response by CI Visibility.
+func ITRSkippableTestsResponseTests() {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skippable_tests.response_tests", 1.0, []string{}, true)
+}
+
+// ITRSkippableTestsResponseSuites the number of suites received in the ITR skippable tests response by CI Visibility.
+func ITRSkippableTestsResponseSuites() {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skippable_tests.response_suites", 1.0, []string{}, true)
+}
+
+// ITRSkipped the number of ITR tests skipped by CI Visibility, tagged by the event type.
+func ITRSkipped(eventType TestingEventType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skipped", 1.0, []string{
+		(string)(eventType),
+	}, true)
+}
+
+// ITRUnskippable the number of ITR tests unskippable by CI Visibility, tagged by the event type.
+func ITRUnskippable(eventType TestingEventType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_unskippable", 1.0, []string{
+		(string)(eventType),
+	}, true)
+}
+
+// ITRForcedRun the number of tests or test suites that would've been skipped by ITR but were forced to run because of their unskippable status by CI Visibility.
+func ITRForcedRun(eventType TestingEventType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_forced_run", 1.0, []string{
+		(string)(eventType),
+	}, true)
+}
+
+// CodeCoverageIsEmpty the number of code coverage payloads that are empty by CI Visibility.
+func CodeCoverageIsEmpty() {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "code_coverage.is_empty", 1.0, []string{}, true)
+}
+
+// CodeCoverageErrors the number of errors while processing code coverage by CI Visibility.
+func CodeCoverageErrors() {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "code_coverage.errors", 1.0, []string{}, true)
+}
+
+// EarlyFlakeDetectionRequest the number of requests sent to the early flake detection endpoint, tagged by the request compressed type.
+func EarlyFlakeDetectionRequest(requestCompressed RequestCompressedType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "early_flake_detection.request", 1.0, []string{
+		(string)(requestCompressed),
+	}, true)
+}
+
+// EarlyFlakeDetectionRequestErrors the number of requests sent to the early flake detection endpoint that errored, tagged by the error type.
+func EarlyFlakeDetectionRequestErrors(errorType ErrorType) {
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "early_flake_detection.request_errors", 1.0, []string{
+		(string)(errorType),
+	}, true)
+}

--- a/internal/civisibility/utils/telemetry_count.go
+++ b/internal/civisibility/utils/telemetry_count.go
@@ -7,326 +7,194 @@ package utils
 
 import "gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 
-// TestingFramework is a type for testing frameworks
-type TestingFramework string
-
-const (
-	GoTestingFramework TestingFramework = "test_framework:testing"
-	UnknownFramework   TestingFramework = "test_framework:unknown"
-)
-
-// TestingEventType is a type for testing event types
-type TestingEventType string
-
-const (
-	TestEventType                                                   TestingEventType = "event_type:test"
-	BenchmarkTestEventType                                          TestingEventType = "event_type:test;is_benchmark"
-	SuiteEventType                                                  TestingEventType = "event_type:suite"
-	ModuleEventType                                                 TestingEventType = "event_type:module"
-	SessionNoCodeOwnerIsSupportedCiEventType                        TestingEventType = "event_type:session"
-	SessionNoCodeOwnerUnsupportedCiEventType                        TestingEventType = "event_type:session;is_unsupported_ci"
-	SessionHasCodeOwnerIsSupportedCiEventType                       TestingEventType = "event_type:session;has_codeowner"
-	SessionHasCodeOwnerUnsupportedCiEventType                       TestingEventType = "event_type:session;has_codeowner;is_unsupported_ci"
-	TestEfdTestIsNewEventType                                       TestingEventType = "event_type:test;is_new:true"
-	TestEfdTestIsNewEfdAbortSlowEventType                           TestingEventType = "event_type:test;is_new:true;early_flake_detection_abort_reason:slow"
-	TestBrowserDriverSeleniumEventType                              TestingEventType = "event_type:test;browser_driver:selenium"
-	TestEfdTestIsNewBrowserDriverSeleniumEventType                  TestingEventType = "event_type:test;is_new:true;browser_driver:selenium"
-	TestEfdTestIsNewEfdAbortSlowBrowserDriverSeleniumEventType      TestingEventType = "event_type:test;is_new:true;early_flake_detection_abort_reason:slow;browser_driver:selenium"
-	TestBrowserDriverSeleniumIsRumEventType                         TestingEventType = "event_type:test;browser_driver:selenium;is_rum:true"
-	TestEfdTestIsNewBrowserDriverSeleniumIsRumEventType             TestingEventType = "event_type:test;is_new:true;browser_driver:selenium;is_rum:true"
-	TestEfdTestIsNewEfdAbortSlowBrowserDriverSeleniumIsRumEventType TestingEventType = "event_type:test;is_new:true;early_flake_detection_abort_reason:slow;browser_driver:selenium;is_rum:true"
-)
-
-// CoverageLibraryType is a type for coverage library types
-type CoverageLibraryType string
-
-const (
-	DefaultCoverageLibraryType CoverageLibraryType = "library:default"
-	UnknownCoverageLibraryType CoverageLibraryType = "library:unknown"
-)
-
-// EndpointAndCompressionType is a type for endpoint and compression types
-type EndpointAndCompressionType string
-
-const (
-	TestCycleUncompressedEndpointType         EndpointAndCompressionType = "endpoint:test_cycle"
-	TestCycleRequestCompressedEndpointType    EndpointAndCompressionType = "endpoint:test_cycle;rq_compressed:true"
-	CodeCoverageUncompressedEndpointType      EndpointAndCompressionType = "endpoint:code_coverage"
-	CodeCoverageRequestCompressedEndpointType EndpointAndCompressionType = "endpoint:code_coverage;rq_compressed:true"
-)
-
-// EndpointType is a type for endpoint types
-type EndpointType string
-
-const (
-	TestCycleEndpointType    EndpointType = "endpoint:test_cycle"
-	CodeCoverageEndpointType EndpointType = "endpoint:code_coverage"
-)
-
-// ErrorType is a type for error types
-type ErrorType string
-
-const (
-	TimeoutErrorType       ErrorType = "error_type:timeout"
-	NetworkErrorType       ErrorType = "error_type:network"
-	StatusCodeErrorType    ErrorType = "error_type:status_code"
-	StatusCode4xxErrorType ErrorType = "error_type:status_code_4xx_response"
-	StatusCode5xxErrorType ErrorType = "error_type:status_code_5xx_response"
-	StatusCode400ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:400"
-	StatusCode401ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:401"
-	StatusCode403ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:403"
-	StatusCode404ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:404"
-	StatusCode408ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:408"
-	StatusCode429ErrorType ErrorType = "error_type:status_code_4xx_response;status_code:429"
-)
-
-// CommandType is a type for commands types
-type CommandType string
-
-const (
-	GetRepositoryCommandsType   CommandType = "command:get_repository"
-	GetBranchCommandsType       CommandType = "command:get_branch"
-	GetRemoteCommandsType       CommandType = "command:get_remote"
-	GetHeadCommandsType         CommandType = "command:get_head"
-	CheckShallowCommandsType    CommandType = "command:check_shallow"
-	UnshallowCommandsType       CommandType = "command:unshallow"
-	GetLocalCommitsCommandsType CommandType = "command:get_local_commits"
-	GetObjectsCommandsType      CommandType = "command:get_objects"
-	PackObjectsCommandsType     CommandType = "command:pack_objects"
-)
-
-// CommandExitCodeType is a type for command exit codes
-type CommandExitCodeType string
-
-const (
-	MissingCommandExitCode  CommandExitCodeType = "exit_code:missing"
-	UnknownCommandExitCode  CommandExitCodeType = "exit_code:unknown"
-	ECMinus1CommandExitCode CommandExitCodeType = "exit_code:-1"
-	EC1CommandExitCode      CommandExitCodeType = "exit_code:1"
-	EC2CommandExitCode      CommandExitCodeType = "exit_code:2"
-	EC127CommandExitCode    CommandExitCodeType = "exit_code:127"
-	EC128CommandExitCode    CommandExitCodeType = "exit_code:128"
-	EC129CommandExitCode    CommandExitCodeType = "exit_code:129"
-)
-
-// RequestCompressedType is a type for request compressed types
-type RequestCompressedType string
-
-const (
-	UncompressedRequestCompressedType RequestCompressedType = ""
-	CompressedRequestCompressedType   RequestCompressedType = "rq_compressed:true"
-)
-
-// ResponseCompressedType is a type for response compressed types
-type ResponseCompressedType string
-
-const (
-	UncompressedResponseCompressedType ResponseCompressedType = ""
-	CompressedResponseCompressedType   ResponseCompressedType = "rs_compressed:true"
-)
-
-// SettingsResponseType is a type for settings response types
-type SettingsResponseType string
-
-const (
-	CoverageDisabledItrSkipDisabledSettingsResponseType           SettingsResponseType = ""
-	CoverageEnabledItrSkipDisabledSettingsResponseType            SettingsResponseType = "coverage_enabled"
-	CoverageDisabledItrSkipEnabledSettingsResponseType            SettingsResponseType = "itrskip_enabled"
-	CoverageEnabledItrSkipEnabledSettingsResponseType             SettingsResponseType = "coverage_enabled;itrskip_enabled"
-	CoverageDisabledItrSkipDisabledEfdEnabledSettingsResponseType SettingsResponseType = "early_flake_detection_enabled:true"
-	CoverageEnabledItrSkipDisabledEfdEnabledSettingsResponseType  SettingsResponseType = "coverage_enabled;early_flake_detection_enabled:true"
-	CoverageDisabledItrSkipEnabledEfdEnabledSettingsResponseType  SettingsResponseType = "itrskip_enabled;early_flake_detection_enabled:true"
-	CoverageEnabledItrSkipEnabledEfdEnabledSettingsResponseType   SettingsResponseType = "coverage_enabled;itrskip_enabled;early_flake_detection_enabled:true"
-)
-
 // EventCreated the number of events created by CI Visibility
 func EventCreated(testingFramework TestingFramework, eventType TestingEventType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "event_created", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "event_created", 1.0, removeEmptyStrings([]string{
 		(string)(testingFramework),
 		(string)(eventType),
-	}, true)
+	}), true)
 }
 
 // EventFinished the number of events finished by CI Visibility
 func EventFinished(testingFramework TestingFramework, eventType TestingEventType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "event_finished", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "event_finished", 1.0, removeEmptyStrings([]string{
 		(string)(testingFramework),
 		(string)(eventType),
-	}, true)
+	}), true)
 }
 
 // CodeCoverageStarted the number of code coverage start calls by CI Visibility
 func CodeCoverageStarted(testingFramework TestingFramework, coverageLibraryType CoverageLibraryType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "code_coverage_started", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "code_coverage_started", 1.0, removeEmptyStrings([]string{
 		(string)(testingFramework),
 		(string)(coverageLibraryType),
-	}, true)
+	}), true)
 }
 
 // CodeCoverageFinished the number of code coverage finished calls by CI Visibility
 func CodeCoverageFinished(testingFramework TestingFramework, coverageLibraryType CoverageLibraryType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "code_coverage_finished", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "code_coverage_finished", 1.0, removeEmptyStrings([]string{
 		(string)(testingFramework),
 		(string)(coverageLibraryType),
-	}, true)
+	}), true)
 }
 
 // EventsEnqueueForSerialization the number of events enqueued for serialization by CI Visibility
 func EventsEnqueueForSerialization() {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "events_enqueued_for_serialization", 1.0, []string{}, true)
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "events_enqueued_for_serialization", 1.0, nil, true)
 }
 
 // EndpointPayloadRequests the number of requests sent to the endpoint, regardless of success, tagged by endpoint type
 func EndpointPayloadRequests(endpointAndCompressionType EndpointAndCompressionType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "endpoint_payload.requests", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "endpoint_payload.requests", 1.0, removeEmptyStrings([]string{
 		(string)(endpointAndCompressionType),
-	}, true)
+	}), true)
 }
 
 // EndpointPayloadRequestsErrors the number of requests sent to the endpoint that errored, tagget by the error type and endpoint type and status code
 func EndpointPayloadRequestsErrors(endpointType EndpointType, errorType ErrorType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "endpoint_payload.requests_errors", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "endpoint_payload.requests_errors", 1.0, removeEmptyStrings([]string{
 		(string)(endpointType),
 		(string)(errorType),
-	}, true)
+	}), true)
 }
 
 // EndpointPayloadDropped the number of payloads dropped after all retries by CI Visibility
 func EndpointPayloadDropped(endpointType EndpointType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "endpoint_payload.dropped", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "endpoint_payload.dropped", 1.0, removeEmptyStrings([]string{
 		(string)(endpointType),
-	}, true)
+	}), true)
 }
 
 // GitCommand the number of git commands executed by CI Visibility
 func GitCommand(commandType CommandType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git.command", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git.command", 1.0, removeEmptyStrings([]string{
 		(string)(commandType),
-	}, true)
+	}), true)
 }
 
 // GitCommandErrors the number of git command that errored by CI Visibility
 func GitCommandErrors(commandType CommandType, exitCode CommandExitCodeType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git.command_errors", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git.command_errors", 1.0, removeEmptyStrings([]string{
 		(string)(commandType),
 		(string)(exitCode),
-	}, true)
+	}), true)
 }
 
 // GitRequestsSearchCommits the number of requests sent to the search commit endpoint, regardless of success.
 func GitRequestsSearchCommits(requestCompressed RequestCompressedType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.search_commits", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.search_commits", 1.0, removeEmptyStrings([]string{
 		(string)(requestCompressed),
-	}, true)
+	}), true)
 }
 
 // GitRequestsSearchCommitsErrors the number of requests sent to the search commit endpoint that errored, tagged by the error type.
 func GitRequestsSearchCommitsErrors(errorType ErrorType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.search_commits_errors", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.search_commits_errors", 1.0, removeEmptyStrings([]string{
 		(string)(errorType),
-	}, true)
+	}), true)
 }
 
 // GitRequestsObjectsPack the number of requests sent to the objects pack endpoint, tagged by the request compressed type.
 func GitRequestsObjectsPack(requestCompressed RequestCompressedType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.objects_pack", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.objects_pack", 1.0, removeEmptyStrings([]string{
 		(string)(requestCompressed),
-	}, true)
+	}), true)
 }
 
 // GitRequestsObjectsPackErrors the number of requests sent to the objects pack endpoint that errored, tagged by the error type.
 func GitRequestsObjectsPackErrors(errorType ErrorType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.objects_pack_errors", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.objects_pack_errors", 1.0, removeEmptyStrings([]string{
 		(string)(errorType),
-	}, true)
+	}), true)
 }
 
 // GitRequestsSettings the number of requests sent to the settings endpoint, tagged by the request compressed type.
 func GitRequestsSettings(requestCompressed RequestCompressedType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.settings", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.settings", 1.0, removeEmptyStrings([]string{
 		(string)(requestCompressed),
-	}, true)
+	}), true)
 }
 
 // GitRequestsSettingsErrors the number of requests sent to the settings endpoint that errored, tagged by the error type.
 func GitRequestsSettingsErrors(errorType ErrorType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.settings_errors", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.settings_errors", 1.0, removeEmptyStrings([]string{
 		(string)(errorType),
-	}, true)
+	}), true)
 }
 
 // GitRequestsSettingsResponse the number of settings responses received by CI Visibility, tagged by the settings response type.
 func GitRequestsSettingsResponse(settingsResponseType SettingsResponseType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.settings_response", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "git_requests.settings_response", 1.0, removeEmptyStrings([]string{
 		(string)(settingsResponseType),
-	}, true)
+	}), true)
 }
 
 // ITRSkippableTestsRequest the number of requests sent to the ITR skippable tests endpoint, tagged by the request compressed type.
 func ITRSkippableTestsRequest(requestCompressed RequestCompressedType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skippable_tests.request", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skippable_tests.request", 1.0, removeEmptyStrings([]string{
 		(string)(requestCompressed),
-	}, true)
+	}), true)
 }
 
 // ITRSkippableTestsRequestErrors the number of requests sent to the ITR skippable tests endpoint that errored, tagged by the error type.
 func ITRSkippableTestsRequestErrors(errorType ErrorType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skippable_tests.request_errors", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skippable_tests.request_errors", 1.0, removeEmptyStrings([]string{
 		(string)(errorType),
-	}, true)
+	}), true)
 }
 
 // ITRSkippableTestsResponseTests the number of tests received in the ITR skippable tests response by CI Visibility.
 func ITRSkippableTestsResponseTests() {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skippable_tests.response_tests", 1.0, []string{}, true)
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skippable_tests.response_tests", 1.0, nil, true)
 }
 
 // ITRSkippableTestsResponseSuites the number of suites received in the ITR skippable tests response by CI Visibility.
 func ITRSkippableTestsResponseSuites() {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skippable_tests.response_suites", 1.0, []string{}, true)
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skippable_tests.response_suites", 1.0, nil, true)
 }
 
 // ITRSkipped the number of ITR tests skipped by CI Visibility, tagged by the event type.
 func ITRSkipped(eventType TestingEventType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skipped", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_skipped", 1.0, removeEmptyStrings([]string{
 		(string)(eventType),
-	}, true)
+	}), true)
 }
 
 // ITRUnskippable the number of ITR tests unskippable by CI Visibility, tagged by the event type.
 func ITRUnskippable(eventType TestingEventType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_unskippable", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_unskippable", 1.0, removeEmptyStrings([]string{
 		(string)(eventType),
-	}, true)
+	}), true)
 }
 
 // ITRForcedRun the number of tests or test suites that would've been skipped by ITR but were forced to run because of their unskippable status by CI Visibility.
 func ITRForcedRun(eventType TestingEventType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_forced_run", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "itr_forced_run", 1.0, removeEmptyStrings([]string{
 		(string)(eventType),
-	}, true)
+	}), true)
 }
 
 // CodeCoverageIsEmpty the number of code coverage payloads that are empty by CI Visibility.
 func CodeCoverageIsEmpty() {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "code_coverage.is_empty", 1.0, []string{}, true)
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "code_coverage.is_empty", 1.0, nil, true)
 }
 
 // CodeCoverageErrors the number of errors while processing code coverage by CI Visibility.
 func CodeCoverageErrors() {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "code_coverage.errors", 1.0, []string{}, true)
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "code_coverage.errors", 1.0, nil, true)
 }
 
 // EarlyFlakeDetectionRequest the number of requests sent to the early flake detection endpoint, tagged by the request compressed type.
 func EarlyFlakeDetectionRequest(requestCompressed RequestCompressedType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "early_flake_detection.request", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "early_flake_detection.request", 1.0, removeEmptyStrings([]string{
 		(string)(requestCompressed),
-	}, true)
+	}), true)
 }
 
 // EarlyFlakeDetectionRequestErrors the number of requests sent to the early flake detection endpoint that errored, tagged by the error type.
 func EarlyFlakeDetectionRequestErrors(errorType ErrorType) {
-	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "early_flake_detection.request_errors", 1.0, []string{
+	telemetry.GlobalClient.Count(telemetry.NamespaceCiVisibility, "early_flake_detection.request_errors", 1.0, removeEmptyStrings([]string{
 		(string)(errorType),
-	}, true)
+	}), true)
 }

--- a/internal/civisibility/utils/telemetry_distribution.go
+++ b/internal/civisibility/utils/telemetry_distribution.go
@@ -9,44 +9,44 @@ import "gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 
 // EndpointPayloadBytes records the size in bytes of the serialized payload by CI Visibility.
 func EndpointPayloadBytes(endpointType EndpointType, value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "endpoint_payload.bytes", value, []string{
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "endpoint_payload.bytes", value, removeEmptyStrings([]string{
 		(string)(endpointType),
-	}, true)
+	}), true)
 }
 
 // EndpointPayloadRequestsMs records the time it takes to send the payload sent to the endpoint in ms by CI Visibility.
 func EndpointPayloadRequestsMs(endpointType EndpointType, value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "endpoint_payload.requests_ms", value, []string{
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "endpoint_payload.requests_ms", value, removeEmptyStrings([]string{
 		(string)(endpointType),
-	}, true)
+	}), true)
 }
 
 // EndpointPayloadEventsCount records the number of events in the payload sent to the endpoint by CI Visibility.
 func EndpointPayloadEventsCount(endpointType EndpointType, value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "endpoint_payload.events_count", value, []string{
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "endpoint_payload.events_count", value, removeEmptyStrings([]string{
 		(string)(endpointType),
-	}, true)
+	}), true)
 }
 
 // EndpointEventsSerializationMs records the time it takes to serialize the events in the payload sent to the endpoint in ms by CI Visibility.
 func EndpointEventsSerializationMs(endpointType EndpointType, value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "endpoint_payload.events_serialization_ms", value, []string{
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "endpoint_payload.events_serialization_ms", value, removeEmptyStrings([]string{
 		(string)(endpointType),
-	}, true)
+	}), true)
 }
 
 // GitCommandMs records the time it takes to execute a git command in ms by CI Visibility.
 func GitCommandMs(commandType CommandType, value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "git.command_ms", value, []string{
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "git.command_ms", value, removeEmptyStrings([]string{
 		(string)(commandType),
-	}, true)
+	}), true)
 }
 
 // GitRequestsSearchCommitsMs records the time it takes to get the response of the search commit quest in ms by CI Visibility.
 func GitRequestsSearchCommitsMs(responseCompressedType ResponseCompressedType, value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "git_requests.search_commits_ms", value, []string{
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "git_requests.search_commits_ms", value, removeEmptyStrings([]string{
 		(string)(responseCompressedType),
-	}, true)
+	}), true)
 }
 
 // GitRequestsObjectsPackMs records the time it takes to get the response of the objects pack request in ms by CI Visibility.
@@ -76,9 +76,9 @@ func ITRSkippableTestsRequestMs(value float64) {
 
 // ITRSkippableTestsResponseBytes records the number of bytes received by the endpoint. Tagged with a boolean flag set to true if response body is compressed.
 func ITRSkippableTestsResponseBytes(responseCompressedType ResponseCompressedType, value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "itr_skippable_tests.response_bytes", value, []string{
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "itr_skippable_tests.response_bytes", value, removeEmptyStrings([]string{
 		(string)(responseCompressedType),
-	}, true)
+	}), true)
 }
 
 // CodeCoverageFiles records the number of files in the code coverage report by CI Visibility.
@@ -93,9 +93,9 @@ func EarlyFlakeDetectionRequestMs(value float64) {
 
 // EarlyFlakeDetectionResponseBytes records the number of bytes received by the endpoint. Tagged with a boolean flag set to true if response body is compressed.
 func EarlyFlakeDetectionResponseBytes(responseCompressedType ResponseCompressedType, value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "early_flake_detection.response_bytes", value, []string{
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "early_flake_detection.response_bytes", value, removeEmptyStrings([]string{
 		(string)(responseCompressedType),
-	}, true)
+	}), true)
 }
 
 // EarlyFlakeDetectionResponseTests records the number of tests in the response of the early flake detection endpoint by CI Visibility.

--- a/internal/civisibility/utils/telemetry_distribution.go
+++ b/internal/civisibility/utils/telemetry_distribution.go
@@ -1,0 +1,104 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package utils
+
+import "gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
+
+// EndpointPayloadBytes records the size in bytes of the serialized payload by CI Visibility.
+func EndpointPayloadBytes(endpointType EndpointType, value float64) {
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "endpoint_payload.bytes", value, []string{
+		(string)(endpointType),
+	}, true)
+}
+
+// EndpointPayloadRequestsMs records the time it takes to send the payload sent to the endpoint in ms by CI Visibility.
+func EndpointPayloadRequestsMs(endpointType EndpointType, value float64) {
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "endpoint_payload.requests_ms", value, []string{
+		(string)(endpointType),
+	}, true)
+}
+
+// EndpointPayloadEventsCount records the number of events in the payload sent to the endpoint by CI Visibility.
+func EndpointPayloadEventsCount(endpointType EndpointType, value float64) {
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "endpoint_payload.events_count", value, []string{
+		(string)(endpointType),
+	}, true)
+}
+
+// EndpointEventsSerializationMs records the time it takes to serialize the events in the payload sent to the endpoint in ms by CI Visibility.
+func EndpointEventsSerializationMs(endpointType EndpointType, value float64) {
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "endpoint_payload.events_serialization_ms", value, []string{
+		(string)(endpointType),
+	}, true)
+}
+
+// GitCommandMs records the time it takes to execute a git command in ms by CI Visibility.
+func GitCommandMs(commandType CommandType, value float64) {
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "git.command_ms", value, []string{
+		(string)(commandType),
+	}, true)
+}
+
+// GitRequestsSearchCommitsMs records the time it takes to get the response of the search commit quest in ms by CI Visibility.
+func GitRequestsSearchCommitsMs(responseCompressedType ResponseCompressedType, value float64) {
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "git_requests.search_commits_ms", value, []string{
+		(string)(responseCompressedType),
+	}, true)
+}
+
+// GitRequestsObjectsPackMs records the time it takes to get the response of the objects pack request in ms by CI Visibility.
+func GitRequestsObjectsPackMs(value float64) {
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "git_requests.objects_pack_ms", value, nil, true)
+}
+
+// GitRequestsObjectsPackBytes records the sum of the sizes of the object pack files inside a single payload by CI Visibility
+func GitRequestsObjectsPackBytes(value float64) {
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "git_requests.objects_pack_bytes", value, nil, true)
+}
+
+// GitRequestsObjectsPackFiles records the number of files sent in the object pack payload by CI Visibility.
+func GitRequestsObjectsPackFiles(value float64) {
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "git_requests.objects_pack_files", value, nil, true)
+}
+
+// GitRequestsSettingsMs records the time it takes to get the response of the settings endpoint request in ms by CI Visibility.
+func GitRequestsSettingsMs(value float64) {
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "git_requests.settings_ms", value, nil, true)
+}
+
+// ITRSkippableTestsRequestMs records the time it takes to get the response of the itr skippable tests endpoint request in ms by CI Visibility.
+func ITRSkippableTestsRequestMs(value float64) {
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "itr_skippable_tests.request_ms", value, nil, true)
+}
+
+// ITRSkippableTestsResponseBytes records the number of bytes received by the endpoint. Tagged with a boolean flag set to true if response body is compressed.
+func ITRSkippableTestsResponseBytes(responseCompressedType ResponseCompressedType, value float64) {
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "itr_skippable_tests.response_bytes", value, []string{
+		(string)(responseCompressedType),
+	}, true)
+}
+
+// CodeCoverageFiles records the number of files in the code coverage report by CI Visibility.
+func CodeCoverageFiles(value float64) {
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "code_coverage.files", value, nil, true)
+}
+
+// EarlyFlakeDetectionRequestMs records the time it takes to get the response of the early flake detection endpoint request in ms by CI Visibility.
+func EarlyFlakeDetectionRequestMs(value float64) {
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "early_flake_detection.request_ms", value, nil, true)
+}
+
+// EarlyFlakeDetectionResponseBytes records the number of bytes received by the endpoint. Tagged with a boolean flag set to true if response body is compressed.
+func EarlyFlakeDetectionResponseBytes(responseCompressedType ResponseCompressedType, value float64) {
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "early_flake_detection.response_bytes", value, []string{
+		(string)(responseCompressedType),
+	}, true)
+}
+
+// EarlyFlakeDetectionResponseTests records the number of tests in the response of the early flake detection endpoint by CI Visibility.
+func EarlyFlakeDetectionResponseTests(value float64) {
+	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "early_flake_detection.response_tests", value, nil, true)
+}

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -575,7 +575,6 @@ func (r *Request) trySubmit() (retry bool, err error) {
 		return false, err
 	}
 
-	log("submitting telemetry request to %s\n%s", r.URL, string(b))
 	req, err := http.NewRequest(http.MethodPost, r.URL, bytes.NewReader(b))
 	if err != nil {
 		return false, err

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -251,7 +251,7 @@ func (c *client) start(configuration []Configuration, namespace Namespace, flush
 	}
 
 	if flush {
-		c.flush()
+		c.flush(nil)
 	}
 	c.heartbeatInterval = heartbeatInterval()
 	c.heartbeatT = time.AfterFunc(c.heartbeatInterval, c.backgroundHeartbeat)
@@ -280,7 +280,16 @@ func (c *client) Stop() {
 	// close request types have no body
 	r := c.newRequest(RequestTypeAppClosing)
 	c.scheduleSubmit(r)
-	c.flush()
+	if internal.BoolEnv("DD_CIVISIBILITY_ENABLED", false) {
+		cnn := make(chan struct{})
+		c.flush(func() {
+			cnn <- struct{}{}
+			close(cnn)
+		})
+		<-cnn
+	} else {
+		c.flush(nil)
+	}
 }
 
 // Disabled returns whether instrumentation telemetry is disabled
@@ -382,7 +391,7 @@ func (c *client) Count(namespace Namespace, name string, value float64, tags []s
 // flush sends any outstanding telemetry messages and aggregated metrics to be
 // sent to the backend. Requests are sent in the background. Must be called
 // with c.mu locked
-func (c *client) flush() {
+func (c *client) flush(callback func()) {
 	// initialize submissions slice of capacity len(c.requests) + 2
 	// to hold all the new events, plus two potential metric events
 	submissions := make([]*Request, 0, len(c.requests)+2)
@@ -442,6 +451,10 @@ func (c *client) flush() {
 			if err != nil {
 				log("submission error: %s", err.Error())
 			}
+		}
+
+		if callback != nil {
+			callback()
 		}
 	}()
 }
@@ -555,6 +568,7 @@ func (r *Request) trySubmit() (retry bool, err error) {
 		return false, err
 	}
 
+	log("submitting telemetry request to %s\n%s", r.URL, string(b))
 	req, err := http.NewRequest(http.MethodPost, r.URL, bytes.NewReader(b))
 	if err != nil {
 		return false, err
@@ -598,6 +612,6 @@ func (c *client) backgroundHeartbeat() {
 		return
 	}
 	c.scheduleSubmit(c.newRequest(RequestTypeAppHeartbeat))
-	c.flush()
+	c.flush(nil)
 	c.heartbeatT.Reset(c.heartbeatInterval)
 }

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -141,6 +141,9 @@ type client struct {
 	metrics    map[Namespace]map[string]*metric
 	newMetrics bool
 
+	// syncFlushOnStop forces a sync flush to ensure all metrics are sent before stopping the client
+	syncFlushOnStop bool
+
 	// Globally registered application configuration sent in the app-started request, along with the locally-defined
 	// configuration of the  event.
 	globalAppConfig []Configuration
@@ -251,7 +254,7 @@ func (c *client) start(configuration []Configuration, namespace Namespace, flush
 	}
 
 	if flush {
-		c.flush()
+		c.flush(false)
 	}
 	c.heartbeatInterval = heartbeatInterval()
 	c.heartbeatT = time.AfterFunc(c.heartbeatInterval, c.backgroundHeartbeat)
@@ -280,16 +283,7 @@ func (c *client) Stop() {
 	// close request types have no body
 	r := c.newRequest(RequestTypeAppClosing)
 	c.scheduleSubmit(r)
-	if internal.BoolEnv("DD_CIVISIBILITY_ENABLED", false) {
-		cnn := make(chan struct{})
-		c.flushWithCallback(func() {
-			cnn <- struct{}{}
-			close(cnn)
-		})
-		<-cnn
-	} else {
-		c.flush()
-	}
+	c.flush(c.syncFlushOnStop)
 }
 
 // Disabled returns whether instrumentation telemetry is disabled
@@ -391,14 +385,7 @@ func (c *client) Count(namespace Namespace, name string, value float64, tags []s
 // flush sends any outstanding telemetry messages and aggregated metrics to be
 // sent to the backend. Requests are sent in the background. Must be called
 // with c.mu locked
-func (c *client) flush() {
-	c.flushWithCallback(nil)
-}
-
-// flushWithCallback sends any outstanding telemetry messages and aggregated metrics to be
-// sent to the backend. Requests are sent in the background and a callback is called after the flush finishes.
-// Must be called with c.mu locked
-func (c *client) flushWithCallback(callback func()) {
+func (c *client) flush(sync bool) {
 	// initialize submissions slice of capacity len(c.requests) + 2
 	// to hold all the new events, plus two potential metric events
 	submissions := make([]*Request, 0, len(c.requests)+2)
@@ -452,18 +439,20 @@ func (c *client) flushWithCallback(callback func()) {
 		}
 	}
 
-	go func() {
+	submit := func() {
 		for _, r := range submissions {
 			err := r.submit()
 			if err != nil {
 				log("submission error: %s", err.Error())
 			}
 		}
+	}
 
-		if callback != nil {
-			callback()
-		}
-	}()
+	if sync {
+		submit()
+	} else {
+		go submit()
+	}
 }
 
 // newRequests populates a request with the common fields shared by all requests
@@ -618,6 +607,6 @@ func (c *client) backgroundHeartbeat() {
 		return
 	}
 	c.scheduleSubmit(c.newRequest(RequestTypeAppHeartbeat))
-	c.flush()
+	c.flush(false)
 	c.heartbeatT.Reset(c.heartbeatInterval)
 }

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -118,7 +118,7 @@ func TestMetrics(t *testing.T) {
 		client.Count(NamespaceTracers, "bonk", 4, []string{"org:1"}, false)
 
 		client.mu.Lock()
-		client.flush()
+		client.flush(false)
 		client.mu.Unlock()
 	}()
 
@@ -187,7 +187,7 @@ func TestDistributionMetrics(t *testing.T) {
 		client.Record(NamespaceTracers, MetricKindDist, "soobar", 1, nil, false)
 		client.Record(NamespaceTracers, MetricKindDist, "soobar", 3, nil, false)
 		client.mu.Lock()
-		client.flush()
+		client.flush(false)
 		client.mu.Unlock()
 	}()
 

--- a/internal/telemetry/message.go
+++ b/internal/telemetry/message.go
@@ -76,6 +76,8 @@ const (
 	NamespaceProfilers Namespace = "profilers"
 	// NamespaceAppSec is for application security management
 	NamespaceAppSec Namespace = "appsec"
+	// NamespaceCiVisibility is for CI Visibility
+	NamespaceCiVisibility Namespace = "civisibility"
 )
 
 // Application is identifying information about the app itself

--- a/internal/telemetry/option.go
+++ b/internal/telemetry/option.go
@@ -63,6 +63,13 @@ func WithHTTPClient(httpClient *http.Client) Option {
 	}
 }
 
+// SyncFlushOnStop forces a sync flush on client stop
+func SyncFlushOnStop() Option {
+	return func(client *client) {
+		client.syncFlushOnStop = true
+	}
+}
+
 func defaultAPIKey() string {
 	return os.Getenv("DD_API_KEY")
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -38,7 +38,7 @@ func (c *client) ProductChange(namespace Namespace, enabled bool, configuration 
 	c.configChange(cfg)
 
 	switch namespace {
-	case NamespaceTracers, NamespaceProfilers, NamespaceAppSec:
+	case NamespaceTracers, NamespaceProfilers, NamespaceAppSec, NamespaceCiVisibility:
 		c.productChange(namespace, enabled)
 	default:
 		log("unknown product namespace %q provided to ProductChange", namespace)
@@ -83,6 +83,8 @@ func (c *client) productChange(namespace Namespace, enabled bool) {
 	case NamespaceProfilers:
 		products.Products.Profiler = ProductDetails{Enabled: enabled}
 	case NamespaceTracers:
+		// Nothing to do
+	case NamespaceCiVisibility:
 		// Nothing to do
 	default:
 		log("unknown product namespace: %q. The app-product-change telemetry event will not send", namespace)

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -82,9 +82,7 @@ func (c *client) productChange(namespace Namespace, enabled bool) {
 		products.Products.AppSec = ProductDetails{Enabled: enabled}
 	case NamespaceProfilers:
 		products.Products.Profiler = ProductDetails{Enabled: enabled}
-	case NamespaceTracers:
-		// Nothing to do
-	case NamespaceCiVisibility:
+	case NamespaceTracers, NamespaceCiVisibility:
 		// Nothing to do
 	default:
 		log("unknown product namespace: %q. The app-product-change telemetry event will not send", namespace)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR contains a complete refactor of the test api to follow and adopt Go conventions, and a complete support of the CI Visibility Telemetry Metrics.

https://app.datadoghq.com/dashboard/d4a-6h6-i8q/test-visibility-libraries-telemetry?fromUser=true&refresh_mode=paused&tpl_var_language_name%5B0%5D=go&from_ts=1730971500000&to_ts=1730982300000&live=false

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We already have telemetry metrics for all other languages, Go was missing this feature.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
