### PR TITLE
(chore) internal/civisibility: add debug logs to the git command execution

### DIFF
--- a/internal/civisibility/utils/git.go
+++ b/internal/civisibility/utils/git.go
@@ -79,8 +79,8 @@ func isGitFound() bool {
 
 // execGit executes a Git command with the given arguments.
 func execGit(commandType telemetry.CommandType, args ...string) (val []byte, err error) {
+	startTime := time.Now()
 	if commandType != telemetry.NotSpecifiedCommandsType {
-		startTime := time.Now()
 		telemetry.GitCommand(commandType)
 		defer func() {
 			telemetry.GitCommandMs(commandType, float64(time.Since(startTime).Milliseconds()))
@@ -107,6 +107,16 @@ func execGit(commandType telemetry.CommandType, args ...string) (val []byte, err
 			}
 		}()
 	}
+	if log.DebugEnabled() {
+		defer func() {
+			durationInMs := float64(time.Since(startTime).Milliseconds())
+			if err != nil {
+				log.Debug("civisibility.git.command [%v][%v][%vms]: git %s", commandType, err.Error(), durationInMs, strings.Join(args, " "))
+			} else {
+				log.Debug("civisibility.git.command [%v][%vms]: git %s", commandType, durationInMs, strings.Join(args, " "))
+			}
+		}()
+	}
 	if !isGitFound() {
 		return nil, errors.New("git executable not found")
 	}
@@ -122,9 +132,11 @@ func execGitString(commandType telemetry.CommandType, args ...string) (string, e
 
 // execGitStringWithInput executes a Git command with the given input and arguments and returns the output as a string.
 func execGitStringWithInput(commandType telemetry.CommandType, input string, args ...string) (val string, err error) {
+	startTime := time.Now()
 	if commandType != telemetry.NotSpecifiedCommandsType {
 		telemetry.GitCommand(commandType)
 		defer func() {
+			telemetry.GitCommandMs(commandType, float64(time.Since(startTime).Milliseconds()))
 			var exitErr *exec.ExitError
 			if errors.As(err, &exitErr) {
 				switch exitErr.ExitCode() {
@@ -145,6 +157,16 @@ func execGitStringWithInput(commandType telemetry.CommandType, input string, arg
 				}
 			} else if err != nil {
 				telemetry.GitCommandErrors(commandType, telemetry.MissingCommandExitCode)
+			}
+		}()
+	}
+	if log.DebugEnabled() {
+		defer func() {
+			durationInMs := float64(time.Since(startTime).Milliseconds())
+			if err != nil {
+				log.Debug("civisibility.git.command [%v][%v][%vms]: git %s", commandType, err.Error(), durationInMs, strings.Join(args, " "))
+			} else {
+				log.Debug("civisibility.git.command [%v][%vms]: git %s", commandType, durationInMs, strings.Join(args, " "))
 			}
 		}()
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds debug logs to the git command execution.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We lack visibility on which git command we are executing in different scenarios.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
