### PR TITLE
feat(contrib/mark3labs/mcp-go): set session ID on tool spans at start time

### DIFF
--- a/contrib/mark3labs/mcp-go/tracing.go
+++ b/contrib/mark3labs/mcp-go/tracing.go
@@ -33,7 +33,13 @@ func appendTracingHooks(hooks *server.Hooks) {
 
 var toolHandlerMiddleware = func(next server.ToolHandlerFunc) server.ToolHandlerFunc {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		toolSpan, ctx := llmobs.StartToolSpan(ctx, request.Params.Name, llmobs.WithIntegration(string(instrumentation.PackageMark3LabsMCPGo)))
+		startOpts := []llmobs.StartSpanOption{
+			llmobs.WithIntegration(string(instrumentation.PackageMark3LabsMCPGo)),
+		}
+		if session := server.ClientSessionFromContext(ctx); session != nil {
+			startOpts = append(startOpts, llmobs.WithSessionID(session.SessionID()))
+		}
+		toolSpan, ctx := llmobs.StartToolSpan(ctx, request.Params.Name, startOpts...)
 
 		var result *mcp.CallToolResult
 		var err error

--- a/contrib/mark3labs/mcp-go/tracing_test.go
+++ b/contrib/mark3labs/mcp-go/tracing_test.go
@@ -178,6 +178,9 @@ func TestIntegrationToolCallSuccess(t *testing.T) {
 	assert.Contains(t, initSpan.Tags, expectedTag)
 	assert.Contains(t, toolSpan.Tags, expectedTag)
 
+	// Tool span carries the session ID natively so LLMObs groups it under the session.
+	assert.Equal(t, sessionID, toolSpan.SessionID)
+
 	assert.Contains(t, toolSpan.Tags, "mcp_method:tools/call")
 	assert.Contains(t, toolSpan.Tags, "mcp_tool_kind:server")
 	assert.Contains(t, toolSpan.Tags, "mcp_tool:calculator")


### PR DESCRIPTION
This PR stack ports functionality added in the clone of this contrib in dd-source back to dd-trace-go.

## Summary

Pass `llmobs.WithSessionID` at `StartToolSpan` time so LLMObs groups tool spans under their MCP session natively. The session is read from `server.ClientSessionFromContext(ctx)` if present.

The existing `mcp_session_id` tag is unchanged — they are complementary: the tag exposes the session ID to span search/filtering, while `WithSessionID` populates the LLMObs session field used for trace grouping.

## Provenance

No single dd-source PR — the change landed as part of a series of LLMObs-session changes. The current dd-source middleware lives at [`mcp-go/tracing.go#L36-L44`](https://github.com/DataDog/dd-source/blob/d10d624c374b69aa02168983be725532a38562b1/domains/mcp_services/libs/go/mcp/pre-release-external/dd-trace-go/contrib/mark3labs/mcp-go/tracing.go#L36-L44):

```go
var toolHandlerMiddleware = func(next server.ToolHandlerFunc) server.ToolHandlerFunc {
    return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
        // Note: WithIntegration is not yet in released llmobs package and cannot be used here
        var startOpts []llmobs.StartSpanOption
        if session := server.ClientSessionFromContext(ctx); session != nil {
            startOpts = append(startOpts, llmobs.WithSessionID(session.SessionID()))
        }
        toolSpan, ctx := llmobs.StartToolSpan(ctx, request.Params.Name, startOpts...)
```

This PR ports that exact pattern, additionally keeping the existing `llmobs.WithIntegration(...)` call since the released llmobs package now has it.

## Test plan

- [x] Extended `TestIntegrationToolCallSuccess` to assert `toolSpan.SessionID` matches the MCP client session.
- [x] Existing tracing tests still pass.

Stacked on #4942.