### PR TITLE
chore: enable shuffle testing for most core packages

### DIFF
--- a/scripts/ci_test_core.sh
+++ b/scripts/ci_test_core.sh
@@ -11,7 +11,8 @@ mkdir -p "$TEST_RESULTS"
 NO_SHUFFLE_PATTERN="(github\.com/DataDog/dd-trace-go/v2/ddtrace/tracer|\
 github\.com/DataDog/dd-trace-go/v2/internal/civisibility/utils|\
 github\.com/DataDog/dd-trace-go/v2/profiler|\
-github\.com/DataDog/dd-trace-go/v2/instrumentation/appsec/dyngo)$"
+github\.com/DataDog/dd-trace-go/v2/instrumentation/appsec/dyngo|\
+github\.com/DataDog/dd-trace-go/v2/instrumentation/httptrace)$"
 
 mapfile -t SHUFFLE_PACKAGES < <(go list ./... | grep -v /contrib/ | grep -Ev "$NO_SHUFFLE_PATTERN")
 mapfile -t NO_SHUFFLE_PACKAGES < <(go list ./... | grep -v /contrib/ | grep -E "$NO_SHUFFLE_PATTERN")


### PR DESCRIPTION
### What does this PR do?

Enable test shuffling for most of our core packages.

Packages that were unable to successfully pass their tests with `-shuffle on` for 10 times in a row (on my local machine) have been excluded. See https://github.com/DataDog/dd-trace-go/pull/4060 for details.

Additionally the following packages were excluded because they flaked in CI (this may or may not be due to shuffle):

* [instrumentation/appsec/dyngo](https://github.com/DataDog/dd-trace-go/actions/runs/18719468509/job/53391568124?pr=4061)
* [instrumentation/httptrace](https://github.com/DataDog/dd-trace-go/actions/runs/18721467422/job/53395484878?pr=4061)

The plan is to enable shuffling for the excluded packages in the future once their test suite has been fixed. Enabling shuffle testing for contrib packages will also be done separately.

If you see test flakes, and suspect that they are caused by this PR, please try to fix them instead of adding the packages to the shuffle exclusion list.

PROF-12813

### Motivation

Some of our tests have come to rely on global state pollution over time. I.e. they need another test to run first in order to pass, or rely on another test not running first in order to pass. This is undesirable as it often causes problems for people debugging test failures (e.g. test passes when `go test -run TestXXX` but not when running all tests in the pkg). It may also hide implementation bugs.

### Reviewer's Checklist

<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
