### PR TITLE
ci: use coverage-upload-github-action for Datadog coverage uploads

### DIFF
--- a/.github/workflows/multios-unit-tests.yml
+++ b/.github/workflows/multios-unit-tests.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Upload Coverage to Datadog
         if: always()
         continue-on-error: true
-        uses: DataDog/coverage-upload-github-action@v1
+        uses: DataDog/coverage-upload-github-action@9bbbf86d16f7db1b14c5b885e61cf0d96053686a
         with:
           api_key: ${{ secrets.DD_CI_API_KEY }}
           files: coverage.txt

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -260,7 +260,7 @@ jobs:
       - name: Upload Coverage to Datadog
         if: always()
         continue-on-error: true
-        uses: DataDog/coverage-upload-github-action@v1
+        uses: DataDog/coverage-upload-github-action@9bbbf86d16f7db1b14c5b885e61cf0d96053686a
         with:
           api_key: ${{ secrets.DD_CI_API_KEY }}
           files: coverage.txt
@@ -433,7 +433,7 @@ jobs:
       - name: Upload Coverage to Datadog
         if: always()
         continue-on-error: true
-        uses: DataDog/coverage-upload-github-action@v1
+        uses: DataDog/coverage-upload-github-action@9bbbf86d16f7db1b14c5b885e61cf0d96053686a
         with:
           api_key: ${{ secrets.DD_CI_API_KEY }}
           files: coverage.txt


### PR DESCRIPTION
## Summary

Follow-up to #4498. Replaces the inline `datadog-ci coverage upload` shell commands with the official [`DataDog/coverage-upload-github-action@v1`](https://github.com/DataDog/coverage-upload-github-action) action.

The action handles installing and running `datadog-ci` automatically, so we no longer depend on the binary being present from the `dd-ci-upload` step.

### Changes
- `unit-integration-tests.yml`: replaced 2 inline shell steps (contrib + core) with the action
- `multios-unit-tests.yml`: replaced 1 inline shell step with the action

No functional change — same coverage data is uploaded to Datadog.

## Test plan
- [ ] Verify `Upload Coverage to Datadog` steps run successfully in CI
- [ ] Confirm coverage data still appears in the Datadog Code Coverage UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)