### PR TITLE
(feat) internal/civisibility: adds the orchestrion integration for testify suite.Run function v2

### DIFF
--- a/internal/civisibility/integrations/gotesting/orchestrion.yml
+++ b/internal/civisibility/integrations/gotesting/orchestrion.yml
@@ -225,9 +225,9 @@ aspects:
           imports:
             testing: testing
           links:
-            - gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations/gotesting
+            - github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting
           template: |-
-            //go:linkname __dd_civisibility_instrumentTestifySuiteRun gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations/gotesting.instrumentTestifySuiteRun
+            //go:linkname __dd_civisibility_instrumentTestifySuiteRun github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting.instrumentTestifySuiteRun
             func __dd_civisibility_instrumentTestifySuiteRun(*testing.T, interface{})
       - prepend-statements:
           template: |-

--- a/internal/civisibility/integrations/gotesting/orchestrion.yml
+++ b/internal/civisibility/integrations/gotesting/orchestrion.yml
@@ -106,7 +106,7 @@ aspects:
       - prepend-statements:
           template: |-
             __dd_civisibility_instrumentSetErrorInfo({{ .Function.Receiver }}, "FailNow", "failed test", 0)
-            __dd_civisibility_ExitCiVisibility()
+            defer __dd_civisibility_ExitCiVisibility()
 
   - id: common.Error
     join-point:
@@ -210,3 +210,25 @@ aspects:
       - prepend-statements:
           template: |-
             __dd_civisibility_instrumentSkipNow({{ .Function.Receiver }})
+
+  - id: testify.suite.Run
+    join-point:
+      all-of:
+        - import-path: github.com/stretchr/testify/suite
+        - function-body:
+            function:
+              - name: Run
+              - signature:
+                  args: ['*testing.T' , 'TestingSuite']
+    advice:
+      - inject-declarations:
+          imports:
+            testing: testing
+          links:
+            - gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations/gotesting
+          template: |-
+            //go:linkname __dd_civisibility_instrumentTestifySuiteRun gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/integrations/gotesting.instrumentTestifySuiteRun
+            func __dd_civisibility_instrumentTestifySuiteRun(*testing.T, interface{})
+      - prepend-statements:
+          template: |-
+            __dd_civisibility_instrumentTestifySuiteRun({{ .Function.Argument 0 }}, {{ .Function.Argument 1 }})


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds the missing orchestrion integration for the testify `suite.Run` function. Improving the visibility of testify suites.

V1: [(feat) internal/civisibility: adds the orchestrion integration for testify suite.Run function](https://github.com/DataDog/dd-trace-go/pull/3247)

Before:
<img width="966" alt="image" src="https://github.com/user-attachments/assets/cd970c9c-c474-4272-91f9-37da631e7c1f" />
<img width="621" alt="image" src="https://github.com/user-attachments/assets/8e72f04f-e8b9-4b4f-87e3-24b0cbab0f49" />


After:
<img width="887" alt="image" src="https://github.com/user-attachments/assets/b03f6d03-f164-4e65-a868-7e4a6e143ae5" />
<img width="540" alt="image" src="https://github.com/user-attachments/assets/718edb54-97db-415d-a715-c3b6f67a716d" />


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Part of the work was done before, but we were missing the orchestrion part.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
