### PR TITLE
feat(scripts/autoreleasetagger): support `-dev` and `-dev.N` version suffixes

### DIFF
--- a/scripts/autoreleasetagger/main.go
+++ b/scripts/autoreleasetagger/main.go
@@ -94,6 +94,7 @@ var (
 	defaultExcludedModules = []string{}
 	defaultExcludedDirs    = []string{
 		"_tools",
+		".claude",
 		".github",
 		"tools",
 	}
@@ -104,11 +105,14 @@ var (
 	// versionTagRe matches the var Tag line in version.go.
 	versionTagRe = regexp.MustCompile(`^(var Tag = )".+"$`)
 
-	// semverRe matches a valid release version: vMAJOR.MINOR.PATCH(-rc.N)?
-	semverRe = regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)(-rc\.\d+)?$`)
+	// semverRe matches a valid release version: vMAJOR.MINOR.PATCH(-rc.N|-dev(.N)?)?
+	semverRe = regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)(-rc\.\d+|-dev(\.\d+)?)?$`)
 
 	// releaseBranchRe matches a release branch name: release-vMAJOR.MINOR.x
 	releaseBranchRe = regexp.MustCompile(`^release-v(\d+)\.(\d+)\.x$`)
+
+	// devBranchRe matches a dev branch name: dev-vMAJOR.MINOR.x
+	devBranchRe = regexp.MustCompile(`^dev-v(\d+)\.(\d+)\.x$`)
 )
 
 type (
@@ -424,14 +428,21 @@ func run(dryRun bool, remote string, disablePush bool, root, version string, exc
 	return nil
 }
 
+// isDevVersion reports whether version carries a -dev or -dev.N pre-release suffix.
+func isDevVersion(version string) bool {
+	return strings.Contains(version, "-dev")
+}
+
 // validateVersionAndBranch ensures the version matches the expected pattern and is
-// consistent with the current release branch (release-vMAJOR.MINOR.x).
+// consistent with the current branch:
+//   - stable/rc versions require a release-vMAJOR.MINOR.x branch
+//   - dev versions (-dev / -dev.N) require a dev-vMAJOR.MINOR.x branch
 func validateVersionAndBranch(root, version string) error {
 	vm := semverRe.FindStringSubmatch(version)
 	if vm == nil {
 		return newStructuredError(
 			errInvalidVersion,
-			fmt.Sprintf("invalid version %q: must match v<MAJOR>.<MINOR>.<PATCH>(-rc.<N>)?", version),
+			fmt.Sprintf("invalid version %q: must match v<MAJOR>.<MINOR>.<PATCH>(-rc.<N>|-dev(.<N>)?)?", version),
 			map[string]any{"version": version},
 		)
 	}
@@ -442,15 +453,28 @@ func validateVersionAndBranch(root, version string) error {
 		return fmt.Errorf("failed to determine current branch: %w", err)
 	}
 
-	bm := releaseBranchRe.FindStringSubmatch(branch)
-	if bm == nil {
-		return newStructuredError(
-			errInvalidBranch,
-			fmt.Sprintf("current branch %q is not a release branch (expected release-v<MAJOR>.<MINOR>.x)", branch),
-			map[string]any{"branch": branch},
-		)
+	var branchMajor, branchMinor string
+	if isDevVersion(version) {
+		bm := devBranchRe.FindStringSubmatch(branch)
+		if bm == nil {
+			return newStructuredError(
+				errInvalidBranch,
+				fmt.Sprintf("current branch %q is not a dev branch (expected dev-v<MAJOR>.<MINOR>.x)", branch),
+				map[string]any{"branch": branch},
+			)
+		}
+		branchMajor, branchMinor = bm[1], bm[2]
+	} else {
+		bm := releaseBranchRe.FindStringSubmatch(branch)
+		if bm == nil {
+			return newStructuredError(
+				errInvalidBranch,
+				fmt.Sprintf("current branch %q is not a release branch (expected release-v<MAJOR>.<MINOR>.x)", branch),
+				map[string]any{"branch": branch},
+			)
+		}
+		branchMajor, branchMinor = bm[1], bm[2]
 	}
-	branchMajor, branchMinor := bm[1], bm[2]
 
 	if verMajor != branchMajor || verMinor != branchMinor {
 		return newStructuredError(

--- a/scripts/autoreleasetagger/main_integration_test.go
+++ b/scripts/autoreleasetagger/main_integration_test.go
@@ -299,6 +299,116 @@ func TestNonReleaseBranch(t *testing.T) {
 	}
 }
 
+// TestDevVersionOnDevBranch verifies that a -dev version is accepted on the
+// matching dev-vMAJOR.MINOR.x branch.
+func TestDevVersionOnDevBranch(t *testing.T) {
+	t.Parallel()
+	testLogger()
+
+	const (
+		branch  = "dev-v2.9.x"
+		version = "v2.9.0-dev"
+	)
+
+	tmpDir := scaffoldRepo(t, branch)
+
+	if err := run(false, "test-remote", true, tmpDir, version, []string{}, []string{}, []string{}); err != nil {
+		t.Fatalf("autoreleasetagger failed for dev version on dev branch: %v", err)
+	}
+	assertVersionFile(t, tmpDir, version)
+}
+
+// TestDevVersionWithNumberOnDevBranch verifies that a -dev.N version is accepted
+// on the matching dev-vMAJOR.MINOR.x branch.
+func TestDevVersionWithNumberOnDevBranch(t *testing.T) {
+	t.Parallel()
+	testLogger()
+
+	const (
+		branch  = "dev-v2.9.x"
+		version = "v2.9.0-dev.3"
+	)
+
+	tmpDir := scaffoldRepo(t, branch)
+
+	if err := run(false, "test-remote", true, tmpDir, version, []string{}, []string{}, []string{}); err != nil {
+		t.Fatalf("autoreleasetagger failed for dev.N version on dev branch: %v", err)
+	}
+	assertVersionFile(t, tmpDir, version)
+}
+
+// TestDevVersionOnReleaseBranch verifies that a -dev version on a release branch
+// is rejected with an invalid_branch error.
+func TestDevVersionOnReleaseBranch(t *testing.T) {
+	t.Parallel()
+	testLogger()
+
+	tmpDir := scaffoldRepo(t, "release-v2.9.x")
+
+	err := run(false, "test-remote", true, tmpDir, "v2.9.0-dev", []string{}, []string{}, []string{})
+	if err == nil {
+		t.Fatal("expected error for dev version on release branch, got nil")
+	}
+	var se *StructuredError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *StructuredError, got %T: %v", err, err)
+	}
+	if se.Code != errInvalidBranch {
+		t.Errorf("expected code %q, got %q", errInvalidBranch, se.Code)
+	}
+	if !strings.Contains(err.Error(), "dev branch") {
+		t.Errorf("error should mention dev branch, got: %v", err)
+	}
+}
+
+// TestDevVersionBranchMismatch verifies that a -dev version whose major.minor
+// does not match the dev branch is rejected with an invalid_branch error.
+func TestDevVersionBranchMismatch(t *testing.T) {
+	t.Parallel()
+	testLogger()
+
+	tmpDir := scaffoldRepo(t, "dev-v2.8.x")
+
+	err := run(false, "test-remote", true, tmpDir, "v2.9.0-dev", []string{}, []string{}, []string{})
+	if err == nil {
+		t.Fatal("expected error for dev version/branch mismatch, got nil")
+	}
+	var se *StructuredError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *StructuredError, got %T: %v", err, err)
+	}
+	if se.Code != errInvalidBranch {
+		t.Errorf("expected code %q, got %q", errInvalidBranch, se.Code)
+	}
+	if !strings.Contains(err.Error(), "mismatch") {
+		t.Errorf("error should mention mismatch, got: %v", err)
+	}
+}
+
+// TestStableVersionOnDevBranch verifies that a stable (non-dev) version on a
+// dev branch is rejected with an invalid_branch error.
+func TestStableVersionOnDevBranch(t *testing.T) {
+	t.Parallel()
+	testLogger()
+
+	tmpDir := scaffoldRepo(t, "dev-v2.9.x")
+
+	err := run(false, "test-remote", true, tmpDir, "v2.9.0", []string{}, []string{}, []string{})
+	if err == nil {
+		t.Fatal("expected error for stable version on dev branch, got nil")
+	}
+	var se *StructuredError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *StructuredError, got %T: %v", err, err)
+	}
+	if se.Code != errInvalidBranch {
+		t.Errorf("expected code %q, got %q", errInvalidBranch, se.Code)
+	}
+	if !strings.Contains(err.Error(), "release branch") {
+		t.Errorf("error should mention release branch, got: %v", err)
+	}
+}
+
 // TestVersionFileUpdate verifies that internal/version/version.go is updated to
 // the target version as part of the single commit.
 func TestVersionFileUpdate(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

- Extend `semverRe` to accept `vX.Y.Z-dev` and `vX.Y.Z-dev.N`
- Add `devBranchRe` and route dev versions to require `dev-vX.Y.x` branches
- Add `.claude` to `defaultExcludedDirs` to skip it during module discovery
- Add integration tests covering dev version success and failure paths

### Motivation

Adapt `autoreleasetagger` to our current workflows.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
