### PR TITLE
chore(codeowners): add database monitoring team as code owner of the sql comment carrier

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -72,6 +72,10 @@
 # Feature Flagging Experiments
 /openfeature                    @DataDog/feature-flagging-and-experimentation-sdk @DataDog/asm-go
 
+# Database Monitoring
+ddtrace/tracer/sqlcomment*      @DataDog/database-monitoring @DataDog/apm-go @Datadog/apm-idm-go
+contrib/database/sql            @DataDog/database-monitoring @DataDog/apm-go @Datadog/apm-idm-go
+
 # no owner: changes to these files will not automatically ping any particular
 # team and can be reviewed by anybody with the appropriate permissions. This is
 # meant to avoid pinging all of @DataDog/dd-trace-go-guild for every PR that


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds the DBM team as a code owner of the SQLCommentCarrier.  

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This is following the [RFC on failure ownership](https://docs.google.com/document/d/1y9imdgzDa3pxvy26DSpi2qMPjBlLAV_G9wk-ct55sUc/edit?pli=1&tab=t.0) that requires for teams to be declared as owner of the tests they own. 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [x] There is a benchmark for any new code, or changes to existing code.
- [x] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
