### PR TITLE
chore: update main version to 1.72.0-dev

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -13,7 +13,7 @@ import (
 // Tag specifies the current release tag. It needs to be manually
 // updated. A test checks that the value of Tag never points to a
 // git tag that is older than HEAD.
-const Tag = "v1.71.0-dev"
+const Tag = "v1.72.0-dev"
 
 // Dissected version number. Filled during init()
 var (


### PR DESCRIPTION
### What does this PR do?

Updates version to `1.72.0-dev`.
