### PR TITLE
Fix Rueidis test

### DIFF
--- a/instrumentation/packages.go
+++ b/instrumentation/packages.go
@@ -608,8 +608,10 @@ var packages = map[Package]PackageInfo{
 		EnvVarPrefix:  "REDIS",
 		naming: map[Component]componentNames{
 			ComponentDefault: {
-				buildOpNameV0: staticName("redis.command"),
-				buildOpNameV1: staticName("redis.command"),
+				useDDServiceV0:     true,
+				buildServiceNameV0: staticName("redis.client"),
+				buildOpNameV0:      staticName("redis.command"),
+				buildOpNameV1:      staticName("redis.command"),
 			},
 		},
 	},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Fix Rueidis test.

<details><summary>error</summary>

```log
go run github.com/DataDog/orchestrion go test ./rueidis/...
INFO:ddapm_test_agent.agent:Trace request stall seconds setting set to 0.0.
WARNING:ddapm_test_agent.agent:default snapshot directory '/home/ubuntu/workspace/dd-trace-go/internal/orchestrion/_integration/rueidis/snapshots' does not exist or is not readable. Snapshotting will not work.
--- FAIL: Test (5.25s)
    agent.go:67: Starting /home/ubuntu/.pyenv/shims/ddapm-test-agent on port 38227
    generated_test.go:19: Running setup
    docker.go:1392: Failed to get image auth for https://index.docker.io/v1/. Setting empty credentials for the image: redis:7-alpine. Error is: credentials not found in native keychain
    lifecycle.go:77: 🐳 Creating container for image redis:7-alpine
    lifecycle.go:77: 🐳 Creating container for image testcontainers/ryuk:0.11.0
    lifecycle.go:83: ✅ Container created: d1067f65a9e2
    lifecycle.go:89: 🐳 Starting container: d1067f65a9e2
    lifecycle.go:95: ✅ Container started: d1067f65a9e2
    lifecycle.go:285: ⏳ Waiting for container id d1067f65a9e2 image: testcontainers/ryuk:0.11.0. Waiting for: &{Port:8080/tcp timeout:<nil> PollInterval:100ms skipInternalCheck:false}
    lifecycle.go:101: 🔔 Container is ready: d1067f65a9e2
    lifecycle.go:83: ✅ Container created: e13240c1f836
    lifecycle.go:89: 🐳 Starting container: e13240c1f836
    lifecycle.go:95: ✅ Container started: e13240c1f836
    lifecycle.go:285: ⏳ Waiting for container id e13240c1f836 image: redis:7-alpine. Waiting for: &{timeout:<nil> deadline:0xc0003ec548 Strategies:[0xc000308a20]}
    logs.go:29: 1:C 11 Mar 2025 10:27:10.482 * oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
        
    logs.go:29: 1:C 11 Mar 2025 10:27:10.482 * Redis version=7.4.2, bits=64, commit=00000000, modified=0, pid=1, just started
        
    logs.go:29: 1:C 11 Mar 2025 10:27:10.482 # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf
        
    logs.go:29: 1:M 11 Mar 2025 10:27:10.482 * monotonic clock: POSIX clock_gettime
        
    logs.go:29: 1:M 11 Mar 2025 10:27:10.483 * Running mode=standalone, port=6379.
        
    logs.go:29: 1:M 11 Mar 2025 10:27:10.483 * Server initialized
        
    logs.go:29: 1:M 11 Mar 2025 10:27:10.483 * Ready to accept connections tcp
        
    lifecycle.go:101: 🔔 Container is ready: e13240c1f836
    lifecycle.go:107: 🐳 Stopping container: e13240c1f836
    logs.go:29: 1:signal-handler (1741688830) Received SIGTERM scheduling shutdown...
        
    logs.go:29: 1:M 11 Mar 2025 10:27:10.887 * User requested shutdown...
        
    logs.go:29: 1:M 11 Mar 2025 10:27:10.887 * Saving the final RDB snapshot before exiting.
        
    logs.go:29: 1:M 11 Mar 2025 10:27:10.892 * DB saved on disk
        
    logs.go:29: 1:M 11 Mar 2025 10:27:10.892 # Redis is now ready to exit, bye bye...
        
    lifecycle.go:113: ✅ Container stopped: e13240c1f836
    lifecycle.go:119: 🐳 Terminating container: e13240c1f836
    lifecycle.go:125: 🚫 Container terminated: e13240c1f836
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xd721a5]

goroutine 36 [running]:
testing.tRunner.func1.2({0x13fc440, 0x230a5c0})
	/snap/go/10866/src/testing/testing.go:1734 +0x21c
testing.tRunner.func1()
	/snap/go/10866/src/testing/testing.go:1737 +0x35e
panic({0x13fc440?, 0x230a5c0?})
	/snap/go/10866/src/runtime/panic.go:792 +0x132
github.com/DataDog/dd-trace-go/v2/instrumentation.(*Instrumentation).ServiceName(0xc000227200, 0x0, 0x0)
	/home/ubuntu/workspace/dd-trace-go/instrumentation/instrumentation.go:67 +0x85
github.com/DataDog/dd-trace-go/contrib/redis/rueidis/v2.defaultConfig()
	/home/ubuntu/workspace/dd-trace-go/contrib/redis/rueidis/option.go:24 +0x39
github.com/DataDog/dd-trace-go/contrib/redis/rueidis/v2.NewClient({0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, {{0x0, {0x0, ...}, ...}, ...}, ...}, ...)
	/home/ubuntu/workspace/dd-trace-go/contrib/redis/rueidis/rueidis.go:40 +0x7a
github.com/DataDog/dd-trace-go/v2/internal/orchestrion/_integration/rueidis.(*TestCase).Setup(0xc000275eb0, {0xc000093f18?, 0x0?}, 0xc0002461c0)
	<generated>:1 +0x12b
github.com/DataDog/dd-trace-go/v2/internal/orchestrion/_integration/internal/harness.Run(0xc0002461c0, {0x1864538, 0xc000275eb0})
	/home/ubuntu/workspace/dd-trace-go/internal/orchestrion/_integration/internal/harness/harness.go:63 +0x20f
github.com/DataDog/dd-trace-go/v2/internal/orchestrion/_integration/rueidis.Test(0xc0002461c0)
	/home/ubuntu/workspace/dd-trace-go/internal/orchestrion/_integration/rueidis/generated_test.go:19 +0x33
testing.tRunner(0xc0002461c0, 0x16ee4f0)
	/snap/go/10866/src/testing/testing.go:1792 +0xf4
created by testing.(*T).Run in goroutine 1
	/snap/go/10866/src/testing/testing.go:1851 +0x42b
FAIL	github.com/DataDog/dd-trace-go/v2/internal/orchestrion/_integration/rueidis	5.287s
FAIL
exit status 1
```

</details>

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

This failure blocks other PRs.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
