### PR TITLE
orchestrion: don't trace the tracer even if tracer.Start(tracer.WithHTTPClient(...)) is called

### DIFF
--- a/contrib/net/http/orchestrion.client.yml
+++ b/contrib/net/http/orchestrion.client.yml
@@ -30,7 +30,6 @@ aspects:
             - import-path: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal
             - import-path: github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/net
             - import-path: github.com/DataDog/dd-trace-go/v2/profiler
-            - import-path: github.com/DataDog/dd-trace-go/v2/internal/orchestrion/_integration/internal/agent # Integration test's custom transport.
         - struct-literal:
             type: net/http.Transport
     advice:

--- a/contrib/net/http/orchestrion.client.yml
+++ b/contrib/net/http/orchestrion.client.yml
@@ -23,15 +23,16 @@ aspects:
     tracer-internal: true
     join-point:
       all-of:
-        - struct-literal:
-            type: net/http.Transport
         - one-of:
             - import-path: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer
             - import-path: github.com/DataDog/dd-trace-go/v2/internal/hostname/httputils
             - import-path: github.com/DataDog/dd-trace-go/v2/internal/remoteconfig
-            - import-path: github.com/DataDog/dd-trace-go/v2/internal/telemetry
+            - import-path: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal
+            - import-path: github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/net
             - import-path: github.com/DataDog/dd-trace-go/v2/profiler
-            - import-path: datadoghq.dev/orchestrion/_integration-tests/utils/agent # Integration test's custom transport.
+            - import-path: github.com/DataDog/dd-trace-go/v2/internal/orchestrion/_integration/internal/agent # Integration test's custom transport.
+        - struct-literal:
+            type: net/http.Transport
     advice:
       - wrap-expression:
           template: |-

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/orchestrion/runtime/built"
 	"golang.org/x/mod/semver"
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
@@ -505,7 +506,10 @@ func newConfig(opts ...StartOption) (*config, error) {
 		c.agentURL = internal.AgentURLFromEnv()
 	}
 	c.originalAgentURL = c.agentURL // Preserve the original agent URL for logging
-	if c.httpClient == nil {
+	if c.httpClient == nil || built.WithOrchestrion {
+		if built.WithOrchestrion && c.httpClient != nil {
+			log.Error("Orchestrion is enabled, but a custom HTTP client was provided to tracer.Start. This is not supported and will be ignored.")
+		}
 		if c.agentURL.Scheme == "unix" {
 			// If we're connecting over UDS we can just rely on the agent to provide the hostname
 			log.Debug("connecting to agent over unix, do not set hostname on any traces")

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/orchestrion/runtime/built"
+	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion"
 	"golang.org/x/mod/semver"
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
@@ -506,8 +506,10 @@ func newConfig(opts ...StartOption) (*config, error) {
 		c.agentURL = internal.AgentURLFromEnv()
 	}
 	c.originalAgentURL = c.agentURL // Preserve the original agent URL for logging
-	if c.httpClient == nil || built.WithOrchestrion {
-		if built.WithOrchestrion && c.httpClient != nil {
+	if c.httpClient == nil || orchestrion.Enabled() {
+		if orchestrion.Enabled() && c.httpClient != nil {
+			// Make sure we don't create http client traces from inside the tracer by using our http client
+			// TODO(eliott.bouhana): remove once dd:no-span is implemented
 			log.Error("Orchestrion is enabled, but a custom HTTP client was provided to tracer.Start. This is not supported and will be ignored.")
 		}
 		if c.agentURL.Scheme == "unix" {

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -510,7 +510,7 @@ func newConfig(opts ...StartOption) (*config, error) {
 		if orchestrion.Enabled() && c.httpClient != nil {
 			// Make sure we don't create http client traces from inside the tracer by using our http client
 			// TODO(eliott.bouhana): remove once dd:no-span is implemented
-			log.Error("Orchestrion is enabled, but a custom HTTP client was provided to tracer.Start. This is not supported and will be ignored.")
+			log.Debug("Orchestrion is enabled, but a custom HTTP client was provided to tracer.Start. This is not supported and will be ignored.")
 		}
 		if c.agentURL.Scheme == "unix" {
 			// If we're connecting over UDS we can just rely on the agent to provide the hostname

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 	"github.com/DataDog/dd-trace-go/v2/internal/traceprof"
 	"github.com/DataDog/dd-trace-go/v2/internal/version"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/civisibility/utils/net/http.go
+++ b/internal/civisibility/utils/net/http.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"mime"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/textproto"
 	"strconv"
@@ -94,12 +95,31 @@ type RequestHandler struct {
 	Client *http.Client
 }
 
+// We copy the transport to avoid using the default one, as it might be
+// augmented with tracing and we don't want these calls to be recorded.
+// This also permits orchestrion to disable tracing on this client.
+// See https://golang.org/pkg/net/http/#DefaultTransport .
+// Except we use a higher timeout for this
+var defaultHttpClient = &http.Client{
+	Timeout: 45 * time.Second,
+	Transport: &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	},
+}
+
 // NewRequestHandler creates a new RequestHandler with a default HTTP client.
 func NewRequestHandler() *RequestHandler {
 	return &RequestHandler{
-		Client: &http.Client{
-			Timeout: 45 * time.Second, // Customize timeout as needed
-		},
+		Client: defaultHttpClient,
 	}
 }
 

--- a/internal/civisibility/utils/net/http.go
+++ b/internal/civisibility/utils/net/http.go
@@ -100,7 +100,7 @@ type RequestHandler struct {
 // This also permits orchestrion to disable tracing on this client.
 // See https://golang.org/pkg/net/http/#DefaultTransport .
 // Except we use a higher timeout for this
-var defaultHttpClient = &http.Client{
+var defaultHTTPClient = http.Client{
 	Timeout: 45 * time.Second,
 	Transport: &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
@@ -119,7 +119,7 @@ var defaultHttpClient = &http.Client{
 // NewRequestHandler creates a new RequestHandler with a default HTTP client.
 func NewRequestHandler() *RequestHandler {
 	return &RequestHandler{
-		Client: defaultHttpClient,
+		Client: &defaultHTTPClient,
 	}
 }
 

--- a/internal/orchestrion/_integration/internal/agent/agent.go
+++ b/internal/orchestrion/_integration/internal/agent/agent.go
@@ -69,7 +69,7 @@ func New(t *testing.T) *MockAgent {
 	return &MockAgent{T: t}
 }
 
-func (m *MockAgent) Start(t *testing.T) {
+func (m *MockAgent) Start(t *testing.T) string {
 	m.T.Log("mockagent: starting")
 
 	srv := httptest.NewServer(m)
@@ -87,6 +87,8 @@ func (m *MockAgent) Start(t *testing.T) {
 		tracer.WithLogger(testLogger{t}),
 	)
 	t.Cleanup(tracer.Stop)
+
+	return srvURL.Host
 }
 
 func (m *MockAgent) Traces(t *testing.T) trace.Traces {

--- a/internal/orchestrion/_integration/internal/agent/agent.go
+++ b/internal/orchestrion/_integration/internal/agent/agent.go
@@ -81,7 +81,6 @@ func (m *MockAgent) Start(t *testing.T) string {
 
 	tracer.Start(
 		tracer.WithAgentAddr(srvURL.Host),
-		tracer.WithHTTPClient(&internalClient),
 		tracer.WithSampler(tracer.NewAllSampler()),
 		tracer.WithLogStartup(false),
 		tracer.WithLogger(testLogger{t}),
@@ -137,19 +136,3 @@ type testLogger struct {
 func (l testLogger) Log(msg string) {
 	l.T.Log(msg)
 }
-
-var (
-	defaultTransport, _ = http.DefaultTransport.(*http.Transport)
-	// A copy of the default transport, except it will be marked internal by orchestrion, so it is not traced.
-	internalTransport = &http.Transport{
-		Proxy:                 defaultTransport.Proxy,
-		DialContext:           defaultTransport.DialContext,
-		ForceAttemptHTTP2:     defaultTransport.ForceAttemptHTTP2,
-		MaxIdleConns:          defaultTransport.MaxIdleConns,
-		IdleConnTimeout:       defaultTransport.IdleConnTimeout,
-		TLSHandshakeTimeout:   defaultTransport.TLSHandshakeTimeout,
-		ExpectContinueTimeout: defaultTransport.ExpectContinueTimeout,
-	}
-
-	internalClient = http.Client{Transport: internalTransport}
-)

--- a/internal/orchestrion/_integration/internal/harness/harness.go
+++ b/internal/orchestrion/_integration/internal/harness/harness.go
@@ -12,7 +12,6 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion/_integration/internal/agent"
 	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion/_integration/internal/trace"
 	"github.com/DataDog/orchestrion/runtime/built"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -60,7 +59,7 @@ func Run(t *testing.T, tc TestCase) {
 
 	t.Log("Running setup")
 	tc.Setup(ctx, t)
-	agentHost := mockAgent.Start(t)
+	mockAgent.Start(t)
 
 	t.Log("Running test")
 	tc.Run(ctx, t)
@@ -71,29 +70,7 @@ func Run(t *testing.T, tc TestCase) {
 		t.Logf("[%d] Trace contains a total of %d spans:\n%v", i, tr.NumSpans(), tr)
 	}
 
-	// Make sure we don't create spans from dd-trace-go
-	for _, span := range got {
-		assertNoInternalSpan(t, span, agentHost)
-	}
-
 	for _, expected := range tc.ExpectedTraces() {
 		expected.RequireAnyMatch(t, got)
-	}
-}
-
-func assertNoInternalSpan(t *testing.T, trace *trace.Trace, agentHost string) {
-	t.Helper()
-	if trace == nil {
-		return
-	}
-
-	// Make sure no spans are created from a connection to the agent
-	assert.NotContains(t, trace.Meta["http.url"], agentHost, "trace should not contain the agent host URL: %s", trace.String())
-
-	// Make sure no spans are created from any agentless http call
-	assert.NotContains(t, trace.Meta["http.url"], "datadoghq", "trace should not contain a datadog URL: %s", trace.String())
-
-	for _, span := range trace.Children {
-		assertNoInternalSpan(t, span, agentHost)
 	}
 }

--- a/internal/telemetry/internal/writer.go
+++ b/internal/telemetry/internal/writer.go
@@ -30,8 +30,6 @@ import (
 // We copy the transport to avoid using the default one, as it might be
 // augmented with tracing and we don't want these calls to be recorded.
 // See https://golang.org/pkg/net/http/#DefaultTransport .
-//
-//orchestrion:ignore
 var defaultHTTPClient = &http.Client{
 	Transport: &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
@@ -138,7 +136,6 @@ func NewWriter(config WriterConfig) (Writer, error) {
 		copyClient := *config.HTTPClient
 		config.HTTPClient = &copyClient
 		config.HTTPClient.Timeout = 5 * time.Second
-		log.Debug("telemetry/writer: client timeout was higher than 5 seconds, clamping it to 5 seconds")
 	}
 
 	body := newBody(config.TracerConfig, config.Debug)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR was originally made to fix an issue where traces where generated on orchestrion apps from the calls made inside dd-trace-go's telemetry client. Which later revealed that any part of the tracer was susceptible to auto-tracing if a call to `tracer.Start` is made using the option `WithHTTPClient` 

This PR also add tests at the orchestrion testing framework harness level to make sure this does not happen anymore.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
