### PR TITLE
Remove an excessive and unactionable error log from AWS SDK

### DIFF
--- a/contrib/aws/aws-sdk-go-v2/aws/aws.go
+++ b/contrib/aws/aws-sdk-go-v2/aws/aws.go
@@ -146,7 +146,7 @@ func resourceNameFromParams(requestInput middleware.InitializeInput, awsService 
 	case "SFN":
 		k, v = ext.SFNStateMachineName, stateMachineName(requestInput)
 	default:
-		return "", "", fmt.Errorf("attemped to extract ResourceNameFromParams of an unsupported AWS service: %s", awsService)
+		return "", "", nil
 	}
 
 	return k, v, nil


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This removes an excessive and (relatively) unactionable error log when `resourceNameFromParams` encounters an unsupported AWS service. Only a subset of AWS services seem to have extra tag data extracted.

Note that this isn't the span resource name.

### Motivation

Seeing this get hit **a lot** in our own dogfood applications and it seems like removing is the simplest option.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
