### PR TITLE
appsec: update ATO SDK

### DIFF
--- a/appsec/appsec.go
+++ b/appsec/appsec.go
@@ -13,6 +13,8 @@ package appsec
 
 import (
 	"context"
+	"maps"
+	"strconv"
 	"sync"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
@@ -41,7 +43,7 @@ func MonitorParsedHTTPBody(ctx context.Context, body any) error {
 	return httpsec.MonitorParsedBody(ctx, body)
 }
 
-// SetUser wraps tracer.SetUser() and extends it with user blocking.
+// SetUser wraps [tracer.SetUser] and extends it with user blocking.
 // On top of associating the authenticated user information to the service entry span,
 // it checks whether the given user ID is blocked or not by returning an error when it is.
 // A user ID is blocked when it is present in your denylist of users to block at https://app.datadoghq.com/security/appsec/denylist
@@ -62,57 +64,85 @@ func SetUser(ctx context.Context, id string, opts ...tracer.UserMonitoringOption
 	}
 
 	op, errPtr := usersec.StartUserLoginOperation(ctx, usersec.UserLoginOperationArgs{})
+	login, userOrg, sessionID := getMetadata(opts)
 	op.Finish(usersec.UserLoginOperationRes{
 		UserID:    id,
-		SessionID: getSessionID(opts...),
+		UserLogin: login,
+		UserOrg:   userOrg,
+		SessionID: sessionID,
 		Success:   true,
 	})
 
 	return *errPtr
 }
 
-// TrackUserLoginSuccessEvent sets a successful user login event, with the given
-// user id and optional metadata, as service entry span tags. It also calls
-// SetUser() to set the currently authenticated user, along with the given
-// tracer.UserMonitoringOption options. As documented in SetUser(), an
-// error is returned when the given user ID is blocked by your denylist. Cf.
-// SetUser()'s documentation for more details.
-// The service entry span is obtained through the given Go context which should
-// contain the currently running span. This function does nothing when no span
-// is found in the given Go context and logs an error message instead.
-// Such events trigger the backend-side events monitoring, such as the Account
-// Take-Over (ATO) monitoring, ultimately blocking the IP address and/or user id
-// associated to them.
-func TrackUserLoginSuccessEvent(ctx context.Context, uid string, md map[string]string, opts ...tracer.UserMonitoringOption) error {
+// TrackUserLoginSuccess denotes a successful user login event, which is used
+// by back-end side event monitoring, such as Account Take-Over (ATO)
+// monitoring, ultimately allowing IP address and/or user ID deny-lists to be
+// configured in order to block associated malicious activity.
+//
+// The login is the username that was provided by the user as part of
+// the authentication attempt, and a single user may have multiple different
+// logins (i.e; user name, email address, etc...). The user however has exactly
+// one user ID which canonically identifies them.
+//
+// The provided metadata is attached to the successful user login event.
+//
+// This function calso calls [SetUser] with the provided user ID and login, as
+// well as any provided [tracer.UserMonitoringOption]s, and returns an error if
+// the provided user ID is found to be on a configured deny list. See the
+// documentation for [SetUser] for more information.
+func TrackUserLoginSuccess(ctx context.Context, login string, uid string, md map[string]string, opts ...tracer.UserMonitoringOption) error {
+	// We need to make sure the metadata contains the correct `usr.id` and
+	// `usr.login` values, so we clone the metadata map and set these two.
+	md = maps.Clone(md)
+	if md == nil {
+		md = make(map[string]string, 2)
+	}
+	md["usr.login"] = login
+	if uid == "" {
+		// Warn if no user ID was provided, as this is necessary for user blocking
+		// to be possible...
+		log.Error("appsec: TrackUserLoginSuccess requires a non-empty user ID (uid) in order for user blocking to be effective")
+	} else {
+		md["usr.id"] = uid
+	}
+
 	TrackCustomEvent(ctx, "users.login.success", md)
-	return SetUser(ctx, uid, opts...)
+	return SetUser(ctx, uid, append(opts, tracer.WithUserLogin(login))...)
 }
 
-// TrackUserLoginFailureEvent sets a failed user login event, with the given
-// user id and the optional metadata, as service entry span tags. The exists
-// argument allows to distinguish whether the given user id actually exists or
-// not.
-// The service entry span is obtained through the given Go context which should
-// contain the currently running span. This function does nothing when no span
-// is found in the given Go context and logs an error message instead.
-// Such events trigger the backend-side events monitoring, such as the Account
-// Take-Over (ATO) monitoring, ultimately blocking the IP address and/or user id
-// associated to them.
-func TrackUserLoginFailureEvent(ctx context.Context, uid string, exists bool, md map[string]string) {
-	span := getRootSpan(ctx)
-	if span == nil {
+// TrackUserLoginFailure denotes a failed user login event, which is used by
+// back-end side event monitoring, such as Account Take-Over (ATO) monitoring,
+// ultimately allowing IP address and/or user ID deny-lists to be configured in
+// order to block associated malicious activity.
+//
+// The login is the username that was provided by the user as part of
+// the authentication attempt, and a single user may have multiple different
+// logins (i.e; user name, email address, etc...).
+//
+// The exists argument allows to distinguish whether the user for which a login
+// attempt failed exists in the system or not, which is usedul when sifting
+// through login activity in search for malicious behavior & compromise.
+//
+// The provided metata is attached to the failed user login event.
+func TrackUserLoginFailure(ctx context.Context, login string, exists bool, md map[string]string) {
+	if getRootSpan(ctx) == nil {
 		return
 	}
 
-	// We need to do the first call to SetTag ourselves because the map taken by TrackCustomEvent is map[string]string
-	// and not map [string]any, so the `exists` boolean variable does not fit int
-	span.SetTag("appsec.events.users.login.failure.usr.exists", exists)
-	span.SetTag("appsec.events.users.login.failure.usr.id", uid)
+	// We need to make sure the metadata contains the correct information
+	md = maps.Clone(md)
+	if md == nil {
+		md = make(map[string]string, 2)
+	}
+	md["usr.exists"] = strconv.FormatBool(exists)
+	md["usr.login"] = login
 
 	TrackCustomEvent(ctx, "users.login.failure", md)
 
 	op, _ := usersec.StartUserLoginOperation(ctx, usersec.UserLoginOperationArgs{})
-	op.Finish(usersec.UserLoginOperationRes{UserID: uid, Success: false})
+	op.Finish(usersec.UserLoginOperationRes{UserLogin: login, Success: false})
 }
 
 // TrackCustomEvent sets a custom event as service entry span tags. This span is
@@ -128,7 +158,7 @@ func TrackCustomEvent(ctx context.Context, name string, md map[string]string) {
 	}
 
 	tagPrefix := "appsec.events." + name + "."
-	span.SetTag(tagPrefix+"track", true)
+	span.SetTag(tagPrefix+"track", "true")
 	span.SetTag(ext.ManualKeep, true)
 	for k, v := range md {
 		span.SetTag(tagPrefix+k, v)
@@ -145,12 +175,12 @@ func getRootSpan(ctx context.Context) *tracer.Span {
 	return span.Root()
 }
 
-func getSessionID(opts ...tracer.UserMonitoringOption) string {
-	cfg := &tracer.UserMonitoringConfig{
+func getMetadata(opts []tracer.UserMonitoringOption) (login string, org string, sessionID string) {
+	cfg := tracer.UserMonitoringConfig{
 		Metadata: make(map[string]string),
 	}
 	for _, opt := range opts {
-		opt(cfg)
+		opt(&cfg)
 	}
-	return cfg.SessionID
+	return cfg.Login, cfg.Org, cfg.SessionID
 }

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -1527,6 +1527,8 @@ func setHeaderTags(headerAsTags []string) bool {
 // This configuration can be set by combining one or several UserMonitoringOption with a call to SetUser().
 type UserMonitoringConfig struct {
 	PropagateID bool
+	Login       string
+	Org         string
 	Email       string
 	Name        string
 	Role        string
@@ -1543,6 +1545,20 @@ type UserMonitoringOption func(*UserMonitoringConfig)
 func WithUserMetadata(key, value string) UserMonitoringOption {
 	return func(cfg *UserMonitoringConfig) {
 		cfg.Metadata[key] = value
+	}
+}
+
+// WithUserLogin returns the option setting the login of the authenticated user.
+func WithUserLogin(login string) UserMonitoringOption {
+	return func(cfg *UserMonitoringConfig) {
+		cfg.Login = login
+	}
+}
+
+// WithUserOrg returns the option setting the organization of the authenticated user.
+func WithUserOrg(org string) UserMonitoringOption {
+	return func(cfg *UserMonitoringConfig) {
+		cfg.Org = org
 	}
 }
 

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -350,6 +350,7 @@ func (s *Span) SetUser(id string, opts ...UserMonitoringOption) {
 
 	usrData := map[string]string{
 		keyUserID:        id,
+		keyUserLogin:     cfg.Login,
 		keyUserEmail:     cfg.Email,
 		keyUserName:      cfg.Name,
 		keyUserScope:     cfg.Scope,
@@ -877,6 +878,7 @@ const (
 // The following set of tags is used for user monitoring and set through calls to span.SetUser().
 const (
 	keyUserID        = "usr.id"
+	keyUserLogin     = "usr.login"
 	keyUserEmail     = "usr.email"
 	keyUserName      = "usr.name"
 	keyUserRole      = "usr.role"

--- a/instrumentation/appsec/emitter/waf/addresses/addresses.go
+++ b/instrumentation/appsec/emitter/waf/addresses/addresses.go
@@ -19,6 +19,8 @@ const (
 	ClientIPAddr = "http.client_ip"
 
 	UserIDAddr           = "usr.id"
+	UserLoginAddr        = "usr.login"
+	UserOrgAddr          = "usr.org"
 	UserSessionIDAddr    = "usr.session_id"
 	UserLoginSuccessAddr = "server.business_logic.users.login.success"
 	UserLoginFailureAddr = "server.business_logic.users.login.failure"

--- a/instrumentation/appsec/emitter/waf/addresses/builder.go
+++ b/instrumentation/appsec/emitter/waf/addresses/builder.go
@@ -109,6 +109,22 @@ func (b *RunAddressDataBuilder) WithUserID(id string) *RunAddressDataBuilder {
 	return b
 }
 
+func (b *RunAddressDataBuilder) WithUserLogin(login string) *RunAddressDataBuilder {
+	if login == "" {
+		return b
+	}
+	b.Persistent[UserLoginAddr] = login
+	return b
+}
+
+func (b *RunAddressDataBuilder) WithUserOrg(org string) *RunAddressDataBuilder {
+	if org == "" {
+		return b
+	}
+	b.Persistent[UserOrgAddr] = org
+	return b
+}
+
 func (b *RunAddressDataBuilder) WithUserSessionID(id string) *RunAddressDataBuilder {
 	if id == "" {
 		return b

--- a/internal/appsec/emitter/usersec/user.go
+++ b/internal/appsec/emitter/usersec/user.go
@@ -29,6 +29,8 @@ type (
 	// UserLoginOperationRes is the user ID operation results.
 	UserLoginOperationRes struct {
 		UserID    string
+		UserLogin string
+		UserOrg   string
 		SessionID string
 		Success   bool
 	}

--- a/internal/appsec/listener/usersec/usec.go
+++ b/internal/appsec/listener/usersec/usec.go
@@ -25,6 +25,8 @@ func (*Feature) Stop() {}
 func NewUserSecFeature(cfg *config.Config, rootOp dyngo.Operation) (listener.Feature, error) {
 	if !cfg.SupportedAddresses.AnyOf(
 		addresses.UserIDAddr,
+		addresses.UserLoginAddr,
+		addresses.UserOrgAddr,
 		addresses.UserSessionIDAddr,
 		addresses.UserLoginSuccessAddr,
 		addresses.UserLoginFailureAddr) {
@@ -39,6 +41,8 @@ func NewUserSecFeature(cfg *config.Config, rootOp dyngo.Operation) (listener.Fea
 func (*Feature) OnFinish(op *usersec.UserLoginOperation, res usersec.UserLoginOperationRes) {
 	builder := addresses.NewAddressesBuilder().
 		WithUserID(res.UserID).
+		WithUserLogin(res.UserLogin).
+		WithUserOrg(res.UserOrg).
 		WithUserSessionID(res.SessionID)
 
 	if res.Success {


### PR DESCRIPTION
Replaced the previous functions for login success and failure tracking with the new standard API that works off user login, and not just user ID.

This is the V2 port of #3192; except deprecated APIs were removed.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
