### PR TITLE
contrib/IBM/sarama.v1: use an unique topic name for tests

### DIFF
--- a/contrib/IBM/sarama.v1/consumer_group_test.go
+++ b/contrib/IBM/sarama.v1/consumer_group_test.go
@@ -91,7 +91,7 @@ func TestWrapConsumerGroupHandler(t *testing.T) {
 	s0 := spans[0]
 	assert.Equal(t, "kafka", s0.Tag(ext.ServiceName))
 	assert.Equal(t, "queue", s0.Tag(ext.SpanType))
-	assert.Equal(t, "Produce Topic gotest", s0.Tag(ext.ResourceName))
+	assert.Equal(t, "Produce Topic gotest_ibm_sarama", s0.Tag(ext.ResourceName))
 	assert.Equal(t, "kafka.produce", s0.OperationName())
 	assert.Equal(t, int32(0), s0.Tag(ext.MessagingKafkaPartition))
 	assert.NotNil(t, s0.Tag("offset"))
@@ -104,7 +104,7 @@ func TestWrapConsumerGroupHandler(t *testing.T) {
 	s1 := spans[1]
 	assert.Equal(t, "kafka", s1.Tag(ext.ServiceName))
 	assert.Equal(t, "queue", s1.Tag(ext.SpanType))
-	assert.Equal(t, "Consume Topic gotest", s1.Tag(ext.ResourceName))
+	assert.Equal(t, "Consume Topic gotest_ibm_sarama", s1.Tag(ext.ResourceName))
 	assert.Equal(t, "kafka.consume", s1.OperationName())
 	assert.Equal(t, int32(0), s1.Tag(ext.MessagingKafkaPartition))
 	assert.NotNil(t, s1.Tag("offset"))

--- a/contrib/IBM/sarama.v1/sarama_test.go
+++ b/contrib/IBM/sarama.v1/sarama_test.go
@@ -23,8 +23,8 @@ import (
 var kafkaBrokers = []string{"localhost:9092", "localhost:9093", "localhost:9094"}
 
 const (
-	testGroupID = "gotest"
-	testTopic   = "gotest"
+	testGroupID = "gotest_ibm_sarama"
+	testTopic   = "gotest_ibm_sarama"
 )
 
 func TestNamingSchema(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Use unique group ID and topic names for the IBM/sarama tests.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

IBM/sarama test are flaking: [example](https://github.com/DataDog/dd-trace-go/actions/runs/12698458107/job/35433419592?pr=3023)

Particularly seeing these logs:

```
    consumer_group_test.go:144: Message claimed: value = test 1, timestamp = 2025-01-10 14:09:58.608 +0000 UTC, topic = gotest
    consumer_group_test.go:144: Message claimed: value = value2, timestamp = 2025-01-10 14:09:59.652 +0000 UTC, topic = gotest
```

The second message seems to be produced by a different kafka test, so there is a chance the failed tests are caused by this extra unexpected message from a different test.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
