### PR TITLE
tracer: Log a warning on NoopTracer.StartSpan()

### DIFF
--- a/ddtrace/tracer/noop.go
+++ b/ddtrace/tracer/noop.go
@@ -5,6 +5,8 @@
 
 package tracer
 
+import "github.com/DataDog/dd-trace-go/v2/internal/log"
+
 var _ Tracer = (*NoopTracer)(nil)
 
 // NoopTracer is an implementation of Tracer that is a no-op.
@@ -12,6 +14,7 @@ type NoopTracer struct{}
 
 // StartSpan implements Tracer.
 func (NoopTracer) StartSpan(_ string, _ ...StartSpanOption) *Span {
+	log.Warn("Tracer must be started before starting a span; Review the docs for more information: https://docs.datadoghq.com/tracing/trace_collection/library_config/go/")
 	return nil
 }
 

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -6,6 +6,7 @@
 package tracer
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/binary"
@@ -13,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	llog "log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2737,4 +2739,30 @@ func TestPprofLabels(t *testing.T) {
 		span.Finish()
 		wasteC(time.Second)
 	})
+}
+
+func TestNoopTracerStartSpan(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Failed to create pipe: %v", err)
+	}
+
+	undo := log.UseLogger(customLogger{l: llog.New(w, "", llog.LstdFlags)})
+	defer undo()
+
+	StartSpan("abcd")
+
+	w.Close()
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+
+	log := buf.String()
+	expected := "Tracer must be started before starting a span"
+	assert.Contains(t, log, expected)
+}
+
+type customLogger struct{ l *llog.Logger }
+
+func (c customLogger) Log(msg string) {
+	c.l.Print(msg)
 }

--- a/instrumentation/httptrace/httptrace_test.go
+++ b/instrumentation/httptrace/httptrace_test.go
@@ -357,6 +357,7 @@ func BenchmarkStartRequestSpan(b *testing.B) {
 		b.Errorf("Failed to create request: %v", err)
 		return
 	}
+	log.UseLogger(log.DiscardLogger{})
 	opts := []tracer.StartSpanOption{
 		tracer.ServiceName("SomeService"),
 		tracer.ResourceName("SomeResource"),


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
**NOTE**: This PR cherry-picks a commit that was previously reverted in v2-dev due to test failures.
### What does this PR do?
Logs a warning about calling `tracer.Start` when `NoopTracer.StartSpan` is invoked.

### Motivation
Users commonly forget to call `tracer.Start` before generating spans with a contrib or the trace API. The tracer must be running in order to collect the spans, so this warning message should direct the user to the necessary steps and effectively prevent against this common customer escalation.

### Background
Until `tracer.Start` is invoked, the `globaltracer` object is set to `NoopTracer`. It doesn't change to `tracer` until `tracer.Start` is run. So any time the `StartSpan` method is invoked on the `NoopTracer`, we know that `tracer.Start` has not yet been called.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
