### PR TITLE
fix(contrib/mark3labs/mcp-go): avoid map race when normalizing RawInputSchema

### DIFF
--- a/contrib/mark3labs/mcp-go/intent_capture.go
+++ b/contrib/mark3labs/mcp-go/intent_capture.go
@@ -45,9 +45,11 @@ func injectTelemetryListToolsHook(ctx context.Context, id any, message *mcp.List
 		t := &result.Tools[i]
 
 		if t.RawInputSchema != nil {
-			if err := json.Unmarshal(t.RawInputSchema, &t.InputSchema); err != nil {
+			var schema mcp.ToolInputSchema
+			if err := json.Unmarshal(t.RawInputSchema, &schema); err != nil {
 				continue
 			}
+			t.InputSchema = schema
 			t.RawInputSchema = nil
 		}
 

--- a/contrib/mark3labs/mcp-go/intent_capture_test.go
+++ b/contrib/mark3labs/mcp-go/intent_capture_test.go
@@ -172,6 +172,45 @@ func TestIntentCaptureConcurrentListTools(t *testing.T) {
 	}
 }
 
+func TestIntentCaptureConcurrentListToolsRawInputSchema(t *testing.T) {
+	tt := testTracer(t)
+	defer tt.Stop()
+
+	srv := server.NewMCPServer("test-server", "1.0.0", WithMCPServerTracing(&TracingConfig{IntentCaptureEnabled: true}))
+
+	rawSchema := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"insight_name": {"type": "string", "description": "The insight to retrieve"},
+			"app_id": {"type": "string", "description": "The application ID"}
+		},
+		"required": ["insight_name", "app_id"]
+	}`)
+
+	rawTool := mcp.NewToolWithRawSchema("raw_tool", "A tool with raw schema", rawSchema)
+	srv.AddTool(rawTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText(`{"ok":true}`), nil
+	})
+
+	ctx := context.Background()
+
+	const numGoroutines = 10
+	done := make(chan struct{})
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			for j := 0; j < 100; j++ {
+				srv.HandleMessage(ctx, []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`))
+			}
+		}()
+	}
+
+	for i := 0; i < numGoroutines; i++ {
+		<-done
+	}
+}
+
 func mustMarshal(v interface{}) []byte {
 	b, _ := json.Marshal(v)
 	return b


### PR DESCRIPTION
This PR stack ports functionality added in the clone of this contrib in dd-source back to dd-trace-go.

## Summary

Follow-up to #4939. That change unmarshalled `RawInputSchema` directly into `&t.InputSchema`, which could leave shared nested map references from server-reused tool definitions. Under true parallelism, concurrent `tools/list` requests could write the same map and crash with `fatal error: concurrent map writes`.

This change unmarshals into a fresh local `mcp.ToolInputSchema` value, then assigns it to `t.InputSchema`. The existing `maps.Clone` of `InputSchema.Properties` remains as defense in depth.

Ported from internal dd-source PR [#469693](https://github.com/DataDog/dd-source/pull/469693).

## Test plan

- [x] Added `TestIntentCaptureConcurrentListToolsRawInputSchema` — 10 goroutines × 100 `tools/list` calls against a raw-schema tool, run under `-race`.
- [x] `go test -race ./...` in `contrib/mark3labs/mcp-go/v2` is green.

Stacked on #4939.