### PR TITLE
fix(profiler): switch back to pre-zstd compression

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -188,7 +188,7 @@ func defaultConfig() (*config, error) {
 		deltaProfiles:        internal.BoolEnv("DD_PROFILING_DELTA", true),
 		logStartup:           internal.BoolEnv("DD_TRACE_STARTUP_LOGS", true),
 		endpointCountEnabled: internal.BoolEnv(traceprof.EndpointCountEnvVar, false),
-		compressionConfig:    cmp.Or(env.Get("DD_PROFILING_DEBUG_COMPRESSION_SETTINGS"), "zstd"),
+		compressionConfig:    cmp.Or(env.Get("DD_PROFILING_DEBUG_COMPRESSION_SETTINGS"), "legacy"),
 		traceConfig: executionTraceConfig{
 			Enabled: internal.BoolEnv("DD_PROFILING_EXECUTION_TRACE_ENABLED", executionTraceEnabledDefault),
 			Period:  internal.DurationEnv("DD_PROFILING_EXECUTION_TRACE_PERIOD", 15*time.Minute),


### PR DESCRIPTION
After switching our default compression to zstd, we've found that the
profiler's memory usage is too high for some internal services. The
memory usage primarily comes from the compression library's history
buffer, which defaults to 8MiB (see the [`zstd.WithWindowSize`](https://pkg.go.dev/github.com/klauspost/compress/zstd#WithWindowSize) option.) We
have one compressor per profile type. For now we'll switch back to the
"legacy" compression scheme by default. Users can opt back in to zstd by
setting `DD_PROFILING_DEBUG_COMPRESSION_SETTINGS=zstd`.
