### PR TITLE
feat(internal/civisibility): add the pr.number tag for github provider

### DIFF
--- a/internal/civisibility/utils/ci_providers.go
+++ b/internal/civisibility/utils/ci_providers.go
@@ -449,6 +449,7 @@ func extractGithubActions() map[string]string {
 			defer eventFile.Close()
 
 			var eventJSON struct {
+				Number      int `json:"number"`
 				PullRequest struct {
 					Base struct {
 						Sha string `json:"sha"`
@@ -465,6 +466,7 @@ func extractGithubActions() map[string]string {
 				tags[constants.GitHeadCommit] = eventJSON.PullRequest.Head.Sha
 				tags[constants.GitPrBaseCommit] = eventJSON.PullRequest.Base.Sha
 				tags[constants.GitPrBaseBranch] = eventJSON.PullRequest.Base.Ref
+				tags[constants.PrNumber] = fmt.Sprintf("%d", eventJSON.Number)
 			}
 		}
 	}

--- a/internal/civisibility/utils/ci_providers_test.go
+++ b/internal/civisibility/utils/ci_providers_test.go
@@ -161,10 +161,12 @@ func TestGitHubEventFile(t *testing.T) {
 		expectedHeadCommit := "df289512a51123083a8e6931dd6f57bb3883d4c4"
 		expectedBaseCommit := "52e0974c74d41160a03d59ddc73bb9f5adab054b"
 		expectedBaseRef := "main"
+		expectedPrNumber := "1"
 
 		checkValue(tags, constants.GitHeadCommit, expectedHeadCommit)
 		checkValue(tags, constants.GitPrBaseCommit, expectedBaseCommit)
 		checkValue(tags, constants.GitPrBaseBranch, expectedBaseRef)
+		checkValue(tags, constants.PrNumber, expectedPrNumber)
 	})
 
 	t.Run("no event file", func(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds `pr.number` test tag for github action jobs.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We have `pr.number` tag for several providers except github.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
