### PR TITLE
(feat) internal/civisibility: civisibility mocktracer

### DIFF
--- a/ddtrace/mocktracer/civisibilitymocktracer.go
+++ b/ddtrace/mocktracer/civisibilitymocktracer.go
@@ -1,0 +1,178 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+package mocktracer
+
+import (
+	"sync"
+	"sync/atomic"
+	_ "unsafe" // for go:linkname
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
+	"github.com/DataDog/dd-trace-go/v2/internal/datastreams"
+)
+
+//go:linkname storeGlobalTracer github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.storeGlobalTracer
+func storeGlobalTracer(t tracer.Tracer)
+
+type civisibilitymocktracer struct {
+	mock   *mocktracer   // mock tracer
+	real   tracer.Tracer // real tracer (for the testotimization/civisibility spans)
+	isnoop atomic.Bool
+}
+
+var (
+	_ tracer.Tracer = (*civisibilitymocktracer)(nil)
+	_ Tracer        = (*civisibilitymocktracer)(nil)
+
+	realSpans      = make(map[*tracer.Span]bool)
+	realSpansMutex sync.Mutex
+)
+
+// Creates a new CIVisibilityMockTracer that uses the mock tracer for all spans except the CIVisibility spans.
+func newCIVisibilityMockTracer() *civisibilitymocktracer {
+	return &civisibilitymocktracer{
+		mock: newMockTracer(),
+		real: tracer.GetGlobalTracer(),
+	}
+}
+
+// SentDSMBacklogs returns the Data Streams Monitoring backlogs that have been sent by the mock tracer.
+// If the tracer is in noop mode, it returns nil. Otherwise, it flushes the processor and returns
+// all captured backlogs from the mock transport.
+func (t *civisibilitymocktracer) SentDSMBacklogs() []datastreams.Backlog {
+	if t.isnoop.Load() {
+		return nil
+	}
+	t.mock.dsmProcessor.Flush()
+	return t.mock.dsmTransport.backlogs
+}
+
+// Stop deactivates the CIVisibility mock tracer by setting it to noop mode and stopping
+// the Data Streams Monitoring processor. This should be called when testing has finished.
+func (t *civisibilitymocktracer) Stop() {
+	t.isnoop.Store(true)
+	t.mock.dsmProcessor.Stop()
+	if civisibility.GetState() == civisibility.StateExiting {
+		t.real.Stop()
+		t.real = &tracer.NoopTracer{}
+	}
+}
+
+// StartSpan creates a new span with the given operation name and options. If the span type
+// indicates it's a CI Visibility span (like a test session, module, suite, or individual test),
+// it uses the real tracer to create the span. For all other spans, it uses the mock tracer.
+// If the tracer is in noop mode, it returns nil.
+func (t *civisibilitymocktracer) StartSpan(operationName string, opts ...tracer.StartSpanOption) *tracer.Span {
+	if t.real != nil {
+		var cfg tracer.StartSpanConfig
+		for _, fn := range opts {
+			fn(&cfg)
+		}
+
+		if spanType, ok := cfg.Tags[ext.SpanType]; ok &&
+			(spanType == constants.SpanTypeTestSession || spanType == constants.SpanTypeTestModule ||
+				spanType == constants.SpanTypeTestSuite || spanType == constants.SpanTypeTest) {
+			// If the span is a civisibility span, use the real tracer to create it.
+			realSpan := t.real.StartSpan(operationName, opts...)
+			realSpansMutex.Lock()
+			defer realSpansMutex.Unlock()
+			realSpans[realSpan] = true
+			return realSpan
+		}
+	}
+
+	if t.isnoop.Load() {
+		return nil
+	}
+
+	// Otherwise, use the mock tracer to create it.
+	return t.mock.StartSpan(operationName, opts...)
+}
+
+// FinishSpan marks the given span as finished in the mock tracer. This is called by spans
+// when they finish, adding them to the list of finished spans for later inspection.
+func (t *civisibilitymocktracer) FinishSpan(s *tracer.Span) {
+	realSpansMutex.Lock()
+	defer realSpansMutex.Unlock()
+	// Check if the span is a real span (i.e., created by the real tracer).
+	if _, isRealSpan := realSpans[s]; isRealSpan {
+		delete(realSpans, s)
+		return
+	}
+	if t.isnoop.Load() {
+		return
+	}
+	t.mock.FinishSpan(s)
+}
+
+// GetDataStreamsProcessor returns the Data Streams Monitoring processor used by the mock tracer.
+// If the tracer is in noop mode, it returns nil. This processor is used to monitor
+// and record data stream metrics.
+func (t *civisibilitymocktracer) GetDataStreamsProcessor() *datastreams.Processor {
+	if t.isnoop.Load() {
+		return nil
+	}
+	return t.mock.dsmProcessor
+}
+
+// OpenSpans returns the set of started spans that have not been finished yet.
+// This is useful for verifying spans are properly finished in tests.
+func (t *civisibilitymocktracer) OpenSpans() []*Span {
+	return t.mock.OpenSpans()
+}
+
+// FinishedSpans returns the set of spans that have been finished.
+// This allows inspection of spans after they've completed for testing and verification.
+func (t *civisibilitymocktracer) FinishedSpans() []*Span {
+	return t.mock.FinishedSpans()
+}
+
+// Reset clears all spans (both open and finished) from the mock tracer.
+// This is especially useful when running tests in a loop, where a clean state
+// is desired between test iterations.
+func (t *civisibilitymocktracer) Reset() {
+	t.mock.Reset()
+}
+
+// Extract retrieves a SpanContext from the carrier using the mock tracer's propagator.
+// If the tracer is in noop mode, it returns nil. This is used for distributed tracing
+// to continue traces across process boundaries.
+func (t *civisibilitymocktracer) Extract(carrier interface{}) (*tracer.SpanContext, error) {
+	if t.isnoop.Load() {
+		return nil, nil
+	}
+	return t.mock.Extract(carrier)
+}
+
+// Inject injects the SpanContext into the carrier using the mock tracer's propagator.
+// If the tracer is in noop mode, it returns nil. This is used for distributed tracing
+// to propagate trace information across process boundaries.
+func (t *civisibilitymocktracer) Inject(context *tracer.SpanContext, carrier interface{}) error {
+	if t.isnoop.Load() {
+		return nil
+	}
+	return t.mock.Inject(context, carrier)
+}
+
+func (t *civisibilitymocktracer) TracerConf() tracer.TracerConf {
+	return t.real.TracerConf()
+}
+func (t *civisibilitymocktracer) Submit(span *tracer.Span) {
+	t.mock.Submit(span)
+}
+func (t *civisibilitymocktracer) SubmitChunk(chunk *tracer.Chunk) {
+	t.real.SubmitChunk(chunk)
+}
+
+// Flush forces a flush of both the mock tracer and the real tracer.
+// This ensures that all buffered spans are processed and ready for inspection.
+func (t *civisibilitymocktracer) Flush() {
+	t.mock.Flush()
+	t.real.Flush()
+}

--- a/ddtrace/mocktracer/civisibilitymocktracer_test.go
+++ b/ddtrace/mocktracer/civisibilitymocktracer_test.go
@@ -1,0 +1,178 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+package mocktracer
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCIVisibilityMockTracer_StartSpan_Routing verifies that spans are routed
+// correctly based on their SpanType tag. CI Visibility spans should go to the
+// real tracer, others to the mock tracer.
+func TestCIVisibilityMockTracer_StartSpan_Routing(t *testing.T) {
+	// Note: The 'real' tracer here will be the default global tracer.
+	// If mocktracer.Start() was called *before* this, 'real' would also be a mock.
+	// We rely on the fact that CI spans won't appear in the *internal* mock tracer (`cmt.mock`).
+	cmt := newCIVisibilityMockTracer()
+	tracer.SetGlobalTracer(cmt)
+	defer tracer.StopTestTracer() // Reset the global tracer to avoid side effects
+	defer cmt.Stop()              // Clean up DSM processor
+
+	// 1. Regular span (should go to internal mock)
+	regSpan := cmt.StartSpan("regular.op")
+	require.NotNil(t, regSpan)
+	regSpan.Finish()
+
+	// 2. CI Visibility span (should go to real tracer)
+	ciSpan := cmt.StartSpan("ci.test.op", tracer.SpanType(constants.SpanTypeTest))
+	// We might not have a real tracer configured to actually *do* anything,
+	// but the key is it *shouldn't* be handled by cmt.mock.
+	// If ciSpan is nil, it means the real tracer is likely a NoopTracer, which is fine for this test.
+	if ciSpan != nil {
+		ciSpan.Finish() // Finish it if we got one
+	}
+
+	// Verification
+	mockedSpans := cmt.mock.FinishedSpans() // Access internal mock directly for verification
+	assert.Len(t, mockedSpans, 1, "Only the regular span should be in the internal mock tracer")
+	if len(mockedSpans) == 1 {
+		assert.Equal(t, "regular.op", mockedSpans[0].OperationName())
+		assert.NotEqual(t, "ci.test.op", mockedSpans[0].OperationName())
+	}
+
+	// Check the public FinishedSpans() method also reflects the internal mock
+	publicFinished := cmt.FinishedSpans()
+	assert.Len(t, publicFinished, 1, "Public FinishedSpans should match internal mock")
+	if len(publicFinished) == 1 {
+		assert.Equal(t, "regular.op", publicFinished[0].OperationName())
+	}
+
+	// Check OpenSpans - should be empty now
+	assert.Empty(t, cmt.OpenSpans(), "OpenSpans should be empty after finishing")
+}
+
+// TestCIVisibilityMockTracer_Delegation verifies basic delegation methods.
+func TestCIVisibilityMockTracer_Delegation(t *testing.T) {
+	cmt := newCIVisibilityMockTracer()
+	tracer.SetGlobalTracer(cmt)
+	defer tracer.StopTestTracer() // Reset the global tracer to avoid side effects
+	defer cmt.Stop()
+
+	// Test Reset
+	span1 := cmt.StartSpan("op1")
+	span1.Finish()
+	assert.Len(t, cmt.FinishedSpans(), 1)
+	cmt.Reset()
+	assert.Empty(t, cmt.FinishedSpans(), "FinishedSpans should be empty after Reset")
+	assert.Empty(t, cmt.OpenSpans(), "OpenSpans should be empty after Reset")
+
+	// Test Open/Finished Spans sequence
+	span2 := cmt.StartSpan("op2")
+	assert.Len(t, cmt.OpenSpans(), 1, "Should have 1 open span")
+	assert.Equal(t, "op2", cmt.OpenSpans()[0].OperationName())
+	assert.Empty(t, cmt.FinishedSpans(), "FinishedSpans should be empty while span is open")
+
+	span2.Finish()
+	assert.Empty(t, cmt.OpenSpans(), "OpenSpans should be empty after finish")
+	assert.Len(t, cmt.FinishedSpans(), 1, "Should have 1 finished span")
+	assert.Equal(t, "op2", cmt.FinishedSpans()[0].OperationName())
+}
+
+// TestCIVisibilityMockTracer_Stop verifies that the tracer becomes no-op after Stop.
+func TestCIVisibilityMockTracer_Stop(t *testing.T) {
+	cmt := newCIVisibilityMockTracer()
+	tracer.SetGlobalTracer(cmt)
+	defer tracer.StopTestTracer() // Reset the global tracer to avoid side effects
+	cmt.Stop()                    // Stop the tracer
+
+	// Verify isnoop is set (internal check, not strictly necessary but good for understanding)
+	assert.True(t, cmt.isnoop.Load(), "isnoop flag should be true after Stop")
+
+	// Verify methods become no-op
+	assert.Nil(t, cmt.StartSpan("op.after.stop"), "StartSpan should return nil after Stop")
+
+	ctx, err := cmt.Extract(http.Header{})
+	assert.Nil(t, ctx, "Extract should return nil context after Stop")
+	assert.NoError(t, err, "Extract should return no error after Stop")
+
+	err = cmt.Inject(nil, http.Header{})
+	assert.NoError(t, err, "Inject should return no error after Stop")
+
+	assert.Nil(t, cmt.GetDataStreamsProcessor(), "GetDataStreamsProcessor should return nil after Stop")
+	assert.Nil(t, cmt.SentDSMBacklogs(), "SentDSMBacklogs should return nil after Stop")
+
+	// Check span lists are not affected (though Reset would clear them)
+	assert.Empty(t, cmt.FinishedSpans(), "FinishedSpans should remain empty")
+	assert.Empty(t, cmt.OpenSpans(), "OpenSpans should remain empty")
+}
+
+// TestCIVisibilityMockTracer_Flush verifies that Flush moves open spans to finished.
+func TestCIVisibilityMockTracer_Flush(t *testing.T) {
+	cmt := newCIVisibilityMockTracer()
+	tracer.SetGlobalTracer(cmt)
+	defer tracer.StopTestTracer() // Reset the global tracer to avoid side effects
+	defer cmt.Stop()
+
+	// Start a regular span (handled by internal mock) but don't finish it
+	s := cmt.StartSpan("span.to.flush")
+	require.NotNil(t, s)
+
+	// Verify it's in OpenSpans
+	open := cmt.OpenSpans()
+	require.Len(t, open, 1)
+	assert.Equal(t, s.Context().SpanID(), open[0].Context().SpanID())
+	assert.Empty(t, cmt.FinishedSpans())
+
+	// Call Flush
+	cmt.Flush() // Should flush both mock and real (though we only check mock here)
+
+	// Verify the span moved from Open to Finished in the mock tracer
+	assert.Empty(t, cmt.OpenSpans(), "OpenSpans should be empty after Flush")
+	finished := cmt.FinishedSpans()
+	require.Len(t, finished, 1)
+	assert.Equal(t, s.Context().SpanID(), finished[0].Context().SpanID())
+	assert.Equal(t, "span.to.flush", finished[0].OperationName())
+}
+
+// TestCIVisibilityMockTracer_TracerConf verifies TracerConf delegates correctly.
+func TestCIVisibilityMockTracer_TracerConf(t *testing.T) {
+	cmt := newCIVisibilityMockTracer()
+	defer cmt.Stop()
+
+	conf := cmt.TracerConf()
+	// The default mock tracer has an empty config, so we check that
+	assert.Equal(t, tracer.TracerConf{}, conf)
+}
+
+// TestCIVisibilityMockTracer_SentDSMBacklogs tests DSM backlog retrieval.
+func TestCIVisibilityMockTracer_SentDSMBacklogs(t *testing.T) {
+	cmt := newCIVisibilityMockTracer()
+	defer cmt.Stop()
+
+	// Initially, no backlogs
+	backlogs := cmt.SentDSMBacklogs()
+	assert.Empty(t, backlogs)
+
+	// Simulate some DSM activity (indirectly, as direct simulation is complex)
+	// For now, we know the mockDSMTransport starts empty, and flushing doesn't add
+	// without pathway activity, so this test mainly ensures the method doesn't panic
+	// and returns the expected (empty) list from the internal mock transport.
+	cmt.Flush() // Flush includes DSM flush
+
+	backlogs = cmt.SentDSMBacklogs() // Flushes again internally
+	assert.Empty(t, backlogs)        // Still expect empty unless DSM was used
+
+	// Test after stop
+	cmt.Stop()
+	assert.Nil(t, cmt.SentDSMBacklogs(), "Should return nil after stop")
+}

--- a/ddtrace/tracer/civisibility_transport.go
+++ b/ddtrace/tracer/civisibility_transport.go
@@ -162,7 +162,6 @@ func (t *ciVisibilityTransport) send(p *payload) (body io.ReadCloser, err error)
 	if t.agentless {
 		req.Header.Set("Content-Encoding", "gzip")
 	}
-	log.Debug("ciVisibilityTransport: sending transport request: %v bytes", buffer.Len())
 
 	log.Debug("ciVisibilityTransport: sending transport request: %v bytes", buffer.Len())
 	startTime := time.Now()

--- a/ddtrace/tracer/globaltracer.go
+++ b/ddtrace/tracer/globaltracer.go
@@ -7,6 +7,7 @@ package tracer
 
 import (
 	"sync/atomic"
+	_ "unsafe" // for go:linkname
 )
 
 var (
@@ -34,4 +35,9 @@ func GetGlobalTracer() Tracer {
 func StopTestTracer() {
 	var tracer Tracer = &NoopTracer{}
 	globalTracer.Swap(&tracer)
+}
+
+//go:linkname storeGlobalTracer
+func storeGlobalTracer(t Tracer) {
+	globalTracer.Store(&t)
 }

--- a/internal/civisibility/civisibility.go
+++ b/internal/civisibility/civisibility.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+package civisibility
+
+import "sync/atomic"
+
+type State int
+
+const (
+	StateUninitialized State = iota
+	StateInitializing
+	StateInitialized
+	StateExiting
+	StateExited
+)
+
+var (
+	status     atomic.Int32
+	isTestMode atomic.Bool
+)
+
+func GetState() State {
+	// Get the state atomically
+	return State(status.Load())
+}
+
+func SetState(state State) {
+	// Set the state atomically
+	status.Store(int32(state))
+}
+
+func SetTestMode() {
+	isTestMode.Store(true)
+}
+
+func IsTestMode() bool {
+	return isTestMode.Load()
+}

--- a/internal/civisibility/integrations/civisibility.go
+++ b/internal/civisibility/integrations/civisibility.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/internal"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
@@ -50,6 +51,8 @@ func EnsureCiVisibilityInitialization() {
 // InitializeCIVisibilityMock initialize the mocktracer for CI Visibility usage
 func InitializeCIVisibilityMock() mocktracer.Tracer {
 	internalCiVisibilityInitialization(func([]tracer.StartOption) {
+		// Set the library to test mode
+		civisibility.SetTestMode()
 		// Initialize the mocktracer
 		mTracer = mocktracer.Start()
 	})
@@ -58,6 +61,9 @@ func InitializeCIVisibilityMock() mocktracer.Tracer {
 
 func internalCiVisibilityInitialization(tracerInitializer func([]tracer.StartOption)) {
 	ciVisibilityInitializationOnce.Do(func() {
+		civisibility.SetState(civisibility.StateInitializing)
+		defer civisibility.SetState(civisibility.StateInitialized)
+
 		// check the debug flag to enable debug logs. The tracer initialization happens
 		// after the CI Visibility initialization so we need to handle this flag ourselves
 		if internal.BoolEnv("DD_TRACE_DEBUG", false) {
@@ -122,6 +128,13 @@ func PushCiVisibilityCloseAction(action ciVisibilityCloseAction) {
 
 // ExitCiVisibility executes all registered close actions and stops the tracer.
 func ExitCiVisibility() {
+	if civisibility.GetState() != civisibility.StateInitialized {
+		log.Debug("civisibility: already closed or not initialized")
+		return
+	}
+
+	civisibility.SetState(civisibility.StateExiting)
+	defer civisibility.SetState(civisibility.StateExited)
 	log.Debug("civisibility: exiting")
 	closeActionsMutex.Lock()
 	defer closeActionsMutex.Unlock()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds a new MockTracer for CI Visibility mode, to allow mocktracer usage while sending ci visibility data to the backend.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

A TestOptimization/CIVisibility customer have some tests over their custom/manual spans using the mocktracer. Currently, those tests are not being reported due the fact that CIVisibility Test spans also end up in the mocktracer instance.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
