### PR TITLE
chore(config): migrate serviceName

### DIFF
--- a/ddtrace/tracer/log.go
+++ b/ddtrace/tracer/log.go
@@ -129,7 +129,7 @@ func logStartup(t *tracer) {
 		Lang:                        "Go",
 		LangVersion:                 runtime.Version(),
 		Env:                         t.config.internalConfig.Env(),
-		Service:                     t.config.serviceName,
+		Service:                     t.config.internalConfig.ServiceName(),
 		AgentURL:                    agentURL,
 		Debug:                       t.config.internalConfig.Debug(),
 		AnalyticsEnabled:            !math.IsNaN(globalconfig.AnalyticsRate()),

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -366,7 +366,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		c, err := newTestConfig()
 		assert.NoError(err)
 		assert.Equal(float64(1), c.sampler.Rate())
-		assert.Regexp(`tracer\.test(\.exe)?`, c.serviceName)
+		assert.Regexp(`tracer\.test(\.exe)?`, c.internalConfig.ServiceName())
 		assert.Equal(&url.URL{Scheme: "http", Host: "localhost:8126"}, c.agentURL)
 		assert.Equal("localhost:8125", c.dogstatsdAddr)
 		assert.Nil(nil, c.httpClient)
@@ -1063,7 +1063,7 @@ func TestServiceName(t *testing.T) {
 			WithService("api-intake"),
 		)
 		assert.NoError(err)
-		assert.Equal("api-intake", c.serviceName)
+		assert.Equal("api-intake", c.internalConfig.ServiceName())
 		assert.Equal("api-intake", globalconfig.ServiceName())
 	})
 
@@ -1074,7 +1074,7 @@ func TestServiceName(t *testing.T) {
 		c, err := newTestConfig()
 
 		assert.NoError(err)
-		assert.Equal("api-intake", c.serviceName)
+		assert.Equal("api-intake", c.internalConfig.ServiceName())
 		assert.Equal("api-intake", globalconfig.ServiceName())
 	})
 
@@ -1087,7 +1087,7 @@ func TestServiceName(t *testing.T) {
 		c, err := newTestConfig()
 		assert.NoError(err)
 
-		assert.Equal("api-intake", c.serviceName)
+		assert.Equal("api-intake", c.internalConfig.ServiceName())
 		assert.Equal("api-intake", globalconfig.ServiceName())
 	})
 
@@ -1096,7 +1096,7 @@ func TestServiceName(t *testing.T) {
 		assert := assert.New(t)
 		c, err := newTestConfig(WithGlobalTag("service", "api-intake"))
 		assert.NoError(err)
-		assert.Equal("api-intake", c.serviceName)
+		assert.Equal("api-intake", c.internalConfig.ServiceName())
 		assert.Equal("api-intake", globalconfig.ServiceName())
 	})
 
@@ -1109,7 +1109,7 @@ func TestServiceName(t *testing.T) {
 		c, err := newTestConfig()
 		assert.NoError(err)
 
-		assert.Equal("api-intake", c.serviceName)
+		assert.Equal("api-intake", c.internalConfig.ServiceName())
 		assert.Equal("api-intake", globalconfig.ServiceName())
 	})
 
@@ -1120,7 +1120,7 @@ func TestServiceName(t *testing.T) {
 		c, err := newTestConfig()
 		assert.NoError(err)
 
-		assert.Equal("api-intake", c.serviceName)
+		assert.Equal("api-intake", c.internalConfig.ServiceName())
 		assert.Equal("api-intake", globalconfig.ServiceName())
 	})
 
@@ -1132,47 +1132,47 @@ func TestServiceName(t *testing.T) {
 		globalconfig.SetServiceName("")
 		c, err := newTestConfig()
 		assert.NoError(err)
-		assert.Equal(c.serviceName, filepath.Base(os.Args[0]))
+		assert.Equal(c.internalConfig.ServiceName(), filepath.Base(os.Args[0]))
 		assert.Equal("", globalconfig.ServiceName())
 
 		t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=testService6")
 		globalconfig.SetServiceName("")
 		c, err = newTestConfig()
 		assert.NoError(err)
-		assert.Equal(c.serviceName, "testService6")
+		assert.Equal(c.internalConfig.ServiceName(), "testService6")
 		assert.Equal("testService6", globalconfig.ServiceName())
 
 		t.Setenv("DD_TAGS", "service:testService")
 		globalconfig.SetServiceName("")
 		c, err = newTestConfig()
 		assert.NoError(err)
-		assert.Equal(c.serviceName, "testService")
+		assert.Equal(c.internalConfig.ServiceName(), "testService")
 		assert.Equal("testService", globalconfig.ServiceName())
 
 		globalconfig.SetServiceName("")
 		c, err = newTestConfig(WithGlobalTag("service", "testService2"))
 		assert.NoError(err)
-		assert.Equal(c.serviceName, "testService2")
+		assert.Equal(c.internalConfig.ServiceName(), "testService2")
 		assert.Equal("testService2", globalconfig.ServiceName())
 
 		t.Setenv("OTEL_SERVICE_NAME", "testService3")
 		globalconfig.SetServiceName("")
 		c, err = newTestConfig(WithGlobalTag("service", "testService2"))
 		assert.NoError(err)
-		assert.Equal(c.serviceName, "testService3")
+		assert.Equal(c.internalConfig.ServiceName(), "testService3")
 		assert.Equal("testService3", globalconfig.ServiceName())
 
 		t.Setenv("DD_SERVICE", "testService4")
 		globalconfig.SetServiceName("")
 		c, err = newTestConfig(WithGlobalTag("service", "testService2"), WithService("testService4"))
 		assert.NoError(err)
-		assert.Equal(c.serviceName, "testService4")
+		assert.Equal(c.internalConfig.ServiceName(), "testService4")
 		assert.Equal("testService4", globalconfig.ServiceName())
 
 		globalconfig.SetServiceName("")
 		c, err = newTestConfig(WithGlobalTag("service", "testService2"), WithService("testService5"))
 		assert.NoError(err)
-		assert.Equal(c.serviceName, "testService5")
+		assert.Equal(c.internalConfig.ServiceName(), "testService5")
 		assert.Equal("testService5", globalconfig.ServiceName())
 	})
 }

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -44,7 +44,7 @@ func startTelemetry(c *config) telemetry.Client {
 		{Name: "send_retries", Value: c.sendRetries},
 		{Name: "retry_interval", Value: c.internalConfig.RetryInterval()},
 		{Name: "trace_startup_logs_enabled", Value: c.internalConfig.LogStartup()},
-		{Name: "service", Value: c.serviceName},
+		{Name: "service", Value: c.internalConfig.ServiceName()},
 		{Name: "universal_version", Value: c.universalVersion},
 		{Name: "env", Value: c.internalConfig.Env()},
 		{Name: "version", Value: c.internalConfig.Version()},
@@ -114,7 +114,7 @@ func startTelemetry(c *config) telemetry.Client {
 	if c.internalConfig.LogToStdout() || c.ciVisibilityAgentless {
 		cfg.APIKey = env.Get("DD_API_KEY")
 	}
-	client, err := telemetry.NewClient(c.serviceName, c.internalConfig.Env(), c.internalConfig.Version(), cfg)
+	client, err := telemetry.NewClient(c.internalConfig.ServiceName(), c.internalConfig.Env(), c.internalConfig.Version(), cfg)
 	if err != nil {
 		log.Debug("tracer: failed to create telemetry client: %s", err.Error())
 		return nil

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -391,7 +391,7 @@ func TestSamplingDecision(t *testing.T) {
 		tracer, _, _, stop, err := startTestTracer(t)
 		assert.Nil(t, err)
 		tracer.prioritySampling.defaultRate = 1
-		tracer.config.serviceName = "test_service"
+		tracer.config.internalConfig.SetServiceName("test_service", internalconfig.OriginCode)
 		span := tracer.StartSpan("name_1")
 		child := tracer.StartSpan("name_2", ChildOf(span.context))
 		child.Finish()
@@ -411,7 +411,7 @@ func TestSamplingDecision(t *testing.T) {
 		tracer, _, _, stop, err := startTestTracer(t, WithStatsComputation(false))
 		assert.Nil(t, err)
 		tracer.prioritySampling.defaultRate = 0
-		tracer.config.serviceName = "test_service"
+		tracer.config.internalConfig.SetServiceName("test_service", internalconfig.OriginCode)
 		span := tracer.StartSpan("name_1")
 		child := tracer.StartSpan("name_2", ChildOf(span.context))
 		child.Finish()
@@ -429,7 +429,7 @@ func TestSamplingDecision(t *testing.T) {
 		tracer, _, _, stop, err := startTestTracer(t)
 		assert.Nil(t, err)
 		tracer.prioritySampling.defaultRate = 0
-		tracer.config.serviceName = "test_service"
+		tracer.config.internalConfig.SetServiceName("test_service", internalconfig.OriginCode)
 		span := tracer.StartSpan("name_1")
 		child := tracer.StartSpan("name_2", ChildOf(span.context))
 		child.Finish()
@@ -447,7 +447,7 @@ func TestSamplingDecision(t *testing.T) {
 		tracer, _, _, stop, err := startTestTracer(t)
 		assert.Nil(t, err)
 		tracer.prioritySampling.defaultRate = 0
-		tracer.config.serviceName = "test_service"
+		tracer.config.internalConfig.SetServiceName("test_service", internalconfig.OriginCode)
 		span := tracer.StartSpan("name_1")
 		child := tracer.StartSpan("name_2", ChildOf(span.context))
 		child.SetTag(ext.EventSampleRate, 1)
@@ -467,7 +467,7 @@ func TestSamplingDecision(t *testing.T) {
 		assert.Nil(t, err)
 		tracer.config.sampler = NewRateSampler(0)
 		tracer.prioritySampling.defaultRate = 0
-		tracer.config.serviceName = "test_service"
+		tracer.config.internalConfig.SetServiceName("test_service", internalconfig.OriginCode)
 		span := tracer.StartSpan("name_1")
 		child := tracer.StartSpan("name_2", ChildOf(span.context))
 		child.SetTag(ext.EventSampleRate, 1)
@@ -496,7 +496,7 @@ func TestSamplingDecision(t *testing.T) {
 		tracer.config.internalConfig.SetFeatureFlags([]string{"discovery"}, internalconfig.OriginCode)
 		tracer.config.sampler = NewRateSampler(0)
 		tracer.prioritySampling.defaultRate = 0
-		tracer.config.serviceName = "test_service"
+		tracer.config.internalConfig.SetServiceName("test_service", internalconfig.OriginCode)
 		parent := tracer.StartSpan("name_1")
 		child := tracer.StartSpan("name_2", ChildOf(parent.context))
 		child.Finish()
@@ -520,7 +520,7 @@ func TestSamplingDecision(t *testing.T) {
 		assert.Nil(t, err)
 		tracer.config.sampler = NewRateSampler(0)
 		tracer.prioritySampling.defaultRate = 0
-		tracer.config.serviceName = "test_service"
+		tracer.config.internalConfig.SetServiceName("test_service", internalconfig.OriginCode)
 		parent := tracer.StartSpan("name_1")
 		child := tracer.StartSpan("name_2", ChildOf(parent.context))
 		child.Finish()
@@ -544,7 +544,7 @@ func TestSamplingDecision(t *testing.T) {
 		assert.Nil(t, err)
 		tracer.config.sampler = NewRateSampler(0)
 		tracer.prioritySampling.defaultRate = 0
-		tracer.config.serviceName = "test_service"
+		tracer.config.internalConfig.SetServiceName("test_service", internalconfig.OriginCode)
 		parent := tracer.StartSpan("name_1")
 		child := tracer.StartSpan("name_2", ChildOf(parent.context))
 		child.Finish()
@@ -568,7 +568,7 @@ func TestSamplingDecision(t *testing.T) {
 		assert.Nil(t, err)
 		tracer.config.sampler = NewRateSampler(1)
 		tracer.prioritySampling.defaultRate = 1
-		tracer.config.serviceName = "test_service"
+		tracer.config.internalConfig.SetServiceName("test_service", internalconfig.OriginCode)
 		parent := tracer.StartSpan("name_1")
 		child := tracer.StartSpan("name_2", ChildOf(parent.context))
 		child.Finish()
@@ -598,7 +598,7 @@ func TestSamplingDecision(t *testing.T) {
 			nowTime = func() time.Time { return time.Now() }
 		}()
 		defer stop()
-		tracer.config.serviceName = "test_service"
+		tracer.config.internalConfig.SetServiceName("test_service", internalconfig.OriginCode)
 		var spans []*Span
 		for i := 0; i < 100; i++ {
 			s := tracer.StartSpan(fmt.Sprintf("name_%d", i))
@@ -637,7 +637,7 @@ func TestSamplingDecision(t *testing.T) {
 		tracer, _, _, stop, err := startTestTracer(t)
 		assert.Nil(t, err)
 		defer stop()
-		tracer.config.serviceName = "test_service"
+		tracer.config.internalConfig.SetServiceName("test_service", internalconfig.OriginCode)
 		spans := []*Span{}
 		for i := 0; i < 100; i++ {
 			s := tracer.StartSpan("name_1")
@@ -672,7 +672,7 @@ func TestSamplingDecision(t *testing.T) {
 		tracer, _, _, stop, err := startTestTracer(t)
 		assert.Nil(t, err)
 		defer stop()
-		tracer.config.serviceName = "test_service"
+		tracer.config.internalConfig.SetServiceName("test_service", internalconfig.OriginCode)
 		spans := []*Span{}
 		for i := 0; i < 100; i++ {
 			s := tracer.StartSpan("name_1")
@@ -2640,7 +2640,7 @@ func BenchmarkSingleSpanRetention(b *testing.B) {
 		tracer.config.internalConfig.SetFeatureFlags([]string{"discovery"}, internalconfig.OriginCode)
 		tracer.config.sampler = NewRateSampler(0)
 		tracer.prioritySampling.defaultRate = 0
-		tracer.config.serviceName = "test_service"
+		tracer.config.internalConfig.SetServiceName("test_service", internalconfig.OriginCode)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			span := tracer.StartSpan("name_1")
@@ -2660,7 +2660,7 @@ func BenchmarkSingleSpanRetention(b *testing.B) {
 		tracer.config.internalConfig.SetFeatureFlags([]string{"discovery"}, internalconfig.OriginCode)
 		tracer.config.sampler = NewRateSampler(0)
 		tracer.prioritySampling.defaultRate = 0
-		tracer.config.serviceName = "test_service"
+		tracer.config.internalConfig.SetServiceName("test_service", internalconfig.OriginCode)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			span := tracer.StartSpan("name_1")
@@ -2684,7 +2684,7 @@ func BenchmarkSingleSpanRetention(b *testing.B) {
 		tracer.config.internalConfig.SetFeatureFlags([]string{"discovery"}, internalconfig.OriginCode)
 		tracer.config.sampler = NewRateSampler(0)
 		tracer.prioritySampling.defaultRate = 0
-		tracer.config.serviceName = "test_service"
+		tracer.config.internalConfig.SetServiceName("test_service", internalconfig.OriginCode)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			span := tracer.StartSpan("name_1")
@@ -2815,7 +2815,7 @@ func TestEmptyChunksNotSent(t *testing.T) {
 
 	tracer.config.internalConfig.SetStatsComputationEnabled(true, internalconfig.OriginCode)
 	tracer.prioritySampling.defaultRate = 0
-	tracer.config.serviceName = "test_service"
+	tracer.config.internalConfig.SetServiceName("test_service", internalconfig.OriginCode)
 
 	span := tracer.StartSpan("name_1")
 	child := tracer.StartSpan("name_2", ChildOf(span.Context()))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,7 +46,8 @@ type Config struct {
 	agentURL *url.URL
 	debug    bool
 	// logStartup, when true, causes various startup info to be written when the tracer starts.
-	logStartup  bool
+	logStartup bool
+	// serviceName specifies the name of this application.
 	serviceName string
 	version     string
 	// env contains the environment that this application will run under.
@@ -564,4 +565,17 @@ func (c *Config) SetRetryInterval(interval time.Duration, origin telemetry.Origi
 	defer c.mu.Unlock()
 	c.retryInterval = interval
 	telemetry.RegisterAppConfig("DD_TRACE_RETRY_INTERVAL", interval, origin)
+}
+
+func (c *Config) ServiceName() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.serviceName
+}
+
+func (c *Config) SetServiceName(name string, origin telemetry.Origin) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.serviceName = name
+	telemetry.RegisterAppConfig("DD_SERVICE", name, origin)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Migrates tracer to use Config.serviceName instead of its local serviceName.
Note that this PR is narrowly scoped; in the future, we can get rid of setting service name on globalconfig altogether, and likely stop passing in the service name to other products, as these products/packages will just query the Config singleton directly.

### Motivation

Go config revamp

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
