### PR TITLE
fix(appsec/gqlgen): recovered from an unexpected panic from an event listener

### DIFF
--- a/instrumentation/appsec/trace/service_entry_span.go
+++ b/instrumentation/appsec/trace/service_entry_span.go
@@ -128,6 +128,9 @@ func (op *ServiceEntrySpanOperation) OnSpanTagEvent(tag SpanTag) {
 
 func StartServiceEntrySpanOperation(ctx context.Context, span TagSetter) (*ServiceEntrySpanOperation, context.Context) {
 	parent, _ := dyngo.FromContext(ctx)
+	if span == nil {
+		span = NoopTagSetter{}
+	}
 	op := &ServiceEntrySpanOperation{
 		Operation: dyngo.NewOperation(parent),
 		jsonTags:  make(map[string]any, 2),
@@ -138,7 +141,7 @@ func StartServiceEntrySpanOperation(ctx context.Context, span TagSetter) (*Servi
 
 func (op *ServiceEntrySpanOperation) Finish() {
 	span := op.tagSetter
-	if _, ok := span.(*NoopTagSetter); ok { // If the span is a NoopTagSetter or is nil, we don't need to set any tags
+	if _, ok := span.(NoopTagSetter); ok { // If the span is a NoopTagSetter or is nil, we don't need to set any tags
 		return
 	}
 

--- a/instrumentation/appsec/trace/span.go
+++ b/instrumentation/appsec/trace/span.go
@@ -54,7 +54,7 @@ func StartSpanOperation(ctx context.Context) (*SpanOperation, context.Context) {
 }
 
 func (op *SpanOperation) Finish(span TagSetter) {
-	if _, ok := span.(*NoopTagSetter); ok { // If the span is a NoopTagSetter or is nil, we don't need to set any tags
+	if _, ok := span.(NoopTagSetter); ok || span == nil { // If the span is a NoopTagSetter or is nil, we don't need to set any tags
 		return
 	}
 


### PR DESCRIPTION
### What does this PR do?

The GraphQL subscription propagates a `nil` span to avoid creating an indefinitely long-running span. This results in a nil-panic later on as tags are being set on this.

To address this, override the `TagSetter` with a `NoopTagSetter` to avoid dealing with nil checks everywhere.

Added a subscriptions test on the gqlgen contrib that I used to validate the panic no longer triggers.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
