### PR TITLE
chore(ci/orchestrion): canonicalize path before `go work use`

### DIFF
--- a/.github/workflows/orchestrion.yml
+++ b/.github/workflows/orchestrion.yml
@@ -155,9 +155,11 @@ jobs:
         # release without requiring coordination with the other. It also adds
         # the local checkout of orchestrion to the `go.work` so that its own
         # `go` directive is correctly managed.
+        shell: bash
         run: |-
-          go work use -r "${{ github.workspace }}/orchestrion"
-          go mod edit -replace="github.com/DataDog/orchestrion=${{ github.workspace }}${{ runner.os == 'Windows' && '\\' || '/' }}orchestrion"
+          orchestrion_path=$(readlink -e "${{ github.workspace }}/orchestrion")
+          go work use -r "${orchestrion_path}"
+          go mod edit -replace="github.com/DataDog/orchestrion=${orchestrion_path}"
           go mod tidy
         working-directory: ${{ github.workspace }}/dd-trace-go/internal/orchestrion/_integration
         env:


### PR DESCRIPTION
### Motivation

Unless doing this, the `go work use` may contain duplicated delimiters (`//` or `\\`) while the `-replace` directive saves the clean path, resulting in an error.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
