### PR TITLE
feat(llmobs/dataset): add WithPullVersion option for historical dataset snapshots

### DIFF
--- a/internal/llmobs/transport/dne.go
+++ b/internal/llmobs/transport/dne.go
@@ -412,7 +412,14 @@ func (c *Transport) GetDatasetWithRecords(ctx context.Context, name, projectID s
 		return nil, nil, err
 	}
 
-	// 2) Fetch all records with pagination support
+	// 2) Fetch all records with pagination support.
+	// The v2 records endpoint has no per-record version field, so stamp the effective
+	// version (requested snapshot or the dataset's current version) onto every record.
+	effectiveVersion := ds.CurrentVersion
+	if version != nil {
+		effectiveVersion = *version
+	}
+
 	var allRecords []DatasetRecordView
 	nextCursor := ""
 	pageNum := 0
@@ -425,6 +432,9 @@ func (c *Transport) GetDatasetWithRecords(ctx context.Context, name, projectID s
 			return nil, nil, fmt.Errorf("get dataset records failed on page %d: %w", pageNum, err)
 		}
 
+		for i := range records {
+			records[i].Version = effectiveVersion
+		}
 		allRecords = append(allRecords, records...)
 
 		nextCursor = cursor

--- a/internal/llmobs/transport/dne.go
+++ b/internal/llmobs/transport/dne.go
@@ -181,17 +181,19 @@ type ResponseList[T any] struct {
 	Meta ResponseMeta      `json:"meta"`
 }
 
-// responseMetaV2 matches the meta shape of the project-scoped v2 API endpoints,
-// which nest the pagination cursor under meta.page.after.
-type responseMetaV2 struct {
-	Page struct {
-		After string `json:"after,omitempty"`
-	} `json:"page"`
+// v2RecordItem is the wire format for a single item in the v2 dataset-records list response.
+// The v2 endpoint returns a flat object (id, input, expected_output, metadata at the top level),
+// unlike the unstable endpoint which wraps fields under "attributes".
+type v2RecordItem struct {
+	ID             string `json:"id"`
+	Input          any    `json:"input"`
+	ExpectedOutput any    `json:"expected_output"`
+	Metadata       any    `json:"metadata"`
 }
 
-type responseListV2[T any] struct {
-	Data []ResponseData[T] `json:"data"`
-	Meta responseMetaV2    `json:"meta"`
+type v2RecordsList struct {
+	Data []v2RecordItem `json:"data"`
+	Meta ResponseMeta   `json:"meta"` // flat meta.after, same shape as unstable endpoint
 }
 
 type ResponseData[T any] struct {
@@ -382,19 +384,22 @@ func (c *Transport) GetDatasetRecordsPage(ctx context.Context, projectID, datase
 		return nil, "", fmt.Errorf("unexpected status %d: %s", result.statusCode, string(result.body))
 	}
 
-	var recordsResp responseListV2[DatasetRecordView]
+	var recordsResp v2RecordsList
 	if err := json.Unmarshal(result.body, &recordsResp); err != nil {
 		return nil, "", fmt.Errorf("failed to decode json response: %w", err)
 	}
 
 	records := make([]DatasetRecordView, 0, len(recordsResp.Data))
 	for _, r := range recordsResp.Data {
-		rec := r.Attributes
-		rec.ID = r.ID
-		records = append(records, rec)
+		records = append(records, DatasetRecordView{
+			ID:             r.ID,
+			Input:          r.Input,
+			ExpectedOutput: r.ExpectedOutput,
+			Metadata:       r.Metadata,
+		})
 	}
 
-	return records, recordsResp.Meta.Page.After, nil
+	return records, recordsResp.Meta.After, nil
 }
 
 // GetDatasetWithRecords fetches the given Dataset and all its records from DataDog.

--- a/internal/llmobs/transport/dne.go
+++ b/internal/llmobs/transport/dne.go
@@ -181,6 +181,19 @@ type ResponseList[T any] struct {
 	Meta ResponseMeta      `json:"meta"`
 }
 
+// responseMetaV2 matches the meta shape of the project-scoped v2 API endpoints,
+// which nest the pagination cursor under meta.page.after.
+type responseMetaV2 struct {
+	Page struct {
+		After string `json:"after,omitempty"`
+	} `json:"page"`
+}
+
+type responseListV2[T any] struct {
+	Data []ResponseData[T] `json:"data"`
+	Meta responseMetaV2    `json:"meta"`
+}
+
 type ResponseData[T any] struct {
 	ID         string `json:"id"`
 	Type       string `json:"type"`
@@ -343,16 +356,25 @@ func (c *Transport) BatchUpdateDataset(
 }
 
 // GetDatasetRecordsPage fetches a single page of records for the given dataset.
+// projectID is the LLM Observability project UUID that owns the dataset.
+// version, when non-nil, requests a specific historical snapshot; nil fetches the latest version.
 // Returns the records, the cursor for the next page (empty string if no more pages), and any error.
-func (c *Transport) GetDatasetRecordsPage(ctx context.Context, datasetID, cursor string) ([]DatasetRecordView, string, error) {
-	method := http.MethodGet
-	recordsPath := fmt.Sprintf("%s/datasets/%s/records", endpointPrefixDNE, url.PathEscape(datasetID))
+func (c *Transport) GetDatasetRecordsPage(ctx context.Context, projectID, datasetID, cursor string, version *int) ([]DatasetRecordView, string, error) {
+	recordsPath := fmt.Sprintf("/api/v2/llm-obs/v1/%s/datasets/%s/records",
+		url.PathEscape(projectID), url.PathEscape(datasetID))
 
+	q := url.Values{}
+	if version != nil {
+		q.Set("filter[version]", fmt.Sprintf("%d", *version))
+	}
 	if cursor != "" {
-		recordsPath = fmt.Sprintf("%s?page[cursor]=%s", recordsPath, url.QueryEscape(cursor))
+		q.Set("page[cursor]", cursor)
+	}
+	if len(q) > 0 {
+		recordsPath = recordsPath + "?" + q.Encode()
 	}
 
-	result, err := c.jsonRequest(ctx, method, recordsPath, subdomainDNE, nil, getDatasetRecordsTimeout)
+	result, err := c.jsonRequest(ctx, http.MethodGet, recordsPath, subdomainDNE, nil, getDatasetRecordsTimeout)
 	if err != nil {
 		return nil, "", err
 	}
@@ -360,7 +382,7 @@ func (c *Transport) GetDatasetRecordsPage(ctx context.Context, datasetID, cursor
 		return nil, "", fmt.Errorf("unexpected status %d: %s", result.statusCode, string(result.body))
 	}
 
-	var recordsResp GetDatasetRecordsResponse
+	var recordsResp responseListV2[DatasetRecordView]
 	if err := json.Unmarshal(result.body, &recordsResp); err != nil {
 		return nil, "", fmt.Errorf("failed to decode json response: %w", err)
 	}
@@ -372,12 +394,13 @@ func (c *Transport) GetDatasetRecordsPage(ctx context.Context, datasetID, cursor
 		records = append(records, rec)
 	}
 
-	return records, recordsResp.Meta.After, nil
+	return records, recordsResp.Meta.Page.After, nil
 }
 
 // GetDatasetWithRecords fetches the given Dataset and all its records from DataDog.
+// version, when non-nil, requests a specific historical snapshot; nil fetches the latest version.
 // This eagerly fetches all pages of records.
-func (c *Transport) GetDatasetWithRecords(ctx context.Context, name, projectID string) (*DatasetView, []DatasetRecordView, error) {
+func (c *Transport) GetDatasetWithRecords(ctx context.Context, name, projectID string, version *int) (*DatasetView, []DatasetRecordView, error) {
 	// 1) Fetch dataset by name
 	ds, err := c.GetDatasetByName(ctx, name, projectID)
 	if err != nil {
@@ -392,7 +415,7 @@ func (c *Transport) GetDatasetWithRecords(ctx context.Context, name, projectID s
 	for {
 		log.Debug("llmobs/transport: fetching dataset records page %d", pageNum)
 
-		records, cursor, err := c.GetDatasetRecordsPage(ctx, ds.ID, nextCursor)
+		records, cursor, err := c.GetDatasetRecordsPage(ctx, projectID, ds.ID, nextCursor, version)
 		if err != nil {
 			return nil, nil, fmt.Errorf("get dataset records failed on page %d: %w", pageNum, err)
 		}

--- a/internal/llmobs/transport/dne.go
+++ b/internal/llmobs/transport/dne.go
@@ -181,21 +181,6 @@ type ResponseList[T any] struct {
 	Meta ResponseMeta      `json:"meta"`
 }
 
-// v2RecordItem is the wire format for a single item in the v2 dataset-records list response.
-// The v2 endpoint returns a flat object (id, input, expected_output, metadata at the top level),
-// unlike the unstable endpoint which wraps fields under "attributes".
-type v2RecordItem struct {
-	ID             string `json:"id"`
-	Input          any    `json:"input"`
-	ExpectedOutput any    `json:"expected_output"`
-	Metadata       any    `json:"metadata"`
-}
-
-type v2RecordsList struct {
-	Data []v2RecordItem `json:"data"`
-	Meta ResponseMeta   `json:"meta"` // flat meta.after, same shape as unstable endpoint
-}
-
 type ResponseData[T any] struct {
 	ID         string `json:"id"`
 	Type       string `json:"type"`
@@ -216,6 +201,21 @@ type (
 
 	CreateExperimentResponse = Response[ExperimentView]
 )
+
+// DatasetRecordItemV2 is the wire format for a single item in the v2 dataset-records list response.
+// The v2 endpoint returns a flat object (id, input, expected_output, metadata at the top level),
+// unlike the unstable endpoint which wraps fields under "attributes".
+type DatasetRecordItemV2 struct {
+	ID             string `json:"id"`
+	Input          any    `json:"input"`
+	ExpectedOutput any    `json:"expected_output"`
+	Metadata       any    `json:"metadata"`
+}
+
+type GetDatasetRecordsResponseV2 struct {
+	Data []DatasetRecordItemV2 `json:"data"`
+	Meta ResponseMeta          `json:"meta"`
+}
 
 func (c *Transport) GetDatasetByName(ctx context.Context, name, projectID string) (*DatasetView, error) {
 	q := url.Values{}
@@ -362,7 +362,7 @@ func (c *Transport) BatchUpdateDataset(
 // version, when non-nil, requests a specific historical snapshot; nil fetches the latest version.
 // Returns the records, the cursor for the next page (empty string if no more pages), and any error.
 func (c *Transport) GetDatasetRecordsPage(ctx context.Context, projectID, datasetID, cursor string, version *int) ([]DatasetRecordView, string, error) {
-	recordsPath := fmt.Sprintf("/api/v2/llm-obs/v1/%s/datasets/%s/records",
+	recordsPath := fmt.Sprintf("%s/%s/datasets/%s/records", endpointPrefixDNEStable,
 		url.PathEscape(projectID), url.PathEscape(datasetID))
 
 	q := url.Values{}
@@ -384,7 +384,7 @@ func (c *Transport) GetDatasetRecordsPage(ctx context.Context, projectID, datase
 		return nil, "", fmt.Errorf("unexpected status %d: %s", result.statusCode, string(result.body))
 	}
 
-	var recordsResp v2RecordsList
+	var recordsResp GetDatasetRecordsResponseV2
 	if err := json.Unmarshal(result.body, &recordsResp); err != nil {
 		return nil, "", fmt.Errorf("failed to decode json response: %w", err)
 	}

--- a/internal/llmobs/transport/transport.go
+++ b/internal/llmobs/transport/transport.go
@@ -37,8 +37,9 @@ const (
 	endpointEvalMetric = "/api/intake/llm-obs/v2/eval-metric"
 	endpointLLMSpan    = "/api/v2/llmobs"
 
-	endpointPrefixEVPProxy = "/evp_proxy/v2"
-	endpointPrefixDNE      = "/api/unstable/llm-obs/v1"
+	endpointPrefixEVPProxy  = "/evp_proxy/v2"
+	endpointPrefixDNE       = "/api/unstable/llm-obs/v1"
+	endpointPrefixDNEStable = "/api/v2/llm-obs/v1"
 
 	subdomainLLMSpan    = "llmobs-intake"
 	subdomainEvalMetric = "api"
@@ -213,8 +214,8 @@ func (c *Transport) request(ctx context.Context, method, path, subdomain string,
 			req.Header.Set(headerEVPSubdomain, subdomain)
 		}
 
-		// Set headers for datasets and experiments endpoints
-		if strings.HasPrefix(path, endpointPrefixDNE) {
+		// Set headers for datasets and experiments endpoints (both unstable and stable v2 paths)
+		if strings.HasPrefix(path, endpointPrefixDNE) || strings.HasPrefix(path, endpointPrefixDNEStable) {
 			if c.agentless && c.appKey != "" {
 				// In agentless mode, set the app key header if available
 				req.Header.Set("DD-APPLICATION-KEY", c.appKey)

--- a/llmobs/dataset/dataset.go
+++ b/llmobs/dataset/dataset.go
@@ -339,12 +339,19 @@ func Pull(ctx context.Context, name string, opts ...PullOption) (*Dataset, error
 			version:        rec.Version,
 		})
 	}
+	// When pulling a specific historical version, report that version so that
+	// experiment.Run registers the run against the correct dataset snapshot
+	// rather than the latest current_version returned by GetDatasetByName.
+	dsVersion := dsResp.CurrentVersion
+	if cfg.version != nil {
+		dsVersion = *cfg.version
+	}
 	ds := &Dataset{
 		id:          dsResp.ID,
 		name:        dsResp.Name,
 		description: dsResp.Description,
 		records:     records,
-		version:     dsResp.CurrentVersion,
+		version:     dsVersion,
 	}
 	return ds, nil
 }

--- a/llmobs/dataset/dataset.go
+++ b/llmobs/dataset/dataset.go
@@ -324,7 +324,7 @@ func Pull(ctx context.Context, name string, opts ...PullOption) (*Dataset, error
 		return nil, fmt.Errorf("failed to get or create project: %w", err)
 	}
 
-	dsResp, recordsResp, err := ll.Transport.GetDatasetWithRecords(ctx, name, project.ID)
+	dsResp, recordsResp, err := ll.Transport.GetDatasetWithRecords(ctx, name, project.ID, cfg.version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get dataset: %w", err)
 	}

--- a/llmobs/dataset/dataset_test.go
+++ b/llmobs/dataset/dataset_test.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -578,8 +579,35 @@ func TestDatasetPull(t *testing.T) {
 		assert.Equal(t, "existing-dataset", ds.Name())
 	})
 	t.Run("pull-dataset-with-non-map-input", func(t *testing.T) {
+		// Return records with string input (not a map) - this simulates a dataset created externally
+		recordsJSON := `{
+			"data": [
+				{
+					"id": "record-1",
+					"type": "dataset_records",
+					"attributes": {
+						"id": "record-1",
+						"input": "This is a simple string input, not a map",
+						"expected_output": "Some output",
+						"version": 1
+					}
+				}
+			]
+		}`
 		h := func(r *http.Request) *http.Response {
 			path := strings.TrimPrefix(r.URL.Path, "/evp_proxy/v2")
+
+			// v2 project-scoped records endpoint
+			if strings.HasPrefix(path, "/api/v2/llm-obs/v1/") && strings.Contains(path, "/records") && r.Method == http.MethodGet {
+				return &http.Response{
+					Status:     "200 OK",
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(recordsJSON)),
+					Request:    r,
+				}
+			}
+
 			if !strings.HasPrefix(path, "/api/unstable/llm-obs/v1") {
 				return nil
 			}
@@ -611,29 +639,6 @@ func TestDatasetPull(t *testing.T) {
 					Body:       io.NopCloser(bytes.NewReader(respData)),
 					Request:    r,
 				}
-			case strings.Contains(path, "/datasets/") && strings.HasSuffix(path, "/records") && r.Method == http.MethodGet:
-				// Return records with string input (not a map) - this simulates a dataset created externally
-				rawJSON := `{
-					"data": [
-						{
-							"id": "record-1",
-							"type": "dataset_records",
-							"attributes": {
-								"id": "record-1",
-								"input": "This is a simple string input, not a map",
-								"expected_output": "Some output",
-								"version": 1
-							}
-						}
-					]
-				}`
-				return &http.Response{
-					Status:     "200 OK",
-					StatusCode: http.StatusOK,
-					Header:     make(http.Header),
-					Body:       io.NopCloser(strings.NewReader(rawJSON)),
-					Request:    r,
-				}
 			default:
 				return nil
 			}
@@ -655,8 +660,36 @@ func TestDatasetPull(t *testing.T) {
 		assert.Equal(t, "Some output", rec.ExpectedOutput)
 	})
 	t.Run("pull-dataset-with-non-map-metadata", func(t *testing.T) {
+		// Return records with string metadata (not a map) - this simulates a dataset created externally
+		recordsJSON := `{
+			"data": [
+				{
+					"id": "record-1",
+					"type": "dataset_records",
+					"attributes": {
+						"id": "record-1",
+						"input": {"question": "What is AI?"},
+						"expected_output": "Artificial Intelligence",
+						"metadata": "simple string metadata from UI",
+						"version": 1
+					}
+				}
+			]
+		}`
 		h := func(r *http.Request) *http.Response {
 			path := strings.TrimPrefix(r.URL.Path, "/evp_proxy/v2")
+
+			// v2 project-scoped records endpoint
+			if strings.HasPrefix(path, "/api/v2/llm-obs/v1/") && strings.Contains(path, "/records") && r.Method == http.MethodGet {
+				return &http.Response{
+					Status:     "200 OK",
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(recordsJSON)),
+					Request:    r,
+				}
+			}
+
 			if !strings.HasPrefix(path, "/api/unstable/llm-obs/v1") {
 				return nil
 			}
@@ -686,30 +719,6 @@ func TestDatasetPull(t *testing.T) {
 					StatusCode: http.StatusOK,
 					Header:     make(http.Header),
 					Body:       io.NopCloser(bytes.NewReader(respData)),
-					Request:    r,
-				}
-			case strings.Contains(path, "/datasets/") && strings.HasSuffix(path, "/records") && r.Method == http.MethodGet:
-				// Return records with string metadata (not a map) - this simulates a dataset created externally
-				rawJSON := `{
-					"data": [
-						{
-							"id": "record-1",
-							"type": "dataset_records",
-							"attributes": {
-								"id": "record-1",
-								"input": {"question": "What is AI?"},
-								"expected_output": "Artificial Intelligence",
-								"metadata": "simple string metadata from UI",
-								"version": 1
-							}
-						}
-					]
-				}`
-				return &http.Response{
-					Status:     "200 OK",
-					StatusCode: http.StatusOK,
-					Header:     make(http.Header),
-					Body:       io.NopCloser(strings.NewReader(rawJSON)),
 					Request:    r,
 				}
 			default:
@@ -742,6 +751,44 @@ func TestDatasetPull(t *testing.T) {
 
 		h := func(r *http.Request) *http.Response {
 			path := strings.TrimPrefix(r.URL.Path, "/evp_proxy/v2")
+
+			// v2 project-scoped records endpoint — simulate 3 pages
+			if strings.HasPrefix(path, "/api/v2/llm-obs/v1/") && strings.Contains(path, "/records") && r.Method == http.MethodGet {
+				requestCount++
+				var rawJSON string
+				switch requestCount {
+				case 1:
+					rawJSON = `{
+						"data": [
+							{"id":"record-1","type":"dataset_records","attributes":{"id":"record-1","input":{"question":"Q1"},"expected_output":"A1","metadata":{},"version":1}},
+							{"id":"record-2","type":"dataset_records","attributes":{"id":"record-2","input":{"question":"Q2"},"expected_output":"A2","metadata":{},"version":1}}
+						],
+						"meta": {"page": {"after": "cursor-page-2"}}
+					}`
+				case 2:
+					rawJSON = `{
+						"data": [
+							{"id":"record-3","type":"dataset_records","attributes":{"id":"record-3","input":{"question":"Q3"},"expected_output":"A3","metadata":{},"version":1}}
+						],
+						"meta": {"page": {"after": "cursor-page-3"}}
+					}`
+				default:
+					rawJSON = `{
+						"data": [
+							{"id":"record-4","type":"dataset_records","attributes":{"id":"record-4","input":{"question":"Q4"},"expected_output":"A4","metadata":{},"version":1}}
+						],
+						"meta": {}
+					}`
+				}
+				return &http.Response{
+					Status:     "200 OK",
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(rawJSON)),
+					Request:    r,
+				}
+			}
+
 			if !strings.HasPrefix(path, "/api/unstable/llm-obs/v1") {
 				return nil
 			}
@@ -773,90 +820,6 @@ func TestDatasetPull(t *testing.T) {
 					Body:       io.NopCloser(bytes.NewReader(respData)),
 					Request:    r,
 				}
-			case strings.Contains(path, "/datasets/") && strings.Contains(path, "/records") && r.Method == http.MethodGet:
-				// Simulate 3 pages of results
-				requestCount++
-				var rawJSON string
-
-				switch requestCount {
-				case 1:
-					// First page - has cursor for next page
-					rawJSON = `{
-						"data": [
-							{
-								"id": "record-1",
-								"type": "dataset_records",
-								"attributes": {
-									"id": "record-1",
-									"input": {"question": "Q1"},
-									"expected_output": "A1",
-									"metadata": {},
-									"version": 1
-								}
-							},
-							{
-								"id": "record-2",
-								"type": "dataset_records",
-								"attributes": {
-									"id": "record-2",
-									"input": {"question": "Q2"},
-									"expected_output": "A2",
-									"metadata": {},
-									"version": 1
-								}
-							}
-						],
-						"meta": {
-							"after": "cursor-page-2"
-						}
-					}`
-				case 2:
-					// Second page - has cursor for next page
-					rawJSON = `{
-						"data": [
-							{
-								"id": "record-3",
-								"type": "dataset_records",
-								"attributes": {
-									"id": "record-3",
-									"input": {"question": "Q3"},
-									"expected_output": "A3",
-									"metadata": {},
-									"version": 1
-								}
-							}
-						],
-						"meta": {
-							"after": "cursor-page-3"
-						}
-					}`
-				default:
-					// Third page - no cursor (last page)
-					rawJSON = `{
-						"data": [
-							{
-								"id": "record-4",
-								"type": "dataset_records",
-								"attributes": {
-									"id": "record-4",
-									"input": {"question": "Q4"},
-									"expected_output": "A4",
-									"metadata": {},
-									"version": 1
-								}
-							}
-						],
-						"meta": {}
-					}`
-				}
-
-				return &http.Response{
-					Status:     "200 OK",
-					StatusCode: http.StatusOK,
-					Header:     make(http.Header),
-					Body:       io.NopCloser(strings.NewReader(rawJSON)),
-					Request:    r,
-				}
 			default:
 				return nil
 			}
@@ -884,6 +847,77 @@ func TestDatasetPull(t *testing.T) {
 			assert.Equal(t, fmt.Sprintf("Q%d", i+1), inputMap["question"])
 			assert.Equal(t, fmt.Sprintf("A%d", i+1), rec.ExpectedOutput)
 		}
+	})
+	t.Run("pull-with-version-option", func(t *testing.T) {
+		var capturedQuery url.Values
+
+		h := func(r *http.Request) *http.Response {
+			path := strings.TrimPrefix(r.URL.Path, "/evp_proxy/v2")
+
+			// v2 project-scoped records endpoint — capture the query params
+			if strings.HasPrefix(path, "/api/v2/llm-obs/v1/") && strings.Contains(path, "/records") && r.Method == http.MethodGet {
+				capturedQuery = r.URL.Query()
+				rawJSON := `{
+					"data": [
+						{"id":"record-1","type":"dataset_records","attributes":{"id":"record-1","input":{"q":"v2 record"},"expected_output":"ans","version":2}}
+					],
+					"meta": {}
+				}`
+				return &http.Response{
+					Status:     "200 OK",
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(rawJSON)),
+					Request:    r,
+				}
+			}
+
+			if !strings.HasPrefix(path, "/api/unstable/llm-obs/v1") {
+				return nil
+			}
+			path = strings.TrimPrefix(path, "/api/unstable/llm-obs/v1")
+
+			switch {
+			case path == "/projects" && r.Method == http.MethodPost:
+				return handleMockProjectCreate(r)
+			case strings.Contains(path, "/datasets") && r.Method == http.MethodGet && !strings.Contains(path, "/records"):
+				response := llmobstransport.GetDatasetResponse{
+					Data: []llmobstransport.ResponseData[llmobstransport.DatasetView]{
+						{
+							ID:   "versioned-dataset-id",
+							Type: "datasets",
+							Attributes: llmobstransport.DatasetView{
+								ID:             "versioned-dataset-id",
+								Name:           "versioned-dataset",
+								CurrentVersion: 5,
+							},
+						},
+					},
+				}
+				respData, _ := json.Marshal(response)
+				return &http.Response{
+					Status:     "200 OK",
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(bytes.NewReader(respData)),
+					Request:    r,
+				}
+			default:
+				return nil
+			}
+		}
+
+		tt := testTracer(t, testtracer.WithMockResponses(h))
+		defer tt.Stop()
+
+		ds, err := Pull(context.Background(), "versioned-dataset", WithPullVersion(2))
+		require.NoError(t, err)
+		assert.NotNil(t, ds)
+		assert.Equal(t, 1, ds.Len())
+
+		// Confirm filter[version]=2 was sent in the records request
+		require.NotNil(t, capturedQuery, "records request should have been made")
+		assert.Equal(t, "2", capturedQuery.Get("filter[version]"))
 	})
 }
 
@@ -1191,6 +1225,12 @@ func createMockHandler() testtracer.MockResponseFunc {
 
 	return func(r *http.Request) *http.Response {
 		path := strings.TrimPrefix(r.URL.Path, "/evp_proxy/v2")
+
+		// v2 project-scoped records endpoint used by GetDatasetRecordsPage
+		if strings.HasPrefix(path, "/api/v2/llm-obs/v1/") && strings.Contains(path, "/datasets/") && strings.Contains(path, "/records") && r.Method == http.MethodGet {
+			return handleMockDatasetGet(r, state)
+		}
+
 		if !strings.HasPrefix(path, "/api/unstable/llm-obs/v1") {
 			return nil
 		}
@@ -1207,9 +1247,6 @@ func createMockHandler() testtracer.MockResponseFunc {
 			return handleMockDatasetBulkUpload(r)
 
 		case strings.Contains(path, "/datasets") && r.Method == http.MethodGet && !strings.Contains(path, "/records"):
-			return handleMockDatasetGet(r, state)
-
-		case strings.Contains(path, "/datasets/") && strings.HasSuffix(path, "/records") && r.Method == http.MethodGet:
 			return handleMockDatasetGet(r, state)
 
 		case strings.Contains(path, "/datasets") && r.Method == http.MethodPost:

--- a/llmobs/dataset/dataset_test.go
+++ b/llmobs/dataset/dataset_test.go
@@ -584,13 +584,8 @@ func TestDatasetPull(t *testing.T) {
 			"data": [
 				{
 					"id": "record-1",
-					"type": "dataset_records",
-					"attributes": {
-						"id": "record-1",
-						"input": "This is a simple string input, not a map",
-						"expected_output": "Some output",
-						"version": 1
-					}
+					"input": "This is a simple string input, not a map",
+					"expected_output": "Some output"
 				}
 			]
 		}`
@@ -665,14 +660,9 @@ func TestDatasetPull(t *testing.T) {
 			"data": [
 				{
 					"id": "record-1",
-					"type": "dataset_records",
-					"attributes": {
-						"id": "record-1",
-						"input": {"question": "What is AI?"},
-						"expected_output": "Artificial Intelligence",
-						"metadata": "simple string metadata from UI",
-						"version": 1
-					}
+					"input": {"question": "What is AI?"},
+					"expected_output": "Artificial Intelligence",
+					"metadata": "simple string metadata from UI"
 				}
 			]
 		}`
@@ -760,22 +750,22 @@ func TestDatasetPull(t *testing.T) {
 				case 1:
 					rawJSON = `{
 						"data": [
-							{"id":"record-1","type":"dataset_records","attributes":{"id":"record-1","input":{"question":"Q1"},"expected_output":"A1","metadata":{},"version":1}},
-							{"id":"record-2","type":"dataset_records","attributes":{"id":"record-2","input":{"question":"Q2"},"expected_output":"A2","metadata":{},"version":1}}
+							{"id":"record-1","input":{"question":"Q1"},"expected_output":"A1","metadata":{}},
+							{"id":"record-2","input":{"question":"Q2"},"expected_output":"A2","metadata":{}}
 						],
-						"meta": {"page": {"after": "cursor-page-2"}}
+						"meta": {"after": "cursor-page-2"}
 					}`
 				case 2:
 					rawJSON = `{
 						"data": [
-							{"id":"record-3","type":"dataset_records","attributes":{"id":"record-3","input":{"question":"Q3"},"expected_output":"A3","metadata":{},"version":1}}
+							{"id":"record-3","input":{"question":"Q3"},"expected_output":"A3","metadata":{}}
 						],
-						"meta": {"page": {"after": "cursor-page-3"}}
+						"meta": {"after": "cursor-page-3"}
 					}`
 				default:
 					rawJSON = `{
 						"data": [
-							{"id":"record-4","type":"dataset_records","attributes":{"id":"record-4","input":{"question":"Q4"},"expected_output":"A4","metadata":{},"version":1}}
+							{"id":"record-4","input":{"question":"Q4"},"expected_output":"A4","metadata":{}}
 						],
 						"meta": {}
 					}`
@@ -861,7 +851,7 @@ func TestDatasetPull(t *testing.T) {
 				capturedHeaders = r.Header.Clone()
 				rawJSON := `{
 					"data": [
-						{"id":"record-1","type":"dataset_records","attributes":{"id":"record-1","input":{"q":"v2 record"},"expected_output":"ans","version":2}}
+						{"id":"record-1","input":{"q":"v2 record"},"expected_output":"ans"}
 					],
 					"meta": {}
 				}`
@@ -1398,38 +1388,20 @@ func handleMockDatasetGet(r *http.Request, state *mockDatasetState) *http.Respon
 		}
 	}
 
-	// Check if this is a request for dataset records
+	// Check if this is a request for dataset records (v2 flat format)
 	if strings.Contains(r.URL.Path, "/records") {
-		recordsResponse := llmobstransport.GetDatasetRecordsResponse{
-			Data: []llmobstransport.ResponseData[llmobstransport.DatasetRecordView]{
-				{
-					ID:   "record-1",
-					Type: "dataset_records",
-					Attributes: llmobstransport.DatasetRecordView{
-						ID:             "record-1",
-						Input:          map[string]any{"question": "What is AI?"},
-						ExpectedOutput: "Artificial Intelligence",
-						Version:        1,
-					},
-				},
-				{
-					ID:   "record-2",
-					Type: "dataset_records",
-					Attributes: llmobstransport.DatasetRecordView{
-						ID:             "record-2",
-						Input:          map[string]any{"question": "What is ML?"},
-						ExpectedOutput: "Machine Learning",
-						Version:        1,
-					},
-				},
-			},
-		}
-		respData, _ := json.Marshal(recordsResponse)
+		rawJSON := `{
+			"data": [
+				{"id":"record-1","input":{"question":"What is AI?"},"expected_output":"Artificial Intelligence"},
+				{"id":"record-2","input":{"question":"What is ML?"},"expected_output":"Machine Learning"}
+			],
+			"meta": {}
+		}`
 		return &http.Response{
 			Status:     "200 OK",
 			StatusCode: http.StatusOK,
 			Header:     make(http.Header),
-			Body:       io.NopCloser(bytes.NewReader(respData)),
+			Body:       io.NopCloser(strings.NewReader(rawJSON)),
 			Request:    r,
 		}
 	}

--- a/llmobs/dataset/dataset_test.go
+++ b/llmobs/dataset/dataset_test.go
@@ -850,13 +850,15 @@ func TestDatasetPull(t *testing.T) {
 	})
 	t.Run("pull-with-version-option", func(t *testing.T) {
 		var capturedQuery url.Values
+		var capturedHeaders http.Header
 
 		h := func(r *http.Request) *http.Response {
 			path := strings.TrimPrefix(r.URL.Path, "/evp_proxy/v2")
 
-			// v2 project-scoped records endpoint — capture the query params
+			// v2 project-scoped records endpoint — capture the query params and headers
 			if strings.HasPrefix(path, "/api/v2/llm-obs/v1/") && strings.Contains(path, "/records") && r.Method == http.MethodGet {
 				capturedQuery = r.URL.Query()
+				capturedHeaders = r.Header.Clone()
 				rawJSON := `{
 					"data": [
 						{"id":"record-1","type":"dataset_records","attributes":{"id":"record-1","input":{"q":"v2 record"},"expected_output":"ans","version":2}}
@@ -918,6 +920,12 @@ func TestDatasetPull(t *testing.T) {
 		// Confirm filter[version]=2 was sent in the records request
 		require.NotNil(t, capturedQuery, "records request should have been made")
 		assert.Equal(t, "2", capturedQuery.Get("filter[version]"))
+
+		// Confirm the auth header was sent on the v2 records path
+		assert.Equal(t, "true", capturedHeaders.Get("X-Datadog-NeedsAppKey"), "auth header must be present on v2 records path")
+
+		// Confirm ds.Version() reflects the requested version, not the dataset's current_version (5)
+		assert.Equal(t, 2, ds.Version(), "Version() must return the pulled version, not the latest current_version")
 	})
 }
 

--- a/llmobs/dataset/dataset_test.go
+++ b/llmobs/dataset/dataset_test.go
@@ -916,6 +916,11 @@ func TestDatasetPull(t *testing.T) {
 
 		// Confirm ds.Version() reflects the requested version, not the dataset's current_version (5)
 		assert.Equal(t, 2, ds.Version(), "Version() must return the pulled version, not the latest current_version")
+
+		// Confirm each record's Version is stamped with the requested version
+		rec, ok := ds.Record(0)
+		require.True(t, ok)
+		assert.Equal(t, 2, rec.Version(), "record Version must equal the pulled snapshot version")
 	})
 }
 

--- a/llmobs/dataset/option.go
+++ b/llmobs/dataset/option.go
@@ -59,11 +59,13 @@ func WithCSVExpectedOutputColumns(cols []string) CreateOption {
 
 type pullConfig struct {
 	projectName string
+	version     *int
 }
 
 func defaultPullConfig() *pullConfig {
 	return &pullConfig{
 		projectName: "",
+		version:     nil,
 	}
 }
 
@@ -74,5 +76,15 @@ type PullOption func(cfg *pullConfig)
 func WithPullProjectName(projectName string) PullOption {
 	return func(cfg *pullConfig) {
 		cfg.projectName = projectName
+	}
+}
+
+// WithPullVersion requests a specific historical snapshot of the dataset.
+// By default Pull fetches the latest version. Pass a version number returned
+// by a previous Pull (via Dataset.Version) to retrieve an earlier snapshot.
+// This is useful for accumulating multiple dataset versions in a single eval run.
+func WithPullVersion(version int) PullOption {
+	return func(cfg *pullConfig) {
+		cfg.version = &version
 	}
 }


### PR DESCRIPTION
Shadow PR for CI jobs that cannot run on fork PRs.

Original PR: https://github.com/DataDog/dd-trace-go/pull/4814 (by @DD-youssef-ahmed)