### PR TITLE
fix(contrib/gorm.io): allow resource name to be overridden by custom tags

### DIFF
--- a/contrib/gorm.io/gorm.v1/option.go
+++ b/contrib/gorm.io/gorm.v1/option.go
@@ -31,11 +31,13 @@ func (fn OptionFn) apply(cfg *config) {
 	fn(cfg)
 }
 
-func defaults(cfg *config) {
+func newConfigWithDefaults() *config {
+	cfg := new(config)
 	cfg.serviceName = "gorm.db"
 	cfg.analyticsRate = instr.AnalyticsRate(false)
 	cfg.errCheck = func(error) bool { return true }
 	cfg.tagFns = make(map[string]func(db *gorm.DB) interface{})
+	return cfg
 }
 
 // WithService sets the given service name when registering a driver,


### PR DESCRIPTION
### What does this PR do?

When using package github.com/DataDog/dd-trace-go/contrib/gorm.io/gorm.v1/v2, I want to override the resource name (because the SQL is long and unwieldy).  Alas, I cannot do this with `gormtrace.WithCustomTag(ext.ResourceName, ...`  because the `span.SetTag(ext.ResourceName, db.Statement.SQL.String())` call is done after processing custom tags.  Thus, I propose moving the custom tag processing to below where the default resource name is set.

Thank you for your consideration!