### PR TITLE
fix(contrib/haproxy): don't warn on each cache deletion

### DIFF
--- a/contrib/haproxy/stream-processing-offload/haproxy.go
+++ b/contrib/haproxy/stream-processing-offload/haproxy.go
@@ -52,9 +52,11 @@ func NewHAProxySPOA(config AppsecHAProxyConfig) *HAProxySPOA {
 			ContinueMessageFunc:  continueActionFunc,
 			BlockMessageFunc:     blockActionFunc,
 		}, instr),
-		requestStateCache: initRequestStateCache(func(rs *proxy.RequestState) {
+		requestStateCache: initRequestStateCache(func(rs *proxy.RequestState, timeout bool) {
 			_ = rs.Close()
-			instr.Logger().Warn("haproxy_spoa: backend server timeout reached, closing the span for the request.\n")
+			if timeout {
+				instr.Logger().Warn("haproxy_spoa: backend server timeout reached, closing the span for the request.\n")
+			}
 		}),
 	}
 }

--- a/go.work.sum
+++ b/go.work.sum
@@ -1652,6 +1652,7 @@ github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQA
 github.com/golang-jwt/jwt/v4 v4.4.3/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
 github.com/golang/glog v1.2.3 h1:oDTdz9f5VGVVNGu/Q7UXKWYsD0873HXLHdJUNBsSEKM=


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR fixed a bug where a warn was logged for all request deleted from the cache (basically every requests).
This bug was introduced first with:
- #4156 by handling the removal in the cache at each end of a request
- #4163 by removing the check on the ongoing status of the request

Now the warning is only logged when the cache item is evicted for a timeout.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Spammy bug discovered while reviewing rel-env logs.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
