### PR TITLE
chore: @DataDog/asm-go owns appsec_test.go files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,6 +19,7 @@
 /contrib/envoyproxy             @DataDog/asm-go
 /contrib/haproxy                @DataDog/asm-go
 /contrib/k8s.io/gateway-api     @DataDog/asm-go
+/contrib/**/appsec_test.go      @DataDog/asm-go
 
 # capabilities - config, dynamic config, remote config
 /internal/env                        @DataDog/apm-sdk-capabilities-go


### PR DESCRIPTION
### What does this PR do?

Assigns ownership of `appsec_test.go` files within `contrib` subdirectories to @DataDog/asm-go as the rightful owners of these tests.

### Motivation

This is as part of the. test ownership initiative.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
