### PR TITLE
fix: sanitize span context debug logging to prevent sensitive data exposure

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -369,7 +369,7 @@ func (p *chainedPropagator) Extract(carrier interface{}) (*SpanContext, error) {
 	if len(links) > 0 {
 		ctx.spanLinks = links
 	}
-	log.Debug("Extracted span context: %#v", ctx)
+	log.Debug("Extracted span context: %s", ctx.safeDebugString())
 	return ctx, nil
 }
 

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -2933,3 +2933,71 @@ func TestExtractBaggageFirstThenDatadog(t *testing.T) {
 	assert.Len(t, got, 1)
 	assert.Equal(t, "xyz", got["item"])
 }
+
+// TestSpanContextDebugLoggingSecurity verifies that debug logging of span context
+// does not expose sensitive data from baggage or other fields.
+func TestSpanContextDebugLoggingSecurity(t *testing.T) {
+	// Set up a record logger to capture debug output
+	tp := new(log.RecordLogger)
+
+	// Enable debug mode to trigger the debug logging
+	tracer, err := newTracer(WithLogger(tp), WithDebugMode(true))
+	assert.NoError(t, err)
+	defer tracer.Stop()
+
+	// Create headers with sensitive data in baggage
+	headers := TextMapCarrier(map[string]string{
+		"baggage":             "api_key=secret123,password=sensitive_password,token=bearer_token_abc",
+		DefaultTraceIDHeader:  "12345",
+		DefaultParentIDHeader: "67890",
+		DefaultPriorityHeader: "1",
+	})
+
+	// Clear any existing logs before extraction
+	tp.Reset()
+
+	// Extract span context - this should trigger the debug log
+	ctx, err := tracer.Extract(headers)
+	assert.NoError(t, err)
+	assert.NotNil(t, ctx)
+
+	// Verify that baggage was extracted
+	got := make(map[string]string)
+	ctx.ForeachBaggageItem(func(k, v string) bool {
+		got[k] = v
+		return true
+	})
+	assert.Len(t, got, 3)
+	assert.Equal(t, "secret123", got["api_key"])
+	assert.Equal(t, "sensitive_password", got["password"])
+	assert.Equal(t, "bearer_token_abc", got["token"])
+
+	// Check the debug logs - they should NOT contain sensitive data
+	logs := tp.Logs()
+
+	// Find the span context debug log
+	var contextLog string
+	for _, logEntry := range logs {
+		if strings.Contains(logEntry, "Extracted span context:") {
+			contextLog = logEntry
+			break
+		}
+	}
+
+	// The log should exist
+	assert.NotEmpty(t, contextLog, "Expected to find span context debug log")
+
+	// The log should NOT contain sensitive baggage values
+	assert.NotContains(t, contextLog, "secret123", "Debug log should not expose API key")
+	assert.NotContains(t, contextLog, "sensitive_password", "Debug log should not expose password")
+	assert.NotContains(t, contextLog, "bearer_token_abc", "Debug log should not expose token")
+
+	// The log should still contain useful debug information (trace ID, span ID)
+	assert.Contains(t, contextLog, "67890", "Debug log should contain span ID")
+	assert.Contains(t, contextLog, "traceID=", "Debug log should contain trace ID field")
+	assert.Contains(t, contextLog, "hasBaggage=true", "Debug log should indicate baggage presence")
+	assert.Contains(t, contextLog, "baggageCount=3", "Debug log should show baggage count")
+
+	// This test ensures that the SafeDebugString() method is used instead of %#v
+	// to prevent sensitive baggage data from being exposed in debug logs.
+}

--- a/internal/telemetry/logger.go
+++ b/internal/telemetry/logger.go
@@ -75,7 +75,6 @@ func (logger *logger) Add(level LogLevel, text string, opts ...LogOption) {
 }
 
 func (logger *logger) add(level LogLevel, text string, opts ...LogOption) {
-
 	key := loggerKey{
 		message: text,
 		level:   level,


### PR DESCRIPTION
The debug logging in textmap.go was using %#v formatting to log the entire
SpanContext structure, which exposed sensitive baggage data in debug logs.

This change:
- Adds a private safeDebugString() method to SpanContext that excludes
  sensitive baggage contents while preserving useful debugging information
- Updates the debug log to use this safe method instead of %#v
- Adds comprehensive test coverage to prevent regressions

The safe debug output includes trace ID, span ID, baggage count, and other
non-sensitive metadata while protecting any sensitive data stored in baggage.

Signed-off-by: Kemal Akkoyun <kemal.akkoyun@datadoghq.com>

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
