### PR TITLE
refactor(config): POC remote config migration

### DIFF
--- a/ddtrace/tracer/dynamic_config_test.go
+++ b/ddtrace/tracer/dynamic_config_test.go
@@ -237,7 +237,7 @@ func TestDynamicInstrumentationRCStateMutex(t *testing.T) {
 // fields remain on the tracer's config struct. When the count reaches 0, the test
 // fails to signal that dynamic_config.go and this test file should be deleted.
 func TestDynamicConfigFieldsRemaining(t *testing.T) {
-	typ := reflect.TypeOf(config{})
+	typ := reflect.TypeFor[config]()
 	var remaining int
 	for i := 0; i < typ.NumField(); i++ {
 		if strings.HasPrefix(typ.Field(i).Type.Name(), "dynamicConfig[") {

--- a/ddtrace/tracer/dynamic_config_test.go
+++ b/ddtrace/tracer/dynamic_config_test.go
@@ -7,6 +7,8 @@ package tracer
 
 import (
 	"fmt"
+	"reflect"
+	"strings"
 	"sync"
 	"testing"
 
@@ -229,4 +231,21 @@ func TestDynamicInstrumentationRCStateMutex(t *testing.T) {
 		assert.Empty(t, diRCState.state)
 		diRCState.mu.Unlock()
 	})
+}
+
+// TestDynamicConfigFieldsRemaining uses reflection to count how many dynamicConfig
+// fields remain on the tracer's config struct. When the count reaches 0, the test
+// fails to signal that dynamic_config.go and this test file should be deleted.
+func TestDynamicConfigFieldsRemaining(t *testing.T) {
+	typ := reflect.TypeOf(config{})
+	var remaining int
+	for i := 0; i < typ.NumField(); i++ {
+		if strings.HasPrefix(typ.Field(i).Type.Name(), "dynamicConfig[") {
+			remaining++
+		}
+	}
+	if remaining == 0 {
+		t.Fatal("All dynamicConfig fields have been migrated to internal/config.DynamicConfig. " +
+			"Delete ddtrace/tracer/dynamic_config.go and ddtrace/tracer/dynamic_config_test.go.")
+	}
 }

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -230,9 +230,6 @@ type config struct {
 	// Only used for telemetry currently.
 	orchestrionCfg orchestrionConfig
 
-	// traceSampleRate holds the trace sample rate.
-	traceSampleRate dynamicConfig[float64]
-
 	// traceSampleRules holds the trace sampling rules
 	traceSampleRules dynamicConfig[[]SamplingRule]
 

--- a/ddtrace/tracer/remote_config.go
+++ b/ddtrace/tracer/remote_config.go
@@ -252,9 +252,11 @@ func (t *tracer) onRemoteConfigUpdate(u remoteconfig.ProductUpdate) map[string]s
 	var telemConfigs []telemetry.Configuration
 
 	// Apply the new configuration values.
-	updated := t.config.traceSampleRate.handleRC(merged.SamplingRate)
+	sampleRateDC := t.config.internalConfig.GlobalSampleRateConfig()
+	updated := sampleRateDC.HandleRC(merged.SamplingRate)
 	if updated {
-		telemConfigs = append(telemConfigs, t.config.traceSampleRate.toTelemetry())
+		t.rulesSampling.traces.setGlobalSampleRate(sampleRateDC.Get())
+		telemConfigs = append(telemConfigs, sampleRateDC.ToTelemetry())
 	}
 	updated = t.config.traceSampleRules.handleRC(convertRemoteSamplingRules(merged.TraceSamplingRules))
 	if updated {

--- a/ddtrace/tracer/remote_config.go
+++ b/ddtrace/tracer/remote_config.go
@@ -252,11 +252,11 @@ func (t *tracer) onRemoteConfigUpdate(u remoteconfig.ProductUpdate) map[string]s
 	var telemConfigs []telemetry.Configuration
 
 	// Apply the new configuration values.
-	sampleRateDC := t.config.internalConfig.GlobalSampleRateConfig()
-	updated := sampleRateDC.HandleRC(merged.SamplingRate)
+	// internalConfig's HandleRC self-reports to telemetry, so no need to append to telemConfigs.
+	sampleRateCfg := t.config.internalConfig.GlobalSampleRateConfig()
+	updated := sampleRateCfg.HandleRC(merged.SamplingRate)
 	if updated {
-		t.rulesSampling.traces.setGlobalSampleRate(sampleRateDC.Get())
-		telemConfigs = append(telemConfigs, sampleRateDC.ToTelemetry())
+		t.rulesSampling.traces.setGlobalSampleRate(sampleRateCfg.Get())
 	}
 	updated = t.config.traceSampleRules.handleRC(convertRemoteSamplingRules(merged.TraceSamplingRules))
 	if updated {

--- a/ddtrace/tracer/remote_config_test.go
+++ b/ddtrace/tracer/remote_config_test.go
@@ -42,7 +42,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.Nil(t, err)
 		defer stop()
 
-		require.Equal(t, telemetry.OriginDefault, tracer.config.traceSampleRate.cfgOrigin)
+		require.Equal(t, telemetry.OriginDefault, tracer.config.internalConfig.GlobalSampleRateConfig().Origin())
 
 		// Apply RC. Assert _dd.rule_psr shows the RC sampling rate (0.5) is applied
 		input := remoteconfig.ProductUpdate{
@@ -111,7 +111,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.Nil(t, err)
 		defer stop()
 
-		require.Equal(t, telemetry.OriginEnvVar, tracer.config.traceSampleRate.cfgOrigin)
+		require.Equal(t, telemetry.OriginEnvVar, tracer.config.internalConfig.GlobalSampleRateConfig().Origin())
 
 		// Apply RC. Assert _dd.rule_psr shows the RC sampling rate (0.2) is applied
 		input := remoteconfig.ProductUpdate{
@@ -156,7 +156,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.Nil(t, err)
 		defer stop()
 
-		require.Equal(t, telemetry.OriginDefault, tracer.config.traceSampleRate.cfgOrigin)
+		require.Equal(t, telemetry.OriginDefault, tracer.config.internalConfig.GlobalSampleRateConfig().Origin())
 
 		s := tracer.StartSpan("web.request")
 		s.Finish()
@@ -353,7 +353,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.Nil(t, err)
 		defer stop()
 
-		require.Equal(t, telemetry.OriginDefault, tracer.config.traceSampleRate.cfgOrigin)
+		require.Equal(t, telemetry.OriginDefault, tracer.config.internalConfig.GlobalSampleRateConfig().Origin())
 
 		// Apply RC. Assert global config shows the RC header tag is applied
 		input := remoteconfig.ProductUpdate{
@@ -392,7 +392,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.Nil(t, err)
 		defer stop()
 
-		require.Equal(t, telemetry.OriginDefault, tr.config.traceSampleRate.cfgOrigin)
+		require.Equal(t, telemetry.OriginDefault, tr.config.internalConfig.GlobalSampleRateConfig().Origin())
 
 		input := remoteconfig.ProductUpdate{
 			"path": []byte(
@@ -547,7 +547,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.Nil(t, err)
 		defer stop()
 
-		require.Equal(t, telemetry.OriginDefault, tracer.config.traceSampleRate.cfgOrigin)
+		require.Equal(t, telemetry.OriginDefault, tracer.config.internalConfig.GlobalSampleRateConfig().Origin())
 
 		input := remoteconfig.ProductUpdate{
 			"path": []byte(
@@ -572,7 +572,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.Nil(t, err)
 		defer stop()
 
-		require.Equal(t, telemetry.OriginDefault, tracer.config.traceSampleRate.cfgOrigin)
+		require.Equal(t, telemetry.OriginDefault, tracer.config.internalConfig.GlobalSampleRateConfig().Origin())
 
 		input := remoteconfig.ProductUpdate{
 			"path": []byte(`{"lib_config": {}, "service_target": {"service": "other-service", "env": "my-env"}}`),
@@ -595,7 +595,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.Nil(t, err)
 		defer stop()
 
-		require.Equal(t, telemetry.OriginDefault, tracer.config.traceSampleRate.cfgOrigin)
+		require.Equal(t, telemetry.OriginDefault, tracer.config.internalConfig.GlobalSampleRateConfig().Origin())
 
 		input := remoteconfig.ProductUpdate{
 			"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "other-env"}}`),
@@ -624,7 +624,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.Nil(t, err)
 		defer stop()
 
-		require.Equal(t, telemetry.OriginDefault, tracer.config.traceSampleRate.cfgOrigin)
+		require.Equal(t, telemetry.OriginDefault, tracer.config.internalConfig.GlobalSampleRateConfig().Origin())
 		require.Equal(t, telemetry.OriginEnvVar, tracer.config.globalTags.cfgOrigin)
 
 		// Apply RC. Assert global tags have the RC tags key3:val3,key4:val4 applied + runtime ID
@@ -754,7 +754,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 				assert.Nil(t, err)
 				defer stop()
 
-				require.Equal(t, telemetry.OriginEnvVar, tracer.config.traceSampleRate.cfgOrigin)
+				require.Equal(t, telemetry.OriginEnvVar, tracer.config.internalConfig.GlobalSampleRateConfig().Origin())
 
 				// Apply RC. Assert configuration is updated to the RC values.
 				initialInput := remoteconfig.ProductUpdate{

--- a/ddtrace/tracer/remote_config_test.go
+++ b/ddtrace/tracer/remote_config_test.go
@@ -25,11 +25,23 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 )
 
+// assertTelemetryConfig checks that cfgs contains at least one entry matching
+// name, value, and origin (ignoring SeqID / ID which are transport metadata).
+func assertTelemetryConfig(t *testing.T, cfgs []telemetry.Configuration, name string, value any, origin telemetry.Origin) {
+	t.Helper()
+	for _, c := range cfgs {
+		if c.Name == name && reflect.DeepEqual(c.Value, value) && c.Origin == origin {
+			return
+		}
+	}
+	t.Errorf("expected telemetry config Name=%q Value=%v Origin=%v not found", name, value, origin)
+}
+
 func assertCalled(t *testing.T, client *telemetrytest.RecordClient, cfgs []telemetry.Configuration) {
 	t.Helper()
 
-	for _, cfg := range cfgs {
-		assert.Contains(t, client.Configuration, cfg)
+	for _, expected := range cfgs {
+		assertTelemetryConfig(t, client.Configuration, expected.Name, expected.Value, expected.Origin)
 	}
 }
 
@@ -41,8 +53,6 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		tracer, _, _, stop, err := startTestTracer(t, WithService("my-service"), WithEnv("my-env"))
 		require.Nil(t, err)
 		defer stop()
-
-		require.Equal(t, telemetry.OriginDefault, tracer.config.internalConfig.GlobalSampleRateConfig().Origin())
 
 		// Apply RC. Assert _dd.rule_psr shows the RC sampling rate (0.5) is applied
 		input := remoteconfig.ProductUpdate{
@@ -58,7 +68,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.Equal(t, 0.5, rate)
 
 		// Telemetry
-		assert.Contains(t, telemetryClient.Configuration, telemetry.Configuration{Name: "trace_sample_rate", Value: 0.5, Origin: telemetry.OriginRemoteConfig})
+		assertTelemetryConfig(t, telemetryClient.Configuration, "trace_sample_rate", 0.5, telemetry.OriginRemoteConfig)
 
 		// Apply RC with sampling rules. Assert _dd.rule_psr shows the corresponding rule matched rate.
 		input = remoteconfig.ProductUpdate{
@@ -99,7 +109,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.NotContains(t, keyRulesSamplerAppliedRate, s.metrics)
 
 		// assert telemetry config contains trace_sample_rate with Nan (marshalled as nil)
-		assert.Contains(t, telemetryClient.Configuration, telemetry.Configuration{Name: "trace_sample_rate", Value: nil, Origin: telemetry.OriginDefault})
+		assertTelemetryConfig(t, telemetryClient.Configuration, "trace_sample_rate", nil, telemetry.OriginDefault)
 	})
 
 	t.Run("DD_TRACE_SAMPLE_RATE=0.1 and RC sampling rate = 0.2", func(t *testing.T) {
@@ -110,8 +120,6 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		tracer, _, _, stop, err := startTestTracer(t, WithService("my-service"), WithEnv("my-env"))
 		require.Nil(t, err)
 		defer stop()
-
-		require.Equal(t, telemetry.OriginEnvVar, tracer.config.internalConfig.GlobalSampleRateConfig().Origin())
 
 		// Apply RC. Assert _dd.rule_psr shows the RC sampling rate (0.2) is applied
 		input := remoteconfig.ProductUpdate{
@@ -126,7 +134,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		rate, _ := getMetric(s, keyRulesSamplerAppliedRate)
 		require.Equal(t, 0.2, rate)
 
-		assert.Contains(t, telemetryClient.Configuration, telemetry.Configuration{Name: "trace_sample_rate", Value: 0.2, Origin: telemetry.OriginRemoteConfig})
+		assertTelemetryConfig(t, telemetryClient.Configuration, "trace_sample_rate", 0.2, telemetry.OriginRemoteConfig)
 
 		// Unset RC. Assert _dd.rule_psr shows the previous sampling rate (0.1) is applied
 		input = remoteconfig.ProductUpdate{
@@ -139,7 +147,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		rate, _ = getMetric(s, keyRulesSamplerAppliedRate)
 		require.Equal(t, 0.1, rate)
 
-		assert.Contains(t, telemetryClient.Configuration, telemetry.Configuration{Name: "trace_sample_rate", Value: 0.1, Origin: telemetry.OriginDefault})
+		assertTelemetryConfig(t, telemetryClient.Configuration, "trace_sample_rate", 0.1, telemetry.OriginEnvVar)
 	})
 
 	t.Run("DD_TRACE_SAMPLING_RULES rate=0.1 and RC trace sampling rules rate = 1.0", func(t *testing.T) {
@@ -155,8 +163,6 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		tracer, _, _, stop, err := startTestTracer(t, WithService("my-service"), WithEnv("my-env"))
 		require.Nil(t, err)
 		defer stop()
-
-		require.Equal(t, telemetry.OriginDefault, tracer.config.internalConfig.GlobalSampleRateConfig().Origin())
 
 		s := tracer.StartSpan("web.request")
 		s.Finish()
@@ -195,7 +201,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 			require.Equal(t, samplernames.RuleRate.DecisionMaker(), s.context.trace.propagatingTags[keyDecisionMaker])
 		}
 
-		assert.Contains(t, telemetryClient.Configuration, telemetry.Configuration{Name: "trace_sample_rate", Value: 0.5, Origin: telemetry.OriginRemoteConfig})
+		assertTelemetryConfig(t, telemetryClient.Configuration, "trace_sample_rate", 0.5, telemetry.OriginRemoteConfig)
 		assert.Contains(t, telemetryClient.Configuration, telemetry.Configuration{
 			Name:   "trace_sample_rules",
 			Value:  `[{"service":"my-service","name":"web.request","resource":"abc","sample_rate":1,"provenance":"customer"}]`,
@@ -353,8 +359,6 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.Nil(t, err)
 		defer stop()
 
-		require.Equal(t, telemetry.OriginDefault, tracer.config.internalConfig.GlobalSampleRateConfig().Origin())
-
 		// Apply RC. Assert global config shows the RC header tag is applied
 		input := remoteconfig.ProductUpdate{
 			"path": []byte(
@@ -391,8 +395,6 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		tr, _, _, stop, err := startTestTracer(t, WithService("my-service"), WithEnv("my-env"))
 		require.Nil(t, err)
 		defer stop()
-
-		require.Equal(t, telemetry.OriginDefault, tr.config.internalConfig.GlobalSampleRateConfig().Origin())
 
 		input := remoteconfig.ProductUpdate{
 			"path": []byte(
@@ -547,8 +549,6 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.Nil(t, err)
 		defer stop()
 
-		require.Equal(t, telemetry.OriginDefault, tracer.config.internalConfig.GlobalSampleRateConfig().Origin())
-
 		input := remoteconfig.ProductUpdate{
 			"path": []byte(
 				`{"lib_config": {"tracing_sampling_rate": "string value", "service_target": {"service": "my-service", "env": "my-env"}}}`,
@@ -572,8 +572,6 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.Nil(t, err)
 		defer stop()
 
-		require.Equal(t, telemetry.OriginDefault, tracer.config.internalConfig.GlobalSampleRateConfig().Origin())
-
 		input := remoteconfig.ProductUpdate{
 			"path": []byte(`{"lib_config": {}, "service_target": {"service": "other-service", "env": "my-env"}}`),
 		}
@@ -594,8 +592,6 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		tracer, _, _, stop, err := startTestTracer(t, WithService("my-service"), WithEnv("my-env"))
 		require.Nil(t, err)
 		defer stop()
-
-		require.Equal(t, telemetry.OriginDefault, tracer.config.internalConfig.GlobalSampleRateConfig().Origin())
 
 		input := remoteconfig.ProductUpdate{
 			"path": []byte(`{"lib_config": {}, "service_target": {"service": "my-service", "env": "other-env"}}`),
@@ -624,7 +620,6 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.Nil(t, err)
 		defer stop()
 
-		require.Equal(t, telemetry.OriginDefault, tracer.config.internalConfig.GlobalSampleRateConfig().Origin())
 		require.Equal(t, telemetry.OriginEnvVar, tracer.config.globalTags.cfgOrigin)
 
 		// Apply RC. Assert global tags have the RC tags key3:val3,key4:val4 applied + runtime ID
@@ -754,8 +749,6 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 				assert.Nil(t, err)
 				defer stop()
 
-				require.Equal(t, telemetry.OriginEnvVar, tracer.config.internalConfig.GlobalSampleRateConfig().Origin())
-
 				// Apply RC. Assert configuration is updated to the RC values.
 				initialInput := remoteconfig.ProductUpdate{
 					samplingRatePath: samplingRateConfig,
@@ -798,7 +791,8 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 				require.Equal(t, tt.expectedSpanTag, ddTag)
 
 				// Check expected telemetry.
-				samplingRateOrigin := telemetry.OriginDefault
+				// DD_TRACE_SAMPLE_RATE=0.1 is set, so resets report OriginEnvVar.
+				samplingRateOrigin := telemetry.OriginEnvVar
 				if tt.expectedSamplingRate == rcSamplingRate {
 					samplingRateOrigin = telemetry.OriginRemoteConfig
 				}

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -64,7 +64,7 @@ func startTelemetry(c *config) telemetry.Client {
 		{Name: "orchestrion_enabled", Value: c.orchestrionCfg.Enabled, Origin: telemetry.OriginCode},
 		{Name: "trace_enabled", Value: traceEnabled, Origin: traceEnabledOrigin},
 		{Name: "trace_log_directory", Value: c.internalConfig.LogDirectory()},
-		c.traceSampleRate.toTelemetry(),
+		c.internalConfig.GlobalSampleRateConfig().ToTelemetry(),
 		c.headerAsTags.toTelemetry(),
 		c.globalTags.toTelemetry(),
 		c.traceSampleRules.toTelemetry(),

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -64,7 +64,6 @@ func startTelemetry(c *config) telemetry.Client {
 		{Name: "orchestrion_enabled", Value: c.orchestrionCfg.Enabled, Origin: telemetry.OriginCode},
 		{Name: "trace_enabled", Value: traceEnabled, Origin: traceEnabledOrigin},
 		{Name: "trace_log_directory", Value: c.internalConfig.LogDirectory()},
-		c.internalConfig.GlobalSampleRateConfig().ToTelemetry(),
 		c.headerAsTags.toTelemetry(),
 		c.globalTags.toTelemetry(),
 		c.traceSampleRules.toTelemetry(),

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -433,13 +433,9 @@ func newUnstartedTracer(opts ...StartOption) (t *tracer, err error) {
 	}
 
 	rulesSampler := newRulesSampler(c.traceRules, c.spanRules, c.internalConfig.GlobalSampleRate(), c.internalConfig.TraceRateLimitPerSecond())
-	c.traceSampleRate = newDynamicConfig("trace_sample_rate", c.internalConfig.GlobalSampleRate(), rulesSampler.traces.setGlobalSampleRate, equal[float64])
 	// If globalSampleRate returns NaN, it means the environment variable was not set or valid.
-	// We could always set the origin to "env_var" inconditionally, but then it wouldn't be possible
-	// to distinguish between the case where the environment variable was not set and the case where
-	// it default to NaN.
 	if !math.IsNaN(c.internalConfig.GlobalSampleRate()) {
-		c.traceSampleRate.setOrigin(telemetry.OriginEnvVar)
+		c.internalConfig.GlobalSampleRateConfig().SetOrigin(telemetry.OriginEnvVar)
 	}
 	c.traceSampleRules = newDynamicConfig("trace_sample_rules", c.traceRules,
 		rulesSampler.traces.setTraceSampleRules, EqualsFalseNegative)

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
-	"math"
 	"os"
 	"runtime/pprof"
 	rt "runtime/trace"
@@ -433,10 +432,6 @@ func newUnstartedTracer(opts ...StartOption) (t *tracer, err error) {
 	}
 
 	rulesSampler := newRulesSampler(c.traceRules, c.spanRules, c.internalConfig.GlobalSampleRate(), c.internalConfig.TraceRateLimitPerSecond())
-	// If globalSampleRate returns NaN, it means the environment variable was not set or valid.
-	if !math.IsNaN(c.internalConfig.GlobalSampleRate()) {
-		c.internalConfig.GlobalSampleRateConfig().SetOrigin(telemetry.OriginEnvVar)
-	}
 	c.traceSampleRules = newDynamicConfig("trace_sample_rules", c.traceRules,
 		rulesSampler.traces.setTraceSampleRules, EqualsFalseNegative)
 	var dataStreamsProcessor *datastreams.Processor

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,7 +86,7 @@ type Config struct {
 	// dynamicInstrumentationEnabled controls if the target application can be modified by Dynamic Instrumentation or not.
 	dynamicInstrumentationEnabled bool
 	// globalSampleRate holds the sample rate for the tracer.
-	globalSampleRate float64
+	globalSampleRate *DynamicConfig[float64]
 	// ciVisibilityEnabled controls if the tracer is loaded with CI Visibility mode. default false
 	ciVisibilityEnabled   bool
 	ciVisibilityAgentless bool
@@ -161,7 +161,7 @@ func loadConfig() *Config {
 	cfg.ciVisibilityAgentless = p.GetBool("DD_CIVISIBILITY_AGENTLESS_ENABLED", false)
 	cfg.logDirectory = p.GetString("DD_TRACE_LOG_DIRECTORY", "")
 	cfg.traceRateLimitPerSecond = p.GetFloatWithValidator("DD_TRACE_RATE_LIMIT", DefaultRateLimit, validateRateLimit)
-	cfg.globalSampleRate = p.GetFloatWithValidator("DD_TRACE_SAMPLE_RATE", math.NaN(), validateSampleRate)
+	cfg.globalSampleRate = NewDynamicConfig("trace_sample_rate", p.GetFloatWithValidator("DD_TRACE_SAMPLE_RATE", math.NaN(), validateSampleRate))
 	cfg.debugStack = p.GetBool("DD_TRACE_DEBUG_STACK", true)
 	cfg.retryInterval = p.GetDuration("DD_TRACE_RETRY_INTERVAL", time.Millisecond)
 	cfg.logsOTelEnabled = p.GetBool("DD_LOGS_OTEL_ENABLED", false)
@@ -409,15 +409,17 @@ func (c *Config) SetIsLambdaFunction(enabled bool, origin telemetry.Origin) {
 }
 
 func (c *Config) GlobalSampleRate() float64 {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	return c.globalSampleRate.Get()
+}
+
+// GlobalSampleRateConfig returns the DynamicConfig for the global sample rate.
+// Products use this to apply RC updates and read telemetry snapshots.
+func (c *Config) GlobalSampleRateConfig() *DynamicConfig[float64] {
 	return c.globalSampleRate
 }
 
 func (c *Config) SetGlobalSampleRate(rate float64, origin telemetry.Origin) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.globalSampleRate = rate
+	c.globalSampleRate.Update(rate, origin)
 	configtelemetry.Report("DD_TRACE_SAMPLE_RATE", rate, origin)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -226,7 +226,7 @@ func loadConfig() *Config {
 	cfg.traceID128BitEnabled = p.GetBool("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", true)
 
 	sampleRate, sampleRateOrigin := p.GetFloatWithValidatorOrigin("DD_TRACE_SAMPLE_RATE", math.NaN(), validateSampleRate)
-	cfg.globalSampleRate = newDynamicConfig("trace_sample_rate", sampleRate, sampleRateOrigin)
+	cfg.globalSampleRate = newDynamicConfig("trace_sample_rate", sampleRate, sampleRateOrigin, equalFloat)
 
 	// Parse feature flags from DD_TRACE_FEATURES as a set
 	cfg.featureFlags = make(map[string]struct{})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -161,7 +161,6 @@ func loadConfig() *Config {
 	cfg.ciVisibilityAgentless = p.GetBool("DD_CIVISIBILITY_AGENTLESS_ENABLED", false)
 	cfg.logDirectory = p.GetString("DD_TRACE_LOG_DIRECTORY", "")
 	cfg.traceRateLimitPerSecond = p.GetFloatWithValidator("DD_TRACE_RATE_LIMIT", DefaultRateLimit, validateRateLimit)
-	cfg.globalSampleRate = newDynamicConfig("trace_sample_rate", p.GetFloatWithValidator("DD_TRACE_SAMPLE_RATE", math.NaN(), validateSampleRate))
 	cfg.debugStack = p.GetBool("DD_TRACE_DEBUG_STACK", true)
 	cfg.retryInterval = p.GetDuration("DD_TRACE_RETRY_INTERVAL", time.Millisecond)
 	cfg.logsOTelEnabled = p.GetBool("DD_LOGS_OTEL_ENABLED", false)
@@ -174,6 +173,9 @@ func loadConfig() *Config {
 	cfg.otlpTraceURL = resolveOTLPTraceURL(cfg.agentURL, p.GetString("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", ""))
 	cfg.otlpHeaders = buildOTLPHeaders(p.GetMap("OTEL_EXPORTER_OTLP_TRACES_HEADERS", nil, internal.OtelTagsDelimeter))
 	cfg.traceID128BitEnabled = p.GetBool("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", true)
+
+	sampleRate, sampleRateOrigin := p.GetFloatWithValidatorOrigin("DD_TRACE_SAMPLE_RATE", math.NaN(), validateSampleRate)
+	cfg.globalSampleRate = newDynamicConfig("trace_sample_rate", sampleRate, sampleRateOrigin)
 
 	// Parse feature flags from DD_TRACE_FEATURES as a set
 	cfg.featureFlags = make(map[string]struct{})
@@ -419,7 +421,7 @@ func (c *Config) GlobalSampleRateConfig() *DynamicConfig[float64] {
 }
 
 func (c *Config) SetGlobalSampleRate(rate float64, origin telemetry.Origin) {
-	c.globalSampleRate.update(rate, origin)
+	c.globalSampleRate.update(rate)
 	configtelemetry.Report("DD_TRACE_SAMPLE_RATE", rate, origin)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -514,7 +514,7 @@ func (c *Config) SetGlobalSampleRate(rate float64, origin telemetry.Origin, prod
 	if c.checkProductConflict("DD_TRACE_SAMPLE_RATE", origin, rate, product...) {
 		return
 	}
-	c.globalSampleRate.update(rate)
+	c.globalSampleRate.setBaseline(rate, origin)
 	configtelemetry.Report("DD_TRACE_SAMPLE_RATE", rate, origin)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -161,7 +161,7 @@ func loadConfig() *Config {
 	cfg.ciVisibilityAgentless = p.GetBool("DD_CIVISIBILITY_AGENTLESS_ENABLED", false)
 	cfg.logDirectory = p.GetString("DD_TRACE_LOG_DIRECTORY", "")
 	cfg.traceRateLimitPerSecond = p.GetFloatWithValidator("DD_TRACE_RATE_LIMIT", DefaultRateLimit, validateRateLimit)
-	cfg.globalSampleRate = NewDynamicConfig("trace_sample_rate", p.GetFloatWithValidator("DD_TRACE_SAMPLE_RATE", math.NaN(), validateSampleRate))
+	cfg.globalSampleRate = newDynamicConfig("trace_sample_rate", p.GetFloatWithValidator("DD_TRACE_SAMPLE_RATE", math.NaN(), validateSampleRate))
 	cfg.debugStack = p.GetBool("DD_TRACE_DEBUG_STACK", true)
 	cfg.retryInterval = p.GetDuration("DD_TRACE_RETRY_INTERVAL", time.Millisecond)
 	cfg.logsOTelEnabled = p.GetBool("DD_LOGS_OTEL_ENABLED", false)
@@ -419,7 +419,7 @@ func (c *Config) GlobalSampleRateConfig() *DynamicConfig[float64] {
 }
 
 func (c *Config) SetGlobalSampleRate(rate float64, origin telemetry.Origin) {
-	c.globalSampleRate.Update(rate, origin)
+	c.globalSampleRate.update(rate, origin)
 	configtelemetry.Report("DD_TRACE_SAMPLE_RATE", rate, origin)
 }
 

--- a/internal/config/dynamic_config.go
+++ b/internal/config/dynamic_config.go
@@ -1,0 +1,102 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+package config
+
+import (
+	"reflect"
+	"sync"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
+)
+
+// DynamicConfig is a thread-safe, RC-aware value store for a single configuration field.
+// It tracks both the current value and the startup baseline (for RC reset).
+// Consumers read via Get().
+type DynamicConfig[T any] struct {
+	mu      sync.RWMutex
+	current T
+	startup T
+	cfgName string
+	origin  telemetry.Origin
+}
+
+// NewDynamicConfig creates a DynamicConfig with the given telemetry name and initial value.
+// Both current and startup are set to val; origin defaults to OriginDefault.
+func NewDynamicConfig[T any](name string, val T) *DynamicConfig[T] {
+	return &DynamicConfig[T]{
+		cfgName: name,
+		current: val,
+		startup: val,
+		origin:  telemetry.OriginDefault,
+	}
+}
+
+// Get returns the current value.
+func (dc *DynamicConfig[T]) Get() T {
+	dc.mu.RLock()
+	defer dc.mu.RUnlock()
+	return dc.current
+}
+
+// Update sets a new value if it differs from the current one.
+// Returns true if the value was changed.
+func (dc *DynamicConfig[T]) Update(val T, origin telemetry.Origin) bool {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	if reflect.DeepEqual(dc.current, val) {
+		return false
+	}
+	dc.current = val
+	dc.origin = origin
+	return true
+}
+
+// Reset restores the startup value. Returns true if the value was changed.
+func (dc *DynamicConfig[T]) Reset() bool {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	if reflect.DeepEqual(dc.current, dc.startup) {
+		return false
+	}
+	dc.current = dc.startup
+	dc.origin = telemetry.OriginDefault
+	return true
+}
+
+// HandleRC processes a remote config update. If val is non-nil, the value is
+// updated; if nil, the field is reset to its startup value.
+// Returns true if the value was changed.
+func (dc *DynamicConfig[T]) HandleRC(val *T) bool {
+	if val != nil {
+		return dc.Update(*val, telemetry.OriginRemoteConfig)
+	}
+	return dc.Reset()
+}
+
+// SetOrigin sets the configuration origin.
+func (dc *DynamicConfig[T]) SetOrigin(origin telemetry.Origin) {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	dc.origin = origin
+}
+
+// Origin returns the current configuration origin.
+func (dc *DynamicConfig[T]) Origin() telemetry.Origin {
+	dc.mu.RLock()
+	defer dc.mu.RUnlock()
+	return dc.origin
+}
+
+// ToTelemetry returns a telemetry snapshot of the current value and origin.
+func (dc *DynamicConfig[T]) ToTelemetry() telemetry.Configuration {
+	dc.mu.RLock()
+	defer dc.mu.RUnlock()
+	return telemetry.Configuration{
+		Name:   dc.cfgName,
+		Value:  dc.current,
+		Origin: dc.origin,
+	}
+}

--- a/internal/config/dynamic_config.go
+++ b/internal/config/dynamic_config.go
@@ -36,19 +36,26 @@ type DynamicConfig[T any] struct {
 	current       T
 	startup       T
 	cfgName       string
-	startupOrigin telemetry.Origin // immutable after construction; used on RC reset
+	startupOrigin telemetry.Origin // used on RC reset; updated by setBaseline
 }
 
 // newDynamicConfig creates a DynamicConfig with the given telemetry name, initial value,
 // and the origin that produced that initial value. The startupOrigin is used when RC
 // resets the field back to its startup value.
 func newDynamicConfig[T any](name string, val T, origin telemetry.Origin) *DynamicConfig[T] {
-	return &DynamicConfig[T]{
-		cfgName:       name,
-		current:       val,
-		startup:       val,
-		startupOrigin: origin,
-	}
+	dc := &DynamicConfig[T]{cfgName: name}
+	dc.setBaseline(val, origin)
+	return dc
+}
+
+// setBaseline sets both the current value and the startup value for a field.
+// The startup value is what the field reverts to when RC is reset or revoked.
+func (dc *DynamicConfig[T]) setBaseline(val T, origin telemetry.Origin) {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	dc.current = val
+	dc.startup = val
+	dc.startupOrigin = origin
 }
 
 // Get returns the current value.
@@ -58,47 +65,30 @@ func (dc *DynamicConfig[T]) Get() T {
 	return dc.current
 }
 
-// update sets a new value if it differs from the current one.
-// Returns true if the value was changed.
-func (dc *DynamicConfig[T]) update(val T) bool {
-	dc.mu.Lock()
-	defer dc.mu.Unlock()
-	if equal(dc.current, val) {
-		return false
-	}
-	dc.current = val
-	return true
-}
-
-// reset restores the startup value. Returns true if the value was changed.
-func (dc *DynamicConfig[T]) reset() bool {
-	dc.mu.Lock()
-	defer dc.mu.Unlock()
-	if equal(dc.current, dc.startup) {
-		return false
-	}
-	dc.current = dc.startup
-	return true
-}
-
 // HandleRC processes a remote config update. If val is non-nil, the value is
 // updated; if nil, the field is reset to its startup value.
 // Reports the new value to telemetry when changed.
 // Returns true if the value was changed.
 func (dc *DynamicConfig[T]) HandleRC(val *T) bool {
+	dc.mu.Lock()
 	var changed bool
 	var origin telemetry.Origin
 	if val != nil {
-		changed = dc.update(*val)
+		if !equal(dc.current, *val) {
+			dc.current = *val
+			changed = true
+		}
 		origin = telemetry.OriginRemoteConfig
 	} else {
-		changed = dc.reset()
+		if !equal(dc.current, dc.startup) {
+			dc.current = dc.startup
+			changed = true
+		}
 		origin = dc.startupOrigin
 	}
+	dc.mu.Unlock()
 	if changed {
-		dc.mu.RLock()
 		configtelemetry.Report(dc.cfgName, dc.current, origin)
-		dc.mu.RUnlock()
 	}
 	return changed
 }

--- a/internal/config/dynamic_config.go
+++ b/internal/config/dynamic_config.go
@@ -7,25 +7,17 @@ package config
 
 import (
 	"math"
-	"reflect"
 	"sync"
 
 	"github.com/DataDog/dd-trace-go/v2/internal/config/configtelemetry"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 )
 
-// equal reports whether a and b are deeply equal, with a special case
-// for float64 NaN (reflect.DeepEqual treats NaN != NaN per IEEE 754,
-// but for config purposes two NaN values are the same "unset" sentinel).
-func equal[T any](a, b T) bool {
-	if reflect.DeepEqual(a, b) {
-		return true
-	}
-	if fa, ok := any(a).(float64); ok {
-		fb, _ := any(b).(float64)
-		return math.IsNaN(fa) && math.IsNaN(fb)
-	}
-	return false
+// equalFloat compares two float64 values, treating NaN as equal to NaN.
+// IEEE 754 defines NaN != NaN, but for config purposes two NaN values
+// represent the same "unset" sentinel.
+func equalFloat(a, b float64) bool {
+	return a == b || (math.IsNaN(a) && math.IsNaN(b))
 }
 
 // DynamicConfig is a thread-safe, RC-aware value store for a single configuration field.
@@ -37,13 +29,14 @@ type DynamicConfig[T any] struct {
 	startup       T
 	cfgName       string
 	startupOrigin telemetry.Origin // used on RC reset; updated by setBaseline
+	equal         func(T, T) bool  // compares values to avoid unnecessary updates
 }
 
 // newDynamicConfig creates a DynamicConfig with the given telemetry name, initial value,
-// and the origin that produced that initial value. The startupOrigin is used when RC
-// resets the field back to its startup value.
-func newDynamicConfig[T any](name string, val T, origin telemetry.Origin) *DynamicConfig[T] {
-	dc := &DynamicConfig[T]{cfgName: name}
+// the origin that produced that initial value, and a comparator used to detect changes.
+// The startupOrigin is used when RC resets the field back to its startup value.
+func newDynamicConfig[T any](name string, val T, origin telemetry.Origin, equal func(T, T) bool) *DynamicConfig[T] {
+	dc := &DynamicConfig[T]{cfgName: name, equal: equal}
 	dc.setBaseline(val, origin)
 	return dc
 }
@@ -75,13 +68,13 @@ func (dc *DynamicConfig[T]) HandleRC(val *T) bool {
 	var changed bool
 	var origin telemetry.Origin
 	if val != nil {
-		if !equal(dc.current, *val) {
+		if !dc.equal(dc.current, *val) {
 			dc.current = *val
 			changed = true
 		}
 		origin = telemetry.OriginRemoteConfig
 	} else {
-		if !equal(dc.current, dc.startup) {
+		if !dc.equal(dc.current, dc.startup) {
 			dc.current = dc.startup
 			changed = true
 		}

--- a/internal/config/dynamic_config.go
+++ b/internal/config/dynamic_config.go
@@ -6,31 +6,48 @@
 package config
 
 import (
+	"math"
 	"reflect"
 	"sync"
 
+	"github.com/DataDog/dd-trace-go/v2/internal/config/configtelemetry"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 )
+
+// equal reports whether a and b are deeply equal, with a special case
+// for float64 NaN (reflect.DeepEqual treats NaN != NaN per IEEE 754,
+// but for config purposes two NaN values are the same "unset" sentinel).
+func equal[T any](a, b T) bool {
+	if reflect.DeepEqual(a, b) {
+		return true
+	}
+	if fa, ok := any(a).(float64); ok {
+		fb, _ := any(b).(float64)
+		return math.IsNaN(fa) && math.IsNaN(fb)
+	}
+	return false
+}
 
 // DynamicConfig is a thread-safe, RC-aware value store for a single configuration field.
 // It tracks both the current value and the startup baseline (for RC reset).
 // Consumers read via Get().
 type DynamicConfig[T any] struct {
-	mu      sync.RWMutex
-	current T
-	startup T
-	cfgName string
-	origin  telemetry.Origin
+	mu            sync.RWMutex
+	current       T
+	startup       T
+	cfgName       string
+	startupOrigin telemetry.Origin // immutable after construction; used on RC reset
 }
 
-// newDynamicConfig creates a DynamicConfig with the given telemetry name and initial value.
-// Both current and startup are set to val; origin defaults to OriginDefault.
-func newDynamicConfig[T any](name string, val T) *DynamicConfig[T] {
+// newDynamicConfig creates a DynamicConfig with the given telemetry name, initial value,
+// and the origin that produced that initial value. The startupOrigin is used when RC
+// resets the field back to its startup value.
+func newDynamicConfig[T any](name string, val T, origin telemetry.Origin) *DynamicConfig[T] {
 	return &DynamicConfig[T]{
-		cfgName: name,
-		current: val,
-		startup: val,
-		origin:  telemetry.OriginDefault,
+		cfgName:       name,
+		current:       val,
+		startup:       val,
+		startupOrigin: origin,
 	}
 }
 
@@ -43,14 +60,13 @@ func (dc *DynamicConfig[T]) Get() T {
 
 // update sets a new value if it differs from the current one.
 // Returns true if the value was changed.
-func (dc *DynamicConfig[T]) update(val T, origin telemetry.Origin) bool {
+func (dc *DynamicConfig[T]) update(val T) bool {
 	dc.mu.Lock()
 	defer dc.mu.Unlock()
-	if reflect.DeepEqual(dc.current, val) {
+	if equal(dc.current, val) {
 		return false
 	}
 	dc.current = val
-	dc.origin = origin
 	return true
 }
 
@@ -58,45 +74,31 @@ func (dc *DynamicConfig[T]) update(val T, origin telemetry.Origin) bool {
 func (dc *DynamicConfig[T]) reset() bool {
 	dc.mu.Lock()
 	defer dc.mu.Unlock()
-	if reflect.DeepEqual(dc.current, dc.startup) {
+	if equal(dc.current, dc.startup) {
 		return false
 	}
 	dc.current = dc.startup
-	dc.origin = telemetry.OriginDefault
 	return true
 }
 
 // HandleRC processes a remote config update. If val is non-nil, the value is
 // updated; if nil, the field is reset to its startup value.
+// Reports the new value to telemetry when changed.
 // Returns true if the value was changed.
 func (dc *DynamicConfig[T]) HandleRC(val *T) bool {
+	var changed bool
+	var origin telemetry.Origin
 	if val != nil {
-		return dc.update(*val, telemetry.OriginRemoteConfig)
+		changed = dc.update(*val)
+		origin = telemetry.OriginRemoteConfig
+	} else {
+		changed = dc.reset()
+		origin = dc.startupOrigin
 	}
-	return dc.reset()
-}
-
-// SetOrigin sets the configuration origin.
-func (dc *DynamicConfig[T]) SetOrigin(origin telemetry.Origin) {
-	dc.mu.Lock()
-	defer dc.mu.Unlock()
-	dc.origin = origin
-}
-
-// Origin returns the current configuration origin.
-func (dc *DynamicConfig[T]) Origin() telemetry.Origin {
-	dc.mu.RLock()
-	defer dc.mu.RUnlock()
-	return dc.origin
-}
-
-// ToTelemetry returns a telemetry snapshot of the current value and origin.
-func (dc *DynamicConfig[T]) ToTelemetry() telemetry.Configuration {
-	dc.mu.RLock()
-	defer dc.mu.RUnlock()
-	return telemetry.Configuration{
-		Name:   dc.cfgName,
-		Value:  dc.current,
-		Origin: dc.origin,
+	if changed {
+		dc.mu.RLock()
+		configtelemetry.Report(dc.cfgName, dc.current, origin)
+		dc.mu.RUnlock()
 	}
+	return changed
 }

--- a/internal/config/dynamic_config.go
+++ b/internal/config/dynamic_config.go
@@ -23,9 +23,9 @@ type DynamicConfig[T any] struct {
 	origin  telemetry.Origin
 }
 
-// NewDynamicConfig creates a DynamicConfig with the given telemetry name and initial value.
+// newDynamicConfig creates a DynamicConfig with the given telemetry name and initial value.
 // Both current and startup are set to val; origin defaults to OriginDefault.
-func NewDynamicConfig[T any](name string, val T) *DynamicConfig[T] {
+func newDynamicConfig[T any](name string, val T) *DynamicConfig[T] {
 	return &DynamicConfig[T]{
 		cfgName: name,
 		current: val,
@@ -41,9 +41,9 @@ func (dc *DynamicConfig[T]) Get() T {
 	return dc.current
 }
 
-// Update sets a new value if it differs from the current one.
+// update sets a new value if it differs from the current one.
 // Returns true if the value was changed.
-func (dc *DynamicConfig[T]) Update(val T, origin telemetry.Origin) bool {
+func (dc *DynamicConfig[T]) update(val T, origin telemetry.Origin) bool {
 	dc.mu.Lock()
 	defer dc.mu.Unlock()
 	if reflect.DeepEqual(dc.current, val) {
@@ -54,8 +54,8 @@ func (dc *DynamicConfig[T]) Update(val T, origin telemetry.Origin) bool {
 	return true
 }
 
-// Reset restores the startup value. Returns true if the value was changed.
-func (dc *DynamicConfig[T]) Reset() bool {
+// reset restores the startup value. Returns true if the value was changed.
+func (dc *DynamicConfig[T]) reset() bool {
 	dc.mu.Lock()
 	defer dc.mu.Unlock()
 	if reflect.DeepEqual(dc.current, dc.startup) {
@@ -71,9 +71,9 @@ func (dc *DynamicConfig[T]) Reset() bool {
 // Returns true if the value was changed.
 func (dc *DynamicConfig[T]) HandleRC(val *T) bool {
 	if val != nil {
-		return dc.Update(*val, telemetry.OriginRemoteConfig)
+		return dc.update(*val, telemetry.OriginRemoteConfig)
 	}
-	return dc.Reset()
+	return dc.reset()
 }
 
 // SetOrigin sets the configuration origin.

--- a/internal/config/dynamic_config.go
+++ b/internal/config/dynamic_config.go
@@ -71,6 +71,7 @@ func (dc *DynamicConfig[T]) Get() T {
 // Returns true if the value was changed.
 func (dc *DynamicConfig[T]) HandleRC(val *T) bool {
 	dc.mu.Lock()
+	defer dc.mu.Unlock()
 	var changed bool
 	var origin telemetry.Origin
 	if val != nil {
@@ -86,7 +87,6 @@ func (dc *DynamicConfig[T]) HandleRC(val *T) bool {
 		}
 		origin = dc.startupOrigin
 	}
-	dc.mu.Unlock()
 	if changed {
 		configtelemetry.Report(dc.cfgName, dc.current, origin)
 	}

--- a/internal/config/dynamic_config_test.go
+++ b/internal/config/dynamic_config_test.go
@@ -1,0 +1,103 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+package config
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDynamicConfig(t *testing.T) {
+	t.Run("get returns initial value", func(t *testing.T) {
+		dc := NewDynamicConfig("test", 42)
+		assert.Equal(t, 42, dc.Get())
+		assert.Equal(t, telemetry.OriginDefault, dc.Origin())
+	})
+
+	t.Run("update changes value and origin", func(t *testing.T) {
+		dc := NewDynamicConfig("test", "initial")
+		changed := dc.Update("updated", telemetry.OriginEnvVar)
+		assert.True(t, changed)
+		assert.Equal(t, "updated", dc.Get())
+		assert.Equal(t, telemetry.OriginEnvVar, dc.Origin())
+	})
+
+	t.Run("update with same value is a no-op", func(t *testing.T) {
+		dc := NewDynamicConfig("test", 3.14)
+		changed := dc.Update(3.14, telemetry.OriginEnvVar)
+		assert.False(t, changed)
+		assert.Equal(t, telemetry.OriginDefault, dc.Origin(), "origin should not change on no-op update")
+	})
+
+	t.Run("reset restores startup value", func(t *testing.T) {
+		dc := NewDynamicConfig("test", "startup")
+		dc.Update("modified", telemetry.OriginRemoteConfig)
+		assert.Equal(t, "modified", dc.Get())
+
+		changed := dc.Reset()
+		assert.True(t, changed)
+		assert.Equal(t, "startup", dc.Get())
+		assert.Equal(t, telemetry.OriginDefault, dc.Origin())
+	})
+
+	t.Run("reset when already at startup is a no-op", func(t *testing.T) {
+		dc := NewDynamicConfig("test", 100)
+		changed := dc.Reset()
+		assert.False(t, changed)
+	})
+
+	t.Run("handleRC with non-nil updates value", func(t *testing.T) {
+		dc := NewDynamicConfig("test", 1.0)
+		rate := 0.5
+		changed := dc.HandleRC(&rate)
+		assert.True(t, changed)
+		assert.Equal(t, 0.5, dc.Get())
+		assert.Equal(t, telemetry.OriginRemoteConfig, dc.Origin())
+	})
+
+	t.Run("handleRC with nil resets to startup", func(t *testing.T) {
+		dc := NewDynamicConfig("test", 1.0)
+		rate := 0.5
+		dc.HandleRC(&rate)
+		assert.Equal(t, 0.5, dc.Get())
+
+		changed := dc.HandleRC(nil)
+		assert.True(t, changed)
+		assert.Equal(t, 1.0, dc.Get())
+		assert.Equal(t, telemetry.OriginDefault, dc.Origin())
+	})
+
+	t.Run("toTelemetry returns snapshot", func(t *testing.T) {
+		dc := NewDynamicConfig("my_field", "hello")
+		dc.Update("world", telemetry.OriginCode)
+
+		cfg := dc.ToTelemetry()
+		assert.Equal(t, "my_field", cfg.Name)
+		assert.Equal(t, "world", cfg.Value)
+		assert.Equal(t, telemetry.OriginCode, cfg.Origin)
+	})
+
+	t.Run("concurrent access is safe", func(t *testing.T) {
+		dc := NewDynamicConfig("test", 0)
+		var wg sync.WaitGroup
+
+		for i := 0; i < 100; i++ {
+			wg.Add(2)
+			go func(v int) {
+				defer wg.Done()
+				dc.Update(v, telemetry.OriginCode)
+			}(i)
+			go func() {
+				defer wg.Done()
+				_ = dc.Get()
+			}()
+		}
+		wg.Wait()
+	})
+}

--- a/internal/config/dynamic_config_test.go
+++ b/internal/config/dynamic_config_test.go
@@ -6,63 +6,60 @@
 package config
 
 import (
+	"math"
 	"sync"
 	"testing"
 
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
+	"github.com/DataDog/dd-trace-go/v2/internal/telemetry/telemetrytest"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDynamicConfig(t *testing.T) {
 	t.Run("get returns initial value", func(t *testing.T) {
-		dc := newDynamicConfig("test", 42)
+		dc := newDynamicConfig("test", 42, telemetry.OriginDefault)
 		assert.Equal(t, 42, dc.Get())
-		assert.Equal(t, telemetry.OriginDefault, dc.Origin())
 	})
 
-	t.Run("update changes value and origin", func(t *testing.T) {
-		dc := newDynamicConfig("test", "initial")
-		changed := dc.update("updated", telemetry.OriginEnvVar)
+	t.Run("update changes value", func(t *testing.T) {
+		dc := newDynamicConfig("test", "initial", telemetry.OriginDefault)
+		changed := dc.update("updated")
 		assert.True(t, changed)
 		assert.Equal(t, "updated", dc.Get())
-		assert.Equal(t, telemetry.OriginEnvVar, dc.Origin())
 	})
 
 	t.Run("update with same value is a no-op", func(t *testing.T) {
-		dc := newDynamicConfig("test", 3.14)
-		changed := dc.update(3.14, telemetry.OriginEnvVar)
+		dc := newDynamicConfig("test", 3.14, telemetry.OriginDefault)
+		changed := dc.update(3.14)
 		assert.False(t, changed)
-		assert.Equal(t, telemetry.OriginDefault, dc.Origin(), "origin should not change on no-op update")
 	})
 
 	t.Run("reset restores startup value", func(t *testing.T) {
-		dc := newDynamicConfig("test", "startup")
-		dc.update("modified", telemetry.OriginRemoteConfig)
+		dc := newDynamicConfig("test", "startup", telemetry.OriginDefault)
+		dc.update("modified")
 		assert.Equal(t, "modified", dc.Get())
 
 		changed := dc.reset()
 		assert.True(t, changed)
 		assert.Equal(t, "startup", dc.Get())
-		assert.Equal(t, telemetry.OriginDefault, dc.Origin())
 	})
 
 	t.Run("reset when already at startup is a no-op", func(t *testing.T) {
-		dc := newDynamicConfig("test", 100)
+		dc := newDynamicConfig("test", 100, telemetry.OriginDefault)
 		changed := dc.reset()
 		assert.False(t, changed)
 	})
 
 	t.Run("handleRC with non-nil updates value", func(t *testing.T) {
-		dc := newDynamicConfig("test", 1.0)
+		dc := newDynamicConfig("test", 1.0, telemetry.OriginDefault)
 		rate := 0.5
 		changed := dc.HandleRC(&rate)
 		assert.True(t, changed)
 		assert.Equal(t, 0.5, dc.Get())
-		assert.Equal(t, telemetry.OriginRemoteConfig, dc.Origin())
 	})
 
 	t.Run("handleRC with nil resets to startup", func(t *testing.T) {
-		dc := newDynamicConfig("test", 1.0)
+		dc := newDynamicConfig("test", 1.0, telemetry.OriginDefault)
 		rate := 0.5
 		dc.HandleRC(&rate)
 		assert.Equal(t, 0.5, dc.Get())
@@ -70,28 +67,78 @@ func TestDynamicConfig(t *testing.T) {
 		changed := dc.HandleRC(nil)
 		assert.True(t, changed)
 		assert.Equal(t, 1.0, dc.Get())
-		assert.Equal(t, telemetry.OriginDefault, dc.Origin())
 	})
 
-	t.Run("toTelemetry returns snapshot", func(t *testing.T) {
-		dc := newDynamicConfig("my_field", "hello")
-		dc.update("world", telemetry.OriginCode)
+	t.Run("NaN startup is treated as equal on reset", func(t *testing.T) {
+		dc := newDynamicConfig("test", math.NaN(), telemetry.OriginDefault)
+		changed := dc.reset()
+		assert.False(t, changed, "NaN→NaN reset should be a no-op")
+	})
 
-		cfg := dc.ToTelemetry()
-		assert.Equal(t, "my_field", cfg.Name)
-		assert.Equal(t, "world", cfg.Value)
-		assert.Equal(t, telemetry.OriginCode, cfg.Origin)
+	t.Run("NaN update is treated as equal", func(t *testing.T) {
+		dc := newDynamicConfig("test", math.NaN(), telemetry.OriginDefault)
+		changed := dc.update(math.NaN())
+		assert.False(t, changed, "NaN→NaN update should be a no-op")
+	})
+
+	t.Run("handleRC update reports OriginRemoteConfig", func(t *testing.T) {
+		client := new(telemetrytest.RecordClient)
+		defer telemetry.MockClient(client)()
+
+		dc := newDynamicConfig("my_field", 1.0, telemetry.OriginEnvVar)
+		rate := 0.5
+		dc.HandleRC(&rate)
+
+		assertTelemetryReport(t, client.Configuration, "my_field", 0.5, telemetry.OriginRemoteConfig)
+	})
+
+	t.Run("handleRC reset reports startupOrigin=OriginEnvVar", func(t *testing.T) {
+		client := new(telemetrytest.RecordClient)
+		defer telemetry.MockClient(client)()
+
+		dc := newDynamicConfig("my_field", 1.0, telemetry.OriginEnvVar)
+		rate := 0.5
+		dc.HandleRC(&rate)
+		client.Configuration = nil // clear so we only see the reset report
+
+		dc.HandleRC(nil)
+
+		assertTelemetryReport(t, client.Configuration, "my_field", 1.0, telemetry.OriginEnvVar)
+	})
+
+	t.Run("handleRC reset reports startupOrigin=OriginDefault", func(t *testing.T) {
+		client := new(telemetrytest.RecordClient)
+		defer telemetry.MockClient(client)()
+
+		dc := newDynamicConfig("my_field", 1.0, telemetry.OriginDefault)
+		rate := 0.5
+		dc.HandleRC(&rate)
+		client.Configuration = nil
+
+		dc.HandleRC(nil)
+
+		assertTelemetryReport(t, client.Configuration, "my_field", 1.0, telemetry.OriginDefault)
+	})
+
+	t.Run("handleRC no-op reset emits no telemetry", func(t *testing.T) {
+		client := new(telemetrytest.RecordClient)
+		defer telemetry.MockClient(client)()
+
+		dc := newDynamicConfig("my_field", 1.0, telemetry.OriginEnvVar)
+		dc.HandleRC(nil)
+
+		assert.Empty(t, client.Configuration)
 	})
 
 	t.Run("concurrent access is safe", func(t *testing.T) {
-		dc := newDynamicConfig("test", 0)
+		dc := newDynamicConfig("test", 0, telemetry.OriginDefault)
 		var wg sync.WaitGroup
 
 		for i := 0; i < 100; i++ {
 			wg.Add(2)
 			go func(v int) {
 				defer wg.Done()
-				dc.update(v, telemetry.OriginCode)
+				dc.update(v)
 			}(i)
 			go func() {
 				defer wg.Done()
@@ -100,4 +147,14 @@ func TestDynamicConfig(t *testing.T) {
 		}
 		wg.Wait()
 	})
+}
+
+func assertTelemetryReport(t *testing.T, cfgs []telemetry.Configuration, name string, value any, origin telemetry.Origin) {
+	t.Helper()
+	for _, c := range cfgs {
+		if c.Name == name && c.Value == value && c.Origin == origin {
+			return
+		}
+	}
+	t.Errorf("expected telemetry report Name=%q Value=%v Origin=%v not found in %v", name, value, origin, cfgs)
 }

--- a/internal/config/dynamic_config_test.go
+++ b/internal/config/dynamic_config_test.go
@@ -67,6 +67,18 @@ func TestDynamicConfig(t *testing.T) {
 		assert.False(t, changed, "NaN→NaN update should be a no-op")
 	})
 
+	t.Run("NaN full cycle: update then reset", func(t *testing.T) {
+		dc := newDynamicConfig("test", math.NaN(), telemetry.OriginDefault, equalFloat)
+		rate := 0.5
+		changed := dc.HandleRC(&rate)
+		assert.True(t, changed)
+		assert.Equal(t, 0.5, dc.Get())
+
+		changed = dc.HandleRC(nil)
+		assert.True(t, changed)
+		assert.True(t, math.IsNaN(dc.Get()), "should reset back to NaN")
+	})
+
 	t.Run("handleRC update reports OriginRemoteConfig", func(t *testing.T) {
 		client := new(telemetrytest.RecordClient)
 		defer telemetry.MockClient(client)()

--- a/internal/config/dynamic_config_test.go
+++ b/internal/config/dynamic_config_test.go
@@ -15,45 +15,45 @@ import (
 
 func TestDynamicConfig(t *testing.T) {
 	t.Run("get returns initial value", func(t *testing.T) {
-		dc := NewDynamicConfig("test", 42)
+		dc := newDynamicConfig("test", 42)
 		assert.Equal(t, 42, dc.Get())
 		assert.Equal(t, telemetry.OriginDefault, dc.Origin())
 	})
 
 	t.Run("update changes value and origin", func(t *testing.T) {
-		dc := NewDynamicConfig("test", "initial")
-		changed := dc.Update("updated", telemetry.OriginEnvVar)
+		dc := newDynamicConfig("test", "initial")
+		changed := dc.update("updated", telemetry.OriginEnvVar)
 		assert.True(t, changed)
 		assert.Equal(t, "updated", dc.Get())
 		assert.Equal(t, telemetry.OriginEnvVar, dc.Origin())
 	})
 
 	t.Run("update with same value is a no-op", func(t *testing.T) {
-		dc := NewDynamicConfig("test", 3.14)
-		changed := dc.Update(3.14, telemetry.OriginEnvVar)
+		dc := newDynamicConfig("test", 3.14)
+		changed := dc.update(3.14, telemetry.OriginEnvVar)
 		assert.False(t, changed)
 		assert.Equal(t, telemetry.OriginDefault, dc.Origin(), "origin should not change on no-op update")
 	})
 
 	t.Run("reset restores startup value", func(t *testing.T) {
-		dc := NewDynamicConfig("test", "startup")
-		dc.Update("modified", telemetry.OriginRemoteConfig)
+		dc := newDynamicConfig("test", "startup")
+		dc.update("modified", telemetry.OriginRemoteConfig)
 		assert.Equal(t, "modified", dc.Get())
 
-		changed := dc.Reset()
+		changed := dc.reset()
 		assert.True(t, changed)
 		assert.Equal(t, "startup", dc.Get())
 		assert.Equal(t, telemetry.OriginDefault, dc.Origin())
 	})
 
 	t.Run("reset when already at startup is a no-op", func(t *testing.T) {
-		dc := NewDynamicConfig("test", 100)
-		changed := dc.Reset()
+		dc := newDynamicConfig("test", 100)
+		changed := dc.reset()
 		assert.False(t, changed)
 	})
 
 	t.Run("handleRC with non-nil updates value", func(t *testing.T) {
-		dc := NewDynamicConfig("test", 1.0)
+		dc := newDynamicConfig("test", 1.0)
 		rate := 0.5
 		changed := dc.HandleRC(&rate)
 		assert.True(t, changed)
@@ -62,7 +62,7 @@ func TestDynamicConfig(t *testing.T) {
 	})
 
 	t.Run("handleRC with nil resets to startup", func(t *testing.T) {
-		dc := NewDynamicConfig("test", 1.0)
+		dc := newDynamicConfig("test", 1.0)
 		rate := 0.5
 		dc.HandleRC(&rate)
 		assert.Equal(t, 0.5, dc.Get())
@@ -74,8 +74,8 @@ func TestDynamicConfig(t *testing.T) {
 	})
 
 	t.Run("toTelemetry returns snapshot", func(t *testing.T) {
-		dc := NewDynamicConfig("my_field", "hello")
-		dc.Update("world", telemetry.OriginCode)
+		dc := newDynamicConfig("my_field", "hello")
+		dc.update("world", telemetry.OriginCode)
 
 		cfg := dc.ToTelemetry()
 		assert.Equal(t, "my_field", cfg.Name)
@@ -84,14 +84,14 @@ func TestDynamicConfig(t *testing.T) {
 	})
 
 	t.Run("concurrent access is safe", func(t *testing.T) {
-		dc := NewDynamicConfig("test", 0)
+		dc := newDynamicConfig("test", 0)
 		var wg sync.WaitGroup
 
 		for i := 0; i < 100; i++ {
 			wg.Add(2)
 			go func(v int) {
 				defer wg.Done()
-				dc.Update(v, telemetry.OriginCode)
+				dc.update(v, telemetry.OriginCode)
 			}(i)
 			go func() {
 				defer wg.Done()

--- a/internal/config/dynamic_config_test.go
+++ b/internal/config/dynamic_config_test.go
@@ -22,35 +22,6 @@ func TestDynamicConfig(t *testing.T) {
 		assert.Equal(t, 42, dc.Get())
 	})
 
-	t.Run("update changes value", func(t *testing.T) {
-		dc := newDynamicConfig("test", "initial", telemetry.OriginDefault)
-		changed := dc.update("updated")
-		assert.True(t, changed)
-		assert.Equal(t, "updated", dc.Get())
-	})
-
-	t.Run("update with same value is a no-op", func(t *testing.T) {
-		dc := newDynamicConfig("test", 3.14, telemetry.OriginDefault)
-		changed := dc.update(3.14)
-		assert.False(t, changed)
-	})
-
-	t.Run("reset restores startup value", func(t *testing.T) {
-		dc := newDynamicConfig("test", "startup", telemetry.OriginDefault)
-		dc.update("modified")
-		assert.Equal(t, "modified", dc.Get())
-
-		changed := dc.reset()
-		assert.True(t, changed)
-		assert.Equal(t, "startup", dc.Get())
-	})
-
-	t.Run("reset when already at startup is a no-op", func(t *testing.T) {
-		dc := newDynamicConfig("test", 100, telemetry.OriginDefault)
-		changed := dc.reset()
-		assert.False(t, changed)
-	})
-
 	t.Run("handleRC with non-nil updates value", func(t *testing.T) {
 		dc := newDynamicConfig("test", 1.0, telemetry.OriginDefault)
 		rate := 0.5
@@ -70,15 +41,29 @@ func TestDynamicConfig(t *testing.T) {
 		assert.Equal(t, 1.0, dc.Get())
 	})
 
+	t.Run("handleRC with same value is a no-op", func(t *testing.T) {
+		dc := newDynamicConfig("test", 3.14, telemetry.OriginDefault)
+		same := 3.14
+		changed := dc.HandleRC(&same)
+		assert.False(t, changed)
+	})
+
+	t.Run("handleRC reset when already at startup is a no-op", func(t *testing.T) {
+		dc := newDynamicConfig("test", 100, telemetry.OriginDefault)
+		changed := dc.HandleRC(nil)
+		assert.False(t, changed)
+	})
+
 	t.Run("NaN startup is treated as equal on reset", func(t *testing.T) {
 		dc := newDynamicConfig("test", math.NaN(), telemetry.OriginDefault)
-		changed := dc.reset()
+		changed := dc.HandleRC(nil)
 		assert.False(t, changed, "NaN→NaN reset should be a no-op")
 	})
 
 	t.Run("NaN update is treated as equal", func(t *testing.T) {
 		dc := newDynamicConfig("test", math.NaN(), telemetry.OriginDefault)
-		changed := dc.update(math.NaN())
+		nan := math.NaN()
+		changed := dc.HandleRC(&nan)
 		assert.False(t, changed, "NaN→NaN update should be a no-op")
 	})
 
@@ -131,15 +116,49 @@ func TestDynamicConfig(t *testing.T) {
 		assert.Empty(t, client.Configuration)
 	})
 
+	t.Run("setBaseline updates RC reset target", func(t *testing.T) {
+		// Simulates: env var sets NaN, then programmatic override sets 1.0,
+		// then RC pushes 0.5, then RC resets. Should reset to 1.0 (the
+		// programmatic baseline), not NaN (the original env var value).
+		dc := newDynamicConfig("test", math.NaN(), telemetry.OriginDefault)
+		dc.setBaseline(1.0, telemetry.OriginCode)
+
+		rate := 0.5
+		dc.HandleRC(&rate)
+		assert.Equal(t, 0.5, dc.Get())
+
+		dc.HandleRC(nil)
+		assert.Equal(t, 1.0, dc.Get())
+	})
+
+	t.Run("setBaseline updates startupOrigin for telemetry", func(t *testing.T) {
+		client := new(telemetrytest.RecordClient)
+		defer telemetry.MockClient(client)()
+
+		dc := newDynamicConfig("my_field", math.NaN(), telemetry.OriginDefault)
+		dc.setBaseline(1.0, telemetry.OriginCode)
+
+		rate := 0.5
+		dc.HandleRC(&rate)
+		client.Configuration = nil
+
+		dc.HandleRC(nil)
+		assertTelemetryReport(t, client.Configuration, "my_field", 1.0, telemetry.OriginCode)
+	})
+
 	t.Run("concurrent access is safe", func(t *testing.T) {
 		dc := newDynamicConfig("test", 0, telemetry.OriginDefault)
 		var wg sync.WaitGroup
 
 		for i := range 100 {
-			wg.Add(2)
+			wg.Add(3)
 			go func(v int) {
 				defer wg.Done()
-				dc.update(v)
+				dc.HandleRC(&v)
+			}(i)
+			go func(v int) {
+				defer wg.Done()
+				dc.setBaseline(v, telemetry.OriginCode)
 			}(i)
 			go func() {
 				defer wg.Done()

--- a/internal/config/dynamic_config_test.go
+++ b/internal/config/dynamic_config_test.go
@@ -18,12 +18,12 @@ import (
 
 func TestDynamicConfig(t *testing.T) {
 	t.Run("get returns initial value", func(t *testing.T) {
-		dc := newDynamicConfig("test", 42, telemetry.OriginDefault)
+		dc := newDynamicConfig("test", 42, telemetry.OriginDefault, func(a, b int) bool { return a == b })
 		assert.Equal(t, 42, dc.Get())
 	})
 
 	t.Run("handleRC with non-nil updates value", func(t *testing.T) {
-		dc := newDynamicConfig("test", 1.0, telemetry.OriginDefault)
+		dc := newDynamicConfig("test", 1.0, telemetry.OriginDefault, equalFloat)
 		rate := 0.5
 		changed := dc.HandleRC(&rate)
 		assert.True(t, changed)
@@ -31,7 +31,7 @@ func TestDynamicConfig(t *testing.T) {
 	})
 
 	t.Run("handleRC with nil resets to startup", func(t *testing.T) {
-		dc := newDynamicConfig("test", 1.0, telemetry.OriginDefault)
+		dc := newDynamicConfig("test", 1.0, telemetry.OriginDefault, equalFloat)
 		rate := 0.5
 		dc.HandleRC(&rate)
 		assert.Equal(t, 0.5, dc.Get())
@@ -42,26 +42,26 @@ func TestDynamicConfig(t *testing.T) {
 	})
 
 	t.Run("handleRC with same value is a no-op", func(t *testing.T) {
-		dc := newDynamicConfig("test", 3.14, telemetry.OriginDefault)
+		dc := newDynamicConfig("test", 3.14, telemetry.OriginDefault, equalFloat)
 		same := 3.14
 		changed := dc.HandleRC(&same)
 		assert.False(t, changed)
 	})
 
 	t.Run("handleRC reset when already at startup is a no-op", func(t *testing.T) {
-		dc := newDynamicConfig("test", 100, telemetry.OriginDefault)
+		dc := newDynamicConfig("test", 100, telemetry.OriginDefault, func(a, b int) bool { return a == b })
 		changed := dc.HandleRC(nil)
 		assert.False(t, changed)
 	})
 
 	t.Run("NaN startup is treated as equal on reset", func(t *testing.T) {
-		dc := newDynamicConfig("test", math.NaN(), telemetry.OriginDefault)
+		dc := newDynamicConfig("test", math.NaN(), telemetry.OriginDefault, equalFloat)
 		changed := dc.HandleRC(nil)
 		assert.False(t, changed, "NaN→NaN reset should be a no-op")
 	})
 
 	t.Run("NaN update is treated as equal", func(t *testing.T) {
-		dc := newDynamicConfig("test", math.NaN(), telemetry.OriginDefault)
+		dc := newDynamicConfig("test", math.NaN(), telemetry.OriginDefault, equalFloat)
 		nan := math.NaN()
 		changed := dc.HandleRC(&nan)
 		assert.False(t, changed, "NaN→NaN update should be a no-op")
@@ -71,7 +71,7 @@ func TestDynamicConfig(t *testing.T) {
 		client := new(telemetrytest.RecordClient)
 		defer telemetry.MockClient(client)()
 
-		dc := newDynamicConfig("my_field", 1.0, telemetry.OriginEnvVar)
+		dc := newDynamicConfig("my_field", 1.0, telemetry.OriginEnvVar, equalFloat)
 		rate := 0.5
 		dc.HandleRC(&rate)
 
@@ -82,7 +82,7 @@ func TestDynamicConfig(t *testing.T) {
 		client := new(telemetrytest.RecordClient)
 		defer telemetry.MockClient(client)()
 
-		dc := newDynamicConfig("my_field", 1.0, telemetry.OriginEnvVar)
+		dc := newDynamicConfig("my_field", 1.0, telemetry.OriginEnvVar, equalFloat)
 		rate := 0.5
 		dc.HandleRC(&rate)
 		client.Configuration = nil // clear so we only see the reset report
@@ -96,7 +96,7 @@ func TestDynamicConfig(t *testing.T) {
 		client := new(telemetrytest.RecordClient)
 		defer telemetry.MockClient(client)()
 
-		dc := newDynamicConfig("my_field", 1.0, telemetry.OriginDefault)
+		dc := newDynamicConfig("my_field", 1.0, telemetry.OriginDefault, equalFloat)
 		rate := 0.5
 		dc.HandleRC(&rate)
 		client.Configuration = nil
@@ -110,7 +110,7 @@ func TestDynamicConfig(t *testing.T) {
 		client := new(telemetrytest.RecordClient)
 		defer telemetry.MockClient(client)()
 
-		dc := newDynamicConfig("my_field", 1.0, telemetry.OriginEnvVar)
+		dc := newDynamicConfig("my_field", 1.0, telemetry.OriginEnvVar, equalFloat)
 		dc.HandleRC(nil)
 
 		assert.Empty(t, client.Configuration)
@@ -120,7 +120,7 @@ func TestDynamicConfig(t *testing.T) {
 		// Simulates: env var sets NaN, then programmatic override sets 1.0,
 		// then RC pushes 0.5, then RC resets. Should reset to 1.0 (the
 		// programmatic baseline), not NaN (the original env var value).
-		dc := newDynamicConfig("test", math.NaN(), telemetry.OriginDefault)
+		dc := newDynamicConfig("test", math.NaN(), telemetry.OriginDefault, equalFloat)
 		dc.setBaseline(1.0, telemetry.OriginCode)
 
 		rate := 0.5
@@ -135,7 +135,7 @@ func TestDynamicConfig(t *testing.T) {
 		client := new(telemetrytest.RecordClient)
 		defer telemetry.MockClient(client)()
 
-		dc := newDynamicConfig("my_field", math.NaN(), telemetry.OriginDefault)
+		dc := newDynamicConfig("my_field", math.NaN(), telemetry.OriginDefault, equalFloat)
 		dc.setBaseline(1.0, telemetry.OriginCode)
 
 		rate := 0.5
@@ -147,7 +147,7 @@ func TestDynamicConfig(t *testing.T) {
 	})
 
 	t.Run("concurrent access is safe", func(t *testing.T) {
-		dc := newDynamicConfig("test", 0, telemetry.OriginDefault)
+		dc := newDynamicConfig("test", 0, telemetry.OriginDefault, func(a, b int) bool { return a == b })
 		var wg sync.WaitGroup
 
 		for i := range 100 {

--- a/internal/config/dynamic_config_test.go
+++ b/internal/config/dynamic_config_test.go
@@ -10,9 +10,10 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry/telemetrytest"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDynamicConfig(t *testing.T) {
@@ -134,7 +135,7 @@ func TestDynamicConfig(t *testing.T) {
 		dc := newDynamicConfig("test", 0, telemetry.OriginDefault)
 		var wg sync.WaitGroup
 
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			wg.Add(2)
 			go func(v int) {
 				defer wg.Done()

--- a/internal/config/provider/provider.go
+++ b/internal/config/provider/provider.go
@@ -150,16 +150,8 @@ func (p *Provider) GetFloat(key string, def float64) float64 {
 }
 
 func (p *Provider) GetFloatWithValidator(key string, def float64, validate func(float64) bool) float64 {
-	return get(p, key, def, func(v string) (float64, bool) {
-		floatVal, err := strconv.ParseFloat(v, 64)
-		if err == nil {
-			if validate != nil && !validate(floatVal) {
-				return 0, false
-			}
-			return floatVal, true
-		}
-		return 0, false
-	})
+	v, _ := p.GetFloatWithValidatorOrigin(key, def, validate)
+	return v
 }
 
 // GetFloatWithValidatorOrigin is like GetFloatWithValidator but also returns the

--- a/internal/config/provider/provider.go
+++ b/internal/config/provider/provider.go
@@ -53,7 +53,14 @@ func New() *Provider {
 // overwrite lower-priority ones, reports telemetry for every source that has a value,
 // and returns the highest-priority successfully-parsed value, or def if none parse.
 func get[T any](p *Provider, key string, def T, parse func(string) (T, bool)) T {
+	v, _ := getWithOrigin(p, key, def, parse)
+	return v
+}
+
+// getWithOrigin is like get but also returns the origin of the winning source.
+func getWithOrigin[T any](p *Provider, key string, def T, parse func(string) (T, bool)) (T, telemetry.Origin) {
 	var final *T
+	var winningOrigin telemetry.Origin
 	for i := len(p.sources) - 1; i >= 0; i-- {
 		source := p.sources[i]
 		v := source.get(key)
@@ -65,14 +72,15 @@ func get[T any](p *Provider, key string, def T, parse func(string) (T, bool)) T 
 			configtelemetry.ReportWithID(key, v, source.origin(), id)
 			if parsed, ok := parse(v); ok {
 				final = &parsed
+				winningOrigin = source.origin()
 			}
 		}
 	}
 	configtelemetry.ReportDefault(key, def)
 	if final != nil {
-		return *final
+		return *final, winningOrigin
 	}
-	return def
+	return def, telemetry.OriginDefault
 }
 
 func (p *Provider) GetString(key string, def string) string {
@@ -143,6 +151,22 @@ func (p *Provider) GetFloat(key string, def float64) float64 {
 
 func (p *Provider) GetFloatWithValidator(key string, def float64, validate func(float64) bool) float64 {
 	return get(p, key, def, func(v string) (float64, bool) {
+		floatVal, err := strconv.ParseFloat(v, 64)
+		if err == nil {
+			if validate != nil && !validate(floatVal) {
+				return 0, false
+			}
+			return floatVal, true
+		}
+		return 0, false
+	})
+}
+
+// GetFloatWithValidatorOrigin is like GetFloatWithValidator but also returns the
+// origin of the winning configuration source. Use this when the caller needs to
+// know where the value came from (e.g. to pass to DynamicConfig).
+func (p *Provider) GetFloatWithValidatorOrigin(key string, def float64, validate func(float64) bool) (float64, telemetry.Origin) {
+	return getWithOrigin(p, key, def, func(v string) (float64, bool) {
 		floatVal, err := strconv.ParseFloat(v, 64)
 		if err == nil {
 			if validate != nil && !validate(floatVal) {

--- a/internal/telemetry/telemetrytest/record.go
+++ b/internal/telemetry/telemetrytest/record.go
@@ -220,10 +220,19 @@ func (r *RecordClient) AppStop() {
 func (r *RecordClient) AddFlushTicker(func(telemetry.Client)) {
 }
 
+// normalizeConfigName maps env-var-style names (e.g. DD_TRACE_SAMPLE_RATE)
+// to the telemetry-style names (e.g. trace_sample_rate) so that callers of
+// CheckConfig don't need to know which style a given reporter uses.
+func normalizeConfigName(name string) string {
+	name = strings.TrimPrefix(name, "DD_")
+	return strings.ToLower(name)
+}
+
 func CheckConfig(t *testing.T, cfgs []telemetry.Configuration, key string, value any) {
 	t.Helper()
+	normKey := normalizeConfigName(key)
 	for _, c := range cfgs {
-		if c.Name == key && reflect.DeepEqual(c.Value, value) {
+		if normalizeConfigName(c.Name) == normKey && reflect.DeepEqual(c.Value, value) {
 			return
 		}
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Adds a `DynamicConfig[T]` type to internal/config and migrates `globalSampleRate` to use it as the first RC-aware field on `internal/config.Config`. `DynamicConfig[T]` is largely a copy of the existing tracer/dynamicConfig[T] with two simplifications:

- No `apply` callback: The tracer's version calls an `apply` function on every update to propagate side effects (e.g., pushing the new rate into the rules sampler). In internal/config, the type is a pure value store -- callers handle side effects after reading the value. This keeps internal/config decoupled from product-specific logic.
- Only `startupOrigin`, no mutable `origin` tracking: The tracer's version maintains a mutable `cfgOrigin` that must be updated on every code path. The new type stores only the immutable `startupOrigin` (captured at construction from the provider). The current origin is always known implicitly: `OriginRemoteConfig` when RC pushes an update, `startupOrigin` when RC resets, and explicitly passed by callers for programmatic API updates via `SetGlobalSampleRate`. This eliminates a class of bugs where origin falls out of sync.

The tracer no longer wraps `globalSampleRate` in its own `dynamicConfig` -- it reads from `internalConfig.GlobalSampleRateConfig()` and calls `HandleRC` directly in its RC handler. Removed the `traceSampleRate` field from the tracer's config struct and its telemetry reporting (now handled by `DynamicConfig.HandleRC`).

### Motivation
Part of the ongoing migration of configuration into internal/config. Dynamic configs (RC-aware fields) need a shared type so that products don't each reimplement RC reset/update/telemetry logic. `globalSampleRate` is the first field migrated to validate the design before applying it to more fields.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
