### PR TITLE
refactor(instrumentation/mcp): replace `ddtrace` argument with `telemetry`

### DIFF
--- a/contrib/mark3labs/mcp-go/intent_capture.go
+++ b/contrib/mark3labs/mcp-go/intent_capture.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
-func ddTraceSchema() map[string]any {
+func telemetrySchema() map[string]any {
 	return map[string]any{
 		"type": "object",
 		"properties": map[string]any{
@@ -30,7 +30,7 @@ func ddTraceSchema() map[string]any {
 }
 
 // Injects tracing parameters into the tool list response by mutating it.
-func injectDdtraceListToolsHook(ctx context.Context, id any, message *mcp.ListToolsRequest, result *mcp.ListToolsResult) {
+func injectTelemetryListToolsHook(ctx context.Context, id any, message *mcp.ListToolsRequest, result *mcp.ListToolsResult) {
 	if result == nil || result.Tools == nil {
 		return
 	}
@@ -50,29 +50,29 @@ func injectDdtraceListToolsHook(ctx context.Context, id any, message *mcp.ListTo
 			t.InputSchema.Properties = map[string]any{}
 		}
 
-		// Insert/overwrite the ddtrace property
-		t.InputSchema.Properties[instrmcp.DDTraceKey] = ddTraceSchema()
+		// Insert/overwrite the telemetry property
+		t.InputSchema.Properties[instrmcp.TelemetryKey] = telemetrySchema()
 
-		// Mark ddtrace as required (idempotent)
-		if !slices.Contains(t.InputSchema.Required, instrmcp.DDTraceKey) {
-			t.InputSchema.Required = append(t.InputSchema.Required, instrmcp.DDTraceKey)
+		// Mark telemetry as required (idempotent)
+		if !slices.Contains(t.InputSchema.Required, instrmcp.TelemetryKey) {
+			t.InputSchema.Required = append(t.InputSchema.Required, instrmcp.TelemetryKey)
 		}
 	}
 }
 
 // Removing tracing parameters from the tool call request so its not sent to the tool.
 // This must be registered after the tool handler middleware (mcp-go runs middleware in registration order).
-// This removes the ddtrace parameter before user-defined middleware or tool handlers can see it.
-var processAndRemoveDDTraceToolMiddleware = func(next server.ToolHandlerFunc) server.ToolHandlerFunc {
+// This removes the telemetry parameter before user-defined middleware or tool handlers can see it.
+var processAndRemoveTelemetryToolMiddleware = func(next server.ToolHandlerFunc) server.ToolHandlerFunc {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		if m, ok := request.Params.Arguments.(map[string]any); ok && m != nil {
-			if ddtraceVal, has := m[instrmcp.DDTraceKey]; has {
-				if ddtraceMap, ok := ddtraceVal.(map[string]any); ok {
-					processDDTrace(ctx, ddtraceMap)
+			if telemetryVal, has := m[instrmcp.TelemetryKey]; has {
+				if telemetryMap, ok := telemetryVal.(map[string]any); ok {
+					processTelemetry(ctx, telemetryMap)
 				} else if instr != nil && instr.Logger() != nil {
-					instr.Logger().Warn("mcp-go intent capture: ddtrace value is not a map")
+					instr.Logger().Warn("mcp-go intent capture: telemetry value is not a map")
 				}
-				delete(m, instrmcp.DDTraceKey)
+				delete(m, instrmcp.TelemetryKey)
 			}
 		}
 
@@ -80,12 +80,12 @@ var processAndRemoveDDTraceToolMiddleware = func(next server.ToolHandlerFunc) se
 	}
 }
 
-func processDDTrace(ctx context.Context, ddTraceVal map[string]any) {
-	if ddTraceVal == nil {
+func processTelemetry(ctx context.Context, telemetryVal map[string]any) {
+	if telemetryVal == nil {
 		return
 	}
 
-	intentVal, exists := ddTraceVal[instrmcp.IntentKey]
+	intentVal, exists := telemetryVal[instrmcp.IntentKey]
 	if !exists {
 		return
 	}

--- a/contrib/mark3labs/mcp-go/intent_capture_test.go
+++ b/contrib/mark3labs/mcp-go/intent_capture_test.go
@@ -52,13 +52,13 @@ func TestIntentCapture(t *testing.T) {
 	assert.Contains(t, props, "operation")
 	assert.Contains(t, props, "x")
 	assert.Contains(t, props, "y")
-	assert.Contains(t, props, "ddtrace")
+	assert.Contains(t, props, "telemetry")
 
-	// Ensure ddtrace is added to schema
-	ddtraceSchema := props["ddtrace"].(map[string]interface{})
-	assert.Equal(t, "object", ddtraceSchema["type"])
-	ddtraceProps := ddtraceSchema["properties"].(map[string]interface{})
-	intentSchema := ddtraceProps["intent"].(map[string]interface{})
+	// Ensure telemetry is added to schema
+	telemetrySchema := props["telemetry"].(map[string]interface{})
+	assert.Equal(t, "object", telemetrySchema["type"])
+	telemetryProps := telemetrySchema["properties"].(map[string]interface{})
+	intentSchema := telemetryProps["intent"].(map[string]interface{})
 	assert.Equal(t, "string", intentSchema["type"])
 	assert.Equal(t, instrmcp.IntentPrompt, intentSchema["description"])
 
@@ -71,14 +71,14 @@ func TestIntentCapture(t *testing.T) {
 	session.Initialize()
 	ctx = srv.WithContext(ctx, session)
 
-	srv.HandleMessage(ctx, []byte(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"calculator","arguments":{"operation":"add","x":5,"y":3,"ddtrace":{"intent":"test intent description"}}}}`))
+	srv.HandleMessage(ctx, []byte(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"calculator","arguments":{"operation":"add","x":5,"y":3,"telemetry":{"intent":"test intent description"}}}}`))
 
-	// Ensure ddtrace is removed in tool call
+	// Ensure telemetry is removed in tool call
 	require.NotNil(t, receivedArgs)
 	assert.Equal(t, "add", receivedArgs["operation"])
 	assert.Equal(t, float64(5), receivedArgs["x"])
 	assert.Equal(t, float64(3), receivedArgs["y"])
-	assert.NotContains(t, receivedArgs, "ddtrace")
+	assert.NotContains(t, receivedArgs, "telemetry")
 
 	// Verify intent was recorded on the LLMObs span
 	spans := tt.WaitForLLMObsSpans(t, 1)

--- a/contrib/mark3labs/mcp-go/option.go
+++ b/contrib/mark3labs/mcp-go/option.go
@@ -62,9 +62,9 @@ func WithMCPServerTracing(options *TracingConfig) server.ServerOption {
 		server.WithToolHandlerMiddleware(toolHandlerMiddleware)(s)
 
 		if options.IntentCaptureEnabled {
-			hooks.AddAfterListTools(injectDdtraceListToolsHook)
+			hooks.AddAfterListTools(injectTelemetryListToolsHook)
 			// Register intent capture middleware second so it runs second (after span is created)
-			server.WithToolHandlerMiddleware(processAndRemoveDDTraceToolMiddleware)(s)
+			server.WithToolHandlerMiddleware(processAndRemoveTelemetryToolMiddleware)(s)
 		}
 	}
 }

--- a/contrib/modelcontextprotocol/go-sdk/intent_capture.go
+++ b/contrib/modelcontextprotocol/go-sdk/intent_capture.go
@@ -15,7 +15,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-func ddTraceSchema() *jsonschema.Schema {
+func telemetrySchema() *jsonschema.Schema {
 	return &jsonschema.Schema{
 		Type: "object",
 		Properties: map[string]*jsonschema.Schema{
@@ -68,8 +68,8 @@ func injectToolsListResponse(res *mcp.ListToolsResult) {
 			inputSchema.Properties = map[string]*jsonschema.Schema{}
 		}
 
-		inputSchema.Properties[instrmcp.DDTraceKey] = ddTraceSchema()
-		inputSchema.Required = append(inputSchema.Required, instrmcp.DDTraceKey)
+		inputSchema.Properties[instrmcp.TelemetryKey] = telemetrySchema()
+		inputSchema.Required = append(inputSchema.Required, instrmcp.TelemetryKey)
 	}
 }
 
@@ -83,14 +83,14 @@ func processToolCallIntent(next mcp.MethodHandler, ctx context.Context, method s
 			return next(ctx, method, req)
 		}
 
-		if ddtraceVal, has := argsMap[instrmcp.DDTraceKey]; has {
-			if ddtraceMap, ok := ddtraceVal.(map[string]any); ok {
-				annotateSpanWithIntent(ctx, ddtraceMap)
+		if telemetryVal, has := argsMap[instrmcp.TelemetryKey]; has {
+			if telemetryMap, ok := telemetryVal.(map[string]any); ok {
+				annotateSpanWithIntent(ctx, telemetryMap)
 			} else {
-				instr.Logger().Warn("go-sdk intent capture: ddtrace value is not a map")
+				instr.Logger().Warn("go-sdk intent capture: telemetry value is not a map")
 			}
 
-			delete(argsMap, instrmcp.DDTraceKey)
+			delete(argsMap, instrmcp.TelemetryKey)
 
 			modifiedArgs, err := json.Marshal(argsMap)
 			if err != nil {
@@ -103,12 +103,12 @@ func processToolCallIntent(next mcp.MethodHandler, ctx context.Context, method s
 	return next(ctx, method, req)
 }
 
-func annotateSpanWithIntent(ctx context.Context, ddTraceVal map[string]any) {
-	if ddTraceVal == nil {
+func annotateSpanWithIntent(ctx context.Context, telemetryVal map[string]any) {
+	if telemetryVal == nil {
 		return
 	}
 
-	intentVal, exists := ddTraceVal[instrmcp.IntentKey]
+	intentVal, exists := telemetryVal[instrmcp.IntentKey]
 	if !exists {
 		return
 	}

--- a/contrib/modelcontextprotocol/go-sdk/intent_capture_test.go
+++ b/contrib/modelcontextprotocol/go-sdk/intent_capture_test.go
@@ -79,26 +79,26 @@ func TestIntentCapture(t *testing.T) {
 	schemaMap, ok := tool.InputSchema.(map[string]any)
 	require.True(t, ok, "expected input schema to be a map[string]any, got %T", tool.InputSchema)
 
-	// Verify the input schema has the ddtrace property added
+	// Verify the input schema has the telemetry property added
 	props := schemaMap["properties"].(map[string]any)
 	assert.Contains(t, props, "operation")
 	assert.Contains(t, props, "x")
 	assert.Contains(t, props, "y")
-	assert.Contains(t, props, "ddtrace")
+	assert.Contains(t, props, "telemetry")
 
-	ddtraceSchema := props["ddtrace"].(map[string]any)
-	assert.Equal(t, "object", ddtraceSchema["type"])
-	ddtraceProps := ddtraceSchema["properties"].(map[string]any)
-	intentSchema := ddtraceProps["intent"].(map[string]any)
+	telemetrySchema := props["telemetry"].(map[string]any)
+	assert.Equal(t, "object", telemetrySchema["type"])
+	telemetryProps := telemetrySchema["properties"].(map[string]any)
+	intentSchema := telemetryProps["intent"].(map[string]any)
 	assert.Equal(t, "string", intentSchema["type"])
 	assert.Equal(t, instrmcp.IntentPrompt, intentSchema["description"])
 
-	// Ensure ddtrace is required, and others are not affected
+	// Ensure telemetry is required, and others are not affected
 	required := schemaMap["required"].([]any)
 	assert.Contains(t, required, "operation")
 	assert.Contains(t, required, "x")
 	assert.Contains(t, required, "y")
-	assert.Contains(t, required, "ddtrace")
+	assert.Contains(t, required, "telemetry")
 
 	result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
 		Name: "calculator",
@@ -106,7 +106,7 @@ func TestIntentCapture(t *testing.T) {
 			"operation": "add",
 			"x":         float64(5),
 			"y":         float64(3),
-			"ddtrace": map[string]any{
+			"telemetry": map[string]any{
 				"intent": "test intent description",
 			},
 		},
@@ -118,10 +118,10 @@ func TestIntentCapture(t *testing.T) {
 	assert.Equal(t, "add", receivedArgs["operation"])
 	assert.Equal(t, float64(5), receivedArgs["x"])
 	assert.Equal(t, float64(3), receivedArgs["y"])
-	assert.NotContains(t, receivedArgs, "ddtrace")
+	assert.NotContains(t, receivedArgs, "telemetry")
 
-	// Received request also does not contain ddtrace
-	assert.NotContains(t, receivedRequest.Params.Arguments, "ddtrace")
+	// Received request also does not contain telemetry
+	assert.NotContains(t, receivedRequest.Params.Arguments, "telemetry")
 
 	spans := tt.WaitForLLMObsSpans(t, 2)
 	require.Len(t, spans, 2)
@@ -138,8 +138,8 @@ func TestIntentCapture(t *testing.T) {
 	assert.Equal(t, "tool", toolSpan.Meta["span.kind"])
 	assert.Equal(t, "calculator", toolSpan.Name)
 	assert.Contains(t, toolSpan.Meta, "intent")
-	// ddtrace should not be recorded in the input
-	assert.NotContains(t, toolSpan.Meta["input"], "ddtrace")
+	// telemetry should not be recorded in the input
+	assert.NotContains(t, toolSpan.Meta["input"], "telemetry")
 
 	// The intent *is* captured on the span
 	assert.Equal(t, "test intent description", toolSpan.Meta["intent"])

--- a/instrumentation/mcp/mcp.go
+++ b/instrumentation/mcp/mcp.go
@@ -5,7 +5,7 @@
 
 package mcp
 
-const DDTraceKey = "ddtrace"
+const TelemetryKey = "telemetry"
 
 const IntentKey = "intent"
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Renames the injected MCP tool argument used for intent capture from `ddtrace` to `telemetry`.

### Motivation

Feedback that it may be confusing to consumers of mcp servers.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
