### PR TITLE
fix(contrib): fix batch race condition in pgx.v5

### DIFF
--- a/contrib/jackc/pgx.v5/pgx_tracer.go
+++ b/contrib/jackc/pgx.v5/pgx_tracer.go
@@ -44,6 +44,15 @@ func (tb *tracedBatchQuery) finish() {
 	tb.span.Finish(tracer.WithError(tb.data.Err))
 }
 
+// batchState holds per-batch mutable tracing state. It is stored in the context
+// returned by TraceBatchStart so that concurrent batches on different pool
+// connections each have isolated state, avoiding a race on shared pgxTracer fields.
+type batchState struct {
+	prevQuery *tracedBatchQuery
+}
+
+type contextKeyBatchState struct{}
+
 type allPgxTracers interface {
 	pgx.QueryTracer
 	pgx.BatchTracer
@@ -63,9 +72,8 @@ type wrappedPgxTracer struct {
 }
 
 type pgxTracer struct {
-	cfg            *config
-	prevBatchQuery *tracedBatchQuery
-	wrapped        wrappedPgxTracer
+	cfg     *config
+	wrapped wrappedPgxTracer
 }
 
 var (
@@ -138,6 +146,7 @@ func (t *pgxTracer) TraceBatchStart(ctx context.Context, conn *pgx.Conn, data pg
 		tracer.Tag(tagBatchNumQueries, data.Batch.Len()),
 	)
 	_, ctx = tracer.StartSpanFromContext(ctx, "pgx.batch", opts...)
+	ctx = context.WithValue(ctx, contextKeyBatchState{}, &batchState{})
 	return ctx
 }
 
@@ -148,19 +157,23 @@ func (t *pgxTracer) TraceBatchQuery(ctx context.Context, conn *pgx.Conn, data pg
 	if t.wrapped.batch != nil {
 		t.wrapped.batch.TraceBatchQuery(ctx, conn, data)
 	}
-	// Finish the previous batch query span before starting the next one, since pgx doesn't provide hooks or timestamp
-	// information about when the actual operation started or finished.
-	// pgx.Batch* types don't support concurrency. This function doesn't support it either.
-	if t.prevBatchQuery != nil {
-		t.prevBatchQuery.finish()
+	// Finish the previous batch query span before starting the next one, since pgx doesn't provide hooks or
+	// timestamp information about when the actual operation started or finished.
+	// batchState is stored per-batch in the context so concurrent batches on different pool connections
+	// each track their own prevQuery without racing on shared tracer state.
+	bs, _ := ctx.Value(contextKeyBatchState{}).(*batchState)
+	if bs != nil && bs.prevQuery != nil {
+		bs.prevQuery.finish()
 	}
 	opts := t.spanOptions(conn.Config(), operationTypeQuery, data.SQL,
 		tracer.Tag(tagRowsAffected, data.CommandTag.RowsAffected()),
 	)
 	span, _ := tracer.StartSpanFromContext(ctx, "pgx.batch.query", opts...)
-	t.prevBatchQuery = &tracedBatchQuery{
-		span: span,
-		data: data,
+	if bs != nil {
+		bs.prevQuery = &tracedBatchQuery{
+			span: span,
+			data: data,
+		}
 	}
 }
 
@@ -171,9 +184,9 @@ func (t *pgxTracer) TraceBatchEnd(ctx context.Context, conn *pgx.Conn, data pgx.
 	if t.wrapped.batch != nil {
 		t.wrapped.batch.TraceBatchEnd(ctx, conn, data)
 	}
-	if t.prevBatchQuery != nil {
-		t.prevBatchQuery.finish()
-		t.prevBatchQuery = nil
+	if bs, _ := ctx.Value(contextKeyBatchState{}).(*batchState); bs != nil && bs.prevQuery != nil {
+		bs.prevQuery.finish()
+		bs.prevQuery = nil
 	}
 	t.finishSpan(ctx, data.Err)
 }

--- a/contrib/jackc/pgx.v5/pgx_tracer_test.go
+++ b/contrib/jackc/pgx.v5/pgx_tracer_test.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -269,6 +270,49 @@ func TestBatch(t *testing.T) {
 	assert.Equal(t, "SELECT 3", s.Tag(ext.DBStatement))
 	assert.EqualValues(t, 1, s.Tag("db.result.rows_affected"))
 	assert.Equal(t, batchSpan.SpanID(), s.ParentID())
+}
+
+// TestConcurrentBatchRace asserts that concurrent batches executing on different
+// pool connections do not race on shared pgxTracer state. Run with -race.
+// Regression test for https://github.com/DataDog/dd-trace-go/issues/4668.
+func TestConcurrentBatchRace(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	opts := append(tracingAllDisabled(), WithTraceBatch(true))
+
+	parent, ctx := tracer.StartSpanFromContext(context.Background(), "parent")
+	defer parent.Finish()
+
+	pool, err := NewPool(ctx, postgresDSN, opts...)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	const (
+		numGoroutines = 10
+		numIterations = 20
+	)
+
+	var wg sync.WaitGroup
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < numIterations; j++ {
+				batch := &pgx.Batch{}
+				batch.Queue(`SELECT 1`)
+				batch.Queue(`SELECT 2`)
+				batch.Queue(`SELECT 3`)
+				br := pool.SendBatch(ctx, batch)
+				var x int
+				_ = br.QueryRow().Scan(&x)
+				_ = br.QueryRow().Scan(&x)
+				_ = br.QueryRow().Scan(&x)
+				require.NoError(t, br.Close())
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 func TestCopyFrom(t *testing.T) {


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

A single pgxTracer instance is shared across all pool connections, so concurrent batch executions raced on the prevBatchQuery field. Move per-batch state into a batchState struct stored in the context returned by TraceBatchStart, giving each concurrent batch its own isolated state.

### Motivation

Fixes https://github.com/DataDog/dd-trace-go/issues/4668

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
