### PR TITLE
(fix) internal/civisibility: impacted tests test

### DIFF
--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -327,8 +327,12 @@ func runFlakyTestRetriesWithEarlyFlakyTestDetectionTests(m *testing.M, impactedT
 
 	// set impacted tests variables
 	if impactedTests {
-		utils.AddCITags(constants.GitPrBaseCommit, "e5cfb7b3dd02d4116b9dd3dd2dd4e39d11e0b61d")
-		utils.AddCITags(constants.GitPrBaseBranch, "main")
+		// set the commit sha to a known value to always have the same git diff
+		// 3808532bc719ca418b938afb680246109768f343 (feat) internal/civisibility: impacted tests (#3389)
+		// ...
+		// b97e7cbb464aef26da8cb5c07a225f7a144f26a4 v2.0.0 (#2427)
+		utils.AddCITags(constants.GitPrBaseCommit, "b97e7cbb464aef26da8cb5c07a225f7a144f26a4")
+		utils.AddCITags(constants.GitHeadCommit, "3808532bc719ca418b938afb680246109768f343")
 	}
 
 	// initialize the mock tracer for doing assertions on the finished spans

--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -328,11 +328,18 @@ func runFlakyTestRetriesWithEarlyFlakyTestDetectionTests(m *testing.M, impactedT
 	// set impacted tests variables
 	if impactedTests {
 		// set the commit sha to a known value to always have the same git diff
+		base := "b97e7cbb464aef26da8cb5c07a225f7a144f26a4"
+		head := "3808532bc719ca418b938afb680246109768f343"
 		// 3808532bc719ca418b938afb680246109768f343 (feat) internal/civisibility: impacted tests (#3389)
 		// ...
 		// b97e7cbb464aef26da8cb5c07a225f7a144f26a4 v2.0.0 (#2427)
-		utils.AddCITags(constants.GitPrBaseCommit, "b97e7cbb464aef26da8cb5c07a225f7a144f26a4")
-		utils.AddCITags(constants.GitHeadCommit, "3808532bc719ca418b938afb680246109768f343")
+
+		// let's make sure we have both shas available
+		_ = exec.Command("git", "fetch", "origin", base).Run()
+		_ = exec.Command("git", "fetch", "origin", head).Run()
+
+		utils.AddCITags(constants.GitPrBaseCommit, base)
+		utils.AddCITags(constants.GitHeadCommit, head)
 	}
 
 	// initialize the mock tracer for doing assertions on the finished spans


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This fixes the impacted tests test by using two well known shas, allowing us to have a deterministic git diff in every run.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Currently it depends on a sha from another branch (v2-dev) and the current sha, so the git diff would behave different in every run (different current shas while the git history increases).

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
