### PR TITLE
internal/orchestrion/_integration: go-redis tests now wait for successful Ping

### DIFF
--- a/internal/orchestrion/_integration/go-redis.v0/go-redis.go
+++ b/internal/orchestrion/_integration/go-redis.v0/go-redis.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/dd-trace-go/internal/orchestrion/_integration/internal/containers"
 	"github.com/DataDog/dd-trace-go/internal/orchestrion/_integration/internal/trace"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/go-redis/redis"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -38,7 +39,22 @@ func (tc *TestCase) Setup(_ context.Context, t *testing.T) {
 	container, addr := containers.StartRedisTestContainer(t)
 	tc.server = container
 
-	tc.Client = redis.NewClient(&redis.Options{Addr: addr})
+	// Wait for a successful Ping to the server, so we're sure it's up and running.
+	require.NoError(t,
+		backoff.Retry(
+			func() error {
+				tc.Client = redis.NewClient(&redis.Options{Addr: addr})
+				if err := tc.Client.Ping().Err(); err != nil {
+					// There was an error, so we'll re-cycle the client entirely...
+					tc.Client.Close()
+					tc.Client = nil
+					return err
+				}
+				return nil
+			},
+			backoff.NewExponentialBackOff(),
+		),
+	)
 	t.Cleanup(func() { assert.NoError(t, tc.Client.Close()) })
 }
 

--- a/internal/orchestrion/_integration/go-redis.v7/go-redis.go
+++ b/internal/orchestrion/_integration/go-redis.v7/go-redis.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/dd-trace-go/internal/orchestrion/_integration/internal/containers"
 	"github.com/DataDog/dd-trace-go/internal/orchestrion/_integration/internal/trace"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/go-redis/redis/v7"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -38,7 +39,23 @@ func (tc *TestCase) Setup(_ context.Context, t *testing.T) {
 	container, addr := containers.StartRedisTestContainer(t)
 	tc.server = container
 
-	tc.Client = redis.NewClient(&redis.Options{Addr: addr})
+	// Wait for a successful Ping to the server, so we're sure it's up and running.
+	require.NoError(t,
+		backoff.Retry(
+			func() error {
+				tc.Client = redis.NewClient(&redis.Options{Addr: addr})
+				if err := tc.Client.Ping().Err(); err != nil {
+					// There was an error, so we'll re-cycle the client entirely...
+					tc.Client.Close()
+					tc.Client = nil
+					return err
+				}
+				return nil
+			},
+			backoff.NewExponentialBackOff(),
+		),
+	)
+
 	t.Cleanup(func() { assert.NoError(t, tc.Client.Close()) })
 }
 

--- a/internal/orchestrion/_integration/go-redis.v8/go-redis.go
+++ b/internal/orchestrion/_integration/go-redis.v8/go-redis.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/dd-trace-go/internal/orchestrion/_integration/internal/containers"
 	"github.com/DataDog/dd-trace-go/internal/orchestrion/_integration/internal/trace"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/go-redis/redis/v8"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -37,7 +38,22 @@ func (tc *TestCase) Setup(_ context.Context, t *testing.T) {
 	container, addr := containers.StartRedisTestContainer(t)
 	tc.server = container
 
-	tc.Client = redis.NewClient(&redis.Options{Addr: addr})
+	// Wait for a successful Ping to the server, so we're sure it's up and running.
+	require.NoError(t,
+		backoff.Retry(
+			func() error {
+				tc.Client = redis.NewClient(&redis.Options{Addr: addr})
+				if err := tc.Client.Ping(context.Background()).Err(); err != nil {
+					// There was an error, so we'll re-cycle the client entirely...
+					tc.Client.Close()
+					tc.Client = nil
+					return err
+				}
+				return nil
+			},
+			backoff.NewExponentialBackOff(),
+		),
+	)
 	t.Cleanup(func() { assert.NoError(t, tc.Client.Close()) })
 }
 

--- a/internal/orchestrion/_integration/go-redis.v9/go-redis.go
+++ b/internal/orchestrion/_integration/go-redis.v9/go-redis.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/dd-trace-go/internal/orchestrion/_integration/internal/containers"
 	"github.com/DataDog/dd-trace-go/internal/orchestrion/_integration/internal/trace"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
@@ -38,7 +39,22 @@ func (tc *TestCase) Setup(_ context.Context, t *testing.T) {
 	container, addr := containers.StartRedisTestContainer(t)
 	tc.server = container
 
-	tc.Client = redis.NewClient(&redis.Options{Addr: addr})
+	// Wait for a successful Ping to the server, so we're sure it's up and running.
+	require.NoError(t,
+		backoff.Retry(
+			func() error {
+				tc.Client = redis.NewClient(&redis.Options{Addr: addr})
+				if err := tc.Client.Ping(context.Background()).Err(); err != nil {
+					// There was an error, so we'll re-cycle the client entirely...
+					tc.Client.Close()
+					tc.Client = nil
+					return err
+				}
+				return nil
+			},
+			backoff.NewExponentialBackOff(),
+		),
+	)
 	t.Cleanup(func() { assert.NoError(t, tc.Client.Close()) })
 }
 


### PR DESCRIPTION
There are frequent flakes on these tests caused by networking errors that typically arise from the server not being completely ready before the tests start. To alleviate this issue, we now wait for a successful ping during the setup phase to make sure we have a valid client before proceeding to tests.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
