### PR TITLE
contrib/julienschmidt/httprouter: add godoc links

### DIFF
--- a/contrib/julienschmidt/httprouter/httprouter.go
+++ b/contrib/julienschmidt/httprouter/httprouter.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
-// Package httprouter provides functions to trace the julienschmidt/httprouter package (https://github.com/julienschmidt/httprouter).
+// Package httprouter provides functions to trace the [github.com/julienschmidt/httprouter] package.
 package httprouter // import "github.com/DataDog/dd-trace-go/contrib/julienschmidt/httprouter/v2"
 
 import (
@@ -22,7 +22,7 @@ func init() {
 	instr = instrumentation.Load(instrumentation.PackageJulienschmidtHTTPRouter)
 }
 
-// Router is a traced version of httprouter.Router.
+// Router is a traced version of [httprouter.Router].
 type Router struct {
 	*httprouter.Router
 	config *tracing.Config
@@ -35,7 +35,7 @@ func New(opts ...RouterOption) *Router {
 	return &Router{httprouter.New(), cfg}
 }
 
-// ServeHTTP implements http.Handler.
+// ServeHTTP implements [http.Handler].
 func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	tw, treq, afterHandle, handled := tracing.BeforeHandle(r.config, r.Router, wrapRouter, w, req)
 	defer afterHandle()


### PR DESCRIPTION
### What does this PR do?

Improve Go doc of package contrib/julienschmidt/httprouter by using [godoc links](https://go.dev/doc/comment#doclinks).

### Motivation

Improved readability of the documentation thanks to cross links.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
