### PR TITLE
tracer: fix potential concurrency bug for trace source tag

### DIFF
--- a/ddtrace/tracer/propagating_tags.go
+++ b/ddtrace/tracer/propagating_tags.go
@@ -31,8 +31,8 @@ func (t *trace) setPropagatingTag(key, value string) {
 }
 
 func (t *trace) setTraceSourcePropagatingTag(key string, value internal.TraceSource) {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
+	t.mu.Lock()
+	defer t.mu.Unlock()
 
 	// If there is already a TraceSource value set in the trace
 	// we need to add the new value to the bitmask.


### PR DESCRIPTION
### What does this PR do?

This PR fixes a potential concurrency bug introduced in #3230, the tag setting logic is using the read lock instead of write.

### Motivation

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
