### PR TITLE
fix(contrib/go-sdk): upgrade go-sdk to v1.3.0, fix concurrent writes in intent capture

### DIFF
--- a/contrib/modelcontextprotocol/go-sdk/go.mod
+++ b/contrib/modelcontextprotocol/go-sdk/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	github.com/DataDog/dd-trace-go/v2 v2.7.0-dev.1
-	github.com/google/jsonschema-go v0.3.0
-	github.com/modelcontextprotocol/go-sdk v1.1.0
+	github.com/google/jsonschema-go v0.4.2
+	github.com/modelcontextprotocol/go-sdk v1.3.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/contrib/modelcontextprotocol/go-sdk/go.sum
+++ b/contrib/modelcontextprotocol/go-sdk/go.sum
@@ -61,6 +61,8 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/mock v1.7.0-rc.1 h1:YojYx61/OLFsiv6Rw1Z96LpldJIy31o+UHmwAUMJ6/U=
 github.com/golang/mock v1.7.0-rc.1/go.mod h1:s42URUywIqd+OcERslBJvOjepvNymP31m3q8d/GkuRs=
@@ -71,8 +73,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/jsonschema-go v0.3.0 h1:6AH2TxVNtk3IlvkkhjrtbUc4S8AvO0Xii0DxIygDg+Q=
-github.com/google/jsonschema-go v0.3.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
+github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgYQBbFN4U4JNXUNYpxael3UzMyo=
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -95,8 +97,8 @@ github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35 h1:PpXWgLPs+Fqr32
 github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35/go.mod h1:autxFIvghDt3jPTLoqZ9OZ7s9qTGNAWmYCjVFWPX/zg=
 github.com/minio/simdjson-go v0.4.5 h1:r4IQwjRGmWCQ2VeMc7fGiilu1z5du0gJ/I/FsKwgo5A=
 github.com/minio/simdjson-go v0.4.5/go.mod h1:eoNz0DcLQRyEDeaPr4Ru6JpjlZPzbA0IodxVJk8lO8E=
-github.com/modelcontextprotocol/go-sdk v1.1.0 h1:Qjayg53dnKC4UZ+792W21e4BpwEZBzwgRW6LrjLWSwA=
-github.com/modelcontextprotocol/go-sdk v1.1.0/go.mod h1:6fM3LCm3yV7pAs8isnKLn07oKtB0MP9LHd3DfAcKw10=
+github.com/modelcontextprotocol/go-sdk v1.3.0 h1:gMfZkv3DzQF5q/DcQePo5rahEY+sguyPfXDfNBcT0Zs=
+github.com/modelcontextprotocol/go-sdk v1.3.0/go.mod h1:AnQ//Qc6+4nIyyrB4cxBU7UW9VibK4iOZBeyP/rF1IE=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/contrib/modelcontextprotocol/go-sdk/intent_capture.go
+++ b/contrib/modelcontextprotocol/go-sdk/intent_capture.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"encoding/json"
 
+	"maps"
+
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -62,15 +64,26 @@ func injectToolsListResponse(res *mcp.ListToolsResult) {
 			continue
 		}
 
-		if inputSchema.Type == "" {
-			inputSchema.Type = "object"
-		}
-		if inputSchema.Properties == nil {
-			inputSchema.Properties = map[string]*jsonschema.Schema{}
+		// Create copies of the tool and schema to avoid mutating the registered
+		// schema used for server-side validation in go-sdk v1.3+.
+		schemaCopy := *inputSchema
+		if schemaCopy.Type == "" {
+			schemaCopy.Type = "object"
 		}
 
-		inputSchema.Properties[instrmcp.TelemetryKey] = telemetrySchema()
-		inputSchema.Required = append(inputSchema.Required, instrmcp.TelemetryKey)
+		newProps := make(map[string]*jsonschema.Schema, len(inputSchema.Properties)+1)
+		maps.Copy(newProps, inputSchema.Properties)
+		newProps[instrmcp.TelemetryKey] = telemetrySchema()
+		schemaCopy.Properties = newProps
+
+		newRequired := make([]string, len(inputSchema.Required)+1)
+		copy(newRequired, inputSchema.Required)
+		newRequired[len(inputSchema.Required)] = instrmcp.TelemetryKey
+		schemaCopy.Required = newRequired
+
+		toolCopy := *res.Tools[i]
+		toolCopy.InputSchema = &schemaCopy
+		res.Tools[i] = &toolCopy
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Upgrades `github.com/modelcontextprotocol/go-sdk` from v1.1.0 to v1.3.0 in the `contrib/modelcontextprotocol/go-sdk` module and fixes two bugs in `injectToolsListResponse` caused by mutating the registered tool schemas in-place.

**Validation failure (new in v1.3.0):** go-sdk v1.3.0 added server-side schema validation of tool arguments inside the tool handler. The intent capture middleware was adding `telemetry` as a required property directly on the registered schema via the `tools/list` response, then stripping it from arguments in the `tools/call` path before the handler ran validation — causing a `missing properties: ["telemetry"]` error.

**Concurrent writes (pre-existing):** Multiple concurrent `tools/list` requests would race on the shared `Properties` map and `Required` slice, risking a map concurrent write panic. Same class of bug as #4362.

Both are fixed by creating per-request copies of the tool, schema, properties map, and required slice in `injectToolsListResponse`, so the registered schemas are never mutated.

### Motivation

Keeping the go-sdk dependency up to date. v1.3.0 includes server-side argument validation and structured tool output support.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.