### PR TITLE
fix: manual publish of Service Extension image

### DIFF
--- a/.github/workflows/service-extensions-publish.yml
+++ b/.github/workflows/service-extensions-publish.yml
@@ -7,12 +7,11 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: 'Docker image tag to use for the package'
-        required: true
-        default: 'dev'
+        description: 'Docker image tag to use for the package (default to selected branch name)'
+        required: false
       commit_sha:
-        description: 'Commit SHA to checkout'
-        required: true
+        description: 'Commit SHA to checkout (default to latest commit on selected branch)'
+        required: false
       set_as_latest:
         description: 'Set the tag as latest'
         required: false
@@ -23,9 +22,8 @@ permissions:
   packages: write
 
 env:
-  TAG_NAME: ${{ github.ref_name || github.event.inputs.tag_name }}
-  REF_NAME: ${{ github.ref || github.event.inputs.commit_sha }}
-  COMMIT_SHA: ${{ github.sha || github.event.inputs.commit_sha }}
+  TAG_NAME: ${{ github.event.inputs.tag_name || github.ref_name }}
+  COMMIT_SHA: ${{ github.event.inputs.commit_sha || github.sha }}
   PUSH_LATEST: ${{ github.event.inputs.set_as_latest || 'true' }}
   REGISTRY_IMAGE: ghcr.io/datadog/dd-trace-go/service-extensions-callout
 
@@ -45,7 +43,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ env.REF_NAME }}
+          ref: ${{ env.COMMIT_SHA }}
 
       - name: Install Docker (only arm64)
         if: matrix.platform == 'linux/arm64'
@@ -119,9 +117,13 @@ jobs:
         id: tags
         run: |
             tagname=${TAG_NAME//\//-} # remove slashes from tag name
-            echo "tags=-t ghcr.io/datadog/dd-trace-go/service-extensions-callout:${tagname} \
-            -t ghcr.io/datadog/dd-trace-go/service-extensions-callout:${{ env.COMMIT_SHA }} \
-            ${{ env.PUSH_LATEST == 'true' && '-t ghcr.io/datadog/dd-trace-go/service-extensions-callout:latest' }}" >> $GITHUB_OUTPUT
+            tags="tags=-t ghcr.io/datadog/dd-trace-go/service-extensions-callout:${tagname} \
+            -t ghcr.io/datadog/dd-trace-go/service-extensions-callout:${{ env.COMMIT_SHA }}"
+            if [ "${PUSH_LATEST}" == "true" ]; then
+              tags="$tags -t ghcr.io/datadog/dd-trace-go/service-extensions-callout:latest"
+            fi
+          
+            echo $tags >> $GITHUB_OUTPUT
 
       - name: Create manifest list and push
         working-directory: /tmp/digests


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR fixes some issues when publishing manually images of the Service Extension.

- The commit sha selected wasn't properly applied (defaulting to the selected branch everytime)
- The docker push failed when the `set_as_latest` was false? The string "false" was evaluated into the command line thus making the process failing

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Publish release/dev/test image manually by triggering the workflow.

### Tests

This was tested locally by running the workflow with the github CLI.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
