### PR TITLE
fix(internal/telemetry): don't use default dependency loader in telemetry tests

### DIFF
--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -1421,11 +1421,15 @@ func TestSendingFailures(t *testing.T) {
 		},
 	}
 
+	config := defaultConfig(cfg)
+	config.DependencyLoader = nil // prevent AppDependenciesLoaded from joining the flush and creating a MessageBatch
+	config.internalMetricsEnabled = false
+
 	c, err := newClient(internal.TracerConfig{
 		Service: "test-service",
 		Env:     "test-env",
 		Version: "1.0.0",
-	}, defaultConfig(cfg))
+	}, config)
 
 	require.NoError(t, err)
 	defer c.Close()


### PR DESCRIPTION
### What does this PR do?

Disables the default dependency loader on `internal/telemetry` test `TestSendingFailures`.

Root cause: commit a45c8032 in golang/go: "cmd/go: include test deps in buildinfo" (merged ~March 17, 2026, landed in gotip). Fixed golang/go#76926 and introduced test deps populated on `BuildInfo.Deps`.

No other test are vulnerable to this.

### Motivation

Fix `gotip` scheduled runs: https://github.com/DataDog/dd-trace-go/actions/workflows/gotip-testing.yml?query=branch%3Amain

Before a45c8032, test binary `BuildInfo.Deps` was empty → `dependencies.Payload()` returned `nil` → only `Logs` in flush → test passed. After: test deps populate `Deps` → `AppDependenciesLoaded` joins flush → 2 payloads → `MessageBatch` → test fails.

Apparently this is a flake but went unnoticed. Looking at historical data, odds to fail since the commit landed on gotip were 1 of every 10-ish runs.

### Reviewer's Checklist

- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.

Unsure? Have a question? Request a review!
