### PR TITLE
perf(ddtrace/tracer): drop span.meta.Range on v1 encoding

### DIFF
--- a/ddtrace/tracer/internal/span_meta.go
+++ b/ddtrace/tracer/internal/span_meta.go
@@ -132,16 +132,6 @@ func (sm *SpanMeta) Version() (string, bool) { return sm.promotedAttrs.Get(AttrV
 // Language returns the value of the "language" promoted attribute.
 func (sm *SpanMeta) Language() (string, bool) { return sm.promotedAttrs.Get(AttrLanguage) }
 
-// Range calls fn for each flat-map entry. Promoted attrs are not in sm.m
-// and are not yielded. Iteration stops if fn returns false.
-func (sm *SpanMeta) Range(fn func(k, v string) bool) {
-	for k, v := range sm.m {
-		if !fn(k, v) {
-			return
-		}
-	}
-}
-
 // ---------------------------------------------------------------------------
 // Write methods
 // ---------------------------------------------------------------------------

--- a/ddtrace/tracer/payload_v1.go
+++ b/ddtrace/tracer/payload_v1.go
@@ -628,12 +628,12 @@ func (p *payloadV1) encodeSpans(bm bitmap, fieldID int, spans spanList, st *stri
 		}
 
 		component, spanKind := "", ""
-		// Range iterates only flat-map entries (promoted attrs are excluded).
-		span.meta.Range(func(k, v string) bool {
+		// Map(false) returns the underlying flat map directly (no copy, no promoted attrs).
+		for k, v := range span.meta.Map(false) {
 			// Span links are serialized separately in the payload, so
 			// we skip them here to avoid duplication.
 			if k == "_dd.span_links" {
-				return true
+				continue
 			}
 			// Grab common attributes early to avoid map lookups later on.
 			if k == ext.Component {
@@ -646,8 +646,7 @@ func (p *payloadV1) encodeSpans(bm bitmap, fieldID int, spans spanList, st *stri
 			p.buf = st.serialize(k, p.buf)
 			p.buf = msgp.AppendUint32(p.buf, uint32(StringValueType))
 			p.buf = st.serialize(v, p.buf)
-			return true
-		})
+		}
 		for k, v := range span.metrics {
 			count++
 			p.buf = st.serialize(k, p.buf)


### PR DESCRIPTION
### What does this PR do?

Replaces the closure-based `SpanMeta.Range` call in the v1 payload encoder with a direct `for k, v := range span.meta.Map(false)` loop, and removes the now-unused `Range` method from `SpanMeta`.

`SpanMeta.Map(false)` returns the underlying flat map by reference (no copy, no allocation) and excludes promoted attributes, matching `Range`'s prior semantics exactly. Behavior on the wire is unchanged.

### Motivation

Profile attribution from `BenchmarkPayloads/v1.0/push/1000_detailed_spans` flagged the closure call inside `encodeSpans` as a meaningful chunk of cumulative time (~8% on the call path). Range was a holdover from before `SpanMeta.Map(false)` exposed the flat map directly; the encoder is the only caller, so the indirection is dead weight on a hot loop.

Local measurements on Apple M1 Max, 6×2s per case, base vs. this branch:

| benchmark | sec/op Δ | B/op Δ | p (time) |
|-----------|---------:|-------:|---------:|
| `BenchmarkPayloads/v1.0/push/high_cardinality_spans` | **−1.49%** | **−1.82%** | 0.015 |
| `BenchmarkPayloads/v1.0/push/1000_detailed_spans`    | ~ | ~ | 0.394 |
| `BenchmarkPayloads/v1.0/push/10_detailed_spans`      | ~ | ~ | 0.485 |

Smaller than the profile-suggested ceiling because most of the time inside the closure body (`stringTable.serialize`, `msgp.AppendUint32`) is the same work either way — only the dispatch overhead is removed.

This change targets `hannahkm/enable-etp` (the ETP-enable parent) rather than stacking on the v1-encoder fast-path bundle in #4768, since it is orthogonal to the bundle helpers and useful on its own.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage. — covered by existing `TestPayloadIntegrity` / `TestPayloadVersions` round-trip tests and `TestSpanMeta*` in `ddtrace/tracer/internal/`.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag. — N/A, wire format unchanged.
- [x] There is a benchmark for any new code, or changes to existing code. — `BenchmarkPayloads/v1.0/push/*` already covers the path.
- [x] New code is free of linting errors. `go vet ./ddtrace/tracer/...` clean.
- [x] New code doesn't break existing tests. `OTEL_TRACES_EXPORTER= go test ./ddtrace/tracer/ ./ddtrace/tracer/internal/` passes.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. — no generated files touched.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. — no go.mod changes.