### PR TITLE
feat(http): add round tripper option for status check functionality and corresponding tests

### DIFF
--- a/contrib/net/http/http_test.go
+++ b/contrib/net/http/http_test.go
@@ -457,6 +457,65 @@ func TestIgnoreRequestOption(t *testing.T) {
 	}
 }
 
+func TestStatusCheck(t *testing.T) {
+	tests := []struct {
+		url           string
+		expectedError bool
+		handler       http.Handler
+	}{
+		{
+			url:           "/200",
+			expectedError: false,
+			handler:       http.HandlerFunc(handler200),
+		},
+		{
+			url:           "/400",
+			expectedError: true,
+			handler:       http.HandlerFunc(handler400),
+		},
+		{
+			url:           "/404",
+			expectedError: false,
+			handler:       http.HandlerFunc(handler404),
+		},
+	}
+	statusCheck := func(statusCode int) bool {
+		return statusCode >= 400 && statusCode != http.StatusNotFound
+	}
+	for _, test := range tests {
+		t.Run("servemux"+test.url, func(t *testing.T) {
+			mt := mocktracer.Start()
+			defer mt.Stop()
+
+			mux := NewServeMux(WithStatusCheck(statusCheck))
+			mux.HandleFunc("/200", handler200)
+			mux.HandleFunc("/400", handler400)
+			mux.HandleFunc("/404", handler404)
+
+			r := httptest.NewRequest("GET", "http://localhost"+test.url, nil)
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, r)
+
+			spans := mt.FinishedSpans()
+			assert.Equal(t, test.expectedError, spans[0].Tag(ext.Error) != nil)
+		})
+		t.Run("wraphandler"+test.url, func(t *testing.T) {
+			mt := mocktracer.Start()
+			defer mt.Stop()
+
+			r := httptest.NewRequest("GET", "http://localhost"+test.url, nil)
+			w := httptest.NewRecorder()
+			f := test.handler
+
+			handler := WrapHandler(f, "my-service", "my-resource", WithStatusCheck(statusCheck))
+			handler.ServeHTTP(w, r)
+
+			spans := mt.FinishedSpans()
+			assert.Equal(t, test.expectedError, spans[0].Tag(ext.Error) != nil)
+		})
+	}
+}
+
 func TestServerNamingSchema(t *testing.T) {
 	genSpans := namingschematest.GenSpansFn(func(t *testing.T, serviceOverride string) []mocktracer.Span {
 		var opts []Option
@@ -498,6 +557,10 @@ func handler500(w http.ResponseWriter, r *http.Request) {
 
 func handler400(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "400!", http.StatusBadRequest)
+}
+
+func handler404(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "404!", http.StatusNotFound)
 }
 
 func BenchmarkHttpServeTrace(b *testing.B) {

--- a/contrib/net/http/option.go
+++ b/contrib/net/http/option.go
@@ -261,6 +261,14 @@ func RTWithErrorCheck(fn func(err error) bool) RoundTripperOption {
 	}
 }
 
+// RTWithStatusCheck sets a span to be an error if the passed function
+// returns true for a given status code.
+func RTWithStatusCheck(fn func(statusCode int) bool) RoundTripperOption {
+	return func(cfg *roundTripperConfig) {
+		cfg.isStatusError = fn
+	}
+}
+
 func isClientError(statusCode int) bool {
 	return statusCode >= 400 && statusCode < 500
 }

--- a/contrib/net/http/roundtripper_test.go
+++ b/contrib/net/http/roundtripper_test.go
@@ -438,6 +438,35 @@ func TestRoundTripperIgnoreRequest(t *testing.T) {
 	assert.Len(t, spans, 1)
 }
 
+func TestRoundTripperStatusCheck(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer s.Close()
+
+	rt := WrapRoundTripper(http.DefaultTransport, RTWithStatusCheck(func(statusCode int) bool {
+		return statusCode >= 400 && statusCode != http.StatusNotFound
+	}))
+
+	client := &http.Client{
+		Transport: rt,
+	}
+	resp, err := client.Get(s.URL + "/hello/world")
+	assert.Nil(t, err)
+	defer resp.Body.Close()
+
+	spans := mt.FinishedSpans()
+	assert.Len(t, spans, 1)
+	assert.Equal(t, "http.request", spans[0].OperationName())
+	assert.Equal(t, "http.request", spans[0].Tag(ext.ResourceName))
+	assert.Equal(t, "404", spans[0].Tag(ext.HTTPCode))
+	assert.Equal(t, "GET", spans[0].Tag(ext.HTTPMethod))
+	assert.Nil(t, spans[0].Tag(ext.Error))
+}
+
 func TestRoundTripperURLWithoutPort(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()


### PR DESCRIPTION
### What does this PR do?

Adds suggested `RTWithStatusCheck` in #3422. Also increases coverage by adding tests to the currently available `WithStatusCheck`.

### Motivation

Ensure that #3422 has proper tests, and it's branched out from `release-v1.73.x`.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
