### PR TITLE
ci: Pin composite actions SHA

### DIFF
--- a/.github/actions/dd-ci-upload/action.yml
+++ b/.github/actions/dd-ci-upload/action.yml
@@ -30,7 +30,7 @@ runs:
 
     - name: Datadog CI CLI cache
       id: dd-ci-cli-cache
-      uses: actions/cache@v3
+      uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3.4.3
       with:
         path: ./datadog-ci
         key: datadog-ci-cli-${{ env.DD_CI_CLI_BUILD }}

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -7,7 +7,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
         go-version: ${{ inputs.go-version }}
         cache: false
@@ -20,7 +20,7 @@ runs:
     # perhaps network activity occasionally.
     - name: Cache go
       id: cache-go
-      uses: actions/cache@v3
+      uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3.4.3
       with:
         path: |
           /home/runner/.cache/go-build

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       - "/"
       - "/.github/actions/*"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       gh-actions-packages:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,11 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     groups:
       gh-actions-packages:
         patterns:


### PR DESCRIPTION
### Motivation

Followed up on https://github.com/DataDog/dd-trace-go/pull/3146

- Composite actions under `.github/actions/*` are not pinned
- Dependabot is only configured to scanned `.github/workflows` 

### What does this PR do?

- Pin actions under `.github/actions/*`
- Configure Dependabot to scan composite actions

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
