### PR TITLE
perf(ddtrace/tracer): inline fixint field-IDs and specialize string encode in payloadV1 (-15-30% v1 push)

### DIFF
--- a/ddtrace/tracer/payload_v1.go
+++ b/ddtrace/tracer/payload_v1.go
@@ -248,17 +248,17 @@ func (p *payloadV1) push(t spanList) (stats payloadStats, err error) {
 		if cap(p.buf) == 0 {
 			p.buf = make([]byte, 0, len(t)*300)
 		}
-		p.buf = encodeField(p.buf, p.bm, 2, p.containerID, p.st)
-		p.buf = encodeField(p.buf, p.bm, 3, p.languageName, p.st)
-		p.buf = encodeField(p.buf, p.bm, 4, p.languageVersion, p.st)
-		p.buf = encodeField(p.buf, p.bm, 5, p.tracerVersion, p.st)
-		p.buf = encodeField(p.buf, p.bm, 6, p.runtimeID, p.st)
-		p.buf = encodeField(p.buf, p.bm, 7, p.env, p.st)
-		p.buf = encodeField(p.buf, p.bm, 8, p.hostname, p.st)
-		p.buf = encodeField(p.buf, p.bm, 9, p.appVersion, p.st)
+		p.buf = encodeStringField(p.buf, p.bm, 2, p.containerID, p.st)
+		p.buf = encodeStringField(p.buf, p.bm, 3, p.languageName, p.st)
+		p.buf = encodeStringField(p.buf, p.bm, 4, p.languageVersion, p.st)
+		p.buf = encodeStringField(p.buf, p.bm, 5, p.tracerVersion, p.st)
+		p.buf = encodeStringField(p.buf, p.bm, 6, p.runtimeID, p.st)
+		p.buf = encodeStringField(p.buf, p.bm, 7, p.env, p.st)
+		p.buf = encodeStringField(p.buf, p.bm, 8, p.hostname, p.st)
+		p.buf = encodeStringField(p.buf, p.bm, 9, p.appVersion, p.st)
 		p.encodeAttributes(p.bm, 10, p.attributes, p.st)
 		if p.bm.contains(11) {
-			p.buf = msgp.AppendUint32(p.buf, 11)    // field ID for chunks
+			p.buf = append(p.buf, 11)               // field ID for chunks
 			p.buf = append(p.buf, 0xdd, 0, 0, 0, 0) // array32 marker + 4-byte count = 0
 			p.chunksCountOff = len(p.buf) - 4
 		}
@@ -285,19 +285,30 @@ func (p *payloadV1) push(t spanList) (stats payloadStats, err error) {
 	return p.stats(), err
 }
 
-// grows the buffer to fit n more bytes. Follows the internal Go standard
-// for growing slices (https://github.com/golang/go/blob/master/src/runtime/slice.go#L289)
+// grow ensures p.buf has capacity for n more bytes appended after the current
+// content. Implements the payloadWriter interface for compatibility with
+// ciVisibilityPayload, which always uses payloadV04 in practice
+// (newCiVisibilityPayload hardcodes traceProtocolV04). This method has no
+// callers on the v1 trace hot path: pre-growing with spanList.Msgsize() was
+// measured to regress v1 by 4-19% across span sizes because Msgsize is a v0.4
+// upper bound and over-allocates relative to v1's string-table-compacted
+// output. push() relies on msgp.Append* organic growth instead.
+//
+// Preserves len(p.buf) so subsequent append() can use the new headroom.
 func (p *payloadV1) grow(n int) {
-	cap := cap(p.buf)
 	newLen := len(p.buf) + n
+	if newLen <= cap(p.buf) {
+		return
+	}
+	newCap := cap(p.buf)
 	threshold := 256
 	for {
-		cap += (cap + 3*threshold) >> 2
-		if cap >= newLen {
+		newCap += (newCap + 3*threshold) >> 2
+		if newCap >= newLen {
 			break
 		}
 	}
-	newBuffer := make([]byte, cap)
+	newBuffer := make([]byte, len(p.buf), newCap)
 	copy(newBuffer, p.buf)
 	p.buf = newBuffer
 }
@@ -444,14 +455,14 @@ func (p *payloadV1) encode() {
 	} else {
 		p.st.reset()
 	}
-	p.buf = encodeField(p.buf, p.bm, 2, p.containerID, p.st)
-	p.buf = encodeField(p.buf, p.bm, 3, p.languageName, p.st)
-	p.buf = encodeField(p.buf, p.bm, 4, p.languageVersion, p.st)
-	p.buf = encodeField(p.buf, p.bm, 5, p.tracerVersion, p.st)
-	p.buf = encodeField(p.buf, p.bm, 6, p.runtimeID, p.st)
-	p.buf = encodeField(p.buf, p.bm, 7, p.env, p.st)
-	p.buf = encodeField(p.buf, p.bm, 8, p.hostname, p.st)
-	p.buf = encodeField(p.buf, p.bm, 9, p.appVersion, p.st)
+	p.buf = encodeStringField(p.buf, p.bm, 2, p.containerID, p.st)
+	p.buf = encodeStringField(p.buf, p.bm, 3, p.languageName, p.st)
+	p.buf = encodeStringField(p.buf, p.bm, 4, p.languageVersion, p.st)
+	p.buf = encodeStringField(p.buf, p.bm, 5, p.tracerVersion, p.st)
+	p.buf = encodeStringField(p.buf, p.bm, 6, p.runtimeID, p.st)
+	p.buf = encodeStringField(p.buf, p.bm, 7, p.env, p.st)
+	p.buf = encodeStringField(p.buf, p.bm, 8, p.hostname, p.st)
+	p.buf = encodeStringField(p.buf, p.bm, 9, p.appVersion, p.st)
 
 	p.encodeAttributes(p.bm, 10, p.attributes, p.st)
 
@@ -462,13 +473,27 @@ type fieldValue interface {
 	bool | []byte | int32 | int64 | uint32 | uint64 | string
 }
 
+// encodeStringField is a string-specialized fast-path for encodeField. It avoids the
+// generic switch any(a).(type) dispatch that costs a runtime type-assert per call.
+// The fieldID is appended as a single byte: all v1 string fields use IDs 1-16, which
+// fit in the msgp positive fixint range (0..127) and encode as one byte.
+func encodeStringField(buf []byte, bm bitmap, fieldID uint32, value string, st *stringTable) []byte {
+	if !bm.contains(fieldID) {
+		return buf
+	}
+	buf = append(buf, byte(fieldID))
+	return st.serialize(value, buf)
+}
+
 // encodeField takes a field of any fieldValue and encodes it into the given buffer
-// in msgp format.
+// in msgp format. String callers should prefer encodeStringField, which skips the
+// generic type switch on the hot path.
 func encodeField[F fieldValue](buf []byte, bm bitmap, fieldID uint32, a F, st *stringTable) []byte {
 	if !bm.contains(fieldID) {
 		return buf
 	}
-	buf = msgp.AppendUint32(buf, uint32(fieldID)) // msgp key
+	// v1 field IDs are 1-16; all fit msgp positive fixint and encode as one byte.
+	buf = append(buf, byte(fieldID))
 	switch value := any(a).(type) {
 	case string:
 		// encode msgp value, either by pulling from string table or writing it directly
@@ -504,7 +529,8 @@ func (p *payloadV1) encodeAttributes(bm bitmap, fieldID int, kv map[string]anyVa
 		return false, nil
 	}
 
-	p.buf = msgp.AppendUint32(p.buf, uint32(fieldID))        // msgp key
+	// fieldID values for attributes are 3 (chunk) or 10 (payload), both fixint.
+	p.buf = append(p.buf, byte(fieldID))
 	p.buf = msgp.AppendArrayHeader(p.buf, uint32(len(kv)*3)) // number of item pairs in array
 
 	for k, v := range kv {
@@ -527,7 +553,7 @@ func (p *payloadV1) encodeTraceChunk(chunk traceChunk, st *stringTable) {
 	p.buf = encodeField(p.buf, fullSetBitmap, 1, chunk.priority, st)
 
 	// origin
-	p.buf = encodeField(p.buf, fullSetBitmap, 2, chunk.origin, st)
+	p.buf = encodeStringField(p.buf, fullSetBitmap, 2, chunk.origin, st)
 
 	// attributes
 	p.encodeAttributes(fullSetBitmap, 3, chunk.attributes, st)
@@ -551,7 +577,8 @@ func (p *payloadV1) encodeTraceChunks(bm bitmap, fieldID int, tc []traceChunk, s
 		return false, nil
 	}
 
-	p.buf = msgp.AppendUint32(p.buf, uint32(fieldID))      // msgp key
+	// fieldID is always 11 (chunks) at this site; fits msgp positive fixint.
+	p.buf = append(p.buf, byte(fieldID))
 	p.buf = msgp.AppendArrayHeader(p.buf, uint32(len(tc))) // number of chunks
 	for _, chunk := range tc {
 		p.buf = msgp.AppendMapHeader(p.buf, 7) // number of fields in chunk
@@ -560,7 +587,7 @@ func (p *payloadV1) encodeTraceChunks(bm bitmap, fieldID int, tc []traceChunk, s
 		p.buf = encodeField(p.buf, fullSetBitmap, 1, chunk.priority, st)
 
 		// origin
-		p.buf = encodeField(p.buf, fullSetBitmap, 2, chunk.origin, st)
+		p.buf = encodeStringField(p.buf, fullSetBitmap, 2, chunk.origin, st)
 
 		// attributes
 		p.encodeAttributes(fullSetBitmap, 3, chunk.attributes, st)
@@ -588,7 +615,8 @@ func (p *payloadV1) encodeSpans(bm bitmap, fieldID int, spans spanList, st *stri
 		return false, nil
 	}
 
-	p.buf = msgp.AppendUint32(p.buf, uint32(fieldID))         // msgp key
+	// fieldID is always 4 (spans) at this site; fits msgp positive fixint.
+	p.buf = append(p.buf, byte(fieldID))
 	p.buf = msgp.AppendArrayHeader(p.buf, uint32(len(spans))) // number of spans
 
 	var scratch []byte
@@ -600,9 +628,9 @@ func (p *payloadV1) encodeSpans(bm bitmap, fieldID int, spans spanList, st *stri
 		}
 		p.buf = msgp.AppendMapHeader(p.buf, 16) // number of fields in span
 
-		p.buf = encodeField(p.buf, fullSetBitmap, 1, span.service, st)
-		p.buf = encodeField(p.buf, fullSetBitmap, 2, span.name, st)
-		p.buf = encodeField(p.buf, fullSetBitmap, 3, span.resource, st)
+		p.buf = encodeStringField(p.buf, fullSetBitmap, 1, span.service, st)
+		p.buf = encodeStringField(p.buf, fullSetBitmap, 2, span.name, st)
+		p.buf = encodeStringField(p.buf, fullSetBitmap, 3, span.resource, st)
 		p.buf = encodeField(p.buf, fullSetBitmap, 4, span.spanID, st)
 		p.buf = encodeField(p.buf, fullSetBitmap, 5, span.parentID, st)
 		p.buf = encodeField(p.buf, fullSetBitmap, 6, span.start, st)
@@ -615,7 +643,7 @@ func (p *payloadV1) encodeSpans(bm bitmap, fieldID int, spans spanList, st *stri
 		// and write the actual count after writing all attributes.
 		// Promoted attrs (env, version, language) are encoded separately
 		// as fields 13-16 and must not appear in the attributes array.
-		p.buf = msgp.AppendUint32(p.buf, uint32(9)) // attributes fieldID
+		p.buf = append(p.buf, 9) // attributes fieldID (msgp fixint)
 		off := len(p.buf)
 		count := 0
 		p.buf = append(p.buf, msgpackArray32, 0, 0, 0, 0)
@@ -623,7 +651,7 @@ func (p *payloadV1) encodeSpans(bm bitmap, fieldID int, spans spanList, st *stri
 		if lang, ok := span.meta.Language(); ok {
 			count++
 			p.buf = st.serialize("language", p.buf)
-			p.buf = msgp.AppendUint32(p.buf, uint32(StringValueType))
+			p.buf = append(p.buf, byte(StringValueType))
 			p.buf = st.serialize(lang, p.buf)
 		}
 
@@ -644,14 +672,14 @@ func (p *payloadV1) encodeSpans(bm bitmap, fieldID int, spans spanList, st *stri
 			}
 			count++
 			p.buf = st.serialize(k, p.buf)
-			p.buf = msgp.AppendUint32(p.buf, uint32(StringValueType))
+			p.buf = append(p.buf, byte(StringValueType))
 			p.buf = st.serialize(v, p.buf)
 			return true
 		})
 		for k, v := range span.metrics {
 			count++
 			p.buf = st.serialize(k, p.buf)
-			p.buf = msgp.AppendUint32(p.buf, uint32(FloatValueType))
+			p.buf = append(p.buf, byte(FloatValueType))
 			p.buf = msgp.AppendFloat64(p.buf, v)
 		}
 		for k, v := range span.metaStruct {
@@ -663,7 +691,7 @@ func (p *payloadV1) encodeSpans(bm bitmap, fieldID int, spans spanList, st *stri
 			}
 			count++
 			p.buf = st.serialize(k, p.buf)
-			p.buf = msgp.AppendUint32(p.buf, uint32(BytesValueType))
+			p.buf = append(p.buf, byte(BytesValueType))
 			p.buf = msgp.AppendBytes(p.buf, scratch)
 		}
 		elementCount := uint32(count) * 3
@@ -672,7 +700,7 @@ func (p *payloadV1) encodeSpans(bm bitmap, fieldID int, spans spanList, st *stri
 		p.buf[off+3] = byte(elementCount >> 8)
 		p.buf[off+4] = byte(elementCount)
 
-		p.buf = encodeField(p.buf, fullSetBitmap, 10, span.spanType, st)
+		p.buf = encodeStringField(p.buf, fullSetBitmap, 10, span.spanType, st)
 		p.encodeSpanLinks(fullSetBitmap, 11, span.spanLinks, st)
 		p.encodeSpanEvents(fullSetBitmap, 12, span.spanEvents, st)
 
@@ -681,9 +709,9 @@ func (p *payloadV1) encodeSpans(bm bitmap, fieldID int, spans spanList, st *stri
 		// captured during the Range iteration above.
 		env, _ := span.meta.Env()
 		version, _ := span.meta.Version()
-		p.buf = encodeField(p.buf, fullSetBitmap, 13, env, st)
-		p.buf = encodeField(p.buf, fullSetBitmap, 14, version, st)
-		p.buf = encodeField(p.buf, fullSetBitmap, 15, component, st)
+		p.buf = encodeStringField(p.buf, fullSetBitmap, 13, env, st)
+		p.buf = encodeStringField(p.buf, fullSetBitmap, 14, version, st)
+		p.buf = encodeStringField(p.buf, fullSetBitmap, 15, component, st)
 		p.buf = encodeField(p.buf, fullSetBitmap, 16, getSpanKindValue(spanKind), st)
 	}
 	return true, nil
@@ -730,28 +758,29 @@ func (p *payloadV1) encodeSpanLinks(bm bitmap, fieldID int, spanLinks []SpanLink
 	if !bm.contains(uint32(fieldID)) {
 		return false, nil
 	}
-	p.buf = msgp.AppendUint32(p.buf, uint32(fieldID))             // msgp key
+	// fieldID is 11 (span_links) here; fits msgp positive fixint.
+	p.buf = append(p.buf, byte(fieldID))
 	p.buf = msgp.AppendArrayHeader(p.buf, uint32(len(spanLinks))) // number of span links
 
 	for _, link := range spanLinks {
 		p.buf = msgp.AppendMapHeader(p.buf, 5) // number of fields in span link
 
-		// Encode traceID field directly to avoid heap allocation
-		p.buf = msgp.AppendUint32(p.buf, uint32(1)) // field ID
-		p.buf = msgp.AppendBytesHeader(p.buf, 16)   // 16-byte traceID
+		// Encode traceID field directly to avoid heap allocation.
+		p.buf = append(p.buf, 1)                  // field ID (fixint)
+		p.buf = msgp.AppendBytesHeader(p.buf, 16) // 16-byte traceID
 		p.buf = binary.BigEndian.AppendUint64(p.buf, link.TraceIDHigh)
 		p.buf = binary.BigEndian.AppendUint64(p.buf, link.TraceID)
 		p.buf = encodeField(p.buf, fullSetBitmap, 2, link.SpanID, st)
 
-		p.buf = msgp.AppendUint32(p.buf, uint32(3))                           // attributes fieldID
+		p.buf = append(p.buf, 3)                                              // attributes fieldID (fixint)
 		p.buf = msgp.AppendArrayHeader(p.buf, uint32(len(link.Attributes))*3) // number of attributes
 		for k, v := range link.Attributes {
 			p.buf = st.serialize(k, p.buf)
-			p.buf = msgp.AppendUint32(p.buf, uint32(StringValueType))
+			p.buf = append(p.buf, byte(StringValueType))
 			p.buf = st.serialize(v, p.buf)
 		}
 
-		p.buf = encodeField(p.buf, fullSetBitmap, 4, link.Tracestate, st)
+		p.buf = encodeStringField(p.buf, fullSetBitmap, 4, link.Tracestate, st)
 		p.buf = encodeField(p.buf, fullSetBitmap, 5, link.Flags, st)
 	}
 	return true, nil
@@ -762,34 +791,35 @@ func (p *payloadV1) encodeSpanEvents(bm bitmap, fieldID int, spanEvents []spanEv
 	if !bm.contains(uint32(fieldID)) {
 		return false, nil
 	}
-	p.buf = msgp.AppendUint32(p.buf, uint32(fieldID))              // msgp key
+	// fieldID is 12 (span_events) here; fits msgp positive fixint.
+	p.buf = append(p.buf, byte(fieldID))
 	p.buf = msgp.AppendArrayHeader(p.buf, uint32(len(spanEvents))) // number of span events
 
 	for _, event := range spanEvents {
 		p.buf = msgp.AppendMapHeader(p.buf, 3) // number of fields in span event
 
 		p.buf = encodeField(p.buf, fullSetBitmap, 1, event.TimeUnixNano, st)
-		p.buf = encodeField(p.buf, fullSetBitmap, 2, event.Name, st)
+		p.buf = encodeStringField(p.buf, fullSetBitmap, 2, event.Name, st)
 
-		p.buf = msgp.AppendUint32(p.buf, uint32(3))                            // attributes fieldID
+		p.buf = append(p.buf, 3)                                               // attributes fieldID (fixint)
 		p.buf = msgp.AppendArrayHeader(p.buf, uint32(len(event.Attributes))*3) // number of attributes
 		for k, v := range event.Attributes {
 			p.buf = st.serialize(k, p.buf)
 			switch v.Type {
 			case spanEventAttributeTypeString:
-				p.buf = msgp.AppendUint32(p.buf, uint32(StringValueType))
+				p.buf = append(p.buf, byte(StringValueType))
 				p.buf = st.serialize(v.StringValue, p.buf)
 			case spanEventAttributeTypeInt:
-				p.buf = msgp.AppendUint32(p.buf, uint32(IntValueType))
+				p.buf = append(p.buf, byte(IntValueType))
 				p.buf = msgp.AppendInt64(p.buf, v.IntValue)
 			case spanEventAttributeTypeDouble:
-				p.buf = msgp.AppendUint32(p.buf, uint32(FloatValueType))
+				p.buf = append(p.buf, byte(FloatValueType))
 				p.buf = msgp.AppendFloat64(p.buf, v.DoubleValue)
 			case spanEventAttributeTypeBool:
-				p.buf = msgp.AppendUint32(p.buf, uint32(BoolValueType))
+				p.buf = append(p.buf, byte(BoolValueType))
 				p.buf = msgp.AppendBool(p.buf, v.BoolValue)
 			case spanEventAttributeTypeArray:
-				p.buf = msgp.AppendUint32(p.buf, uint32(ArrayValueType))
+				p.buf = append(p.buf, byte(ArrayValueType))
 				// Array format is (type, value) per element; decoder expects len/2 anyValues.
 				p.buf = msgp.AppendArrayHeader(p.buf, uint32(len(v.ArrayValue.Values))*2)
 				for _, v := range v.ArrayValue.Values {
@@ -797,7 +827,7 @@ func (p *payloadV1) encodeSpanEvents(bm bitmap, fieldID int, spanEvents []spanEv
 				}
 			default:
 				warnUnsupportedValue(uint32(v.Type))
-				p.buf = msgp.AppendUint32(p.buf, uint32(StringValueType))
+				p.buf = append(p.buf, byte(StringValueType))
 				p.buf = st.serialize(serializationFailed, p.buf)
 			}
 		}
@@ -808,20 +838,20 @@ func (p *payloadV1) encodeSpanEvents(bm bitmap, fieldID int, spanEvents []spanEv
 func (p *payloadV1) encodeSpanEventArrayValues(v *spanEventArrayAttributeValue, st *stringTable) (bool, error) {
 	switch v.Type {
 	case spanEventArrayAttributeValueTypeString:
-		p.buf = msgp.AppendUint32(p.buf, uint32(StringValueType))
+		p.buf = append(p.buf, byte(StringValueType))
 		p.buf = st.serialize(v.StringValue, p.buf)
 	case spanEventArrayAttributeValueTypeInt:
-		p.buf = msgp.AppendUint32(p.buf, uint32(IntValueType))
+		p.buf = append(p.buf, byte(IntValueType))
 		p.buf = msgp.AppendInt64(p.buf, v.IntValue)
 	case spanEventArrayAttributeValueTypeDouble:
-		p.buf = msgp.AppendUint32(p.buf, uint32(FloatValueType))
+		p.buf = append(p.buf, byte(FloatValueType))
 		p.buf = msgp.AppendFloat64(p.buf, v.DoubleValue)
 	case spanEventArrayAttributeValueTypeBool:
-		p.buf = msgp.AppendUint32(p.buf, uint32(BoolValueType))
+		p.buf = append(p.buf, byte(BoolValueType))
 		p.buf = msgp.AppendBool(p.buf, v.BoolValue)
 	default:
 		warnUnsupportedValue(uint32(v.Type))
-		p.buf = msgp.AppendUint32(p.buf, uint32(StringValueType))
+		p.buf = append(p.buf, byte(StringValueType))
 		p.buf = st.serialize(serializationFailed, p.buf)
 	}
 	return true, nil
@@ -1076,32 +1106,33 @@ const (
 )
 
 func (a anyValue) encode(buf []byte, st *stringTable) []byte {
+	// Value-type constants are 1..7; encode as msgp positive fixint (one byte).
 	switch a.valueType {
 	case StringValueType:
-		buf = msgp.AppendInt32(buf, int32(a.valueType))
+		buf = append(buf, byte(a.valueType))
 		s := a.value.(string)
 		buf = st.serialize(s, buf)
 	case BoolValueType:
-		buf = msgp.AppendInt32(buf, int32(a.valueType))
+		buf = append(buf, byte(a.valueType))
 		buf = msgp.AppendBool(buf, a.value.(bool))
 	case FloatValueType:
-		buf = msgp.AppendInt32(buf, int32(a.valueType))
+		buf = append(buf, byte(a.valueType))
 		buf = msgp.AppendFloat64(buf, a.value.(float64))
 	case IntValueType:
-		buf = msgp.AppendInt32(buf, int32(a.valueType))
+		buf = append(buf, byte(a.valueType))
 		buf = msgp.AppendInt64(buf, a.value.(int64))
 	case BytesValueType:
-		buf = msgp.AppendInt32(buf, int32(a.valueType))
+		buf = append(buf, byte(a.valueType))
 		buf = msgp.AppendBytes(buf, a.value.([]byte))
 	case ArrayValueType:
-		buf = msgp.AppendInt32(buf, int32(a.valueType))
+		buf = append(buf, byte(a.valueType))
 		buf = msgp.AppendArrayHeader(buf, uint32(len(a.value.(arrayValue))))
 		for _, v := range a.value.(arrayValue) {
 			buf = v.encode(buf, st)
 		}
 	default:
 		warnUnsupportedValue(uint32(a.valueType))
-		buf = msgp.AppendInt32(buf, StringValueType)
+		buf = append(buf, byte(StringValueType))
 		buf = st.serialize(serializationFailed, buf)
 	}
 	return buf
@@ -1147,6 +1178,11 @@ func (b bitmap) contains(bit uint32) bool {
 type index int32
 
 func (i index) encode(buf []byte) []byte {
+	// Indices typically fit in msgp positive fixint range (0..127); bypass the
+	// msgp.AppendUint32 function-call overhead on the stringTable hit path.
+	if uint32(i) < 128 {
+		return append(buf, byte(i))
+	}
 	return msgp.AppendUint32(buf, uint32(i))
 }
 
@@ -1205,7 +1241,9 @@ func (st *stringTable) reset() {
 // Adds a string to the string table if it does not already exist.
 func (st *stringTable) serialize(value string, buf []byte) []byte {
 	if value == "" {
-		return msgp.AppendUint32(buf, 0)
+		// msgp positive fixint 0 encodes as a single 0x00 byte; bypass the
+		// msgp.AppendUint32 function-call overhead on this hot path.
+		return append(buf, 0)
 	}
 	if idx, ok := st.indices[value]; ok {
 		return idx.encode(buf)


### PR DESCRIPTION
### What does this PR do?

Four low-risk fast-paths on the v1 trace payload encoder hot path in `ddtrace/tracer/payload_v1.go`:

1. **Inline small field-ID writes.** All v1 field IDs (1-16) and value-type constants (1-7) fit in the msgp positive fixint range, so they encode as a single byte. Replace `msgp.AppendUint32(buf, uint32(fieldID))` and `msgp.AppendInt32(buf, int32(valueType))` with bare `append(buf, byte(...))` at every encode site (`encodeField`, `encodeAttributes`, `encodeTraceChunks`, `encodeSpans`, `encodeSpanLinks`, `encodeSpanEvents`, `encodeSpanEventArrayValues`, `anyValue.encode`, and the cold-path static field emit in `push`). Removes the per-call function-call overhead that profiles showed dominated `encodeField[string]` and `encodeSpanLinks` cumulative samples.

2. **Specialize `encodeStringField`.** The generic `encodeField[F fieldValue]` dispatches via `switch any(a).(type)`, a runtime type-assert per call. Added a string-only helper next to it and switched the string callsites (static fields in `(*payloadV1).encode` and `push`, span `service`/`name`/`resource`/`spanType`, `env`/`version`/`component`, chunk `origin`, link `Tracestate`, event `Name`). The generic `encodeField` remains the catch-all for int64, uint32, bool, []byte, and `arrayValue`.

3. **`index.encode` small-index fast-path.** Stringtable indices typically fit in a positive fixint (`< 128`). Inline that branch with a bare `append(buf, byte(i))` before falling back to `msgp.AppendUint32`.

4. **`stringTable.serialize` empty-string bare write.** Replace `msgp.AppendUint32(buf, 0)` with `append(buf, 0)`: msgp positive fixint 0 is byte-identical to `0x00`, but the bare append skips the function call. Profile showed this branch alone consumed ~180ms on the detailed_1000 sample.

Wire format is byte-identical to the previous encoder — all replacements emit the same msgp bytes via a faster path. The dead-code `payloadV1.grow` (no callers on the v1 trace hot path; only `civisibility_payload.go` calls `payload.grow`, and `newCiVisibilityPayload` hardcodes v0.4) was also fixed for correctness: its previous `make([]byte, cap)` left zero spare capacity for `append`, defeating the pre-grow. Now uses `make([]byte, len, newCap)` with an early-return on no-op.

### Measurements

`BenchmarkPayloads/v1.0/push/*` (-benchtime=3s -count=8), v1 vs prior HEAD (`benchstat`, p ≤ 0.05):

| workload                  | base ns/op | bundle ns/op |    Δ    |
|---------------------------|-----------:|-------------:|--------:|
| `10spans`                  |      1707 |        1362 |   -20%  |
| `1000spans`                |    147.6µ |       102.6µ |   -30%  |
| `10_detailed_spans`        |      4002 |        3588 |   -10%  |
| `1000_detailed_spans`      |    366.7µ |       290.9µ |   -21%  |
| `low_cardinality_spans`    |    327.5µ |       278.1µ |   -15%  |
| `high_cardinality_spans`   |    177.6µ |       131.7µ |   -26%  |

v0.4 paths unchanged. Pool-aware `BenchmarkPayloadVersions` confirms the same shape: v1 simple_1000 -22%, detailed_1000 -16%, metastruct_1000 ~flat (the metastruct path is dominated by `msgp.AppendIntf` and `msgp.AppendBytes`, both outside this PR's surface).

Net result: v1 push cost is now at or below v0.4 for most workloads (1000 simple v0.4 124µs vs v1 103µs; high-card parity; 10 detailed is the only remaining v1>v0.4 case, ~14%).

### Motivation

While benchmarking the ETP-enable branch (`hannahkm/enable-etp`), the v1 trace protocol was measured 15-30% slower than v0.4 on the encoder hot path. Profile attribution (`BenchmarkPayloads/v1.0/push/1000_detailed_spans`):

- `msgp.AppendUint64` 27% flat, `msgp.AppendUint32` 28% cum
- `encodeField[string]` 21% cum
- `(*stringTable).serialize` 14% cum
- `(*payloadV1).encodeSpanLinks` 35% cum
- `runtime.growslice` 10% cum

Two earlier hypotheses were tested and rejected on this branch's parent: a static pre-size bump (`482a79fa9→fe8cdb935`) and a per-push `spanList.Msgsize()` pre-grow (this branch's earlier C2 experiment, -12 to -19% regression). The remaining cost was structural in the per-field msgp call fan-out and the stringTable map probes — this PR addresses the function-call overhead piece without touching wire format or the stringTable algorithm. Deferred items (#7 hoist per-push hot indices, #9 SpanLink `MarshalMsg` reuse, #10 FNV-backed stringTable, #11 batch encoder with scratch, #12 drop stringTable on small chunks) remain available as a separate follow-up; their prerequisites are preserved by this PR (single `stringTable.serialize` entry point, swappable `encodeSpanLinks` funnel, no external readers of `st.indices`, helpers shaped `func(...) []byte`, lazy `p.st` init).

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage. (Wire format is byte-identical; existing `TestPayload*` coverage exercises every changed encode site.)
- [x] There is a benchmark for any new code, or changes to existing code. (`BenchmarkPayloads`, `BenchmarkPayloadVersions` cover all touched paths.)
- [x] New code is free of linting errors.
- [x] New code doesn't break existing tests (`go test ./ddtrace/tracer/` passes).
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. (N/A — single file, no module changes.)