### PR TITLE
ci: pin k8s client-go

### DIFF
--- a/scripts/ci_test_contrib.sh
+++ b/scripts/ci_test_contrib.sh
@@ -46,7 +46,7 @@ for contrib in $CONTRIBS; do
     # When the issue is resolved, this line can be removed.
     go get k8s.io/kube-openapi@v0.0.0-20250628140032-d90c4fd18f59
     # Another temporary workaround caused by the upgrade introduced by this commit: https://github.com/kubernetes/client-go/commit/f4d210639bbc61f2f2a8596662d7ad50abaa6544
-    go get k8s.io/client-go@34f52c14eaed7e50c845cc14e85e1c4c91e77470
+    go get k8s.io/client-go@v0.35.0
   fi
   if [[ "$1" = "smoke" && "$contrib" = "./contrib/gin-gonic/gin/" ]]; then
     # Temporary workaround, see: https://github.com/gin-gonic/gin/issues/4441


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Pins k8s.io/client-go to latest version before breaking change.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

[Unexpected upgrade with breaking change](https://github.com/kubernetes/client-go/commit/f4d210639bbc61f2f2a8596662d7ad50abaa6544) is causing smoke tests to fail on PRs with the following error:

```
Error: /home/runner/go/pkg/mod/k8s.io/client-go@v0.34.0-alpha.3/applyconfigurations/meta/v1/unstructured.go:86:9: cannot use c.gvkParser.Type(gvk) (value of type *"sigs.k8s.io/structured-merge-diff/v6/typed".ParseableType) as *"sigs.k8s.io/structured-merge-diff/v4/typed".ParseableType value in return statement
```

We want to unblock PRs. 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
