### PR TITLE
fix(net/http): finish the request span when RASP blocking triggers

### DIFF
--- a/contrib/net/http/internal/wrap/roundtrip.go
+++ b/contrib/net/http/internal/wrap/roundtrip.go
@@ -88,6 +88,7 @@ func ObserveRoundTrip(cfg *config.RoundTripperConfig, req *http.Request) (*http.
 	// if RASP is enabled, check whether the request is supposed to be blocked.
 	if config.Instrumentation.AppSecRASPEnabled() {
 		if err := httpsec.ProtectRoundTrip(ctx, req.URL.String()); err != nil {
+			span.Finish() // Finish the span as we're blocking the request...
 			return nil, nil, err
 		}
 	}

--- a/contrib/net/http/roundtripper_test.go
+++ b/contrib/net/http/roundtripper_test.go
@@ -733,10 +733,10 @@ func TestAppsec(t *testing.T) {
 			require.NoError(t, err)
 
 			TraceAndServe(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				req, err := http.NewRequest("GET", "http://169.254.169.254", nil)
+				req, err := http.NewRequestWithContext(r.Context(), "GET", "http://169.254.169.254", nil)
 				require.NoError(t, err)
 
-				resp, err := client.RoundTrip(req.WithContext(r.Context()))
+				resp, err := client.RoundTrip(req)
 
 				if enabled {
 					require.True(t, events.IsSecurityError(err))


### PR DESCRIPTION
The span was left un-finished and hence was missing from the trace at the end.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
