### PR TITLE
fix(.github/workflows): Add path normalization function to convert forward slashes to backslashes on Windows runners

### DIFF
--- a/.github/workflows/multios-unit-tests.yml
+++ b/.github/workflows/multios-unit-tests.yml
@@ -39,6 +39,17 @@ jobs:
       REPORT: gotestsum-report.xml # path to where test results will be saved
       DD_APPSEC_WAF_TIMEOUT: 1h
     steps:
+      - name: Normalize github.workspace for Windows
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: |
+          $normalizedPath = "${{ github.workspace }}" -replace '\\', '/'
+          "normalized_workspace=$normalizedPath" >> $env:GITHUB_ENV
+      - name: Normalize github.workspace for non-Windows OSes
+        if: ${{ runner.os != 'Windows' }}
+        shell: pwsh
+        run: |
+          "normalized_workspace=${{ github.workspace }}" >> $env:GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v2.7.0
         with:
@@ -47,8 +58,8 @@ jobs:
         uses: ./.github/actions/setup-go
         with:
           go-version: ${{ inputs.go-version }}
-          tools-dir: ${{ github.workspace }}/_tools
-          tools-bin: ${{ github.workspace }}/bin
+          tools-dir: ${{ env.normalized_workspace }}/_tools
+          tools-bin: ${{ env.normalized_workspace }}/bin
       - name: Mac OS Coreutils
         if: inputs.runs-on == 'macos-latest'
         run: brew install coreutils


### PR DESCRIPTION
### What does this PR do?

Fixes `.github/workflows/multios-unit-tests.yml` to work on Windows runners.

### Motivation

CI is unhappy. Enter evidences [A](https://github.com/DataDog/dd-trace-go/actions/runs/16723754002/job/47333990045#step:3:107) & [B](https://github.com/DataDog/dd-trace-go/actions/runs/16723754002/job/47333990044#step:3:104).

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
