### PR TITLE
chore(config): migrate env

### DIFF
--- a/ddtrace/tracer/civisibility_payload.go
+++ b/ddtrace/tracer/civisibility_payload.go
@@ -81,7 +81,7 @@ func (p *ciVisibilityPayload) getBuffer(config *config) (*bytes.Buffer, error) {
 	}
 
 	// Create the visibility payload
-	visibilityPayload := p.writeEnvelope(config.env, payloadBuf.Bytes())
+	visibilityPayload := p.writeEnvelope(config.internalConfig.Env(), payloadBuf.Bytes())
 
 	// Create a new buffer to encode the visibility payload in MessagePack format
 	encodedBuf := new(bytes.Buffer)

--- a/ddtrace/tracer/civisibility_transport_test.go
+++ b/ddtrace/tracer/civisibility_transport_test.go
@@ -82,11 +82,11 @@ func runTransportTest(t *testing.T, agentless, shouldSetAPIKey bool) {
 	defer srv.Close()
 
 	parsedURL, _ := url.Parse(srv.URL)
-	c := config{
-		ciVisibilityEnabled: true,
-		httpClient:          internal.DefaultHTTPClient(defaultHTTPTimeout, false),
-		agentURL:            parsedURL,
-	}
+	cfg, err := newTestConfig()
+	assert.NoError(err)
+	cfg.ciVisibilityEnabled = true
+	cfg.httpClient = internal.DefaultHTTPClient(defaultHTTPTimeout, false)
+	cfg.agentURL = parsedURL
 
 	// Set CI Visibility environment variables for the test
 	if agentless {
@@ -98,7 +98,7 @@ func runTransportTest(t *testing.T, agentless, shouldSetAPIKey bool) {
 	}
 
 	for _, tc := range testCases {
-		transport := newCiVisibilityTransport(&c)
+		transport := newCiVisibilityTransport(cfg)
 
 		p := newCiVisibilityPayload()
 		for _, t := range tc.payload {

--- a/ddtrace/tracer/log.go
+++ b/ddtrace/tracer/log.go
@@ -127,7 +127,7 @@ func logStartup(t *tracer) {
 		Version:                     version.Tag,
 		Lang:                        "Go",
 		LangVersion:                 runtime.Version(),
-		Env:                         t.config.env,
+		Env:                         t.config.internalConfig.Env(),
 		Service:                     t.config.serviceName,
 		AgentURL:                    agentURL,
 		Debug:                       t.config.internalConfig.Debug(),

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -168,9 +168,6 @@ type config struct {
 	// should match to set application version tag. False by default
 	universalVersion bool
 
-	// env contains the environment that this application will run under.
-	env string
-
 	// sampler specifies the sampler that will be used for sampling traces.
 	sampler RateSampler
 
@@ -326,9 +323,6 @@ func newConfig(opts ...StartOption) (*config, error) {
 			return c, fmt.Errorf("unable to look up hostname: %s", err.Error())
 		}
 	}
-	if v := env.Get("DD_ENV"); v != "" {
-		c.env = v
-	}
 	if v := env.Get("DD_TRACE_FEATURES"); v != "" {
 		WithFeatureFlags(strings.FieldsFunc(v, func(r rune) bool {
 			return r == ',' || r == ' '
@@ -416,10 +410,10 @@ func newConfig(opts ...StartOption) (*config, error) {
 	}
 	WithGlobalTag(ext.RuntimeID, globalconfig.RuntimeID())(c)
 	globalTags := c.globalTags.get()
-	if c.env == "" {
+	if c.internalConfig.Env() == "" {
 		if v, ok := globalTags["env"]; ok {
 			if e, ok := v.(string); ok {
-				c.env = e
+				c.internalConfig.SetEnv(e, c.globalTags.cfgOrigin)
 			}
 		}
 	}
@@ -511,7 +505,7 @@ func newConfig(opts ...StartOption) (*config, error) {
 	// Update the llmobs config with stuff needed from the tracer.
 	c.llmobs.TracerConfig = llmobsconfig.TracerConfig{
 		DDTags:     c.globalTags.get(),
-		Env:        c.env,
+		Env:        c.internalConfig.Env(),
 		Service:    c.serviceName,
 		Version:    c.internalConfig.Version(),
 		AgentURL:   c.agentURL,
@@ -777,8 +771,8 @@ func statsTags(c *config) []string {
 		"lang:go",
 		"lang_version:" + runtime.Version(),
 	}
-	if c.env != "" {
-		tags = append(tags, "env:"+c.env)
+	if c.internalConfig.Env() != "" {
+		tags = append(tags, "env:"+c.internalConfig.Env())
 	}
 	if hostname := c.internalConfig.Hostname(); hostname != "" {
 		tags = append(tags, "host:"+hostname)
@@ -966,7 +960,7 @@ func WithAgentTimeout(timeout int) StartOption {
 // The default value is the environment variable DD_ENV, if it is set.
 func WithEnv(env string) StartOption {
 	return func(c *config) {
-		c.env = env
+		c.internalConfig.SetEnv(env, telemetry.OriginCode)
 	}
 }
 

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -616,7 +616,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		assert.NoError(t, err)
 		defer tracer.Stop()
 		c := tracer.config
-		assert.Equal(t, "testEnv", c.env)
+		assert.Equal(t, "testEnv", c.internalConfig.Env())
 	})
 
 	t.Run("env-agentAddr", func(t *testing.T) {
@@ -700,7 +700,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		defer tracer.Stop()
 		assert.NoError(err)
 		c := tracer.config
-		assert.Equal(env, c.env)
+		assert.Equal(env, c.internalConfig.Env())
 	})
 
 	t.Run("trace_enabled", func(t *testing.T) {
@@ -740,7 +740,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		assert.Equal(&url.URL{Scheme: "http", Host: "127.0.0.1:58126"}, c.agentURL)
 		assert.NotNil(c.globalTags.get())
 		assert.Equal("v", c.globalTags.get()["k"])
-		assert.Equal("testEnv", c.env)
+		assert.Equal("testEnv", c.internalConfig.Env())
 		assert.True(c.internalConfig.Debug())
 	})
 
@@ -1383,7 +1383,7 @@ func TestEnvConfig(t *testing.T) {
 			WithEnv("testing"),
 		)
 		assert.NoError(err)
-		assert.Equal("testing", c.env)
+		assert.Equal("testing", c.internalConfig.Env())
 	})
 
 	t.Run("env", func(t *testing.T) {
@@ -1392,14 +1392,14 @@ func TestEnvConfig(t *testing.T) {
 		c, err := newTestConfig()
 
 		assert.NoError(err)
-		assert.Equal("testing", c.env)
+		assert.Equal("testing", c.internalConfig.Env())
 	})
 
 	t.Run("WithGlobalTag", func(t *testing.T) {
 		assert := assert.New(t)
 		c, err := newTestConfig(WithGlobalTag("env", "testing"))
 		assert.NoError(err)
-		assert.Equal("testing", c.env)
+		assert.Equal("testing", c.internalConfig.Env())
 	})
 
 	t.Run("OTEL_RESOURCE_ATTRIBUTES", func(t *testing.T) {
@@ -1408,7 +1408,7 @@ func TestEnvConfig(t *testing.T) {
 		c, err := newTestConfig()
 		assert.NoError(err)
 
-		assert.Equal("testing", c.env)
+		assert.Equal("testing", c.internalConfig.Env())
 	})
 
 	t.Run("DD_TAGS", func(t *testing.T) {
@@ -1417,37 +1417,37 @@ func TestEnvConfig(t *testing.T) {
 		c, err := newTestConfig()
 
 		assert.NoError(err)
-		assert.Equal("testing", c.env)
+		assert.Equal("testing", c.internalConfig.Env())
 	})
 
 	t.Run("override-chain", func(t *testing.T) {
 		assert := assert.New(t)
 		c, err := newTestConfig()
 		assert.NoError(err)
-		assert.Equal(c.env, "")
+		assert.Equal(c.internalConfig.Env(), "")
 
 		t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=testing0")
 		c, err = newTestConfig()
 		assert.NoError(err)
-		assert.Equal("testing0", c.env)
+		assert.Equal("testing0", c.internalConfig.Env())
 
 		t.Setenv("DD_TAGS", "env:testing1")
 		c, err = newTestConfig()
 		assert.NoError(err)
-		assert.Equal("testing1", c.env)
+		assert.Equal("testing1", c.internalConfig.Env())
 
 		c, err = newTestConfig(WithGlobalTag("env", "testing2"))
 		assert.NoError(err)
-		assert.Equal("testing2", c.env)
+		assert.Equal("testing2", c.internalConfig.Env())
 
 		t.Setenv("DD_ENV", "testing3")
 		c, err = newTestConfig(WithGlobalTag("env", "testing2"))
 		assert.NoError(err)
-		assert.Equal("testing3", c.env)
+		assert.Equal("testing3", c.internalConfig.Env())
 
 		c, err = newTestConfig(WithGlobalTag("env", "testing2"), WithEnv("testing4"))
 		assert.NoError(err)
-		assert.Equal("testing4", c.env)
+		assert.Equal("testing4", c.internalConfig.Env())
 	})
 }
 

--- a/ddtrace/tracer/stats.go
+++ b/ddtrace/tracer/stats.go
@@ -66,8 +66,8 @@ func newConcentrator(c *config, bucketSize int64, statsdClient internal.StatsdCl
 		BucketInterval:         defaultStatsBucketSize,
 	}
 	env := c.agent.defaultEnv
-	if c.env != "" {
-		env = c.env
+	if c.internalConfig.Env() != "" {
+		env = c.internalConfig.Env()
 	}
 	if env == "" {
 		// We do this to avoid a panic in the stats calculation logic when env is empty

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -46,7 +46,7 @@ func startTelemetry(c *config) telemetry.Client {
 		{Name: "trace_startup_logs_enabled", Value: c.internalConfig.LogStartup()},
 		{Name: "service", Value: c.serviceName},
 		{Name: "universal_version", Value: c.universalVersion},
-		{Name: "env", Value: c.env},
+		{Name: "env", Value: c.internalConfig.Env()},
 		{Name: "version", Value: c.internalConfig.Version()},
 		{Name: "trace_agent_url", Value: c.agentURL.String()},
 		{Name: "agent_hostname", Value: c.internalConfig.Hostname()},
@@ -114,7 +114,7 @@ func startTelemetry(c *config) telemetry.Client {
 	if c.internalConfig.LogToStdout() || c.ciVisibilityAgentless {
 		cfg.APIKey = env.Get("DD_API_KEY")
 	}
-	client, err := telemetry.NewClient(c.serviceName, c.env, c.internalConfig.Version(), cfg)
+	client, err := telemetry.NewClient(c.serviceName, c.internalConfig.Env(), c.internalConfig.Version(), cfg)
 	if err != nil {
 		log.Debug("tracer: failed to create telemetry client: %s", err.Error())
 		return nil

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -252,7 +252,7 @@ func Start(opts ...StartOption) error {
 	cfg := remoteconfig.DefaultClientConfig()
 	cfg.AgentURL = t.config.agentURL.String()
 	cfg.AppVersion = t.config.internalConfig.Version()
-	cfg.Env = t.config.env
+	cfg.Env = t.config.internalConfig.Env()
 	cfg.HTTP = t.config.httpClient
 	cfg.ServiceName = t.config.serviceName
 	if err := t.startRemoteConfig(cfg); err != nil {
@@ -306,7 +306,7 @@ func storeConfig(c *config) {
 		Version:            version.Tag,
 		Hostname:           c.internalConfig.Hostname(),
 		ServiceName:        c.serviceName,
-		ServiceEnvironment: c.env,
+		ServiceEnvironment: c.internalConfig.Env(),
 		ServiceVersion:     c.internalConfig.Version(),
 		ProcessTags:        processtags.GlobalTags().String(),
 		ContainerID:        globalinternal.ContainerID(),
@@ -319,7 +319,7 @@ func storeConfig(c *config) {
 	}
 
 	processContext := otelProcessContext{
-		DeploymentEnvironmentName: c.env,
+		DeploymentEnvironmentName: c.internalConfig.Env(),
 		HostName:                  c.internalConfig.Hostname(),
 		ServiceInstanceID:         globalconfig.RuntimeID(),
 		ServiceName:               c.serviceName,
@@ -432,7 +432,7 @@ func newUnstartedTracer(opts ...StartOption) (t *tracer, err error) {
 		rulesSampler.traces.setTraceSampleRules, EqualsFalseNegative)
 	var dataStreamsProcessor *datastreams.Processor
 	if c.internalConfig.DataStreamsMonitoringEnabled() {
-		dataStreamsProcessor = datastreams.NewProcessor(statsd, c.env, c.serviceName, c.internalConfig.Version(), c.agentURL, c.httpClient)
+		dataStreamsProcessor = datastreams.NewProcessor(statsd, c.internalConfig.Env(), c.serviceName, c.internalConfig.Version(), c.agentURL, c.httpClient)
 	}
 	var logFile *log.ManagedFile
 	if v := c.internalConfig.LogDirectory(); v != "" {
@@ -784,8 +784,8 @@ func (t *tracer) StartSpan(operationName string, options ...StartSpanOption) *Sp
 			span.setMeta(ext.Version, t.config.internalConfig.Version())
 		}
 	}
-	if t.config.env != "" {
-		span.setMeta(ext.Environment, t.config.env)
+	if t.config.internalConfig.Env() != "" {
+		span.setMeta(ext.Environment, t.config.internalConfig.Env())
 	}
 	if _, ok := span.context.SamplingPriority(); !ok {
 		// if not already sampled or a brand new trace, sample it
@@ -978,7 +978,7 @@ func (t *tracer) TracerConf() TracerConf {
 		PartialFlushMinSpans: t.config.internalConfig.PartialFlushMinSpans(),
 		PeerServiceDefaults:  t.config.peerServiceDefaultsEnabled,
 		PeerServiceMappings:  t.config.peerServiceMappings,
-		EnvTag:               t.config.env,
+		EnvTag:               t.config.internalConfig.Env(),
 		VersionTag:           t.config.internalConfig.Version(),
 		ServiceTag:           t.config.serviceName,
 		TracingAsTransport:   t.config.tracingAsTransport,

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -2465,11 +2465,7 @@ func TestFlush(t *testing.T) {
 	tr.statsd = ts
 
 	transport := newDummyTransport()
-	cfg, err := newTestConfig(func(c *config) {
-		c.transport = transport
-		c.env = "someEnv"
-	})
-	assert.NoError(t, err)
+	cfg := newTestConfigWithTransportAndEnv(t, transport, "someEnv")
 	c := newConcentrator(cfg, defaultStatsBucketSize, &statsd.NoOpClientDirect{})
 	tr.stats.Stop()
 	tr.stats = c

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,9 +44,10 @@ type Config struct {
 	agentURL *url.URL
 	debug    bool
 	// logStartup, when true, causes various startup info to be written when the tracer starts.
-	logStartup      bool
-	serviceName     string
-	version         string
+	logStartup  bool
+	serviceName string
+	version     string
+	// env contains the environment that this application will run under.
 	env             string
 	serviceMappings map[string]string
 	// hostname is automatically assigned from the OS hostname, or from the DD_TRACE_SOURCE_HOSTNAME environment variable or WithHostname() option.
@@ -464,4 +465,17 @@ func (c *Config) SetVersion(version string, origin telemetry.Origin) {
 	defer c.mu.Unlock()
 	c.version = version
 	telemetry.RegisterAppConfig("DD_VERSION", version, origin)
+}
+
+func (c *Config) Env() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.env
+}
+
+func (c *Config) SetEnv(env string, origin telemetry.Origin) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.env = env
+	telemetry.RegisterAppConfig("DD_ENV", env, origin)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Migrates tracer to using Config.env instead of its local c.env.
Note: This PR migrated c.env specifically; other configurations that impact env will be migrated in subsequent PRs

### Motivation
datadoghq.atlassian.net/browse/APMAPI-1748 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
