### PR TITLE
[FIX] set error stack and error type attributes only when not set already in meta

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -426,9 +426,17 @@ func (s *Span) setTagError(value interface{}, cfg errorConfig) {
 		// and provide all the benefits.
 		setError(true)
 		s.setMeta(ext.ErrorMsg, v.Error())
-		s.setMeta(ext.ErrorType, reflect.TypeOf(v).String())
+
+		// set error type if not set already
+		if m, ok := getMeta(s, ext.ErrorType); !ok || m == "" {
+			s.setMeta(ext.ErrorType, reflect.TypeOf(v).String())
+		}
+		
 		if !cfg.noDebugStack {
-			s.setMeta(ext.ErrorStack, takeStacktrace(cfg.stackFrames, cfg.stackSkip))
+			// set error stack if not set already
+			if m, ok := getMeta(s, ext.ErrorStack); !ok || m == "" {
+				s.setMeta(ext.ErrorStack, takeStacktrace(cfg.stackFrames, cfg.stackSkip))
+			}
 		}
 		switch v.(type) {
 		case xerrors.Formatter:

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -431,7 +431,7 @@ func (s *Span) setTagError(value interface{}, cfg errorConfig) {
 		if m, ok := getMeta(s, ext.ErrorType); !ok || m == "" {
 			s.setMeta(ext.ErrorType, reflect.TypeOf(v).String())
 		}
-		
+
 		if !cfg.noDebugStack {
 			// set error stack if not set already
 			if m, ok := getMeta(s, ext.ErrorStack); !ok || m == "" {

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -521,6 +521,14 @@ func TestSpanSetTagError(t *testing.T) {
 		span.setTagError(errors.New("error value with trace"), errorConfig{noDebugStack: false})
 		assert.NotEmpty(t, span.meta[ext.ErrorStack])
 	})
+
+	t.Run("incomingStack", func(t *testing.T) {
+		span := newBasicSpan("web.request")
+		incomingStack := "this is an incoming stack trace"
+		span.meta[ext.ErrorStack] = incomingStack
+		span.setTagError(errors.New("error value with incoming stack"), errorConfig{noDebugStack: false})
+		assert.Equal(t, incomingStack, span.meta[ext.ErrorStack])
+	})
 }
 
 func TestTraceManualKeepAndManualDrop(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

* In setTagError function we were always setting error stack and error type tags
* This was overriding the values that were sent by the client
* As in ddtrace/opentelemetry span End function, we are creating a new error from the description
* Error stack is getting updated which removes all the client stacks

### Motivation

* As we are using this in our errors package, the custom error.stack we are setting is always getting override and the default stack is not helpful as it doesn't include client side stack frames

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
