### PR TITLE
fix codeowners order

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,16 +2,6 @@
 
 # default owner
 *                               @DataDog/dd-trace-go-guild @DataDog/apm-go
-
-# no owner: changes to these files will not automatically ping any particular
-# team and can be reviewed by anybody with the appropriate permissions. This is
-# meant to avoid pinging all of @DataDog/dd-trace-go-guild for every PR that
-# changes one of these files.
-**/go.mod
-**/go.sum
-go.work
-go.work.sum
-
 # tracing
 /contrib                        @DataDog/apm-go @Datadog/apm-idm-go
 /ddtrace                        @DataDog/apm-go
@@ -42,3 +32,12 @@ go.work.sum
 # Orchestrion
 /internal/orchestrion           @DataDog/apm-orchestrion @DataDog/apm-go
 /**/orchestrion.yml             @DataDog/apm-orchestrion @DataDog/apm-go
+
+# no owner: changes to these files will not automatically ping any particular
+# team and can be reviewed by anybody with the appropriate permissions. This is
+# meant to avoid pinging all of @DataDog/dd-trace-go-guild for every PR that
+# changes one of these files.
+**/go.mod
+**/go.sum
+go.work
+go.work.sum


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

CODEOWNERS files always select the last place where a file is mentioned, not the first, meaning setting `**/go.{mod,sum}` before other folders does not work

### Motivation

Less PRs with the guild-dd-trace-go team as reviewer

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
