### PR TITLE
fix(ddtrace/tracer): wire version on aggregation key when adding a span to client-side stats

### DIFF
--- a/ddtrace/tracer/stats.go
+++ b/ddtrace/tracer/stats.go
@@ -67,6 +67,7 @@ type concentrator struct {
 type tracerStatSpan struct {
 	statSpan *stats.StatSpan
 	origin   string
+	version  string // per-span version tag; "" means use global aggKey version
 }
 
 // newConcentrator creates a new concentrator using the given tracer
@@ -197,10 +198,10 @@ func (c *concentrator) newTracerStatSpan(s *Span, obfuscator *obfuscate.Obfuscat
 	if !ok {
 		return nil, false
 	}
-	origin := s.meta[keyOrigin]
 	return &tracerStatSpan{
 		statSpan: statSpan,
-		origin:   origin,
+		origin:   s.meta[keyOrigin],
+		version:  s.meta[ext.Version],
 	}, true
 }
 
@@ -212,7 +213,11 @@ func (c *concentrator) shouldObfuscate() bool {
 
 // add s into the concentrator's internal stats buckets.
 func (c *concentrator) add(s *tracerStatSpan) {
-	c.spanConcentrator.AddSpan(s.statSpan, c.aggregationKey, "", nil, s.origin)
+	aggKey := c.aggregationKey
+	if s.version != "" {
+		aggKey.Version = s.version
+	}
+	c.spanConcentrator.AddSpan(s.statSpan, aggKey, "", nil, s.origin)
 }
 
 // Stop stops the concentrator and blocks until the operation completes.

--- a/ddtrace/tracer/stats_test.go
+++ b/ddtrace/tracer/stats_test.go
@@ -315,6 +315,83 @@ func TestConcentratorDefaultEnv(t *testing.T) {
 	})
 }
 
+func TestPerSpanVersionInStats(t *testing.T) {
+	bucketSize := int64(500_000)
+	makeSpan := func(version string) *Span {
+		s := &Span{
+			name:     "http.request",
+			start:    time.Now().UnixNano() + 3*bucketSize,
+			duration: 1,
+			metrics:  map[string]float64{keyMeasured: 1},
+		}
+		if version != "" {
+			s.meta = map[string]string{ext.Version: version}
+		}
+		return s
+	}
+
+	t.Run("per-span version propagates to stats payload", func(t *testing.T) {
+		spanVersion := "synthtracer-20250501120000"
+		transport := newDummyTransport()
+		c := newConcentrator(newTestConfigWithTransport(t, transport), bucketSize, &statsd.NoOpClientDirect{})
+
+		s := makeSpan(spanVersion)
+		ss, ok := c.newTracerStatSpan(s, nil)
+		require.True(t, ok)
+		c.Start()
+		c.In <- ss
+		c.Stop()
+
+		got := transport.Stats()
+		require.Len(t, got, 1)
+		assert.Equal(t, spanVersion, got[0].Version,
+			"per-span version tag must be used when no global version is configured")
+	})
+
+	t.Run("falls back to global config version when span has no version tag", func(t *testing.T) {
+		transport := newDummyTransport()
+		cfg, err := newTestConfig(withNoopInfoHTTPClient(), func(c *config) {
+			c.ddTransport = transport
+			c.internalConfig.SetVersion("global-v1.2.3", internalconfig.OriginCode)
+		})
+		require.NoError(t, err)
+		c := newConcentrator(cfg, bucketSize, &statsd.NoOpClientDirect{})
+
+		s := makeSpan("")
+		ss, ok := c.newTracerStatSpan(s, nil)
+		require.True(t, ok)
+		c.Start()
+		c.In <- ss
+		c.Stop()
+
+		got := transport.Stats()
+		require.Len(t, got, 1)
+		assert.Equal(t, "global-v1.2.3", got[0].Version)
+	})
+
+	t.Run("two spans with different versions produce separate payloads", func(t *testing.T) {
+		transport := newDummyTransport()
+		c := newConcentrator(newTestConfigWithTransport(t, transport), bucketSize, &statsd.NoOpClientDirect{})
+
+		s1 := makeSpan("v-timestamp-1")
+		s2 := makeSpan("v-timestamp-2")
+		ss1, ok := c.newTracerStatSpan(s1, nil)
+		require.True(t, ok)
+		ss2, ok := c.newTracerStatSpan(s2, nil)
+		require.True(t, ok)
+		c.Start()
+		c.In <- ss1
+		c.In <- ss2
+		c.Stop()
+
+		got := transport.Stats()
+		require.Len(t, got, 2)
+		versions := map[string]struct{}{got[0].Version: {}, got[1].Version: {}}
+		assert.Contains(t, versions, "v-timestamp-1")
+		assert.Contains(t, versions, "v-timestamp-2")
+	})
+}
+
 func TestStatsIncludeHTTPMethodAndEndpoint(t *testing.T) {
 	uniqueMethod := "POST"
 	uniqueEndpoint := "/__unique_endpoint__"


### PR DESCRIPTION
### What does this PR do?

## `ddtrace/tracer/stats.go` — 3 changes

**1. `tracerStatSpan` gets a `version` field**

```go
type tracerStatSpan struct {
    statSpan *stats.StatSpan
    origin   string
    version  string  // per-span version tag; "" means use global aggKey version
}
```

The struct that carries a finished span to the concentrator's goroutine now also carries whatever `version` meta tag was on the span.

**2. `newTracerStatSpan` captures `ext.Version` from the span meta**

```go
return &tracerStatSpan{
    statSpan: statSpan,
    origin:   s.meta[keyOrigin],
    version:  s.meta[ext.Version],  // ← new
}, true
```

Called on the hot path when a span finishes. Reads `s.meta["version"]` — the same tag synthtracer sets via `tracer.Tag("version", currentVersion())`.

**3. `add()` overrides the payload aggregation key version per-span**

```go
func (c *concentrator) add(s *tracerStatSpan) {
    aggKey := c.aggregationKey          // value copy — c.aggregationKey unchanged
    if s.version != "" {
        aggKey.Version = s.version      // per-span version wins
    }
    c.spanConcentrator.AddSpan(s.statSpan, aggKey, "", nil, s.origin)
}
```

`c.aggregationKey` is built once at startup with `Version = c.internalConfig.Version()` (empty for synthtracer). Before this fix, every span used that frozen empty version → `N/A`. Now each span can carry its own version into a separate stats bucket, matching what the agent-side concentrator does when computing server-side stats.

---

## `ddtrace/tracer/stats_test.go` — `TestPerSpanVersionInStats`

Three sub-tests that pin the behaviour:

| Sub-test                                                           | What it verifies                                                                                         |
| ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
| `per-span version propagates to stats payload`                     | Span with `version` tag → `ClientStatsPayload.Version` matches tag (was failing before fix)              |
| `falls back to global config version when span has no version tag` | No span tag → uses `WithServiceVersion()` / `DD_VERSION` (existing behaviour preserved)                  |
| `two spans with different versions produce separate payloads`      | Different per-span versions → separate stats payloads, not collapsed under `""` (was failing before fix) |

### Motivation

Ensure that stats are properly tagged with the version, both global and per-span.

Root cause:
 - PR #4451 (commit 6e49f81ea) introduced periodic /info polling every 5s in v2.8.0.
 - DropP0s + Stats are dynamic fields refreshed by that poll.
 - Once the sidecar agent's client_drop_p0s: true is detected (after startup), the concentrator activates.
 - The concentrator's aggregationKey.Version was set at construction from c.internalConfig.Version() = "" (no global version).
 - All client-side stats are emitted with version="" → N/A.
 - The agent-side concentrator reads version from each span's meta["version"] via pt.AppVersion, so it always picked up the rotating tag. Client-side does not.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
