### PR TITLE
feat(openfeature): add flag evaluation tracking via OTel Metrics

### DIFF
--- a/openfeature/flageval_metrics.go
+++ b/openfeature/flageval_metrics.go
@@ -7,10 +7,11 @@ package openfeature
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"strings"
 	"time"
 
+	of "github.com/open-feature/go-sdk/openfeature"
 	"go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
 
@@ -31,6 +32,33 @@ var (
 	attrReason    = attribute.Key("feature_flag.result.reason")
 	attrErrorType = attribute.Key("error.type")
 )
+
+// flagEvalHook implements the OpenFeature Hook interface to track flag evaluation metrics.
+// It uses the Finally hook stage so that metrics are recorded after all evaluation logic
+// completes, including type conversion errors and "not ready" state evaluations.
+type flagEvalHook struct {
+	of.UnimplementedHook
+	metrics *flagEvalMetrics
+}
+
+// newFlagEvalHook creates a new flag evaluation metrics hook.
+func newFlagEvalHook(m *flagEvalMetrics) *flagEvalHook {
+	return &flagEvalHook{metrics: m}
+}
+
+// Finally is called after every flag evaluation (success or error).
+// It records a metric for the evaluation result.
+func (h *flagEvalHook) Finally(
+	ctx context.Context,
+	hookContext of.HookContext,
+	details of.InterfaceEvaluationDetails,
+	_ of.HookHints,
+) {
+	if h.metrics == nil {
+		return
+	}
+	h.metrics.record(ctx, hookContext.FlagKey(), details)
+}
 
 // flagEvalMetrics manages OTel metric instruments for flag evaluation tracking.
 type flagEvalMetrics struct {
@@ -66,40 +94,37 @@ func newFlagEvalMetrics() (*flagEvalMetrics, error) {
 	}, nil
 }
 
-// record records a single flag evaluation.
+// record records a single flag evaluation from the evaluation details.
 func (m *flagEvalMetrics) record(
 	ctx context.Context,
 	flagKey string,
-	variantKey string,
-	reason string,
-	evalErr error,
+	details of.InterfaceEvaluationDetails,
 ) {
 	attrs := []attribute.KeyValue{
 		attrFlagKey.String(flagKey),
-		attrVariant.String(variantKey),
-		attrReason.String(reason),
+		attrVariant.String(details.Variant),
+		attrReason.String(strings.ToLower(string(details.Reason))),
 	}
 
-	if evalErr != nil {
-		errType := "general"
-		for sentinel, tag := range errorTypeTags {
-			if errors.Is(evalErr, sentinel) {
-				errType = tag
-				break
-			}
-		}
-		attrs = append(attrs, attrErrorType.String(errType))
+	if details.ErrorCode != "" {
+		attrs = append(attrs, attrErrorType.String(errorCodeToTag(details.ErrorCode)))
 	}
 
 	m.counter.Add(ctx, 1, otelmetric.WithAttributes(attrs...))
 }
 
-// errorTypeTags maps sentinel errors to low-cardinality metric tag values.
-var errorTypeTags = map[error]string{
-	errFlagNotFound:    "flag_not_found",
-	errTypeMismatch:    "type_mismatch",
-	errParseError:      "parse_error",
-	errNoConfiguration: "no_configuration",
+// errorCodeToTag maps OpenFeature ErrorCode values to low-cardinality metric tag values.
+func errorCodeToTag(code of.ErrorCode) string {
+	switch code {
+	case of.FlagNotFoundCode:
+		return "flag_not_found"
+	case of.TypeMismatchCode:
+		return "type_mismatch"
+	case of.ParseErrorCode:
+		return "parse_error"
+	default:
+		return "general"
+	}
 }
 
 // shutdown gracefully shuts down the meter provider.

--- a/openfeature/flageval_metrics_test.go
+++ b/openfeature/flageval_metrics_test.go
@@ -7,9 +7,8 @@ package openfeature
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"testing"
+	"time"
 
 	of "github.com/open-feature/go-sdk/openfeature"
 	"go.opentelemetry.io/otel/attribute"
@@ -76,13 +75,24 @@ func getAttr(dp metricdata.DataPoint[int64], key attribute.Key) string {
 	return val.AsString()
 }
 
+// makeDetails constructs an InterfaceEvaluationDetails for testing record().
+func makeDetails(variant string, reason of.Reason, errorCode of.ErrorCode) of.InterfaceEvaluationDetails {
+	return of.InterfaceEvaluationDetails{
+		EvaluationDetails: of.EvaluationDetails{
+			ResolutionDetail: of.ResolutionDetail{
+				Variant:   variant,
+				Reason:    reason,
+				ErrorCode: errorCode,
+			},
+		},
+	}
+}
+
 func TestRecord(t *testing.T) {
 	tests := []struct {
 		name        string
 		flagKey     string
-		variant     string
-		reason      string
-		err         error
+		details     of.InterfaceEvaluationDetails
 		wantValue   int64
 		wantReason  string
 		wantVariant string
@@ -91,9 +101,7 @@ func TestRecord(t *testing.T) {
 		{
 			name:        "success with targeting match",
 			flagKey:     "my-flag",
-			variant:     "variant-a",
-			reason:      "targeting_match",
-			err:         nil,
+			details:     makeDetails("variant-a", of.TargetingMatchReason, ""),
 			wantValue:   1,
 			wantReason:  "targeting_match",
 			wantVariant: "variant-a",
@@ -101,9 +109,7 @@ func TestRecord(t *testing.T) {
 		{
 			name:        "error flag not found",
 			flagKey:     "missing-flag",
-			variant:     "",
-			reason:      "error",
-			err:         fmt.Errorf("%w: %q", errFlagNotFound, "missing-flag"),
+			details:     makeDetails("", of.ErrorReason, of.FlagNotFoundCode),
 			wantValue:   1,
 			wantReason:  "error",
 			wantVariant: "",
@@ -112,9 +118,7 @@ func TestRecord(t *testing.T) {
 		{
 			name:        "default reason",
 			flagKey:     "my-flag",
-			variant:     "",
-			reason:      "default",
-			err:         nil,
+			details:     makeDetails("", of.DefaultReason, ""),
 			wantValue:   1,
 			wantReason:  "default",
 			wantVariant: "",
@@ -122,9 +126,7 @@ func TestRecord(t *testing.T) {
 		{
 			name:        "disabled flag",
 			flagKey:     "disabled-flag",
-			variant:     "",
-			reason:      "disabled",
-			err:         nil,
+			details:     makeDetails("", of.DisabledReason, ""),
 			wantValue:   1,
 			wantReason:  "disabled",
 			wantVariant: "",
@@ -134,7 +136,7 @@ func TestRecord(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			m, reader := setupTestMetrics(t)
-			m.record(context.Background(), tc.flagKey, tc.variant, tc.reason, tc.err)
+			m.record(context.Background(), tc.flagKey, tc.details)
 
 			rm := collectMetrics(t, reader)
 			dps := findCounter(t, rm)
@@ -173,8 +175,9 @@ func TestRecordMultipleEvaluations(t *testing.T) {
 	m, reader := setupTestMetrics(t)
 	ctx := context.Background()
 
+	details := makeDetails("variant-a", of.TargetingMatchReason, "")
 	for range 5 {
-		m.record(ctx, "my-flag", "variant-a", "targeting_match", nil)
+		m.record(ctx, "my-flag", details)
 	}
 
 	rm := collectMetrics(t, reader)
@@ -192,8 +195,8 @@ func TestRecordDifferentFlags(t *testing.T) {
 	m, reader := setupTestMetrics(t)
 	ctx := context.Background()
 
-	m.record(ctx, "flag-a", "on", "targeting_match", nil)
-	m.record(ctx, "flag-b", "off", "default", nil)
+	m.record(ctx, "flag-a", makeDetails("on", of.TargetingMatchReason, ""))
+	m.record(ctx, "flag-b", makeDetails("off", of.DefaultReason, ""))
 
 	rm := collectMetrics(t, reader)
 	dps := findCounter(t, rm)
@@ -216,18 +219,17 @@ func TestRecordAllErrorTypes(t *testing.T) {
 	ctx := context.Background()
 
 	errorCases := []struct {
-		err      error
+		code     of.ErrorCode
 		expected string
 	}{
-		{errFlagNotFound, "flag_not_found"},
-		{errTypeMismatch, "type_mismatch"},
-		{errParseError, "parse_error"},
-		{errNoConfiguration, "no_configuration"},
-		{errors.New("unknown"), "general"},
+		{of.FlagNotFoundCode, "flag_not_found"},
+		{of.TypeMismatchCode, "type_mismatch"},
+		{of.ParseErrorCode, "parse_error"},
+		{of.GeneralCode, "general"},
 	}
 
 	for _, tc := range errorCases {
-		m.record(ctx, "test-flag", "", "error", tc.err)
+		m.record(ctx, "test-flag", makeDetails("", of.ErrorReason, tc.code))
 	}
 
 	rm := collectMetrics(t, reader)
@@ -248,89 +250,140 @@ func TestRecordAllErrorTypes(t *testing.T) {
 	}
 }
 
+// TestIntegrationEvaluate tests that the flag evaluation hook correctly records
+// metrics when evaluations flow through the full OpenFeature client lifecycle.
 func TestIntegrationEvaluate(t *testing.T) {
-	tests := []struct {
-		name        string
-		flagKey     string
-		defaultVal  any
-		flatCtx     of.FlattenedContext
-		setConfig   bool
-		wantReason  string
-		wantVariant string
-		wantError   string
-	}{
-		{
-			name:       "targeting match records metric",
-			flagKey:    "bool-flag",
-			defaultVal: false,
-			flatCtx: of.FlattenedContext{
-				"targetingKey": "user-123",
-				"country":      "US",
-			},
-			setConfig:   true,
-			wantReason:  "targeting_match",
-			wantVariant: "on",
-		},
-		{
-			name:       "non-existent flag records error metric",
-			flagKey:    "non-existent-flag",
-			defaultVal: "default",
-			flatCtx: of.FlattenedContext{
-				"targetingKey": "user-123",
-			},
-			setConfig:  true,
-			wantReason: "error",
-			wantError:  "flag_not_found",
-		},
-		{
-			name:       "no configuration records error metric",
-			flagKey:    "any-flag",
-			defaultVal: "default",
-			flatCtx: of.FlattenedContext{
-				"targetingKey": "user-123",
-			},
-			setConfig:  false,
-			wantReason: "error",
-			wantError:  "no_configuration",
-		},
-	}
+	t.Run("targeting match records metric via hook", func(t *testing.T) {
+		provider := newDatadogProvider(ProviderConfig{})
+		provider.updateConfiguration(createTestConfig())
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			provider := newDatadogProvider(ProviderConfig{})
-			if tc.setConfig {
-				provider.updateConfiguration(createTestConfig())
-			}
+		m, reader := setupTestMetrics(t)
+		provider.flagEvalHook.metrics = m
 
-			m, reader := setupTestMetrics(t)
-			provider.flagEvalMetrics = m
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
 
-			provider.evaluate(context.Background(), tc.flagKey, tc.defaultVal, tc.flatCtx)
+		domain := "test-eval-match"
+		if err := of.SetNamedProviderWithContextAndWait(ctx, domain, provider); err != nil {
+			t.Fatalf("failed to set provider: %v", err)
+		}
 
-			rm := collectMetrics(t, reader)
-			dps := findCounter(t, rm)
-
-			if len(dps) != 1 {
-				t.Fatalf("expected 1 metric data point, got %d", len(dps))
-			}
-
-			dp := dps[0]
-			if got := getAttr(dp, attrFlagKey); got != tc.flagKey {
-				t.Errorf("flag key: got %q, want %q", got, tc.flagKey)
-			}
-			if got := getAttr(dp, attrReason); got != tc.wantReason {
-				t.Errorf("reason: got %q, want %q", got, tc.wantReason)
-			}
-			if tc.wantVariant != "" {
-				if got := getAttr(dp, attrVariant); got != tc.wantVariant {
-					t.Errorf("variant: got %q, want %q", got, tc.wantVariant)
-				}
-			}
-			if tc.wantError != "" {
-				if got := getAttr(dp, attrErrorType); got != tc.wantError {
-					t.Errorf("error.type: got %q, want %q", got, tc.wantError)
-				}
-			}
+		client := of.NewClient(domain)
+		evalCtx := of.NewEvaluationContext("user-123", map[string]any{
+			"country": "US",
 		})
-	}
+
+		_, err := client.BooleanValue(ctx, "bool-flag", false, evalCtx)
+		if err != nil {
+			t.Fatalf("evaluation failed: %v", err)
+		}
+
+		rm := collectMetrics(t, reader)
+		dps := findCounter(t, rm)
+
+		if len(dps) != 1 {
+			t.Fatalf("expected 1 metric data point, got %d", len(dps))
+		}
+
+		dp := dps[0]
+		if got := getAttr(dp, attrFlagKey); got != "bool-flag" {
+			t.Errorf("flag key: got %q, want %q", got, "bool-flag")
+		}
+		if got := getAttr(dp, attrReason); got != "targeting_match" {
+			t.Errorf("reason: got %q, want %q", got, "targeting_match")
+		}
+		if got := getAttr(dp, attrVariant); got != "on" {
+			t.Errorf("variant: got %q, want %q", got, "on")
+		}
+		if _, ok := dp.Attributes.Value(attrErrorType); ok {
+			t.Error("expected no error.type attribute on successful evaluation")
+		}
+	})
+
+	t.Run("flag not found records error metric via hook", func(t *testing.T) {
+		provider := newDatadogProvider(ProviderConfig{})
+		provider.updateConfiguration(createTestConfig())
+
+		m, reader := setupTestMetrics(t)
+		provider.flagEvalHook.metrics = m
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		domain := "test-eval-notfound"
+		if err := of.SetNamedProviderWithContextAndWait(ctx, domain, provider); err != nil {
+			t.Fatalf("failed to set provider: %v", err)
+		}
+
+		client := of.NewClient(domain)
+		evalCtx := of.NewEvaluationContext("user-123", nil)
+
+		// Evaluate a non-existent flag — should record flag_not_found error
+		_, _ = client.StringValue(ctx, "non-existent-flag", "default", evalCtx)
+
+		rm := collectMetrics(t, reader)
+		dps := findCounter(t, rm)
+
+		if len(dps) != 1 {
+			t.Fatalf("expected 1 metric data point, got %d", len(dps))
+		}
+
+		dp := dps[0]
+		if got := getAttr(dp, attrFlagKey); got != "non-existent-flag" {
+			t.Errorf("flag key: got %q, want %q", got, "non-existent-flag")
+		}
+		if got := getAttr(dp, attrReason); got != "error" {
+			t.Errorf("reason: got %q, want %q", got, "error")
+		}
+		if got := getAttr(dp, attrErrorType); got != "flag_not_found" {
+			t.Errorf("error.type: got %q, want %q", got, "flag_not_found")
+		}
+	})
+
+	// This test proves the hook catches type conversion errors that the old
+	// evaluate()-level recording approach missed. string-flag returns a string
+	// value, but we call BooleanValue which triggers a type mismatch error
+	// AFTER evaluate() returns.
+	t.Run("type conversion error records type_mismatch metric via hook", func(t *testing.T) {
+		provider := newDatadogProvider(ProviderConfig{})
+		provider.updateConfiguration(createTestConfig())
+
+		m, reader := setupTestMetrics(t)
+		provider.flagEvalHook.metrics = m
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		domain := "test-eval-typemismatch"
+		if err := of.SetNamedProviderWithContextAndWait(ctx, domain, provider); err != nil {
+			t.Fatalf("failed to set provider: %v", err)
+		}
+
+		client := of.NewClient(domain)
+		evalCtx := of.NewEvaluationContext("user-123", map[string]any{
+			"age": 25,
+		})
+
+		// string-flag returns "version-2" (string), but we request a boolean.
+		// The type mismatch happens in BooleanEvaluation after evaluate() returns.
+		_, _ = client.BooleanValue(ctx, "string-flag", false, evalCtx)
+
+		rm := collectMetrics(t, reader)
+		dps := findCounter(t, rm)
+
+		if len(dps) != 1 {
+			t.Fatalf("expected 1 metric data point, got %d", len(dps))
+		}
+
+		dp := dps[0]
+		if got := getAttr(dp, attrFlagKey); got != "string-flag" {
+			t.Errorf("flag key: got %q, want %q", got, "string-flag")
+		}
+		if got := getAttr(dp, attrReason); got != "error" {
+			t.Errorf("reason: got %q, want %q", got, "error")
+		}
+		if got := getAttr(dp, attrErrorType); got != "type_mismatch" {
+			t.Errorf("error.type: got %q, want %q", got, "type_mismatch")
+		}
+	})
 }

--- a/openfeature/provider.go
+++ b/openfeature/provider.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -60,8 +59,8 @@ type DatadogProvider struct {
 	exposureWriter *exposureWriter
 	exposureHook   *exposureHook
 
-	// Flag evaluation metrics (OTel counter)
-	flagEvalMetrics *flagEvalMetrics
+	// Flag evaluation metrics hook (OTel counter via Finally hook)
+	flagEvalHook *flagEvalHook
 }
 
 // NewDatadogProvider creates a new Datadog OpenFeature provider with default configuration.
@@ -99,9 +98,9 @@ func newDatadogProvider(config ProviderConfig) *DatadogProvider {
 		metadata: openfeature.Metadata{
 			Name: "Datadog Remote Config Provider",
 		},
-		exposureWriter:  writer,
-		exposureHook:    hook,
-		flagEvalMetrics: metrics,
+		exposureWriter: writer,
+		exposureHook:   hook,
+		flagEvalHook:   newFlagEvalHook(metrics),
 	}
 	p.configChange.L = &p.mu
 	return p
@@ -216,8 +215,8 @@ func (p *DatadogProvider) ShutdownWithContext(ctx context.Context) error {
 			p.exposureWriter.stop()
 		}
 		// Shut down flag evaluation metrics
-		if p.flagEvalMetrics != nil {
-			_ = p.flagEvalMetrics.shutdown(ctx)
+		if p.flagEvalHook != nil && p.flagEvalHook.metrics != nil {
+			_ = p.flagEvalHook.metrics.shutdown(ctx)
 		}
 		done <- err
 	}()
@@ -409,12 +408,16 @@ func (p *DatadogProvider) ObjectEvaluation(
 }
 
 // Hooks returns the hooks for this provider.
-// This includes the exposure tracking hook.
+// This includes the exposure tracking hook and the flag evaluation metrics hook.
 func (p *DatadogProvider) Hooks() []openfeature.Hook {
+	var hooks []openfeature.Hook
 	if p.exposureHook != nil {
-		return []openfeature.Hook{p.exposureHook}
+		hooks = append(hooks, p.exposureHook)
 	}
-	return []openfeature.Hook{}
+	if p.flagEvalHook != nil {
+		hooks = append(hooks, p.flagEvalHook)
+	}
+	return hooks
 }
 
 // evaluate is the core evaluation method that all type-specific methods use.
@@ -427,11 +430,6 @@ func (p *DatadogProvider) evaluate(
 	log.Debug("openfeature: evaluating flag %q", flagKey)
 	defer func() {
 		log.Debug("openfeature: evaluated flag %q: value=%v, reason=%s, error=%v", flagKey, res.Value, res.Reason, res.Error)
-		// Record flag evaluation metric
-		if p.flagEvalMetrics != nil {
-			p.flagEvalMetrics.record(ctx, flagKey, res.VariantKey,
-				strings.ToLower(string(res.Reason)), res.Error)
-		}
 	}()
 
 	// Check if context was cancelled before starting evaluation

--- a/openfeature/provider_test.go
+++ b/openfeature/provider_test.go
@@ -255,8 +255,8 @@ func TestNewDatadogProvider(t *testing.T) {
 	}
 
 	hooks := provider.Hooks()
-	if len(hooks) != 1 {
-		t.Errorf("expected 1 hook, got %d", len(hooks))
+	if len(hooks) != 2 {
+		t.Errorf("expected 2 hooks (exposure + flag eval metrics), got %d", len(hooks))
 	}
 }
 


### PR DESCRIPTION
## Motivation

Per the [RFC "Flag evaluations tracking for APM tracers"](https://docs.google.com/document/d/1yOdu6FU3Fw-PMhNlSfqawJ5r6f3tSGomjlJVwdtqpZc/edit?tab=t.0#heading=h.yx4xd78f94da) (Oleksii Shmalko, 2026-01-20): we want to collect a metric for flag evaluations to track usage of flags. This data powers the FFE product's change tracking ("which services evaluate this flag?") and usage analytics.

The RFC evaluated 6 alternatives (tracer-side aggregation via EVP, custom agent aggregation, Metrics Platform, reuse agent pipeline with custom intake, OTel Events) and recommends the **Metrics Platform** approach: implement flag evaluations tracking as regular custom metrics sent via the OpenTelemetry Metrics API. Tracers aggregate metrics via OTel, send aggregated metrics to the agent via OTLP, and the agent sends metrics to Metrics Platform. This approach has the lowest SDK team effort, requires no backend changes, requires no agent changes, and has good performance.

Key RFC constraints:
- **No high-cardinality attributes** (targeting key, evaluation context) — each unique attribute combination creates a custom metric, increasing load and cost
- **Independent from exposure events** — exposures are per-subject deduplication events already implemented; eval metrics are aggregate counts
- **Sampling is OK** — since pricing shifted from charging per-evaluation to charging per-configuration request, we don't need exact counts

## Changes

- **New `openfeature/flageval_metrics.go`**: Creates a dedicated `MeterProvider` via dd-trace-go's OTel metrics support (`ddmetric.NewMeterProvider()`). Defines an `Int64Counter` instrument (`feature_flag.evaluations`, delta temporality, 10s export interval). Provides `record()` to emit metric with attributes: `feature_flag.key`, `feature_flag.result.variant`, `feature_flag.result.reason`, and `error.type` (on error). Error classification uses a declarative `errorTypeTags` map from sentinel errors to low-cardinality strings.
- **Modified `openfeature/provider.go`**: Added `flagEvalMetrics` field to `DatadogProvider`. Wired into `newDatadogProvider()` (creates metrics on init), `evaluate()` (records metric via defer after every evaluation, reason lowercased directly from OpenFeature constants), and `ShutdownWithContext()` (graceful meter provider shutdown).
- **New `openfeature/flageval_metrics_test.go`**: Table-driven unit tests using OTel SDK `ManualReader` for in-memory metric collection. Covers success/error/default/disabled attributes, multiple evaluations aggregation, different flag series, all error types, and integration with `evaluate()`.

## Decisions

- **OTel Metrics (Metrics Platform path)**: Per RFC recommendation. Lowest SDK effort, no agent/backend changes needed, no custom aggregation code — the OTel SDK handles it all.
- **Dedicated MeterProvider**: Self-contained; works without requiring the user to set up OTel separately. Returns noop if `DD_METRICS_OTEL_ENABLED` is not `true` — zero overhead when disabled.
- **10s export interval**: Matches the flush cadence of EVP track implementations (iOS/Unity) for responsive tracking data.
- **Low-cardinality attributes only**: `feature_flag.key`, `feature_flag.result.variant`, `feature_flag.result.reason`, `error.type`. High-cardinality attributes (targeting_key, context, allocation) explicitly excluded per RFC to avoid blowing up custom metric cardinality. `feature_flag.provider.name` also excluded — always "Datadog", adds no value.

## Enabling OTLP in production / dogfooding

The following is needed on the deployment side to receive these metrics:

1. **On the app**: Set `DD_METRICS_OTEL_ENABLED=true` and `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://<agent-host>:4318/v1/metrics`
2. **On the Datadog Agent**: Enable the OTLP HTTP receiver. The env var `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT` doesn't properly nest the config — you need to mount a `datadog.yaml` with the nested YAML structure:
   ```yaml
   otlp_config:
     receiver:
       protocols:
         http:
           endpoint: 0.0.0.0:4318
   ```
3. **On macOS Docker Desktop**: The agent container needs `pid: host` to avoid "failed to register process metrics: process does not exist" which crashes the OTLP pipeline.

Dogfooding branch: https://github.com/DataDog/ffe-dogfooding/tree/leo.romanovsky/flageval-metrics-dogfooding

### Dogfooding evidence

Metric `feature_flag.evaluations` confirmed registered in Datadog (Eppo org, datadoghq.com) with the Go dogfooding app running `dd-trace-go v2.7.0-dev.1`:

```
$ docker logs app-go 2>&1 | head -2
Datadog Tracer v2.7.0-dev.1 INFO: DATADOG TRACER CONFIGURATION ...
Go server starting on port 8081

$ curl -s -X POST http://localhost:8081/evaluate -H "Content-Type: application/json" \
  -d '{"flag":{"key":"dogfood-test-flag","type":"string","defaultVariant":"off"},"subject":{"id":"user-1","attributes":{}}}'
{"timestamp":1772488246999,"allocation":{"key":"default-allocation"},"flag":{"key":"dogfood-test-flag"},"variant":{"key":"off"},...}
```

Metric metadata confirmed in Datadog:
```
feature_flag.evaluations — origin_product: Other, registered with no upload errors
```

## Local test evidence

<img width="1509" height="666" alt="Screenshot 2026-03-02 at 5 01 46 PM" src="https://github.com/user-attachments/assets/a69946a5-9c86-4a88-b06a-2abe1ed1ff3c" />

### Unit tests (all pass)
```
--- PASS: TestRecord/success_with_targeting_match (0.00s)
--- PASS: TestRecord/error_flag_not_found (0.00s)
--- PASS: TestRecord/default_reason (0.00s)
--- PASS: TestRecord/disabled_flag (0.00s)
--- PASS: TestRecordMultipleEvaluations (0.00s)
--- PASS: TestRecordDifferentFlags (0.00s)
--- PASS: TestRecordAllErrorTypes (0.00s)
--- PASS: TestShutdownClean (0.00s)
--- PASS: TestIntegrationEvaluate/targeting_match_records_metric (0.00s)
--- PASS: TestIntegrationEvaluate/non-existent_flag_records_error_metric (0.00s)
--- PASS: TestIntegrationEvaluate/no_configuration_records_error_metric (0.00s)
ok  	github.com/DataDog/dd-trace-go/v2/openfeature	0.651s
```

### System tests (all 17 FFE tests pass — 0 regressions)
```
Scenario: FEATURE_FLAGGING_AND_EXPERIMENTATION
Library: golang@2.7.0-dev.1

tests/ffe/test_dynamic_evaluation.py ..                                  [ 11%]
tests/ffe/test_exposures.py ...........                                  [ 76%]
tests/ffe/test_flag_eval_metrics.py ....                                 [100%]

=============== 17 passed, 2224 deselected in 228.93s (0:03:48) ================
```

## Companion PRs

- **system-tests**: https://github.com/DataDog/system-tests/pull/6410 (E2E tests)
- **ffe-dogfooding**: https://github.com/DataDog/ffe-dogfooding/tree/leo.romanovsky/flageval-metrics-dogfooding (dogfooding setup)