### PR TITLE
chore(ci): update golangci-lint configuration and version (v2) in workflows

### DIFF
--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -87,20 +87,20 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - name: golangci-lint
-        uses: reviewdog/action-golangci-lint@dd3fda91790ca90e75049e5c767509dc0ec7d99b # v2.7.0
+        uses: reviewdog/action-golangci-lint@f9bba13753278f6a73b27a56a3ffb1bfda90ed71 # v2.8.0
         with:
           golangci_lint_flags: "--timeout 10m" # We are hitting timeout when there is no cache
           go_version: ${{ inputs.go-version }}
-          golangci_lint_version: v1.64.5
+          golangci_lint_version: v2.1.2
           fail_level: error
           reporter: github-pr-review
 
       - name: golangci-lint (internal/orchestrion/_integration)
-        uses: reviewdog/action-golangci-lint@dd3fda91790ca90e75049e5c767509dc0ec7d99b # v2.7.0
+        uses: reviewdog/action-golangci-lint@f9bba13753278f6a73b27a56a3ffb1bfda90ed71 # v2.8.0
         with:
           golangci_lint_flags: "--timeout 10m" # We are hitting timeout when there is no cache
           go_version: ${{ inputs.go-version }}
-          golangci_lint_version: v1.64.5
+          golangci_lint_version: v2.1.2
           fail_level: error
           reporter: github-pr-review
           workdir: internal/orchestrion/_integration

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,27 @@
-run:
-  deadline: 10m
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-  - gofmt
-  - govet
-  - revive
-  - bodyclose
+    - bodyclose
+    - govet
+    - revive
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/ddtrace/mocktracer/mockspan.go
+++ b/ddtrace/mocktracer/mockspan.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"testing"
 	"time"
-	_ "unsafe"
+	_ "unsafe" // Needed for go:linkname directive.
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/ddtrace/tracer/logger_test.go
+++ b/ddtrace/tracer/logger_test.go
@@ -21,7 +21,7 @@ type logRecord struct {
 
 func TestAdaptLogger(t *testing.T) {
 	recorder := make([]logRecord, 0)
-	l := tracer.AdaptLogger(func(lvl tracer.LogLevel, msg string, a ...any) {
+	l := tracer.AdaptLogger(func(lvl tracer.LogLevel, msg string, _ ...any) {
 		recorder = append(recorder, logRecord{
 			level: lvl,
 			msg:   msg,

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -548,17 +548,17 @@ func newConfig(opts ...StartOption) (*config, error) {
 	}
 	if c.propagator == nil {
 		envKey := "DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH"
-		max := internal.IntEnv(envKey, defaultMaxTagsHeaderLen)
-		if max < 0 {
-			log.Warn("Invalid value %d for %s. Setting to 0.", max, envKey)
-			max = 0
+		maxLen := internal.IntEnv(envKey, defaultMaxTagsHeaderLen)
+		if maxLen < 0 {
+			log.Warn("Invalid value %d for %s. Setting to 0.", maxLen, envKey)
+			maxLen = 0
 		}
-		if max > maxPropagatedTagsLength {
-			log.Warn("Invalid value %d for %s. Maximum allowed is %d. Setting to %d.", max, envKey, maxPropagatedTagsLength, maxPropagatedTagsLength)
-			max = maxPropagatedTagsLength
+		if maxLen > maxPropagatedTagsLength {
+			log.Warn("Invalid value %d for %s. Maximum allowed is %d. Setting to %d.", maxLen, envKey, maxPropagatedTagsLength, maxPropagatedTagsLength)
+			maxLen = maxPropagatedTagsLength
 		}
 		c.propagator = NewPropagator(&PropagatorConfig{
-			MaxTagsHeaderLen: max,
+			MaxTagsHeaderLen: maxLen,
 		})
 	}
 	if c.logger != nil {

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -363,7 +363,7 @@ func TestIntegrationEnabled(t *testing.T) {
 	if _, err = os.Stat(root); err != nil {
 		t.Fatal(err)
 	}
-	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+	err = filepath.WalkDir(root, func(path string, _ fs.DirEntry, _ error) error {
 		if filepath.Base(path) != "go.mod" || strings.Contains(path, fmt.Sprintf("%cinternal", os.PathSeparator)) {
 			return nil
 		}

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -68,7 +68,7 @@ func TestSpanAsMap(t *testing.T) {
 			want: nil,
 		},
 	} {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(_ *testing.T) {
 			assertions.Equal(tt.want, tt.span.AsMap()[ext.SpanName])
 		})
 	}

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -25,11 +25,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setupteardown(start, max int) func() {
+func setupteardown(startSize, maxSize int) func() {
 	oldStartSize := traceStartSize
 	oldMaxSize := traceMaxSize
-	traceStartSize = start
-	traceMaxSize = max
+	traceStartSize = startSize
+	traceMaxSize = maxSize
 	return func() {
 		traceStartSize = oldStartSize
 		traceMaxSize = oldMaxSize
@@ -97,7 +97,7 @@ func TestIncident37240DoubleFinish(t *testing.T) {
 	assert.Nil(t, err)
 	defer stop()
 
-	t.Run("with link", func(t *testing.T) {
+	t.Run("with link", func(_ *testing.T) {
 		root, _ := StartSpanFromContext(context.Background(), "root", Tag(ext.ManualKeep, true))
 		// My theory is that contrib/aws/internal/span_pointers/span_pointers.go
 		// adds a span link which is causes `serializeSpanLinksInMeta` to write to
@@ -109,14 +109,14 @@ func TestIncident37240DoubleFinish(t *testing.T) {
 		}
 	})
 
-	t.Run("with NoDebugStack", func(t *testing.T) {
+	t.Run("with NoDebugStack", func(_ *testing.T) {
 		root, _ := StartSpanFromContext(context.Background(), "root", Tag(ext.ManualKeep, true))
 		for i := 0; i < 1000; i++ {
 			root.Finish(NoDebugStack())
 		}
 	})
 
-	t.Run("with error", func(t *testing.T) {
+	t.Run("with error", func(_ *testing.T) {
 		root, _ := StartSpanFromContext(context.Background(), "root", Tag(ext.ManualKeep, true))
 		err := errors.New("test error")
 		for i := 0; i < 1000; i++ {

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -124,7 +124,7 @@ func startTelemetry(c *config) {
 	if c.orchestrionCfg.Enabled {
 		// If orchestrion is enabled, report it to the back-end via a telemetry metric on every flush.
 		handle := client.Gauge(telemetry.NamespaceTracers, "orchestrion.enabled", []string{"version:" + c.orchestrionCfg.Metadata.Version})
-		client.AddFlushTicker(func(c telemetry.Client) { handle.Submit(1) })
+		client.AddFlushTicker(func(_ telemetry.Client) { handle.Submit(1) })
 	}
 
 	telemetry.StartApp(client)

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -2494,7 +2494,7 @@ func TestMalformedTID(t *testing.T) {
 	defer tracer.Stop()
 	defer SetGlobalTracer(&NoopTracer{})
 
-	t.Run("datadog, short tid", func(t *testing.T) {
+	t.Run("datadog, short tid", func(_ *testing.T) {
 		headers := TextMapCarrier(map[string]string{
 			DefaultTraceIDHeader:  "1234567890123456789",
 			DefaultParentIDHeader: "987654321",
@@ -2507,7 +2507,7 @@ func TestMalformedTID(t *testing.T) {
 		assert.NotContains(root.meta, keyTraceID128)
 	})
 
-	t.Run("datadog, malformed tid", func(t *testing.T) {
+	t.Run("datadog, malformed tid", func(_ *testing.T) {
 		headers := TextMapCarrier(map[string]string{
 			DefaultTraceIDHeader:  "1234567890123456789",
 			DefaultParentIDHeader: "987654321",
@@ -2520,7 +2520,7 @@ func TestMalformedTID(t *testing.T) {
 		assert.NotContains(root.meta, keyTraceID128)
 	})
 
-	t.Run("datadog, valid tid", func(t *testing.T) {
+	t.Run("datadog, valid tid", func(_ *testing.T) {
 		headers := TextMapCarrier(map[string]string{
 			DefaultTraceIDHeader:  "1234567890123456789",
 			DefaultParentIDHeader: "987654321",

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -336,7 +336,7 @@ func TestWithHTTPClient(t *testing.T) {
 	t.Setenv("DD_TRACE_STARTUP_LOGS", "0")
 	assert := assert.New(t)
 	var hits int
-	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		hits++
 	}))
 	defer srv.Close()

--- a/instrumentation/appsec/dyngo/operation.go
+++ b/instrumentation/appsec/dyngo/operation.go
@@ -77,8 +77,8 @@ var rootOperation atomic.Pointer[Operation]
 // SwapRootOperation allows to atomically swap the current root operation with
 // the given new one. Concurrent uses of the old root operation on already
 // existing and running operation are still valid.
-func SwapRootOperation(new Operation) {
-	rootOperation.Swap(&new)
+func SwapRootOperation(newOp Operation) {
+	rootOperation.Swap(&newOp)
 	// Note: calling Finish(old, ...) could result into mem leaks because
 	// some finish event listeners, possibly releasing memory and resources,
 	// wouldn't be called anymore (because Finish() disables the operation and

--- a/instrumentation/instrumentation.go
+++ b/instrumentation/instrumentation.go
@@ -39,7 +39,7 @@ func Load(pkg Package) *Instrumentation {
 	}
 }
 
-func Register(name string, info PackageInfo) error {
+func Register(_ string, info PackageInfo) error {
 	info.external = true
 	return nil
 }

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -241,7 +241,7 @@ func applyAdditionalFeaturesToTestFunc(f func(*testing.T), testInfo *commonInfo)
 		runTestWithRetry(&runTestWithRetryOptions{
 			targetFunc: f,
 			t:          t,
-			preExecMetaAdjust: func(execMeta *testExecutionMetadata, executionIndex int) {
+			preExecMetaAdjust: func(execMeta *testExecutionMetadata, _ int) {
 				// Synchronize the test execution metadata with the original test execution metadata.
 
 				execMeta.isQuarantined = execMeta.isQuarantined || ptrMeta.isQuarantined
@@ -265,7 +265,7 @@ func applyAdditionalFeaturesToTestFunc(f func(*testing.T), testInfo *commonInfo)
 				ptrMeta.isNew = execMeta.isANewTest
 				ptrMeta.isModified = execMeta.isAModifiedTest
 			},
-			preIsLastRetry: func(execMeta *testExecutionMetadata, executionIndex int, remainingRetries int64) bool {
+			preIsLastRetry: func(execMeta *testExecutionMetadata, _ int, remainingRetries int64) bool {
 				if execMeta.isAttemptToFix || isAnEfdExecution(execMeta) {
 					// For attempt-to-fix tests and EFD, the last retry is when remaining retries == 1.
 					return remainingRetries == 1
@@ -309,7 +309,7 @@ func applyAdditionalFeaturesToTestFunc(f func(*testing.T), testInfo *commonInfo)
 				// No retries
 				return 0
 			},
-			postPerExecution: func(ptrToLocalT *testing.T, execMeta *testExecutionMetadata, executionIndex int, duration time.Duration) {
+			postPerExecution: func(ptrToLocalT *testing.T, execMeta *testExecutionMetadata, executionIndex int, _ time.Duration) {
 				if ptrToLocalT.Failed() || ptrToLocalT.Skipped() {
 					atomic.StoreInt32(&allAttemptsPassed, 0)
 				}
@@ -347,7 +347,7 @@ func applyAdditionalFeaturesToTestFunc(f func(*testing.T), testInfo *commonInfo)
 					return
 				}
 			},
-			postShouldRetry: func(ptrToLocalT *testing.T, execMeta *testExecutionMetadata, executionIndex int, remainingRetries int64) bool {
+			postShouldRetry: func(ptrToLocalT *testing.T, execMeta *testExecutionMetadata, _ int, remainingRetries int64) bool {
 				if execMeta.isAttemptToFix {
 					// For attempt-to-fix tests, retry if remaining retries > 0.
 					return remainingRetries > 0

--- a/internal/civisibility/utils/ci_providers.go
+++ b/internal/civisibility/utils/ci_providers.go
@@ -414,7 +414,7 @@ func extractGithubActions() map[string]string {
 		if eventFile, err := os.Open(eventFilePath); err == nil {
 			defer eventFile.Close()
 
-			var eventJson struct {
+			var eventJSON struct {
 				PullRequest struct {
 					Base struct {
 						Sha string `json:"sha"`
@@ -427,10 +427,10 @@ func extractGithubActions() map[string]string {
 			}
 
 			eventDecoder := json.NewDecoder(eventFile)
-			if eventDecoder.Decode(&eventJson) == nil {
-				tags[constants.GitHeadCommit] = eventJson.PullRequest.Head.Sha
-				tags[constants.GitPrBaseCommit] = eventJson.PullRequest.Base.Sha
-				tags[constants.GitPrBaseBranch] = eventJson.PullRequest.Base.Ref
+			if eventDecoder.Decode(&eventJSON) == nil {
+				tags[constants.GitHeadCommit] = eventJSON.PullRequest.Head.Sha
+				tags[constants.GitPrBaseCommit] = eventJSON.PullRequest.Base.Sha
+				tags[constants.GitPrBaseBranch] = eventJSON.PullRequest.Base.Ref
 			}
 		}
 	}

--- a/internal/civisibility/utils/file_environmental_data.go
+++ b/internal/civisibility/utils/file_environmental_data.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	_ "unsafe"
+	_ "unsafe" // for go:linkname
 
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 	logger "github.com/DataDog/dd-trace-go/v2/internal/log"

--- a/internal/civisibility/utils/impactedtests/impacted_tests.go
+++ b/internal/civisibility/utils/impactedtests/impacted_tests.go
@@ -207,7 +207,7 @@ func getTestImpactInfo(sourceFile string, startLine int, endLine int) []*fileWit
 // parseGitDiffOutput parses the git diff output to extract modified files and their changed lines.
 func parseGitDiffOutput(output string) []fileWithBitmap {
 	var fileChanges []fileWithBitmap
-	var currentFile *fileWithBitmap = nil
+	var currentFile *fileWithBitmap
 	var modifiedLines []lineRange
 
 	// Split output into lines (ignoring empty lines)

--- a/internal/civisibility/utils/net/http.go
+++ b/internal/civisibility/utils/net/http.go
@@ -82,9 +82,8 @@ func (r *Response) Unmarshal(target interface{}) error {
 		if target.(msgp.Unmarshaler) != nil {
 			_, err := target.(msgp.Unmarshaler).UnmarshalMsg(r.Body)
 			return err
-		} else {
-			return errors.New("target must implement msgp.Unmarshaler for MessagePack unmarshalling")
 		}
+		return errors.New("target must implement msgp.Unmarshaler for MessagePack unmarshalling")
 	default:
 		return fmt.Errorf("unsupported format '%s' for unmarshalling", r.Format)
 	}

--- a/internal/civisibility/utils/telemetry/telemetry_count.go
+++ b/internal/civisibility/utils/telemetry/telemetry_count.go
@@ -40,9 +40,8 @@ func GetErrorTypeFromStatusCode(statusCode int) ErrorType {
 			return StatusCode5xxErrorType
 		} else if statusCode >= 400 && statusCode < 500 {
 			return StatusCode4xxErrorType
-		} else {
-			return StatusCodeErrorType
 		}
+		return StatusCodeErrorType
 	}
 }
 

--- a/internal/contrib/telemetrytest/telemetry_test.go
+++ b/internal/contrib/telemetrytest/telemetry_test.go
@@ -42,7 +42,7 @@ func TestTelemetryEnabled(t *testing.T) {
 	if _, err = os.Stat(root); err != nil {
 		t.Fatal(err)
 	}
-	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+	err = filepath.WalkDir(root, func(path string, _ fs.DirEntry, _ error) error {
 		if filepath.Base(path) != "go.mod" {
 			return nil
 		}

--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -387,36 +387,36 @@ func HasProduct(p string) (bool, error) {
 
 // RegisterCapability adds a capability to the list of capabilities exposed by the client when requesting
 // configuration updates
-func RegisterCapability(cap Capability) error {
+func RegisterCapability(c Capability) error {
 	if client == nil {
 		return ErrClientNotStarted
 	}
 	client.capabilitiesMu.Lock()
 	defer client.capabilitiesMu.Unlock()
-	client.capabilities[cap] = struct{}{}
+	client.capabilities[c] = struct{}{}
 	return nil
 }
 
 // UnregisterCapability removes a capability from the list of capabilities exposed by the client when requesting
 // configuration updates
-func UnregisterCapability(cap Capability) error {
+func UnregisterCapability(c Capability) error {
 	if client == nil {
 		return ErrClientNotStarted
 	}
 	client.capabilitiesMu.Lock()
 	defer client.capabilitiesMu.Unlock()
-	delete(client.capabilities, cap)
+	delete(client.capabilities, c)
 	return nil
 }
 
 // HasCapability returns whether a given capability was registered
-func HasCapability(cap Capability) (bool, error) {
+func HasCapability(c Capability) (bool, error) {
 	if client == nil {
 		return false, ErrClientNotStarted
 	}
 	client.capabilitiesMu.RLock()
 	defer client.capabilitiesMu.RUnlock()
-	_, found := client.capabilities[cap]
+	_, found := client.capabilities[c]
 	return found, nil
 }
 

--- a/profiler/metrics.go
+++ b/profiler/metrics.go
@@ -108,7 +108,7 @@ func rate(curr, prev uint64, period float64) float64 {
 }
 
 // maxPauseNs returns maximum pause time within the recent period, assumes stats populated at period end
-func maxPauseNs(stats *runtime.MemStats, periodStart time.Time) (max uint64) {
+func maxPauseNs(stats *runtime.MemStats, periodStart time.Time) (maxPause uint64) {
 	// NB
 	// stats.PauseEnd is a circular buffer of recent GC pause end times as nanoseconds since the epoch.
 	// stats.PauseNs is a circular buffer of recent GC pause times in nanoseconds.
@@ -120,11 +120,11 @@ func maxPauseNs(stats *runtime.MemStats, periodStart time.Time) (max uint64) {
 		if time.Unix(0, int64(stats.PauseEnd[offset])).Before(periodStart) {
 			break
 		}
-		if stats.PauseNs[offset] > max {
-			max = stats.PauseNs[offset]
+		if stats.PauseNs[offset] > maxPause {
+			maxPause = stats.PauseNs[offset]
 		}
 	}
-	return max
+	return maxPause
 }
 
 // removeInvalid removes NaN and +/-Inf values as they can't be json-serialized


### PR DESCRIPTION
- Updated .golangci.yml to set version to "2" and adjusted linters and exclusions.
- Updated golangci-lint version in GitHub workflows from v2.7.0 to v2.8.0 and golangci_lint_version from v1.64.5 to v2.1.2.
- Made minor adjustments to put the linter at ease.

Signed-off-by: Kemal Akkoyun <kemal.akkoyun@datadoghq.com>

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
