### PR TITLE
ci(benchmarks): Fix wrong CI image link for macrobenchmarks

### DIFF
--- a/.gitlab/benchmarks/README.md
+++ b/.gitlab/benchmarks/README.md
@@ -64,14 +64,14 @@ configuration for this suite, open a PR against
 4. The `go-go-prof-app-parallel` and `go-go-prof-app-parallel-slo` stages run the next-generation parallel `go-prof-app`
    macrobenchmarks alongside the legacy `macro/` suite.
 
-Each suite pins its own `BENCHMARKS_CI_IMAGE` and runs on dedicated
+Each suite pins its own CI image and runs on dedicated
 bare-metal GitLab runners to keep results stable:
 
-- **Microbenchmarks** and **test-apps** use
+- **Microbenchmarks** use `MICROBENCHMARKS_CI_IMAGE` and **test-apps** use `TESTAPPS_BENCHMARKS_CI_IMAGE`:
   `registry.ddbuild.io/ci/benchmarking-platform:dd-trace-go-<job-id>`,
   built from `micro/container/` (a `golang` base plus `bp-runner` tooling
   installed via `bp-install`).
-- **Macrobenchmarks** use a separate image:
+- **Macrobenchmarks** use `MACROBENCHMARKS_CI_IMAGE`:
   `486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:go-go-prof-app-and-serviceextensions-and-haproxy-<rev>`,
   which bundles the `go-prof-app` SUT, the Envoy service-extensions and
   HAProxy SPOA harnesses.

--- a/.gitlab/benchmarks/macro/gitlab-ci.yml
+++ b/.gitlab/benchmarks/macro/gitlab-ci.yml
@@ -1,5 +1,5 @@
 variables:
-  BENCHMARKS_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:go-go-prof-app-and-serviceextensions-and-haproxy-0003
+  MACROBENCHMARKS_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:go-go-prof-app-and-serviceextensions-and-haproxy-0003
 
 .on-graphite-never: &on-graphite-never
   if: $CI_COMMIT_BRANCH =~ /^graphite-base\/.*$/
@@ -40,7 +40,7 @@ variables:
   timeout: 1h
   rules: *macrobenchmarks-rules
   # If you have a problem with Gitlab cache, see Troubleshooting section in Benchmarking Platform docs
-  image: $BENCHMARKS_CI_IMAGE
+  image: $MACROBENCHMARKS_CI_IMAGE
   script:
     - git clone --branch go/go-prof-app https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
     - "./generate-run-plan-and-run-benchmarks.sh"
@@ -289,7 +289,7 @@ notify-slo-breaches:
   timeout: 1h
   rules: *macrobenchmarks-rules
   # If you have a problem with Gitlab cache, see Troubleshooting section in Benchmarking Platform docs
-  image: $BENCHMARKS_CI_IMAGE
+  image: $MACROBENCHMARKS_CI_IMAGE
   script:
     - git clone --branch go/go-prof-app https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
     - bp-runner bp-runner.envoy_serviceextension.yml --debug
@@ -385,7 +385,7 @@ se-no-tracer-no-ext_proc:
   timeout: 1h
   rules: *macrobenchmarks-rules
   # If you have a problem with Gitlab cache, see Troubleshooting section in Benchmarking Platform docs
-  image: $BENCHMARKS_CI_IMAGE
+  image: $MACROBENCHMARKS_CI_IMAGE
   script:
     - git clone --branch go/go-prof-app https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
     - bp-runner bp-runner.haproxy_spoa.yml --debug

--- a/.gitlab/benchmarks/micro/README.md
+++ b/.gitlab/benchmarks/micro/README.md
@@ -78,7 +78,7 @@ for instructions on how to measure run-to-run variance.
 
 # How to rebuild the CI Docker image
 
-The `BENCHMARKS_CI_IMAGE` used by the microbenchmarks pipelines
+The `MICROBENCHMARKS_CI_IMAGE` used by the microbenchmarks pipelines
 is built from Dockerfile in `.gitlab/benchmarks/micro/container/`. You need to rebuild and update
 the pinned tag whenever you change any of files in that directory (e.g. bumping the Go
 base image, adding system packages, or updating `bp-runner` / `bp-analyzer` /
@@ -107,7 +107,9 @@ Steps:
 
    ```yaml
    # Benchmarks image is created here: <paste build-base-ci-image job URL>
-   BENCHMARKS_CI_IMAGE: registry.ddbuild.io/ci/benchmarking-platform:dd-trace-go-<NEW_PIPELINE_ID>
+   # In micro/gitlab-ci.yml the variable is named MICROBENCHMARKS_CI_IMAGE;
+   # in test-apps/test-apps.yml it is named TESTAPPS_BENCHMARKS_CI_IMAGE.
+   <VAR_NAME>: registry.ddbuild.io/ci/benchmarking-platform:dd-trace-go-<NEW_PIPELINE_ID>
    ```
 
 5. Push the update. The microbenchmarks will now run

--- a/.gitlab/benchmarks/micro/README.md
+++ b/.gitlab/benchmarks/micro/README.md
@@ -105,11 +105,16 @@ Steps:
    - `.gitlab/benchmarks/micro/gitlab-ci.yml`
    - `.gitlab/benchmarks/test-apps/test-apps.yml`
 
+   In micro/gitlab-ci.yml the variable is named MICROBENCHMARKS_CI_IMAGE:
    ```yaml
    # Benchmarks image is created here: <paste build-base-ci-image job URL>
-   # In micro/gitlab-ci.yml the variable is named MICROBENCHMARKS_CI_IMAGE;
-   # in test-apps/test-apps.yml it is named TESTAPPS_BENCHMARKS_CI_IMAGE.
-   <VAR_NAME>: registry.ddbuild.io/ci/benchmarking-platform:dd-trace-go-<NEW_PIPELINE_ID>
+   MICROBENCHMARKS_CI_IMAGE: registry.ddbuild.io/ci/benchmarking-platform:dd-trace-go-<NEW_PIPELINE_ID>
+   ```
+   
+   In test-apps/test-apps.yml it is named TESTAPPS_BENCHMARKS_CI_IMAGE:
+   ```yaml
+   # Benchmarks image is created here: <paste build-base-ci-image job URL>
+   TESTAPPS_BENCHMARKS_CI_IMAGE: registry.ddbuild.io/ci/benchmarking-platform:dd-trace-go-<NEW_PIPELINE_ID>
    ```
 
 5. Push the update. The microbenchmarks will now run

--- a/.gitlab/benchmarks/micro/gitlab-ci.yml
+++ b/.gitlab/benchmarks/micro/gitlab-ci.yml
@@ -9,7 +9,7 @@ variables:
   BASE_CI_IMAGE_CONTAINER_DIR: .gitlab/benchmarks/micro/container
 
   # Benchmarks image is created here: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-go/-/jobs/1657729516
-  BENCHMARKS_CI_IMAGE: registry.ddbuild.io/ci/benchmarking-platform:dd-trace-go-111525540
+  MICROBENCHMARKS_CI_IMAGE: registry.ddbuild.io/ci/benchmarking-platform:dd-trace-go-111525540
 
   # Changes smaller than SIGNIFICANT_IMPACT_THRESHOLD will be treated as a noise
   SIGNIFICANT_IMPACT_THRESHOLD: 2.0
@@ -32,7 +32,7 @@ variables:
 
 .microbenchmarks:
   stage: microbenchmarks
-  image: $BENCHMARKS_CI_IMAGE
+  image: $MICROBENCHMARKS_CI_IMAGE
   rules: *benchmark-rules
   timeout: 45m
   tags: ["runner:apm-k8s-m8g-metal"]
@@ -89,7 +89,7 @@ pr-performance-gates:
   rules: *benchmark-rules
   tags:
     - "arch:amd64"
-  image: $BENCHMARKS_CI_IMAGE
+  image: $MICROBENCHMARKS_CI_IMAGE
   script:
     - bp-runner .gitlab/benchmarks/pr-gate.thresholds.yml --debug
   artifacts:

--- a/.gitlab/benchmarks/test-apps/test-apps.yml
+++ b/.gitlab/benchmarks/test-apps/test-apps.yml
@@ -1,11 +1,11 @@
 variables:
   # Benchmarks image is created here: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-go/-/jobs/1657729516
-  BENCHMARKS_CI_IMAGE: registry.ddbuild.io/ci/benchmarking-platform:dd-trace-go-111525540
+  TESTAPPS_BENCHMARKS_CI_IMAGE: registry.ddbuild.io/ci/benchmarking-platform:dd-trace-go-111525540
 
 unit-of-work:
   stage: test-apps
   when: manual
-  image: $BENCHMARKS_CI_IMAGE
+  image: $TESTAPPS_BENCHMARKS_CI_IMAGE
   timeout: 1h
   interruptible: true
   tags: ["runner:apm-k8s-tweaked-metal"]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Fix broken CI image link for macrobenchmarks, as a result fixing the failing runs on main branch.

### Motivation

Fix failing macrobenchmark runs on main branch.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
