### PR TITLE
chore(.github/workflows): cache datadog-agent image (POC for general Docker images caching)

### DIFF
--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -54,7 +54,7 @@ jobs:
       matrix:
         chunk: ${{ fromJson(needs.set-up.outputs.matrix) }}
     services:
-      datadog-agent:
+      datadog-agent: &datadog-agent
         image: datadog/agent:latest
         env:
           DD_HOSTNAME: "github-actions-worker"
@@ -264,21 +264,7 @@ jobs:
     env:
        INTEGRATION: true
     services:
-      datadog-agent:
-        image: datadog/agent:latest
-        env:
-          DD_HOSTNAME: "github-actions-worker"
-          DD_APM_ENABLED: true
-          DD_BIND_HOST: "0.0.0.0"
-          DD_API_KEY: "invalid_key_but_this_is_fine"
-        # We need to specify a custom health-check. By default, this container will remain "unhealthy" since
-        # we don't fully configure it with a valid API key (and possibly other reasons)
-        # This command just checks for our ability to connect to port 8126
-        options: >-
-          --health-cmd "bash -c '</dev/tcp/127.0.0.1/8126'"
-        ports:
-          - 8125:8125/udp
-          - 8126:8126
+      datadog-agent: *datadog-agent
     steps:
       - name: Restore repo cache
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
@@ -327,20 +313,7 @@ jobs:
     runs-on:
       group: "APM Larger Runners"
     services:
-      datadog-agent:
-        image: datadog/agent:latest
-        env:
-          DD_HOSTNAME: "github-actions-worker"
-          DD_APM_ENABLED: true
-          DD_BIND_HOST: "0.0.0.0"
-          DD_API_KEY: "invalid_key_but_this_is_fine"
-          DD_TEST_AGENT_HOST: "localhost"
-          DD_TEST_AGENT_PORT: 9126
-        options: >-
-          --health-cmd "bash -c '</dev/tcp/127.0.0.1/8126'"
-        ports:
-          - 8125:8125/udp
-          - 8126:8126
+      datadog-agent: *datadog-agent
       testagent:
         image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.11.0
         ports:


### PR DESCRIPTION
### What does this PR do?

Caches Docker images, starting with `datadog-agent`.

### Motivation

We are running 12 jobs, one per contribs' set and each supported Go version, that each one pulls up to 18 images over and over, thus causing:

- Slow CI time: each services initialization averages around 2 minutes and 30 seconds.
- Rate limiting: we are hitting Docker Hub, only for the pull request tests of a single PR, 216 times. Any increase on the number of PRs running CI will cause rate limiting, failing our pipelines.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
