### PR TITLE
Fix SQL comment injection for empty tags

### DIFF
--- a/ddtrace/tracer/sqlcomment.go
+++ b/ddtrace/tracer/sqlcomment.go
@@ -149,7 +149,7 @@ var (
 // See https://google.github.io/sqlcommenter/spec/ for more details.
 func commentQuery(query string, tags map[string]string) string {
 	if len(tags) == 0 {
-		return ""
+		return query
 	}
 	var b strings.Builder
 	// the sqlcommenter specification dictates that tags should be sorted. Since we know all injected keys,

--- a/ddtrace/tracer/sqlcomment_test.go
+++ b/ddtrace/tracer/sqlcomment_test.go
@@ -353,6 +353,12 @@ func FuzzSpanContextFromTraceComment(f *testing.F) {
 	})
 }
 
+func TestCommentQueryNoTags(t *testing.T) {
+	query := "SELECT * FROM table"
+	result := commentQuery(query, map[string]string{})
+	require.Equal(t, query, result)
+}
+
 func BenchmarkSQLCommentInjection(b *testing.B) {
 	tracer, spanCtx, carrier := setupBenchmark()
 	defer tracer.Stop()


### PR DESCRIPTION
## Summary
- ensure commentQuery returns original query when no tags are provided
- add a unit test for this behavior

## Testing
- `go vet ./ddtrace/...`


------
https://chatgpt.com/codex/tasks/task_b_684c26d302688325b5697b2103682ac6