### PR TITLE
fix: test app fails on schedule

### DIFF
--- a/.github/workflows/test-apps-schedule.yml
+++ b/.github/workflows/test-apps-schedule.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   nightly:
+    if: github.event.schedule == '0 0 * * *'
     uses: ./.github/workflows/test-apps.yml
     secrets: inherit
     permissions:

--- a/.github/workflows/test-apps-schedule.yml
+++ b/.github/workflows/test-apps-schedule.yml
@@ -11,7 +11,6 @@ permissions:
 
 jobs:
   nightly:
-    if: github.event.schedule == '0 0 * * *'
     uses: ./.github/workflows/test-apps.yml
     secrets: inherit
     permissions:

--- a/.github/workflows/test-apps-schedule.yml
+++ b/.github/workflows/test-apps-schedule.yml
@@ -1,6 +1,7 @@
 # See /internal/apps/README.md for more information.
 name: "Test Apps Schedule"
 on:
+  pull_request:
   workflow_dispatch: # manually (just for testing the cron)
   schedule:
     - cron: "0 0 * * *" # nightly
@@ -11,7 +12,6 @@ permissions:
 
 jobs:
   nightly:
-    if: github.event.schedule == '0 0 * * *'
     uses: ./.github/workflows/test-apps.yml
     secrets: inherit
     permissions:

--- a/.github/workflows/test-apps-schedule.yml
+++ b/.github/workflows/test-apps-schedule.yml
@@ -1,22 +1,16 @@
 # See /internal/apps/README.md for more information.
 name: "Test Apps Schedule"
 on:
-  pull_request:
   workflow_dispatch: # manually (just for testing the cron)
   schedule:
     - cron: "0 0 * * *" # nightly
     - cron: "0 0 * * 2" # weekly (tuesdays)
 
-permissions:
-  contents: read
-
 jobs:
   nightly:
+    if: github.event.schedule == '0 0 * * *'
     uses: ./.github/workflows/test-apps.yml
     secrets: inherit
-    permissions:
-      id-token: write
-      contents: read
     with:
       "arg: scenario_duration": "10m"
       "arg: tags": "trigger:nightly"
@@ -25,9 +19,6 @@ jobs:
     if: github.event.schedule == '0 0 * * 2'
     uses: ./.github/workflows/test-apps.yml
     secrets: inherit
-    permissions:
-      id-token: write
-      contents: read
     with:
       "arg: scenario_duration": "1h"
       "arg: tags": "trigger:weekly"

--- a/.github/workflows/test-apps-schedule.yml
+++ b/.github/workflows/test-apps-schedule.yml
@@ -6,11 +6,17 @@ on:
     - cron: "0 0 * * *" # nightly
     - cron: "0 0 * * 2" # weekly (tuesdays)
 
+permissions:
+  contents: read
+
 jobs:
   nightly:
     if: github.event.schedule == '0 0 * * *'
     uses: ./.github/workflows/test-apps.yml
     secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
     with:
       "arg: scenario_duration": "10m"
       "arg: tags": "trigger:nightly"
@@ -19,6 +25,9 @@ jobs:
     if: github.event.schedule == '0 0 * * 2'
     uses: ./.github/workflows/test-apps.yml
     secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
     with:
       "arg: scenario_duration": "1h"
       "arg: tags": "trigger:weekly"

--- a/.github/workflows/test-apps.yml
+++ b/.github/workflows/test-apps.yml
@@ -114,7 +114,7 @@ jobs:
         id: dd-sts
         uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75
         with:
-          policy: dd-trace-go
+          policy: dd-trace-go-staging
       - name: Start Agent
         uses: datadog/agent-github-action@8240b406d73cb84cd5085a3919a78f59c258da3a # v1.3.1
         with:
@@ -178,7 +178,7 @@ jobs:
         id: dd-sts
         uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75
         with:
-          policy: dd-trace-go
+          policy: dd-trace-go-staging
       - name: Start Agent
         uses: datadog/agent-github-action@8240b406d73cb84cd5085a3919a78f59c258da3a # v1.3.1
         with:
@@ -242,7 +242,7 @@ jobs:
         id: dd-sts
         uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75
         with:
-          policy: dd-trace-go
+          policy: dd-trace-go-staging
       - name: Start Agent
         uses: datadog/agent-github-action@8240b406d73cb84cd5085a3919a78f59c258da3a # v1.3.1
         with:
@@ -306,7 +306,7 @@ jobs:
         id: dd-sts
         uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75
         with:
-          policy: dd-trace-go
+          policy: dd-trace-go-staging
       - name: Start Agent
         uses: datadog/agent-github-action@8240b406d73cb84cd5085a3919a78f59c258da3a # v1.3.1
         with:
@@ -370,7 +370,7 @@ jobs:
         id: dd-sts
         uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75
         with:
-          policy: dd-trace-go
+          policy: dd-trace-go-staging
       - name: Start Agent
         uses: datadog/agent-github-action@8240b406d73cb84cd5085a3919a78f59c258da3a # v1.3.1
         with:

--- a/.github/workflows/test-apps.yml
+++ b/.github/workflows/test-apps.yml
@@ -33,6 +33,9 @@ name: Test Apps
         description: The branch to run the workflow on
         required: false
         type: string
+  push:
+    branches:
+      - hannahkm/fix-test-app
   workflow_dispatch:
     inputs:
       scenarios:

--- a/.github/workflows/test-apps.yml
+++ b/.github/workflows/test-apps.yml
@@ -33,10 +33,6 @@ name: Test Apps
         description: The branch to run the workflow on
         required: false
         type: string
-  pull_request:
-  push:
-    branches:
-      - hannahkm/fix-test-app
   workflow_dispatch:
     inputs:
       scenarios:
@@ -75,7 +71,7 @@ jobs:
   job-0-0:
     name: unit-of-work/v1 (prod)
     runs-on: ubuntu-latest
-    if: 'inputs[''env: prod'']'
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''unit-of-work/v1'') && inputs[''env: prod'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -107,7 +103,7 @@ jobs:
   job-0-1:
     name: unit-of-work/v1 (staging)
     runs-on: ubuntu-latest
-    if: 'inputs[''env: staging'']'
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''unit-of-work/v1'') && inputs[''env: staging'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -139,7 +135,7 @@ jobs:
   job-1-0:
     name: unit-of-work/v2 (prod)
     runs-on: ubuntu-latest
-    if: 'inputs[''env: prod'']'
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''unit-of-work/v2'') && inputs[''env: prod'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -171,7 +167,7 @@ jobs:
   job-1-1:
     name: unit-of-work/v2 (staging)
     runs-on: ubuntu-latest
-    if: 'inputs[''env: staging'']'
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''unit-of-work/v2'') && inputs[''env: staging'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -203,7 +199,7 @@ jobs:
   job-2-0:
     name: memory-leak/goroutine (prod)
     runs-on: ubuntu-latest
-    if: 'inputs[''env: prod'']'
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''memory-leak/goroutine'') && inputs[''env: prod'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -235,7 +231,7 @@ jobs:
   job-2-1:
     name: memory-leak/goroutine (staging)
     runs-on: ubuntu-latest
-    if: 'inputs[''env: staging'']'
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''memory-leak/goroutine'') && inputs[''env: staging'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -267,7 +263,7 @@ jobs:
   job-3-0:
     name: memory-leak/heap (prod)
     runs-on: ubuntu-latest
-    if: 'inputs[''env: prod'']'
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''memory-leak/heap'') && inputs[''env: prod'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -299,7 +295,7 @@ jobs:
   job-3-1:
     name: memory-leak/heap (staging)
     runs-on: ubuntu-latest
-    if: 'inputs[''env: staging'']'
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''memory-leak/heap'') && inputs[''env: staging'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -331,7 +327,7 @@ jobs:
   job-4-0:
     name: memory-leak/goroutine-heap (prod)
     runs-on: ubuntu-latest
-    if: 'inputs[''env: prod'']'
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''memory-leak/goroutine-heap'') && inputs[''env: prod'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -363,7 +359,7 @@ jobs:
   job-4-1:
     name: memory-leak/goroutine-heap (staging)
     runs-on: ubuntu-latest
-    if: 'inputs[''env: staging'']'
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''memory-leak/goroutine-heap'') && inputs[''env: staging'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test-apps.yml
+++ b/.github/workflows/test-apps.yml
@@ -33,6 +33,7 @@ name: Test Apps
         description: The branch to run the workflow on
         required: false
         type: string
+  pull_request:
   push:
     branches:
       - hannahkm/fix-test-app

--- a/.github/workflows/test-apps.yml
+++ b/.github/workflows/test-apps.yml
@@ -74,7 +74,7 @@ jobs:
   job-0-0:
     name: unit-of-work/v1 (prod)
     runs-on: ubuntu-latest
-    if: 'contains(fromJSON(inputs[''scenarios'']), ''unit-of-work/v1'') && inputs[''env: prod'']'
+    if: 'inputs[''env: prod'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -106,7 +106,7 @@ jobs:
   job-0-1:
     name: unit-of-work/v1 (staging)
     runs-on: ubuntu-latest
-    if: 'contains(fromJSON(inputs[''scenarios'']), ''unit-of-work/v1'') && inputs[''env: staging'']'
+    if: 'inputs[''env: staging'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -138,7 +138,7 @@ jobs:
   job-1-0:
     name: unit-of-work/v2 (prod)
     runs-on: ubuntu-latest
-    if: 'contains(fromJSON(inputs[''scenarios'']), ''unit-of-work/v2'') && inputs[''env: prod'']'
+    if: 'inputs[''env: prod'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -170,7 +170,7 @@ jobs:
   job-1-1:
     name: unit-of-work/v2 (staging)
     runs-on: ubuntu-latest
-    if: 'contains(fromJSON(inputs[''scenarios'']), ''unit-of-work/v2'') && inputs[''env: staging'']'
+    if: 'inputs[''env: staging'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -202,7 +202,7 @@ jobs:
   job-2-0:
     name: memory-leak/goroutine (prod)
     runs-on: ubuntu-latest
-    if: 'contains(fromJSON(inputs[''scenarios'']), ''memory-leak/goroutine'') && inputs[''env: prod'']'
+    if: 'inputs[''env: prod'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -234,7 +234,7 @@ jobs:
   job-2-1:
     name: memory-leak/goroutine (staging)
     runs-on: ubuntu-latest
-    if: 'contains(fromJSON(inputs[''scenarios'']), ''memory-leak/goroutine'') && inputs[''env: staging'']'
+    if: 'inputs[''env: staging'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -266,7 +266,7 @@ jobs:
   job-3-0:
     name: memory-leak/heap (prod)
     runs-on: ubuntu-latest
-    if: 'contains(fromJSON(inputs[''scenarios'']), ''memory-leak/heap'') && inputs[''env: prod'']'
+    if: 'inputs[''env: prod'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -298,7 +298,7 @@ jobs:
   job-3-1:
     name: memory-leak/heap (staging)
     runs-on: ubuntu-latest
-    if: 'contains(fromJSON(inputs[''scenarios'']), ''memory-leak/heap'') && inputs[''env: staging'']'
+    if: 'inputs[''env: staging'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -330,7 +330,7 @@ jobs:
   job-4-0:
     name: memory-leak/goroutine-heap (prod)
     runs-on: ubuntu-latest
-    if: 'contains(fromJSON(inputs[''scenarios'']), ''memory-leak/goroutine-heap'') && inputs[''env: prod'']'
+    if: 'inputs[''env: prod'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -362,7 +362,7 @@ jobs:
   job-4-1:
     name: memory-leak/goroutine-heap (staging)
     runs-on: ubuntu-latest
-    if: 'contains(fromJSON(inputs[''scenarios'']), ''memory-leak/goroutine-heap'') && inputs[''env: staging'']'
+    if: 'inputs[''env: staging'']'
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Uses a staging policy for `test-app`, which requires API keys in staging (org 2).

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Testing

<img width="1146" height="559" alt="image" src="https://github.com/user-attachments/assets/6152294f-3068-4862-bb47-a18aa07fe628" />
yippee

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
