### PR TITLE
chore(config): migrate statsComputationEnabled

### DIFF
--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -1732,33 +1732,33 @@ func TestWithStatsComputation(t *testing.T) {
 		assert := assert.New(t)
 		c, err := newTestConfig()
 		assert.NoError(err)
-		assert.True(c.statsComputationEnabled)
+		assert.True(c.internalConfig.StatsComputationEnabled())
 	})
 	t.Run("enabled-via-option", func(t *testing.T) {
 		assert := assert.New(t)
 		c, err := newTestConfig(WithStatsComputation(true))
 		assert.NoError(err)
-		assert.True(c.statsComputationEnabled)
+		assert.True(c.internalConfig.StatsComputationEnabled())
 	})
 	t.Run("disabled-via-option", func(t *testing.T) {
 		assert := assert.New(t)
 		c, err := newTestConfig(WithStatsComputation(false))
 		assert.NoError(err)
-		assert.False(c.statsComputationEnabled)
+		assert.False(c.internalConfig.StatsComputationEnabled())
 	})
 	t.Run("enabled-via-env", func(t *testing.T) {
 		assert := assert.New(t)
 		t.Setenv("DD_TRACE_STATS_COMPUTATION_ENABLED", "true")
 		c, err := newTestConfig()
 		assert.NoError(err)
-		assert.True(c.statsComputationEnabled)
+		assert.True(c.internalConfig.StatsComputationEnabled())
 	})
 	t.Run("env-override", func(t *testing.T) {
 		assert := assert.New(t)
 		t.Setenv("DD_TRACE_STATS_COMPUTATION_ENABLED", "false")
 		c, err := newTestConfig(WithStatsComputation(true))
 		assert.NoError(err)
-		assert.True(c.statsComputationEnabled)
+		assert.True(c.internalConfig.StatsComputationEnabled())
 	})
 }
 

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -2822,7 +2822,7 @@ func TestEmptyChunksNotSent(t *testing.T) {
 	assert.NoError(err)
 	defer stop()
 
-	tracer.config.statsComputationEnabled = true
+	tracer.config.internalConfig.SetStatsComputationEnabled(true, internalconfig.OriginCode)
 	tracer.prioritySampling.defaultRate = 0
 	tracer.config.serviceName = "test_service"
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,7 +63,8 @@ type Config struct {
 	partialFlushMinSpans int
 	// partialFlushEnabled specifices whether the tracer should enable partial flushing. Value
 	// from DD_TRACE_PARTIAL_FLUSH_ENABLED, default false.
-	partialFlushEnabled          bool
+	partialFlushEnabled bool
+	// statsComputationEnabled enables client-side stats computation (aka trace metrics).
 	statsComputationEnabled      bool
 	dataStreamsMonitoringEnabled bool
 	// dynamicInstrumentationEnabled controls if the target application can be modified by Dynamic Instrumentation or not.
@@ -108,7 +109,7 @@ func loadConfig() *Config {
 	cfg.spanTimeout = provider.getDuration("DD_TRACE_ABANDONED_SPAN_TIMEOUT", 10*time.Minute)
 	cfg.partialFlushMinSpans = provider.getIntWithValidator("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", 1000, validatePartialFlushMinSpans)
 	cfg.partialFlushEnabled = provider.getBool("DD_TRACE_PARTIAL_FLUSH_ENABLED", false)
-	cfg.statsComputationEnabled = provider.getBool("DD_TRACE_STATS_COMPUTATION_ENABLED", false)
+	cfg.statsComputationEnabled = provider.getBool("DD_TRACE_STATS_COMPUTATION_ENABLED", true)
 	cfg.dataStreamsMonitoringEnabled = provider.getBool("DD_DATA_STREAMS_ENABLED", false)
 	cfg.dynamicInstrumentationEnabled = provider.getBool("DD_DYNAMIC_INSTRUMENTATION_ENABLED", false)
 	cfg.globalSampleRate = provider.getFloat("DD_TRACE_SAMPLE_RATE", 0.0)
@@ -370,4 +371,17 @@ func (c *Config) SetDebugStack(enabled bool, origin telemetry.Origin) {
 	defer c.mu.Unlock()
 	c.debugStack = enabled
 	telemetry.RegisterAppConfig("DD_TRACE_DEBUG_STACK", enabled, origin)
+}
+
+func (c *Config) StatsComputationEnabled() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.statsComputationEnabled
+}
+
+func (c *Config) SetStatsComputationEnabled(enabled bool, origin telemetry.Origin) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.statsComputationEnabled = enabled
+	telemetry.RegisterAppConfig("DD_TRACE_STATS_COMPUTATION_ENABLED", enabled, origin)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Migrate tracer to use Config.statsComputationEnabled

### Motivation
https://datadoghq.atlassian.net/browse/APMAPI-1748

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
