### PR TITLE
chore(internal/log): add benchmark for logging performance

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -284,16 +284,23 @@ func flushLocked() {
 }
 
 func printMsg(lvl Level, format string, a ...interface{}) {
-	msg := fmt.Sprintf("%s %s: %s", prefixMsg, lvl, fmt.Sprintf(format, a...))
+	var b strings.Builder
+	b.Grow(len(prefixMsg) + 1 + len(lvl.String()) + 2 + len(format))
+	b.WriteString(prefixMsg)
+	b.WriteString(" ")
+	b.WriteString(lvl.String())
+	b.WriteString(": ")
+	b.WriteString(fmt.Sprintf(format, a...))
 	mu.RLock()
 	if ll, ok := logger.(interface {
 		LogL(lvl Level, msg string)
 	}); !ok {
-		logger.Log(msg)
+		logger.Log(b.String())
 	} else {
-		ll.LogL(lvl, msg)
+		ll.LogL(lvl, b.String())
 	}
 	mu.RUnlock()
+	b.Reset()
 }
 
 type defaultLogger struct{ l *log.Logger }

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -278,3 +278,11 @@ func containsMessage(lvl, m string, lines []string) bool {
 	}
 	return false
 }
+
+func BenchmarkLog(b *testing.B) {
+	UseLogger(DiscardLogger{})
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		Warn("test")
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Reduces usage of `fmt.Sprintf` to 

### Motivation

Optimizes our logger to reduce memory allocations. From:

```
BenchmarkLog-10    	  367110	      3268 ns/op	     246 B/op	       5 allocs/op
```

To:

```
BenchmarkLog-10    	  652357	      1787 ns/op	     120 B/op	       2 allocs/op
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
