### PR TITLE
chore(ci): fix codeowner resolution

### DIFF
--- a/.github/actions/add-codeowners/codeowners.go
+++ b/.github/actions/add-codeowners/codeowners.go
@@ -91,6 +91,8 @@ func annotate(data []byte) ([]byte, error) {
 	enc := xml.NewEncoder(&buf)
 	enc.Indent("", "\t")
 
+	var currentSuiteName string
+
 	for {
 		tok, err := dec.Token()
 		if err != nil {
@@ -106,8 +108,17 @@ func annotate(data []byte) ([]byte, error) {
 				continue
 			}
 		case xml.StartElement:
+			if t.Name.Local == "testsuite" {
+				currentSuiteName = attrValue(t.Attr, "name")
+			}
 			if t.Name.Local == "testcase" && !hasAttr(t.Attr, "file") {
-				if path := relativePathFromPackageName(attrValue(t.Attr, "classname")); path != "" {
+				path := relativePathFromPackageName(attrValue(t.Attr, "classname"))
+				if path == "" {
+					// Fallback for TestMain failures where gotestsum emits no classname:
+					// derive the path from the enclosing <testsuite> name instead.
+					path = relativePathFromPackageName(currentSuiteName)
+				}
+				if path != "" {
 					t.Attr = append(t.Attr, xml.Attr{
 						Name:  xml.Name{Local: "file"},
 						Value: path,

--- a/.github/actions/add-codeowners/input.xml
+++ b/.github/actions/add-codeowners/input.xml
@@ -198,4 +198,12 @@
 		<testcase classname="github.com/DataDog/dd-trace-go/v2/profiler" name="TestProcessTags/disabled" time="0.010000"></testcase>
 		<testcase classname="github.com/DataDog/dd-trace-go/v2/profiler" name="TestProcessTags" time="0.020000"></testcase>
 	</testsuite>
+	<testsuite tests="1" failures="1" time="0.001000" name="github.com/DataDog/dd-trace-go/v2/internal/appsec/apisec" timestamp="2026-02-23T20:53:12-05:00">
+		<properties>
+			<property name="go.version" value="go1.26.0 darwin/arm64"></property>
+		</properties>
+		<testcase classname="" name="TestMain" time="0.000000">
+			<failure message="exit status 1">exit status 1</failure>
+		</testcase>
+	</testsuite>
 </testsuites>

--- a/.github/actions/add-codeowners/want.xml
+++ b/.github/actions/add-codeowners/want.xml
@@ -197,4 +197,12 @@
 		<testcase classname="github.com/DataDog/dd-trace-go/v2/profiler" name="TestProcessTags/disabled" time="0.010000" file="/profiler"></testcase>
 		<testcase classname="github.com/DataDog/dd-trace-go/v2/profiler" name="TestProcessTags" time="0.020000" file="/profiler"></testcase>
 	</testsuite>
+	<testsuite tests="1" failures="1" time="0.001000" name="github.com/DataDog/dd-trace-go/v2/internal/appsec/apisec" timestamp="2026-02-23T20:53:12-05:00">
+		<properties>
+			<property name="go.version" value="go1.26.0 darwin/arm64"></property>
+		</properties>
+		<testcase classname="" name="TestMain" time="0.000000" file="/internal/appsec/apisec">
+			<failure message="exit status 1">exit status 1</failure>
+		</testcase>
+	</testsuite>
 </testsuites>


### PR DESCRIPTION

### What does this PR do?

Claude says : 

> The root cause is that when TestMain fails, gotestsum may produce a <testcase> element with an empty classname attribute (when there's no individual test output, only a package-level failure). The codeowners.go script can't derive the file path from an empty classname, so test.source.file ends up missing.
 > The fix: track the current <testsuite> name while streaming through the XML and use it as a fallback when classname is absent or doesn't yield a path.

About the fact it's missing only on failure : 

> The issue is specific to the failing TestMain case, not all tests. Here's why:
>
>  - When tests pass normally (e.g. TestSampler), each <testcase> has classname="github.com/DataDog/dd-trace-go/v2/internal/appsec/apisec" → codeowners.go derives file="/internal/appsec/apisec" →  test.source.file is present.
>  - When TestMain fails (package-level binary failure), gotestsum synthesizes a <testcase name="TestMain"> entry without a classname attribute (because there's no individual test event — only a  package-level fail action). Since classname is empty, relativePathFromPackageName("") returns "", no file attribute is added, and test.source.file is missing.
>
>  My fix is targeted at exactly this case: the fallback to currentSuiteName only triggers when classname doesn't yield a path (i.e. it's empty or missing). It doesn't affect passing tests because they  always have a valid classname and the fallback path is never reached.
>
>  The fixture change in input.xml/want.xml directly exercises this: a <testcase classname="" name="TestMain"> inside a testsuite with name="github.com/DataDog/dd-trace-go/v2/internal/appsec/apisec" should  get file="/internal/appsec/apisec" added.


### Motivation

On some failure, the `test.source.file` is missing in test optim : [query](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id_v2%3Agithub.com%2Fdatadog%2Fdd-trace-go%20%28-%40test.codeowners%3A%2A%20OR%20%40test.codeowners%3A%40Datadog%2F%2A%20OR%20%40test.codeowners%3A%40datadog%2F%2A%29%20%40git.branch%3A%28main%20OR%20master%29&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=AwAAAZ6fmEy4dz6pbwAAABhBWjZmbUV5NEFBQ0RPRWs1Rk82ak1tY3oAAAAkZjE5ZTlmOWEtYzE5Yi00ODIwLThmNzYtNGMwNzM5YzM4MDRlAAEv8g&fromUser=false&index=citest&refresh_mode=sliding&testId=AwAAAZ6fmEy4dz6pbwAAABhBWjZmbUV5NEFBQ0RPRWs1Rk82ak1tY3oAAAAkZjE5ZTlmOWEtYzE5Yi00ODIwLThmNzYtNGMwNzM5YzM4MDRlAAEv8g&trace=AwAAAZ6fmEy4dz6pbwAAABhBWjZmbUV5NEFBQ0RPRWs1Rk82ak1tY3oAAAAkZjE5ZTlmOWEtYzE5Yi00ODIwLThmNzYtNGMwNzM5YzM4MDRlAAEv8g&start=1780307765693&end=1780912565693&paused=false)


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
