### PR TITLE
chore: align Datadog Code Coverage uploads with Codecov (contrib, gotip, smoke-tests, core)

### DIFF
--- a/.github/workflows/gotip-testing.yml
+++ b/.github/workflows/gotip-testing.yml
@@ -145,7 +145,5 @@ jobs:
         uses: DataDog/coverage-upload-github-action@d9548b1c3c4ab639d5d3ab29a1508af188975f77
         with:
           api_key: ${{ steps.dd-sts.outputs.api_key }}
-          files: coverage.txt coverage-noshuffle.txt
+          files: coverage.txt coverage-noshuffle.txt internal/exectracetest/coverage.txt
           format: go-coverprofile
-          flags: core
-          extra-args: --carryforward-flags core,contrib

--- a/.github/workflows/gotip-testing.yml
+++ b/.github/workflows/gotip-testing.yml
@@ -138,3 +138,14 @@ jobs:
         uses: ./.github/actions/codecov-upload
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload Coverage to Datadog
+        if: always() && steps.restore.outcome == 'success'
+        continue-on-error: true
+        uses: DataDog/coverage-upload-github-action@d9548b1c3c4ab639d5d3ab29a1508af188975f77
+        with:
+          api_key: ${{ steps.dd-sts.outputs.api_key }}
+          files: coverage.txt coverage-noshuffle.txt
+          format: go-coverprofile
+          flags: core
+          extra-args: --carryforward-flags core,contrib

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -218,8 +218,6 @@ jobs:
           api_key: ${{ steps.dd-sts.outputs.api_key }}
           files: coverage-contrib-merged.txt
           format: go-coverprofile
-          flags: contrib
-          extra-args: --carryforward-flags core,contrib
 
   smoke-test-tracer:
     name: Test dd-trace-go

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -202,6 +202,25 @@ jobs:
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Merge contrib coverage files
+        if: always() && steps.restore.outcome == 'success'
+        run: |
+          echo "mode: atomic" > coverage-contrib-merged.txt
+          find . \( -path "*/contrib/*" -o -path "*/instrumentation/*" \) \
+            -name "coverage-*.txt" \
+            | xargs grep -h -v "^mode:" >> coverage-contrib-merged.txt 2>/dev/null || true
+
+      - name: Upload Coverage to Datadog
+        if: always() && steps.restore.outcome == 'success'
+        continue-on-error: true
+        uses: DataDog/coverage-upload-github-action@d9548b1c3c4ab639d5d3ab29a1508af188975f77
+        with:
+          api_key: ${{ steps.dd-sts.outputs.api_key }}
+          files: coverage-contrib-merged.txt
+          format: go-coverprofile
+          flags: contrib
+          extra-args: --carryforward-flags core,contrib
+
   smoke-test-tracer:
     name: Test dd-trace-go
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -207,8 +207,8 @@ jobs:
         run: |
           echo "mode: atomic" > coverage-contrib-merged.txt
           find . \( -path "*/contrib/*" -o -path "*/instrumentation/*" \) \
-            -name "coverage-*.txt" \
-            | xargs grep -h -v "^mode:" >> coverage-contrib-merged.txt 2>/dev/null || true
+            -name "coverage-*.txt" -print0 \
+            | xargs -0 grep -h -v "^mode:" >> coverage-contrib-merged.txt 2>/dev/null || true
 
       - name: Upload Coverage to Datadog
         if: always() && steps.restore.outcome == 'success'

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -272,8 +272,8 @@ jobs:
         run: |
           echo "mode: atomic" > coverage-contrib-merged.txt
           find . \( -path "*/contrib/*" -o -path "*/instrumentation/*" \) \
-            -name "coverage-*.txt" \
-            | xargs grep -h -v "^mode:" >> coverage-contrib-merged.txt 2>/dev/null || true
+            -name "coverage-*.txt" -print0 \
+            | xargs -0 grep -h -v "^mode:" >> coverage-contrib-merged.txt 2>/dev/null || true
 
       - name: Upload Coverage to Datadog
         if: always()

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -267,15 +267,24 @@ jobs:
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Merge contrib coverage files
+        if: always()
+        run: |
+          echo "mode: atomic" > coverage-contrib-merged.txt
+          find . \( -path "*/contrib/*" -o -path "*/instrumentation/*" \) \
+            -name "coverage-*.txt" \
+            | xargs grep -h -v "^mode:" >> coverage-contrib-merged.txt 2>/dev/null || true
+
       - name: Upload Coverage to Datadog
         if: always()
         continue-on-error: true
         uses: DataDog/coverage-upload-github-action@d9548b1c3c4ab639d5d3ab29a1508af188975f77
         with:
           api_key: ${{ steps.dd-sts.outputs.api_key }}
-          files: coverage.txt
+          files: coverage-contrib-merged.txt
           format: go-coverprofile
           flags: contrib
+          extra-args: --carryforward-flags core,contrib
 
       # Check for changes in the supported_configurations.json file
       - name: Supported Configurations Diff Check
@@ -455,9 +464,10 @@ jobs:
         uses: DataDog/coverage-upload-github-action@d9548b1c3c4ab639d5d3ab29a1508af188975f77
         with:
           api_key: ${{ steps.dd-sts.outputs.api_key }}
-          files: coverage.txt
+          files: coverage.txt coverage-noshuffle.txt
           format: go-coverprofile
           flags: core
+          extra-args: --carryforward-flags core,contrib
 
       # Check for changes in the supported_configurations.json file
       - name: Supported Configurations Diff Check

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -283,8 +283,6 @@ jobs:
           api_key: ${{ steps.dd-sts.outputs.api_key }}
           files: coverage-contrib-merged.txt
           format: go-coverprofile
-          flags: contrib
-          extra-args: --carryforward-flags core,contrib
 
       # Check for changes in the supported_configurations.json file
       - name: Supported Configurations Diff Check
@@ -464,10 +462,8 @@ jobs:
         uses: DataDog/coverage-upload-github-action@d9548b1c3c4ab639d5d3ab29a1508af188975f77
         with:
           api_key: ${{ steps.dd-sts.outputs.api_key }}
-          files: coverage.txt coverage-noshuffle.txt
+          files: coverage.txt coverage-noshuffle.txt internal/exectracetest/coverage.txt
           format: go-coverprofile
-          flags: core
-          extra-args: --carryforward-flags core,contrib
 
       # Check for changes in the supported_configurations.json file
       - name: Supported Configurations Diff Check

--- a/code-coverage.datadog.yml
+++ b/code-coverage.datadog.yml
@@ -1,7 +1,2 @@
 schema-version: v1
-carryforward: true
-flags:
-  core:
-    carryforward: true
-  contrib:
-    carryforward: true
+carryforward: false


### PR DESCRIPTION
Ensures **Datadog Code Coverage receives the same set of coverage reports as Codecov for every CI pipeline run**, and fixes the gaps/inconsistencies between the two.

### Changes
- **gotip** (`gotip-testing.yml`) and **smoke `go-get-u`** (`smoke-tests.yml`): add the missing Datadog coverage upload steps so these flows report coverage to DD just like they already do to Codecov.
- **Contrib**: merge per-module `coverage-*.txt` (contrib + instrumentation) into a single profile before the DD upload (`unit-integration-tests.yml`, `smoke-tests.yml`).
- **Core**: upload `coverage.txt`, `coverage-noshuffle.txt`, and `internal/exectracetest/coverage.txt` — the last is a separate module's profile that Codecov already auto-discovers — for the core jobs (`unit-integration-tests.yml`, `gotip-testing.yml`).
- **No flags / no carryforward** — match Codecov's unflagged uploads and rely on Datadog's server-side per-commit aggregation:
  - Remove `flags: core` / `flags: contrib` from the DD uploads.
  - Remove `extra-args: --carryforward-flags core,contrib`. `datadog-ci coverage upload` has **no such option** (clipanion rejects it with `Unsupported option name`, exit 1); combined with `continue-on-error: true`, the affected DD uploads were **silently uploading nothing**.
  - Set `carryforward: false` in `code-coverage.datadog.yml` and drop the now-unused `core`/`contrib` flag block.
- **shellcheck**: use `-print0 | xargs -0` in the contrib coverage merge (SC2038).

### Why no carryforward
Datadog aggregates all coverage reports for the same commit on the backend, so there is no need to carry forward un-re-tested flags at upload time (unlike Codecov's `carryforward` YAML setting). Carryforward is a Codecov-only concept that does not map to `datadog-ci`.

Companion to #4901 (Codecov removal); ideally merged first or together.
