### PR TITLE
internal/orchestrion/_integration: enable vm.overcommit_memory

### DIFF
--- a/.github/workflows/orchestrion.yml
+++ b/.github/workflows/orchestrion.yml
@@ -186,6 +186,14 @@ jobs:
 
           # Vault service
           docker pull vault:1.7.3
+
+      # Enable VM overcommit memory, which is essential to ensure smooth operations of the Redis
+      # servers. This VM setting is not namespaced, so changing it on the host also affects all
+      # containerized workloads (which our Redis service is).
+      - name: Enable memory overcommit
+        if: runner.os == 'Linux'
+        run: sudo sysctl vm.overcommit_memory=1
+
       # Finally, we run the test suite!
       - name: Run Tests
         shell: bash


### PR DESCRIPTION
This is necessary to safely operate a REDIS server, as it will easily trigger the OOM reaper under tight memory conditions (often the case on CI machines...), but these are artificial because the process maps for fork children is copy-on-write, and should be much leaner than they appear to be. Hopefully this reduces/removes flakes.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
