### PR TITLE
chore(.github/workflowsw): move `main` CI checks to merge queue runs

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -3,10 +3,6 @@ name: Check Pull Request CI Status
 on:
   workflow_dispatch: # allow to trigger the workflow on main, to add it in suggestion on branch protection rules
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
 
 permissions:
   checks: read

--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -2,6 +2,10 @@ name: API Stability Check
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
     paths:
       - 'ddtrace/tracer/**'
       - 'scripts/apiextractor/**'

--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -2,10 +2,6 @@ name: API Stability Check
 
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
     paths:
       - 'ddtrace/tracer/**'
       - 'scripts/apiextractor/**'

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -10,10 +10,6 @@ on:
   schedule: # nightly
     - cron: "0 0 * * *"
   pull_request: # on pull requests touching appsec files
-    types:
-      - opened
-      - synchronize
-      - reopened
     paths:
       - '.github/workflows/appsec.yml'
       - 'internal/appsec/**'

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -10,19 +10,25 @@ on:
   schedule: # nightly
     - cron: "0 0 * * *"
   pull_request: # on pull requests touching appsec files
+    types:
+      - opened
+      - synchronize
+      - reopened
     paths:
       - '.github/workflows/appsec.yml'
       - 'internal/appsec/**'
       - 'appsec/**'
       - 'contrib/**/appsec.go'
       - '**/go.mod'
-  merge_group:
   push:
-    branches: release-v*
+    branches:
+      - release-v*
     tags-ignore:
       - 'contrib/**'
       - 'instrumentation/**'
-
+      - 'internal/**'
+      - 'orchestrion/**'
+      - 'scripts/**'
 env:
   DD_APPSEC_WAF_TIMEOUT: 1m
   GOEXPERIMENT: synctest # TODO: remove once go1.25 is the minimum supported version

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,11 +11,6 @@ on:
     branches:
       - mq-working-branch-**
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,14 +8,13 @@ on:
         required: true
         type: string
   push:
-    branches: [ main, master ]
-    tags-ignore:
-      - 'contrib/**'
-      - 'instrumentation/**'
+    branches:
+      - mq-working-branch-**
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ main ]
-  merge_group:
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   analyze:

--- a/.github/workflows/ecosystems-label-pr.yml
+++ b/.github/workflows/ecosystems-label-pr.yml
@@ -1,12 +1,12 @@
 name: Label APM Ecosystems Pull Requests
 on:
   pull_request:
-    paths:
-      - "contrib/**"
     types:
       - opened
       - reopened
       - edited
+    paths:
+      - "contrib/**"
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -3,12 +3,13 @@ name: Generate
 on:
   push:
     branches:
-      - main
       - release-*
+      - mq-working-branch-**
   pull_request:
-    branches:
-      - main
-      - release-*
+    types:
+      - opened
+      - synchronize
+      - reopened
   workflow_call:
     inputs:
       go-version:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -6,10 +6,6 @@ on:
       - release-*
       - mq-working-branch-**
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
   workflow_call:
     inputs:
       go-version:

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -8,11 +8,14 @@ on:
         type: string
   push:
     branches:
-      - main
       - release-v*
+      - mq-working-branch-**
     tags-ignore:
       - 'contrib/**'
       - 'instrumentation/**'
+      - 'internal/**'
+      - 'orchestrion/**'
+      - 'scripts/**'
   schedule:
     - cron: '00 00 * * *'
   workflow_dispatch:

--- a/.github/workflows/main-branch-tests.yml
+++ b/.github/workflows/main-branch-tests.yml
@@ -1,12 +1,6 @@
 name: Main Branch and Release Tests
 
 on:
-  workflow_call: # allows to reuse this workflow
-    inputs:
-      ref:
-        description: 'The branch to run the workflow on'
-        required: true
-        type: string
   push:
     branches:
       - release-v*
@@ -31,4 +25,3 @@ jobs:
       pull-requests: write
     with:
       go-version: "1.25" # Should be the highest supported version of Go
-      ref: ${{ github.sha }}

--- a/.github/workflows/main-branch-tests.yml
+++ b/.github/workflows/main-branch-tests.yml
@@ -24,24 +24,11 @@ concurrency:
 
 jobs:
   unit-integration-tests:
-    strategy:
-      matrix:
-        go-version: [ "1.25", "1.24" ]
-      fail-fast: false
     uses: ./.github/workflows/unit-integration-tests.yml
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
     with:
-      go-version: ${{ matrix.go-version }}
-      ref: ${{ inputs.ref || github.ref }}
-    secrets: inherit
-  multios-unit-tests:
-    strategy:
-      matrix:
-        runs-on: [ macos-latest, windows-latest, ubuntu-latest ]
-        go-version: [ "1.25", "1.24" ]
-      fail-fast: false
-    uses: ./.github/workflows/multios-unit-tests.yml
-    with:
-      go-version: ${{ matrix.go-version }}
-      runs-on: ${{ matrix.runs-on }}
-      ref: ${{ inputs.ref || github.ref }}
-    secrets: inherit
+      go-version: "1.25" # Should be the highest supported version of Go
+      ref: ${{ github.sha }}

--- a/.github/workflows/main-branch-tests.yml
+++ b/.github/workflows/main-branch-tests.yml
@@ -9,11 +9,14 @@ on:
         type: string
   push:
     branches:
-      - main
       - release-v*
+      - mq-working-branch-**
     tags-ignore:
       - 'contrib/**'
       - 'instrumentation/**'
+      - 'internal/**'
+      - 'orchestrion/**'
+      - 'scripts/**'
 
 concurrency:
   group: ${{ github.ref }}

--- a/.github/workflows/multios-unit-tests.yml
+++ b/.github/workflows/multios-unit-tests.yml
@@ -4,13 +4,11 @@ on:
   workflow_dispatch: # manually
     inputs:
       go-version:
+        description: The Go version to use
         required: true
         type: string
       runs-on:
-        required: true
-        type: string
-      ref:
-        description: 'The branch to run the workflow on'
+        description: The OS to run the tests on
         required: true
         type: string
   workflow_call:
@@ -19,10 +17,6 @@ on:
         required: true
         type: string
       runs-on:
-        required: true
-        type: string
-      ref:
-        description: 'The branch to run the workflow on'
         required: true
         type: string
 
@@ -51,10 +45,16 @@ jobs:
         shell: pwsh
         run: |
           "normalized_workspace=${{ github.workspace }}" >> $env:GITHUB_ENV
+      - name: Restore repo cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: .git
+          key: gitdb-${{ github.repository_id }}-${{ github.sha }}
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v2.7.0
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.sha }}
+          clean: false
       - name: Setup Go and development tools
         uses: ./.github/actions/setup-go
         with:
@@ -64,7 +64,7 @@ jobs:
       - name: Mac OS Coreutils
         if: inputs.runs-on == 'macos-latest'
         run: brew install coreutils
-      - name: "Runner ${{ matrix.runner-index }}: Test Core and Contrib (No Integration Tests)"
+      - name: "Runner: Test Core and Contrib (No Integration Tests)"
         shell: bash
         run: |
           export PATH="${{ github.workspace }}/bin:${PATH}"

--- a/.github/workflows/orchestrion.yml
+++ b/.github/workflows/orchestrion.yml
@@ -15,13 +15,19 @@ on:
       DD_API_KEY:
         required: false
   pull_request:
-  merge_group:
+    types:
+      - opened
+      - synchronize
+      - reopened
   push:
     branches:
       - release-v*
     tags-ignore:
       - 'contrib/**'
       - 'instrumentation/**'
+      - 'internal/**'
+      - 'orchestrion/**'
+      - 'scripts/**'
 
 permissions: read-all
 

--- a/.github/workflows/orchestrion.yml
+++ b/.github/workflows/orchestrion.yml
@@ -15,10 +15,6 @@ on:
       DD_API_KEY:
         required: false
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
   push:
     branches:
       - release-v*

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -9,15 +9,19 @@ on:
         type: string
   push:
     branches:
-      - main
       - release-v*
+      - mq-working-branch-**
     tags-ignore:
       - 'contrib/**'
       - 'instrumentation/**'
+      - 'internal/**'
+      - 'orchestrion/**'
+      - 'scripts/**'
   pull_request:
-    branches:
-      - "**"
-  merge_group:
+    types:
+      - opened
+      - synchronize
+      - reopened
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -18,10 +18,6 @@ on:
       - 'orchestrion/**'
       - 'scripts/**'
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/pull-request-title-validation.yml
+++ b/.github/workflows/pull-request-title-validation.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - edited
       - reopened
+      - synchronize
 
 jobs:
   check-title:

--- a/.github/workflows/pull-request-title-validation.yml
+++ b/.github/workflows/pull-request-title-validation.yml
@@ -2,7 +2,10 @@ name: Validate PR Title
 
 on:
   pull_request:
-    types: [opened, edited,reopened,synchronize]
+    types:
+      - opened
+      - edited
+      - reopened
 
 jobs:
   check-title:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -37,7 +37,10 @@ jobs:
     secrets: inherit
   # This is a simple join point to make it easy to set up branch protection rules in GitHub.
   pull-request-tests-done:
-    name: PR Unit and Integration Tests
+    name: PR Unit and Integration Tests / ${{ matrix.name }}
+    strategy:
+      matrix:
+        name: [ "test-contrib", "test-core" ]
     needs:
       - unit-integration-tests
       - multios-unit-tests

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,8 +12,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  warm-repo-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: .git
+          key: gitdb-${{ github.repository_id }}-${{ github.sha }}
   unit-integration-tests:
     name: PR Unit and Integration Tests
+    needs:
+      - warm-repo-cache
     strategy:
       matrix:
         go-version: [ "1.24", "1.25" ]
@@ -21,9 +35,10 @@ jobs:
     uses: ./.github/workflows/unit-integration-tests.yml
     with:
       go-version: ${{ matrix.go-version }}
-      ref: ${{ github.sha }}
     secrets: inherit
   multios-unit-tests:
+    needs:
+      - warm-repo-cache
     strategy:
       matrix:
         runs-on: [ macos-latest, windows-latest, ubuntu-latest ]
@@ -33,7 +48,6 @@ jobs:
     with:
       go-version: ${{ matrix.go-version }}
       runs-on: ${{ matrix.runs-on }}
-      ref: ${{ github.sha }}
     secrets: inherit
   # This is a simple join point to make it easy to set up branch protection rules in GitHub.
   pull-request-tests-done:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,12 +14,39 @@ concurrency:
 jobs:
   unit-integration-tests:
     name: PR Unit and Integration Tests
+    strategy:
+      matrix:
+        go-version: [ "1.24", "1.25" ]
+      fail-fast: false
     uses: ./.github/workflows/unit-integration-tests.yml
-    permissions:
-      contents: read
-      id-token: write
-      pull-requests: write
     with:
-      go-version: "1.24"
-      ref: ${{ github.ref }}
+      go-version: ${{ matrix.go-version }}
+      ref: ${{ github.sha }}
     secrets: inherit
+  multios-unit-tests:
+    strategy:
+      matrix:
+        runs-on: [ macos-latest, windows-latest, ubuntu-latest ]
+        go-version: [ "1.24", "1.25" ]
+      fail-fast: false
+    uses: ./.github/workflows/multios-unit-tests.yml
+    with:
+      go-version: ${{ matrix.go-version }}
+      runs-on: ${{ matrix.runs-on }}
+      ref: ${{ github.sha }}
+    secrets: inherit
+  # This is a simple join point to make it easy to set up branch protection rules in GitHub.
+  pull-request-tests-done:
+    name: PR Unit and Integration Tests
+    needs:
+      - unit-integration-tests
+      - multios-unit-tests
+    runs-on: ubuntu-latest
+    if: success() || failure()
+    steps:
+      - name: Success
+        if: needs.unit-integration-tests.result == 'success' && needs.multios-unit-tests.result == 'success'
+        run: echo "Success!"
+      - name: Failure
+        if: needs.unit-integration-tests.result != 'success' || needs.multios-unit-tests.result != 'success'
+        run: echo "Failure!" && exit 1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,10 +2,6 @@ name: Pull Request Tests
 
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
 
 concurrency:
   group: ${{ github.ref }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,15 +2,10 @@ name: Pull Request Tests
 
 on:
   pull_request:
-    branches:
-      - "**"
-  merge_group:
-  push:
-    branches:
-      - 'mq-working-branch-**'
-    tags-ignore:
-      - 'contrib/**'
-      - 'instrumentation/**'
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 concurrency:
   group: ${{ github.ref }}

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -13,17 +13,22 @@ on:
         type: string
   push:
     branches:
-      - main
       - release-v*
+      - mq-working-branch-**
     tags-ignore:
       - 'contrib/**'
       - 'instrumentation/**'
+      - 'internal/**'
+      - 'orchestrion/**'
+      - 'scripts/**'
   schedule: # nightly
     - cron: "0 0 * * *"
   workflow_dispatch: { } # manually
   pull_request:
-    branches:
-      - '**'
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 env:
   TEST_RESULTS: /tmp/test-results # path to where test results will be saved

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -25,10 +25,6 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch: { } # manually
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
 
 env:
   TEST_RESULTS: /tmp/test-results # path to where test results will be saved

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -3,12 +3,19 @@ name: Static Checks
 on:
   push:
     branches:
-      - main
       - release-*
+      - mq-working-branch-**
+    tags-ignore:
+      - 'contrib/**'
+      - 'instrumentation/**'
+      - 'internal/**'
+      - 'orchestrion/**'
+      - 'scripts/**'
   pull_request:
-    branches:
-      - main
-      - release-*
+    types:
+      - opened
+      - synchronize
+      - reopened
   workflow_call:
     inputs:
       go-version:

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -12,10 +12,6 @@ on:
       - 'orchestrion/**'
       - 'scripts/**'
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
   workflow_call:
     inputs:
       go-version:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -37,11 +37,32 @@ permissions:
   packages: write
 
 jobs:
+  warm-repo-cache:
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.pin.outputs.sha }}
+    steps:
+      - name: Checkout system-tests
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: 'DataDog/system-tests'
+          ref: ${{ inputs.ref }}
+      - name: Pin exact commit SHA for system-tests
+        id: pin
+        run: |
+          echo "sha=$(git rev-parse FETCH_HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: .git
+          key: gitdb-system-tests-${{ steps.pin.outputs.sha }}
   system-tests:
     if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'DataDog/dd-trace-go')
     # Note: Not using large runners because the jobs spawned by this pipeline
     # don't seem to get a noticable speedup from using larger runners.
     runs-on: ubuntu-latest
+    needs:
+      - warm-repo-cache
     strategy:
       matrix:
         weblog-variant:
@@ -128,11 +149,17 @@ jobs:
       SYSTEM_TESTS_E2E_DD_APP_KEY: ${{ secrets.SYSTEM_TESTS_E2E_DD_APP_KEY }}
     name: Test (${{ matrix.weblog-variant }}, ${{ matrix.scenario }})
     steps:
-      - name: Checkout system tests
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Restore repo cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
-          repository: 'DataDog/system-tests'
-          ref: ${{ inputs.ref }}
+          path: .git
+          key: gitdb-system-tests-${{ needs.warm-repo-cache.outputs.sha }}
+
+      - name: Checkout system tests
+        shell: bash
+        run: |
+          git config safe.directory "$GITHUB_WORKSPACE"
+          git checkout -f ${{ needs.warm-repo-cache.outputs.sha }}
 
       - name: Checkout dd-trace-go
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -9,22 +9,26 @@ on:
         type: string
   push:
     branches:
-      - main
       - release-v*
+      - mq-working-branch-**
     tags-ignore:
       - 'contrib/**'
       - 'instrumentation/**'
+      - 'internal/**'
+      - 'orchestrion/**'
+      - 'scripts/**'
   pull_request:
-    branches:
-      - "**"
-  merge_group:
+    types:
+      - opened
+      - synchronize
+      - reopened
   workflow_dispatch:
-      inputs:
-          ref:
-              description: 'System Tests ref/tag/branch'
-              required: true
-              default: main
-              type: string
+    inputs:
+        ref:
+            description: 'System Tests ref/tag/branch'
+            required: true
+            default: main
+            type: string
   schedule:
     - cron:  '00 04 * * 2-6'
 

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -18,10 +18,6 @@ on:
       - 'orchestrion/**'
       - 'scripts/**'
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
   workflow_dispatch:
     inputs:
         ref:

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -6,10 +6,6 @@ on:
       go-version:
         required: true
         type: string
-      ref:
-        description: 'The branch to run the workflow on'
-        required: true
-        type: string
 
 env:
   DD_APPSEC_WAF_TIMEOUT: 1m # Increase time WAF time budget to reduce CI flakiness
@@ -32,10 +28,16 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
+      - name: Restore repo cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: .git
+          key: gitdb-${{ github.repository_id }}-${{ github.sha }}
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.sha }}
+          clean: false
 
       - name: Compute Matrix
         id: matrix
@@ -202,11 +204,16 @@ jobs:
         ports:
           - 4566:4566
     steps:
+      - name: Restore repo cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: .git
+          key: gitdb-${{ github.repository_id }}-${{ github.sha }}
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          ref: ${{ inputs.ref || github.ref }}
-          fetch-depth: $(( ${{ github.event_name == 'pull_request' && github.event.pull_request.commits || 0 }} + 1 ))
+          ref: ${{ github.sha }}
+          clean: false
 
       - name: Setup Go and development tools
         uses: ./.github/actions/setup-go
@@ -274,11 +281,16 @@ jobs:
           - 8125:8125/udp
           - 8126:8126
     steps:
+      - name: Restore repo cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: .git
+          key: gitdb-${{ github.repository_id }}-${{ github.sha }}
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          ref: ${{ inputs.ref || github.ref }}
-          fetch-depth: $(( ${{ github.event_name == 'pull_request' && github.event.pull_request.commits || 0 }} + 1 ))
+          ref: ${{ github.sha }}
+          clean: false
       - name: Setup Go and development tools
         uses: ./.github/actions/setup-go
         with:

--- a/.github/workflows/update-supported-versions-doc.yml
+++ b/.github/workflows/update-supported-versions-doc.yml
@@ -4,7 +4,8 @@ on:
     # Every time we run smoke tests, we check what version of each library was used to run the tests and this will
     # be used as the latest supported version in our docs.
     workflows: ["Smoke Tests"]
-    branches: [main]
+    branches:
+      - mq-working-branch-**
     types:
       - completed
 


### PR DESCRIPTION
### What does this PR do?

Updates workflows so `main` CI checks happen during a merge queue run. Specifically it marks all workflows that run in push events to `main` to run on those events on branches starting with `mq-working-branch`.

Additionally:

- Standardises `pull_request` triggers to explicitly set `opened`, `reopened`, and `synchronized` default states.
- Standardises `tags-ignore` for `push` triggers to ignore all nested modules' version tags.
- Removes `merge_group` triggers.
- Removes `synchronized` event on `pull-request-title-validation`.
- Updates Go version to the highest supported one on `pull-request` workflow.
- Swaps `main-branch-tests` with `pull-requests`, making sure any flakiness is early detected.
- `main-branch-tests` run only high-signal `unit-integration-tests` with a smaller set.
- Fixes indentation on `system-tests`.
- Introduces repository caching to avoid pulling it in matrix-based tests like `system-tests`, `pull-request`, or `main-branch-tests`.

### Motivation

Clarify CI usage and ensure that failing CI checks have visibility and impact. Currently we can only see if anything is wrong on `main` by looking at the CI checks for a commit in GitHub's UI.

Note 1: this PR requires a small change on repository's settings to move the required checks `PR Unit and Integration Tests / test-core` and `PR Unit and Integration Tests / test-contrib` to `PR Unit and Integration Tests`.

Note 2: this PR would cause that no check will run if somebody with admin privileges doesn't use the merge queue. It should be possible to avoid that by setting some kind of break glass job that must run when merging directly from the UI. Merge queue should work by skipping it.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
