### PR TITLE
fix: DDCI was complaining about a missing job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,19 @@ workflow:
   auto_cancel:
     on_new_commit: interruptible
 
+.benchmark-rules: &benchmark-rules                                                                                                                        
+    - if: '$CI_COMMIT_TAG =~ /^.*\/v\d+\.\d+\.\d+(?:-.*\.\d+)?$/'                                                                                           
+      when: never
+    - if: '$CI_COMMIT_BRANCH =~ /^graphite-base\/.*$/'                                                                                                      
+      when: never                                                                                                                                         
+    - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-.*$/'                                                                                                   
+      when: never                                                                                                                                         
+    - if: '$CI_COMMIT_BRANCH == "main"'                                                                                                                     
+      when: always
+      interruptible: false                                                                                                                                  
+    - when: always                                                                                                                                        
+      interruptible: true
+
 # In order to run benchmarks in parallel, we generate a matrix of test names based on the BENCHMARK_TARGETS variable.
 # This will be used in tandem with bp-runner in benchmarks.yml.
 # This will allow us to spin up a child job in GitLab CI that handles running all of the benchmarks in parallel.
@@ -27,21 +40,7 @@ generate_matrix:
   stage: generate
   image: $BASE_CI_IMAGE
   tags: ["arch:amd64"]
-  rules:
-    # We don't want to run benchmarks when pushing release tags for nested modules
-    - if: '$CI_COMMIT_TAG =~ /^.*\/v\d+\.\d+\.\d+(?:-.*\.\d+)?$/'
-      when: never
-    # We don't want to run benchmarks on graphite commits
-    - if: '$CI_COMMIT_BRANCH =~ /^graphite-base\/.*$/'
-      when: never
-    # We don't want to run benchmarks on merge queue
-    - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-.*$/'
-      when: never
-    - if: '$CI_COMMIT_BRANCH == "main"'
-      when: always
-      interruptible: false
-    - when: always
-      interruptible: true
+  rules: *benchmark-rules
   script: |
     echo "=== Debug: Environment ==="
     echo "Image: ${BASE_CI_IMAGE}"
@@ -65,6 +64,7 @@ trigger_child_pipeline:
     strategy: depend
   needs:
     - generate_matrix
+  rules: *benchmark-rules
   variables:
       PARENT_PIPELINE_ID: $CI_PIPELINE_ID
 
@@ -72,6 +72,7 @@ check-big-regressions:
   stage: benchmarks
   needs:
     - job: trigger_child_pipeline
+  rules: *benchmark-rules
   when: on_success
   tags:
     - "arch:amd64"
@@ -97,6 +98,7 @@ analyze-benchmark-results:
   stage: benchmarks
   needs:
     - job: trigger_child_pipeline
+  rules: *benchmark-rules
   when: always
   tags:
     - "arch:amd64"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Use the same rules for all jobs in the benchmarking workflow so that it never tries to check for a job that doesn't exist/hasn't run.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

```
error: gitlab pipeline creation failed: POST https://gitlab.ddbuild.io/api/v4/projects/DataDog/apm-reliability/dd-trace-go/pipeline: 400 {message: {base: ['trigger_child_pipeline' job needs 'generate_matrix' job, but 'generate_matrix' does not exist in the pipeline. This might be because of the only, except, or rules keywords. To need a job that sometimes does not exist in the pipeline, use needs:optional.]}}
```

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
