### PR TITLE
(fix) internal/civisibility/coverage: [APMLP-379] fix TestCollectCoverageAfterTestExecution flaky test - v2

### DIFF
--- a/internal/civisibility/integrations/gotesting/coverage/test_coverage.go
+++ b/internal/civisibility/integrations/gotesting/coverage/test_coverage.go
@@ -215,11 +215,8 @@ func (t *testCoverage) CollectCoverageAfterTestExecution() {
 		return
 	}
 
-	t.postCoverageFilename = filepath.Join(temporaryDir, fmt.Sprintf("%d-%d-%d-post.out", t.moduleID, t.suiteID, t.testID))
-	_, err := tearDown(t.postCoverageFilename, "")
-	if err != nil {
-		log.Debug("civisibility.coverage: error getting coverage file: %v", err)
-		telemetry.CodeCoverageErrors()
+	if t.getCoverageData() != nil {
+		return
 	}
 
 	var pChannel = make(chan struct{})
@@ -230,6 +227,18 @@ func (t *testCoverage) CollectCoverageAfterTestExecution() {
 		t.processCoverageData()
 		pChannel <- struct{}{}
 	}()
+}
+
+// getCoverageData gets the coverage data.
+func (t *testCoverage) getCoverageData() error {
+	t.postCoverageFilename = filepath.Join(temporaryDir, fmt.Sprintf("%d-%d-%d-post.out", t.moduleID, t.suiteID, t.testID))
+	_, err := tearDown(t.postCoverageFilename, "")
+	if err != nil {
+		log.Debug("civisibility.coverage: error getting coverage file: %v", err)
+		telemetry.CodeCoverageErrors()
+	}
+
+	return err
 }
 
 // processCoverageData processes the coverage data.

--- a/internal/civisibility/integrations/gotesting/coverage/test_coverage_test.go
+++ b/internal/civisibility/integrations/gotesting/coverage/test_coverage_test.go
@@ -306,7 +306,7 @@ func TestCollectCoverageAfterTestExecution(t *testing.T) {
 	f.WriteString("mode: count\n")
 	f.Close()
 
-	tc.CollectCoverageAfterTestExecution()
+	tc.getCoverageData()
 
 	if tc.postCoverageFilename == "" {
 		t.Error("postCoverageFilename is empty after CollectCoverageAfterTestExecution")

--- a/internal/civisibility/integrations/gotesting/coverage/test_coverage_test.go
+++ b/internal/civisibility/integrations/gotesting/coverage/test_coverage_test.go
@@ -306,7 +306,10 @@ func TestCollectCoverageAfterTestExecution(t *testing.T) {
 	f.WriteString("mode: count\n")
 	f.Close()
 
-	tc.getCoverageData()
+	err = tc.getCoverageData()
+	if err != nil {
+		t.Errorf("getCoverageData returned error: %v", err)
+	}
 
 	if tc.postCoverageFilename == "" {
 		t.Error("postCoverageFilename is empty after CollectCoverageAfterTestExecution")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR fixes a race condition in TestCollectCoverageAfterTestExecution due removing the file inside a goroutine

**V1**: https://github.com/DataDog/dd-trace-go/pull/3169

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The test was a flaky test

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
