### PR TITLE
ci: run benchmarks in parallel (part 2)

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -10,7 +10,7 @@
   script: |
     export ARTIFACTS_DIR="$(pwd)/reports" && (mkdir "${ARTIFACTS_DIR}" || :)
     git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
-    git clone --branch hannahkm/bp-runner-2 https://github.com/DataDog/benchmarking-platform /platform && cd /platform
+    git clone --branch hannahkm/parallel2 https://github.com/DataDog/benchmarking-platform /platform && cd /platform
     ./steps/capture-hardware-software-info.sh
     TEST_NAME=$BENCHMARK_NAME bp-runner "${CI_PROJECT_DIR:-.}/.gitlab/bp-runner.yml" --debug -t
     ./steps/analyze-results.sh


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Changes the branch off which we run our benchmarks

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

**IMPORTANT**: Reviewers should look at the new benchmarking-platform branch linked below, as that is where the changes to code have been made. This PR only updates our CI to point at this new branch. The new benchmarking-platform code has been branched off of `hannahkm/bp-runner-2` ([link](https://github.com/DataDog/benchmarking-platform/blob/hannahkm/bp-runner-2/steps/run-benchmarks.sh))

The new `benchmarking-platform` [branch](https://github.com/DataDog/benchmarking-platform/blob/hannahkm/parallel2/steps/run-benchmarks.sh) introduces a few checks that allows us to run benchmarks a little quicker. The changes being:

1. Automatically running through valid directories to run benchmarks in, rather than hardcoding them ourselves
2. Checking to make sure directories are valid before attempting to test
3. Ensuring that the benchmark we are attempting to run actually exists within that subdirectory

This should allow us to have better forward compatibility (adding new benchmarks without needing to update/check our branch in `benchmarking-platform`) and to ensure that benchmarks are always being run correctly.

We should also see the benchmarks running quicker; previously, benchmarks took up to 35 minutes to run (avged around 20 minutes). After this change, they should take <= 15 minutes (give or take the time taken for runners to spin up).

Note that benchmarks have been broken on main for the past 3 weeks (at time of writing) due to benchmarks not being run correctly. This PR, along with [#3544](https://github.com/DataDog/dd-trace-go/pull/3544), should also fix those issues. The breaking PR for benchmarks was introduced May 21, 2025.

Before:
<img width="1019" alt="image" src="https://github.com/user-attachments/assets/e5eb4be1-c23b-4334-8bb8-8559f8a930c0" />

Now:
<img width="702" alt="image" src="https://github.com/user-attachments/assets/b32185f4-9a7e-45ba-868b-f1fd04ac4496" />

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
