### PR TITLE
fix(ddtrace/tracer): ensure that sampling tests on remote config update are consistent

### DIFF
--- a/ddtrace/tracer/remote_config_test.go
+++ b/ddtrace/tracer/remote_config_test.go
@@ -200,7 +200,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		})
 	})
 
-	t.Run("DD_TRACE_SAMPLING_RULES=1.0 and RC rule rate=1.0 and revert", func(t *testing.T) {
+	t.Run("DD_TRACE_SAMPLING_RULES=0.0 and RC rule rate=1.0 and revert", func(t *testing.T) {
 		telemetryClient := new(telemetrytest.RecordClient)
 		defer telemetry.MockClient(telemetryClient)()
 
@@ -208,7 +208,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 				"service": "my-service",
 				"name": "web.request",
 				"resource": "*",
-				"sample_rate": 1.0
+				"sample_rate": 0.0
 			}]`)
 		tracer, _, _, stop, err := startTestTracer(t, WithService("my-service"), WithEnv("my-env"))
 		defer stop()
@@ -218,11 +218,11 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		s := tracer.StartSpan("web.request")
 		s.Finish()
 		rate, _ := getMetric(s, keyRulesSamplerAppliedRate)
-		require.Equal(t, 1.0, rate)
+		require.Equal(t, 0.0, rate)
 		p, ok := s.context.trace.samplingPriority()
 		require.True(t, ok)
-		require.Equal(t, p, 2)
-		require.Equal(t, samplerToDM(samplernames.RuleRate), s.context.trace.propagatingTags[keyDecisionMaker])
+		require.Equal(t, p, -1)
+		require.Empty(t, s.context.trace.propagatingTags[keyDecisionMaker])
 
 		input := remoteconfig.ProductUpdate{
 			"path": []byte(`{"lib_config": {"tracing_sampling_rate": 0.5,
@@ -233,14 +233,14 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 				"provenance": "customer",
 				"sample_rate": 1.0
 			},
-			{
-				"service": "my-service",
-				"name": "web.request",
-				"resource": "*",
-				"provenance": "dynamic",
-				"sample_rate": 0.75
-			}]},
-			"service_target": {"service": "my-service", "env": "my-env"}}`),
+		{
+			"service": "my-service",
+			"name": "web.request",
+			"resource": "*",
+			"provenance": "dynamic",
+			"sample_rate": 1.0
+		}]},
+		"service_target": {"service": "my-service", "env": "my-env"}}`),
 		}
 		applyStatus := tracer.onRemoteConfigUpdate(input)
 		require.Equal(t, state.ApplyStateAcknowledged, applyStatus["path"].State)
@@ -255,7 +255,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		s.resource = "not_abc"
 		s.Finish()
 		rate, _ = getMetric(s, keyRulesSamplerAppliedRate)
-		require.Equal(t, 0.75, rate)
+		require.Equal(t, 1.0, rate)
 		p, ok = s.context.trace.samplingPriority()
 		require.True(t, ok)
 		require.Equal(t, p, 2)
@@ -273,22 +273,22 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		s.resource = "not_abc"
 		s.Finish()
 		rate, _ = getMetric(s, keyRulesSamplerAppliedRate)
-		require.Equal(t, 1.0, rate)
+		require.Equal(t, 0.0, rate)
 		p, ok = s.context.trace.samplingPriority()
 		require.True(t, ok)
-		require.Equal(t, p, 2)
-		require.Equal(t, samplerToDM(samplernames.RuleRate), s.context.trace.propagatingTags[keyDecisionMaker])
+		require.Equal(t, p, -1)
+		require.Empty(t, s.context.trace.propagatingTags[keyDecisionMaker])
 
 		assertCalled(t, telemetryClient, []telemetry.Configuration{
 			{Name: "trace_sample_rate", Value: 0.5, Origin: telemetry.OriginRemoteConfig},
 			{Name: "trace_sample_rules",
-				Value: `[{"service":"my-service","name":"web.request","resource":"abc","sample_rate":1,"provenance":"customer"} {"service":"my-service","name":"web.request","resource":"*","sample_rate":0.75,"provenance":"dynamic"}]`, Origin: telemetry.OriginRemoteConfig},
+				Value: `[{"service":"my-service","name":"web.request","resource":"abc","sample_rate":1,"provenance":"customer"} {"service":"my-service","name":"web.request","resource":"*","sample_rate":1,"provenance":"dynamic"}]`, Origin: telemetry.OriginRemoteConfig},
 		})
 		assertCalled(t, telemetryClient, []telemetry.Configuration{
 			{Name: "trace_sample_rate", Value: nil, Origin: telemetry.OriginDefault},
 			{
 				Name:   "trace_sample_rules",
-				Value:  `[{"service":"my-service","name":"web.request","resource":"*","sample_rate":1}]`,
+				Value:  `[{"service":"my-service","name":"web.request","resource":"*","sample_rate":0}]`,
 				Origin: telemetry.OriginDefault,
 			},
 		})


### PR DESCRIPTION
### What does this PR do?

Modifies `TestOnRemoteConfigUpdate` to ensure that we replace the pattern below with equivalent `require.Equal` calls, as the test might pass without running some assertions.

```go
if p, ok := s.context.trace.samplingPriority(); ok && p > 0 {
	require.Equal(t, samplerToDM(samplernames.RuleRate), s.context.trace.propagatingTags[keyDecisionMaker])
}
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
