### PR TITLE
internal/appsec: fix truncation span tags

### DIFF
--- a/internal/appsec/listener/waf/tags.go
+++ b/internal/appsec/listener/waf/tags.go
@@ -86,8 +86,29 @@ func AddWAFMonitoringTags(th trace.TagSetter, metrics *emitter.ContextMetrics, r
 		th.SetTag(raspTimeoutTag, stats.TimeoutRASPCount)
 	}
 
-	for reason, truncations := range stats.Truncations {
-		th.SetTag(truncationTagPrefix+string(reason), truncations)
+	addTruncationTags(th, stats)
+}
+
+// addTruncationTags adds the span tags related to the truncations
+func addTruncationTags(th trace.TagSetter, stats waf.Stats) {
+	wafMaxTruncationsMapSize := max(len(stats.Truncations), len(stats.TruncationsRASP))
+	if wafMaxTruncationsMapSize == 0 {
+		return
+	}
+
+	wafMaxTruncationsMap := make(map[waf.TruncationReason]int, wafMaxTruncationsMapSize)
+	for reason, list := range stats.Truncations {
+		wafMaxTruncationsMap[reason] = max(0, len(list))
+	}
+
+	for reason, list := range stats.TruncationsRASP {
+		wafMaxTruncationsMap[reason] = max(wafMaxTruncationsMap[reason], len(list))
+	}
+
+	for reason, count := range wafMaxTruncationsMap {
+		if count > 0 {
+			th.SetTag(truncationTagPrefix+reason.String(), count)
+		}
 	}
 }
 

--- a/internal/appsec/listener/waf/tags_test.go
+++ b/internal/appsec/listener/waf/tags_test.go
@@ -6,19 +6,24 @@
 package waf
 
 import (
+	"maps"
+	"slices"
 	"testing"
 	"time"
 
 	waf "github.com/DataDog/go-libddwaf/v3"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/trace"
 	emitter "github.com/DataDog/dd-trace-go/v2/internal/appsec/emitter/waf"
 )
 
 const (
-	wafDurationTag    = "_dd.appsec.waf.duration"
-	wafDurationExtTag = "_dd.appsec.waf.duration_ext"
+	wafDurationTag     = "_dd.appsec.waf.duration"
+	wafDurationExtTag  = "_dd.appsec.waf.duration_ext"
+	raspDurationTag    = "_dd.appsec.rasp.duration"
+	raspDurationExtTag = "_dd.appsec.rasp.duration_ext"
 )
 
 // Test that internal functions used to set span tags use the correct types
@@ -53,7 +58,22 @@ func TestTagsTypes(t *testing.T) {
 	_, ok := tags[eventRulesErrorsTag].(string)
 	require.True(t, ok)
 
-	for _, tag := range []string{eventRulesLoadedTag, eventRulesFailedTag, wafDurationTag, wafDurationExtTag, wafVersionTag, raspTimeoutTag, truncationTagPrefix + string(waf.ObjectTooDeep)} {
-		require.Contains(t, tags, tag)
+	var expectedTags = []string{
+		eventRulesLoadedTag,
+		eventRulesFailedTag,
+		eventRulesErrorsTag,
+		eventRulesVersionTag,
+		wafDurationTag,
+		wafDurationExtTag,
+		raspDurationTag,
+		raspDurationExtTag,
+		wafVersionTag,
+		raspTimeoutTag,
+		truncationTagPrefix + waf.ObjectTooDeep.String(),
+		ext.ManualKeep,
 	}
+
+	slices.Sort(expectedTags)
+
+	require.Equal(t, expectedTags, slices.Sorted(maps.Keys(tags)))
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Fix truncation span tags logic. Current truncation span tags look like `_dd.appsec.truncated.1: [100 2000 333]` while the key should be `_dd.appsec.truncated.string_length` and the value should be the maximum of the list.

### Motivation

https://docs.google.com/document/d/1D4hkC0jwwUyeo0hEQgyKP54kM1LZU98GL8MaP60tQrA/edit?pli=1&tab=t.0

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
