### PR TITLE
chore(.gitlab): align bp-runner.fail-on-breach names to macrobenchmarks

### DIFF
--- a/.gitlab/bp-runner.fail-on-breach.yml
+++ b/.gitlab/bp-runner.fail-on-breach.yml
@@ -10,28 +10,28 @@ experiments:
         warning_range: 10
         scenarios:
           # Go oldstable
-          - name: normal_operation_cgo-cpu-bound/go124-profile-trace-asm
+          - name: normal_operation_cgo-cpu-bound/go-oldstable-profile-trace-asm
             thresholds:
               - agg_http_req_duration_p99 < 125.0 ms
-          - name: high_load_cgo-cpu-bound/go124-profile-trace-asm
+          - name: high_load_cgo-cpu-bound/go-oldstable-profile-trace-asm
             thresholds:
               - throughput < 40 op/s
-          - name: normal_operation_cgo-cpu-bound/go124-only-trace
+          - name: normal_operation_cgo-cpu-bound/go-oldstable-only-trace
             thresholds:
               - agg_http_req_duration_p99 < 125.0 ms
-          - name: high_load_cgo-cpu-bound/go124-only-trace
+          - name: high_load_cgo-cpu-bound/go-oldstable-only-trace
             thresholds:
               - throughput < 40 op/s
           # Go stable
-          - name: normal_operation_cgo-cpu-bound/go125-profile-trace-asm
+          - name: normal_operation_cgo-cpu-bound/go-stable-profile-trace-asm
             thresholds:
               - agg_http_req_duration_p99 < 125.0 ms
-          - name: high_load_cgo-cpu-bound/go125-profile-trace-asm
+          - name: high_load_cgo-cpu-bound/go-stable-profile-trace-asm
             thresholds:
               - throughput < 40 op/s
-          - name: normal_operation_cgo-cpu-bound/go125-only-trace
+          - name: normal_operation_cgo-cpu-bound/go-stable-only-trace
             thresholds:
               - agg_http_req_duration_p99 < 125.0 ms
-          - name: high_load_cgo-cpu-bound/go125-only-trace
+          - name: high_load_cgo-cpu-bound/go-stable-only-trace
             thresholds:
               - throughput < 40 op/s


### PR DESCRIPTION
### What does this PR do?

Aligns bp-runner.fail-on-breach names to macrobenchmarks. Follow up of #3875.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
