### PR TITLE
contrib/hashicorp/vault: add godoc links

### DIFF
--- a/contrib/hashicorp/vault/option.go
+++ b/contrib/hashicorp/vault/option.go
@@ -24,7 +24,7 @@ type Option interface {
 	apply(*config)
 }
 
-// OptionFn represents options applicable to NewHTTPClient and WrapHTTPClient.
+// OptionFn represents options applicable to [NewHTTPClient] and [WrapHTTPClient].
 type OptionFn func(*config)
 
 func (fn OptionFn) apply(cfg *config) {
@@ -52,7 +52,7 @@ func WithAnalyticsRate(rate float64) OptionFn {
 	}
 }
 
-// WithService sets the given service name for the http.Client.
+// WithService sets the given service name for the [*http.Client].
 func WithService(name string) OptionFn {
 	return func(c *config) {
 		c.serviceName = name

--- a/contrib/hashicorp/vault/vault.go
+++ b/contrib/hashicorp/vault/vault.go
@@ -3,16 +3,17 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
-// Package vault contains functions to construct or augment an http.Client that
-// will integrate with the github.com/hashicorp/vault/api and collect traces to
+// Package vault contains functions to construct or augment an [*http.Client] that
+// will integrate with the [github.com/hashicorp/vault/api] and collect traces to
 // send to Datadog.
 //
-// The easiest way to use this package is to create an http.Client with
-// NewHTTPClient, and put it in the Vault API config that is passed to the
+// The easiest way to use this package is to create an [*http.Client] with
+// [NewHTTPClient], and put it in the Vault [api.Config] that is passed to
+// [api.NewClient].
 //
-// If you are already using your own http.Client with the Vault API, you can
-// use the WrapHTTPClient function to wrap the client with the tracer code.
-// Your http.Client will continue to work as before, but will also capture
+// If you are already using your own [*http.Client] with the Vault API, you can
+// use the [WrapHTTPClient] function to wrap the client with the tracer code.
+// Your [*http.Client] will continue to work as before, but will also capture
 // traces.
 package vault
 
@@ -36,8 +37,8 @@ func init() {
 	instr = instrumentation.Load(instrumentation.PackageHashicorpVaultAPI)
 }
 
-// NewHTTPClient returns an http.Client for use in the Vault API config
-// Client. A set of options can be passed in for further configuration.
+// NewHTTPClient returns an [*http.Client] for use in the Vault API config
+// [*api.Client]. A set of options can be passed in for further configuration.
 func NewHTTPClient(opts ...Option) *http.Client {
 	dc := api.DefaultConfig()
 	c := dc.HttpClient
@@ -45,7 +46,7 @@ func NewHTTPClient(opts ...Option) *http.Client {
 	return c
 }
 
-// WrapHTTPClient takes an existing http.Client and wraps the underlying
+// WrapHTTPClient takes an existing [*http.Client] and wraps the underlying
 // transport with tracing.
 func WrapHTTPClient(c *http.Client, opts ...Option) *http.Client {
 	if c.Transport == nil {


### PR DESCRIPTION
### What does this PR do?

Improve Go doc of package `contrib/hashicorp/vault` by using [godoc links](https://go.dev/doc/comment#doclinks).

### Motivation

Improved readability of the documentation thanks to cross links. 

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
