### PR TITLE
feat(llmobs): refactor public API to use concrete types

### DIFF
--- a/ddtrace/tracer/context.go
+++ b/ddtrace/tracer/context.go
@@ -31,10 +31,10 @@ func contextWithPropagatedLLMSpan(ctx context.Context, s *Span) context.Context 
 	newCtx := ctx
 
 	propagatedLLMObs := propagatedLLMSpanFromTags(s)
-	if propagatedLLMObs.SpanID != "" && propagatedLLMObs.TraceID != "" {
-		newCtx = illmobs.ContextWithPropagatedLLMSpan(newCtx, propagatedLLMObs)
+	if propagatedLLMObs.SpanID == "" || propagatedLLMObs.TraceID == "" {
+		return newCtx
 	}
-	return newCtx
+	return illmobs.ContextWithPropagatedLLMSpan(newCtx, propagatedLLMObs)
 }
 
 func propagatedLLMSpanFromTags(s *Span) *illmobs.PropagatedLLMSpan {

--- a/internal/llmobs/span.go
+++ b/internal/llmobs/span.go
@@ -360,16 +360,12 @@ func (s *Span) annotateIO(a SpanAnnotations) {
 	switch s.spanKind {
 	case SpanKindLLM:
 		s.annotateIOLLM(a)
-
 	case SpanKindEmbedding:
 		s.annotateIOEmbedding(a)
-
 	case SpanKindRetrieval:
 		s.annotateIORetrieval(a)
-
 	case SpanKindExperiment:
 		s.annotateIOExperiment(a)
-
 	default:
 		s.annotateIOText(a)
 	}

--- a/llmobs/eval_metrics.go
+++ b/llmobs/eval_metrics.go
@@ -20,11 +20,16 @@ type EvaluationValue interface {
 
 // SubmitEvaluationFromSpan submits an evaluation metric for the given span.
 // The metric will be associated with the span using its span ID and trace ID.
-func SubmitEvaluationFromSpan[T EvaluationValue](label string, value T, span BaseSpan, opts ...EvaluationOption) {
+func SubmitEvaluationFromSpan[T EvaluationValue](label string, value T, span Span, opts ...EvaluationOption) {
+	var spanID, traceID string
+	if span != nil {
+		spanID = span.SpanID()
+		traceID = span.TraceID()
+	}
 	cfg := illmobs.EvaluationConfig{
 		Label:   label,
-		SpanID:  span.SpanID(),
-		TraceID: span.TraceID(),
+		SpanID:  spanID,
+		TraceID: traceID,
 	}
 	for _, opt := range opts {
 		opt(&cfg)

--- a/llmobs/llmobs.go
+++ b/llmobs/llmobs.go
@@ -20,9 +20,9 @@ import (
 // SpanFromContext retrieves the active LLMObs span from the given context.
 // Returns the span and true if found, nil and false otherwise.
 // The returned span can be converted to specific span types using AsLLM(), AsWorkflow(), etc.
-func SpanFromContext(ctx context.Context) (*LLMSpan, bool) {
+func SpanFromContext(ctx context.Context) (Span, bool) {
 	if span, ok := illmobs.ActiveLLMSpanFromContext(ctx); ok {
-		return &LLMSpan{&baseSpan{span}}, true
+		return &baseSpan{span}, true
 	}
 	return nil, false
 }
@@ -150,6 +150,8 @@ type (
 type Span interface {
 	sealed() // Prevents external implementations
 
+	spanConverter
+
 	// SpanID returns the unique identifier for this span.
 	SpanID() string
 
@@ -167,6 +169,31 @@ type Span interface {
 
 	// Finish completes the span and sends it for processing.
 	Finish(opts ...FinishSpanOption)
+}
+
+// spanConverter provides type conversion methods for generic spans.
+// Allows safe conversion from generic Span to specific span types.
+type spanConverter interface {
+	// AsLLM attempts to convert to an LLMSpan. Returns the span and true if successful.
+	AsLLM() (*LLMSpan, bool)
+
+	// AsWorkflow attempts to convert to a WorkflowSpan. Returns the span and true if successful.
+	AsWorkflow() (*WorkflowSpan, bool)
+
+	// AsAgent attempts to convert to an AgentSpan. Returns the span and true if successful.
+	AsAgent() (*AgentSpan, bool)
+
+	// AsTool attempts to convert to a ToolSpan. Returns the span and true if successful.
+	AsTool() (*ToolSpan, bool)
+
+	// AsTask attempts to convert to a TaskSpan. Returns the span and true if successful.
+	AsTask() (*TaskSpan, bool)
+
+	// AsEmbedding attempts to convert to an EmbeddingSpan. Returns the span and true if successful.
+	AsEmbedding() (*EmbeddingSpan, bool)
+
+	// AsRetrieval attempts to convert to a RetrievalSpan. Returns the span and true if successful.
+	AsRetrieval() (*RetrievalSpan, bool)
 }
 
 // WorkflowSpan represents a span for high-level workflow operations.

--- a/llmobs/llmobs.go
+++ b/llmobs/llmobs.go
@@ -20,9 +20,9 @@ import (
 // SpanFromContext retrieves the active LLMObs span from the given context.
 // Returns the span and true if found, nil and false otherwise.
 // The returned span can be converted to specific span types using AsLLM(), AsWorkflow(), etc.
-func SpanFromContext(ctx context.Context) (Span, bool) {
+func SpanFromContext(ctx context.Context) (*LLMSpan, bool) {
 	if span, ok := illmobs.ActiveLLMSpanFromContext(ctx); ok {
-		return &baseSpan{Span: span}, true
+		return &LLMSpan{&baseSpan{span}}, true
 	}
 	return nil, false
 }
@@ -31,76 +31,92 @@ func SpanFromContext(ctx context.Context) (Span, bool) {
 // Pass the returned context to subsequent start span calls to create child spans of this one.
 //
 // Note: LLM spans are annotated with input/output as LLMMessage.
-func StartLLMSpan(ctx context.Context, name string, opts ...StartSpanOption) (LLMSpan, context.Context) {
+func StartLLMSpan(ctx context.Context, name string, opts ...StartSpanOption) (*LLMSpan, context.Context) {
+	var l LLMSpan
 	s, ctx, ok := startSpan(ctx, illmobs.SpanKindLLM, name, opts...)
 	if !ok {
-		return &noopSpan{}, ctx
+		return &l, ctx
 	}
-	return &llmSpan{s}, ctx
+	l.baseSpan = s
+	return &l, ctx
 }
 
 // StartWorkflowSpan starts an LLMObs span of kind Workflow.
 // Pass the returned context to subsequent start span calls to create child spans of this one.
-func StartWorkflowSpan(ctx context.Context, name string, opts ...StartSpanOption) (WorkflowSpan, context.Context) {
-	s, ctx, ok := startSpan(ctx, illmobs.SpanKindWorkflow, name, opts...)
+func StartWorkflowSpan(ctx context.Context, name string, opts ...StartSpanOption) (*WorkflowSpan, context.Context) {
+	var (
+		w  WorkflowSpan
+		ok bool
+	)
+	w.baseSpan, ctx, ok = startSpan(ctx, illmobs.SpanKindWorkflow, name, opts...)
 	if !ok {
-		return &noopSpan{}, ctx
+		return &w, ctx
 	}
-	return &textIOSpan{s}, ctx
+	return &w, ctx
 }
 
 // StartAgentSpan starts an LLMObs span of kind Agent.
 // Pass the returned context to subsequent start span calls to create child spans of this one.
-func StartAgentSpan(ctx context.Context, name string, opts ...StartSpanOption) (AgentSpan, context.Context) {
+func StartAgentSpan(ctx context.Context, name string, opts ...StartSpanOption) (*AgentSpan, context.Context) {
+	var a AgentSpan
 	s, ctx, ok := startSpan(ctx, illmobs.SpanKindAgent, name, opts...)
 	if !ok {
-		return &noopSpan{}, ctx
+		return &a, ctx
 	}
-	return &textIOSpan{s}, ctx
+	a.baseSpan = s
+	return &a, ctx
 }
 
 // StartToolSpan starts an LLMObs span of kind Tool.
 // Pass the returned context to subsequent start span calls to create child spans of this one.
-func StartToolSpan(ctx context.Context, name string, opts ...StartSpanOption) (ToolSpan, context.Context) {
+func StartToolSpan(ctx context.Context, name string, opts ...StartSpanOption) (*ToolSpan, context.Context) {
+	var t ToolSpan
 	s, ctx, ok := startSpan(ctx, illmobs.SpanKindTool, name, opts...)
 	if !ok {
-		return &noopSpan{}, ctx
+		return &t, ctx
 	}
-	return &textIOSpan{s}, ctx
+	t.baseSpan = s
+	return &t, ctx
 }
 
 // StartTaskSpan starts an LLMObs span of kind Task.
 // Pass the returned context to subsequent start span calls to create child spans of this one.
-func StartTaskSpan(ctx context.Context, name string, opts ...StartSpanOption) (TaskSpan, context.Context) {
+func StartTaskSpan(ctx context.Context, name string, opts ...StartSpanOption) (*TaskSpan, context.Context) {
+	var t TaskSpan
 	s, ctx, ok := startSpan(ctx, illmobs.SpanKindTask, name, opts...)
 	if !ok {
-		return &noopSpan{}, ctx
+		return &t, ctx
 	}
-	return &textIOSpan{s}, ctx
+	t.baseSpan = s
+	return &t, ctx
 }
 
 // StartEmbeddingSpan starts an LLMObs span of kind Embedding.
 // Pass the returned context to subsequent start span calls to create child spans of this one.
 //
 // Note: embedding spans are annotated with input EmbeddedDocument and output text.
-func StartEmbeddingSpan(ctx context.Context, name string, opts ...StartSpanOption) (EmbeddingSpan, context.Context) {
+func StartEmbeddingSpan(ctx context.Context, name string, opts ...StartSpanOption) (*EmbeddingSpan, context.Context) {
+	var e EmbeddingSpan
 	s, ctx, ok := startSpan(ctx, illmobs.SpanKindEmbedding, name, opts...)
 	if !ok {
-		return &noopSpan{}, ctx
+		return &e, ctx
 	}
-	return &embeddingSpan{s}, ctx
+	e.baseSpan = s
+	return &e, ctx
 }
 
 // StartRetrievalSpan starts an LLMObs span of kind Retrieval.
 // Pass the returned context to subsequent start span calls to create child spans of this one.
 //
 // Note: retrieval spans are annotated with input text and output RetrievedDocument.
-func StartRetrievalSpan(ctx context.Context, name string, opts ...StartSpanOption) (RetrievalSpan, context.Context) {
+func StartRetrievalSpan(ctx context.Context, name string, opts ...StartSpanOption) (*RetrievalSpan, context.Context) {
+	var r RetrievalSpan
 	s, ctx, ok := startSpan(ctx, illmobs.SpanKindRetrieval, name, opts...)
 	if !ok {
-		return &noopSpan{}, ctx
+		return &r, ctx
 	}
-	return &retrievalSpan{s}, ctx
+	r.baseSpan = s
+	return &r, ctx
 }
 
 type (
@@ -129,59 +145,9 @@ type (
 	ToolDefinition = illmobs.ToolDefinition
 )
 
-type (
-	// Span represents a generic LLMObs span that can be converted to specific span types.
-	// Use AsLLM(), AsWorkflow(), etc. to convert to typed spans with specific annotation methods.
-	Span interface {
-		BaseSpan
-		spanConverter
-	}
-
-	// LLMSpan represents a span for Large Language Model operations.
-	LLMSpan interface {
-		BaseSpan
-		llmIOAnnotator
-	}
-
-	// WorkflowSpan represents a span for high-level workflow operations.
-	WorkflowSpan interface {
-		BaseSpan
-		textIOAnnotator
-	}
-
-	// AgentSpan represents a span for AI agent operations.
-	AgentSpan interface {
-		BaseSpan
-		textIOAnnotator
-	}
-
-	// ToolSpan represents a span for tool/function call operations.
-	ToolSpan interface {
-		BaseSpan
-		textIOAnnotator
-	}
-
-	// TaskSpan represents a span for discrete task operations.
-	TaskSpan interface {
-		BaseSpan
-		textIOAnnotator
-	}
-
-	// EmbeddingSpan represents a span for text embedding operations.
-	EmbeddingSpan interface {
-		BaseSpan
-		embeddingIOAnnotator
-	}
-
-	// RetrievalSpan represents a span for information retrieval operations.
-	RetrievalSpan interface {
-		BaseSpan
-		retrievalIOAnnotator
-	}
-)
-
-// BaseSpan defines the common interface for all LLMObs spans.
-type BaseSpan interface {
+// Span represents a generic LLMObs span that can be converted to specific span types.
+// Use AsLLM(), AsWorkflow(), etc. to convert to typed spans with specific annotation methods.
+type Span interface {
 	sealed() // Prevents external implementations
 
 	// SpanID returns the unique identifier for this span.
@@ -203,114 +169,172 @@ type BaseSpan interface {
 	Finish(opts ...FinishSpanOption)
 }
 
-// spanConverter provides type conversion methods for generic spans.
-// Allows safe conversion from generic Span to specific span types.
-type spanConverter interface {
-	// AsLLM attempts to convert to an LLMSpan. Returns the span and true if successful.
-	AsLLM() (LLMSpan, bool)
-
-	// AsWorkflow attempts to convert to a WorkflowSpan. Returns the span and true if successful.
-	AsWorkflow() (WorkflowSpan, bool)
-
-	// AsAgent attempts to convert to an AgentSpan. Returns the span and true if successful.
-	AsAgent() (AgentSpan, bool)
-
-	// AsTool attempts to convert to a ToolSpan. Returns the span and true if successful.
-	AsTool() (ToolSpan, bool)
-
-	// AsTask attempts to convert to a TaskSpan. Returns the span and true if successful.
-	AsTask() (TaskSpan, bool)
-
-	// AsEmbedding attempts to convert to an EmbeddingSpan. Returns the span and true if successful.
-	AsEmbedding() (EmbeddingSpan, bool)
-
-	// AsRetrieval attempts to convert to a RetrievalSpan. Returns the span and true if successful.
-	AsRetrieval() (RetrievalSpan, bool)
+// WorkflowSpan represents a span for high-level workflow operations.
+type WorkflowSpan struct {
+	textIOSpan
 }
 
-// textIOAnnotator provides annotation methods for spans that work with text input/output.
-// Used by Workflow, Agent, Tool, and Task spans.
-type textIOAnnotator interface {
-	// AnnotateTextIO annotates the span with text input and output.
-	// Use annotation options to add tags, metrics, metadata, etc.
-	AnnotateTextIO(input, output string, opts ...AnnotateOption)
+// AgentSpan represents a span for AI agent operations.
+type AgentSpan struct {
+	textIOSpan
 }
 
-// llmIOAnnotator provides annotation methods for LLM spans.
-// Handles conversation messages with roles (user, assistant, system).
-type llmIOAnnotator interface {
-	// AnnotateLLMIO annotates the span with LLM conversation messages.
-	// Input and output should be slices of LLMMessage with appropriate roles.
-	AnnotateLLMIO(input, output []LLMMessage, opts ...AnnotateOption)
+// ToolSpan represents a span for tool/function call operations.
+type ToolSpan struct {
+	textIOSpan
 }
 
-// embeddingIOAnnotator provides annotation methods for embedding spans.
-// Handles document input and embedding output.
-type embeddingIOAnnotator interface {
-	// AnnotateEmbeddingIO annotates the span with documents to embed and the embedding output.
-	// Input should be documents to convert to embeddings, output is typically a model identifier.
-	AnnotateEmbeddingIO(input []EmbeddedDocument, output string, opts ...AnnotateOption)
+// TaskSpan represents a span for discrete task operations.
+type TaskSpan struct {
+	textIOSpan
 }
 
-// retrievalIOAnnotator provides annotation methods for retrieval spans.
-// Handles search queries and retrieved documents.
-type retrievalIOAnnotator interface {
-	// AnnotateRetrievalIO annotates the span with a search query and retrieved documents.
-	// Input is the search query, output is the list of documents found.
-	AnnotateRetrievalIO(input string, output []RetrievedDocument, opts ...AnnotateOption)
+// EmbeddingSpan represents a span for text embedding operations.
+type EmbeddingSpan struct {
+	*baseSpan
+}
+
+func (s *EmbeddingSpan) AnnotateEmbeddingIO(input []EmbeddedDocument, output string, opts ...AnnotateOption) {
+	if s.baseSpan == nil {
+		return
+	}
+	a := parseAnnotateOptions(opts...)
+	a.InputEmbeddedDocs = input
+	a.OutputText = output
+	s.Span.Annotate(a)
+}
+
+// RetrievalSpan represents a span for information retrieval operations.
+type RetrievalSpan struct {
+	*baseSpan
+}
+
+func (s *RetrievalSpan) AnnotateRetrievalIO(input string, output []RetrievedDocument, opts ...AnnotateOption) {
+	if s.baseSpan == nil {
+		return
+	}
+	a := parseAnnotateOptions(opts...)
+	a.InputText = input
+	a.OutputRetrievedDocs = output
+	s.Span.Annotate(a)
 }
 
 type baseSpan struct {
 	*illmobs.Span
 }
 
-func (s *baseSpan) AsLLM() (LLMSpan, bool) {
-	if illmobs.SpanKind(s.Kind()) == illmobs.SpanKindLLM {
-		return &llmSpan{s}, true
+func (s *baseSpan) SpanID() string {
+	if s == nil {
+		return ""
 	}
-	return nil, false
+	return s.Span.SpanID()
 }
 
-func (s *baseSpan) AsWorkflow() (WorkflowSpan, bool) {
-	return s.asTextIO(illmobs.SpanKindWorkflow)
-}
-
-func (s *baseSpan) AsAgent() (AgentSpan, bool) {
-	return s.asTextIO(illmobs.SpanKindWorkflow)
-}
-
-func (s *baseSpan) AsTool() (ToolSpan, bool) {
-	return s.asTextIO(illmobs.SpanKindWorkflow)
-}
-
-func (s *baseSpan) AsTask() (TaskSpan, bool) {
-	return s.asTextIO(illmobs.SpanKindWorkflow)
-}
-
-func (s *baseSpan) AsEmbedding() (EmbeddingSpan, bool) {
-	if illmobs.SpanKind(s.Kind()) == illmobs.SpanKindEmbedding {
-		return &embeddingSpan{s}, true
+func (s *baseSpan) Kind() string {
+	if s == nil {
+		return ""
 	}
-	return nil, false
+	return s.Span.Kind()
 }
 
-func (s *baseSpan) AsRetrieval() (RetrievalSpan, bool) {
-	if illmobs.SpanKind(s.Kind()) == illmobs.SpanKindRetrieval {
-		return &retrievalSpan{s}, true
+func (s *baseSpan) TraceID() string {
+	if s == nil {
+		return ""
 	}
-	return nil, false
+	return s.Span.TraceID()
 }
 
-func (s *baseSpan) asTextIO(target illmobs.SpanKind) (*textIOSpan, bool) {
-	if illmobs.SpanKind(s.Kind()) == target {
-		return &textIOSpan{s}, true
+func (s *baseSpan) APMTraceID() string {
+	if s == nil {
+		return ""
 	}
-	return nil, false
+	return s.Span.APMTraceID()
+}
+
+func (s *baseSpan) AsLLM() (*LLMSpan, bool) {
+	if illmobs.SpanKind(s.Kind()) != illmobs.SpanKindLLM {
+		return nil, false
+	}
+	return &LLMSpan{s}, true
+}
+
+func (s *baseSpan) AsWorkflow() (*WorkflowSpan, bool) {
+	if !s.isTextIO(illmobs.SpanKindWorkflow) {
+		return nil, false
+	}
+	var w WorkflowSpan
+	w.baseSpan = s
+	return &w, true
+}
+
+func (s *baseSpan) AsAgent() (*AgentSpan, bool) {
+	if !s.isTextIO(illmobs.SpanKindAgent) {
+		return nil, false
+	}
+	var a AgentSpan
+	a.baseSpan = s
+	return &a, true
+}
+
+func (s *baseSpan) AsTool() (*ToolSpan, bool) {
+	if !s.isTextIO(illmobs.SpanKindTool) {
+		return nil, false
+	}
+	var t ToolSpan
+	t.baseSpan = s
+	return &t, true
+}
+
+func (s *baseSpan) AsTask() (*TaskSpan, bool) {
+	if !s.isTextIO(illmobs.SpanKindTask) {
+		return nil, false
+	}
+	var t TaskSpan
+	t.baseSpan = s
+	return &t, true
+}
+
+func (s *baseSpan) AsEmbedding() (*EmbeddingSpan, bool) {
+	if illmobs.SpanKind(s.Kind()) != illmobs.SpanKindEmbedding {
+		return nil, false
+	}
+	var e EmbeddingSpan
+	e.baseSpan = s
+	return &e, true
+}
+
+func (s *baseSpan) AsRetrieval() (*RetrievalSpan, bool) {
+	if illmobs.SpanKind(s.Kind()) != illmobs.SpanKindRetrieval {
+		return nil, false
+	}
+	var r RetrievalSpan
+	r.baseSpan = s
+	return &r, true
+}
+
+func (s *baseSpan) isTextIO(target illmobs.SpanKind) bool {
+	if illmobs.SpanKind(s.Kind()) != target {
+		return false
+	}
+	switch target {
+	case illmobs.SpanKindAgent:
+		fallthrough
+	case illmobs.SpanKindTask:
+		fallthrough
+	case illmobs.SpanKindTool:
+		fallthrough
+	case illmobs.SpanKindWorkflow:
+		return true
+	}
+	return false
 }
 
 func (*baseSpan) sealed() {}
 
 func (s *baseSpan) Finish(opts ...FinishSpanOption) {
+	if s == nil {
+		return
+	}
 	cfg := illmobs.FinishSpanConfig{}
 	for _, opt := range opts {
 		opt(&cfg)
@@ -323,58 +347,28 @@ type textIOSpan struct {
 }
 
 func (s *textIOSpan) AnnotateTextIO(input, output string, opts ...AnnotateOption) {
+	if s.baseSpan == nil {
+		return
+	}
 	a := parseAnnotateOptions(opts...)
 	a.InputText = input
 	a.OutputText = output
 	s.Span.Annotate(a)
 }
 
-type llmSpan struct {
+type LLMSpan struct {
 	*baseSpan
 }
 
-func (s *llmSpan) AnnotateLLMIO(input, output []LLMMessage, opts ...AnnotateOption) {
+func (s *LLMSpan) AnnotateLLMIO(input, output []LLMMessage, opts ...AnnotateOption) {
+	if s.baseSpan == nil {
+		return
+	}
 	a := parseAnnotateOptions(opts...)
 	a.InputMessages = input
 	a.OutputMessages = output
 	s.Span.Annotate(a)
 }
-
-type embeddingSpan struct {
-	*baseSpan
-}
-
-func (s *embeddingSpan) AnnotateEmbeddingIO(input []EmbeddedDocument, output string, opts ...AnnotateOption) {
-	a := parseAnnotateOptions(opts...)
-	a.InputEmbeddedDocs = input
-	a.OutputText = output
-	s.Span.Annotate(a)
-}
-
-type retrievalSpan struct {
-	*baseSpan
-}
-
-func (s *retrievalSpan) AnnotateRetrievalIO(input string, output []RetrievedDocument, opts ...AnnotateOption) {
-	a := parseAnnotateOptions(opts...)
-	a.InputText = input
-	a.OutputRetrievedDocs = output
-	s.Span.Annotate(a)
-}
-
-type noopSpan struct{}
-
-func (s *noopSpan) sealed()                                                                  {}
-func (s *noopSpan) SpanID() string                                                           { return "" }
-func (s *noopSpan) Kind() string                                                             { return "" }
-func (s *noopSpan) TraceID() string                                                          { return "" }
-func (s *noopSpan) APMTraceID() string                                                       { return "" }
-func (s *noopSpan) AddLink(_ SpanLink)                                                       {}
-func (s *noopSpan) Finish(_ ...FinishSpanOption)                                             {}
-func (s *noopSpan) AnnotateTextIO(_, _ string, _ ...AnnotateOption)                          {}
-func (s *noopSpan) AnnotateLLMIO(_, _ []LLMMessage, _ ...AnnotateOption)                     {}
-func (s *noopSpan) AnnotateEmbeddingIO(_ []EmbeddedDocument, _ string, _ ...AnnotateOption)  {}
-func (s *noopSpan) AnnotateRetrievalIO(_ string, _ []RetrievedDocument, _ ...AnnotateOption) {}
 
 func startSpan(ctx context.Context, kind illmobs.SpanKind, name string, opts ...StartSpanOption) (*baseSpan, context.Context, bool) {
 	ll, err := illmobs.ActiveLLMObs()


### PR DESCRIPTION
### What does this PR do?

Refactors all the public API for `llmobs` to avoid returning interfaces in favour of concrete values.

### Motivation

Interfaces are contracts. Changing them is a breaking change.

It's true that @rarguelloF's implementation adds an unexported function to the interface (`sealed`) to avoid people using the interface, but another reason for preferring concrete types is that other packages across the same API are returning concrete types. An API with mixed signatures, some returning interfaces and other concrete values, doesn't feel properly designed.

It also allows to remove multiple interfaces and supporting code that was required to work around the interfaces.

As a downside, I recognize that the nil handling isn't convenient for developers, and I couldn't return nil values from some functions due to all the internal wrappers, the same wrappers that allowed me to implement the concrete types-based API.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
