### PR TITLE
internal/telemetry: add support for submitting values at every flush

### DIFF
--- a/internal/telemetry/api.go
+++ b/internal/telemetry/api.go
@@ -162,4 +162,7 @@ type Client interface {
 	// AppStop sends the telemetry necessary to signal that the app is stopping.
 	// Preferred use via [StopApp] package level function
 	AppStop()
+
+	// AddFlushTicker adds a function that is called at each telemetry Flush. By default, every minute
+	AddFlushTicker(ticker func(Client))
 }

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -214,10 +214,11 @@ func (c *client) Flush() {
 	// We call the flushTickerFuncs before flushing the data for data sources
 	{
 		c.flushTickerFuncsMu.Lock()
+		defer c.flushTickerFuncsMu.Unlock()
+
 		for _, f := range c.flushTickerFuncs {
 			f(c)
 		}
-		c.flushTickerFuncsMu.Unlock()
 	}
 
 	payloads := make([]transport.Payload, 0, 8)

--- a/internal/telemetry/globalclient.go
+++ b/internal/telemetry/globalclient.go
@@ -212,6 +212,13 @@ func LoadIntegration(integration string) {
 	})
 }
 
+// AddFlushTicker adds a function that is called at each telemetry Flush. By default, every minute
+func AddFlushTicker(ticker func(Client)) {
+	globalClientCall(func(client Client) {
+		client.AddFlushTicker(ticker)
+	})
+}
+
 var globalClientLogLossOnce sync.Once
 
 // globalClientCall takes a function that takes a Client and calls it with the global client if it exists.

--- a/internal/telemetry/telemetrytest/mock.go
+++ b/internal/telemetry/telemetrytest/mock.go
@@ -90,4 +90,8 @@ func (m *MockClient) AppStop() {
 	m.Called()
 }
 
+func (m *MockClient) AddFlushTicker(ticker func(telemetry.Client)) {
+	m.Called(ticker)
+}
+
 var _ telemetry.Client = (*MockClient)(nil)

--- a/internal/telemetry/telemetrytest/record.go
+++ b/internal/telemetry/telemetrytest/record.go
@@ -189,6 +189,9 @@ func (r *RecordClient) AppStop() {
 	r.Stopped = true
 }
 
+func (r *RecordClient) AddFlushTicker(func(telemetry.Client)) {
+}
+
 func CheckConfig(t *testing.T, cfgs []telemetry.Configuration, key string, value any) {
 	t.Helper()
 	for _, c := range cfgs {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
