### PR TITLE
fix: use different symbol for orchestrion GLS accessors

### DIFF
--- a/internal/orchestrion/gls.go
+++ b/internal/orchestrion/gls.go
@@ -22,10 +22,10 @@ var (
 // Accessors set by orchestrion in the runtime package. If orchestrion is not enabled, these will be nil as per the default values.
 
 //revive:disable:var-naming
-//go:linkname __dd_orchestrion_gls_get __dd_orchestrion_gls_get
+//go:linkname __dd_orchestrion_gls_get __dd_orchestrion_gls_get.V2
 var __dd_orchestrion_gls_get func() any
 
-//go:linkname __dd_orchestrion_gls_set __dd_orchestrion_gls_set
+//go:linkname __dd_orchestrion_gls_set __dd_orchestrion_gls_set.V2
 var __dd_orchestrion_gls_set func(any)
 
 //revive:enable:var-naming


### PR DESCRIPTION
Current GLS accessors for V1 and V2 conflict because they use the same slot to store different value types. Renaming those accessors means orchestrion will stop populating the accessors for V2, which will address the crasher reported at https://github.com/DataDog/orchestrion/issues/520

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
