### PR TITLE
Add round tripper option to have custom status check

### DIFF
--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -252,6 +252,14 @@ func WithStatusCheck(fn func(statusCode int) bool) Option {
 	}
 }
 
+// WithStatusCheck sets a span to be an error if the passed function
+// returns true for a given status code.
+func RTWithStatusCheck(fn func(statusCode int) bool) RoundTripperOption {
+	return func(cfg *roundTripperConfig) {
+		cfg.isStatusError = fn
+	}
+}
+
 // RTWithErrorCheck specifies a function fn which determines whether the passed
 // error should be marked as an error. The fn is called whenever an http operation
 // finishes with an error


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Allow a user of http client to specify what http status codes should be considered errors on a specific http client.

### Motivation

I have an http client where I want to have a specific handling for all http status codes and they are never considered an error in my client.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
- [ ] For internal contributors, a matching PR should be created to the `v2-dev` branch and reviewed by @DataDog/apm-go.


Unsure? Have a question? Request a review!
