### PR TITLE
fix(testutils): acquire trace mutex in SetPropagatingTag to prevent concurrent map writes

### DIFF
--- a/instrumentation/testutils/testutils.go
+++ b/instrumentation/testutils/testutils.go
@@ -125,7 +125,7 @@ func SetPropagatingTag(t testing.TB, ctx *tracer.SpanContext, k, v string) {
 	type cookieCutter struct {
 		_     bool // spanContext.updated
 		trace *struct {
-			_               sync.RWMutex      // trace.mu
+			mu              sync.RWMutex      // trace.mu
 			_               []any             // trace.spans
 			_               map[string]string // trace.tags
 			propagatingTags map[string]string // trace level tags that will be propagated across service boundaries
@@ -133,7 +133,9 @@ func SetPropagatingTag(t testing.TB, ctx *tracer.SpanContext, k, v string) {
 	}
 	ptr := uintptr(unsafe.Pointer(ctx))
 	cc := (*cookieCutter)(*(*unsafe.Pointer)(unsafe.Pointer(&ptr)))
+	cc.trace.mu.Lock()
 	cc.trace.propagatingTags[k] = v
+	cc.trace.mu.Unlock()
 }
 
 // StartTelemetryRecorder starts a new telemetry mock client and returns it.

--- a/instrumentation/testutils/testutils.go
+++ b/instrumentation/testutils/testutils.go
@@ -134,8 +134,11 @@ func SetPropagatingTag(t testing.TB, ctx *tracer.SpanContext, k, v string) {
 	ptr := uintptr(unsafe.Pointer(ctx))
 	cc := (*cookieCutter)(*(*unsafe.Pointer)(unsafe.Pointer(&ptr)))
 	cc.trace.mu.Lock()
+	defer cc.trace.mu.Unlock()
+	if cc.trace.propagatingTags == nil {
+		cc.trace.propagatingTags = make(map[string]string)
+	}
 	cc.trace.propagatingTags[k] = v
-	cc.trace.mu.Unlock()
 }
 
 // StartTelemetryRecorder starts a new telemetry mock client and returns it.


### PR DESCRIPTION
### What does this PR do?

Locks on `SetPropagatingTags` when running tests with `testutils`.

### Motivation

Fix a concurrent map write.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
