### PR TITLE
contrib/database/sql: sanitize sensitive data in error messages

### DIFF
--- a/contrib/database/sql/internal/dsn.go
+++ b/contrib/database/sql/internal/dsn.go
@@ -6,8 +6,11 @@
 package internal
 
 import (
+	"errors"
+	"fmt"
 	"net"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
@@ -27,24 +30,24 @@ func ParseDSN(driverName, dsn string) (meta map[string]string, err error) {
 	case "mysql":
 		meta, err = parseMySQLDSN(dsn)
 		if err != nil {
-			instr.Logger().Debug("Error parsing DSN for mysql: %v", err)
+			instr.Logger().Debug("Error parsing DSN for mysql: %v", sanitizeError(err))
 			return
 		}
 	case "postgres", "pgx":
 		meta, err = parsePostgresDSN(dsn)
 		if err != nil {
-			instr.Logger().Debug("Error parsing DSN for postgres: %v", err)
+			instr.Logger().Debug("Error parsing DSN for postgres: %v", sanitizeError(err))
 			return
 		}
 	case "sqlserver":
 		meta, err = parseSQLServerDSN(dsn)
 		if err != nil {
-			instr.Logger().Debug("Error parsing DSN for sqlserver: %v", err)
+			instr.Logger().Debug("Error parsing DSN for sqlserver: %v", sanitizeError(err))
 			return
 		}
 	default:
 		// Try to parse the DSN and see if the scheme contains a known driver name.
-		u, e := url.Parse(dsn)
+		u, e := parseSafe(dsn)
 		if e != nil {
 			// dsn is not a valid URL, so just ignore
 			instr.Logger().Debug("Error parsing driver name from DSN: %v", e)
@@ -82,19 +85,19 @@ func reduceKeys(meta map[string]string) map[string]string {
 }
 
 // parseMySQLDSN parses a mysql-type dsn into a map.
-func parseMySQLDSN(dsn string) (m map[string]string, err error) {
-	var cfg *mySQLConfig
-	if cfg, err = mySQLConfigFromDSN(dsn); err == nil {
-		host, port, _ := net.SplitHostPort(cfg.Addr)
-		m = map[string]string{
-			"user":   cfg.User,
-			"host":   host,
-			"port":   port,
-			"dbname": cfg.DBName,
-		}
-		return m, nil
+func parseMySQLDSN(dsn string) (map[string]string, error) {
+	cfg, err := mySQLConfigFromDSN(dsn)
+	if err != nil {
+		return nil, err
 	}
-	return nil, err
+	host, port, _ := net.SplitHostPort(cfg.Addr)
+	meta := map[string]string{
+		"user":   cfg.User,
+		"host":   host,
+		"port":   port,
+		"dbname": cfg.DBName,
+	}
+	return meta, nil
 }
 
 // parsePostgresDSN parses a postgres-type dsn into a map.
@@ -134,4 +137,166 @@ func parseSQLServerDSN(dsn string) (map[string]string, error) {
 	}
 	delete(meta, "password")
 	return meta, nil
+}
+
+// parseSafe behaves like url.Parse, but if parsing fails it returns an
+// error with any credential part of the URL already scrubbed.
+func parseSafe(raw string) (*url.URL, error) {
+	u, err := url.Parse(raw)
+	if err == nil {
+		return u, nil
+	}
+	// url.Parse always wraps the real problem in *url.Error.
+	var ue *url.Error
+	if !errors.As(err, &ue) {
+		return nil, err
+	}
+	return nil, sanitizeURLError(ue)
+}
+
+// sanitizeURLError returns a copy of e whose URL field is redacted.
+func sanitizeURLError(e *url.Error) *url.Error {
+	// Best-case: we can still parse enough to use URL.Redacted().
+	if parsed, perr := url.Parse(e.URL); perr == nil {
+		e.URL = parsed.Redacted()
+		return e
+	}
+
+	// Fallback: use the comprehensive sanitize() function for all password patterns.
+	e.URL = sanitize(e.URL)
+	return e
+}
+
+// sanitizeError returns an error with sensitive information redacted.
+// It handles both URL errors and general errors containing DSN information.
+func sanitizeError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// Check if it's a URL error and use the existing sanitizer.
+	var ue *url.Error
+	if errors.As(err, &ue) {
+		return sanitizeURLError(ue)
+	}
+
+	// For other errors, sanitize the error message.
+	return fmt.Errorf("%s", sanitize(err.Error()))
+}
+
+func sanitize(msg string) string {
+	msg = sanitizeKeyValuePasswords(msg)
+	msg = sanitizeURLPasswords(msg)
+	msg = sanitizeMySQLPasswords(msg)
+	return msg
+}
+
+// Compiled regex patterns for password sanitization - compiled once at package init
+var (
+	keyValueSpacePattern = regexp.MustCompile(`(?i)(password|passwd|pwd)\s*=\s*(.+?)(\s+(?:host|user|port|database|dbname)\s*=)`)
+	keyValueSemiPattern  = regexp.MustCompile(`(?i)(password|passwd|pwd)\s*=\s*([^;]+)(;)`)
+	keyValuePattern      = regexp.MustCompile(`(?i)(password|passwd|pwd)\s*=\s*([^\s;]+)`)
+)
+
+// sanitizeKeyValuePasswords sanitizes password values in key=value format
+func sanitizeKeyValuePasswords(msg string) string {
+	result := keyValueSpacePattern.ReplaceAllString(msg, `$1=xxxxx$3`)
+	result = keyValueSemiPattern.ReplaceAllString(result, `$1=xxxxx$3`)
+	result = keyValuePattern.ReplaceAllString(result, `$1=xxxxx`)
+	return result
+}
+
+// sanitizeURLPasswords sanitizes passwords in URL format (user:pass@host).
+func sanitizeURLPasswords(msg string) string {
+	// Look for URL patterns and manually handle them to avoid issues with @ in passwords.
+	urlStart := strings.Index(msg, "://")
+	if urlStart == -1 {
+		return msg
+	}
+
+	// Find the start of the credentials section
+	credStart := urlStart + 3
+
+	// Look for the rightmost @ that separates credentials from host
+	hostStart := -1
+	for i := len(msg) - 1; i >= credStart; i-- {
+		if msg[i] == '@' {
+			// Check if this @ is followed by what looks like a hostname
+			remaining := msg[i+1:]
+			if hostIdx := strings.IndexAny(remaining, " /\"?"); hostIdx != -1 {
+				remaining = remaining[:hostIdx]
+			}
+			// Simple hostname validation: starts with alphanumeric, contains valid hostname chars
+			if len(remaining) > 0 && isValidHostnameStart(remaining) {
+				hostStart = i
+				break
+			}
+		}
+	}
+
+	if hostStart == -1 {
+		return msg
+	}
+
+	// Find the colon that separates username from password
+	credSection := msg[credStart:hostStart]
+	colonIdx := strings.Index(credSection, ":")
+	if colonIdx == -1 {
+		return msg
+	}
+
+	// Replace the password
+	absoluteColonIdx := credStart + colonIdx
+	result := msg[:absoluteColonIdx+1] + "xxxxx" + msg[hostStart:]
+	return result
+}
+
+// isValidHostnameStart checks if a string starts like a valid hostname
+func isValidHostnameStart(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	// Must start with alphanumeric
+	first := s[0]
+	if !((first >= 'a' && first <= 'z') || (first >= 'A' && first <= 'Z') || (first >= '0' && first <= '9')) {
+		return false
+	}
+	// Should contain hostname-like patterns
+	return strings.Contains(s, ".") || strings.Contains(s, ":") || 
+		   strings.Contains(s, "/") || s == strings.TrimSpace(s)
+}
+
+// sanitizeMySQLPasswords sanitizes passwords in MySQL DSN format (user:pass@tcp...).
+func sanitizeMySQLPasswords(msg string) string {
+	// Find @tcp( and work backwards to find the username:password pattern.
+	tcpIndex := strings.Index(msg, "@tcp(")
+	if tcpIndex == -1 {
+		return msg
+	}
+
+	// Work backwards from @tcp( to find the start of username:password.
+	start := tcpIndex - 1
+	for start >= 0 && msg[start] != ' ' && msg[start] != '\t' && msg[start] != ':' {
+		start--
+	}
+
+	// If we stopped at a colon, we need to find the username before it.
+	if start >= 0 && msg[start] == ':' {
+		// Continue backwards to find the start of the username.
+		userStart := start - 1
+		for userStart >= 0 && (msg[userStart] >= 'a' && msg[userStart] <= 'z' ||
+			msg[userStart] >= 'A' && msg[userStart] <= 'Z' ||
+			msg[userStart] >= '0' && msg[userStart] <= '9' ||
+			msg[userStart] == '_') {
+			userStart--
+		}
+		userStart++ // Move to the first character of the username.
+
+		// Replace the password part.
+		username := msg[userStart:start]
+		result := msg[:userStart] + username + ":xxxxx@tcp(" + msg[tcpIndex+5:]
+		return result
+	}
+
+	return msg
 }

--- a/contrib/database/sql/internal/dsn_test.go
+++ b/contrib/database/sql/internal/dsn_test.go
@@ -6,6 +6,8 @@
 package internal
 
 import (
+	"errors"
+	"net/url"
 	"testing"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
@@ -175,6 +177,259 @@ func TestParseSqlServerDSN(t *testing.T) {
 			m, err := parseSQLServerDSN(tt.dsn)
 			assert.Equal(t, nil, err)
 			assert.Equal(t, tt.expected, m)
+		})
+	}
+}
+
+func TestSanitizeError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		// Nil error handling
+		{
+			name:     "nil_error",
+			err:      nil,
+			expected: "",
+		},
+
+		// URL error type detection
+		{
+			name:     "url_error_with_password",
+			err:      &url.Error{Op: "parse", URL: "postgres://user:secret123@localhost:5432/db", Err: errors.New("invalid port")},
+			expected: `parse "postgres://user:xxxxx@localhost:5432/db": invalid port`,
+		},
+
+		// General error sanitization (non-URL errors)
+		{
+			name:     "mysql_dsn_error_with_password",
+			err:      errors.New("invalid DSN: user:secretpass@tcp(localhost:3306)/database"),
+			expected: "invalid DSN: user:xxxxx@tcp(localhost:3306)/database",
+		},
+		{
+			name:     "key_value_password",
+			err:      errors.New("pq: password authentication failed with password=MySecretPass123 host=localhost"),
+			expected: "pq: password authentication failed with password=xxxxx host=localhost",
+		},
+		{
+			name:     "mixed_format_error",
+			err:      errors.New("tried postgres://user:pass123@host/db and password=pass456 but failed"),
+			expected: "tried postgres://user:xxxxx@host/db and password=xxxxx but failed",
+		},
+
+		// Errors without sensitive data (should remain unchanged)
+		{
+			name:     "no_sensitive_data",
+			err:      errors.New("connection timeout: unable to reach server at localhost:5432"),
+			expected: "connection timeout: unable to reach server at localhost:5432",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeError(tt.err)
+			if tt.err == nil {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+				assert.Equal(t, tt.expected, result.Error())
+			}
+		})
+	}
+}
+
+func TestParseDSNErrorHandling(t *testing.T) {
+	testCases := []struct {
+		name       string
+		driverName string
+		dsn        string
+	}{
+		{
+			name:       "invalid_mysql_dsn",
+			driverName: "mysql",
+			dsn:        "user:pass@invalid@tcp(host:port)/db",
+		},
+		{
+			name:       "unknown_driver_with_valid_url",
+			driverName: "unknown",
+			dsn:        "postgres://user:pass@host:5432/db",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				ParseDSN(tc.driverName, tc.dsn)
+			})
+		})
+	}
+}
+
+func TestParseSafe(t *testing.T) {
+	tests := []struct {
+		name        string
+		rawURL      string
+		expectError bool
+		expectURL   bool
+		expectedErr string
+	}{
+		// Successful parsing cases
+		{
+			name:        "valid_url_with_credentials",
+			rawURL:      "postgres://user:pass@localhost:5432/db",
+			expectError: false,
+			expectURL:   true,
+		},
+
+		// Error sanitization test
+		{
+			name:        "invalid_port_with_credentials",
+			rawURL:      "postgres://user:secret123@localhost:invalid_port/db",
+			expectError: true,
+			expectURL:   false,
+			expectedErr: `parse "postgres://user:xxxxx@localhost:invalid_port/db": invalid port ":invalid_port" after host`,
+		},
+
+		// Non-credential error (should remain unchanged)
+		{
+			name:        "invalid_port_no_credentials",
+			rawURL:      "postgres://localhost:invalid_port/db",
+			expectError: true,
+			expectURL:   false,
+			expectedErr: `parse "postgres://localhost:invalid_port/db": invalid port ":invalid_port" after host`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseSafe(tt.rawURL)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+				if tt.expectedErr != "" {
+					assert.Equal(t, tt.expectedErr, err.Error())
+				}
+			} else {
+				assert.NoError(t, err)
+				if tt.expectURL {
+					assert.NotNil(t, result)
+				}
+			}
+		})
+	}
+}
+
+// Test individual sanitization functions directly
+func TestSanitizeKeyValuePasswords(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "space_separated_password",
+			input:    "password=secret123 host=localhost",
+			expected: "password=xxxxx host=localhost",
+		},
+		{
+			name:     "semicolon_separated_password",
+			input:    "Server=host;Password=secret;Database=db;",
+			expected: "Server=host;Password=xxxxx;Database=db;",
+		},
+		{
+			name:     "case_insensitive",
+			input:    "PASSWORD=secret PWD=secret2",
+			expected: "PASSWORD=xxxxx PWD=xxxxx",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeKeyValuePasswords(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSanitizeURLPasswords(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple_url_password",
+			input:    "postgres://user:secret@localhost:5432/db",
+			expected: "postgres://user:xxxxx@localhost:5432/db",
+		},
+		{
+			name:     "complex_password_with_special_chars",
+			input:    "mysql://admin:p@$$w0rd@host.com/database",
+			expected: "mysql://admin:xxxxx@host.com/database",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeURLPasswords(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSanitizeMySQLPasswords(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "mysql_dsn_format",
+			input:    "Error connecting: user:password@tcp(localhost:3306)/db",
+			expected: "Error connecting: user:xxxxx@tcp(localhost:3306)/db",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeMySQLPasswords(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSanitizeURLError(t *testing.T) {
+	tests := []struct {
+		name     string
+		urlError *url.Error
+		expected string
+	}{
+		{
+			name: "parseable_url_with_password",
+			urlError: &url.Error{
+				Op:  "parse",
+				URL: "postgres://user:secret@localhost:5432/db",
+				Err: errors.New("test error"),
+			},
+			expected: `parse "postgres://user:xxxxx@localhost:5432/db": test error`,
+		},
+		{
+			name: "unparseable_url_fallback",
+			urlError: &url.Error{
+				Op:  "parse",
+				URL: "postgres://user:pass@host with spaces/db",
+				Err: errors.New("invalid character in host name"),
+			},
+			expected: `parse "postgres://user:xxxxx@host with spaces/db": invalid character in host name`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeURLError(tt.urlError)
+			assert.Equal(t, tt.expected, result.Error())
 		})
 	}
 }


### PR DESCRIPTION
## Summary
This PR enhances error handling in the database/sql contrib package by ensuring that sensitive information in database connection strings is properly sanitized before being logged or included in error messages.

## Changes
- Added comprehensive sanitization functions for various DSN formats (MySQL, PostgreSQL, SQL Server)
- Enhanced error logging to prevent credential exposure in application logs
- Implemented robust pattern matching for different connection string formats
- Added test coverage for edge cases and different DSN patterns

## Security Enhancement
This change proactively ensures that database credentials and other sensitive connection details are never exposed in error messages or debug logs, following security best practices for credential handling.

## Test Coverage
- New test cases covering various DSN formats and edge cases
- Verification of sanitization effectiveness across different database drivers