### PR TITLE
fix(internal/remoteconfig): poll immediately on Subscribe

### DIFF
--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -424,36 +424,39 @@ type SubscriptionToken int
 // Subscribe should be preferred over RegisterProduct and RegisterCallback if
 // your callback only handles a single product.
 func Subscribe(product string, callback ProductCallback, capabilities ...Capability) (SubscriptionToken, error) {
-	if client == nil {
+	// Capture the singleton once so a concurrent Stop/Reset (which nils the
+	// global) can't cause a nil deref mid-function.
+	c := client
+	if c == nil {
 		return 0, ErrClientNotStarted
 	}
-	client.productsMu.RLock()
-	defer client.productsMu.RUnlock()
-	if _, found := client.products[product]; found {
+	c.productsMu.RLock()
+	defer c.productsMu.RUnlock()
+	if _, found := c.products[product]; found {
 		return 0, fmt.Errorf("product %s already registered via RegisterProduct", product)
 	}
 
-	client.subscriptionsMu.Lock()
-	defer client.subscriptionsMu.Unlock()
-	client.subscriptionsMu.idAllocator++
-	id := client.subscriptionsMu.idAllocator
+	c.subscriptionsMu.Lock()
+	defer c.subscriptionsMu.Unlock()
+	c.subscriptionsMu.idAllocator++
+	id := c.subscriptionsMu.idAllocator
 	sub := subscription{
 		id:           id,
 		product:      product,
 		capabilities: capabilities,
 		callback:     callback,
 	}
-	client.subscriptionsMu.subs = append(client.subscriptionsMu.subs, sub)
+	c.subscriptionsMu.subs = append(c.subscriptionsMu.subs, sub)
 
-	client.capabilitiesMu.Lock()
-	defer client.capabilitiesMu.Unlock()
+	c.capabilitiesMu.Lock()
+	defer c.capabilitiesMu.Unlock()
 	for _, cap := range capabilities {
-		client.capabilities[cap] = struct{}{}
+		c.capabilities[cap] = struct{}{}
 	}
 	// Poll now: Subscribe registers product+callback+capabilities atomically, so
 	// the poll can't arrive before the callback. (RegisterProduct/RegisterCapability
 	// don't — they're used before a callback exists; see those.)
-	client.requestPoll()
+	c.requestPoll()
 	return SubscriptionToken(id), nil
 }
 

--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -156,10 +156,7 @@ type Client struct {
 	endpoint   string
 	repository *rc.Repository
 	stop       chan struct{}
-	// pollNow signals the poll loop to perform an out-of-cycle config request,
-	// e.g. right after a product or capability is registered, so the first
-	// useful poll does not have to wait a full PollInterval. It is buffered
-	// (size 1) so signals coalesce and senders never block.
+	// pollNow requests an out-of-cycle poll. Buffered(1): sends coalesce and never block.
 	pollNow chan struct{}
 
 	// When acquiring several locks and using defer to release them, make sure to acquire the locks in the following order:
@@ -246,10 +243,13 @@ func Start(config ClientConfig) error {
 	}
 	started = true
 
+	// Capture the client locally so the goroutine never reads the package-global
+	// client, which Stop/Reset mutate under clientMux.
 	var (
-		pollInterval = client.PollInterval
-		stop         = client.stop
-		pollNow      = client.pollNow
+		c            = client
+		pollInterval = c.PollInterval
+		stop         = c.stop
+		pollNow      = c.pollNow
 	)
 	go func() {
 		ticker := time.NewTicker(pollInterval)
@@ -260,25 +260,14 @@ func Start(config ClientConfig) error {
 			case <-stop:
 				close(stop)
 				return
-			case <-pollNow:
-				// An out-of-cycle poll was requested (e.g. a product or
-				// capability was just registered). Poll immediately so the first
-				// useful request does not wait a full PollInterval, then realign
-				// the ticker so the steady-state cadence is measured from here.
-				if client == nil {
-					return
-				}
-				client.Lock()
-				client.updateState()
-				client.Unlock()
-				ticker.Reset(pollInterval)
+			case <-pollNow: // a product/capability was registered
+				c.Lock()
+				c.updateState()
+				c.Unlock()
 			case <-ticker.C:
-				if client == nil {
-					return
-				}
-				client.Lock()
-				client.updateState()
-				client.Unlock()
+				c.Lock()
+				c.updateState()
+				c.Unlock()
 			}
 		}
 	}()
@@ -396,10 +385,8 @@ func (c *Client) updateState() {
 	c.lastError = c.applyUpdate(&update)
 }
 
-// requestPoll asks the poll loop to perform an out-of-cycle configuration
-// request. It is non-blocking: if a poll is already pending, the signal is
-// coalesced (pollNow is buffered with size 1). Safe to call while holding the
-// client's other locks since it never blocks and acquires no locks.
+// requestPoll triggers a poll without waiting for the next tick. Non-blocking,
+// acquires no locks, so it is safe to call while holding the client's locks.
 func (c *Client) requestPoll() {
 	select {
 	case c.pollNow <- struct{}{}:
@@ -449,8 +436,6 @@ func Subscribe(product string, callback ProductCallback, capabilities ...Capabil
 	for _, cap := range capabilities {
 		client.capabilities[cap] = struct{}{}
 	}
-	// Trigger an immediate poll so the newly-advertised product/capabilities are
-	// fetched on the next request rather than after a full PollInterval.
 	client.requestPoll()
 	return SubscriptionToken(id), nil
 }
@@ -518,8 +503,6 @@ func RegisterProduct(p string) error {
 	}
 
 	client.products[p] = struct{}{}
-	// Trigger an immediate poll so the newly-registered product is fetched on the
-	// next request rather than after a full PollInterval.
 	client.requestPoll()
 	return nil
 }
@@ -568,8 +551,6 @@ func RegisterCapability(cpb Capability) error {
 	client.capabilitiesMu.Lock()
 	defer client.capabilitiesMu.Unlock()
 	client.capabilities[cpb] = struct{}{}
-	// Trigger an immediate poll so the newly-registered capability is advertised
-	// on the next request rather than after a full PollInterval.
 	client.requestPoll()
 	return nil
 }

--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -264,23 +264,26 @@ func Start(config ClientConfig) error {
 			case <-stop:
 				return
 			case <-pollNow: // a product/capability was registered
-				c.Lock()
-				c.updateState()
-				c.Unlock()
 			case <-ticker.C:
-				c.Lock()
-				c.updateState()
-				c.Unlock()
 			}
+			// If shutdown was requested at the same time as a pollNow/ticker
+			// wakeup (select picks a ready case at random), exit without polling.
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			c.Lock()
+			c.updateState()
+			c.Unlock()
 		}
 	}()
 	return nil
 }
 
-// Stop stops the client's update poll loop.
-// Noop if the client has already been stopped.
-// The remote config client is supposed to have the same lifecycle as the tracer.
-// It can't be restarted after a call to Stop() unless explicitly calling Reset().
+// Stop stops the client's update poll loop and clears the singleton, so a later
+// Start() can create a fresh client without calling Reset() first.
+// Noop if the client is not running.
 func Stop() {
 	clientMux.Lock()
 	defer clientMux.Unlock()

--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -155,10 +155,10 @@ type Client struct {
 	clientID   string
 	endpoint   string
 	repository *rc.Repository
-	stop       chan struct{} // closed once by Stop/Reset to tell the poll goroutine to exit
-	done       chan struct{} // closed by the poll goroutine when it exits
+	stop       chan struct{} // closed once (by Stop/Reset) to stop the poll goroutine
+	done       chan struct{} // closed by the poll goroutine on exit
 	stopOnce   sync.Once
-	// pollNow requests an out-of-cycle poll. Buffered size 1: sends are coalesced and non-blocking.
+	// pollNow requests an out-of-cycle poll. Buffered(1): coalesced, non-blocking.
 	pollNow chan struct{}
 
 	// When acquiring several locks and using defer to release them, make sure to acquire the locks in the following order:
@@ -246,8 +246,7 @@ func Start(config ClientConfig) error {
 	}
 	started = true
 
-	// Capture the client locally so the goroutine never reads the package-global
-	// client, which Stop/Reset mutate under clientMux.
+	// Capture client locally; the goroutine must not read the global (Stop/Reset mutate it).
 	var (
 		c            = client
 		pollInterval = c.PollInterval
@@ -263,11 +262,10 @@ func Start(config ClientConfig) error {
 			select {
 			case <-stop:
 				return
-			case <-pollNow: // a product/capability was registered
+			case <-pollNow: // Subscribe requested a poll
 			case <-ticker.C:
 			}
-			// If shutdown was requested at the same time as a pollNow/ticker
-			// wakeup (select picks a ready case at random), exit without polling.
+			// stop may be ready alongside pollNow/ticker (select is random); don't poll after stop.
 			select {
 			case <-stop:
 				return
@@ -281,12 +279,10 @@ func Start(config ClientConfig) error {
 	return nil
 }
 
-// Stop stops the client's update poll loop, waits for the poll goroutine to
-// exit (up to the HTTP client's timeout, since a poll may be in flight), then
-// clears the singleton so a later Start() creates a fresh client. If stopping
-// times out (e.g. no HTTP timeout is configured), the singleton is cleared
-// anyway and a restart could briefly overlap the in-flight poll.
-// Noop if the client is not running.
+// Stop ends the poll loop, waits for the goroutine to exit (up to the HTTP
+// timeout, since a poll may be in flight), then clears the singleton so a later
+// Start() is fresh. On wait timeout it clears anyway (a restart could briefly
+// overlap the in-flight poll). Noop if not running.
 func Stop() {
 	clientMux.Lock()
 	defer clientMux.Unlock()
@@ -301,11 +297,8 @@ func Stop() {
 	}
 	log.Debug("remoteconfig: gracefully stopping the client")
 	client.stopOnce.Do(func() { close(client.stop) })
-	// A poll may be in-flight for up to the HTTP client's timeout, so wait that
-	// long (plus a small grace, so done — closed just after the request returns —
-	// wins over the timeout) before clearing the singleton; otherwise a fresh
-	// Start() could overlap a still-running client. Floored at 1s so we don't
-	// block forever when no HTTP timeout is configured.
+	// Wait for the goroutine, up to the HTTP timeout (+1s grace so done wins) since
+	// a poll may be in flight. Floored at 1s; bounded so we don't block forever.
 	wait := time.Second
 	if client.HTTP != nil && client.HTTP.Timeout > 0 {
 		wait = client.HTTP.Timeout + time.Second
@@ -326,9 +319,7 @@ func Reset() {
 	clientMux.Lock()
 	defer clientMux.Unlock()
 
-	// Signal any running poll goroutine to exit. Closing is safe even if the
-	// client was never started; Reset only clears singleton state and does not
-	// wait for the goroutine to finish.
+	// Signal the goroutine to exit (safe even if never started); Reset doesn't wait.
 	if client != nil {
 		client.stopOnce.Do(func() { close(client.stop) })
 	}
@@ -409,8 +400,7 @@ func (c *Client) updateState() {
 	c.lastError = c.applyUpdate(&update)
 }
 
-// requestPoll triggers a poll without waiting for the next tick. Non-blocking,
-// acquires no locks, so it is safe to call while holding the client's locks.
+// requestPoll asks the loop to poll now. Non-blocking, no locks (safe under the client's locks).
 func (c *Client) requestPoll() {
 	select {
 	case c.pollNow <- struct{}{}:
@@ -460,11 +450,9 @@ func Subscribe(product string, callback ProductCallback, capabilities ...Capabil
 	for _, cap := range capabilities {
 		client.capabilities[cap] = struct{}{}
 	}
-	// Subscribe registers the product, callback, and capabilities atomically, so
-	// an immediate poll can't deliver config before the callback exists. The
-	// lower-level RegisterProduct/RegisterCapability are used piecemeal (e.g. by
-	// AppSec, before its callback is registered), so they do NOT poll eagerly —
-	// they're picked up on the next scheduled tick.
+	// Poll now: Subscribe registers product+callback+capabilities atomically, so
+	// the poll can't arrive before the callback. (RegisterProduct/RegisterCapability
+	// don't — they're used before a callback exists; see those.)
 	client.requestPoll()
 	return SubscriptionToken(id), nil
 }
@@ -532,9 +520,8 @@ func RegisterProduct(p string) error {
 	}
 
 	client.products[p] = struct{}{}
-	// No eager poll here: RegisterProduct is used before a callback is registered
-	// (see Subscribe), so a poll could store config the repository later dedupes
-	// before the callback exists. Picked up on the next scheduled tick.
+	// No eager poll: used before a callback exists (see Subscribe), so an early
+	// poll's config would be dedup'd before the callback sees it. Picked up next tick.
 	return nil
 }
 
@@ -582,7 +569,7 @@ func RegisterCapability(cpb Capability) error {
 	client.capabilitiesMu.Lock()
 	defer client.capabilitiesMu.Unlock()
 	client.capabilities[cpb] = struct{}{}
-	// No eager poll here (see RegisterProduct / Subscribe): picked up next tick.
+	// No eager poll (see Subscribe); picked up next tick.
 	return nil
 }
 

--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -281,8 +281,11 @@ func Start(config ClientConfig) error {
 	return nil
 }
 
-// Stop stops the client's update poll loop and clears the singleton, so a later
-// Start() can create a fresh client without calling Reset() first.
+// Stop stops the client's update poll loop, waits for the poll goroutine to
+// exit (up to the HTTP client's timeout, since a poll may be in flight), then
+// clears the singleton so a later Start() creates a fresh client. If stopping
+// times out (e.g. no HTTP timeout is configured), the singleton is cleared
+// anyway and a restart could briefly overlap the in-flight poll.
 // Noop if the client is not running.
 func Stop() {
 	clientMux.Lock()
@@ -298,13 +301,14 @@ func Stop() {
 	}
 	log.Debug("remoteconfig: gracefully stopping the client")
 	client.stopOnce.Do(func() { close(client.stop) })
-	// A poll may be in-flight for up to the HTTP client's timeout, so wait at
-	// least that long for the goroutine to exit before clearing the singleton —
-	// otherwise a fresh Start() could overlap a still-running client. Bounded so
-	// we don't block forever when no HTTP timeout is configured.
+	// A poll may be in-flight for up to the HTTP client's timeout, so wait that
+	// long (plus a small grace, so done — closed just after the request returns —
+	// wins over the timeout) before clearing the singleton; otherwise a fresh
+	// Start() could overlap a still-running client. Floored at 1s so we don't
+	// block forever when no HTTP timeout is configured.
 	wait := time.Second
-	if client.HTTP != nil && client.HTTP.Timeout > wait {
-		wait = client.HTTP.Timeout
+	if client.HTTP != nil && client.HTTP.Timeout > 0 {
+		wait = client.HTTP.Timeout + time.Second
 	}
 	select {
 	case <-client.done:
@@ -456,6 +460,11 @@ func Subscribe(product string, callback ProductCallback, capabilities ...Capabil
 	for _, cap := range capabilities {
 		client.capabilities[cap] = struct{}{}
 	}
+	// Subscribe registers the product, callback, and capabilities atomically, so
+	// an immediate poll can't deliver config before the callback exists. The
+	// lower-level RegisterProduct/RegisterCapability are used piecemeal (e.g. by
+	// AppSec, before its callback is registered), so they do NOT poll eagerly —
+	// they're picked up on the next scheduled tick.
 	client.requestPoll()
 	return SubscriptionToken(id), nil
 }
@@ -523,7 +532,9 @@ func RegisterProduct(p string) error {
 	}
 
 	client.products[p] = struct{}{}
-	client.requestPoll()
+	// No eager poll here: RegisterProduct is used before a callback is registered
+	// (see Subscribe), so a poll could store config the repository later dedupes
+	// before the callback exists. Picked up on the next scheduled tick.
 	return nil
 }
 
@@ -571,7 +582,7 @@ func RegisterCapability(cpb Capability) error {
 	client.capabilitiesMu.Lock()
 	defer client.capabilitiesMu.Unlock()
 	client.capabilities[cpb] = struct{}{}
-	client.requestPoll()
+	// No eager poll here (see RegisterProduct / Subscribe): picked up next tick.
 	return nil
 }
 

--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -298,10 +298,18 @@ func Stop() {
 	}
 	log.Debug("remoteconfig: gracefully stopping the client")
 	client.stopOnce.Do(func() { close(client.stop) })
+	// A poll may be in-flight for up to the HTTP client's timeout, so wait at
+	// least that long for the goroutine to exit before clearing the singleton —
+	// otherwise a fresh Start() could overlap a still-running client. Bounded so
+	// we don't block forever when no HTTP timeout is configured.
+	wait := time.Second
+	if client.HTTP != nil && client.HTTP.Timeout > wait {
+		wait = client.HTTP.Timeout
+	}
 	select {
 	case <-client.done:
 		log.Debug("remoteconfig: client stopped successfully")
-	case <-time.After(time.Second):
+	case <-time.After(wait):
 		log.Debug("remoteconfig: client stopping timeout")
 	}
 	client = nil

--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -156,6 +156,11 @@ type Client struct {
 	endpoint   string
 	repository *rc.Repository
 	stop       chan struct{}
+	// pollNow signals the poll loop to perform an out-of-cycle config request,
+	// e.g. right after a product or capability is registered, so the first
+	// useful poll does not have to wait a full PollInterval. It is buffered
+	// (size 1) so signals coalesce and senders never block.
+	pollNow chan struct{}
 
 	// When acquiring several locks and using defer to release them, make sure to acquire the locks in the following order:
 	callbacks       []Callback
@@ -212,6 +217,7 @@ func newClient(config ClientConfig) (*Client, error) {
 		endpoint:     fmt.Sprintf("%s/v0.7/config", config.AgentURL),
 		repository:   repo,
 		stop:         make(chan struct{}),
+		pollNow:      make(chan struct{}, 1),
 		lastError:    nil,
 		callbacks:    []Callback{},
 		capabilities: map[Capability]struct{}{},
@@ -243,6 +249,7 @@ func Start(config ClientConfig) error {
 	var (
 		pollInterval = client.PollInterval
 		stop         = client.stop
+		pollNow      = client.pollNow
 	)
 	go func() {
 		ticker := time.NewTicker(pollInterval)
@@ -253,6 +260,18 @@ func Start(config ClientConfig) error {
 			case <-stop:
 				close(stop)
 				return
+			case <-pollNow:
+				// An out-of-cycle poll was requested (e.g. a product or
+				// capability was just registered). Poll immediately so the first
+				// useful request does not wait a full PollInterval, then realign
+				// the ticker so the steady-state cadence is measured from here.
+				if client == nil {
+					return
+				}
+				client.Lock()
+				client.updateState()
+				client.Unlock()
+				ticker.Reset(pollInterval)
 			case <-ticker.C:
 				if client == nil {
 					return
@@ -377,6 +396,17 @@ func (c *Client) updateState() {
 	c.lastError = c.applyUpdate(&update)
 }
 
+// requestPoll asks the poll loop to perform an out-of-cycle configuration
+// request. It is non-blocking: if a poll is already pending, the signal is
+// coalesced (pollNow is buffered with size 1). Safe to call while holding the
+// client's other locks since it never blocks and acquires no locks.
+func (c *Client) requestPoll() {
+	select {
+	case c.pollNow <- struct{}{}:
+	default:
+	}
+}
+
 type SubscriptionToken int
 
 // Subscribe registers a product and its callback to be invoked when the client
@@ -419,6 +449,9 @@ func Subscribe(product string, callback ProductCallback, capabilities ...Capabil
 	for _, cap := range capabilities {
 		client.capabilities[cap] = struct{}{}
 	}
+	// Trigger an immediate poll so the newly-advertised product/capabilities are
+	// fetched on the next request rather than after a full PollInterval.
+	client.requestPoll()
 	return SubscriptionToken(id), nil
 }
 
@@ -485,6 +518,9 @@ func RegisterProduct(p string) error {
 	}
 
 	client.products[p] = struct{}{}
+	// Trigger an immediate poll so the newly-registered product is fetched on the
+	// next request rather than after a full PollInterval.
+	client.requestPoll()
 	return nil
 }
 
@@ -532,6 +568,9 @@ func RegisterCapability(cpb Capability) error {
 	client.capabilitiesMu.Lock()
 	defer client.capabilitiesMu.Unlock()
 	client.capabilities[cpb] = struct{}{}
+	// Trigger an immediate poll so the newly-registered capability is advertised
+	// on the next request rather than after a full PollInterval.
+	client.requestPoll()
 	return nil
 }
 

--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -155,8 +155,10 @@ type Client struct {
 	clientID   string
 	endpoint   string
 	repository *rc.Repository
-	stop       chan struct{}
-	// pollNow requests an out-of-cycle poll. Buffered(1): sends coalesce and never block.
+	stop       chan struct{} // closed once by Stop/Reset to tell the poll goroutine to exit
+	done       chan struct{} // closed by the poll goroutine when it exits
+	stopOnce   sync.Once
+	// pollNow requests an out-of-cycle poll. Buffered size 1: sends are coalesced and non-blocking.
 	pollNow chan struct{}
 
 	// When acquiring several locks and using defer to release them, make sure to acquire the locks in the following order:
@@ -214,6 +216,7 @@ func newClient(config ClientConfig) (*Client, error) {
 		endpoint:     fmt.Sprintf("%s/v0.7/config", config.AgentURL),
 		repository:   repo,
 		stop:         make(chan struct{}),
+		done:         make(chan struct{}),
 		pollNow:      make(chan struct{}, 1),
 		lastError:    nil,
 		callbacks:    []Callback{},
@@ -252,13 +255,13 @@ func Start(config ClientConfig) error {
 		pollNow      = c.pollNow
 	)
 	go func() {
+		defer close(c.done)
 		ticker := time.NewTicker(pollInterval)
 		defer ticker.Stop()
 
 		for {
 			select {
 			case <-stop:
-				close(stop)
 				return
 			case <-pollNow: // a product/capability was registered
 				c.Lock()
@@ -291,9 +294,9 @@ func Stop() {
 		return
 	}
 	log.Debug("remoteconfig: gracefully stopping the client")
-	client.stop <- struct{}{}
+	client.stopOnce.Do(func() { close(client.stop) })
 	select {
-	case <-client.stop:
+	case <-client.done:
 		log.Debug("remoteconfig: client stopped successfully")
 	case <-time.After(time.Second):
 		log.Debug("remoteconfig: client stopping timeout")
@@ -308,6 +311,12 @@ func Reset() {
 	clientMux.Lock()
 	defer clientMux.Unlock()
 
+	// Signal any running poll goroutine to exit. Closing is safe even if the
+	// client was never started; Reset only clears singleton state and does not
+	// wait for the goroutine to finish.
+	if client != nil {
+		client.stopOnce.Do(func() { close(client.stop) })
+	}
 	client = nil
 	started = false
 }

--- a/internal/remoteconfig/remoteconfig_test.go
+++ b/internal/remoteconfig/remoteconfig_test.go
@@ -10,9 +10,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -598,5 +601,53 @@ func TestAllCapabilitiesNoDeadlockWithSubscribe(t *testing.T) {
 	case <-done:
 	case <-time.After(5 * time.Second):
 		t.Fatal("allCapabilities deadlocked with concurrent subscribe")
+	}
+}
+
+// TestPollOnRegistration verifies that registering a product or capability
+// triggers an immediate out-of-cycle config poll rather than waiting a full
+// PollInterval. This brings dd-trace-go to parity with the other server SDKs
+// (see FFL-2604).
+func TestPollOnRegistration(t *testing.T) {
+	t.Setenv("DD_REMOTE_CONFIGURATION_ENABLED", "true")
+
+	register := map[string]func() error{
+		"Subscribe": func() error {
+			_, err := Subscribe("TEST_PRODUCT", func(ProductUpdate) map[string]state.ApplyStatus { return nil }, FFEFlagEvaluation)
+			return err
+		},
+		"RegisterProduct":    func() error { return RegisterProduct("TEST_PRODUCT") },
+		"RegisterCapability": func() error { return RegisterCapability(FFEFlagEvaluation) },
+	}
+
+	for name, reg := range register {
+		t.Run(name, func(t *testing.T) {
+			// Reset the package-global RC singleton up front so the test is
+			// robust to ordering and to a prior test panicking before cleanup.
+			Reset()
+			defer Stop()
+
+			var polls int64
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				atomic.AddInt64(&polls, 1)
+				w.Write([]byte(`{}`))
+			}))
+			defer srv.Close()
+
+			cfg := DefaultClientConfig()
+			cfg.AgentURL = srv.URL
+			cfg.ServiceName = "test"
+			// A long interval so any poll observed within the test window must be
+			// the out-of-cycle poll triggered by registration, not a scheduled tick.
+			cfg.PollInterval = time.Hour
+			require.NoError(t, Start(cfg))
+
+			require.NoError(t, reg())
+
+			require.Eventually(t, func() bool {
+				return atomic.LoadInt64(&polls) >= 1
+			}, 5*time.Second, 5*time.Millisecond,
+				name+" should trigger an out-of-cycle poll well before PollInterval elapses")
+		})
 	}
 }

--- a/internal/remoteconfig/remoteconfig_test.go
+++ b/internal/remoteconfig/remoteconfig_test.go
@@ -617,7 +617,11 @@ func recordingClientConfig(requests chan<- struct{}) ClientConfig {
 	cfg.ServiceName = "test"
 	cfg.PollInterval = time.Hour
 	cfg.HTTP = &http.Client{
-		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			// http.RoundTripper is responsible for closing the request body.
+			if r.Body != nil {
+				r.Body.Close()
+			}
 			select {
 			case requests <- struct{}{}:
 			default:

--- a/internal/remoteconfig/remoteconfig_test.go
+++ b/internal/remoteconfig/remoteconfig_test.go
@@ -611,12 +611,18 @@ func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { retu
 // recordingClientConfig returns an RC client config whose HTTP client records
 // each request (non-blocking) and returns an empty body. PollInterval is 1h, so
 // a request seen within the test window can only be a Subscribe-driven poll.
-func recordingClientConfig(requests chan<- struct{}) ClientConfig {
+// AgentURL is set so updateState builds an absolute request URL (as in prod),
+// which the RoundTripper asserts.
+func recordingClientConfig(t *testing.T, requests chan<- struct{}) ClientConfig {
 	cfg := DefaultClientConfig()
 	cfg.ServiceName = "test"
+	cfg.AgentURL = "http://agent.test" // non-routable; the transport is faked anyway
 	cfg.PollInterval = time.Hour
 	cfg.HTTP = &http.Client{
 		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if !r.URL.IsAbs() {
+				t.Errorf("RC request URL is not absolute: %q", r.URL)
+			}
 			// http.RoundTripper is responsible for closing the request body.
 			if r.Body != nil {
 				r.Body.Close()
@@ -642,7 +648,7 @@ func TestPollOnSubscribe(t *testing.T) {
 	defer Stop()
 
 	requests := make(chan struct{}, 1)
-	require.NoError(t, Start(recordingClientConfig(requests)))
+	require.NoError(t, Start(recordingClientConfig(t, requests)))
 	_, err := Subscribe("TEST_PRODUCT", func(ProductUpdate) map[string]state.ApplyStatus { return nil }, FFEFlagEvaluation)
 	require.NoError(t, err)
 
@@ -670,7 +676,7 @@ func TestNoImmediatePollOnRegisterProductOrCapability(t *testing.T) {
 			defer Stop()
 
 			requests := make(chan struct{}, 1)
-			require.NoError(t, Start(recordingClientConfig(requests)))
+			require.NoError(t, Start(recordingClientConfig(t, requests)))
 			require.NoError(t, reg())
 
 			select {
@@ -691,7 +697,7 @@ func TestNoPollWithoutRegistration(t *testing.T) {
 	defer Stop()
 
 	requests := make(chan struct{}, 1)
-	require.NoError(t, Start(recordingClientConfig(requests)))
+	require.NoError(t, Start(recordingClientConfig(t, requests)))
 
 	select {
 	case <-requests:
@@ -709,7 +715,7 @@ func TestPollOnEachSubscribe(t *testing.T) {
 	defer Stop()
 
 	requests := make(chan struct{}, 1)
-	require.NoError(t, Start(recordingClientConfig(requests)))
+	require.NoError(t, Start(recordingClientConfig(t, requests)))
 	cb := func(ProductUpdate) map[string]state.ApplyStatus { return nil }
 
 	_, err := Subscribe("product-a", cb, FFEFlagEvaluation)

--- a/internal/remoteconfig/remoteconfig_test.go
+++ b/internal/remoteconfig/remoteconfig_test.go
@@ -9,13 +9,12 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math/rand"
 	"net/http"
-	"net/http/httptest"
 	"reflect"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -604,6 +603,34 @@ func TestAllCapabilitiesNoDeadlockWithSubscribe(t *testing.T) {
 	}
 }
 
+// roundTripFunc adapts a function to an http.RoundTripper.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// recordingClientConfig returns an RC client config whose HTTP client records
+// each outgoing request on requests (non-blocking) and returns an empty config
+// body. PollInterval is 1h so the ticker cannot be responsible for a request
+// observed within a short window — only a registration-driven poll can be.
+func recordingClientConfig(requests chan<- struct{}) ClientConfig {
+	cfg := DefaultClientConfig()
+	cfg.ServiceName = "test"
+	cfg.PollInterval = time.Hour
+	cfg.HTTP = &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			select {
+			case requests <- struct{}{}:
+			default:
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}, nil
+		}),
+	}
+	return cfg
+}
+
 // TestPollOnRegistration verifies that registering a product or capability
 // triggers an out-of-cycle poll instead of waiting a full PollInterval.
 func TestPollOnRegistration(t *testing.T) {
@@ -623,24 +650,62 @@ func TestPollOnRegistration(t *testing.T) {
 			Reset() // clear any client left by a prior test
 			defer Stop()
 
-			var polls int64
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				atomic.AddInt64(&polls, 1)
-				w.Write([]byte(`{}`))
-			}))
-			defer srv.Close()
-
-			cfg := DefaultClientConfig()
-			cfg.AgentURL = srv.URL
-			cfg.ServiceName = "test"
-			cfg.PollInterval = time.Hour // long: any poll here is the registration-triggered one
-			require.NoError(t, Start(cfg))
-
+			requests := make(chan struct{}, 1)
+			require.NoError(t, Start(recordingClientConfig(requests)))
 			require.NoError(t, reg())
 
-			require.Eventually(t, func() bool {
-				return atomic.LoadInt64(&polls) >= 1
-			}, 5*time.Second, 5*time.Millisecond, name+" should poll before PollInterval")
+			select {
+			case <-requests:
+				// Out-of-cycle poll fired right after registration.
+			case <-time.After(2 * time.Second):
+				t.Fatalf("%s did not trigger a poll within 2s (PollInterval is 1h, so the ticker can't be the cause)", name)
+			}
 		})
+	}
+}
+
+// TestNoPollWithoutRegistration verifies that Start alone does not fire a poll;
+// out-of-cycle polling only happens after a product/capability is registered.
+func TestNoPollWithoutRegistration(t *testing.T) {
+	t.Setenv("DD_REMOTE_CONFIGURATION_ENABLED", "true")
+	Reset()
+	defer Stop()
+
+	requests := make(chan struct{}, 1)
+	require.NoError(t, Start(recordingClientConfig(requests)))
+
+	select {
+	case <-requests:
+		t.Fatal("unexpected poll: Start fired a request with nothing registered")
+	case <-time.After(200 * time.Millisecond):
+		// No poll without a registration.
+	}
+}
+
+// TestPollOnEachRegistration verifies that a second registration triggers
+// another poll once the first has drained: pollNow coalesces while a signal is
+// queued, but still fires for later registrations after the channel drains.
+func TestPollOnEachRegistration(t *testing.T) {
+	t.Setenv("DD_REMOTE_CONFIGURATION_ENABLED", "true")
+	Reset()
+	defer Stop()
+
+	requests := make(chan struct{}, 1)
+	require.NoError(t, Start(recordingClientConfig(requests)))
+
+	require.NoError(t, RegisterProduct("product-a"))
+	select {
+	case <-requests:
+	case <-time.After(2 * time.Second):
+		t.Fatal("no poll within 2s after the first registration")
+	}
+
+	// The channel is drained; a later registration must trigger its own poll.
+	require.NoError(t, RegisterProduct("product-b"))
+	select {
+	case <-requests:
+		// Second registration triggered another poll.
+	case <-time.After(2 * time.Second):
+		t.Fatal("no poll within 2s after the second registration")
 	}
 }

--- a/internal/remoteconfig/remoteconfig_test.go
+++ b/internal/remoteconfig/remoteconfig_test.go
@@ -635,23 +635,43 @@ func recordingClientConfig(requests chan<- struct{}) ClientConfig {
 	return cfg
 }
 
-// TestPollOnRegistration verifies that registering a product or capability
-// triggers an out-of-cycle poll instead of waiting a full PollInterval.
-func TestPollOnRegistration(t *testing.T) {
+// TestPollOnSubscribe verifies that Subscribe triggers an out-of-cycle poll
+// instead of waiting a full PollInterval. Subscribe registers the product,
+// callback, and capabilities atomically, so the poll can't race a callback that
+// isn't registered yet.
+func TestPollOnSubscribe(t *testing.T) {
+	t.Setenv("DD_REMOTE_CONFIGURATION_ENABLED", "true")
+	Reset()
+	defer Stop()
+
+	requests := make(chan struct{}, 1)
+	require.NoError(t, Start(recordingClientConfig(requests)))
+	_, err := Subscribe("TEST_PRODUCT", func(ProductUpdate) map[string]state.ApplyStatus { return nil }, FFEFlagEvaluation)
+	require.NoError(t, err)
+
+	select {
+	case <-requests:
+		// Out-of-cycle poll fired right after Subscribe.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Subscribe did not trigger a poll within 2s (PollInterval is 1h, so the ticker can't be the cause)")
+	}
+}
+
+// TestNoImmediatePollOnRegisterProductOrCapability verifies that the lower-level
+// RegisterProduct/RegisterCapability do NOT trigger an immediate poll. They are
+// used piecemeal (e.g. by AppSec) before a callback is registered, so an eager
+// poll could store config the repository later dedupes before the callback
+// exists; they are picked up on the next scheduled tick instead.
+func TestNoImmediatePollOnRegisterProductOrCapability(t *testing.T) {
 	t.Setenv("DD_REMOTE_CONFIGURATION_ENABLED", "true")
 
 	register := map[string]func() error{
-		"Subscribe": func() error {
-			_, err := Subscribe("TEST_PRODUCT", func(ProductUpdate) map[string]state.ApplyStatus { return nil }, FFEFlagEvaluation)
-			return err
-		},
 		"RegisterProduct":    func() error { return RegisterProduct("TEST_PRODUCT") },
 		"RegisterCapability": func() error { return RegisterCapability(FFEFlagEvaluation) },
 	}
-
 	for name, reg := range register {
 		t.Run(name, func(t *testing.T) {
-			Reset() // clear any client left by a prior test
+			Reset()
 			defer Stop()
 
 			requests := make(chan struct{}, 1)
@@ -660,16 +680,16 @@ func TestPollOnRegistration(t *testing.T) {
 
 			select {
 			case <-requests:
-				// Out-of-cycle poll fired right after registration.
-			case <-time.After(2 * time.Second):
-				t.Fatalf("%s did not trigger a poll within 2s (PollInterval is 1h, so the ticker can't be the cause)", name)
+				t.Fatalf("%s should not trigger an immediate poll", name)
+			case <-time.After(200 * time.Millisecond):
+				// Expected: picked up on the next tick, not eagerly.
 			}
 		})
 	}
 }
 
 // TestNoPollWithoutRegistration verifies that Start alone does not fire a poll;
-// out-of-cycle polling only happens after a product/capability is registered.
+// out-of-cycle polling only happens after a Subscribe.
 func TestNoPollWithoutRegistration(t *testing.T) {
 	t.Setenv("DD_REMOTE_CONFIGURATION_ENABLED", "true")
 	Reset()
@@ -686,30 +706,33 @@ func TestNoPollWithoutRegistration(t *testing.T) {
 	}
 }
 
-// TestPollOnEachRegistration verifies that a second registration triggers
-// another poll once the first has drained: pollNow coalesces while a signal is
-// queued, but still fires for later registrations after the channel drains.
-func TestPollOnEachRegistration(t *testing.T) {
+// TestPollOnEachSubscribe verifies that a second Subscribe triggers another poll
+// once the first has drained: pollNow coalesces while a signal is queued, but
+// still fires for later subscriptions after the channel drains.
+func TestPollOnEachSubscribe(t *testing.T) {
 	t.Setenv("DD_REMOTE_CONFIGURATION_ENABLED", "true")
 	Reset()
 	defer Stop()
 
 	requests := make(chan struct{}, 1)
 	require.NoError(t, Start(recordingClientConfig(requests)))
+	cb := func(ProductUpdate) map[string]state.ApplyStatus { return nil }
 
-	require.NoError(t, RegisterProduct("product-a"))
+	_, err := Subscribe("product-a", cb, FFEFlagEvaluation)
+	require.NoError(t, err)
 	select {
 	case <-requests:
 	case <-time.After(2 * time.Second):
-		t.Fatal("no poll within 2s after the first registration")
+		t.Fatal("no poll within 2s after the first Subscribe")
 	}
 
-	// The channel is drained; a later registration must trigger its own poll.
-	require.NoError(t, RegisterProduct("product-b"))
+	// The channel is drained; a later Subscribe must trigger its own poll.
+	_, err = Subscribe("product-b", cb)
+	require.NoError(t, err)
 	select {
 	case <-requests:
-		// Second registration triggered another poll.
+		// Second Subscribe triggered another poll.
 	case <-time.After(2 * time.Second):
-		t.Fatal("no poll within 2s after the second registration")
+		t.Fatal("no poll within 2s after the second Subscribe")
 	}
 }

--- a/internal/remoteconfig/remoteconfig_test.go
+++ b/internal/remoteconfig/remoteconfig_test.go
@@ -609,9 +609,8 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
 // recordingClientConfig returns an RC client config whose HTTP client records
-// each outgoing request on requests (non-blocking) and returns an empty config
-// body. PollInterval is 1h so the ticker cannot be responsible for a request
-// observed within a short window — only a registration-driven poll can be.
+// each request (non-blocking) and returns an empty body. PollInterval is 1h, so
+// a request seen within the test window can only be a Subscribe-driven poll.
 func recordingClientConfig(requests chan<- struct{}) ClientConfig {
 	cfg := DefaultClientConfig()
 	cfg.ServiceName = "test"
@@ -635,10 +634,8 @@ func recordingClientConfig(requests chan<- struct{}) ClientConfig {
 	return cfg
 }
 
-// TestPollOnSubscribe verifies that Subscribe triggers an out-of-cycle poll
-// instead of waiting a full PollInterval. Subscribe registers the product,
-// callback, and capabilities atomically, so the poll can't race a callback that
-// isn't registered yet.
+// TestPollOnSubscribe verifies Subscribe triggers an out-of-cycle poll instead
+// of waiting a full PollInterval.
 func TestPollOnSubscribe(t *testing.T) {
 	t.Setenv("DD_REMOTE_CONFIGURATION_ENABLED", "true")
 	Reset()
@@ -657,11 +654,9 @@ func TestPollOnSubscribe(t *testing.T) {
 	}
 }
 
-// TestNoImmediatePollOnRegisterProductOrCapability verifies that the lower-level
-// RegisterProduct/RegisterCapability do NOT trigger an immediate poll. They are
-// used piecemeal (e.g. by AppSec) before a callback is registered, so an eager
-// poll could store config the repository later dedupes before the callback
-// exists; they are picked up on the next scheduled tick instead.
+// TestNoImmediatePollOnRegisterProductOrCapability verifies RegisterProduct and
+// RegisterCapability do NOT poll immediately — they're used before a callback
+// exists (e.g. AppSec), so they wait for the next tick.
 func TestNoImmediatePollOnRegisterProductOrCapability(t *testing.T) {
 	t.Setenv("DD_REMOTE_CONFIGURATION_ENABLED", "true")
 
@@ -706,9 +701,8 @@ func TestNoPollWithoutRegistration(t *testing.T) {
 	}
 }
 
-// TestPollOnEachSubscribe verifies that a second Subscribe triggers another poll
-// once the first has drained: pollNow coalesces while a signal is queued, but
-// still fires for later subscriptions after the channel drains.
+// TestPollOnEachSubscribe verifies a second Subscribe polls again after the
+// first drains (pollNow coalesces while queued, then fires for later Subscribes).
 func TestPollOnEachSubscribe(t *testing.T) {
 	t.Setenv("DD_REMOTE_CONFIGURATION_ENABLED", "true")
 	Reset()

--- a/internal/remoteconfig/remoteconfig_test.go
+++ b/internal/remoteconfig/remoteconfig_test.go
@@ -605,9 +605,7 @@ func TestAllCapabilitiesNoDeadlockWithSubscribe(t *testing.T) {
 }
 
 // TestPollOnRegistration verifies that registering a product or capability
-// triggers an immediate out-of-cycle config poll rather than waiting a full
-// PollInterval. This brings dd-trace-go to parity with the other server SDKs
-// (see FFL-2604).
+// triggers an out-of-cycle poll instead of waiting a full PollInterval.
 func TestPollOnRegistration(t *testing.T) {
 	t.Setenv("DD_REMOTE_CONFIGURATION_ENABLED", "true")
 
@@ -622,9 +620,7 @@ func TestPollOnRegistration(t *testing.T) {
 
 	for name, reg := range register {
 		t.Run(name, func(t *testing.T) {
-			// Reset the package-global RC singleton up front so the test is
-			// robust to ordering and to a prior test panicking before cleanup.
-			Reset()
+			Reset() // clear any client left by a prior test
 			defer Stop()
 
 			var polls int64
@@ -637,17 +633,14 @@ func TestPollOnRegistration(t *testing.T) {
 			cfg := DefaultClientConfig()
 			cfg.AgentURL = srv.URL
 			cfg.ServiceName = "test"
-			// A long interval so any poll observed within the test window must be
-			// the out-of-cycle poll triggered by registration, not a scheduled tick.
-			cfg.PollInterval = time.Hour
+			cfg.PollInterval = time.Hour // long: any poll here is the registration-triggered one
 			require.NoError(t, Start(cfg))
 
 			require.NoError(t, reg())
 
 			require.Eventually(t, func() bool {
 				return atomic.LoadInt64(&polls) >= 1
-			}, 5*time.Second, 5*time.Millisecond,
-				name+" should trigger an out-of-cycle poll well before PollInterval elapses")
+			}, 5*time.Second, 5*time.Millisecond, name+" should poll before PollInterval")
 		})
 	}
 }


### PR DESCRIPTION
🤖 **Generated from Claude** (Aaron's AI assistant); Aaron is reviewing. Opened as a **draft for discussion** per CONTRIBUTING.md — happy to move the design discussion to an issue if preferred.

### What
Make the Remote Config client issue an immediate config request **on `Subscribe(...)`**, instead of waiting a full `PollInterval` (default 5s) for the first ticker tick. `RegisterProduct`/`RegisterCapability` deliberately do **not** poll eagerly (see How).

### Why
The Datadog OpenFeature provider blocks initialization until the first RC flag-config payload arrives. Today the RC poll loop only acts on `time.NewTicker(pollInterval)`, and `Start()` is always called *before* the FFE product is subscribed (the tracer's `startRemoteConfig`, and the provider's slow path `internal/openfeature.SubscribeProvider`). So the first useful poll is delayed a full interval, and provider init blocks for that long.

Observed on an internal service in staging: `openfeature.client.init` **p50 4.5s, p95 16.6s**, with ~99.8% of the time spent waiting in `provider.init` for the first RC payload.

The other server SDKs already get config on/near the first poll at startup:

| SDK | first RC poll |
|---|---|
| Python | immediate (`no_wait_at_start=True`) |
| Java | immediate (`initialDelay=0`, FFE registered before poller) |
| Node | immediate (`runAfterDelay(0)`; subscribing the first product starts the scheduler) |
| .NET | immediate (poll-then-delay) |
| **Go (before this PR)** | **deferred one full interval** |

### How
- Add a coalescing `pollNow chan struct{}` (buffered, size 1) to the RC `Client`.
- **`Subscribe(...)` signals it** (non-blocking) after registering the product, callback, and capabilities atomically — so the immediate poll can't deliver config before the callback exists.
- `RegisterProduct`/`RegisterCapability` do **not** signal it. They're used piecemeal (e.g. AppSec registers ASM products before its `RegisterCallback`), where an eager poll could store config the repository later dedupes before the callback exists; they're picked up on the next scheduled tick. FFE and APM_TRACING both register via `Subscribe`, so the cold-start win is preserved.
- The poll loop gains a `select` case that performs an out-of-cycle `updateState()`. It does **not** reset the steady-state ticker; extra work is bounded by the coalesced `pollNow` channel. If `stop` is ready alongside the wakeup, it exits without polling.

Steady-state cadence is unchanged; the normal ticker path is untouched. Shutdown is close-based: `Stop()`/`Reset()` close the client's `stop` channel (once, via `sync.Once`) and the poll goroutine closes `done` on exit. `Stop()` waits for the goroutine (up to the HTTP timeout, since a poll may be in flight) before clearing the singleton, so a restart doesn't overlap an in-flight poll.

### Tests
Use `recordingClientConfig` — a fake `http.RoundTripper` that records each request — with `PollInterval = 1h`, so any request in the assertion window can only be a Subscribe-driven poll:
- `TestPollOnSubscribe` — `Subscribe` triggers an immediate poll; fails without this change.
- `TestNoImmediatePollOnRegisterProductOrCapability` — `RegisterProduct`/`RegisterCapability` do **not** poll immediately.
- `TestNoPollWithoutRegistration` — `Start()` alone fires no poll.
- `TestPollOnEachSubscribe` — a second `Subscribe` polls again after the first drains.

`gofmt`, `go vet`, and `go test -race` on `./internal/remoteconfig`, `./internal/openfeature`, and `./internal/appsec` pass locally.

### Out of scope
- Agent / RC-backend changes (other SDKs prove the server side already serves config promptly).
- The OpenFeature wrapper's unbounded init wait (`InitWithContext(context.Background(), …)`) — separate follow-up.

Internal tracking: FFL-2604 — https://datadoghq.atlassian.net/browse/FFL-2604

🤖 Generated with [Claude Code](https://claude.com/claude-code)
