### PR TITLE
perf(internal/civisibility): reuse missing commit list

### DIFF
--- a/internal/civisibility/integrations/civisibility_features.go
+++ b/internal/civisibility/integrations/civisibility_features.go
@@ -396,11 +396,14 @@ func uploadRepositoryChanges() (bytes int64, err error) {
 		return 0, nil
 	}
 
-	// If:
-	//   - we have local commits
-	//   - there are not missing commits (backend has the total number of local commits already)
-	// then we are good to go with it, we don't need to check if we need to unshallow or anything and just go with that.
-	if initialCommitData.hasCommits() && len(initialCommitData.missingCommits()) == 0 {
+	// Calculate the initial missing commits once and reuse the same ordered list if
+	// the repository cannot be unshallowed. missingCommits walks the local and
+	// remote commit lists, so calling it twice here would repeat identical work.
+	initialMissingCommits := initialCommitData.missingCommits()
+
+	// If there are not missing commits (backend has the total number of local commits already), then we are good to go
+	// with it, we don't need to check if we need to unshallow or anything and just go with that.
+	if len(initialMissingCommits) == 0 {
 		log.Debug("civisibility: initial commit data has everything already, we don't need to upload anything")
 		return 0, nil
 	}
@@ -415,7 +418,7 @@ func uploadRepositoryChanges() (bytes int64, err error) {
 		// the initial commit data
 
 		// send the pack file with the missing commits
-		return sendObjectsPackFile(initialCommitData.LocalCommits[0], initialCommitData.missingCommits(), initialCommitData.RemoteCommits)
+		return sendObjectsPackFile(initialCommitData.LocalCommits[0], initialMissingCommits, initialCommitData.RemoteCommits)
 	}
 
 	// after unshallowing the repository we need to get the search commits to calculate the missing commits again

--- a/internal/civisibility/integrations/civisibility_features.go
+++ b/internal/civisibility/integrations/civisibility_features.go
@@ -71,6 +71,15 @@ var (
 
 	// uploadRepositoryChangesFunc is a must-not-call test seam used to prove offline/file modes suppress git upload.
 	uploadRepositoryChangesFunc = uploadRepositoryChanges
+
+	// getSearchCommitsFunc allows tests to exercise repository upload control flow without reading local git state.
+	getSearchCommitsFunc = getSearchCommits
+
+	// unshallowGitRepositoryFunc allows tests to control the fallback branch without mutating the local repository.
+	unshallowGitRepositoryFunc = utils.UnshallowGitRepository
+
+	// sendObjectsPackFileFunc allows tests to inspect the upload request without creating or sending real pack files.
+	sendObjectsPackFileFunc = sendObjectsPackFile
 )
 
 // ensureSettingsInitialization performs the one-time settings bootstrap, including any git upload work required before a final settings read.
@@ -380,7 +389,7 @@ func GetImpactedTestsAnalyzer() *impactedtests.ImpactedTestAnalyzer {
 // uploadRepositoryChanges discovers the commits and packfiles that must be uploaded so backend features can reason about the current repo state.
 func uploadRepositoryChanges() (bytes int64, err error) {
 	// get the search commits response
-	initialCommitData, err := getSearchCommits()
+	initialCommitData, err := getSearchCommitsFunc()
 	if err != nil {
 		return 0, fmt.Errorf("civisibility: error getting the search commits response: %s", err)
 	}
@@ -409,7 +418,7 @@ func uploadRepositoryChanges() (bytes int64, err error) {
 	}
 
 	// there's some missing commits on the backend, first we need to check if we need to unshallow before sending anything...
-	hasBeenUnshallowed, err := utils.UnshallowGitRepository()
+	hasBeenUnshallowed, err := unshallowGitRepositoryFunc()
 	if err != nil || !hasBeenUnshallowed {
 		if err != nil {
 			log.Warn("%s", err.Error())
@@ -418,11 +427,11 @@ func uploadRepositoryChanges() (bytes int64, err error) {
 		// the initial commit data
 
 		// send the pack file with the missing commits
-		return sendObjectsPackFile(initialCommitData.LocalCommits[0], initialMissingCommits, initialCommitData.RemoteCommits)
+		return sendObjectsPackFileFunc(initialCommitData.LocalCommits[0], initialMissingCommits, initialCommitData.RemoteCommits)
 	}
 
 	// after unshallowing the repository we need to get the search commits to calculate the missing commits again
-	commitsData, err := getSearchCommits()
+	commitsData, err := getSearchCommitsFunc()
 	if err != nil {
 		return 0, fmt.Errorf("civisibility: error getting the search commits response: %s", err)
 	}
@@ -433,7 +442,7 @@ func uploadRepositoryChanges() (bytes int64, err error) {
 	}
 
 	// send the pack file with the missing commits
-	return sendObjectsPackFile(commitsData.LocalCommits[0], commitsData.missingCommits(), commitsData.RemoteCommits)
+	return sendObjectsPackFileFunc(commitsData.LocalCommits[0], commitsData.missingCommits(), commitsData.RemoteCommits)
 }
 
 // getSearchCommits gets the search commits response with the local and remote commits

--- a/internal/civisibility/integrations/civisibility_features_test.go
+++ b/internal/civisibility/integrations/civisibility_features_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSearchCommitsResponseMissingCommitsPreservesLocalOrder(t *testing.T) {
@@ -39,4 +40,62 @@ func TestSearchCommitsResponseMissingCommitsReturnsEmptyWhenAllLocalCommitsAreRe
 	)
 
 	assert.Empty(t, response.missingCommits())
+}
+
+func TestUploadRepositoryChangesSkipsUploadWhenNoCommitsAreMissing(t *testing.T) {
+	resetCIVisibilityStateForTesting()
+
+	getSearchCommitsFunc = func() (*searchCommitsResponse, error) {
+		return newSearchCommitsResponse(
+			[]string{"remote-1", "remote-2"},
+			[]string{"remote-2", "remote-1"},
+			true,
+		), nil
+	}
+	unshallowGitRepositoryFunc = func() (bool, error) {
+		t.Fatal("unshallow should not run when all commits are already known")
+		return false, nil
+	}
+	sendObjectsPackFileFunc = func(_ string, _ []string, _ []string) (int64, error) {
+		t.Fatal("packfile upload should not run when all commits are already known")
+		return 0, nil
+	}
+
+	bytes, err := uploadRepositoryChanges()
+
+	require.NoError(t, err)
+	assert.Zero(t, bytes)
+}
+
+func TestUploadRepositoryChangesReusesInitialMissingCommitsWhenUnshallowIsUnavailable(t *testing.T) {
+	resetCIVisibilityStateForTesting()
+
+	getSearchCommitsFunc = func() (*searchCommitsResponse, error) {
+		return newSearchCommitsResponse(
+			[]string{"local-1", "remote-1", "local-2"},
+			[]string{"remote-1"},
+			true,
+		), nil
+	}
+	unshallowGitRepositoryFunc = func() (bool, error) {
+		return false, nil
+	}
+
+	var uploadedCommit string
+	var uploadedIncludes []string
+	var uploadedExcludes []string
+	sendObjectsPackFileFunc = func(commitSha string, commitsToInclude []string, commitsToExclude []string) (int64, error) {
+		uploadedCommit = commitSha
+		uploadedIncludes = append([]string(nil), commitsToInclude...)
+		uploadedExcludes = append([]string(nil), commitsToExclude...)
+		return 42, nil
+	}
+
+	bytes, err := uploadRepositoryChanges()
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), bytes)
+	assert.Equal(t, "local-1", uploadedCommit)
+	assert.Equal(t, []string{"local-1", "local-2"}, uploadedIncludes)
+	assert.Equal(t, []string{"remote-1"}, uploadedExcludes)
 }

--- a/internal/civisibility/integrations/civisibility_features_test.go
+++ b/internal/civisibility/integrations/civisibility_features_test.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package integrations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSearchCommitsResponseMissingCommitsPreservesLocalOrder(t *testing.T) {
+	response := newSearchCommitsResponse(
+		[]string{"local-1", "remote-1", "local-2", "remote-2", "local-3"},
+		[]string{"remote-2", "remote-1"},
+		true,
+	)
+
+	assert.Equal(t, []string{"local-1", "local-2", "local-3"}, response.missingCommits())
+}
+
+func TestSearchCommitsResponseMissingCommitsKeepsMissingDuplicates(t *testing.T) {
+	response := newSearchCommitsResponse(
+		[]string{"missing-1", "remote-1", "missing-1", "missing-2"},
+		[]string{"remote-1"},
+		true,
+	)
+
+	assert.Equal(t, []string{"missing-1", "missing-1", "missing-2"}, response.missingCommits())
+}
+
+func TestSearchCommitsResponseMissingCommitsReturnsEmptyWhenAllLocalCommitsAreRemote(t *testing.T) {
+	response := newSearchCommitsResponse(
+		[]string{"remote-1", "remote-2"},
+		[]string{"remote-2", "remote-1"},
+		true,
+	)
+
+	assert.Empty(t, response.missingCommits())
+}

--- a/internal/civisibility/integrations/testing_helpers_test.go
+++ b/internal/civisibility/integrations/testing_helpers_test.go
@@ -28,6 +28,9 @@ func resetCIVisibilityStateForTesting() {
 	sourceFileMetadataCache = sync.Map{}
 
 	uploadRepositoryChangesFunc = uploadRepositoryChanges
+	getSearchCommitsFunc = getSearchCommits
+	unshallowGitRepositoryFunc = utils.UnshallowGitRepository
+	sendObjectsPackFileFunc = sendObjectsPackFile
 
 	utils.ResetCITags()
 	utils.ResetCIMetrics()


### PR DESCRIPTION
## Summary
- compute the initial missing commit list once during repository change upload
- reuse the same ordered list when falling back to the initial commit data
- add tests that lock current missing-commit ordering and duplicate behavior

## Testing
- go test ./internal/civisibility/integrations -count=1
- go test ./internal/civisibility/integrations/... -count=1
- go test ./internal/civisibility/... -count=1