### PR TITLE
feat(config): migrate headerAsTags, add apply-callback to DynamicConfig

### DIFF
--- a/ddtrace/tracer/dynamic_config.go
+++ b/ddtrace/tracer/dynamic_config.go
@@ -121,29 +121,8 @@ func (dc *dynamicConfig[T]) getCurrentAndOrigin() (T, telemetry.Origin) {
 	return dc.current, dc.cfgOrigin
 }
 
-// setStartup updates the startup value (used during initialization)
-func (dc *dynamicConfig[T]) setStartup(val T) {
-	dc.mu.Lock()
-	defer dc.mu.Unlock()
-	dc.startup = val
-}
-
 func equal[T comparable](x, y T) bool {
 	return x == y
-}
-
-// equalSlice compares two slices of comparable values
-// The comparison takes into account the order of the elements
-func equalSlice[T comparable](x, y []T) bool {
-	if len(x) != len(y) {
-		return false
-	}
-	for i, v := range x {
-		if v != y[i] {
-			return false
-		}
-	}
-	return true
 }
 
 // equalMap compares two maps of comparable keys and values

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -41,7 +41,6 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/locking"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/namingschema"
-	"github.com/DataDog/dd-trace-go/v2/internal/normalizer"
 	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion"
 	"github.com/DataDog/dd-trace-go/v2/internal/processtags"
 	"github.com/DataDog/dd-trace-go/v2/internal/stableconfig"
@@ -213,9 +212,6 @@ type config struct {
 	// traceSampleRules holds the trace sampling rules
 	traceSampleRules dynamicConfig[[]SamplingRule]
 
-	// headerAsTags holds the header as tags configuration.
-	headerAsTags dynamicConfig[[]string]
-
 	// tracingAsTransport specifies whether the tracer is running in transport-only mode, where traces are only sent when other products request it.
 	tracingAsTransport bool
 
@@ -267,12 +263,6 @@ func newConfig(opts ...StartOption) (*config, error) {
 		if err := c.internalConfig.HostnameLookupError(); err != nil {
 			return c, fmt.Errorf("unable to look up hostname: %s", err.Error())
 		}
-	}
-	c.headerAsTags = newDynamicConfig("trace_header_tags", nil, setHeaderTags, equalSlice[string])
-	if v := env.Get("DD_TRACE_HEADER_TAGS"); v != "" {
-		c.headerAsTags.update(strings.Split(v, ","), telemetry.OriginEnvVar)
-		// Required to ensure that the startup header tags are set on reset.
-		c.headerAsTags.setStartup(c.headerAsTags.get())
 	}
 	if v := getDDorOtelConfig("resourceAttributes"); v != "" {
 		tags := internal.ParseTagString(v)
@@ -1360,8 +1350,7 @@ func WithStartSpanConfig(cfg *StartSpanConfig) StartSpanOption {
 // Special headers can not be sub-selected. E.g., an entire Cookie header would be transmitted, without the ability to choose specific Cookies.
 func WithHeaderTags(headerAsTags []string) StartOption {
 	return func(c *config) {
-		c.headerAsTags = newDynamicConfig("trace_header_tags", headerAsTags, setHeaderTags, equalSlice[string])
-		setHeaderTags(headerAsTags)
+		c.internalConfig.SetHeaderAsTags(headerAsTags, telemetry.OriginCode, internalconfig.ProductTracer)
 	}
 }
 
@@ -1554,21 +1543,6 @@ func (t *dummyTransport) TraceIDs() []uint64 {
 	ids := t.traceIDs
 	t.traceIDs = nil
 	return ids
-}
-
-// setHeaderTags sets the global header tags.
-// Always resets the global value and returns true.
-func setHeaderTags(headerAsTags []string) bool {
-	globalconfig.ClearHeaderTags()
-	for _, h := range headerAsTags {
-		header, tag := normalizer.HeaderTag(h)
-		if len(header) == 0 || len(tag) == 0 {
-			log.Debug("Header-tag input is in unsupported format; dropping input value %q", h)
-			continue
-		}
-		globalconfig.SetHeaderTag(header, tag)
-	}
-	return true
 }
 
 // UserMonitoringConfig is used to configure what is used to identify a user.

--- a/ddtrace/tracer/remote_config.go
+++ b/ddtrace/tracer/remote_config.go
@@ -261,10 +261,8 @@ func (t *tracer) onRemoteConfigUpdate(u remoteconfig.ProductUpdate) map[string]s
 	if updated {
 		telemConfigs = append(telemConfigs, t.config.traceSampleRules.toTelemetry())
 	}
-	updated = t.config.headerAsTags.handleRC(merged.HeaderTags.toSlice())
-	if updated {
-		telemConfigs = append(telemConfigs, t.config.headerAsTags.toTelemetry())
-	}
+	// internalConfig's HandleRC self-reports to telemetry, so no need to append to telemConfigs.
+	t.config.internalConfig.HeaderAsTagsConfig().HandleRC(merged.HeaderTags.toSlice())
 	updated = t.config.globalTags.handleRC(merged.Tags.toMap())
 	if updated {
 		telemConfigs = append(telemConfigs, t.config.globalTags.toTelemetry())

--- a/ddtrace/tracer/remote_config.go
+++ b/ddtrace/tracer/remote_config.go
@@ -261,7 +261,6 @@ func (t *tracer) onRemoteConfigUpdate(u remoteconfig.ProductUpdate) map[string]s
 	if updated {
 		telemConfigs = append(telemConfigs, t.config.traceSampleRules.toTelemetry())
 	}
-	// internalConfig's HandleRC self-reports to telemetry, so no need to append to telemConfigs.
 	t.config.internalConfig.HeaderAsTagsConfig().HandleRC(merged.HeaderTags.toSlice())
 	updated = t.config.globalTags.handleRC(merged.Tags.toMap())
 	if updated {

--- a/ddtrace/tracer/remote_config_test.go
+++ b/ddtrace/tracer/remote_config_test.go
@@ -483,7 +483,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 			// Telemetry
 			assertCalled(t, telemetryClient,
 				[]telemetry.Configuration{
-					{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name-from-env", Origin: telemetry.OriginDefault},
+					{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name-from-env", Origin: telemetry.OriginEnvVar},
 				},
 			)
 		},
@@ -535,7 +535,7 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 			// Telemetry
 			assertCalled(t, telemetryClient,
 				[]telemetry.Configuration{
-					{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name-in-code", Origin: telemetry.OriginDefault},
+					{Name: "trace_header_tags", Value: "X-Test-Header:my-tag-name-in-code", Origin: telemetry.OriginCode},
 				},
 			)
 		},
@@ -796,7 +796,8 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 				if tt.expectedSamplingRate == rcSamplingRate {
 					samplingRateOrigin = telemetry.OriginRemoteConfig
 				}
-				headerTagOrigin := telemetry.OriginDefault
+				// DD_TRACE_HEADER_TAGS is set, so resets report OriginEnvVar.
+				headerTagOrigin := telemetry.OriginEnvVar
 				if tt.expectedHeaderTag == rcHeaderTag {
 					headerTagOrigin = telemetry.OriginRemoteConfig
 				}

--- a/ddtrace/tracer/remote_config_test.go
+++ b/ddtrace/tracer/remote_config_test.go
@@ -796,7 +796,6 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 				if tt.expectedSamplingRate == rcSamplingRate {
 					samplingRateOrigin = telemetry.OriginRemoteConfig
 				}
-				// DD_TRACE_HEADER_TAGS is set, so resets report OriginEnvVar.
 				headerTagOrigin := telemetry.OriginEnvVar
 				if tt.expectedHeaderTag == rcHeaderTag {
 					headerTagOrigin = telemetry.OriginRemoteConfig

--- a/ddtrace/tracer/telemetry.go
+++ b/ddtrace/tracer/telemetry.go
@@ -61,7 +61,6 @@ func startTelemetry(c *config) telemetry.Client {
 		{Name: "orchestrion_enabled", Value: c.orchestrionCfg.Enabled, Origin: telemetry.OriginCode},
 		{Name: "trace_enabled", Value: traceEnabled, Origin: traceEnabledOrigin},
 		{Name: "trace_log_directory", Value: c.internalConfig.LogDirectory()},
-		c.headerAsTags.toTelemetry(),
 		c.globalTags.toTelemetry(),
 		c.traceSampleRules.toTelemetry(),
 		{Name: "span_sample_rules", Value: c.spanRules},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,6 +115,10 @@ type Config struct {
 	dynamicInstrumentationEnabled *DynamicConfig[bool]
 	// globalSampleRate holds the sample rate for the tracer.
 	globalSampleRate *DynamicConfig[float64]
+	// headerAsTags holds the configured "header:tag" entries for HTTP integrations.
+	// On change, the apply callback re-populates globalconfig.HeaderTags with the
+	// parsed mappings — transitional until integrations read directly from here.
+	headerAsTags *DynamicConfig[[]string]
 	// ciVisibilityEnabled controls if the tracer is loaded with CI Visibility mode. default false
 	ciVisibilityEnabled    bool
 	ciVisibilityAgentless  bool
@@ -247,10 +251,13 @@ func loadConfig() *Config {
 	cfg.httpClientTimeout = time.Duration(p.GetIntWithValidator("DD_TRACE_AGENT_TIMEOUT", 10, validateAgentTimeout)) * time.Second
 
 	sampleRate, sampleRateOrigin := p.GetFloatWithValidatorOrigin("DD_TRACE_SAMPLE_RATE", math.NaN(), validateSampleRate)
-	cfg.globalSampleRate = newDynamicConfig("trace_sample_rate", sampleRate, sampleRateOrigin, equalFloat)
+	cfg.globalSampleRate = newDynamicConfig("trace_sample_rate", sampleRate, sampleRateOrigin, equalFloat, nil)
 
 	enabled, origin := p.GetBoolWithOrigin("DD_DYNAMIC_INSTRUMENTATION_ENABLED", false)
-	cfg.dynamicInstrumentationEnabled = newDynamicConfig("dynamic_instrumentation_enabled", enabled, origin, equal[bool])
+	cfg.dynamicInstrumentationEnabled = newDynamicConfig("dynamic_instrumentation_enabled", enabled, origin, equal[bool], nil)
+
+	headerTags, headerTagsOrigin := parseHeaderAsTagsFromEnv(p)
+	cfg.headerAsTags = newDynamicConfig("trace_header_tags", headerTags, headerTagsOrigin, equalSlice[string], propagateHeaderAsTagsToGlobalConfig)
 
 	// Parse feature flags from DD_TRACE_FEATURES as a set
 	cfg.featureFlags = make(map[string]struct{})
@@ -565,6 +572,26 @@ func (c *Config) SetDynamicInstrumentationEnabled(enabled bool, origin telemetry
 	}
 	c.dynamicInstrumentationEnabled.setBaseline(enabled, origin)
 	configtelemetry.Report("DD_DYNAMIC_INSTRUMENTATION_ENABLED", enabled, origin)
+}
+
+func (c *Config) HeaderAsTags() []string {
+	return c.headerAsTags.Get()
+}
+
+// HeaderAsTagsConfig returns the DynamicConfig for header-as-tags. Used by the
+// tracer's RC handler to invoke HandleRC on remote-config updates.
+func (c *Config) HeaderAsTagsConfig() *DynamicConfig[[]string] {
+	return c.headerAsTags
+}
+
+func (c *Config) SetHeaderAsTags(headerAsTags []string, origin telemetry.Origin, product ...Product) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.checkProductConflict("DD_TRACE_HEADER_TAGS", origin, headerAsTags, product...) {
+		return
+	}
+	c.headerAsTags.setBaseline(headerAsTags, origin)
+	configtelemetry.Report("DD_TRACE_HEADER_TAGS", strings.Join(headerAsTags, ","), origin)
 }
 
 func (c *Config) TraceRateLimitPerSecond() float64 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,9 +115,7 @@ type Config struct {
 	dynamicInstrumentationEnabled *DynamicConfig[bool]
 	// globalSampleRate holds the sample rate for the tracer.
 	globalSampleRate *DynamicConfig[float64]
-	// headerAsTags holds the configured "header:tag" entries for HTTP integrations.
-	// On change, the apply callback re-populates globalconfig.HeaderTags with the
-	// parsed mappings — transitional until integrations read directly from here.
+	// headerAsTags holds the header as tags configuration.
 	headerAsTags *DynamicConfig[[]string]
 	// ciVisibilityEnabled controls if the tracer is loaded with CI Visibility mode. default false
 	ciVisibilityEnabled    bool

--- a/internal/config/dynamic_config.go
+++ b/internal/config/dynamic_config.go
@@ -50,10 +50,7 @@ type DynamicConfig[T any] struct {
 	cfgName       string
 	startupOrigin telemetry.Origin // used on RC reset; updated by setBaseline
 	equal         func(T, T) bool  // compares values to avoid unnecessary updates
-	// apply, when non-nil, is invoked with the new value whenever the field
-	// changes via setBaseline or HandleRC. Used to propagate the change to
-	// derived state (e.g. parsed/denormalized form held elsewhere). Invoked
-	// without holding dc.mu so the callback may safely take other locks.
+	// executes any config-specific operations to propagate the update properly, returns whether the update was applied
 	apply func(T) bool
 }
 

--- a/internal/config/dynamic_config.go
+++ b/internal/config/dynamic_config.go
@@ -27,6 +27,19 @@ func equal[T comparable](a, b T) bool {
 	return a == b
 }
 
+// equalSlice compares two slices element-wise (order-sensitive).
+func equalSlice[T comparable](a, b []T) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // DynamicConfig is a thread-safe, RC-aware value store for a single configuration field.
 // It tracks both the current value and the startup baseline (for RC reset).
 // Consumers read via Get().
@@ -37,25 +50,38 @@ type DynamicConfig[T any] struct {
 	cfgName       string
 	startupOrigin telemetry.Origin // used on RC reset; updated by setBaseline
 	equal         func(T, T) bool  // compares values to avoid unnecessary updates
+	// apply, when non-nil, is invoked with the new value whenever the field
+	// changes via setBaseline or HandleRC. Used to propagate the change to
+	// derived state (e.g. parsed/denormalized form held elsewhere). Invoked
+	// without holding dc.mu so the callback may safely take other locks.
+	apply func(T) bool
 }
 
 // newDynamicConfig creates a DynamicConfig with the given telemetry name, initial value,
-// the origin that produced that initial value, and a comparator used to detect changes.
+// the origin that produced that initial value, a comparator used to detect changes,
+// and an optional apply callback invoked when the value changes (pass nil if not needed).
 // The startupOrigin is used when RC resets the field back to its startup value.
-func newDynamicConfig[T any](name string, val T, origin telemetry.Origin, equal func(T, T) bool) *DynamicConfig[T] {
-	dc := &DynamicConfig[T]{cfgName: name, equal: equal}
+func newDynamicConfig[T any](name string, val T, origin telemetry.Origin, equal func(T, T) bool, apply func(T) bool) *DynamicConfig[T] {
+	dc := &DynamicConfig[T]{cfgName: name, equal: equal, apply: apply}
 	dc.setBaseline(val, origin)
 	return dc
 }
 
 // setBaseline sets both the current value and the startup value for a field.
 // The startup value is what the field reverts to when RC is reset or revoked.
+// If an apply callback was registered and the new value differs from the current
+// value, the callback fires after the lock is released.
 func (dc *DynamicConfig[T]) setBaseline(val T, origin telemetry.Origin) {
 	dc.mu.Lock()
-	defer dc.mu.Unlock()
+	changed := !dc.equal(dc.current, val)
 	dc.current = val
 	dc.startup = val
 	dc.startupOrigin = origin
+	apply := dc.apply
+	dc.mu.Unlock()
+	if changed && apply != nil {
+		apply(val)
+	}
 }
 
 // Get returns the current value.
@@ -74,11 +100,11 @@ func (dc *DynamicConfig[T]) Baseline() (T, telemetry.Origin) {
 
 // HandleRC processes a remote config update. If val is non-nil, the value is
 // updated; if nil, the field is reset to its startup value.
-// Reports the new value to telemetry when changed.
+// Reports the new value to telemetry when changed and invokes the apply
+// callback (if registered) outside the lock.
 // Returns true if the value was changed.
 func (dc *DynamicConfig[T]) HandleRC(val *T) bool {
 	dc.mu.Lock()
-	defer dc.mu.Unlock()
 	var changed bool
 	var origin telemetry.Origin
 	if val != nil {
@@ -94,8 +120,14 @@ func (dc *DynamicConfig[T]) HandleRC(val *T) bool {
 		}
 		origin = dc.startupOrigin
 	}
+	newVal := dc.current
+	apply := dc.apply
 	if changed {
-		configtelemetry.Report(dc.cfgName, dc.current, origin)
+		configtelemetry.Report(dc.cfgName, newVal, origin)
+	}
+	dc.mu.Unlock()
+	if changed && apply != nil {
+		apply(newVal)
 	}
 	return changed
 }

--- a/internal/config/dynamic_config_test.go
+++ b/internal/config/dynamic_config_test.go
@@ -18,12 +18,12 @@ import (
 
 func TestDynamicConfig(t *testing.T) {
 	t.Run("get returns initial value", func(t *testing.T) {
-		dc := newDynamicConfig("test", 42, telemetry.OriginDefault, func(a, b int) bool { return a == b })
+		dc := newDynamicConfig("test", 42, telemetry.OriginDefault, func(a, b int) bool { return a == b }, nil)
 		assert.Equal(t, 42, dc.Get())
 	})
 
 	t.Run("handleRC with non-nil updates value", func(t *testing.T) {
-		dc := newDynamicConfig("test", 1.0, telemetry.OriginDefault, equalFloat)
+		dc := newDynamicConfig("test", 1.0, telemetry.OriginDefault, equalFloat, nil)
 		rate := 0.5
 		changed := dc.HandleRC(&rate)
 		assert.True(t, changed)
@@ -31,7 +31,7 @@ func TestDynamicConfig(t *testing.T) {
 	})
 
 	t.Run("handleRC with nil resets to startup", func(t *testing.T) {
-		dc := newDynamicConfig("test", 1.0, telemetry.OriginDefault, equalFloat)
+		dc := newDynamicConfig("test", 1.0, telemetry.OriginDefault, equalFloat, nil)
 		rate := 0.5
 		dc.HandleRC(&rate)
 		assert.Equal(t, 0.5, dc.Get())
@@ -42,33 +42,33 @@ func TestDynamicConfig(t *testing.T) {
 	})
 
 	t.Run("handleRC with same value is a no-op", func(t *testing.T) {
-		dc := newDynamicConfig("test", 3.14, telemetry.OriginDefault, equalFloat)
+		dc := newDynamicConfig("test", 3.14, telemetry.OriginDefault, equalFloat, nil)
 		same := 3.14
 		changed := dc.HandleRC(&same)
 		assert.False(t, changed)
 	})
 
 	t.Run("handleRC reset when already at startup is a no-op", func(t *testing.T) {
-		dc := newDynamicConfig("test", 100, telemetry.OriginDefault, func(a, b int) bool { return a == b })
+		dc := newDynamicConfig("test", 100, telemetry.OriginDefault, func(a, b int) bool { return a == b }, nil)
 		changed := dc.HandleRC(nil)
 		assert.False(t, changed)
 	})
 
 	t.Run("NaN startup is treated as equal on reset", func(t *testing.T) {
-		dc := newDynamicConfig("test", math.NaN(), telemetry.OriginDefault, equalFloat)
+		dc := newDynamicConfig("test", math.NaN(), telemetry.OriginDefault, equalFloat, nil)
 		changed := dc.HandleRC(nil)
 		assert.False(t, changed, "NaN→NaN reset should be a no-op")
 	})
 
 	t.Run("NaN update is treated as equal", func(t *testing.T) {
-		dc := newDynamicConfig("test", math.NaN(), telemetry.OriginDefault, equalFloat)
+		dc := newDynamicConfig("test", math.NaN(), telemetry.OriginDefault, equalFloat, nil)
 		nan := math.NaN()
 		changed := dc.HandleRC(&nan)
 		assert.False(t, changed, "NaN→NaN update should be a no-op")
 	})
 
 	t.Run("NaN full cycle: update then reset", func(t *testing.T) {
-		dc := newDynamicConfig("test", math.NaN(), telemetry.OriginDefault, equalFloat)
+		dc := newDynamicConfig("test", math.NaN(), telemetry.OriginDefault, equalFloat, nil)
 		rate := 0.5
 		changed := dc.HandleRC(&rate)
 		assert.True(t, changed)
@@ -83,7 +83,7 @@ func TestDynamicConfig(t *testing.T) {
 		client := new(telemetrytest.RecordClient)
 		defer telemetry.MockClient(client)()
 
-		dc := newDynamicConfig("my_field", 1.0, telemetry.OriginEnvVar, equalFloat)
+		dc := newDynamicConfig("my_field", 1.0, telemetry.OriginEnvVar, equalFloat, nil)
 		rate := 0.5
 		dc.HandleRC(&rate)
 
@@ -94,7 +94,7 @@ func TestDynamicConfig(t *testing.T) {
 		client := new(telemetrytest.RecordClient)
 		defer telemetry.MockClient(client)()
 
-		dc := newDynamicConfig("my_field", 1.0, telemetry.OriginEnvVar, equalFloat)
+		dc := newDynamicConfig("my_field", 1.0, telemetry.OriginEnvVar, equalFloat, nil)
 		rate := 0.5
 		dc.HandleRC(&rate)
 		client.Configuration = nil // clear so we only see the reset report
@@ -108,7 +108,7 @@ func TestDynamicConfig(t *testing.T) {
 		client := new(telemetrytest.RecordClient)
 		defer telemetry.MockClient(client)()
 
-		dc := newDynamicConfig("my_field", 1.0, telemetry.OriginDefault, equalFloat)
+		dc := newDynamicConfig("my_field", 1.0, telemetry.OriginDefault, equalFloat, nil)
 		rate := 0.5
 		dc.HandleRC(&rate)
 		client.Configuration = nil
@@ -122,7 +122,7 @@ func TestDynamicConfig(t *testing.T) {
 		client := new(telemetrytest.RecordClient)
 		defer telemetry.MockClient(client)()
 
-		dc := newDynamicConfig("my_field", 1.0, telemetry.OriginEnvVar, equalFloat)
+		dc := newDynamicConfig("my_field", 1.0, telemetry.OriginEnvVar, equalFloat, nil)
 		dc.HandleRC(nil)
 
 		assert.Empty(t, client.Configuration)
@@ -132,7 +132,7 @@ func TestDynamicConfig(t *testing.T) {
 		// Simulates: env var sets NaN, then programmatic override sets 1.0,
 		// then RC pushes 0.5, then RC resets. Should reset to 1.0 (the
 		// programmatic baseline), not NaN (the original env var value).
-		dc := newDynamicConfig("test", math.NaN(), telemetry.OriginDefault, equalFloat)
+		dc := newDynamicConfig("test", math.NaN(), telemetry.OriginDefault, equalFloat, nil)
 		dc.setBaseline(1.0, telemetry.OriginCode)
 
 		rate := 0.5
@@ -147,7 +147,7 @@ func TestDynamicConfig(t *testing.T) {
 		client := new(telemetrytest.RecordClient)
 		defer telemetry.MockClient(client)()
 
-		dc := newDynamicConfig("my_field", math.NaN(), telemetry.OriginDefault, equalFloat)
+		dc := newDynamicConfig("my_field", math.NaN(), telemetry.OriginDefault, equalFloat, nil)
 		dc.setBaseline(1.0, telemetry.OriginCode)
 
 		rate := 0.5
@@ -159,14 +159,14 @@ func TestDynamicConfig(t *testing.T) {
 	})
 
 	t.Run("Baseline returns startup value and origin", func(t *testing.T) {
-		dc := newDynamicConfig("test", 1.0, telemetry.OriginEnvVar, equalFloat)
+		dc := newDynamicConfig("test", 1.0, telemetry.OriginEnvVar, equalFloat, nil)
 		val, origin := dc.Baseline()
 		assert.Equal(t, 1.0, val)
 		assert.Equal(t, telemetry.OriginEnvVar, origin)
 	})
 
 	t.Run("Baseline unchanged by HandleRC", func(t *testing.T) {
-		dc := newDynamicConfig("test", 1.0, telemetry.OriginEnvVar, equalFloat)
+		dc := newDynamicConfig("test", 1.0, telemetry.OriginEnvVar, equalFloat, nil)
 		rate := 0.5
 		dc.HandleRC(&rate)
 		val, origin := dc.Baseline()
@@ -176,7 +176,7 @@ func TestDynamicConfig(t *testing.T) {
 	})
 
 	t.Run("Baseline reflects setBaseline updates", func(t *testing.T) {
-		dc := newDynamicConfig("test", 1.0, telemetry.OriginDefault, equalFloat)
+		dc := newDynamicConfig("test", 1.0, telemetry.OriginDefault, equalFloat, nil)
 		dc.setBaseline(2.0, telemetry.OriginCode)
 		val, origin := dc.Baseline()
 		assert.Equal(t, 2.0, val)
@@ -184,7 +184,7 @@ func TestDynamicConfig(t *testing.T) {
 	})
 
 	t.Run("concurrent access is safe", func(t *testing.T) {
-		dc := newDynamicConfig("test", 0, telemetry.OriginDefault, func(a, b int) bool { return a == b })
+		dc := newDynamicConfig("test", 0, telemetry.OriginDefault, func(a, b int) bool { return a == b }, nil)
 		var wg sync.WaitGroup
 
 		for i := range 100 {

--- a/internal/config/header_as_tags.go
+++ b/internal/config/header_as_tags.go
@@ -16,24 +16,17 @@ import (
 )
 
 // parseHeaderAsTagsFromEnv reads DD_TRACE_HEADER_TAGS, splits it on commas, and
-// returns the resulting list with the origin (OriginEnvVar when set, OriginDefault otherwise).
+// returns the resulting list with the origin reported by the provider.
 func parseHeaderAsTagsFromEnv(p *provider.Provider) ([]string, telemetry.Origin) {
-	v := p.GetString("DD_TRACE_HEADER_TAGS", "")
+	v, origin := p.GetStringWithOrigin("DD_TRACE_HEADER_TAGS", "")
 	if v == "" {
-		return nil, telemetry.OriginDefault
+		return nil, origin
 	}
-	return strings.Split(v, ","), telemetry.OriginEnvVar
+	return strings.Split(v, ","), origin
 }
 
-// propagateHeaderAsTagsToGlobalConfig replaces globalconfig.HeaderTags with the
-// parsed mapping derived from headerAsTags. Invoked as the apply callback on the
-// headerAsTags DynamicConfig so the denormalized view stays in sync with every
-// update (env load, programmatic setter, RC).
-//
-// Transitional: this lives in internal/config only until the integrations that
-// read globalconfig.HeaderTags migrate to reading from this package directly.
-// At that point this function, the globalconfig import, and the normalizer
-// import all go away together.
+// propagateHeaderAsTagsToGlobalConfig is the apply callback for headerAsTags.
+// Transitional: removed when integrations read header tags from this package directly.
 func propagateHeaderAsTagsToGlobalConfig(headerAsTags []string) bool {
 	globalconfig.ClearHeaderTags()
 	for _, h := range headerAsTags {

--- a/internal/config/header_as_tags.go
+++ b/internal/config/header_as_tags.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+package config
+
+import (
+	"strings"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/config/provider"
+	"github.com/DataDog/dd-trace-go/v2/internal/globalconfig"
+	"github.com/DataDog/dd-trace-go/v2/internal/log"
+	"github.com/DataDog/dd-trace-go/v2/internal/normalizer"
+	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
+)
+
+// parseHeaderAsTagsFromEnv reads DD_TRACE_HEADER_TAGS, splits it on commas, and
+// returns the resulting list with the origin (OriginEnvVar when set, OriginDefault otherwise).
+func parseHeaderAsTagsFromEnv(p *provider.Provider) ([]string, telemetry.Origin) {
+	v := p.GetString("DD_TRACE_HEADER_TAGS", "")
+	if v == "" {
+		return nil, telemetry.OriginDefault
+	}
+	return strings.Split(v, ","), telemetry.OriginEnvVar
+}
+
+// propagateHeaderAsTagsToGlobalConfig replaces globalconfig.HeaderTags with the
+// parsed mapping derived from headerAsTags. Invoked as the apply callback on the
+// headerAsTags DynamicConfig so the denormalized view stays in sync with every
+// update (env load, programmatic setter, RC).
+//
+// Transitional: this lives in internal/config only until the integrations that
+// read globalconfig.HeaderTags migrate to reading from this package directly.
+// At that point this function, the globalconfig import, and the normalizer
+// import all go away together.
+func propagateHeaderAsTagsToGlobalConfig(headerAsTags []string) bool {
+	globalconfig.ClearHeaderTags()
+	for _, h := range headerAsTags {
+		header, tag := normalizer.HeaderTag(h)
+		if len(header) == 0 || len(tag) == 0 {
+			log.Debug("Header-tag input is in unsupported format; dropping input value %q", h)
+			continue
+		}
+		globalconfig.SetHeaderTag(header, tag)
+	}
+	return true
+}

--- a/internal/config/provider/provider.go
+++ b/internal/config/provider/provider.go
@@ -84,7 +84,15 @@ func getWithOrigin[T any](p *Provider, key string, def T, parse func(string) (T,
 }
 
 func (p *Provider) GetString(key string, def string) string {
-	return get(p, key, def, func(v string) (string, bool) {
+	v, _ := p.GetStringWithOrigin(key, def)
+	return v
+}
+
+// GetStringWithOrigin is like GetString but also returns the origin of the winning
+// configuration source. Use this when the caller needs to know where the value
+// came from (e.g. to pass to DynamicConfig).
+func (p *Provider) GetStringWithOrigin(key string, def string) (string, telemetry.Origin) {
+	return getWithOrigin(p, key, def, func(v string) (string, bool) {
 		return v, true
 	})
 }


### PR DESCRIPTION
### What does this PR do?
Migrates `headerAsTags` to `internal/config.Config` and adds an `apply` callback hook to `internal/config.DynamicConfig` to re-populate `globalconfig.HeaderTags` on every value change (legacy behavior). 

**Note**: The `apply` callback is not introducing new functionality. internalconfig's `DynamicConfig` was modeled after tracer's `dynamicConfig`, but simplified; tracer's original `dynamicConfig` always had `apply` on it, but internalconfig's didn't need it until now.

### Bug fix
`HandleRC` now reports the *true* startup origin on RC reset — previously, the tracer-side `dynamicConfig.reset()` had a TODO and always reported `OriginDefault`. Three `trace_header_tags` test expectations updated to match.

### Motivation
[APMAPI-1903](https://datadoghq.atlassian.net/browse/APMAPI-1903), part of [APMAPI-1881](https://datadoghq.atlassian.net/browse/APMAPI-1881). First dynamic-config migration with an apply callback; pattern for `globalTags` next.

### Reviewer's Checklist
- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] System-Tests covering this feature have been added and enabled with the va.b.c-dev version tag. (N/A — migration of existing feature.)
- [ ] There is a benchmark for any new code, or changes to existing code. (N/A.)
- [ ] If this interacts with the agent in a new way, a system test has been added. (N/A.)
- [x] New code is free of linting errors.
- [x] New code doesn't break existing tests.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date.
- [x] Non-trivial go.mod changes — none.


[APMAPI-1903]: https://datadoghq.atlassian.net/browse/APMAPI-1903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APMAPI-1881]: https://datadoghq.atlassian.net/browse/APMAPI-1881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ