### PR TITLE
ci: fix PR title validation regexp

### DIFF
--- a/.github/workflows/pull-request-title-validation.yml
+++ b/.github/workflows/pull-request-title-validation.yml
@@ -15,7 +15,7 @@ jobs:
 
           # Regex: type(scope?): subject
           # Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
-          REGEX="^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9/\-\.]+\))?: .+"
+          REGEX='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9/_\.-]+\))?: .+'
 
           if [[ ! "$TITLE" =~ $REGEX ]]; then
             echo "::error ::❌ Pull request title does not follow Conventional Commits format."


### PR DESCRIPTION
### What does this PR do?

Fixes the regexp used to validate PR titles in conventional commits.

### Motivation

This [PR](https://github.com/DataDog/dd-trace-go/pull/3928) is failing. Here is the [job passing](https://github.com/DataDog/dd-trace-go/actions/runs/17323072380/job/49180546106?pr=3929) with the fix (same title used)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
