### PR TITLE
[docs] Discourage use of Sprintf in CONTRIBUTING.md 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,13 @@ To run golangci-lint locally:
 docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.63.3 golangci-lint run -v --timeout 5m
 ```
 
+### Code quality
+
+#### Favor string concatenation and string builders over fmt.Sprintf and its variants
+
+[`fmt.Sprintf`](https://pkg.go.dev/fmt#Sprintf) can introduce unnecessary overhead when building a string. Favor simple string concatenation, `a + "b" + c`, or [string builders](https://pkg.go.dev/strings#Builder) over Sprintf when possible, especially in hot paths. 
+Sample PR: https://github.com/DataDog/dd-trace-go/pull/3365
+
 ### Integrations
 
 Please view our contrib [README.md](contrib/README.md) for information on integrations. If you need support for a new integration, please file an issue to discuss before opening a PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.63.3 golangci-l
 
 #### Favor string concatenation and string builders over fmt.Sprintf and its variants
 
-fmt.Sprintf(https://pkg.go.dev/fmt#Sprintf) can introduce unnecessary overhead when building a string. Favor simple string concatenation, `a + "b" + c`, or [string builders](https://pkg.go.dev/strings#Builder) over `fmt.Sprintf` when possible, especially in hot paths. 
+[fmt.Sprintf](https://pkg.go.dev/fmt#Sprintf) can introduce unnecessary overhead when building a string. Favor simple string concatenation, `a + "b" + c`, or [string builders](https://pkg.go.dev/strings#Builder) over `fmt.Sprintf` when possible, especially in hot paths. 
 Sample PR: https://github.com/DataDog/dd-trace-go/pull/3365
 
 ### Integrations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.63.3 golangci-l
 
 #### Favor string concatenation and string builders over fmt.Sprintf and its variants
 
-[fmt.Sprintf](https://pkg.go.dev/fmt#Sprintf) can introduce unnecessary overhead when building a string. Favor simple string concatenation, `a + "b" + c`, or [string builders](https://pkg.go.dev/strings#Builder) over `fmt.Sprintf` when possible, especially in hot paths. 
+[fmt.Sprintf](https://pkg.go.dev/fmt#Sprintf) can introduce unnecessary overhead when building a string. Favor [string builders](https://pkg.go.dev/strings#Builder), or simple string concatenation, `a + "b" + c` over `fmt.Sprintf` when possible, especially in hot paths. 
 Sample PR: https://github.com/DataDog/dd-trace-go/pull/3365
 
 ### Integrations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.63.3 golangci-l
 
 #### Favor string concatenation and string builders over fmt.Sprintf and its variants
 
-[`fmt.Sprintf`](https://pkg.go.dev/fmt#Sprintf) can introduce unnecessary overhead when building a string. Favor simple string concatenation, `a + "b" + c`, or [string builders](https://pkg.go.dev/strings#Builder) over Sprintf when possible, especially in hot paths. 
+fmt.Sprintf(https://pkg.go.dev/fmt#Sprintf) can introduce unnecessary overhead when building a string. Favor simple string concatenation, `a + "b" + c`, or [string builders](https://pkg.go.dev/strings#Builder) over `fmt.Sprintf` when possible, especially in hot paths. 
 Sample PR: https://github.com/DataDog/dd-trace-go/pull/3365
 
 ### Integrations


### PR DESCRIPTION
### What does this PR do?

Introduces a new Code Quality section in CONTRIBUTING.md which calls out using other methods over Sprintf, for perf reasons.

### Motivation
Ensure contributors are aware of this suggestion.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
