### PR TITLE
(feat) internal/civisibility: add support for testify Suites (v2)

### DIFF
--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -103,6 +103,14 @@ func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
 	}
 
 	instrumentedFn := func(t *testing.T) {
+		// Check if we have testify suite data related to this test
+		testifyData := getTestifyTest(t)
+		if testifyData != nil {
+			// If we have testify data, we need to extract the module and suite name from the testify suite
+			moduleName = testifyData.moduleName
+			suiteName = testifyData.suiteName
+		}
+
 		// Initialize module counters if not already present.
 		if _, ok := modulesCounters[moduleName]; !ok {
 			var v int32
@@ -123,7 +131,14 @@ func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
 		module := session.GetOrCreateModule(moduleName)
 		suite := module.GetOrCreateSuite(suiteName)
 		test := suite.CreateTest(t.Name())
-		test.SetTestFunc(originalFunc)
+
+		// If we have testify data we use the method function from testify so the test source is properly set
+		if testifyData != nil {
+			test.SetTestFunc(testifyData.methodFunc)
+		} else {
+			// If not, let's set the original function
+			test.SetTestFunc(originalFunc)
+		}
 
 		// Get the metadata regarding the execution (in case is already created from the additional features)
 		execMeta := getTestMetadata(t)
@@ -406,4 +421,11 @@ func instrumentTestingBFunc(pb *testing.B, name string, f func(*testing.B)) (str
 	setCiVisibilityBenchmarkFunc(originalFunc)
 	setCiVisibilityBenchmarkFunc(runtime.FuncForPC(reflect.Indirect(reflect.ValueOf(instrumentedFunc)).Pointer()))
 	return subBenchmarkAutoName, instrumentedFunc
+}
+
+// instrumentTestifySuiteRun helper function to instrument the testify Suite.Run function
+//
+//go:linkname instrumentTestifySuiteRun
+func instrumentTestifySuiteRun(t *testing.T, suite any) {
+	registerTestifySuite(t, suite)
 }

--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
@@ -94,7 +95,7 @@ func runFlakyTestRetriesTests(m *testing.M) {
 
 	// 1 session span
 	// 1 module span
-	// 2 suite span (testing_test.go and reflections_test.go)
+	// 4 suite span (testing_test.go, testify_test.go, testify_test.go/MySuite and reflections_test.go)
 	// 5 tests from reflections_test.go
 	// 1 TestMyTest01
 	// 1 TestMyTest02 + 2 subtests
@@ -104,10 +105,13 @@ func runFlakyTestRetriesTests(m *testing.M) {
 	// 1 TestRetryWithFail + 3 retry tests from testing_test.go
 	// 1 TestNormalPassingAfterRetryAlwaysFail
 	// 1 TestEarlyFlakeDetection
+	// 3 tests from testify_test.go and testify_test.go/MySuite
 
 	// check spans by resource name
 	checkSpansByResourceName(finishedSpans, "github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting", 1)
 	checkSpansByResourceName(finishedSpans, "reflections_test.go", 1)
+	checkSpansByResourceName(finishedSpans, "testify_test.go", 1)
+	checkSpansByResourceName(finishedSpans, "testify_test.go/MySuite", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestMyTest01", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestMyTest02", 1)
@@ -122,6 +126,14 @@ func runFlakyTestRetriesTests(m *testing.M) {
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestRetryWithFail", 4)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestNormalPassingAfterRetryAlwaysFail", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestEarlyFlakeDetection", 1)
+	checkSpansByResourceName(finishedSpans, "testify_test.go.TestTestifyLikeTest", 1)
+	testifySub01 := checkSpansByResourceName(finishedSpans, "testify_test.go/MySuite.TestTestifyLikeTest/TestMySuite", 1)[0]
+	checkSpansByResourceName(finishedSpans, "testify_test.go/MySuite.TestTestifyLikeTest/TestMySuite/sub01", 1)
+
+	// check that testify span has the correct source file
+	if !strings.HasSuffix(testifySub01.Tag("test.source.file").(string), "/testify_test.go") {
+		panic(fmt.Sprintf("source file should be testify_test.go, got %s", testifySub01.Tag("test.source.file").(string)))
+	}
 
 	// check spans by tag
 	checkSpansByTagName(finishedSpans, constants.TestIsRetry, 6)
@@ -131,8 +143,8 @@ func runFlakyTestRetriesTests(m *testing.M) {
 		28,
 		1,
 		1,
-		2,
-		24,
+		4,
+		27,
 		0)
 
 	fmt.Println("All tests passed.")
@@ -171,7 +183,7 @@ func runEarlyFlakyTestDetectionTests(m *testing.M) {
 
 	// 1 session span
 	// 1 module span
-	// 2 suite span (testing_test.go and reflections_test.go)
+	// 4 suite span (testing_test.go, testify_test.go, testify_test.go/MySuite and reflections_test.go)
 	// 5 tests from reflections_test.go
 	// 11 TestMyTest01
 	// 11 TestMyTest02 + 22 subtests
@@ -182,10 +194,13 @@ func runEarlyFlakyTestDetectionTests(m *testing.M) {
 	// 11 TestNormalPassingAfterRetryAlwaysFail
 	// 11 TestEarlyFlakeDetection
 	// 22 normal spans from testing_test.go
+	// 33 tests from testify_test.go and testify_test.go/MySuite
 
 	// check spans by resource name
 	checkSpansByResourceName(finishedSpans, "github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting", 1)
 	checkSpansByResourceName(finishedSpans, "reflections_test.go", 1)
+	checkSpansByResourceName(finishedSpans, "testify_test.go", 1)
+	checkSpansByResourceName(finishedSpans, "testify_test.go/MySuite", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestMyTest01", 11)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestMyTest02", 11)
@@ -200,18 +215,26 @@ func runEarlyFlakyTestDetectionTests(m *testing.M) {
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestRetryWithFail", 11)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestNormalPassingAfterRetryAlwaysFail", 11)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestEarlyFlakeDetection", 11)
+	checkSpansByResourceName(finishedSpans, "testify_test.go.TestTestifyLikeTest", 11)
+	testifySub01 := checkSpansByResourceName(finishedSpans, "testify_test.go/MySuite.TestTestifyLikeTest/TestMySuite", 11)[0]
+	checkSpansByResourceName(finishedSpans, "testify_test.go/MySuite.TestTestifyLikeTest/TestMySuite/sub01", 11)
+
+	// check that testify span has the correct source file
+	if !strings.HasSuffix(testifySub01.Tag("test.source.file").(string), "/testify_test.go") {
+		panic(fmt.Sprintf("source file should be testify_test.go, got %s", testifySub01.Tag("test.source.file").(string)))
+	}
 
 	// check spans by tag
-	checkSpansByTagName(finishedSpans, constants.TestIsNew, 143)
-	checkSpansByTagName(finishedSpans, constants.TestIsRetry, 130)
+	checkSpansByTagName(finishedSpans, constants.TestIsNew, 176)
+	checkSpansByTagName(finishedSpans, constants.TestIsRetry, 160)
 
 	// check spans by type
 	checkSpansByType(finishedSpans,
 		152,
 		1,
 		1,
-		2,
-		148,
+		4,
+		181,
 		0)
 
 	fmt.Println("All tests passed.")
@@ -241,6 +264,13 @@ func runFlakyTestRetriesWithEarlyFlakyTestDetectionTests(m *testing.M) {
 					"TestRetryAlwaysFail",
 					"TestNormalPassingAfterRetryAlwaysFail",
 				},
+				"testify_test.go": []string{
+					"TestTestifyLikeTest",
+				},
+				"testify_test.go/MySuite": []string{
+					"TestTestifyLikeTest/TestMySuite",
+					"TestTestifyLikeTest/TestMySuite/sub01",
+				},
 			},
 		},
 	}, false, nil)
@@ -264,7 +294,7 @@ func runFlakyTestRetriesWithEarlyFlakyTestDetectionTests(m *testing.M) {
 
 	// 1 session span
 	// 1 module span
-	// 2 suite span (testing_test.go and reflections_test.go)
+	// 4 suite span (testing_test.go, testify_test.go, testify_test.go/MySuite and reflections_test.go)
 	// 5 tests from reflections_test.go
 	// 1 TestMyTest01
 	// 1 TestMyTest02 + 2 subtests
@@ -276,10 +306,13 @@ func runFlakyTestRetriesWithEarlyFlakyTestDetectionTests(m *testing.M) {
 	// 1 TestNormalPassingAfterRetryAlwaysFail
 	// 1 TestEarlyFlakeDetection + 10 EFD retries
 	// 2 normal spans from testing_test.go
+	// 3 tests from testify_test.go and testify_test.go/MySuite
 
 	// check spans by resource name
 	checkSpansByResourceName(finishedSpans, "github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting", 1)
 	checkSpansByResourceName(finishedSpans, "reflections_test.go", 1)
+	checkSpansByResourceName(finishedSpans, "testify_test.go", 1)
+	checkSpansByResourceName(finishedSpans, "testify_test.go/MySuite", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestMyTest01", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestMyTest02", 1)
@@ -294,6 +327,14 @@ func runFlakyTestRetriesWithEarlyFlakyTestDetectionTests(m *testing.M) {
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestRetryWithFail", 4)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestNormalPassingAfterRetryAlwaysFail", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestEarlyFlakeDetection", 11)
+	checkSpansByResourceName(finishedSpans, "testify_test.go.TestTestifyLikeTest", 1)
+	testifySub01 := checkSpansByResourceName(finishedSpans, "testify_test.go/MySuite.TestTestifyLikeTest/TestMySuite", 1)[0]
+	checkSpansByResourceName(finishedSpans, "testify_test.go/MySuite.TestTestifyLikeTest/TestMySuite/sub01", 1)
+
+	// check that testify span has the correct source file
+	if !strings.HasSuffix(testifySub01.Tag("test.source.file").(string), "/testify_test.go") {
+		panic(fmt.Sprintf("source file should be testify_test.go, got %s", testifySub01.Tag("test.source.file").(string)))
+	}
 
 	// check spans by tag
 	checkSpansByTagName(finishedSpans, constants.TestIsNew, 11)
@@ -304,8 +345,8 @@ func runFlakyTestRetriesWithEarlyFlakyTestDetectionTests(m *testing.M) {
 		38,
 		1,
 		1,
-		2,
-		34,
+		4,
+		37,
 		0)
 
 	fmt.Println("All tests passed.")
@@ -361,7 +402,7 @@ func runIntelligentTestRunnerTests(m *testing.M) {
 
 	// 1 session span
 	// 1 module span
-	// 2 suite span (testing_test.go and reflections_test.go)
+	// 4 suite span (testing_test.go, testify_test.go, testify_test.go/MySuite and reflections_test.go)
 	// 5 tests from reflections_test.go
 	// 1 TestMyTest01
 	// 1 TestMyTest02
@@ -372,10 +413,13 @@ func runIntelligentTestRunnerTests(m *testing.M) {
 	// 1 TestRetryAlwaysFail
 	// 1 TestNormalPassingAfterRetryAlwaysFail
 	// 1 TestEarlyFlakeDetection
+	// 3 tests from testify_test.go and testify_test.go/MySuite
 
 	// check spans by resource name
 	checkSpansByResourceName(finishedSpans, "github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting", 1)
 	checkSpansByResourceName(finishedSpans, "reflections_test.go", 1)
+	checkSpansByResourceName(finishedSpans, "testify_test.go", 1)
+	checkSpansByResourceName(finishedSpans, "testify_test.go/MySuite", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go", 1)
 	checkSpansByResourceName(finishedSpans, "reflections_test.go.TestGetFieldPointerFrom", 1)
 	checkSpansByResourceName(finishedSpans, "reflections_test.go.TestGetInternalTestArray", 1)
@@ -395,6 +439,14 @@ func runIntelligentTestRunnerTests(m *testing.M) {
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestRetryWithFail", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestNormalPassingAfterRetryAlwaysFail", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestEarlyFlakeDetection", 1)
+	checkSpansByResourceName(finishedSpans, "testify_test.go.TestTestifyLikeTest", 1)
+	testifySub01 := checkSpansByResourceName(finishedSpans, "testify_test.go/MySuite.TestTestifyLikeTest/TestMySuite", 1)[0]
+	checkSpansByResourceName(finishedSpans, "testify_test.go/MySuite.TestTestifyLikeTest/TestMySuite/sub01", 1)
+
+	// check that testify span has the correct source file
+	if !strings.HasSuffix(testifySub01.Tag("test.source.file").(string), "/testify_test.go") {
+		panic(fmt.Sprintf("source file should be testify_test.go, got %s", testifySub01.Tag("test.source.file").(string)))
+	}
 
 	// check ITR spans
 	// 5 tests skipped by ITR and 1 normal skipped test
@@ -411,8 +463,8 @@ func runIntelligentTestRunnerTests(m *testing.M) {
 		17,
 		1,
 		1,
-		2,
-		13,
+		4,
+		16,
 		0)
 
 	fmt.Println("All tests passed.")

--- a/internal/civisibility/integrations/gotesting/testify.go
+++ b/internal/civisibility/integrations/gotesting/testify.go
@@ -1,0 +1,150 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package gotesting
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"unsafe"
+)
+
+// TestifyTest is a struct that stores the information about a test method from a Testify suite.
+type TestifyTest struct {
+	methodName string
+	suiteName  string
+	moduleName string
+	methodFunc *runtime.Func
+	suite      reflect.Type
+}
+
+var (
+	// testifyTestsByParentT is a map that stores the TestifyTest structs for each parent T.
+	testifyTestsByParentT = map[unsafe.Pointer][]TestifyTest{}
+	// testifyTestsByParentTMutex is a mutex to protect the testifyTestsByParentT map.
+	testifyTestsByParentTMutex sync.RWMutex
+)
+
+// getTestifyTest returns the TestifyTest struct for the given *testing.T.
+func getTestifyTest(t *testing.T) *TestifyTest {
+	return getTestifyTestFromReflectValue(reflect.ValueOf(t))
+}
+
+// getTestifyTestFromReflectValue returns the TestifyTest struct for the given reflect.Value (*testing.T or *common for the parent T).
+func getTestifyTestFromReflectValue(tValue reflect.Value) *TestifyTest {
+	// check if the reflect.Value is valid
+	if !tValue.IsValid() || tValue.IsZero() || tValue.IsNil() {
+		return nil
+	}
+	// get the parent field for testing.T or common
+	member := reflect.Indirect(tValue).FieldByName("parent")
+	if !member.IsValid() && !member.IsNil() {
+		return nil
+	}
+	memberPtr := unsafe.Pointer(member.UnsafeAddr())
+
+	// let's check if the test parent was registered before (`suite.Run(*testing.T, TestSuite)` auto-instrumentation should register the parent T with the suite instance)
+	testifyTestsByParentTMutex.RLock()
+	defer testifyTestsByParentTMutex.RUnlock()
+
+	if tests, ok := testifyTestsByParentT[*(*unsafe.Pointer)(memberPtr)]; ok {
+		// get the name of the test (not the parent)
+		var tName string
+		if ptr, err := getFieldPointerFromValue(reflect.Indirect(tValue), "name"); err == nil && ptr != nil {
+			tName = *(*string)(ptr)
+		} else {
+			return nil
+		}
+
+		// let's find the TestifyTest struct for the current test
+		for _, test := range tests {
+			mName := fmt.Sprintf("/%s", test.methodName)
+			if strings.HasSuffix(tName, mName) {
+				return &test
+			}
+		}
+	} else if member.IsValid() && !member.IsZero() && !member.IsNil() {
+		// if the parent T was not registered, let's try to find the TestifyTest struct for the parent T
+		// this is required for subtests
+		return getTestifyTestFromReflectValue(member)
+	}
+
+	return nil
+}
+
+// registerTestifySuite registers the Testify suite with the given *testing.T.
+func registerTestifySuite(t *testing.T, suite any) {
+	// check if the *testing.T and the suite are valid
+	if t == nil || suite == nil {
+		return
+	}
+
+	// get the reflect.Type of the suite
+	methodFinder := reflect.TypeOf(suite)
+	suiteReflect := methodFinder.Elem()
+
+	// get the suite name and module name
+	suiteName := suiteReflect.Name()
+	moduleName := suiteReflect.PkgPath()
+
+	// get the parent T pointer
+	tPtr := reflect.ValueOf(t).UnsafePointer()
+
+	// lock the mutex to protect the testifyTestsByParentT map
+	testifyTestsByParentTMutex.Lock()
+	defer testifyTestsByParentTMutex.Unlock()
+
+	// get the TestifyTest structs for the parent T in case is not the first Suite registration for the test
+	var tests []TestifyTest
+	if tmpTests, ok := testifyTestsByParentT[tPtr]; ok {
+		tests = tmpTests
+	}
+
+	// check if we already processed the suite
+	for _, test := range tests {
+		if test.suite == methodFinder {
+			// the suite was already registered
+			return
+		}
+	}
+
+	// iterate over the methods of the suite to find the Test methods
+	for i := 0; i < methodFinder.NumMethod(); i++ {
+		method := methodFinder.Method(i)
+
+		// get the name for the method
+		methodName := method.Name
+
+		// filter out non Test methods
+		if ok, _ := regexp.MatchString("^Test", methodName); !ok {
+			continue
+		}
+
+		// get the file for the method
+		methodFunc := runtime.FuncForPC(uintptr(method.Func.UnsafePointer()))
+		var methodFile string
+		if methodFunc != nil {
+			methodFile, _ = methodFunc.FileLine(methodFunc.Entry())
+		}
+
+		// append the TestifyTest struct to the tests slice
+		tests = append(tests, TestifyTest{
+			methodName: methodName,
+			suiteName:  fmt.Sprintf("%s/%s", filepath.Base(methodFile), suiteName),
+			moduleName: moduleName,
+			methodFunc: methodFunc,
+			suite:      methodFinder,
+		})
+	}
+
+	// store the TestifyTest structs for the parent T
+	testifyTestsByParentT[tPtr] = tests
+}

--- a/internal/civisibility/integrations/gotesting/testify_test.go
+++ b/internal/civisibility/integrations/gotesting/testify_test.go
@@ -32,8 +32,8 @@ func TestTestifyLikeTest(t *testing.T) {
 			if test.suiteName != "testify_test.go/MySuite" {
 				t.Errorf("Expected suite name to be testify_test.go/MySuite, got %s", test.suiteName)
 			}
-			if test.moduleName != "gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations/gotesting" {
-				t.Errorf("Expected module name to be gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations/gotesting, got %s", test.moduleName)
+			if test.moduleName != "github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting" {
+				t.Errorf("Expected module name to be github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting, got %s", test.moduleName)
 			}
 		} else {
 			t.Errorf("Expected the parent T to be registered, got %v", reflect.ValueOf(tParent).UnsafePointer())

--- a/internal/civisibility/integrations/gotesting/testify_test.go
+++ b/internal/civisibility/integrations/gotesting/testify_test.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package gotesting
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTestifyLikeTest(t *testing.T) {
+	mySuite := new(MySuite)
+	registerTestifySuite(t, mySuite)
+	Run(t, mySuite)
+
+	tParent := t
+	t.Run("check_suite_registration", func(t *testing.T) {
+		testifyTestsByParentTMutex.Lock()
+		defer testifyTestsByParentTMutex.Unlock()
+
+		if tests, ok := testifyTestsByParentT[reflect.ValueOf(tParent).UnsafePointer()]; ok {
+			if len(tests) != 1 {
+				t.Errorf("Expected 1 test to be registered, got %d", len(tests))
+			}
+
+			test := tests[0]
+			if test.methodName != "TestMySuite" {
+				t.Errorf("Expected method name to be TestMySuite, got %s", test.methodName)
+			}
+			if test.suiteName != "testify_test.go/MySuite" {
+				t.Errorf("Expected suite name to be testify_test.go/MySuite, got %s", test.suiteName)
+			}
+			if test.moduleName != "gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations/gotesting" {
+				t.Errorf("Expected module name to be gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations/gotesting, got %s", test.moduleName)
+			}
+		} else {
+			t.Errorf("Expected the parent T to be registered, got %v", reflect.ValueOf(tParent).UnsafePointer())
+		}
+	})
+}
+
+func (s *MySuite) TestMySuite() {
+	t := (*T)(s.T)
+	t.Log("This is a test")
+	t.Run("sub01", func(t *testing.T) {
+	})
+}

--- a/internal/civisibility/integrations/gotesting/testify_utils_test.go
+++ b/internal/civisibility/integrations/gotesting/testify_utils_test.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package gotesting
+
+import (
+	"reflect"
+	"testing"
+)
+
+type MySuite struct {
+	T *testing.T
+}
+
+func Run(t *testing.T, suite *MySuite) {
+	suite.T = t
+
+	tests := []testing.InternalTest{}
+	methodFinder := reflect.TypeOf(suite)
+	for i := 0; i < methodFinder.NumMethod(); i++ {
+		method := methodFinder.Method(i)
+
+		parentT := t
+		test := testing.InternalTest{
+			Name: method.Name,
+			F: func(t *testing.T) {
+				suite.T = t
+				defer func() {
+					suite.T = parentT
+				}()
+				method.Func.Call([]reflect.Value{reflect.ValueOf(suite)})
+			},
+		}
+		tests = append(tests, test)
+	}
+
+	for _, test := range tests {
+		(*T)(t).Run(test.Name, test.F)
+	}
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds support for testify Suite kind of tests.

**Ticket**: SDTEST-1435

**V1 PR**: https://github.com/DataDog/dd-trace-go/pull/3094

**Note**: This improvements will require a new orchestrion integration to intercept `suite.Run` calls

Example:
```go
....
type USMSuite struct {
	suite.Suite
}

func TestUSMSuite(t *testing.T) {
	suite.Run(t, new(USMSuite))
}

func (s *USMSuite) TestEnableHTTPMonitoring() {
}

func (s *USMSuite) TestDisableUSM() {
}
....
```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Currently the support lacks the correct identification of the Suite name, Module name and Test source affecting features like Codeowners and Impact Analysis

**From**:

<img width="897" alt="image" src="https://github.com/user-attachments/assets/88daa761-dac2-4fda-9187-b76748ca7499" />

<img width="605" alt="image" src="https://github.com/user-attachments/assets/78922296-fa42-4bed-936f-a1515cf76cec" />


**To**:

<img width="821" alt="image" src="https://github.com/user-attachments/assets/7a908bc9-ef0c-46fb-a983-bcaf4c6a486f" />

<img width="466" alt="image" src="https://github.com/user-attachments/assets/2a422bc3-f7b1-4f60-95ef-93f7e3b204d0" />


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
