### PR TITLE
fix(contrib/google.golang.org/api): update tests to use ElectionQuery instead of RepresentativeInfoByAddress

### DIFF
--- a/contrib/google.golang.org/api/api_test.go
+++ b/contrib/google.golang.org/api/api_test.go
@@ -77,7 +77,7 @@ func TestCivicInfo(t *testing.T) {
 		Transport: WrapRoundTripper(badRequestTransport),
 	}))
 	assert.NoError(t, err)
-	svc.Representatives.RepresentativeInfoByAddress().Do()
+	svc.Elections.ElectionQuery().Do()
 
 	spans := mt.FinishedSpans()
 	assert.Len(t, spans, 1)
@@ -86,10 +86,10 @@ func TestCivicInfo(t *testing.T) {
 	assert.Equal(t, "http.request", s0.OperationName())
 	assert.Equal(t, "http", s0.Tag(ext.SpanType))
 	assert.Equal(t, "google.civicinfo", s0.Tag(ext.ServiceName))
-	assert.Equal(t, "civicinfo.representatives.representativeInfoByAddress", s0.Tag(ext.ResourceName))
+	assert.Equal(t, "civicinfo.elections.electionQuery", s0.Tag(ext.ResourceName))
 	assert.Equal(t, "400", s0.Tag(ext.HTTPCode))
 	assert.Equal(t, "GET", s0.Tag(ext.HTTPMethod))
-	assert.Equal(t, svc.BasePath+"civicinfo/v2/representatives?alt=json&prettyPrint=false", s0.Tag(ext.HTTPURL))
+	assert.Equal(t, svc.BasePath+"civicinfo/v2/elections?alt=json&prettyPrint=false", s0.Tag(ext.HTTPURL))
 	assert.Equal(t, "google.golang.org/api", s0.Tag(ext.Component))
 	assert.Equal(t, componentName, s0.Integration())
 	assert.Equal(t, ext.SpanKindClient, s0.Tag(ext.SpanKind))
@@ -131,7 +131,7 @@ func TestWithEndpointMetadataDisabled(t *testing.T) {
 		Transport: WrapRoundTripper(badRequestTransport, WithEndpointMetadataDisabled()),
 	}))
 	require.NoError(t, err)
-	svc.Representatives.RepresentativeInfoByAddress().Do()
+	svc.Elections.ElectionQuery().Do()
 
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
@@ -143,7 +143,7 @@ func TestWithEndpointMetadataDisabled(t *testing.T) {
 	assert.Equal(t, "GET civicinfo.googleapis.com", s0.Tag(ext.ResourceName))
 	assert.Equal(t, "400", s0.Tag(ext.HTTPCode))
 	assert.Equal(t, "GET", s0.Tag(ext.HTTPMethod))
-	assert.Equal(t, svc.BasePath+"civicinfo/v2/representatives?alt=json&prettyPrint=false", s0.Tag(ext.HTTPURL))
+	assert.Equal(t, svc.BasePath+"civicinfo/v2/elections?alt=json&prettyPrint=false", s0.Tag(ext.HTTPURL))
 	assert.Equal(t, "google.golang.org/api", s0.Tag(ext.Component))
 	assert.Equal(t, componentName, s0.Integration())
 	assert.Equal(t, ext.SpanKindClient, s0.Tag(ext.SpanKind))


### PR DESCRIPTION
### What does this PR do?

Replaces the [deprecated `Representatives` API](https://github.com/googleapis/google-api-go-client/commit/25f8d4abda5f98d9ea4dcae64dc5ac51dc296a19#diff-6a6c97dd574f01809e7dc3ab456d35a453c8ffa75ec9e51a8f689ef472a60f78L460) from `google.golang.org/api/civicinfo/v2` with `Election` API, which exists in previous versions and the current one.

### Motivation

Smoke tests are failing: https://github.com/DataDog/dd-trace-go/actions/runs/14881053781/job/41789069646?pr=3482#step:7:341

```
=== FAIL: .  (0.00s)
FAIL	github.com/DataDog/dd-trace-go/contrib/google.golang.org/api/v2 [build failed]

=== Errors
Error: ./api_test.go:80:6: svc.Representatives undefined (type *civicinfo.Service has no field or method Representatives)

Error: ./api_test.go:134:6: svc.Representatives undefined (type *civicinfo.Service has no field or method Representatives)
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
