### PR TITLE
(feat) internal/civisibility: Improve additional features integrations.

### DIFF
--- a/internal/civisibility/constants/test_tags.go
+++ b/internal/civisibility/constants/test_tags.go
@@ -158,3 +158,23 @@ const (
 	// This constant is used to tag traces indicating that the type of test is a benchmark.
 	TestTypeBenchmark = "benchmark"
 )
+
+// Retry reasons
+const (
+	// AttemptToFixRetryReason indicates that the test is retried due to an attempt to fix.
+	AttemptToFixRetryReason = "attempt_to_fix"
+
+	// EarlyFlakeDetectionRetryReason indicates that the test is retried due to early flake detection.
+	EarlyFlakeDetectionRetryReason = "early_flake_detection"
+
+	// AutoTestRetriesRetryReason indicates that the test is retried due to auto test retries.
+	AutoTestRetriesRetryReason = "auto_test_retry"
+
+	// TestManagementRetryReason indicates that we don't know the retry reason.
+	UnknownRetryReason = "unknown"
+)
+
+const (
+	// TestDisabledSkipReason indicates the skip reason for a test that is disabled.
+	TestDisabledSkipReason = "Flaky test is disabled by Datadog"
+)

--- a/internal/civisibility/constants/test_tags.go
+++ b/internal/civisibility/constants/test_tags.go
@@ -170,8 +170,8 @@ const (
 	// AutoTestRetriesRetryReason indicates that the test is retried due to auto test retries.
 	AutoTestRetriesRetryReason = "auto_test_retry"
 
-	// TestManagementRetryReason indicates that we don't know the retry reason.
-	UnknownRetryReason = "unknown"
+	// ExternalRetryReason indicates that the test is retried due to an external reason.
+	ExternalRetryReason = "external"
 )
 
 const (

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -427,15 +427,7 @@ func runTestWithRetry(options *runTestWithRetryOptions) {
 		execMeta.hasAdditionalFeatureWrapper = true
 
 		// Propagate set tags from a parent wrapper
-		if originalExecMeta != nil {
-			execMeta.isANewTest = execMeta.isANewTest || originalExecMeta.isANewTest
-			execMeta.isARetry = execMeta.isARetry || originalExecMeta.isARetry
-			execMeta.isEFDExecution = execMeta.isEFDExecution || originalExecMeta.isEFDExecution
-			execMeta.isATRExecution = execMeta.isATRExecution || originalExecMeta.isATRExecution
-			execMeta.isQuarantined = execMeta.isQuarantined || originalExecMeta.isQuarantined
-			execMeta.isDisabled = execMeta.isDisabled || originalExecMeta.isDisabled
-			execMeta.isAttemptToFix = execMeta.isAttemptToFix || originalExecMeta.isAttemptToFix
-		}
+		propagateTestExecutionMetadataFlags(execMeta, originalExecMeta)
 
 		// If we are in a retry execution, set the `isARetry` flag
 		if executionIndex > 0 {
@@ -643,18 +635,25 @@ func applyTestManagementTestsFeature(testInfo *commonInfo, targetFunc func(*test
 				execMeta.allRetriesFailed = atomic.LoadInt32(&allRetriesFailed) == 1
 
 				// Propagate any flags set in the original test metadata.
-				if originalExecMeta != nil {
-					execMeta.isANewTest = execMeta.isANewTest || originalExecMeta.isANewTest
-					execMeta.isARetry = execMeta.isARetry || originalExecMeta.isARetry
-					execMeta.isEFDExecution = execMeta.isEFDExecution || originalExecMeta.isEFDExecution
-					execMeta.isATRExecution = execMeta.isATRExecution || originalExecMeta.isATRExecution
-					execMeta.isQuarantined = execMeta.isQuarantined || originalExecMeta.isQuarantined
-					execMeta.isDisabled = execMeta.isDisabled || originalExecMeta.isDisabled
-					execMeta.isAttemptToFix = execMeta.isAttemptToFix || originalExecMeta.isAttemptToFix
-				}
+				propagateTestExecutionMetadataFlags(execMeta, originalExecMeta)
 			},
 		})
 	}, true
+}
+
+func propagateTestExecutionMetadataFlags(execMeta *testExecutionMetadata, originalExecMeta *testExecutionMetadata) {
+	if execMeta == nil || originalExecMeta == nil {
+		return
+	}
+
+	// Propagate the test execution metadata
+	execMeta.isANewTest = execMeta.isANewTest || originalExecMeta.isANewTest
+	execMeta.isARetry = execMeta.isARetry || originalExecMeta.isARetry
+	execMeta.isEFDExecution = execMeta.isEFDExecution || originalExecMeta.isEFDExecution
+	execMeta.isATRExecution = execMeta.isATRExecution || originalExecMeta.isATRExecution
+	execMeta.isQuarantined = execMeta.isQuarantined || originalExecMeta.isQuarantined
+	execMeta.isDisabled = execMeta.isDisabled || originalExecMeta.isDisabled
+	execMeta.isAttemptToFix = execMeta.isAttemptToFix || originalExecMeta.isAttemptToFix
 }
 
 //go:linkname testingTRunCleanup testing.(*common).runCleanup

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -35,7 +35,8 @@ type (
 		panicData                   any               // panic data recovered from an internal test execution when using an additional feature wrapper
 		panicStacktrace             string            // stacktrace from the panic recovered from an internal test
 		isARetry                    bool              // flag to tag if a current test execution is a retry
-		isANewTest                  bool              // flag to tag if a current test execution is part of a new test
+		isANewTest                  bool              // flag to tag if a current test a new test
+		isAModifiedTest             bool              // flag to tag if a current test a modified test
 		isEFDExecution              bool              // flag to tag if a current test execution is part of an EFD execution
 		isATRExecution              bool              // flag to tag if a current test execution is part of an ATR execution
 		isQuarantined               bool              // flag to check if the test is quarantined
@@ -648,6 +649,7 @@ func propagateTestExecutionMetadataFlags(execMeta *testExecutionMetadata, origin
 
 	// Propagate the test execution metadata
 	execMeta.isANewTest = execMeta.isANewTest || originalExecMeta.isANewTest
+	execMeta.isAModifiedTest = execMeta.isAModifiedTest || originalExecMeta.isAModifiedTest
 	execMeta.isARetry = execMeta.isARetry || originalExecMeta.isARetry
 	execMeta.isEFDExecution = execMeta.isEFDExecution || originalExecMeta.isEFDExecution
 	execMeta.isATRExecution = execMeta.isATRExecution || originalExecMeta.isATRExecution

--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -6,6 +6,7 @@
 package gotesting
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"reflect"
@@ -457,4 +458,27 @@ func instrumentTestingBFunc(pb *testing.B, name string, f func(*testing.B)) (str
 //go:linkname instrumentTestifySuiteRun
 func instrumentTestifySuiteRun(t *testing.T, suite any) {
 	registerTestifySuite(t, suite)
+}
+
+// getTestOptimizationContext helper function to get the context of the test
+//
+//go:linkname getTestOptimizationContext
+func getTestOptimizationContext(tb testing.TB) context.Context {
+	if iTest := getTestOptimizationTest(tb); iTest != nil {
+		return iTest.Context()
+	}
+
+	return context.Background()
+}
+
+// getTestOptimizationTest helper function to get the test optimization test of the testing.TB
+//
+//go:linkname getTestOptimizationTest
+func getTestOptimizationTest(tb testing.TB) integrations.Test {
+	ciTestItem := getTestMetadata(tb)
+	if ciTestItem != nil && ciTestItem.test != nil {
+		return ciTestItem.test
+	}
+
+	return nil
 }

--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -182,6 +182,9 @@ func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
 			test.SetTag(constants.TestIsNew, "true")
 		}
 
+		// If the execution is for a modified test
+		execMeta.isAModifiedTest = execMeta.isAModifiedTest || test.Context().Value(constants.TestIsModified) == true
+
 		// If the execution is a retry we tag the test event
 		if execMeta.isARetry {
 			// Set the retry tag

--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -115,6 +115,7 @@ func runFlakyTestRetriesTests(m *testing.M) {
 
 	// get all finished spans
 	finishedSpans := mTracer.FinishedSpans()
+	showResourcesNameFromSpans(finishedSpans)
 
 	// 1 session span
 	// 1 module span
@@ -216,6 +217,7 @@ func runEarlyFlakyTestDetectionTests(m *testing.M) {
 
 	// get all finished spans
 	finishedSpans := mTracer.FinishedSpans()
+	showResourcesNameFromSpans(finishedSpans)
 
 	// 1 session span
 	// 1 module span
@@ -354,6 +356,7 @@ func runFlakyTestRetriesWithEarlyFlakyTestDetectionTests(m *testing.M, impactedT
 
 	// get all finished spans
 	finishedSpans := mTracer.FinishedSpans()
+	showResourcesNameFromSpans(finishedSpans)
 
 	// 1 session span
 	// 1 module span
@@ -478,6 +481,7 @@ func runIntelligentTestRunnerTests(m *testing.M) {
 
 	// get all finished spans
 	finishedSpans := mTracer.FinishedSpans()
+	showResourcesNameFromSpans(finishedSpans)
 
 	// 1 session span
 	// 1 module span
@@ -619,6 +623,7 @@ func runTestManagementTests(m *testing.M) {
 
 	// get all finished spans
 	finishedSpans := mTracer.FinishedSpans()
+	showResourcesNameFromSpans(finishedSpans)
 
 	// Disabled test with an attempt to fix with 10 executions
 	testGetInternalTestArray := checkSpansByResourceName(finishedSpans, "reflections_test.go.TestGetInternalTestArray", 10)
@@ -689,7 +694,6 @@ func checkSpansByType(finishedSpans []*mocktracer.Span,
 	sessionSpans := getSpansWithType(finishedSpans, constants.SpanTypeTestSession)
 	calculatedSessionSpans := len(sessionSpans)
 	fmt.Printf("Number of sessions received: %d\n", calculatedSessionSpans)
-	showResourcesNameFromSpans(sessionSpans)
 	if calculatedSessionSpans != sessionSpansCount {
 		panic(fmt.Sprintf("expected exactly %d session span, got %d", sessionSpansCount, calculatedSessionSpans))
 	}
@@ -697,7 +701,6 @@ func checkSpansByType(finishedSpans []*mocktracer.Span,
 	moduleSpans := getSpansWithType(finishedSpans, constants.SpanTypeTestModule)
 	calculatedModuleSpans := len(moduleSpans)
 	fmt.Printf("Number of modules received: %d\n", calculatedModuleSpans)
-	showResourcesNameFromSpans(moduleSpans)
 	if calculatedModuleSpans != moduleSpansCount {
 		panic(fmt.Sprintf("expected exactly %d module span, got %d", moduleSpansCount, calculatedModuleSpans))
 	}
@@ -705,7 +708,6 @@ func checkSpansByType(finishedSpans []*mocktracer.Span,
 	suiteSpans := getSpansWithType(finishedSpans, constants.SpanTypeTestSuite)
 	calculatedSuiteSpans := len(suiteSpans)
 	fmt.Printf("Number of suites received: %d\n", calculatedSuiteSpans)
-	showResourcesNameFromSpans(suiteSpans)
 	if calculatedSuiteSpans != suiteSpansCount {
 		panic(fmt.Sprintf("expected exactly %d suite spans, got %d", suiteSpansCount, calculatedSuiteSpans))
 	}
@@ -713,7 +715,6 @@ func checkSpansByType(finishedSpans []*mocktracer.Span,
 	testSpans := getSpansWithType(finishedSpans, constants.SpanTypeTest)
 	calculatedTestSpans := len(testSpans)
 	fmt.Printf("Number of tests received: %d\n", calculatedTestSpans)
-	showResourcesNameFromSpans(testSpans)
 	if calculatedTestSpans != testSpansCount {
 		panic(fmt.Sprintf("expected exactly %d test spans, got %d", testSpansCount, calculatedTestSpans))
 	}
@@ -721,7 +722,6 @@ func checkSpansByType(finishedSpans []*mocktracer.Span,
 	normalSpans := getSpansWithType(finishedSpans, ext.SpanTypeHTTP)
 	calculatedNormalSpans := len(normalSpans)
 	fmt.Printf("Number of http spans received: %d\n", calculatedNormalSpans)
-	showResourcesNameFromSpans(normalSpans)
 	if calculatedNormalSpans != normalSpansCount {
 		panic(fmt.Sprintf("expected exactly %d normal spans, got %d", normalSpansCount, calculatedNormalSpans))
 	}

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -226,22 +226,31 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo) func(*testing.T) {
 
 		// If the execution is for a modified test
 		execMeta.isAModifiedTest = execMeta.isAModifiedTest || (impactedTestsEnabled && test.Context().Value(constants.TestIsModified) == true)
+		if execMeta.isAModifiedTest {
+			if execMeta.isDisabled || execMeta.isQuarantined {
+				// automatic attempt to fix if a disabled or quarantined test is modified
+				execMeta.isAttemptToFix = true
+			}
+		}
 
 		// If the execution is a retry we tag the test event
 		if execMeta.isARetry {
 			// Set the retry tag
 			test.SetTag(constants.TestIsRetry, "true")
 
-			// If the execution is an EFD execution we tag the test event reason
-			if execMeta.isEFDExecution {
-				// Set the EFD as the retry reason
-				test.SetTag(constants.TestRetryReason, "efd")
-			} else if execMeta.isATRExecution {
-				// Set the ATR as the retry reason
-				test.SetTag(constants.TestRetryReason, "atr")
-			} else if execMeta.isAttemptToFix {
-				// Set the attempt to fix as the retry reason
+			// let's set the retry reason
+			if execMeta.isAttemptToFix {
+				// Set attempt_to_fix as the retry reason
 				test.SetTag(constants.TestRetryReason, "attempt_to_fix")
+			} else if execMeta.isEFDExecution {
+				// Set early_flake_detection as the retry reason
+				test.SetTag(constants.TestRetryReason, "early_flake_detection")
+			} else if execMeta.isATRExecution {
+				// Set auto_test_retry as the retry reason
+				test.SetTag(constants.TestRetryReason, "auto_test_retry")
+			} else {
+				// Set the unknown reason
+				test.SetTag(constants.TestRetryReason, "unknown")
 			}
 		}
 

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -223,7 +223,7 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo) func(*testing.T) {
 		}
 
 		// Check if the test needs to be skipped by ITR (attempt to fix is excluded)
-		if testSkippedByITR && !execMeta.isAttemptToFix {
+		if testSkippedByITR && !execMeta.isAttemptToFix && !execMeta.isAModifiedTest {
 			// check if the test was marked as unskippable
 			if test.Context().Value(constants.TestUnskippable) != true {
 				test.SetTag(constants.TestSkippedByITR, "true")

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -169,6 +169,7 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo) func(*testing.T) {
 	// Get the settings response for this session
 	settings := integrations.GetSettings()
 	coverageEnabled := settings.CodeCoverage
+	impactedTestsEnabled := settings.ImpactedTestsEnabled
 	testSkippedByITR := false
 	testIsNew := true
 
@@ -223,6 +224,9 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo) func(*testing.T) {
 			test.SetTag(constants.TestIsNew, "true")
 		}
 
+		// If the execution is for a modified test
+		execMeta.isAModifiedTest = execMeta.isAModifiedTest || (impactedTestsEnabled && test.Context().Value(constants.TestIsModified) == true)
+
 		// If the execution is a retry we tag the test event
 		if execMeta.isARetry {
 			// Set the retry tag
@@ -260,8 +264,8 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo) func(*testing.T) {
 			}
 		}
 
-		// Check if the test needs to be skipped by ITR
-		if testSkippedByITR {
+		// Check if the test needs to be skipped by ITR (attempt to fix is excluded)
+		if testSkippedByITR && !execMeta.isAttemptToFix {
 			// check if the test was marked as unskippable
 			if test.Context().Value(constants.TestUnskippable) != true {
 				test.SetTag(constants.TestSkippedByITR, "true")

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -637,7 +637,7 @@ func setTestTagsFromExecutionMetadata(test integrations.Test, execMeta *testExec
 			test.SetTag(constants.TestRetryReason, constants.AutoTestRetriesRetryReason)
 		} else {
 			// Set the unknown reason
-			test.SetTag(constants.TestRetryReason, constants.UnknownRetryReason)
+			test.SetTag(constants.TestRetryReason, constants.ExternalRetryReason)
 		}
 	}
 

--- a/internal/civisibility/integrations/gotesting/testingT.go
+++ b/internal/civisibility/integrations/gotesting/testingT.go
@@ -40,12 +40,7 @@ func (ddt *T) Run(name string, f func(*testing.T)) bool {
 // integration tests.
 func (ddt *T) Context() context.Context {
 	t := (*testing.T)(ddt)
-	ciTestItem := getTestMetadata(t)
-	if ciTestItem != nil && ciTestItem.test != nil {
-		return ciTestItem.test.Context()
-	}
-
-	return context.Background()
+	return getTestOptimizationContext(t)
 }
 
 // Fail marks the function as having failed but continues execution.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This pull request introduces several enhancements and refactors to the test instrumentation and tagging logic within the `internal/civisibility` package. The main changes include the addition of new constants for retry reasons, refactoring of metadata propagation and tagging logic, and updates to test cases to reflect the new retry reasons.

### Enhancements and Refactoring:

* **New Constants for Retry Reasons:**
  * Added new constants to represent different retry reasons such as `attempt_to_fix`, `early_flake_detection`, `auto_test_retry`, and `unknown`. (`internal/civisibility/constants/test_tags.go`)

* **Refactoring Metadata Propagation and Tagging Logic:**
  * Refactored the `instrumentTestingTFunc` function to use a new helper function `propagateTestExecutionMetadataFlags` for propagating metadata flags and `setTestTagsFromExecutionMetadata` for setting test tags based on execution metadata. (`internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go`) [[1]](diffhunk://#diff-f7605c2ed3295ba8902a506d1995173511616df51dc537fdabd93d2e1a2919d3L173-R180) [[2]](diffhunk://#diff-f7605c2ed3295ba8902a506d1995173511616df51dc537fdabd93d2e1a2919d3L238-R195)
  * Introduced `setTestTagsFromExecutionMetadata` function to centralize the logic for setting test tags from execution metadata. (`internal/civisibility/integrations/gotesting/testing.go`)

* **Updates to Test Cases:**
  * Updated test cases to reflect the new retry reasons such as `auto_test_retry` and `early_flake_detection`. (`internal/civisibility/integrations/gotesting/testcontroller_test.go`) [[1]](diffhunk://#diff-2e7666330526234ecfe75fdcacc000725467d361f245b9dd37f41c4906e53fd2L164-R166) [[2]](diffhunk://#diff-2e7666330526234ecfe75fdcacc000725467d361f245b9dd37f41c4906e53fd2L267-R270)

* **Additional Enhancements:**
  * Added calls to `showResourcesNameFromSpans` in various test functions to enhance debugging output. (`internal/civisibility/integrations/gotesting/testcontroller_test.go`) [[1]](diffhunk://#diff-2e7666330526234ecfe75fdcacc000725467d361f245b9dd37f41c4906e53fd2R118) [[2]](diffhunk://#diff-2e7666330526234ecfe75fdcacc000725467d361f245b9dd37f41c4906e53fd2R220) [[3]](diffhunk://#diff-2e7666330526234ecfe75fdcacc000725467d361f245b9dd37f41c4906e53fd2R359) [[4]](diffhunk://#diff-2e7666330526234ecfe75fdcacc000725467d361f245b9dd37f41c4906e53fd2R508) [[5]](diffhunk://#diff-2e7666330526234ecfe75fdcacc000725467d361f245b9dd37f41c4906e53fd2R650)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

These changes aim to improve the clarity and maintainability of the test instrumentation code, as well as enhance the debugging capabilities of the test suite.


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
