### PR TITLE
internal: promote toFloat64 from ddtrace/tracer

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -161,7 +161,7 @@ func (s *span) SetTag(key string, value interface{}) {
 		s.setMeta(key, v)
 		return
 	}
-	if v, ok := toFloat64(value); ok {
+	if v, ok := sharedinternal.ToFloat64(value); ok {
 		s.setMetric(key, v)
 		return
 	}
@@ -192,7 +192,7 @@ func (s *span) SetTag(key string, value interface{}) {
 			for i := 0; i < slice.Len(); i++ {
 				key := fmt.Sprintf("%s.%d", key, i)
 				v := slice.Index(i)
-				if num, ok := toFloat64(v.Interface()); ok {
+				if num, ok := sharedinternal.ToFloat64(v.Interface()); ok {
 					s.setMetric(key, num)
 				} else {
 					s.setMeta(key, fmt.Sprintf("%v", v))

--- a/ddtrace/tracer/util.go
+++ b/ddtrace/tracer/util.go
@@ -13,53 +13,6 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/samplernames"
 )
 
-// toFloat64 attempts to convert value into a float64. If the value is an integer
-// greater or equal to 2^53 or less than or equal to -2^53, it will not be converted
-// into a float64 to avoid losing precision. If it succeeds in converting, toFloat64
-// returns the value and true, otherwise 0 and false.
-func toFloat64(value interface{}) (f float64, ok bool) {
-	const max = (int64(1) << 53) - 1
-	const min = -max
-	// If any other type is added here, remember to add it to the type switch in
-	// the `span.SetTag` function to handle pointers to these supported types.
-	switch i := value.(type) {
-	case byte:
-		return float64(i), true
-	case float32:
-		return float64(i), true
-	case float64:
-		return i, true
-	case int:
-		return float64(i), true
-	case int8:
-		return float64(i), true
-	case int16:
-		return float64(i), true
-	case int32:
-		return float64(i), true
-	case int64:
-		if i > max || i < min {
-			return 0, false
-		}
-		return float64(i), true
-	case uint:
-		return float64(i), true
-	case uint16:
-		return float64(i), true
-	case uint32:
-		return float64(i), true
-	case uint64:
-		if i > uint64(max) {
-			return 0, false
-		}
-		return float64(i), true
-	case samplernames.SamplerName:
-		return float64(i), true
-	default:
-		return 0, false
-	}
-}
-
 // parseUint64 parses a uint64 from either an unsigned 64 bit base-10 string
 // or a signed 64 bit base-10 string representing an unsigned integer
 func parseUint64(str string) (uint64, error) {

--- a/ddtrace/tracer/util_test.go
+++ b/ddtrace/tracer/util_test.go
@@ -11,47 +11,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/samplernames"
 )
-
-func TestToFloat64(t *testing.T) {
-	for i, tt := range [...]struct {
-		value interface{}
-		f     float64
-		ok    bool
-	}{
-		0:  {1, 1, true},
-		1:  {byte(1), 1, true},
-		2:  {int(1), 1, true},
-		3:  {int16(1), 1, true},
-		4:  {int32(1), 1, true},
-		5:  {int64(1), 1, true},
-		6:  {uint(1), 1, true},
-		7:  {uint16(1), 1, true},
-		8:  {uint32(1), 1, true},
-		9:  {uint64(1), 1, true},
-		10: {"a", 0, false},
-		11: {float32(1.25), 1.25, true},
-		12: {float64(1.25), 1.25, true},
-		13: {intUpperLimit, 0, false},
-		14: {intUpperLimit + 1, 0, false},
-		15: {intUpperLimit - 1, float64(intUpperLimit - 1), true},
-		16: {intLowerLimit, 0, false},
-		17: {intLowerLimit - 1, 0, false},
-		18: {intLowerLimit + 1, float64(intLowerLimit + 1), true},
-		19: {-1024, -1024.0, true},
-	} {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			f, ok := toFloat64(tt.value)
-			if ok != tt.ok {
-				t.Fatalf("expected ok: %t", tt.ok)
-			}
-			if f != tt.f {
-				t.Fatalf("expected: %#v, got: %#v", tt.f, f)
-			}
-		})
-	}
-}
 
 func TestParseUint64(t *testing.T) {
 	t.Run("negative", func(t *testing.T) {

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 
 	xsync "github.com/puzpuzpuz/xsync/v3"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/samplernames"
 )
 
 // OtelTagsDelimeter is the separator between key-val pairs for OTEL env vars
@@ -101,4 +102,51 @@ func (cm *XSyncMapCounterMap) GetAndReset() map[string]int64 {
 		return true
 	})
 	return ret
+}
+
+// ToFloat64 attempts to convert value into a float64. If the value is an integer
+// greater or equal to 2^53 or less than or equal to -2^53, it will not be converted
+// into a float64 to avoid losing precision. If it succeeds in converting, toFloat64
+// returns the value and true, otherwise 0 and false.
+func ToFloat64(value any) (f float64, ok bool) {
+	const max = (int64(1) << 53) - 1
+	const min = -max
+	// If any other type is added here, remember to add it to the type switch in
+	// the `span.SetTag` function to handle pointers to these supported types.
+	switch i := value.(type) {
+	case byte:
+		return float64(i), true
+	case float32:
+		return float64(i), true
+	case float64:
+		return i, true
+	case int:
+		return float64(i), true
+	case int8:
+		return float64(i), true
+	case int16:
+		return float64(i), true
+	case int32:
+		return float64(i), true
+	case int64:
+		if i > max || i < min {
+			return 0, false
+		}
+		return float64(i), true
+	case uint:
+		return float64(i), true
+	case uint16:
+		return float64(i), true
+	case uint32:
+		return float64(i), true
+	case uint64:
+		if i > uint64(max) {
+			return 0, false
+		}
+		return float64(i), true
+	case samplernames.SamplerName:
+		return float64(i), true
+	default:
+		return 0, false
+	}
 }

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -109,8 +109,8 @@ func (cm *XSyncMapCounterMap) GetAndReset() map[string]int64 {
 // into a float64 to avoid losing precision. If it succeeds in converting, toFloat64
 // returns the value and true, otherwise 0 and false.
 func ToFloat64(value any) (f float64, ok bool) {
-	const max = (int64(1) << 53) - 1
-	const min = -max
+	const maxFloat = (int64(1) << 53) - 1
+	const minFloat = -maxFloat
 	// If any other type is added here, remember to add it to the type switch in
 	// the `span.SetTag` function to handle pointers to these supported types.
 	switch i := value.(type) {
@@ -129,7 +129,7 @@ func ToFloat64(value any) (f float64, ok bool) {
 	case int32:
 		return float64(i), true
 	case int64:
-		if i > max || i < min {
+		if i > maxFloat || i < minFloat {
 			return 0, false
 		}
 		return float64(i), true
@@ -140,7 +140,7 @@ func ToFloat64(value any) (f float64, ok bool) {
 	case uint32:
 		return float64(i), true
 	case uint64:
-		if i > uint64(max) {
+		if i > uint64(maxFloat) {
 			return 0, false
 		}
 		return float64(i), true


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR promotes the helper `toFloat64` from the tracer to an internal method by moving it to `internal/utils.go`

### Motivation

This will be used to get data that is currently used as span metric to telemetry metrics

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
