### PR TITLE
contrib/internal/graphql: rename location -> locations

### DIFF
--- a/contrib/graphql-go/graphql/graphql_test.go
+++ b/contrib/graphql-go/graphql/graphql_test.go
@@ -250,7 +250,7 @@ func TestErrorsAsSpanEvents(t *testing.T) {
 	assert.Equal(t, map[string]any{
 		"message":          "test error",
 		"path":             []string{"withError"},
-		"location":         []string{"1:3"},
+		"locations":        []string{"1:3"},
 		"stacktrace":       evt.Config.Attributes["stacktrace"],
 		"type":             "gqlerrors.FormattedError",
 		"extensions.str":   "1",

--- a/contrib/internal/graphql/graphql.go
+++ b/contrib/internal/graphql/graphql.go
@@ -81,7 +81,7 @@ func errToSpanEventAttributes(gErr Error, errExtensions []string) map[string]any
 		"stacktrace": takeStacktrace(0, 0),
 	}
 	if locs := parseErrLocations(gErr.Locations); len(locs) > 0 {
-		res["location"] = locs
+		res["locations"] = locs
 	}
 	if errPath := parseErrPath(gErr.Path); len(errPath) > 0 {
 		res["path"] = errPath

--- a/contrib/internal/graphql/graphql_test.go
+++ b/contrib/internal/graphql/graphql_test.go
@@ -73,7 +73,7 @@ func TestAddErrorsAsSpanEvents(t *testing.T) {
 	wantAttrs1 := map[string]any{
 		"message":         "message 1",
 		"type":            "*errors.errorString",
-		"location":        []string{"1:2", "100:200"},
+		"locations":       []string{"1:2", "100:200"},
 		"stacktrace":      events[0].Config.Attributes["stacktrace"],
 		"path":            []string{"1", "2", "3", "4", "5", "6"},
 		"extensions.ext1": "ext1",
@@ -88,7 +88,7 @@ func TestAddErrorsAsSpanEvents(t *testing.T) {
 	wantAttrs2 := map[string]any{
 		"message":         "message 2",
 		"type":            "*errors.errorString",
-		"location":        []string{"2:3", "200:300"},
+		"locations":       []string{"2:3", "200:300"},
 		"stacktrace":      events[1].Config.Attributes["stacktrace"],
 		"path":            []string{"1", "2", "3", "4", "5", "6"},
 		"extensions.ext1": "ext1",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Fix typo in the graphql span events (the correct name is `locations`, not `location`).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
