### PR TITLE
feat(ci): update check-slo-breaches to use a template

### DIFF
--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -199,6 +199,7 @@ go-stable-profile-trace-asm:
     DD_PROFILING_EXECUTION_TRACE_ENABLED: "false"
 
 check-slo-breaches:
+  extends: .check-slo-breaches
   stage: gates
   needs: [
     "go-oldstable-baseline",
@@ -217,19 +218,10 @@ check-slo-breaches:
     "go-stable-profile-trace-asm",
   ]
   when: on_success
-  tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:latest
-  id_tokens:
-    DDOCTOSTS_ID_TOKEN:
-      aud: dd-octo-sts
-  before_script:
-    - dd-octo-sts token --scope DataDog/dd-trace-go --policy gitlab.github-access.slo-change-tracking.contents-read > check-slo-breaches.github-token
-  script:
-    - export ARTIFACTS_DIR="$(pwd)/platform/artifacts"
-    - export GITHUB_TOKEN=$(cat check-slo-breaches.github-token)
-    - bp-runner .gitlab/bp-runner.fail-on-breach.yml
-  after_script:
-    - dd-octo-sts revoke -t $(cat check-slo-breaches.github-token)
+  variables:
+    DDOCTOSTS_POLICY: "gitlab.github-access.slo-change-tracking.contents-read"
+    ARTIFACTS_DIR: "platform/artifacts"
+    SLO_FILE: ".gitlab/bp-runner.fail-on-breach.yml"
   artifacts:
     name: "artifacts"
     when: always
@@ -238,8 +230,10 @@ check-slo-breaches:
     expire_in: 3 months
 
 include:
-  project: 'DataDog/benchmarking-platform-tools'
-  file: 'images/templates/gitlab/notify-slo-breaches.template.yml'
+  - project: 'DataDog/benchmarking-platform-tools'
+    file: 'images/templates/gitlab/check-slo-breaches.template.yml'
+  - project: 'DataDog/benchmarking-platform-tools'
+    file: 'images/templates/gitlab/notify-slo-breaches.template.yml'
 
 notify-slo-breaches:
   extends: .notify-slo-breaches


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

- Simplify `check-slo-breaches` by using a template: https://github.com/DataDog/benchmarking-platform-tools/blob/main/images/templates/gitlab/check-slo-breaches.template.yml.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

https://datadoghq.atlassian.net/browse/APMSP-2198

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Testing

Here's a successful `check-slo-breaches` run: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-go/-/jobs/1110708892

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
