### PR TITLE
fix(tracing): do not keep credential metadata in gRPC spans

### DIFF
--- a/contrib/google.golang.org/grpc/grpc_test.go
+++ b/contrib/google.golang.org/grpc/grpc_test.go
@@ -803,6 +803,67 @@ func TestIgnoredMetadata(t *testing.T) {
 	}
 }
 
+// WithMetadataTags must never write credential-bearing or binary metadata keys
+// into span tags, regardless of user-supplied WithIgnoredMetadata options.
+func TestMetadataCredentialLeakPrevention(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	rig, err := newRig(false, WithMetadataTags())
+	require.NoError(t, err)
+	defer rig.Close()
+
+	sensitiveKeys := []string{
+		"authorization",
+		"proxy-authorization",
+		"cookie",
+		"set-cookie",
+		"x-api-key",
+		"x-auth-token",
+	}
+
+	md := metadata.MD{
+		"authorization":           []string{"Bearer secret-token"},
+		"proxy-authorization":     []string{"Basic secret"},
+		"cookie":                  []string{"session=secret"},
+		"set-cookie":              []string{"id=secret; HttpOnly"},
+		"x-api-key":               []string{"secret-api-key"},
+		"x-auth-token":            []string{"secret-auth-token"},
+		"grpc-status-details-bin": []string{"binary-data"},
+		"safe-key":                []string{"visible"},
+	}
+	ctx := metadata.NewOutgoingContext(context.Background(), md)
+	_, err = rig.client.Ping(ctx, &fixturepb.FixtureRequest{Name: "pass"})
+	require.NoError(t, err)
+
+	waitForSpans(mt, 1)
+
+	var serverSpan *mocktracer.Span
+	for _, s := range mt.FinishedSpans() {
+		if s.OperationName() == "grpc.server" {
+			serverSpan = s
+			break
+		}
+	}
+	require.NotNil(t, serverSpan, "grpc.server span not found")
+
+	for _, key := range sensitiveKeys {
+		assert.Nil(t, serverSpan.Tag(tagMetadataPrefix+key), "credential key %q must not appear as span tag", key)
+		assert.Nil(t, serverSpan.Tag(tagMetadataPrefix+key+".0"), "credential key %q must not appear as span tag", key)
+	}
+
+	// Binary metadata must also be suppressed.
+	assert.Nil(t, serverSpan.Tag(tagMetadataPrefix+"grpc-status-details-bin"), "binary metadata must not appear as span tag")
+	assert.Nil(t, serverSpan.Tag(tagMetadataPrefix+"grpc-status-details-bin.0"), "binary metadata must not appear as span tag")
+
+	// Non-sensitive keys must still be tagged.
+	safeTag := serverSpan.Tag(tagMetadataPrefix + "safe-key")
+	if safeTag == nil {
+		safeTag = serverSpan.Tag(tagMetadataPrefix + "safe-key.0")
+	}
+	assert.NotNil(t, safeTag, "non-sensitive metadata key must still be tagged")
+}
+
 func TestSpanOpts(t *testing.T) {
 	t.Run("unary", func(t *testing.T) {
 		mt := mocktracer.Start()

--- a/contrib/google.golang.org/grpc/option.go
+++ b/contrib/google.golang.org/grpc/option.go
@@ -80,6 +80,13 @@ func defaults(cfg *config) {
 		"x-datadog-trace-id":          {},
 		"x-datadog-parent-id":         {},
 		"x-datadog-sampling-priority": {},
+		// Credential-bearing headers
+		"authorization":       {},
+		"proxy-authorization": {},
+		"cookie":              {},
+		"set-cookie":          {},
+		"x-api-key":           {},
+		"x-auth-token":        {},
 	}
 }
 

--- a/contrib/google.golang.org/grpc/server.go
+++ b/contrib/google.golang.org/grpc/server.go
@@ -7,6 +7,7 @@ package grpc
 
 import (
 	"context"
+	"strings"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
@@ -164,9 +165,16 @@ func withMetadataTags(ctx context.Context, cfg *config, span *tracer.Span) {
 	if cfg.withMetadataTags {
 		md, _ := metadata.FromIncomingContext(ctx) // nil is ok
 		for k, v := range md {
-			if _, ok := cfg.ignoredMetadata[k]; !ok {
-				span.SetTag(tagMetadataPrefix+k, v)
+			if _, ok := cfg.ignoredMetadata[k]; ok {
+				continue
 			}
+
+			// gRPC binary metadata keys end in "-bin"; their values are
+			// arbitrary bytes and must not be stored as string span tags.
+			if strings.HasSuffix(k, "-bin") {
+				continue
+			}
+			span.SetTag(tagMetadataPrefix+k, v)
 		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR updates the tracing code for gRPC to ensure that credentials passed as gRPC metadata ("headers") don't get included in the span (which would mean leaking them through traces).  
The PR also excludes any `bin-` metadata since they could contain private/confidential information.

### Reviewer's Checklist

- [X] Changed code has unit tests for its functionality at or near 100% coverage.
- [X] New code is free of linting errors. You can check this by running `make lint` locally.
- [X] New code doesn't break existing tests. You can check this by running `make test` locally.
- [X] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.

