### PR TITLE
chore(.github/workflows): remove APM_TRACING_E2E scenario from system-tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -56,7 +56,6 @@ jobs:
           - APPSEC_API_SECURITY
           - APPSEC_RASP
           - APPSEC_RUNTIME_ACTIVATION
-          - APM_TRACING_E2E
           - APM_TRACING_E2E_SINGLE_SPAN
           - APM_TRACING_E2E_OTEL
           - TRACING_CONFIG_SCENARIOS
@@ -89,11 +88,6 @@ jobs:
           - weblog-variant: net-http
             scenario: APPSEC_WAF_TELEMETRY
           # APM scenarios requiring specific environment settings
-          - scenario: APM_TRACING_E2E
-            env:
-              DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY
-              DD_APPLICATION_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY
-              DD_SITE="datadoghq.com"
           - scenario: APM_TRACING_E2E_SINGLE_SPAN
             env:
               DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY


### PR DESCRIPTION
### What does this PR do?

Removes `APM_TRACING_E2E` scenario from `system-tests`, as it was removed in https://github.com/DataDog/system-tests/pull/4537/.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
