### PR TITLE
return flag metadata/version from get*Details methods

### DIFF
--- a/openfeature/evaluator.go
+++ b/openfeature/evaluator.go
@@ -68,8 +68,13 @@ func evaluateFlag(flag *flag, defaultValue any, context map[string]any) evaluati
 				}
 			}
 
-			// Build metadata for exposure tracking
-			metadata := make(map[string]any)
+			// Build metadata for exposure tracking.
+			// Seed from flag.Metadata (backend passthrough, e.g. version)
+			// so SDK-internal keys below win on collision.
+			metadata := make(map[string]any, len(flag.Metadata)+2)
+			for k, v := range flag.Metadata {
+				metadata[k] = v
+			}
 			metadata[metadataAllocationKey] = allocation.Key
 
 			// Get doLog value (defaults to true if not specified)

--- a/openfeature/evaluator_test.go
+++ b/openfeature/evaluator_test.go
@@ -713,6 +713,84 @@ func TestEvaluateFlag(t *testing.T) {
 	}
 }
 
+func TestEvaluateFlagSurfacesBackendMetadata(t *testing.T) {
+	// Flag carries backend-emitted metadata (version, lastModified, etc.).
+	// On a successful evaluation, it should be merged into result.Metadata
+	// alongside dd.allocation.key / dd.doLog, with SDK-internal keys winning
+	// on collision.
+	matchingFlag := &flag{
+		Key:           "test-flag",
+		Enabled:       true,
+		VariationType: valueTypeBoolean,
+		Variations: map[string]*variant{
+			"on": {Key: "on", Value: true},
+		},
+		Allocations: []*allocation{
+			{
+				Key: "allocation1",
+				Splits: []*split{
+					{
+						Shards: []*shard{
+							{
+								Salt:        "test",
+								Ranges:      []*shardRange{{Start: 0, End: 8192}},
+								TotalShards: 8192,
+							},
+						},
+						VariationKey: "on",
+					},
+				},
+			},
+		},
+		Metadata: map[string]any{
+			"version":           42,
+			"lastModified":      "2026-05-13T10:30:00Z",
+			metadataAllocationKey: "should-be-overridden",
+		},
+	}
+	ctx := map[string]any{of.TargetingKey: "user-123"}
+
+	result := evaluateFlag(matchingFlag, false, ctx)
+
+	if result.Reason != of.TargetingMatchReason {
+		t.Fatalf("expected TargetingMatchReason, got %s", result.Reason)
+	}
+	if got := result.Metadata["version"]; got != 42 {
+		t.Errorf("expected metadata[version]=42, got %v", got)
+	}
+	if got := result.Metadata["lastModified"]; got != "2026-05-13T10:30:00Z" {
+		t.Errorf("expected metadata[lastModified]=2026-05-13T10:30:00Z, got %v", got)
+	}
+	if got := result.Metadata[metadataAllocationKey]; got != "allocation1" {
+		t.Errorf("expected SDK-internal allocation key to win on collision, got %v", got)
+	}
+	if _, ok := result.Metadata[metadataDoLogKey]; !ok {
+		t.Errorf("expected metadata[%s] to be present", metadataDoLogKey)
+	}
+}
+
+func TestEvaluateFlagNoMetadataWhenDefault(t *testing.T) {
+	// When the flag has metadata but no allocation matches, the result
+	// uses the default reason and carries no metadata. Confirms we don't
+	// regress existing behavior.
+	noMatchFlag := &flag{
+		Key:           "test-flag",
+		Enabled:       true,
+		VariationType: valueTypeBoolean,
+		Allocations:   []*allocation{}, // no allocations → no match
+		Metadata: map[string]any{
+			"version": 42,
+		},
+	}
+	result := evaluateFlag(noMatchFlag, false, map[string]any{})
+	if result.Reason != of.DefaultReason {
+		t.Fatalf("expected DefaultReason, got %s", result.Reason)
+	}
+	if result.Metadata != nil {
+		t.Errorf("expected no metadata on default path, got %v", result.Metadata)
+	}
+}
+
 func TestComputeShardIndex(t *testing.T) {
 	// Test consistency: same input should always produce same output
 	key1 := computeShardIndex("salt1", "user-123", 8192)

--- a/openfeature/types.go
+++ b/openfeature/types.go
@@ -57,6 +57,9 @@ type flag struct {
 	// Allocations define targeting and traffic distribution rules
 	// They are evaluated in order, and the first matching allocation wins
 	Allocations []*allocation `json:"allocations"`
+	// Metadata is generic passthrough metadata emitted by the backend
+	// (e.g. version, lastModified). Surfaced via OpenFeature flag_metadata.
+	Metadata map[string]any `json:"metadata,omitempty"`
 }
 
 // variant represents a single variation/variation of a feature flag.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
