### PR TITLE
perf(internal/civisibility): cache testing field offsets

### DIFF
--- a/internal/civisibility/integrations/gotesting/reflection_offsets.go
+++ b/internal/civisibility/integrations/gotesting/reflection_offsets.go
@@ -1,0 +1,540 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package gotesting
+
+import (
+	"context"
+	"io"
+	"reflect"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+// unsafeField describes a private field discovered from a runtime type.
+// Offset zero is a valid offset, so callers must use available instead of
+// treating a zero offset as "not found".
+type unsafeField struct {
+	name      string
+	offset    uintptr
+	size      uintptr
+	typ       reflect.Type
+	available bool
+	optional  bool
+}
+
+// wordCopiedField marks a field that the existing implementation copies as a
+// single pointer-sized word. This preserves compatibility for fields that were
+// intentionally accessed through unsafe.Pointer instead of their real type.
+type wordCopiedField struct {
+	unsafeField
+}
+
+// commonFieldsLayout stores the private testing.common fields used by the
+// gotesting integration. These offsets are always relative to a testing.common
+// base pointer, not directly to a testing.T or testing.B pointer.
+type commonFieldsLayout struct {
+	mu              unsafeField
+	output          unsafeField
+	w               unsafeField
+	ran             unsafeField
+	failed          unsafeField
+	skipped         unsafeField
+	done            unsafeField
+	helperPCs       unsafeField
+	helperNames     unsafeField
+	cleanups        unsafeField
+	cleanupName     unsafeField
+	cleanupPc       unsafeField
+	finished        unsafeField
+	inFuzzFn        unsafeField
+	chatty          wordCopiedField
+	bench           unsafeField
+	hasSub          unsafeField
+	cleanupStarted  unsafeField
+	runner          unsafeField
+	isParallel      unsafeField
+	parent          wordCopiedField
+	level           unsafeField
+	creator         unsafeField
+	name            unsafeField
+	start           wordCopiedField
+	duration        unsafeField
+	barrier         unsafeField
+	signal          unsafeField
+	sub             unsafeField
+	lastRaceErrors  unsafeField
+	raceErrorLogged unsafeField
+	tempDir         unsafeField
+	tempDirErr      unsafeField
+	tempDirSeq      unsafeField
+	isEnvSet        unsafeField
+	context         wordCopiedField
+	ctx             unsafeField
+	cancelCtx       unsafeField
+	o               unsafeField
+}
+
+// contextMatcherLayout stores the private matcher fields reached through
+// testing.T's context or tstate pointer. The source pointer field is optional
+// because Go renamed this path across releases.
+type contextMatcherLayout struct {
+	sourceField wordCopiedField
+	match       wordCopiedField
+	mu          unsafeField
+	subNames    unsafeField
+}
+
+// chattyPrinterLayout stores the fields needed to wrap verbose test output.
+// The layout is only valid when the runtime exposes the expected private
+// chattyPrinter shape.
+type chattyPrinterLayout struct {
+	w        unsafeField
+	lastName unsafeField
+}
+
+// outputWriterLayout stores the Go 1.25+ output writer internals. These fields
+// are optional because older Go layouts do not expose testing.common.o.
+type outputWriterLayout struct {
+	typ     reflect.Type
+	c       unsafeField
+	partial unsafeField
+}
+
+// benchmarkFieldsLayout stores private testing.B fields that are outside the
+// embedded testing.common value.
+type benchmarkFieldsLayout struct {
+	benchFunc unsafeField
+	result    unsafeField
+}
+
+// testingInternalsLayout is the process-local description of the runtime
+// testing package layout. Section flags are computed once so hot helpers do not
+// repeat compatibility decisions on every test execution.
+type testingInternalsLayout struct {
+	disabled bool
+
+	tCommon unsafeField
+	bCommon unsafeField
+	common  commonFieldsLayout
+
+	tstate         wordCopiedField
+	denyParallel   unsafeField
+	contextMatcher contextMatcherLayout
+	chattyPrinter  chattyPrinterLayout
+	outputWriter   outputWriterLayout
+	benchmark      benchmarkFieldsLayout
+
+	testFieldsOK      bool
+	parentFieldsOK    bool
+	contextMatcherOK  bool
+	copyTestOK        bool
+	createTestOK      bool
+	outputWriterOK    bool
+	chattyOK          bool
+	benchmarkFieldsOK bool
+}
+
+var (
+	testingInternalsLayoutOnce  sync.Once
+	testingInternalsLayoutValue *testingInternalsLayout
+)
+
+// getTestingInternalsLayout returns the cached runtime testing layout. If layout
+// discovery sees an unexpected shape, the returned layout has fast paths disabled
+// and callers fall back to the reflection implementation.
+func getTestingInternalsLayout() *testingInternalsLayout {
+	testingInternalsLayoutOnce.Do(func() {
+		testingInternalsLayoutValue = buildTestingInternalsLayout(
+			reflect.TypeFor[testing.T](),
+			reflect.TypeFor[testing.B](),
+		)
+	})
+	return testingInternalsLayoutValue
+}
+
+// buildTestingInternalsLayout builds a layout from explicit types. Keeping this
+// pure lets tests exercise invalid layouts without resetting the package-level
+// sync.Once used by production code.
+func buildTestingInternalsLayout(tType, bType reflect.Type) (layout *testingInternalsLayout) {
+	defer func() {
+		if recover() != nil {
+			layout = &testingInternalsLayout{disabled: true}
+		}
+	}()
+
+	l := &testingInternalsLayout{}
+	if tType.Kind() != reflect.Struct || bType.Kind() != reflect.Struct {
+		l.disabled = true
+		return l
+	}
+
+	commonFromT, ok := exactField(tType, "common", nil, false)
+	if !ok || commonFromT.offset != 0 || commonFromT.typ.Kind() != reflect.Struct {
+		l.disabled = true
+		return l
+	}
+	commonFromB, ok := exactField(bType, "common", commonFromT.typ, false)
+	if !ok || commonFromB.offset != 0 {
+		l.disabled = true
+		return l
+	}
+
+	l.tCommon = commonFromT
+	l.bCommon = commonFromB
+	commonType := commonFromT.typ
+
+	l.common.mu, _ = exactField(commonType, "mu", reflect.TypeFor[sync.RWMutex](), false)
+	l.common.output, _ = exactField(commonType, "output", reflect.TypeFor[[]byte](), false)
+	l.common.w, _ = exactField(commonType, "w", reflect.TypeFor[io.Writer](), false)
+	l.common.ran, _ = exactField(commonType, "ran", reflect.TypeFor[bool](), false)
+	l.common.failed, _ = exactField(commonType, "failed", reflect.TypeFor[bool](), false)
+	l.common.skipped, _ = exactField(commonType, "skipped", reflect.TypeFor[bool](), false)
+	l.common.done, _ = exactField(commonType, "done", reflect.TypeFor[bool](), false)
+	l.common.helperPCs, _ = exactField(commonType, "helperPCs", reflect.TypeFor[map[uintptr]struct{}](), false)
+	l.common.helperNames, _ = exactField(commonType, "helperNames", reflect.TypeFor[map[string]struct{}](), false)
+	l.common.cleanups, _ = exactField(commonType, "cleanups", reflect.TypeFor[[]func()](), false)
+	l.common.cleanupName, _ = exactField(commonType, "cleanupName", reflect.TypeFor[string](), false)
+	l.common.cleanupPc, _ = exactField(commonType, "cleanupPc", reflect.TypeFor[[]uintptr](), false)
+	l.common.finished, _ = exactField(commonType, "finished", reflect.TypeFor[bool](), false)
+	l.common.inFuzzFn, _ = exactField(commonType, "inFuzzFn", reflect.TypeFor[bool](), false)
+	l.common.chatty, _ = wordField(commonType, "chatty", false)
+	l.common.bench, _ = exactField(commonType, "bench", reflect.TypeFor[bool](), false)
+	l.common.hasSub, _ = exactField(commonType, "hasSub", reflect.TypeFor[atomic.Bool](), false)
+	l.common.cleanupStarted, _ = exactField(commonType, "cleanupStarted", reflect.TypeFor[atomic.Bool](), false)
+	l.common.runner, _ = exactField(commonType, "runner", reflect.TypeFor[string](), false)
+	l.common.isParallel, _ = exactField(commonType, "isParallel", reflect.TypeFor[bool](), false)
+	l.common.parent, _ = wordField(commonType, "parent", false)
+	l.common.level, _ = exactField(commonType, "level", reflect.TypeFor[int](), false)
+	l.common.creator, _ = exactField(commonType, "creator", reflect.TypeFor[[]uintptr](), false)
+	l.common.name, _ = exactField(commonType, "name", reflect.TypeFor[string](), false)
+	l.common.start, _ = pointerSizedField(commonType, "start", false)
+	l.common.duration, _ = exactField(commonType, "duration", reflect.TypeFor[time.Duration](), false)
+	l.common.barrier, _ = exactField(commonType, "barrier", reflect.TypeFor[chan bool](), false)
+	l.common.signal, _ = exactField(commonType, "signal", reflect.TypeFor[chan bool](), false)
+	l.common.sub, _ = exactField(commonType, "sub", reflect.TypeFor[[]*testing.T](), false)
+	l.common.lastRaceErrors, _ = exactField(commonType, "lastRaceErrors", reflect.TypeFor[atomic.Int64](), false)
+	l.common.raceErrorLogged, _ = exactField(commonType, "raceErrorLogged", reflect.TypeFor[atomic.Bool](), false)
+	l.common.tempDir, _ = exactField(commonType, "tempDir", reflect.TypeFor[string](), false)
+	l.common.tempDirErr, _ = exactField(commonType, "tempDirErr", reflect.TypeFor[error](), false)
+	l.common.tempDirSeq, _ = exactField(commonType, "tempDirSeq", reflect.TypeFor[int32](), false)
+	l.common.isEnvSet, _ = optionalExactField(commonType, "isEnvSet", reflect.TypeFor[bool]())
+	l.common.context, _ = optionalWordField(commonType, "context")
+	l.common.ctx, _ = optionalExactField(commonType, "ctx", reflect.TypeFor[context.Context]())
+	l.common.cancelCtx, _ = optionalExactField(commonType, "cancelCtx", reflect.TypeFor[context.CancelFunc]())
+	l.common.o, _ = optionalPointerToStructField(commonType, "o")
+
+	l.denyParallel, _ = exactField(tType, "denyParallel", reflect.TypeFor[bool](), false)
+	l.tstate, _ = optionalWordField(tType, "tstate")
+	l.benchmark.benchFunc, _ = exactField(bType, "benchFunc", reflect.TypeFor[func(*testing.B)](), false)
+	l.benchmark.result, _ = exactField(bType, "result", reflect.TypeFor[testing.BenchmarkResult](), false)
+
+	l.buildOutputWriterLayout()
+	l.buildContextMatcherLayout()
+	l.buildChattyPrinterLayout()
+	l.computeSectionFlags()
+	return l
+}
+
+// buildOutputWriterLayout discovers Go 1.25+'s output writer shape when it is
+// present. Older layouts leave outputWriterOK disabled and keep no-op behavior.
+func (l *testingInternalsLayout) buildOutputWriterLayout() {
+	if !l.common.o.available || l.common.o.typ.Kind() != reflect.Pointer || l.common.o.typ.Elem().Kind() != reflect.Struct {
+		return
+	}
+	outputWriterType := l.common.o.typ.Elem()
+	cField, cOK := pointerField(outputWriterType, "c", false)
+	partialField, partialOK := exactField(outputWriterType, "partial", reflect.TypeFor[[]byte](), false)
+	if !cOK || !partialOK {
+		return
+	}
+	l.outputWriter.typ = outputWriterType
+	l.outputWriter.c = cField
+	l.outputWriter.partial = partialField
+	l.outputWriterOK = true
+}
+
+// buildContextMatcherLayout discovers the matcher path through either the old
+// context field or the newer tstate field. The current reflection code tries
+// context first, so this preserves that order when both are present.
+func (l *testingInternalsLayout) buildContextMatcherLayout() {
+	source := l.common.context
+	if !source.available {
+		source = l.tstate
+	}
+	if !source.available || source.typ.Kind() != reflect.Pointer || source.typ.Elem().Kind() != reflect.Struct {
+		return
+	}
+
+	stateType := source.typ.Elem()
+	matchField, ok := wordField(stateType, "match", false)
+	if !ok || matchField.typ.Kind() != reflect.Pointer || matchField.typ.Elem().Kind() != reflect.Struct {
+		return
+	}
+
+	matcherType := matchField.typ.Elem()
+	muField, muOK := exactField(matcherType, "mu", reflect.TypeFor[sync.Mutex](), false)
+	subNamesField, subNamesOK := exactField(matcherType, "subNames", reflect.TypeFor[map[string]int32](), false)
+	if !muOK || !subNamesOK {
+		return
+	}
+
+	l.contextMatcher.sourceField = source
+	l.contextMatcher.match = matchField
+	l.contextMatcher.mu = muField
+	l.contextMatcher.subNames = subNamesField
+	l.contextMatcherOK = true
+}
+
+// buildChattyPrinterLayout discovers the private chattyPrinter fields used to
+// capture verbose test output. Missing chatty internals disable only chatty
+// instrumentation, not the rest of the offset fast paths.
+func (l *testingInternalsLayout) buildChattyPrinterLayout() {
+	if !l.common.chatty.available || l.common.chatty.typ.Kind() != reflect.Pointer || l.common.chatty.typ.Elem().Kind() != reflect.Struct {
+		return
+	}
+	chattyType := l.common.chatty.typ.Elem()
+	wField, wOK := exactField(chattyType, "w", reflect.TypeFor[io.Writer](), false)
+	lastNameField, lastNameOK := exactField(chattyType, "lastName", reflect.TypeFor[string](), false)
+	if !wOK || !lastNameOK {
+		return
+	}
+	l.chattyPrinter.w = wField
+	l.chattyPrinter.lastName = lastNameField
+	l.chattyOK = true
+}
+
+// computeSectionFlags records which helpers can safely use offset access. The
+// helper wrappers read these flags directly instead of repeating compatibility
+// decisions in hot paths.
+func (l *testingInternalsLayout) computeSectionFlags() {
+	l.testFieldsOK = allAvailable(
+		l.common.mu, l.common.output, l.common.level, l.common.name,
+		l.common.failed, l.common.skipped, l.common.parent.unsafeField, l.common.barrier,
+		l.common.signal, l.common.sub,
+	)
+	l.parentFieldsOK = allAvailable(
+		l.common.parent.unsafeField, l.common.mu, l.common.output, l.common.level,
+		l.common.name, l.common.failed, l.common.skipped, l.common.barrier,
+	)
+	l.createTestOK = allAvailable(l.common.barrier, l.common.signal)
+	l.copyTestOK = allAvailable(
+		l.common.mu, l.common.output, l.common.w, l.common.ran, l.common.failed,
+		l.common.skipped, l.common.done, l.common.helperPCs, l.common.helperNames,
+		l.common.cleanups, l.common.cleanupName, l.common.cleanupPc, l.common.finished,
+		l.common.inFuzzFn, l.common.chatty.unsafeField, l.common.bench, l.common.hasSub,
+		l.common.cleanupStarted, l.common.runner, l.common.isParallel, l.common.level,
+		l.common.creator, l.common.name, l.common.start.unsafeField, l.common.duration,
+		l.common.sub, l.common.lastRaceErrors, l.common.raceErrorLogged, l.common.tempDir,
+		l.common.tempDirErr, l.common.tempDirSeq, l.denyParallel,
+	)
+	l.benchmarkFieldsOK = allAvailable(
+		l.common.mu, l.common.level, l.common.name, l.common.failed,
+		l.common.skipped, l.common.parent.unsafeField,
+		l.benchmark.benchFunc, l.benchmark.result,
+	)
+}
+
+// exactField validates that a struct contains a field with the expected type.
+// When expected is nil, only existence is required.
+func exactField(owner reflect.Type, name string, expected reflect.Type, optional bool) (unsafeField, bool) {
+	field, ok := owner.FieldByName(name)
+	if !ok {
+		return unsafeField{name: name, optional: optional}, optional
+	}
+	if expected != nil && field.Type != expected {
+		return unsafeField{name: name, optional: optional}, false
+	}
+	return unsafeField{
+		name:      name,
+		offset:    field.Offset,
+		size:      field.Type.Size(),
+		typ:       field.Type,
+		available: true,
+		optional:  optional,
+	}, true
+}
+
+// optionalExactField validates an optional field. Missing optional fields are a
+// successful no-op; incompatible optional fields are treated as unavailable.
+func optionalExactField(owner reflect.Type, name string, expected reflect.Type) (unsafeField, bool) {
+	field, ok := exactField(owner, name, expected, true)
+	if !ok {
+		return unsafeField{name: name, optional: true}, true
+	}
+	return field, true
+}
+
+// pointerField validates that a field is pointer-typed.
+func pointerField(owner reflect.Type, name string, optional bool) (unsafeField, bool) {
+	field, ok := owner.FieldByName(name)
+	if !ok {
+		return unsafeField{name: name, optional: optional}, optional
+	}
+	if field.Type.Kind() != reflect.Pointer {
+		return unsafeField{name: name, optional: optional}, false
+	}
+	return unsafeField{
+		name:      name,
+		offset:    field.Offset,
+		size:      field.Type.Size(),
+		typ:       field.Type,
+		available: true,
+		optional:  optional,
+	}, true
+}
+
+// optionalPointerToStructField validates an optional pointer-to-struct field.
+func optionalPointerToStructField(owner reflect.Type, name string) (unsafeField, bool) {
+	field, ok := pointerField(owner, name, true)
+	if !ok || !field.available {
+		return unsafeField{name: name, optional: true}, true
+	}
+	if field.typ.Elem().Kind() != reflect.Struct {
+		return unsafeField{name: name, optional: true}, true
+	}
+	return field, true
+}
+
+// wordField validates a pointer-like field copied with the historical
+// unsafe.Pointer semantics. Unlike start, these fields are later treated as real
+// pointers, so uintptr-sized scalar fields must not enable the fast path.
+func wordField(owner reflect.Type, name string, optional bool) (wordCopiedField, bool) {
+	field, ok := owner.FieldByName(name)
+	if !ok {
+		return wordCopiedField{unsafeField: unsafeField{name: name, optional: optional}}, optional
+	}
+	if field.Type.Size() != unsafe.Sizeof(unsafe.Pointer(nil)) || !isPointerLikeKind(field.Type.Kind()) {
+		return wordCopiedField{unsafeField: unsafeField{name: name, optional: optional}}, false
+	}
+	return wordCopiedField{unsafeField: unsafeField{
+		name:      name,
+		offset:    field.Offset,
+		size:      field.Type.Size(),
+		typ:       field.Type,
+		available: true,
+		optional:  optional,
+	}}, true
+}
+
+// isPointerLikeKind reports whether a reflected field can be safely interpreted
+// as one pointer word. It intentionally excludes uintptr and other scalar kinds
+// even when their size matches unsafe.Pointer.
+func isPointerLikeKind(kind reflect.Kind) bool {
+	return kind == reflect.Pointer || kind == reflect.UnsafePointer
+}
+
+// optionalWordField validates an optional pointer-sized field.
+func optionalWordField(owner reflect.Type, name string) (wordCopiedField, bool) {
+	field, ok := wordField(owner, name, true)
+	if !ok {
+		return wordCopiedField{unsafeField: unsafeField{name: name, optional: true}}, true
+	}
+	return field, true
+}
+
+// pointerSizedField validates a field that must be large enough for one machine
+// word. This is used for the historical partial copy of testing.common.start.
+func pointerSizedField(owner reflect.Type, name string, optional bool) (wordCopiedField, bool) {
+	field, ok := owner.FieldByName(name)
+	if !ok {
+		return wordCopiedField{unsafeField: unsafeField{name: name, optional: optional}}, optional
+	}
+	if field.Type.Size() < unsafe.Sizeof(unsafe.Pointer(nil)) {
+		return wordCopiedField{unsafeField: unsafeField{name: name, optional: optional}}, false
+	}
+	return wordCopiedField{unsafeField: unsafeField{
+		name:      name,
+		offset:    field.Offset,
+		size:      field.Type.Size(),
+		typ:       field.Type,
+		available: true,
+		optional:  optional,
+	}}, true
+}
+
+// allAvailable reports whether every required field was discovered.
+func allAvailable(fields ...unsafeField) bool {
+	for _, field := range fields {
+		if !field.available {
+			return false
+		}
+	}
+	return true
+}
+
+// fieldRawPtr returns an unsafe pointer to a validated field.
+func fieldRawPtr(base unsafe.Pointer, field unsafeField) unsafe.Pointer {
+	if base == nil || !field.available {
+		return nil
+	}
+	return unsafe.Add(base, field.offset)
+}
+
+// fieldPtr returns a typed pointer to a validated field.
+func fieldPtr[T any](base unsafe.Pointer, field unsafeField) *T {
+	ptr := fieldRawPtr(base, field)
+	if ptr == nil {
+		return nil
+	}
+	return (*T)(ptr)
+}
+
+// commonBaseForTest returns the embedded testing.common base for a *testing.T.
+func commonBaseForTest(t *testing.T, l *testingInternalsLayout) unsafe.Pointer {
+	if t == nil || l == nil || !l.tCommon.available {
+		return nil
+	}
+	return unsafe.Add(unsafe.Pointer(t), l.tCommon.offset)
+}
+
+// commonBaseForBenchmark returns the embedded testing.common base for a
+// *testing.B.
+func commonBaseForBenchmark(b *testing.B, l *testingInternalsLayout) unsafe.Pointer {
+	if b == nil || l == nil || !l.bCommon.available {
+		return nil
+	}
+	return unsafe.Add(unsafe.Pointer(b), l.bCommon.offset)
+}
+
+// copyTypedField copies a typed field using normal Go assignment so pointer
+// write barriers remain intact.
+func copyTypedField[T any](sourceBase, targetBase unsafe.Pointer, field unsafeField) {
+	*fieldPtr[T](targetBase, field) = *fieldPtr[T](sourceBase, field)
+}
+
+// copyConvertedField copies a typed field through a conversion function. It is
+// used for testing.common.w, which must be wrapped in a thread-safe writer.
+func copyConvertedField[T any](sourceBase, targetBase unsafe.Pointer, field unsafeField, convert func(T) T) {
+	*fieldPtr[T](targetBase, field) = convert(*fieldPtr[T](sourceBase, field))
+}
+
+// copyWordField preserves the current unsafe.Pointer copy semantics for the
+// small set of fields that were historically copied as one machine word.
+func copyWordField(sourceBase, targetBase unsafe.Pointer, field wordCopiedField) {
+	*(*unsafe.Pointer)(fieldRawPtr(targetBase, field.unsafeField)) = *(*unsafe.Pointer)(fieldRawPtr(sourceBase, field.unsafeField))
+}
+
+// pointerWord reads a pointer-sized field.
+func pointerWord(base unsafe.Pointer, field wordCopiedField) unsafe.Pointer {
+	ptr := fieldRawPtr(base, field.unsafeField)
+	if ptr == nil {
+		return nil
+	}
+	return *(*unsafe.Pointer)(ptr)
+}
+
+// setPrivatePointerField assigns a private pointer field using reflect.NewAt so
+// reflect performs the write with the correct field type and write barrier.
+func setPrivatePointerField(fieldType reflect.Type, targetPtr unsafe.Pointer, sourcePtr unsafe.Pointer) {
+	sourceValue := reflect.NewAt(fieldType, unsafe.Pointer(&sourcePtr)).Elem()
+	targetValue := reflect.NewAt(fieldType, targetPtr).Elem()
+	targetValue.Set(sourceValue)
+	runtime.KeepAlive(sourcePtr)
+}

--- a/internal/civisibility/integrations/gotesting/reflections.go
+++ b/internal/civisibility/integrations/gotesting/reflections.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"io"
 	"reflect"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -172,6 +173,39 @@ func getInternalTestArray(m *testing.M) *[]testing.InternalTest {
 // getTestPrivateFields is a method to retrieve all required privates field from
 // testing.T, returning a commonPrivateFields instance
 func getTestPrivateFields(t *testing.T) *commonPrivateFields {
+	layout := getTestingInternalsLayout()
+	if layout != nil && !layout.disabled && layout.testFieldsOK {
+		return getTestPrivateFieldsFast(t, layout)
+	}
+	return getTestPrivateFieldsReflect(t)
+}
+
+// getTestPrivateFieldsFast retrieves testing.common fields through cached
+// offsets. The layout is validated before this function is selected.
+func getTestPrivateFieldsFast(t *testing.T, layout *testingInternalsLayout) *commonPrivateFields {
+	commonBase := commonBaseForTest(t, layout)
+	if commonBase == nil {
+		return nil
+	}
+	fields := &commonPrivateFields{
+		mu:      fieldPtr[sync.RWMutex](commonBase, layout.common.mu),
+		output:  fieldPtr[[]byte](commonBase, layout.common.output),
+		level:   fieldPtr[int](commonBase, layout.common.level),
+		name:    fieldPtr[string](commonBase, layout.common.name),
+		failed:  fieldPtr[bool](commonBase, layout.common.failed),
+		skipped: fieldPtr[bool](commonBase, layout.common.skipped),
+		parent:  (*unsafe.Pointer)(fieldRawPtr(commonBase, layout.common.parent.unsafeField)),
+		barrier: fieldPtr[chan bool](commonBase, layout.common.barrier),
+		signal:  fieldPtr[chan bool](commonBase, layout.common.signal),
+		sub:     fieldPtr[[]*testing.T](commonBase, layout.common.sub),
+	}
+	runtime.KeepAlive(t)
+	return fields
+}
+
+// getTestPrivateFieldsReflect is the original string-reflection implementation.
+// It remains the fallback for unsupported testing layouts.
+func getTestPrivateFieldsReflect(t *testing.T) *commonPrivateFields {
 	testFields := &commonPrivateFields{}
 
 	// testing.common
@@ -212,6 +246,40 @@ func getTestPrivateFields(t *testing.T) *commonPrivateFields {
 // getTestParentPrivateFields is a method to retrieve all required parent privates field from
 // testing.T.parent, returning a commonPrivateFields instance
 func getTestParentPrivateFields(t *testing.T) *commonPrivateFields {
+	layout := getTestingInternalsLayout()
+	if layout != nil && !layout.disabled && layout.parentFieldsOK {
+		return getTestParentPrivateFieldsFast(t, layout)
+	}
+	return getTestParentPrivateFieldsReflect(t)
+}
+
+// getTestParentPrivateFieldsFast retrieves the parent testing.common fields
+// through the cached parent pointer and common-field offsets.
+func getTestParentPrivateFieldsFast(t *testing.T, layout *testingInternalsLayout) *commonPrivateFields {
+	commonBase := commonBaseForTest(t, layout)
+	if commonBase == nil {
+		return nil
+	}
+	parentBase := pointerWord(commonBase, layout.common.parent)
+	if parentBase == nil {
+		runtime.KeepAlive(t)
+		return nil
+	}
+	fields := &commonPrivateFields{
+		mu:      fieldPtr[sync.RWMutex](parentBase, layout.common.mu),
+		output:  fieldPtr[[]byte](parentBase, layout.common.output),
+		level:   fieldPtr[int](parentBase, layout.common.level),
+		name:    fieldPtr[string](parentBase, layout.common.name),
+		failed:  fieldPtr[bool](parentBase, layout.common.failed),
+		skipped: fieldPtr[bool](parentBase, layout.common.skipped),
+		barrier: fieldPtr[chan bool](parentBase, layout.common.barrier),
+	}
+	runtime.KeepAlive(t)
+	return fields
+}
+
+// getTestParentPrivateFieldsReflect is the original string-reflection fallback.
+func getTestParentPrivateFieldsReflect(t *testing.T) *commonPrivateFields {
 	indirectValue := reflect.Indirect(reflect.ValueOf(t))
 	member := indirectValue.FieldByName("parent")
 	if member.IsValid() {
@@ -268,6 +336,48 @@ func (c *contextMatcher) ClearSubNames() {
 // getTestContextMatcherPrivateFields is a method to retrieve all required privates field from
 // testing.T.context.match, returning a contextMatcher instance
 func getTestContextMatcherPrivateFields(t *testing.T) *contextMatcher {
+	layout := getTestingInternalsLayout()
+	if layout != nil && !layout.disabled && layout.contextMatcherOK {
+		return getTestContextMatcherPrivateFieldsFast(t, layout)
+	}
+	return getTestContextMatcherPrivateFieldsReflect(t)
+}
+
+// getTestContextMatcherPrivateFieldsFast follows the validated context/tstate
+// pointer chain using cached offsets and nil-checks every hop.
+func getTestContextMatcherPrivateFieldsFast(t *testing.T, layout *testingInternalsLayout) *contextMatcher {
+	commonBase := commonBaseForTest(t, layout)
+	if commonBase == nil {
+		return nil
+	}
+
+	sourceBase := commonBase
+	if layout.contextMatcher.sourceField.name == "tstate" {
+		sourceBase = unsafe.Pointer(t)
+	}
+
+	stateBase := pointerWord(sourceBase, layout.contextMatcher.sourceField)
+	if stateBase == nil {
+		runtime.KeepAlive(t)
+		return nil
+	}
+	matchBase := pointerWord(stateBase, layout.contextMatcher.match)
+	if matchBase == nil {
+		runtime.KeepAlive(t)
+		return nil
+	}
+
+	fields := &contextMatcher{
+		mu:       fieldPtr[sync.Mutex](matchBase, layout.contextMatcher.mu),
+		subNames: fieldPtr[map[string]int32](matchBase, layout.contextMatcher.subNames),
+	}
+	runtime.KeepAlive(t)
+	return fields
+}
+
+// getTestContextMatcherPrivateFieldsReflect is the original string-reflection
+// fallback for unsupported testing layouts.
+func getTestContextMatcherPrivateFieldsReflect(t *testing.T) *contextMatcher {
 	indirectValue := reflect.Indirect(reflect.ValueOf(t))
 	contextMember := indirectValue.FieldByName("context")
 	if !contextMember.IsValid() {
@@ -299,6 +409,88 @@ var copyMutex sync.Mutex // Mutex to protect concurrent read and writes to testi
 
 // copyTestWithoutParent tries to copy all private fields except the t.parent from a *testing.T to another
 func copyTestWithoutParent(source *testing.T, target *testing.T) {
+	layout := getTestingInternalsLayout()
+	if layout != nil && !layout.disabled && layout.copyTestOK {
+		copyTestWithoutParentFast(source, target, layout)
+		return
+	}
+	copyTestWithoutParentReflect(source, target)
+}
+
+// copyTestWithoutParentFast copies the same fields as the reflection fallback
+// using cached offsets. It owns the same locks as the original implementation.
+func copyTestWithoutParentFast(source *testing.T, target *testing.T, layout *testingInternalsLayout) {
+	copyMutex.Lock()
+	defer copyMutex.Unlock()
+
+	sourceBase := commonBaseForTest(source, layout)
+	targetBase := commonBaseForTest(target, layout)
+	if sourceBase == nil || targetBase == nil {
+		return
+	}
+
+	if mu := fieldPtr[sync.RWMutex](sourceBase, layout.common.mu); mu != nil {
+		mu.RLock()
+		defer mu.RUnlock()
+	}
+	if mu := fieldPtr[sync.RWMutex](targetBase, layout.common.mu); mu != nil {
+		mu.RLock()
+		defer mu.RUnlock()
+	}
+
+	copyTypedField[[]byte](sourceBase, targetBase, layout.common.output)
+	copyConvertedField[io.Writer](sourceBase, targetBase, layout.common.w, getThreadSafeWriter)
+	copyTypedField[bool](sourceBase, targetBase, layout.common.ran)
+	copyTypedField[bool](sourceBase, targetBase, layout.common.failed)
+	copyTypedField[bool](sourceBase, targetBase, layout.common.skipped)
+	copyTypedField[bool](sourceBase, targetBase, layout.common.done)
+	copyTypedField[map[uintptr]struct{}](sourceBase, targetBase, layout.common.helperPCs)
+	copyTypedField[map[string]struct{}](sourceBase, targetBase, layout.common.helperNames)
+	copyTypedField[[]func()](sourceBase, targetBase, layout.common.cleanups)
+	copyTypedField[string](sourceBase, targetBase, layout.common.cleanupName)
+	copyTypedField[[]uintptr](sourceBase, targetBase, layout.common.cleanupPc)
+	copyTypedField[bool](sourceBase, targetBase, layout.common.finished)
+	copyTypedField[bool](sourceBase, targetBase, layout.common.inFuzzFn)
+	copyWordField(sourceBase, targetBase, layout.common.chatty)
+	copyTypedField[bool](sourceBase, targetBase, layout.common.bench)
+	copyTypedField[atomic.Bool](sourceBase, targetBase, layout.common.hasSub)
+	copyTypedField[atomic.Bool](sourceBase, targetBase, layout.common.cleanupStarted)
+	copyTypedField[string](sourceBase, targetBase, layout.common.runner)
+	copyTypedField[bool](sourceBase, targetBase, layout.common.isParallel)
+	copyTypedField[int](sourceBase, targetBase, layout.common.level)
+	copyTypedField[[]uintptr](sourceBase, targetBase, layout.common.creator)
+	copyTypedField[string](sourceBase, targetBase, layout.common.name)
+	copyWordField(sourceBase, targetBase, layout.common.start)
+	copyTypedField[time.Duration](sourceBase, targetBase, layout.common.duration)
+	copyTypedField[[]*testing.T](sourceBase, targetBase, layout.common.sub)
+	copyTypedField[atomic.Int64](sourceBase, targetBase, layout.common.lastRaceErrors)
+	copyTypedField[atomic.Bool](sourceBase, targetBase, layout.common.raceErrorLogged)
+	copyTypedField[string](sourceBase, targetBase, layout.common.tempDir)
+	copyTypedField[error](sourceBase, targetBase, layout.common.tempDirErr)
+	copyTypedField[int32](sourceBase, targetBase, layout.common.tempDirSeq)
+	if layout.common.isEnvSet.available {
+		copyTypedField[bool](sourceBase, targetBase, layout.common.isEnvSet)
+	}
+	if layout.common.context.available {
+		copyWordField(sourceBase, targetBase, layout.common.context)
+	}
+	if layout.common.ctx.available {
+		copyTypedField[context.Context](sourceBase, targetBase, layout.common.ctx)
+	}
+	if layout.common.cancelCtx.available {
+		copyTypedField[context.CancelFunc](sourceBase, targetBase, layout.common.cancelCtx)
+	}
+	copyTypedField[bool](unsafe.Pointer(source), unsafe.Pointer(target), layout.denyParallel)
+	if layout.tstate.available {
+		copyWordField(unsafe.Pointer(source), unsafe.Pointer(target), layout.tstate)
+	}
+
+	runtime.KeepAlive(source)
+	runtime.KeepAlive(target)
+}
+
+// copyTestWithoutParentReflect is the original string-reflection implementation.
+func copyTestWithoutParentReflect(source *testing.T, target *testing.T) {
 	copyMutex.Lock()
 	defer copyMutex.Unlock()
 
@@ -364,6 +556,39 @@ func copyTestWithoutParent(source *testing.T, target *testing.T) {
 
 // createNewTest creates a new testing.T instance
 func createNewTest() *testing.T {
+	layout := getTestingInternalsLayout()
+	if layout != nil && !layout.disabled && layout.createTestOK {
+		return createNewTestFast(layout)
+	}
+	return createNewTestReflect()
+}
+
+// createNewTestFast initializes a testing.T using cached offsets for the
+// private fields that need non-zero values before the cloned test runs.
+func createNewTestFast(layout *testingInternalsLayout) *testing.T {
+	nT := &testing.T{}
+	commonBase := commonBaseForTest(nT, layout)
+	if commonBase == nil {
+		return nT
+	}
+
+	*fieldPtr[chan bool](commonBase, layout.common.barrier) = make(chan bool)
+	*fieldPtr[chan bool](commonBase, layout.common.signal) = make(chan bool, 1)
+	if layout.common.ctx.available {
+		ctxPtr := fieldPtr[context.Context](commonBase, layout.common.ctx)
+		*ctxPtr = context.Background()
+		if layout.common.cancelCtx.available {
+			ctx, cancelCtx := context.WithCancel(*ctxPtr)
+			*ctxPtr = ctx
+			*fieldPtr[context.CancelFunc](commonBase, layout.common.cancelCtx) = cancelCtx
+		}
+	}
+	runtime.KeepAlive(nT)
+	return nT
+}
+
+// createNewTestReflect is the original string-reflection implementation.
+func createNewTestReflect() *testing.T {
 	nT := &testing.T{}
 	var ctxPtr *context.Context
 	if ptr, err := getFieldPointerFrom(nT, "barrier"); err == nil && ptr != nil {
@@ -390,6 +615,35 @@ func createNewTest() *testing.T {
 // reinitOutputWriter ensures the provided *testing.T has a fresh output writer (Go 1.25+),
 // preventing cloned tests from sharing the same output writer (and its partial buffer).
 func reinitOutputWriter(t *testing.T) {
+	layout := getTestingInternalsLayout()
+	if layout != nil && !layout.disabled && layout.outputWriterOK {
+		reinitOutputWriterFast(t, layout)
+		return
+	}
+	reinitOutputWriterReflect(t)
+}
+
+// reinitOutputWriterFast creates a fresh private testing.outputWriter using the
+// cached Go 1.25+ output writer layout.
+func reinitOutputWriterFast(t *testing.T, layout *testingInternalsLayout) {
+	if t == nil {
+		return
+	}
+	commonBase := commonBaseForTest(t, layout)
+	if commonBase == nil {
+		return
+	}
+
+	newOutputWriter := reflect.New(layout.outputWriter.typ)
+	newOutputWriterBase := unsafe.Pointer(newOutputWriter.Pointer())
+	setPrivatePointerField(layout.outputWriter.c.typ, fieldRawPtr(newOutputWriterBase, layout.outputWriter.c), commonBase)
+	setPrivatePointerField(layout.common.o.typ, fieldRawPtr(commonBase, layout.common.o), newOutputWriterBase)
+	runtime.KeepAlive(t)
+	runtime.KeepAlive(newOutputWriter)
+}
+
+// reinitOutputWriterReflect is the original string-reflection implementation.
+func reinitOutputWriterReflect(t *testing.T) {
 	if t == nil {
 		return
 	}
@@ -430,6 +684,60 @@ func reinitOutputWriter(t *testing.T) {
 // flushOutputWriterPartial forces a newline flush if the underlying output writer has buffered a partial line (Go 1.25+).
 // This prevents losing the last (non-newline-terminated) log line when extracting test output.
 func flushOutputWriterPartial(t *testing.T) {
+	layout := getTestingInternalsLayout()
+	if layout != nil && !layout.disabled && layout.testFieldsOK && layout.outputWriterOK {
+		flushOutputWriterPartialFast(t, layout)
+		return
+	}
+	flushOutputWriterPartialReflect(t)
+}
+
+// flushOutputWriterPartialFast flushes a Go 1.25+ output writer's partial line
+// using cached offsets and the writer's exported Write method.
+func flushOutputWriterPartialFast(t *testing.T, layout *testingInternalsLayout) {
+	if t == nil {
+		return
+	}
+	commonBase := commonBaseForTest(t, layout)
+	if commonBase == nil {
+		return
+	}
+	mu := fieldPtr[sync.RWMutex](commonBase, layout.common.mu)
+	if mu == nil {
+		return
+	}
+
+	hasPartial := false
+	mu.RLock()
+	func() {
+		defer func() { _ = recover() }()
+		outputWriterBase := *fieldPtr[unsafe.Pointer](commonBase, layout.common.o)
+		if outputWriterBase == nil {
+			return
+		}
+		partial := fieldPtr[[]byte](outputWriterBase, layout.outputWriter.partial)
+		hasPartial = partial != nil && len(*partial) > 0
+	}()
+	mu.RUnlock()
+
+	if !hasPartial {
+		runtime.KeepAlive(t)
+		return
+	}
+
+	defer func() { _ = recover() }()
+	outputWriterValue := reflect.NewAt(layout.common.o.typ, fieldRawPtr(commonBase, layout.common.o)).Elem()
+	writeMethod := outputWriterValue.MethodByName("Write")
+	if !writeMethod.IsValid() {
+		runtime.KeepAlive(t)
+		return
+	}
+	writeMethod.Call([]reflect.Value{reflect.ValueOf([]byte("\n"))})
+	runtime.KeepAlive(t)
+}
+
+// flushOutputWriterPartialReflect is the original string-reflection fallback.
+func flushOutputWriterPartialReflect(t *testing.T) {
 	if t == nil {
 		return
 	}
@@ -498,6 +806,38 @@ type chattyPrinter struct {
 
 // getTestChattyPrinter retrieves the chattyPrinter from a testing.T instance.
 func getTestChattyPrinter(t *testing.T) *chattyPrinter {
+	layout := getTestingInternalsLayout()
+	if layout != nil && !layout.disabled && layout.chattyOK {
+		return getTestChattyPrinterFast(t, layout)
+	}
+	return getTestChattyPrinterReflect(t)
+}
+
+// getTestChattyPrinterFast retrieves chattyPrinter fields through cached
+// offsets. A nil chatty pointer keeps the current no-op behavior.
+func getTestChattyPrinterFast(t *testing.T, layout *testingInternalsLayout) *chattyPrinter {
+	commonBase := commonBaseForTest(t, layout)
+	if commonBase == nil {
+		return nil
+	}
+	chattyBase := pointerWord(commonBase, layout.common.chatty)
+	if chattyBase == nil {
+		runtime.KeepAlive(t)
+		return nil
+	}
+	fields := &chattyPrinter{
+		w:        fieldPtr[io.Writer](chattyBase, layout.chattyPrinter.w),
+		lastName: fieldPtr[string](chattyBase, layout.chattyPrinter.lastName),
+	}
+	if fields.lastName == nil {
+		fields.lastName = new(string)
+	}
+	runtime.KeepAlive(t)
+	return fields
+}
+
+// getTestChattyPrinterReflect is the original string-reflection implementation.
+func getTestChattyPrinterReflect(t *testing.T) *chattyPrinter {
 	indirectValue := reflect.Indirect(reflect.ValueOf(t))
 	contextMember := indirectValue.FieldByName("chatty")
 	if !contextMember.IsValid() {
@@ -633,6 +973,39 @@ type benchmarkPrivateFields struct {
 // getBenchmarkPrivateFields is a method to retrieve all required privates field from
 // testing.B, returning a benchmarkPrivateFields instance
 func getBenchmarkPrivateFields(b *testing.B) *benchmarkPrivateFields {
+	layout := getTestingInternalsLayout()
+	if layout != nil && !layout.disabled && layout.benchmarkFieldsOK {
+		return getBenchmarkPrivateFieldsFast(b, layout)
+	}
+	return getBenchmarkPrivateFieldsReflect(b)
+}
+
+// getBenchmarkPrivateFieldsFast retrieves the benchmark fields needed by the
+// integration through cached testing.B and testing.common offsets.
+func getBenchmarkPrivateFieldsFast(b *testing.B, layout *testingInternalsLayout) *benchmarkPrivateFields {
+	commonBase := commonBaseForBenchmark(b, layout)
+	if commonBase == nil {
+		return nil
+	}
+	benchFields := &benchmarkPrivateFields{
+		B: b,
+		commonPrivateFields: commonPrivateFields{
+			mu:      fieldPtr[sync.RWMutex](commonBase, layout.common.mu),
+			level:   fieldPtr[int](commonBase, layout.common.level),
+			name:    fieldPtr[string](commonBase, layout.common.name),
+			failed:  fieldPtr[bool](commonBase, layout.common.failed),
+			skipped: fieldPtr[bool](commonBase, layout.common.skipped),
+			parent:  (*unsafe.Pointer)(fieldRawPtr(commonBase, layout.common.parent.unsafeField)),
+		},
+		benchFunc: fieldPtr[func(*testing.B)](unsafe.Pointer(b), layout.benchmark.benchFunc),
+		result:    fieldPtr[testing.BenchmarkResult](unsafe.Pointer(b), layout.benchmark.result),
+	}
+	runtime.KeepAlive(b)
+	return benchFields
+}
+
+// getBenchmarkPrivateFieldsReflect is the original string-reflection fallback.
+func getBenchmarkPrivateFieldsReflect(b *testing.B) *benchmarkPrivateFields {
 	benchFields := &benchmarkPrivateFields{
 		B: b,
 	}

--- a/internal/civisibility/integrations/gotesting/reflections_test.go
+++ b/internal/civisibility/integrations/gotesting/reflections_test.go
@@ -6,8 +6,10 @@
 package gotesting
 
 import (
+	"reflect"
 	"sync"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -50,6 +52,10 @@ func TestGetFieldPointerFrom(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected an error for non-existent field, got nil")
 	}
+
+	exerciseTestingInternalsOffsetLayout(t)
+	exerciseTestingInternalsCopyEquivalence(t)
+	exerciseTestingInternalsPrivatePointerAssignment(t)
 }
 
 // TestGetInternalTestArray tests the getInternalTestArray function.
@@ -150,3 +156,170 @@ func TestGetBenchmarkPrivateFields(t *testing.T) {
 }
 
 func BenchmarkDummy(*testing.B) {}
+
+func exerciseTestingInternalsOffsetLayout(t *testing.T) {
+	layout := getTestingInternalsLayout()
+	if layout == nil {
+		t.Fatal("expected a testing internals layout")
+	}
+	if layout.disabled {
+		t.Fatal("expected the runtime testing layout to enable fast paths")
+	}
+	if layout.tCommon.offset != 0 || layout.bCommon.offset != 0 {
+		t.Fatalf("expected embedded testing.common offsets to be zero, got T=%d B=%d", layout.tCommon.offset, layout.bCommon.offset)
+	}
+	if !layout.testFieldsOK || !layout.parentFieldsOK || !layout.copyTestOK || !layout.createTestOK || !layout.benchmarkFieldsOK {
+		t.Fatalf("expected core layout sections to be enabled: %+v", layout)
+	}
+
+	invalid := buildTestingInternalsLayout(reflect.TypeOf(struct{}{}), reflect.TypeOf(struct{}{}))
+	if invalid == nil || !invalid.disabled {
+		t.Fatal("expected an invalid layout to be disabled")
+	}
+	if scalarWord, ok := wordField(reflect.TypeOf(struct{ parent uintptr }{}), "parent", false); ok || scalarWord.available {
+		t.Fatal("expected pointer-sized scalar fields to be rejected as pointer-word fields")
+	}
+
+	localT := createNewTestFast(layout)
+	localFields := getTestPrivateFieldsReflect(localT)
+	if localFields == nil || localFields.barrier == nil || *localFields.barrier == nil {
+		t.Fatal("expected createNewTestFast to initialize barrier")
+	}
+	if localFields.signal == nil || *localFields.signal == nil {
+		t.Fatal("expected createNewTestFast to initialize signal")
+	}
+
+	parentT := &testing.T{}
+	*localFields.parent = unsafe.Pointer(parentT)
+	createTestMetadata(parentT, parentT)
+	defer deleteTestMetadata(parentT)
+	if getTestMetadataFromPointer(*localFields.parent) == nil {
+		t.Fatal("expected parent metadata lookup through parent pointer to work")
+	}
+
+	parentFields := getTestParentPrivateFieldsFast(localT, layout)
+	if parentFields == nil {
+		t.Fatal("expected fast parent fields")
+	}
+	parentFields.SetFailed(true)
+	parentReflectFields := getTestPrivateFieldsReflect(parentT)
+	if parentReflectFields == nil || parentReflectFields.failed == nil || !*parentReflectFields.failed {
+		t.Fatal("expected fast parent fields to update parent failure state")
+	}
+
+	_ = getTestContextMatcherPrivateFieldsFast(t, layout)
+	if layout.outputWriterOK {
+		outputT := createNewTestReflect()
+		reinitOutputWriterFast(outputT, layout)
+		commonBase := commonBaseForTest(outputT, layout)
+		outputWriterBase := *fieldPtr[unsafe.Pointer](commonBase, layout.common.o)
+		if outputWriterBase == nil {
+			t.Fatal("expected fast output writer initialization to set common.o")
+		}
+		if gotCommon := *fieldPtr[unsafe.Pointer](outputWriterBase, layout.outputWriter.c); gotCommon != commonBase {
+			t.Fatal("expected output writer to point back to the test common")
+		}
+		flushOutputWriterPartialFast(outputT, layout)
+	}
+	if layout.chattyOK {
+		_ = getTestChattyPrinterFast(t, layout)
+	}
+}
+
+func exerciseTestingInternalsCopyEquivalence(t *testing.T) {
+	layout := getTestingInternalsLayout()
+	if layout == nil || layout.disabled || !layout.copyTestOK {
+		t.Fatal("expected copy fast path to be available")
+	}
+
+	source := createNewTestReflect()
+	sourceFields := getTestPrivateFieldsReflect(source)
+	*sourceFields.name = "copy-equivalence"
+	*sourceFields.level = 7
+	*sourceFields.failed = true
+	*sourceFields.skipped = true
+	*sourceFields.output = []byte("copy-output")
+
+	fastTarget := &testing.T{}
+	reflectTarget := &testing.T{}
+	copyTestWithoutParentFast(source, fastTarget, layout)
+	copyTestWithoutParentReflect(source, reflectTarget)
+
+	fastFields := getTestPrivateFieldsReflect(fastTarget)
+	reflectFields := getTestPrivateFieldsReflect(reflectTarget)
+	if *fastFields.name != *reflectFields.name ||
+		*fastFields.level != *reflectFields.level ||
+		*fastFields.failed != *reflectFields.failed ||
+		*fastFields.skipped != *reflectFields.skipped ||
+		string(*fastFields.output) != string(*reflectFields.output) {
+		t.Fatal("expected fast copy to match reflection fallback for representative fields")
+	}
+}
+
+func exerciseTestingInternalsPrivatePointerAssignment(t *testing.T) {
+	type localPrivatePointer struct {
+		ptr *int
+	}
+
+	field, ok := exactField(reflect.TypeOf(localPrivatePointer{}), "ptr", reflect.TypeFor[*int](), false)
+	if !ok {
+		t.Fatal("expected local pointer field layout")
+	}
+
+	value := 42
+	target := localPrivatePointer{}
+	setPrivatePointerField(field.typ, unsafe.Pointer(&target.ptr), unsafe.Pointer(&value))
+	if target.ptr != &value {
+		t.Fatal("expected private pointer assignment to set the target pointer")
+	}
+
+	sourceWord := struct {
+		ptr unsafe.Pointer
+	}{ptr: unsafe.Pointer(&value)}
+	targetWord := struct {
+		ptr unsafe.Pointer
+	}{}
+	word, ok := wordField(reflect.TypeOf(sourceWord), "ptr", false)
+	if !ok {
+		t.Fatal("expected word field layout")
+	}
+	copyWordField(unsafe.Pointer(&sourceWord), unsafe.Pointer(&targetWord), word)
+	if targetWord.ptr != sourceWord.ptr {
+		t.Fatal("expected pointer-word copy to preserve the pointer value")
+	}
+}
+
+func BenchmarkGetTestPrivateFields(b *testing.B) {
+	t := createNewTest()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = getTestPrivateFields(t)
+	}
+}
+
+func BenchmarkGetTestParentPrivateFields(b *testing.B) {
+	t := createNewTest()
+	parent := &testing.T{}
+	fields := getTestPrivateFields(t)
+	*fields.parent = unsafe.Pointer(parent)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = getTestParentPrivateFields(t)
+	}
+}
+
+func BenchmarkCopyTestWithoutParent(b *testing.B) {
+	source := createNewTest()
+	target := &testing.T{}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		copyTestWithoutParent(source, target)
+	}
+}
+
+func BenchmarkCreateNewTest(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = createNewTest()
+	}
+}

--- a/internal/civisibility/integrations/gotesting/reflections_test.go
+++ b/internal/civisibility/integrations/gotesting/reflections_test.go
@@ -172,11 +172,11 @@ func exerciseTestingInternalsOffsetLayout(t *testing.T) {
 		t.Fatalf("expected core layout sections to be enabled: %+v", layout)
 	}
 
-	invalid := buildTestingInternalsLayout(reflect.TypeOf(struct{}{}), reflect.TypeOf(struct{}{}))
+	invalid := buildTestingInternalsLayout(reflect.TypeFor[struct{}](), reflect.TypeFor[struct{}]())
 	if invalid == nil || !invalid.disabled {
 		t.Fatal("expected an invalid layout to be disabled")
 	}
-	if scalarWord, ok := wordField(reflect.TypeOf(struct{ parent uintptr }{}), "parent", false); ok || scalarWord.available {
+	if scalarWord, ok := wordField(reflect.TypeFor[struct{ parent uintptr }](), "parent", false); ok || scalarWord.available {
 		t.Fatal("expected pointer-sized scalar fields to be rejected as pointer-word fields")
 	}
 
@@ -261,7 +261,7 @@ func exerciseTestingInternalsPrivatePointerAssignment(t *testing.T) {
 		ptr *int
 	}
 
-	field, ok := exactField(reflect.TypeOf(localPrivatePointer{}), "ptr", reflect.TypeFor[*int](), false)
+	field, ok := exactField(reflect.TypeFor[localPrivatePointer](), "ptr", reflect.TypeFor[*int](), false)
 	if !ok {
 		t.Fatal("expected local pointer field layout")
 	}
@@ -279,7 +279,7 @@ func exerciseTestingInternalsPrivatePointerAssignment(t *testing.T) {
 	targetWord := struct {
 		ptr unsafe.Pointer
 	}{}
-	word, ok := wordField(reflect.TypeOf(sourceWord), "ptr", false)
+	word, ok := wordField(reflect.TypeFor[struct{ ptr unsafe.Pointer }](), "ptr", false)
 	if !ok {
 		t.Fatal("expected word field layout")
 	}


### PR DESCRIPTION
### What does this PR do?

Adds a runtime-validated offset cache for the private Go `testing` fields used by the CI Visibility gotesting integration.

The hot helpers now resolve the `testing.T`, `testing.B`, `testing.common`, output writer, chatty printer, and context matcher layouts once per process. When the runtime layout matches the expected shape, repeated calls use cached offsets instead of resolving private fields by name through reflection. If a required layout check fails, the code falls back to the existing reflection implementation.

This also adds regression coverage and microbenchmarks for the new fast paths, including validation that pointer-word fields are actually pointer-like before they can be dereferenced.

### Motivation

Profiling the flaky-retry gotesting scenario showed repeated private-field reflection as the next visible CI Visibility hot path after caching `SetTestFunc` source metadata. The goal is to reduce repeated reflection overhead while preserving behavior across supported Go versions and falling back safely on unexpected runtime layouts.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [x] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Tests run:

- `git diff --check`
- `Bypass=true go test ./internal/civisibility/integrations/gotesting -run 'TestGetFieldPointerFrom|TestGetBenchmarkPrivateFields' -count=1`
- `go test ./internal/civisibility/integrations/gotesting/...`
- `go test ./internal/civisibility/integrations/...`
