### PR TITLE
chore(config): migrate partialFlushMinSpans

### DIFF
--- a/ddtrace/tracer/log.go
+++ b/ddtrace/tracer/log.go
@@ -150,7 +150,7 @@ func logStartup(t *tracer) {
 		Integrations:                t.config.integrations,
 		AppSec:                      appsec.Enabled(),
 		PartialFlushEnabled:         t.config.internalConfig.PartialFlushEnabled(),
-		PartialFlushMinSpans:        t.config.partialFlushMinSpans,
+		PartialFlushMinSpans:        t.config.internalConfig.PartialFlushMinSpans(),
 		Orchestrion:                 t.config.orchestrionCfg,
 		FeatureFlags:                featureFlags,
 		PropagationStyleInject:      injectorNames,

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/internal/tracerstats"
 	sharedinternal "github.com/DataDog/dd-trace-go/v2/internal"
+	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/samplernames"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
@@ -372,12 +373,7 @@ var (
 	// reasonable as span is actually way bigger, and avoids re-allocating
 	// over and over. Could be fine-tuned at runtime.
 	traceStartSize = 10
-	// traceMaxSize is the maximum number of spans we keep in memory for a
-	// single trace. This is to avoid memory leaks. If more spans than this
-	// are added to a trace, then the trace is dropped and the spans are
-	// discarded. Adding additional spans after a trace is dropped does
-	// nothing.
-	traceMaxSize = int(1e5)
+	traceMaxSize   = internalconfig.TraceMaxSize
 )
 
 // newTrace creates a new trace using the given callback which will be called

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -975,7 +975,7 @@ func (t *tracer) TracerConf() TracerConf {
 		DebugAbandonedSpans:  t.config.debugAbandonedSpans,
 		Disabled:             !t.config.enabled.current,
 		PartialFlush:         t.config.internalConfig.PartialFlushEnabled(),
-		PartialFlushMinSpans: t.config.partialFlushMinSpans,
+		PartialFlushMinSpans: t.config.internalConfig.PartialFlushMinSpans(),
 		PeerServiceDefaults:  t.config.peerServiceDefaultsEnabled,
 		PeerServiceMappings:  t.config.peerServiceMappings,
 		EnvTag:               t.config.env,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,7 +100,7 @@ func loadConfig() *Config {
 	cfg.peerServiceMappings = provider.getMap("DD_TRACE_PEER_SERVICE_MAPPING", nil)
 	cfg.debugAbandonedSpans = provider.getBool("DD_TRACE_DEBUG_ABANDONED_SPANS", false)
 	cfg.spanTimeout = provider.getDuration("DD_TRACE_ABANDONED_SPAN_TIMEOUT", 0)
-	cfg.partialFlushMinSpans = provider.getInt("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", 0)
+	cfg.partialFlushMinSpans = provider.getIntWithValidator("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", 1000, validatePartialFlushMinSpans)
 	cfg.partialFlushEnabled = provider.getBool("DD_TRACE_PARTIAL_FLUSH_ENABLED", false)
 	cfg.statsComputationEnabled = provider.getBool("DD_TRACE_STATS_COMPUTATION_ENABLED", false)
 	cfg.dataStreamsMonitoringEnabled = provider.getBool("DD_DATA_STREAMS_ENABLED", false)
@@ -298,4 +298,17 @@ func (c *Config) SetPartialFlushEnabled(enabled bool, origin telemetry.Origin) {
 	defer c.mu.Unlock()
 	c.partialFlushEnabled = enabled
 	telemetry.RegisterAppConfig("DD_TRACE_PARTIAL_FLUSH_ENABLED", enabled, origin)
+}
+
+func (c *Config) PartialFlushMinSpans() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.partialFlushMinSpans
+}
+
+func (c *Config) SetPartialFlushMinSpans(minSpans int, origin telemetry.Origin) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.partialFlushMinSpans = minSpans
+	telemetry.RegisterAppConfig("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", minSpans, origin)
 }

--- a/internal/config/configprovider.go
+++ b/internal/config/configprovider.go
@@ -83,6 +83,19 @@ func (p *configProvider) getInt(key string, def int) int {
 	})
 }
 
+func (p *configProvider) getIntWithValidator(key string, def int, validate func(int) bool) int {
+	return get(p, key, def, func(v string) (int, bool) {
+		intVal, err := strconv.Atoi(v)
+		if err == nil {
+			if validate != nil && !validate(intVal) {
+				return 0, false
+			}
+			return intVal, true
+		}
+		return 0, false
+	})
+}
+
 func (p *configProvider) getMap(key string, def map[string]string) map[string]string {
 	return get(p, key, def, func(v string) (map[string]string, bool) {
 		m := parseMapString(v)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Migrates tracer to use Config.partialFlushMinSpans

### Motivation
https://datadoghq.atlassian.net/browse/APMAPI-1745

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
