### PR TITLE
fix(ddtrace/opentelemetry): propagate sampling decision to child spans

### DIFF
--- a/ddtrace/opentelemetry/tracer.go
+++ b/ddtrace/opentelemetry/tracer.go
@@ -44,6 +44,9 @@ func (t *oteltracer) Start(ctx context.Context, spanName string, opts ...oteltra
 			// if the span doesn't originate from the Datadog tracer,
 			// use SpanContextW3C implementation struct to pass span context information
 			ddopts = append(ddopts, tracer.ChildOf(tracer.FromGenericCtx(&otelCtxToDDCtx{sctx})))
+			if sctx.IsSampled() {
+				ddopts = append(ddopts, tracer.Tag(ext.ManualKeep, true))
+			}
 		}
 	}
 	if t := ssConfig.Timestamp(); !t.IsZero() {


### PR DESCRIPTION
### What does this PR do?

Propagates the parent context's sampling decision to child spans if parent has been sampled.

### Motivation

Closes #3639.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
