### PR TITLE
appsec: re-introduce V1 of ATO API

### DIFF
--- a/appsec/appsec.go
+++ b/appsec/appsec.go
@@ -90,7 +90,7 @@ func SetUser(ctx context.Context, id string, opts ...tracer.UserMonitoringOption
 // The provided metadata is attached to the successful user login event.
 //
 // This function calso calls [SetUser] with the provided user ID and login, as
-// well as any provided [tracer.UserMonitoringOption]s, and returns an error if
+// well as any provided [tracer.UserMonitoringOption], and returns an error if
 // the provided user ID is found to be on a configured deny list. See the
 // documentation for [SetUser] for more information.
 func TrackUserLoginSuccess(ctx context.Context, login string, uid string, md map[string]string, opts ...tracer.UserMonitoringOption) error {
@@ -159,6 +159,7 @@ func TrackCustomEvent(ctx context.Context, name string, md map[string]string) {
 	}
 
 	tagPrefix := "appsec.events." + name + "."
+	span.SetTag("_dd."+tagPrefix+"sdk", "true")
 	span.SetTag(tagPrefix+"track", "true")
 	span.SetTag(ext.ManualKeep, true)
 	for k, v := range md {

--- a/appsec/appsec_test.go
+++ b/appsec/appsec_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	privateAppsec "github.com/DataDog/dd-trace-go/v2/internal/appsec"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,14 +32,16 @@ func TestTrackUserLoginSuccess(t *testing.T) {
 		// Check the span contains the expected tags.
 		require.Len(t, mt.FinishedSpans(), 1)
 		finished := mt.FinishedSpans()[0]
-		expectedEventPrefix := "appsec.events.users.login.success."
-		require.Equal(t, "true", finished.Tag(expectedEventPrefix+"track"))
+
 		sp, _ := finished.Context().SamplingPriority()
-		require.Equal(t, ext.PriorityUserKeep, sp)
-		require.Equal(t, "user id", finished.Tag("usr.id"))
-		require.Equal(t, "user login", finished.Tag("usr.login"))
-		require.Equal(t, "us-east-1", finished.Tag(expectedEventPrefix+"region"))
-		require.Equal(t, "username", finished.Tag("usr.name"))
+		assert.Equal(t, ext.PriorityUserKeep, sp, "span should have user keep (%d) priority (has: %d)", ext.PriorityUserKeep, sp)
+
+		expectedEventPrefix := "appsec.events.users.login.success."
+		assertTag(t, finished, expectedEventPrefix+"track", "true")
+		assertTag(t, finished, "usr.id", "user id")
+		assertTag(t, finished, "usr.login", "user login")
+		assertTag(t, finished, expectedEventPrefix+"region", "us-east-1")
+		assertTag(t, finished, "usr.name", "username")
 	})
 
 	t.Run("nominal-nil-metadata", func(t *testing.T) {
@@ -52,15 +55,18 @@ func TestTrackUserLoginSuccess(t *testing.T) {
 		// Check the span contains the expected tags.
 		require.Len(t, mt.FinishedSpans(), 1)
 		finished := mt.FinishedSpans()[0]
-		expectedEventPrefix := "appsec.events.users.login.success."
-		require.Equal(t, "true", finished.Tag(expectedEventPrefix+"track"))
+
 		sp, _ := finished.Context().SamplingPriority()
-		require.Equal(t, ext.PriorityUserKeep, sp)
-		require.Equal(t, "user id", finished.Tag("usr.id"))
+		assert.Equal(t, ext.PriorityUserKeep, sp, "span should have user keep (%d) priority (has: %d)", ext.PriorityUserKeep, sp)
+
+		expectedEventPrefix := "appsec.events.users.login.success."
+		assertTag(t, finished, expectedEventPrefix+"track", "true")
+		assertTag(t, finished, "usr.id", "user id")
 	})
 
 	t.Run("nil-context", func(t *testing.T) {
 		require.NotPanics(t, func() {
+			//lint:ignore SA1012 we are intentionally passing a nil context to verify incorrect use does not lead to panic
 			appsec.TrackUserLoginSuccess(nil, "user login", "user id", map[string]string{"region": "us-east-1"}, tracer.WithUserName("username"))
 		})
 	})
@@ -86,11 +92,15 @@ func TestTrackUserLoginFailure(t *testing.T) {
 				// Check the span contains the expected tags.
 				require.Len(t, mt.FinishedSpans(), 1)
 				finished := mt.FinishedSpans()[0]
+
+				sp, _ := finished.Context().SamplingPriority()
+				assert.Equal(t, ext.PriorityUserKeep, sp, "span should have user keep (%d) priority (has: %d)", ext.PriorityUserKeep, sp)
+
 				expectedEventPrefix := "appsec.events.users.login.failure."
-				require.Equal(t, "true", finished.Tag(expectedEventPrefix+"track"))
-				require.Equal(t, "user login", finished.Tag(expectedEventPrefix+"usr.login"))
-				require.Equal(t, strconv.FormatBool(userExists), finished.Tag(expectedEventPrefix+"usr.exists"))
-				require.Equal(t, "us-east-1", finished.Tag(expectedEventPrefix+"region"))
+				assertTag(t, finished, expectedEventPrefix+"track", "true")
+				assertTag(t, finished, expectedEventPrefix+"usr.login", "user login")
+				assertTag(t, finished, expectedEventPrefix+"usr.exists", strconv.FormatBool(userExists))
+				assertTag(t, finished, expectedEventPrefix+"region", "us-east-1")
 			}
 		}
 		t.Run("user-exists", test(true))
@@ -99,6 +109,7 @@ func TestTrackUserLoginFailure(t *testing.T) {
 
 	t.Run("nil-context", func(t *testing.T) {
 		require.NotPanics(t, func() {
+			//lint:ignore SA1012 we are intentionally passing a nil context to verify incorrect use does not lead to panic
 			appsec.TrackUserLoginFailure(nil, "user login", false, nil)
 		})
 	})
@@ -123,17 +134,20 @@ func TestCustomEvent(t *testing.T) {
 		// Check the span contains the expected tags.
 		require.Len(t, mt.FinishedSpans(), 1)
 		finished := mt.FinishedSpans()[0]
-		expectedEventPrefix := "appsec.events.my-custom-event."
-		require.Equal(t, "true", finished.Tag(expectedEventPrefix+"track"))
+
 		sp, _ := finished.Context().SamplingPriority()
-		require.Equal(t, ext.PriorityUserKeep, sp)
+		assert.Equal(t, ext.PriorityUserKeep, sp, "span should have user keep (%d) priority (has: %d)", ext.PriorityUserKeep, sp)
+
+		expectedEventPrefix := "appsec.events.my-custom-event."
+		assertTag(t, finished, expectedEventPrefix+"track", "true")
 		for k, v := range md {
-			require.Equal(t, v, finished.Tag(expectedEventPrefix+k))
+			assertTag(t, finished, expectedEventPrefix+k, v)
 		}
 	})
 
 	t.Run("nil-context", func(t *testing.T) {
 		require.NotPanics(t, func() {
+			//lint:ignore SA1012 we are intentionally passing a nil context to verify incorrect use does not lead to panic
 			appsec.TrackCustomEvent(nil, "my-custom-event", nil)
 		})
 	})
@@ -162,6 +176,7 @@ func TestSetUser(t *testing.T) {
 	}
 
 	t.Run("early-return/nil-ctx", func(t *testing.T) {
+		//lint:ignore SA1012 we are intentionally passing a nil context to verify incorrect use does not lead to panic
 		err := appsec.SetUser(nil, "usr.id")
 		require.NoError(t, err)
 	})
@@ -178,21 +193,21 @@ func TestSetUser(t *testing.T) {
 
 func ExampleTrackUserLoginSuccess() {
 	// Create an example span and set a user login success appsec event example to it.
-	span, ctx := tracer.StartSpanFromContext(context.Background(), "example")
+	span, ctx := tracer.StartSpanFromContext(context.TODO(), "example")
 	defer span.Finish()
 	appsec.TrackUserLoginSuccess(ctx, "login", "user id", map[string]string{"region": "us-east-1"}, tracer.WithUserName("username"))
 }
 
 func ExampleTrackUserLoginFailure() {
 	// Create an example span and set a user login failure appsec event example to it.
-	span, ctx := tracer.StartSpanFromContext(context.Background(), "example")
+	span, ctx := tracer.StartSpanFromContext(context.TODO(), "example")
 	defer span.Finish()
 	appsec.TrackUserLoginFailure(ctx, "login", false, nil)
 }
 
 func ExampleTrackCustomEvent() {
 	// Create an example span and set a custom appsec event example to it.
-	span, ctx := tracer.StartSpanFromContext(context.Background(), "example")
+	span, ctx := tracer.StartSpanFromContext(context.TODO(), "example")
 	defer span.Finish()
 	appsec.TrackCustomEvent(ctx, "my-custom-event", map[string]string{"region": "us-east-1"})
 

--- a/appsec/appsecv1.go
+++ b/appsec/appsecv1.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022 Datadog, Inc.
+
+package appsec
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	"github.com/DataDog/dd-trace-go/v2/internal/appsec/emitter/usersec"
+)
+
+// TrackUserLoginSuccessEvent sets a successful user login event, with the given
+// user id and optional metadata, as service entry span tags. It also calls
+// SetUser() to set the currently authenticated user, along with the given
+// tracer.UserMonitoringOption options. As documented in SetUser(), an
+// error is returned when the given user ID is blocked by your denylist. Cf.
+// SetUser()'s documentation for more details.
+// The service entry span is obtained through the given Go context which should
+// contain the currently running span. This function does nothing when no span
+// is found in the given Go context and logs an error message instead.
+// Such events trigger the backend-side events monitoring, such as the Account
+// Take-Over (ATO) monitoring, ultimately blocking the IP address and/or user id
+// associated to them.
+//
+// Deprecated: use [TrackUserLoginSuccess] instead. It requires collection of
+// the user login, which is useful for detecting account takeover attacks.
+func TrackUserLoginSuccessEvent(ctx context.Context, uid string, md map[string]string, opts ...tracer.UserMonitoringOption) error {
+	login, _, _ := getMetadata(opts)
+	return TrackUserLoginSuccess(ctx, login, uid, md, opts...)
+}
+
+// TrackUserLoginFailureEvent sets a failed user login event, with the given
+// user id and the optional metadata, as service entry span tags. The exists
+// argument allows to distinguish whether the given user id actually exists or
+// not.
+// The service entry span is obtained through the given Go context which should
+// contain the currently running span. This function does nothing when no span
+// is found in the given Go context and logs an error message instead.
+// Such events trigger the backend-side events monitoring, such as the Account
+// Take-Over (ATO) monitoring, ultimately blocking the IP address and/or user id
+// associated to them.
+//
+// Deprecated: use [TrackUserLoginFailure] instead. It collects the user login,
+// which is what is available during a failed login attempt, instead of the user
+// ID, which is oftern not (especially when the user does not exist).
+func TrackUserLoginFailureEvent(ctx context.Context, uid string, exists bool, md map[string]string) {
+	span := getRootSpan(ctx)
+	if span == nil {
+		return
+	}
+
+	// We need to do the first call to SetTag ourselves because the map taken by TrackCustomEvent is map[string]string
+	// and not map [string]any, so the `exists` boolean variable does not fit int
+	span.SetTag("appsec.events.users.login.failure.usr.exists", strconv.FormatBool(exists))
+	span.SetTag("appsec.events.users.login.failure.usr.id", uid)
+
+	TrackCustomEvent(ctx, "users.login.failure", md)
+
+	op, _ := usersec.StartUserLoginOperation(ctx, usersec.UserLoginOperationArgs{})
+	op.Finish(usersec.UserLoginOperationRes{UserID: uid, Success: false})
+}

--- a/appsec/appsecv1_test.go
+++ b/appsec/appsecv1_test.go
@@ -1,0 +1,125 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022 Datadog, Inc.
+
+package appsec_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/appsec"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrackUserLoginSuccessEvent(t *testing.T) {
+	t.Run("nominal-with-metadata", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		span, ctx := tracer.StartSpanFromContext(context.Background(), "example")
+		appsec.TrackUserLoginSuccessEvent(ctx, "user id", map[string]string{"region": "us-east-1"}, tracer.WithUserName("username"))
+		span.Finish()
+
+		// Check the span contains the expected tags.
+		require.Len(t, mt.FinishedSpans(), 1)
+		finished := mt.FinishedSpans()[0]
+
+		sp, _ := finished.Context().SamplingPriority()
+		assert.Equal(t, ext.PriorityUserKeep, sp, "span should have user keep (%d) priority (has: %d)", ext.PriorityUserKeep, sp)
+
+		expectedEventPrefix := "appsec.events.users.login.success."
+		assertTag(t, finished, "_dd."+expectedEventPrefix+"sdk", "true")
+		assertTag(t, finished, expectedEventPrefix+"track", "true")
+		assertTag(t, finished, "usr.id", "user id")
+		assertTag(t, finished, expectedEventPrefix+"region", "us-east-1")
+		assertTag(t, finished, "usr.name", "username")
+	})
+
+	t.Run("nominal-nil-metadata", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		span, ctx := tracer.StartSpanFromContext(context.Background(), "example")
+		appsec.TrackUserLoginSuccessEvent(ctx, "user id", nil)
+		span.Finish()
+
+		// Check the span contains the expected tags.
+		require.Len(t, mt.FinishedSpans(), 1)
+		finished := mt.FinishedSpans()[0]
+
+		sp, _ := finished.Context().SamplingPriority()
+		assert.Equal(t, ext.PriorityUserKeep, sp, "span should have user keep (%d) priority (has: %d)", ext.PriorityUserKeep, sp)
+
+		expectedEventPrefix := "appsec.events.users.login.success."
+		assertTag(t, finished, expectedEventPrefix+"track", "true")
+		assertTag(t, finished, "usr.id", "user id")
+	})
+
+	t.Run("nil-context", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			//lint:ignore SA1012 we are intentionally passing a nil context to verify incorrect use does not lead to panic
+			appsec.TrackUserLoginSuccessEvent(nil, "user id", map[string]string{"region": "us-east-1"}, tracer.WithUserName("username"))
+		})
+	})
+
+	t.Run("empty-context", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			appsec.TrackUserLoginSuccessEvent(context.Background(), "user id", map[string]string{"region": "us-east-1"}, tracer.WithUserName("username"))
+		})
+	})
+}
+
+func TestTrackUserLoginFailureEvent(t *testing.T) {
+	t.Run("nominal", func(t *testing.T) {
+		test := func(userExists bool) func(t *testing.T) {
+			return func(t *testing.T) {
+				mt := mocktracer.Start()
+				defer mt.Stop()
+
+				span, ctx := tracer.StartSpanFromContext(context.Background(), "example")
+				appsec.TrackUserLoginFailureEvent(ctx, "user id", userExists, map[string]string{"region": "us-east-1"})
+				span.Finish()
+
+				// Check the span contains the expected tags.
+				require.Len(t, mt.FinishedSpans(), 1)
+				finished := mt.FinishedSpans()[0]
+
+				sp, _ := finished.Context().SamplingPriority()
+				assert.Equal(t, ext.PriorityUserKeep, sp, "span should have user keep (%d) priority (has: %d)", ext.PriorityUserKeep, sp)
+
+				expectedEventPrefix := "appsec.events.users.login.failure."
+				assertTag(t, finished, "_dd."+expectedEventPrefix+"sdk", "true")
+				assertTag(t, finished, expectedEventPrefix+"track", "true")
+				assertTag(t, finished, expectedEventPrefix+"usr.id", "user id")
+				assertTag(t, finished, expectedEventPrefix+"usr.exists", strconv.FormatBool(userExists))
+				assertTag(t, finished, expectedEventPrefix+"region", "us-east-1")
+			}
+		}
+		t.Run("user-exists", test(true))
+		t.Run("user-not-exists", test(false))
+	})
+
+	t.Run("nil-context", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			//lint:ignore SA1012 we are intentionally passing a nil context to verify incorrect use does not lead to panic
+			appsec.TrackUserLoginFailureEvent(nil, "user id", false, nil)
+		})
+	})
+
+	t.Run("empty-context", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			appsec.TrackUserLoginFailureEvent(context.Background(), "user id", false, nil)
+		})
+	})
+}
+
+func assertTag(t *testing.T, span *mocktracer.Span, tag string, value any) bool {
+	return assert.EqualValues(t, value, span.Tag(tag), "span tag %q should have value %#v", tag, value)
+}

--- a/go.work.sum
+++ b/go.work.sum
@@ -1150,6 +1150,7 @@ github.com/bytedance/sonic v1.10.0/go.mod h1:iZcSUejdk5aukTND/Eu/ivjQuEL0Cu9/rf5
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.4.1 h1:iKLQ0xPNFxR/2hzXZMrBo8f1j86j5WHzznCCQxV/b8g=


### PR DESCRIPTION
### What does this PR do?

This PR restores the V1 API (and associated tests) to the codebase.

### Motivation

Decision was made to indefinitely retain the old ATO API, as it is still providing value and does not cost much in terms of maintenance; but marking them as deprecated to encourage use of the more modern, more capable V2 API.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
