### PR TITLE
fix(ddtrace/tracer): replace RLock with Lock for NoDebugStack check to prevent race condition

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -625,13 +625,11 @@ func (s *Span) Finish(opts ...FinishOption) {
 			t = cfg.FinishTime.UnixNano()
 		}
 		if cfg.NoDebugStack {
-			s.RLock()
+			s.Lock()
 			if s.finished {
-				s.RUnlock()
+				s.Unlock()
 				return
 			}
-			s.RUnlock()
-			s.Lock()
 			delete(s.meta, ext.ErrorStack)
 			s.Unlock()
 		}


### PR DESCRIPTION
### What does this PR do?

Reduces to a single locking operation everything in `Finish`'s `NoDebugStack`.

### Motivation

Per @felixge's [comment](https://github.com/DataDog/dd-trace-go/pull/3441/files/1b718c17e6dcce3ea626f23d8bbe152c00918d63#diff-25c42ba867d01ba68aa500adcf133d6b446bddb2b0120b20fd2f3e67b6cf62e5), there is a potential race condition in the `NoDebugStack` when finishing a span.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
