### PR TITLE
feat(tracer): add svc.user/svc.auto process tags to signal service name origin

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -44,6 +44,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/namingschema"
 	"github.com/DataDog/dd-trace-go/v2/internal/normalizer"
 	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion"
+	"github.com/DataDog/dd-trace-go/v2/internal/processtags"
 	"github.com/DataDog/dd-trace-go/v2/internal/stableconfig"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 	"github.com/DataDog/dd-trace-go/v2/internal/version"
@@ -381,6 +382,7 @@ func newConfig(opts ...StartOption) (*config, error) {
 			}
 		}
 	}
+	svcIsUserDefined := true
 	if c.internalConfig.ServiceName() == "" {
 		if v, ok := globalTags["service"]; ok {
 			if s, ok := v.(string); ok {
@@ -391,10 +393,12 @@ func newConfig(opts ...StartOption) (*config, error) {
 			// There is not an explicit service set, default to binary name.
 			// In this case, don't set a global service name so the contribs continue using their defaults.
 			c.internalConfig.SetServiceName(filepath.Base(os.Args[0]), internalconfig.OriginDefault, internalconfig.ProductTracer)
+			svcIsUserDefined = false
 		}
 	} else {
 		globalconfig.SetServiceName(c.internalConfig.ServiceName())
 	}
+	processtags.SetServiceNameTag(c.internalConfig.ServiceName(), svcIsUserDefined)
 	if c.ddTransport == nil {
 		agentURL := c.internalConfig.AgentURL().String()
 		traceURL, headers := resolveTraceTransport(c.internalConfig)

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -33,6 +33,7 @@ import (
 	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/globalconfig"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
+	"github.com/DataDog/dd-trace-go/v2/internal/processtags"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 	"github.com/DataDog/dd-trace-go/v2/internal/traceprof"
 	"github.com/DataDog/dd-trace-go/v2/internal/version"
@@ -1284,6 +1285,81 @@ func TestServiceName(t *testing.T) {
 		assert.NoError(err)
 		assert.Equal(c.internalConfig.ServiceName(), "testService5")
 		assert.Equal("testService5", globalconfig.ServiceName())
+	})
+}
+
+func TestServiceNameProcessTag(t *testing.T) {
+	setup := func(t *testing.T) {
+		t.Helper()
+		internalconfig.SetUseFreshConfig(true)
+		t.Cleanup(func() {
+			internalconfig.SetUseFreshConfig(false)
+			processtags.Reload()
+		})
+		processtags.Reload()
+	}
+
+	t.Run("no DD_SERVICE defaults to binary name and sets svc.auto", func(t *testing.T) {
+		setup(t)
+		defer globalconfig.SetServiceName("")
+		_, err := newTestConfig()
+		require.NoError(t, err)
+		tags := processtags.GlobalTags()
+		assert.Contains(t, tags.String(), "svc.auto:"+filepath.Base(os.Args[0]))
+		assert.NotContains(t, tags.String(), "svc.user")
+	})
+
+	t.Run("DD_SERVICE set produces svc.user:true", func(t *testing.T) {
+		setup(t)
+		t.Setenv("DD_SERVICE", "my-service")
+		defer globalconfig.SetServiceName("")
+		_, err := newTestConfig()
+		require.NoError(t, err)
+		tags := processtags.GlobalTags()
+		assert.Contains(t, tags.String(), "svc.user:true")
+		assert.NotContains(t, tags.String(), "svc.auto")
+	})
+
+	t.Run("WithService produces svc.user:true", func(t *testing.T) {
+		setup(t)
+		defer globalconfig.SetServiceName("")
+		_, err := newTestConfig(WithService("my-service"))
+		require.NoError(t, err)
+		tags := processtags.GlobalTags()
+		assert.Contains(t, tags.String(), "svc.user:true")
+		assert.NotContains(t, tags.String(), "svc.auto")
+	})
+
+	t.Run("WithGlobalTag service produces svc.user:true", func(t *testing.T) {
+		setup(t)
+		defer globalconfig.SetServiceName("")
+		_, err := newTestConfig(WithGlobalTag("service", "my-service"))
+		require.NoError(t, err)
+		tags := processtags.GlobalTags()
+		assert.Contains(t, tags.String(), "svc.user:true")
+		assert.NotContains(t, tags.String(), "svc.auto")
+	})
+
+	t.Run("OTEL_SERVICE_NAME produces svc.user:true", func(t *testing.T) {
+		setup(t)
+		t.Setenv("OTEL_SERVICE_NAME", "my-service")
+		defer globalconfig.SetServiceName("")
+		_, err := newTestConfig()
+		require.NoError(t, err)
+		tags := processtags.GlobalTags()
+		assert.Contains(t, tags.String(), "svc.user:true")
+		assert.NotContains(t, tags.String(), "svc.auto")
+	})
+
+	t.Run("DD_TAGS service produces svc.user:true", func(t *testing.T) {
+		setup(t)
+		t.Setenv("DD_TAGS", "service:my-service")
+		defer globalconfig.SetServiceName("")
+		_, err := newTestConfig()
+		require.NoError(t, err)
+		tags := processtags.GlobalTags()
+		assert.Contains(t, tags.String(), "svc.user:true")
+		assert.NotContains(t, tags.String(), "svc.auto")
 	})
 }
 

--- a/internal/processtags/processtags.go
+++ b/internal/processtags/processtags.go
@@ -26,6 +26,8 @@ const (
 	tagEntrypointBasedir = "entrypoint.basedir"
 	tagEntrypointWorkdir = "entrypoint.workdir"
 	tagEntrypointType    = "entrypoint.type"
+	tagSvcUser           = "svc.user"
+	tagSvcAuto           = "svc.auto"
 )
 
 const (
@@ -79,7 +81,12 @@ func (p *ProcessTags) merge(newTags map[string]string) {
 		p.tags = make(map[string]string)
 	}
 	maps.Copy(p.tags, newTags)
+	p.rebuild()
+}
 
+// rebuild re-serializes p.tags into p.str and p.slice.
+// Must be called with p.mu held for writing.
+func (p *ProcessTags) rebuild() {
 	// loop over the sorted map keys so the resulting string and slice versions are created consistently.
 	keys := make([]string, 0, len(p.tags))
 	for k := range p.tags {
@@ -151,4 +158,27 @@ func Add(tags map[string]string) {
 		return
 	}
 	pTags.merge(tags)
+}
+
+// SetServiceNameTag sets the appropriate process tag for the global service name.
+// svc.user and svc.auto are mutually exclusive: calling this function removes the
+// previously set tag before adding the new one.
+// If isUserDefined is true, sets svc.user:true; otherwise sets svc.auto:<name>.
+func SetServiceNameTag(name string, isUserDefined bool) {
+	if !enabled {
+		return
+	}
+	pTags.mu.Lock()
+	defer pTags.mu.Unlock()
+	if pTags.tags == nil {
+		pTags.tags = make(map[string]string)
+	}
+	delete(pTags.tags, tagSvcAuto)
+	delete(pTags.tags, tagSvcUser)
+	if isUserDefined {
+		pTags.tags[tagSvcUser] = "true"
+	} else {
+		pTags.tags[tagSvcAuto] = name
+	}
+	pTags.rebuild()
 }

--- a/internal/processtags/processtags.go
+++ b/internal/processtags/processtags.go
@@ -44,9 +44,12 @@ func init() {
 }
 
 type ProcessTags struct {
-	mu    sync.RWMutex
-	tags  map[string]string
-	str   string
+	mu sync.RWMutex
+	// +checklocks:mu
+	tags map[string]string
+	// +checklocks:mu
+	str string
+	// +checklocks:mu
 	slice []string
 }
 
@@ -86,6 +89,7 @@ func (p *ProcessTags) merge(newTags map[string]string) {
 
 // rebuild re-serializes p.tags into p.str and p.slice.
 // Must be called with p.mu held for writing.
+// +checklocks:p.mu
 func (p *ProcessTags) rebuild() {
 	// loop over the sorted map keys so the resulting string and slice versions are created consistently.
 	keys := make([]string, 0, len(p.tags))

--- a/internal/processtags/processtags_test.go
+++ b/internal/processtags/processtags_test.go
@@ -54,6 +54,16 @@ func TestSetServiceNameTag(t *testing.T) {
 		assert.NotContains(t, tags.String(), "svc.user")
 	})
 
+	t.Run("works when tags map not yet initialised", func(t *testing.T) {
+		t.Cleanup(Reload)
+		// Simulate collect() returning empty (e.g. os.Executable fails):
+		// Reload creates pTags but Add is never called, leaving pTags.tags nil.
+		pTags = &ProcessTags{}
+		SetServiceNameTag("myapp", false)
+		tags := GlobalTags()
+		assert.Contains(t, tags.String(), "svc.auto:myapp")
+	})
+
 	t.Run("no-op when disabled", func(t *testing.T) {
 		t.Cleanup(Reload) // register before t.Setenv so it runs after env is restored
 		t.Setenv("DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED", "false")

--- a/internal/processtags/processtags_test.go
+++ b/internal/processtags/processtags_test.go
@@ -13,6 +13,56 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestSetServiceNameTag(t *testing.T) {
+	t.Run("auto-assigned sets svc.auto", func(t *testing.T) {
+		t.Cleanup(Reload)
+		Reload()
+		SetServiceNameTag("myapp", false)
+		tags := GlobalTags()
+		assert.Contains(t, tags.String(), "svc.auto:myapp")
+		assert.NotContains(t, tags.String(), "svc.user")
+		assert.Contains(t, tags.Slice(), "svc.auto:myapp")
+	})
+
+	t.Run("user-defined sets svc.user", func(t *testing.T) {
+		t.Cleanup(Reload)
+		Reload()
+		SetServiceNameTag("myapp", true)
+		tags := GlobalTags()
+		assert.Contains(t, tags.String(), "svc.user:true")
+		assert.NotContains(t, tags.String(), "svc.auto")
+		assert.Contains(t, tags.Slice(), "svc.user:true")
+	})
+
+	t.Run("switching from auto to user removes svc.auto", func(t *testing.T) {
+		t.Cleanup(Reload)
+		Reload()
+		SetServiceNameTag("myapp", false)
+		SetServiceNameTag("myapp", true)
+		tags := GlobalTags()
+		assert.Contains(t, tags.String(), "svc.user:true")
+		assert.NotContains(t, tags.String(), "svc.auto")
+	})
+
+	t.Run("switching from user to auto removes svc.user", func(t *testing.T) {
+		t.Cleanup(Reload)
+		Reload()
+		SetServiceNameTag("myapp", true)
+		SetServiceNameTag("otherapp", false)
+		tags := GlobalTags()
+		assert.Contains(t, tags.String(), "svc.auto:otherapp")
+		assert.NotContains(t, tags.String(), "svc.user")
+	})
+
+	t.Run("no-op when disabled", func(t *testing.T) {
+		t.Cleanup(Reload) // register before t.Setenv so it runs after env is restored
+		t.Setenv("DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED", "false")
+		Reload()
+		SetServiceNameTag("myapp", false)
+		assert.Nil(t, GlobalTags())
+	})
+}
+
 func TestProcessTags(t *testing.T) {
 	t.Run("enabled", func(t *testing.T) {
 		wantTagsRe := regexp.MustCompile(`^entrypoint\.basedir:[a-zA-Z0-9._-]+,entrypoint\.name:[a-zA-Z0-9._-]+,entrypoint.type:executable,entrypoint\.workdir:[a-zA-Z0-9._-]+$`)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Adds two mutually exclusive process tags that signal to the Datadog backend whether the tracer's default service name was explicitly configured by the user or automatically assigned:

- `svc.user:true` — the user explicitly set a service name (via `DD_SERVICE`, `OTEL_SERVICE_NAME`, `DD_TAGS`, `WithService()`, or `WithGlobalTag("service", ...)`)
- `svc.auto:<name>` — the tracer defaulted to the binary name because no service was configured

The tags are set once during `tracer.Start()` and propagated in all product payloads via the existing process tags mechanism.

### Motivation

Let the backend know when a name is auto-assigned or when it's user-defined in order to apply the best renaming rules for all the products that are already using process tags.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
