### PR TITLE
ci: add STS policy for reviewdog

### DIFF
--- a/.github/chainguard/self.reviewdog.sts.yaml
+++ b/.github/chainguard/self.reviewdog.sts.yaml
@@ -1,0 +1,9 @@
+issuer: https://token.actions.githubusercontent.com
+subject: repo:DataDog/dd-trace-go:pull_request
+claim_pattern:
+  job_workflow_ref: DataDog/dd-trace-go/.github/workflows/unit-integration-tests.yml@.*
+  event_name: pull_request
+  repository: DataDog/dd-trace-go
+permissions:
+  contents: read
+  pull_requests: write


### PR DESCRIPTION
### What does this PR do?

Adds STS policy to support reviewdog steps.

### Motivation

It needs to be merged before using it in the CI, because policies are pulled from `main` only. [It was tested by debugging the generated OIDC claims](https://github.com/DataDog/dd-trace-go/actions/runs/16339742512/job/46159182655):

```json
{
  "actor": "darccio",
  "actor_id": "163009",
  "aud": "dd-octo-sts",
  "base_ref": "main",
  "enterprise": "datadog-inc",
  "enterprise_id": "42",
  "event_name": "pull_request",
  "exp": 1752761380,
  "head_ref": "dario.castane/deprecate-pat-reviewdog",
  "iat": 1752739780,
  "iss": "https://token.actions.githubusercontent.com/",
  "job_workflow_ref": "DataDog/dd-trace-go/.github/workflows/unit-integration-tests.yml@refs/pull/3772/merge",
  "job_workflow_sha": "3288aeab7e7640876c3b81b16bafc79da6897334",
  "jti": "64632276-0c9c-4981-bb28-3c396f34b2f0",
  "nbf": 1752739480,
  "ref": "refs/pull/3772/merge",
  "ref_protected": "false",
  "ref_type": "branch",
  "repository": "DataDog/dd-trace-go",
  "repository_id": "67680905",
  "repository_owner": "DataDog",
  "repository_owner_id": "365230",
  "repository_visibility": "public",
  "run_attempt": "1",
  "run_id": "16339742512",
  "run_number": "11556",
  "runner_environment": "github-hosted",
  "sha": "3288aeab7e7640876c3b81b16bafc79da6897334",
  "sub": "repo:DataDog/dd-trace-go:pull_request",
  "workflow": "Pull Request Tests",
  "workflow_ref": "DataDog/dd-trace-go/.github/workflows/pull-request.yml@refs/pull/3772/merge",
  "workflow_sha": "3288aeab7e7640876c3b81b16bafc79da6897334"
}
```

Validation:

```sh
❯ DDOCTOSTS_ID_TOKEN=$(cat /tmp/claims.json) dd-octo-sts check --scope=DataDog/dd-trace-go --policy=self.reviewdog
```

Output:

```
🔍 Checking repository and policy location...
Assuming repository path "/Users/dario.castane/go/src/github.com/DataDog/dd-trace-go"
  Tip: Use --repo/-r to override.
✅ Policy is in a valid location.
   Location: .github/chainguard/self.reviewdog.sts.yaml

🔍 Checking policy file...
✅ Policy is valid
   Permissions:
   - contents: read
✅ Policy is valid
   Permissions:
   - pull_requests: write

🔍 Checking token...
⚠️ Fabricating a token out of claims.
   This token will not work in production, but is suitable for testing.
✅ Supplied token is valid for policy
   Matching claims:
   - job_workflow_ref: DataDog/dd-trace-go/.github/workflows/unit-integration-tests.yml@refs/pull/3772/merge
   - repository: DataDog/dd-trace-go
   - event_name: pull_request
```

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
