### PR TITLE
revert: don't aggregate benchmarks results [#4355 backport]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,30 +83,6 @@ check-big-regressions:
       - reports/
     expire_in: "30 days"
 
-aggregate-benchmarks:
-  stage: post-pr-comment
-  needs:
-    - job: trigger_child_pipeline
-  when: on_success
-  tags: ["runner:apm-k8s-tweaked-metal"]
-
-  image: $BASE_CI_IMAGE
-
-  script:
-    - export ARTIFACTS_DIR="$(pwd)/reports" && (mkdir "${ARTIFACTS_DIR}" || :)
-    - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
-    - git clone --branch dd-trace-go https://github.com/DataDog/benchmarking-platform /platform && cd /platform
-    - ./steps/download-child-pipeline-artifacts.sh
-    - ./steps/compare-merged-results.sh
-    - ./steps/post-pr-comment.sh
-  artifacts:
-    name: "reports"
-    paths:
-      - reports/
-    expire_in: 3 months
-  variables:
-    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: benchmarking-platform
-
 # Config Registry CI Jobs
 validate_supported_configurations_v2_local_file:
   stage: config-validation


### PR DESCRIPTION
### What does this PR do?

Backports #4355 to the 2.6 release branch.

### Motivation

Fix CI.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
