### PR TITLE
fix(telemetry): data race between test and auto flush

### DIFF
--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -103,6 +103,7 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestAutoFlush(t *testing.T) {
+	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		config := defaultConfig(ClientConfig{
 			AgentURL: "http://localhost:8126",
@@ -116,11 +117,16 @@ func TestAutoFlush(t *testing.T) {
 		defer c.Close()
 
 		recordWriter := &internal.RecordWriter{}
+
+		c.flushMu.Lock()
 		c.writer = recordWriter
+		c.flushMu.Unlock()
 
 		time.Sleep(config.FlushInterval.Max + time.Second)
 
+		c.flushMu.Lock()
 		require.Len(t, recordWriter.Payloads(), 1)
+		c.flushMu.Unlock()
 	})
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds a mutex before flushing data from the telemetry client so only one at a time can happen

### Motivation

This PR fixes the data races found [here](https://github.com/DataDog/dd-trace-go/actions/runs/17233075287/job/48911296431?pr=3887#step:6:440) that could theoretically happen if somehow the main goroutine of a test ran slower than one full minute which would trigger auto flush before the actual writer was changed for the record writer and multiple small other things like this that are very unlikely to happen in real life

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
