### PR TITLE
contrib/gomodule/redigo: adds the DialURLContext method

### DIFF
--- a/contrib/gomodule/redigo/redigo.go
+++ b/contrib/gomodule/redigo/redigo.go
@@ -96,18 +96,7 @@ func wrapConn(c redis.Conn, p *params) redis.Conn {
 // Dial dials into the network address and returns a traced redis.Conn.
 // The set of supported options must be either of type redis.DialOption or this package's DialOption.
 func Dial(network, address string, options ...interface{}) (redis.Conn, error) {
-	dialOpts, cfg := parseOptions(options...)
-	log.Debug("contrib/gomodule/redigo: Dialing %s %s, %#v", network, address, cfg)
-	c, err := redis.Dial(network, address, dialOpts...)
-	if err != nil {
-		return nil, err
-	}
-	host, port, err := net.SplitHostPort(address)
-	if err != nil {
-		return nil, err
-	}
-	tc := wrapConn(c, &params{cfg, network, host, port})
-	return tc, nil
+	return DialContext(context.Background(), network, address, options...)
 }
 
 // DialContext dials into the network address using redis.DialContext and returns a traced redis.Conn.
@@ -132,6 +121,14 @@ func DialContext(ctx context.Context, network, address string, options ...interf
 // scheme (https://www.iana.org/assignments/uri-schemes/prov/redis).
 // The returned redis.Conn is traced.
 func DialURL(rawurl string, options ...interface{}) (redis.Conn, error) {
+	return DialURLContext(context.Background(), rawurl, options...)
+}
+
+// DialURLContext connects to a Redis server at the given URL using the Redis
+// URI scheme. URLs should follow the draft IANA specification for the
+// scheme (https://www.iana.org/assignments/uri-schemes/prov/redis).
+// The returned redis.Conn is traced.
+func DialURLContext(ctx context.Context, rawurl string, options ...interface{}) (redis.Conn, error) {
 	dialOpts, cfg := parseOptions(options...)
 	log.Debug("contrib/gomodule/redigo: Dialing %s, %#v", rawurl, cfg)
 	u, err := url.Parse(rawurl)
@@ -147,7 +144,7 @@ func DialURL(rawurl string, options ...interface{}) (redis.Conn, error) {
 		host = "localhost"
 	}
 	network := "tcp"
-	c, err := redis.DialURL(rawurl, dialOpts...)
+	c, err := redis.DialURLContext(ctx, rawurl, dialOpts...)
 	tc := wrapConn(c, &params{cfg, network, host, port})
 	return tc, err
 }

--- a/contrib/gomodule/redigo/redigo_test.go
+++ b/contrib/gomodule/redigo/redigo_test.go
@@ -196,6 +196,21 @@ func TestTracingDialUrl(t *testing.T) {
 	assert.True(len(spans) > 0)
 }
 
+func TestTracingDialUrlContext(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	ctx := context.Background()
+	url := "redis://127.0.0.1:6379"
+	client, err := DialURLContext(ctx, url, WithServiceName("redis-service"))
+	assert.Nil(err)
+	client.Do("SET", "ONE", " TWO", context.Background())
+
+	spans := mt.FinishedSpans()
+	assert.True(len(spans) > 0)
+}
+
 func TestTracingDialContext(t *testing.T) {
 	assert := assert.New(t)
 	mt := mocktracer.Start()


### PR DESCRIPTION
Matches what the redigo package provides.
Also rewrite non context variant of dialer to use Context equivalent with context.Background

### What does this PR do?
Matches what the redigo package provides.
Also rewrite non context variant of dialer to use Context equivalent with context.Background


### Motivation

Matches what the redigo package provides is done so that DialURL can propagates the caller context.

Also rewrite non context variant of dialer to use Context equivalent with context.Background is done to reduce duplication in code and ensure switching to the Context aware variant has no side effect.


### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
