### PR TITLE
whoops, no need to generate stats msgp anymore

### DIFF
--- a/ddtrace/tracer/log_test.go
+++ b/ddtrace/tracer/log_test.go
@@ -146,7 +146,7 @@ func TestLogSamplingRules(t *testing.T) {
 	tp := new(log.RecordLogger)
 	tp.Ignore("appsec: ", telemetry.LogPrefix)
 	t.Setenv("DD_TRACE_SAMPLING_RULES", `[{"service": "some.service", "sample_rate": 0.234}, {"service": "other.service"}, {"service": "last.service", "sample_rate": 0.56}, {"odd": "pairs"}, {"sample_rate": 9.10}]`)
-	_, _, _, stop := startTestTracer(t, WithLogger(tp))
+	_, _, _, stop := startTestTracer(t, WithLogger(tp), WithEnv("test"))
 	defer stop()
 
 	assert.Len(tp.Logs(), 1)
@@ -159,7 +159,7 @@ func TestLogDefaultSampleRate(t *testing.T) {
 	tp.Ignore("appsec: ", telemetry.LogPrefix)
 	log.UseLogger(tp)
 	t.Setenv("DD_TRACE_SAMPLE_RATE", ``)
-	_, _, _, stop := startTestTracer(t, WithLogger(tp))
+	_, _, _, stop := startTestTracer(t, WithLogger(tp), WithEnv("test"))
 	defer stop()
 
 	assert.Len(tp.Logs(), 0)

--- a/ddtrace/tracer/stats.go
+++ b/ddtrace/tracer/stats.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
-//go:generate msgp -unexported -marshal=false -o=stats_msgp.go -tests=false
-
 package tracer
 
 import (
@@ -68,7 +66,7 @@ func newConcentrator(c *config, bucketSize int64) *concentrator {
 		// This should never actually happen as the agent MUST have an env configured to start-up
 		// That panic will be removed in a future release at which point we can remove this
 		env = "unknown-env"
-		log.Error("No DD Env found, normally the agent MUST have one")
+		log.Debug("No DD Env found, normally the agent should have one")
 	}
 	aggKey := stats.PayloadAggregationKey{
 		Hostname:     c.hostname,

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -24,9 +24,10 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/samplernames"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 
-	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
 const otelHeaderPropagationStyle = "OTEL_PROPAGATORS"
@@ -2001,7 +2002,7 @@ func TestNonePropagator(t *testing.T) {
 		t.Setenv(headerPropagationStyleInject, "none,b3")
 		tp := new(log.RecordLogger)
 		tp.Ignore("appsec: ", telemetry.LogPrefix)
-		tracer := newTracer(WithLogger(tp))
+		tracer := newTracer(WithLogger(tp), WithEnv("test"))
 		defer tracer.Stop()
 		// reinitializing to capture log output, since propagators are parsed before logger is set
 		tracer.config.propagator = NewPropagator(&PropagatorConfig{})

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -712,7 +712,7 @@ func TestTracerRuntimeMetrics(t *testing.T) {
 	t.Run("on", func(t *testing.T) {
 		tp := new(log.RecordLogger)
 		tp.Ignore("appsec: ", telemetry.LogPrefix)
-		tracer := newTracer(WithRuntimeMetrics(), WithLogger(tp), WithDebugMode(true))
+		tracer := newTracer(WithRuntimeMetrics(), WithLogger(tp), WithDebugMode(true), WithEnv("test"))
 		defer tracer.Stop()
 		assert.Contains(t, tp.Logs()[0], "DEBUG: Runtime metrics enabled")
 	})
@@ -721,7 +721,7 @@ func TestTracerRuntimeMetrics(t *testing.T) {
 		t.Setenv("DD_RUNTIME_METRICS_ENABLED", "true")
 		tp := new(log.RecordLogger)
 		tp.Ignore("appsec: ", telemetry.LogPrefix)
-		tracer := newTracer(WithLogger(tp), WithDebugMode(true))
+		tracer := newTracer(WithLogger(tp), WithDebugMode(true), WithEnv("test"))
 		defer tracer.Stop()
 		assert.Contains(t, tp.Logs()[0], "DEBUG: Runtime metrics enabled")
 	})


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Also move env message to debug as it turns out the assumption that the agent always has an env configured is not correct
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Stats msgp is now owned in the agent code so there's no need to generate the stats msgp code here anymore
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
