### PR TITLE
internal/telemetry: remove "testing" import from `internal/telemetry/utils.go`

### DIFF
--- a/internal/telemetry/utils.go
+++ b/internal/telemetry/utils.go
@@ -12,7 +12,6 @@ import (
 	"math"
 	"sort"
 	"strings"
-	"testing"
 )
 
 // MockGlobalClient replaces the global telemetry client with a custom
@@ -30,8 +29,16 @@ func MockGlobalClient(client Client) func() {
 	}
 }
 
+// Errorfer is an interface that allows to call the `Errorf` method.
+// This is the same interface as `testing.T` because the goal of this
+// interface is to remove the need to import `testing` in this package
+// that is actually imported by users.
+type Errorfer interface {
+	Errorf(format string, args ...any)
+}
+
 // Check is a testing utility to assert that a target key in config contains the expected value
-func Check(t *testing.T, configuration []Configuration, key string, expected interface{}) {
+func Check(t Errorfer, configuration []Configuration, key string, expected interface{}) {
 	for _, kv := range configuration {
 		if kv.Name == key {
 			if kv.Value != expected {


### PR DESCRIPTION
### What does this PR do?

Currently when you import `dd-trace-go`, you end up having the "testing" std package in your final binary. Not amazing.
This PR fixes this issue by removing the problematic import in `internal/telemetry/utils.go`, and replacing the usage with an interface.

If you have a better idea for `Errorfer` I'm definitely open to it.

I believe this would be fine if it was in a public API, but this is in an internal package so this change should be fine regarding exported API changes.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
