### PR TITLE
fix(contrib/azure/apim-callout): restore AppSec body inspection on oversized inline bodies and Boomi block enforcement

### DIFF
--- a/contrib/azure/apim-callout/apim_messages.go
+++ b/contrib/azure/apim-callout/apim_messages.go
@@ -22,10 +22,6 @@ var (
 	_ proxy.RequestHeaders  = (*messageRequestHeaders)(nil)
 	_ proxy.ResponseHeaders = (*messageResponseHeaders)(nil)
 	_ proxy.HTTPBody        = (*messageBody)(nil)
-
-	// errBodySizeExceeded is returned when a base64-encoded inline body
-	// exceeds the configured body parsing size limit.
-	errBodySizeExceeded = errors.New("apim_callout: inline body exceeds body parsing size limit")
 )
 
 // calloutMessage represents the JSON body sent by the gateway on POST /.
@@ -214,10 +210,14 @@ func hasRawBody(raw json.RawMessage) bool {
 }
 
 // decodeRawBase64Body extracts the JSON string from a json.RawMessage and
-// base64-decodes its content in place without intermediate copies.
-// Returns nil if the raw message is empty/null.
-// When maxDecodedSize > 0, the function returns errBodySizeExceeded if the
-// decoded body would exceed the limit, preventing unbounded memory allocation.
+// base64-decodes its content. Returns nil if the raw message is empty/null.
+//
+// Security: when maxDecodedSize > 0 the decode is bounded to ~maxDecodedSize
+// bytes (preventing OOM) but the returned prefix may be a few bytes larger. The
+// proxy body buffer then enforces the exact limit and flags the body truncated
+// so the WAF still inspects the retained prefix. Returning a size error instead
+// would skip inspection entirely, letting an attacker bypass the WAF by padding
+// a malicious body past the limit.
 func decodeRawBase64Body(raw json.RawMessage, maxDecodedSize int) ([]byte, error) {
 	first := bytes.IndexByte(raw, '"')
 	if first < 0 {
@@ -228,20 +228,20 @@ func decodeRawBase64Body(raw json.RawMessage, maxDecodedSize int) ([]byte, error
 		return nil, nil
 	}
 	src := raw[first+1 : last]
-	decodedLen := base64.StdEncoding.DecodedLen(len(src))
-	// DecodedLen is an upper bound that can overestimate by up to 2 bytes due to
-	// base64 padding. Allow this tolerance so bodies exactly at the limit aren't
-	// falsely rejected. The exact decoded size is checked after decoding below.
-	if maxDecodedSize > 0 && decodedLen > maxDecodedSize+2 {
-		return nil, errBodySizeExceeded
+	if maxDecodedSize > 0 {
+		// Keep one base64 group (4 chars -> 3 bytes) past the limit so an
+		// oversized body decodes to strictly more than maxDecodedSize, letting
+		// the body buffer detect the overflow and mark it truncated. The bound
+		// is a multiple of 4, so slicing keeps whole, unpadded groups.
+		maxEncodedLen := (maxDecodedSize/3 + 1) * 4
+		if len(src) > maxEncodedLen {
+			src = src[:maxEncodedLen]
+		}
 	}
-	dst := make([]byte, decodedLen)
+	dst := make([]byte, base64.StdEncoding.DecodedLen(len(src)))
 	n, err := base64.StdEncoding.Decode(dst, src)
 	if err != nil {
 		return nil, err
-	}
-	if maxDecodedSize > 0 && n > maxDecodedSize {
-		return nil, errBodySizeExceeded
 	}
 	return dst[:n], nil
 }

--- a/contrib/azure/apim-callout/apim_test.go
+++ b/contrib/azure/apim-callout/apim_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
@@ -255,24 +256,23 @@ func TestDecodeRawBase64Body(t *testing.T) {
 		maxDecodedSize int
 		want           []byte
 		wantErr        bool
-		wantSizeErr    bool
 	}{
-		{"nil", nil, 0, nil, false, false},
-		{"null", json.RawMessage("null"), 0, nil, false, false},
-		{"empty-string", json.RawMessage(`""`), 0, nil, false, false},
-		{"valid", json.RawMessage(`"aGVsbG8="`), 0, []byte("hello"), false, false},
-		{"invalid", json.RawMessage(`"not-valid-base64!!!"`), 0, nil, true, false},
-		{"valid-within-limit", json.RawMessage(`"aGVsbG8="`), 100, []byte("hello"), false, false},
-		{"valid-at-exact-limit", json.RawMessage(`"aGVsbG8="`), 5, []byte("hello"), false, false},
-		{"valid-exceeds-limit", json.RawMessage(`"aGVsbG8="`), 2, nil, true, true},
+		{"nil", nil, 0, nil, false},
+		{"null", json.RawMessage("null"), 0, nil, false},
+		{"empty-string", json.RawMessage(`""`), 0, nil, false},
+		{"valid", json.RawMessage(`"aGVsbG8="`), 0, []byte("hello"), false},
+		{"invalid", json.RawMessage(`"not-valid-base64!!!"`), 0, nil, true},
+		{"valid-within-limit", json.RawMessage(`"aGVsbG8="`), 100, []byte("hello"), false},
+		{"valid-at-exact-limit", json.RawMessage(`"aGVsbG8="`), 5, []byte("hello"), false},
+		// Oversized is not an error: decoder returns a base64-group-bounded prefix
+		// ("hel"); the body buffer enforces the exact limit + truncation flag.
+		{"oversized-bounded-prefix", json.RawMessage(`"aGVsbG8="`), 2, []byte("hel"), false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := decodeRawBase64Body(tt.input, tt.maxDecodedSize)
-			if tt.wantSizeErr {
-				assert.ErrorIs(t, err, errBodySizeExceeded)
-			} else if tt.wantErr {
+			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
@@ -282,7 +282,7 @@ func TestDecodeRawBase64Body(t *testing.T) {
 	}
 }
 
-func TestOversizedInlineBodyFailsOpen(t *testing.T) {
+func TestOversizedInlineBodyStillAnalyzed(t *testing.T) {
 	bodyLimit := 16
 	h := NewHandler(AppsecAPIMConfig{
 		Context:              t.Context(),
@@ -309,7 +309,7 @@ func TestOversizedInlineBodyFailsOpen(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rr.Code)
 	result := decodeResult(t, rr)
-	assert.Nil(t, result.Block, "oversized inline body should fail open")
+	assert.Nil(t, result.Block, "benign oversized inline body should not be blocked")
 	assert.NotEmpty(t, result.RequestID, "request should still be processed")
 }
 
@@ -562,6 +562,38 @@ func TestAppSecBodyParsing(t *testing.T) {
 		require.Len(t, finished, 1)
 		checkForAppsecEvent(t, finished, map[string]int{"custom-001": 1, "crs-933-130-block": 1})
 
+		span := finished[0]
+		assert.Equal(t, "true", span.Tag("appsec.event"))
+		assert.Equal(t, "true", span.Tag("appsec.blocked"))
+	})
+
+	t.Run("blocking-event-on-oversized-inline-request-body", func(t *testing.T) {
+		h, mt := setup(t)
+
+		// Regression guard: malicious token first, then padding that pushes the
+		// decoded body past the 256-byte limit. The oversized body must still be
+		// truncated-and-analyzed (not skipped fail-open) so the prefix is blocked.
+		malicious := `{ "name": "$globals", "padding": "` + strings.Repeat("A", 4096) + `" }`
+		require.Greater(t, len(malicious), 256)
+		reqBody := base64.StdEncoding.EncodeToString([]byte(malicious))
+		rr := doPost(t, h, calloutMessage{
+			Addresses: marshalAddresses(t, addressesRequestHeaders{
+				Method:    "GET",
+				Scheme:    "https",
+				Authority: "datadoghq.com",
+				Path:      "/",
+				Headers:   map[string][]string{"User-Agent": {"Chromium"}, "Content-Type": {"application/json"}},
+				Body:      rawBody(reqBody),
+			}),
+		})
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		result := decodeResult(t, rr)
+		require.NotNil(t, result.Block, "oversized inline body with a malicious prefix must still be blocked")
+		assert.Equal(t, 403, result.Block.Status)
+
+		finished := mt.FinishedSpans()
+		require.Len(t, finished, 1)
 		span := finished[0]
 		assert.Equal(t, "true", span.Tag("appsec.event"))
 		assert.Equal(t, "true", span.Tag("appsec.blocked"))

--- a/contrib/azure/apim-callout/boomi_templates_test.go
+++ b/contrib/azure/apim-callout/boomi_templates_test.go
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+package apimcallout
+
+import (
+	"encoding/json"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var groovyGetAttribute = regexp.MustCompile(`getAttribute\(\s*'([^']+)'\s*\)`)
+
+// TestBoomiTemplateAttributeConsistency guards against the class of bug where a
+// Boomi block enforcer reads a context attribute that the callout template never
+// sets, which silently disables AppSec blocking. It needs no Groovy runtime: it
+// statically asserts every attribute read by each *-block.groovy is produced by
+// the matching *-callout.json variable extraction.
+func TestBoomiTemplateAttributeConsistency(t *testing.T) {
+	cases := []struct {
+		name        string
+		calloutFile string
+		groovyFile  string
+	}{
+		{"request", "deploy/boomi/boomi-request-callout.json", "deploy/boomi/boomi-request-block.groovy"},
+		{"response", "deploy/boomi/boomi-response-callout.json", "deploy/boomi/boomi-response-block.groovy"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			set := calloutVariableNames(t, tc.calloutFile)
+			read := groovyAttributeNames(t, tc.groovyFile)
+			require.NotEmpty(t, read, "block policy reads no attributes; regex or template changed")
+			for _, name := range read {
+				assert.Truef(t, set[name],
+					"block policy %s reads context attribute %q that callout template %s never sets",
+					tc.groovyFile, name, tc.calloutFile)
+			}
+		})
+	}
+}
+
+func calloutVariableNames(t *testing.T, path string) map[string]bool {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var tmpl struct {
+		Variables []struct {
+			Name string `json:"name"`
+		} `json:"variables"`
+	}
+	require.NoError(t, json.Unmarshal(data, &tmpl))
+	names := make(map[string]bool, len(tmpl.Variables))
+	for _, v := range tmpl.Variables {
+		names[v.Name] = true
+	}
+	return names
+}
+
+func groovyAttributeNames(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var names []string
+	seen := map[string]bool{}
+	for _, m := range groovyGetAttribute.FindAllSubmatch(data, -1) {
+		if name := string(m[1]); !seen[name] {
+			seen[name] = true
+			names = append(names, name)
+		}
+	}
+	return names
+}

--- a/contrib/azure/apim-callout/boomi_templates_test.go
+++ b/contrib/azure/apim-callout/boomi_templates_test.go
@@ -9,13 +9,17 @@ import (
 	"encoding/json"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-var groovyGetAttribute = regexp.MustCompile(`getAttribute\(\s*'([^']+)'\s*\)`)
+var (
+	groovyGetAttribute = regexp.MustCompile(`getAttribute\(\s*'([^']+)'\s*\)`)
+	jsonPathExpr       = regexp.MustCompile(`jsonPath\([^,]+,\s*'([^']+)'\)`)
+)
 
 // TestBoomiTemplateAttributeConsistency guards against the class of bug where a
 // Boomi block enforcer reads a context attribute that the callout template never
@@ -76,4 +80,43 @@ func groovyAttributeNames(t *testing.T, path string) []string {
 		}
 	}
 	return names
+}
+
+// TestBoomiRequestResponseBlockCoherence verifies the request and response callout
+// templates extract the block decision coherently: the response attributes mirror
+// the request ones (dd-block<suffix> <-> dd-resp-block<suffix>) and both read the
+// same $.block... JSON paths. It catches drift where one side adds, drops, or
+// renames a block field (or its source path) without the other.
+func TestBoomiRequestResponseBlockCoherence(t *testing.T) {
+	req := blockFieldPaths(t, "deploy/boomi/boomi-request-callout.json", "dd-block")
+	resp := blockFieldPaths(t, "deploy/boomi/boomi-response-callout.json", "dd-resp-block")
+	require.NotEmpty(t, req, "no dd-block* attributes found in the request callout")
+	require.NotEmpty(t, resp, "no dd-resp-block* attributes found in the response callout")
+	assert.Equal(t, req, resp,
+		"request (dd-block*) and response (dd-resp-block*) callouts must extract the same block fields from the same JSON paths")
+}
+
+// blockFieldPaths maps each block sub-field suffix (name minus prefix) to the JSON
+// path it is extracted from, e.g. "-status" -> "$.block.status".
+func blockFieldPaths(t *testing.T, path, prefix string) map[string]string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var tmpl struct {
+		Variables []struct {
+			Name  string `json:"name"`
+			Value string `json:"value"`
+		} `json:"variables"`
+	}
+	require.NoError(t, json.Unmarshal(data, &tmpl))
+	out := map[string]string{}
+	for _, v := range tmpl.Variables {
+		if !strings.HasPrefix(v.Name, prefix) {
+			continue
+		}
+		m := jsonPathExpr.FindStringSubmatch(v.Value)
+		require.NotNilf(t, m, "variable %q value %q has no jsonPath expression", v.Name, v.Value)
+		out[strings.TrimPrefix(v.Name, prefix)] = m[1]
+	}
+	return out
 }

--- a/contrib/azure/apim-callout/deploy/boomi/boomi-request-block.groovy
+++ b/contrib/azure/apim-callout/deploy/boomi/boomi-request-block.groovy
@@ -5,9 +5,12 @@
 // Uses PolicyResult to short-circuit the request chain and return a custom
 // block response. Direct response property setters are not allowed by the
 // Groovy sandbox in Boomi's Gravitee build.
-if (context.getAttribute('dd-action') == 'block') {
+// Attribute names must match boomi-request-callout.json (dd-block / dd-block-status
+// / dd-block-headers / dd-block-content). dd-block is null/empty/'null' when no block.
+def block = context.getAttribute('dd-block')
+if (block != null && block != '' && block != 'null') {
     def statusCode = context.getAttribute('dd-block-status') as int
-    def body = context.getAttribute('dd-block-body')
+    def body = context.getAttribute('dd-block-content')
     def decodedBody = body != null ? new String(body.decodeBase64()) : ''
     def headersJson = context.getAttribute('dd-block-headers')
     def contentType = 'application/json'

--- a/contrib/azure/apim-callout/deploy/boomi/boomi-response-block.groovy
+++ b/contrib/azure/apim-callout/deploy/boomi/boomi-response-block.groovy
@@ -5,9 +5,12 @@
 // Uses PolicyResult to short-circuit the response chain and return a custom
 // block response. Direct response property setters are not allowed by the
 // Groovy sandbox in Boomi's Gravitee build.
-if (context.getAttribute('dd-resp-action') == 'block') {
+// Attribute names must match boomi-response-callout.json (dd-resp-block / dd-resp-block-status
+// / dd-resp-block-headers / dd-resp-block-content). dd-resp-block is null/empty/'null' when no block.
+def block = context.getAttribute('dd-resp-block')
+if (block != null && block != '' && block != 'null') {
     def statusCode = context.getAttribute('dd-resp-block-status') as int
-    def body = context.getAttribute('dd-resp-block-body')
+    def body = context.getAttribute('dd-resp-block-content')
     def decodedBody = body != null ? new String(body.decodeBase64()) : ''
     def headersJson = context.getAttribute('dd-resp-block-headers')
     def contentType = 'application/json'


### PR DESCRIPTION
### What does this PR do?

Fixes two AppSec control bypasses in the Azure APIM / Boomi HTTP callout security processor (`contrib/azure/apim-callout`):

**1. Oversized inline bodies were skipped instead of analyzed.**
`decodeRawBase64Body` returned an error for any inline body whose decoded size exceeded `BodyParsingSizeLimit`, and the callout handlers treated that error as fail-open — they logged it and skipped `OnRequestBody` / `OnResponseBody`. A client could pad a body past the limit to skip WAF body inspection entirely, even with the payload at the start of the body. This diverged from the proxy body pipeline, which truncates to the limit and still analyzes the retained prefix.

The decoder now bounds the base64 decode (still preventing the OOM the limit was added for) but returns a prefix one group past the limit, so the proxy body buffer truncates it to the exact limit and flags it `truncated`. The WAF then still inspects the retained prefix. The `truncated` flag is required: the JSON encoder only tolerates incomplete input when it is set, so a plain byte cap would miss payloads split by padding.

**2. Boomi block decisions were never enforced.**
The Boomi request/response block Groovy policies gated on `dd-action` / `dd-resp-action == 'block'` and read `dd-block-body` / `dd-resp-block-body`, but the callout templates never set those attributes — they extract the decision into `dd-block` / `dd-resp-block` and the body into `dd-block-content` / `dd-resp-block-content`. The block condition was therefore always false and block decisions were silently dropped. The policies now read the attributes the callout templates actually set, with a guard against `null` / empty / `'null'`.

### Motivation

Both issues were flagged as high-severity AppSec body-inspection / blocking bypasses in the apim-callout integration. (1) was a regression from the inline-body OOM hardening; (2) was introduced with the Boomi deployment templates.

### Tests

- `TestAppSecBodyParsing/blocking-event-on-oversized-inline-request-body` — a malicious prefix padded past the limit is now blocked (the regression guard for #1).
- `TestBoomiTemplateAttributeConsistency` — static check that every context attribute each block policy reads is set by the matching callout template; no Groovy runtime required (the regression guard for #2).
- Updated `TestDecodeRawBase64Body` and renamed `TestOversizedInlineBodyFailsOpen` → `TestOversizedInlineBodyStillAnalyzed`.
- Both new tests were confirmed to fail on the pre-fix code and pass with the fix.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.
