### PR TITLE
fix: flaky test

### DIFF
--- a/ddtrace/tracer/sampler_test.go
+++ b/ddtrace/tracer/sampler_test.go
@@ -1885,8 +1885,10 @@ func TestSampleTagsRootOnly(t *testing.T) {
 		// first sampling rule is applied, the sampling decision is 1
 		// and the "_dd.limit_psr" is present
 		root.Finish()
-		assert.Equal(1., root.metrics[keyRulesSamplerAppliedRate])
-		assert.Contains(root.metrics, keyRulesSamplerLimiterRate)
+		ruleRate, _ := getMetric(root, keyRulesSamplerAppliedRate)
+		assert.Equal(1., ruleRate)
+		_, hasLimiterRate := getMetric(root, keyRulesSamplerLimiterRate)
+		assert.True(hasLimiterRate)
 		// Knuth sampling rate tag should be set with rate 1.0
 		rate, ok := getMeta(root, keyKnuthSamplingRate)
 		assert.True(ok)
@@ -1939,8 +1941,10 @@ func TestSampleTagsRootOnly(t *testing.T) {
 		// re-sampling should not occur
 		root.Finish()
 
-		assert.NotContains(child.metrics, keyRulesSamplerAppliedRate)
-		assert.NotContains(root.metrics, keyRulesSamplerLimiterRate)
+		_, hasRulesRate := getMetric(child, keyRulesSamplerAppliedRate)
+		assert.False(hasRulesRate)
+		_, hasLimiterRate := getMetric(root, keyRulesSamplerLimiterRate)
+		assert.False(hasLimiterRate)
 		// Knuth sampling rate tag should still be "0" since no re-sampling occurred
 		rate, ok := getMeta(root, keyKnuthSamplingRate)
 		assert.True(ok)
@@ -1948,8 +1952,10 @@ func TestSampleTagsRootOnly(t *testing.T) {
 
 		// neither"_dd.limit_psr", nor "_dd.rule_psr" should be present
 		// on the child span
-		assert.NotContains(child.metrics, keyRulesSamplerAppliedRate)
-		assert.NotContains(child.metrics, keyRulesSamplerLimiterRate)
+		_, hasRulesRate = getMetric(child, keyRulesSamplerAppliedRate)
+		assert.False(hasRulesRate)
+		_, hasLimiterRate = getMetric(child, keyRulesSamplerLimiterRate)
+		assert.False(hasLimiterRate)
 		// child span should not have Knuth sampling rate tag
 		_, ok = getMeta(child, keyKnuthSamplingRate)
 		assert.False(ok)


### PR DESCRIPTION
When a span is finished writes to meta/metrics require the lock to be held. This is due to first span of the first chunk calling `setMeta` which both calls a delete on metrics map and inserts in meta map.
Test calls need to be protected to avoid the flake

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
