### PR TITLE
chore: reenable tracer release step

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -351,7 +351,7 @@ jobs:
           path: artifact.tar.gz
 
   tracer-release:
-    if: true # do this for testing for now
+    if: github.event_name == 'schedule'
     uses: DataDog/system-tests/.github/workflows/system-tests.yml@main
     permissions:
       id-token: write

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -350,15 +350,11 @@ jobs:
           name: logs_${{ matrix.weblog_variant }}_${{ matrix.scenario }}
           path: artifact.tar.gz
 
-  # Temporarily skipped until system tests enable dd-sts for test optimization
   tracer-release:
-    if: false
-    needs: warm-repo-cache
+    if: true # do this for testing for now
     uses: DataDog/system-tests/.github/workflows/system-tests.yml@main
-    secrets:
-      DD_API_KEY: "invalid_key_but_this_is_fine"
-      TEST_OPTIMIZATION_API_KEY: "invalid_key_but_this_is_fine"
     permissions:
+      id-token: write
       contents: read
       packages: write
     with:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Re-enables a test (tracer-release) that we were temporarily skipping.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Test coverage
<img width="436" height="197" alt="image" src="https://github.com/user-attachments/assets/07deb224-b9e1-475a-adcd-2a24847b4fbb" />

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
