### PR TITLE
refactor(ddtrace/tracer): reorder small scalar fields on SpanContext

### DIFF
--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -116,9 +116,15 @@ type SpanContext struct {
 	updated bool // updated is tracking changes for priority / origin / x-datadog-tags
 
 	// the below group should propagate only locally
+	isRemote bool
+	// when true, indicates this context only propagates baggage items and should not be used for distributed tracing fields
+	// +checklocks:mu
+	baggageOnly bool
+	errors      atomic.Int32 // number of spans with errors in this trace
+	// atomic int for quick checking presence of baggage. 0 indicates no baggage, otherwise baggage exists.
+	hasBaggage uint32 // +checkatomic
 
-	trace  *trace       // reference to the trace that this span belongs too
-	errors atomic.Int32 // number of spans with errors in this trace
+	trace *trace // reference to the trace that this span belongs too
 
 	// The 16-character hex string of the last seen Datadog Span ID
 	// this value will be added as the _dd.parent_id tag to spans
@@ -129,7 +135,6 @@ type SpanContext struct {
 	// Missing parent span could occur when a W3C-compliant tracer
 	// propagated this context, but didn't send any spans to Datadog.
 	reparentID string
-	isRemote   bool
 
 	// the below group should propagate cross-process
 
@@ -140,8 +145,6 @@ type SpanContext struct {
 	mu locking.RWMutex
 	// +checklocks:mu
 	baggage map[string]string
-	// atomic int for quick checking presence of baggage. 0 indicates no baggage, otherwise baggage exists.
-	hasBaggage uint32 // +checkatomic
 	// +checklocks:mu
 	// spanSnapshot stores mirrored data from the span that hosts this context.
 	spanSnapshot spanSnapshot
@@ -152,9 +155,6 @@ type SpanContext struct {
 	// links to related spans in separate|external|disconnected traces
 	// +checklocks:mu
 	spanLinks []SpanLink
-	// when true, indicates this context only propagates baggage items and should not be used for distributed tracing fields
-	// +checklocks:mu
-	baggageOnly bool
 }
 
 // Private interface for span contexts that can propagate sampling decisions.

--- a/instrumentation/testutils/testutils.go
+++ b/instrumentation/testutils/testutils.go
@@ -123,7 +123,11 @@ func SetPropagatingTag(t testing.TB, ctx *tracer.SpanContext, k, v string) {
 	// It's easier than using offsets when the desired data isn't far away from
 	// the struct's beginning.
 	type cookieCutter struct {
-		_     bool // spanContext.updated
+		_     bool   // spanContext.updated
+		_     bool   // spanContext.isRemote
+		_     bool   // spanContext.baggageOnly
+		_     uint32 // spanContext.errors
+		_     uint32 // spanContext.hasBaggage
 		trace *struct {
 			_               sync.RWMutex      // trace.mu
 			_               []any             // trace.spans


### PR DESCRIPTION
### What does this PR do?

Packs `SpanContext` to reduce its memory size after absorbing `span` inherited fields in `SpanContext`.

Out of scope: converting these boolean fields to a bitmap. It'd be more optimized memory-wise, but it's harder to maintain.

### Motivation

Compensate the memory consumption increase on #4816. Prerequisite for #4440.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
