### PR TITLE
contrib/miekg/dns: use random port for test

### DIFF
--- a/contrib/miekg/dns/dns_test.go
+++ b/contrib/miekg/dns/dns_test.go
@@ -191,7 +191,7 @@ func assertClientSpan(t *testing.T, s mocktracer.Span) {
 }
 
 func getAddr(t *testing.T) net.Addr {
-	li, err := net.Listen("tcp4", "127.0.0.1:2020")
+	li, err := net.Listen("tcp4", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/contrib/miekg/dns/dns_test.go
+++ b/contrib/miekg/dns/dns_test.go
@@ -8,6 +8,7 @@ package dns_test
 import (
 	"context"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -28,44 +29,46 @@ func (th *testHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	w.WriteMsg(m)
 }
 
-func startServer(t *testing.T, traced bool) (*dns.Server, func()) {
+func startServer(t *testing.T, traced bool) (*dns.Server, string) {
 	var h dns.Handler = &testHandler{}
 	if traced {
 		h = dnstrace.WrapHandler(h)
 	}
-	addr := getAddr(t).String()
-	server := &dns.Server{
-		Addr:    addr,
-		Net:     "udp",
-		Handler: h,
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := &dns.Server{
+		PacketConn:   pc,
+		ReadTimeout:  time.Hour,
+		WriteTimeout: time.Hour,
+		Handler:      h,
 	}
 
-	// start the server
+	waitLock := sync.Mutex{}
+	waitLock.Lock()
+	srv.NotifyStartedFunc = waitLock.Unlock
+
 	go func() {
-		err := server.ListenAndServe()
-		if err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, srv.ActivateAndServe())
 	}()
-	waitTillUDPReady(addr)
-	stopServer := func() {
-		err := server.Shutdown()
-		assert.NoError(t, err)
-	}
-	return server, stopServer
+	t.Cleanup(func() {
+		require.NoError(t, srv.Shutdown())
+	})
+
+	waitLock.Lock()
+	return srv, pc.LocalAddr().String()
 }
 
 func TestExchange(t *testing.T) {
-	server, stopServer := startServer(t, false)
-	defer stopServer()
+	_, addr := startServer(t, false)
 
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
 	m := newMessage()
 
-	_, err := dnstrace.Exchange(m, server.Addr)
-	assert.NoError(t, err)
+	_, err := dnstrace.Exchange(m, addr)
+	require.NoError(t, err)
 
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
@@ -73,16 +76,15 @@ func TestExchange(t *testing.T) {
 }
 
 func TestExchangeContext(t *testing.T) {
-	server, stopServer := startServer(t, false)
-	defer stopServer()
+	_, addr := startServer(t, false)
 
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
 	m := newMessage()
 
-	_, err := dnstrace.ExchangeContext(context.Background(), m, server.Addr)
-	assert.NoError(t, err)
+	_, err := dnstrace.ExchangeContext(context.Background(), m, addr)
+	require.NoError(t, err)
 
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
@@ -90,19 +92,18 @@ func TestExchangeContext(t *testing.T) {
 }
 
 func TestExchangeConn(t *testing.T) {
-	server, stopServer := startServer(t, false)
-	defer stopServer()
+	_, addr := startServer(t, false)
 
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
 	m := newMessage()
 
-	conn, err := net.Dial("udp", server.Addr)
+	conn, err := net.Dial("udp", addr)
 	require.NoError(t, err)
 
 	_, err = dnstrace.ExchangeConn(conn, m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
@@ -110,18 +111,16 @@ func TestExchangeConn(t *testing.T) {
 }
 
 func TestClient_Exchange(t *testing.T) {
-	server, stopServer := startServer(t, false)
-	defer stopServer()
+	_, addr := startServer(t, false)
 
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
 	m := newMessage()
-
 	client := newTracedClient()
 
-	_, _, err := client.Exchange(m, server.Addr)
-	assert.NoError(t, err)
+	_, _, err := client.Exchange(m, addr)
+	require.NoError(t, err)
 
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
@@ -129,18 +128,16 @@ func TestClient_Exchange(t *testing.T) {
 }
 
 func TestClient_ExchangeContext(t *testing.T) {
-	server, stopServer := startServer(t, false)
-	defer stopServer()
+	_, addr := startServer(t, false)
 
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
 	m := newMessage()
-
 	client := newTracedClient()
 
-	_, _, err := client.ExchangeContext(context.Background(), m, server.Addr)
-	assert.NoError(t, err)
+	_, _, err := client.ExchangeContext(context.Background(), m, addr)
+	require.NoError(t, err)
 
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
@@ -148,16 +145,18 @@ func TestClient_ExchangeContext(t *testing.T) {
 }
 
 func TestWrapHandler(t *testing.T) {
-	server, stopServer := startServer(t, true)
+	_, addr := startServer(t, true)
 
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
 	m := newMessage()
-	_, err := dns.Exchange(m, server.Addr)
-	assert.NoError(t, err)
+	client := newClient()
 
-	stopServer() // Shutdown server so span is closed after DNS request
+	_, _, err := client.Exchange(m, addr)
+	require.NoError(t, err)
+
+	waitForSpans(mt, 1)
 
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
@@ -177,8 +176,12 @@ func newMessage() *dns.Msg {
 	return m
 }
 
+func newClient() *dns.Client {
+	return &dns.Client{Net: "udp"}
+}
+
 func newTracedClient() *dnstrace.Client {
-	return &dnstrace.Client{Client: &dns.Client{Net: "udp"}}
+	return &dnstrace.Client{Client: newClient()}
 }
 
 func assertClientSpan(t *testing.T, s mocktracer.Span) {
@@ -190,24 +193,15 @@ func assertClientSpan(t *testing.T, s mocktracer.Span) {
 	assert.Equal(t, ext.SpanKindClient, s.Tag(ext.SpanKind))
 }
 
-func getAddr(t *testing.T) net.Addr {
-	li, err := net.Listen("tcp4", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr := li.Addr()
-	li.Close()
-	return addr
-}
+func waitForSpans(mt mocktracer.Tracer, sz int) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
 
-func waitTillUDPReady(addr string) {
-	deadline := time.Now().Add(time.Second * 10)
-	for time.Now().Before(deadline) {
-		m := new(dns.Msg)
-		m.SetQuestion("miek.nl.", dns.TypeMX)
-		_, err := dns.Exchange(m, addr)
-		if err == nil {
-			break
+	for len(mt.FinishedSpans()) < sz {
+		select {
+		case <-ctx.Done():
+			return
+		default:
 		}
 		time.Sleep(time.Millisecond * 100)
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Attempt to fix flaky test by using a random port instead of `2020`.

```
Failed

=== RUN   TestExchangeContext
    dns_test.go:47: listen udp 127.0.0.1:2020: bind: address already in use
    dns_test.go:85: 
        	Error Trace:	/home/runner/work/dd-trace-go/dd-trace-go/contrib/miekg/dns/dns_test.go:85
        	Error:      	Received unexpected error:
        	            	read udp 127.0.0.1:45449->127.0.0.1:2020: read: connection refused
        	Test:       	TestExchangeContext
    dns_test.go:53: 
        	Error Trace:	/home/runner/work/dd-trace-go/dd-trace-go/contrib/miekg/dns/dns_test.go:53
        	            				/home/runner/work/dd-trace-go/dd-trace-go/contrib/miekg/dns/dns_test.go:90
        	Error:      	Received unexpected error:
        	            	dns: server not started
        	Test:       	TestExchangeContext
--- FAIL: TestExchangeContext (10.05s)
```

In addition, it changes the way the local server is started. Took inspiration on how it is done in the [original library](https://github.com/miekg/dns/blob/master/server_test.go#L114-L121).

Ran the tests in this packages a few times with `count=1000` and observed no flakes so far.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
