### PR TITLE
feat(apm): add referrer hostname as span tag

### DIFF
--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -53,6 +53,9 @@ const (
 	// HTTPClientIP sets the HTTP client IP tag.
 	HTTPClientIP = "http.client_ip"
 
+	// HTTPReferrerHostname sets the HTTP referrer hostname tag.
+	HTTPReferrerHostname = "http.referrer_hostname"
+
 	// HTTPRequestHeaders sets the HTTP request headers partial tag
 	// This tag is meant to be composed, i.e http.request.headers.headerX, http.request.headers.headerY, etc...
 	// See https://docs.datadoghq.com/tracing/trace_collection/tracing_naming_convention/#http-requests


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Parses referrer hostname from http header when presents and adds it to span tags as http.referrer_hostname.

### Motivation

This will be used to identify frontend clients without leaking the PII which can be contained in the entire referrer.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
