### PR TITLE
chore(ddtrace/tracer): check for goroutine leaks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,3 +282,34 @@ Some benchmarks will run on any new PR commits, the results will be commented in
 
 To add additional benchmarks that should run for every PR, go to `.gitlab-ci.yml`.
 Add the name of your benchmark to the `BENCHMARK_TARGETS` variable using pipe character separators.
+
+### Goroutine Leaks
+
+Some core packages are using [uber-go/goleak](https://github.com/uber-go/goleak) to detect goroutine leaks.
+
+To isolate the leak to a single test, you can use the bash script from the goleak README.
+
+If you are experiencing a leak failure in CI that doesn't seem to reproduce locally, try running a local datadog agent. Some test failures only appear when http connections to the agent are created and become idle after the test completes.
+
+Last but not least, you might find a goroutine leak with an unhelpful stack trace:
+
+```
+Goroutine 92554 in state IO wait, with internal/poll.runtime_pollWait on top of the stack:
+internal/poll.runtime_pollWait(0x7f46dcd5b368, 0x72)
+	/opt/hostedtoolcache/go/1.23.11/x64/src/runtime/netpoll.go:351 +0x85
+...
+net/http.(*persistConn).readLoop(0xc0041c8b40)
+	/opt/hostedtoolcache/go/1.23.11/x64/src/net/http/transport.go:2205 +0x354
+created by net/http.(*Transport).dialConn in goroutine 92609
+	/opt/hostedtoolcache/go/1.23.11/x64/src/net/http/transport.go:1874 +0x29b4
+```
+
+In this case, consider editing the stdlib code (e.g. `http/transport.go:1874`) to print a stack trace at the location where the goroutine is being created:
+
+```go
+fmt.Printf("Leak start at stack=%s\n", string(debug.Stack()))
+```
+
+In practice, leaks often go through `http.(*Client).Do`, so that can be a good place to instrument as well.
+
+Following the advice above, most goroutine leaks should be easy to debug and fix.

--- a/ddtrace/mocktracer/mocktracer.go
+++ b/ddtrace/mocktracer/mocktracer.go
@@ -113,7 +113,8 @@ func (t *mocktracer) FinishSpan(s *tracer.Span) {
 
 // Stop deactivates the mock tracer and sets the active tracer to a no-op.
 func (t *mocktracer) Stop() {
-	tracer.Stop()
+	// N.b.: The main reason for this call is to make TestTracerStop pass.
+	internal.SetGlobalTracer(tracer.Tracer(&tracer.NoopTracer{}))
 	t.dsmProcessor.Stop()
 }
 

--- a/ddtrace/mocktracer/mocktracer_test.go
+++ b/ddtrace/mocktracer/mocktracer_test.go
@@ -27,8 +27,9 @@ func TestStart(t *testing.T) {
 
 func TestTracerStop(t *testing.T) {
 	Start().Stop()
-	if _, ok := getGlobalTracer().(*tracer.NoopTracer); !ok {
-		t.Fail()
+	tr := getGlobalTracer()
+	if _, ok := tr.(*tracer.NoopTracer); !ok {
+		t.Errorf("tracer is not a NoopTracer: %T", tr)
 	}
 }
 

--- a/ddtrace/tracer/civisibility_transport_test.go
+++ b/ddtrace/tracer/civisibility_transport_test.go
@@ -83,7 +83,7 @@ func runTransportTest(t *testing.T, agentless, shouldSetAPIKey bool) {
 	parsedURL, _ := url.Parse(srv.URL)
 	c := config{
 		ciVisibilityEnabled: true,
-		httpClient:          defaultHTTPClient(0),
+		httpClient:          defaultHTTPClient(0, false),
 		agentURL:            parsedURL,
 	}
 

--- a/ddtrace/tracer/civisibility_writer_test.go
+++ b/ddtrace/tracer/civisibility_writer_test.go
@@ -88,7 +88,7 @@ func TestCiVisibilityTraceWriterFlushRetries(t *testing.T) {
 				failCount: test.failCount,
 				assert:    assert,
 			}
-			c, err := newConfig(func(c *config) {
+			c, err := newTestConfig(func(c *config) {
 				c.transport = p
 				c.sendRetries = test.configRetries
 				c.retryInterval = test.retryInterval

--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -36,7 +36,7 @@ func TestReportRuntimeMetrics(t *testing.T) {
 	}()
 	assert := assert.New(t)
 	err = tg.Wait(assert, 35, 1*time.Second)
-	close(trc.stop)
+	trc.Stop()
 	assert.NoError(err)
 	calls := tg.CallNames()
 	assert.True(len(calls) > 30)

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -520,7 +520,7 @@ func newConfig(opts ...StartOption) (*config, error) {
 				Host:   fmt.Sprintf("UDS_%s", strings.NewReplacer(":", "_", "/", "_", `\`, "_").Replace(c.agentURL.Path)),
 			}
 		} else {
-			c.httpClient = defaultHTTPClient(c.httpClientTimeout)
+			c.httpClient = defaultHTTPClient(c.httpClientTimeout, false)
 		}
 	}
 	WithGlobalTag(ext.RuntimeID, globalconfig.RuntimeID())(c)

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -681,7 +681,7 @@ func udsClient(socketPath string, timeout time.Duration) *http.Client {
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-				return defaultDialer.DialContext(ctx, "unix", (&net.UnixAddr{
+				return defaultDialer(timeout).DialContext(ctx, "unix", (&net.UnixAddr{
 					Name: socketPath,
 					Net:  "unix",
 				}).String())

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -363,7 +363,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		assert.Equal(10*time.Second, x.Timeout)
 		assert.Equal(x.Timeout, y.Timeout)
 		compareHTTPClients(t, x, y)
-		assert.True(getFuncName(x.Transport.(*http.Transport).DialContext) == getFuncName(defaultDialer.DialContext))
+		assert.True(getFuncName(x.Transport.(*http.Transport).DialContext) == getFuncName(defaultDialer(30*time.Second).DialContext))
 		assert.False(c.debug)
 	})
 
@@ -373,7 +373,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		x := *c.httpClient
 		y := *defaultHTTPClient(2 * time.Second)
 		compareHTTPClients(t, x, y)
-		assert.True(t, getFuncName(x.Transport.(*http.Transport).DialContext) == getFuncName(defaultDialer.DialContext))
+		assert.True(t, getFuncName(x.Transport.(*http.Transport).DialContext) == getFuncName(defaultDialer(30*time.Second).DialContext))
 		client := &http.Client{}
 		WithHTTPClient(client)(c)
 		assert.Equal(t, client, c.httpClient)
@@ -944,7 +944,7 @@ func TestDefaultHTTPClient(t *testing.T) {
 		x := *defTracerClient(2)
 		y := *defaultHTTPClient(2)
 		compareHTTPClients(t, x, y)
-		assert.True(t, getFuncName(x.Transport.(*http.Transport).DialContext) == getFuncName(defaultDialer.DialContext))
+		assert.True(t, getFuncName(x.Transport.(*http.Transport).DialContext) == getFuncName(defaultDialer(30*time.Second).DialContext))
 	})
 
 	t.Run("socket", func(t *testing.T) {
@@ -961,7 +961,7 @@ func TestDefaultHTTPClient(t *testing.T) {
 		x := *defTracerClient(2)
 		y := *defaultHTTPClient(2)
 		compareHTTPClients(t, x, y)
-		assert.False(t, getFuncName(x.Transport.(*http.Transport).DialContext) == getFuncName(defaultDialer.DialContext))
+		assert.False(t, getFuncName(x.Transport.(*http.Transport).DialContext) == getFuncName(defaultDialer(30*time.Second).DialContext))
 
 	})
 }

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -359,7 +359,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		assert.Equal("localhost:8125", c.dogstatsdAddr)
 		assert.Nil(nil, c.httpClient)
 		x := *c.httpClient
-		y := *defaultHTTPClient(0)
+		y := *defaultHTTPClient(0, false)
 		assert.Equal(10*time.Second, x.Timeout)
 		assert.Equal(x.Timeout, y.Timeout)
 		compareHTTPClients(t, x, y)
@@ -371,7 +371,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		c, err := newConfig(WithAgentTimeout(2))
 		assert.NoError(t, err)
 		x := *c.httpClient
-		y := *defaultHTTPClient(2 * time.Second)
+		y := *defaultHTTPClient(2*time.Second, false)
 		compareHTTPClients(t, x, y)
 		assert.True(t, getFuncName(x.Transport.(*http.Transport).DialContext) == getFuncName(defaultDialer(30*time.Second).DialContext))
 		client := &http.Client{}
@@ -934,7 +934,7 @@ func TestDefaultHTTPClient(t *testing.T) {
 			// we have the UDS socket file, use it
 			return udsClient(internal.DefaultTraceAgentUDSPath, 0)
 		}
-		return defaultHTTPClient(time.Second * time.Duration(timeout))
+		return defaultHTTPClient(time.Second*time.Duration(timeout), false)
 	}
 	t.Run("no-socket", func(t *testing.T) {
 		// We care that whether clients are different, but doing a deep
@@ -942,7 +942,7 @@ func TestDefaultHTTPClient(t *testing.T) {
 		// just compare the pointers.
 
 		x := *defTracerClient(2)
-		y := *defaultHTTPClient(2)
+		y := *defaultHTTPClient(2, false)
 		compareHTTPClients(t, x, y)
 		assert.True(t, getFuncName(x.Transport.(*http.Transport).DialContext) == getFuncName(defaultDialer(30*time.Second).DialContext))
 	})
@@ -959,7 +959,7 @@ func TestDefaultHTTPClient(t *testing.T) {
 		defer func(old string) { internal.DefaultTraceAgentUDSPath = old }(internal.DefaultTraceAgentUDSPath)
 		internal.DefaultTraceAgentUDSPath = f.Name()
 		x := *defTracerClient(2)
-		y := *defaultHTTPClient(2)
+		y := *defaultHTTPClient(2, false)
 		compareHTTPClients(t, x, y)
 		assert.False(t, getFuncName(x.Transport.(*http.Transport).DialContext) == getFuncName(defaultDialer(30*time.Second).DialContext))
 

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -69,7 +69,7 @@ func TestStatsdUDPConnect(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cfg, err := newConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")))
+	cfg, err := newTestConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")))
 	require.NoError(t, err)
 	testStatsd(t, cfg, net.JoinHostPort(defaultHostname, "8111"))
 	addr := net.JoinHostPort(defaultHostname, "8111")
@@ -106,7 +106,7 @@ func TestStatsdUDPConnect(t *testing.T) {
 
 func TestAutoDetectStatsd(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
-		cfg, err := newConfig(WithAgentTimeout(2))
+		cfg, err := newTestConfig(WithAgentTimeout(2))
 		require.NoError(t, err)
 
 		testStatsd(t, cfg, net.JoinHostPort(defaultHostname, "8125"))
@@ -139,7 +139,7 @@ func TestAutoDetectStatsd(t *testing.T) {
 		defer conn.Close()
 		conn.SetDeadline(time.Now().Add(5 * time.Second))
 
-		cfg, err := newConfig(WithAgentTimeout(2))
+		cfg, err := newTestConfig(WithAgentTimeout(2))
 		assert.NoError(t, err)
 		statsd, err := newStatsdClient(cfg)
 		require.NoError(t, err)
@@ -166,7 +166,7 @@ func TestAutoDetectStatsd(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		cfg, err := newConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")))
+		cfg, err := newTestConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")))
 		assert.NoError(t, err)
 		testStatsd(t, cfg, net.JoinHostPort(defaultHostname, "8111"))
 	})
@@ -177,7 +177,7 @@ func TestAutoDetectStatsd(t *testing.T) {
 				w.Write([]byte(`{"endpoints": [], "config": {"statsd_port":0}}`))
 			}))
 			defer srv.Close()
-			cfg, err := newConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")), WithAgentTimeout(2))
+			cfg, err := newTestConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")), WithAgentTimeout(2))
 			assert.NoError(t, err)
 			testStatsd(t, cfg, net.JoinHostPort(defaultHostname, "8125"))
 		})
@@ -187,7 +187,7 @@ func TestAutoDetectStatsd(t *testing.T) {
 				w.Write([]byte(`{"endpoints": [], "config": {"statsd_port":8999}}`))
 			}))
 			defer srv.Close()
-			cfg, err := newConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")))
+			cfg, err := newTestConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")))
 			assert.NoError(t, err)
 			testStatsd(t, cfg, net.JoinHostPort(defaultHostname, "8999"))
 		})
@@ -197,13 +197,13 @@ func TestAutoDetectStatsd(t *testing.T) {
 func TestLoadAgentFeatures(t *testing.T) {
 	t.Run("zero", func(t *testing.T) {
 		t.Run("disabled", func(t *testing.T) {
-			cfg, err := newConfig(WithLambdaMode(true), WithAgentTimeout(2))
+			cfg, err := newTestConfig(WithLambdaMode(true), WithAgentTimeout(2))
 			assert.NoError(t, err)
 			assert.Zero(t, cfg.agent)
 		})
 
 		t.Run("unreachable", func(t *testing.T) {
-			cfg, err := newConfig(WithAgentAddr("127.0.0.1:0"))
+			cfg, err := newTestConfig(WithAgentAddr("127.0.0.1:0"))
 			assert.NoError(t, err)
 			assert.Zero(t, cfg.agent)
 		})
@@ -213,7 +213,7 @@ func TestLoadAgentFeatures(t *testing.T) {
 				w.WriteHeader(http.StatusNotFound)
 			}))
 			defer srv.Close()
-			cfg, err := newConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")), WithAgentTimeout(2))
+			cfg, err := newTestConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")), WithAgentTimeout(2))
 			require.NoError(t, err)
 			assert.Zero(t, cfg.agent)
 		})
@@ -223,7 +223,7 @@ func TestLoadAgentFeatures(t *testing.T) {
 				w.Write([]byte("Not JSON"))
 			}))
 			defer srv.Close()
-			cfg, err := newConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")), WithAgentTimeout(2))
+			cfg, err := newTestConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")), WithAgentTimeout(2))
 			require.NoError(t, err)
 			assert.Zero(t, cfg.agent)
 		})
@@ -234,7 +234,7 @@ func TestLoadAgentFeatures(t *testing.T) {
 			w.Write([]byte(`{"endpoints":["/v0.6/stats"],"feature_flags":["a","b"],"client_drop_p0s":true,"obfuscation_version":2,"peer_tags":["peer.hostname"],"config": {"statsd_port":8999}}`))
 		}))
 		defer srv.Close()
-		cfg, err := newConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")), WithAgentTimeout(2))
+		cfg, err := newTestConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")), WithAgentTimeout(2))
 		assert.NoError(t, err)
 		assert.True(t, cfg.agent.DropP0s)
 		assert.Equal(t, cfg.agent.StatsdPort, 8999)
@@ -255,7 +255,7 @@ func TestLoadAgentFeatures(t *testing.T) {
 			w.Write([]byte(`{"endpoints":["/v0.6/stats"],"client_drop_p0s":true,"config":{"statsd_port":8999}}`))
 		}))
 		defer srv.Close()
-		cfg, err := newConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")), WithAgentTimeout(2))
+		cfg, err := newTestConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")), WithAgentTimeout(2))
 		assert.NoError(t, err)
 		assert.True(t, cfg.agent.DropP0s)
 		assert.True(t, cfg.agent.Stats)
@@ -278,7 +278,7 @@ func TestAgentIntegration(t *testing.T) {
 
 	// this test is run before configuring integrations and after: ensures we clean up global state
 	defaultUninstrumentedTest := func(t *testing.T) {
-		cfg, err := newConfig()
+		cfg, err := newTestConfig()
 		assert.Nil(t, err)
 		defer clearIntegrationsForTests()
 
@@ -291,7 +291,7 @@ func TestAgentIntegration(t *testing.T) {
 	t.Run("default_before", defaultUninstrumentedTest)
 
 	t.Run("OK import", func(t *testing.T) {
-		cfg, err := newConfig()
+		cfg, err := newTestConfig()
 		assert.Nil(t, err)
 		defer clearIntegrationsForTests()
 
@@ -302,7 +302,7 @@ func TestAgentIntegration(t *testing.T) {
 	})
 
 	t.Run("available", func(t *testing.T) {
-		cfg, err := newConfig()
+		cfg, err := newTestConfig()
 		assert.Nil(t, err)
 		defer clearIntegrationsForTests()
 
@@ -318,7 +318,7 @@ func TestAgentIntegration(t *testing.T) {
 	})
 
 	t.Run("grpc", func(t *testing.T) {
-		cfg, err := newConfig()
+		cfg, err := newTestConfig()
 		assert.Nil(t, err)
 		defer clearIntegrationsForTests()
 
@@ -351,7 +351,7 @@ func getFuncName(f any) string {
 func TestTracerOptionsDefaults(t *testing.T) {
 	t.Run("defaults", func(t *testing.T) {
 		assert := assert.New(t)
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(err)
 		assert.Equal(float64(1), c.sampler.Rate())
 		assert.Regexp(`tracer\.test(\.exe)?`, c.serviceName)
@@ -368,7 +368,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 	})
 
 	t.Run("http-client", func(t *testing.T) {
-		c, err := newConfig(WithAgentTimeout(2))
+		c, err := newTestConfig(WithAgentTimeout(2))
 		assert.NoError(t, err)
 		x := *c.httpClient
 		y := *defaultHTTPClient(2*time.Second, false)
@@ -401,14 +401,14 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		t.Run("env/on", func(t *testing.T) {
 			t.Setenv("DD_TRACE_ANALYTICS_ENABLED", "true")
 			defer globalconfig.SetAnalyticsRate(math.NaN())
-			newConfig()
+			newTestConfig()
 			assert.Equal(t, 1.0, globalconfig.AnalyticsRate())
 		})
 
 		t.Run("env/off", func(t *testing.T) {
 			t.Setenv("DD_TRACE_ANALYTICS_ENABLED", "kj12")
 			defer globalconfig.SetAnalyticsRate(math.NaN())
-			newConfig()
+			newTestConfig()
 			assert.True(t, math.IsNaN(globalconfig.AnalyticsRate()))
 		})
 	})
@@ -423,20 +423,20 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		})
 		t.Run("env", func(t *testing.T) {
 			t.Setenv("DD_TRACE_DEBUG", "true")
-			c, err := newConfig()
+			c, err := newTestConfig()
 			assert.NoError(t, err)
 			assert.True(t, c.debug)
 		})
 		t.Run("otel-env-debug", func(t *testing.T) {
 			t.Setenv("OTEL_LOG_LEVEL", "debug")
-			c, err := newConfig()
+			c, err := newTestConfig()
 			assert.NoError(t, err)
 			assert.True(t, c.debug)
 		})
 		t.Run("otel-env-notdebug", func(t *testing.T) {
 			// any value other than debug, does nothing
 			t.Setenv("OTEL_LOG_LEVEL", "notdebug")
-			c, err := newConfig()
+			c, err := newTestConfig()
 			assert.NoError(t, err)
 			assert.False(t, c.debug)
 		})
@@ -444,16 +444,16 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			assert := assert.New(t)
 			// option override otel
 			t.Setenv("OTEL_LOG_LEVEL", "debug")
-			c, err := newConfig(WithDebugMode(false))
+			c, err := newTestConfig(WithDebugMode(false))
 			assert.NoError(err)
 			assert.False(c.debug)
 			// env override otel
 			t.Setenv("DD_TRACE_DEBUG", "false")
-			c, err = newConfig()
+			c, err = newTestConfig()
 			assert.NoError(err)
 			assert.False(c.debug)
 			// option override env
-			c, err = newConfig(WithDebugMode(true))
+			c, err = newTestConfig(WithDebugMode(true))
 			assert.NoError(err)
 			assert.True(c.debug)
 		})
@@ -736,7 +736,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		t.Setenv("DD_TAGS", "env:test, aKey:aVal,bKey:bVal, cKey:")
 
 		assert := assert.New(t)
-		c, err := newConfig(WithAgentTimeout(2))
+		c, err := newTestConfig(WithAgentTimeout(2))
 		assert.NoError(err)
 		globalTags := c.globalTags.get()
 		assert.Equal("test", globalTags["env"])
@@ -751,14 +751,14 @@ func TestTracerOptionsDefaults(t *testing.T) {
 
 	t.Run("profiler-endpoints", func(t *testing.T) {
 		t.Run("default", func(t *testing.T) {
-			c, err := newConfig(WithAgentTimeout(2))
+			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(t, err)
 			assert.True(t, c.profilerEndpoints)
 		})
 
 		t.Run("override", func(t *testing.T) {
 			t.Setenv(traceprof.EndpointEnvVar, "false")
-			c, err := newConfig(WithAgentTimeout(2))
+			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(t, err)
 			assert.False(t, c.profilerEndpoints)
 		})
@@ -766,14 +766,14 @@ func TestTracerOptionsDefaults(t *testing.T) {
 
 	t.Run("profiler-hotspots", func(t *testing.T) {
 		t.Run("default", func(t *testing.T) {
-			c, err := newConfig(WithAgentTimeout(2))
+			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(t, err)
 			assert.True(t, c.profilerHotspots)
 		})
 
 		t.Run("override", func(t *testing.T) {
 			t.Setenv(traceprof.CodeHotspotsEnvVar, "false")
-			c, err := newConfig(WithAgentTimeout(2))
+			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(t, err)
 			assert.False(t, c.profilerHotspots)
 		})
@@ -783,7 +783,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		t.Setenv("DD_SERVICE_MAPPING", "tracer.test:test2, svc:Newsvc,http.router:myRouter, noval:")
 
 		assert := assert.New(t)
-		c, err := newConfig(WithAgentTimeout(2))
+		c, err := newTestConfig(WithAgentTimeout(2))
 
 		assert.NoError(err)
 		assert.Equal("test2", c.serviceMappings["tracer.test"])
@@ -796,7 +796,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		t.Run("can-set-value", func(t *testing.T) {
 			t.Setenv("DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH", "200")
 			assert := assert.New(t)
-			c, err := newConfig(WithAgentTimeout(2))
+			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(err)
 			p := c.propagator.(*chainedPropagator).injectors[0].(*propagator)
 			assert.Equal(200, p.cfg.MaxTagsHeaderLen)
@@ -804,7 +804,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 
 		t.Run("default", func(t *testing.T) {
 			assert := assert.New(t)
-			c, err := newConfig(WithAgentTimeout(2))
+			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(err)
 			p := c.propagator.(*chainedPropagator).injectors[0].(*propagator)
 			assert.Equal(128, p.cfg.MaxTagsHeaderLen)
@@ -813,7 +813,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		t.Run("clamped-to-zero", func(t *testing.T) {
 			t.Setenv("DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH", "-520")
 			assert := assert.New(t)
-			c, err := newConfig(WithAgentTimeout(2))
+			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(err)
 			p := c.propagator.(*chainedPropagator).injectors[0].(*propagator)
 			assert.Equal(0, p.cfg.MaxTagsHeaderLen)
@@ -822,7 +822,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		t.Run("upper-clamp", func(t *testing.T) {
 			t.Setenv("DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH", "1000")
 			assert := assert.New(t)
-			c, err := newConfig(WithAgentTimeout(2))
+			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(err)
 			p := c.propagator.(*chainedPropagator).injectors[0].(*propagator)
 			assert.Equal(512, p.cfg.MaxTagsHeaderLen)
@@ -831,7 +831,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 
 	t.Run("peer-service", func(t *testing.T) {
 		t.Run("defaults", func(t *testing.T) {
-			c, err := newConfig(WithAgentTimeout(2))
+			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(t, err)
 			assert.Equal(t, c.peerServiceDefaultsEnabled, false)
 			assert.Empty(t, c.peerServiceMappings)
@@ -839,7 +839,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 
 		t.Run("defaults-with-schema-v1", func(t *testing.T) {
 			t.Setenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", "v1")
-			c, err := newConfig(WithAgentTimeout(2))
+			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(t, err)
 			assert.Equal(t, c.peerServiceDefaultsEnabled, true)
 			assert.Empty(t, c.peerServiceMappings)
@@ -848,14 +848,14 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		t.Run("env-vars", func(t *testing.T) {
 			t.Setenv("DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED", "true")
 			t.Setenv("DD_TRACE_PEER_SERVICE_MAPPING", "old:new,old2:new2")
-			c, err := newConfig(WithAgentTimeout(2))
+			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(t, err)
 			assert.Equal(t, c.peerServiceDefaultsEnabled, true)
 			assert.Equal(t, c.peerServiceMappings, map[string]string{"old": "new", "old2": "new2"})
 		})
 
 		t.Run("options", func(t *testing.T) {
-			c, err := newConfig(WithAgentTimeout(2))
+			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(t, err)
 			WithPeerServiceDefaults(true)(c)
 			WithPeerServiceMapping("old", "new")(c)
@@ -867,7 +867,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 
 	t.Run("debug-open-spans", func(t *testing.T) {
 		t.Run("defaults", func(t *testing.T) {
-			c, err := newConfig(WithAgentTimeout(2))
+			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(t, err)
 			assert.Equal(t, false, c.debugAbandonedSpans)
 			assert.Equal(t, time.Duration(0), c.spanTimeout)
@@ -875,7 +875,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 
 		t.Run("debug-on", func(t *testing.T) {
 			t.Setenv("DD_TRACE_DEBUG_ABANDONED_SPANS", "true")
-			c, err := newConfig(WithAgentTimeout(2))
+			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(t, err)
 			assert.Equal(t, true, c.debugAbandonedSpans)
 			assert.Equal(t, 10*time.Minute, c.spanTimeout)
@@ -884,14 +884,14 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		t.Run("timeout-set", func(t *testing.T) {
 			t.Setenv("DD_TRACE_DEBUG_ABANDONED_SPANS", "true")
 			t.Setenv("DD_TRACE_ABANDONED_SPAN_TIMEOUT", fmt.Sprint(time.Minute))
-			c, err := newConfig(WithAgentTimeout(2))
+			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(t, err)
 			assert.Equal(t, true, c.debugAbandonedSpans)
 			assert.Equal(t, time.Minute, c.spanTimeout)
 		})
 
 		t.Run("with-function", func(t *testing.T) {
-			c, err := newConfig(WithAgentTimeout(2))
+			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(t, err)
 			WithDebugSpansMode(time.Second)(c)
 			assert.Equal(t, true, c.debugAbandonedSpans)
@@ -901,14 +901,14 @@ func TestTracerOptionsDefaults(t *testing.T) {
 
 	t.Run("agent-timeout", func(t *testing.T) {
 		t.Run("defaults", func(t *testing.T) {
-			c, err := newConfig()
+			c, err := newTestConfig()
 			assert.NoError(t, err)
 			assert.Equal(t, time.Duration(10*time.Second), c.httpClient.Timeout)
 		})
 	})
 
 	t.Run("trace-retries", func(t *testing.T) {
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(t, err)
 		assert.Equal(t, 0, c.sendRetries)
 		assert.Equal(t, time.Millisecond, c.retryInterval)
@@ -917,12 +917,12 @@ func TestTracerOptionsDefaults(t *testing.T) {
 
 func TestTraceRetry(t *testing.T) {
 	t.Run("sendRetries", func(t *testing.T) {
-		c, err := newConfig(WithSendRetries(10))
+		c, err := newTestConfig(WithSendRetries(10))
 		assert.NoError(t, err)
 		assert.Equal(t, 10, c.sendRetries)
 	})
 	t.Run("retryInterval", func(t *testing.T) {
-		c, err := newConfig(WithRetryInterval(10))
+		c, err := newTestConfig(WithRetryInterval(10))
 		assert.NoError(t, err)
 		assert.Equal(t, 10*time.Second, c.retryInterval)
 	})
@@ -1046,7 +1046,7 @@ func TestServiceName(t *testing.T) {
 	t.Run("WithService", func(t *testing.T) {
 		defer globalconfig.SetServiceName("")
 		assert := assert.New(t)
-		c, err := newConfig(
+		c, err := newTestConfig(
 			WithService("api-intake"),
 		)
 		assert.NoError(err)
@@ -1058,7 +1058,7 @@ func TestServiceName(t *testing.T) {
 		defer globalconfig.SetServiceName("")
 		t.Setenv("DD_SERVICE", "api-intake")
 		assert := assert.New(t)
-		c, err := newConfig()
+		c, err := newTestConfig()
 
 		assert.NoError(err)
 		assert.Equal("api-intake", c.serviceName)
@@ -1071,7 +1071,7 @@ func TestServiceName(t *testing.T) {
 		}()
 		t.Setenv("OTEL_SERVICE_NAME", "api-intake")
 		assert := assert.New(t)
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(err)
 
 		assert.Equal("api-intake", c.serviceName)
@@ -1081,7 +1081,7 @@ func TestServiceName(t *testing.T) {
 	t.Run("WithGlobalTag", func(t *testing.T) {
 		defer globalconfig.SetServiceName("")
 		assert := assert.New(t)
-		c, err := newConfig(WithGlobalTag("service", "api-intake"))
+		c, err := newTestConfig(WithGlobalTag("service", "api-intake"))
 		assert.NoError(err)
 		assert.Equal("api-intake", c.serviceName)
 		assert.Equal("api-intake", globalconfig.ServiceName())
@@ -1093,7 +1093,7 @@ func TestServiceName(t *testing.T) {
 		}()
 		t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=api-intake")
 		assert := assert.New(t)
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(err)
 
 		assert.Equal("api-intake", c.serviceName)
@@ -1104,7 +1104,7 @@ func TestServiceName(t *testing.T) {
 		defer globalconfig.SetServiceName("")
 		t.Setenv("DD_TAGS", "service:api-intake")
 		assert := assert.New(t)
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(err)
 
 		assert.Equal("api-intake", c.serviceName)
@@ -1117,47 +1117,47 @@ func TestServiceName(t *testing.T) {
 		}()
 		assert := assert.New(t)
 		globalconfig.SetServiceName("")
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(err)
 		assert.Equal(c.serviceName, filepath.Base(os.Args[0]))
 		assert.Equal("", globalconfig.ServiceName())
 
 		t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=testService6")
 		globalconfig.SetServiceName("")
-		c, err = newConfig()
+		c, err = newTestConfig()
 		assert.NoError(err)
 		assert.Equal(c.serviceName, "testService6")
 		assert.Equal("testService6", globalconfig.ServiceName())
 
 		t.Setenv("DD_TAGS", "service:testService")
 		globalconfig.SetServiceName("")
-		c, err = newConfig()
+		c, err = newTestConfig()
 		assert.NoError(err)
 		assert.Equal(c.serviceName, "testService")
 		assert.Equal("testService", globalconfig.ServiceName())
 
 		globalconfig.SetServiceName("")
-		c, err = newConfig(WithGlobalTag("service", "testService2"))
+		c, err = newTestConfig(WithGlobalTag("service", "testService2"))
 		assert.NoError(err)
 		assert.Equal(c.serviceName, "testService2")
 		assert.Equal("testService2", globalconfig.ServiceName())
 
 		t.Setenv("OTEL_SERVICE_NAME", "testService3")
 		globalconfig.SetServiceName("")
-		c, err = newConfig(WithGlobalTag("service", "testService2"))
+		c, err = newTestConfig(WithGlobalTag("service", "testService2"))
 		assert.NoError(err)
 		assert.Equal(c.serviceName, "testService3")
 		assert.Equal("testService3", globalconfig.ServiceName())
 
 		t.Setenv("DD_SERVICE", "testService4")
 		globalconfig.SetServiceName("")
-		c, err = newConfig(WithGlobalTag("service", "testService2"), WithService("testService4"))
+		c, err = newTestConfig(WithGlobalTag("service", "testService2"), WithService("testService4"))
 		assert.NoError(err)
 		assert.Equal(c.serviceName, "testService4")
 		assert.Equal("testService4", globalconfig.ServiceName())
 
 		globalconfig.SetServiceName("")
-		c, err = newConfig(WithGlobalTag("service", "testService2"), WithService("testService5"))
+		c, err = newTestConfig(WithGlobalTag("service", "testService2"), WithService("testService5"))
 		assert.NoError(err)
 		assert.Equal(c.serviceName, "testService5")
 		assert.Equal("testService5", globalconfig.ServiceName())
@@ -1184,7 +1184,7 @@ func TestOtelResourceAtttributes(t *testing.T) {
 	t.Run("max 10", func(t *testing.T) {
 		assert := assert.New(t)
 		t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "tag1=val1,tag2=val2,tag3=val3,tag4=val4,tag5=val5,tag6=val6,tag7=val7,tag8=val8,tag9=val9,tag10=val10,tag11=val11,tag12=val12")
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(err)
 		globalTags := c.globalTags.get()
 		// runtime-id tag is added automatically, so we expect runtime-id + our first 10 tags
@@ -1277,7 +1277,7 @@ func TestTagSeparators(t *testing.T) {
 	} {
 		t.Run("", func(t *testing.T) {
 			t.Setenv("DD_TAGS", tag.in)
-			c, err := newConfig()
+			c, err := newTestConfig()
 			assert.NoError(err)
 			globalTags := c.globalTags.get()
 			for key, expected := range tag.out {
@@ -1292,7 +1292,7 @@ func TestTagSeparators(t *testing.T) {
 func TestVersionConfig(t *testing.T) {
 	t.Run("WithServiceVersion", func(t *testing.T) {
 		assert := assert.New(t)
-		c, err := newConfig(
+		c, err := newTestConfig(
 			WithServiceVersion("1.2.3"),
 		)
 		assert.NoError(err)
@@ -1302,7 +1302,7 @@ func TestVersionConfig(t *testing.T) {
 	t.Run("env", func(t *testing.T) {
 		t.Setenv("DD_VERSION", "1.2.3")
 		assert := assert.New(t)
-		c, err := newConfig()
+		c, err := newTestConfig()
 
 		assert.NoError(err)
 		assert.Equal("1.2.3", c.version)
@@ -1310,7 +1310,7 @@ func TestVersionConfig(t *testing.T) {
 
 	t.Run("WithGlobalTag", func(t *testing.T) {
 		assert := assert.New(t)
-		c, err := newConfig(WithGlobalTag("version", "1.2.3"))
+		c, err := newTestConfig(WithGlobalTag("version", "1.2.3"))
 		assert.NoError(err)
 		assert.Equal("1.2.3", c.version)
 	})
@@ -1318,7 +1318,7 @@ func TestVersionConfig(t *testing.T) {
 	t.Run("OTEL_RESOURCE_ATTRIBUTES", func(t *testing.T) {
 		t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.version=1.2.3")
 		assert := assert.New(t)
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(err)
 
 		assert.Equal("1.2.3", c.version)
@@ -1327,7 +1327,7 @@ func TestVersionConfig(t *testing.T) {
 	t.Run("DD_TAGS", func(t *testing.T) {
 		t.Setenv("DD_TAGS", "version:1.2.3")
 		assert := assert.New(t)
-		c, err := newConfig()
+		c, err := newTestConfig()
 
 		assert.NoError(err)
 		assert.Equal("1.2.3", c.version)
@@ -1335,30 +1335,30 @@ func TestVersionConfig(t *testing.T) {
 
 	t.Run("override-chain", func(t *testing.T) {
 		assert := assert.New(t)
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(err)
 		assert.Equal(c.version, "")
 
 		t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.version=1.1.0")
-		c, err = newConfig()
+		c, err = newTestConfig()
 		assert.NoError(err)
 		assert.Equal("1.1.0", c.version)
 
 		t.Setenv("DD_TAGS", "version:1.1.1")
-		c, err = newConfig()
+		c, err = newTestConfig()
 		assert.NoError(err)
 		assert.Equal("1.1.1", c.version)
 
-		c, err = newConfig(WithGlobalTag("version", "1.1.2"))
+		c, err = newTestConfig(WithGlobalTag("version", "1.1.2"))
 		assert.NoError(err)
 		assert.Equal("1.1.2", c.version)
 
 		t.Setenv("DD_VERSION", "1.1.3")
-		c, err = newConfig(WithGlobalTag("version", "1.1.2"))
+		c, err = newTestConfig(WithGlobalTag("version", "1.1.2"))
 		assert.NoError(err)
 		assert.Equal("1.1.3", c.version)
 
-		c, err = newConfig(WithGlobalTag("version", "1.1.2"), WithServiceVersion("1.1.4"))
+		c, err = newTestConfig(WithGlobalTag("version", "1.1.2"), WithServiceVersion("1.1.4"))
 		assert.NoError(err)
 		assert.Equal("1.1.4", c.version)
 	})
@@ -1367,7 +1367,7 @@ func TestVersionConfig(t *testing.T) {
 func TestEnvConfig(t *testing.T) {
 	t.Run("WithEnv", func(t *testing.T) {
 		assert := assert.New(t)
-		c, err := newConfig(
+		c, err := newTestConfig(
 			WithEnv("testing"),
 		)
 		assert.NoError(err)
@@ -1377,7 +1377,7 @@ func TestEnvConfig(t *testing.T) {
 	t.Run("env", func(t *testing.T) {
 		t.Setenv("DD_ENV", "testing")
 		assert := assert.New(t)
-		c, err := newConfig()
+		c, err := newTestConfig()
 
 		assert.NoError(err)
 		assert.Equal("testing", c.env)
@@ -1385,7 +1385,7 @@ func TestEnvConfig(t *testing.T) {
 
 	t.Run("WithGlobalTag", func(t *testing.T) {
 		assert := assert.New(t)
-		c, err := newConfig(WithGlobalTag("env", "testing"))
+		c, err := newTestConfig(WithGlobalTag("env", "testing"))
 		assert.NoError(err)
 		assert.Equal("testing", c.env)
 	})
@@ -1393,7 +1393,7 @@ func TestEnvConfig(t *testing.T) {
 	t.Run("OTEL_RESOURCE_ATTRIBUTES", func(t *testing.T) {
 		t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=testing")
 		assert := assert.New(t)
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(err)
 
 		assert.Equal("testing", c.env)
@@ -1402,7 +1402,7 @@ func TestEnvConfig(t *testing.T) {
 	t.Run("DD_TAGS", func(t *testing.T) {
 		t.Setenv("DD_TAGS", "env:testing")
 		assert := assert.New(t)
-		c, err := newConfig()
+		c, err := newTestConfig()
 
 		assert.NoError(err)
 		assert.Equal("testing", c.env)
@@ -1410,30 +1410,30 @@ func TestEnvConfig(t *testing.T) {
 
 	t.Run("override-chain", func(t *testing.T) {
 		assert := assert.New(t)
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(err)
 		assert.Equal(c.env, "")
 
 		t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=testing0")
-		c, err = newConfig()
+		c, err = newTestConfig()
 		assert.NoError(err)
 		assert.Equal("testing0", c.env)
 
 		t.Setenv("DD_TAGS", "env:testing1")
-		c, err = newConfig()
+		c, err = newTestConfig()
 		assert.NoError(err)
 		assert.Equal("testing1", c.env)
 
-		c, err = newConfig(WithGlobalTag("env", "testing2"))
+		c, err = newTestConfig(WithGlobalTag("env", "testing2"))
 		assert.NoError(err)
 		assert.Equal("testing2", c.env)
 
 		t.Setenv("DD_ENV", "testing3")
-		c, err = newConfig(WithGlobalTag("env", "testing2"))
+		c, err = newTestConfig(WithGlobalTag("env", "testing2"))
 		assert.NoError(err)
 		assert.Equal("testing3", c.env)
 
-		c, err = newConfig(WithGlobalTag("env", "testing2"), WithEnv("testing4"))
+		c, err = newTestConfig(WithGlobalTag("env", "testing2"), WithEnv("testing4"))
 		assert.NoError(err)
 		assert.Equal("testing4", c.env)
 	})
@@ -1441,7 +1441,7 @@ func TestEnvConfig(t *testing.T) {
 
 func TestStatsTags(t *testing.T) {
 	assert := assert.New(t)
-	c, err := newConfig(WithService("serviceName"), WithEnv("envName"))
+	c, err := newTestConfig(WithService("serviceName"), WithEnv("envName"))
 	assert.NoError(err)
 	defer globalconfig.SetServiceName("")
 	c.hostname = "hostName"
@@ -1472,7 +1472,7 @@ func TestGlobalTag(t *testing.T) {
 func TestWithHostname(t *testing.T) {
 	t.Run("WithHostname", func(t *testing.T) {
 		assert := assert.New(t)
-		c, err := newConfig(WithHostname("hostname"))
+		c, err := newTestConfig(WithHostname("hostname"))
 		assert.NoError(err)
 		assert.Equal("hostname", c.hostname)
 	})
@@ -1480,7 +1480,7 @@ func TestWithHostname(t *testing.T) {
 	t.Run("env", func(t *testing.T) {
 		assert := assert.New(t)
 		t.Setenv("DD_TRACE_SOURCE_HOSTNAME", "hostname-env")
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(err)
 		assert.Equal("hostname-env", c.hostname)
 	})
@@ -1489,7 +1489,7 @@ func TestWithHostname(t *testing.T) {
 		assert := assert.New(t)
 
 		t.Setenv("DD_TRACE_SOURCE_HOSTNAME", "hostname-env")
-		c, err := newConfig(WithHostname("hostname-middleware"))
+		c, err := newTestConfig(WithHostname("hostname-middleware"))
 		assert.NoError(err)
 		assert.Equal("hostname-middleware", c.hostname)
 	})
@@ -1498,7 +1498,7 @@ func TestWithHostname(t *testing.T) {
 func TestWithTraceEnabled(t *testing.T) {
 	t.Run("WithTraceEnabled", func(t *testing.T) {
 		assert := assert.New(t)
-		c, err := newConfig(WithTraceEnabled(false))
+		c, err := newTestConfig(WithTraceEnabled(false))
 		assert.NoError(err)
 		assert.False(c.enabled.current)
 	})
@@ -1506,7 +1506,7 @@ func TestWithTraceEnabled(t *testing.T) {
 	t.Run("otel-env", func(t *testing.T) {
 		assert := assert.New(t)
 		t.Setenv("OTEL_TRACES_EXPORTER", "none")
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(err)
 		assert.False(c.enabled.current)
 	})
@@ -1514,7 +1514,7 @@ func TestWithTraceEnabled(t *testing.T) {
 	t.Run("dd-env", func(t *testing.T) {
 		assert := assert.New(t)
 		t.Setenv("DD_TRACE_ENABLED", "false")
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(err)
 		assert.False(c.enabled.current)
 	})
@@ -1524,18 +1524,18 @@ func TestWithTraceEnabled(t *testing.T) {
 		// dd env overrides otel env
 		t.Setenv("OTEL_TRACES_EXPORTER", "none")
 		t.Setenv("DD_TRACE_ENABLED", "true")
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(err)
 		assert.True(c.enabled.current)
 		// tracer option overrides dd env
-		c, err = newConfig(WithTraceEnabled(false))
+		c, err = newTestConfig(WithTraceEnabled(false))
 		assert.NoError(err)
 		assert.False(c.enabled.current)
 	})
 }
 
 func TestWithLogStartup(t *testing.T) {
-	c, err := newConfig()
+	c, err := newTestConfig()
 	assert.NoError(t, err)
 	assert.True(t, c.logStartup)
 	WithLogStartup(false)(c)
@@ -1548,7 +1548,7 @@ func TestWithHeaderTags(t *testing.T) {
 	t.Run("default-off", func(t *testing.T) {
 		defer globalconfig.ClearHeaderTags()
 		assert := assert.New(t)
-		newConfig()
+		newTestConfig()
 		assert.Equal(0, globalconfig.HeaderTagsLen())
 	})
 
@@ -1556,7 +1556,7 @@ func TestWithHeaderTags(t *testing.T) {
 		defer globalconfig.ClearHeaderTags()
 		assert := assert.New(t)
 		header := "Header"
-		newConfig(WithHeaderTags([]string{header}))
+		newTestConfig(WithHeaderTags([]string{header}))
 		assert.Equal("http.request.headers.header", globalconfig.HeaderTag(header))
 	})
 
@@ -1565,14 +1565,14 @@ func TestWithHeaderTags(t *testing.T) {
 		assert := assert.New(t)
 		header := "Header"
 		tag := "tag"
-		newConfig(WithHeaderTags([]string{header + ":" + tag}))
+		newTestConfig(WithHeaderTags([]string{header + ":" + tag}))
 		assert.Equal("tag", globalconfig.HeaderTag(header))
 	})
 
 	t.Run("multi-header", func(t *testing.T) {
 		defer globalconfig.ClearHeaderTags()
 		assert := assert.New(t)
-		newConfig(WithHeaderTags([]string{"1header:1tag", "2header", "3header:3tag"}))
+		newTestConfig(WithHeaderTags([]string{"1header:1tag", "2header", "3header:3tag"}))
 		assert.Equal("1tag", globalconfig.HeaderTag("1header"))
 		assert.Equal("http.request.headers.2header", globalconfig.HeaderTag("2header"))
 		assert.Equal("3tag", globalconfig.HeaderTag("3header"))
@@ -1581,7 +1581,7 @@ func TestWithHeaderTags(t *testing.T) {
 	t.Run("normalization", func(t *testing.T) {
 		defer globalconfig.ClearHeaderTags()
 		assert := assert.New(t)
-		newConfig(WithHeaderTags([]string{"  h!e@a-d.e*r  ", "  2header:t!a@g.  "}))
+		newTestConfig(WithHeaderTags([]string{"  h!e@a-d.e*r  ", "  2header:t!a@g.  "}))
 		assert.Equal(ext.HTTPRequestHeaders+".h_e_a-d_e_r", globalconfig.HeaderTag("h!e@a-d.e*r"))
 		assert.Equal("t!a@g.", globalconfig.HeaderTag("2header"))
 	})
@@ -1591,7 +1591,7 @@ func TestWithHeaderTags(t *testing.T) {
 		t.Setenv("DD_TRACE_HEADER_TAGS", "  1header:1tag,2.h.e.a.d.e.r  ")
 
 		assert := assert.New(t)
-		newConfig()
+		newTestConfig()
 
 		assert.Equal("1tag", globalconfig.HeaderTag("1header"))
 		assert.Equal(ext.HTTPRequestHeaders+".2_h_e_a_d_e_r", globalconfig.HeaderTag("2.h.e.a.d.e.r"))
@@ -1602,7 +1602,7 @@ func TestWithHeaderTags(t *testing.T) {
 		t.Setenv("DD_TRACE_HEADER_TAGS", "header1:")
 
 		assert := assert.New(t)
-		newConfig()
+		newTestConfig()
 
 		assert.Equal(0, globalconfig.HeaderTagsLen())
 	})
@@ -1612,7 +1612,7 @@ func TestWithHeaderTags(t *testing.T) {
 		t.Setenv("DD_TRACE_HEADER_TAGS", "header1,header2:")
 
 		assert := assert.New(t)
-		newConfig()
+		newTestConfig()
 
 		assert.Equal(1, globalconfig.HeaderTagsLen())
 		fmt.Println(globalconfig.HeaderTagMap())
@@ -1623,7 +1623,7 @@ func TestWithHeaderTags(t *testing.T) {
 		defer globalconfig.ClearHeaderTags()
 		assert := assert.New(t)
 		t.Setenv("DD_TRACE_HEADER_TAGS", "unexpected")
-		newConfig(WithHeaderTags([]string{"expected"}))
+		newTestConfig(WithHeaderTags([]string{"expected"}))
 		assert.Equal(ext.HTTPRequestHeaders+".expected", globalconfig.HeaderTag("Expected"))
 		assert.Equal(1, globalconfig.HeaderTagsLen())
 	})
@@ -1634,13 +1634,13 @@ func TestWithHeaderTags(t *testing.T) {
 
 func TestHostnameDisabled(t *testing.T) {
 	t.Run("Default", func(t *testing.T) {
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(t, err)
 		assert.False(t, c.enableHostnameDetection)
 	})
 	t.Run("EnableViaEnv", func(t *testing.T) {
 		t.Setenv("DD_TRACE_CLIENT_HOSTNAME_COMPAT", "v1.66")
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(t, err)
 		assert.True(t, c.enableHostnameDetection)
 	})
@@ -1648,28 +1648,28 @@ func TestHostnameDisabled(t *testing.T) {
 
 func TestPartialFlushing(t *testing.T) {
 	t.Run("None", func(t *testing.T) {
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(t, err)
 		assert.False(t, c.partialFlushEnabled)
 		assert.Equal(t, partialFlushMinSpansDefault, c.partialFlushMinSpans)
 	})
 	t.Run("Disabled-DefaultMinSpans", func(t *testing.T) {
 		t.Setenv("DD_TRACE_PARTIAL_FLUSH_ENABLED", "false")
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(t, err)
 		assert.False(t, c.partialFlushEnabled)
 		assert.Equal(t, partialFlushMinSpansDefault, c.partialFlushMinSpans)
 	})
 	t.Run("Default-SetMinSpans", func(t *testing.T) {
 		t.Setenv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", "10")
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(t, err)
 		assert.False(t, c.partialFlushEnabled)
 		assert.Equal(t, 10, c.partialFlushMinSpans)
 	})
 	t.Run("Enabled-DefaultMinSpans", func(t *testing.T) {
 		t.Setenv("DD_TRACE_PARTIAL_FLUSH_ENABLED", "true")
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(t, err)
 		assert.True(t, c.partialFlushEnabled)
 		assert.Equal(t, partialFlushMinSpansDefault, c.partialFlushMinSpans)
@@ -1677,7 +1677,7 @@ func TestPartialFlushing(t *testing.T) {
 	t.Run("Enabled-SetMinSpans", func(t *testing.T) {
 		t.Setenv("DD_TRACE_PARTIAL_FLUSH_ENABLED", "true")
 		t.Setenv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", "10")
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(t, err)
 		assert.True(t, c.partialFlushEnabled)
 		assert.Equal(t, 10, c.partialFlushMinSpans)
@@ -1685,13 +1685,13 @@ func TestPartialFlushing(t *testing.T) {
 	t.Run("Enabled-SetMinSpansNegative", func(t *testing.T) {
 		t.Setenv("DD_TRACE_PARTIAL_FLUSH_ENABLED", "true")
 		t.Setenv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", "-1")
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(t, err)
 		assert.True(t, c.partialFlushEnabled)
 		assert.Equal(t, partialFlushMinSpansDefault, c.partialFlushMinSpans)
 	})
 	t.Run("WithPartialFlushOption", func(t *testing.T) {
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(t, err)
 		WithPartialFlushing(20)(c)
 		assert.True(t, c.partialFlushEnabled)
@@ -1702,33 +1702,33 @@ func TestPartialFlushing(t *testing.T) {
 func TestWithStatsComputation(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		assert := assert.New(t)
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(err)
 		assert.True(c.statsComputationEnabled)
 	})
 	t.Run("enabled-via-option", func(t *testing.T) {
 		assert := assert.New(t)
-		c, err := newConfig(WithStatsComputation(true))
+		c, err := newTestConfig(WithStatsComputation(true))
 		assert.NoError(err)
 		assert.True(c.statsComputationEnabled)
 	})
 	t.Run("disabled-via-option", func(t *testing.T) {
 		assert := assert.New(t)
-		c, err := newConfig(WithStatsComputation(false))
+		c, err := newTestConfig(WithStatsComputation(false))
 		assert.NoError(err)
 		assert.False(c.statsComputationEnabled)
 	})
 	t.Run("enabled-via-env", func(t *testing.T) {
 		assert := assert.New(t)
 		t.Setenv("DD_TRACE_STATS_COMPUTATION_ENABLED", "true")
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(err)
 		assert.True(c.statsComputationEnabled)
 	})
 	t.Run("env-override", func(t *testing.T) {
 		assert := assert.New(t)
 		t.Setenv("DD_TRACE_STATS_COMPUTATION_ENABLED", "false")
-		c, err := newConfig(WithStatsComputation(true))
+		c, err := newTestConfig(WithStatsComputation(true))
 		assert.NoError(err)
 		assert.True(c.statsComputationEnabled)
 	})
@@ -1891,7 +1891,7 @@ func TestNoHTTPClientOverride(t *testing.T) {
 		assert := assert.New(t)
 		client := http.DefaultClient
 		client.Timeout = 30 * time.Second // Default is 10s
-		c, err := newConfig(
+		c, err := newTestConfig(
 			WithHTTPClient(client),
 			WithUDS("/tmp/agent.sock"),
 		)

--- a/ddtrace/tracer/sampler_test.go
+++ b/ddtrace/tracer/sampler_test.go
@@ -214,7 +214,7 @@ func TestRuleEnvVars(t *testing.T) {
 			{in: "1point0", out: math.NaN()}, // default if invalid value
 		} {
 			t.Setenv("DD_TRACE_SAMPLE_RATE", tt.in)
-			c, err := newConfig()
+			c, err := newTestConfig()
 			assert.NoError(err)
 			res := c.globalSampleRate
 			if math.IsNaN(tt.out) {
@@ -241,7 +241,7 @@ func TestRuleEnvVars(t *testing.T) {
 				assert := assert.New(t)
 				t.Setenv("OTEL_TRACES_SAMPLER", tt.config)
 				t.Setenv("OTEL_TRACES_SAMPLER_ARG", fmt.Sprintf("%f", tt.rate))
-				c, err := newConfig()
+				c, err := newTestConfig()
 				assert.NoError(err)
 				res := c.globalSampleRate
 				assert.Equal(tt.rate, res)
@@ -264,7 +264,7 @@ func TestRuleEnvVars(t *testing.T) {
 			{in: "1point0", out: rate.NewLimiter(100.0, 100)}, // default if invalid value
 		} {
 			t.Setenv("DD_TRACE_RATE_LIMIT", tt.in)
-			c, err := newConfig()
+			c, err := newTestConfig()
 			assert.NoError(err)
 			res := newRateLimiter(c.traceRateLimitPerSecond)
 			assert.Equal(tt.out, res.limiter)
@@ -497,7 +497,7 @@ func TestRulesSampler(t *testing.T) {
 	}
 	t.Run("no-rules", func(t *testing.T) {
 		assert := assert.New(t)
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(err)
 		rs := newRulesSampler(nil, nil, c.globalSampleRate, c.traceRateLimitPerSecond)
 
@@ -564,7 +564,7 @@ func TestRulesSampler(t *testing.T) {
 				assert.Nil(t, err)
 
 				assert := assert.New(t)
-				c, err := newConfig()
+				c, err := newTestConfig()
 				assert.NoError(err)
 				rs := newRulesSampler(rules, nil, c.globalSampleRate, c.traceRateLimitPerSecond)
 
@@ -590,7 +590,7 @@ func TestRulesSampler(t *testing.T) {
 		for _, v := range traceRules {
 			t.Run("", func(t *testing.T) {
 				assert := assert.New(t)
-				c, err := newConfig()
+				c, err := newTestConfig()
 				assert.NoError(err)
 				rs := newRulesSampler(v, nil, c.globalSampleRate, c.traceRateLimitPerSecond)
 
@@ -618,7 +618,7 @@ func TestRulesSampler(t *testing.T) {
 		for _, v := range traceRules {
 			t.Run("", func(t *testing.T) {
 				assert := assert.New(t)
-				c, err := newConfig()
+				c, err := newTestConfig()
 				assert.NoError(err)
 				rs := newRulesSampler(v, nil, c.globalSampleRate, c.traceRateLimitPerSecond)
 
@@ -666,7 +666,7 @@ func TestRulesSampler(t *testing.T) {
 				_, rules, err := samplingRulesFromEnv()
 				assert.Nil(t, err)
 				assert := assert.New(t)
-				c, err := newConfig()
+				c, err := newTestConfig()
 				assert.NoError(err)
 				rs := newRulesSampler(nil, rules, c.globalSampleRate, c.traceRateLimitPerSecond)
 
@@ -790,7 +790,7 @@ func TestRulesSampler(t *testing.T) {
 		} {
 			t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
 				assert := assert.New(t)
-				c, err := newConfig(WithSamplingRules(tt.rules))
+				c, err := newTestConfig(WithSamplingRules(tt.rules))
 				assert.NoError(err)
 				rs := newRulesSampler(nil, c.spanRules, c.globalSampleRate, c.traceRateLimitPerSecond)
 
@@ -860,7 +860,7 @@ func TestRulesSampler(t *testing.T) {
 				_, rules, _ := samplingRulesFromEnv()
 
 				assert := assert.New(t)
-				c, err := newConfig()
+				c, err := newTestConfig()
 				assert.NoError(err)
 				rs := newRulesSampler(nil, rules, c.globalSampleRate, c.traceRateLimitPerSecond)
 
@@ -969,7 +969,7 @@ func TestRulesSampler(t *testing.T) {
 		} {
 			t.Run("", func(t *testing.T) {
 				assert := assert.New(t)
-				c, err := newConfig(WithSamplingRules(tt.rules))
+				c, err := newTestConfig(WithSamplingRules(tt.rules))
 				assert.NoError(err)
 				rs := newRulesSampler(nil, c.spanRules, c.globalSampleRate, c.traceRateLimitPerSecond)
 
@@ -1000,7 +1000,7 @@ func TestRulesSampler(t *testing.T) {
 				t.Run("", func(t *testing.T) {
 					assert := assert.New(t)
 					t.Setenv("DD_TRACE_SAMPLE_RATE", fmt.Sprint(rate))
-					c, err := newConfig()
+					c, err := newTestConfig()
 					assert.NoError(err)
 					rs := newRulesSampler(nil, rules, c.globalSampleRate, c.traceRateLimitPerSecond)
 
@@ -1288,7 +1288,7 @@ func TestRulesSamplerInternals(t *testing.T) {
 	t.Run("full-rate", func(t *testing.T) {
 		assert := assert.New(t)
 		now := time.Now()
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(err)
 		rs := newRulesSampler(nil, nil, c.globalSampleRate, c.traceRateLimitPerSecond)
 		// set samplingLimiter to specific state
@@ -1305,7 +1305,7 @@ func TestRulesSamplerInternals(t *testing.T) {
 	t.Run("limited-rate", func(t *testing.T) {
 		assert := assert.New(t)
 		now := time.Now()
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(err)
 		rs := newRulesSampler(nil, nil, c.globalSampleRate, c.traceRateLimitPerSecond)
 		// force sampling limiter to 1.0 spans/sec

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -1610,6 +1610,7 @@ func TestStatsAfterFinish(t *testing.T) {
 		c := newConcentrator(tracer.config, (10 * time.Second).Nanoseconds(), &statsd.NoOpClientDirect{})
 		assert.Len(t, transport.Stats(), 0)
 		c.Start()
+		tracer.stats.Stop()
 		tracer.stats = c
 
 		sp := tracer.StartSpan("sp1")
@@ -1646,6 +1647,7 @@ func TestStatsAfterFinish(t *testing.T) {
 		c := newConcentrator(tracer.config, (10 * time.Second).Nanoseconds(), &statsd.NoOpClientDirect{})
 		assert.Len(t, transport.Stats(), 0)
 		c.Start()
+		tracer.stats.Stop()
 		tracer.stats = c
 
 		sp := tracer.StartSpan("sp1")

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -273,7 +273,7 @@ func TestTraceFinishChunk(t *testing.T) {
 	assert := assert.New(t)
 	tracer, err := newUnstartedTracer()
 	assert.Nil(err)
-	defer tracer.statsd.Close()
+	defer tracer.Stop()
 
 	root := newSpan("name", "service", "resource", 0, 0, 0)
 	trace := root.context.trace

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -28,10 +28,10 @@ func reportTelemetryOnAppStarted(c telemetry.Configuration) {
 // event is sent with tracer config data.
 // Note that the tracer is not considered as a standalone product by telemetry so we cannot send
 // an app-product-change event for the tracer.
-func startTelemetry(c *config) {
+func startTelemetry(c *config) telemetry.Client {
 	if telemetry.Disabled() {
 		// Do not do extra work populating config data if instrumentation telemetry is disabled.
-		return
+		return nil
 	}
 
 	telemetry.ProductStarted(telemetry.NamespaceTracers)
@@ -116,7 +116,7 @@ func startTelemetry(c *config) {
 	client, err := telemetry.NewClient(c.serviceName, c.env, c.version, cfg)
 	if err != nil {
 		log.Debug("tracer: failed to create telemetry client: %s", err.Error())
-		return
+		return nil
 	}
 
 	if c.orchestrionCfg.Enabled {
@@ -126,4 +126,5 @@ func startTelemetry(c *config) {
 	}
 
 	telemetry.StartApp(client)
+	return client
 }

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -2191,7 +2191,7 @@ func TestOtelPropagator(t *testing.T) {
 		t.Setenv(otelHeaderPropagationStyle, test.env)
 		t.Run(fmt.Sprintf("inject with %v=%v", otelHeaderPropagationStyle, test.env), func(t *testing.T) {
 			assert := assert.New(t)
-			c, err := newConfig()
+			c, err := newTestConfig()
 			assert.NoError(err)
 			cp, ok := c.propagator.(*chainedPropagator)
 			assert.True(ok)

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -192,6 +192,7 @@ func TestTextMapExtractTracestatePropagation(t *testing.T) {
 				t.Setenv("DD_TRACE_PROPAGATION_EXTRACT_FIRST", "true")
 			}
 			tracer, err := newTracer()
+			defer tracer.Stop()
 			assert := assert.New(t)
 			assert.NoError(err)
 			headers := TextMapCarrier(map[string]string{

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -852,6 +852,7 @@ func (t *tracer) Stop() {
 	if t.telemetry != nil {
 		t.telemetry.Close()
 	}
+	t.config.httpClient.CloseIdleConnections()
 }
 
 // Inject uses the configured or default TextMap Propagator.

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -420,7 +420,7 @@ func newUnstartedTracer(opts ...StartOption) (t *tracer, err error) {
 	return t, nil
 }
 
-// newTracer creates a new no-op tracer for testing.
+// newTracer creates a new tracer and starts it.
 // NOTE: This function does NOT set the global tracer, which is required for
 // most finish span/flushing operations to work as expected. If you are calling
 // span.Finish and/or expecting flushing to work, you must call

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -213,6 +213,7 @@ func Start(opts ...StartOption) error {
 		// if tracing is disabled, but we still want to capture this
 		// telemetry information. Will be fixed when the tracer and profiler
 		// share control of the global telemetry client.
+		t.Stop()
 		return nil
 	}
 	setGlobalTracer(t)

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -160,6 +160,9 @@ type tracer struct {
 
 	// runtimeMetrics is submitting runtime metrics to the agent using statsd.
 	runtimeMetrics *runtimemetrics.Emitter
+
+	// telemetry is the telemetry client for the tracer.
+	telemetry telemetry.Client
 }
 
 const (
@@ -214,7 +217,7 @@ func Start(opts ...StartOption) error {
 
 		// start instrumentation telemetry unless it is disabled through the
 		// DD_INSTRUMENTATION_TELEMETRY_ENABLED env var
-		startTelemetry(t.config)
+		t.telemetry = startTelemetry(t.config)
 
 		globalinternal.SetTracerInitialized(true)
 		return nil
@@ -242,7 +245,7 @@ func Start(opts ...StartOption) error {
 
 	// start instrumentation telemetry unless it is disabled through the
 	// DD_INSTRUMENTATION_TELEMETRY_ENABLED env var
-	startTelemetry(t.config)
+	t.telemetry = startTelemetry(t.config)
 
 	// store the configuration in an in-memory file, allowing it to be read to
 	// determine if the process is instrumented with a tracer and to retrive
@@ -831,6 +834,9 @@ func (t *tracer) Stop() {
 	// Close log file last to account for any logs from the above calls
 	if t.logFile != nil {
 		t.logFile.Close()
+	}
+	if t.telemetry != nil {
+		t.telemetry.Close()
 	}
 }
 

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -173,6 +173,7 @@ func TestTracerCleanStop(t *testing.T) {
 	}()
 
 	wg.Wait()
+	Stop()
 }
 
 func TestTracerStart(t *testing.T) {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -758,7 +758,7 @@ func TestTracerRuntimeMetrics(t *testing.T) {
 
 	t.Run("otel-env", func(t *testing.T) {
 		t.Setenv("OTEL_METRICS_EXPORTER", "none")
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(t, err)
 		assert.False(t, c.runtimeMetrics)
 	})
@@ -767,12 +767,12 @@ func TestTracerRuntimeMetrics(t *testing.T) {
 		// dd env overrides otel env
 		t.Setenv("OTEL_METRICS_EXPORTER", "none")
 		t.Setenv("DD_RUNTIME_METRICS_ENABLED", "true")
-		c, err := newConfig()
+		c, err := newTestConfig()
 		assert.NoError(t, err)
 		assert.True(t, c.runtimeMetrics)
 		// tracer option overrides dd env
 		t.Setenv("DD_RUNTIME_METRICS_ENABLED", "false")
-		c, err = newConfig(WithRuntimeMetrics())
+		c, err = newTestConfig(WithRuntimeMetrics())
 		assert.NoError(t, err)
 		assert.True(t, c.runtimeMetrics)
 	})

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -121,7 +121,7 @@ func TestTracerCleanStop(t *testing.T) {
 		t.Skip("This test causes windows CI to fail due to out-of-memory issues")
 	}
 	// avoid CI timeouts due to AppSec and telemetry slowing down this test
-	t.Setenv("DD_APPSEC_ENABLED", "")
+	t.Setenv("DD_APPSEC_ENABLED", "false")
 	t.Setenv("DD_INSTRUMENTATION_TELEMETRY_ENABLED", "false")
 	t.Setenv("DD_TRACE_STARTUP_LOGS", "0")
 

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1342,6 +1342,7 @@ func TestTracerPrioritySampler(t *testing.T) {
 			}
 		}`))
 	}))
+	defer srv.Close()
 	url := "http://" + srv.Listener.Addr().String()
 
 	tr, _, flush, stop, err := startTestTracer(t,

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -2362,6 +2362,14 @@ func startTestTracer(t testing.TB, opts ...StartOption) (trc *tracer, transport 
 	}, nil
 }
 
+// newTestConfig wraps newConfig to set a default HTTP client with keep-alives
+// disabled. This is necessary to avoid goroutine leaks between tests, see
+// TestMain.
+func newTestConfig(opts ...StartOption) (*config, error) {
+	opts = append([]StartOption{WithHTTPClient(defaultHTTPClient(0, true))}, opts...)
+	return newConfig(opts...)
+}
+
 // comparePayloadSpans allows comparing two spans which might have been
 // read from the msgpack payload. In that case the private fields will
 // not be available and the maps (meta & metrics will be nil for lengths

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -257,6 +257,7 @@ func TestTracerLogFile(t *testing.T) {
 		}
 		t.Setenv("DD_TRACE_LOG_DIRECTORY", dir)
 		tracer, err := newTracer()
+		defer tracer.Stop()
 		assert.Nil(t, err)
 		assert.Equal(t, dir, tracer.config.logDirectory)
 		assert.NotNil(t, tracer.logFile)
@@ -266,7 +267,7 @@ func TestTracerLogFile(t *testing.T) {
 		t.Setenv("DD_TRACE_LOG_DIRECTORY", "some/nonexistent/path")
 		tracer, err := newTracer()
 		assert.Nil(t, err)
-		defer Stop()
+		defer tracer.Stop()
 		assert.Empty(t, tracer.config.logDirectory)
 		assert.Nil(t, tracer.logFile)
 	})

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/globalconfig"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/statsdtest"
+	"go.uber.org/goleak"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/stretchr/testify/assert"
@@ -77,7 +78,13 @@ func TestMain(m *testing.M) {
 		timeMultiplicator = time.Duration(2)
 	}
 	_, integration = os.LookupEnv("INTEGRATION")
-	os.Exit(m.Run())
+	// TODO(felixge): We should try to get rid of all the ignored functions
+	// below. And we should definitely try to not add any new ones here!
+	goleak.VerifyTestMain(
+		m,
+		goleak.IgnoreAnyFunction("github.com/cihub/seelog.(*asyncLoopLogger).processItem"),
+		goleak.IgnoreAnyFunction("github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.initalizeDynamicInstrumentationRemoteConfigState.func1"),
+	)
 }
 
 func (t *tracer) awaitPayload(tst *testing.T, n int) {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1766,11 +1766,15 @@ func TestPushPayload(t *testing.T) {
 func TestPushTrace(t *testing.T) {
 	assert := assert.New(t)
 
+	oldLvl := log.GetLevel()
+	defer func() { log.SetLevel(oldLvl) }()
+	log.SetLevel(log.LevelDebug)
+
 	tp := new(log.RecordLogger)
 	log.UseLogger(tp)
 	tracer, err := newUnstartedTracer()
 	assert.Nil(err)
-	defer tracer.statsd.Close()
+	defer tracer.Stop()
 	trace := []*Span{
 		{
 			name:     "pylons.request",
@@ -1790,7 +1794,7 @@ func TestPushTrace(t *testing.T) {
 	t0 := <-tracer.out
 	assert.Equal(&chunk{spans: trace}, t0)
 
-	many := payloadQueueSize + 2
+	many := payloadQueueSize * 2
 	for i := 0; i < many; i++ {
 		tracer.pushChunk(&chunk{spans: make([]*Span, i)})
 	}

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -2442,10 +2442,12 @@ func TestFlush(t *testing.T) {
 	tr.traceWriter = tw
 
 	ts := &statsdtest.TestStatsdClient{}
+	tr.statsd.Close()
 	tr.statsd = ts
 
 	transport := newDummyTransport()
 	c := newConcentrator(&config{transport: transport, env: "someEnv"}, defaultStatsBucketSize, &statsd.NoOpClientDirect{})
+	tr.stats.Stop()
 	tr.stats = c
 	c.Start()
 	defer c.Stop()

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1227,7 +1227,7 @@ func TestTracerNoDebugStack(t *testing.T) {
 
 // newDefaultTransport return a default transport for this tracing client
 func newDefaultTransport() transport {
-	return newHTTPTransport(defaultURL, defaultHTTPClient(0))
+	return newHTTPTransport(defaultURL, defaultHTTPClient(0, true))
 }
 
 func TestNewSpan(t *testing.T) {
@@ -1346,7 +1346,7 @@ func TestTracerPrioritySampler(t *testing.T) {
 	url := "http://" + srv.Listener.Addr().String()
 
 	tr, _, flush, stop, err := startTestTracer(t,
-		withTransport(newHTTPTransport(url, defaultHTTPClient(0))),
+		withTransport(newHTTPTransport(url, defaultHTTPClient(0, false))),
 	)
 	assert.Nil(err)
 	defer stop()
@@ -2322,6 +2322,8 @@ func startTestTracer(t testing.TB, opts ...StartOption) (trc *tracer, transport 
 	o := append([]StartOption{
 		withTransport(transport),
 		withTickChan(tick),
+		// disable keep-alives to avoid goroutine leaks between tests
+		WithHTTPClient(defaultHTTPClient(0, true)),
 	}, opts...)
 	tracer, err := newTracer(o...)
 	if err != nil {

--- a/ddtrace/tracer/transport.go
+++ b/ddtrace/tracer/transport.go
@@ -136,6 +136,7 @@ func (t *httpTransport) sendStats(p *pb.ClientStatsPayload, tracerObfuscationVer
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	if code := resp.StatusCode; code >= 400 {
 		// error, check the body for context information and
 		// return a nice error.

--- a/ddtrace/tracer/transport.go
+++ b/ddtrace/tracer/transport.go
@@ -38,7 +38,7 @@ func defaultDialer(timeout time.Duration) *net.Dialer {
 	}
 }
 
-func defaultHTTPClient(timeout time.Duration) *http.Client {
+func defaultHTTPClient(timeout time.Duration, disableKeepAlives bool) *http.Client {
 	if timeout == 0 {
 		timeout = defaultHTTPTimeout
 	}
@@ -50,6 +50,7 @@ func defaultHTTPClient(timeout time.Duration) *http.Client {
 			IdleConnTimeout:       90 * time.Second,
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
+			DisableKeepAlives:     disableKeepAlives,
 		},
 		Timeout: timeout,
 	}

--- a/ddtrace/tracer/transport.go
+++ b/ddtrace/tracer/transport.go
@@ -30,10 +30,12 @@ const (
 	headerComputedTopLevel = "Datadog-Client-Computed-Top-Level"
 )
 
-var defaultDialer = &net.Dialer{
-	Timeout:   30 * time.Second,
-	KeepAlive: 30 * time.Second,
-	DualStack: true,
+func defaultDialer(timeout time.Duration) *net.Dialer {
+	return &net.Dialer{
+		Timeout:   timeout,
+		KeepAlive: 30 * time.Second,
+		DualStack: true,
+	}
 }
 
 func defaultHTTPClient(timeout time.Duration) *http.Client {
@@ -43,7 +45,7 @@ func defaultHTTPClient(timeout time.Duration) *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
 			Proxy:                 http.ProxyFromEnvironment,
-			DialContext:           defaultDialer.DialContext,
+			DialContext:           defaultDialer(timeout).DialContext,
 			MaxIdleConns:          100,
 			IdleConnTimeout:       90 * time.Second,
 			TLSHandshakeTimeout:   10 * time.Second,

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -78,8 +78,9 @@ func TestTracesAgentIntegration(t *testing.T) {
 		transport := newHTTPTransport(defaultURL, defaultHTTPClient(0))
 		p, err := encode(tc.payload)
 		assert.NoError(err)
-		_, err = transport.send(p)
+		body, err := transport.send(p)
 		assert.NoError(err)
+		defer body.Close()
 	}
 }
 

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -391,8 +391,9 @@ func TestWithUDS(t *testing.T) {
 
 	p, err := encode(getTestTrace(1, 1))
 	assert.NoError(err)
-	_, err = trc.config.transport.send(p)
+	body, err := trc.config.transport.send(p)
 	assert.NoError(err)
+	defer body.Close()
 	// There are 2 requests, but one happens on tracer startup before we wrap the round tripper.
 	// This is OK for this test, since we just want to check that WithUDS allows communication
 	// between a server and client over UDS. hits tells us that there were 2 requests received.

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -75,7 +75,7 @@ func TestTracesAgentIntegration(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		transport := newHTTPTransport(defaultURL, defaultHTTPClient(0))
+		transport := newHTTPTransport(defaultURL, defaultHTTPClient(0, false))
 		p, err := encode(tc.payload)
 		assert.NoError(err)
 		body, err := transport.send(p)
@@ -149,7 +149,7 @@ func TestTransportResponse(t *testing.T) {
 				w.Write([]byte(tt.body))
 			}))
 			defer srv.Close()
-			transport := newHTTPTransport(srv.URL, defaultHTTPClient(0))
+			transport := newHTTPTransport(srv.URL, defaultHTTPClient(0, false))
 			rc, err := transport.send(newPayload())
 			if tt.err != "" {
 				assert.Equal(tt.err, err.Error())
@@ -189,7 +189,7 @@ func TestTraceCountHeader(t *testing.T) {
 	}))
 	defer srv.Close()
 	for _, tc := range testCases {
-		transport := newHTTPTransport(srv.URL, defaultHTTPClient(0))
+		transport := newHTTPTransport(srv.URL, defaultHTTPClient(0, false))
 		p, err := encode(tc.payload)
 		assert.NoError(err)
 		_, err = transport.send(p)

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -143,15 +143,12 @@ func TestTransportResponse(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
-			ln, err := net.Listen("tcp4", "localhost:0")
-			assert.Nil(err)
-			go http.Serve(ln, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(tt.status)
 				w.Write([]byte(tt.body))
 			}))
-			defer ln.Close()
-			url := "http://" + ln.Addr().String()
-			transport := newHTTPTransport(url, defaultHTTPClient(0))
+			defer srv.Close()
+			transport := newHTTPTransport(srv.URL, defaultHTTPClient(0))
 			rc, err := transport.send(newPayload())
 			if tt.err != "" {
 				assert.Equal(tt.err, err.Error())

--- a/ddtrace/tracer/writer_test.go
+++ b/ddtrace/tracer/writer_test.go
@@ -100,7 +100,7 @@ func TestLogWriter(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
 		assert := assert.New(t)
 		var buf bytes.Buffer
-		cfg, err := newConfig()
+		cfg, err := newTestConfig()
 		assert.NoError(err)
 		statsd, err := newStatsdClient(cfg)
 		require.NoError(t, err)
@@ -127,7 +127,7 @@ func TestLogWriter(t *testing.T) {
 	t.Run("inf+nan", func(t *testing.T) {
 		assert := assert.New(t)
 		var buf bytes.Buffer
-		cfg, err := newConfig()
+		cfg, err := newTestConfig()
 		require.NoError(t, err)
 		statsd, err := newStatsdClient(cfg)
 		require.NoError(t, err)
@@ -149,7 +149,7 @@ func TestLogWriter(t *testing.T) {
 	t.Run("fullspan", func(t *testing.T) {
 		assert := assert.New(t)
 		var buf bytes.Buffer
-		cfg, err := newConfig()
+		cfg, err := newTestConfig()
 		require.NoError(t, err)
 		statsd, err := newStatsdClient(cfg)
 		require.NoError(t, err)
@@ -257,7 +257,7 @@ func TestLogWriterOverflow(t *testing.T) {
 		assert := assert.New(t)
 		var buf bytes.Buffer
 		var tg statsdtest.TestStatsdClient
-		cfg, err := newConfig(withStatsdClient(&tg))
+		cfg, err := newTestConfig(withStatsdClient(&tg))
 		require.NoError(t, err)
 		statsd, err := newStatsdClient(cfg)
 		require.NoError(t, err)
@@ -278,7 +278,7 @@ func TestLogWriterOverflow(t *testing.T) {
 		assert := assert.New(t)
 		var buf bytes.Buffer
 		var tg statsdtest.TestStatsdClient
-		cfg, err := newConfig(withStatsdClient(&tg))
+		cfg, err := newTestConfig(withStatsdClient(&tg))
 		require.NoError(t, err)
 		statsd, err := newStatsdClient(cfg)
 		require.NoError(t, err)
@@ -310,7 +310,7 @@ func TestLogWriterOverflow(t *testing.T) {
 	t.Run("two-large", func(t *testing.T) {
 		assert := assert.New(t)
 		var buf bytes.Buffer
-		cfg, err := newConfig()
+		cfg, err := newTestConfig()
 		require.NoError(t, err)
 		statsd, err := newStatsdClient(cfg)
 		require.NoError(t, err)
@@ -411,7 +411,7 @@ func TestTraceWriterFlushRetries(t *testing.T) {
 				failCount: test.failCount,
 				assert:    assert,
 			}
-			c, err := newConfig(func(c *config) {
+			c, err := newTestConfig(func(c *config) {
 				c.transport = p
 				c.sendRetries = test.configRetries
 				c.retryInterval = test.retryInterval


### PR DESCRIPTION
### What does this PR do?

Check that `ddtrace/tracer` tests don't leak goroutines using `go.uber.org/goleak`. This required fixing a lot of code, see the individual commits for details. It's possible that some of these goroutines leaks could have impacted customers, but I suspect most of them are just issues for testing.

### Motivation

I keep having the following experience while working on enabling runtime metrics v2 by default:

* Make a change
* Run the `ddtrace/tracer` tests and observe a failing test case
* Re-run the individual test case that failed
* Observe that the test case doesn't fail now

The root cause is always the same: Global state pollution by some previous test interfering with the assertions made by the current test.

There are two primary types of global state pollution in our tests:

1. Package level variables (singletons)
2. Leaked goroutines

This patch addresses most of the issues caused by the latter. But we also need to fix the package variables. We should use much less of them. They are pretty much always a code smell.

We should definitely not allow any new code to be added that adds more singletons or other global state. This should only be allowed in exceptional circumstances. I'll raise this at the next guild meeting.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
