### PR TITLE
refactor(internal/config): extract shared configProvider logic into generic get function

### DIFF
--- a/internal/config/configprovider.go
+++ b/internal/config/configprovider.go
@@ -41,130 +41,75 @@ func defaultconfigProvider() *configProvider {
 	}
 }
 
-func (p *configProvider) getString(key string, def string) string {
-	// TODO: Eventually, iterate over all sources and report telemetry
+// get is a generic helper that iterates through config sources and parses values.
+// The parse function should return the parsed value and true if parsing succeeded, or false otherwise.
+func get[T any](p *configProvider, key string, def T, parse func(string) (T, bool)) T {
 	for _, source := range p.sources {
 		if v := source.get(key); v != "" {
 			var id string
 			if s, ok := source.(idAwareConfigSource); ok {
 				id = s.getID()
 			}
-			telemetry.RegisterAppConfigs(telemetry.Configuration{Name: key, Value: v, Origin: source.origin(), ID: id})
-			return v
+			if parsed, ok := parse(v); ok {
+				telemetry.RegisterAppConfigs(telemetry.Configuration{Name: key, Value: v, Origin: source.origin(), ID: id})
+				return parsed
+			}
 		}
 	}
 	telemetry.RegisterAppConfigs(telemetry.Configuration{Name: key, Value: def, Origin: telemetry.OriginDefault, ID: telemetry.EmptyID})
 	return def
+}
+
+func (p *configProvider) getString(key string, def string) string {
+	return get(p, key, def, func(v string) (string, bool) {
+		return v, true
+	})
 }
 
 func (p *configProvider) getBool(key string, def bool) bool {
-	for _, source := range p.sources {
-		if v := source.get(key); v != "" {
-			var id string
-			if s, ok := source.(idAwareConfigSource); ok {
-				id = s.getID()
-			}
-			if v == "true" {
-				telemetry.RegisterAppConfigs(telemetry.Configuration{Name: key, Value: v, Origin: source.origin(), ID: id})
-				return true
-			} else if v == "false" {
-				telemetry.RegisterAppConfigs(telemetry.Configuration{Name: key, Value: v, Origin: source.origin(), ID: id})
-				return false
-			}
+	return get(p, key, def, func(v string) (bool, bool) {
+		if v == "true" {
+			return true, true
+		} else if v == "false" {
+			return false, true
 		}
-	}
-	telemetry.RegisterAppConfigs(telemetry.Configuration{Name: key, Value: def, Origin: telemetry.OriginDefault, ID: telemetry.EmptyID})
-	return def
+		return false, false
+	})
 }
 
 func (p *configProvider) getInt(key string, def int) int {
-	for _, source := range p.sources {
-		if v := source.get(key); v != "" {
-			var id string
-			if s, ok := source.(idAwareConfigSource); ok {
-				id = s.getID()
-			}
-			intVal, err := strconv.Atoi(v)
-			if err == nil {
-				telemetry.RegisterAppConfigs(telemetry.Configuration{Name: key, Value: v, Origin: source.origin(), ID: id})
-				return intVal
-			}
-		}
-	}
-	telemetry.RegisterAppConfigs(telemetry.Configuration{Name: key, Value: def, Origin: telemetry.OriginDefault, ID: telemetry.EmptyID})
-	return def
+	return get(p, key, def, func(v string) (int, bool) {
+		intVal, err := strconv.Atoi(v)
+		return intVal, err == nil
+	})
 }
 
 func (p *configProvider) getMap(key string, def map[string]string) map[string]string {
-	for _, source := range p.sources {
-		if v := source.get(key); v != "" {
-			var id string
-			if s, ok := source.(idAwareConfigSource); ok {
-				id = s.getID()
-			}
-			m := parseMapString(v)
-			if len(m) > 0 {
-				telemetry.RegisterAppConfigs(telemetry.Configuration{Name: key, Value: v, Origin: source.origin(), ID: id})
-				return m
-			}
-		}
-	}
-	telemetry.RegisterAppConfigs(telemetry.Configuration{Name: key, Value: def, Origin: telemetry.OriginDefault, ID: telemetry.EmptyID})
-	return def
+	return get(p, key, def, func(v string) (map[string]string, bool) {
+		m := parseMapString(v)
+		return m, len(m) > 0
+	})
 }
 
 func (p *configProvider) getDuration(key string, def time.Duration) time.Duration {
-	for _, source := range p.sources {
-		if v := source.get(key); v != "" {
-			var id string
-			if s, ok := source.(idAwareConfigSource); ok {
-				id = s.getID()
-			}
-			d, err := time.ParseDuration(v)
-			if err == nil {
-				telemetry.RegisterAppConfigs(telemetry.Configuration{Name: key, Value: v, Origin: source.origin(), ID: id})
-				return d
-			}
-		}
-	}
-	telemetry.RegisterAppConfigs(telemetry.Configuration{Name: key, Value: def, Origin: telemetry.OriginDefault, ID: telemetry.EmptyID})
-	return def
+	return get(p, key, def, func(v string) (time.Duration, bool) {
+		d, err := time.ParseDuration(v)
+		return d, err == nil
+	})
 }
 
 func (p *configProvider) getFloat(key string, def float64) float64 {
-	for _, source := range p.sources {
-		if v := source.get(key); v != "" {
-			var id string
-			if s, ok := source.(idAwareConfigSource); ok {
-				id = s.getID()
-			}
-			floatVal, err := strconv.ParseFloat(v, 64)
-			if err == nil {
-				telemetry.RegisterAppConfigs(telemetry.Configuration{Name: key, Value: v, Origin: source.origin(), ID: id})
-				return floatVal
-			}
-		}
-	}
-	telemetry.RegisterAppConfigs(telemetry.Configuration{Name: key, Value: def, Origin: telemetry.OriginDefault, ID: telemetry.EmptyID})
-	return def
+	return get(p, key, def, func(v string) (float64, bool) {
+		floatVal, err := strconv.ParseFloat(v, 64)
+		return floatVal, err == nil
+	})
 }
 
 func (p *configProvider) getURL(key string, def *url.URL) *url.URL {
-	for _, source := range p.sources {
-		if v := source.get(key); v != "" {
-			var id string
-			if s, ok := source.(idAwareConfigSource); ok {
-				id = s.getID()
-			}
-			u, err := url.Parse(v)
-			if err == nil {
-				telemetry.RegisterAppConfigs(telemetry.Configuration{Name: key, Value: v, Origin: source.origin(), ID: id})
-				return u
-			}
-		}
-	}
-	telemetry.RegisterAppConfigs(telemetry.Configuration{Name: key, Value: def, Origin: telemetry.OriginDefault, ID: telemetry.EmptyID})
-	return def
+	return get(p, key, def, func(v string) (*url.URL, bool) {
+		u, err := url.Parse(v)
+		return u, err == nil
+	})
 }
 
 // normalizeKey is a helper function for configSource implementations to normalize the key to a valid environment variable name.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Extracts logic that is shared between configProvider "getters" into a generic `get` function

### Motivation
De-duplicate shared logic

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
