### PR TITLE
fix(stats): Remove header when client_drop_p0=false [#4342 backport]

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -748,12 +748,19 @@ func (c *config) loadContribIntegrations(deps []*debug.Module) {
 	c.integrations = integrations
 }
 
+// canComputeStats determines whether Client-Side Stats can be computed, which requires:
+// - 'client_drop_p0' is enabled
+// - Trace Agent exposes 'stats' endpoint
+// - Stats Computation is enabled on the tracer (or has 'discovery' FF)
 func (c *config) canComputeStats() bool {
-	return c.agent.Stats && (c.internalConfig.HasFeature("discovery") || c.internalConfig.StatsComputationEnabled())
+	return c.agent.Stats && c.agent.DropP0s && (c.internalConfig.HasFeature("discovery") || c.internalConfig.StatsComputationEnabled())
 }
 
+// canDropP0s determines whether P0 spans can be dropped.
+// Currently equivalent to canComputeStats() as both capabilities are part
+// of the Client-Side Stats feature and cannot be enabled independently.
 func (c *config) canDropP0s() bool {
-	return c.canComputeStats() && c.agent.DropP0s
+	return c.canComputeStats()
 }
 
 func statsTags(c *config) []string {

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -1938,3 +1938,83 @@ func TestNoHTTPClientOverride(t *testing.T) {
 		assert.Equal(30*time.Second, c.httpClient.Timeout)
 	})
 }
+
+func TestCanComputeStats(t *testing.T) {
+	t.Run("no-stats-endpoint", func(t *testing.T) {
+		// When the agent does not support the /v0.6/stats endpoint,
+		// client-side stats should not be computed
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Write([]byte(`{"endpoints":[],"client_drop_p0s":true}`))
+		}))
+		defer srv.Close()
+		c, err := newTestConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")), WithStatsComputation(true))
+		assert.NoError(t, err)
+		assert.False(t, c.canComputeStats())
+		assert.False(t, c.canDropP0s())
+	})
+
+	t.Run("no-client-drop-p0s", func(t *testing.T) {
+		// When the agent does not support client_drop_p0s,
+		// client-side stats should not be computed
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Write([]byte(`{"endpoints":["/v0.6/stats"],"client_drop_p0s":false}`))
+		}))
+		defer srv.Close()
+		c, err := newTestConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")), WithStatsComputation(true))
+		assert.NoError(t, err)
+		assert.False(t, c.canComputeStats())
+		assert.False(t, c.canDropP0s())
+	})
+
+	t.Run("stats-disabled", func(t *testing.T) {
+		// When stats computation is explicitly disabled,
+		// client-side stats should not be computed even if agent supports it
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Write([]byte(`{"endpoints":["/v0.6/stats"],"client_drop_p0s":true}`))
+		}))
+		defer srv.Close()
+		c, err := newTestConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")), WithStatsComputation(false))
+		assert.NoError(t, err)
+		assert.False(t, c.canComputeStats())
+		assert.False(t, c.canDropP0s())
+	})
+
+	t.Run("both-conditions-met", func(t *testing.T) {
+		// When both conditions are met (stats endpoint + client_drop_p0s),
+		// client-side stats should be computed
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Write([]byte(`{"endpoints":["/v0.6/stats"],"client_drop_p0s":true}`))
+		}))
+		defer srv.Close()
+		c, err := newTestConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")), WithStatsComputation(true))
+		assert.NoError(t, err)
+		assert.True(t, c.canComputeStats())
+		assert.True(t, c.canDropP0s())
+	})
+
+	t.Run("discovery-feature-flag", func(t *testing.T) {
+		// When discovery feature flag is enabled and agent supports both features,
+		// client-side stats should be computed
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Write([]byte(`{"endpoints":["/v0.6/stats"],"client_drop_p0s":true}`))
+		}))
+		defer srv.Close()
+		c, err := newTestConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")), WithFeatureFlags("discovery"))
+		assert.NoError(t, err)
+		assert.True(t, c.canComputeStats())
+		assert.True(t, c.canDropP0s())
+	})
+
+	t.Run("discovery-flag-missing-client-drop-p0s", func(t *testing.T) {
+		// When discovery flag is enabled but client_drop_p0s is not supported,
+		// client-side stats should not be computed
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Write([]byte(`{"endpoints":["/v0.6/stats"],"client_drop_p0s":false}`))
+		}))
+		defer srv.Close()
+		c, err := newTestConfig(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")), WithFeatureFlags("discovery"))
+		assert.NoError(t, err)
+		assert.False(t, c.canComputeStats())
+		assert.False(t, c.canDropP0s())
+	})
+}

--- a/ddtrace/tracer/telemetry_test.go
+++ b/ddtrace/tracer/telemetry_test.go
@@ -31,7 +31,7 @@ func TestTelemetryEnabled(t *testing.T) {
 			if r.URL.Path == "/info" {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"endpoints": ["/v0.4/traces", "/v0.6/stats"]}`))
+				w.Write([]byte(`{"endpoints": ["/v0.4/traces", "/v0.6/stats"],"client_drop_p0s":true}`))
 				return
 			}
 			w.WriteHeader(http.StatusOK)

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -509,3 +509,89 @@ func TestDefaultHeaders(t *testing.T) {
 	err = trc.config.transport.sendStats(&pb.ClientStatsPayload{}, 1)
 	assert.NoError(err)
 }
+
+func TestClientComputedStatsHeader(t *testing.T) {
+	t.Run("header-not-set-when-client-drop-p0s-not-supported", func(t *testing.T) {
+		// When the agent does not support client_drop_p0s,
+		// the Datadog-Client-Computed-Stats header should NOT be set
+		assert := assert.New(t)
+		var headerValue string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/info" {
+				w.Write([]byte(`{"endpoints":["/v0.6/stats"],"client_drop_p0s":false}`))
+				return
+			}
+			headerValue = r.Header.Get("Datadog-Client-Computed-Stats")
+		}))
+		defer srv.Close()
+
+		u, err := url.Parse(srv.URL)
+		assert.NoError(err)
+		trc, err := newTracer(WithAgentAddr(u.Host), WithStatsComputation(true))
+		assert.NoError(err)
+		setGlobalTracer(trc)
+		defer trc.Stop()
+
+		p, err := encode(getTestTrace(1, 1))
+		assert.NoError(err)
+		_, err = trc.config.transport.send(p)
+		assert.NoError(err)
+		assert.Empty(headerValue, "Datadog-Client-Computed-Stats header should not be set when client_drop_p0s is not supported")
+	})
+
+	t.Run("header-not-set-when-stats-endpoint-not-supported", func(t *testing.T) {
+		// When the agent does not support the /v0.6/stats endpoint,
+		// the Datadog-Client-Computed-Stats header should NOT be set
+		assert := assert.New(t)
+		var headerValue string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/info" {
+				w.Write([]byte(`{"endpoints":[],"client_drop_p0s":true}`))
+				return
+			}
+			headerValue = r.Header.Get("Datadog-Client-Computed-Stats")
+		}))
+		defer srv.Close()
+
+		u, err := url.Parse(srv.URL)
+		assert.NoError(err)
+		trc, err := newTracer(WithAgentAddr(u.Host), WithStatsComputation(true))
+		assert.NoError(err)
+		setGlobalTracer(trc)
+		defer trc.Stop()
+
+		p, err := encode(getTestTrace(1, 1))
+		assert.NoError(err)
+		_, err = trc.config.transport.send(p)
+		assert.NoError(err)
+		assert.Empty(headerValue, "Datadog-Client-Computed-Stats header should not be set when stats endpoint is not supported")
+	})
+
+	t.Run("header-set-when-both-conditions-met", func(t *testing.T) {
+		// When both conditions are met (stats endpoint + client_drop_p0s),
+		// the Datadog-Client-Computed-Stats header should be set to "t"
+		assert := assert.New(t)
+		var headerValue string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/info" {
+				w.Write([]byte(`{"endpoints":["/v0.6/stats"],"client_drop_p0s":true}`))
+				return
+			}
+			headerValue = r.Header.Get("Datadog-Client-Computed-Stats")
+		}))
+		defer srv.Close()
+
+		u, err := url.Parse(srv.URL)
+		assert.NoError(err)
+		trc, err := newTracer(WithAgentAddr(u.Host), WithStatsComputation(true))
+		assert.NoError(err)
+		setGlobalTracer(trc)
+		defer trc.Stop()
+
+		p, err := encode(getTestTrace(1, 1))
+		assert.NoError(err)
+		_, err = trc.config.transport.send(p)
+		assert.NoError(err)
+		assert.Equal("t", headerValue, "Datadog-Client-Computed-Stats header should be set to 't' when both conditions are met")
+	})
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Backport #4342 to the v2.6.x release branch.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->
Ensure that this fix makes it to customers in the upcoming release.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
