### PR TITLE
appsec: set HTTP header span tags even if WAF has no interest in them

### DIFF
--- a/internal/appsec/features.go
+++ b/internal/appsec/features.go
@@ -67,10 +67,10 @@ func (a *appsec) SwapRootOperation() error {
 	a.features = newFeatures
 
 	if len(oldFeatures) > 0 {
-		log.Debug("appsec: stopping the following features: %v", oldFeatures)
+		log.Debug("appsec: stopping the following features: %q", oldFeatures)
 	}
 	if len(newFeatures) > 0 {
-		log.Debug("appsec: starting the following features: %v", newFeatures)
+		log.Debug("appsec: starting the following features: %q", newFeatures)
 	}
 
 	dyngo.SwapRootOperation(newRoot)

--- a/internal/appsec/listener/httpsec/http.go
+++ b/internal/appsec/listener/httpsec/http.go
@@ -7,6 +7,7 @@ package httpsec
 
 import (
 	"math/rand"
+	"net/netip"
 
 	internal "github.com/DataDog/appsec-internal-go/appsec"
 
@@ -37,8 +38,13 @@ func NewHTTPSecFeature(config *config.Config, rootOp dyngo.Operation) (listener.
 		addresses.ServerRequestPathParamsAddr,
 		addresses.ServerRequestBodyAddr,
 		addresses.ServerResponseStatusAddr,
-		addresses.ServerResponseHeadersNoCookiesAddr) {
-		return nil, nil
+		addresses.ServerResponseHeadersNoCookiesAddr,
+		addresses.ClientIPAddr,
+	) {
+		// We extract headers even when the security features are not enabled...
+		feature := &BasicFeature{}
+		dyngo.On(rootOp, feature.OnRequest)
+		return feature, nil
 	}
 
 	feature := &Feature{
@@ -51,14 +57,7 @@ func NewHTTPSecFeature(config *config.Config, rootOp dyngo.Operation) (listener.
 }
 
 func (feature *Feature) OnRequest(op *httpsec.HandlerOperation, args httpsec.HandlerOperationArgs) {
-	tags, ip := ClientIPTags(args.Headers, true, args.RemoteAddr)
-	log.Debug("appsec: http client ip detection returned `%s` given the http headers `%v`", ip, args.Headers)
-
-	op.SetStringTags(tags)
-	headers := headersRemoveCookies(args.Headers)
-	headers["host"] = []string{args.Host}
-
-	setRequestHeadersTags(op, headers)
+	headers, ip := extractHeaders(op, args)
 
 	op.Run(op,
 		addresses.NewAddressesBuilder().
@@ -92,4 +91,29 @@ func (feature *Feature) OnResponse(op *httpsec.HandlerOperation, resp httpsec.Ha
 // allows extracting schemas
 func (feature *Feature) canExtractSchemas() bool {
 	return feature.APISec.Enabled && feature.APISec.SampleRate >= rand.Float64()
+}
+
+type BasicFeature struct{}
+
+func (*BasicFeature) String() string {
+	return "HTTP Header Extraction"
+}
+
+func (*BasicFeature) Stop() {}
+
+func (*BasicFeature) OnRequest(op *httpsec.HandlerOperation, args httpsec.HandlerOperationArgs) {
+	_, _ = extractHeaders(op, args)
+}
+
+func extractHeaders(op *httpsec.HandlerOperation, args httpsec.HandlerOperationArgs) (map[string][]string, netip.Addr) {
+	tags, ip := ClientIPTags(args.Headers, true, args.RemoteAddr)
+	log.Debug("appsec: http client ip detection returned `%s` given the http headers `%v`", ip, args.Headers)
+
+	op.SetStringTags(tags)
+	headers := headersRemoveCookies(args.Headers)
+	headers["host"] = []string{args.Host}
+
+	setRequestHeadersTags(op, headers)
+
+	return headers, ip
 }


### PR DESCRIPTION
### What does this PR do?

This registers a "basic HTTP" feature that does the HTTP header extraction and tag setting when the full-on security implementation is not enabled; so that the headers are always collected.

### Motivation

Some products rely on the presence of the HTTP header span tags to be collected. Currently, these are only collected if the WAF is interested in any of the HTTP server addresses; but if that is not the case, these addresses are not set. This is cause System Tests for the ATO SDK to fail as the feature assumes `http.client_ip` is present.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
