### PR TITLE
fix(contrib/aws/datadog-lambda): sort the logs to compare

### DIFF
--- a/contrib/aws/datadog-lambda-go/test/integration_tests/run_integration_tests.sh
+++ b/contrib/aws/datadog-lambda-go/test/integration_tests/run_integration_tests.sh
@@ -189,8 +189,9 @@ for function_name in "${LAMBDA_HANDLERS[@]}"; do
         echo "Overwriting log snapshot for $function_snapshot_path"
         echo "$logs" >$function_snapshot_path
     else
-        # Compare new logs to snapshots
-        diff_output=$(echo "$logs" | diff - $function_snapshot_path)
+        # Compare new logs to snapshots (sort both sides to avoid flaky failures
+        # from non-deterministic log ordering in Lambda/CloudWatch)
+        diff_output=$(diff <(echo "$logs" | sort) <(sort $function_snapshot_path))
         if [ $? -eq 1 ]; then
             echo "Failed: Mismatch found between new $function_name logs (first) and snapshot (second):"
             echo "$diff_output"


### PR DESCRIPTION
### What does this PR do?

This PR sorts the logs generated by `contrib/aws/datadog-lambda-go/test/integration_tests/run_integration_tests.sh` when running Lambda Integration tests.

### Motivation

Avoid flakiness in the scheduled runs.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
