### PR TITLE
fix(ci): update smoke-tests go-libddwaf ref to v5

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       go-libddwaf-ref:
-        description: A git ref to update github.com/DataDog/go-libddwaf/v4 to. No-op if empty.
+        description: A git ref to update github.com/DataDog/go-libddwaf/v5 to. No-op if empty.
         required: false
         type: string
   push:
@@ -73,7 +73,7 @@ jobs:
             go mod tidy
             find . -iname go.mod -exec dirname {} \; | while read -r d; do pushd "$d" && go mod tidy && popd; done
             if [ -n "${GO_LIBDDWAF_REF:-}" ]; then
-              go get -u -t "github.com/DataDog/go-libddwaf/v4@${GO_LIBDDWAF_REF}"
+              go get -u -t "github.com/DataDog/go-libddwaf/v5@${GO_LIBDDWAF_REF}"
               go mod tidy
             fi
             # shellcheck disable=SC2086

--- a/internal/setup-smoke-test/Dockerfile
+++ b/internal/setup-smoke-test/Dockerfile
@@ -49,7 +49,7 @@ RUN if [ "${go_libddwaf_ref}" != "" ]; then \
   alpine) apk update && apk add git;; \
   *) apt update && apt install -y git ;; \
   esac; \
-  go get -u github.com/DataDog/go-libddwaf/v4@${go_libddwaf_ref}; \
+  go get -u github.com/DataDog/go-libddwaf/v5@${go_libddwaf_ref}; \
   fi
 
 RUN go mod tidy


### PR DESCRIPTION
### What does this PR do?

Updates the `go-libddwaf` module major in the Smoke Tests reusable workflow (`.github/workflows/smoke-tests.yml`) from `v4` to `v5` — in both the `go-libddwaf-ref` input description and the `setup-env` injection step:

```diff
-              go get -u -t "github.com/DataDog/go-libddwaf/v4@${GO_LIBDDWAF_REF}"
+              go get -u -t "github.com/DataDog/go-libddwaf/v5@${GO_LIBDDWAF_REF}"
```

### Motivation

`go-libddwaf` has moved to its **v5** module path (`github.com/DataDog/go-libddwaf/v5`). go-libddwaf's own CI reuses this workflow (`DataDog/dd-trace-go/.github/workflows/smoke-tests.yml@main`) with `go-libddwaf-ref` set to a **v5** commit. The hardcoded `v4` path makes the `setup-env` job fail:

```
go: github.com/DataDog/go-libddwaf/v4@<sha>: invalid version:
go.mod has non-.../v4 module path "github.com/DataDog/go-libddwaf/v5"
```

dd-trace-go already depends on go-libddwaf/v5 (e.g. `.github/workflows/apps/go.mod` pins `v5.0.0-rc.2`), so the `v4` in this workflow is a stale reference. Updating it to `v5` unblocks the go-libddwaf smoke tests.

Context: this was surfaced by DataDog/go-libddwaf#224.

### Reviewer's Checklist

> CI-workflow-only change (no library code) — the code/test/benchmark items below are N/A.

- [ ] Changed code has unit tests for its functionality at or near 100% coverage. — N/A (workflow only)
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag. — N/A
- [ ] There is a benchmark for any new code, or changes to existing code. — N/A
- [ ] If this interacts with the agent in a new way, a system test has been added. — N/A
- [ ] New code is free of linting errors. — N/A
- [ ] New code doesn't break existing tests. — validated by re-running the go-libddwaf #224 smoke tests once merged.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date.
- [ ] Non-trivial go.mod changes reviewed by @DataDog/dd-trace-go-guild. — N/A (no go.mod changes)
