### PR TITLE
contrib/log/slog: make orchestrion config lib-side

### DIFF
--- a/contrib/log/slog/orchestrion.yml
+++ b/contrib/log/slog/orchestrion.yml
@@ -13,10 +13,20 @@ meta:
 aspects:
   - id: New
     join-point:
-      function-call: log/slog.New
+      all-of:
+        - import-path: log/slog
+        - function-body:
+            function:
+              - name: New
     advice:
-      - wrap-expression:
-          imports:
-            slogtrace: gopkg.in/DataDog/dd-trace-go.v1/contrib/log/slog
+      - inject-declarations:
+          # We need to use go:linkname to refer to a number of declarations in order to avoid creating
+          # circular dependencies, as these features have transitive dependencies on `log/slog`...
+          links:
+            - gopkg.in/DataDog/dd-trace-go.v1/contrib/log/slog
           template: |-
-            {{ .AST.Fun }}(slogtrace.WrapHandler({{ index .AST.Args 0 }}))
+            //go:linkname __dd_slogtrace_WrapHandlerV1 gopkg.in/DataDog/dd-trace-go.v1/contrib/log/slog.WrapHandler
+            func __dd_slogtrace_WrapHandlerV1(Handler) Handler
+      - prepend-statements:
+          template: |-
+            {{ .Function.Argument 0 }} = __dd_slogtrace_WrapHandlerV1({{ .Function.Argument 0 }})


### PR DESCRIPTION
Avoid creating a circular dependency with `dd-trace-go` through the tracer's OpenTelemetry dependencies (which now use `log/slog`) by instrumenting it library-side using `//go:linkname`.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
