### PR TITLE
chore(ddtrace/tracer): skip TestTracerOptionsDefaults/dogstatsd

### DIFF
--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -450,6 +450,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 	})
 
 	t.Run("dogstatsd", func(t *testing.T) {
+		t.Skip("TODO: fix test that fails only in CI")
 		t.Run("default", func(t *testing.T) {
 			tracer := newTracer(WithAgentTimeout(2))
 			defer tracer.Stop()


### PR DESCRIPTION
### What does this PR do?

Adds `t.Skip` to reduce friction for other teams while we fix the underlying issue.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
