### PR TITLE
fix: database/sql tags not propagated from registers

### DIFF
--- a/contrib/database/sql/option.go
+++ b/contrib/database/sql/option.go
@@ -158,7 +158,7 @@ func defaults(cfg *config, driverName string, rc *registerConfig) {
 		cfg.ignoreQueryTypes = rc.ignoreQueryTypes
 		cfg.childSpansOnly = rc.childSpansOnly
 		cfg.dbStats = rc.dbStats
-		if cfg.tags == nil {
+		if cfg.tags == nil && len(rc.tags) > 0 {
 			cfg.tags = make(map[string]interface{})
 		}
 		for k, v := range rc.tags {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Propagate tags from existing, registered configs to new drivers. Ensures that spans generated from `database/sql` contains custom tags that are added at registration.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Spans were missing custom tags from registered configs. 

Closes https://github.com/DataDog/dd-trace-go/issues/4135

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
