### PR TITLE
(fix) internal/civisibility: fix missing failing tests due to the runtime.Goexit() call from the testing framework.

### DIFF
--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -282,6 +282,12 @@ func instrumentSetErrorInfo(tb testing.TB, errType string, errMessage string, sk
 	ciTestItem := getTestMetadata(tb)
 	if ciTestItem != nil && ciTestItem.test != nil && ciTestItem.error.CompareAndSwap(0, 1) {
 		ciTestItem.test.SetError(integrations.WithErrorInfo(errType, errMessage, utils.GetStacktrace(2+skip)))
+
+		// Ensure to close the test with error before CI visibility exits. In CI visibility mode, we try to never lose data.
+		// If the test gets closed sooner (perhaps with another status), then this will be a noop call
+		integrations.PushCiVisibilityCloseAction(func() {
+			ciTestItem.test.Close(integrations.ResultStatusFail)
+		})
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR fixes an issue when test fails and the `runtime.GoExit()` function gets called (eg. t.FailNow()) . On those cases we end up missing the failing span.

This PR fixes the issue

**V1**: [(fix) internal/civisibility: fix missing failing tests due to the runtime.Goexit() call from the testing framework.](https://github.com/DataDog/dd-trace-go/pull/3243)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We detected a race condition between closing the span and exiting ci visibility, now we make sure to have a close handle to close the span before exit civisibility.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
