### PR TITLE
chore(ci): add `contents: read` permission to test-apps-schedule

### DIFF
--- a/.github/workflows/test-apps-schedule.yml
+++ b/.github/workflows/test-apps-schedule.yml
@@ -16,6 +16,7 @@ jobs:
     secrets: inherit
     permissions:
       id-token: write
+      contents: read
     with:
       "arg: scenario_duration": "10m"
       "arg: tags": "trigger:nightly"
@@ -26,6 +27,7 @@ jobs:
     secrets: inherit
     permissions:
       id-token: write
+      contents: read
     with:
       "arg: scenario_duration": "1h"
       "arg: tags": "trigger:weekly"


### PR DESCRIPTION
### What does this PR do?

Adds `contents: read` permission to `test-apps-schedule.yml` action.

### Motivation

Fix CI scheduled runs: https://github.com/DataDog/dd-trace-go/actions/runs/24374717296

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.

Unsure? Have a question? Request a review!
