### PR TITLE
chore(config): migrate version

### DIFF
--- a/ddtrace/tracer/log.go
+++ b/ddtrace/tracer/log.go
@@ -140,7 +140,7 @@ func logStartup(t *tracer) {
 		Tags:                        tags,
 		RuntimeMetricsEnabled:       t.config.internalConfig.RuntimeMetricsEnabled(),
 		RuntimeMetricsV2Enabled:     t.config.internalConfig.RuntimeMetricsV2Enabled(),
-		ApplicationVersion:          t.config.version,
+		ApplicationVersion:          t.config.internalConfig.Version(),
 		ProfilerCodeHotspotsEnabled: t.config.internalConfig.ProfilerHotspotsEnabled(),
 		ProfilerEndpointsEnabled:    t.config.internalConfig.ProfilerEndpoints(),
 		Architecture:                runtime.GOARCH,

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -168,9 +168,6 @@ type config struct {
 	// should match to set application version tag. False by default
 	universalVersion bool
 
-	// version specifies the version of this application
-	version string
-
 	// env contains the environment that this application will run under.
 	env string
 
@@ -341,9 +338,6 @@ func newConfig(opts ...StartOption) (*config, error) {
 		c.serviceName = v
 		globalconfig.SetServiceName(v)
 	}
-	if ver := env.Get("DD_VERSION"); ver != "" {
-		c.version = ver
-	}
 	if v := env.Get("DD_SERVICE_MAPPING"); v != "" {
 		internal.ForEachStringTag(v, internal.DDTagsDelimiter, func(key, val string) { WithServiceMapping(key, val)(c) })
 	}
@@ -429,10 +423,10 @@ func newConfig(opts ...StartOption) (*config, error) {
 			}
 		}
 	}
-	if c.version == "" {
+	if c.internalConfig.Version() == "" {
 		if v, ok := globalTags["version"]; ok {
 			if ver, ok := v.(string); ok {
-				c.version = ver
+				c.internalConfig.SetVersion(ver, c.globalTags.cfgOrigin)
 			}
 		}
 	}
@@ -519,7 +513,7 @@ func newConfig(opts ...StartOption) (*config, error) {
 		DDTags:     c.globalTags.get(),
 		Env:        c.env,
 		Service:    c.serviceName,
-		Version:    c.version,
+		Version:    c.internalConfig.Version(),
 		AgentURL:   c.agentURL,
 		APIKey:     env.Get("DD_API_KEY"),
 		APPKey:     env.Get("DD_APP_KEY"),
@@ -1128,7 +1122,7 @@ func WithSamplingRules(rules []SamplingRule) StartOption {
 // span service name and config service name match. Do NOT use with WithUniversalVersion.
 func WithServiceVersion(version string) StartOption {
 	return func(cfg *config) {
-		cfg.version = version
+		cfg.internalConfig.SetVersion(version, telemetry.OriginCode)
 		cfg.universalVersion = false
 	}
 }
@@ -1138,7 +1132,7 @@ func WithServiceVersion(version string) StartOption {
 // See: WithService, WithServiceVersion. Do NOT use with WithServiceVersion.
 func WithUniversalVersion(version string) StartOption {
 	return func(c *config) {
-		c.version = version
+		c.internalConfig.SetVersion(version, telemetry.OriginCode)
 		c.universalVersion = true
 	}
 }

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -1308,7 +1308,7 @@ func TestVersionConfig(t *testing.T) {
 			WithServiceVersion("1.2.3"),
 		)
 		assert.NoError(err)
-		assert.Equal("1.2.3", c.version)
+		assert.Equal("1.2.3", c.internalConfig.Version())
 	})
 
 	t.Run("env", func(t *testing.T) {
@@ -1317,14 +1317,14 @@ func TestVersionConfig(t *testing.T) {
 		c, err := newTestConfig()
 
 		assert.NoError(err)
-		assert.Equal("1.2.3", c.version)
+		assert.Equal("1.2.3", c.internalConfig.Version())
 	})
 
 	t.Run("WithGlobalTag", func(t *testing.T) {
 		assert := assert.New(t)
 		c, err := newTestConfig(WithGlobalTag("version", "1.2.3"))
 		assert.NoError(err)
-		assert.Equal("1.2.3", c.version)
+		assert.Equal("1.2.3", c.internalConfig.Version())
 	})
 
 	t.Run("OTEL_RESOURCE_ATTRIBUTES", func(t *testing.T) {
@@ -1333,7 +1333,7 @@ func TestVersionConfig(t *testing.T) {
 		c, err := newTestConfig()
 		assert.NoError(err)
 
-		assert.Equal("1.2.3", c.version)
+		assert.Equal("1.2.3", c.internalConfig.Version())
 	})
 
 	t.Run("DD_TAGS", func(t *testing.T) {
@@ -1342,37 +1342,37 @@ func TestVersionConfig(t *testing.T) {
 		c, err := newTestConfig()
 
 		assert.NoError(err)
-		assert.Equal("1.2.3", c.version)
+		assert.Equal("1.2.3", c.internalConfig.Version())
 	})
 
 	t.Run("override-chain", func(t *testing.T) {
 		assert := assert.New(t)
 		c, err := newTestConfig()
 		assert.NoError(err)
-		assert.Equal(c.version, "")
+		assert.Equal(c.internalConfig.Version(), "")
 
 		t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.version=1.1.0")
 		c, err = newTestConfig()
 		assert.NoError(err)
-		assert.Equal("1.1.0", c.version)
+		assert.Equal("1.1.0", c.internalConfig.Version())
 
 		t.Setenv("DD_TAGS", "version:1.1.1")
 		c, err = newTestConfig()
 		assert.NoError(err)
-		assert.Equal("1.1.1", c.version)
+		assert.Equal("1.1.1", c.internalConfig.Version())
 
 		c, err = newTestConfig(WithGlobalTag("version", "1.1.2"))
 		assert.NoError(err)
-		assert.Equal("1.1.2", c.version)
+		assert.Equal("1.1.2", c.internalConfig.Version())
 
 		t.Setenv("DD_VERSION", "1.1.3")
 		c, err = newTestConfig(WithGlobalTag("version", "1.1.2"))
 		assert.NoError(err)
-		assert.Equal("1.1.3", c.version)
+		assert.Equal("1.1.3", c.internalConfig.Version())
 
 		c, err = newTestConfig(WithGlobalTag("version", "1.1.2"), WithServiceVersion("1.1.4"))
 		assert.NoError(err)
-		assert.Equal("1.1.4", c.version)
+		assert.Equal("1.1.4", c.internalConfig.Version())
 	})
 }
 

--- a/ddtrace/tracer/stats.go
+++ b/ddtrace/tracer/stats.go
@@ -84,7 +84,7 @@ func newConcentrator(c *config, bucketSize int64, statsdClient internal.StatsdCl
 	aggKey := stats.PayloadAggregationKey{
 		Hostname:     c.internalConfig.Hostname(),
 		Env:          env,
-		Version:      c.version,
+		Version:      c.internalConfig.Version(),
 		ContainerID:  "", // This intentionally left empty as the Agent will attach the container ID only in certain situations.
 		GitCommitSha: gitCommitSha,
 		ImageTag:     "",

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -47,7 +47,7 @@ func startTelemetry(c *config) telemetry.Client {
 		{Name: "service", Value: c.serviceName},
 		{Name: "universal_version", Value: c.universalVersion},
 		{Name: "env", Value: c.env},
-		{Name: "version", Value: c.version},
+		{Name: "version", Value: c.internalConfig.Version()},
 		{Name: "trace_agent_url", Value: c.agentURL.String()},
 		{Name: "agent_hostname", Value: c.internalConfig.Hostname()},
 		{Name: "runtime_metrics_v2_enabled", Value: c.internalConfig.RuntimeMetricsV2Enabled()},
@@ -114,7 +114,7 @@ func startTelemetry(c *config) telemetry.Client {
 	if c.internalConfig.LogToStdout() || c.ciVisibilityAgentless {
 		cfg.APIKey = env.Get("DD_API_KEY")
 	}
-	client, err := telemetry.NewClient(c.serviceName, c.env, c.version, cfg)
+	client, err := telemetry.NewClient(c.serviceName, c.env, c.internalConfig.Version(), cfg)
 	if err != nil {
 		log.Debug("tracer: failed to create telemetry client: %s", err.Error())
 		return nil

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -251,7 +251,7 @@ func Start(opts ...StartOption) error {
 	// Start AppSec with remote configuration
 	cfg := remoteconfig.DefaultClientConfig()
 	cfg.AgentURL = t.config.agentURL.String()
-	cfg.AppVersion = t.config.version
+	cfg.AppVersion = t.config.internalConfig.Version()
 	cfg.Env = t.config.env
 	cfg.HTTP = t.config.httpClient
 	cfg.ServiceName = t.config.serviceName
@@ -307,7 +307,7 @@ func storeConfig(c *config) {
 		Hostname:           c.internalConfig.Hostname(),
 		ServiceName:        c.serviceName,
 		ServiceEnvironment: c.env,
-		ServiceVersion:     c.version,
+		ServiceVersion:     c.internalConfig.Version(),
 		ProcessTags:        processtags.GlobalTags().String(),
 		ContainerID:        globalinternal.ContainerID(),
 	}
@@ -323,7 +323,7 @@ func storeConfig(c *config) {
 		HostName:                  c.internalConfig.Hostname(),
 		ServiceInstanceID:         globalconfig.RuntimeID(),
 		ServiceName:               c.serviceName,
-		ServiceVersion:            c.version,
+		ServiceVersion:            c.internalConfig.Version(),
 		TelemetrySDKLanguage:      "go",
 		TelemetrySDKVersion:       version.Tag,
 		TelemetrySdkName:          "dd-trace-go",
@@ -432,7 +432,7 @@ func newUnstartedTracer(opts ...StartOption) (t *tracer, err error) {
 		rulesSampler.traces.setTraceSampleRules, EqualsFalseNegative)
 	var dataStreamsProcessor *datastreams.Processor
 	if c.internalConfig.DataStreamsMonitoringEnabled() {
-		dataStreamsProcessor = datastreams.NewProcessor(statsd, c.env, c.serviceName, c.version, c.agentURL, c.httpClient)
+		dataStreamsProcessor = datastreams.NewProcessor(statsd, c.env, c.serviceName, c.internalConfig.Version(), c.agentURL, c.httpClient)
 	}
 	var logFile *log.ManagedFile
 	if v := c.internalConfig.LogDirectory(); v != "" {
@@ -779,9 +779,9 @@ func (t *tracer) StartSpan(operationName string, options ...StartSpanOption) *Sp
 			span.service = newSvc
 		}
 	}
-	if t.config.version != "" {
+	if t.config.internalConfig.Version() != "" {
 		if t.config.universalVersion || (!t.config.universalVersion && span.service == t.config.serviceName) {
-			span.setMeta(ext.Version, t.config.version)
+			span.setMeta(ext.Version, t.config.internalConfig.Version())
 		}
 	}
 	if t.config.env != "" {
@@ -979,7 +979,7 @@ func (t *tracer) TracerConf() TracerConf {
 		PeerServiceDefaults:  t.config.peerServiceDefaultsEnabled,
 		PeerServiceMappings:  t.config.peerServiceMappings,
 		EnvTag:               t.config.env,
-		VersionTag:           t.config.version,
+		VersionTag:           t.config.internalConfig.Version(),
 		ServiceTag:           t.config.serviceName,
 		TracingAsTransport:   t.config.tracingAsTransport,
 		isLambdaFunction:     t.config.internalConfig.IsLambdaFunction(),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -452,3 +452,16 @@ func (c *Config) HostnameLookupError() error {
 	defer c.mu.RUnlock()
 	return c.hostnameLookupError
 }
+
+func (c *Config) Version() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.version
+}
+
+func (c *Config) SetVersion(version string, origin telemetry.Origin) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.version = version
+	telemetry.RegisterAppConfig("DD_VERSION", version, origin)
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Migrates tracer to use Config.version instead of its local `version`. 
Note: This PR migrated c.version specifically; other configurations that impact `version` will be migrated in subsequent PRs

### Motivation
datadoghq.atlassian.net/browse/APMAPI-1748

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
