### PR TITLE
fix(contrib/aws/aws-sdk-go-v2): fix EventBridge DSM tag structure

### DIFF
--- a/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
+++ b/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
@@ -894,8 +894,9 @@ func TestAppendMiddlewareEventBridgePutEvents(t *testing.T) {
 func eventBridgeEdgeTagsForTest(entry *eventBridgeTypes.PutEventsRequestEntry) []string {
 	return []string{
 		"direction:out",
-		"type:eventbridge:" + eventBridgeNameForTest(entry),
+		"exchange:" + eventBridgeNameForTest(entry),
 		"topic:" + eventBridgeDetailTypeForTest(entry),
+		"type:eventbridge",
 	}
 }
 

--- a/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
+++ b/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
@@ -895,6 +895,7 @@ func eventBridgeEdgeTagsForTest(entry *eventBridgeTypes.PutEventsRequestEntry) [
 	return []string{
 		"direction:out",
 		"exchange:" + eventBridgeNameForTest(entry),
+		"topic:" + eventBridgeDetailTypeForTest(entry),
 		"type:eventbridge",
 	}
 }

--- a/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
+++ b/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
@@ -895,7 +895,6 @@ func eventBridgeEdgeTagsForTest(entry *eventBridgeTypes.PutEventsRequestEntry) [
 	return []string{
 		"direction:out",
 		"exchange:" + eventBridgeNameForTest(entry),
-		"topic:" + eventBridgeDetailTypeForTest(entry),
 		"type:eventbridge",
 	}
 }

--- a/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge.go
+++ b/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge.go
@@ -84,6 +84,7 @@ func eventBridgeEdgeTags(entry *types.PutEventsRequestEntry) []string {
 	return []string{
 		"direction:out",
 		"exchange:" + eventBusName(entry),
+		"topic:" + detailType(entry),
 		"type:eventbridge",
 	}
 }

--- a/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge.go
+++ b/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge.go
@@ -84,7 +84,6 @@ func eventBridgeEdgeTags(entry *types.PutEventsRequestEntry) []string {
 	return []string{
 		"direction:out",
 		"exchange:" + eventBusName(entry),
-		"topic:" + detailType(entry),
 		"type:eventbridge",
 	}
 }

--- a/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge.go
+++ b/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge.go
@@ -83,8 +83,9 @@ func getTraceContext(ctx context.Context, span *tracer.Span, entry *types.PutEve
 func eventBridgeEdgeTags(entry *types.PutEventsRequestEntry) []string {
 	return []string{
 		"direction:out",
-		"type:eventbridge:" + eventBusName(entry),
+		"exchange:" + eventBusName(entry),
 		"topic:" + detailType(entry),
+		"type:eventbridge",
 	}
 }
 

--- a/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge_test.go
+++ b/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge_test.go
@@ -249,7 +249,7 @@ func TestEventBridgeEdgeTags(t *testing.T) {
 	}
 
 	assert.Equal(t,
-		[]string{"direction:out", "type:eventbridge:orders-bus", "topic:order.created"},
+		[]string{"direction:out", "exchange:orders-bus", "topic:order.created", "type:eventbridge"},
 		eventBridgeEdgeTags(entry),
 	)
 }

--- a/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge_test.go
+++ b/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge_test.go
@@ -249,7 +249,7 @@ func TestEventBridgeEdgeTags(t *testing.T) {
 	}
 
 	assert.Equal(t,
-		[]string{"direction:out", "exchange:orders-bus", "type:eventbridge"},
+		[]string{"direction:out", "exchange:orders-bus", "topic:order.created", "type:eventbridge"},
 		eventBridgeEdgeTags(entry),
 	)
 }

--- a/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge_test.go
+++ b/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge_test.go
@@ -249,7 +249,7 @@ func TestEventBridgeEdgeTags(t *testing.T) {
 	}
 
 	assert.Equal(t,
-		[]string{"direction:out", "exchange:orders-bus", "topic:order.created", "type:eventbridge"},
+		[]string{"direction:out", "exchange:orders-bus", "type:eventbridge"},
 		eventBridgeEdgeTags(entry),
 	)
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the DSM edge tag structure for EventBridge `PutEvents` introduced in #4772. That change hasn't released yet, so changing the metrics is not a breaking change.

Before: `type:eventbridge:<bus-name>, topic:<detail-type>`
After: `type:eventbridge, exchange:<bus-name>, topic:<detail-type>`

## Why

The previous shape embedded an instance-specific value (`<bus-name>`) inside the `type` tag. The `type` tag is supposed to just identify the transport technology (e.g. `kafka`, `sqs`, `eventbridge`).

## Testing

Unit tests updated in both `internal/eventbridge` and the top-level `aws` integration test