### PR TITLE
feat(tracer): implement msgp serialization for payloadV1 and spanListV1

### DIFF
--- a/ddtrace/tracer/payload.go
+++ b/ddtrace/tracer/payload.go
@@ -5,6 +5,8 @@
 
 package tracer
 
+import "github.com/tinylib/msgp/msgp"
+
 // https://github.com/msgpack/msgpack/blob/master/spec.md#array-format-family
 const (
 	msgpackArrayFix byte = 144  // up to 15 items
@@ -12,28 +14,41 @@ const (
 	msgpackArray32  byte = 0xdd // up to 2^32-1 items, followed by size in 4 bytes
 )
 
+type spanListV1 []*Span
+
+// EncodeMsg implements msgp.Encodable.
+func (s *spanListV1) EncodeMsg(*msgp.Writer) error {
+	// From here, encoding goes full manual.
+	// Span, SpanLink, and SpanEvent structs are different for v0.4 and v1.0.
+	// For v1 we need to manually encode the spans, span links, and span events
+	// if we don't want to do extra allocations.
+	panic("unimplemented")
+}
+
+var _ msgp.Encodable = (*spanListV1)(nil)
+
 // traceChunk represents a list of spans with the same trace ID,
 // i.e. a chunk of a trace
 type traceChunk struct {
 	// the sampling priority of the trace
-	priority int32
+	priority int32 `msg:"priority"`
 
 	// the optional string origin ("lambda", "rum", etc.) of the trace chunk
-	origin uint32
+	origin uint32 `msg:"origin,omitempty"`
 
 	// a collection of key to value pairs common in all `spans`
-	attributes map[uint32]anyValue
+	attributes map[uint32]anyValue `msg:"attributes,omitempty"`
 
 	// a list of spans in this chunk
-	spans []Span
+	spans spanListV1 `msg:"spans,omitempty"`
 
 	// whether the trace only contains analyzed spans
 	// (not required by tracers and set by the agent)
-	droppedTrace bool
+	droppedTrace bool `msg:"droppedTrace"`
 
 	// the ID of the trace to which all spans in this chunk belong
-	traceID uint8
+	traceID []byte `msg:"traceID"`
 
 	// the optional string decision maker (previously span tag _dd.p.dm)
-	decisionMaker uint32
+	decisionMaker uint32 `msg:"decisionMaker,omitempty"`
 }

--- a/ddtrace/tracer/payload_v1.go
+++ b/ddtrace/tracer/payload_v1.go
@@ -5,6 +5,8 @@
 
 package tracer
 
+import "github.com/tinylib/msgp/msgp"
+
 // payloadV1 is a new version of a msgp payload that can be sent to the agent.
 // Be aware that payloadV1 follows the same rules and constraints as payloadV04. That is:
 //
@@ -20,37 +22,44 @@ package tracer
 // Close the request body before attempting to re-use it again!
 type payloadV1 struct {
 	// array of strings referenced in this tracer payload, its chunks and spans
-	strings []string
+	strings []string `msgp:"strings"`
 
 	// the string ID of the container where the tracer is running
-	containerID uint32
+	containerID uint32 `msgp:"containerID"`
 
 	// the string language name of the tracer
-	languageName uint32
+	languageName uint32 `msgp:"languageName"`
 
 	// the string language version of the tracer
-	languageVersion uint32
+	languageVersion uint32 `msgp:"languageVersion"`
 
 	// the string version of the tracer
-	tracerVersion uint32
+	tracerVersion uint32 `msgp:"tracerVersion"`
 
 	// the V4 string UUID representation of a tracer session
-	runtimeID uint32
+	runtimeID uint32 `msgp:"runtimeID"`
 
 	// the optional `env` string tag that set with the tracer
-	env uint32
+	env uint32 `msgp:"env,omitempty"`
 
 	// the optional string hostname of where the tracer is running
-	hostname uint32
+	hostname uint32 `msgp:"hostname,omitempty"`
 
 	// the optional string `version` tag for the application set in the tracer
-	appVersion uint32
+	appVersion uint32 `msgp:"appVersion,omitempty"`
 
 	// a collection of key to value pairs common in all `chunks`
-	attributes map[uint32]anyValue
+	attributes map[uint32]anyValue `msgp:"attributes,omitempty"`
 
 	// a list of trace `chunks`
-	chunks []traceChunk
+	chunks []traceChunk `msgp:"chunks,omitempty"`
+}
+
+// push pushes a new item into the stream.
+func (p *payloadV1) push(t []*Span) error {
+	// We need to hydrate the payload with everything we get from the spans.
+	// Conceptually, our `t []*Span` corresponds to one `traceChunk`.
+	return nil
 }
 
 // AnyValue is a representation of the `any` value. It can take the following types:
@@ -66,6 +75,13 @@ type anyValue struct {
 	valueType int
 	value     interface{}
 }
+
+// EncodeMsg implements msgp.Encodable.
+func (a *anyValue) EncodeMsg(*msgp.Writer) error {
+	panic("unimplemented")
+}
+
+var _ msgp.Encodable = (*anyValue)(nil)
 
 const (
 	StringValueType  = iota + 1 // string or uint


### PR DESCRIPTION
### What does this PR do?

- Added msgp struct tags to fields in payloadV1 and traceChunk for serialization.
- Introduced EncodeMsg methods for anyValue and spanListV1 to support custom msgp encoding.
- Updated field types in traceChunk to enhance compatibility with msgp serialization.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
