### PR TITLE
ci(codeql): add main to push.branches to unfreeze default-branch status

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,7 @@ on:
         type: string
   push:
     branches:
+      - main
       - mq-working-branch-**
   pull_request:
 jobs:


### PR DESCRIPTION
## Problem

The [CodeQL status page](https://github.com/DataDog/dd-trace-go/security/code-scanning/tools/CodeQL/status) shows the last scan date as **2025-09-03**, even though CodeQL runs successfully on every PR and every `mq-working-branch-**` push.

This is an **association problem, not an execution problem.** GitHub Code Scanning indexes each SARIF upload by the `ref` the trigger event carried. The default-branch status panel only counts uploads tagged with `refs/heads/main`. CodeQL is running, but every upload it produces is filed under a non-default ref.

### Root cause

PR #3887 (2025-09-04, _"move `main` CI checks to merge queue runs"_) restructured the workflow triggers:

| Removed | Kept / Added |
|---|---|
| `push: branches: [main, master]` | `push: branches: [mq-working-branch-**]` |
| `pull_request: branches: [main]` | `pull_request:` (no branch filter) |
| `merge_group:` | `workflow_call:` (unused — no caller wires CodeQL) |

After this change, CodeQL only ever sees refs of the form `refs/pull/<n>/merge` or `refs/heads/mq-working-branch-XXX`. The repository's merge mechanism fast-forwards `main` onto a green staging commit and deletes the staging branch — no `push` event for `refs/heads/main` fires, so CodeQL never runs against the default branch. The SARIF uploaded during the queue run stays tagged with the staging ref even after that exact SHA becomes `HEAD` of `main`.

This is asymmetric with GitHub's _native_ merge queue: native queue events arrive on `refs/heads/gh-readonly-queue/main/<sha>` and Code Scanning rolls those uploads up to the default branch on completion. Custom queues built on fast-forward branches get no such roll-up.

### Why it matters

- The [security tab](https://github.com/DataDog/dd-trace-go/security/code-scanning/tools/CodeQL/status) shows the configuration as inactive, which trips compliance alarms and looks like a regression to auditors.
- New CodeQL findings introduced after 2025-09-03 are recorded against PR / staging refs and never roll up to the canonical `main` view.
- Branch-protection rules of the form "CodeQL must be passing on default branch" can mis-report.

## Verification

- [x] `git diff` shows exactly one inserted line: `      - main`
- [x] `actionlint .github/workflows/codeql-analysis.yml` passes with no errors
- [ ] After merge, the Actions tab shows a new "CodeQL" run on `refs/heads/main`
- [ ] The [status page](https://github.com/DataDog/dd-trace-go/security/code-scanning/tools/CodeQL/status) shows a timestamp newer than 2025-09-03, still with configuration ID `FZTWS5DIOVRC653POJVWM3DPO5ZS6Y3PMRSXC3BNMFXGC3DZONUXGLTZNVWA`