### PR TITLE
chore(.github/workflows): ignore label_issues in all-jobs-are-green job

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -20,6 +20,7 @@ jobs:
           # polling-interval-seconds: "60" # Default
           ignored-name-patterns: |
             devflow/merge
+            label_issues
             check-title
 
 # Reason for ignored-name-patterns:


### PR DESCRIPTION
### What does this PR do?

Adds `label_issues` to the ignored jobs so `all-jobs-are-green` don't fail on it.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
