### PR TITLE
ci: update config inversion CI scripts settings [#4365 backport]

### DIFF
--- a/.gitlab/configuration-central-validation.yml
+++ b/.gitlab/configuration-central-validation.yml
@@ -2,7 +2,7 @@
 # This URL is available in the dd-gitlab/publish-content-addresable-templates job whenever
 # a change is made on the one-pipeline template.
 variables:
-  SCRIPTS_BASE_URL: https://gitlab-templates.ddbuild.io/libdatadog/one-pipeline/ca/ef1b27c2b0cdbbfb25d185344cdb7aa6bb4feb905cb2a77fa1a5a5340b570004/scripts/
+  SCRIPTS_BASE_URL: https://gitlab-templates.ddbuild.io/libdatadog/one-pipeline/ca/1c0dd2e9e6e173100cf3ce89b1d2dd11c5d3ae74ff46ce9f262faf371fd0e736/scripts/config-inversion/
 
 .download-scripts-from-template: &download-scripts-from-template
   - mkdir -p scripts
@@ -23,13 +23,13 @@ variables:
   before_script:
     - *download-scripts-from-template
   script:
-    - scripts/config-inversion-local-validation.py "$LOCAL_JSON_PATH" "$BACKFILLED"
+    - scripts/config-inversion-local-validation.py
 
 .update_central_configurations_version_range_v2:
   allow_failure: false
   rules:
     - if: '$CI_COMMIT_TAG =~ /^v?[0-9]+\.[0-9]+\.[0-9]+$/'
-      when: on_success
+      when: always
   variables:
     LOCAL_JSON_PATH: ""
     LANGUAGE_NAME: ""
@@ -38,4 +38,4 @@ variables:
     - *download-scripts-from-template
     - export FP_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.$CI_PROJECT_NAME.FP_API_KEY --with-decryption --query "Parameter.Value" --out text)
   script:
-    - scripts/config-inversion-update-supported-range.py "$LOCAL_JSON_PATH" "$LANGUAGE_NAME" "$MULTIPLE_RELEASE_LINES"
+    - scripts/config-inversion-update-supported-range.py


### PR DESCRIPTION
### What does this PR do?

Backports #4365 to the 2.6 release branch.

### Motivation

Fix CI.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
