### PR TITLE
ddtrace/tracer: Fix panic on Extract when DD_TRACE_PROPAGATION_EXTRACT_FIRST=true and no trace headers present

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -470,9 +470,9 @@ func (p *propagator) Extract(carrier interface{}) (ddtrace.SpanContext, error) {
 func (p *propagator) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, error) {
 	var ctx spanContext
 	err := reader.ForeachKey(func(k, v string) error {
-		fmt.Println("TEST: key exists")
 		var err error
 		key := strings.ToLower(k)
+		fmt.Println("header key:", key)
 		switch key {
 		case p.cfg.TraceHeader:
 			var lowerTid uint64
@@ -501,6 +501,7 @@ func (p *propagator) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 				ctx.setBaggageItem(strings.TrimPrefix(key, p.cfg.BaggagePrefix), v)
 			}
 		}
+		fmt.Println("default case; header does not match trace header")
 		return nil
 	})
 	if err != nil {
@@ -517,6 +518,7 @@ func (p *propagator) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 		}
 	}
 	if ctx.traceID.Empty() || (ctx.spanID == 0 && ctx.origin != "synthetics") {
+		fmt.Println("returning spancontextnot found")
 		return nil, ErrSpanContextNotFound
 	}
 	return &ctx, nil

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -273,20 +273,22 @@ func (p *chainedPropagator) Inject(spanCtx ddtrace.SpanContext, carrier interfac
 func (p *chainedPropagator) Extract(carrier interface{}) (ddtrace.SpanContext, error) {
 	var ctx ddtrace.SpanContext
 	var links []ddtrace.SpanLink
+
 	for _, v := range p.extractors {
 		firstExtract := (ctx == nil) // ctx stores the most recently extracted ctx across iterations; if it's nil, no extractor has run yet
 		extractedCtx, err := v.Extract(carrier)
+
 		if firstExtract {
-			if err != nil && err != ErrSpanContextNotFound { // We only care if the first extraction returns an error because this breaks distributed tracing
-				return nil, err
+			if err != nil {
+				if p.onlyExtractFirst { // Every error is relevant when we are relying on the first extractor
+					return nil, err
+				}
+				if err != ErrSpanContextNotFound { // We don't care about ErrSpanContextNotFound because we could find a span context in a subsequent extractor
+					return nil, err
+				}
 			}
-			if p.onlyExtractFirst { // Return early if only performing one extraction
-				// if sc, ok := extractedCtx.(*spanContext); ok {
-				// 	return sc, nil
-				// }
-				fmt.Println("TEST: propagator is:", getPropagatorName(v))
-				// return nil, ErrInvalidSpanContext
-				return extractedCtx.(*spanContext), nil
+			if p.onlyExtractFirst {
+				return extractedCtx, nil
 			}
 			ctx = extractedCtx
 		} else { // A local trace context has already been extracted
@@ -473,7 +475,6 @@ func (p *propagator) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 	err := reader.ForeachKey(func(k, v string) error {
 		var err error
 		key := strings.ToLower(k)
-		fmt.Println("header key:", key)
 		switch key {
 		case p.cfg.TraceHeader:
 			var lowerTid uint64
@@ -501,7 +502,6 @@ func (p *propagator) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 			if strings.HasPrefix(key, p.cfg.BaggagePrefix) {
 				ctx.setBaggageItem(strings.TrimPrefix(key, p.cfg.BaggagePrefix), v)
 			}
-			fmt.Println("default case; header does not match trace header")
 		}
 		return nil
 	})
@@ -519,7 +519,6 @@ func (p *propagator) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 		}
 	}
 	if ctx.traceID.Empty() || (ctx.spanID == 0 && ctx.origin != "synthetics") {
-		fmt.Println("returning spancontextnot found")
 		return nil, ErrSpanContextNotFound
 	}
 	return &ctx, nil

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -281,7 +281,11 @@ func (p *chainedPropagator) Extract(carrier interface{}) (ddtrace.SpanContext, e
 				return nil, err
 			}
 			if p.onlyExtractFirst { // Return early if only performing one extraction
-				return extractedCtx.(*spanContext), nil
+				if sc, ok := extractedCtx.(*spanContext); ok {
+					return sc, nil
+				}
+				fmt.Println("TEST: propagator is:", getPropagatorName(v))
+				return nil, ErrInvalidSpanContext
 			}
 			ctx = extractedCtx
 		} else { // A local trace context has already been extracted
@@ -466,6 +470,7 @@ func (p *propagator) Extract(carrier interface{}) (ddtrace.SpanContext, error) {
 func (p *propagator) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, error) {
 	var ctx spanContext
 	err := reader.ForeachKey(func(k, v string) error {
+		fmt.Println("TEST: key exists")
 		var err error
 		key := strings.ToLower(k)
 		switch key {

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -281,11 +281,12 @@ func (p *chainedPropagator) Extract(carrier interface{}) (ddtrace.SpanContext, e
 				return nil, err
 			}
 			if p.onlyExtractFirst { // Return early if only performing one extraction
-				if sc, ok := extractedCtx.(*spanContext); ok {
-					return sc, nil
-				}
+				// if sc, ok := extractedCtx.(*spanContext); ok {
+				// 	return sc, nil
+				// }
 				fmt.Println("TEST: propagator is:", getPropagatorName(v))
 				// return nil, ErrInvalidSpanContext
+				return extractedCtx.(*spanContext), nil
 			}
 			ctx = extractedCtx
 		} else { // A local trace context has already been extracted

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -285,7 +285,7 @@ func (p *chainedPropagator) Extract(carrier interface{}) (ddtrace.SpanContext, e
 					return sc, nil
 				}
 				fmt.Println("TEST: propagator is:", getPropagatorName(v))
-				return nil, ErrInvalidSpanContext
+				// return nil, ErrInvalidSpanContext
 			}
 			ctx = extractedCtx
 		} else { // A local trace context has already been extracted
@@ -500,8 +500,8 @@ func (p *propagator) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 			if strings.HasPrefix(key, p.cfg.BaggagePrefix) {
 				ctx.setBaggageItem(strings.TrimPrefix(key, p.cfg.BaggagePrefix), v)
 			}
+			fmt.Println("default case; header does not match trace header")
 		}
-		fmt.Println("default case; header does not match trace header")
 		return nil
 	})
 	if err != nil {

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -2244,6 +2244,45 @@ func TestOtelPropagator(t *testing.T) {
 	}
 }
 
+// Assert that extraction returns a ErrSpanContextNotFound error when no trace context headers are found
+func TestMissingHeadersExtraction(t *testing.T) {
+	t.Run("single header", func(t *testing.T) {
+		t.Setenv(headerPropagationStyleExtract, "datadog")
+		tracer := newTracer()
+		defer tracer.Stop()
+		ctx, err := tracer.Extract(TextMapCarrier{})
+		assert.Equal(t, ErrSpanContextNotFound, err)
+		assert.Nil(t, ctx)
+	})
+	t.Run("single header - extractFirst", func(t *testing.T) {
+		// Assert that extraction fails gracefully when no trace context headers are found, and DD_TRACE_PROPAGATION_EXTRACT_FIRST=true is configured
+		t.Setenv(headerPropagationStyleExtract, "datadog")
+		t.Setenv("DD_TRACE_PROPAGATION_EXTRACT_FIRST", "true")
+		tracer := newTracer()
+		defer tracer.Stop()
+		ctx, err := tracer.Extract(TextMapCarrier{})
+		assert.Equal(t, ErrSpanContextNotFound, err)
+		assert.Nil(t, ctx)
+	})
+	t.Run("multi header", func(t *testing.T) {
+		t.Setenv(headerPropagationStyleExtract, "datadog,tracecontext")
+		tracer := newTracer()
+		defer tracer.Stop()
+		ctx, err := tracer.Extract(TextMapCarrier{})
+		assert.Equal(t, ErrSpanContextNotFound, err)
+		assert.Nil(t, ctx)
+	})
+	t.Run("multi header - extractFirst", func(t *testing.T) {
+		t.Setenv(headerPropagationStyleExtract, "datadog,tracecontext")
+		t.Setenv("DD_TRACE_PROPAGATION_EXTRACT_FIRST", "true")
+		tracer := newTracer()
+		defer tracer.Stop()
+		ctx, err := tracer.Extract(TextMapCarrier{})
+		assert.Equal(t, ErrSpanContextNotFound, err)
+		assert.Nil(t, ctx)
+	})
+}
+
 func BenchmarkInjectDatadog(b *testing.B) {
 	b.Setenv(headerPropagationStyleInject, "datadog")
 	tracer := newTracer()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Fixes a panic caused by [this line of code](https://github.com/DataDog/dd-trace-go/blob/v1.71.0/ddtrace/tracer/textmap.go#L284): `return extractedCtx.(*spanContext), nil`, when `extractedCtx` is `nil`.

### Motivation
Bug was detected when configuring `DD_TRACE_PROPAGATION_EXTRACT_FIRST=true` and no tracing-related keys are found in carrier. To reproduce this, you can paste the `TestExtractNoHeaders` to the v1.71.0 branch and watch it panic.
Bug was introduced in v1.71.0 as a result of this [PR](https://github.com/DataDog/dd-trace-go/pull/2948).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
