### PR TITLE
chore(config): migrate logToStdout and isLambdaFunction

### DIFF
--- a/ddtrace/tracer/log.go
+++ b/ddtrace/tracer/log.go
@@ -145,7 +145,7 @@ func logStartup(t *tracer) {
 		ProfilerEndpointsEnabled:    t.config.internalConfig.ProfilerEndpoints(),
 		Architecture:                runtime.GOARCH,
 		GlobalService:               globalconfig.ServiceName(),
-		LambdaMode:                  fmt.Sprintf("%t", t.config.logToStdout),
+		LambdaMode:                  fmt.Sprintf("%t", t.config.internalConfig.LogToStdout()),
 		AgentFeatures:               t.config.agent,
 		Integrations:                t.config.integrations,
 		AppSec:                      appsec.Enabled(),
@@ -165,7 +165,7 @@ func logStartup(t *tracer) {
 	if limit, ok := t.rulesSampling.TraceRateLimit(); ok {
 		info.SampleRateLimit = fmt.Sprintf("%v", limit)
 	}
-	if !t.config.logToStdout {
+	if !t.config.internalConfig.LogToStdout() {
 		if err := checkEndpoint(t.config.httpClient, t.config.transport.endpoint(), t.config.traceProtocol); err != nil {
 			info.AgentError = fmt.Sprintf("%s", err.Error())
 			log.Warn("DIAGNOSTICS Unable to reach agent intake: %s", err.Error())

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -40,7 +40,7 @@ func startTelemetry(c *config) telemetry.Client {
 		{Name: "agent_feature_drop_p0s", Value: c.agent.DropP0s},
 		{Name: "stats_computation_enabled", Value: c.canComputeStats()},
 		{Name: "dogstatsd_port", Value: c.agent.StatsdPort},
-		{Name: "lambda_mode", Value: c.logToStdout},
+		{Name: "lambda_mode", Value: c.internalConfig.LogToStdout()},
 		{Name: "send_retries", Value: c.sendRetries},
 		{Name: "retry_interval", Value: c.retryInterval},
 		{Name: "trace_startup_logs_enabled", Value: c.internalConfig.LogStartup()},
@@ -111,7 +111,7 @@ func startTelemetry(c *config) telemetry.Client {
 		HTTPClient: c.httpClient,
 		AgentURL:   c.agentURL.String(),
 	}
-	if c.logToStdout || c.ciVisibilityAgentless {
+	if c.internalConfig.LogToStdout() || c.ciVisibilityAgentless {
 		cfg.APIKey = env.Get("DD_API_KEY")
 	}
 	client, err := telemetry.NewClient(c.serviceName, c.env, c.version, cfg)

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -402,7 +402,7 @@ func newUnstartedTracer(opts ...StartOption) (t *tracer, err error) {
 	var writer traceWriter
 	if c.ciVisibilityEnabled {
 		writer = newCiVisibilityTraceWriter(c)
-	} else if c.logToStdout {
+	} else if c.internalConfig.LogToStdout() {
 		writer = newLogTraceWriter(c, statsd)
 	} else {
 		writer = newAgentTraceWriter(c, sampler, statsd)
@@ -982,7 +982,7 @@ func (t *tracer) TracerConf() TracerConf {
 		VersionTag:           t.config.version,
 		ServiceTag:           t.config.serviceName,
 		TracingAsTransport:   t.config.tracingAsTransport,
-		isLambdaFunction:     t.config.isLambdaFunction,
+		isLambdaFunction:     t.config.internalConfig.IsLambdaFunction(),
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->

### What does this PR do?

Migrate tracer to use Config.logToStdout and Config.isLambdaFunction instead of its own logToStdout and isLambdaFunction

Note: Neither of these options are user-configurable.

### Motivation

[datadoghq.atlassian.net/browse/APMAPI-1748](http://datadoghq.atlassian.net/browse/APMAPI-1748)

### Reviewer's Checklist

<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!