### PR TITLE
fix(instrumentation): restore deleted net/http/pattern package

### DIFF
--- a/instrumentation/net/http/pattern/pattern.go
+++ b/instrumentation/net/http/pattern/pattern.go
@@ -1,0 +1,177 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+// Deprecated: this package was not meant to be exported. It now exists only for
+// compatibility with older contrib module versions and won't be actively
+// maintained.
+package pattern
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"unicode"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/telemetry/log"
+
+	"github.com/puzpuzpuz/xsync/v3"
+)
+
+// Route returns the route part of a go1.22 style ServeMux pattern. I.e.
+// it returns "/foo" for the pattern "/foo" as well as the pattern "GET /foo".
+func Route(s string) string {
+	// Support go1.22 serve mux patterns: [METHOD ][HOST]/[PATH]
+	// Consider any text before a space or tab to be the method of the pattern.
+	// See net/http.parsePattern and the link below for more information.
+	// https://pkg.go.dev/net/http#hdr-Patterns-ServeMux
+	if i := strings.IndexAny(s, " \t"); i > 0 && len(s) >= i+1 {
+		return strings.TrimLeft(s[i+1:], " \t")
+	}
+	return s
+}
+
+// PathParameters return the path parameter values and names from the request.
+func PathParameters(pattern string, request *http.Request) map[string]string {
+	if pattern == "" {
+		return nil
+	}
+	names := patternNames(pattern)
+	res := make(map[string]string, len(names))
+	for _, name := range names {
+		res[name] = request.PathValue(name)
+	}
+	return res
+}
+
+var patternSegmentsCache = xsync.NewMapOf[string, []string]()
+
+func patternNames(pattern string) []string {
+	v, _ := patternSegmentsCache.LoadOrCompute(pattern, func() []string {
+		segments, err := parsePatternNames(pattern)
+		if err != nil {
+			// Ignore the error: Something as gone wrong, but we are not eager to find out why.
+			// We will just log it as a telemetry logs warning (and Debug to the user-facing log).
+			log.Warn("instrumentation/net/http/pattern: failed to parse mux path pattern", slog.Any("error", log.NewSafeError(err)))
+			// here we fallthrough instead of returning to load a nil value into the cache to avoid reparsing the pattern.
+		}
+		return segments
+	})
+	return v
+}
+
+// parsePatternNames returns the names of the wildcards in the pattern.
+// Based on https://cs.opensource.google/go/go/+/refs/tags/go1.23.4:src/net/http/pattern.go;l=84
+// but very simplified as we know that the pattern returned must be valid or `net/http` would have panicked earlier.
+//
+// The pattern string's syntax is
+//
+//	[METHOD] [HOST]/[PATH]
+//
+// where:
+//   - METHOD is an HTTP method
+//   - HOST is a hostname
+//   - PATH consists of slash-separated segments, where each segment is either
+//     a literal or a wildcard of the form "{name}", "{name...}", or "{$}".
+//
+// METHOD, HOST and PATH are all optional; that is, the string can be "/".
+// If METHOD is present, it must be followed by at least one space or tab.
+// Wildcard names must be valid Go identifiers.
+// The "{$}" and "{name...}" wildcard must occur at the end of PATH.
+// PATH may end with a '/'.
+// Wildcard names in a path must be distinct.
+//
+// Some examples could be:
+//   - "/foo/{bar}" returns ["bar"]
+//   - "/foo/{bar}/{baz}" returns ["bar", "baz"]
+//   - "/foo" returns []
+func parsePatternNames(pattern string) ([]string, error) {
+	if len(pattern) == 0 {
+		return nil, errors.New("empty pattern")
+	}
+	method, rest, found := pattern, "", false
+	if i := strings.IndexAny(pattern, " \t"); i >= 0 {
+		method, rest, found = pattern[:i], strings.TrimLeft(pattern[i+1:], " \t"), true
+	}
+	if !found {
+		rest = method
+		method = ""
+	}
+
+	i := strings.IndexByte(rest, '/')
+	if i < 0 {
+		return nil, errors.New("host/path missing /")
+	}
+	host := rest[:i]
+	rest = rest[i:]
+	if j := strings.IndexByte(host, '{'); j >= 0 {
+		return nil, errors.New("host contains '{' (missing initial '/'?)")
+	}
+
+	// At this point, rest is the path.
+	var names []string
+	seenNames := make(map[string]bool)
+	for len(rest) > 0 {
+		// Invariant: rest[0] == '/'.
+		rest = rest[1:]
+		if len(rest) == 0 {
+			// Trailing slash.
+			break
+		}
+		i := strings.IndexByte(rest, '/')
+		if i < 0 {
+			i = len(rest)
+		}
+		var seg string
+		seg, rest = rest[:i], rest[i:]
+		if i := strings.IndexByte(seg, '{'); i >= 0 {
+			// Wildcard.
+			if i != 0 {
+				return nil, errors.New("bad wildcard segment (must start with '{')")
+			}
+			if seg[len(seg)-1] != '}' {
+				return nil, errors.New("bad wildcard segment (must end with '}')")
+			}
+			name := seg[1 : len(seg)-1]
+			if name == "$" {
+				if len(rest) != 0 {
+					return nil, errors.New("{$} not at end")
+				}
+				break
+			}
+			name, multi := strings.CutSuffix(name, "...")
+			if multi && len(rest) != 0 {
+				return nil, errors.New("{...} wildcard not at end")
+			}
+			if name == "" {
+				return nil, errors.New("empty wildcard name")
+			}
+			if !isValidWildcardName(name) {
+				return nil, fmt.Errorf("bad wildcard name %q", name)
+			}
+			if seenNames[name] {
+				return nil, fmt.Errorf("duplicate wildcard name %q", name)
+			}
+			seenNames[name] = true
+			names = append(names, name)
+		}
+	}
+
+	return names, nil
+}
+
+func isValidWildcardName(s string) bool {
+	if s == "" {
+		return false
+	}
+	// Valid Go identifier.
+	for i, c := range s {
+		if !unicode.IsLetter(c) && c != '_' && (i == 0 || !unicode.IsDigit(c)) {
+			return false
+		}
+	}
+	return true
+}

--- a/instrumentation/net/http/pattern/pattern_test.go
+++ b/instrumentation/net/http/pattern/pattern_test.go
@@ -1,0 +1,169 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+package pattern
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathParameters(t *testing.T) {
+	t.Run("blank", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/foo/123", nil)
+		assert.Equal(t, "", req.Pattern)
+		require.Nil(t, PathParameters(req.Pattern, req))
+	})
+
+	for _, tt := range []struct {
+		name     string
+		pattern  string
+		url      string
+		expected map[string]string
+	}{
+		{
+			name:     "simple",
+			pattern:  "/foo/{bar}",
+			url:      "/foo/123",
+			expected: map[string]string{"bar": "123"},
+		},
+		{
+			name:     "multiple",
+			pattern:  "/foo/{bar}/{baz}",
+			url:      "/foo/123/456",
+			expected: map[string]string{"bar": "123", "baz": "456"},
+		},
+		{
+			name:     "nested",
+			pattern:  "/foo/{bar}/baz/{qux}",
+			url:      "/foo/123/baz/456",
+			expected: map[string]string{"bar": "123", "qux": "456"},
+		},
+		{
+			name:     "empty",
+			pattern:  "/foo/{bar}",
+			url:      "/foo/",
+			expected: map[string]string{"bar": ""},
+		},
+		{
+			name:     "http method",
+			pattern:  "GET /foo/{bar}",
+			url:      "/foo/123",
+			expected: map[string]string{"bar": "123"},
+		},
+		{
+			name:     "host",
+			pattern:  "example.com/foo/{bar}",
+			url:      "http://example.com/foo/123",
+			expected: map[string]string{"bar": "123"},
+		},
+		{
+			name:     "host and method",
+			pattern:  "GET example.com/foo/{bar}",
+			url:      "http://example.com/foo/123",
+			expected: map[string]string{"bar": "123"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc(tt.pattern, func(_ http.ResponseWriter, r *http.Request) {
+				_, pattern := mux.Handler(r)
+				params := PathParameters(pattern, r)
+				assert.Equal(t, tt.expected, params)
+			})
+
+			r := httptest.NewRequest("GET", tt.url, nil)
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, r)
+		})
+	}
+}
+
+func TestParsePatternNames(t *testing.T) {
+	tests := []struct {
+		pattern  string
+		expected []string
+		err      bool
+	}{
+		{"/foo/{bar}", []string{"bar"}, false},
+		{"/foo/{bar}/{baz}", []string{"bar", "baz"}, false},
+		{"/foo/{bar}/{bar}", nil, true},
+		{"/foo/{bar}...", nil, true},
+		{"/foo/{bar}.../baz", nil, true},
+		{"/foo/{bar}/{baz}...", nil, true},
+		{"/foo/{bar", nil, true},
+		{"/foo/{bar{baz}}", nil, true},
+		{"/foo/{}", nil, true},
+		{"{}", nil, true},
+		{"GET /foo/{bar}", []string{"bar"}, false},
+		{"POST /foo/{bar}/{baz}", []string{"bar", "baz"}, false},
+		{"PUT /foo/{bar}/{bar}", nil, true},
+		{"DELETE /foo/{bar}...", nil, true},
+		{"PATCH /foo/{bar}.../baz", nil, true},
+		{"OPTIONS /foo/{bar}/{baz}...", nil, true},
+		{"GET /foo/{bar", nil, true},
+		{"POST /foo/{bar{baz}}", nil, true},
+		{"DELETE /foo/{}", nil, true},
+		{"OPTIONS {}", nil, true},
+		{"GET example.com/foo/{bar}", []string{"bar"}, false},
+		{"POST example.com/foo/{bar}/{baz}", []string{"bar", "baz"}, false},
+		{"PUT example.com/foo/{bar}/{bar}", nil, true},
+		{"DELETE example.com/foo/{bar}...", nil, true},
+		{"PATCH example.com/foo/{bar}.../baz", nil, true},
+		{"OPTIONS example.com/foo/{bar}/{baz}...", nil, true},
+		{"GET example.com/foo/{bar", nil, true},
+		{"POST example.com/foo/{bar{baz}}", nil, true},
+		{"DELETE example.com/foo/{}", nil, true},
+		{"OPTIONS example.com/{}", nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern, func(t *testing.T) {
+			names, err := parsePatternNames(tt.pattern)
+			if tt.err {
+				assert.Error(t, err)
+				assert.Nil(t, names)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, names)
+			}
+		})
+	}
+}
+
+func TestServeMuxGo122Patterns(t *testing.T) {
+	// A mux with go1.21 patterns ("/bar") and go1.22 patterns ("GET /foo")
+	mux := http.NewServeMux()
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		route := Route(r.Pattern)
+		w.Write([]byte(route))
+	}
+	mux.HandleFunc("/bar/{id}", handler)
+	mux.HandleFunc("GET /foo/{id}/baz", handler)
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Check for the /bar route
+	res, err := srv.Client().Get(srv.URL + "/bar/1337")
+	require.NoError(t, err)
+	body, err := io.ReadAll(res.Body)
+	res.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, "/bar/{id}", string(body))
+
+	// Check for the /foo route
+	res, err = srv.Client().Get(srv.URL + "/foo/42/baz")
+	require.NoError(t, err)
+	body, err = io.ReadAll(res.Body)
+	res.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, "/foo/{id}/baz", string(body))
+}


### PR DESCRIPTION
The `instrumentation/net/http/pattern` package was moved by #3853. The
`contrib/net/http/v2` module depends on that package at version v2.2.3. As a
result, that verison of `contrib/net/http/v2` won't be able to use newer
versions of the main module. This is a breaking change. This PR restores the
deleted package. While the current `contrib/net/http/v2` package doesn't use it
any more, this maintains compatibility with previous versions.
