### PR TITLE
fix(orchestrion): skip finished entries in GLS Peek to avoid surfacing recycled spans

### DIFF
--- a/internal/orchestrion/context_stack.go
+++ b/internal/orchestrion/context_stack.go
@@ -36,18 +36,30 @@ func getDDContextStack() *contextStack {
 	return newStack
 }
 
-// Peek returns the top context from the stack without removing it.
+// Peek returns the topmost live context from the stack without removing it.
+//
+// Entries whose done cell reads true are skipped: a finished value is no longer
+// a live scope, and under the experimental span pool the recyclable object it
+// points at may already have been reset and reused for an unrelated span.
+// Returning it would surface a stale (or recycled, hence wrong) span as the
+// active one from SpanFromContext's GLS fallback. Skipping such entries here
+// closes that read window; contextStack.Push drains them on the next push so
+// the skip stays bounded. A nil done cell (e.g. the bool under
+// executionTracedKey) is never skipped.
 func (s *contextStack) Peek(key any) any {
 	if s == nil || *s == nil {
 		return nil
 	}
 
-	stack, ok := (*s)[key]
-	if !ok || len(stack) == 0 {
-		return nil
+	stack := (*s)[key]
+	for i := len(stack) - 1; i >= 0; i-- {
+		e := stack[i]
+		if e.done != nil && e.done.Load() {
+			continue // finished/recycled: never surface as the active value
+		}
+		return e.value
 	}
-
-	return stack[len(stack)-1].value
+	return nil
 }
 
 // Push appends val to the stack under key and records done as the liveness

--- a/internal/orchestrion/context_stack_test.go
+++ b/internal/orchestrion/context_stack_test.go
@@ -46,6 +46,41 @@ func TestPopCleansUpEmptyMapEntry(t *testing.T) {
 	assert.False(t, exists, "empty stack entry should be removed from the map")
 }
 
+func TestPeekSkipsDoneEntries(t *testing.T) {
+	s := contextStack(make(map[any][]stackEntry))
+	k := stackTestKey{}
+
+	// Live parent, then a child pushed on top, both live.
+	parentCell := new(atomic.Bool)
+	s.Push(k, "parent", parentCell)
+	childCell := new(atomic.Bool)
+	s.Push(k, "child", childCell)
+	require.Equal(t, "child", s.Peek(k), "live top entry is the active value")
+
+	// The child finishes (e.g. cross-goroutine, so it was not popped here). Its
+	// done cell is true. Peek must skip it and surface the live parent — not the
+	// finished child, which under pooling may already be a recycled, unrelated span.
+	childCell.Store(true)
+	assert.Equal(t, "parent", s.Peek(k), "finished top entry must be skipped; live parent surfaces")
+
+	// Parent finishes too: no live scope remains, Peek reports none.
+	parentCell.Store(true)
+	assert.Nil(t, s.Peek(k), "all entries done: no active value")
+
+	// Depth is unchanged by Peek (it is read-only; Push does the draining).
+	assert.Equal(t, 2, s.Depth(), "Peek must not mutate the stack")
+}
+
+func TestPeekReturnsNilDoneEntries(t *testing.T) {
+	s := contextStack(make(map[any][]stackEntry))
+	k := stackTestKey{}
+
+	// Values with a nil done cell (e.g. the bool under executionTracedKey) are
+	// never skipped, regardless of how many pile up.
+	s.Push(k, true, nil)
+	assert.Equal(t, true, s.Peek(k), "nil-done entries are always live for Peek")
+}
+
 // newCell allocates a fresh liveness cell (not yet done). Convenience for tests.
 func newCell() *atomic.Bool { return new(atomic.Bool) }
 


### PR DESCRIPTION
## What

Second PR in the GLS span-pool stack (on top of the reclaim decouple). Makes `contextStack.Peek` skip finished (done) entries so `SpanFromContext`'s GLS fallback never returns a finished — possibly recycled — span as the active one.

## Why

`contextStack.Push` drains trailing done entries, which bounds GLS growth. But between a cross-goroutine finish and the pushing goroutine's next push, a finished entry sits on top of the stack. `Peek` returned it, so `SpanFromContext`'s GLS fallback could hand back a finished span. With the experimental span pool that span may already have been reset by `clear()` and reused for an unrelated live span, so the caller would get a wrong parent. This is the "wrong active span via Peek" issue raised in the #4891 review.

## How

`Peek` returns the topmost entry whose done cell is not set, skipping finished (hence possibly recycled) entries. `Push` still drains them on the next push, so the skip cost stays bounded. Entries with a nil done cell (e.g. the bool under `executionTracedKey`) are never skipped.

## Tests

`TestPeekSkipsDoneEntries` (finished top entry is skipped; live parent surfaces; all-done returns none; `Peek` does not mutate the stack) and `TestPeekReturnsNilDoneEntries` (nil-done values always live). Full `internal/orchestrion` suite green under `-race`.

## Stack (merge in order)

1. #4926 — decouple the reclaim signal
2. **#4927 (this PR)** — `Peek` skips finished entries
3. #4928 — remove the gate + prove span-pool/GLS coexistence under `-race`

> Based on #4926; review/merge that first.

Refs: #4891 · https://github.com/DataDog/orchestrion/issues/782
