### PR TITLE
[appsec] Set large appsec trace rate limit while benchmarking

### DIFF
--- a/instrumentation/testutils/testutils.go
+++ b/instrumentation/testutils/testutils.go
@@ -73,6 +73,9 @@ func StartAppSec(t *testing.T, opts ...config.StartOption) {
 }
 
 func StartAppSecBench(b *testing.B) {
+	// maximize rate limit to prevent the spam of "too many WAF events" errors
+	// 1000000000 = time.Second.Nanoseconds() is the largest value that we are able to set here
+	b.Setenv("DD_APPSEC_TRACE_RATE_LIMIT", "1000000000")
 	appsec.Start()
 	b.Cleanup(appsec.Stop)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Set a rate limit on the number of traces in `appsec`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

When running certain benchmarks, our logs would often get spammed with this error:

```
ERROR: appsec: too many WAF events, stopping further reporting...
```

This had several side effects, such as noise and misformating our logs (which would prevent test results from being processed correctly in CI). Since our tests do not aim (yet?) to look at _limited_ tracing, we can remove our rate limit to silence these logs.

Benchmark logs for `BenchmarkGraphQL` are [here](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-go/-/jobs/938084350#L312).

Note: further down in the logs we have our benchmarks running on main, which we use as a point of comparison. Since this PR is not merged yet, the error logs will still appear while running `BenchmarkGraphQL` against main. We need to merge this PR first before making changes to benchmarks to fully remove these logs.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
