### PR TITLE
telemetry: submit `orchestrion_usage` counter metric

### DIFF
--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -129,10 +129,9 @@ func startTelemetry(c *config) {
 	}
 
 	// Submit the initial metric tick
-	telemetry.GlobalClient.Record(
+	telemetry.GlobalClient.Gauge(
 		telemetry.NamespaceTracers,
-		telemetry.MetricKindGauge,
-		orchestrionEnabledMetric, orchestrionEnabledValue,
+		orchestrionEnabledMetric, telemetry.GlobalClient.HeartbeatInterval(), orchestrionEnabledValue,
 		orchestrionEnabledTags,
 		false, // Go-specific
 	)

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -7,9 +7,7 @@ package tracer
 
 import (
 	"fmt"
-	"slices"
 	"strings"
-	"testing"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 )
@@ -78,10 +76,6 @@ func startTelemetry(c *config) {
 		for k, v := range c.orchestrionCfg.Metadata {
 			telemetryConfigs = append(telemetryConfigs, telemetry.Configuration{Name: "orchestrion_" + k, Value: v})
 			orchestrionEnabledTags = append(orchestrionEnabledTags, k+":"+v)
-		}
-		if testing.Testing() {
-			// In tests, ensure tags are consistently ordered... Ordering is irrelevant outside of tests.
-			slices.Sort(orchestrionEnabledTags)
 		}
 	}
 

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -119,8 +119,9 @@ func startTelemetry(c *config) {
 			// In tests, ensure tags are consistently ordered...
 			slices.Sort(tags)
 		}
-		telemetry.GlobalClient.Count(
+		telemetry.GlobalClient.Record(
 			telemetry.NamespaceTracers,
+			telemetry.MetricKindGauge,
 			"orchestrion.enabled", 1,
 			tags,
 			false, // Go-specific

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -121,7 +121,7 @@ func startTelemetry(c *config) {
 		}
 		telemetry.GlobalClient.Count(
 			telemetry.NamespaceTracers,
-			"orchestrion_usage", 1,
+			"orchestrion.enabled", 1,
 			tags,
 			false, // Go-specific
 		)

--- a/ddtrace/tracer/telemetry_test.go
+++ b/ddtrace/tracer/telemetry_test.go
@@ -154,11 +154,19 @@ func TestTelemetryEnabled(t *testing.T) {
 		telemetryClient := new(telemetrytest.MockClient)
 		defer telemetry.MockGlobalClient(telemetryClient)()
 
+		telemetryClient.On("Count",
+			telemetry.NamespaceTracers,
+			"orchestrion_usage", 1.0,
+			[]string{"k1:v1", "k2:v2"},
+			false,
+		).Return()
+
 		Start(WithOrchestrion(map[string]string{"k1": "v1", "k2": "v2"}))
 		defer Stop()
 
 		telemetry.Check(t, telemetryClient.Configuration, "orchestrion_enabled", true)
 		telemetry.Check(t, telemetryClient.Configuration, "orchestrion_k1", "v1")
 		telemetry.Check(t, telemetryClient.Configuration, "orchestrion_k2", "v2")
+		telemetryClient.AssertExpectations(t)
 	})
 }

--- a/ddtrace/tracer/telemetry_test.go
+++ b/ddtrace/tracer/telemetry_test.go
@@ -160,8 +160,9 @@ func TestTelemetryEnabled(t *testing.T) {
 		telemetry.Check(t, telemetryClient.Configuration, "orchestrion_enabled", true)
 		telemetry.Check(t, telemetryClient.Configuration, "orchestrion_k1", "v1")
 		telemetry.Check(t, telemetryClient.Configuration, "orchestrion_k2", "v2")
-		telemetryClient.AssertCalled(t, "Count",
+		telemetryClient.AssertCalled(t, "Record",
 			telemetry.NamespaceTracers,
+			telemetry.MetricKindGauge,
 			"orchestrion.enabled", 1.0,
 			[]string{"k1:v1", "k2:v2"},
 			false,

--- a/ddtrace/tracer/telemetry_test.go
+++ b/ddtrace/tracer/telemetry_test.go
@@ -154,19 +154,17 @@ func TestTelemetryEnabled(t *testing.T) {
 		telemetryClient := new(telemetrytest.MockClient)
 		defer telemetry.MockGlobalClient(telemetryClient)()
 
-		telemetryClient.On("Count",
-			telemetry.NamespaceTracers,
-			"orchestrion_usage", 1.0,
-			[]string{"k1:v1", "k2:v2"},
-			false,
-		).Return()
-
 		Start(WithOrchestrion(map[string]string{"k1": "v1", "k2": "v2"}))
 		defer Stop()
 
 		telemetry.Check(t, telemetryClient.Configuration, "orchestrion_enabled", true)
 		telemetry.Check(t, telemetryClient.Configuration, "orchestrion_k1", "v1")
 		telemetry.Check(t, telemetryClient.Configuration, "orchestrion_k2", "v2")
-		telemetryClient.AssertExpectations(t)
+		telemetryClient.AssertCalled(t, "Count",
+			telemetry.NamespaceTracers,
+			"orchestrion.enabled", 1.0,
+			[]string{"k1:v1", "k2:v2"},
+			false,
+		)
 	})
 }

--- a/ddtrace/tracer/telemetry_test.go
+++ b/ddtrace/tracer/telemetry_test.go
@@ -8,6 +8,7 @@ package tracer
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
@@ -160,10 +161,9 @@ func TestTelemetryEnabled(t *testing.T) {
 		telemetry.Check(t, telemetryClient.Configuration, "orchestrion_enabled", true)
 		telemetry.Check(t, telemetryClient.Configuration, "orchestrion_k1", "v1")
 		telemetry.Check(t, telemetryClient.Configuration, "orchestrion_k2", "v2")
-		telemetryClient.AssertCalled(t, "Record",
+		telemetryClient.AssertCalled(t, "Gauge",
 			telemetry.NamespaceTracers,
-			telemetry.MetricKindGauge,
-			"orchestrion.enabled", 1.0,
+			"orchestrion.enabled", time.Second, 1.0,
 			[]string{"k1:v1", "k2:v2"},
 			false,
 		)

--- a/internal/civisibility/utils/telemetry/telemetry_distribution.go
+++ b/internal/civisibility/utils/telemetry/telemetry_distribution.go
@@ -9,96 +9,96 @@ import "gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 
 // EndpointPayloadBytes records the size in bytes of the serialized payload by CI Visibility.
 func EndpointPayloadBytes(endpointType EndpointType, value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "endpoint_payload.bytes", value, removeEmptyStrings([]string{
+	telemetry.GlobalClient.Distribution(telemetry.NamespaceCiVisibility, "endpoint_payload.bytes", value, removeEmptyStrings([]string{
 		(string)(endpointType),
 	}), true)
 }
 
 // EndpointPayloadRequestsMs records the time it takes to send the payload sent to the endpoint in ms by CI Visibility.
 func EndpointPayloadRequestsMs(endpointType EndpointType, value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "endpoint_payload.requests_ms", value, removeEmptyStrings([]string{
+	telemetry.GlobalClient.Distribution(telemetry.NamespaceCiVisibility, "endpoint_payload.requests_ms", value, removeEmptyStrings([]string{
 		(string)(endpointType),
 	}), true)
 }
 
 // EndpointPayloadEventsCount records the number of events in the payload sent to the endpoint by CI Visibility.
 func EndpointPayloadEventsCount(endpointType EndpointType, value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "endpoint_payload.events_count", value, removeEmptyStrings([]string{
+	telemetry.GlobalClient.Distribution(telemetry.NamespaceCiVisibility, "endpoint_payload.events_count", value, removeEmptyStrings([]string{
 		(string)(endpointType),
 	}), true)
 }
 
 // EndpointEventsSerializationMs records the time it takes to serialize the events in the payload sent to the endpoint in ms by CI Visibility.
 func EndpointEventsSerializationMs(endpointType EndpointType, value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "endpoint_payload.events_serialization_ms", value, removeEmptyStrings([]string{
+	telemetry.GlobalClient.Distribution(telemetry.NamespaceCiVisibility, "endpoint_payload.events_serialization_ms", value, removeEmptyStrings([]string{
 		(string)(endpointType),
 	}), true)
 }
 
 // GitCommandMs records the time it takes to execute a git command in ms by CI Visibility.
 func GitCommandMs(commandType CommandType, value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "git.command_ms", value, removeEmptyStrings([]string{
+	telemetry.GlobalClient.Distribution(telemetry.NamespaceCiVisibility, "git.command_ms", value, removeEmptyStrings([]string{
 		(string)(commandType),
 	}), true)
 }
 
 // GitRequestsSearchCommitsMs records the time it takes to get the response of the search commit quest in ms by CI Visibility.
 func GitRequestsSearchCommitsMs(responseCompressedType ResponseCompressedType, value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "git_requests.search_commits_ms", value, removeEmptyStrings([]string{
+	telemetry.GlobalClient.Distribution(telemetry.NamespaceCiVisibility, "git_requests.search_commits_ms", value, removeEmptyStrings([]string{
 		(string)(responseCompressedType),
 	}), true)
 }
 
 // GitRequestsObjectsPackMs records the time it takes to get the response of the objects pack request in ms by CI Visibility.
 func GitRequestsObjectsPackMs(value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "git_requests.objects_pack_ms", value, nil, true)
+	telemetry.GlobalClient.Distribution(telemetry.NamespaceCiVisibility, "git_requests.objects_pack_ms", value, nil, true)
 }
 
 // GitRequestsObjectsPackBytes records the sum of the sizes of the object pack files inside a single payload by CI Visibility
 func GitRequestsObjectsPackBytes(value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "git_requests.objects_pack_bytes", value, nil, true)
+	telemetry.GlobalClient.Distribution(telemetry.NamespaceCiVisibility, "git_requests.objects_pack_bytes", value, nil, true)
 }
 
 // GitRequestsObjectsPackFiles records the number of files sent in the object pack payload by CI Visibility.
 func GitRequestsObjectsPackFiles(value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "git_requests.objects_pack_files", value, nil, true)
+	telemetry.GlobalClient.Distribution(telemetry.NamespaceCiVisibility, "git_requests.objects_pack_files", value, nil, true)
 }
 
 // GitRequestsSettingsMs records the time it takes to get the response of the settings endpoint request in ms by CI Visibility.
 func GitRequestsSettingsMs(value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "git_requests.settings_ms", value, nil, true)
+	telemetry.GlobalClient.Distribution(telemetry.NamespaceCiVisibility, "git_requests.settings_ms", value, nil, true)
 }
 
 // ITRSkippableTestsRequestMs records the time it takes to get the response of the itr skippable tests endpoint request in ms by CI Visibility.
 func ITRSkippableTestsRequestMs(value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "itr_skippable_tests.request_ms", value, nil, true)
+	telemetry.GlobalClient.Distribution(telemetry.NamespaceCiVisibility, "itr_skippable_tests.request_ms", value, nil, true)
 }
 
 // ITRSkippableTestsResponseBytes records the number of bytes received by the endpoint. Tagged with a boolean flag set to true if response body is compressed.
 func ITRSkippableTestsResponseBytes(responseCompressedType ResponseCompressedType, value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "itr_skippable_tests.response_bytes", value, removeEmptyStrings([]string{
+	telemetry.GlobalClient.Distribution(telemetry.NamespaceCiVisibility, "itr_skippable_tests.response_bytes", value, removeEmptyStrings([]string{
 		(string)(responseCompressedType),
 	}), true)
 }
 
 // CodeCoverageFiles records the number of files in the code coverage report by CI Visibility.
 func CodeCoverageFiles(value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "code_coverage.files", value, nil, true)
+	telemetry.GlobalClient.Distribution(telemetry.NamespaceCiVisibility, "code_coverage.files", value, nil, true)
 }
 
 // EarlyFlakeDetectionRequestMs records the time it takes to get the response of the early flake detection endpoint request in ms by CI Visibility.
 func EarlyFlakeDetectionRequestMs(value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "early_flake_detection.request_ms", value, nil, true)
+	telemetry.GlobalClient.Distribution(telemetry.NamespaceCiVisibility, "early_flake_detection.request_ms", value, nil, true)
 }
 
 // EarlyFlakeDetectionResponseBytes records the number of bytes received by the endpoint. Tagged with a boolean flag set to true if response body is compressed.
 func EarlyFlakeDetectionResponseBytes(responseCompressedType ResponseCompressedType, value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "early_flake_detection.response_bytes", value, removeEmptyStrings([]string{
+	telemetry.GlobalClient.Distribution(telemetry.NamespaceCiVisibility, "early_flake_detection.response_bytes", value, removeEmptyStrings([]string{
 		(string)(responseCompressedType),
 	}), true)
 }
 
 // EarlyFlakeDetectionResponseTests records the number of tests in the response of the early flake detection endpoint by CI Visibility.
 func EarlyFlakeDetectionResponseTests(value float64) {
-	telemetry.GlobalClient.Record(telemetry.NamespaceCiVisibility, telemetry.MetricKindDist, "early_flake_detection.response_tests", value, nil, true)
+	telemetry.GlobalClient.Distribution(telemetry.NamespaceCiVisibility, "early_flake_detection.response_tests", value, nil, true)
 }

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -169,8 +169,8 @@ func TestMetrics(t *testing.T) {
 		client.start(nil, NamespaceTracers, true)
 
 		// Records should have the most recent value
-		client.Record(NamespaceTracers, MetricKindGauge, "foobar", 1, nil, false)
-		client.Record(NamespaceTracers, MetricKindGauge, "foobar", 2, nil, false)
+		client.Gauge(NamespaceTracers, "foobar", 1, 1, nil, false)
+		client.Gauge(NamespaceTracers, "foobar", 1, 2, nil, false)
 		// Counts should be aggregated
 		client.Count(NamespaceTracers, "baz", 3, nil, true)
 		client.Count(NamespaceTracers, "baz", 1, nil, true)
@@ -244,8 +244,8 @@ func TestDistributionMetrics(t *testing.T) {
 		}
 		client.start(nil, NamespaceTracers, true)
 		// Records should have the most recent value
-		client.Record(NamespaceTracers, MetricKindDist, "soobar", 1, nil, false)
-		client.Record(NamespaceTracers, MetricKindDist, "soobar", 3, nil, false)
+		client.distribution(NamespaceTracers, "soobar", 1, nil, false)
+		client.distribution(NamespaceTracers, "soobar", 3, nil, false)
 		client.mu.Lock()
 		client.flush(false)
 		client.mu.Unlock()
@@ -275,7 +275,7 @@ func TestDisabledClient(t *testing.T) {
 		URL: server.URL,
 	}
 	client.start(nil, NamespaceTracers, true)
-	client.Record(NamespaceTracers, MetricKindGauge, "foobar", 1, nil, false)
+	client.Gauge(NamespaceTracers, "foobar", 1, 1, nil, false)
 	client.Count(NamespaceTracers, "bonk", 4, []string{"org:1"}, false)
 	client.Stop()
 }
@@ -290,7 +290,7 @@ func TestNonStartedClient(t *testing.T) {
 	client := &client{
 		URL: server.URL,
 	}
-	client.Record(NamespaceTracers, MetricKindGauge, "foobar", 1, nil, false)
+	client.Gauge(NamespaceTracers, "foobar", 1, 1, nil, false)
 	client.Count(NamespaceTracers, "bonk", 4, []string{"org:1"}, false)
 	client.Stop()
 }

--- a/internal/telemetry/option.go
+++ b/internal/telemetry/option.go
@@ -56,6 +56,17 @@ func WithVersion(version string) Option {
 	}
 }
 
+// WithHeartbeatMetric register a metric data point to be emitted at each
+// heartbeat tick. This is useful to maintain gauge metrics at a specific level.
+func WithHeartbeatMetric(namespace Namespace, kind MetricKind, name string, value func() float64, tags []string, common bool) Option {
+	return func(client *client) {
+		client.heartbeatMetrics = append(
+			client.heartbeatMetrics,
+			heartbeatMetric{namespace, kind, name, value, tags, common},
+		)
+	}
+}
+
 // WithHTTPClient specifies the http client for the telemetry client
 func WithHTTPClient(httpClient *http.Client) Option {
 	return func(client *client) {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -121,6 +121,6 @@ func Time(namespace Namespace, name string, tags []string, common bool) (finish 
 	start := time.Now()
 	return func() {
 		elapsed := time.Since(start)
-		GlobalClient.Record(namespace, MetricKindDist, name, float64(elapsed.Milliseconds()), tags, common)
+		GlobalClient.Distribution(namespace, name, float64(elapsed.Milliseconds()), tags, common)
 	}
 }

--- a/internal/telemetry/telemetrytest/telemetrytest.go
+++ b/internal/telemetry/telemetrytest/telemetrytest.go
@@ -7,6 +7,7 @@
 package telemetrytest
 
 import (
+	"slices"
 	"sync"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
@@ -69,10 +70,12 @@ func (c *MockClient) productChange(namespace telemetry.Namespace, enabled bool) 
 }
 
 // Record stores the value for the given metric. It is currently mocked for `Gauge` and `Distribution` metric types.
-func (c *MockClient) Record(ns telemetry.Namespace, _ telemetry.MetricKind, name string, val float64, tags []string, common bool) {
-	c.On("Gauge", ns, name, val, tags, common).Return()
-	c.On("Record", ns, name, val, tags, common).Return()
-	_ = c.Called(ns, name, val, tags, common)
+func (c *MockClient) Record(ns telemetry.Namespace, kind telemetry.MetricKind, name string, val float64, tags []string, common bool) {
+	// Ensure consistent ordering through expectations
+	slices.Sort(tags)
+
+	c.On("Record", ns, kind, name, val, tags, common).Return()
+	_ = c.Called(ns, kind, name, val, tags, common)
 	// record the val for tests that assert based on the value
 	if _, ok := c.Metrics[ns]; !ok {
 		if c.Metrics == nil {

--- a/internal/telemetry/telemetrytest/telemetrytest.go
+++ b/internal/telemetry/telemetrytest/telemetrytest.go
@@ -75,6 +75,9 @@ func (c *MockClient) Record(ns telemetry.Namespace, _ telemetry.MetricKind, name
 	_ = c.Called(ns, name, val, tags, common)
 	// record the val for tests that assert based on the value
 	if _, ok := c.Metrics[ns]; !ok {
+		if c.Metrics == nil {
+			c.Metrics = make(map[telemetry.Namespace]map[string]float64)
+		}
 		c.Metrics[ns] = map[string]float64{}
 	}
 	c.Metrics[ns][name] = val
@@ -82,6 +85,7 @@ func (c *MockClient) Record(ns telemetry.Namespace, _ telemetry.MetricKind, name
 
 // Count counts the value for the given metric
 func (c *MockClient) Count(ns telemetry.Namespace, name string, val float64, tags []string, common bool) {
+	c.On("Count", ns, name, val, tags, common).Return()
 	_ = c.Called(ns, name, val, tags, common)
 }
 

--- a/internal/telemetry/telemetrytest/telemetrytest.go
+++ b/internal/telemetry/telemetrytest/telemetrytest.go
@@ -82,7 +82,6 @@ func (c *MockClient) Record(ns telemetry.Namespace, _ telemetry.MetricKind, name
 
 // Count counts the value for the given metric
 func (c *MockClient) Count(ns telemetry.Namespace, name string, val float64, tags []string, common bool) {
-	c.On("Count", ns, name, val, tags, common).Return()
 	_ = c.Called(ns, name, val, tags, common)
 }
 


### PR DESCRIPTION
### What does this PR do?

To make it easier to get data about orchestrion usage, start submitting a counter metric in telemetry for applications built with orchestrion.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
