### PR TITLE
fix(ddtrace/tracer): ignore agent-provided TCP port when using a UDS w/ WithDogstatsdAddress

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -547,7 +547,9 @@ func newConfig(opts ...StartOption) *config {
 		if agentport := c.agent.StatsdPort; agentport > 0 && !c.agent.ignore {
 			// the agent reported a non-standard port
 			host, _, err := net.SplitHostPort(addr)
-			if err == nil {
+			// the code in the next if-block only makes sense if we are dealing with
+			// a user-defined TCP-based protocol URI.
+			if err == nil && host != "unix" {
 				// we have a valid host:port address; replace the port because
 				// the agent knows better
 				if host == "" {

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -501,7 +501,24 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			assert.Equal(t, c.dogstatsdAddr, "10.1.0.12:4002")
 			assert.Equal(t, globalconfig.DogstatsdAddr(), "10.1.0.12:4002")
 		})
+
 		t.Run("uds", func(t *testing.T) {
+			assert := assert.New(t)
+			dir, err := os.MkdirTemp("", "socket")
+			if err != nil {
+				t.Fatal("Failed to create socket")
+			}
+			addr := filepath.Join(dir, "dsd.socket")
+			defer os.RemoveAll(addr)
+			tracer := newTracer(WithDogstatsdAddress("unix://" + addr))
+			defer tracer.Stop()
+			c := tracer.config
+			assert.NotNil(c)
+			assert.Equal("unix://"+addr, c.dogstatsdAddr)
+			assert.Equal("unix://"+addr, globalconfig.DogstatsdAddr())
+		})
+
+		t.Run("uds:ignore", func(t *testing.T) {
 			assert := assert.New(t)
 			dir, err := os.MkdirTemp("", "socket")
 			if err != nil {
@@ -512,6 +529,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			tracer := newTracer(WithDogstatsdAddress("unix://"+addr), withIgnoreAgent(true))
 			defer tracer.Stop()
 			c := tracer.config
+			assert.NotNil(c)
 			assert.Equal("unix://"+addr, c.dogstatsdAddr)
 			assert.Equal("unix://"+addr, globalconfig.DogstatsdAddr())
 		})

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -451,6 +451,14 @@ func TestTracerOptionsDefaults(t *testing.T) {
 
 	t.Run("dogstatsd", func(t *testing.T) {
 		t.Run("default", func(t *testing.T) {
+			tracer := newTracer(WithAgentTimeout(2))
+			defer tracer.Stop()
+			c := tracer.config
+			assert.Equal(t, c.dogstatsdAddr, "localhost:8125")
+			assert.Equal(t, globalconfig.DogstatsdAddr(), "localhost:8125")
+		})
+
+		t.Run("default:ignore", func(t *testing.T) {
 			tracer := newTracer(WithAgentTimeout(2), withIgnoreAgent(true))
 			defer tracer.Stop()
 			c := tracer.config
@@ -460,6 +468,15 @@ func TestTracerOptionsDefaults(t *testing.T) {
 
 		t.Run("env-host", func(t *testing.T) {
 			t.Setenv("DD_AGENT_HOST", "my-host")
+			tracer := newTracer(WithAgentTimeout(2))
+			defer tracer.Stop()
+			c := tracer.config
+			assert.Equal(t, c.dogstatsdAddr, "my-host:8125")
+			assert.Equal(t, globalconfig.DogstatsdAddr(), "my-host:8125")
+		})
+
+		t.Run("env-host:ignore", func(t *testing.T) {
+			t.Setenv("DD_AGENT_HOST", "my-host")
 			tracer := newTracer(WithAgentTimeout(2), withIgnoreAgent(true))
 			defer tracer.Stop()
 			c := tracer.config
@@ -468,6 +485,15 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		})
 
 		t.Run("env-port", func(t *testing.T) {
+			t.Setenv("DD_DOGSTATSD_PORT", "123")
+			tracer := newTracer(WithAgentTimeout(2))
+			defer tracer.Stop()
+			c := tracer.config
+			assert.Equal(t, "localhost:8125", c.dogstatsdAddr)
+			assert.Equal(t, "localhost:8125", globalconfig.DogstatsdAddr())
+		})
+
+		t.Run("env-port:ignore", func(t *testing.T) {
 			t.Setenv("DD_DOGSTATSD_PORT", "123")
 			tracer := newTracer(WithAgentTimeout(2), withIgnoreAgent(true))
 			defer tracer.Stop()
@@ -479,6 +505,16 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		t.Run("env-both", func(t *testing.T) {
 			t.Setenv("DD_AGENT_HOST", "my-host")
 			t.Setenv("DD_DOGSTATSD_PORT", "123")
+			tracer := newTracer(WithAgentTimeout(2))
+			defer tracer.Stop()
+			c := tracer.config
+			assert.Equal(t, c.dogstatsdAddr, "my-host:123")
+			assert.Equal(t, globalconfig.DogstatsdAddr(), "my-host:123")
+		})
+
+		t.Run("env-both:ignore", func(t *testing.T) {
+			t.Setenv("DD_AGENT_HOST", "my-host")
+			t.Setenv("DD_DOGSTATSD_PORT", "123")
 			tracer := newTracer(WithAgentTimeout(2), withIgnoreAgent(true))
 			defer tracer.Stop()
 			c := tracer.config
@@ -486,20 +522,28 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			assert.Equal(t, globalconfig.DogstatsdAddr(), "my-host:123")
 		})
 
-		t.Run("env-env", func(t *testing.T) {
-			t.Setenv("DD_ENV", "testEnv")
-			tracer := newTracer(WithAgentTimeout(2), withIgnoreAgent(true))
+		t.Run("option", func(t *testing.T) {
+			tracer := newTracer(WithDogstatsdAddress("10.1.0.12:4002"))
 			defer tracer.Stop()
 			c := tracer.config
-			assert.Equal(t, "testEnv", c.env)
+			assert.Equal(t, c.dogstatsdAddr, "10.1.0.12:8125")
+			assert.Equal(t, globalconfig.DogstatsdAddr(), "10.1.0.12:8125")
 		})
 
-		t.Run("option", func(t *testing.T) {
+		t.Run("option:ignore", func(t *testing.T) {
 			tracer := newTracer(WithDogstatsdAddress("10.1.0.12:4002"), withIgnoreAgent(true))
 			defer tracer.Stop()
 			c := tracer.config
 			assert.Equal(t, c.dogstatsdAddr, "10.1.0.12:4002")
 			assert.Equal(t, globalconfig.DogstatsdAddr(), "10.1.0.12:4002")
+		})
+
+		t.Run("env-env", func(t *testing.T) {
+			t.Setenv("DD_ENV", "testEnv")
+			tracer := newTracer(WithAgentTimeout(2))
+			defer tracer.Stop()
+			c := tracer.config
+			assert.Equal(t, "testEnv", c.env)
 		})
 
 		t.Run("uds", func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Fixes a corner case involving using a Unix Domain Socket path as address in `WithDogstatsdAddress`, as it was being ignored by the tracer as it tried to respect the TCP port informed by the agent. This leads to a situation where runtime and tracer health metrics are disabled.

### Motivation

Ensure that runtime and tracer health metrics work in all the scenarios.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
