### PR TITLE
ktlo(ddtrace,contrib): don't use hardcoded FS paths on integration/telemetry tests

### DIFF
--- a/contrib/internal/telemetrytest/telemetry_test.go
+++ b/contrib/internal/telemetrytest/telemetry_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -87,8 +88,9 @@ func TestTelemetryEnabled(t *testing.T) {
 		if strings.Contains(pkg.ImportPath, "/test") || strings.Contains(pkg.ImportPath, "/internal") || strings.Contains(pkg.ImportPath, "/cmd") {
 			continue
 		}
-		p := strings.Replace(pkg.Dir, pkg.Root, "../..", 1)
-		if strings.Contains(p, "/contrib/net/http/client") || strings.Contains(p, "/contrib/os") {
+		sep := string(os.PathSeparator)
+		p := strings.Replace(pkg.Dir, pkg.Root, filepath.Join("..", ".."), 1)
+		if strings.Contains(p, filepath.Join(sep, "contrib", "net", "http", "client")) || strings.Contains(p, filepath.Join(sep, "contrib", "os")) {
 			continue
 		}
 		if !pkg.hasTelemetryImport(t) {

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -346,8 +346,9 @@ func TestIntegrationEnabled(t *testing.T) {
 		if strings.Contains(pkg.ImportPath, "/test") || strings.Contains(pkg.ImportPath, "/internal") || strings.Contains(pkg.ImportPath, "/cmd") {
 			continue
 		}
-		p := strings.Replace(pkg.Dir, pkg.Root, "../..", 1)
-		if strings.Contains(p, "/contrib/net/http/client") || strings.Contains(p, "/contrib/os") {
+		sep := string(os.PathSeparator)
+		p := strings.Replace(pkg.Dir, pkg.Root, filepath.Join("..", ".."), 1)
+		if strings.Contains(p, filepath.Join(sep, "contrib", "net", "http", "client")) || strings.Contains(p, filepath.Join(sep, "contrib", "os")) {
 			continue
 		}
 		body, err := exec.Command("grep", "-rl", "MarkIntegrationImported", p).Output()


### PR DESCRIPTION
### What does this PR do?

Fixes Windows CI removing hardcoded Unix-style filesystem paths in `TestIntegrationEnabled` and `TestTelemetryEnabled`.

### Motivation

Happy CI, happy devs.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
