### PR TITLE
fix(appsec/proxy): avoid nil mutex panic for out-of-order body messages

### DIFF
--- a/instrumentation/appsec/proxy/message_processor.go
+++ b/instrumentation/appsec/proxy/message_processor.go
@@ -130,6 +130,10 @@ func (mp *Processor) OnRequestHeaders(ctx context.Context, req RequestHeaders) (
 // Once the whole body has been received, it will try to parse it following the Content-Type header
 // and if the body is not too large, it will be analyzed by the WAF
 func (mp *Processor) OnRequestBody(req HTTPBody, reqState *RequestState) error {
+	if reqState.Mu == nil {
+		return errors.New("received request body too early")
+	}
+
 	reqState.Mu.Lock()
 	defer reqState.Mu.Unlock()
 
@@ -219,6 +223,10 @@ func (mp *Processor) OnResponseHeaders(res ResponseHeaders, reqState *RequestSta
 // Once the whole body has been received, it will try to parse it following the Content-Type header
 // and if the body is not too large, it will be analyzed by the WAF
 func (mp *Processor) OnResponseBody(resp HTTPBody, reqState *RequestState) error {
+	if reqState.Mu == nil {
+		return fmt.Errorf("received response body too early: %v", reqState.State)
+	}
+
 	reqState.Mu.Lock()
 	defer reqState.Mu.Unlock()
 

--- a/instrumentation/appsec/proxy/metrics_test.go
+++ b/instrumentation/appsec/proxy/metrics_test.go
@@ -208,6 +208,6 @@ func TestOnBody_ZeroValueRequestStateDoesNotPanic(t *testing.T) {
 
 	require.NotPanics(t, func() {
 		err := mp.OnResponseBody(fakeBody{b: []byte("a"), eos: true}, &reqState)
-		require.EqualError(t, err, "received response body too early: 0")
+		require.EqualError(t, err, "received response body too early: <Unknown>")
 	})
 }

--- a/instrumentation/appsec/proxy/metrics_test.go
+++ b/instrumentation/appsec/proxy/metrics_test.go
@@ -184,3 +184,30 @@ func TestOnBody_SubmitsBodySize_ByDirection(t *testing.T) {
 		})
 	}
 }
+
+func TestOnBody_ZeroValueRequestStateDoesNotPanic(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	appsec.Start()
+	defer appsec.Stop()
+
+	instr := instrumentation.Load(instrumentation.PackageEnvoyProxyGoControlPlane)
+	mp := NewProcessor(ProcessorConfig{
+		BlockingUnavailable: false,
+		Framework:           "test-framework",
+		ContinueMessageFunc: func(_ context.Context, _ ContinueActionOptions) error { return nil },
+		BlockMessageFunc:    func(_ context.Context, _ BlockActionOptions) error { return nil },
+	}, instr)
+	defer mp.Close()
+
+	var reqState RequestState
+	require.NotPanics(t, func() {
+		err := mp.OnRequestBody(fakeBody{b: []byte("a"), eos: true}, &reqState)
+		require.EqualError(t, err, "received request body too early")
+	})
+
+	require.NotPanics(t, func() {
+		err := mp.OnResponseBody(fakeBody{b: []byte("a"), eos: true}, &reqState)
+		require.EqualError(t, err, "received response body too early: 0")
+	})
+}


### PR DESCRIPTION
### Motivation
- Prevent a nil-pointer panic when Envoy ext_proc sends out-of-order RequestBody/ResponseBody messages to a zero-value `RequestState` whose `Mu` is `nil`.
- Preserve previous behavior of returning the existing "received ... body too early" errors for body frames that arrive before headers initialize the request state.

### Description
- Guard `OnRequestBody` and `OnResponseBody` with a `nil` check on `reqState.Mu` and return the existing early-body error instead of attempting to lock a nil mutex (file: `instrumentation/appsec/proxy/message_processor.go`).
- Add a regression test `TestOnBody_ZeroValueRequestStateDoesNotPanic` that exercises a zero-value `RequestState` and asserts the handlers do not panic and return the expected error (file: `instrumentation/appsec/proxy/metrics_test.go`).
- Changes are minimal and focused only on avoiding the nil-mutex crash while keeping current semantics for out-of-order messages.

### Testing
- Added unit test `TestOnBody_ZeroValueRequestStateDoesNotPanic` under `./instrumentation/appsec/proxy`; the test asserts no panic and the expected early-body errors are returned.
- Attempted to run the test locally with `GOTOOLCHAIN=local go test ./instrumentation/appsec/proxy -run TestOnBody_ZeroValueRequestStateDoesNotPanic -count=1`, but execution failed due to the environment Go toolchain mismatch (`go.work` requires Go >= 1.25.0 while the runtime provides Go 1.23.8), so automated test execution did not complete in this environment.
- No other automated test runs were performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0c394a2200832487f3368598e7e678)