### PR TITLE
feat(tracer): add DD_TRACE_OTEL_SEMANTICS_ENABLED for OTLP export

### DIFF
--- a/ddtrace/opentelemetry/span.go
+++ b/ddtrace/opentelemetry/span.go
@@ -36,6 +36,9 @@ type span struct {
 	statusInfo
 	*oteltracer
 	events []spanEvent
+	// otelSemanticsEnabled is copied from the tracer when the span starts so span
+	// methods read it directly instead of reaching back into the tracer.
+	otelSemanticsEnabled bool
 }
 
 func (s *span) TracerProvider() oteltrace.TracerProvider { return s.oteltracer.provider }
@@ -43,6 +46,13 @@ func (s *span) TracerProvider() oteltrace.TracerProvider { return s.oteltracer.p
 func (s *span) SetName(name string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.otelSemanticsEnabled {
+		// OTel semantics: the span name maps to the Datadog resource (the OTLP span-name
+		// field), not the DD-only operation name. Changing the default would shift RED
+		// metrics, so it is gated behind the flag.
+		s.attributes[ext.ResourceName] = name
+		return
+	}
 	s.attributes[ext.SpanName] = strings.ToLower(name)
 }
 
@@ -59,20 +69,25 @@ func (s *span) End(options ...oteltrace.SpanEndOption) {
 		return
 	}
 	s.finished = true
-	for k, v := range s.attributes {
-		//	if we find operation.name,
-		if k == "operation.name" || k == ext.SpanName {
-			//	set it and keep track that it was set to ignore everything else
-			if name, ok := v.(string); ok {
-				s.attributes[ext.SpanName] = strings.ToLower(name)
+	if !s.otelSemanticsEnabled {
+		// Datadog operation-name handling. Under OTel semantics the span name maps to
+		// the resource (the OTLP span-name field) and operation.name is suppressed on
+		// export, so we skip this entirely and let the attributes pass through.
+		for k, v := range s.attributes {
+			//	if we find operation.name,
+			if k == "operation.name" || k == ext.SpanName {
+				//	set it and keep track that it was set to ignore everything else
+				if name, ok := v.(string); ok {
+					s.attributes[ext.SpanName] = strings.ToLower(name)
+				}
 			}
 		}
-	}
 
-	// if no operation name was explicitly set,
-	// operation name has to be calculated from the attributes
-	if op, ok := s.attributes[ext.SpanName]; !ok || op == "" {
-		s.DD.SetTag(ext.SpanName, strings.ToLower(s.createOperationName()))
+		// if no operation name was explicitly set,
+		// operation name has to be calculated from the attributes
+		if op, ok := s.attributes[ext.SpanName]; !ok || op == "" {
+			s.DD.SetTag(ext.SpanName, strings.ToLower(s.createOperationName()))
+		}
 	}
 	for k, v := range s.attributes {
 		s.DD.SetTag(k, v)
@@ -219,10 +234,11 @@ func (s *span) AddEvent(name string, opts ...oteltrace.EventOption) {
 // The list of reserved tags might be extended in the future.
 // Any other non-reserved tags will be set as provided.
 func (s *span) SetAttributes(kv ...attribute.KeyValue) {
+	otelSemantics := s.otelSemanticsEnabled
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, kv := range kv {
-		if k, v := toReservedAttributes(string(kv.Key), kv.Value); k != "" {
+		if k, v := toReservedAttributes(string(kv.Key), kv.Value, otelSemantics); k != "" {
 			s.attributes[k] = v
 		}
 	}
@@ -230,7 +246,11 @@ func (s *span) SetAttributes(kv ...attribute.KeyValue) {
 
 // toReservedAttributes recognizes a set of span attributes that have a special meaning.
 // These tags should supersede other values.
-func toReservedAttributes(k string, v attribute.Value) (string, any) {
+func toReservedAttributes(k string, v attribute.Value, otelSemantics bool) (string, any) {
+	if otelSemantics {
+		// Under OTel semantics, set every attribute as-is (no DD reserved-tag remapping).
+		return k, v.AsInterface()
+	}
 	switch k {
 	case "operation.name":
 		if ops := strings.ToLower(v.AsString()); ops != "" {

--- a/ddtrace/opentelemetry/span_test.go
+++ b/ddtrace/opentelemetry/span_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/instrumentation/httpmem"
+	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tinylib/msgp/msgp"
@@ -130,6 +131,39 @@ func TestSpanSetName(t *testing.T) {
 	}
 	p := traces[0]
 	assert.Equal(strings.ToLower("NewName"), p[0]["name"])
+}
+
+// TestSpanSetNameUpdatesResourceOtelSemantics verifies that under OTel semantics SetName
+// updates the resource (the OTLP span name) — e.g. otelhttp renames "GET" to "GET /users/{id}".
+func TestSpanSetNameUpdatesResourceOtelSemantics(t *testing.T) {
+	assert := assert.New(t)
+	// The flag is resolved when the provider is created; reload on cleanup so it
+	// doesn't leak (LIFO order runs this after t.Setenv restores the env).
+	t.Cleanup(func() { internalconfig.CreateNew() })
+	t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true")
+	internalconfig.CreateNew()
+
+	_, payloads, cleanup := mockTracerProvider(t)
+	tr := otel.Tracer("")
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, sp := tr.Start(ctx, "GET")
+	sp.SetName("GET /users/{id}")
+	sp.End()
+
+	tracer.Flush()
+	traces, err := waitForPayload(payloads)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	p := traces[0]
+	// Resource follows the rename. Under OTel semantics the operation-name logic is
+	// skipped entirely (no remap, no computed default), so the operation name is left
+	// as it was set at Start and the span attributes pass through unchanged.
+	assert.Equal("GET /users/{id}", p[0]["resource"])
+	assert.Equal("GET", p[0]["name"])
 }
 
 func TestSpanLink(t *testing.T) {
@@ -841,4 +875,59 @@ func TestRemapWithMultipleSetAttributes(t *testing.T) {
 	assert.Contains(metrics, fmt.Sprintf("%s:%s", "_dd1.sr.eausr", "1"))
 	meta := fmt.Sprintf("%v", p[0]["meta"])
 	assert.Contains(meta, fmt.Sprintf("%s:%s", "http.status_code", "200"))
+}
+
+func TestToReservedAttributesOtelSemantics(t *testing.T) {
+	assert := assert.New(t)
+
+	// Under OTel semantics, reserved tags are passed through unchanged.
+	k, v := toReservedAttributes("operation.name", attribute.StringValue("Op"), true)
+	assert.Equal("operation.name", k)
+	assert.Equal("Op", v)
+
+	k, _ = toReservedAttributes("analytics.event", attribute.BoolValue(true), true)
+	assert.Equal("analytics.event", k)
+
+	k, v = toReservedAttributes("http.response.status_code", attribute.IntValue(500), true)
+	assert.Equal("http.response.status_code", k)
+	assert.Equal(int64(500), v)
+
+	// Without OTel semantics, the same tags are remapped to Datadog conventions.
+	k, _ = toReservedAttributes("operation.name", attribute.StringValue("Op"), false)
+	assert.Equal(ext.SpanName, k)
+	k, _ = toReservedAttributes("http.response.status_code", attribute.IntValue(500), false)
+	assert.Equal("http.status_code", k)
+}
+
+// TestRemapStatusCodeOtelSemantics verifies that under OTel semantics the bridge keeps
+// http.response.status_code instead of remapping it to the legacy http.status_code tag.
+func TestRemapStatusCodeOtelSemantics(t *testing.T) {
+	assert := assert.New(t)
+
+	// Reload global config on cleanup so the flag doesn't leak; LIFO order runs this
+	// after t.Setenv restores the env.
+	t.Cleanup(func() { internalconfig.CreateNew() })
+	t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true")
+	internalconfig.CreateNew()
+
+	_, payloads, cleanup := mockTracerProvider(t, tracer.WithEnv("test_env"), tracer.WithService("test_serv"))
+	tr := otel.Tracer("")
+	defer cleanup()
+
+	_, sp := tr.Start(context.Background(), "otel_span_name",
+		oteltrace.WithSpanKind(oteltrace.SpanKindServer))
+	sp.SetAttributes(attribute.Int("http.response.status_code", 200))
+	sp.End()
+
+	tracer.Flush()
+	traces, err := waitForPayload(payloads)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	p := traces[0]
+	meta := fmt.Sprintf("%v", p[0]["meta"])
+	metrics := fmt.Sprintf("%v", p[0]["metrics"])
+	// No legacy string remap; OTel key retained as a numeric tag.
+	assert.NotContains(meta, "http.status_code")
+	assert.Contains(metrics, "http.response.status_code:200")
 }

--- a/ddtrace/opentelemetry/tracer.go
+++ b/ddtrace/opentelemetry/tracer.go
@@ -30,6 +30,9 @@ type oteltracer struct {
 	noop.Tracer // https://pkg.go.dev/go.opentelemetry.io/otel/trace#hdr-API_Implementations
 	provider    *TracerProvider
 	DD          tracer.Tracer
+	// otelSemanticsEnabled is resolved once when the provider is created, so spans
+	// don't read the global configuration on every SetAttributes call.
+	otelSemanticsEnabled bool
 }
 
 func (t *oteltracer) Start(ctx context.Context, spanName string, opts ...oteltrace.SpanStartOption) (context.Context, oteltrace.Span) {
@@ -105,10 +108,11 @@ func (t *oteltracer) Start(ctx context.Context, spanName string, opts ...oteltra
 	ctx = otelbaggage.ContextWithBaggage(ctx, mergedBag)
 
 	os := oteltrace.Span(&span{
-		DD:         s,
-		oteltracer: t,
-		spanKind:   ssConfig.SpanKind(),
-		attributes: cfg.Tags,
+		DD:                   s,
+		oteltracer:           t,
+		spanKind:             ssConfig.SpanKind(),
+		attributes:           cfg.Tags,
+		otelSemanticsEnabled: t.otelSemanticsEnabled,
 	})
 	// Erase the start span options from the context to prevent them from being propagated to children
 	ctx = context.WithValue(ctx, startOptsKey, nil)

--- a/ddtrace/opentelemetry/tracer_provider.go
+++ b/ddtrace/opentelemetry/tracer_provider.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/internal"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -62,8 +63,9 @@ func NewTracerProvider(opts ...tracer.StartOption) *TracerProvider {
 	tracer.Start(opts...)
 	p := &TracerProvider{}
 	t := &oteltracer{
-		DD:       internal.GetGlobalTracer[tracer.Tracer](),
-		provider: p,
+		DD:                   internal.GetGlobalTracer[tracer.Tracer](),
+		provider:             p,
+		otelSemanticsEnabled: internalconfig.Get().OtelSemanticsEnabled(),
 	}
 	p.tracer = t
 	return p

--- a/ddtrace/opentelemetry/tracer_provider.go
+++ b/ddtrace/opentelemetry/tracer_provider.go
@@ -65,7 +65,7 @@ func NewTracerProvider(opts ...tracer.StartOption) *TracerProvider {
 	t := &oteltracer{
 		DD:                   internal.GetGlobalTracer[tracer.Tracer](),
 		provider:             p,
-		otelSemanticsEnabled: internalconfig.Get().OtelSemanticsEnabled(),
+		otelSemanticsEnabled: internalconfig.Get().OTelSemanticsEnabled(),
 	}
 	p.tracer = t
 	return p

--- a/ddtrace/tracer/otlp_writer.go
+++ b/ddtrace/tracer/otlp_writer.go
@@ -71,10 +71,11 @@ func (w *otlpTraceWriter) reset() []*otlptrace.Span {
 
 func (w *otlpTraceWriter) add(spanList []*Span) {
 	defaultServiceName := w.config.internalConfig.ServiceName()
+	otelSemantics := w.config.internalConfig.OtelSemanticsEnabled()
 	w.mu.Lock()
 	w.spans = slices.Grow(w.spans, len(spanList))
 	for _, span := range spanList {
-		if otlpSpan := convertSpan(span, defaultServiceName); otlpSpan != nil {
+		if otlpSpan := convertSpan(span, defaultServiceName, otelSemantics); otlpSpan != nil {
 			w.spans = append(w.spans, otlpSpan)
 			w.buffSize += proto.Size(otlpSpan)
 		}

--- a/ddtrace/tracer/otlp_writer.go
+++ b/ddtrace/tracer/otlp_writer.go
@@ -71,7 +71,7 @@ func (w *otlpTraceWriter) reset() []*otlptrace.Span {
 
 func (w *otlpTraceWriter) add(spanList []*Span) {
 	defaultServiceName := w.config.internalConfig.ServiceName()
-	otelSemantics := w.config.internalConfig.OtelSemanticsEnabled()
+	otelSemantics := w.config.internalConfig.OTelSemanticsEnabled()
 	w.mu.Lock()
 	w.spans = slices.Grow(w.spans, len(spanList))
 	for _, span := range spanList {

--- a/ddtrace/tracer/otlp_writer_bench_test.go
+++ b/ddtrace/tracer/otlp_writer_bench_test.go
@@ -99,7 +99,7 @@ func BenchmarkOTLPProtoMarshal(b *testing.B) {
 			for i := range sc.n {
 				s := newBasicSpan("bench-span")
 				s.meta.Set("key", "value")
-				spans[i] = convertSpan(s, "bench-svc")
+				spans[i] = convertSpan(s, "bench-svc", false)
 			}
 			tracesData := buildTracesData(spans)
 
@@ -128,7 +128,7 @@ func BenchmarkOTLPProtoMarshal(b *testing.B) {
 				SpanID:      uint64(i + 300),
 				Attributes:  map[string]string{"link-key": "link-val"},
 			})
-			spans[i] = convertSpan(s, "bench-svc")
+			spans[i] = convertSpan(s, "bench-svc", false)
 		}
 		tracesData := buildTracesData(spans)
 
@@ -157,7 +157,7 @@ func BenchmarkOTLPProtoSize(b *testing.B) {
 			spans := make([]*otlptrace.Span, sc.n)
 			for i := range sc.n {
 				s := newBasicSpan("bench-span")
-				spans[i] = convertSpan(s, "bench-svc")
+				spans[i] = convertSpan(s, "bench-svc", false)
 			}
 			tracesData := buildTracesData(spans)
 

--- a/ddtrace/tracer/span_to_otlp.go
+++ b/ddtrace/tracer/span_to_otlp.go
@@ -53,7 +53,7 @@ func buildResource(cfg *internalconfig.Config) *otlpresource.Resource {
 // -----------------------------------------------------------------------------
 
 // +checklocksignore — Post-finish: reads finished span fields during payload encoding.
-func convertSpan(s *Span, defaultServiceName string) *otlptrace.Span {
+func convertSpan(s *Span, defaultServiceName string, otelSemantics bool) *otlptrace.Span {
 	if p, ok := s.context.SamplingPriority(); ok && p < ext.PriorityAutoKeep {
 		return nil
 	}
@@ -65,7 +65,7 @@ func convertSpan(s *Span, defaultServiceName string) *otlptrace.Span {
 		Kind:              convertSpanKind(getSpanKind(s)),
 		StartTimeUnixNano: uint64(s.start),
 		EndTimeUnixNano:   uint64(s.start + s.duration),
-		Attributes:        convertSpanAttributes(s, defaultServiceName),
+		Attributes:        convertSpanAttributes(s, defaultServiceName, otelSemantics),
 		Events:            convertEvents(s),
 		Links:             convertSpanLinks(s.spanLinks),
 		Status:            convertSpanStatus(s),
@@ -185,22 +185,34 @@ var otelIntMetricKeys = map[string]struct{}{
 	"client.port":               {},
 }
 
+// ddOnlyMetaKeys are Datadog-specific span tags omitted under OtelSemanticsEnabled;
+// they have no OTel equivalent. span.kind is already carried by the OTLP SpanKind field.
+var ddOnlyMetaKeys = map[string]struct{}{
+	ext.ErrorMsg:           {},
+	ext.ErrorType:          {},
+	ext.ErrorStack:         {},
+	ext.ErrorHandlingStack: {},
+	ext.SpanKind:           {},
+}
+
 // +checklocksignore — Post-finish: reads finished span fields during payload encoding.
-func convertSpanAttributes(s *Span, defaultServiceName string) []*otlpcommon.KeyValue {
+func convertSpanAttributes(s *Span, defaultServiceName string, otelSemantics bool) []*otlpcommon.KeyValue {
 	n := s.meta.Count() + len(s.metrics) + len(s.metaStruct) + 3
 	if s.service != defaultServiceName {
 		n++
 	}
 	attrs := make([]*otlpcommon.KeyValue, 0, min(n, maxAttributesCount))
 
-	if !addAttribute(&attrs, "operation.name", otlpStringValue(s.name)) {
-		return attrs
-	}
-	if !addAttribute(&attrs, "resource.name", otlpStringValue(s.resource)) {
-		return attrs
-	}
-	if !addAttribute(&attrs, "span.type", otlpStringValue(s.spanType)) {
-		return attrs
+	if !otelSemantics {
+		if !addAttribute(&attrs, "operation.name", otlpStringValue(s.name)) {
+			return attrs
+		}
+		if !addAttribute(&attrs, "resource.name", otlpStringValue(s.resource)) {
+			return attrs
+		}
+		if !addAttribute(&attrs, "span.type", otlpStringValue(s.spanType)) {
+			return attrs
+		}
 	}
 	if s.service != defaultServiceName {
 		if !addAttribute(&attrs, "service.name", otlpStringValue(s.service)) {
@@ -208,6 +220,11 @@ func convertSpanAttributes(s *Span, defaultServiceName string) []*otlpcommon.Key
 		}
 	}
 	for key, value := range s.meta.All() {
+		if otelSemantics {
+			if _, skip := ddOnlyMetaKeys[key]; skip {
+				continue
+			}
+		}
 		if !addAttribute(&attrs, key, otlpStringValue(value)) {
 			return attrs
 		}

--- a/ddtrace/tracer/span_to_otlp.go
+++ b/ddtrace/tracer/span_to_otlp.go
@@ -185,7 +185,7 @@ var otelIntMetricKeys = map[string]struct{}{
 	"client.port":               {},
 }
 
-// ddOnlyMetaKeys are Datadog-specific span tags omitted under OtelSemanticsEnabled;
+// ddOnlyMetaKeys are Datadog-specific span tags omitted under OTelSemanticsEnabled;
 // they have no OTel equivalent. span.kind is already carried by the OTLP SpanKind field.
 var ddOnlyMetaKeys = map[string]struct{}{
 	ext.ErrorMsg:           {},

--- a/ddtrace/tracer/span_to_otlp_test.go
+++ b/ddtrace/tracer/span_to_otlp_test.go
@@ -71,7 +71,7 @@ func TestConvertSpan(t *testing.T) {
 	s.error = 1
 	s.meta.Set(ext.ErrorMsg, "something failed")
 
-	otlp := convertSpan(s, "svc")
+	otlp := convertSpan(s, "svc", false)
 	require.NotNil(t, otlp)
 
 	// DD resource → OTLP name (spec: "resource field must be encoded as the OTLP span's name field")
@@ -103,14 +103,14 @@ func TestConvertSpan(t *testing.T) {
 func TestConvertSpanParentSpanId(t *testing.T) {
 	t.Run("set when parent_id is non-zero", func(t *testing.T) {
 		s := newSpan("op", "svc", "res", 100, 200, 50)
-		otlp := convertSpan(s, "svc")
+		otlp := convertSpan(s, "svc", false)
 		require.NotNil(t, otlp.ParentSpanId)
 		assert.Equal(t, uint64(50), binary.BigEndian.Uint64(otlp.ParentSpanId))
 	})
 
 	t.Run("omitted when parent_id is zero", func(t *testing.T) {
 		s := newSpan("op", "svc", "res", 100, 200, 0)
-		otlp := convertSpan(s, "svc")
+		otlp := convertSpan(s, "svc", false)
 		assert.Nil(t, otlp.ParentSpanId, "ParentSpanId must be omitted for root spans")
 	})
 }
@@ -129,7 +129,7 @@ func TestConvertSpanFiltersUnsampled(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := newSpan("op", "svc", "res", 1, 1, 0)
 			s.context.setSamplingPriority(tt.priority, samplernames.Unknown)
-			result := convertSpan(s, "svc")
+			result := convertSpan(s, "svc", false)
 			if tt.wantNil {
 				assert.Nil(t, result)
 			} else {
@@ -142,14 +142,14 @@ func TestConvertSpanFiltersUnsampled(t *testing.T) {
 func TestConvertSpanPriorityUnset(t *testing.T) {
 	s := newSpan("op", "svc", "res", 1, 1, 0)
 	// priority is not set — span should be included (not dropped)
-	result := convertSpan(s, "")
+	result := convertSpan(s, "", false)
 	assert.NotNil(t, result)
 }
 
 func TestConvertSpanServiceNameOverride(t *testing.T) {
 	t.Run("same as default - no service.name attribute", func(t *testing.T) {
 		s := newSpan("op", "my-service", "res", 1, 1, 0)
-		otlp := convertSpan(s, "my-service")
+		otlp := convertSpan(s, "my-service", false)
 		require.NotNil(t, otlp)
 		attrs := keyValuesToMap(otlp.Attributes)
 		_, hasServiceName := attrs["service.name"]
@@ -158,7 +158,7 @@ func TestConvertSpanServiceNameOverride(t *testing.T) {
 
 	t.Run("different from default - service.name attribute added", func(t *testing.T) {
 		s := newSpan("op", "other-service", "res", 1, 1, 0)
-		otlp := convertSpan(s, "my-service")
+		otlp := convertSpan(s, "my-service", false)
 		require.NotNil(t, otlp)
 		attrs := keyValuesToMap(otlp.Attributes)
 		assert.Equal(t, "other-service", attrs["service.name"])
@@ -211,7 +211,7 @@ func TestConvertSpanAttributes(t *testing.T) {
 	s.meta = tinternal.NewSpanMetaFromMap(map[string]string{"tag": "val", "env": "test"})
 	s.metrics = map[string]float64{"count": 10, "rate": 0.5}
 
-	attrs := convertSpanAttributes(s, "")
+	attrs := convertSpanAttributes(s, "", false)
 	m := keyValuesToMap(attrs)
 	assert.Equal(t, "val", m["tag"])
 	assert.Equal(t, "test", m["env"])
@@ -235,7 +235,7 @@ func TestConvertSpanAttributesIntEncoding(t *testing.T) {
 		"custom.metric":             1.5,
 	}
 
-	m := keyValuesToMap(convertSpanAttributes(s, ""))
+	m := keyValuesToMap(convertSpanAttributes(s, "", false))
 
 	assert.Equal(t, int64(200), m["http.response.status_code"])
 	assert.Equal(t, int64(8080), m["server.port"])
@@ -243,6 +243,33 @@ func TestConvertSpanAttributesIntEncoding(t *testing.T) {
 	assert.Equal(t, int64(1024), m["http.response.body.size"])
 	// Non-semconv-int metrics stay doubles.
 	assert.Equal(t, 1.5, m["custom.metric"])
+}
+
+// TestConvertSpanAttributesOtelSemantics verifies that under OTel semantics the OTLP
+// exporter omits Datadog-specific attributes (span identity, error.*, span.kind).
+func TestConvertSpanAttributesOtelSemantics(t *testing.T) {
+	s := newBasicSpan("op")
+	s.meta = tinternal.NewSpanMetaFromMap(map[string]string{
+		"http.request.method":  "GET",
+		ext.ErrorMsg:           "boom",
+		ext.ErrorType:          "*errors.errorString",
+		ext.ErrorStack:         "goroutine 1 ...",
+		ext.ErrorHandlingStack: "goroutine 1 ...",
+		ext.SpanKind:           ext.SpanKindServer,
+	})
+	m := keyValuesToMap(convertSpanAttributes(s, "", true))
+
+	// DD-only span-identity, error, and span.kind attributes are suppressed.
+	for _, k := range []string{
+		"operation.name", "resource.name", "span.type",
+		ext.ErrorMsg, ext.ErrorType, ext.ErrorStack, ext.ErrorHandlingStack, ext.SpanKind,
+	} {
+		_, ok := m[k]
+		assert.Falsef(t, ok, "%q should be suppressed when OTel semantics is enabled", k)
+	}
+
+	// Non-DD-only meta is preserved unchanged.
+	assert.Equal(t, "GET", m["http.request.method"])
 }
 
 func TestConvertSpanAttributesWithMetaStruct(t *testing.T) {
@@ -253,7 +280,7 @@ func TestConvertSpanAttributesWithMetaStruct(t *testing.T) {
 		"simple": map[string]string{"x": "y"},
 	}
 
-	attrs := convertSpanAttributes(s, "")
+	attrs := convertSpanAttributes(s, "", false)
 
 	var nestedKV, simpleKV *otlpcommon.KeyValue
 	for _, kv := range attrs {
@@ -284,7 +311,7 @@ func TestConvertSpanAttributesMaxLimit(t *testing.T) {
 		s.meta.Set(fmt.Sprintf("key-%d", i), "val")
 	}
 
-	attrs := convertSpanAttributes(s, "other-service")
+	attrs := convertSpanAttributes(s, "other-service", false)
 	assert.LessOrEqual(t, len(attrs), maxAttributesCount)
 }
 
@@ -295,7 +322,7 @@ func TestConvertSpanAttributesPriorityOrder(t *testing.T) {
 	}
 	s.metrics = map[string]float64{"should-be-dropped": 1.0}
 
-	attrs := convertSpanAttributes(s, "")
+	attrs := convertSpanAttributes(s, "", false)
 	m := keyValuesToMap(attrs)
 
 	assert.Equal(t, "op", m["operation.name"], "operation.name should always be present")
@@ -308,7 +335,7 @@ func TestConvertSpanAttributesPriorityOrder(t *testing.T) {
 func TestConvertSpanAttributesServiceNameOverride(t *testing.T) {
 	t.Run("same as default - no attribute", func(t *testing.T) {
 		s := newSpan("op", "my-service", "res", 1, 1, 0)
-		attrs := convertSpanAttributes(s, "my-service")
+		attrs := convertSpanAttributes(s, "my-service", false)
 		m := keyValuesToMap(attrs)
 		_, hasServiceName := m["service.name"]
 		assert.False(t, hasServiceName, "service.name attribute should be absent when it matches the default")
@@ -316,7 +343,7 @@ func TestConvertSpanAttributesServiceNameOverride(t *testing.T) {
 
 	t.Run("different from default - attribute added", func(t *testing.T) {
 		s := newSpan("op", "other-service", "res", 1, 1, 0)
-		attrs := convertSpanAttributes(s, "my-service")
+		attrs := convertSpanAttributes(s, "my-service", false)
 		m := keyValuesToMap(attrs)
 		assert.Equal(t, "other-service", m["service.name"])
 	})
@@ -436,7 +463,7 @@ func TestConvertSpanTraceState(t *testing.T) {
 		s := newSpan("op", "svc", "res", 1, 1, 0)
 		setPropagatingTag(s.context, tracestateHeader, "dd=s:2;o:rum,othervendor=abc")
 
-		otlpSpan := convertSpan(s, "svc")
+		otlpSpan := convertSpan(s, "svc", false)
 		require.NotNil(t, otlpSpan)
 		assert.Equal(t, "dd=s:2;o:rum,othervendor=abc", otlpSpan.TraceState)
 	})
@@ -444,7 +471,7 @@ func TestConvertSpanTraceState(t *testing.T) {
 	t.Run("empty when no tracestate", func(t *testing.T) {
 		s := newSpan("op", "svc", "res", 1, 1, 0)
 
-		otlpSpan := convertSpan(s, "svc")
+		otlpSpan := convertSpan(s, "svc", false)
 		require.NotNil(t, otlpSpan)
 		assert.Empty(t, otlpSpan.TraceState)
 	})
@@ -453,7 +480,7 @@ func TestConvertSpanTraceState(t *testing.T) {
 		s := newSpan("op", "svc", "res", 1, 1, 0)
 		s.context.trace = nil
 
-		otlpSpan := convertSpan(s, "svc")
+		otlpSpan := convertSpan(s, "svc", false)
 		require.NotNil(t, otlpSpan)
 		assert.Empty(t, otlpSpan.TraceState)
 	})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -270,7 +270,7 @@ func loadConfig() *Config {
 	cfg.sendRetries = p.GetIntWithValidator("DD_TRACE_SEND_RETRIES", 0, validateSendRetries)
 	cfg.logsOTelEnabled = p.GetBool("DD_LOGS_OTEL_ENABLED", false)
 	otelSemantics, otelSemanticsOrigin := p.GetBoolWithOrigin("DD_TRACE_OTEL_SEMANTICS_ENABLED", false)
-	cfg.SetOtelSemanticsEnabled(otelSemantics, otelSemanticsOrigin)
+	cfg.SetOTelSemanticsEnabled(otelSemantics, otelSemanticsOrigin)
 	if v := p.GetString("OTEL_LOGS_EXPORTER", ""); v != "" {
 		log.Warn("OTEL_LOGS_EXPORTER is not supported")
 	}
@@ -1205,15 +1205,15 @@ func (c *Config) SetLogsOTelEnabled(enabled bool, origin telemetry.Origin, produ
 	configtelemetry.Report("DD_LOGS_OTEL_ENABLED", enabled, origin)
 }
 
-func (c *Config) OtelSemanticsEnabled() bool {
+func (c *Config) OTelSemanticsEnabled() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.otelSemanticsEnabled
 }
 
-// SetOtelSemanticsEnabled sets whether OTLP-exported spans should match the pure
+// SetOTelSemanticsEnabled sets whether OTLP-exported spans should match the pure
 // OpenTelemetry SDK, and reports the value to configuration telemetry.
-func (c *Config) SetOtelSemanticsEnabled(enabled bool, origin telemetry.Origin, product ...Product) {
+func (c *Config) SetOTelSemanticsEnabled(enabled bool, origin telemetry.Origin, product ...Product) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.checkProductConflict("DD_TRACE_OTEL_SEMANTICS_ENABLED", origin, enabled, product...) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -168,6 +168,9 @@ type Config struct {
 	// otlpExportMetricsMode indicates metrics should be exported via OTLP rather than
 	// a Datadog protocol.
 	otlpExportMetricsMode bool
+	// otelSemanticsEnabled makes OTLP-exported spans match the pure OTel SDK
+	// by omitting Datadog-specific attributes. Set via DD_TRACE_OTEL_SEMANTICS_ENABLED.
+	otelSemanticsEnabled bool
 	// otlpTraceURL is the OTLP collector endpoint for traces
 	otlpTraceURL string
 	// otlpHeaders holds the resolved OTLP trace headers from
@@ -266,6 +269,8 @@ func loadConfig() *Config {
 	cfg.retryInterval = p.GetDuration("DD_TRACE_RETRY_INTERVAL", time.Millisecond)
 	cfg.sendRetries = p.GetIntWithValidator("DD_TRACE_SEND_RETRIES", 0, validateSendRetries)
 	cfg.logsOTelEnabled = p.GetBool("DD_LOGS_OTEL_ENABLED", false)
+	otelSemantics, otelSemanticsOrigin := p.GetBoolWithOrigin("DD_TRACE_OTEL_SEMANTICS_ENABLED", false)
+	cfg.SetOtelSemanticsEnabled(otelSemantics, otelSemanticsOrigin)
 	if v := p.GetString("OTEL_LOGS_EXPORTER", ""); v != "" {
 		log.Warn("OTEL_LOGS_EXPORTER is not supported")
 	}
@@ -1198,6 +1203,24 @@ func (c *Config) SetLogsOTelEnabled(enabled bool, origin telemetry.Origin, produ
 	}
 	c.logsOTelEnabled = enabled
 	configtelemetry.Report("DD_LOGS_OTEL_ENABLED", enabled, origin)
+}
+
+func (c *Config) OtelSemanticsEnabled() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.otelSemanticsEnabled
+}
+
+// SetOtelSemanticsEnabled sets whether OTLP-exported spans should match the pure
+// OpenTelemetry SDK, and reports the value to configuration telemetry.
+func (c *Config) SetOtelSemanticsEnabled(enabled bool, origin telemetry.Origin, product ...Product) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.checkProductConflict("DD_TRACE_OTEL_SEMANTICS_ENABLED", origin, enabled, product...) {
+		return
+	}
+	c.otelSemanticsEnabled = enabled
+	configtelemetry.Report("DD_TRACE_OTEL_SEMANTICS_ENABLED", enabled, origin)
 }
 
 func (c *Config) TraceProtocol() float64 {

--- a/internal/env/supported_configurations.gen.go
+++ b/internal/env/supported_configurations.gen.go
@@ -214,6 +214,7 @@ var SupportedConfigurations = map[string]struct{}{
 	"DD_TRACE_MUX_ANALYTICS_ENABLED":                                  {},
 	"DD_TRACE_NEGRONI_ANALYTICS_ENABLED":                              {},
 	"DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP":                        {},
+	"DD_TRACE_OTEL_SEMANTICS_ENABLED":                                 {},
 	"DD_TRACE_PARTIAL_FLUSH_ENABLED":                                  {},
 	"DD_TRACE_PARTIAL_FLUSH_MIN_SPANS":                                {},
 	"DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED":                          {},

--- a/internal/env/supported_configurations.json
+++ b/internal/env/supported_configurations.json
@@ -1442,6 +1442,13 @@
         "default": "(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:(?:\\\\s|%20)*(?:=|%3D)[^&]+|(?:\\\"|%22)(?:\\\\s|%20)*(?::|%3A)(?:\\\\s|%20)*(?:\\\"|%22)(?:%2[^2]|%[^2]|[^\\\"%])+(?:\\\"|%22))|bearer(?:\\\\s|%20)+[a-z0-9\\\\._\\\\-]|token(?::|%3A)[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L](?:[\\\\w=-]|%3D)+\\\\.ey[I-L](?:[\\\\w=-]|%3D)+(?:\\\\.(?:[\\\\w.+\\\\/=-]|%3D|%2F|%2B)+)?|[\\\\-]{5}BEGIN(?:[a-z\\\\s]|%20)+PRIVATE(?:\\\\s|%20)KEY[\\\\-]{5}[^\\\\-]+[\\\\-]{5}END(?:[a-z\\\\s]|%20)+PRIVATE(?:\\\\s|%20)KEY|ssh-rsa(?:\\\\s|%20)*(?:[a-z0-9\\\\/\\\\.+]|%2F|%5C|%2B){100,}"
       }
     ],
+    "DD_TRACE_OTEL_SEMANTICS_ENABLED": [
+      {
+        "implementation": "A",
+        "type": "boolean",
+        "default": "false"
+      }
+    ],
     "DD_TRACE_PARTIAL_FLUSH_ENABLED": [
       {
         "implementation": "A",


### PR DESCRIPTION
### What does this PR do?
Adds an opt-in `DD_TRACE_OTEL_SEMANTICS_ENABLED` that aligns OTLP-exported spans (and the OTel bridge) with the pure OpenTelemetry SDK by suppressing Datadog-specific attributes and stopping DD-convention remaps. Mirrors dd-trace-py #18495 and libdatadog #2091.

### Behavior when `DD_TRACE_OTEL_SEMANTICS_ENABLED=true`
- Omit `operation.name`, `resource.name`, `span.type` (DD-only span attributes)
- Omit `error.message`/`type`/`stack`/`handling_stack` from the span (they live on the exception span event for Error Tracking)
- Omit `span.kind` (already carried by the first-class OTLP `SpanKind` field)
- Keep `http.response.status_code` under its OTel key instead of remapping to the legacy `http.status_code` string tag
- The OTel bridge no longer interprets Datadog reserved tags (`operation.name`, `analytics.event`, `http.response.status_code`) in `SetAttributes` — they pass through as provided
- `SetName` updates the Datadog **resource** (which the OTLP exporter emits as the span name) instead of the DD-only **operation name**

Default (flag off) behavior is unchanged.

### Why `SetName` is gated here (moved from #4887)
Changing `SetName` to update the resource is the correct OTel-aligned behavior, but doing it unconditionally is a breaking change: it shifts both the operation name **and** resource name, which changes users' RED metrics. Per team discussion (matching the dd-trace-js decision), this belongs behind the semantics flag rather than as a default change in a minor release. This supersedes #4887.

### Performance
The flag is read **once** per export batch in `otlpTraceWriter.add()` and resolved **once** at provider creation for the bridge (cached on the `oteltracer`), then threaded as a parameter / read as a field — no per-span/per-attribute global config lookup.

### Testing
`TestConvertSpanAttributesOtelSemantics`, `TestRemapStatusCodeOtelSemantics`, `TestToReservedAttributesOtelSemantics`, and `TestSpanSetNameUpdatesResourceOtelSemantics` (flag on) plus the existing `TestSpanSetName` (flag off, legacy operation-name behavior). Full `ddtrace/tracer`, `ddtrace/opentelemetry`, and `internal/config` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)