### PR TITLE
refactor(config): migrate ciVisibilityAgentless

### DIFF
--- a/ddtrace/tracer/civisibility_transport.go
+++ b/ddtrace/tracer/civisibility_transport.go
@@ -73,8 +73,8 @@ func newCiVisibilityTransport(config *config) *ciVisibilityTransport {
 		defaultHeaders["Datadog-Entity-ID"] = eid
 	}
 
-	// Determine if agentless mode is enabled through an environment variable.
-	agentlessEnabled := internal.BoolEnv(constants.CIVisibilityAgentlessEnabledEnvironmentVariable, false)
+	// Determine if agentless mode is enabled (sourced from internal/config).
+	agentlessEnabled := config.internalConfig.CIVisibilityAgentless()
 
 	testCycleURL := ""
 	if agentlessEnabled {

--- a/ddtrace/tracer/civisibility_transport_test.go
+++ b/ddtrace/tracer/civisibility_transport_test.go
@@ -87,13 +87,8 @@ func runTransportTest(t *testing.T, agentless, shouldSetAPIKey bool) {
 	defer srv.Close()
 
 	parsedURL, _ := url.Parse(srv.URL)
-	cfg, err := newTestConfig()
-	assert.NoError(err)
-	cfg.internalConfig.SetCIVisibilityEnabled(true, internalconfig.OriginCode)
-	cfg.httpClient = internal.DefaultHTTPClient(defaultHTTPTimeout, false)
-	cfg.internalConfig.SetAgentURL(parsedURL, internalconfig.OriginCode)
 
-	// Set CI Visibility environment variables for the test
+	// Set CI Visibility environment variables before config init so internalConfig picks them up.
 	if agentless {
 		t.Setenv(constants.CIVisibilityAgentlessEnabledEnvironmentVariable, "1")
 		t.Setenv(constants.CIVisibilityAgentlessURLEnvironmentVariable, srv.URL)
@@ -101,6 +96,12 @@ func runTransportTest(t *testing.T, agentless, shouldSetAPIKey bool) {
 			t.Setenv(constants.APIKeyEnvironmentVariable, "12345")
 		}
 	}
+
+	cfg, err := newTestConfig()
+	assert.NoError(err)
+	cfg.internalConfig.SetCIVisibilityEnabled(true, internalconfig.OriginCode)
+	cfg.httpClient = internal.DefaultHTTPClient(defaultHTTPTimeout, false)
+	cfg.internalConfig.SetAgentURL(parsedURL, internalconfig.OriginCode)
 
 	for _, tc := range testCases {
 		transport := newCiVisibilityTransport(cfg)
@@ -132,7 +133,7 @@ func TestCIVisibilityTransportSecureLogging(t *testing.T) {
 			os.Unsetenv(constants.CIVisibilityAgentlessURLEnvironmentVariable)
 		}()
 
-		cfg := &config{}
+		cfg := &config{internalConfig: internalconfig.CreateNew()}
 		transport := newCiVisibilityTransport(cfg)
 		assert.NotNil(t, transport)
 

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -232,9 +232,6 @@ type config struct {
 	// it is frozen -- it cannot be overwritten by Remote Config.
 	dynamicInstrumentationEnabled dynamicConfig[bool]
 
-	// ciVisibilityAgentless controls if the tracer is loaded with CI Visibility agentless mode. default false
-	ciVisibilityAgentless bool
-
 	// ciVisibilityNoopTracer controls if CI Visibility must set a wrapper to behave like a noop tracer. default false
 	ciVisibilityNoopTracer bool
 
@@ -415,12 +412,12 @@ func newConfig(opts ...StartOption) (*config, error) {
 		c.internalConfig.SetLogStartup(false, internalconfig.OriginCalculated) // If we are in CI Visibility mode we don't want to log the startup to stdout to avoid polluting the output
 		ciTransport := newCiVisibilityTransport(c)                             // Create a default CI Visibility Transport
 		c.ddTransport = ciTransport                                            // Replace the default transport with the CI Visibility transport
-		c.ciVisibilityAgentless = ciTransport.agentless
+		c.internalConfig.SetCIVisibilityAgentless(ciTransport.agentless, internalconfig.OriginCalculated, internalconfig.ProductTracer)
 		c.ciVisibilityNoopTracer = internal.BoolEnv(constants.CIVisibilityUseNoopTracer, false)
 	}
 
 	// if using stdout or traces are disabled or we are in ci visibility agentless mode, agent is disabled
-	agentDisabled := c.internalConfig.LogToStdout() || !c.enabled.get() || c.ciVisibilityAgentless
+	agentDisabled := c.internalConfig.LogToStdout() || !c.enabled.get() || c.internalConfig.CIVisibilityAgentless()
 	agentURL := c.internalConfig.AgentURL()
 	af := loadAgentFeatures(agentDisabled, agentURL, c.httpClient)
 	c.agent.store(af)
@@ -771,7 +768,7 @@ func loadAgentFeatures(agentDisabled bool, agentURL *url.URL, httpClient *http.C
 // The agent is considered disabled in serverless (LogToStdout), when the
 // tracer itself is disabled, or in CI visibility agentless mode.
 func (c *config) agentEnabled() bool {
-	return !c.internalConfig.LogToStdout() && c.enabled.get() && !c.ciVisibilityAgentless
+	return !c.internalConfig.LogToStdout() && c.enabled.get() && !c.internalConfig.CIVisibilityAgentless()
 }
 
 // MarkIntegrationImported labels the given integration as imported

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -416,7 +416,7 @@ func newConfig(opts ...StartOption) (*config, error) {
 	}
 
 	// if using stdout or traces are disabled or we are in ci visibility agentless mode, agent is disabled
-	agentDisabled := c.internalConfig.LogToStdout() || !c.enabled.get() || c.internalConfig.CIVisibilityAgentless()
+	agentDisabled := c.internalConfig.LogToStdout() || !c.enabled.get() || c.internalConfig.CIVisibilityAgentlessActive()
 	agentURL := c.internalConfig.AgentURL()
 	af := loadAgentFeatures(agentDisabled, agentURL, c.httpClient)
 	c.agent.store(af)
@@ -767,7 +767,7 @@ func loadAgentFeatures(agentDisabled bool, agentURL *url.URL, httpClient *http.C
 // The agent is considered disabled in serverless (LogToStdout), when the
 // tracer itself is disabled, or in CI visibility agentless mode.
 func (c *config) agentEnabled() bool {
-	return !c.internalConfig.LogToStdout() && c.enabled.get() && !c.internalConfig.CIVisibilityAgentless()
+	return !c.internalConfig.LogToStdout() && c.enabled.get() && !c.internalConfig.CIVisibilityAgentlessActive()
 }
 
 // MarkIntegrationImported labels the given integration as imported

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -412,7 +412,6 @@ func newConfig(opts ...StartOption) (*config, error) {
 		c.internalConfig.SetLogStartup(false, internalconfig.OriginCalculated) // If we are in CI Visibility mode we don't want to log the startup to stdout to avoid polluting the output
 		ciTransport := newCiVisibilityTransport(c)                             // Create a default CI Visibility Transport
 		c.ddTransport = ciTransport                                            // Replace the default transport with the CI Visibility transport
-		c.internalConfig.SetCIVisibilityAgentless(ciTransport.agentless, internalconfig.OriginCalculated, internalconfig.ProductTracer)
 		c.ciVisibilityNoopTracer = internal.BoolEnv(constants.CIVisibilityUseNoopTracer, false)
 	}
 

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/internal"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/globalconfig"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
@@ -2254,4 +2255,15 @@ func TestCanComputeStats(t *testing.T) {
 		assert.False(t, c.canComputeStats())
 		assert.False(t, c.canDropP0s())
 	})
+}
+
+// Regression: agentless flag set without CI Visibility enabled must not disable the agent.
+// Pre-config-migration, c.ciVisibilityAgentless was only assigned inside the CI Vis block,
+// so the raw env var alone couldn't flip agent-bypass behavior.
+func TestAgentEnabledWithAgentlessEnvOnly(t *testing.T) {
+	t.Setenv(constants.CIVisibilityAgentlessEnabledEnvironmentVariable, "true")
+	c, err := newTestConfig()
+	require.NoError(t, err)
+	assert.True(t, c.agentEnabled(), "agent must remain enabled when CI Visibility is off")
+	assert.False(t, c.internalConfig.CIVisibilityAgentlessActive(), "agentless mode must not be active without CI Visibility")
 }

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -2258,8 +2258,6 @@ func TestCanComputeStats(t *testing.T) {
 }
 
 // Regression: agentless flag set without CI Visibility enabled must not disable the agent.
-// Pre-config-migration, c.ciVisibilityAgentless was only assigned inside the CI Vis block,
-// so the raw env var alone couldn't flip agent-bypass behavior.
 func TestAgentEnabledWithAgentlessEnvOnly(t *testing.T) {
 	t.Setenv(constants.CIVisibilityAgentlessEnabledEnvironmentVariable, "true")
 	c, err := newTestConfig()

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -119,7 +119,7 @@ func startTelemetry(c *config) telemetry.Client {
 	if (!a.reachable || a.hasTelemetryProxy) && !c.internalConfig.LogToStdout() {
 		cfg.AgentURL = c.internalConfig.AgentURL().String()
 	}
-	if c.internalConfig.LogToStdout() || c.internalConfig.CIVisibilityAgentless() {
+	if c.internalConfig.LogToStdout() || c.internalConfig.CIVisibilityAgentlessActive() {
 		cfg.APIKey = c.internalConfig.APIKey()
 	}
 	client, err := telemetry.NewClient(c.internalConfig.ServiceName(), c.internalConfig.Env(), c.internalConfig.Version(), cfg)

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -119,7 +119,7 @@ func startTelemetry(c *config) telemetry.Client {
 	if (!a.reachable || a.hasTelemetryProxy) && !c.internalConfig.LogToStdout() {
 		cfg.AgentURL = c.internalConfig.AgentURL().String()
 	}
-	if c.internalConfig.LogToStdout() || c.ciVisibilityAgentless {
+	if c.internalConfig.LogToStdout() || c.internalConfig.CIVisibilityAgentless() {
 		cfg.APIKey = c.internalConfig.APIKey()
 	}
 	client, err := telemetry.NewClient(c.internalConfig.ServiceName(), c.internalConfig.Env(), c.internalConfig.Version(), cfg)

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -260,7 +260,7 @@ func Start(opts ...StartOption) error {
 	if t.dataStreams != nil {
 		t.dataStreams.Start()
 	}
-	if t.config.internalConfig.CIVisibilityAgentless() {
+	if t.config.internalConfig.CIVisibilityAgentlessActive() {
 		// CI Visibility agentless mode doesn't require remote configuration.
 
 		// start instrumentation telemetry unless it is disabled through the

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -260,7 +260,7 @@ func Start(opts ...StartOption) error {
 	if t.dataStreams != nil {
 		t.dataStreams.Start()
 	}
-	if t.config.ciVisibilityAgentless {
+	if t.config.internalConfig.CIVisibilityAgentless() {
 		// CI Visibility agentless mode doesn't require remote configuration.
 
 		// start instrumentation telemetry unless it is disabled through the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -938,16 +938,6 @@ func (c *Config) CIVisibilityAgentless() bool {
 	return c.ciVisibilityAgentless
 }
 
-func (c *Config) SetCIVisibilityAgentless(enabled bool, origin telemetry.Origin, product ...Product) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.checkProductConflict(constants.CIVisibilityAgentlessEnabledEnvironmentVariable, origin, enabled, product...) {
-		return
-	}
-	c.ciVisibilityAgentless = enabled
-	configtelemetry.Report(constants.CIVisibilityAgentlessEnabledEnvironmentVariable, enabled, origin)
-}
-
 func (c *Config) LogsOTelEnabled() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -215,7 +215,7 @@ func loadConfig() *Config {
 	cfg.dataStreamsMonitoringEnabled = p.GetBool("DD_DATA_STREAMS_ENABLED", false)
 	cfg.dynamicInstrumentationEnabled = p.GetBool("DD_DYNAMIC_INSTRUMENTATION_ENABLED", false)
 	cfg.ciVisibilityEnabled = p.GetBool(constants.CIVisibilityEnabledEnvironmentVariable, false)
-	cfg.ciVisibilityAgentless = p.GetBool("DD_CIVISIBILITY_AGENTLESS_ENABLED", false)
+	cfg.ciVisibilityAgentless = p.GetBool(constants.CIVisibilityAgentlessEnabledEnvironmentVariable, false)
 	cfg.logDirectory = p.GetString("DD_TRACE_LOG_DIRECTORY", "")
 	cfg.traceRateLimitPerSecond = p.GetFloatWithValidator("DD_TRACE_RATE_LIMIT", DefaultRateLimit, validateRateLimit)
 	cfg.debugStack = p.GetBool("DD_TRACE_DEBUG_STACK", true)
@@ -930,6 +930,22 @@ func (c *Config) SetCIVisibilityEnabled(enabled bool, origin telemetry.Origin, p
 	}
 	c.ciVisibilityEnabled = enabled
 	configtelemetry.Report(constants.CIVisibilityEnabledEnvironmentVariable, enabled, origin)
+}
+
+func (c *Config) CIVisibilityAgentless() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.ciVisibilityAgentless
+}
+
+func (c *Config) SetCIVisibilityAgentless(enabled bool, origin telemetry.Origin, product ...Product) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.checkProductConflict(constants.CIVisibilityAgentlessEnabledEnvironmentVariable, origin, enabled, product...) {
+		return
+	}
+	c.ciVisibilityAgentless = enabled
+	configtelemetry.Report(constants.CIVisibilityAgentlessEnabledEnvironmentVariable, enabled, origin)
 }
 
 func (c *Config) LogsOTelEnabled() bool {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -938,6 +938,14 @@ func (c *Config) CIVisibilityAgentless() bool {
 	return c.ciVisibilityAgentless
 }
 
+// CIVisibilityAgentlessActive reports whether agentless CI Visibility mode is in effect.
+// Agentless is only meaningful when CI Visibility itself is enabled.
+func (c *Config) CIVisibilityAgentlessActive() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.ciVisibilityEnabled && c.ciVisibilityAgentless
+}
+
 func (c *Config) LogsOTelEnabled() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -958,6 +958,8 @@ func (c *Config) SetCIVisibilityEnabled(enabled bool, origin telemetry.Origin, p
 	configtelemetry.Report(constants.CIVisibilityEnabledEnvironmentVariable, enabled, origin)
 }
 
+// CIVisibilityAgentless returns the raw DD_CIVISIBILITY_AGENTLESS_ENABLED value.
+// Only valid inside a CIVisibilityEnabled() block; prefer CIVisibilityAgentlessActive() elsewhere.
 func (c *Config) CIVisibilityAgentless() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry/telemetrytest"
 )
@@ -884,4 +885,34 @@ func TestAPIKey(t *testing.T) {
 		require.NotNil(t, cfg)
 		assert.Equal(t, "", cfg.APIKey())
 	})
+}
+
+func TestCIVisibilityAgentlessActive(t *testing.T) {
+	// Agentless is only "active" when CI Visibility is also enabled.
+	// Agentless alone must not flip agent-bypass behavior in normal tracer mode.
+	cases := []struct {
+		name      string
+		ciVis     string
+		agentless string
+		want      bool
+	}{
+		{"both unset", "", "", false},
+		{"agentless only", "", "true", false},
+		{"ci vis only", "true", "", false},
+		{"both set", "true", "true", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetGlobalState()
+			defer resetGlobalState()
+			if tc.ciVis != "" {
+				t.Setenv(constants.CIVisibilityEnabledEnvironmentVariable, tc.ciVis)
+			}
+			if tc.agentless != "" {
+				t.Setenv(constants.CIVisibilityAgentlessEnabledEnvironmentVariable, tc.agentless)
+			}
+			cfg := CreateNew()
+			assert.Equal(t, tc.want, cfg.CIVisibilityAgentlessActive())
+		})
+	}
 }


### PR DESCRIPTION
### What does this PR do?
Migrates `ciVisibilityAgentless` from `ddtrace/tracer.config` to be owned by `internal/config`.

- Adds `CIVisibilityAgentless()` getter and `SetCIVisibilityAgentless(...)` setter on `*Config`.
- Routes the CI Visibility transport's runtime determination through the setter
- Updates the four read sites in `ddtrace/tracer` to read via `internalConfig`.
- Switches the env-init line to use the existing `constants.CIVisibilityAgentlessEnabledEnvironmentVariable` for consistency with the sister field `ciVisibilityEnabled`.

### Motivation
Part of the ongoing tracer config migration. Refs APMAPI-1888.

### Reviewer's Checklist
- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] System-Tests covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors.
- [x] New code doesn't break existing tests.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date.
- [x] Non-trivial go.mod changes — none.