### PR TITLE
enhance trace sending retry log visibility

### DIFF
--- a/ddtrace/tracer/writer.go
+++ b/ddtrace/tracer/writer.go
@@ -114,7 +114,7 @@ func (h *agentTraceWriter) flush() {
 			var rc io.ReadCloser
 			rc, err = h.config.transport.send(p)
 			if err == nil {
-				log.Debug("sent traces after %d attempts", attempt+1)
+				log.Info("sent traces after %d attempts", attempt+1)
 				h.statsd.Count("datadog.tracer.flush_bytes", int64(size), nil, 1)
 				h.statsd.Count("datadog.tracer.flush_traces", int64(count), nil, 1)
 				if err := h.prioritySampling.readRatesJSON(rc); err != nil {
@@ -122,7 +122,7 @@ func (h *agentTraceWriter) flush() {
 				}
 				return
 			}
-			log.Error("failure sending traces (attempt %d of %d): %v", attempt+1, h.config.sendRetries+1, err.Error())
+			log.Warn("failure sending traces (attempt %d of %d): %v", attempt+1, h.config.sendRetries+1, err.Error())
 			p.reset()
 			time.Sleep(h.config.retryInterval)
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Improves trace sending retry logging by adjusting log levels for better user visibility:
- Success messages: Debug → Info level (now visible by default)
- Retry failures: Error → Warn level (not final errors)
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Currently, when traces fail initially but succeed on retry, users see error logs but no success confirmation unless debug logging is enabled.
**Before**:
- ERROR: failure sending traces (attempt 1 of 3) - Always visible
- Success after retry - Only visible in debug mode

**After:**
- WARN: failure sending traces (attempt 1 of 3) - Retry in progress
- INFO: sent traces after 2 attempts - Success confirmation
- ERROR: lost 5 traces: connection timeout - Final failure (unchanged)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
