### PR TITLE
chore(ci): Ensure that PR are merged with a green CI

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Ensure CI Success
-        uses: DataDog/ensure-ci-success@v1
+        uses: DataDog/ensure-ci-success@a874030af0d650da8864aff94b8b42f83e88a0b5
         with:
           initial-delay-seconds: "1000"  # smoke tests takes approx 20 mn to finish

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -19,3 +19,4 @@ jobs:
         uses: DataDog/ensure-ci-success@a874030af0d650da8864aff94b8b42f83e88a0b5
         with:
           initial-delay-seconds: "1000"  # smoke tests takes approx 20 mn to finish
+          max-retries: "60"

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -1,0 +1,21 @@
+name: Check Pull Request CI Status
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  checks: read
+  statuses: read
+
+jobs:
+  all-jobs-are-green:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Ensure CI Success
+        uses: DataDog/ensure-ci-success@v1
+        with:
+          initial-delay-seconds: "1000"  # smoke tests takes approx 20 mn to finish


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Add a job in the CI that runs in PR. The job will be a success if all other jobs are skipped/success, and fails otherwise

### Motivation

While it's possible to enforce a green CI policy using GitHub's native "required status checks" feature, doing so requires explicitly listing all job names under branch protection rules. This approach has two key drawbacks:

- It does not support optional jobs
- It introduces ongoing maintenance overhead as the job list evolves

This jobs will check ALL other job, and we'll be able to set this as a requirement. The action used offers a `ignored-name-patterns` parameters`, if at some point a job is flaky. But right now, I think all jobs are healthy.

the plan is to merge this PR, wait few days to be sure that everything is fine. Then add it as a requirement.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
