### PR TITLE
feat: support service source for 19 integrations

### DIFF
--- a/contrib/bradfitz/gomemcache/memcache/memcache.go
+++ b/contrib/bradfitz/gomemcache/memcache/memcache.go
@@ -74,7 +74,7 @@ func (c *Client) WithContext(ctx context.Context) *Client {
 func (c *Client) startSpan(resourceName string) *tracer.Span {
 	opts := []tracer.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeMemcached),
-		tracer.ServiceName(c.cfg.serviceName),
+		instrumentation.ServiceNameWithSource(c.cfg.serviceName, c.cfg.serviceSource),
 		tracer.ResourceName(resourceName),
 		tracer.Tag(ext.Component, componentName),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),

--- a/contrib/bradfitz/gomemcache/memcache/option.go
+++ b/contrib/bradfitz/gomemcache/memcache/option.go
@@ -13,6 +13,7 @@ import (
 
 type clientConfig struct {
 	serviceName   string
+	serviceSource string
 	operationName string
 	analyticsRate float64
 }
@@ -31,6 +32,7 @@ func (fn ClientOptionFn) apply(cfg *clientConfig) {
 
 func defaults(cfg *clientConfig) {
 	cfg.serviceName = instr.ServiceName(instrumentation.ComponentDefault, nil)
+	cfg.serviceSource = string(instrumentation.PackageBradfitzGoMemcache)
 	cfg.operationName = instr.OperationName(instrumentation.ComponentDefault, nil)
 	cfg.analyticsRate = instr.AnalyticsRate(false)
 }
@@ -39,6 +41,7 @@ func defaults(cfg *clientConfig) {
 func WithService(name string) ClientOptionFn {
 	return func(cfg *clientConfig) {
 		cfg.serviceName = name
+		cfg.serviceSource = instrumentation.ServiceSourceWithServiceOption
 	}
 }
 

--- a/contrib/elastic/go-elasticsearch.v6/elastictrace.go
+++ b/contrib/elastic/go-elasticsearch.v6/elastictrace.go
@@ -59,7 +59,7 @@ func (t *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	method := req.Method
 	resource := t.config.resourceNamer(url, method)
 	opts := []tracer.StartSpanOption{
-		tracer.ServiceName(t.config.serviceName),
+		instrumentation.ServiceNameWithSource(t.config.serviceName, t.config.serviceSource),
 		tracer.SpanType(ext.SpanTypeElasticSearch),
 		tracer.ResourceName(resource),
 		tracer.Tag("elasticsearch.method", method),

--- a/contrib/elastic/go-elasticsearch.v6/option.go
+++ b/contrib/elastic/go-elasticsearch.v6/option.go
@@ -14,6 +14,7 @@ import (
 
 type clientConfig struct {
 	serviceName   string
+	serviceSource string
 	operationName string
 	transport     http.RoundTripper
 	analyticsRate float64
@@ -34,6 +35,7 @@ func (fn ClientOptionFn) apply(cfg *clientConfig) {
 
 func defaults(cfg *clientConfig) {
 	cfg.serviceName = instr.ServiceName(instrumentation.ComponentDefault, nil)
+	cfg.serviceSource = string(instrumentation.PackageGoElasticSearchV6)
 	cfg.operationName = instr.OperationName(instrumentation.ComponentDefault, nil)
 	cfg.transport = http.DefaultTransport
 	cfg.resourceNamer = quantize
@@ -51,6 +53,7 @@ func WithTransport(t http.RoundTripper) ClientOptionFn {
 func WithService(name string) ClientOptionFn {
 	return func(cfg *clientConfig) {
 		cfg.serviceName = name
+		cfg.serviceSource = instrumentation.ServiceSourceWithServiceOption
 	}
 }
 

--- a/contrib/emicklei/go-restful.v3/option.go
+++ b/contrib/emicklei/go-restful.v3/option.go
@@ -13,6 +13,7 @@ import (
 
 type config struct {
 	serviceName   string
+	serviceSource string
 	analyticsRate float64
 	headerTags    instrumentation.HeaderTags
 }
@@ -20,6 +21,7 @@ type config struct {
 func newConfig() *config {
 	return &config{
 		serviceName:   instr.ServiceName(instrumentation.ComponentServer, nil),
+		serviceSource: string(instrumentation.PackageEmickleiGoRestfulV3),
 		analyticsRate: instr.AnalyticsRate(true),
 		headerTags:    instr.HTTPHeadersAsTags(),
 	}
@@ -41,6 +43,7 @@ func (fn OptionFn) apply(cfg *config) {
 func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
+		cfg.serviceSource = instrumentation.ServiceSourceWithServiceOption
 	}
 }
 

--- a/contrib/emicklei/go-restful.v3/restful.go
+++ b/contrib/emicklei/go-restful.v3/restful.go
@@ -32,7 +32,7 @@ func FilterFunc(configOpts ...Option) restful.FilterFunction {
 		opt.apply(cfg)
 	}
 	instr.Logger().Debug("contrib/emicklei/go-restful/v3: Creating tracing filter: %#v", cfg)
-	spanOpts := []tracer.StartSpanOption{tracer.ServiceName(cfg.serviceName)}
+	spanOpts := []tracer.StartSpanOption{instrumentation.ServiceNameWithSource(cfg.serviceName, cfg.serviceSource)}
 	return func(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
 		spanOpts := append(
 			spanOpts,

--- a/contrib/go-chi/chi.v5/chi.go
+++ b/contrib/go-chi/chi.v5/chi.go
@@ -37,7 +37,7 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 		fn.apply(cfg)
 	}
 	instr.Logger().Debug("contrib/go-chi/chi.v5: Configuring Middleware: %#v", cfg)
-	spanOpts := append(cfg.spanOpts, tracer.ServiceName(cfg.serviceName),
+	spanOpts := append(cfg.spanOpts, instrumentation.ServiceNameWithSource(cfg.serviceName, cfg.serviceSource),
 		tracer.Tag(ext.Component, componentName),
 		tracer.Tag(ext.SpanKind, ext.SpanKindServer))
 	return func(next http.Handler) http.Handler {

--- a/contrib/go-chi/chi.v5/option.go
+++ b/contrib/go-chi/chi.v5/option.go
@@ -16,6 +16,7 @@ import (
 
 type config struct {
 	serviceName        string
+	serviceSource      string
 	spanOpts           []tracer.StartSpanOption // additional span options to be applied
 	analyticsRate      float64
 	isStatusError      func(statusCode int) bool
@@ -41,6 +42,7 @@ func (fn OptionFn) apply(cfg *config) {
 
 func defaults(cfg *config) {
 	cfg.serviceName = instr.ServiceName(instrumentation.ComponentServer, nil)
+	cfg.serviceSource = string(instrumentation.PackageChiV5)
 	cfg.analyticsRate = instr.AnalyticsRate(true)
 	cfg.headerTags = instr.HTTPHeadersAsTags()
 	cfg.ignoreRequest = func(_ *http.Request) bool { return false }
@@ -55,6 +57,7 @@ func defaults(cfg *config) {
 func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
+		cfg.serviceSource = instrumentation.ServiceSourceWithServiceOption
 	}
 }
 

--- a/contrib/go-chi/chi/chi.go
+++ b/contrib/go-chi/chi/chi.go
@@ -36,7 +36,7 @@ func Middleware(opts ...Option) func(next http.Handler) http.Handler {
 		fn.apply(cfg)
 	}
 	instr.Logger().Debug("contrib/go-chi/chi: Configuring Middleware: %#v", cfg)
-	spanOpts := append(cfg.spanOpts, tracer.ServiceName(cfg.serviceName),
+	spanOpts := append(cfg.spanOpts, instrumentation.ServiceNameWithSource(cfg.serviceName, cfg.serviceSource),
 		tracer.Tag(ext.Component, componentName),
 		tracer.Tag(ext.SpanKind, ext.SpanKindServer))
 	return func(next http.Handler) http.Handler {

--- a/contrib/go-chi/chi/option.go
+++ b/contrib/go-chi/chi/option.go
@@ -17,6 +17,7 @@ import (
 
 type config struct {
 	serviceName   string
+	serviceSource string
 	spanOpts      []tracer.StartSpanOption // additional span options to be applied
 	analyticsRate float64
 	isStatusError func(statusCode int) bool
@@ -39,6 +40,7 @@ func (fn OptionFn) apply(cfg *config) {
 
 func defaults(cfg *config) {
 	cfg.serviceName = instr.ServiceName(instrumentation.ComponentServer, nil)
+	cfg.serviceSource = string(instrumentation.PackageChi)
 	cfg.analyticsRate = instr.AnalyticsRate(true)
 	cfg.headerTags = instr.HTTPHeadersAsTags()
 	cfg.ignoreRequest = func(_ *http.Request) bool { return false }
@@ -56,6 +58,7 @@ func defaults(cfg *config) {
 func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
+		cfg.serviceSource = instrumentation.ServiceSourceWithServiceOption
 	}
 }
 

--- a/contrib/go-redis/redis.v7/option.go
+++ b/contrib/go-redis/redis.v7/option.go
@@ -14,6 +14,7 @@ import (
 
 type clientConfig struct {
 	serviceName   string
+	serviceSource string
 	spanName      string
 	analyticsRate float64
 	skipRaw       bool
@@ -34,6 +35,7 @@ func (fn ClientOptionFn) apply(cfg *clientConfig) {
 
 func defaults(cfg *clientConfig) {
 	cfg.serviceName = instr.ServiceName(instrumentation.ComponentDefault, nil)
+	cfg.serviceSource = string(instrumentation.PackageGoRedisV7)
 	cfg.spanName = instr.OperationName(instrumentation.ComponentDefault, nil)
 	cfg.analyticsRate = instr.AnalyticsRate(false)
 	cfg.skipRaw = !options.GetBoolEnv("DD_TRACE_REDIS_RAW_COMMAND", true)
@@ -53,6 +55,7 @@ func WithSkipRawCommand(skip bool) ClientOptionFn {
 func WithService(name string) ClientOptionFn {
 	return func(cfg *clientConfig) {
 		cfg.serviceName = name
+		cfg.serviceSource = instrumentation.ServiceSourceWithServiceOption
 	}
 }
 

--- a/contrib/go-redis/redis.v7/redis.go
+++ b/contrib/go-redis/redis.v7/redis.go
@@ -114,7 +114,7 @@ func (ddh *datadogHook) BeforeProcess(ctx context.Context, cmd redis.Cmder) (con
 	p := ddh.params
 	opts := []tracer.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeRedis),
-		tracer.ServiceName(p.config.serviceName),
+		instrumentation.ServiceNameWithSource(p.config.serviceName, p.config.serviceSource),
 		tracer.ResourceName(parts[0]),
 		tracer.Tag("redis.args_length", strconv.Itoa(length)),
 		tracer.Tag(ext.Component, componentName),
@@ -151,7 +151,7 @@ func (ddh *datadogHook) BeforeProcessPipeline(ctx context.Context, cmds []redis.
 	p := ddh.params
 	opts := []tracer.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeRedis),
-		tracer.ServiceName(p.config.serviceName),
+		instrumentation.ServiceNameWithSource(p.config.serviceName, p.config.serviceSource),
 		tracer.ResourceName(parts[0]),
 		tracer.Tag("redis.args_length", strconv.Itoa(length)),
 		tracer.Tag(ext.ResourceName, raw),

--- a/contrib/go-redis/redis.v8/option.go
+++ b/contrib/go-redis/redis.v8/option.go
@@ -16,6 +16,7 @@ const defaultServiceName = "redis.client"
 
 type clientConfig struct {
 	serviceName   string
+	serviceSource string
 	spanName      string
 	analyticsRate float64
 	skipRaw       bool
@@ -36,6 +37,7 @@ func (fn ClientOptionFn) apply(cfg *clientConfig) {
 
 func defaults(cfg *clientConfig) {
 	cfg.serviceName = instr.ServiceName(instrumentation.ComponentDefault, nil)
+	cfg.serviceSource = string(instrumentation.PackageGoRedisV8)
 	cfg.spanName = instr.OperationName(instrumentation.ComponentDefault, nil)
 	cfg.analyticsRate = instr.AnalyticsRate(false)
 	cfg.skipRaw = !options.GetBoolEnv("DD_TRACE_REDIS_RAW_COMMAND", true)
@@ -55,6 +57,7 @@ func WithSkipRawCommand(skip bool) ClientOptionFn {
 func WithService(name string) ClientOptionFn {
 	return func(cfg *clientConfig) {
 		cfg.serviceName = name
+		cfg.serviceSource = instrumentation.ServiceSourceWithServiceOption
 	}
 }
 

--- a/contrib/go-redis/redis.v8/redis.go
+++ b/contrib/go-redis/redis.v8/redis.go
@@ -114,7 +114,7 @@ func (ddh *datadogHook) BeforeProcess(ctx context.Context, cmd redis.Cmder) (con
 	opts := make([]tracer.StartSpanOption, 0, 4+1+len(ddh.additionalTags)+1) // 4 options below + redis.raw_command + ddh.additionalTags + analyticsRate
 	opts = append(opts,
 		tracer.SpanType(ext.SpanTypeRedis),
-		tracer.ServiceName(p.config.serviceName),
+		instrumentation.ServiceNameWithSource(p.config.serviceName, p.config.serviceSource),
 		tracer.ResourceName(first),
 		tracer.Tag("redis.args_length", strconv.Itoa(length)),
 		tracer.Tag(ext.Component, componentName),
@@ -152,7 +152,7 @@ func (ddh *datadogHook) BeforeProcessPipeline(ctx context.Context, cmds []redis.
 	opts := make([]tracer.StartSpanOption, 0, 5+1+len(ddh.additionalTags)+1) // 5 options below + redis.raw_command + ddh.additionalTags + analyticsRate
 	opts = append(opts,
 		tracer.SpanType(ext.SpanTypeRedis),
-		tracer.ServiceName(p.config.serviceName),
+		instrumentation.ServiceNameWithSource(p.config.serviceName, p.config.serviceSource),
 		tracer.ResourceName(first),
 		tracer.Tag("redis.args_length", strconv.Itoa(length)),
 		tracer.Tag("redis.pipeline_length", strconv.Itoa(len(cmds))),

--- a/contrib/go-redis/redis/option.go
+++ b/contrib/go-redis/redis/option.go
@@ -13,6 +13,7 @@ import (
 
 type clientConfig struct {
 	serviceName   string
+	serviceSource string
 	spanName      string
 	analyticsRate float64
 }
@@ -31,6 +32,7 @@ func (fn ClientOptionFn) apply(cfg *clientConfig) {
 
 func defaults(cfg *clientConfig) {
 	cfg.serviceName = instr.ServiceName(instrumentation.ComponentDefault, nil)
+	cfg.serviceSource = string(instrumentation.PackageGoRedis)
 	cfg.spanName = instr.OperationName(instrumentation.ComponentDefault, nil)
 	cfg.analyticsRate = instr.AnalyticsRate(false)
 }
@@ -39,6 +41,7 @@ func defaults(cfg *clientConfig) {
 func WithService(name string) ClientOptionFn {
 	return func(cfg *clientConfig) {
 		cfg.serviceName = name
+		cfg.serviceSource = instrumentation.ServiceSourceWithServiceOption
 	}
 }
 

--- a/contrib/go-redis/redis/redis.go
+++ b/contrib/go-redis/redis/redis.go
@@ -125,7 +125,7 @@ func (c *Pipeliner) execWithContext(ctx context.Context) ([]redis.Cmder, error) 
 	p := c.params
 	opts := []tracer.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeRedis),
-		tracer.ServiceName(p.config.serviceName),
+		instrumentation.ServiceNameWithSource(p.config.serviceName, p.config.serviceSource),
 		tracer.ResourceName("redis"),
 		tracer.Tag(ext.TargetHost, p.host),
 		tracer.Tag(ext.TargetPort, p.port),
@@ -197,7 +197,7 @@ func createWrapperFromClient(tc *Client) func(oldProcess func(cmd redis.Cmder) e
 			p := tc.params
 			opts := []tracer.StartSpanOption{
 				tracer.SpanType(ext.SpanTypeRedis),
-				tracer.ServiceName(p.config.serviceName),
+				instrumentation.ServiceNameWithSource(p.config.serviceName, p.config.serviceSource),
 				tracer.ResourceName(parts[0]),
 				tracer.Tag(ext.TargetHost, p.host),
 				tracer.Tag(ext.TargetPort, p.port),

--- a/contrib/go.mongodb.org/mongo-driver.v2/mongo/mongo.go
+++ b/contrib/go.mongodb.org/mongo-driver.v2/mongo/mongo.go
@@ -43,7 +43,7 @@ func (m *monitor) Started(ctx context.Context, evt *event.CommandStartedEvent) {
 	hostname, port := peerInfo(evt)
 	opts := []tracer.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeMongoDB),
-		tracer.ServiceName(m.cfg.serviceName),
+		instrumentation.ServiceNameWithSource(m.cfg.serviceName, m.cfg.serviceSource),
 		tracer.ResourceName("mongo." + evt.CommandName),
 		tracer.Tag(ext.DBInstance, evt.DatabaseName),
 		tracer.Tag(ext.DBType, "mongo"),

--- a/contrib/go.mongodb.org/mongo-driver.v2/mongo/option.go
+++ b/contrib/go.mongodb.org/mongo-driver.v2/mongo/option.go
@@ -10,9 +10,10 @@ import (
 )
 
 type config struct {
-	serviceName  string
-	spanName     string
-	maxQuerySize int
+	serviceName   string
+	serviceSource string
+	spanName      string
+	maxQuerySize  int
 }
 
 // Option describes options for the Mongo integration.
@@ -29,6 +30,7 @@ func (fn OptionFn) apply(cfg *config) {
 
 func defaults(cfg *config) {
 	cfg.serviceName = instr.ServiceName(instrumentation.ComponentDefault, nil)
+	cfg.serviceSource = string(instrumentation.PackageMongoDriverV2)
 	cfg.spanName = instr.OperationName(instrumentation.ComponentDefault, nil)
 	cfg.maxQuerySize = -1
 }
@@ -37,6 +39,7 @@ func defaults(cfg *config) {
 func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
+		cfg.serviceSource = instrumentation.ServiceSourceWithServiceOption
 	}
 }
 

--- a/contrib/go.mongodb.org/mongo-driver/mongo/mongo.go
+++ b/contrib/go.mongodb.org/mongo-driver/mongo/mongo.go
@@ -47,7 +47,7 @@ func (m *monitor) Started(ctx context.Context, evt *event.CommandStartedEvent) {
 	hostname, port := peerInfo(evt)
 	opts := []tracer.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeMongoDB),
-		tracer.ServiceName(m.cfg.serviceName),
+		instrumentation.ServiceNameWithSource(m.cfg.serviceName, m.cfg.serviceSource),
 		tracer.ResourceName("mongo." + evt.CommandName),
 		tracer.Tag(ext.DBInstance, evt.DatabaseName),
 		tracer.Tag(ext.DBType, "mongo"),

--- a/contrib/go.mongodb.org/mongo-driver/mongo/option.go
+++ b/contrib/go.mongodb.org/mongo-driver/mongo/option.go
@@ -13,6 +13,7 @@ import (
 
 type config struct {
 	serviceName   string
+	serviceSource string
 	spanName      string
 	analyticsRate float64
 	maxQuerySize  int
@@ -32,6 +33,7 @@ func (fn OptionFn) apply(cfg *config) {
 
 func defaults(cfg *config) {
 	cfg.serviceName = instr.ServiceName(instrumentation.ComponentDefault, nil)
+	cfg.serviceSource = string(instrumentation.PackageMongoDriver)
 	cfg.spanName = instr.OperationName(instrumentation.ComponentDefault, nil)
 	cfg.analyticsRate = instr.AnalyticsRate(false)
 	cfg.maxQuerySize = -1
@@ -41,6 +43,7 @@ func defaults(cfg *config) {
 func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
+		cfg.serviceSource = instrumentation.ServiceSourceWithServiceOption
 	}
 }
 

--- a/contrib/gocql/gocql/gocql.go
+++ b/contrib/gocql/gocql/gocql.go
@@ -395,7 +395,7 @@ func commonStartSpanOptions(p params) []tracer.StartSpanOption {
 	cfg := p.config
 	opts := []tracer.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeCassandra),
-		tracer.ServiceName(cfg.serviceName),
+		instrumentation.ServiceNameWithSource(cfg.serviceName, cfg.serviceSource),
 		tracer.Tag(ext.Component, instrumentation.PackageGoCQL),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
 		tracer.Tag(ext.DBSystem, ext.DBSystemCassandra),

--- a/contrib/gocql/gocql/option.go
+++ b/contrib/gocql/gocql/option.go
@@ -16,6 +16,7 @@ import (
 
 type config struct {
 	serviceName, resourceName            string
+	serviceSource                        string
 	querySpanName, batchSpanName         string
 	noDebugStack                         bool
 	analyticsRate                        float64
@@ -44,6 +45,7 @@ func defaultConfig() *config {
 		traceConnect: true,
 	}
 	cfg.serviceName = instr.ServiceName(instrumentation.ComponentDefault, nil)
+	cfg.serviceSource = string(instrumentation.PackageGoCQL)
 	cfg.querySpanName = instr.OperationName(instrumentation.ComponentDefault, nil)
 	cfg.batchSpanName = instr.OperationName(instrumentation.ComponentDefault, instrumentation.OperationContext{
 		"operationType": "batch",
@@ -64,6 +66,7 @@ func defaultConfig() *config {
 func WithService(name string) WrapOptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
+		cfg.serviceSource = instrumentation.ServiceSourceWithServiceOption
 	}
 }
 

--- a/contrib/gofiber/fiber.v2/fiber.go
+++ b/contrib/gofiber/fiber.v2/fiber.go
@@ -42,7 +42,7 @@ func Middleware(opts ...Option) func(c *fiber.Ctx) error {
 
 		opts := []tracer.StartSpanOption{
 			tracer.SpanType(ext.SpanTypeWeb),
-			tracer.ServiceName(cfg.serviceName),
+			instrumentation.ServiceNameWithSource(cfg.serviceName, cfg.serviceSource),
 			tracer.Tag(ext.HTTPMethod, c.Method()),
 			tracer.Tag(ext.HTTPURL, string(c.Request().URI().PathOriginal())),
 			tracer.Measured(),

--- a/contrib/gofiber/fiber.v2/option.go
+++ b/contrib/gofiber/fiber.v2/option.go
@@ -16,6 +16,7 @@ import (
 
 type config struct {
 	serviceName   string
+	serviceSource string
 	spanName      string
 	isStatusError func(statusCode int) bool
 	spanOpts      []tracer.StartSpanOption // additional span options to be applied
@@ -38,6 +39,7 @@ func (fn OptionFn) apply(cfg *config) {
 
 func defaults(cfg *config) {
 	cfg.serviceName = instr.ServiceName(instrumentation.ComponentServer, nil)
+	cfg.serviceSource = string(instrumentation.PackageGoFiberV2)
 	cfg.analyticsRate = instr.AnalyticsRate(true)
 	cfg.spanName = instr.OperationName(instrumentation.ComponentServer, nil)
 	cfg.isStatusError = isServerError
@@ -49,6 +51,7 @@ func defaults(cfg *config) {
 func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
+		cfg.serviceSource = instrumentation.ServiceSourceWithServiceOption
 	}
 }
 

--- a/contrib/gomodule/redigo/option.go
+++ b/contrib/gomodule/redigo/option.go
@@ -14,6 +14,7 @@ import (
 
 type dialConfig struct {
 	serviceName    string
+	serviceSource  string
 	spanName       string
 	analyticsRate  float64
 	skipRaw        bool
@@ -40,6 +41,7 @@ func (fn DialOptionFn) apply(cfg *dialConfig) {
 
 func defaults(cfg *dialConfig) {
 	cfg.serviceName = instr.ServiceName(instrumentation.ComponentDefault, nil)
+	cfg.serviceSource = string(instrumentation.PackageRedigo)
 	cfg.spanName = instr.OperationName(instrumentation.ComponentDefault, nil)
 	cfg.analyticsRate = instr.AnalyticsRate(false)
 	cfg.skipRaw = !options.GetBoolEnv("DD_TRACE_REDIS_RAW_COMMAND", true)
@@ -61,6 +63,7 @@ func WithSkipRawCommand(skip bool) DialOptionFn {
 func WithService(name string) DialOptionFn {
 	return func(cfg *dialConfig) {
 		cfg.serviceName = name
+		cfg.serviceSource = instrumentation.ServiceSourceWithServiceOption
 	}
 }
 

--- a/contrib/gomodule/redigo/redigo.go
+++ b/contrib/gomodule/redigo/redigo.go
@@ -152,7 +152,7 @@ func DialURLContext(ctx context.Context, rawurl string, options ...interface{}) 
 func newChildSpan(ctx context.Context, p *params) *tracer.Span {
 	opts := []tracer.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeRedis),
-		tracer.ServiceName(p.config.serviceName),
+		instrumentation.ServiceNameWithSource(p.config.serviceName, p.config.serviceSource),
 		tracer.Tag(ext.Component, componentName),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
 		tracer.Tag(ext.DBSystem, ext.DBSystemRedis),

--- a/contrib/hashicorp/consul/consul.go
+++ b/contrib/hashicorp/consul/consul.go
@@ -72,7 +72,7 @@ func (c *Client) KV() *KV {
 func (k *KV) startSpan(resourceName string, key string) *tracer.Span {
 	opts := []tracer.StartSpanOption{
 		tracer.ResourceName(resourceName),
-		tracer.ServiceName(k.config.serviceName),
+		instrumentation.ServiceNameWithSource(k.config.serviceName, k.config.serviceSource),
 		tracer.SpanType(ext.SpanTypeConsul),
 		tracer.Tag("consul.key", key),
 		tracer.Tag(ext.Component, instrumentation.PackageHashicorpConsulAPI),

--- a/contrib/hashicorp/consul/option.go
+++ b/contrib/hashicorp/consul/option.go
@@ -20,6 +20,7 @@ const (
 
 type clientConfig struct {
 	serviceName   string
+	serviceSource string
 	spanName      string
 	analyticsRate float64
 	hostname      string
@@ -39,6 +40,7 @@ func (fn ClientOptionFn) apply(cfg *clientConfig) {
 
 func defaults(cfg *clientConfig) {
 	cfg.serviceName = instr.ServiceName(instrumentation.ComponentDefault, nil)
+	cfg.serviceSource = string(instrumentation.PackageHashicorpConsulAPI)
 	cfg.spanName = instr.OperationName(instrumentation.ComponentDefault, nil)
 	cfg.analyticsRate = instr.AnalyticsRate(false)
 }
@@ -47,6 +49,7 @@ func defaults(cfg *clientConfig) {
 func WithService(name string) ClientOptionFn {
 	return func(cfg *clientConfig) {
 		cfg.serviceName = name
+		cfg.serviceSource = instrumentation.ServiceSourceWithServiceOption
 	}
 }
 

--- a/contrib/labstack/echo.v4/echotrace.go
+++ b/contrib/labstack/echo.v4/echotrace.go
@@ -50,7 +50,7 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 	}
 	instr.Logger().Debug("contrib/labstack/echo.v4: Configuring Middleware: %#v", cfg)
 	spanOpts := make([]tracer.StartSpanOption, 0, 3+len(cfg.tags))
-	spanOpts = append(spanOpts, tracer.ServiceName(cfg.serviceName))
+	spanOpts = append(spanOpts, instrumentation.ServiceNameWithSource(cfg.serviceName, cfg.serviceSource))
 	for k, v := range cfg.tags {
 		spanOpts = append(spanOpts, tracer.Tag(k, v))
 	}

--- a/contrib/labstack/echo.v4/option.go
+++ b/contrib/labstack/echo.v4/option.go
@@ -21,6 +21,7 @@ const envServerErrorStatuses = "DD_TRACE_HTTP_SERVER_ERROR_STATUSES"
 
 type config struct {
 	serviceName       string
+	serviceSource     string
 	analyticsRate     float64
 	noDebugStack      bool
 	ignoreRequestFunc IgnoreRequestFunc
@@ -48,6 +49,7 @@ type IgnoreRequestFunc func(c echo.Context) bool
 
 func defaults(cfg *config) {
 	cfg.serviceName = instr.ServiceName(instrumentation.ComponentServer, nil)
+	cfg.serviceSource = string(instrumentation.PackageLabstackEchoV4)
 	cfg.analyticsRate = math.NaN()
 	if fn := httptrace.GetErrorCodesFromInput(env.Get(envServerErrorStatuses)); fn != nil {
 		cfg.isStatusError = fn
@@ -69,6 +71,7 @@ func defaults(cfg *config) {
 func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
+		cfg.serviceSource = instrumentation.ServiceSourceWithServiceOption
 	}
 }
 

--- a/contrib/olivere/elastic.v5/elastictrace.go
+++ b/contrib/olivere/elastic.v5/elastictrace.go
@@ -61,7 +61,7 @@ func (t *httpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	method := req.Method
 	resource := t.config.resourceNamer(url, method)
 	opts := []tracer.StartSpanOption{
-		tracer.ServiceName(t.config.serviceName),
+		instrumentation.ServiceNameWithSource(t.config.serviceName, t.config.serviceSource),
 		tracer.SpanType(ext.SpanTypeElasticSearch),
 		tracer.ResourceName(resource),
 		tracer.Tag("elasticsearch.method", method),

--- a/contrib/olivere/elastic.v5/option.go
+++ b/contrib/olivere/elastic.v5/option.go
@@ -14,6 +14,7 @@ import (
 
 type clientConfig struct {
 	serviceName   string
+	serviceSource string
 	spanName      string
 	transport     http.RoundTripper
 	analyticsRate float64
@@ -34,6 +35,7 @@ func (fn ClientOptionFn) apply(cfg *clientConfig) {
 
 func defaults(cfg *clientConfig) {
 	cfg.serviceName = instr.ServiceName(instrumentation.ComponentDefault, nil)
+	cfg.serviceSource = string(instrumentation.PackageOlivereElasticV5)
 	cfg.spanName = instr.OperationName(instrumentation.ComponentDefault, nil)
 	cfg.transport = http.DefaultTransport.(*http.Transport)
 	cfg.resourceNamer = quantize
@@ -44,6 +46,7 @@ func defaults(cfg *clientConfig) {
 func WithService(name string) ClientOptionFn {
 	return func(cfg *clientConfig) {
 		cfg.serviceName = name
+		cfg.serviceSource = instrumentation.ServiceSourceWithServiceOption
 	}
 }
 

--- a/contrib/syndtr/goleveldb/leveldb/leveldb.go
+++ b/contrib/syndtr/goleveldb/leveldb/leveldb.go
@@ -266,7 +266,7 @@ func (it *Iterator) Release() {
 func startSpan(cfg *config, name string) *tracer.Span {
 	opts := []tracer.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeLevelDB),
-		tracer.ServiceName(cfg.serviceName),
+		instrumentation.ServiceNameWithSource(cfg.serviceName, cfg.serviceSource),
 		tracer.ResourceName(name),
 		tracer.Tag(ext.Component, componentName),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),

--- a/contrib/syndtr/goleveldb/leveldb/option.go
+++ b/contrib/syndtr/goleveldb/leveldb/option.go
@@ -15,6 +15,7 @@ import (
 type config struct {
 	ctx           context.Context
 	serviceName   string
+	serviceSource string
 	spanName      string
 	analyticsRate float64
 }
@@ -22,6 +23,7 @@ type config struct {
 func newConfig(opts ...Option) *config {
 	cfg := &config{
 		serviceName:   instr.ServiceName(instrumentation.ComponentDefault, nil),
+		serviceSource: string(instrumentation.PackageSyndtrGoLevelDB),
 		spanName:      instr.OperationName(instrumentation.ComponentDefault, nil),
 		ctx:           context.Background(),
 		analyticsRate: instr.AnalyticsRate(false),
@@ -55,6 +57,7 @@ func WithContext(ctx context.Context) OptionFn {
 func WithService(serviceName string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = serviceName
+		cfg.serviceSource = instrumentation.ServiceSourceWithServiceOption
 	}
 }
 

--- a/contrib/tidwall/buntdb/buntdb.go
+++ b/contrib/tidwall/buntdb/buntdb.go
@@ -101,7 +101,7 @@ func WrapTx(tx *buntdb.Tx, opts ...Option) *Tx {
 func (tx *Tx) startSpan(name string) *tracer.Span {
 	opts := []tracer.StartSpanOption{
 		tracer.SpanType(ext.AppTypeDB),
-		tracer.ServiceName(tx.cfg.serviceName),
+		instrumentation.ServiceNameWithSource(tx.cfg.serviceName, tx.cfg.serviceSource),
 		tracer.ResourceName(name),
 		tracer.Tag(ext.Component, instrumentation.PackageTidwallBuntDB),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),

--- a/contrib/tidwall/buntdb/option.go
+++ b/contrib/tidwall/buntdb/option.go
@@ -15,12 +15,14 @@ import (
 type config struct {
 	ctx           context.Context
 	serviceName   string
+	serviceSource string
 	spanName      string
 	analyticsRate float64
 }
 
 func defaults(cfg *config) {
 	cfg.serviceName = instr.ServiceName(instrumentation.ComponentDefault, nil)
+	cfg.serviceSource = string(instrumentation.PackageTidwallBuntDB)
 	cfg.spanName = instr.OperationName(instrumentation.ComponentDefault, nil)
 	cfg.analyticsRate = instr.AnalyticsRate(false)
 	cfg.ctx = context.Background()
@@ -49,6 +51,7 @@ func WithContext(ctx context.Context) OptionFn {
 func WithService(serviceName string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = serviceName
+		cfg.serviceSource = instrumentation.ServiceSourceWithServiceOption
 	}
 }
 

--- a/contrib/urfave/negroni/negroni.go
+++ b/contrib/urfave/negroni/negroni.go
@@ -36,7 +36,7 @@ type DatadogMiddleware struct {
 func (m *DatadogMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	opts := options.Expand(m.cfg.spanOpts, 0, 4) // opts must be a copy of m.cfg.spanOpts, locally scoped, to avoid races.
 	opts = append(opts,
-		tracer.ServiceName(m.cfg.serviceName),
+		instrumentation.ServiceNameWithSource(m.cfg.serviceName, m.cfg.serviceSource),
 		tracer.ResourceName(m.cfg.resourceNamer(r)),
 		httptrace.HeaderTagsFromRequest(r, m.cfg.headerTags))
 	if !math.IsNaN(m.cfg.analyticsRate) {

--- a/contrib/urfave/negroni/option.go
+++ b/contrib/urfave/negroni/option.go
@@ -16,6 +16,7 @@ import (
 
 type config struct {
 	serviceName   string
+	serviceSource string
 	spanOpts      []tracer.StartSpanOption // additional span options to be applied
 	analyticsRate float64
 	isStatusError func(statusCode int) bool
@@ -37,6 +38,7 @@ func (fn OptionFn) apply(cfg *config) {
 
 func defaults(cfg *config) {
 	cfg.serviceName = instr.ServiceName(instrumentation.ComponentServer, nil)
+	cfg.serviceSource = string(instrumentation.PackageUrfaveNegroni)
 	cfg.analyticsRate = instr.AnalyticsRate(true)
 	cfg.headerTags = instr.HTTPHeadersAsTags()
 	cfg.isStatusError = isServerError
@@ -47,6 +49,7 @@ func defaults(cfg *config) {
 func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
+		cfg.serviceSource = instrumentation.ServiceSourceWithServiceOption
 	}
 }
 

--- a/instrumentation/internal/namingschematest/chi_v1_test.go
+++ b/instrumentation/internal/namingschematest/chi_v1_test.go
@@ -47,6 +47,10 @@ var chiV1Test = harness.TestCase{
 		DDService:       []string{harness.TestDDService},
 		ServiceOverride: []string{harness.TestServiceOverride},
 	},
+	WantServiceSource: harness.ServiceSourceAssertions{
+		Defaults:        []string{string(instrumentation.PackageChi)},
+		ServiceOverride: []string{instrumentation.ServiceSourceWithServiceOption},
+	},
 	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "http.request", spans[0].OperationName())

--- a/instrumentation/internal/namingschematest/chi_v5_test.go
+++ b/instrumentation/internal/namingschematest/chi_v5_test.go
@@ -47,6 +47,10 @@ var chiV5Test = harness.TestCase{
 		DDService:       []string{harness.TestDDService},
 		ServiceOverride: []string{harness.TestServiceOverride},
 	},
+	WantServiceSource: harness.ServiceSourceAssertions{
+		Defaults:        []string{string(instrumentation.PackageChiV5)},
+		ServiceOverride: []string{instrumentation.ServiceSourceWithServiceOption},
+	},
 	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "http.request", spans[0].OperationName())

--- a/instrumentation/internal/namingschematest/elastic_v6_test.go
+++ b/instrumentation/internal/namingschematest/elastic_v6_test.go
@@ -56,6 +56,10 @@ var elasticV6 = harness.TestCase{
 		DDService:       []string{"elastic.client"},
 		ServiceOverride: []string{harness.TestServiceOverride},
 	},
+	WantServiceSource: harness.ServiceSourceAssertions{
+		Defaults:        []string{string(instrumentation.PackageGoElasticSearchV6)},
+		ServiceOverride: []string{instrumentation.ServiceSourceWithServiceOption},
+	},
 	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "elasticsearch.query", spans[0].OperationName())

--- a/instrumentation/internal/namingschematest/fiber_v2_test.go
+++ b/instrumentation/internal/namingschematest/fiber_v2_test.go
@@ -47,6 +47,10 @@ var fiberV2Test = harness.TestCase{
 		DDService:       []string{harness.TestDDService},
 		ServiceOverride: []string{harness.TestServiceOverride},
 	},
+	WantServiceSource: harness.ServiceSourceAssertions{
+		Defaults:        []string{string(instrumentation.PackageGoFiberV2)},
+		ServiceOverride: []string{instrumentation.ServiceSourceWithServiceOption},
+	},
 	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "http.request", spans[0].OperationName())

--- a/instrumentation/internal/namingschematest/go_redis_v1_test.go
+++ b/instrumentation/internal/namingschematest/go_redis_v1_test.go
@@ -40,6 +40,10 @@ var goRedisV1Test = harness.TestCase{
 		DDService:       []string{"redis.client"},
 		ServiceOverride: []string{harness.TestServiceOverride},
 	},
+	WantServiceSource: harness.ServiceSourceAssertions{
+		Defaults:        []string{string(instrumentation.PackageGoRedis)},
+		ServiceOverride: []string{instrumentation.ServiceSourceWithServiceOption},
+	},
 	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "redis.command", spans[0].OperationName())

--- a/instrumentation/internal/namingschematest/go_redis_v7_test.go
+++ b/instrumentation/internal/namingschematest/go_redis_v7_test.go
@@ -40,6 +40,10 @@ var goRedisV7Test = harness.TestCase{
 		DDService:       []string{"redis.client"},
 		ServiceOverride: []string{harness.TestServiceOverride},
 	},
+	WantServiceSource: harness.ServiceSourceAssertions{
+		Defaults:        []string{string(instrumentation.PackageGoRedisV7)},
+		ServiceOverride: []string{instrumentation.ServiceSourceWithServiceOption},
+	},
 	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "redis.command", spans[0].OperationName())

--- a/instrumentation/internal/namingschematest/go_redis_v8_test.go
+++ b/instrumentation/internal/namingschematest/go_redis_v8_test.go
@@ -41,6 +41,10 @@ var goRedisV8Test = harness.TestCase{
 		DDService:       []string{"redis.client"},
 		ServiceOverride: []string{harness.TestServiceOverride},
 	},
+	WantServiceSource: harness.ServiceSourceAssertions{
+		Defaults:        []string{string(instrumentation.PackageGoRedisV8)},
+		ServiceOverride: []string{instrumentation.ServiceSourceWithServiceOption},
+	},
 	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "redis.command", spans[0].OperationName())

--- a/instrumentation/internal/namingschematest/go_restful_v3_test.go
+++ b/instrumentation/internal/namingschematest/go_restful_v3_test.go
@@ -51,6 +51,10 @@ var goRestfulV3 = harness.TestCase{
 		DDService:       []string{"go-restful"},
 		ServiceOverride: []string{harness.TestServiceOverride},
 	},
+	WantServiceSource: harness.ServiceSourceAssertions{
+		Defaults:        []string{string(instrumentation.PackageEmickleiGoRestfulV3)},
+		ServiceOverride: []string{instrumentation.ServiceSourceWithServiceOption},
+	},
 	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "http.request", spans[0].OperationName())

--- a/instrumentation/internal/namingschematest/gocql_test.go
+++ b/instrumentation/internal/namingschematest/gocql_test.go
@@ -64,6 +64,10 @@ var gocqlTest = harness.TestCase{
 		DDService:       []string{"gocql.query", "gocql.query"},
 		ServiceOverride: []string{harness.TestServiceOverride, harness.TestServiceOverride},
 	},
+	WantServiceSource: harness.ServiceSourceAssertions{
+		Defaults:        harness.RepeatString(string(instrumentation.PackageGoCQL), 2),
+		ServiceOverride: harness.RepeatString(instrumentation.ServiceSourceWithServiceOption, 2),
+	},
 	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 2)
 		assert.Equal(t, "cassandra.query", spans[0].OperationName())

--- a/instrumentation/internal/namingschematest/gomemcache_test.go
+++ b/instrumentation/internal/namingschematest/gomemcache_test.go
@@ -54,6 +54,10 @@ var gomemcache = harness.TestCase{
 		DDService:       []string{"memcached"},
 		ServiceOverride: []string{harness.TestServiceOverride},
 	},
+	WantServiceSource: harness.ServiceSourceAssertions{
+		Defaults:        []string{string(instrumentation.PackageBradfitzGoMemcache)},
+		ServiceOverride: []string{instrumentation.ServiceSourceWithServiceOption},
+	},
 	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "memcached.query", spans[0].OperationName())

--- a/instrumentation/internal/namingschematest/hashicorp_consul_test.go
+++ b/instrumentation/internal/namingschematest/hashicorp_consul_test.go
@@ -50,6 +50,10 @@ var hashicorpConsul = harness.TestCase{
 		DDService:       []string{"consul"},
 		ServiceOverride: []string{harness.TestServiceOverride},
 	},
+	WantServiceSource: harness.ServiceSourceAssertions{
+		Defaults:        []string{string(instrumentation.PackageHashicorpConsulAPI)},
+		ServiceOverride: []string{instrumentation.ServiceSourceWithServiceOption},
+	},
 	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "consul.command", spans[0].OperationName())

--- a/instrumentation/internal/namingschematest/labstack_echo_v4_test.go
+++ b/instrumentation/internal/namingschematest/labstack_echo_v4_test.go
@@ -46,6 +46,10 @@ var labstackEchoV4 = harness.TestCase{
 		DDService:       []string{harness.TestDDService},
 		ServiceOverride: []string{harness.TestServiceOverride},
 	},
+	WantServiceSource: harness.ServiceSourceAssertions{
+		Defaults:        []string{string(instrumentation.PackageLabstackEchoV4)},
+		ServiceOverride: []string{instrumentation.ServiceSourceWithServiceOption},
+	},
 	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "http.request", spans[0].OperationName())

--- a/instrumentation/internal/namingschematest/mongodriver_test.go
+++ b/instrumentation/internal/namingschematest/mongodriver_test.go
@@ -52,6 +52,10 @@ var mongoDriverTest = harness.TestCase{
 		DDService:       []string{"mongo"},
 		ServiceOverride: []string{harness.TestServiceOverride},
 	},
+	WantServiceSource: harness.ServiceSourceAssertions{
+		Defaults:        []string{string(instrumentation.PackageMongoDriver)},
+		ServiceOverride: []string{instrumentation.ServiceSourceWithServiceOption},
+	},
 	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "mongodb.query", spans[0].OperationName())

--- a/instrumentation/internal/namingschematest/negroni_test.go
+++ b/instrumentation/internal/namingschematest/negroni_test.go
@@ -50,6 +50,10 @@ var urfaveNegroni = harness.TestCase{
 		DDService:       []string{harness.TestDDService},
 		ServiceOverride: []string{harness.TestServiceOverride},
 	},
+	WantServiceSource: harness.ServiceSourceAssertions{
+		Defaults:        []string{string(instrumentation.PackageUrfaveNegroni)},
+		ServiceOverride: []string{instrumentation.ServiceSourceWithServiceOption},
+	},
 	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "http.request", spans[0].OperationName())

--- a/instrumentation/internal/namingschematest/olivere_elastic_v5_test.go
+++ b/instrumentation/internal/namingschematest/olivere_elastic_v5_test.go
@@ -58,6 +58,10 @@ var olivereElasticV5 = harness.TestCase{
 		DDService:       []string{"elastic.client"},
 		ServiceOverride: []string{harness.TestServiceOverride},
 	},
+	WantServiceSource: harness.ServiceSourceAssertions{
+		Defaults:        []string{string(instrumentation.PackageOlivereElasticV5)},
+		ServiceOverride: []string{instrumentation.ServiceSourceWithServiceOption},
+	},
 	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "elasticsearch.query", spans[0].OperationName())

--- a/instrumentation/internal/namingschematest/redigo_test.go
+++ b/instrumentation/internal/namingschematest/redigo_test.go
@@ -40,6 +40,10 @@ var redigoTest = harness.TestCase{
 		DDService:       []string{"redis.conn"},
 		ServiceOverride: []string{harness.TestServiceOverride},
 	},
+	WantServiceSource: harness.ServiceSourceAssertions{
+		Defaults:        []string{string(instrumentation.PackageRedigo)},
+		ServiceOverride: []string{instrumentation.ServiceSourceWithServiceOption},
+	},
 	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "redis.command", spans[0].OperationName())

--- a/instrumentation/internal/namingschematest/syndtr_goleveldb_test.go
+++ b/instrumentation/internal/namingschematest/syndtr_goleveldb_test.go
@@ -46,6 +46,10 @@ var syndtrGoLevelDB = harness.TestCase{
 		DDService:       []string{"leveldb"},
 		ServiceOverride: []string{harness.TestServiceOverride},
 	},
+	WantServiceSource: harness.ServiceSourceAssertions{
+		Defaults:        []string{string(instrumentation.PackageSyndtrGoLevelDB)},
+		ServiceOverride: []string{instrumentation.ServiceSourceWithServiceOption},
+	},
 	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "leveldb.query", spans[0].OperationName())

--- a/instrumentation/internal/namingschematest/tidwall_buntdb_test.go
+++ b/instrumentation/internal/namingschematest/tidwall_buntdb_test.go
@@ -48,6 +48,10 @@ var tidwallBuntDB = harness.TestCase{
 		DDService:       []string{"buntdb"},
 		ServiceOverride: []string{harness.TestServiceOverride},
 	},
+	WantServiceSource: harness.ServiceSourceAssertions{
+		Defaults:        []string{string(instrumentation.PackageTidwallBuntDB)},
+		ServiceOverride: []string{instrumentation.ServiceSourceWithServiceOption},
+	},
 	AssertOpV0: func(t *testing.T, spans []*mocktracer.Span) {
 		require.Len(t, spans, 1)
 		assert.Equal(t, "buntdb.query", spans[0].OperationName())


### PR DESCRIPTION
Second batch of 19 integrations, follow up of https://github.com/DataDog/dd-trace-go/pull/4500

This PR was fully AI generated with manual check and couple prompt iterations.

The integrations covered are chosen for their simplicity, they only support `WithService` to edit the integration service. And  in particular do not have special APIs  that touch service names behind the scenes like gin middleware, net/http router or database driver name..

All tests are covered by the suite `‎instrumentation/internal/namingschema`


Screen of a couple svc_src (this runs on system-test org)

<img width="928" height="746" alt="Screenshot 2026-03-12 at 15 19 53" src="https://github.com/user-attachments/assets/ebdc6522-97d0-42a5-add0-9db87e743ebe" />
<img width="1116" height="219" alt="Screenshot 2026-03-12 at 15 37 35" src="https://github.com/user-attachments/assets/e1fe4b03-a05a-4bca-8726-f965d8a0f47d" />
<img width="852" height="289" alt="Screenshot 2026-03-12 at 15 46 35" src="https://github.com/user-attachments/assets/3577ce3b-3fee-4313-a197-594ed1032e67" />



Database / Data Store
- go-redis/redis (v1)  
- go-redis/redis.v7
- go-redis/redis.v8                                         (screen1)
- gomodule/redigo                                         (screen1)
- gocql/gocql (Cassandra)                            (screen2)
- go.mongodb.org/mongo-driver                 (screen2)
- go.mongodb.org/mongo-driver.v2            (screen2)
- elastic/go-elasticsearch.v6                      (screen1)
- olivere/elastic.v5    (screen1)
- tidwall/buntdb    (screen1)
- syndtr/goleveldb    (screen1)
- bradfitz/gomemcache    (screen1)
- hashicorp/consul                                       (screen1) 

HTTP Server / Router
- abstack/echo.v4               (screen3)
- go-chi/chi   (screen3)
- go-chi/chi.v5.    (screen3)
- gofiber/fiber.v2    (screen3)
- urfave/negroni  (screen3)
- emicklei/go-restful.v3 (screen1)


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
