### PR TITLE
contrib/99designs/gqlgen: fix introspection query detection by checking Operation.Name

### DIFF
--- a/contrib/99designs/gqlgen/tracer.go
+++ b/contrib/99designs/gqlgen/tracer.go
@@ -144,7 +144,7 @@ func (t *gqlTracer) InterceptOperation(ctx context.Context, next graphql.Operati
 
 func (t *gqlTracer) InterceptField(ctx context.Context, next graphql.Resolver) (res any, err error) {
 	opCtx := graphql.GetOperationContext(ctx)
-	if t.cfg.withoutTraceIntrospectionQuery && opCtx.OperationName == "IntrospectionQuery" {
+	if t.cfg.withoutTraceIntrospectionQuery && isIntrospectionQuery(opCtx) {
 		res, err = next(ctx)
 		return
 	}
@@ -242,6 +242,13 @@ func serverSpanName(octx *graphql.OperationContext) string {
 		nameV0 = fmt.Sprintf("%s.%s", ext.SpanTypeGraphQL, octx.Operation.Operation)
 	}
 	return namingschema.OpNameOverrideV0(namingschema.GraphqlServer, nameV0)
+}
+
+func isIntrospectionQuery(octx *graphql.OperationContext) bool {
+	if octx != nil && octx.Operation != nil {
+		return octx.OperationName == "IntrospectionQuery" || octx.Operation.Name == "IntrospectionQuery"
+	}
+	return false
 }
 
 // Ensure all of these interfaces are implemented.

--- a/contrib/99designs/gqlgen/tracer_test.go
+++ b/contrib/99designs/gqlgen/tracer_test.go
@@ -110,22 +110,30 @@ func TestOptions(t *testing.T) {
 
 	// WithoutTraceIntrospectionQuery tested here since we are specifically checking against an IntrosepctionQuery operation.
 	query = `query IntrospectionQuery { __schema { queryType { name } } }`
+	testFunc := func(assert *assert.Assertions, spans []mocktracer.Span) {
+		var hasFieldSpan bool
+		for _, span := range spans {
+			if span.OperationName() == fieldOp {
+				hasFieldSpan = true
+				break
+			}
+		}
+		assert.Equal(false, hasFieldSpan)
+	}
 	for name, tt := range map[string]struct {
 		tracerOpts []Option
+		clientOpts []client.Option
 		test       func(assert *assert.Assertions, spans []mocktracer.Span)
 	}{
-		"WithoutTraceIntrospectionQuery": {
+		"WithoutTraceIntrospectionQuery with OperationName": {
 			tracerOpts: []Option{WithoutTraceIntrospectionQuery()},
-			test: func(assert *assert.Assertions, spans []mocktracer.Span) {
-				var hasFieldSpan bool
-				for _, span := range spans {
-					if span.OperationName() == fieldOp {
-						hasFieldSpan = true
-						break
-					}
-				}
-				assert.Equal(false, hasFieldSpan)
-			},
+			clientOpts: []client.Option{client.Operation("IntrospectionQuery")},
+			test:       testFunc,
+		},
+		"WithoutTraceIntrospectionQuery without OperationName": {
+			tracerOpts: []Option{WithoutTraceIntrospectionQuery()},
+			clientOpts: []client.Option{},
+			test:       testFunc,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -133,7 +141,7 @@ func TestOptions(t *testing.T) {
 			mt := mocktracer.Start()
 			defer mt.Stop()
 			c := newTestClient(t, testserver.New(), NewTracer(tt.tracerOpts...))
-			c.MustPost(query, &testServerResponse{}, client.Operation("IntrospectionQuery"))
+			c.MustPost(query, &testServerResponse{}, tt.clientOpts...)
 			tt.test(assert, mt.FinishedSpans())
 		})
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.
-->
### What does this PR do?
contrib/99designs/gqlgen: fix introspection query detection by checking Operation.Name
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
InterceptField() relied on OperationName to identify introspection queries. This was insufficient as valid introspection queries can have an unset OperationName while Operation.Name is set to IntrospectionQuery.

Could Fix #3085
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
