### PR TITLE
[v2] fix: implement single-call enforcement for Span.Finish

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -119,7 +119,7 @@ type Span struct {
 
 	pprofCtxActive  context.Context `msg:"-"` // contains pprof.WithLabel labels to tell the profiler more about this span
 	pprofCtxRestore context.Context `msg:"-"` // contains pprof.WithLabel labels of the parent span (if any) that need to be restored when this span finishes
-	sentinel        atomic.Uint32   `msg:"-"` // sentinel value to detect if Span.Finish has been called to only finish the span once
+	finishGuard     atomic.Uint32   `msg:"-"` // finishGuard value to detect if Span.Finish has been called to only finish the span once
 
 	taskEnd func() // ends execution tracer (runtime/trace) task, if started
 }
@@ -586,7 +586,7 @@ func (s *Span) Finish(opts ...FinishOption) {
 	}
 	// If Span.Finish has already been called, do nothing.
 	// In this way, we can ensure that Span.Finish is called at most once.
-	if !s.sentinel.CompareAndSwap(0, 1) {
+	if !s.finishGuard.CompareAndSwap(0, 1) {
 		return
 	}
 	t := now()

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -119,6 +119,7 @@ type Span struct {
 
 	pprofCtxActive  context.Context `msg:"-"` // contains pprof.WithLabel labels to tell the profiler more about this span
 	pprofCtxRestore context.Context `msg:"-"` // contains pprof.WithLabel labels of the parent span (if any) that need to be restored when this span finishes
+	sentinel        atomic.Uint32   `msg:"-"` // sentinel value to detect if Span.Finish has been called to only finish the span once
 
 	taskEnd func() // ends execution tracer (runtime/trace) task, if started
 }
@@ -581,6 +582,11 @@ func (s *Span) serializeSpanLinksInMeta() {
 // of its part of the tracing session.
 func (s *Span) Finish(opts ...FinishOption) {
 	if s == nil {
+		return
+	}
+	// If Span.Finish has already been called, do nothing.
+	// In this way, we can ensure that Span.Finish is called at most once.
+	if !s.sentinel.CompareAndSwap(0, 1) {
 		return
 	}
 	t := now()


### PR DESCRIPTION
### What does this PR do?

This PR adds a sentinel value to ensure that calling `Finish` on any given span will only trigger the finishing flow once.

### Motivation

A potential source of data races is when a user misuses the tracer, as finishing the same span multiple times by calling `Finish` more than once, concurrently or serially in a tight loop.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
