### PR TITLE
test(appsec): add coverage for BlockingSecurityEvent helpers

### DIFF
--- a/appsec/events/block_test.go
+++ b/appsec/events/block_test.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022 Datadog, Inc.
+
+package events
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestBlockingSecurityEventError(t *testing.T) {
+	err := (&BlockingSecurityEvent{}).Error()
+	if err != "request blocked by WAF" {
+		t.Fatalf("unexpected error message: %q", err)
+	}
+}
+
+func TestIsSecurityError(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		if IsSecurityError(nil) {
+			t.Fatal("expected nil error to not be a security error")
+		}
+	})
+
+	t.Run("security error", func(t *testing.T) {
+		err := &BlockingSecurityEvent{}
+		if !IsSecurityError(err) {
+			t.Fatal("expected BlockingSecurityEvent to be detected as security error")
+		}
+	})
+
+	t.Run("wrapped security error", func(t *testing.T) {
+		err := errors.New("outer")
+		wrapped := errors.Join(err, &BlockingSecurityEvent{})
+		if !IsSecurityError(wrapped) {
+			t.Fatal("expected wrapped BlockingSecurityEvent to be detected as security error")
+		}
+	})
+
+	t.Run("non security error", func(t *testing.T) {
+		err := errors.New("not security")
+		if IsSecurityError(err) {
+			t.Fatal("expected non-security error to not be detected as security error")
+		}
+	})
+}


### PR DESCRIPTION
### Motivation
- Provide unit test coverage for the security error helpers to exercise branches in `IsSecurityError` and the `BlockingSecurityEvent.Error()` message.

### Description
- Add `appsec/events/block_test.go` with a test for `BlockingSecurityEvent.Error()` validating the returned string.
- Add `TestIsSecurityError` with subtests covering `nil`, a direct `BlockingSecurityEvent`, a wrapped `BlockingSecurityEvent` using `errors.Join`, and a non-security `error` case.

### Testing
- Run `go test ./appsec/events` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aaa37892c08328a2a797305828b700)