### PR TITLE
exploration: how many profiles are buffered if the agent endpoint is down?

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -54,7 +54,7 @@ const (
 	// DefaultUploadTimeout specifies the default timeout for uploading profiles.
 	// It can be overwritten using the DD_PROFILING_UPLOAD_TIMEOUT env variable
 	// or the WithUploadTimeout option.
-	DefaultUploadTimeout = 10 * time.Second
+	DefaultUploadTimeout = 10 * time.Second // <--
 )
 
 const (
@@ -195,8 +195,8 @@ func defaultConfig() (*config, error) {
 		cpuDuration:          DefaultDuration,
 		blockRate:            DefaultBlockRate,
 		mutexFraction:        DefaultMutexFraction,
-		uploadTimeout:        DefaultUploadTimeout,
-		maxGoroutinesWait:    1000, // arbitrary value, should limit STW to ~30ms
+		uploadTimeout:        DefaultUploadTimeout, // <--
+		maxGoroutinesWait:    1000,                 // arbitrary value, should limit STW to ~30ms
 		deltaProfiles:        internal.BoolEnv("DD_PROFILING_DELTA", true),
 		logStartup:           internal.BoolEnv("DD_TRACE_STARTUP_LOGS", true),
 		endpointCountEnabled: internal.BoolEnv(traceprof.EndpointCountEnvVar, false),


### PR DESCRIPTION
Answer: It should be <= 7 profiles. The last profile of the service we were looking at was 1 MiB and the OOM happened after 3 minutes, so this is unlikey to be explained by the buffering of profile data.

For details look at the comments in this PR.