### PR TITLE
ddtrace/tracer: Ensure SpanLink access is safe from corruption

### DIFF
--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -38,11 +38,8 @@ type SpanContextW3C interface {
 type SpanContextWithLinks interface {
 	SpanContext
 
-	// SpanLinks returns the span links on the SpanContext.
+	// SpanLinks returns a copy of the span links on the SpanContext.
 	SpanLinks() []SpanLink
-
-	// Setlinks takes in a slice of SpanLinks and sets them to the SpanContext.
-	SetLinks(links []SpanLink)
 }
 
 // Tracer specifies an implementation of the Datadog tracer which allows starting

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -87,6 +87,7 @@ func TestStartSpanWithSpanLinks(t *testing.T) {
 	ctx := &spanContext{spanID: 789, traceID: traceIDFrom64Bits(789), spanLinks: []ddtrace.SpanLink{spanLink}}
 
 	t.Run("spanContext with spanLinks satisfies SpanContextWithLinks interface", func(t *testing.T) {
+		var _ ddtrace.SpanContextWithLinks = ctx
 		assert.Equal(t, len(ctx.SpanLinks()), 1)
 		assert.Equal(t, ctx.SpanLinks()[0], spanLink)
 	})

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -84,14 +84,11 @@ func TestStartSpanWithSpanLinks(t *testing.T) {
 	_, _, _, stop := startTestTracer(t)
 	defer stop()
 	spanLink := ddtrace.SpanLink{TraceID: 789, TraceIDHigh: 0, SpanID: 789, Attributes: map[string]string{"reason": "terminated_context", "context_headers": "datadog"}, Flags: 0}
-	var ctx ddtrace.SpanContext
-	ctx = &spanContext{spanID: 789, traceID: traceIDFrom64Bits(789), spanLinks: []ddtrace.SpanLink{spanLink}}
+	ctx := &spanContext{spanID: 789, traceID: traceIDFrom64Bits(789), spanLinks: []ddtrace.SpanLink{spanLink}}
 
 	t.Run("spanContext with spanLinks satisfies SpanContextWithLinks interface", func(t *testing.T) {
-		ctxLink, ok := ctx.(ddtrace.SpanContextWithLinks)
-		assert.True(t, ok)
-		assert.Equal(t, len(ctxLink.SpanLinks()), 1)
-		assert.Equal(t, ctxLink.SpanLinks()[0], spanLink)
+		assert.Equal(t, len(ctx.SpanLinks()), 1)
+		assert.Equal(t, ctx.SpanLinks()[0], spanLink)
 	})
 
 	t.Run("create span from spancontext with links", func(t *testing.T) {

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -183,12 +183,11 @@ func (c *spanContext) TraceID128Bytes() [16]byte {
 	return c.traceID
 }
 
+// SpanLinks implements ddtrace.SpanContextWithLinks
 func (c *spanContext) SpanLinks() []ddtrace.SpanLink {
-	return c.spanLinks
-}
-
-func (c *spanContext) SetLinks(links []ddtrace.SpanLink) {
-	c.spanLinks = links
+	cp := make([]ddtrace.SpanLink, len(c.spanLinks))
+	copy(cp, c.spanLinks)
+	return cp
 }
 
 // ForeachBaggageItem implements ddtrace.SpanContext.


### PR DESCRIPTION
### What does this PR do?
- Changes the (spanContext).SpanLinks() implementation to return a copy of a slice instead of the slice itself
- Removes (spanContext).SetLinks() method
- nit: Clean up a test


### Motivation
Ensure users cannot modify spanContext

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
