### PR TITLE
fix(appsec): clear dataBroadcaster listeners on operation.disable()

### DIFF
--- a/instrumentation/appsec/dyngo/operation.go
+++ b/instrumentation/appsec/dyngo/operation.go
@@ -206,7 +206,7 @@ func RegisterOperation(ctx context.Context, op Operation) context.Context {
 
 // FinishOperation finishes the operation along with its results and emits a
 // finish event with the operation results.
-// The operation is then disabled and its event listeners removed.
+// The operation is then disabled and its listeners removed.
 func FinishOperation[O Operation, E ResultOf[O]](op O, results E) {
 	o := op.unwrap()
 	defer o.disable() // This will need the RLock below to be released...
@@ -228,7 +228,7 @@ func FinishOperation[O Operation, E ResultOf[O]](op O, results E) {
 	}
 }
 
-// Disable the operation and remove all its event listeners.
+// Disable the operation and remove all its listeners.
 func (o *operation) disable() {
 	o.mu.Lock()
 	defer o.mu.Unlock()

--- a/instrumentation/appsec/dyngo/operation.go
+++ b/instrumentation/appsec/dyngo/operation.go
@@ -239,6 +239,7 @@ func (o *operation) disable() {
 
 	o.disabled = true
 	o.eventRegister.clear()
+	o.dataBroadcaster.clear()
 }
 
 // On registers and event listener that will be called when the operation
@@ -362,6 +363,12 @@ func (r *eventRegister) clear() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.listeners = nil
+}
+
+func (b *dataBroadcaster) clear() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.listeners = nil
 }
 
 func emitEvent[O Operation, T any](r *eventRegister, op O, v T) {

--- a/instrumentation/appsec/dyngo/operation_test.go
+++ b/instrumentation/appsec/dyngo/operation_test.go
@@ -511,6 +511,24 @@ func TestOperationData(t *testing.T) {
 			require.Equal(t, 20, data)
 		})
 	})
+
+	t.Run("finished-parent-listener", func(t *testing.T) {
+		data := 0
+		op1 := startOperation(MyOperationArgs{}, nil)
+		dyngo.OnData(op1, func(data *int) {
+			*data++
+		})
+		op2 := startOperation(MyOperation2Args{}, op1)
+
+		dyngo.FinishOperation(op1, MyOperationRes{})
+
+		for range 10 {
+			dyngo.EmitData(op2, &data)
+		}
+
+		dyngo.FinishOperation(op2, MyOperation2Res{})
+		require.Equal(t, 0, data)
+	})
 }
 
 func TestOperationEvents(t *testing.T) {

--- a/instrumentation/appsec/trace/service_entry_span.go
+++ b/instrumentation/appsec/trace/service_entry_span.go
@@ -26,7 +26,7 @@ type (
 	// ServiceEntrySpanArgs is the arguments for a ServiceEntrySpanOperation
 	ServiceEntrySpanArgs struct{}
 
-	// ServiceEntrySpanRes is the result of a ServiceEntrySpanOperation
+	// ServiceEntrySpanRes is the result of a ServiceEntrySpanOperation.
 	ServiceEntrySpanRes struct{}
 
 	// ServiceEntrySpanTag is a key value pair event that is used to tag a service entry span
@@ -49,7 +49,8 @@ type (
 	}
 )
 
-func (ServiceEntrySpanArgs) IsArgOf(*ServiceEntrySpanOperation)   {}
+func (ServiceEntrySpanArgs) IsArgOf(*ServiceEntrySpanOperation) {}
+
 func (ServiceEntrySpanRes) IsResultOf(*ServiceEntrySpanOperation) {}
 
 // SetTag adds the key/value pair to the tags to add to the service entry span
@@ -145,8 +146,6 @@ func StartServiceEntrySpanOperation(ctx context.Context, span TagSetter) (*Servi
 }
 
 func (op *ServiceEntrySpanOperation) Finish() {
-	// Deferred so the GLS entry is popped and dyngo listeners are cleared
-	// even if a misbehaving TagSetter.SetTag panics below.
 	defer dyngo.FinishOperation(op, ServiceEntrySpanRes{})
 
 	span := op.tagSetter

--- a/instrumentation/appsec/trace/service_entry_span.go
+++ b/instrumentation/appsec/trace/service_entry_span.go
@@ -26,6 +26,9 @@ type (
 	// ServiceEntrySpanArgs is the arguments for a ServiceEntrySpanOperation
 	ServiceEntrySpanArgs struct{}
 
+	// ServiceEntrySpanRes is the result of a ServiceEntrySpanOperation
+	ServiceEntrySpanRes struct{}
+
 	// ServiceEntrySpanTag is a key value pair event that is used to tag a service entry span
 	ServiceEntrySpanTag struct {
 		Key   string
@@ -46,7 +49,8 @@ type (
 	}
 )
 
-func (ServiceEntrySpanArgs) IsArgOf(*ServiceEntrySpanOperation) {}
+func (ServiceEntrySpanArgs) IsArgOf(*ServiceEntrySpanOperation)   {}
+func (ServiceEntrySpanRes) IsResultOf(*ServiceEntrySpanOperation) {}
 
 // SetTag adds the key/value pair to the tags to add to the service entry span
 func (op *ServiceEntrySpanOperation) SetTag(key string, value any) {
@@ -141,6 +145,10 @@ func StartServiceEntrySpanOperation(ctx context.Context, span TagSetter) (*Servi
 }
 
 func (op *ServiceEntrySpanOperation) Finish() {
+	// Deferred so the GLS entry is popped and dyngo listeners are cleared
+	// even if a misbehaving TagSetter.SetTag panics below.
+	defer dyngo.FinishOperation(op, ServiceEntrySpanRes{})
+
 	span := op.tagSetter
 	if _, ok := span.(NoopTagSetter); ok { // If the span is a NoopTagSetter or is nil, we don't need to set any tags
 		return

--- a/instrumentation/appsec/trace/service_entry_span_test.go
+++ b/instrumentation/appsec/trace/service_entry_span_test.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package trace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion"
+)
+
+func TestServiceEntrySpanOperationFinishClearsGLS(t *testing.T) {
+	t.Cleanup(orchestrion.MockGLS())
+
+	const iterations = 1000
+	baseline := orchestrion.GLSStackDepth()
+
+	for range iterations {
+		op, _ := StartServiceEntrySpanOperation(context.Background(), NoopTagSetter{})
+		op.Finish()
+
+		if depth := orchestrion.GLSStackDepth(); depth != baseline {
+			t.Fatalf("GLS depth after ServiceEntrySpanOperation.Finish() = %d, want baseline %d", depth, baseline)
+		}
+	}
+}

--- a/internal/appsec/emitter/waf/context_test.go
+++ b/internal/appsec/emitter/waf/context_test.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package waf
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/dyngo"
+	tracelib "github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/trace"
+	appsectrace "github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/trace"
+	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion"
+)
+
+func TestContextOperationFinishClearsServiceEntryGLS(t *testing.T) {
+	t.Cleanup(orchestrion.MockGLS())
+
+	const iterations = 1000
+	baseline := orchestrion.GLSStackDepth()
+
+	for range iterations {
+		op, _ := StartContextOperation(context.Background(), tracelib.NoopTagSetter{})
+		op.Finish()
+
+		if depth := orchestrion.GLSStackDepth(); depth != baseline {
+			t.Fatalf("GLS depth after ContextOperation.Finish() = %d, want baseline %d", depth, baseline)
+		}
+	}
+}
+
+func TestFinishedServiceEntrySpanDoesNotReceiveChildDataEvents(t *testing.T) {
+	t.Cleanup(orchestrion.MockGLS())
+
+	root := dyngo.NewRootOperation()
+	dyngo.SwapRootOperation(root)
+	t.Cleanup(func() { dyngo.SwapRootOperation(nil) })
+
+	transport, err := appsectrace.NewAppsecSpanTransport(nil, root)
+	if err != nil {
+		t.Fatalf("failed to register AppSec span transport: %v", err)
+	}
+	t.Cleanup(transport.Stop)
+
+	tags := newRecordingTagSetter()
+	op, _ := StartContextOperation(context.Background(), tags)
+	op.Finish()
+	child := dyngo.NewOperation(op.ServiceEntrySpanOperation)
+
+	dyngo.EmitData(child, tracelib.ServiceEntrySpanTag{
+		Key:   "after.finish",
+		Value: "should-not-be-seen",
+	})
+
+	if _, ok := tags.Get("after.finish"); ok {
+		t.Fatal("finished service-entry operation still received data events from a child operation")
+	}
+}
+
+type recordingTagSetter struct {
+	mu   sync.Mutex
+	tags map[string]any
+}
+
+func newRecordingTagSetter() *recordingTagSetter {
+	return &recordingTagSetter{tags: make(map[string]any)}
+}
+
+func (r *recordingTagSetter) SetTag(key string, value any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.tags[key] = value
+}
+
+func (r *recordingTagSetter) Get(key string) (any, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	value, ok := r.tags[key]
+	return value, ok
+}


### PR DESCRIPTION
This is a shadow of https://github.com/DataDog/dd-trace-go/pull/4766 so we can have system tests results.