### PR TITLE
fix(tracer): eliminate IEEE 754 flakes in TestSamplingDecision

### DIFF
--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -727,8 +727,8 @@ func TestSamplingDecision(t *testing.T) {
 		// causing spurious failures. Multiplying through by 20 clears the denominator and
 		// yields 7/20 = 0.35 and 13/20 = 0.65 as exact integer bounds.
 		denom := 900 - keptChildren
-		assert.GreaterOrEqual(t, 20*singleSpans, 7*denom)  // singleSpans/denom >= 0.35
-		assert.LessOrEqual(t, 20*singleSpans, 13*denom)    // singleSpans/denom <= 0.65
+		assert.GreaterOrEqual(t, 20*singleSpans, 7*denom) // singleSpans/denom >= 0.35
+		assert.LessOrEqual(t, 20*singleSpans, 13*denom)   // singleSpans/denom <= 0.65
 		assert.InDelta(t, 800, keptTotal, 150)
 		assert.Equal(t, uint32(100-len(keptTraces)), tracerstats.Count(tracerstats.DroppedP0Traces))
 	})


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Four assertions in `TestSamplingDecision` were updated:

**Fixed denominators (three cases):** `assert.InDelta(t, 0.8, float64(n)/1000, 0.15)` is equivalent to `assert.InDelta(t, 800, n, 150)`. Operating on integers eliminates the division and any rounding entirely.

**Dynamic denominator (one case):** `assert.InDelta(t, 0.5, float64(a)/float64(b), 0.15)` cannot be trivially scaled because `b` varies. Instead the tolerance range `[0.35, 0.65]` is expressed as exact integer inequalities by multiplying through by 20 (since `0.35 = 7/20` and `0.65 = 13/20`):

```go
assert.GreaterOrEqual(t, 20*singleSpans, 7*denom)
assert.LessOrEqual(t,   20*singleSpans, 13*denom)
```

All integer values involved are well within the range where `float64` conversion is exact (< 2^53), so testify's internal float64 comparison is lossless.

### Motivation

`TestSamplingDecision` had four `assert.InDelta` calls that compared a float64 ratio (computed via division) against an expected value with a tolerance. When the actual sample count landed exactly on the boundary, IEEE 754 floating-point arithmetic produced a result that exceeded the tolerance by one ULP, causing spurious test failures.

The canonical example: `keptSpans = 650` with `float64(650)/float64(1000) = 0.65`. The mathematical value `|0.8 - 0.65| = 0.15` is exactly at the tolerance boundary, but the IEEE 754 result is `0.15000000000000002`, which fails `assert.InDelta(..., 0.15)`.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.

Unsure? Have a question? Request a review!
