### PR TITLE
feat(llmobs): experiments multi-run

### DIFF
--- a/internal/llmobs/llmobs.go
+++ b/internal/llmobs/llmobs.go
@@ -47,7 +47,9 @@ var (
 )
 
 const (
-	baggageKeyExperimentID = "_ml_obs.experiment_id"
+	baggageKeyExperimentID           = "_ml_obs.experiment_id"
+	baggageKeyExperimentRunID        = "_ml_obs.experiment_run_id"
+	baggageKeyExperimentRunIteration = "_ml_obs.experiment_run_iteration"
 )
 
 const (
@@ -717,22 +719,51 @@ func (l *LLMObs) StartSpan(ctx context.Context, kind SpanKind, name string, cfg 
 		}
 	}
 
-	if experimentID := apmSpan.BaggageItem(baggageKeyExperimentID); experimentID != "" {
-		span.scope = "experiments"
+	experimentID := apmSpan.BaggageItem(baggageKeyExperimentID)
+	experimentRunID := apmSpan.BaggageItem(baggageKeyExperimentRunID)
+	experimentRunIteration := apmSpan.BaggageItem(baggageKeyExperimentRunIteration)
+	if experimentID != "" || experimentRunID != "" || experimentRunIteration != "" {
+		if span.llmCtx.tags == nil {
+			span.llmCtx.tags = make(map[string]string)
+		}
+		if experimentID != "" {
+			span.scope = "experiments"
+			span.llmCtx.tags["experiment_id"] = experimentID
+		}
+		if experimentRunID != "" {
+			span.llmCtx.tags["run_id"] = experimentRunID
+		}
+		if experimentRunIteration != "" {
+			span.llmCtx.tags["run_iteration"] = experimentRunIteration
+		}
 	}
 
 	log.Debug("llmobs: starting LLMObs span: %s, span_kind: %s, ml_app: %s", spanName, kind, span.mlApp)
 	return span, contextWithActiveLLMSpan(ctx, span)
 }
 
-// StartExperimentSpan starts a new experiment span with the given name, experiment ID, and configuration.
+// ExperimentInfo holds the experiment identifiers propagated via baggage to distributed child spans.
+type ExperimentInfo struct {
+	ID           string
+	RunID        string
+	RunIteration int
+}
+
+// StartExperimentSpan starts a new experiment span with the given name and configuration.
+// ExperimentInfo fields are propagated via baggage so distributed child spans inherit them.
 // Returns the created span and a context containing the span.
-func (l *LLMObs) StartExperimentSpan(ctx context.Context, name string, experimentID string, cfg StartSpanConfig) (*Span, context.Context) {
+func (l *LLMObs) StartExperimentSpan(ctx context.Context, name string, params ExperimentInfo, cfg StartSpanConfig) (*Span, context.Context) {
 	span, ctx := l.StartSpan(ctx, SpanKindExperiment, name, cfg)
 
-	if experimentID != "" {
-		span.apm.SetBaggageItem(baggageKeyExperimentID, experimentID)
+	if params.ID != "" {
+		span.apm.SetBaggageItem(baggageKeyExperimentID, params.ID)
 		span.scope = "experiments"
+	}
+	if params.RunID != "" {
+		span.apm.SetBaggageItem(baggageKeyExperimentRunID, params.RunID)
+	}
+	if params.RunIteration > 0 {
+		span.apm.SetBaggageItem(baggageKeyExperimentRunIteration, fmt.Sprintf("%d", params.RunIteration))
 	}
 	return span, ctx
 }

--- a/internal/llmobs/llmobs_test.go
+++ b/internal/llmobs/llmobs_test.go
@@ -258,6 +258,58 @@ func TestStartSpan(t *testing.T) {
 		assert.Equal(t, llmWorkflow1.ParentID, llmLLM1.SpanID, "workflow-1 parent ID should be the llm-1 span ID")
 		assert.Equal(t, llmAgent1.ParentID, llmWorkflow1.SpanID, "agent-1 parent ID should be the workflow-1 span ID")
 	})
+	t.Run("distributed-context-propagation-experiment-baggage", func(t *testing.T) {
+		tt, ll := testTracer(t)
+
+		experimentID := "exp-dist-123"
+		experimentRunID := "run-uuid-xyz"
+		experimentRunIteration := 3
+
+		h := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ctx := req.Context()
+			serverSpan, _ := ll.StartSpan(ctx, llmobs.SpanKindLLM, "server-llm", llmobs.StartSpanConfig{})
+			defer serverSpan.Finish(llmobs.FinishSpanConfig{})
+			w.Write([]byte("ok"))
+		})
+		srv, cl := testClientServer(t, h)
+
+		genSpans := func() {
+			experimentSpan, ctx := ll.StartExperimentSpan(context.Background(), "client-experiment", llmobs.ExperimentInfo{
+				ID:           experimentID,
+				RunID:        experimentRunID,
+				RunIteration: experimentRunIteration,
+			}, llmobs.StartSpanConfig{})
+			defer experimentSpan.Finish(llmobs.FinishSpanConfig{})
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/", nil)
+			require.NoError(t, err)
+			resp, err := cl.Do(req)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			_ = resp.Body.Close()
+		}
+		genSpans()
+
+		_ = tt.WaitForSpans(t, 4) // experiment + server-llm (LLMObs) + HTTP client + HTTP server (APM)
+		llmSpans := tt.WaitForLLMObsSpans(t, 2)
+
+		var experimentLLM, serverLLM *llmobstransport.LLMObsSpanEvent
+		for i := range llmSpans {
+			switch llmSpans[i].Name {
+			case "client-experiment":
+				experimentLLM = &llmSpans[i]
+			case "server-llm":
+				serverLLM = &llmSpans[i]
+			}
+		}
+		require.NotNil(t, experimentLLM, "client experiment span should exist")
+		require.NotNil(t, serverLLM, "server LLM span should exist")
+
+		assert.Equal(t, "experiments", serverLLM.DDAttributes.Scope, "server span should inherit experiments scope via baggage")
+		assert.Equal(t, experimentID, findTag(serverLLM.Tags, "experiment_id"), "server span should inherit experiment_id via baggage")
+		assert.Equal(t, experimentRunID, findTag(serverLLM.Tags, "run_id"), "server span should inherit run_id via baggage")
+		assert.Equal(t, fmt.Sprintf("%d", experimentRunIteration), findTag(serverLLM.Tags, "run_iteration"), "server span should inherit run_iteration via baggage")
+	})
 	t.Run("custom-start-and-finish-times", func(t *testing.T) {
 		tt, ll := testTracer(t)
 
@@ -2080,7 +2132,7 @@ func TestDDAttributes(t *testing.T) {
 		ctx := context.Background()
 
 		experimentID := "test-experiment-123"
-		span, _ := ll.StartExperimentSpan(ctx, "test-experiment", experimentID, llmobs.StartSpanConfig{})
+		span, _ := ll.StartExperimentSpan(ctx, "test-experiment", llmobs.ExperimentInfo{ID: experimentID}, llmobs.StartSpanConfig{})
 		span.Finish(llmobs.FinishSpanConfig{})
 
 		apmSpans := tt.WaitForSpans(t, 1)
@@ -2107,7 +2159,7 @@ func TestDDAttributes(t *testing.T) {
 		ctx := context.Background()
 
 		experimentID := "test-experiment-456"
-		parentSpan, ctx := ll.StartExperimentSpan(ctx, "parent-experiment", experimentID, llmobs.StartSpanConfig{})
+		parentSpan, ctx := ll.StartExperimentSpan(ctx, "parent-experiment", llmobs.ExperimentInfo{ID: experimentID}, llmobs.StartSpanConfig{})
 		childSpan, _ := ll.StartSpan(ctx, llmobs.SpanKindLLM, "child-llm", llmobs.StartSpanConfig{})
 
 		childSpan.Finish(llmobs.FinishSpanConfig{})
@@ -2129,6 +2181,36 @@ func TestDDAttributes(t *testing.T) {
 
 		assert.Equal(t, "experiments", parentLLM.DDAttributes.Scope, "Parent scope should be 'experiments'")
 		assert.Equal(t, "experiments", childLLM.DDAttributes.Scope, "Child scope should be 'experiments' via baggage propagation")
+		assert.Contains(t, childLLM.Tags, "experiment_id:"+experimentID, "Child span should inherit experiment_id tag from baggage")
+	})
+	t.Run("child-span-inherits-run-id-and-run-iteration-from-baggage", func(t *testing.T) {
+		tt, ll := testTracer(t)
+		ctx := context.Background()
+
+		experimentID := "test-experiment-789"
+		experimentRunID := "run-uuid-abc"
+		experimentRunIteration := 2
+		parentSpan, ctx := ll.StartExperimentSpan(ctx, "parent-experiment", llmobs.ExperimentInfo{
+			ID:           experimentID,
+			RunID:        experimentRunID,
+			RunIteration: experimentRunIteration,
+		}, llmobs.StartSpanConfig{})
+		childSpan, _ := ll.StartSpan(ctx, llmobs.SpanKindLLM, "child-llm", llmobs.StartSpanConfig{})
+
+		childSpan.Finish(llmobs.FinishSpanConfig{})
+		parentSpan.Finish(llmobs.FinishSpanConfig{})
+
+		llmSpans := tt.WaitForLLMObsSpans(t, 2)
+
+		var childLLM *llmobstransport.LLMObsSpanEvent
+		for i := range llmSpans {
+			if llmSpans[i].Name == "child-llm" {
+				childLLM = &llmSpans[i]
+			}
+		}
+		require.NotNil(t, childLLM, "Child LLM span should exist")
+		assert.Contains(t, childLLM.Tags, "run_id:"+experimentRunID, "Child span should inherit run_id from baggage")
+		assert.Contains(t, childLLM.Tags, "run_iteration:2", "Child span should inherit run_iteration from baggage")
 	})
 	t.Run("child-span-trace-ids", func(t *testing.T) {
 		tt, ll := testTracer(t)

--- a/internal/llmobs/transport/dne.go
+++ b/internal/llmobs/transport/dne.go
@@ -124,6 +124,12 @@ type RequestAttributesExperimentCreate struct {
 	Config         map[string]any `json:"config,omitempty"`
 	DatasetVersion int            `json:"dataset_version,omitempty"`
 	EnsureUnique   bool           `json:"ensure_unique,omitempty"`
+	RunCount       int            `json:"run_count,omitempty"`
+}
+
+type RequestAttributesExperimentUpdate struct {
+	Status string `json:"status,omitempty"`
+	Error  string `json:"error,omitempty"`
 }
 
 type RequestAttributesExperimentPushEvents struct {
@@ -156,6 +162,7 @@ type (
 	CreateProjectRequest = Request[RequestAttributesProjectCreate]
 
 	CreateExperimentRequest     = Request[RequestAttributesExperimentCreate]
+	UpdateExperimentRequest     = Request[RequestAttributesExperimentUpdate]
 	PushExperimentEventsRequest = Request[RequestAttributesExperimentPushEvents]
 )
 
@@ -441,6 +448,7 @@ func (c *Transport) CreateExperiment(
 	expConfig map[string]any,
 	tags []string,
 	description string,
+	runs int,
 ) (*ExperimentView, error) {
 	path := endpointPrefixDNE + "/experiments"
 	method := http.MethodPost
@@ -461,6 +469,7 @@ func (c *Transport) CreateExperiment(
 				Config:         expConfig,
 				DatasetVersion: datasetVersion,
 				EnsureUnique:   true,
+				RunCount:       runs,
 			},
 		},
 	}
@@ -481,6 +490,29 @@ func (c *Transport) CreateExperiment(
 	exp.ID = resp.Data.ID
 
 	return &exp, nil
+}
+
+func (c *Transport) UpdateExperimentStatus(ctx context.Context, id, status, errSummary string) error {
+	path := fmt.Sprintf("%s/experiments/%s", endpointPrefixDNE, url.PathEscape(id))
+
+	body := UpdateExperimentRequest{
+		Data: RequestData[RequestAttributesExperimentUpdate]{
+			Type: resourceTypeExperiments,
+			Attributes: RequestAttributesExperimentUpdate{
+				Status: status,
+				Error:  errSummary,
+			},
+		},
+	}
+
+	result, err := c.jsonRequest(ctx, http.MethodPatch, path, subdomainDNE, body, defaultTimeout)
+	if err != nil {
+		return err
+	}
+	if result.statusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d: %s", result.statusCode, string(result.body))
+	}
+	return nil
 }
 
 func (c *Transport) PushExperimentEvents(

--- a/llmobs/experiment/experiment.go
+++ b/llmobs/experiment/experiment.go
@@ -169,12 +169,10 @@ type ExperimentResult struct {
 	// Runs holds the results for each run iteration, in order. For a single-run
 	// experiment this slice has exactly one element.
 	Runs []*RunResult
-
 	// Results is kept for single-run backward compatibility and points to Runs[0].Results.
 	//
 	// Deprecated: Use Runs[0].Results instead.
 	Results []*RecordResult
-
 	// SummaryEvaluations is kept for single-run backward compatibility and points to Runs[0].SummaryEvaluations.
 	//
 	// Deprecated: Use Runs[0].SummaryEvaluations instead.
@@ -183,16 +181,23 @@ type ExperimentResult struct {
 
 // RecordResult represents an experiment result for a single record.
 type RecordResult struct {
-	Record      *dataset.Record // The dataset record containing input, expected output, and metadata
-	Output      any             // The task output for this record
-	Evaluations []*Evaluation   // Evaluation results for this record
+	// Record is the dataset record containing input, expected output, and metadata.
+	Record *dataset.Record
+	// Output is the task output for this record.
+	Output any
+	// Evaluations holds the evaluation results for this record.
+	Evaluations []*Evaluation
 
-	// Experiment execution metadata
-	RecordIndex int       // Index of the record in the dataset
-	SpanID      string    // Span ID for tracing
-	TraceID     string    // Trace ID for tracing
-	Timestamp   time.Time // When the task was executed
-	Error       error     // Any error that occurred during task execution
+	// RecordIndex is the index of the record in the dataset.
+	RecordIndex int
+	// SpanID is the span ID for tracing.
+	SpanID string
+	// TraceID is the trace ID for tracing.
+	TraceID string
+	// Timestamp is when the task was executed.
+	Timestamp time.Time
+	// Error is any error that occurred during task execution.
+	Error error
 }
 
 // Evaluation represents the output of an evaluator.
@@ -245,16 +250,7 @@ func New(name string, task Task, ds *dataset.Dataset, evaluators []Evaluator, op
 // Run executes the experiment, running the task and evaluators on each record in the dataset,
 // then running summary evaluators on the aggregated results.
 // When configured with WithRuns(n), the full experiment loop is executed n times.
-// Each run gets a unique run ID and a 1-indexed iteration number propagated as tags.
-//
-// Status updates are sent to the backend at key lifecycle points:
-//   - "running"     — immediately after the experiment is registered on the backend
-//   - "completed"   — all runs finished with no errors
-//   - "failed"      — all runs finished but one or more task/evaluator errors occurred,
-//     or a hard error (e.g. abortOnError) aborted execution early
-//   - "interrupted" — the context was cancelled or its deadline exceeded before the
-//     run loop could finish
-func (e *Experiment) Run(ctx context.Context, opts ...RunOption) (_ *ExperimentResult, retErr error) {
+func (e *Experiment) Run(ctx context.Context, opts ...RunOption) (result *ExperimentResult, retErr error) {
 	ll, err := illmobs.ActiveLLMObs()
 	if err != nil {
 		return nil, err
@@ -281,24 +277,29 @@ func (e *Experiment) Run(ctx context.Context, opts ...RunOption) (_ *ExperimentR
 	// 3) Notify the backend that the experiment is now executing.
 	e.updateStatus(ctx, ll, experimentStatusRunning, "")
 
-	// Ensure a terminal status is always sent when Run returns an error. Two cases:
-	//   - context cancelled/deadline exceeded: sends "interrupted" using a fresh
-	//     context so the request is not immediately rejected.
-	//   - any other hard error: sends "failed" with the error message.
-	// The happy-path terminal status ("completed" or "failed"-with-summary) is sent
-	// explicitly at the end of the function, before returning nil.
+	result = &ExperimentResult{
+		ExperimentName: e.Name,
+		DatasetName:    e.dataset.Name(),
+		Runs:           make([]*RunResult, 0, e.cfg.runs),
+	}
+
+	// Ensure we send the final status in all cases.
 	defer func() {
-		if retErr == nil {
+		if retErr != nil {
+			if ctx.Err() != nil {
+				e.updateStatus(context.Background(), ll, experimentStatusInterrupted, "")
+			} else {
+				e.updateStatus(ctx, ll, experimentStatusFailed, retErr.Error())
+			}
 			return
 		}
-		if ctx.Err() != nil {
-			e.updateStatus(context.Background(), ll, experimentStatusInterrupted, "")
+		if summary := buildErrorSummary(result.Runs); summary != "" {
+			e.updateStatus(ctx, ll, experimentStatusFailed, summary)
 		} else {
-			e.updateStatus(ctx, ll, experimentStatusFailed, retErr.Error())
+			e.updateStatus(ctx, ll, experimentStatusCompleted, "")
 		}
 	}()
 
-	runResults := make([]*RunResult, 0, e.cfg.runs)
 	for i := range e.cfg.runs {
 		run := RunInfo{
 			ID:        uuid.New().String(),
@@ -330,32 +331,20 @@ func (e *Experiment) Run(ctx context.Context, opts ...RunOption) (_ *ExperimentR
 			return nil, fmt.Errorf("run %d: failed to push experiment events: %w", run.Iteration, err)
 		}
 
-		runResults = append(runResults, &RunResult{
+		result.Runs = append(result.Runs, &RunResult{
 			Run:                run,
 			Results:            results,
 			SummaryEvaluations: summaryEvals,
 		})
 	}
 
-	result := &ExperimentResult{
-		ExperimentName: e.Name,
-		DatasetName:    e.dataset.Name(),
-		Runs:           runResults,
-	}
 	// Populate legacy fields from the first run for single-run backward compatibility.
-	if len(runResults) > 0 {
-		result.Results = runResults[0].Results
-		result.SummaryEvaluations = runResults[0].SummaryEvaluations
+	if len(result.Runs) > 0 {
+		result.Results = result.Runs[0].Results
+		result.SummaryEvaluations = result.Runs[0].SummaryEvaluations
 	}
 
-	// 7) Send the terminal status. If any task or evaluator recorded an error the
-	// experiment is considered failed; otherwise it completed successfully.
-	if summary := buildErrorSummary(runResults); summary != "" {
-		e.updateStatus(ctx, ll, experimentStatusFailed, summary)
-	} else {
-		e.updateStatus(ctx, ll, experimentStatusCompleted, "")
-	}
-	return result, nil
+	return
 }
 
 // updateStatus sends a status update to the backend. Failures are logged at debug

--- a/llmobs/experiment/experiment.go
+++ b/llmobs/experiment/experiment.go
@@ -365,7 +365,7 @@ func (e *Experiment) updateStatus(ctx context.Context, ll *illmobs.LLMObs, statu
 		return
 	}
 	if err := ll.Transport.UpdateExperimentStatus(ctx, e.id, status, errSummary); err != nil {
-		log.Debug("llmobs: failed to update experiment %s status to %q: %v", e.id, status, err)
+		log.Debug("llmobs: failed to update experiment %s status to %q: %v", e.id, status, err.Error())
 	}
 }
 

--- a/llmobs/experiment/experiment.go
+++ b/llmobs/experiment/experiment.go
@@ -450,7 +450,11 @@ func (e *Experiment) runTaskForRecord(ctx context.Context, llmobs *illmobs.LLMOb
 		err error
 	)
 
-	span, ctx := llmobs.StartExperimentSpan(ctx, e.task.Name(), e.id, illmobs.StartSpanConfig{})
+	span, ctx := llmobs.StartExperimentSpan(ctx, e.task.Name(), illmobs.ExperimentInfo{
+		ID:           e.id,
+		RunID:        run.ID,
+		RunIteration: run.Iteration,
+	}, illmobs.StartSpanConfig{})
 	defer func() { span.Finish(illmobs.FinishSpanConfig{Error: err}) }()
 
 	tags := make(map[string]string)

--- a/llmobs/experiment/experiment.go
+++ b/llmobs/experiment/experiment.go
@@ -10,8 +10,10 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace"
@@ -26,6 +28,13 @@ var (
 	errRequiresProjectName = errors.New(`a project name must be provided for the experiment, either configured via the DD_LLMOBS_PROJECT_NAME
 environment variable, using the global tracer.WithLLMObsProjectName option, or experiment.WithProjectName option`)
 	errRequiresAppKey = errors.New(`an app key must be provided for the experiment in agentless mode configured via the DD_APP_KEY environment variable`)
+)
+
+const (
+	experimentStatusRunning     = "running"
+	experimentStatusCompleted   = "completed"
+	experimentStatusFailed      = "failed"
+	experimentStatusInterrupted = "interrupted"
 )
 
 // Experiment represents a DataDog LLM Observability experiment.
@@ -137,11 +146,38 @@ func NewSummaryEvaluator(name string, fn SummaryEvaluatorFunc) SummaryEvaluator 
 	}
 }
 
-// ExperimentResult represents the complete results of an experiment run.
-type ExperimentResult struct {
-	ExperimentName     string
-	DatasetName        string
+// RunInfo contains metadata for a single experiment run iteration.
+type RunInfo struct {
+	ID        string // UUID uniquely identifying this run
+	Iteration int    // 1-indexed iteration number
+}
+
+// RunResult contains the results for a single run iteration.
+type RunResult struct {
+	Run                RunInfo
 	Results            []*RecordResult
+	SummaryEvaluations []*Evaluation
+}
+
+// ExperimentResult represents the complete results of an experiment execution.
+// For multi-run experiments (WithRuns > 1), Runs contains one entry per iteration.
+type ExperimentResult struct {
+	// ExperimentName is the name of the experiment as provided to New.
+	ExperimentName string
+	// DatasetName is the name of the dataset the experiment ran against.
+	DatasetName string
+	// Runs holds the results for each run iteration, in order. For a single-run
+	// experiment this slice has exactly one element.
+	Runs []*RunResult
+
+	// Results is kept for single-run backward compatibility and points to Runs[0].Results.
+	//
+	// Deprecated: Use Runs[0].Results instead.
+	Results []*RecordResult
+
+	// SummaryEvaluations is kept for single-run backward compatibility and points to Runs[0].SummaryEvaluations.
+	//
+	// Deprecated: Use Runs[0].SummaryEvaluations instead.
 	SummaryEvaluations []*Evaluation
 }
 
@@ -208,7 +244,17 @@ func New(name string, task Task, ds *dataset.Dataset, evaluators []Evaluator, op
 
 // Run executes the experiment, running the task and evaluators on each record in the dataset,
 // then running summary evaluators on the aggregated results.
-func (e *Experiment) Run(ctx context.Context, opts ...RunOption) (*ExperimentResult, error) {
+// When configured with WithRuns(n), the full experiment loop is executed n times.
+// Each run gets a unique run ID and a 1-indexed iteration number propagated as tags.
+//
+// Status updates are sent to the backend at key lifecycle points:
+//   - "running"     — immediately after the experiment is registered on the backend
+//   - "completed"   — all runs finished with no errors
+//   - "failed"      — all runs finished but one or more task/evaluator errors occurred,
+//     or a hard error (e.g. abortOnError) aborted execution early
+//   - "interrupted" — the context was cancelled or its deadline exceeded before the
+//     run loop could finish
+func (e *Experiment) Run(ctx context.Context, opts ...RunOption) (_ *ExperimentResult, retErr error) {
 	ll, err := illmobs.ActiveLLMObs()
 	if err != nil {
 		return nil, err
@@ -224,45 +270,146 @@ func (e *Experiment) Run(ctx context.Context, opts ...RunOption) (*ExperimentRes
 		return nil, fmt.Errorf("failed to get or create project: %w", err)
 	}
 
-	// 2) Create the experiment
-	expResp, err := ll.Transport.CreateExperiment(ctx, e.Name, e.dataset.ID(), proj.ID, e.dataset.Version(), e.cfg.experimentCfg, e.tagsSlice, e.description)
+	// 2) Create the experiment, telling the backend how many runs to expect
+	expResp, err := ll.Transport.CreateExperiment(ctx, e.Name, e.dataset.ID(), proj.ID, e.dataset.Version(), e.cfg.experimentCfg, e.tagsSlice, e.description, e.cfg.runs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create experiment: %w", err)
 	}
 	e.id = expResp.ID
 	e.runName = expResp.Name
 
-	pushEventsTags := make([]string, len(e.tagsSlice))
-	copy(pushEventsTags, e.tagsSlice)
-	pushEventsTags = append(pushEventsTags, fmt.Sprintf("%s:%s", "experiment_id", e.id))
+	// 3) Notify the backend that the experiment is now executing.
+	e.updateStatus(ctx, ll, experimentStatusRunning, "")
 
-	// 3) Run the experiment task for each record in the dataset
-	results, err := e.runTask(ctx, ll, cfg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to run experiment task: %w", err)
-	}
-	if err := e.runEvaluators(ctx, results, cfg); err != nil {
-		return nil, fmt.Errorf("failed to run experiment evaluators: %w", err)
+	// Ensure a terminal status is always sent when Run returns an error. Two cases:
+	//   - context cancelled/deadline exceeded: sends "interrupted" using a fresh
+	//     context so the request is not immediately rejected.
+	//   - any other hard error: sends "failed" with the error message.
+	// The happy-path terminal status ("completed" or "failed"-with-summary) is sent
+	// explicitly at the end of the function, before returning nil.
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		if ctx.Err() != nil {
+			e.updateStatus(context.Background(), ll, experimentStatusInterrupted, "")
+		} else {
+			e.updateStatus(ctx, ll, experimentStatusFailed, retErr.Error())
+		}
+	}()
+
+	runResults := make([]*RunResult, 0, e.cfg.runs)
+	for i := range e.cfg.runs {
+		run := RunInfo{
+			ID:        uuid.New().String(),
+			Iteration: i + 1,
+		}
+		// Build metric-level tags (per-metric Tags field)
+		metricTags := e.buildRunTags(run, false)
+		// Build request-level tags (outer tags on PushExperimentEvents)
+		pushTags := e.buildRunTags(run, true)
+
+		// 4) Run the experiment task for each record in the dataset
+		results, err := e.runTask(ctx, ll, cfg, run)
+		if err != nil {
+			return nil, fmt.Errorf("run %d: failed to run experiment task: %w", run.Iteration, err)
+		}
+		if err := e.runEvaluators(ctx, results, cfg); err != nil {
+			return nil, fmt.Errorf("run %d: failed to run experiment evaluators: %w", run.Iteration, err)
+		}
+
+		// 5) Run summary evaluators
+		summaryEvals, err := e.runSummaryEvaluators(ctx, results, cfg)
+		if err != nil {
+			return nil, fmt.Errorf("run %d: failed to run summary evaluators: %w", run.Iteration, err)
+		}
+
+		// 6) Generate and publish metrics from the results
+		metrics := e.generateMetrics(results, summaryEvals, metricTags)
+		if err := ll.Transport.PushExperimentEvents(ctx, e.id, metrics, pushTags); err != nil {
+			return nil, fmt.Errorf("run %d: failed to push experiment events: %w", run.Iteration, err)
+		}
+
+		runResults = append(runResults, &RunResult{
+			Run:                run,
+			Results:            results,
+			SummaryEvaluations: summaryEvals,
+		})
 	}
 
-	// 4) Run summary evaluators
-	summaryEvals, err := e.runSummaryEvaluators(ctx, results, cfg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to run summary evaluators: %w", err)
+	result := &ExperimentResult{
+		ExperimentName: e.Name,
+		DatasetName:    e.dataset.Name(),
+		Runs:           runResults,
+	}
+	// Populate legacy fields from the first run for single-run backward compatibility.
+	if len(runResults) > 0 {
+		result.Results = runResults[0].Results
+		result.SummaryEvaluations = runResults[0].SummaryEvaluations
 	}
 
-	// 5) Generate and publish metrics from the results
-	metrics := e.generateMetrics(results, summaryEvals)
-	if err := ll.Transport.PushExperimentEvents(ctx, e.id, metrics, pushEventsTags); err != nil {
-		return nil, fmt.Errorf("failed to push experiment events: %w", err)
+	// 7) Send the terminal status. If any task or evaluator recorded an error the
+	// experiment is considered failed; otherwise it completed successfully.
+	if summary := buildErrorSummary(runResults); summary != "" {
+		e.updateStatus(ctx, ll, experimentStatusFailed, summary)
+	} else {
+		e.updateStatus(ctx, ll, experimentStatusCompleted, "")
 	}
+	return result, nil
+}
 
-	return &ExperimentResult{
-		ExperimentName:     e.Name,
-		DatasetName:        e.dataset.Name(),
-		Results:            results,
-		SummaryEvaluations: summaryEvals,
-	}, nil
+// updateStatus sends a status update to the backend. Failures are logged at debug
+// level and never surfaced to the caller — a status update failure is non-fatal.
+func (e *Experiment) updateStatus(ctx context.Context, ll *illmobs.LLMObs, status, errSummary string) {
+	if e.id == "" {
+		return
+	}
+	if err := ll.Transport.UpdateExperimentStatus(ctx, e.id, status, errSummary); err != nil {
+		log.Debug("llmobs: failed to update experiment %s status to %q: %v", e.id, status, err)
+	}
+}
+
+// buildErrorSummary returns a semicolon-separated string of all task and evaluator
+// errors found across all run results. An empty string means no errors occurred.
+func buildErrorSummary(runs []*RunResult) string {
+	var parts []string
+	for _, run := range runs {
+		for _, res := range run.Results {
+			if res == nil {
+				continue
+			}
+			if res.Error != nil {
+				parts = append(parts, res.Error.Error())
+			}
+			for _, ev := range res.Evaluations {
+				if ev.Error != nil {
+					parts = append(parts, fmt.Sprintf("%s: %s", ev.Name, ev.Error.Error()))
+				}
+			}
+		}
+		for _, ev := range run.SummaryEvaluations {
+			if ev.Error != nil {
+				parts = append(parts, fmt.Sprintf("%s: %s", ev.Name, ev.Error.Error()))
+			}
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
+// buildRunTags returns the tag slice for a given run, optionally including experiment_id.
+// includeExperimentID should be true for the outer PushExperimentEvents tags, false for
+// the per-metric Tags field (which carries the experiment ID in its own struct field).
+func (e *Experiment) buildRunTags(run RunInfo, includeExperimentID bool) []string {
+	tags := make([]string, 0, len(e.tagsSlice)+3)
+	tags = append(tags, e.tagsSlice...)
+	tags = append(tags,
+		fmt.Sprintf("run_id:%s", run.ID),
+		fmt.Sprintf("run_iteration:%d", run.Iteration),
+	)
+	if includeExperimentID {
+		tags = append(tags, fmt.Sprintf("experiment_id:%s", e.id))
+	}
+	return tags
 }
 
 func (e *Experiment) URL() string {
@@ -270,7 +417,7 @@ func (e *Experiment) URL() string {
 	return fmt.Sprintf("%s/llm/experiments/%s", illmobs.PublicResourceBaseURL(), e.id)
 }
 
-func (e *Experiment) runTask(ctx context.Context, llmobs *illmobs.LLMObs, cfg *runCfg) ([]*RecordResult, error) {
+func (e *Experiment) runTask(ctx context.Context, llmobs *illmobs.LLMObs, cfg *runCfg, run RunInfo) ([]*RecordResult, error) {
 	eg, ctx := errgroup.WithContext(ctx)
 	if cfg.maxConcurrency > 0 {
 		eg.SetLimit(cfg.maxConcurrency)
@@ -287,7 +434,7 @@ func (e *Experiment) runTask(ctx context.Context, llmobs *illmobs.LLMObs, cfg *r
 			break
 		}
 		eg.Go(func() error {
-			res := e.runTaskForRecord(ctx, llmobs, i, rec)
+			res := e.runTaskForRecord(ctx, llmobs, i, rec, run)
 			if res.Error != nil {
 				retErr := fmt.Errorf("failed to process record %d: %w", i, res.Error)
 				if cfg.abortOnError {
@@ -309,7 +456,7 @@ func (e *Experiment) runTask(ctx context.Context, llmobs *illmobs.LLMObs, cfg *r
 	return results, nil
 }
 
-func (e *Experiment) runTaskForRecord(ctx context.Context, llmobs *illmobs.LLMObs, recIdx int, rec dataset.Record) *RecordResult {
+func (e *Experiment) runTaskForRecord(ctx context.Context, llmobs *illmobs.LLMObs, recIdx int, rec dataset.Record, run RunInfo) *RecordResult {
 	var (
 		err error
 	)
@@ -322,6 +469,8 @@ func (e *Experiment) runTaskForRecord(ctx context.Context, llmobs *illmobs.LLMOb
 	tags["dataset_id"] = e.dataset.ID()
 	tags["dataset_record_id"] = rec.ID()
 	tags["experiment_id"] = e.id
+	tags["run_id"] = run.ID
+	tags["run_iteration"] = fmt.Sprintf("%d", run.Iteration)
 
 	out, err := e.task.Run(ctx, rec, e.cfg.experimentCfg)
 	if err != nil {
@@ -410,7 +559,7 @@ func (e *Experiment) runSummaryEvaluators(ctx context.Context, results []*Record
 	return summaryEvals, nil
 }
 
-func (e *Experiment) generateMetrics(results []*RecordResult, summaryEvals []*Evaluation) []transport.ExperimentEvalMetricEvent {
+func (e *Experiment) generateMetrics(results []*RecordResult, summaryEvals []*Evaluation, runTags []string) []transport.ExperimentEvalMetricEvent {
 	metrics := make([]transport.ExperimentEvalMetricEvent, 0, len(results)+len(summaryEvals))
 
 	// Track latest timestamp for summary evaluations
@@ -422,19 +571,19 @@ func (e *Experiment) generateMetrics(results []*RecordResult, summaryEvals []*Ev
 			latestTimestamp = res.Timestamp
 		}
 		for _, ev := range res.Evaluations {
-			metrics = append(metrics, e.generateMetricFromEvaluation(res, ev, "custom"))
+			metrics = append(metrics, e.generateMetricFromEvaluation(res, ev, "custom", runTags))
 		}
 	}
 
-	// Generate metrics from summary evaluations
-	// Summary evaluations don't have associated spans, so we use empty span/trace IDs and latest timestamp
+	// Generate metrics from summary evaluations.
+	// Summary evaluations don't have associated spans, so we use empty span/trace IDs and latest timestamp.
 	for _, sumEv := range summaryEvals {
-		metrics = append(metrics, e.generateMetricFromSummaryEvaluation(sumEv, latestTimestamp))
+		metrics = append(metrics, e.generateMetricFromSummaryEvaluation(sumEv, latestTimestamp, runTags))
 	}
 	return metrics
 }
 
-func (e *Experiment) generateMetricFromEvaluation(res *RecordResult, ev *Evaluation, source string) transport.ExperimentEvalMetricEvent {
+func (e *Experiment) generateMetricFromEvaluation(res *RecordResult, ev *Evaluation, source string, runTags []string) transport.ExperimentEvalMetricEvent {
 	var (
 		catVal   *string
 		scoreVal *float64
@@ -468,12 +617,12 @@ func (e *Experiment) generateMetricFromEvaluation(res *RecordResult, ev *Evaluat
 		ScoreValue:       scoreVal,
 		BooleanValue:     boolVal,
 		Error:            transport.NewErrorMessage(ev.Error),
-		Tags:             e.tagsSlice,
+		Tags:             runTags,
 		ExperimentID:     e.id,
 	}
 }
 
-func (e *Experiment) generateMetricFromSummaryEvaluation(ev *Evaluation, timestamp time.Time) transport.ExperimentEvalMetricEvent {
+func (e *Experiment) generateMetricFromSummaryEvaluation(ev *Evaluation, timestamp time.Time, runTags []string) transport.ExperimentEvalMetricEvent {
 	var (
 		catVal   *string
 		scoreVal *float64
@@ -496,7 +645,7 @@ func (e *Experiment) generateMetricFromSummaryEvaluation(ev *Evaluation, timesta
 		catVal = transport.AnyPtr(fmt.Sprintf("%v", t))
 	}
 
-	// Summary evaluations don't have span/trace IDs, but use the latest timestamp from per-record evaluations
+	// Summary evaluations don't have span/trace IDs, but use the latest timestamp from per-record evaluations.
 	return transport.ExperimentEvalMetricEvent{
 		MetricSource:     "summary",
 		SpanID:           "",
@@ -508,7 +657,7 @@ func (e *Experiment) generateMetricFromSummaryEvaluation(ev *Evaluation, timesta
 		ScoreValue:       scoreVal,
 		BooleanValue:     boolVal,
 		Error:            transport.NewErrorMessage(ev.Error),
-		Tags:             e.tagsSlice,
+		Tags:             runTags,
 		ExperimentID:     e.id,
 	}
 }

--- a/llmobs/experiment/experiment_test.go
+++ b/llmobs/experiment/experiment_test.go
@@ -504,6 +504,226 @@ func TestExperimentRun(t *testing.T) {
 	})
 }
 
+func TestExperimentMultiRun(t *testing.T) {
+	t.Run("multiple-runs-produce-separate-run-results", func(t *testing.T) {
+		tt := testTracer(t)
+		defer tt.Stop()
+
+		ds := createTestDataset(t)
+		task := createTestTask()
+		evaluators := createTestEvaluators()
+
+		exp, err := experiment.New(
+			"test-experiment-multi-run",
+			task,
+			ds,
+			evaluators,
+			experiment.WithProjectName("test-project"),
+			experiment.WithRuns(3),
+		)
+		require.NoError(t, err)
+
+		results, err := exp.Run(context.Background())
+		require.NoError(t, err)
+
+		// Should have 3 runs
+		require.Len(t, results.Runs, 3)
+
+		// Each run should have a unique ID and the correct iteration number
+		seenIDs := make(map[string]bool)
+		for i, run := range results.Runs {
+			assert.NotEmpty(t, run.Run.ID, "run ID should be set")
+			assert.Equal(t, i+1, run.Run.Iteration, "run iteration should be 1-indexed")
+			assert.False(t, seenIDs[run.Run.ID], "run ID should be unique across runs")
+			seenIDs[run.Run.ID] = true
+
+			// Each run should have results for all dataset records
+			assert.Len(t, run.Results, 2)
+		}
+
+		// Backward compat: Results and SummaryEvaluations point to first run
+		assert.Equal(t, results.Runs[0].Results, results.Results)
+		assert.Equal(t, results.Runs[0].SummaryEvaluations, results.SummaryEvaluations)
+	})
+
+	t.Run("single-run-default-backward-compat", func(t *testing.T) {
+		tt := testTracer(t)
+		defer tt.Stop()
+
+		ds := createTestDataset(t)
+		task := createTestTask()
+		evaluators := createTestEvaluators()
+
+		exp, err := experiment.New(
+			"test-experiment-single-run",
+			task,
+			ds,
+			evaluators,
+			experiment.WithProjectName("test-project"),
+			// No WithRuns — defaults to 1
+		)
+		require.NoError(t, err)
+
+		results, err := exp.Run(context.Background())
+		require.NoError(t, err)
+
+		require.Len(t, results.Runs, 1)
+		assert.Equal(t, 1, results.Runs[0].Run.Iteration)
+		assert.NotEmpty(t, results.Runs[0].Run.ID)
+
+		// Legacy fields still populated
+		assert.Len(t, results.Results, 2)
+	})
+
+	t.Run("spans-carry-run-id-and-run-iteration-tags", func(t *testing.T) {
+		tt := testTracer(t)
+		defer tt.Stop()
+
+		ds := createTestDataset(t)
+		task := createTestTask()
+
+		exp, err := experiment.New(
+			"test-experiment-span-tags",
+			task,
+			ds,
+			nil,
+			experiment.WithProjectName("test-project"),
+			experiment.WithRuns(2),
+		)
+		require.NoError(t, err)
+
+		results, err := exp.Run(context.Background())
+		require.NoError(t, err)
+		require.Len(t, results.Runs, 2)
+
+		// 2 runs × 2 records = 4 spans
+		spans := tt.WaitForLLMObsSpans(t, 4)
+		require.Len(t, spans, 4)
+
+		// Collect all run_id and run_iteration values seen in span tags.
+		// Tags are []string in "key:value" format.
+		runIDs := make(map[string]bool)
+		runIterations := make(map[string]bool)
+		for _, span := range spans {
+			runID := spanTagValue(span.Tags, "run_id")
+			runIteration := spanTagValue(span.Tags, "run_iteration")
+			assert.NotEmpty(t, runID, "span should have run_id tag")
+			assert.NotEmpty(t, runIteration, "span should have run_iteration tag")
+			runIDs[runID] = true
+			runIterations[runIteration] = true
+		}
+
+		// Should have seen 2 distinct run IDs and iterations "1" and "2"
+		assert.Len(t, runIDs, 2, "should have 2 distinct run IDs across spans")
+		assert.True(t, runIterations["1"], "iteration 1 should appear in span tags")
+		assert.True(t, runIterations["2"], "iteration 2 should appear in span tags")
+
+		// Verify run IDs in results match span tags
+		resultRunIDs := make(map[string]bool)
+		for _, run := range results.Runs {
+			resultRunIDs[run.Run.ID] = true
+		}
+		assert.Equal(t, resultRunIDs, runIDs, "span run_id tags should match RunResult IDs")
+	})
+
+	t.Run("push-events-called-once-per-run", func(t *testing.T) {
+		var pushCount int
+		h := func(r *http.Request) *http.Response {
+			path := strings.TrimPrefix(r.URL.Path, "/evp_proxy/v2")
+			if strings.HasSuffix(path, "/events") {
+				pushCount++
+			}
+			return createMockHandler()(r)
+		}
+
+		tt := testTracer(t, testtracer.WithMockResponses(h))
+		defer tt.Stop()
+
+		ds := createTestDataset(t)
+		task := createTestTask()
+		evaluators := createTestEvaluators()
+
+		const numRuns = 3
+		exp, err := experiment.New(
+			"test-experiment-push-count",
+			task,
+			ds,
+			evaluators,
+			experiment.WithProjectName("test-project"),
+			experiment.WithRuns(numRuns),
+		)
+		require.NoError(t, err)
+
+		_, err = exp.Run(context.Background())
+		require.NoError(t, err)
+
+		assert.Equal(t, numRuns, pushCount, "PushExperimentEvents should be called once per run")
+	})
+
+	t.Run("run-count-sent-to-backend", func(t *testing.T) {
+		var capturedRunCount int
+		h := func(r *http.Request) *http.Response {
+			path := strings.TrimPrefix(r.URL.Path, "/evp_proxy/v2")
+			if path == "/api/unstable/llm-obs/v1/experiments" && r.Method == http.MethodPost {
+				var body struct {
+					Data struct {
+						Attributes struct {
+							RunCount int `json:"run_count"`
+						} `json:"attributes"`
+					} `json:"data"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&body); err == nil {
+					capturedRunCount = body.Data.Attributes.RunCount
+				}
+			}
+			return createMockHandler()(r)
+		}
+
+		tt := testTracer(t, testtracer.WithMockResponses(h))
+		defer tt.Stop()
+
+		ds := createTestDataset(t)
+		task := createTestTask()
+
+		exp, err := experiment.New(
+			"test-experiment-run-count",
+			task,
+			ds,
+			nil,
+			experiment.WithProjectName("test-project"),
+			experiment.WithRuns(4),
+		)
+		require.NoError(t, err)
+
+		_, err = exp.Run(context.Background())
+		require.NoError(t, err)
+
+		assert.Equal(t, 4, capturedRunCount, "run_count should be sent to the backend")
+	})
+
+	t.Run("invalid-runs-value-ignored", func(t *testing.T) {
+		tt := testTracer(t)
+		defer tt.Stop()
+
+		ds := createTestDataset(t)
+		task := createTestTask()
+
+		exp, err := experiment.New(
+			"test-experiment-invalid-runs",
+			task,
+			ds,
+			nil,
+			experiment.WithProjectName("test-project"),
+			experiment.WithRuns(0), // should be ignored, defaulting to 1
+		)
+		require.NoError(t, err)
+
+		results, err := exp.Run(context.Background())
+		require.NoError(t, err)
+		assert.Len(t, results.Runs, 1)
+	})
+}
+
 func TestExperimentURL(t *testing.T) {
 	run := func(t *testing.T) string {
 		tt := testTracer(t)
@@ -626,10 +846,12 @@ func createMockHandler() testtracer.MockResponseFunc {
 		switch {
 		case path == "/api/unstable/llm-obs/v1/projects":
 			return handleMockProjects(r)
-		case path == "/api/unstable/llm-obs/v1/experiments":
+		case path == "/api/unstable/llm-obs/v1/experiments" && r.Method == http.MethodPost:
 			return handleMockExperiments(r)
 		case strings.HasPrefix(path, "/api/unstable/llm-obs/v1/experiments/") && strings.HasSuffix(path, "/events"):
 			return handleMockExperimentEvents(r)
+		case strings.HasPrefix(path, "/api/unstable/llm-obs/v1/experiments/") && r.Method == http.MethodPatch:
+			return handleMockExperimentStatusUpdate(r)
 		case strings.Contains(path, "/datasets") && strings.HasSuffix(path, "/batch_update"):
 			return handleMockDatasetBatchUpdate(r)
 		case strings.Contains(path, "/datasets"):
@@ -683,6 +905,16 @@ func handleMockExperiments(r *http.Request) *http.Response {
 		StatusCode: http.StatusOK,
 		Header:     make(http.Header),
 		Body:       io.NopCloser(bytes.NewReader(respData)),
+		Request:    r,
+	}
+}
+
+func handleMockExperimentStatusUpdate(r *http.Request) *http.Response {
+	return &http.Response{
+		Status:     "200 OK",
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(`{}`)),
 		Request:    r,
 	}
 }
@@ -811,6 +1043,275 @@ func createTestTask() experiment.Task {
 			return "Unknown", nil
 		}
 	})
+}
+
+// statusUpdate captures a single PATCH status call to the backend.
+type statusUpdate struct {
+	Status string
+	Error  string
+}
+
+// captureStatusUpdates returns a mock handler that records every experiment status
+// PATCH alongside the default mock handler for all other requests.
+func captureStatusUpdates(updates *[]statusUpdate) testtracer.MockResponseFunc {
+	base := createMockHandler()
+	return func(r *http.Request) *http.Response {
+		path := strings.TrimPrefix(r.URL.Path, "/evp_proxy/v2")
+		if strings.HasPrefix(path, "/api/unstable/llm-obs/v1/experiments/") && r.Method == http.MethodPatch {
+			var body struct {
+				Data struct {
+					Attributes struct {
+						Status string `json:"status"`
+						Error  string `json:"error"`
+					} `json:"attributes"`
+				} `json:"data"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err == nil {
+				*updates = append(*updates, statusUpdate{
+					Status: body.Data.Attributes.Status,
+					Error:  body.Data.Attributes.Error,
+				})
+			}
+			return handleMockExperimentStatusUpdate(r)
+		}
+		return base(r)
+	}
+}
+
+func TestExperimentStatusUpdates(t *testing.T) {
+	t.Run("completed-on-success", func(t *testing.T) {
+		var updates []statusUpdate
+		tt := testTracer(t, testtracer.WithMockResponses(captureStatusUpdates(&updates)))
+		defer tt.Stop()
+
+		exp, err := experiment.New(
+			"test-status-completed",
+			createTestTask(),
+			createTestDataset(t),
+			createTestEvaluators(),
+			experiment.WithProjectName("test-project"),
+		)
+		require.NoError(t, err)
+
+		_, err = exp.Run(context.Background())
+		require.NoError(t, err)
+
+		require.Len(t, updates, 2)
+		assert.Equal(t, "running", updates[0].Status)
+		assert.Equal(t, "completed", updates[1].Status)
+		assert.Empty(t, updates[1].Error)
+	})
+
+	t.Run("failed-when-task-errors-occur", func(t *testing.T) {
+		var updates []statusUpdate
+		tt := testTracer(t, testtracer.WithMockResponses(captureStatusUpdates(&updates)))
+		defer tt.Stop()
+
+		task := experiment.NewTask("failing-task", func(ctx context.Context, rec dataset.Record, _ map[string]any) (any, error) {
+			return nil, errors.New("task boom")
+		})
+
+		exp, err := experiment.New(
+			"test-status-task-failed",
+			task,
+			createTestDataset(t),
+			nil,
+			experiment.WithProjectName("test-project"),
+		)
+		require.NoError(t, err)
+
+		_, err = exp.Run(context.Background(), experiment.WithAbortOnError(false))
+		require.NoError(t, err) // run itself succeeds; errors are in results
+
+		require.Len(t, updates, 2)
+		assert.Equal(t, "running", updates[0].Status)
+		assert.Equal(t, "failed", updates[1].Status)
+		assert.Contains(t, updates[1].Error, "task boom")
+	})
+
+	t.Run("failed-with-evaluator-errors", func(t *testing.T) {
+		var updates []statusUpdate
+		tt := testTracer(t, testtracer.WithMockResponses(captureStatusUpdates(&updates)))
+		defer tt.Stop()
+
+		evaluators := []experiment.Evaluator{
+			experiment.NewEvaluator("bad-eval", func(ctx context.Context, rec dataset.Record, output any) (any, error) {
+				return nil, errors.New("eval boom")
+			}),
+		}
+
+		exp, err := experiment.New(
+			"test-status-eval-failed",
+			createTestTask(),
+			createTestDataset(t),
+			evaluators,
+			experiment.WithProjectName("test-project"),
+		)
+		require.NoError(t, err)
+
+		_, err = exp.Run(context.Background(), experiment.WithAbortOnError(false))
+		require.NoError(t, err)
+
+		require.Len(t, updates, 2)
+		assert.Equal(t, "running", updates[0].Status)
+		assert.Equal(t, "failed", updates[1].Status)
+		assert.Contains(t, updates[1].Error, "bad-eval: eval boom")
+	})
+
+	t.Run("failed-with-summary-evaluator-errors", func(t *testing.T) {
+		var updates []statusUpdate
+		tt := testTracer(t, testtracer.WithMockResponses(captureStatusUpdates(&updates)))
+		defer tt.Stop()
+
+		exp, err := experiment.New(
+			"test-status-sumeval-failed",
+			createTestTask(),
+			createTestDataset(t),
+			nil,
+			experiment.WithProjectName("test-project"),
+			experiment.WithSummaryEvaluators(
+				experiment.NewSummaryEvaluator("bad-summary", func(ctx context.Context, results []*experiment.RecordResult) (any, error) {
+					return nil, errors.New("summary boom")
+				}),
+			),
+		)
+		require.NoError(t, err)
+
+		_, err = exp.Run(context.Background(), experiment.WithAbortOnError(false))
+		require.NoError(t, err)
+
+		require.Len(t, updates, 2)
+		assert.Equal(t, "running", updates[0].Status)
+		assert.Equal(t, "failed", updates[1].Status)
+		assert.Contains(t, updates[1].Error, "bad-summary: summary boom")
+	})
+
+	t.Run("failed-on-abort-error", func(t *testing.T) {
+		var updates []statusUpdate
+		tt := testTracer(t, testtracer.WithMockResponses(captureStatusUpdates(&updates)))
+		defer tt.Stop()
+
+		task := experiment.NewTask("failing-task", func(ctx context.Context, rec dataset.Record, _ map[string]any) (any, error) {
+			return nil, errors.New("hard abort")
+		})
+
+		exp, err := experiment.New(
+			"test-status-abort",
+			task,
+			createTestDataset(t),
+			nil,
+			experiment.WithProjectName("test-project"),
+		)
+		require.NoError(t, err)
+
+		_, err = exp.Run(context.Background(), experiment.WithAbortOnError(true))
+		require.Error(t, err)
+
+		require.Len(t, updates, 2)
+		assert.Equal(t, "running", updates[0].Status)
+		assert.Equal(t, "failed", updates[1].Status)
+		assert.Contains(t, updates[1].Error, "hard abort")
+	})
+
+	t.Run("interrupted-on-context-cancellation", func(t *testing.T) {
+		var updates []statusUpdate
+		tt := testTracer(t, testtracer.WithMockResponses(captureStatusUpdates(&updates)))
+		defer tt.Stop()
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// Cancel the context as soon as the task starts running.
+		task := experiment.NewTask("cancelling-task", func(ctx context.Context, rec dataset.Record, _ map[string]any) (any, error) {
+			cancel()
+			return nil, ctx.Err()
+		})
+
+		exp, err := experiment.New(
+			"test-status-interrupted",
+			task,
+			createTestDataset(t),
+			nil,
+			experiment.WithProjectName("test-project"),
+		)
+		require.NoError(t, err)
+
+		_, err = exp.Run(ctx, experiment.WithAbortOnError(true))
+		require.Error(t, err)
+
+		require.Len(t, updates, 2)
+		assert.Equal(t, "running", updates[0].Status)
+		assert.Equal(t, "interrupted", updates[1].Status)
+	})
+
+	t.Run("no-status-sent-if-experiment-creation-fails", func(t *testing.T) {
+		var updates []statusUpdate
+		h := func(r *http.Request) *http.Response {
+			path := strings.TrimPrefix(r.URL.Path, "/evp_proxy/v2")
+			if path == "/api/unstable/llm-obs/v1/experiments" && r.Method == http.MethodPost {
+				return &http.Response{
+					Status:     "500 Internal Server Error",
+					StatusCode: http.StatusInternalServerError,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(`{"error":"backend unavailable"}`)),
+					Request:    r,
+				}
+			}
+			return captureStatusUpdates(&updates)(r)
+		}
+
+		tt := testTracer(t, testtracer.WithMockResponses(h))
+		defer tt.Stop()
+
+		exp, err := experiment.New(
+			"test-status-no-creation",
+			createTestTask(),
+			createTestDataset(t),
+			nil,
+			experiment.WithProjectName("test-project"),
+		)
+		require.NoError(t, err)
+
+		_, err = exp.Run(context.Background())
+		require.Error(t, err)
+
+		assert.Empty(t, updates, "no status updates should be sent if experiment creation fails")
+	})
+
+	t.Run("running-sent-once-for-multi-run", func(t *testing.T) {
+		var updates []statusUpdate
+		tt := testTracer(t, testtracer.WithMockResponses(captureStatusUpdates(&updates)))
+		defer tt.Stop()
+
+		exp, err := experiment.New(
+			"test-status-multi-run",
+			createTestTask(),
+			createTestDataset(t),
+			nil,
+			experiment.WithProjectName("test-project"),
+			experiment.WithRuns(3),
+		)
+		require.NoError(t, err)
+
+		_, err = exp.Run(context.Background())
+		require.NoError(t, err)
+
+		// Status is experiment-level, not per-run: exactly one "running" and one "completed".
+		require.Len(t, updates, 2)
+		assert.Equal(t, "running", updates[0].Status)
+		assert.Equal(t, "completed", updates[1].Status)
+	})
+}
+
+// spanTagValue extracts the value for key from a []string tag slice where entries
+// are formatted as "key:value".
+func spanTagValue(tags []string, key string) string {
+	prefix := key + ":"
+	for _, t := range tags {
+		if strings.HasPrefix(t, prefix) {
+			return t[len(prefix):]
+		}
+	}
+	return ""
 }
 
 func createTestEvaluators() []experiment.Evaluator {

--- a/llmobs/experiment/option.go
+++ b/llmobs/experiment/option.go
@@ -15,6 +15,7 @@ type newCfg struct {
 	tags              map[string]string
 	experimentCfg     map[string]any
 	summaryEvaluators []SummaryEvaluator
+	runs              int
 }
 
 func defaultNewCfg(globalCfg *config.Config) *newCfg {
@@ -24,6 +25,7 @@ func defaultNewCfg(globalCfg *config.Config) *newCfg {
 		tags:              nil,
 		experimentCfg:     nil,
 		summaryEvaluators: nil,
+		runs:              1,
 	}
 }
 
@@ -59,6 +61,17 @@ func WithExperimentConfig(experimentCfg map[string]any) Option {
 func WithSummaryEvaluators(summaryEvaluators ...SummaryEvaluator) Option {
 	return func(cfg *newCfg) {
 		cfg.summaryEvaluators = summaryEvaluators
+	}
+}
+
+// WithRuns sets the number of times the experiment will be executed end-to-end.
+// Each run gets a unique run ID and a 1-indexed iteration number, both propagated
+// as tags on spans and evaluation metric events. Defaults to 1.
+func WithRuns(n int) Option {
+	return func(cfg *newCfg) {
+		if n > 0 {
+			cfg.runs = n
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

- Adds `llmobs/experiment.WithRuns(n)` option to enable multiple runs (https://docs.datadoghq.com/llm_observability/experiments/advanced_runs/#multiple-runs).
- Implements experiment lifecycle status, so now the backend is notified of the experiment's state throughout execution: running when it starts, completed or failed when it finishes (based on whether any errors occurred), and interrupted if the context is cancelled before completion.
- Propagate `experiment_id`, `run_id`, and `run_iteration` across distributed boundaries via APM baggage keys. Any LLMObs span started in a downstream service automatically inherits these fields as tags and gets scope=experiments.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
