### PR TITLE
fix(ci-visibility): harden Go retry edge cases

### DIFF
--- a/internal/civisibility/integrations/gotesting/coverage/coverage_writer.go
+++ b/internal/civisibility/integrations/gotesting/coverage/coverage_writer.go
@@ -33,6 +33,7 @@ type coverageWriter struct {
 	payload *coveragePayload // Encodes and buffers events in msgpack format.
 	climit  chan struct{}    // Limits the number of concurrent outgoing connections.
 	wg      sync.WaitGroup   // Waits for all uploads to finish.
+	mu      sync.Mutex       // Guards payload rotation between add and flush.
 }
 
 func newCoverageWriter() *coverageWriter {
@@ -47,11 +48,19 @@ func newCoverageWriter() *coverageWriter {
 func (w *coverageWriter) add(coverage *testCoverage) {
 	telemetry.EventsEnqueueForSerialization()
 	ciTestCoverage := newCiTestCoverageData(coverage)
+	var payloadToFlush *coveragePayload
+
+	w.mu.Lock()
 	if err := w.payload.push(ciTestCoverage); err != nil {
 		log.Error("coverageWriter: Error encoding msgpack: %s", err.Error())
 	}
 	if w.payload.size() > agentlessPayloadSizeLimit {
-		w.flush()
+		payloadToFlush = w.rotatePayloadLocked()
+	}
+	w.mu.Unlock()
+
+	if payloadToFlush != nil {
+		w.flushPayload(payloadToFlush)
 	}
 }
 
@@ -62,15 +71,30 @@ func (w *coverageWriter) stop() {
 }
 
 func (w *coverageWriter) flush() {
+	w.mu.Lock()
+	payloadToFlush := w.rotatePayloadLocked()
+	w.mu.Unlock()
+
+	if payloadToFlush != nil {
+		w.flushPayload(payloadToFlush)
+	}
+}
+
+// rotatePayloadLocked swaps out the current payload while w.mu is held.
+func (w *coverageWriter) rotatePayloadLocked() *coveragePayload {
 	if w.payload.itemCount() == 0 {
-		return
+		return nil
 	}
 
-	w.wg.Add(1)
-	w.climit <- struct{}{}
 	oldp := w.payload
 	w.payload = newCoveragePayload()
+	return oldp
+}
 
+// flushPayload sends a closed payload asynchronously without holding w.mu.
+func (w *coverageWriter) flushPayload(oldp *coveragePayload) {
+	w.wg.Add(1)
+	w.climit <- struct{}{}
 	go func(p *coveragePayload) {
 		defer func() {
 			// Once the payload has been used, clear the buffer for garbage

--- a/internal/civisibility/integrations/gotesting/coverage/coverage_writer_test.go
+++ b/internal/civisibility/integrations/gotesting/coverage/coverage_writer_test.go
@@ -8,6 +8,7 @@ package coverage
 import (
 	"fmt"
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -67,6 +68,25 @@ func TestCoverageWriterFlushError(t *testing.T) {
 	writer.add(coverage)
 	writer.flush()
 	assert.Equal(t, 0, writer.payload.itemCount())
+}
+
+func TestCoverageWriterConcurrentAddAndFlush(t *testing.T) {
+	writer := newCoverageWriter()
+	writer.client = &MockClient{SendCoveragePayloadFunc: func(_ io.Reader) error {
+		return nil
+	}}
+
+	var wg sync.WaitGroup
+	for range 64 {
+		wg.Go(func() {
+			writer.add(&testCoverage{})
+		})
+		wg.Go(func() {
+			writer.flush()
+		})
+	}
+	wg.Wait()
+	writer.stop()
 }
 
 // MockClient is a mock implementation of the Client interface for testing purposes.

--- a/internal/civisibility/integrations/gotesting/failnow/failnow_test.go
+++ b/internal/civisibility/integrations/gotesting/failnow/failnow_test.go
@@ -76,6 +76,10 @@ func TestCleanupSkipDoesNotRetry(t *testing.T) {
 	runTestScenario(t, "test-cleanup-skip-does-not-retry", "^TestCleanupSkipDoesNotRetryFixture$")
 }
 
+func TestCleanupRunsAfterParallelSubtest(t *testing.T) {
+	runTestScenario(t, "test-cleanup-after-parallel-subtest", "^TestCleanupRunsAfterParallelSubtestFixture$")
+}
+
 func TestFlakyRetryGlobalBudget(t *testing.T) {
 	runTestScenario(t, "test-flaky-retry-global-budget", "^TestFlakyRetryGlobalBudgetFixture$")
 }
@@ -162,6 +166,22 @@ func TestCleanupSkipDoesNotRetryFixture(t *testing.T) {
 	})
 }
 
+func TestCleanupRunsAfterParallelSubtestFixture(t *testing.T) {
+	skipUnlessScenario(t, "test-cleanup-after-parallel-subtest")
+
+	var childFinished atomic.Bool
+	t.Cleanup(func() {
+		if !childFinished.Load() {
+			t.Fatal("cleanup ran before the parallel subtest completed")
+		}
+	})
+
+	gotesting.GetTest(t).Run("child", func(t *testing.T) {
+		gotesting.GetTest(t).Parallel()
+		childFinished.Store(true)
+	})
+}
+
 func TestFlakyRetryGlobalBudgetFixture(t *testing.T) {
 	skipUnlessScenario(t, "test-flaky-retry-global-budget")
 	gotesting.GetTest(t).Fail()
@@ -196,7 +216,7 @@ func runScenario(m *testing.M) int {
 	settings := civisibilitynet.SettingsResponseData{}
 	if scenario == "test-failnow-retry-passes" || scenario == "test-failnow-retry-fails" ||
 		scenario == "test-cleanup-panic-retry-passes" || scenario == "test-cleanup-fatal-retry-passes" ||
-		scenario == "test-cleanup-skip-does-not-retry" {
+		scenario == "test-cleanup-skip-does-not-retry" || scenario == "test-cleanup-after-parallel-subtest" {
 		settings.FlakyTestRetriesEnabled = true
 		_ = os.Setenv(constants.CIVisibilityFlakyRetryCountEnvironmentVariable, "2")
 		_ = os.Setenv(constants.CIVisibilityTotalFlakyRetryCountEnvironmentVariable, "10")
@@ -307,11 +327,13 @@ func validateScenario(scenario string, spans []*mocktracer.Span, exitCode int) {
 	case "test-failnow-retry-fails":
 		validateRetryFailScenario(spans, exitCode)
 	case "test-cleanup-panic-retry-passes":
-		validateCleanupRetryPassScenario(spans, exitCode, "failnow_test.go.TestCleanupPanicRetryPassesFixture")
+		validateCleanupRetryPassScenario(spans, exitCode, "failnow_test.go.TestCleanupPanicRetryPassesFixture", "cleanup panic")
 	case "test-cleanup-fatal-retry-passes":
-		validateCleanupRetryPassScenario(spans, exitCode, "failnow_test.go.TestCleanupFatalRetryPassesFixture")
+		validateCleanupRetryPassScenario(spans, exitCode, "failnow_test.go.TestCleanupFatalRetryPassesFixture", "")
 	case "test-cleanup-skip-does-not-retry":
 		validateCleanupSkipDoesNotRetryScenario(spans, exitCode)
+	case "test-cleanup-after-parallel-subtest":
+		validateCleanupAfterParallelSubtestScenario(spans, exitCode)
 	case "test-flaky-retry-global-budget":
 		validateGlobalBudgetScenario(spans, exitCode)
 	default:
@@ -387,7 +409,7 @@ func validateRetryFailScenario(spans []*mocktracer.Span, exitCode int) {
 	assertTagCount(testSpans, constants.TestHasFailedAllRetries, "true", 1)
 }
 
-func validateCleanupRetryPassScenario(spans []*mocktracer.Span, exitCode int, resource string) {
+func validateCleanupRetryPassScenario(spans []*mocktracer.Span, exitCode int, resource, expectedPanicMessage string) {
 	assertEqual("exit code", exitCode, 0)
 	assertSpanTypeCount(spans, constants.SpanTypeTestSession, 1)
 	assertSpanTypeCount(spans, constants.SpanTypeTestModule, 1)
@@ -405,6 +427,33 @@ func validateCleanupRetryPassScenario(spans []*mocktracer.Span, exitCode int, re
 	assertTagCount(testSpans, constants.TestStatus, constants.TestStatusPass, 1)
 	assertTagCount(testSpans, constants.TestFinalStatus, constants.TestStatusPass, 1)
 	assertTagCount(testSpans, constants.TestHasFailedAllRetries, "true", 0)
+	if expectedPanicMessage != "" {
+		for _, span := range testSpans {
+			if span.Tag(constants.TestStatus) == constants.TestStatusFail {
+				assertTag(span, ext.ErrorType, "panic")
+				assertTag(span, ext.ErrorMsg, expectedPanicMessage)
+				return
+			}
+		}
+		panic("expected one failed cleanup panic span")
+	}
+}
+
+func validateCleanupAfterParallelSubtestScenario(spans []*mocktracer.Span, exitCode int) {
+	assertEqual("exit code", exitCode, 0)
+	assertSpanTypeCount(spans, constants.SpanTypeTestSession, 1)
+	assertSpanTypeCount(spans, constants.SpanTypeTestModule, 1)
+	assertSpanTypeCount(spans, constants.SpanTypeTestSuite, 1)
+
+	session := spansByType(spans, constants.SpanTypeTestSession)[0]
+	assertTag(session, constants.TestStatus, constants.TestStatusPass)
+	assertNumericTag(session, constants.TestCommandExitCode, 0)
+
+	resource := "failnow_test.go.TestCleanupRunsAfterParallelSubtestFixture"
+	testSpans := spansByResource(spansByType(spans, constants.SpanTypeTest), resource)
+	assertEqual("test span count", len(testSpans), 1)
+	assertTag(testSpans[0], constants.TestStatus, constants.TestStatusPass)
+	assertTag(testSpans[0], constants.TestFinalStatus, constants.TestStatusPass)
 }
 
 // validateCleanupSkipDoesNotRetryScenario confirms cleanup Skip is reported as

--- a/internal/civisibility/integrations/gotesting/failnow/failnow_test.go
+++ b/internal/civisibility/integrations/gotesting/failnow/failnow_test.go
@@ -29,8 +29,10 @@ import (
 const scenarioEnv = "DD_FAILNOW_SCENARIO"
 
 var (
-	retryPassAttempts atomic.Int32
-	retryFailAttempts atomic.Int32
+	retryPassAttempts    atomic.Int32
+	retryFailAttempts    atomic.Int32
+	cleanupPanicAttempts atomic.Int32
+	cleanupFatalAttempts atomic.Int32
 )
 
 func TestMain(m *testing.M) {
@@ -58,6 +60,20 @@ func TestManualFailNowRetryPasses(t *testing.T) {
 
 func TestManualFailNowRetryFails(t *testing.T) {
 	runTestScenario(t, "test-failnow-retry-fails", "^TestManualFailNowRetryFailsFixture$")
+}
+
+func TestCleanupPanicRetryPasses(t *testing.T) {
+	runTestScenario(t, "test-cleanup-panic-retry-passes", "^TestCleanupPanicRetryPassesFixture$")
+}
+
+func TestCleanupFatalRetryPasses(t *testing.T) {
+	runTestScenario(t, "test-cleanup-fatal-retry-passes", "^TestCleanupFatalRetryPassesFixture$")
+}
+
+// TestCleanupSkipDoesNotRetry verifies cleanup skips stay skipped instead of
+// being converted into retryable failures.
+func TestCleanupSkipDoesNotRetry(t *testing.T) {
+	runTestScenario(t, "test-cleanup-skip-does-not-retry", "^TestCleanupSkipDoesNotRetryFixture$")
 }
 
 func TestManualBenchmarkFailNow(t *testing.T) {
@@ -115,6 +131,33 @@ func TestManualFailNowRetryFailsFixture(t *testing.T) {
 	gt.FailNow()
 }
 
+func TestCleanupPanicRetryPassesFixture(t *testing.T) {
+	skipUnlessScenario(t, "test-cleanup-panic-retry-passes")
+	if cleanupPanicAttempts.Add(1) == 1 {
+		t.Cleanup(func() {
+			panic("cleanup panic")
+		})
+	}
+}
+
+func TestCleanupFatalRetryPassesFixture(t *testing.T) {
+	skipUnlessScenario(t, "test-cleanup-fatal-retry-passes")
+	if cleanupFatalAttempts.Add(1) == 1 {
+		t.Cleanup(func() {
+			t.Fatal("cleanup fatal")
+		})
+	}
+}
+
+// TestCleanupSkipDoesNotRetryFixture skips from cleanup while flaky retries are
+// enabled; a clean skip should not consume retry attempts or fail the process.
+func TestCleanupSkipDoesNotRetryFixture(t *testing.T) {
+	skipUnlessScenario(t, "test-cleanup-skip-does-not-retry")
+	t.Cleanup(func() {
+		t.Skip("cleanup skip")
+	})
+}
+
 func BenchmarkManualFailNowFixture(b *testing.B) {
 	skipUnlessScenario(b, "benchmark-failnow")
 	gb := gotesting.GetBenchmark(b)
@@ -142,7 +185,9 @@ func BenchmarkManualFatalfFixture(b *testing.B) {
 func runScenario(m *testing.M) int {
 	scenario := os.Getenv(scenarioEnv)
 	settings := civisibilitynet.SettingsResponseData{}
-	if scenario == "test-failnow-retry-passes" || scenario == "test-failnow-retry-fails" {
+	if scenario == "test-failnow-retry-passes" || scenario == "test-failnow-retry-fails" ||
+		scenario == "test-cleanup-panic-retry-passes" || scenario == "test-cleanup-fatal-retry-passes" ||
+		scenario == "test-cleanup-skip-does-not-retry" {
 		settings.FlakyTestRetriesEnabled = true
 		_ = os.Setenv(constants.CIVisibilityFlakyRetryCountEnvironmentVariable, "2")
 		_ = os.Setenv(constants.CIVisibilityTotalFlakyRetryCountEnvironmentVariable, "10")
@@ -247,6 +292,12 @@ func validateScenario(scenario string, spans []*mocktracer.Span, exitCode int) {
 		validateRetryPassScenario(spans, exitCode)
 	case "test-failnow-retry-fails":
 		validateRetryFailScenario(spans, exitCode)
+	case "test-cleanup-panic-retry-passes":
+		validateCleanupRetryPassScenario(spans, exitCode, "failnow_test.go.TestCleanupPanicRetryPassesFixture")
+	case "test-cleanup-fatal-retry-passes":
+		validateCleanupRetryPassScenario(spans, exitCode, "failnow_test.go.TestCleanupFatalRetryPassesFixture")
+	case "test-cleanup-skip-does-not-retry":
+		validateCleanupSkipDoesNotRetryScenario(spans, exitCode)
 	default:
 		panic(fmt.Sprintf("unknown scenario %s", scenario))
 	}
@@ -318,6 +369,46 @@ func validateRetryFailScenario(spans []*mocktracer.Span, exitCode int) {
 	assertTagCount(testSpans, constants.TestStatus, constants.TestStatusFail, 3)
 	assertTagCount(testSpans, constants.TestFinalStatus, constants.TestStatusFail, 1)
 	assertTagCount(testSpans, constants.TestHasFailedAllRetries, "true", 1)
+}
+
+func validateCleanupRetryPassScenario(spans []*mocktracer.Span, exitCode int, resource string) {
+	assertEqual("exit code", exitCode, 0)
+	assertSpanTypeCount(spans, constants.SpanTypeTestSession, 1)
+	assertSpanTypeCount(spans, constants.SpanTypeTestModule, 1)
+	assertSpanTypeCount(spans, constants.SpanTypeTestSuite, 1)
+
+	session := spansByType(spans, constants.SpanTypeTestSession)[0]
+	assertTag(session, constants.TestStatus, constants.TestStatusPass)
+	assertNumericTag(session, constants.TestCommandExitCode, 0)
+
+	testSpans := spansByResource(spansByType(spans, constants.SpanTypeTest), resource)
+	assertEqual("test span count", len(testSpans), 2)
+	assertTagCount(testSpans, constants.TestIsRetry, "true", 1)
+	assertTagCount(testSpans, constants.TestRetryReason, constants.AutoTestRetriesRetryReason, 1)
+	assertTagCount(testSpans, constants.TestStatus, constants.TestStatusFail, 1)
+	assertTagCount(testSpans, constants.TestStatus, constants.TestStatusPass, 1)
+	assertTagCount(testSpans, constants.TestFinalStatus, constants.TestStatusPass, 1)
+	assertTagCount(testSpans, constants.TestHasFailedAllRetries, "true", 0)
+}
+
+// validateCleanupSkipDoesNotRetryScenario confirms cleanup Skip is reported as
+// a single skipped attempt even when flaky retries are available.
+func validateCleanupSkipDoesNotRetryScenario(spans []*mocktracer.Span, exitCode int) {
+	assertEqual("exit code", exitCode, 0)
+	assertSpanTypeCount(spans, constants.SpanTypeTestSession, 1)
+	assertSpanTypeCount(spans, constants.SpanTypeTestModule, 1)
+	assertSpanTypeCount(spans, constants.SpanTypeTestSuite, 1)
+
+	session := spansByType(spans, constants.SpanTypeTestSession)[0]
+	assertTag(session, constants.TestStatus, constants.TestStatusPass)
+	assertNumericTag(session, constants.TestCommandExitCode, 0)
+
+	resource := "failnow_test.go.TestCleanupSkipDoesNotRetryFixture"
+	testSpans := spansByResource(spansByType(spans, constants.SpanTypeTest), resource)
+	assertEqual("test span count", len(testSpans), 1)
+	assertTag(testSpans[0], constants.TestStatus, constants.TestStatusSkip)
+	assertTag(testSpans[0], constants.TestFinalStatus, constants.TestStatusSkip)
+	assertTagCount(testSpans, constants.TestIsRetry, "true", 0)
 }
 
 func spansByType(spans []*mocktracer.Span, spanType string) []*mocktracer.Span {

--- a/internal/civisibility/integrations/gotesting/failnow/failnow_test.go
+++ b/internal/civisibility/integrations/gotesting/failnow/failnow_test.go
@@ -76,6 +76,10 @@ func TestCleanupSkipDoesNotRetry(t *testing.T) {
 	runTestScenario(t, "test-cleanup-skip-does-not-retry", "^TestCleanupSkipDoesNotRetryFixture$")
 }
 
+func TestFlakyRetryGlobalBudget(t *testing.T) {
+	runTestScenario(t, "test-flaky-retry-global-budget", "^TestFlakyRetryGlobalBudgetFixture$")
+}
+
 func TestManualBenchmarkFailNow(t *testing.T) {
 	runBenchmarkScenario(t, "benchmark-failnow", "^BenchmarkManualFailNowFixture$")
 }
@@ -158,6 +162,11 @@ func TestCleanupSkipDoesNotRetryFixture(t *testing.T) {
 	})
 }
 
+func TestFlakyRetryGlobalBudgetFixture(t *testing.T) {
+	skipUnlessScenario(t, "test-flaky-retry-global-budget")
+	gotesting.GetTest(t).Fail()
+}
+
 func BenchmarkManualFailNowFixture(b *testing.B) {
 	skipUnlessScenario(b, "benchmark-failnow")
 	gb := gotesting.GetBenchmark(b)
@@ -191,6 +200,11 @@ func runScenario(m *testing.M) int {
 		settings.FlakyTestRetriesEnabled = true
 		_ = os.Setenv(constants.CIVisibilityFlakyRetryCountEnvironmentVariable, "2")
 		_ = os.Setenv(constants.CIVisibilityTotalFlakyRetryCountEnvironmentVariable, "10")
+	}
+	if scenario == "test-flaky-retry-global-budget" {
+		settings.FlakyTestRetriesEnabled = true
+		_ = os.Setenv(constants.CIVisibilityFlakyRetryCountEnvironmentVariable, "10")
+		_ = os.Setenv(constants.CIVisibilityTotalFlakyRetryCountEnvironmentVariable, "1")
 	}
 	server, restore := startManualMockServer(settings)
 	defer restore()
@@ -298,6 +312,8 @@ func validateScenario(scenario string, spans []*mocktracer.Span, exitCode int) {
 		validateCleanupRetryPassScenario(spans, exitCode, "failnow_test.go.TestCleanupFatalRetryPassesFixture")
 	case "test-cleanup-skip-does-not-retry":
 		validateCleanupSkipDoesNotRetryScenario(spans, exitCode)
+	case "test-flaky-retry-global-budget":
+		validateGlobalBudgetScenario(spans, exitCode)
 	default:
 		panic(fmt.Sprintf("unknown scenario %s", scenario))
 	}
@@ -409,6 +425,26 @@ func validateCleanupSkipDoesNotRetryScenario(spans []*mocktracer.Span, exitCode 
 	assertTag(testSpans[0], constants.TestStatus, constants.TestStatusSkip)
 	assertTag(testSpans[0], constants.TestFinalStatus, constants.TestStatusSkip)
 	assertTagCount(testSpans, constants.TestIsRetry, "true", 0)
+}
+
+func validateGlobalBudgetScenario(spans []*mocktracer.Span, exitCode int) {
+	assertEqual("exit code", exitCode, 1)
+	assertSpanTypeCount(spans, constants.SpanTypeTestSession, 1)
+	assertSpanTypeCount(spans, constants.SpanTypeTestModule, 1)
+	assertSpanTypeCount(spans, constants.SpanTypeTestSuite, 1)
+
+	session := spansByType(spans, constants.SpanTypeTestSession)[0]
+	assertTag(session, constants.TestStatus, constants.TestStatusFail)
+	assertNumericTag(session, constants.TestCommandExitCode, 1)
+
+	resource := "failnow_test.go.TestFlakyRetryGlobalBudgetFixture"
+	testSpans := spansByResource(spansByType(spans, constants.SpanTypeTest), resource)
+	assertEqual("test span count", len(testSpans), 2)
+	assertTagCount(testSpans, constants.TestIsRetry, "true", 1)
+	assertTagCount(testSpans, constants.TestRetryReason, constants.AutoTestRetriesRetryReason, 1)
+	assertTagCount(testSpans, constants.TestStatus, constants.TestStatusFail, 2)
+	assertTagCount(testSpans, constants.TestFinalStatus, constants.TestStatusFail, 1)
+	assertTagCount(testSpans, constants.TestHasFailedAllRetries, "true", 1)
 }
 
 func spansByType(spans []*mocktracer.Span, spanType string) []*mocktracer.Span {

--- a/internal/civisibility/integrations/gotesting/final_status.go
+++ b/internal/civisibility/integrations/gotesting/final_status.go
@@ -85,8 +85,9 @@ func willRetryAfterExecution(failed bool, execMeta *testExecutionMetadata, remai
 	}
 
 	if execMeta.isFlakyTestRetriesEnabled {
-		// For flaky test retries, retry if the test failed and remaining retries >= 0.
-		return failed && remainingRetries >= 0 && remainingBudget >= 0
+		// For flaky test retries, the per-test retry counter and global retry
+		// budget must both reserve a retry before another attempt can run.
+		return failed && remainingRetries >= 0 && remainingBudget > 0
 	}
 
 	// No retries for other cases.

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 )
 
@@ -56,11 +57,12 @@ type (
 		hasExplicitAttemptToFix      bool                  // flag to mark if attempt-to-fix state comes from explicit configuration
 
 		// Fields for test.final_status computation
-		anyExecutionPassed            bool  // tracks if any prior execution passed (for final status calculation)
-		anyExecutionFailed            bool  // tracks if any prior execution failed (for final status calculation)
-		remainingRetries              int64 // remaining retries at the start of this execution
-		shouldOrchestrateAttemptToFix bool  // whether this wrapper controls ATF retries
-		isEfdInParallel               bool  // true only when parallel EFD path is active
+		anyExecutionPassed            bool               // tracks if any prior execution passed (for final status calculation)
+		anyExecutionFailed            bool               // tracks if any prior execution failed (for final status calculation)
+		remainingRetries              int64              // remaining retries at the start of this execution
+		shouldOrchestrateAttemptToFix bool               // whether this wrapper controls ATF retries
+		isEfdInParallel               bool               // true only when parallel EFD path is active
+		cleanupResult                 *testCleanupResult // records cleanup completion for this retry attempt.
 	}
 
 	// runTestWithRetryOptions contains the options for calling runTestWithRetry function
@@ -101,6 +103,14 @@ type (
 		executionMetadata         *testExecutionMetadata   // current test execution metadata
 		module                    integrations.TestModule  // module associated with the test
 		suite                     integrations.TestSuite   // suite associated with the test
+	}
+
+	// testCleanupResult captures how testing cleanup execution completed for a retry attempt.
+	testCleanupResult struct {
+		panicData       any    // panic value returned by testing.common.runCleanup.
+		panicStacktrace string // stacktrace captured when cleanup returned a panic value.
+		goexit          bool   // true when cleanup called runtime.Goexit before runCleanup returned.
+		ran             bool   // true after this attempt has executed its testing cleanups.
 	}
 
 	// parallelForwardState coordinates t.Parallel forwarding for Datadog-managed
@@ -780,10 +790,13 @@ func executeTestIteration(execOpts *executionOptions) bool {
 	reinitOutputWriter(dummyParent)
 	*localTPrivateFields.parent = unsafe.Pointer(dummyParent)
 
+	var cleanupResult testCleanupResult
+
 	// Create an execution metadata instance
 	execMeta := createTestMetadata(ptrToLocalT, execOpts.options.t)
 	execMeta.parallelForwardState = execOpts.parallelForwardState
 	execMeta.hasAdditionalFeatureWrapper = true
+	execMeta.cleanupResult = &cleanupResult
 
 	// Propagate set tags from a parent wrapper
 	propagateTestExecutionMetadataFlags(execMeta, execOpts.originalExecutionMetadata)
@@ -835,16 +848,16 @@ func executeTestIteration(execOpts *executionOptions) bool {
 		defer func() {
 			duration = time.Since(startTime)
 		}()
+		defer func() {
+			if !cleanupResult.ran {
+				runTestCleanup(pLocalT, &cleanupResult)
+			}
+		}()
 		pLocalT.Helper()
 		opts.t.Helper()
 		opts.targetFunc(pLocalT)
 	}(ptrToLocalT, execOpts.options, &chn)
 	<-chn
-
-	// Call cleanup functions after this execution
-	if err := testingTRunCleanup(ptrToLocalT, 1); err != nil {
-		fmt.Printf("cleanup error: %v\n", err)
-	}
 
 	// Lock mutex
 	execOpts.mutex.Lock()
@@ -879,6 +892,10 @@ func executeTestIteration(execOpts *executionOptions) bool {
 			execOpts.panicExecutionMetadata = execMeta
 		}
 	}
+	applyTestCleanupResult(ptrToLocalT, execMeta, &cleanupResult)
+	if cleanupResult.panicData != nil && execOpts.panicExecutionMetadata == nil {
+		execOpts.panicExecutionMetadata = execMeta
+	}
 
 	// Adjust retry count after first execution if necessary
 	if execOpts.options.postAdjustRetryCount != nil && currentIndex == 0 {
@@ -899,6 +916,58 @@ func executeTestIteration(execOpts *executionOptions) bool {
 
 	// Decide whether to continue
 	return execOpts.options.postShouldRetry(ptrToLocalT, execMeta, currentIndex, execOpts.retryCount)
+}
+
+// runTestCleanup executes testing cleanups for a retry attempt. It isolates
+// cleanup Goexit in a helper goroutine so retry orchestration can treat cleanup
+// failures as attempt failures instead of letting them escape the retry loop.
+func runTestCleanup(t *testing.T, result *testCleanupResult) {
+	result.ran = true
+	done := make(chan struct{})
+	go func() {
+		completed := false
+		defer func() {
+			if !completed {
+				result.goexit = true
+			}
+			close(done)
+		}()
+		result.panicData = testingTRunCleanup(t, 1)
+		if result.panicData != nil {
+			result.panicStacktrace = utils.GetStacktrace(1)
+		}
+		completed = true
+	}()
+	<-done
+}
+
+// runAndApplyTestCleanup runs a retry attempt's cleanups before its span is
+// finalized, then applies any cleanup failure to the attempt metadata.
+func runAndApplyTestCleanup(t *testing.T, execMeta *testExecutionMetadata) {
+	if execMeta == nil || execMeta.cleanupResult == nil || execMeta.cleanupResult.ran {
+		return
+	}
+	runTestCleanup(t, execMeta.cleanupResult)
+	applyTestCleanupResult(t, execMeta, execMeta.cleanupResult)
+}
+
+// applyTestCleanupResult applies cleanup panics and failing Goexit results to
+// the test attempt so retry orchestration can make the normal retry decision.
+// Cleanup SkipNow also exits with Goexit, but testing treats that as a skipped
+// test when it is not already failed, so it must keep its skipped status.
+func applyTestCleanupResult(t *testing.T, execMeta *testExecutionMetadata, result *testCleanupResult) {
+	if result == nil || (result.panicData == nil && !result.goexit) {
+		return
+	}
+	if result.panicData == nil && result.goexit && t.Skipped() && !t.Failed() {
+		return
+	}
+	t.Fail()
+	if result.panicData == nil {
+		return
+	}
+	execMeta.panicData = result.panicData
+	execMeta.panicStacktrace = result.panicStacktrace
 }
 
 // propagateTestExecutionMetadataFlags propagates the test execution metadata flags from the original test execution metadata to the current one.

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -586,9 +586,12 @@ func applyAdditionalFeaturesToTestFunc(f func(*testing.T), testInfo *commonInfo,
 				}
 
 				if execMeta.isFlakyTestRetriesEnabled {
-					// For flaky test retries, retry if the test failed and remaining retries >= 0.
-					return ptrToLocalT.Failed() && remainingRetries >= 0 &&
-						atomic.LoadInt64(&integrations.GetFlakyRetriesSettings().RemainingTotalRetryCount) >= 0
+					return willRetryAfterExecution(
+						ptrToLocalT.Failed(),
+						execMeta,
+						remainingRetries,
+						atomic.LoadInt64(&integrations.GetFlakyRetriesSettings().RemainingTotalRetryCount),
+					)
 				}
 
 				// No retries for other cases.
@@ -655,7 +658,7 @@ func applyAdditionalFeaturesToTestFunc(f func(*testing.T), testInfo *commonInfo,
 							status = "skipped"
 						}
 						fmt.Printf("    [ %v after %v retries by Datadog's auto test retries ]\n", status, executionIndex)
-						if atomic.LoadInt64(&integrations.GetFlakyRetriesSettings().RemainingTotalRetryCount) < 1 {
+						if atomic.LoadInt64(&integrations.GetFlakyRetriesSettings().RemainingTotalRetryCount) < 0 {
 							fmt.Println("    the maximum number of total retries was exceeded.")
 						}
 					}

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -833,20 +833,7 @@ func executeTestIteration(execOpts *executionOptions) bool {
 			*cn <- struct{}{}
 		}()
 		defer func() {
-			// handle parallel sub tests execution
-			if localTPrivateFields.sub != nil {
-				if len(*localTPrivateFields.sub) > 0 {
-					if localTPrivateFields.barrier != nil {
-						close(*localTPrivateFields.barrier)
-					}
-					for _, sub := range *localTPrivateFields.sub {
-						pvSub := getTestPrivateFields(sub)
-						if pvSub.signal != nil {
-							<-*pvSub.signal
-						}
-					}
-				}
-			}
+			completeParallelSubtests(localTPrivateFields)
 		}()
 		defer func() {
 			duration = time.Since(startTime)
@@ -925,6 +912,7 @@ func executeTestIteration(execOpts *executionOptions) bool {
 // cleanup Goexit in a helper goroutine so retry orchestration can treat cleanup
 // failures as attempt failures instead of letting them escape the retry loop.
 func runTestCleanup(t *testing.T, result *testCleanupResult) {
+	completeParallelSubtests(getTestPrivateFields(t))
 	result.ran = true
 	done := make(chan struct{})
 	go func() {
@@ -942,6 +930,27 @@ func runTestCleanup(t *testing.T, result *testCleanupResult) {
 		completed = true
 	}()
 	<-done
+}
+
+// completeParallelSubtests releases and waits for parallel subtests owned by a
+// Datadog-managed clone. It clears the subtest queue before releasing the
+// barrier so later cleanup paths cannot close the same barrier twice.
+func completeParallelSubtests(localTPrivateFields *commonPrivateFields) {
+	if localTPrivateFields == nil || localTPrivateFields.sub == nil || len(*localTPrivateFields.sub) == 0 {
+		return
+	}
+
+	subtests := *localTPrivateFields.sub
+	*localTPrivateFields.sub = nil
+	if localTPrivateFields.barrier != nil && *localTPrivateFields.barrier != nil {
+		close(*localTPrivateFields.barrier)
+	}
+	for _, sub := range subtests {
+		pvSub := getTestPrivateFields(sub)
+		if pvSub != nil && pvSub.signal != nil {
+			<-*pvSub.signal
+		}
+	}
 }
 
 // runAndApplyTestCleanup runs a retry attempt's cleanups before its span is

--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -233,6 +233,7 @@ func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
 
 			defer func() {
 				duration := time.Since(startTime)
+				runAndApplyTestCleanup(currentT, execMeta)
 				collectAndWriteLogs(currentT, test)
 
 				if r := recover(); r != nil {

--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -301,7 +301,11 @@ func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
 							test.SetTag(constants.TestAttemptToFixPassed, "false")
 						}
 					}
-					test.SetTag(ext.Error, true)
+					if execMeta.panicData != nil {
+						test.SetError(integrations.WithErrorInfo("panic", fmt.Sprint(execMeta.panicData), execMeta.panicStacktrace))
+					} else {
+						test.SetTag(ext.Error, true)
+					}
 					suite.SetTag(ext.Error, true)
 					module.SetTag(ext.Error, true)
 					test.Close(integrations.ResultStatusFail)

--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -237,6 +237,7 @@ func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
 				collectAndWriteLogs(currentT, test)
 
 				if r := recover(); r != nil {
+					stacktrace := utils.GetStacktrace(1)
 					// Compute whether this is the final execution.
 					finalExec := isFinalExecution(true, false, execMeta, duration)
 
@@ -256,8 +257,17 @@ func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
 							test.SetTag(constants.TestAttemptToFixPassed, "false")
 						}
 					}
-					test.SetError(integrations.WithErrorInfo("panic", fmt.Sprint(r), utils.GetStacktrace(1)))
+					test.SetError(integrations.WithErrorInfo("panic", fmt.Sprint(r), stacktrace))
 					test.Close(integrations.ResultStatusFail)
+					if execMeta.hasAdditionalFeatureWrapper {
+						// Retry wrappers own panic propagation. Record the panic as this
+						// attempt's failure and let runTestWithRetry decide whether to
+						// retry or re-panic after the final execution.
+						currentT.Fail()
+						execMeta.panicData = r
+						execMeta.panicStacktrace = stacktrace
+						return
+					}
 					// This branch re-panics immediately, so retry wrappers cannot run their normal
 					// end-of-attempt cleanup. Close suite/module counters and flush CI Visibility
 					// before handing the panic back to the Go test runner.

--- a/internal/civisibility/integrations/gotesting/reflections_test.go
+++ b/internal/civisibility/integrations/gotesting/reflections_test.go
@@ -7,6 +7,7 @@ package gotesting
 
 import (
 	"reflect"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -59,6 +60,7 @@ func TestGetFieldPointerFrom(t *testing.T) {
 	exerciseTestingInternalsPrivatePointerAssignment(t)
 	exerciseParallelForwardMetadataIsolation(t)
 	exerciseParallelForwardedDuplicateGate(t)
+	exerciseBenchmarkFuncInstrumentationConcurrentWrites(t)
 }
 
 // TestGetInternalTestArray tests the getInternalTestArray function.
@@ -341,6 +343,27 @@ func exerciseParallelForwardedDuplicateGate(t *testing.T) {
 	if firstForwarders.Load() != 1 {
 		t.Fatalf("expected exactly one first Parallel forwarder, got %d", firstForwarders.Load())
 	}
+}
+
+// exerciseBenchmarkFuncInstrumentationConcurrentWrites verifies benchmark
+// instrumentation tracking remains safe when multiple goroutines register the
+// same runtime function.
+func exerciseBenchmarkFuncInstrumentationConcurrentWrites(t *testing.T) {
+	pc, _, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("expected caller information")
+	}
+	fn := runtime.FuncForPC(pc)
+
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Go(func() {
+			for range 100 {
+				setCiVisibilityBenchmarkFunc(fn)
+			}
+		})
+	}
+	wg.Wait()
 }
 
 func BenchmarkGetTestPrivateFields(b *testing.B) {

--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -780,6 +780,14 @@ func runIntelligentTestRunnerTests(m *testing.M) {
 	// check capabilities tags
 	checkCapabilitiesTags(finishedSpans)
 
+	sessionSpans := getSpansWithType(finishedSpans, constants.SpanTypeTestSession)
+	if len(sessionSpans) != 1 {
+		panic(fmt.Sprintf("expected exactly one session span, got %d", len(sessionSpans)))
+	}
+	if got := sessionSpans[0].Tag(constants.CodeCoverageEnabled); got != "false" {
+		panic(fmt.Sprintf("expected %s=false when ITR is enabled without coverage, got %v", constants.CodeCoverageEnabled, got))
+	}
+
 	fmt.Println("All tests passed.")
 	os.Exit(0)
 }

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -401,7 +401,11 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo) func(*testing.T) {
 							test.SetTag(constants.TestAttemptToFixPassed, "false")
 						}
 					}
-					test.SetTag(ext.Error, true)
+					if execMeta.panicData != nil {
+						test.SetError(integrations.WithErrorInfo("panic", fmt.Sprint(execMeta.panicData), execMeta.panicStacktrace))
+					} else {
+						test.SetTag(ext.Error, true)
+					}
 					suite.SetTag(ext.Error, true)
 					module.SetTag(ext.Error, true)
 					test.Close(integrations.ResultStatusFail)

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -331,6 +331,7 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo) func(*testing.T) {
 					*tParent.barrier = tParentOldBarrier
 				}
 			}
+			runAndApplyTestCleanup(t, execMeta)
 
 			// check if is a new EFD test and the duration >= 5 min
 			if execMeta.isANewTest && duration.Minutes() >= 5 {

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -156,11 +157,8 @@ func (ddm *M) instrumentInternalTests(internalTests *[]testing.InternalTest) {
 
 	// Check if the test is going to be skipped by ITR
 	if settings.ItrEnabled {
-		if settings.CodeCoverage && coverage.CanCollect() {
-			session.SetTag(constants.CodeCoverageEnabled, "true")
-		} else {
-			session.SetTag(constants.CodeCoverageEnabled, "true")
-		}
+		coverageEnabled := settings.CodeCoverage && coverage.CanCollect()
+		session.SetTag(constants.CodeCoverageEnabled, strconv.FormatBool(coverageEnabled))
 
 		if settings.TestsSkipping {
 			session.SetTag(constants.ITRTestsSkippingEnabled, "true")

--- a/internal/civisibility/integrations/gotesting/testingB.go
+++ b/internal/civisibility/integrations/gotesting/testingB.go
@@ -195,7 +195,7 @@ func hasCiVisibilityBenchmarkFunc(fn *runtime.Func) bool {
 
 // setCiVisibilityBenchmarkFunc tracks a *runtime.Func as instrumented benchmark.
 func setCiVisibilityBenchmarkFunc(fn *runtime.Func) {
-	civisibilityBenchmarksFuncsMutex.RLock()
-	defer civisibilityBenchmarksFuncsMutex.RUnlock()
+	civisibilityBenchmarksFuncsMutex.Lock()
+	defer civisibilityBenchmarksFuncsMutex.Unlock()
 	civisibilityBenchmarksFuncs[fn] = struct{}{}
 }

--- a/internal/civisibility/utils/git.go
+++ b/internal/civisibility/utils/git.go
@@ -733,12 +733,12 @@ func CreatePackFiles(commitsToInclude []string, commitsToExclude []string) []str
 
 	// construct the full path to the pack files
 	var packFiles []string
-	for i, packFile := range strings.Split(out, "\n") {
+	for packFile := range strings.SplitSeq(out, "\n") {
 		file := filepath.Join(temporaryPath, fmt.Sprintf("-%s.pack", packFile))
 
 		// check if the pack file exists
 		if _, err := os.Stat(file); os.IsNotExist(err) {
-			log.Warn("civisibility: pack file not found: %s", packFiles[i])
+			log.Warn("civisibility: pack file not found: %s", file)
 			continue
 		}
 

--- a/internal/civisibility/utils/git_test.go
+++ b/internal/civisibility/utils/git_test.go
@@ -6,6 +6,8 @@
 package utils
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -159,6 +161,48 @@ func TestPackFiles(t *testing.T) {
 	shas = shas[:min(len(shas), 5)]
 	packfiles := CreatePackFiles(shas, []string{})
 	assert.NotEmpty(t, packfiles)
+}
+
+func TestCreatePackFilesMissingPackFile(t *testing.T) {
+	dir := t.TempDir()
+	gitPath := filepath.Join(dir, "git")
+	script := `#!/bin/sh
+if [ "$1" = "-c" ]; then
+	shift 2
+fi
+case "$1" in
+	rev-list)
+		printf 'abc123\n'
+		;;
+	pack-objects)
+		printf 'packhash\n'
+		;;
+	*)
+		exit 0
+		;;
+esac
+`
+	assert.NoError(t, os.WriteFile(gitPath, []byte(script), 0o755))
+	gitBatPath := filepath.Join(dir, "git.bat")
+	batchScript := `@echo off
+if "%1"=="-c" (
+	shift
+	shift
+)
+if "%1"=="rev-list" (
+	echo abc123
+	exit /b 0
+)
+if "%1"=="pack-objects" (
+	echo packhash
+	exit /b 0
+)
+exit /b 0
+`
+	assert.NoError(t, os.WriteFile(gitBatPath, []byte(batchScript), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	assert.Empty(t, CreatePackFiles([]string{"HEAD"}, nil))
 }
 
 func TestFetchCommitData(t *testing.T) {

--- a/internal/orchestrion/_integration/civisibility_failnow_retry/testing_test.go
+++ b/internal/orchestrion/_integration/civisibility_failnow_retry/testing_test.go
@@ -7,6 +7,7 @@ package civisibility_failnow_retry
 
 import (
 	"os"
+	"sync/atomic"
 	"testing"
 
 	"github.com/DataDog/orchestrion/runtime/built"
@@ -16,6 +17,13 @@ import (
 )
 
 var ciVisibilityPayloads *civisibilitytest.Payloads
+
+var (
+	// cleanupPanicAttempts tracks executions for the cleanup panic retry scenario.
+	cleanupPanicAttempts atomic.Int32
+	// cleanupFatalAttempts tracks executions for the cleanup fatal retry scenario.
+	cleanupFatalAttempts atomic.Int32
+)
 
 func TestMain(m *testing.M) {
 	if !built.WithOrchestrion {
@@ -43,6 +51,30 @@ func TestRetryFatalAlwaysFails(t *testing.T) {
 	t.Fatal("retry fatal")
 }
 
+func TestCleanupPanicRetryPasses(t *testing.T) {
+	attempt := cleanupPanicAttempts.Add(1)
+	t.Cleanup(func() {
+		if attempt == 1 {
+			panic("cleanup panic")
+		}
+	})
+}
+
+func TestCleanupFatalRetryPasses(t *testing.T) {
+	attempt := cleanupFatalAttempts.Add(1)
+	t.Cleanup(func() {
+		if attempt == 1 {
+			t.Fatal("cleanup fatal")
+		}
+	})
+}
+
+func TestCleanupSkipDoesNotRetry(t *testing.T) {
+	t.Cleanup(func() {
+		t.Skip("cleanup skip")
+	})
+}
+
 func TestAfterRetryFatal(t *testing.T) {}
 
 func validateRetryEvents(events civisibilitytest.Events) {
@@ -54,7 +86,7 @@ func validateRetryEvents(events civisibilitytest.Events) {
 	events.CheckEventsByType("test_module_end", 1)
 	events.CheckEventsByType("test_suite_end", 1)
 
-	testEvents := events.CheckEventsByType("test", 4)
+	testEvents := events.CheckEventsByType("test", 9)
 	retries := testEvents.
 		CheckEventsByResourceName("testing_test.go.TestRetryFatalAlwaysFails", 3).
 		CheckEventsByTagAndValue("test.status", "fail", 3).
@@ -64,9 +96,31 @@ func validateRetryEvents(events civisibilitytest.Events) {
 	retries.CheckEventsByTagAndValue("test.retry_reason", "auto_test_retry", 2)
 	retries.CheckEventsByTagAndValue("test.has_failed_all_retries", "true", 1)
 	retries.CheckEventsByTagAndValue("test.final_status", "fail", 1)
+	cleanupPanic := testEvents.
+		CheckEventsByResourceName("testing_test.go.TestCleanupPanicRetryPasses", 2)
+	cleanupPanic.CheckEventsByTagAndValue("test.status", "fail", 1).
+		CheckEventsByTagAndValue("error.type", "panic", 1).
+		CheckEventsByTagAndValue("error.message", "cleanup panic", 1)
+	cleanupPanic.CheckEventsByTagAndValue("test.status", "pass", 1).
+		CheckEventsByTagAndValue("test.final_status", "pass", 1)
+	cleanupPanic.CheckEventsByTagAndValue("test.is_retry", "true", 1)
+	cleanupPanic.CheckEventsByTagAndValue("test.retry_reason", "auto_test_retry", 1)
+	cleanupFatal := testEvents.
+		CheckEventsByResourceName("testing_test.go.TestCleanupFatalRetryPasses", 2)
+	cleanupFatal.CheckEventsByTagAndValue("test.status", "fail", 1)
+	cleanupFatal.CheckEventsByTagAndValue("test.status", "pass", 1).
+		CheckEventsByTagAndValue("test.final_status", "pass", 1)
+	cleanupFatal.CheckEventsByTagAndValue("test.is_retry", "true", 1)
+	cleanupFatal.CheckEventsByTagAndValue("test.retry_reason", "auto_test_retry", 1)
+	cleanupSkip := testEvents.
+		CheckEventsByResourceName("testing_test.go.TestCleanupSkipDoesNotRetry", 1).
+		CheckEventsByTagAndValue("test.status", "skip", 1).
+		CheckEventsByTagAndValue("test.final_status", "skip", 1).
+		CheckEventsWithoutTag("test.is_retry", 1).
+		CheckEventsWithoutTag("test.retry_reason", 1)
 	after := testEvents.
 		CheckEventsByResourceName("testing_test.go.TestAfterRetryFatal", 1).
 		CheckEventsByTagAndValue("test.status", "pass", 1)
 
-	testEvents.Except(retries, after).HasCount(0)
+	testEvents.Except(retries, cleanupPanic, cleanupFatal, cleanupSkip, after).HasCount(0)
 }

--- a/internal/orchestrion/_integration/parallel_testing_retries/parallel_testing_retries_test.go
+++ b/internal/orchestrion/_integration/parallel_testing_retries/parallel_testing_retries_test.go
@@ -77,6 +77,7 @@ type scenarioConfig struct {
 }
 
 var flakyAttempts atomic.Int32
+var subtestPanicAttempts atomic.Int32
 
 func TestMain(m *testing.M) {
 	if !built.WithOrchestrion {
@@ -341,6 +342,7 @@ func scenarioOrder() []string {
 		"TestParallelEFDParallel",
 		"TestParallelFlakyRetry",
 		"TestParallelAttemptToFix",
+		"TestSubtestPanicFlakyRetry",
 		"TestFailNowSingleExecution",
 		"TestManualFailNowSingleExecution",
 		"BenchmarkManualFailNow",
@@ -447,6 +449,29 @@ func scenariosByName() map[string]scenarioConfig {
 				events.CheckEventsByTagAndValue(constants.TestHasFailedAllRetries, "true", 0)
 			},
 		},
+		"TestSubtestPanicFlakyRetry": {
+			testName: "TestSubtestPanicFlakyRetry",
+			settings: flakyRetrySettings(),
+			env: map[string]string{
+				constants.CIVisibilityFlakyRetryEnabledEnvironmentVariable:    "true",
+				constants.CIVisibilityFlakyRetryCountEnvironmentVariable:      "1",
+				constants.CIVisibilityTotalFlakyRetryCountEnvironmentVariable: "1",
+			},
+			expectedTestEvents:     4,
+			expectedSuiteEvents:    1,
+			expectedModuleEvents:   1,
+			expectedSessionEvents:  1,
+			expectedTotalEvents:    7,
+			expectedRetryEvents:    2,
+			retryReason:            constants.AutoTestRetriesRetryReason,
+			expectedResourceEvents: 2,
+			resourceName:           suiteName + ".TestSubtestPanicFlakyRetry/child",
+			validate: func(events civisibilitytest.Events, _ string) {
+				events.CheckEventsByTagAndValue(constants.TestStatus, constants.TestStatusFail, 2)
+				events.CheckEventsByTagAndValue(constants.TestStatus, constants.TestStatusPass, 2)
+				events.CheckEventsByTagAndValue(constants.TestFinalStatus, constants.TestStatusPass, 2)
+			},
+		},
 		"TestFailNowSingleExecution": {
 			testName:                "TestFailNowSingleExecution",
 			expectedTestEvents:      1,
@@ -520,20 +545,22 @@ func scenariosByName() map[string]scenarioConfig {
 				constants.CIVisibilityFlakyRetryCountEnvironmentVariable:      "1",
 				constants.CIVisibilityTotalFlakyRetryCountEnvironmentVariable: "1",
 			},
-			expectedTestEvents:      2,
+			expectedTestEvents:      4,
 			expectedSuiteEvents:     1,
 			expectedModuleEvents:    1,
 			expectedSessionEvents:   1,
-			expectedTotalEvents:     5,
-			expectedFailureOutput:   parallelPanic,
-			expectedResourceEvents:  1,
+			expectedTotalEvents:     7,
+			expectedRetryEvents:     2,
+			retryReason:             constants.AutoTestRetriesRetryReason,
+			expectedResourceEvents:  2,
 			resourceName:            suiteName + ".TestSubtestDuplicateParallel/child",
 			expectFailure:           true,
 			validateFailureInParent: true,
 			validate: func(events civisibilitytest.Events, _ string) {
-				events.CheckEventsByTagAndValue(constants.TestStatus, constants.TestStatusFail, 1)
-				events.CheckEventsByTagAndValue(constants.TestStatus, constants.TestStatusPass, 1)
-				events.CheckEventsByTagAndValue(constants.TestFinalStatus, constants.TestStatusPass, 1)
+				events.CheckEventsByTagAndValue(constants.TestStatus, constants.TestStatusFail, 2)
+				events.CheckEventsByTagAndValue(constants.TestStatus, constants.TestStatusPass, 2)
+				events.CheckEventsByTagAndValue(constants.TestFinalStatus, constants.TestStatusFail, 1)
+				events.CheckEventsByTagAndValue(constants.TestFinalStatus, constants.TestStatusPass, 2)
 			},
 		},
 	}
@@ -623,6 +650,15 @@ func TestParallelFlakyRetry(t *testing.T) {
 func TestParallelAttemptToFix(t *testing.T) {
 	skipUnlessScenario(t, "TestParallelAttemptToFix")
 	t.Parallel()
+}
+
+func TestSubtestPanicFlakyRetry(t *testing.T) {
+	skipUnlessScenario(t, "TestSubtestPanicFlakyRetry")
+	t.Run("child", func(t *testing.T) {
+		if subtestPanicAttempts.Add(1) == 1 {
+			panic("subtest panic on first attempt")
+		}
+	})
 }
 
 func TestFailNowSingleExecution(t *testing.T) {

--- a/internal/orchestrion/_integration/parallel_testing_retries/parallel_testing_retries_test.go
+++ b/internal/orchestrion/_integration/parallel_testing_retries/parallel_testing_retries_test.go
@@ -557,10 +557,10 @@ func scenariosByName() map[string]scenarioConfig {
 			expectFailure:           true,
 			validateFailureInParent: true,
 			validate: func(events civisibilitytest.Events, _ string) {
-				events.CheckEventsByTagAndValue(constants.TestStatus, constants.TestStatusFail, 2)
-				events.CheckEventsByTagAndValue(constants.TestStatus, constants.TestStatusPass, 2)
-				events.CheckEventsByTagAndValue(constants.TestFinalStatus, constants.TestStatusFail, 1)
-				events.CheckEventsByTagAndValue(constants.TestFinalStatus, constants.TestStatusPass, 2)
+				events.CheckEventsByTagAndValue(constants.TestStatus, constants.TestStatusFail, 4)
+				events.CheckEventsByTagAndValue(constants.TestStatus, constants.TestStatusPass, 0)
+				events.CheckEventsByTagAndValue(constants.TestFinalStatus, constants.TestStatusFail, 2)
+				events.CheckEventsByTagAndValue(constants.TestFinalStatus, constants.TestStatusPass, 0)
 			},
 		},
 	}


### PR DESCRIPTION
### What does this PR do?

Fixes several Go CI Visibility edge cases found while reviewing retry, cleanup, coverage, and Git metadata handling after #4717 and #4722.

This PR updates Go test retry orchestration so cleanup failures behave like normal test failures. A cleanup `panic` is recorded on the failing attempt, cleanup `Fatal` / `FailNow` no longer escapes the retry loop through `runtime.Goexit`, and cleanups now run after Datadog-managed parallel subtests have completed so parent cleanup order remains consistent with Go's testing lifecycle.

It also fixes Orchestrion subtest panic handling when a Datadog retry wrapper owns the execution. In that case, subtest panics are recorded as failed attempts and returned to the retry owner, instead of immediately repanicking before retries can run.

Other fixes included here:

- stop automatic flaky retries when the global retry budget reaches zero
- protect benchmark instrumentation map writes with the write lock
- synchronize coverage writer payload rotation between `add` and `flush`
- report `test.code_coverage.enabled=false` when ITR is enabled but coverage is not actually active
- avoid an index panic when Git reports a pack hash but the expected `.pack` file is missing

### Motivation

The previous CI Visibility retry fixes addressed known lifecycle bugs, but a follow-up review found more cases where retry attempts could be misclassified, skipped, or allowed to race with shared state.

The highest-risk issues were in Go cleanup and Orchestrion subtest panic flows. Both are part of the real test result, so they need to pass through the same retry owner that handles failures in the test body. Without that, a cleanup failure could be hidden or abort retry orchestration, and a retryable subtest panic could fail the process before Datadog could schedule the next attempt.

The smaller fixes remove incorrect state reporting and race-prone code paths found during the same review.

### Testing

- [x] `go test ./internal/civisibility/integrations/gotesting/failnow -count=1`
- [x] `go test ./internal/civisibility/integrations/gotesting -count=1`
- [x] `go test ./internal/civisibility/integrations/gotesting/subtests -count=1`
- [x] `go test ./internal/civisibility/utils -run 'TestCreatePackFiles|TestGit|TestPackFiles' -count=1`
- [x] `go test -race ./internal/civisibility/integrations/gotesting/coverage -count=1`
- [x] `Bypass=true go test -race ./internal/civisibility/integrations/gotesting -run TestGetFieldPointerFrom -count=1`
- [x] `PATH="$(go env GOPATH)/bin:$PATH" GOFLAGS="-timeout=30m -tags=githubci,buildtag" go run github.com/DataDog/orchestrion go test -count=1 ./parallel_testing_retries`
- [x] `git diff --check main..HEAD`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.
