### PR TITLE
fix (internal/civisibility): fix travis environment variables mapping

### DIFF
--- a/internal/civisibility/utils/ci_providers.go
+++ b/internal/civisibility/utils/ci_providers.go
@@ -609,9 +609,7 @@ func extractTravis() map[string]string {
 	tags[constants.CIJobURL] = os.Getenv("TRAVIS_JOB_WEB_URL")
 	tags[constants.GitCommitMessage] = os.Getenv("TRAVIS_COMMIT_MESSAGE")
 
-	tags[constants.GitHeadCommit] = os.Getenv("TRAVIS_PULL_REQUEST_SHA")
 	tags[constants.GitPrBaseBranch] = os.Getenv("TRAVIS_PULL_REQUEST_BRANCH")
-
 	return tags
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Fixes the environment variables mapping for Travis CI Provider.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

from [travis docs](https://docs.travis-ci.com/user/environment-variables#default-environment-variables):

TRAVIS_PULL_REQUEST_SHA:
if the current job is a pull request, the commit SHA of the HEAD commit of the PR. NOT THE BASE SHA


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
