### PR TITLE
docs: add known build flags to reduce size of instrumented binaries (& scout rule)

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -3,7 +3,7 @@ This document contains answers to questions frequently asked by users. Just beca
 
 ## How can I reduce the size of my instrumented binaries?
 You can use the tags below to reduce the size of your binaries (note that some tags disable features):
-- `datadog.no_waf`: forces AAP's WAF to be disabled, so Application Security detections and blocking will not run even if AppSec is enabled.
+- `datadog.no_waf`: forces AAP's WAF to be disabled, so Application Security Monitoring features can't be activated if you specify this build tag.
 - `grpcnotrace` ([only for gRPC users](https://github.com/grpc/grpc-go/pull/6954)): disables gRPC's built-in `golang.org/x/net/trace` debug tracing endpoints (avoids the `reflect.MethodByName` dependency).
 - `nomsgpack` ([only for Gin users](https://github.com/gin-gonic/gin/blob/master/docs/doc.md#build-without-msgpack-rendering-feature)): disables msgpack binding/rendering support in Gin; msgpack-based request/response handling will not be available (dd-trace-go's msgpack usage is unaffected).
 


### PR DESCRIPTION
### What does this PR do?

Adds a new FAQ about known build tags to reduce size of instrumented binaries. More to come.

Smaller edits to the rest of FAQs to ensure their relevance.

### Motivation

Ensure this knowledge is easier to discover.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
