### PR TITLE
fix (internal/civisibility): use internal code coverage api to get the total percentage.

### DIFF
--- a/internal/civisibility/integrations/gotesting/coverage/test_coverage.go
+++ b/internal/civisibility/integrations/gotesting/coverage/test_coverage.go
@@ -88,10 +88,10 @@ var (
 
 // InitializeCoverage initializes the runtime coverage.
 func InitializeCoverage(m *testing.M) {
-	log.Debug("civisibility.coverage: initializing runtime coverage")
+	log.Debug("civisibility.cov: initializing runtime coverage")
 	testDep, err := getTestDepsCoverage(m)
 	if err != nil || testDep == nil {
-		log.Debug("civisibility.coverage: error initializing runtime coverage: %v", err)
+		log.Debug("civisibility.cov: error initializing runtime coverage: %v", err)
 		return
 	}
 
@@ -124,9 +124,9 @@ func InitializeCoverage(m *testing.M) {
 	// create a temporary directory to store coverage files
 	temporaryDir, err = os.MkdirTemp("", "coverage")
 	if err != nil {
-		log.Debug("civisibility.coverage: error creating temporary directory: %v", err)
+		log.Debug("civisibility.cov: error creating temporary directory: %v", err)
 	} else {
-		log.Debug("civisibility.coverage: temporary coverage directory created: %s", temporaryDir)
+		log.Debug("civisibility.cov: temporary coverage directory created: %s", temporaryDir)
 	}
 	integrations.PushCiVisibilityCloseAction(func() {
 		_ = os.RemoveAll(temporaryDir)
@@ -135,7 +135,7 @@ func InitializeCoverage(m *testing.M) {
 	// executing go list -f '{{.Module.Path}};{{.Module.Dir}}' to get the module path and module dir
 	stdOut, err := exec.Command("go", "list", "-f", "{{.Module.Path}};{{.Module.Dir}}").CombinedOutput()
 	if err != nil {
-		log.Debug("civisibility.coverage: error getting module path and module dir: %v", err)
+		log.Debug("civisibility.cov: error getting module path and module dir: %v", err)
 	} else {
 		parts := strings.Split(string(stdOut), ";")
 		if len(parts) == 2 {
@@ -159,19 +159,19 @@ func GetCoverage() float64 {
 	coverageFile := filepath.Join(temporaryDir, "global_coverage.out")
 	_, err := tearDown(coverageFile, "")
 	if err != nil {
-		log.Debug("civisibility.coverage: error getting coverage file: %v", err)
+		log.Debug("civisibility.cov: error getting coverage file: %v", err)
 	}
 
 	defer func(cFile string) {
 		err = os.Remove(cFile)
 		if err != nil {
-			log.Debug("civisibility.coverage: error removing coverage file: %v", err)
+			log.Debug("civisibility.cov: error removing coverage file: %v", err)
 		}
 	}(coverageFile)
 
 	totalStatements, coveredStatements, err := getCoverageStatementsInfo(coverageFile)
 	if err != nil {
-		log.Debug("civisibility.coverage: error parsing coverage file: %v", err)
+		log.Debug("civisibility.cov: error parsing coverage file: %v", err)
 	}
 
 	if totalStatements == 0 {
@@ -202,7 +202,7 @@ func (t *testCoverage) CollectCoverageBeforeTestExecution() {
 	t.preCoverageFilename = filepath.Join(temporaryDir, fmt.Sprintf("%d-%d-%d-pre.out", t.moduleID, t.suiteID, t.testID))
 	_, err := tearDown(t.preCoverageFilename, "")
 	if err != nil {
-		log.Debug("civisibility.coverage: error getting coverage file: %v", err)
+		log.Debug("civisibility.cov: error getting coverage file: %v", err)
 		telemetry.CodeCoverageErrors()
 	} else {
 		telemetry.CodeCoverageStarted(testFramework, telemetry.DefaultCoverageLibraryType)
@@ -234,7 +234,7 @@ func (t *testCoverage) getCoverageData() error {
 	t.postCoverageFilename = filepath.Join(temporaryDir, fmt.Sprintf("%d-%d-%d-post.out", t.moduleID, t.suiteID, t.testID))
 	_, err := tearDown(t.postCoverageFilename, "")
 	if err != nil {
-		log.Debug("civisibility.coverage: error getting coverage file: %v", err)
+		log.Debug("civisibility.cov: error getting coverage file: %v", err)
 		telemetry.CodeCoverageErrors()
 	}
 
@@ -246,19 +246,19 @@ func (t *testCoverage) processCoverageData() {
 	if t.preCoverageFilename == "" ||
 		t.postCoverageFilename == "" ||
 		t.preCoverageFilename == t.postCoverageFilename {
-		log.Debug("civisibility.coverage: no coverage data to process")
+		log.Debug("civisibility.cov: no coverage data to process")
 		telemetry.CodeCoverageErrors()
 		return
 	}
 	preCoverage, err := parseCoverProfile(t.preCoverageFilename)
 	if err != nil {
-		log.Debug("civisibility.coverage: error parsing pre-coverage file: %v", err)
+		log.Debug("civisibility.cov: error parsing pre-coverage file: %v", err)
 		telemetry.CodeCoverageErrors()
 		return
 	}
 	postCoverage, err := parseCoverProfile(t.postCoverageFilename)
 	if err != nil {
-		log.Debug("civisibility.coverage: error parsing post-coverage file: %v", err)
+		log.Debug("civisibility.cov: error parsing post-coverage file: %v", err)
 		telemetry.CodeCoverageErrors()
 		return
 	}
@@ -273,12 +273,12 @@ func (t *testCoverage) processCoverageData() {
 
 	err = os.Remove(t.preCoverageFilename)
 	if err != nil {
-		log.Debug("civisibility.coverage: error removing pre-coverage file: %v", err)
+		log.Debug("civisibility.cov: error removing pre-coverage file: %v", err)
 	}
 
 	err = os.Remove(t.postCoverageFilename)
 	if err != nil {
-		log.Debug("civisibility.coverage: error removing post-coverage file: %v", err)
+		log.Debug("civisibility.cov: error removing post-coverage file: %v", err)
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR enables the internal api used to get the global code coverage value on Test Impact Analysis scenario to a normal code coverage scenario.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This Go `testing.Coverage()` api is returning a different percentage from the one reported in the stdout. This issue started when the new code coverage algorithm started to be the default algorithm.

See: https://github.com/golang/go/issues/62212

Example:
```log
--- PASS: TestValue (0.00s)
PASS
coverage: 100.0% of statements
testing.Coverage() 25
....
2025/05/22 15:23:38 Datadog Tracer v2.1.0-dev.2 DEBUG: civisibility: done.
ok      awesomeProject10/package1       1.092s  coverage: 100.0% of statements
```

By switching to our internal api (the internal api uses the same mechanism as the stdout format)

![image](https://github.com/user-attachments/assets/eb06900c-50eb-4e76-b89c-4a3758c122fa)


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
