### PR TITLE
feat(internal/config): change internalconfig behavior to use a fresh instance upon tracer creation

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -287,7 +287,7 @@ const maxPropagatedTagsLength = 512
 // and passed user opts.
 func newConfig(opts ...StartOption) (*config, error) {
 	c := new(config)
-	c.internalConfig = internalconfig.GetNew()
+	c.internalConfig = internalconfig.CreateNew()
 
 	// If this was built with a recent-enough version of Orchestrion, force the orchestrion config to
 	// the baked-in values. We do this early so that opts can be used to override the baked-in values,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -203,16 +203,20 @@ func Get() *Config {
 	return instance
 }
 
-// GetNew returns a new global configuration instance.
+// CreateNew returns a new global configuration instance.
 // This function should be used when we need to create a new configuration instance.
 // It build a new configuration instance and override the existing one
+// loosing any programmatic configuration that would have been applied to the existing instance.
+//
+// It shouldn't be used to get the global configuration instance to manipulate it but
+// should be used when there is a need to reset the global configuration instance.
 //
 // This is useful when we need to create a new configuration instance when a new product is initialized.
 // Each product should have its own configuration instance and apply its own programmatic configuration to it.
 //
 // If a customer starts multiple tracer with different programmatic configuration only the latest one will be used
 // and available globally.
-func GetNew() *Config {
+func CreateNew() *Config {
 	mu.Lock()
 	defer mu.Unlock()
 	instance = loadConfig()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -86,10 +86,10 @@ func TestGet(t *testing.T) {
 		require.NotNil(t, cfg2)
 		assert.Same(t, cfg1, cfg2, "Get() should return the same instance")
 
-		// GetNew should return a new instance
-		cfg3 := GetNew()
+		// CreateNew should return a new instance
+		cfg3 := CreateNew()
 		require.NotNil(t, cfg3)
-		assert.NotSame(t, cfg2, cfg3, "GetNew() should return a new instance")
+		assert.NotSame(t, cfg2, cfg3, "CreateNew() should return a new instance")
 
 		// Now it should cache the same instance
 		cfg4 := Get()


### PR DESCRIPTION
### What does this PR do?

This PR adds a new function to the `internal/config` package allowing us to force rebuilding the internal config when required. 

Since the revamp any tracer swap would keep the same configuration without re-reading configuration providers and applying only programmatic configurations. 

This PR changes this behavior. A new tracer would now reset the configuration to reflect better what's currently available and apply its own programmatic options, ignoring the previously applied one.

### Motivation

We've got some feedback during dogfoding about tracers configuration set at runtime `os.Setenv` not being applied when the tracer started. It occured when a first tracer was started and a second one later on with configuration set, in process, via env var.

This is blocking `v2.6.0`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `./scripts/lint.sh` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

Unsure? Have a question? Request a review!
