### PR TITLE
fix(internal/civisibility): fix impacted tests implementation

### DIFF
--- a/internal/civisibility/utils/git.go
+++ b/internal/civisibility/utils/git.go
@@ -753,7 +753,7 @@ func findFallbackDefaultBranch(remoteName string) string {
 	return ""
 }
 
-// GetBaseBranchSha detects the base branch SHA using the algorithm from algorithm.md
+// GetBaseBranchSha detects the base branch SHA using the algorithm
 func GetBaseBranchSha(defaultBranch string) (string, error) {
 	if !isGitFound() {
 		return "", errors.New("git executable not found")

--- a/internal/civisibility/utils/impactedtests/impacted_tests.go
+++ b/internal/civisibility/utils/impactedtests/impacted_tests.go
@@ -63,9 +63,6 @@ func NewImpactedTestAnalyzer() (*ImpactedTestAnalyzer, error) {
 
 	// Get the base commit SHA
 	baseCommitSha := ciTags[constants.GitPrBaseCommit]
-	if baseCommitSha == "" {
-		baseCommitSha = ciTags[constants.GitPrBaseBranch]
-	}
 
 	// If we don't have the base commit from the tags, then let's try to calculate it using the git CLI
 	if baseCommitSha == "" {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR fixes the usage of the `DD_CIVISIBILITY_IMPACTED_TESTS_DETECTION_ENABLED` as a kill switch and also enforces the calculation of the base commit sha if we don't have it (previously it was using the base branch name as a source, but this is wrong because can point to the HEAD commit sha)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Bug fixes.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
