### PR TITLE
feat(internal/config): change internalconfig behavior to use a fresh instance upon tracer creation [#4392 backport]

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -287,7 +287,7 @@ const maxPropagatedTagsLength = 512
 // and passed user opts.
 func newConfig(opts ...StartOption) (*config, error) {
 	c := new(config)
-	c.internalConfig = internalconfig.Get()
+	c.internalConfig = internalconfig.CreateNew()
 
 	// If this was built with a recent-enough version of Orchestrion, force the orchestrion config to
 	// the baked-in values. We do this early so that opts can be used to override the baked-in values,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -203,6 +203,27 @@ func Get() *Config {
 	return instance
 }
 
+// CreateNew returns a new global configuration instance.
+// This function should be used when we need to create a new configuration instance.
+// It build a new configuration instance and override the existing one
+// loosing any programmatic configuration that would have been applied to the existing instance.
+//
+// It shouldn't be used to get the global configuration instance to manipulate it but
+// should be used when there is a need to reset the global configuration instance.
+//
+// This is useful when we need to create a new configuration instance when a new product is initialized.
+// Each product should have its own configuration instance and apply its own programmatic configuration to it.
+//
+// If a customer starts multiple tracer with different programmatic configuration only the latest one will be used
+// and available globally.
+func CreateNew() *Config {
+	mu.Lock()
+	defer mu.Unlock()
+	instance = loadConfig()
+
+	return instance
+}
+
 func SetUseFreshConfig(use bool) {
 	mu.Lock()
 	defer mu.Unlock()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -73,6 +73,30 @@ func TestGet(t *testing.T) {
 		assert.Same(t, cfg4, cfg5, "With useFreshConfig=false, Get() should cache the same instance")
 	})
 
+	t.Run("GetNew forces new instance", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+
+		// Get the first instance
+		cfg1 := Get()
+		require.NotNil(t, cfg1)
+
+		// Get should return the same instance
+		cfg2 := Get()
+		require.NotNil(t, cfg2)
+		assert.Same(t, cfg1, cfg2, "Get() should return the same instance")
+
+		// CreateNew should return a new instance
+		cfg3 := CreateNew()
+		require.NotNil(t, cfg3)
+		assert.NotSame(t, cfg2, cfg3, "CreateNew() should return a new instance")
+
+		// Now it should cache the same instance
+		cfg4 := Get()
+		assert.Same(t, cfg3, cfg4, "Get() should return the same instance")
+		assert.NotSame(t, cfg1, cfg4, "Get() should not return the same instance as the first one")
+	})
+
 	t.Run("concurrent access is safe", func(t *testing.T) {
 		resetGlobalState()
 		defer resetGlobalState()


### PR DESCRIPTION
This backports #4392 to the 2.6 release branch to fix #4388
