### PR TITLE
fix(.github/workflows): add permissions to codeql-v2 job

### DIFF
--- a/.github/workflows/v2-nightly.yml
+++ b/.github/workflows/v2-nightly.yml
@@ -13,6 +13,10 @@ jobs:
 
   codeql-v2:
     uses: DataDog/dd-trace-go/.github/workflows/codeql-analysis.yml@v2-dev
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     secrets: inherit
     with:
       ref: refs/heads/v2-dev


### PR DESCRIPTION
### What does this PR do?

Add missing permissions for running v2 CI jobs.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
