### PR TITLE
ci: unpin system-tests (back to @main)

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -352,13 +352,13 @@ jobs:
 
   tracer-release:
     if: github.event_name == 'schedule'
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@1e5d6b7096279ca43ce4826fda3cc805635b63c1
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@main
     permissions:
       contents: read
       id-token: write
     with:
       library: golang
-      ref: 1e5d6b7096279ca43ce4826fda3cc805635b63c1
+      ref: main
       scenarios_groups: tracer-release
       skip_empty_scenarios: true
       _system_tests_dev_mode: true

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -358,7 +358,6 @@ jobs:
       id-token: write
     with:
       library: golang
-      ref: main
       scenarios_groups: tracer-release
       skip_empty_scenarios: true
       _system_tests_dev_mode: true


### PR DESCRIPTION
Remove temporary system-tests pin (1e5d6b7 → @main) to activate dd-sts test optimization.