### PR TITLE
fix: bump version of golangci-lint

### DIFF
--- a/.github/workflows/main-branch-tests.yml
+++ b/.github/workflows/main-branch-tests.yml
@@ -9,6 +9,7 @@ on:
         type: string
   push:
     branches:
+      - hannahkm/bump-golangcilint
       - main
       - release-v*
     tags-ignore:

--- a/.github/workflows/main-branch-tests.yml
+++ b/.github/workflows/main-branch-tests.yml
@@ -9,7 +9,6 @@ on:
         type: string
   push:
     branches:
-      - hannahkm/bump-golangcilint
       - main
       - release-v*
     tags-ignore:

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -53,8 +53,8 @@ jobs:
         with:
           golangci_lint_flags: "--timeout 10m" # We are hitting timeout when there is no cache
           go_version: ${{ inputs.go-version }}
-          golangci_lint_version: v1.59.1
-          fail_on_error: true
+          golangci_lint_version: v1.63.4
+          fail_level: error
           reporter: github-pr-review
 
       - name: golangci-lint (internal/orchestrion/_integration)
@@ -62,8 +62,8 @@ jobs:
         with:
           golangci_lint_flags: "--timeout 10m" # We are hitting timeout when there is no cache
           go_version: ${{ inputs.go-version }}
-          golangci_lint_version: v1.59.1
-          fail_on_error: true
+          golangci_lint_version: v1.63.4
+          fail_level: error
           reporter: github-pr-review
           workdir: internal/orchestrion/_integration
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Bumps the version of `golangci-lint` being used in CI to the latest version (`v1.63.4`). We were previously at `v1.59.1`. Also replaces a deprecated function (`fail_on_error`) with its up to date version (`fail_level`).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

Linting rules were failing in CI for Go v1.23. The first version of `golangci-lint` that supports v1.23 is `v1.60` ([source](https://github.com/golangci/golangci-lint/issues/4837))

Tested by running `Pull Request Tests` and `Main Branch and Release Tests` pipelines against this branch. `Pull Request Tests` only runs on Go v1.22 (min support version for `dd-trace-go`), while `Main Branch and Release Tests` lints both Go v1.22 and v1.23. `Main Branch and Release Tests` now passes lint:

<img width="293" alt="image" src="https://github.com/user-attachments/assets/ce787d2d-f9bf-4c02-9bbb-99ff78fe04ee" />


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
