### PR TITLE
fix(tracer): use configurable MaxTagsHeaderLen for x-datadog-tags extraction

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -128,9 +128,6 @@ var (
 
 	// defaultStatsdPort specifies the default port to use for connecting to the statsd server.
 	defaultStatsdPort = "8125"
-
-	// defaultMaxTagsHeaderLen specifies the default maximum length of the X-Datadog-Tags header value.
-	defaultMaxTagsHeaderLen = 512
 )
 
 // Supported trace protocols.
@@ -265,9 +262,6 @@ type (
 // StartOption represents a function that can be provided as a parameter to Start.
 type StartOption func(*config)
 
-// maxPropagatedTagsLength limits the size of DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH to prevent HTTP 413 responses.
-const maxPropagatedTagsLength = 512
-
 // newConfig renders the tracer configuration based on defaults, environment variables
 // and passed user opts.
 func newConfig(opts ...StartOption) (*config, error) {
@@ -401,18 +395,8 @@ func newConfig(opts ...StartOption) (*config, error) {
 		c.ddTransport = newHTTPTransport(traceURL, agentURL+statsAPIPath, c.httpClient, headers)
 	}
 	if c.propagator == nil {
-		envKey := "DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH"
-		maxLen := internal.IntEnv(envKey, defaultMaxTagsHeaderLen)
-		if maxLen < 0 {
-			log.Warn("Invalid value %d for %s. Setting to 0.", maxLen, envKey)
-			maxLen = 0
-		}
-		if maxLen > maxPropagatedTagsLength {
-			log.Warn("Invalid value %d for %s. Maximum allowed is %d. Setting to %d.", maxLen, envKey, maxPropagatedTagsLength, maxPropagatedTagsLength)
-			maxLen = maxPropagatedTagsLength
-		}
 		c.propagator = NewPropagator(&PropagatorConfig{
-			MaxTagsHeaderLen: maxLen,
+			MaxTagsHeaderLen: c.internalConfig.MaxTagsHeaderLen(),
 		})
 	}
 	if c.logger != nil {

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -103,9 +103,6 @@ const originHeader = "x-datadog-origin"
 // traceTagsHeader holds the propagated trace tags
 const traceTagsHeader = "x-datadog-tags"
 
-// propagationExtractMaxSize limits the total size of incoming propagated tags to parse
-const propagationExtractMaxSize = 512
-
 // PropagatorConfig defines the configuration for initializing a propagator.
 type PropagatorConfig struct {
 	// BaggagePrefix specifies the prefix that will be used to store baggage
@@ -539,7 +536,7 @@ func (p *propagator) extractTextMap(reader TextMapReader) (*SpanContext, error) 
 		case originHeader:
 			ctx.origin = v // +checklocksignore - Initialization time, freshly extracted ctx not yet shared.
 		case traceTagsHeader:
-			unmarshalPropagatingTags(&ctx, v)
+			unmarshalPropagatingTags(&ctx, v, p.cfg.MaxTagsHeaderLen)
 		default:
 			if after, ok := strings.CutPrefix(key, p.cfg.BaggagePrefix); ok {
 				ctx.setBaggageItem(after, v)
@@ -603,13 +600,18 @@ func overrideDatadogParentID(ctx, w3cCtx, ddCtx *SpanContext) {
 	}
 }
 
-// unmarshalPropagatingTags unmarshals tags from v into ctx
-func unmarshalPropagatingTags(ctx *SpanContext, v string) {
+// unmarshalPropagatingTags unmarshals tags from v into ctx, dropping the
+// entire header if its length exceeds maxLen. A non-positive maxLen disables
+// extraction (mirroring the inject side).
+func unmarshalPropagatingTags(ctx *SpanContext, v string, maxLen int) {
 	if ctx.trace == nil {
 		ctx.trace = newTrace()
 	}
-	if len(v) > propagationExtractMaxSize {
-		log.Warn("Did not extract %s, size limit exceeded: %d. Incoming tags will not be propagated further.", traceTagsHeader, propagationExtractMaxSize)
+	if maxLen <= 0 {
+		return
+	}
+	if len(v) > maxLen {
+		log.Warn("Did not extract %s, size limit exceeded: %d. Incoming tags will not be propagated further.", traceTagsHeader, maxLen)
 		ctx.trace.setTag(keyPropagationError, "extract_max_size")
 		return
 	}

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -675,6 +675,48 @@ func TestTextMapPropagator(t *testing.T) {
 	})
 }
 
+func TestExtractTraceTagsHeaderUsesMaxTagsHeaderLen(t *testing.T) {
+	t.Setenv(headerPropagationStyleExtract, "datadog")
+	const customMax = 200
+	propagator := NewPropagator(&PropagatorConfig{
+		MaxTagsHeaderLen: customMax,
+	})
+
+	// Header is longer than the configured cap but shorter than the previous
+	// hardcoded 512 cap, to confirm extract now honors the configured maxLen.
+	tags := "_dd.p.k=" + strings.Repeat("a", customMax)
+	require.Greater(t, len(tags), customMax)
+	require.Less(t, len(tags), 512)
+
+	src := TextMapCarrier(map[string]string{
+		DefaultTraceIDHeader:  "1",
+		DefaultParentIDHeader: "1",
+		traceTagsHeader:       tags,
+	})
+	ctx, err := propagator.Extract(src)
+	require.NoError(t, err)
+	assert.Equal(t, "extract_max_size", ctx.trace.tags["_dd.propagation_error"])
+}
+
+func TestExtractTraceTagsHeaderDisabled(t *testing.T) {
+	t.Setenv(headerPropagationStyleExtract, "datadog")
+	propagator := NewPropagator(&PropagatorConfig{
+		MaxTagsHeaderLen: 0, // disable, mirroring inject
+	})
+
+	src := TextMapCarrier(map[string]string{
+		DefaultTraceIDHeader:  "1",
+		DefaultParentIDHeader: "1",
+		traceTagsHeader:       "_dd.p.k=v",
+	})
+	ctx, err := propagator.Extract(src)
+	require.NoError(t, err)
+	// Disabled extract: no propagating tags, no error tag.
+	_, hasErr := ctx.trace.tags["_dd.propagation_error"]
+	assert.False(t, hasErr)
+	assert.Empty(t, ctx.trace.propagatingTags)
+}
+
 func TestEnvVars(t *testing.T) {
 	var testEnvs []map[string]string
 
@@ -2434,7 +2476,7 @@ func FuzzMarshalPropagatingTags(f *testing.F) {
 		if _, ok := sendCtx.trace.tags[keyPropagationError]; ok {
 			t.Skipf("Skipping invalid tags")
 		}
-		unmarshalPropagatingTags(recvCtx, marshal)
+		unmarshalPropagatingTags(recvCtx, marshal, pConfig.MaxTagsHeaderLen)
 		marshaled := sendCtx.trace.propagatingTags
 		unmarshaled := recvCtx.trace.propagatingTags
 		if !reflect.DeepEqual(sendCtx.trace.propagatingTags, recvCtx.trace.propagatingTags) {

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/instrumentation/httpmem"
+	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/samplernames"
 
@@ -650,7 +651,7 @@ func TestTextMapPropagator(t *testing.T) {
 			BaggagePrefix:    "bg-",
 			TraceHeader:      "tid",
 			ParentHeader:     "pid",
-			MaxTagsHeaderLen: defaultMaxTagsHeaderLen,
+			MaxTagsHeaderLen: internalconfig.DefaultMaxTagsHeaderLen,
 		})
 		tracer, err := newTracer(WithPropagator(propagator))
 		defer tracer.Stop()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,7 +90,9 @@ type Config struct {
 	profilerEndpoints          bool
 	spanAttributeSchemaVersion int
 	peerServiceDefaultsEnabled bool
-	peerServiceMappings        map[string]string
+	// maxTagsHeaderLen is the size cap on the x-datadog-tags header value
+	maxTagsHeaderLen    int
+	peerServiceMappings map[string]string
 	// debugAbandonedSpans controls if the tracer should log when old, open spans are found
 	debugAbandonedSpans bool
 	// spanTimeout represents how old a span can be before it should be logged as a possible
@@ -246,6 +248,8 @@ func loadConfig() *Config {
 	if cfg.spanAttributeSchemaVersion >= 1 {
 		cfg.peerServiceDefaultsEnabled = true
 	}
+
+	cfg.maxTagsHeaderLen = resolveMaxTagsHeaderLen(p.GetInt("DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH", DefaultMaxTagsHeaderLen))
 
 	// AWS_LAMBDA_FUNCTION_NAME being set indicates that we're running in an AWS Lambda environment.
 	// See: https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html
@@ -793,6 +797,15 @@ func (c *Config) SetServiceMapping(from, to string, origin telemetry.Origin, pro
 func (c *Config) SpanAttributeSchemaVersion() int {
 	c.mu.RLock()
 	v := c.spanAttributeSchemaVersion
+	c.mu.RUnlock()
+	return v
+}
+
+// MaxTagsHeaderLen returns the configured cap on the x-datadog-tags header value
+// (DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH). A non-positive value disables tags propagation.
+func (c *Config) MaxTagsHeaderLen() int {
+	c.mu.RLock()
+	v := c.maxTagsHeaderLen
 	c.mu.RUnlock()
 	return v
 }

--- a/internal/config/config_helpers.go
+++ b/internal/config/config_helpers.go
@@ -23,8 +23,7 @@ const (
 
 	// DefaultMaxTagsHeaderLen is the default value for DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH.
 	DefaultMaxTagsHeaderLen = 512
-	// MaxPropagatedTagsLength is the upper bound on DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH;
-	// values above this are clamped down to prevent HTTP 413 responses from the agent.
+	// MaxPropagatedTagsLength is the upper bound on DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH.
 	MaxPropagatedTagsLength = 512
 	// TraceMaxSize is the maximum number of spans we keep in memory for a
 	// single trace. This is to avoid memory leaks. If more spans than this

--- a/internal/config/config_helpers.go
+++ b/internal/config/config_helpers.go
@@ -20,6 +20,12 @@ const (
 	// DefaultRateLimit specifies the default rate limit per second for traces.
 	// TODO: Maybe delete this. We will have defaults in supported_configuration.json anyway.
 	DefaultRateLimit = 100.0
+
+	// DefaultMaxTagsHeaderLen is the default value for DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH.
+	DefaultMaxTagsHeaderLen = 512
+	// MaxPropagatedTagsLength is the upper bound on DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH;
+	// values above this are clamped down to prevent HTTP 413 responses from the agent.
+	MaxPropagatedTagsLength = 512
 	// TraceMaxSize is the maximum number of spans we keep in memory for a
 	// single trace. This is to avoid memory leaks. If more spans than this
 	// are added to a trace, then the trace is dropped and the spans are
@@ -79,6 +85,21 @@ func parseSpanAttributeSchema(v string) (int, bool) {
 		log.Warn("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA=%s is not a valid value, ignoring", v)
 		return 0, false
 	}
+}
+
+// resolveMaxTagsHeaderLen normalises a DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH value
+// into the supported range. Negative values are clamped to 0 (which disables
+// tags propagation); values above MaxPropagatedTagsLength are clamped down.
+func resolveMaxTagsHeaderLen(v int) int {
+	if v < 0 {
+		log.Warn("Invalid value %d for DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH. Setting to 0.", v)
+		return 0
+	}
+	if v > MaxPropagatedTagsLength {
+		log.Warn("Invalid value %d for DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH. Maximum allowed is %d. Setting to %d.", v, MaxPropagatedTagsLength, MaxPropagatedTagsLength)
+		return MaxPropagatedTagsLength
+	}
+	return v
 }
 
 func validatePartialFlushMinSpans(minSpans int) bool {


### PR DESCRIPTION
### What does this PR do?

`unmarshalPropagatingTags` (the extract path for the `x-datadog-tags` header) now uses the configured `MaxTagsHeaderLen` as the size cap instead of a hardcoded 512-byte constant. A non-positive `MaxTagsHeaderLen` disables extraction, mirroring the existing inject-side disable behavior. The `DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH` environment variable now governs both inject and extract.

### Motivation

The env var was previously respected only on inject; extract used a hardcoded 512-byte cap regardless of the configured value. This brings the two directions into alignment.