### PR TITLE
fix(autoreleasetagger): honor excluded modules in tag guard

### DIFF
--- a/scripts/autoreleasetagger/main.go
+++ b/scripts/autoreleasetagger/main.go
@@ -331,7 +331,15 @@ func run(dryRun bool, remote string, disablePush bool, root, version string, exc
 	// handles the "all tags already point at HEAD" case; this guard catches
 	// tags that point somewhere else — including tags that were pushed from a
 	// different run and are only visible via the remote.
-	if err := checkTagsExist(root, remote, allWouldBeTags(root, version, excludedDirs, untaggedModules)); err != nil {
+	//
+	// allTags (computed above) is the exact set of tags this run will create;
+	// it already respects excludedModules, untaggedModules, and the
+	// dependency-graph filter. Using it directly avoids the false-positive
+	// that the old allWouldBeTags approximation caused: that function had no
+	// knowledge of excludedModules, so it included tags for explicitly
+	// excluded modules — causing a spurious tags_exist failure when one of
+	// those modules carried an old tag on a different commit.
+	if err := checkTagsExist(root, remote, allTags); err != nil {
 		return err
 	}
 
@@ -508,49 +516,6 @@ func checkDirtyTree(root string) error {
 		fmt.Sprintf("working tree has uncommitted changes in: %s", strings.Join(dirty, ", ")),
 		map[string]any{"modified_files": dirty},
 	)
-}
-
-// allWouldBeTags returns a conservative approximation of the tag list derived
-// solely from the filesystem (before modules are fully resolved). It is used
-// only by the pre-mutation tags_exist guard; the real tag list is built later
-// via buildTagList after modules are discovered.
-//
-// excludedDirs must be the same resolved slice passed to findModules so that
-// modules in _tools, .github, tools, etc. are not included — those directories
-// are never tagged and their presence in the list would cause false-positive
-// tags_exist errors if they happened to carry an old tag on a different commit.
-func allWouldBeTags(root, version string, excludedDirs, untaggedModules []string) []string {
-	// Walk the repo and collect every go.mod that is NOT the root so we can
-	// build the tag list without running the full module-discovery pipeline.
-	tags := []string{version}
-	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
-		if d.IsDir() {
-			if d.Name() == ".git" {
-				return filepath.SkipDir
-			}
-			if containsPath(excludedDirs, path) {
-				return filepath.SkipDir
-			}
-		}
-		if d.Name() != "go.mod" || filepath.Dir(path) == root {
-			return nil
-		}
-		rel, err := filepath.Rel(root, filepath.Dir(path))
-		if err != nil {
-			return nil
-		}
-		// Read the module path to check against untaggedModules.
-		mod, err := readModule(path)
-		if err == nil && containsPath(untaggedModules, mod.Module.Path) {
-			return nil
-		}
-		tags = append(tags, rel+"/"+version)
-		return nil
-	})
-	return tags
 }
 
 // checkTagsExist inspects the provided tag names and returns a tags_exist

--- a/scripts/autoreleasetagger/main_integration_test.go
+++ b/scripts/autoreleasetagger/main_integration_test.go
@@ -1133,6 +1133,168 @@ func TestCIInvalidVersionError(t *testing.T) {
 	assertJSONErrorCode(t, stderrOut, string(errInvalidVersion))
 }
 
+// TestExcludeModulesTagConflictGuard is the primary regression test for the
+// P2 bug: when --exclude-modules is used, the tag-conflict guard must NOT flag
+// tags that belong to excluded modules — even when those tags already exist on
+// an older commit.
+//
+// Scenario:
+//  1. Scaffold a repo with moduleA, moduleB, and moduleC.
+//  2. Create an extra commit so HEAD advances past the initial commit.
+//  3. Tag moduleC's slot (moduleC/<version>) on the older commit, simulating a
+//     prior release where moduleC was tagged independently.
+//  4. Run autoreleasetagger with moduleC in --exclude-modules.
+//
+// Expected outcome: the run succeeds (no tags_exist error), moduleA and
+// moduleB are tagged at the new HEAD, and moduleC is NOT re-tagged.
+func TestExcludeModulesTagConflictGuard(t *testing.T) {
+	t.Parallel()
+	testLogger()
+
+	const (
+		branch  = "release-v2.9.x"
+		version = "v2.9.9-rc.1"
+	)
+
+	tmpDir := scaffoldRepo(t, branch)
+
+	// Add an extra commit so the initial commit is no longer HEAD.
+	// The moduleC tag will be placed on this older commit, not on HEAD,
+	// which is exactly the condition that triggered the spurious tags_exist
+	// failure in the old allWouldBeTags code path.
+	if err := os.WriteFile(filepath.Join(tmpDir, "bump.txt"), []byte("bump"), 0o644); err != nil {
+		t.Fatalf("write bump.txt failed: %v", err)
+	}
+	if err := runGitCommand(tmpDir, "add", "."); err != nil {
+		t.Fatalf("git add failed: %v", err)
+	}
+	if err := runGitCommand(tmpDir, "commit", "-m", "pre-existing bump"); err != nil {
+		t.Fatalf("git commit failed: %v", err)
+	}
+
+	// Record the current HEAD so we can assert it advances after the release.
+	head, err := runGitCommandWithOutput(tmpDir, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("rev-parse HEAD failed: %v", err)
+	}
+	head = strings.TrimSpace(head)
+
+	// Place moduleC's tag on the commit BEFORE the bump (HEAD~1), simulating
+	// a tag that exists on a different commit than the one this run will produce.
+	// Without the fix, checkTagsExist would see this tag in its input set and
+	// return a spurious tags_exist error even though moduleC is excluded.
+	moduleCTag := "moduleC/" + version
+	if err := runGitCommand(tmpDir, "tag", "-am", moduleCTag, moduleCTag, "HEAD~1"); err != nil {
+		t.Fatalf("failed to create moduleC tag on HEAD~1: %v", err)
+	}
+
+	// Run with moduleC excluded. Must succeed despite moduleC's tag existing on
+	// a different commit: allTags (derived from filteredModules, which already
+	// excludes moduleC) is what gets passed to checkTagsExist, so moduleC's
+	// tag is never in the conflict-guard's input set.
+	excludedModule := "example.com/root/moduleC/v2"
+	if err := run(false, "test-remote", true, tmpDir, version, []string{excludedModule}, []string{}, []string{}); err != nil {
+		t.Fatalf("run with --exclude-modules failed unexpectedly: %v\n"+
+			"(regression: the tag-conflict guard must not flag tags for excluded modules)", err)
+	}
+
+	// Three commits: initial + bump + release.
+	commits, err := runGitCommandWithOutput(tmpDir, "log", "--oneline")
+	if err != nil {
+		t.Fatalf("failed to read commits: %v", err)
+	}
+	if got := len(nonEmptyLines(commits)); got != 3 {
+		t.Errorf("expected 3 commits (initial + bump + release), got %d:\n%s", got, commits)
+	}
+
+	// HEAD must have advanced past the pre-bump commit.
+	newHead, err := runGitCommandWithOutput(tmpDir, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("rev-parse HEAD failed: %v", err)
+	}
+	if strings.TrimSpace(newHead) == head {
+		t.Error("expected a new release commit, but HEAD did not advance")
+	}
+
+	tagsAtHead, err := runGitCommandWithOutput(tmpDir, "tag", "--points-at", "HEAD")
+	if err != nil {
+		t.Fatalf("failed to list tags at HEAD: %v", err)
+	}
+
+	// Root tag and non-excluded contrib tags must be present at the new HEAD.
+	for _, tag := range []string{version, "moduleA/" + version, "moduleB/" + version} {
+		if !containsLine(tagsAtHead, tag) {
+			t.Errorf("expected tag %q at HEAD, not found in:\n%s", tag, tagsAtHead)
+		}
+	}
+
+	// moduleC must NOT have been re-tagged — it must still point at HEAD~1.
+	// This confirms excludedModules is respected all the way through to Phase 3.
+	if containsLine(tagsAtHead, moduleCTag) {
+		t.Errorf("excluded moduleC tag %q must not appear at the new HEAD", moduleCTag)
+	}
+}
+
+// TestExcludeModulesSkipsTagCreation probes the pipeline at the unit level:
+// filterModules + buildTagList must together produce a tag slice that contains
+// no entry for the excluded module. This slice is the exact input that
+// checkTagsExist receives, so a missing module here means the conflict guard
+// cannot be falsely triggered by that module's stale tags.
+func TestExcludeModulesSkipsTagCreation(t *testing.T) {
+	t.Parallel()
+	testLogger()
+
+	const (
+		branch  = "release-v2.9.x"
+		version = "v2.9.9-rc.1"
+	)
+
+	tmpDir := scaffoldRepo(t, branch)
+
+	modules, err := findModules(tmpDir, []string{})
+	if err != nil {
+		t.Fatalf("findModules failed: %v", err)
+	}
+
+	rootMod, err := readModule(filepath.Join(tmpDir, "go.mod"))
+	if err != nil {
+		t.Fatalf("readModule failed: %v", err)
+	}
+
+	excludedModule := "example.com/root/moduleC/v2"
+	filtered := filterModules(modules, rootMod.Module.Path, []string{excludedModule})
+
+	sorted, err := topologicalSort(buildDependencyGraph(filtered))
+	if err != nil {
+		t.Fatalf("topologicalSort failed: %v", err)
+	}
+
+	tags := buildTagList(tmpDir, rootMod, filtered, sorted, version, []string{})
+
+	// moduleC must not appear in the tag list that checkTagsExist would receive.
+	moduleCTag := "moduleC/" + version
+	for _, tag := range tags {
+		if tag == moduleCTag {
+			t.Errorf("buildTagList must not include %q for excluded module %q; full list: %v",
+				moduleCTag, excludedModule, tags)
+		}
+	}
+
+	// The non-excluded modules must still appear.
+	for _, want := range []string{version, "moduleA/" + version, "moduleB/" + version} {
+		found := false
+		for _, tag := range tags {
+			if tag == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected tag %q in buildTagList output; got: %v", want, tags)
+		}
+	}
+}
+
 // assertJSONErrorCode parses the JSON on stderr and asserts the "error" field
 // matches the expected code.
 func assertJSONErrorCode(t *testing.T, stderrOut, wantCode string) {


### PR DESCRIPTION
### What does this PR do?

Clarifies how modules are excluded and passed around in `autoreleasetagger`. Adds more tests to ensure everything works as designed.

### Motivation

Feedback on #4764.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
