### PR TITLE
feat: alert slack on smoke test failures

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -337,6 +337,7 @@ jobs:
           payload: |
             {
               "text": "Smoke Tests Failed",
+              "linux_result": "${{ needs.setup-requirements-linux.result }}",
               "core_result": "${{ needs.smoke-test-tracer.result }}",
               "contrib_result": "${{ needs.setup-env.result }}",
               "blocks": [
@@ -372,7 +373,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Setup Env Result:*\n${{ needs.setup-env.result }}"
+                      "text": "*Contrib Test Result:*\n${{ needs.go-get-u.result }}"
                     },
                   ]
                 }

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -339,7 +339,7 @@ jobs:
               "text": "Smoke Tests Failed",
               "linux_result": "${{ needs.setup-requirements-linux.result }}",
               "core_result": "${{ needs.smoke-test-tracer.result }}",
-              "contrib_result": "${{ needs.setup-env.result }}",
+              "contrib_result": "${{ needs.go-get-u.result }}",
               "blocks": [
                 {
                   "type": "header",

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -164,6 +164,7 @@ jobs:
         uses: ./.github/actions/supported_configurations_validation
       - name: Get Datadog credentials
         id: dd-sts
+        if: always()
         continue-on-error: true
         uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75
         with:
@@ -321,20 +322,23 @@ jobs:
     needs: 
       - setup-requirements-linux
       - smoke-test-tracer
+      - go-get-u
     runs-on: ubuntu-latest
     if: success() || failure()
     steps:
       - name: Success
-        if: needs.setup-requirements-linux.result == 'success' && needs.smoke-test-tracer.result == 'success'
+        if: needs.setup-requirements-linux.result == 'success' && needs.smoke-test-tracer.result == 'success' && needs.go-get-u.result == 'success'
         run: echo "Success!"
       - name: Failure
-        if: needs.setup-requirements-linux.result != 'success' || needs.smoke-test-tracer.result != 'success'
+        if: needs.setup-requirements-linux.result != 'success' || needs.smoke-test-tracer.result != 'success' || needs.go-get-u.result != 'success'
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook-type: incoming-webhook
           payload: |
             {
               "text": "Smoke Tests Failed",
+              "core_result": "${{ needs.smoke-test-tracer.result }}",
+              "contrib_result": "${{ needs.setup-env.result }}",
               "blocks": [
                 {
                   "type": "header",
@@ -357,6 +361,18 @@ jobs:
                     {
                       "type": "mrkdwn",
                       "text": "*Workflow:*\n${{ github.workflow }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Linux Result:*\n${{ needs.setup-requirements-linux.result }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Tracer Result:*\n${{ needs.smoke-test-tracer.result }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Setup Env Result:*\n${{ needs.setup-env.result }}"
                     },
                   ]
                 }

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -15,7 +15,6 @@ on:
     branches:
       - release-v*
       - main
-      - hannahkm/silence-smoke-tests
     tags-ignore:
       - 'contrib/**'
       - 'instrumentation/**'
@@ -157,7 +156,6 @@ jobs:
           export PATH="${{ github.workspace }}/bin:${PATH}"
           # shellcheck disable=SC2086
           gotestsum --junitfile "${TEST_RESULTS}/gotestsum-report-smoke-tracer.xml" -- -v $PACKAGES
-          exit 1
       # Check for changes in the supported_configurations.json file
       - name: Supported Configurations Diff Check
         if: always()

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -15,6 +15,7 @@ on:
     branches:
       - release-v*
       - main
+      - hannahkm/silence-smoke-tests
     tags-ignore:
       - 'contrib/**'
       - 'instrumentation/**'
@@ -156,6 +157,7 @@ jobs:
           export PATH="${{ github.workspace }}/bin:${PATH}"
           # shellcheck disable=SC2086
           gotestsum --junitfile "${TEST_RESULTS}/gotestsum-report-smoke-tracer.xml" -- -v $PACKAGES
+          exit 1
       # Check for changes in the supported_configurations.json file
       - name: Supported Configurations Diff Check
         if: always()
@@ -325,4 +327,38 @@ jobs:
         run: echo "Success!"
       - name: Failure
         if: needs.setup-requirements-linux.result != 'success'
-        run: echo "Failure!" && exit 1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        with:
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "Smoke Tests Failed",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":x: Smoke Tests Failed on Main!"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Repository:*\n${{ github.repository }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:*\n${{ github.ref_name }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow:*\n${{ github.workflow }}"
+                    },
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SMOKE_TESTS_WEBHOOK_URL }}

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -318,15 +318,17 @@ jobs:
 
   smoke-tests-done:
     name: Smoke Tests
-    needs: setup-requirements-linux
+    needs: 
+      - setup-requirements-linux
+      - smoke-test-tracer
     runs-on: ubuntu-latest
     if: success() || failure()
     steps:
       - name: Success
-        if: needs.setup-requirements-linux.result == 'success'
+        if: needs.setup-requirements-linux.result == 'success' && needs.smoke-test-tracer.result == 'success'
         run: echo "Success!"
       - name: Failure
-        if: needs.setup-requirements-linux.result != 'success'
+        if: needs.setup-requirements-linux.result != 'success' || needs.smoke-test-tracer.result != 'success'
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook-type: incoming-webhook


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Smoke tests now always pass, and any failures are reported to Slack instead.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We don't want Green CI to tank due to smoke test failures, which are usually out of our control.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
