### PR TITLE
chore(openfeature): assign CODEOWNERS solely to FFE SDK team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -83,7 +83,7 @@
 /contrib/aws/datadog-lambda-go  @DataDog/apm-serverless @DataDog/serverless-aws
 
 # Feature Flagging Experiments
-/openfeature                    @DataDog/feature-flagging-and-experimentation-sdk @DataDog/asm-go
+/openfeature                    @DataDog/feature-flagging-and-experimentation-sdk
 
 # Database Monitoring
 ddtrace/tracer/sqlcomment*      @DataDog/database-monitoring @DataDog/apm-go @DataDog/apm-idm-go


### PR DESCRIPTION
## Motivation

The `/openfeature` directory is currently co-owned by `@DataDog/feature-flagging-and-experimentation-sdk` and `@DataDog/asm-go` in CODEOWNERS, which means `asm-go` is auto-requested as a reviewer on every openfeature PR. This doesn't match the other SDK repos:

| Repo | OpenFeature CODEOWNERS |
|------|----------------------|
| `dd-trace-py` | `@DataDog/feature-flagging-and-experimentation-sdk` only |
| `dd-trace-java` | `@DataDog/feature-flagging-and-experimentation-sdk` only |
| `dd-trace-dotnet` | `@DataDog/feature-flagging-and-experimentation-sdk` + `@DataDog/tracing-dotnet` (host team, not ASM) |

## Changes

- Remove `@DataDog/asm-go` from `/openfeature` CODEOWNERS entry, leaving `@DataDog/feature-flagging-and-experimentation-sdk` as sole owner

## Decisions

- Aligns with cross-SDK convention where the FFE SDK team owns openfeature code independently