### PR TITLE
(fix) internal/civisibility: change http default values and reduce test time.

### DIFF
--- a/internal/civisibility/utils/net/client.go
+++ b/internal/civisibility/utils/net/client.go
@@ -29,9 +29,9 @@ import (
 
 const (
 	// DefaultMaxRetries is the default number of retries for a request.
-	DefaultMaxRetries int = 5
+	DefaultMaxRetries int = 3
 	// DefaultBackoff is the default backoff time for a request.
-	DefaultBackoff time.Duration = 150 * time.Millisecond
+	DefaultBackoff time.Duration = 100 * time.Millisecond
 )
 
 type (

--- a/internal/civisibility/utils/net/http.go
+++ b/internal/civisibility/utils/net/http.go
@@ -358,7 +358,7 @@ func decompressData(data []byte) ([]byte, error) {
 
 // exponentialBackoff performs an exponential backoff with retries.
 func exponentialBackoff(retryCount int, initialDelay time.Duration) {
-	maxDelay := 30 * time.Second
+	maxDelay := 10 * time.Second
 	delay := initialDelay * (1 << uint(retryCount)) // Exponential backoff
 	if delay > maxDelay {
 		delay = maxDelay

--- a/internal/civisibility/utils/net/http_test.go
+++ b/internal/civisibility/utils/net/http_test.go
@@ -786,9 +786,9 @@ func TestSendRequestWithInvalidRetryAfterHeader(t *testing.T) {
 
 func TestExponentialBackoffWithMaxDelay(t *testing.T) {
 	start := time.Now()
-	exponentialBackoff(10, 1*time.Second) // Should be limited to maxDelay (30s)
+	exponentialBackoff(10, 1*time.Second) // Should be limited to maxDelay (10s)
 	duration := time.Since(start)
-	assert.LessOrEqual(t, duration, 31*time.Second)
+	assert.LessOrEqual(t, duration, 11*time.Second)
 }
 
 func TestSendRequestWithContextTimeout(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR changes the defaults of the CI Visibility http clients, Currently in the worst case scenario the client were blocking the test process up to 60 seconds. This PR reduces this time by changing the constant default values. As a direct impact, this change reduces the time for testing the package.

**V2**: https://github.com/DataDog/dd-trace-go/pull/3135

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The current defaults are too large...

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [x] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
