### PR TITLE
fix(.github/workflows): revert #4098

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -58,16 +58,6 @@ jobs:
         run: |-
           mkdir -p $TEST_RESULTS
           go get -u -t $PACKAGES
-          go get github.com/DataDog/datadog-agent/pkg/trace@v0.71.0-rc.2
-          go get github.com/DataDog/datadog-agent/pkg/remoteconfig/state@v0.71.0-rc.2
-          go get github.com/DataDog/datadog-agent/pkg/proto@v0.71.0-rc.2
-          go get github.com/DataDog/datadog-agent/pkg/obfuscate@v0.71.0-rc.2
-          go get github.com/DataDog/datadog-agent/comp/core/tagger/origindetection@v0.71.0-rc.2
-          go get github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes@v0.71.0-rc.2
-          go get github.com/DataDog/datadog-agent/pkg/util/log@v0.71.0-rc.2
-          go get github.com/DataDog/datadog-agent/pkg/util/scrubber@v0.71.0-rc.2
-          go get github.com/DataDog/datadog-agent/pkg/version@v0.71.0-rc.2
-          go get go.opentelemetry.io/collector/pdata@v1.39.0
           go mod tidy
           for d in `find . -iname go.mod | xargs -n1 dirname`; do pushd $d; go mod tidy; popd; done;
 

--- a/scripts/ci_test_contrib.sh
+++ b/scripts/ci_test_contrib.sh
@@ -29,16 +29,6 @@ for contrib in $CONTRIBS; do
   cd "$contrib" || exit 1
   if [[ "$1" = "smoke" ]]; then
     go get -u -t ./...
-    go get github.com/DataDog/datadog-agent/pkg/trace@v0.71.0-rc.2
-    go get github.com/DataDog/datadog-agent/pkg/remoteconfig/state@v0.71.0-rc.2
-    go get github.com/DataDog/datadog-agent/pkg/proto@v0.71.0-rc.2
-    go get github.com/DataDog/datadog-agent/pkg/obfuscate@v0.71.0-rc.2
-    go get github.com/DataDog/datadog-agent/comp/core/tagger/origindetection@v0.71.0-rc.2
-    go get github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes@v0.71.0-rc.2
-    go get github.com/DataDog/datadog-agent/pkg/util/log@v0.71.0-rc.2
-    go get github.com/DataDog/datadog-agent/pkg/util/scrubber@v0.71.0-rc.2
-    go get github.com/DataDog/datadog-agent/pkg/version@v0.71.0-rc.2
-    go get go.opentelemetry.io/collector/pdata@v1.39.0
   fi
   if [[ "$1" = "smoke" && "$contrib" = "./contrib/k8s.io/client-go/" ]]; then
     # This is a temporary workaround due to this issue in apimachinery: https://github.com/kubernetes/apimachinery/issues/190


### PR DESCRIPTION
### What does this PR do?

Reverts #4098.

### Motivation

Incompabilities are happening in some [smoke tests' runs](https://github.com/DataDog/dd-trace-go/actions/runs/20232111124/job/58077430311).

```
go: downloading github.com/DataDog/datadog-agent/pkg/obfuscate v0.71.0-rc.2
go: github.com/DataDog/datadog-agent/pkg/obfuscate: github.com/DataDog/datadog-agent/pkg/trace@v0.73.0-devel requires
	github.com/DataDog/datadog-agent/pkg/template@v0.65.1: reading github.com/DataDog/datadog-agent/pkg/template/go.mod at revision pkg/template/v0.65.1: unknown revision pkg/template/v0.65.1
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
