### PR TITLE
refactor(config): create a new DD_API_KEY config on internal/config

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -474,7 +474,7 @@ func newConfig(opts ...StartOption) (*config, error) {
 		Service:    c.internalConfig.ServiceName(),
 		Version:    c.internalConfig.Version(),
 		AgentURL:   c.internalConfig.AgentURL(),
-		APIKey:     env.Get("DD_API_KEY"),
+		APIKey:     c.internalConfig.APIKey(),
 		APPKey:     env.Get("DD_APP_KEY"),
 		HTTPClient: c.httpClient,
 		Site:       env.Get("DD_SITE"),

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/DataDog/dd-trace-go/v2/internal/env"
+	// "github.com/DataDog/dd-trace-go/v2/internal/env"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 )
@@ -122,7 +122,7 @@ func startTelemetry(c *config) telemetry.Client {
 		cfg.AgentURL = c.internalConfig.AgentURL().String()
 	}
 	if c.internalConfig.LogToStdout() || c.ciVisibilityAgentless {
-		cfg.APIKey = env.Get("DD_API_KEY")
+		cfg.APIKey = c.internalConfig.APIKey()
 	}
 	client, err := telemetry.NewClient(c.internalConfig.ServiceName(), c.internalConfig.Env(), c.internalConfig.Version(), cfg)
 	if err != nil {

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"strings"
 
-	// "github.com/DataDog/dd-trace-go/v2/internal/env"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -279,7 +279,6 @@ func loadConfig() *Config {
 		cfg.reportHostname = true
 	}
 
-	// Datadog API key for agentless endpoints (LLM Obs, telemetry, etc.).
 	cfg.apiKey = env.Get("DD_API_KEY")
 
 	return cfg

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -280,7 +280,7 @@ func loadConfig() *Config {
 	}
 
 	// Datadog API key for agentless endpoints (LLM Obs, telemetry, etc.).
-	cfg.apiKey = p.GetString("DD_API_KEY", "")
+	cfg.apiKey = env.Get("DD_API_KEY")
 
 	return cfg
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -142,6 +142,8 @@ type Config struct {
 	otlpHeaders map[string]string
 	// traceID128BitEnabled controls if trace IDs are generated as 128-bits or 64-bits.
 	traceID128BitEnabled bool
+	// apiKey is the Datadog API key from DD_API_KEY (used for agentless intake, LLM Obs, etc.).
+	apiKey string
 }
 
 // checkProductConflict enforces the cross-product gate for programmatic API calls.
@@ -276,6 +278,9 @@ func loadConfig() *Config {
 		cfg.hostname = sourceHostname
 		cfg.reportHostname = true
 	}
+
+	// Datadog API key for agentless endpoints (LLM Obs, telemetry, etc.).
+	cfg.apiKey = p.GetString("DD_API_KEY", "")
 
 	return cfg
 }
@@ -970,4 +975,11 @@ func (c *Config) TraceID128BitEnabled() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.traceID128BitEnabled
+}
+
+// APIKey returns the configured Datadog API key (DD_API_KEY).
+func (c *Config) APIKey() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.apiKey
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -867,3 +867,21 @@ func TestAdditiveConfigs(t *testing.T) {
 		assert.Equal(t, "frontend-v2", to, "last write wins for same mapping key")
 	})
 }
+
+func TestAPIKey(t *testing.T) {
+	t.Run("from env", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+		t.Setenv("DD_API_KEY", "test-api-key-32charslongfake12")
+		cfg := Get()
+		require.NotNil(t, cfg)
+		assert.Equal(t, "test-api-key-32charslongfake12", cfg.APIKey())
+	})
+	t.Run("default empty when unset", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+		cfg := Get()
+		require.NotNil(t, cfg)
+		assert.Equal(t, "", cfg.APIKey())
+	})
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
Centralizes `DD_API_KEY` access through `internalConfig.APIKey()` 
instead of reading the environment variable directly via `env.Get("DD_API_KEY")`.

## Changes

- **`internal/config/config.go`** — Add `APIKey()` method to internal config
- **`internal/config/config_test.go`** — Add test case for `APIKey()`
- **`ddtrace/tracer/option.go`** — Replace `env.Get("DD_API_KEY")` with `c.internalConfig.APIKey()`
- **`ddtrace/tracer/telemetry.go`** — Replace `env.Get("DD_API_KEY")` with `c.internalConfig.APIKey()`, remove unused `env` import

## Testing

```bash
cd dd-trace-go
go test ./internal/config -run '^TestAPIKey$' -count=1 -v
```

<details>
<summary>Result</summary>

=== RUN   TestAPIKey  
=== RUN   TestAPIKey/from_env  
=== RUN   TestAPIKey/default_empty_when_unset  
--- PASS: TestAPIKey (0.00s)  
    --- PASS: TestAPIKey/from_env (0.00s)  
    --- PASS: TestAPIKey/default_empty_when_unset (0.00s)  
PASS
ok      github.com/DataDog/dd-trace-go/v2/internal/config       0.836s  

</details>

```bash
go test ./ddtrace/tracer/... -run Telemetry -count=1 -v
go test ./internal/llmobs/... -count=1
go test ./ddtrace/tracer/... -count=1
```

<details>
<summary>Result</summary>

--- PASS: TestTelemetryEnabled (0.55s)
--- PASS: TestTelemetryEnabled/tracer_start (0.25s)
--- PASS: TestTelemetryEnabled/telemetry_customer_or_dynamic_rules (0.04s)
--- PASS: TestTelemetryEnabled/telemetry_local_rules (0.02s)
--- PASS: TestTelemetryEnabled/tracer_start_with_empty_rules (0.01s)
--- PASS: TestTelemetryEnabled/profiler_start,_tracer_start (0.20s)
--- PASS: TestTelemetryEnabled/orchestrion_telemetry (0.03s)
PASS
ok      github.com/DataDog/dd-trace-go/v2/ddtrace/tracer        1.923s

</details>



<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

- [https://datadoghq.atlassian.net/browse/APMAPI-1895](https://datadoghq.atlassian.net/browse/APMAPI-1895) 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
