### PR TITLE
appsec: treat 100.64.0.0/10 as internal IPs

### DIFF
--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -19,6 +19,9 @@ const (
 	// NetworkDestinationIP is the remote address where the outbound connection is being made to.
 	NetworkDestinationIP = "network.destination.ip"
 
+	// NetworkClientIP is the client IP address.
+	NetworkClientIP = "network.client.ip"
+
 	// TargetPort sets the target host port.
 	// Legacy: Kept for backwards compatability. Use NetworkDestinationPort instead.
 	TargetPort = "out.port"

--- a/internal/appsec/listener/httpsec/clientip.go
+++ b/internal/appsec/listener/httpsec/clientip.go
@@ -1,0 +1,110 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package httpsec
+
+import (
+	"net"
+	"net/netip"
+	"net/textproto"
+	"strings"
+)
+
+// ClientIP returns the first public IP address found in the given headers. If
+// none is present, it returns the first valid IP address present, possibly
+// being a local IP address. The remote address, when valid, is used as fallback
+// when no IP address has been found at all.
+func ClientIP(hdrs map[string][]string, hasCanonicalHeaders bool, remoteAddr string, monitoredHeaders []string) (remoteIP, clientIP netip.Addr) {
+	// Walk IP-related headers
+	var foundIP netip.Addr
+headersLoop:
+	for _, headerName := range monitoredHeaders {
+		if hasCanonicalHeaders {
+			headerName = textproto.CanonicalMIMEHeaderKey(headerName)
+		}
+
+		headerValues, exists := hdrs[headerName]
+		if !exists {
+			continue // this monitored header is not present
+		}
+
+		// Assuming a list of comma-separated IP addresses, split them and build
+		// the list of values to try to parse as IP addresses
+		var ips []string
+		for _, ip := range headerValues {
+			ips = append(ips, strings.Split(ip, ",")...)
+		}
+
+		// Look for the first valid or global IP address in the comma-separated list
+		for _, ipstr := range ips {
+			ip := parseIP(strings.TrimSpace(ipstr))
+			if !ip.IsValid() {
+				continue
+			}
+			// Replace foundIP if still not valid in order to keep the oldest
+			if !foundIP.IsValid() {
+				foundIP = ip
+			}
+			if isGlobalIP(ip) {
+				foundIP = ip
+				break headersLoop
+			}
+		}
+	}
+
+	// Decide which IP address is the client one by starting with the remote IP
+	if ip := parseIP(remoteAddr); ip.IsValid() {
+		remoteIP = ip
+		clientIP = ip
+	}
+
+	// The IP address found in the headers supersedes a private remote IP address.
+	if foundIP.IsValid() && !isGlobalIP(remoteIP) || isGlobalIP(foundIP) {
+		clientIP = foundIP
+	}
+
+	return remoteIP, clientIP
+}
+
+func parseIP(s string) netip.Addr {
+	if ip, err := netip.ParseAddr(s); err == nil {
+		return ip
+	}
+	if h, _, err := net.SplitHostPort(s); err == nil {
+		if ip, err := netip.ParseAddr(h); err == nil {
+			return ip
+		}
+	}
+	return netip.Addr{}
+}
+
+var (
+	ipv6SpecialNetworks = [...]netip.Prefix{
+		netip.MustParsePrefix("fec0::/10"), // site local
+	}
+
+	// This IP block is not routable on internet and an industry standard/trend
+	// is emerging to use it for traditional IT-managed networking environments
+	// with limited RFC1918 space allocations. This is also frequently used by
+	// kubernetes pods' internal networking. It is hence deemed private for the
+	// purpose of Client IP extraction.
+	k8sInternalIPv4Prefix = netip.MustParsePrefix("100.64.0.0/10")
+)
+
+func isGlobalIP(ip netip.Addr) bool {
+	// IsPrivate also checks for ipv6 ULA.
+	// We care to check for these addresses are not considered public, hence not global.
+	// See https://www.rfc-editor.org/rfc/rfc4193.txt for more details.
+	isGlobal := ip.IsValid() && !ip.IsPrivate() && !ip.IsLoopback() && !ip.IsLinkLocalUnicast() && !k8sInternalIPv4Prefix.Contains(ip)
+	if !isGlobal || !ip.Is6() {
+		return isGlobal
+	}
+	for _, n := range ipv6SpecialNetworks {
+		if n.Contains(ip) {
+			return false
+		}
+	}
+	return isGlobal
+}

--- a/internal/appsec/listener/httpsec/clientip_test.go
+++ b/internal/appsec/listener/httpsec/clientip_test.go
@@ -1,0 +1,393 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package httpsec
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
+	"github.com/stretchr/testify/require"
+)
+
+type ipTestCase struct {
+	name            string
+	remoteAddr      string
+	headers         map[string]string
+	expectedIP      netip.Addr
+	clientIPHeaders []string
+}
+
+func genIPTestCases() []ipTestCase {
+	ipv4Global := randGlobalIPv4().String()
+	ipv6Global := randGlobalIPv6().String()
+	ipv4Private := randPrivateIPv4().String()
+	k8sPrivate := randK8sPrivate().String()
+	ipv6Private := randPrivateIPv6().String()
+
+	tcs := []ipTestCase{
+		{
+			name:       "ipv4-global-remoteaddr",
+			remoteAddr: ipv4Global,
+			expectedIP: netip.MustParseAddr(ipv4Global),
+		},
+		{
+			name:       "ipv4-private-remoteaddr",
+			remoteAddr: ipv4Private,
+			expectedIP: netip.MustParseAddr(ipv4Private),
+		},
+		{
+			name:       "ipv6-global-remoteaddr",
+			remoteAddr: ipv6Global,
+			expectedIP: netip.MustParseAddr(ipv6Global),
+		},
+		{
+			name:       "ipv6-private-remoteaddr",
+			remoteAddr: ipv6Private,
+			expectedIP: netip.MustParseAddr(ipv6Private),
+		},
+	}
+
+	testHeaders := []string{
+		"x-forwarded-for",
+		"x-real-ip",
+		"true-client-ip",
+		"x-client-ip",
+		"x-forwarded",
+		"forwarded-for",
+		"x-cluster-client-ip",
+		"fastly-client-ip",
+		"cf-connecting-ip",
+		"cf-connecting-ip6",
+	}
+
+	// Simple ipv4 test cases over all headers
+	for _, header := range testHeaders {
+		tcs = append(tcs,
+			ipTestCase{
+				name:            "ipv4-global." + header,
+				remoteAddr:      ipv4Private,
+				headers:         map[string]string{header: ipv4Global},
+				expectedIP:      netip.MustParseAddr(ipv4Global),
+				clientIPHeaders: testHeaders,
+			},
+			ipTestCase{
+				name:            "ipv4-private." + header,
+				headers:         map[string]string{header: ipv4Private},
+				remoteAddr:      ipv6Private,
+				expectedIP:      netip.MustParseAddr(ipv4Private),
+				clientIPHeaders: testHeaders,
+			},
+			ipTestCase{
+				name:            "ipv4-global-remoteaddr-local-ip-header." + header,
+				remoteAddr:      ipv4Global,
+				headers:         map[string]string{header: ipv4Private},
+				expectedIP:      netip.MustParseAddr(ipv4Global),
+				clientIPHeaders: testHeaders,
+			},
+			ipTestCase{
+				name:            "ipv4-global-remoteaddr-global-ip-header." + header,
+				remoteAddr:      ipv6Global,
+				headers:         map[string]string{header: ipv4Global},
+				expectedIP:      netip.MustParseAddr(ipv4Global),
+				clientIPHeaders: testHeaders,
+			})
+	}
+
+	// Simple ipv6 test cases over all headers
+	for _, header := range testHeaders {
+		tcs = append(tcs, ipTestCase{
+			name:            "ipv6-global." + header,
+			remoteAddr:      ipv4Private,
+			headers:         map[string]string{header: ipv6Global},
+			expectedIP:      netip.MustParseAddr(ipv6Global),
+			clientIPHeaders: testHeaders,
+		},
+			ipTestCase{
+				name:            "ipv6-private." + header,
+				headers:         map[string]string{header: ipv6Private},
+				remoteAddr:      ipv4Private,
+				expectedIP:      netip.MustParseAddr(ipv6Private),
+				clientIPHeaders: testHeaders,
+			},
+			ipTestCase{
+				name:            "ipv6-global-remoteaddr-local-ip-header." + header,
+				remoteAddr:      ipv6Global,
+				headers:         map[string]string{header: ipv6Private},
+				expectedIP:      netip.MustParseAddr(ipv6Global),
+				clientIPHeaders: testHeaders,
+			},
+			ipTestCase{
+				name:            "ipv6-global-remoteaddr-global-ip-header." + header,
+				remoteAddr:      ipv4Global,
+				headers:         map[string]string{header: ipv6Global},
+				expectedIP:      netip.MustParseAddr(ipv6Global),
+				clientIPHeaders: testHeaders,
+			})
+	}
+
+	// private and global in same header
+	tcs = append([]ipTestCase{
+		{
+			name:       "ipv4-private+global",
+			headers:    map[string]string{"x-forwarded-for": ipv4Private + "," + ipv4Global},
+			expectedIP: netip.MustParseAddr(ipv4Global),
+		},
+		{
+			name:       "ipv4-global+private",
+			headers:    map[string]string{"x-forwarded-for": ipv4Global + "," + ipv4Private},
+			expectedIP: netip.MustParseAddr(ipv4Global),
+		},
+		{
+			name:       "ipv6-private+global",
+			headers:    map[string]string{"x-forwarded-for": ipv6Private + "," + ipv6Global},
+			expectedIP: netip.MustParseAddr(ipv6Global),
+		},
+		{
+			name:       "ipv6-global+private",
+			headers:    map[string]string{"x-forwarded-for": ipv6Global + "," + ipv6Private},
+			expectedIP: netip.MustParseAddr(ipv6Global),
+		},
+		{
+			name:       "mixed-global+global",
+			headers:    map[string]string{"x-forwarded-for": ipv4Private + "," + ipv6Global + "," + ipv4Global},
+			expectedIP: netip.MustParseAddr(ipv6Global),
+		},
+		{
+			name:       "mixed-global+global",
+			headers:    map[string]string{"x-forwarded-for": ipv4Private + "," + ipv4Global + "," + ipv6Global},
+			expectedIP: netip.MustParseAddr(ipv4Global),
+		},
+		{
+			name:       "k8s-private+global",
+			headers:    map[string]string{"x-forwarded-for": k8sPrivate + "," + ipv4Global},
+			expectedIP: netip.MustParseAddr(ipv4Global),
+		},
+	}, tcs...)
+
+	// Invalid IPs (or a mix of valid/invalid over a single or multiple headers)
+	tcs = append([]ipTestCase{
+		{
+			name:       "no headers",
+			headers:    nil,
+			expectedIP: netip.Addr{},
+		},
+		{
+			name:       "invalid-ipv4",
+			headers:    map[string]string{"x-forwarded-for": "127..0.0.1"},
+			expectedIP: netip.Addr{},
+		},
+		{
+			name:       "invalid-ipv4-header-valid-remoteaddr",
+			headers:    map[string]string{"x-forwarded-for": "127..0.0.1"},
+			remoteAddr: ipv4Private,
+			expectedIP: netip.MustParseAddr(ipv4Private),
+		},
+		{
+			name:       "invalid-ipv4-recover",
+			headers:    map[string]string{"x-forwarded-for": "127..0.0.1, " + ipv6Private + "," + ipv4Global},
+			expectedIP: netip.MustParseAddr(ipv4Global),
+		},
+		{
+			name:            "ip-multi-header-order-0",
+			headers:         map[string]string{"x-forwarded-for": ipv4Global, "forwarded-for": ipv6Global},
+			clientIPHeaders: []string{"x-forwarded-for", "forwarded-for"},
+			expectedIP:      netip.MustParseAddr(ipv4Global),
+		},
+		{
+			name:            "ip-multi-header-order-1",
+			headers:         map[string]string{"x-forwarded-for": ipv4Global, "forwarded-for": ipv6Global},
+			clientIPHeaders: []string{"forwarded-for", "x-forwarded-for"},
+			expectedIP:      netip.MustParseAddr(ipv6Global),
+		},
+		{
+			name:            "ipv4-multi-header-0",
+			headers:         map[string]string{"x-forwarded-for": ipv4Private, "forwarded-for": ipv4Global},
+			clientIPHeaders: []string{"x-forwarded-for", "forwarded-for"},
+			expectedIP:      netip.MustParseAddr(ipv4Global),
+		},
+		{
+			name:            "ipv4-multi-header-1",
+			headers:         map[string]string{"x-forwarded-for": ipv4Global, "forwarded-for": ipv4Private},
+			clientIPHeaders: []string{"x-forwarded-for", "forwarded-for"},
+			expectedIP:      netip.MustParseAddr(ipv4Global),
+		},
+		{
+			name:            "ipv4-multi-header-2",
+			headers:         map[string]string{"x-forwarded-for": "127.0.0.1, " + ipv4Private, "forwarded-for": fmt.Sprintf("%s, %s", ipv4Private, ipv4Global)},
+			clientIPHeaders: []string{"x-forwarded-for", "forwarded-for"},
+			expectedIP:      netip.MustParseAddr(ipv4Global),
+		},
+		{
+			name:            "ipv4-multi-header-3",
+			headers:         map[string]string{"x-forwarded-for": "127.0.0.1, " + ipv4Global, "forwarded-for": ipv4Private},
+			clientIPHeaders: []string{"x-forwarded-for", "forwarded-for"},
+			expectedIP:      netip.MustParseAddr(ipv4Global),
+		},
+		{
+			name:       "invalid-ipv6",
+			headers:    map[string]string{"x-forwarded-for": "2001:0db8:2001:zzzz::"},
+			expectedIP: netip.Addr{},
+		},
+		{
+			name:       "invalid-ipv6-recover",
+			headers:    map[string]string{"x-forwarded-for": "2001:0db8:2001:zzzz::, " + ipv6Global},
+			expectedIP: netip.MustParseAddr(ipv6Global),
+		},
+		{
+			name:            "ipv6-multi-header-0",
+			headers:         map[string]string{"x-forwarded-for": ipv6Private, "forwarded-for": ipv6Global},
+			clientIPHeaders: []string{"x-forwarded-for", "forwarded-for"},
+			expectedIP:      netip.MustParseAddr(ipv6Global),
+		},
+		{
+			name:            "ipv6-multi-header-1",
+			headers:         map[string]string{"x-forwarded-for": ipv6Global, "forwarded-for": ipv6Private},
+			clientIPHeaders: []string{"x-forwarded-for", "forwarded-for"},
+			expectedIP:      netip.MustParseAddr(ipv6Global),
+		},
+		{
+			name:            "ipv6-multi-header-2",
+			headers:         map[string]string{"x-forwarded-for": "127.0.0.1, " + ipv6Private, "forwarded-for": fmt.Sprintf("%s, %s", ipv6Private, ipv6Global)},
+			clientIPHeaders: []string{"x-forwarded-for", "forwarded-for"},
+			expectedIP:      netip.MustParseAddr(ipv6Global),
+		},
+		{
+			name:            "ipv6-multi-header-3",
+			headers:         map[string]string{"x-forwarded-for": "127.0.0.1, " + ipv6Global, "forwarded-for": ipv6Private},
+			clientIPHeaders: []string{"x-forwarded-for", "forwarded-for"},
+			expectedIP:      netip.MustParseAddr(ipv6Global),
+		},
+		{
+			name:       "no-headers",
+			expectedIP: netip.Addr{},
+		},
+		{
+			name:       "header-case",
+			headers:    map[string]string{"X-fOrWaRdEd-FoR": ipv4Global},
+			expectedIP: netip.MustParseAddr(ipv4Global),
+		},
+		{
+			name:            "user-header",
+			headers:         map[string]string{"x-forwarded-for": ipv6Global, "custom-header": ipv4Global},
+			clientIPHeaders: []string{"custom-header"},
+			expectedIP:      netip.MustParseAddr(ipv4Global),
+		},
+		{
+			name:            "user-header-not-found",
+			headers:         map[string]string{"x-forwarded-for": ipv4Global},
+			clientIPHeaders: []string{"custom-header"},
+			expectedIP:      netip.Addr{},
+		},
+	}, tcs...)
+
+	return tcs
+}
+
+func TestClientIPExtraction(t *testing.T) {
+	for _, hasCanonicalMIMEHeaderKeys := range []bool{true, false} {
+		t.Run(fmt.Sprintf("canonical-headers-%t", hasCanonicalMIMEHeaderKeys), func(t *testing.T) {
+			for _, tc := range genIPTestCases() {
+				t.Run(tc.name, func(t *testing.T) {
+					headers := http.Header{}
+					for k, v := range tc.headers {
+						if hasCanonicalMIMEHeaderKeys {
+							headers.Add(k, v)
+						} else {
+							k = strings.ToLower(k)
+							headers[k] = append(headers[k], v)
+						}
+					}
+
+					// Default list to use - the tests rely on x-forwarded-for only when using this default list
+					monitoredHeaders := []string{"x-client-ip", "x-forwarded-for", "true-client-ip"}
+					if tc.clientIPHeaders != nil {
+						monitoredHeaders = tc.clientIPHeaders
+					}
+					remoteIP, clientIP := ClientIP(headers, hasCanonicalMIMEHeaderKeys, tc.remoteAddr, monitoredHeaders)
+					tags := ClientIPTagsFor(remoteIP, clientIP)
+					if tc.expectedIP.IsValid() {
+						expectedIP := tc.expectedIP.String()
+						require.Equal(t, expectedIP, clientIP.String())
+						if tc.remoteAddr != "" {
+							require.Equal(t, tc.remoteAddr, remoteIP.String())
+							require.Equal(t, tc.remoteAddr, tags[ext.NetworkClientIP])
+						} else {
+							require.NotContains(t, tags, ext.NetworkClientIP)
+						}
+						require.Equal(t, expectedIP, tags[ext.HTTPClientIP])
+					} else {
+						require.NotContains(t, tags, ext.HTTPClientIP)
+						require.False(t, clientIP.IsValid())
+					}
+				})
+			}
+		})
+	}
+}
+
+func randIPv4() netip.Addr {
+	return netip.AddrFrom4([4]byte{byte(rand.Uint32()), byte(rand.Uint32()), byte(rand.Uint32()), byte(rand.Uint32())})
+}
+
+func randIPv6() netip.Addr {
+	return netip.AddrFrom16([16]byte{
+		uint8(rand.Uint32()), uint8(rand.Uint32()), uint8(rand.Uint32()), uint8(rand.Uint32()),
+		uint8(rand.Uint32()), uint8(rand.Uint32()), uint8(rand.Uint32()), uint8(rand.Uint32()),
+		uint8(rand.Uint32()), uint8(rand.Uint32()), uint8(rand.Uint32()), uint8(rand.Uint32()),
+		uint8(rand.Uint32()), uint8(rand.Uint32()), uint8(rand.Uint32()), uint8(rand.Uint32()),
+	})
+}
+
+func randGlobalIPv4() netip.Addr {
+	for {
+		ip := randIPv4()
+		if isGlobalIP(ip) {
+			return ip
+		}
+	}
+}
+
+func randGlobalIPv6() netip.Addr {
+	for {
+		ip := randIPv6()
+		if isGlobalIP(ip) {
+			return ip
+		}
+	}
+}
+
+func randPrivateIPv4() netip.Addr {
+	for {
+		ip := randIPv4()
+		if !isGlobalIP(ip) && ip.IsPrivate() {
+			return ip
+		}
+	}
+}
+
+func randK8sPrivate() netip.Addr {
+	for {
+		// IPs in 100.64.0.0/10 (100.64.0.0 - 100.127.255.255) are considered private
+		ip := netip.AddrFrom4([4]byte{100, 64 + byte(rand.Uint32()%63), byte(rand.Uint32()), byte(rand.Uint32())})
+		if k8sInternalIPv4Prefix.Contains(ip) {
+			return ip
+		}
+	}
+}
+
+func randPrivateIPv6() netip.Addr {
+	for {
+		ip := randIPv6()
+		if !isGlobalIP(ip) && ip.IsPrivate() {
+			return ip
+		}
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Makes AAP treat IPs in the block 100.64.0.0/10 as internal IPs as this is de-facto the case in an growing majority of services out in the wild (and this block is not internet-routable anyway).

Also moves related functionality from `appsec-internal-go` directly in the tracer following our decision to deprecate/retire this package altogether.

### Motivation

Improves the client IP detection heuristic used by AAP features.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
