### PR TITLE
fix(ddtrace/tracer): fix BenchmarkSpanStartConcurrent

### DIFF
--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -2312,32 +2312,18 @@ func BenchmarkStartSpanConcurrent(b *testing.B) {
 	assert.NoError(b, err)
 	defer stop()
 
-	var wg sync.WaitGroup
-	var wgready sync.WaitGroup
-	start := make(chan struct{})
-	for range 10 {
-		wg.Add(1)
-		wgready.Add(1)
-		go func() {
-			defer wg.Done()
-			root := tracer.StartSpan("pylons.request", ServiceName("pylons"), ResourceName("/"))
-			ctx := ContextWithSpan(context.TODO(), root)
-			wgready.Done()
-			<-start
-			for b.Loop() {
-				s, ok := SpanFromContext(ctx)
-				if !ok {
-					b.Error("no span")
-					return
-				}
-				StartSpan("op", ChildOf(s.Context()))
+	b.RunParallel(func(p *testing.PB) {
+		root := tracer.StartSpan("pylons.request", ServiceName("pylons"), ResourceName("/"))
+		ctx := ContextWithSpan(context.TODO(), root)
+		for p.Next() {
+			s, ok := SpanFromContext(ctx)
+			if !ok {
+				b.Error("no span")
+				return
 			}
-		}()
-	}
-	wgready.Wait()
-	b.ResetTimer()
-	close(start)
-	wg.Wait()
+			StartSpan("op", ChildOf(s.Context()))
+		}
+	})
 }
 
 func BenchmarkGenSpanID(b *testing.B) {


### PR DESCRIPTION
### What does this PR do?

Refactors BenchmarkStartSpanConcurrent to use RunParallel

### Motivation

This benchmark currently fails:

	--- FAIL: BenchmarkStartSpanConcurrent
	    benchmark.go:417: B.Loop called with timer stopped
	    benchmark.go:417: B.Loop called with timer stopped
	    benchmark.go:417: B.Loop called with timer stopped

The B.Loop docs don't seem to explicitly prohibit calling B.Loop from
multiple goroutines in the same test. But in practice this is what
happens since B.Loop manages the test timer internally. This benchmark
can be simplified with B.RunParallel, which is specifically made for the
kind of thing this benchmark is supposed to be measuring. And as a bonus
the benchmark works again. We lose the synchronization prior to starting
the main loop with this refactor. We could get it back if we know ahead
of time how many goroutines the test is going to create. But it doesn't
seem like a big loss.
