### PR TITLE
chore(telemetry): exclude OTLP headers from configuration telemetry

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
+# The configinverter check compares this file byte-for-byte against its canonical
+# (LF) encoding; force LF so Windows checkouts don't introduce CRLF and fail the check.
+internal/env/supported_configurations.json text eol=lf
+
 # Mark go.sum files as generated so they're hidden by default in GitHub diffs
 # https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github
 **/go.sum linguist-generated

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -195,6 +195,21 @@ jobs:
           pattern: "**/*.sh"
           filter_mode: nofilter
 
+  check-supported-config:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: ${{ inputs.go-version || 'stable' }}
+          cache: false
+      - name: Verify supported_configurations.json and generated code are in sync
+        run: go run ./scripts/configinverter/main.go check
+
   checklocks:
     runs-on: ubuntu-latest
     steps:

--- a/ddtrace/opentelemetry/log/telemetry_test.go
+++ b/ddtrace/opentelemetry/log/telemetry_test.go
@@ -19,16 +19,16 @@ import (
 
 // TestRegisterTelemetry verifies that registerTelemetry reports all expected configurations.
 func TestRegisterTelemetry(t *testing.T) {
-	t.Run("reports all OTLP configurations", func(t *testing.T) {
+	t.Run("reports non-sensitive OTLP configurations and omits header values", func(t *testing.T) {
 		recorder := &telemetrytest.RecordClient{}
 		defer telemetry.MockClient(recorder)()
 
 		t.Setenv(envOTLPTimeout, "5000")
-		t.Setenv(envOTLPHeaders, "api-key=secret")
+		t.Setenv(envOTLPHeaders, "api-key=SENTINEL_OTLP_BASE")
 		t.Setenv(envOTLPProtocol, "http/protobuf")
 		t.Setenv(envOTLPEndpoint, "http://example.com:4318")
 		t.Setenv(envOTLPLogsTimeout, "8000")
-		t.Setenv(envOTLPLogsHeaders, "log-key=value")
+		t.Setenv(envOTLPLogsHeaders, "log-key=SENTINEL_OTLP_LOGS")
 		t.Setenv(envOTLPLogsProtocol, "grpc")
 		t.Setenv(envOTLPLogsEndpoint, "http://logs.example.com:4317")
 
@@ -36,15 +36,28 @@ func TestRegisterTelemetry(t *testing.T) {
 
 		// Verify generic OTLP configurations
 		telemetrytest.CheckConfig(t, recorder.Configuration, envOTLPTimeout, 5000)
-		telemetrytest.CheckConfig(t, recorder.Configuration, envOTLPHeaders, "api-key=secret")
 		telemetrytest.CheckConfig(t, recorder.Configuration, envOTLPProtocol, "http/protobuf")
 		telemetrytest.CheckConfig(t, recorder.Configuration, envOTLPEndpoint, "http://example.com:4318")
 
 		// Verify logs-specific configurations
 		telemetrytest.CheckConfig(t, recorder.Configuration, envOTLPLogsTimeout, 8000)
-		telemetrytest.CheckConfig(t, recorder.Configuration, envOTLPLogsHeaders, "log-key=value")
 		telemetrytest.CheckConfig(t, recorder.Configuration, envOTLPLogsProtocol, "grpc")
 		telemetrytest.CheckConfig(t, recorder.Configuration, envOTLPLogsEndpoint, "http://logs.example.com:4317")
+
+		// The OTLP header variants must not be reported in configuration telemetry, and
+		// no reported configuration value may contain a header sentinel.
+		for _, cfg := range recorder.Configuration {
+			assert.NotEqual(t, envOTLPHeaders, cfg.Name,
+				"%s should not be reported in configuration telemetry", envOTLPHeaders)
+			assert.NotEqual(t, envOTLPLogsHeaders, cfg.Name,
+				"%s should not be reported in configuration telemetry", envOTLPLogsHeaders)
+			if s, ok := cfg.Value.(string); ok {
+				assert.NotContains(t, s, "SENTINEL_OTLP_BASE",
+					"configuration value for %s must not contain the OTLP headers sentinel", cfg.Name)
+				assert.NotContains(t, s, "SENTINEL_OTLP_LOGS",
+					"configuration value for %s must not contain the OTLP logs headers sentinel", cfg.Name)
+			}
+		}
 	})
 
 	t.Run("reports BLRP configurations", func(t *testing.T) {

--- a/ddtrace/opentelemetry/log/telemetry_test.go
+++ b/ddtrace/opentelemetry/log/telemetry_test.go
@@ -52,10 +52,8 @@ func TestRegisterTelemetry(t *testing.T) {
 			assert.NotEqual(t, envOTLPLogsHeaders, cfg.Name,
 				"%s should not be reported in configuration telemetry", envOTLPLogsHeaders)
 			if s, ok := cfg.Value.(string); ok {
-				assert.NotContains(t, s, "SENTINEL_OTLP_BASE",
-					"configuration value for %s must not contain the OTLP headers sentinel", cfg.Name)
-				assert.NotContains(t, s, "SENTINEL_OTLP_LOGS",
-					"configuration value for %s must not contain the OTLP logs headers sentinel", cfg.Name)
+				assert.NotContains(t, s, "SENTINEL_OTLP",
+					"configuration value for %s must not contain an OTLP header sentinel", cfg.Name)
 			}
 		}
 	})

--- a/ddtrace/opentelemetry/metric/telemetry_test.go
+++ b/ddtrace/opentelemetry/metric/telemetry_test.go
@@ -56,12 +56,10 @@ func TestTelemetryExporterConfigurations(t *testing.T) {
 	recorder := new(telemetrytest.RecordClient)
 	defer telemetry.MockClient(recorder)()
 
-	const headersSentinel = "api-key=SENTINEL_OTLP_BASE,other-config-value=value"
-
 	// Set environment variables
 	t.Setenv("DD_METRICS_OTEL_ENABLED", "true")
 	t.Setenv("OTEL_EXPORTER_OTLP_TIMEOUT", "30000")
-	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", headersSentinel)
+	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "api-key=SENTINEL_OTLP_BASE,other-config-value=value")
 	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
 	t.Setenv("OTEL_METRIC_EXPORT_INTERVAL", "5000")
@@ -115,12 +113,10 @@ func TestTelemetryExporterMetricsConfigurations(t *testing.T) {
 	recorder := new(telemetrytest.RecordClient)
 	defer telemetry.MockClient(recorder)()
 
-	const headersSentinel = "api-key=SENTINEL_OTLP_METRICS,other-config-value=value"
-
 	// Set environment variables
 	t.Setenv("DD_METRICS_OTEL_ENABLED", "true")
 	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_TIMEOUT", "30000")
-	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_HEADERS", headersSentinel)
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "api-key=SENTINEL_OTLP_METRICS,other-config-value=value")
 	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", "http/protobuf")
 	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://localhost:4325")
 

--- a/ddtrace/opentelemetry/metric/telemetry_test.go
+++ b/ddtrace/opentelemetry/metric/telemetry_test.go
@@ -49,16 +49,19 @@ func TestTelemetryDefaultConfigurations(t *testing.T) {
 	}
 }
 
-// TestTelemetryExporterConfigurations verifies that OTEL_EXPORTER_OTLP_* configurations
-// are reported to telemetry when set via environment variables.
+// TestTelemetryExporterConfigurations verifies that non-sensitive OTEL_EXPORTER_OTLP_*
+// configurations are reported to telemetry when set via environment variables, and that
+// OTEL_EXPORTER_OTLP_HEADERS is not reported in configuration telemetry.
 func TestTelemetryExporterConfigurations(t *testing.T) {
 	recorder := new(telemetrytest.RecordClient)
 	defer telemetry.MockClient(recorder)()
 
+	const headersSentinel = "api-key=SENTINEL_OTLP_BASE,other-config-value=value"
+
 	// Set environment variables
 	t.Setenv("DD_METRICS_OTEL_ENABLED", "true")
 	t.Setenv("OTEL_EXPORTER_OTLP_TIMEOUT", "30000")
-	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "api-key=key,other-config-value=value")
+	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", headersSentinel)
 	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
 	t.Setenv("OTEL_METRIC_EXPORT_INTERVAL", "5000")
@@ -70,10 +73,9 @@ func TestTelemetryExporterConfigurations(t *testing.T) {
 	}
 	defer Shutdown(t.Context(), mp)
 
-	// Check configurations are reported with env_var origin
+	// Check non-sensitive configurations are reported with env_var origin
 	expectedConfigs := map[string]any{
 		"OTEL_EXPORTER_OTLP_TIMEOUT":  30000,
-		"OTEL_EXPORTER_OTLP_HEADERS":  "api-key=key,other-config-value=value",
 		"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
 		"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
 		"OTEL_METRIC_EXPORT_INTERVAL": 5000,
@@ -92,18 +94,33 @@ func TestTelemetryExporterConfigurations(t *testing.T) {
 		}
 		assert.True(t, found, "expected config %s not found in telemetry", configName)
 	}
+
+	// OTEL_EXPORTER_OTLP_HEADERS must not be reported in configuration telemetry,
+	// and no reported configuration value may contain the sentinel.
+	for _, cfg := range recorder.Configuration {
+		assert.NotEqual(t, "OTEL_EXPORTER_OTLP_HEADERS", cfg.Name,
+			"OTEL_EXPORTER_OTLP_HEADERS should not be reported in configuration telemetry")
+		if s, ok := cfg.Value.(string); ok {
+			assert.NotContains(t, s, "SENTINEL_OTLP_BASE",
+				"configuration value for %s must not contain the OTLP headers sentinel", cfg.Name)
+		}
+	}
 }
 
-// TestTelemetryExporterMetricsConfigurations verifies that OTEL_EXPORTER_OTLP_METRICS_*
-// configurations are reported to telemetry when set via environment variables.
+// TestTelemetryExporterMetricsConfigurations verifies that non-sensitive
+// OTEL_EXPORTER_OTLP_METRICS_* configurations are reported to telemetry when set via
+// environment variables, and that OTEL_EXPORTER_OTLP_METRICS_HEADERS is not reported in
+// configuration telemetry.
 func TestTelemetryExporterMetricsConfigurations(t *testing.T) {
 	recorder := new(telemetrytest.RecordClient)
 	defer telemetry.MockClient(recorder)()
 
+	const headersSentinel = "api-key=SENTINEL_OTLP_METRICS,other-config-value=value"
+
 	// Set environment variables
 	t.Setenv("DD_METRICS_OTEL_ENABLED", "true")
 	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_TIMEOUT", "30000")
-	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "api-key=key,other-config-value=value")
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_HEADERS", headersSentinel)
 	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", "http/protobuf")
 	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://localhost:4325")
 
@@ -113,10 +130,9 @@ func TestTelemetryExporterMetricsConfigurations(t *testing.T) {
 	}
 	defer Shutdown(t.Context(), mp)
 
-	// Check configurations are reported with env_var origin
+	// Check non-sensitive configurations are reported with env_var origin
 	expectedConfigs := map[string]any{
 		"OTEL_EXPORTER_OTLP_METRICS_TIMEOUT":  30000,
-		"OTEL_EXPORTER_OTLP_METRICS_HEADERS":  "api-key=key,other-config-value=value",
 		"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "http/protobuf",
 		"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://localhost:4325",
 	}
@@ -132,6 +148,17 @@ func TestTelemetryExporterMetricsConfigurations(t *testing.T) {
 			}
 		}
 		assert.True(t, found, "expected config %s not found in telemetry", configName)
+	}
+
+	// OTEL_EXPORTER_OTLP_METRICS_HEADERS must not be reported in configuration telemetry,
+	// and no reported configuration value may contain the sentinel.
+	for _, cfg := range recorder.Configuration {
+		assert.NotEqual(t, "OTEL_EXPORTER_OTLP_METRICS_HEADERS", cfg.Name,
+			"OTEL_EXPORTER_OTLP_METRICS_HEADERS should not be reported in configuration telemetry")
+		if s, ok := cfg.Value.(string); ok {
+			assert.NotContains(t, s, "SENTINEL_OTLP_METRICS",
+				"configuration value for %s must not contain the OTLP metrics headers sentinel", cfg.Name)
+		}
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -540,6 +540,34 @@ func TestOTLPHeaders(t *testing.T) {
 		assert.Equal(t, OTLPContentTypeHeader, headers["Content-Type"])
 	})
 
+	t.Run("OTEL_EXPORTER_OTLP_TRACES_HEADERS not reported in configuration telemetry", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+
+		rec := new(telemetrytest.RecordClient)
+		defer telemetry.MockClient(rec)()
+
+		t.Setenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "api-key=SENTINEL_OTLP_TRACES,x-custom=value")
+
+		cfg := Get()
+		require.NotNil(t, cfg)
+
+		// The value is still resolved and parsed for export use.
+		headers := cfg.OTLPHeaders()
+		assert.Equal(t, "SENTINEL_OTLP_TRACES", headers["api-key"])
+
+		// But it must not be reported in configuration telemetry, and no reported
+		// configuration value may contain the sentinel.
+		for _, c := range rec.Configuration {
+			assert.NotEqual(t, "OTEL_EXPORTER_OTLP_TRACES_HEADERS", c.Name,
+				"OTEL_EXPORTER_OTLP_TRACES_HEADERS should not be reported in configuration telemetry")
+			if s, ok := c.Value.(string); ok {
+				assert.NotContains(t, s, "SENTINEL_OTLP_TRACES",
+					"configuration value for %s must not contain the OTLP traces headers sentinel", c.Name)
+			}
+		}
+	})
+
 }
 
 func TestOTLPExportMode(t *testing.T) {

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -34,7 +34,7 @@ func Get(name string) string {
 		return v
 	}
 
-	for _, alias := range keyAliases[name] {
+	for _, alias := range KeyAliases[name] {
 		if v := os.Getenv(alias); v != "" {
 			return v
 		}
@@ -64,7 +64,7 @@ func Lookup(name string) (string, bool) {
 		return v, true
 	}
 
-	for _, alias := range keyAliases[name] {
+	for _, alias := range KeyAliases[name] {
 		if v, ok := os.LookupEnv(alias); ok {
 			return v, true
 		}

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -49,6 +49,19 @@ func TestVerifySupportedConfiguration(t *testing.T) {
 		require.Equal(t, "TEST_SERVICE", res)
 	})
 
+	t.Run("sensitive configuration", func(t *testing.T) {
+		// OTLP header variants are seeded as sensitive in supported_configurations.json.
+		require.True(t, IsSensitive("OTEL_EXPORTER_OTLP_HEADERS"))
+		require.True(t, IsSensitive("OTEL_EXPORTER_OTLP_TRACES_HEADERS"))
+		require.True(t, IsSensitive("OTEL_EXPORTER_OTLP_METRICS_HEADERS"))
+		require.True(t, IsSensitive("OTEL_EXPORTER_OTLP_LOGS_HEADERS"))
+
+		// Non-sensitive configurations are not flagged.
+		require.False(t, IsSensitive("DD_SERVICE"))
+		require.False(t, IsSensitive("OTEL_EXPORTER_OTLP_ENDPOINT"))
+		require.False(t, IsSensitive("DD_API_KEY"))
+	})
+
 	t.Run("unknown configuration", func(t *testing.T) {
 		// Unknown configuration that would be added to the supported configurations file.
 		t.Setenv("DD_UNKNOWN_CONFIGURATION_KEY", "VALUE")

--- a/internal/env/supported_configurations.gen.go
+++ b/internal/env/supported_configurations.gen.go
@@ -148,6 +148,7 @@ var SupportedConfigurations = map[string]struct{}{
 	"DD_TEST_OPTIMIZATION_MANIFEST_FILE":                              {},
 	"DD_TEST_OPTIMIZATION_PAYLOADS_IN_FILES":                          {},
 	"DD_TEST_SESSION_NAME":                                            {},
+	"DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED":                        {},
 	"DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED":                     {},
 	"DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED":                        {},
 	"DD_TRACE_ABANDONED_SPAN_TIMEOUT":                                 {},
@@ -237,7 +238,6 @@ var SupportedConfigurations = map[string]struct{}{
 	"DD_TRACE_SEND_RETRIES":                                           {},
 	"DD_TRACE_SOURCE_HOSTNAME":                                        {},
 	"DD_TRACE_SPAN_ATTRIBUTE_SCHEMA":                                  {},
-	"DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED":                        {},
 	"DD_TRACE_SQL_ANALYTICS_ENABLED":                                  {},
 	"DD_TRACE_SQL_COMMENT_INJECTION_MODE":                             {},
 	"DD_TRACE_STARTUP_LOGS":                                           {},
@@ -281,6 +281,16 @@ var SupportedConfigurations = map[string]struct{}{
 	"OTEL_TRACES_EXPORTER":                                            {},
 	"OTEL_TRACES_SAMPLER":                                             {},
 	"OTEL_TRACES_SAMPLER_ARG":                                         {},
+}
+
+// SensitiveConfigurations is the set of configuration keys whose value must not be
+// reported in configuration telemetry. It is seeded from entries marked "sensitive": true
+// in supported_configurations.json.
+var SensitiveConfigurations = map[string]struct{}{
+	"OTEL_EXPORTER_OTLP_HEADERS":         {},
+	"OTEL_EXPORTER_OTLP_LOGS_HEADERS":    {},
+	"OTEL_EXPORTER_OTLP_METRICS_HEADERS": {},
+	"OTEL_EXPORTER_OTLP_TRACES_HEADERS":  {},
 }
 
 // keyAliases maps aliases to supported configuration keys.

--- a/internal/env/supported_configurations.gen.go
+++ b/internal/env/supported_configurations.gen.go
@@ -293,8 +293,8 @@ var SensitiveConfigurations = map[string]struct{}{
 	"OTEL_EXPORTER_OTLP_TRACES_HEADERS":  {},
 }
 
-// keyAliases maps aliases to supported configuration keys.
-var keyAliases = map[string][]string{
+// KeyAliases maps canonical configuration keys to their known aliases.
+var KeyAliases = map[string][]string{
 	"DD_API_KEY":                    {"DD-API-KEY"},
 	"DD_APPSEC_STACK_TRACE_ENABLED": {"DD_APPSEC_STACK_TRACE_ENABLE"},
 }

--- a/internal/env/supported_configurations.go
+++ b/internal/env/supported_configurations.go
@@ -98,7 +98,7 @@ func IsSensitive(name string) bool {
 	if _, ok := SensitiveConfigurations[name]; ok {
 		return true
 	}
-	for key, aliases := range keyAliases {
+	for key, aliases := range KeyAliases {
 		if _, ok := SensitiveConfigurations[key]; !ok {
 			continue
 		}

--- a/internal/env/supported_configurations.go
+++ b/internal/env/supported_configurations.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sync"
 
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
@@ -22,6 +23,9 @@ type configurationImplementation struct {
 	Type           string   `json:"type"`
 	Default        *string  `json:"default"`
 	Aliases        []string `json:"aliases,omitempty"`
+	// Sensitive marks a configuration whose value must not be reported in
+	// configuration telemetry.
+	Sensitive bool `json:"sensitive,omitempty"`
 }
 
 // SupportedConfiguration represents the content of the supported_configurations.json file.
@@ -85,6 +89,24 @@ func addSupportedConfigurationToFile(name string) {
 	if err := writeSupportedConfigurations(filePath, cfg); err != nil {
 		log.Error("config: failed to write supported configurations: %s", err.Error())
 	}
+}
+
+// IsSensitive reports whether the given configuration name must not have its value
+// reported in configuration telemetry. A name is sensitive if it is listed in the
+// generated SensitiveConfigurations set, or if it is an alias of such a key.
+func IsSensitive(name string) bool {
+	if _, ok := SensitiveConfigurations[name]; ok {
+		return true
+	}
+	for key, aliases := range keyAliases {
+		if _, ok := SensitiveConfigurations[key]; !ok {
+			continue
+		}
+		if slices.Contains(aliases, name) {
+			return true
+		}
+	}
+	return false
 }
 
 func readSupportedConfigurations(filePath string) (*supportedConfiguration, error) {

--- a/internal/env/supported_configurations.json
+++ b/internal/env/supported_configurations.json
@@ -980,6 +980,13 @@
         "default": null
       }
     ],
+    "DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED": [
+      {
+        "implementation": "A",
+        "type": "boolean",
+        "default": "false"
+      }
+    ],
     "DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED": [
       {
         "implementation": "A",
@@ -1603,13 +1610,6 @@
         "default": "v0"
       }
     ],
-    "DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED": [
-      {
-        "implementation": "A",
-        "type": "boolean",
-        "default": "false"
-      }
-    ],
     "DD_TRACE_SQL_ANALYTICS_ENABLED": [
       {
         "implementation": "A",
@@ -1740,7 +1740,8 @@
       {
         "implementation": "A",
         "type": "map",
-        "default": ""
+        "default": "",
+        "sensitive": true
       }
     ],
     "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT": [
@@ -1754,7 +1755,8 @@
       {
         "implementation": "A",
         "type": "string",
-        "default": null
+        "default": null,
+        "sensitive": true
       }
     ],
     "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL": [
@@ -1782,7 +1784,8 @@
       {
         "implementation": "B",
         "type": "string",
-        "default": null
+        "default": null,
+        "sensitive": true
       }
     ],
     "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": [
@@ -1831,7 +1834,8 @@
       {
         "implementation": "B",
         "type": "map",
-        "default": null
+        "default": null,
+        "sensitive": true
       }
     ],
     "OTEL_LOGS_EXPORTER": [

--- a/internal/telemetry/configuration.go
+++ b/internal/telemetry/configuration.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/DataDog/dd-trace-go/v2/internal/env"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal/transport"
 )
 
@@ -62,6 +63,13 @@ func idOrEmpty(id string) string {
 }
 
 func (c *configuration) Add(kv Configuration) {
+	// Configurations marked sensitive are not reported in configuration telemetry.
+	// They are dropped here so every reporting path (RegisterAppConfig,
+	// RegisterAppConfigs, and configtelemetry.Report*) is covered by a single check.
+	if env.IsSensitive(kv.Name) {
+		return
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/internal/telemetry/configuration_test.go
+++ b/internal/telemetry/configuration_test.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal/transport"
+)
+
+// TestConfigurationOmitsSensitive verifies that configurations marked sensitive are not
+// stored or reported by the configuration data source, regardless of which reporting
+// helper added them. Non-sensitive configurations are reported as usual.
+func TestConfigurationOmitsSensitive(t *testing.T) {
+	c := &configuration{}
+
+	// Sensitive entries (OTLP header variants) must be dropped.
+	c.Add(Configuration{Name: "OTEL_EXPORTER_OTLP_HEADERS", Value: "api-key=SENTINEL", Origin: OriginEnvVar})
+	c.Add(Configuration{Name: "OTEL_EXPORTER_OTLP_TRACES_HEADERS", Value: "api-key=SENTINEL", Origin: OriginEnvVar})
+	c.Add(Configuration{Name: "OTEL_EXPORTER_OTLP_METRICS_HEADERS", Value: "api-key=SENTINEL", Origin: OriginEnvVar})
+	c.Add(Configuration{Name: "OTEL_EXPORTER_OTLP_LOGS_HEADERS", Value: "api-key=SENTINEL", Origin: OriginEnvVar})
+
+	// A non-sensitive entry must be reported.
+	c.Add(Configuration{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: "http://localhost:4318", Origin: OriginEnvVar})
+
+	payload := c.Payload()
+	change, ok := payload.(transport.AppClientConfigurationChange)
+	assert.True(t, ok, "expected an AppClientConfigurationChange payload")
+
+	assertOnlyEndpoint(t, change.Configuration)
+	// All() reflects the same accumulated state used by extended heartbeats.
+	assertOnlyEndpoint(t, c.All())
+}
+
+func assertOnlyEndpoint(t *testing.T, configs []transport.ConfKeyValue) {
+	t.Helper()
+	names := make([]string, 0, len(configs))
+	for _, cfg := range configs {
+		names = append(names, cfg.Name)
+		assert.NotContains(t, cfg.Name, "HEADERS", "header configuration should not be reported")
+		if s, ok := cfg.Value.(string); ok {
+			assert.NotContains(t, s, "SENTINEL", "no reported value may contain the sentinel")
+		}
+	}
+	assert.Equal(t, []string{"OTEL_EXPORTER_OTLP_ENDPOINT"}, names)
+}

--- a/internal/telemetry/telemetrytest/record.go
+++ b/internal/telemetry/telemetrytest/record.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/dd-trace-go/v2/internal/env"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal/knownmetrics"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal/transport"
@@ -178,10 +179,15 @@ func (r *RecordClient) RegisterAppConfig(key string, value any, origin telemetry
 func (r *RecordClient) RegisterAppConfigs(kvs ...telemetry.Configuration) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	for i := range kvs {
-		kvs[i].Value = telemetry.SanitizeConfigValue(kvs[i].Value)
+	for _, kv := range kvs {
+		// Mirror the production sink: configurations marked sensitive are not
+		// reported in configuration telemetry.
+		if env.IsSensitive(kv.Name) {
+			continue
+		}
+		kv.Value = telemetry.SanitizeConfigValue(kv.Value)
+		r.Configuration = append(r.Configuration, kv)
 	}
-	r.Configuration = append(r.Configuration, kvs...)
 }
 
 func (r *RecordClient) MarkIntegrationAsLoaded(integration telemetry.Integration) {

--- a/scripts/configinverter/main.go
+++ b/scripts/configinverter/main.go
@@ -67,6 +67,10 @@ type configurationImplementation struct {
 	Type           string   `json:"type"`
 	Default        *string  `json:"default"`
 	Aliases        []string `json:"aliases,omitempty"`
+	// Sensitive marks a configuration whose value must not be reported in
+	// configuration telemetry. When set on any implementation of a key, that key
+	// is emitted in the generated SensitiveConfigurations set.
+	Sensitive bool `json:"sensitive,omitempty"`
 }
 
 // generate generates the supported configurations map from the supported configurations
@@ -91,6 +95,20 @@ func generate(input, output string) error {
 	f.Comment("SupportedConfigurations is a map of supported configuration keys.")
 	f.Var().Id("SupportedConfigurations").Op("=").Map(jen.String()).Struct().ValuesFunc(func(g *jen.Group) {
 		for _, v := range keys {
+			g.Add(jen.Line(), jen.Lit(v), jen.Op(":"), jen.Values())
+		}
+		g.Line()
+	})
+	f.Line()
+
+	// Collect keys marked sensitive in any of their implementations.
+	sensitiveKeys := sensitiveConfigurationKeys(cfg)
+
+	f.Comment("SensitiveConfigurations is the set of configuration keys whose value must not be")
+	f.Comment("reported in configuration telemetry. It is seeded from entries marked \"sensitive\": true")
+	f.Comment("in supported_configurations.json.")
+	f.Var().Id("SensitiveConfigurations").Op("=").Map(jen.String()).Struct().ValuesFunc(func(g *jen.Group) {
+		for _, v := range sensitiveKeys {
 			g.Add(jen.Line(), jen.Lit(v), jen.Op(":"), jen.Values())
 		}
 		g.Line()
@@ -230,6 +248,22 @@ func sortSupportedConfigurationsKeys(cfg *supportedConfiguration) []string {
 	keys := []string{}
 	for k := range cfg.SupportedConfigurations {
 		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// sensitiveConfigurationKeys returns the sorted list of configuration keys that have
+// at least one implementation marked "sensitive": true.
+func sensitiveConfigurationKeys(cfg *supportedConfiguration) []string {
+	keys := []string{}
+	for k, impls := range cfg.SupportedConfigurations {
+		for _, impl := range impls {
+			if impl.Sensitive {
+				keys = append(keys, k)
+				break
+			}
+		}
 	}
 	sort.Strings(keys)
 	return keys

--- a/scripts/configinverter/main.go
+++ b/scripts/configinverter/main.go
@@ -115,32 +115,18 @@ func generate(input, output string) error {
 	})
 	f.Line()
 
-	// Get aliases keys and sort them
-	// so we can generate the map in a deterministic way
-	aliases := make(map[string][]string)
-	keysWithAliases := make([]string, 0)
-	for k := range cfg.SupportedConfigurations {
-		cfgAliases := []string{}
-		// Iterate over the configuration implementations and collect the aliases
-		for _, impl := range cfg.SupportedConfigurations[k] {
-			if impl.Aliases != nil && len(impl.Aliases) > 0 {
-				cfgAliases = append(cfgAliases, impl.Aliases...)
-			}
-		}
-
-		if len(cfgAliases) > 0 {
-			keysWithAliases = append(keysWithAliases, k)
-			aliases[k] = cfgAliases
-		}
+	aliases := collectAliasMap(cfg)
+	keysWithAliases := make([]string, 0, len(aliases))
+	for k := range aliases {
+		keysWithAliases = append(keysWithAliases, k)
 	}
-
 	if len(keysWithAliases) > 0 {
 		slog.Info("keys with aliases", "count", len(keysWithAliases), "keys", keysWithAliases)
 		sort.Strings(keysWithAliases)
 	}
 
-	f.Comment("keyAliases maps aliases to supported configuration keys.")
-	f.Var().Id("keyAliases").Op("=").Map(jen.String()).Index().String().ValuesFunc(func(g *jen.Group) {
+	f.Comment("KeyAliases maps canonical configuration keys to their known aliases.")
+	f.Var().Id("KeyAliases").Op("=").Map(jen.String()).Index().String().ValuesFunc(func(g *jen.Group) {
 		for _, v := range keysWithAliases {
 			g.Add(jen.Line(), jen.Lit(v), jen.Op(":"), jen.ValuesFunc(func(g *jen.Group) {
 				for _, v := range aliases[v] {
@@ -159,32 +145,118 @@ func generate(input, output string) error {
 }
 
 // check verifies that there is no difference between the supported configurations
-// JSON file and generated Go code map.
+// JSON file and the generated Go code. It validates four things:
+//   - SupportedConfigurations: exact key-set match (no missing, no extra)
+//   - SensitiveConfigurations: exact key-set match (no missing, no extra)
+//   - keyAliases: exact alias-set match per key (no missing, no extra)
+//   - JSON sort order: the JSON file must be byte-identical to its canonical form
 func check(input string) error {
-	keys, err := getSupportedConfigurationsKeys(input)
+	rawJSON, err := os.ReadFile(input)
+	if err != nil {
+		return fmt.Errorf("error reading JSON file: %w", err)
+	}
+
+	cfg, err := getSupportedConfigurations(input)
 	if err != nil {
 		return fmt.Errorf("error getting supported configuration keys: %w", err)
 	}
 
-	slog.Info("supported configuration keys in JSON file", "count", len(keys))
-	slog.Info("supported configuration keys in generated map", "count", len(env.SupportedConfigurations))
+	var failures []string
 
-	missingKeys := []string{}
-	for _, k := range keys {
+	// --- SupportedConfigurations: JSON ↔ generated ---
+	jsonKeys := sortSupportedConfigurationsKeys(cfg)
+	jsonKeySet := make(map[string]struct{}, len(jsonKeys))
+	for _, k := range jsonKeys {
+		jsonKeySet[k] = struct{}{}
+	}
+	for _, k := range jsonKeys {
 		if _, ok := env.SupportedConfigurations[k]; !ok {
-			slog.Error("supported configuration key not found in generated map", "key", k)
-			missingKeys = append(missingKeys, k)
+			failures = append(failures, fmt.Sprintf("SupportedConfigurations: %q present in JSON but missing from generated", k))
+		}
+	}
+	for k := range env.SupportedConfigurations {
+		if _, ok := jsonKeySet[k]; !ok {
+			failures = append(failures, fmt.Sprintf("SupportedConfigurations: %q present in generated but missing from JSON", k))
 		}
 	}
 
-	if len(missingKeys) > 0 {
-		slog.Error("supported configuration keys missing in generated map", "count", len(missingKeys), "keys", missingKeys)
-		slog.Info("run `go run ./scripts/configinverter/main.go generate` to re-generate the supported configurations map with the missing keys")
-		return fmt.Errorf("supported configuration keys missing in generated map, please re-run the generate command")
+	// --- SensitiveConfigurations: JSON ↔ generated ---
+	sensitiveKeys := sensitiveConfigurationKeys(cfg)
+	sensitiveKeySet := make(map[string]struct{}, len(sensitiveKeys))
+	for _, k := range sensitiveKeys {
+		sensitiveKeySet[k] = struct{}{}
+	}
+	for _, k := range sensitiveKeys {
+		if _, ok := env.SensitiveConfigurations[k]; !ok {
+			failures = append(failures, fmt.Sprintf("SensitiveConfigurations: %q is sensitive in JSON but missing from generated", k))
+		}
+	}
+	for k := range env.SensitiveConfigurations {
+		if _, ok := sensitiveKeySet[k]; !ok {
+			failures = append(failures, fmt.Sprintf("SensitiveConfigurations: %q is in generated but not marked sensitive in JSON", k))
+		}
+	}
+
+	// --- keyAliases: JSON ↔ generated ---
+	jsonAliases := collectAliasMap(cfg)
+	genAliases := env.KeyAliases
+	for k, jsonList := range jsonAliases {
+		genList, ok := genAliases[k]
+		if !ok {
+			failures = append(failures, fmt.Sprintf("keyAliases: %q has aliases in JSON but no entry in generated", k))
+			continue
+		}
+		genSet := make(map[string]struct{}, len(genList))
+		for _, a := range genList {
+			genSet[a] = struct{}{}
+		}
+		for _, a := range jsonList {
+			if _, ok := genSet[a]; !ok {
+				failures = append(failures, fmt.Sprintf("keyAliases: alias %q for key %q present in JSON but missing from generated", a, k))
+			}
+		}
+	}
+	for k, genList := range genAliases {
+		jsonList, ok := jsonAliases[k]
+		if !ok {
+			failures = append(failures, fmt.Sprintf("keyAliases: %q has aliases in generated but no aliases in JSON", k))
+			continue
+		}
+		jsonSet := make(map[string]struct{}, len(jsonList))
+		for _, a := range jsonList {
+			jsonSet[a] = struct{}{}
+		}
+		for _, a := range genList {
+			if _, ok := jsonSet[a]; !ok {
+				failures = append(failures, fmt.Sprintf("keyAliases: alias %q for key %q present in generated but missing from JSON", a, k))
+			}
+		}
+	}
+
+	// --- JSON sort and format ---
+	// Re-encode the parsed config with the canonical settings used by generate/add.
+	// If the file was not sorted or was otherwise modified by hand, the bytes will differ.
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(cfg); err != nil {
+		return fmt.Errorf("error re-encoding JSON for sort check: %w", err)
+	}
+	normalized := bytes.TrimRight(buf.Bytes(), "\n")
+	if !bytes.Equal(bytes.TrimRight(rawJSON, "\n"), normalized) {
+		failures = append(failures, "JSON is not sorted or not in canonical format; run `go run ./scripts/configinverter/main.go generate` to fix")
+	}
+
+	if len(failures) > 0 {
+		for _, f := range failures {
+			slog.Error(f)
+		}
+		slog.Info("run `go run ./scripts/configinverter/main.go generate` to re-generate the supported configurations")
+		return fmt.Errorf("%d discrepancy(ies) found between JSON and generated code", len(failures))
 	}
 
 	slog.Info("supported configurations JSON file and generated map are in sync")
-
 	return nil
 }
 
@@ -251,6 +323,22 @@ func sortSupportedConfigurationsKeys(cfg *supportedConfiguration) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// collectAliasMap returns a map from configuration key to the union of all aliases
+// defined across its implementations.
+func collectAliasMap(cfg *supportedConfiguration) map[string][]string {
+	result := make(map[string][]string)
+	for k, impls := range cfg.SupportedConfigurations {
+		var aliases []string
+		for _, impl := range impls {
+			aliases = append(aliases, impl.Aliases...)
+		}
+		if len(aliases) > 0 {
+			result[k] = aliases
+		}
+	}
+	return result
 }
 
 // sensitiveConfigurationKeys returns the sorted list of configuration keys that have

--- a/scripts/configinverter/main.go
+++ b/scripts/configinverter/main.go
@@ -244,7 +244,11 @@ func check(input string) error {
 		return fmt.Errorf("error re-encoding JSON for sort check: %w", err)
 	}
 	normalized := bytes.TrimRight(buf.Bytes(), "\n")
-	if !bytes.Equal(bytes.TrimRight(rawJSON, "\n"), normalized) {
+	// Normalize CRLF to LF before comparing: on Windows the file may be checked out
+	// with CRLF line endings (git core.autocrlf), but the canonical encoding always
+	// uses LF. We validate content and sort order, not platform-specific line endings.
+	rawNormalized := bytes.ReplaceAll(rawJSON, []byte("\r\n"), []byte("\n"))
+	if !bytes.Equal(bytes.TrimRight(rawNormalized, "\n"), normalized) {
 		failures = append(failures, "JSON is not sorted or not in canonical format; run `go run ./scripts/configinverter/main.go generate` to fix")
 	}
 


### PR DESCRIPTION
### What does this PR do?

Excludes the OTLP exporter header configurations from configuration telemetry: `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_TRACES_HEADERS`, `OTEL_EXPORTER_OTLP_METRICS_HEADERS`, and `OTEL_EXPORTER_OTLP_LOGS_HEADERS`. They are marked `sensitive: true` in `internal/env/supported_configurations.json` and skipped when building configuration telemetry.

### Motivation

These configurations should not be included in configuration telemetry.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] System-Tests covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.
