### PR TITLE
don't push latest docker images on v1

### DIFF
--- a/.github/workflows/service-extensions-publish.yml
+++ b/.github/workflows/service-extensions-publish.yml
@@ -119,9 +119,6 @@ jobs:
             tagname=${TAG_NAME//\//-} # remove slashes from tag name
             tags="tags=-t ghcr.io/datadog/dd-trace-go/service-extensions-callout:${tagname} \
             -t ghcr.io/datadog/dd-trace-go/service-extensions-callout:${{ env.COMMIT_SHA }}"
-            if [ "${PUSH_LATEST}" == "true" ]; then
-              tags="$tags -t ghcr.io/datadog/dd-trace-go/service-extensions-callout:latest"
-            fi
           
             echo $tags >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Since we published v2. Don't publish docker images as `latest` from the maintenance branch.

### Motivation

No rollback to previous versions for the system tests running these docker images

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
