### PR TITLE
contrib/envoyproxy: update default env vars

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: string
         default: '["linux/amd64", "linux/arm64"]'
+      version:
+        description: 'DD_VERSION to pass as build argument to Dockerfile'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   build-images:
@@ -84,6 +89,8 @@ jobs:
           file: ${{ inputs.dockerfile }}
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            DD_VERSION=${{ inputs.version }}
           # This builds a Docker image and uploads it using a unique fingerprint, without a name
           outputs: type=image,name=${{ inputs.image }},push-by-digest=true,name-canonical=true,push=true
 
@@ -109,6 +116,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.tags.outputs.list }}
+          build-args: |
+            DD_VERSION=${{ inputs.version }}
           outputs: type=docker,dest=/tmp/${{ inputs.artifact_prefix }}-${{ env.PLATFORM_PAIR }}.tar
           push: false
 

--- a/.github/workflows/docker-images-release.yml
+++ b/.github/workflows/docker-images-release.yml
@@ -63,6 +63,7 @@ jobs:
       dockerfile: ./contrib/envoyproxy/go-control-plane/cmd/serviceextensions/Dockerfile
       artifact_prefix: service-extensions
       commit_sha: ${{ github.event.inputs.commit_sha || github.sha }}
+      version: ${{ needs.prepare-tag.outputs.service_extension_image_tag }}
       tags: >-
         ${{ needs.prepare-tag.outputs.service_extension_image_tag }}
         ${{ github.event.inputs.commit_sha || github.sha }}
@@ -79,6 +80,7 @@ jobs:
       dockerfile: ./contrib/k8s.io/gateway-api/cmd/request-mirror/Dockerfile
       artifact_prefix: request-mirror
       commit_sha: ${{ github.event.inputs.commit_sha || github.sha }}
+      version: ${{ needs.prepare-tag.outputs.request_mirroring_image_tag }}
       tags: >-
         ${{ needs.prepare-tag.outputs.request_mirroring_image_tag }}
         ${{ github.event.inputs.commit_sha || github.sha }}

--- a/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/Dockerfile
+++ b/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/Dockerfile
@@ -25,6 +25,10 @@ RUN go build -tags=appsec -o ./contrib/envoyproxy/go-control-plane/cmd/serviceex
 FROM alpine:3.20.3
 RUN apk --no-cache add ca-certificates tzdata libc6-compat libgcc libstdc++
 WORKDIR /app
+
+ARG DD_VERSION=""
+ENV DD_VERSION=${DD_VERSION}
+
 COPY --from=builder /app/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/serviceextensions /app/serviceextensions
 COPY --from=builder /app/localhost.crt /app/localhost.crt
 COPY --from=builder /app/localhost.key /app/localhost.key

--- a/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/main.go
+++ b/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/main.go
@@ -53,7 +53,7 @@ func initializeEnvironment() {
 
 	defaultEnvVars := []envVar{
 		{key: "DD_VERSION", value: instrumentation.Version()}, // Version of the tracer
-		{key: "DD_TRACE_ENABLED", value: "false"},             // Appsec Standalone
+		{key: "DD_APM_TRACING_ENABLED", value: "false"},       // Appsec Standalone
 		{key: "DD_APPSEC_WAF_TIMEOUT", value: "10ms"},         // Proxy specific WAF timeout
 		{key: "_DD_APPSEC_PROXY_ENVIRONMENT", value: "true"},  // Internal config: Enable API Security proxy sampler
 	}

--- a/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/main.go
+++ b/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/main.go
@@ -70,14 +70,15 @@ func initializeEnvironment() {
 // configureObservabilityMode disables blocking when observability mode is enabled.
 // Note: This requires the Envoy configuration option "observability_mode: true" to be set.
 // This option is only supported when configuring Envoy directly, and is not available when using GCP Service Extension.
-func configureObservabilityMode(config serviceExtensionConfig) error {
-	if config.observabilityMode {
-		internalBlockingUnavailableKey := "_DD_APPSEC_BLOCKING_UNAVAILABLE"
-		if err := os.Setenv(internalBlockingUnavailableKey, "true"); err != nil {
-			return fmt.Errorf("failed to set %s environment variable: %s", internalBlockingUnavailableKey, err.Error())
-		}
-		log.Debug("service_extension: observability mode enabled, disabling blocking\n")
+func configureObservabilityMode(mode bool) error {
+	if !mode {
+		return nil
 	}
+	const internalBlockingUnavailableKey = "_DD_APPSEC_BLOCKING_UNAVAILABLE"
+	if err := os.Setenv(internalBlockingUnavailableKey, "true"); err != nil {
+		return fmt.Errorf("failed to set %s environment variable: %s", internalBlockingUnavailableKey, err.Error())
+	}
+	log.Debug("service_extension: observability mode enabled, disabling blocking\n")
 	return nil
 }
 
@@ -105,7 +106,7 @@ func main() {
 	initializeEnvironment()
 	config := loadConfig()
 
-	if err := configureObservabilityMode(config); err != nil {
+	if err := configureObservabilityMode(config.observabilityMode); err != nil {
 		log.Error("service_extension: %s\n", err.Error())
 	}
 

--- a/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/main.go
+++ b/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/main.go
@@ -61,7 +61,7 @@ func initializeEnvironment() {
 	for _, env := range defaultEnvVars {
 		if os.Getenv(env.key) == "" {
 			if err := os.Setenv(env.key, env.value); err != nil {
-				log.Error("service_extension: failed to set %s environment variable: %w\n", env.key, err)
+				log.Error("service_extension: failed to set %s environment variable: %s\n", env.key, err.Error())
 			}
 		}
 	}
@@ -74,7 +74,7 @@ func configureObservabilityMode(config serviceExtensionConfig) error {
 	if config.observabilityMode {
 		internalBlockingUnavailableKey := "_DD_APPSEC_BLOCKING_UNAVAILABLE"
 		if err := os.Setenv(internalBlockingUnavailableKey, "true"); err != nil {
-			return fmt.Errorf("failed to set %s environment variable: %w", internalBlockingUnavailableKey, err)
+			return fmt.Errorf("failed to set %s environment variable: %s", internalBlockingUnavailableKey, err.Error())
 		}
 		log.Debug("service_extension: observability mode enabled, disabling blocking\n")
 	}

--- a/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/main.go
+++ b/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/main.go
@@ -42,6 +42,46 @@ type serviceExtensionConfig struct {
 	bodyParsingSizeLimit int
 }
 
+var log = NewLogger()
+
+// initializeEnvironment sets up required environment variables with their defaults
+func initializeEnvironment() {
+	type envVar struct {
+		key   string
+		value string
+	}
+
+	defaultEnvVars := []envVar{
+		{key: "DD_VERSION", value: instrumentation.Version()}, // Version of the tracer
+		{key: "DD_TRACE_ENABLED", value: "false"},             // Appsec Standalone
+		{key: "DD_APPSEC_WAF_TIMEOUT", value: "10ms"},         // Proxy specific WAF timeout
+		{key: "_DD_APPSEC_PROXY_ENVIRONMENT", value: "true"},  // Internal config: Enable API Security proxy sampler
+	}
+
+	for _, env := range defaultEnvVars {
+		if os.Getenv(env.key) == "" {
+			if err := os.Setenv(env.key, env.value); err != nil {
+				log.Error("service_extension: failed to set %s environment variable: %w\n", env.key, err)
+			}
+		}
+	}
+}
+
+// configureObservabilityMode disables blocking when observability mode is enabled.
+// Note: This requires the Envoy configuration option "observability_mode: true" to be set.
+// This option is only supported when configuring Envoy directly, and is not available when using GCP Service Extension.
+func configureObservabilityMode(config serviceExtensionConfig) error {
+	if config.observabilityMode {
+		internalBlockingUnavailableKey := "_DD_APPSEC_BLOCKING_UNAVAILABLE"
+		if err := os.Setenv(internalBlockingUnavailableKey, "true"); err != nil {
+			return fmt.Errorf("failed to set %s environment variable: %w", internalBlockingUnavailableKey, err)
+		}
+		log.Debug("service_extension: observability mode enabled, disabling blocking\n")
+	}
+	return nil
+}
+
+// loadConfig loads the configuration from the environment variables
 func loadConfig() serviceExtensionConfig {
 	extensionPortInt := intEnv("DD_SERVICE_EXTENSION_PORT", 443)
 	healthcheckPortInt := intEnv("DD_SERVICE_EXTENSION_HEALTHCHECK_PORT", 80)
@@ -61,22 +101,12 @@ func loadConfig() serviceExtensionConfig {
 	}
 }
 
-var log = NewLogger()
-
 func main() {
-	// Set the DD_VERSION to the current tracer version if not set
-	if os.Getenv("DD_VERSION") == "" {
-		if err := os.Setenv("DD_VERSION", instrumentation.Version()); err != nil {
-			log.Error("service_extension: failed to set DD_VERSION environment variable: %s\n", err.Error())
-		}
-	}
-
+	initializeEnvironment()
 	config := loadConfig()
 
-	// If the observability mode is enabled, disable blocking
-	if config.observabilityMode {
-		_ = os.Setenv("_DD_APPSEC_BLOCKING_UNAVAILABLE", "true")
-		log.Debug("service_extension: observability mode enabled, disabling blocking\n")
+	if err := configureObservabilityMode(config); err != nil {
+		log.Error("service_extension: %s\n", err.Error())
 	}
 
 	if err := startService(config); err != nil {
@@ -92,7 +122,6 @@ func startService(config serviceExtensionConfig) error {
 
 	tracer.Start(tracer.WithAppSecEnabled(true))
 	defer tracer.Stop()
-	// TODO: Enable ASM standalone mode when it is developed (should be done for Q4 2024)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR:
- refactor the way default environment variables are set
- enable appsec standalone
- set the default waf timeout for proxy to `10ms`
- enable the API Security proxy sampler
- set the DD_VERSION tag from the release process to correctly set custom tags that doesn't follow the tracer version (ex: `-docker.0`)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
