### PR TITLE
Dario.castane/fix contrib listing

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -24,6 +24,8 @@ First, find the library which you'd like to integrate with. The naming conventio
 
 Important: the package itself should retain its un-versioned name. For example, the integration under `user/repo.v2` stays as `package repo`, and does not become `package repo.v2`.
 
+All of these packages must be imported using an import URL following the schema `github.com/DataDog/dd-trace-go/contrib/<package path>/v2`.
+
 Second, there are a few tags that should be found in all integration spans:
 
 * The `span.kind` tag should be set in root spans with either a `client`, `server`, `producer`, or `consumer` value according to the [definitions](../ddtrace/ext/span_kind.go) found in the repository.

--- a/go.mod
+++ b/go.mod
@@ -104,4 +104,5 @@ require (
 retract (
 	[v2.0.0-rc.1, v2.0.0-rc.22]
 	[v2.0.0-beta.1, v2.0.0-beta.11]
+	v0.0.0-20240516153256-8d6fa2bea61d
 )


### PR DESCRIPTION
### What does this PR do?

Retracts `v0.0.0-20240516153256-8d6fa2bea61d` and adds a warning about how to import v2 contribs.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
