### PR TITLE
refactor(ddtrace/tracer): improve concurrency handling and clean up span context management

### DIFF
--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -162,14 +162,7 @@ func newSpanContext(span *Span, parent *SpanContext) *SpanContext {
 
 	context.traceID.SetLower(span.traceID)
 	if parent != nil {
-		context.traceID.SetUpper(parent.traceID.Upper())
-		context.trace = parent.trace
-		context.origin = parent.origin
-		context.errors = parent.errors
-		parent.ForeachBaggageItem(func(k, v string) bool {
-			context.setBaggageItem(k, v)
-			return true
-		})
+		context.copyFrom(parent)
 	} else if sharedinternal.BoolEnv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", true) {
 		// add 128 bit trace id, if enabled, formatted as big-endian:
 		// <32-bit unix seconds> <32 bits of zero> <64 random bits>
@@ -262,6 +255,9 @@ func (c *SpanContext) ForeachBaggageItem(handler func(k, v string) bool) {
 
 // sets the sampling priority and decision maker (based on `sampler`).
 func (c *SpanContext) setSamplingPriority(p int, sampler samplernames.SamplerName) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if c.trace == nil {
 		c.trace = newTrace()
 	}
@@ -272,7 +268,14 @@ func (c *SpanContext) setSamplingPriority(p int, sampler samplernames.SamplerNam
 }
 
 func (c *SpanContext) SamplingPriority() (p int, ok bool) {
-	if c == nil || c.trace == nil {
+	if c == nil {
+		return 0, false
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.trace == nil {
 		return 0, false
 	}
 	return c.trace.samplingPriority()
@@ -289,16 +292,35 @@ func (c *SpanContext) setBaggageItem(key, val string) {
 }
 
 func (c *SpanContext) baggageItem(key string) string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	if atomic.LoadUint32(&c.hasBaggage) == 0 {
 		return ""
 	}
-	c.mu.RLock()
-	defer c.mu.RUnlock()
 	return c.baggage[key]
 }
 
+func (c *SpanContext) copyFrom(other *SpanContext) {
+	c.mu.RLock()
+	c.traceID.SetUpper(other.traceID.Upper())
+	c.trace = other.trace
+	c.origin = other.origin
+	c.errors = other.errors
+	c.mu.RUnlock()
+
+	other.ForeachBaggageItem(func(k, v string) bool {
+		c.setBaggageItem(k, v)
+		return true
+	})
+}
+
 // finish marks this span as finished in the trace.
-func (c *SpanContext) finish() { c.trace.finishedOne(c.span) }
+func (c *SpanContext) finish() {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	c.trace.finishedOne(c.span)
+}
 
 // samplingDecision is the decision to send a trace to the agent or not.
 type samplingDecision uint32
@@ -375,10 +397,12 @@ func (t *trace) setSamplingPriority(p int, sampler samplernames.SamplerName) boo
 }
 
 func (t *trace) keep() {
+	// TODO: consider using atomic types
 	atomic.CompareAndSwapUint32((*uint32)(&t.samplingDecision), uint32(decisionNone), uint32(decisionKeep))
 }
 
 func (t *trace) drop() {
+	// TODO: consider using atomic types
 	atomic.CompareAndSwapUint32((*uint32)(&t.samplingDecision), uint32(decisionNone), uint32(decisionDrop))
 }
 
@@ -584,6 +608,17 @@ func (t *trace) finishedOne(s *Span) {
 func (t *trace) finishChunk(tr Tracer, ch *Chunk) {
 	tr.SubmitChunk(ch)
 	t.finished = 0 // important, because a buffer can be used for several flushes
+}
+
+func (t *trace) rootSpan() *Span {
+	if t == nil {
+		return nil
+	}
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	return t.root
 }
 
 // setPeerService sets the peer.service, _dd.peer.service.source, and _dd.peer.service.remapped_from

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -28,7 +28,6 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/globalconfig"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/remoteconfig"
-	"github.com/DataDog/dd-trace-go/v2/internal/samplernames"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 	"github.com/DataDog/dd-trace-go/v2/internal/traceprof"
 
@@ -919,8 +918,7 @@ func (t *tracer) sample(span *Span) {
 	}
 	sampler := t.config.sampler
 	if !sampler.Sample(span) {
-		span.context.trace.drop()
-		span.context.trace.setSamplingPriority(ext.PriorityAutoReject, samplernames.RuleRate)
+		span.drop()
 		return
 	}
 	if sampler.Rate() < 1 {


### PR DESCRIPTION
### What does this PR do?

- Added mutex locks to ensure safe concurrent access to span context and trace data.
- Replaced atomic operations with mutexes for error counting and sampling priority management.
- Introduced new methods for keeping and dropping spans to encapsulate logic and improve readability.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
