### PR TITLE
feat(contrib/mark3labs/mcp-go): support intent capture for tools using RawInputSchema

### DIFF
--- a/contrib/mark3labs/mcp-go/intent_capture.go
+++ b/contrib/mark3labs/mcp-go/intent_capture.go
@@ -7,6 +7,7 @@ package mcpgo
 
 import (
 	"context"
+	"encoding/json"
 	"maps"
 	"slices"
 
@@ -44,8 +45,10 @@ func injectTelemetryListToolsHook(ctx context.Context, id any, message *mcp.List
 		t := &result.Tools[i]
 
 		if t.RawInputSchema != nil {
-			instr.Logger().Warn("mcp-go intent capture: raw input schema not supported")
-			continue
+			if err := json.Unmarshal(t.RawInputSchema, &t.InputSchema); err != nil {
+				continue
+			}
+			t.RawInputSchema = nil
 		}
 
 		if t.InputSchema.Type == "" {

--- a/contrib/mark3labs/mcp-go/intent_capture_test.go
+++ b/contrib/mark3labs/mcp-go/intent_capture_test.go
@@ -92,6 +92,51 @@ func TestIntentCapture(t *testing.T) {
 	assert.Equal(t, "test intent description", toolSpan.Meta["intent"])
 }
 
+func TestIntentCaptureRawInputSchema(t *testing.T) {
+	tt := testTracer(t)
+	defer tt.Stop()
+
+	srv := server.NewMCPServer("test-server", "1.0.0", WithMCPServerTracing(&TracingConfig{IntentCaptureEnabled: true}))
+
+	rawSchema := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"insight_name": {"type": "string", "description": "The insight to retrieve"},
+			"app_id": {"type": "string", "description": "The application ID"}
+		},
+		"required": ["insight_name", "app_id"]
+	}`)
+
+	rawTool := mcp.NewToolWithRawSchema("raw_tool", "A tool with raw schema", rawSchema)
+	srv.AddTool(rawTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText(`{"ok":true}`), nil
+	})
+
+	ctx := context.Background()
+
+	listResp := srv.HandleMessage(ctx, []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`))
+	var listResult map[string]interface{}
+	err := json.Unmarshal(json.RawMessage(mustMarshal(listResp)), &listResult)
+	require.NoError(t, err)
+
+	result := listResult["result"].(map[string]interface{})
+	tools := result["tools"].([]interface{})
+	require.Len(t, tools, 1)
+
+	tool := tools[0].(map[string]interface{})
+	schema := tool["inputSchema"].(map[string]interface{})
+	props := schema["properties"].(map[string]interface{})
+
+	assert.Contains(t, props, "insight_name")
+	assert.Contains(t, props, "app_id")
+	assert.Contains(t, props, "telemetry")
+
+	required := schema["required"].([]interface{})
+	assert.Contains(t, required, "insight_name")
+	assert.Contains(t, required, "app_id")
+	assert.Contains(t, required, "telemetry")
+}
+
 func TestIntentCaptureConcurrentListTools(t *testing.T) {
 	tt := testTracer(t)
 	defer tt.Stop()


### PR DESCRIPTION
This PR stack ports functionality added in the clone of this contrib in dd-source back to dd-trace-go.

## Summary

Tools defined with `WithInputSchema[T]()` use `RawInputSchema` (`json.RawMessage`) instead of the structured `InputSchema`. The intent-capture `ListTools` hook was skipping these tools with a log warning, so they never received the `telemetry.intent` parameter in their schema.

This change normalizes `RawInputSchema` into `InputSchema` before injection by unmarshalling the JSON into the structured fields. The existing code path then handles both schema formats uniformly.

Ported from internal dd-source PR [#413963](https://github.com/DataDog/dd-source/pull/413963).

## Test plan

- [x] Added `TestIntentCaptureRawInputSchema` exercising a tool registered via `mcp.NewToolWithRawSchema` — verifies its own properties and the injected `telemetry` field both end up in the advertised schema.
- [x] `go test ./...` in `contrib/mark3labs/mcp-go/v2` is green.