### PR TITLE
[v2] contrib/net/http: Make DD_TRACE_HTTP_CLIENT_TAG_QUERY_STRING false by default

### DIFF
--- a/contrib/google.golang.org/api/api_test.go
+++ b/contrib/google.golang.org/api/api_test.go
@@ -63,7 +63,7 @@ func TestBooks(t *testing.T) {
 	assert.Equal(t, "books.bookshelves.list", s0.Tag(ext.ResourceName))
 	assert.Equal(t, "400", s0.Tag(ext.HTTPCode))
 	assert.Equal(t, "GET", s0.Tag(ext.HTTPMethod))
-	assert.Equal(t, svc.BasePath+"books/v1/users/montana.banana/bookshelves?alt=json&prettyPrint=false", s0.Tag(ext.HTTPURL))
+	assert.Equal(t, svc.BasePath+"books/v1/users/montana.banana/bookshelves", s0.Tag(ext.HTTPURL))
 	assert.Equal(t, "google.golang.org/api", s0.Tag(ext.Component))
 	assert.Equal(t, ext.SpanKindClient, s0.Tag(ext.SpanKind))
 }
@@ -88,7 +88,7 @@ func TestCivicInfo(t *testing.T) {
 	assert.Equal(t, "civicinfo.representatives.representativeInfoByAddress", s0.Tag(ext.ResourceName))
 	assert.Equal(t, "400", s0.Tag(ext.HTTPCode))
 	assert.Equal(t, "GET", s0.Tag(ext.HTTPMethod))
-	assert.Equal(t, svc.BasePath+"civicinfo/v2/representatives?alt=json&prettyPrint=false", s0.Tag(ext.HTTPURL))
+	assert.Equal(t, svc.BasePath+"civicinfo/v2/representatives", s0.Tag(ext.HTTPURL))
 	assert.Equal(t, "google.golang.org/api", s0.Tag(ext.Component))
 	assert.Equal(t, ext.SpanKindClient, s0.Tag(ext.SpanKind))
 }
@@ -115,7 +115,7 @@ func TestURLShortener(t *testing.T) {
 	assert.Equal(t, "urlshortener.url.list", s0.Tag(ext.ResourceName))
 	assert.Equal(t, "400", s0.Tag(ext.HTTPCode))
 	assert.Equal(t, "GET", s0.Tag(ext.HTTPMethod))
-	assert.Equal(t, "https://www.googleapis.com/urlshortener/v1/url/history?alt=json&prettyPrint=false", s0.Tag(ext.HTTPURL))
+	assert.Equal(t, "https://www.googleapis.com/urlshortener/v1/url/history", s0.Tag(ext.HTTPURL))
 	assert.Equal(t, "google.golang.org/api", s0.Tag(ext.Component))
 	assert.Equal(t, ext.SpanKindClient, s0.Tag(ext.SpanKind))
 }
@@ -140,7 +140,7 @@ func TestWithEndpointMetadataDisabled(t *testing.T) {
 	assert.Equal(t, "GET civicinfo.googleapis.com", s0.Tag(ext.ResourceName))
 	assert.Equal(t, "400", s0.Tag(ext.HTTPCode))
 	assert.Equal(t, "GET", s0.Tag(ext.HTTPMethod))
-	assert.Equal(t, svc.BasePath+"civicinfo/v2/representatives?alt=json&prettyPrint=false", s0.Tag(ext.HTTPURL))
+	assert.Equal(t, svc.BasePath+"civicinfo/v2/representatives", s0.Tag(ext.HTTPURL))
 	assert.Equal(t, "google.golang.org/api", s0.Tag(ext.Component))
 	assert.Equal(t, ext.SpanKindClient, s0.Tag(ext.SpanKind))
 }

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -201,7 +201,7 @@ func newRoundTripperConfig() *roundTripperConfig {
 		commonConfig:  sharedCfg,
 		propagation:   true,
 		spanNamer:     defaultSpanNamer,
-		queryString:   options.GetBoolEnv(envClientQueryStringEnabled, true),
+		queryString:   options.GetBoolEnv(envClientQueryStringEnabled, false),
 		isStatusError: isClientError,
 	}
 	v := os.Getenv(envClientErrorStatuses)

--- a/contrib/net/http/roundtripper_test.go
+++ b/contrib/net/http/roundtripper_test.go
@@ -562,6 +562,25 @@ func TestClientQueryString(t *testing.T) {
 		client := &http.Client{
 			Transport: rt,
 		}
+		resp, err := client.Get(s.URL + "/hello/world?API_KEY=1234")
+		assert.Nil(t, err)
+		defer resp.Body.Close()
+		spans := mt.FinishedSpans()
+		assert.Len(t, spans, 1)
+
+		assert.Regexp(t, regexp.MustCompile(`^http://.*?/hello/world$`), spans[0].Tag(ext.HTTPURL))
+	})
+	t.Run("true", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		os.Setenv("DD_TRACE_HTTP_CLIENT_TAG_QUERY_STRING", "true")
+		defer os.Unsetenv("DD_TRACE_HTTP_CLIENT_TAG_QUERY_STRING")
+
+		rt := WrapRoundTripper(http.DefaultTransport)
+		client := &http.Client{
+			Transport: rt,
+		}
 		resp, err := client.Get(s.URL + "/hello/world?querystring=xyz")
 		assert.Nil(t, err)
 		defer resp.Body.Close()
@@ -570,46 +589,25 @@ func TestClientQueryString(t *testing.T) {
 
 		assert.Regexp(t, regexp.MustCompile(`^http://.*?/hello/world\?querystring=xyz$`), spans[0].Tag(ext.HTTPURL))
 	})
-	t.Run("false", func(t *testing.T) {
-		mt := mocktracer.Start()
-		defer mt.Stop()
-
-		os.Setenv("DD_TRACE_HTTP_CLIENT_TAG_QUERY_STRING", "false")
-		defer os.Unsetenv("DD_TRACE_HTTP_CLIENT_TAG_QUERY_STRING")
-
-		rt := WrapRoundTripper(http.DefaultTransport)
-		client := &http.Client{
-			Transport: rt,
-		}
-		resp, err := client.Get(s.URL + "/hello/world?querystring=xyz")
-		assert.Nil(t, err)
-		defer resp.Body.Close()
-		spans := mt.FinishedSpans()
-		assert.Len(t, spans, 1)
-
-		assert.Regexp(t, regexp.MustCompile(`^http://.*?/hello/world$`), spans[0].Tag(ext.HTTPURL))
-	})
 	// DD_TRACE_HTTP_URL_QUERY_STRING_DISABLED applies only to server spans, not client
 	t.Run("Not impacted by DD_TRACE_HTTP_URL_QUERY_STRING_DISABLED", func(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
-		os.Setenv("DD_TRACE_HTTP_CLIENT_TAG_QUERY_STRING", "true")
-		os.Setenv("DD_TRACE_HTTP_URL_QUERY_STRING_DISABLED", "true")
-		defer os.Unsetenv("DD_TRACE_HTTP_CLIENT_TAG_QUERY_STRING")
+		os.Setenv("DD_TRACE_HTTP_URL_QUERY_STRING_DISABLED", "false")
 		defer os.Unsetenv("DD_TRACE_HTTP_URL_QUERY_STRING_DISABLED")
 
 		rt := WrapRoundTripper(http.DefaultTransport)
 		client := &http.Client{
 			Transport: rt,
 		}
-		resp, err := client.Get(s.URL + "/hello/world?querystring=xyz")
+		resp, err := client.Get(s.URL + "/hello/world?API_KEY=1234")
 		assert.Nil(t, err)
 		defer resp.Body.Close()
 		spans := mt.FinishedSpans()
 		assert.Len(t, spans, 1)
 
-		assert.Contains(t, spans[0].Tag(ext.HTTPURL), "/hello/world?querystring=xyz")
+		assert.Regexp(t, regexp.MustCompile(`^http://.*?/hello/world$`), spans[0].Tag(ext.HTTPURL))
 	})
 }
 


### PR DESCRIPTION

### What does this PR do?
By default, query string is not collected on http client spans.

### Motivation
Without the ability to obfuscate the query string (like what DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP does for http server spans), collecting it by default poses a security risk. Thus, we are disabling it by default, allowing users to opt-in to the feature if they so choose.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
