### PR TITLE
Add missing headers on Stats payload

### DIFF
--- a/ddtrace/tracer/transport.go
+++ b/ddtrace/tracer/transport.go
@@ -125,6 +125,9 @@ func (t *httpTransport) sendStats(p *pb.ClientStatsPayload, tracerObfuscationVer
 	if err != nil {
 		return err
 	}
+	for header, value := range t.headers {
+		req.Header.Set(header, value)
+	}
 	if tracerObfuscationVersion > 0 {
 		req.Header.Set(obfuscationVersionHeader, strconv.Itoa(tracerObfuscationVersion))
 	}

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	traceinternal "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
@@ -422,4 +423,35 @@ func TestExternalEnvironment(t *testing.T) {
 	_, err = trc.config.transport.send(p)
 	assert.NoError(err)
 	assert.True(found)
+}
+
+func TestDefaultHeaders(t *testing.T) {
+	assert := assert.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/info" {
+			return
+		}
+		assert.Equal(r.Header.Get("Datadog-Meta-Lang"), "go")
+		assert.NotEqual(r.Header.Get("Datadog-Meta-Lang-Version"), "")
+		assert.NotEqual(r.Header.Get("Datadog-Meta-Lang-Interpreter"), "")
+		assert.NotEqual(r.Header.Get("Datadog-Meta-Tracer-Version"), "")
+		assert.Equal(r.Header.Get("Content-Type"), "application/msgpack")
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	assert.NoError(err)
+	c := &http.Client{}
+	trc := newTracer(WithAgentTimeout(2), WithAgentAddr(u.Host), WithHTTPClient(c))
+	defer trc.Stop()
+
+	// Test traces endpoint
+	p, err := encode(getTestTrace(1, 1))
+	assert.NoError(err)
+	_, err = trc.config.transport.send(p)
+	assert.NoError(err)
+
+	// Now stats endpoint
+	err = trc.config.transport.sendStats(&pb.ClientStatsPayload{}, 1)
+	assert.NoError(err)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

MIrrors #3330 

Default headers were missing on Stats payloads sent to the agent. This PR ensures the same headers used on Trace Payloads are also attached to POST requests to the agent's stats endpoint.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
