### PR TITLE
ddtrace/tracer: cap execution tracer task name length

### DIFF
--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -978,6 +978,12 @@ func startExecutionTracerTask(ctx gocontext.Context, span *Span) (gocontext.Cont
 	if !spanResourcePIISafe(span) {
 		taskName = span.spanType
 	}
+	// The task name is an arbitrary string from the user. If it's too
+	// large, like a big SQL query, the execution tracer can crash when we
+	// create the task. Cap it at an arbirary length.  For "normal" task
+	// names this should be plenty that we can still have the task names for
+	// debugging.
+	taskName = taskName[:min(128, len(taskName))]
 	end := noopTaskEnd
 	if !globalinternal.IsExecutionTraced(ctx) {
 		var task *rt.Task

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -2835,3 +2835,24 @@ func TestPPROFLabelRootSpanRace(t *testing.T) {
 	}()
 	wg.Wait()
 }
+
+func TestExecTraceLargeTaskNameRegression(t *testing.T) {
+	if rt.IsEnabled() {
+		t.Skip("execution tracing is already enabled")
+	}
+	rt.Start(io.Discard)
+	defer rt.Stop()
+
+	Start()
+	defer Stop()
+
+	// Create a string big enough that in practice the execution tracer will
+	// crash if we try to use it as a task name
+	var b strings.Builder
+	for range 160000 {
+		b.WriteByte('a')
+	}
+
+	s := StartSpan("test", ResourceName(b.String()))
+	s.Finish()
+}


### PR DESCRIPTION
### What does this PR do?

We use the span resource as the name for execution tracer task
annotations. The resource can be an arbitrarily large string, like an
SQL query, and the execution tracer can fail to allocate space for it in
its string table and crash. The task name isn't really used for anything
right now other than debugging. Cap the task name at some arbitrary
length to mitigate this.

### Motivation

Prevent crashes

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
