### PR TITLE
chore(config): migrate partialFlushEnabled

### DIFF
--- a/ddtrace/tracer/log.go
+++ b/ddtrace/tracer/log.go
@@ -149,7 +149,7 @@ func logStartup(t *tracer) {
 		AgentFeatures:               t.config.agent,
 		Integrations:                t.config.integrations,
 		AppSec:                      appsec.Enabled(),
-		PartialFlushEnabled:         t.config.partialFlushEnabled,
+		PartialFlushEnabled:         t.config.internalConfig.PartialFlushEnabled(),
 		PartialFlushMinSpans:        t.config.partialFlushMinSpans,
 		Orchestrion:                 t.config.orchestrionCfg,
 		FeatureFlags:                featureFlags,

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -262,10 +262,6 @@ type config struct {
 	// Value from DD_TRACE_PARTIAL_FLUSH_MIN_SPANS, default 1000.
 	partialFlushMinSpans int
 
-	// partialFlushEnabled specifices whether the tracer should enable partial flushing. Value
-	// from DD_TRACE_PARTIAL_FLUSH_ENABLED, default false.
-	partialFlushEnabled bool
-
 	// statsComputationEnabled enables client-side stats computation (aka trace metrics).
 	statsComputationEnabled bool
 
@@ -422,7 +418,6 @@ func newConfig(opts ...StartOption) (*config, error) {
 		c.spanTimeout = internal.DurationEnv("DD_TRACE_ABANDONED_SPAN_TIMEOUT", 10*time.Minute)
 	}
 	c.statsComputationEnabled = internal.BoolEnv("DD_TRACE_STATS_COMPUTATION_ENABLED", true)
-	c.partialFlushEnabled = internal.BoolEnv("DD_TRACE_PARTIAL_FLUSH_ENABLED", false)
 	c.partialFlushMinSpans = internal.IntEnv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", partialFlushMinSpansDefault)
 	if c.partialFlushMinSpans <= 0 {
 		log.Warn("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS=%d is not a valid value, setting to default %d", c.partialFlushMinSpans, partialFlushMinSpansDefault)
@@ -1277,7 +1272,7 @@ func WithDebugSpansMode(timeout time.Duration) StartOption {
 // is disabled by default.
 func WithPartialFlushing(numSpans int) StartOption {
 	return func(c *config) {
-		c.partialFlushEnabled = true
+		c.internalConfig.SetPartialFlushEnabled(true, internalconfig.OriginCode)
 		c.partialFlushMinSpans = numSpans
 	}
 }

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -1659,28 +1659,28 @@ func TestPartialFlushing(t *testing.T) {
 	t.Run("None", func(t *testing.T) {
 		c, err := newTestConfig()
 		assert.NoError(t, err)
-		assert.False(t, c.partialFlushEnabled)
+		assert.False(t, c.internalConfig.PartialFlushEnabled())
 		assert.Equal(t, partialFlushMinSpansDefault, c.partialFlushMinSpans)
 	})
 	t.Run("Disabled-DefaultMinSpans", func(t *testing.T) {
 		t.Setenv("DD_TRACE_PARTIAL_FLUSH_ENABLED", "false")
 		c, err := newTestConfig()
 		assert.NoError(t, err)
-		assert.False(t, c.partialFlushEnabled)
+		assert.False(t, c.internalConfig.PartialFlushEnabled())
 		assert.Equal(t, partialFlushMinSpansDefault, c.partialFlushMinSpans)
 	})
 	t.Run("Default-SetMinSpans", func(t *testing.T) {
 		t.Setenv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", "10")
 		c, err := newTestConfig()
 		assert.NoError(t, err)
-		assert.False(t, c.partialFlushEnabled)
+		assert.False(t, c.internalConfig.PartialFlushEnabled())
 		assert.Equal(t, 10, c.partialFlushMinSpans)
 	})
 	t.Run("Enabled-DefaultMinSpans", func(t *testing.T) {
 		t.Setenv("DD_TRACE_PARTIAL_FLUSH_ENABLED", "true")
 		c, err := newTestConfig()
 		assert.NoError(t, err)
-		assert.True(t, c.partialFlushEnabled)
+		assert.True(t, c.internalConfig.PartialFlushEnabled())
 		assert.Equal(t, partialFlushMinSpansDefault, c.partialFlushMinSpans)
 	})
 	t.Run("Enabled-SetMinSpans", func(t *testing.T) {
@@ -1688,7 +1688,7 @@ func TestPartialFlushing(t *testing.T) {
 		t.Setenv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", "10")
 		c, err := newTestConfig()
 		assert.NoError(t, err)
-		assert.True(t, c.partialFlushEnabled)
+		assert.True(t, c.internalConfig.PartialFlushEnabled())
 		assert.Equal(t, 10, c.partialFlushMinSpans)
 	})
 	t.Run("Enabled-SetMinSpansNegative", func(t *testing.T) {
@@ -1696,14 +1696,14 @@ func TestPartialFlushing(t *testing.T) {
 		t.Setenv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", "-1")
 		c, err := newTestConfig()
 		assert.NoError(t, err)
-		assert.True(t, c.partialFlushEnabled)
+		assert.True(t, c.internalConfig.PartialFlushEnabled())
 		assert.Equal(t, partialFlushMinSpansDefault, c.partialFlushMinSpans)
 	})
 	t.Run("WithPartialFlushOption", func(t *testing.T) {
 		c, err := newTestConfig()
 		assert.NoError(t, err)
 		WithPartialFlushing(20)(c)
-		assert.True(t, c.partialFlushEnabled)
+		assert.True(t, c.internalConfig.PartialFlushEnabled())
 		assert.Equal(t, 20, c.partialFlushMinSpans)
 	})
 }

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -974,7 +974,7 @@ func (t *tracer) TracerConf() TracerConf {
 		CanDropP0s:           t.config.canDropP0s(),
 		DebugAbandonedSpans:  t.config.debugAbandonedSpans,
 		Disabled:             !t.config.enabled.current,
-		PartialFlush:         t.config.partialFlushEnabled,
+		PartialFlush:         t.config.internalConfig.PartialFlushEnabled(),
 		PartialFlushMinSpans: t.config.partialFlushMinSpans,
 		PeerServiceDefaults:  t.config.peerServiceDefaultsEnabled,
 		PeerServiceMappings:  t.config.peerServiceMappings,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,22 +42,24 @@ type Config struct {
 	agentURL *url.URL
 	debug    bool
 	// logStartup, when true, causes various startup info to be written when the tracer starts.
-	logStartup                    bool
-	serviceName                   string
-	version                       string
-	env                           string
-	serviceMappings               map[string]string
-	hostname                      string
-	runtimeMetrics                bool
-	runtimeMetricsV2              bool
-	profilerHotspots              bool
-	profilerEndpoints             bool
-	spanAttributeSchemaVersion    int
-	peerServiceDefaultsEnabled    bool
-	peerServiceMappings           map[string]string
-	debugAbandonedSpans           bool
-	spanTimeout                   time.Duration
-	partialFlushMinSpans          int
+	logStartup                 bool
+	serviceName                string
+	version                    string
+	env                        string
+	serviceMappings            map[string]string
+	hostname                   string
+	runtimeMetrics             bool
+	runtimeMetricsV2           bool
+	profilerHotspots           bool
+	profilerEndpoints          bool
+	spanAttributeSchemaVersion int
+	peerServiceDefaultsEnabled bool
+	peerServiceMappings        map[string]string
+	debugAbandonedSpans        bool
+	spanTimeout                time.Duration
+	partialFlushMinSpans       int
+	// partialFlushEnabled specifices whether the tracer should enable partial flushing. Value
+	// from DD_TRACE_PARTIAL_FLUSH_ENABLED, default false.
 	partialFlushEnabled           bool
 	statsComputationEnabled       bool
 	dataStreamsMonitoringEnabled  bool
@@ -283,4 +285,17 @@ func (c *Config) SetTraceRateLimitPerSecond(rate float64, origin telemetry.Origi
 	defer c.mu.Unlock()
 	c.traceRateLimitPerSecond = rate
 	telemetry.RegisterAppConfig("DD_TRACE_RATE_LIMIT", rate, origin)
+}
+
+func (c *Config) PartialFlushEnabled() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.partialFlushEnabled
+}
+
+func (c *Config) SetPartialFlushEnabled(enabled bool, origin telemetry.Origin) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.partialFlushEnabled = enabled
+	telemetry.RegisterAppConfig("DD_TRACE_PARTIAL_FLUSH_ENABLED", enabled, origin)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Migrates tracer to using Config.partialFlushEnabled rather than its own partialFlushEnabled

### Motivation
[APMAPI-1745](https://datadoghq.atlassian.net/browse/APMAPI-1745)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!


[APMAPI-1745]: https://datadoghq.atlassian.net/browse/APMAPI-1745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ