### PR TITLE
ci: fix docker images releases

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -56,17 +56,6 @@ jobs:
         with:
           ref: ${{ inputs.commit_sha }}
 
-      - name: Install Docker (only arm64)
-        if: matrix.platform == 'linux/arm64'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y docker.io
-          sudo systemctl start docker
-          sudo systemctl enable docker
-          sudo usermod -aG docker $USER
-          newgrp docker
-          sudo chmod 666 /var/run/docker.sock
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR removes the installation of Docker inside the arm64 runner.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The release of the docker images linked to the release of the go tracer [failed](https://github.com/DataDog/dd-trace-go/actions/runs/16882325191). The job building running in the arm64 runner was failing when installing docker. This was previously required because we were using the runner image `arm-4core-linux` and it has been changed to use `ubuntu-24.04-arm` in this [PR](https://github.com/DataDog/dd-trace-go/pull/3783).
However now in the new runner, docker is already installed by default (everything listed [here](https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-24-image.md)).

This issue was not detected before while building and running the system tests because the system tests are running exclusively on amd64, skipping the arm64 build step.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
