### PR TITLE
refactor(ddtrace/tracer): prepare payload.push for supporting v1 trace protocol

### DIFF
--- a/ddtrace/tracer/payload.go
+++ b/ddtrace/tracer/payload.go
@@ -71,9 +71,10 @@ func newPayload() *payload {
 }
 
 // push pushes a new item into the stream.
-func (p *payload) push(t spanList) error {
-	p.buf.Grow(t.Msgsize())
-	if err := msgp.Encode(&p.buf, t); err != nil {
+func (p *payload) push(t []*Span) error {
+	sl := spanList(t)
+	p.buf.Grow(sl.Msgsize())
+	if err := msgp.Encode(&p.buf, sl); err != nil {
 		return err
 	}
 	atomic.AddUint32(&p.count, 1)


### PR DESCRIPTION
### What does this PR do?

Modifies `payload.push` function signature to internalize the usage of `spanList` into the function.

### Motivation

This PR supports a new trace protocol encoding. The proposed protocol change is expected to improve message size and flexibility, leading to bandwidth savings and easier addition of new features, while also offering significant improvements in serialization time, memory allocations, and compressed data output.

At tracer initialization we'll detect which trace protocol to use, and therefore switch over one encoding or the other by wrapping the `[]*Span` value as `spanList` or the newer encoding type. It's also nicer to use the API types instead of an internal one that's an alias.

No benchmark impact was detected locally.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
