### PR TITLE
feat(config): migrate universalVersion, add DD_TRACE_UNIVERSAL_VERSION_ENABLED

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -158,10 +158,6 @@ type config struct {
 	// if they have a version of the library available to integrate.
 	integrations map[string]integrationConfig
 
-	// universalVersion, reports whether span service name and config service name
-	// should match to set application version tag. False by default
-	universalVersion bool
-
 	// sampler specifies the sampler that will be used for sampling traces.
 	sampler RateSampler
 
@@ -1128,7 +1124,7 @@ func WithSamplingRules(rules []SamplingRule) StartOption {
 func WithServiceVersion(version string) StartOption {
 	return func(cfg *config) {
 		cfg.internalConfig.SetVersion(version, telemetry.OriginCode, internalconfig.ProductTracer)
-		cfg.universalVersion = false
+		cfg.internalConfig.SetUniversalVersion(false, telemetry.OriginCode, internalconfig.ProductTracer)
 	}
 }
 
@@ -1138,7 +1134,7 @@ func WithServiceVersion(version string) StartOption {
 func WithUniversalVersion(version string) StartOption {
 	return func(c *config) {
 		c.internalConfig.SetVersion(version, telemetry.OriginCode, internalconfig.ProductTracer)
-		c.universalVersion = true
+		c.internalConfig.SetUniversalVersion(true, telemetry.OriginCode, internalconfig.ProductTracer)
 	}
 }
 

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -47,7 +47,6 @@ func startTelemetry(c *config) telemetry.Client {
 		{Name: "retry_interval", Value: c.internalConfig.RetryInterval()},
 		{Name: "trace_startup_logs_enabled", Value: c.internalConfig.LogStartup()},
 		{Name: "service", Value: c.internalConfig.ServiceName()},
-		{Name: "universal_version", Value: c.universalVersion},
 		{Name: "env", Value: c.internalConfig.Env()},
 		{Name: "version", Value: c.internalConfig.Version()},
 		{Name: "trace_agent_url", Value: c.internalConfig.AgentURL().String()},

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -550,7 +550,7 @@ func buildSharedAttrs(c *config, base, mainSvc *traceinternal.SpanAttributes) {
 		mainSvc.Set(traceinternal.AttrEnv, env)
 	}
 	if ver := c.internalConfig.Version(); ver != "" {
-		if c.universalVersion {
+		if c.internalConfig.UniversalVersion() {
 			base.Set(traceinternal.AttrVersion, ver)
 		}
 		// Always pre-populate mainSvc with version so that main-service spans
@@ -958,7 +958,7 @@ func (t *tracer) StartSpan(operationName string, options ...StartSpanOption) *Sp
 	// For non-universal version, promote main-service spans to the version-inclusive
 	// shared attrs before applying any tags. This makes the subsequent version write
 	// (from config or global tags) a COW no-op instead of triggering a Clone.
-	if !t.config.universalVersion && span.service == cSnap.ServiceName {
+	if !cSnap.UniversalVersion && span.service == cSnap.ServiceName {
 		span.meta.ReplaceSharedAttrs(&t.sharedAttrs, &t.sharedAttrsForMainSvc)
 	}
 
@@ -977,7 +977,7 @@ func (t *tracer) StartSpan(operationName string, options ...StartSpanOption) *Sp
 	}
 
 	if cSnap.Version != "" {
-		if t.config.universalVersion || span.service == cSnap.ServiceName {
+		if cSnap.UniversalVersion || span.service == cSnap.ServiceName {
 			delete(span.metrics, ext.Version)
 			span.meta.Set(ext.Version, cSnap.Version)
 		}

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -2109,6 +2109,19 @@ func TestVersion(t *testing.T) {
 		v, _ := sp.meta.Get(ext.Version)
 		assert.Equal("4.5.6", v)
 	})
+	t.Run("env-universal", func(t *testing.T) {
+		t.Setenv("DD_SERVICE", "servenv")
+		t.Setenv("DD_VERSION", "4.5.6")
+		t.Setenv("DD_TRACE_UNIVERSAL_VERSION_ENABLED", "true")
+		tracer, _, _, stop, err := startTestTracer(t)
+		assert.Nil(t, err)
+		defer stop()
+
+		assert := assert.New(t)
+		sp := tracer.StartSpan("http.request", ServiceName("otherservenv"))
+		v, _ := sp.meta.Get(ext.Version)
+		assert.Equal("4.5.6", v)
+	})
 	t.Run("service/universal", func(t *testing.T) {
 		tracer, _, _, stop, err := startTestTracer(t, WithServiceVersion("4.5.6"),
 			WithService("servenv"), WithUniversalVersion("1.2.3"))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,6 +78,10 @@ type Config struct {
 	// serviceName specifies the name of this application.
 	serviceName string
 	version     string
+	// universalVersion, when true, applies the configured version tag to every span
+	// regardless of service. When false, only spans whose service matches the
+	// configured service get the version tag.
+	universalVersion bool
 	// env contains the environment that this application will run under.
 	env string
 	// serviceMappings holds a set of service mappings to dynamically rename services
@@ -208,6 +212,7 @@ func loadConfig() *Config {
 	cfg.logStartup = p.GetBool("DD_TRACE_STARTUP_LOGS", true)
 	cfg.serviceName = p.GetString("DD_SERVICE", "")
 	cfg.version = p.GetString("DD_VERSION", "")
+	cfg.universalVersion = p.GetBool("DD_TRACE_UNIVERSAL_VERSION_ENABLED", false)
 	cfg.env = p.GetString("DD_ENV", "")
 	cfg.serviceMappings = p.GetMap("DD_SERVICE_MAPPING", nil, internal.DDTagsDelimiter)
 	cfg.runtimeMetrics = p.GetBool("DD_RUNTIME_METRICS_ENABLED", false)
@@ -741,6 +746,22 @@ func (c *Config) SetVersion(version string, origin telemetry.Origin, product ...
 	}
 	c.version = version
 	configtelemetry.Report("DD_VERSION", version, origin)
+}
+
+func (c *Config) UniversalVersion() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.universalVersion
+}
+
+func (c *Config) SetUniversalVersion(enabled bool, origin telemetry.Origin, product ...Product) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.checkProductConflict("DD_TRACE_UNIVERSAL_VERSION_ENABLED", origin, enabled, product...) {
+		return
+	}
+	c.universalVersion = enabled
+	configtelemetry.Report("DD_TRACE_UNIVERSAL_VERSION_ENABLED", enabled, origin)
 }
 
 func (c *Config) Env() string {

--- a/internal/config/snapshots.go
+++ b/internal/config/snapshots.go
@@ -18,6 +18,7 @@ type SpanStartSnapshot struct {
 	ServiceName             string
 	Env                     string
 	Version                 string
+	UniversalVersion        bool
 	Hostname                string
 	ReportHostname          bool
 	DebugStack              bool
@@ -36,6 +37,7 @@ func (c *Config) SpanStartSnapshot() SpanStartSnapshot {
 		ServiceName:             c.serviceName,
 		Env:                     c.env,
 		Version:                 c.version,
+		UniversalVersion:        c.universalVersion,
 		Hostname:                c.hostname,
 		ReportHostname:          c.reportHostname,
 		DebugStack:              c.debugStack,

--- a/internal/env/supported_configurations.gen.go
+++ b/internal/env/supported_configurations.gen.go
@@ -241,6 +241,7 @@ var SupportedConfigurations = map[string]struct{}{
 	"DD_TRACE_STARTUP_LOGS":                                           {},
 	"DD_TRACE_STATS_COMPUTATION_ENABLED":                              {},
 	"DD_TRACE_TWIRP_ANALYTICS_ENABLED":                                {},
+	"DD_TRACE_UNIVERSAL_VERSION_ENABLED":                              {},
 	"DD_TRACE_VALKEY_ANALYTICS_ENABLED":                               {},
 	"DD_TRACE_VALKEY_RAW_COMMAND":                                     {},
 	"DD_TRACE_VAULT_ANALYTICS_ENABLED":                                {},

--- a/internal/env/supported_configurations.json
+++ b/internal/env/supported_configurations.json
@@ -1631,6 +1631,13 @@
         "default": "false"
       }
     ],
+    "DD_TRACE_UNIVERSAL_VERSION_ENABLED": [
+      {
+        "implementation": "A",
+        "type": "FIX_ME",
+        "default": "FIX_ME"
+      }
+    ],
     "DD_TRACE_VALKEY_ANALYTICS_ENABLED": [
       {
         "implementation": "B",

--- a/internal/env/supported_configurations.json
+++ b/internal/env/supported_configurations.json
@@ -1634,8 +1634,8 @@
     "DD_TRACE_UNIVERSAL_VERSION_ENABLED": [
       {
         "implementation": "A",
-        "type": "FIX_ME",
-        "default": "FIX_ME"
+        "type": "boolean",
+        "default": "false"
       }
     ],
     "DD_TRACE_VALKEY_ANALYTICS_ENABLED": [


### PR DESCRIPTION
### What does this PR do?
Migrates `universalVersion` from `ddtrace/tracer.config` to be owned by `internal/config`. Adds env-var support (`DD_TRACE_UNIVERSAL_VERSION_ENABLED`) to match the existing programmatic options.

### Motivation
Continued config-migration work as part of [APMAPI-1881](https://datadoghq.atlassian.net/browse/APMAPI-1881); this card is [APMAPI-1883](https://datadoghq.atlassian.net/browse/APMAPI-1883).

The env var is added per our convention: when a config field has a `WithX(...)` programmatic option, expose an equivalent env var so customers can configure it from either surface.

### Reviewer's Checklist
- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] System-Tests covering this feature have been added and enabled with the va.b.c-dev version tag. (N/A — small migration.)
- [ ] There is a benchmark for any new code, or changes to existing code. (N/A — snapshot reuse keeps hot-path cost unchanged.)
- [ ] If this interacts with the agent in a new way, a system test has been added. (N/A.)
- [x] New code is free of linting errors.
- [x] New code doesn't break existing tests.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date.
- [x] Non-trivial go.mod changes — none.

Note: `DD_TRACE_UNIVERSAL_VERSION_ENABLED` is a new key in `supported_configurations.json`. Datadog maintainers will need to register it in the internal configuration registry per CONTRIBUTING.md.


[APMAPI-1881]: https://datadoghq.atlassian.net/browse/APMAPI-1881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[APMAPI-1883]: https://datadoghq.atlassian.net/browse/APMAPI-1883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ