### PR TITLE
feat(contrib/modelcontextprotocol/go-sdk): skip intent capture for UI-only tools

### DIFF
--- a/contrib/modelcontextprotocol/go-sdk/intent_capture.go
+++ b/contrib/modelcontextprotocol/go-sdk/intent_capture.go
@@ -56,6 +56,11 @@ func intentCaptureReceivingMiddleware(next mcp.MethodHandler) mcp.MethodHandler 
 
 func injectToolsListResponse(res *mcp.ListToolsResult) {
 	for i := range res.Tools {
+		// UI-only tools cannot be invoked by the model, so injecting a
+		// required telemetry parameter would be useless noise.
+		if !instrmcp.IsModelCallable(res.Tools[i].Meta) {
+			continue
+		}
 		// Round-trip the input schema through map[string]any so unknown JSON
 		// Schema keywords (additionalProperties, oneOf, patternProperties, etc.)
 		// that *jsonschema.Schema does not model pass through verbatim.

--- a/contrib/modelcontextprotocol/go-sdk/intent_capture_test.go
+++ b/contrib/modelcontextprotocol/go-sdk/intent_capture_test.go
@@ -67,6 +67,63 @@ func TestIntentCapturePreservesUnknownSchemaKeywords(t *testing.T) {
 	assert.NotNil(t, schema["oneOf"])
 }
 
+func TestIntentCaptureSkipsUIOnlyTools(t *testing.T) {
+	// Tools whose _meta.ui.visibility omits "model" cannot be model-invoked, so
+	// telemetry injection should be skipped for them.
+	tt := testTracer(t)
+	defer tt.Stop()
+	ctx := context.Background()
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+	AddTracing(server, WithIntentCapture())
+
+	addTool := func(name string, visibility []any) {
+		tool := &mcp.Tool{
+			Name:        name,
+			Description: name,
+			InputSchema: &jsonschema.Schema{Type: "object", Properties: map[string]*jsonschema.Schema{"q": {Type: "string"}}},
+		}
+		if visibility != nil {
+			tool.Meta = mcp.Meta{"ui": map[string]any{"visibility": visibility}}
+		}
+		server.AddTool(tool, func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "ok"}}}, nil
+		})
+	}
+	addTool("plain", nil)
+	addTool("ui_only", []any{"app"})
+	addTool("dual", []any{"model", "app"})
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "1.0.0"}, nil)
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	require.NoError(t, err)
+	defer serverSession.Close()
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+	defer clientSession.Close()
+
+	listResult, err := clientSession.ListTools(ctx, &mcp.ListToolsParams{})
+	require.NoError(t, err)
+	props := func(name string) map[string]any {
+		for _, tl := range listResult.Tools {
+			if tl.Name != name {
+				continue
+			}
+			schema, ok := tl.InputSchema.(map[string]any)
+			if !ok {
+				return nil
+			}
+			p, _ := schema["properties"].(map[string]any)
+			return p
+		}
+		return nil
+	}
+	assert.Contains(t, props("plain"), "telemetry")
+	assert.NotContains(t, props("ui_only"), "telemetry", "UI-only tool should not have telemetry injected")
+	assert.Contains(t, props("dual"), "telemetry")
+}
+
 func TestIntentCapture(t *testing.T) {
 	tt := testTracer(t)
 	defer tt.Stop()


### PR DESCRIPTION
This PR stack ports functionality added in the clone of this contrib in dd-source back to dd-trace-go (Rapid clone at `domains/api_platform/libs/go/mcp/tracing`).

## Summary

Skips telemetry/intent injection for tools whose `_meta.ui.visibility` excludes `"model"`. UI-only tools cannot be invoked by the model, so a required `telemetry` parameter would be useless noise.

`_meta.ui.visibility` is part of the MCP Apps extension (see https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/SEP-1865.md). Absent visibility list ⇒ model-callable (spec default).

## What this enables in dd-source

Same behavior already shipping in the Rapid clone — UI-only tools registered through dd-source's MCP server are silently skipped today; this PR brings that to the public contrib. Source PR: https://github.com/DataDog/dd-source/pull/420911

## Test plan

- [x] `TestIntentCaptureSkipsUIOnlyTools` — three tools (no meta, ui-only, dual-visibility): only the UI-only one is skipped.
- [x] All existing intent-capture tests still pass.

Stacked on #4948.


---

Parallel port in the mark3labs/mcp-go contrib: #4942
