### PR TITLE
internal/telemetry: fix flake in TestTelemetryEnabled

### DIFF
--- a/internal/telemetry/telemetrytest/telemetrytest.go
+++ b/internal/telemetry/telemetrytest/telemetrytest.go
@@ -73,6 +73,9 @@ func (c *MockClient) Record(ns telemetry.Namespace, _ telemetry.MetricKind, name
 	c.On("Gauge", ns, name, val, tags, common).Return()
 	c.On("Record", ns, name, val, tags, common).Return()
 	_ = c.Called(ns, name, val, tags, common)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	// record the val for tests that assert based on the value
 	if _, ok := c.Metrics[ns]; !ok {
 		c.Metrics[ns] = map[string]float64{}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Locks the `mockClient` before updating the values in `Metrics`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

There was a flake in which `TestTelemetryEnabled/tracer_start` did not find the correct init time due to a data race, causing random failures that impacts the health of the tracer.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
