### PR TITLE
chore(claude): remove most permissions from settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,12 +1,6 @@
 {
   "permissions": {
     "allow": [
-      "Bash(make:*)",
-      "Bash(go:*)",
-      "Bash(gh:*)",
-      "Bash(golangci-lint:*)",
-      "Bash(bash script/:*)",
-      "Bash(git:*)",
       "mcp__ide__getDiagnostics"
     ]
   }


### PR DESCRIPTION
Claude (or any other LLM agent) should not have permission by default to
do anything, except possibly read files. Users typically allow Claude to
write code. If Claude then has permission to run make, Go, or bash
scripts, Claude can run arbitrary code on the host machine without
prompting the user. This leaves developers open to unwanted, destructive
behavior due to hallucinations and prompt injection attacks.
And with blanket `gh` and `git` permissions, the agent has the same access
to GitHub as the user running the agent. Additionally, any settings we commit 
to this repo silently take precedence over user settings. This PR removes the
tool permissions. The MCP one seems okay for now.

It would be nice to leave a breadcrumb to remind devlopers to be mindful
about what they add to the shared configuration, but Claude's
configuration doesn't allow comments...
