### PR TITLE
fix(internal/civisibility): fix known-tests API pagination

### DIFF
--- a/internal/civisibility/utils/net/known_tests_api.go
+++ b/internal/civisibility/utils/net/known_tests_api.go
@@ -33,8 +33,7 @@ type (
 	}
 
 	knownTestsRequest struct {
-		Data     knownTestsRequestHeader    `json:"data"`
-		PageInfo *knownTestsRequestPageInfo `json:"page_info,omitempty"`
+		Data knownTestsRequestHeader `json:"data"`
 	}
 
 	knownTestsRequestHeader struct {
@@ -44,10 +43,11 @@ type (
 	}
 
 	KnownTestsRequestData struct {
-		Service        string             `json:"service"`
-		Env            string             `json:"env"`
-		RepositoryURL  string             `json:"repository_url"`
-		Configurations testConfigurations `json:"configurations"`
+		Service        string                     `json:"service"`
+		Env            string                     `json:"env"`
+		RepositoryURL  string                     `json:"repository_url"`
+		Configurations testConfigurations         `json:"configurations"`
+		PageInfo       *knownTestsRequestPageInfo `json:"page_info,omitempty"`
 	}
 
 	knownTestsResponse struct {
@@ -56,11 +56,11 @@ type (
 			Type       string                 `json:"type"`
 			Attributes KnownTestsResponseData `json:"attributes"`
 		} `json:"data"`
-		PageInfo *knownTestsResponsePageInfo `json:"page_info,omitempty"`
 	}
 
 	KnownTestsResponseData struct {
-		Tests KnownTestsResponseDataModules `json:"tests"`
+		Tests    KnownTestsResponseDataModules `json:"tests"`
+		PageInfo *knownTestsResponsePageInfo   `json:"page_info,omitempty"`
 	}
 
 	KnownTestsResponseDataModules map[string]KnownTestsResponseDataSuites
@@ -92,9 +92,9 @@ func (c *client) GetKnownTests() (*KnownTestsResponseData, error) {
 				Env:            c.environment,
 				RepositoryURL:  c.repositoryURL,
 				Configurations: c.testConfigurations,
+				PageInfo:       &knownTestsRequestPageInfo{},
 			},
 		},
-		PageInfo: &knownTestsRequestPageInfo{},
 	}
 
 	accumulated := KnownTestsResponseData{
@@ -146,10 +146,10 @@ func (c *client) GetKnownTests() (*KnownTestsResponseData, error) {
 		}
 
 		// Check if there are more pages
-		if responseObject.PageInfo == nil || !responseObject.PageInfo.HasNext {
+		if responseObject.Data.Attributes.PageInfo == nil || !responseObject.Data.Attributes.PageInfo.HasNext {
 			break
 		}
-		body.PageInfo.PageState = responseObject.PageInfo.Cursor
+		body.Data.Attributes.PageInfo.PageState = responseObject.Data.Attributes.PageInfo.Cursor
 	}
 
 	// Report total test count telemetry

--- a/internal/civisibility/utils/net/known_tests_api_test.go
+++ b/internal/civisibility/utils/net/known_tests_api_test.go
@@ -30,7 +30,7 @@ func TestKnownTestsApiRequest(t *testing.T) {
 			"MySuite1": []string{"Test1", "Test2"},
 		},
 	}
-	page1Response.PageInfo = &knownTestsResponsePageInfo{
+	page1Response.Data.Attributes.PageInfo = &knownTestsResponsePageInfo{
 		Cursor:  "cursor_page2",
 		Size:    2,
 		HasNext: true,
@@ -46,7 +46,7 @@ func TestKnownTestsApiRequest(t *testing.T) {
 			"MySuite2": []string{"Test4", "Test5"},
 		},
 	}
-	page2Response.PageInfo = &knownTestsResponsePageInfo{
+	page2Response.Data.Attributes.PageInfo = &knownTestsResponsePageInfo{
 		Cursor:  "cursor_page3",
 		Size:    3,
 		HasNext: true,
@@ -71,7 +71,7 @@ func TestKnownTestsApiRequest(t *testing.T) {
 
 		if r.Header.Get(HeaderContentType) == ContentTypeJSON {
 			var request knownTestsRequest
-			json.Unmarshal(body, &request)
+			assert.NoError(t, json.Unmarshal(body, &request))
 			assert.Equal(t, c.id, request.Data.ID)
 			assert.Equal(t, knownTestsRequestType, request.Data.Type)
 			assert.Equal(t, knownTestsURLPath, r.URL.Path[1:])
@@ -79,20 +79,36 @@ func TestKnownTestsApiRequest(t *testing.T) {
 			assert.Equal(t, c.repositoryURL, request.Data.Attributes.RepositoryURL)
 			assert.Equal(t, c.serviceName, request.Data.Attributes.Service)
 			assert.Equal(t, c.testConfigurations, request.Data.Attributes.Configurations)
-			assert.NotNil(t, request.PageInfo, "page_info should always be present")
+			assert.NotNil(t, request.Data.Attributes.PageInfo, "page_info should always be present under attributes")
+
+			var envelope map[string]json.RawMessage
+			assert.NoError(t, json.Unmarshal(body, &envelope))
+			assert.NotContains(t, envelope, "page_info", "page_info should not be top-level")
+
+			var requestData struct {
+				Attributes map[string]json.RawMessage `json:"attributes"`
+			}
+			assert.NoError(t, json.Unmarshal(envelope["data"], &requestData))
+			pageInfoRaw, ok := requestData.Attributes["page_info"]
+			assert.True(t, ok, "page_info should be present under data.attributes")
+			var pageInfo map[string]any
+			assert.NoError(t, json.Unmarshal(pageInfoRaw, &pageInfo))
 
 			w.Header().Set(HeaderContentType, ContentTypeJSON)
 			requestCount++
 			var resp knownTestsResponse
 			switch requestCount {
 			case 1:
-				assert.Empty(t, request.PageInfo.PageState, "first request should have empty page_state")
+				assert.Empty(t, request.Data.Attributes.PageInfo.PageState, "first request should have empty page_state")
+				assert.Empty(t, pageInfo, "first request should not send pagination fields")
 				resp = page1Response
 			case 2:
-				assert.Equal(t, "cursor_page2", request.PageInfo.PageState)
+				assert.Equal(t, "cursor_page2", request.Data.Attributes.PageInfo.PageState)
+				assert.Equal(t, map[string]any{"page_state": "cursor_page2"}, pageInfo)
 				resp = page2Response
 			case 3:
-				assert.Equal(t, "cursor_page3", request.PageInfo.PageState)
+				assert.Equal(t, "cursor_page3", request.Data.Attributes.PageInfo.PageState)
+				assert.Equal(t, map[string]any{"page_state": "cursor_page3"}, pageInfo)
 				resp = page3Response
 			default:
 				t.Fatalf("unexpected request count: %d", requestCount)


### PR DESCRIPTION
### What does this PR do?

Moves known-tests pagination metadata into the JSON API attributes payload for both requests and responses.

The known-tests client now sends `data.attributes.page_info` on the initial request and uses `data.attributes.page_info.page_state` for follow-up requests. It also reads `cursor` and `has_next` from `data.attributes.page_info` in backend responses, so it continues paginating after page 1.

The regression test now asserts that `page_info` is not emitted at the top level, verifies the attributes-level request shape, and exercises cursor-based follow-up requests without sending a page size.

### Motivation

https://github.com/DataDog/shepherd/issues/46

Go was modeling `page_info` as a sibling of `data`, while the known-tests API contract used by the backend and other tracers places pagination under `data.attributes`. With a contract-correct backend response, Go could parse the first page of tests but missed `has_next` and stopped without requesting subsequent pages.

### Testing

- [x] `go test ./internal/civisibility/utils/net`
- [x] `go test ./internal/civisibility/...`
- [x] `git diff --check -- internal/civisibility/utils/net/known_tests_api.go internal/civisibility/utils/net/known_tests_api_test.go`