### PR TITLE
(fix) internal/civisibility: add support for detached heads in civisibility backend transactions

### DIFF
--- a/internal/civisibility/utils/net/client.go
+++ b/internal/civisibility/utils/net/client.go
@@ -221,6 +221,11 @@ func NewClientWithServiceNameAndSubdomain(serviceName, subdomain string) Client 
 		})
 	}
 
+	bName := ciTags[constants.GitBranch]
+	if bName == "" {
+		bName = "auto:git-detached-head"
+	}
+
 	return &client{
 		id:               id,
 		agentless:        agentlessEnabled,
@@ -230,7 +235,7 @@ func NewClientWithServiceNameAndSubdomain(serviceName, subdomain string) Client 
 		workingDirectory: ciTags[constants.CIWorkspacePath],
 		repositoryURL:    ciTags[constants.GitRepositoryURL],
 		commitSha:        ciTags[constants.GitCommitSHA],
-		branchName:       ciTags[constants.GitBranch],
+		branchName:       bName,
 		testConfigurations: testConfigurations{
 			OsPlatform:     ciTags[constants.OSPlatform],
 			OsVersion:      ciTags[constants.OSVersion],


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR fixes backend transactions when CI Visibility is running on a git detached head

V1: [(fix) internal/civisibility: add support for detached heads in civisibility backend transactions](https://github.com/DataDog/dd-trace-go/pull/3157)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Currently no ancillary feature can be enabled on detached heads.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
