### PR TITLE
feat(.github/workflows): Migrate outdated integrations to use STS

### DIFF
--- a/.github/workflows/needs-triage.yml
+++ b/.github/workflows/needs-triage.yml
@@ -18,8 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Generate a GitHub token
         id: generate-token

--- a/.github/workflows/outdated-integrations.yml
+++ b/.github/workflows/outdated-integrations.yml
@@ -17,9 +17,15 @@ jobs:
       actions: read
       contents: write
       pull-requests: write
-    env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      id-token: write
     steps:
+      # Retrieve temporary github token
+      - name: Get Github token
+        uses: DataDog/dd-octo-sts-action@08f2144903ced3254a3dafec2592563409ba2aa0 # v1.0.1
+        id: octo-sts
+        with:
+          policy: self.outdated-integrations
+          scope: DataDog/dd-trace-go
       - uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4.2.2
       
       - run: go clean -modcache
@@ -32,3 +38,5 @@ jobs:
           go get github.com/go-git/go-git/v5/storage/memory
 
       - run: go run .github/workflows/apps/latest_major_versions.go
+        env:
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}


### PR DESCRIPTION
### What does this PR do?

Depens on #3842.

Migrates GitHub workflow `outdated-integrations.yml` to use STS.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
