### PR TITLE
feat(appsec): blocking on path params for net/http serve mux tracing

### DIFF
--- a/instrumentation/appsec/emitter/httpsec/http.go
+++ b/instrumentation/appsec/emitter/httpsec/http.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"sync/atomic"
 
+	"github.com/DataDog/dd-trace-go/v2/appsec/events"
 	"github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/dyngo"
 	"github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/emitter/waf/actions"
 	"github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/emitter/waf/addresses"
@@ -168,22 +169,30 @@ func makeCookies(parsed []*http.Cookie) map[string][]string {
 // before the router has matched the request to a route. This can happen when the HTTP handler is wrapped
 // using http.NewServeMux instead of http.WrapHandler. In this case the route is empty and so are the path parameters.
 // In this case the route and path parameters will be filled in later by calling RouteMatched with the actual route.
-func RouteMatched(ctx context.Context, route string, routeParams map[string]string) {
+// If RouteMatched returns an error, the request should be considered blocked and the error should be reported.
+func RouteMatched(ctx context.Context, route string, routeParams map[string]string) error {
 	op, ok := dyngo.FindOperation[HandlerOperation](ctx)
 	if !ok {
 		log.Debug("appsec: RouteMatched called without an active HandlerOperation in the context, ignoring")
 		telemetrylog.Warn("appsec: RouteMatched called without an active HandlerOperation in the context, ignoring", telemetry.WithTags([]string{"product:appsec"}))
-		return
+		return nil
 	}
 
 	// Overwrite the previous route that was created using a quantization algorithm
 	op.route = route
+
+	var err error
+	dyngo.OnData(op, func(e *events.BlockingSecurityEvent) {
+		err = e
+	})
 
 	// Call the WAF with this new data
 	op.Run(op, addresses.NewAddressesBuilder().
 		WithPathParams(routeParams).
 		Build(),
 	)
+
+	return err
 }
 
 // BeforeHandle contains the appsec functionality that should be executed before a http.Handler runs.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR follows https://github.com/DataDog/dd-trace-go/pull/3853 to finish the job and allow security rules to also block on path paramers and route being matched to a handler.

### Motivation



### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
