### PR TITLE
feat: allow `skip-checks` with `reason`

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -3,6 +3,10 @@ schema-version: v1
 kind: mergequeue
 enable: true
 merge_method: squash
+branches:
+  main:
+    allow_skip_checks: true
+    require_reason_for_skip_checks: true
 ---
 schema-version: v1
 kind: mergegate


### PR DESCRIPTION
### What does this PR do?

Enables `skip-checks` to allow to merge to `main` when not all checks are green. Handle with care.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
