### PR TITLE
fix(appsec): finish service-entry span dyngo operation

### DIFF
--- a/instrumentation/appsec/dyngo/operation.go
+++ b/instrumentation/appsec/dyngo/operation.go
@@ -206,7 +206,7 @@ func RegisterOperation(ctx context.Context, op Operation) context.Context {
 
 // FinishOperation finishes the operation along with its results and emits a
 // finish event with the operation results.
-// The operation is then disabled and its event listeners removed.
+// The operation is then disabled and its listeners removed.
 func FinishOperation[O Operation, E ResultOf[O]](op O, results E) {
 	o := op.unwrap()
 	defer o.disable() // This will need the RLock below to be released...
@@ -228,7 +228,7 @@ func FinishOperation[O Operation, E ResultOf[O]](op O, results E) {
 	}
 }
 
-// Disable the operation and remove all its event listeners.
+// Disable the operation and remove all its listeners.
 func (o *operation) disable() {
 	o.mu.Lock()
 	defer o.mu.Unlock()
@@ -239,6 +239,7 @@ func (o *operation) disable() {
 
 	o.disabled = true
 	o.eventRegister.clear()
+	o.dataBroadcaster.clear()
 }
 
 // On registers and event listener that will be called when the operation
@@ -362,6 +363,12 @@ func (r *eventRegister) clear() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.listeners = nil
+}
+
+func (b *dataBroadcaster) clear() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.listeners = nil
 }
 
 func emitEvent[O Operation, T any](r *eventRegister, op O, v T) {

--- a/instrumentation/appsec/dyngo/operation_test.go
+++ b/instrumentation/appsec/dyngo/operation_test.go
@@ -511,6 +511,24 @@ func TestOperationData(t *testing.T) {
 			require.Equal(t, 20, data)
 		})
 	})
+
+	t.Run("finished-parent-listener", func(t *testing.T) {
+		data := 0
+		op1 := startOperation(MyOperationArgs{}, nil)
+		dyngo.OnData(op1, func(data *int) {
+			*data++
+		})
+		op2 := startOperation(MyOperation2Args{}, op1)
+
+		dyngo.FinishOperation(op1, MyOperationRes{})
+
+		for range 10 {
+			dyngo.EmitData(op2, &data)
+		}
+
+		dyngo.FinishOperation(op2, MyOperation2Res{})
+		require.Equal(t, 0, data)
+	})
 }
 
 func TestOperationEvents(t *testing.T) {

--- a/instrumentation/appsec/trace/service_entry_span.go
+++ b/instrumentation/appsec/trace/service_entry_span.go
@@ -26,6 +26,9 @@ type (
 	// ServiceEntrySpanArgs is the arguments for a ServiceEntrySpanOperation
 	ServiceEntrySpanArgs struct{}
 
+	// ServiceEntrySpanRes is the result of a ServiceEntrySpanOperation.
+	ServiceEntrySpanRes struct{}
+
 	// ServiceEntrySpanTag is a key value pair event that is used to tag a service entry span
 	ServiceEntrySpanTag struct {
 		Key   string
@@ -47,6 +50,8 @@ type (
 )
 
 func (ServiceEntrySpanArgs) IsArgOf(*ServiceEntrySpanOperation) {}
+
+func (ServiceEntrySpanRes) IsResultOf(*ServiceEntrySpanOperation) {}
 
 // SetTag adds the key/value pair to the tags to add to the service entry span
 func (op *ServiceEntrySpanOperation) SetTag(key string, value any) {
@@ -141,6 +146,8 @@ func StartServiceEntrySpanOperation(ctx context.Context, span TagSetter) (*Servi
 }
 
 func (op *ServiceEntrySpanOperation) Finish() {
+	defer dyngo.FinishOperation(op, ServiceEntrySpanRes{})
+
 	span := op.tagSetter
 	if _, ok := span.(NoopTagSetter); ok { // If the span is a NoopTagSetter or is nil, we don't need to set any tags
 		return

--- a/instrumentation/appsec/trace/service_entry_span_test.go
+++ b/instrumentation/appsec/trace/service_entry_span_test.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package trace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion"
+)
+
+func TestServiceEntrySpanOperationFinishClearsGLS(t *testing.T) {
+	t.Cleanup(orchestrion.MockGLS())
+
+	const iterations = 1000
+	baseline := orchestrion.GLSStackDepth()
+
+	for range iterations {
+		op, _ := StartServiceEntrySpanOperation(context.Background(), NoopTagSetter{})
+		op.Finish()
+
+		if depth := orchestrion.GLSStackDepth(); depth != baseline {
+			t.Fatalf("GLS depth after ServiceEntrySpanOperation.Finish() = %d, want baseline %d", depth, baseline)
+		}
+	}
+}

--- a/internal/appsec/emitter/waf/context_test.go
+++ b/internal/appsec/emitter/waf/context_test.go
@@ -32,7 +32,7 @@ func TestContextOperationFinishClearsServiceEntryGLS(t *testing.T) {
 	}
 }
 
-func TestFinishedServiceEntrySpanDoesNotReceiveDataEvents(t *testing.T) {
+func TestFinishedServiceEntrySpanDoesNotReceiveChildDataEvents(t *testing.T) {
 	t.Cleanup(orchestrion.MockGLS())
 
 	root := dyngo.NewRootOperation()
@@ -48,14 +48,15 @@ func TestFinishedServiceEntrySpanDoesNotReceiveDataEvents(t *testing.T) {
 	tags := newRecordingTagSetter()
 	op, _ := StartContextOperation(context.Background(), tags)
 	op.Finish()
+	child := dyngo.NewOperation(op.ServiceEntrySpanOperation)
 
-	dyngo.EmitData(op.ServiceEntrySpanOperation, tracelib.ServiceEntrySpanTag{
+	dyngo.EmitData(child, tracelib.ServiceEntrySpanTag{
 		Key:   "after.finish",
 		Value: "should-not-be-seen",
 	})
 
 	if _, ok := tags.Get("after.finish"); ok {
-		t.Fatal("finished service-entry operation still received data events")
+		t.Fatal("finished service-entry operation still received data events from a child operation")
 	}
 }
 

--- a/internal/appsec/emitter/waf/context_test.go
+++ b/internal/appsec/emitter/waf/context_test.go
@@ -1,0 +1,82 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package waf
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/dyngo"
+	tracelib "github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/trace"
+	appsectrace "github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/trace"
+	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion"
+)
+
+func TestContextOperationFinishClearsServiceEntryGLS(t *testing.T) {
+	t.Cleanup(orchestrion.MockGLS())
+
+	const iterations = 1000
+	baseline := orchestrion.GLSStackDepth()
+
+	for range iterations {
+		op, _ := StartContextOperation(context.Background(), tracelib.NoopTagSetter{})
+		op.Finish()
+
+		if depth := orchestrion.GLSStackDepth(); depth != baseline {
+			t.Fatalf("GLS depth after ContextOperation.Finish() = %d, want baseline %d", depth, baseline)
+		}
+	}
+}
+
+func TestFinishedServiceEntrySpanDoesNotReceiveDataEvents(t *testing.T) {
+	t.Cleanup(orchestrion.MockGLS())
+
+	root := dyngo.NewRootOperation()
+	dyngo.SwapRootOperation(root)
+	t.Cleanup(func() { dyngo.SwapRootOperation(nil) })
+
+	transport, err := appsectrace.NewAppsecSpanTransport(nil, root)
+	if err != nil {
+		t.Fatalf("failed to register AppSec span transport: %v", err)
+	}
+	t.Cleanup(transport.Stop)
+
+	tags := newRecordingTagSetter()
+	op, _ := StartContextOperation(context.Background(), tags)
+	op.Finish()
+
+	dyngo.EmitData(op.ServiceEntrySpanOperation, tracelib.ServiceEntrySpanTag{
+		Key:   "after.finish",
+		Value: "should-not-be-seen",
+	})
+
+	if _, ok := tags.Get("after.finish"); ok {
+		t.Fatal("finished service-entry operation still received data events")
+	}
+}
+
+type recordingTagSetter struct {
+	mu   sync.Mutex
+	tags map[string]any
+}
+
+func newRecordingTagSetter() *recordingTagSetter {
+	return &recordingTagSetter{tags: make(map[string]any)}
+}
+
+func (r *recordingTagSetter) SetTag(key string, value any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.tags[key] = value
+}
+
+func (r *recordingTagSetter) Get(key string) (any, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	value, ok := r.tags[key]
+	return value, ok
+}


### PR DESCRIPTION
### What does this PR do?

Finishes the dyngo operation behind `ServiceEntrySpanOperation` when `Finish()` is called.

`Finish()` already flushed collected AppSec tags to the service-entry span, but it did not close the dyngo operation itself. That left the operation on the GLS stack and kept its data listeners active after the request was done.

This PR adds a `ServiceEntrySpanRes` result type and calls `dyngo.FinishOperation` from `ServiceEntrySpanOperation.Finish()`.

### Motivation

Fixes #4763

A finished service-entry span operation should not keep per-request dyngo state alive or receive later data events.

Without the dyngo finish step, repeated AppSec request lifecycles can leave service-entry operations on the GLS stack. The new tests cover the two cases we care about:

- repeated service-entry/context operation finishes return the GLS stack depth to baseline
- finished service-entry operations no longer receive data events

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage. Added `TestServiceEntrySpanOperationFinishClearsGLS`, `TestContextOperationFinishClearsServiceEntryGLS`, and `TestFinishedServiceEntrySpanDoesNotReceiveDataEvents`.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag. N/A, this is internal dyngo lifecycle cleanup.
- [ ] There is a benchmark for any new code, or changes to existing code. N/A, lifecycle fix only.
- [ ] If this interacts with the agent in a new way, a system test has been added. N/A, no new agent interaction.
- [x] New code is free of linting errors.
- [x] New code doesn't break existing tests.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. No generated files touched.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. N/A, no module changes.