### PR TITLE
chore: add test for merging baggage entries

### DIFF
--- a/contrib/internal/httptrace/httptrace_test.go
+++ b/contrib/internal/httptrace/httptrace_test.go
@@ -6,6 +6,7 @@
 package httptrace
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +16,7 @@ import (
 	"testing"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/baggage"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -385,4 +387,31 @@ func TestStartRequestSpanWithBaggage(t *testing.T) {
 	})
 	assert.Equal(t, "value1", spanBm["key1"])
 	assert.Equal(t, "value2", spanBm["key2"])
+}
+
+func TestStartRequestSpanMergedBaggage(t *testing.T) {
+	t.Setenv("DD_TRACE_PROPAGATION_STYLE", "datadog,tracecontext,baggage")
+	tracer.Start()
+	defer tracer.Stop()
+
+	// Create a base context with pre-set baggage.
+	baseCtx := baggage.Set(context.Background(), "pre_key", "pre_value")
+
+	// Create an HTTP request with that context.
+	req := httptest.NewRequest(http.MethodGet, "/somePath", nil).WithContext(baseCtx)
+
+	// Set the baggage header with additional baggage items.
+	req.Header.Set("baggage", "header_key=header_value,another_header=another_value")
+
+	// Start the request span, which will extract header baggage and merge it with the context's baggage.
+	span, ctx, _ := StartRequestSpan(req)
+	span.Finish()
+
+	// Retrieve the merged baggage from the span's context.
+	mergedBaggage := baggage.All(ctx)
+
+	// Verify that both pre-set and header baggage items are present.
+	assert.Equal(t, "pre_value", mergedBaggage["pre_key"], "should contain pre-set baggage")
+	assert.Equal(t, "header_value", mergedBaggage["header_key"], "should contain header baggage")
+	assert.Equal(t, "another_value", mergedBaggage["another_header"], "should contain header baggage")
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Add a test to check that if baggage is set before a request is sent, it is merged into the baggage inside the request headers as well. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
