### PR TITLE
fix: stack and handling_stack were not aligned with ET

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -675,20 +675,12 @@ func (s *Span) setTagErrorLocked(value any, cfg errorConfig) {
 		if cfg.noDebugStack {
 			return
 		}
-		switch err := v.(type) {
-		case xerrors.Formatter:
+		switch v.(type) {
+		case xerrors.Formatter, fmt.Formatter, *errortrace.TracerError:
 			s.setMetaLocked(ext.ErrorStack, fmt.Sprintf("%+v", v))
-		case fmt.Formatter:
-			// pkg/errors approach
-			s.setMetaLocked(ext.ErrorStack, fmt.Sprintf("%+v", v))
-		case *errortrace.TracerError:
-			// instrumentation/errortrace approach
-			s.setMetaLocked(ext.ErrorStack, fmt.Sprintf("%+v", v))
-			s.setMetaLocked(ext.ErrorHandlingStack, err.Format())
-		default:
-			stack := takeStacktrace(cfg.stackFrames, cfg.stackSkip)
-			s.setMetaLocked(ext.ErrorHandlingStack, stack)
 		}
+		handlingStack := takeStacktrace(cfg.stackFrames, cfg.stackSkip)
+		s.setMetaLocked(ext.ErrorHandlingStack, handlingStack)
 	case nil:
 		// no error
 		s.setErrorFlagLocked(false)

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -1066,7 +1066,7 @@ func TestSpanErrorStackMetrics(t *testing.T) {
 			tracer.StartSpan("operation").Finish(WithError(errortrace.New("test")))
 		}
 
-		assert.Equal(0.0, telemetryClient.Count(telemetry.NamespaceTracers, "errorstack.source", []string{"source:takeStacktrace"}).Get())
+		assert.Equal(5.0, telemetryClient.Count(telemetry.NamespaceTracers, "errorstack.source", []string{"source:takeStacktrace"}).Get())
 
 		assert.Equal(5.0, telemetryClient.Count(telemetry.NamespaceTracers, "errorstack.source", []string{"source:TracerError"}).Get())
 		if !windows {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Aligns the values of `error.stack` and `error.handling_stack` with what ET expects.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fix Error Tracking.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
