### PR TITLE
fix(internal/telemetry): don't use default dependency loader in telemetry tests (2)

### DIFF
--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -1163,6 +1163,7 @@ func TestClientFlush(t *testing.T) {
 
 func TestMetricsDisabled(t *testing.T) {
 	t.Setenv("DD_TELEMETRY_METRICS_ENABLED", "false")
+	t.Setenv("DD_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED", "false")
 
 	c, err := NewClient("test-service", "test-env", "1.0.0", ClientConfig{AgentURL: "http://localhost:8126"})
 	require.NoError(t, err)


### PR DESCRIPTION
### What does this PR do?

Extends #4673 to `TestMetricsDisabled`.

### Motivation

Same `gotip` fix as in previous PR, but this one went unnoticed accidentally. The whole telemetry suite has been tested under `gotip` to ensure no more fixes are needed.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.

Unsure? Have a question? Request a review!
