### PR TITLE
ci: add TRACE_STATS_COMPUTATION to system-tests matrix

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -142,6 +142,19 @@ jobs:
             scenario: APM_TRACING_EFFICIENT_PAYLOAD
           - weblog-variant: net-http
             scenario: FEATURE_FLAGGING_AND_EXPERIMENTATION
+          # Client-side stats — run across all weblogs, plus the client_drop_p0s variant on net-http
+          - weblog-variant: net-http
+            scenario: TRACE_STATS_COMPUTATION
+          - weblog-variant: echo
+            scenario: TRACE_STATS_COMPUTATION
+          - weblog-variant: chi
+            scenario: TRACE_STATS_COMPUTATION
+          - weblog-variant: gin
+            scenario: TRACE_STATS_COMPUTATION
+          - weblog-variant: uds-echo
+            scenario: TRACE_STATS_COMPUTATION
+          - weblog-variant: net-http
+            scenario: TRACE_STATS_COMPUTATION_CLIENT_DROP_P0S_FALSE
       fail-fast: false
     env:
       TEST_LIBRARY: golang


### PR DESCRIPTION
Add `TRACE_STATS_COMPUTATION` for all 5 weblogs (net-http, echo, chi, gin, uds-echo) and `TRACE_STATS_COMPUTATION_CLIENT_DROP_P0S_FALSE` for net-http to the system-tests CI matrix. These scenarios were missing from the PR/push matrix, so client-side stats test results were not attributed to dd-trace-go's CI and not counted in the Feature Parity Dashboard. The tests already pass against the released tracer.