### PR TITLE
ci: upload system-tests results to Test Optimization and add tracer-release nightly

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -340,7 +340,7 @@ jobs:
       - system-tests-docker-images
       - tracer-release
     runs-on: ubuntu-latest
-    if: success() || failure()
+    if: '!cancelled()'
     steps:
       - name: Success
         if: |


### PR DESCRIPTION
### What does this PR do?

Two changes to the existing `system-tests.yml` workflow:

1. **Upload all test results to Test Optimization** — adds `datadog-ci junit upload` steps to both the `system-tests` and `system-tests-docker-images` jobs, running on all triggers (PRs, push, schedule).
2. **Add `tracer-release` nightly job** — calls the official [system-tests reusable workflow](https://github.com/DataDog/system-tests/blob/main/.github/workflows/system-tests.yml) with `scenarios_groups: tracer-release` and `_system_tests_dev_mode: true`, only triggered on schedule.

### Motivation

- Gain visibility into system-tests results via Datadog Test Optimization.
- Run the `tracer-release` scenarios group nightly to catch regressions early.
- Follows the same pattern used in [system-tests-dashboard nightly](https://github.com/DataDog/system-tests-dashboard/blob/main/.github/workflows/nightly.yml).

### Reviewer's Checklist

- [x] This is a CI-only change (workflow modifications), no code changes.