### PR TITLE
chore: remove deprecated/unused X-Datadog-NeedsAppKey

### DIFF
--- a/internal/llmobs/transport/transport.go
+++ b/internal/llmobs/transport/transport.go
@@ -219,9 +219,6 @@ func (c *Transport) request(ctx context.Context, method, path, subdomain string,
 			if c.agentless && c.appKey != "" {
 				// In agentless mode, set the app key header if available
 				req.Header.Set("DD-APPLICATION-KEY", c.appKey)
-			} else if !c.agentless {
-				// In agent mode, always set the NeedsAppKey header (app key is ignored)
-				req.Header.Set("X-Datadog-NeedsAppKey", "true")
 			}
 		}
 

--- a/internal/llmobs/transport/transport.go
+++ b/internal/llmobs/transport/transport.go
@@ -74,6 +74,7 @@ type Transport struct {
 	site           string
 	agentURL       *url.URL
 	agentless      bool
+	apiKey         string
 	appKey         string
 }
 
@@ -104,6 +105,7 @@ func New(cfg *config.Config) *Transport {
 		site:           site,
 		agentURL:       cfg.TracerConfig.AgentURL,
 		agentless:      cfg.ResolvedAgentlessEnabled,
+		apiKey:         cfg.TracerConfig.APIKey,
 		appKey:         cfg.TracerConfig.APPKey,
 	}
 }
@@ -182,6 +184,11 @@ func (c *Transport) request(ctx context.Context, method, path, subdomain string,
 		timeout = defaultTimeout
 	}
 	urlStr := c.baseURL(subdomain) + path
+	// DNE endpoints (datasets/experiments) always go direct to the API — agent mode not supported.
+	isDNE := strings.HasPrefix(path, endpointPrefixDNE) || strings.HasPrefix(path, endpointPrefixDNEStable)
+	if isDNE {
+		urlStr = fmt.Sprintf("https://%s.%s", subdomain, c.site) + path
+	}
 	backoffStrat := defaultBackoffStrategy()
 
 	doRequest := func() (result requestResult, err error) {
@@ -210,14 +217,16 @@ func (c *Transport) request(ctx context.Context, method, path, subdomain string,
 		for key, val := range c.defaultHeaders {
 			req.Header.Set(key, val)
 		}
-		if !c.agentless {
+		if !c.agentless && !isDNE {
 			req.Header.Set(headerEVPSubdomain, subdomain)
 		}
 
-		// Set headers for datasets and experiments endpoints (both unstable and stable v2 paths)
-		if strings.HasPrefix(path, endpointPrefixDNE) || strings.HasPrefix(path, endpointPrefixDNEStable) {
-			if c.agentless && c.appKey != "" {
-				// In agentless mode, set the app key header if available
+		// DNE endpoints always go direct to the API; set auth headers regardless of agentless mode.
+		if isDNE {
+			if c.apiKey != "" {
+				req.Header.Set("DD-API-KEY", c.apiKey)
+			}
+			if c.appKey != "" {
 				req.Header.Set("DD-APPLICATION-KEY", c.appKey)
 			}
 		}

--- a/llmobs/dataset/dataset.go
+++ b/llmobs/dataset/dataset.go
@@ -28,7 +28,8 @@ import (
 var (
 	errRequiresProjectName = errors.New(`a project name must be provided for the dataset, either configured via the DD_LLMOBS_PROJECT_NAME
 environment variable, using the global tracer.WithLLMObsProjectName option, or dataset.WithProjectName option`)
-	errRequiresAppKey = errors.New(`an app key must be provided for the dataset in agentless mode configured via the DD_APP_KEY environment variable`)
+	errRequiresAPIKey = errors.New(`an API key must be provided for the dataset, configured via the DD_API_KEY environment variable`)
+	errRequiresAppKey = errors.New(`an app key must be provided for the dataset, configured via the DD_APP_KEY environment variable`)
 )
 
 const (
@@ -116,8 +117,11 @@ func Create(ctx context.Context, name string, records []Record, opts ...CreateOp
 	}
 
 	// Validate required fields
-	if ll.Config.ResolvedAgentlessEnabled && ll.Config.TracerConfig.APPKey == "" {
+	if ll.Config.TracerConfig.APPKey == "" {
 		return nil, errRequiresAppKey
+	}
+	if ll.Config.TracerConfig.APIKey == "" {
+		return nil, errRequiresAPIKey
 	}
 
 	// Determine project name: option takes precedence over global config
@@ -172,8 +176,11 @@ func CreateFromCSV(ctx context.Context, name, csvPath string, inputCols []string
 	}
 
 	// Validate required fields
-	if ll.Config.ResolvedAgentlessEnabled && ll.Config.TracerConfig.APPKey == "" {
+	if ll.Config.TracerConfig.APPKey == "" {
 		return nil, errRequiresAppKey
+	}
+	if ll.Config.TracerConfig.APIKey == "" {
+		return nil, errRequiresAPIKey
 	}
 
 	// Determine project name: option takes precedence over global config
@@ -305,8 +312,11 @@ func Pull(ctx context.Context, name string, opts ...PullOption) (*Dataset, error
 	}
 
 	// Validate required fields
-	if ll.Config.ResolvedAgentlessEnabled && ll.Config.TracerConfig.APPKey == "" {
+	if ll.Config.TracerConfig.APPKey == "" {
 		return nil, errRequiresAppKey
+	}
+	if ll.Config.TracerConfig.APIKey == "" {
+		return nil, errRequiresAPIKey
 	}
 
 	// Determine project name: option takes precedence over global config

--- a/llmobs/dataset/dataset_test.go
+++ b/llmobs/dataset/dataset_test.go
@@ -115,52 +115,90 @@ func TestDatasetCreation(t *testing.T) {
 	t.Run("missing-dd-app-key-agentless", func(t *testing.T) {
 		t.Setenv("DD_API_KEY", testAPIKey)
 		t.Setenv("DD_APP_KEY", "")
-
-		// Use agentless mode to trigger app key requirement
-		tt := testTracer(t, testtracer.WithTracerStartOpts(tracer.WithLLMObsAgentlessEnabled(true)))
+		// Start tracer directly (without testTracer) so that DD_APP_KEY stays unset.
+		tt := testtracer.Start(t,
+			testtracer.WithTracerStartOpts(
+				tracer.WithLLMObsEnabled(true),
+				tracer.WithLLMObsMLApp("test-app"),
+				tracer.WithLLMObsProjectName("test-project"),
+				tracer.WithLLMObsAgentlessEnabled(true),
+				tracer.WithService("test-service"),
+				tracer.WithLogStartup(false),
+			),
+			testtracer.WithAgentInfoResponse(testtracer.AgentInfo{
+				Endpoints: []string{"/evp_proxy/v2/"},
+			}),
+			testtracer.WithMockResponses(createMockHandler()),
+		)
 		defer tt.Stop()
-
-		records := []Record{
-			{
-				Input:          map[string]any{"question": "test"},
-				ExpectedOutput: "answer",
-			},
-		}
 
 		_, err := Create(
 			context.Background(),
 			"test-dataset",
-			records,
+			[]Record{{Input: map[string]any{"question": "test"}, ExpectedOutput: "answer"}},
 		)
 
-		// Should fail - datasets require DD_APP_KEY in agentless mode
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "an app key must be provided")
 	})
 	t.Run("missing-dd-app-key-agent-mode", func(t *testing.T) {
+		// DD_APP_KEY is always required — agent mode no longer supported for datasets.
+		// Start tracer directly (without testTracer) to avoid default app key being set.
+		t.Setenv("DD_API_KEY", testAPIKey)
 		t.Setenv("DD_APP_KEY", "")
-
-		// Use agent mode - app key should not be required
-		tt := testTracer(t, testtracer.WithTracerStartOpts(tracer.WithLLMObsAgentlessEnabled(false)))
+		tt := testtracer.Start(t,
+			testtracer.WithTracerStartOpts(
+				tracer.WithLLMObsEnabled(true),
+				tracer.WithLLMObsMLApp("test-app"),
+				tracer.WithLLMObsProjectName("test-project"),
+				tracer.WithLLMObsAgentlessEnabled(false),
+				tracer.WithService("test-service"),
+				tracer.WithLogStartup(false),
+			),
+			testtracer.WithAgentInfoResponse(testtracer.AgentInfo{
+				Endpoints: []string{"/evp_proxy/v2/"},
+			}),
+			testtracer.WithMockResponses(createMockHandler()),
+		)
 		defer tt.Stop()
 
-		records := []Record{
-			{
-				Input:          map[string]any{"question": "test"},
-				ExpectedOutput: "answer",
-			},
-		}
-
-		ds, err := Create(
+		_, err := Create(
 			context.Background(),
 			"test-dataset",
-			records,
+			[]Record{{Input: map[string]any{"question": "test"}, ExpectedOutput: "answer"}},
 		)
 
-		// Should succeed - app key not required in agent mode
-		require.NoError(t, err)
-		assert.NotNil(t, ds)
-		assert.Equal(t, "test-dataset", ds.Name())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "an app key must be provided")
+	})
+	t.Run("missing-dd-api-key-agent-mode", func(t *testing.T) {
+		// DD_API_KEY is always required because datasets go directly to the API.
+		t.Setenv("DD_API_KEY", "")
+		t.Setenv("DD_APP_KEY", testAppKey)
+		tt := testtracer.Start(t,
+			testtracer.WithTracerStartOpts(
+				tracer.WithLLMObsEnabled(true),
+				tracer.WithLLMObsMLApp("test-app"),
+				tracer.WithLLMObsProjectName("test-project"),
+				tracer.WithLLMObsAgentlessEnabled(false),
+				tracer.WithService("test-service"),
+				tracer.WithLogStartup(false),
+			),
+			testtracer.WithAgentInfoResponse(testtracer.AgentInfo{
+				Endpoints: []string{"/evp_proxy/v2/"},
+			}),
+			testtracer.WithMockResponses(createMockHandler()),
+		)
+		defer tt.Stop()
+
+		_, err := Create(
+			context.Background(),
+			"test-dataset",
+			[]Record{{Input: map[string]any{"question": "test"}, ExpectedOutput: "answer"}},
+		)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "an API key must be provided")
 	})
 	t.Run("missing-project-name", func(t *testing.T) {
 
@@ -553,30 +591,78 @@ func TestDatasetPull(t *testing.T) {
 	t.Run("pull-missing-dd-app-key-agentless", func(t *testing.T) {
 		t.Setenv("DD_API_KEY", testAPIKey)
 		t.Setenv("DD_APP_KEY", "")
-
-		// Use agentless mode to trigger app key requirement
-		tt := testTracer(t, testtracer.WithTracerStartOpts(tracer.WithLLMObsAgentlessEnabled(true)))
+		// Start tracer directly (without testTracer) so that DD_APP_KEY stays unset.
+		tt := testtracer.Start(t,
+			testtracer.WithTracerStartOpts(
+				tracer.WithLLMObsEnabled(true),
+				tracer.WithLLMObsMLApp("test-app"),
+				tracer.WithLLMObsProjectName("test-project"),
+				tracer.WithLLMObsAgentlessEnabled(true),
+				tracer.WithService("test-service"),
+				tracer.WithLogStartup(false),
+			),
+			testtracer.WithAgentInfoResponse(testtracer.AgentInfo{
+				Endpoints: []string{"/evp_proxy/v2/"},
+			}),
+			testtracer.WithMockResponses(createMockHandler()),
+		)
 		defer tt.Stop()
 
 		_, err := Pull(context.Background(), "existing-dataset")
 
-		// Should fail - datasets require DD_APP_KEY in agentless mode
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "an app key must be provided")
 	})
 	t.Run("pull-missing-dd-app-key-agent-mode", func(t *testing.T) {
+		// DD_APP_KEY is always required — agent mode no longer supported for datasets.
+		// Start tracer directly (without testTracer) to avoid default app key being set.
+		t.Setenv("DD_API_KEY", testAPIKey)
 		t.Setenv("DD_APP_KEY", "")
-
-		// Use agent mode - app key should not be required
-		tt := testTracer(t, testtracer.WithTracerStartOpts(tracer.WithLLMObsAgentlessEnabled(false)))
+		tt := testtracer.Start(t,
+			testtracer.WithTracerStartOpts(
+				tracer.WithLLMObsEnabled(true),
+				tracer.WithLLMObsMLApp("test-app"),
+				tracer.WithLLMObsProjectName("test-project"),
+				tracer.WithLLMObsAgentlessEnabled(false),
+				tracer.WithService("test-service"),
+				tracer.WithLogStartup(false),
+			),
+			testtracer.WithAgentInfoResponse(testtracer.AgentInfo{
+				Endpoints: []string{"/evp_proxy/v2/"},
+			}),
+			testtracer.WithMockResponses(createMockHandler()),
+		)
 		defer tt.Stop()
 
-		ds, err := Pull(context.Background(), "existing-dataset")
+		_, err := Pull(context.Background(), "existing-dataset")
 
-		// Should succeed - app key not required in agent mode
-		require.NoError(t, err)
-		assert.NotNil(t, ds)
-		assert.Equal(t, "existing-dataset", ds.Name())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "an app key must be provided")
+	})
+	t.Run("pull-missing-dd-api-key-agent-mode", func(t *testing.T) {
+		// DD_API_KEY is always required because datasets go directly to the API.
+		t.Setenv("DD_API_KEY", "")
+		t.Setenv("DD_APP_KEY", testAppKey)
+		tt := testtracer.Start(t,
+			testtracer.WithTracerStartOpts(
+				tracer.WithLLMObsEnabled(true),
+				tracer.WithLLMObsMLApp("test-app"),
+				tracer.WithLLMObsProjectName("test-project"),
+				tracer.WithLLMObsAgentlessEnabled(false),
+				tracer.WithService("test-service"),
+				tracer.WithLogStartup(false),
+			),
+			testtracer.WithAgentInfoResponse(testtracer.AgentInfo{
+				Endpoints: []string{"/evp_proxy/v2/"},
+			}),
+			testtracer.WithMockResponses(createMockHandler()),
+		)
+		defer tt.Stop()
+
+		_, err := Pull(context.Background(), "existing-dataset")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "an API key must be provided")
 	})
 	t.Run("pull-dataset-with-non-map-input", func(t *testing.T) {
 		// Return records with string input (not a map) - this simulates a dataset created externally
@@ -1046,17 +1132,19 @@ func TestDDAppKeyHeader(t *testing.T) {
 	})
 	t.Run("dd-app-key-header-agent-mode", func(t *testing.T) {
 		var capturedHeaders http.Header
+		var capturedPath string
 		h := func(r *http.Request) *http.Response {
 			path := strings.TrimPrefix(r.URL.Path, "/evp_proxy/v2")
 
 			if strings.Contains(path, "/api/unstable/llm-obs/v1/datasets") {
 				capturedHeaders = r.Header.Clone()
+				capturedPath = r.URL.Path
 			}
 			// Let the default dataset mock handler handle the response
 			return createMockHandler()(r)
 		}
 
-		// Force agent mode explicitly
+		// Even in agent mode, DNE endpoints always go direct to the API with the app key header.
 		tt := testTracer(t,
 			testtracer.WithTracerStartOpts(
 				tracer.WithLLMObsAgentlessEnabled(false),
@@ -1082,31 +1170,29 @@ func TestDDAppKeyHeader(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NotNil(t, capturedHeaders, "No headers were captured")
-		assert.Empty(t, capturedHeaders.Get("DD-APPLICATION-KEY"), "DD-APPLICATION-KEY header should not be set in agent mode")
+		assert.NotContains(t, capturedPath, "/evp_proxy/v2", "DNE endpoints should bypass the EVP proxy path")
+		assert.Empty(t, capturedHeaders.Get("X-Datadog-EVP-Subdomain"), "DNE endpoints should not set the EVP proxy header")
+		assert.Equal(t, testAPIKey, capturedHeaders.Get("DD-API-KEY"), "DD-API-KEY header should be set: DNE endpoints always use direct API regardless of agent mode")
+		assert.Equal(t, testAppKey, capturedHeaders.Get("DD-APPLICATION-KEY"), "DD-APPLICATION-KEY header should be set: DNE endpoints always use direct API regardless of agent mode")
 	})
-	t.Run("needs-app-key-header-agent-mode", func(t *testing.T) {
-		t.Setenv("DD_APP_KEY", "") // No app key provided
-
-		var capturedHeaders http.Header
-		h := func(r *http.Request) *http.Response {
-			path := strings.TrimPrefix(r.URL.Path, "/evp_proxy/v2")
-
-			if strings.Contains(path, "/api/unstable/llm-obs/v1/datasets") {
-				capturedHeaders = r.Header.Clone()
-			}
-			// Let the default dataset mock handler handle the response
-			return createMockHandler()(r)
-		}
-
-		// Force agent mode explicitly
-		tt := testTracer(t,
+	t.Run("no-app-key-returns-error", func(t *testing.T) {
+		// DD_APP_KEY is always required — agent mode no longer supported for datasets.
+		// Start tracer directly (without testTracer) to avoid default app key being set.
+		t.Setenv("DD_API_KEY", testAPIKey)
+		t.Setenv("DD_APP_KEY", "")
+		tt := testtracer.Start(t,
 			testtracer.WithTracerStartOpts(
+				tracer.WithLLMObsEnabled(true),
+				tracer.WithLLMObsMLApp("test-app"),
+				tracer.WithLLMObsProjectName("test-project"),
 				tracer.WithLLMObsAgentlessEnabled(false),
+				tracer.WithService("test-service"),
+				tracer.WithLogStartup(false),
 			),
 			testtracer.WithAgentInfoResponse(testtracer.AgentInfo{
-				Endpoints: []string{"/evp_proxy/v2/"}, // Agent supports evp_proxy
+				Endpoints: []string{"/evp_proxy/v2/"},
 			}),
-			testtracer.WithMockResponses(h),
+			testtracer.WithMockResponses(createMockHandler()),
 		)
 		defer tt.Stop()
 
@@ -1116,10 +1202,8 @@ func TestDDAppKeyHeader(t *testing.T) {
 				ExpectedOutput: "answer",
 			},
 		})
-		require.NoError(t, err)
-
-		require.NotNil(t, capturedHeaders, "No headers were captured")
-		assert.Empty(t, capturedHeaders.Get("DD-APPLICATION-KEY"), "DD-APPLICATION-KEY header should not be set when no app key is provided")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "an app key must be provided")
 	})
 }
 
@@ -1194,6 +1278,8 @@ func generateRandomRecords(n int) []*Record {
 }
 
 func testTracer(t *testing.T, opts ...testtracer.Option) *testtracer.TestTracer {
+	t.Setenv("DD_API_KEY", testAPIKey)
+	t.Setenv("DD_APP_KEY", testAppKey)
 	tracerOpts := []tracer.StartOption{
 		tracer.WithLLMObsEnabled(true),
 		tracer.WithLLMObsMLApp("test-app"),

--- a/llmobs/dataset/dataset_test.go
+++ b/llmobs/dataset/dataset_test.go
@@ -1087,7 +1087,6 @@ func TestDDAppKeyHeader(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NotNil(t, capturedHeaders, "No headers were captured")
-		assert.Equal(t, "true", capturedHeaders.Get("X-Datadog-NeedsAppKey"), "X-Datadog-NeedsAppKey header should always be set in agent mode")
 		assert.Empty(t, capturedHeaders.Get("DD-APPLICATION-KEY"), "DD-APPLICATION-KEY header should not be set in agent mode")
 	})
 	t.Run("needs-app-key-header-agent-mode", func(t *testing.T) {
@@ -1125,7 +1124,6 @@ func TestDDAppKeyHeader(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NotNil(t, capturedHeaders, "No headers were captured")
-		assert.Equal(t, "true", capturedHeaders.Get("X-Datadog-NeedsAppKey"), "X-Datadog-NeedsAppKey header should be set when no app key is provided in agent mode")
 		assert.Empty(t, capturedHeaders.Get("DD-APPLICATION-KEY"), "DD-APPLICATION-KEY header should not be set when no app key is provided")
 	})
 }

--- a/llmobs/dataset/dataset_test.go
+++ b/llmobs/dataset/dataset_test.go
@@ -840,15 +840,13 @@ func TestDatasetPull(t *testing.T) {
 	})
 	t.Run("pull-with-version-option", func(t *testing.T) {
 		var capturedQuery url.Values
-		var capturedHeaders http.Header
 
 		h := func(r *http.Request) *http.Response {
 			path := strings.TrimPrefix(r.URL.Path, "/evp_proxy/v2")
 
-			// v2 project-scoped records endpoint — capture the query params and headers
+			// v2 project-scoped records endpoint — capture the query params
 			if strings.HasPrefix(path, "/api/v2/llm-obs/v1/") && strings.Contains(path, "/records") && r.Method == http.MethodGet {
 				capturedQuery = r.URL.Query()
-				capturedHeaders = r.Header.Clone()
 				rawJSON := `{
 					"data": [
 						{"id":"record-1","input":{"q":"v2 record"},"expected_output":"ans"}
@@ -910,9 +908,6 @@ func TestDatasetPull(t *testing.T) {
 		// Confirm filter[version]=2 was sent in the records request
 		require.NotNil(t, capturedQuery, "records request should have been made")
 		assert.Equal(t, "2", capturedQuery.Get("filter[version]"))
-
-		// Confirm the auth header was sent on the v2 records path
-		assert.Equal(t, "true", capturedHeaders.Get("X-Datadog-NeedsAppKey"), "auth header must be present on v2 records path")
 
 		// Confirm ds.Version() reflects the requested version, not the dataset's current_version (5)
 		assert.Equal(t, 2, ds.Version(), "Version() must return the pulled version, not the latest current_version")

--- a/llmobs/experiment/experiment.go
+++ b/llmobs/experiment/experiment.go
@@ -27,7 +27,8 @@ import (
 var (
 	errRequiresProjectName = errors.New(`a project name must be provided for the experiment, either configured via the DD_LLMOBS_PROJECT_NAME
 environment variable, using the global tracer.WithLLMObsProjectName option, or experiment.WithProjectName option`)
-	errRequiresAppKey = errors.New(`an app key must be provided for the experiment in agentless mode configured via the DD_APP_KEY environment variable`)
+	errRequiresAPIKey = errors.New(`an API key must be provided for the experiment, configured via the DD_API_KEY environment variable`)
+	errRequiresAppKey = errors.New(`an app key must be provided for the experiment, configured via the DD_APP_KEY environment variable`)
 )
 
 const (
@@ -266,8 +267,11 @@ func New(name string, task Task, ds *dataset.Dataset, evaluators []Evaluator, op
 	if cfg.projectName == "" {
 		return nil, errRequiresProjectName
 	}
-	if ll.Config.ResolvedAgentlessEnabled && ll.Config.TracerConfig.APPKey == "" {
+	if ll.Config.TracerConfig.APPKey == "" {
 		return nil, errRequiresAppKey
+	}
+	if ll.Config.TracerConfig.APIKey == "" {
+		return nil, errRequiresAPIKey
 	}
 
 	if cfg.tags == nil {

--- a/llmobs/experiment/experiment_test.go
+++ b/llmobs/experiment/experiment_test.go
@@ -78,11 +78,22 @@ func TestExperimentCreation(t *testing.T) {
 	})
 	t.Run("missing-dd-app-key-agentless", func(t *testing.T) {
 		t.Setenv("DD_API_KEY", testAPIKey)
-		// DD_APP_KEY is mandatory for experiments in agentless mode
 		t.Setenv("DD_APP_KEY", "")
-
-		// Use agentless mode to trigger app key requirement
-		tt := testTracer(t, testtracer.WithTracerStartOpts(tracer.WithLLMObsAgentlessEnabled(true)))
+		// Start tracer directly (without testTracer) so that DD_APP_KEY stays unset.
+		tt := testtracer.Start(t,
+			testtracer.WithTracerStartOpts(
+				tracer.WithLLMObsEnabled(true),
+				tracer.WithLLMObsMLApp("test-app"),
+				tracer.WithLLMObsAgentlessEnabled(true),
+				tracer.WithLLMObsProjectName("test-project"),
+				tracer.WithService("test-service"),
+				tracer.WithLogStartup(false),
+			),
+			testtracer.WithAgentInfoResponse(testtracer.AgentInfo{
+				Endpoints: []string{"/evp_proxy/v2/"},
+			}),
+			testtracer.WithMockResponses(createMockHandler()),
+		)
 		defer tt.Stop()
 
 		_, err := experiment.New(
@@ -97,28 +108,67 @@ func TestExperimentCreation(t *testing.T) {
 		assert.Contains(t, err.Error(), "an app key must be provided")
 	})
 	t.Run("missing-dd-app-key-agent-mode", func(t *testing.T) {
-		// DD_APP_KEY is not required in agent mode
+		// DD_APP_KEY is always required — agent mode no longer supported for experiments.
+		// Start tracer directly (without testTracer) to avoid default app key being set.
+		t.Setenv("DD_API_KEY", testAPIKey)
 		t.Setenv("DD_APP_KEY", "")
-
-		// Use agent mode - app key should not be required
-		tt := testTracer(t, testtracer.WithTracerStartOpts(tracer.WithLLMObsAgentlessEnabled(false)))
+		tt := testtracer.Start(t,
+			testtracer.WithTracerStartOpts(
+				tracer.WithLLMObsEnabled(true),
+				tracer.WithLLMObsMLApp("test-app"),
+				tracer.WithLLMObsAgentlessEnabled(false),
+				tracer.WithLLMObsProjectName("test-project"),
+				tracer.WithService("test-service"),
+				tracer.WithLogStartup(false),
+			),
+			testtracer.WithAgentInfoResponse(testtracer.AgentInfo{
+				Endpoints: []string{"/evp_proxy/v2/"},
+			}),
+			testtracer.WithMockResponses(createMockHandler()),
+		)
 		defer tt.Stop()
 
-		ds := createTestDataset(t)
-		task := createTestTask()
-		evaluators := createTestEvaluators()
-
-		exp, err := experiment.New(
+		_, err := experiment.New(
 			"test-experiment",
-			task,
-			ds,
-			evaluators,
+			createTestTask(),
+			nil,
+			createTestEvaluators(),
 			experiment.WithDescription("Test experiment description"),
 			experiment.WithProjectName("test-project"),
 		)
-		require.NoError(t, err)
-		assert.NotNil(t, exp)
-		assert.Equal(t, "test-experiment", exp.Name)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "an app key must be provided")
+	})
+	t.Run("missing-dd-api-key-agent-mode", func(t *testing.T) {
+		// DD_API_KEY is always required because experiments go directly to the API.
+		t.Setenv("DD_API_KEY", "")
+		t.Setenv("DD_APP_KEY", testAppKey)
+		tt := testtracer.Start(t,
+			testtracer.WithTracerStartOpts(
+				tracer.WithLLMObsEnabled(true),
+				tracer.WithLLMObsMLApp("test-app"),
+				tracer.WithLLMObsAgentlessEnabled(false),
+				tracer.WithLLMObsProjectName("test-project"),
+				tracer.WithService("test-service"),
+				tracer.WithLogStartup(false),
+			),
+			testtracer.WithAgentInfoResponse(testtracer.AgentInfo{
+				Endpoints: []string{"/evp_proxy/v2/"},
+			}),
+			testtracer.WithMockResponses(createMockHandler()),
+		)
+		defer tt.Stop()
+
+		_, err := experiment.New(
+			"test-experiment",
+			createTestTask(),
+			nil,
+			createTestEvaluators(),
+			experiment.WithDescription("Test experiment description"),
+			experiment.WithProjectName("test-project"),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "an API key must be provided")
 	})
 	t.Run("project-name-from-env-variable", func(t *testing.T) {
 		t.Setenv("DD_LLMOBS_PROJECT_NAME", "env-project")
@@ -254,8 +304,10 @@ func TestDDAppKeyHeader(t *testing.T) {
 		assert.Equal(t, testAppKey, capturedHeaders.Get("DD-APPLICATION-KEY"), "DD-APPLICATION-KEY header should be set in agentless mode")
 	})
 	t.Run("dd-app-key-header-agent-mode", func(t *testing.T) {
+		t.Setenv("DD_APP_KEY", testAppKey)
 
 		var capturedHeaders http.Header
+		var capturedPath string
 		h := func(r *http.Request) *http.Response {
 			// Normalize URL by trimming evp_proxy prefix if present
 			path := strings.TrimPrefix(r.URL.Path, "/evp_proxy/v2")
@@ -263,12 +315,13 @@ func TestDDAppKeyHeader(t *testing.T) {
 			// Capture headers from experiment-related requests
 			if strings.Contains(path, "/api/unstable/llm-obs/v1/projects") {
 				capturedHeaders = r.Header.Clone()
+				capturedPath = r.URL.Path
 			}
 			// Let the default experiment mock handler handle the response
 			return createMockHandler()(r)
 		}
 
-		// Force agent mode explicitly
+		// Even in agent mode, DNE endpoints always go direct to the API with the app key header.
 		tt := testTracer(t,
 			testtracer.WithTracerStartOpts(
 				tracer.WithLLMObsAgentlessEnabled(false),
@@ -299,7 +352,10 @@ func TestDDAppKeyHeader(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NotNil(t, capturedHeaders, "No headers were captured")
-		assert.Empty(t, capturedHeaders.Get("DD-APPLICATION-KEY"), "DD-APPLICATION-KEY header should not be set in agent mode")
+		assert.NotContains(t, capturedPath, "/evp_proxy/v2", "DNE endpoints should bypass the EVP proxy path")
+		assert.Empty(t, capturedHeaders.Get("X-Datadog-EVP-Subdomain"), "DNE endpoints should not set the EVP proxy header")
+		assert.Equal(t, testAPIKey, capturedHeaders.Get("DD-API-KEY"), "DD-API-KEY header should be set: DNE endpoints always use direct API regardless of agent mode")
+		assert.Equal(t, testAppKey, capturedHeaders.Get("DD-APPLICATION-KEY"), "DD-APPLICATION-KEY header should be set: DNE endpoints always use direct API regardless of agent mode")
 	})
 }
 
@@ -817,6 +873,8 @@ func TestExperimentMetricGeneration(t *testing.T) {
 // Helper functions
 
 func testTracer(t *testing.T, opts ...testtracer.Option) *testtracer.TestTracer {
+	t.Setenv("DD_API_KEY", testAPIKey)
+	t.Setenv("DD_APP_KEY", testAppKey)
 	defaultOpts := []testtracer.Option{
 		testtracer.WithTracerStartOpts(
 			tracer.WithLLMObsEnabled(true),

--- a/llmobs/experiment/experiment_test.go
+++ b/llmobs/experiment/experiment_test.go
@@ -298,9 +298,7 @@ func TestDDAppKeyHeader(t *testing.T) {
 		_, err = exp.Run(context.Background())
 		require.NoError(t, err)
 
-		// Verify X-Datadog-NeedsAppKey header is set in agent mode (app key is ignored)
 		require.NotNil(t, capturedHeaders, "No headers were captured")
-		assert.Equal(t, "true", capturedHeaders.Get("X-Datadog-NeedsAppKey"), "X-Datadog-NeedsAppKey header should always be set in agent mode")
 		assert.Empty(t, capturedHeaders.Get("DD-APPLICATION-KEY"), "DD-APPLICATION-KEY header should not be set in agent mode")
 	})
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Removes all references to the now deprecated `X-Datadog-NeedsAppKey` header.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->
Follow up to https://github.com/DataDog/datadog-agent/pull/51580, avoiding keeping dead code.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
