### PR TITLE
fix(internal/civisibility): fix base branch SHA usage.

### DIFF
--- a/internal/civisibility/constants/git.go
+++ b/internal/civisibility/constants/git.go
@@ -77,6 +77,9 @@ const (
 	// GitPrBaseCommit indicates the GIT PR base commit hash.
 	GitPrBaseCommit = "git.pull_request.base_branch_sha"
 
+	// GitPrBaseHeadCommit indicates the GIT PR base branch head commit hash.
+	GitPrBaseHeadCommit = "git.pull_request.base_branch_head_sha"
+
 	// GitPrBaseBranch indicates the GIT PR base branch name.
 	GitPrBaseBranch = "git.pull_request.base_branch"
 

--- a/internal/civisibility/utils/ci_providers.go
+++ b/internal/civisibility/utils/ci_providers.go
@@ -517,6 +517,7 @@ func extractGitlab() map[string]string {
 
 	tags[constants.GitHeadCommit] = os.Getenv("CI_MERGE_REQUEST_SOURCE_BRANCH_SHA")
 	tags[constants.GitPrBaseHeadCommit] = os.Getenv("CI_MERGE_REQUEST_TARGET_BRANCH_SHA")
+	tags[constants.GitPrBaseCommit] = os.Getenv("CI_MERGE_REQUEST_DIFF_BASE_SHA")
 	tags[constants.GitPrBaseBranch] = os.Getenv("CI_MERGE_REQUEST_TARGET_BRANCH_NAME")
 	tags[constants.PrNumber] = os.Getenv("CI_MERGE_REQUEST_IID")
 

--- a/internal/civisibility/utils/ci_providers.go
+++ b/internal/civisibility/utils/ci_providers.go
@@ -464,7 +464,7 @@ func extractGithubActions() map[string]string {
 			eventDecoder := json.NewDecoder(eventFile)
 			if eventDecoder.Decode(&eventJSON) == nil {
 				tags[constants.GitHeadCommit] = eventJSON.PullRequest.Head.Sha
-				tags[constants.GitPrBaseCommit] = eventJSON.PullRequest.Base.Sha
+				tags[constants.GitPrBaseHeadCommit] = eventJSON.PullRequest.Base.Sha
 				tags[constants.GitPrBaseBranch] = eventJSON.PullRequest.Base.Ref
 				tags[constants.PrNumber] = fmt.Sprintf("%d", eventJSON.Number)
 			}
@@ -516,7 +516,7 @@ func extractGitlab() map[string]string {
 	}
 
 	tags[constants.GitHeadCommit] = os.Getenv("CI_MERGE_REQUEST_SOURCE_BRANCH_SHA")
-	tags[constants.GitPrBaseCommit] = os.Getenv("CI_MERGE_REQUEST_TARGET_BRANCH_SHA")
+	tags[constants.GitPrBaseHeadCommit] = os.Getenv("CI_MERGE_REQUEST_TARGET_BRANCH_SHA")
 	tags[constants.GitPrBaseBranch] = os.Getenv("CI_MERGE_REQUEST_TARGET_BRANCH_NAME")
 	tags[constants.PrNumber] = os.Getenv("CI_MERGE_REQUEST_IID")
 

--- a/internal/civisibility/utils/ci_providers_test.go
+++ b/internal/civisibility/utils/ci_providers_test.go
@@ -164,7 +164,7 @@ func TestGitHubEventFile(t *testing.T) {
 		expectedPrNumber := "1"
 
 		checkValue(tags, constants.GitHeadCommit, expectedHeadCommit)
-		checkValue(tags, constants.GitPrBaseCommit, expectedBaseCommit)
+		checkValue(tags, constants.GitPrBaseHeadCommit, expectedBaseCommit)
 		checkValue(tags, constants.GitPrBaseBranch, expectedBaseRef)
 		checkValue(tags, constants.PrNumber, expectedPrNumber)
 	})


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR fixes the use of the base branch sha value, we thought this sha was the BASE sha, but we realized it is the HEAD sha of the base branch.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

JIRA: https://datadoghq.atlassian.net/browse/SDTEST-2353

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
