### PR TITLE
fix(ddtrace/tracer): skip TestPartialFlushSpanLockOrderingCycle

### DIFF
--- a/ddtrace/tracer/spancontext_deadlock_test.go
+++ b/ddtrace/tracer/spancontext_deadlock_test.go
@@ -44,6 +44,7 @@ import (
 // Under the fixed code, s.mu is released before fSpan.mu is acquired, so neither
 // direction is ever recorded and the test passes cleanly.
 func TestPartialFlushSpanLockOrderingCycle(t *testing.T) {
+	t.Skip("too flaky; skipped while investigating")
 	t.Setenv("DD_TRACE_PARTIAL_FLUSH_ENABLED", "true")
 	t.Setenv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", "2")
 


### PR DESCRIPTION
### What does this PR do?

Skips `TestPartialFlushSpanLockOrderingCycle`.

### Motivation

Too flaky: https://github.com/DataDog/dd-trace-go/actions/runs/28007799053/job/82893651296?pr=4916#step:6:373

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
