### PR TITLE
fix(internal/civisibility): resolve trimpath source files

### DIFF
--- a/internal/civisibility/integrations/manual_api_ddtest.go
+++ b/internal/civisibility/integrations/manual_api_ddtest.go
@@ -229,20 +229,22 @@ func (t *tslvTest) SetTestFunc(fn *runtime.Func) {
 		return
 	}
 
-	// let's get the file path and the start line of the function
-	absolutePath, runtimeStartLine := fn.FileLine(fn.Entry())
-	file := utils.GetRelativePathFromCITagsSourceRoot(absolutePath)
-	log.Debug("civisibility: resolving test source location [function:%s file:%s start_line:%d relative_file:%s entry:%#x]",
-		fn.Name(), absolutePath, runtimeStartLine, file, fn.Entry())
+	// Resolve the runtime file into separate tag and filesystem paths. Go -trimpath can
+	// return a logical module path here, while source parsing still needs a local file path.
+	runtimePath, runtimeStartLine := fn.FileLine(fn.Entry())
+	sourcePath := resolveTestSourcePath(runtimePath)
+	file := sourcePath.RelativePath
+	log.Debug("civisibility: resolving test source location [function:%s file:%s start_line:%d relative_file:%s runtime_file:%s filesystem_file:%s filesystem_known:%t entry:%#x]",
+		fn.Name(), runtimePath, runtimeStartLine, file, sourcePath.RuntimePath, sourcePath.FilesystemPath, sourcePath.FilesystemKnown, fn.Entry())
 	t.SetTag(constants.TestSourceFile, file)
 	t.SetTag(constants.TestSourceStartLine, runtimeStartLine)
 	t.suite.SetTag(constants.TestSourceFile, file)
 
 	// Source inspection is cached per file so repeated retries/subtests do not reparse the same file.
-	metadata := loadSourceFileMetadata(absolutePath)
+	metadata := loadSourceFileMetadata(sourcePath.FilesystemPath)
 	if !metadata.parseOK {
-		log.Debug("civisibility: failed parsing test source file [function:%s file:%s start_line:%d error:%v]",
-			fn.Name(), absolutePath, runtimeStartLine, metadata.parseErr)
+		log.Debug("civisibility: failed parsing test source file [function:%s file:%s runtime_file:%s relative_file:%s start_line:%d error:%v]",
+			fn.Name(), sourcePath.FilesystemPath, runtimePath, file, runtimeStartLine, metadata.parseErr)
 	}
 	if metadata.parseOK {
 		// let's check if the suite was marked as unskippable before
@@ -256,8 +258,8 @@ func (t *tslvTest) SetTestFunc(fn *runtime.Func) {
 		fullName := fn.Name()
 		firstDot := strings.LastIndex(fullName, ".") + 1
 		name := fullName[firstDot:]
-		log.Debug("civisibility: scanning AST for test source range [function:%s short_name:%s file:%s runtime_start_line:%d]",
-			fullName, name, absolutePath, runtimeStartLine)
+		log.Debug("civisibility: scanning AST for test source range [function:%s short_name:%s file:%s runtime_file:%s relative_file:%s runtime_start_line:%d]",
+			fullName, name, sourcePath.FilesystemPath, runtimePath, file, runtimeStartLine)
 
 		// Resolve the source range from cached metadata but keep the existing declaration/literal
 		// matching rules and the same debug logs the tests already assert.
@@ -321,6 +323,11 @@ func (t *tslvTest) SetTestFunc(fn *runtime.Func) {
 			t.suite.SetTag(constants.TestCodeOwners, ownerString)
 		}
 	}
+}
+
+// resolveTestSourcePath resolves a runtime source path using the production CI tag context.
+func resolveTestSourcePath(runtimePath string) utils.SourceFilePath {
+	return utils.ResolveSourceFilePathFromCITags(runtimePath)
 }
 
 // SetBenchmarkData sets benchmark data for the test.

--- a/internal/civisibility/integrations/manual_api_sourcecache_test.go
+++ b/internal/civisibility/integrations/manual_api_sourcecache_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 
 	"github.com/stretchr/testify/assert"
@@ -35,21 +36,39 @@ func literalSourceFixtureRuntimeFunc() *runtime.Func {
 	return runtime.FuncForPC(reflect.ValueOf(literal).Pointer())
 }
 
-func TestLoadSourceFileMetadataCachesValidFiles(t *testing.T) {
+// resetSourceCacheTestState installs repository metadata so sourcecache tests also work with -trimpath.
+func resetSourceCacheTestState(t *testing.T) {
+	t.Helper()
+
 	resetCIVisibilityStateForTesting()
+	utils.AddCITagsMap(map[string]string{
+		constants.CIWorkspacePath:  sourcePathRepositoryRoot(t),
+		constants.GitRepositoryURL: "https://github.com/DataDog/dd-trace-go.git",
+	})
+	t.Cleanup(resetCIVisibilityStateForTesting)
+}
+
+// filesystemPathForRuntimeSource resolves a runtime source path into the file path used by source parsing.
+func filesystemPathForRuntimeSource(runtimePath string) string {
+	return resolveTestSourcePath(runtimePath).FilesystemPath
+}
+
+func TestLoadSourceFileMetadataCachesValidFiles(t *testing.T) {
+	resetSourceCacheTestState(t)
 
 	_, file, _, ok := runtime.Caller(0)
 	require.True(t, ok)
+	filesystemPath := filesystemPathForRuntimeSource(file)
 
-	first := loadSourceFileMetadata(file)
-	second := loadSourceFileMetadata(file)
+	first := loadSourceFileMetadata(filesystemPath)
+	second := loadSourceFileMetadata(filesystemPath)
 
 	require.True(t, first.parseOK)
 	assert.Equal(t, first, second)
 }
 
 func TestLoadSourceFileMetadataNegativeCachesParseFailures(t *testing.T) {
-	resetCIVisibilityStateForTesting()
+	resetSourceCacheTestState(t)
 
 	tmpFile, err := os.CreateTemp(t.TempDir(), "sourcecache-invalid-*.go")
 	require.NoError(t, err)
@@ -66,7 +85,7 @@ func TestLoadSourceFileMetadataNegativeCachesParseFailures(t *testing.T) {
 }
 
 func TestLoadSourceFileMetadataHandlesDeclarationsWithoutBody(t *testing.T) {
-	resetCIVisibilityStateForTesting()
+	resetSourceCacheTestState(t)
 
 	tmpFile, err := os.CreateTemp(t.TempDir(), "sourcecache-decl-*.go")
 	require.NoError(t, err)
@@ -442,7 +461,7 @@ func TestResolveSourceLocationLeavesNoMatchUnchanged(t *testing.T) {
 }
 
 func TestSetTestFuncKeepsRealFunc1DeclarationWhenLineConfirmed(t *testing.T) {
-	resetCIVisibilityStateForTesting()
+	resetSourceCacheTestState(t)
 	mockTracer.Reset()
 
 	recordLogger := new(log.RecordLogger)
@@ -464,7 +483,7 @@ func TestSetTestFuncKeepsRealFunc1DeclarationWhenLineConfirmed(t *testing.T) {
 	file, runtimeStartLine := fn.FileLine(fn.Entry())
 	require.Equal(t, "manual_api_sourcecache_funcn_fixture_test.go", filepath.Base(file))
 
-	metadata := loadSourceFileMetadata(file)
+	metadata := loadSourceFileMetadata(filesystemPathForRuntimeSource(file))
 	require.True(t, metadata.parseOK)
 	require.Len(t, metadata.namedFunctions["func1"], 1)
 	declaration := metadata.namedFunctions["func1"][0]
@@ -490,7 +509,7 @@ func TestSetTestFuncKeepsRealFunc1DeclarationWhenLineConfirmed(t *testing.T) {
 }
 
 func TestSetTestFuncResolvesGeneratedFunc1LiteralWhenDeclarationExists(t *testing.T) {
-	resetCIVisibilityStateForTesting()
+	resetSourceCacheTestState(t)
 	mockTracer.Reset()
 
 	recordLogger := new(log.RecordLogger)
@@ -513,7 +532,7 @@ func TestSetTestFuncResolvesGeneratedFunc1LiteralWhenDeclarationExists(t *testin
 	file, runtimeStartLine := fn.FileLine(fn.Entry())
 	require.Equal(t, "manual_api_sourcecache_funcn_fixture_test.go", filepath.Base(file))
 
-	metadata := loadSourceFileMetadata(file)
+	metadata := loadSourceFileMetadata(filesystemPathForRuntimeSource(file))
 	require.True(t, metadata.parseOK)
 	require.Len(t, metadata.namedFunctions["func1"], 1)
 	require.Len(t, metadata.functionLiterals, 1)
@@ -548,7 +567,7 @@ func TestSetTestFuncResolvesGeneratedFunc1LiteralWhenDeclarationExists(t *testin
 
 // TestSetTestFuncResolvesAdjacentFuncNLiteralToExactSourceRange verifies adjacent closures resolve to their own source ranges.
 func TestSetTestFuncResolvesAdjacentFuncNLiteralToExactSourceRange(t *testing.T) {
-	resetCIVisibilityStateForTesting()
+	resetSourceCacheTestState(t)
 	mockTracer.Reset()
 
 	recordLogger := new(log.RecordLogger)
@@ -573,7 +592,7 @@ func TestSetTestFuncResolvesAdjacentFuncNLiteralToExactSourceRange(t *testing.T)
 	file, secondRuntimeStartLine := secondFn.FileLine(secondFn.Entry())
 	require.Equal(t, "manual_api_sourcecache_adjacent_literal_fixture_test.go", filepath.Base(file))
 
-	metadata := loadSourceFileMetadata(file)
+	metadata := loadSourceFileMetadata(filesystemPathForRuntimeSource(file))
 	require.True(t, metadata.parseOK)
 	require.Len(t, metadata.functionLiterals, 2)
 	firstLiteral := metadata.functionLiterals[0]
@@ -601,10 +620,11 @@ func TestSetTestFuncResolvesAdjacentFuncNLiteralToExactSourceRange(t *testing.T)
 }
 
 func TestLoadSourceFileMetadataIsConcurrentSafe(t *testing.T) {
-	resetCIVisibilityStateForTesting()
+	resetSourceCacheTestState(t)
 
 	_, file, _, ok := runtime.Caller(0)
 	require.True(t, ok)
+	filesystemPath := filesystemPathForRuntimeSource(file)
 
 	results := make([]sourceFileMetadata, 16)
 	var wg sync.WaitGroup
@@ -612,7 +632,7 @@ func TestLoadSourceFileMetadataIsConcurrentSafe(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			results[i] = loadSourceFileMetadata(file)
+			results[i] = loadSourceFileMetadata(filesystemPath)
 		}(idx)
 	}
 	wg.Wait()
@@ -623,7 +643,7 @@ func TestLoadSourceFileMetadataIsConcurrentSafe(t *testing.T) {
 }
 
 func TestSetTestFuncCachesNamedFunctionSourceTagsAndLogs(t *testing.T) {
-	resetCIVisibilityStateForTesting()
+	resetSourceCacheTestState(t)
 	mockTracer.Reset()
 
 	recordLogger := new(log.RecordLogger)
@@ -663,7 +683,7 @@ func TestSetTestFuncCachesNamedFunctionSourceTagsAndLogs(t *testing.T) {
 }
 
 func TestSetTestFuncCachesFunctionLiteralSourceTagsAndLogs(t *testing.T) {
-	resetCIVisibilityStateForTesting()
+	resetSourceCacheTestState(t)
 	mockTracer.Reset()
 
 	recordLogger := new(log.RecordLogger)
@@ -704,7 +724,7 @@ func TestSetTestFuncCachesFunctionLiteralSourceTagsAndLogs(t *testing.T) {
 }
 
 func TestSetTestFuncPreservesSuiteLevelUnskippable(t *testing.T) {
-	resetCIVisibilityStateForTesting()
+	resetSourceCacheTestState(t)
 	mockTracer.Reset()
 
 	now := time.Now()
@@ -724,7 +744,7 @@ func TestSetTestFuncPreservesSuiteLevelUnskippable(t *testing.T) {
 }
 
 func TestSetTestFuncPreservesDeclarationLevelUnskippable(t *testing.T) {
-	resetCIVisibilityStateForTesting()
+	resetSourceCacheTestState(t)
 	mockTracer.Reset()
 
 	now := time.Now()
@@ -744,7 +764,7 @@ func TestSetTestFuncPreservesDeclarationLevelUnskippable(t *testing.T) {
 }
 
 func TestSetTestFuncDisambiguatesSameNamedMethodsInTheSameFile(t *testing.T) {
-	resetCIVisibilityStateForTesting()
+	resetSourceCacheTestState(t)
 	mockTracer.Reset()
 
 	now := time.Now()
@@ -764,7 +784,7 @@ func TestSetTestFuncDisambiguatesSameNamedMethodsInTheSameFile(t *testing.T) {
 	firstFile, firstRuntimeStartLine := firstFn.FileLine(firstFn.Entry())
 	secondFile, secondRuntimeStartLine := secondFn.FileLine(secondFn.Entry())
 	require.Equal(t, firstFile, secondFile)
-	metadata := loadSourceFileMetadata(firstFile)
+	metadata := loadSourceFileMetadata(filesystemPathForRuntimeSource(firstFile))
 	require.Len(t, metadata.namedFunctions["TestSharedName"], 2)
 
 	firstTest.SetTestFunc(firstFn)

--- a/internal/civisibility/integrations/manual_api_sourcepath_test.go
+++ b/internal/civisibility/integrations/manual_api_sourcepath_test.go
@@ -1,0 +1,152 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package integrations
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sourcePathFixtureFunc is a real runtime function used to exercise SetTestFunc path resolution.
+func sourcePathFixtureFunc() {
+}
+
+// sourcePathRepositoryRoot returns the repository root from the package test working directory.
+func sourcePathRepositoryRoot(t *testing.T) string {
+	t.Helper()
+
+	workingDirectory, err := os.Getwd()
+	require.NoError(t, err)
+	return filepath.Clean(filepath.Join(workingDirectory, "..", "..", ".."))
+}
+
+// configureSourcePathTestState resets process-global CI Visibility state and installs source tags.
+func configureSourcePathTestState(t *testing.T, workspacePath string) {
+	t.Helper()
+
+	resetCIVisibilityStateForTesting()
+	mockTracer.Reset()
+	utils.AddCITagsMap(map[string]string{
+		constants.CIWorkspacePath:  workspacePath,
+		constants.GitRepositoryURL: "https://github.com/DataDog/dd-trace-go.git",
+	})
+	t.Cleanup(resetCIVisibilityStateForTesting)
+}
+
+// currentBinaryWasBuiltWithTrimpath reports whether the running test binary has -trimpath enabled.
+func currentBinaryWasBuiltWithTrimpath(t *testing.T) bool {
+	t.Helper()
+
+	buildInfo, ok := debug.ReadBuildInfo()
+	require.True(t, ok)
+	for _, setting := range buildInfo.Settings {
+		if setting.Key == "-trimpath" {
+			return setting.Value == "true"
+		}
+	}
+	return false
+}
+
+// assertSourceRangeTags verifies that SetTestFunc parsed source metadata and published a valid range.
+func assertSourceRangeTags(t *testing.T, test Test) {
+	t.Helper()
+
+	startLine, startOK := test.GetTag(constants.TestSourceStartLine)
+	endLine, endOK := test.GetTag(constants.TestSourceEndLine)
+	require.True(t, startOK)
+	require.True(t, endOK)
+	require.IsType(t, float64(0), startLine)
+	require.IsType(t, float64(0), endLine)
+	assert.GreaterOrEqual(t, endLine.(float64), startLine.(float64))
+}
+
+func TestSetTestFuncUsesResolvedSourcePathForTagsAndParsing(t *testing.T) {
+	configureSourcePathTestState(t, sourcePathRepositoryRoot(t))
+
+	now := time.Now()
+	session, module, suite, test := createDDTest(now)
+	defer func() {
+		session.Close(0)
+		module.Close()
+		suite.Close()
+	}()
+
+	fn := runtime.FuncForPC(reflect.ValueOf(sourcePathFixtureFunc).Pointer())
+	require.NotNil(t, fn)
+	runtimePath, _ := fn.FileLine(fn.Entry())
+	expectedSourcePath := resolveTestSourcePath(runtimePath)
+
+	test.SetTestFunc(fn)
+
+	testSourceFile, testSourceFileOK := test.GetTag(constants.TestSourceFile)
+	suiteSourceFile, suiteSourceFileOK := suite.GetTag(constants.TestSourceFile)
+	require.True(t, testSourceFileOK)
+	require.True(t, suiteSourceFileOK)
+	assert.Equal(t, expectedSourcePath.RelativePath, testSourceFile)
+	assert.Equal(t, expectedSourcePath.RelativePath, suiteSourceFile)
+	assertSourceRangeTags(t, test)
+}
+
+func TestResolveTestSourcePathCanParseTrimpathModulePath(t *testing.T) {
+	workspacePath := t.TempDir()
+	configureSourcePathTestState(t, workspacePath)
+
+	relativePath := filepath.Join("internal", "civisibility", "integrations", "manual_api_sourcepath_test.go")
+	sourceFilePath := filepath.Join(workspacePath, relativePath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(sourceFilePath), 0o700))
+	require.NoError(t, os.WriteFile(sourceFilePath, []byte("package integrations\n\nfunc sourcePathTemporaryFixture() {\n}\n"), 0o600))
+
+	sourcePath := resolveTestSourcePath("github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/manual_api_sourcepath_test.go")
+	metadata := loadSourceFileMetadata(sourcePath.FilesystemPath)
+
+	assert.Equal(t, "internal/civisibility/integrations/manual_api_sourcepath_test.go", sourcePath.RelativePath)
+	assert.Equal(t, sourceFilePath, sourcePath.FilesystemPath)
+	assert.True(t, sourcePath.FilesystemKnown)
+	require.True(t, metadata.parseOK, "expected %q to parse: %v", sourcePath.FilesystemPath, metadata.parseErr)
+	assert.Contains(t, metadata.namedFunctions, "sourcePathTemporaryFixture")
+}
+
+func TestSetTestFuncUnderTrimpathUsesRepositoryRelativeTagsAndParsesSource(t *testing.T) {
+	if !currentBinaryWasBuiltWithTrimpath(t) {
+		t.Skip("this regression is meaningful only when the test binary is built with -trimpath")
+	}
+	configureSourcePathTestState(t, sourcePathRepositoryRoot(t))
+
+	now := time.Now()
+	session, module, suite, test := createDDTest(now)
+	defer func() {
+		session.Close(0)
+		module.Close()
+		suite.Close()
+	}()
+
+	fn := runtime.FuncForPC(reflect.ValueOf(sourcePathFixtureFunc).Pointer())
+	require.NotNil(t, fn)
+	runtimePath, _ := fn.FileLine(fn.Entry())
+	require.False(t, filepath.IsAbs(runtimePath), "go test -trimpath should not report an absolute runtime source path")
+	require.True(t, strings.HasPrefix(runtimePath, "github.com/DataDog/dd-trace-go/v2/"), "unexpected trimpath runtime source path: %s", runtimePath)
+
+	test.SetTestFunc(fn)
+
+	testSourceFile, ok := test.GetTag(constants.TestSourceFile)
+	require.True(t, ok)
+	assert.Equal(t, "internal/civisibility/integrations/manual_api_sourcepath_test.go", testSourceFile)
+	assert.NotContains(t, testSourceFile, "github.com/DataDog/dd-trace-go")
+	assert.NotContains(t, testSourceFile, "v2/internal")
+	assertSourceRangeTags(t, test)
+}

--- a/internal/civisibility/utils/environmentTags_test.go
+++ b/internal/civisibility/utils/environmentTags_test.go
@@ -108,6 +108,7 @@ func TestAddCIMetricsMap(t *testing.T) {
 
 func TestGetRelativePathFromCITagsSourceRoot(t *testing.T) {
 	ResetCITags()
+	t.Cleanup(ResetCITags)
 	originalCiTags = map[string]string{constants.CIWorkspacePath: "/ci/workspace"}
 
 	absPath := "/ci/workspace/subdir/file.txt"
@@ -115,6 +116,16 @@ func TestGetRelativePathFromCITagsSourceRoot(t *testing.T) {
 
 	relPath := GetRelativePathFromCITagsSourceRoot(absPath)
 	assert.Equal(t, expectedRelPath, relPath)
+
+	outsidePath := "/tmp/build/file.txt"
+	expectedOutsideRelPath, err := filepath.Rel("/ci/workspace", outsidePath)
+	assert.NoError(t, err)
+	relPath = GetRelativePathFromCITagsSourceRoot(outsidePath)
+	assert.Equal(t, filepath.ToSlash(expectedOutsideRelPath), relPath)
+
+	modulePath := "github.com/myorg/myrepo/pkg/file_test.go"
+	relPath = GetRelativePathFromCITagsSourceRoot(modulePath)
+	assert.Equal(t, modulePath, relPath)
 
 	// Test case when CIWorkspacePath is not set in ciTags
 	originalCiTags = map[string]string{}

--- a/internal/civisibility/utils/source_paths.go
+++ b/internal/civisibility/utils/source_paths.go
@@ -1,0 +1,270 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package utils
+
+import (
+	"net"
+	"net/url"
+	"path"
+	"path/filepath"
+	"runtime/debug"
+	"strings"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
+)
+
+// SourceFilePath contains the source path variants CI Visibility needs for one runtime source file.
+type SourceFilePath struct {
+	// RuntimePath is the raw path returned by runtime.Func.FileLine.
+	RuntimePath string
+	// FilesystemPath is the best-effort local filesystem path used for source parsing.
+	FilesystemPath string
+	// RelativePath is the slash-normalized repository path used for tags, CODEOWNERS, and impacted tests.
+	RelativePath string
+	// FilesystemKnown is true when FilesystemPath is derived from a trusted filesystem or workspace path.
+	FilesystemKnown bool
+}
+
+// ResolveSourceFilePathFromCITags resolves a runtime source path into tag and filesystem forms.
+func ResolveSourceFilePathFromCITags(sourcePath string) SourceFilePath {
+	return resolveSourceFilePath(sourcePath, GetCITags(), buildInfoMainModulePath())
+}
+
+// resolveSourceFilePath resolves a runtime source path with injectable inputs for deterministic tests.
+func resolveSourceFilePath(sourcePath string, tags map[string]string, mainModulePath string) SourceFilePath {
+	if sourcePath == "" {
+		return SourceFilePath{}
+	}
+
+	result := SourceFilePath{
+		RuntimePath:     sourcePath,
+		FilesystemPath:  sourcePath,
+		RelativePath:    sourcePath,
+		FilesystemKnown: false,
+	}
+
+	workspacePath := tags[constants.CIWorkspacePath]
+	if filepath.IsAbs(sourcePath) {
+		cleanedPath := filepath.Clean(sourcePath)
+		result.FilesystemPath = cleanedPath
+		result.FilesystemKnown = true
+		result.RelativePath = filepath.ToSlash(cleanedPath)
+		if relPath, ok := relativePathInsideWorkspace(workspacePath, cleanedPath); ok {
+			result.RelativePath = filepath.ToSlash(relPath)
+		}
+		return result
+	}
+
+	logicalPath := cleanLogicalSourcePath(sourcePath)
+	result.RelativePath = logicalPath
+
+	repoPrefix := repositoryPathFromURL(tags[constants.GitRepositoryURL])
+	if relativePath, ok := trimLogicalPrefix(logicalPath, repoPrefix); ok {
+		relativePath = stripConfirmedSemanticImportVersion(relativePath, repoPrefix, mainModulePath)
+		result.RelativePath = relativePath
+		if workspacePath != "" {
+			result.FilesystemPath = filepath.Join(filepath.Clean(workspacePath), filepath.FromSlash(relativePath))
+			result.FilesystemKnown = true
+		}
+		return result
+	}
+
+	if relativePath, ok := trimLogicalPrefix(logicalPath, mainModulePath); ok && mainModulePath != "" && mainModulePath != "command-line-arguments" {
+		result.RelativePath = relativePath
+		return result
+	}
+
+	if isWorkspaceRelativeLogicalPath(logicalPath) {
+		result.RelativePath = logicalPath
+		if workspacePath != "" {
+			result.FilesystemPath = filepath.Join(filepath.Clean(workspacePath), filepath.FromSlash(logicalPath))
+			result.FilesystemKnown = true
+		}
+		return result
+	}
+
+	return result
+}
+
+// relativePathInsideWorkspace returns a clean relative path only when filePath is inside workspacePath.
+func relativePathInsideWorkspace(workspacePath, filePath string) (string, bool) {
+	if workspacePath == "" {
+		return "", false
+	}
+	relPath, err := filepath.Rel(filepath.Clean(workspacePath), filepath.Clean(filePath))
+	if err != nil || relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) || filepath.IsAbs(relPath) {
+		return "", false
+	}
+	return relPath, true
+}
+
+// cleanLogicalSourcePath normalizes a non-absolute runtime path for logical repository matching.
+func cleanLogicalSourcePath(sourcePath string) string {
+	logicalPath := strings.ReplaceAll(sourcePath, "\\", "/")
+	logicalPath = path.Clean(logicalPath)
+	if logicalPath == "." {
+		return ""
+	}
+	return strings.TrimPrefix(logicalPath, "./")
+}
+
+// trimLogicalPrefix strips prefix from logicalPath only when the match ends on a path segment boundary.
+func trimLogicalPrefix(logicalPath, prefix string) (string, bool) {
+	if logicalPath == "" || prefix == "" {
+		return "", false
+	}
+	prefix = strings.Trim(path.Clean(strings.ReplaceAll(prefix, "\\", "/")), "/")
+	if prefix == "." || prefix == "" {
+		return "", false
+	}
+	if logicalPath == prefix {
+		return "", true
+	}
+	if strings.HasPrefix(logicalPath, prefix+"/") {
+		return strings.TrimPrefix(logicalPath, prefix+"/"), true
+	}
+	return "", false
+}
+
+// repositoryPathFromURL converts common Git remote URL forms into a Go-import-style host/path prefix.
+func repositoryPathFromURL(repositoryURL string) string {
+	repositoryURL = strings.TrimSpace(repositoryURL)
+	if repositoryURL == "" {
+		return ""
+	}
+
+	if scpHost, scpPath, ok := parseSCPStyleRepositoryURL(repositoryURL); ok {
+		return cleanRepositoryHostPath(scpHost, scpPath)
+	}
+
+	parsedURL, err := url.Parse(repositoryURL)
+	if err != nil || parsedURL.Host == "" {
+		return ""
+	}
+	host := parsedURL.Hostname()
+	if host == "" {
+		host = parsedURL.Host
+	}
+	return cleanRepositoryHostPath(host, parsedURL.EscapedPath())
+}
+
+// stripConfirmedSemanticImportVersion removes a build-info-confirmed semantic import suffix from a repo-relative path.
+func stripConfirmedSemanticImportVersion(relativePath, repoPrefix, mainModulePath string) string {
+	moduleDir, version, ok := semanticImportVersionSuffix(mainModulePath, repoPrefix)
+	if !ok {
+		return relativePath
+	}
+	if moduleDir == "" {
+		if strings.HasPrefix(relativePath, version+"/") {
+			return strings.TrimPrefix(relativePath, version+"/")
+		}
+		return relativePath
+	}
+	versionedModuleDir := moduleDir + "/" + version
+	if suffix, ok := trimLogicalPrefix(relativePath, versionedModuleDir); ok {
+		if suffix == "" {
+			return moduleDir
+		}
+		return moduleDir + "/" + suffix
+	}
+	return relativePath
+}
+
+// semanticImportVersionSuffix returns the module directory and semantic version suffix inside repoPrefix.
+func semanticImportVersionSuffix(modulePath, repoPrefix string) (moduleDir string, version string, ok bool) {
+	moduleRelativePath, ok := trimLogicalPrefix(modulePath, repoPrefix)
+	if !ok || moduleRelativePath == "" {
+		return "", "", false
+	}
+	lastSlash := strings.LastIndex(moduleRelativePath, "/")
+	if lastSlash == -1 {
+		version = moduleRelativePath
+	} else {
+		moduleDir = moduleRelativePath[:lastSlash]
+		version = moduleRelativePath[lastSlash+1:]
+	}
+	if !isSemanticImportVersion(version) {
+		return "", "", false
+	}
+	return moduleDir, version, true
+}
+
+// isSemanticImportVersion reports whether segment is a Go semantic import version suffix.
+func isSemanticImportVersion(segment string) bool {
+	if len(segment) < 2 || segment[0] != 'v' || segment[1] < '2' || segment[1] > '9' {
+		return false
+	}
+	for _, r := range segment[2:] {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// buildInfoMainModulePath returns the main module path embedded in the current binary, if available.
+func buildInfoMainModulePath() string {
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	return buildInfo.Main.Path
+}
+
+// parseSCPStyleRepositoryURL parses Git scp-like remotes such as git@github.com:org/repo.git.
+func parseSCPStyleRepositoryURL(repositoryURL string) (host string, repositoryPath string, ok bool) {
+	if strings.Contains(repositoryURL, "://") {
+		return "", "", false
+	}
+	colonIndex := strings.Index(repositoryURL, ":")
+	if colonIndex == -1 {
+		return "", "", false
+	}
+	hostPart := repositoryURL[:colonIndex]
+	repositoryPath = repositoryURL[colonIndex+1:]
+	if atIndex := strings.LastIndex(hostPart, "@"); atIndex != -1 {
+		hostPart = hostPart[atIndex+1:]
+	}
+	if hostPart == "" || repositoryPath == "" {
+		return "", "", false
+	}
+	return hostPart, repositoryPath, true
+}
+
+// cleanRepositoryHostPath joins a repository host and path into a stable import-prefix candidate.
+func cleanRepositoryHostPath(host, repositoryPath string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if hostWithoutPort, _, err := net.SplitHostPort(host); err == nil {
+		host = hostWithoutPort
+	}
+	repositoryPath = strings.TrimSpace(repositoryPath)
+	if unescapedPath, err := url.PathUnescape(repositoryPath); err == nil {
+		repositoryPath = unescapedPath
+	}
+	repositoryPath = strings.Trim(path.Clean(strings.ReplaceAll(repositoryPath, "\\", "/")), "/")
+	repositoryPath = strings.TrimSuffix(repositoryPath, ".git")
+	if host == "" || repositoryPath == "" || repositoryPath == "." {
+		return ""
+	}
+	return host + "/" + repositoryPath
+}
+
+// isWorkspaceRelativeLogicalPath reports whether logicalPath is safe to resolve from ci.workspace_path.
+func isWorkspaceRelativeLogicalPath(logicalPath string) bool {
+	if logicalPath == "" || strings.HasPrefix(logicalPath, "../") || logicalPath == ".." {
+		return false
+	}
+	for _, segment := range strings.Split(logicalPath, "/") {
+		if segment == ".." {
+			return false
+		}
+	}
+	segments := strings.Split(logicalPath, "/")
+	if len(segments) >= 3 && strings.ContainsAny(segments[0], ".:@") {
+		return false
+	}
+	return true
+}

--- a/internal/civisibility/utils/source_paths.go
+++ b/internal/civisibility/utils/source_paths.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime/debug"
+	"slices"
 	"strings"
 
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
@@ -123,8 +124,8 @@ func trimLogicalPrefix(logicalPath, prefix string) (string, bool) {
 	if logicalPath == prefix {
 		return "", true
 	}
-	if strings.HasPrefix(logicalPath, prefix+"/") {
-		return strings.TrimPrefix(logicalPath, prefix+"/"), true
+	if suffix, ok := strings.CutPrefix(logicalPath, prefix+"/"); ok {
+		return suffix, true
 	}
 	return "", false
 }
@@ -158,8 +159,8 @@ func stripConfirmedSemanticImportVersion(relativePath, repoPrefix, mainModulePat
 		return relativePath
 	}
 	if moduleDir == "" {
-		if strings.HasPrefix(relativePath, version+"/") {
-			return strings.TrimPrefix(relativePath, version+"/")
+		if suffix, ok := strings.CutPrefix(relativePath, version+"/"); ok {
+			return suffix
 		}
 		return relativePath
 	}
@@ -219,12 +220,10 @@ func parseSCPStyleRepositoryURL(repositoryURL string) (host string, repositoryPa
 	if strings.Contains(repositoryURL, "://") {
 		return "", "", false
 	}
-	colonIndex := strings.Index(repositoryURL, ":")
-	if colonIndex == -1 {
+	hostPart, repositoryPath, ok := strings.Cut(repositoryURL, ":")
+	if !ok {
 		return "", "", false
 	}
-	hostPart := repositoryURL[:colonIndex]
-	repositoryPath = repositoryURL[colonIndex+1:]
 	if atIndex := strings.LastIndex(hostPart, "@"); atIndex != -1 {
 		hostPart = hostPart[atIndex+1:]
 	}
@@ -257,12 +256,10 @@ func isWorkspaceRelativeLogicalPath(logicalPath string) bool {
 	if logicalPath == "" || strings.HasPrefix(logicalPath, "../") || logicalPath == ".." {
 		return false
 	}
-	for _, segment := range strings.Split(logicalPath, "/") {
-		if segment == ".." {
-			return false
-		}
-	}
 	segments := strings.Split(logicalPath, "/")
+	if slices.Contains(segments, "..") {
+		return false
+	}
 	if len(segments) >= 3 && strings.ContainsAny(segments[0], ".:@") {
 		return false
 	}

--- a/internal/civisibility/utils/source_paths_test.go
+++ b/internal/civisibility/utils/source_paths_test.go
@@ -1,0 +1,361 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+//go:build !windows
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveSourceFilePath(t *testing.T) {
+	workspace := "/ci/workspace"
+	tests := []struct {
+		name                string
+		runtimePath         string
+		tags                map[string]string
+		mainModulePath      string
+		expectedRelative    string
+		expectedFilesystem  string
+		expectedKnown       bool
+		unexpectedRelative  []string
+		unexpectedFilePaths []string
+	}{
+		{
+			name:               "empty input",
+			expectedRelative:   "",
+			expectedFilesystem: "",
+			expectedKnown:      false,
+		},
+		{
+			name:               "absolute path inside workspace",
+			runtimePath:        "/ci/workspace/services/foo/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace},
+			expectedRelative:   "services/foo/foo_test.go",
+			expectedFilesystem: "/ci/workspace/services/foo/foo_test.go",
+			expectedKnown:      true,
+		},
+		{
+			name:               "absolute path outside workspace",
+			runtimePath:        "/tmp/build/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace},
+			expectedRelative:   "/tmp/build/foo_test.go",
+			expectedFilesystem: "/tmp/build/foo_test.go",
+			expectedKnown:      true,
+		},
+		{
+			name:               "repo relative path with workspace",
+			runtimePath:        "services/foo/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace},
+			expectedRelative:   "services/foo/foo_test.go",
+			expectedFilesystem: "/ci/workspace/services/foo/foo_test.go",
+			expectedKnown:      true,
+		},
+		{
+			name:               "root file repo relative path with workspace",
+			runtimePath:        "foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace},
+			expectedRelative:   "foo_test.go",
+			expectedFilesystem: "/ci/workspace/foo_test.go",
+			expectedKnown:      true,
+		},
+		{
+			name:               "repo relative path without workspace",
+			runtimePath:        "services/foo/foo_test.go",
+			expectedRelative:   "services/foo/foo_test.go",
+			expectedFilesystem: "services/foo/foo_test.go",
+			expectedKnown:      false,
+		},
+		{
+			name:               "relative path with parent traversal",
+			runtimePath:        "../services/foo/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace},
+			expectedRelative:   "../services/foo/foo_test.go",
+			expectedFilesystem: "../services/foo/foo_test.go",
+			expectedKnown:      false,
+		},
+		{
+			name:               "https repository URL",
+			runtimePath:        "github.com/myorg/myrepo/services/foo/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace, constants.GitRepositoryURL: "https://github.com/myorg/myrepo.git"},
+			expectedRelative:   "services/foo/foo_test.go",
+			expectedFilesystem: "/ci/workspace/services/foo/foo_test.go",
+			expectedKnown:      true,
+		},
+		{
+			name:               "scp style repository URL",
+			runtimePath:        "github.com/myorg/myrepo/services/foo/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace, constants.GitRepositoryURL: "git@github.com:myorg/myrepo.git"},
+			expectedRelative:   "services/foo/foo_test.go",
+			expectedFilesystem: "/ci/workspace/services/foo/foo_test.go",
+			expectedKnown:      true,
+		},
+		{
+			name:               "ssh URL repository URL",
+			runtimePath:        "github.com/myorg/myrepo/services/foo/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace, constants.GitRepositoryURL: "ssh://git@github.com/myorg/myrepo.git"},
+			expectedRelative:   "services/foo/foo_test.go",
+			expectedFilesystem: "/ci/workspace/services/foo/foo_test.go",
+			expectedKnown:      true,
+		},
+		{
+			name:               "repository URL with credentials",
+			runtimePath:        "github.com/myorg/myrepo/services/foo/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace, constants.GitRepositoryURL: "https://token@github.com/myorg/myrepo.git"},
+			expectedRelative:   "services/foo/foo_test.go",
+			expectedFilesystem: "/ci/workspace/services/foo/foo_test.go",
+			expectedKnown:      true,
+		},
+		{
+			name:               "repository URL with username and password",
+			runtimePath:        "github.com/myorg/myrepo/services/foo/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace, constants.GitRepositoryURL: "https://user:password@github.com/myorg/myrepo.git"},
+			expectedRelative:   "services/foo/foo_test.go",
+			expectedFilesystem: "/ci/workspace/services/foo/foo_test.go",
+			expectedKnown:      true,
+		},
+		{
+			name:               "repository URL with port",
+			runtimePath:        "github.com/myorg/myrepo/services/foo/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace, constants.GitRepositoryURL: "ssh://git@github.com:2222/myorg/myrepo.git"},
+			expectedRelative:   "services/foo/foo_test.go",
+			expectedFilesystem: "/ci/workspace/services/foo/foo_test.go",
+			expectedKnown:      true,
+		},
+		{
+			name:               "repository URL with trailing slash",
+			runtimePath:        "github.com/myorg/myrepo/services/foo/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace, constants.GitRepositoryURL: "https://github.com/myorg/myrepo/"},
+			expectedRelative:   "services/foo/foo_test.go",
+			expectedFilesystem: "/ci/workspace/services/foo/foo_test.go",
+			expectedKnown:      true,
+		},
+		{
+			name:               "repository URL without git suffix",
+			runtimePath:        "github.com/myorg/myrepo/services/foo/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace, constants.GitRepositoryURL: "https://github.com/myorg/myrepo"},
+			expectedRelative:   "services/foo/foo_test.go",
+			expectedFilesystem: "/ci/workspace/services/foo/foo_test.go",
+			expectedKnown:      true,
+		},
+		{
+			name:               "azure devops textual repository URL",
+			runtimePath:        "dev.azure.com/org/project/_git/repo/services/foo/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace, constants.GitRepositoryURL: "https://dev.azure.com/org/project/_git/repo"},
+			expectedRelative:   "services/foo/foo_test.go",
+			expectedFilesystem: "/ci/workspace/services/foo/foo_test.go",
+			expectedKnown:      true,
+		},
+		{
+			name:               "segment boundary safety",
+			runtimePath:        "github.com/myorg/myrepository/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace, constants.GitRepositoryURL: "https://github.com/myorg/myrepo.git"},
+			expectedRelative:   "github.com/myorg/myrepository/foo_test.go",
+			expectedFilesystem: "github.com/myorg/myrepository/foo_test.go",
+			expectedKnown:      false,
+		},
+		{
+			name:               "semantic import version from main module path",
+			runtimePath:        "github.com/DataDog/dd-trace-go/v2/internal/civisibility/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace, constants.GitRepositoryURL: "https://github.com/DataDog/dd-trace-go.git"},
+			mainModulePath:     "github.com/DataDog/dd-trace-go/v2",
+			expectedRelative:   "internal/civisibility/foo_test.go",
+			expectedFilesystem: "/ci/workspace/internal/civisibility/foo_test.go",
+			expectedKnown:      true,
+			unexpectedRelative: []string{"v2/internal/civisibility/foo_test.go"},
+		},
+		{
+			name:               "ambiguous physical v2 subdirectory uses documented root module default",
+			runtimePath:        "github.com/org/repo/v2/pkg/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace, constants.GitRepositoryURL: "https://github.com/org/repo.git"},
+			mainModulePath:     "github.com/org/repo/v2",
+			expectedRelative:   "pkg/foo_test.go",
+			expectedFilesystem: "/ci/workspace/pkg/foo_test.go",
+			expectedKnown:      true,
+		},
+		{
+			name:                "semantic import version in monorepo module",
+			runtimePath:         "github.com/org/repo/services/foo/v2/pkg/foo_test.go",
+			tags:                map[string]string{constants.CIWorkspacePath: workspace, constants.GitRepositoryURL: "https://github.com/org/repo.git"},
+			mainModulePath:      "github.com/org/repo/services/foo/v2",
+			expectedRelative:    "services/foo/pkg/foo_test.go",
+			expectedFilesystem:  "/ci/workspace/services/foo/pkg/foo_test.go",
+			expectedKnown:       true,
+			unexpectedRelative:  []string{"pkg/foo_test.go", "services/foo/v2/pkg/foo_test.go"},
+			unexpectedFilePaths: []string{"/ci/workspace/pkg/foo_test.go", "/ci/workspace/services/foo/v2/pkg/foo_test.go"},
+		},
+		{
+			name:               "semantic import version not inferred without build info",
+			runtimePath:        "github.com/DataDog/dd-trace-go/v2/internal/civisibility/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace, constants.GitRepositoryURL: "https://github.com/DataDog/dd-trace-go.git"},
+			expectedRelative:   "v2/internal/civisibility/foo_test.go",
+			expectedFilesystem: "/ci/workspace/v2/internal/civisibility/foo_test.go",
+			expectedKnown:      true,
+		},
+		{
+			name:               "v1 is not a semantic import suffix",
+			runtimePath:        "github.com/myorg/myrepo/v1/pkg/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace, constants.GitRepositoryURL: "https://github.com/myorg/myrepo.git"},
+			mainModulePath:     "github.com/myorg/myrepo/v1",
+			expectedRelative:   "v1/pkg/foo_test.go",
+			expectedFilesystem: "/ci/workspace/v1/pkg/foo_test.go",
+			expectedKnown:      true,
+		},
+		{
+			name:               "v2x is not a semantic import suffix",
+			runtimePath:        "github.com/myorg/myrepo/v2x/pkg/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace, constants.GitRepositoryURL: "https://github.com/myorg/myrepo.git"},
+			mainModulePath:     "github.com/myorg/myrepo/v2x",
+			expectedRelative:   "v2x/pkg/foo_test.go",
+			expectedFilesystem: "/ci/workspace/v2x/pkg/foo_test.go",
+			expectedKnown:      true,
+		},
+		{
+			name:               "nested v2 directory is not stripped without matching module path",
+			runtimePath:        "github.com/myorg/myrepo/pkg/v2/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace, constants.GitRepositoryURL: "https://github.com/myorg/myrepo.git"},
+			mainModulePath:     "github.com/myorg/myrepo",
+			expectedRelative:   "pkg/v2/foo_test.go",
+			expectedFilesystem: "/ci/workspace/pkg/v2/foo_test.go",
+			expectedKnown:      true,
+		},
+		{
+			name:               "build info fallback stays module relative",
+			runtimePath:        "github.com/myorg/myrepo/pkg/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace},
+			mainModulePath:     "github.com/myorg/myrepo",
+			expectedRelative:   "pkg/foo_test.go",
+			expectedFilesystem: "github.com/myorg/myrepo/pkg/foo_test.go",
+			expectedKnown:      false,
+		},
+		{
+			name:               "repository URL preferred over build info",
+			runtimePath:        "github.com/myorg/myrepo/services/foo/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace, constants.GitRepositoryURL: "https://github.com/myorg/myrepo.git"},
+			mainModulePath:     "github.com/myorg/myrepo/services/foo",
+			expectedRelative:   "services/foo/foo_test.go",
+			expectedFilesystem: "/ci/workspace/services/foo/foo_test.go",
+			expectedKnown:      true,
+			unexpectedRelative: []string{"foo_test.go"},
+		},
+		{
+			name:               "unknown import like logical path",
+			runtimePath:        "github.com/other/repo/pkg/foo_test.go",
+			expectedRelative:   "github.com/other/repo/pkg/foo_test.go",
+			expectedFilesystem: "github.com/other/repo/pkg/foo_test.go",
+			expectedKnown:      false,
+		},
+		{
+			name:               "unmatched import like logical path with workspace",
+			runtimePath:        "github.com/other/repo/pkg/foo_test.go",
+			tags:               map[string]string{constants.CIWorkspacePath: workspace},
+			expectedRelative:   "github.com/other/repo/pkg/foo_test.go",
+			expectedFilesystem: "github.com/other/repo/pkg/foo_test.go",
+			expectedKnown:      false,
+		},
+		{
+			name:               "backslash logical path",
+			runtimePath:        `github.com\myorg\myrepo\pkg\foo_test.go`,
+			tags:               map[string]string{constants.CIWorkspacePath: workspace, constants.GitRepositoryURL: "https://github.com/myorg/myrepo.git"},
+			expectedRelative:   "pkg/foo_test.go",
+			expectedFilesystem: "/ci/workspace/pkg/foo_test.go",
+			expectedKnown:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolveSourceFilePath(tt.runtimePath, tt.tags, tt.mainModulePath)
+
+			assert.Equal(t, tt.runtimePath, result.RuntimePath)
+			assert.Equal(t, tt.expectedRelative, result.RelativePath)
+			if tt.expectedFilesystem == "" {
+				assert.Equal(t, tt.expectedFilesystem, result.FilesystemPath)
+			} else {
+				assert.Equal(t, filepath.Clean(tt.expectedFilesystem), filepath.Clean(result.FilesystemPath))
+			}
+			assert.Equal(t, tt.expectedKnown, result.FilesystemKnown)
+			for _, unexpected := range tt.unexpectedRelative {
+				assert.NotEqual(t, unexpected, result.RelativePath)
+			}
+			for _, unexpected := range tt.unexpectedFilePaths {
+				assert.NotEqual(t, filepath.Clean(unexpected), filepath.Clean(result.FilesystemPath))
+			}
+		})
+	}
+}
+
+func TestRepositoryPathFromURL(t *testing.T) {
+	tests := map[string]string{
+		"https://github.com/myorg/myrepo.git":           "github.com/myorg/myrepo",
+		"https://github.com/myorg/myrepo":               "github.com/myorg/myrepo",
+		"https://github.com/myorg/myrepo/":              "github.com/myorg/myrepo",
+		"https://token@github.com/myorg/myrepo.git":     "github.com/myorg/myrepo",
+		"https://user:pass@github.com/myorg/myrepo.git": "github.com/myorg/myrepo",
+		"ssh://git@github.com/myorg/myrepo.git":         "github.com/myorg/myrepo",
+		"ssh://git@github.com:2222/myorg/myrepo.git":    "github.com/myorg/myrepo",
+		"git@github.com:myorg/myrepo.git":               "github.com/myorg/myrepo",
+		"git@github.com:myorg/myrepo":                   "github.com/myorg/myrepo",
+		"https://dev.azure.com/org/project/_git/repo":   "dev.azure.com/org/project/_git/repo",
+	}
+
+	for repositoryURL, expectedPath := range tests {
+		t.Run(repositoryURL, func(t *testing.T) {
+			assert.Equal(t, expectedPath, repositoryPathFromURL(repositoryURL))
+		})
+	}
+}
+
+func TestResolveSourceFilePathFromCITags(t *testing.T) {
+	ResetCITags()
+	t.Cleanup(ResetCITags)
+	originalCiTags = map[string]string{
+		constants.CIWorkspacePath:  "/ci/workspace",
+		constants.GitRepositoryURL: "https://github.com/myorg/myrepo.git",
+	}
+
+	result := ResolveSourceFilePathFromCITags("github.com/myorg/myrepo/pkg/foo_test.go")
+
+	assert.Equal(t, "pkg/foo_test.go", result.RelativePath)
+	assert.Equal(t, filepath.Clean("/ci/workspace/pkg/foo_test.go"), filepath.Clean(result.FilesystemPath))
+	assert.True(t, result.FilesystemKnown)
+}
+
+func TestResolvedTrimpathSourceFileMatchesCodeOwners(t *testing.T) {
+	ResetCITags()
+	ResetCodeOwnersForTesting()
+	t.Cleanup(func() {
+		ResetCITags()
+		ResetCodeOwnersForTesting()
+	})
+
+	workspace := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, "CODEOWNERS"), []byte("/services/foo/* @team/foo\n"), 0o600))
+	originalCiTags = map[string]string{
+		constants.CIWorkspacePath:  workspace,
+		constants.GitRepositoryURL: "https://github.com/myorg/myrepo.git",
+	}
+
+	sourcePath := resolveSourceFilePath(
+		"github.com/myorg/myrepo/v2/services/foo/foo_test.go",
+		originalCiTags,
+		"github.com/myorg/myrepo/v2",
+	)
+	codeOwners := GetCodeOwners()
+	require.NotNil(t, codeOwners)
+
+	match, found := codeOwners.Match("/" + sourcePath.RelativePath)
+	require.True(t, found)
+	assert.Equal(t, "services/foo/foo_test.go", sourcePath.RelativePath)
+	assert.Equal(t, "[\"@team/foo\"]", match.GetOwnersString())
+}

--- a/internal/civisibility/utils/source_paths_windows_test.go
+++ b/internal/civisibility/utils/source_paths_windows_test.go
@@ -1,0 +1,66 @@
+//go:build windows
+
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package utils
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveSourceFilePathWindows(t *testing.T) {
+	tests := []struct {
+		name               string
+		workspace          string
+		runtimePath        string
+		expectedRelative   string
+		expectedFilesystem string
+	}{
+		{
+			name:               "same drive inside workspace",
+			workspace:          `C:\workspace`,
+			runtimePath:        `C:\workspace\pkg\foo_test.go`,
+			expectedRelative:   "pkg/foo_test.go",
+			expectedFilesystem: `C:\workspace\pkg\foo_test.go`,
+		},
+		{
+			name:               "different drive outside workspace",
+			workspace:          `C:\workspace`,
+			runtimePath:        `D:\src\pkg\foo_test.go`,
+			expectedRelative:   "D:/src/pkg/foo_test.go",
+			expectedFilesystem: `D:\src\pkg\foo_test.go`,
+		},
+		{
+			name:               "same UNC share inside workspace",
+			workspace:          `\\server\share\workspace`,
+			runtimePath:        `\\server\share\workspace\pkg\foo_test.go`,
+			expectedRelative:   "pkg/foo_test.go",
+			expectedFilesystem: `\\server\share\workspace\pkg\foo_test.go`,
+		},
+		{
+			name:               "different UNC share outside workspace",
+			workspace:          `\\server\share\workspace`,
+			runtimePath:        `\\server\other\workspace\pkg\foo_test.go`,
+			expectedRelative:   "//server/other/workspace/pkg/foo_test.go",
+			expectedFilesystem: `\\server\other\workspace\pkg\foo_test.go`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolveSourceFilePath(tt.runtimePath, map[string]string{constants.CIWorkspacePath: tt.workspace}, "")
+
+			assert.Equal(t, tt.expectedRelative, result.RelativePath)
+			assert.Equal(t, filepath.Clean(tt.expectedFilesystem), filepath.Clean(result.FilesystemPath))
+			assert.True(t, result.FilesystemKnown)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Fixes CI Visibility test source resolution when Go test binaries are built with `-trimpath`.

`runtime.Func.FileLine` can return a logical module path such as `github.com/DataDog/dd-trace-go/v2/internal/...` instead of a local filesystem path. `SetTestFunc` previously used that single value for both source tags and source parsing, which could leave `test.source.file` with the module prefix and prevent AST parsing from finding source ranges.

This PR adds a source-path resolver that keeps those concerns separate:
- repository-relative paths for `test.source.file`, CODEOWNERS, and impacted-tests inputs
- best-effort filesystem paths for source parsing

The resolver preserves the existing legacy helper behavior for other callers, handles repository URL normalization, supports semantic import suffixes like `/v2`, preserves monorepo module subdirectories, and includes Windows-specific path coverage.

### Motivation

Fix CI Visibility source metadata for `-trimpath` test binaries, including the bug reported in DataDog/orchestrion#826, without changing unrelated path handling for existing CI Visibility callers.

### Testing

- `go test ./internal/civisibility/utils -count=1`
- `go test ./internal/civisibility/integrations -count=1`
- `go test ./internal/civisibility/integrations/gotesting -count=1`
- `go test ./internal/civisibility/... -count=1`
- `go test -trimpath ./internal/civisibility/... -count=1`
- `go test -race ./internal/civisibility/... -count=1`
- `go test -race -trimpath ./internal/civisibility/... -count=1`
- `git diff --check`
