### PR TITLE
fix(options): Don't override c.httpClient if it is set via the options

### DIFF
--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -1510,3 +1510,16 @@ func TestWithStatsComputation(t *testing.T) {
 		assert.True(c.statsComputationEnabled)
 	})
 }
+
+func TestNoHTTPClientOverride(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		assert := assert.New(t)
+		client := http.DefaultClient
+		client.Timeout = 30 * time.Second // Default is 10s
+		c := newConfig(
+			WithHTTPClient(client),
+			WithUDS("/tmp/agent.sock"),
+		)
+		assert.Equal(30*time.Second, c.httpClient.Timeout)
+	})
+}


### PR DESCRIPTION
### What does this PR do?
Prevents overrides to `c.httpClient` if it has been set by customers; even if the agent URL points to a unix socket

### Motivation
For my software to work I had to update the HTTP client of my tracer. Using the latest agent and tracer and letting other settings as default, the HTTP client override didn't work. 

This is because:
1.  Newer agent creates the socket by default (https://github.com/DataDog/datadog-agent/pull/26969)
2. As the [documentation](https://github.com/DataDog/dd-trace-go/blob/a8bb4691781d3bdbf8243153ea3e1192a148fe0c/internal/agent.go#L24-L32) states, if the socket file exists and no env var is set, the socket will be used as the agent URL
3. If the socket is used as the agent URL, [we override `c.httpClient` regardless of whether it has been previously set](https://github.com/DataDog/dd-trace-go/blob/eee2487e79a0171064194ded5cff2cdd228f834d/ddtrace/tracer/option.go#L417)

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
