### PR TITLE
fix(.github/workflows/apps): ignore parsed fetched go.mod

### DIFF
--- a/.github/workflows/apps/latest_major_versions.go
+++ b/.github/workflows/apps/latest_major_versions.go
@@ -93,14 +93,14 @@ func main() {
 		// 4. Get the latest version of each major. For each latest version of each major:
 		// curl https://raw.githubusercontent.com/<module>/refs/tags/v4.18.3/go.mod
 		// 5a. If request returns 404, module is not a go module. This means version belongs to the module without /v at the end.
-		// 5b. If request returns a `go.mod`, parse the modfile and extract the mod name
+		// 5b. If request returns a `go.mod`, parse the modfile.
 		// Get the latest version for each major
 
 		for major, versions := range majors {
 			latest := getLatestVersion(versions)
 
 			log.Printf("fetching go.mod for %s@%s\n", origin, latest)
-			f, err := fetchGoMod(origin, latest)
+			_, err := fetchGoMod(origin, latest)
 			if err != nil {
 				log.Printf("failed to fetch go.mod for %s@%s: %+v\n", origin, latest, err)
 				continue


### PR DESCRIPTION
### What does this PR do?

Ignores the returned parsed `go.mod` from `fetchGoMod` as it's unused in Outdated Integrations' script.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
