### PR TITLE
feat(profiler): switch back to zstd compression by default

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -188,7 +188,7 @@ func defaultConfig() (*config, error) {
 		deltaProfiles:        internal.BoolEnv("DD_PROFILING_DELTA", true),
 		logStartup:           internal.BoolEnv("DD_TRACE_STARTUP_LOGS", true),
 		endpointCountEnabled: internal.BoolEnv(traceprof.EndpointCountEnvVar, false),
-		compressionConfig:    cmp.Or(env.Get("DD_PROFILING_DEBUG_COMPRESSION_SETTINGS"), "legacy"),
+		compressionConfig:    cmp.Or(env.Get("DD_PROFILING_DEBUG_COMPRESSION_SETTINGS"), "zstd"),
 		traceConfig: executionTraceConfig{
 			Enabled: internal.BoolEnv("DD_PROFILING_EXECUTION_TRACE_ENABLED", executionTraceEnabledDefault),
 			Period:  internal.DurationEnv("DD_PROFILING_EXECUTION_TRACE_PERIOD", 15*time.Minute),


### PR DESCRIPTION
Switching to zstd compression noticeably increased memory usage from the
profiler, since we were creating a zstd encoder per profile type, and
each encoder uses ~8MiB of memory. Because of this, we switched back to
the privous compression scheme by default. #4058 improved the memory
usage by sharing a single zstd encoder between all the profile types.
With that fix in place we can switch back to zstd compression by
default.

PROF-11815