### PR TITLE
feat(contrib/grpc): add WithErrorMapper option for non-standard error types

### DIFF
--- a/contrib/google.golang.org/grpc/grpc.go
+++ b/contrib/google.golang.org/grpc/grpc.go
@@ -84,6 +84,9 @@ func finishWithError(span *tracer.Span, err error, cfg *config) {
 	if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
 		err = nil
 	}
+	if err != nil && cfg.errorMapper != nil {
+		err = cfg.errorMapper(err)
+	}
 	errcode := status.Code(err)
 	if errcode == codes.OK || cfg.nonErrorCodes[errcode] {
 		err = nil

--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -934,6 +935,85 @@ func TestWithErrorDetailTags(t *testing.T) {
 		assert.Equal(t, c.details2, serverSpan.Tag("grpc.status_details._2"))
 		rig.Close()
 		mt.Reset()
+	}
+}
+
+// statusOnlyError implements `Status() *status.Status` but not the standard
+// gRPC `GRPCStatus() *status.Status`. This mirrors libraries (e.g.
+// go.temporal.io/api/serviceerror) whose typed errors expose their gRPC code
+// via a non-standard method, causing status.Code(err) to fall back to
+// codes.Unknown unless something maps them first.
+type statusOnlyError struct {
+	st *status.Status
+}
+
+func (e *statusOnlyError) Error() string         { return e.st.Message() }
+func (e *statusOnlyError) Status() *status.Status { return e.st }
+
+func TestWithErrorMapper(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	for _, tc := range []struct {
+		name     string
+		opts     []Option
+		wantCode string
+		wantErr  bool
+	}{
+		{
+			name:     "no mapper falls back to Unknown",
+			opts:     nil,
+			wantCode: codes.Unknown.String(),
+			wantErr:  true,
+		},
+		{
+			name: "mapper recovers real code",
+			opts: []Option{WithErrorMapper(func(err error) error {
+				var soe *statusOnlyError
+				if errors.As(err, &soe) {
+					return soe.st.Err()
+				}
+				return err
+			})},
+			wantCode: codes.NotFound.String(),
+			wantErr:  true,
+		},
+		{
+			name: "mapper combined with NonErrorCodes drops error tag",
+			opts: []Option{
+				WithErrorMapper(func(err error) error {
+					var soe *statusOnlyError
+					if errors.As(err, &soe) {
+						return soe.st.Err()
+					}
+					return err
+				}),
+				NonErrorCodes(codes.NotFound),
+			},
+			wantCode: codes.NotFound.String(),
+			wantErr:  false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer mt.Reset()
+
+			interceptor := UnaryServerInterceptor(tc.opts...)
+			handler := func(_ context.Context, _ interface{}) (interface{}, error) {
+				return nil, &statusOnlyError{st: status.New(codes.NotFound, "not found")}
+			}
+			info := &grpc.UnaryServerInfo{FullMethod: "/pkg.Svc/Method"}
+			_, _ = interceptor(context.Background(), nil, info, handler)
+
+			spans := mt.FinishedSpans()
+			require.Len(t, spans, 1)
+			s := spans[0]
+			assert.Equal(t, tc.wantCode, s.Tag(tagCode))
+			if tc.wantErr {
+				assert.NotNil(t, s.Tag(ext.ErrorMsg))
+			} else {
+				assert.Nil(t, s.Tag(ext.ErrorMsg))
+			}
+		})
 	}
 }
 

--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -947,7 +947,7 @@ type statusOnlyError struct {
 	st *status.Status
 }
 
-func (e *statusOnlyError) Error() string         { return e.st.Message() }
+func (e *statusOnlyError) Error() string          { return e.st.Message() }
 func (e *statusOnlyError) Status() *status.Status { return e.st }
 
 func TestWithErrorMapper(t *testing.T) {

--- a/contrib/google.golang.org/grpc/option.go
+++ b/contrib/google.golang.org/grpc/option.go
@@ -65,6 +65,7 @@ type config struct {
 	ignoredMetadata     map[string]struct{}
 	withRequestTags     bool
 	withErrorDetailTags bool
+	errorMapper         ErrorMapper
 	spanOpts            []tracer.StartSpanOption
 	tags                map[string]interface{}
 }
@@ -205,6 +206,33 @@ func WithRequestTags() OptionFn {
 func WithErrorDetailTags() OptionFn {
 	return func(cfg *config) {
 		cfg.withErrorDetailTags = true
+	}
+}
+
+// ErrorMapper translates a handler/call error into a different error before the
+// gRPC integration extracts its status code. It is intended for libraries whose
+// typed errors do not implement the standard `GRPCStatus() *status.Status`
+// interface — for example go.temporal.io/api/serviceerror.*, which exposes
+// `Status() *status.Status` only. Returning err unchanged (or nil) is a safe
+// no-op; returning a *status.Error (or any error implementing GRPCStatus) lets
+// the tracer record the real gRPC code instead of falling back to Unknown.
+type ErrorMapper func(err error) error
+
+// WithErrorMapper installs a custom mapper invoked on every non-nil handler
+// error before the integration reads its gRPC status code. The mapper runs
+// after the io.EOF / context.Canceled short-circuits and before
+// status.Code(err) / status.FromError(err) are called.
+//
+// Example, integrating with go.temporal.io/api/serviceerror:
+//
+//	import "go.temporal.io/api/serviceerror"
+//
+//	grpctrace.WithErrorMapper(func(err error) error {
+//	    return serviceerror.ToStatus(err).Err()
+//	})
+func WithErrorMapper(m ErrorMapper) OptionFn {
+	return func(cfg *config) {
+		cfg.errorMapper = m
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds a `WithErrorMapper` option to the `contrib/google.golang.org/grpc` integration. The mapper translates a handler/call error into a different error before the integration extracts its gRPC status code. It is intended for libraries whose typed errors do not implement the standard `GRPCStatus() *status.Status` interface.

### Motivation

The gRPC integration extracts response codes via `google.golang.org/grpc/status.Code(err)`, which only consults `GRPCStatus()`. Libraries that expose their gRPC code via a different method silently end up reported as `grpc.code:Unknown` on every span. The most common offender today is [`go.temporal.io/api/serviceerror`](https://github.com/temporalio/api-go/tree/master/serviceerror) — every typed temporal error (`NotFound`, `AlreadyExists`, `WorkflowExecutionAlreadyStarted`, `Internal`, …) implements only `Status() *status.Status`. The result is that every temporal error span across server and client is reported as `Unknown`, which makes APM error breakdowns useless and forces consumers to maintain per-application converter interceptors.

This is happening today across Datadog itself — every Atlas (Temporal-as-a-service) cluster, plus every service that calls into Temporal, surfaces the same issue:

- **staging**: [grpc.code:Unknown traces](https://ddstaging.datadoghq.com/apm/traces?query=env%3Astaging%20%40grpc.code%3AUnknown&agg_m=count&agg_m_source=base&agg_t=count&cols=service%2Cresource_name%2C%40duration%2C%40http.status_code%2C%40_span.count%2C%40_duration.by_service&fromUser=false&graphType=flamegraph&historicalData=true&query_translation_version=v0&shouldShowLegend=true&spanType=all&step=auto&storage=hot&traceQuery=&view=spans&viz=stream&start=1778076870997&end=1778077770997&paused=false)
- **prod**: [grpc.code:Unknown traces](https://app.datadoghq.com/apm/traces?query=env%3Aprod%20%40grpc.code%3AUnknown&agg_m=count&agg_m_source=base&agg_t=count&cols=service%2Cresource_name%2C%40duration%2C%40http.status_code%2C%40_span.count%2C%40_duration.by_service&fromUser=false&graphType=flamegraph&historicalData=true&messageDisplay=inline&query_translation_version=v0&refresh_mode=sliding&shouldShowLegend=true&sort=desc&spanType=all&step=auto&storage=hot&trace_group_by_from=a&traceQuery=&view=spans&viz=stream&start=1778076887506&end=1778077787506&paused=false)

A large fraction of those `Unknown`s are temporal-frontend / temporal-history / temporal-matching spans where the underlying error is a typed `serviceerror.*` whose code never made it past `status.Code(err)`.

### Proposed change

Introduce a single hook:

```go
// ErrorMapper translates a handler/call error into a different error before
// the gRPC integration extracts its status code.
type ErrorMapper func(err error) error

// WithErrorMapper installs a custom mapper invoked on every non-nil handler
// error before the integration reads its gRPC status code. The mapper runs
// after the io.EOF / context.Canceled short-circuits and before
// status.Code(err) / status.FromError(err) are called.
func WithErrorMapper(m ErrorMapper) OptionFn
```

Wired into `finishWithError` as a single new line, immediately after the existing EOF/Canceled short-circuit and before code extraction. When no mapper is configured, behaviour is identical to before.

### Usage

For temporal:

```go
import (
    grpctrace "github.com/DataDog/dd-trace-go/contrib/google.golang.org/grpc/v2"
    "go.temporal.io/api/serviceerror"
)

grpctrace.UnaryServerInterceptor(
    grpctrace.WithErrorMapper(func(err error) error {
        return serviceerror.ToStatus(err).Err()
    }),
)
```

The same option also works on `UnaryClientInterceptor`, `StreamServerInterceptor`, `StreamClientInterceptor`, and the stats handlers, so a single mapper covers both directions of every gRPC call.

### Tests

Added `TestWithErrorMapper` with three cases:

- **no mapper**: handler returns a `Status()`-only typed error → span reports `grpc.code:Unknown` (current behaviour preserved).
- **mapper recovers real code**: mapper rewrites the error to `*status.Error{NotFound}` → span reports `grpc.code:NotFound` and is tagged as error.
- **mapper + `NonErrorCodes(NotFound)`**: same as above but combined with the existing option → span reports `grpc.code:NotFound` and `error` tag is unset.

### Backwards compatibility

Strictly additive. No existing call sites are affected. The default `config.errorMapper` is `nil`, in which case `finishWithError` skips the new branch and falls through to the existing `status.Code(err)` path.

### Describe how to test/QA your changes

`go test -count=1 -run TestWithErrorMapper ./contrib/google.golang.org/grpc/...`

### Reviewer's Checklist

- [x] Library functionality changes
- [ ] Bug fixes
- [x] New feature (non-breaking change which adds functionality)
- [x] Unit tests added
