### PR TITLE
[APM] Ensure empty chunks are not flushed

### DIFF
--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -482,7 +482,9 @@ func (t *tracer) worker(tick <-chan time.Time) {
 		select {
 		case trace := <-t.out:
 			t.sampleChunk(trace)
-			t.traceWriter.add(trace.spans)
+			if len(trace.spans) > 0 {
+				t.traceWriter.add(trace.spans)
+			}
 		case <-tick:
 			t.statsd.Incr("datadog.tracer.flush_triggered", []string{"reason:scheduled"}, 1)
 			t.traceWriter.flush()
@@ -507,7 +509,9 @@ func (t *tracer) worker(tick <-chan time.Time) {
 				select {
 				case trace := <-t.out:
 					t.sampleChunk(trace)
-					t.traceWriter.add(trace.spans)
+					if len(trace.spans) > 0 {
+						t.traceWriter.add(trace.spans)
+					}
 				default:
 					break loop
 				}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This commit fixes a regression on v2 where empty TraceChunks may be flushed and sent to the trace-agent.

The fix is to check whether there are spans to the added to the trace writer, and never add empty spans. This was how v1 handled this logic as well.

Summary of the issue:

* After the merge on dd-go last Friday, the agent starts reporting considerably more traces from service:datadog-agent. See [here](https://app.datadoghq.com/metric/explorer?fromUser=false&state=H4sIAAAAAAAAE12R62rDMAyF30U_hylJ2q2dX2UUY2I5FfiSWk4hDXn3ofQy2D_p8PnoSF7ghoUpJ9DQNd3BtK1pWlAwFDteGPTPAg49JaobtEClGhA0gHqUhukuffv1VmygQQwD-iriPApQKSJjIWRQUPA6IdfHgII85sRofC7R1v_sdXpUgiYbxUukWWI6W63hPJVe5Ii1UP96M4MGexs0z1wx7vpx2k2MZflYYT0rkGFTsA_fZ_NnvZ7X8yoYj4GqcRQxyZ0Ef6t9Tp6GzSBQpAq6bRRwLlUulYvDAhoccg-bl6zly7bCAlytcO3xcPzuTl3XfDcHBZjcpp0-9_vmqRX0BfliYnayJQdylAZQMNqJ0YH2NjCuCjyFiuUZ8R3Z3OhuXp-Qx0BcYf0FIKo7SPkBAAA&start=1747928220904&end=1748533020904&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYAEwGIFCeGE4a+NoAxkrIIOoIulmWgWZxyhp4qsgpCBhQODAAdIUYOU4Y8CIITUY5EABuOi3abZpOfexDUMCYIjDIMDg8AAQARlgrwH4DEDk8TRgaTln43QAUAJQgPAC6VK7ueJih4Y+qzxgxZQk39yAaORoXKgeQYYEIBC5ZKNE4vDR7JJoURwJxyRQVHDIqBIlFOehMZQiNweNA3fgQeyYLBohTQjBGL53Hh8AHyZEIADCUmEMBQImeaB4QA)
* This is scoped to this tracer version. No agent version interference.
* The issue is the following:
    * When Client-Side Stats is enabled, the tracer can drop spans
    * When all spans are dropped (P0), the tracewriter.add() may receive empty chunks [here](https://github.com/DataDog/dd-trace-go/blob/main/ddtrace/tracer/tracer.go#L485), which will still be sent to the agent
The agent reports traces received for service:"" (which is then mapped to datadog-agent, not sure where)
This didn’t happen on v1.73.1, probably because of [this extra check](https://github.com/DataDog/dd-trace-go/blob/release-v1.73.x/ddtrace/tracer/tracer.go#L456-L458) before adding spans.

Impact:
* Empty chunks are sent from tracer to agent
* Received traces metric from agent is broken because of this
* I initially suspected sampling may be broken as well, but it’s not the case

Broken metric:
<img width="1813" alt="image" src="https://github.com/user-attachments/assets/a5403fbb-7710-46b7-bd1e-efc1ce417a59" />



<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
