### PR TITLE
fix(contrib/modelcontextprotocol/go-sdk): inject telemetry via map[string]any

### DIFF
--- a/contrib/modelcontextprotocol/go-sdk/intent_capture.go
+++ b/contrib/modelcontextprotocol/go-sdk/intent_capture.go
@@ -9,25 +9,22 @@ import (
 	"context"
 	"encoding/json"
 
-	"maps"
-
-	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	instrmcp "github.com/DataDog/dd-trace-go/v2/instrumentation/mcp"
 	"github.com/DataDog/dd-trace-go/v2/llmobs"
 )
 
-func telemetrySchema() *jsonschema.Schema {
-	return &jsonschema.Schema{
-		Type: "object",
-		Properties: map[string]*jsonschema.Schema{
-			instrmcp.IntentKey: {
-				Type:        "string",
-				Description: instrmcp.IntentPrompt,
+func telemetrySchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			instrmcp.IntentKey: map[string]any{
+				"type":        "string",
+				"description": instrmcp.IntentPrompt,
 			},
 		},
-		Required: []string{instrmcp.IntentKey},
+		"required": []any{instrmcp.IntentKey},
 	}
 }
 
@@ -58,31 +55,41 @@ func intentCaptureReceivingMiddleware(next mcp.MethodHandler) mcp.MethodHandler 
 
 func injectToolsListResponse(res *mcp.ListToolsResult) {
 	for i := range res.Tools {
-		inputSchema, ok := res.Tools[i].InputSchema.(*jsonschema.Schema)
-		if !ok {
-			instr.Logger().Warn("go-sdk intent capture: unexpected input schema type: %T", res.Tools[i].InputSchema)
+		// Round-trip the input schema through map[string]any so unknown JSON
+		// Schema keywords (additionalProperties, oneOf, patternProperties, etc.)
+		// that *jsonschema.Schema does not model pass through verbatim.
+		schemaBytes, err := json.Marshal(res.Tools[i].InputSchema)
+		if err != nil {
+			instr.Logger().Warn("go-sdk intent capture: failed to marshal input schema: %v", err)
 			continue
 		}
-
-		// Create copies of the tool and schema to avoid mutating the registered
-		// schema used for server-side validation in go-sdk v1.3+.
-		schemaCopy := *inputSchema
-		if schemaCopy.Type == "" {
-			schemaCopy.Type = "object"
+		var schema map[string]any
+		if err := json.Unmarshal(schemaBytes, &schema); err != nil {
+			instr.Logger().Warn("go-sdk intent capture: failed to unmarshal input schema: %v", err)
+			continue
+		}
+		if schema == nil {
+			schema = map[string]any{}
+		}
+		if _, ok := schema["type"]; !ok {
+			schema["type"] = "object"
 		}
 
-		newProps := make(map[string]*jsonschema.Schema, len(inputSchema.Properties)+1)
-		maps.Copy(newProps, inputSchema.Properties)
-		newProps[instrmcp.TelemetryKey] = telemetrySchema()
-		schemaCopy.Properties = newProps
+		props, _ := schema["properties"].(map[string]any)
+		if props == nil {
+			props = map[string]any{}
+		}
+		props[instrmcp.TelemetryKey] = telemetrySchema()
+		schema["properties"] = props
 
-		newRequired := make([]string, len(inputSchema.Required)+1)
-		copy(newRequired, inputSchema.Required)
-		newRequired[len(inputSchema.Required)] = instrmcp.TelemetryKey
-		schemaCopy.Required = newRequired
+		required, _ := schema["required"].([]any)
+		required = append(required, instrmcp.TelemetryKey)
+		schema["required"] = required
 
+		// Mutate a copy of the tool so the registered tool (used for server-side
+		// validation in go-sdk v1.3+) is not affected.
 		toolCopy := *res.Tools[i]
-		toolCopy.InputSchema = &schemaCopy
+		toolCopy.InputSchema = schema
 		res.Tools[i] = &toolCopy
 	}
 }

--- a/contrib/modelcontextprotocol/go-sdk/intent_capture_test.go
+++ b/contrib/modelcontextprotocol/go-sdk/intent_capture_test.go
@@ -7,6 +7,7 @@ package gosdk
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -17,6 +18,54 @@ import (
 	instrmcp "github.com/DataDog/dd-trace-go/v2/instrumentation/mcp"
 	"github.com/DataDog/dd-trace-go/v2/instrumentation/testutils/testtracer"
 )
+
+func TestIntentCapturePreservesUnknownSchemaKeywords(t *testing.T) {
+	// *jsonschema.Schema doesn't model additionalProperties/oneOf; the map-based
+	// injection must pass those through verbatim instead of dropping them.
+	tt := testTracer(t)
+	defer tt.Stop()
+
+	ctx := context.Background()
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+	AddTracing(server, WithIntentCapture())
+
+	server.AddTool(&mcp.Tool{
+		Name:        "raw_tool",
+		Description: "raw",
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {"app_id": {"type": "string"}},
+			"required": ["app_id"],
+			"additionalProperties": false,
+			"oneOf": [{"required": ["app_id"]}]
+		}`),
+	}, func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "ok"}}}, nil
+	})
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "1.0.0"}, nil)
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	require.NoError(t, err)
+	defer serverSession.Close()
+
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+	defer clientSession.Close()
+
+	listResult, err := clientSession.ListTools(ctx, &mcp.ListToolsParams{})
+	require.NoError(t, err)
+	require.Len(t, listResult.Tools, 1)
+
+	schema, ok := listResult.Tools[0].InputSchema.(map[string]any)
+	require.True(t, ok, "expected input schema to be map[string]any, got %T", listResult.Tools[0].InputSchema)
+	assert.Contains(t, schema["properties"].(map[string]any), "telemetry")
+	assert.Contains(t, schema["required"].([]any), "telemetry")
+	assert.Equal(t, false, schema["additionalProperties"])
+	assert.NotNil(t, schema["oneOf"])
+}
 
 func TestIntentCapture(t *testing.T) {
 	tt := testTracer(t)


### PR DESCRIPTION
This PR stack ports functionality added in the clone of this contrib in dd-source back to dd-trace-go (Rapid clone at `domains/api_platform/libs/go/mcp/tracing`).

## Summary

Round-trips `mcp.Tool.InputSchema` through `map[string]any` instead of type-asserting to `*jsonschema.Schema`. `*jsonschema.Schema` doesn't model keywords like `additionalProperties`, `oneOf`, `anyOf`, `patternProperties`, or `$defs`; those keywords were silently dropped when telemetry was injected. The map approach preserves whatever the tool author registered, verbatim.

## What this enables in dd-source

Without this change, Rapid tools that rely on JSON Schema features beyond the typed struct (e.g., `additionalProperties: false`, `oneOf` branches) lose those constraints once telemetry is injected, leaving the model with a more permissive schema than the server actually enforces. Source PR: https://github.com/DataDog/dd-source/pull/429982

## Test plan

- [x] `TestIntentCapturePreservesUnknownSchemaKeywords` — `additionalProperties: false` and `oneOf` pass through after injection.
- [x] All existing intent-capture tests still pass.
