### PR TITLE
fix(civisibility): isolate mock server read cache

### DIFF
--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -1375,6 +1375,8 @@ func setUpHTTPServer(
 	testManagementData *net.TestManagementTestsResponseDataModules,
 	impactedTests bool,
 	itrCoverage map[string][]byte) *httptest.Server {
+	isolateReadCacheForMockServer()
+
 	// Reset the collected logs for the new server instance.
 	logsEntries = nil
 	enableKnownTests := knownTestsEnabled || earlyFlakyDetectionEnabled
@@ -1507,6 +1509,21 @@ func setUpHTTPServer(
 	os.Setenv(constants.APIKeyEnvironmentVariable, "12345")
 
 	return server
+}
+
+func isolateReadCacheForMockServer() {
+	// httptest ports can be reused between scenario subprocesses, so keep mock
+	// CI Visibility responses out of the shared short-lived read cache.
+	cacheRoot, err := os.MkdirTemp("", "dd-trace-go-civisibility-read-cache-*")
+	if err != nil {
+		log.Debug("unable to isolate CI Visibility read cache for mock server: %s", err.Error())
+		return
+	}
+	net.SetReadCacheHooksForTesting(cacheRoot, nil, nil, nil, nil)
+	integrations.PushCiVisibilityCloseAction(func() {
+		net.ResetReadCacheHooksForTesting()
+		_ = os.RemoveAll(cacheRoot)
+	})
 }
 
 func getSpansWithType(spans []*mocktracer.Span, spanType string) []*mocktracer.Span {

--- a/internal/orchestrion/_integration/civisibilitytest/payloads.go
+++ b/internal/orchestrion/_integration/civisibilitytest/payloads.go
@@ -206,7 +206,7 @@ func StartMockServerWithOptions(opts ...MockServerOption) (*httptest.Server, *Pa
 // propagated to subprocesses. This is needed when the mock server runs in a
 // parent process but CI Visibility initializes in a child process.
 func ConfigureMockServerReadCacheFromEnv() func() {
-	cacheRoot := os.Getenv(mockServerReadCacheRootEnv)
+	cacheRoot := ddenv.Get(mockServerReadCacheRootEnv)
 	if cacheRoot == "" {
 		return func() {}
 	}

--- a/internal/orchestrion/_integration/civisibilitytest/payloads.go
+++ b/internal/orchestrion/_integration/civisibilitytest/payloads.go
@@ -32,6 +32,8 @@ type envUpdate struct {
 	unset bool
 }
 
+const mockServerReadCacheRootEnv = "CIVISIBILITY_TEST_READ_CACHE_ROOT"
+
 type mockServerConfig struct {
 	settings       civisibilitynet.SettingsResponseData
 	knownTests     *civisibilitynet.KnownTestsResponseData
@@ -177,14 +179,8 @@ func StartMockServerWithOptions(opts ...MockServerOption) (*httptest.Server, *Pa
 
 	// httptest ports can be reused between scenario subprocesses, so keep mock
 	// CI Visibility responses out of the shared short-lived read cache.
-	cacheRoot, err := os.MkdirTemp("", "dd-trace-go-civisibility-read-cache-*")
-	if err != nil {
-		log.Printf("unable to isolate CI Visibility read cache for mock server: %s", err)
-	} else {
-		civisibilitynet.SetReadCacheHooksForTesting(cacheRoot, nil, nil, nil, nil)
-	}
-
-	restore := applyEnvUpdates(append([]envUpdate{
+	cacheRoot, cleanupReadCache := isolateReadCacheForMockServer("")
+	envUpdates := []envUpdate{
 		{key: "DD_CIVISIBILITY_ENABLED", value: "true"},
 		{key: "DD_CIVISIBILITY_AGENTLESS_ENABLED", value: "true"},
 		{key: "DD_CIVISIBILITY_AGENTLESS_URL", value: server.URL},
@@ -192,13 +188,48 @@ func StartMockServerWithOptions(opts ...MockServerOption) (*httptest.Server, *Pa
 		{key: "DD_GIT_REPOSITORY_URL", value: "https://github.com/DataDog/dd-trace-go.git"},
 		{key: "DD_GIT_COMMIT_SHA", value: "1234567890abcdef1234567890abcdef12345678"},
 		{key: "DD_GIT_BRANCH", value: "main"},
-	}, cfg.env...))
+	}
+	if cacheRoot != "" {
+		envUpdates = append(envUpdates, envUpdate{key: mockServerReadCacheRootEnv, value: cacheRoot})
+	}
+
+	restore := applyEnvUpdates(append(envUpdates, cfg.env...))
 
 	return server, payloads, func() {
 		restore()
 		server.Close()
-		if cacheRoot != "" {
-			civisibilitynet.ResetReadCacheHooksForTesting()
+		cleanupReadCache()
+	}
+}
+
+// ConfigureMockServerReadCacheFromEnv installs the mock server read cache root
+// propagated to subprocesses. This is needed when the mock server runs in a
+// parent process but CI Visibility initializes in a child process.
+func ConfigureMockServerReadCacheFromEnv() func() {
+	cacheRoot := os.Getenv(mockServerReadCacheRootEnv)
+	if cacheRoot == "" {
+		return func() {}
+	}
+	_, cleanupReadCache := isolateReadCacheForMockServer(cacheRoot)
+	return cleanupReadCache
+}
+
+func isolateReadCacheForMockServer(cacheRoot string) (string, func()) {
+	removeOnCleanup := false
+	if cacheRoot == "" {
+		var err error
+		cacheRoot, err = os.MkdirTemp("", "dd-trace-go-civisibility-read-cache-*")
+		if err != nil {
+			log.Printf("unable to isolate CI Visibility read cache for mock server: %s", err)
+			return "", func() {}
+		}
+		removeOnCleanup = true
+	}
+
+	civisibilitynet.SetReadCacheHooksForTesting(cacheRoot, nil, nil, nil, nil)
+	return cacheRoot, func() {
+		civisibilitynet.ResetReadCacheHooksForTesting()
+		if removeOnCleanup {
 			_ = os.RemoveAll(cacheRoot)
 		}
 	}

--- a/internal/orchestrion/_integration/civisibilitytest/payloads.go
+++ b/internal/orchestrion/_integration/civisibilitytest/payloads.go
@@ -175,6 +175,15 @@ func StartMockServerWithOptions(opts ...MockServerOption) (*httptest.Server, *Pa
 		}
 	}))
 
+	// httptest ports can be reused between scenario subprocesses, so keep mock
+	// CI Visibility responses out of the shared short-lived read cache.
+	cacheRoot, err := os.MkdirTemp("", "dd-trace-go-civisibility-read-cache-*")
+	if err != nil {
+		log.Printf("unable to isolate CI Visibility read cache for mock server: %s", err)
+	} else {
+		civisibilitynet.SetReadCacheHooksForTesting(cacheRoot, nil, nil, nil, nil)
+	}
+
 	restore := applyEnvUpdates(append([]envUpdate{
 		{key: "DD_CIVISIBILITY_ENABLED", value: "true"},
 		{key: "DD_CIVISIBILITY_AGENTLESS_ENABLED", value: "true"},
@@ -188,6 +197,10 @@ func StartMockServerWithOptions(opts ...MockServerOption) (*httptest.Server, *Pa
 	return server, payloads, func() {
 		restore()
 		server.Close()
+		if cacheRoot != "" {
+			civisibilitynet.ResetReadCacheHooksForTesting()
+			_ = os.RemoveAll(cacheRoot)
+		}
 	}
 }
 

--- a/internal/orchestrion/_integration/parallel_testing_retries/parallel_testing_retries_test.go
+++ b/internal/orchestrion/_integration/parallel_testing_retries/parallel_testing_retries_test.go
@@ -128,6 +128,8 @@ func TestMain(m *testing.M) {
 
 func runScenarioChild(m *testing.M, cfg scenarioConfig) int {
 	if os.Getenv(externalMockServerEnv) == "true" {
+		restoreReadCache := civisibilitytest.ConfigureMockServerReadCacheFromEnv()
+		defer restoreReadCache()
 		return m.Run()
 	}
 


### PR DESCRIPTION
### What does this PR do?

Isolates the CI Visibility short-lived read cache used by test mock servers in two places:

- `internal/civisibility/integrations/gotesting/testcontroller_test.go`
- `internal/orchestrion/_integration/civisibilitytest/payloads.go`

Each mock server now uses a temporary read-cache root and cleans it up when the scenario shuts down. This is a test-only change; production CI Visibility read-cache behavior is unchanged.

### Motivation

CI Visibility scenario tests spin up multiple `httptest.Server` instances with different synthetic settings and known-tests responses. The production short-lived read cache scopes entries by request and base URL. Because `httptest` ports can be reused between subprocess scenarios, a later mock server can occasionally hit a cached response from an earlier scenario.

That explains the observed flakes:

- `TestParallelEarlyFlakeDetection` could see a test as known instead of new and emit one span instead of the expected EFD fan-out.
- `TestParallelEFDParallel` could reuse settings from the previous scenario and emit fewer retry events than expected.

Keeping mock-server responses out of the shared cache preserves the production cache while making these tests deterministic.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage. — test harness fix covered by affected integration tests.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag. — N/A, test-only change.
- [ ] There is a benchmark for any new code, or changes to existing code. — N/A.
- [ ] If this interacts with the agent in a new way, a system test has been added. — N/A.
- [x] New code is free of linting errors. You can check this by running `make lint` locally. — `gofmt` and `git diff --check`.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally. — no generated files changed.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally. — N/A.

Validation:

```sh
INTEGRATION=true TestParallelEarlyFlakeDetection=true go test -count=1 -race -tags=deadlock -shuffle=1783349356086329016 -covermode=atomic -coverprofile=/tmp/parallel-efd-branch-coverage.txt ./internal/civisibility/integrations/gotesting

GOFLAGS='-timeout=30m -tags=githubci,buildtag' DD_ORCHESTRION_IS_GOMOD_VERSION=true TESTCONTAINERS_RYUK_DISABLED=true orchestrion go test -json -shuffle=1783353044879498939 ./parallel_testing_retries
```

Additional local stress while investigating:

- Full `gotesting` scenario suite passed with `-race -tags=deadlock -shuffle=1783349356086329016`.
- `parallel_testing_retries` passed 5/5 repeated Orchestrion runs with the CI seed.