### PR TITLE
perf(profiler): WIP cap profile stack count to reduce overhead

### DIFF
--- a/profiler/collect_capped.go
+++ b/profiler/collect_capped.go
@@ -1,0 +1,303 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package profiler
+
+import (
+	"bytes"
+	"cmp"
+	"fmt"
+	"io"
+	"runtime"
+	"slices"
+	"time"
+
+	"github.com/DataDog/dd-trace-go/v2/profiler/internal/pproflite"
+)
+
+// collectCappedProfile returns a capped pprof for pt if a stack cap is
+// configured, or (nil, nil) if no cap is set for that profile type.
+func collectCappedProfile(cfg *config, pt ProfileType) ([]byte, error) {
+	switch pt {
+	case HeapProfile:
+		if cfg.maxHeapStacks > 0 {
+			return buildCappedHeapPprof(cfg.maxHeapStacks)
+		}
+	case MutexProfile:
+		if cfg.maxMutexStacks > 0 {
+			return buildCappedMutexPprof(cfg.maxMutexStacks)
+		}
+	case BlockProfile:
+		if cfg.maxBlockStacks > 0 {
+			return buildCappedBlockPprof(cfg.maxBlockStacks)
+		}
+	}
+	return nil, nil
+}
+
+// applyDeltaOrCompress applies delta profiling (if enabled) or compresses raw
+// pprof bytes using the configured compressor for the given profile type.
+func applyDeltaOrCompress(p *profiler, pt ProfileType, name string, raw []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	dp, ok := p.deltas[pt]
+	if !ok || !p.cfg.deltaProfiles {
+		c := p.compressors[pt]
+		c.Reset(&buf)
+		if _, err := c.Write(raw); err != nil {
+			c.Close()
+			return nil, err
+		}
+		if err := c.Close(); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	}
+
+	start := time.Now()
+	delta, err := dp.Delta(raw)
+	tags := append(p.cfg.tags.Slice(), fmt.Sprintf("profile_type:%s", name))
+	p.cfg.statsd.Timing("datadog.profiling.go.delta_time", time.Since(start), tags, 1)
+	if err != nil {
+		return nil, fmt.Errorf("delta profile error: %s", err.Error())
+	}
+	return delta, err
+}
+
+// buildCappedHeapPprof collects all MemProfileRecords, keeps only the top
+// maxStacks by InUseBytes, and serializes to uncompressed pprof protobuf.
+func buildCappedHeapPprof(maxStacks int) ([]byte, error) {
+	var records []runtime.MemProfileRecord
+	for {
+		n, ok := runtime.MemProfile(records, true)
+		if ok {
+			records = records[:n]
+			break
+		}
+		records = make([]runtime.MemProfileRecord, n+10)
+	}
+	slices.SortFunc(records, func(a, b runtime.MemProfileRecord) int {
+		return cmp.Compare(b.InUseBytes(), a.InUseBytes())
+	})
+	if len(records) > maxStacks {
+		records = records[:maxStacks]
+	}
+	return encodeHeapPprof(records)
+}
+
+// buildCappedMutexPprof collects all mutex BlockProfileRecords, keeps only the
+// top maxStacks by Cycles, and serializes to uncompressed pprof protobuf.
+func buildCappedMutexPprof(maxStacks int) ([]byte, error) {
+	return buildCappedContentionPprof(maxStacks, runtime.MutexProfile)
+}
+
+// buildCappedBlockPprof collects all block BlockProfileRecords, keeps only the
+// top maxStacks by Cycles, and serializes to uncompressed pprof protobuf.
+func buildCappedBlockPprof(maxStacks int) ([]byte, error) {
+	return buildCappedContentionPprof(maxStacks, runtime.BlockProfile)
+}
+
+// buildCappedContentionPprof is the shared implementation for mutex and block
+// profiles, which both use runtime.BlockProfileRecord sorted by Cycles.
+func buildCappedContentionPprof(maxStacks int, collect func([]runtime.BlockProfileRecord) (int, bool)) ([]byte, error) {
+	var records []runtime.BlockProfileRecord
+	for {
+		n, ok := collect(records)
+		if ok {
+			records = records[:n]
+			break
+		}
+		records = make([]runtime.BlockProfileRecord, n+10)
+	}
+	slices.SortFunc(records, func(a, b runtime.BlockProfileRecord) int {
+		return cmp.Compare(b.Cycles, a.Cycles)
+	})
+	if len(records) > maxStacks {
+		records = records[:maxStacks]
+	}
+	return encodeContentionPprof(records)
+}
+
+// encodeHeapPprof serializes MemProfileRecords to uncompressed pprof protobuf.
+// Sample types match the standard Go heap profile:
+// alloc_objects/count, alloc_space/bytes, inuse_objects/count, inuse_space/bytes.
+func encodeHeapPprof(records []runtime.MemProfileRecord) ([]byte, error) {
+	st := newStringTable()
+	aoType, countUnit := st.intern("alloc_objects"), st.intern("count")
+	asType, bytesUnit := st.intern("alloc_space"), st.intern("bytes")
+	ioType := st.intern("inuse_objects")
+	isType := st.intern("inuse_space")
+
+	sampleTypes := []pproflite.SampleType{
+		{ValueType: pproflite.ValueType{Type: aoType, Unit: countUnit}},
+		{ValueType: pproflite.ValueType{Type: asType, Unit: bytesUnit}},
+		{ValueType: pproflite.ValueType{Type: ioType, Unit: countUnit}},
+		{ValueType: pproflite.ValueType{Type: isType, Unit: bytesUnit}},
+	}
+
+	b := newProfBuilder(st)
+	samples := make([]pproflite.Sample, 0, len(records))
+	for i := range records {
+		rec := &records[i]
+		if stack := rec.Stack(); len(stack) > 0 {
+			samples = append(samples, pproflite.Sample{
+				LocationID: b.resolveStack(stack),
+				Value:      []int64{rec.AllocObjects, rec.AllocBytes, rec.InUseObjects(), rec.InUseBytes()},
+			})
+		}
+	}
+
+	var buf bytes.Buffer
+	err := b.encode(&buf, sampleTypes, samples)
+	return buf.Bytes(), err
+}
+
+// encodeContentionPprof serializes BlockProfileRecords to uncompressed pprof
+// protobuf. Used for both mutex and block profiles.
+// Sample types: contentions/count, delay/nanoseconds.
+// Note: Cycles is stored directly as the delay value without converting to
+// nanoseconds, which is sufficient for delta computation and relative ordering.
+func encodeContentionPprof(records []runtime.BlockProfileRecord) ([]byte, error) {
+	st := newStringTable()
+	contentionsType, countUnit := st.intern("contentions"), st.intern("count")
+	delayType, nanosUnit := st.intern("delay"), st.intern("nanoseconds")
+
+	sampleTypes := []pproflite.SampleType{
+		{ValueType: pproflite.ValueType{Type: contentionsType, Unit: countUnit}},
+		{ValueType: pproflite.ValueType{Type: delayType, Unit: nanosUnit}},
+	}
+
+	b := newProfBuilder(st)
+	samples := make([]pproflite.Sample, 0, len(records))
+	for i := range records {
+		rec := &records[i]
+		if stack := rec.Stack(); len(stack) > 0 {
+			samples = append(samples, pproflite.Sample{
+				LocationID: b.resolveStack(stack),
+				Value:      []int64{rec.Count, rec.Cycles},
+			})
+		}
+	}
+
+	var buf bytes.Buffer
+	err := b.encode(&buf, sampleTypes, samples)
+	return buf.Bytes(), err
+}
+
+// stringTable maps strings to their index in the pprof string table.
+// Index 0 is always the empty string.
+type stringTable struct {
+	strs []string
+	idx  map[string]int64
+}
+
+func newStringTable() *stringTable {
+	return &stringTable{
+		strs: []string{""},
+		idx:  map[string]int64{"": 0},
+	}
+}
+
+func (st *stringTable) intern(s string) int64 {
+	if i, ok := st.idx[s]; ok {
+		return i
+	}
+	i := int64(len(st.strs))
+	st.strs = append(st.strs, s)
+	st.idx[s] = i
+	return i
+}
+
+// profBuilder accumulates locations and functions while resolving symbols via
+// runtime.CallersFrames. Each unique PC is resolved at most once.
+type profBuilder struct {
+	st        *stringTable
+	locs      []pproflite.Location
+	fns       []pproflite.Function
+	locByPC   map[uintptr]uint64 // PC -> location ID
+	fnByKey   map[string]uint64  // "name\x00file" -> function ID
+	nextLocID uint64
+	nextFnID  uint64
+}
+
+func newProfBuilder(st *stringTable) *profBuilder {
+	return &profBuilder{
+		st:        st,
+		locByPC:   make(map[uintptr]uint64),
+		fnByKey:   make(map[string]uint64),
+		nextLocID: 1,
+		nextFnID:  1,
+	}
+}
+
+// resolveStack returns location IDs for the given PCs, resolving symbols for
+// any PC not previously seen. Inlined frames produce multiple lines per location.
+func (b *profBuilder) resolveStack(pcs []uintptr) []uint64 {
+	locIDs := make([]uint64, 0, len(pcs))
+	for _, pc := range pcs {
+		if locID, ok := b.locByPC[pc]; ok {
+			locIDs = append(locIDs, locID)
+			continue
+		}
+		frames := runtime.CallersFrames([]uintptr{pc})
+		var lines []pproflite.Line
+		for {
+			f, more := frames.Next()
+			fnKey := f.Function + "\x00" + f.File
+			fnID, ok := b.fnByKey[fnKey]
+			if !ok {
+				fnID = b.nextFnID
+				b.nextFnID++
+				b.fnByKey[fnKey] = fnID
+				b.fns = append(b.fns, pproflite.Function{
+					ID:         fnID,
+					Name:       b.st.intern(f.Function),
+					SystemName: b.st.intern(f.Function),
+					FileName:   b.st.intern(f.File),
+				})
+			}
+			lines = append(lines, pproflite.Line{FunctionID: fnID, Line: int64(f.Line)})
+			if !more {
+				break
+			}
+		}
+		locID := b.nextLocID
+		b.nextLocID++
+		b.locByPC[pc] = locID
+		b.locs = append(b.locs, pproflite.Location{ID: locID, Address: uint64(pc), Line: lines})
+		locIDs = append(locIDs, locID)
+	}
+	return locIDs
+}
+
+// encode writes the profile to w as an uncompressed pprof protobuf message.
+func (b *profBuilder) encode(w io.Writer, sampleTypes []pproflite.SampleType, samples []pproflite.Sample) error {
+	enc := pproflite.NewEncoder(w)
+	for i := range sampleTypes {
+		if err := enc.Encode(&sampleTypes[i]); err != nil {
+			return fmt.Errorf("encoding sample type: %w", err)
+		}
+	}
+	for i := range samples {
+		if err := enc.Encode(&samples[i]); err != nil {
+			return fmt.Errorf("encoding sample: %w", err)
+		}
+	}
+	for i := range b.locs {
+		if err := enc.Encode(&b.locs[i]); err != nil {
+			return fmt.Errorf("encoding location: %w", err)
+		}
+	}
+	for i := range b.fns {
+		if err := enc.Encode(&b.fns[i]); err != nil {
+			return fmt.Errorf("encoding function: %w", err)
+		}
+	}
+	for _, s := range b.st.strs {
+		if err := enc.Encode(&pproflite.StringTable{Value: []byte(s)}); err != nil {
+			return fmt.Errorf("encoding string table: %w", err)
+		}
+	}
+	return enc.Encode(&pproflite.TimeNanos{Value: time.Now().UnixNano()})
+}

--- a/profiler/collect_capped_delta_test.go
+++ b/profiler/collect_capped_delta_test.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package profiler
+
+import (
+	"bytes"
+	"runtime"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/profiler/internal/fastdelta"
+	"github.com/DataDog/dd-trace-go/v2/profiler/internal/pprofutils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCappedSampleCountSurvivesDelta verifies that the sample count in the
+// delta output does not exceed the cap set on the raw pprof input.
+func TestCappedSampleCountSurvivesDelta(t *testing.T) {
+	old := runtime.MemProfileRate
+	runtime.MemProfileRate = 1
+	defer func() { runtime.MemProfileRate = old }()
+
+	allocUniqueStacks(500)
+	runtime.GC()
+	runtime.GC()
+
+	total, _ := runtime.MemProfile(nil, true)
+	require.Greater(t, total, 20, "need more than 20 runtime entries to test the cap")
+
+	const cap = 10
+	raw, err := buildCappedHeapPprof(cap)
+	require.NoError(t, err)
+
+	rawSamples := countSamplesInRaw(t, raw)
+	assert.LessOrEqual(t, rawSamples, cap, "raw pprof must not exceed cap")
+	t.Logf("runtime entries: %d, cap: %d, raw samples: %d", total, cap, rawSamples)
+
+	// Run through fastdelta (first call: delta vs empty = full profile).
+	dc := fastdelta.NewDeltaComputer(
+		pprofutils.ValueType{Type: "alloc_objects", Unit: "count"},
+		pprofutils.ValueType{Type: "alloc_space", Unit: "bytes"},
+	)
+	var deltaBuf bytes.Buffer
+	require.NoError(t, dc.Delta(raw, &deltaBuf))
+
+	deltaBytes := deltaBuf.Bytes()
+	require.NotEmpty(t, deltaBytes, "delta output must be non-empty")
+
+	deltaSamples := countSamplesInRaw(t, deltaBytes)
+	t.Logf("delta output samples: %d", deltaSamples)
+	assert.LessOrEqual(t, deltaSamples, cap, "delta output must not exceed cap")
+}

--- a/profiler/collect_capped_test.go
+++ b/profiler/collect_capped_test.go
@@ -1,0 +1,116 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package profiler
+
+import (
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/profiler/internal/fastdelta"
+	"github.com/DataDog/dd-trace-go/v2/profiler/internal/pproflite"
+	"github.com/DataDog/dd-trace-go/v2/profiler/internal/pprofutils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var heapSink [][]byte
+
+// allocUniqueStacks generates n allocations from distinct call sites.
+//
+//go:noinline
+func allocUniqueStacks(n int) {
+	for i := range n {
+		heapSink = append(heapSink, makeAlloc(i))
+	}
+}
+
+//go:noinline
+func makeAlloc(n int) []byte { return make([]byte, 1024+n) }
+
+func TestBuildCappedHeapPprof(t *testing.T) {
+	old := runtime.MemProfileRate
+	runtime.MemProfileRate = 1
+	defer func() { runtime.MemProfileRate = old }()
+
+	allocUniqueStacks(200)
+	runtime.GC()
+	runtime.GC()
+
+	total, _ := runtime.MemProfile(nil, true)
+	require.Greater(t, total, 0, "expected heap profile entries")
+
+	cap := 10
+	raw, err := buildCappedHeapPprof(cap)
+	require.NoError(t, err)
+	require.NotEmpty(t, raw, "capped pprof must be non-empty")
+
+	// Parse it with fastdelta to confirm it's valid pprof protobuf.
+	dc := fastdelta.NewDeltaComputer(
+		pprofutils.ValueType{Type: "alloc_objects", Unit: "count"},
+		pprofutils.ValueType{Type: "alloc_space", Unit: "bytes"},
+	)
+	var buf nopWriter
+	err = dc.Delta(raw, &buf)
+	require.NoError(t, err, "fastdelta must accept our capped pprof as valid")
+	assert.NotEmpty(t, buf.n, "delta output must be non-empty")
+
+	// Verify the cap: parse sample count from raw pprof.
+	// Verify the cap on the RAW bytes (before delta): this is what determines
+	// how many stacks go through symbol resolution. This is the key invariant.
+	samples := countSamplesInRaw(t, raw)
+	assert.LessOrEqual(t, samples, cap, "raw samples must not exceed cap")
+	assert.Greater(t, samples, 0, "must have at least one sample")
+	t.Logf("runtime entries: %d, cap: %d, raw serialized: %d", total, cap, samples)
+}
+
+func TestBuildCappedMutexPprof(t *testing.T) {
+	old := runtime.SetMutexProfileFraction(1)
+	defer runtime.SetMutexProfileFraction(old)
+
+	// Generate some mutex contention.
+	var mu sync.Mutex
+	for range 50 {
+		mu.Lock()
+		mu.Unlock()
+	}
+
+	cap := 5
+	raw, err := buildCappedMutexPprof(cap)
+	require.NoError(t, err)
+	// May be empty if no contention was recorded; just verify no error and valid format.
+	if len(raw) > 0 {
+		dc := fastdelta.NewDeltaComputer(
+			pprofutils.ValueType{Type: "contentions", Unit: "count"},
+			pprofutils.ValueType{Type: "delay", Unit: "nanoseconds"},
+		)
+		var buf nopWriter
+		err = dc.Delta(raw, &buf)
+		assert.NoError(t, err)
+	}
+	t.Logf("raw mutex pprof: %d bytes", len(raw))
+}
+
+type nopWriter struct{ n int }
+
+func (w *nopWriter) Write(p []byte) (int, error) { w.n += len(p); return len(p), nil }
+
+// countSamplesInRaw counts Sample records in a raw pprof protobuf
+// using the pproflite decoder (same parser fastdelta uses).
+func countSamplesInRaw(t *testing.T, data []byte) int {
+	t.Helper()
+	dec := pproflite.NewDecoder(data)
+	count := 0
+	err := dec.FieldEach(func(f pproflite.Field) error {
+		if _, ok := f.(*pproflite.Sample); ok {
+			count++
+		}
+		return nil
+	}, pproflite.SampleDecoder)
+	require.NoError(t, err)
+	return count
+}

--- a/profiler/options.go
+++ b/profiler/options.go
@@ -116,6 +116,9 @@ type config struct {
 	enabled              bool
 	flushOnExit          bool
 	compressionConfig    string
+	maxHeapStacks        int // 0 = unlimited
+	maxMutexStacks       int // 0 = unlimited
+	maxBlockStacks       int // 0 = unlimited
 }
 
 // logStartup records the configuration to the configured logger in JSON format
@@ -519,5 +522,35 @@ var executionTraceEnabledDefault = runtime.GOARCH == "arm64" || runtime.GOARCH =
 func WithCustomProfilerLabelKeys(keys ...string) Option {
 	return func(cfg *config) {
 		cfg.customProfilerLabels = append(cfg.customProfilerLabels, keys...)
+	}
+}
+
+// WithMaxHeapStacks caps the number of unique heap allocation stacks serialized
+// in each heap profile to the n highest-weight stacks (by InUseBytes).
+// This reduces symbol resolution overhead for services with many unique
+// allocation sites. 0 means no cap (default).
+func WithMaxHeapStacks(n int) Option {
+	return func(cfg *config) {
+		cfg.maxHeapStacks = n
+	}
+}
+
+// WithMaxMutexStacks caps the number of unique mutex contention stacks
+// serialized in each mutex profile to the n highest-weight stacks (by Cycles).
+// This reduces symbol resolution overhead for services with heavy mutex
+// contention. 0 means no cap (default).
+func WithMaxMutexStacks(n int) Option {
+	return func(cfg *config) {
+		cfg.maxMutexStacks = n
+	}
+}
+
+// WithMaxBlockStacks caps the number of unique block contention stacks
+// serialized in each block profile to the n highest-weight stacks (by Cycles).
+// This reduces symbol resolution overhead for services with many unique
+// blocking sites. 0 means no cap (default).
+func WithMaxBlockStacks(n int) Option {
+	return func(cfg *config) {
+		cfg.maxBlockStacks = n
 	}
 }

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -263,6 +263,14 @@ func collectGenericProfile(name string, pt ProfileType) func(p *profiler) ([]byt
 	return func(p *profiler) ([]byte, error) {
 		p.interruptibleSleep(p.cfg.period)
 
+		raw, err := collectCappedProfile(p.cfg, pt)
+		if err != nil {
+			return nil, err
+		}
+		if raw != nil {
+			return applyDeltaOrCompress(p, pt, name, raw)
+		}
+
 		var buf bytes.Buffer
 		dp, ok := p.deltas[pt]
 		if !ok || !p.cfg.deltaProfiles {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Add three new options `WithMaxHeapStacks`, `WithMaxMutexStacks`, and `WithMaxBlockStacks` to cap the number of unique stacks serialized per profile collection.

### Motivation

The Go heap and mutex profilers accumulate unique stack traces in runtime-internal hash tables over the lifetime of a process and never evict them. In production services with many unique allocation sites or lock contention points, these tables grow to tens of thousands of entries. Every profile collection resolves symbols for every unique program counter across all accumulated stacks (function names, file names, line numbers), consuming CPU, allocating strings and triggering GC.

### How it works

When a cap is set, the collection path bypasses `pprof.Lookup().WriteTo()` entirely. Instead it calls the go runtime directly to get raw records (this is fast, no symbol resolution), sorts by weight (InUseBytes for heap, Cycles for mutex/block), keeps the top N, and serializes only those using a custom pprof encoder. The encode basically mimics 

The standard behavior (no cap) is completely unchanged. The existing `WriteTo` path is used as before.

### Usage

```go
profiler.Start(
    profiler.WithMaxHeapStacks(1000),
    profiler.WithMaxMutexStacks(500),
    profiler.WithMaxBlockStacks(200),
)
```

The right cap value depends on your service. Start high (1000–2000) and lower it until you stop seeing stacks you care about in the UI.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
