### PR TITLE
Fix typo in FAQ.md

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -4,7 +4,7 @@ This document contains answers to questions frequently asked by users. Just beca
 #### Why do client integration spans not use the global service name?
 Integrations that are considered *clients* (http clients, grpc clients, sql clients) do **not** use the globally-configured service name. This is by design and is a product-level decision that spans across all the languages' tracers. This is likely to segregate the time spent actually doing the work of the service from the time waiting for another service (i.e. waiting on a web server to return a response).
 
-While there are good arguments to be made that client integrations should take the same service name as everything else in the service, that's not how the library is intended to function today. As a work-around, most integrations have a `WithService` `Option` that will allow you to override the default. If the integration you are using cannot be configured the way you want, please open an issue to discuss adding as option.
+While there are good arguments to be made that client integrations should take the same service name as everything else in the service, that's not how the library is intended to function today. As a work-around, most integrations have a `WithService` `Option` that will allow you to override the default. If the integration you are using cannot be configured the way you want, please open an issue to discuss adding an option.
 
 See also: https://github.com/DataDog/dd-trace-go/pull/603
 


### PR DESCRIPTION
(note: this is just me testing some coding agent stuff)

<!-- dd-meta {"pullId":"bedcb029-52b2-4393-abd4-0c782209fff6","source":"chat","resourceId":"2ea835bc-0138-448b-bff5-38b4944c0f82","workflowId":"59c270d1-d1c9-46e4-8d03-63be168dc263","codeChangeId":"59c270d1-d1c9-46e4-8d03-63be168dc263","sourceType":""} -->
PR by [Bits](https://app.datadoghq.com/code?session_id=bedcb029-52b2-4393-abd4-0c782209fff6) for chat [2ea835bc-0138-448b-bff5-38b4944c0f82](https://app.datadoghq.com/code/2ea835bc-0138-448b-bff5-38b4944c0f82).

You can ask for changes by mentioning @Datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do?

Fixes a grammatical error in FAQ.md by adding the missing article "an" before "option" in the sentence "please open an issue to discuss adding an option."

### Motivation

Found and corrected a typo in the documentation to improve readability and grammatical correctness.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!