### PR TITLE
fix: pin DataDog/datadog-go to v5.6.0 becaue of a breaking change in v5.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ godebug x509negativeserial=1
 
 replace github.com/DataDog/datadog-agent/pkg/trace => github.com/DataDog/datadog-agent/pkg/trace v0.67.0
 
+replace github.com/DataDog/datadog-go/v5 v5.7.0 => github.com/DataDog/datadog-go/v5 v5.6.0
+
 require (
 	github.com/DataDog/appsec-internal-go v1.13.0
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.67.0


### PR DESCRIPTION

### What does this PR do?

This PR is the result of https://github.com/DataDog/datadog-go/issues/332

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
