### PR TITLE
feat(contrib/aws/aws-sdk-go-v2): add Data Streams Monitoring for SQS

### DIFF
--- a/contrib/aws/aws-sdk-go-v2/aws/aws.go
+++ b/contrib/aws/aws-sdk-go-v2/aws/aws.go
@@ -110,10 +110,14 @@ func (mw *traceMiddleware) startTraceMiddleware(stack *middleware.Stack) error {
 			tracer.Tag(ext.Component, componentName),
 			tracer.Tag(ext.SpanKind, ext.SpanKindClient),
 		}
+		var sqsQueueName string
 		resourceTags, ok := resourceTagsFromParams(in, serviceID, region, partition)
 		if !ok {
 			instr.Logger().Debug("attempted to extract resourceTagsFromParams of an unsupported AWS service: %s", serviceID)
 		} else {
+			if serviceID == "SQS" {
+				sqsQueueName = resourceTags[ext.SQSQueueName]
+			}
 			for k, v := range resourceTags {
 				if v != "" {
 					opts = append(opts, tracer.Tag(k, v))
@@ -131,7 +135,7 @@ func (mw *traceMiddleware) startTraceMiddleware(stack *middleware.Stack) error {
 		// Inject trace context
 		switch serviceID {
 		case "SQS":
-			sqsTracer.EnrichOperation(spanctx, span, in, operation)
+			sqsTracer.EnrichOperation(spanctx, span, in, operation, mw.cfg.dataStreamsEnabled)
 		case "SNS":
 			snsTracer.EnrichOperation(spanctx, span, in, operation)
 		case "Kinesis":
@@ -149,6 +153,12 @@ func (mw *traceMiddleware) startTraceMiddleware(stack *middleware.Stack) error {
 		if err != nil && (mw.cfg.errCheck == nil || mw.cfg.errCheck(err)) {
 			span.SetTag(ext.Error, err)
 		}
+
+		// Post-process the response (e.g. SQS consume DSM checkpoints).
+		if serviceID == "SQS" && err == nil {
+			sqsTracer.EnrichOperationOutput(out, operation, mw.cfg.dataStreamsEnabled, sqsQueueName)
+		}
+
 		span.Finish()
 
 		return out, metadata, err

--- a/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
+++ b/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
@@ -294,7 +294,7 @@ func TestAppendMiddlewareSqsSendMessage(t *testing.T) {
 		EndpointResolver: resolver,
 	}
 
-	AppendMiddleware(&awsCfg)
+	AppendMiddleware(&awsCfg, WithDataStreams())
 
 	sqsClient := sqs.NewFromConfig(awsCfg)
 	sendMessageInput := &sqs.SendMessageInput{
@@ -348,6 +348,57 @@ func TestAppendMiddlewareSqsSendMessage(t *testing.T) {
 	pathway, ok := datastreams.PathwayFromContext(datastreams.ExtractFromBase64Carrier(context.Background(), tracer.TextMapCarrier(traceContext)))
 	require.True(t, ok)
 	assert.Equal(t, expectedPathway.GetHash(), pathway.GetHash())
+}
+
+func TestAppendMiddlewareSqsWithDataStreams(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	server := mockAWS(200)
+	defer server.Close()
+
+	resolver := aws.EndpointResolverFunc(func(_, _ string) (aws.Endpoint, error) {
+		return aws.Endpoint{
+			PartitionID:   "aws",
+			URL:           server.URL,
+			SigningRegion: "eu-west-1",
+		}, nil
+	})
+
+	awsCfg := aws.Config{
+		Region:           "eu-west-1",
+		Credentials:      aws.AnonymousCredentials{},
+		EndpointResolver: resolver,
+	}
+
+	AppendMiddleware(&awsCfg, WithDataStreams())
+
+	queueName := "MyQueueName"
+	sqsClient := sqs.NewFromConfig(awsCfg)
+	sendInput := &sqs.SendMessageInput{
+		MessageBody: aws.String("hello"),
+		QueueUrl:    aws.String("https://sqs.eu-west-1.amazonaws.com/123456789012/" + queueName),
+	}
+	_, err := sqsClient.SendMessage(context.Background(), sendInput)
+	require.NoError(t, err)
+
+	require.NotNil(t, sendInput.MessageAttributes)
+	ddAttr, ok := sendInput.MessageAttributes["_datadog"]
+	require.True(t, ok)
+
+	var carrier map[string]string
+	require.NoError(t, json.Unmarshal([]byte(*ddAttr.StringValue), &carrier))
+	assert.Contains(t, carrier, "x-datadog-trace-id")
+
+	pathwayKey := ""
+	for k := range carrier {
+		if strings.HasPrefix(k, "dd-pathway-ctx") {
+			pathwayKey = k
+			break
+		}
+	}
+	require.NotEmpty(t, pathwayKey, "expected DSM pathway key in carrier, got: %v", carrier)
+	assert.NotEmpty(t, carrier[pathwayKey])
 }
 
 func TestAppendMiddlewareS3ListObjects(t *testing.T) {

--- a/contrib/aws/aws-sdk-go-v2/aws/option.go
+++ b/contrib/aws/aws-sdk-go-v2/aws/option.go
@@ -12,10 +12,11 @@ import (
 )
 
 type config struct {
-	serviceName   string
-	serviceSource string
-	analyticsRate float64
-	errCheck      func(err error) bool
+	serviceName        string
+	serviceSource      string
+	analyticsRate      float64
+	errCheck           func(err error) bool
+	dataStreamsEnabled bool
 }
 
 // Option describes options for the AWS integration.
@@ -32,6 +33,7 @@ func (fn OptionFn) apply(cfg *config) {
 
 func defaults(cfg *config) {
 	cfg.analyticsRate = instr.AnalyticsRate(false)
+	cfg.dataStreamsEnabled = instr.DataStreamsEnabled()
 }
 
 // WithService sets the given service name for the dialled connection.
@@ -75,3 +77,13 @@ func WithErrorCheck(fn func(err error) bool) OptionFn {
 		cfg.errCheck = fn
 	}
 }
+
+// WithDataStreams enables Data Streams Monitoring for supported AWS services
+// (currently SQS). When enabled, produce and consume checkpoints are set and
+// the DSM pathway is propagated via the _datadog SQS message attribute.
+func WithDataStreams() OptionFn {
+	return func(cfg *config) {
+		cfg.dataStreamsEnabled = true
+	}
+}
+

--- a/contrib/aws/aws-sdk-go-v2/internal/sqs/sqs.go
+++ b/contrib/aws/aws-sdk-go-v2/internal/sqs/sqs.go
@@ -29,24 +29,44 @@ const (
 
 var instr = internal.Instr
 
-func EnrichOperation(ctx context.Context, span *tracer.Span, in middleware.InitializeInput, operation string) {
+func EnrichOperation(ctx context.Context, span *tracer.Span, in middleware.InitializeInput, operation string, dsmEnabled bool) {
 	switch operation {
 	case "SendMessage":
-		handleSendMessage(ctx, span, in)
+		handleSendMessage(ctx, span, in, dsmEnabled)
 	case "SendMessageBatch":
-		handleSendMessageBatch(ctx, span, in)
+		handleSendMessageBatch(ctx, span, in, dsmEnabled)
+	case "ReceiveMessage":
+		if dsmEnabled {
+			ensureDatadogAttributeRequested(in)
+		}
 	}
 	span.SetTag(ext.MessagingSystem, ext.MessagingSystemSQS)
 }
 
-func handleSendMessage(ctx context.Context, span *tracer.Span, in middleware.InitializeInput) {
+// EnrichOperationOutput processes the SQS response after the API call returns.
+// For ReceiveMessage it sets a DSM consume checkpoint for each returned message
+// and writes the updated pathway back into the message attributes.
+func EnrichOperationOutput(out middleware.InitializeOutput, operation string, dsmEnabled bool, queueName string) {
+	if !dsmEnabled || operation != "ReceiveMessage" {
+		return
+	}
+	resp, ok := out.Result.(*sqs.ReceiveMessageOutput)
+	if !ok || resp == nil {
+		return
+	}
+	for i := range resp.Messages {
+		setConsumeCheckpoint(&resp.Messages[i], queueName)
+	}
+}
+
+func handleSendMessage(ctx context.Context, span *tracer.Span, in middleware.InitializeInput, dsmEnabled bool) {
 	params, ok := in.Parameters.(*sqs.SendMessageInput)
 	if !ok {
 		instr.Logger().Debug("Unable to read SendMessage params")
 		return
 	}
 
-	traceContext, err := getTraceContext(ctx, span, queueName(params.QueueUrl), sendMessageSize(params))
+	traceContext, err := getTraceContext(ctx, span, queueName(params.QueueUrl), sendMessageSize(params), dsmEnabled)
 	if err != nil {
 		instr.Logger().Debug("Unable to get trace context: %s", err.Error())
 		return
@@ -59,7 +79,7 @@ func handleSendMessage(ctx context.Context, span *tracer.Span, in middleware.Ini
 	injectTraceContext(traceContext, params.MessageAttributes)
 }
 
-func handleSendMessageBatch(ctx context.Context, span *tracer.Span, in middleware.InitializeInput) {
+func handleSendMessageBatch(ctx context.Context, span *tracer.Span, in middleware.InitializeInput, dsmEnabled bool) {
 	params, ok := in.Parameters.(*sqs.SendMessageBatchInput)
 	if !ok {
 		instr.Logger().Debug("Unable to read SendMessageBatch params")
@@ -67,7 +87,7 @@ func handleSendMessageBatch(ctx context.Context, span *tracer.Span, in middlewar
 	}
 
 	for i := range params.Entries {
-		traceContext, err := getTraceContext(ctx, span, queueName(params.QueueUrl), sendMessageBatchEntrySize(&params.Entries[i]))
+		traceContext, err := getTraceContext(ctx, span, queueName(params.QueueUrl), sendMessageBatchEntrySize(&params.Entries[i]), dsmEnabled)
 		if err != nil {
 			instr.Logger().Debug("Unable to get trace context: %s", err.Error())
 			continue
@@ -79,22 +99,24 @@ func handleSendMessageBatch(ctx context.Context, span *tracer.Span, in middlewar
 	}
 }
 
-func getTraceContext(ctx context.Context, span *tracer.Span, queue string, payloadSize int64) (types.MessageAttributeValue, error) {
+func getTraceContext(ctx context.Context, span *tracer.Span, queue string, payloadSize int64, dsmEnabled bool) (types.MessageAttributeValue, error) {
 	carrier := tracer.TextMapCarrier{}
 	err := tracer.Inject(span.Context(), carrier)
 	if err != nil {
 		return types.MessageAttributeValue{}, err
 	}
 
-	checkpointCtx, ok := tracer.SetDataStreamsCheckpointWithParams(
-		ctx,
-		options.CheckpointParams{PayloadSize: payloadSize},
-		"direction:out",
-		"type:sqs",
-		"topic:"+queue,
-	)
-	if ok {
-		datastreams.InjectToBase64Carrier(checkpointCtx, carrier)
+	if dsmEnabled {
+		checkpointCtx, ok := tracer.SetDataStreamsCheckpointWithParams(
+			ctx,
+			options.CheckpointParams{PayloadSize: payloadSize},
+			"direction:out",
+			"type:sqs",
+			"topic:"+queue,
+		)
+		if ok {
+			datastreams.InjectToBase64Carrier(checkpointCtx, carrier)
+		}
 	}
 
 	jsonBytes, err := json.Marshal(carrier)
@@ -108,6 +130,89 @@ func getTraceContext(ctx context.Context, span *tracer.Span, queue string, paylo
 	}
 
 	return attribute, nil
+}
+
+// setConsumeCheckpoint extracts the producer pathway from msg's _datadog
+// attribute (if any), sets a consume DSM checkpoint chained from it, and
+// writes the updated pathway back into the message attributes.
+func setConsumeCheckpoint(msg *types.Message, queueName string) {
+	if msg == nil {
+		return
+	}
+	carrier := readDatadogCarrier(msg.MessageAttributes)
+	parentCtx := datastreams.ExtractFromBase64Carrier(context.Background(), carrier)
+	newCtx, ok := tracer.SetDataStreamsCheckpointWithParams(
+		parentCtx,
+		options.CheckpointParams{PayloadSize: messageSize(msg)},
+		"direction:in", "topic:"+queueName, "type:sqs",
+	)
+	if !ok {
+		return
+	}
+	if carrier == nil {
+		carrier = tracer.TextMapCarrier{}
+	}
+	datastreams.InjectToBase64Carrier(newCtx, carrier)
+	writeDatadogCarrier(msg, carrier)
+}
+
+// ensureDatadogAttributeRequested adds _datadog to MessageAttributeNames so
+// SQS returns it with each message. SQS does not return message attributes by
+// default; the caller must explicitly list them.
+func ensureDatadogAttributeRequested(in middleware.InitializeInput) {
+	params, ok := in.Parameters.(*sqs.ReceiveMessageInput)
+	if !ok {
+		return
+	}
+	for _, name := range params.MessageAttributeNames {
+		if name == "All" || name == ".*" || name == datadogKey {
+			return
+		}
+	}
+	params.MessageAttributeNames = append(params.MessageAttributeNames, datadogKey)
+}
+
+func readDatadogCarrier(attrs map[string]types.MessageAttributeValue) tracer.TextMapCarrier {
+	if attrs == nil {
+		return nil
+	}
+	attr, ok := attrs[datadogKey]
+	if !ok {
+		return nil
+	}
+	var raw []byte
+	if attr.StringValue != nil {
+		raw = []byte(*attr.StringValue)
+	} else if len(attr.BinaryValue) > 0 {
+		raw = attr.BinaryValue
+	}
+	if len(raw) == 0 {
+		return nil
+	}
+	carrier := tracer.TextMapCarrier{}
+	if err := json.Unmarshal(raw, &carrier); err != nil {
+		instr.Logger().Debug("Unable to decode _datadog message attribute: %s", err.Error())
+		return nil
+	}
+	return carrier
+}
+
+func writeDatadogCarrier(msg *types.Message, carrier tracer.TextMapCarrier) {
+	if msg == nil || len(carrier) == 0 {
+		return
+	}
+	jsonBytes, err := json.Marshal(carrier)
+	if err != nil {
+		instr.Logger().Debug("Unable to encode _datadog message attribute: %s", err.Error())
+		return
+	}
+	if msg.MessageAttributes == nil {
+		msg.MessageAttributes = make(map[string]types.MessageAttributeValue)
+	}
+	msg.MessageAttributes[datadogKey] = types.MessageAttributeValue{
+		DataType:    aws.String("String"),
+		StringValue: aws.String(string(jsonBytes)),
+	}
 }
 
 func injectTraceContext(traceContext types.MessageAttributeValue, messageAttributes map[string]types.MessageAttributeValue) {
@@ -165,6 +270,24 @@ func messageAttributesSize(attrs map[string]types.MessageAttributeValue) int64 {
 			size += int64(len(*attr.StringValue))
 		}
 		size += int64(len(attr.BinaryValue))
+	}
+	return size
+}
+
+func messageSize(msg *types.Message) int64 {
+	var size int64
+	if msg.Body != nil {
+		size += int64(len(*msg.Body))
+	}
+	for k, v := range msg.MessageAttributes {
+		size += int64(len(k))
+		if v.DataType != nil {
+			size += int64(len(*v.DataType))
+		}
+		if v.StringValue != nil {
+			size += int64(len(*v.StringValue))
+		}
+		size += int64(len(v.BinaryValue))
 	}
 	return size
 }

--- a/contrib/aws/aws-sdk-go-v2/internal/sqs/sqs_test.go
+++ b/contrib/aws/aws-sdk-go-v2/internal/sqs/sqs_test.go
@@ -11,10 +11,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/aws/smithy-go/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -139,7 +138,7 @@ func TestEnrichOperation(t *testing.T) {
 			ctx, _ := tracer.SetDataStreamsCheckpoint(context.Background(), "direction:in", "topic:upstream", "type:kafka")
 			span, spanCtx := tracer.StartSpanFromContext(ctx, "test-span")
 
-			EnrichOperation(spanCtx, span, tt.input, tt.operation)
+			EnrichOperation(spanCtx, span, tt.input, tt.operation, true)
 
 			if tt.check != nil {
 				tt.check(t, tt.input, span, spanCtx)
@@ -187,7 +186,7 @@ func TestInjectTraceContext(t *testing.T) {
 				}
 			}
 
-			traceContext, err := getTraceContext(spanCtx, span, "test-queue", 42)
+			traceContext, err := getTraceContext(spanCtx, span, "test-queue", 42, true)
 			assert.NoError(t, err)
 			injectTraceContext(traceContext, messageAttributes)
 
@@ -212,6 +211,132 @@ func TestInjectTraceContext(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReceiveMessageEnsuresDatadogAttribute(t *testing.T) {
+	tests := []struct {
+		name      string
+		initial   []string
+		wantNames []string
+	}{
+		{
+			name:      "empty",
+			initial:   nil,
+			wantNames: []string{datadogKey},
+		},
+		{
+			name:      "preserves existing",
+			initial:   []string{"foo"},
+			wantNames: []string{"foo", datadogKey},
+		},
+		{
+			name:      "no-op when _datadog already present",
+			initial:   []string{datadogKey},
+			wantNames: []string{datadogKey},
+		},
+		{
+			name:      "no-op when All present",
+			initial:   []string{"All"},
+			wantNames: []string{"All"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mt := mocktracer.Start()
+			defer mt.Stop()
+
+			input := middleware.InitializeInput{
+				Parameters: &sqs.ReceiveMessageInput{
+					QueueUrl:              aws.String("https://sqs.us-east-1.amazonaws.com/1234567890/q"),
+					MessageAttributeNames: tt.initial,
+				},
+			}
+			span, ctx := tracer.StartSpanFromContext(context.Background(), "test-span")
+			EnrichOperation(ctx, span, input, "ReceiveMessage", true)
+			params := input.Parameters.(*sqs.ReceiveMessageInput)
+			assert.Equal(t, tt.wantNames, params.MessageAttributeNames)
+		})
+	}
+}
+
+func TestReceiveMessageNoDSMNoMutation(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	input := middleware.InitializeInput{
+		Parameters: &sqs.ReceiveMessageInput{
+			QueueUrl: aws.String("https://sqs.us-east-1.amazonaws.com/1234567890/q"),
+		},
+	}
+	span, ctx := tracer.StartSpanFromContext(context.Background(), "test-span")
+	EnrichOperation(ctx, span, input, "ReceiveMessage", false)
+	params := input.Parameters.(*sqs.ReceiveMessageInput)
+	assert.Empty(t, params.MessageAttributeNames)
+}
+
+func TestEnrichOperationOutputConsumeCheckpoint(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	queueName := "consume-queue"
+
+	// Build a message whose _datadog attribute carries a producer pathway.
+	producerCtx, ok := tracer.SetDataStreamsCheckpoint(context.Background(), "direction:out", "topic:"+queueName, "type:sqs")
+	require.True(t, ok)
+	producerCarrier := tracer.TextMapCarrier{}
+	datastreams.InjectToBase64Carrier(producerCtx, producerCarrier)
+	producerJSON, err := json.Marshal(producerCarrier)
+	require.NoError(t, err)
+
+	out := middleware.InitializeOutput{
+		Result: &sqs.ReceiveMessageOutput{
+			Messages: []types.Message{
+				{
+					Body: aws.String("payload"),
+					MessageAttributes: map[string]types.MessageAttributeValue{
+						datadogKey: {
+							DataType:    aws.String("String"),
+							StringValue: aws.String(string(producerJSON)),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	EnrichOperationOutput(out, "ReceiveMessage", true, queueName)
+
+	resp := out.Result.(*sqs.ReceiveMessageOutput)
+	require.Len(t, resp.Messages, 1)
+	require.Contains(t, resp.Messages[0].MessageAttributes, datadogKey)
+
+	consumeCarrier := tracer.TextMapCarrier{}
+	require.NoError(t, json.Unmarshal([]byte(*resp.Messages[0].MessageAttributes[datadogKey].StringValue), &consumeCarrier))
+
+	got, ok := datastreams.PathwayFromContext(datastreams.ExtractFromBase64Carrier(context.Background(), consumeCarrier))
+	require.True(t, ok)
+
+	wantCtx, _ := tracer.SetDataStreamsCheckpoint(producerCtx, "direction:in", "topic:"+queueName, "type:sqs")
+	want, _ := datastreams.PathwayFromContext(wantCtx)
+	assert.NotZero(t, want.GetHash())
+	assert.Equal(t, want.GetHash(), got.GetHash())
+}
+
+func TestEnrichOperationOutputDisabled(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	out := middleware.InitializeOutput{
+		Result: &sqs.ReceiveMessageOutput{
+			Messages: []types.Message{
+				{Body: aws.String("payload")},
+			},
+		},
+	}
+	EnrichOperationOutput(out, "ReceiveMessage", false, "q")
+	resp := out.Result.(*sqs.ReceiveMessageOutput)
+	assert.Nil(t, resp.Messages[0].MessageAttributes)
 }
 
 func assertInjectedPathway(t *testing.T, raw string, expected datastreams.Pathway, span *tracer.Span) {


### PR DESCRIPTION
### What does this PR do?

Adds Data Streams Monitoring (DSM) support to `aws-sdk-go-v2` for SQS. `WithDataStreams()` enables DSM produce/consume checkpoints for `SendMessage`, `SendMessageBatch` and `ReceiveMessage`.

### Testing

Set up a test app to see it e2e:
 