### PR TITLE
civisibility: add `civisibility` folder and fix a race condition - v2

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -29,6 +29,7 @@ go.sum
 /internal/datastreams           @Datadog/data-streams-monitoring @DataDog/apm-go
 
 # civisibility
+/civisibility                   @DataDog/ci-app-libraries @DataDog/apm-go
 /internal/civisibility          @DataDog/ci-app-libraries @DataDog/apm-go
 
 # Gitlab configuration

--- a/civisibility/linker.go
+++ b/civisibility/linker.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
 package civisibility
 
 // Let's import all the internal package so we can enable the go:linkname directive over the internal packages

--- a/civisibility/linker.go
+++ b/civisibility/linker.go
@@ -1,6 +1,7 @@
 package civisibility
 
 // Let's import all the internal package so we can enable the go:linkname directive over the internal packages
+// This will be useful for dogfooding in dd-go by using a shim package that will call the internal package
 import (
 	_ "gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/constants"
 	_ "gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations"

--- a/civisibility/linker.go
+++ b/civisibility/linker.go
@@ -8,11 +8,11 @@ package civisibility
 // Let's import all the internal package so we can enable the go:linkname directive over the internal packages
 // This will be useful for dogfooding in dd-go by using a shim package that will call the internal package
 import (
-	_ "gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/constants"
-	_ "gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations"
-	_ "gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations/gotesting"
-	_ "gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations/gotesting/coverage"
-	_ "gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils"
-	_ "gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils/net"
-	_ "gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils/telemetry"
+	_ "github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
+	_ "github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations"
+	_ "github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting"
+	_ "github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting/coverage"
+	_ "github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils"
+	_ "github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/net"
+	_ "github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/telemetry"
 )

--- a/civisibility/linker.go
+++ b/civisibility/linker.go
@@ -1,0 +1,12 @@
+package civisibility
+
+// Let's import all the internal package so we can enable the go:linkname directive over the internal packages
+import (
+	_ "gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/constants"
+	_ "gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations"
+	_ "gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations/gotesting"
+	_ "gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations/gotesting/coverage"
+	_ "gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils"
+	_ "gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils/net"
+	_ "gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/utils/telemetry"
+)

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -162,6 +162,9 @@ func applyAdditionalFeaturesToTestFunc(f func(*testing.T), testInfo *commonInfo)
 	// Apply additional features
 	settings := integrations.GetSettings()
 
+	// ensure that the additional features are initialized
+	_ = integrations.GetKnownTests()
+
 	// Check if we have something to do, if not we bail out
 	if !settings.TestManagement.Enabled && !settings.FlakyTestRetriesEnabled && !settings.EarlyFlakeDetection.Enabled {
 		return f


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds:
- [x] Add the `civisibility` folder and modify the CODEOWNERS file to include the folder.
- [x] Add the linker.go file to import internal packages while doing `go:linkname` over internal packages. (This will be used for instrumenting dd-go)
- [x] Fix a race condition.  

**V1**: [civisibility: add civisibility folder and fix a race condition](https://github.com/DataDog/dd-trace-go/pull/3235)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

I'm working on a shim layer in dd-go to be able to instrument tests using the test optimization product.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
