### PR TITLE
feat: add process tags to metrics with service tag

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -44,6 +44,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/namingschema"
 	"github.com/DataDog/dd-trace-go/v2/internal/normalizer"
 	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion"
+	"github.com/DataDog/dd-trace-go/v2/internal/processtags"
 	"github.com/DataDog/dd-trace-go/v2/internal/stableconfig"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 	"github.com/DataDog/dd-trace-go/v2/internal/version"
@@ -850,6 +851,7 @@ func statsTags(c *config) []string {
 	}
 	globalconfig.SetStatsTags(tags)
 	tags = append(tags, "tracer_version:"+version.Tag)
+	tags = append(tags, processtags.GlobalTags().Slice()...)
 	if v := c.internalConfig.ServiceName(); v != "" {
 		tags = append(tags, "service:"+v)
 	}

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -852,9 +852,11 @@ func statsTags(c *config) []string {
 			tags = append(tags, k+":"+vstr)
 		}
 	}
+	tags = append(tags, processtags.GlobalTags().Slice()...)
+	// globalconfig.StatsTags is shared with contrib statsd clients. Process
+	// tags are shared too; keep only tracer_version and service tracer-only.
 	globalconfig.SetStatsTags(tags)
 	tags = append(tags, "tracer_version:"+version.Tag)
-	tags = append(tags, processtags.GlobalTags().Slice()...)
 	if v := c.internalConfig.ServiceName(); v != "" {
 		tags = append(tags, "service:"+v)
 	}

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -1573,17 +1573,38 @@ func TestStatsTags(t *testing.T) {
 	assert.Contains(tags, "service:serviceName")
 	assert.Contains(tags, "env:envName")
 	assert.Contains(tags, "host:hostName")
+	assert.Contains(tags, ext.RuntimeID+":"+globalconfig.RuntimeID())
+	assertTagPrefix(t, tags, "entrypoint.name:")
+	assertTagPrefix(t, tags, "entrypoint.workdir:")
 	assert.Contains(tags, "tracer_version:"+version.Tag)
 
 	st := globalconfig.StatsTags()
-	// all of the tracer tags except `service` and `version` should be on `st`
-	assert.Len(st, len(tags)-2)
 	assert.Contains(st, "env:envName")
 	assert.Contains(st, "host:hostName")
 	assert.Contains(st, "lang:go")
 	assert.Contains(st, "lang_version:"+runtime.Version())
+	assert.Contains(st, ext.RuntimeID+":"+globalconfig.RuntimeID())
+	assertNoTagPrefix(t, st, "entrypoint.name:")
+	assertNoTagPrefix(t, st, "entrypoint.workdir:")
 	assert.NotContains(st, "tracer_version:"+version.Tag)
 	assert.NotContains(st, "service:serviceName")
+}
+
+func assertTagPrefix(t *testing.T, tags []string, prefix string) {
+	t.Helper()
+	for _, tag := range tags {
+		if strings.HasPrefix(tag, prefix) {
+			return
+		}
+	}
+	assert.Failf(t, "missing tag", "expected a tag with prefix %q in %v", prefix, tags)
+}
+
+func assertNoTagPrefix(t *testing.T, tags []string, prefix string) {
+	t.Helper()
+	for _, tag := range tags {
+		assert.Falsef(t, strings.HasPrefix(tag, prefix), "unexpected tag with prefix %q in %v", prefix, tags)
+	}
 }
 
 func TestGlobalTag(t *testing.T) {

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -1639,48 +1639,74 @@ func TestEnvConfig(t *testing.T) {
 }
 
 func TestStatsTags(t *testing.T) {
-	assert := assert.New(t)
-	c, err := newTestConfig(WithService("serviceName"), WithEnv("envName"))
-	assert.NoError(err)
-	defer globalconfig.SetServiceName("")
-	c.internalConfig.SetHostname("hostName", telemetry.OriginCode)
-	tags := statsTags(c)
+	setupProcessTags := func(t *testing.T, enabled string) {
+		t.Helper()
+		t.Cleanup(processtags.Reload)
+		t.Setenv("DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED", enabled)
+		processtags.Reload()
+	}
 
-	assert.Contains(tags, "service:serviceName")
-	assert.Contains(tags, "env:envName")
-	assert.Contains(tags, "host:hostName")
-	assert.Contains(tags, ext.RuntimeID+":"+globalconfig.RuntimeID())
-	assertTagPrefix(t, tags, "entrypoint.name:")
-	assertTagPrefix(t, tags, "entrypoint.workdir:")
-	assert.Contains(tags, "tracer_version:"+version.Tag)
+	t.Run("process tags are shared with contrib stats tags", func(t *testing.T) {
+		assert := assert.New(t)
+		setupProcessTags(t, "true")
+		t.Cleanup(func() {
+			globalconfig.SetServiceName("")
+			globalconfig.SetStatsTags(nil)
+		})
+		c, err := newTestConfig(WithService("serviceName"), WithEnv("envName"))
+		assert.NoError(err)
+		c.internalConfig.SetHostname("hostName", telemetry.OriginCode)
+		tags := statsTags(c)
 
-	st := globalconfig.StatsTags()
-	assert.Contains(st, "env:envName")
-	assert.Contains(st, "host:hostName")
-	assert.Contains(st, "lang:go")
-	assert.Contains(st, "lang_version:"+runtime.Version())
-	assert.Contains(st, ext.RuntimeID+":"+globalconfig.RuntimeID())
-	assertNoTagPrefix(t, st, "entrypoint.name:")
-	assertNoTagPrefix(t, st, "entrypoint.workdir:")
-	assert.NotContains(st, "tracer_version:"+version.Tag)
-	assert.NotContains(st, "service:serviceName")
-}
-
-func assertTagPrefix(t *testing.T, tags []string, prefix string) {
-	t.Helper()
-	for _, tag := range tags {
-		if strings.HasPrefix(tag, prefix) {
-			return
+		assert.Contains(tags, "service:serviceName")
+		assert.Contains(tags, "env:envName")
+		assert.Contains(tags, "host:hostName")
+		assert.Contains(tags, ext.RuntimeID+":"+globalconfig.RuntimeID())
+		processTags := processtags.GlobalTags().Slice()
+		require.NotEmpty(t, processTags)
+		for _, tag := range processTags {
+			assert.Contains(tags, tag)
 		}
-	}
-	assert.Failf(t, "missing tag", "expected a tag with prefix %q in %v", prefix, tags)
-}
+		assert.Contains(tags, "tracer_version:"+version.Tag)
 
-func assertNoTagPrefix(t *testing.T, tags []string, prefix string) {
-	t.Helper()
-	for _, tag := range tags {
-		assert.Falsef(t, strings.HasPrefix(tag, prefix), "unexpected tag with prefix %q in %v", prefix, tags)
-	}
+		st := globalconfig.StatsTags()
+		assert.Len(st, len(tags)-2)
+		assert.Contains(st, "env:envName")
+		assert.Contains(st, "host:hostName")
+		assert.Contains(st, "lang:go")
+		assert.Contains(st, "lang_version:"+runtime.Version())
+		assert.Contains(st, ext.RuntimeID+":"+globalconfig.RuntimeID())
+		for _, tag := range processTags {
+			assert.Contains(st, tag)
+		}
+		assert.NotContains(st, "tracer_version:"+version.Tag)
+		assert.NotContains(st, "service:serviceName")
+	})
+
+	t.Run("process tags collection disabled", func(t *testing.T) {
+		assert := assert.New(t)
+		setupProcessTags(t, "false")
+		t.Cleanup(func() {
+			globalconfig.SetServiceName("")
+			globalconfig.SetStatsTags(nil)
+		})
+		c, err := newTestConfig(WithService("serviceName"), WithEnv("envName"))
+		assert.NoError(err)
+		c.internalConfig.SetHostname("hostName", telemetry.OriginCode)
+		tags := statsTags(c)
+
+		assert.Nil(processtags.GlobalTags())
+		assert.Contains(tags, "service:serviceName")
+		assert.Contains(tags, "tracer_version:"+version.Tag)
+		st := globalconfig.StatsTags()
+		assert.Len(st, len(tags)-2)
+		for _, tag := range append(tags, st...) {
+			assert.Falsef(strings.HasPrefix(tag, "entrypoint."), "unexpected process tag %q", tag)
+			assert.Falsef(strings.HasPrefix(tag, "svc."), "unexpected process tag %q", tag)
+		}
+		assert.NotContains(st, "tracer_version:"+version.Tag)
+		assert.NotContains(st, "service:serviceName")
+	})
 }
 
 func TestGlobalTag(t *testing.T) {

--- a/internal/processtags/processtags.go
+++ b/internal/processtags/processtags.go
@@ -124,7 +124,7 @@ func Reload() {
 	pTags = &ProcessTags{}
 	tags := collect()
 	if len(tags) > 0 {
-		Add(tags)
+		add(tags)
 	}
 }
 
@@ -156,8 +156,7 @@ func GlobalTags() *ProcessTags {
 	return pTags
 }
 
-// Add merges the given tags into the global processTags map.
-func Add(tags map[string]string) {
+func add(tags map[string]string) {
 	if !enabled {
 		return
 	}

--- a/internal/processtags/processtags_test.go
+++ b/internal/processtags/processtags_test.go
@@ -57,7 +57,7 @@ func TestSetServiceNameTag(t *testing.T) {
 	t.Run("works when tags map not yet initialised", func(t *testing.T) {
 		t.Cleanup(Reload)
 		// Simulate collect() returning empty (e.g. os.Executable fails):
-		// Reload creates pTags but Add is never called, leaving pTags.tags nil.
+		// Reload creates pTags but add is never called, leaving pTags.tags nil.
 		pTags = &ProcessTags{}
 		SetServiceNameTag("myapp", false)
 		tags := GlobalTags()


### PR DESCRIPTION
Add process tags to statsd metrics (including contrib metrics like database ones), they were missing while being necessary for service remapping and default service changes. This is already implemented in other languages

<img width="1331" height="532" alt="Screenshot 2026-05-05 at 00 01 52" src="https://github.com/user-attachments/assets/aaad1800-271d-4c6c-8e13-093b156c2131" />


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
