### PR TITLE
ci: remove commit sha tag from released images and add it as container label

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -91,6 +91,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             DD_VERSION=${{ inputs.version }}
+            COMMIT_SHA=${{ inputs.commit_sha }}
           # This builds a Docker image and uploads it using a unique fingerprint, without a name
           outputs: type=image,name=${{ inputs.image }},push-by-digest=true,name-canonical=true,push=true
 
@@ -118,6 +119,7 @@ jobs:
           tags: ${{ steps.tags.outputs.list }}
           build-args: |
             DD_VERSION=${{ inputs.version }}
+            COMMIT_SHA=${{ inputs.commit_sha }}
           outputs: type=docker,dest=/tmp/${{ inputs.artifact_prefix }}-${{ env.PLATFORM_PAIR }}.tar
           push: false
 

--- a/.github/workflows/docker-images-release.yml
+++ b/.github/workflows/docker-images-release.yml
@@ -66,7 +66,6 @@ jobs:
       version: ${{ needs.prepare-tag.outputs.service_extension_image_tag }}
       tags: >-
         ${{ needs.prepare-tag.outputs.service_extension_image_tag }}
-        ${{ github.event.inputs.commit_sha || github.sha }}
         ${{ (github.event.inputs.set_as_latest == 'true' || github.event_name == 'push') && 'latest' || '' }}
 
   build-request-mirror:
@@ -83,5 +82,4 @@ jobs:
       version: ${{ needs.prepare-tag.outputs.request_mirroring_image_tag }}
       tags: >-
         ${{ needs.prepare-tag.outputs.request_mirroring_image_tag }}
-        ${{ github.event.inputs.commit_sha || github.sha }}
         ${{ (github.event.inputs.set_as_latest == 'true' || github.event_name == 'push') && 'latest' || '' }}

--- a/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/Dockerfile
+++ b/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/Dockerfile
@@ -29,6 +29,9 @@ LABEL org.opencontainers.image.source=https://github.com/DataDog/dd-trace-go/tre
 LABEL org.opencontainers.image.description="An Envoy External Processor service with Datadog App & API Protection support"
 LABEL org.opencontainers.image.licenses=Apache-2.0
 
+ARG COMMIT_SHA=""
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+
 RUN apk --no-cache add ca-certificates tzdata libc6-compat libgcc libstdc++
 WORKDIR /app
 

--- a/contrib/k8s.io/gateway-api/cmd/request-mirror/Dockerfile
+++ b/contrib/k8s.io/gateway-api/cmd/request-mirror/Dockerfile
@@ -13,6 +13,9 @@ LABEL org.opencontainers.image.source=https://github.com/DataDog/dd-trace-go/tre
 LABEL org.opencontainers.image.description="A request mirror for the Kubernetes Gateway API with Datadog App & API Protection support"
 LABEL org.opencontainers.image.licenses=Apache-2.0
 
+ARG COMMIT_SHA=""
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+
 RUN apk --no-cache add ca-certificates tzdata libc6-compat libgcc libstdc++
 WORKDIR /app
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR removes the commit sha tag that is added to all docker images released (service extension callout and request mirror). The commit sha is now set as a label.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Less orhpan tags in the registry for a better visibility of all released versions tags.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
