### PR TITLE
feat(opentelemetry): implement RecordError on the OTel bridge span

### DIFF
--- a/ddtrace/opentelemetry/span.go
+++ b/ddtrace/opentelemetry/span.go
@@ -8,6 +8,8 @@ package opentelemetry
 import (
 	"encoding/binary"
 	"errors"
+	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -188,7 +190,11 @@ func (s *span) SetStatus(code otelcodes.Code, description string) {
 
 // AddEvent adds a span event onto the span with the provided name and EventOptions
 func (s *span) AddEvent(name string, opts ...oteltrace.EventOption) {
-	if !s.IsRecording() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// s.events is read under s.mu by End; guard the append so a concurrent
+	// AddEvent/RecordError can't race the flush.
+	if s.finished {
 		return
 	}
 	c := oteltrace.NewEventConfig(opts...)
@@ -204,6 +210,39 @@ func (s *span) AddEvent(name string, opts ...oteltrace.EventOption) {
 		},
 	}
 	s.events = append(s.events, e)
+}
+
+// RecordError records err as an OpenTelemetry "exception" span event (with a stack
+// trace when WithStackTrace is set). Like the OTel SDK, it does not set the status.
+// See https://github.com/open-telemetry/opentelemetry-go/blob/v1.44.0/sdk/trace/span.go#L631
+func (s *span) RecordError(err error, opts ...oteltrace.EventOption) {
+	if err == nil || !s.IsRecording() {
+		return
+	}
+	cfg := oteltrace.NewEventConfig(opts...)
+	attrs := []attribute.KeyValue{
+		attribute.String("exception.type", errorTypeName(err)),
+		attribute.String("exception.message", err.Error()),
+	}
+	if cfg.StackTrace() {
+		attrs = append(attrs, attribute.String("exception.stacktrace", recordStackTrace()))
+	}
+	s.AddEvent("exception", append(opts, oteltrace.WithAttributes(attrs...))...)
+}
+
+// errorTypeName formats err's type like the OTel SDK's exception.type.
+func errorTypeName(err error) string {
+	t := reflect.TypeOf(err)
+	if t.PkgPath() == "" && t.Name() == "" {
+		return t.String() // builtin or pointer type, e.g. *errors.errorString
+	}
+	return t.PkgPath() + "." + t.Name()
+}
+
+func recordStackTrace() string {
+	buf := make([]byte, 2048)
+	n := runtime.Stack(buf, false)
+	return string(buf[:n])
 }
 
 // SetAttributes sets the key-value pairs as tags on the span.

--- a/ddtrace/opentelemetry/span_test.go
+++ b/ddtrace/opentelemetry/span_test.go
@@ -402,6 +402,115 @@ func attributesContains(attrs map[string]any, key string, val any) bool {
 	return false
 }
 
+type recordErrorTestErr struct{ msg string }
+
+func (e recordErrorTestErr) Error() string { return e.msg }
+
+func TestSpanRecordError(t *testing.T) {
+	_, _, cleanup := mockTracerProvider(t)
+	tr := otel.Tracer("")
+	defer cleanup()
+
+	eventAttrs := func(sp oteltrace.Span) map[string]any {
+		dd := sp.(*span)
+		for _, ev := range dd.events {
+			if ev.name == "exception" {
+				cfg := tracer.SpanEventConfig{}
+				for _, opt := range ev.options {
+					opt(&cfg)
+				}
+				return cfg.Attributes
+			}
+		}
+		return nil
+	}
+
+	t.Run("records exception event with type and message", func(t *testing.T) {
+		assert := assert.New(t)
+		_, sp := tr.Start(context.Background(), "span_record_error")
+		sp.RecordError(errors.New("boom"))
+		sp.End()
+		dd := sp.(*span)
+
+		assert.Len(dd.events, 1)
+		assert.Equal("exception", dd.events[0].name)
+		attrs := eventAttrs(sp)
+		assert.True(attributesContains(attrs, "exception.type", "*errors.errorString"))
+		assert.True(attributesContains(attrs, "exception.message", "boom"))
+		// No stack trace unless explicitly requested.
+		_, hasStack := attrs["exception.stacktrace"]
+		assert.False(hasStack)
+	})
+
+	t.Run("records stack trace when requested", func(t *testing.T) {
+		assert := assert.New(t)
+		_, sp := tr.Start(context.Background(), "span_record_error_stack")
+		sp.RecordError(errors.New("boom"), oteltrace.WithStackTrace(true))
+		sp.End()
+
+		attrs := eventAttrs(sp)
+		stack, ok := attrs["exception.stacktrace"].(string)
+		assert.True(ok)
+		assert.NotEmpty(stack)
+	})
+
+	t.Run("named error type uses fully-qualified exception.type", func(t *testing.T) {
+		assert := assert.New(t)
+		_, sp := tr.Start(context.Background(), "span_record_error_named")
+		sp.RecordError(recordErrorTestErr{"boom"})
+		sp.End()
+
+		attrs := eventAttrs(sp)
+		// Named value types use the full pkg-path form, matching the OTel SDK.
+		assert.True(attributesContains(attrs,
+			"exception.type", "github.com/DataDog/dd-trace-go/v2/ddtrace/opentelemetry.recordErrorTestErr"))
+	})
+
+	t.Run("nil error is a no-op", func(t *testing.T) {
+		assert := assert.New(t)
+		_, sp := tr.Start(context.Background(), "span_record_error_nil")
+		sp.RecordError(nil)
+		sp.End()
+		dd := sp.(*span)
+		assert.Empty(dd.events)
+	})
+
+	t.Run("non-recording span is a no-op", func(t *testing.T) {
+		assert := assert.New(t)
+		_, sp := tr.Start(context.Background(), "span_record_error_finished")
+		sp.End() // span is no longer recording
+		assert.False(sp.IsRecording())
+		sp.RecordError(errors.New("boom"))
+		dd := sp.(*span)
+		assert.Empty(dd.events)
+	})
+}
+
+// TestSpanRecordErrorDoesNotSetStatus covers the spec contract that RecordError
+// records an exception event but must NOT mark the span as errored — the error
+// status is only set via SetStatus.
+func TestSpanRecordErrorDoesNotSetStatus(t *testing.T) {
+	assert := assert.New(t)
+	_, payloads, cleanup := mockTracerProvider(t)
+	tr := otel.Tracer("")
+	defer cleanup()
+
+	_, sp := tr.Start(context.Background(), "op")
+	sp.RecordError(errors.New("boom"))
+	sp.End()
+
+	tracer.Flush()
+	traces, err := waitForPayload(payloads)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	p := traces[0]
+	assert.NotEqual(1.0, p[0]["error"], "RecordError must not flag the span as errored")
+	meta := fmt.Sprintf("%v", p[0]["meta"])
+	assert.NotContains(meta, "error.message")
+	assert.NotContains(meta, "error.type")
+}
+
 func TestSpanContextWithStartOptions(t *testing.T) {
 	assert := assert.New(t)
 	_, payloads, cleanup := mockTracerProvider(t)


### PR DESCRIPTION
### What does this PR do?
Implements `RecordError` on the OpenTelemetry bridge span. Previously the bridge embedded `noop.Span` and never implemented `RecordError`, so `span.RecordError(err)` — the canonical OTel way to record an exception — was a **silent no-op** on the Datadog SDK while working on the pure OTel SDK. `SetStatus` and `AddEvent` were already implemented; `RecordError` was the conspicuous omission.

### Behavior
Mirrors the OpenTelemetry SDK's `RecordError`:
- records an `exception` span event with `exception.type` and `exception.message`
- adds `exception.stacktrace` when `WithStackTrace(true)` is set
- consistent with the spec, **does not** set the span status (call `SetStatus` for that)
- no-ops on `nil` error and non-recording spans

`exception.type` uses the same `PkgPath()+"."+Name()` formatting as the OTel SDK, so the value matches what the pure OTel SDK emits (e.g. `*errors.errorString`).

### Motivation
dd-trace-js (`bridge-span-base.js`), dd-trace-py (`internal/opentelemetry/span.py`), and dd-trace-java (`OtelSpan.java`) already implement record-exception on their OTel bridges — dd-trace-go was the only one missing it. A customer following standard OTel error-handling guidance (`span.RecordError(err)`) silently loses exception events on the Datadog SDK today. Relates to #3424, #3731, and the earlier #4462.

### Testing
Adds `TestSpanRecordError` covering: exception type/message, stack trace when requested (and absent by default), fully-qualified type name for a named error type, and nil/no-op. Full `ddtrace/opentelemetry` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)