### PR TITLE
feat(remoteconfig): add support to the RC client for unsubscribing from a product

### DIFF
--- a/ddtrace/tracer/remote_config.go
+++ b/ddtrace/tracer/remote_config.go
@@ -385,10 +385,10 @@ func (t *tracer) startRemoteConfig(rcConfig remoteconfig.ClientConfig) error {
 	var dynamicInstrumentationError, apmTracingError error
 
 	if t.config.dynamicInstrumentationEnabled {
-		liveDebuggingError := remoteconfig.Subscribe(
+		_, liveDebuggingError := remoteconfig.Subscribe(
 			"LIVE_DEBUGGING", t.dynamicInstrumentationRCUpdate,
 		)
-		liveDebuggingSymDBError := remoteconfig.Subscribe(
+		_, liveDebuggingSymDBError := remoteconfig.Subscribe(
 			"LIVE_DEBUGGING_SYMBOL_DB", t.dynamicInstrumentationSymDBRCUpdate,
 		)
 		if liveDebuggingError != nil && liveDebuggingSymDBError != nil {
@@ -405,7 +405,7 @@ func (t *tracer) startRemoteConfig(rcConfig remoteconfig.ClientConfig) error {
 
 	initalizeRC.Do(initalizeDynamicInstrumentationRemoteConfigState)
 
-	apmTracingError = remoteconfig.Subscribe(
+	_, apmTracingError = remoteconfig.Subscribe(
 		state.ProductAPMTracing,
 		t.onRemoteConfigUpdate,
 		remoteconfig.APMTracingSampleRate,

--- a/internal/appsec/remoteconfig.go
+++ b/internal/appsec/remoteconfig.go
@@ -306,7 +306,8 @@ func (a *appsec) enableRemoteActivation() error {
 		return errors.New("no valid remote configuration client")
 	}
 	log.Debug("appsec: Remote Config: subscribing to ASM_FEATURES updates...")
-	return remoteconfig.Subscribe(state.ProductASMFeatures, a.handleASMFeatures, remoteconfig.ASMActivation)
+	_, err := remoteconfig.Subscribe(state.ProductASMFeatures, a.handleASMFeatures, remoteconfig.ASMActivation)
+	return err
 }
 
 var baseCapabilities = [...]remoteconfig.Capability{

--- a/internal/env/supported_configurations.json
+++ b/internal/env/supported_configurations.json
@@ -102,10 +102,10 @@
     "DD_CIVISIBILITY_SUBTEST_FEATURES_ENABLED": [
       "A"
     ],
-    "DD_CIVISIBILITY_USE_NOOP_TRACER": [
+    "DD_CIVISIBILITY_TOTAL_FLAKY_RETRY_COUNT": [
       "A"
     ],
-    "DD_CIVISIBILITY_TOTAL_FLAKY_RETRY_COUNT": [
+    "DD_CIVISIBILITY_USE_NOOP_TRACER": [
       "A"
     ],
     "DD_CUSTOM_TRACE_ID": [
@@ -217,6 +217,9 @@
       "A"
     ],
     "DD_LOGGING_RATE": [
+      "A"
+    ],
+    "DD_METRICS_OTEL_ENABLED": [
       "A"
     ],
     "DD_PIPELINE_EXECUTION_ID": [
@@ -639,28 +642,25 @@
     "DD_VERSION": [
       "A"
     ],
-    "DD_METRICS_OTEL_ENABLED": [
-      "A"
-    ],
     "OTEL_EXPORTER_OTLP_ENDPOINT": [
       "A"
     ],
-    "OTEL_EXPORTER_OTLP_METRICS_HEADERS": [
-      "A"
-    ],
-    "OTEL_EXPORTER_OTLP_PROTOCOL": [
-      "A"
-    ],
-    "OTEL_EXPORTER_OTLP_METRICS_TIMEOUT": [
-      "A"
-    ],
     "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": [
+      "A"
+    ],
+    "OTEL_EXPORTER_OTLP_METRICS_HEADERS": [
       "A"
     ],
     "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": [
       "A"
     ],
     "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE": [
+      "A"
+    ],
+    "OTEL_EXPORTER_OTLP_METRICS_TIMEOUT": [
+      "A"
+    ],
+    "OTEL_EXPORTER_OTLP_PROTOCOL": [
       "A"
     ],
     "OTEL_LOGS_EXPORTER": [

--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -149,16 +149,33 @@ type Client struct {
 	stop       chan struct{}
 
 	// When acquiring several locks and using defer to release them, make sure to acquire the locks in the following order:
-	callbacks               []Callback
-	_callbacksMu            sync.RWMutex
-	products                map[string]struct{}
-	productsMu              sync.RWMutex
-	productsWithCallbacks   map[string]ProductCallback
-	productsWithCallbacksMu sync.RWMutex
-	capabilities            map[Capability]struct{}
-	capabilitiesMu          sync.RWMutex
+	callbacks       []Callback
+	_callbacksMu    sync.RWMutex
+	products        map[string]struct{}
+	productsMu      sync.RWMutex
+	subscriptionsMu struct {
+		sync.RWMutex
+		subs        []subscription
+		idAllocator int
+	}
+	// capabilities contains the capabilities that have been registered through
+	// RegisterCapability. The capabilities of the subscribers added through
+	// RegisterSubscribers are reflected inside subscriptions.
+	capabilities   map[Capability]struct{}
+	capabilitiesMu sync.RWMutex
 
 	lastError error
+}
+
+// subscription represents a callback that was registered to run on updates to a
+// specific product.
+type subscription struct {
+	// id uniquely identifies this subscription. It is used to remove a specific
+	// subscription.
+	id           int
+	product      string
+	capabilities []Capability
+	callback     ProductCallback
 }
 
 var (
@@ -180,16 +197,15 @@ func newClient(config ClientConfig) (*Client, error) {
 	}
 
 	return &Client{
-		ClientConfig:          config,
-		clientID:              generateID(),
-		endpoint:              fmt.Sprintf("%s/v0.7/config", config.AgentURL),
-		repository:            repo,
-		stop:                  make(chan struct{}),
-		lastError:             nil,
-		callbacks:             []Callback{},
-		capabilities:          map[Capability]struct{}{},
-		products:              map[string]struct{}{},
-		productsWithCallbacks: make(map[string]ProductCallback),
+		ClientConfig: config,
+		clientID:     generateID(),
+		endpoint:     fmt.Sprintf("%s/v0.7/config", config.AgentURL),
+		repository:   repo,
+		stop:         make(chan struct{}),
+		lastError:    nil,
+		callbacks:    []Callback{},
+		capabilities: map[Capability]struct{}{},
+		products:     map[string]struct{}{},
 	}, nil
 }
 
@@ -331,28 +347,67 @@ func (c *Client) updateState() {
 	c.lastError = c.applyUpdate(&update)
 }
 
-// Subscribe registers a product and its callback to be invoked when the client receives configuration updates.
-// Subscribe should be preferred over RegisterProduct and RegisterCallback if your callback only handles a single product.
-func Subscribe(product string, callback ProductCallback, capabilities ...Capability) error {
+type SubscriptionToken int
+
+// Subscribe registers a product and its callback to be invoked when the client
+// receives configuration updates for the specified product. The returned token
+// can be passed to Unsubscribe to remove the subscription.
+//
+// It is legal to call Subscribe multiple times with the same product, and even
+// to call it multiple times with the same product and different capabilities.
+// Note, however, that the capabilities reported to RC are the union of all
+// capabilities passed to Subscribe and RegisterCapability (across all
+// products); in other words, the capabilities are not tied to a specific
+// product or subscription.
+//
+// Subscribe should be preferred over RegisterProduct and RegisterCallback if
+// your callback only handles a single product.
+func Subscribe(product string, callback ProductCallback, capabilities ...Capability) (SubscriptionToken, error) {
 	if client == nil {
-		return ErrClientNotStarted
+		return 0, ErrClientNotStarted
 	}
 	client.productsMu.RLock()
 	defer client.productsMu.RUnlock()
 	if _, found := client.products[product]; found {
-		return fmt.Errorf("product %s already registered via RegisterProduct", product)
+		return 0, fmt.Errorf("product %s already registered via RegisterProduct", product)
 	}
 
-	client.productsWithCallbacksMu.Lock()
-	defer client.productsWithCallbacksMu.Unlock()
-	client.productsWithCallbacks[product] = callback
+	client.subscriptionsMu.Lock()
+	defer client.subscriptionsMu.Unlock()
+	client.subscriptionsMu.idAllocator++
+	id := client.subscriptionsMu.idAllocator
+	sub := subscription{
+		id:           id,
+		product:      product,
+		capabilities: capabilities,
+		callback:     callback,
+	}
+	client.subscriptionsMu.subs = append(client.subscriptionsMu.subs, sub)
 
 	client.capabilitiesMu.Lock()
 	defer client.capabilitiesMu.Unlock()
 	for _, cap := range capabilities {
 		client.capabilities[cap] = struct{}{}
 	}
-	return nil
+	return SubscriptionToken(id), nil
+}
+
+// Unsubscribe removes a subscription previously registered via Subscribe. The
+// capabilities associated with that subscription will no longer be reported to
+// RC.
+func Unsubscribe(token SubscriptionToken) error {
+	if client == nil {
+		return ErrClientNotStarted
+	}
+	client.subscriptionsMu.Lock()
+	defer client.subscriptionsMu.Unlock()
+	for i, sub := range client.subscriptionsMu.subs {
+		if sub.id == int(token) {
+			client.subscriptionsMu.subs = append(client.subscriptionsMu.subs[:i], client.subscriptionsMu.subs[i+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("subscription %d not found", token)
 }
 
 // RegisterCallback allows registering a callback that will be invoked when the client
@@ -391,11 +446,14 @@ func RegisterProduct(p string) error {
 	}
 	client.productsMu.Lock()
 	defer client.productsMu.Unlock()
-	client.productsWithCallbacksMu.RLock()
-	defer client.productsWithCallbacksMu.RUnlock()
-	if _, found := client.productsWithCallbacks[p]; found {
-		return fmt.Errorf("product %s already registered via Subscribe", p)
+	client.subscriptionsMu.RLock()
+	defer client.subscriptionsMu.RUnlock()
+	for _, s := range client.subscriptionsMu.subs {
+		if s.product == p {
+			return fmt.Errorf("product %s already registered via Subscribe", p)
+		}
 	}
+
 	client.products[p] = struct{}{}
 	return nil
 }
@@ -418,11 +476,21 @@ func HasProduct(p string) (bool, error) {
 	}
 	client.productsMu.RLock()
 	defer client.productsMu.RUnlock()
-	client.productsWithCallbacksMu.RLock()
-	defer client.productsWithCallbacksMu.RUnlock()
+
 	_, found := client.products[p]
-	_, foundWithCallback := client.productsWithCallbacks[p]
-	return found || foundWithCallback, nil
+	if found {
+		return true, nil
+	}
+
+	client.subscriptionsMu.RLock()
+	defer client.subscriptionsMu.RUnlock()
+	for _, s := range client.subscriptionsMu.subs {
+		if s.product == p {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 // RegisterCapability adds a capability to the list of capabilities exposed by the client when requesting
@@ -467,6 +535,15 @@ func (c *Client) allCapabilities() *big.Int {
 	for i := range c.capabilities {
 		capa.SetBit(capa, int(i), 1)
 	}
+
+	c.subscriptionsMu.RLock()
+	defer c.subscriptionsMu.RUnlock()
+	for _, s := range c.subscriptionsMu.subs {
+		for _, cap := range s.capabilities {
+			capa.SetBit(capa, int(cap), 1)
+		}
+	}
+
 	return capa
 }
 
@@ -479,11 +556,11 @@ func (c *Client) globalCallbacks() []Callback {
 }
 
 func (c *Client) productCallbacks() map[string]ProductCallback {
-	c.productsWithCallbacksMu.RLock()
-	defer c.productsWithCallbacksMu.RUnlock()
-	callbacks := make(map[string]ProductCallback, len(c.productsWithCallbacks))
-	for k, v := range c.productsWithCallbacks {
-		callbacks[k] = v
+	c.subscriptionsMu.RLock()
+	defer c.subscriptionsMu.RUnlock()
+	callbacks := make(map[string]ProductCallback, len(c.subscriptionsMu.subs))
+	for _, v := range c.subscriptionsMu.subs {
+		callbacks[v.product] = v.callback
 	}
 	return callbacks
 }
@@ -491,15 +568,24 @@ func (c *Client) productCallbacks() map[string]ProductCallback {
 func (c *Client) allProducts() []string {
 	c.productsMu.RLock()
 	defer c.productsMu.RUnlock()
-	c.productsWithCallbacksMu.RLock()
-	defer c.productsWithCallbacksMu.RUnlock()
-	products := make([]string, 0, len(c.products)+len(c.productsWithCallbacks))
+	c.subscriptionsMu.RLock()
+	defer c.subscriptionsMu.RUnlock()
+
+	// Dedup products across all subscriptions and registered products.
+	ps := make(map[string]struct{}, len(c.products)+len(c.subscriptionsMu.subs))
+
 	for p := range c.products {
+		ps[p] = struct{}{}
+	}
+	for _, s := range c.subscriptionsMu.subs {
+		ps[s.product] = struct{}{}
+	}
+
+	products := make([]string, 0, len(ps))
+	for p := range ps {
 		products = append(products, p)
 	}
-	for p := range c.productsWithCallbacks {
-		products = append(products, p)
-	}
+
 	return products
 }
 

--- a/internal/remoteconfig/remoteconfig_test.go
+++ b/internal/remoteconfig/remoteconfig_test.go
@@ -19,8 +19,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/DataDog/dd-trace-go/v2/internal/processtags"
+
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 )
 
 // The RC client relies on Repository (in the datadog-agent) which performs config signature validation
@@ -80,7 +81,9 @@ func TestRCClient(t *testing.T) {
 		require.NoError(t, err)
 
 		cfgPath := "datadog/2/APM_TRACING/foo/bar"
-		err = Subscribe(state.ProductAPMTracing, func(u ProductUpdate) map[string]state.ApplyStatus {
+		updates := new(int)
+		tok, err := Subscribe(state.ProductAPMTracing, func(u ProductUpdate) map[string]state.ApplyStatus {
+			*updates++
 			statuses := map[string]state.ApplyStatus{}
 			require.NotNil(t, u)
 			require.Len(t, u, 1)
@@ -92,8 +95,18 @@ func TestRCClient(t *testing.T) {
 		require.NoError(t, err)
 
 		resp := genUpdateResponse([]byte("test"), cfgPath)
-		err := client.applyUpdate(resp)
+		err = client.applyUpdate(resp)
 		require.NoError(t, err)
+		require.Equal(t, 1, *updates)
+		*updates = 0
+
+		// Check that the callback is not called again after Unsubscribe.
+		err = Unsubscribe(tok)
+		cfgPath2 := "datadog/2/APM_TRACING/foo/baz"
+		resp = genUpdateResponse([]byte("test"), cfgPath2)
+		err = client.applyUpdate(resp)
+		require.NoError(t, err)
+		require.Equal(t, 0, *updates)
 	})
 }
 
@@ -324,29 +337,34 @@ func TestSubscribe(t *testing.T) {
 	var callback Callback = func(_ map[string]ProductUpdate) map[string]state.ApplyStatus { return nil }
 	var pCallback ProductCallback = func(_ ProductUpdate) map[string]state.ApplyStatus { return nil }
 
-	err = Subscribe("my-product", pCallback)
+	tok1, err := Subscribe("my-product", pCallback)
 	require.NoError(t, err)
 	require.Len(t, client.callbacks, 0)
-	require.Len(t, client.productsWithCallbacks, 1)
-	require.Equal(t, reflect.ValueOf(pCallback), reflect.ValueOf(client.productsWithCallbacks["my-product"]))
+	require.Len(t, client.subscriptionsMu.subs, 1)
+	require.Equal(t, reflect.ValueOf(pCallback), reflect.ValueOf(client.subscriptionsMu.subs[0].callback))
 
 	err = RegisterProduct("my-product")
 	require.Error(t, err)
-	require.Len(t, client.productsWithCallbacks, 1)
+	require.Len(t, client.subscriptionsMu.subs, 1)
 
 	err = RegisterProduct("my-second-product")
 	require.NoError(t, err)
-	require.Len(t, client.productsWithCallbacks, 1)
+	require.Len(t, client.subscriptionsMu.subs, 1)
 
-	err = Subscribe("my-second-product", pCallback)
+	_, err = Subscribe("my-second-product", pCallback)
 	require.Error(t, err)
-	require.Len(t, client.productsWithCallbacks, 1)
+	require.Len(t, client.subscriptionsMu.subs, 1)
 
 	err = RegisterCallback(callback)
 	require.NoError(t, err)
 	require.Len(t, client.callbacks, 1)
-	require.Len(t, client.productsWithCallbacks, 1)
+	require.Len(t, client.subscriptionsMu.subs, 1)
 	require.Equal(t, reflect.ValueOf(callback), reflect.ValueOf(client.callbacks[0]))
+
+	err = Unsubscribe(tok1)
+	require.NoError(t, err)
+	require.Len(t, client.subscriptionsMu.subs, 0)
+	require.Len(t, client.callbacks, 1)
 }
 
 func TestNewUpdateRequest(t *testing.T) {
@@ -363,7 +381,7 @@ func TestNewUpdateRequest(t *testing.T) {
 	require.NoError(t, err)
 	err = RegisterCapability(ASMActivation)
 	require.NoError(t, err)
-	err = Subscribe("my-second-product", func(_ ProductUpdate) map[string]state.ApplyStatus { return nil }, APMTracingSampleRate)
+	_, err = Subscribe("my-second-product", func(_ ProductUpdate) map[string]state.ApplyStatus { return nil }, APMTracingSampleRate)
 	require.NoError(t, err)
 
 	b, err := client.newUpdateRequest()
@@ -373,7 +391,7 @@ func TestNewUpdateRequest(t *testing.T) {
 	err = json.Unmarshal(b.Bytes(), &req)
 	require.NoError(t, err)
 
-	require.Equal(t, []string{"my-product", "my-second-product"}, req.Client.Products)
+	require.ElementsMatch(t, []string{"my-product", "my-second-product"}, req.Client.Products)
 	require.Equal(t, []uint8([]byte{0x10, 0x2}), req.Client.Capabilities)
 	require.Equal(t, "go", req.Client.ClientTracer.Language)
 	require.Equal(t, "test-svc", req.Client.ClientTracer.Service)
@@ -397,7 +415,7 @@ func TestProcessTags(t *testing.T) {
 	require.NoError(t, err)
 	err = RegisterCapability(ASMActivation)
 	require.NoError(t, err)
-	err = Subscribe("my-second-product", func(_ ProductUpdate) map[string]state.ApplyStatus { return nil }, APMTracingSampleRate)
+	_, err = Subscribe("my-second-product", func(_ ProductUpdate) map[string]state.ApplyStatus { return nil }, APMTracingSampleRate)
 	require.NoError(t, err)
 
 	t.Run("enabled", func(t *testing.T) {

--- a/openfeature/remoteconfig.go
+++ b/openfeature/remoteconfig.go
@@ -29,7 +29,7 @@ func startWithRemoteConfig(config ProviderConfig) (*DatadogProvider, error) {
 	}
 
 	// Subscribe to Remote Config updates for the OpenFeature product
-	if err := remoteconfig.Subscribe(ffeProductName, provider.rcCallback, ffeCapability); err != nil {
+	if _, err := remoteconfig.Subscribe(ffeProductName, provider.rcCallback, ffeCapability); err != nil {
 		return nil, fmt.Errorf("failed to subscribe to Remote Config: %w (did you already create a provider ?)", err)
 	}
 


### PR DESCRIPTION
Unsubscribing removes a previously registered callback from being invoked when its specific product receives an update. When the last subscription for a particular product is remove, remote config is not polled for that product anymore.

This will be useful for remotely disabling Live Debugger on a tracer: once disabled, the previously-established subscription to the respective RC product needs to be terminated.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.


