### PR TITLE
instrumentation: stop sending telemetry logs for each log a contrib would send to stdout

### DIFF
--- a/instrumentation/logger.go
+++ b/instrumentation/logger.go
@@ -6,7 +6,6 @@
 package instrumentation
 
 import (
-	"fmt"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 )
@@ -38,14 +37,10 @@ func (l logger) Info(msg string, args ...any) {
 
 func (l logger) Warn(msg string, args ...any) {
 	log.Warn(msg, args...)
-	if hasErrors(args...) {
-		telemetry.Log(telemetry.LogError, fmt.Sprintf(msg, args...), l.logOpts...)
-	}
 }
 
 func (l logger) Error(msg string, args ...any) {
 	log.Error(msg, args...)
-	telemetry.Log(telemetry.LogError, fmt.Sprintf(msg, args...), l.logOpts...)
 }
 
 func hasErrors(args ...any) bool {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR stops reporting all contriberrors that would be on stdout to telemetry.

Partial revert of: https://github.com/DataDog/dd-trace-go/pull/3294/files

### Motivation

Some logs can incluse sensitive data. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!