### PR TITLE
feat(ddtrace/tracer): preallocate span meta map to reduce growth cycles

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -739,7 +739,7 @@ func (s *Span) setMetaLocked(key, v string) {
 // +checklocksignore — Initialization time, span not yet shared.
 func (s *Span) setMetaInit(key, v string) {
 	if s.meta == nil {
-		s.meta = make(map[string]string, 1)
+		s.meta = initMeta()
 	}
 	delete(s.metrics, key)
 	switch key {
@@ -1227,6 +1227,19 @@ func setLLMObsPropagatingTags(ctx context.Context, spanCtx *SpanContext) {
 	spanCtx.trace.setPropagatingTag(keyPropagatedLLMObsParentID, llmSpan.SpanID())
 	spanCtx.trace.setPropagatingTag(keyPropagatedLLMObsTraceID, llmSpan.TraceID())
 	spanCtx.trace.setPropagatingTag(keyPropagatedLLMObsMLAPP, llmSpan.MLApp())
+}
+
+// initMeta pre-allocates the meta map with headroom.
+// expectedEntries should be the count of tags known at construction time.
+// The 4/3 factor (≈ inverse of the standard 0.75 load factor) provides
+// ~33% slack so small overestimates don't trigger an immediate rehash.
+func initMeta() map[string]string {
+	// Unconditionally set meta tags: env, version, component, span.kind, language
+	const (
+		expectedEntries = 5
+		loadFactor      = 4 / 3
+	)
+	return make(map[string]string, expectedEntries*loadFactor)
 }
 
 // used in internal/civisibility/integrations/manual_api_common.go using linkname


### PR DESCRIPTION
### What does this PR do?

Preallocates `span.meta` to a safe size using a loadFactor in relation to the known number of tags that are usually set by span. This is backed by number of tags measurement across our services.

### Motivation

Reducing CPU-related usage for memory growth.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [x] There is a benchmark for any new code, or changes to existing code.
- [x] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
