### PR TITLE
feat: new msgp types for v1 trace protocol

### DIFF
--- a/contrib/database/sql/internal/dsn.go
+++ b/contrib/database/sql/internal/dsn.go
@@ -263,7 +263,7 @@ func isValidHostnameStart(s string) bool {
 	}
 	// Should contain hostname-like patterns
 	return strings.Contains(s, ".") || strings.Contains(s, ":") ||
-		   strings.Contains(s, "/") || s == strings.TrimSpace(s)
+		strings.Contains(s, "/") || s == strings.TrimSpace(s)
 }
 
 // sanitizeMySQLPasswords sanitizes passwords in MySQL DSN format (user:pass@tcp...).

--- a/ddtrace/tracer/civisibility_payload.go
+++ b/ddtrace/tracer/civisibility_payload.go
@@ -7,8 +7,9 @@ package tracer
 
 import (
 	"bytes"
-	"sync/atomic"
 	"time"
+
+	"github.com/tinylib/msgp/msgp"
 
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils"
@@ -16,13 +17,12 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/globalconfig"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/version"
-	"github.com/tinylib/msgp/msgp"
 )
 
 // ciVisibilityPayload represents a payload specifically designed for CI Visibility events.
-// It embeds the generic payload structure and adds methods to handle CI Visibility specific data.
+// It uses the generic payload interface and adds methods to handle CI Visibility specific data.
 type ciVisibilityPayload struct {
-	*payloadV04
+	payload           payload
 	serializationTime time.Duration
 }
 
@@ -36,18 +36,17 @@ type ciVisibilityPayload struct {
 // Returns:
 //
 //	An error if encoding the event fails.
-func (p *ciVisibilityPayload) push(event *ciVisibilityEvent) error {
-	p.buf.Grow(event.Msgsize())
+func (p *ciVisibilityPayload) push(event *ciVisibilityEvent) (size int, err error) {
+	p.payload.grow(event.Msgsize())
 	startTime := time.Now()
 	defer func() {
 		p.serializationTime += time.Since(startTime)
 	}()
-	if err := msgp.Encode(&p.buf, event); err != nil {
-		return err
+	if err := msgp.Encode(p.payload, event); err != nil {
+		return 0, err
 	}
-	atomic.AddUint32(&p.count, 1)
-	p.updateHeader()
-	return nil
+	p.payload.recordItem() // This already calls updateHeader() internally.
+	return p.size(), nil
 }
 
 // newCiVisibilityPayload creates a new instance of civisibilitypayload.
@@ -57,7 +56,7 @@ func (p *ciVisibilityPayload) push(event *ciVisibilityEvent) error {
 //	A pointer to a newly initialized civisibilitypayload instance.
 func newCiVisibilityPayload() *ciVisibilityPayload {
 	log.Debug("ciVisibilityPayload: creating payload instance")
-	return &ciVisibilityPayload{newPayload(), 0}
+	return &ciVisibilityPayload{payload: newPayload(traceProtocolV04), serializationTime: 0}
 }
 
 // getBuffer retrieves the complete body of the CI Visibility payload, including metadata.
@@ -73,11 +72,11 @@ func newCiVisibilityPayload() *ciVisibilityPayload {
 //	An error if reading from the buffer or encoding the payload fails.
 func (p *ciVisibilityPayload) getBuffer(config *config) (*bytes.Buffer, error) {
 	startTime := time.Now()
-	log.Debug("ciVisibilityPayload: .getBuffer (count: %d)", p.itemCount())
+	log.Debug("ciVisibilityPayload: .getBuffer (count: %d)", p.payload.stats().itemCount)
 
 	// Create a buffer to read the current payload
 	payloadBuf := new(bytes.Buffer)
-	if _, err := payloadBuf.ReadFrom(p.payloadV04); err != nil {
+	if _, err := payloadBuf.ReadFrom(p.payload); err != nil {
 		return nil, err
 	}
 
@@ -90,7 +89,7 @@ func (p *ciVisibilityPayload) getBuffer(config *config) (*bytes.Buffer, error) {
 		return nil, err
 	}
 
-	telemetry.EndpointPayloadEventsCount(telemetry.TestCycleEndpointType, float64(p.itemCount()))
+	telemetry.EndpointPayloadEventsCount(telemetry.TestCycleEndpointType, float64(p.payload.stats().itemCount))
 	telemetry.EndpointPayloadBytes(telemetry.TestCycleEndpointType, float64(encodedBuf.Len()))
 	telemetry.EndpointEventsSerializationMs(telemetry.TestCycleEndpointType, float64((p.serializationTime + time.Since(startTime)).Milliseconds()))
 	return encodedBuf, nil
@@ -149,4 +148,44 @@ func (p *ciVisibilityPayload) writeEnvelope(env string, events []byte) *ciTestCy
 	}
 
 	return visibilityPayload
+}
+
+// stats returns the current stats of the payload.
+func (p *ciVisibilityPayload) stats() payloadStats {
+	return p.payload.stats()
+}
+
+// size returns the payload size in bytes (for backward compatibility).
+func (p *ciVisibilityPayload) size() int {
+	return p.payload.size()
+}
+
+// itemCount returns the number of items available in the stream (for backward compatibility).
+func (p *ciVisibilityPayload) itemCount() int {
+	return p.payload.itemCount()
+}
+
+// protocol returns the protocol version of the payload.
+func (p *ciVisibilityPayload) protocol() float64 {
+	return p.payload.protocol()
+}
+
+// clear empties the payload buffers.
+func (p *ciVisibilityPayload) clear() {
+	p.payload.clear()
+}
+
+// reset sets up the payload to be read a second time.
+func (p *ciVisibilityPayload) reset() {
+	p.payload.reset()
+}
+
+// Read implements io.Reader by reading from the underlying payload.
+func (p *ciVisibilityPayload) Read(b []byte) (n int, err error) {
+	return p.payload.Read(b)
+}
+
+// Close implements io.Closer by closing the underlying payload.
+func (p *ciVisibilityPayload) Close() error {
+	return p.payload.Close()
 }

--- a/ddtrace/tracer/civisibility_transport.go
+++ b/ddtrace/tracer/civisibility_transport.go
@@ -128,8 +128,8 @@ func newCiVisibilityTransport(config *config) *ciVisibilityTransport {
 // Returns:
 //
 //	An io.ReadCloser for reading the response body, and an error if the operation fails.
-func (t *ciVisibilityTransport) send(p *payloadV04) (body io.ReadCloser, err error) {
-	ciVisibilityPayload := &ciVisibilityPayload{p, 0}
+func (t *ciVisibilityTransport) send(p payload) (body io.ReadCloser, err error) {
+	ciVisibilityPayload := &ciVisibilityPayload{payload: p, serializationTime: 0}
 	buffer, bufferErr := ciVisibilityPayload.getBuffer(t.config)
 	if bufferErr != nil {
 		return nil, fmt.Errorf("cannot create buffer payload: %v", bufferErr)

--- a/ddtrace/tracer/civisibility_transport_test.go
+++ b/ddtrace/tracer/civisibility_transport_test.go
@@ -102,12 +102,12 @@ func runTransportTest(t *testing.T, agentless, shouldSetAPIKey bool) {
 		p := newCiVisibilityPayload()
 		for _, t := range tc.payload {
 			for _, span := range t {
-				err := p.push(getCiVisibilityEvent(span))
+				_, err := p.push(getCiVisibilityEvent(span))
 				assert.NoError(err)
 			}
 		}
 
-		_, err := transport.send(p.payloadV04)
+		_, err := transport.send(p.payload)
 		assert.NoError(err)
 	}
 	assert.Equal(hits, len(testCases))

--- a/ddtrace/tracer/civisibility_writer.go
+++ b/ddtrace/tracer/civisibility_writer.go
@@ -64,10 +64,11 @@ func (w *ciVisibilityTraceWriter) add(trace []*Span) {
 	telemetry.EventsEnqueueForSerialization()
 	for _, s := range trace {
 		cvEvent := getCiVisibilityEvent(s)
-		if err := w.payload.push(cvEvent); err != nil {
+		size, err := w.payload.push(cvEvent)
+		if err != nil {
 			log.Error("ciVisibilityTraceWriter: Error encoding msgpack: %s", err.Error())
 		}
-		if w.payload.size() > agentlessPayloadSizeLimit {
+		if size > agentlessPayloadSizeLimit {
 			w.flush()
 		}
 	}
@@ -82,7 +83,7 @@ func (w *ciVisibilityTraceWriter) stop() {
 // flush sends the current payload to the transport. It ensures that the payload is reset
 // and the resources are freed after the flush operation is completed.
 func (w *ciVisibilityTraceWriter) flush() {
-	if w.payload.itemCount() == 0 {
+	if w.payload.stats().itemCount == 0 {
 		return
 	}
 
@@ -113,9 +114,10 @@ func (w *ciVisibilityTraceWriter) flush() {
 		telemetry.EndpointPayloadRequests(telemetry.TestCycleEndpointType, requestCompressedType)
 
 		for attempt := 0; attempt <= w.config.sendRetries; attempt++ {
-			size, count = p.size(), p.itemCount()
+			stats := p.stats()
+			size, count = stats.size, stats.itemCount
 			log.Debug("ciVisibilityTraceWriter: sending payload: size: %d events: %d\n", size, count)
-			_, err = w.config.transport.send(p.payloadV04)
+			_, err = w.config.transport.send(p.payload)
 			if err == nil {
 				log.Debug("ciVisibilityTraceWriter: sent events after %d attempts", attempt+1)
 				return

--- a/ddtrace/tracer/civisibility_writer_test.go
+++ b/ddtrace/tracer/civisibility_writer_test.go
@@ -30,10 +30,10 @@ type failingCiVisibilityTransport struct {
 	assert       *assert.Assertions
 }
 
-func (t *failingCiVisibilityTransport) send(p *payloadV04) (io.ReadCloser, error) {
+func (t *failingCiVisibilityTransport) send(p payload) (io.ReadCloser, error) {
 	t.sendAttempts++
 
-	ciVisibilityPayload := &ciVisibilityPayload{p, 0}
+	ciVisibilityPayload := &ciVisibilityPayload{payload: p, serializationTime: 0}
 
 	var events ciVisibilityEvents
 	err := msgp.Decode(ciVisibilityPayload, &events)

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -27,6 +27,8 @@ import (
 	"golang.org/x/mod/semver"
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+	"github.com/tinylib/msgp/msgp"
+
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/internal"
 	appsecconfig "github.com/DataDog/dd-trace-go/v2/internal/appsec/config"
@@ -40,7 +42,6 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 	"github.com/DataDog/dd-trace-go/v2/internal/traceprof"
 	"github.com/DataDog/dd-trace-go/v2/internal/version"
-	"github.com/tinylib/msgp/msgp"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 )
@@ -1505,7 +1506,7 @@ func (t *dummyTransport) ObfuscationVersion() int {
 	return t.obfVersion
 }
 
-func (t *dummyTransport) send(p *payloadV04) (io.ReadCloser, error) {
+func (t *dummyTransport) send(p payload) (io.ReadCloser, error) {
 	traces, err := decode(p)
 	if err != nil {
 		return nil, err
@@ -1521,7 +1522,7 @@ func (t *dummyTransport) endpoint() string {
 	return "http://localhost:9/v0.4/traces"
 }
 
-func decode(p *payloadV04) (spanLists, error) {
+func decode(p payloadReader) (spanLists, error) {
 	var traces spanLists
 	err := msgp.Decode(p, &traces)
 	return traces, err

--- a/ddtrace/tracer/payload.go
+++ b/ddtrace/tracer/payload.go
@@ -5,12 +5,168 @@
 
 package tracer
 
+import (
+	"io"
+	"sync"
+)
+
+// payloadStats contains the statistics of a payload.
+type payloadStats struct {
+	size      int // size in bytes
+	itemCount int // number of items (traces)
+}
+
+// payloadWriter defines the interface for writing data to a payload.
+type payloadWriter interface {
+	io.Writer
+
+	push(t spanList) (stats payloadStats, err error)
+	grow(n int)
+	reset()
+	clear()
+
+	// recordItem records that an item was added and updates the header
+	recordItem()
+}
+
+// payloadReader defines the interface for reading data from a payload.
+type payloadReader interface {
+	io.Reader
+	io.Closer
+
+	stats() payloadStats
+	size() int
+	itemCount() int
+	protocol() float64
+}
+
+// unsafePayload defines the interface for unsafe (non-thread-safe) payload implementations.
+type unsafePayload interface {
+	io.Reader
+	io.Writer
+	io.Closer
+
+	push(t spanList) (stats payloadStats, err error)
+	itemCount() int
+	size() int
+	reset()
+	clear()
+	grow(n int)
+	recordItem()
+	stats() payloadStats
+	protocol() float64
+}
+
+// payload combines both reading and writing operations for a payload.
+type payload interface {
+	payloadWriter
+	payloadReader
+}
+
 // https://github.com/msgpack/msgpack/blob/master/spec.md#array-format-family
 const (
 	msgpackArrayFix byte = 144  // up to 15 items
 	msgpackArray16  byte = 0xdc // up to 2^16-1 items, followed by size in 2 bytes
 	msgpackArray32  byte = 0xdd // up to 2^32-1 items, followed by size in 4 bytes
 )
+
+// newPayload returns a ready to use thread-safe payload.
+func newPayload(protocol float64) payload {
+	// TODO(hannahkm): add support for v1 protocol
+	// if protocol == traceProtocolV1 {
+	// }
+	return &safePayload{
+		p: newPayloadV04(protocol),
+	}
+}
+
+// safePayload provides a thread-safe wrapper around unsafePayload.
+type safePayload struct {
+	mu sync.RWMutex
+	p  unsafePayload
+}
+
+// push pushes a new item into the stream in a thread-safe manner.
+func (sp *safePayload) push(t spanList) (stats payloadStats, err error) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	return sp.p.push(t)
+}
+
+// itemCount returns the number of items available in the stream in a thread-safe manner.
+func (sp *safePayload) itemCount() int {
+	return sp.p.itemCount()
+}
+
+// size returns the payload size in bytes in a thread-safe manner.
+func (sp *safePayload) size() int {
+	sp.mu.RLock()
+	defer sp.mu.RUnlock()
+	return sp.p.size()
+}
+
+// reset sets up the payload to be read a second time in a thread-safe manner.
+func (sp *safePayload) reset() {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.p.reset()
+}
+
+// clear empties the payload buffers in a thread-safe manner.
+func (sp *safePayload) clear() {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.p.clear()
+}
+
+// Read implements io.Reader in a thread-safe manner.
+func (sp *safePayload) Read(b []byte) (n int, err error) {
+	// Note: Read modifies internal state (off, reader), so we need full lock
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	return sp.p.Read(b)
+}
+
+// Close implements io.Closer in a thread-safe manner.
+func (sp *safePayload) Close() error {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	return sp.p.Close()
+}
+
+// Write implements io.Writer in a thread-safe manner.
+func (sp *safePayload) Write(data []byte) (n int, err error) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	return sp.p.Write(data)
+}
+
+// grow grows the buffer to ensure it can accommodate n more bytes in a thread-safe manner.
+func (sp *safePayload) grow(n int) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.p.grow(n)
+}
+
+// recordItem records that an item was added and updates the header in a thread-safe manner.
+func (sp *safePayload) recordItem() {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.p.recordItem()
+}
+
+// stats returns the current stats of the payload in a thread-safe manner.
+func (sp *safePayload) stats() payloadStats {
+	sp.mu.RLock()
+	defer sp.mu.RUnlock()
+	return sp.p.stats()
+}
+
+// protocol returns the protocol version of the payload in a thread-safe manner.
+func (sp *safePayload) protocol() float64 {
+	// Protocol is immutable after creation - no lock needed
+	return sp.p.protocol()
+}
 
 // traceChunk represents a list of spans with the same trace ID,
 // i.e. a chunk of a trace

--- a/ddtrace/tracer/payload_v04.go
+++ b/ddtrace/tracer/payload_v04.go
@@ -21,8 +21,8 @@ import (
 // from the msgpack array spec:
 // https://github.com/msgpack/msgpack/blob/master/spec.md#array-format-family
 //
-// payloadV04 implements io.Reader and can be used with the decoder directly. To create
-// a new payload use the newPayload method.
+// payloadV04 implements unsafePayload and can be used with the decoder directly. To create
+// a new payload use the newPayloadV04 method.
 //
 // payloadV04 is not safe for concurrent use.
 //
@@ -58,35 +58,30 @@ type payloadV04 struct {
 	// reader is used for reading the contents of buf.
 	reader *bytes.Reader
 
-	// protocol specifies the trace protocol to use.
-	protocol float64
+	// protocolVersion specifies the trace protocol to use.
+	protocolVersion float64
 }
 
 var _ io.Reader = (*payloadV04)(nil)
 
-// newPayload returns a ready to use payload.
-func newPayload() *payloadV04 {
+// newPayloadV04 returns a ready to use payload.
+func newPayloadV04(protocol float64) *payloadV04 {
 	p := &payloadV04{
-		header: make([]byte, 8),
-		off:    8,
+		header:          make([]byte, 8),
+		off:             8,
+		protocolVersion: protocol,
 	}
 	return p
 }
 
 // push pushes a new item into the stream.
-func (p *payloadV04) push(t []*Span) error {
-	// if p.protocol == traceProtocolV1 {
-	//     // TODO: implement v1.0 encoding
-	// } else {
-	sl := spanList(t)
-	// }
-	p.buf.Grow(sl.Msgsize())
-	if err := msgp.Encode(&p.buf, sl); err != nil {
-		return err
+func (p *payloadV04) push(t spanList) (stats payloadStats, err error) {
+	p.buf.Grow(t.Msgsize())
+	if err := msgp.Encode(&p.buf, t); err != nil {
+		return payloadStats{}, err
 	}
-	atomic.AddUint32(&p.count, 1)
-	p.updateHeader()
-	return nil
+	p.recordItem()
+	return p.stats(), nil
 }
 
 // itemCount returns the number of items available in the stream.
@@ -116,6 +111,30 @@ func (p *payloadV04) clear() {
 	p.reader = nil
 }
 
+// grow grows the buffer to ensure it can accommodate n more bytes.
+func (p *payloadV04) grow(n int) {
+	p.buf.Grow(n)
+}
+
+// recordItem records that an item was added and updates the header.
+func (p *payloadV04) recordItem() {
+	atomic.AddUint32(&p.count, 1)
+	p.updateHeader()
+}
+
+// stats returns the current stats of the payload.
+func (p *payloadV04) stats() payloadStats {
+	return payloadStats{
+		size:      p.size(),
+		itemCount: int(atomic.LoadUint32(&p.count)),
+	}
+}
+
+// protocol returns the protocol version of the payload.
+func (p *payloadV04) protocol() float64 {
+	return p.protocolVersion
+}
+
 // updateHeader updates the payload header based on the number of items currently
 // present in the stream.
 func (p *payloadV04) updateHeader() {
@@ -138,6 +157,11 @@ func (p *payloadV04) updateHeader() {
 // Close implements io.Closer
 func (p *payloadV04) Close() error {
 	return nil
+}
+
+// Write implements io.Writer. It writes data directly to the buffer.
+func (p *payloadV04) Write(data []byte) (n int, err error) {
+	return p.buf.Write(data)
 }
 
 // Read implements io.Reader. It reads from the msgpack-encoded stream.

--- a/ddtrace/tracer/payload_v1.go
+++ b/ddtrace/tracer/payload_v1.go
@@ -51,6 +51,10 @@ type payloadV1 struct {
 
 	// a list of trace `chunks`
 	chunks []traceChunk
+
+	// fields needed to implement unsafePayload interface
+	protocolVersion float64
+	itemsCount      uint32
 }
 
 // AnyValue is a representation of the `any` value. It can take the following types:
@@ -86,3 +90,13 @@ type keyValue struct {
 }
 
 type keyValueList = []keyValue
+
+// newPayloadV1 returns a ready to use payloadV1.
+func newPayloadV1(protocol float64) *payloadV1 {
+	return &payloadV1{
+		protocolVersion: protocol,
+		strings:         make([]string, 0),
+		attributes:      make(map[uint32]anyValue),
+		chunks:          make([]traceChunk, 0),
+	}
+}

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -174,7 +174,7 @@ func TestSpanFinishTwice(t *testing.T) {
 	assert.Nil(err)
 	defer stop()
 
-	assert.Equal(tracer.traceWriter.(*agentTraceWriter).payload.itemCount(), 0)
+	assert.Equal(tracer.traceWriter.(*agentTraceWriter).payload.stats().itemCount, 0)
 
 	// the finish must be idempotent
 	span := tracer.newRootSpan("pylons.request", "pylons", "/")

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -106,7 +106,7 @@ loop:
 		case <-timeout:
 			tst.Fatalf("timed out waiting for payload to contain %d", n)
 		default:
-			if t.traceWriter.(*agentTraceWriter).payload.itemCount() == n {
+			if t.traceWriter.(*agentTraceWriter).payload.stats().itemCount == n {
 				break loop
 			}
 			time.Sleep(10 * time.Millisecond)
@@ -1447,7 +1447,7 @@ func TestTracerEdgeSampler(t *testing.T) {
 		span1.Finish()
 	}
 
-	assert.Equal(tracer0.traceWriter.(*agentTraceWriter).payload.itemCount(), 0)
+	assert.Equal(tracer0.traceWriter.(*agentTraceWriter).payload.stats().itemCount, 0)
 	tracer1.awaitPayload(t, count)
 }
 

--- a/ddtrace/tracer/transport.go
+++ b/ddtrace/tracer/transport.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/internal/tracerstats"
 	"github.com/DataDog/dd-trace-go/v2/internal"
 	"github.com/DataDog/dd-trace-go/v2/internal/version"
@@ -64,13 +65,16 @@ const (
 	defaultHTTPTimeout       = 10 * time.Second              // defines the current timeout before giving up with the send process
 	traceCountHeader         = "X-Datadog-Trace-Count"       // header containing the number of traces in the payload
 	obfuscationVersionHeader = "Datadog-Obfuscation-Version" // header containing the version of obfuscation used, if any
+
+	tracesAPIPath = "/v0.4/traces"
+	statsAPIPath  = "/v0.6/stats"
 )
 
 // transport is an interface for communicating data to the agent.
 type transport interface {
 	// send sends the payload p to the agent using the transport set up.
 	// It returns a non-nil response body when no error occurred.
-	send(p *payloadV04) (body io.ReadCloser, err error)
+	send(p payload) (body io.ReadCloser, err error)
 	// sendStats sends the given stats payload to the agent.
 	// tracerObfuscationVersion is the version of obfuscation applied (0 if none was applied)
 	sendStats(s *pb.ClientStatsPayload, tracerObfuscationVersion int) error
@@ -111,8 +115,8 @@ func newHTTPTransport(url string, client *http.Client) *httpTransport {
 		defaultHeaders["Datadog-External-Env"] = extEnv
 	}
 	return &httpTransport{
-		traceURL: fmt.Sprintf("%s/v0.4/traces", url),
-		statsURL: fmt.Sprintf("%s/v0.6/stats", url),
+		traceURL: fmt.Sprintf("%s%s", url, tracesAPIPath),
+		statsURL: fmt.Sprintf("%s%s", url, statsAPIPath),
 		client:   client,
 		headers:  defaultHeaders,
 	}
@@ -135,10 +139,12 @@ func (t *httpTransport) sendStats(p *pb.ClientStatsPayload, tracerObfuscationVer
 	}
 	resp, err := t.client.Do(req)
 	if err != nil {
+		reportAPIErrorsMetric(resp, err, statsAPIPath)
 		return err
 	}
 	defer resp.Body.Close()
 	if code := resp.StatusCode; code >= 400 {
+		reportAPIErrorsMetric(resp, err, statsAPIPath)
 		// error, check the body for context information and
 		// return a nice error.
 		msg := make([]byte, 1000)
@@ -153,16 +159,17 @@ func (t *httpTransport) sendStats(p *pb.ClientStatsPayload, tracerObfuscationVer
 	return nil
 }
 
-func (t *httpTransport) send(p *payloadV04) (body io.ReadCloser, err error) {
+func (t *httpTransport) send(p payload) (body io.ReadCloser, err error) {
 	req, err := http.NewRequest("POST", t.traceURL, p)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create http request: %s", err.Error())
 	}
-	req.ContentLength = int64(p.size())
+	stats := p.stats()
+	req.ContentLength = int64(stats.size)
 	for header, value := range t.headers {
 		req.Header.Set(header, value)
 	}
-	req.Header.Set(traceCountHeader, strconv.Itoa(p.itemCount()))
+	req.Header.Set(traceCountHeader, strconv.Itoa(stats.itemCount))
 	req.Header.Set(headerComputedTopLevel, "yes")
 	if t := getGlobalTracer(); t != nil {
 		tc := t.TracerConf()
@@ -186,11 +193,11 @@ func (t *httpTransport) send(p *payloadV04) (body io.ReadCloser, err error) {
 	}
 	response, err := t.client.Do(req)
 	if err != nil {
-		reportAPIErrorsMetric(response, err)
+		reportAPIErrorsMetric(response, err, tracesAPIPath)
 		return nil, err
 	}
 	if code := response.StatusCode; code >= 400 {
-		reportAPIErrorsMetric(response, err)
+		reportAPIErrorsMetric(response, err, tracesAPIPath)
 		// error, check the body for context information and
 		// return a nice error.
 		msg := make([]byte, 1000)
@@ -205,7 +212,7 @@ func (t *httpTransport) send(p *payloadV04) (body io.ReadCloser, err error) {
 	return response.Body, nil
 }
 
-func reportAPIErrorsMetric(response *http.Response, err error) {
+func reportAPIErrorsMetric(response *http.Response, err error, endpoint string) {
 	if t, ok := getGlobalTracer().(*tracer); ok {
 		var reason string
 		if err != nil {
@@ -214,7 +221,8 @@ func reportAPIErrorsMetric(response *http.Response, err error) {
 		if response != nil {
 			reason = fmt.Sprintf("server_response_%d", response.StatusCode)
 		}
-		t.statsd.Incr("datadog.tracer.api.errors", []string{"reason:" + reason}, 1)
+		tags := []string{"reason:" + reason, "endpoint:" + endpoint}
+		t.statsd.Incr("datadog.tracer.api.errors", tags, 1)
 	} else {
 		return
 	}

--- a/ddtrace/tracer/transport_bench_test.go
+++ b/ddtrace/tracer/transport_bench_test.go
@@ -1,0 +1,101 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package tracer
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func BenchmarkHTTPTransportSend(b *testing.B) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"rate_by_service":{}}`))
+	}))
+	defer server.Close()
+
+	transport := newHTTPTransport(server.URL, defaultHTTPClient(5*time.Second, false))
+
+	payloadSizes := []struct {
+		name     string
+		numSpans int
+		spanSize int
+	}{
+		{"small_1span", 1, 1},
+		{"medium_10spans", 10, 1},
+		{"large_100spans", 100, 1},
+		{"xlarge_1000spans", 1000, 1},
+	}
+
+	for _, size := range payloadSizes {
+		b.Run(size.name, func(b *testing.B) {
+			payload := newPayload(traceProtocolV04)
+			spans := make([]*Span, size.numSpans)
+			for i := 0; i < size.numSpans; i++ {
+				span := newBasicSpan("transport-test")
+				span.meta["data"] = strings.Repeat("x", size.spanSize*1024)
+				spans[i] = span
+			}
+			_, _ = payload.push(spans)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				payload.reset()
+				rc, err := transport.send(payload)
+				if err == nil {
+					rc.Close()
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkTransportSendConcurrent(b *testing.B) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"rate_by_service":{}}`))
+	}))
+	defer server.Close()
+
+	transport := newHTTPTransport(server.URL, defaultHTTPClient(5*time.Second, false))
+	concurrencyLevels := []int{1, 2, 4, 8}
+
+	for _, concurrency := range concurrencyLevels {
+		b.Run(fmt.Sprintf("concurrency_%d", concurrency), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				var wg sync.WaitGroup
+
+				for j := 0; j < concurrency; j++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+
+						payload := newPayload(traceProtocolV04)
+						spans := []*Span{newBasicSpan("concurrent-transport-test")}
+						_, _ = payload.push(spans)
+
+						rc, err := transport.send(payload)
+						if err == nil {
+							rc.Close()
+						}
+					}()
+				}
+
+				wg.Wait()
+			}
+		})
+	}
+}

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -59,10 +59,10 @@ func getTestTrace(traceN, size int) [][]*Span {
 	return traces
 }
 
-func encode(traces [][]*Span) (*payloadV04, error) {
-	p := newPayload()
+func encode(traces [][]*Span) (payload, error) {
+	p := newPayload(traceProtocolV04)
 	for _, t := range traces {
-		if err := p.push(t); err != nil {
+		if _, err := p.push(t); err != nil {
 			return p, err
 		}
 	}
@@ -160,7 +160,7 @@ func TestTransportResponse(t *testing.T) {
 			}))
 			defer srv.Close()
 			transport := newHTTPTransport(srv.URL, defaultHTTPClient(0, false))
-			rc, err := transport.send(newPayload())
+			rc, err := transport.send(newPayload(traceProtocolV04))
 			if tt.err != "" {
 				assert.Equal(tt.err, err.Error())
 				return
@@ -271,7 +271,7 @@ func (t *OkTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
 }
 
 func TestApiErrorsMetric(t *testing.T) {
-	t.Run("error", func(t *testing.T) {
+	t.Run("traces error", func(t *testing.T) {
 		assert := assert.New(t)
 		c := &http.Client{
 			Transport: &ErrTransport{},
@@ -291,10 +291,10 @@ func TestApiErrorsMetric(t *testing.T) {
 		calls := statsdtest.FilterCallsByName(tg.IncrCalls(), "datadog.tracer.api.errors")
 		assert.Len(calls, 1)
 		call := calls[0]
-		assert.Equal([]string{"reason:network_failure"}, call.Tags())
+		assert.Equal([]string{"reason:network_failure", "endpoint:" + tracesAPIPath}, call.Tags())
 
 	})
-	t.Run("response with err code", func(t *testing.T) {
+	t.Run("traces response with err code", func(t *testing.T) {
 		assert := assert.New(t)
 		c := &http.Client{
 			Transport: &ErrResponseTransport{},
@@ -314,7 +314,45 @@ func TestApiErrorsMetric(t *testing.T) {
 		calls := statsdtest.FilterCallsByName(tg.IncrCalls(), "datadog.tracer.api.errors")
 		assert.Len(calls, 1)
 		call := calls[0]
-		assert.Equal([]string{"reason:server_response_400"}, call.Tags())
+		assert.Equal([]string{"reason:server_response_400", "endpoint:" + tracesAPIPath}, call.Tags())
+	})
+	t.Run("stats error", func(t *testing.T) {
+		assert := assert.New(t)
+		c := &http.Client{
+			Transport: &ErrTransport{},
+		}
+		var tg statsdtest.TestStatsdClient
+		trc, err := newTracer(WithHTTPClient(c), withStatsdClient(&tg))
+		assert.NoError(err)
+		setGlobalTracer(trc)
+		defer trc.Stop()
+
+		// We're expecting an error
+		err = trc.config.transport.sendStats(&pb.ClientStatsPayload{}, 1)
+		assert.Error(err)
+		calls := statsdtest.FilterCallsByName(tg.IncrCalls(), "datadog.tracer.api.errors")
+		assert.Len(calls, 1)
+		call := calls[0]
+		assert.Equal([]string{"reason:network_failure", "endpoint:" + statsAPIPath}, call.Tags())
+	})
+	t.Run("stats response with err code", func(t *testing.T) {
+		assert := assert.New(t)
+		c := &http.Client{
+			Transport: &ErrResponseTransport{},
+		}
+		var tg statsdtest.TestStatsdClient
+		trc, err := newTracer(WithHTTPClient(c), withStatsdClient(&tg))
+		assert.NoError(err)
+		setGlobalTracer(trc)
+		defer trc.Stop()
+
+		err = trc.config.transport.sendStats(&pb.ClientStatsPayload{}, 1)
+		assert.Error(err)
+
+		calls := statsdtest.FilterCallsByName(tg.IncrCalls(), "datadog.tracer.api.errors")
+		assert.Len(calls, 1)
+		call := calls[0]
+		assert.Equal([]string{"reason:server_response_400", "endpoint:" + statsAPIPath}, call.Tags())
 	})
 	t.Run("successful send - no metric", func(t *testing.T) {
 		assert := assert.New(t)

--- a/ddtrace/tracer/writer.go
+++ b/ddtrace/tracer/writer.go
@@ -36,8 +36,11 @@ type agentTraceWriter struct {
 	// config holds the tracer configuration
 	config *config
 
+	// mu synchronizes access to payload operations
+	mu sync.Mutex
+
 	// payload encodes and buffers traces in msgpack format
-	payload *payloadV04
+	payload payload
 
 	// climit limits the number of concurrent outgoing connections
 	climit chan struct{}
@@ -67,12 +70,21 @@ func newAgentTraceWriter(c *config, s *prioritySampler, statsdClient globalinter
 }
 
 func (h *agentTraceWriter) add(trace []*Span) {
-	if err := h.payload.push(trace); err != nil {
+	h.mu.Lock()
+	stats, err := h.payload.push(trace)
+	if err != nil {
+		h.mu.Unlock()
 		h.statsd.Incr("datadog.tracer.traces_dropped", []string{"reason:encoding_error"}, 1)
 		log.Error("Error encoding msgpack: %s", err.Error())
+		return
 	}
-	atomic.AddUint32(&h.tracesQueued, 1) // TODO: This does not differentiate between complete traces and partial chunks
-	if h.payload.size() > payloadSizeLimit {
+	// TODO: This does not differentiate between complete traces and partial chunks
+	atomic.AddUint32(&h.tracesQueued, 1)
+
+	needsFlush := stats.size > payloadSizeLimit
+	h.mu.Unlock()
+
+	if needsFlush {
 		h.statsd.Incr("datadog.tracer.flush_triggered", []string{"reason:size"}, 1)
 		h.flush()
 	}
@@ -85,22 +97,25 @@ func (h *agentTraceWriter) stop() {
 }
 
 // newPayload returns a new payload based on the trace protocol.
-func (h *agentTraceWriter) newPayload() *payloadV04 {
-	p := newPayload()
-	p.protocol = h.config.traceProtocol
-	return p
+func (h *agentTraceWriter) newPayload() payload {
+	return newPayload(h.config.traceProtocol)
 }
 
 // flush will push any currently buffered traces to the server.
 func (h *agentTraceWriter) flush() {
-	if h.payload.itemCount() == 0 {
+	h.mu.Lock()
+	oldp := h.payload
+	// Check after acquiring lock
+	if oldp.itemCount() == 0 {
+		h.mu.Unlock()
 		return
 	}
-	h.wg.Add(1)
-	h.climit <- struct{}{}
-	oldp := h.payload
 	h.payload = h.newPayload()
-	go func(p *payloadV04) {
+	h.mu.Unlock()
+
+	h.climit <- struct{}{}
+	h.wg.Add(1)
+	go func(p payload) {
 		defer func(start time.Time) {
 			// Once the payload has been used, clear the buffer for garbage
 			// collection to avoid a memory leak when references to this object
@@ -114,17 +129,16 @@ func (h *agentTraceWriter) flush() {
 			h.wg.Done()
 		}(time.Now())
 
-		var count, size int
+		stats := p.stats()
 		var err error
 		for attempt := 0; attempt <= h.config.sendRetries; attempt++ {
-			size, count = p.size(), p.itemCount()
-			log.Debug("Attempt to send payload: size: %d traces: %d\n", size, count)
+			log.Debug("Attempt to send payload: size: %d traces: %d\n", stats.size, stats.itemCount)
 			var rc io.ReadCloser
 			rc, err = h.config.transport.send(p)
 			if err == nil {
 				log.Debug("sent traces after %d attempts", attempt+1)
-				h.statsd.Count("datadog.tracer.flush_bytes", int64(size), nil, 1)
-				h.statsd.Count("datadog.tracer.flush_traces", int64(count), nil, 1)
+				h.statsd.Count("datadog.tracer.flush_bytes", int64(stats.size), nil, 1)
+				h.statsd.Count("datadog.tracer.flush_traces", int64(stats.itemCount), nil, 1)
 				if err := h.prioritySampling.readRatesJSON(rc); err != nil {
 					h.statsd.Incr("datadog.tracer.decode_error", nil, 1)
 				}
@@ -137,8 +151,8 @@ func (h *agentTraceWriter) flush() {
 			p.reset()
 			time.Sleep(h.config.retryInterval)
 		}
-		h.statsd.Count("datadog.tracer.traces_dropped", int64(count), []string{"reason:send_failed"}, 1)
-		log.Error("lost %d traces: %v", count, err.Error())
+		h.statsd.Count("datadog.tracer.traces_dropped", int64(stats.itemCount), []string{"reason:send_failed"}, 1)
+		log.Error("lost %d traces: %v", stats.itemCount, err.Error())
 	}(oldp)
 }
 

--- a/ddtrace/tracer/writer_bench_test.go
+++ b/ddtrace/tracer/writer_bench_test.go
@@ -1,0 +1,123 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package tracer
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/statsdtest"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkAgentTraceWriterAdd(b *testing.B) {
+	traceSizes := []struct {
+		name     string
+		numSpans int
+	}{
+		{"1span", 1},
+		{"5spans", 5},
+		{"10spans", 10},
+		{"50spans", 50},
+	}
+
+	for _, size := range traceSizes {
+		b.Run(size.name, func(b *testing.B) {
+			var statsd statsdtest.TestStatsdClient
+			cfg, err := newTestConfig()
+			require.NoError(b, err)
+
+			writer := newAgentTraceWriter(cfg, nil, &statsd)
+
+			trace := make([]*Span, size.numSpans)
+			for i := 0; i < size.numSpans; i++ {
+				trace[i] = newBasicSpan("benchmark-span")
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				writer.add(trace)
+			}
+		})
+	}
+}
+
+func BenchmarkAgentTraceWriterFlush(b *testing.B) {
+	var statsd statsdtest.TestStatsdClient
+	cfg, err := newTestConfig()
+	require.NoError(b, err)
+
+	writer := newAgentTraceWriter(cfg, nil, &statsd)
+	trace := []*Span{newBasicSpan("flush-test")}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		writer.add(trace)
+		writer.flush()
+		writer.wg.Wait()
+	}
+}
+
+func BenchmarkAgentTraceWriterConcurrent(b *testing.B) {
+	concurrencyLevels := []int{1, 2, 4, 8}
+
+	for _, concurrency := range concurrencyLevels {
+		b.Run(fmt.Sprintf("concurrency_%d", concurrency), func(b *testing.B) {
+			var statsd statsdtest.TestStatsdClient
+			cfg, err := newTestConfig()
+			require.NoError(b, err)
+
+			writer := newAgentTraceWriter(cfg, nil, &statsd)
+			trace := []*Span{newBasicSpan("concurrent-test")}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				var wg sync.WaitGroup
+
+				for j := 0; j < concurrency; j++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						writer.add(trace)
+					}()
+				}
+
+				wg.Wait()
+			}
+		})
+	}
+}
+
+func BenchmarkAgentTraceWriterStats(b *testing.B) {
+	var statsd statsdtest.TestStatsdClient
+	cfg, err := newTestConfig()
+	require.NoError(b, err)
+
+	writer := newAgentTraceWriter(cfg, nil, &statsd)
+
+	for i := 0; i < 10; i++ {
+		trace := []*Span{newBasicSpan("stats-test")}
+		writer.add(trace)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		writer.mu.Lock()
+		stats := writer.payload.stats()
+		writer.mu.Unlock()
+		_ = stats.size
+		_ = stats.itemCount
+	}
+}

--- a/ddtrace/tracer/writer_test.go
+++ b/ddtrace/tracer/writer_test.go
@@ -13,6 +13,8 @@ import (
 	"io"
 	"math"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -345,7 +347,7 @@ type failingTransport struct {
 	assert       *assert.Assertions
 }
 
-func (t *failingTransport) send(p *payloadV04) (io.ReadCloser, error) {
+func (t *failingTransport) send(p payload) (io.ReadCloser, error) {
 	t.sendAttempts++
 
 	traces, err := decode(p)
@@ -419,7 +421,7 @@ func TestTraceWriterFlushRetries(t *testing.T) {
 			assert.Nil(err)
 			var statsd statsdtest.TestStatsdClient
 
-			h := newAgentTraceWriter(c, nil, &statsd)
+			h := newAgentTraceWriter(c, newPrioritySampler(), &statsd)
 			h.add(ss)
 			start := time.Now()
 			h.flush()
@@ -457,7 +459,7 @@ func TestTraceProtocol(t *testing.T) {
 		cfg, err := newTestConfig()
 		require.NoError(t, err)
 		h := newAgentTraceWriter(cfg, nil, nil)
-		assert.Equal(traceProtocolV1, h.payload.protocol)
+		assert.Equal(traceProtocolV1, h.payload.protocol())
 	})
 
 	t.Run("v0.4", func(t *testing.T) {
@@ -465,14 +467,14 @@ func TestTraceProtocol(t *testing.T) {
 		cfg, err := newTestConfig()
 		require.NoError(t, err)
 		h := newAgentTraceWriter(cfg, nil, nil)
-		assert.Equal(traceProtocolV04, h.payload.protocol)
+		assert.Equal(traceProtocolV04, h.payload.protocol())
 	})
 
 	t.Run("default", func(t *testing.T) {
 		cfg, err := newTestConfig()
 		require.NoError(t, err)
 		h := newAgentTraceWriter(cfg, nil, nil)
-		assert.Equal(traceProtocolV04, h.payload.protocol)
+		assert.Equal(traceProtocolV04, h.payload.protocol())
 	})
 
 	t.Run("invalid", func(t *testing.T) {
@@ -480,7 +482,7 @@ func TestTraceProtocol(t *testing.T) {
 		cfg, err := newTestConfig()
 		require.NoError(t, err)
 		h := newAgentTraceWriter(cfg, nil, nil)
-		assert.Equal(traceProtocolV04, h.payload.protocol)
+		assert.Equal(traceProtocolV04, h.payload.protocol())
 	})
 }
 func BenchmarkJsonEncodeSpan(b *testing.B) {
@@ -502,4 +504,149 @@ func BenchmarkJsonEncodeFloat(b *testing.B) {
 		bs := ba[:0]
 		encodeFloat(bs, float64(1e-9))
 	}
+}
+
+func TestAgentWriterRaceCondition(t *testing.T) {
+	// This test reproduces a race condition between add() and flush() operations
+	// The race occurs when:
+	// 1. add() loads payload, flush() replaces it before add() can push to it
+	// 2. add() increments tracesQueued while flush() goroutine resets it to 0
+	//
+	// Run with: go test -race -run TestAgentWriterRaceCondition
+
+	assert := assert.New(t)
+	var tg statsdtest.TestStatsdClient
+	cfg, err := newTestConfig(withStatsdClient(&tg))
+	require.NoError(t, err)
+	statsd, err := newStatsdClient(cfg)
+	require.NoError(t, err)
+	defer statsd.Close()
+
+	writer := newAgentTraceWriter(cfg, newPrioritySampler(), &tg)
+
+	const numGoroutines = 50
+	const numOperations = 100
+
+	// Channel to coordinate goroutines
+	start := make(chan struct{})
+
+	var wg sync.WaitGroup
+
+	// Spawn goroutines that continuously add traces
+	for i := 0; i < numGoroutines/2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start // Wait for coordination signal
+
+			for j := 0; j < numOperations; j++ {
+				spans := []*Span{makeSpan(1)}
+				writer.add(spans)
+			}
+		}()
+	}
+
+	// Spawn goroutines that continuously flush
+	for i := 0; i < numGoroutines/2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start // Wait for coordination signal
+
+			for j := 0; j < numOperations; j++ {
+				writer.flush()
+			}
+		}()
+	}
+
+	// Start all goroutines simultaneously to maximize race condition probability
+	close(start)
+
+	// Wait for all operations to complete
+	wg.Wait()
+
+	// Final flush to process any remaining traces
+	writer.flush()
+	writer.wg.Wait()
+
+	// The race condition might cause:
+	// 1. Traces to be lost (added to old payload after it was flushed)
+	// 2. Incorrect trace counts due to counter races
+	// 3. Data races detected by Go's race detector
+
+	assert.True(true, "Test completed - check for race conditions with -race flag")
+}
+
+func TestAgentWriterTraceCountAccuracy(t *testing.T) {
+	// This test validates that trace counting remains accurate under concurrent operations
+	// It detects both data races and logical errors in trace counting
+
+	assert := assert.New(t)
+	var tg statsdtest.TestStatsdClient
+	cfg, err := newTestConfig(withStatsdClient(&tg))
+	require.NoError(t, err)
+	statsd, err := newStatsdClient(cfg)
+	require.NoError(t, err)
+	defer statsd.Close()
+
+	writer := newAgentTraceWriter(cfg, newPrioritySampler(), &tg)
+
+	const numAddGoroutines = 20
+	const numFlushGoroutines = 10
+	const numTracesPerGoroutine = 50
+	const expectedTotalTraces = numAddGoroutines * numTracesPerGoroutine
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Track traces added for verification
+	var tracesAdded int32
+
+	// Spawn goroutines that add traces
+	for i := 0; i < numAddGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+
+			for j := 0; j < numTracesPerGoroutine; j++ {
+				spans := []*Span{makeSpan(1)}
+				writer.add(spans)
+				atomic.AddInt32(&tracesAdded, 1)
+			}
+		}()
+	}
+
+	// Spawn goroutines that flush occasionally
+	for i := 0; i < numFlushGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+
+			// Flush periodically while adds are happening
+			for j := 0; j < 10; j++ {
+				time.Sleep(time.Microsecond * 100)
+				writer.flush()
+			}
+		}()
+	}
+
+	// Start all goroutines
+	close(start)
+	wg.Wait()
+
+	// Final flush to ensure all traces are processed
+	writer.flush()
+	writer.wg.Wait()
+
+	// Verify that the number of traces added matches our expectation
+	actualTracesAdded := atomic.LoadInt32(&tracesAdded)
+	assert.Equal(int32(expectedTotalTraces), actualTracesAdded,
+		"Expected %d traces to be added, but got %d", expectedTotalTraces, actualTracesAdded)
+
+	// The race condition could cause:
+	// 1. Loss of traces if they're added to an old payload after flush starts
+	// 2. Incorrect metrics reporting due to counter races
+	// 3. Data corruption in payload structures
 }

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -259,7 +259,7 @@ func newProfiler(opts ...Option) (*profiler, error) {
 		types = append(types, executionTrace)
 	}
 	for _, pt := range types {
-		isDelta := len(profileTypes[pt].DeltaValues) > 0
+		isDelta := p.cfg.deltaProfiles && len(profileTypes[pt].DeltaValues) > 0
 		in, out := compressionStrategy(pt, isDelta, p.cfg.compressionConfig)
 		compressor, err := newCompressionPipeline(in, out)
 		if err != nil {

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -7,6 +7,7 @@ package profiler
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -35,6 +36,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/traceprof"
 	"github.com/DataDog/dd-trace-go/v2/internal/version"
 
+	pprofile "github.com/google/pprof/profile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -898,5 +900,44 @@ func TestMetricsProfileStopEarlyNoLog(t *testing.T) {
 		if strings.Contains(msg, "ERROR:") {
 			t.Errorf("unexpected error log: %s", msg)
 		}
+	}
+}
+
+func gzipDecompress(data []byte) ([]byte, error) {
+	r, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	return io.ReadAll(r)
+}
+
+func TestHeapProfileCompression(t *testing.T) {
+	t.Run("delta", func(t *testing.T) { testHeapProfileCompression(t, true) })
+	t.Run("non-delta", func(t *testing.T) { testHeapProfileCompression(t, false) })
+}
+
+func testHeapProfileCompression(t *testing.T, delta bool) {
+	profiles := startTestProfiler(t, 1,
+		WithPeriod(10*time.Millisecond), WithProfileTypes(HeapProfile), WithDeltaProfiles(delta),
+	)
+	p := <-profiles
+	attachment := "heap.pprof"
+	if delta {
+		attachment = "delta-heap.pprof"
+	}
+	data, ok := p.attachments[attachment]
+	if !ok {
+		t.Fatalf("no heap profile, got %s", p.event.Attachments)
+	}
+	decompressed, err := gzipDecompress(data)
+	if err != nil {
+		t.Fatalf("decompressing the heap profile failed: %s", err)
+	}
+	t.Logf("%x", decompressed[:16])
+	// We assume the profile is gzip compressed. The pprof pacakge
+	// can parse gzip-compressed profiles (it checks for the magic number).
+	// So we should be able to parse the original data
+	if _, err := pprofile.ParseData(data); err != nil {
+		t.Fatalf("parsing profile data failed: %s", err)
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Creates the new types that are needed to support the v1 trace protocol. Future PRs will work on implementation. For now, the work included in this PR is to:

1. Rename the current payload type to `payloadV04`
2. Create a new payload type called `payloadV1`
3. Move payload types and related work into new files for better organization
4. Create new types (`AnyValue`, `KeyValue`, and `traceChunk`) to support payload representations.

### Motivation

Jira: https://datadoghq.atlassian.net/browse/LANGPLAT-709

We want to start implementing the v1 trace protocol to be used with the agent.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
