### PR TITLE
fix(ci-visibility): avoid Go FailNow teardown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ static-analysis.datadog.yml
 coverage-*.txt
 
 # Editors and Agents
+/.codex/
 /.cursor
 /.vscode
 /.claude/*

--- a/internal/civisibility/integrations/gotesting/failnow/failnow_test.go
+++ b/internal/civisibility/integrations/gotesting/failnow/failnow_test.go
@@ -1,0 +1,407 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package failnow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"sync/atomic"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations"
+	gotesting "github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting"
+	civisibilitynet "github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/net"
+	"github.com/DataDog/dd-trace-go/v2/internal/env"
+)
+
+const scenarioEnv = "DD_FAILNOW_SCENARIO"
+
+var (
+	retryPassAttempts atomic.Int32
+	retryFailAttempts atomic.Int32
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv(scenarioEnv) == "" {
+		os.Exit(m.Run())
+	}
+	os.Exit(runScenario(m))
+}
+
+func TestManualFailNow(t *testing.T) {
+	runTestScenario(t, "test-failnow", "^TestManualFailNowFixture$")
+}
+
+func TestManualFatal(t *testing.T) {
+	runTestScenario(t, "test-fatal", "^TestManualFatalFixture$")
+}
+
+func TestManualFatalf(t *testing.T) {
+	runTestScenario(t, "test-fatalf", "^TestManualFatalfFixture$")
+}
+
+func TestManualFailNowRetryPasses(t *testing.T) {
+	runTestScenario(t, "test-failnow-retry-passes", "^TestManualFailNowRetryPassesFixture$")
+}
+
+func TestManualFailNowRetryFails(t *testing.T) {
+	runTestScenario(t, "test-failnow-retry-fails", "^TestManualFailNowRetryFailsFixture$")
+}
+
+func TestManualBenchmarkFailNow(t *testing.T) {
+	runBenchmarkScenario(t, "benchmark-failnow", "^BenchmarkManualFailNowFixture$")
+}
+
+func TestManualBenchmarkFatal(t *testing.T) {
+	runBenchmarkScenario(t, "benchmark-fatal", "^BenchmarkManualFatalFixture$")
+}
+
+func TestManualBenchmarkFatalf(t *testing.T) {
+	runBenchmarkScenario(t, "benchmark-fatalf", "^BenchmarkManualFatalfFixture$")
+}
+
+func TestManualFailNowFixture(t *testing.T) {
+	skipUnlessScenario(t, "test-failnow")
+	gt := gotesting.GetTest(t)
+	ctx := gt.Context()
+	t.Cleanup(func() { finishCleanupSpan(ctx, "manual.failnow.cleanup") })
+	gt.FailNow()
+}
+
+func TestManualFatalFixture(t *testing.T) {
+	skipUnlessScenario(t, "test-fatal")
+	gt := gotesting.GetTest(t)
+	ctx := gt.Context()
+	t.Cleanup(func() { finishCleanupSpan(ctx, "manual.fatal.cleanup") })
+	gt.Fatal("manual fatal")
+}
+
+func TestManualFatalfFixture(t *testing.T) {
+	skipUnlessScenario(t, "test-fatalf")
+	gt := gotesting.GetTest(t)
+	ctx := gt.Context()
+	t.Cleanup(func() { finishCleanupSpan(ctx, "manual.fatalf.cleanup") })
+	gt.Fatalf("manual %s", "fatalf")
+}
+
+func TestManualFailNowRetryPassesFixture(t *testing.T) {
+	skipUnlessScenario(t, "test-failnow-retry-passes")
+	gt := gotesting.GetTest(t)
+	ctx := gt.Context()
+	t.Cleanup(func() { finishCleanupSpan(ctx, "manual.failnow.retry.passes.cleanup") })
+	if retryPassAttempts.Add(1) < 3 {
+		gt.FailNow()
+	}
+}
+
+func TestManualFailNowRetryFailsFixture(t *testing.T) {
+	skipUnlessScenario(t, "test-failnow-retry-fails")
+	gt := gotesting.GetTest(t)
+	ctx := gt.Context()
+	t.Cleanup(func() { finishCleanupSpan(ctx, "manual.failnow.retry.fails.cleanup") })
+	retryFailAttempts.Add(1)
+	gt.FailNow()
+}
+
+func BenchmarkManualFailNowFixture(b *testing.B) {
+	skipUnlessScenario(b, "benchmark-failnow")
+	gb := gotesting.GetBenchmark(b)
+	ctx := gb.Context()
+	b.Cleanup(func() { finishCleanupSpan(ctx, "manual.benchmark.failnow.cleanup") })
+	gb.FailNow()
+}
+
+func BenchmarkManualFatalFixture(b *testing.B) {
+	skipUnlessScenario(b, "benchmark-fatal")
+	gb := gotesting.GetBenchmark(b)
+	ctx := gb.Context()
+	b.Cleanup(func() { finishCleanupSpan(ctx, "manual.benchmark.fatal.cleanup") })
+	gb.Fatal("manual fatal")
+}
+
+func BenchmarkManualFatalfFixture(b *testing.B) {
+	skipUnlessScenario(b, "benchmark-fatalf")
+	gb := gotesting.GetBenchmark(b)
+	ctx := gb.Context()
+	b.Cleanup(func() { finishCleanupSpan(ctx, "manual.benchmark.fatalf.cleanup") })
+	gb.Fatalf("manual %s", "fatalf")
+}
+
+func runScenario(m *testing.M) int {
+	scenario := os.Getenv(scenarioEnv)
+	settings := civisibilitynet.SettingsResponseData{}
+	if scenario == "test-failnow-retry-passes" || scenario == "test-failnow-retry-fails" {
+		settings.FlakyTestRetriesEnabled = true
+		_ = os.Setenv(constants.CIVisibilityFlakyRetryCountEnvironmentVariable, "2")
+		_ = os.Setenv(constants.CIVisibilityTotalFlakyRetryCountEnvironmentVariable, "10")
+	}
+	server, restore := startManualMockServer(settings)
+	defer restore()
+	_ = server
+
+	mt := integrations.InitializeCIVisibilityMock()
+	exitCode := gotesting.RunM(m)
+	validateScenario(scenario, mt.FinishedSpans(), exitCode)
+	return 0
+}
+
+func runTestScenario(t *testing.T, scenario, pattern string) {
+	runSubprocess(t, scenario, "-test.run", pattern)
+}
+
+func runBenchmarkScenario(t *testing.T, scenario, pattern string) {
+	runSubprocess(t, scenario, "-test.run", "^$", "-test.bench", pattern, "-test.benchtime=1x")
+}
+
+func runSubprocess(t *testing.T, scenario string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], args...)
+	cmd.Env = append(os.Environ(), scenarioEnv+"="+scenario)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("scenario %s failed: %v\n%s", scenario, err, output)
+	}
+}
+
+func skipUnlessScenario(tb testing.TB, scenario string) {
+	tb.Helper()
+	if os.Getenv(scenarioEnv) != scenario {
+		tb.Skip("fixture runs only in its subprocess scenario")
+	}
+}
+
+func finishCleanupSpan(ctx context.Context, resource string) {
+	span, _ := tracer.StartSpanFromContext(ctx, "manual.cleanup", tracer.ResourceName(resource))
+	if span != nil {
+		span.Finish()
+	}
+}
+
+func startManualMockServer(settings civisibilitynet.SettingsResponseData) (*httptest.Server, func()) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/libraries/tests/services/setting":
+			w.Header().Set("Content-Type", "application/json")
+			response := struct {
+				Data struct {
+					ID         string                               `json:"id"`
+					Type       string                               `json:"type"`
+					Attributes civisibilitynet.SettingsResponseData `json:"attributes"`
+				} `json:"data"`
+			}{}
+			response.Data.ID = "settings"
+			response.Data.Type = "ci_app_libraries_tests_settings"
+			response.Data.Attributes = settings
+			_ = json.NewEncoder(w).Encode(response)
+		case "/api/v2/git/repository/search_commits":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("{}"))
+		case "/api/v2/git/repository/packfile", "/api/v2/logs":
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	restore := setEnv(map[string]string{
+		constants.CIVisibilityAgentlessEnabledEnvironmentVariable: "1",
+		constants.CIVisibilityAgentlessURLEnvironmentVariable:     server.URL,
+		constants.APIKeyEnvironmentVariable:                       "12345",
+		"DD_GIT_REPOSITORY_URL":                                   "https://github.com/DataDog/dd-trace-go.git",
+		"DD_GIT_COMMIT_SHA":                                       "1234567890abcdef1234567890abcdef12345678",
+		"DD_GIT_BRANCH":                                           "main",
+	})
+	return server, func() {
+		restore()
+		server.Close()
+	}
+}
+
+func validateScenario(scenario string, spans []*mocktracer.Span, exitCode int) {
+	switch scenario {
+	case "test-failnow":
+		validateFailureScenario(spans, exitCode, "failnow_test.go.TestManualFailNowFixture", "manual.failnow.cleanup", "FailNow", "failed test", true)
+	case "test-fatal":
+		validateFailureScenario(spans, exitCode, "failnow_test.go.TestManualFatalFixture", "manual.fatal.cleanup", "Fatal", "manual fatal", true)
+	case "test-fatalf":
+		validateFailureScenario(spans, exitCode, "failnow_test.go.TestManualFatalfFixture", "manual.fatalf.cleanup", "Fatalf", "manual fatalf", true)
+	case "benchmark-failnow":
+		validateFailureScenario(spans, exitCode, "failnow_test.go.BenchmarkManualFailNowFixture", "manual.benchmark.failnow.cleanup", "FailNow", "failed test", false)
+	case "benchmark-fatal":
+		validateFailureScenario(spans, exitCode, "failnow_test.go.BenchmarkManualFatalFixture", "manual.benchmark.fatal.cleanup", "Fatal", "manual fatal", false)
+	case "benchmark-fatalf":
+		validateFailureScenario(spans, exitCode, "failnow_test.go.BenchmarkManualFatalfFixture", "manual.benchmark.fatalf.cleanup", "Fatalf", "manual fatalf", false)
+	case "test-failnow-retry-passes":
+		validateRetryPassScenario(spans, exitCode)
+	case "test-failnow-retry-fails":
+		validateRetryFailScenario(spans, exitCode)
+	default:
+		panic(fmt.Sprintf("unknown scenario %s", scenario))
+	}
+}
+
+func validateFailureScenario(spans []*mocktracer.Span, exitCode int, resource, cleanupResource, errorType, errorMessage string, expectFinalStatus bool) {
+	assertEqual("exit code", exitCode, 1)
+	assertSpanTypeCount(spans, constants.SpanTypeTestSession, 1)
+	assertSpanTypeCount(spans, constants.SpanTypeTestModule, 1)
+	assertSpanTypeCount(spans, constants.SpanTypeTestSuite, 1)
+
+	testSpans := spansByResource(spansByType(spans, constants.SpanTypeTest), resource)
+	assertEqual("test span count", len(testSpans), 1)
+	assertTag(testSpans[0], constants.TestStatus, constants.TestStatusFail)
+	if expectFinalStatus {
+		assertTag(testSpans[0], constants.TestFinalStatus, constants.TestStatusFail)
+	}
+	assertTag(testSpans[0], ext.ErrorType, errorType)
+	assertTag(testSpans[0], ext.ErrorMsg, errorMessage)
+	assertEqual("cleanup span count", len(spansByResource(spans, cleanupResource)), 1)
+
+	session := spansByType(spans, constants.SpanTypeTestSession)[0]
+	assertTag(session, constants.TestStatus, constants.TestStatusFail)
+	assertTag(session, ext.ErrorType, "ExitCode")
+	assertTag(session, ext.ErrorMsg, "exit code is not zero.")
+	assertNumericTag(session, constants.TestCommandExitCode, 1)
+}
+
+func validateRetryPassScenario(spans []*mocktracer.Span, exitCode int) {
+	assertEqual("exit code", exitCode, 0)
+	assertSpanTypeCount(spans, constants.SpanTypeTestSession, 1)
+	assertSpanTypeCount(spans, constants.SpanTypeTestModule, 1)
+	assertSpanTypeCount(spans, constants.SpanTypeTestSuite, 1)
+
+	session := spansByType(spans, constants.SpanTypeTestSession)[0]
+	assertTag(session, constants.TestStatus, constants.TestStatusPass)
+	assertNumericTag(session, constants.TestCommandExitCode, 0)
+
+	resource := "failnow_test.go.TestManualFailNowRetryPassesFixture"
+	testSpans := spansByResource(spansByType(spans, constants.SpanTypeTest), resource)
+	assertEqual("test span count", len(testSpans), 3)
+	assertEqual("cleanup span count", len(spansByResource(spans, "manual.failnow.retry.passes.cleanup")), 3)
+	assertTagCount(testSpans, constants.TestIsRetry, "true", 2)
+	assertTagCount(testSpans, constants.TestRetryReason, constants.AutoTestRetriesRetryReason, 2)
+	assertTagCount(testSpans, constants.TestStatus, constants.TestStatusFail, 2)
+	assertTagCount(testSpans, constants.TestStatus, constants.TestStatusPass, 1)
+	assertTagCount(testSpans, constants.TestFinalStatus, constants.TestStatusPass, 1)
+	assertTagCount(testSpans, constants.TestHasFailedAllRetries, "true", 0)
+}
+
+func validateRetryFailScenario(spans []*mocktracer.Span, exitCode int) {
+	assertEqual("exit code", exitCode, 1)
+	assertSpanTypeCount(spans, constants.SpanTypeTestSession, 1)
+	assertSpanTypeCount(spans, constants.SpanTypeTestModule, 1)
+	assertSpanTypeCount(spans, constants.SpanTypeTestSuite, 1)
+
+	session := spansByType(spans, constants.SpanTypeTestSession)[0]
+	assertTag(session, constants.TestStatus, constants.TestStatusFail)
+	assertTag(session, ext.ErrorType, "ExitCode")
+	assertTag(session, ext.ErrorMsg, "exit code is not zero.")
+	assertNumericTag(session, constants.TestCommandExitCode, 1)
+
+	resource := "failnow_test.go.TestManualFailNowRetryFailsFixture"
+	testSpans := spansByResource(spansByType(spans, constants.SpanTypeTest), resource)
+	assertEqual("test span count", len(testSpans), 3)
+	assertEqual("cleanup span count", len(spansByResource(spans, "manual.failnow.retry.fails.cleanup")), 3)
+	assertTagCount(testSpans, constants.TestIsRetry, "true", 2)
+	assertTagCount(testSpans, constants.TestRetryReason, constants.AutoTestRetriesRetryReason, 2)
+	assertTagCount(testSpans, constants.TestStatus, constants.TestStatusFail, 3)
+	assertTagCount(testSpans, constants.TestFinalStatus, constants.TestStatusFail, 1)
+	assertTagCount(testSpans, constants.TestHasFailedAllRetries, "true", 1)
+}
+
+func spansByType(spans []*mocktracer.Span, spanType string) []*mocktracer.Span {
+	var result []*mocktracer.Span
+	for _, span := range spans {
+		if span.Tag(ext.SpanType) == spanType {
+			result = append(result, span)
+		}
+	}
+	return result
+}
+
+func spansByResource(spans []*mocktracer.Span, resource string) []*mocktracer.Span {
+	var result []*mocktracer.Span
+	for _, span := range spans {
+		if span.Tag(ext.ResourceName) == resource {
+			result = append(result, span)
+		}
+	}
+	return result
+}
+
+func assertSpanTypeCount(spans []*mocktracer.Span, spanType string, expected int) {
+	assertEqual("span type "+spanType, len(spansByType(spans, spanType)), expected)
+}
+
+func assertTag(span *mocktracer.Span, key string, expected any) {
+	assertEqual("tag "+key, span.Tag(key), expected)
+}
+
+func assertNumericTag(span *mocktracer.Span, key string, expected float64) {
+	switch value := span.Tag(key).(type) {
+	case int:
+		if float64(value) == expected {
+			return
+		}
+	case int64:
+		if float64(value) == expected {
+			return
+		}
+	case float64:
+		if value == expected {
+			return
+		}
+	}
+	panic(fmt.Sprintf("expected numeric tag %s=%v, got %v", key, expected, span.Tag(key)))
+}
+
+func assertTagCount(spans []*mocktracer.Span, key string, expected any, count int) {
+	var actual int
+	for _, span := range spans {
+		if span.Tag(key) == expected {
+			actual++
+		}
+	}
+	assertEqual("tag count "+key, actual, count)
+}
+
+func assertEqual(label string, actual, expected any) {
+	if actual != expected {
+		panic(fmt.Sprintf("expected %s to be %v, got %v", label, expected, actual))
+	}
+}
+
+type envSnapshot struct {
+	key   string
+	value string
+	had   bool
+}
+
+func setEnv(values map[string]string) func() {
+	snapshots := make([]envSnapshot, 0, len(values))
+	for key, value := range values {
+		old, had := env.Lookup(key)
+		snapshots = append(snapshots, envSnapshot{key: key, value: old, had: had})
+		_ = os.Setenv(key, value)
+	}
+	return func() {
+		for i := len(snapshots) - 1; i >= 0; i-- {
+			if snapshots[i].had {
+				_ = os.Setenv(snapshots[i].key, snapshots[i].value)
+			} else {
+				_ = os.Unsetenv(snapshots[i].key)
+			}
+		}
+	}
+}

--- a/internal/civisibility/integrations/gotesting/orchestrion.yml
+++ b/internal/civisibility/integrations/gotesting/orchestrion.yml
@@ -41,7 +41,6 @@ aspects:
       - inject-declarations:
           links:
             - github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting
-            - github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations
           template: |-
             //go:linkname __dd_civisibility_instrumentTestingTFunc github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting.instrumentTestingTFunc
             func __dd_civisibility_instrumentTestingTFunc(func(*T)) func(*T)
@@ -57,9 +56,6 @@ aspects:
             
             //go:linkname __dd_civisibility_instrumentTestingParallel github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting.instrumentTestingParallel
             func __dd_civisibility_instrumentTestingParallel(t *T) bool
-
-            //go:linkname __dd_civisibility_ExitCiVisibility github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations.ExitCiVisibility
-            func __dd_civisibility_ExitCiVisibility()
 
       - prepend-statements:
           template: |-
@@ -109,7 +105,6 @@ aspects:
       - prepend-statements:
           template: |-
             __dd_civisibility_instrumentSetErrorInfo({{ .Function.Receiver }}, "FailNow", "failed test", 0)
-            defer __dd_civisibility_ExitCiVisibility()
 
   - id: common.Error
     join-point:

--- a/internal/civisibility/integrations/gotesting/testingB.go
+++ b/internal/civisibility/integrations/gotesting/testingB.go
@@ -13,8 +13,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations"
 )
 
 var (
@@ -73,7 +71,6 @@ func (ddb *B) Fail() { ddb.getBWithError("Fail", "failed test").Fail() }
 // those other goroutines.
 func (ddb *B) FailNow() {
 	b := ddb.getBWithError("FailNow", "failed test")
-	integrations.ExitCiVisibility()
 	b.FailNow()
 }
 

--- a/internal/civisibility/integrations/gotesting/testingT.go
+++ b/internal/civisibility/integrations/gotesting/testingT.go
@@ -10,8 +10,6 @@ import (
 	"fmt"
 	"testing"
 	"time"
-
-	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations"
 )
 
 // T is a type alias for testing.T to provide additional methods for CI visibility.
@@ -54,7 +52,6 @@ func (ddt *T) Fail() { ddt.getTWithError("Fail", "failed test").Fail() }
 // those other goroutines.
 func (ddt *T) FailNow() {
 	t := ddt.getTWithError("FailNow", "failed test")
-	integrations.ExitCiVisibility()
 	t.FailNow()
 }
 

--- a/internal/orchestrion/_integration/civisibility_failnow/testing_test.go
+++ b/internal/orchestrion/_integration/civisibility_failnow/testing_test.go
@@ -1,0 +1,97 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package civisibility_failnow
+
+import (
+	"os"
+	"testing"
+
+	"github.com/DataDog/orchestrion/runtime/built"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/net"
+	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion/_integration/civisibilitytest"
+)
+
+var ciVisibilityPayloads *civisibilitytest.Payloads
+
+func TestMain(m *testing.M) {
+	if !built.WithOrchestrion {
+		panic("Orchestrion is not enabled, please run this test with orchestrion")
+	}
+
+	settings := net.SettingsResponseData{}
+	server, payloads, restore := civisibilitytest.StartMockServer(settings)
+	defer restore()
+	_ = server
+	ciVisibilityPayloads = payloads
+
+	exitCode := m.Run()
+	if exitCode != 1 {
+		panic("expected m.Run to fail with exit code 1")
+	}
+
+	validateFailNowEvents(ciVisibilityPayloads.Events())
+	os.Exit(0)
+}
+
+func TestFailNowDoesNotTearDownCIVisibility(t *testing.T) {
+	t.Run("Require", func(t *testing.T) {
+		require.FailNow(t, "require failure")
+	})
+	t.Run("FailNow", func(t *testing.T) {
+		t.FailNow()
+	})
+	t.Run("Fatal", func(t *testing.T) {
+		t.Fatal("fatal failure")
+	})
+	t.Run("Fatalf", func(t *testing.T) {
+		t.Fatalf("fatalf %s", "failure")
+	})
+	t.Run("After", func(t *testing.T) {})
+}
+
+func validateFailNowEvents(events civisibilitytest.Events) {
+	events.CheckEventsByType("test_session_end", 1).
+		CheckEventsByTagAndValue("test.status", "fail", 1).
+		CheckEventsByTagAndValue("error.type", "ExitCode", 1).
+		CheckEventsByTagAndValue("error.message", "exit code is not zero.", 1).
+		CheckEventsByMetricAndValue("test.exit_code", 1, 1)
+	events.CheckEventsByType("test_module_end", 1)
+	events.CheckEventsByType("test_suite_end", 1)
+
+	testEvents := events.CheckEventsByType("test", 6)
+	parent := testEvents.
+		CheckEventsByResourceName("testing_test.go.TestFailNowDoesNotTearDownCIVisibility", 1).
+		CheckEventsByTagAndValue("test.status", "fail", 1)
+	requireFailure := testEvents.
+		CheckEventsByResourceName("testing_test.go.TestFailNowDoesNotTearDownCIVisibility/Require", 1).
+		CheckEventsByTagAndValue("test.status", "fail", 1).
+		CheckEventsByTagAndValue("error.type", "Errorf", 1)
+	failNow := testEvents.
+		CheckEventsByResourceName("testing_test.go.TestFailNowDoesNotTearDownCIVisibility/FailNow", 1).
+		CheckEventsByTagAndValue("test.status", "fail", 1).
+		CheckEventsByTagAndValue("test.final_status", "fail", 1).
+		CheckEventsByTagAndValue("error.type", "FailNow", 1).
+		CheckEventsByTagAndValue("error.message", "failed test", 1)
+	fatal := testEvents.
+		CheckEventsByResourceName("testing_test.go.TestFailNowDoesNotTearDownCIVisibility/Fatal", 1).
+		CheckEventsByTagAndValue("test.status", "fail", 1).
+		CheckEventsByTagAndValue("test.final_status", "fail", 1).
+		CheckEventsByTagAndValue("error.type", "Fatal", 1).
+		CheckEventsByTagAndValue("error.message", "fatal failure", 1)
+	fatalf := testEvents.
+		CheckEventsByResourceName("testing_test.go.TestFailNowDoesNotTearDownCIVisibility/Fatalf", 1).
+		CheckEventsByTagAndValue("test.status", "fail", 1).
+		CheckEventsByTagAndValue("test.final_status", "fail", 1).
+		CheckEventsByTagAndValue("error.type", "Fatalf", 1).
+		CheckEventsByTagAndValue("error.message", "fatalf failure", 1)
+	after := testEvents.
+		CheckEventsByResourceName("testing_test.go.TestFailNowDoesNotTearDownCIVisibility/After", 1).
+		CheckEventsByTagAndValue("test.status", "pass", 1)
+
+	testEvents.Except(parent, requireFailure, failNow, fatal, fatalf, after).HasCount(0)
+}

--- a/internal/orchestrion/_integration/civisibility_failnow_benchmark/benchmark_test.go
+++ b/internal/orchestrion/_integration/civisibility_failnow_benchmark/benchmark_test.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package civisibility_failnow_benchmark
+
+import (
+	"os"
+	"testing"
+
+	"github.com/DataDog/orchestrion/runtime/built"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/net"
+	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion/_integration/civisibilitytest"
+)
+
+var ciVisibilityPayloads *civisibilitytest.Payloads
+
+func TestMain(m *testing.M) {
+	if !built.WithOrchestrion {
+		panic("Orchestrion is not enabled, please run this test with orchestrion")
+	}
+
+	settings := net.SettingsResponseData{}
+	server, payloads, restore := civisibilitytest.StartMockServer(settings)
+	defer restore()
+	_ = server
+	ciVisibilityPayloads = payloads
+
+	exitCode := m.Run()
+	if exitCode != 1 {
+		panic("expected m.Run to fail with exit code 1")
+	}
+
+	validateBenchmarkEvents(ciVisibilityPayloads.Events())
+	os.Exit(0)
+}
+
+func BenchmarkFailNow(b *testing.B) {
+	b.FailNow()
+}
+
+func BenchmarkAfterFailNow(b *testing.B) {
+	for b.Loop() {
+	}
+}
+
+func validateBenchmarkEvents(events civisibilitytest.Events) {
+	events.CheckEventsByType("test_session_end", 1).
+		CheckEventsByTagAndValue("test.status", "fail", 1).
+		CheckEventsByTagAndValue("error.type", "ExitCode", 1).
+		CheckEventsByTagAndValue("error.message", "exit code is not zero.", 1).
+		CheckEventsByMetricAndValue("test.exit_code", 1, 1)
+	events.CheckEventsByType("test_module_end", 1)
+	events.CheckEventsByType("test_suite_end", 1)
+
+	testEvents := events.CheckEventsByType("test", 2)
+	failNow := testEvents.
+		CheckEventsByResourceName("benchmark_test.go.BenchmarkFailNow", 1).
+		CheckEventsByTagAndValue("test.status", "fail", 1).
+		CheckEventsByTagAndValue("error.type", "FailNow", 1).
+		CheckEventsByTagAndValue("error.message", "failed test", 1)
+	after := testEvents.
+		CheckEventsByResourceName("benchmark_test.go.BenchmarkAfterFailNow", 1).
+		CheckEventsByTagAndValue("test.status", "pass", 1)
+
+	testEvents.Except(failNow, after).HasCount(0)
+}

--- a/internal/orchestrion/_integration/civisibility_failnow_retry/testing_test.go
+++ b/internal/orchestrion/_integration/civisibility_failnow_retry/testing_test.go
@@ -1,0 +1,72 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package civisibility_failnow_retry
+
+import (
+	"os"
+	"testing"
+
+	"github.com/DataDog/orchestrion/runtime/built"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/net"
+	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion/_integration/civisibilitytest"
+)
+
+var ciVisibilityPayloads *civisibilitytest.Payloads
+
+func TestMain(m *testing.M) {
+	if !built.WithOrchestrion {
+		panic("Orchestrion is not enabled, please run this test with orchestrion")
+	}
+
+	settings := net.SettingsResponseData{FlakyTestRetriesEnabled: true}
+	server, payloads, restore := civisibilitytest.StartMockServer(settings)
+	defer restore()
+	_ = server
+	ciVisibilityPayloads = payloads
+	_ = os.Setenv("DD_CIVISIBILITY_FLAKY_RETRY_COUNT", "2")
+	_ = os.Setenv("DD_CIVISIBILITY_TOTAL_FLAKY_RETRY_COUNT", "10")
+
+	exitCode := m.Run()
+	if exitCode != 1 {
+		panic("expected m.Run to fail with exit code 1")
+	}
+
+	validateRetryEvents(ciVisibilityPayloads.Events())
+	os.Exit(0)
+}
+
+func TestRetryFatalAlwaysFails(t *testing.T) {
+	t.Fatal("retry fatal")
+}
+
+func TestAfterRetryFatal(t *testing.T) {}
+
+func validateRetryEvents(events civisibilitytest.Events) {
+	events.CheckEventsByType("test_session_end", 1).
+		CheckEventsByTagAndValue("test.status", "fail", 1).
+		CheckEventsByTagAndValue("error.type", "ExitCode", 1).
+		CheckEventsByTagAndValue("error.message", "exit code is not zero.", 1).
+		CheckEventsByMetricAndValue("test.exit_code", 1, 1)
+	events.CheckEventsByType("test_module_end", 1)
+	events.CheckEventsByType("test_suite_end", 1)
+
+	testEvents := events.CheckEventsByType("test", 4)
+	retries := testEvents.
+		CheckEventsByResourceName("testing_test.go.TestRetryFatalAlwaysFails", 3).
+		CheckEventsByTagAndValue("test.status", "fail", 3).
+		CheckEventsByTagAndValue("error.type", "Fatal", 3).
+		CheckEventsByTagAndValue("error.message", "retry fatal", 3)
+	retries.CheckEventsByTagAndValue("test.is_retry", "true", 2)
+	retries.CheckEventsByTagAndValue("test.retry_reason", "auto_test_retry", 2)
+	retries.CheckEventsByTagAndValue("test.has_failed_all_retries", "true", 1)
+	retries.CheckEventsByTagAndValue("test.final_status", "fail", 1)
+	after := testEvents.
+		CheckEventsByResourceName("testing_test.go.TestAfterRetryFatal", 1).
+		CheckEventsByTagAndValue("test.status", "pass", 1)
+
+	testEvents.Except(retries, after).HasCount(0)
+}

--- a/internal/orchestrion/_integration/civisibilitytest/payloads.go
+++ b/internal/orchestrion/_integration/civisibilitytest/payloads.go
@@ -1,0 +1,295 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package civisibilitytest
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+
+	"github.com/tinylib/msgp/msgp"
+
+	civisibilitynet "github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/net"
+	"github.com/DataDog/dd-trace-go/v2/internal/env"
+)
+
+// Payloads stores decoded CI Visibility test-cycle payloads received by the mock intake.
+type Payloads struct {
+	mu       sync.Mutex
+	payloads []*Payload
+}
+
+// Payload is the decoded CI Visibility test-cycle payload shape used by the fixtures.
+type Payload struct {
+	Version  int      `json:"version"`
+	Metadata Metadata `json:"metadata"`
+	Events   Events   `json:"events"`
+}
+
+// Metadata is the decoded metadata block included in CI Visibility payloads.
+type Metadata struct {
+	All            MetadataAll   `json:"*"`
+	TestSessionEnd MetadataOther `json:"test_session_end"`
+	TestModuleEnd  MetadataOther `json:"test_module_end"`
+	TestSuiteEnd   MetadataOther `json:"test_suite_end"`
+	Test           MetadataOther `json:"test"`
+}
+
+// MetadataAll is the decoded payload-wide metadata shape.
+type MetadataAll struct {
+	Language       string `json:"language"`
+	LibraryVersion string `json:"library_version"`
+	RuntimeID      string `json:"runtime-id"`
+}
+
+// MetadataOther is the decoded per-event metadata shape.
+type MetadataOther struct {
+	TestSessionName string `json:"test_session.name"`
+}
+
+// Events is a collection of decoded CI Visibility events with assertion helpers.
+type Events []Event
+
+// Event is a decoded CI Visibility event.
+type Event struct {
+	Type    string  `json:"type"`
+	Version int     `json:"version"`
+	Content Content `json:"content"`
+}
+
+// Content is the decoded span content for a CI Visibility event.
+type Content struct {
+	TestSessionID uint64             `json:"test_session_id"`
+	TestModuleID  uint64             `json:"test_module_id"`
+	TestSuiteID   uint64             `json:"test_suite_id"`
+	SpanID        uint64             `json:"span_id"`
+	TraceID       uint64             `json:"trace_id"`
+	Name          string             `json:"name"`
+	Service       string             `json:"service"`
+	Resource      string             `json:"resource"`
+	Type          string             `json:"type"`
+	Start         uint64             `json:"start"`
+	Duration      uint               `json:"duration"`
+	Error         int                `json:"error"`
+	Meta          map[string]string  `json:"meta"`
+	Metrics       map[string]float64 `json:"metrics"`
+}
+
+// StartMockServer starts an agentless CI Visibility intake mock and configures the process environment.
+func StartMockServer(settings civisibilitynet.SettingsResponseData) (*httptest.Server, *Payloads, func()) {
+	payloads := &Payloads{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/citestcycle":
+			payloads.handleTestCycle(w, r)
+		case "/api/v2/libraries/tests/services/setting":
+			w.Header().Set("Content-Type", "application/json")
+			response := struct {
+				Data struct {
+					ID         string                               `json:"id"`
+					Type       string                               `json:"type"`
+					Attributes civisibilitynet.SettingsResponseData `json:"attributes"`
+				} `json:"data"`
+			}{}
+			response.Data.ID = "settings"
+			response.Data.Type = "ci_app_libraries_tests_settings"
+			response.Data.Attributes = settings
+			_ = json.NewEncoder(w).Encode(response)
+		case "/api/v2/git/repository/search_commits":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("{}"))
+		case "/api/v2/git/repository/packfile", "/api/v2/logs":
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	restore := setEnv(map[string]string{
+		"DD_CIVISIBILITY_ENABLED":           "true",
+		"DD_CIVISIBILITY_AGENTLESS_ENABLED": "true",
+		"DD_CIVISIBILITY_AGENTLESS_URL":     server.URL,
+		"DD_API_KEY":                        "***",
+		"DD_GIT_REPOSITORY_URL":             "https://github.com/DataDog/dd-trace-go.git",
+		"DD_GIT_COMMIT_SHA":                 "1234567890abcdef1234567890abcdef12345678",
+		"DD_GIT_BRANCH":                     "main",
+	})
+
+	return server, payloads, func() {
+		restore()
+		server.Close()
+	}
+}
+
+func (p *Payloads) handleTestCycle(w http.ResponseWriter, r *http.Request) {
+	body, err := decodeTestCycleBody(r.Body)
+	if err != nil {
+		log.Println(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	var payload Payload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		log.Println(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	p.mu.Lock()
+	p.payloads = append(p.payloads, &payload)
+	p.mu.Unlock()
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func decodeTestCycleBody(body io.Reader) ([]byte, error) {
+	gzipReader, err := gzip.NewReader(body)
+	if err != nil {
+		return nil, err
+	}
+	defer gzipReader.Close()
+
+	var jsonBuf bytes.Buffer
+	if _, err := msgp.CopyToJSON(&jsonBuf, gzipReader); err != nil {
+		return nil, err
+	}
+	return jsonBuf.Bytes(), nil
+}
+
+// Events returns all decoded events received so far.
+func (p *Payloads) Events() Events {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var events Events
+	for _, payload := range p.payloads {
+		events = append(events, payload.Events...)
+	}
+	return events
+}
+
+// CheckEventsByType returns events with the given type and panics if the count does not match.
+func (e Events) CheckEventsByType(eventType string, count int) Events {
+	var result Events
+	for _, event := range e {
+		if event.Type == eventType {
+			result = append(result, event)
+		}
+	}
+	if len(result) != count {
+		panic(fmt.Sprintf("expected exactly %d event(s) with type %s, got %d", count, eventType, len(result)))
+	}
+	return result
+}
+
+// CheckEventsByResourceName returns events with the given resource and panics if the count does not match.
+func (e Events) CheckEventsByResourceName(resourceName string, count int) Events {
+	var result Events
+	for _, event := range e {
+		if event.Content.Resource == resourceName {
+			result = append(result, event)
+		}
+	}
+	if len(result) != count {
+		e.ShowResourceNames()
+		panic(fmt.Sprintf("expected exactly %d event(s) with resource %s, got %d", count, resourceName, len(result)))
+	}
+	return result
+}
+
+// CheckEventsByTagAndValue returns events with the given meta tag value and panics if the count does not match.
+func (e Events) CheckEventsByTagAndValue(tagName, tagValue string, count int) Events {
+	var result Events
+	for _, event := range e {
+		if value, ok := event.Content.Meta[tagName]; ok && value == tagValue {
+			result = append(result, event)
+		}
+	}
+	if len(result) != count {
+		panic(fmt.Sprintf("expected exactly %d event(s) with tag %s=%s, got %d", count, tagName, tagValue, len(result)))
+	}
+	return result
+}
+
+// CheckEventsByMetricAndValue returns events with the given metric value and panics if the count does not match.
+func (e Events) CheckEventsByMetricAndValue(metricName string, metricValue float64, count int) Events {
+	var result Events
+	for _, event := range e {
+		if value, ok := event.Content.Metrics[metricName]; ok && value == metricValue {
+			result = append(result, event)
+		}
+	}
+	if len(result) != count {
+		panic(fmt.Sprintf("expected exactly %d event(s) with metric %s=%v, got %d", count, metricName, metricValue, len(result)))
+	}
+	return result
+}
+
+// Except returns events whose resource does not appear in any provided event collection.
+func (e Events) Except(groups ...Events) Events {
+	var filtered Events
+	for _, event := range e {
+		contains := false
+		for _, group := range groups {
+			for _, candidate := range group {
+				if event.Content.Resource == candidate.Content.Resource {
+					contains = true
+				}
+			}
+		}
+		if !contains {
+			filtered = append(filtered, event)
+		}
+	}
+	return filtered
+}
+
+// HasCount panics if the number of events does not match count.
+func (e Events) HasCount(count int) Events {
+	if len(e) != count {
+		e.ShowResourceNames()
+		panic(fmt.Sprintf("expected exactly %d event(s), got %d", count, len(e)))
+	}
+	return e
+}
+
+// ShowResourceNames prints event resources to help diagnose failed assertions.
+func (e Events) ShowResourceNames() Events {
+	for i, event := range e {
+		_, _ = fmt.Printf("  [%d] = type:%s resource:%s\n", i, event.Type, event.Content.Resource)
+	}
+	return e
+}
+
+type envSnapshot struct {
+	key   string
+	value string
+	had   bool
+}
+
+func setEnv(values map[string]string) func() {
+	snapshots := make([]envSnapshot, 0, len(values))
+	for key, value := range values {
+		old, had := env.Lookup(key)
+		snapshots = append(snapshots, envSnapshot{key: key, value: old, had: had})
+		_ = os.Setenv(key, value)
+	}
+	return func() {
+		for i := len(snapshots) - 1; i >= 0; i-- {
+			if snapshots[i].had {
+				_ = os.Setenv(snapshots[i].key, snapshots[i].value)
+			} else {
+				_ = os.Unsetenv(snapshots[i].key)
+			}
+		}
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Prevents Go CI Visibility from shutting down the tracer when a test or benchmark calls `FailNow`.

`testing.T.FailNow` and `testing.B.FailNow` stop the current test goroutine via `runtime.Goexit`; they do not end the whole test process. The previous CI Visibility wrappers and Orchestrion advice called `ExitCiVisibility()` from those paths, which could close the span pipeline mid-package and drop later test spans, retry attempts, and cleanup-created spans.

This PR removes the premature teardown from:
- `gotesting.T.FailNow`
- `gotesting.B.FailNow`
- Orchestrion instrumentation of `testing.common.FailNow`

The real process teardown paths are left unchanged: `M.Run`, signal handling, panic/re-panic paths, benchmark panic finalization, retry re-panic, and close actions still call `ExitCiVisibility()`.

It also adds regression coverage for direct wrappers and Orchestrion-instrumented tests, including fatal assertions, retries, benchmarks, and cleanup spans created after `FailNow`. No new dependency is introduced; module files are unchanged.

### Motivation

A customer reported that when any Go test called `FailNow`, `Fatal`, `Fatalf`, or `require.*`, subsequent tests in the package were silently missing from CI Visibility and ATR retry spans were not reported.

The root cause was that CI Visibility treated `FailNow` like a process exit, but Go only stops the current test or benchmark. Closing CI Visibility there loses spans that are created later in the same process.

### Testing

- [x] `go test ./internal/civisibility/integrations/gotesting/failnow -count=1`
- [x] `go test ./internal/civisibility/integrations/gotesting/... -count=1`
- [x] `cd internal/orchestrion/_integration && go run github.com/DataDog/orchestrion go test ./civisibility -count=1`
- [x] `cd internal/orchestrion/_integration && go run github.com/DataDog/orchestrion go test ./civisibility_failnow -count=1`
- [x] `cd internal/orchestrion/_integration && go run github.com/DataDog/orchestrion go test ./civisibility_failnow_retry -count=1`
- [x] `cd internal/orchestrion/_integration && go run github.com/DataDog/orchestrion go test ./civisibility_failnow_benchmark -run '^$' -bench . -benchtime=1x -count=1`
- [x] `go test ./internal/orchestrion/_integration/civisibilitytest`
- [x] `git diff --check`
- [x] Verified `go.mod` and `go.sum` are unchanged in both the root module and Orchestrion integration module.