### PR TITLE
feat(profiler): implement ProfileType.UnmarshalText method

### DIFF
--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -338,6 +338,26 @@ func (t ProfileType) Tag() string {
 	return fmt.Sprintf("profile_type:%s", t)
 }
 
+// UnmarshalText parses a profile type from text.
+func (t *ProfileType) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "cpu":
+		*t = CPUProfile
+	case "heap":
+		*t = HeapProfile
+	case "block":
+		*t = BlockProfile
+	case "mutex":
+		*t = MutexProfile
+	case "goroutine":
+		*t = GoroutineProfile
+	default:
+		return fmt.Errorf("unknown profile type: %s", text)
+	}
+
+	return nil
+}
+
 // profile specifies a profiles data (gzipped protobuf, json), and the types contained within it.
 type profile struct {
 	// name indicates profile type and format (e.g. cpu.pprof, metrics.json)

--- a/profiler/profile_test.go
+++ b/profiler/profile_test.go
@@ -414,6 +414,41 @@ func TestProfileTypeSoundness(t *testing.T) {
 	})
 }
 
+func TestUnmarshalText(t *testing.T) {
+	tests := []struct {
+		Text            []byte
+		WantProfileType ProfileType
+	}{
+		{
+			Text:            []byte("cpu"),
+			WantProfileType: CPUProfile,
+		},
+		{
+			Text:            []byte("heap"),
+			WantProfileType: HeapProfile,
+		},
+		{
+			Text:            []byte("mutex"),
+			WantProfileType: MutexProfile,
+		},
+		{
+			Text:            []byte("goroutine"),
+			WantProfileType: GoroutineProfile,
+		},
+		{
+			Text:            []byte("block"),
+			WantProfileType: BlockProfile,
+		},
+	}
+
+	for _, test := range tests {
+		var p ProfileType
+		err := p.UnmarshalText(test.Text)
+		require.NoError(t, err)
+		assert.Equal(t, test.WantProfileType, p)
+	}
+}
+
 func requirePprofEqual(t *testing.T, a, b []byte) {
 	t.Helper()
 	pprofA, err := pprofile.ParseData(a)


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This change supports configuration use cases where the profile type is parsed from text sources like environment variables or config file, such that the parsed values can be passed to `profiler.WithProfileTypes`.

Question for reviewers, should I implement a `MarshalText` method as well for completeness? These methods are related because `UnmarshalText` is expected to be able to unmarshal the output from `MarshalText`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Related to discussion: https://github.com/DataDog/dd-trace-go/discussions/3872

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
