### PR TITLE
test(internal/appsec/apisec): fix flaky/broken API Sec sampler test on gotip

### DIFF
--- a/internal/appsec/apisec/sampler_test.go
+++ b/internal/appsec/apisec/sampler_test.go
@@ -33,7 +33,7 @@ func TestSampler(t *testing.T) {
 		defer cancel()
 	}
 
-	const samplesToTake = config.MaxItemCount << 10
+	const samplesToTake = config.MaxItemCount << 7
 
 	type testCase struct {
 		// KeySpace is the set of keys to randomly draw from when sampling.
@@ -61,23 +61,23 @@ func TestSampler(t *testing.T) {
 		"high": {
 			KeySpace:         testVector[:config.MaxItemCount*2/3],
 			SimulatedTPS:     1000,
-			ExpectedKeepRate: .0091,
+			ExpectedKeepRate: .0094,
 			AllowedDelta:     .0001,
 		},
 		"large": {
 			KeySpace:         testVector[:config.MaxItemCount],
 			SimulatedTPS:     1000,
-			ExpectedKeepRate: .01,
-			AllowedDelta:     .005, // Small chance of collision here... so a bit more wiggle room...
+			ExpectedKeepRate: .0145,
+			AllowedDelta:     .001, // Small chance of collision here... so a bit more wiggle room...
 		},
 		"extreme": { // Not actually realistic usage... Evictions galore!
 			KeySpace:         testVector[:2*config.MaxItemCount],
 			SimulatedTPS:     10000,
-			ExpectedKeepRate: .21,
+			ExpectedKeepRate: .16,
 			// Very random evictions, so keep rate can be pretty off...
 			// It appears that some newer gen P-cores/E-cores CPU are significantly worse at running this job
-			// so we allow a bit more wiggle room here (like 50% worse).
-			AllowedDelta: .5,
+			// so we allow a bit more wiggle room here.
+			AllowedDelta: .07,
 		},
 	}
 

--- a/internal/appsec/apisec/sampler_test.go
+++ b/internal/appsec/apisec/sampler_test.go
@@ -76,8 +76,8 @@ func TestSampler(t *testing.T) {
 			ExpectedKeepRate: .16,
 			// Very random evictions, so keep rate can be pretty off...
 			// It appears that some newer gen P-cores/E-cores CPU are significantly worse at running this job
-			// so we allow a bit more wiggle room here.
-			AllowedDelta: .07,
+			// so we keep this tolerance intentionally broad.
+			AllowedDelta: .5,
 		},
 	}
 

--- a/internal/appsec/apisec/sampler_test.go
+++ b/internal/appsec/apisec/sampler_test.go
@@ -97,13 +97,14 @@ func TestSampler(t *testing.T) {
 					dropped atomic.Uint64
 				)
 				sb.Add(1 + goroutineCount) // All child goroutines + this one...
-				for range goroutineCount {
+				for workerID := range goroutineCount {
 					wg.Go(func() {
+						rng := rand.New(rand.NewSource(int64(workerID)))
 						sb.Done() // We're ready for business, signal to the start barrier...
 						sb.Wait() // Wait for all the goroutines to have started...
 
 						for i := range samplesToTake {
-							if subject.DecisionFor(randomOne(tc.KeySpace)) {
+							if subject.DecisionFor(randomOneFrom(rng, tc.KeySpace)) {
 								kept.Add(1)
 							} else {
 								dropped.Add(1)
@@ -209,8 +210,8 @@ func BenchmarkSampler(b *testing.B) {
 	}
 }
 
-func randomOne[T any](list []T) T {
-	return list[rand.Intn(len(list))]
+func randomOneFrom[T any](rng *rand.Rand, list []T) T {
+	return list[rng.Intn(len(list))]
 }
 
 var (


### PR DESCRIPTION
Give each sampler test worker its own deterministic random source instead
of using the package-level math/rand generator. This makes the generated
sampling sequence reproducible and keeps random input generation local to
each worker, making the concurrent sampler workload easier to reason about.

This is a small cleanup/diagnostic step for the gotip timeout investigation;
local measurements showed only a minor runtime improvement, so further test
reduction is still likely needed.

JJ-Change-Id: qwtmuk

---

Reduce the statistical sampler test from MaxItemCount<<10 samples per
worker to MaxItemCount<<7 and update the expected keep-rate brackets for
the lower sample count. The previous workload performed hundreds of
millions of race-instrumented sampler decisions across all subtests, which
could exceed the default 10 minute package timeout in the gotip sandbox.

The reduced workload still exercises the same traffic shapes, concurrent
sampler access, and eviction-heavy scenarios while keeping the test runtime
bounded. Repeated gotip -race runs passed with the adjusted brackets.

JJ-Change-Id: znnmoy