### PR TITLE
fix(tracer): drop dd= list-entries over 256 bytes from incoming tracestate

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -1245,7 +1245,8 @@ func parseTracestate(ctx *SpanContext, header string) {
 		return
 	}
 	hasOversizedDD := false
-	for group := range strings.SplitSeq(strings.Trim(header, "\t "), ",") {
+	for group := range strings.SplitSeq(header, ",") {
+		group = strings.Trim(group, "\t ")
 		if !strings.HasPrefix(group, "dd=") {
 			continue
 		}
@@ -1313,7 +1314,8 @@ func parseTracestate(ctx *SpanContext, header string) {
 	cleaned.Grow(len(header))
 	first := true
 	for entry := range strings.SplitSeq(header, ",") {
-		if strings.HasPrefix(entry, "dd=") && len(entry) > tracestateDDMaxSize {
+		trimmed := strings.Trim(entry, "\t ")
+		if strings.HasPrefix(trimmed, "dd=") && len(trimmed) > tracestateDDMaxSize {
 			continue
 		}
 		if !first {

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -820,6 +820,8 @@ func (*propagatorB3SingleHeader) extractTextMap(reader TextMapReader) (*SpanCont
 const (
 	traceparentHeader = "traceparent"
 	tracestateHeader  = "tracestate"
+	// tracestateDDMaxSize bounds the length of a `dd=` list-entry in tracestate.
+	tracestateDDMaxSize = 256
 )
 
 // propagatorW3c implements Propagator and injects/extracts span contexts
@@ -1076,7 +1078,7 @@ func composeTracestate(ctx *SpanContext, priority int, oldState string) string {
 		// with the `t.` prefix. Tag value must have all `=` signs replaced with a tilde (`~`).
 		key := sm.Mutate(keyDisallowedFn, k[len("_dd.p."):])
 		value := sm.Mutate(valueDisallowedFn, v)
-		if b.Len()+len(key)+len(value)+4 > 256 { // the +4 here is to account for the `t.` prefix, the `;` needed between the tags, and the `:` between the key and value
+		if b.Len()+len(key)+len(value)+4 > tracestateDDMaxSize { // the +4 here is to account for the `t.` prefix, the `;` needed between the tags, and the `:` between the key and value
 			return false
 		}
 		b.WriteString(";t.")
@@ -1242,12 +1244,14 @@ func parseTracestate(ctx *SpanContext, header string) {
 		// https://www.w3.org/TR/trace-context-1/#tracestate-header-field-values
 		return
 	}
-	// if multiple headers are present, they must be combined and stored
-	setPropagatingTag(ctx, tracestateHeader, header)
-	combined := strings.SplitSeq(strings.Trim(header, "\t "), ",")
-	for group := range combined {
+	hasOversizedDD := false
+	for group := range strings.SplitSeq(strings.Trim(header, "\t "), ",") {
 		if !strings.HasPrefix(group, "dd=") {
 			continue
+		}
+		if len(group) > tracestateDDMaxSize {
+			hasOversizedDD = true
+			break
 		}
 		ddMembers := strings.Split(group[len("dd="):], ";")
 		dropDM := false
@@ -1299,6 +1303,29 @@ func parseTracestate(ctx *SpanContext, header string) {
 			}
 		}
 	}
+	// Store the propagating tag, rebuilding the header to exclude oversized
+	// dd= entries when present.
+	if !hasOversizedDD {
+		setPropagatingTag(ctx, tracestateHeader, header)
+		return
+	}
+	var cleaned strings.Builder
+	cleaned.Grow(len(header))
+	first := true
+	for entry := range strings.SplitSeq(header, ",") {
+		if strings.HasPrefix(entry, "dd=") && len(entry) > tracestateDDMaxSize {
+			continue
+		}
+		if !first {
+			cleaned.WriteByte(',')
+		}
+		cleaned.WriteString(entry)
+		first = false
+	}
+	if cleaned.Len() == 0 {
+		return
+	}
+	setPropagatingTag(ctx, tracestateHeader, cleaned.String())
 }
 
 // extractTraceID128 extracts the trace id from v and populates the traceID

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -445,7 +445,61 @@ func Test257CharacterDDTracestateLengh(t *testing.T) {
 	ddTag := strings.SplitN(headers[tracestateHeader], ",", 2)[0]
 	assert.Contains(ddTag, "s:2")
 	assert.Regexp(regexp.MustCompile(`dd=[\w:,]+`), ddTag)
-	assert.LessOrEqual(len(ddTag), 256) // one of the propagated tags will not be propagated
+	assert.LessOrEqual(len(ddTag), tracestateDDMaxSize) // one of the propagated tags will not be propagated
+}
+
+func TestExtractTracestateDropsOversizedDD(t *testing.T) {
+	t.Setenv(headerPropagationStyle, "tracecontext")
+	tracer, err := newTracer()
+	require.NoError(t, err)
+	defer tracer.Stop()
+
+	// Build a dd= entry that exceeds tracestateDDMaxSize.
+	ddEntry := "dd=s:1;o:rum;p:0000000000000001;t.foo:" + strings.Repeat("a", tracestateDDMaxSize)
+	require.Greater(t, len(ddEntry), tracestateDDMaxSize)
+	rawTracestate := ddEntry + ",vendor1=v1,vendor2=v2"
+
+	headers := TextMapCarrier(map[string]string{
+		traceparentHeader: "00-00000000000000000000000000000004-2222222222222222-01",
+		tracestateHeader:  rawTracestate,
+	})
+	sctx, err := tracer.Extract(headers)
+	require.NoError(t, err)
+
+	// Oversized dd entry must not appear in the stored propagating tag.
+	stored := sctx.trace.propagatingTag(tracestateHeader)
+	assert.NotContains(t, stored, "dd=")
+	assert.Contains(t, stored, "vendor1=v1")
+	assert.Contains(t, stored, "vendor2=v2")
+	// dd entry was not parsed, so its origin/reparentID were not extracted.
+	assert.Empty(t, sctx.origin)
+	assert.Empty(t, sctx.reparentID)
+	// And no _dd.p.foo propagating tag was created from t.foo.
+	assert.False(t, sctx.trace.hasPropagatingTag("_dd.p.foo"))
+}
+
+func TestExtractTracestateKeepsDDAtBoundary(t *testing.T) {
+	t.Setenv(headerPropagationStyle, "tracecontext")
+	tracer, err := newTracer()
+	require.NoError(t, err)
+	defer tracer.Stop()
+
+	// dd= entry exactly at the limit should be kept and parsed.
+	prefix := "dd=s:1;t.foo:"
+	ddEntry := prefix + strings.Repeat("a", tracestateDDMaxSize-len(prefix))
+	require.Equal(t, tracestateDDMaxSize, len(ddEntry))
+
+	headers := TextMapCarrier(map[string]string{
+		traceparentHeader: "00-00000000000000000000000000000004-2222222222222222-01",
+		tracestateHeader:  ddEntry + ",vendor1=v1",
+	})
+	sctx, err := tracer.Extract(headers)
+	require.NoError(t, err)
+
+	stored := sctx.trace.propagatingTag(tracestateHeader)
+	assert.Contains(t, stored, "dd=")
+	assert.Contains(t, stored, "vendor1=v1")
+	assert.True(t, sctx.trace.hasPropagatingTag("_dd.p.foo"))
 }
 
 func TestTextMapPropagator(t *testing.T) {

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -502,6 +502,33 @@ func TestExtractTracestateKeepsDDAtBoundary(t *testing.T) {
 	assert.True(t, sctx.trace.hasPropagatingTag("_dd.p.foo"))
 }
 
+func TestExtractTracestateDropsOversizedDDWithWhitespace(t *testing.T) {
+	t.Setenv(headerPropagationStyle, "tracecontext")
+	tracer, err := newTracer()
+	require.NoError(t, err)
+	defer tracer.Stop()
+
+	// Same as the basic oversized-dd case but with leading OWS on the dd entry.
+	// W3C list-member parsing allows surrounding whitespace, so the prefix and
+	// length check must trim each entry before evaluating it.
+	ddEntry := " dd=s:1;o:rum;p:0000000000000001;t.foo:" + strings.Repeat("a", tracestateDDMaxSize)
+	rawTracestate := "vendor1=v1," + ddEntry + ",vendor2=v2"
+
+	headers := TextMapCarrier(map[string]string{
+		traceparentHeader: "00-00000000000000000000000000000004-2222222222222222-01",
+		tracestateHeader:  rawTracestate,
+	})
+	sctx, err := tracer.Extract(headers)
+	require.NoError(t, err)
+
+	stored := sctx.trace.propagatingTag(tracestateHeader)
+	assert.NotContains(t, stored, "dd=")
+	assert.Contains(t, stored, "vendor1=v1")
+	assert.Contains(t, stored, "vendor2=v2")
+	assert.Empty(t, sctx.origin)
+	assert.False(t, sctx.trace.hasPropagatingTag("_dd.p.foo"))
+}
+
 func TestTextMapPropagator(t *testing.T) {
 	bigMap := make(map[string]string)
 	for i := range 100 {


### PR DESCRIPTION
### What does this PR do?

During extraction, `parseTracestate` drops any `dd=` list-entry from the incoming tracestate header whose length exceeds 256 bytes, mirroring the cap already enforced on inject. The entry is excluded from both the parsed fields and the propagating tag stored on the SpanContext. Other vendors' list-entries are preserved.

Also adds a `tracestateDDMaxSize` constant and switches the existing inject-side literal to reference it.

This PR also modifies existing behavior: the prior loop iterated through every `dd=` list-entry it found (a quirk whose purpose wasn't clear), whereas now encountering an oversized `dd=` list-entry halts further parsing, so any later `dd=` list-entries are not considered. Multi-`dd=` headers are invalid per W3C anyway.

### Motivation

Inject already caps the `dd=` list-entry; extract had no equivalent ceiling.