### PR TITLE
perf(ddtrace/tracer): snapshot config in StartSpan to avoid RWMutex contention

### DIFF
--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -29,6 +29,7 @@ import (
 	globalinternal "github.com/DataDog/dd-trace-go/v2/internal"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec"
 	appsecConfig "github.com/DataDog/dd-trace-go/v2/internal/appsec/config"
+	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/datastreams"
 	"github.com/DataDog/dd-trace-go/v2/internal/globalconfig"
 	"github.com/DataDog/dd-trace-go/v2/internal/llmobs"
@@ -924,41 +925,45 @@ func (t *tracer) StartSpan(operationName string, options ...StartSpanOption) *Sp
 		return nil
 	}
 	span := spanStart(operationName, &t.sharedAttrs, options...)
+
+	// Snapshot all stable config fields needed below under a single RLock to avoid
+	// reader-counter contention on Config.mu when many goroutines call StartSpan.
+	snap := t.config.internalConfig.SpanStartSnapshot()
+
 	if span.service == "" {
-		span.service = t.config.internalConfig.ServiceName()
+		span.service = snap.ServiceName
 	}
 
 	// For non-universal version, promote main-service spans to the version-inclusive
 	// shared attrs before applying any tags. This makes the subsequent version write
 	// (from config or global tags) a COW no-op instead of triggering a Clone.
-	if !t.config.universalVersion && span.service == t.config.internalConfig.ServiceName() {
+	if !t.config.universalVersion && span.service == snap.ServiceName {
 		span.meta.ReplaceSharedAttrs(&t.sharedAttrs, &t.sharedAttrsForMainSvc)
 	}
 
-	cfg := t.config.internalConfig
-	span.noDebugStack = !cfg.DebugStack()
-	if hostname := cfg.Hostname(); hostname != "" && cfg.ReportHostname() {
-		span.setMetaInit(keyHostname, hostname)
+	span.noDebugStack = !snap.DebugStack
+	if snap.Hostname != "" && snap.ReportHostname {
+		span.setMetaInit(keyHostname, snap.Hostname)
 	}
 	span.supportsEvents = t.config.agent.load().spanEventsAvailable
 
 	// add global tags
 	span.setTags(t.config.globalTags.get())
 
-	if newSvc, ok := cfg.ServiceMapping(span.service); ok {
+	if newSvc, ok := t.config.internalConfig.ServiceMapping(span.service); ok {
 		span.service = newSvc
 		span.serviceSource = ext.ServiceSourceMapping
 	}
 
-	if ver := cfg.Version(); ver != "" {
-		if t.config.universalVersion || (!t.config.universalVersion && span.service == t.config.internalConfig.ServiceName()) {
+	if snap.Version != "" {
+		if t.config.universalVersion || span.service == snap.ServiceName {
 			delete(span.metrics, ext.Version)
-			span.meta.Set(ext.Version, ver)
+			span.meta.Set(ext.Version, snap.Version)
 		}
 	}
-	if env := cfg.Env(); env != "" {
+	if snap.Env != "" {
 		delete(span.metrics, ext.Environment)
-		span.meta.Set(ext.Environment, env)
+		span.meta.Set(ext.Environment, snap.Env)
 	}
 	if _, ok := span.context.SamplingPriority(); !ok {
 		// if not already sampled or a brand new trace, sample it
@@ -969,12 +974,12 @@ func (t *tracer) StartSpan(operationName string, options ...StartSpanOption) *Sp
 		log.Debug("Started Span: %v, Operation: %s, Resource: %s, Tags: %v, %v", //nolint:gocritic // Debug logging needs full span representation
 			span, span.name, span.resource, &span.meta, span.metrics)
 	}
-	if t.config.internalConfig.ProfilerHotspotsEnabled() || t.config.internalConfig.ProfilerEndpoints() {
-		t.applyPPROFLabels(span.pprofCtxRestore, span)
+	if snap.ProfilerHotspotsEnabled || snap.ProfilerEndpoints {
+		t.applyPPROFLabels(span.pprofCtxRestore, span, snap)
 	} else {
 		span.pprofCtxRestore = nil
 	}
-	if t.config.internalConfig.DebugAbandonedSpans() {
+	if snap.DebugAbandonedSpans {
 		select {
 		case t.abandonedSpansDebugger.In <- newAbandonedSpanCandidate(span, false):
 			// ok
@@ -997,21 +1002,21 @@ func (t *tracer) StartSpan(operationName string, options ...StartSpanOption) *Sp
 // found in ctx are restored. Additionally, this func informs the profiler how
 // many times each endpoint is called.
 // +checklocksignore — Initialization time, called from StartSpan before span is shared.
-func (t *tracer) applyPPROFLabels(ctx gocontext.Context, span *Span) {
+func (t *tracer) applyPPROFLabels(ctx gocontext.Context, span *Span, snap internalconfig.SpanStartSnapshot) {
 	// Important: The label keys are ordered alphabetically to take advantage of
 	// an upstream optimization that landed in go1.24.  This results in ~10%
 	// better performance on BenchmarkStartSpan. See
 	// https://go-review.googlesource.com/c/go/+/574516 for more information.
 	labels := make([]string, 0, 3*2 /* 3 key value pairs */)
 	localRootSpan := span.Root()
-	if t.config.internalConfig.ProfilerHotspotsEnabled() && localRootSpan != nil {
+	if snap.ProfilerHotspotsEnabled && localRootSpan != nil {
 		spanID := localRootSpan.getSpanID()
 		labels = append(labels, traceprof.LocalRootSpanID, strconv.FormatUint(spanID, 10))
 	}
-	if t.config.internalConfig.ProfilerHotspotsEnabled() {
+	if snap.ProfilerHotspotsEnabled {
 		labels = append(labels, traceprof.SpanID, strconv.FormatUint(span.spanID, 10))
 	}
-	if t.config.internalConfig.ProfilerEndpoints() && localRootSpan != nil {
+	if snap.ProfilerEndpoints && localRootSpan != nil {
 		resource := localRootSpan.getResource()
 		if spanResourcePIISafe(localRootSpan) {
 			labels = append(labels, traceprof.TraceEndpoint, resource)

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -926,24 +926,24 @@ func (t *tracer) StartSpan(operationName string, options ...StartSpanOption) *Sp
 	}
 	span := spanStart(operationName, &t.sharedAttrs, options...)
 
-	// Snapshot all stable config fields needed below under a single RLock to avoid
+	// Snapshot all internal config fields needed below under a single RLock to avoid
 	// reader-counter contention on Config.mu when many goroutines call StartSpan.
-	snap := t.config.internalConfig.SpanStartSnapshot()
+	cSnap := t.config.internalConfig.SpanStartSnapshot()
 
 	if span.service == "" {
-		span.service = snap.ServiceName
+		span.service = cSnap.ServiceName
 	}
 
 	// For non-universal version, promote main-service spans to the version-inclusive
 	// shared attrs before applying any tags. This makes the subsequent version write
 	// (from config or global tags) a COW no-op instead of triggering a Clone.
-	if !t.config.universalVersion && span.service == snap.ServiceName {
+	if !t.config.universalVersion && span.service == cSnap.ServiceName {
 		span.meta.ReplaceSharedAttrs(&t.sharedAttrs, &t.sharedAttrsForMainSvc)
 	}
 
-	span.noDebugStack = !snap.DebugStack
-	if snap.Hostname != "" && snap.ReportHostname {
-		span.setMetaInit(keyHostname, snap.Hostname)
+	span.noDebugStack = !cSnap.DebugStack
+	if cSnap.Hostname != "" && cSnap.ReportHostname {
+		span.setMetaInit(keyHostname, cSnap.Hostname)
 	}
 	span.supportsEvents = t.config.agent.load().spanEventsAvailable
 
@@ -955,15 +955,15 @@ func (t *tracer) StartSpan(operationName string, options ...StartSpanOption) *Sp
 		span.serviceSource = ext.ServiceSourceMapping
 	}
 
-	if snap.Version != "" {
-		if t.config.universalVersion || span.service == snap.ServiceName {
+	if cSnap.Version != "" {
+		if t.config.universalVersion || span.service == cSnap.ServiceName {
 			delete(span.metrics, ext.Version)
-			span.meta.Set(ext.Version, snap.Version)
+			span.meta.Set(ext.Version, cSnap.Version)
 		}
 	}
-	if snap.Env != "" {
+	if cSnap.Env != "" {
 		delete(span.metrics, ext.Environment)
-		span.meta.Set(ext.Environment, snap.Env)
+		span.meta.Set(ext.Environment, cSnap.Env)
 	}
 	if _, ok := span.context.SamplingPriority(); !ok {
 		// if not already sampled or a brand new trace, sample it
@@ -974,12 +974,12 @@ func (t *tracer) StartSpan(operationName string, options ...StartSpanOption) *Sp
 		log.Debug("Started Span: %v, Operation: %s, Resource: %s, Tags: %v, %v", //nolint:gocritic // Debug logging needs full span representation
 			span, span.name, span.resource, &span.meta, span.metrics)
 	}
-	if snap.ProfilerHotspotsEnabled || snap.ProfilerEndpoints {
-		t.applyPPROFLabels(span.pprofCtxRestore, span, snap)
+	if cSnap.ProfilerHotspotsEnabled || cSnap.ProfilerEndpoints {
+		t.applyPPROFLabels(span.pprofCtxRestore, span, cSnap)
 	} else {
 		span.pprofCtxRestore = nil
 	}
-	if snap.DebugAbandonedSpans {
+	if cSnap.DebugAbandonedSpans {
 		select {
 		case t.abandonedSpansDebugger.In <- newAbandonedSpanCandidate(span, false):
 			// ok

--- a/internal/config/README.md
+++ b/internal/config/README.md
@@ -62,6 +62,6 @@ for attempt := 0; attempt <= sendRetries; attempt++ {
 When a hot path reads ~3+ `Config` fields, define a snapshot struct + method in `snapshots.go` and have the caller read from the local copy.
 
 - **Why**: at high concurrency the bottleneck isn't blocking — readers don't block each other — but cache-line contention on `sync.RWMutex`'s reader counter. Folding N `RLock` pairs into 1 collapses N atomic ops on a shared cache line into 1.
-- **Convention**: one bespoke struct per caller. Don't build a generic `Snapshot(fields...)` API — see the comment at the top of `snapshots.go` for the reasoning.
+- **Convention**: one bespoke struct per caller (e.g, a calling function `StartSpan` gets a snapshot API called `SpanStartSnapshot`).
 - **Prior art**: `SpanStartSnapshot` for `tracer.StartSpan` (13 → 1 RLock acquisitions, ~60% speedup on `BenchmarkStartSpanConcurrent-8`).
 

--- a/internal/config/README.md
+++ b/internal/config/README.md
@@ -57,4 +57,11 @@ for attempt := 0; attempt <= sendRetries; attempt++ {
 }
 ```
 
+### Snapshot many-field hot paths under one lock
+
+When a hot path reads ~3+ `Config` fields, define a snapshot struct + method in `snapshots.go` and have the caller read from the local copy.
+
+- **Why**: at high concurrency the bottleneck isn't blocking — readers don't block each other — but cache-line contention on `sync.RWMutex`'s reader counter. Folding N `RLock` pairs into 1 collapses N atomic ops on a shared cache line into 1.
+- **Convention**: one bespoke struct per caller. Don't build a generic `Snapshot(fields...)` API — see the comment at the top of `snapshots.go` for the reasoning.
+- **Prior art**: `SpanStartSnapshot` for `tracer.StartSpan` (13 → 1 RLock acquisitions, ~60% speedup on `BenchmarkStartSpanConcurrent-8`).
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,6 +61,8 @@ type programmaticOverride struct {
 // Config represents global configuration properties.
 // Config instances should be obtained via Get() which always returns a non-nil value.
 // Methods on Config assume a non-nil receiver and will panic if called on nil.
+// Hot paths that read many fields should use a snapshot (see snapshots.go) to
+// avoid per-field RLock contention on the reader counter.
 type Config struct {
 	mu sync.RWMutex
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -971,38 +971,3 @@ func (c *Config) TraceID128BitEnabled() bool {
 	defer c.mu.RUnlock()
 	return c.traceID128BitEnabled
 }
-
-// SpanStartSnapshot bundles the config fields read by tracer.StartSpan so a single
-// RLock can fetch them all, instead of one RLock per field. The savings are not
-// from blocking — these are all readers — but from cache-line contention on the
-// RWMutex's reader counter at high concurrency.
-type SpanStartSnapshot struct {
-	ServiceName             string
-	Env                     string
-	Version                 string
-	Hostname                string
-	ReportHostname          bool
-	DebugStack              bool
-	DebugAbandonedSpans     bool
-	ProfilerHotspotsEnabled bool
-	ProfilerEndpoints       bool
-}
-
-// SpanStartSnapshot returns a snapshot of the config fields read by tracer.StartSpan.
-// Captured under a single RLock; service mappings are not included because the lookup
-// key (the resolved span service) isn't known until after this snapshot is read.
-func (c *Config) SpanStartSnapshot() SpanStartSnapshot {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return SpanStartSnapshot{
-		ServiceName:             c.serviceName,
-		Env:                     c.env,
-		Version:                 c.version,
-		Hostname:                c.hostname,
-		ReportHostname:          c.reportHostname,
-		DebugStack:              c.debugStack,
-		DebugAbandonedSpans:     c.debugAbandonedSpans,
-		ProfilerHotspotsEnabled: c.profilerHotspots,
-		ProfilerEndpoints:       c.profilerEndpoints,
-	}
-}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -971,3 +971,38 @@ func (c *Config) TraceID128BitEnabled() bool {
 	defer c.mu.RUnlock()
 	return c.traceID128BitEnabled
 }
+
+// SpanStartSnapshot bundles the config fields read by tracer.StartSpan so a single
+// RLock can fetch them all, instead of one RLock per field. The savings are not
+// from blocking — these are all readers — but from cache-line contention on the
+// RWMutex's reader counter at high concurrency.
+type SpanStartSnapshot struct {
+	ServiceName             string
+	Env                     string
+	Version                 string
+	Hostname                string
+	ReportHostname          bool
+	DebugStack              bool
+	DebugAbandonedSpans     bool
+	ProfilerHotspotsEnabled bool
+	ProfilerEndpoints       bool
+}
+
+// SpanStartSnapshot returns a snapshot of the config fields read by tracer.StartSpan.
+// Captured under a single RLock; service mappings are not included because the lookup
+// key (the resolved span service) isn't known until after this snapshot is read.
+func (c *Config) SpanStartSnapshot() SpanStartSnapshot {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return SpanStartSnapshot{
+		ServiceName:             c.serviceName,
+		Env:                     c.env,
+		Version:                 c.version,
+		Hostname:                c.hostname,
+		ReportHostname:          c.reportHostname,
+		DebugStack:              c.debugStack,
+		DebugAbandonedSpans:     c.debugAbandonedSpans,
+		ProfilerHotspotsEnabled: c.profilerHotspots,
+		ProfilerEndpoints:       c.profilerEndpoints,
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,7 +61,7 @@ type programmaticOverride struct {
 // Config represents global configuration properties.
 // Config instances should be obtained via Get() which always returns a non-nil value.
 // Methods on Config assume a non-nil receiver and will panic if called on nil.
-// Hot paths that read many fields should use a snapshot (see snapshots.go) to
+// Hot paths that read many fields within a single function should use a snapshot (see snapshots.go) to
 // avoid per-field RLock contention on the reader counter.
 type Config struct {
 	mu sync.RWMutex

--- a/internal/config/snapshots.go
+++ b/internal/config/snapshots.go
@@ -1,0 +1,50 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+// Snapshots bundle the config fields read by a single hot-path caller so they
+// can be fetched under one RLock instead of one RLock per field. The win is
+// not from blocking — these are all readers — but from cache-line contention
+// on the RWMutex's reader counter when many goroutines call the hot path
+// concurrently.
+//
+// Convention: one bespoke struct + method per caller. A generic
+// Snapshot(fields...) API would either box values through interface{} (costly
+// in a hot path) or expose unexported fields through a callback (no win over
+// adding a method here directly). Add a new struct + method below when a new
+// hot path needs more than ~3 fields under lock.
+
+package config
+
+// SpanStartSnapshot holds the config fields read by tracer.StartSpan.
+type SpanStartSnapshot struct {
+	ServiceName             string
+	Env                     string
+	Version                 string
+	Hostname                string
+	ReportHostname          bool
+	DebugStack              bool
+	DebugAbandonedSpans     bool
+	ProfilerHotspotsEnabled bool
+	ProfilerEndpoints       bool
+}
+
+// SpanStartSnapshot returns a snapshot of the config fields read by
+// tracer.StartSpan. Service mappings are not included because the lookup key
+// (the resolved span service) isn't known until after this snapshot is read.
+func (c *Config) SpanStartSnapshot() SpanStartSnapshot {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return SpanStartSnapshot{
+		ServiceName:             c.serviceName,
+		Env:                     c.env,
+		Version:                 c.version,
+		Hostname:                c.hostname,
+		ReportHostname:          c.reportHostname,
+		DebugStack:              c.debugStack,
+		DebugAbandonedSpans:     c.debugAbandonedSpans,
+		ProfilerHotspotsEnabled: c.profilerHotspots,
+		ProfilerEndpoints:       c.profilerEndpoints,
+	}
+}

--- a/internal/config/snapshots.go
+++ b/internal/config/snapshots.go
@@ -9,15 +9,11 @@
 // on the RWMutex's reader counter when many goroutines call the hot path
 // concurrently.
 //
-// Convention: one bespoke struct + method per caller. A generic
-// Snapshot(fields...) API would either box values through interface{} (costly
-// in a hot path) or expose unexported fields through a callback (no win over
-// adding a method here directly). Add a new struct + method below when a new
-// hot path needs more than ~3 fields under lock.
+// Add a new struct + method below when a new hot path needs more than ~3 fields
+// under the lock.
 
 package config
 
-// SpanStartSnapshot holds the config fields read by tracer.StartSpan.
 type SpanStartSnapshot struct {
 	ServiceName             string
 	Env                     string


### PR DESCRIPTION
### What does this PR do?

Adds `Config.SpanStartSnapshot()` to `internal/config`, which returns all the config fields read by `tracer.StartSpan` under a single `RLock`. `StartSpan` and `applyPPROFLabels` are updated to read from the snapshot instead of calling individual getters. Lock acquisitions per `StartSpan` drop from **13 → 2** (snapshot + `ServiceMapping(span.service)`, which can't be folded in because the lookup key isn't known until after the snapshot is read).

### Motivation

Each per-field getter on `internal/config.Config` acquires the same `sync.RWMutex` for read. These don't block each other, but every `RLock`/`RUnlock` does an atomic op on the mutex's internal reader counter — when StartSpan is invoked at high concurrency -- which it very well may be in many environments -- the counter cache line bounces across cores, so the read path scales negatively with parallelism. 

Benchmarks (Apple M3 Max, 5 runs, `-benchtime=3s`, via `benchstat`):

```
                      │ baseline   │  after      vs base
StartSpan             │  802.5 ns  │  773.9 ns       ~ (p=0.222)
StartSpan-8           │  643.6 ns  │  628.6 ns   -2.33% (p=0.016)
StartSpanConcurrent   │  817.2 ns  │  781.4 ns   -4.38% (p=0.008)
StartSpanConcurrent-8 │  937.6 ns  │  366.9 ns  -60.87% (p=0.008)
geomean               │  793.1 ns  │  611.1 ns  -22.95%
```

Allocation count and bytes/op are unchanged (15 allocs/op, ~1.5 KiB/op) across all four benchmarks. The single-goroutine cases barely move because uncontended atomics are cheap; the win is concentrated in the multi-core concurrent case (~2.5× speedup), which is exactly what we were targeting.

### Reviewer's Checklist

- [x] New code doesn't break existing tests (`./internal/config/...` and `./ddtrace/tracer/...` pass under `-race`).
- [x] There is a benchmark covering the change (existing `BenchmarkStartSpan`/`BenchmarkStartSpanConcurrent`).
- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] New code is free of linting errors.