### PR TITLE
contrib/envoyproxy: fix grpc error "context cancelled"

### DIFF
--- a/contrib/envoyproxy/go-control-plane/envoy.go
+++ b/contrib/envoyproxy/go-control-plane/envoy.go
@@ -145,6 +145,11 @@ func (s *appsecEnvoyExternalProcessorServer) Process(processServer envoyextproc.
 			return status.Errorf(codes.Unknown, "Error sending response (probably because of an Envoy timeout): %v", err)
 		}
 
+		if currentRequest == nil {
+			instr.Logger().Debug("external_processing: request fully analyzed, end the stream")
+			return nil
+		}
+
 		if !blocked {
 			continue
 		}

--- a/contrib/envoyproxy/go-control-plane/envoy_test.go
+++ b/contrib/envoyproxy/go-control-plane/envoy_test.go
@@ -638,7 +638,6 @@ func end2EndStreamRequest(t *testing.T, stream envoyextproc.ExternalProcessor_Pr
 			},
 		},
 	})
-	require.NoError(t, err)
 
 	// The stream should now be closed
 	_, err = stream.Recv()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Fix errors that can be detected with the grpc integration.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

When creating a Rapid service that implements an Envoy integration to be used in Datadog backend for dogfooding, the grpc server is instrumented. Some "context cancelled" error where reported by the grpc service of this new Rapid service. This errors where pop-ing up because the integration could wait for more messages even if we know that the request won't be processed anymore.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
