### PR TITLE
feat(config): source-tagged undo for programmatic overrides (POC)

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -274,7 +274,8 @@ const maxPropagatedTagsLength = 512
 // and passed user opts.
 func newConfig(opts ...StartOption) (*config, error) {
 	c := new(config)
-	c.internalConfig = internalconfig.CreateNew()
+	c.internalConfig = internalconfig.Get()
+	c.internalConfig.PrepareForStart(internalconfig.ProductTracer)
 
 	// If this was built with a recent-enough version of Orchestrion, force the orchestrion config to
 	// the baked-in values. We do this early so that opts can be used to override the baked-in values,

--- a/ddtrace/tracer/span_to_otlp_test.go
+++ b/ddtrace/tracer/span_to_otlp_test.go
@@ -30,7 +30,7 @@ func TestBuildResource(t *testing.T) {
 	})
 
 	t.Run("populated", func(t *testing.T) {
-		cfg := internalconfig.CreateNew()
+		cfg := newFreshInternalConfig()
 		cfg.SetServiceName("my-service", internalconfig.OriginCode)
 		cfg.SetEnv("prod", internalconfig.OriginCode)
 		cfg.SetVersion("1.2.3", internalconfig.OriginCode)
@@ -47,7 +47,7 @@ func TestBuildResource(t *testing.T) {
 	})
 
 	t.Run("optional fields omitted when empty", func(t *testing.T) {
-		cfg := internalconfig.CreateNew()
+		cfg := newFreshInternalConfig()
 		cfg.SetServiceName("svc", internalconfig.OriginCode)
 
 		r := buildResource(cfg)

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -2512,6 +2512,18 @@ func newTestConfig(opts ...StartOption) (*config, error) {
 	return newConfig(opts...)
 }
 
+// newFreshInternalConfig returns a brand-new internal config singleton, bypassing
+// the process-wide cache. Use this in tests that want to exercise behaviour
+// against a config loaded fresh from env vars and defaults (e.g. URL resolution,
+// OTLP mode derivation) without inheriting overrides or values from prior tests.
+//
+// For tests that need a tracer-local *config wrapper, prefer newTestConfig.
+func newFreshInternalConfig() *internalconfig.Config {
+	internalconfig.SetUseFreshConfig(true)
+	defer internalconfig.SetUseFreshConfig(false)
+	return internalconfig.Get()
+}
+
 // comparePayloadSpans allows comparing two spans which might have been
 // read from the msgpack payload. In that case the private fields will
 // not be available and the maps (meta & metrics will be nil for lengths

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -25,7 +25,6 @@ import (
 
 	tinternal "github.com/DataDog/dd-trace-go/v2/ddtrace/tracer/internal"
 	"github.com/DataDog/dd-trace-go/v2/internal"
-	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/statsdtest"
 
 	"github.com/stretchr/testify/assert"
@@ -122,10 +121,10 @@ func TestResolveAgentAddr(t *testing.T) {
 			if tt.envPort != "" {
 				t.Setenv("DD_TRACE_AGENT_PORT", tt.envPort)
 			}
-			// Use CreateNew directly to test URL resolution without triggering
+			// Fetch a fresh singleton to test URL resolution without triggering
 			// loadAgentFeatures, which would make real HTTP calls to the configured URL.
 			c := new(config)
-			c.internalConfig = internalconfig.CreateNew()
+			c.internalConfig = newFreshInternalConfig()
 			if tt.inOpt != nil {
 				tt.inOpt(c)
 			}
@@ -140,7 +139,7 @@ func TestResolveAgentAddr(t *testing.T) {
 		internal.DefaultTraceAgentUDSPath = d // Choose a file we know will exist
 		defer func() { internal.DefaultTraceAgentUDSPath = old }()
 		c := new(config)
-		c.internalConfig = internalconfig.CreateNew()
+		c.internalConfig = newFreshInternalConfig()
 		assert.Equal(t, &url.URL{Scheme: "unix", Path: d}, c.internalConfig.RawAgentURL())
 	})
 }

--- a/internal/config/SOURCE_TAGGED_UNDO_POC.md
+++ b/internal/config/SOURCE_TAGGED_UNDO_POC.md
@@ -1,0 +1,177 @@
+# Source-Tagged Undo POC — Design Notes
+
+Reference document for review of the source-tagged undo mechanism introduced in
+PR #4692. This file is intentionally not for merge — it exists as a companion
+to the PR while the design is being reviewed. Delete before merge (or move to
+an architecture doc if useful long-term).
+
+## 1. What we introduced
+
+A source-tagged override + undo mechanism on the shared `internal/config`
+singleton, plus an in-place env refresh path. Concretely:
+
+- **`programmaticOverride` extended** with a `restore func()` closure, captured
+  once per (field, product) on the first code-origin write.
+- **`snapshotAndCheck`** — the write-time gate that enforces
+  first-product-wins conflict semantics AND records the restore baseline.
+  Legacy setters keep using the old `checkProductConflict` as a thin wrapper
+  that skips baseline capture.
+- **`undoProduct` / `refreshFromEnv`** (unexported methods) — internal
+  primitives. `undoProduct` iterates the overrides map and calls `restore()`
+  for entries matching the given product, then deletes them. `refreshFromEnv`
+  re-reads env-backed values via `loadEnvInto`.
+- **`(c *Config) PrepareForStart(Product)`** — the single Start-time entry
+  point for products. Wraps `undoProduct + refreshFromEnv` as an opaque
+  ceremony on an already-fetched Config. Contribs and other read-only
+  consumers call `Get()` alone; products call `Get()` + `PrepareForStart()`
+  at the top of their Start. The primitives are unexported to keep the
+  product-facing surface narrow and prevent products from invoking only
+  part of the ceremony.
+- **`loadEnvInto`** — factored the env-reading portion of `loadConfig` into a
+  method guarded by the overrides map, shared by initial load and refresh.
+- **`CreateNew` removed** — the sledgehammer that rebuilt the whole singleton
+  is gone; tracer's `newConfig` now uses `PrepareForStart(ProductTracer)`.
+- **`SetEnv` migrated** as the POC setter demonstrating full undo + refresh
+  participation.
+- **`profiler.WithEnv` migrated** to route through the singleton via
+  `cfg.internalConfig.SetEnv(...)`, and `profiler.defaultConfig` uses the same
+  `PrepareForStart` call as tracer.
+
+## 2. Why / toward what goal
+
+The migration to a shared Config singleton in dd-trace-go kept running into
+the same problem: supporting `tracer.Start(...)` being called more than once
+("last options win") without wiping code-origin overrides from other products
+like the profiler. The existing approach — `CreateNew()` rebuilding the
+singleton on every tracer `Start` — solved the env-refresh case but forced
+every product into its own isolated Config instance, which broke cross-product
+conflict detection and caused drift between products' views of shared fields
+like service/env/version.
+
+The goal was a single shared Config that could be re-initialized on a
+per-product basis, with env refresh on restart, without any product's restart
+affecting another's overrides.
+
+## 3. Why this was the right solution
+
+We explored alternatives and ruled them out in order:
+
+- **Per-product Config instances (current `CreateNew` model)**: causes drift
+  and loses write-time conflict detection. The whole motivation for migrating
+  to a singleton.
+- **Base config + per-product overlays** (colleague's proposal): either
+  requires API-break ("clean overlay") or reintroduces read-time merge
+  ambiguity without resolving the underlying conflict-detection problem
+  ("messy overlay"). And in the version where cross-cutting fields still flow
+  through every product's API, you get no shared telemetry key — a structural
+  flaw.
+- **Tracer-only `CreateNew`**: pragmatic escape hatch, but asymmetric (two
+  different Start semantics across products) and still wipes other products'
+  overrides on repeat tracer Start.
+
+Source-tagged undo + in-place env refresh via `PrepareForStart` gives you everything at once:
+one singleton pointer shared across all products, write-time conflict
+detection, per-product last-Start-wins, env refresh on restart, and no wipe of
+other products' overrides. The mechanism extends existing primitives
+(`overrides` map, `DynamicConfig[T]` baseline pattern) rather than introducing
+a new abstraction.
+
+## 4. How this unblocks us moving forward
+
+- **Unblocks further field migration.** The mechanism is in place. Every
+  subsequent setter migration is a one-function diff: capture `priorVal`,
+  build a silent restore closure, call `snapshotAndCheck` instead of
+  `checkProductConflict`. Add a corresponding guarded line in `loadEnvInto`
+  for env-backed fields. No further design work per field.
+- **Unblocks adding new products to the singleton.** Any new product (appsec,
+  llmobs, CI vis, …) now has a clear Start-time pattern at the top of its
+  Start: `c := internalconfig.Get(); c.PrepareForStart(<self>)`, followed by
+  option application. Contribs and any read-only consumer only need `Get()`.
+  Conflict detection with existing products is automatic.
+- **Unblocks removing the `CreateNew` / `SetUseFreshConfig` sledgehammers.**
+  `CreateNew` is gone. `SetUseFreshConfig` remains as a test helper but is no
+  longer load-bearing for production.
+- **Cleans up the "whack-a-mole" pattern** from earlier migration work. Each
+  new field had been surfacing fresh cross-cutting questions (env refresh,
+  restart, conflict). Those now have one answer each instead of one-per-field.
+- **Known follow-ups, deliberately deferred:**
+  - (a) Per-product `initialized atomic.Bool` to skip the redundant refresh on
+    cold first-Starts — `TODO(perf)` in `refreshFromEnv`.
+  - (b) Remote-config interaction with the new override/baseline layer.
+  - (c) Expanding telemetry reporting in `loadEnvInto` to non-DD_ENV fields as
+    they migrate to the new undo path.
+
+  None of these block merging the POC.
+
+## Scope reminder
+
+- One singleton setter (`SetEnv`) is on the new undo path. The other 27
+  setters still use `checkProductConflict`; they retain ownership tracking but
+  do not participate in undo until individually migrated.
+- One profiler option (`WithEnv`) is routed through the singleton. Others
+  stay local.
+- No RC integration.
+
+## Follow-up: split commits for easier review
+
+Commit 2 (`feat(config): in-place env refresh, PrepareForStart, remove
+CreateNew`) exceeds GitHub's single-file diff-render threshold for
+`internal/config/config.go`. Reviewers see "Diff is too big to render" in
+the Files-changed tab.
+
+The fix is to split commit 2 into four smaller, single-concern commits. This
+does not change the end state of the branch; it just makes the Commits tab
+walkable piece by piece.
+
+Target split (apply with interactive rebase, `edit` the original commit 2,
+then commit the four pieces in order):
+
+**2a. Pure refactor: extract `loadEnvInto` from `loadConfig`**
+- Move the inline env reads in `loadConfig` into a new `(c *Config)
+  loadEnvInto()` method. `loadConfig` calls it.
+- No guards, no new exported API, no renames.
+- Reviewable as "this is just a code move."
+
+**2b. Add override guards + DD_ENV telemetry inside `loadEnvInto`**
+- Wrap each field write in `if _, ov := c.overrides["..."]; !ov { ... }`.
+- Add `envOrigin(p, key)` helper.
+- Add the one `configtelemetry.Report("DD_ENV", ...)` call in `loadEnvInto`
+  using `envOrigin(p, "DD_ENV")`.
+- Reviewable as "the guards are the behavior change; telemetry wires up
+  for the single migrated field."
+
+**2c. Add `refreshFromEnv` + `PrepareForStart`; unexport `undoProduct`**
+- Add `(c *Config) refreshFromEnv()` (locks + calls `loadEnvInto`).
+- Add `(c *Config) PrepareForStart(Product)` (wraps `undoProduct +
+  refreshFromEnv`).
+- Rename `UndoProduct` to `undoProduct` (unexport). Update commit 1's
+  `TestUndoProduct` call sites to lowercase.
+
+**2d. Remove `CreateNew`; wire tracer to `PrepareForStart`**
+- Delete `CreateNew` function.
+- `ddtrace/tracer/option.go`: `newConfig` does `Get + PrepareForStart`.
+- Introduce `newFreshInternalConfig` helper in `tracer_test.go`; use it in
+  `transport_test.go` and `span_to_otlp_test.go` where `CreateNew` was
+  previously called.
+- Drop `TestGet/GetNew forces new instance` subtest.
+
+If commit 1 also hits the diff threshold after splitting commit 2 makes it
+the visible offender, split it the same way:
+- **1a.** Mechanism: extend `programmaticOverride` with `restore`, add
+  `snapshotAndCheck`, keep `checkProductConflict` as a thin wrapper.
+- **1b.** Add `UndoProduct` method (originally exported, unexported in 2c).
+- **1c.** Migrate `SetEnv` to the new path + add `TestUndoProduct`.
+
+Procedure (when ready to split):
+
+```sh
+git rebase -i 8c4fe256b   # commit 1 hash (before commit 2)
+# mark commit 2 as `edit`, save, exit
+git reset HEAD~1          # now commit 2's changes are in the working tree, unstaged
+# commit the four pieces in order using `git add -p` or file-scoped staging
+git rebase --continue
+git push --force-with-lease
+```
+
+The end-state tree must match pre-split — diff the rebased branch against
+the original tip (before `--force-with-lease`) and expect empty output.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,7 +55,7 @@ const (
 // programmaticOverride records which product claimed a field via programmatic API
 // and, for the first code-origin write per (field, product), the closure that reverts
 // the field to its pre-code state. restore is captured exactly once and preserved
-// across same-product rewrites so UndoProduct always restores to the true baseline.
+// across same-product rewrites so undoProduct always restores to the true baseline.
 type programmaticOverride struct {
 	product Product
 	value   any
@@ -150,7 +150,8 @@ type Config struct {
 
 // snapshotAndCheck enforces the cross-product gate for programmatic API calls and,
 // on the first code-origin write to a field by a given product, records the baseline
-// restore closure so the override can later be reverted via UndoProduct.
+// restore closure so the override can later be reverted by undoProduct (invoked
+// as part of PrepareForStart).
 //
 // Returns true if the caller should abort the update (a different product already
 // claimed this field). No-op when product is not supplied or origin is not OriginCode.
@@ -197,15 +198,15 @@ func (c *Config) snapshotAndCheck(field string, origin telemetry.Origin, value a
 // checkProductConflict is a thin wrapper around snapshotAndCheck for setters
 // that have not yet been migrated to capture undo baselines. It enforces the
 // same first-product-wins gate, but fields updated through this path will NOT
-// participate in UndoProduct — their entries remain in the overrides map to
-// preserve ownership, but no restore closure is recorded.
+// participate in PrepareForStart's undo step — their entries remain in the
+// overrides map to preserve ownership, but no restore closure is recorded.
 //
 // Must be called while c.mu is held.
 func (c *Config) checkProductConflict(field string, origin telemetry.Origin, value any, product ...Product) bool {
 	return c.snapshotAndCheck(field, origin, value, nil, product...)
 }
 
-// UndoProduct reverts every programmatic (OriginCode) override recorded for the
+// undoProduct reverts every programmatic (OriginCode) override recorded for the
 // given product back to the value it held before the first code-origin write.
 // Only overrides registered with a non-nil restore closure are undone; setters
 // that still use the legacy checkProductConflict path retain their values, but
@@ -213,10 +214,10 @@ func (c *Config) checkProductConflict(field string, origin telemetry.Origin, val
 // field. Overrides owned by other products and values written via non-code
 // origins (env vars, defaults, remote config) are left untouched.
 //
-// Intended to be called by a product's Start() before applying new options, so
-// that repeat Start calls yield last-Start-wins semantics without wiping other
-// products' overrides.
-func (c *Config) UndoProduct(p Product) {
+// Not intended to be called directly by products — PrepareForStart runs this
+// as part of the Start ceremony. Unexported to keep the product-facing API
+// narrow; same-package tests access it directly.
+func (c *Config) undoProduct(p Product) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for field, ov := range c.overrides {
@@ -230,56 +231,203 @@ func (c *Config) UndoProduct(p Product) {
 	}
 }
 
+// loadEnvInto reads env-backed config values from the provider into c. Fields
+// currently claimed by an OriginCode override (tracked in c.overrides) are left
+// alone — they represent programmatic writes that outrank env.
+//
+// Called by loadConfig on initial load and by refreshFromEnv (via
+// PrepareForStart) on subsequent product Starts. Callers must hold c.mu.
+//
+// Telemetry reporting: fields whose setters participate in the new undo path
+// (currently DD_ENV) also emit configtelemetry.Report so that post-undo the
+// reported value matches the restored in-memory value. Other fields keep their
+// current behavior — no configtelemetry.Report on load, only on setter writes.
+// That asymmetry is intentional and scoped to the POC; migrating more setters
+// to the undo path will add the corresponding reports here.
+//
+// Env-source coverage: the provider's own internal telemetry reports which
+// source (OTEL env, DD env, stable/declarative config, default) produced each
+// lookup; that is the authoritative per-source record. Our configtelemetry.Report
+// calls record the effective (winning) value+origin after layering.
+//
+// Edge case: if an env var's value changes between two product Starts while a
+// code override is active for that field, the override guard above skips the
+// re-read and we do not emit fresh env telemetry. The effective value does not
+// change (the code override still wins), so no behavioral regression — only a
+// stale env-source report in telemetry until the override is released. Not
+// considered a realistic operator workflow, but documented here as a known
+// limitation.
+func (c *Config) loadEnvInto() {
+	p := provider.New()
+
+	// Resolve agent URL from DD_TRACE_AGENT_URL, DD_AGENT_HOST, DD_TRACE_AGENT_PORT.
+	// All three are read through the provider so telemetry is reported for each.
+	// Guarded as one unit under DD_TRACE_AGENT_URL since that's the field's canonical key.
+	if _, ov := c.overrides["DD_TRACE_AGENT_URL"]; !ov {
+		agentURLStr := p.GetString("DD_TRACE_AGENT_URL", "")
+		agentHost := p.GetString("DD_AGENT_HOST", "")
+		agentPort := p.GetString("DD_TRACE_AGENT_PORT", "")
+		c.agentURL = resolveAgentURL(agentURLStr, agentHost, agentPort)
+	}
+
+	if _, ov := c.overrides["DD_TRACE_DEBUG"]; !ov {
+		c.debug = p.GetBool("DD_TRACE_DEBUG", false)
+	}
+	if _, ov := c.overrides["DD_TRACE_STARTUP_LOGS"]; !ov {
+		c.logStartup = p.GetBool("DD_TRACE_STARTUP_LOGS", true)
+	}
+	if _, ov := c.overrides["DD_SERVICE"]; !ov {
+		c.serviceName = p.GetString("DD_SERVICE", "")
+	}
+	if _, ov := c.overrides["DD_VERSION"]; !ov {
+		c.version = p.GetString("DD_VERSION", "")
+	}
+	// DD_ENV participates in the new undo path: report telemetry here so that
+	// post-undo, the backend sees the restored env/default value with its
+	// correct origin, not the stale OriginCode value from the last setter write.
+	if _, ov := c.overrides["DD_ENV"]; !ov {
+		c.env = p.GetString("DD_ENV", "")
+		configtelemetry.Report("DD_ENV", c.env, envOrigin(p, "DD_ENV"))
+	}
+	if _, ov := c.overrides["DD_SERVICE_MAPPING"]; !ov {
+		c.serviceMappings = p.GetMap("DD_SERVICE_MAPPING", nil, internal.DDTagsDelimiter)
+	}
+	if _, ov := c.overrides["DD_RUNTIME_METRICS_ENABLED"]; !ov {
+		c.runtimeMetrics = p.GetBool("DD_RUNTIME_METRICS_ENABLED", false)
+	}
+	if _, ov := c.overrides["DD_RUNTIME_METRICS_V2_ENABLED"]; !ov {
+		c.runtimeMetricsV2 = p.GetBool("DD_RUNTIME_METRICS_V2_ENABLED", true)
+	}
+	if _, ov := c.overrides[traceprof.CodeHotspotsEnvVar]; !ov {
+		c.profilerHotspots = p.GetBool("DD_PROFILING_CODE_HOTSPOTS_COLLECTION_ENABLED", true)
+	}
+	if _, ov := c.overrides["DD_PROFILING_ENDPOINT_COLLECTION_ENABLED"]; !ov {
+		c.profilerEndpoints = p.GetBool("DD_PROFILING_ENDPOINT_COLLECTION_ENABLED", true)
+	}
+	if _, ov := c.overrides["DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED"]; !ov {
+		c.peerServiceDefaultsEnabled = p.GetBool("DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED", false)
+	}
+	if _, ov := c.overrides["DD_TRACE_PEER_SERVICE_MAPPING"]; !ov {
+		c.peerServiceMappings = p.GetMap("DD_TRACE_PEER_SERVICE_MAPPING", nil, internal.DDTagsDelimiter)
+	}
+	if _, ov := c.overrides["DD_TRACE_DEBUG_ABANDONED_SPANS"]; !ov {
+		c.debugAbandonedSpans = p.GetBool("DD_TRACE_DEBUG_ABANDONED_SPANS", false)
+	}
+	if _, ov := c.overrides["DD_TRACE_ABANDONED_SPAN_TIMEOUT"]; !ov {
+		c.spanTimeout = p.GetDuration("DD_TRACE_ABANDONED_SPAN_TIMEOUT", 10*time.Minute)
+	}
+	if _, ov := c.overrides["DD_TRACE_PARTIAL_FLUSH_MIN_SPANS"]; !ov {
+		c.partialFlushMinSpans = p.GetIntWithValidator("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", 1000, validatePartialFlushMinSpans)
+	}
+	if _, ov := c.overrides["DD_TRACE_PARTIAL_FLUSH_ENABLED"]; !ov {
+		c.partialFlushEnabled = p.GetBool("DD_TRACE_PARTIAL_FLUSH_ENABLED", false)
+	}
+	if _, ov := c.overrides["DD_TRACE_STATS_COMPUTATION_ENABLED"]; !ov {
+		c.statsComputationEnabled = p.GetBool("DD_TRACE_STATS_COMPUTATION_ENABLED", true)
+	}
+	if _, ov := c.overrides["DD_DATA_STREAMS_ENABLED"]; !ov {
+		c.dataStreamsMonitoringEnabled = p.GetBool("DD_DATA_STREAMS_ENABLED", false)
+	}
+	if _, ov := c.overrides["DD_DYNAMIC_INSTRUMENTATION_ENABLED"]; !ov {
+		c.dynamicInstrumentationEnabled = p.GetBool("DD_DYNAMIC_INSTRUMENTATION_ENABLED", false)
+	}
+	if _, ov := c.overrides[constants.CIVisibilityEnabledEnvironmentVariable]; !ov {
+		c.ciVisibilityEnabled = p.GetBool(constants.CIVisibilityEnabledEnvironmentVariable, false)
+	}
+	if _, ov := c.overrides["DD_CIVISIBILITY_AGENTLESS_ENABLED"]; !ov {
+		c.ciVisibilityAgentless = p.GetBool("DD_CIVISIBILITY_AGENTLESS_ENABLED", false)
+	}
+	if _, ov := c.overrides["DD_TRACE_LOG_DIRECTORY"]; !ov {
+		c.logDirectory = p.GetString("DD_TRACE_LOG_DIRECTORY", "")
+	}
+	if _, ov := c.overrides["DD_TRACE_RATE_LIMIT"]; !ov {
+		c.traceRateLimitPerSecond = p.GetFloatWithValidator("DD_TRACE_RATE_LIMIT", DefaultRateLimit, validateRateLimit)
+	}
+	if _, ov := c.overrides["DD_TRACE_DEBUG_STACK"]; !ov {
+		c.debugStack = p.GetBool("DD_TRACE_DEBUG_STACK", true)
+	}
+	if _, ov := c.overrides["DD_TRACE_RETRY_INTERVAL"]; !ov {
+		c.retryInterval = p.GetDuration("DD_TRACE_RETRY_INTERVAL", time.Millisecond)
+	}
+	if _, ov := c.overrides["DD_LOGS_OTEL_ENABLED"]; !ov {
+		c.logsOTelEnabled = p.GetBool("DD_LOGS_OTEL_ENABLED", false)
+	}
+	if _, ov := c.overrides["DD_TRACE_AGENT_PROTOCOL_VERSION"]; !ov {
+		c.traceProtocol = resolveTraceProtocol(p.GetStringWithValidator("DD_TRACE_AGENT_PROTOCOL_VERSION", TraceProtocolVersionStringV04, validateTraceProtocolVersion))
+	}
+	if _, ov := c.overrides["OTEL_TRACES_EXPORTER"]; !ov {
+		c.otlpExportMode = p.GetString("OTEL_TRACES_EXPORTER", "") == "otlp"
+		// DD_TRACE_AGENT_PROTOCOL_VERSION overrides OTEL_TRACES_EXPORTER
+		if p.IsSet("DD_TRACE_AGENT_PROTOCOL_VERSION") {
+			c.otlpExportMode = false
+		}
+	}
+	// otlpTraceURL and otlpHeaders have no setter / no override key — always refresh.
+	c.otlpTraceURL = resolveOTLPTraceURL(c.agentURL, p.GetString("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", ""))
+	c.otlpHeaders = buildOTLPHeaders(p.GetMap("OTEL_EXPORTER_OTLP_TRACES_HEADERS", nil, internal.OtelTagsDelimeter))
+	c.traceID128BitEnabled = p.GetBool("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", true)
+}
+
+// envOrigin returns OriginEnvVar if key is set in the environment, else OriginDefault.
+func envOrigin(p *provider.Provider, key string) telemetry.Origin {
+	if p.IsSet(key) {
+		return telemetry.OriginEnvVar
+	}
+	return telemetry.OriginDefault
+}
+
+// refreshFromEnv re-reads env-backed config values into the singleton,
+// skipping fields currently claimed by code-origin overrides (tracked in
+// c.overrides). Called by PrepareForStart after undoProduct so env changes
+// between Start invocations are picked up on restart.
+//
+// Not intended to be called directly by products — PrepareForStart runs this
+// as part of the Start ceremony. Unexported to keep the product-facing API
+// narrow; same-package tests access it directly.
+//
+// TODO(perf): PrepareForStart currently invokes this on every product Start,
+// which re-reads env vars even on cold startup where Get's lazy loadConfig
+// already did the work. A per-product `initialized atomic.Bool` in each
+// product's package would let Start gate the undo+refresh behind
+// `started.Swap(true)`, so cold first-Starts skip both and only re-inits pay
+// the refresh cost. Not done here to keep the POC scope small.
+func (c *Config) refreshFromEnv() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.loadEnvInto()
+}
+
+// PrepareForStart resets and refreshes the Config so that the given product
+// can apply its Start options on top. It:
+//
+//  1. Rolls back any programmatic (OriginCode) overrides this product recorded
+//     on a previous Start, leaving other products' overrides intact.
+//  2. Re-reads env-backed values so env changes between Starts are picked up.
+//
+// Products should call this at the top of their Start, after obtaining the
+// singleton via Get. Callers that only need to read the current configuration
+// (e.g. contribs) should use Get alone and not invoke this method.
+//
+//	c := internalconfig.Get()
+//	c.PrepareForStart(internalconfig.ProductTracer)
+//	// ... apply product Start options on top of c
+//
+// The underlying undo and refresh steps are internal details; they are not
+// exported so products cannot accidentally invoke only one half of the
+// ceremony or misorder them.
+func (c *Config) PrepareForStart(product Product) {
+	c.undoProduct(product)
+	c.refreshFromEnv()
+}
+
 // loadConfig initializes and returns a new config by reading from all configured sources.
 // This function is NOT thread-safe and should only be called once through Get's sync.Once.
 func loadConfig() *Config {
 	cfg := &Config{
 		overrides: make(map[string]programmaticOverride),
 	}
+	cfg.loadEnvInto()
 	p := provider.New()
-
-	// Resolve agent URL from DD_TRACE_AGENT_URL, DD_AGENT_HOST, DD_TRACE_AGENT_PORT.
-	// All three are read through the provider so telemetry is reported for each.
-	agentURLStr := p.GetString("DD_TRACE_AGENT_URL", "")
-	agentHost := p.GetString("DD_AGENT_HOST", "")
-	agentPort := p.GetString("DD_TRACE_AGENT_PORT", "")
-	cfg.agentURL = resolveAgentURL(agentURLStr, agentHost, agentPort)
-
-	cfg.debug = p.GetBool("DD_TRACE_DEBUG", false)
-	cfg.logStartup = p.GetBool("DD_TRACE_STARTUP_LOGS", true)
-	cfg.serviceName = p.GetString("DD_SERVICE", "")
-	cfg.version = p.GetString("DD_VERSION", "")
-	cfg.env = p.GetString("DD_ENV", "")
-	cfg.serviceMappings = p.GetMap("DD_SERVICE_MAPPING", nil, internal.DDTagsDelimiter)
-	cfg.runtimeMetrics = p.GetBool("DD_RUNTIME_METRICS_ENABLED", false)
-	cfg.runtimeMetricsV2 = p.GetBool("DD_RUNTIME_METRICS_V2_ENABLED", true)
-	cfg.profilerHotspots = p.GetBool("DD_PROFILING_CODE_HOTSPOTS_COLLECTION_ENABLED", true)
-	cfg.profilerEndpoints = p.GetBool("DD_PROFILING_ENDPOINT_COLLECTION_ENABLED", true)
-	cfg.peerServiceDefaultsEnabled = p.GetBool("DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED", false)
-	cfg.peerServiceMappings = p.GetMap("DD_TRACE_PEER_SERVICE_MAPPING", nil, internal.DDTagsDelimiter)
-	cfg.debugAbandonedSpans = p.GetBool("DD_TRACE_DEBUG_ABANDONED_SPANS", false)
-	cfg.spanTimeout = p.GetDuration("DD_TRACE_ABANDONED_SPAN_TIMEOUT", 10*time.Minute)
-	cfg.partialFlushMinSpans = p.GetIntWithValidator("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", 1000, validatePartialFlushMinSpans)
-	cfg.partialFlushEnabled = p.GetBool("DD_TRACE_PARTIAL_FLUSH_ENABLED", false)
-	cfg.statsComputationEnabled = p.GetBool("DD_TRACE_STATS_COMPUTATION_ENABLED", true)
-	cfg.dataStreamsMonitoringEnabled = p.GetBool("DD_DATA_STREAMS_ENABLED", false)
-	cfg.dynamicInstrumentationEnabled = p.GetBool("DD_DYNAMIC_INSTRUMENTATION_ENABLED", false)
-	cfg.ciVisibilityEnabled = p.GetBool(constants.CIVisibilityEnabledEnvironmentVariable, false)
-	cfg.ciVisibilityAgentless = p.GetBool("DD_CIVISIBILITY_AGENTLESS_ENABLED", false)
-	cfg.logDirectory = p.GetString("DD_TRACE_LOG_DIRECTORY", "")
-	cfg.traceRateLimitPerSecond = p.GetFloatWithValidator("DD_TRACE_RATE_LIMIT", DefaultRateLimit, validateRateLimit)
-	cfg.debugStack = p.GetBool("DD_TRACE_DEBUG_STACK", true)
-	cfg.retryInterval = p.GetDuration("DD_TRACE_RETRY_INTERVAL", time.Millisecond)
-	cfg.logsOTelEnabled = p.GetBool("DD_LOGS_OTEL_ENABLED", false)
-	cfg.traceProtocol = resolveTraceProtocol(p.GetStringWithValidator("DD_TRACE_AGENT_PROTOCOL_VERSION", TraceProtocolVersionStringV04, validateTraceProtocolVersion))
-	cfg.otlpExportMode = p.GetString("OTEL_TRACES_EXPORTER", "") == "otlp"
-	// DD_TRACE_AGENT_PROTOCOL_VERSION overrides OTEL_TRACES_EXPORTER
-	if p.IsSet("DD_TRACE_AGENT_PROTOCOL_VERSION") {
-		cfg.otlpExportMode = false
-	}
-	cfg.otlpTraceURL = resolveOTLPTraceURL(cfg.agentURL, p.GetString("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", ""))
-	cfg.otlpHeaders = buildOTLPHeaders(p.GetMap("OTEL_EXPORTER_OTLP_TRACES_HEADERS", nil, internal.OtelTagsDelimeter))
-	cfg.traceID128BitEnabled = p.GetBool("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", true)
 
 	sampleRate, sampleRateOrigin := p.GetFloatWithValidatorOrigin("DD_TRACE_SAMPLE_RATE", math.NaN(), validateSampleRate)
 	cfg.globalSampleRate = newDynamicConfig("trace_sample_rate", sampleRate, sampleRateOrigin, equalFloat)
@@ -346,27 +494,6 @@ func Get() *Config {
 	if useFreshConfig || instance == nil {
 		instance = loadConfig()
 	}
-
-	return instance
-}
-
-// CreateNew returns a new global configuration instance.
-// This function should be used when we need to create a new configuration instance.
-// It build a new configuration instance and override the existing one
-// loosing any programmatic configuration that would have been applied to the existing instance.
-//
-// It shouldn't be used to get the global configuration instance to manipulate it but
-// should be used when there is a need to reset the global configuration instance.
-//
-// This is useful when we need to create a new configuration instance when a new product is initialized.
-// Each product should have its own configuration instance and apply its own programmatic configuration to it.
-//
-// If a customer starts multiple tracer with different programmatic configuration only the latest one will be used
-// and available globally.
-func CreateNew() *Config {
-	mu.Lock()
-	defer mu.Unlock()
-	instance = loadConfig()
 
 	return instance
 }
@@ -754,8 +881,9 @@ func (c *Config) SetEnv(env string, origin telemetry.Origin, product ...Product)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	priorVal := c.env
-	// Silent restore — telemetry is re-reported by the next RefreshFromEnv
-	// (called from each product's Start) or by a subsequent code write.
+	// Silent restore — telemetry is re-reported by the next refreshFromEnv
+	// (invoked via PrepareForStart on each product Start) or by a subsequent
+	// code write.
 	restore := func() {
 		c.env = priorVal
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,10 +52,14 @@ const (
 	ProductProfiler Product = "profiler"
 )
 
-// programmaticOverride records which product claimed a field via programmatic API.
+// programmaticOverride records which product claimed a field via programmatic API
+// and, for the first code-origin write per (field, product), the closure that reverts
+// the field to its pre-code state. restore is captured exactly once and preserved
+// across same-product rewrites so UndoProduct always restores to the true baseline.
 type programmaticOverride struct {
 	product Product
 	value   any
+	restore func()
 }
 
 // Config represents global configuration properties.
@@ -65,7 +69,7 @@ type Config struct {
 	mu sync.RWMutex
 
 	// overrides tracks which product claimed each field via programmatic API (OriginCode).
-	// Used by checkOverrideConflict to enforce the cross-product gate.
+	// Used by snapshotAndCheck to enforce the cross-product gate and to record undo baselines.
 	overrides map[string]programmaticOverride
 
 	// Config fields are protected by the mutex.
@@ -144,34 +148,86 @@ type Config struct {
 	traceID128BitEnabled bool
 }
 
-// checkProductConflict enforces the cross-product gate for programmatic API calls.
+// snapshotAndCheck enforces the cross-product gate for programmatic API calls and,
+// on the first code-origin write to a field by a given product, records the baseline
+// restore closure so the override can later be reverted via UndoProduct.
+//
 // Returns true if the caller should abort the update (a different product already
 // claimed this field). No-op when product is not supplied or origin is not OriginCode.
 // The product parameter is variadic for ergonomic pass-through from Set* methods;
 // only the first value is used and callers should pass at most one.
+//
+// restore is the closure the caller passes on every invocation; it is stored only
+// on the first write per (field, product). Subsequent writes from the same product
+// update the current value but preserve the original restore closure, so the baseline
+// always reflects the true pre-any-code state.
+//
 // Must be called while c.mu is held.
-func (c *Config) checkProductConflict(field string, origin telemetry.Origin, value any, product ...Product) bool {
+func (c *Config) snapshotAndCheck(field string, origin telemetry.Origin, value any, restore func(), product ...Product) bool {
 	if origin != telemetry.OriginCode || len(product) == 0 {
 		return false
 	}
 	p := product[0]
-	if prev, exists := c.overrides[field]; exists && prev.product != p {
-		if reflect.DeepEqual(prev.value, value) {
-			return false
+	if prev, exists := c.overrides[field]; exists {
+		if prev.product != p {
+			if reflect.DeepEqual(prev.value, value) {
+				return false
+			}
+			telemetry.Count(telemetry.NamespaceGeneral, "config.product_conflict", []string{
+				"name:" + field,
+				"first_product:" + string(prev.product),
+				"second_product:" + string(p),
+				"first_value:" + fmt.Sprint(prev.value),
+				"second_value:" + fmt.Sprint(value),
+			}).Submit(1)
+			log.Warn("config: %s already set %s via programmatic API; ignoring %s's attempt to override it",
+				prev.product, field, p)
+			return true
 		}
-		telemetry.Count(telemetry.NamespaceGeneral, "config.product_conflict", []string{
-			"name:" + field,
-			"first_product:" + string(prev.product),
-			"second_product:" + string(p),
-			"first_value:" + fmt.Sprint(prev.value),
-			"second_value:" + fmt.Sprint(value),
-		}).Submit(1)
-		log.Warn("config: %s already set %s via programmatic API; ignoring %s's attempt to override it",
-			prev.product, field, p)
-		return true
+		// Same-product rewrite: update the current value but preserve the
+		// original restore closure so undo still reverts to the pre-any-code baseline.
+		prev.value = value
+		c.overrides[field] = prev
+		return false
 	}
-	c.overrides[field] = programmaticOverride{product: p, value: value}
+	c.overrides[field] = programmaticOverride{product: p, value: value, restore: restore}
 	return false
+}
+
+// checkProductConflict is a thin wrapper around snapshotAndCheck for setters
+// that have not yet been migrated to capture undo baselines. It enforces the
+// same first-product-wins gate, but fields updated through this path will NOT
+// participate in UndoProduct — their entries remain in the overrides map to
+// preserve ownership, but no restore closure is recorded.
+//
+// Must be called while c.mu is held.
+func (c *Config) checkProductConflict(field string, origin telemetry.Origin, value any, product ...Product) bool {
+	return c.snapshotAndCheck(field, origin, value, nil, product...)
+}
+
+// UndoProduct reverts every programmatic (OriginCode) override recorded for the
+// given product back to the value it held before the first code-origin write.
+// Only overrides registered with a non-nil restore closure are undone; setters
+// that still use the legacy checkProductConflict path retain their values, but
+// their ownership entry is released so a subsequent code write can claim the
+// field. Overrides owned by other products and values written via non-code
+// origins (env vars, defaults, remote config) are left untouched.
+//
+// Intended to be called by a product's Start() before applying new options, so
+// that repeat Start calls yield last-Start-wins semantics without wiping other
+// products' overrides.
+func (c *Config) UndoProduct(p Product) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for field, ov := range c.overrides {
+		if ov.product != p {
+			continue
+		}
+		if ov.restore != nil {
+			ov.restore()
+		}
+		delete(c.overrides, field)
+	}
 }
 
 // loadConfig initializes and returns a new config by reading from all configured sources.
@@ -697,7 +753,13 @@ func (c *Config) Env() string {
 func (c *Config) SetEnv(env string, origin telemetry.Origin, product ...Product) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.checkProductConflict("DD_ENV", origin, env, product...) {
+	priorVal := c.env
+	// Silent restore — telemetry is re-reported by the next RefreshFromEnv
+	// (called from each product's Start) or by a subsequent code write.
+	restore := func() {
+		c.env = priorVal
+	}
+	if c.snapshotAndCheck("DD_ENV", origin, env, restore, product...) {
 		return
 	}
 	c.env = env

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -867,3 +867,142 @@ func TestAdditiveConfigs(t *testing.T) {
 		assert.Equal(t, "frontend-v2", to, "last write wins for same mapping key")
 	})
 }
+
+func TestUndoProduct(t *testing.T) {
+	t.Run("restores prior value to default baseline", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+
+		cfg := Get()
+		// Baseline is the zero value loaded from env/defaults (empty string here,
+		// since no DD_ENV is set in the test env).
+		before := cfg.Env()
+
+		cfg.SetEnv("staging", OriginCode, ProductTracer)
+		assert.Equal(t, "staging", cfg.Env())
+
+		cfg.UndoProduct(ProductTracer)
+		assert.Equal(t, before, cfg.Env(), "undo should revert to pre-code baseline")
+	})
+
+	t.Run("same-product rewrite preserves original baseline", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+
+		cfg := Get()
+		before := cfg.Env()
+
+		cfg.SetEnv("staging", OriginCode, ProductTracer)
+		cfg.SetEnv("production", OriginCode, ProductTracer)
+		assert.Equal(t, "production", cfg.Env())
+
+		cfg.UndoProduct(ProductTracer)
+		assert.Equal(t, before, cfg.Env(),
+			"undo should revert all the way back to pre-any-code state, not to intermediate value")
+	})
+
+	t.Run("leaves other product's overrides intact", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+
+		cfg := Get()
+
+		// Tracer and profiler each set DD_ENV via their own product tag. The first
+		// Start wins the field; the losing product's attempt is rejected by the
+		// conflict gate. Here we test that undoing the winner cleanly releases it.
+		cfg.SetEnv("tracer-env", OriginCode, ProductTracer)
+		assert.Equal(t, "tracer-env", cfg.Env())
+
+		cfg.UndoProduct(ProductProfiler) // no-op: profiler owns nothing
+		assert.Equal(t, "tracer-env", cfg.Env(),
+			"undo on non-owner product must not touch field")
+	})
+
+	t.Run("conflict-rejected writes are not recorded and not undone", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+
+		cfg := Get()
+		before := cfg.Env()
+
+		cfg.SetEnv("tracer-env", OriginCode, ProductTracer)
+		// Conflict: different product trying to override same field. Rejected.
+		cfg.SetEnv("profiler-env", OriginCode, ProductProfiler)
+		assert.Equal(t, "tracer-env", cfg.Env())
+
+		// Undoing profiler should be a no-op for this field (profiler never claimed it).
+		cfg.UndoProduct(ProductProfiler)
+		assert.Equal(t, "tracer-env", cfg.Env(),
+			"undo on non-owner product must not touch field")
+
+		// Undoing tracer restores the baseline.
+		cfg.UndoProduct(ProductTracer)
+		assert.Equal(t, before, cfg.Env())
+	})
+
+	t.Run("is idempotent", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+
+		cfg := Get()
+		before := cfg.Env()
+
+		cfg.SetEnv("staging", OriginCode, ProductTracer)
+		cfg.UndoProduct(ProductTracer)
+		cfg.UndoProduct(ProductTracer) // second call must not panic or re-mutate
+		assert.Equal(t, before, cfg.Env())
+	})
+
+	t.Run("does not touch non-code-origin values", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+
+		cfg := Get()
+		// Simulate an env-var-origin write (no product, no override recorded).
+		cfg.SetEnv("from-env", telemetry.OriginEnvVar)
+		assert.Equal(t, "from-env", cfg.Env())
+
+		cfg.UndoProduct(ProductTracer)
+		assert.Equal(t, "from-env", cfg.Env(),
+			"env-origin values are not in the overrides map and must not be undone")
+	})
+
+	t.Run("re-Start pattern: undo then apply new options", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+
+		cfg := Get()
+		before := cfg.Env()
+
+		// First Start with an env override.
+		cfg.SetEnv("first-env", OriginCode, ProductTracer)
+		assert.Equal(t, "first-env", cfg.Env())
+
+		// Simulate re-Start: undo then apply a new value. Because UndoProduct
+		// restored the baseline, the new write is treated as the first code
+		// write — not a rewrite on top of the previous override.
+		cfg.UndoProduct(ProductTracer)
+		assert.Equal(t, before, cfg.Env(), "baseline should be restored before new Start")
+
+		cfg.SetEnv("second-env", OriginCode, ProductTracer)
+		assert.Equal(t, "second-env", cfg.Env())
+
+		// And a second undo should still roll all the way back to the true baseline.
+		cfg.UndoProduct(ProductTracer)
+		assert.Equal(t, before, cfg.Env())
+	})
+
+	t.Run("after undo, other product can now claim the field", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+
+		cfg := Get()
+
+		cfg.SetEnv("tracer-env", OriginCode, ProductTracer)
+		cfg.UndoProduct(ProductTracer)
+
+		// Profiler should now be free to claim the field since tracer released it.
+		cfg.SetEnv("profiler-env", OriginCode, ProductProfiler)
+		assert.Equal(t, "profiler-env", cfg.Env())
+	})
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -75,30 +75,6 @@ func TestGet(t *testing.T) {
 		assert.Same(t, cfg4, cfg5, "With useFreshConfig=false, Get() should cache the same instance")
 	})
 
-	t.Run("GetNew forces new instance", func(t *testing.T) {
-		resetGlobalState()
-		defer resetGlobalState()
-
-		// Get the first instance
-		cfg1 := Get()
-		require.NotNil(t, cfg1)
-
-		// Get should return the same instance
-		cfg2 := Get()
-		require.NotNil(t, cfg2)
-		assert.Same(t, cfg1, cfg2, "Get() should return the same instance")
-
-		// CreateNew should return a new instance
-		cfg3 := CreateNew()
-		require.NotNil(t, cfg3)
-		assert.NotSame(t, cfg2, cfg3, "CreateNew() should return a new instance")
-
-		// Now it should cache the same instance
-		cfg4 := Get()
-		assert.Same(t, cfg3, cfg4, "Get() should return the same instance")
-		assert.NotSame(t, cfg1, cfg4, "Get() should not return the same instance as the first one")
-	})
-
 	t.Run("concurrent access is safe", func(t *testing.T) {
 		resetGlobalState()
 		defer resetGlobalState()
@@ -881,7 +857,7 @@ func TestUndoProduct(t *testing.T) {
 		cfg.SetEnv("staging", OriginCode, ProductTracer)
 		assert.Equal(t, "staging", cfg.Env())
 
-		cfg.UndoProduct(ProductTracer)
+		cfg.undoProduct(ProductTracer)
 		assert.Equal(t, before, cfg.Env(), "undo should revert to pre-code baseline")
 	})
 
@@ -896,7 +872,7 @@ func TestUndoProduct(t *testing.T) {
 		cfg.SetEnv("production", OriginCode, ProductTracer)
 		assert.Equal(t, "production", cfg.Env())
 
-		cfg.UndoProduct(ProductTracer)
+		cfg.undoProduct(ProductTracer)
 		assert.Equal(t, before, cfg.Env(),
 			"undo should revert all the way back to pre-any-code state, not to intermediate value")
 	})
@@ -913,7 +889,7 @@ func TestUndoProduct(t *testing.T) {
 		cfg.SetEnv("tracer-env", OriginCode, ProductTracer)
 		assert.Equal(t, "tracer-env", cfg.Env())
 
-		cfg.UndoProduct(ProductProfiler) // no-op: profiler owns nothing
+		cfg.undoProduct(ProductProfiler) // no-op: profiler owns nothing
 		assert.Equal(t, "tracer-env", cfg.Env(),
 			"undo on non-owner product must not touch field")
 	})
@@ -931,12 +907,12 @@ func TestUndoProduct(t *testing.T) {
 		assert.Equal(t, "tracer-env", cfg.Env())
 
 		// Undoing profiler should be a no-op for this field (profiler never claimed it).
-		cfg.UndoProduct(ProductProfiler)
+		cfg.undoProduct(ProductProfiler)
 		assert.Equal(t, "tracer-env", cfg.Env(),
 			"undo on non-owner product must not touch field")
 
 		// Undoing tracer restores the baseline.
-		cfg.UndoProduct(ProductTracer)
+		cfg.undoProduct(ProductTracer)
 		assert.Equal(t, before, cfg.Env())
 	})
 
@@ -948,8 +924,8 @@ func TestUndoProduct(t *testing.T) {
 		before := cfg.Env()
 
 		cfg.SetEnv("staging", OriginCode, ProductTracer)
-		cfg.UndoProduct(ProductTracer)
-		cfg.UndoProduct(ProductTracer) // second call must not panic or re-mutate
+		cfg.undoProduct(ProductTracer)
+		cfg.undoProduct(ProductTracer) // second call must not panic or re-mutate
 		assert.Equal(t, before, cfg.Env())
 	})
 
@@ -962,7 +938,7 @@ func TestUndoProduct(t *testing.T) {
 		cfg.SetEnv("from-env", telemetry.OriginEnvVar)
 		assert.Equal(t, "from-env", cfg.Env())
 
-		cfg.UndoProduct(ProductTracer)
+		cfg.undoProduct(ProductTracer)
 		assert.Equal(t, "from-env", cfg.Env(),
 			"env-origin values are not in the overrides map and must not be undone")
 	})
@@ -978,17 +954,17 @@ func TestUndoProduct(t *testing.T) {
 		cfg.SetEnv("first-env", OriginCode, ProductTracer)
 		assert.Equal(t, "first-env", cfg.Env())
 
-		// Simulate re-Start: undo then apply a new value. Because UndoProduct
+		// Simulate re-Start: undo then apply a new value. Because undoProduct
 		// restored the baseline, the new write is treated as the first code
 		// write — not a rewrite on top of the previous override.
-		cfg.UndoProduct(ProductTracer)
+		cfg.undoProduct(ProductTracer)
 		assert.Equal(t, before, cfg.Env(), "baseline should be restored before new Start")
 
 		cfg.SetEnv("second-env", OriginCode, ProductTracer)
 		assert.Equal(t, "second-env", cfg.Env())
 
 		// And a second undo should still roll all the way back to the true baseline.
-		cfg.UndoProduct(ProductTracer)
+		cfg.undoProduct(ProductTracer)
 		assert.Equal(t, before, cfg.Env())
 	})
 
@@ -999,7 +975,7 @@ func TestUndoProduct(t *testing.T) {
 		cfg := Get()
 
 		cfg.SetEnv("tracer-env", OriginCode, ProductTracer)
-		cfg.UndoProduct(ProductTracer)
+		cfg.undoProduct(ProductTracer)
 
 		// Profiler should now be free to claim the field since tracer released it.
 		cfg.SetEnv("profiler-env", OriginCode, ProductProfiler)

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -22,11 +22,13 @@ import (
 	"unicode"
 
 	"github.com/DataDog/dd-trace-go/v2/internal"
+	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/env"
 	"github.com/DataDog/dd-trace-go/v2/internal/globalconfig"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/osinfo"
 	"github.com/DataDog/dd-trace-go/v2/internal/stableconfig"
+	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 	"github.com/DataDog/dd-trace-go/v2/internal/traceprof"
 	"github.com/DataDog/dd-trace-go/v2/internal/version"
 	"github.com/DataDog/dd-trace-go/v2/profiler/internal/immutable"
@@ -87,6 +89,9 @@ var defaultClient = &http.Client{
 var defaultProfileTypes = []ProfileType{MetricsProfile, CPUProfile, HeapProfile}
 
 type config struct {
+	// internalConfig holds a reference to the global configuration singleton.
+	internalConfig *internalconfig.Config
+
 	apiKey    string
 	agentless bool
 	// targetURL is the upload destination URL. It will be set by the profiler on start to either apiURL or agentURL
@@ -173,7 +178,11 @@ func (c *config) addProfileType(t ProfileType) {
 }
 
 func defaultConfig() (*config, error) {
+	cfg := internalconfig.Get()
+	cfg.PrepareForStart(internalconfig.ProductProfiler)
+
 	c := config{
+		internalConfig:       cfg,
 		apiURL:               defaultAPIURL,
 		service:              filepath.Base(os.Args[0]),
 		statsd:               &statsd.NoOpClient{},
@@ -370,9 +379,16 @@ func WithService(name string) Option {
 }
 
 // WithEnv specifies the environment to which these profiles should be registered.
-func WithEnv(env string) Option {
+//
+// This is the first profiler option to route through the shared Config singleton.
+// The origin-tagged write records the profiler's claim on DD_ENV so that:
+//   - cross-product conflicts are detected (e.g., tracer.WithEnv("a") already set)
+//   - profiler.Start's PrepareForStart(ProductProfiler) call can revert the write
+//     on a subsequent Start without disturbing other products' overrides.
+func WithEnv(e string) Option {
 	return func(cfg *config) {
-		cfg.env = env
+		cfg.env = e
+		cfg.internalConfig.SetEnv(e, telemetry.OriginCode, internalconfig.ProductProfiler)
 	}
 }
 

--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -170,8 +170,9 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("WithEnv", func(t *testing.T) {
-		var cfg config
-		WithEnv("envName")(&cfg)
+		cfg, err := defaultConfig()
+		require.NoError(t, err)
+		WithEnv("envName")(cfg)
 		assert.Equal(t, "envName", cfg.env)
 	})
 


### PR DESCRIPTION
## Summary

A POC for adding per-product undo semantics to the shared `internal/config` singleton, so a product's repeat `Start` can roll back its own programmatic overrides without disturbing other products.

Three commits, each reviewable on its own:

1. **`feat(config): source-tagged undo for programmatic overrides`** — the mechanism: extended `programmaticOverride` with a restore closure, new `snapshotAndCheck` helper, new `UndoProduct(Product)` method, `SetEnv` migrated as the worked example. Legacy setters continue using `checkProductConflict` (now a thin wrapper) until migrated individually.
2. **`feat(config): in-place env refresh, remove CreateNew`** — the refresh path: extract `loadEnvInto` from `loadConfig`, add `RefreshFromEnv` that reuses it. Remove `CreateNew`. Tracer's `newConfig` now does `Get + UndoProduct(ProductTracer) + RefreshFromEnv` instead of rebuilding the singleton. Two tests that called `CreateNew` updated to use `SetUseFreshConfig + Get`.
3. **`feat(profiler): route WithEnv through the shared Config singleton`** — first profiler option migrated: `WithEnv` now calls `internalconfig.Get().SetEnv(...)` with `ProductProfiler`, and `profiler.Start` runs the same `Get + UndoProduct + RefreshFromEnv` ceremony as the tracer.

## Design

Cross-cutting configuration (service, env, version, …) stays in the shared singleton with first-product-wins conflict detection at write time. Per-product restart semantics come from `UndoProduct(Product)` rolling back only that product's code-origin writes. Env-var refresh on restart comes from `RefreshFromEnv` mutating the singleton in place (guarded by the overrides map), so re-reading env doesn't clobber other products' overrides.

## Scope

- One singleton setter (`SetEnv`) is on the new undo path as the POC. The other 27 setters still use `checkProductConflict`; they retain ownership tracking but do not participate in undo until individually migrated.
- One profiler option (`WithEnv`) is routed through the singleton. Others stay local.
- Remote config interaction with the new override/baseline layer is out of scope for this POC.
- `RefreshFromEnv` does full env re-read on every product Start. A `TODO(perf)` in the code describes the per-product `initialized atomic.Bool` optimization that would gate the refresh on cold-vs-reinit; intentionally deferred.

## Test plan

- [x] `TestUndoProduct` — new test exercising baseline restoration, same-product rewrite preserving original baseline, cross-product isolation, conflict-rejected writes, idempotent undo, non-code-origin values untouched, re-Start pattern, post-undo ownership release
- [x] `TestProductConflict`, `TestGet`, `TestAdditiveConfigs`, `TestHostnameConfiguration`, `TestOTLPHeaders` — pre-existing config tests still pass
- [x] `TestSetFeatureFlagsReportsFullList`, `TestSetServiceMappingReportsFullList` — telemetry-reporting tests still pass
- [x] Profiler tests (`TestStart`, `TestOptions`, `TestAllOptions`) still pass
- [ ] CI runs to confirm nothing else regresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)