### PR TITLE
appsec: add tracer start option for appsec enablement

### DIFF
--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -181,7 +181,10 @@ func Start(opts ...StartOption) {
 	// appsec.Start() may use the telemetry client to report activation, so it is
 	// important this happens _AFTER_ startTelemetry() has been called, so the
 	// client is appropriately configured.
-	appsec.Start(appsecConfig.WithRCConfig(cfg))
+	appsecopts := make([]appsecConfig.StartOption, 0, len(t.config.appsecStartOptions)+1)
+	appsecopts = append(appsecopts, t.config.appsecStartOptions...)
+	appsecopts = append(appsecopts, appsecConfig.WithRCConfig(cfg))
+	appsec.Start(appsecopts...)
 	_ = t.hostname() // Prime the hostname cache
 }
 

--- a/internal/appsec/config/config.go
+++ b/internal/appsec/config/config.go
@@ -57,7 +57,7 @@ type StartConfig struct {
 	RC *remoteconfig.ClientConfig
 	// IsEnabled is a function that determines whether AppSec is enabled or not. When unset, the
 	// default [IsEnabled] function is used.
-	EnablementMode func() (EnablementMode, ConfigOrigin, error)
+	EnablementMode func() (EnablementMode, Origin, error)
 }
 
 type EnablementMode int8
@@ -71,11 +71,11 @@ const (
 	ForcedOn EnablementMode = 1
 )
 
-type ConfigOrigin uint8
+type Origin uint8
 
 const (
 	// OriginDefault is the origin of configuration values not explicitly set by the user in any way.
-	OriginDefault ConfigOrigin = iota
+	OriginDefault Origin = iota
 	// OriginEnvVar is the origin of configuration values set through environment variables.
 	OriginEnvVar
 	// OriginExplicitOption is the origin of configuration values set though explicit options in code.
@@ -84,7 +84,7 @@ const (
 
 func NewStartConfig(opts ...StartOption) *StartConfig {
 	c := &StartConfig{
-		EnablementMode: func() (mode EnablementMode, origin ConfigOrigin, err error) {
+		EnablementMode: func() (mode EnablementMode, origin Origin, err error) {
 			enabled, set, err := IsEnabledByEnvironment()
 			if set {
 				origin = OriginEnvVar
@@ -110,7 +110,7 @@ func NewStartConfig(opts ...StartOption) *StartConfig {
 // implemented by [IsEnabledByEnvironment].
 func WithEnablementMode(mode EnablementMode) StartOption {
 	return func(c *StartConfig) {
-		c.EnablementMode = func() (EnablementMode, ConfigOrigin, error) {
+		c.EnablementMode = func() (EnablementMode, Origin, error) {
 			return mode, OriginExplicitOption, nil
 		}
 	}

--- a/internal/appsec/config/config.go
+++ b/internal/appsec/config/config.go
@@ -50,7 +50,78 @@ const (
 )
 
 // StartOption is used to customize the AppSec configuration when invoked with appsec.Start()
-type StartOption func(c *Config)
+type StartOption func(c *StartConfig)
+
+type StartConfig struct {
+	// RC is the remote config client configuration to be used.
+	RC *remoteconfig.ClientConfig
+	// IsEnabled is a function that determines whether AppSec is enabled or not. When unset, the
+	// default [IsEnabled] function is used.
+	EnablementMode func() (EnablementMode, ConfigOrigin, error)
+}
+
+type EnablementMode int8
+
+const (
+	// ForcedOff is the mode where AppSec is forced to be disabled, not allowing remote activation.
+	ForcedOff EnablementMode = -1
+	// RCStandby is the mode where AppSec is in stand-by, waiting remote activation.
+	RCStandby EnablementMode = 0
+	// ForcedOn is the mode where AppSec is forced to be enabled.
+	ForcedOn EnablementMode = 1
+)
+
+type ConfigOrigin uint8
+
+const (
+	// OriginDefault is the origin of configuration values not explicitly set by the user in any way.
+	OriginDefault ConfigOrigin = iota
+	// OriginEnvVar is the origin of configuration values set through environment variables.
+	OriginEnvVar
+	// OriginExplicitOption is the origin of configuration values set though explicit options in code.
+	OriginExplicitOption
+)
+
+func NewStartConfig(opts ...StartOption) *StartConfig {
+	c := &StartConfig{
+		EnablementMode: func() (mode EnablementMode, origin ConfigOrigin, err error) {
+			enabled, set, err := IsEnabledByEnvironment()
+			if set {
+				origin = OriginEnvVar
+				if enabled {
+					mode = ForcedOn
+				} else {
+					mode = ForcedOff
+				}
+			} else {
+				origin = OriginDefault
+				mode = RCStandby
+			}
+			return mode, origin, err
+		},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// WithEnablementMode forces AppSec enablement, replacing the default initialization conditions
+// implemented by [IsEnabledByEnvironment].
+func WithEnablementMode(mode EnablementMode) StartOption {
+	return func(c *StartConfig) {
+		c.EnablementMode = func() (EnablementMode, ConfigOrigin, error) {
+			return mode, OriginExplicitOption, nil
+		}
+	}
+}
+
+// WithRCConfig sets the AppSec remote config client configuration to the specified cfg
+func WithRCConfig(cfg remoteconfig.ClientConfig) StartOption {
+	return func(c *StartConfig) {
+		c.RC = &cfg
+	}
+}
 
 // Config is the AppSec configuration.
 type Config struct {
@@ -94,17 +165,12 @@ func (set AddressSet) AnyOf(anyOf ...string) bool {
 	return false
 }
 
-// WithRCConfig sets the AppSec remote config client configuration to the specified cfg
-func WithRCConfig(cfg remoteconfig.ClientConfig) StartOption {
-	return func(c *Config) {
-		c.RC = &cfg
-	}
-}
-
-// IsEnabled returns true when appsec is enabled by the environment variable DD_APPSEC_ENABLED (as of strconv's boolean
-// parsing rules). When false, it also returns whether the env var was actually set or not.
-// In case of a parsing error, it returns a detailed error.
-func IsEnabled() (enabled bool, set bool, err error) {
+// IsEnabledByEnvironment returns true when appsec is enabled by the environment variable
+// [EnvEnabled] being set to a truthy value, as well as whether the environment variable was set at
+// all or not (so it is possible to distinguish between explicitly false, and false-by-default).
+// If the [EnvEnabled] variable is set to a value that is not a valid boolean (according to
+// [strconv.ParseBool]), it is considered false-y, and a detailed error is also returned.
+func IsEnabledByEnvironment() (enabled bool, set bool, err error) {
 	return parseBoolEnvVar(EnvEnabled)
 }
 
@@ -123,7 +189,7 @@ func parseBoolEnvVar(env string) (enabled bool, set bool, err error) {
 }
 
 // NewConfig returns a fresh appsec configuration read from the env
-func NewConfig() (*Config, error) {
+func (c *StartConfig) NewConfig() (*Config, error) {
 	rules, err := internal.RulesFromEnv()
 	if err != nil {
 		return nil, err
@@ -141,5 +207,6 @@ func NewConfig() (*Config, error) {
 		Obfuscator:     internal.NewObfuscatorConfig(),
 		APISec:         internal.NewAPISecConfig(),
 		RASP:           internal.RASPEnabled(),
+		RC:             c.RC,
 	}, nil
 }

--- a/internal/appsec/telemetry.go
+++ b/internal/appsec/telemetry.go
@@ -57,6 +57,14 @@ func (a *appsecTelemetry) addConfig(name string, value any) {
 	a.configs = append(a.configs, telemetry.Configuration{Name: name, Value: value})
 }
 
+// addCodeConfig adds a new configuration entry to this telemetry event.
+func (a *appsecTelemetry) addCodeConfig(name string, value any) {
+	if a == nil {
+		return
+	}
+	a.configs = append(a.configs, telemetry.Configuration{Name: name, Value: value, Origin: telemetry.OriginCode})
+}
+
 // addEnvConfig adds a new envionment-sourced configuration entry to this event.
 func (a *appsecTelemetry) addEnvConfig(name string, value any) {
 	if a == nil {


### PR DESCRIPTION

### What does this PR do?

Adds a new tracer start option that allows to explicitly enable or disable appsec, overriding the default activation criteria (from `DD_APPSEC_ENABLED` and remote configuration).

### Motivation

There is a use-case in https://github.com/DataDog/datadog-agent where a tracer is started but AppSec features are undesirable (and unsupported) in this context. Explicitly disabling AppSec features allows to avoid emitting an AppSec startup error message when the agent's environment includes `DD_APPSEC_ENABLED=true`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
