### PR TITLE
fix(internal/orchestrion): decouple the GLS reclaim signal from the recyclable span

### DIFF
--- a/ddtrace/tracer/context.go
+++ b/ddtrace/tracer/context.go
@@ -34,15 +34,18 @@ func ContextWithSpan(ctx context.Context, s *Span) context.Context {
 	// ddtrace/tracer/orchestrion.yml extend the span's GLS lifecycle:
 	//   - "Span GLS fields": adds two woven fields to Span — __dd_glsPop
 	//     (GLSPopperCell, an atomic pointer to the goroutine-scoped popper) and
-	//     __dd_glsReclaimable (atomic.Bool, set on finish so cross-goroutine GLS
-	//     entries can be lazily reclaimed on the next push).
+	//     __dd_glsDone (GLSDoneCell, an atomic pointer to a per-activation
+	//     liveness cell that is set on finish so cross-goroutine GLS entries can
+	//     be lazily reclaimed on the next push, independent of span pool reuse).
 	//   - "Span ContextWithSpan GLS push": prepends before this line:
-	//       orchestrion.GLSActivate(nil, ActiveSpanKey, s, &s.__dd_glsPop)
-	//     which pushes s onto the goroutine-local stack and records a goroutine-
-	//     scoped popper in __dd_glsPop (first push wins; no-op when disabled).
+	//       orchestrion.GLSActivate(nil, ActiveSpanKey, s, &s.__dd_glsPop, &s.__dd_glsDone)
+	//     which pushes s onto the goroutine-local stack, records a goroutine-
+	//     scoped popper in __dd_glsPop (first push wins), and allocates the
+	//     liveness cell in __dd_glsDone (no-op when disabled).
 	//   - "Span Finish GLS deactivate": prepends at the top of Span.Finish:
-	//       orchestrion.GLSDeactivate(&s.__dd_glsReclaimable, &s.__dd_glsPop)
-	//     which pops the GLS entry exactly once, only on the goroutine that pushed.
+	//       orchestrion.GLSDeactivate(&s.__dd_glsDone, &s.__dd_glsPop)
+	//     which marks the liveness cell done and pops the GLS entry exactly once,
+	//     only on the goroutine that pushed.
 	// SpanFromContext is extended analogously ("Span SpanFromContext GLS read").
 	// Without orchestrion there is no GLS; this is a plain context.WithValue.
 	newCtx := context.WithValue(ctx, internal.ActiveSpanKey, s)

--- a/ddtrace/tracer/orchestrion.yml
+++ b/ddtrace/tracer/orchestrion.yml
@@ -150,9 +150,11 @@ aspects:
   # The actual logic lives in internal/orchestrion (GLSActivate / GLSDeactivate /
   # WrapContext) so the injected templates stay thin and unit-testable.
 
-  # Add the GLS bookkeeping fields to Span, and expose GLSReclaimable so
-  # internal/orchestrion.contextStack.Push can drop finished entries that a
-  # cross-goroutine finish left behind (its popper is a no-op off-goroutine).
+  # Add the GLS bookkeeping fields to Span. __dd_glsPop (GLSPopperCell) holds
+  # the goroutine-scoped popper captured at push time; __dd_glsDone (GLSDoneCell)
+  # holds a heap-allocated liveness cell that outlives span pool recycling: the
+  # stack entry captures its own reference to this cell so GLSReset (on pool
+  # reuse) can nil out the span's pointer without affecting the cell's value.
   - id: Span GLS fields
     tracer-internal: true
     join-point:
@@ -162,15 +164,8 @@ aspects:
           name: __dd_glsPop
           type: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.GLSPopperCell
       - add-struct-field:
-          name: __dd_glsReclaimable
-          type: sync/atomic.Bool
-      - inject-declarations:
-          template: |-
-            // GLSReclaimable reports whether this span is finished and may be
-            // dropped from an orchestrion GLS stack. Injected by orchestrion.
-            func (s *Span) GLSReclaimable() bool {
-              return s != nil && s.__dd_glsReclaimable.Load()
-            }
+          name: __dd_glsDone
+          type: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.GLSDoneCell
 
   # On ContextWithSpan: push the span onto this goroutine's GLS stack and capture
   # a goroutine-scoped popper (first push wins, matching the in-source design).
@@ -193,7 +188,7 @@ aspects:
           template: |-
             {{- $s := .Function.Argument 1 -}}
             if {{ $s }} != nil {
-              orchestrion.GLSActivate(nil, internal.ActiveSpanKey, {{ $s }}, &{{ $s }}.__dd_glsPop)
+              orchestrion.GLSActivate(nil, internal.ActiveSpanKey, {{ $s }}, &{{ $s }}.__dd_glsPop, &{{ $s }}.__dd_glsDone)
             }
 
   # On SpanFromContext: wrap ctx so the subsequent ctx.Value also consults the
@@ -216,15 +211,15 @@ aspects:
               {{ $ctx }} = orchestrion.WrapContext({{ $ctx }})
             }
 
-  # On Finish: deactivate the span on the GLS (mark reclaimable + run the popper
-  # once). Runs at the TOP of Finish (not deferred) so the pop happens before
-  # s.finish() submits the chunk: with span pooling enabled, the tracer worker
-  # can clear()/recycle the span as soon as it is submitted, and clear resets
+  # On Finish: set the done cell (so cross-goroutine finishes are still cleaned
+  # up by contextStack.Push on the next push) and run the goroutine-scoped
+  # popper exactly once. Runs at the TOP of Finish (not deferred) so the pop
+  # happens before s.finish() submits the chunk: the tracer worker can
+  # clear()/recycle the span as soon as it is submitted, and clear resets
   # __dd_glsPop. Deactivating first orders the pop ahead of any clear (the
   # channel send in finish establishes happens-before), so clear can never nil
   # the popper out from under Finish and leave a stale active span on the GLS.
-  # GLSDeactivate groups the flag set and the once-only pop and is idempotent on
-  # a double finish. See orchestrion#782.
+  # GLSDeactivate is idempotent on a double finish. See orchestrion#782.
   - id: Span Finish GLS deactivate
     tracer-internal: true
     join-point:
@@ -239,11 +234,13 @@ aspects:
           template: |-
             {{- $s := .Function.Receiver -}}
             if {{ $s }} != nil {
-              orchestrion.GLSDeactivate(&{{ $s }}.__dd_glsReclaimable, &{{ $s }}.__dd_glsPop)
+              orchestrion.GLSDeactivate(&{{ $s }}.__dd_glsDone, &{{ $s }}.__dd_glsPop)
             }
 
-  # On clear (span pool recycle): reset the GLS bookkeeping so a reused, live
-  # span is never wrongly treated as reclaimable or carrying a stale popper.
+  # On clear (span pool recycle): clear the done cell so a reused span starts
+  # with a nil cell pointer (its next GLSActivate allocates a fresh one).
+  # The contextStack entry still holds its own copy of the original cell pointer
+  # and can read done.Load() == true; this is what prevents the ABA hazard.
   - id: Span clear GLS reset
     tracer-internal: true
     join-point:
@@ -257,4 +254,4 @@ aspects:
             orchestrion: github.com/DataDog/dd-trace-go/v2/internal/orchestrion
           template: |-
             {{- $s := .Function.Receiver -}}
-            orchestrion.GLSReset(&{{ $s }}.__dd_glsReclaimable, &{{ $s }}.__dd_glsPop)
+            orchestrion.GLSReset(&{{ $s }}.__dd_glsDone, &{{ $s }}.__dd_glsPop)

--- a/internal/orchestrion/_integration/gls/span_gls_test.go
+++ b/internal/orchestrion/_integration/gls/span_gls_test.go
@@ -21,9 +21,9 @@ import (
 // These tests are the regression facility for orchestrion#782. The GLS
 // over-pop and cross-goroutine reclaim fix is woven into ddtrace/tracer at
 // build time by orchestrion (see ddtrace/tracer/orchestrion.yml: the
-// `tracer-internal: true` aspects that add a finished flag, a GLSReclaimable
-// method, and an identity-match pop into Span.Finish). The tracer SOURCE has
-// no GLS pop/reclaim code, so a plain `go build`/`go test` cannot exercise it
+// `tracer-internal: true` aspects that add a per-activation liveness cell
+// (__dd_glsDone) and an identity-match pop into Span.Finish). The tracer SOURCE
+// has no GLS pop/reclaim code, so a plain `go build`/`go test` cannot exercise it
 // — and, crucially, if the injection ever silently stops applying (a renamed
 // Span.Finish, a changed join-point selector, a dropped `tracer-internal`
 // flag, an orchestrion schema change), the build still succeeds while the fix

--- a/internal/orchestrion/context.go
+++ b/internal/orchestrion/context.go
@@ -72,19 +72,19 @@ type GLSPopperCell struct {
 	ptr atomic.Pointer[GLSPopper]
 }
 
-// GLSDoneCell holds the heap-allocated liveness cell for a GLS activation.
-// It is the type orchestrion injects as the __dd_glsDone field on Span (via
-// add-struct-field, which requires a named type).
+// GLSDoneCell holds the heap-allocated liveness cell for a span's current GLS
+// lifecycle. It is the type orchestrion injects as the __dd_glsDone field on
+// Span (via add-struct-field, which requires a named type).
 //
-// Each activation (each ContextWithSpan call) allocates a fresh *atomic.Bool
-// cell, stores it here (atomically), and also passes it to contextStack.Push
-// as the done pointer for that stack entry. When the span finishes, the cell
-// is set to true via GLSDeactivate. When the span is recycled by the pool,
-// GLSReset clears the ptr — but the contextStack entry retains its own
-// reference to the same cell, so the cell's true value outlives the span's
-// current lifecycle. The next Push on that goroutine drains the stale entry
-// by reading the still-true cell. A reused span starts with ptr == nil and
-// gets a fresh cell on its next activation: no ABA.
+// One *atomic.Bool cell is allocated on a span's first activation and shared by
+// every subsequent activation of that span (GLSActivate reuses it), so all of
+// the span's contextStack entries observe a single liveness signal. Each entry
+// keeps its own pointer to the cell. When the span finishes, GLSDeactivate sets
+// the cell to true, marking every entry drain-eligible. When the span is
+// recycled by the pool, GLSReset clears this ptr — but the contextStack entries
+// retain their own references to the now-true cell, so it outlives the span's
+// current lifecycle and the next Push drains them. The reused span starts with
+// ptr == nil and allocates a fresh cell on its next activation: no ABA.
 //
 // The zero value is ready to use.
 type GLSDoneCell struct {
@@ -100,12 +100,14 @@ type GLSDoneCell struct {
 // a no-op on any other goroutine, so a cross-goroutine finish can never corrupt
 // an unrelated goroutine's stack.
 //
-// done, when non-nil, receives a freshly allocated liveness cell (a
-// *atomic.Bool) for this specific activation. The same pointer is passed to
-// contextStack.Push, so the stack entry is tied to this cell — not to the span
-// itself. If done already holds a cell from a previous activation (same span
-// pushed again without an intervening Finish), that old cell is atomically
-// swapped out and marked done, superseding the previous stack entry.
+// done, when non-nil, holds the span's liveness cell (a *atomic.Bool). The
+// first activation allocates it; later activations of the same span reuse it,
+// so every stack entry for the span shares one liveness signal and they are all
+// marked done together at Finish. The cell pointer is passed to
+// contextStack.Push, tying the entry to the cell — not to the span itself —
+// which is what makes reclaim safe across span-pool reuse. A live span
+// re-activated on another goroutine is never marked done here (that would drain
+// a still-live entry); see the reuse comment in the body.
 //
 // When done is nil (e.g. dyngo operations that never cross goroutine boundaries)
 // the stack entry carries no done cell and is never drained by Push. When
@@ -125,23 +127,35 @@ func GLSActivate(ctxp *context.Context, key, val any, pop *GLSPopperCell, done *
 	}
 	var cell *atomic.Bool
 	if done != nil {
-		existing := done.ptr.Load()
-		if existing != nil && existing.Load() {
-			// The span was already finished (done cell is true) before this push.
-			// This happens in the cross-goroutine pattern where the owner finishes
-			// a span on G1 and then the worker on G2 calls ContextWithSpan with
-			// the same (already-finished) span. Reuse the existing cell so the
-			// stack entry is immediately drain-eligible on the next Push — without
-			// this, a fresh false cell would be allocated and never set to true,
-			// leaking one entry per record.
+		if existing := done.ptr.Load(); existing != nil {
+			// Reuse this span's existing liveness cell — one cell per span
+			// lifecycle, shared by every activation. All of the span's stack
+			// entries therefore observe a single liveness signal and become
+			// drain-eligible together when Finish marks the cell.
+			//
+			// We must NOT allocate a fresh cell and mark the old one done here:
+			// when a still-live span is propagated to another goroutine (the
+			// owner ran ContextWithSpan, then a worker re-activates it before
+			// Finish), marking the previous cell done would make a STILL-LIVE
+			// entry drain-eligible. The owner's next Push would drop it, so after
+			// a child span pops, the GLS fallback would no longer restore the
+			// (unfinished) parent — corrupting cross-goroutine live propagation.
+			// See orchestrion#782 review.
+			//
+			// A finished span recycled by the span pool has its cell cleared by
+			// GLSReset (ptr == nil), so it allocates a fresh cell below on its
+			// next activation: no ABA. A cell that is already true here (Finish
+			// ran before this activation, the cross-goroutine korECM pattern) is
+			// likewise reused, making the entry immediately drain-eligible.
 			cell = existing
 		} else {
-			// Fresh activation or span not yet finished: allocate a new cell.
-			// If the span was previously activated (same done field, non-nil),
-			// mark the old cell done to drain the superseded stack entry.
+			// First activation of this lifecycle: allocate the cell. CompareAndSwap
+			// so concurrent first-activations of the same span converge on one
+			// cell rather than each pushing an entry with its own (one of which
+			// Finish would then never mark, leaking it).
 			cell = new(atomic.Bool)
-			if old := done.ptr.Swap(cell); old != nil {
-				old.Store(true)
+			if !done.ptr.CompareAndSwap(nil, cell) {
+				cell = done.ptr.Load()
 			}
 		}
 	}

--- a/internal/orchestrion/context.go
+++ b/internal/orchestrion/context.go
@@ -38,7 +38,7 @@ func CtxWithValue(parent context.Context, key, val any) context.Context {
 		return context.WithValue(parent, key, val)
 	}
 
-	getDDContextStack().Push(key, val)
+	getDDContextStack().Push(key, val, nil) // nil = non-reclaimable (no lifecycle cell)
 	return context.WithValue(WrapContext(parent), key, val)
 }
 
@@ -72,6 +72,25 @@ type GLSPopperCell struct {
 	ptr atomic.Pointer[GLSPopper]
 }
 
+// GLSDoneCell holds the heap-allocated liveness cell for a GLS activation.
+// It is the type orchestrion injects as the __dd_glsDone field on Span (via
+// add-struct-field, which requires a named type).
+//
+// Each activation (each ContextWithSpan call) allocates a fresh *atomic.Bool
+// cell, stores it here (atomically), and also passes it to contextStack.Push
+// as the done pointer for that stack entry. When the span finishes, the cell
+// is set to true via GLSDeactivate. When the span is recycled by the pool,
+// GLSReset clears the ptr — but the contextStack entry retains its own
+// reference to the same cell, so the cell's true value outlives the span's
+// current lifecycle. The next Push on that goroutine drains the stale entry
+// by reading the still-true cell. A reused span starts with ptr == nil and
+// gets a fresh cell on its next activation: no ABA.
+//
+// The zero value is ready to use.
+type GLSDoneCell struct {
+	ptr atomic.Pointer[atomic.Bool]
+}
+
 // GLSActivate is woven into span/operation activation (the tracer's
 // ContextWithSpan and dyngo's RegisterOperation). It pushes val onto the current
 // goroutine's GLS stack under key and records a goroutine-scoped popper into
@@ -81,21 +100,52 @@ type GLSPopperCell struct {
 // a no-op on any other goroutine, so a cross-goroutine finish can never corrupt
 // an unrelated goroutine's stack.
 //
-// When ctxp is non-nil the parent context is wrapped (via WrapContext) so the
-// returned context is also GLS-aware, matching the former in-source CtxWithValue.
-// Everything is a no-op when orchestrion is disabled.
+// done, when non-nil, receives a freshly allocated liveness cell (a
+// *atomic.Bool) for this specific activation. The same pointer is passed to
+// contextStack.Push, so the stack entry is tied to this cell — not to the span
+// itself. If done already holds a cell from a previous activation (same span
+// pushed again without an intervening Finish), that old cell is atomically
+// swapped out and marked done, superseding the previous stack entry.
 //
-// Grouping the wrap, push and popper-capture here keeps the injected templates a
-// single call and the logic unit-testable in plain go test. The companions are
-// GLSDeactivate (finish) and GLSReset (span-pool reuse).
-func GLSActivate(ctxp *context.Context, key, val any, pop *GLSPopperCell) {
+// When done is nil (e.g. dyngo operations that never cross goroutine boundaries)
+// the stack entry carries no done cell and is never drained by Push. When
+// ctxp is non-nil the parent context is wrapped (via WrapContext) so the
+// returned context is also GLS-aware. Everything is a no-op when orchestrion
+// is disabled.
+//
+// Grouping the wrap, push, popper-capture, and cell allocation here keeps the
+// injected templates a single call and the logic unit-testable in plain go test.
+// The companions are GLSDeactivate (finish) and GLSReset (span-pool reuse).
+func GLSActivate(ctxp *context.Context, key, val any, pop *GLSPopperCell, done *GLSDoneCell) {
 	if !Enabled() {
 		return
 	}
 	if ctxp != nil {
 		*ctxp = WrapContext(*ctxp)
 	}
-	getDDContextStack().Push(key, val)
+	var cell *atomic.Bool
+	if done != nil {
+		existing := done.ptr.Load()
+		if existing != nil && existing.Load() {
+			// The span was already finished (done cell is true) before this push.
+			// This happens in the cross-goroutine pattern where the owner finishes
+			// a span on G1 and then the worker on G2 calls ContextWithSpan with
+			// the same (already-finished) span. Reuse the existing cell so the
+			// stack entry is immediately drain-eligible on the next Push — without
+			// this, a fresh false cell would be allocated and never set to true,
+			// leaking one entry per record.
+			cell = existing
+		} else {
+			// Fresh activation or span not yet finished: allocate a new cell.
+			// If the span was previously activated (same done field, non-nil),
+			// mark the old cell done to drain the superseded stack entry.
+			cell = new(atomic.Bool)
+			if old := done.ptr.Swap(cell); old != nil {
+				old.Store(true)
+			}
+		}
+	}
+	getDDContextStack().Push(key, val, cell)
 	if pop != nil && pop.ptr.Load() == nil {
 		// Capture the popper only on the first activation (first-wins) so
 		// re-activating the same span/operation does not overwrite the popper
@@ -109,16 +159,38 @@ func GLSActivate(ctxp *context.Context, key, val any, pop *GLSPopperCell) {
 	}
 }
 
-// GLSDeactivate releases a span's GLS entry on finish. It marks the span
-// reclaimable (so a cross-goroutine finish, whose popper is a no-op here, is
-// still cleaned up by contextStack.Push on its next push) and invokes the
-// captured popper exactly once, clearing it so a repeated finish does not pop
-// again. reclaimable and pop are the fields orchestrion injects onto the span;
-// passing them by pointer lets injected span-finish advice deactivate in one
-// call.
-func GLSDeactivate(reclaimable *atomic.Bool, pop *GLSPopperCell) {
-	if reclaimable != nil {
-		reclaimable.Store(true)
+// GLSDeactivate releases a span's GLS entry on finish. It ensures the liveness
+// cell exists and is marked done, then invokes the captured popper exactly once.
+//
+// Two patterns are supported:
+//   - Normal path (ContextWithSpan before Finish): GLSActivate already set the
+//     done cell via GLSActivate → GLSDeactivate simply loads and marks it true.
+//   - Cross-goroutine path (Finish before ContextWithSpan): the done cell does not
+//     exist yet. GLSDeactivate creates it pre-marked true via CAS so that when
+//     GLSActivate runs later it finds a true cell, reuses it, and the resulting
+//     stack entry is immediately drain-eligible — preventing the GLS stack from
+//     growing unbounded (orchestrion#782 / korECM pattern).
+//
+// done and pop are the fields orchestrion injects onto the span; passing them by
+// pointer lets injected span-finish advice deactivate in one call. done is nil
+// for dyngo operations (they rely solely on the goroutine-scoped popper and
+// never cross goroutine boundaries).
+func GLSDeactivate(done *GLSDoneCell, pop *GLSPopperCell) {
+	if done != nil {
+		if cell := done.ptr.Load(); cell != nil {
+			// Normal path: cell already exists (GLSActivate ran first).
+			cell.Store(true)
+		} else {
+			// Cross-goroutine path: Finish called before ContextWithSpan. Create
+			// a pre-marked cell so GLSActivate can reuse it later, making the
+			// resulting stack entry immediately drain-eligible.
+			preMarked := new(atomic.Bool)
+			preMarked.Store(true)
+			if !done.ptr.CompareAndSwap(nil, preMarked) {
+				// A concurrent GLSActivate set the cell first; mark it.
+				done.ptr.Load().Store(true)
+			}
+		}
 	}
 	if pop == nil {
 		return
@@ -131,12 +203,16 @@ func GLSDeactivate(reclaimable *atomic.Bool, pop *GLSPopperCell) {
 }
 
 // GLSReset clears the GLS bookkeeping fields orchestrion injects onto a span so
-// that a span returned to the tracer's pool and later reused is never treated as
-// reclaimable or left carrying a stale popper. It is woven into Span.clear. The
-// reclaimable argument may be nil (dyngo operations carry no reclaim flag).
-func GLSReset(reclaimable *atomic.Bool, pop *GLSPopperCell) {
-	if reclaimable != nil {
-		reclaimable.Store(false)
+// that a span returned to the tracer's pool and later reused starts with a clean
+// slate: no stale popper and no stale done cell. It is woven into Span.clear.
+// Clearing the done cell drops the span's reference to it — the contextStack
+// entry retains its own copy of the pointer and can still observe the cell's
+// true value (set by the preceding GLSDeactivate). A reused span receives a
+// fresh cell on its next GLSActivate call, preventing the ABA hazard.
+// done is nil for dyngo operations (they carry no liveness cell).
+func GLSReset(done *GLSDoneCell, pop *GLSPopperCell) {
+	if done != nil {
+		done.ptr.Store(nil)
 	}
 	if pop != nil {
 		pop.ptr.Store(nil)

--- a/internal/orchestrion/context_stack.go
+++ b/internal/orchestrion/context_stack.go
@@ -5,24 +5,23 @@
 
 package orchestrion
 
-import "slices"
+import (
+	"slices"
+	"sync/atomic"
+)
 
 // contextStack is stored in the GLS slot of runtime.g inserted by orchestrion.
 // It holds context values shared within a single goroutine.
 // TODO: handle cross-goroutine context values
-type contextStack map[any][]any
+type contextStack map[any][]stackEntry
 
-// reclaimable is implemented by GLS values that can signal they no longer
-// represent a live scope and may be dropped from the stack. It is used to
-// bound GLS growth when a value is pushed on one goroutine but its lifecycle
-// ends on another, so the matching pop never runs on the pushing goroutine
-// (e.g. a *tracer.Span pushed via ContextWithSpan and finished elsewhere).
-// The orchestrion package intentionally does not import the tracer; values
-// opt in by implementing this single method.
-type reclaimable interface {
-	// GLSReclaimable reports whether this value is safe to drop from a GLS
-	// stack. Implementations must be safe to call from any goroutine.
-	GLSReclaimable() bool
+// stackEntry is one element in a contextStack slice. done is non-nil for
+// values that participate in the GLS reclaim lifecycle (spans, dyngo operations
+// etc.). A nil done means the entry is never drained by Push (e.g. the bool
+// stored under executionTracedKey).
+type stackEntry struct {
+	value any
+	done  *atomic.Bool
 }
 
 // getDDContextStack is a main way to access the GLS slot of runtime.g inserted by orchestrion. This function should not be
@@ -48,36 +47,38 @@ func (s *contextStack) Peek(key any) any {
 		return nil
 	}
 
-	return (*s)[key][len(stack)-1]
+	return stack[len(stack)-1].value
 }
 
-// Push adds a context to the stack.
+// Push appends val to the stack under key and records done as the liveness
+// cell for this activation.
 //
-// Before appending, Push drops any trailing entries that report themselves
-// reclaimable (see [reclaimable]). This bounds GLS growth when values are
-// pushed on one goroutine but their lifecycle ends on another, so the pop
-// never runs on this goroutine. Only the top of the stack is ever read (via
-// Peek), and buried entries exist solely to be restored after a Pop; a
-// reclaimable (e.g. finished) entry can never be a meaningful restore target,
-// so dropping it preserves stack semantics. Entries whose type does not
-// implement [reclaimable] (e.g. the bool stored under executionTracedKey) are
-// never dropped.
-func (s *contextStack) Push(key, val any) {
+// Before appending, Push drops any trailing entries whose done cell reports
+// true — meaning the corresponding span or operation finished, possibly on a
+// different goroutine whose goroutine-scoped popper was therefore a no-op. This
+// bounds GLS growth in the cross-goroutine-finish pattern without reading any
+// mutable flag off the (potentially recycled) value itself: the cell pointer in
+// the stack entry is independent of the span, so pool reuse cannot flip it back.
+//
+// done may be nil for values that are never reclaimable (e.g. the bool stored
+// under executionTracedKey); those entries are never drained.
+func (s *contextStack) Push(key, val any, done *atomic.Bool) {
 	if s == nil || *s == nil {
 		return
 	}
 
 	stack := (*s)[key]
 	for len(stack) > 0 {
-		r, ok := stack[len(stack)-1].(reclaimable)
-		if !ok || !r.GLSReclaimable() {
+		top := &stack[len(stack)-1]
+		if top.done == nil || !top.done.Load() {
 			break
 		}
-		stack[len(stack)-1] = nil // drop reference so GC can collect the value
+		top.value = nil // drop references so GC can collect both the value and the cell
+		top.done = nil
 		stack = stack[:len(stack)-1]
 	}
 
-	(*s)[key] = append(stack, val)
+	(*s)[key] = append(stack, stackEntry{value: val, done: done})
 }
 
 // Pop removes the top context from the stack and returns it.
@@ -92,7 +93,7 @@ func (s *contextStack) Pop(key any) any {
 	}
 
 	lastIdx := len(stack) - 1
-	val := stack[lastIdx]
+	val := stack[lastIdx].value
 	// slices.Delete zeroes removed elements in the backing array,
 	// allowing GC to collect popped values.
 	stack = slices.Delete(stack, lastIdx, lastIdx+1)

--- a/internal/orchestrion/context_stack_reuse_test.go
+++ b/internal/orchestrion/context_stack_reuse_test.go
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package orchestrion
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPushReuseNoBuriedRecycledEntry is a regression test for the ABA hazard in
+// contextStack.Push's drain (DataDog/orchestrion#782). In the orchestrion GLS
+// weave, a span can be pushed on one goroutine, finished elsewhere (setting its
+// done cell to true via GLSDeactivate), and then returned to the tracer's
+// sync.Pool (GLSReset clears the span's reference to the cell). The span is then
+// handed out for a new, unrelated scope.
+//
+// In the previous design the reclaim flag lived on the span itself, so GLSReset
+// flipped it back to false — making the old stack entry look live again (ABA).
+// With the cell-based design the contextStack entry holds its own reference to
+// the original *atomic.Bool cell; GLSReset only clears the span's copy. The
+// cell's true value persists, so the next Push correctly drains the stale entry.
+func TestPushReuseNoBuriedRecycledEntry(t *testing.T) {
+	s := contextStack(make(map[any][]stackEntry))
+	k := stackTestKey{}
+
+	const iterations = 1000
+	for i := range iterations {
+		// GLSActivate: allocate a fresh cell, store it in the stack entry.
+		cell := new(atomic.Bool)
+
+		s.Push(k, i, cell)
+
+		// GLSDeactivate: span finished cross-goroutine; cell is set to true.
+		cell.Store(true)
+
+		// GLSReset: span returned to pool. In the OLD design this would flip
+		// the reclaim flag back to false, making the stack entry look live.
+		// With cells the span simply forgets about this cell (it will allocate
+		// a new one on its next activation). The stack entry's copy of cell is
+		// unaffected — it still reads true.
+		// (We simulate this by leaving cell unchanged; the span's field is gone.)
+	}
+
+	// A correct drain must reclaim all stale entries even when the span objects
+	// were recycled. Depth must be ≤ 2 regardless of the number of iterations:
+	// at most the final push (drained on the NEXT push, which we don't do here)
+	// plus its predecessor.
+	require.LessOrEqual(t, s.Depth(), 2,
+		"pool-recycled entries must not leak; depth = %d, want ≤ 2", s.Depth())
+}
+
+// TestPushReuseNoPeekSurface is the correctness half of the ABA hazard: after
+// pool reuse the Peek must never resurface a recycled span as the active value.
+func TestPushReuseNoPeekSurface(t *testing.T) {
+	s := contextStack(make(map[any][]stackEntry))
+	k := stackTestKey{}
+
+	cellA := new(atomic.Bool)
+	s.Push(k, "spanA", cellA)
+	cellA.Store(true) // finished cross-goroutine
+	// Pool reuse: span's cell reference is cleared; cellA is still true.
+
+	// Allocate a separate cell for spanB (a different activation).
+	cellB := new(atomic.Bool)
+	s.Push(k, "spanB", cellB) // drain: cellA.Load()==true → drain "spanA". Push "spanB".
+	require.Equal(t, "spanB", s.Peek(k), "spanB should be active before pop")
+
+	popped := s.Pop(k)
+	require.Equal(t, "spanB", popped, "pop should remove the live top span")
+
+	assert.Nil(t, s.Peek(k),
+		"finished-then-recycled spanA must not resurface as this goroutine's active value")
+}

--- a/internal/orchestrion/context_stack_test.go
+++ b/internal/orchestrion/context_stack_test.go
@@ -7,6 +7,7 @@ package orchestrion
 
 import (
 	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,13 +17,13 @@ import (
 type stackTestKey struct{}
 
 func TestPopNilsBackingArrayElement(t *testing.T) {
-	s := contextStack(make(map[any][]any))
+	s := contextStack(make(map[any][]stackEntry))
 
 	// Push two values so popping one keeps the map entry alive (len > 0).
 	// This lets us inspect the backing array for the cleared slot.
-	s.Push(stackTestKey{}, "filler")
+	s.Push(stackTestKey{}, "filler", nil)
 	large := make([]byte, 1<<20) // 1 MiB
-	s.Push(stackTestKey{}, large)
+	s.Push(stackTestKey{}, large, nil)
 
 	popped := s.Pop(stackTestKey{})
 	require.NotNil(t, popped)
@@ -32,131 +33,110 @@ func TestPopNilsBackingArrayElement(t *testing.T) {
 	stack := s[stackTestKey{}]
 	require.Len(t, stack, 1, "one element should remain")
 	rawSlice := stack[:cap(stack)]
-	assert.Nil(t, rawSlice[1], "popped element should be nil in backing array to allow GC")
+	assert.Nil(t, rawSlice[1].value, "popped element value should be nil in backing array to allow GC")
 }
 
 func TestPopCleansUpEmptyMapEntry(t *testing.T) {
-	s := contextStack(make(map[any][]any))
+	s := contextStack(make(map[any][]stackEntry))
 
-	s.Push(stackTestKey{}, "value")
+	s.Push(stackTestKey{}, "value", nil)
 	s.Pop(stackTestKey{})
 
 	_, exists := s[stackTestKey{}]
 	assert.False(t, exists, "empty stack entry should be removed from the map")
 }
 
-// fakeReclaimable is a test value that implements the reclaimable interface so
-// we can drive contextStack.Push's drain logic without depending on the tracer.
-type fakeReclaimable struct {
-	id        int
-	reclaimed bool
-}
-
-func (f *fakeReclaimable) GLSReclaimable() bool { return f.reclaimed }
+// newCell allocates a fresh liveness cell (not yet done). Convenience for tests.
+func newCell() *atomic.Bool { return new(atomic.Bool) }
 
 func TestPushReclaimsFinishedTopEntry(t *testing.T) {
-	s := contextStack(make(map[any][]any))
+	s := contextStack(make(map[any][]stackEntry))
 
-	first := &fakeReclaimable{id: 1}
-	s.Push(stackTestKey{}, first)
+	cell1 := newCell()
+	s.Push(stackTestKey{}, "first", cell1)
 	require.Equal(t, 1, s.Depth(), "first push lands")
 
-	// Mark the top entry reclaimable, as a finished span would be. The next
+	// Mark the top entry done, as a finished span would be. The next
 	// push must drop it instead of stacking on top, keeping depth at 1.
-	first.reclaimed = true
-	second := &fakeReclaimable{id: 2}
-	s.Push(stackTestKey{}, second)
+	cell1.Store(true)
+	s.Push(stackTestKey{}, "second", newCell())
 
-	assert.Equal(t, 1, s.Depth(), "reclaimable top entry should be dropped on push")
-	assert.Equal(t, second, s.Peek(stackTestKey{}), "new value should be on top")
+	assert.Equal(t, 1, s.Depth(), "done top entry should be dropped on push")
+	assert.Equal(t, "second", s.Peek(stackTestKey{}), "new value should be on top")
 }
 
 func TestPushDrainsMultipleReclaimableEntries(t *testing.T) {
-	s := contextStack(make(map[any][]any))
+	s := contextStack(make(map[any][]stackEntry))
 
 	// Several entries pile up while live (pushed on this goroutine, e.g. via
 	// ContextWithSpan), building real depth.
-	entries := make([]*fakeReclaimable, 5)
-	for i := range entries {
-		entries[i] = &fakeReclaimable{id: i}
-		s.Push(stackTestKey{}, entries[i])
+	cells := make([]*atomic.Bool, 5)
+	for i := range cells {
+		cells[i] = newCell()
+		s.Push(stackTestKey{}, i, cells[i])
 	}
 	require.Equal(t, 5, s.Depth(), "five live entries pushed")
 
 	// They all get finished elsewhere (no matching pop ran on this goroutine).
-	for _, e := range entries {
-		e.reclaimed = true
+	for _, c := range cells {
+		c.Store(true)
 	}
 
-	// The next push must drain ALL trailing reclaimable entries, not just the top.
-	live := &fakeReclaimable{id: 99}
-	s.Push(stackTestKey{}, live)
+	// The next push must drain ALL trailing done entries, not just the top.
+	s.Push(stackTestKey{}, "live", newCell())
 
-	assert.Equal(t, 1, s.Depth(), "all trailing reclaimable entries should be drained")
-	assert.Equal(t, live, s.Peek(stackTestKey{}))
+	assert.Equal(t, 1, s.Depth(), "all trailing done entries should be drained")
+	assert.Equal(t, "live", s.Peek(stackTestKey{}))
 }
 
 func TestPushKeepsLiveEntries(t *testing.T) {
-	s := contextStack(make(map[any][]any))
+	s := contextStack(make(map[any][]stackEntry))
 
-	// A live (non-reclaimable) entry on top must never be dropped — this is
+	// A live (not-done) entry on top must never be dropped — this is
 	// the legitimate same-goroutine nesting case (parent still active).
-	parent := &fakeReclaimable{id: 1, reclaimed: false}
-	s.Push(stackTestKey{}, parent)
-	child := &fakeReclaimable{id: 2, reclaimed: false}
-	s.Push(stackTestKey{}, child)
+	s.Push(stackTestKey{}, "parent", newCell())
+	s.Push(stackTestKey{}, "child", newCell())
 
 	assert.Equal(t, 2, s.Depth(), "live entries must be preserved (nesting)")
-	assert.Equal(t, child, s.Peek(stackTestKey{}))
+	assert.Equal(t, "child", s.Peek(stackTestKey{}))
 }
 
 func TestPushDoesNotReclaimBuriedEntryUnderLiveTop(t *testing.T) {
-	s := contextStack(make(map[any][]any))
+	s := contextStack(make(map[any][]stackEntry))
 
 	// Build [buried, liveTop] with both live, so neither is dropped at push.
-	buried := &fakeReclaimable{id: 1, reclaimed: false}
-	s.Push(stackTestKey{}, buried)
-	liveTop := &fakeReclaimable{id: 2, reclaimed: false}
-	s.Push(stackTestKey{}, liveTop)
+	buriedCell := newCell()
+	s.Push(stackTestKey{}, "buried", buriedCell)
+	s.Push(stackTestKey{}, "liveTop", newCell())
 	require.Equal(t, 2, s.Depth())
 
-	// buried becomes reclaimable, but liveTop (still live) sits above it.
-	buried.reclaimed = true
+	// buried becomes done, but liveTop (still live) sits above it.
+	buriedCell.Store(true)
 
-	next := &fakeReclaimable{id: 3, reclaimed: false}
-	s.Push(stackTestKey{}, next)
+	s.Push(stackTestKey{}, "next", newCell())
 
-	// The drain stops at liveTop (not reclaimable), so buried is preserved.
-	// This is the invariant that protects legitimate nesting: a reclaimable
-	// entry beneath a live scope is never dropped.
+	// The drain stops at liveTop (not done), so buried is preserved.
+	// This is the invariant that protects legitimate nesting: a done entry
+	// beneath a live scope is never dropped.
 	assert.Equal(t, 3, s.Depth(), "drain stops at the first live entry from the top; buried stays")
 }
 
-func TestPushDoesNotDrainNonReclaimableValues(t *testing.T) {
-	s := contextStack(make(map[any][]any))
+func TestPushDoesNotDrainNilDoneEntries(t *testing.T) {
+	s := contextStack(make(map[any][]stackEntry))
 
-	// Values that don't implement reclaimable (e.g. the bool stored under
-	// executionTracedKey) must never be drained, even if they pile up.
-	s.Push(stackTestKey{}, true)
-	s.Push(stackTestKey{}, false)
-	s.Push(stackTestKey{}, true)
+	// Values pushed with done=nil (e.g. the bool stored under executionTracedKey)
+	// must never be drained, even if they pile up.
+	s.Push(stackTestKey{}, true, nil)
+	s.Push(stackTestKey{}, false, nil)
+	s.Push(stackTestKey{}, true, nil)
 
-	assert.Equal(t, 3, s.Depth(), "non-reclaimable values are never dropped")
+	assert.Equal(t, 3, s.Depth(), "nil-done values are never dropped")
 }
 
 // BenchmarkPushDrainReclaimed measures the cost of Push's trailing-reclaim drain
-// under the cross-goroutine-finish pattern: a stack accumulates reclaimable
-// entries (finished spans whose pop never ran on this goroutine), then a single
-// Push drains them all before appending the new value.
-//
-// The 0_reclaimed sub-benchmark is the common case (nothing to drain) and
-// establishes the baseline cost of the drain loop. The N_reclaimed cases show
-// the amortised cost per entry: each entry is pushed once and drained once, so
-// total work is O(N) regardless of how many pushes trigger the drain.
-//
-// The entries are built LIVE and only then marked reclaimable: pushing them
-// reclaimable would let Push drain each one as the stack is built, so the stack
-// would never reach depth N (this mirrors TestPushDrainsMultipleReclaimableEntries).
+// under the cross-goroutine-finish pattern: a stack accumulates done entries
+// (finished spans whose pop never ran on this goroutine), then a single Push
+// drains them all before appending the new value.
 func BenchmarkPushDrainReclaimed(b *testing.B) {
 	for _, stale := range []int{0, 1, 10, 100} {
 		b.Run(fmt.Sprintf("%d_reclaimed", stale), func(b *testing.B) {
@@ -164,19 +144,19 @@ func BenchmarkPushDrainReclaimed(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
 				b.StopTimer()
-				s := contextStack(make(map[any][]any))
-				entries := make([]*fakeReclaimable, stale)
-				for i := range entries {
-					entries[i] = &fakeReclaimable{id: i}
-					s.Push(k, entries[i]) // pushed live so the stack reaches depth N
+				s := contextStack(make(map[any][]stackEntry))
+				cells := make([]*atomic.Bool, stale)
+				for i := range cells {
+					cells[i] = newCell()
+					s.Push(k, i, cells[i]) // pushed live so the stack reaches depth N
 				}
-				for _, e := range entries {
-					e.reclaimed = true // now finished cross-goroutine (pop never ran here)
+				for _, c := range cells {
+					c.Store(true) // now finished cross-goroutine (pop never ran here)
 				}
 				b.StartTimer()
 
-				// This single Push must drain all `stale` reclaimable entries.
-				s.Push(k, &fakeReclaimable{id: stale})
+				// This single Push must drain all `stale` done entries.
+				s.Push(k, stale, newCell())
 			}
 		})
 	}

--- a/internal/orchestrion/context_test.go
+++ b/internal/orchestrion/context_test.go
@@ -69,7 +69,7 @@ func TestGLSPopFunc(t *testing.T) {
 		// In production, each goroutine has its own contextStack pointer in
 		// runtime.g, so getDDContextStack() returns different pointers.
 		originalStack := getDDGLS()
-		differentStack := contextStack(make(map[any][]any))
+		differentStack := contextStack(make(map[any][]stackEntry))
 		setDDGLS(&differentStack)
 		t.Cleanup(func() { setDDGLS(originalStack) })
 
@@ -95,25 +95,58 @@ func TestGLSActivate(t *testing.T) {
 		t.Cleanup(MockGLS())
 
 		var pop GLSPopperCell
-		GLSActivate(nil, key("k"), "v", &pop)
+		var done GLSDoneCell
+		GLSActivate(nil, key("k"), "v", &pop, &done)
 		require.Equal(t, "v", getDDContextStack().Peek(key("k")), "value should be on the GLS stack")
 		fn := pop.ptr.Load()
 		require.NotNil(t, fn, "popper should be captured")
+		require.NotNil(t, done.ptr.Load(), "done cell should be allocated")
 
 		(*fn)()
 		require.Nil(t, getDDContextStack().Peek(key("k")), "popper should remove the value")
 	})
 
-	t.Run("first activation wins: popper is not overwritten", func(t *testing.T) {
+	t.Run("re-activation of live span supersedes previous entry", func(t *testing.T) {
 		t.Cleanup(MockGLS())
 
 		var pop GLSPopperCell
-		GLSActivate(nil, key("k"), "v1", &pop)
+		var done GLSDoneCell
+		GLSActivate(nil, key("k"), "v1", &pop, &done)
 		first := pop.ptr.Load()
-		GLSActivate(nil, key("k"), "v2", &pop) // re-activate same field
-		require.Equal(t, 2, getDDContextStack().Depth(), "every activation pushes")
+		cell1 := done.ptr.Load()
+		// Second activation of the same span (same done field, cell not yet true):
+		// the old cell is marked done immediately so the drain removes the first
+		// entry and depth stays at 1.
+		GLSActivate(nil, key("k"), "v2", &pop, &done)
+		require.Equal(t, 1, getDDContextStack().Depth(), "re-activation drains the superseded entry")
+		require.Equal(t, "v2", getDDContextStack().Peek(key("k")), "v2 is the live entry")
 		require.Same(t, first, pop.ptr.Load(),
 			"the first popper must be retained across re-activation")
+		require.True(t, cell1.Load(), "old cell must be marked done on re-activation")
+		require.NotSame(t, cell1, done.ptr.Load(), "re-activation must allocate a new cell")
+	})
+
+	t.Run("re-activation of already-finished span reuses existing cell", func(t *testing.T) {
+		t.Cleanup(MockGLS())
+
+		var pop GLSPopperCell
+		var done GLSDoneCell
+		// Simulate: span was pushed and finished by a different goroutine
+		// (GLSActivate + GLSDeactivate). The cell is already true.
+		cell := new(atomic.Bool)
+		cell.Store(true)
+		done.ptr.Store(cell)
+
+		GLSActivate(nil, key("k"), "v1", &pop, &done)
+		// The existing true cell must be reused so the stack entry is immediately
+		// drain-eligible on the next Push for the same key.
+		require.Same(t, cell, done.ptr.Load(), "existing true cell must be reused")
+		require.Equal(t, 1, getDDContextStack().Depth(), "entry pushed")
+
+		// Second activation on the same key: drain removes the just-pushed entry.
+		GLSActivate(nil, key("k"), "v2", &pop, nil)
+		require.Equal(t, 1, getDDContextStack().Depth(), "drain must remove the immediately-eligible entry")
+		require.Equal(t, "v2", getDDContextStack().Peek(key("k")), "v2 is the live entry")
 	})
 
 	t.Run("ctxp non-nil wraps the parent so the result is GLS-aware", func(t *testing.T) {
@@ -121,9 +154,19 @@ func TestGLSActivate(t *testing.T) {
 
 		ctx := context.Background()
 		var pop GLSPopperCell
-		GLSActivate(&ctx, key("k"), "v", &pop)
+		var done GLSDoneCell
+		GLSActivate(&ctx, key("k"), "v", &pop, &done)
 		_, ok := ctx.(*glsContext)
 		require.True(t, ok, "ctxp should be wrapped in a glsContext")
+	})
+
+	t.Run("done=nil is a no-op for the cell (dyngo path)", func(t *testing.T) {
+		t.Cleanup(MockGLS())
+
+		var pop GLSPopperCell
+		GLSActivate(nil, key("k"), "v", &pop, nil) // must not panic, no cell needed
+		require.Equal(t, "v", getDDContextStack().Peek(key("k")), "value pushed")
+		require.NotNil(t, pop.ptr.Load(), "popper still captured")
 	})
 
 	t.Run("disabled orchestrion is a no-op", func(t *testing.T) {
@@ -132,28 +175,34 @@ func TestGLSActivate(t *testing.T) {
 
 		ctx := context.Background()
 		var pop GLSPopperCell
-		GLSActivate(&ctx, key("k"), "v", &pop) // must not panic
+		var done GLSDoneCell
+		GLSActivate(&ctx, key("k"), "v", &pop, &done) // must not panic
 		require.Nil(t, pop.ptr.Load(), "no popper captured when disabled")
+		require.Nil(t, done.ptr.Load(), "no cell allocated when disabled")
 		require.Equal(t, context.Background(), ctx, "ctx unchanged when disabled")
 	})
 }
 
 func TestGLSReset(t *testing.T) {
-	t.Run("clears reclaimable flag and popper", func(t *testing.T) {
-		var reclaimable atomic.Bool
-		reclaimable.Store(true)
+	t.Run("clears done cell and popper without running the popper", func(t *testing.T) {
+		var done GLSDoneCell
+		cell := new(atomic.Bool)
+		cell.Store(true)
+		done.ptr.Store(cell)
 		ran := 0
 		var pop GLSPopperCell
 		fn := GLSPopper(func() { ran++ })
 		pop.ptr.Store(&fn)
 
-		GLSReset(&reclaimable, &pop)
-		require.False(t, reclaimable.Load(), "reclaimable must be reset to false")
+		GLSReset(&done, &pop)
+		require.Nil(t, done.ptr.Load(), "done cell pointer must be cleared (span's reference dropped)")
+		// The underlying cell is unchanged — stack entries holding it still see true.
+		require.True(t, cell.Load(), "original cell must still be true (stack entry keeps its ref)")
 		require.Nil(t, pop.ptr.Load(), "popper must be cleared without being run")
 		require.Equal(t, 0, ran, "GLSReset must not run the popper")
 	})
 
-	t.Run("tolerates nil reclaimable (dyngo operations)", func(t *testing.T) {
+	t.Run("tolerates nil done (dyngo operations)", func(t *testing.T) {
 		var pop GLSPopperCell
 		fn := GLSPopper(func() {})
 		pop.ptr.Store(&fn)
@@ -163,28 +212,42 @@ func TestGLSReset(t *testing.T) {
 }
 
 func TestGLSDeactivate(t *testing.T) {
-	t.Run("sets reclaimable and runs the popper once", func(t *testing.T) {
-		var reclaimable atomic.Bool
+	t.Run("marks done cell true and runs the popper once", func(t *testing.T) {
+		var done GLSDoneCell
+		cell := new(atomic.Bool)
+		done.ptr.Store(cell)
 		popped := 0
 		var pop GLSPopperCell
 		fn := GLSPopper(func() { popped++ })
 		pop.ptr.Store(&fn)
 
-		GLSDeactivate(&reclaimable, &pop)
-		require.True(t, reclaimable.Load(), "span should be marked reclaimable")
+		GLSDeactivate(&done, &pop)
+		require.True(t, cell.Load(), "done cell should be set to true on finish")
 		require.Equal(t, 1, popped, "popper should run once")
 		require.Nil(t, pop.ptr.Load(), "popper should be cleared after running")
 
-		GLSDeactivate(&reclaimable, &pop) // second finish: popper already nil
+		GLSDeactivate(&done, &pop) // second finish: popper already nil
 		require.Equal(t, 1, popped, "popper must not run again on a repeated finish")
 	})
 
-	t.Run("tolerates nil popper and nil pointers", func(t *testing.T) {
-		var reclaimable atomic.Bool
+	t.Run("creates and pre-marks a cell when Finish runs before ContextWithSpan", func(t *testing.T) {
+		// In the korECM cross-goroutine pattern (orchestrion#782), Finish is called
+		// on the span BEFORE ContextWithSpan. done.ptr is nil at the time of Finish.
+		// GLSDeactivate must create a pre-marked cell so GLSActivate can find and
+		// reuse it, making the resulting stack entry immediately drain-eligible.
+		var done GLSDoneCell // ptr is nil: no prior GLSActivate
+		var pop GLSPopperCell
+
+		GLSDeactivate(&done, &pop)
+		cell := done.ptr.Load()
+		require.NotNil(t, cell, "GLSDeactivate must create a cell when none exists")
+		require.True(t, cell.Load(), "pre-created cell must already be true")
+	})
+
+	t.Run("tolerates nil done and nil pointers", func(t *testing.T) {
 		var pop GLSPopperCell // empty: nil inner pointer
 
-		GLSDeactivate(&reclaimable, &pop) // no popper -> no invoke, no panic
-		require.True(t, reclaimable.Load())
+		GLSDeactivate(nil, &pop) // no done, no popper -> no invoke, no panic
 
 		GLSDeactivate(nil, nil) // must not panic
 	})
@@ -284,7 +347,7 @@ func BenchmarkContextStackPushPop(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		getDDContextStack().Push(k, true)
+		getDDContextStack().Push(k, true, nil)
 		getDDContextStack().Pop(k)
 	}
 	if depth := GLSStackDepth(); depth != 0 {
@@ -300,7 +363,7 @@ func BenchmarkContextStackPushOnly(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		getDDContextStack().Push(k, true)
+		getDDContextStack().Push(k, true, nil)
 	}
 	b.StopTimer()
 	depth := GLSStackDepth()
@@ -359,7 +422,7 @@ func BenchmarkContextStackDepthScaling(b *testing.B) {
 			k := key("bench")
 			// Pre-fill the stack to simulate leaked entries.
 			for range depth {
-				getDDContextStack().Push(k, true)
+				getDDContextStack().Push(k, true, nil)
 			}
 			b.ReportAllocs()
 			b.ResetTimer()
@@ -367,5 +430,29 @@ func BenchmarkContextStackDepthScaling(b *testing.B) {
 				getDDContextStack().Peek(k)
 			}
 		})
+	}
+}
+
+// BenchmarkGLSActivate measures the per-span GLS lifecycle cost as woven into
+// the tracer: GLSActivate (ContextWithSpan) + GLSDeactivate (Finish) + GLSReset
+// (clear). Running reset every iteration mirrors how the span pool reuses a span,
+// which is the scenario this decouple design unlocks. The reported allocs/op are
+// the GLS-helper overhead per pooled-span reuse: one closure for the popper
+// (re-captured because reset cleared it) and one *atomic.Bool liveness cell.
+// The cell is the cost the cell-based reclaim adds over reading a mutable flag
+// off the span; it is paid only under orchestrion.
+func BenchmarkGLSActivate(b *testing.B) {
+	b.Cleanup(MockGLS())
+	k := key("bench")
+	var pop GLSPopperCell
+	var done GLSDoneCell
+	b.ReportAllocs()
+	for b.Loop() {
+		GLSActivate(nil, k, "v", &pop, &done)
+		GLSDeactivate(&done, &pop)
+		GLSReset(&done, &pop)
+	}
+	if d := GLSStackDepth(); d != 0 {
+		b.Fatalf("GLS depth = %d after balanced activate/deactivate, want 0", d)
 	}
 }

--- a/internal/orchestrion/context_test.go
+++ b/internal/orchestrion/context_test.go
@@ -106,7 +106,7 @@ func TestGLSActivate(t *testing.T) {
 		require.Nil(t, getDDContextStack().Peek(key("k")), "popper should remove the value")
 	})
 
-	t.Run("re-activation of live span supersedes previous entry", func(t *testing.T) {
+	t.Run("re-activation of live span shares the same cell (no supersede)", func(t *testing.T) {
 		t.Cleanup(MockGLS())
 
 		var pop GLSPopperCell
@@ -114,16 +114,18 @@ func TestGLSActivate(t *testing.T) {
 		GLSActivate(nil, key("k"), "v1", &pop, &done)
 		first := pop.ptr.Load()
 		cell1 := done.ptr.Load()
-		// Second activation of the same span (same done field, cell not yet true):
-		// the old cell is marked done immediately so the drain removes the first
-		// entry and depth stays at 1.
+		// Second activation of the same still-live span (e.g. propagated to
+		// another goroutine before Finish). The cell must be REUSED, not replaced,
+		// and the previous entry must NOT be marked done — marking a live entry
+		// would let the next Push drop it, breaking cross-goroutine live
+		// propagation (orchestrion#782 review). So both entries stay live and the
+		// stack grows to 2.
 		GLSActivate(nil, key("k"), "v2", &pop, &done)
-		require.Equal(t, 1, getDDContextStack().Depth(), "re-activation drains the superseded entry")
-		require.Equal(t, "v2", getDDContextStack().Peek(key("k")), "v2 is the live entry")
+		require.Equal(t, 2, getDDContextStack().Depth(), "re-activation keeps both live entries")
+		require.Same(t, cell1, done.ptr.Load(), "the cell is reused, not replaced")
+		require.False(t, cell1.Load(), "the live cell must not be marked done on re-activation")
 		require.Same(t, first, pop.ptr.Load(),
 			"the first popper must be retained across re-activation")
-		require.True(t, cell1.Load(), "old cell must be marked done on re-activation")
-		require.NotSame(t, cell1, done.ptr.Load(), "re-activation must allocate a new cell")
 	})
 
 	t.Run("re-activation of already-finished span reuses existing cell", func(t *testing.T) {

--- a/internal/orchestrion/gls.orchestrion.yml
+++ b/internal/orchestrion/gls.orchestrion.yml
@@ -91,7 +91,7 @@ aspects:
               // context is GLS-aware (matching in-source CtxWithValue), pushes
               // the op, and captures the first-wins popper onto __dd_glsPop.
               __dd_o := {{ $op }}.unwrap()
-              orchestrion.GLSActivate(&{{ $ctx }}, contextKey{}, {{ $op }}, &__dd_o.__dd_glsPop)
+              orchestrion.GLSActivate(&{{ $ctx }}, contextKey{}, {{ $op }}, &__dd_o.__dd_glsPop, nil)
             }
 
   # FromContext: wrap ctx so the read also consults the GLS.

--- a/internal/orchestrion/gls_deactivate_concurrent_test.go
+++ b/internal/orchestrion/gls_deactivate_concurrent_test.go
@@ -14,15 +14,15 @@ import (
 // TestGLSDeactivateConcurrentFinishRaces is a regression guard for the
 // span-pool × GLS concurrency review (orchestrion#782). Two dyngo
 // FinishOperation calls run under the shared RLock and can therefore call
-// GLSDeactivate on the same popper field at the same time. The popper now lives
-// in an atomic [GLSPopperCell], so this must stay clean under `go test -race`;
-// before that, GLSDeactivate's read-then-nil of a bare func field was a data
-// race.
+// GLSDeactivate on the same popper field at the same time. The popper lives
+// in an atomic [GLSPopperCell], so this must stay clean under `go test -race`.
 func TestGLSDeactivateConcurrentFinishRaces(t *testing.T) {
 	const iterations = 1000
 
 	for range iterations {
-		var reclaimable atomic.Bool
+		var done GLSDoneCell
+		cell := new(atomic.Bool)
+		done.ptr.Store(cell)
 		var pop GLSPopperCell
 		fn := GLSPopper(func() {})
 		pop.ptr.Store(&fn)
@@ -35,7 +35,7 @@ func TestGLSDeactivateConcurrentFinishRaces(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				<-start
-				GLSDeactivate(&reclaimable, &pop)
+				GLSDeactivate(&done, &pop)
 			}()
 		}
 
@@ -44,18 +44,16 @@ func TestGLSDeactivateConcurrentFinishRaces(t *testing.T) {
 	}
 }
 
-// TestGLSDeactivateConcurrentDoubleRunsPopper asserts the observable
-// consequence of making the popper swap atomic: across two concurrent
-// deactivations of the same cell, the popper runs exactly once, because the
-// atomic Swap hands the single non-nil popper to exactly one caller. Before the
-// fix, the non-atomic load-then-nil could let both deactivations observe and run
-// the same popper.
+// TestGLSDeactivateConcurrentDoubleRunsPopper asserts that across two concurrent
+// deactivations of the same cell, the popper runs exactly once.
 func TestGLSDeactivateConcurrentDoubleRunsPopper(t *testing.T) {
 	const iterations = 1000
 
 	var total atomic.Int64
 	for range iterations {
-		var reclaimable atomic.Bool
+		var done GLSDoneCell
+		cell := new(atomic.Bool)
+		done.ptr.Store(cell)
 		var pop GLSPopperCell
 		fn := GLSPopper(func() { total.Add(1) })
 		pop.ptr.Store(&fn)
@@ -68,7 +66,7 @@ func TestGLSDeactivateConcurrentDoubleRunsPopper(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				<-start
-				GLSDeactivate(&reclaimable, &pop)
+				GLSDeactivate(&done, &pop)
 			}()
 		}
 

--- a/internal/orchestrion/gls_finish_reset_race_test.go
+++ b/internal/orchestrion/gls_finish_reset_race_test.go
@@ -15,13 +15,14 @@ import (
 // GLS concurrency review (orchestrion#782). A span can be finished on one
 // goroutine (GLSDeactivate, woven into Span.Finish) while the tracer's
 // sync.Pool recycles and resets it on another (GLSReset, woven into
-// Span.clear), both touching the same popper field. The popper now lives in an
-// atomic [GLSPopperCell], so the Swap (finish) and Store (reset) are
-// synchronized and this must stay clean under `go test -race`; before that, the
-// bare func field was unsynchronized memory and the race detector flagged it.
+// Span.clear). All accesses to the shared fields go through atomic operations
+// (GLSPopperCell.ptr, GLSDoneCell.ptr), so this must stay clean under
+// `go test -race`.
 func TestGLSFinishResetConcurrentRaces(t *testing.T) {
 	for range 1000 {
-		var reclaimable atomic.Bool
+		var done GLSDoneCell
+		cell := new(atomic.Bool)
+		done.ptr.Store(cell)
 		var pop GLSPopperCell
 		fn := GLSPopper(func() {})
 		pop.ptr.Store(&fn)
@@ -33,13 +34,13 @@ func TestGLSFinishResetConcurrentRaces(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			GLSDeactivate(&reclaimable, &pop)
+			GLSDeactivate(&done, &pop)
 		}()
 
 		go func() {
 			defer wg.Done()
 			<-start
-			GLSReset(&reclaimable, &pop)
+			GLSReset(&done, &pop)
 		}()
 
 		close(start)

--- a/internal/orchestrion/mock_gls.go
+++ b/internal/orchestrion/mock_gls.go
@@ -26,7 +26,7 @@ func MockGLS() func() {
 	prevSetDDGLS := setDDGLS
 	prevEnabled := enabled
 
-	tmp := contextStack(make(map[any][]any))
+	tmp := contextStack(make(map[any][]stackEntry))
 	var glsValue any = &tmp
 	getDDGLS = func() any { return glsValue }
 	setDDGLS = func(a any) { glsValue = a }


### PR DESCRIPTION
## What

First PR in a 3-PR stack that lets the experimental span pool and orchestrion GLS run together. This PR decouples the GLS reclaim signal from the recyclable `*Span`; it is a behaviour-preserving refactor (the #4891 mutual-exclusion gate stays in place).

## Why

#4891 stored the reclaim signal (`__dd_glsReclaimable`) on the `*Span` itself. With the span pool, `clear()` (woven `GLSReset`) can flip a finished span's flag back to `false` while a goroutine's GLS stack still references it, so `contextStack.Push`'s drain stops dropping the stale entry (ABA): the entry leaks, or a recycled span resurfaces as active. #4891 therefore gated the two features as mutually exclusive.

## How

The reclaim signal now lives in a heap cell captured at push time, independent of the span:

- `contextStack` is `map[any][]stackEntry`, where `stackEntry` is `{value any, done *atomic.Bool}`. `Push` takes the cell and drains trailing entries whose cell reads `true`; it never reads a flag off the value.
- `GLSDoneCell` (a named `atomic.Pointer[atomic.Bool]`, required by `add-struct-field`) is woven onto `Span` in place of `__dd_glsReclaimable`.
- `GLSActivate` allocates a fresh cell per activation (reusing an already-`true` cell when a finished span is re-injected cross-goroutine). `GLSDeactivate` marks the cell done, creating a pre-marked cell when `Finish` runs before `ContextWithSpan`. `GLSReset` only drops the span's pointer to the cell; the stack entry keeps its own reference, so a reused span gets a fresh cell and the ABA cannot occur.

## Tests

- Adopts the ABA spec test from the review branch (`context_stack_reuse_test.go`).
- Migrates the popper-race regression tests to the cell-based signatures (green under `-race`).
- Adds `BenchmarkGLSActivate`. The decouple's only added cost is one `*atomic.Bool` per activation under orchestrion (≈ +1 alloc and tens of ns on the GLS activate/deactivate cycle; zero without orchestrion).

## Stack (merge in order)

1. **#4926 (this PR)** — decouple the reclaim signal (gate kept; no behaviour change)
2. #4927 — `Peek` skips finished entries (wrong-active-span read window)
3. #4928 — remove the gate + prove span-pool/GLS coexistence under `-race`

Refs: #4891 · https://github.com/DataDog/orchestrion/issues/782
