### PR TITLE
ddtrace/tracer: Fix panic on Extract when DD_TRACE_PROPAGATION_EXTRACT_FIRST=true and no trace headers present [1.71 backport]

### DIFF
--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -2244,6 +2244,49 @@ func TestOtelPropagator(t *testing.T) {
 	}
 }
 
+// Assert that extraction returns a ErrSpanContextNotFound error when no trace context headers are found
+func TestExtractNoHeaders(t *testing.T) {
+	tests := []struct {
+		name         string
+		extractEnv   string
+		extractFirst bool
+	}{
+		{
+			name:         "single header",
+			extractEnv:   "datadog",
+			extractFirst: false,
+		},
+		{
+			name:         "single header - extractFirst",
+			extractEnv:   "datadog",
+			extractFirst: true,
+		},
+		{
+			name:         "multi header",
+			extractEnv:   "datadog,tracecontext",
+			extractFirst: false,
+		},
+		{
+			name:         "multi header - extractFirst",
+			extractEnv:   "datadog,tracecontext",
+			extractFirst: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(headerPropagationStyleExtract, tt.extractEnv)
+			if tt.extractFirst {
+				t.Setenv("DD_TRACE_PROPAGATION_EXTRACT_FIRST", "true")
+			}
+			tracer := newTracer()
+			defer tracer.Stop()
+			ctx, err := tracer.Extract(TextMapCarrier{})
+			assert.Equal(t, ErrSpanContextNotFound, err)
+			assert.Nil(t, ctx)
+		})
+	}
+}
+
 func BenchmarkInjectDatadog(b *testing.B) {
 	b.Setenv(headerPropagationStyleInject, "datadog")
 	tracer := newTracer()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Cherry-picks commit 2ee7731c7ad9833b771f2b338d640c6c472215de from PR #3128 onto release branch release-v1.71.x

### Motivation
dd-trace-go v1.71.0 crashes on trace context extraction when `DD_TRACE_PROPAGATION_EXTRACT_FIRST` set to `true` and no tracing-related keys are found in carrier, with no workaround other than disabling the feature. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
