### PR TITLE
feat(ddtrace/opentelemetry): add AddLink & RecordError

### DIFF
--- a/ddtrace/opentelemetry/span.go
+++ b/ddtrace/opentelemetry/span.go
@@ -8,6 +8,9 @@ package opentelemetry
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
+	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -19,6 +22,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	otelcodes "go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 )
@@ -204,6 +208,42 @@ func (s *span) AddEvent(name string, opts ...oteltrace.EventOption) {
 		},
 	}
 	s.events = append(s.events, e)
+}
+
+// RecordError will record err as an exception span event for this span. An
+// additional call to SetStatus is required if the Status of the Span should
+// be set to Error, as this method does not change the Span status. If this
+// span is not being recorded or err is nil then this method does nothing.
+func (s *span) RecordError(err error, opts ...oteltrace.EventOption) {
+	if !s.IsRecording() || err == nil {
+		return
+	}
+
+	opts = append(opts, oteltrace.WithAttributes(
+		semconv.ExceptionType(typeStr(err)),
+		semconv.ExceptionMessage(err.Error()),
+	))
+
+	cfg := oteltrace.NewEventConfig(opts...)
+	if cfg.StackTrace() {
+		buf := make([]byte, 2048)
+		n := runtime.Stack(buf, false)
+		stacktrace := string(buf[0:n])
+		opts = append(opts, oteltrace.WithAttributes(
+			semconv.ExceptionStacktrace(stacktrace),
+		))
+	}
+
+	s.AddEvent(semconv.ExceptionEventName, opts...)
+}
+
+func typeStr(i any) string {
+	t := reflect.TypeOf(i)
+	if t.PkgPath() == "" && t.Name() == "" {
+		// Likely a builtin type.
+		return t.String()
+	}
+	return fmt.Sprintf("%s.%s", t.PkgPath(), t.Name())
 }
 
 // AddLink adds OTel Span Links to the underlying Datadog span.

--- a/ddtrace/opentelemetry/span_test.go
+++ b/ddtrace/opentelemetry/span_test.go
@@ -458,6 +458,40 @@ func attributesContains(attrs map[string]any, key string, val any) bool {
 	return false
 }
 
+func TestRecordError(t *testing.T) {
+	assert := assert.New(t)
+	_, _, cleanup := mockTracerProvider(t)
+	tr := otel.Tracer("")
+	defer cleanup()
+
+	errMsg := "something went wrong"
+	_, sp := tr.Start(context.Background(), "span_record_error")
+
+	// Record the error as an event
+	sp.RecordError(errors.New(errMsg), oteltrace.WithStackTrace(true))
+	sp.End()
+
+	dd := sp.(*span)
+	assert.Len(dd.events, 1)
+	e := dd.events[0]
+	assert.Equal("exception", e.name)
+
+	cfg := tracer.SpanEventConfig{}
+	for _, opt := range e.options {
+		opt(&cfg)
+	}
+
+	// Assert expected attributes exist on the event
+	assert.Len(cfg.Attributes, 3)
+
+	assert.True(attributesContains(cfg.Attributes, "exception.message", errMsg))
+	assert.True(attributesContains(cfg.Attributes, "exception.type", "*errors.errorString"))
+	assert.Contains(cfg.Attributes, "exception.stacktrace")
+
+	// verify status did not change to error since RecordError should not change span status
+	assert.Equal(codes.Unset, dd.statusInfo.code)
+}
+
 func TestSpanContextWithStartOptions(t *testing.T) {
 	assert := assert.New(t)
 	_, payloads, cleanup := mockTracerProvider(t)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This implements [AddLink](https://github.com/open-telemetry/opentelemetry-go/blob/main/trace/span.go#L37-L41) and [RecordError](https://github.com/open-telemetry/opentelemetry-go/blob/main/trace/span.go#L47-L51) in the opentelemetry to DD adaptor span.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

I am trying to use OTel's `AddLink` and discovered that it currently delegates to the `noop.Span` handler. I temporarily swapped `noop.Span` with `embedded.Span` to also discover `RecordError` was missing.

I looked at OpenTelemetry's `RecordError` implementation's for the appropriate attributes (`exception.type`, `exception.message` and `exception.stacktrace`), for example: [sdk/trace/span.go](https://github.com/open-telemetry/opentelemetry-go/blob/248da958375e4dfb4a1105645107be3ef04b1c59/sdk/trace/span.go#L540-L568)

For `AddLink`, I re-used the basic logic from [ddtrace/opentelemetry/tracer.go](https://github.com/DataDog/dd-trace-go/blob/69beee14d541e56fd6492db25d0ae03c597a1ea8/ddtrace/opentelemetry/tracer.go#L72-L94).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
