### PR TITLE
refactor(profiler): centralize compression logic

### DIFF
--- a/profiler/compression.go
+++ b/profiler/compression.go
@@ -1,0 +1,147 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+package profiler
+
+/*
+In order to save bandwidth and networking cost, the profiler compresses the
+profiling data it collects before sending it to Datadog. This file contains
+the logic that controls this compression.
+
+For historical reasons, the profiler has used varying levels of compression for
+different profile types. pprof files coming from the Go runtime are already
+compressed using gzip-1 (aka gzip.BestSpeed) [1], so they were uploaded as-is.
+Other profiles that were produced (or derived) by the profiler itself have been
+either compressed with gzip-6 (aka gzip.DefaultCompression) or were left
+uncompressed. The exact details are captured in the legacyOutputCompression
+function below.
+
+This legacy compression strategy was haphazard and not designed to achieve an
+optimal tradeoff between overhead and cost savings. Due to this, it is going to
+be succeeded by a new compression strategy. The implementation for it will
+follow in the next update to this file.
+
+[1] https://github.com/golang/go/blob/go1.24.3/src/runtime/pprof/proto.go#L260
+*/
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+)
+
+// legacyCompressionStrategy returns the input and output compression to be used
+// by the compressor for the given profile type and isDelta flavor using the
+// legacy compression strategy.
+func legacyCompressionStrategy(pt ProfileType, isDelta bool) (compression, compression) {
+	return inputCompression(pt, isDelta), legacyOutputCompression(pt, isDelta)
+}
+
+// inputCompression maps the given profile type and isDelta flavor to the
+// compression level that was already applied to the data by the the Go runtime.
+// Profiles produced (or derived) by our profiler itself are expected to be
+// uncompressed.
+func inputCompression(pt ProfileType, isDelta bool) compression {
+	switch pt {
+	case CPUProfile, GoroutineProfile:
+		return gzip1Compression
+	case HeapProfile, BlockProfile, MutexProfile:
+		if isDelta {
+			return noCompression
+		}
+		return gzip1Compression
+	case MetricsProfile, executionTrace, expGoroutineWaitProfile:
+		return noCompression
+	default:
+		panic(fmt.Sprintf("unknown profile type: %s", pt))
+	}
+}
+
+// legacyOutputCompression maps the given profile type and isDelta flavor to
+// a compression level using our legacy compression strategy.
+func legacyOutputCompression(pt ProfileType, isDelta bool) compression {
+	switch pt {
+	case CPUProfile, GoroutineProfile:
+		return gzip1Compression
+	case expGoroutineWaitProfile:
+		return gzip6Compression
+	case HeapProfile, BlockProfile, MutexProfile:
+		if isDelta {
+			return gzip6Compression
+		}
+		return gzip1Compression
+	case executionTrace, MetricsProfile:
+		return noCompression
+	default:
+		panic(fmt.Sprintf("unknown profile type: %s", pt))
+	}
+}
+
+type compressionAlgorithm string
+
+const (
+	compressionAlgorithmNone compressionAlgorithm = "none"
+	compressionAlgorithmGzip compressionAlgorithm = "gzip"
+)
+
+type compression struct {
+	algorithm compressionAlgorithm
+	level     int
+}
+
+func (c compression) String() string {
+	if c.algorithm == compressionAlgorithmNone {
+		return string(c.algorithm)
+	}
+	return fmt.Sprintf("%s-%d", c.algorithm, c.level)
+}
+
+// Common compression algorithm and level combinations.
+var (
+	noCompression    = compression{algorithm: compressionAlgorithmNone}
+	gzip1Compression = compression{algorithm: compressionAlgorithmGzip, level: 1}
+	gzip6Compression = compression{algorithm: compressionAlgorithmGzip, level: 6}
+)
+
+// newCompressionPipeline returns a compressor that converts the data written to
+// it from the expected input compression to the given output compression.
+func newCompressionPipeline(in compression, out compression) (compressor, error) {
+	if in == out {
+		return newPassthroughCompressor(), nil
+	}
+
+	if in == noCompression && out.algorithm == compressionAlgorithmGzip {
+		return gzip.NewWriterLevel(nil, out.level)
+	}
+
+	return nil, fmt.Errorf("unsupported recompression: %s -> %s", in, out)
+}
+
+// compressor provides an interface for compressing profiling data. If the input
+// is already compressed, it can also act as a re-compressor that decompresses
+// the data from one format and then re-compresses it into another format.
+type compressor interface {
+	io.Writer
+	io.Closer
+	Reset(w io.Writer)
+}
+
+// newPassthroughCompressor returns a compressor that simply passes all data
+// through without applying any compression.
+func newPassthroughCompressor() *passthroughCompressor {
+	return &passthroughCompressor{}
+}
+
+type passthroughCompressor struct {
+	io.Writer
+}
+
+func (r *passthroughCompressor) Reset(w io.Writer) {
+	r.Writer = w
+}
+
+func (r *passthroughCompressor) Close() error {
+	return nil
+}

--- a/profiler/compression_test.go
+++ b/profiler/compression_test.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+package profiler
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCompressionPipeline(t *testing.T) {
+	plainData := []byte("hello world")
+	gzip1Data := compressData(t, plainData, gzip1Compression)
+	gzip6Data := compressData(t, plainData, gzip6Compression)
+
+	tests := []struct {
+		in   compression
+		out  compression
+		data []byte
+		want []byte
+	}{
+		{noCompression, gzip1Compression, plainData, gzip1Data},
+		{noCompression, gzip6Compression, plainData, gzip6Data},
+		{noCompression, noCompression, plainData, plainData},
+		{gzip1Compression, gzip1Compression, gzip1Data, gzip1Data},
+		{gzip6Compression, gzip6Compression, gzip6Data, gzip6Data},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s->%s", test.in, test.out), func(t *testing.T) {
+			pipeline, err := newCompressionPipeline(test.in, test.out)
+			require.NoError(t, err)
+			buf := &bytes.Buffer{}
+			pipeline.Reset(buf)
+			_, err = pipeline.Write(test.data)
+			require.NoError(t, err)
+			require.NoError(t, pipeline.Close())
+			require.Equal(t, test.want, buf.Bytes())
+		})
+	}
+}
+
+func compressData(t *testing.T, data []byte, c compression) []byte {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	switch c.algorithm {
+	case compressionAlgorithmGzip:
+		gw, err := gzip.NewWriterLevel(buf, c.level)
+		require.NoError(t, err)
+		_, err = gw.Write(data)
+		require.NoError(t, err)
+		require.NoError(t, gw.Close())
+	default:
+		t.Fatalf("unsupported compression algorithm: %s", c.algorithm)
+	}
+	return buf.Bytes()
+}

--- a/profiler/metrics.go
+++ b/profiler/metrics.go
@@ -6,9 +6,9 @@
 package profiler
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
 	"runtime"
 	"time"
@@ -59,7 +59,7 @@ func (m *metrics) reset(now time.Time) {
 	m.snapshot.NumGoroutine = runtime.NumGoroutine()
 }
 
-func (m *metrics) report(now time.Time, buf *bytes.Buffer) error {
+func (m *metrics) report(now time.Time, w io.Writer) error {
 	period := now.Sub(m.collectedAt)
 	if period <= 0 {
 		// It is technically possible, though very unlikely, for period
@@ -85,7 +85,7 @@ func (m *metrics) report(now time.Time, buf *bytes.Buffer) error {
 		return err
 	}
 
-	_, err = buf.Write(data)
+	_, err = w.Write(data)
 	return err
 }
 


### PR DESCRIPTION
For historical reasons, the profiler has used varying levels of
compression for different profile types (no compression, gzip-1 and
gzip-6). This has been identified as target for cost optimization,
see PROF-11815.

Refactor the compression related code in order to pave the path for
introducing a new compression strategy, which will most likely be based
on zstd.

This patch should not have any observable impact. Profiles are expected
to be uploaded with exactly the same compression settings as before, and
the performance is expected to stay exactly the same as well.

Introduce a dedicated compressor for each profile type that handles
converting the profile data produced by it from the existing compression
(gzip-1 or no compression) to the desired output compression.

Update delta profiles and expGoroutineWaitProfile to perform their
gzip-6 compression in the compressor for their profile type, rather than
doing it themselves.

A few TestRunProfile tests had to be modified because they were not
explicitly declaring the profile types they were testing when
initializing the profiler, which caused panics due to their compressors
being uninitialized.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.