### PR TITLE
chore(internal/config): cover #4373 changes

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -431,3 +431,85 @@ func TestSetServiceMappingReportsFullList(t *testing.T) {
 	sort.Strings(parts)
 	assert.Equal(t, []string{"a:3", "b:2"}, parts)
 }
+
+func TestHostnameConfiguration(t *testing.T) {
+	t.Run("default behavior - hostname empty when not configured", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+
+		cfg := Get()
+		require.NotNil(t, cfg)
+
+		assert.Empty(t, cfg.Hostname(), "Hostname should be empty by default")
+		assert.False(t, cfg.ReportHostname(), "ReportHostname should be false by default")
+	})
+
+	t.Run("DD_TRACE_REPORT_HOSTNAME=true enables hostname lookup", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+
+		t.Setenv("DD_TRACE_REPORT_HOSTNAME", "true")
+
+		cfg := Get()
+		require.NotNil(t, cfg)
+
+		assert.NotEmpty(t, cfg.Hostname(), "Hostname should be set when DD_TRACE_REPORT_HOSTNAME=true")
+		assert.True(t, cfg.ReportHostname(), "ReportHostname should be true when DD_TRACE_REPORT_HOSTNAME=true")
+		assert.NoError(t, cfg.HostnameLookupError(), "HostnameLookupError should be nil on successful lookup")
+	})
+
+	t.Run("DD_TRACE_REPORT_HOSTNAME=false keeps hostname empty", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+
+		t.Setenv("DD_TRACE_REPORT_HOSTNAME", "false")
+
+		cfg := Get()
+		require.NotNil(t, cfg)
+
+		assert.Empty(t, cfg.Hostname(), "Hostname should be empty when DD_TRACE_REPORT_HOSTNAME=false")
+		assert.False(t, cfg.ReportHostname(), "ReportHostname should be false when DD_TRACE_REPORT_HOSTNAME=false")
+	})
+
+	t.Run("DD_TRACE_SOURCE_HOSTNAME sets explicit hostname", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+
+		t.Setenv("DD_TRACE_SOURCE_HOSTNAME", "custom-hostname")
+
+		cfg := Get()
+		require.NotNil(t, cfg)
+
+		assert.Equal(t, "custom-hostname", cfg.Hostname(), "Hostname should match DD_TRACE_SOURCE_HOSTNAME")
+		assert.True(t, cfg.ReportHostname(), "ReportHostname should be true when DD_TRACE_SOURCE_HOSTNAME is set")
+	})
+
+	t.Run("DD_TRACE_SOURCE_HOSTNAME takes precedence over DD_TRACE_REPORT_HOSTNAME", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+
+		t.Setenv("DD_TRACE_REPORT_HOSTNAME", "true")
+		t.Setenv("DD_TRACE_SOURCE_HOSTNAME", "override-hostname")
+
+		cfg := Get()
+		require.NotNil(t, cfg)
+
+		assert.Equal(t, "override-hostname", cfg.Hostname(), "DD_TRACE_SOURCE_HOSTNAME should take precedence")
+		assert.True(t, cfg.ReportHostname(), "ReportHostname should be true")
+	})
+
+	t.Run("empty DD_TRACE_SOURCE_HOSTNAME is used when explicitly set", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+
+		t.Setenv("DD_TRACE_REPORT_HOSTNAME", "true")
+		t.Setenv("DD_TRACE_SOURCE_HOSTNAME", "")
+
+		cfg := Get()
+		require.NotNil(t, cfg)
+
+		// Empty string explicitly set should override the looked-up hostname
+		assert.Empty(t, cfg.Hostname(), "Empty DD_TRACE_SOURCE_HOSTNAME should override hostname lookup")
+		assert.True(t, cfg.ReportHostname(), "ReportHostname should be true when DD_TRACE_SOURCE_HOSTNAME is explicitly set")
+	})
+}


### PR DESCRIPTION
### What does this PR do?

On `main` this test works, but in `release-v2.6.x` before backporting the fix it fails:

```
=== RUN   TestHostnameConfiguration
=== RUN   TestHostnameConfiguration/default_behavior_-_hostname_empty_when_not_configured
    /Users/dario.castane/go/src/github.com/DataDog/dd-trace-go/internal/config/config_test.go:443: 
                Error Trace:    /Users/dario.castane/go/src/github.com/DataDog/dd-trace-go/internal/config/config_test.go:443
                Error:          Should be empty, but was COMP-WDWT6G66NH
                Test:           TestHostnameConfiguration/default_behavior_-_hostname_empty_when_not_configured
                Messages:       Hostname should be empty by default
=== RUN   TestHostnameConfiguration/DD_TRACE_REPORT_HOSTNAME=true_enables_hostname_lookup
=== RUN   TestHostnameConfiguration/DD_TRACE_REPORT_HOSTNAME=false_keeps_hostname_empty
    /Users/dario.castane/go/src/github.com/DataDog/dd-trace-go/internal/config/config_test.go:470: 
                Error Trace:    /Users/dario.castane/go/src/github.com/DataDog/dd-trace-go/internal/config/config_test.go:470
                Error:          Should be empty, but was COMP-WDWT6G66NH
                Test:           TestHostnameConfiguration/DD_TRACE_REPORT_HOSTNAME=false_keeps_hostname_empty
                Messages:       Hostname should be empty when DD_TRACE_REPORT_HOSTNAME=false
=== RUN   TestHostnameConfiguration/DD_TRACE_SOURCE_HOSTNAME_sets_explicit_hostname
=== RUN   TestHostnameConfiguration/DD_TRACE_SOURCE_HOSTNAME_takes_precedence_over_DD_TRACE_REPORT_HOSTNAME
=== RUN   TestHostnameConfiguration/empty_DD_TRACE_SOURCE_HOSTNAME_is_used_when_explicitly_set
--- FAIL: TestHostnameConfiguration (0.00s)
    --- FAIL: TestHostnameConfiguration/default_behavior_-_hostname_empty_when_not_configured (0.00s)
    --- PASS: TestHostnameConfiguration/DD_TRACE_REPORT_HOSTNAME=true_enables_hostname_lookup (0.00s)
    --- FAIL: TestHostnameConfiguration/DD_TRACE_REPORT_HOSTNAME=false_keeps_hostname_empty (0.00s)
    --- PASS: TestHostnameConfiguration/DD_TRACE_SOURCE_HOSTNAME_sets_explicit_hostname (0.00s)
    --- PASS: TestHostnameConfiguration/DD_TRACE_SOURCE_HOSTNAME_takes_precedence_over_DD_TRACE_REPORT_HOSTNAME (0.00s)
    --- PASS: TestHostnameConfiguration/empty_DD_TRACE_SOURCE_HOSTNAME_is_used_when_explicitly_set (0.00s)
FAIL
FAIL    github.com/DataDog/dd-trace-go/v2/internal/config       0.766s
FAIL
```

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.

Unsure? Have a question? Request a review!
