### PR TITLE
[v2] fix(contrib/hashicorp/{consul,vault}): pin armon/go-metrics to v0.4.1

### DIFF
--- a/contrib/hashicorp/consul/go.mod
+++ b/contrib/hashicorp/consul/go.mod
@@ -94,3 +94,8 @@ require (
 )
 
 replace github.com/DataDog/dd-trace-go/v2 => ../../..
+
+// Pin github.com/armon/go-metrics to the last version available to avoid breaking changes
+// due to the migration to github.com/hashicorp/go-metrics.
+// This will be a no-op once hashicorp/consul/api is updated to use the new go-metrics package.
+replace github.com/armon/go-metrics => github.com/armon/go-metrics v0.4.1

--- a/contrib/hashicorp/consul/go.sum
+++ b/contrib/hashicorp/consul/go.sum
@@ -37,7 +37,6 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
-github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-metrics v0.4.1 h1:hR91U9KYmb6bLBYLQjyM+3j+rcd/UhE+G78SFnF8gJA=
 github.com/armon/go-metrics v0.4.1/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+3JqfkOG4=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=

--- a/contrib/hashicorp/vault/go.mod
+++ b/contrib/hashicorp/vault/go.mod
@@ -95,3 +95,8 @@ require (
 replace github.com/DataDog/dd-trace-go/contrib/net/http/v2 => ../../net/http
 
 replace github.com/DataDog/dd-trace-go/v2 => ../../..
+
+// Pin github.com/armon/go-metrics to the last version available to avoid breaking changes
+// due to the migration to github.com/hashicorp/go-metrics.
+// This will be a no-op once hashicorp/vault/api is updated to use the new go-metrics package.
+replace github.com/armon/go-metrics => github.com/armon/go-metrics v0.4.1


### PR DESCRIPTION
### What does this PR do?

Pins `armon/go-metrics` to `v0.4.1` using a `replace` directive.

### Motivation

To reduce CI times and noise in smoke tests' logs, we pin `github.com/armon/go-metrics` to `v0.4.1`, the last version released before it was migirated to Hashicorp's organization.

Without this, running our smoke tests that rely on `go get -u` tend to run longer due to Go's toolchain mechanism to try to find the right version that fits the import URL. Versions higher than `v0.4.1` use `github.com/hashicorp/go-metrics` instead.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
