### PR TITLE
profiler: skip flaky TestDebugCompressionEnv test

### DIFF
--- a/profiler/compression_test.go
+++ b/profiler/compression_test.go
@@ -74,6 +74,7 @@ func checkZstdLevel(t *testing.T, data []byte, level zstd.EncoderLevel) {
 }
 
 func TestDebugCompressionEnv(t *testing.T) {
+	t.Skip("Flaky. See #3681")
 	mustGzipDecompress := func(t *testing.T, b []byte) {
 		t.Helper()
 		r, err := gzip.NewReader(bytes.NewReader(b))


### PR DESCRIPTION
### What does this PR do?

The flakes we've seen are errors of the form

	profiler_test.go:363: bad multipart form: unexpected EOF

I don't think this error case is necesarily specific to this test (maybe
there's a "race" between stopping the test profiler and mock backend
server) but this test is where we're seeing it. Skip it for now to keep
CI green while we root-cause the failures.

Updates #3681

### Motivation

Flaky tests undermine our confidence in our CI
