### PR TITLE
test(civisibility): cover JSON retry recovery

### DIFF
--- a/internal/civisibility/utils/net/http_test.go
+++ b/internal/civisibility/utils/net/http_test.go
@@ -13,6 +13,7 @@ import (
 	stdnet "net"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -800,6 +801,45 @@ func TestSendRequestExpectJSONResponseRetriesOnUnknownFormat(t *testing.T) {
 	assert.NotNil(t, resp2)
 	assert.Equal(t, "unknown", resp2.Format)
 	assert.Equal(t, 1, calls, "expected exactly 1 call without retry")
+}
+
+func TestSendRequestExpectJSONResponseRecoversAfterUnknownFormat(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			w.Header().Set(HeaderContentType, "text/plain")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("not json"))
+			return
+		}
+
+		w.Header().Set(HeaderContentType, ContentTypeJSON)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer ts.Close()
+
+	handler := NewRequestHandlerWithClient(createNewHTTPClient())
+	config := RequestConfig{
+		Method:             "GET",
+		URL:                ts.URL,
+		MaxRetries:         2,
+		Backoff:            1,
+		ExpectJSONResponse: true,
+	}
+
+	resp, err := handler.SendRequest(config)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, FormatJSON, resp.Format)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(2), calls.Load(), "expected retry to recover on the second call")
+
+	var data map[string]bool
+	require.NoError(t, resp.Unmarshal(&data))
+	assert.True(t, data["ok"])
 }
 
 func TestPrepareContentWithNonByteContentForOctetStream(t *testing.T) {

--- a/internal/civisibility/utils/net/http_test.go
+++ b/internal/civisibility/utils/net/http_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1023,6 +1024,45 @@ func TestSendRequestExpectJSONResponseRetriesOnUnknownFormat(t *testing.T) {
 	assert.NotNil(t, resp2)
 	assert.Equal(t, "unknown", resp2.Format)
 	assert.Equal(t, 1, calls, "expected exactly 1 call without retry")
+}
+
+func TestSendRequestExpectJSONResponseRecoversAfterUnknownFormat(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			w.Header().Set(HeaderContentType, "text/plain")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("not json"))
+			return
+		}
+
+		w.Header().Set(HeaderContentType, ContentTypeJSON)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer ts.Close()
+
+	handler := NewRequestHandlerWithClient(createNewHTTPClient())
+	config := RequestConfig{
+		Method:             "GET",
+		URL:                ts.URL,
+		MaxRetries:         2,
+		Backoff:            1,
+		ExpectJSONResponse: true,
+	}
+
+	resp, err := handler.SendRequest(config)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, FormatJSON, resp.Format)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(2), calls.Load(), "expected retry to recover on the second call")
+
+	var data map[string]bool
+	require.NoError(t, resp.Unmarshal(&data))
+	assert.True(t, data["ok"])
 }
 
 func TestPrepareContentWithNonByteContentForOctetStream(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds the recovery-path unit test Tony suggested on merged PR #4917.

The existing test covered the retry-exhaustion path for repeated 2xx non-JSON responses and the default behavior when `ExpectJSONResponse` is false. This adds coverage for the main transient recovery scenario: the first 2xx response has a non-JSON `Content-Type`, then a retry returns a valid 2xx JSON response and succeeds.

## Validation

- `go test ./internal/civisibility/utils/net -run 'TestSendRequestExpectJSONResponse(RetriesOnUnknownFormat|RecoversAfterUnknownFormat)$' -count=1`
- `git diff --check`

Note: full `go test ./internal/civisibility/utils/net/... -count=1` failed locally in existing `TestNewClient_DefaultValues` with `Expected serviceName to be set, got empty string`, plus CI Visibility agentless API key logging. The targeted retry tests pass.