### PR TITLE
test(ddtrace/tracer): add harness tests for removing SpanContext's span back-reference

### DIFF
--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -1598,3 +1598,53 @@ func TestFromGenericCtxSamplingDecision(t *testing.T) {
 			"drop() after keep() should be a no-op — the trace stays rescued")
 	})
 }
+
+// TestChildInheritsUpdatedParentService verifies that when a parent span's service
+// is changed via SetTag after creation, a subsequently-started child inherits the
+// updated service name from context.inherited.
+func TestChildInheritsUpdatedParentService(t *testing.T) {
+	trc, _, _, stop, err := startTestTracer(t, WithService("global-svc"))
+	require.NoError(t, err)
+	defer stop()
+
+	parent := trc.StartSpan("parent", ServiceName("original-svc"))
+	defer parent.Finish()
+	parent.SetTag(ext.ServiceName, "updated-svc")
+
+	child := trc.StartSpan("child", ChildOf(parent.Context()))
+	defer child.Finish()
+
+	assert.Equal(t, "updated-svc", child.service)
+}
+
+// TestExtractedContextOriginMarkedOnFirstChildOnly verifies that origin from an
+// extracted remote context is set on the first local child span only. The condition
+// context.trace.root == nil must be true for remote contexts and false for local ones.
+func TestExtractedContextOriginMarkedOnFirstChildOnly(t *testing.T) {
+	trc, _, _, stop, err := startTestTracer(t)
+	require.NoError(t, err)
+	defer stop()
+
+	// Simulate a remote extracted context with an origin.
+	// +checklocksignore — initialization time, not yet shared.
+	remoteCtx := &SpanContext{
+		traceID: traceIDFrom64Bits(42),
+		spanID:  99,
+		origin:  "synthetics",
+	}
+	remoteCtx.trace = newTrace() // trace.root is nil — no local spans yet
+
+	child := trc.StartSpan("local-op", ChildOf(remoteCtx))
+	defer child.Finish()
+
+	origin, ok := child.meta.Get(keyOrigin)
+	assert.True(t, ok, "first local span from remote context should have origin marked")
+	assert.Equal(t, "synthetics", origin)
+
+	// Grandchild: parent.Context().trace.root is now non-nil, so origin must not be set.
+	grandchild := trc.StartSpan("grandchild", ChildOf(child.Context()))
+	defer grandchild.Finish()
+
+	_, hasOrigin := grandchild.meta.Get(keyOrigin)
+	assert.False(t, hasOrigin, "grandchild should not have origin — it is not the first local span")
+}

--- a/ddtrace/tracer/sqlcomment_test.go
+++ b/ddtrace/tracer/sqlcomment_test.go
@@ -19,6 +19,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type sqlCommentStringer string
+
+func (s sqlCommentStringer) String() string {
+	return string(s)
+}
+
 func TestSQLCommentCarrier(t *testing.T) {
 	testCases := []struct {
 		name               string
@@ -351,6 +357,61 @@ func FuzzSpanContextFromTraceComment(f *testing.F) {
 				wanted: %d`, p, expectedSampled)
 		}
 	})
+}
+
+// TestSQLCommentUsesUpdatedInheritedTags verifies that when env, version, and
+// peer.service are set on a span after creation, SQLCommentCarrier.Inject reads
+// the updated values from context.inherited rather than stale initial values.
+func TestSQLCommentUsesUpdatedInheritedTags(t *testing.T) {
+	trc, err := newTracer(WithService("my-svc"))
+	require.NoError(t, err)
+	defer globalconfig.SetServiceName("")
+	defer trc.Stop()
+
+	span := trc.StartSpan("op")
+	defer span.Finish()
+
+	span.SetTag(ext.Environment, "staging")
+	span.SetTag(ext.Version, "2.0")
+	span.SetTag(ext.PeerService, "peer-svc")
+
+	carrier := SQLCommentCarrier{
+		Query:         "SELECT 1",
+		Mode:          DBMPropagationModeService,
+		DBServiceName: "mydb",
+	}
+	err = carrier.Inject(span.Context())
+	require.NoError(t, err)
+
+	assert.Contains(t, carrier.Query, "dde='staging'")
+	assert.Contains(t, carrier.Query, "ddpv='2.0'")
+	assert.Contains(t, carrier.Query, "ddprs='peer-svc'")
+}
+
+func TestSQLCommentUsesConvertedInheritedTags(t *testing.T) {
+	trc, err := newTracer(WithService("my-svc"))
+	require.NoError(t, err)
+	defer globalconfig.SetServiceName("")
+	defer trc.Stop()
+
+	span := trc.StartSpan("op")
+	defer span.Finish()
+
+	span.SetTag(ext.Environment, []byte("staging"))
+	span.SetTag(ext.Version, sqlCommentStringer("2.0"))
+	span.SetTag(ext.PeerService, true)
+
+	carrier := SQLCommentCarrier{
+		Query:         "SELECT 1",
+		Mode:          DBMPropagationModeService,
+		DBServiceName: "mydb",
+	}
+	err = carrier.Inject(span.Context())
+	require.NoError(t, err)
+
+	assert.Contains(t, carrier.Query, "dde='staging'")
+	assert.Contains(t, carrier.Query, "ddpv='2.0'")
+	assert.Contains(t, carrier.Query, "ddprs='true'")
 }
 
 func BenchmarkSQLCommentInjection(b *testing.B) {

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -1950,7 +1950,7 @@ func TestEnvVars(t *testing.T) {
 					err = tracer.Inject(s.Context(), headers)
 					assert.NoError(err)
 					assert.Equal(tc.tid.value, sctx.traceID.value)
-					assert.Equal(tc.out[0], sctx.span.parentID)
+					assert.Equal(tc.out[0], s.parentID)
 					assert.Equal(tc.out[1], sctx.spanID)
 
 					checkSameElements(assert, tc.outMap[traceparentHeader], headers[traceparentHeader])


### PR DESCRIPTION
### What does this PR do?

Adds harness tests to ensure that removing `SpanContext.span` is done without side effects.

### Motivation

Prerequisite to enable span pooling in #4440.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
