### PR TITLE
fix(contrib/aws/aws-sdk-go-v2): skip `_datadog` attribute if batch size larger than 262144-byte payload limit

### DIFF
--- a/contrib/aws/aws-sdk-go-v2/internal/sns/sns.go
+++ b/contrib/aws/aws-sdk-go-v2/internal/sns/sns.go
@@ -87,8 +87,9 @@ func handlePublishBatch(span *tracer.Span, in middleware.InitializeInput) {
 		if params.PublishBatchRequestEntries[i].MessageAttributes == nil {
 			params.PublishBatchRequestEntries[i].MessageAttributes = make(map[string]types.MessageAttributeValue)
 		}
-		injectTraceContext(traceContext, params.PublishBatchRequestEntries[i].MessageAttributes)
-		runningSize += ctxSize
+		if injectTraceContext(traceContext, params.PublishBatchRequestEntries[i].MessageAttributes) {
+			runningSize += ctxSize
+		}
 	}
 }
 
@@ -155,14 +156,13 @@ func batchTotalSize(entries []types.PublishBatchRequestEntry) int {
 	return total
 }
 
-func injectTraceContext(traceContext types.MessageAttributeValue, messageAttributes map[string]types.MessageAttributeValue) {
-	// SNS only allows a maximum of 10 message attributes.
+func injectTraceContext(traceContext types.MessageAttributeValue, messageAttributes map[string]types.MessageAttributeValue) bool {
 	// https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html
-	// Only inject if there's room.
 	if len(messageAttributes) >= maxMessageAttributes {
 		instr.Logger().Info("Cannot inject trace context: message already has maximum allowed attributes")
-		return
+		return false
 	}
 
 	messageAttributes[datadogKey] = traceContext
+	return true
 }

--- a/contrib/aws/aws-sdk-go-v2/internal/sns/sns.go
+++ b/contrib/aws/aws-sdk-go-v2/internal/sns/sns.go
@@ -20,6 +20,11 @@ import (
 const (
 	datadogKey           = "_datadog"
 	maxMessageAttributes = 10
+	// maxMessageSizeBytes is the SNS maximum payload size for both Publish and
+	// PublishBatch (262 144 bytes), minus a 256-byte safety margin for potential
+	// undocumented framing overhead in SNS's internal size accounting.
+	// https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html
+	maxMessageSizeBytes = 262144 - 256
 )
 
 var instr = internal.Instr
@@ -46,10 +51,15 @@ func handlePublish(span *tracer.Span, in middleware.InitializeInput) {
 		return
 	}
 
+	msgSize := publishInputSize(params)
+	if msgSize+attributeSize(datadogKey, traceContext) > maxMessageSizeBytes {
+		instr.Logger().Debug("Cannot inject trace context: message size limit would be exceeded")
+		return
+	}
+
 	if params.MessageAttributes == nil {
 		params.MessageAttributes = make(map[string]types.MessageAttributeValue)
 	}
-
 	injectTraceContext(traceContext, params.MessageAttributes)
 }
 
@@ -66,11 +76,19 @@ func handlePublishBatch(span *tracer.Span, in middleware.InitializeInput) {
 		return
 	}
 
+	ctxSize := attributeSize(datadogKey, traceContext)
+	runningSize := batchTotalSize(params.PublishBatchRequestEntries)
+
 	for i := range params.PublishBatchRequestEntries {
+		if runningSize+ctxSize > maxMessageSizeBytes {
+			instr.Logger().Debug("Cannot inject trace context: batch size limit would be exceeded")
+			break
+		}
 		if params.PublishBatchRequestEntries[i].MessageAttributes == nil {
 			params.PublishBatchRequestEntries[i].MessageAttributes = make(map[string]types.MessageAttributeValue)
 		}
 		injectTraceContext(traceContext, params.PublishBatchRequestEntries[i].MessageAttributes)
+		runningSize += ctxSize
 	}
 }
 
@@ -94,6 +112,47 @@ func getTraceContext(span *tracer.Span) (types.MessageAttributeValue, error) {
 	}
 
 	return attribute, nil
+}
+
+// attributeSize returns the byte size SNS counts for a single message attribute:
+// name + data type + value length.
+func attributeSize(name string, attr types.MessageAttributeValue) int {
+	size := len(name)
+	if attr.DataType != nil {
+		size += len(*attr.DataType)
+	}
+	if attr.StringValue != nil {
+		size += len(*attr.StringValue)
+	}
+	size += len(attr.BinaryValue)
+	return size
+}
+
+func sizeAttributes(attrs map[string]types.MessageAttributeValue) int {
+	size := 0
+	for name, attr := range attrs {
+		size += attributeSize(name, attr)
+	}
+	return size
+}
+
+func publishInputSize(params *sns.PublishInput) int {
+	size := 0
+	if params.Message != nil {
+		size += len(*params.Message)
+	}
+	return size + sizeAttributes(params.MessageAttributes)
+}
+
+func batchTotalSize(entries []types.PublishBatchRequestEntry) int {
+	total := 0
+	for _, entry := range entries {
+		if entry.Message != nil {
+			total += len(*entry.Message)
+		}
+		total += sizeAttributes(entry.MessageAttributes)
+	}
+	return total
 }
 
 func injectTraceContext(traceContext types.MessageAttributeValue, messageAttributes map[string]types.MessageAttributeValue) {

--- a/contrib/aws/aws-sdk-go-v2/internal/sns/sns_test.go
+++ b/contrib/aws/aws-sdk-go-v2/internal/sns/sns_test.go
@@ -113,6 +113,118 @@ func TestEnrichOperation(t *testing.T) {
 	}
 }
 
+func TestPublishSizeLimit(t *testing.T) {
+	t.Run("body at limit blocks injection", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		span, _ := tracer.StartSpanFromContext(context.Background(), "test-span")
+
+		input := middleware.InitializeInput{
+			Parameters: &sns.PublishInput{
+				Message:  aws.String(string(make([]byte, maxMessageSizeBytes))),
+				TopicArn: aws.String("arn:aws:sns:us-east-1:123456789012:test-topic"),
+			},
+		}
+
+		EnrichOperation(span, input, "Publish")
+
+		params := input.Parameters.(*sns.PublishInput)
+		assert.NotContains(t, params.MessageAttributes, datadogKey)
+	})
+
+	t.Run("body plus existing attributes at limit blocks injection", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		span, _ := tracer.StartSpanFromContext(context.Background(), "test-span")
+		traceCtx, err := getTraceContext(span)
+		require.NoError(t, err)
+		ctxSize := attributeSize(datadogKey, traceCtx)
+
+		// Existing attribute eats into budget; body fills the rest.
+		existingAttr := types.MessageAttributeValue{
+			DataType:    aws.String("String"),
+			StringValue: aws.String("val"),
+		}
+		existingAttrSize := attributeSize("myattr", existingAttr)
+		bodyLen := maxMessageSizeBytes - existingAttrSize - ctxSize + 1 // +1 to go over
+		require.Positive(t, bodyLen)
+
+		input := middleware.InitializeInput{
+			Parameters: &sns.PublishInput{
+				Message:  aws.String(string(make([]byte, bodyLen))),
+				TopicArn: aws.String("arn:aws:sns:us-east-1:123456789012:test-topic"),
+				MessageAttributes: map[string]types.MessageAttributeValue{
+					"myattr": existingAttr,
+				},
+			},
+		}
+
+		EnrichOperation(span, input, "Publish")
+
+		params := input.Parameters.(*sns.PublishInput)
+		assert.NotContains(t, params.MessageAttributes, datadogKey)
+	})
+}
+
+func TestPublishBatchSizeLimit(t *testing.T) {
+	t.Run("partial injection when budget exhausted", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		span, _ := tracer.StartSpanFromContext(context.Background(), "test-span")
+
+		traceCtx, err := getTraceContext(span)
+		require.NoError(t, err)
+		ctxSize := attributeSize(datadogKey, traceCtx)
+
+		// Layout: firstBody + secondBody + ctxSize = maxMessageSizeBytes.
+		// Injecting _datadog into entry 1 fills budget exactly;
+		// entry 2 would push over → skipped.
+		firstBody := "x"
+		secondBodyLen := maxMessageSizeBytes - len(firstBody) - ctxSize
+		require.Positive(t, secondBodyLen, "test setup: secondBodyLen must be positive")
+
+		input := middleware.InitializeInput{
+			Parameters: &sns.PublishBatchInput{
+				TopicArn: aws.String("arn:aws:sns:us-east-1:123456789012:test-topic"),
+				PublishBatchRequestEntries: []types.PublishBatchRequestEntry{
+					{Id: aws.String("1"), Message: aws.String(firstBody)},
+					{Id: aws.String("2"), Message: aws.String(string(make([]byte, secondBodyLen)))},
+				},
+			},
+		}
+
+		EnrichOperation(span, input, "PublishBatch")
+
+		params := input.Parameters.(*sns.PublishBatchInput)
+		assert.Contains(t, params.PublishBatchRequestEntries[0].MessageAttributes, datadogKey)
+		assert.NotContains(t, params.PublishBatchRequestEntries[1].MessageAttributes, datadogKey)
+	})
+
+	t.Run("single entry at limit blocks injection", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		span, _ := tracer.StartSpanFromContext(context.Background(), "test-span")
+
+		input := middleware.InitializeInput{
+			Parameters: &sns.PublishBatchInput{
+				TopicArn: aws.String("arn:aws:sns:us-east-1:123456789012:test-topic"),
+				PublishBatchRequestEntries: []types.PublishBatchRequestEntry{
+					{Id: aws.String("1"), Message: aws.String(string(make([]byte, maxMessageSizeBytes)))},
+				},
+			},
+		}
+
+		EnrichOperation(span, input, "PublishBatch")
+
+		params := input.Parameters.(*sns.PublishBatchInput)
+		assert.NotContains(t, params.PublishBatchRequestEntries[0].MessageAttributes, datadogKey)
+	})
+}
+
 func TestInjectTraceContext(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/contrib/aws/aws-sdk-go-v2/internal/sns/sns_test.go
+++ b/contrib/aws/aws-sdk-go-v2/internal/sns/sns_test.go
@@ -203,6 +203,50 @@ func TestPublishBatchSizeLimit(t *testing.T) {
 		assert.NotContains(t, params.PublishBatchRequestEntries[1].MessageAttributes, datadogKey)
 	})
 
+	t.Run("full-attribute entry does not inflate running size", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		span, _ := tracer.StartSpanFromContext(context.Background(), "test-span")
+
+		traceCtx, err := getTraceContext(span)
+		require.NoError(t, err)
+		ctxSize := attributeSize(datadogKey, traceCtx)
+
+		// entry[0] has max attributes so injection is skipped;
+		// entry[1] has room and must still receive _datadog.
+		fullAttrs := make(map[string]types.MessageAttributeValue)
+		for i := range maxMessageAttributes {
+			fullAttrs[fmt.Sprintf("attr%d", i)] = types.MessageAttributeValue{
+				DataType:    aws.String("String"),
+				StringValue: aws.String("v"),
+			}
+		}
+
+		smallBody := "small"
+		fullAttrsSize := sizeAttributes(fullAttrs)
+		bodyLen := maxMessageSizeBytes - fullAttrsSize - len(smallBody) - ctxSize
+		require.Positive(t, bodyLen, "test setup: bodyLen must leave room for one injection")
+
+		input := middleware.InitializeInput{
+			Parameters: &sns.PublishBatchInput{
+				TopicArn: aws.String("arn:aws:sns:us-east-1:123456789012:test-topic"),
+				PublishBatchRequestEntries: []types.PublishBatchRequestEntry{
+					{Id: aws.String("1"), Message: aws.String(string(make([]byte, bodyLen))), MessageAttributes: fullAttrs},
+					{Id: aws.String("2"), Message: aws.String(smallBody)},
+				},
+			},
+		}
+
+		EnrichOperation(span, input, "PublishBatch")
+
+		params := input.Parameters.(*sns.PublishBatchInput)
+		assert.NotContains(t, params.PublishBatchRequestEntries[0].MessageAttributes, datadogKey,
+			"entry with max attributes should not get _datadog")
+		assert.Contains(t, params.PublishBatchRequestEntries[1].MessageAttributes, datadogKey,
+			"entry with room should still get _datadog when prior entry was skipped")
+	})
+
 	t.Run("single entry at limit blocks injection", func(t *testing.T) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
@@ -265,7 +309,8 @@ func TestInjectTraceContext(t *testing.T) {
 
 			traceContext, err := getTraceContext(span)
 			assert.NoError(t, err)
-			injectTraceContext(traceContext, messageAttributes)
+			injected := injectTraceContext(traceContext, messageAttributes)
+			assert.Equal(t, tt.expectInjection, injected)
 
 			if tt.expectInjection {
 				assert.Contains(t, messageAttributes, datadogKey)


### PR DESCRIPTION
### What does this PR do?

SNS `_datadog` trace context injection (about 338 bytes) was unconditionally added to every message, pushing payloads over SNS's 262,144-byte limit and causing `BatchRequestTooLong` errors.

### Motivation

Fixes #4664.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.

Unsure? Have a question? Request a review!
