### PR TITLE
refactor: replace atomic operations with atomic.Int32 for error tracking in SpanContext

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
@@ -401,13 +400,13 @@ func (s *Span) setTagError(value interface{}, cfg errorConfig) {
 		if yes {
 			if s.error == 0 {
 				// new error
-				atomic.AddInt32(&s.context.errors, 1)
+				s.context.errors.Add(1)
 			}
 			s.error = 1
 		} else {
 			if s.error > 0 {
 				// flip from active to inactive
-				atomic.AddInt32(&s.context.errors, -1)
+				s.context.errors.Add(-1)
 			}
 			s.error = 0
 		}
@@ -788,7 +787,7 @@ func shouldKeep(s *Span) bool {
 		// positive sampling priorities stay
 		return true
 	}
-	if atomic.LoadInt32(&s.context.errors) > 0 {
+	if s.context.errors.Load() > 0 {
 		// traces with any span containing an error get kept
 		return true
 	}

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -12,7 +12,6 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -272,7 +271,7 @@ func TestShouldDrop(t *testing.T) {
 			s := newSpan("", "", "", 1, 1, 0)
 			s.setSamplingPriority(tt.prio, samplernames.Default)
 			s.SetTag(ext.EventSampleRate, tt.rate)
-			atomic.StoreInt32(&s.context.errors, tt.errors)
+			s.context.errors.Store(tt.errors)
 			assert.Equal(t, shouldKeep(s), tt.want)
 		})
 	}

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -88,9 +88,9 @@ type SpanContext struct {
 
 	// the below group should propagate only locally
 
-	trace  *trace // reference to the trace that this span belongs too
-	span   *Span  // reference to the span that hosts this context
-	errors int32  // number of spans with errors in this trace
+	trace  *trace       // reference to the trace that this span belongs too
+	span   *Span        // reference to the span that hosts this context
+	errors atomic.Int32 // number of spans with errors in this trace
 
 	// The 16-character hex string of the last seen Datadog Span ID
 	// this value will be added as the _dd.parent_id tag to spans
@@ -166,7 +166,7 @@ func newSpanContext(span *Span, parent *SpanContext) *SpanContext {
 		context.traceID.SetUpper(parent.traceID.Upper())
 		context.trace = parent.trace
 		context.origin = parent.origin
-		context.errors = parent.errors
+		context.errors.Store(parent.errors.Load())
 		parent.ForeachBaggageItem(func(k, v string) bool {
 			context.setBaggageItem(k, v)
 			return true


### PR DESCRIPTION
### What does this PR do?

Replaces `atomic.*Int32` functions with `atomic.Int32` value and functions to avoid race conditions.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
