### PR TITLE
fix(ddtrace/tracer): honor DD_DOGSTATSD_PORT over agent StatsD port

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -533,8 +533,8 @@ func apmTracingDisabled(c *config) {
 }
 
 // resolveDogstatsdAddr resolves the Dogstatsd address to use, based on the user-defined
-// address and the agent-reported port. If the agent reports a port, it will be used
-// instead of the user-defined address' port. UDS paths are honored regardless of the
+// address and the agent-reported port. If the agent reports a port, it is used unless
+// the user explicitly set DD_DOGSTATSD_PORT. UDS paths are honored regardless of the
 // agent-reported port.
 func resolveDogstatsdAddr(addr string, af agentFeatures) string {
 	if addr == "" {
@@ -546,6 +546,10 @@ func resolveDogstatsdAddr(addr string, af agentFeatures) string {
 	if agentport == 0 {
 		// the agent didn't report a port; use the already resolved address as
 		// features are loaded from the trace-agent, which might be not running
+		return addr
+	}
+	if env.Get("DD_DOGSTATSD_PORT") != "" {
+		// user explicitly configured the port via env var; keep that value
 		return addr
 	}
 	// the agent reported a port
@@ -563,8 +567,7 @@ func resolveDogstatsdAddr(addr string, af agentFeatures) string {
 		// no host was provided; use the default hostname
 		host = defaultHostname
 	}
-	// use agent-reported address if it differs from the user-defined TCP-based protocol URI
-	// we have a valid host:port address; replace the port because the agent knows better
+	// use agent-reported port when no explicit DD_DOGSTATSD_PORT was provided.
 	addr = net.JoinHostPort(host, strconv.Itoa(agentport))
 	return addr
 }
@@ -1163,7 +1166,8 @@ func WithRuntimeMetrics() StartOption {
 // attempts to determine the address of the statsd service according to the following rules:
 //  1. Look for /var/run/datadog/dsd.socket and use it if present. IF NOT, continue to #2.
 //  2. The host is determined by DD_AGENT_HOST, and defaults to "localhost"
-//  3. The port is retrieved from the agent. If not present, it is determined by DD_DOGSTATSD_PORT, and defaults to 8125
+//  3. If DD_DOGSTATSD_PORT is set, use it. Otherwise the port is retrieved from the agent.
+//     If the agent does not provide one, it defaults to 8125.
 //
 // This option is in effect when WithRuntimeMetrics is enabled.
 func WithDogstatsdAddr(addr string) StartOption {

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -561,8 +561,8 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			defer tracer.Stop()
 			assert.NoError(t, err)
 			c := tracer.config
-			assert.Equal(t, "localhost:8125", c.dogstatsdAddr)
-			assert.Equal(t, "localhost:8125", globalconfig.DogstatsdAddr())
+			assert.Equal(t, "localhost:123", c.dogstatsdAddr)
+			assert.Equal(t, "localhost:123", globalconfig.DogstatsdAddr())
 		})
 
 		t.Run("env-port: agent not available", func(t *testing.T) {
@@ -585,8 +585,8 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			assert.NoError(t, err)
 			defer tracer.Stop()
 			c := tracer.config
-			assert.Equal(t, "localhost:8125", c.dogstatsdAddr)
-			assert.Equal(t, "localhost:8125", globalconfig.DogstatsdAddr())
+			assert.Equal(t, "localhost:123", c.dogstatsdAddr)
+			assert.Equal(t, "localhost:123", globalconfig.DogstatsdAddr())
 		})
 
 		t.Run("env-all: agent not available", func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

- Updates `resolveDogstatsdAddr` so an explicitly configured `DD_DOGSTATSD_PORT` is preserved instead of being overwritten by the agent-reported StatsD port.
- Keeps existing behavior for UDS and for cases where `DD_DOGSTATSD_PORT` is not set.
- Updates `TestTracerOptionsDefaults/dogstatsd` expectations for `env-port` and `env-all` to match the new precedence.
- Updates the `WithDogstatsdAddr` docs to reflect the new precedence rule.

### Motivation

Issue #4518 reports that `DD_DOGSTATSD_PORT` is ignored when the agent reports a port, which prevents users from enforcing a different exposed DogStatsD port.

This change gives precedence to explicit `DD_DOGSTATSD_PORT` configuration while keeping the agent-reported port behavior as the default fallback.

Fixes #4518

Validation:
- Attempted: `go test ./ddtrace/tracer -run "dogstatsd/env-(port|all)$" -count=1`
- Result: not runnable in current upstream state due unrelated compile errors in existing tests (`option_test.go` / `writer_test.go` referencing removed config fields like `agentURL` / `traceProtocol`).

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.
