### PR TITLE
[chore] pin k8s version to prevent incompatible types

### DIFF
--- a/scripts/ci-test-contrib.sh
+++ b/scripts/ci-test-contrib.sh
@@ -23,6 +23,11 @@ for contrib in $CONTRIBS; do
   contrib_id=$(echo $contrib | sed 's/^\.\///g;s/[\/\.]/_/g')
   cd $contrib
   [[ "$1" = "smoke" ]] && go get -u -t ./...
+  if [[ "$1" = "smoke" && $contrib = "./contrib/k8s.io/client-go/"]]; then
+    # This is a temporary workaround due to this issue in apimachinery: https://github.com/kubernetes/apimachinery/issues/190
+    # When the issue is resolved, this line can be removed.
+    go get k8s.io/kube-openapi@v0.0.0-20250628140032-d90c4fd18f59
+  fi
   gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report-$contrib_id.xml -- ./... -v -race -coverprofile=coverage-$contrib_id.txt -covermode=atomic
   [[ $? -ne 0 ]] && report_error=1
   cd -
@@ -33,6 +38,11 @@ for mod in $INSTRUMENTATION_SUBMODULES; do
   mod_id=$(echo $mod | sed 's/^\.\///g;s/[\/\.]/_/g')
   cd $mod
   [[ "$1" = "smoke" ]] && go get -u -t ./...
+  if [[ "$1" = "smoke" && $contrib = "./contrib/k8s.io/client-go/"]]; then
+    # This is a temporary workaround due to this issue in apimachinery: https://github.com/kubernetes/apimachinery/issues/190
+    # When the issue is resolved, this line can be removed.
+    go get k8s.io/kube-openapi@v0.0.0-20250628140032-d90c4fd18f59
+  fi
   gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report-$mod_id.xml -- ./... -v -race -coverprofile=coverage-$mod_id.txt -covermode=atomic
   [[ $? -ne 0 ]] && report_error=1
   cd -

--- a/scripts/ci-test-contrib.sh
+++ b/scripts/ci-test-contrib.sh
@@ -23,7 +23,7 @@ for contrib in $CONTRIBS; do
   contrib_id=$(echo $contrib | sed 's/^\.\///g;s/[\/\.]/_/g')
   cd $contrib
   [[ "$1" = "smoke" ]] && go get -u -t ./...
-  if [[ "$1" = "smoke" && $contrib = "./contrib/k8s.io/client-go/"]]; then
+  if [[ "$1" = "smoke" && "$contrib" = "./contrib/k8s.io/client-go/" ]]; then
     # This is a temporary workaround due to this issue in apimachinery: https://github.com/kubernetes/apimachinery/issues/190
     # When the issue is resolved, this line can be removed.
     go get k8s.io/kube-openapi@v0.0.0-20250628140032-d90c4fd18f59
@@ -38,7 +38,7 @@ for mod in $INSTRUMENTATION_SUBMODULES; do
   mod_id=$(echo $mod | sed 's/^\.\///g;s/[\/\.]/_/g')
   cd $mod
   [[ "$1" = "smoke" ]] && go get -u -t ./...
-  if [[ "$1" = "smoke" && $contrib = "./contrib/k8s.io/client-go/"]]; then
+  if [[ "$1" = "smoke" && "$contrib" = "./contrib/k8s.io/client-go/" ]]; then
     # This is a temporary workaround due to this issue in apimachinery: https://github.com/kubernetes/apimachinery/issues/190
     # When the issue is resolved, this line can be removed.
     go get k8s.io/kube-openapi@v0.0.0-20250628140032-d90c4fd18f59


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Pins `kube-openapi` to a previous version.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

`kube-openapi` recently upgraded their version of `structured-merge-diff` from `v4` to `v6`. However, `apimachinery` , which imports both `kube-openapi` and `structured-merge-diff` is still using `structured-merge-diff@v4`. This was causing our smoke tests to fail. To temporarily resolve this issue and unblock CI, we pin the version of `kube-openapi` when running smoke tests to the latest version before they upgraded.

The error:
```
Error: /home/runner/go/pkg/mod/k8s.io/apimachinery@v0.33.2/pkg/util/managedfields/internal/typeconverter.go:51:61: cannot use typeSchema.Types (variable of type []"sigs.k8s.io/structured-merge-diff/v6/schema".TypeDef) as []"sigs.k8s.io/structured-merge-diff/v4/schema".TypeDef value in struct literal
```

This workaround can be removed once [the issue](https://github.com/kubernetes/apimachinery/issues/190) is closed.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
