### PR TITLE
fix(.gitlab): disable macrobenchmarks on merge queue

### DIFF
--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -5,6 +5,10 @@ variables:
   if: $CI_COMMIT_BRANCH =~ /^graphite-base\/.*$/
   when: never
 
+.on-mq-never: &on-mq-never
+  if: $CI_COMMIT_BRANCH =~ /^mq-working-branch\/.*$/
+  when: never
+
 .on-main-or-release-always-and-not-interruptible: &on-main-or-release-always-and-not-interruptible
   if: $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /^release-v[0-9]+.*$/
   when: always
@@ -12,12 +16,14 @@ variables:
 
 .macrobenchmarks-rules: &macrobenchmarks-rules
   - <<: *on-graphite-never
+  - <<: *on-mq-never
   - <<: *on-main-or-release-always-and-not-interruptible
   - when: manual
     interruptible: true
 
 .pre-release-performance-quality-gates-rules: &pre-release-performance-quality-gates-rules
   - <<: *on-graphite-never
+  - <<: *on-mq-never
   - <<: *on-main-or-release-always-and-not-interruptible
   # Unlike in "main" or release branches, in development branches there's
   # no strict requirement to run the check unconditionally with "when: always".


### PR DESCRIPTION
### What does this PR do?

Disables macrobenchmarks on merge queue.

### Motivation

Faster merging times, less usage of `benchmarking-platform` resources.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
