### PR TITLE
feat(llmobs): read experiment scope from APM baggage in StartSpan

### DIFF
--- a/ddtrace/tracer/llmobs.go
+++ b/ddtrace/tracer/llmobs.go
@@ -72,3 +72,7 @@ func (l *llmobsSpanAdapter) TraceID() string {
 func (l *llmobsSpanAdapter) SetBaggageItem(key string, value string) {
 	l.span.SetBaggageItem(key, value)
 }
+
+func (l *llmobsSpanAdapter) BaggageItem(key string) string {
+	return l.span.BaggageItem(key)
+}

--- a/internal/llmobs/llmobs.go
+++ b/internal/llmobs/llmobs.go
@@ -717,6 +717,10 @@ func (l *LLMObs) StartSpan(ctx context.Context, kind SpanKind, name string, cfg 
 		}
 	}
 
+	if experimentID := apmSpan.BaggageItem(baggageKeyExperimentID); experimentID != "" {
+		span.scope = "experiments"
+	}
+
 	log.Debug("llmobs: starting LLMObs span: %s, span_kind: %s, ml_app: %s", spanName, kind, span.mlApp)
 	return span, contextWithActiveLLMSpan(ctx, span)
 }

--- a/internal/llmobs/llmobs_test.go
+++ b/internal/llmobs/llmobs_test.go
@@ -2102,6 +2102,34 @@ func TestDDAttributes(t *testing.T) {
 		// Verify Scope is set to "experiments"
 		assert.Equal(t, "experiments", llmSpan.DDAttributes.Scope, "DDAttributes.Scope should be 'experiments' for experiment spans")
 	})
+	t.Run("child-span-inherits-experiment-scope-from-baggage", func(t *testing.T) {
+		tt, ll := testTracer(t)
+		ctx := context.Background()
+
+		experimentID := "test-experiment-456"
+		parentSpan, ctx := ll.StartExperimentSpan(ctx, "parent-experiment", experimentID, llmobs.StartSpanConfig{})
+		childSpan, _ := ll.StartSpan(ctx, llmobs.SpanKindLLM, "child-llm", llmobs.StartSpanConfig{})
+
+		childSpan.Finish(llmobs.FinishSpanConfig{})
+		parentSpan.Finish(llmobs.FinishSpanConfig{})
+
+		llmSpans := tt.WaitForLLMObsSpans(t, 2)
+
+		var parentLLM, childLLM *llmobstransport.LLMObsSpanEvent
+		for i := range llmSpans {
+			if llmSpans[i].Name == "parent-experiment" {
+				parentLLM = &llmSpans[i]
+			} else if llmSpans[i].Name == "child-llm" {
+				childLLM = &llmSpans[i]
+			}
+		}
+
+		require.NotNil(t, parentLLM, "Parent LLM span should exist")
+		require.NotNil(t, childLLM, "Child LLM span should exist")
+
+		assert.Equal(t, "experiments", parentLLM.DDAttributes.Scope, "Parent scope should be 'experiments'")
+		assert.Equal(t, "experiments", childLLM.DDAttributes.Scope, "Child scope should be 'experiments' via baggage propagation")
+	})
 	t.Run("child-span-trace-ids", func(t *testing.T) {
 		tt, ll := testTracer(t)
 		ctx := context.Background()

--- a/internal/llmobs/tracer.go
+++ b/internal/llmobs/tracer.go
@@ -46,6 +46,8 @@ type APMSpan interface {
 	TraceID() string
 	// SetBaggageItem sets a baggage item on the span.
 	SetBaggageItem(key string, value string)
+	// BaggageItem returns the baggage item value for the given key.
+	BaggageItem(key string) string
 }
 
 // SpanLink represents a link between spans, aliased from the transport package.


### PR DESCRIPTION


### What does this PR do?

Adds experiment scope propagation to `StartSpan` via APM baggage. When a parent span sets `_ml_obs.experiment_id` as a baggage item (e.g. via `StartExperimentSpan`), child LLMObs spans created with `StartSpan` now automatically read that baggage and set their scope to `"experiments"`.

This requires exposing `BaggageItem(key string) string` on the `APMSpan` interface (the underlying `Span` type already has this method).

### Motivation

The Python SDK already [does this](https://github.com/DataDog/dd-trace-py/blob/main/ddtrace/llmobs/_llmobs.py#L582) — every span checks `span.context.get_baggage_item("_ml_obs.experiment_id")` and sets `_dd.scope = "experiments"` if present. The Go SDK only set scope inside `StartExperimentSpan` directly, meaning child spans created via `StartSpan` were missing the experiments scope even when the baggage was propagated on the APM span.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.