### PR TITLE
feat(llmobs/experiment): add summary evaluators

### DIFF
--- a/internal/llmobs/transport/dne.go
+++ b/internal/llmobs/transport/dne.go
@@ -131,6 +131,7 @@ type RequestAttributesExperimentPushEvents struct {
 }
 
 type ExperimentEvalMetricEvent struct {
+	MetricSource     string        `json:"metric_source,omitempty"`
 	SpanID           string        `json:"span_id,omitempty"`
 	TraceID          string        `json:"trace_id,omitempty"`
 	TimestampMS      int64         `json:"timestamp_ms,omitempty"`

--- a/llmobs/experiment/experiment_example_test.go
+++ b/llmobs/experiment/experiment_example_test.go
@@ -107,9 +107,10 @@ func ExampleNew() {
 		log.Fatal(err)
 	}
 
-	for _, res := range results {
-		fmt.Printf("Record: %d", res.RecordIndex)
-		fmt.Printf("Input: %v", res.Input)
+	for _, res := range results.Results {
+		fmt.Printf("Record ID: %s", res.Record.ID())
+		fmt.Printf("Input: %v", res.Record.Input)
+		fmt.Printf("Expected Output: %v", res.Record.ExpectedOutput)
 		fmt.Printf("Output: %v", res.Output)
 		for _, ev := range res.Evaluations {
 			fmt.Printf("Evaluator score (%s): %v", ev.Name, ev.Value)

--- a/llmobs/experiment/experiment_test.go
+++ b/llmobs/experiment/experiment_test.go
@@ -327,18 +327,16 @@ func TestExperimentRun(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify results
-		assert.Len(t, results, 2) // Our test dataset has 2 records
+		assert.Len(t, results.Results, 2) // Our test dataset has 2 records
 
-		for i, result := range results {
-			assert.Equal(t, i, result.RecordIndex)
+		for _, result := range results.Results {
 			assert.NotEmpty(t, result.SpanID)
 			assert.NotEmpty(t, result.TraceID)
 			assert.NotZero(t, result.Timestamp)
-			assert.NotNil(t, result.Input)
+			assert.NotNil(t, result.Record.Input)
 			assert.NotNil(t, result.Output)
-			assert.NotNil(t, result.ExpectedOutput)
+			assert.NotNil(t, result.Record.ExpectedOutput)
 			assert.Len(t, result.Evaluations, 2) // We have 2 evaluators
-			assert.NotNil(t, result.Metadata)
 			assert.NoError(t, result.Error)
 
 			// Check evaluations
@@ -383,8 +381,8 @@ func TestExperimentRun(t *testing.T) {
 		require.NoError(t, err)
 
 		// Should only have 1 result due to sample size
-		assert.Len(t, results, 1)
-		assert.Equal(t, 0, results[0].RecordIndex)
+		assert.Len(t, results.Results, 1)
+		assert.NotNil(t, results.Results[0].Record)
 
 		// Verify only 1 span was created
 		spans := tt.WaitForLLMObsSpans(t, 1)
@@ -418,8 +416,8 @@ func TestExperimentRun(t *testing.T) {
 		require.NoError(t, err)
 
 		// Should have results but with errors
-		assert.Len(t, results, 2)
-		for _, result := range results {
+		assert.Len(t, results.Results, 2)
+		for _, result := range results.Results {
 			if assert.Error(t, result.Error) {
 				assert.Contains(t, result.Error.Error(), "task failed")
 			}
@@ -459,8 +457,8 @@ func TestExperimentRun(t *testing.T) {
 		require.NoError(t, err)
 
 		// Should have results
-		assert.Len(t, results, 2)
-		for _, result := range results {
+		assert.Len(t, results.Results, 2)
+		for _, result := range results.Results {
 			assert.NoError(t, result.Error) // Task should succeed
 			assert.Len(t, result.Evaluations, 2)
 
@@ -551,8 +549,8 @@ func TestExperimentMetricGeneration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify results contain evaluations with different value types
-	require.Len(t, results, 2) // 2 dataset records
-	for _, result := range results {
+	require.Len(t, results.Results, 2) // 2 dataset records
+	for _, result := range results.Results {
 		assert.Len(t, result.Evaluations, 4) // 4 evaluators
 
 		// Check that evaluations have the expected values

--- a/llmobs/experiment/option.go
+++ b/llmobs/experiment/option.go
@@ -10,18 +10,20 @@ import (
 )
 
 type newCfg struct {
-	projectName   string
-	description   string
-	tags          map[string]string
-	experimentCfg map[string]any
+	projectName       string
+	description       string
+	tags              map[string]string
+	experimentCfg     map[string]any
+	summaryEvaluators []SummaryEvaluator
 }
 
 func defaultNewCfg(globalCfg *config.Config) *newCfg {
 	return &newCfg{
-		projectName:   globalCfg.ProjectName,
-		description:   "",
-		tags:          nil,
-		experimentCfg: nil,
+		projectName:       globalCfg.ProjectName,
+		description:       "",
+		tags:              nil,
+		experimentCfg:     nil,
+		summaryEvaluators: nil,
 	}
 }
 
@@ -48,6 +50,15 @@ func WithDescription(description string) Option {
 func WithExperimentConfig(experimentCfg map[string]any) Option {
 	return func(cfg *newCfg) {
 		cfg.experimentCfg = experimentCfg
+	}
+}
+
+// WithSummaryEvaluators sets the summary evaluators for the experiment.
+// Summary evaluators run after all tasks and evaluators have completed,
+// receiving all experiment results to compute aggregate metrics.
+func WithSummaryEvaluators(summaryEvaluators ...SummaryEvaluator) Option {
+	return func(cfg *newCfg) {
+		cfg.summaryEvaluators = summaryEvaluators
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Adds `WithSummaryEvaluators` to the llmobs/experiment package to provide summary evaluators to the experiment.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->
Feature parity with dd-trace-py

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
