### PR TITLE
internal/civisibility: specify if the user is setting the DD_SERVICE

### DIFF
--- a/internal/civisibility/constants/tags.go
+++ b/internal/civisibility/constants/tags.go
@@ -33,6 +33,9 @@ const (
 	// ItrCorrelationIDTag defines the correlation ID for the intelligent test runner tag for the CI Visibility Protocol.
 	// This constant is used to tag traces with the correlation ID for intelligent test runs.
 	ItrCorrelationIDTag string = "itr_correlation_id"
+
+	// UserProvidedTestServiceTag defines if the user provided the test service.
+	UserProvidedTestServiceTag string = "_dd.test.is_user_provided_service"
 )
 
 // Coverage tags

--- a/internal/civisibility/utils/environmentTags.go
+++ b/internal/civisibility/utils/environmentTags.go
@@ -152,6 +152,13 @@ func createCITagsMap() map[string]string {
 	}
 	log.Debug("civisibility: test session name: %v", localTags[constants.TestSessionName])
 
+	// Check if the user provided the test service
+	if ddService := os.Getenv("DD_SERVICE"); ddService != "" {
+		ciTags[constants.UserProvidedTestServiceTag] = "true"
+	} else {
+		ciTags[constants.UserProvidedTestServiceTag] = "false"
+	}
+
 	// Populate missing git data
 	gitData, _ := getLocalGitData()
 

--- a/internal/civisibility/utils/environmentTags.go
+++ b/internal/civisibility/utils/environmentTags.go
@@ -154,9 +154,9 @@ func createCITagsMap() map[string]string {
 
 	// Check if the user provided the test service
 	if ddService := os.Getenv("DD_SERVICE"); ddService != "" {
-		ciTags[constants.UserProvidedTestServiceTag] = "true"
+		localTags[constants.UserProvidedTestServiceTag] = "true"
 	} else {
-		ciTags[constants.UserProvidedTestServiceTag] = "false"
+		localTags[constants.UserProvidedTestServiceTag] = "false"
 	}
 
 	// Populate missing git data


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR sets a tag to let the ci visibility backend know if the DD_SERVICE value was provided by the user or auto-generated.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This required by the backend.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
