### PR TITLE
envoyproxy: fix partial parsing jsoniter truncated map key

### DIFF
--- a/contrib/envoyproxy/go-control-plane/internal/json/encoder_test.go
+++ b/contrib/envoyproxy/go-control-plane/internal/json/encoder_test.go
@@ -427,6 +427,26 @@ func TestJSONEncode_MalformedInput(t *testing.T) {
 			},
 		},
 		{
+			name:      "array first object key truncated",
+			jsonInput: `[{"name": "value", "test`,
+			truncatedTestCase: testCase{
+				expectOutput: []any{map[string]any{"name": "value"}},
+			},
+			notTruncatedTestCase: testCase{
+				expectEncodingError: true,
+			},
+		},
+		{
+			name:      "object in object with key truncated",
+			jsonInput: `{"name": {"key": "val", "test`,
+			truncatedTestCase: testCase{
+				expectOutput: map[string]any{"name": map[string]any{"key": "val"}},
+			},
+			notTruncatedTestCase: testCase{
+				expectEncodingError: true,
+			},
+		},
+		{
 			name:      "malformed json - missing colon",
 			jsonInput: `{"key" "value"}`,
 			truncatedTestCase: testCase{

--- a/contrib/envoyproxy/go-control-plane/internal/json/unsafe.go
+++ b/contrib/envoyproxy/go-control-plane/internal/json/unsafe.go
@@ -43,3 +43,19 @@ func getIteratorHeadAndTail(iter *jsoniter.Iterator) (int, int) {
 	runtime.KeepAlive(iter) // Ensure the iterator is not garbage collected while we're using it
 	return head, tail
 }
+
+// getIteratorHead retrieves the head field from a jsoniter.Iterator.
+// This is done using unsafe operations to avoid the overhead of reflection.
+func getIteratorHead(iter *jsoniter.Iterator) int {
+	head := *(*int)(unsafe.Add(unsafe.Pointer(iter), headOffset))
+	runtime.KeepAlive(iter) // Ensure the iterator is not garbage collected while we're using it
+	return head
+}
+
+// getIteratorTail retrieves the tail field from a jsoniter.Iterator.
+// This is done using unsafe operations to avoid the overhead of reflection.
+func getIteratorTail(iter *jsoniter.Iterator) int {
+	tail := *(*int)(unsafe.Add(unsafe.Pointer(iter), tailOffset))
+	runtime.KeepAlive(iter) // Ensure the iterator is not garbage collected while we're using it
+	return tail
+}


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue in partial‐parsing mode where a truncated map key would wrongly trigger an error, ensuring that such keys no longer cause failures.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Error in partial parsing.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
