### PR TITLE
feat(internal/civisibility): add source file and codeowners tags to the suite span

### DIFF
--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -206,6 +206,11 @@ func runFlakyTestRetriesTests(m *testing.M) {
 	// check the test is new tag
 	checkSpansByTagName(finishedSpans, constants.TestIsNew, 26)
 
+	// check if suite has both test code owners and source file tags
+	suiteSpans := getSpansWithType(finishedSpans, constants.SpanTypeTestSuite)
+	checkSpansByTagName(suiteSpans, constants.TestCodeOwners, 4)
+	checkSpansByTagName(suiteSpans, constants.TestSourceFile, 4)
+
 	// check spans by type
 	checkSpansByType(finishedSpans,
 		32,
@@ -309,6 +314,11 @@ func runEarlyFlakyTestDetectionTests(m *testing.M) {
 	if trrSpan.Tag(constants.TestRetryReason) != "early_flake_detection" {
 		panic(fmt.Sprintf("expected retry reason to be %s, got %s", "early_flake_detection", trrSpan.Tag(constants.TestRetryReason)))
 	}
+
+	// check if suite has both test code owners and source file tags
+	suiteSpans := getSpansWithType(finishedSpans, constants.SpanTypeTestSuite)
+	checkSpansByTagName(suiteSpans, constants.TestCodeOwners, 4)
+	checkSpansByTagName(suiteSpans, constants.TestSourceFile, 4)
 
 	// check spans by type
 	checkSpansByType(finishedSpans,
@@ -550,6 +560,11 @@ func runFlakyTestRetriesWithEarlyFlakyTestDetectionTests(m *testing.M, impactedT
 	// check spans by tag
 	checkSpansByTagName(finishedSpans, constants.TestIsNew, 55)
 
+	// check if suite has both test code owners and source file tags
+	suiteSpans := getSpansWithType(finishedSpans, constants.SpanTypeTestSuite)
+	checkSpansByTagName(suiteSpans, constants.TestCodeOwners, 4)
+	checkSpansByTagName(suiteSpans, constants.TestSourceFile, 4)
+
 	// Impacted tests
 	if impactedTests {
 		checkSpansByTagName(finishedSpans, constants.TestIsRetry, 96)
@@ -694,6 +709,11 @@ func runIntelligentTestRunnerTests(m *testing.M) {
 	checkSpansByTagValue(finishedSpans, constants.TestUnskippable, "true", 7)
 	checkSpansByTagValue(finishedSpans, constants.TestForcedToRun, "true", 1)
 
+	// check if suite has both test code owners and source file tags
+	suiteSpans := getSpansWithType(finishedSpans, constants.SpanTypeTestSuite)
+	checkSpansByTagName(suiteSpans, constants.TestCodeOwners, 4)
+	checkSpansByTagName(suiteSpans, constants.TestSourceFile, 4)
+
 	// check spans by type
 	checkSpansByType(finishedSpans,
 		17,
@@ -835,6 +855,11 @@ func runTestManagementTests(m *testing.M) {
 
 	// check capabilities tags
 	checkCapabilitiesTags(finishedSpans)
+
+	// check if suite has both test code owners and source file tags
+	suiteSpans := getSpansWithType(finishedSpans, constants.SpanTypeTestSuite)
+	checkSpansByTagName(suiteSpans, constants.TestCodeOwners, 4)
+	checkSpansByTagName(suiteSpans, constants.TestSourceFile, 4)
 
 	// check logs
 	checkLogs()

--- a/internal/civisibility/integrations/manual_api_ddtest.go
+++ b/internal/civisibility/integrations/manual_api_ddtest.go
@@ -237,6 +237,7 @@ func (t *tslvTest) SetTestFunc(fn *runtime.Func) {
 	file := utils.GetRelativePathFromCITagsSourceRoot(absolutePath)
 	t.SetTag(constants.TestSourceFile, file)
 	t.SetTag(constants.TestSourceStartLine, startLine)
+	t.suite.SetTag(constants.TestSourceFile, file)
 
 	// now, let's try to get the end line of the function using ast
 	// parse the entire file where the function is defined to create an abstract syntax tree (AST)
@@ -339,7 +340,9 @@ func (t *tslvTest) SetTestFunc(fn *runtime.Func) {
 	if codeOwners != nil {
 		match, found := codeOwners.Match("/" + file)
 		if found {
-			t.SetTag(constants.TestCodeOwners, match.GetOwnersString())
+			ownerString := match.GetOwnersString()
+			t.SetTag(constants.TestCodeOwners, ownerString)
+			t.suite.SetTag(constants.TestCodeOwners, ownerString)
 		}
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds the test source file and codeowners tag to the suite span in Test Optimization.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

A customer is asking for this and it is a low hanging fruit.

Jira: https://datadoghq.atlassian.net/browse/SDTEST-2375

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
