### PR TITLE
contrib/net/http: support for path params from go 1.22 proposal

### DIFF
--- a/contrib/net/http/get_pattern.go
+++ b/contrib/net/http/get_pattern.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+//go:build go1.23
+
+package http
+
+import (
+	"net/http"
+)
+
+// getPattern returns the pattern associated with the request or the route if no wildcard is used
+func getPattern(mux *http.ServeMux, r *http.Request) string {
+	if r.Pattern != "" { // Will not be available if the user uses NewServeMux
+		return r.Pattern
+	}
+
+	if mux == nil { // Will not be available if the user uses WrapHandler
+		return ""
+	}
+
+	_, pattern := mux.Handler(r)
+	return pattern
+}

--- a/contrib/net/http/get_pattern_go122.go
+++ b/contrib/net/http/get_pattern_go122.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+//go:build go1.22 && !go1.23
+
+package http
+
+import (
+	"net/http"
+)
+
+func getPattern(mux *http.ServeMux, r *http.Request) string {
+	if mux == nil { // Will not be available if the user uses WrapHandler
+		return ""
+	}
+
+	_, pattern := mux.Handler(r)
+	return pattern
+}

--- a/contrib/net/http/http.go
+++ b/contrib/net/http/http.go
@@ -63,7 +63,7 @@ func (mux *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Resource:    resource,
 		SpanOpts:    so,
 		Route:       route,
-		RouteParams: patternValues(r),
+		RouteParams: patternValues(pattern, r),
 	})
 }
 
@@ -83,6 +83,7 @@ func WrapHandler(h http.Handler, service, resource string, opts ...Option) http.
 			h.ServeHTTP(w, req)
 			return
 		}
+		// TODO: add calls to patternRoute and patternValues once 1.23 is the minimum supported version because 1.23 adds an `(*http.Request).Pattern` field
 		resc := resource
 		if r := cfg.resourceNamer(req); r != "" {
 			resc = r
@@ -91,11 +92,10 @@ func WrapHandler(h http.Handler, service, resource string, opts ...Option) http.
 		copy(so, cfg.spanOpts)
 		so = append(so, httptrace.HeaderTagsFromRequest(req, cfg.headerTags))
 		TraceAndServe(h, w, req, &ServeConfig{
-			Service:     service,
-			Resource:    resc,
-			FinishOpts:  cfg.finishOpts,
-			SpanOpts:    so,
-			RouteParams: patternValues(req),
+			Service:    service,
+			Resource:   resc,
+			FinishOpts: cfg.finishOpts,
+			SpanOpts:   so,
 		})
 	})
 }

--- a/contrib/net/http/http_test.go
+++ b/contrib/net/http/http_test.go
@@ -285,39 +285,6 @@ func TestServeMuxUsesResourceNamer(t *testing.T) {
 	assert.Equal("net/http", s.Tag(ext.Component))
 }
 
-func TestServeMuxGo122Patterns(t *testing.T) {
-	mt := mocktracer.Start()
-	defer mt.Stop()
-
-	// A mux with go1.21 patterns ("/bar") and go1.22 patterns ("GET /foo")
-	mux := NewServeMux()
-	mux.HandleFunc("/bar", func(w http.ResponseWriter, r *http.Request) {})
-	mux.HandleFunc("GET /foo", func(w http.ResponseWriter, r *http.Request) {})
-
-	// Try to hit both routes
-	barW := httptest.NewRecorder()
-	mux.ServeHTTP(barW, httptest.NewRequest("GET", "/bar", nil))
-	fooW := httptest.NewRecorder()
-	mux.ServeHTTP(fooW, httptest.NewRequest("GET", "/foo", nil))
-
-	// Assert the number of spans
-	assert := assert.New(t)
-	spans := mt.FinishedSpans()
-	assert.Equal(2, len(spans))
-
-	// Check the /bar span
-	barSpan := spans[0]
-	assert.Equal(http.StatusOK, barW.Code)
-	assert.Equal("/bar", barSpan.Tag(ext.HTTPRoute))
-	assert.Equal("GET /bar", barSpan.Tag(ext.ResourceName))
-
-	// Check the /foo span
-	fooSpan := spans[1]
-	assert.Equal(http.StatusOK, fooW.Code)
-	assert.Equal("/foo", fooSpan.Tag(ext.HTTPRoute))
-	assert.Equal("GET /foo", fooSpan.Tag(ext.ResourceName))
-}
-
 func TestWrapHandlerWithResourceNameNoRace(_ *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()

--- a/contrib/net/http/pattern.go
+++ b/contrib/net/http/pattern.go
@@ -61,6 +61,24 @@ func getPatternNames(pattern string) []string {
 
 // patternNames returns the names of the wildcards in the pattern.
 // Based on https://cs.opensource.google/go/go/+/refs/tags/go1.23.4:src/net/http/pattern.go;l=84
+// but very simplified as we know that the pattern returned must be valid or `net/http` would have panicked earlier.
+//
+// The pattern string's syntax is
+//
+//	[METHOD] [HOST]/[PATH]
+//
+// where:
+//   - METHOD is an HTTP method
+//   - HOST is a hostname
+//   - PATH consists of slash-separated segments, where each segment is either
+//     a literal or a wildcard of the form "{name}", "{name...}", or "{$}".
+//
+// METHOD, HOST and PATH are all optional; that is, the string can be "/".
+// If METHOD is present, it must be followed by at least one space or tab.
+// Wildcard names must be valid Go identifiers.
+// The "{$}" and "{name...}" wildcard must occur at the end of PATH.
+// PATH may end with a '/'.
+// Wildcard names in a path must be distinct.
 func patternNames(pattern string) ([]string, error) {
 	if len(pattern) == 0 {
 		return nil, errors.New("empty pattern")

--- a/contrib/net/http/pattern.go
+++ b/contrib/net/http/pattern.go
@@ -1,0 +1,150 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+package http
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"unicode"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+)
+
+// patternRoute returns the route part of a go1.22 style ServeMux pattern. I.e.
+// it returns "/foo" for the pattern "/foo" as well as the pattern "GET /foo".
+func patternRoute(s string) string {
+	// Support go1.22 serve mux patterns: [METHOD ][HOST]/[PATH]
+	// Consider any text before a space or tab to be the method of the pattern.
+	// See net/http.parsePattern and the link below for more information.
+	// https://pkg.go.dev/net/http#hdr-Patterns-ServeMux
+	if i := strings.IndexAny(s, " \t"); i > 0 && len(s) >= i+1 {
+		return strings.TrimLeft(s[i+1:], " \t")
+	}
+	return s
+}
+
+var patternSegmentsCache sync.Map // map[string][]string
+
+// patternValues return the path parameter values and names from the request.
+func patternValues(r *http.Request) map[string]string {
+	if r.Pattern == "" { // using <=1.21 serve mux behavior, aborting
+		return nil
+	}
+	names := getPatternNames(r.Pattern)
+	res := make(map[string]string, len(names))
+	for _, name := range names {
+		res[name] = r.PathValue(name)
+	}
+	return res
+}
+
+func getPatternNames(pattern string) []string {
+	if v, ok := patternSegmentsCache.Load(pattern); ok {
+		return v.([]string)
+	}
+
+	segments, err := patternNames(pattern)
+	if err != nil {
+		log.Debug("contrib/net/http: failed to parse mux path pattern %q: %v", pattern, err)
+		return nil
+	}
+
+	v, _ := patternSegmentsCache.LoadOrStore(pattern, segments)
+	return v.([]string)
+}
+
+// patternNames returns the names of the wildcards in the pattern.
+// Based on https://cs.opensource.google/go/go/+/refs/tags/go1.23.4:src/net/http/pattern.go;l=84
+func patternNames(s string) ([]string, error) {
+	if len(s) == 0 {
+		return nil, errors.New("empty pattern")
+	}
+	method, rest, found := s, "", false
+	if i := strings.IndexAny(s, " \t"); i >= 0 {
+		method, rest, found = s[:i], strings.TrimLeft(s[i+1:], " \t"), true
+	}
+	if !found {
+		rest = method
+		method = ""
+	}
+
+	i := strings.IndexByte(rest, '/')
+	if i < 0 {
+		return nil, errors.New("host/path missing /")
+	}
+	host := rest[:i]
+	rest = rest[i:]
+	if j := strings.IndexByte(host, '{'); j >= 0 {
+		return nil, errors.New("host contains '{' (missing initial '/'?)")
+	}
+
+	// At this point, rest is the path.
+	var names []string
+	seenNames := make(map[string]bool)
+	for len(rest) > 0 {
+		// Invariant: rest[0] == '/'.
+		rest = rest[1:]
+		if len(rest) == 0 {
+			// Trailing slash.
+			break
+		}
+		i := strings.IndexByte(rest, '/')
+		if i < 0 {
+			i = len(rest)
+		}
+		var seg string
+		seg, rest = rest[:i], rest[i:]
+		if i := strings.IndexByte(seg, '{'); i >= 0 {
+			// Wildcard.
+			if i != 0 {
+				return nil, errors.New("bad wildcard segment (must start with '{')")
+			}
+			if seg[len(seg)-1] != '}' {
+				return nil, errors.New("bad wildcard segment (must end with '}')")
+			}
+			name := seg[1 : len(seg)-1]
+			if name == "$" {
+				if len(rest) != 0 {
+					return nil, errors.New("{$} not at end")
+				}
+				break
+			}
+			name, multi := strings.CutSuffix(name, "...")
+			if multi && len(rest) != 0 {
+				return nil, errors.New("{...} wildcard not at end")
+			}
+			if name == "" {
+				return nil, errors.New("empty wildcard name")
+			}
+			if !isValidWildcardName(name) {
+				return nil, fmt.Errorf("bad wildcard name %q", name)
+			}
+			if seenNames[name] {
+				return nil, fmt.Errorf("duplicate wildcard name %q", name)
+			}
+			seenNames[name] = true
+			names = append(names, name)
+		}
+	}
+
+	return names, nil
+}
+
+func isValidWildcardName(s string) bool {
+	if s == "" {
+		return false
+	}
+	// Valid Go identifier.
+	for i, c := range s {
+		if !unicode.IsLetter(c) && c != '_' && (i == 0 || !unicode.IsDigit(c)) {
+			return false
+		}
+	}
+	return true
+}

--- a/contrib/net/http/pattern.go
+++ b/contrib/net/http/pattern.go
@@ -33,7 +33,7 @@ var patternSegmentsCache sync.Map // map[string][]string
 
 // patternValues return the path parameter values and names from the request.
 func patternValues(pattern string, request *http.Request) map[string]string {
-	if pattern == "" { // using <=1.21 serve mux behavior, aborting
+	if pattern == "" {
 		return nil
 	}
 	names := getPatternNames(pattern)

--- a/contrib/net/http/pattern.go
+++ b/contrib/net/http/pattern.go
@@ -46,11 +46,15 @@ func patternValues(pattern string, request *http.Request) map[string]string {
 
 func getPatternNames(pattern string) []string {
 	if v, ok := patternSegmentsCache.Load(pattern); ok {
+		if v == nil {
+			return nil
+		}
 		return v.([]string)
 	}
 
 	segments, err := patternNames(pattern)
 	if err != nil {
+		// Ignore the error: Something as gone wrong, but we are not eager to find out why.
 		log.Debug("contrib/net/http: failed to parse mux path pattern %q: %v", pattern, err)
 		// here we fallthrough instead of returning to load a nil value into the cache to avoid reparsing the pattern.
 	}

--- a/contrib/net/http/pattern_test.go
+++ b/contrib/net/http/pattern_test.go
@@ -94,7 +94,6 @@ func TestPatternNames(t *testing.T) {
 		{"/foo/{bar}/{baz}...", nil, true},
 		{"/foo/{bar", nil, true},
 		{"/foo/{bar{baz}}", nil, true},
-		{"/foo/{bar!}", nil, true},
 		{"/foo/{}", nil, true},
 		{"{}", nil, true},
 		{"GET /foo/{bar}", []string{"bar"}, false},
@@ -105,7 +104,6 @@ func TestPatternNames(t *testing.T) {
 		{"OPTIONS /foo/{bar}/{baz}...", nil, true},
 		{"GET /foo/{bar", nil, true},
 		{"POST /foo/{bar{baz}}", nil, true},
-		{"PUT /foo/{bar!}", nil, true},
 		{"DELETE /foo/{}", nil, true},
 		{"OPTIONS {}", nil, true},
 		{"GET example.com/foo/{bar}", []string{"bar"}, false},
@@ -116,7 +114,6 @@ func TestPatternNames(t *testing.T) {
 		{"OPTIONS example.com/foo/{bar}/{baz}...", nil, true},
 		{"GET example.com/foo/{bar", nil, true},
 		{"POST example.com/foo/{bar{baz}}", nil, true},
-		{"PUT example.com/foo/{bar!}", nil, true},
 		{"DELETE example.com/foo/{}", nil, true},
 		{"OPTIONS example.com/{}", nil, true},
 	}

--- a/contrib/net/http/pattern_test.go
+++ b/contrib/net/http/pattern_test.go
@@ -123,7 +123,7 @@ func TestPatternNames(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.pattern, func(t *testing.T) {
-			names, err := patternNames(tt.pattern)
+			names, err := parsePatternNames(tt.pattern)
 			if tt.err {
 				assert.Error(t, err)
 				assert.Nil(t, names)

--- a/contrib/net/http/pattern_test.go
+++ b/contrib/net/http/pattern_test.go
@@ -1,0 +1,133 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPathParams(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		pattern  string
+		url      string
+		expected map[string]string
+	}{
+		{
+			name:     "simple",
+			pattern:  "/foo/{bar}",
+			url:      "/foo/123",
+			expected: map[string]string{"bar": "123"},
+		},
+		{
+			name:     "multiple",
+			pattern:  "/foo/{bar}/{baz}",
+			url:      "/foo/123/456",
+			expected: map[string]string{"bar": "123", "baz": "456"},
+		},
+		{
+			name:     "nested",
+			pattern:  "/foo/{bar}/baz/{qux}",
+			url:      "/foo/123/baz/456",
+			expected: map[string]string{"bar": "123", "qux": "456"},
+		},
+		{
+			name:     "empty",
+			pattern:  "/foo/{bar}",
+			url:      "/foo/",
+			expected: map[string]string{"bar": ""},
+		},
+		{
+			name:     "http method",
+			pattern:  "GET /foo/{bar}",
+			url:      "/foo/123",
+			expected: map[string]string{"bar": "123"},
+		},
+		{
+			name:     "host",
+			pattern:  "example.com/foo/{bar}",
+			url:      "http://example.com/foo/123",
+			expected: map[string]string{"bar": "123"},
+		},
+		{
+			name:     "host and method",
+			pattern:  "GET example.com/foo/{bar}",
+			url:      "http://example.com/foo/123",
+			expected: map[string]string{"bar": "123"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := NewServeMux()
+			mux.HandleFunc(tt.pattern, func(_ http.ResponseWriter, r *http.Request) {
+				params := patternValues(r)
+				assert.Equal(t, tt.expected, params)
+			})
+
+			r := httptest.NewRequest("GET", tt.url, nil)
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, r)
+		})
+	}
+}
+
+func TestPatternNames(t *testing.T) {
+	tests := []struct {
+		pattern  string
+		expected []string
+		err      bool
+	}{
+		{"/foo/{bar}", []string{"bar"}, false},
+		{"/foo/{bar}/{baz}", []string{"bar", "baz"}, false},
+		{"/foo/{bar}/{bar}", nil, true},
+		{"/foo/{bar}...", nil, true},
+		{"/foo/{bar}.../baz", nil, true},
+		{"/foo/{bar}/{baz}...", nil, true},
+		{"/foo/{bar", nil, true},
+		{"/foo/{bar{baz}}", nil, true},
+		{"/foo/{bar!}", nil, true},
+		{"/foo/{}", nil, true},
+		{"{}", nil, true},
+		{"GET /foo/{bar}", []string{"bar"}, false},
+		{"POST /foo/{bar}/{baz}", []string{"bar", "baz"}, false},
+		{"PUT /foo/{bar}/{bar}", nil, true},
+		{"DELETE /foo/{bar}...", nil, true},
+		{"PATCH /foo/{bar}.../baz", nil, true},
+		{"OPTIONS /foo/{bar}/{baz}...", nil, true},
+		{"GET /foo/{bar", nil, true},
+		{"POST /foo/{bar{baz}}", nil, true},
+		{"PUT /foo/{bar!}", nil, true},
+		{"DELETE /foo/{}", nil, true},
+		{"OPTIONS {}", nil, true},
+		{"GET example.com/foo/{bar}", []string{"bar"}, false},
+		{"POST example.com/foo/{bar}/{baz}", []string{"bar", "baz"}, false},
+		{"PUT example.com/foo/{bar}/{bar}", nil, true},
+		{"DELETE example.com/foo/{bar}...", nil, true},
+		{"PATCH example.com/foo/{bar}.../baz", nil, true},
+		{"OPTIONS example.com/foo/{bar}/{baz}...", nil, true},
+		{"GET example.com/foo/{bar", nil, true},
+		{"POST example.com/foo/{bar{baz}}", nil, true},
+		{"PUT example.com/foo/{bar!}", nil, true},
+		{"DELETE example.com/foo/{}", nil, true},
+		{"OPTIONS example.com/{}", nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern, func(t *testing.T) {
+			names, err := patternNames(tt.pattern)
+			if tt.err {
+				assert.Error(t, err)
+				assert.Nil(t, names)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, names)
+			}
+		})
+	}
+}

--- a/contrib/net/http/pattern_test.go
+++ b/contrib/net/http/pattern_test.go
@@ -66,7 +66,8 @@ func TestPathParams(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mux := NewServeMux()
 			mux.HandleFunc(tt.pattern, func(_ http.ResponseWriter, r *http.Request) {
-				params := patternValues(r)
+				_, pattern := mux.Handler(r)
+				params := patternValues(pattern, r)
 				assert.Equal(t, tt.expected, params)
 			})
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR add support for importing path params into `dd-trace-go/contrib/internal/httptrace` data pipeline as multiple other contribs already do.

In details I did:

- [x] Import the code that parses path patterns from `net/http` into dd-trace-go
- [x] Setup a cache for the results of this operation
- [x] Once the names have been extracted, loop over them and run `(*http.Request).PathValue(name)` and build a `map[string]string` with it  

### Motivation

* Better coverage for ASM WAF.
* Enabling a big bunch for tests in the system-tests that work with path params

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
