### PR TITLE
ddtrace/tracer: report number of instrumentations used as health metric

### DIFF
--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -8,6 +8,7 @@ package tracer
 import (
 	gocontext "context"
 	"encoding/binary"
+	"fmt"
 	"log/slog"
 	"math"
 	"os"
@@ -347,6 +348,13 @@ func newTracer(opts ...StartOption) *tracer {
 		t.abandonedSpansDebugger = newAbandonedSpansDebugger()
 		t.abandonedSpansDebugger.Start(t.config.spanTimeout)
 	}
+	for name, conf := range c.integrations {
+		if !conf.Instrumented {
+			continue
+		}
+		t.statsd.Incr("datadog.tracer.instrumentations", []string{fmt.Sprintf("source:%s", name)}, 1)
+	}
+
 	t.wg.Add(1)
 	go func() {
 		defer t.wg.Done()

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -255,6 +255,23 @@ func TestTracerStart(t *testing.T) {
 		tr.Stop()
 		tr.Stop()
 	})
+
+	t.Run("integration_health_metric", func(t *testing.T) {
+		defer clearIntegrationsForTests()
+		var tg statsdtest.TestStatsdClient
+
+		ok := MarkIntegrationImported("github.com/go-chi/chi")
+		assert.True(t, ok)
+		tr, _, _, stop := startTestTracer(t, withStatsdClient(&tg))
+		defer stop()
+
+		conf, ok := tr.config.integrations["chi"]
+		assert.True(t, ok)
+		assert.True(t, conf.Instrumented)
+
+		counts := tg.Counts()
+		assert.Equal(t, int64(1), counts["datadog.tracer.instrumentations"])
+	})
 }
 
 func TestTracerLogFile(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Creates and reports a new health metric, `datadog.tracer.instrumentations`, that counts the number of contribs the user is implementing.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

This information is currently in the startup logs, but we want to also give this to our support teams without the extra step of requesting this info from the customer.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
