### PR TITLE
fix(ddtrace/tracer): TestSpansStartedTags

### DIFF
--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -104,7 +104,9 @@ func TestSpansStartedTags(t *testing.T) {
 		defer stop()
 
 		tracer.StartSpan("operation").Finish()
-		tg.Wait(assert, 1, 100*time.Millisecond)
+		assert.Eventually(func() bool {
+			return tg.Counts()["datadog.tracer.spans_started"] == 1
+		}, 1*time.Second, 10*time.Millisecond)
 		assertSpanMetricCountsAreZero(t, tracer.spansStarted)
 
 		counts := tg.Counts()
@@ -124,7 +126,9 @@ func TestSpansStartedTags(t *testing.T) {
 		sp := tracer.StartSpan("operation", Tag(ext.Component, "contrib"))
 		defer sp.Finish()
 
-		tg.Wait(assert, 1, 100*time.Millisecond)
+		assert.Eventually(func() bool {
+			return tg.Counts()["datadog.tracer.spans_started"] == 1
+		}, 1*time.Second, 10*time.Millisecond)
 		assertSpanMetricCountsAreZero(t, tracer.spansStarted)
 
 		counts := tg.Counts()


### PR DESCRIPTION
<!-- dd-meta {"pullId":"475f81a8-71b6-464b-8798-a6512321592f","source":"chat","resourceId":"f199aa20-40f5-4f60-abb5-5edb355812e8","workflowId":"1679768a-6aaf-458c-b7a6-c4203b4ec13d","codeChangeId":"1679768a-6aaf-458c-b7a6-c4203b4ec13d","sourceType":"test-optimization"} -->
PR by [Bits](https://app.datadoghq.com/code?session_id=475f81a8-71b6-464b-8798-a6512321592f) : [Fix test TestSpansStartedTags](https://app.datadoghq.com/code/f199aa20-40f5-4f60-abb5-5edb355812e8) automatically detected by [Flaky Test monitoring](https://app.datadoghq.com/ci/test/flaky?query=%40git.repository.id_v2%3A%22github.com%2Fdatadog%2Fdd-trace-go%22+%40test.name%3A%22TestSpansStartedTags%22).

You can ask for changes by mentioning @Datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Replaces the fixed-time wait in TestSpansStartedTags with assert.Eventually to wait for the spans_started metric to reach 1. This change is applied in two places in ddtrace/tracer/metrics_test.go.

### Motivation

The test was flaky because the metric increment for datadog.tracer.spans_started happens asynchronously. The previous fixed 100ms wait was sometimes insufficient in CI, leading to intermittent failures where the count was still 0 when asserted. Using assert.Eventually (1s timeout, 10ms poll) removes the timing race and stabilizes the test.

- Impact: Flaked on 4 branches
- Last flaked branch: rachel.yang/knuth-sample-tag
- Category: Unit test (ddtrace/tracer/metrics_test.go)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!