### PR TITLE
fix(tracer): don't activate runtime metrics v1 if otel runtime metrics are enabled

### DIFF
--- a/ddtrace/tracer/metrics_otel_test.go
+++ b/ddtrace/tracer/metrics_otel_test.go
@@ -64,6 +64,26 @@ func TestTracerStartOtelRuntimeMetricsRequiresAllFlags(t *testing.T) {
 	assert.True(t, *started, "StartRuntimeMetrics hook should have been called")
 }
 
+func TestTracerLegacyRuntimeMetricsSuppressedWhenOtelActive(t *testing.T) {
+	t.Setenv("DD_RUNTIME_METRICS_ENABLED", "true")
+	t.Setenv("DD_METRICS_OTEL_ENABLED", "true")
+	internalconfig.SetUseFreshConfig(true)
+	defer internalconfig.SetUseFreshConfig(false)
+
+	withTestHooks(t)
+
+	tp := new(log.RecordLogger)
+	tp.Ignore(commonLogIgnore...)
+	tr, err := newTracer(WithLogger(tp), WithDebugMode(true))
+	require.NoError(t, err)
+	defer tr.Stop()
+
+	assert.True(t, tr.config.otelRuntimeMetricsShouldBeEnabled, "otelRuntimeMetricsShouldBeEnabled must be true for this test to be meaningful")
+	for _, l := range tp.Logs() {
+		assert.NotContains(t, l, "Runtime metrics enabled.", "legacy runtime metrics goroutine must not start when OTel is active")
+	}
+}
+
 func TestTracerStartSkipsOtelRuntimeMetricsWhenExporterNone(t *testing.T) {
 	t.Setenv("OTEL_METRICS_EXPORTER", "none")
 	t.Setenv("OTEL_METRIC_EXPORT_INTERVAL", "86400000")

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -40,6 +40,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/namingschema"
 	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion"
+	"github.com/DataDog/dd-trace-go/v2/internal/otelmetricsinstall"
 	"github.com/DataDog/dd-trace-go/v2/internal/processtags"
 	"github.com/DataDog/dd-trace-go/v2/internal/stableconfig"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
@@ -192,6 +193,10 @@ type config struct {
 
 	// spanPoolEnabled controls whether finished spans are recycled via sync.Pool.
 	spanPoolEnabled bool
+
+	// otelRuntimeMetricsShouldBeEnabled reports whether OTel runtime metrics
+	// should be started instead of the DD statsd runtime metrics paths.
+	otelRuntimeMetricsShouldBeEnabled bool
 }
 
 // StartOption represents a function that can be provided as a parameter to Start.
@@ -374,7 +379,16 @@ func newConfig(opts ...StartOption) (*config, error) {
 	// Set global 128-bits trace ID generation variable
 	traceID128BitEnabled.Store(c.internalConfig.TraceID128BitEnabled())
 
+	c.otelRuntimeMetricsShouldBeEnabled = computeOtelRuntimeMetricsShouldBeEnabled(c)
+
 	return c, nil
+}
+
+func computeOtelRuntimeMetricsShouldBeEnabled(c *config) bool {
+	return otelmetricsinstall.StartHook != nil &&
+		c.internalConfig.RuntimeMetricsOtelEnabled() &&
+		c.internalConfig.OTLPExportMetricsMode() &&
+		(c.internalConfig.RuntimeMetricsV2Enabled() || c.internalConfig.RuntimeMetricsEnabled())
 }
 
 // shouldDisableSpanPool reports whether the experimental span pool must be

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -240,6 +240,7 @@ func Start(opts ...StartOption) error {
 	defer startStopMu.Unlock()
 
 	defer reportInitTime(time.Now())
+
 	t, err := newTracer(opts...)
 	if err != nil {
 		return err
@@ -273,12 +274,7 @@ func Start(opts ...StartOption) error {
 		return nil
 	}
 
-	otelRuntimeMetricsShouldBeEnabled := otelmetricsinstall.StartHook != nil &&
-		t.config.internalConfig.RuntimeMetricsOtelEnabled() &&
-		t.config.internalConfig.OTLPExportMetricsMode() &&
-		(t.config.internalConfig.RuntimeMetricsV2Enabled() || t.config.internalConfig.RuntimeMetricsEnabled())
-
-	if otelRuntimeMetricsShouldBeEnabled {
+	if t.config.otelRuntimeMetricsShouldBeEnabled {
 		if err := otelmetricsinstall.StartHook(gocontext.Background()); err != nil {
 			log.Error("Failed to start OTel runtime metrics: %v", err.Error())
 		} else {
@@ -591,12 +587,13 @@ func newTracer(opts ...StartOption) (*tracer, error) {
 	}
 	c := t.config
 	t.statsd.Incr("datadog.tracer.started", nil, 1)
-	if c.internalConfig.RuntimeMetricsEnabled() {
+	if c.internalConfig.RuntimeMetricsEnabled() && !c.otelRuntimeMetricsShouldBeEnabled {
 		log.Debug("Runtime metrics enabled.")
 		t.wg.Go(func() {
 			t.reportRuntimeMetrics(defaultMetricsReportInterval)
 		})
 	}
+
 	if c.internalConfig.DebugAbandonedSpans() {
 		log.Info("Abandoned spans logs enabled.")
 		t.abandonedSpansDebugger = newAbandonedSpansDebugger()


### PR DESCRIPTION
Following #4803, fixes dual-emission when both `DD_RUNTIME_METRICS_ENABLED=true` and `DD_METRICS_OTEL_ENABLED=true` are set: the legacy v1 runtime metrics shouldn't start.

**Fix:** Pre-compute `otelRuntimeMetricsShouldBeEnabled` in `config` (`option.go`) and add a `!otelRuntimeMetricsShouldBeEnabled` guard around the legacy goroutine in `newTracer()`.

**Testing:**
- `TestTracerRuntimeMetrics` (all subtests) pass
- Validated against [system-tests PR #6857](https://github.com/DataDog/system-tests/pull/6857) (`OTLP_RUNTIME_METRICS` scenario): `test_otel_metrics_are_present_and_attributed` and `test_dd_metrics_are_absent` both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)