### PR TITLE
feat(contrib/mark3labs/mcp-go): skip telemetry injection for UI-only tools

### DIFF
--- a/contrib/mark3labs/mcp-go/intent_capture.go
+++ b/contrib/mark3labs/mcp-go/intent_capture.go
@@ -44,6 +44,18 @@ func injectTelemetryListToolsHook(ctx context.Context, id any, message *mcp.List
 	for i := range result.Tools {
 		t := &result.Tools[i]
 
+		// UI-only tools (_meta.ui.visibility without "model") are invoked by the
+		// app UI, not by the model. OpenAI's MCP client strictly validates tool
+		// arguments against the advertised schema, so injecting telemetry as
+		// required would break UI calls that legitimately omit it.
+		var toolMeta map[string]any
+		if t.Meta != nil {
+			toolMeta = t.Meta.AdditionalFields
+		}
+		if !instrmcp.IsModelCallable(toolMeta) {
+			continue
+		}
+
 		// mcp.ToolInputSchema only models type/properties/required/$defs;
 		// for tools defined with NewToolWithRawSchema we mutate the raw
 		// JSON via a generic map so keywords like additionalProperties,

--- a/contrib/mark3labs/mcp-go/intent_capture_test.go
+++ b/contrib/mark3labs/mcp-go/intent_capture_test.go
@@ -100,6 +100,68 @@ func TestIntentCapture(t *testing.T) {
 	assert.Equal(t, "test intent description", toolSpan.Meta["intent"])
 }
 
+func TestIntentCaptureSkipsUIOnlyTools(t *testing.T) {
+	tt := testTracer(t)
+	defer tt.Stop()
+
+	srv := server.NewMCPServer("test-server", "1.0.0", WithMCPServerTracing(&TracingConfig{IntentCaptureEnabled: true}))
+
+	modelTool := mcp.NewTool("model_tool",
+		mcp.WithDescription("model-callable"),
+		mcp.WithString("q", mcp.Required()))
+	srv.AddTool(modelTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("ok"), nil
+	})
+
+	uiTool := mcp.NewTool("ui_tool",
+		mcp.WithDescription("UI-only"),
+		mcp.WithString("q", mcp.Required()))
+	uiTool.Meta = &mcp.Meta{AdditionalFields: map[string]any{"ui": map[string]any{"visibility": []string{"app"}}}}
+	srv.AddTool(uiTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("ok"), nil
+	})
+
+	dualTool := mcp.NewTool("dual_tool",
+		mcp.WithDescription("Model and UI"),
+		mcp.WithString("q", mcp.Required()))
+	dualTool.Meta = &mcp.Meta{AdditionalFields: map[string]any{"ui": map[string]any{"visibility": []string{"app", "model"}}}}
+	srv.AddTool(dualTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("ok"), nil
+	})
+
+	ctx := context.Background()
+	listResp := srv.HandleMessage(ctx, []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`))
+	var listResult map[string]interface{}
+	require.NoError(t, json.Unmarshal(mustMarshal(listResp), &listResult))
+
+	tools := listResult["result"].(map[string]interface{})["tools"].([]interface{})
+	require.Len(t, tools, 3)
+
+	byName := map[string]map[string]interface{}{}
+	for _, raw := range tools {
+		tool := raw.(map[string]interface{})
+		byName[tool["name"].(string)] = tool["inputSchema"].(map[string]interface{})
+	}
+
+	// Model-callable tools get telemetry injected.
+	for _, name := range []string{"model_tool", "dual_tool"} {
+		schema := byName[name]
+		require.NotNil(t, schema, name)
+		props := schema["properties"].(map[string]interface{})
+		assert.Contains(t, props, "telemetry", "%s should have telemetry", name)
+		assert.Contains(t, schema["required"].([]interface{}), "telemetry", "%s should require telemetry", name)
+	}
+
+	// UI-only tool does NOT.
+	uiSchema := byName["ui_tool"]
+	require.NotNil(t, uiSchema)
+	props := uiSchema["properties"].(map[string]interface{})
+	assert.NotContains(t, props, "telemetry")
+	if req, ok := uiSchema["required"].([]interface{}); ok {
+		assert.NotContains(t, req, "telemetry")
+	}
+}
+
 func TestIntentFromContext(t *testing.T) {
 	ctx := context.Background()
 

--- a/instrumentation/mcp/mcp.go
+++ b/instrumentation/mcp/mcp.go
@@ -5,6 +5,8 @@
 
 package mcp
 
+import "slices"
+
 const TelemetryKey = "telemetry"
 
 const IntentKey = "intent"
@@ -17,3 +19,40 @@ const MCPMethodTag = "mcp_method"
 const MCPSessionIDTag = "mcp_session_id"
 const MCPClientNameTag = "client_name"
 const MCPClientVersionTag = "client_version"
+
+// IsModelCallable reports whether a tool's _meta permits the model to call it.
+// Absent _meta.ui.visibility means model-callable (MCP Apps spec default); a
+// visibility list that omits "model" means UI-only and the model should not
+// be asked to supply telemetry/intent for it.
+//
+// Callers pass the raw _meta map regardless of SDK wrapping: mark3labs/mcp-go
+// stores it as mcp.Meta.AdditionalFields; modelcontextprotocol/go-sdk uses
+// mcp.Meta directly (which is map[string]any).
+//
+// See https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/SEP-1865.md
+func IsModelCallable(meta map[string]any) bool {
+	if meta == nil {
+		return true
+	}
+	uiMap, ok := meta["ui"].(map[string]any)
+	if !ok {
+		return true
+	}
+	raw, ok := uiMap["visibility"]
+	if !ok {
+		return true
+	}
+	switch v := raw.(type) {
+	case []string:
+		return slices.Contains(v, "model")
+	case []any:
+		for _, item := range v {
+			if s, ok := item.(string); ok && s == "model" {
+				return true
+			}
+		}
+		return false
+	default:
+		return true
+	}
+}


### PR DESCRIPTION
This PR stack ports functionality added in the clone of this contrib in dd-source back to dd-trace-go.

## Summary

The intent-capture `ListTools` hook unconditionally adds `telemetry` as a required field to every tool's input schema. That breaks tools annotated as UI-only (`_meta.ui.visibility` excluding `"model"`): they are invoked by the app UI, not by the model, so the UI caller has no `intent` to supply. OpenAI's MCP client strictly validates tool arguments against the advertised schema and rejects every UI-driven call as a result.

This change adds an `isModelCallable` helper that inspects `*mcp.Meta.AdditionalFields["ui"]["visibility"]` (handling both `[]string` and `[]any` shapes from JSON round-trips) and short-circuits the injection when the model is not in the visibility list. Tools with no `_meta.ui.visibility` continue to default to model-callable per the MCP Apps spec.

Ported from internal dd-source PR [#420911](https://github.com/DataDog/dd-source/pull/420911).

## Test plan

- [x] `TestIntentCaptureSkipsUIOnlyTools` — three tools (model-only, UI-only `[app]`, dual `[app, model]`); asserts `telemetry` is injected for model and dual but not for UI-only.
- [x] Existing intent-capture tests still pass.

Stacked on #4941.

## MCP standard reference

The `_meta.ui.visibility` field is part of the official [MCP Apps extension](https://modelcontextprotocol.io/extensions/apps/overview). Values: `["model", "app"]` (default), `["model"]`, or `["app"]` — they control which actor may invoke the tool. UI-only tools (`["app"]`) are invoked by the host shell, never by the model. This PR's skip logic respects that standard.

---

Parallel port in the modelcontextprotocol/go-sdk contrib: #4949
