### PR TITLE
gh issue template: add other discussion option

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,3 +9,6 @@ contact_links:
   - name: Feature Request (Low Priority)
     url: https://github.com/DataDog/dd-trace-go/discussions/new?category=feature-request
     about: Start a discussion about a Feature Request in GitHub discussions. This helps prioritization and allows you to provide additional information in public.
+  - name: Other Discussion (Low Priority)
+    url: https://github.com/DataDog/dd-trace-go/discussions/new
+    about: Start a new GitHub discussions about any other topic.


### PR DESCRIPTION
### What does this PR do?

Adds a catch-all "Other Discussion (Low Priority)" option to our issue creation modal.

![2025-03-12 Issues · DataDogdd-trace-go at 16 02 20@2x](https://github.com/user-attachments/assets/3ef6f411-c648-4ecf-a3fc-ad84fbd074b1)


### Motivation

Allow people to ask questions about APIs or give other feedback easily. See [2025-03-12 guild meeting notes](https://docs.google.com/document/d/1YvhcWdYWwXI51hlMyjx1Jr4kORKtdzxbc0L1Pk9SKLw/edit?tab=t.0#task=SjZ5UYmG_uyR9Hyh).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
