### PR TITLE
(fix) internal/civisibility: add some checks before performing the http requests.

### DIFF
--- a/internal/civisibility/integrations/gotesting/coverage/coverage_writer_test.go
+++ b/internal/civisibility/integrations/gotesting/coverage/coverage_writer_test.go
@@ -70,16 +70,21 @@ func TestCoverageWriterFlushError(t *testing.T) {
 
 // MockClient is a mock implementation of the Client interface for testing purposes.
 type MockClient struct {
-	SendCoveragePayloadFunc        func(ciTestCovPayload io.Reader) error
-	GetSettingsFunc                func() (*net.SettingsResponseData, error)
-	GetEarlyFlakeDetectionDataFunc func() (*net.EfdResponseData, error)
-	GetCommitsFunc                 func(localCommits []string) ([]string, error)
-	SendPackFilesFunc              func(commitSha string, packFiles []string) (bytes int64, err error)
-	GetSkippableTestsFunc          func() (correlationId string, skippables map[string]map[string][]net.SkippableResponseDataAttributes, err error)
+	SendCoveragePayloadFunc           func(ciTestCovPayload io.Reader) error
+	SendCoveragePayloadWithFormatFunc func(ciTestCovPayload io.Reader, format string) error
+	GetSettingsFunc                   func() (*net.SettingsResponseData, error)
+	GetEarlyFlakeDetectionDataFunc    func() (*net.EfdResponseData, error)
+	GetCommitsFunc                    func(localCommits []string) ([]string, error)
+	SendPackFilesFunc                 func(commitSha string, packFiles []string) (bytes int64, err error)
+	GetSkippableTestsFunc             func() (correlationId string, skippables map[string]map[string][]net.SkippableResponseDataAttributes, err error)
 }
 
 func (m *MockClient) SendCoveragePayload(ciTestCovPayload io.Reader) error {
 	return m.SendCoveragePayloadFunc(ciTestCovPayload)
+}
+
+func (m *MockClient) SendCoveragePayloadWithFormat(ciTestCovPayload io.Reader, format string) error {
+	return m.SendCoveragePayloadWithFormatFunc(ciTestCovPayload, format)
 }
 
 func (m *MockClient) GetSettings() (*net.SettingsResponseData, error) {

--- a/internal/civisibility/utils/net/client.go
+++ b/internal/civisibility/utils/net/client.go
@@ -42,6 +42,7 @@ type (
 		GetCommits(localCommits []string) ([]string, error)
 		SendPackFiles(commitSha string, packFiles []string) (bytes int64, err error)
 		SendCoveragePayload(ciTestCovPayload io.Reader) error
+		SendCoveragePayloadWithFormat(ciTestCovPayload io.Reader, format string) error
 		GetSkippableTests() (correlationID string, skippables map[string]map[string][]SkippableResponseDataAttributes, err error)
 	}
 

--- a/internal/civisibility/utils/net/coverage.go
+++ b/internal/civisibility/utils/net/coverage.go
@@ -27,16 +27,39 @@ func NewClientForCodeCoverage() Client {
 
 // SendCoveragePayload sends a code coverage payload to the backend.
 func (c *client) SendCoveragePayload(ciTestCovPayload io.Reader) error {
+	return c.SendCoveragePayloadWithFormat(ciTestCovPayload, FormatMessagePack)
+}
+
+// SendCoveragePayload sends a code coverage payload to the backend.
+func (c *client) SendCoveragePayloadWithFormat(ciTestCovPayload io.Reader, format string) error {
 	if ciTestCovPayload == nil {
 		return errors.New("coverage payload is nil")
 	}
-
 	// Create a dummy event to send with the coverage payload.
 	dummyEvent := FormFile{
 		FieldName:   "event",
 		ContentType: ContentTypeJSON,
 		FileName:    "fileevent.json",
 		Content:     []byte("{\"dummy\": true}"),
+	}
+
+	var coverageEvent FormFile
+	if format == FormatMessagePack {
+		coverageEvent = FormFile{
+			FieldName:   "coveragex",
+			Content:     ciTestCovPayload,
+			FileName:    "filecoveragex.msgpack",
+			ContentType: ContentTypeMessagePack,
+		}
+	} else if format == FormatJSON {
+		coverageEvent = FormFile{
+			FieldName:   "coveragex",
+			Content:     ciTestCovPayload,
+			FileName:    "filecoveragex.json",
+			ContentType: ContentTypeJSON,
+		}
+	} else {
+		return fmt.Errorf("unsupported format: %s", format)
 	}
 
 	// Send the coverage payload.
@@ -46,12 +69,7 @@ func (c *client) SendCoveragePayload(ciTestCovPayload io.Reader) error {
 		Headers: c.headers,
 		Files: []FormFile{
 			dummyEvent,
-			{
-				FieldName:   "coveragex",
-				Content:     ciTestCovPayload,
-				FileName:    "filecoveragex.msgpack",
-				ContentType: ContentTypeMessagePack,
-			},
+			coverageEvent,
 		},
 	}
 

--- a/internal/civisibility/utils/net/efd_api.go
+++ b/internal/civisibility/utils/net/efd_api.go
@@ -52,6 +52,10 @@ type (
 )
 
 func (c *client) GetEarlyFlakeDetectionData() (*EfdResponseData, error) {
+	if c.repositoryURL == "" || c.commitSha == "" {
+		return nil, fmt.Errorf("civisibility.GetEarlyFlakeDetectionData: repository URL and commit SHA are required")
+	}
+
 	body := efdRequest{
 		Data: efdRequestHeader{
 			ID:   c.id,

--- a/internal/civisibility/utils/net/searchcommits_api.go
+++ b/internal/civisibility/utils/net/searchcommits_api.go
@@ -32,6 +32,10 @@ type (
 )
 
 func (c *client) GetCommits(localCommits []string) ([]string, error) {
+	if c.repositoryURL == "" {
+		return nil, fmt.Errorf("civisibility.GetCommits: repository URL is required")
+	}
+
 	body := searchCommits{
 		Data: []searchCommitsData{},
 		Meta: searchCommitsMeta{

--- a/internal/civisibility/utils/net/sendpackfiles_api.go
+++ b/internal/civisibility/utils/net/sendpackfiles_api.go
@@ -40,6 +40,11 @@ func (c *client) SendPackFiles(commitSha string, packFiles []string) (bytes int6
 		commitSha = c.commitSha
 	}
 
+	if c.repositoryURL == "" || commitSha == "" {
+		err = fmt.Errorf("civisibility.SendPackFiles: repository URL and commit SHA are required")
+		return
+	}
+
 	pushedShaFormFile := FormFile{
 		FieldName: "pushedSha",
 		Content: pushedShaBody{

--- a/internal/civisibility/utils/net/settings_api.go
+++ b/internal/civisibility/utils/net/settings_api.go
@@ -66,6 +66,10 @@ type (
 )
 
 func (c *client) GetSettings() (*SettingsResponseData, error) {
+	if c.repositoryURL == "" || c.commitSha == "" {
+		return nil, fmt.Errorf("civisibility.GetSettings: repository URL and commit SHA are required")
+	}
+
 	body := settingsRequest{
 		Data: settingsRequestHeader{
 			ID:   c.id,
@@ -100,14 +104,14 @@ func (c *client) GetSettings() (*SettingsResponseData, error) {
 		telemetry.GitRequestsSettingsErrors(telemetry.GetErrorTypeFromStatusCode(response.StatusCode))
 	}
 
+	if log.DebugEnabled() {
+		log.Debug("civisibility.settings: %s", string(response.Body))
+	}
+
 	var responseObject settingsResponse
 	err = response.Unmarshal(&responseObject)
 	if err != nil {
 		return nil, fmt.Errorf("unmarshalling settings response: %s", err.Error())
-	}
-
-	if log.DebugEnabled() {
-		log.Debug("civisibility.settings: %s", string(response.Body))
 	}
 
 	var settingsResponseType telemetry.SettingsResponseType

--- a/internal/civisibility/utils/net/skippable.go
+++ b/internal/civisibility/utils/net/skippable.go
@@ -60,6 +60,10 @@ type (
 )
 
 func (c *client) GetSkippableTests() (correlationID string, skippables map[string]map[string][]SkippableResponseDataAttributes, err error) {
+	if c.repositoryURL == "" || c.commitSha == "" {
+		err = fmt.Errorf("civisibility.GetSkippableTests: repository URL and commit SHA are required")
+		return
+	}
 
 	body := skippableRequest{
 		Data: skippableRequestHeader{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR add some checks before performing the http requests and also add support for sending code coverage data in a different format.

PR for V2: https://github.com/DataDog/dd-trace-go/pull/3088

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

I saw some http client response with status code 400 when testing on a Go project without a git repo.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
