### PR TITLE
contrib/envoyproxy: fix empty request

### DIFF
--- a/contrib/envoyproxy/go-control-plane/envoy.go
+++ b/contrib/envoyproxy/go-control-plane/envoy.go
@@ -77,8 +77,6 @@ func (s *appsecEnvoyExternalProcessorServer) Process(processServer envoyextproc.
 
 	// Close the span when the request is done processing
 	defer func() {
-		defer log.Flush()
-
 		if currentRequest == nil {
 			return
 		}

--- a/contrib/envoyproxy/go-control-plane/envoy_test.go
+++ b/contrib/envoyproxy/go-control-plane/envoy_test.go
@@ -365,6 +365,53 @@ func TestXForwardedForHeaderClientIp(t *testing.T) {
 	})
 }
 
+func TestMalformedEnvoyProcessing(t *testing.T) {
+	appsec.Start()
+	defer appsec.Stop()
+	if !appsec.Enabled() {
+		t.Skip("appsec disabled")
+	}
+
+	setup := func() (envoyextproc.ExternalProcessorClient, mocktracer.Tracer, func()) {
+		rig, err := newEnvoyAppsecRig(t, false)
+		require.NoError(t, err)
+
+		mt := mocktracer.Start()
+
+		return rig.client, mt, func() {
+			rig.Close()
+			mt.Stop()
+		}
+	}
+
+	t.Run("response-received-without-request", func(t *testing.T) {
+		client, mt, cleanup := setup()
+		defer cleanup()
+
+		ctx := context.Background()
+		stream, err := client.Process(ctx)
+		require.NoError(t, err)
+
+		err = stream.Send(&envoyextproc.ProcessingRequest{
+			Request: &envoyextproc.ProcessingRequest_ResponseHeaders{
+				ResponseHeaders: &envoyextproc.HttpHeaders{
+					Headers: makeResponseHeaders(t, map[string]string{}, "400"),
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = stream.Recv()
+		require.Error(t, err)
+		stream.Recv()
+
+		// No span created, the request is invalid.
+		// Span couldn't be created without request data
+		finished := mt.FinishedSpans()
+		require.Len(t, finished, 0)
+	})
+}
+
 func newEnvoyAppsecRig(t *testing.T, traceClient bool, interceptorOpts ...ddgrpc.Option) (*envoyAppsecRig, error) {
 	t.Helper()
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR fixes an issue that could cause a crash when a response was processed without any corresponding request being received.

This can happen when Envoy fails to send a request headers processing and only send the processing of the response.

Related issue opened in the envoy repo: https://github.com/envoyproxy/envoy/issues/38022

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
