### PR TITLE
fix(ddtrace/tracer): avoid tests to fail with error "non-constant format string" from upcoming Go 1.24 release

### DIFF
--- a/ddtrace/opentelemetry/span.go
+++ b/ddtrace/opentelemetry/span.go
@@ -9,7 +9,6 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -85,7 +84,7 @@ func (s *span) End(options ...oteltrace.SpanEndOption) {
 		if err == nil {
 			s.DD.SetTag("events", string(b))
 		} else {
-			log.Debug(fmt.Sprintf("Issue marshaling span events; events dropped from span meta\n%v", err))
+			log.Debug("Issue marshaling span events; events dropped from span meta\n%v", err)
 		}
 	}
 	var finishCfg = oteltrace.NewSpanEndConfig(options...)

--- a/ddtrace/opentelemetry/span_test.go
+++ b/ddtrace/opentelemetry/span_test.go
@@ -104,7 +104,7 @@ func TestSpanResourceNameDefault(t *testing.T) {
 	tracer.Flush()
 	traces, err := waitForPayload(payloads)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	p := traces[0]
 	assert.Equal("internal", p[0]["name"])
@@ -127,7 +127,7 @@ func TestSpanSetName(t *testing.T) {
 	tracer.Flush()
 	traces, err := waitForPayload(payloads)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	p := traces[0]
 	assert.Equal(strings.ToLower("NewName"), p[0]["name"])
@@ -165,7 +165,7 @@ func TestSpanLink(t *testing.T) {
 	tracer.Flush()
 	payload, err := waitForPayload(payloads)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	assert.NotNil(payload)
 	assert.Len(payload, 1)    // only one trace
@@ -222,7 +222,7 @@ func TestSpanEnd(t *testing.T) {
 	tracer.Flush()
 	traces, err := waitForPayload(payloads)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	p := traces[0]
 
@@ -285,7 +285,7 @@ func TestSpanSetStatus(t *testing.T) {
 				tracer.Flush()
 				traces, err := waitForPayload(payloads)
 				if err != nil {
-					t.Fatalf(err.Error())
+					t.Fatal(err.Error())
 				}
 				p := traces[0]
 				// An error description is set IFF the span has an error
@@ -425,7 +425,7 @@ func TestSpanContextWithStartOptions(t *testing.T) {
 	tracer.Flush()
 	traces, err := waitForPayload(payloads)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	p := traces[0]
 	t.Logf("%v", p[0])
@@ -463,7 +463,7 @@ func TestSpanContextWithStartOptionsPriorityOrder(t *testing.T) {
 	tracer.Flush()
 	traces, err := waitForPayload(payloads)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	p := traces[0]
 	assert.Equal("persisted_srv", p[0]["service"])
@@ -502,7 +502,7 @@ func TestSpanEndOptionsPriorityOrder(t *testing.T) {
 	tracer.Flush()
 	traces, err := waitForPayload(payloads)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	p := traces[0]
 	assert.Equal(float64(duration.Nanoseconds()), p[0]["duration"])
@@ -531,7 +531,7 @@ func TestSpanEndOptions(t *testing.T) {
 	tracer.Flush()
 	traces, err := waitForPayload(payloads)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	p := traces[0]
 	assert.Equal("ctx_srv", p[0]["service"])
@@ -579,7 +579,7 @@ func TestSpanSetAttributes(t *testing.T) {
 	tracer.Flush()
 	traces, err := waitForPayload(payloads)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	p := traces[0]
 	meta := fmt.Sprintf("%v", p[0]["meta"])
@@ -620,7 +620,7 @@ func TestSpanSetAttributesWithRemapping(t *testing.T) {
 	tracer.Flush()
 	traces, err := waitForPayload(payloads)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	p := traces[0]
 	assert.Equal("graphql.server.request", p[0]["name"])
@@ -638,7 +638,7 @@ func TestTracerStartOptions(t *testing.T) {
 	tracer.Flush()
 	traces, err := waitForPayload(payloads)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	p := traces[0]
 	assert.Equal("test_serv", p[0]["service"])
@@ -661,7 +661,7 @@ func TestOperationNameRemapping(t *testing.T) {
 	tracer.Flush()
 	traces, err := waitForPayload(payloads)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	p := traces[0]
 	assert.Equal("graphql.server.request", p[0]["name"])
@@ -788,7 +788,7 @@ func TestRemapName(t *testing.T) {
 			tracer.Flush()
 			traces, err := waitForPayload(payloads)
 			if err != nil {
-				t.Fatalf(err.Error())
+				t.Fatal(err.Error())
 			}
 			p := traces[0]
 			assert.Equal(test.out, p[0]["name"])
@@ -818,7 +818,7 @@ func TestRemapWithMultipleSetAttributes(t *testing.T) {
 	tracer.Flush()
 	traces, err := waitForPayload(payloads)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	p := traces[0]
 	assert.Equal("overriden.name", p[0]["name"])

--- a/ddtrace/tracer/abandonedspans.go
+++ b/ddtrace/tracer/abandonedspans.go
@@ -273,7 +273,7 @@ func (d *abandonedSpansDebugger) log(interval *time.Duration) {
 		log.Warn("Too many abandoned spans. Truncating message.")
 		sb.WriteString("...")
 	}
-	log.Warn(sb.String())
+	log.Log(log.LevelWarn, sb.String())
 }
 
 // formatAbandonedSpans takes a bucket and returns a human-readable string representing

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -338,7 +338,7 @@ func TestIntegrationEnabled(t *testing.T) {
 		var out contribPkg
 		err := stream.Decode(&out)
 		if err != nil {
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 		packages = append(packages, out)
 	}

--- a/ddtrace/tracer/otel_dd_mappings.go
+++ b/ddtrace/tracer/otel_dd_mappings.go
@@ -98,7 +98,7 @@ func getDDorOtelConfig(configName string) string {
 		} else {
 			v, err := config.remapper(otVal)
 			if err != nil {
-				log.Warn(err.Error())
+				log.Warn("%v", err)
 				telemetryTags := []string{ddPrefix + strings.ToLower(config.dd), otelPrefix + strings.ToLower(config.ot)}
 				telemetry.GlobalClient.Count(telemetry.NamespaceTracers, "otel.env.invalid", 1.0, telemetryTags, true)
 			}

--- a/ddtrace/tracer/slog.go
+++ b/ddtrace/tracer/slog.go
@@ -30,24 +30,23 @@ func (h slogHandler) Enabled(ctx context.Context, lvl slog.Level) bool {
 }
 
 func (h slogHandler) Handle(ctx context.Context, r slog.Record) error {
-	parts := make([]string, 0, 1+len(h.attrs)+r.NumAttrs())
-	parts = append(parts, r.Message)
+	parts := make([]string, 0, len(h.attrs)+r.NumAttrs())
 	parts = append(parts, h.attrs...)
 	r.Attrs(func(a slog.Attr) bool {
 		parts = append(parts, formatAttr(a, h.groups))
 		return true
 	})
 
-	msg := strings.Join(parts, " ")
+	extra := strings.Join(parts, " ")
 	switch r.Level {
 	case slog.LevelDebug:
-		log.Debug(msg)
+		log.Debug("%s %s", r.Message, extra)
 	case slog.LevelInfo:
-		log.Info(msg)
+		log.Info("%s %s", r.Message, extra)
 	case slog.LevelWarn:
-		log.Warn(msg)
+		log.Warn("%s %s", r.Message, extra)
 	case slog.LevelError:
-		log.Error(msg)
+		log.Error("%s %s", r.Message, extra)
 	}
 	return nil
 }

--- a/internal/appsec/appsec.go
+++ b/internal/appsec/appsec.go
@@ -222,7 +222,7 @@ func init() {
 		Warn:  log.Warn,
 		Errorf: func(s string, a ...any) error {
 			err := fmt.Errorf(s, a...)
-			log.Error(err.Error())
+			log.Error("%v", err)
 			return err
 		},
 	})

--- a/internal/appsec/emitter/waf/run.go
+++ b/internal/appsec/emitter/waf/run.go
@@ -61,7 +61,7 @@ func (op *ContextOperation) Run(eventReceiver dyngo.Operation, addrs waf.RunAddr
 func RunSimple(ctx context.Context, addrs waf.RunAddressData, errorLog string) error {
 	parent, _ := dyngo.FromContext(ctx)
 	if parent == nil {
-		log.Error(errorLog)
+		log.Error("%s", errorLog)
 		return nil
 	}
 

--- a/internal/civisibility/integrations/civisibility_features.go
+++ b/internal/civisibility/integrations/civisibility_features.go
@@ -224,7 +224,7 @@ func uploadRepositoryChanges() (bytes int64, err error) {
 	hasBeenUnshallowed, err := utils.UnshallowGitRepository()
 	if err != nil || !hasBeenUnshallowed {
 		if err != nil {
-			log.Warn(err.Error())
+			log.Warn("%v", err)
 		}
 		// if unshallowing the repository failed or if there's nothing to unshallow then we try to upload the packfiles from
 		// the initial commit data

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -125,6 +125,16 @@ func GetLevel() Level {
 	return level
 }
 
+// Log writes the given message to the logger at the given level.
+func Log(lvl Level, msg string) {
+	switch lvl {
+	case LevelDebug:
+		Debug("%s", msg)
+	case LevelWarn:
+		Warn("%s", msg)
+	}
+}
+
 // DebugEnabled returns true if debug log messages are enabled. This can be used in extremely
 // hot code paths to avoid allocating the ...interface{} argument.
 func DebugEnabled() bool {
@@ -239,15 +249,15 @@ func Flush() {
 
 func flushLocked() {
 	for _, report := range erragg {
-		msg := fmt.Sprintf("%v", report.err)
+		var extra string
 		if report.count > defaultErrorLimit {
-			msg += fmt.Sprintf(", %d+ additional messages skipped (first occurrence: %s)", defaultErrorLimit, report.first.Format(time.RFC822))
+			extra = fmt.Sprintf(", %d+ additional messages skipped (first occurrence: %s)", defaultErrorLimit, report.first.Format(time.RFC822))
 		} else if report.count > 1 {
-			msg += fmt.Sprintf(", %d additional messages skipped (first occurrence: %s)", report.count-1, report.first.Format(time.RFC822))
+			extra = fmt.Sprintf(", %d additional messages skipped (first occurrence: %s)", report.count-1, report.first.Format(time.RFC822))
 		} else {
-			msg += fmt.Sprintf(" (occurred: %s)", report.first.Format(time.RFC822))
+			extra = fmt.Sprintf(" (occurred: %s)", report.first.Format(time.RFC822))
 		}
-		printMsg("ERROR", msg)
+		printMsg("ERROR", "%v%s", report.err, extra)
 	}
 	for k := range erragg {
 		// compiler-optimized map-clearing post go1.11 (golang/go#20138)

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -151,7 +151,7 @@ type client struct {
 
 func log(msg string, args ...interface{}) {
 	// Debug level so users aren't spammed with telemetry info.
-	logger.Debug(fmt.Sprintf(LogPrefix+msg, args...))
+	logger.Debug(LogPrefix+msg, args...)
 }
 
 // RegisterAppConfig allows to register a globally-defined application configuration.


### PR DESCRIPTION
### What does this PR do?

Upcoming Go 1.24 release introduces a new `go vet` check (https://github.com/golang/go/issues/60529) for printf calls with non-const format and no args. This causes `go test` to fail to run in `gotip`:

```
❯ gotip test gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer
# gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer
# [gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer]
ddtrace/tracer/abandonedspans.go:276:11: non-constant format string in call to gopkg.in/DataDog/dd-trace-go.v1/internal/log.Warn
ddtrace/tracer/otel_dd_mappings.go:101:14: non-constant format string in call to gopkg.in/DataDog/dd-trace-go.v1/internal/log.Warn
ddtrace/tracer/slog.go:44:13: non-constant format string in call to gopkg.in/DataDog/dd-trace-go.v1/internal/log.Debug
ddtrace/tracer/slog.go:46:12: non-constant format string in call to gopkg.in/DataDog/dd-trace-go.v1/internal/log.Info
ddtrace/tracer/slog.go:48:12: non-constant format string in call to gopkg.in/DataDog/dd-trace-go.v1/internal/log.Warn
ddtrace/tracer/slog.go:50:13: non-constant format string in call to gopkg.in/DataDog/dd-trace-go.v1/internal/log.Error
ddtrace/tracer/option_test.go:341:13: non-constant format string in call to (*testing.common).Fatalf
FAIL    gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer [build failed]
FAIL
```

We decided to strategically modify all logging statements, after trying refactoring `internal/log` API to offer:

* `Debug`, `Info`, `Warn`, `Error` functions for logging a string without arguments
* `Debugf`, `Infof`, `Warnf`, `Errorf` function for logging formatted messages with arguments

This caused a significant amount of changes across the repository, but we want to keep the API as coherent as possible. It mirrors stdlib's `log` API.

### Motivation

Avoid unintended consequences from upcoming Go 1.24 release.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
