### PR TITLE
internal/telemetry: fix deadlock when recorder queue is full

### DIFF
--- a/internal/telemetry/globalclient.go
+++ b/internal/telemetry/globalclient.go
@@ -228,9 +228,7 @@ func globalClientCall(fun func(client Client)) {
 	if client == nil || *client == nil {
 		if !globalClientRecorder.Record(fun) {
 			globalClientLogLossOnce.Do(func() {
-				msg := "telemetry: global client recorder queue is full, dropping telemetry data, please start the telemetry client earlier to avoid data loss"
-				log.Debug("%s\n", msg)
-				Log(LogError, msg, WithStacktrace())
+				log.Debug("telemetry: global client recorder queue is full, dropping telemetry data, please start the telemetry client earlier to avoid data loss")
 			})
 		}
 		return


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR fix a case where, inside the `sync.Once.Do` a call to the same `sync.Once` was done, ending up in a deadload.

### Motivation

Fix tests timeout-ing

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
