### PR TITLE
feat(contrib/mark3labs/mcp-go,contrib/modelcontextprotocol/go-sdk): Add mcp_method, mcp_tool, mcp_tool_kind tags to mcp server tracing

### DIFF
--- a/contrib/mark3labs/mcp-go/tracing_test.go
+++ b/contrib/mark3labs/mcp-go/tracing_test.go
@@ -176,6 +176,10 @@ func TestIntegrationToolCallSuccess(t *testing.T) {
 	assert.Contains(t, initSpan.Tags, expectedTag)
 	assert.Contains(t, toolSpan.Tags, expectedTag)
 
+	assert.Contains(t, toolSpan.Tags, "mcp_method:tools/call")
+	assert.Contains(t, toolSpan.Tags, "mcp_tool_kind:server")
+	assert.Contains(t, toolSpan.Tags, "mcp_tool:calculator")
+
 	assert.Equal(t, "calculator", toolSpan.Name)
 	assert.Equal(t, "tool", toolSpan.Meta["span.kind"])
 

--- a/contrib/modelcontextprotocol/go-sdk/tracing.go
+++ b/contrib/modelcontextprotocol/go-sdk/tracing.go
@@ -54,7 +54,9 @@ func traceToolCallRequest(next mcp.MethodHandler, ctx context.Context, method st
 	var err error
 
 	defer func() {
+		tagWithMethod(method, toolSpan)
 		tagWithSessionID(req, toolSpan)
+		toolSpan.Annotate(llmobs.WithAnnotatedTags(map[string]string{"mcp_tool": req.Params.Name, "mcp_tool_kind": "server"}))
 		finishSpanWithIO(toolSpan, method, req, result, err)
 	}()
 
@@ -83,6 +85,7 @@ func traceInitializeRequest(next mcp.MethodHandler, ctx context.Context, method 
 	var err error
 
 	defer func() {
+		tagWithMethod(method, taskSpan)
 		tagWithSessionID(req, taskSpan)
 		finishSpanWithIO(taskSpan, method, req, res, err)
 	}()
@@ -101,6 +104,10 @@ func tagWithSessionID(req mcp.Request, span llmobs.Span) {
 		return
 	}
 	span.Annotate(llmobs.WithAnnotatedTags(map[string]string{"mcp_session_id": sessionID}))
+}
+
+func tagWithMethod(method string, span llmobs.Span) {
+	span.Annotate(llmobs.WithAnnotatedTags(map[string]string{"mcp_method": method}))
 }
 
 type textIOSpan interface {

--- a/contrib/modelcontextprotocol/go-sdk/tracing_test.go
+++ b/contrib/modelcontextprotocol/go-sdk/tracing_test.go
@@ -178,6 +178,10 @@ func TestIntegrationToolCallSuccess(t *testing.T) {
 	require.NotNil(t, initSpan, "initialize span not found")
 	require.NotNil(t, toolSpan, "tool span not found")
 
+	assert.Contains(t, toolSpan.Tags, "mcp_method:tools/call")
+	assert.Contains(t, toolSpan.Tags, "mcp_tool_kind:server")
+	assert.Contains(t, toolSpan.Tags, "mcp_tool:calculator")
+
 	// Session id must be the same between spans
 	assert.Contains(t, initSpan.Tags, "mcp_session_id:"+sessionID)
 	assert.Contains(t, toolSpan.Tags, "mcp_session_id:"+sessionID)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Adds mcp_method, mcp_tool, and mcp_tool_kind tags. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

The mcp_method and mcp_tool tags will allow for more explicit span queries rather than relying on the span name and type. These were [changes I made in python](https://github.com/DataDog/dd-trace-py/pull/15648), and I'm bringing back to Go. 

The mcp_tool_kind span is something that was in the Python sdk historically to differentiate from client tool calls, and this makes Go spans match.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
