### PR TITLE
feat(internal/llmobs): add FlushSync for synchronous flush in tests

### DIFF
--- a/instrumentation/testutils/testtracer/testtracer.go
+++ b/instrumentation/testutils/testtracer/testtracer.go
@@ -107,12 +107,11 @@ func Start(t testing.TB, opts ...Option) *TestTracer {
 		opt(cfg)
 	}
 
-	payloadChan := make(chan any)
 	payloads := &Payloads{}
 
 	rt := &mockTransport{
 		T:            t,
-		payloadChan:  payloadChan,
+		payloads:     payloads,
 		agentInfo:    cfg.AgentInfoResponse,
 		mockResponse: cfg.MockResponse,
 		requestDelay: cfg.RequestDelay,
@@ -125,8 +124,6 @@ func Start(t testing.TB, opts ...Option) *TestTracer {
 		roundTripper: rt,
 	}
 
-	// Start payload collector goroutine
-	go tt.collectPayloads(payloadChan)
 	t.Cleanup(tt.Stop)
 
 	startOpts := append([]tracer.StartOption{
@@ -201,22 +198,6 @@ func WithMockResponses(mr MockResponseFunc) Option {
 func WithRequireNoTracerStartError(requireNoErr bool) Option {
 	return func(cfg *config) {
 		cfg.RequireNoError = requireNoErr
-	}
-}
-
-// collectPayloads runs in a goroutine and collects payloads from the channel
-func (tt *TestTracer) collectPayloads(payloadChan <-chan any) {
-	for payload := range payloadChan {
-		tt.payloads.mu.Lock()
-		switch p := payload.(type) {
-		case Span:
-			tt.payloads.Spans = append(tt.payloads.Spans, p)
-		case LLMObsSpan:
-			tt.payloads.LLMSpans = append(tt.payloads.LLMSpans, p)
-		case LLMObsMetric:
-			tt.payloads.LLMMetrics = append(tt.payloads.LLMMetrics, p)
-		}
-		tt.payloads.mu.Unlock()
 	}
 }
 
@@ -311,7 +292,7 @@ func (tt *TestTracer) SentPayloads() Payloads {
 
 type mockTransport struct {
 	T            testing.TB
-	payloadChan  chan<- any
+	payloads     *Payloads
 	mu           sync.RWMutex
 	finished     bool
 	agentInfo    AgentInfo
@@ -331,7 +312,6 @@ func (rt *mockTransport) Stop() {
 		return
 	}
 	rt.finished = true
-	close(rt.payloadChan)
 }
 
 var noLogPaths = []string{
@@ -426,11 +406,13 @@ func (rt *mockTransport) handleTraces(r *http.Request) {
 	if len(traces) == 0 {
 		return
 	}
+	rt.payloads.mu.Lock()
 	for _, spans := range traces {
 		for _, span := range spans {
-			rt.payloadChan <- span
+			rt.payloads.Spans = append(rt.payloads.Spans, span)
 		}
 	}
+	rt.payloads.mu.Unlock()
 }
 
 func (rt *mockTransport) handleLLMObsSpanEvents(r *http.Request) {
@@ -444,11 +426,13 @@ func (rt *mockTransport) handleLLMObsSpanEvents(r *http.Request) {
 	err = json.Unmarshal(buf, &payload)
 	require.NoError(rt.T, err)
 
+	rt.payloads.mu.Lock()
 	for _, p := range payload {
 		for _, span := range p.Spans {
-			rt.payloadChan <- *span
+			rt.payloads.LLMSpans = append(rt.payloads.LLMSpans, *span)
 		}
 	}
+	rt.payloads.mu.Unlock()
 }
 
 func (rt *mockTransport) handleLLMObsEvalMetrics(r *http.Request) {
@@ -462,9 +446,11 @@ func (rt *mockTransport) handleLLMObsEvalMetrics(r *http.Request) {
 	err = json.Unmarshal(buf, &payload)
 	require.NoError(rt.T, err)
 
+	rt.payloads.mu.Lock()
 	for _, metric := range payload.Data.Attributes.Metrics {
-		rt.payloadChan <- *metric
+		rt.payloads.LLMMetrics = append(rt.payloads.LLMMetrics, *metric)
 	}
+	rt.payloads.mu.Unlock()
 }
 
 type testLogger struct {

--- a/internal/llmobs/llmobs.go
+++ b/internal/llmobs/llmobs.go
@@ -146,9 +146,11 @@ type LLMObs struct {
 	// lifecycle
 	mu            sync.Mutex
 	running       bool
-	wg            sync.WaitGroup
-	stopCh        chan struct{} // signal stop
+	wg            sync.WaitGroup // tracks in-flight async batchSend goroutines only (not the main loop)
+	stopCh        chan struct{}  // signal stop
+	stoppedCh     chan struct{}  // closed when the main run loop exits
 	flushNowCh    chan struct{}
+	flushSyncCh   chan chan struct{} // synchronous flush: send a done channel, blocks until flush completes
 	flushInterval time.Duration
 }
 
@@ -188,7 +190,9 @@ func newLLMObs(cfg *config.Config, tracer Tracer) (*LLMObs, error) {
 		spanEventsCh:  make(chan *transport.LLMObsSpanEvent),
 		evalMetricsCh: make(chan *transport.LLMObsMetric),
 		stopCh:        make(chan struct{}),
+		stoppedCh:     make(chan struct{}),
 		flushNowCh:    make(chan struct{}, 1),
+		flushSyncCh:   make(chan chan struct{}),
 		flushInterval: defaultFlushInterval,
 	}, nil
 }
@@ -245,6 +249,14 @@ func Flush() {
 	}
 }
 
+// FlushSync flushes all buffered LLMObs data and blocks until the send completes.
+func FlushSync() {
+	if activeLLMObs == nil {
+		return
+	}
+	activeLLMObs.FlushSync()
+}
+
 // Run starts the worker loop that processes span events and metrics.
 func (l *LLMObs) Run() {
 	l.mu.Lock()
@@ -255,8 +267,9 @@ func (l *LLMObs) Run() {
 	l.running = true
 	l.mu.Unlock()
 
-	l.wg.Go(func() {
+	go func() {
 		// this goroutine should be the only one writing to the internal buffers
+		defer close(l.stoppedCh)
 
 		ticker := time.NewTicker(l.flushInterval)
 		defer ticker.Stop()
@@ -267,10 +280,7 @@ func (l *LLMObs) Run() {
 				evSize := jsonSize(ev)
 				if l.bufSpanEventsSize+evSize > sizeLimitEVPEvent {
 					log.Debug("llmobs: span events buffer size limit reached, flushing before adding new event")
-					params := l.clearBuffersNonLocked()
-					l.wg.Go(func() {
-						l.batchSend(params)
-					})
+					l.sendAsync(l.clearBuffersNonLocked())
 				}
 				l.bufSpanEvents = append(l.bufSpanEvents, ev)
 				l.bufSpanEventsSize += evSize
@@ -279,27 +289,44 @@ func (l *LLMObs) Run() {
 				l.bufEvalMetrics = append(l.bufEvalMetrics, evalMetric)
 
 			case <-ticker.C:
-				params := l.clearBuffersNonLocked()
-				l.wg.Go(func() {
-					l.batchSend(params)
-				})
+				l.sendAsync(l.clearBuffersNonLocked())
 
 			case <-l.flushNowCh:
 				log.Debug("llmobs: on-demand flush signal")
-				params := l.clearBuffersNonLocked()
-				l.wg.Go(func() {
-					l.batchSend(params)
-				})
+				l.sendAsync(l.clearBuffersNonLocked())
+
+			case done := <-l.flushSyncCh:
+				log.Debug("llmobs: synchronous flush signal")
+				// wg tracks only async batchSend goroutines (not this main loop),
+				// so Wait() here cannot deadlock.
+				l.wg.Wait()
+				l.batchSend(l.clearBuffersNonLocked())
+				close(done)
 
 			case <-l.stopCh:
 				log.Debug("llmobs: stop signal")
 				l.drainChannels()
-				params := l.clearBuffersNonLocked()
-				l.batchSend(params)
+				l.batchSend(l.clearBuffersNonLocked())
 				return
 			}
 		}
+	}()
+}
+
+// sendAsync dispatches params to batchSend in a new goroutine tracked by wg,
+// so FlushSync can wait for all in-flight sends via wg.Wait(). Must be called
+// only from the main Run worker goroutine.
+func (l *LLMObs) sendAsync(params batchSendParams) {
+	l.wg.Go(func() {
+		l.batchSend(params)
 	})
+}
+
+// FlushSync flushes all currently buffered data and blocks until the HTTP send completes.
+func (l *LLMObs) FlushSync() {
+	done := make(chan struct{})
+	l.flushSyncCh <- done
+	<-done
 }
 
 // clearBuffersNonLocked clears the internal buffers and returns the corresponding batchSendParams to send to the backend.
@@ -342,7 +369,9 @@ func (l *LLMObs) Stop() {
 		close(l.stopCh)
 	}
 
-	// Wait for the main worker to exit (it will do a final flush)
+	// Wait for the main loop to exit (it does a final synchronous flush before returning).
+	<-l.stoppedCh
+	// Wait for any async batchSend goroutines that were in flight when the loop stopped.
 	l.wg.Wait()
 }
 

--- a/internal/llmobs/llmobs_test.go
+++ b/internal/llmobs/llmobs_test.go
@@ -1958,6 +1958,52 @@ func TestLLMObsLifecycle(t *testing.T) {
 	})
 }
 
+func TestFlushSync(t *testing.T) {
+	t.Run("does-not-hang-with-empty-buffer", func(t *testing.T) {
+		// FlushSync must return promptly even when there is nothing to flush.
+		_, ll := testTracer(t)
+
+		done := make(chan struct{})
+		go func() {
+			ll.FlushSync()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("FlushSync hung with empty buffer")
+		}
+	})
+	t.Run("waits-for-slow-transport", func(t *testing.T) {
+		// FlushSync must block the caller until the HTTP send completes.
+		// Verify by timing: if FlushSync returned before the request delay,
+		// the blocking guarantee would be violated.
+		const delay = 200 * time.Millisecond
+
+		tt, ll := testTracer(t, testtracer.WithRequestDelay(delay))
+
+		span, _ := ll.StartSpan(context.Background(), llmobs.SpanKindLLM, "slow-span", llmobs.StartSpanConfig{})
+		span.Finish(llmobs.FinishSpanConfig{})
+
+		start := time.Now()
+		ll.FlushSync()
+		elapsed := time.Since(start)
+
+		// Must have waited at least the request delay.
+		assert.GreaterOrEqual(t, elapsed, delay, "FlushSync should block until the slow HTTP send completes")
+
+		payloads := tt.SentPayloads()
+		require.Len(t, payloads.LLMSpans, 1)
+		assert.Equal(t, "slow-span", payloads.LLMSpans[0].Name)
+	})
+	t.Run("no-panic-without-active-llmobs", func(t *testing.T) {
+		// Package-level FlushSync should be safe when no active LLMObs.
+		assert.NotPanics(t, func() {
+			llmobs.FlushSync()
+		})
+	})
+}
+
 func BenchmarkLLMObsStartSpan(b *testing.B) {
 	run := func(b *testing.B, ll *llmobs.LLMObs, tt *testtracer.TestTracer, done chan struct{}) {
 		b.Log("starting benchmark")


### PR DESCRIPTION
### What does this PR do?

`FlushSync` blocks until all currently buffered spans have been sent via HTTP, making it safe to assert on received spans immediately after calling it.

The implementation requires restructuring goroutine lifetime tracking:
- Main loop moved out of `wg` (tracked via `stoppedCh` instead) so `wg.Wait()` inside the `flushSyncCh` handler cannot deadlock
- `wg` now tracks only async `batchSend` goroutines; `FlushSync` waits on `wg` before the sync `batchSend` to ensure no in-flight sends are missed
- `sendAsync` helper extracts the `wg.Add`/`Go`/`Done` pattern for size-based and periodic flushes
- `Stop` waits on `stoppedCh` then `wg.Wait()` to preserve the same guarantee

### Motivation

Allowing to introduce the inspectable tracer from PR #4512.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.

Unsure? Have a question? Request a review!
