### PR TITLE
fix(profiler): overlap execution trace with CPU profiling window

### DIFF
--- a/profiler/options.go
+++ b/profiler/options.go
@@ -490,10 +490,12 @@ type executionTraceConfig struct {
 	// Traces may be slightly larger than this limit due to flushing pending
 	// buffers at the end of tracing.
 	//
-	// We attempt to record for a full profiling period. The size limit of
-	// the trace is a better proxy for overhead (it scales with the number
-	// of events recorded) than duration, so we use that to decide when to
-	// stop tracing.
+	// We attempt to record for a full profiling period (or, when the trace
+	// is delayed to overlap the CPU profiling window, for the CPU profile
+	// duration -- see executionTraceSchedule). The size limit of the trace
+	// is a better proxy for overhead (it scales with the number of events
+	// recorded) than duration, so we use that to decide when to stop
+	// tracing.
 	Limit int
 
 	// warned is checked to prevent spamming a log every minute if the trace

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -178,6 +178,15 @@ var profileTypes = map[ProfileType]profileType{
 		Name:     "execution-trace",
 		Filename: "go.trace",
 		Collect: func(p *profiler) ([]byte, error) {
+			// Delay the trace so that it overlaps the CPU profiling
+			// window, otherwise timelines may lack CPU samples (see
+			// executionTraceSchedule).
+			_, cpuEnabled := p.cfg.types[CPUProfile]
+			delay, duration := executionTraceSchedule(p.cfg.period, p.cfg.cpuDuration, cpuEnabled, p.lastTrace.IsZero())
+			if delay > 0 && p.interruptibleSleep(delay) {
+				// The profiler was stopped while waiting to start the trace.
+				return nil, errProfilerStopped
+			}
 			p.lastTrace = time.Now()
 			buf := new(bytes.Buffer)
 			outBuf := new(bytes.Buffer)
@@ -188,7 +197,7 @@ var profileTypes = map[ProfileType]profileType{
 			traceLogCPUProfileRate(p.cfg.cpuProfileRate)
 			select {
 			case <-p.exit: // Profiling was stopped
-			case <-time.After(p.cfg.period): // The profiling cycle has ended
+			case <-time.After(duration): // The profiling cycle has ended
 			case <-lt.done: // The trace size limit was exceeded
 			}
 			trace.Stop()
@@ -205,6 +214,28 @@ var profileTypes = map[ProfileType]profileType{
 		Filename: "goroutineleak.pprof",
 		Collect:  collectGenericProfile("goroutineleak", goroutineLeakProfile),
 	},
+}
+
+// executionTraceSchedule decides when the execution trace should start and how
+// long it should run for. By default the trace covers the whole profiling
+// period (delay 0, duration period).
+//
+// When CPU profiling is enabled and runs for less than the full period, the CPU
+// profiler is scheduled at the end of the period (see the CPUProfile collector).
+// In that case an undelayed trace would start at the beginning of the period
+// and, for busy services, hit its size limit well before CPU profiling begins,
+// leaving timelines without any CPU samples. To keep CPU samples in timelines we
+// delay the trace by (period - cpuDuration) so that it overlaps the CPU
+// profiling window, and shorten its duration to cpuDuration so the cycle does
+// not overrun the profiling period.
+//
+// The first trace (firstTrace) is never delayed so that we still capture startup
+// activity, which is generally quite different from steady state.
+func executionTraceSchedule(period, cpuDuration time.Duration, cpuEnabled, firstTrace bool) (delay, duration time.Duration) {
+	if cpuEnabled && !firstTrace && cpuDuration > 0 && cpuDuration < period {
+		return period - cpuDuration, cpuDuration
+	}
+	return 0, period
 }
 
 // traceLogCPUProfileRate logs the cpuProfileRate to the execution tracer if

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -113,7 +113,9 @@ type profiler struct {
 	seq             uint64         // seq is the value of the profile_seq tag
 	pendingProfiles sync.WaitGroup // signal that profile collection is done, for stopping CPU profiling
 
-	// lastTrace is the last time an execution trace was collected
+	// lastTrace is the last time an execution trace was collected. Its zero
+	// value is also load-bearing: it is used (via IsZero) to detect the first
+	// trace, which is never delayed. See executionTraceSchedule.
 	lastTrace time.Time
 }
 

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -580,6 +580,89 @@ func assertContainsCPUProfileRateLog(t *testing.T, traceData []byte, cpuProfileR
 	assert.True(t, bytes.Contains(traceData, fmt.Appendf(nil, "%d", cpuProfileRate)))
 }
 
+func TestExecutionTraceSchedule(t *testing.T) {
+	const period = 2 * time.Minute
+	for _, tc := range []struct {
+		name         string
+		period       time.Duration
+		cpuDuration  time.Duration
+		cpuEnabled   bool
+		firstTrace   bool
+		wantDelay    time.Duration
+		wantDuration time.Duration
+	}{
+		{
+			// Default schedule: CPU profiling covers the whole period, so
+			// the trace already overlaps it and must not be delayed.
+			name:         "cpu-duration-equals-period",
+			period:       period,
+			cpuDuration:  period,
+			cpuEnabled:   true,
+			wantDelay:    0,
+			wantDuration: period,
+		},
+		{
+			// CPU profiling is scheduled at the end of the period, so the
+			// trace is delayed to overlap it and shortened to cpuDuration.
+			name:         "cpu-shorter-than-period-delays-trace",
+			period:       period,
+			cpuDuration:  time.Minute,
+			cpuEnabled:   true,
+			wantDelay:    time.Minute,
+			wantDuration: time.Minute,
+		},
+		{
+			// The first trace is never delayed so that we still capture
+			// startup activity.
+			name:         "first-trace-not-delayed",
+			period:       period,
+			cpuDuration:  time.Minute,
+			cpuEnabled:   true,
+			firstTrace:   true,
+			wantDelay:    0,
+			wantDuration: period,
+		},
+		{
+			// With CPU profiling disabled there is no window to overlap, so
+			// the trace covers the whole period as before.
+			name:         "cpu-disabled-not-delayed",
+			period:       period,
+			cpuDuration:  time.Minute,
+			cpuEnabled:   false,
+			wantDelay:    0,
+			wantDuration: period,
+		},
+		{
+			// A zero cpuDuration must not produce a full-period delay
+			// followed by a zero-duration (empty) trace; fall back to the
+			// full-period trace.
+			name:         "zero-cpu-duration-not-delayed",
+			period:       period,
+			cpuDuration:  0,
+			cpuEnabled:   true,
+			wantDelay:    0,
+			wantDuration: period,
+		},
+		{
+			// cpuDuration is clamped to period by newProfiler, but guard
+			// the helper in isolation: a cpuDuration > period must never
+			// yield a negative delay.
+			name:         "cpu-duration-greater-than-period-not-delayed",
+			period:       period,
+			cpuDuration:  2 * period,
+			cpuEnabled:   true,
+			wantDelay:    0,
+			wantDuration: period,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			delay, duration := executionTraceSchedule(tc.period, tc.cpuDuration, tc.cpuEnabled, tc.firstTrace)
+			assert.Equal(t, tc.wantDelay, delay, "delay")
+			assert.Equal(t, tc.wantDuration, duration, "duration")
+		})
+	}
+}
+
 func TestExecutionTraceMisconfiguration(t *testing.T) {
 	rl := new(log.RecordLogger)
 	defer log.UseLogger(rl)()


### PR DESCRIPTION
### What does this PR do?

Delays the runtime execution trace so that it overlaps the CPU profiling window, ensuring profiling **timelines** retain their on-CPU breakdown.

Today the CPU profile is scheduled at the *end* of the profiling period (it sleeps `period - cpuDuration`, then profiles for `cpuDuration`), while the execution trace starts at the *beginning* of the period and stops when it either reaches the period end or hits its size limit (5MB). For busy services the trace fills 5MB within seconds and stops long before CPU profiling begins, so the trace contains no `traceEvCPUSample` events and timelines show no on-CPU time.

This change delays `trace.Start` by `period - cpuDuration` (and shortens the trace to `cpuDuration`) so the trace window lands inside the CPU profiling window. The total trace goroutine wall time stays `delay + duration == period`, so the cycle does not overrun the period ticker.

The scheduling decision is extracted into a small pure helper, `executionTraceSchedule`, which is unit-tested across all branches.

Behavior is unchanged when:
- CPU profiling covers the whole period (`cpuDuration == period`, the default) — `(delay 0, duration period)`.
- CPU profiling is disabled.
- It is the first trace — never delayed, so we still capture startup activity.
- `cpuDuration <= 0` — falls back to a full-period trace (guards against a full-period delay followed by an empty trace).

### Motivation

When CPUDuration != Period, the execution tracer no longer overlaps CPU profiling, so timelines lose their on-CPU breakdown. This restores CPU samples in timelines without changing CPU sample rate, CPU profile duration, or upload frequency.

Go records CPU samples into the execution trace whenever the CPU profiler and execution tracer are both active at sample time; arranging the overlap is the supported way to get those samples (see golang/go#60701, golang/go#66679).

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality (`TestExecutionTraceSchedule` covers all scheduling branches incl. zero/oversized `cpuDuration`).
- [ ] System-Tests covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors (`make lint`).
- [ ] New code doesn't break existing tests (`make test`).
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date (`make generate`).
- [ ] Non-trivial go.mod changes reviewed by @DataDog/dd-trace-go-guild (n/a — no go.mod changes).

### Notes

- Pure-helper logic verified locally; full `go test ./profiler/` should be run in CI (local sandbox cannot write the Go module cache).
- One thing worth a visual check before/after merge: since the trace now overlaps the end-of-period CPU window (which exists to capture the profiler's own post-processing), the profiler's post-processing goroutines may appear in timelines. Expected to be minor.
