### PR TITLE
fix: trim undesired process tags

### DIFF
--- a/internal/processtags/processtags.go
+++ b/internal/processtags/processtags.go
@@ -117,6 +117,16 @@ func Reload() {
 	}
 }
 
+// isValidTagValue returns false for values that are not meaningful as process tags.
+// This filters out empty strings, filesystem roots, and the "bin" directory.
+func isValidTagValue(value string) bool {
+	switch value {
+	case "", "/", "\\", "bin":
+		return false
+	}
+	return true
+}
+
 func collect() map[string]string {
 	tags := make(map[string]string)
 	execPath, err := os.Executable()
@@ -125,14 +135,19 @@ func collect() map[string]string {
 	} else {
 		baseDirName := filepath.Base(filepath.Dir(execPath))
 		tags[tagEntrypointName] = filepath.Base(execPath)
-		tags[tagEntrypointBasedir] = baseDirName
+		if isValidTagValue(baseDirName) {
+			tags[tagEntrypointBasedir] = baseDirName
+		}
 		tags[tagEntrypointType] = entrypointTypeExecutable
 	}
 	wd, err := os.Getwd()
 	if err != nil {
 		log.Debug("failed to get working directory: %s", err.Error())
 	} else {
-		tags[tagEntrypointWorkdir] = filepath.Base(wd)
+		workdir := filepath.Base(wd)
+		if isValidTagValue(workdir) {
+			tags[tagEntrypointWorkdir] = workdir
+		}
 	}
 	return tags
 }

--- a/internal/processtags/processtags_test.go
+++ b/internal/processtags/processtags_test.go
@@ -35,3 +35,27 @@ func TestProcessTags(t *testing.T) {
 		assert.Empty(t, p.Slice())
 	})
 }
+
+func TestIsValidTagValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "empty string", value: "", want: false},
+		{name: "forward slash", value: "/", want: false},
+		{name: "backslash", value: "\\", want: false},
+		{name: "bin", value: "bin", want: false},
+		{name: "dot", value: ".", want: true},
+		{name: "valid app name", value: "myapp", want: true},
+		{name: "valid usr", value: "usr", want: true},
+		{name: "valid workspace", value: "workspace", want: true},
+		{name: "valid hyphenated name", value: "my-service", want: true},
+		{name: "valid dotted name", value: "app.test", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isValidTagValue(tt.value))
+		})
+	}
+}


### PR DESCRIPTION
This PR removes dir process tags that are unused/trimmed from other tracers, see these other implementation
-  [python implem](https://github.com/DataDog/dd-trace-py/blob/71a034dbd245cdfd21199df754d5abaca0dec411/ddtrace/internal/process_tags/__init__.py#L52-L60) 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
