### PR TITLE
ci(contribs): fix tag extraction for docker images releases

### DIFF
--- a/.github/workflows/docker-images-release.yml
+++ b/.github/workflows/docker-images-release.yml
@@ -58,9 +58,9 @@ jobs:
           PREFIX_REQUEST_MIRRORING: contrib/k8s.io/gateway-api/
           PREFIX_HAPROXY: contrib/haproxy/stream-processing-offload/
         run: |
-          echo "service_extension_image_tag=${RAW_TAG#PREFIX_SERVICE_EXTENSION}" >> $GITHUB_OUTPUT
-          echo "request_mirroring_image_tag=${RAW_TAG#PREFIX_REQUEST_MIRRORING}" >> $GITHUB_OUTPUT
-          echo "haproxy_image_tag=${RAW_TAG#PREFIX_HAPROXY}" >> $GITHUB_OUTPUT
+          echo "service_extension_image_tag=${RAW_TAG#$PREFIX_SERVICE_EXTENSION}" >> $GITHUB_OUTPUT
+          echo "request_mirroring_image_tag=${RAW_TAG#$PREFIX_REQUEST_MIRRORING}" >> $GITHUB_OUTPUT
+          echo "haproxy_image_tag=${RAW_TAG#$PREFIX_HAPROXY}" >> $GITHUB_OUTPUT
 
   build-service-extensions-callout:
     needs: prepare-tag


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR fixes the `Extract raw/tag inputs` job from the docker images release process workflow.
The tag got from a branch is resolved like `RAW_TAG: contrib/envoyproxy/go-control-plane/v2.4.1`.
However in the script that exclude the contrib path, the variable `PREFIX_xxx` where not prefixed with the `$` to refer to that variable.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Failed to publish docker images (service extensions, request mirror and haproxy spoa) when a tag from the release it mades.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
