### PR TITLE
fix(ddtrace/tracer): fix race condition in ETP

### DIFF
--- a/ddtrace/tracer/civisibility_transport.go
+++ b/ddtrace/tracer/civisibility_transport.go
@@ -130,6 +130,7 @@ func newCiVisibilityTransport(config *config) *ciVisibilityTransport {
 //
 //	An io.ReadCloser for reading the response body, and an error if the operation fails.
 func (t *ciVisibilityTransport) send(p payload) (body io.ReadCloser, err error) {
+	defer p.Close()
 	ciVisibilityPayload := &ciVisibilityPayload{payload: p, serializationTime: 0}
 	buffer, bufferErr := ciVisibilityPayload.getBuffer(t.config)
 	if bufferErr != nil {

--- a/ddtrace/tracer/civisibility_writer_test.go
+++ b/ddtrace/tracer/civisibility_writer_test.go
@@ -33,6 +33,7 @@ type failingCiVisibilityTransport struct {
 }
 
 func (t *failingCiVisibilityTransport) send(p payload) (io.ReadCloser, error) {
+	defer p.Close()
 	t.sendAttempts++
 
 	ciVisibilityPayload := &ciVisibilityPayload{payload: p, serializationTime: 0}

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -1498,6 +1498,7 @@ func (t *dummyTransport) ObfuscationVersion() int {
 }
 
 func (t *dummyTransport) send(p payload) (io.ReadCloser, error) {
+	defer p.Close()
 	traces, ids, err := decode(p)
 	if err != nil {
 		return nil, err

--- a/ddtrace/tracer/payload_test.go
+++ b/ddtrace/tracer/payload_test.go
@@ -1168,3 +1168,67 @@ func BenchmarkPayloads(b *testing.B) {
 
 	// ... Add more payload versions here...
 }
+
+func TestPayloadV1Handoff(t *testing.T) {
+	// handoff must trigger a pool return exactly once regardless of ordering.
+	// wouldRelease mirrors handoff's Or+compare logic without the putPayloadV1
+	// side-effect, since putPayloadV1 isn't mockable.
+	wouldRelease := func(p *payloadV1, ownBit uint32) bool {
+		counterpart := (pv1StateFlushDone | pv1StateBodyClosed) &^ ownBit
+		return p.poolState.Or(ownBit) == counterpart
+	}
+
+	fresh := func() *payloadV1 {
+		// getPayloadV1 calls clear() which resets poolState to 0.
+		return getPayloadV1()
+	}
+
+	t.Run("flush first then close", func(t *testing.T) {
+		p := fresh()
+		assert.False(t, wouldRelease(p, pv1StateFlushDone), "flush alone must not release")
+		assert.True(t, wouldRelease(p, pv1StateBodyClosed), "close after flush must release")
+		putPayloadV1(p)
+	})
+
+	t.Run("close first then flush", func(t *testing.T) {
+		p := fresh()
+		assert.False(t, wouldRelease(p, pv1StateBodyClosed), "close alone must not release")
+		assert.True(t, wouldRelease(p, pv1StateFlushDone), "flush after close must release")
+		putPayloadV1(p)
+	})
+
+	t.Run("repeated close idempotent", func(t *testing.T) {
+		p := fresh()
+		assert.False(t, wouldRelease(p, pv1StateBodyClosed), "first close — flush not done")
+		assert.False(t, wouldRelease(p, pv1StateBodyClosed), "second close — bit already set, no-op")
+		assert.False(t, wouldRelease(p, pv1StateBodyClosed), "third close — still no-op")
+		// Flush must still release correctly after repeated closes.
+		assert.True(t, wouldRelease(p, pv1StateFlushDone), "flush after repeated closes must release")
+		putPayloadV1(p)
+	})
+
+	t.Run("concurrent flush and close", func(t *testing.T) {
+		const iterations = 10000
+		for range iterations {
+			p := fresh()
+			var wg sync.WaitGroup
+			var released atomic.Int32
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				if wouldRelease(p, pv1StateFlushDone) {
+					released.Add(1)
+				}
+			}()
+			go func() {
+				defer wg.Done()
+				if wouldRelease(p, pv1StateBodyClosed) {
+					released.Add(1)
+				}
+			}()
+			wg.Wait()
+			assert.Equal(t, int32(1), released.Load(), "exactly one release per iteration")
+			putPayloadV1(p)
+		}
+	})
+}

--- a/ddtrace/tracer/payload_v1.go
+++ b/ddtrace/tracer/payload_v1.go
@@ -116,7 +116,18 @@ type payloadV1 struct {
 	// avoiding repeated boxing of the string into any.
 	processTagsCached anyValue
 	processTagsStr    string
+
+	// poolState coordinates returning this payload to the pool after all HTTP
+	// activity is done. roundTrip() can return before writeLoop calls body.Close(),
+	// so we use two bits — whoever sets both is responsible for pool return.
+	poolState atomic.Uint32
 }
+
+// Bits for payloadV1.poolState.
+const (
+	pv1StateFlushDone  uint32 = 1 << 0 // set by flush goroutine after all sends complete
+	pv1StateBodyClosed uint32 = 1 << 1 // set by payloadV1.Close() when HTTP is done
+)
 
 // Constant dummy value to represent a serialization failure. Used to prevent failures while
 // decoding the payload.
@@ -298,6 +309,7 @@ func (p *payloadV1) clear() {
 	clear(p.attributes)
 	atomic.StoreUint32(&p.fields, 0)
 	atomic.StoreUint32(&p.count, 0)
+	p.poolState.Store(0)
 }
 
 // recordItem records that a new chunk was added to the payload.
@@ -362,8 +374,11 @@ func (p *payloadV1) setProcessTags() {
 }
 
 func (p *payloadV1) Close() error {
-	// No-op: clear() is called by getPayloadV1() after pool.Get(), which provides
-	// the happens-before guarantee. Clearing here would race with pool reuse.
+	// Set the "body closed" bit. If the flush goroutine already set its bit,
+	// all HTTP activity (reads + close) is done — return to pool.
+	if old := p.poolState.Or(pv1StateBodyClosed); old == pv1StateFlushDone {
+		putPayloadV1(p)
+	}
 	return nil
 }
 

--- a/ddtrace/tracer/payload_v1.go
+++ b/ddtrace/tracer/payload_v1.go
@@ -123,11 +123,22 @@ type payloadV1 struct {
 	poolState atomic.Uint32
 }
 
-// Bits for payloadV1.poolState.
+// Bits for payloadV1.poolState, used by handoff.
 const (
 	pv1StateFlushDone  uint32 = 1 << 0 // set by flush goroutine after all sends complete
 	pv1StateBodyClosed uint32 = 1 << 1 // set by payloadV1.Close() when HTTP is done
 )
+
+// handoff signals that one side (flush or HTTP close) is done with the payload.
+// It sets own bit and returns the payload to the pool if the counterpart bit was
+// already set — i.e., both parties are done. Idempotent: repeated calls with the
+// same bit are no-ops after the first.
+func (p *payloadV1) handoff(ownBit uint32) {
+	counterpart := (pv1StateFlushDone | pv1StateBodyClosed) &^ ownBit
+	if old := p.poolState.Or(ownBit); old == counterpart { // both parties done
+		putPayloadV1(p)
+	}
+}
 
 // Constant dummy value to represent a serialization failure. Used to prevent failures while
 // decoding the payload.
@@ -374,11 +385,7 @@ func (p *payloadV1) setProcessTags() {
 }
 
 func (p *payloadV1) Close() error {
-	// Set the "body closed" bit. If the flush goroutine already set its bit,
-	// all HTTP activity (reads + close) is done — return to pool.
-	if old := p.poolState.Or(pv1StateBodyClosed); old == pv1StateFlushDone {
-		putPayloadV1(p)
-	}
+	p.handoff(pv1StateBodyClosed)
 	return nil
 }
 

--- a/ddtrace/tracer/payload_v1.go
+++ b/ddtrace/tracer/payload_v1.go
@@ -362,7 +362,8 @@ func (p *payloadV1) setProcessTags() {
 }
 
 func (p *payloadV1) Close() error {
-	p.clear()
+	// No-op: clear() is called by getPayloadV1() after pool.Get(), which provides
+	// the happens-before guarantee. Clearing here would race with pool reuse.
 	return nil
 }
 

--- a/ddtrace/tracer/writer.go
+++ b/ddtrace/tracer/writer.go
@@ -150,13 +150,7 @@ func (h *agentTraceWriter) flush() {
 			// standard library. See dd-trace-go#976
 			h.statsd.Count("datadog.tracer.queue.enqueued.traces", int64(atomic.SwapUint32(&h.tracesQueued, 0)), nil, 1)
 			if p.protocol() == traceProtocolV1 {
-				pv1 := p.(*safePayload).p.(*payloadV1)
-				// Set the "flush done" bit. If HTTP already closed the body, we
-				// are last and all activity is done — return to pool.
-				// Otherwise, payloadV1.Close() will handle the pool return.
-				if old := pv1.poolState.Or(pv1StateFlushDone); old == pv1StateBodyClosed {
-					putPayloadV1(pv1)
-				}
+				p.(*safePayload).p.(*payloadV1).handoff(pv1StateFlushDone)
 			} else {
 				p.clear()
 			}

--- a/ddtrace/tracer/writer.go
+++ b/ddtrace/tracer/writer.go
@@ -150,8 +150,13 @@ func (h *agentTraceWriter) flush() {
 			// standard library. See dd-trace-go#976
 			h.statsd.Count("datadog.tracer.queue.enqueued.traces", int64(atomic.SwapUint32(&h.tracesQueued, 0)), nil, 1)
 			if p.protocol() == traceProtocolV1 {
-				sp := p.(*safePayload)
-				putPayloadV1(sp.p.(*payloadV1))
+				pv1 := p.(*safePayload).p.(*payloadV1)
+				// Set the "flush done" bit. If HTTP already closed the body, we
+				// are last and all activity is done — return to pool.
+				// Otherwise, payloadV1.Close() will handle the pool return.
+				if old := pv1.poolState.Or(pv1StateFlushDone); old == pv1StateBodyClosed {
+					putPayloadV1(pv1)
+				}
 			} else {
 				p.clear()
 			}

--- a/ddtrace/tracer/writer_test.go
+++ b/ddtrace/tracer/writer_test.go
@@ -358,6 +358,7 @@ type failingTransport struct {
 }
 
 func (t *failingTransport) send(p payload) (io.ReadCloser, error) {
+	defer p.Close()
 	t.sendAttempts++
 
 	traces, _, err := decode(p)
@@ -783,6 +784,7 @@ func TestPayloadSizeReporting(t *testing.T) {
 type simpleTransport struct{}
 
 func (t *simpleTransport) send(p payload) (io.ReadCloser, error) {
+	defer p.Close()
 	// Just read and discard the payload to simulate a successful send
 	_, _ = io.Copy(io.Discard, p)
 	return io.NopCloser(strings.NewReader("{}")), nil

--- a/internal/civisibility/integrations/testing_helpers_test.go
+++ b/internal/civisibility/integrations/testing_helpers_test.go
@@ -33,7 +33,13 @@ func resetCIVisibilityStateForTesting() {
 
 	uploadRepositoryChangesFunc = uploadRepositoryChanges
 	newCIVisibilityClientWithServiceNameFunc = net.NewClientWithServiceName
-	getSearchCommitsFunc = getSearchCommits
+	// Return "no commits" so the upload goroutine spawned by ensureSettingsInitialization
+	// exits immediately without reading ciVisibilityClient, preventing a data race with the
+	// next reset call that sets ciVisibilityClient = nil.
+	// Tests that need real commit data override getSearchCommitsFunc themselves.
+	getSearchCommitsFunc = func() (*searchCommitsResponse, error) {
+		return newSearchCommitsResponse(nil, nil, false), nil
+	}
 	unshallowGitRepositoryFunc = utils.UnshallowGitRepository
 	sendObjectsPackFileFunc = sendObjectsPackFile
 


### PR DESCRIPTION
### What does this PR do?

Removes `p.clear()` in `payloadV1.Close()` to avoid a race condition detected on #4719: https://github.com/DataDog/dd-trace-go/actions/runs/25758684755/job/75653908653?pr=4719#step:6:283

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
