### PR TITLE
internal/contrib: fix TestTelemetryEnabled flakiness on Windows

### DIFF
--- a/internal/contrib/telemetrytest/telemetry_test.go
+++ b/internal/contrib/telemetrytest/telemetry_test.go
@@ -35,8 +35,7 @@ func (p *contribPkg) hasInstrumentationImport() bool {
 
 // TestTelemetryEnabled verifies that the expected contrib packages leverage instrumentation telemetry
 func TestTelemetryEnabled(t *testing.T) {
-	p := fmt.Sprintf("..%c..%c..%ccontrib", os.PathSeparator, os.PathSeparator, os.PathSeparator)
-	root, err := filepath.Abs(p)
+	root, err := filepath.Abs(filepath.Join("..", "..", "..", "contrib"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +61,6 @@ func testTelemetryEnabled(t *testing.T, contribPath string) error {
 	t.Helper()
 	t.Log(contribPath)
 	pwd, err := os.Getwd()
-	separator := fmt.Sprintf("%c", os.PathSeparator)
 	if err != nil {
 		return err
 	}
@@ -72,7 +70,7 @@ func testTelemetryEnabled(t *testing.T, contribPath string) error {
 	if err = os.Chdir(contribPath); err != nil {
 		return err
 	}
-	body, err := exec.Command("go", "list", "-json", "."+separator+"...").Output()
+	body, err := exec.Command("go", "list", "-json", "./...").Output()
 	if err != nil {
 		t.Log(string(body))
 		return err
@@ -88,7 +86,7 @@ func testTelemetryEnabled(t *testing.T, contribPath string) error {
 		packages = append(packages, out)
 	}
 	for _, pkg := range packages {
-		if strings.Contains(pkg.ImportPath, separator+"test") || strings.Contains(pkg.ImportPath, separator+"internal") {
+		if strings.Contains(pkg.ImportPath, "/test") || strings.Contains(pkg.ImportPath, "/internal") {
 			continue
 		}
 		if !pkg.hasInstrumentationImport() {

--- a/internal/contrib/telemetrytest/telemetry_test.go
+++ b/internal/contrib/telemetrytest/telemetry_test.go
@@ -35,7 +35,8 @@ func (p *contribPkg) hasInstrumentationImport() bool {
 
 // TestTelemetryEnabled verifies that the expected contrib packages leverage instrumentation telemetry
 func TestTelemetryEnabled(t *testing.T) {
-	root, err := filepath.Abs("../../../contrib")
+	p := fmt.Sprintf("..%c..%c..%ccontrib", os.PathSeparator, os.PathSeparator, os.PathSeparator)
+	root, err := filepath.Abs(p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,6 +62,7 @@ func testTelemetryEnabled(t *testing.T, contribPath string) error {
 	t.Helper()
 	t.Log(contribPath)
 	pwd, err := os.Getwd()
+	separator := fmt.Sprintf("%c", os.PathSeparator)
 	if err != nil {
 		return err
 	}
@@ -70,7 +72,7 @@ func testTelemetryEnabled(t *testing.T, contribPath string) error {
 	if err = os.Chdir(contribPath); err != nil {
 		return err
 	}
-	body, err := exec.Command("go", "list", "-json", "./...").Output()
+	body, err := exec.Command("go", "list", "-json", "."+separator+"...").Output()
 	if err != nil {
 		t.Log(string(body))
 		return err
@@ -86,7 +88,7 @@ func testTelemetryEnabled(t *testing.T, contribPath string) error {
 		packages = append(packages, out)
 	}
 	for _, pkg := range packages {
-		if strings.Contains(pkg.ImportPath, "/test") || strings.Contains(pkg.ImportPath, "/internal") {
+		if strings.Contains(pkg.ImportPath, separator+"test") || strings.Contains(pkg.ImportPath, separator+"internal") {
 			continue
 		}
 		if !pkg.hasInstrumentationImport() {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Allows other path separators to prevent flaking on Windows OS.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

Test was flaking in CI due to different results from Windows vs other OS's.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
