### PR TITLE
refactor(ddtrace/tracer): remove SpanContext.span back-reference

### DIFF
--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016 Datadog, Inc.
 
-//msgp:ignore inheritedData
+//msgp:ignore spanSnapshot
 //go:generate go run github.com/tinylib/msgp -unexported -marshal=false -o=span_msgp.go -tests=false
 //go:generate go run ../../scripts/msgp_span_meta_omitempty.go -file span_msgp.go
 //go:generate go run ../../scripts/msgp_checklocks_ignore.go -type Span -file span_msgp.go
@@ -192,7 +192,7 @@ func (s *Span) Context() *SpanContext {
 	return s.context
 }
 
-type inheritedData struct {
+type spanSnapshot struct {
 	env           string
 	version       string
 	service       string
@@ -202,13 +202,13 @@ type inheritedData struct {
 }
 
 // +checklocksignore — Initialization time.
-func (s *Span) inheritedData() inheritedData {
+func (s *Span) spanSnapshot() spanSnapshot {
 	var (
 		env, _         = s.meta.Env()
 		version, _     = s.meta.Version()
 		peerService, _ = s.meta.Get(ext.PeerService)
 	)
-	return inheritedData{
+	return spanSnapshot{
 		env:           env,
 		version:       version,
 		service:       s.service,
@@ -432,7 +432,7 @@ func (s *Span) setTagLocked(key string, value any) {
 			s.service = so.Name
 			s.serviceSource = so.Source
 			if s.context != nil {
-				s.context.setInheritedService(so.Name, so.Source)
+				s.context.setSpanSnapshotService(so.Name, so.Source)
 			}
 			return
 		}
@@ -452,7 +452,7 @@ func (s *Span) setTagLocked(key string, value any) {
 			s.pprofCtxActive = pprof.WithLabels(s.pprofCtxActive, pprof.Labels(traceprof.TraceEndpoint, v))
 			pprof.SetGoroutineLabels(s.pprofCtxActive)
 			if s.context != nil {
-				s.context.setInheritedPPROFCtx(s.pprofCtxActive)
+				s.context.setSpanSnapshotPPROFCtx(s.pprofCtxActive)
 			}
 		}
 		s.setMetaLocked(key, v)
@@ -741,7 +741,7 @@ func (s *Span) setMetaLocked(key, v string) {
 	assert.RWMutexLocked(&s.mu)
 	s.setMetaInit(key, v)
 	if s.context != nil {
-		s.context.setInheritedMeta(key, v)
+		s.context.setSpanSnapshotMeta(key, v)
 	}
 }
 
@@ -756,7 +756,7 @@ func (s *Span) setMetaInit(key, v string) {
 		s.service = v
 		s.serviceSource = serviceSourceManual
 		if s.context != nil {
-			s.context.setInheritedService(v, serviceSourceManual)
+			s.context.setSpanSnapshotService(v, serviceSourceManual)
 		}
 	case ext.ResourceName:
 		s.resource = v
@@ -834,7 +834,7 @@ func (s *Span) setMetricLocked(key string, v float64) {
 	}
 	s.meta.Delete(key)
 	if s.context != nil {
-		s.context.setInheritedMeta(key, "")
+		s.context.setSpanSnapshotMeta(key, "")
 	}
 	switch key {
 	case ext.ManualKeep:

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -193,17 +193,27 @@ func (s *Span) Context() *SpanContext {
 }
 
 type inheritedData struct {
+	env           string
+	version       string
 	service       string
 	serviceSource string
+	peerService   string
 	pprofCtx      context.Context
 }
 
+// +checklocksignore — Initialization time.
 func (s *Span) inheritedData() inheritedData {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	var (
+		env, _         = s.meta.Env()
+		version, _     = s.meta.Version()
+		peerService, _ = s.meta.Get(ext.PeerService)
+	)
 	return inheritedData{
+		env:           env,
+		version:       version,
 		service:       s.service,
 		serviceSource: s.serviceSource,
+		peerService:   peerService,
 		pprofCtx:      s.pprofCtxActive,
 	}
 }
@@ -421,6 +431,9 @@ func (s *Span) setTagLocked(key string, value any) {
 		if so, ok := value.(sharedinternal.ServiceOverride); ok {
 			s.service = so.Name
 			s.serviceSource = so.Source
+			if s.context != nil {
+				s.context.setInheritedService(so.Name, so.Source)
+			}
 			return
 		}
 	}
@@ -438,6 +451,9 @@ func (s *Span) setTagLocked(key string, value any) {
 			// of what we change at a lower level.
 			s.pprofCtxActive = pprof.WithLabels(s.pprofCtxActive, pprof.Labels(traceprof.TraceEndpoint, v))
 			pprof.SetGoroutineLabels(s.pprofCtxActive)
+			if s.context != nil {
+				s.context.setInheritedPPROFCtx(s.pprofCtxActive)
+			}
 		}
 		s.setMetaLocked(key, v)
 		return
@@ -724,6 +740,9 @@ func (s *Span) setMeta(key, v string) {
 func (s *Span) setMetaLocked(key, v string) {
 	assert.RWMutexLocked(&s.mu)
 	s.setMetaInit(key, v)
+	if s.context != nil {
+		s.context.setInheritedMeta(key, v)
+	}
 }
 
 // setMetaInit sets a string tag without acquiring the lock and asserting the lock is held.
@@ -736,6 +755,9 @@ func (s *Span) setMetaInit(key, v string) {
 	case ext.ServiceName:
 		s.service = v
 		s.serviceSource = serviceSourceManual
+		if s.context != nil {
+			s.context.setInheritedService(v, serviceSourceManual)
+		}
 	case ext.ResourceName:
 		s.resource = v
 	case ext.SpanType:
@@ -811,6 +833,9 @@ func (s *Span) setMetricLocked(key string, v float64) {
 		s.metrics = make(map[string]float64, 1)
 	}
 	s.meta.Delete(key)
+	if s.context != nil {
+		s.context.setInheritedMeta(key, "")
+	}
 	switch key {
 	case ext.ManualKeep:
 		if v == float64(samplernames.AppSec) {
@@ -1025,7 +1050,7 @@ func (s *Span) finish(finishTime int64) {
 	// Call context.finish() which handles trace-level bookkeeping and may modify
 	// this span (to set trace-level tags).
 	// Lock ordering is span.mu -> trace.mu.
-	s.context.finish()
+	s.context.finish(s)
 
 	// compute stats after finishing the span. This ensures any normalization or tag propagation has been applied
 	if hasTracer {

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -143,8 +143,8 @@ type SpanContext struct {
 	// atomic int for quick checking presence of baggage. 0 indicates no baggage, otherwise baggage exists.
 	hasBaggage uint32 // +checkatomic
 	// +checklocks:mu
-	// inherited stores mirrored data from the span that hosts this context
-	inherited inheritedData
+	// spanSnapshot stores mirrored data from the span that hosts this context.
+	spanSnapshot spanSnapshot
 	// e.g. "synthetics"
 	// +checklocks:mu
 	origin string
@@ -294,7 +294,7 @@ func newSpanContext(span *Span, parent *SpanContext) *SpanContext {
 	}
 	// put span in context's trace
 	context.trace.push(span)
-	context.setInherited(span.inheritedData())
+	context.setSpanSnapshot(span.spanSnapshot())
 	// setting context.updated to false here is necessary to distinguish
 	// between initializing properties of the span (priority)
 	// and updating them after extracting context through propagators
@@ -302,44 +302,44 @@ func newSpanContext(span *Span, parent *SpanContext) *SpanContext {
 	return context
 }
 
-func (c *SpanContext) inheritedSnapshot() inheritedData {
+func (c *SpanContext) getSpanSnapshot() spanSnapshot {
 	if c == nil {
-		return inheritedData{}
+		return spanSnapshot{}
 	}
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.inherited
+	return c.spanSnapshot
 }
 
-func (c *SpanContext) setInherited(data inheritedData) {
+func (c *SpanContext) setSpanSnapshot(data spanSnapshot) {
 	if c == nil {
 		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.inherited = data
+	c.spanSnapshot = data
 }
 
-func (c *SpanContext) setInheritedService(service, source string) {
+func (c *SpanContext) setSpanSnapshotService(service, source string) {
 	if c == nil {
 		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.inherited.service = service
-	c.inherited.serviceSource = source
+	c.spanSnapshot.service = service
+	c.spanSnapshot.serviceSource = source
 }
 
-func (c *SpanContext) setInheritedPPROFCtx(ctx context.Context) {
+func (c *SpanContext) setSpanSnapshotPPROFCtx(ctx context.Context) {
 	if c == nil {
 		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.inherited.pprofCtx = ctx
+	c.spanSnapshot.pprofCtx = ctx
 }
 
-func (c *SpanContext) setInheritedMeta(key, value string) {
+func (c *SpanContext) setSpanSnapshotMeta(key, value string) {
 	if c == nil {
 		return
 	}
@@ -350,19 +350,19 @@ func (c *SpanContext) setInheritedMeta(key, value string) {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.setInheritedMetaLocked(key, value)
+	c.setSpanSnapshotMetaLocked(key, value)
 }
 
 // +checklocks:c.mu
-func (c *SpanContext) setInheritedMetaLocked(key, value string) {
+func (c *SpanContext) setSpanSnapshotMetaLocked(key, value string) {
 	assert.RWMutexLocked(&c.mu)
 	switch key {
 	case ext.PeerService:
-		c.inherited.peerService = value
+		c.spanSnapshot.peerService = value
 	case ext.Environment:
-		c.inherited.env = value
+		c.spanSnapshot.env = value
 	case ext.Version:
-		c.inherited.version = value
+		c.spanSnapshot.version = value
 	}
 }
 

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -116,9 +116,15 @@ type SpanContext struct {
 	updated bool // updated is tracking changes for priority / origin / x-datadog-tags
 
 	// the below group should propagate only locally
+	isRemote bool
+	// when true, indicates this context only propagates baggage items and should not be used for distributed tracing fields
+	// +checklocks:mu
+	baggageOnly bool
+	errors      atomic.Int32 // number of spans with errors in this trace
+	// atomic int for quick checking presence of baggage. 0 indicates no baggage, otherwise baggage exists.
+	hasBaggage uint32 // +checkatomic
 
-	trace  *trace       // reference to the trace that this span belongs too
-	errors atomic.Int32 // number of spans with errors in this trace
+	trace *trace // reference to the trace that this span belongs too
 
 	// The 16-character hex string of the last seen Datadog Span ID
 	// this value will be added as the _dd.parent_id tag to spans
@@ -129,7 +135,6 @@ type SpanContext struct {
 	// Missing parent span could occur when a W3C-compliant tracer
 	// propagated this context, but didn't send any spans to Datadog.
 	reparentID string
-	isRemote   bool
 
 	// the below group should propagate cross-process
 
@@ -140,8 +145,6 @@ type SpanContext struct {
 	mu locking.RWMutex
 	// +checklocks:mu
 	baggage map[string]string
-	// atomic int for quick checking presence of baggage. 0 indicates no baggage, otherwise baggage exists.
-	hasBaggage uint32 // +checkatomic
 	// +checklocks:mu
 	// spanSnapshot stores mirrored data from the span that hosts this context.
 	spanSnapshot spanSnapshot
@@ -152,9 +155,6 @@ type SpanContext struct {
 	// links to related spans in separate|external|disconnected traces
 	// +checklocks:mu
 	spanLinks []SpanLink
-	// when true, indicates this context only propagates baggage items and should not be used for distributed tracing fields
-	// +checklocks:mu
-	baggageOnly bool
 }
 
 // Private interface for span contexts that can propagate sampling decisions.

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -6,6 +6,7 @@
 package tracer
 
 import (
+	"context"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -117,7 +118,6 @@ type SpanContext struct {
 	// the below group should propagate only locally
 
 	trace  *trace       // reference to the trace that this span belongs too
-	span   *Span        // reference to the span that hosts this context
 	errors atomic.Int32 // number of spans with errors in this trace
 
 	// The 16-character hex string of the last seen Datadog Span ID
@@ -142,6 +142,9 @@ type SpanContext struct {
 	baggage map[string]string
 	// atomic int for quick checking presence of baggage. 0 indicates no baggage, otherwise baggage exists.
 	hasBaggage uint32 // +checkatomic
+	// +checklocks:mu
+	// inherited stores mirrored data from the span that hosts this context
+	inherited inheritedData
 	// e.g. "synthetics"
 	// +checklocks:mu
 	origin string
@@ -254,7 +257,6 @@ func FromGenericCtx(c ddtrace.SpanContext) *SpanContext {
 func newSpanContext(span *Span, parent *SpanContext) *SpanContext {
 	context := &SpanContext{
 		spanID: span.spanID,
-		span:   span,
 	}
 
 	context.traceID.SetLower(span.traceID)
@@ -292,11 +294,76 @@ func newSpanContext(span *Span, parent *SpanContext) *SpanContext {
 	}
 	// put span in context's trace
 	context.trace.push(span)
+	context.setInherited(span.inheritedData())
 	// setting context.updated to false here is necessary to distinguish
 	// between initializing properties of the span (priority)
 	// and updating them after extracting context through propagators
 	context.updated = false
 	return context
+}
+
+func (c *SpanContext) inheritedSnapshot() inheritedData {
+	if c == nil {
+		return inheritedData{}
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.inherited
+}
+
+func (c *SpanContext) setInherited(data inheritedData) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.inherited = data
+}
+
+func (c *SpanContext) setInheritedService(service, source string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.inherited.service = service
+	c.inherited.serviceSource = source
+}
+
+func (c *SpanContext) setInheritedPPROFCtx(ctx context.Context) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.inherited.pprofCtx = ctx
+}
+
+func (c *SpanContext) setInheritedMeta(key, value string) {
+	if c == nil {
+		return
+	}
+	switch key {
+	case ext.PeerService, ext.Environment, ext.Version:
+	default:
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.setInheritedMetaLocked(key, value)
+}
+
+// +checklocks:c.mu
+func (c *SpanContext) setInheritedMetaLocked(key, value string) {
+	assert.RWMutexLocked(&c.mu)
+	switch key {
+	case ext.PeerService:
+		c.inherited.peerService = value
+	case ext.Environment:
+		c.inherited.env = value
+	case ext.Version:
+		c.inherited.version = value
+	}
 }
 
 // SpanID implements ddtrace.SpanContext.
@@ -445,8 +512,8 @@ func (c *SpanContext) baggageItem(key string) string {
 
 // finish marks this span as finished in the trace.
 // The span must be locked by the caller.
-func (c *SpanContext) finish() {
-	c.trace.finishedOneLocked(c.span)
+func (c *SpanContext) finish(s *Span) {
+	c.trace.finishedOneLocked(s)
 }
 
 // safeDebugString returns a safe string representation of the SpanContext for debug logging.

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -1601,7 +1601,7 @@ func TestFromGenericCtxSamplingDecision(t *testing.T) {
 
 // TestChildInheritsUpdatedParentService verifies that when a parent span's service
 // is changed via SetTag after creation, a subsequently-started child inherits the
-// updated service name from context.inherited.
+// updated service name from the parent's span snapshot.
 func TestChildInheritsUpdatedParentService(t *testing.T) {
 	trc, _, _, stop, err := startTestTracer(t, WithService("global-svc"))
 	require.NoError(t, err)
@@ -1649,9 +1649,9 @@ func TestExtractedContextOriginMarkedOnFirstChildOnly(t *testing.T) {
 	assert.False(t, hasOrigin, "grandchild should not have origin — it is not the first local span")
 }
 
-// TestInheritedFieldsMirrorSetTag verifies that context.inherited is updated when
-// env, version, and peer.service tags are mutated on a live span via SetTag.
-func TestInheritedFieldsMirrorSetTag(t *testing.T) {
+// TestSpanSnapshotFieldsMirrorSetTag verifies that context.spanSnapshot is updated
+// when env, version, and peer.service tags are mutated on a live span via SetTag.
+func TestSpanSnapshotFieldsMirrorSetTag(t *testing.T) {
 	trc, _, _, stop, err := startTestTracer(t)
 	require.NoError(t, err)
 	defer stop()
@@ -1663,16 +1663,16 @@ func TestInheritedFieldsMirrorSetTag(t *testing.T) {
 	span.SetTag(ext.Version, "2.0")
 	span.SetTag(ext.PeerService, "my-peer")
 
-	inherited := span.context.inheritedSnapshot()
-	assert.Equal(t, "staging", inherited.env)
-	assert.Equal(t, "2.0", inherited.version)
-	assert.Equal(t, "my-peer", inherited.peerService)
+	spanSnapshot := span.context.getSpanSnapshot()
+	assert.Equal(t, "staging", spanSnapshot.env)
+	assert.Equal(t, "2.0", spanSnapshot.version)
+	assert.Equal(t, "my-peer", spanSnapshot.peerService)
 }
 
-// TestSiblingSpansGetFreshInheritedState verifies that each sibling span captures
-// the parent's inherited state at its own creation time, and that siblings do not
+// TestSiblingSpansGetFreshSpanSnapshot verifies that each sibling span captures
+// the parent's span snapshot at its own creation time, and that siblings do not
 // share or leak context state between them.
-func TestSiblingSpansGetFreshInheritedState(t *testing.T) {
+func TestSiblingSpansGetFreshSpanSnapshot(t *testing.T) {
 	trc, _, _, stop, err := startTestTracer(t, WithService("global-svc"))
 	require.NoError(t, err)
 	defer stop()
@@ -1690,11 +1690,11 @@ func TestSiblingSpansGetFreshInheritedState(t *testing.T) {
 
 	assert.Equal(t, "parent-svc", child1.service, "child1 was created before service update")
 	assert.Equal(t, "new-parent-svc", child2.service, "child2 was created after service update")
-	assert.Equal(t, "parent-svc", child1.context.inheritedSnapshot().service)
-	assert.Equal(t, "new-parent-svc", child2.context.inheritedSnapshot().service)
+	assert.Equal(t, "parent-svc", child1.context.getSpanSnapshot().service)
+	assert.Equal(t, "new-parent-svc", child2.context.getSpanSnapshot().service)
 }
 
-func TestInheritedFieldsConcurrentAccess(t *testing.T) {
+func TestSpanSnapshotFieldsConcurrentAccess(t *testing.T) {
 	trc, _, _, stop, err := startTestTracer(t)
 	require.NoError(t, err)
 	defer stop()

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -1648,3 +1648,90 @@ func TestExtractedContextOriginMarkedOnFirstChildOnly(t *testing.T) {
 	_, hasOrigin := grandchild.meta.Get(keyOrigin)
 	assert.False(t, hasOrigin, "grandchild should not have origin — it is not the first local span")
 }
+
+// TestInheritedFieldsMirrorSetTag verifies that context.inherited is updated when
+// env, version, and peer.service tags are mutated on a live span via SetTag.
+func TestInheritedFieldsMirrorSetTag(t *testing.T) {
+	trc, _, _, stop, err := startTestTracer(t)
+	require.NoError(t, err)
+	defer stop()
+
+	span := trc.StartSpan("op")
+	defer span.Finish()
+
+	span.SetTag(ext.Environment, "staging")
+	span.SetTag(ext.Version, "2.0")
+	span.SetTag(ext.PeerService, "my-peer")
+
+	inherited := span.context.inheritedSnapshot()
+	assert.Equal(t, "staging", inherited.env)
+	assert.Equal(t, "2.0", inherited.version)
+	assert.Equal(t, "my-peer", inherited.peerService)
+}
+
+// TestSiblingSpansGetFreshInheritedState verifies that each sibling span captures
+// the parent's inherited state at its own creation time, and that siblings do not
+// share or leak context state between them.
+func TestSiblingSpansGetFreshInheritedState(t *testing.T) {
+	trc, _, _, stop, err := startTestTracer(t, WithService("global-svc"))
+	require.NoError(t, err)
+	defer stop()
+
+	parent := trc.StartSpan("parent", ServiceName("parent-svc"))
+	defer parent.Finish()
+
+	child1 := trc.StartSpan("child1", ChildOf(parent.Context()))
+	defer child1.Finish()
+
+	parent.SetTag(ext.ServiceName, "new-parent-svc")
+
+	child2 := trc.StartSpan("child2", ChildOf(parent.Context()))
+	defer child2.Finish()
+
+	assert.Equal(t, "parent-svc", child1.service, "child1 was created before service update")
+	assert.Equal(t, "new-parent-svc", child2.service, "child2 was created after service update")
+	assert.Equal(t, "parent-svc", child1.context.inheritedSnapshot().service)
+	assert.Equal(t, "new-parent-svc", child2.context.inheritedSnapshot().service)
+}
+
+func TestInheritedFieldsConcurrentAccess(t *testing.T) {
+	trc, _, _, stop, err := startTestTracer(t)
+	require.NoError(t, err)
+	defer stop()
+
+	parent := trc.StartSpan("parent")
+	defer parent.Finish()
+	ctx := parent.Context()
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 100)
+	for i := range 100 {
+		wg.Add(3)
+		go func(i int) {
+			defer wg.Done()
+			parent.SetTag(ext.Environment, fmt.Sprintf("env-%d", i))
+			parent.SetTag(ext.Version, fmt.Sprintf("version-%d", i))
+			parent.SetTag(ext.PeerService, fmt.Sprintf("peer-%d", i))
+			parent.SetTag(ext.ServiceName, fmt.Sprintf("service-%d", i))
+		}(i)
+		go func() {
+			defer wg.Done()
+			child := trc.StartSpan("child", ChildOf(ctx))
+			child.Finish()
+		}()
+		go func() {
+			defer wg.Done()
+			carrier := SQLCommentCarrier{
+				Query:         "SELECT 1",
+				Mode:          DBMPropagationModeService,
+				DBServiceName: "db",
+			}
+			errCh <- carrier.Inject(ctx)
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		assert.NoError(t, err)
+	}
+}

--- a/ddtrace/tracer/sqlcomment.go
+++ b/ddtrace/tracer/sqlcomment.go
@@ -85,15 +85,15 @@ func (c *SQLCommentCarrier) Inject(ctx *SpanContext) error {
 		fallthrough
 	case DBMPropagationModeService:
 		if ctx != nil {
-			inherited := ctx.inheritedSnapshot()
-			if inherited.env != "" {
-				tags[sqlCommentEnv] = inherited.env
+			spanSnapshot := ctx.getSpanSnapshot()
+			if spanSnapshot.env != "" {
+				tags[sqlCommentEnv] = spanSnapshot.env
 			}
-			if inherited.version != "" {
-				tags[sqlCommentParentVersion] = inherited.version
+			if spanSnapshot.version != "" {
+				tags[sqlCommentParentVersion] = spanSnapshot.version
 			}
-			if inherited.peerService != "" {
-				tags[sqlCommentPeerService] = inherited.peerService
+			if spanSnapshot.peerService != "" {
+				tags[sqlCommentPeerService] = spanSnapshot.peerService
 			}
 		}
 		if c.PeerDBName != "" {

--- a/ddtrace/tracer/sqlcomment.go
+++ b/ddtrace/tracer/sqlcomment.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/internal/globalconfig"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/samplernames"
@@ -85,15 +84,16 @@ func (c *SQLCommentCarrier) Inject(ctx *SpanContext) error {
 		tags[sqlCommentTraceParent] = encodeTraceParent(traceID, c.SpanID, sampled)
 		fallthrough
 	case DBMPropagationModeService:
-		if ctx != nil && ctx.span != nil {
-			if e, ok := getMeta(ctx.span, ext.Environment); ok && e != "" {
-				tags[sqlCommentEnv] = e
+		if ctx != nil {
+			inherited := ctx.inheritedSnapshot()
+			if inherited.env != "" {
+				tags[sqlCommentEnv] = inherited.env
 			}
-			if v, ok := getMeta(ctx.span, ext.Version); ok && v != "" {
-				tags[sqlCommentParentVersion] = v
+			if inherited.version != "" {
+				tags[sqlCommentParentVersion] = inherited.version
 			}
-			if v, ok := getMeta(ctx.span, ext.PeerService); ok && v != "" {
-				tags[sqlCommentPeerService] = v
+			if inherited.peerService != "" {
+				tags[sqlCommentPeerService] = inherited.peerService
 			}
 		}
 		if c.PeerDBName != "" {

--- a/ddtrace/tracer/sqlcomment_test.go
+++ b/ddtrace/tracer/sqlcomment_test.go
@@ -359,10 +359,10 @@ func FuzzSpanContextFromTraceComment(f *testing.F) {
 	})
 }
 
-// TestSQLCommentUsesUpdatedInheritedTags verifies that when env, version, and
+// TestSQLCommentUsesUpdatedSpanSnapshotTags verifies that when env, version, and
 // peer.service are set on a span after creation, SQLCommentCarrier.Inject reads
-// the updated values from context.inherited rather than stale initial values.
-func TestSQLCommentUsesUpdatedInheritedTags(t *testing.T) {
+// the updated values from context.spanSnapshot rather than stale initial values.
+func TestSQLCommentUsesUpdatedSpanSnapshotTags(t *testing.T) {
 	trc, err := newTracer(WithService("my-svc"))
 	require.NoError(t, err)
 	defer globalconfig.SetServiceName("")

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -839,15 +839,15 @@ func spanStart(operationName string, sharedAttrs *traceinternal.SpanAttributes, 
 		context = opts.Parent
 		// Batch read service and pprofContext from parent span under single lock
 		// to minimize lock contention on the parent span during child creation.
-		inheritedData := context.inheritedSnapshot()
-		parentService = inheritedData.service
-		parentServiceSource = inheritedData.serviceSource
+		spanSnapshot := context.getSpanSnapshot()
+		parentService = spanSnapshot.service
+		parentServiceSource = spanSnapshot.serviceSource
 
 		// Inherit the context.Context from parent span if it was propagated
 		// using ChildOf() rather than StartSpanFromContext(), see
 		// applyPPROFLabels() below.
 		if pprofContext == nil {
-			pprofContext = inheritedData.pprofCtx
+			pprofContext = spanSnapshot.pprofCtx
 		}
 	}
 	if pprofContext == nil {
@@ -905,9 +905,9 @@ func spanStart(operationName string, sharedAttrs *traceinternal.SpanAttributes, 
 	span.setMetaInit("language", "go")
 	// add tags from options
 	span.setTags(opts.Tags)
-	// Re-sync inherited after constructor tags: setTags may have mutated service,
-	// env, version, or peerService via SetTag before the span is shared.
-	span.context.setInherited(span.inheritedData())
+	// Re-sync the span snapshot after constructor tags: setTags may have mutated
+	// service, env, version, or peerService via SetTag before the span is shared.
+	span.context.setSpanSnapshot(span.spanSnapshot())
 	if isRootSpan {
 		traceprof.SetProfilerRootTags(span)
 	}
@@ -997,10 +997,11 @@ func (t *tracer) StartSpan(operationName string, options ...StartSpanOption) *Sp
 	}
 	span.setMetricInit(ext.Pid, float64(t.pid))
 	t.spansStarted.Inc(span.integration)
-	// Re-sync inherited after all tracer-level config (env, version, service
-	// mapping, pprof labels) has been applied. spanStart sets inherited earlier,
-	// but tracer.StartSpan may overwrite span fields after that re-sync.
-	span.context.setInherited(span.inheritedData())
+	// Re-sync the span snapshot after all tracer-level config (env, version,
+	// service mapping, pprof labels) has been applied. spanStart sets the span
+	// snapshot earlier, but tracer.StartSpan may overwrite span fields after that
+	// re-sync.
+	span.context.setSpanSnapshot(span.spanSnapshot())
 
 	return span
 }

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -837,19 +837,17 @@ func spanStart(operationName string, sharedAttrs *traceinternal.SpanAttributes, 
 
 	if opts.Parent != nil {
 		context = opts.Parent
-		if context.span != nil {
-			// Batch read service and pprofContext from parent span under single lock
-			// to minimize lock contention on the parent span during child creation.
-			inheritedData := context.span.inheritedData()
-			parentService = inheritedData.service
-			parentServiceSource = inheritedData.serviceSource
+		// Batch read service and pprofContext from parent span under single lock
+		// to minimize lock contention on the parent span during child creation.
+		inheritedData := context.inheritedSnapshot()
+		parentService = inheritedData.service
+		parentServiceSource = inheritedData.serviceSource
 
-			// Inherit the context.Context from parent span if it was propagated
-			// using ChildOf() rather than StartSpanFromContext(), see
-			// applyPPROFLabels() below.
-			if pprofContext == nil {
-				pprofContext = inheritedData.pprofCtx
-			}
+		// Inherit the context.Context from parent span if it was propagated
+		// using ChildOf() rather than StartSpanFromContext(), see
+		// applyPPROFLabels() below.
+		if pprofContext == nil {
+			pprofContext = inheritedData.pprofCtx
 		}
 	}
 	if pprofContext == nil {
@@ -888,7 +886,7 @@ func spanStart(operationName string, sharedAttrs *traceinternal.SpanAttributes, 
 		if p, ok := context.SamplingPriority(); ok {
 			span.setMetricInit(keySamplingPriority, float64(p))
 		}
-		if context.span == nil && context.origin != "" { // +checklocksignore - Read-only after init.
+		if (context.trace == nil || context.trace.root == nil) && context.origin != "" { // +checklocksignore - Read-only after init.
 			// mark origin
 			span.setMetaInit(keyOrigin, context.origin) // +checklocksignore - Read-only after init.
 		}
@@ -897,6 +895,9 @@ func spanStart(operationName string, sharedAttrs *traceinternal.SpanAttributes, 
 		}
 
 	}
+	// Must evaluate isRootSpan before newSpanContext: newSpanContext sets
+	// context.trace.root = span, making the nil check unreliable afterward.
+	isRootSpan := context == nil || context.trace == nil || context.trace.root == nil
 	span.context = newSpanContext(span, context)
 	if pprofContext != nil {
 		setLLMObsPropagatingTags(pprofContext, span.context)
@@ -904,11 +905,13 @@ func spanStart(operationName string, sharedAttrs *traceinternal.SpanAttributes, 
 	span.setMetaInit("language", "go")
 	// add tags from options
 	span.setTags(opts.Tags)
-	isRootSpan := context == nil || context.span == nil
+	// Re-sync inherited after constructor tags: setTags may have mutated service,
+	// env, version, or peerService via SetTag before the span is shared.
+	span.context.setInherited(span.inheritedData())
 	if isRootSpan {
 		traceprof.SetProfilerRootTags(span)
 	}
-	if isRootSpan || context.span.service != span.service {
+	if isRootSpan || parentService != span.service {
 		// The span is the local root span.
 		span.setMetricInit(keyTopLevel, 1)
 		// all top level spans are measured. So the measured tag is redundant.
@@ -994,6 +997,10 @@ func (t *tracer) StartSpan(operationName string, options ...StartSpanOption) *Sp
 	}
 	span.setMetricInit(ext.Pid, float64(t.pid))
 	t.spansStarted.Inc(span.integration)
+	// Re-sync inherited after all tracer-level config (env, version, service
+	// mapping, pprof labels) has been applied. spanStart sets inherited earlier,
+	// but tracer.StartSpan may overwrite span fields after that re-sync.
+	span.context.setInherited(span.inheritedData())
 
 	return span
 }

--- a/instrumentation/testutils/testutils.go
+++ b/instrumentation/testutils/testutils.go
@@ -123,7 +123,11 @@ func SetPropagatingTag(t testing.TB, ctx *tracer.SpanContext, k, v string) {
 	// It's easier than using offsets when the desired data isn't far away from
 	// the struct's beginning.
 	type cookieCutter struct {
-		_     bool // spanContext.updated
+		_     bool   // spanContext.updated
+		_     bool   // spanContext.isRemote
+		_     bool   // spanContext.baggageOnly
+		_     uint32 // spanContext.errors
+		_     uint32 // spanContext.hasBaggage
 		trace *struct {
 			_               sync.RWMutex      // trace.mu
 			_               []any             // trace.spans


### PR DESCRIPTION
Removes the `span *Span` back-reference from `SpanContext`. Instead of holding a pointer to the owning span, `SpanContext` now carries an `spanSnapshot` snapshot: a copy of the span fields that downstream consumers (child span creation, SQL comment injection) need to read.

Key changes:
- Drop `SpanContext.span` field; add `SpanContext.spanSnapshot` (protected by `mu`)
- Expand `spanSnapshot` with `env`, `version`, and `peerService` fields (previously only accessible via the back-reference)
- Add `spanSnapshot()` / `setSpanSnapshot*()` methods on `SpanContext` to read and update the snapshot safely
- Propagate mutations: `SetTag`, `setMetaLocked`, and `setMetaInit` on a `Span` call the matching `context.setSpanSnapshot*` method so the snapshot stays current
- `SpanContext.finish()` now accepts a `*Span` argument instead of reading `c.span`
- `sqlcomment.go`: replace `ctx.span` + `getMeta()` calls with `ctx.spanSnapshot()`
- `tracer.go`: replace `context.span.inheritedData()` with `context.spanSnapshot()`; re-evaluate `isRootSpan` via `trace.root` nil-check instead of `context.span == nil`

Memory increase in benchmarks is expected. Upcoming PR will introduce changes to revert them.

### Motivation

`SpanContext.span` created a circular reference (`Span → SpanContext → Span`) and violated the intended ownership model: the span owns its context, not the other way around. The back-reference was used in a handful of read-only ways (reading `service`, `env`, `version`, `peerService`, `pprofCtx` for child creation and SQL comment injection). Replacing it with a mirrored snapshot eliminates the cycle, makes the data-flow direction explicit, and removes an implicit locking dependency across the cycle boundary.

Builds on top of #4815 (harness tests for this refactor, branch `dario.castane/langplat-59/span-backreference-harness`).

Prerequisite to enable span pooling in https://github.com/DataDog/dd-trace-go/pull/4440.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
