### PR TITLE
docs(contrib/labstack/echo.v4): fix inverted WithErrorCheck doc comment

### DIFF
--- a/contrib/labstack/echo.v4/option.go
+++ b/contrib/labstack/echo.v4/option.go
@@ -146,8 +146,9 @@ func WithHeaderTags(headers []string) OptionFn {
 	}
 }
 
-// WithErrorCheck sets the func which determines if err would be ignored (if it returns true, the error is not tagged).
-// This function also checks the errors created from the WithStatusCheck option.
+// WithErrorCheck specifies a function fn which determines whether the passed error
+// should be marked as an error. If fn returns true the error is tagged on the span,
+// otherwise it is ignored. This also applies to errors created from the WithStatusCheck option.
 func WithErrorCheck(errCheck func(error) bool) OptionFn {
 	return func(cfg *config) {
 		cfg.errCheck = errCheck


### PR DESCRIPTION
### What does this PR do?

Fixes the `WithErrorCheck` doc comment in the labstack/echo.v4 contrib. Right now it says the opposite of what the code actually does.

### Motivation

The comment claims that returning `true` makes the error get ignored. It's the other way around: `true` tags the error, `false` ignores it.

The callback result gets negated in `shouldIgnoreError`, which is what the tracing code checks before tagging:

```go
func shouldIgnoreError(cfg *config, err error) bool {
	return cfg.errCheck != nil && !cfg.errCheck(err)
}

// ...
if err != nil && !shouldIgnoreError(cfg, err) {
	// error is tagged on the span
}
```

So `errCheck` returning `true` leaves the error tagged, and `false` drops it. The existing `TestWithErrorCheck` cases already rely on that. This only touches the comment, so nothing changes at runtime.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
