### PR TITLE
fix(contrib/aws/aws-sdk-go-v2): update eventbridge dsm checkpoint tags

### DIFF
--- a/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
+++ b/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
@@ -894,9 +894,8 @@ func TestAppendMiddlewareEventBridgePutEvents(t *testing.T) {
 func eventBridgeEdgeTagsForTest(entry *eventBridgeTypes.PutEventsRequestEntry) []string {
 	return []string{
 		"direction:out",
-		"exchange:" + eventBridgeNameForTest(entry),
-		"topic:" + eventBridgeDetailTypeForTest(entry),
 		"type:eventbridge",
+		"topic:" + eventBridgeNameForTest(entry) + ":" + eventBridgeDetailTypeForTest(entry),
 	}
 }
 
@@ -909,7 +908,7 @@ func eventBridgeNameForTest(entry *eventBridgeTypes.PutEventsRequestEntry) strin
 
 func eventBridgeDetailTypeForTest(entry *eventBridgeTypes.PutEventsRequestEntry) string {
 	if entry == nil || entry.DetailType == nil {
-		return ""
+		return "unknown"
 	}
 	return *entry.DetailType
 }

--- a/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge.go
+++ b/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge.go
@@ -83,9 +83,8 @@ func getTraceContext(ctx context.Context, span *tracer.Span, entry *types.PutEve
 func eventBridgeEdgeTags(entry *types.PutEventsRequestEntry) []string {
 	return []string{
 		"direction:out",
-		"exchange:" + eventBusName(entry),
-		"topic:" + detailType(entry),
 		"type:eventbridge",
+		"topic:" + eventBusName(entry) + ":" + detailType(entry),
 	}
 }
 

--- a/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge_test.go
+++ b/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge_test.go
@@ -249,7 +249,7 @@ func TestEventBridgeEdgeTags(t *testing.T) {
 	}
 
 	assert.Equal(t,
-		[]string{"direction:out", "exchange:orders-bus", "topic:order.created", "type:eventbridge"},
+		[]string{"direction:out", "type:eventbridge", "topic:orders-bus:order.created"},
 		eventBridgeEdgeTags(entry),
 	)
 }


### PR DESCRIPTION
### What does this PR do?

This is a small follow on PR from what that was [merged a couple of weeks ago](https://github.com/DataDog/dd-trace-go/pull/4772). After chatting further with the DSM team we've decided to change the naming convention slightly.

### Motivation

Small naming convention change to existing functionality.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
