### PR TITLE
ci: solve incident 48034

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,7 +98,7 @@ analyze-benchmark-results:
       mkdir -p reports
       export ARTIFACTS_DIR="$(pwd)/reports"
       git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
-      git clone --branch fayssal/incident-48034 https://github.com/DataDog/benchmarking-platform platform && cd platform
+      git clone --branch dd-trace-go https://github.com/DataDog/benchmarking-platform platform && cd platform
       ./steps/download-child-pipeline-artifacts.sh
       echo "All benchmark artifacts collected:"
       ls -la "${ARTIFACTS_DIR}/"

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -15,7 +15,7 @@
   script: |
     export ARTIFACTS_DIR="$(pwd)/reports" && (mkdir "${ARTIFACTS_DIR}" || :)
     git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
-    git clone --branch fayssal/incident-48034 https://github.com/DataDog/benchmarking-platform /platform && cd /platform
+    git clone --branch dd-trace-go https://github.com/DataDog/benchmarking-platform /platform && cd /platform
     ./steps/capture-hardware-software-info.sh
     TEST_NAME=$BENCHMARK_NAME bp-runner "${CI_PROJECT_DIR:-.}/.gitlab/bp-runner.yml" --debug -t
     ./steps/convert-results.sh


### PR DESCRIPTION
### TODO before merging
This PR is linked to [the PR in benchmarking platform](https://github.com/DataDog/benchmarking-platform/pull/230), thus before merging it requires:

- [x]  Merging the other PR first
- [x]  Reverting the branch used for benchmarks here to dd-trace-go

### What does this PR do?
This PR fixes the following:
- sending results to BP UI
- posting PR comments:
     - the PR comments do not fail anymore
     - there is no more race conditions between PR comments as we aggregate benchmarks first
- checking big regressions

### Checks
- [ Full pipeline running against this PR](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-go/-/pipelines/90843328)
- [Successful PR comment](https://github.com/DataDog/dd-trace-go/pull/4356#issuecomment-3754099582)
- [Successful upload to BP-UI](https://benchmarking.us1.prod.dog/benchmarks?projectId=2&page=1&ciJobDateStart=1765881837356&ciJobDateEnd=1768473837356&benchmarkGroupPipelineId=90845248&benchmarkGroupSha=f2d28c1676b8957783fa81c9e0626a5f628efa24)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
[incident-48034](https://dd.enterprise.slack.com/archives/C0A8TN3HBJQ)
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
