### PR TITLE
perf(internal/civisibility): cache impacted-test decisions

### DIFF
--- a/internal/civisibility/utils/impactedtests/impacted_tests.go
+++ b/internal/civisibility/utils/impactedtests/impacted_tests.go
@@ -8,9 +8,9 @@ package impactedtests
 import (
 	"fmt"
 	"regexp"
-	"slices"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils"
@@ -25,18 +25,69 @@ type (
 		bitmap []byte // coverage bitmap
 	}
 
-	// ImpactedTestAnalyzer is a struct that holds information about impacted tests.
+	// ImpactedTestAnalyzer is a struct that holds information about impacted tests. It caches
+	// prepared diff data and impacted decisions, so analyzers should be used by pointer and must
+	// not be copied after first use.
 	ImpactedTestAnalyzer struct {
-		modifiedFiles    []fileWithBitmap
+		modifiedFiles []fileWithBitmap
+
+		// modifiedFilesOnce protects preparation of modifiedFiles. modifiedFiles remains the
+		// source of truth until this preparation runs; after that, preparedModifiedFiles is the
+		// analyzer-local snapshot used by IsImpacted.
+		modifiedFilesOnce sync.Once
+
+		// preparedModifiedFiles preserves the original modifiedFiles order because impacted-test
+		// matching is suffix-based and first-match-wins. Bitmap byte slices are referenced, not
+		// deep-copied, because diff data is immutable after analyzer creation in production.
+		preparedModifiedFiles []preparedModifiedFile
+
+		// decisionCache stores per-analyzer impacted decisions. testName is intentionally not part
+		// of the cache key because it only affects debug logging, not the decision.
+		decisionCache sync.Map
+
 		currentCommitSha string
 		baseCommitSha    string
 	}
+
+	// preparedModifiedFile is the per-analyzer representation used by IsImpacted after modified
+	// file preparation has run. The bitmap field shares the original immutable bitmap bytes.
+	preparedModifiedFile struct {
+		file   string
+		bitmap []byte
+	}
+
+	// impactCacheKey identifies an impacted-test decision for one source range.
+	impactCacheKey struct {
+		sourceFile string
+		startLine  int
+		endLine    int
+	}
+
+	// impactCacheEntry stores a cached impacted-test decision plus enough context to replay
+	// observable debug log fragments on cache hits.
+	impactCacheEntry struct {
+		impacted    bool
+		matchedFile string
+		reason      impactDecisionReason
+	}
+
+	// impactDecisionReason explains which branch produced a cached impacted-test decision.
+	impactDecisionReason uint8
 
 	// lineRange represents a tuple of start and end line numbers.
 	lineRange struct {
 		start int
 		end   int
 	}
+)
+
+const (
+	// impactDecisionNoMatch means either no file matched or a matched file had no intersecting lines.
+	impactDecisionNoMatch impactDecisionReason = iota
+	// impactDecisionNoLineInfo means the file matched but either side lacked usable line details.
+	impactDecisionNoLineInfo
+	// impactDecisionLineIntersection means the test range intersects modified lines.
+	impactDecisionLineIntersection
 )
 
 // Precompiled regex for diff header and line changes.
@@ -91,60 +142,82 @@ func NewImpactedTestAnalyzer() (*ImpactedTestAnalyzer, error) {
 	}
 
 	logger.Debug("civisibility.ImpactedTests: loaded [from: %s to %s]: %v", baseCommitSha, currentCommitSha, modifiedFiles) //nolint:gocritic // File list debug logging
-	return &ImpactedTestAnalyzer{
+	analyzer := &ImpactedTestAnalyzer{
 		modifiedFiles:    modifiedFiles,
 		currentCommitSha: currentCommitSha,
 		baseCommitSha:    baseCommitSha,
-	}, nil
+	}
+	analyzer.getPreparedModifiedFiles()
+	return analyzer, nil
 }
 
 // IsImpacted checks if a test is impacted based on the modified files and their line ranges.
 func (a *ImpactedTestAnalyzer) IsImpacted(testName string, sourceFile string, startLine int, endLine int) bool {
-	if len(a.modifiedFiles) == 0 {
+	if sourceFile == "" {
 		return false
 	}
 
-	// Has the test been modified?
-	modified := false
-
-	// Get the test impact information
-	testFiles := getTestImpactInfo(sourceFile, startLine, endLine)
-	if len(testFiles) == 0 {
+	modifiedFiles := a.getPreparedModifiedFiles()
+	if len(modifiedFiles) == 0 {
 		return false
 	}
+	validateImpactedLineRange(startLine, endLine)
 
-	for _, testFile := range testFiles {
-		if testFile == nil || testFile.file == "" {
+	cacheKey := impactCacheKey{
+		sourceFile: sourceFile,
+		startLine:  startLine,
+		endLine:    endLine,
+	}
+	if cached, ok := a.decisionCache.Load(cacheKey); ok {
+		entry := cached.(impactCacheEntry)
+		logImpactDecision(testName, entry)
+		return entry.impacted
+	}
+
+	for _, modifiedFile := range modifiedFiles {
+		if modifiedFile.file == "" {
 			continue
 		}
 
-		modifiedFileIndex := slices.IndexFunc(a.modifiedFiles, func(file fileWithBitmap) bool {
-			if file.file == "" {
-				return false
-			}
-			return strings.HasSuffix(testFile.file, file.file)
-		})
-		if modifiedFileIndex >= 0 {
-			modifiedFile := a.modifiedFiles[modifiedFileIndex]
-			logger.Debug("civisibility.ImpactedTests: DiffFile found: %s...", modifiedFile.file)
-			if testFile.bitmap == nil || modifiedFile.bitmap == nil {
-				logger.Debug("civisibility.ImpactedTests: No line info found")
-				modified = true
-				break
+		if strings.HasSuffix(sourceFile, modifiedFile.file) {
+			logDiffFileFound(modifiedFile.file)
+			if startLine == 0 || endLine == 0 || modifiedFile.bitmap == nil {
+				logNoLineInfo()
+				entry := impactCacheEntry{
+					impacted:    true,
+					matchedFile: modifiedFile.file,
+					reason:      impactDecisionNoLineInfo,
+				}
+				a.decisionCache.Store(cacheKey, entry)
+				return true
 			}
 
-			testFileBitmap := filebitmap.NewFileBitmapFromBytes(testFile.bitmap)
-			modifiedFileBitmap := filebitmap.NewFileBitmapFromBytes(modifiedFile.bitmap)
-
-			if testFileBitmap.IntersectsWith(modifiedFileBitmap) {
-				logger.Debug("civisibility.ImpactedTests: Intersecting lines. Marking test %s as modified.", testName)
-				modified = true
-				break
+			if bitmapIntersectsLineRange(modifiedFile.bitmap, startLine, endLine) {
+				logLineIntersection(testName)
+				entry := impactCacheEntry{
+					impacted:    true,
+					matchedFile: modifiedFile.file,
+					reason:      impactDecisionLineIntersection,
+				}
+				a.decisionCache.Store(cacheKey, entry)
+				return true
 			}
+
+			entry := impactCacheEntry{
+				impacted:    false,
+				matchedFile: modifiedFile.file,
+				reason:      impactDecisionNoMatch,
+			}
+			a.decisionCache.Store(cacheKey, entry)
+			return false
 		}
 	}
 
-	return modified
+	a.decisionCache.Store(cacheKey, impactCacheEntry{
+		impacted: false,
+		reason:   impactDecisionNoMatch,
+	})
+	return false
 }
 
 // getGitDiffFrom retrieves the diff files and lines from the Git CLI.
@@ -161,28 +234,6 @@ func getGitDiffFrom(baseCommitSha string, currentCommitSha string) []fileWithBit
 		logger.Debug("civisibility.ImpactedTests: No diff files found from Git CLI")
 	}
 	return modifiedFiles
-}
-
-// getTestImpactInfo returns the test impact information based on the tags.
-func getTestImpactInfo(sourceFile string, startLine int, endLine int) []*fileWithBitmap {
-	result := make([]*fileWithBitmap, 0)
-	if sourceFile == "" {
-		return result
-	}
-
-	// Milestone 1: Return only the test definition file
-	file := &fileWithBitmap{file: sourceFile}
-	result = append(result, file)
-
-	// Milestone 1.5: Return the test definition lines
-	if startLine == 0 || endLine == 0 {
-		return result
-	}
-
-	bitmap := filebitmap.FromActiveRange(startLine, endLine)
-	file.bitmap = bitmap.GetBuffer()
-
-	return result
 }
 
 // parseGitDiffOutput parses the git diff output to extract modified files and their changed lines.
@@ -259,6 +310,114 @@ func parseGitDiffOutput(output string) []fileWithBitmap {
 	}
 
 	return fileChanges
+}
+
+// prepareModifiedFiles creates the analyzer-local modified-file snapshot used by IsImpacted.
+func prepareModifiedFiles(files []fileWithBitmap) []preparedModifiedFile {
+	prepared := make([]preparedModifiedFile, len(files))
+	for i, file := range files {
+		prepared[i] = preparedModifiedFile{
+			file:   file.file,
+			bitmap: file.bitmap,
+		}
+	}
+	return prepared
+}
+
+// getPreparedModifiedFiles returns the analyzer-local modified-file snapshot.
+func (a *ImpactedTestAnalyzer) getPreparedModifiedFiles() []preparedModifiedFile {
+	a.modifiedFilesOnce.Do(func() {
+		a.preparedModifiedFiles = prepareModifiedFiles(a.modifiedFiles)
+	})
+	return a.preparedModifiedFiles
+}
+
+// logImpactDecision replays the debug log fragments that are observable from IsImpacted.
+func logImpactDecision(testName string, entry impactCacheEntry) {
+	if entry.matchedFile != "" {
+		logDiffFileFound(entry.matchedFile)
+	}
+	switch entry.reason {
+	case impactDecisionNoLineInfo:
+		logNoLineInfo()
+	case impactDecisionLineIntersection:
+		logLineIntersection(testName)
+	}
+}
+
+// logDiffFileFound emits the existing diff-match debug log without allocating when debug logs
+// are disabled.
+func logDiffFileFound(file string) {
+	if logger.DebugEnabled() {
+		logger.Debug("civisibility.ImpactedTests: DiffFile found: %s...", file)
+	}
+}
+
+// logNoLineInfo emits the existing missing-line-info debug log without allocating when debug
+// logs are disabled.
+func logNoLineInfo() {
+	if logger.DebugEnabled() {
+		logger.Debug("civisibility.ImpactedTests: No line info found")
+	}
+}
+
+// logLineIntersection emits the existing line-intersection debug log without allocating when
+// debug logs are disabled.
+func logLineIntersection(testName string) {
+	if logger.DebugEnabled() {
+		logger.Debug("civisibility.ImpactedTests: Intersecting lines. Marking test %s as modified.", testName)
+	}
+}
+
+// bitmapIntersectsLineRange reports whether bitmap has any active bit in the inclusive
+// 1-indexed line range. It uses the same MSB-first byte layout as filebitmap.Set.
+func bitmapIntersectsLineRange(bitmap []byte, startLine int, endLine int) bool {
+	if startLine == 0 || endLine == 0 {
+		return false
+	}
+	validateImpactedLineRange(startLine, endLine)
+	if len(bitmap) == 0 {
+		return false
+	}
+
+	maxLine := len(bitmap) * 8
+	if startLine > maxLine {
+		return false
+	}
+	if endLine > maxLine {
+		endLine = maxLine
+	}
+
+	startBit := startLine - 1
+	endBit := endLine - 1
+	startByte := startBit / 8
+	endByte := endBit / 8
+	startOffset := startBit % 8
+	endOffset := endBit % 8
+
+	firstMask := byte(0xff >> startOffset)
+	lastMask := byte(0xff << (7 - endOffset))
+	if startByte == endByte {
+		return bitmap[startByte]&(firstMask&lastMask) != 0
+	}
+
+	if bitmap[startByte]&firstMask != 0 {
+		return true
+	}
+	for i := startByte + 1; i < endByte; i++ {
+		if bitmap[i] != 0 {
+			return true
+		}
+	}
+	return bitmap[endByte]&lastMask != 0
+}
+
+// validateImpactedLineRange preserves the range validation behavior previously
+// provided by filebitmap.FromActiveRange for non-zero line ranges.
+func validateImpactedLineRange(startLine int, endLine int) {
+	if startLine != 0 && endLine != 0 && (startLine <= 0 || endLine < startLine) {
+		panic("Invalid range")
+	}
 }
 
 // splitLines splits the text into lines, ignoring empty lines.

--- a/internal/civisibility/utils/impactedtests/impacted_tests_bench_test.go
+++ b/internal/civisibility/utils/impactedtests/impacted_tests_bench_test.go
@@ -1,0 +1,113 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package impactedtests
+
+import (
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/filebitmap"
+)
+
+// newBenchmarkImpactedTestAnalyzer creates a representative analyzer with
+// several modified files so benchmarks exercise the same suffix scan used in
+// production.
+func newBenchmarkImpactedTestAnalyzer() *ImpactedTestAnalyzer {
+	return &ImpactedTestAnalyzer{
+		modifiedFiles: []fileWithBitmap{
+			{
+				file:   "pkg/first/first_test.go",
+				bitmap: filebitmap.FromActiveRange(20, 30).GetBuffer(),
+			},
+			{
+				file:   "pkg/second/second_test.go",
+				bitmap: filebitmap.FromActiveRange(100, 120).GetBuffer(),
+			},
+			{
+				file:   "pkg/third/third_test.go",
+				bitmap: filebitmap.FromActiveRange(200, 240).GetBuffer(),
+			},
+			{
+				file: "pkg/no_line_info/no_line_info_test.go",
+			},
+		},
+		currentCommitSha: "benchmark-current-sha",
+		baseCommitSha:    "benchmark-base-sha",
+	}
+}
+
+// BenchmarkIsImpactedRepeatedSameRange measures repeated calls for the same
+// source file and line range, which is the case optimized by decision caching.
+func BenchmarkIsImpactedRepeatedSameRange(b *testing.B) {
+	analyzer := newBenchmarkImpactedTestAnalyzer()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = analyzer.IsImpacted("BenchmarkTest", "/workspace/pkg/second/second_test.go", 110, 115)
+	}
+}
+
+// BenchmarkIsImpactedRepeatedDistinctRanges measures calls that hit the same
+// modified file while cycling through a small working set of source ranges.
+func BenchmarkIsImpactedRepeatedDistinctRanges(b *testing.B) {
+	analyzer := newBenchmarkImpactedTestAnalyzer()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		startLine := 90 + (i % 40)
+		_ = analyzer.IsImpacted("BenchmarkTest", "/workspace/pkg/second/second_test.go", startLine, startLine+5)
+	}
+}
+
+// BenchmarkIsImpactedColdDistinctRanges measures calls that use a different
+// range on every iteration so the decision cache cannot reuse prior results.
+func BenchmarkIsImpactedColdDistinctRanges(b *testing.B) {
+	analyzer := newBenchmarkImpactedTestAnalyzer()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		startLine := 10_000 + (i * 10)
+		_ = analyzer.IsImpacted("BenchmarkTest", "/workspace/pkg/second/second_test.go", startLine, startLine+5)
+	}
+}
+
+// BenchmarkIsImpactedRepeatedMiss measures repeated calls for a source file
+// that does not match any modified file.
+func BenchmarkIsImpactedRepeatedMiss(b *testing.B) {
+	analyzer := newBenchmarkImpactedTestAnalyzer()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = analyzer.IsImpacted("BenchmarkTest", "/workspace/pkg/missing/missing_test.go", 10, 20)
+	}
+}
+
+// BenchmarkIsImpactedNoLineInfo measures the file-level impacted path used when
+// either the test or modified file has no usable line information.
+func BenchmarkIsImpactedNoLineInfo(b *testing.B) {
+	analyzer := newBenchmarkImpactedTestAnalyzer()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = analyzer.IsImpacted("BenchmarkTest", "/workspace/pkg/no_line_info/no_line_info_test.go", 0, 0)
+	}
+}
+
+// BenchmarkBitmapIntersectsLineRange measures the allocation-free bitmap range
+// check used by the optimized IsImpacted implementation.
+func BenchmarkBitmapIntersectsLineRange(b *testing.B) {
+	bitmap := filebitmap.FromActiveRange(100, 120).GetBuffer()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = bitmapIntersectsLineRange(bitmap, 110, 115)
+	}
+}

--- a/internal/civisibility/utils/impactedtests/impacted_tests_test.go
+++ b/internal/civisibility/utils/impactedtests/impacted_tests_test.go
@@ -7,12 +7,14 @@ package impactedtests
 
 import (
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/filebitmap"
+	ddlog "github.com/DataDog/dd-trace-go/v2/internal/log"
 )
 
 // dummyTestSpan is a dummy implementation of the TestSpan interface for testing purposes.
@@ -92,25 +94,6 @@ func TestSplitLines(t *testing.T) {
 	}
 }
 
-// TestGetTestImpactInfo tests the getTestImpactInfo method of tagsMap.
-func TestGetTestImpactInfo(t *testing.T) {
-	// Create a tagsMap with the necessary tags.
-	testFile := "testfile.go"
-	startLine := 5
-	endLine := 10
-
-	files := getTestImpactInfo(testFile, startLine, endLine)
-	if len(files) != 1 {
-		t.Fatalf("Expected 1 file from getTestImpactInfo, got %d", len(files))
-	}
-	if files[0].file != testFile {
-		t.Errorf("Expected file %q, got %q", testFile, files[0].file)
-	}
-	if files[0].bitmap == nil {
-		t.Errorf("Expected non-nil bitmap for file %q", testFile)
-	}
-}
-
 // TestProcessImpactedTest tests the ProcessImpactedTest method of ImpactedTestAnalyzer.
 func TestProcessImpactedTest(t *testing.T) {
 	// Create a dummy TestSpan with the necessary test source tags.
@@ -172,4 +155,430 @@ func TestNewImpactedTestAnalyzerWithNoBaseBranch(t *testing.T) {
 	// Test that IsImpacted works correctly with empty modified files
 	isImpacted := analyzer.IsImpacted("test", "testfile.go", 1, 10)
 	assert.False(t, isImpacted, "Should not be impacted when no modified files are present")
+}
+
+func TestIsImpactedDecisionCases(t *testing.T) {
+	tests := []struct {
+		name          string
+		modifiedFiles []fileWithBitmap
+		sourceFile    string
+		startLine     int
+		endLine       int
+		want          bool
+	}{
+		{
+			name: "matching file plus intersecting range returns true",
+			modifiedFiles: []fileWithBitmap{
+				{file: "pkg/source_test.go", bitmap: filebitmap.FromActiveRange(10, 20).GetBuffer()},
+			},
+			sourceFile: "/workspace/pkg/source_test.go",
+			startLine:  15,
+			endLine:    18,
+			want:       true,
+		},
+		{
+			name: "matching file plus non-intersecting range returns false",
+			modifiedFiles: []fileWithBitmap{
+				{file: "pkg/source_test.go", bitmap: filebitmap.FromActiveRange(10, 20).GetBuffer()},
+			},
+			sourceFile: "/workspace/pkg/source_test.go",
+			startLine:  30,
+			endLine:    40,
+			want:       false,
+		},
+		{
+			name: "no matching file returns false",
+			modifiedFiles: []fileWithBitmap{
+				{file: "pkg/source_test.go", bitmap: filebitmap.FromActiveRange(10, 20).GetBuffer()},
+			},
+			sourceFile: "/workspace/pkg/other_test.go",
+			startLine:  15,
+			endLine:    18,
+			want:       false,
+		},
+		{
+			name:          "empty modified files returns false",
+			modifiedFiles: []fileWithBitmap{},
+			sourceFile:    "/workspace/pkg/source_test.go",
+			startLine:     15,
+			endLine:       18,
+			want:          false,
+		},
+		{
+			name: "empty source file returns false",
+			modifiedFiles: []fileWithBitmap{
+				{file: "pkg/source_test.go", bitmap: filebitmap.FromActiveRange(10, 20).GetBuffer()},
+			},
+			sourceFile: "",
+			startLine:  15,
+			endLine:    18,
+			want:       false,
+		},
+		{
+			name: "zero start line returns true when file matches",
+			modifiedFiles: []fileWithBitmap{
+				{file: "pkg/source_test.go", bitmap: filebitmap.FromActiveRange(10, 20).GetBuffer()},
+			},
+			sourceFile: "/workspace/pkg/source_test.go",
+			startLine:  0,
+			endLine:    18,
+			want:       true,
+		},
+		{
+			name: "zero end line returns true when file matches",
+			modifiedFiles: []fileWithBitmap{
+				{file: "pkg/source_test.go", bitmap: filebitmap.FromActiveRange(10, 20).GetBuffer()},
+			},
+			sourceFile: "/workspace/pkg/source_test.go",
+			startLine:  15,
+			endLine:    0,
+			want:       true,
+		},
+		{
+			name: "nil modified bitmap returns true when file matches",
+			modifiedFiles: []fileWithBitmap{
+				{file: "pkg/source_test.go"},
+			},
+			sourceFile: "/workspace/pkg/source_test.go",
+			startLine:  15,
+			endLine:    18,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			analyzer := &ImpactedTestAnalyzer{modifiedFiles: tt.modifiedFiles}
+			got := analyzer.IsImpacted("test", tt.sourceFile, tt.startLine, tt.endLine)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsImpactedInvalidNonZeroRangePanicsBeforeFileMatch(t *testing.T) {
+	analyzer := &ImpactedTestAnalyzer{
+		modifiedFiles: []fileWithBitmap{
+			{file: "pkg/source_test.go", bitmap: filebitmap.FromActiveRange(10, 20).GetBuffer()},
+		},
+	}
+
+	assert.PanicsWithValue(t, "Invalid range", func() {
+		_ = analyzer.IsImpacted("test", "/workspace/pkg/does_not_match_test.go", 20, 10)
+	})
+}
+
+func TestIsImpactedFirstMatchWins(t *testing.T) {
+	t.Run("first suffix match intersects and second does not", func(t *testing.T) {
+		analyzer := &ImpactedTestAnalyzer{
+			modifiedFiles: []fileWithBitmap{
+				{file: "foo_test.go", bitmap: filebitmap.FromActiveRange(10, 11).GetBuffer()},
+				{file: "pkg/foo_test.go", bitmap: filebitmap.FromActiveRange(1, 2).GetBuffer()},
+			},
+		}
+
+		assert.True(t, analyzer.IsImpacted("test", "/workspace/pkg/foo_test.go", 10, 11))
+	})
+
+	t.Run("first suffix match does not intersect and second would intersect", func(t *testing.T) {
+		analyzer := &ImpactedTestAnalyzer{
+			modifiedFiles: []fileWithBitmap{
+				{file: "foo_test.go", bitmap: filebitmap.FromActiveRange(1, 2).GetBuffer()},
+				{file: "pkg/foo_test.go", bitmap: filebitmap.FromActiveRange(10, 11).GetBuffer()},
+			},
+		}
+
+		assert.False(t, analyzer.IsImpacted("test", "/workspace/pkg/foo_test.go", 10, 11))
+	})
+}
+
+func TestIsImpactedDecisionCacheKeys(t *testing.T) {
+	analyzer := &ImpactedTestAnalyzer{
+		modifiedFiles: []fileWithBitmap{
+			{file: "pkg/source_test.go", bitmap: filebitmap.FromActiveRange(10, 20).GetBuffer()},
+			{file: "pkg/other_test.go", bitmap: filebitmap.FromActiveRange(30, 40).GetBuffer()},
+		},
+	}
+
+	assert.True(t, analyzer.IsImpacted("test", "/workspace/pkg/source_test.go", 12, 14))
+	assert.True(t, analyzer.IsImpacted("renamed test", "/workspace/pkg/source_test.go", 12, 14))
+	assert.True(t, analyzer.IsImpacted("test", "/workspace/pkg/other_test.go", 32, 34))
+	assert.False(t, analyzer.IsImpacted("test", "/workspace/pkg/source_test.go", 1, 2))
+	assert.True(t, analyzer.IsImpacted("test", "/workspace/pkg/source_test.go", 20, 20))
+
+	_, sameKeyCached := analyzer.decisionCache.Load(impactCacheKey{sourceFile: "/workspace/pkg/source_test.go", startLine: 12, endLine: 14})
+	_, differentFileCached := analyzer.decisionCache.Load(impactCacheKey{sourceFile: "/workspace/pkg/other_test.go", startLine: 32, endLine: 34})
+	_, differentStartCached := analyzer.decisionCache.Load(impactCacheKey{sourceFile: "/workspace/pkg/source_test.go", startLine: 1, endLine: 2})
+	_, differentEndCached := analyzer.decisionCache.Load(impactCacheKey{sourceFile: "/workspace/pkg/source_test.go", startLine: 20, endLine: 20})
+
+	assert.True(t, sameKeyCached)
+	assert.True(t, differentFileCached)
+	assert.True(t, differentStartCached)
+	assert.True(t, differentEndCached)
+}
+
+func TestIsImpactedDecisionCacheStability(t *testing.T) {
+	t.Run("positive cached result survives modified files mutation", func(t *testing.T) {
+		analyzer := &ImpactedTestAnalyzer{
+			modifiedFiles: []fileWithBitmap{
+				{file: "pkg/source_test.go", bitmap: filebitmap.FromActiveRange(10, 20).GetBuffer()},
+			},
+		}
+
+		assert.True(t, analyzer.IsImpacted("test", "/workspace/pkg/source_test.go", 12, 14))
+		analyzer.modifiedFiles = []fileWithBitmap{
+			{file: "pkg/source_test.go", bitmap: filebitmap.FromActiveRange(1, 2).GetBuffer()},
+		}
+		assert.True(t, analyzer.IsImpacted("test", "/workspace/pkg/source_test.go", 12, 14))
+	})
+
+	t.Run("negative cached result survives modified files mutation", func(t *testing.T) {
+		analyzer := &ImpactedTestAnalyzer{
+			modifiedFiles: []fileWithBitmap{
+				{file: "pkg/source_test.go", bitmap: filebitmap.FromActiveRange(1, 2).GetBuffer()},
+			},
+		}
+
+		assert.False(t, analyzer.IsImpacted("test", "/workspace/pkg/source_test.go", 12, 14))
+		analyzer.modifiedFiles = []fileWithBitmap{
+			{file: "pkg/source_test.go", bitmap: filebitmap.FromActiveRange(10, 20).GetBuffer()},
+		}
+		assert.False(t, analyzer.IsImpacted("test", "/workspace/pkg/source_test.go", 12, 14))
+	})
+}
+
+func TestIsImpactedPreparedFilesFreezeAfterFirstUse(t *testing.T) {
+	analyzer := &ImpactedTestAnalyzer{
+		modifiedFiles: []fileWithBitmap{
+			{file: "pkg/source_test.go", bitmap: filebitmap.FromActiveRange(1, 2).GetBuffer()},
+		},
+	}
+
+	assert.False(t, analyzer.IsImpacted("test", "/workspace/pkg/source_test.go", 12, 14))
+	analyzer.modifiedFiles = []fileWithBitmap{
+		{file: "pkg/source_test.go", bitmap: filebitmap.FromActiveRange(10, 20).GetBuffer()},
+	}
+	assert.False(t, analyzer.IsImpacted("test", "/workspace/pkg/source_test.go", 15, 16))
+
+	freshAnalyzer := &ImpactedTestAnalyzer{
+		modifiedFiles: []fileWithBitmap{
+			{file: "pkg/source_test.go", bitmap: filebitmap.FromActiveRange(10, 20).GetBuffer()},
+		},
+	}
+	assert.True(t, freshAnalyzer.IsImpacted("test", "/workspace/pkg/source_test.go", 15, 16))
+}
+
+func TestIsImpactedEmptySourceDoesNotPrepareModifiedFiles(t *testing.T) {
+	analyzer := &ImpactedTestAnalyzer{
+		modifiedFiles: []fileWithBitmap{
+			{file: "pkg/source_test.go", bitmap: filebitmap.FromActiveRange(1, 2).GetBuffer()},
+		},
+	}
+
+	assert.False(t, analyzer.IsImpacted("test", "", 12, 14))
+	analyzer.modifiedFiles = []fileWithBitmap{
+		{file: "pkg/source_test.go", bitmap: filebitmap.FromActiveRange(10, 20).GetBuffer()},
+	}
+
+	assert.True(t, analyzer.IsImpacted("test", "/workspace/pkg/source_test.go", 15, 16))
+}
+
+func TestIsImpactedDebugLogsReplayOnCacheHit(t *testing.T) {
+	oldLevel := ddlog.GetLevel()
+	ddlog.SetLevel(ddlog.LevelDebug)
+	defer ddlog.SetLevel(oldLevel)
+
+	recordLogger := new(ddlog.RecordLogger)
+	defer ddlog.UseLogger(recordLogger)()
+
+	analyzer := &ImpactedTestAnalyzer{
+		modifiedFiles: []fileWithBitmap{
+			{file: "pkg/source_test.go", bitmap: filebitmap.FromActiveRange(10, 20).GetBuffer()},
+			{file: "pkg/no_line_info_test.go"},
+		},
+	}
+
+	assert.True(t, analyzer.IsImpacted("first test", "/workspace/pkg/source_test.go", 12, 14))
+	assert.True(t, analyzer.IsImpacted("second test", "/workspace/pkg/source_test.go", 12, 14))
+	assert.True(t, analyzer.IsImpacted("no line first", "/workspace/pkg/no_line_info_test.go", 0, 0))
+	assert.True(t, analyzer.IsImpacted("no line second", "/workspace/pkg/no_line_info_test.go", 0, 0))
+
+	logs := recordLogger.Logs()
+	assert.Equal(t, 4, countLogsContaining(logs, "DiffFile found"))
+	assert.Equal(t, 2, countLogsContaining(logs, "Intersecting lines"))
+	assert.Equal(t, 2, countLogsContaining(logs, "No line info found"))
+	assert.True(t, hasLogContaining(logs, "Marking test first test as modified"))
+	assert.True(t, hasLogContaining(logs, "Marking test second test as modified"))
+}
+
+func TestBitmapIntersectsLineRange(t *testing.T) {
+	tests := []struct {
+		name      string
+		bitmap    []byte
+		startLine int
+		endLine   int
+		want      bool
+	}{
+		{
+			name:      "first bit in a byte",
+			bitmap:    []byte{0b10000000},
+			startLine: 1,
+			endLine:   1,
+			want:      true,
+		},
+		{
+			name:      "middle bit in a byte",
+			bitmap:    []byte{0b00010000},
+			startLine: 4,
+			endLine:   4,
+			want:      true,
+		},
+		{
+			name:      "last bit in a byte",
+			bitmap:    []byte{0b00000001},
+			startLine: 8,
+			endLine:   8,
+			want:      true,
+		},
+		{
+			name:      "range crossing byte boundaries",
+			bitmap:    []byte{0b00000001, 0b10000000},
+			startLine: 8,
+			endLine:   9,
+			want:      true,
+		},
+		{
+			name:      "range before active bits",
+			bitmap:    []byte{0b00000001},
+			startLine: 1,
+			endLine:   7,
+			want:      false,
+		},
+		{
+			name:      "range after bitmap length",
+			bitmap:    []byte{0b11111111},
+			startLine: 9,
+			endLine:   12,
+			want:      false,
+		},
+		{
+			name:      "range partly beyond bitmap length",
+			bitmap:    []byte{0b00000001},
+			startLine: 8,
+			endLine:   12,
+			want:      true,
+		},
+		{
+			name:      "empty non-nil bitmap",
+			bitmap:    []byte{},
+			startLine: 1,
+			endLine:   8,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := bitmapIntersectsLineRange(tt.bitmap, tt.startLine, tt.endLine)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBitmapIntersectsLineRangeMatchesFileBitmapIntersection(t *testing.T) {
+	modifiedBitmaps := []struct {
+		name   string
+		bitmap []byte
+	}{
+		{name: "empty bitmap", bitmap: []byte{}},
+		{name: "single active bit", bitmap: filebitmap.FromActiveRange(4, 4).GetBuffer()},
+		{name: "multiple active bits in one byte", bitmap: filebitmap.FromActiveRange(2, 6).GetBuffer()},
+		{name: "range crosses byte boundary", bitmap: filebitmap.FromActiveRange(7, 10).GetBuffer()},
+		{name: "sparse manual bitmap", bitmap: []byte{0b10000001, 0b00010000, 0b00000001}},
+	}
+	testRanges := []lineRange{
+		{start: 1, end: 1},
+		{start: 1, end: 8},
+		{start: 4, end: 4},
+		{start: 5, end: 9},
+		{start: 8, end: 12},
+		{start: 11, end: 20},
+		{start: 21, end: 24},
+		{start: 25, end: 40},
+	}
+
+	for _, modifiedBitmap := range modifiedBitmaps {
+		t.Run(modifiedBitmap.name, func(t *testing.T) {
+			for _, testRange := range testRanges {
+				testBitmap := filebitmap.FromActiveRange(testRange.start, testRange.end)
+				modifiedFileBitmap := filebitmap.NewFileBitmapFromBytes(modifiedBitmap.bitmap)
+				want := testBitmap.IntersectsWith(modifiedFileBitmap)
+
+				got := bitmapIntersectsLineRange(modifiedBitmap.bitmap, testRange.start, testRange.end)
+				assert.Equal(t, want, got, "range %d-%d", testRange.start, testRange.end)
+			}
+		})
+	}
+}
+
+func TestBitmapIntersectsLineRangeInvalidRangesPanic(t *testing.T) {
+	tests := []struct {
+		name      string
+		startLine int
+		endLine   int
+	}{
+		{name: "negative start", startLine: -1, endLine: 5},
+		{name: "start after end", startLine: 10, endLine: 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.PanicsWithValue(t, "Invalid range", func() {
+				_ = bitmapIntersectsLineRange([]byte{0xff}, tt.startLine, tt.endLine)
+			})
+		})
+	}
+}
+
+func TestBitmapIntersectsLineRangeAllocs(t *testing.T) {
+	bitmap := filebitmap.FromActiveRange(100, 200).GetBuffer()
+	allocs := testing.AllocsPerRun(1000, func() {
+		_ = bitmapIntersectsLineRange(bitmap, 150, 160)
+	})
+	assert.Zero(t, allocs)
+}
+
+func TestIsImpactedConcurrentAccess(t *testing.T) {
+	analyzer := &ImpactedTestAnalyzer{
+		modifiedFiles: []fileWithBitmap{
+			{file: "pkg/source_test.go", bitmap: filebitmap.FromActiveRange(10, 20).GetBuffer()},
+			{file: "pkg/other_test.go", bitmap: filebitmap.FromActiveRange(30, 40).GetBuffer()},
+			{file: "pkg/no_line_info_test.go"},
+		},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Go(func() {
+			assert.True(t, analyzer.IsImpacted("test", "/workspace/pkg/source_test.go", 12, 14))
+			assert.False(t, analyzer.IsImpacted("test", "/workspace/pkg/source_test.go", 1, 2))
+			assert.True(t, analyzer.IsImpacted("test", "/workspace/pkg/other_test.go", 35, 36))
+			assert.True(t, analyzer.IsImpacted("test", "/workspace/pkg/no_line_info_test.go", 0, 0))
+			assert.False(t, analyzer.IsImpacted("test", "/workspace/pkg/missing_test.go", 1, 2))
+		})
+	}
+	wg.Wait()
+}
+
+func countLogsContaining(logs []string, fragment string) int {
+	count := 0
+	for _, log := range logs {
+		if strings.Contains(log, fragment) {
+			count++
+		}
+	}
+	return count
+}
+
+func hasLogContaining(logs []string, fragment string) bool {
+	return countLogsContaining(logs, fragment) > 0
 }

--- a/internal/civisibility/utils/impactedtests/impacted_tests_test.go
+++ b/internal/civisibility/utils/impactedtests/impacted_tests_test.go
@@ -557,7 +557,7 @@ func TestIsImpactedConcurrentAccess(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		wg.Go(func() {
 			assert.True(t, analyzer.IsImpacted("test", "/workspace/pkg/source_test.go", 12, 14))
 			assert.False(t, analyzer.IsImpacted("test", "/workspace/pkg/source_test.go", 1, 2))


### PR DESCRIPTION
### What does this PR do?

Optimizes CI Visibility impacted-test analysis by caching `IsImpacted` decisions per analyzer and replacing per-call temporary test bitmap allocation with a direct bitmap range intersection check.

The implementation preserves existing behavior:
- suffix-based modified-file matching
- first matching modified file wins
- missing line information marks matching files as impacted
- existing debug log fragments are still emitted, including on cache hits
- analyzer state is safe for concurrent `IsImpacted` calls

It also adds benchmarks for repeated cached calls, cold distinct ranges, misses, missing-line-info decisions, and the direct bitmap range check.

### Motivation

Profiling after the previous CI Visibility optimizations showed `IsImpacted` still doing repeated work on retries/subtests. The previous flow rebuilt a temporary bitmap for each test range and scanned modified files on every call. This change keeps the same decisions while avoiding that repeated allocation and memoizing repeated source range lookups.

Latest local benchmark sample:

```text
BenchmarkIsImpactedRepeatedSameRange-12          36.02 ns/op    0 B/op    0 allocs/op
BenchmarkIsImpactedRepeatedDistinctRanges-12     41.69 ns/op    0 B/op    0 allocs/op
BenchmarkIsImpactedColdDistinctRanges-12        533.9 ns/op   173 B/op    3 allocs/op
BenchmarkIsImpactedRepeatedMiss-12               27.41 ns/op    0 B/op    0 allocs/op
BenchmarkIsImpactedNoLineInfo-12                 35.36 ns/op    0 B/op    0 allocs/op
BenchmarkBitmapIntersectsLineRange-12            2.953 ns/op    0 B/op    0 allocs/op
```

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [x] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Local verification:

```text
git diff --check
go test ./internal/civisibility/utils/impactedtests -count=1
go test -race ./internal/civisibility/utils/impactedtests -count=1
go test ./internal/civisibility/utils/... -count=1
go test ./internal/civisibility/integrations/... -count=1
go test ./internal/civisibility/utils/impactedtests -bench='BenchmarkIsImpacted|BenchmarkBitmapIntersects' -benchmem -run '^$'
```

Notes:
- System tests are not added because this is an internal performance refactor with no agent protocol or user-facing behavior change.
- `make lint`, `make test`, `make generate`, and `make fix-modules` were not run directly; the narrower local commands above were run against the affected CI Visibility packages, and no generated files or module files changed.
