### PR TITLE
ddtrace/tracer: sanitize URLs in CI Visibility transport logs

### DIFF
--- a/ddtrace/tracer/civisibility_transport.go
+++ b/ddtrace/tracer/civisibility_transport.go
@@ -17,10 +17,12 @@ import (
 	"time"
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+
 	"github.com/DataDog/dd-trace-go/v2/internal"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/telemetry"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
+	"github.com/DataDog/dd-trace-go/v2/internal/urlsanitizer"
 	"github.com/DataDog/dd-trace-go/v2/internal/version"
 )
 
@@ -106,9 +108,7 @@ func newCiVisibilityTransport(config *config) *ciVisibilityTransport {
 		defaultHeaders["X-Datadog-EVP-Subdomain"] = TestCycleSubdomain
 		testCycleURL = fmt.Sprintf("%s/%s/%s", config.agentURL.String(), EvpProxyPath, TestCyclePath)
 	}
-	log.Debug("ciVisibilityTransport: creating transport instance [agentless: %v, testcycleurl: %v]", agentlessEnabled, testCycleURL)
-
-	log.Debug("ciVisibilityTransport: creating transport instance [agentless: %v, testcycleurl: %v]", agentlessEnabled, testCycleURL)
+	log.Debug("ciVisibilityTransport: creating transport instance [agentless: %v, testcycleurl: %v]", agentlessEnabled, urlsanitizer.SanitizeURL(testCycleURL))
 
 	return &ciVisibilityTransport{
 		config:           config,

--- a/ddtrace/tracer/civisibility_transport_test.go
+++ b/ddtrace/tracer/civisibility_transport_test.go
@@ -11,12 +11,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 
-	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 	"github.com/stretchr/testify/assert"
 	"github.com/tinylib/msgp/msgp"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
+	"github.com/DataDog/dd-trace-go/v2/internal/urlsanitizer"
 )
 
 func TestCiVisibilityTransport(t *testing.T) {
@@ -109,4 +112,45 @@ func runTransportTest(t *testing.T, agentless, shouldSetAPIKey bool) {
 	}
 	assert.Equal(hits, len(testCases))
 	assert.Equal(remainingEvents, 0)
+}
+
+func TestCIVisibilityTransportSecureLogging(t *testing.T) {
+	t.Run("agentless_mode_with_credentials_in_url", func(t *testing.T) {
+		// Set environment variables with sensitive data
+		os.Setenv(constants.CIVisibilityAgentlessEnabledEnvironmentVariable, "true")
+		os.Setenv(constants.APIKeyEnvironmentVariable, "test-api-key")
+		os.Setenv(constants.CIVisibilityAgentlessURLEnvironmentVariable, "https://user:secret@example.com/path")
+		defer func() {
+			os.Unsetenv(constants.CIVisibilityAgentlessEnabledEnvironmentVariable)
+			os.Unsetenv(constants.APIKeyEnvironmentVariable)
+			os.Unsetenv(constants.CIVisibilityAgentlessURLEnvironmentVariable)
+		}()
+
+		cfg := &config{}
+		transport := newCiVisibilityTransport(cfg)
+		assert.NotNil(t, transport)
+
+		// Verify URL still contains credentials (stored for actual use)
+		assert.Contains(t, transport.testCycleURLPath, "https://user:secret@example.com/path/api/v2/citestcycle")
+	})
+
+	t.Run("sanitize_url_function", func(t *testing.T) {
+		// Test the sanitizeURL function directly
+		tests := []struct {
+			input    string
+			expected string
+		}{
+			{"https://user:password@example.com/path", "https://user:xxxxx@example.com/path"},
+			{"http://token@example.com", "http://token@example.com"}, // no password, so username preserved
+			{"https://user:pass@example.com:8080/path", "https://user:xxxxx@example.com:8080/path"},
+			{"https://example.com/path", "https://example.com/path"},
+			{"", ""},
+			{"://invalid", "://invalid"}, // unparseable but no credentials, returned as-is
+		}
+
+		for _, test := range tests {
+			result := urlsanitizer.SanitizeURL(test.input)
+			assert.Equal(t, test.expected, result, "Failed for input: %s", test.input)
+		}
+	})
 }

--- a/internal/urlsanitizer/sanitizer.go
+++ b/internal/urlsanitizer/sanitizer.go
@@ -1,0 +1,70 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/)
+// Copyright 2016 Datadog, Inc.
+
+// Package urlsanitizer provides utilities for sanitizing URLs and DSNs by removing sensitive information.
+package urlsanitizer
+
+import (
+	"net/url"
+	"strings"
+)
+
+// SanitizeURL removes user credentials from URLs for safe logging.
+// It uses Go's built-in url.Redacted() when possible, which preserves usernames but redacts passwords.
+// If the URL can't be parsed but appears to contain credentials, it's fully redacted for security.
+func SanitizeURL(rawURL string) string {
+	if rawURL == "" {
+		return rawURL
+	}
+
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		// If parsing fails but we suspect credentials,
+		// redact entirely for safety.
+		if containsCredentials(rawURL) {
+			return "[REDACTED_URL_WITH_CREDENTIALS]"
+		}
+		// If no credentials suspected,
+		// return as-is (might just be a malformed URL without sensitive data)
+		return rawURL
+	}
+
+	// If URL has user info,
+	// use Go's built-in redaction (preserves username, redacts password).
+	if parsedURL.User != nil {
+		return parsedURL.Redacted()
+	}
+
+	// No credentials detected, return as-is
+	return rawURL
+}
+
+// containsCredentials checks if a URL string might contain credentials
+func containsCredentials(rawURL string) bool {
+	// Look for patterns that suggest credentials: username:password@host
+	// This is a simple heuristic - if we see :...@ we assume credentials.
+	if !strings.Contains(rawURL, "://") {
+		return false
+	}
+
+	// Find the scheme part.
+	schemeEnd := strings.Index(rawURL, "://")
+	if schemeEnd == -1 {
+		return false
+	}
+
+	// Look in the part after the scheme for credentials.
+	rest := rawURL[schemeEnd+3:]
+
+	// If we see a colon followed by an @ sign, likely credentials.
+	colonIndex := strings.Index(rest, ":")
+	if colonIndex == -1 {
+		return false
+	}
+
+	// Check if there's an @ after the colon
+	atIndex := strings.Index(rest[colonIndex:], "@")
+	return atIndex != -1
+}

--- a/internal/urlsanitizer/sanitizer_test.go
+++ b/internal/urlsanitizer/sanitizer_test.go
@@ -1,0 +1,68 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/)
+// Copyright 2016 Datadog, Inc.
+
+package urlsanitizer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeURL(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// URLs with credentials - use Go's built-in redaction (preserves username, redacts password)
+		{"https://user:password@example.com/path", "https://user:xxxxx@example.com/path"},
+		{"http://admin:secret@db.example.com:5432/mydb", "http://admin:xxxxx@db.example.com:5432/mydb"},
+
+		// URL with just username (no password) - preserved as-is
+		{"http://token@example.com", "http://token@example.com"},
+
+		// URLs without credentials - returned as-is
+		{"https://example.com/path", "https://example.com/path"},
+		{"http://localhost:8080", "http://localhost:8080"},
+		{"ftp://files.example.com/data", "ftp://files.example.com/data"},
+
+		// Edge cases
+		{"", ""},
+		{"not-a-url", "not-a-url"}, // no credentials suspected, return as-is
+		{"://invalid:password@host", "[REDACTED_URL_WITH_CREDENTIALS]"}, // unparseable but has credentials pattern
+		{"://invalid", "://invalid"},                                    // unparseable but no credentials, return as-is
+	}
+
+	for _, test := range tests {
+		result := SanitizeURL(test.input)
+		assert.Equal(t, test.expected, result, "Failed for input: %s", test.input)
+	}
+}
+
+func TestContainsCredentials(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		// Should detect credentials
+		{"https://user:password@example.com", true},
+		{"http://admin:secret@db.example.com:5432/mydb", true},
+		{"postgres://user:pass@localhost:5432/db", true},
+
+		// Should not detect credentials
+		{"https://example.com/path", false},
+		{"http://localhost:8080", false},
+		{"ftp://files.example.com", false},
+		{"http://token@example.com", false}, // no colon, so no password
+		{"not-a-url", false},
+		{"", false},
+		{"://invalid", false}, // no valid scheme
+	}
+
+	for _, test := range tests {
+		result := containsCredentials(test.input)
+		assert.Equal(t, test.expected, result, "Failed for input: %s", test.input)
+	}
+}


### PR DESCRIPTION
Prevent potential credential exposure in CI Visibility transport debug logs
by adding URL sanitization. This is a precautionary measure to ensure
credentials don't accidentally leak through logging.

Changes:
- Add internal/urlsanitizer package with balanced URL redaction
- Use Go's built-in url.Redacted() to preserve usernames while redacting passwords
- Only fully redact unparseable URLs that contain credential patterns
- Apply sanitization to CI Visibility transport debug logging

The sanitizer maintains debugging utility while securing credentials.
URLs like "https://user:password@host/path" become "https://user:xxxxx@host/path",
keeping hostname and username info for troubleshooting.

Signed-off-by: Kemal Akkoyun <kemal.akkoyun@datadoghq.com>

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
