### PR TITLE
chore(ddtrace/tracer): shave 4s from test suite

### DIFF
--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -206,14 +206,7 @@ func TestLoadAgentFeatures(t *testing.T) {
 		})
 
 		t.Run("unreachable", func(t *testing.T) {
-			if testing.Short() {
-				return
-			}
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusInternalServerError)
-			}))
-			defer srv.Close()
-			cfg, err := newConfig(WithAgentAddr("127.9.9.9:8181"), WithAgentTimeout(2))
+			cfg, err := newConfig(WithAgentAddr("127.0.0.1:0"))
 			assert.NoError(t, err)
 			assert.Zero(t, cfg.agent)
 		})

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -151,6 +151,7 @@ func TestAutoDetectStatsd(t *testing.T) {
 		// Ensure globalconfig also gets the auto-detected UDS address
 		require.Equal(t, "unix://"+addr, globalconfig.DogstatsdAddr())
 		statsd.Count("name", 1, []string{"tag"}, 1)
+		statsd.Flush()
 
 		buf := make([]byte, 17)
 		n, err := conn.Read(buf)


### PR DESCRIPTION
### What does this PR do?

Shave 4s from the `ddtrace/tracer` test suite.

### Motivation

Same as https://github.com/DataDog/dd-trace-go/pull/3789.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
