### PR TITLE
feat(appsec): add command injection (CMDi) RASP via os.StartProcess

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -71,6 +71,7 @@ jobs:
           - graph-gophers
           - graphql-go
           - gqlgen
+          - net-http-orchestrion
     name: Build weblog (${{ matrix.weblog-variant }})
     env:
       TEST_LIBRARY: golang
@@ -219,6 +220,13 @@ jobs:
             scenario: TRACE_STATS_COMPUTATION
           - weblog-variant: net-http
             scenario: TRACE_STATS_COMPUTATION_CLIENT_DROP_P0S_FALSE
+          # RASP scenarios run on net-http-orchestrion because LFI and CMDi detection require orchestrion
+          - weblog-variant: net-http-orchestrion
+            scenario: APPSEC_RASP
+          - weblog-variant: net-http-orchestrion
+            scenario: APPSEC_RASP_NON_BLOCKING
+          - weblog-variant: net-http-orchestrion
+            scenario: REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD
       fail-fast: false
     env:
       TEST_LIBRARY: golang

--- a/contrib/os/orchestrion.yml
+++ b/contrib/os/orchestrion.yml
@@ -7,7 +7,7 @@
 meta:
   name: github.com/DataDog/dd-trace-go/v2/contrib/os
   description: |-
-    Protection from Local File Inclusion (LFI) Attacks
+    Protection from Local File Inclusion (LFI) and Command Injection (CMDi) Attacks
 
     All known functions that open files are susceptible to Local File Inclusion (LFI) attacks. This aspect protects
     against LFI attacks by wrapping the `os.OpenFile` function with a security operation that will block the operation if
@@ -15,6 +15,13 @@ meta:
 
     Instrumenting only the `os.OpenFile` function is sufficient to protect against LFI attacks, as all other functions in
     the `os` package that open files ultimately call `os.OpenFile` (as of Go 1.23).
+
+    Likewise, all known functions that execute commands are susceptible to Command Injection (CMDi) attacks. This aspect
+    protects against CMDi attacks by wrapping the `os.StartProcess` function with a security operation that will block the
+    operation if it is deemed unsafe.
+
+    Instrumenting only the `os.StartProcess` function is sufficient to protect against CMDi attacks, as all other
+    functions in the `os` and `os/exec` packages that spawn processes ultimately call `os.StartProcess` (as of Go 1.23).
 
 aspects:
   - id: OpenFile
@@ -50,6 +57,45 @@ aspects:
 
                 defer dyngo.FinishOperation(__dd_op, ossec.OpenOperationRes[*File]{
                     File: &{{ .Function.Result 0 }},
+                    Err: &{{ .Function.Result 1 }},
+                })
+
+                if __dd_block {
+                    return
+                }
+            }
+  - id: StartProcess
+    join-point:
+      all-of:
+        - import-path: os
+        - function-body:
+            function:
+              - name: StartProcess
+    advice:
+      - prepend-statements:
+          imports:
+            ossec: github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/emitter/ossec
+            dyngo: github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/dyngo
+            events: github.com/DataDog/dd-trace-go/v2/appsec/events
+          template: |-
+            __dd_parent_op, _ := dyngo.FromContext(nil)
+            if __dd_parent_op != nil {
+                __dd_op := &ossec.RunCommandOperation{
+                    Operation: dyngo.NewOperation(__dd_parent_op),
+                }
+
+                var __dd_block bool
+                dyngo.OnData(__dd_op, func(_ *events.BlockingSecurityEvent) {
+                    __dd_block = true
+                })
+
+                dyngo.StartOperation(__dd_op, ossec.RunCommandOperationArgs{
+                    Name: {{ .Function.Argument 0 }},
+                    Commands: {{ .Function.Argument 1 }},
+                })
+
+                defer dyngo.FinishOperation(__dd_op, ossec.RunCommandOperationRes[*Process]{
+                    Process: &{{ .Function.Result 0 }},
                     Err: &{{ .Function.Result 1 }},
                 })
 

--- a/contrib/os/os.go
+++ b/contrib/os/os.go
@@ -4,7 +4,8 @@
 // Copyright 2024 Datadog, Inc.
 
 // Package os provides integrations into the standard library's `os` package,
-// allowing protection against Local File Inclusion (LFI) attacks.
+// allowing protection against Local File Inclusion (LFI) and Command Injection
+// (CMDi) attacks.
 package os
 
 // These imports satisfy injected dependencies for Orchestrion auto instrumentation.
@@ -55,4 +56,36 @@ func OpenFile(ctx context.Context, path string, flag int, perm os.FileMode) (fil
 	}
 
 	return os.OpenFile(path, flag, perm)
+}
+
+// StartProcess is a [context.Context]-aware version of [os.StartProcess], that allows
+// the use of ASM rules to protect against Command Injection (CMDi) attacks.
+func StartProcess(ctx context.Context, name string, argv []string, attr *os.ProcAttr) (proc *os.Process, err error) {
+	parent, _ := dyngo.FromContext(ctx)
+	if parent != nil {
+		op := &ossec.RunCommandOperation{
+			Operation: dyngo.NewOperation(parent),
+		}
+
+		var block bool
+		dyngo.OnData(op, func(*events.BlockingSecurityEvent) {
+			block = true
+		})
+
+		dyngo.StartOperation(op, ossec.RunCommandOperationArgs{
+			Name:     name,
+			Commands: argv,
+		})
+
+		defer dyngo.FinishOperation(op, ossec.RunCommandOperationRes[*os.Process]{
+			Process: &proc,
+			Err:     &err,
+		})
+
+		if block {
+			return
+		}
+	}
+
+	return os.StartProcess(name, argv, attr)
 }

--- a/contrib/os/os_test.go
+++ b/contrib/os/os_test.go
@@ -8,8 +8,13 @@ package os_test
 import (
 	"context"
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 
+	"github.com/DataDog/go-libddwaf/v5"
+	"github.com/DataDog/go-libddwaf/v5/timer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -21,6 +26,74 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/config"
 	lfi "github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/ossec"
 )
+
+func TestCmdiDetectorVectors(t *testing.T) {
+	if wafOk, err := libddwaf.Usable(); !wafOk {
+		t.Skipf("WAF must be usable for this test to run correctly: %v", err)
+	}
+
+	_, testFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	rules, err := os.ReadFile(filepath.Join(filepath.Dir(testFile), "..", "..", "internal", "orchestrion", "_integration", "testdata", "rasp-only-rules.json"))
+	require.NoError(t, err)
+
+	manager, err := config.NewWAFManagerWithStaticRules(config.ObfuscatorConfig{}, rules)
+	require.NoError(t, err)
+	defer manager.Close()
+
+	handle, _ := manager.NewHandle()
+	require.NotNil(t, handle)
+	defer handle.Close()
+
+	cases := []struct {
+		name      string
+		resource  []string
+		param     string
+		wantMatch bool
+	}{
+		{name: "no injection unrelated reboot", resource: []string{"/usr/bin/reboot", "-f"}, param: "whatever"},
+		{name: "no injection unrelated ls", resource: []string{"ls", "-l", "/file/in/repository"}, param: "whatever"},
+		{name: "no injection unrelated shell command", resource: []string{"/usr/bin/ash", "-c", "ls -l $file ; cat /etc/passwd"}, param: "whatever"},
+		{name: "no executable injection basename only", resource: []string{"/usr/bin/reboot"}, param: "reboot"},
+		{name: "no executable injection unrelated executable", resource: []string{"/usr/bin/reboot", "-f"}, param: "unrelated.exe"},
+		{name: "no executable injection path prefix", resource: []string{"/usr/bin/reboot", "-f"}, param: "/usr"},
+		{name: "no executable injection path segment", resource: []string{"/usr/bin/reboot", "-f"}, param: "usr"},
+		{name: "no executable injection argument", resource: []string{"/usr/bin/reboot", "-f"}, param: "-f"},
+		{name: "no shell injection partial command", resource: []string{"/usr/bin/ash", "-c", "ls -l $file ; cat /etc/passwd"}, param: "cat"},
+		{name: "no shell injection shell substring", resource: []string{"/bin/fish", "ls -l -r -t"}, param: "-r -t"},
+		{name: "executable injection full path", resource: []string{"/usr/bin/reboot"}, param: "/usr/bin/reboot", wantMatch: true},
+		{name: "executable injection full path with args", resource: []string{"/usr/bin/reboot", "-f"}, param: "/usr/bin/reboot", wantMatch: true},
+		{name: "executable injection repeated separators", resource: []string{"//usr//bin//reboot", "-f"}, param: "//usr//bin//reboot", wantMatch: true},
+		{name: "executable injection relative bin path", resource: []string{"bin/reboot", "-f"}, param: "bin/reboot", wantMatch: true},
+		{name: "executable injection parent relative path", resource: []string{"../reboot", "-f"}, param: "../reboot", wantMatch: true},
+		{name: "executable injection root path", resource: []string{"/reboot", "-f"}, param: "/reboot", wantMatch: true},
+		{name: "executable injection normalized traversal text", resource: []string{"/bin/../usr/bin/reboot", "-f"}, param: "/bin/../usr/bin/reboot", wantMatch: true},
+		{name: "executable with spaces trims resource and param", resource: []string{"   /usr/bin/ls         ", "-l", "/file/in/repository"}, param: " /usr/bin/ls ", wantMatch: true},
+		{name: "executable with spaces trims newline", resource: []string{"  /usr/bin/ls\n", "-l", "/file/in/repository"}, param: " /usr/bin/ls\n", wantMatch: true},
+		{name: "shell injection sh command", resource: []string{"/bin/sh", "-c", "ls -l"}, param: "ls -l", wantMatch: true},
+		{name: "shell injection bash command", resource: []string{"/usr/bin/bash", "-c", "--", "ls -l"}, param: "ls -l", wantMatch: true},
+		{name: "shell injection fish command equals", resource: []string{"/usr/bin/fish", "--command=ls -l"}, param: "ls -l", wantMatch: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wafCtx, err := handle.NewContext(context.Background(), timer.WithBudget(time.Second), timer.WithComponents(addresses.Scopes[:]...))
+			require.NoError(t, err)
+			defer wafCtx.Close()
+
+			runData := addresses.NewAddressesBuilder().
+				WithQuery(map[string][]string{"cmd": {tc.param}}).
+				WithSysExecCmd(tc.resource).
+				Build()
+
+			result, err := wafCtx.Run(context.Background(), runData)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equalf(t, tc.wantMatch, result.HasEvents(), "resource=%q param=%q", tc.resource, tc.param)
+			assert.Equalf(t, tc.wantMatch, result.HasActions(), "resource=%q param=%q", tc.resource, tc.param)
+		})
+	}
+}
 
 func TestOpenFile(t *testing.T) {
 	ctx := context.Background()
@@ -48,4 +121,82 @@ func TestOpenFile(t *testing.T) {
 	file, err := wrapos.OpenFile(ctx, "/etc/passwd", os.O_RDONLY, 0)
 	require.ErrorContains(t, err, "blocked")
 	require.Nil(t, file)
+}
+
+func TestStartProcess(t *testing.T) {
+	t.Run("blocking", func(t *testing.T) {
+		cases := []struct {
+			name string
+			argv []string
+		}{
+			{name: "/usr/bin/reboot", argv: []string{"/usr/bin/reboot", "-f"}},
+			{name: "/usr/bin/reboot", argv: []string{"/usr/bin/reboot"}},
+			{name: "bin/reboot", argv: []string{"bin/reboot", "-f"}},
+			{name: "//usr//bin//reboot", argv: []string{"//usr//bin//reboot", "-f"}},
+			{name: "../reboot", argv: []string{"../reboot", "-f"}},
+			{name: "/usr/bin/ls", argv: []string{"/usr/bin/ls", "-l", "/file/in/repository"}},
+			{name: "/usr/bin/bash", argv: []string{"/usr/bin/bash", "-c", "ls -l ; $(cat /etc/passwd)"}},
+			{name: "C:/bin/powershell.exe", argv: []string{"C:/bin/powershell.exe", "-Command", "ls -l"}},
+			{name: "/usr/bin/wget", argv: []string{"ls", "-la"}},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				ctx := context.Background()
+				rootOp := dyngo.NewRootOperation()
+				feature, err := lfi.NewExecSecFeature(
+					&config.Config{
+						RASP:               true,
+						SupportedAddresses: map[string]struct{}{addresses.ServerSysExecCmd: {}},
+					},
+					rootOp,
+				)
+				require.NoError(t, err)
+				defer feature.Stop()
+
+				ctx = dyngo.RegisterOperation(ctx, rootOp)
+				dyngo.On(rootOp, func(op *ossec.RunCommandOperation, args ossec.RunCommandOperationArgs) {
+					// Blocking happens before os.StartProcess, so these attack samples are not executed.
+					dyngo.EmitData(op, &events.BlockingSecurityEvent{})
+
+					assert.Equal(t, tc.name, args.Name)
+					assert.Equal(t, tc.argv, args.Commands)
+				})
+
+				proc, err := wrapos.StartProcess(ctx, tc.name, tc.argv, &os.ProcAttr{})
+				require.ErrorContains(t, err, "blocked")
+				require.True(t, events.IsSecurityError(err))
+				require.Nil(t, proc)
+			})
+		}
+	})
+
+	t.Run("non-blocking", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("self-exec pass-through test is Unix-only")
+		}
+
+		ctx := context.Background()
+		rootOp := dyngo.NewRootOperation()
+		feature, err := lfi.NewExecSecFeature(
+			&config.Config{
+				RASP:               true,
+				SupportedAddresses: map[string]struct{}{addresses.ServerSysExecCmd: {}},
+			},
+			rootOp,
+		)
+		require.NoError(t, err)
+		defer feature.Stop()
+
+		ctx = dyngo.RegisterOperation(ctx, rootOp)
+
+		exe, err := os.Executable()
+		require.NoError(t, err)
+
+		proc, err := wrapos.StartProcess(ctx, exe, []string{exe, "-test.run=^$"}, &os.ProcAttr{})
+		require.NoError(t, err)
+		require.NotNil(t, proc)
+		// Reap the child to avoid leaking a process.
+		_, _ = proc.Wait()
+	})
 }

--- a/instrumentation/appsec/emitter/ossec/exec.go
+++ b/instrumentation/appsec/emitter/ossec/exec.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package ossec
+
+import (
+	"github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/dyngo"
+)
+
+type (
+	// RunCommandOperation type embodies any kind of function call that will result in a call to an execve(2) syscall
+	RunCommandOperation struct {
+		dyngo.Operation
+	}
+
+	// RunCommandOperationArgs is the arguments for a command execution operation
+	RunCommandOperationArgs struct {
+		// Name is the resolved executable path (os.StartProcess name); enforced as argv[0] for WAF evaluation.
+		Name string
+		// Commands is the argument vector (argv) passed to the execve(2) syscall
+		Commands []string
+	}
+
+	// RunCommandOperationRes is the result of a command execution operation
+	RunCommandOperationRes[Process any] struct {
+		// Process is the process handle returned by the execution
+		Process *Process
+		// Err is the error returned by the function
+		Err *error
+	}
+)
+
+func (RunCommandOperationArgs) IsArgOf(*RunCommandOperation)            {}
+func (RunCommandOperationRes[Process]) IsResultOf(*RunCommandOperation) {}

--- a/internal/appsec/README.md
+++ b/internal/appsec/README.md
@@ -206,6 +206,7 @@ All currently available features are the following ones:
 | GraphQL WAF Protection | Protects GraphQL requests from attacks                 |
 | SQL RASP               | Runtime Application Self-Protection for SQL injections |
 | OS RASP                | Runtime Application Self-Protection for LFI attacks    |
+| CMDi RASP              | Runtime Application Self-Protection for command injection attacks |
 | HTTP RASP              | Runtime Application Self-Protection for SSRF attacks   |
 | User Security          | User blocking and login failures/success events        |
 | WAF Context            | Setup of the request scoped context system of the WAF  |

--- a/internal/appsec/features.go
+++ b/internal/appsec/features.go
@@ -30,6 +30,7 @@ var features = []listener.NewFeature{
 	usersec.NewUserSecFeature,
 	sqlsec.NewSQLSecFeature,
 	ossec.NewOSSecFeature,
+	ossec.NewExecSecFeature,
 	httpsec.NewSSRFProtectionFeature,
 }
 

--- a/internal/appsec/listener/ossec/exec.go
+++ b/internal/appsec/listener/ossec/exec.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package ossec
+
+import (
+	"os"
+
+	"github.com/DataDog/dd-trace-go/v2/appsec/events"
+	"github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/dyngo"
+	"github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/emitter/ossec"
+	"github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/emitter/waf/addresses"
+	"github.com/DataDog/dd-trace-go/v2/internal/appsec/config"
+	"github.com/DataDog/dd-trace-go/v2/internal/appsec/emitter/waf"
+	"github.com/DataDog/dd-trace-go/v2/internal/appsec/listener"
+)
+
+type ExecFeature struct{}
+
+func (*ExecFeature) String() string {
+	return "CMDi Protection"
+}
+
+func (*ExecFeature) Stop() {}
+
+func NewExecSecFeature(cfg *config.Config, rootOp dyngo.Operation) (listener.Feature, error) {
+	if !cfg.RASP || !cfg.SupportedAddresses.AnyOf(addresses.ServerSysExecCmd) {
+		return nil, nil
+	}
+
+	feature := &ExecFeature{}
+	dyngo.On(rootOp, feature.OnStart)
+	return feature, nil
+}
+
+func (*ExecFeature) OnStart(op *ossec.RunCommandOperation, args ossec.RunCommandOperationArgs) {
+	dyngo.OnData(op, func(err *events.BlockingSecurityEvent) {
+		dyngo.OnFinish(op, func(_ *ossec.RunCommandOperation, res ossec.RunCommandOperationRes[*os.Process]) {
+			if res.Err != nil {
+				*res.Err = err
+			}
+		})
+	})
+
+	ctxOp, ok := waf.ContextOperationFromParents(op)
+	if !ok {
+		return
+	}
+
+	subOp := ctxOp.NewSubcontextOp()
+	defer subOp.Close()
+	subOp.Run(op, addresses.NewAddressesBuilder().
+		WithSysExecCmd(execCommandVector(args.Name, args.Commands)).
+		Build())
+}
+
+// execCommandVector returns the argv to evaluate, forcing element 0 to the
+// real executable (name) so the WAF sees the actual injected binary (RFC-0989),
+// without mutating the caller's slice.
+func execCommandVector(name string, argv []string) []string {
+	if len(argv) == 0 {
+		return []string{name}
+	}
+	out := append([]string(nil), argv...)
+	out[0] = name
+	return out
+}

--- a/internal/appsec/listener/ossec/exec_test.go
+++ b/internal/appsec/listener/ossec/exec_test.go
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package ossec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecCommandVector_forcesExecutableNameAsArgv0(t *testing.T) {
+	tests := []struct {
+		name string
+		exe  string
+		argv []string
+		want []string
+	}{
+		{
+			name: "replaces spoofed argv0 with executed binary",
+			exe:  "/usr/bin/wget",
+			argv: []string{"ls", "-la"},
+			want: []string{"/usr/bin/wget", "-la"},
+		},
+		{
+			name: "keeps normal argv unchanged",
+			exe:  "/usr/bin/touch",
+			argv: []string{"/usr/bin/touch", "/tmp/passwd"},
+			want: []string{"/usr/bin/touch", "/tmp/passwd"},
+		},
+		{
+			name: "uses executable name when argv is empty",
+			exe:  "/bin/sh",
+			argv: nil,
+			want: []string{"/bin/sh"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given
+			argv := append([]string(nil), tt.argv...)
+
+			// When
+			got := execCommandVector(tt.exe, argv)
+
+			// Then
+			require.Equal(t, tt.want, got)
+			require.Equal(t, tt.argv, argv)
+		})
+	}
+}

--- a/internal/appsec/remoteconfig.go
+++ b/internal/appsec/remoteconfig.go
@@ -391,6 +391,9 @@ func (a *appsec) enableRASP() {
 		if err := remoteconfig.RegisterCapability(remoteconfig.ASMRASPLFI); err != nil {
 			log.Debug("appsec: remote config: couldn't register RASP LFI: %s", err.Error())
 		}
+		if err := remoteconfig.RegisterCapability(remoteconfig.ASMRASPCommandInjection); err != nil {
+			log.Debug("appsec: remote config: couldn't register RASP CMDi: %s", err.Error())
+		}
 	}
 }
 

--- a/internal/orchestrion/_integration/os/cmdi.go
+++ b/internal/orchestrion/_integration/os/cmdi.go
@@ -1,0 +1,116 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package os
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/DataDog/go-libddwaf/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/dd-trace-go/v2/appsec/events"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion/_integration/internal/net"
+	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion/_integration/internal/trace"
+)
+
+type TestCaseCmdi struct {
+	*http.Server
+	*testing.T
+}
+
+func (tc *TestCaseCmdi) Setup(_ context.Context, t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("appsec does not support Windows")
+	}
+	if ok, err := libddwaf.Usable(); !ok {
+		t.Skip("WAF is not available:", err)
+	}
+
+	t.Setenv("DD_APPSEC_RULES", "../testdata/rasp-only-rules.json")
+	t.Setenv("DD_APPSEC_ENABLED", "true")
+	t.Setenv("DD_APPSEC_RASP_ENABLED", "true")
+	t.Setenv("DD_APPSEC_WAF_TIMEOUT", "1h")
+	mux := http.NewServeMux()
+	tc.Server = &http.Server{
+		Addr:    fmt.Sprintf("127.0.0.1:%d", net.FreePort(t)),
+		Handler: mux,
+	}
+
+	mux.HandleFunc("/", tc.handleRoot)
+
+	go func() { assert.ErrorIs(t, tc.Server.ListenAndServe(), http.ErrServerClosed) }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		require.NoError(t, tc.Server.Shutdown(ctx))
+	})
+}
+
+func (tc *TestCaseCmdi) Run(_ context.Context, t *testing.T) {
+	tc.T = t
+	resp, err := http.Get(fmt.Sprintf("http://%s/?command=/usr/bin/touch%%20/tmp/passwd", tc.Server.Addr))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func (*TestCaseCmdi) ExpectedTraces() trace.Traces {
+	return trace.Traces{
+		{
+			Tags: map[string]any{
+				"name":     "http.request",
+				"resource": "GET /",
+				"type":     "http",
+			},
+			Meta: map[string]string{
+				"component": "net/http",
+				"span.kind": "client",
+			},
+			Children: trace.Traces{
+				{
+					Tags: map[string]any{
+						"name":     "http.request",
+						"resource": "GET /",
+						"type":     "web",
+					},
+					Meta: map[string]string{
+						"component":         "net/http",
+						"span.kind":         "server",
+						"appsec.blocked":    "true",
+						"is.security.error": "true",
+					},
+				},
+			},
+		},
+	}
+}
+
+func (tc *TestCaseCmdi) handleRoot(w http.ResponseWriter, r *http.Request) {
+	command := r.URL.Query().Get("command")
+	err := (&exec.Cmd{Path: command, Args: []string{command}}).Run()
+
+	assert.ErrorIs(tc.T, err, &events.BlockingSecurityEvent{})
+	if events.IsSecurityError(err) {
+		span, _ := tracer.SpanFromContext(r.Context())
+		span.SetTag("is.security.error", true)
+		return
+	}
+
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/orchestrion/_integration/os/generated_test.go
+++ b/internal/orchestrion/_integration/os/generated_test.go
@@ -16,3 +16,7 @@ import (
 func Test(t *testing.T) {
 	harness.Run(t, new(TestCase))
 }
+
+func TestCmdi(t *testing.T) {
+	harness.Run(t, new(TestCaseCmdi))
+}

--- a/internal/orchestrion/_integration/testdata/rasp-only-rules.json
+++ b/internal/orchestrion/_integration/testdata/rasp-only-rules.json
@@ -152,6 +152,55 @@
                 "stack_trace",
                 "block"
             ]
+        },
+        {
+            "id": "rasp-932-110",
+            "name": "OS command injection exploit",
+            "tags": {
+                "type": "command_injection",
+                "category": "vulnerability_trigger",
+                "cwe": "77",
+                "capec": "1000/152/248/88",
+                "confidence": "1",
+                "module": "rasp"
+            },
+            "conditions": [
+                {
+                    "parameters": {
+                        "resource": [
+                            {
+                                "address": "server.sys.exec.cmd"
+                            }
+                        ],
+                        "params": [
+                            {
+                                "address": "server.request.query"
+                            },
+                            {
+                                "address": "server.request.body"
+                            },
+                            {
+                                "address": "server.request.path_params"
+                            },
+                            {
+                                "address": "grpc.server.request.message"
+                            },
+                            {
+                                "address": "graphql.server.all_resolvers"
+                            },
+                            {
+                                "address": "graphql.server.resolver"
+                            }
+                        ]
+                    },
+                    "operator": "cmdi_detector"
+                }
+            ],
+            "transformers": [],
+            "on_match": [
+                "stack_trace",
+                "block"
+            ]
         }
     ],
     "rules_data": []


### PR DESCRIPTION
### What does this PR do?

Adds **Command Injection (CMDi) RASP** to the tracer, wired end-to-end at the single `os.StartProcess` choke point (which underlies every `os/exec` call) and active under Orchestrion. When the WAF detects a command-injection attempt (rule `rasp-932-110`, address `server.sys.exec.cmd`), `os.StartProcess` is blocked: it returns a `BlockingSecurityEvent` error and `(nil, err)` instead of launching the process. This mirrors the existing LFI feature.

- **emitter**: `RunCommandOperation`/`Args`/`Res` in `instrumentation/appsec/emitter/ossec` (no `os` import; generic).
- **listener**: `NewExecSecFeature` (activates on `server.sys.exec.cmd`), registered in `internal/appsec/features.go`. Forces `argv[0] = name` so the WAF evaluates the real executable per [RFC-0989] (defeats an `argv[0]`-spoofing bypass on raw `os.StartProcess`).
- **contrib/os**: context-aware `StartProcess` wrapper (named returns, argv forwarded unchanged).
- **orchestrion**: `os.StartProcess` aspect in `contrib/os/orchestrion.yml`.
- **remoteconfig**: advertise `ASM_RASP_CMDI` capability under `orchestrion.Enabled()`.
- **tests**: `contrib/os` unit tests (mock wrapper + table-driven real-WAF `cmdi_detector` vectors mirroring libddwaf) + orchestrion integration test (real WAF, HTTP 403) + testdata `rasp-932-110`.
- **ci**: run `APPSEC_RASP`, `APPSEC_RASP_NON_BLOCKING`, and `REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD` on `net-http-orchestrion`.
- **docs**: appsec README + orchestrion.yml meta.

No spans, no shell variant, no `go-libddwaf` change.

### Motivation

Exploit prevention for command injection ([RFC-0989]). The shipped WAF ruleset already contains the command-injection rule and the tracer already has the `server.sys.exec.cmd` address/metrics/rule-type plumbing, so this is a wiring-plus-tests change.

Companion system-tests PR (adds the `/rasp/cmdi` weblog endpoint and enables `Test_Cmdi_*` for `net-http-orchestrion`): **DataDog/system-tests#7251**. The CMDi `net-http-orchestrion` `APPSEC_RASP` run goes green once that endpoint/manifest is available; a manual cross-branch `workflow_dispatch` run validating both branches together will be linked below.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes reviewed by @DataDog/dd-trace-go-guild.

[RFC-0989]: internal exploit-prevention command-injection RFC
