### PR TITLE
fix(contrib/gofiber/fiber.v2): clone zero-copy fasthttp strings in span tags

### DIFF
--- a/contrib/gofiber/fiber.v2/fiber.go
+++ b/contrib/gofiber/fiber.v2/fiber.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
@@ -44,7 +45,9 @@ func Middleware(opts ...Option) func(c *fiber.Ctx) error {
 		opts := []tracer.StartSpanOption{
 			tracer.SpanType(ext.SpanTypeWeb),
 			instrumentation.ServiceNameWithSource(cfg.serviceName, cfg.serviceSource),
-			tracer.Tag(ext.HTTPMethod, c.Method()),
+			// c.Method() aliases fasthttp's connection buffer (zero-copy); clone it so the
+			// tag remains valid after fasthttp reuses the buffer for a later request.
+			tracer.Tag(ext.HTTPMethod, strings.Clone(c.Method())),
 			tracer.Tag(ext.HTTPURL, string(c.Request().URI().PathOriginal())),
 			tracer.Measured(),
 		}
@@ -54,11 +57,15 @@ func Middleware(opts ...Option) func(c *fiber.Ctx) error {
 		// Create a http.Header object so that a parent trace can be extracted. Fiber uses a non-standard header carrier
 		h := http.Header{}
 		for k, headers := range c.GetReqHeaders() {
+			// GetReqHeaders returns keys and values that alias fasthttp's connection buffer
+			// (zero-copy); clone them since h may be used to populate span tags, and the
+			// buffer can be reused by fasthttp for a later request before spans are flushed.
+			k = strings.Clone(k)
 			for _, v := range headers {
 				// GetReqHeaders returns a list of headers associated with the given key.
 				// http.Header.Add supports appending multiple values, so the previous
 				// value will not be overwritten.
-				h.Add(k, v)
+				h.Add(k, strings.Clone(v))
 			}
 		}
 		if spanctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(h)); err == nil {

--- a/contrib/gofiber/fiber.v2/fiber_test.go
+++ b/contrib/gofiber/fiber.v2/fiber_test.go
@@ -6,10 +6,14 @@
 package fiber
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
@@ -382,4 +386,110 @@ func TestSecurityTestingHeaders(t *testing.T) {
 	span := spans[0]
 	assert.Equal("true", span.Tag(ext.HTTPRequestHeaders+".x-datadog-endpoint-scan"))
 	assert.Equal("test-value", span.Tag(ext.HTTPRequestHeaders+".x-datadog-security-test"))
+}
+
+// TestFinishedSpanTagsChangeWhenFasthttpReusesConnectionBuffer reproduces
+// https://github.com/DataDog/dd-trace-go/issues/4968.
+//
+// Fiber's Ctx.Method() and Ctx.GetReqHeaders() return zero-copy strings that
+// alias fasthttp's per-connection read buffer. The middleware stores those
+// strings directly as span tags instead of copying them, so once fasthttp
+// reuses the buffer to parse a later keep-alive request on the same
+// connection, an already-finished span's tags can silently change. Same
+// root cause as https://github.com/gofiber/fiber/issues/4464, referenced
+// from #4968.
+//
+// Each subtest drives a real fasthttp.Server over a real connection with two
+// sequential requests, rather than manually overwriting fasthttp's buffer,
+// so the reuse is the same one fasthttp performs in production.
+func TestFinishedSpanTagsChangeWhenFasthttpReusesConnectionBuffer(t *testing.T) {
+	t.Run("http-method", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		router := fiber.New()
+		router.Use(Middleware(WithService("foobar")))
+		router.Use(func(c *fiber.Ctx) error {
+			return c.SendString("ok")
+		})
+
+		conn := serveOnPipe(t, router)
+
+		sendRequest(t, conn, "GET", "/first")
+		sendRequest(t, conn, "DELETE", "/second")
+
+		spans := mt.FinishedSpans()
+		require.Len(t, spans, 2)
+		assert.Equal(t, "GET", spans[0].Tag(ext.HTTPMethod),
+			"first request's http.method tag changed after being served: it aliases fasthttp's reused connection buffer instead of holding a copy")
+	})
+
+	t.Run("security-testing-header", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		router := fiber.New()
+		router.Use(Middleware(WithService("foobar")))
+		router.Use(func(c *fiber.Ctx) error {
+			return c.SendString("ok")
+		})
+
+		conn := serveOnPipe(t, router)
+
+		sendRequest(t, conn, "GET", "/first", "X-Datadog-Security-Test: test-value")
+		sendRequest(t, conn, "GET", "/second", "X-Datadog-Security-Test: corrupted!")
+
+		spans := mt.FinishedSpans()
+		require.Len(t, spans, 2)
+		tagName := ext.HTTPRequestHeaders + ".x-datadog-security-test"
+		assert.Equal(t, "test-value", spans[0].Tag(tagName),
+			"first request's security-testing header tag changed after being served: it aliases fasthttp's reused connection buffer instead of holding a copy")
+	})
+}
+
+// pipedConn is a real, single keep-alive connection to router's underlying
+// fasthttp.Server, backed by a net.Pipe.
+type pipedConn struct {
+	net.Conn
+	r *bufio.Reader
+}
+
+// serveOnPipe starts router's underlying fasthttp.Server serving a single,
+// real keep-alive connection over a net.Pipe, and returns the client side.
+func serveOnPipe(t *testing.T, router *fiber.App) *pipedConn {
+	t.Helper()
+
+	// Build the route tree before serving.
+	router.Handler()
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() { clientConn.Close() })
+	go func() {
+		_ = router.Server().ServeConn(serverConn)
+	}()
+
+	return &pipedConn{Conn: clientConn, r: bufio.NewReader(clientConn)}
+}
+
+// sendRequest writes a raw HTTP/1.1 request for method/path (with optional
+// extra "Key: value" header lines) onto conn, and reads+discards the
+// response so the connection is ready for the next keep-alive request.
+func sendRequest(t *testing.T, conn *pipedConn, method, path string, extraHeaders ...string) {
+	t.Helper()
+
+	var req strings.Builder
+	fmt.Fprintf(&req, "%s %s HTTP/1.1\r\nHost: example.com\r\n", method, path)
+	for _, h := range extraHeaders {
+		req.WriteString(h + "\r\n")
+	}
+	req.WriteString("\r\n")
+
+	_, err := conn.Write([]byte(req.String()))
+	require.NoError(t, err)
+
+	resp, err := http.ReadResponse(conn.r, nil)
+	require.NoError(t, err)
+	_, err = io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
 }


### PR DESCRIPTION
### What does this PR do?

Clones the strings coming from `Ctx.Method()` and `GetReqHeaders()` before storing them as span tags in the gofiber middleware.

### Motivation

Fixes #4968

Fiber's `Ctx.Method()` and `GetReqHeaders()` return strings that alias fasthttp's connection buffer (zero-copy). fasthttp reuses that buffer for the next request, so any span tag built from these values without copying can silently change after the span has already finished.

This is a different failure mode than the HPACK panic in gofiber/fiber#4464, since that one needs gRPC's stateful encoder to crash. Here it just corrupts APM tags, and it also creates a data race between the tracer's flush goroutine and fasthttp reusing the buffer.

The fix clones the strings before storing them as tags, matching what Fiber's own docs recommend (`strings.Clone` / `utils.CopyString`).

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!