### PR TITLE
feat(.github/workflows): use `registry.datadoghq.com` to pull agent in CI

### DIFF
--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -61,7 +61,7 @@ jobs:
         chunk: ${{ fromJson(needs.set-up.outputs.matrix) }}
     services:
       datadog-agent:
-        image: datadog/agent:latest
+        image: registry.datadoghq.com/agent:latest
         env:
           DD_HOSTNAME: "github-actions-worker"
           DD_APM_ENABLED: true
@@ -277,7 +277,7 @@ jobs:
        INTEGRATION: true
     services:
       datadog-agent:
-        image: datadog/agent:latest
+        image: registry.datadoghq.com/agent:latest
         env:
           DD_HOSTNAME: "github-actions-worker"
           DD_APM_ENABLED: true
@@ -347,7 +347,7 @@ jobs:
       group: "APM Larger Runners"
     services:
       datadog-agent:
-        image: datadog/agent:latest
+        image: registry.datadoghq.com/agent:latest
         env:
           DD_HOSTNAME: "github-actions-worker"
           DD_APM_ENABLED: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -104,7 +104,7 @@ services:
         soft: 65536
         hard: 65536
   datadog-agent:
-    image: gcr.io/datadoghq/agent:latest
+    image: registry.datadoghq.com/agent:latest
     environment:
       DD_APM_ENABLED: "true"
       DD_BIND_HOST: "0.0.0.0"


### PR DESCRIPTION
### What does this PR do?

Introduces `registry.datadoghq.com`, our public registry, in `dd-trace-go` CI.

### Motivation

Dogfood our own public registry.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
