### PR TITLE
otel sampling fix

### DIFF
--- a/ddtrace/opentelemetry/tracer_test.go
+++ b/ddtrace/opentelemetry/tracer_test.go
@@ -98,9 +98,12 @@ func TestTracerOptions(t *testing.T) {
 	assert.Contains(fmt.Sprint(sp), "dd.env=wrapper_env")
 }
 
-func TestSpanContext(t *testing.T) {
+func TestExtractSpanContext(t *testing.T) {
 	assert := assert.New(t)
-	tp := NewTracerProvider()
+	// Start tracer with trace sample rules, which should be ignored in favor of the sampling priority inherited from tracer.Extract
+	tp := NewTracerProvider(tracer.WithSamplingRules([]tracer.SamplingRule{
+		{Rate: 0}, // This should be applied only when a brand new root span is started
+	}))
 	defer tp.Shutdown()
 	otel.SetTracerProvider(tp)
 	tr := otel.Tracer("")

--- a/ddtrace/opentelemetry/tracer_test.go
+++ b/ddtrace/opentelemetry/tracer_test.go
@@ -98,7 +98,7 @@ func TestTracerOptions(t *testing.T) {
 	assert.Contains(fmt.Sprint(sp), "dd.env=wrapper_env")
 }
 
-func TestExtractSpanContext(t *testing.T) {
+func TestParentContext(t *testing.T) {
 	assert := assert.New(t)
 	// Start tracer with trace sample rules, which should be ignored in favor of the sampling priority inherited from tracer.Extract
 	tp := NewTracerProvider(tracer.WithSamplingRules([]tracer.SamplingRule{

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -469,8 +469,7 @@ func (t *trace) finishedOne(s *span) {
 		// we won't be able to make changes to a span after finishing
 		// without causing a race condition.
 		t.root.setMetric(keySamplingPriority, *t.priority)
-		t.setLocked(true)
-		// t.locked = true
+		t.locked = true
 	}
 	if len(t.spans) > 0 && s == t.spans[0] {
 		// first span in chunk finished, lock down the tags

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -469,7 +469,8 @@ func (t *trace) finishedOne(s *span) {
 		// we won't be able to make changes to a span after finishing
 		// without causing a race condition.
 		t.root.setMetric(keySamplingPriority, *t.priority)
-		t.locked = true
+		t.setLocked(true)
+		// t.locked = true
 	}
 	if len(t.spans) > 0 && s == t.spans[0] {
 		// first span in chunk finished, lock down the tags

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -627,6 +627,8 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		span.ParentID = context.spanID
 		if p, ok := context.SamplingPriority(); ok {
 			span.setMetric(keySamplingPriority, float64(p))
+			// TODO: Check whether prio is trace rules or span rules?
+			context.trace.setLocked(true)
 		}
 		if context.span != nil {
 			// local parent, inherit service

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -891,7 +891,6 @@ func TestStartSpanOrigin(t *testing.T) {
 }
 
 func TestInjectNotOverwriteSampling(t *testing.T) {
-
 	assert := assert.New(t)
 
 	tracer := newTracer(WithSamplingRules([]SamplingRule{
@@ -907,7 +906,6 @@ func TestInjectNotOverwriteSampling(t *testing.T) {
 	tracer.Inject(ctx, carrier)
 
 	assert.Equal("2", headers.Get(DefaultPriorityHeader))
-
 }
 
 func TestPropagationDefaults(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?
Locks the trace sampling priority when it's been inherited by a parent span context.

### Motivation
[APMS-15887](https://datadoghq.atlassian.net/browse/APMS-15887)


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!


[APMS-15887]: https://datadoghq.atlassian.net/browse/APMS-15887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ