### PR TITLE
internal/orchestrion/_integration: pull container images before running tests

### DIFF
--- a/.github/workflows/orchestrion.yml
+++ b/.github/workflows/orchestrion.yml
@@ -161,6 +161,29 @@ jobs:
         run: go mod tidy
         working-directory: ${{ github.workspace }}/dd-trace-go/internal/orchestrion/_integration
 
+      # Pull docker images ahead of time so the pulls of large images don't have to fit within the
+      # test timeout.
+      - name: Pull container images
+        run: |-
+          # AWS DynamoDB Local is used to have a pretend AWS API endpoint
+          docker pull amazon/dynamodb-local:latest
+
+          # ElasticSearch images
+          docker pull docker.elastic.co/elasticsearch/elasticsearch:6.8.23
+          docker pull docker.elastic.co/elasticsearch/elasticsearch:7.17.24
+          docker pull docker.elastic.co/elasticsearch/elasticsearch:8.15.3
+
+          # Kafka service
+          docker pull confluentinc/confluent-local:7.5.0
+
+          # PostgreSQL service
+          docker pull docker.io/postgres:16-alpine
+
+          # Redis service
+          docker pull redis:7-alpine
+
+          # Vault service
+          docker pull vault:1.7.3
       # Finally, we run the test suite!
       - name: Run Tests
         shell: bash

--- a/.github/workflows/orchestrion.yml
+++ b/.github/workflows/orchestrion.yml
@@ -164,6 +164,8 @@ jobs:
       # Pull docker images ahead of time so the pulls of large images don't have to fit within the
       # test timeout.
       - name: Pull container images
+        # Docker is only supported on Linux runners at the moment
+        if: runner.os == 'Linux'
         run: |-
           # AWS DynamoDB Local is used to have a pretend AWS API endpoint
           docker pull amazon/dynamodb-local:latest

--- a/internal/orchestrion/_integration/go-elasticsearch/v6.go
+++ b/internal/orchestrion/_integration/go-elasticsearch/v6.go
@@ -30,6 +30,7 @@ func (tc *TestCaseV6) Setup(ctx context.Context, t *testing.T) {
 	} else if runtime.GOOS == "darwin" && runtime.GOARCH != "amd64" {
 		t.Skip("Skipping test as the official elasticsearch v6 docker image cannot run under rosetta")
 	}
+	// Change the docker pull stage in .github/workflows/orchestrion.yml if you update this
 	tc.base.Setup(ctx, t, "docker.elastic.co/elasticsearch/elasticsearch:6.8.23", func(addr string, _ []byte) (esClient, error) {
 		return elasticsearch.NewClient(elasticsearch.Config{
 			Addresses: []string{addr},

--- a/internal/orchestrion/_integration/go-elasticsearch/v7.go
+++ b/internal/orchestrion/_integration/go-elasticsearch/v7.go
@@ -22,6 +22,7 @@ type TestCaseV7 struct {
 }
 
 func (tc *TestCaseV7) Setup(ctx context.Context, t *testing.T) {
+	// Change the docker pull stage in .github/workflows/orchestrion.yml if you update this
 	tc.base.Setup(ctx, t, "docker.elastic.co/elasticsearch/elasticsearch:7.17.24", func(addr string, _ []byte) (esClient, error) {
 		return elasticsearch.NewClient(elasticsearch.Config{
 			Addresses: []string{addr},

--- a/internal/orchestrion/_integration/go-elasticsearch/v8.go
+++ b/internal/orchestrion/_integration/go-elasticsearch/v8.go
@@ -25,6 +25,7 @@ type TestCaseV8 struct {
 }
 
 func (tc *TestCaseV8) Setup(ctx context.Context, t *testing.T) {
+	// Change the docker pull stage in .github/workflows/orchestrion.yml if you update this
 	tc.base.Setup(ctx, t, "docker.elastic.co/elasticsearch/elasticsearch:8.15.3", func(addr string, caCert []byte) (esClient, error) {
 		// from v8, there's a certificate configured by default.
 		// we cannot configure directly in the elasticsearch.Config type as it makes a type assertion on the underlying

--- a/internal/orchestrion/_integration/internal/containers/aws-dynamodb.go
+++ b/internal/orchestrion/_integration/internal/containers/aws-dynamodb.go
@@ -23,7 +23,7 @@ func StartDynamoDBTestContainer(t testing.TB) (testcontainers.Container, string,
 	exposedPort := "8000/tcp"
 	req := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "amazon/dynamodb-local:latest",
+			Image:        "amazon/dynamodb-local:latest", // Change the docker pull stage in .github/workflows/orchestrion.yml if you update this
 			ExposedPorts: []string{exposedPort},
 			WaitingFor:   wait.ForHTTP("").WithStatusCodeMatcher(func(int) bool { return true }),
 			WorkingDir:   "/home/dynamodblocal",

--- a/internal/orchestrion/_integration/internal/containers/kafka.go
+++ b/internal/orchestrion/_integration/internal/containers/kafka.go
@@ -25,7 +25,7 @@ func StartKafkaTestContainer(t testing.TB) (*kafka.KafkaContainer, string) {
 	exposedPort := "9093/tcp"
 
 	container, err := kafka.Run(ctx,
-		"confluentinc/confluent-local:7.5.0",
+		"confluentinc/confluent-local:7.5.0", // Change the docker pull stage in .github/workflows/orchestrion.yml if you update this
 		kafka.WithClusterID("test-cluster"),
 		WithTestLogConsumer(t),
 		testcontainers.WithWaitStrategy(

--- a/internal/orchestrion/_integration/internal/containers/redis.go
+++ b/internal/orchestrion/_integration/internal/containers/redis.go
@@ -29,7 +29,7 @@ func StartRedisTestContainer(t testing.TB) (*redis.RedisContainer, string) {
 	}
 
 	container, err := redis.Run(ctx,
-		"redis:7-alpine",
+		"redis:7-alpine", // Change the docker pull stage in .github/workflows/orchestrion.yml if you update this
 		testcontainers.WithLogger(testcontainers.TestLogger(t)),
 		WithTestLogConsumer(t),
 		testcontainers.WithWaitStrategy(

--- a/internal/orchestrion/_integration/pgx/pgx.go
+++ b/internal/orchestrion/_integration/pgx/pgx.go
@@ -33,7 +33,7 @@ func (tc *TestCase) Setup(ctx context.Context, t *testing.T) {
 
 	var err error
 	tc.container, err = testpostgres.Run(ctx,
-		"docker.io/postgres:16-alpine",
+		"docker.io/postgres:16-alpine", // Change the docker pull stage in .github/workflows/orchestrion.yml if you update this
 		testcontainers.WithLogger(testcontainers.TestLogger(t)),
 		containers.WithTestLogConsumer(t),
 		// https://golang.testcontainers.org/modules/postgres/#wait-strategies_1

--- a/internal/orchestrion/_integration/vault/vault.go
+++ b/internal/orchestrion/_integration/vault/vault.go
@@ -30,7 +30,7 @@ func (tc *TestCase) Setup(ctx context.Context, t *testing.T) {
 
 	var err error
 	tc.server, err = testvault.Run(ctx,
-		"vault:1.7.3",
+		"vault:1.7.3", // Change the docker pull stage in .github/workflows/orchestrion.yml if you update this
 		testcontainers.WithLogger(testcontainers.TestLogger(t)),
 		containers.WithTestLogConsumer(t),
 		testvault.WithToken("root"),


### PR DESCRIPTION
This aims to avoid having image pull times have to fit within the tests timeout, and hopefully will reduce flakiness.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
