### PR TITLE
docs(.github/workflows): clarify Docker login token requirements in `docker-build-and-push` workflow

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -72,6 +72,9 @@ jobs:
 
       - name: Login to Docker
         shell: bash
+        # It's not possible to use a `dd-octo-sts` token here because GitHub Packages
+        # only supports PATs for authentication.
+        # https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry
         run: docker login -u publisher -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
 
       - name: Docker meta


### PR DESCRIPTION
### What does this PR do?

Documents why `docker-build-and-push` can't be migrated from `GITHUB_WORKFLOW` to `dd-octo-sts` tokens.

### Motivation

Spreading awareness on https://github.com/orgs/community/discussions/38467

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
