### PR TITLE
fix(contrib/net/http): workaround to fix symbol collision in Orchestrion

### DIFF
--- a/contrib/net/http/orchestrion.client.yml
+++ b/contrib/net/http/orchestrion.client.yml
@@ -94,6 +94,9 @@ aspects:
       # Wire the context that is found to the handlers...
       - wrap-expression:
           imports:
+            # Temporarily add a namespaced alias to ensure we don't have symbol name collisions.
+            # The root issue is solved at https://github.com/DataDog/orchestrion/pull/678 but this should
+            # ensure dd-trace-go users using older Orchestrion versions don't have build errors.
             __ddtrace_client: github.com/DataDog/dd-trace-go/contrib/net/http/v2/client
           template: |-
             {{- $ctx := .Function.ArgumentOfType "context.Context" -}}

--- a/contrib/net/http/orchestrion.client.yml
+++ b/contrib/net/http/orchestrion.client.yml
@@ -94,18 +94,18 @@ aspects:
       # Wire the context that is found to the handlers...
       - wrap-expression:
           imports:
-            client: github.com/DataDog/dd-trace-go/contrib/net/http/v2/client
+            __ddtrace_client: github.com/DataDog/dd-trace-go/contrib/net/http/v2/client
           template: |-
             {{- $ctx := .Function.ArgumentOfType "context.Context" -}}
             {{- $req := .Function.ArgumentOfType "*net/http.Request" }}
             {{- if $ctx -}}
-              client.{{ .AST.Fun.Name }}(
+              __ddtrace_client.{{ .AST.Fun.Name }}(
                 {{ $ctx }},
                 {{ range .AST.Args }}{{ . }},
                 {{ end }}
               )
             {{- else if $req -}}
-              client.{{ .AST.Fun.Name }}(
+              __ddtrace_client.{{ .AST.Fun.Name }}(
                 {{ $req }}.Context(),
                 {{ range .AST.Args }}{{ . }},
                 {{ end }}

--- a/internal/orchestrion/_integration/net_http/generated_test.go
+++ b/internal/orchestrion/_integration/net_http/generated_test.go
@@ -21,6 +21,10 @@ func TestFuncHandler(t *testing.T) {
 	harness.Run(t, new(TestCaseFuncHandler))
 }
 
+func TestGlobalFunctions(t *testing.T) {
+	harness.Run(t, new(TestCaseGlobalFunctions))
+}
+
 func TestHandlerImplementation(t *testing.T) {
 	harness.Run(t, new(TestCaseHandlerImplementation))
 }

--- a/internal/orchestrion/_integration/net_http/global_functions.go
+++ b/internal/orchestrion/_integration/net_http/global_functions.go
@@ -1,0 +1,38 @@
+package nethttp
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCaseGlobalFunctions tests the aspect replacing global functions.
+type TestCaseGlobalFunctions struct {
+	base
+}
+
+func (b *TestCaseGlobalFunctions) Run(_ context.Context, t *testing.T) {
+	cl := newHttpClient(b.srv.Addr)
+
+	resp, err := cl.Get("/")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusTeapot, resp.StatusCode)
+}
+
+type httpClient struct {
+	serverHost string
+}
+
+func newHttpClient(serverHost string) *httpClient {
+	return &httpClient{
+		serverHost: serverHost,
+	}
+}
+
+func (client *httpClient) Get(path string) (*http.Response, error) {
+	serverHost := client.serverHost
+
+	return http.Get("http://" + serverHost + path)
+}

--- a/internal/orchestrion/_integration/net_http/global_functions.go
+++ b/internal/orchestrion/_integration/net_http/global_functions.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
 package nethttp
 
 import (

--- a/internal/orchestrion/_integration/net_http/global_functions.go
+++ b/internal/orchestrion/_integration/net_http/global_functions.go
@@ -16,12 +16,17 @@ type TestCaseGlobalFunctions struct {
 	base
 }
 
-func (b *TestCaseGlobalFunctions) Run(_ context.Context, t *testing.T) {
-	cl := newHttpClient(b.srv.Addr)
+func (tc *TestCaseGlobalFunctions) Setup(ctx context.Context, t *testing.T) {
+	tc.handler = tc.serveMuxHandler()
+	tc.base.Setup(ctx, t)
+}
+
+func (tc *TestCaseGlobalFunctions) Run(_ context.Context, t *testing.T) {
+	cl := newHttpClient(tc.srv.Addr)
 
 	resp, err := cl.Get("/")
 	require.NoError(t, err)
-	require.Equal(t, http.StatusTeapot, resp.StatusCode)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
 type httpClient struct {

--- a/internal/orchestrion/_integration/net_http/global_functions.go
+++ b/internal/orchestrion/_integration/net_http/global_functions.go
@@ -9,6 +9,9 @@ import (
 )
 
 // TestCaseGlobalFunctions tests the aspect replacing global functions.
+// See: https://github.com/DataDog/orchestrion/issues/670 and https://github.com/DataDog/orchestrion/issues/674
+// The issue is reproduced in this test since the receiver defined below is called `client`, same as the synthetic
+// import added by Orchestrion.
 type TestCaseGlobalFunctions struct {
 	base
 }
@@ -32,7 +35,5 @@ func newHttpClient(serverHost string) *httpClient {
 }
 
 func (client *httpClient) Get(path string) (*http.Response, error) {
-	serverHost := client.serverHost
-
-	return http.Get("http://" + serverHost + path)
+	return http.Get("http://" + client.serverHost + path)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Fixes https://github.com/DataDog/orchestrion/issues/670

The core issue is solved in https://github.com/DataDog/orchestrion/pull/678, but this should make it work even if using older Orchestrion versions.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
