### PR TITLE
CI: Add TRACING_CONFIG_SCENARIOS to system-tests.yml

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -58,6 +58,7 @@ jobs:
           - APM_TRACING_E2E
           - APM_TRACING_E2E_SINGLE_SPAN
           - APM_TRACING_E2E_OTEL
+          - TRACING_CONFIG_SCENARIOS
         include:
           - weblog-variant: net-http
             scenario: REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES


### PR DESCRIPTION
### What does this PR do?
Enables weblog tests from the`TRACING_CONFIG_SCENARIOS` scenarios to run in CI against all dd-trace-go PRs. See: [link](https://github.com/DataDog/system-tests/blob/main/scenario_groups.yml#L42-L46)

### Motivation
A [recent PR](https://github.com/DataDog/dd-trace-go/pull/2946) caused one of the weblogs (go-chi) to fail one of the system-tests(`Test_Config_HttpServerErrorStatuses_FeatureFlagCustom`) covered by `TRACING_CONFIG_SCENARIOS`, but the issue was left undetected because the test was not run against the PR in CI.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
