### PR TITLE
perf(ddtrace/tracer): make propagatingTags lock-free

### DIFF
--- a/ddtrace/tracer/propagating_tags.go
+++ b/ddtrace/tracer/propagating_tags.go
@@ -6,24 +6,113 @@
 package tracer
 
 import (
+	"maps"
 	"strconv"
+	_ "unsafe" // for go:linkname
 
 	"github.com/DataDog/dd-trace-go/v2/internal"
 	"github.com/DataDog/dd-trace-go/v2/internal/locking/assert"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 )
 
+// loadPropagatingTags returns the current propagating-tags snapshot. The
+// returned map must not be modified.
+func (t *trace) loadPropagatingTags() map[string]string {
+	if snap := t.propagatingTags.Load(); snap != nil {
+		return snap.(map[string]string)
+	}
+	return nil
+}
+
+// copyOnWriteSet stores key=value in the propagating-tags map using
+// copy-on-write so concurrent readers remain lock-free. Caller must hold t.mu.
+// +checklocks:t.mu
+func (t *trace) copyOnWriteSet(key, value string) {
+	assert.RWMutexLocked(&t.mu)
+	oldMap := t.loadPropagatingTags()
+	if oldMap != nil && oldMap[key] == value {
+		return // value unchanged — skip allocation
+	}
+	var m map[string]string
+	if oldMap == nil {
+		m = map[string]string{key: value}
+	} else {
+		n := len(oldMap)
+		if _, exists := oldMap[key]; !exists {
+			n++ // new key, not an update
+		}
+		m = make(map[string]string, n)
+		maps.Copy(m, oldMap)
+		m[key] = value
+	}
+	t.propagatingTags.Store(m)
+}
+
+// copyOnWriteDelete removes key from the propagating-tags map.
+// Caller must hold t.mu.
+// +checklocks:t.mu
+func (t *trace) copyOnWriteDelete(key string) {
+	assert.RWMutexLocked(&t.mu)
+	oldMap := t.loadPropagatingTags()
+	if oldMap == nil {
+		return
+	}
+	if _, exists := oldMap[key]; !exists {
+		return
+	}
+	m := make(map[string]string, len(oldMap)-1)
+	for k, v := range oldMap {
+		if k != key {
+			m[k] = v
+		}
+	}
+	t.propagatingTags.Store(m)
+}
+
 func (t *trace) hasPropagatingTag(k string) bool {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	_, ok := t.propagatingTags[k]
+	m := t.loadPropagatingTags()
+	if m == nil {
+		return false
+	}
+	_, ok := m[k]
 	return ok
 }
 
 func (t *trace) propagatingTag(k string) string {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	return t.propagatingTags[k]
+	if m := t.loadPropagatingTags(); m != nil {
+		return m[k]
+	}
+	return ""
+}
+
+// iteratePropagatingTags iterates the propagating tags without holding any
+// lock. f should return false to stop iteration.
+func (t *trace) iteratePropagatingTags(f func(k, v string) bool) {
+	for k, v := range t.loadPropagatingTags() {
+		if !f(k, v) {
+			break
+		}
+	}
+}
+
+// setPropagatingTagUnsafe writes key=value directly into the propagating-tags
+// map without copy-on-write. Caller must guarantee the trace is not yet visible
+// to other goroutines (e.g. during header extraction, before SpanContext is
+// returned). The currently stored map is mutated in place; a new map is
+// allocated (and stored atomically) only when the atomic.Value holds nil. If
+// an intervening CoW write (e.g. from setSamplingPriority) has swapped in a
+// new map, this call loads and mutates that newer map instead.
+// +checklocksignore - Caller guarantees no concurrent access.
+func (t *trace) setPropagatingTagUnsafe(key, value string) {
+	m := t.loadPropagatingTags()
+	if m == nil {
+		m = make(map[string]string, 4)
+		t.propagatingTags.Store(m)
+	}
+	m[key] = value
+	if key == keyDecisionMaker {
+		t.dm = parseDecisionMaker(value)
+	}
 }
 
 // setPropagatingTag sets the key/value pair as a trace propagating tag.
@@ -33,24 +122,30 @@ func (t *trace) setPropagatingTag(key, value string) {
 	t.setPropagatingTagLocked(key, value)
 }
 
+// setSpanContextPropagatingTag is a testing helper reachable via go:linkname
+// from instrumentation/testutils. It exists to avoid unsafe struct mirroring
+// in tests. Panics if ctx has no trace attached (i.e. was not created from a span).
+//
+//go:linkname setSpanContextPropagatingTag
+func setSpanContextPropagatingTag(ctx *SpanContext, k, v string) {
+	ctx.trace.setPropagatingTag(k, v)
+}
+
 func (t *trace) setTraceSourcePropagatingTag(key string, value internal.TraceSource) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	// If there is already a TraceSource value set in the trace
 	// we need to add the new value to the bitmask.
-	if source := t.propagatingTags[key]; source != "" {
+	if source := t.propagatingTag(key); source != "" {
 		tSource, err := internal.ParseTraceSource(source)
 		if err != nil {
 			log.Error("failed to parse trace source tag: %s", err.Error())
 		}
-
 		tSource |= value
-
 		t.setPropagatingTagLocked(key, tSource.String())
 		return
 	}
-
 	t.setPropagatingTagLocked(key, value.String())
 }
 
@@ -59,10 +154,7 @@ func (t *trace) setTraceSourcePropagatingTag(key string, value internal.TraceSou
 // +checklocks:t.mu
 func (t *trace) setPropagatingTagLocked(key, value string) {
 	assert.RWMutexLocked(&t.mu)
-	if t.propagatingTags == nil {
-		t.propagatingTags = make(map[string]string, 1)
-	}
-	t.propagatingTags[key] = value
+	t.copyOnWriteSet(key, value)
 	if key == keyDecisionMaker {
 		t.dm = parseDecisionMaker(value)
 	}
@@ -78,41 +170,35 @@ func (t *trace) unsetPropagatingTag(key string) {
 // +checklocks:t.mu
 func (t *trace) unsetPropagatingTagLocked(key string) {
 	assert.RWMutexLocked(&t.mu)
-	delete(t.propagatingTags, key)
+	t.copyOnWriteDelete(key)
 	if key == keyDecisionMaker {
 		t.dm = 0
-	}
-}
-
-// iteratePropagatingTags allows safe iteration through the propagating tags of a trace.
-// the trace must not be modified during this call, as it is locked for reading.
-//
-// f should return whether the iteration should continue.
-func (t *trace) iteratePropagatingTags(f func(k, v string) bool) {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	for k, v := range t.propagatingTags {
-		if !f(k, v) {
-			break
-		}
 	}
 }
 
 func (t *trace) replacePropagatingTags(tags map[string]string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.propagatingTags = tags
-	if dm, ok := tags[keyDecisionMaker]; ok {
-		t.dm = parseDecisionMaker(dm)
-	} else {
+	if len(tags) == 0 {
+		// Typed nil keeps the atomic.Value type consistent across all stores
+		// (Store(nil) would panic; a typed nil is a valid same-type value).
+		t.propagatingTags.Store(map[string]string(nil))
 		t.dm = 0
+	} else {
+		// Clone so that the stored snapshot is immutable and independent of
+		// whatever the caller holds.
+		cp := maps.Clone(tags)
+		t.propagatingTags.Store(cp)
+		if dm, ok := cp[keyDecisionMaker]; ok {
+			t.dm = parseDecisionMaker(dm)
+		} else {
+			t.dm = 0
+		}
 	}
 }
 
 func (t *trace) propagatingTagsLen() int {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	return len(t.propagatingTags)
+	return len(t.loadPropagatingTags())
 }
 
 // parseDecisionMaker parses the decision maker string (e.g. "-4") into

--- a/ddtrace/tracer/propagating_tags_bench_test.go
+++ b/ddtrace/tracer/propagating_tags_bench_test.go
@@ -1,0 +1,163 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package tracer
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// BenchmarkInjectOnly measures the cost of a single Inject call with no concurrency.
+func BenchmarkInjectOnly(b *testing.B) {
+	trc, err := newTracer(withTransport(newDummyTransport()), withNoopStats())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer trc.Stop()
+	root := trc.StartSpan("server")
+	ctx := root.Context()
+	carrier := HTTPHeadersCarrier(http.Header{})
+	b.ResetTimer()
+	for range b.N {
+		_ = trc.Inject(ctx, carrier)
+	}
+	root.Finish()
+}
+
+// BenchmarkTraceMuContention measures raw trace.mu lock/unlock throughput as a
+// baseline for other contention benchmarks.
+func BenchmarkTraceMuContention(b *testing.B) {
+	for _, n := range []int{1, 2, 4, 8, 16, 32, 64, 128} {
+		b.Run(fmt.Sprintf("goroutines_%03d", n), func(b *testing.B) {
+			t := newTrace()
+			var counter atomic.Int64
+			var wg sync.WaitGroup
+			b.ResetTimer()
+			for range n {
+				wg.Go(func() {
+					for counter.Add(1) <= int64(b.N) {
+						t.mu.Lock()
+						t.mu.Unlock()
+					}
+				})
+			}
+			wg.Wait()
+		})
+	}
+}
+
+// BenchmarkInjectMultiG measures Inject throughput as goroutine count increases.
+// ns/op rising with N indicates serialisation; falling indicates parallel scaling.
+func BenchmarkInjectMultiG(b *testing.B) {
+	for _, n := range []int{1, 2, 4, 8, 16, 32, 64} {
+		b.Run(fmt.Sprintf("goroutines_%03d", n), func(b *testing.B) {
+			trc, err := newTracer(withTransport(newDummyTransport()), withNoopStats())
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer trc.Stop()
+			root := trc.StartSpan("server")
+			ctx := root.Context()
+			var counter atomic.Int64
+			var wg sync.WaitGroup
+			b.ResetTimer()
+			for range n {
+				wg.Go(func() {
+					carrier := HTTPHeadersCarrier(http.Header{})
+					for counter.Add(1) <= int64(b.N) {
+						_ = trc.Inject(ctx, carrier)
+					}
+				})
+			}
+			wg.Wait()
+			root.Finish()
+		})
+	}
+}
+
+// BenchmarkInjectPushMuContention measures Inject throughput when competing with
+// concurrent writers (simulating push). Half the goroutines call Inject; the
+// other half acquire trace.mu directly, as push does.
+func BenchmarkInjectPushMuContention(b *testing.B) {
+	for _, n := range []int{1, 2, 4, 8, 16, 32, 64, 128} {
+		b.Run(fmt.Sprintf("goroutines_%03d", n), func(b *testing.B) {
+			trc, err := newTracer(withTransport(newDummyTransport()), withNoopStats())
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer trc.Stop()
+
+			root := trc.StartSpan("server")
+			ctx := root.Context()
+			tr := root.context.trace
+
+			var counter atomic.Int64
+			var wg sync.WaitGroup
+
+			b.ResetTimer()
+
+			for i := range n {
+				isInjector := i%2 != 0
+				wg.Go(func() {
+					carrier := HTTPHeadersCarrier(http.Header{})
+					for counter.Add(1) <= int64(b.N) {
+						if isInjector {
+							_ = trc.Inject(ctx, carrier)
+						} else {
+							tr.mu.Lock()
+							tr.mu.Unlock()
+						}
+					}
+				})
+			}
+			wg.Wait()
+			root.Finish()
+		})
+	}
+}
+
+// BenchmarkTraceContention measures the full outgoing-call sequence
+// (StartSpan → Inject → Finish) under increasing concurrency.
+func BenchmarkTraceContention(b *testing.B) {
+	old := traceMaxSize
+	traceMaxSize = 1 << 27
+	b.Cleanup(func() { traceMaxSize = old })
+
+	for _, n := range []int{1, 2, 4, 8, 16, 32, 64, 128} {
+		b.Run(fmt.Sprintf("goroutines_%03d", n), func(b *testing.B) {
+			trc, err := newTracer(withTransport(newDummyTransport()), withNoopStats())
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer trc.Stop()
+
+			root := trc.StartSpan("server")
+			ctx := root.Context()
+
+			var counter atomic.Int64
+			var wg sync.WaitGroup
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for range n {
+				wg.Go(func() {
+					carrier := HTTPHeadersCarrier(http.Header{})
+					for counter.Add(1) <= int64(b.N) {
+						child := trc.StartSpan("client", ChildOf(ctx))
+						_ = trc.Inject(ctx, carrier)
+						child.Finish()
+					}
+				})
+			}
+			wg.Wait()
+			root.Finish()
+		})
+	}
+}

--- a/ddtrace/tracer/remote_config_test.go
+++ b/ddtrace/tracer/remote_config_test.go
@@ -88,14 +88,14 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		s.Finish()
 		rate, _ = getMetric(s, keyRulesSamplerAppliedRate)
 		require.Equal(t, 1.0, rate)
-		require.Equal(t, samplernames.RemoteUserRule.DecisionMaker(), s.context.trace.propagatingTags[keyDecisionMaker])
+		require.Equal(t, samplernames.RemoteUserRule.DecisionMaker(), s.context.trace.propagatingTag(keyDecisionMaker))
 		// Spans not matching the rule still gets the global rate
 		s = tracer.StartSpan("not.web.request")
 		s.Finish()
 		rate, _ = getMetric(s, keyRulesSamplerAppliedRate)
 		require.Equal(t, 0.5, rate)
 		if p, ok := s.context.trace.samplingPriority(); ok && p > 0 {
-			require.Equal(t, samplernames.RuleRate.DecisionMaker(), s.context.trace.propagatingTags[keyDecisionMaker])
+			require.Equal(t, samplernames.RuleRate.DecisionMaker(), s.context.trace.propagatingTag(keyDecisionMaker))
 		}
 
 		// Unset RC. Assert _dd.rule_psr is not set
@@ -169,7 +169,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		rate, _ := getMetric(s, keyRulesSamplerAppliedRate)
 		require.Equal(t, 0.1, rate)
 		if p, ok := s.context.trace.samplingPriority(); ok && p > 0 {
-			require.Equal(t, samplernames.RuleRate.DecisionMaker(), s.context.trace.propagatingTags[keyDecisionMaker])
+			require.Equal(t, samplernames.RuleRate.DecisionMaker(), s.context.trace.propagatingTag(keyDecisionMaker))
 		}
 
 		input := remoteconfig.ProductUpdate{
@@ -190,7 +190,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		s.Finish()
 		rate, _ = getMetric(s, keyRulesSamplerAppliedRate)
 		require.Equal(t, 1.0, rate)
-		require.Equal(t, samplernames.RemoteUserRule.DecisionMaker(), s.context.trace.propagatingTags[keyDecisionMaker])
+		require.Equal(t, samplernames.RemoteUserRule.DecisionMaker(), s.context.trace.propagatingTag(keyDecisionMaker))
 		// Spans not matching the rule gets the global rate, but not the local rule, which is no longer in effect
 		s = tracer.StartSpan("web.request")
 		s.resource = "not_abc"
@@ -198,7 +198,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		rate, _ = getMetric(s, keyRulesSamplerAppliedRate)
 		require.Equal(t, 0.5, rate)
 		if p, ok := s.context.trace.samplingPriority(); ok && p > 0 {
-			require.Equal(t, samplernames.RuleRate.DecisionMaker(), s.context.trace.propagatingTags[keyDecisionMaker])
+			require.Equal(t, samplernames.RuleRate.DecisionMaker(), s.context.trace.propagatingTag(keyDecisionMaker))
 		}
 
 		assertTelemetryConfig(t, telemetryClient.Configuration, "trace_sample_rate", 0.5, telemetry.OriginRemoteConfig)
@@ -231,7 +231,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		p, ok := s.context.trace.samplingPriority()
 		require.True(t, ok)
 		require.Equal(t, p, -1)
-		require.Empty(t, s.context.trace.propagatingTags[keyDecisionMaker])
+		require.Empty(t, s.context.trace.propagatingTag(keyDecisionMaker))
 
 		input := remoteconfig.ProductUpdate{
 			"path": []byte(`{"lib_config": {"tracing_sampling_rate": 0.5,
@@ -258,7 +258,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		s.Finish()
 		rate, _ = getMetric(s, keyRulesSamplerAppliedRate)
 		require.Equal(t, 1.0, rate)
-		require.Equal(t, samplernames.RemoteUserRule.DecisionMaker(), s.context.trace.propagatingTags[keyDecisionMaker])
+		require.Equal(t, samplernames.RemoteUserRule.DecisionMaker(), s.context.trace.propagatingTag(keyDecisionMaker))
 		// Spans not matching the rule gets the global rate, but not the local rule, which is no longer in effect
 		s = tracer.StartSpan("web.request")
 		s.resource = "not_abc"
@@ -271,7 +271,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.Equal(
 			t,
 			samplernames.RemoteDynamicRule.DecisionMaker(),
-			s.context.trace.propagatingTags[keyDecisionMaker],
+			s.context.trace.propagatingTag(keyDecisionMaker),
 		)
 
 		// Reset restores local rules
@@ -286,7 +286,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		p, ok = s.context.trace.samplingPriority()
 		require.True(t, ok)
 		require.Equal(t, p, -1)
-		require.Empty(t, s.context.trace.propagatingTags[keyDecisionMaker])
+		require.Empty(t, s.context.trace.propagatingTag(keyDecisionMaker))
 
 		assertCalled(t, telemetryClient, []telemetry.Configuration{
 			{Name: "trace_sample_rate", Value: 0.5, Origin: telemetry.OriginRemoteConfig},
@@ -331,7 +331,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		s.Finish()
 		rate, _ := getMetric(s, keyRulesSamplerAppliedRate)
 		require.Equal(t, 1.0, rate)
-		require.Equal(t, samplernames.RemoteUserRule.DecisionMaker(), s.context.trace.propagatingTags[keyDecisionMaker])
+		require.Equal(t, samplernames.RemoteUserRule.DecisionMaker(), s.context.trace.propagatingTag(keyDecisionMaker))
 
 		// A span with non-matching tags gets the global rate
 		s = tracer.StartSpan("web.request")

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -10,6 +10,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -240,10 +241,15 @@ func FromGenericCtx(c ddtrace.SpanContext) *SpanContext {
 	if sc.trace == nil {
 		sc.trace = newTrace()
 	}
-	sc.trace.tags = ctx.Tags()                                    // +checklocksignore - Initialization time, not shared yet.
-	sc.trace.propagatingTags = ctx.PropagatingTags()              // +checklocksignore - Initialization time, not shared yet.
-	if dm, ok := sc.trace.propagatingTags[keyDecisionMaker]; ok { // +checklocksignore - Initialization time, not shared yet.
-		sc.trace.dm = parseDecisionMaker(dm) // +checklocksignore - Initialization time, not shared yet.
+	sc.trace.tags = ctx.Tags()                    // +checklocksignore - Initialization time, not shared yet.
+	if pt := ctx.PropagatingTags(); len(pt) > 0 { // +checklocksignore - Initialization time, not shared yet.
+		// Clone the map so that the atomic.Value snapshot is immutable and
+		// independent of whatever the adapter holds internally.
+		cp := maps.Clone(pt)
+		sc.trace.propagatingTags.Store(cp)
+		if dm, ok := cp[keyDecisionMaker]; ok {
+			sc.trace.dm = parseDecisionMaker(dm) // +checklocksignore - Initialization time, not shared yet.
+		}
 	}
 	return &sc
 }
@@ -566,8 +572,8 @@ type trace struct {
 	// +checklocks:mu
 	tags map[string]string
 	// trace level tags that will be propagated across service boundaries
-	// +checklocks:mu
-	propagatingTags map[string]string
+	// holds map[string]string; readers are lock-free (atomic.Value); writers hold mu and use copy-on-write
+	propagatingTags atomic.Value
 	// the number of finished spans
 	// +checklocks:mu
 	finished int
@@ -712,7 +718,8 @@ func (t *trace) setSamplingPriorityLockedWithForce(p int, sampler samplernames.S
 	updatedPriority := old == nil || *old != float64(p)
 
 	t.priority.Store(samplingPriorityPtr(p)) // +checklocksignore
-	curDM, existed := t.propagatingTags[keyDecisionMaker]
+	curDM := t.propagatingTag(keyDecisionMaker)
+	existed := curDM != ""
 	if p > 0 && sampler != samplernames.Unknown {
 		// We have a positive priority and the sampling mechanism isn't set.
 		// Send nothing when sampler is `Unknown` for RFC compliance.
@@ -783,7 +790,7 @@ func (t *trace) push(sp *Span) {
 }
 
 // setTraceTagsLocked sets all "trace level" tags on the provided span
-// t must already be locked.
+// t must already be read-locked (t.mu.RLock held by caller).
 // +checklocksread:t.mu
 // +checklocks:s.mu
 func (t *trace) setTraceTagsLocked(s *Span) {
@@ -792,7 +799,7 @@ func (t *trace) setTraceTagsLocked(s *Span) {
 	for k, v := range t.tags {
 		s.setMetaLocked(k, v)
 	}
-	for k, v := range t.propagatingTags {
+	for k, v := range t.loadPropagatingTags() {
 		s.setMetaLocked(k, v)
 	}
 	updateTracerGitMetadataTags(s)

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -1248,51 +1248,59 @@ func BenchmarkBaggageItemEmpty(b *testing.B) {
 	}
 }
 
+func TestReplacePropagatingTagsImmutability(t *testing.T) {
+	// Mutating the input map after replacePropagatingTags must not affect the
+	// stored snapshot — lock-free readers rely on the map being immutable.
+	var tr trace
+	tags := map[string]string{"key": "original"}
+	tr.replacePropagatingTags(tags)
+
+	tags["key"] = "mutated"
+	tags["extra"] = "added"
+
+	assert.Equal(t, "original", tr.propagatingTag("key"))
+	assert.Equal(t, "", tr.propagatingTag("extra"))
+}
+
 func TestSetSamplingPriorityLocked(t *testing.T) {
 	t.Run("NoPriorAndP0IsIgnored", func(t *testing.T) {
-		tr := trace{
-			propagatingTags: map[string]string{},
-		}
+		var tr trace
 		tr.mu.Lock()
 		tr.setSamplingPriorityLocked(ext.PriorityAutoReject, samplernames.RemoteRate)
 		tr.mu.Unlock()
-		assert.Empty(t, tr.propagatingTags[keyDecisionMaker])
+		assert.Empty(t, tr.propagatingTag(keyDecisionMaker))
 	})
 	t.Run("UnknownSamplerIsIgnored", func(t *testing.T) {
-		tr := trace{
-			propagatingTags: map[string]string{},
-		}
+		var tr trace
 		tr.mu.Lock()
 		tr.setSamplingPriorityLocked(ext.PriorityAutoReject, samplernames.Unknown)
 		tr.mu.Unlock()
-		assert.Empty(t, tr.propagatingTags[keyDecisionMaker])
+		assert.Empty(t, tr.propagatingTag(keyDecisionMaker))
 	})
 	t.Run("NoPriorAndP1IsAccepted", func(t *testing.T) {
-		tr := trace{
-			propagatingTags: map[string]string{},
-		}
+		var tr trace
 		tr.mu.Lock()
 		tr.setSamplingPriorityLocked(ext.PriorityAutoKeep, samplernames.RemoteRate)
 		tr.mu.Unlock()
-		assert.Equal(t, "-2", tr.propagatingTags[keyDecisionMaker])
+		assert.Equal(t, "-2", tr.propagatingTag(keyDecisionMaker))
 	})
 	t.Run("PriorAndP1AndSameDMIsIgnored", func(t *testing.T) {
-		tr := trace{
-			propagatingTags: map[string]string{keyDecisionMaker: "-1"},
-		}
+		var tr trace
+		tr.propagatingTags.Store(map[string]string{keyDecisionMaker: "-1"})
+		tr.dm = parseDecisionMaker("-1")
 		tr.mu.Lock()
 		tr.setSamplingPriorityLocked(ext.PriorityAutoKeep, samplernames.AgentRate)
 		tr.mu.Unlock()
-		assert.Equal(t, "-1", tr.propagatingTags[keyDecisionMaker])
+		assert.Equal(t, "-1", tr.propagatingTag(keyDecisionMaker))
 	})
 	t.Run("PriorAndP1DifferentDMAccepted", func(t *testing.T) {
-		tr := trace{
-			propagatingTags: map[string]string{keyDecisionMaker: "-1"},
-		}
+		var tr trace
+		tr.propagatingTags.Store(map[string]string{keyDecisionMaker: "-1"})
+		tr.dm = parseDecisionMaker("-1")
 		tr.mu.Lock()
 		tr.setSamplingPriorityLocked(ext.PriorityAutoKeep, samplernames.RemoteRate)
 		tr.mu.Unlock()
-		assert.Equal(t, "-2", tr.propagatingTags[keyDecisionMaker])
+		assert.Equal(t, "-2", tr.propagatingTag(keyDecisionMaker))
 	})
 }
 

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -552,9 +552,15 @@ func (p *propagator) injectTextMap(spanCtx *SpanContext, writer TextMapWriter) e
 		return ErrInvalidSpanContext
 	}
 	// propagate the TraceID and the current active SpanID
+	// traceID.Upper is immutable after span creation, so check before writing:
+	// the read of propagatingTag is lock-free, and skipping the write avoids
+	// the CoW allocation on every Inject call.
 	if ctx.traceID.HasUpper() {
-		setPropagatingTag(ctx, keyTraceID128, ctx.traceID.UpperHex())
-	} else if ctx.trace != nil {
+		upper := ctx.traceID.UpperHex()
+		if ctx.trace == nil || ctx.trace.propagatingTag(keyTraceID128) != upper {
+			setPropagatingTag(ctx, keyTraceID128, upper)
+		}
+	} else if ctx.trace != nil && ctx.trace.hasPropagatingTag(keyTraceID128) {
 		ctx.trace.unsetPropagatingTag(keyTraceID128)
 	}
 	writer.Set(p.cfg.TraceHeader, strconv.FormatUint(ctx.traceID.Lower(), 10))
@@ -756,6 +762,17 @@ func setPropagatingTag(ctx *SpanContext, k, v string) {
 		ctx.trace = newTrace()
 	}
 	ctx.trace.setPropagatingTag(k, v)
+}
+
+// setPropagatingTagUnsafe is like setPropagatingTag but writes directly into
+// the map without copy-on-write. Caller must guarantee the trace is not yet
+// shared with other goroutines (i.e. during extraction, before SpanContext is
+// returned to the caller).
+func setPropagatingTagUnsafe(ctx *SpanContext, k, v string) {
+	if ctx.trace == nil {
+		ctx.trace = newTrace()
+	}
+	ctx.trace.setPropagatingTagUnsafe(k, v)
 }
 
 const (
@@ -993,11 +1010,14 @@ func (*propagatorW3c) injectTextMap(spanCtx *SpanContext, writer TextMapWriter) 
 
 	var traceID string
 	if ctx.traceID.HasUpper() {
-		setPropagatingTag(ctx, keyTraceID128, ctx.traceID.UpperHex())
+		upper := ctx.traceID.UpperHex()
+		if ctx.trace == nil || ctx.trace.propagatingTag(keyTraceID128) != upper {
+			setPropagatingTag(ctx, keyTraceID128, upper)
+		}
 		traceID = ctx.TraceID()
 	} else {
 		traceID = ctx.TraceID()
-		if ctx.trace != nil {
+		if ctx.trace != nil && ctx.trace.hasPropagatingTag(keyTraceID128) {
 			ctx.trace.unsetPropagatingTag(keyTraceID128)
 		}
 	}
@@ -1442,18 +1462,18 @@ func parseTracestate(ctx *SpanContext, header string) {
 				if ctx.trace.hasPropagatingTag(keyDecisionMaker) || dropDM {
 					continue
 				}
-				setPropagatingTag(ctx, keyDecisionMaker, val)
+				setPropagatingTagUnsafe(ctx, keyDecisionMaker, val)
 			} else if strings.HasPrefix(key, "t.") {
 				keySuffix := key[len("t."):]
 				val = strings.ReplaceAll(val, "~", "=")
-				setPropagatingTag(ctx, "_dd.p."+keySuffix, val)
+				setPropagatingTagUnsafe(ctx, "_dd.p."+keySuffix, val)
 			}
 		}
 	}
 	// Store the propagating tag, rebuilding the header to exclude oversized
 	// dd= entries when present.
 	if !hasOversizedDD {
-		setPropagatingTag(ctx, tracestateHeader, header)
+		setPropagatingTagUnsafe(ctx, tracestateHeader, header)
 		return
 	}
 	var cleaned strings.Builder
@@ -1473,7 +1493,7 @@ func parseTracestate(ctx *SpanContext, header string) {
 	if cleaned.Len() == 0 {
 		return
 	}
-	setPropagatingTag(ctx, tracestateHeader, cleaned.String())
+	setPropagatingTagUnsafe(ctx, tracestateHeader, cleaned.String())
 }
 
 // extractTraceID128 extracts the trace id from v and populates the traceID

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -342,10 +342,8 @@ func TestTextMapPropagatorTraceTagsWithPriority(t *testing.T) {
 	assert.Nil(t, err)
 	child := tracer.StartSpan("test", ChildOf(ctx))
 	childSpanID := child.Context().spanID
-	assert.Equal(t, map[string]string{
-		"hello":    "world=",
-		"_dd.p.dm": "934086a6-4",
-	}, ctx.trace.propagatingTags)
+	assert.Equal(t, "world=", ctx.trace.propagatingTag("hello"))
+	assert.Equal(t, "934086a6-4", ctx.trace.propagatingTag("_dd.p.dm"))
 	dst := map[string]string{}
 	err = tracer.Inject(child.Context(), TextMapCarrier(dst))
 	assert.Nil(t, err)
@@ -371,10 +369,8 @@ func TestTextMapPropagatorTraceTagsWithoutPriority(t *testing.T) {
 	assert.Nil(t, err)
 	child := tracer.StartSpan("test", ChildOf(ctx))
 	childSpanID := child.Context().spanID
-	assert.Equal(t, map[string]string{
-		"hello":    "world",
-		"_dd.p.dm": "-1",
-	}, ctx.trace.propagatingTags)
+	assert.Equal(t, "world", ctx.trace.propagatingTag("hello"))
+	assert.Equal(t, "-1", ctx.trace.propagatingTag("_dd.p.dm"))
 	dst := map[string]string{}
 	err = tracer.Inject(child.Context(), TextMapCarrier(dst))
 	assert.Nil(t, err)
@@ -417,9 +413,9 @@ func Test257CharacterDDTracestateLengh(t *testing.T) {
 	ctx.origin = "rum"
 	ctx.traceID = traceIDFrom64Bits(1)
 	ctx.spanID = 2
-	ctx.trace.propagatingTags = map[string]string{
+	ctx.trace.replacePropagatingTags(map[string]string{
 		"tracestate": "valid_vendor=a:1",
-	}
+	})
 	// need to create a tracestate where the dd portion will be 257 chars long
 	// we currently have:
 	// 3 chars ->  dd=
@@ -435,8 +431,8 @@ func Test257CharacterDDTracestateLengh(t *testing.T) {
 	longKey := strings.Repeat("a", 234) // 234 is correct num for 257
 	shortKey := "a"
 
-	ctx.trace.propagatingTags[fmt.Sprintf("_dd.p.%s", shortKey)] = "0"
-	ctx.trace.propagatingTags[fmt.Sprintf("_dd.p.%s", longKey)] = "0"
+	ctx.trace.setPropagatingTag(fmt.Sprintf("_dd.p.%s", shortKey), "0")
+	ctx.trace.setPropagatingTag(fmt.Sprintf("_dd.p.%s", longKey), "0")
 
 	headers := TextMapCarrier(map[string]string{})
 	err = tracer.Inject(ctx, headers)
@@ -714,7 +710,7 @@ func TestExtractTraceTagsHeaderDisabled(t *testing.T) {
 	// Disabled extract: no propagating tags, no error tag.
 	_, hasErr := ctx.trace.tags["_dd.propagation_error"]
 	assert.False(t, hasErr)
-	assert.Empty(t, ctx.trace.propagatingTags)
+	assert.Zero(t, ctx.trace.propagatingTagsLen())
 }
 
 func TestEnvVars(t *testing.T) {
@@ -1387,7 +1383,13 @@ func TestEnvVars(t *testing.T) {
 					assert.True(ok)
 					assert.Equal(int(tc.out[1]), p)
 
-					assert.Equal(tc.propagatingTags, ctx.trace.propagatingTags)
+					if tc.propagatingTags != nil {
+						var got map[string]string
+						if snap := ctx.trace.propagatingTags.Load(); snap != nil {
+							got = snap.(map[string]string)
+						}
+						assert.Equal(tc.propagatingTags, got)
+					}
 				})
 			}
 		}
@@ -1688,7 +1690,7 @@ func TestEnvVars(t *testing.T) {
 					ctx.origin = tc.origin
 					ctx.traceID = tc.tid
 					ctx.spanID = tc.sid
-					ctx.trace.propagatingTags = tc.propagatingTags
+					ctx.trace.replacePropagatingTags(tc.propagatingTags)
 					ctx.reparentID = "0123456789abcdef"
 					headers := TextMapCarrier(map[string]string{})
 					err = tracer.Inject(ctx, headers)
@@ -1718,12 +1720,12 @@ func TestEnvVars(t *testing.T) {
 					ctx.origin = "old_tracestate"
 					ctx.traceID = traceIDFrom64Bits(1229782938247303442)
 					ctx.spanID = 2459565876494606882
-					ctx.trace.propagatingTags = map[string]string{
+					ctx.trace.replacePropagatingTags(map[string]string{
 						"tracestate": "valid_vendor=a:1",
-					}
+					})
 					// dd part of the tracestate must not exceed 256 characters
 					for i := range 32 {
-						ctx.trace.propagatingTags[fmt.Sprintf("_dd.p.a%v", i)] = "i"
+						ctx.trace.setPropagatingTag(fmt.Sprintf("_dd.p.a%v", i), "i")
 					}
 					headers := TextMapCarrier(map[string]string{})
 					err = tracer.Inject(ctx, headers)
@@ -2755,9 +2757,14 @@ func FuzzMarshalPropagatingTags(f *testing.F) {
 			t.Skipf("Skipping invalid tags")
 		}
 		unmarshalPropagatingTags(recvCtx, marshal, pConfig.MaxTagsHeaderLen)
-		marshaled := sendCtx.trace.propagatingTags
-		unmarshaled := recvCtx.trace.propagatingTags
-		if !reflect.DeepEqual(sendCtx.trace.propagatingTags, recvCtx.trace.propagatingTags) {
+		var marshaled, unmarshaled map[string]string
+		if snap := sendCtx.trace.propagatingTags.Load(); snap != nil {
+			marshaled = snap.(map[string]string)
+		}
+		if snap := recvCtx.trace.propagatingTags.Load(); snap != nil {
+			unmarshaled = snap.(map[string]string)
+		}
+		if !reflect.DeepEqual(marshaled, unmarshaled) {
 			t.Fatalf("Inconsistent marshaling/unmarshaling: (%q) is different from (%q)", marshaled, unmarshaled)
 		}
 	})
@@ -2808,14 +2815,19 @@ func FuzzComposeTracestate(f *testing.F) {
 		traceState := composeTracestate(sendCtx, priority, oldState)
 		parseTracestate(recvCtx, traceState)
 		setPropagatingTag(sendCtx, tracestateHeader, traceState)
-		if !reflect.DeepEqual(sendCtx.trace.propagatingTags, recvCtx.trace.propagatingTags) {
+		var sendPTags, recvPTags map[string]string
+		if snap := sendCtx.trace.propagatingTags.Load(); snap != nil {
+			sendPTags = snap.(map[string]string)
+		}
+		if snap := recvCtx.trace.propagatingTags.Load(); snap != nil {
+			recvPTags = snap.(map[string]string)
+		}
+		if !reflect.DeepEqual(sendPTags, recvPTags) {
 			t.Fatalf(`Inconsistent composing/parsing:
 			pre compose: (%q)
 			is different from
 			parsed: (%q)
-			for tracestate of: (%s)`, sendCtx.trace.propagatingTags,
-				recvCtx.trace.propagatingTags,
-				traceState)
+			for tracestate of: (%s)`, sendPTags, recvPTags, traceState)
 		}
 	})
 }

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -325,7 +325,7 @@ func TestTracerStartSpan(t *testing.T) {
 			ext.PriorityAutoReject,
 			ext.PriorityAutoKeep,
 		}, span.metrics[keySamplingPriority])
-		assert.Equal("-1", span.context.trace.propagatingTags[keyDecisionMaker])
+		assert.Equal("-1", span.context.trace.propagatingTag(keyDecisionMaker))
 		// A span is not measured unless made so specifically
 		_, ok := span.meta.Get(keyMeasured)
 		assert.False(ok)
@@ -340,7 +340,7 @@ func TestTracerStartSpan(t *testing.T) {
 		assert.NoError(t, err)
 		span := tracer.StartSpan("web.request", Tag(ext.ManualKeep, true))
 		assert.Equal(t, float64(ext.PriorityUserKeep), span.metrics[keySamplingPriority])
-		assert.Equal(t, "-4", span.context.trace.propagatingTags[keyDecisionMaker])
+		assert.Equal(t, "-4", span.context.trace.propagatingTag(keyDecisionMaker))
 	})
 
 	t.Run("name", func(t *testing.T) {
@@ -423,7 +423,7 @@ func TestSamplingDecision(t *testing.T) {
 		assert.Equal(t, uint32(0), tracerstats.Count(tracerstats.DroppedP0Traces))
 		assert.Equal(t, uint32(0), tracerstats.Count(tracerstats.DroppedP0Spans))
 		assert.Equal(t, float64(ext.PriorityAutoKeep), span.metrics[keySamplingPriority])
-		assert.Equal(t, "-1", span.context.trace.propagatingTags[keyDecisionMaker])
+		assert.Equal(t, "-1", span.context.trace.propagatingTag(keyDecisionMaker))
 		assert.Equal(t, decisionKeep, span.context.trace.samplingDecision)
 	})
 
@@ -442,7 +442,7 @@ func TestSamplingDecision(t *testing.T) {
 		assert.Equal(t, uint32(0), tracerstats.Count(tracerstats.DroppedP0Traces))
 		assert.Equal(t, uint32(2), tracerstats.Count(tracerstats.DroppedP0Spans))
 		assert.Equal(t, float64(ext.PriorityAutoReject), span.metrics[keySamplingPriority])
-		assert.Equal(t, "", span.context.trace.propagatingTags[keyDecisionMaker])
+		assert.Equal(t, "", span.context.trace.propagatingTag(keyDecisionMaker))
 		assert.Equal(t, decisionKeep, span.context.trace.samplingDecision)
 	})
 
@@ -459,7 +459,7 @@ func TestSamplingDecision(t *testing.T) {
 		assert.Equal(t, uint32(1), tracerstats.Count(tracerstats.DroppedP0Traces))
 		assert.Equal(t, uint32(2), tracerstats.Count(tracerstats.DroppedP0Spans))
 		assert.Equal(t, float64(ext.PriorityAutoReject), span.metrics[keySamplingPriority])
-		assert.Equal(t, "", span.context.trace.propagatingTags[keyDecisionMaker])
+		assert.Equal(t, "", span.context.trace.propagatingTag(keyDecisionMaker))
 		assert.Equal(t, decisionNone, span.context.trace.samplingDecision)
 	})
 
@@ -501,7 +501,7 @@ func TestSamplingDecision(t *testing.T) {
 		assert.Equal(t, float64(ext.PriorityAutoReject), span.metrics[keySamplingPriority])
 		// this trace won't be sent to the agent,
 		// therefore not necessary to populate keyDecisionMaker
-		assert.Equal(t, "", span.context.trace.propagatingTags[keyDecisionMaker])
+		assert.Equal(t, "", span.context.trace.propagatingTag(keyDecisionMaker))
 		assert.Equal(t, decisionDrop, span.context.trace.samplingDecision)
 	})
 
@@ -1065,7 +1065,7 @@ func TestTracerSamplingPriorityPropagation(t *testing.T) {
 	root := tracer.StartSpan("web.request", Tag(ext.ManualKeep, true))
 	child := tracer.StartSpan("db.query", ChildOf(root.Context()))
 	assert.EqualValues(2, root.metrics[keySamplingPriority])
-	assert.Equal("-4", root.context.trace.propagatingTags[keyDecisionMaker])
+	assert.Equal("-4", root.context.trace.propagatingTag(keyDecisionMaker))
 	assert.EqualValues(2, child.metrics[keySamplingPriority])
 	assert.EqualValues(2., *root.context.trace.priority.Load())
 	assert.EqualValues(2., *child.context.trace.priority.Load())
@@ -1084,7 +1084,7 @@ func TestTracerSamplingPriorityEmptySpanCtx(t *testing.T) {
 	}
 	child := tracer.StartSpan("db.query", ChildOf(spanCtx))
 	assert.EqualValues(1, child.metrics[keySamplingPriority])
-	assert.Equal("-1", child.context.trace.propagatingTags[keyDecisionMaker])
+	assert.Equal("-1", child.context.trace.propagatingTag(keyDecisionMaker))
 }
 
 func TestTracerDDUpstreamServicesManualKeep(t *testing.T) {
@@ -1102,7 +1102,7 @@ func TestTracerDDUpstreamServicesManualKeep(t *testing.T) {
 	grandChild := tracer.StartSpan("db.query", ChildOf(child.Context()))
 	grandChild.SetTag(ext.ManualDrop, true)
 	grandChild.SetTag(ext.ManualKeep, true)
-	assert.Equal("-4", grandChild.context.trace.propagatingTags[keyDecisionMaker])
+	assert.Equal("-4", grandChild.context.trace.propagatingTag(keyDecisionMaker))
 }
 
 func TestTracerBaggageImmutability(t *testing.T) {
@@ -1375,7 +1375,7 @@ func TestTracerPrioritySampler(t *testing.T) {
 	s := tr.newEnvSpan("pylons", "")
 	assert.Equal(1., s.metrics[keySamplingPriorityRate])
 	assert.Equal(1., s.metrics[keySamplingPriority])
-	assert.Equal("-1", s.context.trace.propagatingTags[keyDecisionMaker])
+	assert.Equal("-1", s.context.trace.propagatingTag(keyDecisionMaker))
 	p, ok := s.context.SamplingPriority()
 	assert.True(ok)
 	assert.EqualValues(p, s.metrics[keySamplingPriority])
@@ -1428,9 +1428,9 @@ func TestTracerPrioritySampler(t *testing.T) {
 		assert.Equal(tt.rate, s.metrics[keySamplingPriorityRate], strconv.Itoa(i))
 		prio, ok := s.metrics[keySamplingPriority]
 		if prio > 0 {
-			assert.Equal("-1", s.context.trace.propagatingTags[keyDecisionMaker])
+			assert.Equal("-1", s.context.trace.propagatingTag(keyDecisionMaker))
 		} else {
-			assert.Equal("", s.context.trace.propagatingTags[keyDecisionMaker])
+			assert.Equal("", s.context.trace.propagatingTag(keyDecisionMaker))
 		}
 		assert.True(ok)
 		assert.Contains([]float64{0, 1}, prio)
@@ -2774,7 +2774,7 @@ func TestUserMonitoring(t *testing.T) {
 		v, _ := s.meta.Get(keyUserID)
 		assert.Equal(t, id, v)
 		encoded := base64.StdEncoding.EncodeToString([]byte(id))
-		assert.Equal(t, encoded, s.context.trace.propagatingTags[keyPropagatedUserID])
+		assert.Equal(t, encoded, s.context.trace.propagatingTag(keyPropagatedUserID))
 		v, _ = s.meta.Get(keyPropagatedUserID)
 		assert.Equal(t, encoded, v)
 	})
@@ -2787,8 +2787,7 @@ func TestUserMonitoring(t *testing.T) {
 		assert.True(t, ok)
 		_, ok = s.meta.Get(keyPropagatedUserID)
 		assert.False(t, ok)
-		_, ok = s.context.trace.propagatingTags[keyPropagatedUserID]
-		assert.False(t, ok)
+		assert.False(t, s.context.trace.hasPropagatingTag(keyPropagatedUserID))
 	})
 
 	// This tests data races for trace.propagatingTags reads/writes through public API.

--- a/instrumentation/testutils/testutils.go
+++ b/instrumentation/testutils/testutils.go
@@ -6,9 +6,8 @@
 package testutils
 
 import (
-	"sync"
 	"testing"
-	"unsafe" // also enables go:linkname directives below
+	_ "unsafe" // enables go:linkname directives below
 
 	"github.com/DataDog/go-libddwaf/v4"
 	"github.com/stretchr/testify/assert"
@@ -113,36 +112,13 @@ func NewMockStatsdClient() *MockStatsdClient {
 	return &MockStatsdClient{}
 }
 
-// SetPropagatingTag sets a tag on the given span context. It assumes it comes from a span,
-// so it has a trace attached to it.
+//go:linkname setSpanContextPropagatingTag github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.setSpanContextPropagatingTag
+func setSpanContextPropagatingTag(ctx *tracer.SpanContext, k, v string)
+
+// SetPropagatingTag sets a propagating tag on the given span context.
 func SetPropagatingTag(t testing.TB, ctx *tracer.SpanContext, k, v string) {
 	t.Helper()
-
-	// Forgive us for the following hack, oh great and powerful GODpher.
-	// Assuming the context contains a trace, we extract it by cookie-cutting it.
-	// It's easier than using offsets when the desired data isn't far away from
-	// the struct's beginning.
-	type cookieCutter struct {
-		_     bool   // spanContext.updated
-		_     bool   // spanContext.isRemote
-		_     bool   // spanContext.baggageOnly
-		_     uint32 // spanContext.errors
-		_     uint32 // spanContext.hasBaggage
-		trace *struct {
-			mu              sync.RWMutex      // trace.mu
-			_               []any             // trace.spans
-			_               map[string]string // trace.tags
-			propagatingTags map[string]string // trace level tags that will be propagated across service boundaries
-		}
-	}
-	ptr := uintptr(unsafe.Pointer(ctx))
-	cc := (*cookieCutter)(*(*unsafe.Pointer)(unsafe.Pointer(&ptr)))
-	cc.trace.mu.Lock()
-	defer cc.trace.mu.Unlock()
-	if cc.trace.propagatingTags == nil {
-		cc.trace.propagatingTags = make(map[string]string)
-	}
-	cc.trace.propagatingTags[k] = v
+	setSpanContextPropagatingTag(ctx, k, v)
 }
 
 // StartTelemetryRecorder starts a new telemetry mock client and returns it.


### PR DESCRIPTION
### What does this PR do?

Make `propagatingTags` lock-free for readers by storing it as an `atomic.Value` (holding a `map[string]string`) with copy-on-write semantics. Readers (e.g. during `Inject`) load the snapshot atomically without acquiring any lock. Writers still hold `trace.mu`, clone the map, and atomically swap the snapshot. A fast-path check skips the clone if the value is unchanged.

### Motivation

The typical scenario that will benefit from this optimization is a service that receives a request and fans out to N downstream services concurrently. Each goroutine calls `StartSpan` + `Inject` on the same trace to propagate context into outgoing headers. All N goroutines share the same trace object, so they all contend the same lock. Before this change, `Inject` acquired a write lock to set `_dd.p.tid`, a value that doesn't change after the first inject. With many concurrent outgoing calls on the same trace, this contention is visible in mutex profiles and adds latency proportional to fan-out width.

Example mutex profile from a production application. This change will eliminate the middle section of the flamegraph. StartSpan and Finish still use the mutex.

<img width="1824" height="439" alt="Screenshot 2026-05-12 at 19 49 50" src="https://github.com/user-attachments/assets/edabbbb2-31b4-4a10-8f0e-5371fd79caa4" />

## Benchmark
```
go test ./ddtrace/... -bench='BenchmarkInjectDatadog|BenchmarkInjectW3C|BenchmarkTraceContention|BenchmarkInjectMultiG|BenchmarkStartSpanConcurrent|BenchmarkExtractW3C|BenchmarkHttpServeTrace|BenchmarkOTelApiWithCustomTags|BenchmarkOTelApiWithCustomTags|BenchmarkStartSpanConfig|BenchmarkTracerAddSpans' -benchmem -count=3 -run='^$' -benchtime=3s
```

Results: [main](https://gist.github.com/opsengine/a7d4d6f740fb8358bb5e2dc4c0fba938) vs [branch](https://gist.github.com/opsengine/2749b0890d87c81dd34cfbbce5743ac0). [benchstat](https://gist.github.com/opsengine/bbb2cbafddb4ff9e99c92a2193d878a5)

Measured on Apple M4 Max.

BenchmarkInjectMultiG: N goroutines all calling Inject on the same span concurrently:

```
  ┌────────────┬────────────┬───────────┐
  │ goroutines │    main    │  this PR  │
  ├────────────┼────────────┼───────────┤
  │ 1          │ 929 ns/op  │ 899 ns/op │
  ├────────────┼────────────┼───────────┤
  │ 2          │ 1215 ns/op │ 587 ns/op │
  ├────────────┼────────────┼───────────┤
  │ 8          │ 1365 ns/op │ 406 ns/op │
  ├────────────┼────────────┼───────────┤
  │ 16         │ 1324 ns/op │ 330 ns/op │
  ├────────────┼────────────┼───────────┤
  │ 64         │ 1410 ns/op │ 328 ns/op │
  └────────────┴────────────┴───────────┘
```

BenchmarkTraceContention: full StartSpan → Inject → Finish loop:
```
  ┌────────────┬────────────┬────────────┐
  │ goroutines │    main    │  this PR   │
  ├────────────┼────────────┼────────────┤
  │ 1          │ 1.73 µs/op │ 1.76 µs/op │
  ├────────────┼────────────┼────────────┤
  │ 2          │ 2.23 µs/op │ 1.32 µs/op │
  ├────────────┼────────────┼────────────┤
  │ 8          │ 2.33 µs/op │ 1.48 µs/op │
  ├────────────┼────────────┼────────────┤
  │ 64         │ 2.21 µs/op │ 1.54 µs/op │
  ├────────────┼────────────┼────────────┤
  │ 128        │ 2.36 µs/op │ 1.81 µs/op │
  └────────────┴────────────┴────────────┘
```

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [x] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.
