### PR TITLE
fix(ddtrace/tracer): prevent applying rate to finished spans and add test coverage for this finishing code path (#3474 backport)

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -127,6 +127,7 @@ func (s *span) SetTag(key string, value interface{}) {
 	value = dereference(value)
 	s.Lock()
 	defer s.Unlock()
+
 	// We don't lock spans when flushing, so we could have a data race when
 	// modifying a span as it's being flushed. This protects us against that
 	// race, since spans are marked `finished` before we flush them.
@@ -266,6 +267,7 @@ func (s *span) SetUser(id string, opts ...UserMonitoringOption) {
 	trace := root.context.trace
 	root.Lock()
 	defer root.Unlock()
+
 	// We don't lock spans when flushing, so we could have a data race when
 	// modifying a span as it's being flushed. This protects us against that
 	// race, since spans are marked `finished` before we flush them.
@@ -339,6 +341,9 @@ func (s *span) setTagError(value interface{}, cfg errorConfig) {
 			s.Error = 0
 		}
 	}
+	// We don't lock spans when flushing, so we could have a data race when
+	// modifying a span as it's being flushed. This protects us against that
+	// race, since spans are marked `finished` before we flush them.
 	if s.finished {
 		return
 	}
@@ -486,6 +491,7 @@ func (s *span) setMetric(key string, v float64) {
 func (s *span) AddSpanLink(link ddtrace.SpanLink) {
 	s.Lock()
 	defer s.Unlock()
+
 	// We don't lock spans when flushing, so we could have a data race when
 	// modifying a span as it's being flushed. This protects us against that
 	// race, since spans are marked `finished` before we flush them.
@@ -592,6 +598,7 @@ func (s *span) Finish(opts ...ddtrace.FinishOption) {
 func (s *span) SetOperationName(operationName string) {
 	s.Lock()
 	defer s.Unlock()
+
 	// We don't lock spans when flushing, so we could have a data race when
 	// modifying a span as it's being flushed. This protects us against that
 	// race, since spans are marked `finished` before we flush them.
@@ -605,6 +612,7 @@ func (s *span) SetOperationName(operationName string) {
 func (s *span) finish(finishTime int64) {
 	s.Lock()
 	defer s.Unlock()
+
 	// We don't lock spans when flushing, so we could have a data race when
 	// modifying a span as it's being flushed. This protects us against that
 	// race, since spans are marked `finished` before we flush them.
@@ -801,6 +809,10 @@ func (s *span) Format(f fmt.State, c rune) {
 func (s *span) AddEvent(name string, opts ...ddtrace.SpanEventOption) {
 	s.Lock()
 	defer s.Unlock()
+
+	// We don't lock spans when flushing, so we could have a data race when
+	// modifying a span as it's being flushed. This protects us against that
+	// race, since spans are marked `finished` before we flush them.
 	if s.finished {
 		return
 	}


### PR DESCRIPTION
### What does this PR do?

Backports #3474.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
