### PR TITLE
(feat) internal/civisibility: civisibility mock tracer

### DIFF
--- a/ddtrace/mocktracer/civisibilitymocktracer.go
+++ b/ddtrace/mocktracer/civisibilitymocktracer.go
@@ -1,0 +1,98 @@
+package mocktracer
+
+import (
+	"sync/atomic"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/civisibility/constants"
+	"gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams"
+)
+
+type civisibilitymocktracer struct {
+	mock   *mocktracer    // mock tracer
+	real   ddtrace.Tracer // real tracer (for the testotimization/civisibility spans)
+	isnoop atomic.Bool
+}
+
+var _ ddtrace.Tracer = (*civisibilitymocktracer)(nil)
+var _ Tracer = (*civisibilitymocktracer)(nil)
+
+// Creates a new CIVisibilityMockTracer that uses the mock tracer for all spans except the CIVisibility spans.
+func newCIVisibilityMockTracer() *civisibilitymocktracer {
+	return &civisibilitymocktracer{
+		mock: newMockTracer(),
+		real: internal.GetGlobalTracer(),
+	}
+}
+
+func (t *civisibilitymocktracer) SentDSMBacklogs() []datastreams.Backlog {
+	if t.isnoop.Load() {
+		return nil
+	}
+	t.mock.dsmProcessor.Flush()
+	return t.mock.dsmTransport.backlogs
+}
+
+func (t *civisibilitymocktracer) Stop() {
+	t.isnoop.Store(true)
+	internal.Testing = false
+	t.mock.dsmProcessor.Stop()
+}
+
+func (t *civisibilitymocktracer) StartSpan(operationName string, opts ...ddtrace.StartSpanOption) ddtrace.Span {
+	if t.real != nil {
+		var cfg ddtrace.StartSpanConfig
+		for _, fn := range opts {
+			fn(&cfg)
+		}
+
+		if spanType, ok := cfg.Tags[ext.SpanType]; ok &&
+			(spanType == constants.SpanTypeTestSession || spanType == constants.SpanTypeTestModule ||
+				spanType == constants.SpanTypeTestSuite || spanType == constants.SpanTypeTest) {
+			// If the span is a civisibility span, use the real tracer to create it.
+			return t.real.StartSpan(operationName, opts...)
+		}
+	}
+
+	if t.isnoop.Load() {
+		return internal.NoopSpan{}
+	}
+
+	// Otherwise, use the mock tracer to create it.
+	return t.mock.StartSpan(operationName, opts...)
+}
+
+func (t *civisibilitymocktracer) GetDataStreamsProcessor() *datastreams.Processor {
+	if t.isnoop.Load() {
+		return nil
+	}
+	return t.mock.dsmProcessor
+}
+
+func (t *civisibilitymocktracer) OpenSpans() []Span {
+	return t.mock.OpenSpans()
+}
+
+func (t *civisibilitymocktracer) FinishedSpans() []Span {
+	return t.mock.FinishedSpans()
+}
+
+func (t *civisibilitymocktracer) Reset() {
+	t.mock.Reset()
+}
+
+func (t *civisibilitymocktracer) Extract(carrier interface{}) (ddtrace.SpanContext, error) {
+	if t.isnoop.Load() {
+		return internal.NoopSpanContext{}, nil
+	}
+	return t.mock.Extract(carrier)
+}
+
+func (t *civisibilitymocktracer) Inject(context ddtrace.SpanContext, carrier interface{}) error {
+	if t.isnoop.Load() {
+		return nil
+	}
+	return t.mock.Inject(context, carrier)
+}

--- a/ddtrace/mocktracer/civisibilitymocktracer.go
+++ b/ddtrace/mocktracer/civisibilitymocktracer.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
 package mocktracer
 
 import (

--- a/internal/civisibility/constants/env.go
+++ b/internal/civisibility/constants/env.go
@@ -11,6 +11,9 @@ const (
 	// features related to CI Visibility in the Datadog platform.
 	CIVisibilityEnabledEnvironmentVariable = "DD_CIVISIBILITY_ENABLED"
 
+	// CIVisibilityTestingEnabledEnvironmentVariable indicates if CI Visibility testing mode is enabled.
+	CIVisibilityTestingEnabledEnvironmentVariable = "DD_INTERNAL_CIVISIBILITY_TESTING_ENABLED"
+
 	// CIVisibilityAgentlessEnabledEnvironmentVariable indicates if CI Visibility agentless mode is enabled.
 	// This environment variable should be set to "1" or "true" to enable agentless mode for CI Visibility, where traces
 	// are sent directly to Datadog without using a local agent.

--- a/internal/civisibility/integrations/civisibility.go
+++ b/internal/civisibility/integrations/civisibility.go
@@ -50,6 +50,8 @@ func EnsureCiVisibilityInitialization() {
 // InitializeCIVisibilityMock initialize the mocktracer for CI Visibility usage
 func InitializeCIVisibilityMock() mocktracer.Tracer {
 	internalCiVisibilityInitialization(func([]tracer.StartOption) {
+		// Set the environment variable to enable testing mode
+		_ = os.Setenv(constants.CIVisibilityTestingEnabledEnvironmentVariable, "true")
 		// Initialize the mocktracer
 		mTracer = mocktracer.Start()
 	})


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds a new MockTracer for CI Visibility mode, to allow mocktracer usage while sending ci visibility data to the backend.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
