### PR TITLE
fix: labelling ecosystems workflow would fail

### DIFF
--- a/.github/chainguard/self.ecosystems-label-issue.sts.yaml
+++ b/.github/chainguard/self.ecosystems-label-issue.sts.yaml
@@ -1,5 +1,5 @@
 issuer: https://token.actions.githubusercontent.com
-subject: repo:DataDog/dd-trace-go:issues
+subject: repo:DataDog/dd-trace-go:ref:refs/heads/main
 claim_pattern:
   event_name: issues
   repository: DataDog/dd-trace-go


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Changes subject line to match what is expected. We previously expected `:issue`, but runs returned a subject line of `:refs/heads/main`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Workflows ([example](https://github.com/DataDog/dd-trace-go/actions/runs/24532446733)) fail due to a mismatched subject line. 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
