### PR TITLE
refactor(config): migrate ciVisibilityNoopTracer

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -375,8 +375,8 @@ func newConfig(opts ...StartOption) (*config, error) {
 	if c.internalConfig.CIVisibilityEnabled() {
 		c.httpClientTimeout = time.Second * 45                                 // Increase timeout up to 45 seconds (same as other tracers in CIVis mode)
 		c.internalConfig.SetLogStartup(false, internalconfig.OriginCalculated) // If we are in CI Visibility mode we don't want to log the startup to stdout to avoid polluting the output
-		ciTransport := newCiVisibilityTransport(c) // Create a default CI Visibility Transport
-		c.ddTransport = ciTransport                // Replace the default transport with the CI Visibility transport
+		ciTransport := newCiVisibilityTransport(c)                             // Create a default CI Visibility Transport
+		c.ddTransport = ciTransport                                            // Replace the default transport with the CI Visibility transport
 	}
 
 	// if using stdout or traces are disabled or we are in ci visibility agentless mode, agent is disabled

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -34,7 +34,6 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/internal"
 	appsecconfig "github.com/DataDog/dd-trace-go/v2/internal/appsec/config"
-	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/env"
 	"github.com/DataDog/dd-trace-go/v2/internal/globalconfig"
@@ -223,9 +222,6 @@ type config struct {
 	// headerAsTags holds the header as tags configuration.
 	headerAsTags dynamicConfig[[]string]
 
-	// ciVisibilityNoopTracer controls if CI Visibility must set a wrapper to behave like a noop tracer. default false
-	ciVisibilityNoopTracer bool
-
 	// tracingAsTransport specifies whether the tracer is running in transport-only mode, where traces are only sent when other products request it.
 	tracingAsTransport bool
 
@@ -379,9 +375,8 @@ func newConfig(opts ...StartOption) (*config, error) {
 	if c.internalConfig.CIVisibilityEnabled() {
 		c.httpClientTimeout = time.Second * 45                                 // Increase timeout up to 45 seconds (same as other tracers in CIVis mode)
 		c.internalConfig.SetLogStartup(false, internalconfig.OriginCalculated) // If we are in CI Visibility mode we don't want to log the startup to stdout to avoid polluting the output
-		ciTransport := newCiVisibilityTransport(c)                             // Create a default CI Visibility Transport
-		c.ddTransport = ciTransport                                            // Replace the default transport with the CI Visibility transport
-		c.ciVisibilityNoopTracer = internal.BoolEnv(constants.CIVisibilityUseNoopTracer, false)
+		ciTransport := newCiVisibilityTransport(c) // Create a default CI Visibility Transport
+		c.ddTransport = ciTransport                // Replace the default transport with the CI Visibility transport
 	}
 
 	// if using stdout or traces are disabled or we are in ci visibility agentless mode, agent is disabled

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -253,7 +253,7 @@ func Start(opts ...StartOption) error {
 	}
 	ciVisibilityEnabled := t.config.internalConfig.CIVisibilityEnabled()
 	globalTracer := Tracer(t)
-	if ciVisibilityEnabled && t.config.ciVisibilityNoopTracer {
+	if ciVisibilityEnabled && t.config.internalConfig.CIVisibilityNoopTracer() {
 		globalTracer = wrapWithCiVisibilityNoopTracer(t)
 	}
 	setGlobalTracerPreservingCIVisibilityMockTracer(globalTracer, ciVisibilityEnabled)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,8 +116,9 @@ type Config struct {
 	// globalSampleRate holds the sample rate for the tracer.
 	globalSampleRate *DynamicConfig[float64]
 	// ciVisibilityEnabled controls if the tracer is loaded with CI Visibility mode. default false
-	ciVisibilityEnabled   bool
-	ciVisibilityAgentless bool
+	ciVisibilityEnabled    bool
+	ciVisibilityAgentless  bool
+	ciVisibilityNoopTracer bool
 	// logDirectory is directory for tracer logs
 	logDirectory string
 	// traceRateLimitPerSecond specifies the rate limit per second for traces.
@@ -220,6 +221,7 @@ func loadConfig() *Config {
 	cfg.dataStreamsMonitoringEnabled = p.GetBool("DD_DATA_STREAMS_ENABLED", false)
 	cfg.ciVisibilityEnabled = p.GetBool(constants.CIVisibilityEnabledEnvironmentVariable, false)
 	cfg.ciVisibilityAgentless = p.GetBool(constants.CIVisibilityAgentlessEnabledEnvironmentVariable, false)
+	cfg.ciVisibilityNoopTracer = p.GetBool(constants.CIVisibilityUseNoopTracer, false)
 	cfg.logDirectory = p.GetString("DD_TRACE_LOG_DIRECTORY", "")
 	cfg.traceRateLimitPerSecond = p.GetFloatWithValidator("DD_TRACE_RATE_LIMIT", DefaultRateLimit, validateRateLimit)
 	cfg.debugStack = p.GetBool("DD_TRACE_DEBUG_STACK", true)
@@ -975,6 +977,12 @@ func (c *Config) CIVisibilityAgentless() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.ciVisibilityAgentless
+}
+
+func (c *Config) CIVisibilityNoopTracer() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.ciVisibilityNoopTracer
 }
 
 // CIVisibilityAgentlessActive reports whether agentless CI Visibility mode is in effect.


### PR DESCRIPTION
### What does this PR do?
Migrates `ciVisibilityNoopTracer` from `ddtrace/tracer.config` to be owned by `internal/config`.

- Adds `CIVisibilityNoopTracer()` getter on `*Config`
- Updates the single read site in `tracer.go` to route through `internalConfig`.
- Removes the env-init from `option.go`'s CI Visibility block; the env var is now read at startup in `loadConfig`.

### Motivation
Continued config-migration work as part of [APMAPI-1881](https://datadoghq.atlassian.net/browse/APMAPI-1881); this card is [APMAPI-1889](https://datadoghq.atlassian.net/browse/APMAPI-1889). Sister-field migration to #4793.

### Reviewer's Checklist
- [x] Changed code has unit tests for its functionality at or near 100% coverage. (Pure refactor; existing CI Visibility tests cover the read path.)
- [ ] System-Tests covering this feature have been added and enabled with the va.b.c-dev version tag. (N/A — pure refactor.)
- [ ] There is a benchmark for any new code, or changes to existing code. (N/A.)
- [ ] If this interacts with the agent in a new way, a system test has been added. (N/A.)
- [x] New code is free of linting errors.
- [x] New code doesn't break existing tests.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date.
- [x] Non-trivial go.mod changes — none.


[APMAPI-1881]: https://datadoghq.atlassian.net/browse/APMAPI-1881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APMAPI-1889]: https://datadoghq.atlassian.net/browse/APMAPI-1889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ