### PR TITLE
fix(internal/orchestrion): sort clean ups in mongo integration tests

### DIFF
--- a/internal/orchestrion/_integration/mongo.v2/mongo.go
+++ b/internal/orchestrion/_integration/mongo.v2/mongo.go
@@ -29,6 +29,13 @@ type TestCase struct {
 
 func (tc *TestCase) Setup(_ context.Context, t *testing.T) {
 	containers.SkipIfProviderIsNotHealthy(t)
+	t.Cleanup(func() {
+		// Using a new 10s-timeout context, as we may be running cleanup after the original context expired.
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		assert.NoError(t, tc.client.Disconnect(ctx))
+	})
+
 	_, mongoURI := containers.StartMongoDBTestContainer(t)
 
 	opts := options.Client()
@@ -36,13 +43,6 @@ func (tc *TestCase) Setup(_ context.Context, t *testing.T) {
 	client, err := mongo.Connect(opts)
 	require.NoError(t, err)
 	tc.client = client
-
-	t.Cleanup(func() {
-		// Using a new 10s-timeout context, as we may be running cleanup after the original context expired.
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		assert.NoError(t, tc.client.Disconnect(ctx))
-	})
 }
 
 func (tc *TestCase) Run(ctx context.Context, t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Ensures that the container logger is stopped before any potential log happens after stopping the container and closing the client.

This was attempted previously in #4296, but it seems to flake anyway. After this change, tests still work locally. 

### Motivation

Avoiding failed pipelines like this one: https://github.com/DataDog/dd-trace-go/actions/runs/20648157742/job/59288647814#step:13:104

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
