### PR TITLE
fix(.github/chainguard): Remove event_name field in outdated integrations policy

### DIFF
--- a/.github/chainguard/self.outdated-integrations.sts.yaml
+++ b/.github/chainguard/self.outdated-integrations.sts.yaml
@@ -2,7 +2,6 @@ issuer: https://token.actions.githubusercontent.com
 subject: repo:DataDog/dd-trace-go:ref:refs/heads/main
 
 claim_pattern:
-  event_name: workflow_run
   ref: refs/heads/main
   ref_protected: "true"
   repository: DataDog/dd-trace-go


### PR DESCRIPTION
### What does this PR do?

Removes `event_name` in `.github/chainguard/self.outdated-integrations.sts.yml` to ensure the policy works for the script's requirements.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
