### PR TITLE
fix(appsec): use path instead of product as status map key in RC update handler

### DIFF
--- a/internal/appsec/remoteconfig.go
+++ b/internal/appsec/remoteconfig.go
@@ -63,7 +63,7 @@ func (a *appsec) onRCRulesUpdate(updates map[string]remoteconfig.ProductUpdate) 
 				cfg := UpdatedConfig{Product: product}
 				if err := json.Unmarshal(data, &cfg.Content); err != nil {
 					log.Error("appsec: unmarshaling remote config update for %s (%q): %s", product, path, err.Error())
-					statuses[product] = state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()}
+					statuses[path] = state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()}
 					continue
 				}
 				addOrUpdates[path] = cfg


### PR DESCRIPTION
The onRCRulesUpdate function was incorrectly using 'product' as the key when recording an error status for failed JSON unmarshaling. All other status assignments in this function use 'path' as the key, which is the expected key format for the returned status map.

This bug could cause config acknowledgment failures when multiple configs from the same product were updated and one failed to unmarshal.


JJ-Change-Id: vruxtm

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
