### PR TITLE
refactor(profiler): remove unused t field from mockBackend

### DIFF
--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -179,7 +179,7 @@ func TestStart(t *testing.T) {
 // profiler is already running will restart it with the given configuration.
 func TestStartWithoutStopReconfigures(t *testing.T) {
 	got := make(chan profileMeta)
-	backend := &mockBackend{t: t, profiles: got}
+	backend := &mockBackend{profiles: got}
 	server, client := httpmem.ServerAndClient(backend)
 	defer server.Close()
 
@@ -347,7 +347,6 @@ type profileMeta struct {
 }
 
 type mockBackend struct {
-	t        *testing.T
 	profiles chan profileMeta
 }
 
@@ -417,7 +416,7 @@ func (m *mockBackend) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // and mock backend will be stopped when the calling test case completes
 func startTestProfiler(t *testing.T, size int, options ...Option) *mockBackend {
 	profiles := make(chan profileMeta, size)
-	backend := &mockBackend{t: t, profiles: profiles}
+	backend := &mockBackend{profiles: profiles}
 	server, client := httpmem.ServerAndClient(backend)
 	t.Cleanup(func() { server.Close() })
 
@@ -848,7 +847,7 @@ func TestUDSDefault(t *testing.T) {
 	internal.DefaultTraceAgentUDSPath = socket
 
 	profiles := make(chan profileMeta, 1)
-	backend := &mockBackend{t: t, profiles: profiles}
+	backend := &mockBackend{profiles: profiles}
 	mux := http.NewServeMux()
 	// Specifically set up a handler for /profiling/v1/input to test that we
 	// don't use the filesystem path to the Unix domain socket in the HTTP

--- a/profiler/upload_test.go
+++ b/profiler/upload_test.go
@@ -42,7 +42,7 @@ func TestTryUploadUDS(t *testing.T) {
 		t.Skip("Unix domain sockets are non-functional on windows.")
 	}
 	profiles := make(chan profileMeta, 1)
-	server := httptest.NewUnstartedServer(&mockBackend{t: t, profiles: profiles})
+	server := httptest.NewUnstartedServer(&mockBackend{profiles: profiles})
 	udsPath := "/tmp/com.datadoghq.dd-trace-go.profiler.test.sock"
 	l, err := net.Listen("unix", udsPath)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Suggested follow-up for #4436: removes the now-unused `t *testing.T` field from the `mockBackend` struct and all its initialization sites.

After #4436 de-flaked the mock backend by removing all `testing.T` usage from `ServeHTTP`, the `t` field on `mockBackend` is no longer referenced anywhere. This PR cleans up the leftover field and the `t: t` assignments in 4 initialization sites across `profiler_test.go` and `upload_test.go`.

### Motivation

Code cleanup suggestion for https://github.com/DataDog/dd-trace-go/pull/4436. The `t` field became dead code after that PR moved error handling out of the mock backend's HTTP handler.