### PR TITLE
perf(ddtrace/tracer): open-addressed maphash stringTable on v1 encoding

### DIFF
--- a/ddtrace/tracer/payload_v1.go
+++ b/ddtrace/tracer/payload_v1.go
@@ -10,6 +10,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"hash/maphash"
 	"sync"
 	"sync/atomic"
 
@@ -1177,26 +1178,39 @@ func (s *stringValue) decode(buf []byte) ([]byte, error) {
 
 var errUnableDecodeString = errors.New("unable to read string value")
 
+// stringTable maps strings to insertion-order indices for v1 payload encoding.
+// Insertion order is preserved by strings[]; the open-addressed hash table maps
+// string -> existing index. Empty slots are marked by hashes[slot] == 0; a real
+// hash of 0 is folded to 1 (probability 2^-64).
 type stringTable struct {
-	strings   []stringValue    // list of strings
-	indices   map[string]index // map strings to their indices
-	nextIndex index            // last index of the stringTable
+	strings   []stringValue // ordered list; strings[0] == ""; index = position
+	nextIndex index         // == len(strings)
+
+	hashes []uint64 // maphash.String of strings[slots[i]]; 0 means empty slot
+	slots  []index  // strings[] index occupying this slot
+	mask   uint64   // cap-1
+	used   int      // occupied slots; grow when used*2 >= cap
+	seed   maphash.Seed
 }
+
+const stringTableInitCap = 64 // power of two; load factor 0.5 → first grow at 32 entries
 
 func newStringTable() *stringTable {
 	st := &stringTable{
-		strings:   make([]stringValue, 1, 64),
-		indices:   make(map[string]index, 64),
+		strings:   make([]stringValue, 1, stringTableInitCap),
 		nextIndex: 1,
+		hashes:    make([]uint64, stringTableInitCap),
+		slots:     make([]index, stringTableInitCap),
+		mask:      stringTableInitCap - 1,
+		seed:      maphash.MakeSeed(),
 	}
 	st.strings[0] = ""
-	st.indices[""] = 0
 	return st
 }
 
 func (st *stringTable) reset() {
-	clear(st.indices)
-	st.indices[""] = 0
+	clear(st.hashes)
+	st.used = 0
 	st.strings = st.strings[:1]
 	st.strings[0] = ""
 	st.nextIndex = 1
@@ -1207,16 +1221,54 @@ func (st *stringTable) serialize(value string, buf []byte) []byte {
 	if value == "" {
 		return msgp.AppendUint32(buf, 0)
 	}
-	if idx, ok := st.indices[value]; ok {
-		return idx.encode(buf)
+	h := maphash.String(st.seed, value)
+	if h == 0 {
+		h = 1
 	}
-	sv := stringValue(value)
-	buf = sv.encode(buf)
-	st.indices[value] = st.nextIndex
-	st.strings = append(st.strings, sv)
-	st.nextIndex++
-	return buf
+	slot := h & st.mask
+	for {
+		sh := st.hashes[slot]
+		if sh == 0 {
+			sv := stringValue(value)
+			buf = sv.encode(buf)
+			idx := st.nextIndex
+			st.strings = append(st.strings, sv)
+			st.hashes[slot] = h
+			st.slots[slot] = idx
+			st.nextIndex++
+			st.used++
+			if st.used*2 >= len(st.hashes) {
+				st.grow()
+			}
+			return buf
+		}
+		if sh == h && string(st.strings[st.slots[slot]]) == value {
+			return st.slots[slot].encode(buf)
+		}
+		slot = (slot + 1) & st.mask
+	}
+}
 
+// grow doubles the hash table capacity and rehashes all existing entries.
+func (st *stringTable) grow() {
+	newCap := len(st.hashes) * 2
+	newHashes := make([]uint64, newCap)
+	newSlots := make([]index, newCap)
+	newMask := uint64(newCap - 1)
+	for i, h := range st.hashes {
+		if h == 0 {
+			continue
+		}
+		slot := h & newMask
+		for newHashes[slot] != 0 {
+			slot = (slot + 1) & newMask
+		}
+		newHashes[slot] = h
+		newSlots[slot] = st.slots[i]
+	}
+	st.hashes = newHashes
+	st.slots = newSlots
+	st.mask = newMask
 }
 
 // Reads a string from a byte slice and returns it from the string table if it exists.


### PR DESCRIPTION
### What does this PR do?

Replaces the `map[string]index` in `payloadV1.stringTable` with an open-addressed flat hash table keyed by `hash/maphash.String`. Lookup and insert on the v1 encode hot path now run without per-call map probing or bucket allocation.

- Parallel arrays `hashes []uint64` + `slots []index`, power-of-two capacity, linear probe, load factor 0.5.
- `maphash.String(seed, value)` for hashing — stateless, no allocs, runtime-quality distribution. Seeded per-table; per-process random seed produces non-deterministic hash values but the wire format depends on insertion order (preserved by `strings[]`), so output stays byte-identical across runs.
- `grow()` doubles capacity and rehashes; starts at 64 slots, scales to 100k+ unique strings per payload (large-org case).
- Empty slots marked by `hashes[slot] == 0`; a real hash of 0 is folded to 1 (probability 2^-64).
- `reset()` zeroes `hashes` via `clear()` (lowers to `memclrNoHeapPointers`); `slots` does not need clearing.

### Motivation

Profiling `BenchmarkPayloads/v1.0/push/1000_detailed_spans` attributed ~14% cum to `(*stringTable).serialize`. Cost was dominated by `map[string]index` lookup (hash + bucket walk + tophash compare + key compare) plus allocations on growth.

`benchstat` on `BenchmarkPayloads` (Apple M1 Max, `count=8`, `benchtime=3s`):

| workload (v1.0/push)            | sec/op       | p     |
|---------------------------------|--------------|-------|
| 10spans                         | **-8.32%**   | 0.000 |
| 1000spans                       | **-8.07%**   | 0.002 |
| 10_detailed_spans               | **-8.42%**   | 0.000 |
| 1000_detailed_spans             | **-6.39%**   | 0.000 |
| low_cardinality_spans           | **-10.02%**  | 0.000 |
| high_cardinality_spans          | **-9.12%**   | 0.000 |

v0.4 rows unchanged (they do not touch `stringTable`). `allocs/op` unchanged on every row. `B/op` slightly higher on two v1.0 rows (`10spans` +462 B, `low_cardinality_spans` +62 KB) due to `grow()` intermediates trading memory for time; total working set at N=100k is still ~3 MB vs Go map ~6 MB.

`TestPayloadIntegrity` and `TestPayloadVersions` verify wire-format identity. Full `./ddtrace/tracer/...` suite passes.

Item #10 from the v1 encoder performance backlog. Parent-track — no dependency on the encoder fast-path bundle.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [x] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running \`make lint\` locally.
- [x] New code doesn't break existing tests. You can check this by running \`make test\` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running \`make generate\` locally.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running \`make fix-modules\` locally.

Unsure? Have a question? Request a review!