### PR TITLE
internal/newtelemetry: reduce flakiness of the heartbeat

### DIFF
--- a/internal/newtelemetry/client_test.go
+++ b/internal/newtelemetry/client_test.go
@@ -132,6 +132,10 @@ func TestClientFlush(t *testing.T) {
 			},
 			when: func(c *client) {
 				c.RegisterAppConfig("key", "value", OriginDefault)
+
+				// Make sure the limiter of the heartbeat is triggered
+				time.Sleep(time.Microsecond)
+				runtime.Gosched()
 			},
 			expect: func(t *testing.T, payloads []transport.Payload) {
 				payload := payloads[0]
@@ -151,6 +155,10 @@ func TestClientFlush(t *testing.T) {
 			},
 			when: func(c *client) {
 				c.MarkIntegrationAsLoaded(Integration{Name: "test-integration", Version: "1.0.0"})
+
+				// Make sure the limiter of the heartbeat is triggered
+				time.Sleep(time.Microsecond)
+				runtime.Gosched()
 			},
 			expect: func(t *testing.T, payloads []transport.Payload) {
 				payload := payloads[0]
@@ -342,6 +350,10 @@ func TestClientFlush(t *testing.T) {
 			when: func(c *client) {
 				c.ProductStarted("test-product")
 				c.MarkIntegrationAsLoaded(Integration{Name: "test-integration", Version: "1.0.0"})
+
+				// Make sure the limiter of the heartbeat is triggered
+				time.Sleep(time.Microsecond)
+				runtime.Gosched()
 			},
 			expect: func(t *testing.T, payloads []transport.Payload) {
 				payload := payloads[0]
@@ -440,6 +452,10 @@ func TestClientFlush(t *testing.T) {
 			},
 			when: func(c *client) {
 				c.AppStart()
+
+				// Make sure the limiter of the heartbeat is triggered
+				time.Sleep(time.Microsecond)
+				runtime.Gosched()
 			},
 			expect: func(t *testing.T, payloads []transport.Payload) {
 				payload := payloads[0]

--- a/internal/newtelemetry/client_test.go
+++ b/internal/newtelemetry/client_test.go
@@ -128,7 +128,6 @@ func TestClientFlush(t *testing.T) {
 		{
 			name: "extended-heartbeat-config",
 			clientConfig: ClientConfig{
-				HeartbeatInterval:         time.Nanosecond,
 				ExtendedHeartbeatInterval: time.Nanosecond,
 			},
 			when: func(c *client) {
@@ -148,7 +147,6 @@ func TestClientFlush(t *testing.T) {
 		{
 			name: "extended-heartbeat-integrations",
 			clientConfig: ClientConfig{
-				HeartbeatInterval:         time.Nanosecond,
 				ExtendedHeartbeatInterval: time.Nanosecond,
 			},
 			when: func(c *client) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Rework the order we decide which heartbeat to send so we don't need to set config values that would send the wrong heartbeat in case of a flake

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
Signed-off-by: Eliott Bouhana <eliott.bouhana@datadoghq.com>