### PR TITLE
refactor(config): migrate spanAttributeSchemaVersion

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -218,9 +218,6 @@ type config struct {
 	// enableHostnameDetection specifies whether the tracer should enable hostname detection.
 	enableHostnameDetection bool
 
-	// spanAttributeSchemaVersion holds the selected DD_TRACE_SPAN_ATTRIBUTE_SCHEMA version.
-	spanAttributeSchemaVersion int
-
 	// orchestrionCfg holds Orchestrion (aka auto-instrumentation) configuration.
 	// Only used for telemetry currently.
 	orchestrionCfg orchestrionConfig
@@ -339,7 +336,6 @@ func newConfig(opts ...StartOption) (*config, error) {
 	c.dynamicInstrumentationEnabled.setOrigin(origin)
 
 	namingschema.LoadFromEnv()
-	c.spanAttributeSchemaVersion = int(namingschema.GetVersion())
 
 	// LLM Observability config
 	c.llmobs = llmobsconfig.Config{

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -59,7 +59,7 @@ func startTelemetry(c *config) telemetry.Client {
 		{Name: "profiling_endpoints_enabled", Value: c.internalConfig.ProfilerEndpoints()},
 		{Name: "debug_stack_enabled", Value: c.internalConfig.DebugStack()},
 		{Name: "profiling_hotspots_enabled", Value: c.internalConfig.ProfilerHotspotsEnabled()},
-		{Name: "trace_span_attribute_schema", Value: c.spanAttributeSchemaVersion},
+		{Name: "trace_span_attribute_schema", Value: c.internalConfig.SpanAttributeSchemaVersion()},
 		{Name: "trace_peer_service_defaults_enabled", Value: c.internalConfig.PeerServiceDefaultsEnabled()},
 		{Name: "orchestrion_enabled", Value: c.orchestrionCfg.Enabled, Origin: telemetry.OriginCode},
 		{Name: "trace_enabled", Value: traceEnabled, Origin: traceEnabledOrigin},

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -59,7 +59,6 @@ func startTelemetry(c *config) telemetry.Client {
 		{Name: "profiling_endpoints_enabled", Value: c.internalConfig.ProfilerEndpoints()},
 		{Name: "debug_stack_enabled", Value: c.internalConfig.DebugStack()},
 		{Name: "profiling_hotspots_enabled", Value: c.internalConfig.ProfilerHotspotsEnabled()},
-		{Name: "trace_span_attribute_schema", Value: c.internalConfig.SpanAttributeSchemaVersion()},
 		{Name: "trace_peer_service_defaults_enabled", Value: c.internalConfig.PeerServiceDefaultsEnabled()},
 		{Name: "orchestrion_enabled", Value: c.orchestrionCfg.Enabled, Origin: telemetry.OriginCode},
 		{Name: "trace_enabled", Value: traceEnabled, Origin: traceEnabledOrigin},

--- a/ddtrace/tracer/telemetry_test.go
+++ b/ddtrace/tracer/telemetry_test.go
@@ -73,7 +73,7 @@ func TestTelemetryEnabled(t *testing.T) {
 		telemetrytest.CheckConfig(t, telemetryClient.Configuration, "runtime_metrics_enabled", true)
 		telemetrytest.CheckConfig(t, telemetryClient.Configuration, "stats_computation_enabled", true)
 		telemetrytest.CheckConfig(t, telemetryClient.Configuration, "trace_enabled", true)
-		telemetrytest.CheckConfig(t, telemetryClient.Configuration, "DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", "")
+		telemetrytest.CheckConfig(t, telemetryClient.Configuration, "trace_span_attribute_schema", "")
 		telemetrytest.CheckConfig(t, telemetryClient.Configuration, "trace_peer_service_defaults_enabled", true)
 		telemetrytest.CheckConfig(t, telemetryClient.Configuration, "trace_peer_service_mapping", "key:val")
 		telemetrytest.CheckConfig(t, telemetryClient.Configuration, "debug_stack_enabled", false)

--- a/ddtrace/tracer/telemetry_test.go
+++ b/ddtrace/tracer/telemetry_test.go
@@ -73,7 +73,7 @@ func TestTelemetryEnabled(t *testing.T) {
 		telemetrytest.CheckConfig(t, telemetryClient.Configuration, "runtime_metrics_enabled", true)
 		telemetrytest.CheckConfig(t, telemetryClient.Configuration, "stats_computation_enabled", true)
 		telemetrytest.CheckConfig(t, telemetryClient.Configuration, "trace_enabled", true)
-		telemetrytest.CheckConfig(t, telemetryClient.Configuration, "trace_span_attribute_schema", 0)
+		telemetrytest.CheckConfig(t, telemetryClient.Configuration, "DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", "")
 		telemetrytest.CheckConfig(t, telemetryClient.Configuration, "trace_peer_service_defaults_enabled", true)
 		telemetrytest.CheckConfig(t, telemetryClient.Configuration, "trace_peer_service_mapping", "key:val")
 		telemetrytest.CheckConfig(t, telemetryClient.Configuration, "debug_stack_enabled", false)

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -984,7 +984,7 @@ func (t *tracer) StartSpan(operationName string, options ...StartSpanOption) *Sp
 	}
 	if span.metrics[keyTopLevel] == 1 {
 		// The span is the local root span.
-		span.setMetricInit(keySpanAttributeSchemaVersion, float64(t.config.spanAttributeSchemaVersion))
+		span.setMetricInit(keySpanAttributeSchemaVersion, float64(t.config.internalConfig.SpanAttributeSchemaVersion()))
 	}
 	span.setMetricInit(ext.Pid, float64(t.pid))
 	t.spansStarted.Inc(span.integration)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -788,6 +788,15 @@ func (c *Config) SetServiceMapping(from, to string, origin telemetry.Origin, pro
 	configtelemetry.Report("DD_SERVICE_MAPPING", strings.Join(all, ","), origin)
 }
 
+// SpanAttributeSchemaVersion returns the configured DD_TRACE_SPAN_ATTRIBUTE_SCHEMA version.
+// Read on the span-creation hot path; avoids defer to minimise lock cost.
+func (c *Config) SpanAttributeSchemaVersion() int {
+	c.mu.RLock()
+	v := c.spanAttributeSchemaVersion
+	c.mu.RUnlock()
+	return v
+}
+
 func (c *Config) PeerServiceDefaultsEnabled() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()


### PR DESCRIPTION
## Summary

- Adds a public `Config.SpanAttributeSchemaVersion()` getter on `internal/config.Config`. The field itself was already declared and initialised by `loadConfig`; this just exposes a public accessor.
- Removes the duplicate `spanAttributeSchemaVersion` field from the legacy tracer `config` struct and the `c.spanAttributeSchemaVersion = int(namingschema.GetVersion())` assignment in `newConfig`.
- Rewires the two readers (`telemetry.go` startup config and `tracer.go` `StartSpan` hot path) to read through the new getter.
- Getter avoids `defer` because it is read once per local-root span — matches the hot-path pattern from the peer-service migration (#4653) and the README guidance.
- `namingschema.LoadFromEnv()` is preserved: contrib packages still consume the namingschema global via `GetVersion()`.

Jira: [APMAPI-1887](https://datadoghq.atlassian.net/browse/APMAPI-1887)
EPIC: [APMAPI-1881](https://datadoghq.atlassian.net/browse/APMAPI-1881) — Go Config Revamp: Migrate tracer

## Test plan

- [x] `go build ./...`
- [x] `go vet ./ddtrace/tracer/... ./internal/config/...`
- [x] `go test ./internal/config/...`
- [x] `go test ./ddtrace/tracer/...` (full suite)
- [x] Existing `attribute_schema_is_set_v0/v1/wrong_value` (tracer_test.go) and `defaults-with-schema-v1` (option_test.go) pass without modification.

[APMAPI-1887]: https://datadoghq.atlassian.net/browse/APMAPI-1887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APMAPI-1881]: https://datadoghq.atlassian.net/browse/APMAPI-1881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ