### PR TITLE
[APM] Add 'endpoint' tag to API error metric

### DIFF
--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -271,7 +271,7 @@ func (t *OkTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
 }
 
 func TestApiErrorsMetric(t *testing.T) {
-	t.Run("error", func(t *testing.T) {
+	t.Run("traces error", func(t *testing.T) {
 		assert := assert.New(t)
 		c := &http.Client{
 			Transport: &ErrTransport{},
@@ -291,10 +291,10 @@ func TestApiErrorsMetric(t *testing.T) {
 		calls := statsdtest.FilterCallsByName(tg.IncrCalls(), "datadog.tracer.api.errors")
 		assert.Len(calls, 1)
 		call := calls[0]
-		assert.Equal([]string{"reason:network_failure"}, call.Tags())
+		assert.Equal([]string{"reason:network_failure", "endpoint:" + tracesAPIPath}, call.Tags())
 
 	})
-	t.Run("response with err code", func(t *testing.T) {
+	t.Run("traces response with err code", func(t *testing.T) {
 		assert := assert.New(t)
 		c := &http.Client{
 			Transport: &ErrResponseTransport{},
@@ -314,7 +314,45 @@ func TestApiErrorsMetric(t *testing.T) {
 		calls := statsdtest.FilterCallsByName(tg.IncrCalls(), "datadog.tracer.api.errors")
 		assert.Len(calls, 1)
 		call := calls[0]
-		assert.Equal([]string{"reason:server_response_400"}, call.Tags())
+		assert.Equal([]string{"reason:server_response_400", "endpoint:" + tracesAPIPath}, call.Tags())
+	})
+	t.Run("stats error", func(t *testing.T) {
+		assert := assert.New(t)
+		c := &http.Client{
+			Transport: &ErrTransport{},
+		}
+		var tg statsdtest.TestStatsdClient
+		trc, err := newTracer(WithHTTPClient(c), withStatsdClient(&tg))
+		assert.NoError(err)
+		setGlobalTracer(trc)
+		defer trc.Stop()
+
+		// We're expecting an error
+		err = trc.config.transport.sendStats(&pb.ClientStatsPayload{}, 1)
+		assert.Error(err)
+		calls := statsdtest.FilterCallsByName(tg.IncrCalls(), "datadog.tracer.api.errors")
+		assert.Len(calls, 1)
+		call := calls[0]
+		assert.Equal([]string{"reason:network_failure", "endpoint:" + statsAPIPath}, call.Tags())
+	})
+	t.Run("stats response with err code", func(t *testing.T) {
+		assert := assert.New(t)
+		c := &http.Client{
+			Transport: &ErrResponseTransport{},
+		}
+		var tg statsdtest.TestStatsdClient
+		trc, err := newTracer(WithHTTPClient(c), withStatsdClient(&tg))
+		assert.NoError(err)
+		setGlobalTracer(trc)
+		defer trc.Stop()
+
+		err = trc.config.transport.sendStats(&pb.ClientStatsPayload{}, 1)
+		assert.Error(err)
+
+		calls := statsdtest.FilterCallsByName(tg.IncrCalls(), "datadog.tracer.api.errors")
+		assert.Len(calls, 1)
+		call := calls[0]
+		assert.Equal([]string{"reason:server_response_400", "endpoint:" + statsAPIPath}, call.Tags())
 	})
 	t.Run("successful send - no metric", func(t *testing.T) {
 		assert := assert.New(t)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This metric is becoming part of the [CSS spec](https://docs.google.com/document/d/1NmGVxNyd9o8UQ7AvFKjOVq5tBDN6GN8jeQmvyBUnkrQ/edit?pli=1&tab=t.0), and having it tagged with the trace-agent endpoint will be useful for debugging purposes.


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

See above

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
