### PR TITLE
perf(datastreams): reduce per-message allocations and lock contention in DSM hot path

### DIFF
--- a/contrib/confluentinc/confluent-kafka-go/kafkatrace/dsm.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafkatrace/dsm.go
@@ -49,7 +49,7 @@ func (tr *Tracer) SetConsumeCheckpoint(msg Message) {
 	topic := msg.GetTopicPartition().GetTopic()
 	groupID := tr.groupID
 	clusterID := tr.ClusterID()
-	key := "in\x00" + topic + "\x00" + groupID + "\x00" + clusterID
+	key := edgeFingerprint("in", topic, groupID, clusterID)
 	edges := tr.dsmTagCache.get(key)
 	if edges == nil {
 		edges = []string{"direction:in", "topic:" + topic, "type:kafka"}
@@ -79,7 +79,7 @@ func (tr *Tracer) SetProduceCheckpoint(msg Message) {
 	}
 	topic := msg.GetTopicPartition().GetTopic()
 	clusterID := tr.ClusterID()
-	key := "out\x00" + topic + "\x00" + clusterID
+	key := edgeFingerprint("out", topic, "", clusterID)
 	edges := tr.dsmTagCache.get(key)
 	if edges == nil {
 		edges = []string{"direction:out", "topic:" + topic, "type:kafka"}

--- a/contrib/confluentinc/confluent-kafka-go/kafkatrace/dsm.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafkatrace/dsm.go
@@ -46,12 +46,20 @@ func (tr *Tracer) SetConsumeCheckpoint(msg Message) {
 	if !tr.dsmEnabled || msg == nil {
 		return
 	}
-	edges := []string{"direction:in", "topic:" + msg.GetTopicPartition().GetTopic(), "type:kafka"}
-	if tr.groupID != "" {
-		edges = append(edges, "group:"+tr.groupID)
-	}
-	if tr.ClusterID() != "" {
-		edges = append(edges, "kafka_cluster_id:"+tr.ClusterID())
+	topic := msg.GetTopicPartition().GetTopic()
+	groupID := tr.groupID
+	clusterID := tr.ClusterID()
+	key := "in\x00" + topic + "\x00" + groupID + "\x00" + clusterID
+	edges := tr.dsmTagCache.get(key)
+	if edges == nil {
+		edges = []string{"direction:in", "topic:" + topic, "type:kafka"}
+		if groupID != "" {
+			edges = append(edges, "group:"+groupID)
+		}
+		if clusterID != "" {
+			edges = append(edges, "kafka_cluster_id:"+clusterID)
+		}
+		edges = tr.dsmTagCache.getOrStore(key, edges)
 	}
 	carrier := NewMessageCarrier(msg)
 	ctx, ok := tracer.SetDataStreamsCheckpointWithParams(
@@ -69,9 +77,16 @@ func (tr *Tracer) SetProduceCheckpoint(msg Message) {
 	if !tr.dsmEnabled || msg == nil {
 		return
 	}
-	edges := []string{"direction:out", "topic:" + msg.GetTopicPartition().GetTopic(), "type:kafka"}
-	if tr.ClusterID() != "" {
-		edges = append(edges, "kafka_cluster_id:"+tr.ClusterID())
+	topic := msg.GetTopicPartition().GetTopic()
+	clusterID := tr.ClusterID()
+	key := "out\x00" + topic + "\x00" + clusterID
+	edges := tr.dsmTagCache.get(key)
+	if edges == nil {
+		edges = []string{"direction:out", "topic:" + topic, "type:kafka"}
+		if clusterID != "" {
+			edges = append(edges, "kafka_cluster_id:"+clusterID)
+		}
+		edges = tr.dsmTagCache.getOrStore(key, edges)
 	}
 	carrier := NewMessageCarrier(msg)
 	ctx, ok := tracer.SetDataStreamsCheckpointWithParams(

--- a/contrib/confluentinc/confluent-kafka-go/kafkatrace/fingerprint_test.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafkatrace/fingerprint_test.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package kafkatrace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEdgeFingerprint(t *testing.T) {
+	base := edgeFingerprint("in", "orders", "grp", "clusterA")
+
+	// Deterministic for identical inputs within a process.
+	assert.Equal(t, base, edgeFingerprint("in", "orders", "grp", "clusterA"))
+
+	// Each field contributes to the fingerprint.
+	assert.NotEqual(t, base, edgeFingerprint("out", "orders", "grp", "clusterA"), "direction")
+	assert.NotEqual(t, base, edgeFingerprint("in", "payments", "grp", "clusterA"), "topic")
+	assert.NotEqual(t, base, edgeFingerprint("in", "orders", "grp2", "clusterA"), "group")
+	assert.NotEqual(t, base, edgeFingerprint("in", "orders", "grp", "clusterB"), "cluster")
+
+	// Separators disambiguate field boundaries: (topic="ab",group="c") must not
+	// collide with (topic="a",group="bc").
+	assert.NotEqual(t, edgeFingerprint("in", "ab", "c", ""), edgeFingerprint("in", "a", "bc", ""))
+}

--- a/contrib/confluentinc/confluent-kafka-go/kafkatrace/tracer.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafkatrace/tracer.go
@@ -21,9 +21,6 @@ import (
 
 const dsmEdgeTagCacheMax = 1000
 
-// dsmEdgeTagCache caches edge-tag slices keyed by a composite string to avoid
-// per-message []string allocations. Entries are shared read-only after store;
-// callers must not mutate the returned slice.
 type dsmEdgeTagCache struct {
 	m    sync.Map
 	size atomic.Int32
@@ -40,7 +37,6 @@ func (c *dsmEdgeTagCache) getOrStore(key string, tags []string) []string {
 	if v, ok := c.m.Load(key); ok {
 		return v.([]string)
 	}
-	// Pre-sort: nodeHash sorts in place, so a shared cached slice must already be sorted to keep that a no-op.
 	sort.Strings(tags)
 	if c.size.Load() >= dsmEdgeTagCacheMax {
 		return tags

--- a/contrib/confluentinc/confluent-kafka-go/kafkatrace/tracer.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafkatrace/tracer.go
@@ -7,6 +7,7 @@ package kafkatrace
 
 import (
 	"context"
+	"hash/maphash"
 	"math"
 	"net"
 	"sort"
@@ -21,29 +22,47 @@ import (
 
 const dsmEdgeTagCacheMax = 1000
 
+var dsmEdgeTagSeed = maphash.MakeSeed()
+
+// edgeFingerprint is a zero-alloc cache key for an edge-tag set
+func edgeFingerprint(direction, topic, group, cluster string) uint64 {
+	var h maphash.Hash
+	h.SetSeed(dsmEdgeTagSeed)
+	h.WriteString(direction)
+	h.WriteByte(0)
+	h.WriteString(topic)
+	h.WriteByte(0)
+	h.WriteString(group)
+	h.WriteByte(0)
+	h.WriteString(cluster)
+	return h.Sum64()
+}
+
 type dsmEdgeTagCache struct {
 	m    sync.Map
 	size atomic.Int32
 }
 
-func (c *dsmEdgeTagCache) get(key string) []string {
+func (c *dsmEdgeTagCache) get(key uint64) []string {
 	if v, ok := c.m.Load(key); ok {
 		return v.([]string)
 	}
 	return nil
 }
 
-func (c *dsmEdgeTagCache) getOrStore(key string, tags []string) []string {
+func (c *dsmEdgeTagCache) getOrStore(key uint64, tags []string) []string {
 	if v, ok := c.m.Load(key); ok {
 		return v.([]string)
 	}
 	sort.Strings(tags)
-	if c.size.Load() >= dsmEdgeTagCacheMax {
+	// Reserve a slot atomically; give it back if we'd exceed the bound or the key is already present.
+	if c.size.Add(1) > dsmEdgeTagCacheMax {
+		c.size.Add(-1)
 		return tags
 	}
 	actual, loaded := c.m.LoadOrStore(key, tags)
-	if !loaded {
-		c.size.Add(1)
+	if loaded {
+		c.size.Add(-1)
 	}
 	return actual.([]string)
 }

--- a/contrib/confluentinc/confluent-kafka-go/kafkatrace/tracer.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafkatrace/tracer.go
@@ -9,13 +9,48 @@ import (
 	"context"
 	"math"
 	"net"
+	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/instrumentation"
 	"github.com/DataDog/dd-trace-go/v2/internal"
 )
+
+const dsmEdgeTagCacheMax = 1000
+
+// dsmEdgeTagCache caches edge-tag slices keyed by a composite string to avoid
+// per-message []string allocations. Entries are shared read-only after store;
+// callers must not mutate the returned slice.
+type dsmEdgeTagCache struct {
+	m    sync.Map
+	size atomic.Int32
+}
+
+func (c *dsmEdgeTagCache) get(key string) []string {
+	if v, ok := c.m.Load(key); ok {
+		return v.([]string)
+	}
+	return nil
+}
+
+func (c *dsmEdgeTagCache) getOrStore(key string, tags []string) []string {
+	if v, ok := c.m.Load(key); ok {
+		return v.([]string)
+	}
+	// Pre-sort: nodeHash sorts in place, so a shared cached slice must already be sorted to keep that a no-op.
+	sort.Strings(tags)
+	if c.size.Load() >= dsmEdgeTagCacheMax {
+		return tags
+	}
+	actual, loaded := c.m.LoadOrStore(key, tags)
+	if !loaded {
+		c.size.Add(1)
+	}
+	return actual.([]string)
+}
 
 type Tracer struct {
 	PrevSpan            *tracer.Span
@@ -34,6 +69,7 @@ type Tracer struct {
 	dsmEnabled          bool
 	ckgoVersion         CKGoVersion
 	librdKafkaVersion   int
+	dsmTagCache         dsmEdgeTagCache
 }
 
 func (tr *Tracer) DSMEnabled() bool {

--- a/internal/datastreams/hash_cache.go
+++ b/internal/datastreams/hash_cache.go
@@ -25,7 +25,6 @@ type hashCache struct {
 var maphashSeed = maphash.MakeSeed()
 
 // computeFingerprint returns a fast, allocation-free fingerprint for a cache lookup key.
-// Collision probability is ~2^-64 per distinct input pair — negligible for a telemetry cache.
 func computeFingerprint(edgeTags, processTags []string, containerTagsHash string, parentHash uint64) uint64 {
 	var h maphash.Hash
 	h.SetSeed(maphashSeed)
@@ -48,7 +47,6 @@ func (c *hashCache) get(service, env string, edgeTags, processTags []string, con
 		return v.(uint64)
 	}
 	hash := pathwayHash(nodeHash(service, env, edgeTags, processTags, containerTagsHash), parentHash)
-	// Bounded: high topic cardinality per service is not expected.
 	if c.size.Load() >= maxHashCacheSize {
 		return hash
 	}

--- a/internal/datastreams/hash_cache.go
+++ b/internal/datastreams/hash_cache.go
@@ -6,73 +6,58 @@
 package datastreams
 
 import (
-	"strings"
+	"encoding/binary"
+	"hash/maphash"
 	"sync"
+	"sync/atomic"
 )
 
 const (
 	maxHashCacheSize = 1000
 )
 
+// hashCache maps a fingerprint to a pathway hash. sync.Map gives lock-free reads on the per-message hot path; size bounds growth.
 type hashCache struct {
-	mu sync.RWMutex
-	m  map[string]uint64
+	m    sync.Map // map[uint64]uint64
+	size atomic.Int32
 }
 
-func getHashKey(edgeTags, processTags []string, containerTagsHash string, parentHash uint64) string {
-	var s strings.Builder
-	l := 0
-	for _, t := range edgeTags {
-		l += len(t)
-	}
-	for _, t := range processTags {
-		l += len(t)
-	}
-	l += len(containerTagsHash)
-	l += 8
-	s.Grow(l)
-	for _, t := range edgeTags {
-		s.WriteString(t)
-	}
-	for _, t := range processTags {
-		s.WriteString(t)
-	}
-	s.WriteString(containerTagsHash)
-	s.WriteByte(byte(parentHash))
-	s.WriteByte(byte(parentHash >> 8))
-	s.WriteByte(byte(parentHash >> 16))
-	s.WriteByte(byte(parentHash >> 24))
-	s.WriteByte(byte(parentHash >> 32))
-	s.WriteByte(byte(parentHash >> 40))
-	s.WriteByte(byte(parentHash >> 48))
-	s.WriteByte(byte(parentHash >> 56))
-	return s.String()
-}
+var maphashSeed = maphash.MakeSeed()
 
-func (c *hashCache) computeAndGet(key string, parentHash uint64, service, env string, edgeTags, processTags []string, containerTagsHash string) uint64 {
-	hash := pathwayHash(nodeHash(service, env, edgeTags, processTags, containerTagsHash), parentHash)
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if len(c.m) >= maxHashCacheSize {
-		// high cardinality of hashes shouldn't happen in practice, due to a limited amount of topics consumed
-		// by each service.
-		c.m = make(map[string]uint64)
+// computeFingerprint returns a fast, allocation-free fingerprint for a cache lookup key.
+// Collision probability is ~2^-64 per distinct input pair — negligible for a telemetry cache.
+func computeFingerprint(edgeTags, processTags []string, containerTagsHash string, parentHash uint64) uint64 {
+	var h maphash.Hash
+	h.SetSeed(maphashSeed)
+	for _, t := range edgeTags {
+		_, _ = h.WriteString(t)
 	}
-	c.m[key] = hash
-	return hash
+	for _, t := range processTags {
+		_, _ = h.WriteString(t)
+	}
+	_, _ = h.WriteString(containerTagsHash)
+	var b [8]byte
+	binary.LittleEndian.PutUint64(b[:], parentHash)
+	_, _ = h.Write(b[:])
+	return h.Sum64()
 }
 
 func (c *hashCache) get(service, env string, edgeTags, processTags []string, containerTagsHash string, parentHash uint64) uint64 {
-	key := getHashKey(edgeTags, processTags, containerTagsHash, parentHash)
-	c.mu.RLock()
-	if hash, ok := c.m[key]; ok {
-		c.mu.RUnlock()
+	fp := computeFingerprint(edgeTags, processTags, containerTagsHash, parentHash)
+	if v, ok := c.m.Load(fp); ok {
+		return v.(uint64)
+	}
+	hash := pathwayHash(nodeHash(service, env, edgeTags, processTags, containerTagsHash), parentHash)
+	// Bounded: high topic cardinality per service is not expected.
+	if c.size.Load() >= maxHashCacheSize {
 		return hash
 	}
-	c.mu.RUnlock()
-	return c.computeAndGet(key, parentHash, service, env, edgeTags, processTags, containerTagsHash)
+	if _, loaded := c.m.LoadOrStore(fp, hash); !loaded {
+		c.size.Add(1)
+	}
+	return hash
 }
 
 func newHashCache() *hashCache {
-	return &hashCache{m: make(map[string]uint64)}
+	return &hashCache{}
 }

--- a/internal/datastreams/hash_cache.go
+++ b/internal/datastreams/hash_cache.go
@@ -47,11 +47,13 @@ func (c *hashCache) get(service, env string, edgeTags, processTags []string, con
 		return v.(uint64)
 	}
 	hash := pathwayHash(nodeHash(service, env, edgeTags, processTags, containerTagsHash), parentHash)
-	if c.size.Load() >= maxHashCacheSize {
+	// Reserve a slot atomically; give it back if we'd exceed the bound or the key is already present.
+	if c.size.Add(1) > maxHashCacheSize {
+		c.size.Add(-1)
 		return hash
 	}
-	if _, loaded := c.m.LoadOrStore(fp, hash); !loaded {
-		c.size.Add(1)
+	if _, loaded := c.m.LoadOrStore(fp, hash); loaded {
+		c.size.Add(-1)
 	}
 	return hash
 }

--- a/internal/datastreams/hash_cache_test.go
+++ b/internal/datastreams/hash_cache_test.go
@@ -6,37 +6,109 @@
 package datastreams
 
 import (
-	"encoding/binary"
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
+// hashCacheKey returns a distinct, pre-sorted edge-tag set and parent hash for index i.
+func hashCacheKey(i int) (edgeTags []string, parentHash uint64) {
+	return []string{"direction:in", "topic:topic" + strconv.Itoa(i), "type:kafka"}, uint64(i)
+}
+
+func hashCacheExpected(i int) uint64 {
+	et, parentHash := hashCacheKey(i)
+	return pathwayHash(nodeHash("svc", "env", et, nil, ""), parentHash)
+}
+
 func TestHashCache(t *testing.T) {
 	cache := newHashCache()
 	assert.Equal(t, pathwayHash(nodeHash("service", "env", []string{"type:kafka"}, nil, ""), 1234), cache.get("service", "env", []string{"type:kafka"}, nil, "", 1234))
-	assert.Len(t, cache.m, 1)
+	assert.Equal(t, int32(1), cache.size.Load())
 	assert.Equal(t, pathwayHash(nodeHash("service", "env", []string{"type:kafka"}, nil, ""), 1234), cache.get("service", "env", []string{"type:kafka"}, nil, "", 1234))
-	assert.Len(t, cache.m, 1)
+	assert.Equal(t, int32(1), cache.size.Load())
 	assert.Equal(t, pathwayHash(nodeHash("service", "env", []string{"type:kafka2"}, nil, ""), 1234), cache.get("service", "env", []string{"type:kafka2"}, nil, "", 1234))
-	assert.Len(t, cache.m, 2)
+	assert.Equal(t, int32(2), cache.size.Load())
 
 	pTags := []string{"entrypoint.name:something", "entrypoint.type:executable"}
 	h1 := pathwayHash(nodeHash("service", "env", []string{"type:kafka"}, pTags, "container-hash"), 1234)
 	h2 := cache.get("service", "env", []string{"type:kafka"}, pTags, "container-hash", 1234)
 
 	assert.Equal(t, h1, h2)
-	assert.Len(t, cache.m, 3)
+	assert.Equal(t, int32(3), cache.size.Load())
 
 	h3 := cache.get("service", "env", []string{"type:kafka"}, pTags, "other-container-hash", 1234)
 	assert.NotEqual(t, h2, h3)
-	assert.Len(t, cache.m, 4)
+	assert.Equal(t, int32(4), cache.size.Load())
 }
 
-func TestGetHashKey(t *testing.T) {
+// TestHashCacheConcurrent drives concurrent misses then hits over distinct keys, checking each against a reference (run under -race).
+func TestHashCacheConcurrent(t *testing.T) {
+	const (
+		goroutines = 32
+		keys       = 200 // < maxHashCacheSize so nothing is dropped
+		iters      = 20
+	)
+	expected := make([]uint64, keys)
+	for i := range keys {
+		expected[i] = hashCacheExpected(i)
+	}
+
+	cache := newHashCache()
+	var wg sync.WaitGroup
+	errs := make(chan string, goroutines)
+	for range goroutines {
+		wg.Go(func() {
+			for range iters {
+				for i := range keys {
+					et, parentHash := hashCacheKey(i) // fresh slice per call
+					if got := cache.get("svc", "env", et, nil, "", parentHash); got != expected[i] {
+						select {
+						case errs <- strconv.Itoa(i) + ": got " + strconv.FormatUint(got, 10) + " want " + strconv.FormatUint(expected[i], 10):
+						default:
+						}
+						return
+					}
+				}
+			}
+		})
+	}
+	wg.Wait()
+	close(errs)
+	if msg, ok := <-errs; ok {
+		t.Fatal(msg)
+	}
+	assert.Equal(t, int32(keys), cache.size.Load())
+}
+
+// TestHashCacheEviction overflows past maxHashCacheSize and verifies the cache stays bounded and still correct.
+func TestHashCacheEviction(t *testing.T) {
+	cache := newHashCache()
+	n := maxHashCacheSize + 50
+	for i := range n {
+		et, parentHash := hashCacheKey(i)
+		assert.Equal(t, hashCacheExpected(i), cache.get("svc", "env", et, nil, "", parentHash))
+		assert.LessOrEqual(t, cache.size.Load(), int32(maxHashCacheSize))
+	}
+	// Uncached keys past the bound still return the correct value (recomputed).
+	et, parentHash := hashCacheKey(n)
+	assert.Equal(t, hashCacheExpected(n), cache.get("svc", "env", et, nil, "", parentHash))
+}
+
+func TestComputeFingerprint(t *testing.T) {
 	parentHash := uint64(87234)
-	key := getHashKey([]string{"type:kafka", "topic:topic1", "group:group1"}, []string{"entrypoint.name:something", "entrypoint.type:executable"}, "container-hash", parentHash)
-	hash := make([]byte, 8)
-	binary.LittleEndian.PutUint64(hash, parentHash)
-	assert.Equal(t, "type:kafkatopic:topic1group:group1entrypoint.name:somethingentrypoint.type:executablecontainer-hash"+string(hash), key)
+	edgeTags := []string{"type:kafka", "topic:topic1", "group:group1"}
+	pTags := []string{"entrypoint.name:something", "entrypoint.type:executable"}
+
+	fp := computeFingerprint(edgeTags, pTags, "container-hash", parentHash)
+	// Deterministic for identical inputs within a process.
+	assert.Equal(t, fp, computeFingerprint(edgeTags, pTags, "container-hash", parentHash))
+
+	// Each component contributes to the fingerprint.
+	assert.NotEqual(t, fp, computeFingerprint([]string{"type:kafka", "topic:topic2", "group:group1"}, pTags, "container-hash", parentHash))
+	assert.NotEqual(t, fp, computeFingerprint(edgeTags, nil, "container-hash", parentHash))
+	assert.NotEqual(t, fp, computeFingerprint(edgeTags, pTags, "other-container-hash", parentHash))
+	assert.NotEqual(t, fp, computeFingerprint(edgeTags, pTags, "container-hash", parentHash+1))
 }

--- a/internal/datastreams/pathway.go
+++ b/internal/datastreams/pathway.go
@@ -26,7 +26,6 @@ func isWellFormedEdgeTag(t string) bool {
 	return false
 }
 
-// nodeHash sorts edgeTags in place; callers sharing a slice across goroutines must pre-sort it.
 func nodeHash(service, env string, edgeTags, processTags []string, containerTagsHash string) uint64 {
 	h := fnv.New64()
 	sort.Strings(edgeTags)

--- a/internal/datastreams/pathway.go
+++ b/internal/datastreams/pathway.go
@@ -26,6 +26,7 @@ func isWellFormedEdgeTag(t string) bool {
 	return false
 }
 
+// nodeHash sorts edgeTags in place; callers sharing a slice across goroutines must pre-sort it.
 func nodeHash(service, env string, edgeTags, processTags []string, containerTagsHash string) uint64 {
 	h := fnv.New64()
 	sort.Strings(edgeTags)

--- a/internal/processtags/processtags.go
+++ b/internal/processtags/processtags.go
@@ -49,10 +49,6 @@ type ProcessTags struct {
 	mu sync.RWMutex
 	// +checklocks:mu
 	tags map[string]string
-	// +checklocks:mu
-	str string
-	// +checklocks:mu
-	slice []string
 
 	sliceAtomic atomic.Pointer[[]string]
 	strAtomic   atomic.Pointer[string]
@@ -119,8 +115,6 @@ func (p *ProcessTags) rebuild() {
 		tagsSlice = append(tagsSlice, keyVal)
 	}
 	str := b.String()
-	p.slice = tagsSlice
-	p.str = str
 	p.sliceAtomic.Store(&tagsSlice)
 	p.strAtomic.Store(&str)
 }

--- a/internal/processtags/processtags.go
+++ b/internal/processtags/processtags.go
@@ -54,7 +54,6 @@ type ProcessTags struct {
 	// +checklocks:mu
 	slice []string
 
-	// lock-free read cache; updated after every write while mu is held
 	sliceAtomic atomic.Pointer[[]string]
 	strAtomic   atomic.Pointer[string]
 }
@@ -122,7 +121,6 @@ func (p *ProcessTags) rebuild() {
 	str := b.String()
 	p.slice = tagsSlice
 	p.str = str
-	// Publish fresh snapshots, not &p.slice/&p.str: the next rebuild overwrites those fields and would race lock-free readers.
 	p.sliceAtomic.Store(&tagsSlice)
 	p.strAtomic.Store(&str)
 }

--- a/internal/processtags/processtags.go
+++ b/internal/processtags/processtags.go
@@ -53,6 +53,10 @@ type ProcessTags struct {
 	str string
 	// +checklocks:mu
 	slice []string
+
+	// lock-free read cache; updated after every write while mu is held
+	sliceAtomic atomic.Pointer[[]string]
+	strAtomic   atomic.Pointer[string]
 }
 
 // String returns the string representation of the process tags.
@@ -60,9 +64,10 @@ func (p *ProcessTags) String() string {
 	if p == nil {
 		return ""
 	}
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	return p.str
+	if s := p.strAtomic.Load(); s != nil {
+		return *s
+	}
+	return ""
 }
 
 // Slice returns the string slice representation of the process tags.
@@ -70,9 +75,10 @@ func (p *ProcessTags) Slice() []string {
 	if p == nil {
 		return nil
 	}
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	return p.slice
+	if s := p.sliceAtomic.Load(); s != nil {
+		return *s
+	}
+	return nil
 }
 
 func (p *ProcessTags) merge(newTags map[string]string) {
@@ -113,8 +119,12 @@ func (p *ProcessTags) rebuild() {
 		b.WriteString(keyVal)
 		tagsSlice = append(tagsSlice, keyVal)
 	}
+	str := b.String()
 	p.slice = tagsSlice
-	p.str = b.String()
+	p.str = str
+	// Publish fresh snapshots, not &p.slice/&p.str: the next rebuild overwrites those fields and would race lock-free readers.
+	p.sliceAtomic.Store(&tagsSlice)
+	p.strAtomic.Store(&str)
 }
 
 // Reload initializes the configuration and process tags collection. This is useful for tests.

--- a/internal/processtags/processtags_test.go
+++ b/internal/processtags/processtags_test.go
@@ -9,11 +9,57 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// TestProcessTagsConcurrentReadWrite races lock-free String()/Slice() readers against rebuild() writers (run under -race).
+func TestProcessTagsConcurrentReadWrite(t *testing.T) {
+	t.Cleanup(Reload)
+	Reload()
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	for w := range 4 {
+		wg.Go(func() {
+			for i := 0; ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				SetServiceNameTag("svc-"+strconv.Itoa(w)+"-"+strconv.Itoa(i), i%2 == 0)
+			}
+		})
+	}
+
+	for range 8 {
+		wg.Go(func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				tags := GlobalTags()
+				_ = len(tags.String())
+				for _, s := range tags.Slice() { // dereference header + elements
+					_ = len(s)
+				}
+			}
+		})
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
 
 func TestSetServiceNameTag(t *testing.T) {
 	t.Run("auto-assigned sets svc.auto", func(t *testing.T) {


### PR DESCRIPTION
## Problem

The DSM checkpoint runs on every Kafka message. Under high throughput it adds measurable per-message overhead (~5%). This PR reduces that by ~20% (5% overhead to 4% overhead)

## What changed

- **Hash cache**: key it by a zero-alloc `maphash` fingerprint instead of a built string, and store it in a `sync.Map` so warm lookups are lock-free. Bounded by `maxHashCacheSize`.
- **processtags**: serve `String()`/`Slice()` from an atomic snapshot, so the per-message readers take no lock.
- **confluent-kafka-go**: cache the per-topic edge-tag slice to avoid rebuilding and allocating it on every message.

## Results

End-to-end Kafka throughput benchmark (ran locally, not in a very rigorous environment):

| | Throughput | ns/msg | vs baseline |
|---|---|---|---|
| Baseline (stock main) | 4.00M msg/s | 249.7 ns | — |
| Optimized (full changeset) | 4.75M msg/s | 210.4 ns | **+18.7%** |

With an application-level tag cache on top (recommended for manual instrumentation that rebuilds tag slices per message):

| | Throughput | ns/msg | vs baseline |
|---|---|---|---|
| Baseline + app tag cache | 4.30M msg/s | 232.4 ns | +7.4% |
| Optimized + app tag cache | 5.18M msg/s | 193.0 ns | **+29.4%** |

## Notes

- The edge-tag slice cache is scoped to `confluent-kafka-go` for now
- Race-safety: cached edge-tag slices are shared and `nodeHash` sorts edge tags in place, so cached slices are pre-sorted to keep that sort a no-op
