### PR TITLE
feat(ddtrace/tracer): reduce allocations in ETP partial flush hot path

### DIFF
--- a/ddtrace/tracer/payload_v1.go
+++ b/ddtrace/tracer/payload_v1.go
@@ -308,9 +308,19 @@ func (p *payloadV1) reset() {
 	}
 }
 
+// maxRetainedBufCap is the maximum buffer capacity retained in the sync.Pool.
+// Buffers larger than this are discarded so that large one-off flushes (e.g.
+// 100k-span traces) do not permanently inflate pool memory, matching the
+// behaviour of payloadV04 which always discards its buffer on clear.
+const maxRetainedBufCap = 1 << 20 // 1 MB
+
 func (p *payloadV1) clear() {
 	p.bm = 0
-	p.buf = p.buf[:0]
+	if cap(p.buf) > maxRetainedBufCap {
+		p.buf = nil
+	} else {
+		p.buf = p.buf[:0]
+	}
 	p.reader = nil
 	// header is pre-allocated; keep backing array, reset length for sentinel check.
 	p.header = p.header[:0]

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -852,6 +852,9 @@ func (t *trace) finishedOneLocked(s *Span) {
 	willSend := decisionKeep == samplingDecision(atomic.LoadUint32((*uint32)(&t.samplingDecision)))
 
 	// Update trace state and release lock BEFORE acquiring fSpan lock
+	// Clear the tail so the GC can collect the flushed spans; without this the
+	// backing array retains pointers past len(t.spans) and keeps them alive.
+	clear(t.spans[leftIdx:])
 	t.spans = t.spans[:leftIdx]
 	t.finished = 0 // important, because a buffer can be used for several flushes
 	t.mu.Unlock()

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -825,29 +825,34 @@ func (t *trace) finishedOneLocked(s *Span) {
 	log.Debug("Partial flush triggered with %d finished spans", t.finished)
 	telemetry.Count(telemetry.NamespaceTracers, "trace_partial_flush.count", []string{"reason:large_trace"}).Submit(1)
 
+	// Partition spans in-place: finished spans go to finishedSpans, unfinished
+	// spans are compacted to the front of t.spans. This avoids a separate
+	// leftoverSpans allocation on every partial flush trigger.
+	originalFirst := t.spans[0]
 	finishedSpans := make([]*Span, 0, t.finished)
-	leftoverSpans := make([]*Span, 0, len(t.spans)-t.finished)
+	leftIdx := 0
 	for _, s2 := range t.spans {
 		if s2.finished {
 			finishedSpans = append(finishedSpans, s2)
 		} else {
-			leftoverSpans = append(leftoverSpans, s2)
+			t.spans[leftIdx] = s2
+			leftIdx++
 		}
 	}
 
 	telemetry.Distribution(telemetry.NamespaceTracers, "trace_partial_flush.spans_closed", nil).Submit(float64(len(finishedSpans)))
-	telemetry.Distribution(telemetry.NamespaceTracers, "trace_partial_flush.spans_remaining", nil).Submit(float64(len(leftoverSpans)))
+	telemetry.Distribution(telemetry.NamespaceTracers, "trace_partial_flush.spans_remaining", nil).Submit(float64(leftIdx))
 
 	// #incident-46344 -- if we set metrics and tags on a different span than what was passed into this function,
 	// we need to lock this new span. However, to preserve lock ordering (span.mu -> trace.mu), we must
 	// release trace.mu before acquiring fSpan.mu.
 	fSpan := finishedSpans[0]
 	currentSpanIsFirstInChunk := s == fSpan
-	needsFirstSpanTags := s != t.spans[0]
+	needsFirstSpanTags := s != originalFirst
 	willSend := decisionKeep == samplingDecision(atomic.LoadUint32((*uint32)(&t.samplingDecision)))
 
 	// Update trace state and release lock BEFORE acquiring fSpan lock
-	t.spans = leftoverSpans
+	t.spans = t.spans[:leftIdx]
 	t.finished = 0 // important, because a buffer can be used for several flushes
 	t.mu.Unlock()
 

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -341,6 +341,125 @@ func TestPartialFlush(t *testing.T) {
 		comparePayloadSpans(t, children[2], tsRoot[0][1])
 	})
 
+	// Verify partition correctness when finished and unfinished spans interleave in t.spans.
+	// t.spans order: [root, c0, c1, c2, c3]. Finish c1 and c3 first; root, c0, c2 stay open.
+	t.Run("InterleavedFinishOrder", func(t *testing.T) {
+		tracer, transport, flush, stop, err := startTestTracer(t)
+		assert.Nil(t, err)
+		defer stop()
+
+		root := tracer.StartSpan("root")
+		var children []*Span
+		for i := range 4 {
+			children = append(children, tracer.StartSpan(fmt.Sprintf("child%d", i), ChildOf(root.Context())))
+		}
+		// Finish interleaved: child[1] and child[3]; leave root, child[0], child[2] open.
+		children[1].Finish()
+		children[3].Finish() // triggers partial flush (t.finished == 2 >= min 2)
+		flush(1)
+
+		ts := transport.Traces()
+		require.Len(t, ts, 1)
+		require.Len(t, ts[0], 2, "first chunk must contain exactly the two finished spans")
+		flushedNames := map[string]bool{ts[0][0].name: true, ts[0][1].name: true}
+		assert.True(t, flushedNames["child1"], "child1 must be in first chunk")
+		assert.True(t, flushedNames["child3"], "child3 must be in first chunk")
+
+		// Finish remaining spans. With min=2 a second partial flush may fire (root+c0),
+		// then c2 completes the trace. Collect all remaining chunks and flatten.
+		root.Finish()
+		children[0].Finish()
+		children[2].Finish()
+		flush(2) // wait for the two remaining chunks: {root,c0} and {c2}
+
+		remainingNames := map[string]bool{}
+		for _, chunk := range transport.Traces() {
+			for _, s := range chunk {
+				remainingNames[s.name] = true
+			}
+		}
+		assert.True(t, remainingNames["root"])
+		assert.True(t, remainingNames["child0"])
+		assert.True(t, remainingNames["child2"])
+		assert.False(t, remainingNames["child1"], "child1 must not reappear")
+		assert.False(t, remainingNames["child3"], "child3 must not reappear")
+	})
+
+	// Verify originalFirst is captured correctly when t.spans[0] (root) is itself flushed.
+	// root finishes before children, triggering a partial flush where originalFirst == s == root.
+	t.Run("OriginalFirstSpanFlushed", func(t *testing.T) {
+		t.Setenv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", "3")
+		tracer, transport, flush, stop, err := startTestTracer(t)
+		assert.Nil(t, err)
+		defer stop()
+
+		root := tracer.StartSpan("root")
+		root.context.trace.setTag("someTraceTag", "someValue")
+		var children []*Span
+		for i := range 4 {
+			children = append(children, tracer.StartSpan(fmt.Sprintf("child%d", i), ChildOf(root.Context())))
+		}
+		// Finish root + two children; root is t.spans[0] and ends up in finishedSpans.
+		root.Finish()
+		children[0].Finish()
+		children[1].Finish() // triggers partial flush (t.finished == 3 >= min 3)
+		flush(1)
+
+		ts := transport.Traces()
+		require.Len(t, ts, 1)
+		require.Len(t, ts[0], 3, "first chunk must contain root + child[0] + child[1]")
+		flushedNames := map[string]bool{}
+		for _, s := range ts[0] {
+			flushedNames[s.name] = true
+		}
+		assert.True(t, flushedNames["root"])
+		assert.True(t, flushedNames["child0"])
+		assert.True(t, flushedNames["child1"])
+
+		// Remaining children should appear in second chunk; root must not.
+		children[2].Finish()
+		children[3].Finish()
+		flush(1)
+
+		ts2 := transport.Traces()
+		require.Len(t, ts2, 1)
+		remainingNames := map[string]bool{}
+		for _, s := range ts2[0] {
+			remainingNames[s.name] = true
+		}
+		assert.False(t, remainingNames["root"], "root must not reappear in second chunk")
+		assert.True(t, remainingNames["child2"])
+		assert.True(t, remainingNames["child3"])
+	})
+
+	// Verify that the backing array tail is cleared after in-place compaction so that
+	// flushed spans are not kept alive through stale pointers past len(t.spans).
+	t.Run("TailClearedAfterFlush", func(t *testing.T) {
+		tracer, _, _, stop, err := startTestTracer(t)
+		assert.Nil(t, err)
+		defer stop()
+
+		root := tracer.StartSpan("root")
+		child0 := tracer.StartSpan("child0", ChildOf(root.Context()))
+		child1 := tracer.StartSpan("child1", ChildOf(root.Context()))
+
+		child0.Finish()
+		child1.Finish() // triggers partial flush; root is the sole leftover
+
+		// Inspect t.spans immediately: len==1 (root only), tail must be nil.
+		root.context.trace.mu.RLock()
+		spans := root.context.trace.spans
+		root.context.trace.mu.RUnlock()
+
+		require.Equal(t, 1, len(spans), "only root must remain in trace after partial flush")
+		full := spans[:cap(spans)]
+		for i := len(spans); i < len(full); i++ {
+			assert.Nil(t, full[i], "tail slot %d must be nil so flushed spans can be GC'd", i)
+		}
+
+		root.Finish()
+	})
+
 	// This test covers an issue where partial flushing + a rate sampler would panic
 	t.Run("WithRateSamplerNoPanic", func(t *testing.T) {
 		tracer, _, _, stop, err := startTestTracer(t, WithSamplerRate(0.000001))


### PR DESCRIPTION
### What does this PR do?

Two small allocator improvements to the ETP / partial-flush path, built on top of `hannahkm/enable-etp`.

**1. Cap `payloadV1` pool buffer retention (`payload_v1.go`)**

`payloadV1.clear()` used `p.buf = p.buf[:0]`, retaining the backing array in the `sync.Pool` indefinitely. A single large flush (e.g. a 100k-span trace) could grow the buffer to several MB and keep it alive in the pool across all future cycles. Changed to discard buffers larger than 1 MB (mirroring `payloadV04.clear()` which always discards via `bytes.Buffer{}`).

**2. Eliminate `leftoverSpans` allocation in partial flush (`spancontext.go`)**

`finishedOneLocked()` allocated two slices on every partial flush trigger (`finishedSpans` + `leftoverSpans`). The leftover (unfinished) spans are compacted in-place into the front of the existing `t.spans` backing array instead, removing one allocation per flush. `finishedSpans` still requires a separate allocation because the chunk takes ownership of that slice. The original first span is captured before the loop to preserve the `needsFirstSpanTags` correctness.

### Motivation

Benchmark analysis of `hannahkm/enable-etp` identified these two allocation sources in the partial flush hot path. Neither change alters observable behaviour; both are pure allocator improvements.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] There is a benchmark for any new code, or changes to existing code.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
