### PR TITLE
fix (internal/civisibility): fix code coverage stdout data race

### DIFF
--- a/internal/civisibility/integrations/gotesting/coverage/test_coverage.go
+++ b/internal/civisibility/integrations/gotesting/coverage/test_coverage.go
@@ -72,9 +72,6 @@ var (
 	// tearDown is the function to write the coverage counters to the file.
 	tearDown func(coverprofile string, gocoverdir string) (string, error)
 
-	// tempFile is the temp file to store coverage messages that we don't want to print to stdout.
-	tempFile *os.File
-
 	// covWriter is the coverage writer for sending test coverage data to the backend.
 	covWriter *coverageWriter
 
@@ -99,10 +96,6 @@ func InitializeCoverage(m *testing.M) {
 	tMode, tDown, _ := testDep.InitRuntimeCoverage()
 	mode = tMode
 	tearDown = func(coverprofile string, gocoverdir string) (string, error) {
-		// redirecting stdout to a temp file to avoid printing coverage messages to stdout
-		stdout := os.Stdout
-		os.Stdout = tempFile
-		defer func() { os.Stdout = stdout }()
 		// writing the coverage counters to the file
 		return tDown(coverprofile, gocoverdir)
 	}
@@ -111,9 +104,6 @@ func InitializeCoverage(m *testing.M) {
 	if !CanCollect() {
 		return
 	}
-
-	// creating a temp file to store coverage messages that we don't want to print to stdout
-	tempFile, _ = os.CreateTemp("", "coverage")
 
 	// initializing coverage writer
 	covWriter = newCoverageWriter()

--- a/internal/civisibility/integrations/gotesting/coverage/test_coverage_test.go
+++ b/internal/civisibility/integrations/gotesting/coverage/test_coverage_test.go
@@ -52,10 +52,6 @@ func TestGetCoverage(t *testing.T) {
 		return "", nil
 	}
 
-	// Redirect stdout to tempFile to avoid cluttering output
-	tempFile, _ = os.CreateTemp("", "coverage")
-	defer tempFile.Close()
-
 	coverage := GetCoverage()
 	if coverage != 1.0 {
 		t.Errorf("Expected coverage to be 1.0, got %v", coverage)
@@ -240,10 +236,6 @@ func TestCollectCoverageBeforeTestExecution(t *testing.T) {
 		return "", nil
 	}
 
-	// Redirect stdout to tempFile to avoid cluttering output
-	tempFile, _ = os.CreateTemp("", "coverage")
-	defer tempFile.Close()
-
 	mode = "count"
 
 	tc := &testCoverage{
@@ -284,10 +276,6 @@ func TestCollectCoverageAfterTestExecution(t *testing.T) {
 		return fmt.Errorf("mock error")
 	},
 	}
-
-	// Redirect stdout to tempFile to avoid cluttering output
-	tempFile, _ = os.CreateTemp("", "coverage")
-	defer tempFile.Close()
 
 	mode = "count"
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Removes the stdout replacement while extracting the coverage of a test due to a possible race condition with any function writing to stdout at the same time.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

```log
WARNING: DATA RACE
Read at 0x000002334aa8 by goroutine 54:
  fmt.Printf()
      /opt/hostedtoolcache/go/1.23.10/x64/src/fmt/print.go:233 +0x145
  github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting.setUpHTTPServer.func1()
      /home/runner/work/dd-trace-go/dd-trace-go/internal/civisibility/integrations/gotesting/testcontroller_test.go:995 +0xa8
  net/http.HandlerFunc.ServeHTTP()
      /opt/hostedtoolcache/go/1.23.10/x64/src/net/http/server.go:2220 +0x47
  net/http.serverHandler.ServeHTTP()
      /opt/hostedtoolcache/go/1.23.10/x64/src/net/http/server.go:3210 +0x2a1
  net/http.(*conn).serve()
      /opt/hostedtoolcache/go/1.23.10/x64/src/net/http/server.go:2092 +0x12a4
  net/http.(*Server).Serve.gowrap3()
      /opt/hostedtoolcache/go/1.23.10/x64/src/net/http/server.go:3360 +0x4f

Previous write at 0x000002334aa8 by main goroutine:
  github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting/coverage.InitializeCoverage.func1.1()
      /home/runner/work/dd-trace-go/dd-trace-go/internal/civisibility/integrations/gotesting/coverage/test_coverage.go:105 +0x30
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.23.10/x64/src/runtime/panic.go:611 +0x5d
  github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting/coverage.GetCoverage()
      /home/runner/work/dd-trace-go/dd-trace-go/internal/civisibility/integrations/gotesting/coverage/test_coverage.go:160 +0x3b7
  github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting.instrumentTestingM.func2()
      /home/runner/work/dd-trace-go/dd-trace-go/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go:88 +0x69
  github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting.(*M).Run()
      /home/runner/work/dd-trace-go/dd-trace-go/internal/civisibility/integrations/gotesting/testing.go:96 +0xa2
  github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting.RunM()
      /home/runner/work/dd-trace-go/dd-trace-go/internal/civisibility/integrations/gotesting/testing.go:578 +0x485
  github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting.runFlakyTestRetriesTests()
      /home/runner/work/dd-trace-go/dd-trace-go/internal/civisibility/integrations/gotesting/testcontroller_test.go:121 +0x426
  github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting.TestMain()
      /home/runner/work/dd-trace-go/dd-trace-go/internal/civisibility/integrations/gotesting/testcontroller_test.go:47 +0x264
  main.main()
      _testmain.go:87 +0x171
```

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
