### PR TITLE
fix: skip benchmarks on merge queue

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,6 +32,9 @@ generate_matrix:
     # We don't want to run benchmarks on graphite commits
     - if: '$CI_COMMIT_BRANCH =~ /^graphite-base\/.*$/'
       when: never
+    # We don't want to run benchmarks on merge queue
+    - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch\/.*$/'
+      when: never
     - if: '$CI_COMMIT_BRANCH == "main"'
       when: always
       interruptible: false


### PR DESCRIPTION
### What does this PR do?

Avoid failures on merge queue.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
