### PR TITLE
internal/telemetry: fix telemetry metric submit datarace double pool insertion

### DIFF
--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -57,7 +57,6 @@ func newClient(tracerConfig internal.TracerConfig, config ClientConfig) (*client
 		},
 		metrics: metrics{
 			store:         xsync.NewMapOf[metricKey, metricHandle](xsync.WithPresize(knownmetrics.SizeWithFilter(func(decl knownmetrics.Declaration) bool { return decl.Type != transport.DistMetric }))),
-			pool:          internal.NewSyncPool(func() *metricPoint { return &metricPoint{} }),
 			skipAllowlist: config.Debug,
 		},
 		distributions: distributions{

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -91,12 +91,12 @@ func (m *metrics) LoadOrStore(namespace Namespace, kind transport.MetricType, na
 	)
 	switch kind {
 	case transport.CountMetric:
-		handle, loaded = m.store.LoadOrCompute(key, func() metricHandle { return &count{metric: metric{key: key, pool: m.pool}} })
+		handle, loaded = m.store.LoadOrCompute(key, func() metricHandle { return &count{metric: metric{key: key}} })
 	case transport.GaugeMetric:
-		handle, loaded = m.store.LoadOrCompute(key, func() metricHandle { return &gauge{metric: metric{key: key, pool: m.pool}} })
+		handle, loaded = m.store.LoadOrCompute(key, func() metricHandle { return &gauge{metric: metric{key: key}} })
 	case transport.RateMetric:
 		handle, loaded = m.store.LoadOrCompute(key, func() metricHandle {
-			rate := &rate{count: count{metric: metric{key: key, pool: m.pool}}}
+			rate := &rate{count: count{metric: metric{key: key}}}
 			now := time.Now()
 			rate.intervalStart.Store(&now)
 			return rate
@@ -138,9 +138,8 @@ type metricPoint struct {
 
 // metric is a meta t
 type metric struct {
-	key  metricKey
-	ptr  atomic.Pointer[metricPoint]
-	pool *internal.SyncPool[*metricPoint]
+	key metricKey
+	ptr atomic.Pointer[metricPoint]
 }
 
 func (m *metric) Get() float64 {
@@ -156,7 +155,6 @@ func (m *metric) Payload() transport.MetricData {
 	if point == nil {
 		return transport.MetricData{}
 	}
-	defer m.pool.Put(point)
 	return m.payload(point)
 }
 
@@ -183,7 +181,7 @@ type count struct {
 }
 
 func (m *count) Submit(newValue float64) {
-	newPoint := m.pool.Get()
+	newPoint := new(metricPoint)
 	newPoint.time = time.Now()
 	for {
 		oldPoint := m.ptr.Load()
@@ -193,9 +191,6 @@ func (m *count) Submit(newValue float64) {
 		}
 		newPoint.value = oldValue + newValue
 		if m.ptr.CompareAndSwap(oldPoint, newPoint) {
-			if oldPoint != nil {
-				m.pool.Put(oldPoint)
-			}
 			return
 		}
 	}
@@ -207,15 +202,12 @@ type gauge struct {
 }
 
 func (g *gauge) Submit(value float64) {
-	newPoint := g.pool.Get()
+	newPoint := new(metricPoint)
 	newPoint.time = time.Now()
 	newPoint.value = value
 	for {
 		oldPoint := g.ptr.Load()
 		if g.ptr.CompareAndSwap(oldPoint, newPoint) {
-			if oldPoint != nil {
-				g.pool.Put(oldPoint)
-			}
 			return
 		}
 	}
@@ -258,7 +250,6 @@ func (r *rate) Payload() transport.MetricData {
 	if point == nil {
 		return transport.MetricData{}
 	}
-	defer r.pool.Put(point)
 
 	point.value /= intervalSeconds
 	payload := r.metric.payload(point)

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -16,7 +16,6 @@ import (
 	"github.com/puzpuzpuz/xsync/v3"
 
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
-	"github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal/knownmetrics"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal/transport"
 )
@@ -77,7 +76,6 @@ type metricHandle interface {
 
 type metrics struct {
 	store         *xsync.MapOf[metricKey, metricHandle]
-	pool          *internal.SyncPool[*metricPoint]
 	skipAllowlist bool // Debugging feature to skip the allowlist of known metrics
 }
 


### PR DESCRIPTION

### What does this PR do?

This PR remove the sync.Pool usage in telemetry metrics because it created a data race 

### Motivation

Fixes #3413 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
