### PR TITLE
fix(internal/civisibility): fixes an scenario where we might be deadlocking by waiting on a channel.

### DIFF
--- a/internal/civisibility/integrations/civisibility_features.go
+++ b/internal/civisibility/integrations/civisibility_features.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/DataDog/dd-trace-go/v2/internal"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
@@ -83,14 +84,33 @@ func ensureSettingsInitialization(serviceName string) {
 		// upload the repository changes
 		var uploadChannel = make(chan struct{})
 		go func() {
+			defer func() {
+				close(uploadChannel)
+			}()
 			bytes, err := uploadRepositoryChanges()
 			if err != nil {
 				log.Error("civisibility: error uploading repository changes: %s", err.Error())
 			} else {
 				log.Debug("civisibility: uploaded %d bytes in pack files", bytes)
 			}
-			uploadChannel <- struct{}{}
 		}()
+
+		//Wait for the upload with timeout func
+		waitUpload := func(timeout time.Duration) bool {
+			select {
+			case <-uploadChannel:
+				// All ok, upload succeeded
+				return true
+			case <-time.After(timeout):
+				log.Warn("civisibility: timeout waiting for upload repository changes")
+				return false
+			}
+		}
+		// returns a closure suitable for PushCiVisibilityCloseAction that will wait
+		// for the upload to complete (or time out) using the given timeout.
+		waitUploadFactory := func(timeout time.Duration) func() {
+			return func() { waitUpload(timeout) }
+		}
 
 		// Get the CI Visibility settings payload for this test session
 		ciSettings, err := ciVisibilityClient.GetSettings()
@@ -98,16 +118,17 @@ func ensureSettingsInitialization(serviceName string) {
 			log.Error("civisibility: error getting CI visibility settings: %s", err.Error())
 			log.Debug("civisibility: no need to wait for the git upload to finish")
 			// Enqueue a close action to wait for the upload to finish before finishing the process
-			PushCiVisibilityCloseAction(func() {
-				<-uploadChannel
-			})
+			PushCiVisibilityCloseAction(waitUploadFactory(time.Minute))
 			return
 		}
 
 		// check if we need to wait for the upload to finish and repeat the settings request or we can just continue
 		if ciSettings.RequireGit {
 			log.Debug("civisibility: waiting for the git upload to finish and repeating the settings request")
-			<-uploadChannel
+			if !waitUpload(1 * time.Minute) {
+				log.Error("civisibility: error getting CI visibility settings due to timeout")
+				return
+			}
 			ciSettings, err = ciVisibilityClient.GetSettings()
 			if err != nil {
 				log.Error("civisibility: error getting CI visibility settings: %s", err.Error())
@@ -157,13 +178,11 @@ func ensureSettingsInitialization(serviceName string) {
 		// check if we need to wait for the upload to finish before continuing
 		if ciSettings.ImpactedTestsEnabled {
 			log.Debug("civisibility: impacted tests is enabled we need to wait for the upload to finish (for the unshallow process)")
-			<-uploadChannel
+			waitUpload(30 * time.Second)
 		} else {
 			log.Debug("civisibility: no need to wait for the git upload to finish")
 			// Enqueue a close action to wait for the upload to finish before finishing the process
-			PushCiVisibilityCloseAction(func() {
-				<-uploadChannel
-			})
+			PushCiVisibilityCloseAction(waitUploadFactory(time.Minute))
 		}
 
 		// set the ciVisibilitySettings with the settings from the backend
@@ -382,7 +401,7 @@ func uploadRepositoryChanges() (bytes int64, err error) {
 	}
 
 	// let's check if we could retrieve commit data
-	if !initialCommitData.IsOk {
+	if !commitsData.IsOk {
 		return 0, nil
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR fixes a possible deadlock by double waiting over a channel in CI Visibility mode.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We received a support ticket about a test session being cancelled after 10min

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
