### PR TITLE
chore(ci): skip checklocks check

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -155,6 +155,11 @@ jobs:
           filter_mode: nofilter
 
   checklocks:
+    # We have the infrastructure in place for this check,
+    # but we still need to add the required annotations for
+    # checklocks to actually identify issues. Skipping the
+    # check until we do so.
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -170,5 +175,4 @@ jobs:
       - name: Run checklocks
         run: |-
           export PATH="${{ github.workspace }}/bin:${PATH}"
-          # Errors are expected here, but we want to fail the CI if there are any errors for now
-          ./scripts/check_locks.sh || true
+          ./scripts/check_locks.sh


### PR DESCRIPTION
### What does this PR do?

We have the infrastructure in place for this check, but we still need to
add the required annotations for checklocks to actually identify issues.
Right now it's running and adding annotations to every PR, mostly just
errors due to missing annotations. Skip the check until we add those
annotations.

### Motivation

Remove noise from PRs.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
