### PR TITLE
sampling: fix unit test traceID for sampling

### DIFF
--- a/ddtrace/tracer/sampler_test.go
+++ b/ddtrace/tracer/sampler_test.go
@@ -177,9 +177,9 @@ func TestRateSampler(t *testing.T) {
 	assert.False(NewRateSampler(0.99).Sample(nil))
 	assert.False(NewRateSampler(0.5).Sample(newSpan("test", "test", "test", 0, 12078589664685934330, 0)))
 	assert.True(NewRateSampler(0.5).Sample(newSpan("test", "test", "test", 0, 13794769880582338323, 0)))
-	// traceID 5826373039044427785 * knuthFactor = 9223372036854775807 (leveraging the overflow logic)
+	// traceID 9223372036854775808 * knuthFactor = 9223372036854775808 (leveraging the overflow logic)
 	// which is 0.5 * MaxUint64
-	assert.True(NewRateSampler(0.5).Sample(newSpan("test", "test", "test", 0, 5826373039044427785, 0)))
+	assert.True(NewRateSampler(0.5).Sample(newSpan("test", "test", "test", 0, 9223372036854775808, 0)))
 }
 
 func TestSamplerRates(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Changes the traceID given in the unit test from `5826373039044427785` to `9223372036854775808`

### Motivation

In #3423 I introduced a new traceID in a sampler unit test, unfortunately I used `MaxUint64/2` instead of `MaxUint*0.5` when I wrote some code to find which `TraceID * KNUTH == MaxUint64 * 0.5`.

```
maxUint64 * 0.5 9223372036854775808 (round)
maxUint64 / 2 9223372036854775807 (truncate)
```


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
