### PR TITLE
Add test to reproduce slog deadlock with orchestrion

### DIFF
--- a/internal/orchestrion/_integration/slog/slog.go
+++ b/internal/orchestrion/_integration/slog/slog.go
@@ -47,6 +47,8 @@ func (tc *TestCase) Run(ctx context.Context, t *testing.T) {
 		tc.logger.Log(ctx, slog.LevelInfo, s, a...)
 	}, "log")
 
+	tc.testDeadlock(ctx, t)
+
 	logs := tc.logs.String()
 	t.Logf("got logs: %s", logs)
 	for _, msg := range []string{"debug", "info", "warn", "error", "log"} {
@@ -67,6 +69,18 @@ func (tc *TestCase) Run(ctx context.Context, t *testing.T) {
 			t.Errorf("no trace ID")
 		}
 	}
+}
+
+func (tc *TestCase) testDeadlock(ctx context.Context, t *testing.T) {
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	orig := slog.Default()
+	slog.SetDefault(slog.New(handler))
+
+	slog.SetDefault(orig)
+
+	logger := slog.Default()
+	logger.InfoContext(ctx, "This should deadlock")
 }
 
 func (*TestCase) ExpectedTraces() trace.Traces { return trace.Traces{} }


### PR DESCRIPTION
This test reproduces the deadlock issue that occurs when orchestrion is used with `slog.SetDefault()`. 

I was trying with go 1.24.6, but it seems like this is an issue with other versions as well. The lock is [here](https://github.com/golang/go/blob/release-branch.go1.24/src/log/log.go#L243). The orchestrion handler calls into the handler writer which calls calls back into the orchestrion handler [here](https://github.com/golang/go/blob/release-branch.go1.24/src/log/slog/logger.go#L102)

### What does this PR do?

Just adds a test that shows the deadlock

### Motivation

I was trying to add orchestrion to our project and we had tests failing for this reason.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
