### PR TITLE
feat(config): Add DD_TRACE_AGENT_TIMEOUT config option

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -175,9 +175,6 @@ type config struct {
 	// ddTransport specifies the Datadog transport used to send msgpack traces and stats to the agent.
 	ddTransport ddTransport
 
-	// httpClientTimeout specifies the timeout for the HTTP client.
-	httpClientTimeout time.Duration
-
 	// propagator propagates span context cross-process
 	propagator Propagator
 
@@ -262,7 +259,6 @@ func newConfig(opts ...StartOption) (*config, error) {
 	}
 
 	c.sampler = NewAllSampler()
-	c.httpClientTimeout = time.Second * 10 // 10 seconds
 
 	if c.internalConfig.TraceAnalyticsEnabled() {
 		globalconfig.SetAnalyticsRate(1.0)
@@ -317,9 +313,9 @@ func newConfig(opts ...StartOption) (*config, error) {
 		if rawAgentURL != nil && rawAgentURL.Scheme == "unix" {
 			// If we're connecting over UDS we can just rely on the agent to provide the hostname
 			log.Debug("connecting to agent over unix, do not set hostname on any traces")
-			c.httpClient = internal.UDSClient(rawAgentURL.Path, cmp.Or(c.httpClientTimeout, defaultHTTPTimeout))
+			c.httpClient = internal.UDSClient(rawAgentURL.Path, cmp.Or(c.internalConfig.AgentTimeout(), defaultHTTPTimeout))
 		} else {
-			c.httpClient = internal.DefaultHTTPClient(c.httpClientTimeout, false)
+			c.httpClient = internal.DefaultHTTPClient(c.internalConfig.AgentTimeout(), false)
 		}
 	}
 	WithGlobalTag(ext.RuntimeID, globalconfig.RuntimeID())(c)
@@ -373,7 +369,8 @@ func newConfig(opts ...StartOption) (*config, error) {
 	}
 	// Check if CI Visibility mode is enabled
 	if c.internalConfig.CIVisibilityEnabled() {
-		c.httpClientTimeout = time.Second * 45                                 // Increase timeout up to 45 seconds (same as other tracers in CIVis mode)
+		// Increase timeout up to 45 seconds (same as other tracers in CIVis mode)
+		c.internalConfig.SetAgentTimeout(time.Second*45, internalconfig.OriginCalculated)
 		c.internalConfig.SetLogStartup(false, internalconfig.OriginCalculated) // If we are in CI Visibility mode we don't want to log the startup to stdout to avoid polluting the output
 		ciTransport := newCiVisibilityTransport(c)                             // Create a default CI Visibility Transport
 		c.ddTransport = ciTransport                                            // Replace the default transport with the CI Visibility transport
@@ -970,7 +967,7 @@ func WithAgentURL(agentURL string) StartOption {
 // WithAgentTimeout sets the timeout for the agent connection. Timeout is in seconds.
 func WithAgentTimeout(timeout int) StartOption {
 	return func(c *config) {
-		c.httpClientTimeout = time.Duration(timeout) * time.Second
+		c.internalConfig.SetAgentTimeout(time.Duration(timeout)*time.Second, telemetry.OriginCode)
 	}
 }
 

--- a/ddtrace/tracer/otlp_writer.go
+++ b/ddtrace/tracer/otlp_writer.go
@@ -49,7 +49,7 @@ func newOTLPTraceWriter(c *config) *otlpTraceWriter {
 	})
 	return &otlpTraceWriter{
 		config:    c,
-		transport: newOTLPTransport(internal.DefaultHTTPClient(c.httpClientTimeout, false), c.internalConfig.OTLPTraceURL(), c.internalConfig.OTLPHeaders()),
+		transport: newOTLPTransport(internal.DefaultHTTPClient(c.internalConfig.AgentTimeout(), false), c.internalConfig.OTLPTraceURL(), c.internalConfig.OTLPHeaders()),
 		resource:  resource,
 		scope:     scope,
 		spans:     make([]*otlptrace.Span, 0),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -241,7 +241,7 @@ func loadConfig() *Config {
 	cfg.otlpTraceURL = resolveOTLPTraceURL(cfg.agentURL, p.GetString("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", ""))
 	cfg.otlpHeaders = buildOTLPHeaders(p.GetMap("OTEL_EXPORTER_OTLP_TRACES_HEADERS", nil, internal.OtelTagsDelimeter))
 	cfg.traceID128BitEnabled = p.GetBool("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", true)
-	cfg.httpClientTimeout = time.Duration(p.GetInt("DD_TRACE_AGENT_TIMEOUT", 10)) * time.Second
+	cfg.httpClientTimeout = time.Duration(p.GetIntWithValidator("DD_TRACE_AGENT_TIMEOUT", 10, validateAgentTimeout)) * time.Second
 
 	sampleRate, sampleRateOrigin := p.GetFloatWithValidatorOrigin("DD_TRACE_SAMPLE_RATE", math.NaN(), validateSampleRate)
 	cfg.globalSampleRate = newDynamicConfig("trace_sample_rate", sampleRate, sampleRateOrigin, equalFloat)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -153,6 +153,8 @@ type Config struct {
 	traceID128BitEnabled bool
 	// apiKey is the Datadog API key from DD_API_KEY (used for agentless intake, LLM Obs, etc.).
 	apiKey string
+	// httpClientTimeout is the timeout for HTTP requests to the Datadog Agent.
+	httpClientTimeout time.Duration
 }
 
 // checkProductConflict enforces the cross-product gate for programmatic API calls.
@@ -239,6 +241,7 @@ func loadConfig() *Config {
 	cfg.otlpTraceURL = resolveOTLPTraceURL(cfg.agentURL, p.GetString("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", ""))
 	cfg.otlpHeaders = buildOTLPHeaders(p.GetMap("OTEL_EXPORTER_OTLP_TRACES_HEADERS", nil, internal.OtelTagsDelimeter))
 	cfg.traceID128BitEnabled = p.GetBool("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", true)
+	cfg.httpClientTimeout = time.Duration(p.GetInt("DD_TRACE_AGENT_TIMEOUT", 10)) * time.Second
 
 	sampleRate, sampleRateOrigin := p.GetFloatWithValidatorOrigin("DD_TRACE_SAMPLE_RATE", math.NaN(), validateSampleRate)
 	cfg.globalSampleRate = newDynamicConfig("trace_sample_rate", sampleRate, sampleRateOrigin, equalFloat)
@@ -1066,4 +1069,22 @@ func (c *Config) APIKey() string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.apiKey
+}
+
+// AgentTimeout returns the HTTP client timeout used for requests to the Datadog Agent.
+func (c *Config) AgentTimeout() time.Duration {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.httpClientTimeout
+}
+
+// SetAgentTimeout sets the HTTP client timeout used for requests to the Datadog Agent.
+func (c *Config) SetAgentTimeout(timeout time.Duration, origin telemetry.Origin, product ...Product) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.checkProductConflict("DD_TRACE_AGENT_TIMEOUT", origin, timeout, product...) {
+		return
+	}
+	c.httpClientTimeout = timeout
+	configtelemetry.Report("DD_TRACE_AGENT_TIMEOUT", timeout, origin)
 }

--- a/internal/config/config_helpers.go
+++ b/internal/config/config_helpers.go
@@ -71,6 +71,14 @@ func validateRateLimit(rate float64) bool {
 	return true
 }
 
+func validateAgentTimeout(timeout int) bool {
+	if timeout < 0 {
+		log.Warn("ignoring DD_TRACE_AGENT_TIMEOUT: negative value %d", timeout)
+		return false
+	}
+	return true
+}
+
 // parseSpanAttributeSchema parses the DD_TRACE_SPAN_ATTRIBUTE_SCHEMA value.
 // It accepts "v0", "v1" (case-insensitive) and returns the corresponding integer version.
 // An empty string defaults to 0 (v0). Invalid values are rejected.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -952,6 +952,18 @@ func TestAgentTimeout(t *testing.T) {
 		assert.Equal(t, 10*time.Second, cfg.AgentTimeout())
 	})
 
+	t.Run("negative DD_TRACE_AGENT_TIMEOUT falls back to default", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+
+		t.Setenv("DD_TRACE_AGENT_TIMEOUT", "-5")
+
+		cfg := Get()
+		require.NotNil(t, cfg)
+
+		assert.Equal(t, 10*time.Second, cfg.AgentTimeout())
+	})
+
 	t.Run("SetAgentTimeout updates value", func(t *testing.T) {
 		resetGlobalState()
 		defer resetGlobalState()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -916,3 +916,50 @@ func TestCIVisibilityAgentlessActive(t *testing.T) {
 		})
 	}
 }
+
+func TestAgentTimeout(t *testing.T) {
+	t.Run("default is 10s when unset", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+
+		cfg := Get()
+		require.NotNil(t, cfg)
+
+		assert.Equal(t, 10*time.Second, cfg.AgentTimeout())
+	})
+
+	t.Run("DD_TRACE_AGENT_TIMEOUT overrides default", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+
+		t.Setenv("DD_TRACE_AGENT_TIMEOUT", "30")
+
+		cfg := Get()
+		require.NotNil(t, cfg)
+
+		assert.Equal(t, 30*time.Second, cfg.AgentTimeout())
+	})
+
+	t.Run("invalid DD_TRACE_AGENT_TIMEOUT falls back to default", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+
+		t.Setenv("DD_TRACE_AGENT_TIMEOUT", "not-a-number")
+
+		cfg := Get()
+		require.NotNil(t, cfg)
+
+		assert.Equal(t, 10*time.Second, cfg.AgentTimeout())
+	})
+
+	t.Run("SetAgentTimeout updates value", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+
+		cfg := Get()
+		require.NotNil(t, cfg)
+
+		cfg.SetAgentTimeout(45*time.Second, OriginCalculated)
+		assert.Equal(t, 45*time.Second, cfg.AgentTimeout())
+	})
+}

--- a/internal/env/supported_configurations.gen.go
+++ b/internal/env/supported_configurations.gen.go
@@ -152,6 +152,7 @@ var SupportedConfigurations = map[string]struct{}{
 	"DD_TRACE_ABANDONED_SPAN_TIMEOUT":                                 {},
 	"DD_TRACE_AGENT_PORT":                                             {},
 	"DD_TRACE_AGENT_PROTOCOL_VERSION":                                 {},
+	"DD_TRACE_AGENT_TIMEOUT":                                          {},
 	"DD_TRACE_AGENT_URL":                                              {},
 	"DD_TRACE_ANALYTICS_ENABLED":                                      {},
 	"DD_TRACE_AWS_ANALYTICS_ENABLED":                                  {},

--- a/internal/env/supported_configurations.json
+++ b/internal/env/supported_configurations.json
@@ -1008,6 +1008,13 @@
         "default": "1.0"
       }
     ],
+    "DD_TRACE_AGENT_TIMEOUT": [
+      {
+        "implementation": "A",
+        "type": "int",
+        "default": "10"
+      }
+    ],
     "DD_TRACE_AGENT_URL": [
       {
         "implementation": "C",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Migrates the HTTPClientTimeout config to the internal/config and adds the `DD_TRACE_AGENT_TIMEOUT` config option for feature parity with the other SDKS.

 - Adds `httpClientTimeout` field to `internal/config.Config`, loaded from the new `DD_TRACE_AGENT_TIMEOUT` env var (default 10s), with a public AgentTimeout() getter and SetAgentTimeout() setter following the established config pattern.
- Removes the duplicate httpClientTimeout field from the legacy tracer config struct, rewiring all read/write paths (WithAgentTimeout, CIVis 45s override, HTTP client construction, OTLP writer) to go through internalConfig.
- Adds TestAgentTimeout in internal/config covering default value, env var override, invalid input fallback, and setter behavior.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

[APMAPI-1881](https://datadoghq.atlassian.net/browse/APMAPI-1881)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!


[APMAPI-1881]: https://datadoghq.atlassian.net/browse/APMAPI-1881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ