### PR TITLE
fix(internal/civisibility): avoid tests-only race condition on CIVis reset

### DIFF
--- a/internal/civisibility/integrations/testing_helpers_test.go
+++ b/internal/civisibility/integrations/testing_helpers_test.go
@@ -40,7 +40,13 @@ func resetCIVisibilityStateForTesting() {
 
 	repositoryUploadHooksMu.Lock()
 	uploadRepositoryChangesFunc = nil
-	getSearchCommitsFunc = getSearchCommits
+	// Return "no commits" so the upload goroutine spawned by ensureSettingsInitialization
+	// exits immediately without reading ciVisibilityClient, preventing a data race with the
+	// next reset call that sets ciVisibilityClient = nil.
+	// Tests that need real commit data override getSearchCommitsFunc themselves.
+	getSearchCommitsFunc = func() (*searchCommitsResponse, error) {
+		return newSearchCommitsResponse(nil, nil, false), nil
+	}
 	unshallowGitRepositoryFunc = utils.UnshallowGitRepository
 	sendObjectsPackFileFunc = sendObjectsPackFile
 	repositoryUploadHooksMu.Unlock()


### PR DESCRIPTION
### What does this PR do?

In `resetCIVisibilityStateForTesting`, replaces `getSearchCommitsFunc = getSearchCommits` (the real git function) with a stub that immediately returns (nil, nil, false) ("no commits, upload skipped").

The upload goroutine short-circuits in `uploadRepositoryChangesWithHooks` at the `!IsOk` check and exits immediately — never reading `ciVisibilityClient`. No concurrent reader, no race. Tests that need real commit behavior already override `getSearchCommitsFunc` after reset.

### Motivation

Root cause: `resetCIVisibilityStateForTesting` resets `settingsInitializationOnce` to fresh, so the first call to `GetImpactedTestsAnalyzer()` inside `SetTestFunc` triggers the real settings initialization. That spawns an upload goroutine which calls `getSearchCommits()` → `utils.GetLastLocalGitCommitShas()` (git subprocess, slow) → `ciVisibilityClient.GetCommits()`. When the test cleanup then runs `ciVisibilityClient = nil`, the race detector fires.

The race is timing-dependent: fast on Mac (goroutine finishes first), [caught more often in CI under load](https://github.com/DataDog/dd-trace-go/actions/runs/25589929959/job/75125581955#step:6:283) or with race-detector overhead widening the window.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
