### PR TITLE
[internal/remoteconfig] Propagate container ids headers

### DIFF
--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -268,6 +268,12 @@ func (c *Client) updateState() {
 		log.Error("remoteconfig: unexpected error while creating a new http request: %s", err.Error())
 		return
 	}
+	if internal.ContainerID() != "" {
+		req.Header.Set("Datadog-Container-ID", internal.ContainerID())
+	}
+	if internal.EntityID() != "" {
+		req.Header.Set("Datadog-Entity-ID", internal.EntityID())
+	}
 
 	resp, err := c.HTTP.Do(req)
 	if err != nil {


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/DEBUG-4205

### What does this PR do?

Propagate container/entity id headers on remoteconfig requests (similiar to how we annotate trace spans).

### Motivation

These are used by live debugger to filter on specific instances of the service.