### PR TITLE
refactor(config): migrate traceAnalyticsEnabled

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -283,7 +283,7 @@ func newConfig(opts ...StartOption) (*config, error) {
 	if v := env.Get("OTEL_LOGS_EXPORTER"); v != "" {
 		log.Warn("OTEL_LOGS_EXPORTER is not supported")
 	}
-	if internal.BoolEnv("DD_TRACE_ANALYTICS_ENABLED", false) {
+	if c.internalConfig.TraceAnalyticsEnabled() {
 		globalconfig.SetAnalyticsRate(1.0)
 	}
 	if c.internalConfig.ReportHostname() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,9 +105,7 @@ type Config struct {
 	// from DD_TRACE_PARTIAL_FLUSH_ENABLED, default false.
 	partialFlushEnabled bool
 	// statsComputationEnabled enables client-side stats computation (aka trace metrics).
-	statsComputationEnabled bool
-	// traceAnalyticsEnabled is the legacy DD_TRACE_ANALYTICS_ENABLED toggle (sets the
-	// global analytics rate to 1.0 when true).
+	statsComputationEnabled      bool
 	traceAnalyticsEnabled        bool
 	dataStreamsMonitoringEnabled bool
 	// dynamicInstrumentationEnabled controls if the target application can be modified by Dynamic Instrumentation or not.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,7 +105,10 @@ type Config struct {
 	// from DD_TRACE_PARTIAL_FLUSH_ENABLED, default false.
 	partialFlushEnabled bool
 	// statsComputationEnabled enables client-side stats computation (aka trace metrics).
-	statsComputationEnabled      bool
+	statsComputationEnabled bool
+	// traceAnalyticsEnabled is the legacy DD_TRACE_ANALYTICS_ENABLED toggle (sets the
+	// global analytics rate to 1.0 when true).
+	traceAnalyticsEnabled        bool
 	dataStreamsMonitoringEnabled bool
 	// dynamicInstrumentationEnabled controls if the target application can be modified by Dynamic Instrumentation or not.
 	dynamicInstrumentationEnabled bool
@@ -212,6 +215,7 @@ func loadConfig() *Config {
 	cfg.partialFlushMinSpans = p.GetIntWithValidator("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", 1000, validatePartialFlushMinSpans)
 	cfg.partialFlushEnabled = p.GetBool("DD_TRACE_PARTIAL_FLUSH_ENABLED", false)
 	cfg.statsComputationEnabled = p.GetBool("DD_TRACE_STATS_COMPUTATION_ENABLED", true)
+	cfg.traceAnalyticsEnabled = p.GetBool("DD_TRACE_ANALYTICS_ENABLED", false)
 	cfg.dataStreamsMonitoringEnabled = p.GetBool("DD_DATA_STREAMS_ENABLED", false)
 	cfg.dynamicInstrumentationEnabled = p.GetBool("DD_DYNAMIC_INSTRUMENTATION_ENABLED", false)
 	cfg.ciVisibilityEnabled = p.GetBool(constants.CIVisibilityEnabledEnvironmentVariable, false)
@@ -635,6 +639,12 @@ func (c *Config) SetStatsComputationEnabled(enabled bool, origin telemetry.Origi
 	}
 	c.statsComputationEnabled = enabled
 	configtelemetry.Report("DD_TRACE_STATS_COMPUTATION_ENABLED", enabled, origin)
+}
+
+func (c *Config) TraceAnalyticsEnabled() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.traceAnalyticsEnabled
 }
 
 func (c *Config) LogDirectory() string {


### PR DESCRIPTION
### What does this PR do?
Migrates the `DD_TRACE_ANALYTICS_ENABLED` env-var read from `ddtrace/tracer` to be owned by `internal/config`.

- Adds `traceAnalyticsEnabled` field, `loadConfig` env-init, and `TraceAnalyticsEnabled()` getter on `*Config`.
- Switches the lone tracer call site (`option.go:286`) from `internal.BoolEnv` to `internalConfig.TraceAnalyticsEnabled()`.

### Motivation
Part of the ongoing tracer config migration. Refs APMAPI-1891.

### Reviewer's Checklist
- [x] Changed code has unit tests for its functionality at or near 100% coverage (existing tests in `option_test.go` cover the `env/on` and `env/off` cases).
- [ ] System-Tests covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors.
- [x] New code doesn't break existing tests.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date.
- [x] Non-trivial go.mod changes — none.
