### PR TITLE
chore(config): migrate serviceMappings

### DIFF
--- a/ddtrace/tracer/log.go
+++ b/ddtrace/tracer/log.go
@@ -137,7 +137,7 @@ func logStartup(t *tracer) {
 		SampleRateLimit:             "disabled",
 		TraceSamplingRules:          t.config.traceRules,
 		SpanSamplingRules:           t.config.spanRules,
-		ServiceMappings:             t.config.serviceMappings,
+		ServiceMappings:             t.config.internalConfig.ServiceMappings(),
 		Tags:                        tags,
 		RuntimeMetricsEnabled:       t.config.internalConfig.RuntimeMetricsEnabled(),
 		RuntimeMetricsV2Enabled:     t.config.internalConfig.RuntimeMetricsV2Enabled(),

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -798,10 +798,11 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		c, err := newTestConfig(WithAgentTimeout(2))
 
 		assert.NoError(err)
-		assert.Equal("test2", c.serviceMappings["tracer.test"])
-		assert.Equal("Newsvc", c.serviceMappings["svc"])
-		assert.Equal("myRouter", c.serviceMappings["http.router"])
-		assert.Equal("", c.serviceMappings["noval"])
+		serviceMappings := c.internalConfig.ServiceMappings()
+		assert.Equal("test2", serviceMappings["tracer.test"])
+		assert.Equal("Newsvc", serviceMappings["svc"])
+		assert.Equal("myRouter", serviceMappings["http.router"])
+		assert.Equal("", serviceMappings["noval"])
 	})
 
 	t.Run("datadog-tags", func(t *testing.T) {

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -82,7 +82,7 @@ func startTelemetry(c *config) telemetry.Client {
 	for k, v := range c.internalConfig.FeatureFlags() {
 		telemetryConfigs = append(telemetryConfigs, telemetry.Configuration{Name: k, Value: v})
 	}
-	for k, v := range c.serviceMappings {
+	for k, v := range c.internalConfig.ServiceMappings() {
 		telemetryConfigs = append(telemetryConfigs, telemetry.Configuration{Name: "service_mapping_" + k, Value: v})
 	}
 	for k, v := range c.globalTags.get() {

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -774,8 +774,8 @@ func (t *tracer) StartSpan(operationName string, options ...StartSpanOption) *Sp
 	for k, v := range t.config.globalTags.get() {
 		span.SetTag(k, v)
 	}
-	if t.config.serviceMappings != nil {
-		if newSvc, ok := t.config.serviceMappings[span.service]; ok {
+	if mappings := t.config.internalConfig.ServiceMappings(); mappings != nil {
+		if newSvc, ok := mappings[span.service]; ok {
 			span.service = newSvc
 		}
 	}
@@ -791,8 +791,8 @@ func (t *tracer) StartSpan(operationName string, options ...StartSpanOption) *Sp
 		// if not already sampled or a brand new trace, sample it
 		t.sample(span)
 	}
-	if t.config.serviceMappings != nil {
-		if newSvc, ok := t.config.serviceMappings[span.service]; ok {
+	if mappings := t.config.internalConfig.ServiceMappings(); mappings != nil {
+		if newSvc, ok := mappings[span.service]; ok {
 			span.service = newSvc
 		}
 	}

--- a/internal/config/configprovider.go
+++ b/internal/config/configprovider.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/dd-trace-go/v2/internal"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 )
 
@@ -147,35 +148,11 @@ func normalizeKey(key string) string {
 
 // parseMapString parses a string containing key:value pairs separated by comma or space.
 // Format: "key1:value1,key2:value2" or "key1:value1 key2:value2"
+// Uses internal.ForEachStringTag to ensure consistent parsing with other tag-like env vars.
 func parseMapString(str string) map[string]string {
 	result := make(map[string]string)
-
-	// Determine separator (comma or space)
-	sep := " "
-	if strings.Contains(str, ",") {
-		sep = ","
-	}
-
-	// Parse each key:value pair
-	for _, pair := range strings.Split(str, sep) {
-		pair = strings.TrimSpace(pair)
-		if pair == "" {
-			continue
-		}
-
-		// Split on colon delimiter
-		kv := strings.SplitN(pair, ":", 2)
-		key := strings.TrimSpace(kv[0])
-		if key == "" {
-			continue
-		}
-
-		var val string
-		if len(kv) == 2 {
-			val = strings.TrimSpace(kv[1])
-		}
+	internal.ForEachStringTag(str, internal.DDTagsDelimiter, func(key, val string) {
 		result[key] = val
-	}
-
+	})
 	return result
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Migrate tracer to use Config.serviceMapping instead of its local serviceMapping

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
