### PR TITLE
contrib/envoyproxy: refine component detection

### DIFF
--- a/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/main.go
+++ b/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/main.go
@@ -188,10 +188,10 @@ func startGPRCSsl(ctx context.Context, service extproc.ExternalProcessorServer, 
 	appsecEnvoyExternalProcessorServer := gocontrolplane.AppsecEnvoyExternalProcessorServer(
 		service,
 		gocontrolplane.AppsecEnvoyConfig{
-			IsGCPServiceExtension: true,
-			BlockingUnavailable:   config.observabilityMode,
-			Context:               ctx,
-			BodyParsingSizeLimit:  config.bodyParsingSizeLimit,
+			Integration:          gocontrolplane.GCPServiceExtensionIntegration,
+			BlockingUnavailable:  config.observabilityMode,
+			Context:              ctx,
+			BodyParsingSizeLimit: config.bodyParsingSizeLimit,
 		})
 
 	go func() {

--- a/contrib/envoyproxy/go-control-plane/example_test.go
+++ b/contrib/envoyproxy/go-control-plane/example_test.go
@@ -32,8 +32,8 @@ func Example_server() {
 
 	// Register the appsec envoy external processor service
 	appsecSrv := AppsecEnvoyExternalProcessorServer(srv, AppsecEnvoyConfig{
-		IsGCPServiceExtension: false,
-		BlockingUnavailable:   false,
+		Integration:         EnvoyIntegration,
+		BlockingUnavailable: false,
 	})
 
 	extprocv3.RegisterExternalProcessorServer(s, appsecSrv)

--- a/contrib/envoyproxy/go-control-plane/message_processor.go
+++ b/contrib/envoyproxy/go-control-plane/message_processor.go
@@ -44,7 +44,7 @@ func (mp *messageProcessor) ProcessRequestHeaders(ctx context.Context, req *envo
 		return nil, requestState{}, status.Errorf(codes.InvalidArgument, "Error processing request headers from ext_proc: %s", err.Error())
 	}
 
-	state, blocked := newRequestState(httpReq, mp.config.BodyParsingSizeLimit, mp.config.IsGCPServiceExtension)
+	state, blocked := newRequestState(ctx, httpReq, mp.config.BodyParsingSizeLimit, mp.config.IsGCPServiceExtension)
 	if state.Span == nil {
 		state.Close()
 		return nil, requestState{}, status.Errorf(codes.Unknown, "Error getting span from context")

--- a/contrib/envoyproxy/go-control-plane/message_processor.go
+++ b/contrib/envoyproxy/go-control-plane/message_processor.go
@@ -44,7 +44,7 @@ func (mp *messageProcessor) ProcessRequestHeaders(ctx context.Context, req *envo
 		return nil, requestState{}, status.Errorf(codes.InvalidArgument, "Error processing request headers from ext_proc: %s", err.Error())
 	}
 
-	state, blocked := newRequestState(ctx, httpReq, mp.config.BodyParsingSizeLimit, mp.config.IsGCPServiceExtension)
+	state, blocked := newRequestState(ctx, httpReq, mp.config.BodyParsingSizeLimit, mp.config.Integration)
 	if state.Span == nil {
 		state.Close()
 		return nil, requestState{}, status.Errorf(codes.Unknown, "Error getting span from context")

--- a/go.work.sum
+++ b/go.work.sum
@@ -2367,6 +2367,7 @@ golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/telemetry v0.0.0-20240521205824-bda55230c457 h1:zf5N6UOrA487eEFacMePxjXAJctxKmyjKUsjA11Uzuk=
 golang.org/x/telemetry v0.0.0-20240521205824-bda55230c457/go.mod h1:pRgIJT+bRLFKnoM1ldnzKoxTIn14Yxz928LQRYYgIN0=
+golang.org/x/telemetry v0.0.0-20250710130107-8d8967aff50b h1:DU+gwOBXU+6bO0sEyO7o/NeMlxZxCZEvI7v+J4a1zRQ=
 golang.org/x/telemetry v0.0.0-20250710130107-8d8967aff50b/go.mod h1:4ZwOYna0/zsOKwuR5X/m0QFOJpSZvAxFfkQT+Erd9D4=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.25.0/go.mod h1:RPyXicDX+6vLxogjjRxjgD2TKtmAO6NZBsBRfrOLu7M=


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR refines how the value of the component tag is selected for the GCP Service Extension/Envoy/Istio integration.

#### Changes

- The `AppsecEnvoyConfig` is now taking an `Integration` value instead of an `IsGCPServiceExtension` bool.
- Updated the envoy component from `envoyproxy/go-control-plane` to `envoy` (The UI currently doesn't use any of the tag component to show the correct proxy icon in the service catalog, so it's safe to change)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

At first, the Service Extension callout image was only used for GCP Service Extension. However today it's also used and advertised for an Envoy integration. The component tag could be used to determine which integration type is it in the UI.

This could be configured in 2 ways:
- By code: When registering the `ExternalProcessorServer`, the `Integration` is used to select the component tag.
    - This flag is set to `GCPServiceExtensionIntegration` in the official release of the External Processor callout image
- By an injected grpc header: `x-datadog-envoy-integration` or `x-datadog-istio-integration` with the value set to `"1"`
    - This header is injected when configuring Envoy/Istio to do it. This is documented in the installation public docs.


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
