### PR TITLE
chore(ci): work around smoke test breaking changes

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -58,15 +58,16 @@ jobs:
         run: |-
           mkdir -p $TEST_RESULTS
           go get -u -t $PACKAGES
-          go get github.com/DataDog/datadog-agent/comp/core/tagger/origindetection@v0.71.0-rc.2
-          go get github.com/DataDog/datadog-agent/pkg/obfuscate@v0.71.0-rc.2
-          go get github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes@v0.71.0-rc.2
-          go get github.com/DataDog/datadog-agent/pkg/proto@v0.71.0-rc.2
-          go get github.com/DataDog/datadog-agent/pkg/remoteconfig/state@v0.71.0-rc.2
           go get github.com/DataDog/datadog-agent/pkg/trace@v0.71.0-rc.2
+          go get github.com/DataDog/datadog-agent/pkg/remoteconfig/state@v0.71.0-rc.2
+          go get github.com/DataDog/datadog-agent/pkg/proto@v0.71.0-rc.2
+          go get github.com/DataDog/datadog-agent/pkg/obfuscate@v0.71.0-rc.2
+          go get github.com/DataDog/datadog-agent/comp/core/tagger/origindetection@v0.71.0-rc.2
+          go get github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes@v0.71.0-rc.2
           go get github.com/DataDog/datadog-agent/pkg/util/log@v0.71.0-rc.2
           go get github.com/DataDog/datadog-agent/pkg/util/scrubber@v0.71.0-rc.2
           go get github.com/DataDog/datadog-agent/pkg/version@v0.71.0-rc.2
+          go get go.opentelemetry.io/collector/pdata@v1.39.0
           go mod tidy
           for d in `find . -iname go.mod | xargs -n1 dirname`; do pushd $d; go mod tidy; popd; done;
 

--- a/scripts/ci_test_contrib.sh
+++ b/scripts/ci_test_contrib.sh
@@ -26,15 +26,16 @@ for contrib in $CONTRIBS; do
   cd "$contrib" || exit 1
   if [[ "$1" = "smoke" ]]; then
     go get -u -t ./...
-    go get github.com/DataDog/datadog-agent/comp/core/tagger/origindetection@v0.71.0-rc.2
-    go get github.com/DataDog/datadog-agent/pkg/obfuscate@v0.71.0-rc.2
-    go get github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes@v0.71.0-rc.2
-    go get github.com/DataDog/datadog-agent/pkg/proto@v0.71.0-rc.2
-    go get github.com/DataDog/datadog-agent/pkg/remoteconfig/state@v0.71.0-rc.2
     go get github.com/DataDog/datadog-agent/pkg/trace@v0.71.0-rc.2
+    go get github.com/DataDog/datadog-agent/pkg/remoteconfig/state@v0.71.0-rc.2
+    go get github.com/DataDog/datadog-agent/pkg/proto@v0.71.0-rc.2
+    go get github.com/DataDog/datadog-agent/pkg/obfuscate@v0.71.0-rc.2
+    go get github.com/DataDog/datadog-agent/comp/core/tagger/origindetection@v0.71.0-rc.2
+    go get github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes@v0.71.0-rc.2
     go get github.com/DataDog/datadog-agent/pkg/util/log@v0.71.0-rc.2
     go get github.com/DataDog/datadog-agent/pkg/util/scrubber@v0.71.0-rc.2
     go get github.com/DataDog/datadog-agent/pkg/version@v0.71.0-rc.2
+    go get go.opentelemetry.io/collector/pdata@v1.39.0
   fi
   if [[ "$1" = "smoke" && "$contrib" = "./contrib/k8s.io/client-go/" ]]; then
     # This is a temporary workaround due to this issue in apimachinery: https://github.com/kubernetes/apimachinery/issues/190


### PR DESCRIPTION
The "go get -u" smoke tests have yet again broken due to dependency
troubles with the datadog-agent package and the Go OpenTelemetry
SDK. There are two issues (at least):

- The datadog-agent modules we depend upon have under-specified go.mod
  files. They depend on one another but don't have specific require
  directives. As such, unexpected things happen when trying to upgrade
  and downgrade those dependencies. Version 0.72.0 of those modules were
  just released, and doing a downgrade to 0.71.0-rc.2 (like we try to do
  in the smoke test job) can unexpectly downgrade a transitive
  datadog-agent dependency to 0.72.0-devel, which has breaking changes.
  [Example failure](https://github.com/DataDog/dd-trace-go/actions/runs/19071468437/job/54475190301).
- In classic fashion, the Go OpenTelemetry SDK does not follow semver at
  all and introduced breaking changes somewhere between version 1.39.0
  and 1.45.0. [Example failure](https://github.com/DataDog/dd-trace-go/actions/runs/19061751615/job/54447203770?pr=3984).

This commit works around these issues with two changes:

- Downgrade the datadog-agent modules in dependency order, so that one
  doesn't do an unexpected downgrade of another. I got this order by
  running `go mod graph | grep datadog-agent | tsort`.
- Downgrade the offending OpenTelemetry module to 1.39.0, which is where
  it was at before.
