### PR TITLE
fix: strip unused process tags

### DIFF
--- a/internal/processtags/processtags.go
+++ b/internal/processtags/processtags.go
@@ -134,18 +134,32 @@ func collect() map[string]string {
 	if err != nil {
 		log.Debug("failed to get binary path: %s", err.Error())
 	} else {
-		baseDirName := filepath.Base(filepath.Dir(execPath))
 		tags[tagEntrypointName] = filepath.Base(execPath)
-		tags[tagEntrypointBasedir] = baseDirName
+		if baseDirName, ok := directoryTagValue(filepath.Dir(execPath)); ok {
+			tags[tagEntrypointBasedir] = baseDirName
+		}
 		tags[tagEntrypointType] = entrypointTypeExecutable
 	}
 	wd, err := os.Getwd()
 	if err != nil {
 		log.Debug("failed to get working directory: %s", err.Error())
 	} else {
-		tags[tagEntrypointWorkdir] = filepath.Base(wd)
+		if workDirName, ok := directoryTagValue(wd); ok {
+			tags[tagEntrypointWorkdir] = workDirName
+		}
 	}
 	return tags
+}
+
+func directoryTagValue(dir string) (string, bool) {
+	if dir == "" {
+		return "", false
+	}
+	name := filepath.Base(dir)
+	if name == "" || name == "bin" || name == string(os.PathSeparator) {
+		return "", false
+	}
+	return name, true
 }
 
 // GlobalTags returns the global process tags.

--- a/internal/processtags/processtags_test.go
+++ b/internal/processtags/processtags_test.go
@@ -6,6 +6,8 @@
 package processtags
 
 import (
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -93,5 +95,30 @@ func TestProcessTags(t *testing.T) {
 		assert.Nil(t, p)
 		assert.Empty(t, p.String())
 		assert.Empty(t, p.Slice())
+	})
+}
+
+func TestDirectoryTagValue(t *testing.T) {
+	t.Run("filters non-informative directory names", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			dir  string
+		}{
+			{name: "empty", dir: ""},
+			{name: "bin", dir: "bin"},
+			{name: "root", dir: string(os.PathSeparator)},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				dir := tc.dir
+				_, ok := directoryTagValue(dir)
+				assert.False(t, ok)
+			})
+		}
+	})
+
+	t.Run("keeps informative directory names", func(t *testing.T) {
+		got, ok := directoryTagValue(filepath.Join("usr", "local", "app"))
+		assert.True(t, ok)
+		assert.Equal(t, "app", got)
 	})
 }


### PR DESCRIPTION
Strip unused process tags, in particulat directories that are empty `/` and `bin`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
