### PR TITLE
ddtrace/tracer: Enable 128bit trace ID logging by default

### DIFF
--- a/contrib/log/slog/slog_test.go
+++ b/contrib/log/slog/slog_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -19,12 +20,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	internallog "gopkg.in/DataDog/dd-trace-go.v1/internal/log"
 )
 
-func assertLogEntry(t *testing.T, rawEntry, wantMsg, wantLevel string, span tracer.Span, assertExtra func(t *testing.T, entry map[string]interface{})) {
+func assertLogEntry(t *testing.T, rawEntry, wantMsg, wantLevel string, traceID string, spanID string, assertExtra func(t *testing.T, entry map[string]interface{})) {
 	t.Helper()
 
 	t.Log(rawEntry)
@@ -38,9 +40,6 @@ func assertLogEntry(t *testing.T, rawEntry, wantMsg, wantLevel string, span trac
 	assert.Equal(t, wantLevel, entry["level"])
 	assert.NotEmpty(t, entry["time"])
 
-	//TODO: Update tests to account for 128bit logging by default
-	traceID := strconv.FormatUint(span.Context().TraceID(), 10)
-	spanID := strconv.FormatUint(span.Context().SpanID(), 10)
 	assert.Equal(t, traceID, entry[ext.LogKeyTraceID], "trace id not found")
 	assert.Equal(t, spanID, entry[ext.LogKeySpanID], "span id not found")
 
@@ -61,6 +60,18 @@ func testLogger(t *testing.T, createLogger func(b io.Writer) *slog.Logger, asser
 	span, ctx := tracer.StartSpanFromContext(context.Background(), "test")
 	defer span.Finish()
 
+	var traceID string
+	spanID := strconv.FormatUint(span.Context().SpanID(), 10)
+	if log128bits, ok := os.LookupEnv("DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED"); ok && log128bits == "false" {
+		// Re-initialize to account for race condition between setting env var in the test and reading it in the contrib
+		cfg = newConfig()
+		traceID = strconv.FormatUint(span.Context().TraceID(), 10)
+	} else {
+		ctxW3c, ok := span.Context().(ddtrace.SpanContextW3C)
+		assert.True(t, ok)
+		traceID = ctxW3c.TraceID128()
+	}
+
 	// log a message using the context containing span information
 	logger.Log(ctx, slog.LevelInfo, "this is an info log with tracing information")
 	logger.Log(ctx, slog.LevelError, "this is an error log with tracing information")
@@ -71,9 +82,43 @@ func testLogger(t *testing.T, createLogger func(b io.Writer) *slog.Logger, asser
 	)
 	// assert log entries contain trace information
 	require.Len(t, logs, 2)
-	assertLogEntry(t, logs[0], "this is an info log with tracing information", "INFO", span, assertExtra)
-	assertLogEntry(t, logs[1], "this is an error log with tracing information", "ERROR", span, assertExtra)
+
+	assertLogEntry(t, logs[0], "this is an info log with tracing information", "INFO", traceID, spanID, assertExtra)
+	assertLogEntry(t, logs[1], "this is an error log with tracing information", "ERROR", traceID, spanID, assertExtra)
 }
+
+// func testLogger128BitDisabled(t *testing.T, createLogger func(b io.Writer) *slog.Logger, assertExtra func(t *testing.T, entry map[string]interface{})) {
+// 	tracer.Start(tracer.WithLogger(internallog.DiscardLogger{}))
+// 	defer tracer.Stop()
+
+// 	// create the application logger
+// 	var b bytes.Buffer
+// 	logger := createLogger(&b)
+
+// 	// start a new span
+// 	span, ctx := tracer.StartSpanFromContext(context.Background(), "test")
+// 	defer span.Finish()
+
+// 	t.Setenv("DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED", "false")
+// 	// Re-initialize to account for race condition between setting env var in the test and reading it in the contrib
+// 	cfg = newConfig()
+// 	// log a message using the context containing span information
+// 	logger.Log(ctx, slog.LevelInfo, "this is an info log with tracing information")
+// 	logger.Log(ctx, slog.LevelError, "this is an error log with tracing information")
+
+// 	logs := strings.Split(
+// 		strings.TrimRight(b.String(), "\n"),
+// 		"\n",
+// 	)
+// 	// assert log entries contain trace information
+// 	require.Len(t, logs, 2)
+
+// 	// Assert that 64 bit IDs are logged when 128bit logging is disabled
+// 	traceID := strconv.FormatUint(span.Context().TraceID(), 10)
+// 	spanID := strconv.FormatUint(span.Context().SpanID(), 10)
+// 	assertLogEntry(t, logs[0], "this is an info log with tracing information", "INFO", traceID, spanID, assertExtra)
+// 	assertLogEntry(t, logs[1], "this is an error log with tracing information", "ERROR", traceID, spanID, assertExtra)
+// }
 
 func TestNewJSONHandler(t *testing.T) {
 	testLogger(
@@ -205,6 +250,20 @@ func TestRecordClone(t *testing.T) {
 		return true
 	})
 	assert.True(t, foundSentinel)
+}
+
+func Test128BitLoggingDisabled(t *testing.T) {
+	os.Setenv("DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED", "false")
+	defer os.Unsetenv("DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED")
+	t.Run("testLogger", func(t *testing.T) {
+		testLogger(
+			t,
+			func(w io.Writer) *slog.Logger {
+				return slog.New(WrapHandler(slog.NewJSONHandler(w, nil)))
+			},
+			nil,
+		)
+	})
 }
 
 func BenchmarkHandler(b *testing.B) {

--- a/contrib/log/slog/slog_test.go
+++ b/contrib/log/slog/slog_test.go
@@ -38,6 +38,7 @@ func assertLogEntry(t *testing.T, rawEntry, wantMsg, wantLevel string, span trac
 	assert.Equal(t, wantLevel, entry["level"])
 	assert.NotEmpty(t, entry["time"])
 
+	//TODO: Update tests to account for 128bit logging by default
 	traceID := strconv.FormatUint(span.Context().TraceID(), 10)
 	spanID := strconv.FormatUint(span.Context().SpanID(), 10)
 	assert.Equal(t, traceID, entry[ext.LogKeyTraceID], "trace id not found")

--- a/contrib/net/http/trace_test.go
+++ b/contrib/net/http/trace_test.go
@@ -329,8 +329,8 @@ func TestTraceAndServe(t *testing.T) {
 		t.Setenv("DD_TRACE_HTTP_SERVER_ERROR_STATUSES", "500")
 
 		cfg := &ServeConfig{
-			Service:       "service",
-			Resource:      "resource",
+			Service:  "service",
+			Resource: "resource",
 		}
 
 		handler := func(w http.ResponseWriter, r *http.Request) {

--- a/contrib/sirupsen/logrus/logrus.go
+++ b/contrib/sirupsen/logrus/logrus.go
@@ -7,6 +7,8 @@
 package logrus
 
 import (
+	"strconv"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -42,8 +44,8 @@ func (d *DDContextLogHook) Fire(e *logrus.Entry) error {
 	if ctxW3c, ok := span.Context().(ddtrace.SpanContextW3C); ok && log128bits {
 		e.Data[ext.LogKeyTraceID] = ctxW3c.TraceID128()
 	} else {
-		e.Data[ext.LogKeyTraceID] = span.Context().TraceID()
+		e.Data[ext.LogKeyTraceID] = strconv.FormatUint(span.Context().TraceID(), 10)
 	}
-	e.Data[ext.LogKeySpanID] = span.Context().SpanID()
+	e.Data[ext.LogKeySpanID] = strconv.FormatUint(span.Context().SpanID(), 10)
 	return nil
 }

--- a/contrib/sirupsen/logrus/logrus.go
+++ b/contrib/sirupsen/logrus/logrus.go
@@ -7,6 +7,7 @@
 package logrus
 
 import (
+	"fmt"
 	"strconv"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
@@ -37,13 +38,16 @@ func (d *DDContextLogHook) Levels() []logrus.Level {
 
 // Fire implements logrus.Hook interface, attaches trace and span details found in entry context
 func (d *DDContextLogHook) Fire(e *logrus.Entry) error {
+	fmt.Println("Is it enabled?", log128bits)
 	span, found := tracer.SpanFromContext(e.Context)
 	if !found {
 		return nil
 	}
 	if ctxW3c, ok := span.Context().(ddtrace.SpanContextW3C); ok && log128bits {
+		fmt.Println("a true?")
 		e.Data[ext.LogKeyTraceID] = ctxW3c.TraceID128()
 	} else {
+		fmt.Println("false")
 		e.Data[ext.LogKeyTraceID] = strconv.FormatUint(span.Context().TraceID(), 10)
 	}
 	e.Data[ext.LogKeySpanID] = strconv.FormatUint(span.Context().SpanID(), 10)

--- a/contrib/sirupsen/logrus/logrus.go
+++ b/contrib/sirupsen/logrus/logrus.go
@@ -7,6 +7,7 @@
 package logrus
 
 import (
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
@@ -35,7 +36,12 @@ func (d *DDContextLogHook) Fire(e *logrus.Entry) error {
 	if !found {
 		return nil
 	}
-	e.Data[ext.LogKeyTraceID] = span.Context().TraceID()
+	spanCtx128, ok := span.Context().(ddtrace.SpanContextW3C)
+	if ok {
+		e.Data[ext.LogKeyTraceID] = spanCtx128.TraceID128()
+	} else {
+		e.Data[ext.LogKeyTraceID] = span.Context().TraceID()
+	}
 	e.Data[ext.LogKeySpanID] = span.Context().SpanID()
 	return nil
 }

--- a/contrib/sirupsen/logrus/logrus_test.go
+++ b/contrib/sirupsen/logrus/logrus_test.go
@@ -12,7 +12,6 @@ import (
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
-	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -43,7 +42,7 @@ func TestFire128BitDisabled(t *testing.T) {
 	t.Setenv("DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED", "false")
 
 	// Re-initialize to account for race condition between setting env var in the test and reading it in the contrib
-	log128bits = internal.BoolEnv("DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED", true)
+	cfg = newConfig()
 
 	tracer.Start()
 	defer tracer.Stop()

--- a/contrib/sirupsen/logrus/logrus_test.go
+++ b/contrib/sirupsen/logrus/logrus_test.go
@@ -7,15 +7,18 @@ package logrus
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFire(t *testing.T) {
+func TestFire128BitEnabled(t *testing.T) {
+	// By default, trace IDs are logged in 128bit format
 	tracer.Start()
 	defer tracer.Stop()
 	_, sctx := tracer.StartSpanFromContext(context.Background(), "testSpan", tracer.WithSpanID(1234))
@@ -24,8 +27,27 @@ func TestFire(t *testing.T) {
 	e := logrus.NewEntry(logrus.New())
 	e.Context = sctx
 	err := hook.Fire(e)
-
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(1234), e.Data["dd.trace_id"])
-	assert.Equal(t, uint64(1234), e.Data["dd.span_id"])
+
+	ctxW3c, ok := sctx.(ddtrace.SpanContextW3C)
+	assert.True(t, ok)
+	assert.Equal(t, strconv.FormatUint(ctxW3c.TraceID(), 10), e.Data["dd.trace_id"])
+	assert.Equal(t, strconv.FormatUint(ctxW3c.SpanID(), 10), e.Data["dd.span_id"])
+}
+
+func TestFire128BitDisabled(t *testing.T) {
+	// By default, trace IDs are logged in 128bit format
+	t.Setenv("DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED", "false")
+	tracer.Start()
+	defer tracer.Stop()
+	_, sctx := tracer.StartSpanFromContext(context.Background(), "testSpan", tracer.WithSpanID(1234))
+
+	hook := &DDContextLogHook{}
+	e := logrus.NewEntry(logrus.New())
+	e.Context = sctx
+	err := hook.Fire(e)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "1234", e.Data["dd.trace_id"])
+	assert.Equal(t, "1234", e.Data["dd.span_id"])
 }

--- a/ddtrace/tracer/log_test.go
+++ b/ddtrace/tracer/log_test.go
@@ -187,9 +187,11 @@ func TestLogFormat(t *testing.T) {
 	defer stop()
 	tp.Reset()
 	tp.Ignore("appsec: ", telemetry.LogPrefix)
-	tracer.StartSpan("test", ServiceName("test-service"), ResourceName("/"), WithSpanID(12345))
+	sp := tracer.StartSpan("test", ServiceName("test-service"), ResourceName("/"), WithSpanID(12345))
+	sCtx, ok := sp.Context().(*spanContext)
+	assert.True(ok)
 	assert.Len(tp.Logs(), 1)
-	assert.Regexp(logPrefixRegexp+` DEBUG: Started Span: dd.trace_id="12345" dd.span_id="12345" dd.parent_id="0", Operation: test, Resource: /, Tags: map.*, map.*`, tp.Logs()[0])
+	assert.Regexp(logPrefixRegexp+` DEBUG: Started Span: dd.trace_id="`+sCtx.TraceID128()+`" dd.span_id="12345" dd.parent_id="0", Operation: test, Resource: /, Tags: map.*, map.*`, tp.Logs()[0])
 }
 
 func TestLogPropagators(t *testing.T) {

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -709,7 +709,7 @@ func (s *span) Format(f fmt.State, c rune) {
 			}
 		}
 		var traceID string
-		if sharedinternal.BoolEnv("DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED", false) && s.context.traceID.HasUpper() {
+		if sharedinternal.BoolEnv("DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED", true) && s.context.traceID.HasUpper() {
 			traceID = s.context.TraceID128()
 		} else {
 			traceID = fmt.Sprintf("%d", s.TraceID)

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -712,7 +712,8 @@ func TestSpanLog(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
 		span := tracer.StartSpan("test.request").(*span)
-		expect := fmt.Sprintf(`dd.trace_id="%d" dd.span_id="%d" dd.parent_id="0"`, span.TraceID, span.SpanID)
+		sctx := span.Context().(*spanContext)
+		expect := fmt.Sprintf(`dd.trace_id="%s" dd.span_id="%d" dd.parent_id="0"`, sctx.TraceID128(), span.SpanID)
 		assert.Equal(expect, fmt.Sprintf("%v", span))
 	}
 	t.Run("noservice_first", noServiceTest)
@@ -722,7 +723,8 @@ func TestSpanLog(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"))
 		defer stop()
 		span := tracer.StartSpan("test.request").(*span)
-		expect := fmt.Sprintf(`dd.service=tracer.test dd.trace_id="%d" dd.span_id="%d" dd.parent_id="0"`, span.TraceID, span.SpanID)
+		sctx := span.Context().(*spanContext)
+		expect := fmt.Sprintf(`dd.service=tracer.test dd.trace_id="%s" dd.span_id="%d" dd.parent_id="0"`, sctx.TraceID128(), span.SpanID)
 		assert.Equal(expect, fmt.Sprintf("%v", span))
 	})
 
@@ -731,7 +733,8 @@ func TestSpanLog(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithEnv("testenv"))
 		defer stop()
 		span := tracer.StartSpan("test.request").(*span)
-		expect := fmt.Sprintf(`dd.service=tracer.test dd.env=testenv dd.trace_id="%d" dd.span_id="%d" dd.parent_id="0"`, span.TraceID, span.SpanID)
+		sctx := span.Context().(*spanContext)
+		expect := fmt.Sprintf(`dd.service=tracer.test dd.env=testenv dd.trace_id="%s" dd.span_id="%d" dd.parent_id="0"`, sctx.TraceID128(), span.SpanID)
 		assert.Equal(expect, fmt.Sprintf("%v", span))
 	})
 
@@ -740,7 +743,8 @@ func TestSpanLog(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithServiceVersion("1.2.3"))
 		defer stop()
 		span := tracer.StartSpan("test.request").(*span)
-		expect := fmt.Sprintf(`dd.service=tracer.test dd.version=1.2.3 dd.trace_id="%d" dd.span_id="%d" dd.parent_id="0"`, span.TraceID, span.SpanID)
+		sctx := span.Context().(*spanContext)
+		expect := fmt.Sprintf(`dd.service=tracer.test dd.version=1.2.3 dd.trace_id="%s" dd.span_id="%d" dd.parent_id="0"`, sctx.TraceID128(), span.SpanID)
 		assert.Equal(expect, fmt.Sprintf("%v", span))
 	})
 
@@ -749,7 +753,8 @@ func TestSpanLog(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithServiceVersion("1.2.3"), WithEnv("testenv"))
 		defer stop()
 		span := tracer.StartSpan("test.request").(*span)
-		expect := fmt.Sprintf(`dd.service=tracer.test dd.env=testenv dd.version=1.2.3 dd.trace_id="%d" dd.span_id="%d" dd.parent_id="0"`, span.TraceID, span.SpanID)
+		sctx := span.Context().(*spanContext)
+		expect := fmt.Sprintf(`dd.service=tracer.test dd.env=testenv dd.version=1.2.3 dd.trace_id="%s" dd.span_id="%d" dd.parent_id="0"`, sctx.TraceID128(), span.SpanID)
 		assert.Equal(expect, fmt.Sprintf("%v", span))
 	})
 
@@ -761,7 +766,8 @@ func TestSpanLog(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithServiceVersion("1.2.3"), WithEnv("testenv"))
 		defer stop()
 		span := tracer.StartSpan("test.request", ServiceName("subservice name")).(*span)
-		expect := fmt.Sprintf(`dd.service=tracer.test dd.env=testenv dd.version=1.2.3 dd.trace_id="%d" dd.span_id="%d" dd.parent_id="0"`, span.TraceID, span.SpanID)
+		sctx := span.Context().(*spanContext)
+		expect := fmt.Sprintf(`dd.service=tracer.test dd.env=testenv dd.version=1.2.3 dd.trace_id="%s" dd.span_id="%d" dd.parent_id="0"`, sctx.TraceID128(), span.SpanID)
 		assert.Equal(expect, fmt.Sprintf("%v", span))
 	})
 
@@ -773,7 +779,8 @@ func TestSpanLog(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t)
 		defer stop()
 		span := tracer.StartSpan("test.request").(*span)
-		expect := fmt.Sprintf(`dd.service=tracer.test dd.env=testenv dd.version=1.2.3 dd.trace_id="%d" dd.span_id="%d" dd.parent_id="0"`, span.TraceID, span.SpanID)
+		sctx := span.Context().(*spanContext)
+		expect := fmt.Sprintf(`dd.service=tracer.test dd.env=testenv dd.version=1.2.3 dd.trace_id="%s" dd.span_id="%d" dd.parent_id="0"`, sctx.TraceID128(), span.SpanID)
 		assert.Equal(expect, fmt.Sprintf("%v", span))
 	})
 
@@ -782,7 +789,8 @@ func TestSpanLog(t *testing.T) {
 		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithServiceVersion("1.2.3"))
 		defer stop()
 		span := tracer.StartSpan("test.request").(*span)
-		expect := fmt.Sprintf(`%%!b(ddtrace.Span=dd.service=tracer.test dd.version=1.2.3 dd.trace_id="%d" dd.span_id="%d" dd.parent_id="0")`, span.TraceID, span.SpanID)
+		sctx := span.Context().(*spanContext)
+		expect := fmt.Sprintf(`%%!b(ddtrace.Span=dd.service=tracer.test dd.version=1.2.3 dd.trace_id="%s" dd.span_id="%d" dd.parent_id="0")`, sctx.TraceID128(), span.SpanID)
 		assert.Equal(expect, fmt.Sprintf("%b", span))
 	})
 
@@ -790,9 +798,10 @@ func TestSpanLog(t *testing.T) {
 		assert := assert.New(t)
 		tracer, _, _, stop := startTestTracer(t, WithService("tracer.test"), WithServiceVersion("1.2.3"), WithEnv("testenv"))
 		span := tracer.StartSpan("test.request").(*span)
+		sctx := span.Context().(*spanContext)
 		stop()
 		// no service, env, or version after the tracer is stopped
-		expect := fmt.Sprintf(`dd.trace_id="%d" dd.span_id="%d" dd.parent_id="0"`, span.TraceID, span.SpanID)
+		expect := fmt.Sprintf(`dd.trace_id="%s" dd.span_id="%d" dd.parent_id="0"`, sctx.TraceID128(), span.SpanID)
 		assert.Equal(expect, fmt.Sprintf("%v", span))
 	})
 
@@ -803,10 +812,11 @@ func TestSpanLog(t *testing.T) {
 		assert := assert.New(t)
 		tracer, _, _, stop := startTestTracer(t)
 		span := tracer.StartSpan("test.request").(*span)
+		sctx := span.Context().(*spanContext)
 		stop()
 		// service is not included: it is cleared when we stop the tracer
 		// env, version are included: it reads the environment variable when there is no tracer
-		expect := fmt.Sprintf(`dd.env=testenv dd.version=1.2.3 dd.trace_id="%d" dd.span_id="%d" dd.parent_id="0"`, span.TraceID, span.SpanID)
+		expect := fmt.Sprintf(`dd.env=testenv dd.version=1.2.3 dd.trace_id="%s" dd.span_id="%d" dd.parent_id="0"`, sctx.TraceID128(), span.SpanID)
 		assert.Equal(expect, fmt.Sprintf("%v", span))
 	})
 
@@ -825,7 +835,7 @@ func TestSpanLog(t *testing.T) {
 	})
 
 	t.Run("128-bit-logging-only", func(t *testing.T) {
-		// Logging 128-bit trace ids is enabled, but it's not present in
+		// Logging 128-bit trace ids is enabled, but format is not present in
 		// the span. So only the lower 64 bits should be logged in decimal form.
 		t.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "false")
 		assert := assert.New(t)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Logs the full 128bits of the trace id by default. Can be disabled with `DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED=false`.

### Motivation
[Config consistency](https://docs.google.com/document/d/1kI-gTAKghfcwI7YzKhqRv2ExUstcHqADIWA4-TZ387o/edit?tab=t.bkepxflevyzs#heading=h.rysof5z57829)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
