### PR TITLE
(fix) internal/civisibility: fix the attempt-to-fix-passed tag

### DIFF
--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -191,7 +191,9 @@ func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
 					if execMeta.allRetriesFailed {
 						test.SetTag(constants.TestHasFailedAllRetries, "true")
 					}
-					test.SetTag(constants.TestAttemptToFixPassed, "false")
+					if execMeta.isAttemptToFix {
+						test.SetTag(constants.TestAttemptToFixPassed, "false")
+					}
 				}
 				test.SetError(integrations.WithErrorInfo("panic", fmt.Sprint(r), utils.GetStacktrace(1)))
 				test.Close(integrations.ResultStatusFail)
@@ -210,19 +212,21 @@ func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
 					if execMeta.allRetriesFailed {
 						test.SetTag(constants.TestHasFailedAllRetries, "true")
 					}
-					test.SetTag(constants.TestAttemptToFixPassed, "false")
+					if execMeta.isAttemptToFix {
+						test.SetTag(constants.TestAttemptToFixPassed, "false")
+					}
 				}
 				test.SetTag(ext.Error, true)
 				suite.SetTag(ext.Error, true)
 				module.SetTag(ext.Error, true)
 				test.Close(integrations.ResultStatusFail)
 			} else if t.Skipped() {
-				if execMeta.isARetry && execMeta.isLastRetry {
+				if execMeta.isAttemptToFix && execMeta.isARetry && execMeta.isLastRetry {
 					test.SetTag(constants.TestAttemptToFixPassed, "false")
 				}
 				test.Close(integrations.ResultStatusSkip)
 			} else {
-				if execMeta.isARetry && execMeta.isLastRetry {
+				if execMeta.isAttemptToFix && execMeta.isARetry && execMeta.isLastRetry {
 					if execMeta.allAttemptsPassed {
 						test.SetTag(constants.TestAttemptToFixPassed, "true")
 					} else {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

We are incorrectly tagging the tests with the `TestAttemptToFixPassed` flag when we are not in an `Attempt to fix` execution, this PR solves that.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fix the tagging issue.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
