### PR TITLE
fix(tracer): fix TestTraceProtocol broken by agent:latest v1 endpoint discovery

### DIFF
--- a/ddtrace/tracer/writer_test.go
+++ b/ddtrace/tracer/writer_test.go
@@ -459,17 +459,17 @@ func minInts(a, b int) int {
 }
 
 func TestTraceProtocol(t *testing.T) {
-	assert := assert.New(t)
-
 	t.Run("v1.0, no endpoint", func(t *testing.T) {
+		assert := assert.New(t)
 		t.Setenv("DD_TRACE_AGENT_PROTOCOL_VERSION", "1.0")
-		cfg, err := newTestConfig()
+		cfg, err := newTestConfig(withNoopInfoHTTPClient())
 		require.NoError(t, err)
 		h := newAgentTraceWriter(cfg, nil, nil)
 		assert.Equal(traceProtocolV04, h.payload.protocol())
 	})
 
 	t.Run("v1.0, with endpoint", func(t *testing.T) {
+		assert := assert.New(t)
 		t.Setenv("DD_TRACE_AGENT_PROTOCOL_VERSION", "1.0")
 
 		// Create a mock agent endpoint to mimic having a v1 trace endpoint
@@ -489,21 +489,24 @@ func TestTraceProtocol(t *testing.T) {
 	})
 
 	t.Run("v0.4", func(t *testing.T) {
+		assert := assert.New(t)
 		t.Setenv("DD_TRACE_AGENT_PROTOCOL_VERSION", "0.4")
-		cfg, err := newTestConfig()
+		cfg, err := newTestConfig(withNoopInfoHTTPClient())
 		require.NoError(t, err)
 		h := newAgentTraceWriter(cfg, nil, nil)
 		assert.Equal(traceProtocolV04, h.payload.protocol())
 	})
 
 	t.Run("default, no endpoint", func(t *testing.T) {
-		cfg, err := newTestConfig()
+		assert := assert.New(t)
+		cfg, err := newTestConfig(withNoopInfoHTTPClient())
 		require.NoError(t, err)
 		h := newAgentTraceWriter(cfg, nil, nil)
 		assert.Equal(traceProtocolV04, h.payload.protocol())
 	})
 
 	t.Run("default, with endpoint", func(t *testing.T) {
+		assert := assert.New(t)
 		// Create a mock agent endpoint to mimic having a v1 trace endpoint
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
@@ -521,14 +524,16 @@ func TestTraceProtocol(t *testing.T) {
 	})
 
 	t.Run("invalid, no endpoint", func(t *testing.T) {
+		assert := assert.New(t)
 		t.Setenv("DD_TRACE_AGENT_PROTOCOL_VERSION", "random")
-		cfg, err := newTestConfig()
+		cfg, err := newTestConfig(withNoopInfoHTTPClient())
 		require.NoError(t, err)
 		h := newAgentTraceWriter(cfg, nil, nil)
 		assert.Equal(traceProtocolV04, h.payload.protocol())
 	})
 
 	t.Run("invalid, with endpoint", func(t *testing.T) {
+		assert := assert.New(t)
 		// Create a mock agent endpoint to mimic having a v1 trace endpoint
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
### What does this PR do?

Fixes `TestTraceProtocol` in `ddtrace/tracer/writer_test.go` which broke after the CI agent image (`agent:latest`) was updated to advertise the `/v1.0/traces` endpoint.

- Adds `withNoopInfoHTTPClient()` to the "no endpoint" test cases so they don't contact the real CI agent and discover the v1 endpoint unexpectedly.
- Moves `assert := assert.New(t)` into each subtest so assertion failures are attributed to the correct subtest's `t`, not the parent test.

### Motivation

Agent PR [datadog-agent#45981](https://github.com/DataDog/datadog-agent/pull/45981) enabled the v1.0 traces endpoint by default (milestoned for 7.77.0) and was merged on Feb 18. The next day, tracer PR [#4446](https://github.com/DataDog/dd-trace-go/pull/4446) changed the env var for Enhanced Trace Protocol from `DD_TRACE_V1_PAYLOAD_FORMAT_ENABLED` to `DD_TRACE_AGENT_PROTOCOL_VERSION`. That PR's CI passed because `agent:latest` was still on 7.75.4 at the time. Agent 7.77.0 was released on Mar 18, updating the `agent:latest` image to include the v1 endpoint — causing the "no endpoint" test cases to start failing because `loadAgentFeatures()` now discovers `/v1.0/traces` on the real CI agent.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)