### PR TITLE
fix: empty decision maker causes errors

### DIFF
--- a/ddtrace/tracer/payload_test.go
+++ b/ddtrace/tracer/payload_test.go
@@ -56,10 +56,6 @@ func newDetailedSpanList(n int) spanList {
 	return list
 }
 
-func addPriority(sl *spanList) {
-	(*sl)[0].context.trace.setSamplingPriorityLocked(1, samplernames.Manual)
-}
-
 // TestPayloadIntegrity tests that whatever we push into the payload
 // allows us to read the same content as would have been encoded by
 // the codec.
@@ -224,7 +220,7 @@ func TestPayloadV1Decode(t *testing.T) {
 
 			for i := 0; i < n; i++ {
 				sl := newSpanList(i%5 + 1)
-				addPriority(&sl) // also set the sampling priority
+				sl[0].context.trace.setSamplingPriorityLocked(1, samplernames.Manual)
 				_, _ = p.push(sl)
 			}
 

--- a/ddtrace/tracer/payload_v1.go
+++ b/ddtrace/tracer/payload_v1.go
@@ -119,7 +119,7 @@ func (p *payloadV1) push(t spanList) (stats payloadStats, err error) {
 			continue
 		}
 
-		if span.Context() == nil {
+		if span.context == nil {
 			continue
 		}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Removes error thrown when decision maker is empty in payload v1. Instead, an empty decision maker will return a sampling decision of `uint32(0)`, which is the default value.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The logs were extremely noisy. Like
<img width="1435" height="347" alt="image" src="https://github.com/user-attachments/assets/166349c5-e864-46fd-991a-e69b8ba3fbf1" />
Really noisy.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
