### PR TITLE
internal/telemetry: make sure only backend known metrics are released

### DIFF
--- a/internal/telemetry/telemetrytest/globalclient_test.go
+++ b/internal/telemetry/telemetrytest/globalclient_test.go
@@ -89,6 +89,7 @@ func TestGlobalClient(t *testing.T) {
 
 	t.Run("count", func(t *testing.T) {
 		recorder := new(RecordClient)
+		recorder.knownMetrics = true
 		defer telemetry.MockClient(recorder)()
 
 		telemetry.Count(telemetry.NamespaceTracers, "init_time", nil).Submit(1)
@@ -99,6 +100,7 @@ func TestGlobalClient(t *testing.T) {
 
 	t.Run("gauge", func(t *testing.T) {
 		recorder := new(RecordClient)
+		recorder.knownMetrics = true
 		defer telemetry.MockClient(recorder)()
 
 		telemetry.Gauge(telemetry.NamespaceTracers, "init_time", nil).Submit(1)
@@ -109,6 +111,7 @@ func TestGlobalClient(t *testing.T) {
 
 	t.Run("rate", func(t *testing.T) {
 		recorder := new(RecordClient)
+		recorder.knownMetrics = true
 		defer telemetry.MockClient(recorder)()
 
 		telemetry.Rate(telemetry.NamespaceTracers, "init_time", nil).Submit(1)
@@ -120,6 +123,7 @@ func TestGlobalClient(t *testing.T) {
 
 	t.Run("distribution", func(t *testing.T) {
 		recorder := new(RecordClient)
+		recorder.knownMetrics = true
 		defer telemetry.MockClient(recorder)()
 
 		telemetry.Distribution(telemetry.NamespaceGeneral, "init_time", nil).Submit(1)

--- a/internal/telemetry/telemetrytest/mock.go
+++ b/internal/telemetry/telemetrytest/mock.go
@@ -18,6 +18,8 @@ import (
 // e.g. the tracer and profiler.
 type MockClient struct {
 	mock.Mock
+
+	knownMetrics bool
 }
 
 func (m *MockClient) Close() error {
@@ -37,28 +39,28 @@ func (m *MockMetricHandle) Get() float64 {
 }
 
 func (m *MockClient) Count(namespace telemetry.Namespace, name string, tags []string) telemetry.MetricHandle {
-	if !knownmetrics.IsKnownMetric(namespace, transport.CountMetric, name) {
+	if !m.knownMetrics && !knownmetrics.IsKnownMetric(namespace, transport.CountMetric, name) {
 		panic("telemetrytest.RecordClient should only be used with backend-side known metrics")
 	}
 	return m.Called(namespace, name, tags).Get(0).(telemetry.MetricHandle)
 }
 
 func (m *MockClient) Rate(namespace telemetry.Namespace, name string, tags []string) telemetry.MetricHandle {
-	if !knownmetrics.IsKnownMetric(namespace, transport.RateMetric, name) {
+	if !m.knownMetrics && !knownmetrics.IsKnownMetric(namespace, transport.RateMetric, name) {
 		panic("telemetrytest.RecordClient should only be used with backend-side known metrics")
 	}
 	return m.Called(namespace, name, tags).Get(0).(telemetry.MetricHandle)
 }
 
 func (m *MockClient) Gauge(namespace telemetry.Namespace, name string, tags []string) telemetry.MetricHandle {
-	if !knownmetrics.IsKnownMetric(namespace, transport.GaugeMetric, name) {
+	if !m.knownMetrics && !knownmetrics.IsKnownMetric(namespace, transport.GaugeMetric, name) {
 		panic("telemetrytest.RecordClient should only be used with backend-side known metrics")
 	}
 	return m.Called(namespace, name, tags).Get(0).(telemetry.MetricHandle)
 }
 
 func (m *MockClient) Distribution(namespace telemetry.Namespace, name string, tags []string) telemetry.MetricHandle {
-	if !knownmetrics.IsKnownMetric(namespace, transport.DistMetric, name) {
+	if !m.knownMetrics && !knownmetrics.IsKnownMetric(namespace, transport.DistMetric, name) {
 		panic("telemetrytest.RecordClient should only be used with backend-side known metrics")
 	}
 	return m.Called(namespace, name, tags).Get(0).(telemetry.MetricHandle)

--- a/internal/telemetry/telemetrytest/record.go
+++ b/internal/telemetry/telemetrytest/record.go
@@ -39,6 +39,7 @@ type RecordClient struct {
 	Integrations  []telemetry.Integration
 	Products      map[telemetry.Namespace]bool
 	Metrics       map[MetricKey]*RecordMetricHandle
+	knownMetrics  bool
 }
 
 func (r *RecordClient) Close() error {
@@ -73,7 +74,7 @@ func (r *RecordClient) metric(kind string, namespace telemetry.Namespace, name s
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if !knownmetrics.IsKnownMetric(namespace, transport.MetricType(kind), name) {
+	if !r.knownMetrics && !knownmetrics.IsKnownMetric(namespace, transport.MetricType(kind), name) {
 		panic("telemetrytest.RecordClient should only be used with backend-side known metrics")
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds a check in telemetry testing code to make sure we don't release metrics that would get refused by the backend

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!