### PR TITLE
ci: revert use coverage-upload-github-action for Datadog coverage uploads

### DIFF
--- a/.github/workflows/multios-unit-tests.yml
+++ b/.github/workflows/multios-unit-tests.yml
@@ -90,8 +90,7 @@ jobs:
       - name: Upload Coverage to Datadog
         if: always()
         continue-on-error: true
-        uses: DataDog/coverage-upload-github-action@9bbbf86d16f7db1b14c5b885e61cf0d96053686a
-        with:
-          api_key: ${{ secrets.DD_CI_API_KEY }}
-          files: coverage.txt
-          format: go-coverprofile
+        shell: bash
+        run: ./datadog-ci coverage upload --format=go-coverprofile coverage.txt
+        env:
+          DD_API_KEY: ${{ secrets.DD_CI_API_KEY }}

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -260,12 +260,10 @@ jobs:
       - name: Upload Coverage to Datadog
         if: always()
         continue-on-error: true
-        uses: DataDog/coverage-upload-github-action@9bbbf86d16f7db1b14c5b885e61cf0d96053686a
-        with:
-          api_key: ${{ secrets.DD_CI_API_KEY }}
-          files: coverage.txt
-          format: go-coverprofile
-          flags: contrib
+        shell: bash
+        run: ./datadog-ci coverage upload --format=go-coverprofile --flags contrib coverage.txt
+        env:
+          DD_API_KEY: ${{ secrets.DD_CI_API_KEY }}
 
       # Check for changes in the supported_configurations.json file
       - name: Supported Configurations Diff Check
@@ -433,12 +431,10 @@ jobs:
       - name: Upload Coverage to Datadog
         if: always()
         continue-on-error: true
-        uses: DataDog/coverage-upload-github-action@9bbbf86d16f7db1b14c5b885e61cf0d96053686a
-        with:
-          api_key: ${{ secrets.DD_CI_API_KEY }}
-          files: coverage.txt
-          format: go-coverprofile
-          flags: core
+        shell: bash
+        run: ./datadog-ci coverage upload --format=go-coverprofile --flags core coverage.txt
+        env:
+          DD_API_KEY: ${{ secrets.DD_CI_API_KEY }}
 
       # Check for changes in the supported_configurations.json file
       - name: Supported Configurations Diff Check


### PR DESCRIPTION
Reverts DataDog/dd-trace-go#4501