### PR TITLE
fix(ddtrace/tracer): don't fail on error when starting statsd client

### DIFF
--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -344,7 +344,8 @@ func newUnstartedTracer(opts ...StartOption) (t *tracer, err error) {
 	statsd, err := newStatsdClient(c)
 	if err != nil {
 		log.Error("Runtime and health metrics disabled: %s", err.Error())
-		return nil, fmt.Errorf("could not initialize statsd client: %s", err.Error())
+		// We are not failing here because the error could be cause by
+		// a transitory issue.
 	}
 	defer func() {
 		if err != nil {

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -2918,3 +2918,9 @@ func TestTracerStartMultipleTimesGlobalService(t *testing.T) {
 
 	assert.Equal(t, "global_service", globalconfig.ServiceName())
 }
+
+func TestNewUnstartedTracerDDAgentHostNotFound(t *testing.T) {
+	t.Setenv("DD_AGENT_HOST", "ddapm-test-agent-c07208")
+	_, err := newUnstartedTracer()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
### What does this PR do?

Reverts the behaviour of the statsd client initialization when creating the tracer to [the old behaviour in v1](https://github.com/DataDog/dd-trace-go/blob/release-v1.73.x/ddtrace/tracer/tracer.go#L301):

```go
statsd, err := newStatsdClient(c)
if err != nil {
	log.Warn("Runtime and health metrics disabled: %v", err)
}
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
