### PR TITLE
fix(profiler/test): use atomic.Pointer[string] for containerID/entityID to prevent data race

### DIFF
--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -101,11 +101,11 @@ func (p *profiler) doRequest(bat batch) error {
 	if p.cfg.apiKey != "" {
 		req.Header.Set("DD-API-KEY", p.cfg.apiKey)
 	}
-	if containerID != "" {
-		req.Header.Set("Datadog-Container-ID", containerID)
+	if cid := containerID.Load(); cid != nil && *cid != "" {
+		req.Header.Set("Datadog-Container-ID", *cid)
 	}
-	if entityID != "" {
-		req.Header.Set("Datadog-Entity-ID", entityID)
+	if eid := entityID.Load(); eid != nil && *eid != "" {
+		req.Header.Set("Datadog-Entity-ID", *eid)
 	}
 	req.Header.Set("Content-Type", contentType)
 

--- a/profiler/upload_test.go
+++ b/profiler/upload_test.go
@@ -100,20 +100,27 @@ func TestOldAgent(t *testing.T) {
 	assert.Equal(t, errOldAgent, err)
 }
 
+func setContainerEntityIDs(t *testing.T, cid, eid string) {
+	t.Helper()
+	origCID := containerID.Load()
+	origEID := entityID.Load()
+	t.Cleanup(func() {
+		containerID.Store(origCID)
+		entityID.Store(origEID)
+	})
+	containerID.Store(&cid)
+	entityID.Store(&eid)
+}
+
 func TestEntityContainerIDHeaders(t *testing.T) {
 	t.Run("set", func(t *testing.T) {
-		defer func(cid, eid string) { containerID = cid; entityID = eid }(containerID, entityID)
-		entityID = "fakeEntityID"
-		containerID = "fakeContainerID"
+		setContainerEntityIDs(t, "fakeContainerID", "fakeEntityID")
 		profile := doOneShortProfileUpload(t)
-		assert.Equal(t, containerID, profile.headers.Get("Datadog-Container-Id"))
-		assert.Equal(t, entityID, profile.headers.Get("Datadog-Entity-Id"))
+		assert.Equal(t, "fakeContainerID", profile.headers.Get("Datadog-Container-Id"))
+		assert.Equal(t, "fakeEntityID", profile.headers.Get("Datadog-Entity-Id"))
 	})
 	t.Run("unset", func(t *testing.T) {
-		// Force an empty containerid and entityID on this test.
-		defer func(cid, eid string) { containerID = cid; entityID = eid }(containerID, entityID)
-		entityID = ""
-		containerID = ""
+		setContainerEntityIDs(t, "", "")
 		profile := doOneShortProfileUpload(t)
 		assert.Empty(t, profile.headers.Get("Datadog-Container-ID"))
 		assert.Empty(t, profile.headers.Get("Datadog-Entity-ID"))


### PR DESCRIPTION
The TestEntityContainerIDHeaders test directly assigns the package-level
containerID and entityID globals while the profiler's background goroutine
reads them concurrently in doRequest(). Replace plain string vars with
atomic.Pointer[string] for race-free access with compile-time type safety
and zero overhead on the read path.

- Use atomic.Pointer[string] instead of atomic.Value to eliminate runtime
  type assertions that could panic
- Extract setContainerEntityIDs test helper with t.Cleanup for robust
  global state restoration
- Fix typo: "suppressng" -> "suppressing" in errProfilerStopped comment

Signed-off-by: Kemal Akkoyun <kemal.akkoyun@datadoghq.com>

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

Race detector output:

<details><summary>Details</summary>
<p>

ok      github.com/DataDog/dd-trace-go/v2/appsec        3.559s
?       github.com/DataDog/dd-trace-go/v2/appsec/events [no test files]
?       github.com/DataDog/dd-trace-go/v2/civisibility  [no test files]
?       github.com/DataDog/dd-trace-go/v2/contrib       [no test files]
?       github.com/DataDog/dd-trace-go/v2/contrib/cloud.google.com/go/pubsubtrace       [no test files]
ok      github.com/DataDog/dd-trace-go/v2/contrib/confluentinc/confluent-kafka-go/kafkatrace    1.595s
ok      github.com/DataDog/dd-trace-go/v2/contrib/os    1.555s
ok      github.com/DataDog/dd-trace-go/v2/datastreams   1.437s
?       github.com/DataDog/dd-trace-go/v2/datastreams/options   [no test files]
ok      github.com/DataDog/dd-trace-go/v2/ddtrace       1.491s [no tests to run]
ok      github.com/DataDog/dd-trace-go/v2/ddtrace/baggage       1.251s
ok      github.com/DataDog/dd-trace-go/v2/ddtrace/ext   1.166s
?       github.com/DataDog/dd-trace-go/v2/ddtrace/internal      [no test files]
?       github.com/DataDog/dd-trace-go/v2/ddtrace/internal/tracerstats  [no test files]
ok      github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer    1.734s
ok      github.com/DataDog/dd-trace-go/v2/ddtrace/opentelemetry 11.805s
ok      github.com/DataDog/dd-trace-go/v2/ddtrace/opentelemetry/log     3.696s
ok      github.com/DataDog/dd-trace-go/v2/ddtrace/opentelemetry/metric  2.100s
ok      github.com/DataDog/dd-trace-go/v2/ddtrace/tracer        167.444s
ok      github.com/DataDog/dd-trace-go/v2/instrumentation       3.085s
ok      github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/dyngo  2.060s
?       github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/emitter        [no test files]
?       github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/emitter/graphqlsec     [no test files]
?       github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/emitter/grpcsec        [no test files]
?       github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/emitter/httpsec        [no test files]
?       github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/emitter/ossec  [no test files]
?       github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/emitter/sqlsec [no test files]
ok      github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/emitter/waf/actions    1.666s
?       github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/emitter/waf/addresses  [no test files]
ok      github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/proxy  3.357s
?       github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/trace  [no test files]
?       github.com/DataDog/dd-trace-go/v2/instrumentation/env   [no test files]
ok      github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace    1.529s
ok      github.com/DataDog/dd-trace-go/v2/instrumentation/graphql       1.549s
ok      github.com/DataDog/dd-trace-go/v2/instrumentation/httpmem       1.397s
ok      github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace     4.585s
?       github.com/DataDog/dd-trace-go/v2/instrumentation/httptracemock [no test files]
?       github.com/DataDog/dd-trace-go/v2/instrumentation/internal/namingschema [no test files]
ok      github.com/DataDog/dd-trace-go/v2/instrumentation/internal/telemetrytest        89.947s
?       github.com/DataDog/dd-trace-go/v2/instrumentation/mcp   [no test files]
ok      github.com/DataDog/dd-trace-go/v2/instrumentation/net/http/pattern      1.368s
ok      github.com/DataDog/dd-trace-go/v2/instrumentation/options       1.244s
ok      github.com/DataDog/dd-trace-go/v2/instrumentation/testutils     2.838s
?       github.com/DataDog/dd-trace-go/v2/instrumentation/testutils/sql [no test files]
?       github.com/DataDog/dd-trace-go/v2/instrumentation/testutils/testtracer  [no test files]
ok      github.com/DataDog/dd-trace-go/v2/internal      1.296s
ok      github.com/DataDog/dd-trace-go/v2/internal/appsec       9.894s


ok      github.com/DataDog/dd-trace-go/v2/internal/appsec/apisec        252.157s
?       github.com/DataDog/dd-trace-go/v2/internal/appsec/apisec/internal/config        [no test files]
ok      github.com/DataDog/dd-trace-go/v2/internal/appsec/apisec/internal/timed 13.612s
ok      github.com/DataDog/dd-trace-go/v2/internal/appsec/body  1.236s
ok      github.com/DataDog/dd-trace-go/v2/internal/appsec/body/json     1.268s
ok      github.com/DataDog/dd-trace-go/v2/internal/appsec/config        1.319s
?       github.com/DataDog/dd-trace-go/v2/internal/appsec/emitter/usersec       [no test files]
?       github.com/DataDog/dd-trace-go/v2/internal/appsec/emitter/waf   [no test files]
ok      github.com/DataDog/dd-trace-go/v2/internal/appsec/limiter       3.523s
?       github.com/DataDog/dd-trace-go/v2/internal/appsec/listener      [no test files]
?       github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/graphqlsec   [no test files]
ok      github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/grpcsec      1.305s
ok      github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/httpsec      2.441s
ok      github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/httpsec/internal     2.123s
?       github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/ossec        [no test files]
?       github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/sqlsec       [no test files]
?       github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/trace        [no test files]
?       github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/usersec      [no test files]
ok      github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/waf  2.423s
?       github.com/DataDog/dd-trace-go/v2/internal/civisibility [no test files]
?       github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants       [no test files]
ok      github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations    1.967s
ok      github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting  43.465s
ok      github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting/coverage 23.167s
ok      github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting/subtests 23.492s
ok      github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/logs       3.252s
ok      github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils   14.531s
ok      github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/filebitmap        1.165s
ok      github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/impactedtests     5.268s
ok      github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/net       14.807s
ok      github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/telemetry 1.305s
ok      github.com/DataDog/dd-trace-go/v2/internal/config       1.798s
ok      github.com/DataDog/dd-trace-go/v2/internal/datastreams  1.541s
ok      github.com/DataDog/dd-trace-go/v2/internal/env  1.388s
ok      github.com/DataDog/dd-trace-go/v2/internal/globalconfig 1.251s
ok      github.com/DataDog/dd-trace-go/v2/internal/hostname     1.285s
ok      github.com/DataDog/dd-trace-go/v2/internal/hostname/azure       1.291s
ok      github.com/DataDog/dd-trace-go/v2/internal/hostname/cachedfetch 1.220s
ok      github.com/DataDog/dd-trace-go/v2/internal/hostname/ec2 1.317s
ok      github.com/DataDog/dd-trace-go/v2/internal/hostname/ecs 1.306s
ok      github.com/DataDog/dd-trace-go/v2/internal/hostname/gce 1.285s
ok      github.com/DataDog/dd-trace-go/v2/internal/hostname/httputils   6.336s
ok      github.com/DataDog/dd-trace-go/v2/internal/hostname/validate    1.223s
ok      github.com/DataDog/dd-trace-go/v2/internal/llmobs       12.168s
?       github.com/DataDog/dd-trace-go/v2/internal/llmobs/config        [no test files]
?       github.com/DataDog/dd-trace-go/v2/internal/llmobs/transport     [no test files]
ok      github.com/DataDog/dd-trace-go/v2/internal/locking      1.300s
ok      github.com/DataDog/dd-trace-go/v2/internal/locking/assert       1.156s
ok      github.com/DataDog/dd-trace-go/v2/internal/log  2.252s
ok      github.com/DataDog/dd-trace-go/v2/internal/namingschema 1.256s
ok      github.com/DataDog/dd-trace-go/v2/internal/normalizer   1.221s
ok      github.com/DataDog/dd-trace-go/v2/internal/orchestrion  1.226s
?       github.com/DataDog/dd-trace-go/v2/internal/orchestrion/generator        [no test files]
?       github.com/DataDog/dd-trace-go/v2/internal/orchestrion/matrix   [no test files]
ok      github.com/DataDog/dd-trace-go/v2/internal/osinfo       1.252s
ok      github.com/DataDog/dd-trace-go/v2/internal/processtags  1.250s
ok      github.com/DataDog/dd-trace-go/v2/internal/remoteconfig 10.039s
?       github.com/DataDog/dd-trace-go/v2/internal/samplernames [no test files]
ok      github.com/DataDog/dd-trace-go/v2/internal/stableconfig 1.399s
ok      github.com/DataDog/dd-trace-go/v2/internal/stacktrace   2.730s
?       github.com/DataDog/dd-trace-go/v2/internal/statsdtest   [no test files]
?       github.com/DataDog/dd-trace-go/v2/internal/synctest     [no test files]
ok      github.com/DataDog/dd-trace-go/v2/internal/telemetry    11.469s
ok      github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal   2.545s
?       github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal/knownmetrics      [no test files]
?       github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal/knownmetrics/generator    [no test files]
?       github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal/mapper    [no test files]
?       github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal/transport [no test files]
ok      github.com/DataDog/dd-trace-go/v2/internal/telemetry/log        1.348s
ok      github.com/DataDog/dd-trace-go/v2/internal/telemetry/telemetrytest      1.531s
ok      github.com/DataDog/dd-trace-go/v2/internal/traceprof    1.240s
ok      github.com/DataDog/dd-trace-go/v2/internal/urlsanitizer 1.236s
ok      github.com/DataDog/dd-trace-go/v2/internal/version      1.174s
ok      github.com/DataDog/dd-trace-go/v2/llmobs        5.405s
ok      github.com/DataDog/dd-trace-go/v2/llmobs/dataset        7.209s
ok      github.com/DataDog/dd-trace-go/v2/llmobs/experiment     4.886s
ok      github.com/DataDog/dd-trace-go/v2/openfeature   2.647s
?       github.com/DataDog/dd-trace-go/v2/orchestrion   [no test files]
runtime: cannot set cpu profile rate until previous profile has finished.
runtime: cannot set cpu profile rate until previous profile has finished.
==================
WARNING: DATA RACE
Read at 0x0001046a4760 by goroutine 2717:
  github.com/DataDog/dd-trace-go/v2/profiler.(*profiler).doRequest()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/upload.go:104 +0x3b4
  github.com/DataDog/dd-trace-go/v2/profiler.(*profiler).upload()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/upload.go:47 +0x214
  github.com/DataDog/dd-trace-go/v2/profiler.(*profiler).upload-fm()
      <autogenerated>:1 +0x68
  github.com/DataDog/dd-trace-go/v2/profiler.(*profiler).send()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/profiler.go:507 +0x234
  github.com/DataDog/dd-trace-go/v2/profiler.(*profiler).run.func3()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/profiler.go:304 +0x70

Previous write at 0x0001046a4760 by goroutine 2714:
  github.com/DataDog/dd-trace-go/v2/profiler.TestEntityContainerIDHeaders.func1.1()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/upload_test.go:105 +0x40
  github.com/DataDog/dd-trace-go/v2/profiler.TestEntityContainerIDHeaders.func1.deferwrap1()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/upload_test.go:105 +0x18
  runtime.deferreturn()
      /opt/homebrew/Cellar/go/1.26.0/libexec/src/runtime/panic.go:668 +0x5c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.0/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.0/libexec/src/testing/testing.go:2101 +0x34

Goroutine 2717 (running) created at:
  github.com/DataDog/dd-trace-go/v2/profiler.(*profiler).run()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/profiler.go:302 +0x1e8
  github.com/DataDog/dd-trace-go/v2/profiler.Start()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/profiler.go:71 +0x140
  github.com/DataDog/dd-trace-go/v2/profiler.startTestProfiler()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/profiler_test.go:410 +0x228
  github.com/DataDog/dd-trace-go/v2/profiler.doOneShortProfileUpload()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/profiler_test.go:424 +0x1d8
  github.com/DataDog/dd-trace-go/v2/profiler.TestEntityContainerIDHeaders.func1()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/upload_test.go:108 +0x17c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.0/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.0/libexec/src/testing/testing.go:2101 +0x34

Goroutine 2714 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.26.0/libexec/src/testing/testing.go:2101 +0x7bc
  github.com/DataDog/dd-trace-go/v2/profiler.TestEntityContainerIDHeaders()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/upload_test.go:104 +0x3c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.0/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.0/libexec/src/testing/testing.go:2101 +0x34
==================
==================
WARNING: DATA RACE
Read at 0x0001046a4770 by goroutine 2717:
  github.com/DataDog/dd-trace-go/v2/profiler.(*profiler).doRequest()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/upload.go:107 +0x4c4
  github.com/DataDog/dd-trace-go/v2/profiler.(*profiler).upload()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/upload.go:47 +0x214
  github.com/DataDog/dd-trace-go/v2/profiler.(*profiler).upload-fm()
      <autogenerated>:1 +0x68
  github.com/DataDog/dd-trace-go/v2/profiler.(*profiler).send()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/profiler.go:507 +0x234
  github.com/DataDog/dd-trace-go/v2/profiler.(*profiler).run.func3()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/profiler.go:304 +0x70

Previous write at 0x0001046a4770 by goroutine 2714:
  github.com/DataDog/dd-trace-go/v2/profiler.TestEntityContainerIDHeaders.func1.1()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/upload_test.go:105 +0x88
  github.com/DataDog/dd-trace-go/v2/profiler.TestEntityContainerIDHeaders.func1.deferwrap1()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/upload_test.go:105 +0x18
  runtime.deferreturn()
      /opt/homebrew/Cellar/go/1.26.0/libexec/src/runtime/panic.go:668 +0x5c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.0/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.0/libexec/src/testing/testing.go:2101 +0x34

Goroutine 2717 (running) created at:
  github.com/DataDog/dd-trace-go/v2/profiler.(*profiler).run()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/profiler.go:302 +0x1e8
  github.com/DataDog/dd-trace-go/v2/profiler.Start()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/profiler.go:71 +0x140
  github.com/DataDog/dd-trace-go/v2/profiler.startTestProfiler()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/profiler_test.go:410 +0x228
  github.com/DataDog/dd-trace-go/v2/profiler.doOneShortProfileUpload()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/profiler_test.go:424 +0x1d8
  github.com/DataDog/dd-trace-go/v2/profiler.TestEntityContainerIDHeaders.func1()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/upload_test.go:108 +0x17c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.0/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.0/libexec/src/testing/testing.go:2101 +0x34

Goroutine 2714 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.26.0/libexec/src/testing/testing.go:2101 +0x7bc
  github.com/DataDog/dd-trace-go/v2/profiler.TestEntityContainerIDHeaders()
      /Users/kemal.akkoyun/go/src/github.com/DataDog/dd-trace-go/profiler/upload_test.go:104 +0x3c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.0/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.0/libexec/src/testing/testing.go:2101 +0x34
==================
--- FAIL: TestEntityContainerIDHeaders (0.06s)
    --- FAIL: TestEntityContainerIDHeaders/set (0.04s)
        testing.go:1712: race detected during execution of test
FAIL
FAIL    github.com/DataDog/dd-trace-go/v2/profiler      25.170s
?       github.com/DataDog/dd-trace-go/v2/profiler/internal     [no test files]
ok      github.com/DataDog/dd-trace-go/v2/profiler/internal/fastdelta   10.892s
ok      github.com/DataDog/dd-trace-go/v2/profiler/internal/immutable   1.274s
ok      github.com/DataDog/dd-trace-go/v2/profiler/internal/pproflite   1.563s
ok      github.com/DataDog/dd-trace-go/v2/profiler/internal/pprofutils  1.304s
FAIL
prove_it: recorded full-tests fail

</p>
</details> 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
