### PR TITLE
appsec: new user monitoring SDK telemetry

### DIFF
--- a/appsec/appsecv1.go
+++ b/appsec/appsecv1.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/emitter/usersec"
+	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 )
 
 // TrackUserLoginSuccessEvent sets a successful user login event, with the given
@@ -29,6 +30,8 @@ import (
 // Deprecated: use [TrackUserLoginSuccess] instead. It requires collection of
 // the user login, which is useful for detecting account takeover attacks.
 func TrackUserLoginSuccessEvent(ctx context.Context, uid string, md map[string]string, opts ...tracer.UserMonitoringOption) error {
+	telemetry.Count(telemetry.NamespaceAppSec, "sdk.event", []string{"event_type:login_success", "sdk_version:v1"}).Submit(1)
+
 	login, _, _ := getMetadata(opts)
 	return TrackUserLoginSuccess(ctx, login, uid, md, opts...)
 }
@@ -48,6 +51,8 @@ func TrackUserLoginSuccessEvent(ctx context.Context, uid string, md map[string]s
 // which is what is available during a failed login attempt, instead of the user
 // ID, which is oftern not (especially when the user does not exist).
 func TrackUserLoginFailureEvent(ctx context.Context, uid string, exists bool, md map[string]string) {
+	telemetry.Count(telemetry.NamespaceAppSec, "sdk.event", []string{"event_type:login_failure", "sdk_version:v1"}).Submit(1)
+
 	span := getRootSpan(ctx)
 	if span == nil {
 		return


### PR DESCRIPTION
Adds the new user monitoring SDK telemetry as specified by RFC-1017. This is used to track usage of the old & new APIs for user monitoring.

APPSEC-56555

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
