### PR TITLE
feat(tracer): add WithStatsdClient option for sharing statsd clients

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -1000,9 +1000,13 @@ func WithDogstatsdAddr(addr string) StartOption {
 // WithStatsdClient sets a custom statsd client to be used by the tracer for
 // internal metrics. When set, the tracer will not create its own statsd client,
 // allowing callers to share a single client across the tracer and application code.
-func WithStatsdClient(client internal.StatsdClient) StartOption {
+// The client must satisfy internal.StatsdClient; *statsd.ClientDirect from
+// github.com/DataDog/datadog-go/v5 satisfies this requirement.
+func WithStatsdClient(client statsd.ClientInterface) StartOption {
 	return func(cfg *config) {
-		cfg.statsdClient = client
+		if c, ok := client.(internal.StatsdClient); ok {
+			cfg.statsdClient = c
+		}
 	}
 }
 

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -997,6 +997,15 @@ func WithDogstatsdAddr(addr string) StartOption {
 	}
 }
 
+// WithStatsdClient sets a custom statsd client to be used by the tracer for
+// internal metrics. When set, the tracer will not create its own statsd client,
+// allowing callers to share a single client across the tracer and application code.
+func WithStatsdClient(client internal.StatsdClient) StartOption {
+	return func(cfg *config) {
+		cfg.statsdClient = client
+	}
+}
+
 // WithSamplingRules specifies the sampling rates to apply to spans based on the
 // provided rules.
 func WithSamplingRules(rules []SamplingRule) StartOption {

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -1000,10 +1000,10 @@ func WithDogstatsdAddr(addr string) StartOption {
 // WithStatsdClient sets a custom statsd client to be used by the tracer for
 // internal metrics. When set, the tracer will not create its own statsd client,
 // allowing callers to share a single client across the tracer and application code.
-// The client must satisfy internal.StatsdClient; *statsd.ClientDirect from
-// github.com/DataDog/datadog-go/v5 satisfies this requirement.
 func WithStatsdClient(client statsd.ClientInterface) StartOption {
 	return func(cfg *config) {
+		// The client must satisfy internal.StatsdClient; *statsd.ClientDirect from
+		// github.com/DataDog/datadog-go/v5 satisfies this requirement.
 		if c, ok := client.(internal.StatsdClient); ok {
 			cfg.statsdClient = c
 		}

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -997,16 +997,21 @@ func WithDogstatsdAddr(addr string) StartOption {
 	}
 }
 
+// StatsdClient is the method set the tracer needs from an injected statsd
+// client. *statsd.ClientDirect from github.com/DataDog/datadog-go/v5 satisfies
+// this at compile time, so passing an incompatible type is a build error
+// rather than a silent no-op.
+type StatsdClient interface {
+	statsd.ClientInterface
+	statsd.ClientDirectInterface
+}
+
 // WithStatsdClient sets a custom statsd client to be used by the tracer for
 // internal metrics. When set, the tracer will not create its own statsd client,
 // allowing callers to share a single client across the tracer and application code.
-func WithStatsdClient(client statsd.ClientInterface) StartOption {
+func WithStatsdClient(client StatsdClient) StartOption {
 	return func(cfg *config) {
-		// The client must satisfy internal.StatsdClient; *statsd.ClientDirect from
-		// github.com/DataDog/datadog-go/v5 satisfies this requirement.
-		if c, ok := client.(internal.StatsdClient); ok {
-			cfg.statsdClient = c
-		}
+		cfg.statsdClient = client
 	}
 }
 

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -221,6 +221,22 @@ func TestAutoDetectStatsd(t *testing.T) {
 	})
 }
 
+func TestWithStatsdClient(t *testing.T) {
+	// Create a real *statsd.ClientDirect — it satisfies both statsd.ClientInterface
+	// and internal.StatsdClient, which is the contract WithStatsdClient documents.
+	client, err := statsd.NewDirect("localhost:8125", statsd.WithMaxMessagesPerPayload(40))
+	require.NoError(t, err)
+	defer client.Close()
+
+	cfg, err := newTestConfig(WithStatsdClient(client))
+	require.NoError(t, err)
+
+	// The injected client should be used directly instead of creating a new one.
+	got, err := newStatsdClient(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, client, got, "WithStatsdClient: tracer should use the provided client")
+}
+
 func TestInternalMetricsDisabled(t *testing.T) {
 	isNoop := func(c internal.StatsdClient) bool {
 		_, ok := c.(*statsd.NoOpClientDirect)


### PR DESCRIPTION
## Summary

Exposes `WithStatsdClient` as a public `StartOption` so callers can inject a pre-existing statsd client into the tracer instead of having it create its own.

## Motivation

The tracer unconditionally creates its own `*statsd.ClientDirect` via `internal.NewStatsdClient`. In services that already have a statsd client (e.g. via application-level initialization), this results in two independent clients, two buffer pools, two UDS connections, and two sets of goroutines — all for the same agent endpoint.

The injectable field (`config.statsdClient`) and the short-circuit path in `newStatsdClient` already existed (used by `WithTestDefaults` in tests). This PR simply makes that path available to production callers.

## Change

Adds `WithStatsdClient(client StatsdClient) StartOption` in `ddtrace/tracer/option.go`, plus a test. No other files changed.

```go
// StatsdClient is the method set the tracer needs from an injected statsd
// client. *statsd.ClientDirect from github.com/DataDog/datadog-go/v5 satisfies
// this at compile time, so passing an incompatible type is a build error
// rather than a silent no-op.
type StatsdClient interface {
    statsd.ClientInterface
    statsd.ClientDirectInterface
}

// WithStatsdClient sets a custom statsd client to be used by the tracer for
// internal metrics. When set, the tracer will not create its own statsd client,
// allowing callers to share a single client across the tracer and application code.
func WithStatsdClient(client StatsdClient) StartOption {
    return func(cfg *config) {
        cfg.statsdClient = client
    }
}
```

**Why a new exported `StatsdClient` interface instead of `statsd.ClientInterface` directly?** The tracer's internal client type (`internal.StatsdClient`) requires 9 methods: `Incr`, `Count`, `CountWithTimestamp`, `Gauge`, `GaugeWithTimestamp`, `DistributionSamples`, `Timing`, `Flush`, `Close`. The public `statsd.ClientInterface` covers 8 of those but is missing `DistributionSamples`, which only lives on the separate public `statsd.ClientDirectInterface`. Neither public interface alone is sufficient, and there's no existing public type in `datadog-go/v5/statsd` that combines them.

An earlier version of this PR accepted the plain `statsd.ClientInterface` and used a runtime type assertion (`client.(internal.StatsdClient)`) to bridge the gap, silently falling back to the tracer's own client if the assertion failed. That's a footgun: passing a client missing `DistributionSamples` (e.g. the base `*statsd.Client` instead of `*statsd.ClientDirect`) compiled fine but silently discarded the injected client with no error.

The new `StatsdClient` interface embeds `statsd.ClientInterface` + `statsd.ClientDirectInterface`, whose combined method set exactly matches `internal.StatsdClient`. Go verifies interface-to-interface assignability structurally at compile time, so `cfg.statsdClient = client` now requires the caller's concrete type to satisfy the full set — an incompatible client is a build error naming the missing method, not a silent no-op.

## Test

`TestWithStatsdClient` in `option_test.go` creates a real `*statsd.ClientDirect`, passes it via `WithStatsdClient`, calls `newStatsdClient`, and asserts the same client is returned rather than a new one being created.

---

## Related PRs (APII-1294)

- **[DataDog/dd-source#475509](https://github.com/DataDog/dd-source/pull/475509)** — `WithDynamicBuffers`: scale buffer pool with GOMAXPROCS
- **[DataDog/dd-source#476809](https://github.com/DataDog/dd-source/pull/476809)** — Unify statsd clients: eliminate redundant pools, add `NewTaggedClient`
- **[DataDog/dd-trace-go#4935](https://github.com/DataDog/dd-trace-go/pull/4935)** — This PR: expose `WithStatsdClient` so dd-source can inject a shared client into the tracer

## Staging Measurements

**[Staging notebook](https://ddstaging.datadoghq.com/notebook/14842169)** — gc_heap_live, gc_cpu_fraction, gc_cycles rate, heap-live-size profiling, and drop-safety across all test drives.