### PR TITLE
fix(smoke-tests): pin amazonlinux:2 digest and block Dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,4 +60,3 @@ updates:
       # Allowing Dependabot to update this digest risks silently switching to
       # AL2023 if the :2 tag is ever redirected, which would remove AL2 coverage.
       - dependency-name: "amazonlinux"
-        versions: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,10 +56,11 @@ updates:
     cooldown:
       default-days: 2
     ignore:
-      # amazonlinux:2 is pinned to a specific AL2 (glibc 2.26) digest.
-      # Allowing Dependabot to update this digest risks silently switching to
-      # AL2023 if the :2 tag is ever redirected, which would remove AL2 coverage.
-      # versions: ["= 2"] scopes this ignore to the :2 tag only, so Dependabot
-      # still proposes digest refreshes for amazonlinux:2023.
+      # amazonlinux:2 is pinned to a specific AL2 (glibc 2.26) digest and must
+      # never be upgraded to AL2023 (glibc 2.34).  Omitting `versions` blocks
+      # ALL Dependabot updates for this image — both digest refreshes of :2 and
+      # any tag-change PR proposing :2023 — because a version-scoped rule like
+      # "= 2" would still permit a :2 → :2023 tag upgrade.  The :2023 stage in
+      # the same Dockerfile is unpinned and always pulls the current :2023 at
+      # build time, so losing automated digest updates there is acceptable.
       - dependency-name: "amazonlinux"
-        versions: ["= 2"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,4 +59,7 @@ updates:
       # amazonlinux:2 is pinned to a specific AL2 (glibc 2.26) digest.
       # Allowing Dependabot to update this digest risks silently switching to
       # AL2023 if the :2 tag is ever redirected, which would remove AL2 coverage.
+      # versions: ["= 2"] scopes this ignore to the :2 tag only, so Dependabot
+      # still proposes digest refreshes for amazonlinux:2023.
       - dependency-name: "amazonlinux"
+        versions: ["= 2"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,3 +55,9 @@ updates:
       - "dependencies"
     cooldown:
       default-days: 2
+    ignore:
+      # amazonlinux:2 is pinned to a specific AL2 (glibc 2.26) digest.
+      # Allowing Dependabot to update this digest risks silently switching to
+      # AL2023 if the :2 tag is ever redirected, which would remove AL2 coverage.
+      - dependency-name: "amazonlinux"
+        versions: ["*"]

--- a/internal/setup-smoke-test/Dockerfile
+++ b/internal/setup-smoke-test/Dockerfile
@@ -95,7 +95,9 @@ CMD ["/usr/local/bin/smoke-test"]
 # IMPORTANT NOTE: Nothing else than the compiled program must be copied into
 # this image to preperly highlight the fact that the compiled program is running
 # out of the box in it without any further installation.
-FROM amazonlinux:2 AS al2
+# Digest pinned to AL2 (glibc 2.26) — do NOT let Dependabot update this to AL2023.
+# See .github/dependabot.yml ignore rule for amazonlinux.
+FROM amazonlinux:2@sha256:2582ac21e3f770177b45f8c9eb9e43b3a3034e2d2021c2a4ec97e2715f9c93b2 AS al2
 COPY --from=build-env /src/internal/setup-smoke-test/smoke-test /usr/local/bin
 CMD ["/usr/local/bin/smoke-test"]
 


### PR DESCRIPTION
## Summary

- Pins the `amazonlinux:2` base image in [`internal/setup-smoke-test/Dockerfile`](internal/setup-smoke-test/Dockerfile) to a specific SHA256 digest verified to be genuine Amazon Linux 2 (VERSION=2, glibc 2.26).
- Adds a Dependabot `ignore` rule in [`.github/dependabot.yml`](.github/dependabot.yml) for `amazonlinux` so the digest pin is never automatically updated.

## Why

The `al2` smoke-test matrix jobs (`deployment-env: al2`) rely on the `amazonlinux:2` tag to exercise glibc 2.26 compatibility. Without a pinned digest, Dependabot (or an upstream tag redirect by Amazon) can silently swap the AL2 base image for AL2023, meaning the `al2` jobs would duplicate `al2023` coverage while glibc 2.26 regressions go undetected.

Pinning to the digest freezes the image at a known-good AL2 state; blocking Dependabot prevents automated PRs from moving the pin forward to whatever `:2` resolves to in the future.

## Reviewer notes

- The pinned digest (`sha256:2582ac21e3f770177b45f8c9eb9e43b3a3034e2d2021c2a4ec97e2715f9c93b2`) was verified locally: `docker run --rm amazonlinux:2 cat /etc/os-release` reports `VERSION="2"`.
- The Dependabot ignore applies to all versions (`["*"]`) so that even a patch-level digest bump for AL2 does not sneak through — the pin should only move intentionally via a manual PR.
- Amazon Linux 2 support ends 2026-06-30; at that point the `al2` matrix leg can be retired rather than updated.