### PR TITLE
(fix) internal/civisibility: Fix git command to extract the source root - v2

### DIFF
--- a/internal/civisibility/utils/git.go
+++ b/internal/civisibility/utils/git.go
@@ -188,23 +188,23 @@ func getLocalGitData() (localGitData, error) {
 
 	// Extract the absolute path to the Git directory
 	log.Debug("civisibility.git: getting the absolute path to the Git directory")
-	out, err := execGitString(telemetry.NotSpecifiedCommandsType, "rev-parse", "--absolute-git-dir")
+	out, err := execGitString(telemetry.NotSpecifiedCommandsType, "rev-parse", "--show-toplevel")
 	if err == nil {
-		gitData.SourceRoot = strings.ReplaceAll(strings.Trim(string(out), "\n"), ".git", "")
+		gitData.SourceRoot = out
 	}
 
 	// Extract the repository URL
 	log.Debug("civisibility.git: getting the repository URL")
 	out, err = execGitString(telemetry.GetRepositoryCommandsType, "ls-remote", "--get-url")
 	if err == nil {
-		gitData.RepositoryURL = filterSensitiveInfo(strings.Trim(string(out), "\n"))
+		gitData.RepositoryURL = filterSensitiveInfo(out)
 	}
 
 	// Extract the current branch name
 	log.Debug("civisibility.git: getting the current branch name")
 	out, err = execGitString(telemetry.GetBranchCommandsType, "rev-parse", "--abbrev-ref", "HEAD")
 	if err == nil {
-		gitData.Branch = strings.Trim(string(out), "\n")
+		gitData.Branch = out
 	}
 
 	// Get commit details from the latest commit using git log (git log -1 --pretty='%H","%aI","%an","%ae","%cI","%cn","%ce","%B')
@@ -215,7 +215,7 @@ func getLocalGitData() (localGitData, error) {
 	}
 
 	// Split the output into individual components
-	outArray := strings.Split(string(out), "\",\"")
+	outArray := strings.Split(out, "\",\"")
 	if len(outArray) < 8 {
 		return gitData, errors.New("git log failed")
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR changes the way we extract the source root using git.

From:  `git rev-parse --absolute-git-dir`
To: `git rev-parse --show-toplevel` 

V1: [(fix) internal/civisibility: Fix git command to extract the source root](https://github.com/DataDog/dd-trace-go/pull/3306)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The current `--absolute-git-dir` doesn't work on submodules nor git worktrees

`show-toplevel` fixes that.

>--show-toplevel
Show the (by default, absolute) path of the top-level directory of the working tree. If there is no working tree, report an error.


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
