### PR TITLE
refactor(tracer): read DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED via internalConfig

### DIFF
--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -157,13 +157,11 @@ func TestStartSpanFromContextRace(t *testing.T) {
 }
 
 func Test128(t *testing.T) {
-	_, _, _, stop, err := startTestTracer(t)
-	assert.Nil(t, err)
-	defer stop()
-
 	t.Run("disable 128 bit trace ids", func(t *testing.T) {
-		old := traceID128BitEnabled.Swap(false)
-		defer func(v bool) { traceID128BitEnabled.Store(v) }(old)
+		t.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "false")
+		_, _, _, stop, err := startTestTracer(t)
+		assert.Nil(t, err)
+		defer stop()
 		span, _ := StartSpanFromContext(context.Background(), "http.request")
 		assert.NotZero(t, span.Context().TraceID())
 		w3cCtx := span.Context()
@@ -178,6 +176,9 @@ func Test128(t *testing.T) {
 
 	t.Run("enable 128 bit trace ids", func(t *testing.T) {
 		// DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED is true by default
+		_, _, _, stop, err := startTestTracer(t)
+		assert.Nil(t, err)
+		defer stop()
 		span128, _ := StartSpanFromContext(context.Background(), "http.request")
 		assert.NotZero(t, span128.Context().TraceID())
 		w3cCtx := span128.Context()

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -369,9 +369,6 @@ func newConfig(opts ...StartOption) (*config, error) {
 	c.llmobs.AgentFeatures = llmobsconfig.AgentFeatures{
 		EVPProxyV2: af.evpProxyV2,
 	}
-	// Set global 128-bits trace ID generation variable
-	traceID128BitEnabled.Store(c.internalConfig.TraceID128BitEnabled())
-
 	return c, nil
 }
 

--- a/ddtrace/tracer/span_test.go
+++ b/ddtrace/tracer/span_test.go
@@ -1384,12 +1384,11 @@ func TestSpanLog(t *testing.T) {
 	t.Run("128-bit-logging-only", func(t *testing.T) {
 		// Logging 128-bit trace ids is enabled, but 128bit format is not present in
 		// the span. So only the lower 64 bits should be logged in decimal form.
+		t.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "false")
 		assert := assert.New(t)
 		tracer, _, _, stop, err := startTestTracer(t, WithService("tracer.test"), WithEnv("testenv"))
 		assert.Nil(err)
 		defer stop()
-		old := traceID128BitEnabled.Swap(false)
-		defer func(v bool) { traceID128BitEnabled.Store(v) }(old)
 		span := tracer.StartSpan("test.request")
 		span.traceID = 12345678
 		span.spanID = 87654321
@@ -1401,8 +1400,6 @@ func TestSpanLog(t *testing.T) {
 	t.Run("128-bit-logging-with-generation", func(t *testing.T) {
 		// Logging 128-bit trace ids is enabled, and a 128-bit trace id, so
 		// a quoted 32 byte hex string should be printed for the dd.trace_id.
-		old := traceID128BitEnabled.Swap(true)
-		defer func(v bool) { traceID128BitEnabled.Store(v) }(old)
 		t.Setenv("DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED", "true")
 		assert := assert.New(t)
 		tracer, _, _, stop, err := startTestTracer(t, WithService("tracer.test"), WithEnv("testenv"))
@@ -1420,8 +1417,7 @@ func TestSpanLog(t *testing.T) {
 	t.Run("128-bit-logging-with-small-upper-bits", func(t *testing.T) {
 		// Logging 128-bit trace ids is enabled, and a 128-bit trace id, so
 		// a quoted 32 byte hex string should be printed for the dd.trace_id.
-		old := traceID128BitEnabled.Swap(false)
-		defer func(v bool) { traceID128BitEnabled.Store(v) }(old)
+		t.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "false")
 		assert := assert.New(t)
 		tracer, _, _, stop, err := startTestTracer(t, WithService("tracer.test"), WithEnv("testenv"))
 		assert.Nil(err)
@@ -1437,12 +1433,11 @@ func TestSpanLog(t *testing.T) {
 	t.Run("128-bit-logging-with-empty-upper-bits", func(t *testing.T) {
 		// Logging 128-bit trace ids is enabled, but the upper 64 bits
 		// are empty, so the dd.trace_id should be printed as raw digits (not hex).
+		t.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "false")
 		assert := assert.New(t)
 		tracer, _, _, stop, err := startTestTracer(t, WithService("tracer.test"), WithEnv("testenv"))
 		assert.Nil(err)
 		defer stop()
-		old := traceID128BitEnabled.Swap(false)
-		defer func(v bool) { traceID128BitEnabled.Store(v) }(old)
 		span := tracer.StartSpan("test.request", WithSpanID(87654321))
 		span.Finish()
 		assert.False(span.context.traceID.HasUpper()) // it should not have generated upper bits

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -31,17 +31,6 @@ import (
 
 const TraceIDZero string = "00000000000000000000000000000000"
 
-// traceID128BitEnabled caches DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED
-// at init time so that newSpanContext avoids calling BoolEnv on every span.
-// It is re-set by newConfig on every tracer start so that restarts pick up
-// any changed value. The init here ensures it is correct even when using
-// mocktracer (which does not call newConfig).
-var traceID128BitEnabled atomic.Bool
-
-func init() {
-	traceID128BitEnabled.Store(sharedinternal.BoolEnv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", true))
-}
-
 var _ ddtrace.SpanContext = (*SpanContext)(nil)
 
 // traceID in big endian, i.e. <upper><lower>
@@ -272,17 +261,13 @@ func newSpanContext(span *Span, parent *SpanContext) *SpanContext {
 			return true
 		})
 	}
-	// We generate a new upper trace ID when the trace is brand new (no parent)
-	// or when the parent is baggage only, since baggage only parents should
-	// not propagate their trace IDs
-	if (parent == nil || parent.baggageOnly) && traceID128BitEnabled.Load() { // +checklocksignore - Read-only after init.
-		// add 128 bit trace id, if enabled, formatted as big-endian:
-		// <32-bit unix seconds> <32 bits of zero> <64 random bits>
+
+	// Generate the upper 64 bits of a 128-bit trace ID when this is a new
+	// root span (no parent, or baggage-only parent that doesn't propagate IDs).
+	if (parent == nil || parent.baggageOnly) && internalconfig.Get().TraceID128BitEnabled() { // +checklocksignore - Read-only after init.
+		// Format: <32-bit unix seconds> <32 bits of zero> <64 random bits>
 		id128 := time.Duration(span.start) / time.Second
-		// casting from int64 -> uint32 should be safe since the start time won't be
-		// negative, and the seconds should fit within 32-bits for the foreseeable future.
-		// (We only want 32 bits of time, then the rest is zero)
-		tUp := uint64(uint32(id128)) << 32 // We need the time at the upper 32 bits of the uint
+		tUp := uint64(uint32(id128)) << 32
 		context.traceID.SetUpper(tUp)
 	}
 	if context.trace == nil {

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -643,8 +643,6 @@ func TestTextMapPropagator(t *testing.T) {
 	})
 
 	t.Run("InjectExtract", func(t *testing.T) {
-		old := traceID128BitEnabled.Swap(true)
-		defer func(v bool) { traceID128BitEnabled.Store(v) }(old)
 		t.Setenv(headerPropagationStyleExtract, "datadog")
 		t.Setenv(headerPropagationStyleInject, "datadog")
 		propagator := NewPropagator(&PropagatorConfig{

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -806,15 +806,14 @@ func TestTracerStartSpanOptions(t *testing.T) {
 }
 
 func TestTracerStartSpanOptions128(t *testing.T) {
-	tracer, err := newTracer()
-	assert.NoError(t, err)
-	setGlobalTracer(tracer)
-	defer tracer.Stop()
-	defer setGlobalTracer(&NoopTracer{})
 	t.Run("64-bit-trace-id", func(t *testing.T) {
+		t.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "false")
+		tracer, err := newTracer()
+		assert.NoError(t, err)
+		setGlobalTracer(tracer)
+		defer tracer.Stop()
+		defer setGlobalTracer(&NoopTracer{})
 		assert := assert.New(t)
-		old := traceID128BitEnabled.Swap(false)
-		defer func(v bool) { traceID128BitEnabled.Store(v) }(old)
 		opts := []StartSpanOption{
 			WithSpanID(987654),
 		}
@@ -831,8 +830,13 @@ func TestTracerStartSpanOptions128(t *testing.T) {
 		assert.Equal(tid[:], idBytes)
 	})
 	t.Run("128-bit-trace-id", func(t *testing.T) {
-		assert := assert.New(t)
 		// 128-bit trace ids are enabled by default.
+		tracer, err := newTracer()
+		assert.NoError(t, err)
+		setGlobalTracer(tracer)
+		defer tracer.Stop()
+		defer setGlobalTracer(&NoopTracer{})
+		assert := assert.New(t)
 		opts128 := []StartSpanOption{
 			WithSpanID(987654),
 			StartTime(time.Unix(123456, 0)),
@@ -1267,14 +1271,13 @@ func testNewSpanChild(t *testing.T, is128 bool) {
 	t.Run(fmt.Sprintf("TestNewChildSpan(is128=%t)", is128), func(t *testing.T) {
 		assert := assert.New(t)
 
+		if !is128 {
+			t.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "false")
+		}
 		// the tracer must create child spans
 		tracer, err := newTracer(withTransport(newDefaultTransport()))
 		setGlobalTracer(tracer)
 		defer tracer.Stop()
-		if !is128 {
-			old := traceID128BitEnabled.Swap(false)
-			defer func(v bool) { traceID128BitEnabled.Store(v) }(old)
-		}
 		assert.Nil(err)
 		parent := tracer.newRootSpan("pylons.request", "pylons", "/")
 		child := tracer.newChildSpan("redis.command", parent)


### PR DESCRIPTION
## What does this PR do?

Removes the `traceID128BitEnabled` package-level `atomic.Bool` from `spancontext.go`. The 128-bit trace ID generation condition (`parent == nil || parent.baggageOnly`) is preserved exactly, but the config value is now read from `internalconfig.Get().TraceID128BitEnabled()` instead of a direct `BoolEnv` call in an `init()` function. The re-set in `option.go`'s `newConfig` is also removed.

## Motivation

`DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED` showed up as `STILL_READ` in the config audit tool — the package `init()` was reading the env var directly, bypassing the `internal/config` provider. This change routes the read through the config singleton, consistent with how all other migrated configs are accessed.