### PR TITLE
test(contrib/ibm/sarama): fix consumer group flaky test

### DIFF
--- a/contrib/IBM/sarama/consumer_test.go
+++ b/contrib/IBM/sarama/consumer_test.go
@@ -8,6 +8,7 @@ package sarama
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/IBM/sarama"
 	"github.com/stretchr/testify/assert"
@@ -61,7 +62,7 @@ func TestWrapConsumer(t *testing.T) {
 	require.NoError(t, err)
 	// wait for the channel to be closed
 	<-partitionConsumer.Messages()
-	waitForSpans(mt, 2)
+	waitForSpans(t, mt, 2, 5*time.Second)
 
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 2)
@@ -157,7 +158,7 @@ func TestWrapConsumerWithCustomConsumerSpanOptions(t *testing.T) {
 	require.NoError(t, err)
 	// wait for the channel to be closed
 	<-partitionConsumer.Messages()
-	waitForSpans(mt, 1)
+	waitForSpans(t, mt, 1, 5*time.Second)
 
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)

--- a/contrib/IBM/sarama/producer_test.go
+++ b/contrib/IBM/sarama/producer_test.go
@@ -7,6 +7,7 @@ package sarama
 
 import (
 	"testing"
+	"time"
 
 	"github.com/IBM/sarama"
 	"github.com/stretchr/testify/assert"
@@ -183,7 +184,7 @@ func TestWrapAsyncProducer(t *testing.T) {
 		}
 		producer.Input() <- msg1
 
-		waitForSpans(mt, 1)
+		waitForSpans(t, mt, 1, 5*time.Second)
 
 		spans := mt.FinishedSpans()
 		require.Len(t, spans, 1)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
The consumer group integration for IBM/sarama finishes receive message spans once the next message is received or when the consumer shuts down (detected when the underlying channel is closed).

Before these changes, the test was uselessly waiting for 2 spans for 5 seconds before shutting down the consumer, and immediately after shutting down the consumer group, giving a smaller window of time for the last span to be received, and therefore being flaky:

Here its shown how the test was always lasting 5+ seconds to finish consistently:
 
```
INTEGRATION=1 go test -v -run TestWrapConsumerGroupHandler -count=50 -failfast ./contrib/IBM/sarama/
=== RUN   TestWrapConsumerGroupHandler
2025/12/18 11:20:45 Sarama consumer up and running!...
    consumer_group_test.go:146: Message claimed: value = test 1, timestamp = 2025-12-18 11:20:45.232 +0100 CET, topic = IBM_sarama_TestWrapConsumerGroupHandler
--- PASS: TestWrapConsumerGroupHandler (6.08s)
=== RUN   TestWrapConsumerGroupHandler
2025/12/18 11:20:50 Sarama consumer up and running!...
    consumer_group_test.go:146: Message claimed: value = test 1, timestamp = 2025-12-18 11:20:50.484 +0100 CET, topic = IBM_sarama_TestWrapConsumerGroupHandler
--- PASS: TestWrapConsumerGroupHandler (5.20s)
=== RUN   TestWrapConsumerGroupHandler
2025/12/18 11:20:55 Sarama consumer up and running!...
    consumer_group_test.go:146: Message claimed: value = test 1, timestamp = 2025-12-18 11:20:55.681 +0100 CET, topic = IBM_sarama_TestWrapConsumerGroupHandler
--- PASS: TestWrapConsumerGroupHandler (5.20s)
=== RUN   TestWrapConsumerGroupHandler
```

This PR changes the order in which this happens: first shutdown the consumer, then wait for the spans to be received with a timeout of 5 seconds. This considerably reduces the duration of the test and hopefully fixes the flakiness:

```
 INTEGRATION=1 go test -v -run TestWrapConsumerGroupHandler -count=50 -failfast ./contrib/IBM/sarama/
=== RUN   TestWrapConsumerGroupHandler
2025/12/18 11:25:58 Sarama consumer up and running!...
    consumer_group_test.go:152: Message claimed: value = test 1, timestamp = 2025-12-18 11:25:58.263 +0100 CET, topic = IBM_sarama_TestWrapConsumerGroupHandler
--- PASS: TestWrapConsumerGroupHandler (0.64s)
=== RUN   TestWrapConsumerGroupHandler
2025/12/18 11:25:58 Sarama consumer up and running!...
    consumer_group_test.go:152: Message claimed: value = test 1, timestamp = 2025-12-18 11:25:58.904 +0100 CET, topic = IBM_sarama_TestWrapConsumerGroupHandler
--- PASS: TestWrapConsumerGroupHandler (0.64s)
=== RUN   TestWrapConsumerGroupHandler
2025/12/18 11:25:59 Sarama consumer up and running!...

....


PASS
ok  	github.com/DataDog/dd-trace-go/contrib/IBM/sarama/v2	32.852s
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
