### PR TITLE
fix(ddtrace/tracer): add finished check on NoDebugStack and WithError code branches

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -625,11 +625,13 @@ func (s *Span) Finish(opts ...FinishOption) {
 			t = cfg.FinishTime.UnixNano()
 		}
 		if cfg.NoDebugStack {
-			s.Lock()
+			s.RLock()
 			if s.finished {
-				s.Unlock()
+				s.RUnlock()
 				return
 			}
+			s.RUnlock()
+			s.Lock()
 			delete(s.meta, ext.ErrorStack)
 			s.Unlock()
 		}

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -612,6 +612,14 @@ func (s *Span) Finish(opts ...FinishOption) {
 	if s == nil {
 		return
 	}
+
+	s.RLock()
+	if s.finished {
+		s.RUnlock()
+		return
+	}
+	s.RUnlock()
+
 	t := now()
 	if len(opts) > 0 {
 		cfg := FinishConfig{

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -613,13 +613,6 @@ func (s *Span) Finish(opts ...FinishOption) {
 		return
 	}
 
-	s.RLock()
-	if s.finished {
-		s.RUnlock()
-		return
-	}
-	s.RUnlock()
-
 	t := now()
 	if len(opts) > 0 {
 		cfg := FinishConfig{
@@ -633,6 +626,10 @@ func (s *Span) Finish(opts ...FinishOption) {
 		}
 		if cfg.NoDebugStack {
 			s.Lock()
+			if s.finished {
+				s.Unlock()
+				return
+			}
 			delete(s.meta, ext.ErrorStack)
 			s.Unlock()
 		}

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -118,8 +118,9 @@ func TestIncident37240DoubleFinish(t *testing.T) {
 
 	t.Run("with error", func(t *testing.T) {
 		root, _ := StartSpanFromContext(context.Background(), "root", Tag(ext.ManualKeep, true))
+		err := errors.New("test error")
 		for i := 0; i < 1000; i++ {
-			root.Finish(WithError(errors.New("test error")))
+			root.Finish(WithError(err))
 		}
 	})
 }


### PR DESCRIPTION
### What does this PR do?

Follow-up from #3435 & #3427. Adds a check on `span.finished` when applying `NoDebugStack`.

### Motivation

Adds an extra layer of resilience on high concurrency scenarios.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
