### PR TITLE
internal/appsec: rework appsec telemetry

### DIFF
--- a/instrumentation/appsec/emitter/waf/addresses/rasp_rule_type.go
+++ b/instrumentation/appsec/emitter/waf/addresses/rasp_rule_type.go
@@ -38,7 +38,7 @@ func (r RASPRuleType) String() string {
 	case RASPRuleTypeCMDI:
 		return "command_injection"
 	}
-	return ""
+	return "unknown()"
 }
 
 // RASPRuleTypeFromAddressSet returns the RASPRuleType for the given address set if it has a RASP address.

--- a/instrumentation/appsec/emitter/waf/addresses/rasp_rule_type.go
+++ b/instrumentation/appsec/emitter/waf/addresses/rasp_rule_type.go
@@ -6,31 +6,45 @@
 package addresses
 
 import (
+	"math"
+
 	waf "github.com/DataDog/go-libddwaf/v3"
 )
 
-type RASPRuleType string
+type RASPRuleType uint8
 
 const (
-	RASPRuleTypeLFI  RASPRuleType = "lfi"
-	RASPRuleTypeSSRF RASPRuleType = "ssrf"
-	RASPRuleTypeSQLI RASPRuleType = "sql_injection"
-	RASPRuleTypeCMDI RASPRuleType = "command_injection"
+	RASPRuleTypeLFI RASPRuleType = iota
+	RASPRuleTypeSSRF
+	RASPRuleTypeSQLI
+	RASPRuleTypeCMDI
 )
 
-func RASPRuleTypes() []RASPRuleType {
-	return []RASPRuleType{
-		RASPRuleTypeLFI,
-		RASPRuleTypeSSRF,
-		RASPRuleTypeSQLI,
-		RASPRuleTypeCMDI,
+var RASPRuleTypes = [...]RASPRuleType{
+	RASPRuleTypeLFI,
+	RASPRuleTypeSSRF,
+	RASPRuleTypeSQLI,
+	RASPRuleTypeCMDI,
+}
+
+func (r RASPRuleType) String() string {
+	switch r {
+	case RASPRuleTypeLFI:
+		return "lfi"
+	case RASPRuleTypeSSRF:
+		return "ssrf"
+	case RASPRuleTypeSQLI:
+		return "sql_injection"
+	case RASPRuleTypeCMDI:
+		return "command_injection"
 	}
+	return ""
 }
 
 // RASPRuleTypeFromAddressSet returns the RASPRuleType for the given address set if it has a RASP address.
 func RASPRuleTypeFromAddressSet(addressSet waf.RunAddressData) (RASPRuleType, bool) {
 	if addressSet.Scope != waf.RASPScope {
-		return "", false
+		return math.MaxUint8, false
 	}
 
 	for address := range addressSet.Ephemeral {
@@ -46,5 +60,5 @@ func RASPRuleTypeFromAddressSet(addressSet waf.RunAddressData) (RASPRuleType, bo
 		}
 	}
 
-	return "", false
+	return math.MaxUint8, false
 }

--- a/internal/appsec/config/config.go
+++ b/internal/appsec/config/config.go
@@ -52,7 +52,7 @@ type StartConfig struct {
 	RC *remoteconfig.ClientConfig
 	// IsEnabled is a function that determines whether AppSec is enabled or not. When unset, the
 	// default [IsEnabled] function is used.
-	EnablementMode func() (EnablementMode, Origin, error)
+	EnablementMode func() (EnablementMode, telemetry.Origin, error)
 	// MetaStructAvailable is true if meta struct is supported by the trace agent.
 	MetaStructAvailable bool
 
@@ -70,30 +70,19 @@ const (
 	ForcedOn EnablementMode = 1
 )
 
-type Origin uint8
-
-const (
-	// OriginDefault is the origin of configuration values not explicitly set by the user in any way.
-	OriginDefault Origin = iota
-	// OriginEnvVar is the origin of configuration values set through environment variables.
-	OriginEnvVar
-	// OriginExplicitOption is the origin of configuration values set though explicit options in code.
-	OriginExplicitOption
-)
-
 func NewStartConfig(opts ...StartOption) *StartConfig {
 	c := &StartConfig{
-		EnablementMode: func() (mode EnablementMode, origin Origin, err error) {
+		EnablementMode: func() (mode EnablementMode, origin telemetry.Origin, err error) {
 			enabled, set, err := IsEnabledByEnvironment()
 			if set {
-				origin = OriginEnvVar
+				origin = telemetry.OriginEnvVar
 				if enabled {
 					mode = ForcedOn
 				} else {
 					mode = ForcedOff
 				}
 			} else {
-				origin = OriginDefault
+				origin = telemetry.OriginDefault
 				mode = RCStandby
 			}
 			return mode, origin, err
@@ -109,8 +98,8 @@ func NewStartConfig(opts ...StartOption) *StartConfig {
 // implemented by [IsEnabledByEnvironment].
 func WithEnablementMode(mode EnablementMode) StartOption {
 	return func(c *StartConfig) {
-		c.EnablementMode = func() (EnablementMode, Origin, error) {
-			return mode, OriginExplicitOption, nil
+		c.EnablementMode = func() (EnablementMode, telemetry.Origin, error) {
+			return mode, telemetry.OriginCode, nil
 		}
 	}
 }

--- a/internal/appsec/listener/waf/tags.go
+++ b/internal/appsec/listener/waf/tags.go
@@ -7,6 +7,7 @@ package waf
 
 import (
 	"encoding/json"
+	"slices"
 	"time"
 
 	waf "github.com/DataDog/go-libddwaf/v3"
@@ -98,11 +99,11 @@ func addTruncationTags(th trace.TagSetter, stats waf.Stats) {
 
 	wafMaxTruncationsMap := make(map[waf.TruncationReason]int, wafMaxTruncationsMapSize)
 	for reason, list := range stats.Truncations {
-		wafMaxTruncationsMap[reason] = max(0, len(list))
+		wafMaxTruncationsMap[reason] = slices.Max(list)
 	}
 
 	for reason, list := range stats.TruncationsRASP {
-		wafMaxTruncationsMap[reason] = max(wafMaxTruncationsMap[reason], len(list))
+		wafMaxTruncationsMap[reason] = max(wafMaxTruncationsMap[reason], slices.Max(list))
 	}
 
 	for reason, count := range wafMaxTruncationsMap {

--- a/internal/appsec/remoteconfig_test.go
+++ b/internal/appsec/remoteconfig_test.go
@@ -87,7 +87,7 @@ func TestASMFeaturesCallback(t *testing.T) {
 			defer a.stop()
 			require.NotNil(t, a)
 			if tc.startBefore {
-				a.start(nil)
+				a.start()
 			}
 			require.Equal(t, tc.startBefore, a.started)
 			a.handleASMFeatures(tc.update)

--- a/internal/appsec/telemetry_nocgo.go
+++ b/internal/appsec/telemetry_nocgo.go
@@ -1,10 +1,10 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016 Datadog, Inc.
+// Copyright 2025 Datadog, Inc.
 
-//go:build cgo
+//go:build !cgo
 
 package appsec
 
-const cgoEnabled = true
+const cgoEnabled = false

--- a/internal/appsec/waf_test.go
+++ b/internal/appsec/waf_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/DataDog/appsec-internal-go/apisec"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/stretchr/testify/mock"
+
 	pAppsec "github.com/DataDog/dd-trace-go/v2/appsec"
 	"github.com/DataDog/dd-trace-go/v2/appsec/events"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
@@ -35,7 +37,6 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/instrumentation/testutils"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/config"
-	"github.com/stretchr/testify/mock"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry/telemetrytest"
 
@@ -993,9 +994,6 @@ func TestAttackerFingerprinting(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.name == "CustomRule" {
-				t.Skip("Custom rule is not working on v2")
-			}
 			mt := mocktracer.Start()
 			defer mt.Stop()
 

--- a/internal/appsec/waf_test.go
+++ b/internal/appsec/waf_test.go
@@ -18,13 +18,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DataDog/appsec-internal-go/apisec"
 	internal "github.com/DataDog/appsec-internal-go/appsec"
 	waf "github.com/DataDog/go-libddwaf/v3"
-
-	"github.com/DataDog/appsec-internal-go/apisec"
 	"github.com/stretchr/testify/assert"
-
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	pAppsec "github.com/DataDog/dd-trace-go/v2/appsec"
 	"github.com/DataDog/dd-trace-go/v2/appsec/events"
@@ -39,8 +38,6 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry/telemetrytest"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestCustomRules(t *testing.T) {

--- a/internal/appsec/waf_test.go
+++ b/internal/appsec/waf_test.go
@@ -107,6 +107,7 @@ func TestCustomRules(t *testing.T) {
 				"waf_error:false",
 				"waf_version:" + waf.Version(),
 				"event_rules_version:1.4.2",
+				"input_truncated:false",
 			}).Get())
 		})
 	}
@@ -466,6 +467,7 @@ func TestBlocking(t *testing.T) {
 				"waf_error:false",
 				"waf_version:" + waf.Version(),
 				"event_rules_version:1.4.2",
+				"input_truncated:false",
 			}).Get())
 		})
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

- [x] Fix truncation metrics count that were not using a bitfield before
- [x] Add more tags to the telemetry `rasp.timeout` metric.
- [x] Change the `RASPRuleType` type from string to uint8 to make arrays of static size and use them as a dictionnary
- [x] in `waf.HandleMetrics` replace a lot of makes with keys being `RASPRuleType` with an array
- [x] Order metrics by their frequency of access and using this, replace some of the map generated ahead of time by lazily generated maps using `xsync.MapOf`
- [x] Rework the appsec start telemetry by simplyfing it
- [x] Remove the `config.Origin` type and replace it by the more general purpose `telemetry.Origin` (That I am thinking of promoting to the package `internal/globalconfig` :thinking: )  

### Motivation



### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
