### PR TITLE
feat(internal/remoteconfig): fire an eager initial poll on startup

### DIFF
--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -175,6 +175,12 @@ type Client struct {
 
 	lastError        error
 	lastConfigStates []*configState
+
+	// immediateUpdate is a buffered channel of size 1 used to trigger an
+	// out-of-band poll. A non-blocking send queues one extra poll; subsequent
+	// sends while a poll is already queued are silently dropped, acting as a
+	// natural debounce.
+	immediateUpdate chan struct{}
 }
 
 // subscription represents a callback that was registered to run on updates to a
@@ -207,15 +213,16 @@ func newClient(config ClientConfig) (*Client, error) {
 	}
 
 	return &Client{
-		ClientConfig: config,
-		clientID:     generateID(),
-		endpoint:     fmt.Sprintf("%s/v0.7/config", config.AgentURL),
-		repository:   repo,
-		stop:         make(chan struct{}),
-		lastError:    nil,
-		callbacks:    []Callback{},
-		capabilities: map[Capability]struct{}{},
-		products:     map[string]struct{}{},
+		ClientConfig:    config,
+		clientID:        generateID(),
+		endpoint:        fmt.Sprintf("%s/v0.7/config", config.AgentURL),
+		repository:      repo,
+		stop:            make(chan struct{}),
+		lastError:       nil,
+		callbacks:       []Callback{},
+		capabilities:    map[Capability]struct{}{},
+		products:        map[string]struct{}{},
+		immediateUpdate: make(chan struct{}, 1),
 	}, nil
 }
 
@@ -241,25 +248,20 @@ func Start(config ClientConfig) error {
 	started = true
 
 	var (
-		pollInterval = client.PollInterval
-		stop         = client.stop
+		pollInterval    = client.PollInterval
+		stop            = client.stop
+		immediateUpdate = client.immediateUpdate
 	)
 	go func() {
 		ticker := time.NewTicker(pollInterval)
 		defer ticker.Stop()
-
-		// Prime with one value so the first iteration fires immediately,
-		// avoiding a full poll-interval wait before the initial RC payload
-		// is delivered to subscribers (e.g. the OpenFeature provider).
-		immediate := make(chan struct{}, 1)
-		immediate <- struct{}{}
 
 		for {
 			select {
 			case <-stop:
 				close(stop)
 				return
-			case <-immediate:
+			case <-immediateUpdate:
 			case <-ticker.C:
 			}
 			if client == nil {
@@ -271,6 +273,18 @@ func Start(config ClientConfig) error {
 		}
 	}()
 	return nil
+}
+
+// triggerUpdate queues an immediate out-of-band poll. If a poll is already
+// queued, this is a no-op — the buffered channel acts as a natural debounce.
+func triggerUpdate() {
+	if client == nil {
+		return
+	}
+	select {
+	case client.immediateUpdate <- struct{}{}:
+	default:
+	}
 }
 
 // Stop stops the client's update poll loop.
@@ -426,6 +440,8 @@ func Subscribe(product string, callback ProductCallback, capabilities ...Capabil
 	for _, cap := range capabilities {
 		client.capabilities[cap] = struct{}{}
 	}
+
+	triggerUpdate()
 	return SubscriptionToken(id), nil
 }
 
@@ -492,6 +508,7 @@ func RegisterProduct(p string) error {
 	}
 
 	client.products[p] = struct{}{}
+	triggerUpdate()
 	return nil
 }
 

--- a/internal/remoteconfig/remoteconfig.go
+++ b/internal/remoteconfig/remoteconfig.go
@@ -248,19 +248,26 @@ func Start(config ClientConfig) error {
 		ticker := time.NewTicker(pollInterval)
 		defer ticker.Stop()
 
+		// Prime with one value so the first iteration fires immediately,
+		// avoiding a full poll-interval wait before the initial RC payload
+		// is delivered to subscribers (e.g. the OpenFeature provider).
+		immediate := make(chan struct{}, 1)
+		immediate <- struct{}{}
+
 		for {
 			select {
 			case <-stop:
 				close(stop)
 				return
+			case <-immediate:
 			case <-ticker.C:
-				if client == nil {
-					return
-				}
-				client.Lock()
-				client.updateState()
-				client.Unlock()
 			}
+			if client == nil {
+				return
+			}
+			client.Lock()
+			client.updateState()
+			client.Unlock()
 		}
 	}()
 	return nil

--- a/internal/remoteconfig/remoteconfig_test.go
+++ b/internal/remoteconfig/remoteconfig_test.go
@@ -9,7 +9,9 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math/rand"
+	"net/http"
 	"reflect"
 	"strings"
 	"sync"
@@ -273,6 +275,47 @@ func TestConfig(t *testing.T) {
 			})
 		}
 	})
+}
+
+// roundTripFunc allows using a plain function as an http.RoundTripper.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// TestEagerInitialPoll verifies that the RC polling goroutine fires an immediate
+// updateState call on startup without waiting for the first ticker interval.
+// It uses a 1-hour poll interval so the ticker cannot be responsible for any
+// request that arrives within the 500ms assertion window.
+func TestEagerInitialPoll(t *testing.T) {
+	Stop()
+	Reset()
+	defer Stop()
+
+	requestCh := make(chan struct{}, 1)
+	cfg := DefaultClientConfig()
+	cfg.ServiceName = "test"
+	cfg.PollInterval = 1 * time.Hour
+	cfg.HTTP = &http.Client{
+		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			select {
+			case requestCh <- struct{}{}:
+			default:
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}, nil
+		}),
+	}
+
+	require.NoError(t, Start(cfg))
+
+	select {
+	case <-requestCh:
+		// Success: eager first poll fired immediately without waiting for the ticker.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("no HTTP request within 500ms; eager initial poll did not fire (poll interval is 1h, so ticker cannot be the cause)")
+	}
 }
 
 func dummyCallback1(map[string]ProductUpdate) map[string]state.ApplyStatus {

--- a/internal/remoteconfig/remoteconfig_test.go
+++ b/internal/remoteconfig/remoteconfig_test.go
@@ -320,6 +320,121 @@ func TestEagerInitialPoll(t *testing.T) {
 	}
 }
 
+// TestNoEagerPollWithoutRegistration verifies that Start alone does not trigger
+// an immediate poll — the poll goroutine should only wake up via the ticker or
+// a product registration.
+func TestNoEagerPollWithoutRegistration(t *testing.T) {
+	Stop()
+	Reset()
+	defer Stop()
+
+	requestCh := make(chan struct{}, 1)
+	cfg := DefaultClientConfig()
+	cfg.ServiceName = "test"
+	cfg.PollInterval = 1 * time.Hour
+	cfg.HTTP = &http.Client{
+		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			select {
+			case requestCh <- struct{}{}:
+			default:
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}, nil
+		}),
+	}
+
+	require.NoError(t, Start(cfg))
+
+	select {
+	case <-requestCh:
+		t.Fatal("unexpected HTTP request: poll fired without any product registration")
+	case <-time.After(100 * time.Millisecond):
+		// Success: no poll fired without a registration.
+	}
+}
+
+// TestEagerPollOnEachRegistration verifies that each product registration
+// triggers its own poll once the previous one has drained. Back-to-back
+// registrations are debounced to a single poll; this test registers a second
+// product only after confirming the first poll has completed.
+func TestEagerPollOnEachRegistration(t *testing.T) {
+	Stop()
+	Reset()
+	defer Stop()
+
+	requestCh := make(chan struct{}, 10)
+	cfg := DefaultClientConfig()
+	cfg.ServiceName = "test"
+	cfg.PollInterval = 1 * time.Hour
+	cfg.HTTP = &http.Client{
+		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			requestCh <- struct{}{}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}, nil
+		}),
+	}
+
+	require.NoError(t, Start(cfg))
+
+	_, err := Subscribe("product-a", func(ProductUpdate) map[string]state.ApplyStatus { return nil })
+	require.NoError(t, err)
+
+	// Wait for the first poll to complete before registering the second product.
+	select {
+	case <-requestCh:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("no HTTP request within 500ms after first Subscribe")
+	}
+
+	require.NoError(t, RegisterProduct("product-b"))
+
+	select {
+	case <-requestCh:
+		// Success: second registration triggered its own poll.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("no HTTP request within 500ms after second RegisterProduct")
+	}
+}
+
+// TestEagerPollViaRegisterProduct verifies that RegisterProduct (not just
+// Subscribe) also triggers an immediate poll.
+func TestEagerPollViaRegisterProduct(t *testing.T) {
+	Stop()
+	Reset()
+	defer Stop()
+
+	requestCh := make(chan struct{}, 1)
+	cfg := DefaultClientConfig()
+	cfg.ServiceName = "test"
+	cfg.PollInterval = 1 * time.Hour
+	cfg.HTTP = &http.Client{
+		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			select {
+			case requestCh <- struct{}{}:
+			default:
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}, nil
+		}),
+	}
+
+	require.NoError(t, Start(cfg))
+	require.NoError(t, RegisterProduct("test-product"))
+
+	select {
+	case <-requestCh:
+		// Success: eager poll fired after RegisterProduct.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("no HTTP request within 500ms; eager poll after RegisterProduct did not fire (poll interval is 1h, so ticker cannot be the cause)")
+	}
+}
+
 func dummyCallback1(map[string]ProductUpdate) map[string]state.ApplyStatus {
 	return nil
 }

--- a/internal/remoteconfig/remoteconfig_test.go
+++ b/internal/remoteconfig/remoteconfig_test.go
@@ -283,9 +283,9 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
 // TestEagerInitialPoll verifies that the RC polling goroutine fires an immediate
-// updateState call on startup without waiting for the first ticker interval.
-// It uses a 1-hour poll interval so the ticker cannot be responsible for any
-// request that arrives within the 500ms assertion window.
+// updateState call after a product is registered, without waiting for the first
+// ticker interval. It uses a 1-hour poll interval so the ticker cannot be
+// responsible for any request that arrives within the 500ms assertion window.
 func TestEagerInitialPoll(t *testing.T) {
 	Stop()
 	Reset()
@@ -309,12 +309,14 @@ func TestEagerInitialPoll(t *testing.T) {
 	}
 
 	require.NoError(t, Start(cfg))
+	_, err := Subscribe("test-product", func(ProductUpdate) map[string]state.ApplyStatus { return nil })
+	require.NoError(t, err)
 
 	select {
 	case <-requestCh:
-		// Success: eager first poll fired immediately without waiting for the ticker.
+		// Success: eager poll fired immediately after Subscribe, without waiting for the ticker.
 	case <-time.After(500 * time.Millisecond):
-		t.Fatal("no HTTP request within 500ms; eager initial poll did not fire (poll interval is 1h, so ticker cannot be the cause)")
+		t.Fatal("no HTTP request within 500ms; eager poll after Subscribe did not fire (poll interval is 1h, so ticker cannot be the cause)")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Moves the immediate-poll trigger out of `Start()` and into `Subscribe()` and `RegisterProduct()`, so the first out-of-band poll only fires once a product is actually registered — avoiding an empty product-set request to the RC backend on startup
- Adds `immediateUpdate chan struct{}` (buffer size 1) to the `Client` struct; non-blocking sends from `triggerUpdate()` act as a natural debounce across back-to-back registrations
- Each registration (including runtime subscriptions after startup) fires its own poll once the previous one drains, so e.g. the OpenFeature provider doesn't wait up to `DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS` (default 5s) for its first config delivery

## Test plan

- [ ] `TestEagerInitialPoll` — Subscribe triggers an immediate poll without waiting for the ticker (1h interval used to rule out ticker)
- [ ] `TestNoEagerPollWithoutRegistration` — Start alone does not trigger a poll
- [ ] `TestEagerPollOnEachRegistration` — each registration fires its own poll once the previous one drains
- [ ] `TestEagerPollViaRegisterProduct` — RegisterProduct triggers the same behavior as Subscribe
- [ ] `go test ./internal/remoteconfig/...` passes (54 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)