### PR TITLE
fix(contrib/azure/apim-callout): bound inline body decoding to prevent OOM

### DIFF
--- a/contrib/azure/apim-callout/apim.go
+++ b/contrib/azure/apim-callout/apim.go
@@ -80,6 +80,13 @@ type handler struct {
 	bodyParsingSizeLimit *int
 }
 
+func (h *handler) effectiveBodyParsingSizeLimit() int {
+	if h.bodyParsingSizeLimit != nil {
+		return *h.bodyParsingSizeLimit
+	}
+	return proxy.DefaultBodyParsingSizeLimit
+}
+
 // requestStateEntry wraps a RequestState with an atomic flag so the response
 // handler can claim exclusive ownership before the TTL eviction callback fires.
 // This prevents the race where both the eviction goroutine and the HTTP handler
@@ -131,6 +138,15 @@ func writeJSON(w http.ResponseWriter, statusCode int, v any) error {
 // handleCallout processes POST / from the gateway and dispatches based on
 // whether a request-id is present (two-tier dispatch).
 func (h *handler) handleCallout(w http.ResponseWriter, r *http.Request) {
+	// Cap the request body to prevent OOM from oversized payloads. The limit
+	// accounts for base64 encoding expansion (~4/3×) plus JSON envelope overhead.
+	maxReqSize := int64(h.effectiveBodyParsingSizeLimit()) * 2
+	const minRequestSize = 1 << 20 // 1MB floor for envelope-only requests
+	if maxReqSize < minRequestSize {
+		maxReqSize = minRequestSize
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxReqSize)
+
 	var msg calloutMessage
 	if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
 		instr.Logger().Error("apim_callout: error decoding request: %s\n", err.Error())
@@ -190,7 +206,7 @@ func (h *handler) handleNewRequest(w http.ResponseWriter, r *http.Request, msg *
 
 	// If the processor wants the request body AND it was provided inline, process it now.
 	if reqState.State == proxy.MessageTypeRequestBody && hasRawBody(addrs.Body) {
-		bodyBytes, decErr := decodeRawBase64Body(addrs.Body)
+		bodyBytes, decErr := decodeRawBase64Body(addrs.Body, h.effectiveBodyParsingSizeLimit())
 		if decErr != nil {
 			instr.Logger().Error("apim_callout: error decoding request body base64: %s\n", decErr.Error())
 		} else if bodyBytes != nil {
@@ -307,7 +323,7 @@ func (h *handler) handleRequestBodyPhase(w http.ResponseWriter, msg *calloutMess
 		return
 	}
 
-	bodyBytes, decErr := decodeRawBase64Body(addrs.Body)
+	bodyBytes, decErr := decodeRawBase64Body(addrs.Body, h.effectiveBodyParsingSizeLimit())
 	if decErr != nil {
 		instr.Logger().Error("apim_callout: error decoding request body base64: %s\n", decErr.Error())
 		h.requestStateCache.Delete(msg.RequestID)
@@ -379,7 +395,7 @@ func (h *handler) processResponseHeaders(w http.ResponseWriter, msg *calloutMess
 
 	// If response body is needed and body was provided inline
 	if reqState.State == proxy.MessageTypeResponseBody && hasRawBody(addrs.Body) {
-		bodyBytes, decErr := decodeRawBase64Body(addrs.Body)
+		bodyBytes, decErr := decodeRawBase64Body(addrs.Body, h.effectiveBodyParsingSizeLimit())
 		if decErr != nil {
 			instr.Logger().Error("apim_callout: error decoding response body base64: %s\n", decErr.Error())
 		} else if bodyBytes != nil {
@@ -440,7 +456,7 @@ func (h *handler) handleResponseBodyPhase(w http.ResponseWriter, msg *calloutMes
 		return
 	}
 
-	bodyBytes, decErr := decodeRawBase64Body(addrs.Body)
+	bodyBytes, decErr := decodeRawBase64Body(addrs.Body, h.effectiveBodyParsingSizeLimit())
 	if decErr != nil {
 		instr.Logger().Error("apim_callout: error decoding response body base64: %s\n", decErr.Error())
 		h.requestStateCache.Delete(msg.RequestID)

--- a/contrib/azure/apim-callout/apim_messages.go
+++ b/contrib/azure/apim-callout/apim_messages.go
@@ -22,6 +22,10 @@ var (
 	_ proxy.RequestHeaders  = (*messageRequestHeaders)(nil)
 	_ proxy.ResponseHeaders = (*messageResponseHeaders)(nil)
 	_ proxy.HTTPBody        = (*messageBody)(nil)
+
+	// errBodySizeExceeded is returned when a base64-encoded inline body
+	// exceeds the configured body parsing size limit.
+	errBodySizeExceeded = errors.New("apim_callout: inline body exceeds body parsing size limit")
 )
 
 // calloutMessage represents the JSON body sent by the gateway on POST /.
@@ -212,7 +216,9 @@ func hasRawBody(raw json.RawMessage) bool {
 // decodeRawBase64Body extracts the JSON string from a json.RawMessage and
 // base64-decodes its content in place without intermediate copies.
 // Returns nil if the raw message is empty/null.
-func decodeRawBase64Body(raw json.RawMessage) ([]byte, error) {
+// When maxDecodedSize > 0, the function returns errBodySizeExceeded if the
+// decoded body would exceed the limit, preventing unbounded memory allocation.
+func decodeRawBase64Body(raw json.RawMessage, maxDecodedSize int) ([]byte, error) {
 	first := bytes.IndexByte(raw, '"')
 	if first < 0 {
 		return nil, nil
@@ -222,7 +228,11 @@ func decodeRawBase64Body(raw json.RawMessage) ([]byte, error) {
 		return nil, nil
 	}
 	src := raw[first+1 : last]
-	dst := make([]byte, base64.StdEncoding.DecodedLen(len(src)))
+	decodedLen := base64.StdEncoding.DecodedLen(len(src))
+	if maxDecodedSize > 0 && decodedLen > maxDecodedSize {
+		return nil, errBodySizeExceeded
+	}
+	dst := make([]byte, decodedLen)
 	n, err := base64.StdEncoding.Decode(dst, src)
 	if err != nil {
 		return nil, err

--- a/contrib/azure/apim-callout/apim_messages.go
+++ b/contrib/azure/apim-callout/apim_messages.go
@@ -229,13 +229,19 @@ func decodeRawBase64Body(raw json.RawMessage, maxDecodedSize int) ([]byte, error
 	}
 	src := raw[first+1 : last]
 	decodedLen := base64.StdEncoding.DecodedLen(len(src))
-	if maxDecodedSize > 0 && decodedLen > maxDecodedSize {
+	// DecodedLen is an upper bound that can overestimate by up to 2 bytes due to
+	// base64 padding. Allow this tolerance so bodies exactly at the limit aren't
+	// falsely rejected. The exact decoded size is checked after decoding below.
+	if maxDecodedSize > 0 && decodedLen > maxDecodedSize+2 {
 		return nil, errBodySizeExceeded
 	}
 	dst := make([]byte, decodedLen)
 	n, err := base64.StdEncoding.Decode(dst, src)
 	if err != nil {
 		return nil, err
+	}
+	if maxDecodedSize > 0 && n > maxDecodedSize {
+		return nil, errBodySizeExceeded
 	}
 	return dst[:n], nil
 }

--- a/contrib/azure/apim-callout/apim_test.go
+++ b/contrib/azure/apim-callout/apim_test.go
@@ -250,22 +250,28 @@ func TestMethodNotAllowed(t *testing.T) {
 
 func TestDecodeRawBase64Body(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   json.RawMessage
-		want    []byte
-		wantErr bool
+		name           string
+		input          json.RawMessage
+		maxDecodedSize int
+		want           []byte
+		wantErr        bool
+		wantSizeErr    bool
 	}{
-		{"nil", nil, nil, false},
-		{"null", json.RawMessage("null"), nil, false},
-		{"empty-string", json.RawMessage(`""`), nil, false},
-		{"valid", json.RawMessage(`"aGVsbG8="`), []byte("hello"), false},
-		{"invalid", json.RawMessage(`"not-valid-base64!!!"`), nil, true},
+		{"nil", nil, 0, nil, false, false},
+		{"null", json.RawMessage("null"), 0, nil, false, false},
+		{"empty-string", json.RawMessage(`""`), 0, nil, false, false},
+		{"valid", json.RawMessage(`"aGVsbG8="`), 0, []byte("hello"), false, false},
+		{"invalid", json.RawMessage(`"not-valid-base64!!!"`), 0, nil, true, false},
+		{"valid-within-limit", json.RawMessage(`"aGVsbG8="`), 100, []byte("hello"), false, false},
+		{"valid-exceeds-limit", json.RawMessage(`"aGVsbG8="`), 2, nil, true, true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := decodeRawBase64Body(tt.input)
-			if tt.wantErr {
+			got, err := decodeRawBase64Body(tt.input, tt.maxDecodedSize)
+			if tt.wantSizeErr {
+				assert.ErrorIs(t, err, errBodySizeExceeded)
+			} else if tt.wantErr {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
@@ -273,6 +279,37 @@ func TestDecodeRawBase64Body(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOversizedInlineBodyFailsOpen(t *testing.T) {
+	bodyLimit := 16
+	h := NewHandler(AppsecAPIMConfig{
+		Context:              t.Context(),
+		BodyParsingSizeLimit: &bodyLimit,
+	})
+
+	tracer.Start()
+	t.Cleanup(tracer.Stop)
+
+	largePayload := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte("A"), 64))
+	rr := doPost(t, h, calloutMessage{
+		Addresses: marshalAddresses(t, addressesRequestHeaders{
+			Method:    "POST",
+			Scheme:    "https",
+			Authority: "datadoghq.com",
+			Path:      "/api/data",
+			Headers: map[string][]string{
+				"User-Agent":   {"Mozilla/5.0"},
+				"Content-Type": {"application/json"},
+			},
+			Body: rawBody(largePayload),
+		}),
+	})
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	result := decodeResult(t, rr)
+	assert.Nil(t, result.Block, "oversized inline body should fail open")
+	assert.NotEmpty(t, result.RequestID, "request should still be processed")
 }
 
 // AppSec tests -- these use DD_APPSEC_RULES to test WAF detection and blocking.

--- a/contrib/azure/apim-callout/apim_test.go
+++ b/contrib/azure/apim-callout/apim_test.go
@@ -263,6 +263,7 @@ func TestDecodeRawBase64Body(t *testing.T) {
 		{"valid", json.RawMessage(`"aGVsbG8="`), 0, []byte("hello"), false, false},
 		{"invalid", json.RawMessage(`"not-valid-base64!!!"`), 0, nil, true, false},
 		{"valid-within-limit", json.RawMessage(`"aGVsbG8="`), 100, []byte("hello"), false, false},
+		{"valid-at-exact-limit", json.RawMessage(`"aGVsbG8="`), 5, []byte("hello"), false, false},
 		{"valid-exceeds-limit", json.RawMessage(`"aGVsbG8="`), 2, nil, true, true},
 	}
 


### PR DESCRIPTION
## What Does This Do?

Fixes **APMSP-3076** — unbounded inline body decoding in the APIM callout handler that could lead to OOM via oversized payloads.

### The Vulnerability

The callout handler had two unbounded memory allocation paths:

1. **`json.NewDecoder(r.Body).Decode()`** (line 135) — no `MaxBytesReader` or `io.LimitReader` on the incoming HTTP request body. An attacker could send an arbitrarily large JSON payload.

2. **`decodeRawBase64Body()`** — allocated `base64.StdEncoding.DecodedLen(len(src))` bytes based on attacker-controlled input **before** checking any body size limit. Inline-body integrations (Boomi) bypass the `allowed-body-size` backpressure sent to the gateway.

### The Fix

**Defense layer 1 — HTTP request size cap:**
- Wrap `r.Body` with `http.MaxBytesReader` using `2× bodyParsingSizeLimit` (accounts for base64 expansion + JSON envelope), with a 1MB floor for envelope-only requests.

**Defense layer 2 — Inline body decode size check:**
- Add `maxDecodedSize int` parameter to `decodeRawBase64Body`. Before allocating the decode buffer, check that `decodedLen <= maxDecodedSize`. Returns `errBodySizeExceeded` if exceeded.
- All 4 call sites updated to pass `effectiveBodyParsingSizeLimit()`.

**Fail-open semantics preserved** — oversized bodies are logged and skipped, never cause request rejection (consistent with existing behavior).

### Files Changed

| File | Change |
|---|---|
| `contrib/azure/apim-callout/apim.go` | `effectiveBodyParsingSizeLimit()` helper, `MaxBytesReader` in `handleCallout`, pass limit to all 4 `decodeRawBase64Body` calls |
| `contrib/azure/apim-callout/apim_messages.go` | `errBodySizeExceeded` sentinel, `maxDecodedSize` param + pre-allocation check in `decodeRawBase64Body` |
| `contrib/azure/apim-callout/apim_test.go` | Updated `TestDecodeRawBase64Body` with size limit cases, added `TestOversizedInlineBodyFailsOpen` |

### Testing

- All existing tests pass (including 4-call flow, AppSec body parsing, skip body transition)
- New test `TestDecodeRawBase64Body/valid-exceeds-limit` — verifies `errBodySizeExceeded` returned
- New test `TestOversizedInlineBodyFailsOpen` — verifies handler processes request normally when inline body exceeds limit (body analysis skipped, request continues)
