### PR TITLE
WIP: Datadog Baggage API

### DIFF
--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -72,12 +72,22 @@ type Span interface {
 	// a representative name for a group of spans (e.g. "grpc.server" or "http.request").
 	SetOperationName(operationName string)
 
-	// BaggageItem returns the baggage item held by the given key.
-	BaggageItem(key string) string
+	// GetBaggageItem returns the baggage item held by the given key.
+	GetBaggageItem(key string) string
 
 	// SetBaggageItem sets a new baggage item at the given key. The baggage
 	// item should propagate to all descendant spans, both in- and cross-process.
 	SetBaggageItem(key, val string)
+
+	// GetAllBaggageItems returns a copy of all baggage items.
+	// If no items exist, returns an empty map.
+	GetAllBaggageItems() map[string]string
+
+	// RemoveBaggageItem removes a single baggage item by its key.
+	RemoveBaggageItem(key string)
+
+	// RemoveAllBaggageItems removes all baggage items from the span.
+	RemoveAllBaggageItems()
 
 	// Finish finishes the current span with the given options. Finish calls should be idempotent.
 	Finish(opts ...FinishOption)

--- a/ddtrace/ddtrace.go
+++ b/ddtrace/ddtrace.go
@@ -72,8 +72,8 @@ type Span interface {
 	// a representative name for a group of spans (e.g. "grpc.server" or "http.request").
 	SetOperationName(operationName string)
 
-	// GetBaggageItem returns the baggage item held by the given key.
-	GetBaggageItem(key string) string
+	// BaggageItem returns the baggage item held by the given key.
+	BaggageItem(key string) string
 
 	// SetBaggageItem sets a new baggage item at the given key. The baggage
 	// item should propagate to all descendant spans, both in- and cross-process.

--- a/ddtrace/internal/globaltracer.go
+++ b/ddtrace/internal/globaltracer.go
@@ -75,10 +75,21 @@ func (NoopSpan) SetTag(_ string, _ interface{}) {}
 func (NoopSpan) SetOperationName(_ string) {}
 
 // BaggageItem implements ddtrace.Span.
-func (NoopSpan) BaggageItem(_ string) string { return "" }
+func (NoopSpan) GetBaggageItem(_ string) string { return "" }
 
 // SetBaggageItem implements ddtrace.Span.
 func (NoopSpan) SetBaggageItem(_, _ string) {}
+
+// RemoveBaggageItem implements ddtrace.Span.
+func (NoopSpan) RemoveBaggageItem(_ string) {}
+
+// RemoveAllBaggageItems implements ddtrace.Span.
+func (NoopSpan) RemoveAllBaggageItems() {}
+
+// GetAllBaggageItems implements ddtrace.Span.
+func (NoopSpan) GetAllBaggageItems() map[string]string {
+	return make(map[string]string)
+}
 
 // Finish implements ddtrace.Span.
 func (NoopSpan) Finish(_ ...ddtrace.FinishOption) {}

--- a/ddtrace/internal/globaltracer.go
+++ b/ddtrace/internal/globaltracer.go
@@ -75,7 +75,7 @@ func (NoopSpan) SetTag(_ string, _ interface{}) {}
 func (NoopSpan) SetOperationName(_ string) {}
 
 // BaggageItem implements ddtrace.Span.
-func (NoopSpan) GetBaggageItem(_ string) string { return "" }
+func (NoopSpan) BaggageItem(_ string) string { return "" }
 
 // SetBaggageItem implements ddtrace.Span.
 func (NoopSpan) SetBaggageItem(_, _ string) {}

--- a/ddtrace/mocktracer/mockspan.go
+++ b/ddtrace/mocktracer/mockspan.go
@@ -176,9 +176,9 @@ func (s *mockspan) SetOperationName(operationName string) {
 	return
 }
 
-// BaggageItem returns the baggage item with the given key.
-func (s *mockspan) BaggageItem(key string) string {
-	return s.context.baggageItem(key)
+// GetBaggageItem returns the baggage item with the given key.
+func (s *mockspan) GetBaggageItem(key string) string {
+	return s.context.getBaggageItem(key)
 }
 
 // SetBaggageItem sets a new baggage item at the given key. The baggage
@@ -186,6 +186,22 @@ func (s *mockspan) BaggageItem(key string) string {
 func (s *mockspan) SetBaggageItem(key, val string) {
 	s.context.setBaggageItem(key, val)
 	return
+}
+
+// RemoveBaggageItem removes the baggage item identified by the given key.
+func (s *mockspan) RemoveBaggageItem(key string) {
+	s.context.removeBaggageItem(key)
+}
+
+// RemoveAllBaggageItems removes all baggage items from this span.
+func (s *mockspan) RemoveAllBaggageItems() {
+	s.context.removeAllBaggageItems()
+}
+
+// GetAllBaggageItems returns a copy of all baggage items.
+// If there are no items, it returns an empty map.
+func (s *mockspan) GetAllBaggageItems() map[string]string {
+	return s.context.getAllBaggageItems()
 }
 
 // Finish finishes the current span with the given options.

--- a/ddtrace/mocktracer/mockspan.go
+++ b/ddtrace/mocktracer/mockspan.go
@@ -176,9 +176,9 @@ func (s *mockspan) SetOperationName(operationName string) {
 	return
 }
 
-// GetBaggageItem returns the baggage item with the given key.
-func (s *mockspan) GetBaggageItem(key string) string {
-	return s.context.getBaggageItem(key)
+// BaggageItem returns the baggage item with the given key.
+func (s *mockspan) BaggageItem(key string) string {
+	return s.context.baggageItem(key)
 }
 
 // SetBaggageItem sets a new baggage item at the given key. The baggage

--- a/ddtrace/mocktracer/mockspan_test.go
+++ b/ddtrace/mocktracer/mockspan_test.go
@@ -144,7 +144,7 @@ func TestSpanBaggageFunctions(t *testing.T) {
 	t.Run("BaggageItem", func(t *testing.T) {
 		s := basicSpan("http.request")
 		s.SetBaggageItem("a", "b")
-		assert.Equal(t, "b", s.GetBaggageItem("a"))
+		assert.Equal(t, "b", s.BaggageItem("a"))
 	})
 
 	t.Run("GetAllBaggageItems", func(t *testing.T) {

--- a/ddtrace/mocktracer/mockspan_test.go
+++ b/ddtrace/mocktracer/mockspan_test.go
@@ -144,7 +144,32 @@ func TestSpanBaggageFunctions(t *testing.T) {
 	t.Run("BaggageItem", func(t *testing.T) {
 		s := basicSpan("http.request")
 		s.SetBaggageItem("a", "b")
-		assert.Equal(t, "b", s.BaggageItem("a"))
+		assert.Equal(t, "b", s.GetBaggageItem("a"))
+	})
+
+	t.Run("GetAllBaggageItems", func(t *testing.T) {
+		s := basicSpan("http.request")
+		s.SetBaggageItem("a", "b")
+		s.SetBaggageItem("c", "d")
+		baggage := s.GetAllBaggageItems()
+		assert.Len(t, baggage, 2)
+		assert.Equal(t, "b", baggage["a"])
+		assert.Equal(t, "d", baggage["c"])
+	})
+
+	t.Run("RemoveBaggageItem", func(t *testing.T) {
+		s := basicSpan("http.request")
+		s.SetBaggageItem("a", "b")
+		s.RemoveBaggageItem("a")
+		assert.Empty(t, s.context.baggage)
+	})
+
+	t.Run("RemoveAllBaggageItems", func(t *testing.T) {
+		s := basicSpan("http.request")
+		s.SetBaggageItem("a", "b")
+		s.SetBaggageItem("c", "d")
+		s.RemoveAllBaggageItems()
+		assert.Empty(t, s.context.baggage)
 	})
 }
 

--- a/ddtrace/mocktracer/mockspancontext.go
+++ b/ddtrace/mocktracer/mockspancontext.go
@@ -48,10 +48,42 @@ func (sc *spanContext) setBaggageItem(k, v string) {
 	sc.baggage[k] = v
 }
 
-func (sc *spanContext) baggageItem(k string) string {
+func (sc *spanContext) getBaggageItem(k string) string {
 	sc.RLock()
 	defer sc.RUnlock()
 	return sc.baggage[k]
+}
+
+func (sc *spanContext) removeBaggageItem(k string) {
+	sc.Lock()
+	defer sc.Unlock()
+	if sc.baggage == nil {
+		return
+	}
+	delete(sc.baggage, k)
+	if len(sc.baggage) == 0 {
+		sc.baggage = nil
+	}
+}
+
+func (sc *spanContext) removeAllBaggageItems() {
+	sc.Lock()
+	defer sc.Unlock()
+	sc.baggage = nil
+}
+
+func (sc *spanContext) getAllBaggageItems() map[string]string {
+	sc.RLock()
+	defer sc.RUnlock()
+	if sc.baggage == nil {
+		return make(map[string]string)
+	}
+	// Return a copy to avoid callers mutating the internal map
+	copyMap := make(map[string]string, len(sc.baggage))
+	for key, val := range sc.baggage {
+		copyMap[key] = val
+	}
+	return copyMap
 }
 
 func (sc *spanContext) setSamplingPriority(p int) {

--- a/ddtrace/mocktracer/mockspancontext.go
+++ b/ddtrace/mocktracer/mockspancontext.go
@@ -48,7 +48,7 @@ func (sc *spanContext) setBaggageItem(k, v string) {
 	sc.baggage[k] = v
 }
 
-func (sc *spanContext) getBaggageItem(k string) string {
+func (sc *spanContext) baggageItem(k string) string {
 	sc.RLock()
 	defer sc.RUnlock()
 	return sc.baggage[k]

--- a/ddtrace/mocktracer/mockspancontext_test.go
+++ b/ddtrace/mocktracer/mockspancontext_test.go
@@ -31,12 +31,12 @@ func TestSpanContextSetBaggage(t *testing.T) {
 	assert.Equal(t, sc.baggage["c"], "d")
 }
 
-func TestSpanContextGetBaggage(t *testing.T) {
+func TestSpanContextBaggage(t *testing.T) {
 	var sc spanContext
 	sc.setBaggageItem("a", "b")
 	sc.setBaggageItem("c", "d")
-	assert.Equal(t, sc.getBaggageItem("a"), "b")
-	assert.Equal(t, sc.getBaggageItem("c"), "d")
+	assert.Equal(t, sc.baggageItem("a"), "b")
+	assert.Equal(t, sc.baggageItem("c"), "d")
 }
 
 func TestSpanContextGetAllBaggage(t *testing.T) {

--- a/ddtrace/mocktracer/mockspancontext_test.go
+++ b/ddtrace/mocktracer/mockspancontext_test.go
@@ -35,8 +35,32 @@ func TestSpanContextGetBaggage(t *testing.T) {
 	var sc spanContext
 	sc.setBaggageItem("a", "b")
 	sc.setBaggageItem("c", "d")
-	assert.Equal(t, sc.baggageItem("a"), "b")
-	assert.Equal(t, sc.baggageItem("c"), "d")
+	assert.Equal(t, sc.getBaggageItem("a"), "b")
+	assert.Equal(t, sc.getBaggageItem("c"), "d")
+}
+
+func TestSpanContextGetAllBaggage(t *testing.T) {
+	var sc spanContext
+	sc.setBaggageItem("a", "b")
+	sc.setBaggageItem("c", "d")
+	assert.Equal(t, map[string]string{"a": "b", "c": "d"}, sc.getAllBaggageItems())
+}
+
+func TestSpanContextRemoveBaggage(t *testing.T) {
+	var sc spanContext
+	sc.setBaggageItem("a", "b")
+	sc.setBaggageItem("c", "d")
+	sc.removeBaggageItem("a")
+	assert.Equal(t, sc.baggage["c"], "d")
+	assert.Empty(t, sc.baggage["a"])
+}
+
+func TestSpanContextRemoveAllBaggage(t *testing.T) {
+	var sc spanContext
+	sc.setBaggageItem("a", "b")
+	sc.setBaggageItem("c", "d")
+	sc.removeAllBaggageItems()
+	assert.Empty(t, sc.baggage)
 }
 
 func TestSpanContextIterator(t *testing.T) {

--- a/ddtrace/mocktracer/mocktracer_test.go
+++ b/ddtrace/mocktracer/mocktracer_test.go
@@ -278,8 +278,8 @@ func TestTracerExtract(t *testing.T) {
 		assert.Nil(err)
 		sc, ok = ctx.(*spanContext)
 		assert.True(ok)
-		assert.Equal("B", sc.getBaggageItem("a"))
-		assert.Equal("D", sc.getBaggageItem("c"))
+		assert.Equal("B", sc.baggageItem("a"))
+		assert.Equal("D", sc.baggageItem("c"))
 
 		ctx, err = mt.Extract(carry(traceHeader, "1", spanHeader, "2", priorityHeader, "-1"))
 		assert.Nil(err)
@@ -302,7 +302,7 @@ func TestTracerExtract(t *testing.T) {
 
 		assert.Equal(uint64(1), got.traceID)
 		assert.Equal(uint64(2), got.spanID)
-		assert.Equal("D", got.getBaggageItem("c"))
-		assert.Equal("B", got.getBaggageItem("a"))
+		assert.Equal("D", got.baggageItem("c"))
+		assert.Equal("B", got.baggageItem("a"))
 	})
 }

--- a/ddtrace/mocktracer/mocktracer_test.go
+++ b/ddtrace/mocktracer/mocktracer_test.go
@@ -278,8 +278,8 @@ func TestTracerExtract(t *testing.T) {
 		assert.Nil(err)
 		sc, ok = ctx.(*spanContext)
 		assert.True(ok)
-		assert.Equal("B", sc.baggageItem("a"))
-		assert.Equal("D", sc.baggageItem("c"))
+		assert.Equal("B", sc.getBaggageItem("a"))
+		assert.Equal("D", sc.getBaggageItem("c"))
 
 		ctx, err = mt.Extract(carry(traceHeader, "1", spanHeader, "2", priorityHeader, "-1"))
 		assert.Nil(err)
@@ -302,7 +302,7 @@ func TestTracerExtract(t *testing.T) {
 
 		assert.Equal(uint64(1), got.traceID)
 		assert.Equal(uint64(2), got.spanID)
-		assert.Equal("D", got.baggageItem("c"))
-		assert.Equal("B", got.baggageItem("a"))
+		assert.Equal("D", got.getBaggageItem("c"))
+		assert.Equal("B", got.getBaggageItem("a"))
 	})
 }

--- a/ddtrace/tracer/civisibility_tslv.go
+++ b/ddtrace/tracer/civisibility_tslv.go
@@ -177,7 +177,7 @@ func (e *ciVisibilityEvent) SetOperationName(operationName string) {
 	e.Content.Name = e.span.Name
 }
 
-// BaggageItem retrieves the baggage item associated with the given key from the event's span.
+// GetBaggageItem retrieves the baggage item associated with the given key from the event's span.
 //
 // Parameters:
 //
@@ -186,8 +186,8 @@ func (e *ciVisibilityEvent) SetOperationName(operationName string) {
 // Returns:
 //
 //	The baggage item value.
-func (e *ciVisibilityEvent) BaggageItem(key string) string {
-	return e.span.BaggageItem(key)
+func (e *ciVisibilityEvent) GetBaggageItem(key string) string {
+	return e.span.GetBaggageItem(key)
 }
 
 // SetBaggageItem sets a baggage item on the event's span.
@@ -198,6 +198,26 @@ func (e *ciVisibilityEvent) BaggageItem(key string) string {
 //	val - The baggage item value.
 func (e *ciVisibilityEvent) SetBaggageItem(key, val string) {
 	e.span.SetBaggageItem(key, val)
+}
+
+// GetAllBaggageItems returns a copy of all baggage items from the event's span.
+// If there are no items, it returns an empty map.
+func (e *ciVisibilityEvent) GetAllBaggageItems() map[string]string {
+	return e.span.GetAllBaggageItems()
+}
+
+// RemoveBaggageItem removes a baggage item from the event's span.
+//
+// Parameters:
+//
+//	key - The baggage item key.
+func (e *ciVisibilityEvent) RemoveBaggageItem(key string) {
+	e.span.RemoveBaggageItem(key)
+}
+
+// RemoveAllBaggageItems removes all baggage items from the event's span.
+func (e *ciVisibilityEvent) RemoveAllBaggageItems() {
+	e.span.RemoveAllBaggageItems()
 }
 
 // Finish completes the event's span with optional finish options.

--- a/ddtrace/tracer/civisibility_tslv.go
+++ b/ddtrace/tracer/civisibility_tslv.go
@@ -177,7 +177,7 @@ func (e *ciVisibilityEvent) SetOperationName(operationName string) {
 	e.Content.Name = e.span.Name
 }
 
-// GetBaggageItem retrieves the baggage item associated with the given key from the event's span.
+// BaggageItem retrieves the baggage item associated with the given key from the event's span.
 //
 // Parameters:
 //
@@ -186,8 +186,8 @@ func (e *ciVisibilityEvent) SetOperationName(operationName string) {
 // Returns:
 //
 //	The baggage item value.
-func (e *ciVisibilityEvent) GetBaggageItem(key string) string {
-	return e.span.GetBaggageItem(key)
+func (e *ciVisibilityEvent) BaggageItem(key string) string {
+	return e.span.BaggageItem(key)
 }
 
 // SetBaggageItem sets a baggage item on the event's span.

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -103,10 +103,10 @@ func (s *span) SetBaggageItem(key, val string) {
 	s.context.setBaggageItem(key, val)
 }
 
-// GetBaggageItem gets the value for a baggage item given its key. Returns the
+// BaggageItem gets the value for a baggage item given its key. Returns the
 // empty string if the value isn't found in this Span.
-func (s *span) GetBaggageItem(key string) string { // change this to GetBaggageItem
-	return s.context.getBaggageItem(key)
+func (s *span) BaggageItem(key string) string {
+	return s.context.baggageItem(key)
 }
 
 // GetAllBaggageItems returns a copy of all baggage items.

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -103,10 +103,26 @@ func (s *span) SetBaggageItem(key, val string) {
 	s.context.setBaggageItem(key, val)
 }
 
-// BaggageItem gets the value for a baggage item given its key. Returns the
+// GetBaggageItem gets the value for a baggage item given its key. Returns the
 // empty string if the value isn't found in this Span.
-func (s *span) BaggageItem(key string) string {
-	return s.context.baggageItem(key)
+func (s *span) GetBaggageItem(key string) string { // change this to GetBaggageItem
+	return s.context.getBaggageItem(key)
+}
+
+// GetAllBaggageItems returns a copy of all baggage items.
+// If no items exist, returns an empty map.
+func (s *span) GetAllBaggageItems() map[string]string {
+	return s.context.getAllBaggageItems()
+}
+
+// RemoveBaggageItem removes a single baggage item by its key.
+func (s *span) RemoveBaggageItem(key string) {
+	s.context.removeBaggageItem(key)
+}
+
+// RemoveAllBaggageItems removes all baggage items from the span.
+func (s *span) RemoveAllBaggageItems() {
+	s.context.removeAllBaggageItems()
 }
 
 // SetTag adds a set of key/value metadata to the span.

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -54,7 +54,43 @@ func TestSpanBaggage(t *testing.T) {
 
 	span := newBasicSpan("web.request")
 	span.SetBaggageItem("key", "value")
-	assert.Equal("value", span.BaggageItem("key"))
+	assert.Equal("value", span.GetBaggageItem("key"))
+}
+
+func TestSpanBaggageRemove(t *testing.T) {
+	assert := assert.New(t)
+
+	span := newBasicSpan("web.request")
+	span.SetBaggageItem("key", "value")
+	assert.Equal("value", span.GetBaggageItem("key"))
+	// test remove baggage
+	span.RemoveBaggageItem("key")
+	assert.Equal("", span.GetBaggageItem("key"))
+}
+
+func TestSpanBaggageRemoveAll(t *testing.T) {
+	assert := assert.New(t)
+
+	span := newBasicSpan("web.request")
+	span.SetBaggageItem("key", "value")
+	span.SetBaggageItem("key2", "value2")
+	assert.Equal("value", span.GetBaggageItem("key"))
+	assert.Equal("value2", span.GetBaggageItem("key2"))
+	// test remove all baggage
+	span.RemoveAllBaggageItems()
+	assert.Equal("", span.GetBaggageItem("key"))
+	assert.Equal("", span.GetBaggageItem("key2"))
+}
+
+func TestSpanBaggageGetAll(t *testing.T) {
+	assert := assert.New(t)
+
+	span := newBasicSpan("web.request")
+	span.SetBaggageItem("key", "value")
+	span.SetBaggageItem("key2", "value2")
+	baggage := span.GetAllBaggageItems()
+	assert.Equal("value", baggage["key"])
+	assert.Equal("value2", baggage["key2"])
 }
 
 func TestSpanContext(t *testing.T) {

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -54,7 +54,7 @@ func TestSpanBaggage(t *testing.T) {
 
 	span := newBasicSpan("web.request")
 	span.SetBaggageItem("key", "value")
-	assert.Equal("value", span.GetBaggageItem("key"))
+	assert.Equal("value", span.BaggageItem("key"))
 }
 
 func TestSpanBaggageRemove(t *testing.T) {
@@ -62,10 +62,10 @@ func TestSpanBaggageRemove(t *testing.T) {
 
 	span := newBasicSpan("web.request")
 	span.SetBaggageItem("key", "value")
-	assert.Equal("value", span.GetBaggageItem("key"))
+	assert.Equal("value", span.BaggageItem("key"))
 	// test remove baggage
 	span.RemoveBaggageItem("key")
-	assert.Equal("", span.GetBaggageItem("key"))
+	assert.Equal("", span.BaggageItem("key"))
 }
 
 func TestSpanBaggageRemoveAll(t *testing.T) {
@@ -74,12 +74,12 @@ func TestSpanBaggageRemoveAll(t *testing.T) {
 	span := newBasicSpan("web.request")
 	span.SetBaggageItem("key", "value")
 	span.SetBaggageItem("key2", "value2")
-	assert.Equal("value", span.GetBaggageItem("key"))
-	assert.Equal("value2", span.GetBaggageItem("key2"))
+	assert.Equal("value", span.BaggageItem("key"))
+	assert.Equal("value2", span.BaggageItem("key2"))
 	// test remove all baggage
 	span.RemoveAllBaggageItems()
-	assert.Equal("", span.GetBaggageItem("key"))
-	assert.Equal("", span.GetBaggageItem("key2"))
+	assert.Equal("", span.BaggageItem("key"))
+	assert.Equal("", span.BaggageItem("key2"))
 }
 
 func TestSpanBaggageGetAll(t *testing.T) {

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -232,7 +232,7 @@ func (c *spanContext) setBaggageItem(key, val string) {
 	c.baggage[key] = val
 }
 
-func (c *spanContext) getBaggageItem(key string) string { // change this function name to getBaggageItem
+func (c *spanContext) baggageItem(key string) string {
 	if atomic.LoadUint32(&c.hasBaggage) == 0 {
 		return ""
 	}

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -783,6 +783,14 @@ func TestSpanContextBaggage(t *testing.T) {
 	var ctx spanContext
 	ctx.setBaggageItem("key", "value")
 	assert.Equal("value", ctx.baggage["key"])
+	ctx.setBaggageItem("foo", "bar")
+	assert.Equal("bar", ctx.getBaggageItem("foo"))
+	ctx.removeBaggageItem("key")
+	assert.NotContains(ctx.baggage, "key")
+	ctx.setBaggageItem("key1", "value1")
+	assert.Equal(map[string]string{"foo": "bar", "key1": "value1"}, ctx.getAllBaggageItems())
+	ctx.removeAllBaggageItems()
+	assert.Empty(ctx.baggage)
 }
 
 func TestSpanContextIterator(t *testing.T) {

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -784,7 +784,7 @@ func TestSpanContextBaggage(t *testing.T) {
 	ctx.setBaggageItem("key", "value")
 	assert.Equal("value", ctx.baggage["key"])
 	ctx.setBaggageItem("foo", "bar")
-	assert.Equal("bar", ctx.getBaggageItem("foo"))
+	assert.Equal("bar", ctx.baggageItem("foo"))
 	ctx.removeBaggageItem("key")
 	assert.NotContains(ctx.baggage, "key")
 	ctx.setBaggageItem("key1", "value1")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Adding baggage API. This includes `getAllBaggageItems`, `removeBaggageItem`, and `removeAllBaggageItems`. `baggageItem` has been renamed to `getBaggageItem` to align with the Baggage RFC as well as other tracers that have already implemented baggage. This is the first PR to add baggage functionality to dd-trace-go and only adds the public API methods. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
