### PR TITLE
chore(chainguard): add dd-octo-sts policy for FPD config-inversion

### DIFF
--- a/.github/chainguard/gitlab.github-access.config-inversion.read.sts.yaml
+++ b/.github/chainguard/gitlab.github-access.config-inversion.read.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://gitlab.ddbuild.io
+
+# Used by the FPD origin-tracking validate job (config-inversion).
+# Allows the dd-trace-go GitLab CI to read GitHub PRs + contents for diff
+# computation against the merge-base. See:
+# https://datadoghq.atlassian.net/browse/APMAPI-1939
+subject_pattern: "project_path:DataDog/apm-reliability/dd-trace-go:ref_type:(branch|tag):ref:.*"
+
+permissions:
+  pull_requests: read
+  contents: read


### PR DESCRIPTION
### What does this PR do?

Adds a new dd-octo-sts trust policy enabling GitLab CI in `DataDog/apm-reliability/dd-trace-go` to mint short-lived GitHub installation tokens with `pull_requests: read` + `contents: read`.

The policy will be used by the FPD (Feature Parity Dashboard) origin-tracking validate job to:
- Resolve the GitHub PR for a given commit SHA (lookup via `/repos/<owner>/<repo>/commits/<sha>/pulls`).
- Diff the current `internal/env/supported_configurations.json` against the merge-base via `/repos/<owner>/<repo>/compare/...` and `/repos/<owner>/<repo>/contents/...`.

### Motivation

Part of APMAPI-1939 — improving the lifecycle tracking of `ConfigurationKey` entries in the Feature Parity Dashboard. The validate job needs short-lived, narrowly-scoped GitHub access without long-lived PATs. Following the existing convention in this repo (see `gitlab.github-access.actions-read.sts.yaml` and `gitlab.github-access.slo-change-tracking.contents-read.sts.yaml`).

Linked: https://datadoghq.atlassian.net/browse/APMAPI-1939

### Reviewer's Checklist

- [ ] ~Changed code has unit tests~ — policy file, not code.
- [ ] ~System-Tests~ — n/a.
- [ ] ~Benchmark~ — n/a.
- [ ] ~Agent system test~ — n/a.
- [ ] ~make lint~ — n/a.
- [ ] ~make test~ — n/a.
- [ ] ~Team label / release notes~ — internal infra, not customer-facing.
- [ ] ~make generate~ — n/a.
- [ ] ~go.mod~ — n/a.

This PR is **the first of two** for the FPD origin-tracking work. Once merged, a follow-up draft PR will land the smoke-test job in `.gitlab/configuration-central-validation.yml` that actually exercises the policy.