### PR TITLE
orchestrion/CI: prevent go mod edit from changing go directive

### DIFF
--- a/.github/workflows/orchestrion.yml
+++ b/.github/workflows/orchestrion.yml
@@ -146,8 +146,8 @@ jobs:
       - name: Set up orchestrion
         if: inputs.orchestrion-version != ''
         run: |-
-          go mod edit -replace="github.com/DataDog/orchestrion=${{ github.workspace }}/orchestrion"
-          go mod tidy -go ${{ steps.setup-go.outputs.go-version }}
+          go mod edit -go="$(go mod edit -json | jq -r '.Go')" -replace="github.com/DataDog/orchestrion=${{ github.workspace }}/orchestrion"
+          go mod tidy -go="$(go mod edit -json | jq -r '.Go')"
         working-directory: ${{ github.workspace }}/dd-trace-go/internal/orchestrion/_integration
         env:
           VERSION: ${{ inputs.orchestrion-version }}


### PR DESCRIPTION
This would prevent the `go.mod` file from becoming out-of-sync with the `go.work` file, resulting in subsequent failures...

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
