### PR TITLE
chore(.github/workflows) enable golangci-lint steps on unit-integration-tests

### DIFF
--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -86,11 +86,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      ## Disabled for v2 until the main PR is merged,
       - name: golangci-lint
-        ## Disabled for v2 until the main PR is merged,
-        ## as it's too large for reviewdog: https://github.com/DataDog/dd-trace-go/actions/runs/8423412332/job/23064985838#step:3:94
-        if: false
         uses: reviewdog/action-golangci-lint@dd3fda91790ca90e75049e5c767509dc0ec7d99b # v2.7.0
         with:
           golangci_lint_flags: "--timeout 10m" # We are hitting timeout when there is no cache
@@ -100,8 +96,6 @@ jobs:
           reporter: github-pr-review
 
       - name: golangci-lint (internal/orchestrion/_integration)
-        # Disable while Orchestrion is not ported to v2
-        if: false
         uses: reviewdog/action-golangci-lint@dd3fda91790ca90e75049e5c767509dc0ec7d99b # v2.7.0
         with:
           golangci_lint_flags: "--timeout 10m" # We are hitting timeout when there is no cache


### PR DESCRIPTION
### What does this PR do?

Enables `golangci-lint` steps, as they were disabled while `v2` was under development.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
