### PR TITLE
chore(contrib/valkey-io/valkey-go): Add db.instance to Valkey spans

### DIFF
--- a/contrib/valkey-io/valkey-go/option.go
+++ b/contrib/valkey-io/valkey-go/option.go
@@ -14,6 +14,7 @@ import (
 type config struct {
 	rawCommand  bool
 	serviceName string
+	dbInstance  string
 	errCheck    func(err error) bool
 }
 
@@ -43,6 +44,13 @@ func WithRawCommand(rawCommand bool) Option {
 func WithService(name string) Option {
 	return func(cfg *config) {
 		cfg.serviceName = name
+	}
+}
+
+// WithDBInstance sets the given database instance name.
+func WithDBInstance(instance string) Option {
+	return func(cfg *config) {
+		cfg.dbInstance = instance
 	}
 }
 

--- a/contrib/valkey-io/valkey-go/valkey.go
+++ b/contrib/valkey-io/valkey-go/valkey.go
@@ -202,6 +202,9 @@ func (c *client) startSpan(ctx context.Context, cmd command) (*tracer.Span, cont
 	if c.user != "" {
 		opts = append(opts, tracer.Tag(ext.DBUser, c.user))
 	}
+	if c.cfg.dbInstance != "" {
+		opts = append(opts, tracer.Tag(ext.DBInstance, c.cfg.dbInstance))
+	}
 	return tracer.StartSpanFromContext(ctx, "valkey.command", opts...)
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Adding `db.instance` field to Valkey spans.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->
This is to align with [inferred services](https://docs.datadoghq.com/tracing/services/inferred_services/?tab=agentv7600). Without this, `peer.hostname` field (in a k8s environment the value is a pod name) and cardinality is too high.
`db.name` takes precedence over `db.instance` but in case of Valkey I was not sure what `db.name` represented so I chose `db.instance`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
