### PR TITLE
ci(contrib/haproxy): deploy to reliability at each releases

### DIFF
--- a/.gitlab/docker-images-reliability-env.yml
+++ b/.gitlab/docker-images-reliability-env.yml
@@ -23,6 +23,10 @@ wait_for_github_workflow:
       when: on_success
     - if: '$CI_COMMIT_TAG =~ /^contrib\/envoyproxy\/go-control-plane\/v[0-9]+\.[0-9]+\.[0-9]+-docker\.[0-9]+/'
       when: on_success
+    - if: '$CI_COMMIT_TAG =~ /^contrib\/haproxy\/stream-processing-offload\/v[0-9]+\.[0-9]+\.[0-9]+/'
+      when: on_success
+    - if: '$CI_COMMIT_TAG =~ /^contrib\/haproxy\/stream-processing-offload\/v[0-9]+\.[0-9]+\.[0-9]+-docker\.[0-9]+/'
+      when: on_success
     - when: manual
       allow_failure: true
 
@@ -87,7 +91,10 @@ prepare_release_tag:
 
   script:
     - |
-      echo "ENVOY_RELEASE_TAG=${CI_COMMIT_TAG#contrib/envoyproxy/go-control-plane/}" > release_tag.env
+      cat > release_tag.env <<EOF
+      ENVOY_RELEASE_TAG=${CI_COMMIT_TAG#contrib/envoyproxy/go-control-plane/}
+      HAPROXY_SPOA_RELEASE_TAG=${CI_COMMIT_TAG#contrib/haproxy/stream-processing-offload/}
+      EOF
 
   artifacts:
     reports:
@@ -99,6 +106,13 @@ deploy_new_release_service_extensions:
   needs:
     - prepare_release_tag
 
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^contrib\/envoyproxy\/go-control-plane\/v[0-9]+\.[0-9]+\.[0-9]+/'
+      when: always
+    - if: '$CI_COMMIT_TAG =~ /^contrib\/envoyproxy\/go-control-plane\/v[0-9]+\.[0-9]+\.[0-9]+-docker\.[0-9]+/'
+      when: always
+    - when: never
+
   trigger:
     project: DataDog/apm-reliability/datadog-reliability-env
     branch: master
@@ -109,3 +123,27 @@ deploy_new_release_service_extensions:
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA
     ENVOY_EXT_PROC_RELEASED: "true"
     ENVOY_RELEASE_TAG: $ENVOY_RELEASE_TAG
+
+deploy_new_release_haproxy_spoa:
+  stage: docker-images-reliability-env
+
+  needs:
+    - prepare_release_tag
+
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^contrib\/haproxy\/stream-processing-offload\/v[0-9]+\.[0-9]+\.[0-9]+/'
+      when: always
+    - if: '$CI_COMMIT_TAG =~ /^contrib\/haproxy\/stream-processing-offload\/v[0-9]+\.[0-9]+\.[0-9]+-docker\.[0-9]+/'
+      when: always
+    - when: never
+
+  trigger:
+    project: DataDog/apm-reliability/datadog-reliability-env
+    branch: master
+  variables:
+    UPSTREAM_SUB_PROJECT_NAME: "haproxy"
+    UPSTREAM_PIPELINE_ID: $CI_PIPELINE_ID
+    UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME
+    UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA
+    HAPROXY_SPOA_RELEASED: "true"
+    HAPROXY_SPOA_RELEASE_TAG: $HAPROXY_SPOA_RELEASE_TAG


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR adds the deployment of the HAProxy SPOA docker image after its release.
Following the same implementation and detection as made in #3761.

This PR is linked to the HAProxy SPOA implementation PR in rel-env https://github.com/DataDog/datadog-reliability-env/pull/1172.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

QA.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `golangci-lint run` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


Unsure? Have a question? Request a review!
