### PR TITLE
chore(ddtrace/tracer): remove unused exported functions

### DIFF
--- a/ddtrace/tracer/api.txt
+++ b/ddtrace/tracer/api.txt
@@ -365,8 +365,6 @@ type TextMapCarrier map[string]string
 func Extract(interface{}) (*SpanContext, error)
 func Flush()
 func Inject(*SpanContext, interface{}) (error)
-func NewChunk([]*Span, bool) (*Chunk)
-func NewUnstartedTracer(...StartOption) (Tracer, error)
 func SetUser(*Span, string, ...UserMonitoringOption)
 func Start(...StartOption) (error)
 func StartSpan(string, ...StartSpanOption) (*Span)

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -520,6 +520,8 @@ func (t *tracer) worker(tick <-chan time.Time) {
 // Chunk holds information about a trace chunk to be flushed, including its spans.
 // The chunk may be a fully finished local trace chunk, or only a portion of the local trace chunk in the case of
 // partial flushing.
+//
+// It's exported for supporting `mocktracer`.
 type Chunk struct {
 	spans    []*Span
 	willSend bool // willSend indicates whether the trace will be sent to the agent.

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -314,11 +314,6 @@ func SetUser(s *Span, id string, opts ...UserMonitoringOption) {
 // payloadQueueSize is the buffer size of the trace channel.
 const payloadQueueSize = 1000
 
-// NewUnstartedTracer returns a new Tracer instance without starting it. This is
-func NewUnstartedTracer(opts ...StartOption) (Tracer, error) {
-	return newUnstartedTracer(opts...)
-}
-
 func newUnstartedTracer(opts ...StartOption) (*tracer, error) {
 	c, err := newConfig(opts...)
 	if err != nil {

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -530,13 +530,6 @@ type Chunk struct {
 	willSend bool // willSend indicates whether the trace will be sent to the agent.
 }
 
-func NewChunk(spans []*Span, willSend bool) *Chunk {
-	return &Chunk{
-		spans:    spans,
-		willSend: willSend,
-	}
-}
-
 // sampleChunk applies single-span sampling to the provided trace.
 func (t *tracer) sampleChunk(c *Chunk) {
 	if len(c.spans) > 0 {


### PR DESCRIPTION
### What does this PR do?

These functions are exported and not used in our repository. They were introduced during `v2` development, and have been deemed as not needed.

[Chunk](https://github.com/DataDog/dd-trace-go/pull/2408/files#diff-ad86e517e9501587fea706a500cf65dbf92b14f3c3bfc3f821194125a3c79d46R449) was exported in #2408. Its fields were unexported later, so it's an opaque type that needs to be exported for `mocktracer`.

Once we remove/improve the `mocktracer`, we'll be able to unexport it again. As it's opaque and there isn't public API using it, it won't be a breaking change for external users.

### Motivation

Reduce API.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
