### PR TITLE
fix(civisibility): retry JSON-expected 2xx responses with unrecognised Content-Type; harden subtest matrix harness

### DIFF
--- a/internal/civisibility/integrations/gotesting/subtests/main_test.go
+++ b/internal/civisibility/integrations/gotesting/subtests/main_test.go
@@ -32,29 +32,46 @@ func TestMain(m *testing.M) {
 	}
 
 	for _, scenario := range matrixScenarioNames() {
-		cmd := exec.Command(os.Args[0], scenarioArgs(os.Args[1:])...)
-		var buffer bytes.Buffer
-		cmd.Stdout = &buffer
-		cmd.Stderr = &buffer
-		if log.DebugEnabled() {
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-		}
-		cmd.Env = append(os.Environ(), fmt.Sprintf("%s=%s", subtestScenarioEnv, scenario))
-
-		fmt.Printf("\n**** [RUNNING SUBTEST SCENARIO: %s]\n", scenario)
-		if err := cmd.Run(); err != nil {
-			if exitErr, ok := err.(*exec.ExitError); ok {
-				fmt.Printf("\n**** [SCENARIO %s FAILED WITH EXIT CODE: %d]\n", scenario, exitErr.ExitCode())
-				fmt.Printf("**** [SCENARIO %s OUTPUT]\n%s\n", scenario, buffer.String())
-				restoreEnv(constants.CIVisibilitySubtestFeaturesEnabled, prevDD, hadDD)
-				os.Exit(exitErr.ExitCode())
+		const maxInitRetries = 2
+		for attempt := 0; ; attempt++ {
+			cmd := exec.Command(os.Args[0], scenarioArgs(os.Args[1:])...)
+			var buffer bytes.Buffer
+			cmd.Stdout = &buffer
+			cmd.Stderr = &buffer
+			if log.DebugEnabled() {
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
 			}
-			fmt.Printf("failed to run scenario %s: %v\n", scenario, err)
+			cmd.Env = append(os.Environ(), fmt.Sprintf("%s=%s", subtestScenarioEnv, scenario))
+
+			fmt.Printf("\n**** [RUNNING SUBTEST SCENARIO: %s]\n", scenario)
+			err := cmd.Run()
+			if err == nil {
+				fmt.Printf("**** [SCENARIO %s COMPLETED]\n", scenario)
+				break
+			}
+
+			exitErr, ok := err.(*exec.ExitError)
+			if !ok {
+				fmt.Printf("failed to run scenario %s: %v\n", scenario, err)
+				restoreEnv(constants.CIVisibilitySubtestFeaturesEnabled, prevDD, hadDD)
+				os.Exit(1)
+			}
+
+			// scenarioInitFailureExitCode means CI Visibility features were not initialised
+			// (transient settings/management fetch failure).  Retry up to maxInitRetries times
+			// so a genuine one-shot network hiccup doesn't fail the whole test suite.
+			if exitErr.ExitCode() == scenarioInitFailureExitCode && attempt < maxInitRetries {
+				fmt.Printf("**** [SCENARIO %s INIT FAILURE (attempt %d/%d), retrying]\n", scenario, attempt+1, maxInitRetries)
+				fmt.Printf("**** [SCENARIO %s OUTPUT]\n%s\n", scenario, buffer.String())
+				continue
+			}
+
+			fmt.Printf("\n**** [SCENARIO %s FAILED WITH EXIT CODE: %d]\n", scenario, exitErr.ExitCode())
+			fmt.Printf("**** [SCENARIO %s OUTPUT]\n%s\n", scenario, buffer.String())
 			restoreEnv(constants.CIVisibilitySubtestFeaturesEnabled, prevDD, hadDD)
-			os.Exit(1)
+			os.Exit(exitErr.ExitCode())
 		}
-		fmt.Printf("**** [SCENARIO %s COMPLETED]\n", scenario)
 	}
 
 	code := m.Run()

--- a/internal/civisibility/integrations/gotesting/subtests/subtestcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/subtests/subtestcontroller_test.go
@@ -34,6 +34,11 @@ const (
 	suiteUnderTest    = "fixtures_test.go"
 	parentTestName    = "TestSubtestManagement"
 	parallelToggleEnv = "SUBTEST_MATRIX_PARALLEL"
+
+	// scenarioInitFailureExitCode is returned by runMatrixScenario when CI Visibility features
+	// were not initialised (e.g. a transient settings fetch failure).  main_test.go uses this
+	// sentinel to retry the subprocess rather than failing the whole suite immediately.
+	scenarioInitFailureExitCode = 3
 )
 
 var (
@@ -804,6 +809,19 @@ func runMatrixScenario(m *testing.M, scenario string) int {
 
 	tracer := integrations.InitializeCIVisibilityMock()
 
+	// Guard against the scenario running with Test Management silently disabled due to a
+	// transient settings or test-management fetch failure.  Returning scenarioInitFailureExitCode
+	// lets the parent process retry the subprocess rather than producing a confusing span-count
+	// validation panic.
+	if s := integrations.GetSettings(); s == nil || !s.TestManagement.Enabled {
+		fmt.Printf("subtest matrix: scenario %s init failure: Test Management not enabled (transient settings fetch failure?)\n", scenario)
+		return scenarioInitFailureExitCode
+	}
+	if d := integrations.GetTestManagementTestsData(); d == nil || len(d.Modules) == 0 {
+		fmt.Printf("subtest matrix: scenario %s init failure: test-management data empty (transient fetch failure?)\n", scenario)
+		return scenarioInitFailureExitCode
+	}
+
 	exitCode := gotesting.RunM(m)
 	// When the run fails, dump span resources for easier diagnosis.
 	if exitCode != 0 {
@@ -990,7 +1008,7 @@ func startSubtestServer(cfg subtestServerConfig) (*httptest.Server, func()) {
 			debugMatrixf("subtest server: search-commits request")
 			defer r.Body.Close()
 			_, _ = io.Copy(io.Discard, r.Body)
-			w.WriteHeader(http.StatusOK)
+			w.Header().Set("Content-Type", "application/json")
 			w.Write([]byte(`{}`))
 		case "/api/v2/git/repository/packfile":
 			// Accept packfile uploads even though the sandbox blocks writes.

--- a/internal/civisibility/utils/net/http.go
+++ b/internal/civisibility/utils/net/http.go
@@ -51,15 +51,16 @@ type FormFile struct {
 
 // RequestConfig holds configuration for a request.
 type RequestConfig struct {
-	Method     string            // HTTP method: GET or POST
-	URL        string            // Request URL
-	Headers    map[string]string // Additional HTTP headers
-	Body       any               // Request body for JSON, MessagePack, or raw bytes
-	Format     string            // Format: "json" or "msgpack"
-	Compressed bool              // Whether to use gzip compression
-	Files      []FormFile        // Files to be uploaded in a multipart form data request
-	MaxRetries int               // Maximum number of retries
-	Backoff    time.Duration     // Initial backoff duration for retries
+	Method             string            // HTTP method: GET or POST
+	URL                string            // Request URL
+	Headers            map[string]string // Additional HTTP headers
+	Body               any               // Request body for JSON, MessagePack, or raw bytes
+	Format             string            // Format: "json" or "msgpack"
+	Compressed         bool              // Whether to use gzip compression
+	Files              []FormFile        // Files to be uploaded in a multipart form data request
+	MaxRetries         int               // Maximum number of retries
+	Backoff            time.Duration     // Initial backoff duration for retries
+	ExpectJSONResponse bool              // When true, a 2xx response with a non-JSON Content-Type is retried instead of being returned as-is
 }
 
 // Response represents the HTTP response with deserialization capabilities and status code.
@@ -369,6 +370,18 @@ func (rh *RequestHandler) internalSendRequest(config *RequestConfig, attempt int
 		if mediaType == ContentTypeJSON || mediaType == ContentTypeJSONAlternative {
 			responseFormat = FormatJSON
 		}
+	}
+
+	// When the caller requires a JSON response but the server returned something
+	// unrecognised (e.g. a keep-alive reuse EOF that Go promotes to a 200 with an
+	// empty/plain-text body), treat it as a transient failure and retry.  Upload
+	// endpoints that never decode the response body must leave ExpectJSONResponse
+	// false so they are unaffected.
+	if config.ExpectJSONResponse && responseFormat == "unknown" && statusCode >= 200 && statusCode < 300 {
+		log.Debug("ciVisibilityHttpClient: expected JSON response but got format %q [method: %s, url: %s, status_code: %d]; retrying",
+			responseFormat, config.Method, config.URL, statusCode)
+		exponentialBackoff(attempt, config.Backoff)
+		return false, nil, nil
 	}
 
 	if log.DebugEnabled() {

--- a/internal/civisibility/utils/net/http_test.go
+++ b/internal/civisibility/utils/net/http_test.go
@@ -753,6 +753,55 @@ func TestSendRequestWithUnsupportedResponseFormat(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported format 'unknown'")
 }
 
+// TestSendRequestExpectJSONResponseRetriesOnUnknownFormat verifies that when
+// ExpectJSONResponse is true a 2xx response with a non-JSON Content-Type is
+// retried up to MaxRetries times and then surfaces an error.  When
+// ExpectJSONResponse is false the existing behaviour (return as success) is
+// preserved so upload endpoints are unaffected.
+func TestSendRequestExpectJSONResponseRetriesOnUnknownFormat(t *testing.T) {
+	t.Parallel()
+
+	// Count how many times the server is called.
+	calls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set(HeaderContentType, "text/plain")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("not json"))
+	}))
+	defer ts.Close()
+
+	handler := NewRequestHandlerWithClient(createNewHTTPClient())
+
+	// With ExpectJSONResponse: true — should exhaust retries and return an error.
+	// The loop runs attempt 0..MaxRetries inclusive, so MaxRetries=2 → 3 total calls.
+	config := RequestConfig{
+		Method:             "GET",
+		URL:                ts.URL,
+		MaxRetries:         2,
+		Backoff:            1, // minimal backoff for tests
+		ExpectJSONResponse: true,
+	}
+	resp, err := handler.SendRequest(config)
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+	assert.Equal(t, "max retries exceeded", err.Error())
+	assert.Equal(t, 3, calls, "expected MaxRetries+1 total calls")
+
+	// With ExpectJSONResponse: false (default) — should return the response as-is, no retry.
+	calls = 0
+	config2 := RequestConfig{
+		Method:             "GET",
+		URL:                ts.URL,
+		ExpectJSONResponse: false,
+	}
+	resp2, err2 := handler.SendRequest(config2)
+	assert.NoError(t, err2)
+	assert.NotNil(t, resp2)
+	assert.Equal(t, "unknown", resp2.Format)
+	assert.Equal(t, 1, calls, "expected exactly 1 call without retry")
+}
+
 func TestPrepareContentWithNonByteContentForOctetStream(t *testing.T) {
 	t.Parallel()
 	_, err := prepareContent(12345, ContentTypeOctetStream)

--- a/internal/civisibility/utils/net/known_tests_api.go
+++ b/internal/civisibility/utils/net/known_tests_api.go
@@ -112,6 +112,7 @@ func (c *client) GetKnownTests() (*KnownTestsResponseData, error) {
 
 			for {
 				request := c.getPostRequestConfig(knownTestsURLPath, body)
+				request.ExpectJSONResponse = true
 				if request.Compressed {
 					telemetry.KnownTestsRequest(telemetry.CompressedRequestCompressedType)
 				} else {

--- a/internal/civisibility/utils/net/searchcommits_api.go
+++ b/internal/civisibility/utils/net/searchcommits_api.go
@@ -56,6 +56,7 @@ func (c *client) GetCommits(localCommits []string) ([]string, error) {
 	}
 
 	request := c.getPostRequestConfig(searchCommitsURLPath, body)
+	request.ExpectJSONResponse = true
 	if request.Compressed {
 		telemetry.GitRequestsSearchCommits(telemetry.CompressedRequestCompressedType)
 	} else {

--- a/internal/civisibility/utils/net/settings_api.go
+++ b/internal/civisibility/utils/net/settings_api.go
@@ -113,6 +113,7 @@ func (c *client) GetSettings() (*SettingsResponseData, error) {
 		cacheRequest,
 		func() (readCacheLiveResult[*SettingsResponseData], error) {
 			request := c.getPostRequestConfig(settingsURLPath, body)
+			request.ExpectJSONResponse = true
 			if request.Compressed {
 				telemetry.GitRequestsSettings(telemetry.CompressedRequestCompressedType)
 			} else {

--- a/internal/civisibility/utils/net/skippable.go
+++ b/internal/civisibility/utils/net/skippable.go
@@ -129,6 +129,7 @@ func (c *client) GetSkippableTests() (*SkippableTestsResponse, error) {
 		body,
 		func() (readCacheLiveResult[cachedSkippableTests], error) {
 			request := c.getPostRequestConfig(skippableURLPath, body)
+			request.ExpectJSONResponse = true
 			if request.Compressed {
 				telemetry.ITRSkippableTestsRequest(telemetry.CompressedRequestCompressedType)
 			} else {

--- a/internal/civisibility/utils/net/test_management_tests_api.go
+++ b/internal/civisibility/utils/net/test_management_tests_api.go
@@ -121,6 +121,7 @@ func (c *client) GetTestManagementTests() (*TestManagementTestsResponseDataModul
 		cacheRequest,
 		func() (readCacheLiveResult[*TestManagementTestsResponseDataModules], error) {
 			request := c.getPostRequestConfig(testManagementTestsURLPath, body)
+			request.ExpectJSONResponse = true
 			if request.Compressed {
 				telemetry.TestManagementTestsRequest(telemetry.CompressedRequestCompressedType)
 			} else {


### PR DESCRIPTION
## Summary

- **Root cause:** A 2xx HTTP response with a non-JSON `Content-Type` (format `"unknown"`) from any CI Visibility backend endpoint was returned as a success instead of being retried. A transient network hiccup (e.g. a keep-alive reuse delivering an empty or plain-text body on an otherwise-200 response) silently left `TestManagement.Enabled=false`, so the Go test wrapper was never installed for attempt-to-fix retries — causing the parent test to run once instead of 3× and producing 1 span instead of the expected 3.
- **This was the direct cause of the ~8% flaky `parent_disabled_attempt_to_fix_sub_explicit_false` scenario** in the "Dynamic Analysis with Debug Detection / test-core" CI job.
- The `search_commits` mock handler in the test harness also lacked `Content-Type: application/json`, providing a reliable in-tree trigger for the same failure mode.

## What changed

### Production hardening (`internal/civisibility/utils/net/`)

- Added `ExpectJSONResponse bool` to `RequestConfig`. When `true`, a 2xx response whose `Content-Type` is not recognised as JSON is treated as a transient failure and retried within the existing `MaxRetries` budget.
- Set `ExpectJSONResponse: true` on all JSON-decoding callers: `settings_api.go`, `test_management_tests_api.go`, `known_tests_api.go`, `skippable.go`, `searchcommits_api.go`. Upload endpoints (`sendpackfiles`, `logs`) are unaffected since they never decode the response body.
- Added unit test `TestSendRequestExpectJSONResponseRetriesOnUnknownFormat` covering both the retry path (`ExpectJSONResponse: true`) and the unchanged behaviour (`ExpectJSONResponse: false`).

### Test harness stabilisation (`internal/civisibility/integrations/gotesting/subtests/`)

- **Fixed `search_commits` mock** to set `Content-Type: application/json`, eliminating the deterministic `unsupported format 'unknown'` error logged every run and the reliable trigger for the flaky path.
- **Added `scenarioInitFailureExitCode = 3` sentinel** and a post-init guard in `runMatrixScenario`: if `Test Management` is not enabled or the test-management data is empty after `InitializeCIVisibilityMock()`, the subprocess exits with the sentinel and a clear log message instead of running and producing a confusing span-count validation panic.
- **Retry in `main_test.go`:** the parent process now retries a subprocess that exits with `scenarioInitFailureExitCode` up to 2 times, so a genuine one-shot transient fetch failure self-heals without failing the whole CI job.

## Test plan

- [x] `go test ./internal/civisibility/utils/net/... -count=1` — all tests including the new one pass
- [x] `INTEGRATION=true go test -tags debug -covermode=atomic -count=1 ./internal/civisibility/integrations/gotesting/subtests/ -timeout 180s` — all 13 scenarios pass including `parent_disabled_attempt_to_fix_sub_explicit_false`
- [x] No `unsupported format 'unknown'` / `search_commits` errors in the test output
- [x] `go build ./...` — clean
- [x] `go vet ./internal/civisibility/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)