### PR TITLE
fix(ddtrace/internal): log to debug instead of warning when starting spans without an active tracer

### DIFF
--- a/ddtrace/internal/globaltracer.go
+++ b/ddtrace/internal/globaltracer.go
@@ -6,7 +6,6 @@
 package internal // import "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
 
 import (
-	"sync"
 	"sync/atomic"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
@@ -43,16 +42,12 @@ var Testing = false
 
 var _ ddtrace.Tracer = (*NoopTracer)(nil)
 
-var warnOnce sync.Once
-
 // NoopTracer is an implementation of ddtrace.Tracer that is a no-op.
 type NoopTracer struct{}
 
 // StartSpan implements ddtrace.Tracer.
 func (NoopTracer) StartSpan(_ string, _ ...ddtrace.StartSpanOption) ddtrace.Span {
-	warnOnce.Do(func() {
-		log.Warn("Tracer must be started before starting a span; Review the docs for more information: https://docs.datadoghq.com/tracing/trace_collection/library_config/go/")
-	})
+	log.Debug("Tracer must be started before starting a span; Review the docs for more information: https://docs.datadoghq.com/tracing/trace_collection/library_config/go/")
 	return NoopSpan{}
 }
 

--- a/ddtrace/internal/globaltracer.go
+++ b/ddtrace/internal/globaltracer.go
@@ -6,6 +6,7 @@
 package internal // import "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal"
 
 import (
+	"sync"
 	"sync/atomic"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
@@ -42,12 +43,16 @@ var Testing = false
 
 var _ ddtrace.Tracer = (*NoopTracer)(nil)
 
+var warnOnce sync.Once
+
 // NoopTracer is an implementation of ddtrace.Tracer that is a no-op.
 type NoopTracer struct{}
 
 // StartSpan implements ddtrace.Tracer.
 func (NoopTracer) StartSpan(_ string, _ ...ddtrace.StartSpanOption) ddtrace.Span {
-	log.Warn("Tracer must be started before starting a span; Review the docs for more information: https://docs.datadoghq.com/tracing/trace_collection/library_config/go/")
+	warnOnce.Do(func() {
+		log.Warn("Tracer must be started before starting a span; Review the docs for more information: https://docs.datadoghq.com/tracing/trace_collection/library_config/go/")
+	})
 	return NoopSpan{}
 }
 

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -2708,6 +2708,9 @@ func TestNoopTracerStartSpan(t *testing.T) {
 	undo := log.UseLogger(customLogger{l: llog.New(w, "", llog.LstdFlags)})
 	defer undo()
 
+	log.SetLevel(log.LevelDebug)
+	defer log.SetLevel(log.LevelWarn)
+
 	StartSpan("abcd")
 
 	w.Close()


### PR DESCRIPTION
### What does this PR do?

Sets the log level to debug for warning about tracer not being started when starting spans to once.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
