### PR TITLE
fix(contrib/aws/aws-sdk-go-v2): update eventbridge dsm checkpoint tags (shadow)

### DIFF
--- a/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
+++ b/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
@@ -894,9 +894,8 @@ func TestAppendMiddlewareEventBridgePutEvents(t *testing.T) {
 func eventBridgeEdgeTagsForTest(entry *eventBridgeTypes.PutEventsRequestEntry) []string {
 	return []string{
 		"direction:out",
-		"exchange:" + eventBridgeNameForTest(entry),
-		"topic:" + eventBridgeDetailTypeForTest(entry),
 		"type:eventbridge",
+		"topic:" + eventBridgeNameForTest(entry) + ":" + eventBridgeDetailTypeForTest(entry),
 	}
 }
 
@@ -909,7 +908,7 @@ func eventBridgeNameForTest(entry *eventBridgeTypes.PutEventsRequestEntry) strin
 
 func eventBridgeDetailTypeForTest(entry *eventBridgeTypes.PutEventsRequestEntry) string {
 	if entry == nil || entry.DetailType == nil {
-		return ""
+		return "unknown"
 	}
 	return *entry.DetailType
 }

--- a/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge.go
+++ b/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge.go
@@ -83,9 +83,8 @@ func getTraceContext(ctx context.Context, span *tracer.Span, entry *types.PutEve
 func eventBridgeEdgeTags(entry *types.PutEventsRequestEntry) []string {
 	return []string{
 		"direction:out",
-		"exchange:" + eventBusName(entry),
-		"topic:" + detailType(entry),
 		"type:eventbridge",
+		"topic:" + eventBusName(entry) + ":" + detailType(entry),
 	}
 }
 

--- a/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge_test.go
+++ b/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge_test.go
@@ -249,7 +249,7 @@ func TestEventBridgeEdgeTags(t *testing.T) {
 	}
 
 	assert.Equal(t,
-		[]string{"direction:out", "exchange:orders-bus", "topic:order.created", "type:eventbridge"},
+		[]string{"direction:out", "type:eventbridge", "topic:orders-bus:order.created"},
 		eventBridgeEdgeTags(entry),
 	)
 }


### PR DESCRIPTION
Shadow PR for CI jobs that cannot run on fork PRs.

Original PR: https://github.com/DataDog/dd-trace-go/pull/4867 (by @jeastham1993)