### PR TITLE
feat: add ruleguard rules to prevent uncontrolled data leakage in logging

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,11 +1,18 @@
 version: "2"
+issues:
+  max-same-issues: 0
+  max-issues-per-linter: 0
 linters:
   default: none
   enable:
     - bodyclose
+    - depguard
+    - gocritic
     - govet
     - revive
-    - depguard
+    # - errorlint # TODO: Enable this once we've fixed all the errorlint issues.
+    # - loggercheck # TODO: Enable this once we've migrated to structured logging.
+    # - perfsprint # TODO: Enable this once we've fixed all the perfsprint issues.
   exclusions:
     generated: lax
     presets:
@@ -41,6 +48,32 @@ linters:
               desc: "Use github.com/DataDog/dd-trace-go/v2/internal/log instead of standard log package"
           allow:
             - "log/slog"
+    gocritic:
+      disable-all: true
+      enabled-checks:
+        - dynamicFmtString
+        - ruleguard
+      settings:
+        ruleguard:
+          failOn: dsl,import
+          rules: "rules/*_rules.go"
+    # TODO: Enable this when we migrated to structed logging.
+    loggercheck:
+      require-string-key: true
+      # no-printf-like: true
+      rules:
+        - github.com/DataDog/dd-trace-go/v2/internal/telemetry/log.Debug
+        - github.com/DataDog/dd-trace-go/v2/internal/telemetry/log.Warn
+        - github.com/DataDog/dd-trace-go/v2/internal/telemetry/log.Error
+        - github.com/DataDog/dd-trace-go/v2/internal/telemetry/log.Info
+        - github.com/DataDog/dd-trace-go/v2/internal/log.Debug
+        - github.com/DataDog/dd-trace-go/v2/internal/log.Warn
+        - github.com/DataDog/dd-trace-go/v2/internal/log.Error
+        - github.com/DataDog/dd-trace-go/v2/internal/log.Info
+        - (github.com/DataDog/dd-trace-go/v2/instrumentation.Logger).Debug
+        - (github.com/DataDog/dd-trace-go/v2/instrumentation.Logger).Info
+        - (github.com/DataDog/dd-trace-go/v2/instrumentation.Logger).Warn
+        - (github.com/DataDog/dd-trace-go/v2/instrumentation.Logger).Error
 formatters:
   enable:
     - gofmt

--- a/ddtrace/mocktracer/mockspan.go
+++ b/ddtrace/mocktracer/mockspan.go
@@ -257,7 +257,7 @@ func (s *Span) Events() []SpanEvent {
 
 	var events []SpanEvent
 	if err := json.Unmarshal([]byte(eventsJSON), &events); err != nil {
-		log.Error("mocktracer: failed to unmarshal span events: %v", err)
+		log.Error("mocktracer: failed to unmarshal span events: %v", err.Error())
 		return nil
 	}
 	return events

--- a/ddtrace/opentelemetry/span.go
+++ b/ddtrace/opentelemetry/span.go
@@ -138,7 +138,7 @@ func (s *span) extractTraceData(c *oteltrace.SpanContextConfig) {
 	}
 	state, err := oteltrace.ParseTraceState(headers["tracestate"])
 	if err != nil {
-		log.Debug("Couldn't parse tracestate: %v", err)
+		log.Debug("Couldn't parse tracestate: %v", err.Error())
 		return
 	}
 	c.TraceState = state
@@ -149,7 +149,7 @@ func (s *span) extractTraceData(c *oteltrace.SpanContextConfig) {
 		// where flags represents the propagated flags in the format of 2 hex-encoded digits at the end of the traceparent.
 		otelFlagLen := 2
 		if f, err := strconv.ParseUint(parent[len(parent)-otelFlagLen:], 16, 8); err != nil {
-			log.Debug("Couldn't parse traceparent: %v", err)
+			log.Debug("Couldn't parse traceparent: %v", err.Error())
 		} else {
 			c.TraceFlags = oteltrace.TraceFlags(f)
 		}

--- a/ddtrace/tracer/civisibility_payload.go
+++ b/ddtrace/tracer/civisibility_payload.go
@@ -73,7 +73,7 @@ func newCiVisibilityPayload() *ciVisibilityPayload {
 //	An error if reading from the buffer or encoding the payload fails.
 func (p *ciVisibilityPayload) getBuffer(config *config) (*bytes.Buffer, error) {
 	startTime := time.Now()
-	log.Debug("ciVisibilityPayload: .getBuffer (count: %v)", p.itemCount())
+	log.Debug("ciVisibilityPayload: .getBuffer (count: %d)", p.itemCount())
 
 	// Create a buffer to read the current payload
 	payloadBuf := new(bytes.Buffer)

--- a/ddtrace/tracer/civisibility_transport.go
+++ b/ddtrace/tracer/civisibility_transport.go
@@ -108,7 +108,7 @@ func newCiVisibilityTransport(config *config) *ciVisibilityTransport {
 		defaultHeaders["X-Datadog-EVP-Subdomain"] = TestCycleSubdomain
 		testCycleURL = fmt.Sprintf("%s/%s/%s", config.agentURL.String(), EvpProxyPath, TestCyclePath)
 	}
-	log.Debug("ciVisibilityTransport: creating transport instance [agentless: %v, testcycleurl: %v]", agentlessEnabled, urlsanitizer.SanitizeURL(testCycleURL))
+	log.Debug("ciVisibilityTransport: creating transport instance [agentless: %t, testcycleurl: %s]", agentlessEnabled, urlsanitizer.SanitizeURL(testCycleURL))
 
 	return &ciVisibilityTransport{
 		config:           config,
@@ -161,9 +161,8 @@ func (t *ciVisibilityTransport) send(p *payload) (body io.ReadCloser, err error)
 	if t.agentless {
 		req.Header.Set("Content-Encoding", "gzip")
 	}
-	log.Debug("ciVisibilityTransport: sending transport request: %v bytes", buffer.Len())
+	log.Debug("ciVisibilityTransport: sending transport request: %d bytes", buffer.Len())
 
-	log.Debug("ciVisibilityTransport: sending transport request: %v bytes", buffer.Len())
 	startTime := time.Now()
 	response, err := t.config.httpClient.Do(req)
 	telemetry.EndpointPayloadRequestsMs(telemetry.TestCycleEndpointType, float64(time.Since(startTime).Milliseconds()))

--- a/ddtrace/tracer/civisibility_writer.go
+++ b/ddtrace/tracer/civisibility_writer.go
@@ -65,7 +65,7 @@ func (w *ciVisibilityTraceWriter) add(trace []*Span) {
 	for _, s := range trace {
 		cvEvent := getCiVisibilityEvent(s)
 		if err := w.payload.push(cvEvent); err != nil {
-			log.Error("ciVisibilityTraceWriter: Error encoding msgpack: %v", err)
+			log.Error("ciVisibilityTraceWriter: Error encoding msgpack: %v", err.Error())
 		}
 		if w.payload.size() > agentlessPayloadSizeLimit {
 			w.flush()
@@ -120,11 +120,11 @@ func (w *ciVisibilityTraceWriter) flush() {
 				log.Debug("ciVisibilityTraceWriter: sent events after %d attempts", attempt+1)
 				return
 			}
-			log.Error("ciVisibilityTraceWriter: failure sending events (attempt %d of %d): %v", attempt+1, w.config.sendRetries+1, err)
+			log.Error("ciVisibilityTraceWriter: failure sending events (attempt %d of %d): %v", attempt+1, w.config.sendRetries+1, err.Error())
 			p.reset()
 			time.Sleep(w.config.retryInterval)
 		}
-		log.Error("ciVisibilityTraceWriter: lost %d events: %v", count, err)
+		log.Error("ciVisibilityTraceWriter: lost %d events: %v", count, err.Error())
 		telemetry.EndpointPayloadDropped(telemetry.TestCycleEndpointType)
 	}(oldp)
 }

--- a/ddtrace/tracer/log.go
+++ b/ddtrace/tracer/log.go
@@ -168,6 +168,7 @@ func logStartup(t *tracer) {
 	}
 	bs, err := json.Marshal(info)
 	if err != nil {
+		//nolint:gocritic // Diagnostic logging needs full struct representation
 		log.Warn("DIAGNOSTICS Failed to serialize json for startup log (%v) %#v\n", err, info)
 		return
 	}

--- a/ddtrace/tracer/log_test.go
+++ b/ddtrace/tracer/log_test.go
@@ -147,7 +147,7 @@ func TestLogSamplingRules(t *testing.T) {
 	assert.Error(err)
 
 	assert.Len(tp.Logs(), 1)
-	assert.Regexp(logPrefixRegexp+` WARN: DIAGNOSTICS Error\(s\) parsing sampling rules: found errors:\n\tat index 4: ignoring rule {Rate:9\.10}: rate is out of \[0\.0, 1\.0] range$`, tp.Logs()[0])
+	assert.Regexp(logPrefixRegexp+` WARN: DIAGNOSTICS Error\(s\) parsing sampling rules: found errors: \n\s*\tat index 4: ignoring rule \{Rate:9\.10\}: rate is out of \[0\.0, 1\.0\] range$`, tp.Logs()[0])
 }
 
 func TestLogDefaultSampleRate(t *testing.T) {

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -8,6 +8,7 @@ package tracer
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -351,7 +352,7 @@ func newConfig(opts ...StartOption) (*config, error) {
 		var err error
 		sampleRate, err = strconv.ParseFloat(r, 64)
 		if err != nil {
-			log.Warn("ignoring DD_TRACE_SAMPLE_RATE, error: %v", err)
+			log.Warn("ignoring DD_TRACE_SAMPLE_RATE, error: %v", err.Error())
 			sampleRate = math.NaN()
 		} else if sampleRate < 0.0 || sampleRate > 1.0 {
 			log.Warn("ignoring DD_TRACE_SAMPLE_RATE: out of range %f", sampleRate)
@@ -366,7 +367,7 @@ func newConfig(opts ...StartOption) (*config, error) {
 	if v, ok := os.LookupEnv("DD_TRACE_RATE_LIMIT"); ok {
 		l, err := strconv.ParseFloat(v, 64)
 		if err != nil {
-			log.Warn("DD_TRACE_RATE_LIMIT invalid, using default value %f: %v", defaultRateLimit, err)
+			log.Warn("DD_TRACE_RATE_LIMIT invalid, using default value %f: %v", defaultRateLimit, err.Error())
 		} else if l < 0.0 {
 			log.Warn("DD_TRACE_RATE_LIMIT negative, using default value %f", defaultRateLimit)
 		} else {
@@ -387,7 +388,7 @@ func newConfig(opts ...StartOption) (*config, error) {
 		var err error
 		c.hostname, err = os.Hostname()
 		if err != nil {
-			log.Warn("unable to look up hostname: %v", err)
+			log.Warn("unable to look up hostname: %v", err.Error())
 			return c, fmt.Errorf("unable to look up hostnamet: %v", err)
 		}
 	}
@@ -774,7 +775,7 @@ func loadAgentFeatures(agentDisabled bool, agentURL *url.URL, httpClient *http.C
 	}
 	resp, err := httpClient.Get(fmt.Sprintf("%s/info", agentURL))
 	if err != nil {
-		log.Error("Loading features: %v", err)
+		log.Error("Loading features: %v", err.Error())
 		return
 	}
 	if resp.StatusCode == http.StatusNotFound {
@@ -797,7 +798,7 @@ func loadAgentFeatures(agentDisabled bool, agentURL *url.URL, httpClient *http.C
 
 	var info infoResponse
 	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
-		log.Error("Decoding features: %v", err)
+		log.Error("Decoding features: %v", err.Error())
 		return
 	}
 
@@ -921,7 +922,7 @@ func WithFeatureFlags(feats ...string) StartOption {
 		for _, f := range feats {
 			c.featureFlags[strings.TrimSpace(f)] = struct{}{}
 		}
-		log.Info("FEATURES enabled: %v", feats)
+		log.Info("FEATURES enabled: %s", feats)
 	}
 }
 
@@ -1015,7 +1016,18 @@ func WithAgentURL(agentURL string) StartOption {
 	return func(c *config) {
 		u, err := url.Parse(agentURL)
 		if err != nil {
-			log.Warn("Fail to parse Agent URL: %v", err)
+			var urlErr *url.Error
+			if errors.As(err, &urlErr) {
+				u, err = url.Parse(urlErr.URL)
+				if u != nil {
+					urlErr.URL = u.Redacted()
+					log.Warn("Fail to parse Agent URL: %s", urlErr.Err)
+					return
+				}
+				log.Warn("Fail to parse Agent URL")
+				return
+			}
+			log.Warn("Fail to parse Agent URL: %v", err.Error())
 			return
 		}
 		switch u.Scheme {
@@ -1533,7 +1545,7 @@ func setHeaderTags(headerAsTags []string) bool {
 	for _, h := range headerAsTags {
 		header, tag := normalizer.HeaderTag(h)
 		if len(header) == 0 || len(tag) == 0 {
-			log.Debug("Header-tag input is in unsupported format; dropping input value %v", h)
+			log.Debug("Header-tag input is in unsupported format; dropping input value %q", h)
 			continue
 		}
 		globalconfig.SetHeaderTag(header, tag)

--- a/ddtrace/tracer/otel_dd_mappings.go
+++ b/ddtrace/tracer/otel_dd_mappings.go
@@ -110,13 +110,13 @@ func getDDorOtelConfig(configName string) string {
 		ddPrefix := "config_datadog:"
 		otelPrefix := "config_opentelemetry:"
 		if val != "" {
-			log.Warn("Both %v and %v are set, using %v=%v", config.ot, config.dd, config.dd, val)
+			log.Warn("Both %s and %s are set, using %s=%s", config.ot, config.dd, config.dd, val)
 			telemetryTags := []string{ddPrefix + strings.ToLower(config.dd), otelPrefix + strings.ToLower(config.ot)}
 			telemetry.Count(telemetry.NamespaceTracers, "otel.env.hiding", telemetryTags).Submit(1)
 		} else {
 			v, err := config.remapper(otVal)
 			if err != nil {
-				log.Warn("%v", err)
+				log.Warn("%v", err.Error())
 				telemetryTags := []string{ddPrefix + strings.ToLower(config.dd), otelPrefix + strings.ToLower(config.ot)}
 				telemetry.Count(telemetry.NamespaceTracers, "otel.env.invalid", telemetryTags).Submit(1)
 			}
@@ -149,7 +149,7 @@ func mapDDTags(ot string) (string, error) {
 	})
 
 	if len(ddTags) > 10 {
-		log.Warn("The following resource attributes have been dropped: %v. Only the first 10 resource attributes will be applied: %v", ddTags[10:], ddTags[:10])
+		log.Warn("The following resource attributes have been dropped: %v. Only the first 10 resource attributes will be applied: %s", ddTags[10:], ddTags[:10]) //nolint:gocritic // Slice logging for debugging
 		ddTags = ddTags[:10]
 	}
 
@@ -198,7 +198,7 @@ func otelTraceIDRatio() string {
 func mapSampleRate(ot string) (string, error) {
 	ot = strings.TrimSpace(strings.ToLower(ot))
 	if v, ok := unsupportedSamplerMapping[ot]; ok {
-		log.Warn("The following configuration is not supported: OTEL_TRACES_SAMPLER=%v. %v will be used", ot, v)
+		log.Warn("The following configuration is not supported: OTEL_TRACES_SAMPLER=%s. %s will be used", ot, v)
 		ot = v
 	}
 
@@ -222,7 +222,7 @@ func mapPropagationStyle(ot string) (string, error) {
 		if _, ok := propagationMapping[otStyle]; ok {
 			supportedStyles = append(supportedStyles, propagationMapping[otStyle])
 		} else {
-			log.Warn("Invalid configuration: %v is not supported. This propagation style will be ignored.", otStyle)
+			log.Warn("Invalid configuration: %s is not supported. This propagation style will be ignored.", otStyle)
 		}
 	}
 	return strings.Join(supportedStyles, ","), nil

--- a/ddtrace/tracer/propagating_tags.go
+++ b/ddtrace/tracer/propagating_tags.go
@@ -39,7 +39,7 @@ func (t *trace) setTraceSourcePropagatingTag(key string, value internal.TraceSou
 	if source := t.propagatingTags[key]; source != "" {
 		tSource, err := internal.ParseTraceSource(source)
 		if err != nil {
-			log.Error("failed to parse trace source tag: %v", err)
+			log.Error("failed to parse trace source tag: %v", err.Error())
 		}
 
 		tSource |= value

--- a/ddtrace/tracer/remote_config.go
+++ b/ddtrace/tracer/remote_config.go
@@ -197,7 +197,7 @@ func (t *tracer) onRemoteConfigUpdate(u remoteconfig.ProductUpdate) map[string]s
 		log.Debug("Processing config from RC. Path: %s. Raw: %s", path, raw)
 		var c configData
 		if err := json.Unmarshal(raw, &c); err != nil {
-			log.Debug("Error while unmarshalling payload for %s: %v. Configuration won't be applied.", path, err)
+			log.Debug("Error while unmarshalling payload for %s: %v. Configuration won't be applied.", path, err.Error())
 			statuses[path] = state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()}
 			continue
 		}

--- a/ddtrace/tracer/rules_sampler.go
+++ b/ddtrace/tracer/rules_sampler.go
@@ -869,7 +869,7 @@ func (sr SamplingRule) MarshalJSON() ([]byte, error) {
 func (sr SamplingRule) String() string {
 	s, err := sr.MarshalJSON()
 	if err != nil {
-		log.Error("Error marshalling SamplingRule to json: %v", err)
+		log.Error("Error marshalling SamplingRule to json: %s", err)
 	}
 	return string(s)
 }

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -102,7 +102,7 @@ func (s *Span) spanEventsAsJSONString() string {
 	}
 	events, err := json.Marshal(s.spanEvents)
 	if err != nil {
-		log.Error("failed to marshal span events: %v", err)
+		log.Error("failed to marshal span events: %v", err.Error())
 		return ""
 	}
 	return string(events)
@@ -606,7 +606,7 @@ func (s *Span) serializeSpanEvents() {
 	b, err := json.Marshal(s.spanEvents)
 	s.spanEvents = nil
 	if err != nil {
-		log.Debug("Unable to marshal span events; events dropped from span meta\n%v", err)
+		log.Debug("Unable to marshal span events; events dropped from span meta\n%v", err.Error())
 		return
 	}
 	s.meta["events"] = string(b)
@@ -738,7 +738,7 @@ func (s *Span) finish(finishTime int64) {
 	}
 	if log.DebugEnabled() {
 		// avoid allocating the ...interface{} argument if debug logging is disabled
-		log.Debug("Finished Span: %v, Operation: %s, Resource: %s, Tags: %v, %v",
+		log.Debug("Finished Span: %v, Operation: %s, Resource: %s, Tags: %v, %v", //nolint:gocritic // Debug logging needs full span representation
 			s, s.name, s.resource, s.meta, s.metrics)
 	}
 	s.context.finish()
@@ -769,7 +769,7 @@ func obfuscatedResource(o *obfuscate.Obfuscator, typ, resource string) string {
 	case "sql", "cassandra":
 		oq, err := o.ObfuscateSQLString(resource)
 		if err != nil {
-			log.Error("Error obfuscating stats group resource %q: %v", resource, err)
+			log.Error("Error obfuscating stats group resource %q: %v", resource, err.Error())
 			return textNonParsable
 		}
 		return oq.Query

--- a/ddtrace/tracer/stats.go
+++ b/ddtrace/tracer/stats.go
@@ -238,7 +238,7 @@ func (c *concentrator) flushAndSend(timenow time.Time, includeCurrent bool) {
 		flushedBuckets += len(csp.Stats)
 		if err := c.cfg.transport.sendStats(csp, obfVersion); err != nil {
 			c.statsd().Incr("datadog.tracer.stats.flush_errors", nil, 1)
-			log.Error("Error sending stats payload: %v", err)
+			log.Error("Error sending stats payload: %v", err.Error())
 		}
 	}
 	c.statsd().Incr("datadog.tracer.stats.flush_buckets", nil, float64(flushedBuckets))

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -117,7 +117,7 @@ func startTelemetry(c *config) {
 	}
 	client, err := telemetry.NewClient(c.serviceName, c.env, c.version, cfg)
 	if err != nil {
-		log.Debug("tracer: failed to create telemetry client: %v", err)
+		log.Debug("tracer: failed to create telemetry client: %v", err.Error())
 		return
 	}
 

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -483,7 +483,7 @@ func (p *propagator) marshalPropagatingTags(ctx *SpanContext) string {
 			return true // don't propagate W3C headers with the DD propagator
 		}
 		if err := isValidPropagatableTag(k, v); err != nil {
-			log.Warn("Won't propagate tag '%s': %v", k, err.Error())
+			log.Warn("Won't propagate tag '%s': %s", k, err.Error())
 			properr = "encoding_error"
 			return true
 		}
@@ -619,7 +619,7 @@ func unmarshalPropagatingTags(ctx *SpanContext, v string) {
 	}
 	tags, err := parsePropagatableTraceTags(v)
 	if err != nil {
-		log.Warn("Did not extract %s: %v. Incoming tags will not be propagated further.", traceTagsHeader, err.Error())
+		log.Warn("Did not extract %s: %s. Incoming tags will not be propagated further.", traceTagsHeader, err.Error())
 		ctx.trace.setTag(keyPropagationError, "decoding_error")
 	}
 	ctx.trace.replacePropagatingTags(tags)

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -322,7 +322,7 @@ func newUnstartedTracer(opts ...StartOption) (*tracer, error) {
 	sampler := newPrioritySampler()
 	statsd, err := newStatsdClient(c)
 	if err != nil {
-		log.Error("Runtime and health metrics disabled: %v", err)
+		log.Error("Runtime and health metrics disabled: %v", err.Error())
 		return nil, fmt.Errorf("could not initialize statsd client: %v", err)
 	}
 	var writer traceWriter
@@ -335,8 +335,8 @@ func newUnstartedTracer(opts ...StartOption) (*tracer, error) {
 	}
 	traces, spans, err := samplingRulesFromEnv()
 	if err != nil {
-		log.Warn("DIAGNOSTICS Error(s) parsing sampling rules: found errors:%s", err)
-		return nil, fmt.Errorf("found errors when parsing sampling rules: %v", err)
+		log.Warn("DIAGNOSTICS Error(s) parsing sampling rules: found errors: %v", err.Error())
+		return nil, fmt.Errorf("found errors when parsing sampling rules: %w", err)
 	}
 	if traces != nil {
 		c.traceRules = traces
@@ -364,7 +364,7 @@ func newUnstartedTracer(opts ...StartOption) (*tracer, error) {
 	if v := c.logDirectory; v != "" {
 		logFile, err = log.OpenFileAtPath(v)
 		if err != nil {
-			log.Warn("%v", err)
+			log.Warn("%v", err.Error())
 			c.logDirectory = ""
 		}
 	}
@@ -728,7 +728,7 @@ func (t *tracer) StartSpan(operationName string, options ...StartSpanOption) *Sp
 	}
 	if log.DebugEnabled() {
 		// avoid allocating the ...interface{} argument if debug logging is disabled
-		log.Debug("Started Span: %v, Operation: %s, Resource: %s, Tags: %v, %v",
+		log.Debug("Started Span: %v, Operation: %s, Resource: %s, Tags: %v, %v", //nolint:gocritic // Debug logging needs full span representation
 			span, span.name, span.resource, span.meta, span.metrics)
 	}
 	if t.config.profilerHotspots || t.config.profilerEndpoints {

--- a/ddtrace/tracer/writer.go
+++ b/ddtrace/tracer/writer.go
@@ -68,7 +68,7 @@ func newAgentTraceWriter(c *config, s *prioritySampler, statsdClient globalinter
 func (h *agentTraceWriter) add(trace []*Span) {
 	if err := h.payload.push(trace); err != nil {
 		h.statsd.Incr("datadog.tracer.traces_dropped", []string{"reason:encoding_error"}, 1)
-		log.Error("Error encoding msgpack: %v", err)
+		log.Error("Error encoding msgpack: %v", err.Error())
 	}
 	atomic.AddUint32(&h.tracesQueued, 1) // TODO: This does not differentiate between complete traces and partial chunks
 	if h.payload.size() > payloadSizeLimit {
@@ -122,12 +122,12 @@ func (h *agentTraceWriter) flush() {
 				}
 				return
 			}
-			log.Error("failure sending traces (attempt %d of %d): %v", attempt+1, h.config.sendRetries+1, err)
+			log.Error("failure sending traces (attempt %d of %d): %v", attempt+1, h.config.sendRetries+1, err.Error())
 			p.reset()
 			time.Sleep(h.config.retryInterval)
 		}
 		h.statsd.Count("datadog.tracer.traces_dropped", int64(count), []string{"reason:send_failed"}, 1)
-		log.Error("lost %d traces: %v", count, err)
+		log.Error("lost %d traces: %v", count, err.Error())
 	}(oldp)
 }
 
@@ -235,7 +235,7 @@ func (h *logTraceWriter) encodeSpan(s *Span) {
 		h.buf.WriteString(":")
 		jsonValue, err := json.Marshal(v)
 		if err != nil {
-			log.Error("Error marshaling value %q: %v", v, err)
+			log.Error("Error marshaling value %q: %v", v, err.Error())
 			continue
 		}
 		h.marshalString(string(jsonValue))
@@ -270,7 +270,7 @@ func (h *logTraceWriter) encodeSpan(s *Span) {
 func (h *logTraceWriter) marshalString(str string) {
 	m, err := json.Marshal(str)
 	if err != nil {
-		log.Error("Error marshaling value %q: %v", str, err)
+		log.Error("Error marshaling value %q: %v", str, err.Error())
 	} else {
 		h.buf.Write(m)
 	}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/klauspost/compress v1.18.0
 	github.com/puzpuzpuz/xsync/v3 v3.5.1
+	github.com/quasilyte/go-ruleguard/dsl v0.3.22
 	github.com/richardartoul/molecule v1.0.1-0.20240531184615-7ca0df43c0b3
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/puzpuzpuz/xsync/v3 v3.5.1 h1:GJYJZwO6IdxN/IKbneznS6yPkVC+c3zyY/j19c++5Fg=
 github.com/puzpuzpuz/xsync/v3 v3.5.1/go.mod h1:VjzYrABPabuM4KyBh1Ftq6u8nhwY5tBPKP9jpmh0nnA=
+github.com/quasilyte/go-ruleguard/dsl v0.3.22 h1:wd8zkOhSNr+I+8Qeciml08ivDt1pSXe60+5DqOpCjPE=
+github.com/quasilyte/go-ruleguard/dsl v0.3.22/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/richardartoul/molecule v1.0.1-0.20240531184615-7ca0df43c0b3 h1:4+LEVOB87y175cLJC/mbsgKmoDOjrBldtXvioEy96WY=
 github.com/richardartoul/molecule v1.0.1-0.20240531184615-7ca0df43c0b3/go.mod h1:vl5+MqJ1nBINuSsUI2mGgH79UweUT/B5Fy8857PqyyI=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/instrumentation/appsec/emitter/waf/actions/actions.go
+++ b/instrumentation/appsec/emitter/waf/actions/actions.go
@@ -39,7 +39,7 @@ func registerActionHandler(aType string, handler actionHandler) {
 func SendActionEvents(op dyngo.Operation, actions map[string]any) bool {
 	var blocked bool
 	for aType, params := range actions {
-		log.Debug("appsec: processing %s action with params %v", aType, params)
+		log.Debug("appsec: processing %s action with params %v", aType, params) //nolint:gocritic
 		params, ok := params.(map[string]any)
 		if !ok {
 			telemetrylog.Error("appsec: could not cast action params to map[string]any from %T", params)

--- a/instrumentation/appsec/emitter/waf/actions/block.go
+++ b/instrumentation/appsec/emitter/waf/actions/block.go
@@ -37,7 +37,7 @@ func init() {
 	for env, template := range map[string]*[]byte{envBlockedTemplateJSON: &blockedTemplateJSON, envBlockedTemplateHTML: &blockedTemplateHTML} {
 		if path, ok := os.LookupEnv(env); ok {
 			if t, err := os.ReadFile(path); err != nil {
-				log.Error("Could not read template at %s: %v", path, err)
+				log.Error("Could not read template at %s: %v", path, err.Error())
 			} else {
 				*template = t
 			}

--- a/instrumentation/appsec/trace/service_entry_span.go
+++ b/instrumentation/appsec/trace/service_entry_span.go
@@ -152,7 +152,7 @@ func (op *ServiceEntrySpanOperation) Finish() {
 	for k, v := range op.jsonTags {
 		strValue, err := json.Marshal(v)
 		if err != nil {
-			log.Debug("appsec: failed to marshal tag %s: %v", k, err)
+			log.Debug("appsec: failed to marshal tag %s: %v", k, err.Error())
 			continue
 		}
 		span.SetTag(k, string(strValue))

--- a/instrumentation/graphql/graphql.go
+++ b/instrumentation/graphql/graphql.go
@@ -113,7 +113,7 @@ func setErrExtensions(result map[string]any, extensions map[string]any, whitelis
 		key := fmt.Sprintf("extensions.%s", errExt)
 		mapVal, err := errExtensionMapValue(val)
 		if err != nil {
-			log.Debug("failed to set error extension as span event attribute %s: %v", errExt, err)
+			log.Debug("failed to set error extension as span event attribute %s: %v", errExt, err.Error())
 			continue
 		}
 		result[key] = mapVal

--- a/instrumentation/httptrace/config.go
+++ b/instrumentation/httptrace/config.go
@@ -6,6 +6,7 @@
 package httptrace
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"strconv"
@@ -39,6 +40,10 @@ type config struct {
 	traceClientIP                bool
 	isStatusError                func(statusCode int) bool
 	inferredProxyServicesEnabled bool
+}
+
+func (c config) String() string {
+	return fmt.Sprintf("config{queryString: %t, traceClientIP: %t, inferredProxyServicesEnabled: %t}", c.queryString, c.traceClientIP, c.inferredProxyServicesEnabled)
 }
 
 // ResetCfg sets local variable cfg back to its defaults (mainly useful for testing)
@@ -96,24 +101,24 @@ func GetErrorCodesFromInput(s string) func(statusCode int) bool {
 		if strings.Contains(val, "-") {
 			bounds := strings.Split(val, "-")
 			if len(bounds) != 2 {
-				log.Debug("Trouble parsing %v due to entry %v, using default error status determination logic", s, val)
+				log.Debug("Trouble parsing %s due to entry %s, using default error status determination logic", s, val)
 				return nil
 			}
 			before, err := strconv.Atoi(bounds[0])
 			if err != nil {
-				log.Debug("Trouble parsing %v due to entry %v, using default error status determination logic", s, val)
+				log.Debug("Trouble parsing %s due to entry %s, using default error status determination logic", s, val)
 				return nil
 			}
 			after, err := strconv.Atoi(bounds[1])
 			if err != nil {
-				log.Debug("Trouble parsing %v due to entry %v, using default error status determination logic", s, val)
+				log.Debug("Trouble parsing %s due to entry %s, using default error status determination logic", s, val)
 				return nil
 			}
 			ranges = append(ranges, []int{before, after})
 		} else {
 			intVal, err := strconv.Atoi(val)
 			if err != nil {
-				log.Debug("Trouble parsing %v due to entry %v, using default error status determination logic", s, val)
+				log.Debug("Trouble parsing %s due to entry %s, using default error status determination logic", s, val)
 				return nil
 			}
 			codes = append(codes, intVal)

--- a/instrumentation/httptrace/httptrace.go
+++ b/instrumentation/httptrace/httptrace.go
@@ -50,7 +50,7 @@ func StartRequestSpan(r *http.Request, opts ...tracer.StartSpanOption) (*tracer.
 	// is not initialized yet
 	reportTelemetryConfigOnce.Do(func() {
 		telemetry.RegisterAppConfig("inferred_proxy_services_enabled", cfg.inferredProxyServicesEnabled, telemetry.OriginEnvVar)
-		log.Debug("internal/httptrace: telemetry.RegisterAppConfig called with cfg: %v", cfg)
+		log.Debug("internal/httptrace: telemetry.RegisterAppConfig called with cfg: %s", cfg)
 	})
 
 	var ipTags map[string]string

--- a/instrumentation/logger.go
+++ b/instrumentation/logger.go
@@ -28,19 +28,19 @@ func newLogger(pkg Package) *logger {
 }
 
 func (l logger) Debug(msg string, args ...any) {
-	log.Debug(msg, args...)
+	log.Debug(msg, args...) //nolint:gocritic // Logger plumbing needs to pass through variable format strings
 }
 
 func (l logger) Info(msg string, args ...any) {
-	log.Info(msg, args...)
+	log.Info(msg, args...) //nolint:gocritic // Logger plumbing needs to pass through variable format strings
 }
 
 func (l logger) Warn(msg string, args ...any) {
-	log.Warn(msg, args...)
+	log.Warn(msg, args...) //nolint:gocritic // Logger plumbing needs to pass through variable format strings
 }
 
 func (l logger) Error(msg string, args ...any) {
-	log.Error(msg, args...)
+	log.Error(msg, args...) //nolint:gocritic // Logger plumbing needs to pass through variable format strings
 }
 
 func hasErrors(args ...any) bool {

--- a/instrumentation/net/http/pattern/pattern.go
+++ b/instrumentation/net/http/pattern/pattern.go
@@ -50,7 +50,7 @@ func patternNames(pattern string) []string {
 		if err != nil {
 			// Ignore the error: Something as gone wrong, but we are not eager to find out why.
 			// We will just log it as a telemetry logs warning (and Debug to the user-facing log).
-			log.Warn("instrumentation/net/http/pattern: failed to parse mux path pattern %q: %v", pattern, err)
+			log.Warn("instrumentation/net/http/pattern: failed to parse mux path pattern %q: %s", pattern, err)
 			// here we fallthrough instead of returning to load a nil value into the cache to avoid reparsing the pattern.
 		}
 		return segments

--- a/internal/agent.go
+++ b/internal/agent.go
@@ -34,7 +34,7 @@ func AgentURLFromEnv() *url.URL {
 	if agentURL := os.Getenv("DD_TRACE_AGENT_URL"); agentURL != "" {
 		u, err := url.Parse(agentURL)
 		if err != nil {
-			log.Warn("Failed to parse DD_TRACE_AGENT_URL: %v", err)
+			log.Warn("Failed to parse DD_TRACE_AGENT_URL: %v", err.Error())
 		} else {
 			switch u.Scheme {
 			case "unix", "http", "https":

--- a/internal/appsec/appsec.go
+++ b/internal/appsec/appsec.go
@@ -64,14 +64,14 @@ func Start(opts ...config.StartOption) {
 	}
 
 	// Check whether libddwaf - required for Threats Detection - is ok or not
-	if ok, err := libddwaf.Usable(); !ok {
+	if ok, err := libddwaf.Usable(); !ok && err != nil {
 		// We need to avoid logging an error to APM tracing users who don't necessarily intend to enable appsec
 		if mode == config.ForcedOn {
 			logUnexpectedStartError(err)
 		} else {
 			// DD_APPSEC_ENABLED is not set so we cannot know what the intent is here, we must log a
 			// debug message instead to avoid showing an error to APM-tracing-only users.
-			telemetrylog.Error("appsec: remote activation of threats detection cannot be enabled for the following reasons: %v", err)
+			telemetrylog.Error("appsec: remote activation of threats detection cannot be enabled for the following reasons: %s", err)
 		}
 		return
 	}
@@ -87,7 +87,7 @@ func Start(opts ...config.StartOption) {
 	// Start the remote configuration client
 	log.Debug("appsec: starting the remote configuration client")
 	if err := appsec.startRC(); err != nil {
-		telemetrylog.Error("appsec: Remote config: disabled due to an instanciation error: %v", err)
+		telemetrylog.Error("appsec: Remote config: disabled due to an instanciation error: %s", err)
 	}
 
 	if mode == config.RCStandby {
@@ -116,7 +116,7 @@ func Start(opts ...config.StartOption) {
 
 // Implement the AppSec log message C1
 func logUnexpectedStartError(err error) {
-	log.Error("appsec: could not start because of an unexpected error: %v\nNo security activities will be collected. Please contact support at https://docs.datadoghq.com/help/ for help.", err)
+	log.Error("appsec: could not start because of an unexpected error: %v\nNo security activities will be collected. Please contact support at https://docs.datadoghq.com/help/ for help.", err.Error())
 	telemetry.Log(telemetry.LogError, fmt.Sprintf("appsec: could not start because of an unexpected error: %v", err), telemetry.WithTags([]string{"product:appsec"}))
 	telemetry.ProductStartError(telemetry.NamespaceAppSec, err)
 }
@@ -165,7 +165,7 @@ func (a *appsec) start() error {
 			return fmt.Errorf("error while loading libddwaf: %w", err)
 		}
 		// 2. If there is an error and the loading is ok: log as an informative error where appsec can be used
-		log.Error("appsec: non-critical error while loading libddwaf: %v", err)
+		log.Error("appsec: non-critical error while loading libddwaf: %v", err.Error())
 	}
 
 	// Register dyngo listeners
@@ -220,7 +220,7 @@ func init() {
 		Warn:  log.Warn,
 		Errorf: func(s string, a ...any) error {
 			err := fmt.Errorf(s, a...)
-			log.Error("%v", err)
+			log.Error("%v", err.Error())
 			return err
 		},
 	})

--- a/internal/appsec/config/config.go
+++ b/internal/appsec/config/config.go
@@ -28,7 +28,7 @@ func init() {
 func registerSCAAppConfigTelemetry() {
 	val, origin, err := stableconfig.Bool(EnvSCAEnabled, false)
 	if err != nil {
-		log.Error("appsec: %v", err)
+		log.Error("appsec: %s", err)
 		return
 	}
 	if origin != telemetry.OriginDefault {

--- a/internal/appsec/emitter/waf/metrics.go
+++ b/internal/appsec/emitter/waf/metrics.go
@@ -203,7 +203,7 @@ func (m *ContextMetrics) Submit(truncations map[libddwaf.TruncationReason][]int,
 		// Add metrics `{waf,rasp}.duration_ext`
 		metric, found := m.externalTimerDistributions[scope]
 		if !found {
-			telemetrylog.Error("unexpected scope name: %v", scope, telemetry.WithTags([]string{"product:appsec"}))
+			telemetrylog.Error("unexpected scope name: %s", scope, telemetry.WithTags([]string{"product:appsec"}))
 			continue
 		}
 
@@ -327,7 +327,7 @@ func (m *ContextMetrics) RegisterWafRun(addrs libddwaf.RunAddressData, timerStat
 			m.Milestones.wafError = true
 		}
 	default:
-		telemetrylog.Error("unexpected scope name: %v", addrs.TimerKey, telemetry.WithTags([]string{"product:appsec"}))
+		telemetrylog.Error("unexpected scope name: %s", addrs.TimerKey, telemetry.WithTags([]string{"product:appsec"}))
 	}
 }
 
@@ -341,7 +341,7 @@ func (m *ContextMetrics) IncWafError(addrs libddwaf.RunAddressData, in error) {
 	}
 
 	if !errors.Is(in, waferrors.ErrTimeout) {
-		telemetrylog.Error("unexpected WAF error: %v", in, telemetry.WithTags(append([]string{
+		telemetrylog.Error("unexpected WAF error: %s", in, telemetry.WithTags(append([]string{
 			"product:appsec",
 		}, m.baseTags...)))
 	}
@@ -350,13 +350,13 @@ func (m *ContextMetrics) IncWafError(addrs libddwaf.RunAddressData, in error) {
 	case addresses.RASPScope:
 		ruleType, ok := addresses.RASPRuleTypeFromAddressSet(addrs)
 		if !ok {
-			telemetrylog.Error("unexpected call to RASPRuleTypeFromAddressSet: %v", in, telemetry.WithTags([]string{"product:appsec"}))
+			telemetrylog.Error("unexpected call to RASPRuleTypeFromAddressSet: %s", in, telemetry.WithTags([]string{"product:appsec"}))
 		}
 		m.raspError(in, ruleType)
 	case addresses.WAFScope, "":
 		m.wafError(in)
 	default:
-		telemetrylog.Error("unexpected scope name: %v", addrs.TimerKey, telemetry.WithTags([]string{"product:appsec"}))
+		telemetrylog.Error("unexpected scope name: %s", addrs.TimerKey, telemetry.WithTags([]string{"product:appsec"}))
 	}
 }
 

--- a/internal/appsec/emitter/waf/run.go
+++ b/internal/appsec/emitter/waf/run.go
@@ -42,7 +42,7 @@ func (op *ContextOperation) Run(eventReceiver dyngo.Operation, addrs libddwaf.Ru
 
 	result, err := ctx.Run(addrs)
 	if errors.Is(err, waferrors.ErrTimeout) {
-		log.Debug("appsec: WAF timeout value reached: %v", err)
+		log.Debug("appsec: WAF timeout value reached: %v", err.Error())
 	}
 
 	op.metrics.IncWafError(addrs, err)

--- a/internal/appsec/listener/waf/waf.go
+++ b/internal/appsec/listener/waf/waf.go
@@ -51,7 +51,7 @@ func NewWAFFeature(cfg *config.Config, rootOp dyngo.Operation) (listener.Feature
 			return nil, fmt.Errorf("error while loading libddwaf: %w", err)
 		}
 		// 2. If there is an error and the loading is ok: log as an informative error where appsec can be used
-		telemetrylog.Warn("appsec: non-critical error while loading libddwaf: %v", err, telemetry.WithTags([]string{"product:appsec"}))
+		telemetrylog.Warn("appsec: non-critical error while loading libddwaf: %s", err, telemetry.WithTags([]string{"product:appsec"}))
 	}
 
 	newHandle, rulesVersion := cfg.NewHandle()
@@ -94,7 +94,7 @@ func (waf *Feature) onStart(op *waf.ContextOperation, _ waf.ContextArgs) {
 
 	ctx, err := waf.handle.NewContext(timer.WithBudget(waf.timeout), timer.WithComponents(addresses.Scopes[:]...))
 	if err != nil {
-		log.Debug("appsec: failed to create WAF context: %v", err)
+		log.Debug("appsec: failed to create WAF context: %v", err.Error())
 	}
 
 	op.SwapContext(ctx)

--- a/internal/appsec/remoteconfig.go
+++ b/internal/appsec/remoteconfig.go
@@ -61,7 +61,7 @@ func (a *appsec) onRCRulesUpdate(updates map[string]remoteconfig.ProductUpdate) 
 				}
 				cfg := UpdatedConfig{Product: product}
 				if err := json.Unmarshal(data, &cfg.Content); err != nil {
-					log.Error("appsec: unmarshaling remote config update for %s (%q): %v", product, path, err)
+					log.Error("appsec: unmarshaling remote config update for %s (%q): %v", product, path, err.Error())
 					statuses[product] = state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()}
 					continue
 				}
@@ -93,7 +93,7 @@ func (a *appsec) onRCRulesUpdate(updates map[string]remoteconfig.ProductUpdate) 
 		log.Debug("appsec: remote config: adding/updating configuration %q", path)
 		diag, err := a.cfg.WAFManager.AddOrUpdateConfig(path, update.Content)
 		if err != nil {
-			log.Debug("appsec: remote config: error while adding/updating configuration %q: %v", path, err)
+			log.Debug("appsec: remote config: error while adding/updating configuration %q: %v", path, err.Error())
 			// Configuration object has been fully rejected; or there was an error processing it or parsing the diagnostics
 			// value. If we have a diagnostics object, encode all errors from the diagnostics object as a JSON value, as
 			// described by:
@@ -135,7 +135,7 @@ func (a *appsec) onRCRulesUpdate(updates map[string]remoteconfig.ProductUpdate) 
 				if data, err := json.Marshal(errs); err == nil {
 					errMsg = string(data)
 				} else {
-					telemetrylog.Error("appsec: remote config: failed to marshal error details: %v", err)
+					telemetrylog.Error("appsec: remote config: failed to marshal error details: %s", err)
 				}
 			}
 
@@ -149,7 +149,7 @@ func (a *appsec) onRCRulesUpdate(updates map[string]remoteconfig.ProductUpdate) 
 	if len(a.cfg.WAFManager.ConfigPaths(`^(?:datadog/\d+|employee)/ASM_DD/.+`)) == 0 {
 		log.Debug("appsec: remote config: no ASM_DD config loaded; restoring default config if available")
 		if err := a.cfg.WAFManager.RestoreDefaultConfig(); err != nil {
-			telemetrylog.Error("appsec: RC could not restore default config: %v", err)
+			telemetrylog.Error("appsec: RC could not restore default config: %s", err)
 		}
 	}
 
@@ -161,7 +161,7 @@ func (a *appsec) onRCRulesUpdate(updates map[string]remoteconfig.ProductUpdate) 
 	// If an error occurs while updating the WAF handle, don't swap the RulesManager and propagate the error
 	// to all config statuses since we can't know which config is the faulty one
 	if err := a.SwapRootOperation(); err != nil {
-		log.Error("appsec: remote config: could not apply the new security rules: %v", err)
+		log.Error("appsec: remote config: could not apply the new security rules: %v", err.Error())
 		for k := range statuses {
 			if statuses[k].State == state.ApplyStateError || statuses[k].State == state.ApplyStateUnacknowledged {
 				// Leave failed & un-acknowledged configs as-is... This failure is not related to these...
@@ -239,7 +239,7 @@ func (a *appsec) handleASMFeatures(u remoteconfig.ProductUpdate) map[string]stat
 	// Parse the config object we just received...
 	var parsed state.ASMFeaturesData
 	if err := json.Unmarshal(raw, &parsed); err != nil {
-		log.Error("appsec: remote config: error while unmarshalling %s: %v. Configuration won't be applied.", path, err)
+		log.Error("appsec: remote config: error while unmarshalling %s: %v. Configuration won't be applied.", path, err.Error())
 		return map[string]state.ApplyStatus{path: {State: state.ApplyStateError, Error: err.Error()}}
 	}
 
@@ -247,7 +247,7 @@ func (a *appsec) handleASMFeatures(u remoteconfig.ProductUpdate) map[string]stat
 	if parsed.ASM.Enabled && !a.started {
 		log.Debug("appsec: remote config: Starting AppSec")
 		if err := a.start(); err != nil {
-			log.Error("appsec: remote config: error while processing %s. Configuration won't be applied: %v", path, err)
+			log.Error("appsec: remote config: error while processing %s. Configuration won't be applied: %v", path, err.Error())
 			return map[string]state.ApplyStatus{path: {State: state.ApplyStateError, Error: err.Error()}}
 		}
 	}
@@ -336,18 +336,18 @@ func (a *appsec) enableRCBlocking() {
 	products := []string{state.ProductASM, state.ProductASMDD, state.ProductASMData}
 	for _, p := range products {
 		if err := a.registerRCProduct(p); err != nil {
-			log.Debug("appsec: remote config: couldn't register product %s: %v", p, err)
+			log.Debug("appsec: remote config: couldn't register product %s: %v", p, err.Error())
 		}
 	}
 
 	log.Debug("appsec: remote config: registering onRCRulesUpdate callback")
 	if err := remoteconfig.RegisterCallback(a.onRCRulesUpdate); err != nil {
-		log.Debug("appsec: remote config: couldn't register callback: %v", err)
+		log.Debug("appsec: remote config: couldn't register callback: %v", err.Error())
 	}
 
 	for _, c := range baseCapabilities {
 		if err := a.registerRCCapability(c); err != nil {
-			log.Debug("appsec: remote config: couldn't register capability %v: %v", c, err)
+			log.Debug("appsec: remote config: couldn't register capability %d: %v", c, err.Error())
 		}
 	}
 
@@ -358,7 +358,7 @@ func (a *appsec) enableRCBlocking() {
 	if !a.cfg.BlockingUnavailable {
 		for _, c := range blockingCapabilities {
 			if err := a.registerRCCapability(c); err != nil {
-				log.Debug("appsec: remote config: couldn't register capability %v: %v", c, err)
+				log.Debug("appsec: remote config: couldn't register capability %d: %v", c, err.Error())
 			}
 		}
 	}
@@ -369,14 +369,14 @@ func (a *appsec) enableRASP() {
 		return
 	}
 	if err := remoteconfig.RegisterCapability(remoteconfig.ASMRASPSSRF); err != nil {
-		log.Debug("appsec: remote config: couldn't register RASP SSRF: %v", err)
+		log.Debug("appsec: remote config: couldn't register RASP SSRF: %v", err.Error())
 	}
 	if err := remoteconfig.RegisterCapability(remoteconfig.ASMRASPSQLI); err != nil {
-		log.Debug("appsec: remote config: couldn't register RASP SQLI: %v", err)
+		log.Debug("appsec: remote config: couldn't register RASP SQLI: %v", err.Error())
 	}
 	if orchestrion.Enabled() {
 		if err := remoteconfig.RegisterCapability(remoteconfig.ASMRASPLFI); err != nil {
-			log.Debug("appsec: remote config: couldn't register RASP LFI: %v", err)
+			log.Debug("appsec: remote config: couldn't register RASP LFI: %v", err.Error())
 		}
 	}
 }
@@ -387,17 +387,17 @@ func (a *appsec) disableRCBlocking() {
 	}
 	for _, c := range baseCapabilities {
 		if err := a.unregisterRCCapability(c); err != nil {
-			log.Debug("appsec: remote config: couldn't unregister capability %v: %v", c, err)
+			log.Debug("appsec: remote config: couldn't unregister capability %d: %v", c, err.Error())
 		}
 	}
 	if !a.cfg.BlockingUnavailable {
 		for _, c := range blockingCapabilities {
 			if err := a.unregisterRCCapability(c); err != nil {
-				log.Debug("appsec: remote config: couldn't unregister capability %v: %v", c, err)
+				log.Debug("appsec: remote config: couldn't unregister capability %d: %v", c, err.Error())
 			}
 		}
 	}
 	if err := remoteconfig.UnregisterCallback(a.onRCRulesUpdate); err != nil {
-		log.Debug("appsec: remote config: couldn't unregister callback: %v", err)
+		log.Debug("appsec: remote config: couldn't unregister callback: %v", err.Error())
 	}
 }

--- a/internal/appsec/telemetry.go
+++ b/internal/appsec/telemetry.go
@@ -68,7 +68,7 @@ func detectLibDL() {
 			telemetry.RegisterAppConfig("libdl_present", true, telemetry.OriginCode)
 			return
 		} else if err != nil {
-			log.Debug("failed to detect libdl with method %s: %v", method.name, err)
+			log.Debug("failed to detect libdl with method %s: %v", method.name, err.Error())
 		}
 	}
 

--- a/internal/civisibility/integrations/civisibility_features.go
+++ b/internal/civisibility/integrations/civisibility_features.go
@@ -85,9 +85,9 @@ func ensureSettingsInitialization(serviceName string) {
 		go func() {
 			bytes, err := uploadRepositoryChanges()
 			if err != nil {
-				log.Error("civisibility: error uploading repository changes: %v", err)
+				log.Error("civisibility: error uploading repository changes: %v", err.Error())
 			} else {
-				log.Debug("civisibility: uploaded %v bytes in pack files", bytes)
+				log.Debug("civisibility: uploaded %d bytes in pack files", bytes)
 			}
 			uploadChannel <- struct{}{}
 		}()
@@ -95,7 +95,7 @@ func ensureSettingsInitialization(serviceName string) {
 		// Get the CI Visibility settings payload for this test session
 		ciSettings, err := ciVisibilityClient.GetSettings()
 		if err != nil || ciSettings == nil {
-			log.Error("civisibility: error getting CI visibility settings: %v", err)
+			log.Error("civisibility: error getting CI visibility settings: %v", err.Error())
 			log.Debug("civisibility: no need to wait for the git upload to finish")
 			// Enqueue a close action to wait for the upload to finish before finishing the process
 			PushCiVisibilityCloseAction(func() {
@@ -110,7 +110,7 @@ func ensureSettingsInitialization(serviceName string) {
 			<-uploadChannel
 			ciSettings, err = ciVisibilityClient.GetSettings()
 			if err != nil {
-				log.Error("civisibility: error getting CI visibility settings: %v", err)
+				log.Error("civisibility: error getting CI visibility settings: %v", err.Error())
 				return
 			}
 		} else if ciSettings.ImpactedTestsEnabled {
@@ -173,7 +173,7 @@ func ensureAdditionalFeaturesInitialization(_ string) {
 		additionalTags := make(map[string]string)
 		defer func() {
 			if len(additionalTags) > 0 {
-				log.Debug("civisibility: adding additional tags: %v", additionalTags)
+				log.Debug("civisibility: adding additional tags: %v", additionalTags) //nolint:gocritic // Map structure logging for debugging
 				utils.AddCITagsMap(additionalTags)
 			}
 		}()
@@ -204,7 +204,7 @@ func ensureAdditionalFeaturesInitialization(_ string) {
 				TotalRetryCount:          totalRetriesCount,
 				RemainingTotalRetryCount: totalRetriesCount,
 			}
-			log.Debug("civisibility: automatic test retries enabled [retryCount: %v, totalRetryCount: %v]", retryCount, totalRetriesCount)
+			log.Debug("civisibility: automatic test retries enabled [retryCount: %d, totalRetryCount: %d]", retryCount, totalRetriesCount)
 		}
 
 		// wait group to wait for all the additional features to be loaded
@@ -217,7 +217,7 @@ func ensureAdditionalFeaturesInitialization(_ string) {
 				defer wg.Done()
 				ciEfdData, err := ciVisibilityClient.GetKnownTests()
 				if err != nil {
-					log.Error("civisibility: error getting CI visibility known tests data: %v", err)
+					log.Error("civisibility: error getting CI visibility known tests data: %v", err.Error())
 				} else if ciEfdData != nil {
 					ciVisibilityKnownTests = *ciEfdData
 					log.Debug("civisibility: known tests data loaded.")
@@ -233,7 +233,7 @@ func ensureAdditionalFeaturesInitialization(_ string) {
 				// get the skippable tests
 				correlationID, skippableTests, err := ciVisibilityClient.GetSkippableTests()
 				if err != nil {
-					log.Error("civisibility: error getting CI visibility skippable tests: %v", err)
+					log.Error("civisibility: error getting CI visibility skippable tests: %v", err.Error())
 				} else if skippableTests != nil {
 					log.Debug("civisibility: skippable tests loaded: %d suites", len(skippableTests))
 					setAdditionalTags(constants.ItrCorrelationIDTag, correlationID)
@@ -249,10 +249,10 @@ func ensureAdditionalFeaturesInitialization(_ string) {
 				defer wg.Done()
 				testManagementTests, err := ciVisibilityClient.GetTestManagementTests()
 				if err != nil {
-					log.Error("civisibility: error getting CI visibility test management tests: %v", err)
+					log.Error("civisibility: error getting CI visibility test management tests: %v", err.Error())
 				} else if testManagementTests != nil {
 					ciVisibilityTestManagementTests = *testManagementTests
-					log.Debug("civisibility: test management loaded [attemptToFixRetries: %v]", currentSettings.TestManagement.AttemptToFixRetries)
+					log.Debug("civisibility: test management loaded [attemptToFixRetries: %d]", currentSettings.TestManagement.AttemptToFixRetries)
 				}
 			}()
 		}
@@ -265,7 +265,7 @@ func ensureAdditionalFeaturesInitialization(_ string) {
 				defer wg.Done()
 				iTests, err := impactedtests.NewImpactedTestAnalyzer()
 				if err != nil {
-					log.Error("civisibility: error getting CI visibility impacted tests analyzer: %v", err)
+					log.Error("civisibility: error getting CI visibility impacted tests analyzer: %v", err.Error())
 				} else {
 					ciVisibilityImpactedTestsAnalyzer = iTests
 					log.Debug("civisibility: impacted tests analyzer loaded")
@@ -351,7 +351,7 @@ func uploadRepositoryChanges() (bytes int64, err error) {
 	hasBeenUnshallowed, err := utils.UnshallowGitRepository()
 	if err != nil || !hasBeenUnshallowed {
 		if err != nil {
-			log.Warn("%v", err)
+			log.Warn("%v", err.Error())
 		}
 		// if unshallowing the repository failed or if there's nothing to unshallow then we try to upload the packfiles from
 		// the initial commit data
@@ -423,7 +423,7 @@ func sendObjectsPackFile(commitSha string, commitsToInclude []string, commitsToE
 	}
 
 	// send the pack files
-	log.Debug("civisibility: sending pack file with missing commits. files: %v", packFiles)
+	log.Debug("civisibility: sending pack file with missing commits. files: %v", packFiles) //nolint:gocritic // File list logging for debugging
 
 	// try to remove the pack files after sending them
 	defer func(files []string) {

--- a/internal/civisibility/integrations/gotesting/coverage/coverage_payload.go
+++ b/internal/civisibility/integrations/gotesting/coverage/coverage_payload.go
@@ -162,7 +162,7 @@ func (p *coveragePayload) Read(b []byte) (n int, err error) {
 //	An error if reading from the buffer or encoding the payload fails.
 func (p *coveragePayload) getBuffer() (*bytes.Buffer, error) {
 	startTime := time.Now()
-	log.Debug("coveragePayload: .getBuffer (count: %v)", p.itemCount())
+	log.Debug("coveragePayload: .getBuffer (count: %d)", p.itemCount())
 
 	// Create a buffer to read the current payload
 	payloadBuf := new(bytes.Buffer)

--- a/internal/civisibility/integrations/gotesting/coverage/coverage_writer.go
+++ b/internal/civisibility/integrations/gotesting/coverage/coverage_writer.go
@@ -48,7 +48,7 @@ func (w *coverageWriter) add(coverage *testCoverage) {
 	telemetry.EventsEnqueueForSerialization()
 	ciTestCoverage := newCiTestCoverageData(coverage)
 	if err := w.payload.push(ciTestCoverage); err != nil {
-		log.Error("coverageWriter: Error encoding msgpack: %v", err)
+		log.Error("coverageWriter: Error encoding msgpack: %v", err.Error())
 	}
 	if w.payload.size() > agentlessPayloadSizeLimit {
 		w.flush()
@@ -88,14 +88,14 @@ func (w *coverageWriter) flush() {
 
 		buf, err := p.getBuffer()
 		if err != nil {
-			log.Error("coverageWriter: failure getting coverage data: %v", err)
+			log.Error("coverageWriter: failure getting coverage data: %v", err.Error())
 			return
 		}
 
 		telemetry.CodeCoverageFiles(float64(p.itemCount()))
 		err = w.client.SendCoveragePayload(buf)
 		if err != nil {
-			log.Error("coverageWriter: failure sending coverage data: %v", err)
+			log.Error("coverageWriter: failure sending coverage data: %v", err.Error())
 		}
 	}(oldp)
 }

--- a/internal/civisibility/integrations/gotesting/coverage/test_coverage.go
+++ b/internal/civisibility/integrations/gotesting/coverage/test_coverage.go
@@ -88,7 +88,7 @@ func InitializeCoverage(m *testing.M) {
 	log.Debug("civisibility.cov: initializing runtime coverage")
 	testDep, err := getTestDepsCoverage(m)
 	if err != nil || testDep == nil {
-		log.Debug("civisibility.cov: error initializing runtime coverage: %v", err)
+		log.Debug("civisibility.cov: error initializing runtime coverage: %v", err.Error())
 		return
 	}
 
@@ -114,7 +114,7 @@ func InitializeCoverage(m *testing.M) {
 	// create a temporary directory to store coverage files
 	temporaryDir, err = os.MkdirTemp("", "coverage")
 	if err != nil {
-		log.Debug("civisibility.cov: error creating temporary directory: %v", err)
+		log.Debug("civisibility.cov: error creating temporary directory: %v", err.Error())
 	} else {
 		log.Debug("civisibility.cov: temporary coverage directory created: %s", temporaryDir)
 	}
@@ -125,7 +125,7 @@ func InitializeCoverage(m *testing.M) {
 	// executing go list -f '{{.Module.Path}};{{.Module.Dir}}' to get the module path and module dir
 	stdOut, err := exec.Command("go", "list", "-f", "{{.Module.Path}};{{.Module.Dir}}").CombinedOutput()
 	if err != nil {
-		log.Debug("civisibility.cov: error getting module path and module dir: %v", err)
+		log.Debug("civisibility.cov: error getting module path and module dir: %v", err.Error())
 	} else {
 		parts := strings.Split(string(stdOut), ";")
 		if len(parts) == 2 {
@@ -149,19 +149,19 @@ func GetCoverage() float64 {
 	coverageFile := filepath.Join(temporaryDir, "global_coverage.out")
 	_, err := tearDown(coverageFile, "")
 	if err != nil {
-		log.Debug("civisibility.cov: error getting coverage file: %v", err)
+		log.Debug("civisibility.cov: error getting coverage file: %v", err.Error())
 	}
 
 	defer func(cFile string) {
 		err = os.Remove(cFile)
 		if err != nil {
-			log.Debug("civisibility.cov: error removing coverage file: %v", err)
+			log.Debug("civisibility.cov: error removing coverage file: %v", err.Error())
 		}
 	}(coverageFile)
 
 	totalStatements, coveredStatements, err := getCoverageStatementsInfo(coverageFile)
 	if err != nil {
-		log.Debug("civisibility.cov: error parsing coverage file: %v", err)
+		log.Debug("civisibility.cov: error parsing coverage file: %v", err.Error())
 	}
 
 	if totalStatements == 0 {
@@ -192,7 +192,7 @@ func (t *testCoverage) CollectCoverageBeforeTestExecution() {
 	t.preCoverageFilename = filepath.Join(temporaryDir, fmt.Sprintf("%d-%d-%d-pre.out", t.moduleID, t.suiteID, t.testID))
 	_, err := tearDown(t.preCoverageFilename, "")
 	if err != nil {
-		log.Debug("civisibility.cov: error getting coverage file: %v", err)
+		log.Debug("civisibility.cov: error getting coverage file: %v", err.Error())
 		telemetry.CodeCoverageErrors()
 	} else {
 		telemetry.CodeCoverageStarted(testFramework, telemetry.DefaultCoverageLibraryType)
@@ -224,7 +224,7 @@ func (t *testCoverage) getCoverageData() error {
 	t.postCoverageFilename = filepath.Join(temporaryDir, fmt.Sprintf("%d-%d-%d-post.out", t.moduleID, t.suiteID, t.testID))
 	_, err := tearDown(t.postCoverageFilename, "")
 	if err != nil {
-		log.Debug("civisibility.cov: error getting coverage file: %v", err)
+		log.Debug("civisibility.cov: error getting coverage file: %v", err.Error())
 		telemetry.CodeCoverageErrors()
 	}
 
@@ -242,13 +242,13 @@ func (t *testCoverage) processCoverageData() {
 	}
 	preCoverage, err := parseCoverProfile(t.preCoverageFilename)
 	if err != nil {
-		log.Debug("civisibility.cov: error parsing pre-coverage file: %v", err)
+		log.Debug("civisibility.cov: error parsing pre-coverage file: %v", err.Error())
 		telemetry.CodeCoverageErrors()
 		return
 	}
 	postCoverage, err := parseCoverProfile(t.postCoverageFilename)
 	if err != nil {
-		log.Debug("civisibility.cov: error parsing post-coverage file: %v", err)
+		log.Debug("civisibility.cov: error parsing post-coverage file: %v", err.Error())
 		telemetry.CodeCoverageErrors()
 		return
 	}
@@ -263,12 +263,12 @@ func (t *testCoverage) processCoverageData() {
 
 	err = os.Remove(t.preCoverageFilename)
 	if err != nil {
-		log.Debug("civisibility.cov: error removing pre-coverage file: %v", err)
+		log.Debug("civisibility.cov: error removing pre-coverage file: %v", err.Error())
 	}
 
 	err = os.Remove(t.postCoverageFilename)
 	if err != nil {
-		log.Debug("civisibility.cov: error removing post-coverage file: %v", err)
+		log.Debug("civisibility.cov: error removing post-coverage file: %v", err.Error())
 	}
 }
 

--- a/internal/civisibility/integrations/logs/logs_writer.go
+++ b/internal/civisibility/integrations/logs/logs_writer.go
@@ -47,7 +47,7 @@ func newLogsWriter() *logsWriter {
 
 func (w *logsWriter) add(entry *logEntry) {
 	if err := w.payload.push(entry); err != nil {
-		log.Error("logsWriter: Error encoding msgpack: %v", err)
+		log.Error("logsWriter: Error encoding msgpack: %v", err.Error())
 	}
 	if w.payload.size() > agentlessPayloadSizeLimit {
 		w.flush()
@@ -87,7 +87,7 @@ func (w *logsWriter) flush() {
 
 		err := w.client.SendLogs(p)
 		if err != nil {
-			log.Error("logsWriter: failure sending logs data data: %v", err)
+			log.Error("logsWriter: failure sending logs data data: %v", err.Error())
 		}
 	}(oldp)
 }

--- a/internal/civisibility/utils/ci_providers.go
+++ b/internal/civisibility/utils/ci_providers.go
@@ -80,7 +80,7 @@ func getProviderTags() map[string]string {
 
 	if log.DebugEnabled() {
 		if providerName, ok := tags[constants.CIProviderName]; ok {
-			log.Debug("civisibility: detected ci provider: %v", providerName)
+			log.Debug("civisibility: detected ci provider: %s", providerName)
 		} else {
 			log.Debug("civisibility: no ci provider was detected.")
 		}

--- a/internal/civisibility/utils/codeowners.go
+++ b/internal/civisibility/utils/codeowners.go
@@ -99,7 +99,7 @@ func parseCodeOwners(filePath string) (*CodeOwners, error) {
 	cow, err := NewCodeOwners(filePath)
 	if err == nil {
 		if logger.DebugEnabled() {
-			logger.Debug("civisibility: codeowner file '%v' was loaded successfully.", filePath)
+			logger.Debug("civisibility: codeowner file '%s' was loaded successfully.", filePath)
 		}
 		return cow, nil
 	}

--- a/internal/civisibility/utils/environmentTags.go
+++ b/internal/civisibility/utils/environmentTags.go
@@ -227,9 +227,9 @@ func createCITagsMap() map[string]string {
 	localTags[constants.OSArchitecture] = runtime.GOARCH
 	localTags[constants.RuntimeName] = runtime.Compiler
 	localTags[constants.RuntimeVersion] = runtime.Version()
-	log.Debug("civisibility: os platform: %v", runtime.GOOS)
-	log.Debug("civisibility: os architecture: %v", runtime.GOARCH)
-	log.Debug("civisibility: runtime version: %v", runtime.Version())
+	log.Debug("civisibility: os platform: %s", runtime.GOOS)
+	log.Debug("civisibility: os architecture: %s", runtime.GOARCH)
+	log.Debug("civisibility: runtime version: %s", runtime.Version())
 
 	// Get command line test command
 	var cmd string
@@ -245,7 +245,7 @@ func createCITagsMap() map[string]string {
 	cmd = regexp.MustCompile(`(?si)-test.testlogfile=(.*)\s`).ReplaceAllString(cmd, "")
 	cmd = strings.TrimSpace(cmd)
 	localTags[constants.TestCommand] = cmd
-	log.Debug("civisibility: test command: %v", cmd)
+	log.Debug("civisibility: test command: %s", cmd)
 
 	// Populate the test session name
 	if testSessionName, ok := os.LookupEnv(constants.CIVisibilityTestSessionNameEnvironmentVariable); ok {
@@ -255,7 +255,7 @@ func createCITagsMap() map[string]string {
 	} else {
 		localTags[constants.TestSessionName] = cmd
 	}
-	log.Debug("civisibility: test session name: %v", localTags[constants.TestSessionName])
+	log.Debug("civisibility: test session name: %s", localTags[constants.TestSessionName])
 
 	// Check if the user provided the test service
 	if ddService := os.Getenv("DD_SERVICE"); ddService != "" {
@@ -309,8 +309,8 @@ func createCITagsMap() map[string]string {
 	// Apply environmental data if is available
 	applyEnvironmentalDataIfRequired(localTags)
 
-	log.Debug("civisibility: workspace directory: %v", localTags[constants.CIWorkspacePath])
-	log.Debug("civisibility: common tags created with %v items", len(localTags))
+	log.Debug("civisibility: workspace directory: %s", localTags[constants.CIWorkspacePath])
+	log.Debug("civisibility: common tags created with %d items", len(localTags))
 	return localTags
 }
 
@@ -323,6 +323,6 @@ func createCIMetricsMap() map[string]float64 {
 	localMetrics := make(map[string]float64)
 	localMetrics[constants.LogicalCPUCores] = float64(runtime.NumCPU())
 
-	log.Debug("civisibility: common metrics created with %v items", len(localMetrics))
+	log.Debug("civisibility: common metrics created with %d items", len(localMetrics))
 	return localMetrics
 }

--- a/internal/civisibility/utils/file_environmental_data.go
+++ b/internal/civisibility/utils/file_environmental_data.go
@@ -84,13 +84,13 @@ func getEnvironmentalData() *fileEnvironmentalData {
 	}
 	file, err := os.Open(envDataFileName)
 	if err != nil {
-		logger.Error("civisibility: error reading environmental data from %s: %v", envDataFileName, err)
+		logger.Error("civisibility: error reading environmental data from %s: %v", envDataFileName, err.Error())
 		return nil
 	}
 	defer file.Close()
 	var envData fileEnvironmentalData
 	if err := json.NewDecoder(file).Decode(&envData); err != nil {
-		logger.Error("civisibility: error decoding environmental data from %s: %v", envDataFileName, err)
+		logger.Error("civisibility: error decoding environmental data from %s: %v", envDataFileName, err.Error())
 		return nil
 	}
 	logger.Debug("civisibility: loaded environmental data from %s", envDataFileName)

--- a/internal/civisibility/utils/home.go
+++ b/internal/civisibility/utils/home.go
@@ -59,7 +59,7 @@ func ExpandPath(path string) string {
 //	The home directory of the current user.
 func getHomeDir() (homeDir string) {
 	defer func() {
-		log.Debug("civisibility: home directory: %v", homeDir)
+		log.Debug("civisibility: home directory: %s", homeDir)
 	}()
 
 	if runtime.GOOS == "windows" {

--- a/internal/civisibility/utils/impactedtests/impacted_tests.go
+++ b/internal/civisibility/utils/impactedtests/impacted_tests.go
@@ -93,7 +93,7 @@ func NewImpactedTestAnalyzer() (*ImpactedTestAnalyzer, error) {
 		modifiedFiles = []fileWithBitmap{}
 	}
 
-	logger.Debug("civisibility.ImpactedTests: loaded [from: %s to %s]: %v", baseCommitSha, currentCommitSha, modifiedFiles)
+	logger.Debug("civisibility.ImpactedTests: loaded [from: %s to %s]: %v", baseCommitSha, currentCommitSha, modifiedFiles) //nolint:gocritic // File list debug logging
 	return &ImpactedTestAnalyzer{
 		modifiedFiles:    modifiedFiles,
 		currentCommitSha: currentCommitSha,

--- a/internal/civisibility/utils/net/client.go
+++ b/internal/civisibility/utils/net/client.go
@@ -206,7 +206,7 @@ func NewClientWithServiceNameAndSubdomain(serviceName, subdomain string) Client 
 	defaultHeaders["trace_id"] = id
 	defaultHeaders["parent_id"] = id
 
-	log.Debug("ciVisibilityHttpClient: new client created [id: %v, agentless: %v, url: %v, env: %v, serviceName: %v, subdomain: %v]",
+	log.Debug("ciVisibilityHttpClient: new client created [id: %s, agentless: %t, url: %s, env: %s, serviceName: %s, subdomain: %s]",
 		id, agentlessEnabled, baseURL, environment, serviceName, subdomain)
 
 	if !telemetry.Disabled() {
@@ -230,7 +230,7 @@ func NewClientWithServiceNameAndSubdomain(serviceName, subdomain string) Client 
 			}
 			client, err := telemetry.NewClient(serviceName, environment, os.Getenv("DD_VERSION"), cfg)
 			if err != nil {
-				log.Debug("civisibility: failed to create telemetry client: %v", err)
+				log.Debug("civisibility: failed to create telemetry client: %v", err.Error())
 				return
 			}
 			telemetry.StartApp(client)

--- a/internal/civisibility/utils/net/http.go
+++ b/internal/civisibility/utils/net/http.go
@@ -167,12 +167,12 @@ func (rh *RequestHandler) internalSendRequest(config *RequestConfig, attempt int
 		}
 
 		if log.DebugEnabled() {
-			var files []string
+			var fileNames []string
 			for _, f := range config.Files {
-				files = append(files, f.FieldName)
+				fileNames = append(fileNames, f.FieldName)
 			}
-			log.Debug("ciVisibilityHttpClient: new request with files [method: %v, url: %v, attempt: %v, maxRetries: %v] %v",
-				config.Method, config.URL, attempt, config.MaxRetries, files)
+			log.Debug("ciVisibilityHttpClient: new request with files [method: %s, url: %s, attempt: %d, maxRetries: %d] %s",
+				config.Method, config.URL, attempt, config.MaxRetries, fileNames)
 		}
 		req, err = http.NewRequest(config.Method, config.URL, bytes.NewBuffer(body))
 		if err != nil {
@@ -198,7 +198,7 @@ func (rh *RequestHandler) internalSendRequest(config *RequestConfig, attempt int
 		}
 
 		if log.DebugEnabled() {
-			log.Debug("ciVisibilityHttpClient: new request with body [method: %v, url: %v, attempt: %v, maxRetries: %v, compressed: %v] %v bytes",
+			log.Debug("ciVisibilityHttpClient: new request with body [method: %s, url: %s, attempt: %d, maxRetries: %d, compressed: %t] %d bytes",
 				config.Method, config.URL, attempt, config.MaxRetries, config.Compressed, len(serializedBody))
 		}
 
@@ -223,7 +223,7 @@ func (rh *RequestHandler) internalSendRequest(config *RequestConfig, attempt int
 			return true, nil, err
 		}
 
-		log.Debug("ciVisibilityHttpClient: new request [method: %v, url: %v, attempt: %v, maxRetries: %v]",
+		log.Debug("ciVisibilityHttpClient: new request [method: %s, url: %s, attempt: %d, maxRetries: %d]",
 			config.Method, config.URL, attempt, config.MaxRetries)
 	}
 
@@ -237,7 +237,7 @@ func (rh *RequestHandler) internalSendRequest(config *RequestConfig, attempt int
 
 	resp, err := rh.Client.Do(req)
 	if err != nil {
-		log.Debug("ciVisibilityHttpClient: error = %v", err)
+		log.Debug("ciVisibilityHttpClient: error = %s", err)
 		// Retry if there's an error
 		exponentialBackoff(attempt, config.Backoff)
 		return false, nil, nil
@@ -250,7 +250,7 @@ func (rh *RequestHandler) internalSendRequest(config *RequestConfig, attempt int
 
 	// Check for rate-limiting (HTTP 429)
 	if resp.StatusCode == HTTPStatusTooManyRequests {
-		log.Debug("ciVisibilityHttpClient: response status code = %v", resp.StatusCode)
+		log.Debug("ciVisibilityHttpClient: response status code = %d", resp.StatusCode)
 
 		rateLimitReset := resp.Header.Get(HeaderRateLimitReset)
 		if rateLimitReset != "" {
@@ -278,7 +278,7 @@ func (rh *RequestHandler) internalSendRequest(config *RequestConfig, attempt int
 	// Check status code for retries
 	if statusCode >= 406 {
 		// Retry if the status code is >= 406
-		log.Debug("ciVisibilityHttpClient: response status code = %v", resp.StatusCode)
+		log.Debug("ciVisibilityHttpClient: response status code = %d", resp.StatusCode)
 		exponentialBackoff(attempt, config.Backoff)
 		return false, nil, nil
 	}
@@ -308,7 +308,7 @@ func (rh *RequestHandler) internalSendRequest(config *RequestConfig, attempt int
 	}
 
 	if log.DebugEnabled() {
-		log.Debug("ciVisibilityHttpClient: response received [method: %v, url: %v, status_code: %v, format: %v] %v bytes",
+		log.Debug("ciVisibilityHttpClient: response received [method: %s, url: %s, status_code: %d, format: %s] %d bytes",
 			config.Method, config.URL, resp.StatusCode, responseFormat, len(responseBody))
 	}
 

--- a/internal/datastreams/processor.go
+++ b/internal/datastreams/processor.go
@@ -84,17 +84,17 @@ func (b bucket) export(timestampType TimestampType) StatsBucket {
 	for _, s := range b.points {
 		pathwayLatency, err := proto.Marshal(s.pathwayLatency.ToProto())
 		if err != nil {
-			log.Error("can't serialize pathway latency. Ignoring: %v", err)
+			log.Error("can't serialize pathway latency. Ignoring: %v", err.Error())
 			continue
 		}
 		edgeLatency, err := proto.Marshal(s.edgeLatency.ToProto())
 		if err != nil {
-			log.Error("can't serialize edge latency. Ignoring: %v", err)
+			log.Error("can't serialize edge latency. Ignoring: %v", err.Error())
 			continue
 		}
 		payloadSize, err := proto.Marshal(s.payloadSize.ToProto())
 		if err != nil {
-			log.Error("can't serialize payload size. Ignoring: %v", err)
+			log.Error("can't serialize payload size. Ignoring: %v", err.Error())
 			continue
 		}
 		stats = append(stats, StatsPoint{
@@ -256,13 +256,13 @@ func (p *Processor) addToBuckets(point statsPoint, btime int64, buckets map[buck
 		b.points[point.hash] = group
 	}
 	if err := group.pathwayLatency.Add(math.Max(float64(point.pathwayLatency)/float64(time.Second), 0)); err != nil {
-		log.Error("failed to add pathway latency. Ignoring %v.", err)
+		log.Error("failed to add pathway latency. Ignoring %v.", err.Error())
 	}
 	if err := group.edgeLatency.Add(math.Max(float64(point.edgeLatency)/float64(time.Second), 0)); err != nil {
-		log.Error("failed to add edge latency. Ignoring %v.", err)
+		log.Error("failed to add edge latency. Ignoring %v.", err.Error())
 	}
 	if err := group.payloadSize.Add(float64(point.payloadSize)); err != nil {
-		log.Error("failed to add payload size. Ignoring %v.", err)
+		log.Error("failed to add payload size. Ignoring %v.", err.Error())
 	}
 }
 

--- a/internal/env.go
+++ b/internal/env.go
@@ -24,7 +24,7 @@ func BoolEnv(key string, def bool) bool {
 	}
 	v, err := strconv.ParseBool(vv)
 	if err != nil {
-		log.Warn("Non-boolean value for env var %s, defaulting to %t. Parse failed with error: %v", key, def, err)
+		log.Warn("Non-boolean value for env var %s, defaulting to %t. Parse failed with error: %v", key, def, err.Error())
 		return def
 	}
 	return v
@@ -39,7 +39,7 @@ func IntEnv(key string, def int) int {
 	}
 	v, err := strconv.Atoi(vv)
 	if err != nil {
-		log.Warn("Non-integer value for env var %s, defaulting to %d. Parse failed with error: %v", key, def, err)
+		log.Warn("Non-integer value for env var %s, defaulting to %d. Parse failed with error: %v", key, def, err.Error())
 		return def
 	}
 	return v
@@ -54,7 +54,7 @@ func DurationEnv(key string, def time.Duration) time.Duration {
 	}
 	v, err := time.ParseDuration(vv)
 	if err != nil {
-		log.Warn("Non-duration value for env var %s, defaulting to %d. Parse failed with error: %v", key, def, err)
+		log.Warn("Non-duration value for env var %s, defaulting to %d. Parse failed with error: %v", key, def, err.Error())
 		return def
 	}
 	return v
@@ -119,7 +119,7 @@ func FloatEnv(key string, def float64) float64 {
 	}
 	v, err := strconv.ParseFloat(env, 64)
 	if err != nil {
-		log.Warn("Non-float value for env var %s, defaulting to %f. Parse failed with error: %v", key, def, err)
+		log.Warn("Non-float value for env var %s, defaulting to %f. Parse failed with error: %v", key, def, err.Error())
 		return def
 	}
 	return v

--- a/internal/hostname/providers.go
+++ b/internal/hostname/providers.go
@@ -150,7 +150,7 @@ func updateHostname(now time.Time) {
 	for _, p := range providerCatalog {
 		detectedHostname, err := p.pf(ctx, hostname)
 		if err != nil {
-			log.Debug("Unable to get hostname from provider %s: %v", p.name, err)
+			log.Debug("Unable to get hostname from provider %s: %v", p.name, err.Error())
 			continue
 		}
 		hostname = detectedHostname

--- a/internal/normalizer/normalizer.go
+++ b/internal/normalizer/normalizer.go
@@ -43,7 +43,7 @@ func HeaderTagSlice(headers []string) map[string]string {
 		header, tag := HeaderTag(h)
 		// If `header` or `tag` is just the empty string, we don't want to set it.
 		if len(header) == 0 || len(tag) == 0 {
-			log.Debug("Header-tag input is in unsupported format; dropping input value %v", h)
+			log.Debug("Header-tag input is in unsupported format; dropping input value %s", h)
 			continue
 		}
 		headerTagsMap[header] = tag

--- a/internal/processtags/processtags.go
+++ b/internal/processtags/processtags.go
@@ -122,7 +122,7 @@ func collect() map[string]string {
 	tags := make(map[string]string)
 	execPath, err := os.Executable()
 	if err != nil {
-		log.Debug("failed to get binary path: %v", err)
+		log.Debug("failed to get binary path: %v", err.Error())
 	} else {
 		baseDirName := filepath.Base(filepath.Dir(execPath))
 		tags[tagEntrypointName] = filepath.Base(execPath)
@@ -131,7 +131,7 @@ func collect() map[string]string {
 	}
 	wd, err := os.Getwd()
 	if err != nil {
-		log.Debug("failed to get working directory: %v", err)
+		log.Debug("failed to get working directory: %v", err.Error())
 	} else {
 		tags[tagEntrypointWorkdir] = filepath.Base(wd)
 	}

--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -259,19 +259,19 @@ func Reset() {
 func (c *Client) updateState() {
 	data, err := c.newUpdateRequest()
 	if err != nil {
-		log.Error("remoteconfig: unexpected error while creating a new update request payload: %v", err)
+		log.Error("remoteconfig: unexpected error while creating a new update request payload: %v", err.Error())
 		return
 	}
 
 	req, err := http.NewRequest(http.MethodGet, c.endpoint, &data)
 	if err != nil {
-		log.Error("remoteconfig: unexpected error while creating a new http request: %v", err)
+		log.Error("remoteconfig: unexpected error while creating a new http request: %v", err.Error())
 		return
 	}
 
 	resp, err := c.HTTP.Do(req)
 	if err != nil {
-		log.Debug("remoteconfig: http request error: %v", err)
+		log.Debug("remoteconfig: http request error: %v", err.Error())
 		return
 	}
 	// Flush and close the response body when returning (cf. https://pkg.go.dev/net/http#Client.Do)
@@ -287,7 +287,7 @@ func (c *Client) updateState() {
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Error("remoteconfig: http request error: could not read the response body: %v", err)
+		log.Error("remoteconfig: http request error: could not read the response body: %v", err.Error())
 		return
 	}
 
@@ -297,7 +297,7 @@ func (c *Client) updateState() {
 
 	var update clientGetConfigsResponse
 	if err := json.Unmarshal(respBody, &update); err != nil {
-		log.Error("remoteconfig: http request error: could not parse the json response body: %v", err)
+		log.Error("remoteconfig: http request error: could not parse the json response body: %v", err.Error())
 		return
 	}
 
@@ -489,7 +489,7 @@ func (c *Client) applyUpdate(pbUpdate *clientGetConfigsResponse) error {
 
 		fileMap[f.Path] = f.Raw
 		if !slices.Contains(allProducts, path.Product) {
-			log.Debug("remoteconfig: received file for unknown product %s (known: %#v): %s", path.Product, allProducts, f.Path)
+			log.Debug("remoteconfig: received file for unknown product %s (known: %#v): %s", path.Product, allProducts, f.Path) //nolint:gocritic // Debug logging for unknown products
 		}
 		if productUpdates[path.Product] == nil {
 			productUpdates[path.Product] = make(ProductUpdate)

--- a/internal/stableconfig/stableconfigsource.go
+++ b/internal/stableconfig/stableconfigsource.go
@@ -57,7 +57,7 @@ func parseFile(filePath string) *stableConfig {
 	if err != nil {
 		// It's expected that the stable config file may not exist; its absence is not an error.
 		if !os.IsNotExist(err) {
-			log.Warn("Failed to stat stable config file %s, dropping: %v", filePath, err)
+			log.Warn("Failed to stat stable config file %s, dropping: %v", filePath, err.Error())
 		}
 		return emptyStableConfig()
 	}
@@ -72,7 +72,7 @@ func parseFile(filePath string) *stableConfig {
 	if err != nil {
 		// It's expected that the stable config file may not exist; its absence is not an error.
 		if !os.IsNotExist(err) {
-			log.Warn("Failed to read stable config file %s, dropping: %v", filePath, err)
+			log.Warn("Failed to read stable config file %s, dropping: %v", filePath, err.Error())
 		}
 		return emptyStableConfig()
 	}
@@ -86,7 +86,7 @@ func fileContentsToConfig(data []byte, fileName string) *stableConfig {
 	scfg := &stableConfig{}
 	err := yaml.Unmarshal(data, scfg)
 	if err != nil {
-		log.Warn("Parsing stable config file" + fileName + "failed due to error, dropping: " + err.Error())
+		log.Warn("Parsing stable config file %s failed due to error, dropping: %s", fileName, err)
 		return emptyStableConfig()
 	}
 	if scfg.Config == nil {

--- a/internal/stacktrace/stacktrace.go
+++ b/internal/stacktrace/stacktrace.go
@@ -48,7 +48,7 @@ func init() {
 		if e, err := strconv.ParseBool(env); err == nil {
 			enabled = e
 		} else {
-			log.Error("Failed to parse %s env var as boolean: %v (using default value: %v)", envStackTraceEnabled, err, enabled)
+			log.Error("Failed to parse %s env var as boolean: (using default value: %t) %v", envStackTraceEnabled, enabled, err.Error())
 		}
 	}
 
@@ -64,7 +64,7 @@ func init() {
 			if depth <= 0 {
 				err = errors.New("value is not a strictly positive integer")
 			}
-			log.Error("Failed to parse %s env var as a positive integer: %v (using default value: %v)", envStackTraceDepth, err, defaultMaxDepth)
+			log.Error("Failed to parse %s env var as a positive integer: (using default value: %d) %v", envStackTraceDepth, defaultMaxDepth, err.Error())
 		}
 	}
 

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -209,7 +209,11 @@ func (c *client) Flush() {
 		if r == nil {
 			return
 		}
-		log.Warn("panic while flushing telemetry data, stopping telemetry: %v", r)
+		if err, ok := r.(error); ok {
+			log.Warn("panic while flushing telemetry data, stopping telemetry: %v", err.Error())
+		} else {
+			log.Warn("panic while flushing telemetry data, stopping telemetry!")
+		}
 		telemetryClientDisabled = true
 		if gc, ok := GlobalClient().(*client); ok && gc == c {
 			SwapClient(nil)
@@ -244,9 +248,9 @@ func (c *client) Flush() {
 			}
 		}
 		if dependenciesFound {
-			log.Warn("appsec: error while flushing SCA Security Data: %v", err)
+			log.Warn("appsec: error while flushing SCA Security Data: %v", err.Error())
 		} else {
-			log.Debug("telemetry: error while flushing telemetry data: %v", err)
+			log.Debug("telemetry: error while flushing telemetry data: %v", err.Error())
 		}
 
 		return
@@ -318,7 +322,7 @@ func (c *client) flush(payloads []transport.Payload) (int, error) {
 		for _, call := range failedCalls {
 			errs = append(errs, call.Error)
 		}
-		log.Debug("non-fatal error(s) while flushing telemetry data: %v", errors.Join(errs...))
+		log.Debug("non-fatal error(s) while flushing telemetry data: %v", errors.Join(errs...).Error())
 	}
 
 	return nbBytes, nil

--- a/internal/telemetry/client_config.go
+++ b/internal/telemetry/client_config.go
@@ -194,7 +194,7 @@ func defaultConfig(config ClientConfig) ClientConfig {
 	envVal := globalinternal.FloatEnv("DD_TELEMETRY_HEARTBEAT_INTERVAL", heartBeatInterval.Seconds())
 	config.HeartbeatInterval = defaultAuthorizedHearbeatRange.Clamp(time.Duration(envVal * float64(time.Second)))
 	if config.HeartbeatInterval != defaultHeartbeatInterval {
-		log.Debug("telemetry: using custom heartbeat interval %v", config.HeartbeatInterval)
+		log.Debug("telemetry: using custom heartbeat interval %s", config.HeartbeatInterval)
 	}
 	// Make sure we flush at least at each heartbeat interval
 	config.FlushInterval = config.FlushInterval.ReduceMax(config.HeartbeatInterval)

--- a/internal/telemetry/distributions.go
+++ b/internal/telemetry/distributions.go
@@ -36,7 +36,7 @@ func (d *distributions) LoadOrStore(namespace Namespace, name string, tags []str
 	})
 	if !loaded && !d.skipAllowlist { // The metric is new: validate and log issues about it
 		if err := validateMetricKey(namespace, kind, name, tags); err != nil {
-			log.Warn("telemetry: %v", err)
+			log.Warn("telemetry: %v", err.Error())
 		}
 	}
 

--- a/internal/telemetry/internal/knownmetrics/known_metrics.go
+++ b/internal/telemetry/internal/knownmetrics/known_metrics.go
@@ -34,7 +34,7 @@ var (
 func parseMetricNames(bytes []byte) []Declaration {
 	var names []Declaration
 	if err := json.Unmarshal(bytes, &names); err != nil {
-		log.Error("telemetry: failed to parse metric names: %v", err)
+		log.Error("telemetry: failed to parse metric names: %v", err.Error())
 	}
 	return names
 }

--- a/internal/telemetry/internal/writer.go
+++ b/internal/telemetry/internal/writer.go
@@ -213,9 +213,12 @@ func (w *writer) newRequest(endpoint *http.Request, requestType transport.Reques
 		defer func() {
 			// This should normally never happen but since we are encoding arbitrary data in client configuration values payload we need to be careful.
 			if panicValue := recover(); panicValue != nil {
-				log.Error("telemetry/writer: panic while encoding payload: %v", panicValue)
+				log.Error("telemetry/writer: panic while encoding payload!")
 				if err == nil {
-					panicErr, _ := panicValue.(error)   // check if we can use the panic value as an error
+					panicErr, ok := panicValue.(error) // check if we can use the panic value as an error
+					if ok {
+						log.Error("telemetry/writer: panic while encoding payload: %v", panicErr.Error())
+					}
 					pipeWriter.CloseWithError(panicErr) // CloseWithError with nil as parameter is like Close()
 				}
 			}

--- a/internal/telemetry/log/log.go
+++ b/internal/telemetry/log/log.go
@@ -49,6 +49,6 @@ func log(lvl telemetry.LogLevel, format string, args []any) {
 	telemetry.Log(lvl, fmt.Sprintf(format, fmtArgs...), opts...)
 
 	if lvl != telemetry.LogDebug {
-		internallog.Debug(format, fmtArgs...)
+		internallog.Debug(format, fmtArgs...) //nolint:gocritic // Telemetry log plumbing needs to pass through variable format strings
 	}
 }

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -106,7 +106,7 @@ func (m *metrics) LoadOrStore(namespace Namespace, kind transport.MetricType, na
 
 	if !loaded && !m.skipAllowlist { // The metric is new: validate and log issues about it
 		if err := validateMetricKey(namespace, kind, name, tags); err != nil {
-			log.Warn("telemetry: %v", err)
+			log.Warn("telemetry: %v", err.Error())
 		}
 	}
 

--- a/internal/trace_source.go
+++ b/internal/trace_source.go
@@ -49,7 +49,7 @@ func VerifyTraceSourceEnabled(hexStr string, target TraceSource) bool {
 	ts, err := ParseTraceSource(hexStr)
 	if err != nil {
 		if len(hexStr) != 0 { // Empty trace source should not trigger an error log.
-			log.Error("invalid trace-source hex string given for source verification: %v", err)
+			log.Error("invalid trace-source hex string given for source verification: %v", err.Error())
 		}
 		return false
 	}

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -196,7 +196,7 @@ func newProfiler(opts ...Option) (*profiler, error) {
 			if cfg.targetURL == cfg.apiURL {
 				return nil, fmt.Errorf("could not obtain hostname: %v", err)
 			}
-			log.Warn("unable to look up hostname: %v", err)
+			log.Warn("unable to look up hostname: %v", err.Error())
 		}
 		cfg.hostname = hostname
 	}
@@ -385,7 +385,7 @@ func (p *profiler) collect(ticker <-chan time.Time) {
 				profs, err := p.runProfile(t)
 				if err != nil {
 					if err != errProfilerStopped {
-						log.Error("Error getting %s profile: %v; skipping.", t, err)
+						log.Error("Error getting %s profile: %v; skipping.", t, err.Error())
 						tags := append(p.cfg.tags.Slice(), t.Tag())
 						p.cfg.statsd.Count("datadog.profiling.go.collect_error", 1, tags, 1)
 					}
@@ -500,10 +500,10 @@ func (p *profiler) send() {
 				return
 			}
 			if err := p.outputDir(bat); err != nil {
-				log.Error("Failed to output profile to dir: %v", err)
+				log.Error("Failed to output profile to dir: %v", err.Error())
 			}
 			if err := p.uploadFunc(bat); err != nil {
-				log.Error("Failed to upload profile: %v", err)
+				log.Error("Failed to upload profile: %v", err.Error())
 			}
 		}
 	}

--- a/profiler/telemetry.go
+++ b/profiler/telemetry.go
@@ -30,7 +30,7 @@ func startTelemetry(c *config) {
 			AgentURL:   c.agentURL,
 		})
 		if err != nil {
-			log.Debug("profiler: failed to create telemetry client: %v", err)
+			log.Debug("profiler: failed to create telemetry client: %v", err.Error())
 			return
 		}
 		telemetry.StartApp(client)

--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -48,7 +48,7 @@ func (p *profiler) upload(bat batch) error {
 		if rerr, ok := err.(*retriableError); ok {
 			statsd.Count("datadog.profiling.go.upload_retry", 1, nil, 1)
 			wait := time.Duration(rand.Int63n(p.cfg.period.Nanoseconds())) * time.Nanosecond
-			log.Error("Uploading profile failed: %v. Trying again in %s...", rerr, wait)
+			log.Error("Uploading profile failed: %s. Trying again in %s...", rerr.Error(), wait)
 			p.interruptibleSleep(wait)
 			continue
 		}

--- a/rules/logging_rules.go
+++ b/rules/logging_rules.go
@@ -1,0 +1,406 @@
+//go:build ruleguard
+
+// Package gorules contains security-focused linting rules for logging in dd-trace-go.
+//
+// SECURITY LOGGING MODEL:
+//
+// This package implements differentiated security policies for different types of logging:
+//
+// 1. TELEMETRY LOGGING (internal/telemetry/log):
+//   - STRICT POLICY: Ban ALL %v usage to prevent uncontrolled data exposure
+//   - Rationale: Telemetry data is sent to external services and must be carefully controlled
+//   - All format verbs must be explicit (%s, %d, %q, etc.) to ensure data visibility
+//
+// 2. INTERNAL/STANDARD LOGGING (internal/log, log):
+//   - PERMISSIVE POLICY: Allow %v for error types and err.Error() calls
+//   - Rationale: Internal logs stay within the application but still need data protection
+//   - ALLOWED: err.Error() with %v (returns controlled string)
+//   - SUGGESTED: Raw error variables with %v (suggest err.Error() for explicitness)
+//
+// 3. ERROR TYPE HANDLING:
+//   - err.Error() calls with %v are ALLOWED (returns controlled string)
+//   - Raw error variables with %v get SUGGESTIONS (recommend err.Error())
+//   - Position requirement: %v must be the last format verb (allows trailing chars like \n)
+//
+// 4. RECOMMENDED PRACTICE:
+//   - Prefer err.Error() for explicitness even though raw errors are allowed
+//   - This makes the intent clear and follows defensive programming principles
+//
+// EXAMPLES:
+//
+// ❌ Forbidden (telemetry):
+//
+//	telemetrylog.Error("user data: %v", userData)  // Any %v usage banned
+//
+// ❌ Forbidden (internal):
+//
+//	log.Error("value: %v", someString)             // Non-error type with %v
+//	log.Error("error %v at line %d", err, 123)     // %v not at end
+//
+// ✅ Allowed (internal):
+//
+//	log.Error("operation failed: %v", err.Error()) // err.Error() with %v is fine
+//	log.Error("failed with %v\n", err.Error())     // %v at end, trailing chars OK
+//
+// 🔍 Suggested improvement (internal):
+//
+//	log.Error("operation failed: %v", err)         // Raw error - suggest err.Error()
+//	log.Error("failed with %v\n", err)             // Raw error - suggest err.Error()
+package gorules
+
+import (
+	"github.com/quasilyte/go-ruleguard/dsl"
+	"github.com/quasilyte/go-ruleguard/dsl/types"
+)
+
+const (
+	telemetryLogPackage    = "github.com/DataDog/dd-trace-go/v2/internal/telemetry/log"
+	internalLogPackage     = "github.com/DataDog/dd-trace-go/v2/internal/log"
+	formatVerbRegexPattern = `.*%[+#]?v.*` // %v, %+v, %#v
+
+	// Pattern for %v as the last format verb (allows other non-format chars like \n after)
+	endVerbPattern = `.*%[+#]?v[^%]*$` // %v as last format verb, no more % after it
+
+	// Base security messages explaining the rationale
+	logMessageFormat  = "format verbs %v, %+v, or %#v prevents controlled data exposure. Use specific format verbs like %s, %d, %q and sanitize data before logging."
+	logMessageDynamic = "logging with variable format string. Use compile-time constant format strings to ensure controlled data exposure and prevent format string injection."
+
+	// Best practice suggestion for error types
+	logMessageErrorSuggestion = "prefer err.Error() over %v for explicit error formatting. While %v with error types is allowed, err.Error() makes the intent clearer and follows defensive programming practices."
+
+	// Predefined complete messages for violations:
+	telemetryLogPrefix         = "Forbidden: (telemetry logging) "
+	telemetryLogFormatMessage  = telemetryLogPrefix + logMessageFormat
+	telemetryLogDynamicMessage = telemetryLogPrefix + logMessageDynamic
+	internalLogPrefix          = "Forbidden: (internal log) "
+	internalLogFormatMessage   = internalLogPrefix + logMessageFormat
+	internalLogDynamicMessage  = internalLogPrefix + logMessageDynamic
+	stdLogPrefix               = "Forbidden: (standard log) "
+	stdLogFormatMessage        = stdLogPrefix + logMessageFormat
+	stdLogDynamicMessage       = stdLogPrefix + logMessageDynamic
+
+	// Best practice suggestions for error types:
+	internalLogSuggestionPrefix = "Suggestion: (internal log) "
+	internalLogErrorSuggestion  = internalLogSuggestionPrefix + logMessageErrorSuggestion
+	stdLogSuggestionPrefix      = "Suggestion: (standard log) "
+	stdLogErrorSuggestion       = stdLogSuggestionPrefix + logMessageErrorSuggestion
+)
+
+//doc:summary TELEMETRY SECURITY: detects usage of %v, %+v, %#v format verbs in telemetry logging
+//doc:before  telemetrylog.Error("unexpected error: %v", err)
+//doc:after   telemetrylog.Error("unexpected error: %s", err.Error())
+//doc:tags    security telemetry data-leak format-verbs
+func telemetryLogFormatVerbs(m dsl.Matcher) {
+	// SECURITY POLICY: Telemetry logging has STRICT policy - ALL %v usage is forbidden
+	// Rationale: Telemetry data is sent to external services and must be carefully controlled
+	// ALL format verbs must be explicit (%s, %d, %q, etc.) to ensure data visibility
+	m.Import(telemetryLogPackage)
+
+	// Match ALL telemetry log calls that use dangerous format verbs (%v, %+v, %#v)
+	// No exceptions - even error types must use explicit formatting in telemetry
+	m.Match(
+		`log.Debug($format, $*args)`,
+		`log.Warn($format, $*args)`,
+		`log.Error($format, $*args)`,
+		`log.Info($format, $*args)`,
+	).
+		Where(m["format"].Text.Matches(formatVerbRegexPattern)).
+		Report(telemetryLogFormatMessage)
+}
+
+//doc:summary TELEMETRY SECURITY: detects usage of variable format strings in telemetry logging
+//doc:before  telemetrylog.Error(msg, err)
+//doc:after   telemetrylog.Error("specific error message: %s", err.Error())
+//doc:tags    security telemetry compile-time-safety injection
+func telemetryLogVariableFormat(m dsl.Matcher) {
+	// SECURITY POLICY: Telemetry logging requires compile-time constant format strings
+	// Rationale: Variable format strings can lead to format string injection attacks
+	// and make it impossible to audit what data might be exposed to external services
+	m.Import(telemetryLogPackage)
+
+	// Match telemetry log calls with non-constant format strings
+	// All format strings must be compile-time constants for security auditing
+	m.Match(
+		`log.Debug($format, $*args)`,
+		`log.Warn($format, $*args)`,
+		`log.Error($format, $*args)`,
+		`log.Info($format, $*args)`,
+	).
+		Where(!m["format"].Const).
+		Report(telemetryLogDynamicMessage)
+}
+
+//doc:summary INTERNAL SECURITY: detects unsafe %v usage in internal logging (non-error types or wrong position)
+//doc:before  log.Error("user value: %v", someString)
+//doc:after   log.Error("user value: %s", someString)
+//doc:tags    security internal-log data-leak format-verbs
+func internalLogFormatVerbs(m dsl.Matcher) {
+	// SECURITY POLICY: Internal logging has PERMISSIVE policy with error handling
+	// - ALLOWED: %v with err.Error() calls (returns controlled string)
+	// - SUGGESTED: %v with raw error types (suggest err.Error() for explicitness)
+	// - FORBIDDEN: %v with non-error types or %v not at end
+	// - Position requirement: %v must be the last format verb (trailing chars like \n are OK)
+	m.Import(internalLogPackage)
+
+	// Match internal log calls that violate the error handling rules:
+	// 1. %v with non-error types (any position) - VIOLATION
+	// 2. %v not at end of format string (even with error types) - VIOLATION
+	// 3. %v with err.Error() calls - ALLOWED (no violation)
+	// 4. %v at end with raw error type - SUGGESTION (handled by suggestion rule)
+	m.Match(
+		`log.Debug($format, $*_, $lastArg)`,
+		`log.Info($format, $*_, $lastArg)`,
+		`log.Warn($format, $*_, $lastArg)`,
+		`log.Error($format, $*_, $lastArg)`,
+		`log.Debug($format, $lastArg)`,
+		`log.Info($format, $lastArg)`,
+		`log.Warn($format, $lastArg)`,
+		`log.Error($format, $lastArg)`,
+	).
+		Where(
+			!m.File().Name.Matches(`.*_test\.go$`) &&
+				m["format"].Text.Matches(formatVerbRegexPattern) &&
+				!m["lastArg"].Text.Matches(`.*\.Error\(\).*`) && // Allow err.Error() calls
+				(!m["format"].Text.Matches(endVerbPattern) ||
+					(!m["lastArg"].Type.Is(`error`) && !m["lastArg"].Filter(implementsError))),
+		).
+		Report(internalLogFormatMessage)
+}
+
+//doc:summary STANDARD LOG SECURITY: detects unsafe %v usage in standard logging (depguard-allowed files only)
+//doc:before  log.Printf("user value: %v", someString)
+//doc:after   log.Printf("user value: %s", someString)
+//doc:tags    security standard-log data-leak format-verbs depguard
+func stdLogFormatVerbs(m dsl.Matcher) {
+	// SECURITY POLICY: Standard logging follows same policy as internal logging
+	// - ALLOWED: %v with err.Error() calls (returns controlled string)
+	// - SUGGESTED: %v with raw error types (suggest err.Error() for explicitness)
+	// - FORBIDDEN: %v with non-error types or %v not at end
+	// - Only applies to files where depguard allows standard log usage
+	m.Import(`log`)
+
+	// Match standard log calls in depguard-allowed files that violate error handling rules
+	// Same rules as internal logging: allow err.Error(), suggest for raw errors
+	m.Match(
+		`log.Printf($format, $lastArg)`,
+		`log.Fatalf($format, $lastArg)`,
+		`log.Panicf($format, $lastArg)`,
+		`log.Printf($format, $*_, $lastArg)`,
+		`log.Fatalf($format, $*_, $lastArg)`,
+		`log.Panicf($format, $*_, $lastArg)`,
+	).
+		Where(
+			(m.File().PkgPath.Matches(`.*/scripts/.*`) ||
+				m.File().PkgPath.Matches(`.*/tools/.*`) ||
+				m.File().PkgPath.Matches(`.*/internal/log/log\.go$`) ||
+				m.File().PkgPath.Matches(`.*/internal/orchestrion/.*`) ||
+				m.File().PkgPath.Matches(`.*/instrumentation/testutils/sql/sql\.go$`)) &&
+				!m.File().Name.Matches(`.*_test\.go$`) &&
+				m["format"].Text.Matches(formatVerbRegexPattern) &&
+				!m["lastArg"].Text.Matches(`.*\.Error\(\).*`) && // Allow err.Error() calls
+				(!m["format"].Text.Matches(endVerbPattern) ||
+					(!m["lastArg"].Type.Is(`error`) && !m["lastArg"].Filter(implementsError))),
+		).
+		Report(stdLogFormatMessage)
+}
+
+//doc:summary INTERNAL SECURITY: detects usage of variable format strings in internal DD log functions
+//doc:before  log.Error(msg, err)
+//doc:after   log.Error("specific error message: %s", err.Error())
+//doc:tags    security internal-log compile-time-safety injection
+func internalLogVariableFormat(m dsl.Matcher) {
+	// SECURITY POLICY: Internal logging requires compile-time constant format strings
+	// Rationale: Variable format strings can lead to format string injection attacks
+	// and make security auditing difficult
+	m.Import(internalLogPackage)
+
+	// Match internal log calls with non-constant format strings
+	// All format strings should be compile-time constants for security and auditing
+	m.Match(
+		`log.Debug($format, $*args)`,
+		`log.Info($format, $*args)`,
+		`log.Warn($format, $*args)`,
+		`log.Error($format, $*args)`,
+	).
+		Where(
+			!m.File().Name.Matches(`.*_test\.go$`) &&
+				!m["format"].Const,
+		).
+		Report(internalLogDynamicMessage)
+}
+
+//doc:summary STANDARD LOG SECURITY: detects usage of variable format strings in standard log functions (depguard-allowed files only)
+//doc:before  log.Printf(msg, err)
+//doc:after   log.Printf("specific error message: %s", err.Error())
+//doc:tags    security standard-log compile-time-safety injection depguard
+func stdLogVariableFormat(m dsl.Matcher) {
+	// SECURITY POLICY: Standard logging requires compile-time constant format strings
+	// Same rationale as internal logging - prevent format string injection attacks
+	// Only applies to files where depguard allows standard log usage
+	m.Import(`log`)
+
+	// Match standard log calls with non-constant format strings in allowed files
+	// Enforce same security requirements as internal logging
+	m.Match(
+		`log.Printf($format, $*args)`,
+		`log.Fatalf($format, $*args)`,
+		`log.Panicf($format, $*args)`,
+	).
+		Where(
+			(m.File().PkgPath.Matches(`.*/scripts/.*`) ||
+				m.File().PkgPath.Matches(`.*/tools/.*`) ||
+				m.File().PkgPath.Matches(`.*/internal/log/log\.go$`) ||
+				m.File().PkgPath.Matches(`.*/internal/orchestrion/.*`) ||
+				m.File().PkgPath.Matches(`.*/instrumentation/testutils/sql/sql\.go$`)) &&
+				!m.File().Name.Matches(`.*_test\.go$`) &&
+				!m["format"].Const,
+		).
+		Report(stdLogDynamicMessage)
+}
+
+//doc:summary AUTO-FIX: suggests err.Error() with %s for error types in internal logging
+//doc:before  log.Error("operation failed: %v", err)
+//doc:after   log.Error("operation failed: %s", err.Error())
+//doc:tags    best-practice internal-log error-handling auto-fix
+func internalLogSuggestErrorString(m dsl.Matcher) {
+	m.Import(internalLogPackage)
+
+	// AUTO-FIX: Debug single error patterns (generic alias matching)
+	m.Match(`$pkg.Debug($format, $err)`).
+		Where(
+			!m.File().Name.Matches(`.*_test\.go$`) &&
+				m["format"].Text.Matches(formatVerbRegexPattern) &&
+				m["format"].Text.Matches(endVerbPattern) &&
+				(m["err"].Type.Is(`error`) || m["err"].Filter(implementsError)) &&
+				!m["err"].Text.Matches(`.*\.Error\(\)`),
+		).
+		Suggest(`$pkg.Debug($format, $err.Error())`)
+
+	// AUTO-FIX: Info single error patterns (generic alias matching)
+	m.Match(`$pkg.Info($format, $err)`).
+		Where(
+			!m.File().Name.Matches(`.*_test\.go$`) &&
+				m["format"].Text.Matches(formatVerbRegexPattern) &&
+				m["format"].Text.Matches(endVerbPattern) &&
+				(m["err"].Type.Is(`error`) || m["err"].Filter(implementsError)) &&
+				!m["err"].Text.Matches(`.*\.Error\(\)`),
+		).
+		Suggest(`$pkg.Info($format, $err.Error())`)
+
+	// AUTO-FIX: Warn single error patterns (generic alias matching)
+	m.Match(`$pkg.Warn($format, $err)`).
+		Where(
+			!m.File().Name.Matches(`.*_test\.go$`) &&
+				m["format"].Text.Matches(formatVerbRegexPattern) &&
+				m["format"].Text.Matches(endVerbPattern) &&
+				(m["err"].Type.Is(`error`) || m["err"].Filter(implementsError)) &&
+				!m["err"].Text.Matches(`.*\.Error\(\)`),
+		).
+		Suggest(`$pkg.Warn($format, $err.Error())`)
+
+	// AUTO-FIX: Error single error patterns (generic alias matching)
+	m.Match(`$pkg.Error($format, $err)`).
+		Where(
+			!m.File().Name.Matches(`.*_test\.go$`) &&
+				m["format"].Text.Matches(formatVerbRegexPattern) &&
+				m["format"].Text.Matches(endVerbPattern) &&
+				(m["err"].Type.Is(`error`) || m["err"].Filter(implementsError)) &&
+				!m["err"].Text.Matches(`.*\.Error\(\)`),
+		).
+		Suggest(`$pkg.Error($format, $err.Error())`)
+}
+
+// AUTO-FIX: Multi-argument error patterns with %v at end (raw error variables only)
+func internalLogSuggestErrorStringMulti(m dsl.Matcher) {
+	m.Import(internalLogPackage)
+
+	// AUTO-FIX: Two-argument error patterns (format, arg1, err)
+	m.Match(`$pkg.Debug($format, $arg1, $err)`).
+		Where(
+			!m.File().Name.Matches(`.*_test\.go$`) &&
+				m["format"].Text.Matches(formatVerbRegexPattern) &&
+				m["format"].Text.Matches(endVerbPattern) &&
+				(m["err"].Type.Is(`error`) || m["err"].Filter(implementsError)) &&
+				!m["err"].Text.Matches(`.*\.Error\(\)`),
+		).
+		Suggest(`$pkg.Debug($format, $arg1, $err.Error())`)
+
+	m.Match(`$pkg.Info($format, $arg1, $err)`).
+		Where(
+			!m.File().Name.Matches(`.*_test\.go$`) &&
+				m["format"].Text.Matches(formatVerbRegexPattern) &&
+				m["format"].Text.Matches(endVerbPattern) &&
+				(m["err"].Type.Is(`error`) || m["err"].Filter(implementsError)) &&
+				!m["err"].Text.Matches(`.*\.Error\(\)`),
+		).
+		Suggest(`$pkg.Info($format, $arg1, $err.Error())`)
+
+	m.Match(`$pkg.Warn($format, $arg1, $err)`).
+		Where(
+			!m.File().Name.Matches(`.*_test\.go$`) &&
+				m["format"].Text.Matches(formatVerbRegexPattern) &&
+				m["format"].Text.Matches(endVerbPattern) &&
+				(m["err"].Type.Is(`error`) || m["err"].Filter(implementsError)) &&
+				!m["err"].Text.Matches(`.*\.Error\(\)`),
+		).
+		Suggest(`$pkg.Warn($format, $arg1, $err.Error())`)
+
+	m.Match(`$pkg.Error($format, $arg1, $err)`).
+		Where(
+			!m.File().Name.Matches(`.*_test\.go$`) &&
+				m["format"].Text.Matches(formatVerbRegexPattern) &&
+				m["format"].Text.Matches(endVerbPattern) &&
+				(m["err"].Type.Is(`error`) || m["err"].Filter(implementsError)) &&
+				!m["err"].Text.Matches(`.*\.Error\(\)`),
+		).
+		Suggest(`$pkg.Error($format, $arg1, $err.Error())`)
+
+	// AUTO-FIX: Three-argument error patterns (format, arg1, arg2, err)
+	m.Match(`$pkg.Debug($format, $arg1, $arg2, $err)`).
+		Where(
+			!m.File().Name.Matches(`.*_test\.go$`) &&
+				m["format"].Text.Matches(formatVerbRegexPattern) &&
+				m["format"].Text.Matches(endVerbPattern) &&
+				(m["err"].Type.Is(`error`) || m["err"].Filter(implementsError)) &&
+				!m["err"].Text.Matches(`.*\.Error\(\)`),
+		).
+		Suggest(`$pkg.Debug($format, $arg1, $arg2, $err.Error())`)
+
+	m.Match(`$pkg.Info($format, $arg1, $arg2, $err)`).
+		Where(
+			!m.File().Name.Matches(`.*_test\.go$`) &&
+				m["format"].Text.Matches(formatVerbRegexPattern) &&
+				m["format"].Text.Matches(endVerbPattern) &&
+				(m["err"].Type.Is(`error`) || m["err"].Filter(implementsError)) &&
+				!m["err"].Text.Matches(`.*\.Error\(\)`),
+		).
+		Suggest(`$pkg.Info($format, $arg1, $arg2, $err.Error())`)
+
+	m.Match(`$pkg.Warn($format, $arg1, $arg2, $err)`).
+		Where(
+			!m.File().Name.Matches(`.*_test\.go$`) &&
+				m["format"].Text.Matches(formatVerbRegexPattern) &&
+				m["format"].Text.Matches(endVerbPattern) &&
+				(m["err"].Type.Is(`error`) || m["err"].Filter(implementsError)) &&
+				!m["err"].Text.Matches(`.*\.Error\(\)`),
+		).
+		Suggest(`$pkg.Warn($format, $arg1, $arg2, $err.Error())`)
+
+	m.Match(`$pkg.Error($format, $arg1, $arg2, $err)`).
+		Where(
+			!m.File().Name.Matches(`.*_test\.go$`) &&
+				m["format"].Text.Matches(formatVerbRegexPattern) &&
+				m["format"].Text.Matches(endVerbPattern) &&
+				(m["err"].Type.Is(`error`) || m["err"].Filter(implementsError)) &&
+				!m["err"].Text.Matches(`.*\.Error\(\)`),
+		).
+		Suggest(`$pkg.Error($format, $arg1, $arg2, $err.Error())`)
+}
+
+// implementsError checks if a type implements the error interface.
+// This includes both direct implementations and pointer receivers.
+// Used to identify when %v usage is safe in internal/standard logging contexts.
+func implementsError(ctx *dsl.VarFilterContext) bool {
+	iface := ctx.GetInterface(`error`)
+	return types.Implements(ctx.Type, iface) || types.Implements(types.NewPointer(ctx.Type), iface)
+}


### PR DESCRIPTION
feat: add ruleguard rules to prevent uncontrolled data leakage in logging

Add comprehensive ruleguard rules that detect and prevent dangerous logging
patterns that could expose sensitive data through uncontrolled format verbs.

Security protections:
- Forbids %v, %+v, %#v format verbs that can leak sensitive data
- Requires compile-time constant format strings to prevent injection attacks
- Enforces explicit format verbs like %s, %d, %q for controlled output
- Respects existing depguard policies for standard log usage

Error handling improvements:
- Allows err.Error() calls with %v (safe, returns controlled strings)
- Suggests explicit err.Error() for raw error variables
- Provides auto-fix suggestions to improve code safety

Examples of what gets caught:
  ❌ log.Error("user data: %v", userData)     // Could leak sensitive fields
  ✅ log.Error("user data: %s", userData.ID) // Explicit, safe

  ❌ log.Error("failed: %v", err)             // Works but not explicit
  ✅ log.Error("failed: %s", err.Error())     // Clear intent, auto-suggested

Coverage includes telemetry, internal logging, and standard log packages
(where permitted by depguard). Test files are excluded from violations.

This ensures telemetry systems receive only sanitized, controlled data
while helping developers write safer logging code.

Signed-off-by: Kemal Akkoyun <kemal.akkoyun@datadoghq.com>

fix: apply logging security fixes and prevent uncontrolled data exposure

Apply comprehensive fixes to eliminate potential data leakage in logging
across the codebase. These changes address violations detected by the
new ruleguard security rules.

Key improvements:
- Replace %v format verbs with explicit format specifiers (%s, %d, %q)
- Use err.Error() instead of raw error variables for controlled output
- Sanitize URL logging to prevent credential exposure
- Remove dynamic format strings that could enable injection attacks
- Ensure only intended data is logged to telemetry systems

Examples of fixes applied:
  - log.Error("failed: %v", err) → log.Error("failed: %s", err.Error())
  - log.Debug("value: %v", data) → log.Debug("value: %s", data.String())
  - Sanitized URLs in CI visibility transport logs
  - Replaced unsafe format patterns in span context debugging

These changes ensure that sensitive data like credentials, tokens, or
uncontrolled user input cannot leak through logging, improving overall
security posture while maintaining debugging capabilities.

Signed-off-by: Kemal Akkoyun <kemal.akkoyun@datadoghq.com>

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
