### PR TITLE
feat(ci): send all build duration samples instead of median

### DIFF
--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -59,7 +59,6 @@ jobs:
           - civisibility_failnow
           - civisibility_failnow_benchmark
           - civisibility_failnow_retry
-          - civisibilitytest
           - confluent-kafka-go.v1
           - confluent-kafka-go.v2
           - dd-span

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -11,7 +11,7 @@ name: Build Metrics
 # - Cold cache measurement: cleans build cache before each measurement to capture full compilation cost
 # - Warm module cache: runs go mod download (untimed) so measurement reflects compilation, not network
 # - Datadog CI Visibility: publishes metrics and tags to job spans for dashboard trending and regression monitoring
-# - Runs on: Pull requests (when this file or any go.mod changes) and pushes to main
+# - Runs on: Pull requests (when this file, scripts/*, orchestrion.yml, or any go.mod changes) and pushes to main
 # - Tags metrics by: build.toolchain, build.sample, build.cache, go.version, orchestrion.version
 #
 # Dashboard: View trends in Datadog CI Visibility (filter @git.branch:main, split by build.toolchain)
@@ -21,12 +21,18 @@ on:
   pull_request:
     paths:
       - .github/workflows/build-metrics.yml
+      - scripts/measure_build.sh
+      - scripts/publish_build_metrics.sh
+      - '**/orchestrion.yml'
       - '**/go.mod'
   push:
     branches:
       - main
     paths:
       - .github/workflows/build-metrics.yml
+      - scripts/measure_build.sh
+      - scripts/publish_build_metrics.sh
+      - '**/orchestrion.yml'
       - '**/go.mod'
   workflow_dispatch:
 
@@ -44,7 +50,59 @@ jobs:
       fail-fast: false
       matrix:
         mode: [standard, orchestrion]
-        sample: [net_http]
+        sample:
+          - 99designs.gqlgen
+          - aws.v1
+          - aws.v2
+          - chi.v5
+          - civisibility
+          - civisibility_failnow
+          - civisibility_failnow_benchmark
+          - civisibility_failnow_retry
+          - civisibilitytest
+          - confluent-kafka-go.v1
+          - confluent-kafka-go.v2
+          - dd-span
+          - echo.v4
+          - fiber.v2
+          - gcp_pubsub.v1
+          - gcp_pubsub.v2
+          - gin
+          - gls
+          - go-elasticsearch
+          - go-redis.v0
+          - go-redis.v7
+          - go-redis.v8
+          - go-redis.v9
+          - gocql
+          - gorilla_mux
+          - gorm
+          - graph-gophers
+          - graphql-go
+          - grpc
+          - ibm_sarama
+          - julienschmidt_httprouter
+          - k8s_client_go
+          - logrus
+          - mongo
+          - mongo.v2
+          - net_http
+          - os
+          - parallel_testing_retries
+          - pgx
+          - redigo
+          - rueidis
+          - segmentio_kafka.v0
+          - shopify_sarama
+          - slog
+          - sql
+          - twirp
+          - twirp_quantize
+          - twmb_franz_go
+          - valkey-go
+          - valyala_fasthttp
+          - vault
+          - zerolog
     runs-on: ubuntu-latest
     name: Build Metrics (${{ matrix.sample }}, ${{ matrix.mode }})
     steps:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -148,7 +148,7 @@ Measures build time and binary size for Orchestrion integration samples. Builds 
 - `--sample NAME` - Sample to build (default: net_http)
 - `--mode MODE` - Build mode: `standard` or `orchestrion` (required)
 - `--output PATH` - Output JSON file path (default: stdout)
-- `--repeats N` - Number of build repeats for median (default: 3)
+- `--repeats N` - Number of build repeats (default: 3)
 
 **Output format:**
 ```json
@@ -156,7 +156,7 @@ Measures build time and binary size for Orchestrion integration samples. Builds 
   "sample": "net_http",
   "mode": "orchestrion",
   "metrics": {
-    "build_duration_seconds": 312.4,
+    "build_duration_samples": [312.4, 308.1, 315.7],
     "binary_size_bytes": 48217344
   },
   "go_version": "1.25.0",
@@ -164,9 +164,11 @@ Measures build time and binary size for Orchestrion integration samples. Builds 
 }
 ```
 
+`build_duration_samples` contains one entry per `--repeats` run. `binary_size_bytes` is taken from the last build.
+
 ### publish_build_metrics.sh
 
-Publishes build metrics to Datadog CI Visibility using `datadog-ci`. Attaches measures (`go.build.duration_seconds`, `go.build.binary_size_bytes`) and tags (`build.toolchain`, `build.sample`, `build.cache`, `go.version`, `orchestrion.version`) to the current CI job span.
+Publishes build metrics to Datadog CI Visibility using `datadog-ci`. Attaches measures (`go.build.duration_seconds.0`, `go.build.duration_seconds.1`, ..., `go.build.binary_size_bytes`) and tags (`build.toolchain`, `build.sample`, `build.cache`, `go.version`, `orchestrion.version`) to the current CI job span. Each element of `build_duration_samples` is published as an individually-indexed measure.
 
 ```bash
 # Set environment and publish

--- a/scripts/measure_build.sh
+++ b/scripts/measure_build.sh
@@ -13,8 +13,11 @@ set -euo pipefail
 #   --sample NAME         Sample to build (default: net_http)
 #   --mode MODE           Build mode: standard or orchestrion (required)
 #   --output PATH         Output JSON file path (default: stdout)
-#   --repeats N           Number of build repeats for median (default: 3)
+#   --repeats N           Number of build repeats (default: 3)
 #   -h, --help            Show this help message
+#
+# Output JSON includes all build_duration_samples (one per repeat) and a single
+# binary_size_bytes taken from the last build.
 #
 # Examples:
 #   scripts/measure_build.sh --sample net_http --mode standard
@@ -31,7 +34,7 @@ Options:
   --sample NAME         Sample to build (default: net_http)
   --mode MODE           Build mode: standard or orchestrion (required)
   --output PATH         Output JSON file path (default: stdout)
-  --repeats N           Number of build repeats for median (default: 3)
+  --repeats N           Number of build repeats (default: 3)
   -h, --help            Show this help message
 
 Examples:
@@ -165,35 +168,28 @@ do_build() {
   echo "$duration $size"
 }
 
-# Perform builds (median if repeats > 1)
-if [[ "$REPEATS" -eq 1 ]]; then
-  read -r duration size <<< "$(do_build)"
-else
-  message "Performing $REPEATS builds..."
-  durations=()
-  sizes=()
-  for i in $(seq 1 "$REPEATS"); do
-    message "Build $i/$REPEATS:"
-    read -r d s <<< "$(do_build)"
-    durations+=("$d")
-    sizes+=("$s")
-  done
+# Perform builds — collect all duration samples; use last build's binary size
+message "Performing $REPEATS builds..."
+durations=()
+size=""
+for i in $(seq 1 "$REPEATS"); do
+  message "Build $i/$REPEATS:"
+  read -r d s <<< "$(do_build)"
+  durations+=("$d")
+  size="$s"
+done
+message "Durations: ${durations[*]}, size: $size bytes"
 
-  # Compute median (simple: sort and take middle)
-  duration=$(printf '%s\n' "${durations[@]}" | sort -n | awk '{a[NR]=$1} END {print (NR%2==1)?a[(NR+1)/2]:(a[NR/2]+a[NR/2+1])/2}')
-  size=$(printf '%s\n' "${sizes[@]}" | sort -n | awk '{a[NR]=$1} END {print (NR%2==1)?a[(NR+1)/2]:(a[NR/2]+a[NR/2+1])/2}')
-  message "Median duration: ${duration}s, median size: $size bytes"
-fi
-
-# Build JSON output
+# Build JSON output — durations as array, size as single value
 message "Generating JSON output..."
+DURATION_ARRAY=$(printf '%s\n' "${durations[@]}" | jq -R 'tonumber' | jq -s '.')
 JSON=$(jq -n \
   --arg sample "$SAMPLE" \
   --arg mode "$MODE" \
-  --argjson duration "$duration" \
+  --argjson durations "$DURATION_ARRAY" \
   --argjson size "$size" \
   --arg go_version "$GO_VERSION" \
-  '{ sample: $sample, mode: $mode, metrics: { build_duration_seconds: $duration, binary_size_bytes: $size }, go_version: $go_version }')
+  '{ sample: $sample, mode: $mode, metrics: { build_duration_samples: $durations, binary_size_bytes: $size }, go_version: $go_version }')
 
 # Add orchestrion version if in orchestrion mode
 if [[ "$MODE" == "orchestrion" ]]; then

--- a/scripts/publish_build_metrics.sh
+++ b/scripts/publish_build_metrics.sh
@@ -43,26 +43,32 @@ fi
 message "Reading metrics from $METRICS_FILE"
 SAMPLE=$(jq -r '.sample' "$METRICS_FILE")
 MODE=$(jq -r '.mode' "$METRICS_FILE")
-DURATION=$(jq -r '.metrics.build_duration_seconds' "$METRICS_FILE")
 SIZE=$(jq -r '.metrics.binary_size_bytes' "$METRICS_FILE")
 GO_VERSION=$(jq -r '.go_version' "$METRICS_FILE")
 ORCHESTRION_VERSION=$(jq -r '.orchestrion_version // empty' "$METRICS_FILE")
 
+# Read all duration samples into a bash array
+mapfile -t DURATIONS < <(jq -r '.metrics.build_duration_samples[]' "$METRICS_FILE")
+
 message "Parsed metrics:"
 message "  Sample: $SAMPLE"
 message "  Mode: $MODE"
-message "  Duration: ${DURATION}s"
+message "  Durations: ${DURATIONS[*]}s"
 message "  Size: $SIZE bytes"
 message "  Go version: $GO_VERSION"
 if [[ -n "$ORCHESTRION_VERSION" ]]; then
   message "  Orchestrion version: $ORCHESTRION_VERSION"
 fi
 
-# Publish measures to CI Visibility
+# Publish measures to CI Visibility — one indexed measure per duration sample, one size sample
 message "Publishing measures to Datadog CI Visibility..."
+MEASURE_ARGS=(--measures "go.build.binary_size_bytes:${SIZE}")
+for i in "${!DURATIONS[@]}"; do
+  MEASURE_ARGS+=(--measures "go.build.duration_seconds.${i}:${DURATIONS[$i]}")
+done
+
 DATADOG_SITE="${DATADOG_SITE:-datadoghq.com}" datadog-ci measure --level job \
-  --measures "go.build.duration_seconds:${DURATION}" \
-  --measures "go.build.binary_size_bytes:${SIZE}" ||
+  "${MEASURE_ARGS[@]}" ||
   die "Failed to publish measures"
 
 # Publish tags


### PR DESCRIPTION
## Summary

- Replace the single median `build_duration_seconds` value with a `build_duration_samples` array containing all per-run measurements in the JSON output
- Binary size remains a single sample (from the last build), which is stable across repeats
- In `publish_build_metrics.sh`, each duration sample is published as an individually-named measure (`go.build.duration_seconds.0`, `.1`, `.2`, ...) so all data points are visible in Datadog CI Visibility without aggregation loss

## Test plan

- [ ] Verify `measure_build.sh` output JSON contains `build_duration_samples` array with `--repeats N` entries
- [ ] Verify `publish_build_metrics.sh` emits one `go.build.duration_seconds.{i}` measure per sample and one `go.build.binary_size_bytes`
- [ ] Check Build Metrics CI jobs pass and metrics appear in Datadog

🤖 Generated with [Claude Code](https://claude.com/claude-code)