### PR TITLE
feat(internal/log): remove locking

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/dyngo"
@@ -93,10 +94,14 @@ func (m *ManagedFile) Name() string {
 }
 
 var (
-	mu             sync.RWMutex // guards below fields
-	levelThreshold              = LevelWarn
+	levelThreshold atomic.Int32 // stores Level as int32; accessed atomically to avoid lock contention in hot paths
+	mu             sync.RWMutex // guards logger instance
 	logger         Logger       = &defaultLogger{l: log.New(os.Stderr, "", log.LstdFlags)}
 )
+
+func init() {
+	levelThreshold.Store(int32(LevelWarn))
+}
 
 // UseLogger sets l as the active logger and returns a function to restore the
 // previous logger. The return value is mostly useful when testing.
@@ -134,31 +139,22 @@ func OpenFileAtPath(dirPath string) (*ManagedFile, error) {
 
 // SetLevel sets the given lvl as log threshold for logging.
 func SetLevel(lvl Level) {
-	mu.Lock()
-	defer mu.Unlock()
-	levelThreshold = lvl
+	levelThreshold.Store(int32(lvl))
 }
 
 func DefaultLevel() Level {
-	mu.RLock()
-	defer mu.RUnlock()
-	return levelThreshold
+	return GetLevel()
 }
 
 // GetLevel returns the currrent log level.
 func GetLevel() Level {
-	mu.Lock()
-	defer mu.Unlock()
-	return levelThreshold
+	return Level(levelThreshold.Load())
 }
 
 // DebugEnabled returns true if debug log messages are enabled. This can be used in extremely
 // hot code paths to avoid allocating the ...interface{} argument.
 func DebugEnabled() bool {
-	mu.RLock()
-	lvl := levelThreshold
-	mu.RUnlock()
-	return lvl == LevelDebug
+	return GetLevel() == LevelDebug
 }
 
 // Debug prints the given message if the level is LevelDebug.

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -69,7 +69,7 @@ func TestLogDirectory(t *testing.T) {
 			assert.False(t, f.closed)
 
 			// ensure this setting plays nicely with other log features
-			oldLvl := levelThreshold
+			oldLvl := Level(levelThreshold.Load())
 			SetLevel(LevelDebug)
 			defer func() {
 				SetLevel(oldLvl)
@@ -133,7 +133,7 @@ func TestLog(t *testing.T) {
 	t.Run("Debug", func(t *testing.T) {
 		t.Run("on", func(t *testing.T) {
 			tp.Reset()
-			defer func(old Level) { levelThreshold = old }(levelThreshold)
+			defer func(old Level) { levelThreshold.Store(int32(old)) }(Level(levelThreshold.Load()))
 			SetLevel(LevelDebug)
 			assert.True(t, DebugEnabled())
 


### PR DESCRIPTION
### What does this PR do?

Turns `internal/log` to use `atomic.Int32` to avoid using `log.mu` locking when checking the level.

### Motivation

Complete #1905 work using the current benchmarking platform.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] There is a benchmark for any new code, or changes to existing code.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.

Unsure? Have a question? Request a review!