### PR TITLE
fix(openfeature): allow empty targeting key in exposure events 

### DIFF
--- a/openfeature/exposure_hook.go
+++ b/openfeature/exposure_hook.go
@@ -66,10 +66,6 @@ func (h *exposureHook) After(
 	// Get targeting key (subject ID) from evaluation context
 	evalContext := hookContext.EvaluationContext()
 	targetingKey := evalContext.TargetingKey()
-	if targetingKey == "" {
-		log.Debug("openfeature: skipping exposure event (no targeting key) for flag %q", hookContext.FlagKey())
-		return nil
-	}
 
 	// Build flat context from evaluation context
 	flatContext := make(map[string]any)

--- a/openfeature/exposure_test.go
+++ b/openfeature/exposure_test.go
@@ -6,9 +6,12 @@
 package openfeature
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
+
+	of "github.com/open-feature/go-sdk/openfeature"
 )
 
 func TestLRUCache_NewEntry(t *testing.T) {
@@ -333,5 +336,254 @@ func TestExposureWriter_ConcurrentAppend_Deduplication(t *testing.T) {
 	// Only 1 event should be in the buffer due to deduplication
 	if len(writer.buffer) != 1 {
 		t.Errorf("expected exactly 1 event due to deduplication, got %d", len(writer.buffer))
+	}
+}
+
+func TestExposureHook_After(t *testing.T) {
+	tests := []struct {
+		name              string
+		targetingKey      string
+		attributes        map[string]interface{}
+		flagKey           string
+		variant           string
+		metadata          of.FlagMetadata
+		expectEvent       bool
+		expectedSubjectID string
+	}{
+		{
+			name:         "with targeting key",
+			targetingKey: "user-123",
+			attributes:   map[string]interface{}{"org_id": 456},
+			flagKey:      "test-flag",
+			variant:      "variant-a",
+			metadata: of.FlagMetadata{
+				metadataAllocationKey: "test-allocation",
+				metadataDoLogKey:      true,
+			},
+			expectEvent:       true,
+			expectedSubjectID: "user-123",
+		},
+		{
+			name:         "with empty targeting key",
+			targetingKey: "",
+			attributes:   map[string]interface{}{"org_id": 789},
+			flagKey:      "server-side-flag",
+			variant:      "enabled",
+			metadata: of.FlagMetadata{
+				metadataAllocationKey: "server-allocation",
+				metadataDoLogKey:      true,
+			},
+			expectEvent:       true,
+			expectedSubjectID: "",
+		},
+		{
+			name:         "missing allocation key",
+			targetingKey: "user-123",
+			attributes:   map[string]interface{}{},
+			flagKey:      "test-flag",
+			variant:      "variant-a",
+			metadata:     of.FlagMetadata{}, // no allocation key
+			expectEvent:  false,
+		},
+		{
+			name:         "doLog is false",
+			targetingKey: "user-123",
+			attributes:   map[string]interface{}{},
+			flagKey:      "test-flag",
+			variant:      "variant-a",
+			metadata: of.FlagMetadata{
+				metadataAllocationKey: "test-allocation",
+				metadataDoLogKey:      false,
+			},
+			expectEvent: false,
+		},
+		{
+			name:         "nil metadata",
+			targetingKey: "user-123",
+			attributes:   map[string]interface{}{},
+			flagKey:      "test-flag",
+			variant:      "variant-a",
+			metadata:     nil,
+			expectEvent:  false, // no allocation key means no event
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a writer to capture events
+			writer := &exposureWriter{
+				buffer: make([]exposureEvent, 0, 256),
+				cache:  newExposureLRUCache(1000),
+			}
+			hook := newExposureHook(writer)
+
+			// Create evaluation context
+			evalCtx := of.NewEvaluationContext(tc.targetingKey, tc.attributes)
+
+			// Create hook context
+			hookCtx := of.NewHookContext(
+				tc.flagKey,
+				of.Boolean,
+				false,
+				of.ClientMetadata{},
+				of.Metadata{},
+				evalCtx,
+			)
+
+			// Create evaluation details
+			details := of.InterfaceEvaluationDetails{
+				Value: true,
+				EvaluationDetails: of.EvaluationDetails{
+					FlagKey:  tc.flagKey,
+					FlagType: of.Boolean,
+					ResolutionDetail: of.ResolutionDetail{
+						Variant:      tc.variant,
+						FlagMetadata: tc.metadata,
+					},
+				},
+			}
+
+			// Call After hook
+			err := hook.After(context.Background(), hookCtx, details, of.HookHints{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Check if event was created
+			if tc.expectEvent {
+				if len(writer.buffer) != 1 {
+					t.Errorf("expected 1 event, got %d", len(writer.buffer))
+					return
+				}
+				event := writer.buffer[0]
+				if event.Subject.ID != tc.expectedSubjectID {
+					t.Errorf("expected subject ID %q, got %q", tc.expectedSubjectID, event.Subject.ID)
+				}
+				if event.Flag.Key != tc.flagKey {
+					t.Errorf("expected flag key %q, got %q", tc.flagKey, event.Flag.Key)
+				}
+				if event.Variant.Key != tc.variant {
+					t.Errorf("expected variant %q, got %q", tc.variant, event.Variant.Key)
+				}
+			} else {
+				if len(writer.buffer) != 0 {
+					t.Errorf("expected no events, got %d", len(writer.buffer))
+				}
+			}
+		})
+	}
+}
+
+func TestExposureHook_After_EmptyTargetingKeyWithAttributes(t *testing.T) {
+	// This test specifically verifies that exposures with empty targeting keys
+	// but with attributes are correctly logged (server-side evaluations)
+	writer := &exposureWriter{
+		buffer: make([]exposureEvent, 0, 256),
+		cache:  newExposureLRUCache(1000),
+	}
+	hook := newExposureHook(writer)
+
+	// Server-side evaluation: no user, but has org context
+	evalCtx := of.NewEvaluationContext("", map[string]interface{}{
+		"org_id":  12345,
+		"service": "backend-service",
+	})
+
+	hookCtx := of.NewHookContext(
+		"feature-rollout",
+		of.Boolean,
+		false,
+		of.ClientMetadata{},
+		of.Metadata{},
+		evalCtx,
+	)
+
+	details := of.InterfaceEvaluationDetails{
+		Value: true,
+		EvaluationDetails: of.EvaluationDetails{
+			FlagKey:  "feature-rollout",
+			FlagType: of.Boolean,
+			ResolutionDetail: of.ResolutionDetail{
+				Variant: "enabled",
+				FlagMetadata: of.FlagMetadata{
+					metadataAllocationKey: "org-rollout",
+					metadataDoLogKey:      true,
+				},
+			},
+		},
+	}
+
+	err := hook.After(context.Background(), hookCtx, details, of.HookHints{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(writer.buffer) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(writer.buffer))
+	}
+
+	event := writer.buffer[0]
+
+	// Subject ID should be empty
+	if event.Subject.ID != "" {
+		t.Errorf("expected empty subject ID, got %q", event.Subject.ID)
+	}
+
+	// Attributes should be populated
+	if event.Subject.Attributes == nil {
+		t.Error("expected subject attributes to be populated")
+	}
+
+	// Check that org_id is in attributes
+	if orgID, ok := event.Subject.Attributes["org_id"]; !ok {
+		t.Error("expected org_id in subject attributes")
+	} else if orgID != int64(12345) && orgID != 12345 {
+		t.Errorf("expected org_id to be 12345, got %v (type %T)", orgID, orgID)
+	}
+}
+
+func TestExposureHook_After_ContextCancelled(t *testing.T) {
+	writer := &exposureWriter{
+		buffer: make([]exposureEvent, 0, 256),
+		cache:  newExposureLRUCache(1000),
+	}
+	hook := newExposureHook(writer)
+
+	// Create a cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	evalCtx := of.NewEvaluationContext("user-123", nil)
+	hookCtx := of.NewHookContext(
+		"test-flag",
+		of.Boolean,
+		false,
+		of.ClientMetadata{},
+		of.Metadata{},
+		evalCtx,
+	)
+
+	details := of.InterfaceEvaluationDetails{
+		Value: true,
+		EvaluationDetails: of.EvaluationDetails{
+			FlagKey:  "test-flag",
+			FlagType: of.Boolean,
+			ResolutionDetail: of.ResolutionDetail{
+				Variant: "enabled",
+				FlagMetadata: of.FlagMetadata{
+					metadataAllocationKey: "test-allocation",
+				},
+			},
+		},
+	}
+
+	err := hook.After(ctx, hookCtx, details, of.HookHints{})
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled error, got %v", err)
+	}
+
+	// No event should be logged
+	if len(writer.buffer) != 0 {
+		t.Errorf("expected no events when context cancelled, got %d", len(writer.buffer))
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Cherry-pick of #4361

### Motivation

This [system-test](https://github.com/DataDog/dd-trace-go/actions/runs/21219748859/job/61475990597?pr=4368) error

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
