### PR TITLE
tracer/stats: Only get CI tags when CI Visibility is enabled [1.71 backport]

### DIFF
--- a/ddtrace/tracer/stats.go
+++ b/ddtrace/tracer/stats.go
@@ -70,12 +70,17 @@ func newConcentrator(c *config, bucketSize int64, statsdClient internal.StatsdCl
 		env = "unknown-env"
 		log.Debug("No DD Env found, normally the agent should have one")
 	}
+	gitCommitSha := ""
+	if c.ciVisibilityEnabled {
+		// We only have this data if we're in CI Visibility
+		gitCommitSha = utils.GetCITags()[constants.GitCommitSHA]
+	}
 	aggKey := stats.PayloadAggregationKey{
 		Hostname:     c.hostname,
 		Env:          env,
 		Version:      c.version,
 		ContainerID:  "", // This intentionally left empty as the Agent will attach the container ID only in certain situations.
-		GitCommitSha: utils.GetCITags()[constants.GitCommitSHA],
+		GitCommitSha: gitCommitSha,
 		ImageTag:     "",
 	}
 	spanConcentrator := stats.NewSpanConcentrator(sCfg, time.Now())

--- a/ddtrace/tracer/stats_test.go
+++ b/ddtrace/tracer/stats_test.go
@@ -105,7 +105,7 @@ func TestConcentrator(t *testing.T) {
 		t.Run("ciGitSha", func(t *testing.T) {
 			utils.AddCITags(constants.GitCommitSHA, "DEADBEEF")
 			transport := newDummyTransport()
-			c := newConcentrator(&config{transport: transport, env: "someEnv"}, (10 * time.Second).Nanoseconds(), &statsd.NoOpClientDirect{})
+			c := newConcentrator(&config{transport: transport, env: "someEnv", ciVisibilityEnabled: true}, (10 * time.Second).Nanoseconds(), &statsd.NoOpClientDirect{})
 			assert.Len(t, transport.Stats(), 0)
 			ss1, ok := c.newTracerStatSpan(&s1, nil)
 			assert.True(t, ok)

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,10 @@ module gopkg.in/DataDog/dd-trace-go.v1
 
 go 1.22.0
 
+// This replace is a temporary workaround to deal with a breaking change here that is used by the datadog-agent
+// It can safely be removed once this PR is released: https://github.com/DataDog/datadog-agent/pull/33370
+replace github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes => github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.20.0
+
 require (
 	cloud.google.com/go/pubsub v1.36.1
 	github.com/99designs/gqlgen v0.17.36


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Cherry-picks ec054a5cbf955e0f018ff9d2fb41a63c645558fb from PR #3129 onto release branch release-v1.71.x

### Motivation
CI tags 
We were fetching and initializing CI tags even when CI visibility was disabled, leading to unnecessary subprocesses that impacted performance and could trigger SIGCHLD issues. In this PR, we've ensured that tags are only attached when CI visibility is enabled

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
