### PR TITLE
ci: reactivate tracer-release with dd-sts for test optimization

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -358,7 +358,7 @@ jobs:
       id-token: write
     with:
       library: golang
-      ref: main
+      ref: 1e5d6b7096279ca43ce4826fda3cc805635b63c1
       scenarios_groups: tracer-release
       skip_empty_scenarios: true
       _system_tests_dev_mode: true

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -352,7 +352,7 @@ jobs:
 
   tracer-release:
     if: github.event_name == 'schedule'
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@main
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@1e5d6b7096279ca43ce4826fda3cc805635b63c1
     permissions:
       id-token: write
     with:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -355,8 +355,6 @@ jobs:
     uses: DataDog/system-tests/.github/workflows/system-tests.yml@main
     permissions:
       id-token: write
-      contents: read
-      packages: write
     with:
       library: golang
       ref: main

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -354,6 +354,7 @@ jobs:
     if: github.event_name == 'schedule'
     uses: DataDog/system-tests/.github/workflows/system-tests.yml@1e5d6b7096279ca43ce4826fda3cc805635b63c1
     permissions:
+      contents: read
       id-token: write
     with:
       library: golang


### PR DESCRIPTION
## Summary

Migrates system-tests CI to use [dd-sts](https://github.com/DataDog/dd-sts-action) for Datadog Test Optimization instead of long-lived API keys.

All repositories now share a single `system-tests` policy (see [dd-source#408172](https://github.com/DataDog/dd-source/pull/408172)) — no per-repo policy is needed.

Depends on [DataDog/system-tests#6726](https://github.com/DataDog/system-tests/pull/6726).

### Changes
- Add `id-token: write` permission to the system-tests reusable workflow call so it can obtain short-lived credentials via OIDC
- Pin system-tests to `1e5d6b709` (current `main`, pre-migration) to allow a controlled rollout: repos stay on the pre-migration workflow until their pin is explicitly updated to the post-merge SHA

## How to review

The only functional change is adding `id-token: write`. It has no effect at the pinned SHA (dd-sts is not yet used there) but will be required once each repo's pin is updated after [DataDog/system-tests#6726](https://github.com/DataDog/system-tests/pull/6726) merges.