### PR TITLE
(feat) internal/civisibility: add support for attempt_to_fix v2 workflow - v2

### DIFF
--- a/internal/civisibility/integrations/civisibility_features.go
+++ b/internal/civisibility/integrations/civisibility_features.go
@@ -134,12 +134,12 @@ func ensureAdditionalFeaturesInitialization(serviceName string) {
 		}()
 
 		// set the default values for the additional tags
-		additionalTags[constants.LibraryCapabilitiesEarlyFlakeDetection] = "false"
-		additionalTags[constants.LibraryCapabilitiesAutoTestRetries] = "false"
-		additionalTags[constants.LibraryCapabilitiesTestImpactAnalysis] = "false"
-		additionalTags[constants.LibraryCapabilitiesTestManagementQuarantine] = "false"
-		additionalTags[constants.LibraryCapabilitiesTestManagementDisable] = "false"
-		additionalTags[constants.LibraryCapabilitiesTestManagementAttemptToFix] = "false"
+		additionalTags[constants.LibraryCapabilitiesEarlyFlakeDetection] = "1"
+		additionalTags[constants.LibraryCapabilitiesAutoTestRetries] = "1"
+		additionalTags[constants.LibraryCapabilitiesTestImpactAnalysis] = "1"
+		additionalTags[constants.LibraryCapabilitiesTestManagementQuarantine] = "1"
+		additionalTags[constants.LibraryCapabilitiesTestManagementDisable] = "1"
+		additionalTags[constants.LibraryCapabilitiesTestManagementAttemptToFix] = "2"
 
 		// mutex to protect the additional tags map
 		var aTagsMutex sync.Mutex
@@ -164,7 +164,6 @@ func ensureAdditionalFeaturesInitialization(serviceName string) {
 					ciVisibilityKnownTests = *ciEfdData
 					log.Debug("civisibility: known tests data loaded.")
 				}
-				setAdditionalTags(constants.LibraryCapabilitiesEarlyFlakeDetection, "true")
 			} else {
 				// "known_tests_enabled" parameter works as a kill-switch for EFD, so if “known_tests_enabled” is false it
 				// will disable EFD even if “early_flake_detection.enabled” is set to true (which should not happen normally,
@@ -188,7 +187,6 @@ func ensureAdditionalFeaturesInitialization(serviceName string) {
 						RemainingTotalRetryCount: totalRetriesCount,
 					}
 					log.Debug("civisibility: automatic test retries enabled [retryCount: %v, totalRetryCount: %v]", retryCount, totalRetriesCount)
-					setAdditionalTags(constants.LibraryCapabilitiesAutoTestRetries, "true")
 				} else {
 					log.Warn("civisibility: flaky test retries was disabled by the environment variable")
 					ciVisibilitySettings.FlakyTestRetriesEnabled = false
@@ -210,7 +208,6 @@ func ensureAdditionalFeaturesInitialization(serviceName string) {
 					setAdditionalTags(constants.ItrCorrelationIDTag, correlationID)
 					ciVisibilitySkippables = skippableTests
 				}
-				setAdditionalTags(constants.LibraryCapabilitiesTestImpactAnalysis, "true")
 			}
 			wg.Done()
 		}()
@@ -233,9 +230,6 @@ func ensureAdditionalFeaturesInitialization(serviceName string) {
 						ciVisibilityTestManagementTests = *testManagementTests
 						log.Debug("civisibility: test management loaded [attemptToFixRetries: %v]", ciVisibilitySettings.TestManagement.AttemptToFixRetries)
 					}
-					setAdditionalTags(constants.LibraryCapabilitiesTestManagementQuarantine, "true")
-					setAdditionalTags(constants.LibraryCapabilitiesTestManagementDisable, "true")
-					setAdditionalTags(constants.LibraryCapabilitiesTestManagementAttemptToFix, "true")
 				} else {
 					ciVisibilitySettings.TestManagement.Enabled = false
 					log.Warn("civisibility: test management was disabled by the environment variable")

--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -8,6 +8,7 @@ package gotesting
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -773,6 +774,8 @@ func setUpHTTPServer(
 
 		// Settings request
 		if r.URL.Path == "/api/v2/libraries/tests/services/setting" {
+			body, _ := io.ReadAll(r.Body)
+			fmt.Printf("MockApi received body: %s\n", body)
 			w.Header().Set("Content-Type", "application/json")
 			response := struct {
 				Data struct {
@@ -801,6 +804,8 @@ func setUpHTTPServer(
 			fmt.Printf("MockApi sending response: %v\n", response)
 			json.NewEncoder(w).Encode(&response)
 		} else if enableKnownTests && r.URL.Path == "/api/v2/ci/libraries/tests" {
+			body, _ := io.ReadAll(r.Body)
+			fmt.Printf("MockApi received body: %s\n", body)
 			w.Header().Set("Content-Type", "application/json")
 			response := struct {
 				Data struct {
@@ -817,11 +822,15 @@ func setUpHTTPServer(
 			fmt.Printf("MockApi sending response: %v\n", response)
 			json.NewEncoder(w).Encode(&response)
 		} else if r.URL.Path == "/api/v2/git/repository/search_commits" {
+			body, _ := io.ReadAll(r.Body)
+			fmt.Printf("MockApi received body: %s\n", body)
 			w.Header().Set("Content-Type", "application/json")
 			w.Write([]byte("{}"))
 		} else if r.URL.Path == "/api/v2/git/repository/packfile" {
 			w.WriteHeader(http.StatusAccepted)
 		} else if itrEnabled && r.URL.Path == "/api/v2/ci/tests/skippable" {
+			body, _ := io.ReadAll(r.Body)
+			fmt.Printf("MockApi received body: %s\n", body)
 			w.Header().Set("Content-Type", "application/json")
 			response := skippableResponse{
 				Meta: skippableResponseMeta{
@@ -839,6 +848,8 @@ func setUpHTTPServer(
 			fmt.Printf("MockApi sending response: %v\n", response)
 			json.NewEncoder(w).Encode(&response)
 		} else if r.URL.Path == "/api/v2/test/libraries/test-management/tests" {
+			body, _ := io.ReadAll(r.Body)
+			fmt.Printf("MockApi received body: %s\n", body)
 			w.Header().Set("Content-Type", "application/json")
 			response := struct {
 				Data struct {

--- a/internal/civisibility/utils/net/client.go
+++ b/internal/civisibility/utils/net/client.go
@@ -57,6 +57,7 @@ type (
 		workingDirectory   string
 		repositoryURL      string
 		commitSha          string
+		commitMessage      string
 		branchName         string
 		testConfigurations testConfigurations
 		headers            map[string]string
@@ -248,6 +249,7 @@ func NewClientWithServiceNameAndSubdomain(serviceName, subdomain string) Client 
 		workingDirectory: ciTags[constants.CIWorkspacePath],
 		repositoryURL:    ciTags[constants.GitRepositoryURL],
 		commitSha:        ciTags[constants.GitCommitSHA],
+		commitMessage:    ciTags[constants.GitCommitMessage],
 		branchName:       bName,
 		testConfigurations: testConfigurations{
 			OsPlatform:     ciTags[constants.OSPlatform],

--- a/internal/civisibility/utils/net/test_management_tests_api.go
+++ b/internal/civisibility/utils/net/test_management_tests_api.go
@@ -30,7 +30,8 @@ type (
 
 	testManagementTestsRequestData struct {
 		RepositoryURL string `json:"repository_url"`
-		Module        string `json:"module"`
+		Module        string `json:"module,omitempty"`
+		CommitMessage string `json:"commit_message"`
 	}
 
 	testManagementTestsResponse struct {
@@ -75,6 +76,7 @@ func (c *client) GetTestManagementTests() (*TestManagementTestsResponseDataModul
 			Type: testManagementTestsRequestType,
 			Attributes: testManagementTestsRequestData{
 				RepositoryURL: c.repositoryURL,
+				CommitMessage: c.commitMessage,
 			},
 		},
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR changes the way the attempt_to_fix workflow works following the v2 spec.

**V1**: [(feat) internal/civisibility: add support for attempt_to_fix v2 workflow](https://github.com/DataDog/dd-trace-go/pull/3288)

### Motivation

https://datadoghq.atlassian.net/wiki/spaces/SDTEST/pages/4714201218/Flaky+test+management+flow

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
