### PR TITLE
feat(contrib/mark3labs/mcp-go): Add mcp_method, mcp_tool, mcp_tool_kind tags to mcp server tracing

### DIFF
--- a/contrib/mark3labs/mcp-go/tracing.go
+++ b/contrib/mark3labs/mcp-go/tracing.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"github.com/DataDog/dd-trace-go/v2/instrumentation"
+	instrmcp "github.com/DataDog/dd-trace-go/v2/instrumentation/mcp"
 	"github.com/DataDog/dd-trace-go/v2/llmobs"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -51,6 +52,11 @@ var toolHandlerMiddleware = func(next server.ToolHandlerFunc) server.ToolHandler
 				outputText = string(resultJSON)
 			}
 
+			toolSpan.Annotate(llmobs.WithAnnotatedTags(map[string]string{
+				instrmcp.MCPToolTag:     request.Params.Name,
+				instrmcp.MCPToolKindTag: "server",
+				instrmcp.MCPMethodTag:   request.Method,
+			}))
 			tagWithSessionID(ctx, toolSpan)
 			toolSpan.AnnotateTextIO(string(inputJSON), outputText)
 
@@ -83,7 +89,11 @@ func (h *hooks) onBeforeInitialize(ctx context.Context, id any, request *mcp.Ini
 
 	clientName := request.Params.ClientInfo.Name
 	clientVersion := request.Params.ClientInfo.Version
-	taskSpan.Annotate(llmobs.WithAnnotatedTags(map[string]string{"client_name": clientName, "client_version": clientName + "_" + clientVersion}))
+	taskSpan.Annotate(llmobs.WithAnnotatedTags(map[string]string{
+		instrmcp.MCPClientNameTag:    clientName,
+		instrmcp.MCPClientVersionTag: clientName + "_" + clientVersion,
+		instrmcp.MCPMethodTag:        request.Method,
+	}))
 
 	h.spanCache.Store(id, taskSpan)
 	tagWithSessionID(ctx, taskSpan)
@@ -121,7 +131,7 @@ func tagWithSessionID(ctx context.Context, span llmobs.Span) {
 	session := server.ClientSessionFromContext(ctx)
 	if session != nil {
 		sessionID := session.SessionID()
-		span.Annotate(llmobs.WithAnnotatedTags(map[string]string{"mcp_session_id": sessionID}))
+		span.Annotate(llmobs.WithAnnotatedTags(map[string]string{instrmcp.MCPSessionIDTag: sessionID}))
 	}
 }
 

--- a/contrib/mark3labs/mcp-go/tracing_test.go
+++ b/contrib/mark3labs/mcp-go/tracing_test.go
@@ -79,6 +79,7 @@ func TestIntegrationSessionInitialize(t *testing.T) {
 	assert.Contains(t, taskSpan.Tags, "client_version:test-client_1.0.0")
 
 	assert.Contains(t, taskSpan.Tags, "mcp_session_id:test-session-init")
+	assert.Contains(t, taskSpan.Tags, "mcp_method:initialize")
 
 	assert.Contains(t, taskSpan.Meta, "input")
 	assert.Contains(t, taskSpan.Meta, "output")
@@ -175,6 +176,10 @@ func TestIntegrationToolCallSuccess(t *testing.T) {
 	expectedTag := "mcp_session_id:test-session-123"
 	assert.Contains(t, initSpan.Tags, expectedTag)
 	assert.Contains(t, toolSpan.Tags, expectedTag)
+
+	assert.Contains(t, toolSpan.Tags, "mcp_method:tools/call")
+	assert.Contains(t, toolSpan.Tags, "mcp_tool_kind:server")
+	assert.Contains(t, toolSpan.Tags, "mcp_tool:calculator")
 
 	assert.Equal(t, "calculator", toolSpan.Name)
 	assert.Equal(t, "tool", toolSpan.Meta["span.kind"])

--- a/instrumentation/mcp/mcp.go
+++ b/instrumentation/mcp/mcp.go
@@ -10,3 +10,10 @@ const DDTraceKey = "ddtrace"
 const IntentKey = "intent"
 
 const IntentPrompt string = "Briefly describe the wider context task, and why this tool was chosen. Omit argument values, PII/secrets. Use English."
+
+const MCPToolTag = "mcp_tool"
+const MCPToolKindTag = "mcp_tool_kind"
+const MCPMethodTag = "mcp_method"
+const MCPSessionIDTag = "mcp_session_id"
+const MCPClientNameTag = "client_name"
+const MCPClientVersionTag = "client_version"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Adds mcp_method, mcp_tool, and mcp_tool_kind tags. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

The mcp_method and mcp_tool tags will allow for more explicit span queries rather than relying on the span name and type. These were [changes I made in python](https://github.com/DataDog/dd-trace-py/pull/15648), and I'm bringing back to Go. 

The mcp_tool_kind span is something that was in the Python sdk historically to differentiate from client tool calls, and this makes Go spans match.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
