### PR TITLE
test(sampler): verify formatKnuthSamplingRate output and locale-independence

### DIFF
--- a/ddtrace/tracer/sampler_test.go
+++ b/ddtrace/tracer/sampler_test.go
@@ -2264,6 +2264,31 @@ func TestKnuthSamplingRateWithFloatRules(t *testing.T) {
 	}
 }
 
+func TestFormatKnuthSamplingRate(t *testing.T) {
+	// Go's strconv.AppendFloat (used by formatKnuthSamplingRate) is
+	// locale-independent by design — it always uses '.' as the decimal
+	// separator. This test documents that contract and verifies the
+	// trailing-zero trimming behavior.
+	tests := []struct {
+		rate float64
+		want string
+	}{
+		{0.3, "0.3"},
+		{1.0, "1"},
+		{0.0, "0"},
+		{0.5, "0.5"},
+		{0.000001, "0.000001"},
+		{0.0000001, "0"},
+		{0.00000051, "0.000001"},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%v", tt.rate), func(t *testing.T) {
+			got := formatKnuthSamplingRate(tt.rate)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func BenchmarkFormatKnuthSamplingRate(b *testing.B) {
 	rates := []float64{1.0, 0.5, 0.000001, 0.0000001, 0.00000051, 0.7654321}
 	b.ResetTimer()


### PR DESCRIPTION
### What does this PR do?

Adds a unit test for `formatKnuthSamplingRate` that verifies output correctness and documents the locale-independence contract. The test covers decimal formatting, trailing-zero trimming, rounding at the precision boundary, and the `0`/`1` edge cases.

### Motivation

Go's `strconv.AppendFloat` is locale-independent by design (always uses `.` as the decimal separator), but this contract was not explicitly tested. This test documents that guarantee and guards against regressions in the trailing-zero trimming logic.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!