### PR TITLE
chore(ci/orchestrion): integration tests break if orchestrion updates `go` directive

### DIFF
--- a/.github/workflows/orchestrion.yml
+++ b/.github/workflows/orchestrion.yml
@@ -149,9 +149,13 @@ jobs:
 
       - name: Set up orchestrion
         if: inputs.orchestrion-version != ''
+        # This does not pass `-go` so that it transparently uses the correct go
+        # version, which is the highest one between that of dd-trace-go and
+        # orchestrion. This way each can change their own minimum supported go
+        # release without requiring coordination with the other.
         run: |-
-          go mod edit -go="$(go mod edit -json | jq -r '.Go')" -replace="github.com/DataDog/orchestrion=${{ github.workspace }}/orchestrion"
-          go mod tidy -go="$(go mod edit -json | jq -r '.Go')"
+          go mod edit -replace="github.com/DataDog/orchestrion=${{ github.workspace }}/orchestrion"
+          go mod tidy
         working-directory: ${{ github.workspace }}/dd-trace-go/internal/orchestrion/_integration
         env:
           VERSION: ${{ inputs.orchestrion-version }}


### PR DESCRIPTION
### What does this PR do?

Removes the `-go` constraint on the `go mod` commands in the CI setup so that the toolchain can update the `go` directive appropriately when `orchestrion` and `dd-trace-go` have different Go runtime requirirements.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
