### PR TITLE
feat(aap): collect security testing headers

### DIFF
--- a/contrib/gofiber/fiber.v2/fiber.go
+++ b/contrib/gofiber/fiber.v2/fiber.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/instrumentation"
+	appsechttpsec "github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/httpsec"
 
 	"github.com/gofiber/fiber/v2"
 )
@@ -67,6 +68,7 @@ func Middleware(opts ...Option) func(c *fiber.Ctx) error {
 			}
 			opts = append(opts, tracer.ChildOf(spanctx))
 		}
+		opts = append(opts, appsechttpsec.SecurityTestingHeaderTagsOption(h))
 		opts = append(opts, cfg.spanOpts...)
 		opts = append(opts,
 			tracer.Tag(ext.Component, componentName),

--- a/contrib/gofiber/fiber.v2/fiber.go
+++ b/contrib/gofiber/fiber.v2/fiber.go
@@ -68,7 +68,7 @@ func Middleware(opts ...Option) func(c *fiber.Ctx) error {
 			}
 			opts = append(opts, tracer.ChildOf(spanctx))
 		}
-		opts = append(opts, appsechttpsec.SecurityTestingHeaderTagsOption(h))
+		opts = appsechttpsec.AppendSecurityTestingHeaderTags(opts, h)
 		opts = append(opts, cfg.spanOpts...)
 		opts = append(opts,
 			tracer.Tag(ext.Component, componentName),

--- a/contrib/gofiber/fiber.v2/fiber_test.go
+++ b/contrib/gofiber/fiber.v2/fiber_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestChildSpan(t *testing.T) {
@@ -353,4 +354,32 @@ func TestIgnoreRequest(t *testing.T) {
 	spans := mt.FinishedSpans()
 
 	assert.Len(spans, 0)
+}
+
+func TestSecurityTestingHeaders(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	router := fiber.New()
+	router.Use(Middleware(WithService("foobar")))
+	router.Get("/test", func(c *fiber.Ctx) error {
+		return c.SendString("ok")
+	})
+
+	r := httptest.NewRequest("GET", "/test", nil)
+	r.Header.Set("x-datadog-endpoint-scan", "true")
+	r.Header.Set("x-datadog-security-test", "test-value")
+
+	resp, err := router.Test(r)
+	assert.Equal(nil, err)
+	defer resp.Body.Close()
+	assert.Equal(resp.StatusCode, 200)
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+
+	span := spans[0]
+	assert.Equal("true", span.Tag(ext.HTTPRequestHeaders+".x-datadog-endpoint-scan"))
+	assert.Equal("test-value", span.Tag(ext.HTTPRequestHeaders+".x-datadog-security-test"))
 }

--- a/contrib/twitchtv/twirp/twirp.go
+++ b/contrib/twitchtv/twirp/twirp.go
@@ -149,7 +149,7 @@ func WrapServer(h http.Handler, opts ...Option) http.Handler {
 			}
 			spanOpts = append(spanOpts, tracer.ChildOf(spanctx))
 		}
-		spanOpts = append(spanOpts, appsechttpsec.SecurityTestingHeaderTagsOption(r.Header))
+		spanOpts = appsechttpsec.AppendSecurityTestingHeaderTags(spanOpts, r.Header)
 		span, ctx := tracer.StartSpanFromContext(r.Context(), "twirp.handler", spanOpts...)
 		defer span.Finish()
 

--- a/contrib/twitchtv/twirp/twirp.go
+++ b/contrib/twitchtv/twirp/twirp.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/instrumentation"
+	appsechttpsec "github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/httpsec"
 
 	"github.com/twitchtv/twirp"
 )
@@ -148,6 +149,7 @@ func WrapServer(h http.Handler, opts ...Option) http.Handler {
 			}
 			spanOpts = append(spanOpts, tracer.ChildOf(spanctx))
 		}
+		spanOpts = append(spanOpts, appsechttpsec.SecurityTestingHeaderTagsOption(r.Header))
 		span, ctx := tracer.StartSpanFromContext(r.Context(), "twirp.handler", spanOpts...)
 		defer span.Finish()
 

--- a/contrib/twitchtv/twirp/twirp_test.go
+++ b/contrib/twitchtv/twirp/twirp_test.go
@@ -432,3 +432,50 @@ func startIntegrationTestServer(t *testing.T, opts ...Option) (example.Haberdash
 		assert.NoError(t, l.Close())
 	}
 }
+
+func TestWrapServerSecurityTestingHeaders(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	l, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l.Close()
+
+	readyCh := make(chan struct{})
+	nl := &notifyListener{Listener: l, ch: readyCh}
+
+	server := WrapServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	errCh := make(chan error)
+	go func() {
+		err := http.Serve(nl, server)
+		if err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+		close(errCh)
+	}()
+	select {
+	case <-readyCh:
+		break
+	case err := <-errCh:
+		assert.FailNow(t, "server not started", err)
+	}
+
+	req, err := http.NewRequest("GET", "http://"+nl.Addr().String()+"/test", nil)
+	require.NoError(t, err)
+	req.Header.Set("x-datadog-endpoint-scan", "true")
+	req.Header.Set("x-datadog-security-test", "test-value")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+
+	span := spans[0]
+	assert.Equal(t, "true", span.Tag(ext.HTTPRequestHeaders+".x-datadog-endpoint-scan"))
+	assert.Equal(t, "test-value", span.Tag(ext.HTTPRequestHeaders+".x-datadog-security-test"))
+}

--- a/contrib/valyala/fasthttp/fasthttp.go
+++ b/contrib/valyala/fasthttp/fasthttp.go
@@ -86,6 +86,6 @@ func defaultSpanOptions(fctx *fasthttp.RequestCtx) []tracer.StartSpanOption {
 	if host := string(fctx.Host()); len(host) > 0 {
 		opts = append(opts, tracer.Tag("http.host", host))
 	}
-	opts = append(opts, appsechttpsec.SecurityTestingHeaderTagsFromBytesOption(fctx.Request.Header.PeekAll))
+	opts = appsechttpsec.AppendSecurityTestingHeaderTagsFromBytes(opts, fctx.Request.Header.PeekAll)
 	return opts
 }

--- a/contrib/valyala/fasthttp/fasthttp.go
+++ b/contrib/valyala/fasthttp/fasthttp.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/instrumentation"
+	appsechttpsec "github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/httpsec"
 )
 
 var instr *instrumentation.Instrumentation
@@ -85,5 +86,6 @@ func defaultSpanOptions(fctx *fasthttp.RequestCtx) []tracer.StartSpanOption {
 	if host := string(fctx.Host()); len(host) > 0 {
 		opts = append(opts, tracer.Tag("http.host", host))
 	}
+	opts = append(opts, appsechttpsec.SecurityTestingHeaderTagsFromBytesOption(fctx.Request.Header.PeekAll))
 	return opts
 }

--- a/contrib/valyala/fasthttp/fasthttp.go
+++ b/contrib/valyala/fasthttp/fasthttp.go
@@ -86,6 +86,6 @@ func defaultSpanOptions(fctx *fasthttp.RequestCtx) []tracer.StartSpanOption {
 	if host := string(fctx.Host()); len(host) > 0 {
 		opts = append(opts, tracer.Tag("http.host", host))
 	}
-	opts = appsechttpsec.AppendSecurityTestingHeaderTagsFromBytes(opts, fctx.Request.Header.PeekAll)
+	opts = appsechttpsec.AppendSecurityTestingHeaderTagsFromBytes(opts, fctx.Request.Header.VisitAll)
 	return opts
 }

--- a/contrib/valyala/fasthttp/fasthttp_test.go
+++ b/contrib/valyala/fasthttp/fasthttp_test.go
@@ -32,6 +32,10 @@ func ignoreResources(fctx *fasthttp.RequestCtx) bool {
 }
 
 func startServer(t *testing.T, opts ...Option) string {
+	return startServerWithConfig(t, nil, opts...)
+}
+
+func startServerWithConfig(t *testing.T, configure func(*fasthttp.Server), opts ...Option) string {
 	router := WrapHandler(func(fctx *fasthttp.RequestCtx) {
 		switch string(fctx.Path()) {
 		case "/any":
@@ -63,6 +67,9 @@ func startServer(t *testing.T, opts ...Option) string {
 	addr := ln.Addr()
 	server := &fasthttp.Server{
 		Handler: router,
+	}
+	if configure != nil {
+		configure(server)
 	}
 	go func() {
 		require.NoError(t, server.Serve(ln))
@@ -275,6 +282,32 @@ func TestSecurityTestingHeaders(t *testing.T) {
 	require.NoError(t, err)
 	req.Header.Set("x-datadog-endpoint-scan", "true")
 	req.Header.Set("x-datadog-security-test", "test-value")
+
+	resp, err := (&http.Client{}).Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+
+	span := spans[0]
+	assert.Equal("true", span.Tag(ext.HTTPRequestHeaders+".x-datadog-endpoint-scan"))
+	assert.Equal("test-value", span.Tag(ext.HTTPRequestHeaders+".x-datadog-security-test"))
+}
+
+func TestSecurityTestingHeadersWithDisabledHeaderNamesNormalizing(t *testing.T) {
+	assert := assert.New(t)
+	addr := startServerWithConfig(t, func(server *fasthttp.Server) {
+		server.DisableHeaderNamesNormalizing = true
+	})
+
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	req, err := http.NewRequest("GET", addr+"/any", nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Datadog-Endpoint-Scan", "true")
+	req.Header.Set("X-Datadog-Security-Test", "test-value")
 
 	resp, err := (&http.Client{}).Do(req)
 	require.NoError(t, err)

--- a/contrib/valyala/fasthttp/fasthttp_test.go
+++ b/contrib/valyala/fasthttp/fasthttp_test.go
@@ -263,3 +263,27 @@ func TestPropagation(t *testing.T) {
 	two := spans[1]
 	assert.Equal(one.TraceID(), two.TraceID())
 }
+
+func TestSecurityTestingHeaders(t *testing.T) {
+	assert := assert.New(t)
+	addr := startServer(t)
+
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	req, err := http.NewRequest("GET", addr+"/any", nil)
+	require.NoError(t, err)
+	req.Header.Set("x-datadog-endpoint-scan", "true")
+	req.Header.Set("x-datadog-security-test", "test-value")
+
+	resp, err := (&http.Client{}).Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+
+	span := spans[0]
+	assert.Equal("true", span.Tag(ext.HTTPRequestHeaders+".x-datadog-endpoint-scan"))
+	assert.Equal("test-value", span.Tag(ext.HTTPRequestHeaders+".x-datadog-security-test"))
+}

--- a/instrumentation/appsec/httpsec/span.go
+++ b/instrumentation/appsec/httpsec/span.go
@@ -12,22 +12,29 @@ import (
 	listenerhttpsec "github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/httpsec"
 )
 
-// SecurityTestingHeaderTagsOption tags security-testing headers from the request.
-func SecurityTestingHeaderTagsOption(headers http.Header) tracer.StartSpanOption {
-	return func(cfg *tracer.StartSpanConfig) {
-		if cfg.Tags == nil {
-			cfg.Tags = make(map[string]any)
-		}
-		listenerhttpsec.SetSecurityTestingHeaderTags(cfg.Tags, headers)
+// SetSecurityTestingHeaderTags tags security-testing headers from the request.
+func SetSecurityTestingHeaderTags(tags map[string]any, headers http.Header) {
+	tagNames, tagValues, count := listenerhttpsec.SecurityTestingHeaderTagValues(headers)
+	for i := range count {
+		tags[tagNames[i]] = tagValues[i]
 	}
 }
 
-// SecurityTestingHeaderTagsFromBytesOption tags security-testing headers from byte lookup results.
-func SecurityTestingHeaderTagsFromBytesOption(values func(string) [][]byte) tracer.StartSpanOption {
-	return func(cfg *tracer.StartSpanConfig) {
-		if cfg.Tags == nil {
-			cfg.Tags = make(map[string]any)
-		}
-		listenerhttpsec.SetSecurityTestingHeaderTagsFromBytes(cfg.Tags, values)
+// AppendSecurityTestingHeaderTags appends tag options for present security-testing headers.
+func AppendSecurityTestingHeaderTags(opts []tracer.StartSpanOption, headers http.Header) []tracer.StartSpanOption {
+	tagNames, tagValues, count := listenerhttpsec.SecurityTestingHeaderTagValues(headers)
+	return appendSecurityTestingHeaderTags(opts, tagNames, tagValues, count)
+}
+
+// AppendSecurityTestingHeaderTagsFromBytes appends tag options for present byte header lookups.
+func AppendSecurityTestingHeaderTagsFromBytes(opts []tracer.StartSpanOption, values func(string) [][]byte) []tracer.StartSpanOption {
+	tagNames, tagValues, count := listenerhttpsec.SecurityTestingHeaderByteTagValues(values)
+	return appendSecurityTestingHeaderTags(opts, tagNames, tagValues, count)
+}
+
+func appendSecurityTestingHeaderTags(opts []tracer.StartSpanOption, tagNames, tagValues [2]string, count int) []tracer.StartSpanOption {
+	for i := range count {
+		opts = append(opts, tracer.Tag(tagNames[i], tagValues[i]))
 	}
+	return opts
 }

--- a/instrumentation/appsec/httpsec/span.go
+++ b/instrumentation/appsec/httpsec/span.go
@@ -26,9 +26,9 @@ func AppendSecurityTestingHeaderTags(opts []tracer.StartSpanOption, headers http
 	return appendSecurityTestingHeaderTags(opts, tagNames, tagValues, count)
 }
 
-// AppendSecurityTestingHeaderTagsFromBytes appends tag options for present byte header lookups.
-func AppendSecurityTestingHeaderTagsFromBytes(opts []tracer.StartSpanOption, values func(string) [][]byte) []tracer.StartSpanOption {
-	tagNames, tagValues, count := listenerhttpsec.SecurityTestingHeaderByteTagValues(values)
+// AppendSecurityTestingHeaderTagsFromBytes appends tag options for present byte header entries.
+func AppendSecurityTestingHeaderTagsFromBytes(opts []tracer.StartSpanOption, visit func(func(key, value []byte))) []tracer.StartSpanOption {
+	tagNames, tagValues, count := listenerhttpsec.SecurityTestingHeaderByteTagValues(visit)
 	return appendSecurityTestingHeaderTags(opts, tagNames, tagValues, count)
 }
 

--- a/instrumentation/appsec/httpsec/span.go
+++ b/instrumentation/appsec/httpsec/span.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package httpsec
+
+import (
+	"net/http"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	listenerhttpsec "github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/httpsec"
+)
+
+// SecurityTestingHeaderTagsOption tags security-testing headers from the request.
+func SecurityTestingHeaderTagsOption(headers http.Header) tracer.StartSpanOption {
+	return func(cfg *tracer.StartSpanConfig) {
+		if cfg.Tags == nil {
+			cfg.Tags = make(map[string]any)
+		}
+		listenerhttpsec.SetSecurityTestingHeaderTags(cfg.Tags, headers)
+	}
+}
+
+// SecurityTestingHeaderTagsFromBytesOption tags security-testing headers from byte lookup results.
+func SecurityTestingHeaderTagsFromBytesOption(values func(string) [][]byte) tracer.StartSpanOption {
+	return func(cfg *tracer.StartSpanConfig) {
+		if cfg.Tags == nil {
+			cfg.Tags = make(map[string]any)
+		}
+		listenerhttpsec.SetSecurityTestingHeaderTagsFromBytes(cfg.Tags, values)
+	}
+}

--- a/instrumentation/httptrace/httptrace.go
+++ b/instrumentation/httptrace/httptrace.go
@@ -110,6 +110,7 @@ func StartRequestSpan(r *http.Request, opts ...tracer.StartSpanOption) (*tracer.
 			if r.Host != "" {
 				ssCfg.Tags["http.host"] = r.Host
 			}
+			httpsec.SetSecurityTestingHeaderTags(ssCfg.Tags, r.Header)
 
 			if inferredProxySpan != nil {
 				tracer.ChildOf(inferredProxySpan.Context())(ssCfg)

--- a/instrumentation/httptrace/httptrace.go
+++ b/instrumentation/httptrace/httptrace.go
@@ -97,7 +97,7 @@ func StartRequestSpan(r *http.Request, opts ...tracer.StartSpanOption) (*tracer.
 		r = r.WithContext(ctx2)
 	}
 
-	nopts := make([]tracer.StartSpanOption, 0, len(opts)+2+len(ipTags))
+	nopts := make([]tracer.StartSpanOption, 0, len(opts)+1+len(ipTags))
 	nopts = append(nopts,
 		func(ssCfg *tracer.StartSpanConfig) {
 			if ssCfg.Tags == nil {
@@ -111,6 +111,7 @@ func StartRequestSpan(r *http.Request, opts ...tracer.StartSpanOption) (*tracer.
 			if r.Host != "" {
 				ssCfg.Tags["http.host"] = r.Host
 			}
+			appsechttpsec.SetSecurityTestingHeaderTags(ssCfg.Tags, r.Header)
 
 			if inferredProxySpan != nil {
 				tracer.ChildOf(inferredProxySpan.Context())(ssCfg)
@@ -132,7 +133,6 @@ func StartRequestSpan(r *http.Request, opts ...tracer.StartSpanOption) (*tracer.
 				ssCfg.Tags[k] = v
 			}
 		})
-	nopts = append(nopts, appsechttpsec.SecurityTestingHeaderTagsOption(r.Header))
 	nopts = append(nopts, opts...)
 
 	requestContext := r.Context()

--- a/instrumentation/httptrace/httptrace.go
+++ b/instrumentation/httptrace/httptrace.go
@@ -19,7 +19,8 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/instrumentation"
-	"github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/httpsec"
+	appsechttpsec "github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/httpsec"
+	listenerhttpsec "github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/httpsec"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 )
@@ -55,7 +56,7 @@ func StartRequestSpan(r *http.Request, opts ...tracer.StartSpanOption) (*tracer.
 
 	var ipTags map[string]string
 	if cfg.traceClientIP {
-		ipTags, _ = httpsec.ClientIPTags(r.Header, true, r.RemoteAddr)
+		ipTags, _ = listenerhttpsec.ClientIPTags(r.Header, true, r.RemoteAddr)
 	}
 
 	var inferredProxySpan *tracer.Span
@@ -96,7 +97,7 @@ func StartRequestSpan(r *http.Request, opts ...tracer.StartSpanOption) (*tracer.
 		r = r.WithContext(ctx2)
 	}
 
-	nopts := make([]tracer.StartSpanOption, 0, len(opts)+1+len(ipTags))
+	nopts := make([]tracer.StartSpanOption, 0, len(opts)+2+len(ipTags))
 	nopts = append(nopts,
 		func(ssCfg *tracer.StartSpanConfig) {
 			if ssCfg.Tags == nil {
@@ -110,7 +111,6 @@ func StartRequestSpan(r *http.Request, opts ...tracer.StartSpanOption) (*tracer.
 			if r.Host != "" {
 				ssCfg.Tags["http.host"] = r.Host
 			}
-			httpsec.SetSecurityTestingHeaderTags(ssCfg.Tags, r.Header)
 
 			if inferredProxySpan != nil {
 				tracer.ChildOf(inferredProxySpan.Context())(ssCfg)
@@ -132,6 +132,7 @@ func StartRequestSpan(r *http.Request, opts ...tracer.StartSpanOption) (*tracer.
 				ssCfg.Tags[k] = v
 			}
 		})
+	nopts = append(nopts, appsechttpsec.SecurityTestingHeaderTagsOption(r.Header))
 	nopts = append(nopts, opts...)
 
 	requestContext := r.Context()

--- a/instrumentation/httptrace/httptrace_test.go
+++ b/instrumentation/httptrace/httptrace_test.go
@@ -8,6 +8,7 @@ package httptrace
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
@@ -29,6 +30,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var securityTestingHeaders = [...]struct {
+	header string
+	tag    string
+}{
+	{header: "x-datadog-endpoint-scan", tag: ext.HTTPRequestHeaders + ".x-datadog-endpoint-scan"},
+	{header: "x-datadog-security-test", tag: ext.HTTPRequestHeaders + ".x-datadog-security-test"},
+}
 
 func TestGetErrorCodesFromInput(t *testing.T) {
 	codesOnly := "400,401,402"
@@ -164,6 +173,116 @@ func TestHeaderTagsFromRequest(t *testing.T) {
 	for expectedTag, expectedTagVal := range expectedHeaderTags {
 		assert.Equal(t, expectedTagVal, spans[0].Tags()[expectedTag])
 	}
+}
+
+func TestStartRequestSpanSecurityTestingHeaders(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		headers  http.Header
+		expected map[string]string
+	}{
+		{
+			name: "present",
+			headers: http.Header{
+				"x-datadog-endpoint-scan": {"scan-uuid"},
+				"X-Datadog-Security-Test": {" test-uuid "},
+			},
+			expected: map[string]string{
+				"http.request.headers.x-datadog-endpoint-scan": "scan-uuid",
+				"http.request.headers.x-datadog-security-test": "test-uuid",
+			},
+		},
+		{
+			name: "empty-values",
+			headers: http.Header{
+				"X-Datadog-Endpoint-Scan": {""},
+				"X-Datadog-Security-Test": {""},
+			},
+			expected: map[string]string{
+				"http.request.headers.x-datadog-endpoint-scan": "",
+				"http.request.headers.x-datadog-security-test": "",
+			},
+		},
+		{
+			name:     "missing",
+			headers:  http.Header{},
+			expected: map[string]string{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mt := mocktracer.Start()
+			defer mt.Stop()
+
+			r := httptest.NewRequest(http.MethodGet, "/test", nil)
+			maps.Copy(r.Header, tc.headers)
+			span, _, _ := StartRequestSpan(r)
+			span.Finish()
+
+			spans := mt.FinishedSpans()
+			require.Len(t, spans, 1)
+			tags := spans[0].Tags()
+
+			for _, h := range securityTestingHeaders {
+				value, ok := tc.expected[h.tag]
+				if !ok {
+					assert.NotContains(t, tags, h.tag)
+					continue
+				}
+				assert.Contains(t, tags, h.tag)
+				assert.Equal(t, value, tags[h.tag])
+			}
+		})
+	}
+}
+
+func TestStartRequestSpanSecurityTestingHeadersNotPropagated(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	r := httptest.NewRequest(http.MethodGet, "/test", nil)
+	r.Header.Set("X-Datadog-Endpoint-Scan", "scan-uuid")
+	r.Header.Set("X-Datadog-Security-Test", "test-uuid")
+	span, _, _ := StartRequestSpan(r)
+	outgoing := http.Header{}
+	require.NoError(t, tracer.Inject(span.Context(), tracer.HTTPHeadersCarrier(outgoing)))
+	span.Finish()
+
+	for _, h := range securityTestingHeaders {
+		_, ok := outgoing[http.CanonicalHeaderKey(h.header)]
+		assert.False(t, ok)
+	}
+}
+
+func TestBeforeHandleSecurityTestingHeadersWithAppSec(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skipf("cgo disabled / no appsec tag")
+	}
+
+	oldCfg := cfg
+	defer func() { cfg = oldCfg }()
+
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	t.Setenv("DD_APPSEC_ENABLED", "true")
+	appsec.Start()
+	defer appsec.Stop()
+	ResetCfg()
+
+	r := httptest.NewRequest(http.MethodGet, "https://example.com/test", nil)
+	r.Header.Set("X-Datadog-Endpoint-Scan", "scan-uuid")
+	r.Header.Set("X-Datadog-Security-Test", " test-uuid ")
+	w := httptest.NewRecorder()
+
+	rw, rt, after, handled := BeforeHandle(&ServeConfig{Route: "/test"}, w, r)
+	assert.False(t, handled)
+	http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }).ServeHTTP(rw, rt)
+	after()
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "scan-uuid", spans[0].Tag(securityTestingHeaders[0].tag))
+	assert.Equal(t, "test-uuid", spans[0].Tag(securityTestingHeaders[1].tag))
 }
 
 func TestStartRequestSpan(t *testing.T) {

--- a/internal/appsec/listener/httpsec/request.go
+++ b/internal/appsec/listener/httpsec/request.go
@@ -160,11 +160,11 @@ func SecurityTestingHeaderTagValues(headers http.Header) ([2]string, [2]string, 
 
 // SecurityTestingHeaderByteTagValues returns span tag names and values from byte header entries.
 func SecurityTestingHeaderByteTagValues(visit func(func(key, value []byte))) ([2]string, [2]string, int) {
-	var headerValues [len(securityTestingHeaders)][][]byte
+	var headerValues [len(securityTestingHeaders)][]string
 	visit(func(key, value []byte) {
 		for i, h := range securityTestingHeaders {
 			if bytes.EqualFold(key, h.HeaderBytes) {
-				headerValues[i] = append(headerValues[i], value)
+				headerValues[i] = append(headerValues[i], string(value))
 				break
 			}
 		}
@@ -179,7 +179,7 @@ func SecurityTestingHeaderByteTagValues(visit func(func(key, value []byte))) ([2
 			continue
 		}
 		tagNames[count] = h.Tag
-		tagValues[count] = strings.TrimSpace(normalizeHTTPHeaderBytesValue(values))
+		tagValues[count] = strings.TrimSpace(normalizeHTTPHeaderValue(values))
 		count++
 	}
 	return tagNames, tagValues, count
@@ -222,28 +222,6 @@ func normalizeHTTPHeaderName(name string) string {
 
 func normalizeHTTPHeaderValue(values []string) string {
 	return strings.Join(values, ",")
-}
-
-func normalizeHTTPHeaderBytesValue(values [][]byte) string {
-	if len(values) == 1 {
-		return string(values[0])
-	}
-
-	var length int
-	for _, value := range values {
-		length += len(value)
-	}
-	length += len(values) - 1
-
-	var b strings.Builder
-	b.Grow(length)
-	for i, value := range values {
-		if i > 0 {
-			b.WriteByte(',')
-		}
-		b.Write(value)
-	}
-	return b.String()
 }
 
 func init() {

--- a/internal/appsec/listener/httpsec/request.go
+++ b/internal/appsec/listener/httpsec/request.go
@@ -18,6 +18,14 @@ import (
 const (
 	// envClientIPHeader is the name of the env var used to specify the IP header to be used for client IP collection.
 	envClientIPHeader = "DD_TRACE_CLIENT_IP_HEADER"
+
+	// Headers used to identify Datadog security testing requests.
+	securityTestingEndpointScanHeader = "x-datadog-endpoint-scan"
+	securityTestingHeader             = "x-datadog-security-test"
+
+	// Span tags for the corresponding security testing request headers.
+	securityTestingEndpointScanTag = ext.HTTPRequestHeaders + "." + securityTestingEndpointScanHeader
+	securityTestingTag             = ext.HTTPRequestHeaders + "." + securityTestingHeader
 )
 
 var (
@@ -62,6 +70,17 @@ var (
 		"x-sigsci-tags",
 	}, defaultIPHeaders...)
 
+	// securityTestingHeaders maps security testing headers to service-entry span tags.
+	// These headers are tracked separately from defaultCollectedHeaders because
+	// they are tagged on HTTP service-entry spans even when AppSec is disabled.
+	securityTestingHeaders = [...]struct {
+		Header string
+		Tag    string
+	}{
+		{Header: securityTestingEndpointScanHeader, Tag: securityTestingEndpointScanTag},
+		{Header: securityTestingHeader, Tag: securityTestingTag},
+	}
+
 	// collectedHeadersLookupMap is a helper lookup map of HTTP headers to
 	// collect as request span tags when appsec is enabled. It is computed at
 	// init-time based on defaultCollectedHeaders and leveraged by NormalizeHTTPHeaders.
@@ -72,24 +91,6 @@ var (
 	// time in function of the value of the envClientIPHeader environment variable.
 	monitoredClientIPHeadersCfg []string
 )
-
-const (
-	securityTestingEndpointScanHeader = "x-datadog-endpoint-scan"
-	securityTestingHeader             = "x-datadog-security-test"
-
-	securityTestingEndpointScanTag = ext.HTTPRequestHeaders + "." + securityTestingEndpointScanHeader
-	securityTestingTag             = ext.HTTPRequestHeaders + "." + securityTestingHeader
-)
-
-type securityTestingHeaderTag struct {
-	Header string
-	Tag    string
-}
-
-var securityTestingHeaders = [...]securityTestingHeaderTag{
-	{Header: securityTestingEndpointScanHeader, Tag: securityTestingEndpointScanTag},
-	{Header: securityTestingHeader, Tag: securityTestingTag},
-}
 
 // ClientIPTags returns the resulting Datadog span tags `http.client_ip`
 // containing the client IP and `network.client.ip` containing the remote IP.
@@ -138,7 +139,7 @@ func NormalizeHTTPHeaders(headers map[string][]string) (normalized map[string]st
 	return normalized
 }
 
-// SetSecurityTestingHeaderTags sets RFC-1105 security testing header tags on tags.
+// SetSecurityTestingHeaderTags sets security testing header tags on tags.
 func SetSecurityTestingHeaderTags(tags map[string]any, headers http.Header) {
 	for _, h := range securityTestingHeaders {
 		values, ok := securityTestingHeaderValues(headers, h.Header)

--- a/internal/appsec/listener/httpsec/request.go
+++ b/internal/appsec/listener/httpsec/request.go
@@ -71,8 +71,8 @@ var (
 	}, defaultIPHeaders...)
 
 	// securityTestingHeaders maps security testing headers to service-entry span tags.
-	// These headers are tracked separately from defaultCollectedHeaders because
-	// they are tagged on HTTP service-entry spans even when AppSec is disabled.
+	// These headers are tagged separately from defaultCollectedHeaders because
+	// they are collected even when AppSec is disabled.
 	securityTestingHeaders = [...]struct {
 		Header string
 		Tag    string
@@ -139,26 +139,38 @@ func NormalizeHTTPHeaders(headers map[string][]string) (normalized map[string]st
 	return normalized
 }
 
-// SetSecurityTestingHeaderTags sets security testing header tags on tags.
-func SetSecurityTestingHeaderTags(tags map[string]any, headers http.Header) {
+// SecurityTestingHeaderTagValues returns span tag names and values from security testing headers.
+func SecurityTestingHeaderTagValues(headers http.Header) ([2]string, [2]string, int) {
+	var tagNames [2]string
+	var tagValues [2]string
+	var count int
 	for _, h := range securityTestingHeaders {
 		values, ok := securityTestingHeaderValues(headers, h.Header)
 		if !ok {
 			continue
 		}
-		tags[h.Tag] = strings.TrimSpace(normalizeHTTPHeaderValue(values))
+		tagNames[count] = h.Tag
+		tagValues[count] = strings.TrimSpace(normalizeHTTPHeaderValue(values))
+		count++
 	}
+	return tagNames, tagValues, count
 }
 
-// SetSecurityTestingHeaderTagsFromBytes sets security testing header tags from byte values.
-func SetSecurityTestingHeaderTagsFromBytes(tags map[string]any, values func(string) [][]byte) {
+// SecurityTestingHeaderByteTagValues returns span tag names and values from byte header lookups.
+func SecurityTestingHeaderByteTagValues(values func(string) [][]byte) ([2]string, [2]string, int) {
+	var tagNames [2]string
+	var tagValues [2]string
+	var count int
 	for _, h := range securityTestingHeaders {
 		headerValues := values(h.Header)
 		if len(headerValues) == 0 {
 			continue
 		}
-		tags[h.Tag] = strings.TrimSpace(normalizeHTTPHeaderBytesValue(headerValues))
+		tagNames[count] = h.Tag
+		tagValues[count] = strings.TrimSpace(normalizeHTTPHeaderBytesValue(headerValues))
+		count++
 	}
+	return tagNames, tagValues, count
 }
 
 func securityTestingHeaderValues(headers http.Header, header string) ([]string, bool) {

--- a/internal/appsec/listener/httpsec/request.go
+++ b/internal/appsec/listener/httpsec/request.go
@@ -73,6 +73,24 @@ var (
 	monitoredClientIPHeadersCfg []string
 )
 
+const (
+	securityTestingEndpointScanHeader = "x-datadog-endpoint-scan"
+	securityTestingHeader             = "x-datadog-security-test"
+
+	securityTestingEndpointScanTag = ext.HTTPRequestHeaders + "." + securityTestingEndpointScanHeader
+	securityTestingTag             = ext.HTTPRequestHeaders + "." + securityTestingHeader
+)
+
+type securityTestingHeaderTag struct {
+	Header string
+	Tag    string
+}
+
+var securityTestingHeaders = [...]securityTestingHeaderTag{
+	{Header: securityTestingEndpointScanHeader, Tag: securityTestingEndpointScanTag},
+	{Header: securityTestingHeader, Tag: securityTestingTag},
+}
+
 // ClientIPTags returns the resulting Datadog span tags `http.client_ip`
 // containing the client IP and `network.client.ip` containing the remote IP.
 // The tags are present only if a valid ip address has been returned by
@@ -118,6 +136,26 @@ func NormalizeHTTPHeaders(headers map[string][]string) (normalized map[string]st
 		return nil
 	}
 	return normalized
+}
+
+// SetSecurityTestingHeaderTags sets RFC-1105 security testing header tags on tags.
+func SetSecurityTestingHeaderTags(tags map[string]any, headers http.Header) {
+	for _, h := range securityTestingHeaders {
+		values, ok := securityTestingHeaderValues(headers, h.Header)
+		if !ok {
+			continue
+		}
+		tags[h.Tag] = strings.TrimSpace(normalizeHTTPHeaderValue(values))
+	}
+}
+
+func securityTestingHeaderValues(headers http.Header, header string) ([]string, bool) {
+	for name, values := range headers {
+		if strings.EqualFold(name, header) {
+			return values, true
+		}
+	}
+	return nil, false
 }
 
 // Remove cookies from the request headers and return the map of headers

--- a/internal/appsec/listener/httpsec/request.go
+++ b/internal/appsec/listener/httpsec/request.go
@@ -150,6 +150,17 @@ func SetSecurityTestingHeaderTags(tags map[string]any, headers http.Header) {
 	}
 }
 
+// SetSecurityTestingHeaderTagsFromBytes sets security testing header tags from byte values.
+func SetSecurityTestingHeaderTagsFromBytes(tags map[string]any, values func(string) [][]byte) {
+	for _, h := range securityTestingHeaders {
+		headerValues := values(h.Header)
+		if len(headerValues) == 0 {
+			continue
+		}
+		tags[h.Tag] = strings.TrimSpace(normalizeHTTPHeaderBytesValue(headerValues))
+	}
+}
+
 func securityTestingHeaderValues(headers http.Header, header string) ([]string, bool) {
 	for name, values := range headers {
 		if strings.EqualFold(name, header) {
@@ -187,6 +198,28 @@ func normalizeHTTPHeaderName(name string) string {
 
 func normalizeHTTPHeaderValue(values []string) string {
 	return strings.Join(values, ",")
+}
+
+func normalizeHTTPHeaderBytesValue(values [][]byte) string {
+	if len(values) == 1 {
+		return string(values[0])
+	}
+
+	var length int
+	for _, value := range values {
+		length += len(value)
+	}
+	length += len(values) - 1
+
+	var b strings.Builder
+	b.Grow(length)
+	for i, value := range values {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.Write(value)
+	}
+	return b.String()
 }
 
 func init() {

--- a/internal/appsec/listener/httpsec/request.go
+++ b/internal/appsec/listener/httpsec/request.go
@@ -6,6 +6,7 @@
 package httpsec
 
 import (
+	"bytes"
 	"net/http"
 	"net/netip"
 	"strings"
@@ -74,11 +75,12 @@ var (
 	// These headers are tagged separately from defaultCollectedHeaders because
 	// they are collected even when AppSec is disabled.
 	securityTestingHeaders = [...]struct {
-		Header string
-		Tag    string
+		Header      string
+		HeaderBytes []byte
+		Tag         string
 	}{
-		{Header: securityTestingEndpointScanHeader, Tag: securityTestingEndpointScanTag},
-		{Header: securityTestingHeader, Tag: securityTestingTag},
+		{Header: securityTestingEndpointScanHeader, HeaderBytes: []byte(securityTestingEndpointScanHeader), Tag: securityTestingEndpointScanTag},
+		{Header: securityTestingHeader, HeaderBytes: []byte(securityTestingHeader), Tag: securityTestingTag},
 	}
 
 	// collectedHeadersLookupMap is a helper lookup map of HTTP headers to
@@ -156,18 +158,28 @@ func SecurityTestingHeaderTagValues(headers http.Header) ([2]string, [2]string, 
 	return tagNames, tagValues, count
 }
 
-// SecurityTestingHeaderByteTagValues returns span tag names and values from byte header lookups.
-func SecurityTestingHeaderByteTagValues(values func(string) [][]byte) ([2]string, [2]string, int) {
+// SecurityTestingHeaderByteTagValues returns span tag names and values from byte header entries.
+func SecurityTestingHeaderByteTagValues(visit func(func(key, value []byte))) ([2]string, [2]string, int) {
+	var headerValues [len(securityTestingHeaders)][][]byte
+	visit(func(key, value []byte) {
+		for i, h := range securityTestingHeaders {
+			if bytes.EqualFold(key, h.HeaderBytes) {
+				headerValues[i] = append(headerValues[i], value)
+				break
+			}
+		}
+	})
+
 	var tagNames [2]string
 	var tagValues [2]string
 	var count int
-	for _, h := range securityTestingHeaders {
-		headerValues := values(h.Header)
-		if len(headerValues) == 0 {
+	for i, h := range securityTestingHeaders {
+		values := headerValues[i]
+		if len(values) == 0 {
 			continue
 		}
 		tagNames[count] = h.Tag
-		tagValues[count] = strings.TrimSpace(normalizeHTTPHeaderBytesValue(headerValues))
+		tagValues[count] = strings.TrimSpace(normalizeHTTPHeaderBytesValue(values))
 		count++
 	}
 	return tagNames, tagValues, count

--- a/internal/appsec/listener/httpsec/request_test.go
+++ b/internal/appsec/listener/httpsec/request_test.go
@@ -250,6 +250,19 @@ func TestTags(t *testing.T) {
 	}
 }
 
+func TestSetRequestHeadersTagsDoesNotOwnSecurityTestingHeaders(t *testing.T) {
+	var span MockSpan
+	setRequestHeadersTags(&span, map[string][]string{
+		"X-Datadog-Endpoint-Scan": {"scan-uuid"},
+		"X-Datadog-Security-Test": {"test-uuid"},
+		"X-Forwarded-For":         {"1.2.3.4"},
+	})
+
+	require.Equal(t, "1.2.3.4", span.Tags["http.request.headers.x-forwarded-for"])
+	require.NotContains(t, span.Tags, "http.request.headers.x-datadog-endpoint-scan")
+	require.NotContains(t, span.Tags, "http.request.headers.x-datadog-security-test")
+}
+
 //go:embed testdata/trace_tagging_rules.json
 var wafRulesJSON []byte
 

--- a/internal/appsec/listener/httpsec/request_test.go
+++ b/internal/appsec/listener/httpsec/request_test.go
@@ -288,7 +288,15 @@ func TestSecurityTestingHeaderByteTagValues(t *testing.T) {
 
 	tagNames, tagValues, count := SecurityTestingHeaderByteTagValues(func(visit func(key, value []byte)) {
 		for _, value := range values {
-			visit(value[0], value[1])
+			key := append([]byte(nil), value[0]...)
+			headerValue := append([]byte(nil), value[1]...)
+			visit(key, headerValue)
+			for i := range key {
+				key[i] = 'x'
+			}
+			for i := range headerValue {
+				headerValue[i] = 'x'
+			}
 		}
 	})
 

--- a/internal/appsec/listener/httpsec/request_test.go
+++ b/internal/appsec/listener/httpsec/request_test.go
@@ -280,13 +280,16 @@ func TestSecurityTestingHeaderTagValues(t *testing.T) {
 }
 
 func TestSecurityTestingHeaderByteTagValues(t *testing.T) {
-	values := map[string][][]byte{
-		securityTestingEndpointScanHeader: {[]byte(" scan-uuid ")},
-		securityTestingHeader:             {[]byte("test-uuid"), []byte("second-value")},
+	values := [][2][]byte{
+		{[]byte("X-Datadog-Endpoint-Scan"), []byte(" scan-uuid ")},
+		{[]byte("X-Datadog-Security-Test"), []byte("test-uuid")},
+		{[]byte("x-datadog-security-test"), []byte("second-value")},
 	}
 
-	tagNames, tagValues, count := SecurityTestingHeaderByteTagValues(func(header string) [][]byte {
-		return values[header]
+	tagNames, tagValues, count := SecurityTestingHeaderByteTagValues(func(visit func(key, value []byte)) {
+		for _, value := range values {
+			visit(value[0], value[1])
+		}
 	})
 
 	require.Equal(t, 2, count)

--- a/internal/appsec/listener/httpsec/request_test.go
+++ b/internal/appsec/listener/httpsec/request_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/http"
 	"net/netip"
 	"testing"
 	"time"
@@ -263,19 +264,36 @@ func TestSetRequestHeadersTagsDoesNotOwnSecurityTestingHeaders(t *testing.T) {
 	require.NotContains(t, span.Tags, "http.request.headers.x-datadog-security-test")
 }
 
-func TestSetSecurityTestingHeaderTagsFromBytes(t *testing.T) {
-	tags := map[string]any{}
+func TestSecurityTestingHeaderTagValues(t *testing.T) {
+	headers := http.Header{
+		"X-Datadog-Endpoint-Scan": {" scan-uuid "},
+		"X-Datadog-Security-Test": {"test-uuid", "second-value"},
+	}
+
+	tagNames, tagValues, count := SecurityTestingHeaderTagValues(headers)
+
+	require.Equal(t, 2, count)
+	require.Equal(t, securityTestingEndpointScanTag, tagNames[0])
+	require.Equal(t, "scan-uuid", tagValues[0])
+	require.Equal(t, securityTestingTag, tagNames[1])
+	require.Equal(t, "test-uuid,second-value", tagValues[1])
+}
+
+func TestSecurityTestingHeaderByteTagValues(t *testing.T) {
 	values := map[string][][]byte{
 		securityTestingEndpointScanHeader: {[]byte(" scan-uuid ")},
 		securityTestingHeader:             {[]byte("test-uuid"), []byte("second-value")},
 	}
 
-	SetSecurityTestingHeaderTagsFromBytes(tags, func(header string) [][]byte {
+	tagNames, tagValues, count := SecurityTestingHeaderByteTagValues(func(header string) [][]byte {
 		return values[header]
 	})
 
-	require.Equal(t, "scan-uuid", tags[securityTestingEndpointScanTag])
-	require.Equal(t, "test-uuid,second-value", tags[securityTestingTag])
+	require.Equal(t, 2, count)
+	require.Equal(t, securityTestingEndpointScanTag, tagNames[0])
+	require.Equal(t, "scan-uuid", tagValues[0])
+	require.Equal(t, securityTestingTag, tagNames[1])
+	require.Equal(t, "test-uuid,second-value", tagValues[1])
 }
 
 //go:embed testdata/trace_tagging_rules.json

--- a/internal/appsec/listener/httpsec/request_test.go
+++ b/internal/appsec/listener/httpsec/request_test.go
@@ -263,6 +263,21 @@ func TestSetRequestHeadersTagsDoesNotOwnSecurityTestingHeaders(t *testing.T) {
 	require.NotContains(t, span.Tags, "http.request.headers.x-datadog-security-test")
 }
 
+func TestSetSecurityTestingHeaderTagsFromBytes(t *testing.T) {
+	tags := map[string]any{}
+	values := map[string][][]byte{
+		securityTestingEndpointScanHeader: {[]byte(" scan-uuid ")},
+		securityTestingHeader:             {[]byte("test-uuid"), []byte("second-value")},
+	}
+
+	SetSecurityTestingHeaderTagsFromBytes(tags, func(header string) [][]byte {
+		return values[header]
+	})
+
+	require.Equal(t, "scan-uuid", tags[securityTestingEndpointScanTag])
+	require.Equal(t, "test-uuid,second-value", tags[securityTestingTag])
+}
+
 //go:embed testdata/trace_tagging_rules.json
 var wafRulesJSON []byte
 


### PR DESCRIPTION
### What does this PR do?

Collects Datadog security-testing request headers on HTTP service-entry spans. ([RFC](https://docs.google.com/document/d/1uR4QQvU8pItEV2zFqr3-L6jO2jxzmvLrFTX_yyvqIOA/edit))

When an incoming request includes `x-datadog-endpoint-scan` or `x-datadog-security-test`, the HTTP instrumentation now sets these span tags:

- `http.request.headers.x-datadog-endpoint-scan`
- `http.request.headers.x-datadog-security-test`

The collection is unconditional: it does not depend on `DD_TRACE_HEADER_TAGS` or AppSec being enabled. The headers are also not propagated downstream.

This PR keeps the header/tag mapping in `internal/appsec`, then calls it from `instrumentation/httptrace` when starting HTTP request spans.

### Motivation

These markers let the API inventory pipeline distinguish Datadog endpoint scans and security tests from real user traffic.

Related system-tests coverage: https://github.com/DataDog/system-tests/pull/6915

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [x] There is a benchmark for any new code, or changes to existing code. N/A, this only adds a small request-header lookup on HTTP entry spans.
- [x] If this interacts with the agent in a new way, a system test has been added. N/A, no new agent interaction.
- [x] New code is free of linting errors. `go vet ./instrumentation/httptrace ./internal/appsec/listener/httpsec`
- [x] New code doesn't break existing tests. `go test -count=1 ./instrumentation/httptrace ./internal/appsec/listener/httpsec`
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. No generated files touched.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. N/A, no module changes.

---
https://datadoghq.atlassian.net/browse/APPSEC-64418