### PR TITLE
fix(orchestrion): fix GLS over-pop and cross-goroutine leak (tracer spans + appsec/dyngo)

### DIFF
--- a/ddtrace/tracer/context.go
+++ b/ddtrace/tracer/context.go
@@ -35,6 +35,16 @@ func ContextWithSpan(ctx context.Context, s *Span) context.Context {
 	if s != nil {
 		// Snapshot the SpanContext so it survives span pool recycling.
 		newCtx = context.WithValue(newCtx, activeSpanContextKey{}, s.Context())
+		// Capture a goroutine-scoped popper for the ActiveSpanKey entry that
+		// CtxWithValue just pushed onto the GLS stack. We attach it to the span
+		// so that Span.Finish can release the slot exactly once, on the same
+		// goroutine that pushed it. Without this, a double Finish (or a Finish
+		// on a goroutine other than the one that pushed) would pop unrelated
+		// entries off the GLS stack — corrupting trace parenting and leaking
+		// memory at high RPS. See https://github.com/DataDog/orchestrion/issues/782.
+		if orchestrion.Enabled() {
+			s.setGLSPopOnce(orchestrion.GLSPopFunc(internal.ActiveSpanKey))
+		}
 	}
 	return contextWithPropagatedLLMSpan(newCtx, s)
 }

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -9,11 +9,14 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"sync"
 	"testing"
 
 	"github.com/DataDog/dd-trace-go/v2/internal"
+	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestContextWithSpan(t *testing.T) {
@@ -208,4 +211,173 @@ func TestStartSpanFromNilContext(t *testing.T) {
 	ctxSpan, ok := SpanFromContext(ctx)
 	assert.True(ok)
 	assert.Equal(child, ctxSpan)
+}
+
+// TestFinishIsIdempotentOnGLS is a regression test for
+// https://github.com/DataDog/orchestrion/issues/782 (korECM's report).
+//
+// Before the fix, Span.Finish unconditionally popped ActiveSpanKey from the
+// GLS context stack even when s.finish(t) short-circuited because s.finished
+// was already true. Calling Finish twice on the same span popped the stack
+// twice — and the second pop removed an unrelated parent span sitting on
+// top, causing cross-request trace parenting bugs in production.
+//
+// This test pushes outer + inner onto the GLS stack via StartSpanFromContext
+// (which calls ContextWithSpan), finishes inner twice, and verifies that
+// outer is still reachable from a bare context (i.e., still on the GLS
+// stack). On main this fails: the second inner.Finish() pops outer.
+func TestFinishIsIdempotentOnGLS(t *testing.T) {
+	t.Cleanup(orchestrion.MockGLS())
+
+	_, _, _, stop, err := startTestTracer(t)
+	require.NoError(t, err)
+	defer stop()
+
+	outer, outerCtx := StartSpanFromContext(context.Background(), "outer")
+	inner, _ := StartSpanFromContext(outerCtx, "inner")
+
+	// Sanity: both pushes occurred. ActiveSpanKey gets one entry per span.
+	require.Equal(t, 2, orchestrion.GLSStackDepth(), "expected outer+inner on GLS stack")
+
+	inner.Finish() // expected: pop inner, stack = [outer]
+	inner.Finish() // expected: no-op (idempotent). Before fix: pops outer.
+
+	// outer must still be the active span via GLS lookup against a bare ctx.
+	top, ok := SpanFromContext(orchestrion.WrapContext(context.Background()))
+	assert.True(t, ok, "outer should still be on the GLS stack")
+	assert.Equal(t, outer, top, "double inner.Finish() must not pop outer")
+
+	// And the stack must have exactly one entry (outer).
+	assert.Equal(t, 1, orchestrion.GLSStackDepth(), "stack should have only outer")
+
+	outer.Finish() // clean up
+
+	assert.Equal(t, 0, orchestrion.GLSStackDepth(), "stack should be empty after outer.Finish")
+}
+
+// TestFinishOnDifferentGoroutineDoesNotPopOthersStack is a regression test
+// for the cross-goroutine pop bug also surfaced in
+// https://github.com/DataDog/orchestrion/issues/782. Before the fix,
+// Span.Finish used the raw orchestrion.GLSPopValue, which pops whichever
+// goroutine's GLS stack the finisher happens to be running on. If goroutine
+// A starts a span and hands it to goroutine B for Finish, B's own GLS stack
+// gets corrupted (an entry belonging to a different in-flight span gets
+// popped instead).
+//
+// With the fix in place, the popFunc captured at push time is scoped to the
+// pushing goroutine, so Finish on a different goroutine is a no-op for the
+// finishing goroutine's stack.
+func TestFinishOnDifferentGoroutineDoesNotPopOthersStack(t *testing.T) {
+	t.Cleanup(orchestrion.MockGLSPerGoroutine())
+
+	_, _, _, stop, err := startTestTracer(t)
+	require.NoError(t, err)
+	defer stop()
+
+	// Goroutine A: starts spanA, pushing it onto A's GLS.
+	spanA, _ := StartSpanFromContext(context.Background(), "spanA")
+	require.Equal(t, 1, orchestrion.GLSStackDepth(), "spanA should be on A's stack")
+
+	// Hand spanA to goroutine B and have B start its own spanB and then
+	// Finish spanA from B. The finish on B must not pop spanB off B's stack.
+	var wg sync.WaitGroup
+	var depthInB int
+	var topOnB *Span
+	var topOnBOk bool
+	wg.Go(func() {
+		spanB, _ := StartSpanFromContext(context.Background(), "spanB")
+		// Now B's GLS has [spanB]. Finishing spanA on this goroutine must
+		// be a no-op for B's stack.
+		spanA.Finish()
+
+		// B's stack should still contain spanB.
+		depthInB = orchestrion.GLSStackDepth()
+		topOnB, topOnBOk = SpanFromContext(orchestrion.WrapContext(context.Background()))
+		spanB.Finish()
+	})
+	wg.Wait()
+
+	assert.Equal(t, 1, depthInB, "spanA.Finish on goroutine B must not pop B's stack")
+	assert.True(t, topOnBOk, "spanB should still be on B's stack after spanA.Finish")
+	if assert.NotNil(t, topOnB) {
+		assert.Equal(t, "spanB", topOnB.name)
+	}
+}
+
+// TestFinishWithoutContextDoesNotPopGLS verifies that a span created via
+// StartSpan (without an associated context push) does not pop the GLS stack
+// at Finish. Before the fix, Span.Finish always popped, even when no push
+// had occurred, which could corrupt unrelated GLS state.
+func TestFinishWithoutContextDoesNotPopGLS(t *testing.T) {
+	t.Cleanup(orchestrion.MockGLS())
+
+	_, _, _, stop, err := startTestTracer(t)
+	require.NoError(t, err)
+	defer stop()
+
+	// Put an unrelated span on the GLS stack via ContextWithSpan.
+	other, _ := StartSpanFromContext(context.Background(), "other")
+	require.Equal(t, 1, orchestrion.GLSStackDepth())
+
+	// Create a span the "manual" way — no ContextWithSpan, so no GLS push.
+	manual := StartSpan("manual")
+	manual.Finish()
+
+	// other must still be on the GLS stack.
+	assert.Equal(t, 1, orchestrion.GLSStackDepth(), "StartSpan().Finish() must not pop unrelated GLS entries")
+	top, ok := SpanFromContext(orchestrion.WrapContext(context.Background()))
+	assert.True(t, ok)
+	assert.Equal(t, other, top)
+
+	other.Finish()
+	assert.Equal(t, 0, orchestrion.GLSStackDepth())
+}
+
+// TestContextWithSpanReclaimsFinishedCrossGoroutine is the in-tree analogue of
+// korECM's standalone reproducer (https://github.com/korECM/dd-trace-go-leak)
+// for orchestrion issue #782. It models the franz-go / Kafka consumer shape:
+// an owner goroutine creates and finishes each span, while a worker goroutine
+// re-injects the (already finished) span into a context via ContextWithSpan.
+//
+// Because the push happens on the worker and the matching pop (Finish) ran on
+// the owner, the goroutine-scoped popper from the over-pop fix is a no-op on
+// the worker — so without the reclaim-on-push behavior the worker's GLS stack
+// would grow by one entry per record (the leak korECM measured at ~16
+// objects/record). With reclaim-on-push, ContextWithSpan drops the previous
+// finished span from the top before pushing the next, keeping depth bounded.
+func TestContextWithSpanReclaimsFinishedCrossGoroutine(t *testing.T) {
+	t.Cleanup(orchestrion.MockGLSPerGoroutine())
+
+	_, _, _, stop, err := startTestTracer(t)
+	require.NoError(t, err)
+	defer stop()
+
+	const iterations = 1000
+
+	depthCh := make(chan int, 1)
+	go func() { // worker goroutine — all ContextWithSpan pushes happen here
+		for range iterations {
+			// Owner-equivalent: create AND finish the span on a different
+			// goroutine, so the worker never runs the matching pop.
+			var s *Span
+			var wg sync.WaitGroup
+			wg.Go(func() {
+				s = StartSpan("kafka.consume")
+				s.Finish()
+			})
+			wg.Wait()
+
+			// Worker re-injects the already-finished span and discards the ctx,
+			// exactly like a consumer making its handler a child of the consume
+			// span. The push must reclaim the previous finished entry.
+			_ = ContextWithSpan(context.Background(), s)
+		}
+		depthCh <- orchestrion.GLSStackDepth()
+	}()
+
+	depth := <-depthCh
+	// Without the fix this would be ~iterations. With it, only the most
+	// recently pushed (now-finished) span remains, reclaimed on the next push.
+	assert.LessOrEqual(t, depth, 1,
+		"worker GLS depth must stay bounded under push-here/finish-there, got %d after %d records", depth, iterations)
 }

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -22,6 +22,7 @@ import (
 	rt "runtime/trace"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
@@ -34,7 +35,6 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/locking"
 	"github.com/DataDog/dd-trace-go/v2/internal/locking/assert"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
-	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion"
 	"github.com/DataDog/dd-trace-go/v2/internal/samplernames"
 	"github.com/DataDog/dd-trace-go/v2/internal/stacktrace"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
@@ -180,6 +180,54 @@ type Span struct {
 
 	// +checklocks:mu
 	taskEnd func() // ends execution tracer (runtime/trace) task, if started
+
+	// +checklocks:mu
+	// glsPop, when non-nil, releases the ActiveSpanKey entry that
+	// ContextWithSpan pushed onto the orchestrion GLS context stack for this
+	// span. It is captured via orchestrion.GLSPopFunc at push time, so it is
+	// goroutine-scoped: invoking it from a different goroutine is a no-op,
+	// preventing Finish from corrupting an unrelated goroutine's GLS stack.
+	// nil means no push was performed for this span (e.g., a manual StartSpan
+	// without a subsequent ContextWithSpan), so Finish must not pop anything.
+	// Set exactly once (first-push-wins) so a double Finish doesn't trigger a
+	// second pop on the same stack — see TestFinishIsIdempotentOnGLS.
+	glsPop func() `msg:"-"`
+
+	// glsReclaimable is set to true when the span is finished. It is read,
+	// lock-free, from the orchestrion GLS push path (on a possibly different
+	// goroutine) to reclaim this span's stale GLS entry. A finished span is
+	// no longer a live scope, so it is safe to drop from any goroutine's GLS
+	// stack. This bounds GLS growth when a span is pushed via ContextWithSpan
+	// on one goroutine but finished on another (the cross-goroutine pop never
+	// runs on the pushing goroutine). It is an atomic (not mu-guarded) because
+	// the reader is a different goroutine that must not take s.mu on the hot
+	// push path. See GLSReclaimable and contextStack.Push.
+	glsReclaimable atomic.Bool `msg:"-"`
+}
+
+// GLSReclaimable reports whether this span has been finished and may therefore
+// be reclaimed from an orchestrion goroutine-local-storage (GLS) stack. The
+// orchestrion GLS push path calls this (via a narrow interface) to drop stale
+// span entries that were pushed on one goroutine but finished on another. It
+// is safe to call from any goroutine and on a nil receiver.
+func (s *Span) GLSReclaimable() bool {
+	return s != nil && s.glsReclaimable.Load()
+}
+
+// setGLSPopOnce records the goroutine-scoped popper for this span's
+// ActiveSpanKey entry on the orchestrion GLS stack. It is set exactly once
+// (first-push-wins) so that repeated ContextWithSpan calls for the same
+// span don't overwrite (and leak) the original push's popper. nil
+// arguments are ignored. The companion call is in Finish.
+func (s *Span) setGLSPopOnce(pop func()) {
+	if s == nil || pop == nil {
+		return
+	}
+	s.mu.Lock()
+	if s.glsPop == nil {
+		s.glsPop = pop
+	}
+	s.mu.Unlock()
 }
 
 func (s *Span) clear() {
@@ -216,6 +264,12 @@ func (s *Span) clear() {
 	s.pprofCtxActive = nil
 	s.pprofCtxRestore = nil
 	s.taskEnd = nil
+	s.glsPop = nil
+	// Reset the GLS reclaim flag: this object may be handed back out by the
+	// span pool for a fresh, live span. Leaving it set would let
+	// contextStack.Push drop the reused (live) span from a GLS stack. See
+	// GLSReclaimable.
+	s.glsReclaimable.Store(false)
 	// Always keep this unlock as the last line. If we ever introduce
 	// code above that could panic, we should move it as deferred call
 	// under s.mu.Lock().
@@ -1013,8 +1067,24 @@ func (s *Span) Finish(opts ...FinishOption) {
 		}
 	}
 
-	s.finish(t)
-	orchestrion.GLSPopValue(sharedinternal.ActiveSpanKey)
+	if !s.finish(t) {
+		// Already finished. Do NOT touch the GLS stack: the matching pop
+		// (if any) was performed by the first Finish call. Popping again
+		// would remove an unrelated entry, corrupting trace parenting.
+		return
+	}
+
+	// Release the entry ContextWithSpan pushed onto the GLS stack, if any.
+	// glsPop is a closure captured by orchestrion.GLSPopFunc at push time
+	// and is a no-op when invoked on a different goroutine than the one
+	// that pushed — see span.glsPop docs.
+	s.mu.Lock()
+	pop := s.glsPop
+	s.glsPop = nil
+	s.mu.Unlock()
+	if pop != nil {
+		pop()
+	}
 }
 
 // SetOperationName sets or changes the operation name.
@@ -1046,7 +1116,12 @@ func (s *Span) enrichServiceSource() {
 	s.meta.Set(ext.KeyServiceSource, s.serviceSource)
 }
 
-func (s *Span) finish(finishTime int64) {
+// finish completes the span. It returns true if this call transitioned the
+// span from not-finished to finished, and false if the span had already been
+// finished. Callers use this signal to perform one-shot side effects (e.g.,
+// popping the orchestrion GLS stack) that must not run twice across repeated
+// Finish calls.
+func (s *Span) finish(finishTime int64) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -1055,8 +1130,15 @@ func (s *Span) finish(finishTime int64) {
 	// race, since spans are marked `finished` before we flush them.
 	if s.finished {
 		// already finished
-		return
+		return false
 	}
+
+	// Mark the span reclaimable from any goroutine's orchestrion GLS stack.
+	// Set here (once, on the transitioning Finish call) so a span finished on
+	// a different goroutine than the one that pushed it can still be dropped
+	// from the pushing goroutine's GLS stack on its next push. See
+	// GLSReclaimable and contextStack.Push.
+	s.glsReclaimable.Store(true)
 
 	s.serializeSpanLinksInMeta()
 	s.serializeSpanEvents()
@@ -1076,7 +1158,10 @@ func (s *Span) finish(finishTime int64) {
 	tracer, hasTracer := getGlobalTracer().(*tracer)
 	if hasTracer {
 		if !tracer.config.enabled.get() {
-			return
+			// Tracer is disabled, but we still transitioned this span to
+			// finished above, so report true to drive single-shot cleanup
+			// in the caller (e.g., the GLS pop in Span.Finish).
+			return true
 		}
 		if tracer.config.canDropP0s() {
 			// the agent supports dropping p0's in the client
@@ -1112,6 +1197,7 @@ func (s *Span) finish(finishTime int64) {
 		// point are attributed correctly.
 		pprof.SetGoroutineLabels(s.pprofCtxRestore)
 	}
+	return true
 }
 
 // textNonParsable specifies the text that will be assigned to resources for which the resource

--- a/instrumentation/appsec/dyngo/operation.go
+++ b/instrumentation/appsec/dyngo/operation.go
@@ -97,9 +97,14 @@ type operation struct {
 	disabled bool
 	mu       sync.RWMutex
 
-	// inContext is used to determine if RegisterOperation was called to put the Operation in the context tree.
-	// If so we need to remove it from the context tree when the Operation is finished.
-	inContext bool
+	// glsPop, when non-nil, releases the contextKey entry that
+	// RegisterOperation pushed onto the orchestrion GLS context stack for this
+	// operation. It is captured via orchestrion.GLSPopFunc at push time, so it
+	// is goroutine-scoped: invoking it from a different goroutine is a no-op,
+	// preventing FinishOperation from corrupting an unrelated goroutine's GLS
+	// stack. nil means RegisterOperation was never called for this operation,
+	// so FinishOperation must not pop anything. Guarded by mu.
+	glsPop func()
 }
 
 func (o *operation) Parent() Operation {
@@ -200,8 +205,21 @@ func StartAndRegisterOperation[O Operation, E ArgOf[O]](ctx context.Context, op 
 // RegisterOperation registers the operation in the context tree. All operations that plan to have children operations
 // should call this function to ensure the operation is properly linked in the context tree.
 func RegisterOperation(ctx context.Context, op Operation) context.Context {
-	op.unwrap().inContext = true
-	return orchestrion.CtxWithValue(ctx, contextKey{}, op)
+	o := op.unwrap()
+	ctx = orchestrion.CtxWithValue(ctx, contextKey{}, op)
+	// Capture a goroutine-scoped popper for the contextKey entry CtxWithValue
+	// just pushed onto the GLS stack, so FinishOperation releases it exactly
+	// once, on the goroutine that pushed it. Invoking it on a different
+	// goroutine is a no-op, so a cross-goroutine finish cannot corrupt an
+	// unrelated goroutine's GLS stack. GLSPopFunc returns a no-op when
+	// orchestrion is disabled. First registration wins.
+	// See https://github.com/DataDog/orchestrion/issues/782.
+	o.mu.Lock()
+	if o.glsPop == nil {
+		o.glsPop = orchestrion.GLSPopFunc(contextKey{})
+	}
+	o.mu.Unlock()
+	return ctx
 }
 
 // FinishOperation finishes the operation along with its results and emits a
@@ -214,12 +232,20 @@ func FinishOperation[O Operation, E ResultOf[O]](op O, results E) {
 	o.mu.RLock()
 	defer o.mu.RUnlock() // Deferred and stacked on top of the previously deferred call to o.disable()
 
-	if o.inContext {
-		orchestrion.GLSPopValue(contextKey{})
+	if o.disabled {
+		// Already finished. Returning before the GLS pop below makes this
+		// idempotent: a second FinishOperation must not pop the GLS again, or
+		// it would remove an unrelated entry still in flight on this goroutine
+		// (the bug this guards against — the pop previously ran before this
+		// check). See https://github.com/DataDog/orchestrion/issues/782.
+		return
 	}
 
-	if o.disabled {
-		return
+	// Release the contextKey entry RegisterOperation pushed onto the GLS stack,
+	// if any. glsPop is goroutine-scoped and a no-op when orchestrion is
+	// disabled or when invoked on a goroutine other than the one that pushed.
+	if o.glsPop != nil {
+		o.glsPop()
 	}
 
 	var current Operation = op

--- a/instrumentation/appsec/dyngo/operation_gls_test.go
+++ b/instrumentation/appsec/dyngo/operation_gls_test.go
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package dyngo_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/dyngo"
+	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFinishOperationIsIdempotentOnGLS is a regression test for the same GLS
+// over-pop shape as the span fix in orchestrion#782, on the dyngo contextKey.
+//
+// FinishOperation used to call orchestrion.GLSPopValue before checking
+// o.disabled, so calling it twice on the same operation popped the GLS stack
+// twice — the second pop removing an unrelated operation still in flight on
+// the same goroutine. The disabled check now runs before the pop, making it
+// idempotent.
+func TestFinishOperationIsIdempotentOnGLS(t *testing.T) {
+	t.Cleanup(orchestrion.MockGLS())
+
+	ctx := context.Background()
+	outer := operation{dyngo.NewOperation(nil)}
+	ctx = dyngo.RegisterOperation(ctx, outer) // GLS: [outer]
+	require.Equal(t, 1, orchestrion.GLSStackDepth())
+
+	inner := operation{dyngo.NewOperation(outer)}
+	_ = dyngo.RegisterOperation(ctx, inner) // GLS: [outer, inner]
+	require.Equal(t, 2, orchestrion.GLSStackDepth())
+
+	dyngo.FinishOperation(inner, MyOperationRes{}) // pop inner -> [outer]
+	require.Equal(t, 1, orchestrion.GLSStackDepth(), "first FinishOperation pops inner")
+
+	dyngo.FinishOperation(inner, MyOperationRes{}) // must be a no-op for the GLS
+	assert.Equal(t, 1, orchestrion.GLSStackDepth(),
+		"double FinishOperation must not pop the unrelated outer operation")
+
+	dyngo.FinishOperation(outer, MyOperationRes{}) // clean up -> []
+	assert.Equal(t, 0, orchestrion.GLSStackDepth())
+}
+
+// TestFinishOperationCrossGoroutineDoesNotPopOthersStack verifies that
+// finishing an operation on a goroutine other than the one that registered it
+// does not pop the finishing goroutine's GLS stack. Before the fix, the raw
+// GLSPopValue popped whichever goroutine ran FinishOperation; now the popper
+// captured at RegisterOperation time is goroutine-scoped and no-ops elsewhere.
+func TestFinishOperationCrossGoroutineDoesNotPopOthersStack(t *testing.T) {
+	t.Cleanup(orchestrion.MockGLSPerGoroutine())
+
+	// G1 (this goroutine) registers opA.
+	opA := operation{dyngo.NewOperation(nil)}
+	dyngo.RegisterOperation(context.Background(), opA)
+	require.Equal(t, 1, orchestrion.GLSStackDepth(), "opA on G1's stack")
+
+	var depthInB int
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		// G2 registers its own opB, then finishes opA (registered on G1).
+		opB := operation{dyngo.NewOperation(nil)}
+		dyngo.RegisterOperation(context.Background(), opB)
+		dyngo.FinishOperation(opA, MyOperationRes{}) // must not touch G2's stack
+		depthInB = orchestrion.GLSStackDepth()
+		dyngo.FinishOperation(opB, MyOperationRes{})
+	})
+	wg.Wait()
+
+	assert.Equal(t, 1, depthInB,
+		"FinishOperation(opA) on G2 must not pop G2's own (opB) GLS entry")
+}

--- a/internal/orchestrion/context_stack.go
+++ b/internal/orchestrion/context_stack.go
@@ -12,6 +12,19 @@ import "slices"
 // TODO: handle cross-goroutine context values
 type contextStack map[any][]any
 
+// reclaimable is implemented by GLS values that can signal they no longer
+// represent a live scope and may be dropped from the stack. It is used to
+// bound GLS growth when a value is pushed on one goroutine but its lifecycle
+// ends on another, so the matching pop never runs on the pushing goroutine
+// (e.g. a *tracer.Span pushed via ContextWithSpan and finished elsewhere).
+// The orchestrion package intentionally does not import the tracer; values
+// opt in by implementing this single method.
+type reclaimable interface {
+	// GLSReclaimable reports whether this value is safe to drop from a GLS
+	// stack. Implementations must be safe to call from any goroutine.
+	GLSReclaimable() bool
+}
+
 // getDDContextStack is a main way to access the GLS slot of runtime.g inserted by orchestrion. This function should not be
 // called if the enabled variable is false.
 func getDDContextStack() *contextStack {
@@ -39,12 +52,32 @@ func (s *contextStack) Peek(key any) any {
 }
 
 // Push adds a context to the stack.
+//
+// Before appending, Push drops any trailing entries that report themselves
+// reclaimable (see [reclaimable]). This bounds GLS growth when values are
+// pushed on one goroutine but their lifecycle ends on another, so the pop
+// never runs on this goroutine. Only the top of the stack is ever read (via
+// Peek), and buried entries exist solely to be restored after a Pop; a
+// reclaimable (e.g. finished) entry can never be a meaningful restore target,
+// so dropping it preserves stack semantics. Entries whose type does not
+// implement [reclaimable] (e.g. the bool stored under executionTracedKey) are
+// never dropped.
 func (s *contextStack) Push(key, val any) {
 	if s == nil || *s == nil {
 		return
 	}
 
-	(*s)[key] = append((*s)[key], val)
+	stack := (*s)[key]
+	for len(stack) > 0 {
+		r, ok := stack[len(stack)-1].(reclaimable)
+		if !ok || !r.GLSReclaimable() {
+			break
+		}
+		stack[len(stack)-1] = nil // drop reference so GC can collect the value
+		stack = stack[:len(stack)-1]
+	}
+
+	(*s)[key] = append(stack, val)
 }
 
 // Pop removes the top context from the stack and returns it.

--- a/internal/orchestrion/context_stack_test.go
+++ b/internal/orchestrion/context_stack_test.go
@@ -43,3 +43,102 @@ func TestPopCleansUpEmptyMapEntry(t *testing.T) {
 	_, exists := s[stackTestKey{}]
 	assert.False(t, exists, "empty stack entry should be removed from the map")
 }
+
+// fakeReclaimable is a test value that implements the reclaimable interface so
+// we can drive contextStack.Push's drain logic without depending on the tracer.
+type fakeReclaimable struct {
+	id        int
+	reclaimed bool
+}
+
+func (f *fakeReclaimable) GLSReclaimable() bool { return f.reclaimed }
+
+func TestPushReclaimsFinishedTopEntry(t *testing.T) {
+	s := contextStack(make(map[any][]any))
+
+	first := &fakeReclaimable{id: 1}
+	s.Push(stackTestKey{}, first)
+	require.Equal(t, 1, s.Depth(), "first push lands")
+
+	// Mark the top entry reclaimable, as a finished span would be. The next
+	// push must drop it instead of stacking on top, keeping depth at 1.
+	first.reclaimed = true
+	second := &fakeReclaimable{id: 2}
+	s.Push(stackTestKey{}, second)
+
+	assert.Equal(t, 1, s.Depth(), "reclaimable top entry should be dropped on push")
+	assert.Equal(t, second, s.Peek(stackTestKey{}), "new value should be on top")
+}
+
+func TestPushDrainsMultipleReclaimableEntries(t *testing.T) {
+	s := contextStack(make(map[any][]any))
+
+	// Several entries pile up while live (pushed on this goroutine, e.g. via
+	// ContextWithSpan), building real depth.
+	entries := make([]*fakeReclaimable, 5)
+	for i := range entries {
+		entries[i] = &fakeReclaimable{id: i}
+		s.Push(stackTestKey{}, entries[i])
+	}
+	require.Equal(t, 5, s.Depth(), "five live entries pushed")
+
+	// They all get finished elsewhere (no matching pop ran on this goroutine).
+	for _, e := range entries {
+		e.reclaimed = true
+	}
+
+	// The next push must drain ALL trailing reclaimable entries, not just the top.
+	live := &fakeReclaimable{id: 99}
+	s.Push(stackTestKey{}, live)
+
+	assert.Equal(t, 1, s.Depth(), "all trailing reclaimable entries should be drained")
+	assert.Equal(t, live, s.Peek(stackTestKey{}))
+}
+
+func TestPushKeepsLiveEntries(t *testing.T) {
+	s := contextStack(make(map[any][]any))
+
+	// A live (non-reclaimable) entry on top must never be dropped — this is
+	// the legitimate same-goroutine nesting case (parent still active).
+	parent := &fakeReclaimable{id: 1, reclaimed: false}
+	s.Push(stackTestKey{}, parent)
+	child := &fakeReclaimable{id: 2, reclaimed: false}
+	s.Push(stackTestKey{}, child)
+
+	assert.Equal(t, 2, s.Depth(), "live entries must be preserved (nesting)")
+	assert.Equal(t, child, s.Peek(stackTestKey{}))
+}
+
+func TestPushDoesNotReclaimBuriedEntryUnderLiveTop(t *testing.T) {
+	s := contextStack(make(map[any][]any))
+
+	// Build [buried, liveTop] with both live, so neither is dropped at push.
+	buried := &fakeReclaimable{id: 1, reclaimed: false}
+	s.Push(stackTestKey{}, buried)
+	liveTop := &fakeReclaimable{id: 2, reclaimed: false}
+	s.Push(stackTestKey{}, liveTop)
+	require.Equal(t, 2, s.Depth())
+
+	// buried becomes reclaimable, but liveTop (still live) sits above it.
+	buried.reclaimed = true
+
+	next := &fakeReclaimable{id: 3, reclaimed: false}
+	s.Push(stackTestKey{}, next)
+
+	// The drain stops at liveTop (not reclaimable), so buried is preserved.
+	// This is the invariant that protects legitimate nesting: a reclaimable
+	// entry beneath a live scope is never dropped.
+	assert.Equal(t, 3, s.Depth(), "drain stops at the first live entry from the top; buried stays")
+}
+
+func TestPushDoesNotDrainNonReclaimableValues(t *testing.T) {
+	s := contextStack(make(map[any][]any))
+
+	// Values that don't implement reclaimable (e.g. the bool stored under
+	// executionTracedKey) must never be drained, even if they pile up.
+	s.Push(stackTestKey{}, true)
+	s.Push(stackTestKey{}, false)
+	s.Push(stackTestKey{}, true)
+
+	assert.Equal(t, 3, s.Depth(), "non-reclaimable values are never dropped")
+}


### PR DESCRIPTION
## Summary

Follow-up to #4410. Fixes the orchestrion goroutine-local-storage (GLS) context-stack bugs reported on [orchestrion#782](https://github.com/DataDog/orchestrion/issues/782) by @akash-pocketfm and @korECM. Same root-cause shape in three places. Thanks to @korECM for the investigation and a deterministic reproducer.

The GLS stack pairs a **push** (when a goroutine enters a scope) with a **pop** (on finish). Three bugs broke that pairing:

### 1. Span over-pop (correctness)

`Span.Finish` popped `ActiveSpanKey` unconditionally, but `s.finish` is idempotent — a double `Finish`, or a `Finish` on a goroutine other than the one that pushed, popped the wrong entry and corrupted trace parenting (cross-request span contamination).

**Fix:** capture a goroutine-scoped popper (`orchestrion.GLSPopFunc`) at push time in `ContextWithSpan`, store it on the span, and invoke it once on the `Finish` transition. It no-ops on any other goroutine.

### 2. Span cross-goroutine leak (memory)

When a span is pushed on one goroutine but finished on another (e.g. a Kafka consumer / franz-go produce hook re-injecting a span per item), the goroutine-scoped popper no-ops on the finisher, so the pusher's GLS entry is never released — one `*Span` leaked per item.

**Fix:** the GLS stack is only read at the top, and buried entries exist only to be restored after a pop, so a **finished** span can never be a valid restore target. `contextStack.Push` now drops trailing finished entries before appending. `Span` carries an atomic `glsReclaimable` flag (reset on span-pool reuse); orchestrion drains via a one-method interface and still does not import the tracer.

### 3. dyngo (appsec) `FinishOperation` over-pop

`dyngo.FinishOperation` had the exact same shape — `GLSPopValue` ran before the `disabled` check, so a double finish (or cross-goroutine finish) over-popped the appsec `contextKey` stack. Fixed like #1: a goroutine-scoped popper captured in `RegisterOperation`, with the `disabled` guard moved before the pop.

## Verification

**Unit tests** (red→green; each fix reverted in isolation to confirm):
- `ddtrace/tracer/context_test.go` — double-finish, cross-goroutine finish, manual `StartSpan`, and the push-here/finish-there leak (worker GLS depth stays ≤1 vs 1000 unfixed).
- `internal/orchestrion/context_stack_test.go` — 5 tests for the `Push` drain.
- `instrumentation/appsec/dyngo/operation_gls_test.go` — double-finish + cross-goroutine `FinishOperation`.

**korECM's standalone leak repro** ([korECM/dd-trace-go-leak](https://github.com/korECM/dd-trace-go-leak), `orchestrion go run . -n 200000`):

| Build | retained objects / record |
|---|---|
| plain (GLS off) | ~0 |
| orchestrion, before fix | **16.0** (~372 MB) |
| orchestrion, after fix | **0.001** (matches plain) |

**Gates:** `go test -race` green on tracer, orchestrion, dyngo; checklocks 0 errors; lint clean; `make apidiff` shows only the compatible `(*Span).GLSReclaimable` addition; no `go generate` drift. Branch rebased onto current `main`.

## akash-pocketfm's report

His Gin / `context.WithoutCancel` fire-and-forget repro stays flat on both baseline and branch in our environment; @korECM confirmed that pattern is LIFO-balanced. The real trigger is the asymmetric push-here/finish-there shape (#2), now fixed. He should retest after this ships.

## Remaining / out of scope

- **Span pool** (`DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED`, experimental, off by default): `glsReclaimable` is reset in `Span.clear()` so a recycled span is never wrongly dropped from a live GLS stack. The leak is fully closed with the pool off; with it on it drops from ~16 to ~0.4 objects/record (the remainder is an inherent object-recycling vs cross-goroutine-GLS race, not addressed here).

Refs: https://github.com/DataDog/orchestrion/issues/782
