### PR TITLE
fix(internal/setup-smoke-test): use JSON arguments for CMD/ENTRYPOINT and change alias in FROM scratch

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -165,7 +165,7 @@ jobs:
         go: [ "1.23", "1.24" ]
         build-env: [ alpine, bookworm, bullseye ]
         build-with-cgo: [ 0, 1 ]
-        deployment-env: [ alpine, debian11, debian12, al2, al2023, busybox, scratch ]
+        deployment-env: [ alpine, debian11, debian12, al2, al2023, busybox, scratchy ]
         include:
           # GitHub limits the number of matrix jobs to 256, so we need to reduce
           # it a bit, and we can reduce redundant tests.
@@ -208,7 +208,7 @@ jobs:
             deployment-env: busybox
           - build-env: alpine
             build-with-cgo: 1
-            deployment-env: scratch
+            deployment-env: scratchy
           # 2. Too old glibc on the deployment environment than on the build env
           - build-env: bookworm
             deployment-env: al2
@@ -218,7 +218,7 @@ jobs:
           #    image requires copying the dynamic lib dependencies (full example
           #    provided at https://github.com/DataDog/appsec-go-test-app/blob/main/examples/docker/scratch/Dockerfile)
           - build-with-cgo: 1
-            deployment-env: scratch
+            deployment-env: scratchy
 
     steps:
       - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4.2.2

--- a/internal/setup-smoke-test/Dockerfile
+++ b/internal/setup-smoke-test/Dockerfile
@@ -69,7 +69,7 @@ RUN ldd smoke-test || true
 # out of the box in it without any further installation.
 FROM debian:11 AS debian11
 COPY --from=build-env /src/internal/setup-smoke-test/smoke-test /usr/local/bin
-CMD /usr/local/bin/smoke-test
+CMD ["/usr/local/bin/smoke-test"]
 
 # debian12 deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
@@ -77,7 +77,7 @@ CMD /usr/local/bin/smoke-test
 # out of the box in it without any further installation.
 FROM debian:12 AS debian12
 COPY --from=build-env /src/internal/setup-smoke-test/smoke-test /usr/local/bin
-CMD /usr/local/bin/smoke-test
+CMD ["/usr/local/bin/smoke-test"]
 
 # alpine deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
@@ -89,7 +89,7 @@ RUN set -ex; if [ "$build_with_cgo" = "1" ]; then \
       apk update && apk add libc6-compat; \
     fi
 COPY --from=build-env /src/internal/setup-smoke-test/smoke-test /usr/local/bin
-CMD /usr/local/bin/smoke-test
+CMD ["/usr/local/bin/smoke-test"]
 
 # amazonlinux:2 deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
@@ -97,7 +97,7 @@ CMD /usr/local/bin/smoke-test
 # out of the box in it without any further installation.
 FROM amazonlinux:2 AS al2
 COPY --from=build-env /src/internal/setup-smoke-test/smoke-test /usr/local/bin
-CMD /usr/local/bin/smoke-test
+CMD ["/usr/local/bin/smoke-test"]
 
 # amazonlinux:2023 deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
@@ -105,7 +105,7 @@ CMD /usr/local/bin/smoke-test
 # out of the box in it without any further installation.
 FROM amazonlinux:2023 AS al2023
 COPY --from=build-env /src/internal/setup-smoke-test/smoke-test /usr/local/bin
-CMD /usr/local/bin/smoke-test
+CMD ["/usr/local/bin/smoke-test"]
 
 # busybox deployment environment
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
@@ -114,15 +114,15 @@ CMD /usr/local/bin/smoke-test
 FROM busybox AS busybox
 RUN mkdir -p /usr/local/bin
 COPY --from=build-env /src/internal/setup-smoke-test/smoke-test /usr/local/bin
-CMD /usr/local/bin/smoke-test
+CMD ["/usr/local/bin/smoke-test"]
 
 # scratch deployment environment - meant to be used with CGO_ENABLED=0
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.
-FROM scratch AS scratch
+FROM scratch AS scratchy
 COPY --from=build-env /src/internal/setup-smoke-test/smoke-test /
-ENTRYPOINT [ "/smoke-test" ]
+CMD ["/smoke-test"]
 
 # Final deployment environment - helper target to end up a single one
 FROM $deployment_env AS deployment-env


### PR DESCRIPTION
### What does this PR do?

Migrates `CMD`/`ENTRYPOINT` instructions to use JSON arguments, and changes the non-complaint alias on `FROM scratch` instruction, as warned by Docker while building images on our smoke tests.

<img width="1297" height="637" alt="image" src="https://github.com/user-attachments/assets/528128cf-6539-4673-a75e-d283d141f214" />

<img width="1297" height="637" alt="image" src="https://github.com/user-attachments/assets/51d2f93d-d0ad-45ee-891a-2e297dd0fa3c" />

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
