### PR TITLE
test(ddtrace/tracer): de-flake TestPartialFlushSpanLockOrderingCycle via deterministic acquire hook

### DIFF
--- a/ddtrace/tracer/span_pool.go
+++ b/ddtrace/tracer/span_pool.go
@@ -19,6 +19,12 @@ var spanPool = sync.Pool{
 }
 
 func acquireSpan(poolEnabled bool) *Span {
+	// maybeTestAcquireSpan is a no-op (returns nil, inlined away) outside the
+	// deadlock build; under -tags deadlock it lets the lock-ordering test inject
+	// specific *Span instances. See span_pool_testhook*.go.
+	if s := maybeTestAcquireSpan(); s != nil {
+		return s
+	}
 	if poolEnabled {
 		return spanPool.Get().(*Span)
 	}

--- a/ddtrace/tracer/span_pool_testhook.go
+++ b/ddtrace/tracer/span_pool_testhook.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+//go:build deadlock
+
+package tracer
+
+// testAcquireSpan, when non-nil, supplies the next span returned by acquireSpan
+// instead of the pool. It exists only for the lock-ordering deadlock test, which
+// must drive two StartSpan calls back through a specific pair of *Span instances
+// so the reversed lock ordering is recorded on the same mutexes. sync.Pool cannot
+// do this deterministically (it is process-global, the worker concurrently Puts
+// into it, and it guarantees no Get/Put ordering or identity). The hook is read
+// only on the StartSpan path, which only the test goroutine drives while it is
+// set, so it needs no synchronization.
+var testAcquireSpan func() *Span
+
+func maybeTestAcquireSpan() *Span {
+	if testAcquireSpan != nil {
+		return testAcquireSpan()
+	}
+	return nil
+}

--- a/ddtrace/tracer/span_pool_testhook_off.go
+++ b/ddtrace/tracer/span_pool_testhook_off.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+//go:build !deadlock
+
+package tracer
+
+// maybeTestAcquireSpan is a no-op in normal builds. It is inlined and the dead
+// branch in acquireSpan is eliminated, so it costs nothing on the hot path.
+func maybeTestAcquireSpan() *Span { return nil }

--- a/ddtrace/tracer/spancontext_deadlock_test.go
+++ b/ddtrace/tracer/spancontext_deadlock_test.go
@@ -8,8 +8,6 @@
 package tracer
 
 import (
-	"runtime"
-	"runtime/debug"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,28 +25,25 @@ import (
 // childA. childA.Finish() crosses the partial-flush threshold: s=childA, fSpan=root.
 // The buggy code would hold childA.mu while acquiring root.mu, which linkdata/deadlock
 // records as "childA.mu → root.mu" in its global ordering map. childB is left open so
-// the worker only releases childA to the pool (root is exempt from mid-trace recycling).
+// the partial flush fires mid-trace.
 //
-// Phase 2 needs to trigger the reverse ordering "root.mu → childA.mu" using the
-// same Span instances so the detector can find the existing edge and panic. The
-// pool-seeding approach seeds the global spanPool with [childA (private), root
-// (shared.head)] so that the next two StartSpan calls return them in swapped roles.
+// Phase 2 must trigger the reverse ordering "root.mu → childA.mu" on the *same two
+// Span instances so the detector finds the existing edge and panics. It reuses the
+// childA and root instances in swapped roles: newRoot is the childA instance and
+// newChildA is the root instance. newChildA.Finish() then crosses the threshold with
+// s=root, fSpan=childA, recording "root.mu → childA.mu" — the reverse of Phase 1 on
+// the same mutexes.
 //
-// Because sync.Pool gives no ordering guarantees (spanPool is process-global and
-// shared with the tracer worker, the Go runtime, and every other span-pool-enabled
-// tracer in the binary), seeding is wrapped in a bounded retry: the pool is
-// explicitly drained of stale/foreign entries, re-seeded in LIFO order, and the
-// returned instances are checked for pointer identity. On mismatch the attempt is
-// discarded and the loop retries. If all attempts are exhausted the test skips
-// with a diagnostic instead of failing non-deterministically.
-//
-// The same caveat applies to the final StartSpan acquisition. Single-threaded the
-// restore->acquire handoff is deterministic, but spanPool is process-global: any
-// other goroutine that performs a spanPool.Get in that window (every StartSpan on
-// a span-pool-enabled tracer in the binary does one) steals a seeded instance from
-// P0, and the acquiring Get then returns a different span. So the acquired
-// instances are likewise checked for identity and the test skips (after cleanup)
-// rather than failing if they diverge.
+// The two instances are fed back into StartSpan via the testAcquireSpan hook (see
+// span_pool_testhook.go). An earlier version recycled them through the global span
+// pool, but that flaked: spanPool is process-global, the tracer worker concurrently
+// Puts into it (confirmed by -race), and sync.Pool guarantees no Get/Put ordering or
+// identity — even single-threaded, with GOMAXPROCS=1 and GC disabled, a Put-then-Get
+// is not guaranteed to return the same instance once the pool has been churned across
+// multiple Ps by sibling tests. The hook sidesteps the pool entirely: it is read only
+// on the StartSpan path, which only this goroutine drives while the hook is set, so the
+// handoff is deterministic. The span pool is irrelevant to the lock-ordering being
+// tested, so this test does not enable it.
 //
 // Under the fixed code, s.mu is released before fSpan.mu is acquired, so neither
 // direction is ever recorded and the test passes cleanly.
@@ -56,128 +51,51 @@ func TestPartialFlushSpanLockOrderingCycle(t *testing.T) {
 	t.Setenv("DD_TRACE_PARTIAL_FLUSH_ENABLED", "true")
 	t.Setenv("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", "2")
 
-	tracer, transport, flush, stop, err := startTestTracer(t, WithSpanPool(true))
+	tracer, transport, flush, stop, err := startTestTracer(t)
 	require.NoError(t, err)
 	defer stop()
 
 	// Phase 1: establish ordering "childA.mu → root.mu".
-	// Three spans so partial flush fires while childB is still open, letting the
-	// worker release only childA to the pool (root is exempt from mid-trace
-	// recycling until the full trace is submitted; childB is still open).
+	// Three spans so the partial flush fires mid-trace, while childB is still open:
+	// that is the !finishingSpanIsFirstInChunk path where s=childA but fSpan=root.
 	root := tracer.StartSpan("root", Tag(ext.ManualKeep, true))
 	childA := tracer.StartSpan("childA", ChildOf(root.Context()))
 	childB := tracer.StartSpan("childB", ChildOf(root.Context()))
 
 	root.Finish()
 	childA.Finish() // triggers partial flush: s=childA (holds childA.mu), fSpan=root
-	// flush(1) waits until the worker has processed the partial-flush chunk and
-	// called releaseSpans, so childA is in the pool by the time flush returns.
-	// root is excluded from spansToRelease (the tracer keeps the trace-root span
-	// alive for the eventual full-trace submission), so it is NOT in the pool yet.
-	// childB is still open and has not been submitted at all.
 	flush(1)
 	transport.Traces()
 
-	// Phase 2: seed the pool with [childA, root] and acquire them back via StartSpan
-	// so they play swapped roles in a second partial-flush cycle.
+	// Phase 2: reuse the childA and root instances in swapped roles.
 	//
-	// GOMAXPROCS=1 pins all Put/Get calls to P0, making the LIFO order deterministic
-	// on the fast path.  SetGCPercent(-1) prevents GC from evicting seeded entries.
-	// Both are restored as soon as the instances are in hand.
-	//
-	// The acquisition is wrapped in a bounded retry loop because sync.Pool provides
-	// no ordering guarantees. Each iteration:
-	//   1. Clears both spans (idempotent; ensures clean state for StartSpan reuse).
-	//   2. Drains stale/foreign entries from the pool (private + shared + victim).
-	//   3. Seeds: childA → P0.private (Get #1), root → P0.shared.head (Get #2).
-	//   4. Calls StartSpan twice and checks pointer identity.
-	// On mismatch, the attempt's spans are abandoned and the loop retries.
-	// On exhaustion the test skips rather than flake-failing.
-	const (
-		poolDrainCount = 64 // clears private + shared + victim cache in any realistic scenario
-		maxAttempts    = 50
-	)
-
-	// Clear both spans before seeding. childA was already cleared by releaseSpans
-	// after Phase 1; root was not recycled and must be cleared so that
+	// Clear both spans before reuse so StartSpan can re-initialize them and so
 	// newChildA.Finish() does not exit early on the s.finished guard.
 	childA.clear()
 	root.clear()
 
-	// Verify pool ordering using raw Get calls — intentionally NOT via
-	// tracer.StartSpan — so that failed attempts do not create new Span/trace
-	// instances that flood the deadlock detector's lock-order map and cause
-	// flush timeouts. On each attempt:
-	//   1. Drain stale/foreign entries so P0's private+shared+victim are clear.
-	//   2. Seed: childA → P0.private (Get #1), root → P0.shared.head (Get #2).
-	//   3. Verify pointers via raw Get without initializing the spans.
-	//   4. On success, restore them to the pool so StartSpan can acquire them.
-	//   5. On failure, discard and retry. childA/root are kept alive by the
-	//      test variables, so discarding the raw Gets is safe.
-	numCPU := runtime.GOMAXPROCS(1)
-	prevGC := debug.SetGCPercent(-1)
-	var seeded bool
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		for i := 0; i < poolDrainCount; i++ {
-			spanPool.Get() //nolint:staticcheck // intentional pool drain; return value discarded
+	// Hand the two instances back to the next two StartSpan calls, in order:
+	// newRoot := childA instance, newChildA := root instance. testAcquireSpan is
+	// consulted only on the StartSpan path, which only this goroutine drives here,
+	// so no synchronization is needed; clear it immediately afterwards so the
+	// remaining spans allocate normally.
+	reuse := []*Span{childA, root}
+	testAcquireSpan = func() *Span {
+		if len(reuse) == 0 {
+			return nil
 		}
-		spanPool.Put(childA)
-		spanPool.Put(root)
-		got1 := spanPool.Get().(*Span) //nolint:staticcheck // raw identity check; span not initialized
-		got2 := spanPool.Get().(*Span) //nolint:staticcheck
-		if got1 == childA && got2 == root {
-			// Restore for StartSpan's Get calls below.
-			spanPool.Put(childA)
-			spanPool.Put(root)
-			seeded = true
-			break
-		}
-		// Wrong order: clear and retry. (got1/got2 are discarded safely.)
-		childA.clear()
-		root.clear()
-	}
-	if !seeded {
-		debug.SetGCPercent(prevGC)
-		runtime.GOMAXPROCS(numCPU)
-		t.Skipf("span pool did not return the expected instances in %d attempts; "+
-			"skipping deadlock-cycle check", maxAttempts)
+		s := reuse[0]
+		reuse = reuse[1:]
+		return s
 	}
 
-	// Acquire the instances via StartSpan while GOMAXPROCS=1 and GC are still
-	// active.
-	//
-	// Single-threaded this handoff is deterministic: the verification above left
-	// childA in P0.private and root in P0.shared, so the two StartSpan Gets return
-	// them in order. But spanPool is process-global. If any other goroutine runs a
-	// spanPool.Get in the window between the restore above and these Gets, it pops
-	// childA out of P0.private and the first Get here returns root (or a fresh
-	// span) instead — every StartSpan on a span-pool-enabled tracer in the binary
-	// does exactly one Get, and GOMAXPROCS=1 does not prevent that goroutine from
-	// being scheduled. When the seeded pair does not come back the swapped-role
-	// reverse-ordering scenario can no longer be built on the same Span pointers,
-	// so we clean up and skip rather than fail non-deterministically — consistent
-	// with the seeding-exhaustion skip above. On the cooperative happy path the
-	// seeded instances come back and the cycle is exercised.
 	newRoot := tracer.StartSpan("newRoot", Tag(ext.ManualKeep, true))
 	newChildA := tracer.StartSpan("newChildA", ChildOf(newRoot.Context()))
-	debug.SetGCPercent(prevGC)
-	runtime.GOMAXPROCS(numCPU)
+	testAcquireSpan = nil
 
-	if newRoot != childA || newChildA != root {
-		// The seeded pair did not come back (another goroutine touched the global
-		// pool). Tear down the spans we created plus the still-open Phase 1 span,
-		// then skip. Clearing rootFlushed keeps Phase 1's full-trace flush from
-		// recycling root a second time (root's fate is already decided by the
-		// StartSpan Gets above, exactly as on the happy path below).
-		childB.context.trace.mu.Lock()
-		childB.context.trace.rootFlushed = false
-		childB.context.trace.mu.Unlock()
-		newChildA.Finish()
-		newRoot.Finish()
-		childB.Finish()
-		t.Skip("span pool returned unexpected instances after seeding " +
-			"(concurrent pool access); skipping deadlock-cycle check")
-	}
+	require.Same(t, childA, newRoot)
+	require.Same(t, root, newChildA)
+
 	newChildB := tracer.StartSpan("newChildB", ChildOf(newRoot.Context()))
 
 	newRoot.Finish()   // childA instance is now finishedSpans[0] = fSpan
@@ -186,15 +104,6 @@ func TestPartialFlushSpanLockOrderingCycle(t *testing.T) {
 	// and finds the earlier "childA.mu → root.mu" entry — AB/BA cycle.
 	flush(1)
 	transport.Traces()
-
-	// Prevent double-put: Phase 1's trace has rootFlushed=true, meaning it will
-	// try to recycle root (via spansToRelease) when childB.Finish() completes
-	// the trace. But Phase 2's partial flush above already recycled root. Clear
-	// rootFlushed so the Phase 1 full-trace flush does not put root back in the
-	// pool a second time.
-	childB.context.trace.mu.Lock()
-	childB.context.trace.rootFlushed = false
-	childB.context.trace.mu.Unlock()
 
 	// Cleanup: finish the two leftover spans.
 	childB.Finish()


### PR DESCRIPTION
### What does this PR do?

De-flakes `TestPartialFlushSpanLockOrderingCycle` (`ddtrace/tracer`, `//go:build deadlock`) by removing its dependency on `sync.Pool` ordering.

The test reuses two specific `*Span` instances (`childA`, `root`) in swapped roles so the deadlock detector records the reverse lock-ordering edge on the *same mutexes*. It previously did this by seeding the process-global `spanPool` and relying on `sync.Pool` to hand the instances back in order, wrapped in a `GOMAXPROCS(1)` + `SetGCPercent(-1)` + drain + 50-attempt retry + skip-on-mismatch dance.

This PR replaces all of that with a small, build-tag-gated test hook:

- `span_pool_testhook.go` (`//go:build deadlock`): `testAcquireSpan` + `maybeTestAcquireSpan()`.
- `span_pool_testhook_off.go` (`//go:build !deadlock`): a no-op `maybeTestAcquireSpan()` that returns `nil`, is inlined, and the dead branch in `acquireSpan` is eliminated — **zero hot-path cost in normal builds**.
- `span_pool.go`: `acquireSpan` consults the hook first.

The test installs the hook to return `childA` then `root` for the two Phase-2 `StartSpan` calls, asserts identity with `require.Same`, and no longer enables `WithSpanPool` (the pool is irrelevant to the lock ordering under test). The handoff is now fully deterministic — no retry, no skip.

### Motivation

The flake was investigated end-to-end and the original "a concurrent goroutine steals a seeded pool entry" hypothesis was **disproven**:

- Instrumenting `acquireSpan` showed **zero foreign `spanPool.Get`** during the window across thousands of runs, including the failing ones. `spanPool.Get` is reachable only via `StartSpan`, and no background goroutine starts spans during the test.
- A standalone repro proved the real cause: single-threaded `Put(childA); Put(root); Get(); Get()` under `GOMAXPROCS(1)` + GC-off mismatches **~45%** once the pool has been churned across multiple Ps by sibling span-pool tests, and **0%** on a fresh pool. `sync.Pool` guarantees no Get/Put ordering or identity; `GOMAXPROCS(1)` + GC-off do not make a churned pool deterministic.
- The only concurrent pool actor is the tracer's own worker (`releaseSpans` → `spanPool.Put`, confirmed by `-race`); it only ever `Put`s, never steals.

Since the pool was only the reuse vehicle and the deadlock edge in `finishedOneLocked` is pool-independent, bypassing the pool eliminates the flake at its root.

### Testing

- Passes under `-race -tags deadlock` isolated, in the span-pool subset, and in the full `ddtrace/tracer` package (20/20 + 15/15 + full-package runs; no skips, no data races).
- Confirmed the test still has teeth: reintroducing the partial-flush lock-ordering bug (nesting `fSpan.mu` inside `s.mu` in `finishedOneLocked`) makes the detector fire and the test fail.
- Builds cleanly without the `deadlock` tag.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage. *(Test-only change; behavior verified by bug-injection.)*
- [ ] System-Tests covering this feature have been added. *(N/A — test de-flake.)*
- [ ] There is a benchmark for any new code. *(N/A — no new production behavior; the test hook is inlined away in normal builds.)*
- [ ] If this interacts with the agent in a new way, a system test has been added. *(N/A.)*
- [x] New code is free of linting errors.
- [x] New code doesn't break existing tests.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date.
- [x] Non-trivial go.mod changes reviewed. *(N/A — no go.mod changes.)*