### PR TITLE
docs(contrib/labstack/echo.v4): fix inverted WithErrorCheck doc comment (shadow)

### DIFF
--- a/contrib/labstack/echo.v4/option.go
+++ b/contrib/labstack/echo.v4/option.go
@@ -146,8 +146,9 @@ func WithHeaderTags(headers []string) OptionFn {
 	}
 }
 
-// WithErrorCheck sets the func which determines if err would be ignored (if it returns true, the error is not tagged).
-// This function also checks the errors created from the WithStatusCheck option.
+// WithErrorCheck specifies a function fn which determines whether the passed error
+// should be marked as an error. If fn returns true the error is tagged on the span,
+// otherwise it is ignored. This also applies to errors created from the WithStatusCheck option.
 func WithErrorCheck(errCheck func(error) bool) OptionFn {
 	return func(cfg *config) {
 		cfg.errCheck = errCheck


### PR DESCRIPTION
Shadow PR for CI jobs that cannot run on fork PRs.

Original PR: https://github.com/DataDog/dd-trace-go/pull/4858 (by @korECM)