### PR TITLE
feat(internal/appsec): activation metric and config key

### DIFF
--- a/internal/appsec/appsec.go
+++ b/internal/appsec/appsec.go
@@ -55,9 +55,11 @@ func Start(opts ...config.StartOption) {
 	// and enforces to have AppSec disabled.
 	mode, modeOrigin, err := startConfig.EnablementMode()
 	if err != nil {
-		logUnexpectedStartError(err)
-		return
+		// Even when DD_APPSEC_ENABLED is an empty string or unset, an error can be returned here
+		log.Debug("appsec: could not determine the AppSec enablement mode from DD_APPSEC_ENABLED: %s", err.Error())
 	}
+
+	defer registerAppsecStartTelemetry(mode, modeOrigin)
 
 	if mode == config.ForcedOff {
 		log.Debug("appsec: disabled by the configuration: set the environment variable DD_APPSEC_ENABLED to true to enable it")
@@ -111,7 +113,6 @@ func Start(opts ...config.StartOption) {
 		return
 	}
 
-	registerAppsecStartTelemetry(mode, modeOrigin)
 	setActiveAppSec(appsec)
 }
 

--- a/internal/appsec/appsec_test.go
+++ b/internal/appsec/appsec_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/instrumentation/testutils"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/config"
+	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
+	"github.com/DataDog/dd-trace-go/v2/internal/telemetry/telemetrytest"
 	"github.com/DataDog/go-libddwaf/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,4 +40,54 @@ func TestStartStop(t *testing.T) {
 	os.Unsetenv(config.EnvEnabled)
 	testutils.StartAppSec(t)
 	appsec.Stop()
+}
+
+func TestAppsecEnabledTelemetry(t *testing.T) {
+	var telemetryClient telemetrytest.RecordClient
+	defer telemetry.MockClient(&telemetryClient)()
+
+	t.Run("default", func(t *testing.T) {
+		t.Setenv(config.EnvEnabled, "")
+
+		appsec.Start()
+		defer appsec.Stop()
+
+		assert.Contains(t, telemetryClient.Configuration, telemetry.Configuration{Name: config.EnvEnabled, Value: false, Origin: telemetry.OriginDefault})
+	})
+
+	t.Run("env_enabled", func(t *testing.T) {
+		t.Setenv(config.EnvEnabled, "true")
+
+		appsec.Start()
+		defer appsec.Stop()
+
+		assert.Contains(t, telemetryClient.Configuration, telemetry.Configuration{Name: config.EnvEnabled, Value: true, Origin: telemetry.OriginEnvVar})
+	})
+
+	t.Run("env_disable", func(t *testing.T) {
+		t.Setenv(config.EnvEnabled, "false")
+
+		appsec.Start()
+		defer appsec.Stop()
+
+		assert.Contains(t, telemetryClient.Configuration, telemetry.Configuration{Name: config.EnvEnabled, Value: false, Origin: telemetry.OriginEnvVar})
+	})
+
+	t.Run("code_enabled", func(t *testing.T) {
+		t.Setenv(config.EnvEnabled, "")
+
+		appsec.Start(config.WithEnablementMode(config.ForcedOn))
+		defer appsec.Stop()
+
+		assert.Contains(t, telemetryClient.Configuration, telemetry.Configuration{Name: config.EnvEnabled, Value: true, Origin: telemetry.OriginCode})
+	})
+
+	t.Run("code_enabled", func(t *testing.T) {
+		t.Setenv(config.EnvEnabled, "")
+
+		appsec.Start(config.WithEnablementMode(config.ForcedOff))
+		defer appsec.Stop()
+
+		assert.Contains(t, telemetryClient.Configuration, telemetry.Configuration{Name: config.EnvEnabled, Value: false, Origin: telemetry.OriginCode})
+	})
 }

--- a/internal/appsec/remoteconfig.go
+++ b/internal/appsec/remoteconfig.go
@@ -250,12 +250,14 @@ func (a *appsec) handleASMFeatures(u remoteconfig.ProductUpdate) map[string]stat
 			log.Error("appsec: remote config: error while processing %q. Configuration won't be applied: %s", path, err.Error())
 			return map[string]state.ApplyStatus{path: {State: state.ApplyStateError, Error: err.Error()}}
 		}
+		registerAppsecStartTelemetry(config.ForcedOn, telemetry.OriginRemoteConfig)
 	}
 
 	// RC triggers desactivation of ASM; ASM is started... Stopping it!
 	if !parsed.ASM.Enabled && a.started {
 		log.Debug("appsec: remote config: Stopping AppSec")
 		a.stop()
+		registerAppsecStartTelemetry(config.ForcedOff, telemetry.OriginRemoteConfig)
 		return map[string]state.ApplyStatus{path: {State: state.ApplyStateAcknowledged}}
 	}
 

--- a/internal/appsec/telemetry.go
+++ b/internal/appsec/telemetry.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"runtime"
 	"sync"
+	"sync/atomic"
 
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
@@ -33,15 +34,33 @@ var (
 		{Name: "waf_supports_target", Value: wafSupported, Origin: telemetry.OriginCode},
 		{Name: "waf_healthy", Value: wafUsable, Origin: telemetry.OriginCode},
 	}
+	appsecEnabledOrigin atomic.Pointer[telemetry.Origin]
 )
 
 // init sends the static telemetry for AppSec.
 func init() {
 	telemetry.RegisterAppConfigs(staticConfigs...)
+	telemetry.AddFlushTicker(func(client telemetry.Client) {
+		var val float64
+		if Enabled() {
+			val = 1.0
+		}
+
+		origin := telemetry.OriginDefault
+		if o := appsecEnabledOrigin.Load(); o != nil {
+			origin = *o
+		}
+
+		client.Gauge(telemetry.NamespaceAppSec, "enabled", []string{"origin:" + string(origin)}).Submit(val)
+	})
 }
 
 func registerAppsecStartTelemetry(mode config.EnablementMode, origin telemetry.Origin) {
-	if mode == config.RCStandby {
+	telemetry.RegisterAppConfig(config.EnvEnabled, Enabled(), origin)
+	appsecEnabledOrigin.Store(&origin)
+	detectLibDLOnce.Do(detectLibDL)
+
+	if !Enabled() {
 		return
 	}
 
@@ -50,9 +69,6 @@ func registerAppsecStartTelemetry(mode config.EnablementMode, origin telemetry.O
 	}
 
 	telemetry.ProductStarted(telemetry.NamespaceAppSec)
-	// TODO: add appsec.enabled metric once this metric is enabled backend-side
-
-	detectLibDLOnce.Do(detectLibDL)
 }
 
 func detectLibDL() {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds the `DD_APPSEC_ENABLED` configuration that was supposed to already be there but was removed by stableconfig APM work. It also adds the `appsec.enabled` telemetyr metric to also report the value of appsec being enabled or not. This PR ALSO fixes a bug that stableconfig introduced by returning an error even when the env var is not set which made us branch out of appsec.Start too early. And since telemetry logs are dropped backend side we could not have find out earlier.

### Motivation

Better data even appsec enablement and how it was enabled.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
