### PR TITLE
feat(CODEOWNERS): new policy, all PRs require apm-go approval

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # Note: Later matches take precedence
 
 # default owner
-*                               @DataDog/dd-trace-go-guild
+*                               @DataDog/dd-trace-go-guild @DataDog/apm-go
 
 # no owner: changes to these files will not automatically ping any particular
 # team and can be reviewed by anybody with the appropriate permissions. This is
@@ -15,22 +15,22 @@ go.sum
 /ddtrace                        @DataDog/apm-go
 
 # profiling
-/profiler                       @DataDog/profiling-go
-/internal/traceprof             @DataDog/profiling-go
+/profiler                       @DataDog/profiling-go @DataDog/apm-go
+/internal/traceprof             @DataDog/profiling-go @DataDog/apm-go
 
 # appsec
-/appsec                         @DataDog/asm-go
-/internal/appsec                @DataDog/asm-go
-/contrib/**/*appsec*.go         @DataDog/asm-go
-/.github/workflows/appsec.yml   @DataDog/asm-go
+/appsec                         @DataDog/asm-go @DataDog/apm-go
+/internal/appsec                @DataDog/asm-go @DataDog/apm-go
+/contrib/**/*appsec*.go         @DataDog/asm-go @DataDog/apm-go
+/.github/workflows/appsec.yml   @DataDog/asm-go @DataDog/apm-go
 
 # datastreams
-/datastreams                    @Datadog/data-streams-monitoring
-/internal/datastreams           @Datadog/data-streams-monitoring
+/datastreams                    @Datadog/data-streams-monitoring @DataDog/apm-go
+/internal/datastreams           @Datadog/data-streams-monitoring @DataDog/apm-go
 
 # civisibility
-/internal/civisibility          @DataDog/ci-app-libraries
+/internal/civisibility          @DataDog/ci-app-libraries @DataDog/apm-go
 
 # Gitlab configuration
-.gitlab-ci.yml                  @DataDog/dd-trace-go-guild @DataDog/apm-core-reliability-and-performance
-/.gitlab-ci                     @DataDog/dd-trace-go-guild @DataDog/apm-core-reliability-and-performance
+.gitlab-ci.yml                  @DataDog/dd-trace-go-guild @DataDog/apm-core-reliability-and-performance @DataDog/apm-go
+/.gitlab-ci                     @DataDog/dd-trace-go-guild @DataDog/apm-core-reliability-and-performance @DataDog/apm-go


### PR DESCRIPTION
### What does this PR do?

Adds `apm-go` as owner of everything along each team. This is temporary while `v2` isn't GA.

### Motivation

Per the new guild guidelines for PRs, we want our internal contributors to make any new code changes to both v1 and v2.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
