### PR TITLE
chore(ci): regression checks must be interruptible as they become redundant

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,6 +49,7 @@ check-big-regressions:
   tags:
     - "arch:amd64"
   image: $BASE_CI_IMAGE
+  interruptible: true
   script:
     - |
       pwd

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -5,7 +5,9 @@
   only:
     refs:
       - branches
-  interruptible: true
+  rules:
+    - if: $CI_COMMIT_REF_NAME == "main"
+      interruptible: false
   tags: ["runner:apm-k8s-tweaked-metal"]
   variables:
     GOEXPERIMENT: "synctest" # TODO: remove once go1.25 is the minimum supported version

--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -8,6 +8,7 @@ variables:
   timeout: 1h
   rules:
     - if: $CI_COMMIT_REF_NAME == "main"
+      interruptible: false
       when: always
     - if: $CI_COMMIT_BRANCH =~ /^release-v[0-9]+.*$/
       when: always

--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -8,8 +8,8 @@ variables:
   timeout: 1h
   rules:
     - if: $CI_COMMIT_REF_NAME == "main"
-      interruptible: false
       when: always
+      interruptible: false
     - if: $CI_COMMIT_BRANCH =~ /^release-v[0-9]+.*$/
       when: always
     - when: manual


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

- Sets `check-big-regression` as interruptible as new runs make it redundant.
- Sets benchmarks to not be interruptible on main.
 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

https://datadoghq.atlassian.net/browse/APMSP-2369

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
