### PR TITLE
feat: update EventBridge tag convention

### DIFF
--- a/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
+++ b/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
@@ -894,8 +894,8 @@ func TestAppendMiddlewareEventBridgePutEvents(t *testing.T) {
 func eventBridgeEdgeTagsForTest(entry *eventBridgeTypes.PutEventsRequestEntry) []string {
 	return []string{
 		"direction:out",
-		"type:eventbridge:" + eventBridgeNameForTest(entry),
-		"topic:" + eventBridgeDetailTypeForTest(entry),
+		"type:eventbridge",
+		"topic:" + eventBridgeNameForTest(entry) + ":" + eventBridgeDetailTypeForTest(entry),
 	}
 }
 
@@ -908,7 +908,7 @@ func eventBridgeNameForTest(entry *eventBridgeTypes.PutEventsRequestEntry) strin
 
 func eventBridgeDetailTypeForTest(entry *eventBridgeTypes.PutEventsRequestEntry) string {
 	if entry == nil || entry.DetailType == nil {
-		return ""
+		return "unknown"
 	}
 	return *entry.DetailType
 }

--- a/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge.go
+++ b/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge.go
@@ -83,8 +83,8 @@ func getTraceContext(ctx context.Context, span *tracer.Span, entry *types.PutEve
 func eventBridgeEdgeTags(entry *types.PutEventsRequestEntry) []string {
 	return []string{
 		"direction:out",
-		"type:eventbridge:" + eventBusName(entry),
-		"topic:" + detailType(entry),
+		"type:eventbridge",
+		"topic:" + eventBusName(entry) + ":" + detailType(entry),
 	}
 }
 

--- a/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge_test.go
+++ b/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge_test.go
@@ -249,7 +249,7 @@ func TestEventBridgeEdgeTags(t *testing.T) {
 	}
 
 	assert.Equal(t,
-		[]string{"direction:out", "type:eventbridge:orders-bus", "topic:order.created"},
+		[]string{"direction:out", "type:eventbridge", "topic:orders-bus:order.created"},
 		eventBridgeEdgeTags(entry),
 	)
 }

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -271,9 +271,6 @@ func newConfig(opts ...StartOption) (*config, error) {
 	c.sampler = NewAllSampler()
 	c.httpClientTimeout = time.Second * 10 // 10 seconds
 
-	if v := env.Get("OTEL_LOGS_EXPORTER"); v != "" {
-		log.Warn("OTEL_LOGS_EXPORTER is not supported")
-	}
 	if c.internalConfig.TraceAnalyticsEnabled() {
 		globalconfig.SetAnalyticsRate(1.0)
 	}

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -274,7 +274,7 @@ func newConfig(opts ...StartOption) (*config, error) {
 	if v := env.Get("OTEL_LOGS_EXPORTER"); v != "" {
 		log.Warn("OTEL_LOGS_EXPORTER is not supported")
 	}
-	if internal.BoolEnv("DD_TRACE_ANALYTICS_ENABLED", false) {
+	if c.internalConfig.TraceAnalyticsEnabled() {
 		globalconfig.SetAnalyticsRate(1.0)
 	}
 	if c.internalConfig.ReportHostname() {

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -28,8 +28,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.org/x/mod/semver"
-
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/tinylib/msgp/msgp"
 
@@ -215,9 +213,6 @@ type config struct {
 	// enabled reports whether tracing is enabled.
 	enabled dynamicConfig[bool]
 
-	// enableHostnameDetection specifies whether the tracer should enable hostname detection.
-	enableHostnameDetection bool
-
 	// orchestrionCfg holds Orchestrion (aka auto-instrumentation) configuration.
 	// Only used for telemetry currently.
 	orchestrionCfg orchestrionConfig
@@ -311,13 +306,6 @@ func newConfig(opts ...StartOption) (*config, error) {
 	c.enabled = newDynamicConfig("tracing_enabled", internal.BoolVal(getDDorOtelConfig("enabled"), true), func(_ bool) bool { return true }, equal[bool])
 	if _, ok := env.Lookup("DD_TRACE_ENABLED"); ok {
 		c.enabled.setOrigin(telemetry.OriginEnvVar)
-	}
-	if compatMode := env.Get("DD_TRACE_CLIENT_HOSTNAME_COMPAT"); compatMode != "" {
-		if semver.IsValid(compatMode) {
-			c.enableHostnameDetection = semver.Compare(semver.MajorMinor(compatMode), "v1.66") <= 0
-		} else {
-			log.Warn("ignoring DD_TRACE_CLIENT_HOSTNAME_COMPAT, invalid version %q", compatMode)
-		}
 	}
 
 	dynamicInstrumentationEnabledDefault, origin, _ := stableconfig.Bool("DD_DYNAMIC_INSTRUMENTATION_ENABLED", false)

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -223,12 +223,6 @@ type config struct {
 	// headerAsTags holds the header as tags configuration.
 	headerAsTags dynamicConfig[[]string]
 
-	// dynamicInstrumentationEnabled controls whether the target application can
-	// be modified by Dynamic Instrumentation / Live Debugger. If the value is
-	// explicitly set to false (as opposed to starting as false by default), then
-	// it is frozen -- it cannot be overwritten by Remote Config.
-	dynamicInstrumentationEnabled dynamicConfig[bool]
-
 	// ciVisibilityAgentless controls if the tracer is loaded with CI Visibility agentless mode. default false
 	ciVisibilityAgentless bool
 
@@ -307,18 +301,6 @@ func newConfig(opts ...StartOption) (*config, error) {
 	if _, ok := env.Lookup("DD_TRACE_ENABLED"); ok {
 		c.enabled.setOrigin(telemetry.OriginEnvVar)
 	}
-
-	dynamicInstrumentationEnabledDefault, origin, _ := stableconfig.Bool("DD_DYNAMIC_INSTRUMENTATION_ENABLED", false)
-	c.dynamicInstrumentationEnabled = newDynamicConfig(
-		"dynamic_instrumentation_enabled",
-		dynamicInstrumentationEnabledDefault,
-		func(bool) bool {
-			// NOTE: the side effects of changes are performed in onRemoteConfigUpdate.
-			return true
-		}, /* apply */
-		equal[bool],
-	)
-	c.dynamicInstrumentationEnabled.setOrigin(origin)
 
 	namingschema.LoadFromEnv()
 
@@ -1266,12 +1248,7 @@ func WithStatsComputation(enabled bool) StartOption {
 // and Dynamic Instrumentation products.
 func WithDynamicInstrumentationEnabled(enabled bool) StartOption {
 	return func(c *config) {
-		apply := func(bool) bool {
-			// NOTE: the side effects of changes are performed in onRemoteConfigUpdate.
-			return true
-		}
-		c.dynamicInstrumentationEnabled = newDynamicConfig("dynamic_instrumentation_enabled", enabled, apply, equal[bool])
-		c.dynamicInstrumentationEnabled.setOrigin(telemetry.OriginCode)
+		c.internalConfig.SetDynamicInstrumentationEnabled(enabled, telemetry.OriginCode, internalconfig.ProductTracer)
 	}
 }
 

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -1878,20 +1878,6 @@ func TestWithHeaderTags(t *testing.T) {
 	assert.Equal(t, 0, globalconfig.HeaderTagsLen())
 }
 
-func TestHostnameDisabled(t *testing.T) {
-	t.Run("Default", func(t *testing.T) {
-		c, err := newTestConfig()
-		assert.NoError(t, err)
-		assert.False(t, c.enableHostnameDetection)
-	})
-	t.Run("EnableViaEnv", func(t *testing.T) {
-		t.Setenv("DD_TRACE_CLIENT_HOSTNAME_COMPAT", "v1.66")
-		c, err := newTestConfig()
-		assert.NoError(t, err)
-		assert.True(t, c.enableHostnameDetection)
-	})
-}
-
 func TestPartialFlushing(t *testing.T) {
 	partialFlushMinSpansDefault := 1000
 	t.Run("None", func(t *testing.T) {

--- a/ddtrace/tracer/remote_config.go
+++ b/ddtrace/tracer/remote_config.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"regexp"
-	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -271,9 +270,7 @@ func (t *tracer) onRemoteConfigUpdate(u remoteconfig.ProductUpdate) map[string]s
 		telemConfigs = append(telemConfigs, t.config.globalTags.toTelemetry())
 	}
 
-	if telem := t.handleDynamicInstrumentationEnabledRC(merged.LiveDebuggingEnabled); telem != nil {
-		telemConfigs = append(telemConfigs, *telem)
-	}
+	t.handleDynamicInstrumentationEnabledRC(merged.LiveDebuggingEnabled)
 
 	if merged.Enabled != nil {
 		if t.config.enabled.get() && !*merged.Enabled {
@@ -292,47 +289,33 @@ func (t *tracer) onRemoteConfigUpdate(u remoteconfig.ProductUpdate) map[string]s
 }
 
 // Handle enabling or disabling of Dynamic Instrumentation / Live Debugger.
-//
-// Returns a telemetry configuration if the value changed.
-func (t *tracer) handleDynamicInstrumentationEnabledRC(val *bool) *telemetry.Configuration {
-	// Do not overwrite a "false" value coming from the
-	// DD_DYNAMIC_INSTRUMENTATION_ENABLED env var, or from other local sources.
-	explicitOrigins := []telemetry.Origin{
-		telemetry.OriginCode,
-		telemetry.OriginDDConfig,
-		telemetry.OriginEnvVar,
-		telemetry.OriginLocalStableConfig,
-		telemetry.OriginManagedStableConfig,
-	}
-	enabled, origin := t.config.dynamicInstrumentationEnabled.getCurrentAndOrigin()
-	if !enabled && slices.Contains(explicitOrigins, origin) {
-		return nil
+func (t *tracer) handleDynamicInstrumentationEnabledRC(val *bool) {
+	cfg := t.config.internalConfig.DynamicInstrumentationEnabledConfig()
+
+	// Do not overwrite a "false" value coming from any explicit local source
+	// (env var, stable config, programmatic API).
+	baselineEnabled, baselineOrigin := cfg.Baseline()
+	if !baselineEnabled && baselineOrigin != telemetry.OriginDefault {
+		return
 	}
 
-	if !t.config.dynamicInstrumentationEnabled.handleRC(val) {
-		return nil
+	if !cfg.HandleRC(val) {
+		return
 	}
 
 	// The value changed; subscribe or unsubscribe from the Live Debugging RC
 	// product.
-	if t.config.dynamicInstrumentationEnabled.get() {
+	if cfg.Get() {
 		log.Info("Dynamic Instrumentation starting through Remote Config update")
-		err := t.startDynamicInstrumentationRCSubscriptions()
-		if err != nil {
+		if err := t.startDynamicInstrumentationRCSubscriptions(); err != nil {
 			log.Error("failed to start Dynamic Instrumentation subscriptions: %s", err)
-			return nil
 		}
 	} else {
 		log.Info("Dynamic Instrumentation stopping through Remote Config update")
-		err := t.stopDynamicInstrumentationRCSubscriptions()
-		if err != nil {
+		if err := t.stopDynamicInstrumentationRCSubscriptions(); err != nil {
 			log.Error("failed to stop Dynamic Instrumentation subscriptions: %s", err)
-			return nil
 		}
 	}
-
-	telem := t.config.dynamicInstrumentationEnabled.toTelemetry()
-	return &telem
 }
 
 type dynamicInstrumentationRCProbeConfig struct {
@@ -489,7 +472,7 @@ func (t *tracer) startRemoteConfig(rcConfig remoteconfig.ClientConfig) error {
 
 	var dynamicInstrumentationError, apmTracingError error
 
-	if t.config.dynamicInstrumentationEnabled.get() {
+	if t.config.internalConfig.DynamicInstrumentationEnabled() {
 		dynamicInstrumentationError = t.startDynamicInstrumentationRCSubscriptions()
 	}
 

--- a/ddtrace/tracer/remote_config_test.go
+++ b/ddtrace/tracer/remote_config_test.go
@@ -916,6 +916,46 @@ func TestOnRemoteConfigUpdate(t *testing.T) {
 		checkLiveDebuggerRemoteConfigState(false)
 	})
 
+	// Test that Live Debugger cannot be enabled through RC if the env var has
+	// explicitly disabled it.
+	t.Run("enable Live Debugger through RC with env var explicitly disabling it", func(t *testing.T) {
+		telemetryClient := new(telemetrytest.RecordClient)
+		defer telemetry.MockClient(telemetryClient)()
+
+		t.Setenv("DD_DYNAMIC_INSTRUMENTATION_ENABLED", "false")
+
+		startRemoteConfig := func(tracer *tracer) {
+			t.Cleanup(remoteconfig.Reset)
+			t.Cleanup(remoteconfig.Stop)
+			err := tracer.startRemoteConfig(remoteconfig.DefaultClientConfig())
+			require.NoError(t, err)
+		}
+
+		tr, _, _, stop, err := startTestTracer(t,
+			WithService("my-service"), WithEnv("my-env"),
+		)
+		require.Nil(t, err)
+		defer stop()
+		startRemoteConfig(tr)
+
+		checkLiveDebuggerRemoteConfigState := func(enabled bool) {
+			found, err := remoteconfig.HasProduct(state.ProductLiveDebugging)
+			require.NoError(t, err)
+			require.Equal(t, enabled, found)
+		}
+
+		checkLiveDebuggerRemoteConfigState(false)
+
+		input := remoteconfig.ProductUpdate{
+			"path": []byte(
+				`{"lib_config": {"dynamic_instrumentation_enabled": true}, "service_target": {"service": "my-service", "env": "my-env"}}`,
+			),
+		}
+		tr.onRemoteConfigUpdate(input)
+		// Tracer is still not subscribed; the RC update did not override the env-var disable.
+		checkLiveDebuggerRemoteConfigState(false)
+	})
+
 	assert.Equal(t, 0, globalconfig.HeaderTagsLen())
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -225,6 +225,9 @@ func loadConfig() *Config {
 	cfg.debugStack = p.GetBool("DD_TRACE_DEBUG_STACK", true)
 	cfg.retryInterval = p.GetDuration("DD_TRACE_RETRY_INTERVAL", time.Millisecond)
 	cfg.logsOTelEnabled = p.GetBool("DD_LOGS_OTEL_ENABLED", false)
+	if v := p.GetString("OTEL_LOGS_EXPORTER", ""); v != "" {
+		log.Warn("OTEL_LOGS_EXPORTER is not supported")
+	}
 	cfg.traceProtocol = resolveTraceProtocol(p.GetStringWithValidator("DD_TRACE_AGENT_PROTOCOL_VERSION", TraceProtocolVersionStringV04, validateTraceProtocolVersion))
 	cfg.otlpExportMode = p.GetString("OTEL_TRACES_EXPORTER", "") == "otlp"
 	// DD_TRACE_AGENT_PROTOCOL_VERSION overrides OTEL_TRACES_EXPORTER

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,6 +106,7 @@ type Config struct {
 	partialFlushEnabled bool
 	// statsComputationEnabled enables client-side stats computation (aka trace metrics).
 	statsComputationEnabled      bool
+	traceAnalyticsEnabled        bool
 	dataStreamsMonitoringEnabled bool
 	// dynamicInstrumentationEnabled controls whether the target application can
 	// be modified by Dynamic Instrumentation / Live Debugger. If the value is
@@ -215,6 +216,7 @@ func loadConfig() *Config {
 	cfg.partialFlushMinSpans = p.GetIntWithValidator("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", 1000, validatePartialFlushMinSpans)
 	cfg.partialFlushEnabled = p.GetBool("DD_TRACE_PARTIAL_FLUSH_ENABLED", false)
 	cfg.statsComputationEnabled = p.GetBool("DD_TRACE_STATS_COMPUTATION_ENABLED", true)
+	cfg.traceAnalyticsEnabled = p.GetBool("DD_TRACE_ANALYTICS_ENABLED", false)
 	cfg.dataStreamsMonitoringEnabled = p.GetBool("DD_DATA_STREAMS_ENABLED", false)
 	cfg.ciVisibilityEnabled = p.GetBool(constants.CIVisibilityEnabledEnvironmentVariable, false)
 	cfg.ciVisibilityAgentless = p.GetBool("DD_CIVISIBILITY_AGENTLESS_ENABLED", false)
@@ -661,6 +663,12 @@ func (c *Config) SetStatsComputationEnabled(enabled bool, origin telemetry.Origi
 	}
 	c.statsComputationEnabled = enabled
 	configtelemetry.Report("DD_TRACE_STATS_COMPUTATION_ENABLED", enabled, origin)
+}
+
+func (c *Config) TraceAnalyticsEnabled() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.traceAnalyticsEnabled
 }
 
 func (c *Config) LogDirectory() string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -107,8 +107,11 @@ type Config struct {
 	// statsComputationEnabled enables client-side stats computation (aka trace metrics).
 	statsComputationEnabled      bool
 	dataStreamsMonitoringEnabled bool
-	// dynamicInstrumentationEnabled controls if the target application can be modified by Dynamic Instrumentation or not.
-	dynamicInstrumentationEnabled bool
+	// dynamicInstrumentationEnabled controls whether the target application can
+	// be modified by Dynamic Instrumentation / Live Debugger. If the value is
+	// explicitly set to false (as opposed to starting as false by default), then
+	// it is frozen -- it cannot be overwritten by Remote Config.
+	dynamicInstrumentationEnabled *DynamicConfig[bool]
 	// globalSampleRate holds the sample rate for the tracer.
 	globalSampleRate *DynamicConfig[float64]
 	// ciVisibilityEnabled controls if the tracer is loaded with CI Visibility mode. default false
@@ -213,7 +216,6 @@ func loadConfig() *Config {
 	cfg.partialFlushEnabled = p.GetBool("DD_TRACE_PARTIAL_FLUSH_ENABLED", false)
 	cfg.statsComputationEnabled = p.GetBool("DD_TRACE_STATS_COMPUTATION_ENABLED", true)
 	cfg.dataStreamsMonitoringEnabled = p.GetBool("DD_DATA_STREAMS_ENABLED", false)
-	cfg.dynamicInstrumentationEnabled = p.GetBool("DD_DYNAMIC_INSTRUMENTATION_ENABLED", false)
 	cfg.ciVisibilityEnabled = p.GetBool(constants.CIVisibilityEnabledEnvironmentVariable, false)
 	cfg.ciVisibilityAgentless = p.GetBool("DD_CIVISIBILITY_AGENTLESS_ENABLED", false)
 	cfg.logDirectory = p.GetString("DD_TRACE_LOG_DIRECTORY", "")
@@ -233,6 +235,9 @@ func loadConfig() *Config {
 
 	sampleRate, sampleRateOrigin := p.GetFloatWithValidatorOrigin("DD_TRACE_SAMPLE_RATE", math.NaN(), validateSampleRate)
 	cfg.globalSampleRate = newDynamicConfig("trace_sample_rate", sampleRate, sampleRateOrigin, equalFloat)
+
+	enabled, origin := p.GetBoolWithOrigin("DD_DYNAMIC_INSTRUMENTATION_ENABLED", false)
+	cfg.dynamicInstrumentationEnabled = newDynamicConfig("dynamic_instrumentation_enabled", enabled, origin, equal[bool])
 
 	// Parse feature flags from DD_TRACE_FEATURES as a set
 	cfg.featureFlags = make(map[string]struct{})
@@ -526,6 +531,27 @@ func (c *Config) SetGlobalSampleRate(rate float64, origin telemetry.Origin, prod
 	}
 	c.globalSampleRate.setBaseline(rate, origin)
 	configtelemetry.Report("DD_TRACE_SAMPLE_RATE", rate, origin)
+}
+
+func (c *Config) DynamicInstrumentationEnabled() bool {
+	return c.dynamicInstrumentationEnabled.Get()
+}
+
+// DynamicInstrumentationEnabledConfig returns the DynamicConfig for the
+// dynamic instrumentation enabled flag. Products use this to apply RC updates
+// and inspect the baseline for local-explicit gating.
+func (c *Config) DynamicInstrumentationEnabledConfig() *DynamicConfig[bool] {
+	return c.dynamicInstrumentationEnabled
+}
+
+func (c *Config) SetDynamicInstrumentationEnabled(enabled bool, origin telemetry.Origin, product ...Product) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.checkProductConflict("DD_DYNAMIC_INSTRUMENTATION_ENABLED", origin, enabled, product...) {
+		return
+	}
+	c.dynamicInstrumentationEnabled.setBaseline(enabled, origin)
+	configtelemetry.Report("DD_DYNAMIC_INSTRUMENTATION_ENABLED", enabled, origin)
 }
 
 func (c *Config) TraceRateLimitPerSecond() float64 {

--- a/internal/config/dynamic_config.go
+++ b/internal/config/dynamic_config.go
@@ -20,6 +20,13 @@ func equalFloat(a, b float64) bool {
 	return a == b || (math.IsNaN(a) && math.IsNaN(b))
 }
 
+// equal compares two scalar values using Go's == operator. Use for bool, int,
+// string, and other comparable types where reference equality is sufficient.
+// For float64, prefer equalFloat to handle NaN.
+func equal[T comparable](a, b T) bool {
+	return a == b
+}
+
 // DynamicConfig is a thread-safe, RC-aware value store for a single configuration field.
 // It tracks both the current value and the startup baseline (for RC reset).
 // Consumers read via Get().
@@ -56,6 +63,13 @@ func (dc *DynamicConfig[T]) Get() T {
 	dc.mu.RLock()
 	defer dc.mu.RUnlock()
 	return dc.current
+}
+
+// Baseline returns the startup value and its origin atomically.
+func (dc *DynamicConfig[T]) Baseline() (T, telemetry.Origin) {
+	dc.mu.RLock()
+	defer dc.mu.RUnlock()
+	return dc.startup, dc.startupOrigin
 }
 
 // HandleRC processes a remote config update. If val is non-nil, the value is

--- a/internal/config/dynamic_config_test.go
+++ b/internal/config/dynamic_config_test.go
@@ -158,6 +158,31 @@ func TestDynamicConfig(t *testing.T) {
 		assertTelemetryReport(t, client.Configuration, "my_field", 1.0, telemetry.OriginCode)
 	})
 
+	t.Run("Baseline returns startup value and origin", func(t *testing.T) {
+		dc := newDynamicConfig("test", 1.0, telemetry.OriginEnvVar, equalFloat)
+		val, origin := dc.Baseline()
+		assert.Equal(t, 1.0, val)
+		assert.Equal(t, telemetry.OriginEnvVar, origin)
+	})
+
+	t.Run("Baseline unchanged by HandleRC", func(t *testing.T) {
+		dc := newDynamicConfig("test", 1.0, telemetry.OriginEnvVar, equalFloat)
+		rate := 0.5
+		dc.HandleRC(&rate)
+		val, origin := dc.Baseline()
+		assert.Equal(t, 1.0, val, "baseline value should not reflect RC update")
+		assert.Equal(t, telemetry.OriginEnvVar, origin, "baseline origin should not reflect RC")
+		assert.Equal(t, 0.5, dc.Get(), "current value should reflect RC update")
+	})
+
+	t.Run("Baseline reflects setBaseline updates", func(t *testing.T) {
+		dc := newDynamicConfig("test", 1.0, telemetry.OriginDefault, equalFloat)
+		dc.setBaseline(2.0, telemetry.OriginCode)
+		val, origin := dc.Baseline()
+		assert.Equal(t, 2.0, val)
+		assert.Equal(t, telemetry.OriginCode, origin)
+	})
+
 	t.Run("concurrent access is safe", func(t *testing.T) {
 		dc := newDynamicConfig("test", 0, telemetry.OriginDefault, func(a, b int) bool { return a == b })
 		var wg sync.WaitGroup

--- a/internal/config/provider/provider.go
+++ b/internal/config/provider/provider.go
@@ -99,7 +99,15 @@ func (p *Provider) GetStringWithValidator(key string, def string, validate func(
 }
 
 func (p *Provider) GetBool(key string, def bool) bool {
-	return get(p, key, def, func(v string) (bool, bool) {
+	v, _ := p.GetBoolWithOrigin(key, def)
+	return v
+}
+
+// GetBoolWithOrigin is like GetBool but also returns the origin of the winning
+// configuration source. Use this when the caller needs to know where the value
+// came from (e.g. to pass to DynamicConfig).
+func (p *Provider) GetBoolWithOrigin(key string, def bool) (bool, telemetry.Origin) {
+	return getWithOrigin(p, key, def, func(v string) (bool, bool) {
 		boolVal, err := strconv.ParseBool(v)
 		if err == nil {
 			return boolVal, true

--- a/internal/config/provider/provider_test.go
+++ b/internal/config/provider/provider_test.go
@@ -162,6 +162,34 @@ func TestGetMethods(t *testing.T) {
 			assert.Equal(t, false, p.GetBool("TEST_BOOL", false), "Expected default (false) for invalid value %q", val)
 		}
 	})
+	t.Run("GetBoolWithOrigin returns OriginDefault when unset", func(t *testing.T) {
+		p := newTestProvider(newTestConfigSource(nil, telemetry.OriginEnvVar))
+		v, origin := p.GetBoolWithOrigin("TEST_BOOL", false)
+		assert.Equal(t, false, v)
+		assert.Equal(t, telemetry.OriginDefault, origin)
+
+		v, origin = p.GetBoolWithOrigin("TEST_BOOL", true)
+		assert.Equal(t, true, v)
+		assert.Equal(t, telemetry.OriginDefault, origin)
+	})
+	t.Run("GetBoolWithOrigin returns source origin when set", func(t *testing.T) {
+		for _, origin := range []telemetry.Origin{
+			telemetry.OriginEnvVar,
+			telemetry.OriginLocalStableConfig,
+			telemetry.OriginManagedStableConfig,
+		} {
+			p := newTestProvider(newTestConfigSource(map[string]string{"TEST_BOOL": "true"}, origin))
+			v, gotOrigin := p.GetBoolWithOrigin("TEST_BOOL", false)
+			assert.Equal(t, true, v)
+			assert.Equal(t, origin, gotOrigin)
+		}
+	})
+	t.Run("GetBoolWithOrigin returns OriginDefault for invalid value", func(t *testing.T) {
+		p := newTestProvider(newTestConfigSource(map[string]string{"TEST_BOOL": "notabool"}, telemetry.OriginEnvVar))
+		v, origin := p.GetBoolWithOrigin("TEST_BOOL", true)
+		assert.Equal(t, true, v)
+		assert.Equal(t, telemetry.OriginDefault, origin)
+	})
 }
 
 func TestNew(t *testing.T) {

--- a/internal/env/supported_configurations.gen.go
+++ b/internal/env/supported_configurations.gen.go
@@ -157,7 +157,6 @@ var SupportedConfigurations = map[string]struct{}{
 	"DD_TRACE_BAGGAGE_TAG_KEYS":                                       {},
 	"DD_TRACE_BUNTDB_ANALYTICS_ENABLED":                               {},
 	"DD_TRACE_CHI_ANALYTICS_ENABLED":                                  {},
-	"DD_TRACE_CLIENT_HOSTNAME_COMPAT":                                 {},
 	"DD_TRACE_CLIENT_IP_ENABLED":                                      {},
 	"DD_TRACE_CLIENT_IP_HEADER":                                       {},
 	"DD_TRACE_CONSUL_ANALYTICS_ENABLED":                               {},

--- a/internal/env/supported_configurations.json
+++ b/internal/env/supported_configurations.json
@@ -1043,13 +1043,6 @@
         "default": "false"
       }
     ],
-    "DD_TRACE_CLIENT_HOSTNAME_COMPAT": [
-      {
-        "implementation": "A",
-        "type": "string",
-        "default": null
-      }
-    ],
     "DD_TRACE_CLIENT_IP_ENABLED": [
       {
         "implementation": "A",


### PR DESCRIPTION
### What does this PR do?

This is a small follow on PR from what that was [merged a couple of weeks ago](https://github.com/DataDog/dd-trace-go/pull/4772). After chatting further with the DSM team we've decided to change the naming convention slightly.

### Motivation

Small naming convention change to existing functionality.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
