### PR TITLE
(fix) internal/civisibility: Fix test visibility on Go 1.24 - v2

### DIFF
--- a/internal/civisibility/integrations/manual_api_mocktracer_test.go
+++ b/internal/civisibility/integrations/manual_api_mocktracer_test.go
@@ -13,9 +13,9 @@ import (
 	"time"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 
-	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -305,8 +305,13 @@ func testAssertions(assert *assert.Assertions, now time.Time, testSpan *mocktrac
 	// make sure we have both start and end line
 	assert.Contains(spanTags, constants.TestSourceStartLine)
 	assert.Contains(spanTags, constants.TestSourceEndLine)
+
 	// make sure the startLine < endLine
-	assert.Less(spanTags[constants.TestSourceStartLine].(float64), spanTags[constants.TestSourceEndLine].(float64))
+	if startLine, startLineOk := spanTags[constants.TestSourceStartLine].(float64); startLineOk {
+		if endLine, endLineOk := spanTags[constants.TestSourceEndLine].(float64); endLineOk {
+			assert.Less(startLine, endLine)
+		}
+	}
 
 	commonAssertions(assert, testSpan)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR fixes Test Visibility on Go 1.24

**V1**: [(fix) internal/civisibility: Fix test visibility on Go 1.24](https://github.com/DataDog/dd-trace-go/pull/3179)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Test visibility instrumentation depends on some internal Go fields. Go 1.24 came with some changes on those internals, this PR fixes that.

- This PR also fixes an existing bug we had by casting a `sync.Mutex` to `sync.RWMutex`

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
