### PR TITLE
feat(ddtrace/tracer): add NewFinishConfig function

### DIFF
--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -8,6 +8,7 @@ package tracer
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -1893,6 +1894,25 @@ func TestWithStartSpanConfig(t *testing.T) {
 	assert.Equal(spanID, s.spanID)
 	assert.Equal(ext.SpanTypeWeb, s.spanType)
 	assert.Equal(tm.UnixNano(), s.start)
+}
+
+func TestNewFinishConfig(t *testing.T) {
+	var (
+		assert = assert.New(t)
+		now    = time.Now()
+		err    = errors.New("error")
+	)
+	cfg := NewFinishConfig(
+		FinishTime(now),
+		WithError(err),
+		StackFrames(10, 0),
+		NoDebugStack(),
+	)
+	assert.True(cfg.NoDebugStack)
+	assert.Equal(now, cfg.FinishTime)
+	assert.Equal(err, cfg.Error)
+	assert.Equal(uint(10), cfg.StackFrames)
+	assert.Equal(uint(0), cfg.SkipStackFrames)
 }
 
 func TestWithStartSpanConfigNonEmptyTags(t *testing.T) {

--- a/ddtrace/tracer/span_config.go
+++ b/ddtrace/tracer/span_config.go
@@ -75,6 +75,16 @@ type FinishConfig struct {
 	SkipStackFrames uint
 }
 
+// NewFinishConfig allows to build a base finish config struct. It accepts the same options as Finish.
+// It's useful to reduce the number of operations in any hot path and update it for request/operation specifics.
+func NewFinishConfig(opts ...FinishOption) *FinishConfig {
+	cfg := new(FinishConfig)
+	for _, fn := range opts {
+		fn(cfg)
+	}
+	return cfg
+}
+
 // FinishTime sets the given time as the finishing time for the span. By default,
 // the current time is used.
 func FinishTime(t time.Time) FinishOption {


### PR DESCRIPTION
### What does this PR do?

Adds `tracer.NewFinishConfig` to mirror `tracer.NewStartSpanConfig`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
