### PR TITLE
fix(telemetry): Disable starting tracer telemetry client if running as Lambda function

### DIFF
--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -20,9 +20,10 @@ func reportTelemetryOnAppStarted(c telemetry.Configuration) {
 	additionalConfigs = append(additionalConfigs, c)
 }
 
-// startTelemetry starts the global instrumentation telemetry client with tracer data
-// unless instrumentation telemetry is disabled via the DD_INSTRUMENTATION_TELEMETRY_ENABLED
-// env var.
+// startTelemetry starts the global instrumentation telemetry client with tracer data unless:
+//   - instrumentation telemetry is disabled via the DD_INSTRUMENTATION_TELEMETRY_ENABLED env var.
+//   - running as a Lambda function
+//
 // If the telemetry client has already been started by the profiler, then
 // an app-product-change event is sent with appsec information and an app-client-configuration-change
 // event is sent with tracer config data.
@@ -30,7 +31,7 @@ func reportTelemetryOnAppStarted(c telemetry.Configuration) {
 // an app-product-change event for the tracer.
 // TODO (APMAPI-1771): This function should be deleted once config migration is complete
 func startTelemetry(c *config) telemetry.Client {
-	if telemetry.Disabled() {
+	if c.internalConfig.IsLambdaFunction() || telemetry.Disabled() {
 		// Do not do extra work populating config data if instrumentation telemetry is disabled.
 		return nil
 	}

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -243,7 +243,7 @@ func Start(opts ...StartOption) error {
 		// CI Visibility agentless mode doesn't require remote configuration.
 
 		// start instrumentation telemetry unless it is disabled through the
-		// DD_INSTRUMENTATION_TELEMETRY_ENABLED env var
+		// DD_INSTRUMENTATION_TELEMETRY_ENABLED env var or running under a Lambda function
 		t.telemetry = startTelemetry(t.config)
 
 		globalinternal.SetTracerInitialized(true)
@@ -290,7 +290,7 @@ func Start(opts ...StartOption) error {
 	}
 
 	// start instrumentation telemetry unless it is disabled through the
-	// DD_INSTRUMENTATION_TELEMETRY_ENABLED env var
+	// DD_INSTRUMENTATION_TELEMETRY_ENABLED env var or running under a Lambda function
 	t.telemetry = startTelemetry(t.config)
 
 	// store the configuration in an in-memory file and in a named anonymous mapping,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This change will not longer perform startup tasks under `startTelemetry()` if running under an AWS Lambda function or (existing behaviour) env var `DD_INSTRUMENTATION_TELEMETRY_ENABLED` set.

### Motivation

As per https://github.com/DataDog/dd-trace-go/issues/3808, currently when using `dd-trace-go` under an AWS Lambda function, the user will be greeted with many log messages being outputted in the follow form:

```
2026/02/16 03:42:33 Datadog Tracer v2.6.0 WARN: appsec: error while flushing SCA Security Data: Post "http://localhost:8126/telemetry/proxy/api/v2/apmtelemetry": dial tcp 127.0.0.1:8126: connect: connection refused
```

Is is because the APM Telemetry service will never exist within the content of a Lambda function.

Alternative methods were proposed at the time (see [this](https://github.com/DataDog/datadog-lambda-go/pull/206#issuecomment-3226623409) and [this](https://github.com/DataDog/datadog-lambda-go/commit/4d70949b03947cf243d758025b66b7e6e5937e9f)) - but using the already available `IsLambdaFunction()` method feels cleaner.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
