### PR TITLE
fix(datastreams): disable Data Streams Monitoring on UNKNOWN_SERVER_ERROR

### DIFF
--- a/contrib/confluentinc/confluent-kafka-go/kafka.v2/go.mod
+++ b/contrib/confluentinc/confluent-kafka-go/kafka.v2/go.mod
@@ -1,4 +1,4 @@
-module github.com/DataDog/dd-trace-go/contrib/confluentinc/confluent-kafka-go/kafka.v2/v2
+module github.com/DataDog/dd-trace-go/contrib/confluentinc/confluent-kafka-go/kafka.v2
 
 go 1.23.0
 

--- a/contrib/confluentinc/confluent-kafka-go/kafka.v2/kafka.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka.v2/kafka.go
@@ -195,11 +195,11 @@ func (p *Producer) Produce(msg *kafka.Message, deliveryChan chan kafka.Event) er
 	span := p.tracer.StartProduceSpan(tMsg)
 
 	var errChan chan error
-	deliveryChan, errChan = tracing.WrapDeliveryChannel(p.tracer, deliveryChan, span, wrapEvent)
+	newDeliveryChan, errChan := tracing.WrapDeliveryChannel(p.tracer, deliveryChan, span, wrapEvent)
 
 	p.tracer.SetProduceCheckpoint(tMsg)
 
-	err := p.Producer.Produce(msg, deliveryChan)
+	err := p.Producer.Produce(msg, newDeliveryChan)
 	if err != nil {
 		if errChan != nil {
 			errChan <- err

--- a/contrib/confluentinc/confluent-kafka-go/kafka.v2/tracing.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafka.v2/tracing.go
@@ -104,8 +104,11 @@ func (w wTopicPartition) GetOffset() int64 {
 	return int64(w.Offset)
 }
 
-func (w wTopicPartition) GetError() error {
-	return w.Error
+func (w wTopicPartition) GetError() tracing.TopicPartitionError {
+	if w.Error == nil {
+		return nil
+	}
+	return wTopicPartitionError{w.Error}
 }
 
 type wEvent struct {
@@ -128,6 +131,18 @@ func (w wEvent) KafkaOffsetsCommitted() (tracing.OffsetsCommitted, bool) {
 		return wrapOffsetsCommitted(oc), true
 	}
 	return nil, false
+}
+
+type wTopicPartitionError struct {
+	error
+}
+
+func (w wTopicPartitionError) IsGenericServerError() bool {
+	return w.error.(kafka.Error).Code() == kafka.ErrUnknown
+}
+
+func (w wTopicPartitionError) GetError() error {
+	return w.error
 }
 
 type wOffsetsCommitted struct {

--- a/contrib/confluentinc/confluent-kafka-go/types.go
+++ b/contrib/confluentinc/confluent-kafka-go/types.go
@@ -39,11 +39,16 @@ type OffsetsCommitted interface {
 	GetOffsets() []TopicPartition
 }
 
+type TopicPartitionError interface {
+	GetError() error
+	IsGenericServerError() bool
+}
+
 type TopicPartition interface {
 	GetTopic() string
 	GetPartition() int32
 	GetOffset() int64
-	GetError() error
+	GetError() TopicPartitionError
 }
 
 type Event interface {


### PR DESCRIPTION
### What does this PR do?

DSM relies on header injection as a way of propagating context through Kafka messages. Not all Kafka brokers support this, and we have a rudimentary check that librdkafka is above a specific version to allow header injection. Headers are also unsupported if `log.message.format.version` is set to a pre-0.11 value, but there is no way to check this setting from a client.

The failure mode here is that messages fail to send because even with a recent librdkafka & broker version, we still use a message protocol before message headers are supported. The broker will return an UNKNOWN_SERVER_ERRROR.

The workaround is to disable DSM when we see this error, to avoid dropping all subsequent messages. We considered retrying the failed message, but because the surface area of this bug is small, we went with a simpler approach. This is the same approach as in other tracers. (e.g. https://github.com/DataDog/dd-trace-py/pull/13313)

### Motivation


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
