### PR TITLE
profiler: re-introduce `enabled` field to startup log

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -139,11 +139,9 @@ func logStartup(c *config) {
 	}
 	b, err := json.Marshal(info)
 	if err != nil {
-		fmt.Printf("MTOFF: Marshaling profiler configuration: %s\n", err)
 		log.Error("Marshaling profiler configuration: %s", err)
 		return
 	}
-	fmt.Print("MTOFF: Profiler configuration: ", string(b), "\n")
 	log.Info("Profiler configuration: %s\n", b)
 }
 

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -220,7 +220,6 @@ func newProfiler(opts ...Option) (*profiler, error) {
 		cfg.cpuDuration = cfg.period
 	}
 	if cfg.logStartup {
-		fmt.Print("MTOFF: logStartup\n")
 		logStartup(cfg)
 	}
 	var tags []string


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Re-introduces "enabled" field to the profiler startup log. Was removed in https://github.com/DataDog/dd-trace-go/pull/3570.

### Motivation
system-tests rely on this field to report whether profiling is enabled. 
The presence of the profiler startup log is insufficient to determine this. Given the following scenario:
env: `DD_TRACE_PROFILING_ENABLED=false`
```
profiler.Start()
defer profiler.Stop()
```
The profiler is disabled. The profiler startup log will be generated, but with the field `"enabled": "false"`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
