### PR TITLE
[v1] fix(tracer): Baggage extraction

### DIFF
--- a/contrib/internal/httptrace/httptrace_test.go
+++ b/contrib/internal/httptrace/httptrace_test.go
@@ -380,8 +380,9 @@ func TestStartRequestSpanWithBaggage(t *testing.T) {
 
 	r := httptest.NewRequest(http.MethodGet, "/somePath", nil)
 	r.Header.Set("baggage", "key1=value1,key2=value2")
-	s, _, _ := StartRequestSpan(r)
+	s, ctx, _ := StartRequestSpan(r)
 	s.Finish()
+	// TODO: This behavior is not ideal. We want baggage headers accessible with r.Context (baggage.All(r.Context())) -- not the generated span's context.
 	spanBm := make(map[string]string)
 	s.Context().ForeachBaggageItem(func(k, v string) bool {
 		spanBm[k] = v
@@ -389,6 +390,9 @@ func TestStartRequestSpanWithBaggage(t *testing.T) {
 	})
 	assert.Equal(t, "value1", spanBm["key1"])
 	assert.Equal(t, "value2", spanBm["key2"])
+	baggageMap := baggage.All(ctx)
+	assert.Equal(t, "value1", baggageMap["key1"], "should propagate baggage from header to context")
+	assert.Equal(t, "value2", baggageMap["key2"], "should propagate baggage from header to context")
 }
 
 func TestStartRequestSpanMergedBaggage(t *testing.T) {
@@ -416,4 +420,30 @@ func TestStartRequestSpanMergedBaggage(t *testing.T) {
 	assert.Equal(t, "pre_value", mergedBaggage["pre_key"], "should contain pre-set baggage")
 	assert.Equal(t, "header_value", mergedBaggage["header_key"], "should contain header baggage")
 	assert.Equal(t, "another_value", mergedBaggage["another_header"], "should contain header baggage")
+}
+
+// TestStartRequestSpanOnlyBaggageCreatesNewTrace verifies that when only baggage headers are present
+// (no trace/span IDs), a new trace is created with a non-zero trace ID while still preserving the baggage.
+func TestStartRequestSpanOnlyBaggageCreatesNewTrace(t *testing.T) {
+	tracer.Start()
+	defer tracer.Stop()
+
+	// Create a request with only baggage header, no trace context
+	req := httptest.NewRequest(http.MethodGet, "/somePath", nil).WithContext(context.Background())
+	req.Header.Set("baggage", "foo=bar")
+
+	span, ctx, _ := StartRequestSpan(req)
+	span.Finish()
+
+	// Verify that a new trace was created with a non-zero trace ID
+	sc := span.Context()
+	assert.NotZero(
+		t,
+		sc.TraceID(),
+		"expected a new non‐zero TraceID when only baggage header is present",
+	)
+
+	// Verify that baggage is still propagated despite the new trace
+	baggageMap := baggage.All(ctx)
+	assert.Equal(t, "bar", baggageMap["foo"], "should propagate baggage even when it's the only header")
 }

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -2808,3 +2808,59 @@ func TestInjectBaggageMaxBytes(t *testing.T) {
 	headerSize := len([]byte(headerValue))
 	assert.LessOrEqual(headerSize, baggageMaxBytes)
 }
+
+func TestExtractOnlyBaggage(t *testing.T) {
+	t.Setenv("DD_TRACE_PROPAGATION_STYLE", "baggage")
+	headers := TextMapCarrier(map[string]string{
+		"baggage": "foo=bar,baz=qux",
+	})
+
+	tracer := newTracer()
+	defer tracer.Stop()
+
+	ctx, err := tracer.Extract(headers)
+	assert.Nil(t, err)
+
+	got := make(map[string]string)
+	ctx.ForeachBaggageItem(func(k, v string) bool {
+		got[k] = v
+		return true
+	})
+	assert.Len(t, got, 2)
+	assert.Equal(t, "bar", got["foo"])
+	assert.Equal(t, "qux", got["baz"])
+}
+
+// TestExtractBaggageFirstThenDatadog verifies that when both baggage and trace headers are present,
+// the trace context (trace ID, parent ID, etc.) is extracted from trace headers, and the baggage items are properly inherited,
+// specifically when baggage has a higher precedence than trace headers in the propagation style.
+func TestExtractBaggageFirstThenDatadog(t *testing.T) {
+	t.Setenv("DD_TRACE_PROPAGATION_STYLE", "baggage,datadog")
+
+	// Set up headers with both baggage and Datadog trace context
+	headers := TextMapCarrier(map[string]string{
+		"baggage":             "item=xyz",
+		DefaultTraceIDHeader:  "12345",
+		DefaultParentIDHeader: "67890",
+		DefaultPriorityHeader: "1",
+	})
+
+	tracer := newTracer()
+	defer tracer.Stop()
+
+	ctx, err := tracer.Extract(headers)
+	assert.NoError(t, err)
+
+	// Verify that trace context is taken from Datadog headers, despite baggage being listed first in propagation style
+	expectedTraceID := uint64(12345)
+	assert.Equal(t, expectedTraceID, ctx.TraceID())
+	assert.Equal(t, uint64(67890), ctx.SpanID())
+
+	got := make(map[string]string)
+	ctx.ForeachBaggageItem(func(k, v string) bool {
+		got[k] = v
+		return true
+	})
+	assert.Len(t, got, 1)
+	assert.Equal(t, "xyz", got["item"])
+}

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -621,7 +621,7 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 	if t.config.hostname != "" {
 		span.setMeta(keyHostname, t.config.hostname)
 	}
-	if context != nil {
+	if context != nil && !context.baggageOnly {
 		// this is a child span
 		span.TraceID = context.traceID.Lower()
 		span.ParentID = context.spanID


### PR DESCRIPTION

### What does this PR do?
Ports changes from #3597 into v1

### Motivation

The baggage propagator introduced in v1.73.0 broke trace extraction and trace injection in the case that the baggage propagator was the first propagator to run.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
