### PR TITLE
fix(instrumentation/testutils/containers): stop log producers on cleanup

### DIFF
--- a/instrumentation/testutils/containers/cleanup.go
+++ b/instrumentation/testutils/containers/cleanup.go
@@ -20,6 +20,12 @@ import (
 // RegisterContainerCleanup registers a function to terminate the provided container to be executed after the test finishes.
 func RegisterContainerCleanup(t testing.TB, container testcontainers.Container) {
 	t.Cleanup(func() {
+		// Always stop log production to prevent goroutines from logging after the test completes
+		if err := container.StopLogProducer(); err != nil {
+			t.Logf("failed to stop log producer: %v", err)
+		}
+
+		// In CI, we skip container termination to allow container reuse
 		if _, ok := env.Lookup("CI"); ok {
 			t.Log("skipping container cleanup in CI environment")
 			return


### PR DESCRIPTION
### What does this PR do?

Adds a call to `container.StopLogProducer` when cleaning up a container. If `CI=true`, new log producers are created when the container is reused.

This has been validated with AI assistance:

```go
package main

import (
	"context"
	"fmt"
	"os"
	"testing"
	"time"

	"github.com/testcontainers/testcontainers-go"
	"github.com/testcontainers/testcontainers-go/modules/mongodb"
)

type testLogger struct {
	name string
}

func (t testLogger) Accept(log testcontainers.Log) {
	fmt.Printf("[%s] %s\n", t.name, string(log.Content))
}

func main() {
	os.Setenv("CI", "true")

	// First test
	fmt.Println("\n=== FIRST TEST ===")
	t1 := &testing.T{}
	container1, err := mongodb.Run(context.Background(), "mongo:8",
		testcontainers.WithLogConsumers(testLogger{"TEST1"}),
		testcontainers.CustomizeRequest(testcontainers.GenericContainerRequest{
			ContainerRequest: testcontainers.ContainerRequest{
				Name: "test-mongo",
			},
			Started: true,
			Reuse:   true,
		}),
	)
	if err != nil {
		panic(err)
	}

	time.Sleep(2 * time.Second)
	fmt.Println("Stopping log producer for TEST1...")
	if err := container1.StopLogProducer(); err != nil {
		fmt.Printf("Error stopping log producer: %v\n", err)
	}
	fmt.Println("TEST1 complete, container NOT terminated\n")

	// Second test - reusing container
	fmt.Println("=== SECOND TEST (reusing container) ===")
	t2 := &testing.T{}
	container2, err := mongodb.Run(context.Background(), "mongo:8",
		testcontainers.WithLogConsumers(testLogger{"TEST2"}),
		testcontainers.CustomizeRequest(testcontainers.GenericContainerRequest{
			ContainerRequest: testcontainers.ContainerRequest{
				Name: "test-mongo",
			},
			Started: true,
			Reuse:   true,
		}),
	)
	if err != nil {
		panic(err)
	}

	time.Sleep(2 * time.Second)
	fmt.Println("Stopping log producer for TEST2...")
	if err := container2.StopLogProducer(); err != nil {
		fmt.Printf("Error stopping log producer: %v\n", err)
	}
	fmt.Println("TEST2 complete")

	// Cleanup
	fmt.Println("\n=== CLEANUP ===")
	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
	defer cancel()
	if err := container2.Terminate(ctx); err != nil {
		fmt.Printf("Error terminating: %v\n", err)
	}

	_ = t1
	_ = t2
}


```

### Motivation

Avoid issues like [this one](https://github.com/DataDog/dd-trace-go/pull/4294#issuecomment-3669541870):

```
Failed

-test.shuffle 1766053058601918740
PASS
panic: Log in goroutine after Test has completed: {"t":{"$date":"2025-12-18T10:17:38.832+00:00"},"s":"I",  "c":"-",        "id":20883,   "ctx":"conn2","msg":"Interrupted operation as its client disconnected","attr":{"opId":16385}}
	    
	

goroutine 90 [running]:
testing.(*common).log(0xc00023ee00, {0xc000160240?, 0xb6?})
...
```

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
