### PR TITLE
feat: introduce `noprotobuf` build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,10 @@ test-deadlock: tools-install ## Run tests with deadlock detection
 test-debug-deadlock: tools-install ## Run tests with debug and deadlock detection
 	BUILD_TAGS=debug,deadlock $(BIN_PATH) ./scripts/test.sh --all
 
+.PHONY: test-noprotobuf
+test-noprotobuf: tools-install ## Run tests with noprotobuf build tag
+	BUILD_TAGS=noprotobuf $(BIN_PATH) ./scripts/test.sh --all
+
 .PHONY: fix-modules
 fix-modules: tools-install ## Fix module dependencies and consistency
 	$(BIN_PATH) ./scripts/fix_modules.sh

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Targets:
   test/integration     Run integration tests
   test-deadlock        Run tests with deadlock detection
   test-debug-deadlock  Run tests with debug and deadlock detection
+  test-noprotobuf      Run tests with noprotobuf build tag
   fix-modules          Fix module dependencies and consistency
   docs                 Generate and Update embedded documentation in README files
   upgrade/orchestrion  Upgrade Orchestrion and fix modules

--- a/ddtrace/tracer/abandonedspans_test.go
+++ b/ddtrace/tracer/abandonedspans_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/civisibility_nooptracer_test.go
+++ b/ddtrace/tracer/civisibility_nooptracer_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/civisibility_payload_test.go
+++ b/ddtrace/tracer/civisibility_payload_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/civisibility_transport_test.go
+++ b/ddtrace/tracer/civisibility_transport_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/civisibility_writer_test.go
+++ b/ddtrace/tracer/civisibility_writer_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/data_streams_noprotobuf_test.go
+++ b/ddtrace/tracer/data_streams_noprotobuf_test.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build noprotobuf
+
+package tracer
+
+import (
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/log"
+)
+
+func TestTrackKafkaCommitOffset(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("DSM panicked: %v", r)
+		}
+	}()
+	Start(WithTestDefaults(nil), WithLogger(log.DiscardLogger{}))
+	defer Stop()
+
+	TrackKafkaCommitOffset("group", "topic", 1, 0)
+}
+
+func TestNewProcessorNoProtobuf(t *testing.T) {
+	t.Setenv("DD_DATA_STREAMS_ENABLED", "true")
+
+	Start(WithTestDefaults(nil), WithLogger(log.DiscardLogger{}))
+	defer Stop()
+
+	var (
+		tr dataStreamsContainer
+		ok bool
+	)
+	if tr, ok = getGlobalTracer().(dataStreamsContainer); !ok {
+		t.Fatalf("Tracer doesn't support DSM")
+	}
+	if p := tr.GetDataStreamsProcessor(); p != nil {
+		t.Fatalf("NewProcessor with tag noprotobuf should return nil")
+	}
+}

--- a/ddtrace/tracer/log_test.go
+++ b/ddtrace/tracer/log_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/metrics_test.go
+++ b/ddtrace/tracer/metrics_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/payload_test.go
+++ b/ddtrace/tracer/payload_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/remote_config_test.go
+++ b/ddtrace/tracer/remote_config_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/sampler_test.go
+++ b/ddtrace/tracer/sampler_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/span_event_test.go
+++ b/ddtrace/tracer/span_event_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/stats.go
+++ b/ddtrace/tracer/stats.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (
@@ -100,10 +102,6 @@ func newConcentrator(c *config, bucketSize int64, statsdClient internal.StatsdCl
 		statsdClient:     statsdClient,
 	}
 }
-
-// alignTs returns the provided timestamp truncated to the bucket size.
-// It gives us the start time of the time bucket in which such timestamp falls.
-func alignTs(ts, bucketSize int64) int64 { return ts - ts%bucketSize }
 
 // Start starts the concentrator. A started concentrator needs to be stopped
 // in order to gracefully shut down, using Stop.

--- a/ddtrace/tracer/stats_noprotobuf.go
+++ b/ddtrace/tracer/stats_noprotobuf.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+//go:build noprotobuf
+
+package tracer
+
+import (
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/obfuscate"
+)
+
+var (
+	defaultStatsBucketSize = 10
+	withCurrentBucket      = true
+)
+
+type concentrator struct {
+	In chan any
+}
+
+func newConcentrator(_ any, _ int, _ any) *concentrator {
+	return nil
+}
+
+func (*concentrator) Start() {
+}
+
+func (*concentrator) Stop() {
+}
+
+func (*concentrator) newTracerStatSpan(_ *Span, _ *obfuscate.Obfuscator) (any, bool) {
+	return nil, false
+}
+
+func (*concentrator) flushAndSend(_ time.Time, _ any) {
+}

--- a/ddtrace/tracer/stats_test.go
+++ b/ddtrace/tracer/stats_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/time.go
+++ b/ddtrace/tracer/time.go
@@ -15,3 +15,7 @@ var nowTime = func() time.Time { return time.Now() }
 
 // now returns the current UNIX time in nanoseconds, as computed by Time.UnixNano().
 var now = func() int64 { return time.Now().UnixNano() }
+
+// alignTs returns the provided timestamp truncated to the bucket size.
+// It gives us the start time of the time bucket in which such timestamp falls.
+func alignTs(ts, bucketSize int64) int64 { return ts - ts%bucketSize }

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/transport_bench_test.go
+++ b/ddtrace/tracer/transport_bench_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/util_test.go
+++ b/ddtrace/tracer/util_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/writer_bench_test.go
+++ b/ddtrace/tracer/writer_bench_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/ddtrace/tracer/writer_test.go
+++ b/ddtrace/tracer/writer_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
+//go:build !noprotobuf
+
 package tracer
 
 import (

--- a/internal/datastreams/fast_queue.go
+++ b/internal/datastreams/fast_queue.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !noprotobuf
+
 package datastreams
 
 import (

--- a/internal/datastreams/fast_queue_test.go
+++ b/internal/datastreams/fast_queue_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !noprotobuf
+
 package datastreams
 
 import (

--- a/internal/datastreams/pathway_test.go
+++ b/internal/datastreams/pathway_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !noprotobuf
+
 package datastreams
 
 import (

--- a/internal/datastreams/processor.go
+++ b/internal/datastreams/processor.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !noprotobuf
+
 package datastreams
 
 import (

--- a/internal/datastreams/processor_noprotobuf.go
+++ b/internal/datastreams/processor_noprotobuf.go
@@ -32,8 +32,10 @@ func (*Processor) SetCheckpointWithParams(ctx context.Context, _ options.Checkpo
 	return ctx
 }
 
-func (*Processor) TrackKafkaCommitOffset(_, _ string, _ int32, _ int64) {}
+func (*Processor) TrackKafkaCommitOffset(_, _ string, _ int32, _ int64) {
+	panic("not implemented")
+}
 
 func (*Processor) TrackKafkaProduceOffset(_ string, _ int32, _ int64) {}
 
-func (*Processor) TrackKafkaHighWatermarkOffset(_ string, _ string, _ int32, _ int64)
+func (*Processor) TrackKafkaHighWatermarkOffset(_ string, _ string, _ int32, _ int64) {}

--- a/internal/datastreams/processor_noprotobuf.go
+++ b/internal/datastreams/processor_noprotobuf.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build noprotobuf
+
+package datastreams
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"github.com/DataDog/dd-trace-go/v2/datastreams/options"
+	"github.com/DataDog/dd-trace-go/v2/internal"
+)
+
+type Processor struct{}
+
+func NewProcessor(_ internal.StatsdClient, _, _, _ string, _ *url.URL, _ *http.Client) *Processor {
+	return nil
+}
+
+func (*Processor) Start() {}
+
+func (*Processor) Stop() {}
+
+func (*Processor) Flush() {}
+
+func (*Processor) SetCheckpointWithParams(ctx context.Context, _ options.CheckpointParams, _ ...string) context.Context {
+	return ctx
+}
+
+func (*Processor) TrackKafkaCommitOffset(_, _ string, _ int32, _ int64) {}
+
+func (*Processor) TrackKafkaProduceOffset(_ string, _ int32, _ int64) {}
+
+func (*Processor) TrackKafkaHighWatermarkOffset(_ string, _ string, _ int32, _ int64)

--- a/internal/datastreams/processor_test.go
+++ b/internal/datastreams/processor_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !noprotobuf
+
 package datastreams
 
 import (


### PR DESCRIPTION
### What does this PR do?

Adds `noprotobuf` to enable reduced binaries adding a `datastreams.Processor` no-op implementation that doesn't depend on `google.golang.org/protobuf`.

### Motivation

Introduce mechanisms for removing unneeded dependencies.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
