### PR TITLE
ci: add new sts policies for ecosystems-label checks

### DIFF
--- a/.github/chainguard/self.ecosystems-label-issue.sts.yaml
+++ b/.github/chainguard/self.ecosystems-label-issue.sts.yaml
@@ -1,0 +1,9 @@
+issuer: https://token.actions.githubusercontent.com
+subject: repo:DataDog/dd-trace-go:issues
+claim_pattern:
+  event_name: issues
+  repository: DataDog/dd-trace-go
+  job_workflow_ref: DataDog/dd-trace-go/.github/workflows/ecosystems-label-issue.yml@.*
+permissions:
+  contents: read
+  issues: write

--- a/.github/chainguard/self.ecosystems-label-pr.sts.yaml
+++ b/.github/chainguard/self.ecosystems-label-pr.sts.yaml
@@ -1,0 +1,9 @@
+issuer: https://token.actions.githubusercontent.com
+subject: repo:DataDog/dd-trace-go:pull_request
+claim_pattern:
+  event_name: pull_request
+  repository: DataDog/dd-trace-go
+  job_workflow_ref: DataDog/dd-trace-go/.github/workflows/ecosystems-label-pr.yml@.*
+permissions:
+  contents: read
+  pull_requests: write


### PR DESCRIPTION
### What does this PR do?

Add two new policies needed to migrate `ecosystems-label-pr.yml` and `ecosystems-label-issue.yml` workflows away from PAT.  