### PR TITLE
feat(civisibility): add `branch` parameter to test management tests API

### DIFF
--- a/internal/civisibility/utils/net/test_management_tests_api.go
+++ b/internal/civisibility/utils/net/test_management_tests_api.go
@@ -33,6 +33,7 @@ type (
 		CommitSha     string `json:"sha"`
 		Module        string `json:"module,omitempty"`
 		CommitMessage string `json:"commit_message"`
+		Branch        string `json:"branch"`
 	}
 
 	testManagementTestsResponse struct {
@@ -91,6 +92,7 @@ func (c *client) GetTestManagementTests() (*TestManagementTestsResponseDataModul
 				RepositoryURL: c.repositoryURL,
 				CommitSha:     commitSha,
 				CommitMessage: commitMessage,
+				Branch:        c.branchName,
 			},
 		},
 	}

--- a/internal/civisibility/utils/net/test_management_tests_api_test.go
+++ b/internal/civisibility/utils/net/test_management_tests_api_test.go
@@ -59,6 +59,7 @@ func TestTestManagementTestsApiRequest(t *testing.T) {
 			assert.Equal(t, c.id, request.Data.ID, "ID mismatch")
 			assert.Equal(t, testManagementTestsRequestType, request.Data.Type, "Type mismatch")
 			assert.Equal(t, c.repositoryURL, request.Data.Attributes.RepositoryURL, "RepositoryURL mismatch")
+			assert.Equal(t, c.branchName, request.Data.Attributes.Branch, "Branch mismatch")
 			// Check the URL (remove the "/" prefix).
 			assert.Equal(t, testManagementTestsURLPath, r.URL.Path[1:], "URL path mismatch")
 


### PR DESCRIPTION
### What does this PR do?

Add `branch` parameter to the test management tests API 

### Motivation

New flaky PR gates require this parameter. 

**Note**: the backend does not do anything with `branch` yet, but the earlier we get this out the better, so more versions include it. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
