### PR TITLE
feat(internal/civisibility): start reporting ci.job.id tag on supported providers.

### DIFF
--- a/internal/civisibility/constants/ci.go
+++ b/internal/civisibility/constants/ci.go
@@ -6,6 +6,9 @@
 package constants
 
 const (
+	// CIJobId indicates the id of the CI job.
+	CIJobId = "ci.job.id"
+
 	// CIJobName indicates the name of the CI job.
 	CIJobName = "ci.job.name"
 

--- a/internal/civisibility/utils/ci_providers.go
+++ b/internal/civisibility/utils/ci_providers.go
@@ -221,6 +221,7 @@ func extractAzurePipelines() map[string]string {
 
 	tags[constants.CIStageName] = os.Getenv("SYSTEM_STAGEDISPLAYNAME")
 
+	tags[constants.CIJobId] = os.Getenv("SYSTEM_JOBID")
 	tags[constants.CIJobName] = os.Getenv("SYSTEM_JOBDISPLAYNAME")
 	tags[constants.CIJobURL] = jobURL
 
@@ -315,6 +316,7 @@ func extractBuildkite() map[string]string {
 	tags[constants.CIPipelineName] = os.Getenv("BUILDKITE_PIPELINE_SLUG")
 	tags[constants.CIPipelineNumber] = os.Getenv("BUILDKITE_BUILD_NUMBER")
 	tags[constants.CIPipelineURL] = os.Getenv("BUILDKITE_BUILD_URL")
+	tags[constants.CIJobId] = os.Getenv("BUILDKITE_CI_JOB_ID")
 	tags[constants.CIJobURL] = fmt.Sprintf("%s#%s", os.Getenv("BUILDKITE_BUILD_URL"), os.Getenv("BUILDKITE_JOB_ID"))
 	tags[constants.CIProviderName] = "buildkite"
 	tags[constants.CIWorkspacePath] = os.Getenv("BUILDKITE_BUILD_CHECKOUT_PATH")
@@ -368,6 +370,7 @@ func extractCircleCI() map[string]string {
 	tags[constants.CIPipelineNumber] = os.Getenv("CIRCLE_BUILD_NUM")
 	tags[constants.CIPipelineURL] = fmt.Sprintf("https://app.circleci.com/pipelines/workflows/%s", os.Getenv("CIRCLE_WORKFLOW_ID"))
 	tags[constants.CIJobName] = os.Getenv("CIRCLE_JOB")
+	tags[constants.CIJobId] = os.Getenv("CIRCLE_BUILD_NUM")
 	tags[constants.CIJobURL] = os.Getenv("CIRCLE_BUILD_URL")
 
 	jsonString, err := getEnvVarsJSON("CIRCLE_BUILD_NUM", "CIRCLE_WORKFLOW_ID")
@@ -410,6 +413,7 @@ func extractGithubActions() map[string]string {
 	tags[constants.CIPipelineNumber] = os.Getenv("GITHUB_RUN_NUMBER")
 	tags[constants.CIPipelineName] = os.Getenv("GITHUB_WORKFLOW")
 	tags[constants.CIJobURL] = fmt.Sprintf("%s/commit/%s/checks", rawRepository, commitSha)
+	tags[constants.CIJobId] = os.Getenv("GITHUB_JOB")
 	tags[constants.CIJobName] = os.Getenv("GITHUB_JOB")
 
 	attempts := os.Getenv("GITHUB_RUN_ATTEMPT")
@@ -475,6 +479,7 @@ func extractGitlab() map[string]string {
 	tags[constants.CIPipelineNumber] = os.Getenv("CI_PIPELINE_IID")
 	tags[constants.CIPipelineURL] = url
 	tags[constants.CIJobURL] = os.Getenv("CI_JOB_URL")
+	tags[constants.CIJobId] = os.Getenv("CI_JOB_ID")
 	tags[constants.CIJobName] = os.Getenv("CI_JOB_NAME")
 	tags[constants.CIStageName] = os.Getenv("CI_JOB_STAGE")
 	tags[constants.GitCommitMessage] = os.Getenv("CI_COMMIT_MESSAGE")
@@ -624,6 +629,7 @@ func extractAwsCodePipeline() map[string]string {
 
 	tags[constants.CIProviderName] = "awscodepipeline"
 	tags[constants.CIPipelineID] = os.Getenv("DD_PIPELINE_EXECUTION_ID")
+	tags[constants.CIJobId] = os.Getenv("DD_ACTION_EXECUTION_ID")
 
 	jsonString, err := getEnvVarsJSON("CODEBUILD_BUILD_ARN", "DD_ACTION_EXECUTION_ID", "DD_PIPELINE_EXECUTION_ID")
 	if err == nil {


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds the `ci.job.id` tag for some CI providers that report this data.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

JIRA: SDTEST-2288

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
