### PR TITLE
fix(ddtrace/tracer): fix TestSpanString deadlock

### DIFF
--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -702,8 +702,6 @@ func TestSpanString(t *testing.T) {
 	// don't bother checking the contents, just make sure it works.
 	assert.NotEqual("", span.String())
 	span.Finish()
-	span.mu.RLock()
-	defer span.mu.RUnlock()
 	assert.NotEqual("", span.String())
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
TestSpanString takes a read lock on a span's mutex before calling
span.String. However, span.String also takes a read lock. The docs
for sync.RWMutex explicitly state that recursive read-locking is
prohibited. It can lead to deadlocks. For example:

- The test goroutine takes a read lock on the span.
- The tracer background goroutine takes a write lock in, e.g.
  span.setProcessTags. This blocks because there is a read lock held, as
  expected.
- The test goroutine then tries to take a read lock again on the span.
  The sync.RWMutex implementation sees that there is a pending write
  lock and blocks ([ref](https://cs.opensource.google/go/go/+/refs/tags/go1.25.3:src/sync/rwmutex.go;l=72-75;drc=bc0406333f686a754c2d787f93b143c27721925d)).

In this scenario, the test goroutine won't unblock until the write lock
is taken and released, which can't happen until the test goroutine
releases its initial read lock. So the test gets stuck. Fix this by not
taking the read lock in the test.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->
Fix deadlocks like the one I hit in https://github.com/DataDog/dd-trace-go/actions/runs/18697071225/job/53317204566

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
