### PR TITLE
feat(apm): add referrer hostname as span tag

### DIFF
--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -53,6 +53,9 @@ const (
 	// HTTPClientIP sets the HTTP client IP tag.
 	HTTPClientIP = "http.client_ip"
 
+	// HTTPReferrerHostname sets the HTTP referrer hostname tag.
+	HTTPReferrerHostname = "http.referrer_hostname"
+
 	// HTTPRequestHeaders sets the HTTP request headers partial tag
 	// This tag is meant to be composed, i.e http.request.headers.headerX, http.request.headers.headerY, etc...
 	// See https://docs.datadoghq.com/tracing/trace_collection/tracing_naming_convention/#http-requests

--- a/instrumentation/httptrace/httptrace.go
+++ b/instrumentation/httptrace/httptrace.go
@@ -10,7 +10,9 @@ package httptrace
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -212,12 +214,41 @@ func URLFromRequest(r *http.Request, queryString bool) string {
 	return url
 }
 
+// extractReferrerHost extracts the host from a referrer URL
+func extractReferrerHost(referrer string) string {
+	if referrer == "" {
+		return ""
+	}
+	// Try to parse the URL
+	u, err := url.Parse(referrer)
+	if err != nil {
+		return ""
+	}
+	// Split host and port, and return only the host part
+	host, _, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		// If there's no port, just return the host
+		return u.Host
+	}
+	return host
+}
+
 // HeaderTagsFromRequest matches req headers to user-defined list of header tags
 // and creates span tags based on the header tag target and the req header value
 func HeaderTagsFromRequest(req *http.Request, headerTags instrumentation.HeaderTags) tracer.StartSpanOption {
 	var tags []struct {
 		key string
 		val string
+	}
+
+	// Handle referer header separately
+	if referer := req.Header.Get("referer"); referer != "" {
+		if host := extractReferrerHost(referer); host != "" {
+			tags = append(tags, struct {
+				key string
+				val string
+			}{ext.HTTPReferrerHostname, host})
+		}
 	}
 
 	headerTags.Iter(func(header, tag string) {

--- a/instrumentation/httptrace/httptrace_test.go
+++ b/instrumentation/httptrace/httptrace_test.go
@@ -385,3 +385,69 @@ func TestStartRequestSpanWithBaggage(t *testing.T) {
 	assert.Equal(t, "value1", spanBm["key1"])
 	assert.Equal(t, "value2", spanBm["key2"])
 }
+
+func TestExtractReferrerHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		referrer string
+		expected string
+	}{
+		{
+			name:     "valid URL with host",
+			referrer: "https://example.com/path",
+			expected: "example.com",
+		},
+		{
+			name:     "valid URL with subdomain",
+			referrer: "https://sub.example.com/path",
+			expected: "sub.example.com",
+		},
+		{
+			name:     "valid URL with port",
+			referrer: "https://example.com:8080/path",
+			expected: "example.com",
+		},
+		{
+			name:     "empty referrer",
+			referrer: "",
+			expected: "",
+		},
+		{
+			name:     "invalid URL",
+			referrer: "not a url",
+			expected: "",
+		},
+		{
+			name:     "URL without scheme",
+			referrer: "example.com/path",
+			expected: "",
+		},
+		{
+			name:     "URL with IPv6 and port",
+			referrer: "https://[2001:db8::1]:8080/path",
+			expected: "2001:db8::1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractReferrerHost(tt.referrer)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestReferrerHostSpanTag(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	r := httptest.NewRequest(http.MethodGet, "/test", nil)
+	r.Header.Set("referer", "https://example.com/path")
+
+	s, _, _ := StartRequestSpan(r, HeaderTagsFromRequest(r, internal.NewLockMap(nil)))
+	s.Finish()
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "example.com", spans[0].Tag("http.referrer_hostname"))
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Parses referrer hostname from http header when presents and adds it to span tags as http.referrer_hostname.

### Motivation

This will be used to identify frontend clients without leaking the PII which can be contained in the entire referrer.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!

main PR: https://github.com/DataDog/dd-trace-go/pull/3311
