### PR TITLE
test(ddtrace/tracer): stabilize span pool agent POV's flaky tests

### DIFF
--- a/ddtrace/tracer/span_pool_test.go
+++ b/ddtrace/tracer/span_pool_test.go
@@ -385,6 +385,19 @@ func observeAgentSpans(spans []*Span) []observedAgentSpan {
 	return out
 }
 
+func spansWithoutProcessTags(spans []observedAgentSpan) []observedAgentSpan {
+	out := make([]observedAgentSpan, len(spans))
+	for i, span := range spans {
+		out[i] = span
+		out[i].Meta = maps.Clone(span.Meta)
+		delete(out[i].Meta, keyProcessTags)
+		if len(out[i].Meta) == 0 {
+			out[i].Meta = nil
+		}
+	}
+	return out
+}
+
 func spanByID(t *testing.T, spans []observedAgentSpan, id uint64) observedAgentSpan {
 	t.Helper()
 	for _, span := range spans {
@@ -656,7 +669,7 @@ func TestSpanPoolAgentPOVMatchesNoPool(t *testing.T) {
 
 			requireStrictSpanPoolAgentScenario(t, nopool)
 			requireStrictSpanPoolAgentScenario(t, pool)
-			require.Equal(t, nopool, pool)
+			require.Equal(t, spansWithoutProcessTags(nopool), spansWithoutProcessTags(pool))
 			requireProtocolRequests(t, nopoolRequests, protocol)
 			requireProtocolRequests(t, poolRequests, protocol)
 		})
@@ -782,7 +795,7 @@ func TestSpanPoolPartialFlushAgentPOVMatchesNoPoolAfterReuse(t *testing.T) {
 
 			requirePartialFlushReuseAgentScenario(t, nopool)
 			requirePartialFlushReuseAgentScenario(t, pool)
-			require.Equal(t, nopool, pool)
+			require.Equal(t, spansWithoutProcessTags(nopool), spansWithoutProcessTags(pool))
 			requireProtocolRequests(t, nopoolRequests, protocol)
 			requireProtocolRequests(t, poolRequests, protocol)
 		})
@@ -874,7 +887,7 @@ func TestSpanPoolSingleSpanSamplingAgentPOVMatchesNoPool(t *testing.T) {
 
 			requireSingleSpanSamplingAgentScenario(t, nopool)
 			requireSingleSpanSamplingAgentScenario(t, pool)
-			require.Equal(t, nopool, pool)
+			require.Equal(t, spansWithoutProcessTags(nopool), spansWithoutProcessTags(pool))
 			requireProtocolRequests(t, nopoolRequests, protocol)
 			requireProtocolRequests(t, poolRequests, protocol)
 		})

--- a/ddtrace/tracer/tracertest_test.go
+++ b/ddtrace/tracer/tracertest_test.go
@@ -218,6 +218,12 @@ func flushAgentTracerTest(tb testing.TB, tr *tracer, agent *testAgent, wantSpans
 	tb.Helper()
 	deadline := time.Now().Add(time.Second * timeMultiplicator)
 	for {
+		for len(tr.out) > 0 {
+			if time.Now().After(deadline) {
+				require.Zero(tb, len(tr.out), "timed out waiting for tracer worker to queue finished spans")
+			}
+			time.Sleep(time.Millisecond)
+		}
 		tr.Flush()
 		if w, ok := tr.traceWriter.(*agentTraceWriter); ok {
 			w.wg.Wait()


### PR DESCRIPTION
### What does this PR do?

Stabilizes span pool agent POV tests by:

- Ignoring `_dd.tags.process` carrier placement when comparing pooled and non-pooled span output.
- Waiting for finished traces to be queued by the tracer worker before flushing the mock agent test tracer.

### Motivation

In v0.4 payloads, process tags are attached to the first span of the first encoded chunk. That carrier placement is a transport detail and can vary with chunk ordering, causing flaky pooled vs non-pooled comparisons.

Separately, mock agent tests could call `Flush` before the tracer worker moved finished spans into the writer payload, leading to occasional timeouts where the mock agent received zero spans.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.