### PR TITLE
fix(ddtrace/tracer): Lock sampling priority after inheriting from parent

### DIFF
--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -646,6 +646,7 @@ func spanStart(operationName string, options ...StartSpanOption) *Span {
 		if p, ok := context.SamplingPriority(); ok {
 			// inheriting the sampling priority from the parent trace; do not re-sample
 			context.trace.setLocked(true)
+			// TODO: Check whether prio is trace rules or span rules?
 			span.setMetric(keySamplingPriority, float64(p))
 		}
 		if context.span != nil {

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -644,6 +644,8 @@ func spanStart(operationName string, options ...StartSpanOption) *Span {
 		span.traceID = context.traceID.Lower()
 		span.parentID = context.spanID
 		if p, ok := context.SamplingPriority(); ok {
+			// inheriting the sampling priority from the parent trace; do not re-sample
+			context.trace.setLocked(true)
 			span.setMetric(keySamplingPriority, float64(p))
 		}
 		if context.span != nil {

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -645,7 +645,7 @@ func spanStart(operationName string, options ...StartSpanOption) *Span {
 		span.parentID = context.spanID
 		if p, ok := context.SamplingPriority(); ok {
 			// inheriting the sampling priority from the parent trace; do not re-sample
-			context.trace.setLocked(true)
+			// context.trace.setLocked(true)
 			span.setMetric(keySamplingPriority, float64(p))
 		}
 		if context.span != nil {

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -645,7 +645,7 @@ func spanStart(operationName string, options ...StartSpanOption) *Span {
 		span.parentID = context.spanID
 		if p, ok := context.SamplingPriority(); ok {
 			// inheriting the sampling priority from the parent trace; do not re-sample
-			// context.trace.setLocked(true)
+			context.trace.setLocked(true)
 			span.setMetric(keySamplingPriority, float64(p))
 		}
 		if context.span != nil {


### PR DESCRIPTION
### What does this PR do?
When creating a new span from parent context, inherit parent's sampling decision and lock the sampling priority to avoid re-sampling.

### Motivation
I noticed that the sampler is re-run during tracer.Inject; re-sampling probably occurs at this point to check for any span metadata after the span was started that could impact sampling rules. However, this code did not respect the sampling priority if it had already been determined/inherited from a parent.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
