### PR TITLE
perf(ddtrace/tracer): make propagatingTags lock-free via atomic copy-on-write

### DIFF
--- a/ddtrace/tracer/propagating_tags.go
+++ b/ddtrace/tracer/propagating_tags.go
@@ -6,6 +6,7 @@
 package tracer
 
 import (
+	"maps"
 	"strconv"
 
 	"github.com/DataDog/dd-trace-go/v2/internal"
@@ -13,18 +14,79 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 )
 
+// propagatingTags is stored as an atomic.Pointer to an immutable map so that
+// readers (e.g. Inject / marshalPropagatingTags) are completely lock-free.
+// Writers hold t.mu and use copy-on-write to produce a new immutable snapshot.
+
+// copyOnWriteSet stores key=value in the propagating-tags map using
+// copy-on-write so concurrent readers remain lock-free. Caller must hold t.mu.
+// +checklocks:t.mu
+func (t *trace) copyOnWriteSet(key, value string) {
+	old := t.propagatingTags.Load()
+	var m map[string]string
+	if old == nil || *old == nil {
+		m = map[string]string{key: value}
+	} else {
+		if (*old)[key] == value {
+			return // value unchanged — skip allocation
+		}
+		m = make(map[string]string, len(*old)+1)
+		maps.Copy(m, *old)
+		m[key] = value
+	}
+	t.propagatingTags.Store(&m)
+}
+
+// copyOnWriteDelete removes key from the propagating-tags map.
+// Caller must hold t.mu.
+// +checklocks:t.mu
+func (t *trace) copyOnWriteDelete(key string) {
+	old := t.propagatingTags.Load()
+	if old == nil {
+		return
+	}
+	if _, exists := (*old)[key]; !exists {
+		return
+	}
+	m := make(map[string]string, len(*old)-1)
+	for k, v := range *old {
+		if k != key {
+			m[k] = v
+		}
+	}
+	t.propagatingTags.Store(&m)
+}
+
+// --- Lock-free read accessors ---
+
 func (t *trace) hasPropagatingTag(k string) bool {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	_, ok := t.propagatingTags[k]
-	return ok
+	if m := t.propagatingTags.Load(); m != nil {
+		_, ok := (*m)[k]
+		return ok
+	}
+	return false
 }
 
 func (t *trace) propagatingTag(k string) string {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	return t.propagatingTags[k]
+	if m := t.propagatingTags.Load(); m != nil {
+		return (*m)[k]
+	}
+	return ""
 }
+
+// iteratePropagatingTags iterates the propagating tags without holding any
+// lock. f should return false to stop iteration.
+func (t *trace) iteratePropagatingTags(f func(k, v string) bool) {
+	if m := t.propagatingTags.Load(); m != nil {
+		for k, v := range *m {
+			if !f(k, v) {
+				break
+			}
+		}
+	}
+}
+
+// --- Write accessors (acquire t.mu internally) ---
 
 // setPropagatingTag sets the key/value pair as a trace propagating tag.
 func (t *trace) setPropagatingTag(key, value string) {
@@ -39,18 +101,15 @@ func (t *trace) setTraceSourcePropagatingTag(key string, value internal.TraceSou
 
 	// If there is already a TraceSource value set in the trace
 	// we need to add the new value to the bitmask.
-	if source := t.propagatingTags[key]; source != "" {
+	if source := t.propagatingTag(key); source != "" {
 		tSource, err := internal.ParseTraceSource(source)
 		if err != nil {
 			log.Error("failed to parse trace source tag: %s", err.Error())
 		}
-
 		tSource |= value
-
 		t.setPropagatingTagLocked(key, tSource.String())
 		return
 	}
-
 	t.setPropagatingTagLocked(key, value.String())
 }
 
@@ -59,10 +118,7 @@ func (t *trace) setTraceSourcePropagatingTag(key string, value internal.TraceSou
 // +checklocks:t.mu
 func (t *trace) setPropagatingTagLocked(key, value string) {
 	assert.RWMutexLocked(&t.mu)
-	if t.propagatingTags == nil {
-		t.propagatingTags = make(map[string]string, 1)
-	}
-	t.propagatingTags[key] = value
+	t.copyOnWriteSet(key, value)
 	if key == keyDecisionMaker {
 		t.dm = parseDecisionMaker(value)
 	}
@@ -78,41 +134,36 @@ func (t *trace) unsetPropagatingTag(key string) {
 // +checklocks:t.mu
 func (t *trace) unsetPropagatingTagLocked(key string) {
 	assert.RWMutexLocked(&t.mu)
-	delete(t.propagatingTags, key)
+	t.copyOnWriteDelete(key)
 	if key == keyDecisionMaker {
 		t.dm = 0
-	}
-}
-
-// iteratePropagatingTags allows safe iteration through the propagating tags of a trace.
-// the trace must not be modified during this call, as it is locked for reading.
-//
-// f should return whether the iteration should continue.
-func (t *trace) iteratePropagatingTags(f func(k, v string) bool) {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	for k, v := range t.propagatingTags {
-		if !f(k, v) {
-			break
-		}
 	}
 }
 
 func (t *trace) replacePropagatingTags(tags map[string]string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.propagatingTags = tags
-	if dm, ok := tags[keyDecisionMaker]; ok {
-		t.dm = parseDecisionMaker(dm)
-	} else {
+	if len(tags) == 0 {
+		t.propagatingTags.Store(nil)
 		t.dm = 0
+	} else {
+		// Clone so that the stored snapshot is immutable and independent of
+		// whatever the caller holds.
+		cp := maps.Clone(tags)
+		t.propagatingTags.Store(&cp)
+		if dm, ok := cp[keyDecisionMaker]; ok {
+			t.dm = parseDecisionMaker(dm)
+		} else {
+			t.dm = 0
+		}
 	}
 }
 
 func (t *trace) propagatingTagsLen() int {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	return len(t.propagatingTags)
+	if m := t.propagatingTags.Load(); m != nil {
+		return len(*m)
+	}
+	return 0
 }
 
 // parseDecisionMaker parses the decision maker string (e.g. "-4") into

--- a/ddtrace/tracer/propagating_tags_bench_test.go
+++ b/ddtrace/tracer/propagating_tags_bench_test.go
@@ -1,0 +1,194 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package tracer
+
+// BenchmarkTraceContention measures lock contention on trace.mu by running N
+// goroutines simultaneously in a tight loop, each doing the canonical outgoing-
+// call sequence (StartSpan → Inject → Finish) on the same shared trace.
+//
+// traceMaxSize is set large so the trace never fills up and every iteration
+// goes through the real lock path.
+//
+// How to read results:
+//   - ns/op CONSTANT or RISING with N → lock contention (goroutines waiting)
+//   - ns/op FALLING with N           → parallel speedup (no contention)
+//
+// Copy before benchmarking:
+//   cp /tmp/bench_outgoing_call_test.go ddtrace/tracer/
+//
+// Run: go test -bench=BenchmarkTraceContention -benchmem -benchtime=5s
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// BenchmarkInjectOnly measures the cost of a single Inject call with no concurrency.
+func BenchmarkInjectOnly(b *testing.B) {
+	trc, err := newTracer(withTransport(newDummyTransport()), withNoopStats())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer trc.Stop()
+	root := trc.StartSpan("server")
+	ctx := root.Context()
+	carrier := HTTPHeadersCarrier(http.Header{})
+	b.ResetTimer()
+	for range b.N {
+		_ = trc.Inject(ctx, carrier)
+	}
+	root.Finish()
+}
+
+// BenchmarkTraceMuContention isolates contention on trace.mu directly,
+// stripping all overhead so goroutines hit the lock as fast as possible.
+func BenchmarkTraceMuContention(b *testing.B) {
+	for _, n := range []int{1, 2, 4, 8, 16, 32, 64, 128} {
+		b.Run(fmt.Sprintf("goroutines_%03d", n), func(b *testing.B) {
+			t := newTrace()
+			var counter atomic.Int64
+			var wg sync.WaitGroup
+			b.ResetTimer()
+			for range n {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for counter.Add(1) <= int64(b.N) {
+						t.mu.Lock()
+						t.mu.Unlock()
+					}
+				}()
+			}
+			wg.Wait()
+		})
+	}
+}
+
+// BenchmarkInjectMultiG measures how inject throughput scales with goroutine count.
+// On main, every inject acquires t.mu.Lock (write lock) unconditionally — goroutines
+// serialize. On PR1, inject is lock-free — goroutines scale in parallel.
+//
+// Signal: ns/op RISING with N → write-lock contention (serialised).
+//         ns/op FALLING with N → parallel speedup (lock-free).
+func BenchmarkInjectMultiG(b *testing.B) {
+	for _, n := range []int{1, 2, 4, 8, 16, 32, 64} {
+		b.Run(fmt.Sprintf("goroutines_%03d", n), func(b *testing.B) {
+			trc, err := newTracer(withTransport(newDummyTransport()), withNoopStats())
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer trc.Stop()
+			root := trc.StartSpan("server")
+			ctx := root.Context()
+			var counter atomic.Int64
+			var wg sync.WaitGroup
+			b.ResetTimer()
+			for range n {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					carrier := HTTPHeadersCarrier(http.Header{})
+					for counter.Add(1) <= int64(b.N) {
+						_ = trc.Inject(ctx, carrier)
+					}
+				}()
+			}
+			wg.Wait()
+			root.Finish()
+		})
+	}
+}
+
+// BenchmarkInjectPushMuContention isolates the RW-mutex interaction between
+// inject (reader on main, lockless on PR1) and push (writer on both).
+// Half goroutines call trc.Inject — on main this acquires t.mu.RLock,
+// on PR1 it is completely lockless. Half goroutines acquire t.mu.Lock
+// directly, simulating what push() does.
+//
+// With -cpu=1 this forces goroutines to queue at the mutex, producing
+// superlinear growth on main and flat growth on PR1 if contention is reduced.
+func BenchmarkInjectPushMuContention(b *testing.B) {
+	for _, n := range []int{1, 2, 4, 8, 16, 32, 64, 128} {
+		b.Run(fmt.Sprintf("goroutines_%03d", n), func(b *testing.B) {
+			trc, err := newTracer(withTransport(newDummyTransport()), withNoopStats())
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer trc.Stop()
+
+			root := trc.StartSpan("server")
+			ctx := root.Context()
+			tr := root.context.trace
+
+			var counter atomic.Int64
+			var wg sync.WaitGroup
+
+			b.ResetTimer()
+
+			for i := range n {
+				wg.Add(1)
+				isInjector := i%2 != 0
+				go func() {
+					defer wg.Done()
+					carrier := HTTPHeadersCarrier(http.Header{})
+					for counter.Add(1) <= int64(b.N) {
+						if isInjector {
+							_ = trc.Inject(ctx, carrier)
+						} else {
+							tr.mu.Lock()
+							tr.mu.Unlock()
+						}
+					}
+				}()
+			}
+			wg.Wait()
+			root.Finish()
+		})
+	}
+}
+
+func BenchmarkTraceContention(b *testing.B) {
+	old := traceMaxSize
+	traceMaxSize = 1 << 27
+	b.Cleanup(func() { traceMaxSize = old })
+
+	for _, n := range []int{1, 2, 4, 8, 16, 32, 64, 128} {
+		b.Run(fmt.Sprintf("goroutines_%03d", n), func(b *testing.B) {
+			trc, err := newTracer(withTransport(newDummyTransport()), withNoopStats())
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer trc.Stop()
+
+			root := trc.StartSpan("server")
+			ctx := root.Context()
+
+			var counter atomic.Int64
+			var wg sync.WaitGroup
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for range n {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					carrier := HTTPHeadersCarrier(http.Header{})
+					for counter.Add(1) <= int64(b.N) {
+						child := trc.StartSpan("client", ChildOf(ctx))
+						_ = trc.Inject(ctx, carrier)
+						child.Finish()
+					}
+				}()
+			}
+			wg.Wait()
+			root.Finish()
+		})
+	}
+}

--- a/ddtrace/tracer/remote_config_test.go
+++ b/ddtrace/tracer/remote_config_test.go
@@ -88,14 +88,14 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		s.Finish()
 		rate, _ = getMetric(s, keyRulesSamplerAppliedRate)
 		require.Equal(t, 1.0, rate)
-		require.Equal(t, samplernames.RemoteUserRule.DecisionMaker(), s.context.trace.propagatingTags[keyDecisionMaker])
+		require.Equal(t, samplernames.RemoteUserRule.DecisionMaker(), s.context.trace.propagatingTag(keyDecisionMaker))
 		// Spans not matching the rule still gets the global rate
 		s = tracer.StartSpan("not.web.request")
 		s.Finish()
 		rate, _ = getMetric(s, keyRulesSamplerAppliedRate)
 		require.Equal(t, 0.5, rate)
 		if p, ok := s.context.trace.samplingPriority(); ok && p > 0 {
-			require.Equal(t, samplernames.RuleRate.DecisionMaker(), s.context.trace.propagatingTags[keyDecisionMaker])
+			require.Equal(t, samplernames.RuleRate.DecisionMaker(), s.context.trace.propagatingTag(keyDecisionMaker))
 		}
 
 		// Unset RC. Assert _dd.rule_psr is not set
@@ -169,7 +169,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		rate, _ := getMetric(s, keyRulesSamplerAppliedRate)
 		require.Equal(t, 0.1, rate)
 		if p, ok := s.context.trace.samplingPriority(); ok && p > 0 {
-			require.Equal(t, samplernames.RuleRate.DecisionMaker(), s.context.trace.propagatingTags[keyDecisionMaker])
+			require.Equal(t, samplernames.RuleRate.DecisionMaker(), s.context.trace.propagatingTag(keyDecisionMaker))
 		}
 
 		input := remoteconfig.ProductUpdate{
@@ -190,7 +190,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		s.Finish()
 		rate, _ = getMetric(s, keyRulesSamplerAppliedRate)
 		require.Equal(t, 1.0, rate)
-		require.Equal(t, samplernames.RemoteUserRule.DecisionMaker(), s.context.trace.propagatingTags[keyDecisionMaker])
+		require.Equal(t, samplernames.RemoteUserRule.DecisionMaker(), s.context.trace.propagatingTag(keyDecisionMaker))
 		// Spans not matching the rule gets the global rate, but not the local rule, which is no longer in effect
 		s = tracer.StartSpan("web.request")
 		s.resource = "not_abc"
@@ -198,7 +198,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		rate, _ = getMetric(s, keyRulesSamplerAppliedRate)
 		require.Equal(t, 0.5, rate)
 		if p, ok := s.context.trace.samplingPriority(); ok && p > 0 {
-			require.Equal(t, samplernames.RuleRate.DecisionMaker(), s.context.trace.propagatingTags[keyDecisionMaker])
+			require.Equal(t, samplernames.RuleRate.DecisionMaker(), s.context.trace.propagatingTag(keyDecisionMaker))
 		}
 
 		assertTelemetryConfig(t, telemetryClient.Configuration, "trace_sample_rate", 0.5, telemetry.OriginRemoteConfig)
@@ -231,7 +231,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		p, ok := s.context.trace.samplingPriority()
 		require.True(t, ok)
 		require.Equal(t, p, -1)
-		require.Empty(t, s.context.trace.propagatingTags[keyDecisionMaker])
+		require.Empty(t, s.context.trace.propagatingTag(keyDecisionMaker))
 
 		input := remoteconfig.ProductUpdate{
 			"path": []byte(`{"lib_config": {"tracing_sampling_rate": 0.5,
@@ -258,7 +258,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		s.Finish()
 		rate, _ = getMetric(s, keyRulesSamplerAppliedRate)
 		require.Equal(t, 1.0, rate)
-		require.Equal(t, samplernames.RemoteUserRule.DecisionMaker(), s.context.trace.propagatingTags[keyDecisionMaker])
+		require.Equal(t, samplernames.RemoteUserRule.DecisionMaker(), s.context.trace.propagatingTag(keyDecisionMaker))
 		// Spans not matching the rule gets the global rate, but not the local rule, which is no longer in effect
 		s = tracer.StartSpan("web.request")
 		s.resource = "not_abc"
@@ -271,7 +271,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		require.Equal(
 			t,
 			samplernames.RemoteDynamicRule.DecisionMaker(),
-			s.context.trace.propagatingTags[keyDecisionMaker],
+			s.context.trace.propagatingTag(keyDecisionMaker),
 		)
 
 		// Reset restores local rules
@@ -286,7 +286,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		p, ok = s.context.trace.samplingPriority()
 		require.True(t, ok)
 		require.Equal(t, p, -1)
-		require.Empty(t, s.context.trace.propagatingTags[keyDecisionMaker])
+		require.Empty(t, s.context.trace.propagatingTag(keyDecisionMaker))
 
 		assertCalled(t, telemetryClient, []telemetry.Configuration{
 			{Name: "trace_sample_rate", Value: 0.5, Origin: telemetry.OriginRemoteConfig},
@@ -331,7 +331,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		s.Finish()
 		rate, _ := getMetric(s, keyRulesSamplerAppliedRate)
 		require.Equal(t, 1.0, rate)
-		require.Equal(t, samplernames.RemoteUserRule.DecisionMaker(), s.context.trace.propagatingTags[keyDecisionMaker])
+		require.Equal(t, samplernames.RemoteUserRule.DecisionMaker(), s.context.trace.propagatingTag(keyDecisionMaker))
 
 		// A span with non-matching tags gets the global rate
 		s = tracer.StartSpan("web.request")

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -9,6 +9,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -237,9 +238,14 @@ func FromGenericCtx(c ddtrace.SpanContext) *SpanContext {
 		sc.trace = newTrace()
 	}
 	sc.trace.tags = ctx.Tags()                                    // +checklocksignore - Initialization time, not shared yet.
-	sc.trace.propagatingTags = ctx.PropagatingTags()              // +checklocksignore - Initialization time, not shared yet.
-	if dm, ok := sc.trace.propagatingTags[keyDecisionMaker]; ok { // +checklocksignore - Initialization time, not shared yet.
-		sc.trace.dm = parseDecisionMaker(dm) // +checklocksignore - Initialization time, not shared yet.
+	if pt := ctx.PropagatingTags(); len(pt) > 0 { // +checklocksignore - Initialization time, not shared yet.
+		// Clone the map so that the atomic.Pointer snapshot is immutable and
+		// independent of whatever the adapter holds internally.
+		cp := maps.Clone(pt)
+		sc.trace.propagatingTags.Store(&cp)
+		if dm, ok := cp[keyDecisionMaker]; ok {
+			sc.trace.dm = parseDecisionMaker(dm)
+		}
 	}
 	return &sc
 }
@@ -284,6 +290,13 @@ func newSpanContext(span *Span, parent *SpanContext) *SpanContext {
 	if context.trace.root == nil {
 		// first span in the trace can safely be assumed to be the root
 		context.trace.root = span
+		// Pre-populate _dd.p.tid once at root-span creation so that Inject()
+		// finds it already written and skips the write lock on every outgoing
+		// call. Only add if not already present (extracted contexts may carry
+		// it from incoming headers).
+		if context.traceID.HasUpper() && !context.trace.hasPropagatingTag(keyTraceID128) {
+			context.trace.setPropagatingTag(keyTraceID128, context.traceID.UpperHex())
+		}
 	}
 	// put span in context's trace
 	context.trace.push(span)
@@ -490,9 +503,10 @@ type trace struct {
 	// trace level tags
 	// +checklocks:mu
 	tags map[string]string
-	// trace level tags that will be propagated across service boundaries
-	// +checklocks:mu
-	propagatingTags map[string]string
+	// trace level tags that will be propagated across service boundaries.
+	// Stored as an atomic.Pointer to an immutable snapshot so that readers
+	// (e.g. Inject) are lock-free. Writers hold mu and use copy-on-write.
+	propagatingTags atomic.Pointer[map[string]string]
 	// the number of finished spans
 	// +checklocks:mu
 	finished int
@@ -631,7 +645,8 @@ func (t *trace) setSamplingPriorityLockedWithForce(p int, sampler samplernames.S
 	updatedPriority := old == nil || *old != float64(p)
 
 	t.priority.Store(samplingPriorityPtr(p)) // +checklocksignore
-	curDM, existed := t.propagatingTags[keyDecisionMaker]
+	curDM := t.propagatingTag(keyDecisionMaker)
+	existed := curDM != ""
 	if p > 0 && sampler != samplernames.Unknown {
 		// We have a positive priority and the sampling mechanism isn't set.
 		// Send nothing when sampler is `Unknown` for RFC compliance.
@@ -711,8 +726,10 @@ func (t *trace) setTraceTagsLocked(s *Span) {
 	for k, v := range t.tags {
 		s.setMetaLocked(k, v)
 	}
-	for k, v := range t.propagatingTags {
-		s.setMetaLocked(k, v)
+	if m := t.propagatingTags.Load(); m != nil {
+		for k, v := range *m {
+			s.setMetaLocked(k, v)
+		}
 	}
 	updateTracerGitMetadataTags(s)
 	if s.context != nil && s.context.traceID.HasUpper() {

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -1129,51 +1129,61 @@ func BenchmarkBaggageItemEmpty(b *testing.B) {
 	}
 }
 
+func TestReplacePropagatingTagsImmutability(t *testing.T) {
+	// Mutating the input map after replacePropagatingTags must not affect the
+	// stored snapshot — lock-free readers rely on the map being immutable.
+	var tr trace
+	tags := map[string]string{"key": "original"}
+	tr.replacePropagatingTags(tags)
+
+	tags["key"] = "mutated"
+	tags["extra"] = "added"
+
+	assert.Equal(t, "original", tr.propagatingTag("key"))
+	assert.Equal(t, "", tr.propagatingTag("extra"))
+}
+
 func TestSetSamplingPriorityLocked(t *testing.T) {
 	t.Run("NoPriorAndP0IsIgnored", func(t *testing.T) {
-		tr := trace{
-			propagatingTags: map[string]string{},
-		}
+		var tr trace
 		tr.mu.Lock()
 		tr.setSamplingPriorityLocked(ext.PriorityAutoReject, samplernames.RemoteRate)
 		tr.mu.Unlock()
-		assert.Empty(t, tr.propagatingTags[keyDecisionMaker])
+		assert.Empty(t, tr.propagatingTag(keyDecisionMaker))
 	})
 	t.Run("UnknownSamplerIsIgnored", func(t *testing.T) {
-		tr := trace{
-			propagatingTags: map[string]string{},
-		}
+		var tr trace
 		tr.mu.Lock()
 		tr.setSamplingPriorityLocked(ext.PriorityAutoReject, samplernames.Unknown)
 		tr.mu.Unlock()
-		assert.Empty(t, tr.propagatingTags[keyDecisionMaker])
+		assert.Empty(t, tr.propagatingTag(keyDecisionMaker))
 	})
 	t.Run("NoPriorAndP1IsAccepted", func(t *testing.T) {
-		tr := trace{
-			propagatingTags: map[string]string{},
-		}
+		var tr trace
 		tr.mu.Lock()
 		tr.setSamplingPriorityLocked(ext.PriorityAutoKeep, samplernames.RemoteRate)
 		tr.mu.Unlock()
-		assert.Equal(t, "-2", tr.propagatingTags[keyDecisionMaker])
+		assert.Equal(t, "-2", tr.propagatingTag(keyDecisionMaker))
 	})
 	t.Run("PriorAndP1AndSameDMIsIgnored", func(t *testing.T) {
-		tr := trace{
-			propagatingTags: map[string]string{keyDecisionMaker: "-1"},
-		}
+		var tr trace
+		m := map[string]string{keyDecisionMaker: "-1"}
+		tr.propagatingTags.Store(&m)
+		tr.dm = parseDecisionMaker("-1")
 		tr.mu.Lock()
 		tr.setSamplingPriorityLocked(ext.PriorityAutoKeep, samplernames.AgentRate)
 		tr.mu.Unlock()
-		assert.Equal(t, "-1", tr.propagatingTags[keyDecisionMaker])
+		assert.Equal(t, "-1", tr.propagatingTag(keyDecisionMaker))
 	})
 	t.Run("PriorAndP1DifferentDMAccepted", func(t *testing.T) {
-		tr := trace{
-			propagatingTags: map[string]string{keyDecisionMaker: "-1"},
-		}
+		var tr trace
+		m := map[string]string{keyDecisionMaker: "-1"}
+		tr.propagatingTags.Store(&m)
+		tr.dm = parseDecisionMaker("-1")
 		tr.mu.Lock()
 		tr.setSamplingPriorityLocked(ext.PriorityAutoKeep, samplernames.RemoteRate)
 		tr.mu.Unlock()
-		assert.Equal(t, "-2", tr.propagatingTags[keyDecisionMaker])
+		assert.Equal(t, "-2", tr.propagatingTag(keyDecisionMaker))
 	})
 }
 

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -435,10 +435,15 @@ func (p *propagator) injectTextMap(spanCtx *SpanContext, writer TextMapWriter) e
 	if ctx.traceID.Empty() || ctx.spanID == 0 {
 		return ErrInvalidSpanContext
 	}
-	// propagate the TraceID and the current active SpanID
+	// propagate the TraceID and the current active SpanID.
+	// traceID.Upper is immutable after span creation, so check before writing
+	// to avoid a write lock on every Inject call (lock-free read path).
 	if ctx.traceID.HasUpper() {
-		setPropagatingTag(ctx, keyTraceID128, ctx.traceID.UpperHex())
-	} else if ctx.trace != nil {
+		upper := ctx.traceID.UpperHex()
+		if ctx.trace == nil || ctx.trace.propagatingTag(keyTraceID128) != upper {
+			setPropagatingTag(ctx, keyTraceID128, upper)
+		}
+	} else if ctx.trace != nil && ctx.trace.hasPropagatingTag(keyTraceID128) {
 		ctx.trace.unsetPropagatingTag(keyTraceID128)
 	}
 	writer.Set(p.cfg.TraceHeader, strconv.FormatUint(ctx.traceID.Lower(), 10))
@@ -868,11 +873,14 @@ func (*propagatorW3c) injectTextMap(spanCtx *SpanContext, writer TextMapWriter) 
 
 	var traceID string
 	if ctx.traceID.HasUpper() {
-		setPropagatingTag(ctx, keyTraceID128, ctx.traceID.UpperHex())
+		upper := ctx.traceID.UpperHex()
+		if ctx.trace == nil || ctx.trace.propagatingTag(keyTraceID128) != upper {
+			setPropagatingTag(ctx, keyTraceID128, upper)
+		}
 		traceID = ctx.TraceID()
 	} else {
 		traceID = ctx.TraceID()
-		if ctx.trace != nil {
+		if ctx.trace != nil && ctx.trace.hasPropagatingTag(keyTraceID128) {
 			ctx.trace.unsetPropagatingTag(keyTraceID128)
 		}
 	}

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -342,10 +342,8 @@ func TestTextMapPropagatorTraceTagsWithPriority(t *testing.T) {
 	assert.Nil(t, err)
 	child := tracer.StartSpan("test", ChildOf(ctx))
 	childSpanID := child.Context().spanID
-	assert.Equal(t, map[string]string{
-		"hello":    "world=",
-		"_dd.p.dm": "934086a6-4",
-	}, ctx.trace.propagatingTags)
+	assert.Equal(t, "world=", ctx.trace.propagatingTag("hello"))
+	assert.Equal(t, "934086a6-4", ctx.trace.propagatingTag("_dd.p.dm"))
 	dst := map[string]string{}
 	err = tracer.Inject(child.Context(), TextMapCarrier(dst))
 	assert.Nil(t, err)
@@ -371,10 +369,8 @@ func TestTextMapPropagatorTraceTagsWithoutPriority(t *testing.T) {
 	assert.Nil(t, err)
 	child := tracer.StartSpan("test", ChildOf(ctx))
 	childSpanID := child.Context().spanID
-	assert.Equal(t, map[string]string{
-		"hello":    "world",
-		"_dd.p.dm": "-1",
-	}, ctx.trace.propagatingTags)
+	assert.Equal(t, "world", ctx.trace.propagatingTag("hello"))
+	assert.Equal(t, "-1", ctx.trace.propagatingTag("_dd.p.dm"))
 	dst := map[string]string{}
 	err = tracer.Inject(child.Context(), TextMapCarrier(dst))
 	assert.Nil(t, err)
@@ -417,9 +413,9 @@ func Test257CharacterDDTracestateLengh(t *testing.T) {
 	ctx.origin = "rum"
 	ctx.traceID = traceIDFrom64Bits(1)
 	ctx.spanID = 2
-	ctx.trace.propagatingTags = map[string]string{
+	ctx.trace.replacePropagatingTags(map[string]string{
 		"tracestate": "valid_vendor=a:1",
-	}
+	})
 	// need to create a tracestate where the dd portion will be 257 chars long
 	// we currently have:
 	// 3 chars ->  dd=
@@ -435,8 +431,8 @@ func Test257CharacterDDTracestateLengh(t *testing.T) {
 	longKey := strings.Repeat("a", 234) // 234 is correct num for 257
 	shortKey := "a"
 
-	ctx.trace.propagatingTags[fmt.Sprintf("_dd.p.%s", shortKey)] = "0"
-	ctx.trace.propagatingTags[fmt.Sprintf("_dd.p.%s", longKey)] = "0"
+	ctx.trace.setPropagatingTag(fmt.Sprintf("_dd.p.%s", shortKey), "0")
+	ctx.trace.setPropagatingTag(fmt.Sprintf("_dd.p.%s", longKey), "0")
 
 	headers := TextMapCarrier(map[string]string{})
 	err = tracer.Inject(ctx, headers)
@@ -714,7 +710,7 @@ func TestExtractTraceTagsHeaderDisabled(t *testing.T) {
 	// Disabled extract: no propagating tags, no error tag.
 	_, hasErr := ctx.trace.tags["_dd.propagation_error"]
 	assert.False(t, hasErr)
-	assert.Empty(t, ctx.trace.propagatingTags)
+	assert.Zero(t, ctx.trace.propagatingTagsLen())
 }
 
 func TestEnvVars(t *testing.T) {
@@ -1387,7 +1383,13 @@ func TestEnvVars(t *testing.T) {
 					assert.True(ok)
 					assert.Equal(int(tc.out[1]), p)
 
-					assert.Equal(tc.propagatingTags, ctx.trace.propagatingTags)
+					if tc.propagatingTags != nil {
+						var got map[string]string
+						if m := ctx.trace.propagatingTags.Load(); m != nil {
+							got = *m
+						}
+						assert.Equal(tc.propagatingTags, got)
+					}
 				})
 			}
 		}
@@ -1688,7 +1690,7 @@ func TestEnvVars(t *testing.T) {
 					ctx.origin = tc.origin
 					ctx.traceID = tc.tid
 					ctx.spanID = tc.sid
-					ctx.trace.propagatingTags = tc.propagatingTags
+					ctx.trace.replacePropagatingTags(tc.propagatingTags)
 					ctx.reparentID = "0123456789abcdef"
 					headers := TextMapCarrier(map[string]string{})
 					err = tracer.Inject(ctx, headers)
@@ -1718,12 +1720,12 @@ func TestEnvVars(t *testing.T) {
 					ctx.origin = "old_tracestate"
 					ctx.traceID = traceIDFrom64Bits(1229782938247303442)
 					ctx.spanID = 2459565876494606882
-					ctx.trace.propagatingTags = map[string]string{
+					ctx.trace.replacePropagatingTags(map[string]string{
 						"tracestate": "valid_vendor=a:1",
-					}
+					})
 					// dd part of the tracestate must not exceed 256 characters
 					for i := range 32 {
-						ctx.trace.propagatingTags[fmt.Sprintf("_dd.p.a%v", i)] = "i"
+						ctx.trace.setPropagatingTag(fmt.Sprintf("_dd.p.a%v", i), "i")
 					}
 					headers := TextMapCarrier(map[string]string{})
 					err = tracer.Inject(ctx, headers)
@@ -2477,9 +2479,14 @@ func FuzzMarshalPropagatingTags(f *testing.F) {
 			t.Skipf("Skipping invalid tags")
 		}
 		unmarshalPropagatingTags(recvCtx, marshal, pConfig.MaxTagsHeaderLen)
-		marshaled := sendCtx.trace.propagatingTags
-		unmarshaled := recvCtx.trace.propagatingTags
-		if !reflect.DeepEqual(sendCtx.trace.propagatingTags, recvCtx.trace.propagatingTags) {
+		var marshaled, unmarshaled map[string]string
+		if m := sendCtx.trace.propagatingTags.Load(); m != nil {
+			marshaled = *m
+		}
+		if m := recvCtx.trace.propagatingTags.Load(); m != nil {
+			unmarshaled = *m
+		}
+		if !reflect.DeepEqual(marshaled, unmarshaled) {
 			t.Fatalf("Inconsistent marshaling/unmarshaling: (%q) is different from (%q)", marshaled, unmarshaled)
 		}
 	})
@@ -2531,14 +2538,19 @@ func FuzzComposeTracestate(f *testing.F) {
 		traceState := composeTracestate(sendCtx, priority, oldState)
 		parseTracestate(recvCtx, traceState)
 		setPropagatingTag(sendCtx, tracestateHeader, traceState)
-		if !reflect.DeepEqual(sendCtx.trace.propagatingTags, recvCtx.trace.propagatingTags) {
+		var sendPTags, recvPTags map[string]string
+		if m := sendCtx.trace.propagatingTags.Load(); m != nil {
+			sendPTags = *m
+		}
+		if m := recvCtx.trace.propagatingTags.Load(); m != nil {
+			recvPTags = *m
+		}
+		if !reflect.DeepEqual(sendPTags, recvPTags) {
 			t.Fatalf(`Inconsistent composing/parsing:
 			pre compose: (%q)
 			is different from
 			parsed: (%q)
-			for tracestate of: (%s)`, sendCtx.trace.propagatingTags,
-				recvCtx.trace.propagatingTags,
-				traceState)
+			for tracestate of: (%s)`, sendPTags, recvPTags, traceState)
 		}
 	})
 }

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -325,7 +325,7 @@ func TestTracerStartSpan(t *testing.T) {
 			ext.PriorityAutoReject,
 			ext.PriorityAutoKeep,
 		}, span.metrics[keySamplingPriority])
-		assert.Equal("-1", span.context.trace.propagatingTags[keyDecisionMaker])
+		assert.Equal("-1", span.context.trace.propagatingTag(keyDecisionMaker))
 		// A span is not measured unless made so specifically
 		_, ok := span.meta.Get(keyMeasured)
 		assert.False(ok)
@@ -340,7 +340,7 @@ func TestTracerStartSpan(t *testing.T) {
 		assert.NoError(t, err)
 		span := tracer.StartSpan("web.request", Tag(ext.ManualKeep, true))
 		assert.Equal(t, float64(ext.PriorityUserKeep), span.metrics[keySamplingPriority])
-		assert.Equal(t, "-4", span.context.trace.propagatingTags[keyDecisionMaker])
+		assert.Equal(t, "-4", span.context.trace.propagatingTag(keyDecisionMaker))
 	})
 
 	t.Run("name", func(t *testing.T) {
@@ -423,7 +423,7 @@ func TestSamplingDecision(t *testing.T) {
 		assert.Equal(t, uint32(0), tracerstats.Count(tracerstats.DroppedP0Traces))
 		assert.Equal(t, uint32(0), tracerstats.Count(tracerstats.DroppedP0Spans))
 		assert.Equal(t, float64(ext.PriorityAutoKeep), span.metrics[keySamplingPriority])
-		assert.Equal(t, "-1", span.context.trace.propagatingTags[keyDecisionMaker])
+		assert.Equal(t, "-1", span.context.trace.propagatingTag(keyDecisionMaker))
 		assert.Equal(t, decisionKeep, span.context.trace.samplingDecision)
 	})
 
@@ -442,7 +442,7 @@ func TestSamplingDecision(t *testing.T) {
 		assert.Equal(t, uint32(0), tracerstats.Count(tracerstats.DroppedP0Traces))
 		assert.Equal(t, uint32(2), tracerstats.Count(tracerstats.DroppedP0Spans))
 		assert.Equal(t, float64(ext.PriorityAutoReject), span.metrics[keySamplingPriority])
-		assert.Equal(t, "", span.context.trace.propagatingTags[keyDecisionMaker])
+		assert.Equal(t, "", span.context.trace.propagatingTag(keyDecisionMaker))
 		assert.Equal(t, decisionKeep, span.context.trace.samplingDecision)
 	})
 
@@ -459,7 +459,7 @@ func TestSamplingDecision(t *testing.T) {
 		assert.Equal(t, uint32(1), tracerstats.Count(tracerstats.DroppedP0Traces))
 		assert.Equal(t, uint32(2), tracerstats.Count(tracerstats.DroppedP0Spans))
 		assert.Equal(t, float64(ext.PriorityAutoReject), span.metrics[keySamplingPriority])
-		assert.Equal(t, "", span.context.trace.propagatingTags[keyDecisionMaker])
+		assert.Equal(t, "", span.context.trace.propagatingTag(keyDecisionMaker))
 		assert.Equal(t, decisionNone, span.context.trace.samplingDecision)
 	})
 
@@ -501,7 +501,7 @@ func TestSamplingDecision(t *testing.T) {
 		assert.Equal(t, float64(ext.PriorityAutoReject), span.metrics[keySamplingPriority])
 		// this trace won't be sent to the agent,
 		// therefore not necessary to populate keyDecisionMaker
-		assert.Equal(t, "", span.context.trace.propagatingTags[keyDecisionMaker])
+		assert.Equal(t, "", span.context.trace.propagatingTag(keyDecisionMaker))
 		assert.Equal(t, decisionDrop, span.context.trace.samplingDecision)
 	})
 
@@ -1065,7 +1065,7 @@ func TestTracerSamplingPriorityPropagation(t *testing.T) {
 	root := tracer.StartSpan("web.request", Tag(ext.ManualKeep, true))
 	child := tracer.StartSpan("db.query", ChildOf(root.Context()))
 	assert.EqualValues(2, root.metrics[keySamplingPriority])
-	assert.Equal("-4", root.context.trace.propagatingTags[keyDecisionMaker])
+	assert.Equal("-4", root.context.trace.propagatingTag(keyDecisionMaker))
 	assert.EqualValues(2, child.metrics[keySamplingPriority])
 	assert.EqualValues(2., *root.context.trace.priority.Load())
 	assert.EqualValues(2., *child.context.trace.priority.Load())
@@ -1084,7 +1084,7 @@ func TestTracerSamplingPriorityEmptySpanCtx(t *testing.T) {
 	}
 	child := tracer.StartSpan("db.query", ChildOf(spanCtx))
 	assert.EqualValues(1, child.metrics[keySamplingPriority])
-	assert.Equal("-1", child.context.trace.propagatingTags[keyDecisionMaker])
+	assert.Equal("-1", child.context.trace.propagatingTag(keyDecisionMaker))
 }
 
 func TestTracerDDUpstreamServicesManualKeep(t *testing.T) {
@@ -1102,7 +1102,7 @@ func TestTracerDDUpstreamServicesManualKeep(t *testing.T) {
 	grandChild := tracer.StartSpan("db.query", ChildOf(child.Context()))
 	grandChild.SetTag(ext.ManualDrop, true)
 	grandChild.SetTag(ext.ManualKeep, true)
-	assert.Equal("-4", grandChild.context.trace.propagatingTags[keyDecisionMaker])
+	assert.Equal("-4", grandChild.context.trace.propagatingTag(keyDecisionMaker))
 }
 
 func TestTracerBaggageImmutability(t *testing.T) {
@@ -1375,7 +1375,7 @@ func TestTracerPrioritySampler(t *testing.T) {
 	s := tr.newEnvSpan("pylons", "")
 	assert.Equal(1., s.metrics[keySamplingPriorityRate])
 	assert.Equal(1., s.metrics[keySamplingPriority])
-	assert.Equal("-1", s.context.trace.propagatingTags[keyDecisionMaker])
+	assert.Equal("-1", s.context.trace.propagatingTag(keyDecisionMaker))
 	p, ok := s.context.SamplingPriority()
 	assert.True(ok)
 	assert.EqualValues(p, s.metrics[keySamplingPriority])
@@ -1428,9 +1428,9 @@ func TestTracerPrioritySampler(t *testing.T) {
 		assert.Equal(tt.rate, s.metrics[keySamplingPriorityRate], strconv.Itoa(i))
 		prio, ok := s.metrics[keySamplingPriority]
 		if prio > 0 {
-			assert.Equal("-1", s.context.trace.propagatingTags[keyDecisionMaker])
+			assert.Equal("-1", s.context.trace.propagatingTag(keyDecisionMaker))
 		} else {
-			assert.Equal("", s.context.trace.propagatingTags[keyDecisionMaker])
+			assert.Equal("", s.context.trace.propagatingTag(keyDecisionMaker))
 		}
 		assert.True(ok)
 		assert.Contains([]float64{0, 1}, prio)
@@ -2719,7 +2719,7 @@ func TestUserMonitoring(t *testing.T) {
 		v, _ := s.meta.Get(keyUserID)
 		assert.Equal(t, id, v)
 		encoded := base64.StdEncoding.EncodeToString([]byte(id))
-		assert.Equal(t, encoded, s.context.trace.propagatingTags[keyPropagatedUserID])
+		assert.Equal(t, encoded, s.context.trace.propagatingTag(keyPropagatedUserID))
 		v, _ = s.meta.Get(keyPropagatedUserID)
 		assert.Equal(t, encoded, v)
 	})
@@ -2732,8 +2732,7 @@ func TestUserMonitoring(t *testing.T) {
 		assert.True(t, ok)
 		_, ok = s.meta.Get(keyPropagatedUserID)
 		assert.False(t, ok)
-		_, ok = s.context.trace.propagatingTags[keyPropagatedUserID]
-		assert.False(t, ok)
+		assert.False(t, s.context.trace.hasPropagatingTag(keyPropagatedUserID))
 	})
 
 	// This tests data races for trace.propagatingTags reads/writes through public API.


### PR DESCRIPTION
Shadow of #4740 to run the full-CI suite.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
