### PR TITLE
ci: update import url for one-pipeline scripts

### DIFF
--- a/.gitlab/configuration-central-validation.yml
+++ b/.gitlab/configuration-central-validation.yml
@@ -2,7 +2,7 @@
 # This URL is available in the dd-gitlab/publish-content-addresable-templates job whenever
 # a change is made on the one-pipeline template.
 variables:
-  SCRIPTS_BASE_URL: https://gitlab-templates.ddbuild.io/libdatadog/one-pipeline/ca/50d49f6898ce86e93326856210e8ab6526895273cb6341ac2d7d0e6c1c14e31e/scripts
+  SCRIPTS_BASE_URL: https://gitlab-templates.ddbuild.io/libdatadog/one-pipeline/ca/bc1184decb7b0dedcce721eb08819b3bd8a36c0473e832b3ec1b804c8f1b5807/scripts
 
 .download-scripts-from-template: &download-scripts-from-template
   - mkdir -p scripts


### PR DESCRIPTION
### What does this PR do?

We found a bug in the libdatadog CI scripts related to config centralization. The CI job ran upon tagging a release with the current import URL has an hardcoded language value to `nodejs`. 

I fixed it on the script and we need to import the new ones to have it correctly tagged.

⚠️  This will need to be cherry-picked into the ongoing release to avoid tagging golang keys are nodejs (with our tags, this would create a mess)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
