### PR TITLE
feat(llmobs): add tool_version to ToolDefinition and thread it to child tool spans

### DIFF
--- a/internal/llmobs/llmobs.go
+++ b/internal/llmobs/llmobs.go
@@ -119,7 +119,8 @@ type llmobsContext struct {
 	outputText      string
 
 	// tool specific
-	intent string
+	intent      string
+	toolVersion string
 
 	// experiment specific
 	experimentInput          any
@@ -559,6 +560,10 @@ func (l *LLMObs) llmobsSpanEvent(span *Span) *transport.LLMObsSpanEvent {
 		}
 	}
 
+	if toolVersion := span.llmCtx.toolVersion; toolVersion != "" {
+		meta["tool.version"] = toolVersion
+	}
+
 	spanStatus := "ok"
 	var errMsg *transport.ErrorMessage
 	if span.error != nil {
@@ -801,6 +806,12 @@ func (l *LLMObs) StartSpan(ctx context.Context, kind SpanKind, name string, cfg 
 	span.llmCtx = llmobsContext{
 		modelName:     cfg.ModelName,
 		modelProvider: cfg.ModelProvider,
+	}
+
+	if kind == SpanKindTool {
+		if v := span.resolvedToolVersion(); v != "" {
+			span.llmCtx.toolVersion = v
+		}
 	}
 
 	if span.sessionID == "" {

--- a/internal/llmobs/llmobs_test.go
+++ b/internal/llmobs/llmobs_test.go
@@ -352,6 +352,117 @@ func TestStartSpan(t *testing.T) {
 
 }
 
+func TestToolVersionPropagation(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("threaded-to-child-tool-span", func(t *testing.T) {
+		tt, ll := testTracer(t)
+
+		llmSpan, llmCtx := ll.StartSpan(ctx, llmobs.SpanKindLLM, "llm-op", llmobs.StartSpanConfig{})
+		llmSpan.Annotate(llmobs.SpanAnnotations{
+			ToolDefinitions: []llmobs.ToolDefinition{
+				{Name: "search", ToolVersion: "2.0.0"},
+			},
+		})
+		toolSpan, _ := ll.StartSpan(llmCtx, llmobs.SpanKindTool, "search", llmobs.StartSpanConfig{})
+		toolSpan.Finish(llmobs.FinishSpanConfig{})
+		llmSpan.Finish(llmobs.FinishSpanConfig{})
+
+		spans := tt.WaitForLLMObsSpans(t, 2)
+		require.Len(t, spans, 2)
+		var toolMeta map[string]any
+		for _, s := range spans {
+			if s.Meta["span.kind"] == "tool" {
+				toolMeta = s.Meta
+			}
+		}
+		require.NotNil(t, toolMeta)
+		assert.Equal(t, "2.0.0", toolMeta["tool.version"])
+	})
+
+	t.Run("no-version-when-tool-name-unmatched", func(t *testing.T) {
+		tt, ll := testTracer(t)
+
+		llmSpan, llmCtx := ll.StartSpan(ctx, llmobs.SpanKindLLM, "llm-op", llmobs.StartSpanConfig{})
+		llmSpan.Annotate(llmobs.SpanAnnotations{
+			ToolDefinitions: []llmobs.ToolDefinition{
+				{Name: "other-tool", ToolVersion: "1.0.0"},
+			},
+		})
+		toolSpan, _ := ll.StartSpan(llmCtx, llmobs.SpanKindTool, "search", llmobs.StartSpanConfig{})
+		toolSpan.Finish(llmobs.FinishSpanConfig{})
+		llmSpan.Finish(llmobs.FinishSpanConfig{})
+
+		spans := tt.WaitForLLMObsSpans(t, 2)
+		require.Len(t, spans, 2)
+		for _, s := range spans {
+			if s.Meta["span.kind"] == "tool" {
+				assert.NotContains(t, s.Meta, "tool.version")
+			}
+		}
+	})
+
+	t.Run("no-version-when-llm-parent-has-empty-tool-version", func(t *testing.T) {
+		tt, ll := testTracer(t)
+
+		llmSpan, llmCtx := ll.StartSpan(ctx, llmobs.SpanKindLLM, "llm-op", llmobs.StartSpanConfig{})
+		llmSpan.Annotate(llmobs.SpanAnnotations{
+			ToolDefinitions: []llmobs.ToolDefinition{
+				{Name: "search"},
+			},
+		})
+		toolSpan, _ := ll.StartSpan(llmCtx, llmobs.SpanKindTool, "search", llmobs.StartSpanConfig{})
+		toolSpan.Finish(llmobs.FinishSpanConfig{})
+		llmSpan.Finish(llmobs.FinishSpanConfig{})
+
+		spans := tt.WaitForLLMObsSpans(t, 2)
+		require.Len(t, spans, 2)
+		for _, s := range spans {
+			if s.Meta["span.kind"] == "tool" {
+				assert.NotContains(t, s.Meta, "tool.version")
+			}
+		}
+	})
+
+	t.Run("no-version-when-no-llm-parent", func(t *testing.T) {
+		tt, ll := testTracer(t)
+
+		toolSpan, _ := ll.StartSpan(ctx, llmobs.SpanKindTool, "search", llmobs.StartSpanConfig{})
+		toolSpan.Finish(llmobs.FinishSpanConfig{})
+
+		spans := tt.WaitForLLMObsSpans(t, 1)
+		require.Len(t, spans, 1)
+		assert.NotContains(t, spans[0].Meta, "tool.version")
+	})
+
+	t.Run("skips-non-llm-parent-to-find-llm-ancestor", func(t *testing.T) {
+		tt, ll := testTracer(t)
+
+		llmSpan, llmCtx := ll.StartSpan(ctx, llmobs.SpanKindLLM, "llm-op", llmobs.StartSpanConfig{})
+		llmSpan.Annotate(llmobs.SpanAnnotations{
+			ToolDefinitions: []llmobs.ToolDefinition{
+				{Name: "search", ToolVersion: "3.0.0"},
+			},
+		})
+		agentSpan, agentCtx := ll.StartSpan(llmCtx, llmobs.SpanKindAgent, "agent-op", llmobs.StartSpanConfig{})
+		toolSpan, _ := ll.StartSpan(agentCtx, llmobs.SpanKindTool, "search", llmobs.StartSpanConfig{})
+		toolSpan.Finish(llmobs.FinishSpanConfig{})
+		agentSpan.Finish(llmobs.FinishSpanConfig{})
+		llmSpan.Finish(llmobs.FinishSpanConfig{})
+
+		spans := tt.WaitForLLMObsSpans(t, 3)
+		require.Len(t, spans, 3)
+		var toolMeta map[string]any
+		for _, s := range spans {
+			if s.Meta["span.kind"] == "tool" {
+				toolMeta = s.Meta
+			}
+		}
+		require.NotNil(t, toolMeta)
+		assert.Equal(t, "3.0.0", toolMeta["tool.version"])
+	})
+}
+
 func TestSpanAnnotate(t *testing.T) {
 	testCases := []struct {
 		name          string

--- a/internal/llmobs/span.go
+++ b/internal/llmobs/span.go
@@ -558,6 +558,23 @@ func (s *Span) propagatedMLApp() string {
 	return ""
 }
 
+// resolvedToolVersion walks the parent chain to find the nearest LLM ancestor and returns the
+// ToolVersion for the tool matching this span's name in its tool_definitions, if any.
+func (s *Span) resolvedToolVersion() string {
+	for cur := s.parent; cur != nil; cur = cur.parent {
+		if cur.spanKind != SpanKindLLM {
+			continue
+		}
+		for _, td := range cur.llmCtx.toolDefinitions {
+			if td.Name == s.name {
+				return td.ToolVersion
+			}
+		}
+		return ""
+	}
+	return ""
+}
+
 // updateMapKeys adds key/values from updates into src, overriding existing keys.
 func updateMapKeys[K comparable, V any](src map[K]V, updates map[K]V) map[K]V {
 	if len(updates) == 0 {

--- a/internal/llmobs/span.go
+++ b/internal/llmobs/span.go
@@ -118,7 +118,7 @@ type ToolDefinition struct {
 	// Description is the description of what the tool does.
 	Description string `json:"description,omitempty"`
 	// ToolVersion is the version of the tool.
-	ToolVersion string `json:"tool_version,omitempty"`
+	ToolVersion string `json:"version,omitempty"`
 	// Schema is the JSON schema defining the tool's parameters.
 	Schema json.RawMessage `json:"schema,omitempty"`
 }

--- a/internal/llmobs/span.go
+++ b/internal/llmobs/span.go
@@ -117,6 +117,8 @@ type ToolDefinition struct {
 	Name string `json:"name"`
 	// Description is the description of what the tool does.
 	Description string `json:"description,omitempty"`
+	// ToolVersion is the version of the tool.
+	ToolVersion string `json:"tool_version,omitempty"`
 	// Schema is the JSON schema defining the tool's parameters.
 	Schema json.RawMessage `json:"schema,omitempty"`
 }

--- a/llmobs/llmobs_test.go
+++ b/llmobs/llmobs_test.go
@@ -615,6 +615,31 @@ func TestSpanAnnotations(t *testing.T) {
 		require.Len(t, spans, 1)
 		assert.NotNil(t, spans[0].Meta["tool_definitions"])
 	})
+	t.Run("tool-version-propagated-to-child-tool-span", func(t *testing.T) {
+		tt := testTracer(t)
+		defer tt.Stop()
+
+		llmSpan, llmCtx := llmobs.StartLLMSpan(ctx, "test-llm")
+		llmSpan.AnnotateLLMIO(nil, nil,
+			llmobs.WithAnnotatedToolDefinitions([]llmobs.ToolDefinition{
+				{Name: "get_weather", Description: "Get the current weather", ToolVersion: "1.0.0"},
+			}),
+		)
+		toolSpan, _ := llmobs.StartToolSpan(llmCtx, "get_weather")
+		toolSpan.Finish()
+		llmSpan.Finish()
+
+		spans := tt.WaitForLLMObsSpans(t, 2)
+		require.Len(t, spans, 2)
+		var toolMeta map[string]any
+		for _, s := range spans {
+			if s.Meta["span.kind"] == "tool" {
+				toolMeta = s.Meta
+			}
+		}
+		require.NotNil(t, toolMeta)
+		assert.Equal(t, "1.0.0", toolMeta["tool.version"])
+	})
 }
 
 func TestEvaluationMetrics(t *testing.T) {

--- a/llmobs/llmobs_test.go
+++ b/llmobs/llmobs_test.go
@@ -606,7 +606,7 @@ func TestSpanAnnotations(t *testing.T) {
 		span, _ := llmobs.StartLLMSpan(ctx, "test-llm-tool-definitions")
 		span.AnnotateLLMIO(nil, nil,
 			llmobs.WithAnnotatedToolDefinitions([]llmobs.ToolDefinition{
-				{Name: "get_weather", Description: "Get the current weather for a location"},
+				{Name: "get_weather", Description: "Get the current weather for a location", ToolVersion: "1.0.0"},
 			}),
 		)
 		span.Finish()


### PR DESCRIPTION
## Summary

- Adds a `ToolVersion` field to the `ToolDefinition` struct in `internal/llmobs/span.go`, serialized as `tool_version` in `meta.tool_definitions[*].version`
- At `StartToolSpan` time, walks the parent chain to find the nearest LLM ancestor, looks up the tool name in its `tool_definitions`, and stamps the resolved version as `meta.tool.version` on the tool span — threading the version through to child tool spans without requiring callers to set it explicitly
- Brings dd-trace-go to parity with [dd-trace-py #17933](https://github.com/DataDog/dd-trace-py/pull/17933)
- Jira: https://datadoghq.atlassian.net/browse/MLOB-7432

## Test plan

- [x] Updated existing `TestSpanAnnotations/with-annotated-tool-definitions` in `llmobs/llmobs_test.go` to exercise `ToolVersion`
- [x] Added `TestSpanAnnotations/tool-version-propagated-to-child-tool-span` in `llmobs/llmobs_test.go` to verify end-to-end threading via the public API
- [x] Added `TestToolVersionPropagation` in `internal/llmobs/llmobs_test.go` covering all branches: happy path, name mismatch, empty version, no LLM parent, non-LLM intermediate ancestor

🤖 Generated with [Claude Code](https://claude.com/claude-code)