### PR TITLE
[ci] Remove equal signs from benchmarks

### DIFF
--- a/contrib/graphql-go/graphql/bench_test.go
+++ b/contrib/graphql-go/graphql/bench_test.go
@@ -126,9 +126,9 @@ func BenchmarkGraphQL(b *testing.B) {
 		},
 	}
 
-	b.Run("version=baseline", func(b *testing.B) {
+	b.Run("version_baseline", func(b *testing.B) {
 		for name, tc := range testCases {
-			b.Run(fmt.Sprintf("scenario=%s", name), func(b *testing.B) {
+			b.Run(fmt.Sprintf("scenario_%s", name), func(b *testing.B) {
 				b.StopTimer()
 				b.ReportAllocs()
 				schema, err := graphql.NewSchema(graphql.SchemaConfig{Query: rootQuery})
@@ -148,9 +148,9 @@ func BenchmarkGraphQL(b *testing.B) {
 		}
 	})
 
-	b.Run("version=dyngo", func(b *testing.B) {
+	b.Run("version_dyngo", func(b *testing.B) {
 		for name, tc := range testCases {
-			b.Run(fmt.Sprintf("scenario=%s", name), func(b *testing.B) {
+			b.Run(fmt.Sprintf("scenario_%s", name), func(b *testing.B) {
 				b.StopTimer()
 				b.ReportAllocs()
 				opts := []Option{WithService("test-graphql-service")}

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -1919,7 +1919,7 @@ func optsTestConsumer(opts ...StartSpanOption) {
 }
 
 func BenchmarkConfig(b *testing.B) {
-	b.Run("scenario=none", func(b *testing.B) {
+	b.Run("scenario_none", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			optsTestConsumer(
@@ -1929,7 +1929,7 @@ func BenchmarkConfig(b *testing.B) {
 			)
 		}
 	})
-	b.Run("scenario=WithStartSpanConfig", func(b *testing.B) {
+	b.Run("scenario_WithStartSpanConfig", func(b *testing.B) {
 		b.ReportAllocs()
 		cfg := NewStartSpanConfig(
 			ServiceName("SomeService"),
@@ -1946,7 +1946,7 @@ func BenchmarkConfig(b *testing.B) {
 }
 
 func BenchmarkStartSpanConfig(b *testing.B) {
-	b.Run("scenario=none", func(b *testing.B) {
+	b.Run("scenario_none", func(b *testing.B) {
 		tracer, err := newTracer()
 		defer tracer.Stop()
 		assert.NoError(b, err)
@@ -1961,7 +1961,7 @@ func BenchmarkStartSpanConfig(b *testing.B) {
 
 		}
 	})
-	b.Run("scenario=WithStartSpanConfig", func(b *testing.B) {
+	b.Run("scenario_WithStartSpanConfig", func(b *testing.B) {
 		tracer, err := newTracer()
 		defer tracer.Stop()
 		assert.NoError(b, err)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Removes regex-breaking equal signs from benchmark names.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

Having equal signs in benchmark names breaks the regex that we use to run our benchmarks. This prevents us from reporting the output of those benchmarks in CI.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
