### PR TITLE
ci: make sure benchmarks do not run on mq branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ generate_matrix:
     - if: '$CI_COMMIT_BRANCH =~ /^graphite-base\/.*$/'
       when: never
     # We don't want to run benchmarks on merge queue
-    - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch\/.*$/'
+    - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-.*$/'
       when: never
     - if: '$CI_COMMIT_BRANCH == "main"'
       when: always


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Makes sure that the benchmarks are not run on mq branches.

### Motivation

The benchmarks are still ran on mq branches because the regex is using the wrong separator, [example](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-go/-/pipelines/90703908)
### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
