### PR TITLE
test: add sleep to SetTag for performance regression

### DIFF
--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -1305,6 +1305,7 @@ func BenchmarkSetTagStringPtr(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		k := keys[i%len(keys)]
 		span.SetTag(k, v)
+		time.Sleep(time.Nanosecond * 100)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Reproducing a performance regression to get a performance quality gate failure.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
