### PR TITLE
chore(profiler): remove unstartedProfiler

### DIFF
--- a/profiler/options_test.go
+++ b/profiler/options_test.go
@@ -395,32 +395,18 @@ func TestAddProfileType(t *testing.T) {
 }
 
 func TestWith_outputDir(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	dir := t.TempDir()
 
 	// Use env to enable this like a user would.
-	t.Setenv("DD_PROFILING_OUTPUT_DIR", tmpDir)
+	t.Setenv("DD_PROFILING_OUTPUT_DIR", dir)
 
-	p, err := unstartedProfiler()
-	require.NoError(t, err)
-	bat := batch{
-		end: time.Now(),
-		profiles: []*profile{
-			{name: "foo.pprof", data: []byte("foo")},
-			{name: "bar.pprof", data: []byte("bar")},
-		},
-	}
-	require.NoError(t, p.outputDir(bat))
-	files, err := filepath.Glob(filepath.Join(tmpDir, "*", "*.pprof"))
-	require.NoError(t, err)
+	startTestProfiler(t, 1,
+		WithProfileTypes(HeapProfile),
+		WithPeriod(10*time.Millisecond),
+	).ReceiveProfile(t)
 
-	fileData := map[string]string{}
-	for _, file := range files {
-		data, err := os.ReadFile(file)
-		require.NoError(t, err)
-		fileData[filepath.Base(file)] = string(data)
-	}
-	want := map[string]string{"foo.pprof": "foo", "bar.pprof": "bar"}
-	require.Equal(t, want, fileData)
+	// At least one subdirectory with .pprof files should have been written.
+	files, err := filepath.Glob(filepath.Join(dir, "*", "delta-heap.pprof"))
+	require.NoError(t, err)
+	require.NotEmpty(t, files)
 }

--- a/profiler/profile_test.go
+++ b/profiler/profile_test.go
@@ -224,14 +224,14 @@ func TestProfileTypeSoundness(t *testing.T) {
 		for pt := range profileTypes {
 			allProfileTypes = append(allProfileTypes, pt)
 		}
-		p, err := unstartedProfiler(WithProfileTypes(allProfileTypes...))
+		p, err := newProfiler(WithProfileTypes(allProfileTypes...))
 		require.NoError(t, err)
 		types := p.enabledProfileTypes()
-		require.Equal(t, len(allProfileTypes), len(types))
+		require.ElementsMatch(t, types, allProfileTypes)
 	})
 
 	t.Run("profileTypes", func(t *testing.T) {
-		_, err := unstartedProfiler(WithProfileTypes(ProfileType(-1)))
+		err := Start(WithProfileTypes(ProfileType(-1)))
 		require.EqualError(t, err, "unknown profile type: -1")
 	})
 }

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -102,13 +102,12 @@ func Stop() {
 // profiler collects and sends preset profiles to the Datadog API at a given frequency
 // using a given configuration.
 type profiler struct {
-	cfg             *config           // profile configuration
-	out             chan batch        // upload queue
-	uploadFunc      func(batch) error // defaults to (*profiler).upload; replaced in tests
-	exit            chan struct{}     // exit signals the profiler to stop; it is closed after stopping
-	stopOnce        sync.Once         // stopOnce ensures the profiler is stopped exactly once.
-	wg              sync.WaitGroup    // wg waits for all goroutines to exit when stopping.
-	met             *metrics          // metric collector state
+	cfg             *config        // profile configuration
+	out             chan batch     // upload queue
+	exit            chan struct{}  // exit signals the profiler to stop; it is closed after stopping
+	stopOnce        sync.Once      // stopOnce ensures the profiler is stopped exactly once.
+	wg              sync.WaitGroup // wg waits for all goroutines to exit when stopping.
+	met             *metrics       // metric collector state
 	deltas          map[ProfileType]*fastDeltaProfiler
 	compressors     map[ProfileType]compressor
 	seq             uint64         // seq is the value of the profile_seq tag
@@ -262,7 +261,6 @@ func newProfiler(opts ...Option) (*profiler, error) {
 			p.deltas[pt] = newFastDeltaProfiler(compressor, profileTypes[pt].DeltaValues...)
 		}
 	}
-	p.uploadFunc = p.upload
 	return &p, nil
 }
 
@@ -505,7 +503,7 @@ func (p *profiler) send() {
 			if err := p.outputDir(bat); err != nil {
 				log.Error("Failed to output profile to dir: %s", err.Error())
 			}
-			if err := p.uploadFunc(bat); err != nil {
+			if err := p.upload(bat); err != nil {
 				log.Error("Failed to upload profile: %s", err.Error())
 			}
 		}

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -312,31 +312,16 @@ func TestSetProfileFraction(t *testing.T) {
 	t.Run("on", func(t *testing.T) {
 		start := runtime.SetMutexProfileFraction(0)
 		defer runtime.SetMutexProfileFraction(start)
-		p, err := unstartedProfiler(WithProfileTypes(MutexProfile))
-		require.NoError(t, err)
-		p.run()
-		p.stop()
+		startTestProfiler(t, 0, WithProfileTypes(MutexProfile))
 		assert.Equal(t, DefaultMutexFraction, runtime.SetMutexProfileFraction(-1))
 	})
 
 	t.Run("off", func(t *testing.T) {
 		start := runtime.SetMutexProfileFraction(0)
 		defer runtime.SetMutexProfileFraction(start)
-		p, err := unstartedProfiler()
-		require.NoError(t, err)
-		p.run()
-		p.stop()
+		startTestProfiler(t, 0, WithProfileTypes())
 		assert.Zero(t, runtime.SetMutexProfileFraction(-1))
 	})
-}
-
-func unstartedProfiler(opts ...Option) (*profiler, error) {
-	p, err := newProfiler(opts...)
-	if err != nil {
-		return nil, err
-	}
-	p.uploadFunc = func(_ batch) error { return nil }
-	return p, nil
 }
 
 type profileMeta struct {

--- a/profiler/upload_test.go
+++ b/profiler/upload_test.go
@@ -10,10 +10,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"runtime"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/DataDog/dd-trace-go/v2/instrumentation/httpmem"
 	maininternal "github.com/DataDog/dd-trace-go/v2/internal"
+	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/processtags"
 
 	"github.com/stretchr/testify/assert"
@@ -42,7 +46,8 @@ func TestTryUploadUDS(t *testing.T) {
 		t.Skip("Unix domain sockets are non-functional on windows.")
 	}
 	profiles := make(chan profileMeta, 1)
-	server := httptest.NewUnstartedServer(&fakeBackend{profiles: profiles})
+	backend := &fakeBackend{profiles: profiles}
+	server := httptest.NewUnstartedServer(backend)
 	udsPath := "/tmp/com.datadoghq.dd-trace-go.profiler.test.sock"
 	l, err := net.Listen("unix", udsPath)
 	if err != nil {
@@ -53,51 +58,58 @@ func TestTryUploadUDS(t *testing.T) {
 	server.Start()
 	defer server.Close()
 
-	p, err := unstartedProfiler(
+	require.NoError(t, Start(
 		WithUDS(udsPath),
-	)
-	require.NoError(t, err)
-	err = p.doRequest(testBatch)
-	require.NoError(t, err)
-	profile := <-profiles
+		WithProfileTypes(),
+		WithPeriod(10*time.Millisecond),
+	))
+	defer Stop()
 
-	assert := assert.New(t)
-	assert.Subset(profile.tags, []string{
-		"host:my-host",
-		"runtime:go",
-	})
+	profile := backend.ReceiveProfile(t)
+	assert.Contains(t, profile.tags, "runtime:go")
 }
 
 func Test202Accepted(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusAccepted)
-	}))
-	defer server.Close()
-	p, err := unstartedProfiler(
-		WithAgentAddr(server.Listener.Addr().String()),
+	// startTestProfiler's fakeBackend returns 202; ReceiveProfile confirms
+	// the profiler treats 202 as success and continues uploading.
+	backend := startTestProfiler(t, 1,
+		WithProfileTypes(),
+		WithPeriod(10*time.Millisecond),
 		WithService("my-service"),
 		WithEnv("my-env"),
 		WithTags("tag1:1", "tag2:2"),
 	)
-	require.NoError(t, err)
-	err = p.doRequest(testBatch)
-	require.NoError(t, err)
+	backend.ReceiveProfile(t)
 }
 
 func TestOldAgent(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	ch := make(chan struct{}, 2)
+	server, client := httpmem.ServerAndClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/profiling/v1/input" {
+			return
+		}
 		w.WriteHeader(http.StatusNotFound)
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
 	}))
 	defer server.Close()
-	p, err := unstartedProfiler(
-		WithAgentAddr(server.Listener.Addr().String()),
-		WithService("my-service"),
-		WithEnv("my-env"),
-		WithTags("tag1:1", "tag2:2"),
-	)
-	require.NoError(t, err)
-	err = p.doRequest(testBatch)
-	assert.Equal(t, errOldAgent, err)
+	rl := &log.RecordLogger{}
+	defer log.UseLogger(rl)()
+
+	Start(WithHTTPClient(client), WithProfileTypes(), WithPeriod(time.Millisecond))
+	defer Stop()
+	<-ch
+	<-ch
+	log.Flush()
+	logs := rl.Logs()
+	const want = "Datadog Agent is not accepting profiles"
+	if !slices.ContainsFunc(logs, func(s string) bool {
+		return strings.Contains(s, "Datadog Agent is not accepting profiles")
+	}) {
+		t.Errorf("didn't see log message containing %s, got: %s", want, logs)
+	}
 }
 
 func setContainerEntityIDs(t *testing.T, cid, eid string) {


### PR DESCRIPTION
This is another internal thing we shouldn't have in tests. Get rid of
it. This lets us delete the uploadHook in the profiler. After this
change, we still have a call to newProfiler in a test since I couldn't
think of a better, non-intrusive way to write TestProfileTypeSoundness.
If Go had sum types and exhaustive switch statments then the compiler
would be our test that enabledProfileTypes doesn't miss anything ;)
