### PR TITLE
fix(net/http: orchestrion): obfuscate query string parameters when auto-instrumenting

### DIFF
--- a/contrib/net/http/orchestrion.client.yml
+++ b/contrib/net/http/orchestrion.client.yml
@@ -87,6 +87,12 @@ aspects:
             //go:linkname __dd_httptrace_GetErrorCodesFromInput gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.GetErrorCodesFromInput
             func __dd_httptrace_GetErrorCodesFromInput(string) func(int) bool
 
+            //go:linkname __dd_httptrace_UrlFromRequest gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.UrlFromRequest
+            func __dd_httptrace_UrlFromRequest(*Request, bool) string
+
+            //go:linkname __dd_internal_BoolEnv gopkg.in/DataDog/dd-trace-go.v1/internal.BoolEnv
+            func __dd_internal_BoolEnv(string, bool) bool
+
             type __dd_tracer_HTTPHeadersCarrier Header
             func (c __dd_tracer_HTTPHeadersCarrier) Set(key, val string) {
               Header(c).Set(key, val)
@@ -96,6 +102,8 @@ aspects:
               // Treat HTTP 4XX as errors
               return statusCode >= 400 && statusCode < 500
             }
+
+            var __dd_queryStringEnabled = __dd_internal_BoolEnv("DD_TRACE_HTTP_CLIENT_TAG_QUERY_STRING", true)
 
             func init() {
               v := os.Getenv("DD_TRACE_HTTP_CLIENT_ERROR_STATUSES")
@@ -130,7 +138,7 @@ aspects:
                 __dd_tracer_SpanType(ext.SpanTypeHTTP),
                 __dd_tracer_ResourceName(resourceName),
                 __dd_tracer_Tag(ext.HTTPMethod, {{ $req }}.Method),
-                __dd_tracer_Tag(ext.HTTPURL, url.String()),
+                __dd_tracer_Tag(ext.HTTPURL, __dd_httptrace_UrlFromRequest({{ $req }}, __dd_queryStringEnabled)),
                 __dd_tracer_Tag(ext.Component, "net/http"),
                 __dd_tracer_Tag(ext.SpanKind, ext.SpanKindClient),
                 __dd_tracer_Tag(ext.NetworkDestinationName, url.Hostname()),

--- a/contrib/net/http/orchestrion.client.yml
+++ b/contrib/net/http/orchestrion.client.yml
@@ -55,6 +55,7 @@ aspects:
             ddtrace: gopkg.in/DataDog/dd-trace-go.v1/ddtrace
             os: os
           links:
+            - gopkg.in/DataDog/dd-trace-go.v1/internal
             - gopkg.in/DataDog/dd-trace-go.v1/internal/appsec
             - gopkg.in/DataDog/dd-trace-go.v1/internal/appsec/emitter/httpsec
             - gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer

--- a/internal/orchestrion/_integration/aws.v2/base.go
+++ b/internal/orchestrion/_integration/aws.v2/base.go
@@ -9,7 +9,6 @@ package awsv2
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/DataDog/dd-trace-go/internal/orchestrion/_integration/internal/containers"
@@ -67,7 +66,7 @@ func (b *base) expectedTraces() trace.Traces {
 					Meta: map[string]string{
 						"http.method":              "POST",
 						"http.status_code":         "200",
-						"http.url":                 fmt.Sprintf("http://localhost:%s/", b.port),
+						"http.url":                 "/",
 						"network.destination.name": "localhost",
 						"component":                "net/http",
 						"span.kind":                "client",


### PR DESCRIPTION
### What does this PR do?

Retrofits #3071 into the orchestrion specification.

### Motivation

This puts automatic instrumentation on par with manual instrumentation.
This is necessary for the upcoming orchestrion system tests to pass.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
