### PR TITLE
feat(config): migrate dogstatsdAddr, add DD_DOGSTATSD_URL

### DIFF
--- a/ddtrace/tracer/log.go
+++ b/ddtrace/tracer/log.go
@@ -160,7 +160,7 @@ func logStartup(t *tracer) {
 		PropagationStyleInject:      injectorNames,
 		PropagationStyleExtract:     extractorNames,
 		TracingAsTransport:          t.config.tracingAsTransport,
-		DogstatsdAddr:               t.config.dogstatsdAddr,
+		DogstatsdAddr:               t.config.internalConfig.DogstatsdAddr(),
 		DataStreamsEnabled:          t.config.internalConfig.DataStreamsMonitoringEnabled(),
 	}
 	if _, _, err := samplingRulesFromEnv(); err != nil {

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -426,7 +426,7 @@ func newConfig(opts ...StartOption) (*config, error) {
 		// Push the agent-reported StatsdPort into internal/config so it can
 		// fill in the resolved port if no other source provided one. Then
 		// mirror the resolved value into globalconfig for contrib readers.
-		c.internalConfig.SetAgentReportedStatsdPort(af.StatsdPort)
+		c.internalConfig.ApplyAgentReportedStatsdPort(af.StatsdPort)
 		globalconfig.SetDogstatsdAddr(c.internalConfig.DogstatsdAddr())
 	}
 	// Re-initialize the globalTags config with the value constructed from the environment and start options

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -14,14 +14,12 @@ import (
 	"io"
 	"maps"
 	"math"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -122,15 +120,6 @@ var contribIntegrations = map[string]struct {
 	"github.com/valkey-io/valkey-go":                {"Valkey", false},
 }
 
-var (
-	// defaultSocketDSD specifies the socket path to use for connecting to the statsd server.
-	// Replaced in tests
-	defaultSocketDSD = "/var/run/datadog/dsd.socket"
-
-	// defaultStatsdPort specifies the default port to use for connecting to the statsd server.
-	defaultStatsdPort = "8125"
-)
-
 // Supported trace protocols.
 const (
 	traceProtocolV04 = internalconfig.TraceProtocolV04
@@ -188,11 +177,6 @@ type config struct {
 	// logger specifies the logger to use when printing errors. If not specified, the "log" package
 	// will be used.
 	logger Logger
-
-	// dogstatsdAddr specifies the address to connect for sending metrics to the
-	// Datadog Agent. If not set, it defaults to "localhost:8125" or to the
-	// combination of the environment variables DD_AGENT_HOST and DD_DOGSTATSD_PORT.
-	dogstatsdAddr string
 
 	// statsdClient is set when a user provides a custom statsd client for tracking metrics
 	// associated with the runtime and the tracer.
@@ -439,10 +423,11 @@ func newConfig(opts ...StartOption) (*config, error) {
 		c.loadContribIntegrations(info.Deps)
 	}
 	if c.statsdClient == nil {
-		// configure statsd client
-		addr := resolveDogstatsdAddr(c.dogstatsdAddr, af, defaultSocketDSD)
-		globalconfig.SetDogstatsdAddr(addr)
-		c.dogstatsdAddr = addr
+		// Push the agent-reported StatsdPort into internal/config so it can
+		// fill in the resolved port if no other source provided one. Then
+		// mirror the resolved value into globalconfig for contrib readers.
+		c.internalConfig.SetAgentReportedStatsdPort(af.StatsdPort)
+		globalconfig.SetDogstatsdAddr(c.internalConfig.DogstatsdAddr())
 	}
 	// Re-initialize the globalTags config with the value constructed from the environment and start options
 	// This allows persisting the initial value of globalTags for future resets and updates.
@@ -508,66 +493,11 @@ func resolveTraceTransport(cfg *internalconfig.Config) (traceURL string, headers
 	return traceURL, datadogHeaders()
 }
 
-// resolveDogstatsdAddr resolves the Dogstatsd address to use with the following
-// priority order:
-//  1. Explicitly configured address via WithDogstatsdAddr.
-//  2. Environment variables DD_DOGSTATSD_HOST (or DD_AGENT_HOST) and DD_DOGSTATSD_PORT.
-//  3. Auto-discovery: UDS socket at /var/run/datadog/dsd.socket, agent-reported port,
-//     or the default localhost:8125.
-func resolveDogstatsdAddr(configAddr string, af agentFeatures, socketDSDPath string) string {
-	// 1. User explicitly set address via WithDogstatsdAddr; honor it as-is.
-	if configAddr != "" {
-		return configAddr
-	}
-
-	// 2. Build address from dogstatsd-specific environment variables.
-	// DD_AGENT_HOST is only used as a host fallback when DD_DOGSTATSD_HOST or
-	// DD_DOGSTATSD_PORT is set — on its own it does not trigger this path.
-	envHost := env.Get("DD_DOGSTATSD_HOST")
-	envPort := env.Get("DD_DOGSTATSD_PORT")
-	if envHost != "" || envPort != "" {
-		host := envHost
-		if host == "" {
-			host = env.Get("DD_AGENT_HOST")
-		}
-		if host == "" {
-			host = defaultHostname
-		}
-		// For the port, prefer the env var, then the agent-reported port
-		// (loaded from the trace-agent /info endpoint), then the default.
-		port := envPort
-		if port == "" && af.StatsdPort != 0 {
-			port = strconv.Itoa(af.StatsdPort)
-		} else if port == "" {
-			port = defaultStatsdPort
-		}
-		return net.JoinHostPort(host, port)
-	}
-
-	// 3. No user configuration at all — auto-discover.
-	// Check for the UDS socket first; this is the preferred transport when available.
-	if _, err := os.Stat(socketDSDPath); err == nil {
-		return "unix://" + socketDSDPath
-	}
-	// For TCP, use DD_AGENT_HOST as the hostname if available, otherwise localhost.
-	host := env.Get("DD_AGENT_HOST")
-	if host == "" {
-		host = defaultHostname
-	}
-	// Use the agent-reported port if available. Agent features are loaded from
-	// the trace-agent, which may not be running — in that case StatsdPort is 0.
-	if af.StatsdPort != 0 {
-		return net.JoinHostPort(host, strconv.Itoa(af.StatsdPort))
-	}
-	// Fall back to default port 8125.
-	return net.JoinHostPort(host, defaultStatsdPort)
-}
-
 func newStatsdClient(c *config) (internal.StatsdClient, error) {
 	if c.statsdClient != nil {
 		return c.statsdClient, nil
 	}
-	return internal.NewStatsdClient(c.dogstatsdAddr, statsTags(c))
+	return internal.NewStatsdClient(c.internalConfig.DogstatsdAddr(), statsTags(c))
 }
 
 type integrationConfig struct {
@@ -1144,8 +1074,7 @@ func WithRuntimeMetrics() StartOption {
 // This option is in effect when WithRuntimeMetrics is enabled.
 func WithDogstatsdAddr(addr string) StartOption {
 	return func(cfg *config) {
-		cfg.dogstatsdAddr = addr
-		globalconfig.SetDogstatsdAddr(addr)
+		cfg.internalConfig.SetDogstatsdAddr(addr, telemetry.OriginCode, internalconfig.ProductTracer)
 	}
 }
 

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -566,6 +566,28 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			assert.Equal(t, "localhost:123", globalconfig.DogstatsdAddr())
 		})
 
+		t.Run("env-url", func(t *testing.T) {
+			t.Setenv("DD_DOGSTATSD_URL", "10.1.0.12:4002")
+			tracer, err := newTracer(opts...)
+			assert.NoError(t, err)
+			defer tracer.Stop()
+			c := tracer.config
+			assert.Equal(t, "10.1.0.12:4002", c.internalConfig.DogstatsdAddr())
+			assert.Equal(t, "10.1.0.12:4002", globalconfig.DogstatsdAddr())
+		})
+
+		t.Run("env-url overrides host+port", func(t *testing.T) {
+			t.Setenv("DD_DOGSTATSD_URL", "10.1.0.12:4002")
+			t.Setenv("DD_DOGSTATSD_HOST", "ignored")
+			t.Setenv("DD_DOGSTATSD_PORT", "9999")
+			tracer, err := newTracer(opts...)
+			assert.NoError(t, err)
+			defer tracer.Stop()
+			c := tracer.config
+			assert.Equal(t, "10.1.0.12:4002", c.internalConfig.DogstatsdAddr())
+			assert.Equal(t, "10.1.0.12:4002", globalconfig.DogstatsdAddr())
+		})
+
 		t.Run("env-port: agent not available", func(t *testing.T) {
 			t.Setenv("DD_DOGSTATSD_PORT", "123")
 			fail = true

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -78,7 +78,7 @@ func testStatsd(t *testing.T, cfg *config, addr string) {
 	client, err := newStatsdClient(cfg)
 	require.NoError(t, err)
 	defer client.Close()
-	require.Equal(t, addr, cfg.dogstatsdAddr)
+	require.Equal(t, addr, cfg.internalConfig.DogstatsdAddr())
 	_, err = net.ResolveUDPAddr("udp", addr)
 	require.NoError(t, err)
 
@@ -102,7 +102,7 @@ func TestStatsdUDPConnect(t *testing.T) {
 	client, err := newStatsdClient(cfg)
 	require.NoError(t, err)
 	defer client.Close()
-	require.Equal(t, addr, cfg.dogstatsdAddr)
+	require.Equal(t, addr, cfg.internalConfig.DogstatsdAddr())
 	udpaddr, err := net.ResolveUDPAddr("udp", addr)
 	require.NoError(t, err)
 	conn, err := net.ListenUDP("udp", udpaddr)
@@ -150,8 +150,8 @@ func TestAutoDetectStatsd(t *testing.T) {
 		}
 		addr := filepath.Join(dir, "dsd.socket")
 
-		defer func(old string) { defaultSocketDSD = old }(defaultSocketDSD)
-		defaultSocketDSD = addr
+		defer func(old string) { internalconfig.DefaultSocketDSDPath = old }(internalconfig.DefaultSocketDSDPath)
+		internalconfig.DefaultSocketDSDPath = addr
 
 		uaddr, err := net.ResolveUnixAddr("unixgram", addr)
 		if err != nil {
@@ -169,7 +169,7 @@ func TestAutoDetectStatsd(t *testing.T) {
 		statsd, err := newStatsdClient(cfg)
 		require.NoError(t, err)
 		defer statsd.Close()
-		require.Equal(t, cfg.dogstatsdAddr, "unix://"+addr)
+		require.Equal(t, cfg.internalConfig.DogstatsdAddr(), "unix://"+addr)
 		// Ensure globalconfig also gets the auto-detected UDS address
 		require.Equal(t, "unix://"+addr, globalconfig.DogstatsdAddr())
 		statsd.Count("name", 1, []string{"tag"}, 1)
@@ -408,7 +408,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 		assert.Equal(float64(1), c.sampler.Rate())
 		assert.Regexp(`tracer\.test(\.exe)?`, c.internalConfig.ServiceName())
 		assert.Equal(&url.URL{Scheme: "http", Host: "localhost:8126"}, c.internalConfig.RawAgentURL())
-		assert.Equal("localhost:8125", c.dogstatsdAddr)
+		assert.Equal("localhost:8125", c.internalConfig.DogstatsdAddr())
 		assert.Nil(nil, c.httpClient)
 		x := *c.httpClient
 		y := *internal.DefaultHTTPClient(defaultHTTPTimeout, false)
@@ -532,7 +532,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			assert.NoError(t, err)
 			defer tracer.Stop()
 			c := tracer.config
-			assert.Equal(t, "localhost:8125", c.dogstatsdAddr)
+			assert.Equal(t, "localhost:8125", c.internalConfig.DogstatsdAddr())
 			assert.Equal(t, "localhost:8125", globalconfig.DogstatsdAddr())
 		})
 
@@ -542,7 +542,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			assert.NoError(t, err)
 			defer tracer.Stop()
 			c := tracer.config
-			assert.Equal(t, "localhost:8125", c.dogstatsdAddr)
+			assert.Equal(t, "localhost:8125", c.internalConfig.DogstatsdAddr())
 			assert.Equal(t, "localhost:8125", globalconfig.DogstatsdAddr())
 		})
 
@@ -552,7 +552,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			assert.NoError(t, err)
 			defer tracer.Stop()
 			c := tracer.config
-			assert.Equal(t, "localhost:8125", c.dogstatsdAddr)
+			assert.Equal(t, "localhost:8125", c.internalConfig.DogstatsdAddr())
 			assert.Equal(t, "localhost:8125", globalconfig.DogstatsdAddr())
 		})
 
@@ -562,7 +562,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			defer tracer.Stop()
 			assert.NoError(t, err)
 			c := tracer.config
-			assert.Equal(t, "localhost:123", c.dogstatsdAddr)
+			assert.Equal(t, "localhost:123", c.internalConfig.DogstatsdAddr())
 			assert.Equal(t, "localhost:123", globalconfig.DogstatsdAddr())
 		})
 
@@ -573,7 +573,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			assert.NoError(t, err)
 			defer tracer.Stop()
 			c := tracer.config
-			assert.Equal(t, "localhost:123", c.dogstatsdAddr)
+			assert.Equal(t, "localhost:123", c.internalConfig.DogstatsdAddr())
 			assert.Equal(t, "localhost:123", globalconfig.DogstatsdAddr())
 			fail = false
 		})
@@ -586,7 +586,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			assert.NoError(t, err)
 			defer tracer.Stop()
 			c := tracer.config
-			assert.Equal(t, "localhost:123", c.dogstatsdAddr)
+			assert.Equal(t, "localhost:123", c.internalConfig.DogstatsdAddr())
 			assert.Equal(t, "localhost:123", globalconfig.DogstatsdAddr())
 		})
 
@@ -599,7 +599,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			assert.NoError(t, err)
 			defer tracer.Stop()
 			c := tracer.config
-			assert.Equal(t, "localhost:123", c.dogstatsdAddr)
+			assert.Equal(t, "localhost:123", c.internalConfig.DogstatsdAddr())
 			assert.Equal(t, "localhost:123", globalconfig.DogstatsdAddr())
 			fail = false
 		})
@@ -612,7 +612,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			assert.NoError(t, err)
 			defer tracer.Stop()
 			c := tracer.config
-			assert.Equal(t, "10.1.0.12:4002", c.dogstatsdAddr)
+			assert.Equal(t, "10.1.0.12:4002", c.internalConfig.DogstatsdAddr())
 			assert.Equal(t, "10.1.0.12:4002", globalconfig.DogstatsdAddr())
 		})
 
@@ -625,7 +625,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			assert.NoError(t, err)
 			defer tracer.Stop()
 			c := tracer.config
-			assert.Equal(t, "10.1.0.12:4002", c.dogstatsdAddr)
+			assert.Equal(t, "10.1.0.12:4002", c.internalConfig.DogstatsdAddr())
 			assert.Equal(t, "10.1.0.12:4002", globalconfig.DogstatsdAddr())
 			fail = false
 		})
@@ -645,7 +645,7 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			assert.NoError(err)
 			defer tracer.Stop()
 			c := tracer.config
-			assert.Equal("unix://"+addr, c.dogstatsdAddr)
+			assert.Equal("unix://"+addr, c.internalConfig.DogstatsdAddr())
 			assert.Equal("unix://"+addr, globalconfig.DogstatsdAddr())
 		})
 	})
@@ -1023,148 +1023,6 @@ func TestDefaultHTTPClient(t *testing.T) {
 	})
 }
 
-func TestResolveDogstatsdAddr(t *testing.T) {
-	socketFile, err := os.CreateTemp("", "dsd.socket")
-	require.NoError(t, err)
-	require.NoError(t, socketFile.Close())
-	t.Cleanup(func() { os.RemoveAll(socketFile.Name()) })
-	socketPath := socketFile.Name()
-
-	tests := []struct {
-		name       string
-		configAddr string
-		af         agentFeatures
-		env        map[string]string
-		socketPath string
-		expected   string
-	}{
-		{
-			name:     "defaults",
-			expected: "localhost:8125",
-		},
-		{
-			name:     "host-env",
-			env:      map[string]string{"DD_DOGSTATSD_HOST": "111.111.1.1", "DD_AGENT_HOST": "222.222.2.2"},
-			expected: "111.111.1.1:8125",
-		},
-		{
-			name:     "port-env",
-			env:      map[string]string{"DD_DOGSTATSD_PORT": "8111"},
-			expected: "localhost:8111",
-		},
-		{
-			name:     "port-env+agent-host-env",
-			env:      map[string]string{"DD_DOGSTATSD_PORT": "8111", "DD_AGENT_HOST": "222.222.2.2"},
-			expected: "222.222.2.2:8111",
-		},
-		{
-			name:     "host-env+port-env",
-			env:      map[string]string{"DD_DOGSTATSD_HOST": "111.111.1.1", "DD_DOGSTATSD_PORT": "8888", "DD_AGENT_HOST": "222.222.2.2"},
-			expected: "111.111.1.1:8888",
-		},
-		{
-			name:       "host-env+socket",
-			env:        map[string]string{"DD_DOGSTATSD_HOST": "111.111.1.1"},
-			socketPath: socketPath,
-			expected:   "111.111.1.1:8125",
-		},
-		{
-			name:       "port-env+socket",
-			env:        map[string]string{"DD_DOGSTATSD_PORT": "8111"},
-			socketPath: socketPath,
-			expected:   "localhost:8111",
-		},
-		{
-			name:       "socket",
-			socketPath: socketPath,
-			expected:   "unix://" + socketPath,
-		},
-		// DD_AGENT_HOST alone should not trigger the env var path;
-		// it falls through to auto-discovery.
-		{
-			name:       "agent-host-env-only+socket",
-			env:        map[string]string{"DD_AGENT_HOST": "222.222.2.2"},
-			socketPath: socketPath,
-			expected:   "unix://" + socketPath,
-		},
-		{
-			name:     "agent-host-env-only",
-			env:      map[string]string{"DD_AGENT_HOST": "222.222.2.2"},
-			expected: "222.222.2.2:8125",
-		},
-		{
-			name:     "agent-host-env-only+agent-port",
-			env:      map[string]string{"DD_AGENT_HOST": "222.222.2.2"},
-			af:       agentFeatures{StatsdPort: 9876},
-			expected: "222.222.2.2:9876",
-		},
-		// configAddr (priority 1) wins over everything.
-		{
-			name:       "config-addr",
-			configAddr: "custom:9999",
-			expected:   "custom:9999",
-		},
-		{
-			name:       "config-addr+env",
-			configAddr: "custom:9999",
-			env:        map[string]string{"DD_DOGSTATSD_HOST": "111.111.1.1", "DD_DOGSTATSD_PORT": "8111"},
-			expected:   "custom:9999",
-		},
-		{
-			name:       "config-addr+socket",
-			configAddr: "custom:9999",
-			socketPath: socketPath,
-			expected:   "custom:9999",
-		},
-		{
-			name:       "config-addr+agent-port",
-			configAddr: "custom:9999",
-			af:         agentFeatures{StatsdPort: 9876},
-			expected:   "custom:9999",
-		},
-		// Agent-reported port used as fallback when env host is set but no env port.
-		{
-			name:     "host-env+agent-port",
-			env:      map[string]string{"DD_DOGSTATSD_HOST": "111.111.1.1"},
-			af:       agentFeatures{StatsdPort: 9876},
-			expected: "111.111.1.1:9876",
-		},
-		// Env port wins over agent-reported port.
-		{
-			name:     "host-env+port-env+agent-port",
-			env:      map[string]string{"DD_DOGSTATSD_HOST": "111.111.1.1", "DD_DOGSTATSD_PORT": "8111"},
-			af:       agentFeatures{StatsdPort: 9876},
-			expected: "111.111.1.1:8111",
-		},
-		// Auto-discovery: agent-reported port when no env and no socket.
-		{
-			name:     "agent-port",
-			af:       agentFeatures{StatsdPort: 9876},
-			expected: "localhost:9876",
-		},
-		// Auto-discovery: socket wins over agent-reported port.
-		{
-			name:       "socket+agent-port",
-			af:         agentFeatures{StatsdPort: 9876},
-			socketPath: socketPath,
-			expected:   "unix://" + socketPath,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Clear all relevant env vars so that each subtest is isolated
-			// from the host environment and other subtests.
-			for _, key := range []string{"DD_DOGSTATSD_HOST", "DD_DOGSTATSD_PORT", "DD_AGENT_HOST"} {
-				t.Setenv(key, "")
-			}
-			for k, v := range tt.env {
-				t.Setenv(k, v)
-			}
-			assert.Equal(t, tt.expected, resolveDogstatsdAddr(tt.configAddr, tt.af, tt.socketPath))
-		})
-	}
-}
 
 func TestServiceName(t *testing.T) {
 	t.Run("WithService", func(t *testing.T) {

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -1023,7 +1023,6 @@ func TestDefaultHTTPClient(t *testing.T) {
 	})
 }
 
-
 func TestServiceName(t *testing.T) {
 	t.Run("WithService", func(t *testing.T) {
 		defer globalconfig.SetServiceName("")

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -54,7 +54,7 @@ func startTelemetry(c *config) telemetry.Client {
 		{Name: "trace_agent_url", Value: c.internalConfig.AgentURL().String()},
 		{Name: "agent_hostname", Value: c.internalConfig.Hostname()},
 		{Name: "runtime_metrics_v2_enabled", Value: c.internalConfig.RuntimeMetricsV2Enabled()},
-		{Name: "dogstatsd_addr", Value: c.dogstatsdAddr},
+		{Name: "dogstatsd_addr", Value: c.internalConfig.DogstatsdAddr()},
 		{Name: "profiling_endpoints_enabled", Value: c.internalConfig.ProfilerEndpoints()},
 		{Name: "debug_stack_enabled", Value: c.internalConfig.DebugStack()},
 		{Name: "profiling_hotspots_enabled", Value: c.internalConfig.ProfilerHotspotsEnabled()},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"maps"
 	"math"
+	"net"
 	"net/url"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -72,7 +74,15 @@ type Config struct {
 
 	// Config fields are protected by the mutex.
 	agentURL *url.URL
-	debug    bool
+	// dogstatsdAddr is the address to connect for sending metrics to the
+	// Datadog Agent. If not set, it defaults to "localhost:8125" or to the
+	// combination of the environment variables DD_AGENT_HOST and DD_DOGSTATSD_PORT.
+	//
+	// The URL stores only what was explicitly set: an empty Port means no
+	// explicit port was provided (the getter fills in the default; the
+	// agent-reported port may also fill it in via SetAgentReportedStatsdPort).
+	dogstatsdAddr *url.URL
+	debug         bool
 	// logStartup, when true, causes various startup info to be written when the tracer starts.
 	logStartup bool
 	// serviceName specifies the name of this application.
@@ -194,6 +204,15 @@ func loadConfig() *Config {
 	agentHost := p.GetString("DD_AGENT_HOST", "")
 	agentPort := p.GetString("DD_TRACE_AGENT_PORT", "")
 	cfg.agentURL = resolveAgentURL(agentURLStr, agentHost, agentPort)
+
+	// DogStatsD address. DD_DOGSTATSD_HOST and DD_DOGSTATSD_PORT are read here
+	// so the provider reports telemetry for them; the values feed into the
+	// initial URL build. An empty Port on the resulting URL means no source
+	// has explicitly set the port yet (default will be filled at read time, or
+	// the agent-reported port may set it via SetAgentReportedStatsdPort).
+	dogstatsdEnvHost := p.GetString("DD_DOGSTATSD_HOST", "")
+	dogstatsdEnvPort := p.GetString("DD_DOGSTATSD_PORT", "")
+	cfg.dogstatsdAddr = initialDogstatsdURL(dogstatsdEnvHost, dogstatsdEnvPort, agentHost, DefaultSocketDSDPath)
 
 	cfg.debug = p.GetBool("DD_TRACE_DEBUG", false)
 	cfg.logStartup = p.GetBool("DD_TRACE_STARTUP_LOGS", true)
@@ -365,6 +384,60 @@ func (c *Config) AgentURL() *url.URL {
 		return internal.UnixDataSocketURL(u.Path)
 	}
 	return u
+}
+
+// DogstatsdAddr returns the resolved DogStatsD address as a string in the
+// form expected by NewStatsdClient: "host:port" for UDP or
+// "unix:///path/to/socket" for UDS. Defaults are filled in here when the
+// underlying URL has no explicit host or port.
+func (c *Config) DogstatsdAddr() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return formatDogstatsdAddr(c.dogstatsdAddr)
+}
+
+// SetDogstatsdAddr records a user-supplied DogStatsD address (priority 1) and
+// replaces the stored URL whole-cloth. Reports config telemetry under
+// DD_DOGSTATSD_URL.
+func (c *Config) SetDogstatsdAddr(addr string, origin telemetry.Origin, product ...Product) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if addr == "" {
+		return
+	}
+	if c.checkProductConflict("DD_DOGSTATSD_URL", origin, addr, product...) {
+		return
+	}
+	c.dogstatsdAddr = parseDogstatsdAddr(addr)
+	configtelemetry.Report("DD_DOGSTATSD_URL", addr, origin)
+}
+
+// SetAgentReportedStatsdPort fills the port on the resolved DogStatsD URL
+// using the value reported by the trace-agent /info endpoint. Skipped when
+// the user has claimed DD_DOGSTATSD_URL, the URL already has a port (env
+// explicitly set it), or the URL is a unix socket. Reports config telemetry
+// under DD_DOGSTATSD_URL with OriginCalculated when the port is applied.
+func (c *Config) SetAgentReportedStatsdPort(port int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if port <= 0 {
+		return
+	}
+	if _, claimed := c.overrides["DD_DOGSTATSD_URL"]; claimed {
+		return
+	}
+	if c.dogstatsdAddr == nil || c.dogstatsdAddr.Scheme == "unix" {
+		return
+	}
+	if c.dogstatsdAddr.Port() != "" {
+		return
+	}
+	host := c.dogstatsdAddr.Hostname()
+	if host == "" {
+		host = internal.DefaultAgentHostname
+	}
+	c.dogstatsdAddr.Host = net.JoinHostPort(host, strconv.Itoa(port))
+	configtelemetry.Report("DD_DOGSTATSD_URL", formatDogstatsdAddr(c.dogstatsdAddr), telemetry.OriginCalculated)
 }
 
 func (c *Config) Debug() bool {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,7 +81,7 @@ type Config struct {
 	// dogstatsdAddrExplicit is true when the user explicitly configured the DogStatsD
 	// address (via DD_DOGSTATSD_PORT or DD_DOGSTATSD_URL), so agent-reported ports must not overwrite it.
 	dogstatsdAddrExplicit bool
-	debug            bool
+	debug                 bool
 	// logStartup, when true, causes various startup info to be written when the tracer starts.
 	logStartup bool
 	// serviceName specifies the name of this application.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,7 +79,7 @@ type Config struct {
 	// combination of the environment variables DD_AGENT_HOST and DD_DOGSTATSD_PORT.
 	dogstatsdAddr *url.URL
 	// dogstatsdEnvPortSet is true when env explicitly set the dogstatsd port
-	// at loadConfig time; gates SetAgentReportedStatsdPort.
+	// at loadConfig time; gates ApplyAgentReportedStatsdPort.
 	dogstatsdEnvPortSet bool
 	debug               bool
 	// logStartup, when true, causes various startup info to be written when the tracer starts.
@@ -399,10 +399,10 @@ func (c *Config) SetDogstatsdAddr(addr string, origin telemetry.Origin, product 
 	configtelemetry.Report("DD_DOGSTATSD_URL", addr, origin)
 }
 
-// SetAgentReportedStatsdPort overwrites the URL port with the agent /info
+// ApplyAgentReportedStatsdPort overwrites the URL port with the agent /info
 // value. No-op when the user claimed DD_DOGSTATSD_URL, the URL is a unix
 // socket, or env already set the port.
-func (c *Config) SetAgentReportedStatsdPort(port int) {
+func (c *Config) ApplyAgentReportedStatsdPort(port int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if port <= 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,10 +77,6 @@ type Config struct {
 	// dogstatsdAddr is the address to connect for sending metrics to the
 	// Datadog Agent. If not set, it defaults to "localhost:8125" or to the
 	// combination of the environment variables DD_AGENT_HOST and DD_DOGSTATSD_PORT.
-	//
-	// The URL stores only what was explicitly set: an empty Port means no
-	// explicit port was provided (the getter fills in the default; the
-	// agent-reported port may also fill it in via SetAgentReportedStatsdPort).
 	dogstatsdAddr *url.URL
 	debug         bool
 	// logStartup, when true, causes various startup info to be written when the tracer starts.
@@ -205,11 +201,6 @@ func loadConfig() *Config {
 	agentPort := p.GetString("DD_TRACE_AGENT_PORT", "")
 	cfg.agentURL = resolveAgentURL(agentURLStr, agentHost, agentPort)
 
-	// DogStatsD address. DD_DOGSTATSD_HOST and DD_DOGSTATSD_PORT are read here
-	// so the provider reports telemetry for them; the values feed into the
-	// initial URL build. An empty Port on the resulting URL means no source
-	// has explicitly set the port yet (default will be filled at read time, or
-	// the agent-reported port may set it via SetAgentReportedStatsdPort).
 	dogstatsdEnvHost := p.GetString("DD_DOGSTATSD_HOST", "")
 	dogstatsdEnvPort := p.GetString("DD_DOGSTATSD_PORT", "")
 	cfg.dogstatsdAddr = initialDogstatsdURL(dogstatsdEnvHost, dogstatsdEnvPort, agentHost, DefaultSocketDSDPath)
@@ -386,19 +377,12 @@ func (c *Config) AgentURL() *url.URL {
 	return u
 }
 
-// DogstatsdAddr returns the resolved DogStatsD address as a string in the
-// form expected by NewStatsdClient: "host:port" for UDP or
-// "unix:///path/to/socket" for UDS. Defaults are filled in here when the
-// underlying URL has no explicit host or port.
 func (c *Config) DogstatsdAddr() string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return formatDogstatsdAddr(c.dogstatsdAddr)
 }
 
-// SetDogstatsdAddr records a user-supplied DogStatsD address (priority 1) and
-// replaces the stored URL whole-cloth. Reports config telemetry under
-// DD_DOGSTATSD_URL.
 func (c *Config) SetDogstatsdAddr(addr string, origin telemetry.Origin, product ...Product) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -412,11 +396,9 @@ func (c *Config) SetDogstatsdAddr(addr string, origin telemetry.Origin, product 
 	configtelemetry.Report("DD_DOGSTATSD_URL", addr, origin)
 }
 
-// SetAgentReportedStatsdPort fills the port on the resolved DogStatsD URL
-// using the value reported by the trace-agent /info endpoint. Skipped when
-// the user has claimed DD_DOGSTATSD_URL, the URL already has a port (env
-// explicitly set it), or the URL is a unix socket. Reports config telemetry
-// under DD_DOGSTATSD_URL with OriginCalculated when the port is applied.
+// SetAgentReportedStatsdPort fills the URL port from the agent /info value.
+// No-op when the user claimed DD_DOGSTATSD_URL, the URL is a unix socket, or
+// a port is already set.
 func (c *Config) SetAgentReportedStatsdPort(port int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -404,8 +404,8 @@ func (c *Config) SetDogstatsdAddr(addr string, origin telemetry.Origin, product 
 }
 
 // ApplyAgentReportedStatsdPort overwrites the URL port with the agent /info
-// value. No-op when the user explicitly configured via DD_DOGSTATSD_PORT or DD_DOGSTATSD_URL, and if the URL is a unix
-// socket.
+// value. No-op when the user explicitly configured the address (via WithDogstatsdAddr,
+// DD_DOGSTATSD_PORT, or DD_DOGSTATSD_URL), or if the URL is a unix socket.
 func (c *Config) ApplyAgentReportedStatsdPort(port int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -400,6 +400,7 @@ func (c *Config) SetDogstatsdAddr(addr string, origin telemetry.Origin, product 
 		return
 	}
 	c.dogstatsdAddr = parseDogstatsdAddr(addr)
+	c.dogstatsdAddrExplicit = true
 	configtelemetry.Report("DD_DOGSTATSD_URL", addr, origin)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -204,9 +204,9 @@ func loadConfig() *Config {
 	agentPort := p.GetString("DD_TRACE_AGENT_PORT", "")
 	cfg.agentURL = resolveAgentURL(agentURLStr, agentHost, agentPort)
 
-	dogstatsdEnvHost := p.GetString("DD_DOGSTATSD_HOST", "")
-	dogstatsdEnvPort := p.GetString("DD_DOGSTATSD_PORT", "")
-	cfg.dogstatsdAddr, cfg.dogstatsdEnvPortSet = initialDogstatsdURL(dogstatsdEnvHost, dogstatsdEnvPort, agentHost, DefaultSocketDSDPath)
+	dogstatsdHost := p.GetString("DD_DOGSTATSD_HOST", "")
+	dogstatsdPort := p.GetString("DD_DOGSTATSD_PORT", "")
+	cfg.dogstatsdAddr, cfg.dogstatsdEnvPortSet = initialDogstatsdURL(dogstatsdHost, dogstatsdPort, agentHost, DefaultSocketDSDPath)
 
 	cfg.debug = p.GetBool("DD_TRACE_DEBUG", false)
 	cfg.logStartup = p.GetBool("DD_TRACE_STARTUP_LOGS", true)
@@ -400,8 +400,8 @@ func (c *Config) SetDogstatsdAddr(addr string, origin telemetry.Origin, product 
 }
 
 // ApplyAgentReportedStatsdPort overwrites the URL port with the agent /info
-// value. No-op when the user claimed DD_DOGSTATSD_URL, the URL is a unix
-// socket, or env already set the port.
+// value. No-op when the user explicitly configured via DD_DOGSTATSD_PORT or DD_DOGSTATSD_URL, and if the URL is a unix
+// socket.
 func (c *Config) ApplyAgentReportedStatsdPort(port int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,7 +78,10 @@ type Config struct {
 	// Datadog Agent. If not set, it defaults to "localhost:8125" or to the
 	// combination of the environment variables DD_AGENT_HOST and DD_DOGSTATSD_PORT.
 	dogstatsdAddr *url.URL
-	debug         bool
+	// dogstatsdEnvPortSet is true when env explicitly set the dogstatsd port
+	// at loadConfig time; gates SetAgentReportedStatsdPort.
+	dogstatsdEnvPortSet bool
+	debug               bool
 	// logStartup, when true, causes various startup info to be written when the tracer starts.
 	logStartup bool
 	// serviceName specifies the name of this application.
@@ -203,7 +206,7 @@ func loadConfig() *Config {
 
 	dogstatsdEnvHost := p.GetString("DD_DOGSTATSD_HOST", "")
 	dogstatsdEnvPort := p.GetString("DD_DOGSTATSD_PORT", "")
-	cfg.dogstatsdAddr = initialDogstatsdURL(dogstatsdEnvHost, dogstatsdEnvPort, agentHost, DefaultSocketDSDPath)
+	cfg.dogstatsdAddr, cfg.dogstatsdEnvPortSet = initialDogstatsdURL(dogstatsdEnvHost, dogstatsdEnvPort, agentHost, DefaultSocketDSDPath)
 
 	cfg.debug = p.GetBool("DD_TRACE_DEBUG", false)
 	cfg.logStartup = p.GetBool("DD_TRACE_STARTUP_LOGS", true)
@@ -396,9 +399,9 @@ func (c *Config) SetDogstatsdAddr(addr string, origin telemetry.Origin, product 
 	configtelemetry.Report("DD_DOGSTATSD_URL", addr, origin)
 }
 
-// SetAgentReportedStatsdPort fills the URL port from the agent /info value.
-// No-op when the user claimed DD_DOGSTATSD_URL, the URL is a unix socket, or
-// a port is already set.
+// SetAgentReportedStatsdPort overwrites the URL port with the agent /info
+// value. No-op when the user claimed DD_DOGSTATSD_URL, the URL is a unix
+// socket, or env already set the port.
 func (c *Config) SetAgentReportedStatsdPort(port int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -411,14 +414,10 @@ func (c *Config) SetAgentReportedStatsdPort(port int) {
 	if c.dogstatsdAddr == nil || c.dogstatsdAddr.Scheme == "unix" {
 		return
 	}
-	if c.dogstatsdAddr.Port() != "" {
+	if c.dogstatsdEnvPortSet {
 		return
 	}
-	host := c.dogstatsdAddr.Hostname()
-	if host == "" {
-		host = internal.DefaultAgentHostname
-	}
-	c.dogstatsdAddr.Host = net.JoinHostPort(host, strconv.Itoa(port))
+	c.dogstatsdAddr.Host = net.JoinHostPort(c.dogstatsdAddr.Hostname(), strconv.Itoa(port))
 	configtelemetry.Report("DD_DOGSTATSD_URL", formatDogstatsdAddr(c.dogstatsdAddr), telemetry.OriginCalculated)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -390,6 +390,10 @@ func (c *Config) DogstatsdAddr() string {
 	return formatDogstatsdAddr(c.dogstatsdAddr)
 }
 
+// SetDogstatsdAddr records a user-configured DogStatsD address and marks it
+// explicit so agent-reported ports cannot overwrite it. Call this only from
+// user-facing paths (options, env vars). For agent-reported updates use
+// ApplyAgentReportedStatsdPort.
 func (c *Config) SetDogstatsdAddr(addr string, origin telemetry.Origin, product ...Product) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -404,9 +408,9 @@ func (c *Config) SetDogstatsdAddr(addr string, origin telemetry.Origin, product 
 	configtelemetry.Report("DD_DOGSTATSD_URL", addr, origin)
 }
 
-// ApplyAgentReportedStatsdPort overwrites the URL port with the agent /info
-// value. No-op when the user explicitly configured the address (via WithDogstatsdAddr,
-// DD_DOGSTATSD_PORT, or DD_DOGSTATSD_URL), or if the URL is a unix socket.
+// ApplyAgentReportedStatsdPort applies a port from the agent /info response.
+// For user-configured addresses use SetDogstatsdAddr instead. No-op when the
+// user already provided an explicit address or the current address is a unix socket.
 func (c *Config) ApplyAgentReportedStatsdPort(port int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -203,12 +203,13 @@ func loadConfig() *Config {
 	agentPort := p.GetString("DD_TRACE_AGENT_PORT", "")
 	cfg.agentURL = resolveAgentURL(agentURLStr, agentHost, agentPort)
 
+	dogstatsdURL := p.GetString("DD_DOGSTATSD_URL", "")
 	dogstatsdHost := p.GetString("DD_DOGSTATSD_HOST", "")
 	dogstatsdPort := p.GetString("DD_DOGSTATSD_PORT", "")
-	if dogstatsdPort != "" {
+	if dogstatsdPort != "" || dogstatsdURL != "" {
 		cfg.dogstatsdPortSet = true
 	}
-	cfg.dogstatsdAddr = initialDogstatsdURL(dogstatsdHost, dogstatsdPort, agentHost, DefaultSocketDSDPath)
+	cfg.dogstatsdAddr = initialDogstatsdURL(dogstatsdURL, dogstatsdHost, dogstatsdPort, agentHost, DefaultSocketDSDPath)
 
 	cfg.debug = p.GetBool("DD_TRACE_DEBUG", false)
 	cfg.logStartup = p.GetBool("DD_TRACE_STARTUP_LOGS", true)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,10 +78,9 @@ type Config struct {
 	// Datadog Agent. If not set, it defaults to "localhost:8125" or to the
 	// combination of the environment variables DD_AGENT_HOST and DD_DOGSTATSD_PORT.
 	dogstatsdAddr *url.URL
-	// dogstatsdEnvPortSet is true when env explicitly set the dogstatsd port
-	// at loadConfig time; gates ApplyAgentReportedStatsdPort.
-	dogstatsdEnvPortSet bool
-	debug               bool
+	// dogstatsdPortSet is true when dogstatsd port is explicitly set by user configuration
+	dogstatsdPortSet bool
+	debug            bool
 	// logStartup, when true, causes various startup info to be written when the tracer starts.
 	logStartup bool
 	// serviceName specifies the name of this application.
@@ -206,7 +205,10 @@ func loadConfig() *Config {
 
 	dogstatsdHost := p.GetString("DD_DOGSTATSD_HOST", "")
 	dogstatsdPort := p.GetString("DD_DOGSTATSD_PORT", "")
-	cfg.dogstatsdAddr, cfg.dogstatsdEnvPortSet = initialDogstatsdURL(dogstatsdHost, dogstatsdPort, agentHost, DefaultSocketDSDPath)
+	if dogstatsdPort != "" {
+		cfg.dogstatsdPortSet = true
+	}
+	cfg.dogstatsdAddr = initialDogstatsdURL(dogstatsdHost, dogstatsdPort, agentHost, DefaultSocketDSDPath)
 
 	cfg.debug = p.GetBool("DD_TRACE_DEBUG", false)
 	cfg.logStartup = p.GetBool("DD_TRACE_STARTUP_LOGS", true)
@@ -411,10 +413,11 @@ func (c *Config) ApplyAgentReportedStatsdPort(port int) {
 	if _, claimed := c.overrides["DD_DOGSTATSD_URL"]; claimed {
 		return
 	}
-	if c.dogstatsdAddr == nil || c.dogstatsdAddr.Scheme == "unix" {
+	// dogstatsdAddr is always set non-nil by loadConfig.
+	if c.dogstatsdAddr.Scheme == "unix" {
 		return
 	}
-	if c.dogstatsdEnvPortSet {
+	if c.dogstatsdPortSet {
 		return
 	}
 	c.dogstatsdAddr.Host = net.JoinHostPort(c.dogstatsdAddr.Hostname(), strconv.Itoa(port))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,8 +78,9 @@ type Config struct {
 	// Datadog Agent. If not set, it defaults to "localhost:8125" or to the
 	// combination of the environment variables DD_AGENT_HOST and DD_DOGSTATSD_PORT.
 	dogstatsdAddr *url.URL
-	// dogstatsdPortSet is true when dogstatsd port is explicitly set by user configuration
-	dogstatsdPortSet bool
+	// dogstatsdAddrExplicit is true when the user explicitly configured the DogStatsD
+	// address (via DD_DOGSTATSD_PORT or DD_DOGSTATSD_URL), so agent-reported ports must not overwrite it.
+	dogstatsdAddrExplicit bool
 	debug            bool
 	// logStartup, when true, causes various startup info to be written when the tracer starts.
 	logStartup bool
@@ -207,7 +208,7 @@ func loadConfig() *Config {
 	dogstatsdHost := p.GetString("DD_DOGSTATSD_HOST", "")
 	dogstatsdPort := p.GetString("DD_DOGSTATSD_PORT", "")
 	if dogstatsdPort != "" || dogstatsdURL != "" {
-		cfg.dogstatsdPortSet = true
+		cfg.dogstatsdAddrExplicit = true
 	}
 	cfg.dogstatsdAddr = initialDogstatsdURL(dogstatsdURL, dogstatsdHost, dogstatsdPort, agentHost, DefaultSocketDSDPath)
 
@@ -418,7 +419,7 @@ func (c *Config) ApplyAgentReportedStatsdPort(port int) {
 	if c.dogstatsdAddr.Scheme == "unix" {
 		return
 	}
-	if c.dogstatsdPortSet {
+	if c.dogstatsdAddrExplicit {
 		return
 	}
 	c.dogstatsdAddr.Host = net.JoinHostPort(c.dogstatsdAddr.Hostname(), strconv.Itoa(port))

--- a/internal/config/config_helpers.go
+++ b/internal/config/config_helpers.go
@@ -236,7 +236,6 @@ func formatDogstatsdAddr(u *url.URL) string {
 	return u.Host
 }
 
-
 // resolveOTLPTraceURL resolves the OTLP trace endpoint from OTEL_EXPORTER_OTLP_TRACES_ENDPOINT if set, else agentURL host + default OTLP port 4318 + /v1/traces.
 // When the user-provided endpoint is set, it is validated: it must be a parseable URL with an http or https scheme.
 // If validation fails, the default endpoint is used instead.

--- a/internal/config/config_helpers.go
+++ b/internal/config/config_helpers.go
@@ -17,8 +17,7 @@ import (
 )
 
 // DefaultSocketDSDPath is the UDS socket path probed during DogStatsD
-// auto-discovery. Exported as a var so tests can override the location;
-// production code must not modify it.
+// auto-discovery. Exported as a var only for test overrides.
 var DefaultSocketDSDPath = "/var/run/datadog/dsd.socket"
 
 const (
@@ -48,8 +47,6 @@ const (
 	URLSchemeHTTP  = "http"
 	URLSchemeHTTPS = "https"
 
-	// DefaultStatsdPort is the default port for the DogStatsD service when no
-	// other source provides one.
 	DefaultStatsdPort = "8125"
 
 	// Trace API paths appended to the agent URL for each protocol.
@@ -188,19 +185,9 @@ func detectUDSURL() *url.URL {
 	}
 }
 
-// initialDogstatsdURL builds the resolved DogStatsD URL at loadConfig time
-// from the env-sourced inputs. The URL is canonical:
-//   - Scheme "unix" with Path means UDS auto-discovery found a socket.
-//   - Empty Port means no source has explicitly set a port; the getter or a
-//     later SetAgentReportedStatsdPort fills it.
-//   - Empty Host means no source has explicitly set a host; the getter fills
-//     in the default.
-//
-// Priority follows the legacy resolveDogstatsdAddr:
-//  1. DD_DOGSTATSD_HOST / DD_DOGSTATSD_PORT (with DD_AGENT_HOST as host
-//     fallback).
-//  2. UDS socket at socketPath if it exists.
-//  3. Otherwise leave Host empty and Port empty for the getter to default.
+// initialDogstatsdURL builds the resolved DogStatsD URL from env inputs.
+// Convention: empty Port means no source explicitly set it; empty Host
+// means no source explicitly set it. The getter fills defaults at read time.
 func initialDogstatsdURL(envHost, envPort, agentHost, socketPath string) *url.URL {
 	if envHost != "" || envPort != "" {
 		host := envHost
@@ -218,9 +205,7 @@ func initialDogstatsdURL(envHost, envPort, agentHost, socketPath string) *url.UR
 	return &url.URL{Host: agentHost}
 }
 
-// parseDogstatsdAddr converts a user-supplied DogStatsD address (e.g. from
-// WithDogstatsdAddr) into the canonical URL form. Accepts "host:port" or
-// "unix:///path/to/socket".
+// parseDogstatsdAddr accepts "host:port" or "unix:///path/to/socket".
 func parseDogstatsdAddr(addr string) *url.URL {
 	if strings.HasPrefix(addr, "unix://") {
 		if u, err := url.Parse(addr); err == nil {
@@ -230,8 +215,8 @@ func parseDogstatsdAddr(addr string) *url.URL {
 	return &url.URL{Host: addr}
 }
 
-// formatDogstatsdAddr renders a DogStatsD URL into the string form expected
-// by NewStatsdClient. Defaults are filled in here when the URL omits them.
+// formatDogstatsdAddr renders the URL for NewStatsdClient, filling defaults
+// when host or port are unset.
 func formatDogstatsdAddr(u *url.URL) string {
 	if u == nil {
 		return net.JoinHostPort(internal.DefaultAgentHostname, DefaultStatsdPort)

--- a/internal/config/config_helpers.go
+++ b/internal/config/config_helpers.go
@@ -186,18 +186,20 @@ func detectUDSURL() *url.URL {
 }
 
 // initialDogstatsdURL builds the resolved DogStatsD URL from env inputs.
-// The returned URL is always complete: host+port for TCP, or unix scheme +
-// path for UDS.
-func initialDogstatsdURL(envHost, envPort, agentHost, socketPath string) *url.URL {
-	if envHost != "" || envPort != "" {
-		host := envHost
+// Precedence: addr (DD_DOGSTATSD_URL) > host/port (DD_DOGSTATSD_HOST/PORT) >
+// UDS auto-discovery > agentHost:DefaultStatsdPort. The returned URL is
+// always complete: host+port for TCP, or unix scheme + path for UDS.
+func initialDogstatsdURL(addr, host, port, agentHost, socketPath string) *url.URL {
+	if addr != "" {
+		return parseDogstatsdAddr(addr)
+	}
+	if host != "" || port != "" {
 		if host == "" {
 			host = agentHost
 		}
 		if host == "" {
 			host = internal.DefaultAgentHostname
 		}
-		port := envPort
 		if port == "" {
 			port = DefaultStatsdPort
 		}
@@ -206,7 +208,7 @@ func initialDogstatsdURL(envHost, envPort, agentHost, socketPath string) *url.UR
 	if _, err := os.Stat(socketPath); err == nil {
 		return &url.URL{Scheme: URLSchemeUnix, Path: socketPath}
 	}
-	host := agentHost
+	host = agentHost
 	if host == "" {
 		host = internal.DefaultAgentHostname
 	}

--- a/internal/config/config_helpers.go
+++ b/internal/config/config_helpers.go
@@ -186,11 +186,9 @@ func detectUDSURL() *url.URL {
 }
 
 // initialDogstatsdURL builds the resolved DogStatsD URL from env inputs.
-// The returned URL is always complete (host+port for TCP, or unix scheme +
-// path for UDS). The bool reports whether env explicitly set the port; used
-// by ApplyAgentReportedStatsdPort to decide whether to override later.
-func initialDogstatsdURL(envHost, envPort, agentHost, socketPath string) (*url.URL, bool) {
-	envPortSet := envPort != ""
+// The returned URL is always complete: host+port for TCP, or unix scheme +
+// path for UDS.
+func initialDogstatsdURL(envHost, envPort, agentHost, socketPath string) *url.URL {
 	if envHost != "" || envPort != "" {
 		host := envHost
 		if host == "" {
@@ -203,16 +201,16 @@ func initialDogstatsdURL(envHost, envPort, agentHost, socketPath string) (*url.U
 		if port == "" {
 			port = DefaultStatsdPort
 		}
-		return &url.URL{Host: net.JoinHostPort(host, port)}, envPortSet
+		return &url.URL{Host: net.JoinHostPort(host, port)}
 	}
 	if _, err := os.Stat(socketPath); err == nil {
-		return &url.URL{Scheme: URLSchemeUnix, Path: socketPath}, false
+		return &url.URL{Scheme: URLSchemeUnix, Path: socketPath}
 	}
 	host := agentHost
 	if host == "" {
 		host = internal.DefaultAgentHostname
 	}
-	return &url.URL{Host: net.JoinHostPort(host, DefaultStatsdPort)}, false
+	return &url.URL{Host: net.JoinHostPort(host, DefaultStatsdPort)}
 }
 
 // parseDogstatsdAddr accepts "host:port" or "unix:///path/to/socket".

--- a/internal/config/config_helpers.go
+++ b/internal/config/config_helpers.go
@@ -16,6 +16,11 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 )
 
+// DefaultSocketDSDPath is the UDS socket path probed during DogStatsD
+// auto-discovery. Exported as a var so tests can override the location;
+// production code must not modify it.
+var DefaultSocketDSDPath = "/var/run/datadog/dsd.socket"
+
 const (
 	// DefaultRateLimit specifies the default rate limit per second for traces.
 	// TODO: Maybe delete this. We will have defaults in supported_configuration.json anyway.
@@ -42,6 +47,10 @@ const (
 	URLSchemeUnix  = "unix"
 	URLSchemeHTTP  = "http"
 	URLSchemeHTTPS = "https"
+
+	// DefaultStatsdPort is the default port for the DogStatsD service when no
+	// other source provides one.
+	DefaultStatsdPort = "8125"
 
 	// Trace API paths appended to the agent URL for each protocol.
 	TracesPathV04 = "/v0.4/traces"
@@ -178,6 +187,69 @@ func detectUDSURL() *url.URL {
 		Path:   internal.DefaultTraceAgentUDSPath,
 	}
 }
+
+// initialDogstatsdURL builds the resolved DogStatsD URL at loadConfig time
+// from the env-sourced inputs. The URL is canonical:
+//   - Scheme "unix" with Path means UDS auto-discovery found a socket.
+//   - Empty Port means no source has explicitly set a port; the getter or a
+//     later SetAgentReportedStatsdPort fills it.
+//   - Empty Host means no source has explicitly set a host; the getter fills
+//     in the default.
+//
+// Priority follows the legacy resolveDogstatsdAddr:
+//  1. DD_DOGSTATSD_HOST / DD_DOGSTATSD_PORT (with DD_AGENT_HOST as host
+//     fallback).
+//  2. UDS socket at socketPath if it exists.
+//  3. Otherwise leave Host empty and Port empty for the getter to default.
+func initialDogstatsdURL(envHost, envPort, agentHost, socketPath string) *url.URL {
+	if envHost != "" || envPort != "" {
+		host := envHost
+		if host == "" {
+			host = agentHost
+		}
+		if envPort != "" {
+			return &url.URL{Host: net.JoinHostPort(host, envPort)}
+		}
+		return &url.URL{Host: host}
+	}
+	if _, err := os.Stat(socketPath); err == nil {
+		return &url.URL{Scheme: URLSchemeUnix, Path: socketPath}
+	}
+	return &url.URL{Host: agentHost}
+}
+
+// parseDogstatsdAddr converts a user-supplied DogStatsD address (e.g. from
+// WithDogstatsdAddr) into the canonical URL form. Accepts "host:port" or
+// "unix:///path/to/socket".
+func parseDogstatsdAddr(addr string) *url.URL {
+	if strings.HasPrefix(addr, "unix://") {
+		if u, err := url.Parse(addr); err == nil {
+			return u
+		}
+	}
+	return &url.URL{Host: addr}
+}
+
+// formatDogstatsdAddr renders a DogStatsD URL into the string form expected
+// by NewStatsdClient. Defaults are filled in here when the URL omits them.
+func formatDogstatsdAddr(u *url.URL) string {
+	if u == nil {
+		return net.JoinHostPort(internal.DefaultAgentHostname, DefaultStatsdPort)
+	}
+	if u.Scheme == URLSchemeUnix {
+		return "unix://" + u.Path
+	}
+	host := u.Hostname()
+	if host == "" {
+		host = internal.DefaultAgentHostname
+	}
+	port := u.Port()
+	if port == "" {
+		port = DefaultStatsdPort
+	}
+	return net.JoinHostPort(host, port)
+}
+
 
 // resolveOTLPTraceURL resolves the OTLP trace endpoint from OTEL_EXPORTER_OTLP_TRACES_ENDPOINT if set, else agentURL host + default OTLP port 4318 + /v1/traces.
 // When the user-provided endpoint is set, it is validated: it must be a parseable URL with an http or https scheme.

--- a/internal/config/config_helpers.go
+++ b/internal/config/config_helpers.go
@@ -186,23 +186,33 @@ func detectUDSURL() *url.URL {
 }
 
 // initialDogstatsdURL builds the resolved DogStatsD URL from env inputs.
-// Convention: empty Port means no source explicitly set it; empty Host
-// means no source explicitly set it. The getter fills defaults at read time.
-func initialDogstatsdURL(envHost, envPort, agentHost, socketPath string) *url.URL {
+// The returned URL is always complete (host+port for TCP, or unix scheme +
+// path for UDS). The bool reports whether env explicitly set the port; used
+// by SetAgentReportedStatsdPort to decide whether to override later.
+func initialDogstatsdURL(envHost, envPort, agentHost, socketPath string) (*url.URL, bool) {
+	envPortSet := envPort != ""
 	if envHost != "" || envPort != "" {
 		host := envHost
 		if host == "" {
 			host = agentHost
 		}
-		if envPort != "" {
-			return &url.URL{Host: net.JoinHostPort(host, envPort)}
+		if host == "" {
+			host = internal.DefaultAgentHostname
 		}
-		return &url.URL{Host: host}
+		port := envPort
+		if port == "" {
+			port = DefaultStatsdPort
+		}
+		return &url.URL{Host: net.JoinHostPort(host, port)}, envPortSet
 	}
 	if _, err := os.Stat(socketPath); err == nil {
-		return &url.URL{Scheme: URLSchemeUnix, Path: socketPath}
+		return &url.URL{Scheme: URLSchemeUnix, Path: socketPath}, false
 	}
-	return &url.URL{Host: agentHost}
+	host := agentHost
+	if host == "" {
+		host = internal.DefaultAgentHostname
+	}
+	return &url.URL{Host: net.JoinHostPort(host, DefaultStatsdPort)}, false
 }
 
 // parseDogstatsdAddr accepts "host:port" or "unix:///path/to/socket".
@@ -215,24 +225,15 @@ func parseDogstatsdAddr(addr string) *url.URL {
 	return &url.URL{Host: addr}
 }
 
-// formatDogstatsdAddr renders the URL for NewStatsdClient, filling defaults
-// when host or port are unset.
+// formatDogstatsdAddr renders the URL for NewStatsdClient.
 func formatDogstatsdAddr(u *url.URL) string {
 	if u == nil {
-		return net.JoinHostPort(internal.DefaultAgentHostname, DefaultStatsdPort)
+		return ""
 	}
 	if u.Scheme == URLSchemeUnix {
 		return "unix://" + u.Path
 	}
-	host := u.Hostname()
-	if host == "" {
-		host = internal.DefaultAgentHostname
-	}
-	port := u.Port()
-	if port == "" {
-		port = DefaultStatsdPort
-	}
-	return net.JoinHostPort(host, port)
+	return u.Host
 }
 
 

--- a/internal/config/config_helpers.go
+++ b/internal/config/config_helpers.go
@@ -188,7 +188,7 @@ func detectUDSURL() *url.URL {
 // initialDogstatsdURL builds the resolved DogStatsD URL from env inputs.
 // The returned URL is always complete (host+port for TCP, or unix scheme +
 // path for UDS). The bool reports whether env explicitly set the port; used
-// by SetAgentReportedStatsdPort to decide whether to override later.
+// by ApplyAgentReportedStatsdPort to decide whether to override later.
 func initialDogstatsdURL(envHost, envPort, agentHost, socketPath string) (*url.URL, bool) {
 	envPortSet := envPort != ""
 	if envHost != "" || envPort != "" {

--- a/internal/config/config_helpers.go
+++ b/internal/config/config_helpers.go
@@ -220,6 +220,8 @@ func parseDogstatsdAddr(addr string) *url.URL {
 	if strings.HasPrefix(addr, "unix://") {
 		if u, err := url.Parse(addr); err == nil {
 			return u
+		} else {
+			log.Warn("Failed to parse DogStatsD unix address %q: %s", addr, err)
 		}
 	}
 	return &url.URL{Host: addr}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -246,9 +246,8 @@ func TestGet(t *testing.T) {
 // settersWithoutTelemetry lists Set methods that don't report telemetry.
 // Add your setter here with a reason if telemetry reporting is not needed.
 var settersWithoutTelemetry = map[string]string{
-	"SetLogToStdout":             "not user-configurable",
-	"SetIsLambdaFunction":        "not user-configurable",
-	"SetAgentReportedStatsdPort": "reports telemetry with fixed OriginCalculated; origin not caller-supplied",
+	"SetLogToStdout":      "not user-configurable",
+	"SetIsLambdaFunction": "not user-configurable",
 }
 
 // specialCaseSetters handles setters with non-standard signatures.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -246,8 +246,9 @@ func TestGet(t *testing.T) {
 // settersWithoutTelemetry lists Set methods that don't report telemetry.
 // Add your setter here with a reason if telemetry reporting is not needed.
 var settersWithoutTelemetry = map[string]string{
-	"SetLogToStdout":      "not user-configurable",
-	"SetIsLambdaFunction": "not user-configurable",
+	"SetLogToStdout":             "not user-configurable",
+	"SetIsLambdaFunction":        "not user-configurable",
+	"SetAgentReportedStatsdPort": "reports telemetry with fixed OriginCalculated; origin not caller-supplied",
 }
 
 // specialCaseSetters handles setters with non-standard signatures.

--- a/internal/config/dogstatsd_test.go
+++ b/internal/config/dogstatsd_test.go
@@ -1,0 +1,170 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
+)
+
+// TestDogstatsdAddrResolution exercises the full DogStatsD address
+// resolution path through internal/config: env-sourced inputs at loadConfig
+// time, an optional user-supplied address via SetDogstatsdAddr, and the
+// agent-reported port via SetAgentReportedStatsdPort.
+func TestDogstatsdAddrResolution(t *testing.T) {
+	socketFile, err := os.CreateTemp("", "dsd.socket")
+	require.NoError(t, err)
+	require.NoError(t, socketFile.Close())
+	t.Cleanup(func() { os.RemoveAll(socketFile.Name()) })
+	socketPath := socketFile.Name()
+
+	tests := []struct {
+		name            string
+		userAddr        string
+		agentStatsdPort int
+		env             map[string]string
+		socketPath      string
+		expected        string
+	}{
+		{
+			name:     "defaults",
+			expected: "localhost:8125",
+		},
+		{
+			name:     "host-env",
+			env:      map[string]string{"DD_DOGSTATSD_HOST": "111.111.1.1", "DD_AGENT_HOST": "222.222.2.2"},
+			expected: "111.111.1.1:8125",
+		},
+		{
+			name:     "port-env",
+			env:      map[string]string{"DD_DOGSTATSD_PORT": "8111"},
+			expected: "localhost:8111",
+		},
+		{
+			name:     "port-env+agent-host-env",
+			env:      map[string]string{"DD_DOGSTATSD_PORT": "8111", "DD_AGENT_HOST": "222.222.2.2"},
+			expected: "222.222.2.2:8111",
+		},
+		{
+			name:     "host-env+port-env",
+			env:      map[string]string{"DD_DOGSTATSD_HOST": "111.111.1.1", "DD_DOGSTATSD_PORT": "8888", "DD_AGENT_HOST": "222.222.2.2"},
+			expected: "111.111.1.1:8888",
+		},
+		{
+			name:       "host-env+socket",
+			env:        map[string]string{"DD_DOGSTATSD_HOST": "111.111.1.1"},
+			socketPath: socketPath,
+			expected:   "111.111.1.1:8125",
+		},
+		{
+			name:       "port-env+socket",
+			env:        map[string]string{"DD_DOGSTATSD_PORT": "8111"},
+			socketPath: socketPath,
+			expected:   "localhost:8111",
+		},
+		{
+			name:       "socket",
+			socketPath: socketPath,
+			expected:   "unix://" + socketPath,
+		},
+		// DD_AGENT_HOST alone should not trigger the env var path;
+		// it falls through to auto-discovery.
+		{
+			name:       "agent-host-env-only+socket",
+			env:        map[string]string{"DD_AGENT_HOST": "222.222.2.2"},
+			socketPath: socketPath,
+			expected:   "unix://" + socketPath,
+		},
+		{
+			name:     "agent-host-env-only",
+			env:      map[string]string{"DD_AGENT_HOST": "222.222.2.2"},
+			expected: "222.222.2.2:8125",
+		},
+		{
+			name:            "agent-host-env-only+agent-port",
+			env:             map[string]string{"DD_AGENT_HOST": "222.222.2.2"},
+			agentStatsdPort: 9876,
+			expected:        "222.222.2.2:9876",
+		},
+		// userAddr (priority 1) wins over everything.
+		{
+			name:     "user-addr",
+			userAddr: "custom:9999",
+			expected: "custom:9999",
+		},
+		{
+			name:     "user-addr+env",
+			userAddr: "custom:9999",
+			env:      map[string]string{"DD_DOGSTATSD_HOST": "111.111.1.1", "DD_DOGSTATSD_PORT": "8111"},
+			expected: "custom:9999",
+		},
+		{
+			name:       "user-addr+socket",
+			userAddr:   "custom:9999",
+			socketPath: socketPath,
+			expected:   "custom:9999",
+		},
+		{
+			name:            "user-addr+agent-port",
+			userAddr:        "custom:9999",
+			agentStatsdPort: 9876,
+			expected:        "custom:9999",
+		},
+		// Agent-reported port used as fallback when env host is set but no env port.
+		{
+			name:            "host-env+agent-port",
+			env:             map[string]string{"DD_DOGSTATSD_HOST": "111.111.1.1"},
+			agentStatsdPort: 9876,
+			expected:        "111.111.1.1:9876",
+		},
+		// Env port wins over agent-reported port.
+		{
+			name:            "host-env+port-env+agent-port",
+			env:             map[string]string{"DD_DOGSTATSD_HOST": "111.111.1.1", "DD_DOGSTATSD_PORT": "8111"},
+			agentStatsdPort: 9876,
+			expected:        "111.111.1.1:8111",
+		},
+		// Auto-discovery: agent-reported port when no env and no socket.
+		{
+			name:            "agent-port",
+			agentStatsdPort: 9876,
+			expected:        "localhost:9876",
+		},
+		// Auto-discovery: socket wins over agent-reported port.
+		{
+			name:            "socket+agent-port",
+			agentStatsdPort: 9876,
+			socketPath:      socketPath,
+			expected:        "unix://" + socketPath,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, key := range []string{"DD_DOGSTATSD_HOST", "DD_DOGSTATSD_PORT", "DD_AGENT_HOST"} {
+				t.Setenv(key, "")
+			}
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			restoreSocket := DefaultSocketDSDPath
+			DefaultSocketDSDPath = tt.socketPath
+			defer func() { DefaultSocketDSDPath = restoreSocket }()
+
+			c := CreateNew()
+			if tt.userAddr != "" {
+				c.SetDogstatsdAddr(tt.userAddr, telemetry.OriginCode)
+			}
+			c.SetAgentReportedStatsdPort(tt.agentStatsdPort)
+			assert.Equal(t, tt.expected, c.DogstatsdAddr())
+		})
+	}
+}

--- a/internal/config/dogstatsd_test.go
+++ b/internal/config/dogstatsd_test.go
@@ -161,7 +161,7 @@ func TestDogstatsdAddrResolution(t *testing.T) {
 
 			c := CreateNew()
 			if tt.userAddr != "" {
-				c.SetDogstatsdAddr(tt.userAddr, telemetry.OriginCode)
+				c.SetDogstatsdAddr(tt.userAddr, telemetry.OriginCode, ProductTracer)
 			}
 			c.SetAgentReportedStatsdPort(tt.agentStatsdPort)
 			assert.Equal(t, tt.expected, c.DogstatsdAddr())

--- a/internal/config/dogstatsd_test.go
+++ b/internal/config/dogstatsd_test.go
@@ -18,7 +18,7 @@ import (
 // TestDogstatsdAddrResolution exercises the full DogStatsD address
 // resolution path through internal/config: env-sourced inputs at loadConfig
 // time, an optional user-supplied address via SetDogstatsdAddr, and the
-// agent-reported port via SetAgentReportedStatsdPort.
+// agent-reported port via ApplyAgentReportedStatsdPort.
 func TestDogstatsdAddrResolution(t *testing.T) {
 	socketFile, err := os.CreateTemp("", "dsd.socket")
 	require.NoError(t, err)
@@ -163,7 +163,7 @@ func TestDogstatsdAddrResolution(t *testing.T) {
 			if tt.userAddr != "" {
 				c.SetDogstatsdAddr(tt.userAddr, telemetry.OriginCode, ProductTracer)
 			}
-			c.SetAgentReportedStatsdPort(tt.agentStatsdPort)
+			c.ApplyAgentReportedStatsdPort(tt.agentStatsdPort)
 			assert.Equal(t, tt.expected, c.DogstatsdAddr())
 		})
 	}

--- a/internal/config/dogstatsd_test.go
+++ b/internal/config/dogstatsd_test.go
@@ -145,11 +145,43 @@ func TestDogstatsdAddrResolution(t *testing.T) {
 			socketPath:      socketPath,
 			expected:        "unix://" + socketPath,
 		},
+		// DD_DOGSTATSD_URL: TCP host:port form.
+		{
+			name:     "url-env-tcp",
+			env:      map[string]string{"DD_DOGSTATSD_URL": "myhost:9999"},
+			expected: "myhost:9999",
+		},
+		// DD_DOGSTATSD_URL: unix socket form.
+		{
+			name:     "url-env-unix",
+			env:      map[string]string{"DD_DOGSTATSD_URL": "unix://" + socketPath},
+			expected: "unix://" + socketPath,
+		},
+		// DD_DOGSTATSD_URL wins over DD_DOGSTATSD_HOST/PORT.
+		{
+			name:     "url-env+host-port-env",
+			env:      map[string]string{"DD_DOGSTATSD_URL": "myhost:9999", "DD_DOGSTATSD_HOST": "111.111.1.1", "DD_DOGSTATSD_PORT": "8111"},
+			expected: "myhost:9999",
+		},
+		// DD_DOGSTATSD_URL (unix) blocks agent-reported port override.
+		{
+			name:            "url-env-unix+agent-port",
+			env:             map[string]string{"DD_DOGSTATSD_URL": "unix://" + socketPath},
+			agentStatsdPort: 9876,
+			expected:        "unix://" + socketPath,
+		},
+		// DD_DOGSTATSD_URL (tcp) blocks agent-reported port override.
+		{
+			name:            "url-env-tcp+agent-port",
+			env:             map[string]string{"DD_DOGSTATSD_URL": "myhost:9999"},
+			agentStatsdPort: 9876,
+			expected:        "myhost:9999",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			for _, key := range []string{"DD_DOGSTATSD_HOST", "DD_DOGSTATSD_PORT", "DD_AGENT_HOST"} {
+			for _, key := range []string{"DD_DOGSTATSD_HOST", "DD_DOGSTATSD_PORT", "DD_DOGSTATSD_URL", "DD_AGENT_HOST"} {
 				t.Setenv(key, "")
 			}
 			for k, v := range tt.env {

--- a/internal/env/supported_configurations.gen.go
+++ b/internal/env/supported_configurations.gen.go
@@ -60,6 +60,7 @@ var SupportedConfigurations = map[string]struct{}{
 	"DD_DBM_PROPAGATION_MODE":                                         {},
 	"DD_DOGSTATSD_HOST":                                               {},
 	"DD_DOGSTATSD_PORT":                                               {},
+	"DD_DOGSTATSD_URL":                                                {},
 	"DD_DYNAMIC_INSTRUMENTATION_ENABLED":                              {},
 	"DD_ENV":                                                          {},
 	"DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED":                       {},

--- a/internal/env/supported_configurations.json
+++ b/internal/env/supported_configurations.json
@@ -368,7 +368,7 @@
       {
         "implementation": "A",
         "type": "string",
-        "default": null
+        "default": "http://localhost:8125"
       }
     ],
     "DD_DYNAMIC_INSTRUMENTATION_ENABLED": [

--- a/internal/env/supported_configurations.json
+++ b/internal/env/supported_configurations.json
@@ -364,6 +364,13 @@
         "default": "8125"
       }
     ],
+    "DD_DOGSTATSD_URL": [
+      {
+        "implementation": "A",
+        "type": "string",
+        "default": null
+      }
+    ],
     "DD_DYNAMIC_INSTRUMENTATION_ENABLED": [
       {
         "implementation": "A",


### PR DESCRIPTION
### What does this PR do?
Migrates `dogstatsdAddr` off of `tracer.config`, over to `internal/config.Config`, stored as a `*url.URL`. Adds support for `DD_DOGSTATSD_URL` (read at startup, precedence over `DD_DOGSTATSD_HOST`/`PORT`). A small bool tracks whether the port was explicitly configured, so the agent-reported port only overrides when no other source claimed it.

### Public API

- `WithDogstatsdAddr` → `SetDogstatsdAddr(addr, OriginCode, ProductTracer)`
- New env var: `DD_DOGSTATSD_URL` (accepts `host:port` or `unix:///path`).
- After `loadAgentFeatures`: `ApplyAgentReportedStatsdPort(af.StatsdPort)`. No-op when the user provided `DD_DOGSTATSD_URL`, the URL is a unix socket, or some source already supplied a port at load time.

### Notes

- The DogStatsD UDS path is a package-level var (`DefaultSocketDSDPath`) so tests can override it without a dedicated public setter.
- `DD_DOGSTATSD_URL` is also our telemetry-backend canonical name for this config: https://github.com/DataDog/dd-go/blob/d4e1875427b69fa2d42beaddbbe5e583e36a8ab4/trace/apps/tracer-telemetry-intake/telemetry-payload/static/config_norm_rules.json#L105

### Motivation
Continued config-migration work as part of [APMAPI-1881](https://datadoghq.atlassian.net/browse/APMAPI-1881); this card is [APMAPI-1885](https://datadoghq.atlassian.net/browse/APMAPI-1885). Pattern follows `internal/config/AGENTS.md` (#4792).

### Reviewer's Checklist
- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] System-Tests covering this feature have been added and enabled with the va.b.c-dev version tag. (N/A — pure refactor.)
- [ ] There is a benchmark for any new code, or changes to existing code. (N/A.)
- [ ] If this interacts with the agent in a new way, a system test has been added. (N/A.)
- [x] New code is free of linting errors.
- [x] New code doesn't break existing tests.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date.
- [x] Non-trivial go.mod changes — none.


[APMAPI-1881]: https://datadoghq.atlassian.net/browse/APMAPI-1881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
