### PR TITLE
ddtrace/tracer: fix flake in TestTracerMetrics

### DIFF
--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -94,7 +94,7 @@ func TestTracerMetrics(t *testing.T) {
 
 	tracer.StartSpan("operation").Finish()
 	flush(1)
-	tg.Wait(assert, 6, 500*time.Millisecond)
+	tg.Wait(assert, 5, 500*time.Millisecond)
 
 	calls := tg.CallsByName()
 	counts := tg.Counts()

--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -94,7 +94,7 @@ func TestTracerMetrics(t *testing.T) {
 
 	tracer.StartSpan("operation").Finish()
 	flush(1)
-	tg.Wait(assert, 5, 100*time.Millisecond)
+	tg.Wait(assert, 6, 500*time.Millisecond)
 
 	calls := tg.CallsByName()
 	counts := tg.Counts()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Increases the wait time for reporting metrics in `TestTracerMetrics` from `100` milliseconds to `500` milliseconds. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

The test was flaking, leading to intermittent failures on Windows. The issue was caused because the `tg.Wait()` function was not waiting long enough for metrics to be reported. Running the test `5000` times on both Windows and Mac succeeded.

The `Wait()` function returns either when the time runs out or when `n` metrics have been reported. When running tests on MacOS, which was previously succeeding, there should be no change in runtime. On Windows, we might see a slight increase in time taken to run the test, as it was previously taking more than `100` milliseconds to fetch all expected metrics. This change does not impact anything outside of testing code.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
