### PR TITLE
fix(tracer): enforce baggage item and byte limits on extraction

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -1441,27 +1441,29 @@ func (*propagatorBaggage) extractTextMap(reader TextMapReader) (*SpanContext, er
 		return &ctx, nil
 	}
 
-	parts := strings.Split(baggageHeader, ",")
-
-	// 1) validation & single-trim pass
-	for i, kv := range parts {
+	// Single pass: enforce baggageMaxItems and baggageMaxBytes, validate, and apply.
+	ctr := 0
+	byteCount := 0
+	for kv := range strings.SplitSeq(baggageHeader, ",") {
+		itemBytes := len(kv)
+		if ctr > 0 {
+			itemBytes++ // comma separator
+		}
+		if ctr >= baggageMaxItems || byteCount+itemBytes > baggageMaxBytes {
+			break
+		}
 		k, v, ok := strings.Cut(kv, "=")
 		trimmedK := strings.TrimSpace(k)
 		trimmedV := strings.TrimSpace(v)
 		if !ok || trimmedK == "" || trimmedV == "" {
 			log.Warn("invalid baggage item: %q, dropping entire header", kv)
-			return &ctx, nil
+			return &SpanContext{}, nil
 		}
-		// store back the trimmed pair so we don't re-trim below
-		parts[i] = trimmedK + "=" + trimmedV
-	}
-
-	// 2) safe to URL-decode & apply
-	for _, kv := range parts {
-		rawK, rawV, _ := strings.Cut(kv, "=")
-		key, _ := url.QueryUnescape(rawK)
-		val, _ := url.QueryUnescape(rawV)
+		key, _ := url.QueryUnescape(trimmedK)
+		val, _ := url.QueryUnescape(trimmedV)
 		ctx.setBaggageItem(key, val)
+		byteCount += itemBytes
+		ctr++
 	}
 
 	return &ctx, nil

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -1449,7 +1449,12 @@ func (*propagatorBaggage) extractTextMap(reader TextMapReader) (*SpanContext, er
 		if ctr > 0 {
 			itemBytes++ // comma separator
 		}
-		if ctr >= baggageMaxItems || byteCount+itemBytes > baggageMaxBytes {
+		if ctr >= baggageMaxItems {
+			log.Warn("baggage item count exceeded limit (%d), dropping remaining items", baggageMaxItems)
+			break
+		}
+		if byteCount+itemBytes > baggageMaxBytes {
+			log.Warn("baggage byte limit exceeded (%d), dropping remaining items", baggageMaxBytes)
 			break
 		}
 		k, v, ok := strings.Cut(kv, "=")

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -2892,6 +2892,127 @@ func TestExtractBaggagePropagatorMalformedHeader(t *testing.T) {
 	})
 }
 
+func TestExtractBaggagePropagatorMaxItems(t *testing.T) {
+	tracer, err := newTracer()
+	assert.NoError(t, err)
+	defer tracer.Stop()
+
+	var b strings.Builder
+	for i := 0; i < baggageMaxItems+5; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		iStr := strconv.Itoa(i)
+		b.WriteString("key" + iStr + "=val" + iStr)
+	}
+
+	headers := TextMapCarrier{
+		DefaultTraceIDHeader:  "4",
+		DefaultParentIDHeader: "1",
+		DefaultBaggageHeader:  b.String(),
+	}
+	s, err := tracer.Extract(headers)
+	assert.NoError(t, err)
+
+	got := make(map[string]string)
+	s.ForeachBaggageItem(func(k, v string) bool {
+		got[k] = v
+		return true
+	})
+	assert.Len(t, got, baggageMaxItems)
+	for i := 0; i < baggageMaxItems; i++ {
+		iStr := strconv.Itoa(i)
+		assert.Equal(t, "val"+iStr, got["key"+iStr])
+	}
+	for i := baggageMaxItems; i < baggageMaxItems+5; i++ {
+		iStr := strconv.Itoa(i)
+		_, present := got["key"+iStr]
+		assert.False(t, present, "key%s should not be present", iStr)
+	}
+}
+
+func TestExtractBaggagePropagatorMaxBytes(t *testing.T) {
+	tracer, err := newTracer()
+	assert.NoError(t, err)
+	defer tracer.Stop()
+
+	// 12 items, each "keyN=" + 1000 'a's = 1005 wire bytes. Including comma
+	// separators, the first 8 fit under baggageMaxBytes (8192); the 9th would
+	// push the running total to 9053 > 8192, so items 8..11 are dropped.
+	const itemValLen = 1000
+	const numItems = 12
+	const expectedKept = 8
+	val := strings.Repeat("a", itemValLen)
+
+	var b strings.Builder
+	for i := 0; i < numItems; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString("key" + strconv.Itoa(i) + "=" + val)
+	}
+
+	headers := TextMapCarrier{
+		DefaultTraceIDHeader:  "4",
+		DefaultParentIDHeader: "1",
+		DefaultBaggageHeader:  b.String(),
+	}
+	s, err := tracer.Extract(headers)
+	assert.NoError(t, err)
+
+	got := make(map[string]string)
+	s.ForeachBaggageItem(func(k, v string) bool {
+		got[k] = v
+		return true
+	})
+	assert.Len(t, got, expectedKept)
+	for i := 0; i < expectedKept; i++ {
+		assert.Equal(t, val, got["key"+strconv.Itoa(i)])
+	}
+	for i := expectedKept; i < numItems; i++ {
+		_, present := got["key"+strconv.Itoa(i)]
+		assert.False(t, present, "key%d should not be present", i)
+	}
+}
+
+func TestExtractBaggagePropagatorMalformedPastLimit(t *testing.T) {
+	tracer, err := newTracer()
+	assert.NoError(t, err)
+	defer tracer.Stop()
+
+	// baggageMaxItems valid entries followed by a malformed entry. Because
+	// the malformed entry sits past the items limit it is never inspected,
+	// so the valid prefix is kept (regression check on the single-pass design).
+	var b strings.Builder
+	for i := 0; i < baggageMaxItems; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		iStr := strconv.Itoa(i)
+		b.WriteString("key" + iStr + "=val" + iStr)
+	}
+	b.WriteString(",malformed_no_equals_sign")
+
+	headers := TextMapCarrier{
+		DefaultTraceIDHeader:  "4",
+		DefaultParentIDHeader: "1",
+		DefaultBaggageHeader:  b.String(),
+	}
+	s, err := tracer.Extract(headers)
+	assert.NoError(t, err)
+
+	got := make(map[string]string)
+	s.ForeachBaggageItem(func(k, v string) bool {
+		got[k] = v
+		return true
+	})
+	assert.Len(t, got, baggageMaxItems)
+	for i := 0; i < baggageMaxItems; i++ {
+		iStr := strconv.Itoa(i)
+		assert.Equal(t, "val"+iStr, got["key"+iStr])
+	}
+}
+
 func TestExtractOnlyBaggage(t *testing.T) {
 	t.Setenv("DD_TRACE_PROPAGATION_STYLE", "baggage")
 	headers := TextMapCarrier(map[string]string{

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -2898,7 +2898,7 @@ func TestExtractBaggagePropagatorMaxItems(t *testing.T) {
 	defer tracer.Stop()
 
 	var b strings.Builder
-	for i := 0; i < baggageMaxItems+5; i++ {
+	for i := range baggageMaxItems + 5 {
 		if i > 0 {
 			b.WriteByte(',')
 		}
@@ -2920,7 +2920,7 @@ func TestExtractBaggagePropagatorMaxItems(t *testing.T) {
 		return true
 	})
 	assert.Len(t, got, baggageMaxItems)
-	for i := 0; i < baggageMaxItems; i++ {
+	for i := range baggageMaxItems {
 		iStr := strconv.Itoa(i)
 		assert.Equal(t, "val"+iStr, got["key"+iStr])
 	}
@@ -2945,7 +2945,7 @@ func TestExtractBaggagePropagatorMaxBytes(t *testing.T) {
 	val := strings.Repeat("a", itemValLen)
 
 	var b strings.Builder
-	for i := 0; i < numItems; i++ {
+	for i := range numItems {
 		if i > 0 {
 			b.WriteByte(',')
 		}
@@ -2966,7 +2966,7 @@ func TestExtractBaggagePropagatorMaxBytes(t *testing.T) {
 		return true
 	})
 	assert.Len(t, got, expectedKept)
-	for i := 0; i < expectedKept; i++ {
+	for i := range expectedKept {
 		assert.Equal(t, val, got["key"+strconv.Itoa(i)])
 	}
 	for i := expectedKept; i < numItems; i++ {
@@ -2984,7 +2984,7 @@ func TestExtractBaggagePropagatorMalformedPastLimit(t *testing.T) {
 	// the malformed entry sits past the items limit it is never inspected,
 	// so the valid prefix is kept (regression check on the single-pass design).
 	var b strings.Builder
-	for i := 0; i < baggageMaxItems; i++ {
+	for i := range baggageMaxItems {
 		if i > 0 {
 			b.WriteByte(',')
 		}
@@ -3007,7 +3007,7 @@ func TestExtractBaggagePropagatorMalformedPastLimit(t *testing.T) {
 		return true
 	})
 	assert.Len(t, got, baggageMaxItems)
-	for i := 0; i < baggageMaxItems; i++ {
+	for i := range baggageMaxItems {
 		iStr := strconv.Itoa(i)
 		assert.Equal(t, "val"+iStr, got["key"+iStr])
 	}


### PR DESCRIPTION
### What does this PR do?

Applies `baggageMaxItems` (64) and `baggageMaxBytes` (8192) when extracting baggage from incoming headers in `(*propagatorBaggage).extractTextMap`. Once either limit would be breached by the next entry, the remaining entries are dropped.

### Motivation

Brings extract-side behavior in line with the existing inject-side enforcement of these same limits.