### PR TITLE
perf(internal/civisibility): cache CODEOWNERS discovery misses

### DIFF
--- a/internal/civisibility/integrations/testing_helpers_test.go
+++ b/internal/civisibility/integrations/testing_helpers_test.go
@@ -31,5 +31,6 @@ func resetCIVisibilityStateForTesting() {
 
 	utils.ResetCITags()
 	utils.ResetCIMetrics()
+	utils.ResetCodeOwnersForTesting()
 	bazel.ResetForTesting()
 }

--- a/internal/civisibility/utils/codeowners.go
+++ b/internal/civisibility/utils/codeowners.go
@@ -44,13 +44,19 @@ type (
 )
 
 var (
-	// codeowners holds the parsed CODEOWNERS file data.
-	codeowners      *CodeOwners
+	// codeowners holds the parsed CODEOWNERS file data after discovery succeeds.
+	codeowners *CodeOwners
+
+	// codeownersLookupDone distinguishes "not looked up yet" from "looked up and no CODEOWNERS file exists".
+	codeownersLookupDone bool
+
+	// codeownersMutex protects CODEOWNERS discovery state.
 	codeownersMutex sync.Mutex
 )
 
-// GetCodeOwners retrieves and caches the CODEOWNERS data.
+// GetCodeOwners retrieves and caches CODEOWNERS discovery for this process.
 // It looks for the CODEOWNERS file in various standard locations within the CI workspace.
+// Successful parsed data is cached, and true missing-file discovery results are cached as nil.
 // This function is thread-safe due to the use of a mutex.
 //
 // Returns:
@@ -60,10 +66,11 @@ func GetCodeOwners() *CodeOwners {
 	codeownersMutex.Lock()
 	defer codeownersMutex.Unlock()
 
-	if codeowners != nil {
+	if codeownersLookupDone {
 		return codeowners
 	}
 
+	hasNonMissingError := false
 	tags := GetCITags()
 	if v, ok := tags[constants.CIWorkspacePath]; ok {
 		paths := []string{
@@ -75,7 +82,10 @@ func GetCodeOwners() *CodeOwners {
 		for _, path := range paths {
 			if cow, err := parseCodeOwners(path); err == nil {
 				codeowners = cow
+				codeownersLookupDone = true
 				return codeowners
+			} else if !os.IsNotExist(err) {
+				hasNonMissingError = true
 			}
 		}
 	}
@@ -84,11 +94,26 @@ func GetCodeOwners() *CodeOwners {
 	for _, path := range []string{"CODEOWNERS", filepath.Join(filepath.Dir(os.Args[0]), "CODEOWNERS")} {
 		if cow, err := parseCodeOwners(path); err == nil {
 			codeowners = cow
+			codeownersLookupDone = true
 			return codeowners
+		} else if !os.IsNotExist(err) {
+			hasNonMissingError = true
 		}
 	}
 
+	if !hasNonMissingError {
+		codeownersLookupDone = true
+	}
 	return nil
+}
+
+// ResetCodeOwnersForTesting clears the process-local CODEOWNERS discovery cache.
+func ResetCodeOwnersForTesting() {
+	codeownersMutex.Lock()
+	defer codeownersMutex.Unlock()
+
+	codeowners = nil
+	codeownersLookupDone = false
 }
 
 // parseCodeOwners reads and parses the CODEOWNERS file located at the given filePath.

--- a/internal/civisibility/utils/codeowners_test.go
+++ b/internal/civisibility/utils/codeowners_test.go
@@ -7,11 +7,33 @@ package utils
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func resetCodeOwnersTestState(t *testing.T, workspaceDir string) {
+	t.Helper()
+
+	ResetCodeOwnersForTesting()
+	ResetCITags()
+	originalCiTags = map[string]string{constants.CIWorkspacePath: workspaceDir}
+	t.Cleanup(func() {
+		ResetCodeOwnersForTesting()
+		ResetCITags()
+	})
+}
+
+func writeCodeOwnersFile(t *testing.T, path string, content string) {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}
 
 func TestNewCodeOwners(t *testing.T) {
 	// Create a temporary file for testing
@@ -44,6 +66,86 @@ func TestNewCodeOwners(t *testing.T) {
 	// Test empty file path
 	_, err = NewCodeOwners("")
 	assert.Error(t, err)
+}
+
+func TestGetCodeOwnersCachesMissingDiscovery(t *testing.T) {
+	workspaceDir := t.TempDir()
+	workingDir := t.TempDir()
+	t.Chdir(workingDir)
+	resetCodeOwnersTestState(t, workspaceDir)
+
+	assert.Nil(t, GetCodeOwners())
+
+	writeCodeOwnersFile(t, filepath.Join(workspaceDir, "CODEOWNERS"), "/cached/miss @owner\n")
+	assert.Nil(t, GetCodeOwners())
+
+	ResetCodeOwnersForTesting()
+	codeOwners := GetCodeOwners()
+	require.NotNil(t, codeOwners)
+
+	match, ok := codeOwners.Match("/cached/miss")
+	require.True(t, ok)
+	assert.Equal(t, "[\"@owner\"]", match.GetOwnersString())
+}
+
+func TestGetCodeOwnersCachesSuccessfulDiscovery(t *testing.T) {
+	workspaceDir := t.TempDir()
+	otherWorkspaceDir := t.TempDir()
+	workingDir := t.TempDir()
+	t.Chdir(workingDir)
+	resetCodeOwnersTestState(t, workspaceDir)
+
+	writeCodeOwnersFile(t, filepath.Join(workspaceDir, "CODEOWNERS"), "/cached/success @first\n")
+	writeCodeOwnersFile(t, filepath.Join(otherWorkspaceDir, "CODEOWNERS"), "/cached/success @second\n")
+
+	codeOwners := GetCodeOwners()
+	require.NotNil(t, codeOwners)
+
+	ResetCITags()
+	originalCiTags = map[string]string{constants.CIWorkspacePath: otherWorkspaceDir}
+
+	cachedCodeOwners := GetCodeOwners()
+	require.True(t, codeOwners == cachedCodeOwners)
+	match, ok := cachedCodeOwners.Match("/cached/success")
+	require.True(t, ok)
+	assert.Equal(t, "[\"@first\"]", match.GetOwnersString())
+}
+
+func TestGetCodeOwnersDoesNotCacheMalformedFileAsMissing(t *testing.T) {
+	workspaceDir := t.TempDir()
+	workingDir := t.TempDir()
+	t.Chdir(workingDir)
+	resetCodeOwnersTestState(t, workspaceDir)
+
+	codeOwnersPath := filepath.Join(workspaceDir, "CODEOWNERS")
+	writeCodeOwnersFile(t, codeOwnersPath, strings.Repeat("x", 70*1024))
+	assert.Nil(t, GetCodeOwners())
+
+	writeCodeOwnersFile(t, codeOwnersPath, "/fixed @owner\n")
+	codeOwners := GetCodeOwners()
+	require.NotNil(t, codeOwners)
+
+	match, ok := codeOwners.Match("/fixed")
+	require.True(t, ok)
+	assert.Equal(t, "[\"@owner\"]", match.GetOwnersString())
+}
+
+func TestGetCodeOwnersMalformedCandidateDoesNotBlockLaterCandidate(t *testing.T) {
+	workspaceDir := t.TempDir()
+	workingDir := t.TempDir()
+	t.Chdir(workingDir)
+	resetCodeOwnersTestState(t, workspaceDir)
+
+	writeCodeOwnersFile(t, filepath.Join(workspaceDir, "CODEOWNERS"), strings.Repeat("x", 70*1024))
+	require.NoError(t, os.MkdirAll(filepath.Join(workspaceDir, ".github"), 0o700))
+	writeCodeOwnersFile(t, filepath.Join(workspaceDir, ".github", "CODEOWNERS"), "/fallback @owner\n")
+
+	codeOwners := GetCodeOwners()
+	require.NotNil(t, codeOwners)
+
+	match, ok := codeOwners.Match("/fallback")
+	require.True(t, ok)
+	assert.Equal(t, "[\"@owner\"]", match.GetOwnersString())
 }
 
 func TestFindSectionIgnoreCase(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Caches CI Visibility CODEOWNERS discovery misses. Successful CODEOWNERS loads were already cached, but when no CODEOWNERS file existed, each call to `GetCodeOwners()` repeated the same filesystem checks. This PR records that the initial lookup completed with no file and returns `nil` directly on later calls.

The change keeps CODEOWNERS parsing and matching behavior unchanged. Existing-but-invalid CODEOWNERS files are not cached as misses, so they remain retryable if fixed during tests.

### Motivation

Reduce repeated CI Visibility startup/test-source overhead in repositories without CODEOWNERS while preserving the existing process-local configuration model.

### Reviewers Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code does not break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Validation performed:

- `go test ./internal/civisibility/utils/...`
- `go test ./internal/civisibility/integrations/...`
- `go test ./internal/civisibility/utils -run 'TestGetCodeOwners' -count=10`
- `git diff --check`
