### PR TITLE
feat(llmobs): add MetricKey constants for cache breakdown and other token metrics

### DIFF
--- a/llmobs/option.go
+++ b/llmobs/option.go
@@ -23,6 +23,27 @@ const (
 
 	// MetricKeyTotalTokens is the standard key for total token count metrics.
 	MetricKeyTotalTokens = "total_tokens"
+
+	// MetricKeyCacheReadInputTokens is the standard key for cache read input token count metrics.
+	MetricKeyCacheReadInputTokens = "cache_read_input_tokens"
+
+	// MetricKeyCacheWriteInputTokens is the standard key for cache write input token count metrics.
+	MetricKeyCacheWriteInputTokens = "cache_write_input_tokens"
+
+	// MetricKeyEphemeral1HInputTokens is the standard key for ephemeral 1-hour cache write input token count metrics.
+	MetricKeyEphemeral1HInputTokens = "ephemeral_1h_input_tokens"
+
+	// MetricKeyEphemeral5MInputTokens is the standard key for ephemeral 5-minute cache write input token count metrics.
+	MetricKeyEphemeral5MInputTokens = "ephemeral_5m_input_tokens"
+
+	// MetricKeyReasoningOutputTokens is the standard key for reasoning output token count metrics.
+	MetricKeyReasoningOutputTokens = "reasoning_output_tokens"
+
+	// MetricKeyBillableCharacterCount is the standard key for billable character count metrics.
+	MetricKeyBillableCharacterCount = "billable_character_count"
+
+	// MetricKeyTimeToFirstToken is the standard key for time-to-first-token metrics.
+	MetricKeyTimeToFirstToken = "time_to_first_token"
 )
 
 // ------------- Start options -------------


### PR DESCRIPTION
- Add `MetricKey*` constants in `llmobs/option.go` for cache read/write input tokens, ephemeral 1h/5m input tokens, reasoning output tokens, billable character count, and time-to-first-token.
- Reaches parity with the dd-trace-py constants in `ddtrace/llmobs/_constants.py`.

Fixes #4769