### PR TITLE
fix: reduce allocations for BenchmarkInjectW3C

### DIFF
--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -310,11 +310,6 @@ func newSpanContext(span *Span, parent *SpanContext) *SpanContext {
 	// put span in context's trace
 	context.trace.push(span)
 	context.traceID.cacheHex()
-	// Finalize the hex cache now that all SetLower/SetUpper mutations are done
-	// and before the context is shared with other goroutines. This keeps
-	// HexEncoded a pure cached read on the propagation hot path (Inject), so
-	// locally-started spans don't re-allocate the hex string on every call.
-	context.traceID.cacheHex()
 	// The span snapshot is populated by tracer.StartSpan after all
 	// env/version/service-mapping mutations, so we skip the intermediate
 	// write here. Direct callers of newSpanContext (tests) do not read

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -309,6 +309,12 @@ func newSpanContext(span *Span, parent *SpanContext) *SpanContext {
 	}
 	// put span in context's trace
 	context.trace.push(span)
+	context.traceID.cacheHex()
+	// Finalize the hex cache now that all SetLower/SetUpper mutations are done
+	// and before the context is shared with other goroutines. This keeps
+	// HexEncoded a pure cached read on the propagation hot path (Inject), so
+	// locally-started spans don't re-allocate the hex string on every call.
+	context.traceID.cacheHex()
 	// The span snapshot is populated by tracer.StartSpan after all
 	// env/version/service-mapping mutations, so we skip the intermediate
 	// write here. Direct callers of newSpanContext (tests) do not read


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
