### PR TITLE
chore(configinverter): extend check to validate sensitive keys, aliases, extra data, and JSON sort order

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -195,6 +195,21 @@ jobs:
           pattern: "**/*.sh"
           filter_mode: nofilter
 
+  check-supported-config:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: ${{ inputs.go-version || 'stable' }}
+          cache: false
+      - name: Verify supported_configurations.json and generated code are in sync
+        run: go run ./scripts/configinverter/main.go check
+
   checklocks:
     runs-on: ubuntu-latest
     steps:

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -34,7 +34,7 @@ func Get(name string) string {
 		return v
 	}
 
-	for _, alias := range keyAliases[name] {
+	for _, alias := range KeyAliases[name] {
 		if v := os.Getenv(alias); v != "" {
 			return v
 		}
@@ -64,7 +64,7 @@ func Lookup(name string) (string, bool) {
 		return v, true
 	}
 
-	for _, alias := range keyAliases[name] {
+	for _, alias := range KeyAliases[name] {
 		if v, ok := os.LookupEnv(alias); ok {
 			return v, true
 		}

--- a/internal/env/supported_configurations.gen.go
+++ b/internal/env/supported_configurations.gen.go
@@ -292,8 +292,8 @@ var SensitiveConfigurations = map[string]struct{}{
 	"OTEL_EXPORTER_OTLP_TRACES_HEADERS":  {},
 }
 
-// keyAliases maps aliases to supported configuration keys.
-var keyAliases = map[string][]string{
+// KeyAliases maps canonical configuration keys to their known aliases.
+var KeyAliases = map[string][]string{
 	"DD_API_KEY":                    {"DD-API-KEY"},
 	"DD_APPSEC_STACK_TRACE_ENABLED": {"DD_APPSEC_STACK_TRACE_ENABLE"},
 }

--- a/internal/env/supported_configurations.go
+++ b/internal/env/supported_configurations.go
@@ -98,7 +98,7 @@ func IsSensitive(name string) bool {
 	if _, ok := SensitiveConfigurations[name]; ok {
 		return true
 	}
-	for key, aliases := range keyAliases {
+	for key, aliases := range KeyAliases {
 		if _, ok := SensitiveConfigurations[key]; !ok {
 			continue
 		}

--- a/scripts/configinverter/main.go
+++ b/scripts/configinverter/main.go
@@ -115,32 +115,18 @@ func generate(input, output string) error {
 	})
 	f.Line()
 
-	// Get aliases keys and sort them
-	// so we can generate the map in a deterministic way
-	aliases := make(map[string][]string)
-	keysWithAliases := make([]string, 0)
-	for k := range cfg.SupportedConfigurations {
-		cfgAliases := []string{}
-		// Iterate over the configuration implementations and collect the aliases
-		for _, impl := range cfg.SupportedConfigurations[k] {
-			if impl.Aliases != nil && len(impl.Aliases) > 0 {
-				cfgAliases = append(cfgAliases, impl.Aliases...)
-			}
-		}
-
-		if len(cfgAliases) > 0 {
-			keysWithAliases = append(keysWithAliases, k)
-			aliases[k] = cfgAliases
-		}
+	aliases := collectAliasMap(cfg)
+	keysWithAliases := make([]string, 0, len(aliases))
+	for k := range aliases {
+		keysWithAliases = append(keysWithAliases, k)
 	}
-
 	if len(keysWithAliases) > 0 {
 		slog.Info("keys with aliases", "count", len(keysWithAliases), "keys", keysWithAliases)
 		sort.Strings(keysWithAliases)
 	}
 
-	f.Comment("keyAliases maps aliases to supported configuration keys.")
-	f.Var().Id("keyAliases").Op("=").Map(jen.String()).Index().String().ValuesFunc(func(g *jen.Group) {
+	f.Comment("KeyAliases maps canonical configuration keys to their known aliases.")
+	f.Var().Id("KeyAliases").Op("=").Map(jen.String()).Index().String().ValuesFunc(func(g *jen.Group) {
 		for _, v := range keysWithAliases {
 			g.Add(jen.Line(), jen.Lit(v), jen.Op(":"), jen.ValuesFunc(func(g *jen.Group) {
 				for _, v := range aliases[v] {
@@ -159,32 +145,118 @@ func generate(input, output string) error {
 }
 
 // check verifies that there is no difference between the supported configurations
-// JSON file and generated Go code map.
+// JSON file and the generated Go code. It validates four things:
+//   - SupportedConfigurations: exact key-set match (no missing, no extra)
+//   - SensitiveConfigurations: exact key-set match (no missing, no extra)
+//   - keyAliases: exact alias-set match per key (no missing, no extra)
+//   - JSON sort order: the JSON file must be byte-identical to its canonical form
 func check(input string) error {
-	keys, err := getSupportedConfigurationsKeys(input)
+	rawJSON, err := os.ReadFile(input)
+	if err != nil {
+		return fmt.Errorf("error reading JSON file: %w", err)
+	}
+
+	cfg, err := getSupportedConfigurations(input)
 	if err != nil {
 		return fmt.Errorf("error getting supported configuration keys: %w", err)
 	}
 
-	slog.Info("supported configuration keys in JSON file", "count", len(keys))
-	slog.Info("supported configuration keys in generated map", "count", len(env.SupportedConfigurations))
+	var failures []string
 
-	missingKeys := []string{}
-	for _, k := range keys {
+	// --- SupportedConfigurations: JSON ↔ generated ---
+	jsonKeys := sortSupportedConfigurationsKeys(cfg)
+	jsonKeySet := make(map[string]struct{}, len(jsonKeys))
+	for _, k := range jsonKeys {
+		jsonKeySet[k] = struct{}{}
+	}
+	for _, k := range jsonKeys {
 		if _, ok := env.SupportedConfigurations[k]; !ok {
-			slog.Error("supported configuration key not found in generated map", "key", k)
-			missingKeys = append(missingKeys, k)
+			failures = append(failures, fmt.Sprintf("SupportedConfigurations: %q present in JSON but missing from generated", k))
+		}
+	}
+	for k := range env.SupportedConfigurations {
+		if _, ok := jsonKeySet[k]; !ok {
+			failures = append(failures, fmt.Sprintf("SupportedConfigurations: %q present in generated but missing from JSON", k))
 		}
 	}
 
-	if len(missingKeys) > 0 {
-		slog.Error("supported configuration keys missing in generated map", "count", len(missingKeys), "keys", missingKeys)
-		slog.Info("run `go run ./scripts/configinverter/main.go generate` to re-generate the supported configurations map with the missing keys")
-		return fmt.Errorf("supported configuration keys missing in generated map, please re-run the generate command")
+	// --- SensitiveConfigurations: JSON ↔ generated ---
+	sensitiveKeys := sensitiveConfigurationKeys(cfg)
+	sensitiveKeySet := make(map[string]struct{}, len(sensitiveKeys))
+	for _, k := range sensitiveKeys {
+		sensitiveKeySet[k] = struct{}{}
+	}
+	for _, k := range sensitiveKeys {
+		if _, ok := env.SensitiveConfigurations[k]; !ok {
+			failures = append(failures, fmt.Sprintf("SensitiveConfigurations: %q is sensitive in JSON but missing from generated", k))
+		}
+	}
+	for k := range env.SensitiveConfigurations {
+		if _, ok := sensitiveKeySet[k]; !ok {
+			failures = append(failures, fmt.Sprintf("SensitiveConfigurations: %q is in generated but not marked sensitive in JSON", k))
+		}
+	}
+
+	// --- keyAliases: JSON ↔ generated ---
+	jsonAliases := collectAliasMap(cfg)
+	genAliases := env.KeyAliases
+	for k, jsonList := range jsonAliases {
+		genList, ok := genAliases[k]
+		if !ok {
+			failures = append(failures, fmt.Sprintf("keyAliases: %q has aliases in JSON but no entry in generated", k))
+			continue
+		}
+		genSet := make(map[string]struct{}, len(genList))
+		for _, a := range genList {
+			genSet[a] = struct{}{}
+		}
+		for _, a := range jsonList {
+			if _, ok := genSet[a]; !ok {
+				failures = append(failures, fmt.Sprintf("keyAliases: alias %q for key %q present in JSON but missing from generated", a, k))
+			}
+		}
+	}
+	for k, genList := range genAliases {
+		jsonList, ok := jsonAliases[k]
+		if !ok {
+			failures = append(failures, fmt.Sprintf("keyAliases: %q has aliases in generated but no aliases in JSON", k))
+			continue
+		}
+		jsonSet := make(map[string]struct{}, len(jsonList))
+		for _, a := range jsonList {
+			jsonSet[a] = struct{}{}
+		}
+		for _, a := range genList {
+			if _, ok := jsonSet[a]; !ok {
+				failures = append(failures, fmt.Sprintf("keyAliases: alias %q for key %q present in generated but missing from JSON", a, k))
+			}
+		}
+	}
+
+	// --- JSON sort and format ---
+	// Re-encode the parsed config with the canonical settings used by generate/add.
+	// If the file was not sorted or was otherwise modified by hand, the bytes will differ.
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(cfg); err != nil {
+		return fmt.Errorf("error re-encoding JSON for sort check: %w", err)
+	}
+	normalized := bytes.TrimRight(buf.Bytes(), "\n")
+	if !bytes.Equal(bytes.TrimRight(rawJSON, "\n"), normalized) {
+		failures = append(failures, "JSON is not sorted or not in canonical format; run `go run ./scripts/configinverter/main.go generate` to fix")
+	}
+
+	if len(failures) > 0 {
+		for _, f := range failures {
+			slog.Error(f)
+		}
+		slog.Info("run `go run ./scripts/configinverter/main.go generate` to re-generate the supported configurations")
+		return fmt.Errorf("%d discrepancy(ies) found between JSON and generated code", len(failures))
 	}
 
 	slog.Info("supported configurations JSON file and generated map are in sync")
-
 	return nil
 }
 
@@ -251,6 +323,22 @@ func sortSupportedConfigurationsKeys(cfg *supportedConfiguration) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// collectAliasMap returns a map from configuration key to the union of all aliases
+// defined across its implementations.
+func collectAliasMap(cfg *supportedConfiguration) map[string][]string {
+	result := make(map[string][]string)
+	for k, impls := range cfg.SupportedConfigurations {
+		var aliases []string
+		for _, impl := range impls {
+			aliases = append(aliases, impl.Aliases...)
+		}
+		if len(aliases) > 0 {
+			result[k] = aliases
+		}
+	}
+	return result
 }
 
 // sensitiveConfigurationKeys returns the sorted list of configuration keys that have


### PR DESCRIPTION
### What does this PR do?

Extends the `configinverter check` command (used in CI) to validate four properties instead of just one:

- **SupportedConfigurations**: bidirectional key-set check — flags keys present in JSON but missing from generated, and keys present in generated but missing from JSON (the original check only caught the first direction)
- **SensitiveConfigurations**: bidirectional check — flags sensitive keys in JSON not reflected in generated `SensitiveConfigurations`, and stale entries in generated not backed by `"sensitive": true` in JSON
- **KeyAliases**: bidirectional alias-set check per key — catches missing or extra aliases in the generated map
- **JSON sort/format**: byte-compares the JSON file against its canonical re-encoded form, catching hand-edits that break alphabetical key order or formatting

Also:
- Extracts a `collectAliasMap` helper to deduplicate alias-collection logic between `generate` and `check`
- Exports `env.KeyAliases` as a package-level map (replacing the unexported `keyAliases`) so the check command can compare against the generated alias map
- Adds a `check-supported-config` job to `static-checks.yml` so every PR is gated on JSON ↔ generated consistency before any tests run

### Motivation

Stacked on #4859. That PR introduces `SensitiveConfigurations` (generated from `"sensitive": true` entries in the JSON) but the CI `check` command only validated `SupportedConfigurations`. A future change marking a new key sensitive without regenerating would pass CI validation while `env.IsSensitive` silently returned stale data — potentially leaking a secret value in telemetry.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.