### PR TITLE
fix: appsec enablement at startup for resource renaming

### DIFF
--- a/instrumentation/httptrace/config.go
+++ b/instrumentation/httptrace/config.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/dd-trace-go/v2/internal"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec"
+	appsecconfig "github.com/DataDog/dd-trace-go/v2/internal/appsec/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/env"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 )
@@ -46,7 +47,7 @@ type config struct {
 	baggageTagKeys                           map[string]struct{} // when allowAllBaggage is false, only tag baggage items whose keys are listed here.
 	resourceRenamingEnabled                  *bool
 	resourceRenamingAlwaysSimplifiedEndpoint bool
-	appsecEnabledMode                        func() bool // first state of Appsec (registered at the start of the application) // TODO: remove and use the real state of appsec
+	appsecEnabledMode                        func() bool // first AppSec enablement mode at startup.
 }
 
 func (c config) String() string {
@@ -67,7 +68,7 @@ func newConfig() config {
 		inferredProxyServicesEnabled:             internal.BoolEnv(envInferredProxyServicesEnabled, false),
 		baggageTagKeys:                           make(map[string]struct{}),
 		resourceRenamingAlwaysSimplifiedEndpoint: internal.BoolEnv("DD_TRACE_RESOURCE_RENAMING_ALWAYS_SIMPLIFIED_ENDPOINT", false),
-		appsecEnabledMode:                        sync.OnceValue(appsec.Enabled),
+		appsecEnabledMode:                        sync.OnceValue(appsecEnabledAtStartup),
 	}
 	if v, ok := env.Lookup("DD_TRACE_BAGGAGE_TAG_KEYS"); ok {
 		if v == "*" {
@@ -92,6 +93,14 @@ func newConfig() config {
 		c.resourceRenamingEnabled = &vv
 	}
 	return c
+}
+
+func appsecEnabledAtStartup() bool {
+	enabled, set, _ := appsecconfig.IsEnabledByEnvironment()
+	if set {
+		return enabled
+	}
+	return appsec.Enabled()
 }
 
 func isServerError(statusCode int) bool {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR fixes the default activation logic for HTTP resource renaming in `httptrace` when `DD_TRACE_RESOURCE_RENAMING_ENABLED` is unset.

Instead of relying only on `appsec.Enabled()`, it now first checks the enablement intent from `DD_APPSEC_ENABLED`. If the env var is explicitly set, that value is used. If it is not set, behavior falls back to `appsec.Enabled()` as before.


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

`test-tip` was [failing](https://github.com/DataDog/dd-trace-go/actions/runs/22151857096/job/64047458144#step:5:387) related to #4391

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
