### PR TITLE
internal/telemetry: implement temporary telemetry fix for configurations

### DIFF
--- a/contrib/internal/httptrace/httptrace.go
+++ b/contrib/internal/httptrace/httptrace.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/log"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 	"net/http"
 	"strconv"
 	"strings"
@@ -67,6 +68,8 @@ func StartRequestSpan(r *http.Request, opts ...ddtrace.StartSpanOption) (tracer.
 					}
 				}
 				inferredProxySpan = startInferredProxySpan(requestProxyContext, spanParentCtx, inferredStartSpanOpts...)
+				telemetry.GlobalClient.IntegrationConfigChange([]telemetry.Configuration{{Name: "inferred_proxy_services_enabled",
+					Value: cfg.inferredProxyServicesEnabled}})
 			}
 		}
 	}

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -32,6 +32,7 @@ import (
 type Client interface {
 	RegisterAppConfig(name string, val interface{}, origin Origin)
 	ProductChange(namespace Namespace, enabled bool, configuration []Configuration)
+	IntegrationConfigChange(configuration []Configuration)
 	ConfigChange(configuration []Configuration)
 	Record(namespace Namespace, metric MetricKind, name string, value float64, tags []string, common bool)
 	Count(namespace Namespace, name string, value float64, tags []string, common bool)

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -47,6 +47,20 @@ func TestConfigChange(t *testing.T) {
 	Check(t, configPayload.Configuration, "delta_profiles", true)
 }
 
+func TestIntegrationConfigChange(t *testing.T) {
+	client := new(client)
+	client.start(nil, NamespaceTracers, true)
+	client.integrationConfigChange([]Configuration{BoolConfig("delta_profiles", true)})
+	require.Len(t, client.requests, 1)
+
+	body := client.requests[0].Body
+	assert.Equal(t, RequestTypeAppStarted, body.RequestType)
+	var configPayload = client.requests[0].Body.Payload.(*ConfigurationChange)
+	require.Len(t, configPayload.Configuration, 1)
+
+	Check(t, configPayload.Configuration, "delta_profiles", true)
+}
+
 // mockServer initializes a server that expects a strict amount of telemetry events. It saves these
 // events in a slice until the expected number of events is reached.
 // the `genTelemetry` argument accepts a function that should generate the expected telemetry events via calls to the global client

--- a/internal/telemetry/telemetrytest/telemetrytest.go
+++ b/internal/telemetry/telemetrytest/telemetrytest.go
@@ -101,3 +101,9 @@ func (c *MockClient) ConfigChange(args []telemetry.Configuration) {
 	c.On("ConfigChange", args).Return()
 	_ = c.Called(args)
 }
+
+// IntegrationConfigChange is a mock for the IntegrationConfigChange method.
+func (c *MockClient) IntegrationConfigChange(args []telemetry.Configuration) {
+	c.On("IntegrationConfigChange", args).Return()
+	_ = c.Called(args)
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
 
Implements a new type of telemetry function `IntegrationConfigChange` that masquerades as an `AppStart` request due to limitations on the intake level. This will be overwritten once @eliottness fixes the telemetry client to include other request types.

### Motivation

We want to be able to track configuration changes despite limitations on the backend. This way we can send events that we know for sure are not filtered out and appear on all data tracking services on the backend

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
