### PR TITLE
fix(tools/apiextractor): Add better support for type literals

### DIFF
--- a/ddtrace/tracer/api.txt
+++ b/ddtrace/tracer/api.txt
@@ -295,7 +295,7 @@ type SpanContext interface {
 	func (*SpanContext) SpanID() (uint64)
 	func (*SpanContext) SpanLinks() ([]SpanLink)
 	func (*SpanContext) TraceID() (string)
-	func (*SpanContext) TraceIDBytes() ([&ast.BasicLit{ValuePos:304432, Kind:5, Value:"16"}]byte)
+	func (*SpanContext) TraceIDBytes() ([16]byte)
 	func (*SpanContext) TraceIDLower() (uint64)
 	func (*SpanContext) TraceIDUpper() (uint64)
 }
@@ -305,7 +305,7 @@ func (*SpanContext) SamplingPriority() (int, bool)
 func (*SpanContext) SpanID() (uint64)
 func (*SpanContext) SpanLinks() ([]SpanLink)
 func (*SpanContext) TraceID() (string)
-func (*SpanContext) TraceIDBytes() ([&ast.BasicLit{ValuePos:304432, Kind:5, Value:"16"}]byte)
+func (*SpanContext) TraceIDBytes() ([16]byte)
 func (*SpanContext) TraceIDLower() (uint64)
 func (*SpanContext) TraceIDUpper() (uint64)
 

--- a/scripts/apiextractor/.gitignore
+++ b/scripts/apiextractor/.gitignore
@@ -1,0 +1,1 @@
+apiextractor

--- a/scripts/apiextractor/_testdata/dummy/dummy.go
+++ b/scripts/apiextractor/_testdata/dummy/dummy.go
@@ -40,5 +40,11 @@ func DummyFuncWithParams(_ int, _ string) {
 	dummyUnexportedFunc()
 }
 
+// ArrayTestType is a type containing array fields for testing array type formatting
+type ArrayTestType struct {
+	FixedArray    [16]byte
+	MultiDimArray [2][3]int
+}
+
 // dummyUnexportedFunc is an unexported function
 func dummyUnexportedFunc() {}

--- a/scripts/apiextractor/_testdata/expected_output.txt
+++ b/scripts/apiextractor/_testdata/expected_output.txt
@@ -9,6 +9,11 @@ func DummyFunc()
 func DummyFuncWithParams(int, string)
 
 // Types
+type ArrayTestType struct {
+	FixedArray [16]byte
+	MultiDimArray [2][3]int
+}
+
 type DummyInterface interface {
 	func ExportedMethod()
 }

--- a/scripts/apiextractor/api_extractor.go
+++ b/scripts/apiextractor/api_extractor.go
@@ -438,6 +438,8 @@ func formatReceiver(expr ast.Expr) string {
 
 func formatExpr(expr ast.Expr) string {
 	switch t := expr.(type) {
+	case *ast.BasicLit:
+		return t.Value
 	case *ast.Ident:
 		return t.Name
 	case *ast.StarExpr:


### PR DESCRIPTION
Addresses the issue on https://github.com/DataDog/dd-trace-go/actions/runs/15140015964/job/42565830420

Follow-up to https://github.com/DataDog/dd-trace-go/pull/3526

Signed-off-by: Kemal Akkoyun <kemal.akkoyun@datadoghq.com>

### What does this PR do?

Fixes the API extractor to format array types without including AST position information. This prevents unnecessary diffs in the API stability check caused by internal compiler data.

- Changed the return type of the TraceIDBytes method in the SpanContext interface from a specific literal to a fixed-size byte array.

- Added a new .gitignore file for the apiextractor directory to exclude generated files.
- Enhanced api_extractor.go to handle BasicLit expressions in formatExpr.
- Introduced ArrayTestType with array fields in expected_output.txt and dummy.go for testing purposes.

### Motivation

The API stability check was showing diffs due to AST position information in array types (like `[16]byte`). This information is internal and shouldn't affect API compatibility checks.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] System-Tests covering this feature have been added and enabled with the va.b.c-dev version tag.
  - N/A - Development tooling change
- [ ] There is a benchmark for any new code, or changes to existing code.
  - N/A - Development tooling change
- [ ] If this interacts with the agent in a new way, a system test has been added.
  - N/A - Development tooling change
- [x] New code is free of linting errors.
- [x] Add an appropriate team label: `team/tooling`
- [ ] Non-trivial go.mod changes reviewed by @DataDog/dd-trace-go-guild.
  - N/A - No go.mod changes
