### PR TITLE
(feat) internal/civisibility: adds the `test_session` telemetry metric

### DIFF
--- a/internal/civisibility/constants/env.go
+++ b/internal/civisibility/constants/env.go
@@ -43,4 +43,7 @@ const (
 
 	// CIVisibilityTestManagementAttemptToFixRetriesEnvironmentVariable indicates the maximum number of retries for the attempt to fix a test.
 	CIVisibilityTestManagementAttemptToFixRetriesEnvironmentVariable = "DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES"
+
+	// CIVisibilityAutoInstrumentationProviderEnvironmentVariable indicates that the auto-instrumentation script was used.
+	CIVisibilityAutoInstrumentationProviderEnvironmentVariable = "DD_CIVISIBILITY_AUTO_INSTRUMENTATION_PROVIDER"
 )

--- a/internal/civisibility/integrations/manual_api_ddtestsession.go
+++ b/internal/civisibility/integrations/manual_api_ddtestsession.go
@@ -108,9 +108,14 @@ func CreateTestSession(options ...TestSessionStartOption) TestSession {
 	if utils.GetCodeOwners() != nil {
 		testingEventType = append(testingEventType, telemetry.HasCodeOwnerEventType...)
 	}
-	if _, hasCiProvider := utils.GetCITags()[constants.CIProviderName]; !hasCiProvider {
+
+	ciProviderName, hasCiProvider := utils.GetCITags()[constants.CIProviderName]
+	if !hasCiProvider {
 		testingEventType = append(testingEventType, telemetry.UnsupportedCiEventType...)
 	}
+
+	// Write test session telemetry
+	telemetry.TestSession(ciProviderName)
 	telemetry.EventCreated(s.framework, testingEventType)
 	return s
 }

--- a/internal/civisibility/utils/telemetry/telemetry.go
+++ b/internal/civisibility/utils/telemetry/telemetry.go
@@ -13,6 +13,29 @@ const (
 	UnknownFramework   TestingFramework = "test_framework:unknown"
 )
 
+// TestSessionEventType is a type for test session event types
+type TestSessionType []string
+
+var (
+	AppVeyorTestSessionType       TestSessionType = []string{"provider:appveyor"}
+	AzurePipelinesTestSessionType TestSessionType = []string{"provider:azp"}
+	BitbucketTestSessionType      TestSessionType = []string{"provider:bitbucket"}
+	BitRiseTestSessionType        TestSessionType = []string{"provider:bitrise"}
+	BuildKiteTestSessionType      TestSessionType = []string{"provider:buildkite"}
+	CircleCiTestSessionType       TestSessionType = []string{"provider:circleci"}
+	CodeFreshTestSessionType      TestSessionType = []string{"provider:codefresh"}
+	GithubActionsTestSessionType  TestSessionType = []string{"provider:githubactions"}
+	GitlabTestSessionType         TestSessionType = []string{"provider:gitlab"}
+	JenkinsTestSessionType        TestSessionType = []string{"provider:jenkins"}
+	TeamcityTestSessionType       TestSessionType = []string{"provider:teamcity"}
+	TravisCiTestSessionType       TestSessionType = []string{"provider:travisci"}
+	BuddyCiTestSessionType        TestSessionType = []string{"provider:buddyci"}
+	AwsCodePipelineSessionType    TestSessionType = []string{"provider:aws"}
+	UnsupportedTestSessionType    TestSessionType = []string{"provider:unsupported"}
+
+	IsAutoInstrumentationTestSessionType TestSessionType = []string{"auto_injected:true"}
+)
+
 // TestingEventType is a type for testing event types
 type TestingEventType []string
 

--- a/internal/civisibility/utils/telemetry/telemetry_count.go
+++ b/internal/civisibility/utils/telemetry/telemetry_count.go
@@ -6,6 +6,8 @@
 package telemetry
 
 import (
+	utils "gopkg.in/DataDog/dd-trace-go.v1/internal"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/constants"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry"
 )
 
@@ -42,6 +44,50 @@ func GetErrorTypeFromStatusCode(statusCode int) ErrorType {
 			return StatusCodeErrorType
 		}
 	}
+}
+
+func getProviderTestSessionTypeFromProviderString(provider string) TestSessionType {
+	switch provider {
+	case "appveyor":
+		return AppVeyorTestSessionType
+	case "azurepipelines":
+		return AzurePipelinesTestSessionType
+	case "bitbucket":
+		return BitbucketTestSessionType
+	case "bitrise":
+		return BitRiseTestSessionType
+	case "buildkite":
+		return BuildKiteTestSessionType
+	case "circleci":
+		return CircleCiTestSessionType
+	case "codefresh":
+		return CodeFreshTestSessionType
+	case "github":
+		return GithubActionsTestSessionType
+	case "gitlab":
+		return GitlabTestSessionType
+	case "jenkins":
+		return JenkinsTestSessionType
+	case "teamcity":
+		return TeamcityTestSessionType
+	case "travisci":
+		return TravisCiTestSessionType
+	case "buddy":
+		return BuddyCiTestSessionType
+	case "awscodepipeline":
+		return AwsCodePipelineSessionType
+	default:
+		return UnsupportedTestSessionType
+	}
+}
+
+func TestSession(providerName string) {
+	var tags []string
+	tags = append(tags, getProviderTestSessionTypeFromProviderString(providerName)...)
+	if utils.BoolEnv(constants.CIVisibilityAutoInstrumentationProviderEnvironmentVariable, false) {
+		tags = append(tags, IsAutoInstrumentationTestSessionType...)
+	}
+	telemetry.Count(telemetry.NamespaceCIVisibility, "test_session", removeEmptyStrings(tags)).Submit(1.0)
 }
 
 // EventCreated the number of events created by CI Visibility


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds the `test_session` telemetry metric to the test optimization product.

**V2**: [(feat) internal/civisibility: adds the test_session telemetry metric - v2](https://github.com/DataDog/dd-trace-go/pull/3269)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The metric was missing

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
