### PR TITLE
fix(civisibility): improve ci.job.url format for GitHub Actions

### DIFF
--- a/internal/civisibility/utils/testdata/fixtures/providers/github.json
+++ b/internal/civisibility/utils/testdata/fixtures/providers/github.json
@@ -762,5 +762,158 @@
       "git.pull_request.base_branch": "target-branch",
       "git.repository_url": "https://github.com/ghactions-repo.git"
     }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
+      "GITHUB_REF": "master",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SERVER_URL": "https://github.com",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "JOB_CHECK_RUN_ID": "12345678901"
+    },
+    {
+      "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "12345678901",
+      "ci.job.name": "github-job-name",
+      "ci.job.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/12345678901",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/attempts/ghactions-run-attempt",
+      "ci.provider.name": "github",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
+      "GITHUB_REF": "master",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SERVER_URL": "https://ghenterprise.com",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "JOB_CHECK_RUN_ID": "12345678901"
+    },
+    {
+      "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://ghenterprise.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "12345678901",
+      "ci.job.name": "github-job-name",
+      "ci.job.url": "https://ghenterprise.com/ghactions-repo/actions/runs/ghactions-pipeline-id/job/12345678901",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://ghenterprise.com/ghactions-repo/actions/runs/ghactions-pipeline-id/attempts/ghactions-run-attempt",
+      "ci.provider.name": "github",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://ghenterprise.com/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
+      "GITHUB_REF": "master",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
+      "GITHUB_RUN_ID": "",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SERVER_URL": "https://github.com",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "JOB_CHECK_RUN_ID": "12345678901"
+    },
+    {
+      "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
+      "ci.job.name": "github-job-name",
+      "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.provider.name": "github",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
+      "GITHUB_REF": "master",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SERVER_URL": "https://github.com",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "JOB_CHECK_RUN_ID": ""
+    },
+    {
+      "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
+      "ci.job.name": "github-job-name",
+      "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/attempts/ghactions-run-attempt",
+      "ci.provider.name": "github",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
+      "GITHUB_REF": "master",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SERVER_URL": "https://github.com",
+      "GITHUB_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "JOB_CHECK_RUN_ID": "invalid-not-numeric"
+    },
+    {
+      "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
+      "ci.job.name": "github-job-name",
+      "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/actions/runs/ghactions-pipeline-id/attempts/ghactions-run-attempt",
+      "ci.provider.name": "github",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
+    }
   ]
 ]


### PR DESCRIPTION
### What does this PR do?

Improves the `ci.job.url` tag format for GitHub Actions to enable direct navigation to specific job logs and proper correlation between Test Optimization and CI Visibility.

**Before:** Generic URL routing to all jobs overview
```
https://github.com/{owner}/{repo}/commit/{commit_sha}/checks
```

**After:** Job-specific URL when numeric job ID is available
```
https://github.com/{owner}/{repo}/actions/runs/{run_id}/job/{job_id}
```

### Changes

- Add `getGithubActionsJobID()` to resolve numeric job ID in priority order:
  1. `JOB_CHECK_RUN_ID` environment variable
  2. GitHub Actions runner diagnostics files (`Worker_*.log`)
  3. Fallback to current behavior
- Add helper functions for diagnostics parsing (JSON + regex fallback)
- Support Linux, macOS, and Windows diagnostics directory paths
- Add numeric validation, whitespace trimming, and file size guards
- Guard `ci.pipeline.url` and `ci.pipeline.id` when `GITHUB_RUN_ID` is empty
- Add 5 new test fixtures covering all scenarios
- Add unit tests for `isNumericJobID` and diagnostics parsing

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.