### PR TITLE
fix(.github/chainguard): add workflows permission to sync-cue-actions

### DIFF
--- a/.github/chainguard/self.sync-cue-actions.sts.yaml
+++ b/.github/chainguard/self.sync-cue-actions.sts.yaml
@@ -9,3 +9,4 @@ claim_pattern:
 
 permissions:
   contents: write
+  workflows: write


### PR DESCRIPTION
### What does this PR do?

Adds `workflows: write` to `sync-cue-actions`'s chainguard configuration.

### Motivation

Fixes issues on #4779.

### Reviewer's Checklist

- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
