### PR TITLE
tracer: allow disabling APM tracing with DD_APM_TRACING_ENABLED=false

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -81,6 +81,8 @@ jobs:
           - weblog-variant: net-http
             scenario: APPSEC_STANDALONE
           - weblog-variant: net-http
+            scenario: APPSEC_STANDALONE_V2
+          - weblog-variant: net-http
             scenario: APPSEC_META_STRUCT_DISABLED
           - weblog-variant: net-http
             scenario: APPSEC_CUSTOM_OBFUSCATION

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -79,8 +79,6 @@ jobs:
           - weblog-variant: net-http
             scenario: APPSEC_LOW_WAF_TIMEOUT
           - weblog-variant: net-http
-            scenario: APPSEC_STANDALONE
-          - weblog-variant: net-http
             scenario: APPSEC_STANDALONE_V2
           - weblog-variant: net-http
             scenario: APPSEC_META_STRUCT_DISABLED

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -591,8 +591,7 @@ func newConfig(opts ...StartOption) (*config, error) {
 	globalTagsOrigin := c.globalTags.cfgOrigin
 	c.initGlobalTags(c.globalTags.get(), globalTagsOrigin)
 
-	// TODO: change the name once APM Platform RFC is approved
-	if internal.BoolEnv("DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED", false) {
+	if !internal.BoolEnv("DD_APM_TRACING_ENABLED", true) {
 		// Enable tracing as transport layer mode
 		// This means to stop sending trace metrics, send one trace per minute and those force-kept by other products
 		// using the tracer as transport layer for their data. And finally adding the _dd.apm.enabled=0 tag to all traces

--- a/ddtrace/tracer/propagating_tags.go
+++ b/ddtrace/tracer/propagating_tags.go
@@ -5,6 +5,11 @@
 
 package tracer
 
+import (
+	"github.com/DataDog/dd-trace-go/v2/internal"
+	"github.com/DataDog/dd-trace-go/v2/internal/log"
+)
+
 func (t *trace) hasPropagatingTag(k string) bool {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
@@ -23,6 +28,27 @@ func (t *trace) setPropagatingTag(key, value string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.setPropagatingTagLocked(key, value)
+}
+
+func (t *trace) setTraceSourcePropagatingTag(key string, value internal.TraceSource) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	// If there is already a TraceSource value set in the trace
+	// we need to add the new value to the bitmask.
+	if source := t.propagatingTags[key]; source != "" {
+		tSource, err := internal.ParseTraceSource(source)
+		if err != nil {
+			log.Error("failed to parse trace source tag: %v", err)
+		}
+
+		tSource |= value
+
+		t.setPropagatingTagLocked(key, tSource.String())
+		return
+	}
+
+	t.setPropagatingTagLocked(key, value.String())
 }
 
 // setPropagatingTagLocked sets the key/value pair as a trace propagating tag.
@@ -44,7 +70,7 @@ func (t *trace) unsetPropagatingTag(key string) {
 // iteratePropagatingTags allows safe iteration through the propagating tags of a trace.
 // the trace must not be modified during this call, as it is locked for reading.
 //
-// f should return whether or not the iteration should continue.
+// f should return whether the iteration should continue.
 func (t *trace) iteratePropagatingTags(f func(k, v string) bool) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -249,10 +249,10 @@ func (s *Span) SetTag(key string, value interface{}) {
 			return
 		}
 
-		// Add this tag to propagating tags and to span tags
+		// Add this trace source tag to propagating tags and to span tags
 		// reserved for internal use only
-		if v, ok := value.(sharedinternal.PropagatingTagValue); ok {
-			s.context.trace.setPropagatingTag(key, v.Value)
+		if v, ok := value.(sharedinternal.TraceSourceTagValue); ok {
+			s.context.trace.setTraceSourcePropagatingTag(key, v.Value)
 		}
 	}
 
@@ -863,6 +863,11 @@ const (
 	keySingleSpanSamplingMPS = "_dd.span_sampling.max_per_second"
 	// keyPropagatedUserID holds the propagated user identifier, if user id propagation is enabled.
 	keyPropagatedUserID = "_dd.p.usr.id"
+	// keyPropagatedTraceSource holds a 2 character hexadecimal string representation of the product responsible
+	// for the span creation.
+	keyPropagatedTraceSource = "_dd.p.ts"
+	//keyTracerHostname holds the tracer detected hostname, only present when not connected over UDS to agent.
+	keyTracerHostname = "_dd.tracer_hostname"
 	// keyTraceID128 is the lowercase, hex encoded upper 64 bits of a 128-bit trace id, if present.
 	keyTraceID128 = "_dd.p.tid"
 	// keySpanAttributeSchemaVersion holds the selected DD_TRACE_SPAN_ATTRIBUTE_SCHEMA version.

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -793,8 +793,8 @@ func (t *tracer) Inject(ctx *SpanContext, carrier interface{}) error {
 
 	if t.config.tracingAsTransport {
 		// in tracing as transport mode, only propagate when there is an upstream appsec event
-		// TODO: replace with _dd.p.ts in the next iteration standardizing this for other products, comparing enabled products in `t.config` with their corresponding `_dd.p.ts` bitfields
-		if ctx.trace != nil && ctx.trace.propagatingTag("_dd.p.appsec") != "1" {
+		if ctx.trace != nil && !globalinternal.VerifyTraceSourceEnabled(
+			ctx.trace.propagatingTag(keyPropagatedTraceSource), globalinternal.ASMTraceSource) {
 			return nil
 		}
 	}
@@ -840,8 +840,8 @@ func (t *tracer) Extract(carrier interface{}) (*SpanContext, error) {
 	ctx, err := t.config.propagator.Extract(carrier)
 	if t.config.tracingAsTransport && ctx != nil {
 		// in tracing as transport mode, reset upstream sampling decision to make sure we keep 1 trace/minute
-		// TODO: replace with _dd.p.ts in the next iteration standardizing this for other products, comparing enabled products in `t.config` with their corresponding `_dd.p.ts` bitfields
-		if ctx.trace != nil && ctx.trace.propagatingTag("_dd.p.appsec") != "1" {
+		if ctx.trace != nil && !globalinternal.VerifyTraceSourceEnabled(
+			ctx.trace.propagatingTag(keyPropagatedTraceSource), globalinternal.ASMTraceSource) {
 			ctx.trace.priority = nil
 		}
 	}

--- a/internal/appsec/listener/httpsec/request_test.go
+++ b/internal/appsec/listener/httpsec/request_test.go
@@ -230,7 +230,7 @@ func TestTags(t *testing.T) {
 							"manual.keep":     true,
 							"appsec.event":    true,
 							"_dd.origin":      "appsec",
-							"_dd.p.appsec":    internal.PropagatingTagValue{Value: "1"},
+							"_dd.p.ts":        internal.TraceSourceTagValue{Value: internal.ASMTraceSource},
 						})
 					}
 

--- a/internal/appsec/listener/waf/tags.go
+++ b/internal/appsec/listener/waf/tags.go
@@ -72,5 +72,5 @@ func SetEventSpanTags(span trace.TagSetter) {
 	span.SetTag("_dd.origin", "appsec")
 	// Set the appsec.event tag needed by the appsec backend
 	span.SetTag("appsec.event", true)
-	span.SetTag("_dd.p.appsec", internal.PropagatingTagValue{Value: "1"})
+	span.SetTag("_dd.p.ts", internal.TraceSourceTagValue{Value: internal.ASMTraceSource})
 }

--- a/internal/meta_internal_types.go
+++ b/internal/meta_internal_types.go
@@ -11,8 +11,9 @@ type MetaStructValue struct {
 	Value any // TODO: further constraining Value's type, especially if it becomes public
 }
 
-// PropagatingTagValue is a custom type wrapper used to create tags that will be propagated
-// to downstream distributed traces via the `X-Datadog-Tags` HTTP header for example.
-type PropagatingTagValue struct {
-	Value string
+// TraceSourceTagValue is a custom type wrapper used to create the trace source (_dd.p.ts) tag that will
+// be propagated to downstream distributed traces via the `X-Datadog-Tags` HTTP header for example.
+// It is represented as a 2 character hexadecimal string
+type TraceSourceTagValue struct {
+	Value TraceSource
 }

--- a/internal/trace_source.go
+++ b/internal/trace_source.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+package internal
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/log"
+)
+
+// TraceSource represents the 8-bit bitmask for the _dd.p.ts tag
+type TraceSource uint8
+
+const (
+	APMTraceSource TraceSource = 0x01
+	ASMTraceSource TraceSource = 0x02
+	DSMTraceSource TraceSource = 0x04
+	DJMTraceSource TraceSource = 0x08
+	DBMTraceSource TraceSource = 0x10
+)
+
+// String converts the bitmask to a two-character hexadecimal string
+func (ts TraceSource) String() string {
+	return fmt.Sprintf("%02X", uint8(ts))
+}
+
+// ParseTraceSource parses a hexadecimal string into a TraceSource bitmask
+func ParseTraceSource(hexStr string) (TraceSource, error) {
+	// Ensure at least 2 chars, allowing up to 8 for forward compatibility (32-bit)
+	if len(hexStr) < 2 || len(hexStr) > 8 {
+		return 0, fmt.Errorf("invalid length for TraceSource mask, expected 2 to 8 characters")
+	}
+
+	// Parse the full mask as a 32-bit unsigned integer
+	value, err := strconv.ParseUint(hexStr, 16, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid hexadecimal format: %w", err)
+	}
+
+	// Extract only the least significant 8 bits (ensuring compliance with 8-bit mask)
+	return TraceSource(value & 0xFF), nil
+}
+
+func VerifyTraceSourceEnabled(hexStr string, target TraceSource) bool {
+	ts, err := ParseTraceSource(hexStr)
+	if err != nil {
+		if len(hexStr) != 0 { // Empty trace source should not trigger an error log.
+			log.Error("invalid trace-source hex string given for source verification: %v", err)
+		}
+		return false
+	}
+
+	return ts.IsSet(target)
+}
+
+// Set enables specific TraceSource (bit) in the bitmask
+func (ts *TraceSource) Set(src TraceSource) {
+	*ts |= src
+}
+
+// Unset disables specific TraceSource (bit) in the bitmask
+func (ts *TraceSource) Unset(src TraceSource) {
+	*ts &^= src
+}
+
+// IsSet checks if a specific TraceSource (bit) is enabled
+func (ts TraceSource) IsSet(src TraceSource) bool {
+	return ts&src != 0
+}

--- a/internal/trace_source_test.go
+++ b/internal/trace_source_test.go
@@ -1,0 +1,262 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+package internal
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTraceSourceProduct(t *testing.T) {
+	type args struct {
+		hexStr string
+	}
+
+	var allSources = map[string]TraceSource{
+		"APM": APMTraceSource,
+		"ASM": ASMTraceSource,
+		"DSM": DSMTraceSource,
+		"DJM": DJMTraceSource,
+		"DBM": DBMTraceSource,
+	}
+
+	tests := []struct {
+		name        string
+		args        args
+		wantSources map[TraceSource]bool
+		want        uint8
+		wantErr     assert.ErrorAssertionFunc
+	}{
+		{
+			name:        "empty",
+			args:        args{"00"},
+			wantSources: map[TraceSource]bool{},
+			want:        0,
+			wantErr:     assert.NoError,
+		},
+		{
+			name:        "APM",
+			args:        args{"01"},
+			wantSources: map[TraceSource]bool{APMTraceSource: true},
+			want:        1,
+			wantErr:     assert.NoError,
+		},
+		{
+			name:        "ASM",
+			args:        args{"02"},
+			wantSources: map[TraceSource]bool{ASMTraceSource: true},
+			want:        2,
+			wantErr:     assert.NoError,
+		},
+		{
+			name:        "ASM-APM",
+			args:        args{"03"},
+			wantSources: map[TraceSource]bool{APMTraceSource: true, ASMTraceSource: true},
+			want:        3,
+			wantErr:     assert.NoError,
+		},
+		{
+			name:        "DSM-DJM-DBM",
+			args:        args{"1C"},
+			wantSources: map[TraceSource]bool{DSMTraceSource: true, DBMTraceSource: true, DJMTraceSource: true},
+			want:        28,
+			wantErr:     assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseTraceSource(tt.args.hexStr)
+			if !tt.wantErr(t, err, fmt.Sprintf("ParseTraceSourceProduct(%v)", tt.args.hexStr)) {
+				return
+			}
+
+			for k, v := range allSources {
+				assert.Equalf(t, tt.wantSources[v], got.IsSet(v), "Source %s should be %v", k, got.IsSet(v))
+			}
+			assert.EqualValuesf(t, tt.want, got, "ParseTraceSourceProduct(%v) should equal uint8 %v got value %v", tt.args.hexStr, tt.want, uint8(got))
+		})
+	}
+}
+
+func TestTraceSource_Set(t *testing.T) {
+	type args struct {
+		sources []TraceSource
+	}
+	tests := []struct {
+		name string
+		args args
+		res  string
+	}{
+		{
+			name: "empty",
+			args: args{sources: nil},
+			res:  "00",
+		},
+		{
+			name: "APM",
+			args: args{
+				sources: []TraceSource{APMTraceSource},
+			},
+			res: "01",
+		},
+		{
+			name: "ASM-twice",
+			args: args{
+				// Setting the same source twice does not change the underneath mask
+				sources: []TraceSource{ASMTraceSource, ASMTraceSource},
+			},
+			res: "02",
+		},
+		{
+			name: "APM-ASM-DBM",
+			args: args{
+				sources: []TraceSource{
+					APMTraceSource,
+					ASMTraceSource,
+					DBMTraceSource,
+				},
+			},
+			res: "13",
+		},
+		{
+			name: "DSM-DJM",
+			args: args{
+				sources: []TraceSource{
+					DSMTraceSource,
+					DJMTraceSource,
+				},
+			},
+			res: "0C",
+		},
+		{
+			name: "DBM",
+			args: args{
+				sources: []TraceSource{DBMTraceSource},
+			},
+			res: "10",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := TraceSource(0)
+
+			for _, source := range tt.args.sources {
+				s.Set(source)
+			}
+
+			assert.EqualValuesf(t, tt.res, s.String(), "Set() should return %v", tt.args.sources)
+
+		})
+	}
+}
+
+func TestVerifyTraceSourceEnabled(t *testing.T) {
+	type args struct {
+		hexStr string
+	}
+
+	var allSources = map[string]TraceSource{
+		"APM": APMTraceSource,
+		"ASM": ASMTraceSource,
+		"DSM": DSMTraceSource,
+		"DJM": DJMTraceSource,
+		"DBM": DBMTraceSource,
+	}
+
+	tests := []struct {
+		name        string
+		args        args
+		wantSources map[TraceSource]bool
+	}{
+		{
+			name: "empty",
+			args: args{
+				hexStr: "",
+			},
+			wantSources: map[TraceSource]bool{},
+		},
+		{
+			name: "invalid",
+			args: args{
+				hexStr: "nope",
+			},
+			wantSources: map[TraceSource]bool{},
+		},
+		{
+			name: "00",
+			args: args{
+				hexStr: "00",
+			},
+			wantSources: map[TraceSource]bool{},
+		},
+		{
+			name: "01",
+			args: args{
+				hexStr: "01",
+			},
+			wantSources: map[TraceSource]bool{APMTraceSource: true},
+		},
+		{
+			name: "02",
+			args: args{
+				hexStr: "02",
+			},
+			wantSources: map[TraceSource]bool{ASMTraceSource: true},
+		},
+		{
+			name: "03",
+			args: args{
+				hexStr: "03",
+			},
+			wantSources: map[TraceSource]bool{APMTraceSource: true, ASMTraceSource: true},
+		},
+		{
+			name: "04",
+			args: args{
+				hexStr: "04",
+			},
+			wantSources: map[TraceSource]bool{DSMTraceSource: true},
+		},
+		{
+			name: "05",
+			args: args{
+				hexStr: "05",
+			},
+			wantSources: map[TraceSource]bool{APMTraceSource: true, DSMTraceSource: true},
+		},
+		{
+			name: "08",
+			args: args{
+				hexStr: "08",
+			},
+			wantSources: map[TraceSource]bool{DJMTraceSource: true},
+		},
+		{
+			name: "0C",
+			args: args{
+				hexStr: "0C",
+			},
+			wantSources: map[TraceSource]bool{DSMTraceSource: true, DJMTraceSource: true},
+		},
+		{
+			name: "10",
+			args: args{
+				hexStr: "10",
+			},
+			wantSources: map[TraceSource]bool{DBMTraceSource: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range allSources {
+				assert.Equalf(t, tt.wantSources[v], VerifyTraceSourceEnabled(tt.args.hexStr, v), "Source %s should be %v for mask %s",
+					k, tt.wantSources[v], tt.args.hexStr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

V2 PR of #3230 

This PR implements the new RFC that adds support for new tag `_dd.p.ts` containing the "source" of a trace. This source represents the product that interacted with a trace. 

This tag is forwarded to downstream services that will decide wether to keep a trace or not based on their configuration plus the value of this tag.

The representation of this source is 2 character hexadecimal string of the bitmask. (eg: `02` when ASM interacts with a trace)

The RFC also includes the renaming of the env var `DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED` used to disable APM while keeping other product that use traces as their transport active.

✅ System test successful [run](https://github.com/DataDog/dd-trace-go/actions/runs/13564111008)

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.

