### PR TITLE
fix(orchestrion/_integration): prevent TOCTOU race between mock agent and tested services

### DIFF
--- a/internal/orchestrion/_integration/internal/harness/harness.go
+++ b/internal/orchestrion/_integration/internal/harness/harness.go
@@ -58,6 +58,12 @@ func Run(t *testing.T, tc TestCase) {
 		defer cancel()
 	}
 
+	// Listen before Setup so the mock agent's port is bound before any call to
+	// net.FreePort inside Setup. Without this ordering, httptest.NewServer
+	// (called inside Start) can steal the port that FreePort just released,
+	// making the test server and mock agent share the same address.
+	mockAgent.Listen(t)
+
 	t.Log("Running setup")
 	tc.Setup(ctx, t)
 	mockAgent.Start(t)


### PR DESCRIPTION
### What does this PR do?

Introduces `MockAgent.Listen` to reserve a port before calling `testcase.Setup` so the mock agent and the tested service don't compete for it when the latter calls `net.FreePort` and uses the return port later.

### Motivation

Prevent TOCTOU races leading to flakiness.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [x] There is a benchmark for any new code, or changes to existing code.
- [x] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
