### PR TITLE
chore(config): migrate spanTimeout

### DIFF
--- a/ddtrace/tracer/abandonedspans_test.go
+++ b/ddtrace/tracer/abandonedspans_test.go
@@ -133,7 +133,7 @@ func TestReportAbandonedSpans(t *testing.T) {
 		assert.Nil(err)
 		defer stop()
 		assert.True(tracer.config.internalConfig.DebugAbandonedSpans())
-		assert.Equal(tracer.config.spanTimeout, 100*time.Millisecond)
+		assert.Equal(tracer.config.internalConfig.SpanTimeout(), 100*time.Millisecond)
 	})
 
 	t.Run("finished", func(t *testing.T) {
@@ -351,7 +351,7 @@ func TestDebugAbandonedSpansOff(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		assert := assert.New(t)
 		assert.False(tracer.config.internalConfig.DebugAbandonedSpans())
-		assert.Equal(time.Duration(0), tracer.config.spanTimeout)
+		assert.Equal(10*time.Minute, tracer.config.internalConfig.SpanTimeout())
 		expected := "Abandoned spans logs enabled."
 		s := tracer.StartSpan("operation", StartTime(spanStartTime))
 		time.Sleep(100 * time.Millisecond)

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -250,10 +250,6 @@ type config struct {
 	// peerServiceMappings holds a set of service mappings to dynamically rename peer.service values.
 	peerServiceMappings map[string]string
 
-	// spanTimeout represents how old a span can be before it should be logged as a possible
-	// misconfiguration
-	spanTimeout time.Duration
-
 	// statsComputationEnabled enables client-side stats computation (aka trace metrics).
 	statsComputationEnabled bool
 
@@ -397,9 +393,6 @@ func newConfig(opts ...StartOption) (*config, error) {
 		} else {
 			log.Warn("ignoring DD_TRACE_CLIENT_HOSTNAME_COMPAT, invalid version %q", compatMode)
 		}
-	}
-	if c.internalConfig.DebugAbandonedSpans() {
-		c.spanTimeout = internal.DurationEnv("DD_TRACE_ABANDONED_SPAN_TIMEOUT", 10*time.Minute)
 	}
 	c.statsComputationEnabled = internal.BoolEnv("DD_TRACE_STATS_COMPUTATION_ENABLED", true)
 
@@ -1230,7 +1223,7 @@ func WithProfilerEndpoints(enabled bool) StartOption {
 func WithDebugSpansMode(timeout time.Duration) StartOption {
 	return func(c *config) {
 		c.internalConfig.SetDebugAbandonedSpans(true, internalconfig.OriginCode)
-		c.spanTimeout = timeout
+		c.internalConfig.SetSpanTimeout(timeout, internalconfig.OriginCode)
 	}
 }
 

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -882,7 +882,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(t, err)
 			assert.Equal(t, false, c.internalConfig.DebugAbandonedSpans())
-			assert.Equal(t, time.Duration(0), c.spanTimeout)
+			assert.Equal(t, 10*time.Minute, c.internalConfig.SpanTimeout())
 		})
 
 		t.Run("debug-on", func(t *testing.T) {
@@ -890,7 +890,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(t, err)
 			assert.Equal(t, true, c.internalConfig.DebugAbandonedSpans())
-			assert.Equal(t, 10*time.Minute, c.spanTimeout)
+			assert.Equal(t, 10*time.Minute, c.internalConfig.SpanTimeout())
 		})
 
 		t.Run("timeout-set", func(t *testing.T) {
@@ -899,7 +899,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			c, err := newTestConfig(WithAgentTimeout(2))
 			assert.NoError(t, err)
 			assert.Equal(t, true, c.internalConfig.DebugAbandonedSpans())
-			assert.Equal(t, time.Minute, c.spanTimeout)
+			assert.Equal(t, time.Minute, c.internalConfig.SpanTimeout())
 		})
 
 		t.Run("with-function", func(t *testing.T) {
@@ -907,7 +907,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			assert.NoError(t, err)
 			WithDebugSpansMode(time.Second)(c)
 			assert.Equal(t, true, c.internalConfig.DebugAbandonedSpans())
-			assert.Equal(t, time.Second, c.spanTimeout)
+			assert.Equal(t, time.Second, c.internalConfig.SpanTimeout())
 		})
 	})
 

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -493,7 +493,7 @@ func newTracer(opts ...StartOption) (*tracer, error) {
 	if c.internalConfig.DebugAbandonedSpans() {
 		log.Info("Abandoned spans logs enabled.")
 		t.abandonedSpansDebugger = newAbandonedSpansDebugger()
-		t.abandonedSpansDebugger.Start(t.config.spanTimeout)
+		t.abandonedSpansDebugger.Start(t.config.internalConfig.SpanTimeout())
 	}
 	t.wg.Add(1)
 	go func() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,7 +56,9 @@ type Config struct {
 	peerServiceDefaultsEnabled bool
 	peerServiceMappings        map[string]string
 	// debugAbandonedSpans controls if the tracer should log when old, open spans are found
-	debugAbandonedSpans  bool
+	debugAbandonedSpans bool
+	// spanTimeout represents how old a span can be before it should be logged as a possible
+	// misconfiguration. Unused if debugAbandonedSpans is false.
 	spanTimeout          time.Duration
 	partialFlushMinSpans int
 	// partialFlushEnabled specifices whether the tracer should enable partial flushing. Value
@@ -101,7 +103,7 @@ func loadConfig() *Config {
 	cfg.peerServiceDefaultsEnabled = provider.getBool("DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED", false)
 	cfg.peerServiceMappings = provider.getMap("DD_TRACE_PEER_SERVICE_MAPPING", nil)
 	cfg.debugAbandonedSpans = provider.getBool("DD_TRACE_DEBUG_ABANDONED_SPANS", false)
-	cfg.spanTimeout = provider.getDuration("DD_TRACE_ABANDONED_SPAN_TIMEOUT", 0)
+	cfg.spanTimeout = provider.getDuration("DD_TRACE_ABANDONED_SPAN_TIMEOUT", 10*time.Minute)
 	cfg.partialFlushMinSpans = provider.getIntWithValidator("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", 1000, validatePartialFlushMinSpans)
 	cfg.partialFlushEnabled = provider.getBool("DD_TRACE_PARTIAL_FLUSH_ENABLED", false)
 	cfg.statsComputationEnabled = provider.getBool("DD_TRACE_STATS_COMPUTATION_ENABLED", false)
@@ -339,4 +341,17 @@ func (c *Config) SetDebugAbandonedSpans(enabled bool, origin telemetry.Origin) {
 	defer c.mu.Unlock()
 	c.debugAbandonedSpans = enabled
 	telemetry.RegisterAppConfig("DD_TRACE_DEBUG_ABANDONED_SPANS", enabled, origin)
+}
+
+func (c *Config) SpanTimeout() time.Duration {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.spanTimeout
+}
+
+func (c *Config) SetSpanTimeout(timeout time.Duration, origin telemetry.Origin) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.spanTimeout = timeout
+	telemetry.RegisterAppConfig("DD_TRACE_ABANDONED_SPAN_TIMEOUT", timeout, origin)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Migrate tracer to use Config.spanTimeout. Also, change spanTimeout true default from 0 to 10 minutes. This was always the effective default, although only set if debugAbandonedSpans was enabled. With this change, the default is consistent, but the feature remains unused if debugAbandonedSpans is not enabled.

### Motivation
https://datadoghq.atlassian.net/browse/APMAPI-1748

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
