### PR TITLE
fix: workaround for otel agent dependency causes orchestrion failure

### DIFF
--- a/internal/agent-otel-workaround.go
+++ b/internal/agent-otel-workaround.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022 Datadog, Inc.
+
+//go:build otel_workaround
+
+package internal
+
+import (
+	// OTel did a breaking change to the module go.opentelemetry.io/collector/pdata which is imported by the agent
+	// and go.opentelemetry.io/collector/pdata/pprofile depends on it and is breaking because of it
+	// For some reason the dependency closure won't let use upgrade this module past the point where it does not break anymore
+	// So we are forced to add a blank import of this module to give us back the control over its version
+	//
+	// TODO: remove this once github.com/datadog-agent/pkg/trace has upgraded both modules past the breaking change
+	_ "go.opentelemetry.io/collector/pdata/pprofile"
+)

--- a/internal/agent.go
+++ b/internal/agent.go
@@ -11,14 +11,6 @@ import (
 	"os"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
-
-	// OTel did a breaking change to the module go.opentelemetry.io/collector/pdata which is imported by the agent
-	// and go.opentelemetry.io/collector/pdata/pprofile depends on it and is breaking because of it
-	// For some reason the dependency closure won't let use upgrade this module past the point where it does not break anymore
-	// So we are forced to add a blank import of this module to give us back the control over its version
-	//
-	// TODO: remove this once github.com/datadog-agent/pkg/trace has upgraded both modules past the breaking change
-	_ "go.opentelemetry.io/collector/pdata/pprofile"
 )
 
 const (


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Moved the blank import of `go.opentelemetry.io/collector/pdata/pprofile`` which was introduced to avoid `go mod tidy` from failing to resolve a coherent dependency closure into a new file guarded by a build tag so that it is not present in builds uder normal circumstances.

This removes a dependency cycle caused by the `pprofile` package having a transitive dependency on `net/http`, while the
`gopkg.in/DataDog/dd-trace-go.v1/internal` package is imported some code that is injected by orchestrion into `net/http` itself (resulting in a cycle, breaking builds).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
