### PR TITLE
fix(ci): use GITHUB_TOKEN for GHCR image publishing

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -42,7 +42,6 @@ on:
 permissions:
   contents: read
   packages: write
-  id-token: write
 
 jobs:
   build-images:
@@ -65,16 +64,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Get GitHub Token via dd-octo-sts
-        id: generate-token
-        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
-        with:
-          scope: DataDog/dd-trace-go
-          policy: self.docker-build-and-push
-
       - name: Login to Docker
         shell: bash
-        run: docker login -u publisher -p ${{ steps.generate-token.outputs.token }} ghcr.io
+        # GitHub Packages only supports PATs and GITHUB_TOKEN for authentication.
+        # https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry
+        run: docker login -u publisher -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
 
       - name: Docker meta
         id: meta
@@ -166,16 +160,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Get GitHub Token via dd-octo-sts
-        id: generate-token
-        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
-        with:
-          scope: DataDog/dd-trace-go
-          policy: self.docker-build-and-push
-
       - name: Login to Docker
         shell: bash
-        run: docker login -u publisher -p ${{ steps.generate-token.outputs.token }} ghcr.io
+        run: docker login -u publisher -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
 
       - name: Create manifest list and push
         working-directory: /tmp/digests


### PR DESCRIPTION
### What does this PR do?

Restores `secrets.GITHUB_TOKEN` for the GHCR login steps in the reusable Docker image workflow.

PR #4749 moved these logins to a dd-octo-sts installation token. The token can be minted and Docker accepts the login, but GHCR rejects it when the workflow tries to write organization packages. The failing service-extension and HAProxy jobs hit that path with:

```text
denied: permission_denied: installation not allowed to Write organization package
```

The reusable workflow no longer needs OIDC for this path, so this also removes `id-token: write` from its permissions.

### Motivation

Scheduled System Tests started failing after the token migration when pushing `service-extensions-callout` and `haproxy-spoa` to GHCR. GitHub documents `GITHUB_TOKEN` and PAT auth for package publishing from Actions ([GitHub documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry), [octo-sts/app#840](https://github.com/octo-sts/app/issues/840), [community note](https://github.com/orgs/community/discussions/24636)).

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage. N/A, workflow-only change.
- [x] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag. N/A, fixes the CI packaging path itself.
- [x] There is a benchmark for any new code, or changes to existing code. N/A.
- [x] If this interacts with the agent in a new way, a system test has been added. N/A.
- [x] New code is free of linting errors. `make lint/action` passes.
- [x] New code doesn't break existing tests. N/A, workflow-only change; `make lint/action` validates the changed workflow.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes. Workflow-only change, no release-note impact expected.
- [x] All generated files are up to date. No generated files touched.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. No go.mod changes.

Unsure? Have a question? Request a review!

---
https://datadoghq.atlassian.net/browse/APPSEC-64493