### PR TITLE
chore(internal/telemetry): remove debug log

### DIFF
--- a/internal/telemetry/telemetrytest/record.go
+++ b/internal/telemetry/telemetrytest/record.go
@@ -6,7 +6,6 @@
 package telemetrytest
 
 import (
-	"fmt"
 	"log/slog"
 	"reflect"
 	"sort"
@@ -95,8 +94,6 @@ func (r *RecordClient) metric(kind string, namespace telemetry.Namespace, name s
 
 func (r *RecordClient) Count(namespace telemetry.Namespace, name string, tags []string) telemetry.MetricHandle {
 	return r.metric(string(transport.CountMetric), namespace, name, tags, func(handle *RecordMetricHandle, value float64) {
-		// DEBUG LOGGING
-		fmt.Printf("Count %s %s %v %.0f (prev=%.0f, new=%.0f)\n", namespace, name, tags, value, handle.count, handle.count+value)
 		handle.count += value
 	}, func(handle *RecordMetricHandle) float64 {
 		return handle.count


### PR DESCRIPTION
I noticed these debug logs while running profiler unit tests locally.
They don't seem necessary, and none of the other methods have similar
logs.
