### PR TITLE
fix(serverless): Support returning errors with new line characters.

### DIFF
--- a/contrib/aws/datadog-lambda-go/internal/extension/extension.go
+++ b/contrib/aws/datadog-lambda-go/internal/extension/extension.go
@@ -172,7 +172,7 @@ func (em *ExtensionManager) SendEndInvocationRequest(ctx context.Context, functi
 	// Mark the invocation as an error if any
 	if cfg.Error != nil {
 		req.Header.Set(string(DdInvocationError), "true")
-		req.Header.Set(string(DdInvocationErrorMsg), cfg.Error.Error())
+		req.Header.Set(string(DdInvocationErrorMsg), hdrEncode(cfg.Error.Error()))
 		req.Header.Set(string(DdInvocationErrorType), reflect.TypeOf(cfg.Error).String())
 		req.Header.Set(string(DdInvocationErrorStack), takeStacktrace(cfg))
 	}
@@ -247,7 +247,12 @@ func takeStacktrace(opts ddtracer.FinishConfig) string {
 		}
 	}
 
-	return base64.StdEncoding.EncodeToString([]byte(builder.String()))
+	return hdrEncode(builder.String())
+}
+
+// hdrEncode encodes a header value to base64.
+func hdrEncode(value string) string {
+	return base64.StdEncoding.EncodeToString([]byte(value))
 }
 
 func (em *ExtensionManager) IsExtensionRunning() bool {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Base64 encodes the error message header before sending it to the lambda extension.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

Calling `Clien.Do` with a header that contains a new line character will return an error. The extension already handles decoding all headers end invocation headers as base64.

https://github.com/DataDog/datadog-lambda-go/issues/203

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
