### PR TITLE
feat(ddtrace/tracer): optimize tracer Git metadata tags updates

### DIFF
--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -625,11 +625,21 @@ func (t *trace) setTraceTagsLocked(s *Span) {
 	for k, v := range t.propagatingTags {
 		s.setMetaLocked(k, v)
 	}
-	for k, v := range sharedinternal.GetTracerGitMetadataTags() {
-		s.setMetaLocked(k, v)
-	}
+	updateTracerGitMetadataTags(s)
 	if s.context != nil && s.context.traceID.HasUpper() {
 		s.setMetaLocked(keyTraceID128, s.context.traceID.UpperHex())
+	}
+}
+
+// updateTracerGitMetadataTags updates the tracer git metadata tags on the given span.
+func updateTracerGitMetadataTags(s *Span) {
+	gitMetadataTags := sharedinternal.GetGitMetadataTags()
+	for ix := range sharedinternal.TracerGitMetadataKeys {
+		pair := sharedinternal.TracerGitMetadataKeys[ix]
+		src, dst := pair[0], pair[1]
+		if v := gitMetadataTags[src]; v != "" {
+			s.setMetaLocked(dst, v)
+		}
 	}
 }
 

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
+	"github.com/DataDog/dd-trace-go/v2/internal"
 	"github.com/DataDog/dd-trace-go/v2/internal/globalconfig"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/processtags"
@@ -1278,6 +1279,43 @@ func FuzzSpanIDHexEncoded(f *testing.F) {
 		actual := spanIDHexEncoded(v, p)
 		if actual != expected {
 			t.Fatalf("expected %s, got %s", expected, actual)
+		}
+	})
+}
+
+func BenchmarkUpdateTracerGitMetadataTags(b *testing.B) {
+	b.Run("old GetTracerGitMetadataTags", func(b *testing.B) {
+		b.Setenv(internal.EnvGitMetadataEnabledFlag, "true")
+		internal.RefreshGitMetadataTags()
+		updateTags := func(tags map[string]string, key, value string) {
+			if _, ok := tags[key]; !ok && value != "" {
+				tags[key] = value
+			}
+		}
+		// Emulates old implementation of GetTracerGitMetadataTags
+		old := func() map[string]string {
+			results := make(map[string]string)
+			tags := internal.GetGitMetadataTags()
+			updateTags(results, internal.TraceTagRepositoryURL, tags[internal.TagRepositoryURL])
+			updateTags(results, internal.TraceTagCommitSha, tags[internal.TagCommitSha])
+			updateTags(results, internal.TraceTagGoPath, tags[internal.TagGoPath])
+			return results
+		}
+		var sink map[string]string
+		b.ResetTimer()
+		for b.Loop() {
+			sink = old()
+		}
+		// This is to avoid the compiler optimizing out the map allocation.
+		_ = sink
+	})
+	b.Run("new UpdateTracerGitMetadataTags", func(b *testing.B) {
+		b.Setenv(internal.EnvGitMetadataEnabledFlag, "true")
+		internal.RefreshGitMetadataTags()
+		span := newBasicSpan("span")
+		b.ResetTimer()
+		for b.Loop() {
+			updateTracerGitMetadataTags(span)
 		}
 	})
 }

--- a/internal/gitmetadata.go
+++ b/internal/gitmetadata.go
@@ -129,19 +129,13 @@ func CleanGitMetadataTags(tags map[string]string) {
 	delete(tags, TagGoPath)
 }
 
-// GetTracerGitMetadataTags returns git metadata tags for tracer
-// NB: Currently tracer inject tags with some workaround
-// (only with _dd prefix and only for the first span in payload)
-// So we provide different tag names
-func GetTracerGitMetadataTags() map[string]string {
-	res := make(map[string]string)
-	tags := GetGitMetadataTags()
-
-	updateTags(res, TraceTagRepositoryURL, tags[TagRepositoryURL])
-	updateTags(res, TraceTagCommitSha, tags[TagCommitSha])
-	updateTags(res, TraceTagGoPath, tags[TagGoPath])
-
-	return res
+// TracerGitMetadataKeys maps canonical git metadata tag keys to their
+// _dd-prefixed tracer equivalents. The tracer injects these with a _dd
+// prefix because they are only attached to the first span in a payload.
+var TracerGitMetadataKeys = [3][2]string{
+	{TagRepositoryURL, TraceTagRepositoryURL},
+	{TagCommitSha, TraceTagCommitSha},
+	{TagGoPath, TraceTagGoPath},
 }
 
 // removeCredentials returns the passed url with potential credentials removed.


### PR DESCRIPTION
### What does this PR do?

Drops `GetTracerGitMetadataTags` in favour of `TracerGitMetadataKeys` known keys array + a similar `updateTracerGitMetadataTags` in `spancontext.go` using the former known keys array.

### Motivation

Avoid allocating a map for every root span, and make it easier to benchmark against the old implementation. This is the reason the benchmark is in `spancontext.go` as doing this the opposite way - adding it to `internal/gitmetadata.go` would cause a circular dependency with `ddtrace/tracer`.

Using fixed arrays instead of a map helps to make this really fast and maintainable. `updateTracerGitMetadataTags` encapsulates the kind-of-gnarly details of iterating by index the pairs instead of just doing it over key-value from a map.

#### Microbenchmarks

```
goos: darwin
goarch: arm64
pkg: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer
cpu: Apple M1 Max
BenchmarkUpdateTracerGitMetadataTags
BenchmarkUpdateTracerGitMetadataTags/old_GetTracerGitMetadataTags
BenchmarkUpdateTracerGitMetadataTags/old_GetTracerGitMetadataTags-10            13495472               138.2 ns/op       48 B/op          1 allocs/op
BenchmarkUpdateTracerGitMetadataTags/new_UpdateTracerGitMetadataTags
BenchmarkUpdateTracerGitMetadataTags/new_UpdateTracerGitMetadataTags-10         71804235                16.91 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/DataDog/dd-trace-go/v2/ddtrace/tracer        4.335s
```

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] <s>[System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.</s>
- [x] There is a benchmark for any new code, or changes to existing code.
- [x] <s>If this interacts with the agent in a new way, a system test has been added.</s>
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] <s>All generated files are up to date. You can check this by running `make generate` locally.</s>
- [x] <s>Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.</s>

Unsure? Have a question? Request a review!
