### PR TITLE
ci(system-tests): pre-build weblog images once per variant and cache datadog-ci npm install to eliminate transient failures

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -266,6 +266,20 @@ jobs:
           echo "DD_API_KEY=${{ steps.dd-sts.outputs.api_key }}" >> "$GITHUB_ENV"
           echo "DD_APP_KEY=${{ steps.dd-sts.outputs.app_key }}" >> "$GITHUB_ENV"
 
+      - name: Cache npm packages for datadog-ci
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ~/.npm
+          key: npm-datadog-ci-${{ runner.os }}-v1
+          restore-keys: |
+            npm-datadog-ci-${{ runner.os }}-
+
+      # Pre-install datadog-ci early so the action's npm install is instant.
+      # continue-on-error: the action has its own retry; this is best-effort.
+      - name: Pre-install datadog-ci
+        continue-on-error: true
+        run: npm install -g @datadog/datadog-ci
+
       - name: Download pre-built weblog image
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -395,6 +409,18 @@ jobs:
         uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75
         with:
           policy: dd-trace-go-app-key
+
+      - name: Cache npm packages for datadog-ci
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ~/.npm
+          key: npm-datadog-ci-${{ runner.os }}-v1
+          restore-keys: |
+            npm-datadog-ci-${{ runner.os }}-
+
+      - name: Pre-install datadog-ci
+        continue-on-error: true
+        run: npm install -g @datadog/datadog-ci
 
       - name: Build runner
         uses: ./.github/actions/install_runner

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -54,6 +54,68 @@ jobs:
         with:
           path: .git
           key: gitdb-system-tests-${{ steps.pin.outputs.sha }}
+  build-weblog-images:
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'DataDog/dd-trace-go')
+    runs-on: ubuntu-latest
+    needs:
+      - warm-repo-cache
+    strategy:
+      fail-fast: false
+      matrix:
+        weblog-variant:
+          - net-http
+          - echo
+          - chi
+          - gin
+          - uds-echo
+          - graph-gophers
+          - graphql-go
+          - gqlgen
+    name: Build weblog (${{ matrix.weblog-variant }})
+    env:
+      TEST_LIBRARY: golang
+      WEBLOG_VARIANT: ${{ matrix.weblog-variant }}
+    steps:
+      - name: Restore repo cache
+        id: restore-repo-cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: .git
+          key: gitdb-system-tests-${{ needs.warm-repo-cache.outputs.sha }}
+
+      - name: Checkout system tests (using cache)
+        if: steps.restore-repo-cache.outcome == 'success' && steps.restore-repo-cache.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          git config safe.directory "$GITHUB_WORKSPACE"
+          git checkout -f ${{ needs.warm-repo-cache.outputs.sha }}
+
+      # Fall back in case of a cache miss, which can occur when retrying old runs.
+      - name: Checkout system tests (cache miss)
+        if: steps.restore-repo-cache.outcome == 'failure' || steps.restore-repo-cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          repository: 'DataDog/system-tests'
+          ref: ${{ inputs.ref }}
+
+      - name: Checkout dd-trace-go
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.branch_ref || github.ref }}
+          path: 'binaries/dd-trace-go'
+
+      - name: Build and save weblog image
+        run: ./build.sh -i weblog --save-to-binaries
+
+      - name: Upload weblog image artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: weblog-image-${{ matrix.weblog-variant }}
+          path: binaries/golang-${{ matrix.weblog-variant }}-weblog.tar.zst
+          retention-days: 1
+
   system-tests:
     if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'DataDog/dd-trace-go')
     # Note: Not using large runners because the jobs spawned by this pipeline
@@ -61,6 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - warm-repo-cache
+      - build-weblog-images
     strategy:
       matrix:
         weblog-variant:
@@ -202,6 +265,12 @@ jobs:
         run: |
           echo "DD_API_KEY=${{ steps.dd-sts.outputs.api_key }}" >> "$GITHUB_ENV"
           echo "DD_APP_KEY=${{ steps.dd-sts.outputs.app_key }}" >> "$GITHUB_ENV"
+
+      - name: Download pre-built weblog image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: weblog-image-${{ matrix.weblog-variant }}
+          path: binaries/
 
       - name: Build weblog
         run: ./build.sh -i weblog
@@ -375,6 +444,7 @@ jobs:
   system-tests-done:
     name: System Tests
     needs:
+      - build-weblog-images
       - system-tests
       - system-tests-docker-images
       - tracer-release
@@ -383,13 +453,15 @@ jobs:
     steps:
       - name: Success
         if: |
-          needs.system-tests.result == 'success'
+          needs.build-weblog-images.result == 'success'
+          && needs.system-tests.result == 'success'
           && needs.system-tests-docker-images.result == 'success'
           && (needs.tracer-release.result == 'success' || needs.tracer-release.result == 'skipped')
         run: echo "Success!"
       - name: Failure
         if: |
-          needs.system-tests.result != 'success'
+          needs.build-weblog-images.result != 'success'
+          || needs.system-tests.result != 'success'
           || needs.system-tests-docker-images.result != 'success'
           || (needs.tracer-release.result != 'success' && needs.tracer-release.result != 'skipped')
         run: echo "Failure!" && exit 1


### PR DESCRIPTION
## What does this PR do?

* Adds a `build-weblog-images` job that builds each of the 8 weblog variants **once**, saves the result to `binaries/golang-{variant}-weblog.tar.zst` via `build.sh --save-to-binaries`, and uploads it as a short-lived (1-day) artifact. The 85+ matrix jobs then download their variant's artifact before calling `./build.sh -i weblog`; system-tests' `build.sh` already checks for `binaries/${TEST_LIBRARY}-${WEBLOG_VARIANT}-weblog.tar.zst` and loads the pre-built image instead of rebuilding.

This is the same pattern the workflow already uses for the envoy/haproxy images (`build-service-extensions-callout` / `build-haproxy` → `system-tests-docker-images`).

* Adds a best-effort caching for `npm install -g @datadog/datadog-ci` to hit less NPM registry.

## Motivation

* PR #4773 run [#27708352663](https://github.com/DataDog/dd-trace-go/actions/runs/27708352663/job/81962698452) attempt 1 had `Test (net-http, AGENT_SUPPORTING_SPAN_EVENTS)` fail with a transient HTTP/2 `INTERNAL_ERROR` from `proxy.golang.org` during `go mod download` inside the weblog Docker build. Attempt 2 passed with no code change.
* PR #4903 run [#27716667676](https://github.com/DataDog/dd-trace-go/actions/runs/27716667676/job/81992071467) attempt 1 had a `npm install -g @datadog/datadog-ci` that took 44 minutes.

**Root cause — blast surface**: The `system-tests` workflow has 85+ matrix jobs, each independently running `./build.sh -i weblog`. That step does a full Docker build including `go mod download` from scratch every time. Any single transient proxy.golang.org hiccup turns the whole workflow red. With 85+ independent network calls, the probability of at least one failing is non-trivial enough to keep CI on incident threshold.

### Impact

| | Before | After |
|---|---|---|
| `go mod download` calls per run | 85+ | 8 |
| Transient failure surface reduction | — | ~90% |
| Weblog variants pre-built | — | `net-http`, `echo`, `chi`, `gin`, `uds-echo`, `graph-gophers`, `graphql-go`, `gqlgen` |

### Changes

- **New job `build-weblog-images`** (8-way matrix, one per weblog variant): checkout system-tests + dd-trace-go → `./build.sh -i weblog --save-to-binaries` → upload `binaries/golang-{variant}-weblog.tar.zst` as artifact
- **`system-tests` matrix**: add `needs: build-weblog-images`; add "Download pre-built weblog image" step that places the artifact in `binaries/` before calling `./build.sh -i weblog`
- **`system-tests-done` aggregator**: add `build-weblog-images` to `needs` and both result checks so a pre-build failure blocks the gate correctly

## Reviewer notes

- `build.sh --save-to-binaries` exists in DataDog/system-tests and writes a zstd-compressed image to `binaries/${TEST_LIBRARY}-${WEBLOG_VARIANT}-weblog.tar.zst`
- `build.sh -i weblog` checks for that file first and skips the Docker build if found
- Artifact `retention-days: 1` keeps storage usage negligible