### PR TITLE
fix: data race in civisibility/integrations/logs/logs_payload.go

### DIFF
--- a/internal/civisibility/integrations/logs/logs_payload.go
+++ b/internal/civisibility/integrations/logs/logs_payload.go
@@ -42,6 +42,9 @@ func newLogsPayload() *logsPayload {
 
 // push pushes a new item into the stream.
 func (p *logsPayload) push(logEntryData *logEntry) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	if p.reader != nil {
 		// If the reader is already set, we cannot push new items.
 		return io.ErrClosedPipe
@@ -58,8 +61,6 @@ func (p *logsPayload) push(logEntryData *logEntry) error {
 		return err
 	}
 
-	p.mu.Lock()
-	defer p.mu.Unlock()
 	p.count = p.count + 1 // increment the count after acquiring the lock to ensure consistency
 	if p.count > 1 {
 		p.buf.WriteByte(',')


### PR DESCRIPTION
### What does this PR do?

Protects `logsPayload` concurrent using its mutex.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
