### PR TITLE
fix(spanlinks) missing spanlinks in spancontext

### DIFF
--- a/ddtrace/mocktracer/mockspan.go
+++ b/ddtrace/mocktracer/mockspan.go
@@ -39,7 +39,7 @@ func MockSpan(s *tracer.Span) *Span {
 	if s == nil {
 		return nil
 	}
-	return &Span{sp: s, m: s.AsMap()}
+	return &Span{sp: s, m: s.AsMap(), links: s.Context().SpanLinks()}
 }
 
 func (s *Span) OperationName() string {
@@ -127,7 +127,8 @@ id: %d
 parent: %d
 trace: %v
 baggage: %#v
-`, s.OperationName(), s.Tags(), s.StartTime(), s.Duration(), sc.SpanID(), s.ParentID(), sc.TraceID(), baggage)
+links: %#v
+`, s.OperationName(), s.Tags(), s.StartTime(), s.Duration(), sc.SpanID(), s.ParentID(), sc.TraceID(), baggage, s.links)
 }
 
 func (s *Span) ParentID() uint64 {
@@ -215,14 +216,7 @@ func (s *Span) Unwrap() *tracer.Span {
 
 // Links returns the span's span links.
 func (s *Span) Links() []tracer.SpanLink {
-	payload := s.Tag("_dd.span_links")
-	if payload == nil {
-		return nil
-	}
-	// Unmarshal the JSON payload into the SpanLink slice.
-	var links []tracer.SpanLink
-	json.Unmarshal([]byte(payload.(string)), &links)
-	return links
+	return s.links
 }
 
 // SpanEvent represents a span event from a mockspan.

--- a/ddtrace/mocktracer/mocktracer_test.go
+++ b/ddtrace/mocktracer/mocktracer_test.go
@@ -326,3 +326,27 @@ func TestTracerExtract(t *testing.T) {
 		})
 	})
 }
+
+func TestSpanLinks(t *testing.T) {
+	spanLink := tracer.SpanLink{
+		TraceID:     789,
+		TraceIDHigh: 0,
+		SpanID:      789,
+		Attributes:  map[string]string{"reason": "terminated_context", "context_headers": "datadog"},
+		Flags:       0,
+	}
+
+	t.Run("create span with links", func(t *testing.T) {
+		mt := Start()
+		defer mt.Stop()
+
+		span := mt.StartSpan("http.request", tracer.WithSpanLinks([]tracer.SpanLink{spanLink}))
+		span.Finish()
+
+		finishedSpans := mt.FinishedSpans()
+
+		assert.Len(t, finishedSpans, 1)
+		assert.Len(t, finishedSpans[0].Links(), 1)
+		assert.Equal(t, spanLink, finishedSpans[0].Links()[0])
+	})
+}

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -573,6 +573,7 @@ func (s *Span) AddLink(link SpanLink) {
 		return
 	}
 	s.spanLinks = append(s.spanLinks, link)
+	s.context.spanLinks = append(s.context.spanLinks, link)
 }
 
 // serializeSpanLinksInMeta saves span links as a JSON string under `Span[meta][_dd.span_links]`.

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -156,8 +156,9 @@ func FromGenericCtx(c ddtrace.SpanContext) *SpanContext {
 // for the same span.
 func newSpanContext(span *Span, parent *SpanContext) *SpanContext {
 	context := &SpanContext{
-		spanID: span.spanID,
-		span:   span,
+		spanID:    span.spanID,
+		span:      span,
+		spanLinks: span.spanLinks,
 	}
 
 	context.traceID.SetLower(span.traceID)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
This PR fixes an oversight where `SpanLinks` added via `AddLink` or `WithLinks` were not being propagated to the span's internal context struct. As a result,` span.Context().SpanLinks()` did not reflect the links associated with the span.

This fix ensures that when links are added—either during span initialization with WithLinks, or dynamically via `AddLink`—they are also present in the span's context. In addition, it updates the mock tracer to align with this behavior for testing purposes.
### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->
While reviewing the SpanLinks behavior, I realized that although links could be added to a span, they were not visible through `span.Context().SpanLinks()`. Since `SpanContext` is meant to reflect the state of the current span (not its parent), I believe this was an unintended omission.

This PR corrects that, allowing users to reliably access `SpanLinks` via the span's context—whether the links were added at creation or afterward. That said, if my understanding of the SpanContext’s intended behavior is incorrect, I’d appreciate guidance and would be happy to adjust the implementation accordingly.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


