### PR TITLE
internal/remoteconfig: support for DD_REMOTE_CONFIGURATION_ENABLED

### DIFF
--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 
 	rc "github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
@@ -185,6 +186,10 @@ func Start(config ClientConfig) error {
 	startOnce.Do(func() {
 		client, err = newClient(config)
 		if err != nil {
+			return
+		}
+		if !internal.BoolEnv("DD_REMOTE_CONFIGURATION_ENABLED", true) {
+			// Don't start polling if the feature is disabled explicitly
 			return
 		}
 		go func() {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Introduces a new env var called `DD_REMOTE_CONFIGURATION_ENABLED` to disable remote config client side. 

### Motivation

Closes #3060 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
