### PR TITLE
feat(tracer): add WithStatsdClient option for sharing statsd clients [shadow]

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -1000,9 +1000,13 @@ func WithDogstatsdAddr(addr string) StartOption {
 // WithStatsdClient sets a custom statsd client to be used by the tracer for
 // internal metrics. When set, the tracer will not create its own statsd client,
 // allowing callers to share a single client across the tracer and application code.
-func WithStatsdClient(client internal.StatsdClient) StartOption {
+// The client must satisfy internal.StatsdClient; *statsd.ClientDirect from
+// github.com/DataDog/datadog-go/v5 satisfies this requirement.
+func WithStatsdClient(client statsd.ClientInterface) StartOption {
 	return func(cfg *config) {
-		cfg.statsdClient = client
+		if c, ok := client.(internal.StatsdClient); ok {
+			cfg.statsdClient = c
+		}
 	}
 }
 

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -997,6 +997,15 @@ func WithDogstatsdAddr(addr string) StartOption {
 	}
 }
 
+// WithStatsdClient sets a custom statsd client to be used by the tracer for
+// internal metrics. When set, the tracer will not create its own statsd client,
+// allowing callers to share a single client across the tracer and application code.
+func WithStatsdClient(client internal.StatsdClient) StartOption {
+	return func(cfg *config) {
+		cfg.statsdClient = client
+	}
+}
+
 // WithSamplingRules specifies the sampling rates to apply to spans based on the
 // provided rules.
 func WithSamplingRules(rules []SamplingRule) StartOption {

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -1000,10 +1000,10 @@ func WithDogstatsdAddr(addr string) StartOption {
 // WithStatsdClient sets a custom statsd client to be used by the tracer for
 // internal metrics. When set, the tracer will not create its own statsd client,
 // allowing callers to share a single client across the tracer and application code.
-// The client must satisfy internal.StatsdClient; *statsd.ClientDirect from
-// github.com/DataDog/datadog-go/v5 satisfies this requirement.
 func WithStatsdClient(client statsd.ClientInterface) StartOption {
 	return func(cfg *config) {
+		// The client must satisfy internal.StatsdClient; *statsd.ClientDirect from
+		// github.com/DataDog/datadog-go/v5 satisfies this requirement.
 		if c, ok := client.(internal.StatsdClient); ok {
 			cfg.statsdClient = c
 		}

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -997,16 +997,21 @@ func WithDogstatsdAddr(addr string) StartOption {
 	}
 }
 
+// StatsdClient is the method set the tracer needs from an injected statsd
+// client. *statsd.ClientDirect from github.com/DataDog/datadog-go/v5 satisfies
+// this at compile time, so passing an incompatible type is a build error
+// rather than a silent no-op.
+type StatsdClient interface {
+	statsd.ClientInterface
+	statsd.ClientDirectInterface
+}
+
 // WithStatsdClient sets a custom statsd client to be used by the tracer for
 // internal metrics. When set, the tracer will not create its own statsd client,
 // allowing callers to share a single client across the tracer and application code.
-func WithStatsdClient(client statsd.ClientInterface) StartOption {
+func WithStatsdClient(client StatsdClient) StartOption {
 	return func(cfg *config) {
-		// The client must satisfy internal.StatsdClient; *statsd.ClientDirect from
-		// github.com/DataDog/datadog-go/v5 satisfies this requirement.
-		if c, ok := client.(internal.StatsdClient); ok {
-			cfg.statsdClient = c
-		}
+		cfg.statsdClient = client
 	}
 }
 

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -221,6 +221,22 @@ func TestAutoDetectStatsd(t *testing.T) {
 	})
 }
 
+func TestWithStatsdClient(t *testing.T) {
+	// Create a real *statsd.ClientDirect — it satisfies both statsd.ClientInterface
+	// and internal.StatsdClient, which is the contract WithStatsdClient documents.
+	client, err := statsd.NewDirect("localhost:8125", statsd.WithMaxMessagesPerPayload(40))
+	require.NoError(t, err)
+	defer client.Close()
+
+	cfg, err := newTestConfig(WithStatsdClient(client))
+	require.NoError(t, err)
+
+	// The injected client should be used directly instead of creating a new one.
+	got, err := newStatsdClient(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, client, got, "WithStatsdClient: tracer should use the provided client")
+}
+
 func TestInternalMetricsDisabled(t *testing.T) {
 	isNoop := func(c internal.StatsdClient) bool {
 		_, ok := c.(*statsd.NoOpClientDirect)


### PR DESCRIPTION
### What does this PR do?

Shadows #4935

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
