### PR TITLE
[v2] ci: add codeowners to gotestsum report (#3118)

### DIFF
--- a/.github/actions/add-codeowners/codeowners.sh
+++ b/.github/actions/add-codeowners/codeowners.sh
@@ -12,8 +12,11 @@ for file in "$@"; do
         # we might try to report gotestsum-report.xml multiple times, so don't
         # calculate codeowners more times than we need
         if [[ "$p" =~ \<testcase && ! "$p" =~ "file=" ]]; then
-            class=$(echo "$p" | grep -o '.v1/[^"]*"')
-            file_name=$(echo "${class:3}" | sed 's/.$//') # trim off the edges to get the path
+            # in v2, some of our paths contain a "/v2" before the subdirectory path, but
+            # the contribs do not. We optionally remove it.
+            class=$(echo "$p" | sed "s|/v2||")
+            class=$(echo "$class" | grep -o 'dd-trace-go/[^"]*"')
+            file_name=$(echo "${class:11}" | sed 's/.$//') # trim off the edges to get the path
             new_line=$(echo "$p" | sed "s|<testcase \([^>]*\)>|<testcase \1 file=\"$file_name\">|")
             echo "$new_line" >> "$temp_file"
         else 

--- a/.github/actions/add-codeowners/codeowners.sh
+++ b/.github/actions/add-codeowners/codeowners.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+for file in "$@"; do
+    temp_file="tempfile.xml"
+
+    # force write a new line at the end of the gotestsum-report.xml, or else
+    # the loop will skip the last line.
+    # fixes issue with a missing </testsuites>
+    echo -e "\n" >> $file
+
+    while read p; do
+        # we might try to report gotestsum-report.xml multiple times, so don't
+        # calculate codeowners more times than we need
+        if [[ "$p" =~ \<testcase && ! "$p" =~ "file=" ]]; then
+            class=$(echo "$p" | grep -o '.v1/[^"]*"')
+            file_name=$(echo "${class:3}" | sed 's/.$//') # trim off the edges to get the path
+            new_line=$(echo "$p" | sed "s|<testcase \([^>]*\)>|<testcase \1 file=\"$file_name\">|")
+            echo "$new_line" >> "$temp_file"
+        else 
+            echo "$p" >> "$temp_file"
+        fi
+    done < $file
+
+    mv "$temp_file" $file
+done 

--- a/.github/actions/dd-ci-upload/action.yml
+++ b/.github/actions/dd-ci-upload/action.yml
@@ -42,6 +42,10 @@ runs:
         curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_${{ env.DD_CI_CLI_BUILD }}" --output datadog-ci    
         chmod +x datadog-ci
 
+    - name: Add CodeOwners to JUnit files
+      shell: bash
+      run: cd ./.github/actions/add-codeowners && ./codeowners.sh ${{ inputs.files }}
+
     - name: Upload the JUnit files
       shell: bash
       run: |


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

ports #3118 to v2

Contrib `CODEOWNERS`
<img width="1047" alt="image" src="https://github.com/user-attachments/assets/b0f12d4f-7aec-4a50-9bd5-1eb253c1580d" />

Other `CODEOWNERS`
<img width="1071" alt="image" src="https://github.com/user-attachments/assets/2c08d416-84a8-4eb3-a2c8-88382b9d3e88" />


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Add `CODEOWNERS` support to v2.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
