### PR TITLE
fix(ddtrace/tracer): add test and fix for deadlock issue #3541 in remote configuration

### DIFF
--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -199,12 +199,12 @@ func newClient(config ClientConfig) (*Client, error) {
 func Start(config ClientConfig) error {
 	var err error
 	startOnce.Do(func() {
-		client, err = newClient(config)
-		if err != nil {
-			return
-		}
 		if !internal.BoolEnv("DD_REMOTE_CONFIGURATION_ENABLED", true) {
 			// Don't start polling if the feature is disabled explicitly
+			return
+		}
+		client, err = newClient(config)
+		if err != nil {
 			return
 		}
 		go func() {


### PR DESCRIPTION
### What does this PR do?

Fix deadlock reported in #3541.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
