### PR TITLE
[APM] Compute stats after span is fully finished

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -710,20 +710,20 @@ func (s *Span) finish(finishTime int64) {
 	}
 
 	keep := true
-	if t, ok := GetGlobalTracer().(*tracer); ok {
-		if !t.config.enabled.current {
+	tracer, hasTracer := GetGlobalTracer().(*tracer)
+	if hasTracer {
+		if !tracer.config.enabled.current {
 			return
 		}
-		t.Submit(s)
-		if t.config.canDropP0s() {
+		if tracer.config.canDropP0s() {
 			// the agent supports dropping p0's in the client
 			keep = shouldKeep(s)
 		}
-		if t.config.debugAbandonedSpans {
+		if tracer.config.debugAbandonedSpans {
 			// the tracer supports debugging abandoned spans
-			t.submitAbandonedSpan(s, true)
+			tracer.submitAbandonedSpan(s, true)
 		}
-		t.spansFinished.Inc(s.integration)
+		tracer.spansFinished.Inc(s.integration)
 	}
 	if keep {
 		// a single kept span keeps the whole trace.
@@ -735,6 +735,11 @@ func (s *Span) finish(finishTime int64) {
 			s, s.name, s.resource, s.meta, s.metrics)
 	}
 	s.context.finish()
+
+	// compute stats after finishing the span. This ensures any normalization or tag propagation has been applied
+	if hasTracer {
+		tracer.Submit(s)
+	}
 
 	if s.pprofCtxRestore != nil {
 		// Restore the labels of the parent span so any CPU samples after this

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -1374,7 +1374,6 @@ func TestStatsAfterFinish(t *testing.T) {
 		c.Stop()
 		stats := transport.Stats()
 		assert.Equal(t, 1, len(stats))
-		log.Info("%v", stats)
 		peerTags := stats[0].Stats[0].Stats[0].PeerTags
 		assert.Contains(t, peerTags, "peer.service:kafka-cluster")
 	})
@@ -1410,7 +1409,6 @@ func TestStatsAfterFinish(t *testing.T) {
 		c.Stop()
 		stats := transport.Stats()
 		assert.Equal(t, 1, len(stats))
-		log.Info("%v", stats)
 		peerTags := stats[0].Stats[0].Stats[0].PeerTags
 		assert.Empty(t, peerTags)
 	})

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/samplernames"
 	"github.com/DataDog/dd-trace-go/v2/internal/traceprof"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1336,5 +1337,81 @@ func TestSpanLinksInMeta(t *testing.T) {
 		assert.Equal(t, uint64(456), links[0].TraceID)
 		assert.Equal(t, uint64(789), links[1].SpanID)
 		assert.Equal(t, uint64(012), links[1].TraceID)
+	})
+}
+
+func TestStatsAfterFinish(t *testing.T) {
+	t.Run("peerServiceDefaults-enabled", func(t *testing.T) {
+		tracer, err := newTracer(
+			WithPeerServiceDefaults(true),
+			WithStatsComputation(true),
+		)
+		assert.NoError(t, err)
+		defer tracer.Stop()
+		SetGlobalTracer(tracer)
+
+		transport := newDummyTransport()
+		tracer.config.transport = transport
+		tracer.config.agent.Stats = true
+		tracer.config.agent.DropP0s = true
+		tracer.config.agent.peerTags = []string{"peer.service"}
+
+		c := newConcentrator(tracer.config, (10 * time.Second).Nanoseconds(), &statsd.NoOpClientDirect{})
+		assert.Len(t, transport.Stats(), 0)
+		c.Start()
+		tracer.stats = c
+
+		sp := tracer.StartSpan("sp1")
+		sp.SetTag("span.kind", "client")
+		sp.SetTag("messaging.system", "kafka")
+		sp.SetTag("messaging.kafka.bootstrap.servers", "kafka-cluster")
+		sp.SetTag(keyMeasured, 1)
+		sp.Finish()
+
+		assert.Equal(t, "kafka-cluster", sp.meta["peer.service"])
+
+		// peer.service has been added on the span.Finish() call. Ensure the StatSpan is also accessing this.
+		c.Stop()
+		stats := transport.Stats()
+		assert.Equal(t, 1, len(stats))
+		log.Info("%v", stats)
+		peerTags := stats[0].Stats[0].Stats[0].PeerTags
+		assert.Contains(t, peerTags, "peer.service:kafka-cluster")
+	})
+	t.Run("peerServiceDefaults-disabled", func(t *testing.T) {
+		tracer, err := newTracer(
+			WithPeerServiceDefaults(false),
+			WithStatsComputation(true),
+		)
+		assert.NoError(t, err)
+		defer tracer.Stop()
+		SetGlobalTracer(tracer)
+
+		transport := newDummyTransport()
+		tracer.config.transport = transport
+		tracer.config.agent.Stats = true
+		tracer.config.agent.DropP0s = true
+		tracer.config.agent.peerTags = []string{"peer.service"}
+
+		c := newConcentrator(tracer.config, (10 * time.Second).Nanoseconds(), &statsd.NoOpClientDirect{})
+		assert.Len(t, transport.Stats(), 0)
+		c.Start()
+		tracer.stats = c
+
+		sp := tracer.StartSpan("sp1")
+		sp.SetTag("span.kind", "client")
+		sp.SetTag("messaging.system", "kafka")
+		sp.SetTag("messaging.kafka.bootstrap.servers", "kafka-cluster")
+		sp.SetTag(keyMeasured, 1)
+		sp.Finish()
+
+		assert.Equal(t, "", sp.meta["peer.service"])
+
+		c.Stop()
+		stats := transport.Stats()
+		assert.Equal(t, 1, len(stats))
+		log.Info("%v", stats)
+		peerTags := stats[0].Stats[0].Stats[0].PeerTags
+		assert.Empty(t, peerTags)
 	})
 }

--- a/ddtrace/tracer/stats.go
+++ b/ddtrace/tracer/stats.go
@@ -60,7 +60,7 @@ type tracerStatSpan struct {
 // configuration c. It creates buckets of bucketSize nanoseconds duration.
 func newConcentrator(c *config, bucketSize int64, statsdClient internal.StatsdClient) *concentrator {
 	sCfg := &stats.SpanConcentratorConfig{
-		ComputeStatsBySpanKind: false,
+		ComputeStatsBySpanKind: true,
 		BucketInterval:         defaultStatsBucketSize,
 	}
 	env := c.agent.defaultEnv

--- a/ddtrace/tracer/stats_test.go
+++ b/ddtrace/tracer/stats_test.go
@@ -183,3 +183,27 @@ func TestObfuscation(t *testing.T) {
 	assert.Equal(t, 2, tsp.obfVersion)
 	assert.Equal(t, "GET", actualStats[0].Stats[0].Stats[0].Resource)
 }
+
+func TestStatsByKind(t *testing.T) {
+	s1 := Span{
+		name:     "http.request",
+		start:    time.Now().UnixNano(),
+		duration: 1,
+		metrics:  map[string]float64{keyMeasured: 0},
+	}
+	s2 := Span{
+		name:     "sql.query",
+		start:    time.Now().UnixNano(),
+		duration: 1,
+		metrics:  map[string]float64{keyMeasured: 0},
+	}
+	s1.SetTag("span.kind", "client")
+	s2.SetTag("span.kind", "invalid")
+
+	c := newConcentrator(&config{transport: newDummyTransport(), env: "someEnv"}, 100, &statsd.NoOpClientDirect{})
+	_, ok := c.newTracerStatSpan(&s1, nil)
+	assert.True(t, ok)
+
+	_, ok = c.newTracerStatSpan(&s2, nil)
+	assert.False(t, ok)
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

We must ensure all internal normalization happening in the Finish() call is performed before passing the Span to the SpanConcentrator. This ensures the StatSpan has a representation of the Span after being fully finalized.

This PR is a remediation for the following 2 issues from [this list](https://docs.google.com/document/d/10ect0b8BLS9_lmO_u9rr191tJcEy0aTEbcN4zm6S1XU/edit?pli=1&tab=t.0):
* [Stats by Kind Not Computed on dd-trace-go ](https://docs.google.com/document/d/10ect0b8BLS9_lmO_u9rr191tJcEy0aTEbcN4zm6S1XU/edit?pli=1&tab=t.0#bookmark=id.pq6hidir7n84)
* [Stats Computation Performed Before Final Span Normalizations](https://docs.google.com/document/d/10ect0b8BLS9_lmO_u9rr191tJcEy0aTEbcN4zm6S1XU/edit?pli=1&tab=t.0#bookmark=id.5q1tvnlm3ppg)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

See above link

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
