### PR TITLE
orchestrion: extend dd:span to support echo.Context

### DIFF
--- a/ddtrace/tracer/orchestrion.yml
+++ b/ddtrace/tracer/orchestrion.yml
@@ -76,12 +76,17 @@ aspects:
           template: |-
             {{- $ctx := .Function.ArgumentOfType "context.Context" -}}
             {{- $req := .Function.ArgumentOfType "*net/http.Request" -}}
+            {{- $echoCtx := .Function.ArgumentOfType "echo.Context" -}}
             {{- if (eq $ctx "") -}}
               {{- $ctx = "ctx" -}}
               ctx := {{- with $req -}}
                 {{ $req }}.Context()
               {{- else -}}
-                context.TODO()
+                {{- with $echoCtx -}}
+                  {{ $echoCtx }}.Request().Context()
+                {{- else -}}
+                  context.TODO()
+                {{- end -}}
               {{- end }}
             {{ end -}}
 
@@ -109,6 +114,10 @@ aspects:
             )
             {{- with $req }}
               {{ $req }} = {{ $req }}.WithContext({{ $ctx }})
+            {{- else -}}
+              {{- with $echoCtx }}
+                {{ $echoCtx }}.SetRequest({{ $echoCtx }}.Request().WithContext({{ $ctx }}))
+              {{- end -}}
             {{- end }}
 
             {{ with .Function.ResultOfType "error" -}}


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Previously, the `//dd:span` integration was limited to functions that accepted a
`context.Context` or `*http.Request` parameter. As many frameworks like Echo (using `echo.Context`)
require additional handling, users had to add manual tracing.

This improvement specifically targets `echo.Context` support to streamline the process
and reduce boilerplate code.

However, I do not believe that this approach is scalable. If you are considering extending
the support of `//dd:span` to a broader range of function signatures, I would appreciate it if
alternative methods could be discussed.

Related discussions:
- https://github.com/DataDog/orchestrion/discussions/539
- https://github.com/DataDog/dd-trace-go/discussions/3333

### Reviewer's Checklist
- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.

