### PR TITLE
contrib/log/slog: fix orchestrion aspect

### DIFF
--- a/contrib/log/slog/orchestrion.yml
+++ b/contrib/log/slog/orchestrion.yml
@@ -13,20 +13,20 @@ meta:
 aspects:
   - id: New
     join-point:
-      function-call: log/slog.New
+      all-of:
+        - import-path: log/slog
+        - function-body:
+            function:
+              - name: New
     advice:
-      # We are injecting around use of a standard library package, so we are
-      # being extra careful to avoid creating a new compile-time dependency arc,
-      # as it would be very easy for a dependency of dd-trace-go to suddenly
-      # create a cycle.
       - inject-declarations:
-          imports:
-            slog: log/slog
+          # We need to use go:linkname to refer to a number of declarations in order to avoid creating
+          # circular dependencies, as these features have transitive dependencies on `log/slog`...
           links:
             - github.com/DataDog/dd-trace-go/contrib/log/slog/v2
           template: |-
             //go:linkname __dd_slogtrace_WrapHandler github.com/DataDog/dd-trace-go/contrib/log/slog/v2.WrapHandler
-            func __dd_slogtrace_WrapHandler(slog.Handler) slog.Handler
-      - wrap-expression:
+            func __dd_slogtrace_WrapHandler(Handler) Handler
+      - prepend-statements:
           template: |-
-            {{ .AST.Fun }}(__dd_slogtrace_WrapHandler({{ index .AST.Args 0 }}))
+            {{ .Function.Argument 0 }} = __dd_slogtrace_WrapHandler({{ .Function.Argument 0 }})

--- a/internal/orchestrion/_integration/slog/slog.go
+++ b/internal/orchestrion/_integration/slog/slog.go
@@ -24,12 +24,13 @@ type TestCase struct {
 
 func (tc *TestCase) Setup(context.Context, *testing.T) {
 	tc.logs = new(bytes.Buffer)
-	tc.logger = slog.New(
-		slog.NewTextHandler(
-			tc.logs,
-			&slog.HandlerOptions{Level: slog.LevelDebug},
-		),
+	handler := slog.NewTextHandler(
+		tc.logs,
+		&slog.HandlerOptions{Level: slog.LevelDebug},
 	)
+	tc.logger = slog.New(handler)
+	// call slog.New again to trigger possible errors in the aspect
+	slog.New(handler)
 }
 
 //dd:span


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
contrib/log/slog: fix orchestrion aspect by changing the aspect to instrument library-side.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->
We introduced a bug in https://github.com/DataDog/dd-trace-go/pull/3376 that triggered the following error:

```
# cloud.google.com/go/compute/metadata
<generated>:4: __dd_slogtrace_WrapHandler redeclared in this block
	<generated>:1[/tmp/go-build1833941632/b861/orchestrion/src/cloud.google.com/go/compute/metadata/metadata.go:894:6]: other declaration of __dd_slogtrace_WrapHandler
exit status 2
# github.com/googleapis/gax-go/v2/internallog/internal
<generated>:4: __dd_slogtrace_WrapHandler redeclared in this block
	<generated>:1[/tmp/go-build1833941632/b876/orchestrion/src/github.com/googleapis/gax-go/v2/internallog/internal/internal.go:154:6]: other declaration of __dd_slogtrace_WrapHandler
exit status 2
✖  confluent-kafka-go.v1 (12.552s) (-test.shuffle 1743754855488201333)
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
