### PR TITLE
fix(ci-visibility): harden mocktracer, HTTP bodies, and EFD skips

### DIFF
--- a/ddtrace/mocktracer/civisibilitymocktracer.go
+++ b/ddtrace/mocktracer/civisibilitymocktracer.go
@@ -17,31 +17,88 @@ import (
 )
 
 type civisibilitymocktracer struct {
-	mock   *mocktracer   // mock tracer
-	real   tracer.Tracer // real tracer (for the testotimization/civisibility spans)
+	// mock records user-created spans so tests that use mocktracer keep their existing assertions.
+	mock *mocktracer
+
+	// realMu protects real while CI Visibility startup, span creation, flush, and shutdown can overlap.
+	realMu sync.RWMutex
+	real   tracer.Tracer // real receives CI Visibility spans that must not be captured by mock.
+
+	// realSpansMu protects realSpans, which tracks spans that must bypass mock FinishSpan handling.
+	realSpansMu sync.Mutex
+	realSpans   map[*tracer.Span]struct{}
+
+	// isnoop disables user-facing mock behavior after Stop while allowing CI Visibility cleanup to continue.
 	isnoop atomic.Bool
 }
 
 var (
 	_ tracer.Tracer = (*civisibilitymocktracer)(nil)
 	_ Tracer        = (*civisibilitymocktracer)(nil)
-
-	realSpans      = make(map[*tracer.Span]bool)
-	realSpansMutex sync.Mutex
 )
 
-// Creates a new CIVisibilityMockTracer that uses the mock tracer for all spans except the CIVisibility spans.
+// newCIVisibilityMockTracer creates a mock tracer that delegates CI Visibility spans to the real tracer.
 func newCIVisibilityMockTracer() *civisibilitymocktracer {
 	currentTracer := getGlobalTracer()
-	// let's check if the current tracer is already a civisibilitymocktracer
-	// if so, we need to get the real tracer from it
+	// Repeated mocktracer starts should unwrap the previous CI Visibility mock tracer
+	// and keep its real tracer delegate instead of stacking wrappers.
 	if currentCIVisibilityMockTracer, ok := currentTracer.(*civisibilitymocktracer); ok && currentCIVisibilityMockTracer != nil {
-		currentTracer = currentCIVisibilityMockTracer.real
+		currentTracer = currentCIVisibilityMockTracer.realTracer()
 	}
 	return &civisibilitymocktracer{
-		mock: newMockTracer(),
-		real: currentTracer,
+		mock:      newMockTracer(),
+		real:      currentTracer,
+		realSpans: make(map[*tracer.Span]struct{}),
 	}
+}
+
+// realTracer returns the currently installed CI Visibility tracer delegate.
+func (t *civisibilitymocktracer) realTracer() tracer.Tracer {
+	t.realMu.RLock()
+	defer t.realMu.RUnlock()
+	return t.real
+}
+
+// SetCIVisibilityTracer installs the tracer used for CI Visibility spans while
+// keeping this mock tracer as the process global tracer.
+func (t *civisibilitymocktracer) SetCIVisibilityTracer(real tracer.Tracer) bool {
+	if real == nil {
+		return false
+	}
+
+	t.realMu.Lock()
+	if t.isnoop.Load() {
+		old := t.real
+		t.real = &tracer.NoopTracer{}
+		t.realMu.Unlock()
+		if old != nil && old != real {
+			stopRealTracerDelegate(old)
+		}
+		return false
+	}
+	old := t.real
+	t.real = real
+	t.realMu.Unlock()
+
+	if old != nil && old != real {
+		stopRealTracerDelegate(old)
+	}
+	return true
+}
+
+// stopRealTracerDelegate stops a tracer owned by civisibilitymocktracer without
+// letting mocktracer cleanup overwrite the process global tracer.
+func stopRealTracerDelegate(real tracer.Tracer) {
+	if real == nil {
+		return
+	}
+	if mt, ok := real.(*mocktracer); ok {
+		if mt.dsmProcessor != nil {
+			mt.dsmProcessor.Stop()
+		}
+		return
+	}
+	real.Stop()
 }
 
 // SentDSMBacklogs returns the Data Streams Monitoring backlogs that have been sent by the mock tracer.
@@ -55,38 +112,49 @@ func (t *civisibilitymocktracer) SentDSMBacklogs() []datastreams.Backlog {
 	return t.mock.dsmTransport.backlogs
 }
 
-// Stop deactivates the CIVisibility mock tracer by setting it to noop mode and stopping
+// Stop deactivates the CI Visibility mock tracer by setting it to noop mode and stopping
 // the Data Streams Monitoring processor. This should be called when testing has finished.
 func (t *civisibilitymocktracer) Stop() {
+	var realToStop tracer.Tracer
+	t.realMu.Lock()
 	t.isnoop.Store(true)
-	t.mock.dsmProcessor.Stop()
 	if civisibility.GetState() == civisibility.StateExiting {
-		t.real.Stop()
+		realToStop = t.real
 		t.real = &tracer.NoopTracer{}
 	}
+	t.realMu.Unlock()
+
+	t.mock.dsmProcessor.Stop()
+	stopRealTracerDelegate(realToStop)
 }
 
 // StartSpan creates a new span with the given operation name and options. If the span type
 // indicates it's a CI Visibility span (like a test session, module, suite, or individual test),
 // it uses the real tracer to create the span. For all other spans, it uses the mock tracer.
-// If the tracer is in noop mode, it returns nil.
+// If the mock tracer is in noop mode, non-CI Visibility spans return nil while
+// CI Visibility spans may still use the real tracer until CI Visibility exits.
 func (t *civisibilitymocktracer) StartSpan(operationName string, opts ...tracer.StartSpanOption) *tracer.Span {
-	if t.real != nil {
-		var cfg tracer.StartSpanConfig
-		for _, fn := range opts {
-			fn(&cfg)
-		}
+	var cfg tracer.StartSpanConfig
+	for _, fn := range opts {
+		fn(&cfg)
+	}
 
-		if spanType, ok := cfg.Tags[ext.SpanType]; ok &&
-			(spanType == constants.SpanTypeTestSession || spanType == constants.SpanTypeTestModule ||
-				spanType == constants.SpanTypeTestSuite || spanType == constants.SpanTypeTest) {
-			// If the span is a civisibility span, use the real tracer to create it.
-			realSpan := t.real.StartSpan(operationName, opts...)
-			realSpansMutex.Lock()
-			defer realSpansMutex.Unlock()
-			realSpans[realSpan] = true
+	if isCIVisibilitySpan(cfg) {
+		t.realMu.RLock()
+		real := t.real
+		if real != nil {
+			// If the span is a CI Visibility span, use the real tracer to create it.
+			realSpan := real.StartSpan(operationName, opts...)
+			t.realMu.RUnlock()
+
+			if realSpan != nil {
+				t.realSpansMu.Lock()
+				t.realSpans[realSpan] = struct{}{}
+				t.realSpansMu.Unlock()
+			}
 			return realSpan
 		}
+		t.realMu.RUnlock()
 	}
 
 	if t.isnoop.Load() {
@@ -97,20 +165,59 @@ func (t *civisibilitymocktracer) StartSpan(operationName string, opts ...tracer.
 	return t.mock.StartSpan(operationName, opts...)
 }
 
-// FinishSpan marks the given span as finished in the mock tracer. This is called by spans
-// when they finish, adding them to the list of finished spans for later inspection.
+// isCIVisibilitySpan reports whether cfg describes a CI Visibility span that
+// must bypass user-facing mocktracer storage.
+func isCIVisibilitySpan(cfg tracer.StartSpanConfig) bool {
+	spanType, ok := cfg.Tags[ext.SpanType]
+	return ok && (spanType == constants.SpanTypeTestSession ||
+		spanType == constants.SpanTypeTestModule ||
+		spanType == constants.SpanTypeTestSuite ||
+		spanType == constants.SpanTypeTest)
+}
+
+// FinishSpan marks mock-created spans as finished while keeping CI Visibility
+// spans out of the user-facing mock span list.
 func (t *civisibilitymocktracer) FinishSpan(s *tracer.Span) {
-	realSpansMutex.Lock()
-	defer realSpansMutex.Unlock()
+	if s == nil {
+		return
+	}
+
+	t.realSpansMu.Lock()
 	// Check if the span is a real span (i.e., created by the real tracer).
-	if _, isRealSpan := realSpans[s]; isRealSpan {
-		delete(realSpans, s)
+	_, isRealSpan := t.realSpans[s]
+	t.realSpansMu.Unlock()
+	if isRealSpan {
 		return
 	}
 	if t.isnoop.Load() {
 		return
 	}
 	t.mock.FinishSpan(s)
+}
+
+// TracerForFinishedChunk returns the current real tracer when a finished chunk
+// contains CI Visibility spans created by this wrapper.
+func (t *civisibilitymocktracer) TracerForFinishedChunk(spans []*tracer.Span) (tracer.Tracer, bool) {
+	hasRealSpan := false
+	t.realSpansMu.Lock()
+	for _, s := range spans {
+		if _, ok := t.realSpans[s]; ok {
+			delete(t.realSpans, s)
+			hasRealSpan = true
+		}
+	}
+	t.realSpansMu.Unlock()
+	if !hasRealSpan {
+		return nil, false
+	}
+
+	t.realMu.RLock()
+	real := t.real
+	t.realMu.RUnlock()
+	if real == nil {
+		return nil, false
+	}
+	return real, true
 }
 
 // GetDataStreamsProcessor returns the Data Streams Monitoring processor used by the mock tracer.
@@ -163,6 +270,11 @@ func (t *civisibilitymocktracer) Inject(context *tracer.SpanContext, carrier any
 }
 
 func (t *civisibilitymocktracer) TracerConf() tracer.TracerConf {
+	t.realMu.RLock()
+	defer t.realMu.RUnlock()
+	if t.real == nil {
+		return tracer.TracerConf{}
+	}
 	return t.real.TracerConf()
 }
 
@@ -170,5 +282,9 @@ func (t *civisibilitymocktracer) TracerConf() tracer.TracerConf {
 // This ensures that all buffered spans are processed and ready for inspection.
 func (t *civisibilitymocktracer) Flush() {
 	t.mock.Flush()
-	t.real.Flush()
+	t.realMu.RLock()
+	defer t.realMu.RUnlock()
+	if t.real != nil {
+		t.real.Flush()
+	}
 }

--- a/ddtrace/mocktracer/civisibilitymocktracer.go
+++ b/ddtrace/mocktracer/civisibilitymocktracer.go
@@ -113,12 +113,16 @@ func (t *civisibilitymocktracer) SentDSMBacklogs() []datastreams.Backlog {
 }
 
 // Stop deactivates the CI Visibility mock tracer by setting it to noop mode and stopping
-// the Data Streams Monitoring processor. This should be called when testing has finished.
+// the Data Streams Monitoring processor. If this wrapper has already been removed from
+// the global tracer slot, it also stops the real delegate because CI Visibility shutdown
+// can no longer reach it through the global tracer.
 func (t *civisibilitymocktracer) Stop() {
 	var realToStop tracer.Tracer
+	removedFromGlobalTracer := getGlobalTracer() != t
+
 	t.realMu.Lock()
 	t.isnoop.Store(true)
-	if civisibility.GetState() == civisibility.StateExiting {
+	if removedFromGlobalTracer || civisibility.GetState() == civisibility.StateExiting {
 		realToStop = t.real
 		t.real = &tracer.NoopTracer{}
 	}

--- a/ddtrace/mocktracer/civisibilitymocktracer_test.go
+++ b/ddtrace/mocktracer/civisibilitymocktracer_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
+	internaltelemetry "github.com/DataDog/dd-trace-go/v2/internal/telemetry"
+	"github.com/DataDog/dd-trace-go/v2/internal/telemetry/telemetrytest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -61,6 +63,7 @@ func setupCIVisibilityMockTracerIntegrationTest(t *testing.T, useNoop bool) *ciV
 	t.Helper()
 
 	resetCIVisibilityMockTracerTestState(t)
+	t.Cleanup(internaltelemetry.MockClient(new(telemetrytest.RecordClient)))
 	server := newCIVisibilityMockTracerTestServer(t)
 	t.Setenv(constants.CIVisibilityEnabledEnvironmentVariable, "parent")
 	t.Setenv(constants.CIVisibilityUseNoopTracer, boolString(useNoop))

--- a/ddtrace/mocktracer/civisibilitymocktracer_test.go
+++ b/ddtrace/mocktracer/civisibilitymocktracer_test.go
@@ -519,6 +519,7 @@ func TestCIVisibilityMockTracer_SecondStopDuringCIVisibilityExitStopsRealTracer(
 	resetCIVisibilityMockTracerTestState(t)
 
 	cmt := newCIVisibilityMockTracer()
+	internal.StoreGlobalTracer[Tracer, tracer.Tracer](cmt)
 	real := &countingTracer{}
 	require.True(t, cmt.SetCIVisibilityTracer(real))
 
@@ -528,4 +529,18 @@ func TestCIVisibilityMockTracer_SecondStopDuringCIVisibilityExitStopsRealTracer(
 	civisibility.SetState(civisibility.StateExiting)
 	cmt.Stop()
 	assert.Equal(t, int32(1), real.stopCount.Load())
+}
+
+func TestCIVisibilityMockTracer_GlobalStopStopsRealTracerDelegate(t *testing.T) {
+	resetCIVisibilityMockTracerTestState(t)
+
+	cmt := newCIVisibilityMockTracer()
+	internal.StoreGlobalTracer[Tracer, tracer.Tracer](cmt)
+	real := &countingTracer{}
+	require.True(t, cmt.SetCIVisibilityTracer(real))
+
+	tracer.Stop()
+
+	assert.Equal(t, int32(1), real.stopCount.Load())
+	assert.IsType(t, &tracer.NoopTracer{}, cmt.realTracer())
 }

--- a/ddtrace/mocktracer/civisibilitymocktracer_test.go
+++ b/ddtrace/mocktracer/civisibilitymocktracer_test.go
@@ -6,6 +6,7 @@
 package mocktracer
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -34,6 +35,9 @@ func newCIVisibilityMockTracerTestServer(t *testing.T) *ciVisibilityMockTracerTe
 
 	server := new(ciVisibilityMockTracerTestServer)
 	server.handler = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		_ = r.Body.Close()
+
 		server.mu.Lock()
 		server.paths = append(server.paths, r.URL.Path)
 		server.mu.Unlock()
@@ -64,13 +68,17 @@ func setupCIVisibilityMockTracerIntegrationTest(t *testing.T, useNoop bool) *ciV
 	t.Setenv(constants.CIVisibilityAgentlessURLEnvironmentVariable, server.URL())
 	t.Setenv(constants.APIKeyEnvironmentVariable, "dummy")
 	t.Setenv("DD_INSTRUMENTATION_TELEMETRY_ENABLED", "false")
-	t.Cleanup(func() {
-		civisibility.SetState(civisibility.StateExiting)
-		tracer.Stop()
-		civisibility.ResetForTesting()
-		setGlobalNoopTracer()
-	})
+	t.Cleanup(stopCIVisibilityMockTracerIntegrationTest)
 	return server
+}
+
+// stopCIVisibilityMockTracerIntegrationTest shuts down CI Visibility through the
+// same global tracer path used by these tests and waits for pending uploads.
+func stopCIVisibilityMockTracerIntegrationTest() {
+	civisibility.SetState(civisibility.StateExiting)
+	tracer.Stop()
+	civisibility.ResetForTesting()
+	setGlobalNoopTracer()
 }
 
 func boolString(v bool) string {
@@ -83,9 +91,10 @@ func boolString(v bool) string {
 func requireTestCycleRequest(t *testing.T, server *ciVisibilityMockTracerTestServer) {
 	t.Helper()
 
+	stopCIVisibilityMockTracerIntegrationTest()
 	require.Eventually(t, func() bool {
 		return server.hasPath("/api/v2/citestcycle")
-	}, 2*time.Second, 10*time.Millisecond)
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 type countingTracer struct {

--- a/ddtrace/mocktracer/civisibilitymocktracer_test.go
+++ b/ddtrace/mocktracer/civisibilitymocktracer_test.go
@@ -7,26 +7,133 @@ package mocktracer
 
 import (
 	"net/http"
+	"net/http/httptest"
+	"slices"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/internal"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+type ciVisibilityMockTracerTestServer struct {
+	mu      sync.Mutex
+	paths   []string
+	handler *httptest.Server
+}
+
+func newCIVisibilityMockTracerTestServer(t *testing.T) *ciVisibilityMockTracerTestServer {
+	t.Helper()
+
+	server := new(ciVisibilityMockTracerTestServer)
+	server.handler = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		server.mu.Lock()
+		server.paths = append(server.paths, r.URL.Path)
+		server.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.handler.Close)
+	return server
+}
+
+func (s *ciVisibilityMockTracerTestServer) URL() string {
+	return s.handler.URL
+}
+
+func (s *ciVisibilityMockTracerTestServer) hasPath(path string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Contains(s.paths, path)
+}
+
+func setupCIVisibilityMockTracerIntegrationTest(t *testing.T, useNoop bool) *ciVisibilityMockTracerTestServer {
+	t.Helper()
+
+	resetCIVisibilityMockTracerTestState(t)
+	server := newCIVisibilityMockTracerTestServer(t)
+	t.Setenv(constants.CIVisibilityEnabledEnvironmentVariable, "parent")
+	t.Setenv(constants.CIVisibilityUseNoopTracer, boolString(useNoop))
+	t.Setenv(constants.CIVisibilityAgentlessEnabledEnvironmentVariable, "true")
+	t.Setenv(constants.CIVisibilityAgentlessURLEnvironmentVariable, server.URL())
+	t.Setenv(constants.APIKeyEnvironmentVariable, "dummy")
+	t.Setenv("DD_INSTRUMENTATION_TELEMETRY_ENABLED", "false")
+	t.Cleanup(func() {
+		civisibility.SetState(civisibility.StateExiting)
+		tracer.Stop()
+		civisibility.ResetForTesting()
+		setGlobalNoopTracer()
+	})
+	return server
+}
+
+func boolString(v bool) string {
+	if v {
+		return "true"
+	}
+	return "false"
+}
+
+func requireTestCycleRequest(t *testing.T, server *ciVisibilityMockTracerTestServer) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		return server.hasPath("/api/v2/citestcycle")
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+type countingTracer struct {
+	stopCount atomic.Int32
+}
+
+func (*countingTracer) StartSpan(_ string, _ ...tracer.StartSpanOption) *tracer.Span {
+	return nil
+}
+
+func (*countingTracer) SetServiceInfo(_, _, _ string) {}
+
+func (*countingTracer) Extract(_ any) (*tracer.SpanContext, error) {
+	return nil, nil
+}
+
+func (*countingTracer) Inject(_ *tracer.SpanContext, _ any) error { return nil }
+
+func (t *countingTracer) Stop() {
+	t.stopCount.Add(1)
+}
+
+func (*countingTracer) TracerConf() tracer.TracerConf {
+	return tracer.TracerConf{}
+}
+
+func (*countingTracer) Flush() {}
+
+type nilSpanTracer struct{}
+
+func (nilSpanTracer) StartSpan(string, ...tracer.StartSpanOption) *tracer.Span { return nil }
+func (nilSpanTracer) SetServiceInfo(_, _, _ string)                            {}
+func (nilSpanTracer) Extract(any) (*tracer.SpanContext, error)                 { return nil, nil }
+func (nilSpanTracer) Inject(*tracer.SpanContext, any) error                    { return nil }
+func (nilSpanTracer) TracerConf() tracer.TracerConf                            { return tracer.TracerConf{} }
+func (nilSpanTracer) Flush()                                                   {}
+func (nilSpanTracer) Stop()                                                    {}
+
 // TestCIVisibilityMockTracer_StartSpan_Routing verifies that spans are routed
 // correctly based on their SpanType tag. CI Visibility spans should go to the
 // real tracer, others to the mock tracer.
 func TestCIVisibilityMockTracer_StartSpan_Routing(t *testing.T) {
+	resetCIVisibilityMockTracerTestState(t)
 	// Note: The 'real' tracer here will be the default global tracer.
 	// If mocktracer.Start() was called *before* this, 'real' would also be a mock.
 	// We rely on the fact that CI spans won't appear in the *internal* mock tracer (`cmt.mock`).
 	cmt := newCIVisibilityMockTracer()
 	internal.StoreGlobalTracer[Tracer, tracer.Tracer](cmt)
-	defer internal.SetGlobalTracer(cmt.real)
 
 	// 1. Regular span (should go to internal mock)
 	regSpan := cmt.StartSpan("regular.op")
@@ -63,9 +170,9 @@ func TestCIVisibilityMockTracer_StartSpan_Routing(t *testing.T) {
 
 // TestCIVisibilityMockTracer_Delegation verifies basic delegation methods.
 func TestCIVisibilityMockTracer_Delegation(t *testing.T) {
+	resetCIVisibilityMockTracerTestState(t)
 	cmt := newCIVisibilityMockTracer()
 	internal.StoreGlobalTracer[Tracer, tracer.Tracer](cmt)
-	defer internal.SetGlobalTracer(cmt.real)
 
 	// Test Reset
 	span1 := cmt.StartSpan("op1")
@@ -89,9 +196,9 @@ func TestCIVisibilityMockTracer_Delegation(t *testing.T) {
 
 // TestCIVisibilityMockTracer_Stop verifies that the tracer becomes no-op after Stop.
 func TestCIVisibilityMockTracer_Stop(t *testing.T) {
+	resetCIVisibilityMockTracerTestState(t)
 	cmt := newCIVisibilityMockTracer()
 	internal.StoreGlobalTracer[Tracer, tracer.Tracer](cmt)
-	defer internal.SetGlobalTracer(cmt.real)
 
 	cmt.Stop() // Stop the tracer
 
@@ -118,9 +225,9 @@ func TestCIVisibilityMockTracer_Stop(t *testing.T) {
 
 // TestCIVisibilityMockTracer_Flush verifies that Flush moves open spans to finished.
 func TestCIVisibilityMockTracer_Flush(t *testing.T) {
+	resetCIVisibilityMockTracerTestState(t)
 	cmt := newCIVisibilityMockTracer()
 	internal.StoreGlobalTracer[Tracer, tracer.Tracer](cmt)
-	defer internal.SetGlobalTracer(cmt.real)
 
 	// Start a regular span (handled by internal mock) but don't finish it
 	s := cmt.StartSpan("span.to.flush")
@@ -145,6 +252,7 @@ func TestCIVisibilityMockTracer_Flush(t *testing.T) {
 
 // TestCIVisibilityMockTracer_TracerConf verifies TracerConf delegates correctly.
 func TestCIVisibilityMockTracer_TracerConf(t *testing.T) {
+	resetCIVisibilityMockTracerTestState(t)
 	cmt := newCIVisibilityMockTracer()
 	defer cmt.Stop()
 
@@ -155,6 +263,7 @@ func TestCIVisibilityMockTracer_TracerConf(t *testing.T) {
 
 // TestCIVisibilityMockTracer_SentDSMBacklogs tests DSM backlog retrieval.
 func TestCIVisibilityMockTracer_SentDSMBacklogs(t *testing.T) {
+	resetCIVisibilityMockTracerTestState(t)
 	cmt := newCIVisibilityMockTracer()
 	defer cmt.Stop()
 
@@ -174,4 +283,249 @@ func TestCIVisibilityMockTracer_SentDSMBacklogs(t *testing.T) {
 	// Test after stop
 	cmt.Stop()
 	assert.Nil(t, cmt.SentDSMBacklogs(), "Should return nil after stop")
+}
+
+func TestCIVisibilityMockTracer_PreservesGlobalWhenCIStartsAfterMockTracer(t *testing.T) {
+	for _, useNoop := range []bool{true, false} {
+		t.Run(boolString(useNoop), func(t *testing.T) {
+			server := setupCIVisibilityMockTracerIntegrationTest(t, useNoop)
+
+			mt := Start()
+			cmt, ok := mt.(*civisibilitymocktracer)
+			require.True(t, ok)
+
+			t.Setenv(constants.CIVisibilityEnabledEnvironmentVariable, "1")
+			require.NoError(t, tracer.Start(tracer.WithTestDefaults(nil)))
+			t.Setenv(constants.CIVisibilityEnabledEnvironmentVariable, "false")
+
+			if got := getGlobalTracer(); got != cmt {
+				t.Fatalf("global tracer = %T, want preserved CI Visibility mock tracer", got)
+			}
+			var mockCompatible Tracer
+			require.NotPanics(t, func() {
+				mockCompatible = getGlobalTracer().(Tracer)
+			})
+			if mockCompatible != mt {
+				t.Fatalf("mock-compatible global tracer = %T, want started mock tracer", mockCompatible)
+			}
+
+			normalSpan := tracer.StartSpan("app.operation")
+			require.NotNil(t, normalSpan)
+			normalSpan.Finish()
+			require.Len(t, mt.FinishedSpans(), 1)
+			assert.Equal(t, "app.operation", mt.FinishedSpans()[0].OperationName())
+
+			ciSpan := tracer.StartSpan("ci.test", tracer.SpanType(constants.SpanTypeTest))
+			require.NotNil(t, ciSpan)
+			ciSpan.Finish()
+			assert.Len(t, mt.FinishedSpans(), 1)
+
+			tracer.Flush()
+			requireTestCycleRequest(t, server)
+		})
+	}
+}
+
+func TestCIVisibilityMockTracer_WrapsAlreadyStartedCIVisibilityTracer(t *testing.T) {
+	server := setupCIVisibilityMockTracerIntegrationTest(t, true)
+
+	t.Setenv(constants.CIVisibilityEnabledEnvironmentVariable, "1")
+	require.NoError(t, tracer.Start(tracer.WithTestDefaults(nil)))
+	realBeforeMock := getGlobalTracer()
+
+	t.Setenv(constants.CIVisibilityEnabledEnvironmentVariable, "false")
+	civisibility.SetState(civisibility.StateInitialized)
+	mt := Start()
+	cmt, ok := mt.(*civisibilitymocktracer)
+	require.True(t, ok)
+
+	if got := getGlobalTracer(); got != cmt {
+		t.Fatalf("global tracer = %T, want CI Visibility mock tracer", got)
+	}
+	if got := cmt.realTracer(); got != realBeforeMock {
+		t.Fatalf("real tracer delegate = %T, want already-started tracer", got)
+	}
+
+	normalSpan := tracer.StartSpan("app.operation")
+	require.NotNil(t, normalSpan)
+	normalSpan.Finish()
+	require.Len(t, mt.FinishedSpans(), 1)
+
+	ciSpan := tracer.StartSpan("ci.test", tracer.SpanType(constants.SpanTypeTest))
+	require.NotNil(t, ciSpan)
+	ciSpan.Finish()
+	assert.Len(t, mt.FinishedSpans(), 1)
+
+	tracer.Flush()
+	requireTestCycleRequest(t, server)
+}
+
+func TestCIVisibilityMockTracer_StoppedMockTracerIsNotPreserved(t *testing.T) {
+	setupCIVisibilityMockTracerIntegrationTest(t, true)
+
+	mt := Start()
+	cmt, ok := mt.(*civisibilitymocktracer)
+	require.True(t, ok)
+	previousReal := &countingTracer{}
+	require.True(t, cmt.SetCIVisibilityTracer(previousReal))
+
+	mt.Stop()
+	t.Setenv(constants.CIVisibilityEnabledEnvironmentVariable, "1")
+	require.NoError(t, tracer.Start(tracer.WithTestDefaults(nil)))
+
+	if got := getGlobalTracer(); got == cmt {
+		t.Fatal("stopped CI Visibility mock tracer was preserved as the global tracer")
+	}
+	assert.Equal(t, int32(1), previousReal.stopCount.Load())
+}
+
+func TestCIVisibilityMockTracer_ReplacingRealTracerStopsPreviousDelegate(t *testing.T) {
+	resetCIVisibilityMockTracerTestState(t)
+
+	cmt := newCIVisibilityMockTracer()
+	t.Cleanup(cmt.Stop)
+	firstReal := &countingTracer{}
+	secondReal := &countingTracer{}
+
+	require.True(t, cmt.SetCIVisibilityTracer(firstReal))
+	require.True(t, cmt.SetCIVisibilityTracer(secondReal))
+
+	assert.Equal(t, int32(1), firstReal.stopCount.Load())
+	assert.Equal(t, int32(0), secondReal.stopCount.Load())
+	if got := cmt.realTracer(); got != secondReal {
+		t.Fatalf("real tracer delegate = %T, want second real tracer", got)
+	}
+}
+
+func TestCIVisibilityMockTracer_RepeatedTracerStartsUpdateRealTracer(t *testing.T) {
+	setupCIVisibilityMockTracerIntegrationTest(t, true)
+
+	mt := Start()
+	cmt, ok := mt.(*civisibilitymocktracer)
+	require.True(t, ok)
+
+	t.Setenv(constants.CIVisibilityEnabledEnvironmentVariable, "1")
+	require.NoError(t, tracer.Start(tracer.WithTestDefaults(nil)))
+	firstReal := cmt.realTracer()
+
+	t.Setenv(constants.CIVisibilityEnabledEnvironmentVariable, "1")
+	require.NoError(t, tracer.Start(tracer.WithTestDefaults(nil)))
+	t.Setenv(constants.CIVisibilityEnabledEnvironmentVariable, "false")
+	secondReal := cmt.realTracer()
+
+	if got := getGlobalTracer(); got != cmt {
+		t.Fatalf("global tracer = %T, want preserved CI Visibility mock tracer", got)
+	}
+	if firstReal == secondReal {
+		t.Fatal("real tracer delegate was not replaced after the second tracer start")
+	}
+
+	normalSpan := tracer.StartSpan("app.operation")
+	require.NotNil(t, normalSpan)
+	normalSpan.Finish()
+	require.Len(t, mt.FinishedSpans(), 1)
+
+	ciSpan := tracer.StartSpan("ci.test", tracer.SpanType(constants.SpanTypeTest))
+	require.NotNil(t, ciSpan)
+	ciSpan.Finish()
+	assert.Len(t, mt.FinishedSpans(), 1)
+}
+
+func TestCIVisibilityMockTracer_EarlyRealSpanFinishKeepsSubmitRouting(t *testing.T) {
+	server := setupCIVisibilityMockTracerIntegrationTest(t, true)
+
+	mt := Start()
+	_, ok := mt.(*civisibilitymocktracer)
+	require.True(t, ok)
+
+	t.Setenv(constants.CIVisibilityEnabledEnvironmentVariable, "1")
+	require.NoError(t, tracer.Start(tracer.WithTestDefaults(nil)))
+
+	parent := tracer.StartSpan("ci.parent", tracer.SpanType(constants.SpanTypeTest))
+	require.NotNil(t, parent)
+	child := tracer.StartSpan("ci.child", tracer.SpanType(constants.SpanTypeTest), tracer.ChildOf(parent.Context()))
+	require.NotNil(t, child)
+
+	child.Finish()
+	assert.Empty(t, mt.FinishedSpans())
+
+	parent.Finish()
+	tracer.Flush()
+	requireTestCycleRequest(t, server)
+}
+
+func TestCIVisibilityMockTracer_ReplacingOldMockDelegateKeepsGlobal(t *testing.T) {
+	resetCIVisibilityMockTracerTestState(t)
+	t.Setenv(constants.CIVisibilityEnabledEnvironmentVariable, "parent")
+
+	oldMock := newMockTracer()
+	t.Cleanup(func() {
+		oldMock.dsmProcessor.Stop()
+	})
+	internal.SetGlobalTracer(tracer.Tracer(oldMock))
+
+	cmt := newCIVisibilityMockTracer()
+	internal.StoreGlobalTracer[Tracer, tracer.Tracer](cmt)
+
+	fakeReal := &countingTracer{}
+	require.True(t, cmt.SetCIVisibilityTracer(fakeReal))
+	if got := getGlobalTracer(); got != cmt {
+		t.Fatalf("global tracer = %T, want preserved CI Visibility mock tracer", got)
+	}
+	if got := cmt.realTracer(); got != fakeReal {
+		t.Fatalf("real tracer delegate = %T, want fake real tracer", got)
+	}
+}
+
+func TestCIVisibilityMockTracer_DoesNotTrackNilRealSpan(t *testing.T) {
+	resetCIVisibilityMockTracerTestState(t)
+
+	cmt := newCIVisibilityMockTracer()
+	t.Cleanup(cmt.Stop)
+	require.True(t, cmt.SetCIVisibilityTracer(nilSpanTracer{}))
+
+	ciSpan := cmt.StartSpan("ci.test", tracer.SpanType(constants.SpanTypeTest))
+	require.Nil(t, ciSpan)
+
+	cmt.realSpansMu.Lock()
+	assert.Empty(t, cmt.realSpans)
+	cmt.realSpansMu.Unlock()
+	require.NotPanics(t, func() {
+		cmt.FinishSpan(nil)
+	})
+}
+
+func TestCIVisibilityMockTracer_ResetDoesNotReclassifyInFlightCIVisibilitySpans(t *testing.T) {
+	resetCIVisibilityMockTracerTestState(t)
+
+	cmt := newCIVisibilityMockTracer()
+	internal.StoreGlobalTracer[Tracer, tracer.Tracer](cmt)
+	realMock := newMockTracer()
+	t.Cleanup(func() {
+		realMock.dsmProcessor.Stop()
+	})
+	require.True(t, cmt.SetCIVisibilityTracer(realMock))
+
+	ciSpan := cmt.StartSpan("ci.test", tracer.SpanType(constants.SpanTypeTest))
+	require.NotNil(t, ciSpan)
+
+	cmt.Reset()
+	ciSpan.Finish()
+
+	assert.Empty(t, cmt.FinishedSpans())
+}
+
+func TestCIVisibilityMockTracer_SecondStopDuringCIVisibilityExitStopsRealTracer(t *testing.T) {
+	resetCIVisibilityMockTracerTestState(t)
+
+	cmt := newCIVisibilityMockTracer()
+	real := &countingTracer{}
+	require.True(t, cmt.SetCIVisibilityTracer(real))
+
+	cmt.Stop()
+	assert.Equal(t, int32(0), real.stopCount.Load())
+
+	civisibility.SetState(civisibility.StateExiting)
+	cmt.Stop()
+	assert.Equal(t, int32(1), real.stopCount.Load())
 }

--- a/ddtrace/tracer/civisibility_mocktracer.go
+++ b/ddtrace/tracer/civisibility_mocktracer.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package tracer
+
+// setGlobalTracerPreservingCIVisibilityMockTracer installs globalTracer unless
+// the current global tracer can keep ownership and route CI Visibility spans to it.
+func setGlobalTracerPreservingCIVisibilityMockTracer(globalTracer Tracer, ciVisibilityEnabled bool) {
+	if ciVisibilityEnabled {
+		if current, ok := getGlobalTracer().(interface{ SetCIVisibilityTracer(Tracer) bool }); ok && current.SetCIVisibilityTracer(globalTracer) {
+			return
+		}
+	}
+
+	setGlobalTracer(globalTracer)
+}
+
+// submitTracerForFinishedChunk returns the concrete tracer that should receive
+// a finished chunk for the current global tracer snapshot.
+func submitTracerForFinishedChunk(globalTracer Tracer, spans []*Span) Tracer {
+	if provider, ok := globalTracer.(interface {
+		TracerForFinishedChunk([]*Span) (Tracer, bool)
+	}); ok {
+		if submitTracer, ok := provider.TracerForFinishedChunk(spans); ok {
+			return submitTracer
+		}
+		return nil
+	}
+	return globalTracer
+}

--- a/ddtrace/tracer/civisibility_writer.go
+++ b/ddtrace/tracer/civisibility_writer.go
@@ -6,6 +6,7 @@
 package tracer
 
 import (
+	"io"
 	"sync"
 	"time"
 
@@ -117,7 +118,11 @@ func (w *ciVisibilityTraceWriter) flush() {
 			stats := p.stats()
 			size, count = stats.size, stats.itemCount
 			log.Debug("ciVisibilityTraceWriter: sending payload: size: %d events: %d\n", size, count)
-			_, err = w.config.ddTransport.send(p.payload)
+			var body io.ReadCloser
+			body, err = w.config.ddTransport.send(p.payload)
+			if body != nil {
+				closeCIVisibilityResponseBody(body)
+			}
 			if err == nil {
 				log.Debug("ciVisibilityTraceWriter: sent events after %d attempts", attempt+1)
 				return
@@ -129,4 +134,12 @@ func (w *ciVisibilityTraceWriter) flush() {
 		log.Error("ciVisibilityTraceWriter: lost %d events: %v", count, err.Error())
 		telemetry.EndpointPayloadDropped(telemetry.TestCycleEndpointType)
 	}(oldp)
+}
+
+// closeCIVisibilityResponseBody drains and closes a body returned by ddTransport.send.
+// The CI Visibility writer owns returned response bodies and must release them
+// before shutdown so net/http can close or reuse the underlying connection.
+func closeCIVisibilityResponseBody(body io.ReadCloser) {
+	_, _ = io.Copy(io.Discard, body)
+	_ = body.Close()
 }

--- a/ddtrace/tracer/civisibility_writer_test.go
+++ b/ddtrace/tracer/civisibility_writer_test.go
@@ -9,6 +9,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -25,11 +28,13 @@ func TestCIVisibilityImplementsTraceWriter(t *testing.T) {
 
 type failingCiVisibilityTransport struct {
 	dummyTransport
-	failCount    int
-	sendAttempts int
-	tracesSent   bool
-	events       ciVisibilityEvents
-	assert       *assert.Assertions
+	failCount     int
+	sendAttempts  int
+	tracesSent    bool
+	bodyOnFailure bool                  // Returns a response body with send errors to verify defensive cleanup.
+	events        ciVisibilityEvents    // Records the first payload so retry attempts can verify payload stability.
+	assert        *assert.Assertions    // Reports payload mismatches from the writer goroutine.
+	bodies        []*trackingReadCloser // Tracks response bodies returned to the writer.
 }
 
 func (t *failingCiVisibilityTransport) send(p payload) (io.ReadCloser, error) {
@@ -50,11 +55,18 @@ func (t *failingCiVisibilityTransport) send(p payload) (io.ReadCloser, error) {
 
 	if t.failCount > 0 {
 		t.failCount--
+		if t.bodyOnFailure {
+			body := newTrackingReadCloser("ERROR")
+			t.bodies = append(t.bodies, body)
+			return body, errors.New("oops, I failed")
+		}
 		return nil, errors.New("oops, I failed")
 	}
 
 	t.tracesSent = true
-	return io.NopCloser(strings.NewReader("OK")), nil
+	body := newTrackingReadCloser("OK")
+	t.bodies = append(t.bodies, body)
+	return body, nil
 }
 
 func TestCiVisibilityTraceWriterFlushRetries(t *testing.T) {
@@ -62,6 +74,7 @@ func TestCiVisibilityTraceWriterFlushRetries(t *testing.T) {
 		configRetries int
 		retryInterval time.Duration
 		failCount     int
+		bodyOnFailure bool
 		tracesSent    bool
 		expAttempts   int
 	}{
@@ -70,6 +83,7 @@ func TestCiVisibilityTraceWriterFlushRetries(t *testing.T) {
 
 		{configRetries: 1, retryInterval: time.Millisecond, failCount: 0, tracesSent: true, expAttempts: 1},
 		{configRetries: 1, retryInterval: time.Millisecond, failCount: 1, tracesSent: true, expAttempts: 2},
+		{configRetries: 1, retryInterval: time.Millisecond, failCount: 1, bodyOnFailure: true, tracesSent: true, expAttempts: 2},
 		{configRetries: 1, retryInterval: time.Millisecond, failCount: 2, tracesSent: false, expAttempts: 2},
 
 		{configRetries: 2, retryInterval: time.Millisecond, failCount: 0, tracesSent: true, expAttempts: 1},
@@ -83,12 +97,13 @@ func TestCiVisibilityTraceWriterFlushRetries(t *testing.T) {
 
 	ss := []*Span{makeSpan(0)}
 	for _, test := range testcases {
-		name := fmt.Sprintf("%d-%d-%t-%d", test.configRetries, test.failCount, test.tracesSent, test.expAttempts)
+		name := fmt.Sprintf("%d-%d-%t-%t-%d", test.configRetries, test.failCount, test.bodyOnFailure, test.tracesSent, test.expAttempts)
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 			p := &failingCiVisibilityTransport{
-				failCount: test.failCount,
-				assert:    assert,
+				failCount:     test.failCount,
+				bodyOnFailure: test.bodyOnFailure,
+				assert:        assert,
 			}
 			c, err := newTestConfig(func(c *config) {
 				c.ddTransport = p
@@ -107,10 +122,101 @@ func TestCiVisibilityTraceWriterFlushRetries(t *testing.T) {
 
 			assert.Equal(test.expAttempts, p.sendAttempts)
 			assert.Equal(test.tracesSent, p.tracesSent)
+			for _, body := range p.bodies {
+				assert.Equal(body.expectedBytes, body.bytesRead)
+				assert.True(body.closed)
+			}
 
 			if test.configRetries > 0 && test.failCount > 1 {
 				assert.GreaterOrEqual(elapsed, test.retryInterval*time.Duration(minInts(test.configRetries+1, test.failCount)))
 			}
 		})
+	}
+}
+
+func TestCiVisibilityTraceWriterClosesHTTPResponseBody(t *testing.T) {
+	assert := assert.New(t)
+	closedConn := make(chan struct{}, 1)
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		_ = r.Body.Close()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateClosed {
+			signalCIVisibilityHTTPConnectionState(closedConn)
+		}
+	}
+	server.Start()
+	defer server.Close()
+
+	c, err := newTestConfig(func(c *config) {
+		c.httpClient = server.Client()
+		c.ddTransport = &ciVisibilityTransport{
+			config:           c,
+			testCycleURLPath: server.URL,
+			headers:          map[string]string{"Content-Type": "application/msgpack"},
+			agentless:        false,
+		}
+		c.sendRetries = 0
+	})
+	assert.NoError(err)
+
+	h := newCiVisibilityTraceWriter(c)
+	h.add([]*Span{makeSpan(0)})
+	h.flush()
+	h.wg.Wait()
+
+	server.Client().CloseIdleConnections()
+	waitForCIVisibilityHTTPConnectionState(t, closedConn, "closed")
+}
+
+// trackingReadCloser records whether a response body was fully drained and closed.
+type trackingReadCloser struct {
+	reader        *strings.Reader
+	closed        bool
+	bytesRead     int
+	expectedBytes int
+}
+
+// newTrackingReadCloser creates a response body tracker for the given content.
+func newTrackingReadCloser(body string) *trackingReadCloser {
+	return &trackingReadCloser{
+		reader:        strings.NewReader(body),
+		expectedBytes: len(body),
+	}
+}
+
+// Read records how many bytes the writer consumes from the response body.
+func (rc *trackingReadCloser) Read(p []byte) (int, error) {
+	n, err := rc.reader.Read(p)
+	rc.bytesRead += n
+	return n, err
+}
+
+// Close records that the writer released the response body.
+func (rc *trackingReadCloser) Close() error {
+	rc.closed = true
+	return nil
+}
+
+// signalCIVisibilityHTTPConnectionState records a connection state transition
+// without blocking the HTTP server connection-state callback.
+func signalCIVisibilityHTTPConnectionState(state chan<- struct{}) {
+	select {
+	case state <- struct{}{}:
+	default:
+	}
+}
+
+// waitForCIVisibilityHTTPConnectionState waits for an expected server
+// connection-state transition produced after response-body cleanup.
+func waitForCIVisibilityHTTPConnectionState(t *testing.T, state <-chan struct{}, stateName string) {
+	t.Helper()
+	select {
+	case <-state:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for connection to become %s", stateName)
 	}
 }

--- a/ddtrace/tracer/globaltracer_civisibility_test.go
+++ b/ddtrace/tracer/globaltracer_civisibility_test.go
@@ -1,0 +1,127 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package tracer
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+type preservingTestTracer struct {
+	accept   bool
+	received Tracer
+	setCalls int
+	stopCnt  atomic.Int32
+}
+
+func (*preservingTestTracer) StartSpan(_ string, _ ...StartSpanOption) *Span {
+	return nil
+}
+
+func (*preservingTestTracer) SetServiceInfo(_, _, _ string) {}
+
+func (*preservingTestTracer) Extract(_ any) (*SpanContext, error) {
+	return nil, nil
+}
+
+func (*preservingTestTracer) Inject(_ *SpanContext, _ any) error { return nil }
+
+func (p *preservingTestTracer) Stop() {
+	p.stopCnt.Add(1)
+}
+
+func (*preservingTestTracer) TracerConf() TracerConf {
+	return TracerConf{}
+}
+
+func (*preservingTestTracer) Flush() {}
+
+func (p *preservingTestTracer) SetCIVisibilityTracer(real Tracer) bool {
+	p.setCalls++
+	p.received = real
+	return p.accept
+}
+
+func TestSetGlobalTracerPreservingCIVisibilityMockTracerPreservesWhenAccepted(t *testing.T) {
+	t.Cleanup(func() {
+		setGlobalTracer(&NoopTracer{})
+	})
+
+	current := &preservingTestTracer{accept: true}
+	real := &preservingTestTracer{}
+	setGlobalTracer(current)
+
+	setGlobalTracerPreservingCIVisibilityMockTracer(real, true)
+
+	if got := getGlobalTracer(); got != current {
+		t.Fatalf("global tracer = %T, want preserved tracer", got)
+	}
+	if current.setCalls != 1 {
+		t.Fatalf("SetCIVisibilityTracer calls = %d, want 1", current.setCalls)
+	}
+	if current.received != real {
+		t.Fatalf("received tracer = %T, want real tracer", current.received)
+	}
+	if current.stopCnt.Load() != 0 {
+		t.Fatalf("preserved tracer was stopped %d times", current.stopCnt.Load())
+	}
+	if real.stopCnt.Load() != 0 {
+		t.Fatalf("real tracer was stopped %d times", real.stopCnt.Load())
+	}
+}
+
+func TestSetGlobalTracerPreservingCIVisibilityMockTracerFallsBackWhenCIVisibilityDisabled(t *testing.T) {
+	t.Cleanup(func() {
+		setGlobalTracer(&NoopTracer{})
+	})
+
+	current := &preservingTestTracer{accept: true}
+	real := &preservingTestTracer{}
+	setGlobalTracer(current)
+
+	setGlobalTracerPreservingCIVisibilityMockTracer(real, false)
+
+	if got := getGlobalTracer(); got != real {
+		t.Fatalf("global tracer = %T, want real tracer", got)
+	}
+	if current.setCalls != 0 {
+		t.Fatalf("SetCIVisibilityTracer calls = %d, want 0", current.setCalls)
+	}
+	if current.stopCnt.Load() != 1 {
+		t.Fatalf("previous tracer stop count = %d, want 1", current.stopCnt.Load())
+	}
+	if real.stopCnt.Load() != 0 {
+		t.Fatalf("real tracer was stopped %d times", real.stopCnt.Load())
+	}
+}
+
+func TestSetGlobalTracerPreservingCIVisibilityMockTracerFallsBackWhenPreserverRejects(t *testing.T) {
+	t.Cleanup(func() {
+		setGlobalTracer(&NoopTracer{})
+	})
+
+	current := &preservingTestTracer{accept: false}
+	real := &preservingTestTracer{}
+	setGlobalTracer(current)
+
+	setGlobalTracerPreservingCIVisibilityMockTracer(real, true)
+
+	if got := getGlobalTracer(); got != real {
+		t.Fatalf("global tracer = %T, want real tracer", got)
+	}
+	if current.setCalls != 1 {
+		t.Fatalf("SetCIVisibilityTracer calls = %d, want 1", current.setCalls)
+	}
+	if current.received != real {
+		t.Fatalf("received tracer = %T, want real tracer", current.received)
+	}
+	if current.stopCnt.Load() != 1 {
+		t.Fatalf("previous tracer stop count = %d, want 1", current.stopCnt.Load())
+	}
+	if real.stopCnt.Load() != 0 {
+		t.Fatalf("real tracer was stopped %d times", real.stopCnt.Load())
+	}
+}

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -806,9 +806,7 @@ func (t *trace) finishedOneLocked(s *Span) {
 		t.spans = nil
 		t.finished = 0 // important, because a buffer can be used for several flushes
 		t.mu.Unlock()
-		if tr, ok := tr.(*tracer); ok {
-			tr.submitChunk(&chunk{spans: spans, willSend: willSend})
-		}
+		submitChunkWithTracer(submitTracerForFinishedChunk(tr, spans), &chunk{spans: spans, willSend: willSend})
 		return
 	}
 
@@ -864,8 +862,16 @@ func (t *trace) finishedOneLocked(s *Span) {
 		t.mu.RUnlock()
 	}
 
-	if tr, ok := tr.(*tracer); ok {
-		tr.submitChunk(&chunk{spans: finishedSpans, willSend: willSend})
+	submitChunkWithTracer(submitTracerForFinishedChunk(tr, finishedSpans), &chunk{spans: finishedSpans, willSend: willSend})
+}
+
+// submitChunkWithTracer submits a finished chunk when tr is backed by the real tracer.
+func submitChunkWithTracer(tr Tracer, c *chunk) {
+	switch t := tr.(type) {
+	case *tracer:
+		t.submitChunk(c)
+	case *ciVisibilityNoopTracer:
+		submitChunkWithTracer(t.Tracer, c)
 	}
 }
 

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -251,11 +251,12 @@ func Start(opts ...StartOption) error {
 		t.Stop()
 		return nil
 	}
-	if t.config.internalConfig.CIVisibilityEnabled() && t.config.ciVisibilityNoopTracer {
-		setGlobalTracer(wrapWithCiVisibilityNoopTracer(t))
-	} else {
-		setGlobalTracer(t)
+	ciVisibilityEnabled := t.config.internalConfig.CIVisibilityEnabled()
+	globalTracer := Tracer(t)
+	if ciVisibilityEnabled && t.config.ciVisibilityNoopTracer {
+		globalTracer = wrapWithCiVisibilityNoopTracer(t)
 	}
+	setGlobalTracerPreservingCIVisibilityMockTracer(globalTracer, ciVisibilityEnabled)
 	if t.dataStreams != nil {
 		t.dataStreams.Start()
 	}

--- a/internal/civisibility/integrations/gotesting/final_status.go
+++ b/internal/civisibility/integrations/gotesting/final_status.go
@@ -72,16 +72,18 @@ func computeAdjustedRetryCount(execMeta *testExecutionMetadata, duration time.Du
 }
 
 // willRetryAfterExecution mirrors postShouldRetry logic to determine if another retry
-// will happen after the current execution.
-func willRetryAfterExecution(failed bool, execMeta *testExecutionMetadata, remainingRetries int64, remainingBudget int64) bool {
+// will happen after the current execution. The skipped state is needed because
+// clean skipped EFD executions are terminal even when retry budget remains.
+func willRetryAfterExecution(failed, skipped bool, execMeta *testExecutionMetadata, remainingRetries int64, remainingBudget int64) bool {
 	if execMeta.isAttemptToFix && execMeta.shouldOrchestrateAttemptToFix {
 		// For attempt-to-fix tests, retry if remaining retries > 0.
 		return remainingRetries > 0
 	}
 
 	if isAnEfdExecution(execMeta) {
-		// For EFD, retry if remaining retries >= 0.
-		return remainingRetries >= 0
+		// For EFD, retry executions that are not clean skips.
+		cleanSkip := skipped && !failed
+		return !cleanSkip && remainingRetries >= 0
 	}
 
 	if execMeta.isFlakyTestRetriesEnabled {
@@ -141,6 +143,6 @@ func isFinalExecution(failed, skipped bool, execMeta *testExecutionMetadata, dur
 	}
 
 	// Check if another retry would happen.
-	willRetry := willRetryAfterExecution(failed, execMeta, remainingRetries, remainingBudget)
+	willRetry := willRetryAfterExecution(failed, skipped, execMeta, remainingRetries, remainingBudget)
 	return !willRetry
 }

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -770,13 +770,15 @@ func applyAdditionalFeaturesToTestFunc(f func(*testing.T), testInfo *commonInfo,
 				}
 
 				if isAnEfdExecution(execMeta) {
-					// For EFD, retry if remaining retries >= 0.
-					return remainingRetries >= 0
+					// Clean skips do not add flakiness signal, so EFD stops before scheduling retries.
+					cleanSkip := ptrToLocalT.Skipped() && !ptrToLocalT.Failed()
+					return !cleanSkip && remainingRetries >= 0
 				}
 
 				if execMeta.isFlakyTestRetriesEnabled {
 					return willRetryAfterExecution(
 						ptrToLocalT.Failed(),
+						ptrToLocalT.Skipped(),
 						execMeta,
 						remainingRetries,
 						atomic.LoadInt64(&integrations.GetFlakyRetriesSettings().RemainingTotalRetryCount),

--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -298,7 +298,7 @@ func runEarlyFlakyTestDetectionTests(m *testing.M) {
 	// 11 TestMyTest01
 	// 11 TestMyTest02 + 22 subtests
 	// 11 Test_Foo + 33 subtests
-	// 11 TestSkip
+	// 1 TestSkip
 	// 11 TestRetryWithPanic
 	// 11 TestRetryWithFail
 	// 11 TestNormalPassingAfterRetryAlwaysFail
@@ -320,7 +320,7 @@ func runEarlyFlakyTestDetectionTests(m *testing.M) {
 	checkSpansByResourceName(finishedSpans, "testing_test.go.Test_Foo/yellow_should_return_color", 11)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.Test_Foo/banana_should_return_fruit", 11)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.Test_Foo/duck_should_return_animal", 11)
-	checkSpansByResourceName(finishedSpans, "testing_test.go.TestSkip", 11)
+	checkSpansByResourceName(finishedSpans, "testing_test.go.TestSkip", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestRetryWithPanic", 11)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestRetryWithFail", 11)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestNormalPassingAfterRetryAlwaysFail", 11)
@@ -335,21 +335,26 @@ func runEarlyFlakyTestDetectionTests(m *testing.M) {
 	}
 
 	// check spans by tag
-	checkSpansByTagName(finishedSpans, constants.TestIsNew, 220)
-	checkSpansByTagName(finishedSpans, constants.TestIsRetry, 200)
-	trrSpan := checkSpansByTagName(finishedSpans, constants.TestRetryReason, 200)[0]
+	checkSpansByTagName(finishedSpans, constants.TestIsNew, 210)
+	checkSpansByTagName(finishedSpans, constants.TestIsRetry, 190)
+	trrSpan := checkSpansByTagName(finishedSpans, constants.TestRetryReason, 190)[0]
 	if trrSpan.Tag(constants.TestRetryReason) != "early_flake_detection" {
 		panic(fmt.Sprintf("expected retry reason to be %s, got %s", "early_flake_detection", trrSpan.Tag(constants.TestRetryReason)))
 	}
 
-	// check test.final_status - EFD runs 11 executions (1 original + 10 retries), final_status only on the last
+	// check test.final_status - most EFD tests run 11 executions (1 original + 10 retries), final_status only on the last
+	// Clean skips are terminal and report final_status on their single execution.
 	// TestMyTest01 passes all 11 times -> final_status=pass (only on last execution)
 	efdTestMyTest01Spans := checkSpansByResourceName(finishedSpans, "testing_test.go.TestMyTest01", 11)
 	checkSpansByTagValue(efdTestMyTest01Spans, constants.TestFinalStatus, constants.TestStatusPass, 1)
 
-	// TestSkip skips all 11 times -> final_status=skip (only on last execution)
-	efdTestSkipSpans := checkSpansByResourceName(finishedSpans, "testing_test.go.TestSkip", 11)
+	// TestSkip clean-skips once and does not schedule EFD retries -> final_status=skip
+	efdTestSkipSpans := checkSpansByResourceName(finishedSpans, "testing_test.go.TestSkip", 1)
+	checkSpansByTagValue(efdTestSkipSpans, constants.TestStatus, constants.TestStatusSkip, 1)
 	checkSpansByTagValue(efdTestSkipSpans, constants.TestFinalStatus, constants.TestStatusSkip, 1)
+	checkSpansByTagName(efdTestSkipSpans, constants.TestRetryReason, 0)
+	checkSpansByTagName(efdTestSkipSpans, constants.TestIsRetry, 0)
+	checkSpansByTagValue(efdTestSkipSpans, constants.TestSkipReason, "Nothing to do here, skipping!", 1)
 
 	// TestRetryWithPanic fails first 3 times, passes 4-11 -> anyPassed=true -> final_status=pass (only on last execution)
 	efdTestRetryWithPanicSpans := checkSpansByResourceName(finishedSpans, "testing_test.go.TestRetryWithPanic", 11)
@@ -374,7 +379,7 @@ func runEarlyFlakyTestDetectionTests(m *testing.M) {
 		1,
 		1,
 		4,
-		225,
+		215,
 		0)
 
 	// check capabilities tags
@@ -437,7 +442,8 @@ func runParallelEarlyFlakyTestDetectionTests(m *testing.M) {
 	// 1 TestNormalPassingAfterRetryAlwaysFail
 	// 11 TestEarlyFlakeDetection
 	// 2 normal spans from testing_test.go
-	// 3 tests from testify_test.go and testify_test.go/MySuite
+	// 1 clean skipped test from testify_test.go
+	// 2 normal spans from testify_test.go and testify_test.go/MySuite
 
 	// check spans by resource name
 	checkSpansByResourceName(finishedSpans, "github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting", 1)
@@ -448,26 +454,39 @@ func runParallelEarlyFlakyTestDetectionTests(m *testing.M) {
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestMyTest01", 11)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestMyTest02", 11)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.Test_Foo", 11)
-	checkSpansByResourceName(finishedSpans, "testing_test.go.TestSkip", 11)
+	checkSpansByResourceName(finishedSpans, "testing_test.go.TestSkip", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestRetryWithPanic", 11)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestRetryWithFail", 11)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestNormalPassingAfterRetryAlwaysFail", 11)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestEarlyFlakeDetection", 11)
-	checkSpansByResourceName(finishedSpans, "testify_test.go.TestTestifyLikeTest", 11)
+	checkSpansByResourceName(finishedSpans, "testify_test.go.TestTestifyLikeTest", 1)
 
 	// check spans by tag
-	checkSpansByTagName(finishedSpans, constants.TestIsNew, 198)
-	checkSpansByTagName(finishedSpans, constants.TestIsRetry, 180)
-	trrSpan := checkSpansByTagName(finishedSpans, constants.TestRetryReason, 180)[0]
+	checkSpansByTagName(finishedSpans, constants.TestIsNew, 178)
+	checkSpansByTagName(finishedSpans, constants.TestIsRetry, 160)
+	trrSpan := checkSpansByTagName(finishedSpans, constants.TestRetryReason, 160)[0]
 	if trrSpan.Tag(constants.TestRetryReason) != "early_flake_detection" {
 		panic(fmt.Sprintf("expected retry reason to be %s, got %s", "early_flake_detection", trrSpan.Tag(constants.TestRetryReason)))
 	}
 
-	// check test.final_status - parallel EFD uses Option A: no final_status is set for EFD tests
-	// because all parallel executions capture the same remainingRetries value.
-	// Only the 5 known tests from reflections_test.go (single execution, no EFD) have final_status=pass
-	checkSpansByTagName(finishedSpans, constants.TestFinalStatus, 5)
+	// check test.final_status - parallel EFD still skips final_status for fanned-out
+	// EFD attempts. A clean skip stops before fan-out, so it keeps final_status=skip.
+	// The 5 known tests from reflections_test.go (single execution, no EFD) have final_status=pass.
+	checkSpansByTagName(finishedSpans, constants.TestFinalStatus, 7)
 	checkSpansByTagValue(finishedSpans, constants.TestFinalStatus, constants.TestStatusPass, 5)
+	checkSpansByTagValue(finishedSpans, constants.TestFinalStatus, constants.TestStatusSkip, 2)
+	parallelEFDTestSkipSpans := checkSpansByResourceName(finishedSpans, "testing_test.go.TestSkip", 1)
+	checkSpansByTagValue(parallelEFDTestSkipSpans, constants.TestStatus, constants.TestStatusSkip, 1)
+	checkSpansByTagValue(parallelEFDTestSkipSpans, constants.TestFinalStatus, constants.TestStatusSkip, 1)
+	checkSpansByTagName(parallelEFDTestSkipSpans, constants.TestRetryReason, 0)
+	checkSpansByTagName(parallelEFDTestSkipSpans, constants.TestIsRetry, 0)
+	checkSpansByTagValue(parallelEFDTestSkipSpans, constants.TestSkipReason, "Nothing to do here, skipping!", 1)
+	parallelEFDTestifySkipSpans := checkSpansByResourceName(finishedSpans, "testify_test.go.TestTestifyLikeTest", 1)
+	checkSpansByTagValue(parallelEFDTestifySkipSpans, constants.TestStatus, constants.TestStatusSkip, 1)
+	checkSpansByTagValue(parallelEFDTestifySkipSpans, constants.TestFinalStatus, constants.TestStatusSkip, 1)
+	checkSpansByTagName(parallelEFDTestifySkipSpans, constants.TestRetryReason, 0)
+	checkSpansByTagName(parallelEFDTestifySkipSpans, constants.TestIsRetry, 0)
+	checkSpansByTagName(parallelEFDTestifySkipSpans, constants.TestSkipReason, 0)
 
 	// check capabilities tags
 	checkCapabilitiesTags(finishedSpans)


### PR DESCRIPTION
### What does this PR do?

This PR fixes three CI Visibility issues found while validating Test Optimization in downstream repositories:

1. It preserves `mocktracer` when CI Visibility starts after a package has already called `mocktracer.Start()`.
2. It drains and closes successful CI Visibility writer HTTP response bodies so test-cycle upload connections can shut down cleanly before goleak runs.
3. It stops Early Flake Detection from retrying tests that cleanly skip on the first execution.

For the mocktracer startup path, `tracer.Start()` now keeps the existing `civisibilitymocktracer` installed as the process global tracer when CI Visibility starts later. Instead of replacing that mock-compatible wrapper, it injects the real CI Visibility tracer into it. Normal application spans keep going to the mock tracer, while CI Visibility test/session/module/suite spans go to the real tracer.

The PR also adds a finished-chunk submit hook so CI Visibility chunks are still submitted through the real tracer even though the process global tracer remains the mock wrapper. The mock wrapper now owns its real tracer delegate explicitly, protects delegate replacement and span routing with locks, keeps real-span routing state instance-local, and preserves shutdown behavior so user `mocktracer.Stop()` calls do not kill CI Visibility before package exit.

For the HTTP cleanup path, the CI Visibility trace writer now owns every non-nil body returned by `ddTransport.send`. It drains and closes those bodies on success and on the defensive `(body, err)` path, preserving retry behavior while allowing the HTTP transport to release keep-alive connections.

For the EFD skip path, clean skips now stop at the common EFD retry decision. That keeps pass/fail EFD retries unchanged, but avoids burning the retry budget on executions that only produce `skip` signal. The final-status prediction mirrors the same decision so the single skipped execution receives `test.final_status=skip` immediately and does not get retry tags.

No new environment variables are introduced, and this does not change `/civisibility` or `/internal/civisibility`.

### Motivation

The downstream mocktracer failure happens when test packages start mocktracer in `TestMain`, and the test optimizer later starts CI Visibility through `RunM`.

Before this change, CI Visibility startup replaced the global `civisibilitymocktracer` with either the real `*tracer.tracer` or the CI Visibility noop wrapper. Code already using the v1 mocktracer path still expected the global tracer to be mock-compatible, so finishing adapted mock spans could panic with an interface conversion error.

Preserving the wrapper fixes that ownership problem without losing CI Visibility data: user test spans remain available through `FinishedSpans()`, and CI Visibility spans still reach the real tracer and submit to the test-cycle intake.

A later downstream run also exposed a goleak failure with `net/http.(*persistConn).readLoop` and `net/http.(*persistConn).writeLoop` after tests had passed. The CI Visibility writer was ignoring successful response bodies returned by the transport, leaving the client connection in use. Draining and closing those bodies makes shutdown deterministic for the HTTP transport.

Downstream EFD validation also showed output like `skipped after 10 retries by Datadog's early flake detection`. Retrying a clean skipped test does not add useful flakiness signal, so this PR stops scheduling EFD retries when the first execution is `skipped && !failed`.

### Testing

- [x] `go test ./ddtrace/mocktracer -count=1`
- [x] `go test ./ddtrace/mocktracer -race -count=1`
- [x] `go test ./ddtrace/mocktracer -race -count=3`
- [x] `go test ./ddtrace/mocktracer -run 'TestCIVisibilityMockTracer' -count=10`
- [x] `go test ./ddtrace/tracer -run 'TestSetGlobalTracerPreservingCIVisibilityMockTracer|TestGlobalTracer' -count=1`
- [x] `go test ./ddtrace/tracer -run 'TestSetGlobalTracerPreservingCIVisibilityMockTracer|TestGlobalTracer' -race -count=10`
- [x] `go test ./ddtrace/tracer -run 'TestCIVisibilityImplementsTraceWriter|TestCiVisibilityTraceWriterFlushRetries|TestCiVisibilityTraceWriterClosesHTTPResponseBody' -count=1`
- [x] `go test ./ddtrace/tracer -run 'TestCIVisibilityImplementsTraceWriter|TestCiVisibilityTraceWriterFlushRetries|TestCiVisibilityTraceWriterClosesHTTPResponseBody' -race -count=1`
- [x] `go test ./ddtrace/tracer -run 'TestCIVisibility|TestCiVisibility' -count=1`
- [x] `go test ./internal/civisibility/integrations/gotesting -count=1`
- [x] `go test ./internal/civisibility/integrations/gotesting/subtests -count=1`
- [x] `go test ./internal/civisibility/integrations/gotesting/failnow -count=1`
- [x] `git diff --check`

Local note: full `go test ./ddtrace/tracer -count=1` is blocked in this checkout by environment-sensitive DogStatsD autodetection expectations. The local agent reports DogStatsD port `8135`, while existing tracer tests expect `8125` in startup-log/default-config assertions. The focused tracer tests for these changes pass.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.
