### PR TITLE
[contrib/aws] finish span in middleware func where it was created

### DIFF
--- a/contrib/aws/aws-sdk-go-v2/aws/aws.go
+++ b/contrib/aws/aws-sdk-go-v2/aws/aws.go
@@ -122,6 +122,10 @@ func (mw *traceMiddleware) startTraceMiddleware(stack *middleware.Stack) error {
 
 		// Handle initialize and continue through the middleware chain.
 		out, metadata, err = next.HandleInitialize(spanctx, in)
+		if err != nil && (mw.cfg.errCheck == nil || mw.cfg.errCheck(err)) {
+			span.SetTag(ext.Error, err)
+		}
+		span.Finish()
 
 		return out, metadata, err
 	}), middleware.After)
@@ -355,11 +359,6 @@ func (mw *traceMiddleware) deserializeTraceMiddleware(stack *middleware.Stack) e
 
 		// Create span pointers
 		spanpointers.AddSpanPointers(ctx, in, out, span)
-
-		if err != nil && (mw.cfg.errCheck == nil || mw.cfg.errCheck(err)) {
-			span.SetTag(ext.Error, err)
-		}
-		span.Finish()
 
 		return out, metadata, err
 	}), middleware.Before)

--- a/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
+++ b/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
@@ -866,10 +866,10 @@ func TestAppendMiddleware_ChainTerminated(t *testing.T) {
 
 	s3Client := s3.NewFromConfig(awsCfg)
 	stackFn := func(stack *middleware.Stack) error {
-		return stack.Finalize.Add(middleware.FinalizeMiddlewareFunc("stop", func(
-			ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler,
+		return stack.Initialize.Add(middleware.InitializeMiddlewareFunc("stop", func(
+			ctx context.Context, in middleware.InitializeInput, next middleware.InitializeHandler,
 		) (
-			out middleware.FinalizeOutput, metadata middleware.Metadata, err error,
+			out middleware.InitializeOutput, metadata middleware.Metadata, err error,
 		) {
 			// Terminate the middleware chain by not calling the next handler
 			out.Result = &s3.ListObjectsOutput{}
@@ -909,15 +909,15 @@ func TestAppendMiddleware_InnerSpan(t *testing.T) {
 
 	s3Client := s3.NewFromConfig(awsCfg)
 	stackFn := func(stack *middleware.Stack) error {
-		return stack.Finalize.Add(middleware.FinalizeMiddlewareFunc("stop", func(
-			ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler,
+		return stack.Initialize.Add(middleware.InitializeMiddlewareFunc("stop", func(
+			ctx context.Context, in middleware.InitializeInput, next middleware.InitializeHandler,
 		) (
-			out middleware.FinalizeOutput, metadata middleware.Metadata, err error,
+			out middleware.InitializeOutput, metadata middleware.Metadata, err error,
 		) {
 			// Start a new child span
 			span, ctx := tracer.StartSpanFromContext(ctx, "inner span")
 			defer span.Finish()
-			out, metadata, err = next.HandleFinalize(ctx, in)
+			out, metadata, err = next.HandleInitialize(ctx, in)
 			return
 		}), middleware.After)
 	}

--- a/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
+++ b/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
@@ -853,6 +854,79 @@ func TestAppendMiddlewareSfnDescribeStateMachine(t *testing.T) {
 			assert.Equal(t, componentName, s.Integration())
 		})
 	}
+}
+
+func TestAppendMiddleware_ChainTerminated(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	awsCfg := aws.Config{}
+
+	AppendMiddleware(&awsCfg)
+
+	s3Client := s3.NewFromConfig(awsCfg)
+	stackFn := func(stack *middleware.Stack) error {
+		return stack.Finalize.Add(middleware.FinalizeMiddlewareFunc("stop", func(
+			ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler,
+		) (
+			out middleware.FinalizeOutput, metadata middleware.Metadata, err error,
+		) {
+			// Terminate the middleware chain by not calling the next handler
+			out.Result = &s3.ListObjectsOutput{}
+			return
+		}), middleware.After)
+	}
+	s3Client.ListObjects(context.Background(), &s3.ListObjectsInput{
+		Bucket: aws.String("MyBucketName"),
+	}, s3.WithAPIOptions(stackFn))
+
+	spans := mt.FinishedSpans()
+	assert.Len(t, spans, 1)
+}
+
+func TestAppendMiddleware_InnerSpan(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	server := mockAWS(200)
+	defer server.Close()
+
+	resolver := aws.EndpointResolverFunc(func(_, _ string) (aws.Endpoint, error) {
+		return aws.Endpoint{
+			PartitionID:   "aws",
+			URL:           server.URL,
+			SigningRegion: "eu-west-1",
+		}, nil
+	})
+
+	awsCfg := aws.Config{
+		Region:           "eu-west-1",
+		Credentials:      aws.AnonymousCredentials{},
+		EndpointResolver: resolver,
+	}
+
+	AppendMiddleware(&awsCfg)
+
+	s3Client := s3.NewFromConfig(awsCfg)
+	stackFn := func(stack *middleware.Stack) error {
+		return stack.Finalize.Add(middleware.FinalizeMiddlewareFunc("stop", func(
+			ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler,
+		) (
+			out middleware.FinalizeOutput, metadata middleware.Metadata, err error,
+		) {
+			// Start a new child span
+			span, ctx := tracer.StartSpanFromContext(ctx, "inner span")
+			defer span.Finish()
+			out, metadata, err = next.HandleFinalize(ctx, in)
+			return
+		}), middleware.After)
+	}
+	s3Client.ListObjects(context.Background(), &s3.ListObjectsInput{
+		Bucket: aws.String("MyBucketName"),
+	}, s3.WithAPIOptions(stackFn))
+
+	spans := mt.FinishedSpans()
+	assert.Len(t, spans, 2)
 }
 
 func TestAppendMiddleware_WithNoTracer(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Moves `span.Finish()` back to the middleware func where the span is created.

### Motivation

The span finish was moved to its current location in https://github.com/DataDog/dd-trace-go/pull/3083, but in cases where the entire middleware stack is not traversed (e.g. [presign requests](https://github.com/aws/aws-sdk-go-v2/blob/29bbb566e87daa8cf4b0ea93546b92f19c15cf39/aws/signer/v4/presign_middleware.go#L69)) the span may never be finished.

see https://github.com/DataDog/dd-trace-go/issues/3696

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
