### PR TITLE
chore(config): migrate debugAbandonedSpans

### DIFF
--- a/ddtrace/tracer/abandonedspans_test.go
+++ b/ddtrace/tracer/abandonedspans_test.go
@@ -132,7 +132,7 @@ func TestReportAbandonedSpans(t *testing.T) {
 		tracer, _, _, stop, err := startTestTracer(t, WithLogger(tp), WithDebugSpansMode(100*time.Millisecond))
 		assert.Nil(err)
 		defer stop()
-		assert.True(tracer.config.debugAbandonedSpans)
+		assert.True(tracer.config.internalConfig.DebugAbandonedSpans())
 		assert.Equal(tracer.config.spanTimeout, 100*time.Millisecond)
 	})
 
@@ -350,7 +350,7 @@ func TestDebugAbandonedSpansOff(t *testing.T) {
 
 	t.Run("default", func(t *testing.T) {
 		assert := assert.New(t)
-		assert.False(tracer.config.debugAbandonedSpans)
+		assert.False(tracer.config.internalConfig.DebugAbandonedSpans())
 		assert.Equal(time.Duration(0), tracer.config.spanTimeout)
 		expected := "Abandoned spans logs enabled."
 		s := tracer.StartSpan("operation", StartTime(spanStartTime))

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -250,9 +250,6 @@ type config struct {
 	// peerServiceMappings holds a set of service mappings to dynamically rename peer.service values.
 	peerServiceMappings map[string]string
 
-	// debugAbandonedSpans controls if the tracer should log when old, open spans are found
-	debugAbandonedSpans bool
-
 	// spanTimeout represents how old a span can be before it should be logged as a possible
 	// misconfiguration
 	spanTimeout time.Duration
@@ -401,8 +398,7 @@ func newConfig(opts ...StartOption) (*config, error) {
 			log.Warn("ignoring DD_TRACE_CLIENT_HOSTNAME_COMPAT, invalid version %q", compatMode)
 		}
 	}
-	c.debugAbandonedSpans = internal.BoolEnv("DD_TRACE_DEBUG_ABANDONED_SPANS", false)
-	if c.debugAbandonedSpans {
+	if c.internalConfig.DebugAbandonedSpans() {
 		c.spanTimeout = internal.DurationEnv("DD_TRACE_ABANDONED_SPAN_TIMEOUT", 10*time.Minute)
 	}
 	c.statsComputationEnabled = internal.BoolEnv("DD_TRACE_STATS_COMPUTATION_ENABLED", true)
@@ -1233,7 +1229,7 @@ func WithProfilerEndpoints(enabled bool) StartOption {
 // be expensive, so it should only be enabled for debugging purposes.
 func WithDebugSpansMode(timeout time.Duration) StartOption {
 	return func(c *config) {
-		c.debugAbandonedSpans = true
+		c.internalConfig.SetDebugAbandonedSpans(true, internalconfig.OriginCode)
 		c.spanTimeout = timeout
 	}
 }

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -881,7 +881,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		t.Run("defaults", func(t *testing.T) {
 			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(t, err)
-			assert.Equal(t, false, c.debugAbandonedSpans)
+			assert.Equal(t, false, c.internalConfig.DebugAbandonedSpans())
 			assert.Equal(t, time.Duration(0), c.spanTimeout)
 		})
 
@@ -889,7 +889,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			t.Setenv("DD_TRACE_DEBUG_ABANDONED_SPANS", "true")
 			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(t, err)
-			assert.Equal(t, true, c.debugAbandonedSpans)
+			assert.Equal(t, true, c.internalConfig.DebugAbandonedSpans())
 			assert.Equal(t, 10*time.Minute, c.spanTimeout)
 		})
 
@@ -898,7 +898,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			t.Setenv("DD_TRACE_ABANDONED_SPAN_TIMEOUT", fmt.Sprint(time.Minute))
 			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(t, err)
-			assert.Equal(t, true, c.debugAbandonedSpans)
+			assert.Equal(t, true, c.internalConfig.DebugAbandonedSpans())
 			assert.Equal(t, time.Minute, c.spanTimeout)
 		})
 
@@ -906,7 +906,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(t, err)
 			WithDebugSpansMode(time.Second)(c)
-			assert.Equal(t, true, c.debugAbandonedSpans)
+			assert.Equal(t, true, c.internalConfig.DebugAbandonedSpans())
 			assert.Equal(t, time.Second, c.spanTimeout)
 		})
 	})

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -746,7 +746,7 @@ func (s *Span) finish(finishTime int64) {
 			// the agent supports dropping p0's in the client
 			keep = shouldKeep(s)
 		}
-		if tracer.config.debugAbandonedSpans {
+		if tracer.config.internalConfig.DebugAbandonedSpans() {
 			// the tracer supports debugging abandoned spans
 			tracer.submitAbandonedSpan(s, true)
 		}

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -490,7 +490,7 @@ func newTracer(opts ...StartOption) (*tracer, error) {
 			t.reportRuntimeMetrics(defaultMetricsReportInterval)
 		}()
 	}
-	if c.debugAbandonedSpans {
+	if c.internalConfig.DebugAbandonedSpans() {
 		log.Info("Abandoned spans logs enabled.")
 		t.abandonedSpansDebugger = newAbandonedSpansDebugger()
 		t.abandonedSpansDebugger.Start(t.config.spanTimeout)
@@ -806,7 +806,7 @@ func (t *tracer) StartSpan(operationName string, options ...StartSpanOption) *Sp
 	} else {
 		span.pprofCtxRestore = nil
 	}
-	if t.config.debugAbandonedSpans {
+	if t.config.internalConfig.DebugAbandonedSpans() {
 		select {
 		case t.abandonedSpansDebugger.In <- newAbandonedSpanCandidate(span, false):
 			// ok
@@ -972,7 +972,7 @@ func (t *tracer) TracerConf() TracerConf {
 	return TracerConf{
 		CanComputeStats:      t.config.canComputeStats(),
 		CanDropP0s:           t.config.canDropP0s(),
-		DebugAbandonedSpans:  t.config.debugAbandonedSpans,
+		DebugAbandonedSpans:  t.config.internalConfig.DebugAbandonedSpans(),
 		Disabled:             !t.config.enabled.current,
 		PartialFlush:         t.config.internalConfig.PartialFlushEnabled(),
 		PartialFlushMinSpans: t.config.internalConfig.PartialFlushMinSpans(),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,9 +55,10 @@ type Config struct {
 	spanAttributeSchemaVersion int
 	peerServiceDefaultsEnabled bool
 	peerServiceMappings        map[string]string
-	debugAbandonedSpans        bool
-	spanTimeout                time.Duration
-	partialFlushMinSpans       int
+	// debugAbandonedSpans controls if the tracer should log when old, open spans are found
+	debugAbandonedSpans  bool
+	spanTimeout          time.Duration
+	partialFlushMinSpans int
 	// partialFlushEnabled specifices whether the tracer should enable partial flushing. Value
 	// from DD_TRACE_PARTIAL_FLUSH_ENABLED, default false.
 	partialFlushEnabled          bool
@@ -325,4 +326,17 @@ func (c *Config) SetDynamicInstrumentationEnabled(enabled bool, origin telemetry
 	defer c.mu.Unlock()
 	c.dynamicInstrumentationEnabled = enabled
 	telemetry.RegisterAppConfig("DD_DYNAMIC_INSTRUMENTATION_ENABLED", enabled, origin)
+}
+
+func (c *Config) DebugAbandonedSpans() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.debugAbandonedSpans
+}
+
+func (c *Config) SetDebugAbandonedSpans(enabled bool, origin telemetry.Origin) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.debugAbandonedSpans = enabled
+	telemetry.RegisterAppConfig("DD_TRACE_DEBUG_ABANDONED_SPANS", enabled, origin)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Migrate tracer to use Config.debugAbandonedSpans

### Motivation
https://datadoghq.atlassian.net/browse/APMAPI-1748

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
