### PR TITLE
feat(ci): add build metrics tracking for standard vs Orchestrion builds

### DIFF
--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -1,0 +1,114 @@
+name: Build Metrics
+
+# Build Metrics Workflow
+#
+# Measures build time and binary size for representative Orchestrion integration samples
+# built two ways from identical source:
+#   - Standard Go toolchain (go test -c)
+#   - Orchestrion (go test -c -toolexec='orchestrion toolexec')
+#
+# Key features:
+# - Cold cache measurement: cleans build cache before each measurement to capture full compilation cost
+# - Warm module cache: runs go mod download (untimed) so measurement reflects compilation, not network
+# - Datadog CI Visibility: publishes metrics and tags to job spans for dashboard trending and regression monitoring
+# - Runs on: Pull requests (when this file or any go.mod changes) and pushes to main
+# - Tags metrics by: build.toolchain, build.sample, build.cache, go.version, orchestrion.version
+#
+# Dashboard: View trends in Datadog CI Visibility (filter @git.branch:main, split by build.toolchain)
+# Monitor: Alerts on binary size or build time regressions >5% (size) or >25% (duration) vs main baseline
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/build-metrics.yml
+      - '**/go.mod'
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/build-metrics.yml
+      - '**/go.mod'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build-metrics:
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [standard, orchestrion]
+        sample: [net_http]
+    runs-on: ubuntu-latest
+    name: Build Metrics (${{ matrix.sample }}, ${{ matrix.mode }})
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: stable
+          cache: false  # Cold build cache for accurate measurements
+          check-latest: true
+
+      - name: Measure build
+        id: measure
+        run: ./scripts/measure_build.sh --sample ${{ matrix.sample }} --mode ${{ matrix.mode }} --output "$RUNNER_TEMP/metrics.json"
+
+      - name: Upload metrics artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: build-metrics-${{ matrix.sample }}-${{ matrix.mode }}
+          path: ${{ runner.temp }}/metrics.json
+          if-no-files-found: error
+          retention-days: 7
+
+      # ---- Publish to Datadog: main repo only (forks lack OIDC) ----
+      - name: Get Datadog credentials
+        id: dd-sts
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'DataDog/dd-trace-go'
+        continue-on-error: true
+        uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75
+        with:
+          policy: dd-trace-go
+
+      # Install datadog-ci using the same pattern as dd-ci-upload action
+      - name: Set datadog-ci platform
+        if: steps.dd-sts.outcome == 'success'
+        run: echo "DD_CI_CLI_BUILD=linux-x64" >> $GITHUB_ENV
+
+      - name: Cache datadog-ci
+        if: steps.dd-sts.outcome == 'success'
+        id: dd-ci-cli-cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ./datadog-ci
+          key: datadog-ci-cli-${{ env.DD_CI_CLI_BUILD }}
+
+      - name: Install datadog-ci
+        if: steps.dd-sts.outcome == 'success' && steps.dd-ci-cli-cache.outputs.cache-hit != 'true'
+        run: |
+          curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_${{ env.DD_CI_CLI_BUILD }}" --output datadog-ci
+          chmod +x datadog-ci
+
+      - name: Add datadog-ci to PATH
+        if: steps.dd-sts.outcome == 'success'
+        run: echo "${{ github.workspace }}" >> $GITHUB_PATH
+
+      - name: Publish measures to CI Visibility
+        if: steps.dd-sts.outcome == 'success'
+        env:
+          DATADOG_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
+          DATADOG_SITE: datadoghq.com
+          METRICS_FILE: ${{ runner.temp }}/metrics.json
+        run: ./scripts/publish_build_metrics.sh

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Add datadog-ci to PATH
         if: steps.dd-sts.outcome == 'success'
-        run: echo "${{ github.workspace }}" >> $GITHUB_PATH
+        run: echo "${{ github.workspace }}" >> "$GITHUB_PATH"
 
       - name: Publish measures to CI Visibility
         if: steps.dd-sts.outcome == 'success'

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -85,7 +85,7 @@ jobs:
       # Install datadog-ci using the same pattern as dd-ci-upload action
       - name: Set datadog-ci platform
         if: steps.dd-sts.outcome == 'success'
-        run: echo "DD_CI_CLI_BUILD=linux-x64" >> $GITHUB_ENV
+        run: echo "DD_CI_CLI_BUILD=linux-x64" >> "$GITHUB_ENV"
 
       - name: Cache datadog-ci
         if: steps.dd-sts.outcome == 'success'

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -125,6 +125,62 @@ go run ./scripts/program-name.go
 3. If it needs dependencies, create a separate `go.mod` file
 4. Don't add the module to `go.work`
 
+## Build Metrics Scripts
+
+Scripts for measuring build cost and publishing to Datadog CI Visibility:
+
+### measure_build.sh
+
+Measures build time and binary size for Orchestrion integration samples. Builds are performed with a cold build cache to measure full compilation cost, after warming the module download cache (untimed) so the measurement reflects compilation rather than network downloads.
+
+```bash
+# Build with standard Go toolchain
+./scripts/measure_build.sh --sample net_http --mode standard --output /tmp/metrics.json
+
+# Build with Orchestrion
+./scripts/measure_build.sh --sample net_http --mode orchestrion --output /tmp/metrics.json
+
+# Multiple repeats for median (reduces noise)
+./scripts/measure_build.sh --sample net_http --mode standard --repeats 3
+```
+
+**Options:**
+- `--sample NAME` - Sample to build (default: net_http)
+- `--mode MODE` - Build mode: `standard` or `orchestrion` (required)
+- `--output PATH` - Output JSON file path (default: stdout)
+- `--repeats N` - Number of build repeats for median (default: 3)
+
+**Output format:**
+```json
+{
+  "sample": "net_http",
+  "mode": "orchestrion",
+  "metrics": {
+    "build_duration_seconds": 312.4,
+    "binary_size_bytes": 48217344
+  },
+  "go_version": "1.25.0",
+  "orchestrion_version": "v1.9.0"
+}
+```
+
+### publish_build_metrics.sh
+
+Publishes build metrics to Datadog CI Visibility using `datadog-ci`. Attaches measures (`go.build.duration_seconds`, `go.build.binary_size_bytes`) and tags (`build.toolchain`, `build.sample`, `build.cache`, `go.version`, `orchestrion.version`) to the current CI job span.
+
+```bash
+# Set environment and publish
+export METRICS_FILE=/tmp/metrics.json
+export DATADOG_API_KEY=<key>
+export DATADOG_SITE=datadoghq.com
+./scripts/publish_build_metrics.sh
+```
+
+**Required environment variables:**
+- `METRICS_FILE` - Path to metrics JSON from `measure_build.sh`
+- `DATADOG_API_KEY` - Datadog API key
+- `DATADOG_SITE` - Datadog site (default: datadoghq.com)
+
 ## Guidelines
 
 - Scripts should be idempotent when possible

--- a/scripts/measure_build.sh
+++ b/scripts/measure_build.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2026 Datadog, Inc.
+set -euo pipefail
+
+# measure_build.sh — measure build time and binary size for Orchestrion integration samples
+#
+# Usage: scripts/measure_build.sh [OPTIONS]
+#
+# Options:
+#   --sample NAME         Sample to build (default: net_http)
+#   --mode MODE           Build mode: standard or orchestrion (required)
+#   --output PATH         Output JSON file path (default: stdout)
+#   --repeats N           Number of build repeats for median (default: 3)
+#   -h, --help            Show this help message
+#
+# Examples:
+#   scripts/measure_build.sh --sample net_http --mode standard
+#   scripts/measure_build.sh --sample net_http --mode orchestrion --output /tmp/metrics.json
+
+usage() {
+  cat << EOF
+Usage: $(basename "${BASH_SOURCE[0]}") [OPTIONS]
+
+Measure build time and binary size for Orchestrion integration samples.
+Builds are performed with a cold build cache to measure full compilation cost.
+
+Options:
+  --sample NAME         Sample to build (default: net_http)
+  --mode MODE           Build mode: standard or orchestrion (required)
+  --output PATH         Output JSON file path (default: stdout)
+  --repeats N           Number of build repeats for median (default: 3)
+  -h, --help            Show this help message
+
+Examples:
+  $(basename "${BASH_SOURCE[0]}") --sample net_http --mode standard
+  $(basename "${BASH_SOURCE[0]}") --sample net_http --mode orchestrion --output /tmp/metrics.json
+EOF
+  exit 0
+}
+
+message() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >&2
+}
+
+die() {
+  message "ERROR: $*"
+  exit 1
+}
+
+# Defaults
+SAMPLE="net_http"
+MODE=""
+OUTPUT=""
+REPEATS=3
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sample)
+      SAMPLE="$2"
+      shift 2
+      ;;
+    --mode)
+      MODE="$2"
+      shift 2
+      ;;
+    --output)
+      OUTPUT="$2"
+      shift 2
+      ;;
+    --repeats)
+      REPEATS="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      ;;
+    *)
+      die "Unknown argument: $1"
+      ;;
+  esac
+done
+
+# Validate required arguments
+if [[ -z "$MODE" ]]; then
+  die "--mode is required (standard or orchestrion)"
+fi
+
+if [[ "$MODE" != "standard" && "$MODE" != "orchestrion" ]]; then
+  die "--mode must be 'standard' or 'orchestrion', got: $MODE"
+fi
+
+# Find repo root
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+INTEGRATION_DIR="$REPO_ROOT/internal/orchestrion/_integration"
+
+# Validate sample exists
+if [[ ! -d "$INTEGRATION_DIR/$SAMPLE" ]]; then
+  die "Sample directory not found: $INTEGRATION_DIR/$SAMPLE"
+fi
+
+# Output directory for binaries
+OUT_DIR="$(mktemp -d)"
+trap 'rm -rf "$OUT_DIR"' EXIT
+
+message "Build configuration:"
+message "  Sample: $SAMPLE"
+message "  Mode: $MODE"
+message "  Repeats: $REPEATS"
+message "  Integration dir: $INTEGRATION_DIR"
+message "  Output dir: $OUT_DIR"
+
+cd "$INTEGRATION_DIR" || die "Failed to cd to $INTEGRATION_DIR"
+
+# Warm module cache (untimed)
+message "Warming module download cache..."
+go mod download || die "go mod download failed"
+
+# For orchestrion mode, ensure the binary is installed (untimed)
+if [[ "$MODE" == "orchestrion" ]]; then
+  message "Installing orchestrion binary..."
+  go install "github.com/DataDog/orchestrion" || die "Failed to install orchestrion"
+  ORCHESTRION_VERSION="$(go list -m -f '{{.Version}}' github.com/DataDog/orchestrion)"
+  message "  Orchestrion version: $ORCHESTRION_VERSION"
+fi
+
+# Get Go version
+GO_VERSION="$(go version | awk '{print $3}' | sed 's/go//')"
+message "  Go version: $GO_VERSION"
+
+# Build function
+do_build() {
+  local bin_path="$OUT_DIR/$SAMPLE-$MODE.test"
+
+  # Cold build cache
+  message "Cleaning build cache..."
+  go clean -cache
+
+  # Timed build
+  message "Building $SAMPLE with $MODE toolchain..."
+  local start_time
+  start_time=$(date +%s.%N 2> /dev/null || date +%s)
+
+  if [[ "$MODE" == "standard" ]]; then
+    go test -c -o "$bin_path" "./$SAMPLE" || die "Build failed (standard)"
+  else
+    go test -c -toolexec='orchestrion toolexec' -o "$bin_path" "./$SAMPLE" || die "Build failed (orchestrion)"
+  fi
+
+  local end_time
+  end_time=$(date +%s.%N 2> /dev/null || date +%s)
+  local duration
+  duration=$(awk "BEGIN {print $end_time - $start_time}")
+
+  # Binary size
+  local size
+  size=$(stat -c %s "$bin_path" 2> /dev/null || stat -f %z "$bin_path" 2> /dev/null) || die "Failed to stat binary"
+
+  message "  Duration: ${duration}s"
+  message "  Size: $size bytes"
+
+  echo "$duration $size"
+}
+
+# Perform builds (median if repeats > 1)
+if [[ "$REPEATS" -eq 1 ]]; then
+  read -r duration size <<< "$(do_build)"
+else
+  message "Performing $REPEATS builds..."
+  durations=()
+  sizes=()
+  for i in $(seq 1 "$REPEATS"); do
+    message "Build $i/$REPEATS:"
+    read -r d s <<< "$(do_build)"
+    durations+=("$d")
+    sizes+=("$s")
+  done
+
+  # Compute median (simple: sort and take middle)
+  duration=$(printf '%s\n' "${durations[@]}" | sort -n | awk '{a[NR]=$1} END {print (NR%2==1)?a[(NR+1)/2]:(a[NR/2]+a[NR/2+1])/2}')
+  size=$(printf '%s\n' "${sizes[@]}" | sort -n | awk '{a[NR]=$1} END {print (NR%2==1)?a[(NR+1)/2]:(a[NR/2]+a[NR/2+1])/2}')
+  message "Median duration: ${duration}s, median size: $size bytes"
+fi
+
+# Build JSON output
+message "Generating JSON output..."
+JSON=$(jq -n \
+  --arg sample "$SAMPLE" \
+  --arg mode "$MODE" \
+  --argjson duration "$duration" \
+  --argjson size "$size" \
+  --arg go_version "$GO_VERSION" \
+  '{ sample: $sample, mode: $mode, metrics: { build_duration_seconds: $duration, binary_size_bytes: $size }, go_version: $go_version }')
+
+# Add orchestrion version if in orchestrion mode
+if [[ "$MODE" == "orchestrion" ]]; then
+  JSON=$(echo "$JSON" | jq --arg orch_version "$ORCHESTRION_VERSION" '. + {orchestrion_version: $orch_version}')
+fi
+
+# Output
+if [[ -z "$OUTPUT" ]]; then
+  echo "$JSON"
+else
+  echo "$JSON" > "$OUTPUT"
+  message "Wrote JSON to $OUTPUT"
+fi
+
+message "Done."

--- a/scripts/publish_build_metrics.sh
+++ b/scripts/publish_build_metrics.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2026 Datadog, Inc.
+set -euo pipefail
+
+# publish_build_metrics.sh — publish build metrics to Datadog CI Visibility
+#
+# Reads build metrics JSON (from measure_build.sh) and publishes them as
+# custom measures and tags on the current CI job span using datadog-ci.
+#
+# Environment variables:
+#   METRICS_FILE        Path to metrics JSON file (required)
+#   DATADOG_API_KEY     Datadog API key (required)
+#   DATADOG_SITE        Datadog site (default: datadoghq.com)
+#
+# Usage: scripts/publish_build_metrics.sh
+
+message() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >&2
+}
+
+die() {
+  message "ERROR: $*"
+  exit 1
+}
+
+# Validate environment
+if [[ -z "${METRICS_FILE:-}" ]]; then
+  die "METRICS_FILE environment variable is required"
+fi
+
+if [[ -z "${DATADOG_API_KEY:-}" ]]; then
+  die "DATADOG_API_KEY environment variable is required"
+fi
+
+if [[ ! -f "$METRICS_FILE" ]]; then
+  die "Metrics file not found: $METRICS_FILE"
+fi
+
+# Parse JSON
+message "Reading metrics from $METRICS_FILE"
+SAMPLE=$(jq -r '.sample' "$METRICS_FILE")
+MODE=$(jq -r '.mode' "$METRICS_FILE")
+DURATION=$(jq -r '.metrics.build_duration_seconds' "$METRICS_FILE")
+SIZE=$(jq -r '.metrics.binary_size_bytes' "$METRICS_FILE")
+GO_VERSION=$(jq -r '.go_version' "$METRICS_FILE")
+ORCHESTRION_VERSION=$(jq -r '.orchestrion_version // empty' "$METRICS_FILE")
+
+message "Parsed metrics:"
+message "  Sample: $SAMPLE"
+message "  Mode: $MODE"
+message "  Duration: ${DURATION}s"
+message "  Size: $SIZE bytes"
+message "  Go version: $GO_VERSION"
+if [[ -n "$ORCHESTRION_VERSION" ]]; then
+  message "  Orchestrion version: $ORCHESTRION_VERSION"
+fi
+
+# Publish measures to CI Visibility
+message "Publishing measures to Datadog CI Visibility..."
+DATADOG_SITE="${DATADOG_SITE:-datadoghq.com}" datadog-ci measure --level job \
+  --measures "go.build.duration_seconds:${DURATION}" \
+  --measures "go.build.binary_size_bytes:${SIZE}" ||
+  die "Failed to publish measures"
+
+# Publish tags
+message "Publishing tags to Datadog CI Visibility..."
+TAGS=(
+  "build.toolchain:${MODE}"
+  "build.sample:${SAMPLE}"
+  "build.cache:cold"
+  "go.version:${GO_VERSION}"
+)
+
+if [[ -n "$ORCHESTRION_VERSION" ]]; then
+  TAGS+=("orchestrion.version:${ORCHESTRION_VERSION}")
+fi
+
+# Build tag arguments
+TAG_ARGS=()
+for tag in "${TAGS[@]}"; do
+  TAG_ARGS+=(--tags "$tag")
+done
+
+DATADOG_SITE="${DATADOG_SITE:-datadoghq.com}" datadog-ci tag --level job "${TAG_ARGS[@]}" ||
+  die "Failed to publish tags"
+
+message "Successfully published metrics and tags"


### PR DESCRIPTION
## Summary

This PR adds a new CI workflow to measure and track build time and binary size for Orchestrion integration samples, comparing the standard Go toolchain against Orchestrion's `-toolexec` instrumentation mode.

## What Changed

### New Scripts
- **`scripts/measure_build.sh`**: Measures build time and binary size with cold cache builds
  - Warms module download cache (untimed) so measurement reflects compilation, not network
  - Supports median of N repeats (default 3) to reduce noise
  - Emits structured JSON output
  
- **`scripts/publish_build_metrics.sh`**: Publishes metrics to Datadog CI Visibility
  - Attaches job-level measures: `go.build.duration_seconds`, `go.build.binary_size_bytes`
  - Tags by: `build.toolchain` (standard/orchestrion), `build.sample`, `build.cache`, `go.version`, `orchestrion.version`

### New Workflow
- **`.github/workflows/build-metrics.yml`**: GitHub Actions workflow
  - Matrix: `{mode: [standard, orchestrion]} × {sample: [net_http]}`
  - Triggers: PRs and pushes to `main` (only when workflow file or any `go.mod` changes)
  - Fork-safe: publish step skipped on fork PRs (no OIDC credentials)
  - Each matrix cell runs on a fresh runner → naturally cold cache

### Documentation
- **`scripts/README.md`**: Added documentation for both new scripts
- **Workflow comments**: Comprehensive header explaining the workflow, dashboard, and monitor setup

## Why

Track the build-time and binary-size overhead that Orchestrion adds via auto-instrumentation. This enables:
1. **Trend visibility**: Dashboard in Datadog CI Visibility showing size/time over commits
2. **Regression alerts**: Monitor alerts on >5% size or >25% duration increase vs main baseline
3. **PR awareness**: Artifacts uploaded on every PR for spot-checking

## How It Works

1. Workflow runs on PR/main when go.mod or the workflow file changes
2. Each matrix cell (standard/orchestrion) builds the same sample with a fresh cold cache
3. Script measures wall-clock build time and binary size, emits JSON
4. Publish script sends measures + tags to the current CI job span via `datadog-ci`
5. `git.branch`, `git.commit.sha`, PR number captured natively by CI Visibility (no cardinality cost)

## Prerequisite

**CI Pipeline Visibility must be enabled** for this repo in Datadog. The workflow checks for OIDC credentials and skips publish gracefully if they're unavailable, but for the metrics to actually appear in CI Visibility, the GitHub Actions integration needs to be configured to ingest pipeline events.

Once metrics start flowing, create:
- **Dashboard**: Filter `@git.branch:main`, split by `build.toolchain`, plot size/duration trends
- **Monitor**: Alert on % increase vs main baseline (grouped by `build.toolchain`)

## Testing

- ✅ All linters pass: `shellcheck`, `shfmt`, `check_copyright.go`, `actionlint`
- ✅ Local test: Built `net_http/standard` successfully (~32s cold build, 28MB binary)
- ✅ JSON output validated with `jq`
- ✅ Scripts are executable and portable

## Reviewer Notes

- Cold cache builds are slow (~30-60s each) but that's intentional — we're measuring full compilation cost including dependencies
- Default 3 repeats (median) to damp runner noise
- The workflow is non-blocking and doesn't appear in the required checks join point
- Scaling to more samples is a one-line matrix addition

## Next Steps

1. Verify CI Pipeline Visibility is enabled for this repo
2. Merge and let the workflow run on main to establish a baseline
3. Create the Datadog dashboard and monitor in CI Visibility
4. (Optional) Add more samples to the matrix as needed