### PR TITLE
Fix flaky TestMultipleSpanIntegrationTags in dd-trace-go

### DIFF
--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -209,7 +209,10 @@ func TestMultipleSpanIntegrationTags(t *testing.T) {
 		tracer.StartSpan("operation", Tag(ext.Component, "contrib")).Finish()
 	}
 	flush(10)
-	tg.Wait(assert, 10, 100*time.Millisecond)
+	assert.Eventually(func() bool {
+		counts := tg.Counts()
+		return counts["datadog.tracer.spans_started"] == 10 && counts["datadog.tracer.spans_finished"] == 10
+	}, 1*time.Second, 10*time.Millisecond)
 
 	counts := tg.Counts()
 	assert.Equal(int64(10), counts["datadog.tracer.spans_started"])


### PR DESCRIPTION
<!-- dd-meta {"pullId":"6409c07c-6cd9-45c7-8038-e033ec6be8a6","source":"chat","resourceId":"a4236c47-9a21-425c-bebf-e7a175c44518","workflowId":"ac8218d5-a254-4852-92d2-0174550e9f1d","codeChangeId":"ac8218d5-a254-4852-92d2-0174550e9f1d","sourceType":"chat"} -->
PR by [Bits](https://app.datadoghq.com/code?session_id=6409c07c-6cd9-45c7-8038-e033ec6be8a6) for [Dev Agent Session](https://app.datadoghq.com/code/a4236c47-9a21-425c-bebf-e7a175c44518).

You can ask for changes by mentioning @Datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

- Deflakes TestMultipleSpanIntegrationTags by replacing a timing-sensitive tg.Wait call with assert.Eventually that waits for both spans_started and spans_finished to reach 10 within 1s (polling every 10ms).
- Keeps the final equality assertions unchanged once the expected counts are observed.

### Motivation

- CI showed intermittent failures where counts were off by one (expected 10, actual 9 and expected 5, actual 4), indicating the test asserted before the asynchronous metrics aggregation had fully caught up.
- The tracer’s metrics emission is asynchronous; flush alone wasn’t sufficient to guarantee the counts had been recorded when tg.Wait returned.
- Using assert.Eventually ensures the test only proceeds once both counters reach their expected values, eliminating the race and stabilizing the test.
- Related failure: https://app.datadoghq.com/ci/test/AwAAAZmlrr_OlXRWBAAAABhBWm1scnJfT0FBQnBudTZZMmJpODRyWmYAAAAkZjE5OWE1YWYtMTk1Zi00MDE1LTg0OWItODRmNDE3MWNmM2RiAAcvXA

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!