### PR TITLE
perf(appsec): make rate limiter synchronous to remove idle goroutine cost

### DIFF
--- a/internal/appsec/apisec/sampler.go
+++ b/internal/appsec/apisec/sampler.go
@@ -41,6 +41,7 @@ type (
 
 // NewProxySampler creates a new sampler suitable for proxy environments where the sampling decision
 // is not based on the request's properties, but on a rate.
+// The returned sampler is backed by a synchronous token-bucket limiter that does not start a background goroutine.
 func NewProxySampler(rate int, interval time.Duration) Sampler {
 	if rate <= 0 {
 		return &nullSampler{}

--- a/internal/appsec/apisec/sampler.go
+++ b/internal/appsec/apisec/sampler.go
@@ -48,7 +48,6 @@ func NewProxySampler(rate int, interval time.Duration) Sampler {
 	}
 	r := int64(rate)
 	l := limiter.NewTokenTickerWithInterval(r, r, interval)
-	l.Start()
 	return &proxySampler{
 		limiter: l,
 	}

--- a/internal/appsec/limiter/limiter.go
+++ b/internal/appsec/limiter/limiter.go
@@ -45,10 +45,7 @@ func newLimiter(tokens, maxTokens int64, interval time.Duration) *rate.Limiter {
 	limit := rate.Limit(float64(maxTokens) / interval.Seconds())
 	lim := rate.NewLimiter(limit, burst)
 	t0 := time.Now()
-	initial := tokens
-	if initial > int64(burst) {
-		initial = int64(burst)
-	}
+	initial := min(tokens, int64(burst))
 	if drain := int64(burst) - initial; drain > 0 {
 		lim.AllowN(t0, int(drain))
 	}

--- a/internal/appsec/limiter/limiter.go
+++ b/internal/appsec/limiter/limiter.go
@@ -3,12 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022-present Datadog, Inc.
 
-// Package limiter provides simple rate limiting primitives, and an implementation of a token bucket rate limiter.
+// Package limiter provides simple rate limiting primitives backed by a synchronous token bucket.
 package limiter
 
 import (
-	"sync/atomic"
+	"math"
 	"time"
+
+	"golang.org/x/time/rate"
 )
 
 // Limiter is used to abstract the rate limiter implementation to only expose the needed function for rate limiting.
@@ -18,136 +20,68 @@ type Limiter interface {
 	Allow() bool
 }
 
-// TokenTicker is a thread-safe and lock-free rate limiter based on a token bucket.
-// The idea is to have a goroutine that will update  the bucket with fresh tokens at regular intervals using a time.Ticker.
-// The advantage of using a goroutine here is  that the implementation becomes easily thread-safe using a few
-// atomic operations with little overhead overall. TokenTicker.Start() *should* be called before the first call to
-// TokenTicker.Allow() and TokenTicker.Stop() *must* be called once done using. Note that calling TokenTicker.Allow()
-// before TokenTicker.Start() is valid, but it means the bucket won't be refilling until the call to TokenTicker.Start() is made
+// TokenTicker is a thread-safe rate limiter based on a lazily refilled token bucket.
+// Start and Stop are retained for compatibility and do not affect refill behavior.
 type TokenTicker struct {
-	tokens    atomic.Int64  // The amount of tokens currently available
-	maxTokens int64         // The maximum amount of tokens the bucket can hold
-	interval  time.Duration // The interval at which the tokens are refilled
-	ticker    *time.Ticker  // The ticker used to update the bucket (nil if not started yet)
-	stopChan  chan struct{} // The channel to stop the ticker updater (nil if not started yet)
+	lim *rate.Limiter
+	now func() time.Time
 }
 
 // NewTokenTicker is a utility function that allocates a token ticker, initializes necessary fields and returns it
 func NewTokenTicker(tokens, maxTokens int64) *TokenTicker {
-	return NewTokenTickerWithInterval(tokens, maxTokens, time.Second)
+	return newTokenTicker(tokens, maxTokens, time.Second, time.Now)
 }
 
 // NewTokenTickerWithInterval is a utility function that allocates a token ticker with a custom interval
 func NewTokenTickerWithInterval(tokens, maxTokens int64, interval time.Duration) *TokenTicker {
-	t := &TokenTicker{
-		maxTokens: maxTokens,
-		interval:  interval,
+	return newTokenTicker(tokens, maxTokens, interval, time.Now)
+}
+
+func newTokenTicker(tokens, maxTokens int64, interval time.Duration, now func() time.Time) *TokenTicker {
+	if now == nil {
+		now = time.Now
 	}
-	t.tokens.Store(tokens)
-	return t
-}
 
-// updateBucket performs a select loop to update the token amount in the bucket.
-// Used in a goroutine by the rate limiter.
-func (t *TokenTicker) updateBucket(startTime time.Time, ticksChan <-chan time.Time, stopChan <-chan struct{}, syncChan chan<- struct{}) {
-	nsPerToken := t.interval.Nanoseconds() / t.maxTokens
-	elapsedNs := int64(0)
-	prevStamp := startTime
-
-	for {
-		select {
-		case <-stopChan:
-			if syncChan != nil {
-				close(syncChan)
-			}
-			return
-		case stamp, ok := <-ticksChan:
-			if !ok {
-				// The ticker has been closed, stamp is a zero-value, we ignore that. We nil-out the
-				// ticksChan so we don't get stuck endlessly reading from this closed channel again.
-				ticksChan = nil
-				continue
-			}
-
-			// Compute the time in nanoseconds that passed between the previous timestamp and this one
-			// This will be used to know how many tokens can be added into the bucket depending on the limiter rate
-			elapsedNs += stamp.Sub(prevStamp).Nanoseconds()
-			if elapsedNs > t.maxTokens*nsPerToken {
-				elapsedNs = t.maxTokens * nsPerToken
-			}
-			prevStamp = stamp
-			// Update the number of tokens in the bucket if enough nanoseconds have passed
-			if elapsedNs >= nsPerToken {
-				// Atomic spin lock to make sure we don't race for `t.tokens`
-				for {
-					tokens := t.tokens.Load()
-					if tokens == t.maxTokens {
-						break // Bucket is already full, nothing to do
-					}
-					inc := elapsedNs / nsPerToken
-					// Make sure not to add more tokens than we are allowed to into the bucket
-					if tokens+inc > t.maxTokens {
-						inc -= (tokens + inc) % t.maxTokens
-					}
-					if t.tokens.CompareAndSwap(tokens, tokens+inc) {
-						// Keep track of remaining elapsed ns that were not taken into account for this computation,
-						// so that increment computation remains precise over time
-						elapsedNs = elapsedNs % nsPerToken
-						break
-					}
-				}
-			}
-			// Sync channel used to signify that the goroutine is done updating the bucket. Used for tests to guarantee
-			// that the goroutine ticked at least once.
-			if syncChan != nil {
-				syncChan <- struct{}{}
-			}
-		}
+	if tokens < 0 {
+		tokens = 0
+	} else if tokens > maxTokens {
+		tokens = maxTokens
 	}
+
+	if maxTokens <= 0 || interval <= 0 {
+		// Non-positive intervals are deny-safe: computing a rate from them could create an infinite limiter.
+		return &TokenTicker{lim: rate.NewLimiter(0, 0), now: now}
+	}
+
+	burst := int(maxTokens)
+	if maxTokens > int64(math.MaxInt) {
+		burst = math.MaxInt
+	}
+
+	limit := rate.Limit(float64(maxTokens) / interval.Seconds())
+	lim := rate.NewLimiter(limit, burst)
+	t0 := now()
+	initial := tokens
+	if initial > int64(burst) {
+		initial = int64(burst)
+	}
+	if drain := int64(burst) - initial; drain > 0 {
+		lim.AllowN(t0, int(drain))
+	}
+
+	return &TokenTicker{lim: lim, now: now}
 }
 
-// Start starts the ticker and launches the goroutine responsible for updating the token bucket.
-// The ticker is set to tick at a fixed rate of 500us.
-func (t *TokenTicker) Start() {
-	timeNow := time.Now()
-	t.ticker = time.NewTicker(500 * time.Microsecond)
-	t.start(timeNow, t.ticker.C, nil)
-}
+// Start is retained for compatibility and is safe to call any number of times.
+func (t *TokenTicker) Start() {}
 
-// start is used for internal testing. Controlling the ticker means being able to test per-tick
-// rather than per-duration, which is more reliable if the app is under a lot of stress. The
-// syncChan, if non-nil, will receive one message after each tick from the ticksChan has been
-// processed, providing a strong synchronization primitive. The limiter will close the syncChan when
-// it is stopped, signaling that no further ticks will be processed.
-func (t *TokenTicker) start(startTime time.Time, ticksChan <-chan time.Time, syncChan chan<- struct{}) {
-	t.stopChan = make(chan struct{})
-	go t.updateBucket(startTime, ticksChan, t.stopChan, syncChan)
-}
-
-// Stop shuts down the rate limiter, taking care stopping the ticker and closing all channels
+// Stop is retained for compatibility and is safe to call any number of times.
 func (t *TokenTicker) Stop() {
-	// Stop the ticker only if it has been instantiated (not the case when testing by calling start() directly)
-	if t.ticker != nil {
-		t.ticker.Stop()
-		t.ticker = nil // Ensure stop can be called multiple times idempotently.
-	}
-	// Close the stop channel only if it has been created. This covers the case where Stop() is called without any prior
-	// call to Start()
-	if t.stopChan != nil {
-		close(t.stopChan)
-		t.stopChan = nil // Ensure stop can be called multiple times idempotently.
-	}
 }
 
 // Allow checks and returns whether a token can be retrieved from the bucket and consumed.
 // Thread-safe.
 func (t *TokenTicker) Allow() bool {
-	for {
-		tokens := t.tokens.Load()
-		if tokens == 0 {
-			return false
-		} else if t.tokens.CompareAndSwap(tokens, tokens-1) {
-			return true
-		}
-	}
+	// Use AllowN with the injected clock; Allow reads time.Now internally and would bypass tests.
+	return t.lim.AllowN(t.now(), 1)
 }

--- a/internal/appsec/limiter/limiter.go
+++ b/internal/appsec/limiter/limiter.go
@@ -20,37 +20,21 @@ type Limiter interface {
 	Allow() bool
 }
 
-// TokenTicker is a thread-safe rate limiter based on a lazily refilled token bucket.
-// Start and Stop are retained for compatibility and do not affect refill behavior.
-type TokenTicker struct {
-	lim *rate.Limiter
-	now func() time.Time
-}
-
 // NewTokenTicker is a utility function that allocates a token ticker, initializes necessary fields and returns it
-func NewTokenTicker(tokens, maxTokens int64) *TokenTicker {
-	return newTokenTicker(tokens, maxTokens, time.Second, time.Now)
+func NewTokenTicker(tokens, maxTokens int64) Limiter {
+	return newLimiter(tokens, maxTokens, time.Second)
 }
 
 // NewTokenTickerWithInterval is a utility function that allocates a token ticker with a custom interval
-func NewTokenTickerWithInterval(tokens, maxTokens int64, interval time.Duration) *TokenTicker {
-	return newTokenTicker(tokens, maxTokens, interval, time.Now)
+func NewTokenTickerWithInterval(tokens, maxTokens int64, interval time.Duration) Limiter {
+	return newLimiter(tokens, maxTokens, interval)
 }
 
-func newTokenTicker(tokens, maxTokens int64, interval time.Duration, now func() time.Time) *TokenTicker {
-	if now == nil {
-		now = time.Now
-	}
-
-	if tokens < 0 {
-		tokens = 0
-	} else if tokens > maxTokens {
-		tokens = maxTokens
-	}
-
+func newLimiter(tokens, maxTokens int64, interval time.Duration) *rate.Limiter {
+	tokens = max(0, min(tokens, maxTokens))
 	if maxTokens <= 0 || interval <= 0 {
 		// Non-positive intervals are deny-safe: computing a rate from them could create an infinite limiter.
-		return &TokenTicker{lim: rate.NewLimiter(0, 0), now: now}
+		return rate.NewLimiter(0, 0)
 	}
 
 	burst := int(maxTokens)
@@ -60,7 +44,7 @@ func newTokenTicker(tokens, maxTokens int64, interval time.Duration, now func() 
 
 	limit := rate.Limit(float64(maxTokens) / interval.Seconds())
 	lim := rate.NewLimiter(limit, burst)
-	t0 := now()
+	t0 := time.Now()
 	initial := tokens
 	if initial > int64(burst) {
 		initial = int64(burst)
@@ -69,19 +53,5 @@ func newTokenTicker(tokens, maxTokens int64, interval time.Duration, now func() 
 		lim.AllowN(t0, int(drain))
 	}
 
-	return &TokenTicker{lim: lim, now: now}
-}
-
-// Start is retained for compatibility and is safe to call any number of times.
-func (t *TokenTicker) Start() {}
-
-// Stop is retained for compatibility and is safe to call any number of times.
-func (t *TokenTicker) Stop() {
-}
-
-// Allow checks and returns whether a token can be retrieved from the bucket and consumed.
-// Thread-safe.
-func (t *TokenTicker) Allow() bool {
-	// Use AllowN with the injected clock; Allow reads time.Now internally and would bypass tests.
-	return t.lim.AllowN(t.now(), 1)
+	return lim
 }

--- a/internal/appsec/limiter/limiter_test.go
+++ b/internal/appsec/limiter/limiter_test.go
@@ -24,7 +24,7 @@ func TestLimiterUnit(t *testing.T) {
 	t.Run("no-ticks-1", func(t *testing.T) {
 		defer goleak.VerifyNone(t)
 
-		l := newTestTicker(1, 100)
+		l := newTestTicker(startTime, 1, 100)
 		l.start(startTime)
 		defer l.stop()
 		// No ticks between the requests
@@ -35,7 +35,7 @@ func TestLimiterUnit(t *testing.T) {
 	t.Run("no-ticks-2", func(t *testing.T) {
 		defer goleak.VerifyNone(t)
 
-		l := newTestTicker(100, 100)
+		l := newTestTicker(startTime, 100, 100)
 		l.start(startTime)
 		defer l.stop()
 		// No ticks between the requests
@@ -48,7 +48,7 @@ func TestLimiterUnit(t *testing.T) {
 	t.Run("10ms-ticks", func(t *testing.T) {
 		defer goleak.VerifyNone(t)
 
-		l := newTestTicker(1, 100)
+		l := newTestTicker(startTime, 1, 100)
 		l.start(startTime)
 		defer l.stop()
 		require.True(t, l.Allow(), "First call to limiter.Allow() should return True")
@@ -60,7 +60,7 @@ func TestLimiterUnit(t *testing.T) {
 	t.Run("9ms-ticks", func(t *testing.T) {
 		defer goleak.VerifyNone(t)
 
-		l := newTestTicker(1, 100)
+		l := newTestTicker(startTime, 1, 100)
 		l.start(startTime)
 		defer l.stop()
 		require.True(t, l.Allow(), "First call to limiter.Allow() should return True")
@@ -73,7 +73,7 @@ func TestLimiterUnit(t *testing.T) {
 	t.Run("1s-rate", func(t *testing.T) {
 		defer goleak.VerifyNone(t)
 
-		l := newTestTicker(1, 1)
+		l := newTestTicker(startTime, 1, 1)
 		l.start(startTime)
 		defer l.stop()
 		require.True(t, l.Allow(), "First call to limiter.Allow() should return True with 1s per token")
@@ -86,7 +86,7 @@ func TestLimiterUnit(t *testing.T) {
 	t.Run("100-requests-burst", func(t *testing.T) {
 		defer goleak.VerifyNone(t)
 
-		l := newTestTicker(100, 100)
+		l := newTestTicker(startTime, 100, 100)
 		l.start(startTime)
 		defer l.stop()
 		for i := range 100 {
@@ -99,14 +99,13 @@ func TestLimiterUnit(t *testing.T) {
 	t.Run("101-requests-burst", func(t *testing.T) {
 		defer goleak.VerifyNone(t)
 
-		l := newTestTicker(100, 100)
+		l := newTestTicker(startTime, 100, 100)
 		l.start(startTime)
 		defer l.stop()
 		for i := range 100 {
 			require.Truef(t, l.Allow(),
 				"Burst call %d to limiter.Allow() should return True with 100 initial tokens", i)
-			startTime = startTime.Add(50 * time.Microsecond)
-			l.tick(0)
+			l.tick(50 * time.Microsecond)
 		}
 		require.False(t, l.Allow(),
 			"Burst call 101 to limiter.Allow() should return False with 100 initial tokens")
@@ -115,33 +114,33 @@ func TestLimiterUnit(t *testing.T) {
 	t.Run("bucket-refill-short", func(t *testing.T) {
 		defer goleak.VerifyNone(t)
 
-		l := newTestTicker(100, 100)
+		l := newTestTicker(startTime, 100, 100)
 		l.start(startTime)
 		defer l.stop()
 
 		for range 1000 {
 			l.tick(time.Millisecond)
-			require.Equalf(t, int64(100), l.t.tokens.Load(), "Bucket should have exactly 100 tokens")
+			require.Equalf(t, int64(100), int64(l.t.lim.TokensAt(l.clock.now())), "Bucket should have exactly 100 tokens")
 		}
 	})
 
 	t.Run("bucket-refill-long", func(t *testing.T) {
 		defer goleak.VerifyNone(t)
 
-		l := newTestTicker(100, 100)
+		l := newTestTicker(startTime, 100, 100)
 		l.start(startTime)
 		defer l.stop()
 
 		for range 1000 {
 			l.tick(3 * time.Second)
 		}
-		require.Equalf(t, int64(100), l.t.tokens.Load(), "Bucket should have exactly 100 tokens")
+		require.Equalf(t, int64(100), int64(l.t.lim.TokensAt(l.clock.now())), "Bucket should have exactly 100 tokens")
 	})
 
 	t.Run("allow-after-stop", func(t *testing.T) {
 		defer goleak.VerifyNone(t)
 
-		l := newTestTicker(3, 3)
+		l := newTestTicker(startTime, 3, 3)
 		l.start(startTime)
 		require.True(t, l.Allow())
 		l.stop()
@@ -154,16 +153,16 @@ func TestLimiterUnit(t *testing.T) {
 	t.Run("allow-before-start", func(t *testing.T) {
 		defer goleak.VerifyNone(t)
 
-		l := newTestTicker(2, 100)
+		l := newTestTicker(startTime, 2, 100)
 		// The limiter keeps allowing until there's no more tokens
 		require.True(t, l.Allow())
 		require.True(t, l.Allow())
 		require.False(t, l.Allow())
 		l.start(startTime)
-		// The limiter has used all its tokens and the bucket is not getting refilled yet
+		// Start is a no-op, so the fake clock has not advanced enough to lazily refill a token yet.
 		require.False(t, l.Allow())
 		l.tick(10 * time.Millisecond)
-		// The limiter has started refilling its tokens
+		// Advancing the fake clock refills the next token lazily on Allow.
 		require.True(t, l.Allow())
 		l.stop()
 	})
@@ -222,7 +221,7 @@ func TestLimiter(t *testing.T) {
 
 				skipped := 0
 				kept := 0
-				l := newTestTicker(100, 100)
+				l := newTestTicker(startTime, 100, 100)
 				l.start(startTime)
 				defer l.stop()
 
@@ -261,9 +260,6 @@ func BenchmarkLimiter(b *testing.B) {
 			limiter.Start()
 			defer limiter.Stop()
 
-			b.StopTimer()
-			b.ResetTimer()
-
 			for b.Loop() {
 				var startBarrier, stopBarrier sync.WaitGroup
 				// Create a start barrier to synchronize every goroutine's launch and
@@ -274,8 +270,6 @@ func BenchmarkLimiter(b *testing.B) {
 				for range nbUsers {
 					stopBarrier.Go(func() {
 						startBarrier.Wait() // Sync the starts of the goroutines
-
-						b.StartTimer() // Ensure the timer is started now...
 
 						for range 100 {
 							if !limiter.Allow() {
@@ -289,7 +283,6 @@ func BenchmarkLimiter(b *testing.B) {
 
 				startBarrier.Done() // Unblock the user goroutines
 				stopBarrier.Wait()  // Wait for the user goroutines to be done
-				b.StopTimer()
 			}
 
 			assert.NotEqual(b, 0, kept.Load(), "expected to have accepted at least 1")
@@ -298,58 +291,53 @@ func BenchmarkLimiter(b *testing.B) {
 	}
 }
 
-// TestTicker is a utility struct used to send hand-crafted ticks to the rate limiter for controlled testing
-// It also makes sure to give time to the bucket update goroutine by using the optional sync channel
 type TestTicker struct {
-	C         chan time.Time
-	syncChan  <-chan struct{}
-	t         *TokenTicker
-	timestamp time.Time
+	clock *fakeClock
+	t     *TokenTicker
 }
 
-func newTestTicker(tokens, maxTokens int64) *TestTicker {
+type fakeClock struct {
+	t time.Time
+}
+
+func (c *fakeClock) now() time.Time {
+	return c.t
+}
+
+func (c *fakeClock) advance(delta time.Duration) {
+	c.t = c.t.Add(delta)
+}
+
+func newTestTicker(startTime time.Time, tokens, maxTokens int64) *TestTicker {
+	clock := &fakeClock{t: startTime}
 	return &TestTicker{
-		C: make(chan time.Time),
-		t: NewTokenTicker(tokens, maxTokens),
+		clock: clock,
+		t:     newTokenTicker(tokens, maxTokens, time.Second, clock.now),
 	}
 }
 
 func (t *TestTicker) start(timestamp time.Time) {
-	syncChan := make(chan struct{}, 1)
-	t.syncChan = syncChan
-	t.timestamp = timestamp
-	t.t.start(timestamp, t.C, syncChan)
+	t.clock.t = timestamp
+	t.t.Start()
 }
 
 func (t *TestTicker) stop() {
 	t.t.Stop()
-	close(t.C)
-	// syncChan is closed by the token ticker when sure that nothing else will be sent on it.
-	for _, ok := <-t.syncChan; ok; _, ok = <-t.syncChan {
-		// Drain the channel.
-	}
-	t.syncChan = nil
-	t.timestamp = time.Time{}
 }
 
-// tick advances the `TestTicker`'s internal clock by the provided duration, and sends a tick to the
-// underlying `TokenTicker`. It then waits for the `TokenTicker` to be done processing that tick, so
-// the caller can assume the tocken bucket has been appropriately updated.
 func (t *TestTicker) tick(delta time.Duration) {
-	t.timestamp = t.timestamp.Add(delta)
-
-	t.C <- t.timestamp
-	<-t.syncChan
+	t.clock.advance(delta)
 }
 
 func (t *TestTicker) Allow() bool {
 	return t.t.Allow()
 }
 
-func newTestTickerWithInterval(tokens, maxTokens int64, interval time.Duration) *TestTicker {
+func newTestTickerWithInterval(startTime time.Time, tokens, maxTokens int64, interval time.Duration) *TestTicker {
+	clock := &fakeClock{t: startTime}
 	return &TestTicker{
-		C: make(chan time.Time),
-		t: NewTokenTickerWithInterval(tokens, maxTokens, interval),
+		clock: clock,
+		t:     newTokenTicker(tokens, maxTokens, interval, clock.now),
 	}
 }
 
@@ -358,7 +346,7 @@ func TestLimiterWithInterval(t *testing.T) {
 	t.Run("60-per-minute-rate", func(t *testing.T) {
 		defer goleak.VerifyNone(t)
 
-		l := newTestTickerWithInterval(1, 60, time.Minute) // 60 tokens per minute, so 1 per second
+		l := newTestTickerWithInterval(startTime, 1, 60, time.Minute) // 60 tokens per minute, so 1 per second
 		l.start(startTime)
 		defer l.stop()
 		require.True(t, l.Allow(), "First call should be allowed")
@@ -375,7 +363,7 @@ func TestLimiterWithInterval(t *testing.T) {
 	t.Run("1-per-100ms-rate", func(t *testing.T) {
 		defer goleak.VerifyNone(t)
 
-		l := newTestTickerWithInterval(1, 1, 100*time.Millisecond) // 1 token per 100ms
+		l := newTestTickerWithInterval(startTime, 1, 1, 100*time.Millisecond) // 1 token per 100ms
 		l.start(startTime)
 		defer l.stop()
 		require.True(t, l.Allow(), "First call should be allowed")

--- a/internal/appsec/limiter/limiter_test.go
+++ b/internal/appsec/limiter/limiter_test.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -19,153 +20,125 @@ import (
 )
 
 func TestLimiterUnit(t *testing.T) {
-	startTime := time.Now()
-
 	t.Run("no-ticks-1", func(t *testing.T) {
-		defer goleak.VerifyNone(t)
-
-		l := newTestTicker(startTime, 1, 100)
-		l.start(startTime)
-		defer l.stop()
-		// No ticks between the requests
-		require.True(t, l.Allow(), "First call to limiter.Allow() should return True")
-		require.False(t, l.Allow(), "Second call to limiter.Allow() should return False")
+		synctest.Test(t, func(t *testing.T) {
+			l := NewTokenTicker(1, 100)
+			require.True(t, l.Allow(), "First call to limiter.Allow() should return True")
+			require.False(t, l.Allow(), "Second call to limiter.Allow() should return False")
+		})
 	})
 
 	t.Run("no-ticks-2", func(t *testing.T) {
-		defer goleak.VerifyNone(t)
-
-		l := newTestTicker(startTime, 100, 100)
-		l.start(startTime)
-		defer l.stop()
-		// No ticks between the requests
-		for range 100 {
-			require.True(t, l.Allow())
-		}
-		require.False(t, l.Allow())
+		synctest.Test(t, func(t *testing.T) {
+			l := NewTokenTicker(100, 100)
+			for range 100 {
+				require.True(t, l.Allow())
+			}
+			require.False(t, l.Allow())
+		})
 	})
 
 	t.Run("10ms-ticks", func(t *testing.T) {
-		defer goleak.VerifyNone(t)
-
-		l := newTestTicker(startTime, 1, 100)
-		l.start(startTime)
-		defer l.stop()
-		require.True(t, l.Allow(), "First call to limiter.Allow() should return True")
-		require.False(t, l.Allow(), "Second call to limiter.Allow() should return false")
-		l.tick(10 * time.Millisecond)
-		require.True(t, l.Allow(), "Third call to limiter.Allow() after 10ms should return True")
+		synctest.Test(t, func(t *testing.T) {
+			l := NewTokenTicker(1, 100)
+			require.True(t, l.Allow(), "First call to limiter.Allow() should return True")
+			require.False(t, l.Allow(), "Second call to limiter.Allow() should return false")
+			time.Sleep(10 * time.Millisecond)
+			require.True(t, l.Allow(), "Third call to limiter.Allow() after 10ms should return True")
+		})
 	})
 
 	t.Run("9ms-ticks", func(t *testing.T) {
-		defer goleak.VerifyNone(t)
-
-		l := newTestTicker(startTime, 1, 100)
-		l.start(startTime)
-		defer l.stop()
-		require.True(t, l.Allow(), "First call to limiter.Allow() should return True")
-		l.tick(9 * time.Millisecond)
-		require.False(t, l.Allow(), "Second call to limiter.Allow() after 9ms should return False")
-		l.tick(10 * time.Millisecond)
-		require.True(t, l.Allow(), "Third call to limiter.Allow() after 10ms should return True")
+		synctest.Test(t, func(t *testing.T) {
+			l := NewTokenTicker(1, 100)
+			require.True(t, l.Allow(), "First call to limiter.Allow() should return True")
+			time.Sleep(9 * time.Millisecond)
+			require.False(t, l.Allow(), "Second call to limiter.Allow() after 9ms should return False")
+			time.Sleep(10 * time.Millisecond)
+			require.True(t, l.Allow(), "Third call to limiter.Allow() after 10ms should return True")
+		})
 	})
 
 	t.Run("1s-rate", func(t *testing.T) {
-		defer goleak.VerifyNone(t)
-
-		l := newTestTicker(startTime, 1, 1)
-		l.start(startTime)
-		defer l.stop()
-		require.True(t, l.Allow(), "First call to limiter.Allow() should return True with 1s per token")
-		l.tick(500 * time.Millisecond)
-		require.False(t, l.Allow(), "Second call to limiter.Allow() should return False with 1s per Token")
-		l.tick(1000 * time.Millisecond)
-		require.True(t, l.Allow(), "Third call to limiter.Allow() should return True with 1s per Token")
+		synctest.Test(t, func(t *testing.T) {
+			l := NewTokenTicker(1, 1)
+			require.True(t, l.Allow(), "First call to limiter.Allow() should return True with 1s per token")
+			time.Sleep(500 * time.Millisecond)
+			require.False(t, l.Allow(), "Second call to limiter.Allow() should return False with 1s per Token")
+			time.Sleep(1000 * time.Millisecond)
+			require.True(t, l.Allow(), "Third call to limiter.Allow() should return True with 1s per Token")
+		})
 	})
 
 	t.Run("100-requests-burst", func(t *testing.T) {
-		defer goleak.VerifyNone(t)
-
-		l := newTestTicker(startTime, 100, 100)
-		l.start(startTime)
-		defer l.stop()
-		for i := range 100 {
-			require.Truef(t, l.Allow(),
-				"Burst call %d to limiter.Allow() should return True with 100 initial tokens", i)
-			l.tick(50 * time.Millisecond)
-		}
+		synctest.Test(t, func(t *testing.T) {
+			l := NewTokenTicker(100, 100)
+			for i := range 100 {
+				require.Truef(t, l.Allow(),
+					"Burst call %d to limiter.Allow() should return True with 100 initial tokens", i)
+				time.Sleep(50 * time.Millisecond)
+			}
+		})
 	})
 
 	t.Run("101-requests-burst", func(t *testing.T) {
-		defer goleak.VerifyNone(t)
-
-		l := newTestTicker(startTime, 100, 100)
-		l.start(startTime)
-		defer l.stop()
-		for i := range 100 {
-			require.Truef(t, l.Allow(),
-				"Burst call %d to limiter.Allow() should return True with 100 initial tokens", i)
-			l.tick(50 * time.Microsecond)
-		}
-		require.False(t, l.Allow(),
-			"Burst call 101 to limiter.Allow() should return False with 100 initial tokens")
+		synctest.Test(t, func(t *testing.T) {
+			l := NewTokenTicker(100, 100)
+			for i := range 100 {
+				require.Truef(t, l.Allow(),
+					"Burst call %d to limiter.Allow() should return True with 100 initial tokens", i)
+				time.Sleep(50 * time.Microsecond)
+			}
+			require.False(t, l.Allow(),
+				"Burst call 101 to limiter.Allow() should return False with 100 initial tokens")
+		})
 	})
 
 	t.Run("bucket-refill-short", func(t *testing.T) {
-		defer goleak.VerifyNone(t)
-
-		l := newTestTicker(startTime, 100, 100)
-		l.start(startTime)
-		defer l.stop()
-
-		for range 1000 {
-			l.tick(time.Millisecond)
-			require.Equalf(t, int64(100), int64(l.t.lim.TokensAt(l.clock.now())), "Bucket should have exactly 100 tokens")
-		}
+		synctest.Test(t, func(t *testing.T) {
+			l := NewTokenTicker(100, 100)
+			time.Sleep(time.Millisecond)
+			require.Equal(t, 100, drain(l))
+		})
 	})
 
 	t.Run("bucket-refill-long", func(t *testing.T) {
-		defer goleak.VerifyNone(t)
-
-		l := newTestTicker(startTime, 100, 100)
-		l.start(startTime)
-		defer l.stop()
-
-		for range 1000 {
-			l.tick(3 * time.Second)
-		}
-		require.Equalf(t, int64(100), int64(l.t.lim.TokensAt(l.clock.now())), "Bucket should have exactly 100 tokens")
+		synctest.Test(t, func(t *testing.T) {
+			l := NewTokenTicker(100, 100)
+			time.Sleep(3 * time.Second)
+			require.Equal(t, 100, drain(l))
+		})
 	})
 
-	t.Run("allow-after-stop", func(t *testing.T) {
-		defer goleak.VerifyNone(t)
-
-		l := newTestTicker(startTime, 3, 3)
-		l.start(startTime)
-		require.True(t, l.Allow())
-		l.stop()
-		// The limiter keeps allowing until there's no more tokens
-		require.True(t, l.Allow())
-		require.True(t, l.Allow())
-		require.False(t, l.Allow())
+	t.Run("exhaust-burst-no-refill", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			l := NewTokenTicker(3, 3)
+			require.True(t, l.Allow())
+			require.True(t, l.Allow())
+			require.True(t, l.Allow())
+			require.False(t, l.Allow())
+		})
 	})
 
-	t.Run("allow-before-start", func(t *testing.T) {
-		defer goleak.VerifyNone(t)
-
-		l := newTestTicker(startTime, 2, 100)
-		// The limiter keeps allowing until there's no more tokens
-		require.True(t, l.Allow())
-		require.True(t, l.Allow())
-		require.False(t, l.Allow())
-		l.start(startTime)
-		// Start is a no-op, so the fake clock has not advanced enough to lazily refill a token yet.
-		require.False(t, l.Allow())
-		l.tick(10 * time.Millisecond)
-		// Advancing the fake clock refills the next token lazily on Allow.
-		require.True(t, l.Allow())
-		l.stop()
+	t.Run("refill-after-empty", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			l := NewTokenTicker(2, 100)
+			require.True(t, l.Allow())
+			require.True(t, l.Allow())
+			require.False(t, l.Allow())
+			require.False(t, l.Allow())
+			time.Sleep(10 * time.Millisecond)
+			require.True(t, l.Allow())
+		})
 	})
+}
+
+func drain(l Limiter) int {
+	n := 0
+	for l.Allow() {
+		n++
+	}
+	return n
 }
 
 func TestLimiter(t *testing.T) {
@@ -198,8 +171,6 @@ func TestLimiter(t *testing.T) {
 					})
 				}
 
-				l.Start()
-				defer l.Stop()
 				start := time.Now()
 				startBarrier.Done() // Unblock the user goroutines
 				stopBarrier.Wait()  // Wait for the user goroutines to be done
@@ -213,38 +184,33 @@ func TestLimiter(t *testing.T) {
 
 		burstFreq := 1000 * time.Millisecond
 		burstSize := 101
-		startTime := time.Now()
-		// Simulate sporadic bursts during up to 1 minute
 		for burstAmount := 1; burstAmount <= 10; burstAmount++ {
 			t.Run(fmt.Sprintf("requests-bursts-%d-iterations", burstAmount), func(t *testing.T) {
-				defer goleak.VerifyNone(t)
+				synctest.Test(t, func(t *testing.T) {
+					skipped := 0
+					kept := 0
+					l := NewTokenTicker(100, 100)
 
-				skipped := 0
-				kept := 0
-				l := newTestTicker(startTime, 100, 100)
-				l.start(startTime)
-				defer l.stop()
-
-				for c := 0; c < burstAmount; c++ {
-					for range burstSize {
-						if !l.Allow() {
-							skipped++
-						} else {
-							kept++
+					for c := 0; c < burstAmount; c++ {
+						for range burstSize {
+							if !l.Allow() {
+								skipped++
+							} else {
+								kept++
+							}
 						}
+						time.Sleep(burstFreq)
 					}
-					// Schedule next burst 1sec later
-					l.tick(burstFreq)
-				}
 
-				expectedSkipped := (burstSize - 100) * burstAmount
-				expectedKept := 100 * burstAmount
-				if burstSize < 100 {
-					expectedSkipped = 0
-					expectedKept = burstSize * burstAmount
-				}
-				require.Equalf(t, kept, expectedKept, "Expected %d burst requests to be kept", expectedKept)
-				require.Equalf(t, expectedSkipped, skipped, "Expected %d burst requests to be skipped", expectedSkipped)
+					expectedSkipped := (burstSize - 100) * burstAmount
+					expectedKept := 100 * burstAmount
+					if burstSize < 100 {
+						expectedSkipped = 0
+						expectedKept = burstSize * burstAmount
+					}
+					require.Equalf(t, kept, expectedKept, "Expected %d burst requests to be kept", expectedKept)
+					require.Equalf(t, expectedSkipped, skipped, "Expected %d burst requests to be skipped", expectedSkipped)
+				})
 			})
 		}
 	})
@@ -257,8 +223,6 @@ func BenchmarkLimiter(b *testing.B) {
 		b.Run(fmt.Sprintf("%d-users", nbUsers), func(b *testing.B) {
 			var skipped, kept atomic.Uint64
 			limiter := NewTokenTicker(0, 100)
-			limiter.Start()
-			defer limiter.Stop()
 
 			for b.Loop() {
 				var startBarrier, stopBarrier sync.WaitGroup
@@ -291,89 +255,34 @@ func BenchmarkLimiter(b *testing.B) {
 	}
 }
 
-type TestTicker struct {
-	clock *fakeClock
-	t     *TokenTicker
-}
-
-type fakeClock struct {
-	t time.Time
-}
-
-func (c *fakeClock) now() time.Time {
-	return c.t
-}
-
-func (c *fakeClock) advance(delta time.Duration) {
-	c.t = c.t.Add(delta)
-}
-
-func newTestTicker(startTime time.Time, tokens, maxTokens int64) *TestTicker {
-	clock := &fakeClock{t: startTime}
-	return &TestTicker{
-		clock: clock,
-		t:     newTokenTicker(tokens, maxTokens, time.Second, clock.now),
-	}
-}
-
-func (t *TestTicker) start(timestamp time.Time) {
-	t.clock.t = timestamp
-	t.t.Start()
-}
-
-func (t *TestTicker) stop() {
-	t.t.Stop()
-}
-
-func (t *TestTicker) tick(delta time.Duration) {
-	t.clock.advance(delta)
-}
-
-func (t *TestTicker) Allow() bool {
-	return t.t.Allow()
-}
-
-func newTestTickerWithInterval(startTime time.Time, tokens, maxTokens int64, interval time.Duration) *TestTicker {
-	clock := &fakeClock{t: startTime}
-	return &TestTicker{
-		clock: clock,
-		t:     newTokenTicker(tokens, maxTokens, interval, clock.now),
-	}
-}
-
 func TestLimiterWithInterval(t *testing.T) {
-	startTime := time.Now()
 	t.Run("60-per-minute-rate", func(t *testing.T) {
-		defer goleak.VerifyNone(t)
+		synctest.Test(t, func(t *testing.T) {
+			l := NewTokenTickerWithInterval(1, 60, time.Minute)
+			require.True(t, l.Allow(), "First call should be allowed")
+			require.False(t, l.Allow(), "Second call should be disallowed")
 
-		l := newTestTickerWithInterval(startTime, 1, 60, time.Minute) // 60 tokens per minute, so 1 per second
-		l.start(startTime)
-		defer l.stop()
-		require.True(t, l.Allow(), "First call should be allowed")
-		require.False(t, l.Allow(), "Second call should be disallowed")
+			time.Sleep(500 * time.Millisecond)
+			require.False(t, l.Allow(), "A call after 0.5s should be disallowed")
 
-		l.tick(500 * time.Millisecond)
-		require.False(t, l.Allow(), "A call after 0.5s should be disallowed")
-
-		l.tick(500 * time.Millisecond) // Total 1 second passed
-		require.True(t, l.Allow(), "A call after 1s should be allowed")
-		require.False(t, l.Allow(), "Another call should be disallowed")
+			time.Sleep(500 * time.Millisecond)
+			require.True(t, l.Allow(), "A call after 1s should be allowed")
+			require.False(t, l.Allow(), "Another call should be disallowed")
+		})
 	})
 
 	t.Run("1-per-100ms-rate", func(t *testing.T) {
-		defer goleak.VerifyNone(t)
+		synctest.Test(t, func(t *testing.T) {
+			l := NewTokenTickerWithInterval(1, 1, 100*time.Millisecond)
+			require.True(t, l.Allow(), "First call should be allowed")
+			require.False(t, l.Allow(), "Second call should be disallowed")
 
-		l := newTestTickerWithInterval(startTime, 1, 1, 100*time.Millisecond) // 1 token per 100ms
-		l.start(startTime)
-		defer l.stop()
-		require.True(t, l.Allow(), "First call should be allowed")
-		require.False(t, l.Allow(), "Second call should be disallowed")
+			time.Sleep(50 * time.Millisecond)
+			require.False(t, l.Allow(), "A call after 50ms should be disallowed")
 
-		l.tick(50 * time.Millisecond)
-		require.False(t, l.Allow(), "A call after 50ms should be disallowed")
-
-		l.tick(50 * time.Millisecond) // Total 100ms passed
-		require.True(t, l.Allow(), "A call after 100ms should be allowed")
-		require.False(t, l.Allow(), "Another call should be disallowed")
+			time.Sleep(50 * time.Millisecond)
+			require.True(t, l.Allow(), "A call after 100ms should be allowed")
+			require.False(t, l.Allow(), "Another call should be disallowed")
+		})
 	})
 }

--- a/internal/appsec/listener/waf/waf.go
+++ b/internal/appsec/listener/waf/waf.go
@@ -32,7 +32,7 @@ import (
 
 type Feature struct {
 	timeout         time.Duration
-	limiter         *limiter.TokenTicker
+	limiter         limiter.Limiter
 	handle          *libddwaf.Handle
 	supportedAddrs  config.AddressSet
 	rulesVersion    string
@@ -76,13 +76,10 @@ func NewWAFFeature(cfg *config.Config, rootOp dyngo.Operation) (listener.Feature
 
 	cfg.SupportedAddresses = config.NewAddressSet(newHandle.Addresses())
 
-	tokenTicker := limiter.NewTokenTicker(cfg.TraceRateLimit, cfg.TraceRateLimit)
-	tokenTicker.Start()
-
 	feature := &Feature{
 		handle:              newHandle,
 		timeout:             cfg.WAFTimeout,
-		limiter:             tokenTicker,
+		limiter:             limiter.NewTokenTicker(cfg.TraceRateLimit, cfg.TraceRateLimit),
 		supportedAddrs:      cfg.SupportedAddresses,
 		telemetryMetrics:    telemetryMetrics,
 		metaStructAvailable: cfg.MetaStructAvailable,
@@ -170,6 +167,5 @@ func (*Feature) String() string {
 }
 
 func (waf *Feature) Stop() {
-	waf.limiter.Stop()
 	waf.handle.Close()
 }


### PR DESCRIPTION
### What does this PR do?

Replaces the AppSec rate limiter's background-goroutine token bucket with a synchronous implementation backed by `golang.org/x/time/rate.Limiter`.

- Removes the per-instance background goroutine and hard-coded 500µs `time.Ticker` that woke ~2000×/sec on **every** pod, even idle ones.
- `Allow()` now refills the bucket lazily on call via `rate.Limiter`, so idle pods incur **zero** limiter CPU cost.
- Deletes the `TokenTicker` struct and its `Start()`/`Stop()` lifecycle. The `NewTokenTicker` / `NewTokenTickerWithInterval` constructors now return the `limiter.Limiter` interface backed directly by `*rate.Limiter` (which already satisfies `Allow() bool`).
- Drops the now-unused `Start()`/`Stop()` calls in the WAF listener and the apisec proxy sampler. As a side effect, the proxy sampler's previously-leaked goroutine (the `Sampler` interface had no `Stop`) is eliminated.
- Migrates the limiter unit tests from an injected fake clock to the standard `testing/synctest` package (deterministic virtual time); concurrency and benchmark tests remain on real time. Also fixes `BenchmarkLimiter`, which no longer built on modern Go (`B.Loop called with timer stopped`).

No change to rate-limit values, defaults, env vars, or the `Limiter` interface contract; behavior is preserved.

### Motivation

The limiter's background goroutine consumed roughly 0.3% of a CPU core per instance **continuously** — even on idle pods with no traffic — which adds up meaningfully across the fleet. `golang.org/x/time/rate` is already a direct dependency and is fully synchronous (no goroutine, no ticker), so it gives zero idle cost while preserving the existing token-bucket behavior. Per-call cost (~50ns uncontended) is irrelevant given `Allow()` is invoked at most ~100/s.

### Performance notes

Rough local microbenchmarks (single machine, quick comparison — directional only, not a rigorous A/B) informed the choice of `rate.Limiter`:

- **Idle cost (what we actually care about):** the old background ticker burned on the order of ~0.3% of a CPU core *per limiter instance, continuously*, even with zero traffic (it woke ~2000×/s regardless of load). The synchronous `rate.Limiter` does no background work, so idle cost drops to ~zero.
- **Per-call `Allow()`:** the old lock-free atomic path was a few ns uncontended; `rate.Limiter` is in the tens of ns uncontended, and the two are roughly comparable under contention. Both are allocation-free. At our call frequency (`Allow()` fires at most ~100/s) the difference is noise.
- **Why `rate.Limiter` vs a bespoke lazy bucket:** it's already a direct dependency, fully synchronous, and well-tested upstream — not worth hand-rolling and maintaining an equivalent for a sub-microsecond, low-frequency path.

Net trade: a negligible per-call overhead in exchange for eliminating a continuous, fleet-wide idle CPU cost.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [x] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

