### PR TITLE
fix(appsec): add missing `_dd.appsec_request_downstream` span tag

### DIFF
--- a/contrib/net/http/appsec_test.go
+++ b/contrib/net/http/appsec_test.go
@@ -242,6 +242,9 @@ func TestAppsecAPI10(t *testing.T) {
 
 			require.Contains(t, serviceSpan.Tags(), tc.tagName)
 			require.Equal(t, serviceSpan.Tags()[tc.tagName], tc.tagValue)
+
+			require.Contains(t, serviceSpan.Tags(), "_dd.appsec.downstream_request")
+			require.Equal(t, serviceSpan.Tags()["_dd.appsec.downstream_request"], float64(1))
 		})
 	}
 }
@@ -301,6 +304,9 @@ func TestAppsecHTTP30X(t *testing.T) {
 
 		require.Contains(t, serviceSpan.Tags(), "appsec.api.redirection.nothing")
 		require.Equal(t, serviceSpan.Tags()["appsec.api.redirection.nothing"], float64(1))
+
+		require.Contains(t, serviceSpan.Tags(), "_dd.appsec.downstream_request")
+		require.Equal(t, serviceSpan.Tags()["_dd.appsec.downstream_request"], float64(2))
 	})
 
 	t.Run("redirect", func(t *testing.T) {
@@ -336,5 +342,8 @@ func TestAppsecHTTP30X(t *testing.T) {
 
 		require.Contains(t, serviceSpan.Tags(), "appsec.api.redirection.nothing")
 		require.Equal(t, serviceSpan.Tags()["appsec.api.redirection.nothing"], float64(1))
+
+		require.Contains(t, serviceSpan.Tags(), "_dd.appsec.downstream_request")
+		require.Equal(t, serviceSpan.Tags()["_dd.appsec.downstream_request"], float64(2))
 	})
 }

--- a/internal/appsec/emitter/waf/metrics.go
+++ b/internal/appsec/emitter/waf/metrics.go
@@ -173,6 +173,9 @@ func (m *HandleMetrics) NewContextMetrics() *ContextMetrics {
 type ContextMetrics struct {
 	*HandleMetrics
 
+	// SumDownstreamRequestsCalls is the sum of all the downstream requests calls analyzed by the WAF.
+	SumDownstreamRequestsCalls atomic.Uint32
+
 	// SumRASPCalls is the sum of all the RASP calls made by the WAF whatever the rasp rule type it is.
 	SumRASPCalls atomic.Uint32
 	// SumWAFErrors is the sum of all the WAF errors that happened not in the RASP scope.

--- a/internal/appsec/listener/httpsec/roundtripper.go
+++ b/internal/appsec/listener/httpsec/roundtripper.go
@@ -72,6 +72,10 @@ func (feature *DownwardRequestFeature) OnStart(op *httpsec.RoundTripOperation, a
 		WithDownwardMethod(args.Method).
 		WithDownwardRequestHeaders(args.Headers)
 
+	// Increment the span metric for downward requests
+	op.HandlerOp.ContextOperation.GetMetricsInstance().SumDownstreamRequestsCalls.Add(1)
+
+	// Increment the internal sampling counter for downward requests
 	requestCount := feature.downstreamRequestAnalysis.Add(1)
 
 	// Sampling algorithm based on:

--- a/internal/appsec/listener/waf/tags.go
+++ b/internal/appsec/listener/waf/tags.go
@@ -31,13 +31,22 @@ const (
 
 	durationExtSuffix = ".duration_ext"
 
-	blockedRequestTag = "appsec.blocked"
+	blockedRequestTag  = "appsec.blocked"
+	downwardRequestTag = wafSpanTagPrefix + "downstream_request"
 )
 
 // AddRulesMonitoringTags adds the tags related to security rules monitoring
 func AddRulesMonitoringTags(th trace.TagSetter) {
 	th.SetTag(wafVersionTag, libddwaf.Version())
 	th.SetTag(ext.ManualKeep, samplernames.AppSec)
+}
+
+func addDownwardRequestTag(th trace.TagSetter, value int) {
+	if value == 0 {
+		return
+	}
+
+	th.SetTag(downwardRequestTag, value)
 }
 
 // AddWAFMonitoringTags adds the tags related to the monitoring of the WAF

--- a/internal/appsec/listener/waf/waf.go
+++ b/internal/appsec/listener/waf/waf.go
@@ -143,6 +143,7 @@ func (waf *Feature) onFinish(op *waf.ContextOperation, _ waf.ContextRes) {
 	timerStats := ctx.Timer.Stats()
 	metrics := op.GetMetricsInstance()
 	AddWAFMonitoringTags(op, metrics, waf.rulesVersion, truncations, timerStats)
+	addDownwardRequestTag(op, int(metrics.SumDownstreamRequestsCalls.Load()))
 	metrics.Submit(truncations, timerStats)
 
 	if wafEvents := op.Events(); len(wafEvents) > 0 {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

add missing _dd.appsec_request_downstream span tag

### Motivation

This feature was missing the span tag described [here](https://docs.google.com/document/d/1DIGuCl1rkhx5swmGxKO7Je8Y4zvaobXBlgbm6C89yzU/edit?tab=t.0#heading=h.4smyj73p24n4)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
