### PR TITLE
feat(llmobs): propagate experiment project_id via baggage

### DIFF
--- a/internal/llmobs/llmobs.go
+++ b/internal/llmobs/llmobs.go
@@ -50,6 +50,7 @@ const (
 	baggageKeyExperimentID           = "_ml_obs.experiment_id"
 	baggageKeyExperimentRunID        = "_ml_obs.experiment_run_id"
 	baggageKeyExperimentRunIteration = "_ml_obs.experiment_run_iteration"
+	baggageKeyExperimentProjectID    = "_ml_obs.experiment_project_id"
 )
 
 const (
@@ -816,7 +817,8 @@ func (l *LLMObs) StartSpan(ctx context.Context, kind SpanKind, name string, cfg 
 	experimentID := apmSpan.BaggageItem(baggageKeyExperimentID)
 	experimentRunID := apmSpan.BaggageItem(baggageKeyExperimentRunID)
 	experimentRunIteration := apmSpan.BaggageItem(baggageKeyExperimentRunIteration)
-	if experimentID != "" || experimentRunID != "" || experimentRunIteration != "" {
+	experimentProjectID := apmSpan.BaggageItem(baggageKeyExperimentProjectID)
+	if experimentID != "" || experimentRunID != "" || experimentRunIteration != "" || experimentProjectID != "" {
 		if span.llmCtx.tags == nil {
 			span.llmCtx.tags = make(map[string]string)
 		}
@@ -830,6 +832,9 @@ func (l *LLMObs) StartSpan(ctx context.Context, kind SpanKind, name string, cfg 
 		if experimentRunIteration != "" {
 			span.llmCtx.tags["run_iteration"] = experimentRunIteration
 		}
+		if experimentProjectID != "" {
+			span.llmCtx.tags["project_id"] = experimentProjectID
+		}
 	}
 
 	log.Debug("llmobs: starting LLMObs span: %s, span_kind: %s, ml_app: %s", spanName, kind, span.mlApp)
@@ -841,6 +846,7 @@ type ExperimentInfo struct {
 	ID           string
 	RunID        string
 	RunIteration int
+	ProjectID    string
 }
 
 // StartExperimentSpan starts a new experiment span with the given name and configuration.
@@ -858,6 +864,9 @@ func (l *LLMObs) StartExperimentSpan(ctx context.Context, name string, params Ex
 	}
 	if params.RunIteration > 0 {
 		span.apm.SetBaggageItem(baggageKeyExperimentRunIteration, fmt.Sprintf("%d", params.RunIteration))
+	}
+	if params.ProjectID != "" {
+		span.apm.SetBaggageItem(baggageKeyExperimentProjectID, params.ProjectID)
 	}
 	return span, ctx
 }

--- a/internal/llmobs/llmobs_test.go
+++ b/internal/llmobs/llmobs_test.go
@@ -267,6 +267,7 @@ func TestStartSpan(t *testing.T) {
 		experimentID := "exp-dist-123"
 		experimentRunID := "run-uuid-xyz"
 		experimentRunIteration := 3
+		experimentProjectID := "proj-dist-456"
 
 		h := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			ctx := req.Context()
@@ -281,6 +282,7 @@ func TestStartSpan(t *testing.T) {
 				ID:           experimentID,
 				RunID:        experimentRunID,
 				RunIteration: experimentRunIteration,
+				ProjectID:    experimentProjectID,
 			}, llmobs.StartSpanConfig{})
 			defer experimentSpan.Finish(llmobs.FinishSpanConfig{})
 
@@ -312,6 +314,7 @@ func TestStartSpan(t *testing.T) {
 		assert.Equal(t, experimentID, findTag(serverLLM.Tags, "experiment_id"), "server span should inherit experiment_id via baggage")
 		assert.Equal(t, experimentRunID, findTag(serverLLM.Tags, "run_id"), "server span should inherit run_id via baggage")
 		assert.Equal(t, fmt.Sprintf("%d", experimentRunIteration), findTag(serverLLM.Tags, "run_iteration"), "server span should inherit run_iteration via baggage")
+		assert.Equal(t, experimentProjectID, findTag(serverLLM.Tags, "project_id"), "server span should inherit project_id via baggage")
 	})
 	t.Run("custom-start-and-finish-times", func(t *testing.T) {
 		tt, ll := testTracer(t)
@@ -2345,10 +2348,12 @@ func TestDDAttributes(t *testing.T) {
 		experimentID := "test-experiment-789"
 		experimentRunID := "run-uuid-abc"
 		experimentRunIteration := 2
+		experimentProjectID := "test-project-789"
 		parentSpan, ctx := ll.StartExperimentSpan(ctx, "parent-experiment", llmobs.ExperimentInfo{
 			ID:           experimentID,
 			RunID:        experimentRunID,
 			RunIteration: experimentRunIteration,
+			ProjectID:    experimentProjectID,
 		}, llmobs.StartSpanConfig{})
 		childSpan, _ := ll.StartSpan(ctx, llmobs.SpanKindLLM, "child-llm", llmobs.StartSpanConfig{})
 
@@ -2366,6 +2371,7 @@ func TestDDAttributes(t *testing.T) {
 		require.NotNil(t, childLLM, "Child LLM span should exist")
 		assert.Contains(t, childLLM.Tags, "run_id:"+experimentRunID, "Child span should inherit run_id from baggage")
 		assert.Contains(t, childLLM.Tags, "run_iteration:2", "Child span should inherit run_iteration from baggage")
+		assert.Contains(t, childLLM.Tags, "project_id:"+experimentProjectID, "Child span should inherit project_id from baggage")
 	})
 	t.Run("child-span-trace-ids", func(t *testing.T) {
 		tt, ll := testTracer(t)

--- a/llmobs/experiment/experiment.go
+++ b/llmobs/experiment/experiment.go
@@ -50,8 +50,9 @@ type Experiment struct {
 	tagsSlice         []string
 
 	// these are set after the experiment is run
-	id      string
-	runName string
+	id        string
+	runName   string
+	projectID string
 }
 
 // Task represents the task to run for an Experiment.
@@ -265,6 +266,7 @@ func (e *Experiment) Run(ctx context.Context, opts ...RunOption) (result *Experi
 	if err != nil {
 		return nil, fmt.Errorf("failed to get or create project: %w", err)
 	}
+	e.projectID = proj.ID
 
 	// 2) Create the experiment, telling the backend how many runs to expect
 	expResp, err := ll.Transport.CreateExperiment(ctx, e.Name, e.dataset.ID(), proj.ID, e.dataset.Version(), e.cfg.experimentCfg, e.tagsSlice, e.description, e.cfg.runs)
@@ -454,6 +456,7 @@ func (e *Experiment) runTaskForRecord(ctx context.Context, llmobs *illmobs.LLMOb
 		ID:           e.id,
 		RunID:        run.ID,
 		RunIteration: run.Iteration,
+		ProjectID:    e.projectID,
 	}, illmobs.StartSpanConfig{})
 	defer func() { span.Finish(illmobs.FinishSpanConfig{Error: err}) }()
 
@@ -464,6 +467,9 @@ func (e *Experiment) runTaskForRecord(ctx context.Context, llmobs *illmobs.LLMOb
 	tags["experiment_id"] = e.id
 	tags["run_id"] = run.ID
 	tags["run_iteration"] = fmt.Sprintf("%d", run.Iteration)
+	if e.projectID != "" {
+		tags["project_id"] = e.projectID
+	}
 
 	out, err := e.task.Run(ctx, rec, e.cfg.experimentCfg)
 	if err != nil {


### PR DESCRIPTION
Propagate missing experiment `projectID` via the `_ml_obs.experiment_project_id` baggage key (same as it was being done like the experiment ID and the run ID).