### PR TITLE
chore(profiler): enable shuffle testing

### DIFF
--- a/scripts/ci_test_core.sh
+++ b/scripts/ci_test_core.sh
@@ -10,7 +10,6 @@ mkdir -p "$TEST_RESULTS"
 # Packages that don't support -shuffle on yet
 NO_SHUFFLE_PATTERN="(github\.com/DataDog/dd-trace-go/v2/ddtrace/tracer|\
 github\.com/DataDog/dd-trace-go/v2/internal/civisibility/utils|\
-github\.com/DataDog/dd-trace-go/v2/profiler|\
 github\.com/DataDog/dd-trace-go/v2/instrumentation/appsec/dyngo|\
 github\.com/DataDog/dd-trace-go/v2/instrumentation/httptrace)$"
 


### PR DESCRIPTION
I haven't been able to reproduce shuffle test failures for the profiler,
even after hundreds of runs. The initial failures may have been
timing-related flakes due to running many instances of the test suite in
parallel. It's probably fine to just enable shuffle testing for the
profiler.
