### PR TITLE
[v2] internal/civisibility: Add auto test retries telemetry metric

### DIFF
--- a/internal/civisibility/utils/net/settings_api.go
+++ b/internal/civisibility/utils/net/settings_api.go
@@ -120,6 +120,9 @@ func (c *client) GetSettings() (*SettingsResponseData, error) {
 	if responseObject.Data.Attributes.EarlyFlakeDetection.Enabled {
 		settingsResponseType = append(settingsResponseType, telemetry.EfdEnabledSettingsResponseType...)
 	}
+	if responseObject.Data.Attributes.FlakyTestRetriesEnabled {
+		settingsResponseType = append(settingsResponseType, telemetry.FlakyTestRetriesEnabledSettingsResponseType...)
+	}
 	telemetry.GitRequestsSettingsResponse(settingsResponseType)
 	return &responseObject.Data.Attributes, nil
 }

--- a/internal/civisibility/utils/telemetry/telemetry.go
+++ b/internal/civisibility/utils/telemetry/telemetry.go
@@ -113,9 +113,10 @@ const (
 type SettingsResponseType []string
 
 var (
-	CoverageEnabledSettingsResponseType SettingsResponseType = []string{"coverage_enabled"}
-	ItrSkipEnabledSettingsResponseType  SettingsResponseType = []string{"itrskip_enabled"}
-	EfdEnabledSettingsResponseType      SettingsResponseType = []string{"early_flake_detection_enabled:true"}
+	CoverageEnabledSettingsResponseType         SettingsResponseType = []string{"coverage_enabled"}
+	ItrSkipEnabledSettingsResponseType          SettingsResponseType = []string{"itrskip_enabled"}
+	EfdEnabledSettingsResponseType              SettingsResponseType = []string{"early_flake_detection_enabled:true"}
+	FlakyTestRetriesEnabledSettingsResponseType SettingsResponseType = []string{"flaky_test_retries_enabled:true"}
 )
 
 // removeEmptyStrings removes empty string values inside an array or use the same if not empty string is found.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds a new telemetry metric for the auto test retries feature.

**v1**: https://github.com/DataDog/dd-trace-go/pull/3028

Ticket: SDTEST-1296

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This metric was missing.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [x] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
