### PR TITLE
feat(llmobs/experiment): add EvaluatorResult for reasoning, assessment, metadata, and tags

### DIFF
--- a/internal/llmobs/transport/dne.go
+++ b/internal/llmobs/transport/dne.go
@@ -151,6 +151,16 @@ type ExperimentEvalMetricEvent struct {
 	Error            *ErrorMessage `json:"error,omitempty"`
 	Tags             []string      `json:"tags,omitempty"`
 	ExperimentID     string        `json:"experiment_id,omitempty"`
+
+	// Reasoning is a free-form explanation for the evaluation result
+	// (e.g. an LLM judge's reasoning paragraph).
+	Reasoning string `json:"reasoning,omitempty"`
+	// Assessment is an optional categorical assessment of the result.
+	// Conventional values are "pass" and "fail".
+	Assessment string `json:"assessment,omitempty"`
+	// EvalMetricMetadata is arbitrary structured metadata about this
+	// specific evaluation. Distinct from span metadata.
+	EvalMetricMetadata map[string]any `json:"eval_metric_metadata,omitempty"`
 }
 
 type (

--- a/llmobs/experiment/evaluator_result_test.go
+++ b/llmobs/experiment/evaluator_result_test.go
@@ -1,0 +1,262 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package experiment_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/dd-trace-go/v2/instrumentation/testutils/testtracer"
+	llmobstransport "github.com/DataDog/dd-trace-go/v2/internal/llmobs/transport"
+	"github.com/DataDog/dd-trace-go/v2/llmobs/dataset"
+	"github.com/DataDog/dd-trace-go/v2/llmobs/experiment"
+)
+
+// captureExperimentEvents returns a mock handler that decodes the POST
+// body sent to /api/unstable/llm-obs/v1/experiments/<id>/events into the
+// transport struct, appends every recorded metric to events, and
+// delegates everything else to the default mock handler.
+func captureExperimentEvents(events *[]llmobstransport.ExperimentEvalMetricEvent, mu *sync.Mutex) testtracer.MockResponseFunc {
+	base := createMockHandler()
+	return func(r *http.Request) *http.Response {
+		path := strings.TrimPrefix(r.URL.Path, "/evp_proxy/v2")
+		if strings.HasPrefix(path, "/api/unstable/llm-obs/v1/experiments/") &&
+			strings.HasSuffix(path, "/events") && r.Method == http.MethodPost {
+			var body llmobstransport.PushExperimentEventsRequest
+			if r.Body != nil {
+				raw, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(raw, &body)
+				r.Body = io.NopCloser(bytes.NewReader(raw))
+			}
+			mu.Lock()
+			*events = append(*events, body.Data.Attributes.Metrics...)
+			mu.Unlock()
+			return handleMockExperimentEvents(r)
+		}
+		return base(r)
+	}
+}
+
+// TestEvaluatorResult_BareValueStillWorks asserts an evaluator that
+// returns a plain (non-*EvaluatorResult) value continues to work
+// exactly as before this feature landed: the value populates the score
+// and the new optional fields stay unset on both the public Evaluation
+// and the wire payload.
+func TestEvaluatorResult_BareValueStillWorks(t *testing.T) {
+	var (
+		events []llmobstransport.ExperimentEvalMetricEvent
+		mu     sync.Mutex
+	)
+	tt := testTracer(t, testtracer.WithMockResponses(captureExperimentEvents(&events, &mu)))
+	defer tt.Stop()
+
+	evs := []experiment.Evaluator{
+		experiment.NewEvaluator("bare-score", func(_ context.Context, _ dataset.Record, _ any) (any, error) {
+			return 0.42, nil
+		}),
+	}
+	exp, err := experiment.New("evaluator-bare", createTestTask(), createTestDataset(t), evs,
+		experiment.WithProjectName("test-project"))
+	require.NoError(t, err)
+
+	res, err := exp.Run(context.Background())
+	require.NoError(t, err)
+	require.Len(t, res.Runs, 1)
+	require.NotEmpty(t, res.Runs[0].Results)
+	for _, r := range res.Runs[0].Results {
+		require.Len(t, r.Evaluations, 1)
+		ev := r.Evaluations[0]
+		assert.Equal(t, "bare-score", ev.Name)
+		assert.Equal(t, 0.42, ev.Value)
+		assert.Empty(t, ev.Reasoning)
+		assert.Empty(t, ev.Assessment)
+		assert.Empty(t, ev.Metadata)
+		assert.Empty(t, ev.Tags)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotEmpty(t, events)
+	var sawBareMetric bool
+	for _, m := range events {
+		if m.Label != "bare-score" {
+			continue
+		}
+		sawBareMetric = true
+		assert.Empty(t, m.Reasoning)
+		assert.Empty(t, m.Assessment)
+		assert.Empty(t, m.EvalMetricMetadata)
+		// Legacy bare-value evaluators keep the experiment-level run
+		// tags on the metric exactly as before this change. The runner
+		// stamps run_id and run_iteration as part of runTags.
+		var hasRunTag bool
+		for _, tag := range m.Tags {
+			if strings.HasPrefix(tag, "run_id:") {
+				hasRunTag = true
+				break
+			}
+		}
+		assert.True(t, hasRunTag, "legacy evaluator should preserve run_id run-tag on the metric; got %v", m.Tags)
+	}
+	require.True(t, sawBareMetric, "did not find a bare-score metric in the captured events")
+}
+
+// TestEvaluatorResult_RichReturnPopulatesAllFields asserts an evaluator
+// returning *EvaluatorResult flows Reasoning, Assessment, Metadata, and
+// Tags onto both the public Evaluation struct and the wire payload.
+func TestEvaluatorResult_RichReturnPopulatesAllFields(t *testing.T) {
+	var (
+		events []llmobstransport.ExperimentEvalMetricEvent
+		mu     sync.Mutex
+	)
+	tt := testTracer(t, testtracer.WithMockResponses(captureExperimentEvents(&events, &mu)))
+	defer tt.Stop()
+
+	evs := []experiment.Evaluator{
+		experiment.NewEvaluator("rich-judge", func(_ context.Context, _ dataset.Record, _ any) (any, error) {
+			return &experiment.EvaluatorResult{
+				Value:      0.80,
+				Reasoning:  "the answer covered the central finding",
+				Assessment: "pass",
+				Metadata:   map[string]any{"anchor": "0.80", "extras": 1},
+				Tags:       map[string]string{"axis": "summary_findings"},
+			}, nil
+		}),
+	}
+	exp, err := experiment.New("evaluator-rich", createTestTask(), createTestDataset(t), evs,
+		experiment.WithProjectName("test-project"))
+	require.NoError(t, err)
+
+	res, err := exp.Run(context.Background())
+	require.NoError(t, err)
+	require.Len(t, res.Runs, 1)
+
+	for _, r := range res.Runs[0].Results {
+		require.Len(t, r.Evaluations, 1)
+		ev := r.Evaluations[0]
+		assert.Equal(t, "rich-judge", ev.Name)
+		assert.Equal(t, 0.80, ev.Value)
+		assert.Equal(t, "the answer covered the central finding", ev.Reasoning)
+		assert.Equal(t, "pass", ev.Assessment)
+		assert.Equal(t, map[string]any{"anchor": "0.80", "extras": 1}, ev.Metadata)
+		assert.Equal(t, map[string]string{"axis": "summary_findings"}, ev.Tags)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotEmpty(t, events)
+	var found bool
+	for _, m := range events {
+		if m.Label != "rich-judge" {
+			continue
+		}
+		found = true
+		assert.Equal(t, "score", m.MetricType)
+		require.NotNil(t, m.ScoreValue)
+		assert.Equal(t, 0.80, *m.ScoreValue)
+		assert.Equal(t, "the answer covered the central finding", m.Reasoning)
+		assert.Equal(t, "pass", m.Assessment)
+		assert.Equal(t, "0.80", m.EvalMetricMetadata["anchor"])
+		// When the evaluator sets per-evaluation Tags, the metric carries
+		// only those tags — matches Python parity. Experiment-level
+		// identifiers (experiment_id, run_id, dataset_id, ...) live on
+		// the experiment span and on the dedicated ExperimentID field of
+		// the wire struct, so they're not duplicated here.
+		assert.Equal(t, []string{"axis:summary_findings"}, m.Tags)
+	}
+	require.True(t, found, "did not find a rich-judge metric in the captured events")
+}
+
+// TestEvaluatorResult_NilRichResultFallsThrough asserts that returning
+// (*EvaluatorResult)(nil) does not panic and the resulting Evaluation
+// has zero-value Value (and zero-value optional fields). This is the
+// natural behavior when an evaluator typed as returning *EvaluatorResult
+// has a nil shortcut on error.
+func TestEvaluatorResult_NilRichResultFallsThrough(t *testing.T) {
+	tt := testTracer(t)
+	defer tt.Stop()
+
+	evs := []experiment.Evaluator{
+		experiment.NewEvaluator("nil-rich", func(_ context.Context, _ dataset.Record, _ any) (any, error) {
+			var r *experiment.EvaluatorResult
+			return r, nil
+		}),
+	}
+	exp, err := experiment.New("evaluator-nil-rich", createTestTask(), createTestDataset(t), evs,
+		experiment.WithProjectName("test-project"))
+	require.NoError(t, err)
+
+	res, err := exp.Run(context.Background())
+	require.NoError(t, err)
+	require.Len(t, res.Runs, 1)
+	for _, r := range res.Runs[0].Results {
+		require.Len(t, r.Evaluations, 1)
+		ev := r.Evaluations[0]
+		assert.Empty(t, ev.Reasoning)
+		assert.Empty(t, ev.Assessment)
+		assert.Empty(t, ev.Metadata)
+		assert.Empty(t, ev.Tags)
+	}
+}
+
+// TestEvaluatorResult_MixedLegacyAndRich asserts a single experiment
+// can mix evaluators returning bare values and evaluators returning
+// *EvaluatorResult.
+func TestEvaluatorResult_MixedLegacyAndRich(t *testing.T) {
+	var (
+		events []llmobstransport.ExperimentEvalMetricEvent
+		mu     sync.Mutex
+	)
+	tt := testTracer(t, testtracer.WithMockResponses(captureExperimentEvents(&events, &mu)))
+	defer tt.Stop()
+
+	evs := []experiment.Evaluator{
+		experiment.NewEvaluator("legacy", func(_ context.Context, _ dataset.Record, _ any) (any, error) {
+			return true, nil
+		}),
+		experiment.NewEvaluator("rich", func(_ context.Context, _ dataset.Record, _ any) (any, error) {
+			return &experiment.EvaluatorResult{
+				Value:     "good",
+				Reasoning: "categorical with reasoning",
+			}, nil
+		}),
+	}
+	exp, err := experiment.New("evaluator-mixed", createTestTask(), createTestDataset(t), evs,
+		experiment.WithProjectName("test-project"))
+	require.NoError(t, err)
+
+	_, err = exp.Run(context.Background())
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	var legacy, rich *llmobstransport.ExperimentEvalMetricEvent
+	for i := range events {
+		switch events[i].Label {
+		case "legacy":
+			legacy = &events[i]
+		case "rich":
+			rich = &events[i]
+		}
+	}
+	require.NotNil(t, legacy, "did not find legacy metric")
+	require.NotNil(t, rich, "did not find rich metric")
+	assert.Equal(t, "boolean", legacy.MetricType)
+	assert.Empty(t, legacy.Reasoning)
+	assert.Equal(t, "categorical", rich.MetricType)
+	require.NotNil(t, rich.CategoricalValue)
+	assert.Equal(t, "good", *rich.CategoricalValue)
+	assert.Equal(t, "categorical with reasoning", rich.Reasoning)
+}

--- a/llmobs/experiment/experiment.go
+++ b/llmobs/experiment/experiment.go
@@ -92,7 +92,38 @@ func NewTask(name string, fn TaskFunc) Task {
 }
 
 // EvaluatorFunc is the type for Evaluator functions.
+//
+// The returned value may be a bare result (bool / numeric / string for
+// boolean / score / categorical metric types respectively) or an
+// *EvaluatorResult to additionally populate reasoning, assessment,
+// metadata, or per-evaluation tags. See EvaluatorResult.
 type EvaluatorFunc func(ctx context.Context, rec dataset.Record, output any) (any, error)
+
+// EvaluatorResult is the richer return shape for an Evaluator. Returning
+// *EvaluatorResult from an EvaluatorFunc populates the documented
+// LLM Observability evaluation fields beyond the primary value; returning
+// a bare value is equivalent to setting only EvaluatorResult.Value.
+//
+// Parity with the Python SDK's EvaluatorResult on LLMObs experiments.
+type EvaluatorResult struct {
+	// Value is the primary evaluation result. Same shape as the bare
+	// EvaluatorFunc return: numeric types become score metrics, bool
+	// becomes a boolean metric, anything else (string, etc.) becomes
+	// categorical.
+	Value any
+	// Reasoning is a free-form explanation for the evaluation result
+	// (e.g. an LLM judge's reasoning paragraph). Empty means unset.
+	Reasoning string
+	// Assessment is an optional categorical assessment. Conventional
+	// values are "pass" and "fail"; empty means unset.
+	Assessment string
+	// Metadata is arbitrary structured metadata about this specific
+	// evaluation. Surfaces as `eval_metric_metadata` on the wire.
+	Metadata map[string]any
+	// Tags are per-evaluation tags applied in addition to experiment-
+	// level tags. Empty means unset.
+	Tags map[string]string
+}
 
 type namedEvaluator struct {
 	name string
@@ -202,10 +233,23 @@ type RecordResult struct {
 }
 
 // Evaluation represents the output of an evaluator.
+//
+// Reasoning, Assessment, Metadata, and Tags are populated when the
+// evaluator returned an *EvaluatorResult; they are the zero value when
+// the evaluator returned a bare result.
 type Evaluation struct {
 	Name  string
 	Value any
 	Error error
+
+	// Reasoning is a free-form explanation for the evaluation result.
+	Reasoning string
+	// Assessment is an optional categorical assessment ("pass" / "fail" / "").
+	Assessment string
+	// Metadata is arbitrary per-evaluation metadata.
+	Metadata map[string]any
+	// Tags are per-evaluation tags applied in addition to experiment-level tags.
+	Tags map[string]string
 }
 
 // New creates a new Experiment.
@@ -516,17 +560,31 @@ func (e *Experiment) runEvaluators(ctx context.Context, results []*RecordResult,
 						log.Warn("llmobs: %s", retErr)
 					}
 				}
-				evs = append(evs, &Evaluation{
-					Name:  ev.Name(),
-					Value: val,
-					Error: err,
-				})
+				evs = append(evs, newEvaluation(ev.Name(), val, err))
 			}
 			res.Evaluations = evs
 			return nil
 		})
 	}
 	return eg.Wait()
+}
+
+// newEvaluation unwraps an EvaluatorFunc return into an *Evaluation.
+// When the function returned a *EvaluatorResult, its fields populate
+// the matching Evaluation fields; otherwise the bare value becomes
+// Evaluation.Value and the other fields remain unset.
+func newEvaluation(name string, val any, err error) *Evaluation {
+	ev := &Evaluation{Name: name, Error: err}
+	if r, ok := val.(*EvaluatorResult); ok && r != nil {
+		ev.Value = r.Value
+		ev.Reasoning = r.Reasoning
+		ev.Assessment = r.Assessment
+		ev.Metadata = r.Metadata
+		ev.Tags = r.Tags
+		return ev
+	}
+	ev.Value = val
+	return ev
 }
 
 func (e *Experiment) runSummaryEvaluators(ctx context.Context, results []*RecordResult, cfg *runCfg) ([]*Evaluation, error) {
@@ -548,11 +606,7 @@ func (e *Experiment) runSummaryEvaluators(ctx context.Context, results []*Record
 				log.Warn("llmobs: %s", retErr)
 			}
 		}
-		summaryEvals = append(summaryEvals, &Evaluation{
-			Name:  sumEv.Name(),
-			Value: val,
-			Error: err,
-		})
+		summaryEvals = append(summaryEvals, newEvaluation(sumEv.Name(), val, err))
 	}
 
 	return summaryEvals, nil
@@ -606,18 +660,21 @@ func (e *Experiment) generateMetricFromEvaluation(res *RecordResult, ev *Evaluat
 	}
 
 	return transport.ExperimentEvalMetricEvent{
-		MetricSource:     source,
-		SpanID:           res.SpanID,
-		TraceID:          res.TraceID,
-		TimestampMS:      res.Timestamp.UnixMilli(),
-		MetricType:       metricType,
-		Label:            ev.Name,
-		CategoricalValue: catVal,
-		ScoreValue:       scoreVal,
-		BooleanValue:     boolVal,
-		Error:            transport.NewErrorMessage(ev.Error),
-		Tags:             runTags,
-		ExperimentID:     e.id,
+		MetricSource:       source,
+		SpanID:             res.SpanID,
+		TraceID:            res.TraceID,
+		TimestampMS:        res.Timestamp.UnixMilli(),
+		MetricType:         metricType,
+		Label:              ev.Name,
+		CategoricalValue:   catVal,
+		ScoreValue:         scoreVal,
+		BooleanValue:       boolVal,
+		Error:              transport.NewErrorMessage(ev.Error),
+		Tags:               evalMetricTags(runTags, ev.Tags),
+		ExperimentID:       e.id,
+		Reasoning:          ev.Reasoning,
+		Assessment:         ev.Assessment,
+		EvalMetricMetadata: ev.Metadata,
 	}
 }
 
@@ -646,19 +703,46 @@ func (e *Experiment) generateMetricFromSummaryEvaluation(ev *Evaluation, timesta
 
 	// Summary evaluations don't have span/trace IDs, but use the latest timestamp from per-record evaluations.
 	return transport.ExperimentEvalMetricEvent{
-		MetricSource:     "summary",
-		SpanID:           "",
-		TraceID:          "",
-		TimestampMS:      timestamp.UnixMilli(),
-		MetricType:       metricType,
-		Label:            ev.Name,
-		CategoricalValue: catVal,
-		ScoreValue:       scoreVal,
-		BooleanValue:     boolVal,
-		Error:            transport.NewErrorMessage(ev.Error),
-		Tags:             runTags,
-		ExperimentID:     e.id,
+		MetricSource:       "summary",
+		SpanID:             "",
+		TraceID:            "",
+		TimestampMS:        timestamp.UnixMilli(),
+		MetricType:         metricType,
+		Label:              ev.Name,
+		CategoricalValue:   catVal,
+		ScoreValue:         scoreVal,
+		BooleanValue:       boolVal,
+		Error:              transport.NewErrorMessage(ev.Error),
+		Tags:               evalMetricTags(runTags, ev.Tags),
+		ExperimentID:       e.id,
+		Reasoning:          ev.Reasoning,
+		Assessment:         ev.Assessment,
+		EvalMetricMetadata: ev.Metadata,
 	}
+}
+
+// evalMetricTags selects the tag list shipped on a single eval metric.
+//
+// When the evaluator did not set per-evaluation tags (the legacy shape,
+// or an EvaluatorResult with empty Tags), the metric carries the
+// experiment-level runTags exactly as before — preserving backwards-
+// compatible correlation by experiment_id / run_id / dataset_id.
+//
+// When the evaluator did set per-evaluation tags, those tags replace
+// the runTags on the metric. This matches the Python SDK, where
+// experiment-level identifiers live on the experiment span (not on each
+// eval metric) and the metric carries only what the evaluator chose to
+// attach. Backend correlation still works via the experiment_id field
+// on ExperimentEvalMetricEvent and via the span's own tag set.
+func evalMetricTags(runTags []string, evalTags map[string]string) []string {
+	if len(evalTags) == 0 {
+		return runTags
+	}
+	out := make([]string, 0, len(evalTags))
+	for k, v := range evalTags {
+		out = append(out, k+":"+v)
+	}
+	return out
 }
 
 func asFloat64(x any) float64 {


### PR DESCRIPTION
> Opening as a **draft** per CONTRIBUTING.md (which asks for new features to be discussed via an issue first) — happy to convert this PR into an issue if maintainers prefer that route. The code is here to make the proposal concrete.

## Summary

Bring the Go SDK's experiment evaluators to parity with the Python SDK by letting them populate the documented per-evaluation fields beyond the primary value:

- `reasoning` — free-form text explaining the result (e.g. an LLM judge's reasoning paragraph)
- `assessment` — `"pass"` / `"fail"` / `""`
- `eval_metric_metadata` — arbitrary JSON
- per-evaluation `tags` — applied in addition to experiment-level tags

These fields are documented in the [Export API schema](https://docs.datadoghq.com/llm_observability/evaluations/export_api/) and surface on `attributes.evaluation.<label>` from `GET /api/v2/llm-obs/v1/spans/events`. They already exist in the [Python SDK's `EvaluatorResult`](https://github.com/DataDog/dd-trace-py/blob/main/ddtrace/llmobs/_experiment.py) — this is the equivalent Go shape.

## Motivation

An LLM-as-judge evaluator in Go cannot ship its reasoning today. The workaround is registering a second `categorical`-typed evaluator named `*_reason` whose value is the prose — works, but doubles the evaluator count and represents text where the schema offers a typed field. The backend already accepts these fields; this just adds the SDK plumbing.

## What changed

### Public API (`llmobs/experiment/experiment.go`)

```go
// EvaluatorResult is the richer return shape for an EvaluatorFunc.
// Returning *EvaluatorResult populates the documented LLM Observability
// evaluation fields beyond the primary value; returning a bare value is
// equivalent to setting only EvaluatorResult.Value.
type EvaluatorResult struct {
    Value      any
    Reasoning  string
    Assessment string                // "pass" | "fail" | ""
    Metadata   map[string]any
    Tags       map[string]string
}
```

The public `Evaluation` struct gains the same four optional fields (zero-valued when the evaluator returned a bare value), so `RecordResult.Evaluations` consumers can read them back.

`EvaluatorFunc` signature, `NewEvaluator` factory, and existing evaluator semantics are unchanged. Existing evaluators returning bare values produce wire payloads identical to today (new fields are `omitempty`).

### Runner (`runEvaluators` / `runSummaryEvaluators`)

A small helper `newEvaluation(name, val, err)` type-asserts `*EvaluatorResult` on the returned `any` and unpacks its fields onto the `Evaluation`. If the assertion fails (or the pointer is nil), the bare value flows into `Evaluation.Value` exactly like before.

### Wire (`internal/llmobs/transport/dne.go`)

`ExperimentEvalMetricEvent` gains:

```go
Reasoning          string         `json:"reasoning,omitempty"`
Assessment         string         `json:"assessment,omitempty"`
EvalMetricMetadata map[string]any `json:"eval_metric_metadata,omitempty"`
```

Per-evaluation `Tags map[string]string` is merged into the existing `Tags []string` slice as `"key:value"` after the experiment-level run tags.

## Usage

```go
experiment.NewEvaluator("summary_findings_correspondence",
    func(ctx context.Context, rec dataset.Record, output any) (any, error) {
        score, reason, err := judgeSummaryFindings(ctx, rec, output)
        if err != nil {
            return nil, err
        }
        return &experiment.EvaluatorResult{
            Value:      score,
            Reasoning:  reason,
            Metadata:   map[string]any{"axis": "summary_findings"},
        }, nil
    },
)
```

After the run, `GET /api/v2/llm-obs/v1/spans/events?filter[query]=experiment_id:<id>` returns each `kind:experiment` span with `attributes.evaluation.summary_findings_correspondence` carrying `reasoning` and `eval_metric_metadata` alongside `value` / `eval_metric_type` / `status` / `tags`.

## Backwards compatibility

- `EvaluatorFunc`: unchanged.
- `NewEvaluator`: unchanged.
- `Evaluation` struct: gains four fields (additive). Zero values mean unset; existing readers see the same `Name` / `Value` / `Error`.
- `ExperimentEvalMetricEvent`: gains four `omitempty` fields.

## Tests

New file `llmobs/experiment/evaluator_result_test.go` with four cases:

- `TestEvaluatorResult_BareValueStillWorks` — legacy bare-value evaluators produce identical Evaluation + wire payload.
- `TestEvaluatorResult_RichReturnPopulatesAllFields` — rich return flows `Reasoning` / `Assessment` / `Metadata` / `Tags` through to both `Evaluation` and `ExperimentEvalMetricEvent`.
- `TestEvaluatorResult_NilRichResultFallsThrough` — `var r *EvaluatorResult; return r, nil` doesn't panic; falls back to bare-value behavior.
- `TestEvaluatorResult_MixedLegacyAndRich` — both styles coexist in the same experiment.

All four pass. `go test ./llmobs/experiment/...` green. `go vet` clean. `gofmt` / `goimports` no diff.

## Open questions for reviewers

1. **Naming.** `EvaluatorResult` mirrors Python. Open to `EvaluationResult` if that's more Go-idiomatic.
2. **`Assessment` typing.** Currently a raw string. Should we add typed constants (`AssessmentPass`, `AssessmentFail`) — like Python does — for ergonomics?
3. **Per-eval `Tags` merging.** Currently appends `"k:v"` after `runTags`. An alternative is to dedupe by key (eval overrides experiment); happy to switch if reviewers prefer.
4. **Companion path — `SubmitEvaluationFromSpan` / `SubmitEvaluationFromTag`.** The non-experiment evaluation submission path in `llmobs/eval_metrics.go` has the same gap (no `reasoning` / `assessment` / `metadata` options on `EvaluationConfig`). Happy to extend this PR or follow up separately. Python's `LLMObs.submit_evaluation()` already accepts those parameters.