### PR TITLE
contrib/gin-gonic/gin: refactor Option, deprecate OptionFn

### DIFF
--- a/contrib/gin-gonic/gin/gintrace.go
+++ b/contrib/gin-gonic/gin/gintrace.go
@@ -32,7 +32,7 @@ func init() {
 func Middleware(service string, opts ...Option) gin.HandlerFunc {
 	cfg := newConfig(service)
 	for _, opt := range opts {
-		opt.apply(cfg)
+		opt(cfg)
 	}
 	instr.Logger().Debug("contrib/gin-gonic/gin: Configuring Middleware: Service: %s, %#v", cfg.serviceName, cfg)
 	spanOpts := []tracer.StartSpanOption{

--- a/contrib/gin-gonic/gin/option.go
+++ b/contrib/gin-gonic/gin/option.go
@@ -36,20 +36,19 @@ func newConfig(serviceName string) *config {
 	}
 }
 
-// Option describes options for the Gin integration.
-type Option interface {
-	apply(*config)
-}
+// Option describes an option for the Gin integration.
+type Option = option
 
-// OptionFn represents options applicable to Middleware.
-type OptionFn func(*config)
+// option is the hidden concrete implementation of [Option] using the functional options pattern.
+type option func(*config)
 
-func (fn OptionFn) apply(cfg *config) {
-	fn(cfg)
-}
+// OptionFn is an implementation detail of [Option].
+//
+// Deprecated: use [Option].
+type OptionFn = Option
 
 // WithAnalytics enables Trace Analytics for all started spans.
-func WithAnalytics(on bool) OptionFn {
+func WithAnalytics(on bool) Option {
 	return func(cfg *config) {
 		if on {
 			cfg.analyticsRate = 1.0
@@ -61,7 +60,7 @@ func WithAnalytics(on bool) OptionFn {
 
 // WithAnalyticsRate sets the sampling rate for Trace Analytics events
 // correlated to started spans.
-func WithAnalyticsRate(rate float64) OptionFn {
+func WithAnalyticsRate(rate float64) Option {
 	return func(cfg *config) {
 		if rate >= 0.0 && rate <= 1.0 {
 			cfg.analyticsRate = rate
@@ -73,7 +72,7 @@ func WithAnalyticsRate(rate float64) OptionFn {
 
 // WithResourceNamer specifies a function which will be used to obtain a resource name for a given
 // gin request, using the request's context.
-func WithResourceNamer(namer func(c *gin.Context) string) OptionFn {
+func WithResourceNamer(namer func(c *gin.Context) string) Option {
 	return func(cfg *config) {
 		cfg.resourceNamer = namer
 	}
@@ -83,7 +82,7 @@ func WithResourceNamer(namer func(c *gin.Context) string) OptionFn {
 // Warning:
 // Using this feature can risk exposing sensitive data such as authorization tokens to Datadog.
 // Special headers can not be sub-selected. E.g., an entire Cookie header would be transmitted, without the ability to choose specific Cookies.
-func WithHeaderTags(headers []string) OptionFn {
+func WithHeaderTags(headers []string) Option {
 	return func(cfg *config) {
 		cfg.headerTags = instrumentation.NewHeaderTags(headers)
 	}
@@ -91,7 +90,7 @@ func WithHeaderTags(headers []string) OptionFn {
 
 // WithIgnoreRequest specifies a function to use for determining if the
 // incoming HTTP request tracing should be skipped.
-func WithIgnoreRequest(f func(c *gin.Context) bool) OptionFn {
+func WithIgnoreRequest(f func(c *gin.Context) bool) Option {
 	return func(cfg *config) {
 		cfg.ignoreRequest = f
 	}


### PR DESCRIPTION
### What does this PR do?

Full rationale for this change: see discussion https://github.com/DataDog/dd-trace-go/discussions/3612

* Refactor [`contrib/gin-gonic/gin.Option`](https://pkg.go.dev/github.com/DataDog/dd-trace-go/contrib/gin-gonic/gin#Option)s handling.
* Deprecate [`OptionFn`](https://pkg.go.dev/github.com/DataDog/dd-trace-go/contrib/gin-gonic/gin#OptionFn) which was an implementation detail that is not needed anymore.

This change is fully source compatible with existing client code. Also, as implementation details are now hidden behind the new private `option` type, the API is more future-proof.


### Motivation

API cleanup. 

Full rationale for this change: https://github.com/DataDog/dd-trace-go/discussions/3612


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
