### PR TITLE
ci(gitlab): reorder config-validation stage in CI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 stages:
   - ci-image
   - docker-images-reliability-env
+  - config-validation
   - generate
   - microbenchmarks
   - macrobenchmarks
@@ -8,7 +9,6 @@ stages:
   - go-go-prof-app-parallel
   - go-go-prof-app-parallel-slo
   - gates
-  - config-validation
   - test-apps
 
 variables:


### PR DESCRIPTION
### What does this PR do?

Config validation should be triggered before other steps.

### Motivation

Avoid waiting for brenchmarks and other things to get the config validation result

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
