### PR TITLE
chore(ci): add dd-octo-sts chainguard policy files

### DIFF
--- a/.github/chainguard/self.code-freeze-check.sts.yaml
+++ b/.github/chainguard/self.code-freeze-check.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/dd-trace-go:pull_request
+
+claim_pattern:
+  event_name: pull_request
+  repository: DataDog/dd-trace-go
+  job_workflow_ref: DataDog/dd-trace-go/\.github/workflows/code_freeze_check\.yml@.*
+
+permissions:
+  statuses: write
+  issues: read
+  pull_requests: read

--- a/.github/chainguard/self.code-freeze-end.sts.yaml
+++ b/.github/chainguard/self.code-freeze-end.sts.yaml
@@ -1,0 +1,14 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-go:ref:refs/heads/.*"
+
+claim_pattern:
+  event_name: (workflow_dispatch|milestone)
+  repository: DataDog/dd-trace-go
+  job_workflow_ref: DataDog/dd-trace-go/\.github/workflows/code_freeze_end\.yml@refs/heads/.+
+
+permissions:
+  contents: read
+  pull_requests: read
+  statuses: write
+  issues: read

--- a/.github/chainguard/self.code-freeze-start.sts.yaml
+++ b/.github/chainguard/self.code-freeze-start.sts.yaml
@@ -1,0 +1,14 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-go:ref:refs/heads/.*"
+
+claim_pattern:
+  event_name: (workflow_dispatch|milestone)
+  repository: DataDog/dd-trace-go
+  job_workflow_ref: DataDog/dd-trace-go/\.github/workflows/code_freeze_start\.yml@refs/heads/.+
+
+permissions:
+  contents: read
+  pull_requests: read
+  statuses: write
+  issues: read

--- a/.github/chainguard/self.docker-build-and-push.sts.yaml
+++ b/.github/chainguard/self.docker-build-and-push.sts.yaml
@@ -1,0 +1,10 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-go:.*"
+
+claim_pattern:
+  repository: DataDog/dd-trace-go
+  job_workflow_ref: DataDog/dd-trace-go/\.github/workflows/docker-build-and-push\.yml@.*
+
+permissions:
+  packages: write

--- a/.github/chainguard/self.static-checks-shellcheck.sts.yaml
+++ b/.github/chainguard/self.static-checks-shellcheck.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-go:.*"
+
+claim_pattern:
+  repository: DataDog/dd-trace-go
+  job_workflow_ref: DataDog/dd-trace-go/\.github/workflows/static-checks\.yml@.*
+
+permissions:
+  pull_requests: write
+  checks: write

--- a/.github/chainguard/self.sync-cue-actions.sts.yaml
+++ b/.github/chainguard/self.sync-cue-actions.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-go:ref:refs/heads/dependabot/.*"
+
+claim_pattern:
+  event_name: push
+  repository: DataDog/dd-trace-go
+  job_workflow_ref: DataDog/dd-trace-go/\.github/workflows/sync-cue-actions\.yml@refs/heads/dependabot/.+
+
+permissions:
+  contents: write


### PR DESCRIPTION
### What does this PR do?

Add 6 Chainguard policy files under `.github/chainguard/` for the upcoming migration of `secrets.GITHUB_TOKEN` to `DataDog/dd-octo-sts-action`.

### Motivation

These policies must be on the default branch before the corresponding workflow changes can use them. They declare which workflow, event, and ref pattern may request which permissions via the dd-octo-sts OIDC token exchange.

Policy files only — no workflow changes. Stacked with #4749.

### Reviewer's Checklist

- [x] New code is free of linting errors.
- [x] New code doesn't break existing tests.
- [x] All generated files are up to date.

### Jira

- [APMLP-1602](https://datadoghq.atlassian.net/browse/APMLP-1602)


[APMLP-1602]: https://datadoghq.atlassian.net/browse/APMLP-1602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ