### PR TITLE
feat(profiler): start the first CPU profile at the beginning of the period

### DIFF
--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -91,10 +91,17 @@ var profileTypes = map[ProfileType]profileType{
 		Collect: func(p *profiler) ([]byte, error) {
 			var buf bytes.Buffer
 			var outBuf bytes.Buffer
-			// Start the CPU profiler at the end of the profiling
-			// period so that we're sure to capture the CPU usage of
-			// this library, which mostly happens at the end
-			p.interruptibleSleep(p.cfg.period - p.cfg.cpuDuration)
+			// Normally the CPU profiler is scheduled at the end of the
+			// profiling period so that we're sure to capture the CPU usage
+			// of this library, which mostly happens at the end. The first
+			// CPU profile is instead started at the beginning of the period
+			// so that it overlaps the first (also-undelayed) execution trace
+			// and the first timeline gets on-CPU samples. See
+			// cpuProfileSchedule.
+			firstCPU := p.lastCPUProfile.IsZero()
+			p.lastCPUProfile = time.Now()
+			delay, finishLast := cpuProfileSchedule(p.cfg.period, p.cfg.cpuDuration, firstCPU)
+			p.interruptibleSleep(delay)
 			if p.cfg.cpuProfileRate != 0 {
 				// The profile has to be set each time before
 				// profiling is started. Otherwise,
@@ -110,8 +117,12 @@ var profileTypes = map[ProfileType]profileType{
 
 			// We want the CPU profiler to finish last so that it can
 			// properly record all of our profile processing work for
-			// the other profile types
-			p.pendingProfiles.Wait()
+			// the other profile types. The first CPU profile is an
+			// exception: it stops after cpuDuration so that its window
+			// stays equal to cpuDuration (see cpuProfileSchedule).
+			if finishLast {
+				p.pendingProfiles.Wait()
+			}
 			pprof.StopCPUProfile()
 
 			c := p.compressors[CPUProfile]
@@ -214,6 +225,26 @@ var profileTypes = map[ProfileType]profileType{
 		Filename: "goroutineleak.pprof",
 		Collect:  collectGenericProfile("goroutineleak", goroutineLeakProfile),
 	},
+}
+
+// cpuProfileSchedule decides when CPU profiling should start within the period
+// and whether it should finish last. By default CPU profiling is scheduled at
+// the end of the period (delay = period - cpuDuration) and finishes last, so
+// that it captures this library's own post-processing work for the other
+// profile types.
+//
+// On the first CPU profile, when CPU profiling covers less than the full period,
+// we instead start it at the beginning of the period (delay 0) and stop it after
+// cpuDuration (finishLast = false), so that it overlaps the first (also-undelayed)
+// execution trace and the first timeline gets on-CPU samples. The first profile
+// still respects cpuDuration, so its window and sample count match every other
+// cycle; the trade-off is that it does not capture this library's own
+// post-processing overhead (subsequent cycles still do).
+func cpuProfileSchedule(period, cpuDuration time.Duration, firstCPU bool) (delay time.Duration, finishLast bool) {
+	if firstCPU && cpuDuration > 0 && cpuDuration < period {
+		return 0, false
+	}
+	return max(0, period-cpuDuration), true
 }
 
 // executionTraceSchedule decides when the execution trace should start and how

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -117,6 +117,11 @@ type profiler struct {
 	// value is also load-bearing: it is used (via IsZero) to detect the first
 	// trace, which is never delayed. See executionTraceSchedule.
 	lastTrace time.Time
+
+	// lastCPUProfile is the last time a CPU profile was collected. Its zero
+	// value is load-bearing: it is used (via IsZero) to detect the first CPU
+	// profile, which is scheduled differently. See cpuProfileSchedule.
+	lastCPUProfile time.Time
 }
 
 func (p *profiler) lookupProfile(name string, w io.Writer, debug int) error {

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -663,6 +663,79 @@ func TestExecutionTraceSchedule(t *testing.T) {
 	}
 }
 
+func TestCPUProfileSchedule(t *testing.T) {
+	const period = 2 * time.Minute
+	for _, tc := range []struct {
+		name           string
+		cpuDuration    time.Duration
+		firstCPU       bool
+		wantDelay      time.Duration
+		wantFinishLast bool
+	}{
+		{
+			// Default schedule: CPU covers the whole period, so it already
+			// starts at t=0 and finishes last on every cycle, including the
+			// first. No special-casing.
+			name:           "cpu-duration-equals-period",
+			cpuDuration:    period,
+			wantDelay:      0,
+			wantFinishLast: true,
+		},
+		{
+			// Steady-state cycle with a shorter CPU duration: scheduled at
+			// the end of the period and finishes last.
+			name:           "cpu-shorter-than-period-steady-state",
+			cpuDuration:    time.Minute,
+			wantDelay:      time.Minute,
+			wantFinishLast: true,
+		},
+		{
+			// First CPU profile with a shorter CPU duration: start at t=0
+			// and stop after cpuDuration (do not finish last) so it overlaps
+			// the first execution trace while still respecting cpuDuration.
+			name:           "first-cpu-shorter-than-period",
+			cpuDuration:    time.Minute,
+			firstCPU:       true,
+			wantDelay:      0,
+			wantFinishLast: false,
+		},
+		{
+			// First cycle but CPU covers the whole period: no special-casing,
+			// behaves like the default.
+			name:           "first-cpu-duration-equals-period",
+			cpuDuration:    period,
+			firstCPU:       true,
+			wantDelay:      0,
+			wantFinishLast: true,
+		},
+		{
+			// A degenerate zero cpuDuration falls back to normal scheduling
+			// rather than the first-cycle special case.
+			name:           "zero-cpu-duration",
+			cpuDuration:    0,
+			firstCPU:       true,
+			wantDelay:      period,
+			wantFinishLast: true,
+		},
+		{
+			// cpuDuration is clamped to period by newProfiler, but guard the
+			// helper in isolation: a cpuDuration > period must never yield a
+			// negative delay.
+			name:           "cpu-duration-greater-than-period",
+			cpuDuration:    2 * period,
+			wantDelay:      0,
+			wantFinishLast: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			delay, finishLast := cpuProfileSchedule(period, tc.cpuDuration, tc.firstCPU)
+			assert.Equal(t, tc.wantDelay, delay, "delay")
+			assert.Equal(t, tc.wantFinishLast, finishLast, "finishLast")
+			assert.GreaterOrEqual(t, delay, time.Duration(0), "delay must be non-negative")
+		})
+	}
+}
+
 func TestExecutionTraceMisconfiguration(t *testing.T) {
 	rl := new(log.RecordLogger)
 	defer log.UseLogger(rl)()


### PR DESCRIPTION
> **Stacked on #4839** (base branch `nayef/profiler-delay-execution-trace`). Review/merge that one first; this PR's diff shows only the CPU-scheduling change.

### What does this PR do?

Starts the **first** CPU profile at the beginning of the profiling period (instead of the end) so the **first/startup timeline** gets on-CPU samples.

PR #4839 made the execution trace overlap the end-of-period CPU window for steady-state cycles, but deliberately leaves the **first** trace undelayed so it still captures startup activity. That left a gap: for services where `cpuDuration < period`, the first CPU profile runs at the end of the period while the first trace runs at the start (and, for busy services, hits its 5MB size limit within seconds), so the first timeline has no on-CPU breakdown.

This change introduces `cpuProfileSchedule(period, cpuDuration, firstCPU)`:
- **First CPU profile** with `cpuDuration < period` → start at `t=0`, stop after `cpuDuration` (do **not** finish last). It overlaps the undelayed first trace, so the first timeline gets CPU samples, while still respecting `cpuDuration` (same window/sample-count/cost as every other cycle).
- **Everything else** (steady-state cycles, the default `cpuDuration == period`, degenerate `cpuDuration <= 0` or `> period`) → unchanged: scheduled at the end of the period and finishes last.

### Motivation

Completes the timeline fix from #4839 for the first/startup profile. Under (`period=2m`, `cpuDuration=1m`) the startup timeline would otherwise show no on-CPU time.

### Design notes / trade-offs

- **Why start-at-`t=0` *and* stop-after-`cpuDuration` (not just start early):** the CPU collector normally `pendingProfiles.Wait()`s so it finishes last and captures this library's own end-of-period post-processing. If we only skipped the initial sleep, that `Wait()` would stretch the first CPU profile across the **whole** period. Stopping after `cpuDuration` keeps the first profile's window == `cpuDuration` (consistent cost/semantics with every cycle).
- **Trade-off:** the first CPU profile does not capture this library's own end-of-period post-processing overhead. Subsequent cycles still do.
- **Concurrency:** skipping `pendingProfiles.Wait()` on the first cycle is WaitGroup-safe — non-CPU collectors still `defer pendingProfiles.Done()`, and the outer `wg.Wait()` still bounds the cycle.
- **First-cycle detection:** uses a dedicated `lastCPUProfile` field (mirrors `lastTrace`) because `p.seq` is already incremented by the time `Collect` runs.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality (`TestCPUProfileSchedule` covers steady-state, first-cycle, default `cpuDuration==period`, zero, and `>period`).
- [ ] System-Tests covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors (`make lint`).
- [ ] New code doesn't break existing tests (`make test`).
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date (`make generate`).
- [ ] Non-trivial go.mod changes reviewed by @DataDog/dd-trace-go-guild (n/a — no go.mod changes).

### Notes

- Pure-helper logic verified locally; full `go test ./profiler/` should run in CI (local sandbox cannot write the Go module cache).
