### PR TITLE
fix(staticcheck): Fix trivial go vet issues

### DIFF
--- a/contrib/jackc/pgx.v5/example_test.go
+++ b/contrib/jackc/pgx.v5/example_test.go
@@ -45,7 +45,7 @@ func ExampleConnect() {
 	}
 }
 
-func ExamplePool() {
+func ExampleNewPool() {
 	ctx := context.TODO()
 
 	// The pgxpool uses the same tracer and is exposed the same way.

--- a/contrib/labstack/echo.v4/appsec_test.go
+++ b/contrib/labstack/echo.v4/appsec_test.go
@@ -271,7 +271,6 @@ func TestControlFlow(t *testing.T) {
 			},
 			handler: func(echo.Context) error {
 				panic("unexpected control flow")
-				return nil
 			},
 			test: func(t *testing.T, rec *httptest.ResponseRecorder, mt mocktracer.Tracer, err error) {
 				require.Error(t, err)

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -26,7 +26,8 @@ func BenchmarkIter(b *testing.B) {
 
 func TestLockMapThrash(t *testing.T) {
 	wg := sync.WaitGroup{}
-	ctx, _ := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	t.Cleanup(cancel)
 	lm := NewLockMap(map[string]string{})
 	wg.Add(6)
 	for i := 0; i < 3; i++ {


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kemal.akkoyun@datadoghq.com>

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR fixes triage issues in the codebase that has been identified by the `go vet` tool.
```text
# gopkg.in/DataDog/dd-trace-go.v1/contrib/labstack/echo.v4
# [gopkg.in/DataDog/dd-trace-go.v1/contrib/labstack/echo.v4]
contrib/labstack/echo.v4/appsec_test.go:274:5: unreachable code
# gopkg.in/DataDog/dd-trace-go.v1/contrib/jackc/pgx.v5_test
# [gopkg.in/DataDog/dd-trace-go.v1/contrib/jackc/pgx.v5_test]
contrib/jackc/pgx.v5/example_test.go:48:1: ExamplePool refers to unknown identifier: Pool
# gopkg.in/DataDog/dd-trace-go.v1/internal
# [gopkg.in/DataDog/dd-trace-go.v1/internal]
internal/utils_test.go:29:7: the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
