### PR TITLE
fix(ci): update oldstable Go version to 1.25.7 in macrobenchmarks

### DIFF
--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -94,7 +94,7 @@ variables:
 .go-oldstable-benchmarks:
   extends: .benchmarks-default
   variables:
-    GO_VERSION: "1.25.0"
+    GO_VERSION: "1.25.7"
 
 #
 # Specific macrobenchmark configurations extending 


### PR DESCRIPTION
### What does this PR do?

Updates `GO_VERSION` from `1.25.0` to `1.25.7` for `.go-oldstable-benchmarks` in the macrobenchmarks CI config to match the Go versions installed in the rebuilt Docker image.

### Motivation

The macrobenchmarks Docker image was rebuilt with Go 1.26.0 and 1.25.7 ([benchmarking-platform#232](https://github.com/DataDog/benchmarking-platform/pull/232)), but the CI config still referenced `1.25.0` which no longer exists in the image. The `build-go-prof-app.sh` script creates a Go binary wrapper that calls `/root/go/bin/go${GO_VERSION}` directly, so `go-oldstable-*` jobs fail with `/root/go/bin/go1.25.0: not found`.

Companion fix for microbenchmarks: https://github.com/DataDog/benchmarking-platform/pull/234

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [x] There is a benchmark for any new code, or changes to existing code.
- [x] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!