### PR TITLE
fix(envoyproxy): replace telemetry header by env var for envoy gateway

### DIFF
--- a/contrib/envoyproxy/go-control-plane/envoy_messages.go
+++ b/contrib/envoyproxy/go-control-plane/envoy_messages.go
@@ -69,8 +69,7 @@ const (
 )
 
 var isK8s = sync.OnceValue(func() bool {
-	isk8s, _ := strconv.ParseBool(os.Getenv("KUBERNETES"))
-	return isk8s
+	return os.Getenv("KUBERNETES") != ""
 })
 
 func (i Integration) String() string {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR changes the way we get telemetry out of envoy gateway instances because we cannot add the usual custom header using EnvoyExtensionPolicy CRD. Therefore we fall back to only look if we run in kubernetes if we have not found another header we know of

### Motivation

Better telemetry

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
