### PR TITLE
feat(contrib/modelcontextprotocol/go-sdk): set additionalProperties:false on telemetry schema

### DIFF
--- a/contrib/modelcontextprotocol/go-sdk/intent_capture.go
+++ b/contrib/modelcontextprotocol/go-sdk/intent_capture.go
@@ -24,7 +24,8 @@ func telemetrySchema() map[string]any {
 				"description": instrmcp.IntentPrompt,
 			},
 		},
-		"required": []any{instrmcp.IntentKey},
+		"required":             []any{instrmcp.IntentKey},
+		"additionalProperties": false,
 	}
 }
 

--- a/contrib/modelcontextprotocol/go-sdk/intent_capture_test.go
+++ b/contrib/modelcontextprotocol/go-sdk/intent_capture_test.go
@@ -142,6 +142,7 @@ func TestIntentCapture(t *testing.T) {
 	intentSchema := telemetryProps["intent"].(map[string]any)
 	assert.Equal(t, "string", intentSchema["type"])
 	assert.Equal(t, instrmcp.IntentPrompt, intentSchema["description"])
+	assert.Equal(t, false, telemetrySchema["additionalProperties"])
 
 	// Ensure telemetry is required, and others are not affected
 	required := schemaMap["required"].([]any)


### PR DESCRIPTION
This PR stack ports functionality added in the clone of this contrib in dd-source back to dd-trace-go (Rapid clone at `domains/api_platform/libs/go/mcp/tracing`).

## Summary

Adds `additionalProperties: false` to the injected `telemetry` schema so that clients can't quietly attach unknown fields under `telemetry`. The intent capture middleware only reads `intent` from this object, and any other keys would be dropped before the tool sees them — surfacing that as a schema-level constraint is clearer.

## What this enables in dd-source

The Rapid clone added this constraint after observing client agents probing telemetry with extra fields; mirroring it here lines up the public contrib with the production behavior. Source PR: https://github.com/DataDog/dd-source/pull/428353

## Test plan

- [x] Existing `TestIntentCapture` now asserts `additionalProperties == false` on the telemetry sub-schema.

Stacked on #4947.
