### PR TITLE
chore(profiler): Set EVP origin headers on profile uploads

### DIFF
--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion"
 	"github.com/DataDog/dd-trace-go/v2/internal/processtags"
+	"github.com/DataDog/dd-trace-go/v2/internal/version"
 )
 
 // maxRetries specifies the maximum number of retries to have when an error occurs.
@@ -30,9 +31,11 @@ const maxRetries = 2
 
 // headerEVPOrigin and evpOrigin identify the dd-trace-go profiler as the origin
 // of profile uploads in the shared profiling ingestion pipeline.
+// headerEVPOriginVersion carries the dd-trace-go release version.
 const (
-	headerEVPOrigin = "DD-EVP-ORIGIN"
-	evpOrigin       = "dd-trace-go"
+	headerEVPOrigin        = "DD-EVP-ORIGIN"
+	evpOrigin              = "dd-trace-go"
+	headerEVPOriginVersion = "DD-EVP-ORIGIN-VERSION"
 )
 
 var errOldAgent = errors.New("Datadog Agent is not accepting profiles. Agent-based profiling deployments " +
@@ -115,6 +118,7 @@ func (p *profiler) doRequest(bat batch) error {
 		req.Header.Set("Datadog-Entity-ID", *eid)
 	}
 	req.Header.Set(headerEVPOrigin, evpOrigin)
+	req.Header.Set(headerEVPOriginVersion, version.Tag)
 	req.Header.Set("Content-Type", contentType)
 
 	resp, err := p.cfg.httpClient.Do(req)

--- a/profiler/upload.go
+++ b/profiler/upload.go
@@ -28,6 +28,13 @@ import (
 // maxRetries specifies the maximum number of retries to have when an error occurs.
 const maxRetries = 2
 
+// headerEVPOrigin and evpOrigin identify the dd-trace-go profiler as the origin
+// of profile uploads in the shared profiling ingestion pipeline.
+const (
+	headerEVPOrigin = "DD-EVP-ORIGIN"
+	evpOrigin       = "dd-trace-go"
+)
+
 var errOldAgent = errors.New("Datadog Agent is not accepting profiles. Agent-based profiling deployments " +
 	"require Datadog Agent >= 7.20")
 
@@ -107,6 +114,7 @@ func (p *profiler) doRequest(bat batch) error {
 	if eid := entityID.Load(); eid != nil && *eid != "" {
 		req.Header.Set("Datadog-Entity-ID", *eid)
 	}
+	req.Header.Set(headerEVPOrigin, evpOrigin)
 	req.Header.Set("Content-Type", contentType)
 
 	resp, err := p.cfg.httpClient.Do(req)

--- a/profiler/upload_test.go
+++ b/profiler/upload_test.go
@@ -19,6 +19,7 @@ import (
 	maininternal "github.com/DataDog/dd-trace-go/v2/internal"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/processtags"
+	"github.com/DataDog/dd-trace-go/v2/internal/version"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -142,6 +143,7 @@ func TestEntityContainerIDHeaders(t *testing.T) {
 func TestEVPOriginHeader(t *testing.T) {
 	profile := doOneShortProfileUpload(t)
 	assert.Equal(t, "dd-trace-go", profile.headers.Get("DD-EVP-Origin"))
+	assert.Equal(t, version.Tag, profile.headers.Get("DD-EVP-Origin-Version"))
 }
 
 func TestGitMetadata(t *testing.T) {

--- a/profiler/upload_test.go
+++ b/profiler/upload_test.go
@@ -139,6 +139,11 @@ func TestEntityContainerIDHeaders(t *testing.T) {
 	})
 }
 
+func TestEVPOriginHeader(t *testing.T) {
+	profile := doOneShortProfileUpload(t)
+	assert.Equal(t, "dd-trace-go", profile.headers.Get("DD-EVP-Origin"))
+}
+
 func TestGitMetadata(t *testing.T) {
 	t.Run("git-metadata-from-dd-tags", func(t *testing.T) {
 		t.Setenv(maininternal.EnvDDTags, "git.commit.sha:123456789ABCD git.repository_url:github.com/user/repo go_path:somepath")


### PR DESCRIPTION
<!-- dd-meta {"pullId":"695cf9e4-3748-4e43-a136-18cc62196bbe","source":"chat","resourceId":"856beaf3-a0f3-4934-83c5-a02f3abd5309","workflowId":"50061d5e-209d-4a28-bb68-8f87f05f3289","codeChangeId":"50061d5e-209d-4a28-bb68-8f87f05f3289","sourceType":"assistant"} -->
### What does this PR do?

Sets the `DD-EVP-ORIGIN: dd-trace-go` and `DD-EVP-ORIGIN-VERSION: <dd-trace-go version>` headers on profiler upload requests in `(*profiler).doRequest`. The header names and origin value are defined as constants near the other upload constants to avoid magic strings.

### Motivation

dd-trace-go profile uploads currently arrive without EVP origin metadata, so they fall into the `dd_evp_origin:N/A` bucket in the [shared profiling ingestion metric](https://app.datadoghq.com/s/yB5yjZ/vyz-drv-dci). Other profilers identify themselves with values like `dd-trace-java`, `dd-trace-py`, `dd-trace-js`, `dd-trace-rb`, and `datadog-profiling`. Adding `dd-trace-go` follows that same naming convention so Go profile uploads are correctly attributed, and sending the dd-trace-go release version enables version-level attribution for those uploads.

### Testing

- `go test ./profiler -run 'TestEVPOriginHeader|TestEntityContainerIDHeaders'` passes.
- `go build ./profiler` and `gofmt` are clean.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/856beaf3-a0f3-4934-83c5-a02f3abd5309)

Comment @datadog to request changes
