### PR TITLE
chore: add tracing macrobenchmark with runtime metrics enabled

### DIFF
--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -87,6 +87,16 @@ go123-only-trace:
     ENABLE_APPSEC: "false"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
 
+go123-only-trace-with-runtime-metrics:
+  extends: .go123-benchmarks
+  variables:
+    ENABLE_DDPROF: "false"
+    ENABLE_TRACING: "true"
+    ENABLE_PROFILING: "false"
+    ENABLE_APPSEC: "false"
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
+    DD_RUNTIME_METRICS_ENABLED: "true"
+
 go123-only-profile:
   extends: .go123-benchmarks
   variables:
@@ -140,6 +150,16 @@ go124-only-trace:
     ENABLE_PROFILING: "false"
     ENABLE_APPSEC: "false"
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
+
+go124-only-trace-with-runtime-metrics:
+  extends: .go124-benchmarks
+  variables:
+    ENABLE_DDPROF: "false"
+    ENABLE_TRACING: "true"
+    ENABLE_PROFILING: "false"
+    ENABLE_APPSEC: "false"
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
+    DD_RUNTIME_METRICS_ENABLED: "true"
 
 go124-only-profile:
   extends: .go124-benchmarks


### PR DESCRIPTION
### What does this PR do?

Adds a new macrobenchmark configuration that enables only tracing and runtime metrics.

### Motivation
We are investigating turning on runtime metrics by default. This parallel macrobenchmark configuration will help us understand the relative performance overhead of enabling the feature, so we can ensure that the feature overhead is acceptable.

### Reviewer's Checklist
- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
