### PR TITLE
fix(ddtrace/tracer): unexport Span.{,R}{,Un}Lock functions

### DIFF
--- a/ddtrace/tracer/abandonedspans_test.go
+++ b/ddtrace/tracer/abandonedspans_test.go
@@ -59,7 +59,7 @@ func assertProcessedSpans(assert *assert.Assertions, t *tracer, startedSpans, fi
 }
 
 func formatSpanString(s *Span) string {
-	s.Lock()
+	s.mu.Lock()
 	var integration string
 	if v, ok := s.meta[ext.Component]; ok {
 		integration = v
@@ -67,7 +67,7 @@ func formatSpanString(s *Span) string {
 		integration = "manual"
 	}
 	msg := fmt.Sprintf("[name: %s, integration: %s, span_id: %d, trace_id: %d, age: %s],", s.name, integration, s.spanID, s.traceID, spanAge(s))
-	s.Unlock()
+	s.mu.Unlock()
 	return msg
 }
 

--- a/ddtrace/tracer/civisibility_tslv.go
+++ b/ddtrace/tracer/civisibility_tslv.go
@@ -408,8 +408,8 @@ func createTslvSpan(span *Span) tslvSpan {
 //
 //	The retrieved metadata value.
 func getAndRemoveMeta(span *Span, key string) string {
-	span.Lock()
-	defer span.Unlock()
+	span.mu.Lock()
+	defer span.mu.Unlock()
 	if span.meta == nil {
 		span.meta = make(map[string]string, 1)
 	}

--- a/ddtrace/tracer/rules_sampler.go
+++ b/ddtrace/tracer/rules_sampler.go
@@ -196,8 +196,8 @@ func (sr *SamplingRule) match(s *Span) bool {
 	if sr.Resource != nil && !sr.Resource.MatchString(s.resource) {
 		return false
 	}
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if sr.Tags != nil {
 		for k, regex := range sr.Tags {
 			if regex == nil {
@@ -481,8 +481,8 @@ func (rs *traceRulesSampler) sampleRules(span *Span) bool {
 }
 
 func (rs *traceRulesSampler) applyRate(span *Span, rate float64, now time.Time, sampler samplernames.SamplerName) {
-	span.Lock()
-	defer span.Unlock()
+	span.mu.Lock()
+	defer span.mu.Unlock()
 
 	span.setMetric(keyRulesSamplerAppliedRate, rate)
 	delete(span.metrics, keySamplingPriorityRate)

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -655,9 +655,9 @@ func spanStart(operationName string, options ...StartSpanOption) *Span {
 		}
 		if context.span != nil {
 			// local parent, inherit service
-			context.span.RLock()
+			context.span.mu.RLock()
 			span.service = context.span.service
-			context.span.RUnlock()
+			context.span.mu.RUnlock()
 		} else {
 			// remote parent
 			if context.origin != "" {


### PR DESCRIPTION
### What does this PR do?

Unexports `Span.{,R}{,Un}Lock` functions, as they were exposed in `v2` as side effect of changing `span` to `Span`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
