### PR TITLE
perf(datastreams): avoid per-header string alloc on Kafka consume hot path

### DIFF
--- a/contrib/IBM/sarama/headers.go
+++ b/contrib/IBM/sarama/headers.go
@@ -6,6 +6,7 @@
 package sarama
 
 import (
+	"github.com/DataDog/dd-trace-go/v2/datastreams"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 
 	"github.com/IBM/sarama"
@@ -21,6 +22,10 @@ var _ interface {
 	tracer.TextMapWriter
 } = (*ProducerMessageCarrier)(nil)
 
+// Guard the DSM single-key fast path; if Get drifts, extraction silently falls
+// back to the slow ForeachKey path.
+var _ datastreams.TextMapReaderByKey = (*ProducerMessageCarrier)(nil)
+
 // ForeachKey iterates over every header.
 func (c ProducerMessageCarrier) ForeachKey(handler func(key, val string) error) error {
 	for _, h := range c.msg.Headers {
@@ -30,6 +35,25 @@ func (c ProducerMessageCarrier) ForeachKey(handler func(key, val string) error) 
 		}
 	}
 	return nil
+}
+
+// Get implements datastreams.TextMapReaderByKey, converting only the matched
+// header's value to a string (unlike ForeachKey, which converts them all). When
+// a key appears more than once it returns the last occurrence, matching
+// ForeachKey's last-wins behavior for duplicate headers.
+func (c ProducerMessageCarrier) Get(key string) (string, bool) {
+	var val []byte
+	found := false
+	for _, h := range c.msg.Headers {
+		if string(h.Key) == key {
+			val = h.Value
+			found = true
+		}
+	}
+	if !found {
+		return "", false
+	}
+	return string(val), true
 }
 
 // Set sets a header.
@@ -62,6 +86,8 @@ var _ interface {
 	tracer.TextMapWriter
 } = (*ConsumerMessageCarrier)(nil)
 
+var _ datastreams.TextMapReaderByKey = (*ConsumerMessageCarrier)(nil)
+
 // NewConsumerMessageCarrier creates a new ConsumerMessageCarrier.
 func NewConsumerMessageCarrier(msg *sarama.ConsumerMessage) ConsumerMessageCarrier {
 	return ConsumerMessageCarrier{msg}
@@ -78,6 +104,25 @@ func (c ConsumerMessageCarrier) ForeachKey(handler func(key, val string) error) 
 		}
 	}
 	return nil
+}
+
+// Get implements datastreams.TextMapReaderByKey, converting only the matched
+// header's value to a string (unlike ForeachKey, which converts them all). When
+// a key appears more than once it returns the last occurrence, matching
+// ForeachKey's last-wins behavior for duplicate headers.
+func (c ConsumerMessageCarrier) Get(key string) (string, bool) {
+	var val []byte
+	found := false
+	for _, h := range c.msg.Headers {
+		if h != nil && string(h.Key) == key {
+			val = h.Value
+			found = true
+		}
+	}
+	if !found {
+		return "", false
+	}
+	return string(val), true
 }
 
 // Set sets a header.

--- a/contrib/IBM/sarama/headers.go
+++ b/contrib/IBM/sarama/headers.go
@@ -22,8 +22,6 @@ var _ interface {
 	tracer.TextMapWriter
 } = (*ProducerMessageCarrier)(nil)
 
-// Guard the DSM single-key fast path; if Get drifts, extraction silently falls
-// back to the slow ForeachKey path.
 var _ datastreams.TextMapReaderByKey = (*ProducerMessageCarrier)(nil)
 
 // ForeachKey iterates over every header.

--- a/contrib/IBM/sarama/headers_bench_test.go
+++ b/contrib/IBM/sarama/headers_bench_test.go
@@ -1,0 +1,71 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package sarama
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/datastreams"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+
+	"github.com/IBM/sarama"
+)
+
+// foreachOnlyReader hides the carrier's Get method so ExtractFromBase64Carrier
+// falls back to ForeachKey. This lets each benchmark measure the exact same
+// message both ways (slow ForeachKey vs the fast single-key path).
+type foreachOnlyReader struct {
+	r datastreams.TextMapReader
+}
+
+func (f foreachOnlyReader) ForeachKey(handler func(key, val string) error) error {
+	return f.r.ForeachKey(handler)
+}
+
+func pathwayHeaderValue(topic string) string {
+	ctx, _ := tracer.SetDataStreamsCheckpoint(context.Background(), "direction:out", "type:kafka", "topic:"+topic)
+	pm := &sarama.ProducerMessage{}
+	datastreams.InjectToBase64Carrier(ctx, NewProducerMessageCarrier(pm))
+	for _, h := range pm.Headers {
+		if string(h.Key) == "dd-pathway-ctx-base64" {
+			return string(h.Value)
+		}
+	}
+	return ""
+}
+
+func noiseHeaders(pathway string, extra int) []*sarama.RecordHeader {
+	hs := []*sarama.RecordHeader{{Key: []byte("dd-pathway-ctx-base64"), Value: []byte(pathway)}}
+	for i := range extra {
+		hs = append(hs, &sarama.RecordHeader{
+			Key:   fmt.Appendf(nil, "x-header-%d", i),
+			Value: fmt.Appendf(nil, "some-moderately-long-header-value-%d", i),
+		})
+	}
+	return hs
+}
+
+func benchExtract(b *testing.B, r datastreams.TextMapReader) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		datastreams.ExtractFromBase64Carrier(context.Background(), r)
+	}
+}
+
+// BenchmarkExtractConsumer measures ExtractFromBase64Carrier on a consumer message
+// carrying the pathway header plus 10 other headers (typical of a real message).
+func BenchmarkExtractConsumer(b *testing.B) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	msg := &sarama.ConsumerMessage{Headers: noiseHeaders(pathwayHeaderValue("orders"), 10)}
+	carrier := NewConsumerMessageCarrier(msg)
+	b.Run("ForeachKey", func(b *testing.B) { benchExtract(b, foreachOnlyReader{carrier}) })
+	b.Run("FastPath", func(b *testing.B) { benchExtract(b, carrier) })
+}

--- a/contrib/Shopify/sarama/headers.go
+++ b/contrib/Shopify/sarama/headers.go
@@ -22,8 +22,6 @@ var _ interface {
 	tracer.TextMapWriter
 } = (*ProducerMessageCarrier)(nil)
 
-// Guard the DSM single-key fast path; if Get drifts, extraction silently falls
-// back to the slow ForeachKey path.
 var _ datastreams.TextMapReaderByKey = (*ProducerMessageCarrier)(nil)
 
 // ForeachKey iterates over every header.

--- a/contrib/Shopify/sarama/headers.go
+++ b/contrib/Shopify/sarama/headers.go
@@ -6,6 +6,7 @@
 package sarama
 
 import (
+	"github.com/DataDog/dd-trace-go/v2/datastreams"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 
 	"github.com/Shopify/sarama"
@@ -21,6 +22,10 @@ var _ interface {
 	tracer.TextMapWriter
 } = (*ProducerMessageCarrier)(nil)
 
+// Guard the DSM single-key fast path; if Get drifts, extraction silently falls
+// back to the slow ForeachKey path.
+var _ datastreams.TextMapReaderByKey = (*ProducerMessageCarrier)(nil)
+
 // ForeachKey iterates over every header.
 func (c ProducerMessageCarrier) ForeachKey(handler func(key, val string) error) error {
 	for _, h := range c.msg.Headers {
@@ -30,6 +35,25 @@ func (c ProducerMessageCarrier) ForeachKey(handler func(key, val string) error) 
 		}
 	}
 	return nil
+}
+
+// Get implements datastreams.TextMapReaderByKey, converting only the matched
+// header's value to a string (unlike ForeachKey, which converts them all). When
+// a key appears more than once it returns the last occurrence, matching
+// ForeachKey's last-wins behavior for duplicate headers.
+func (c ProducerMessageCarrier) Get(key string) (string, bool) {
+	var val []byte
+	found := false
+	for _, h := range c.msg.Headers {
+		if string(h.Key) == key {
+			val = h.Value
+			found = true
+		}
+	}
+	if !found {
+		return "", false
+	}
+	return string(val), true
 }
 
 // Set sets a header.
@@ -62,6 +86,8 @@ var _ interface {
 	tracer.TextMapWriter
 } = (*ConsumerMessageCarrier)(nil)
 
+var _ datastreams.TextMapReaderByKey = (*ConsumerMessageCarrier)(nil)
+
 // NewConsumerMessageCarrier creates a new ConsumerMessageCarrier.
 func NewConsumerMessageCarrier(msg *sarama.ConsumerMessage) ConsumerMessageCarrier {
 	return ConsumerMessageCarrier{msg}
@@ -78,6 +104,25 @@ func (c ConsumerMessageCarrier) ForeachKey(handler func(key, val string) error) 
 		}
 	}
 	return nil
+}
+
+// Get implements datastreams.TextMapReaderByKey, converting only the matched
+// header's value to a string (unlike ForeachKey, which converts them all). When
+// a key appears more than once it returns the last occurrence, matching
+// ForeachKey's last-wins behavior for duplicate headers.
+func (c ConsumerMessageCarrier) Get(key string) (string, bool) {
+	var val []byte
+	found := false
+	for _, h := range c.msg.Headers {
+		if h != nil && string(h.Key) == key {
+			val = h.Value
+			found = true
+		}
+	}
+	if !found {
+		return "", false
+	}
+	return string(val), true
 }
 
 // Set sets a header.

--- a/contrib/Shopify/sarama/headers_bench_test.go
+++ b/contrib/Shopify/sarama/headers_bench_test.go
@@ -1,0 +1,71 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package sarama
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/datastreams"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+
+	"github.com/Shopify/sarama"
+)
+
+// foreachOnlyReader hides the carrier's Get method so ExtractFromBase64Carrier
+// falls back to ForeachKey. This lets each benchmark measure the exact same
+// message both ways (slow ForeachKey vs the fast single-key path).
+type foreachOnlyReader struct {
+	r datastreams.TextMapReader
+}
+
+func (f foreachOnlyReader) ForeachKey(handler func(key, val string) error) error {
+	return f.r.ForeachKey(handler)
+}
+
+func pathwayHeaderValue(topic string) string {
+	ctx, _ := tracer.SetDataStreamsCheckpoint(context.Background(), "direction:out", "type:kafka", "topic:"+topic)
+	pm := &sarama.ProducerMessage{}
+	datastreams.InjectToBase64Carrier(ctx, NewProducerMessageCarrier(pm))
+	for _, h := range pm.Headers {
+		if string(h.Key) == "dd-pathway-ctx-base64" {
+			return string(h.Value)
+		}
+	}
+	return ""
+}
+
+func noiseHeaders(pathway string, extra int) []*sarama.RecordHeader {
+	hs := []*sarama.RecordHeader{{Key: []byte("dd-pathway-ctx-base64"), Value: []byte(pathway)}}
+	for i := range extra {
+		hs = append(hs, &sarama.RecordHeader{
+			Key:   fmt.Appendf(nil, "x-header-%d", i),
+			Value: fmt.Appendf(nil, "some-moderately-long-header-value-%d", i),
+		})
+	}
+	return hs
+}
+
+func benchExtract(b *testing.B, r datastreams.TextMapReader) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		datastreams.ExtractFromBase64Carrier(context.Background(), r)
+	}
+}
+
+// BenchmarkExtractConsumer measures ExtractFromBase64Carrier on a consumer message
+// carrying the pathway header plus 10 other headers (typical of a real message).
+func BenchmarkExtractConsumer(b *testing.B) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	msg := &sarama.ConsumerMessage{Headers: noiseHeaders(pathwayHeaderValue("orders"), 10)}
+	carrier := NewConsumerMessageCarrier(msg)
+	b.Run("ForeachKey", func(b *testing.B) { benchExtract(b, foreachOnlyReader{carrier}) })
+	b.Run("FastPath", func(b *testing.B) { benchExtract(b, carrier) })
+}

--- a/contrib/confluentinc/confluent-kafka-go/kafkatrace/message_carrier.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafkatrace/message_carrier.go
@@ -5,7 +5,10 @@
 
 package kafkatrace
 
-import "github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+import (
+	"github.com/DataDog/dd-trace-go/v2/datastreams"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+)
 
 // A MessageCarrier implements TextMapReader/TextMapWriter for extracting/injecting traces on a kafka.msg
 type MessageCarrier struct {
@@ -17,6 +20,11 @@ var _ interface {
 	tracer.TextMapWriter
 } = (*MessageCarrier)(nil)
 
+// Ensure MessageCarrier keeps satisfying the DSM single-key fast path; if the
+// Get signature drifts, extraction silently falls back to the slow ForeachKey
+// path, so guard it at compile time.
+var _ datastreams.TextMapReaderByKey = (*MessageCarrier)(nil)
+
 // ForeachKey conforms to the TextMapReader interface.
 func (c MessageCarrier) ForeachKey(handler func(key, val string) error) error {
 	for _, h := range c.msg.GetHeaders() {
@@ -26,6 +34,25 @@ func (c MessageCarrier) ForeachKey(handler func(key, val string) error) error {
 		}
 	}
 	return nil
+}
+
+// Get implements datastreams.TextMapReaderByKey, converting only the matched
+// header's value to a string (unlike ForeachKey, which converts them all).
+// When a key appears more than once it returns the last occurrence, matching
+// ForeachKey's last-wins behavior for duplicate headers.
+func (c MessageCarrier) Get(key string) (string, bool) {
+	var val []byte
+	found := false
+	for _, h := range c.msg.GetHeaders() {
+		if h.GetKey() == key {
+			val = h.GetValue()
+			found = true
+		}
+	}
+	if !found {
+		return "", false
+	}
+	return string(val), true
 }
 
 // Set implements TextMapWriter

--- a/contrib/confluentinc/confluent-kafka-go/kafkatrace/message_carrier.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafkatrace/message_carrier.go
@@ -20,9 +20,6 @@ var _ interface {
 	tracer.TextMapWriter
 } = (*MessageCarrier)(nil)
 
-// Ensure MessageCarrier keeps satisfying the DSM single-key fast path; if the
-// Get signature drifts, extraction silently falls back to the slow ForeachKey
-// path, so guard it at compile time.
 var _ datastreams.TextMapReaderByKey = (*MessageCarrier)(nil)
 
 // ForeachKey conforms to the TextMapReader interface.

--- a/contrib/confluentinc/confluent-kafka-go/kafkatrace/message_carrier_bench_test.go
+++ b/contrib/confluentinc/confluent-kafka-go/kafkatrace/message_carrier_bench_test.go
@@ -1,0 +1,103 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package kafkatrace
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/datastreams"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+)
+
+// benchHeader/benchMsg mirror the real confluent wHeader/wMessage: GetHeaders
+// allocates a fresh []Header and boxes each header on every call, so the
+// benchmark reflects production per-message allocation behavior.
+type benchHeader struct {
+	key string
+	val []byte
+}
+
+func (h *benchHeader) GetKey() string   { return h.key }
+func (h *benchHeader) GetValue() []byte { return h.val }
+
+type benchMsg struct {
+	raw []benchHeader
+}
+
+func (m *benchMsg) GetValue() []byte { return nil }
+func (m *benchMsg) GetKey() []byte   { return nil }
+func (m *benchMsg) GetHeaders() []Header {
+	hs := make([]Header, 0, len(m.raw))
+	for i := range m.raw {
+		hs = append(hs, &m.raw[i])
+	}
+	return hs
+}
+func (m *benchMsg) SetHeaders([]Header)               {}
+func (m *benchMsg) GetTopicPartition() TopicPartition { return nil }
+func (m *benchMsg) Unwrap() any                       { return nil }
+
+// foreachOnlyReader hides Get so ExtractFromBase64Carrier uses the ForeachKey
+// fallback, letting us benchmark the same message both ways.
+type foreachOnlyReader struct {
+	r datastreams.TextMapReader
+}
+
+func (f foreachOnlyReader) ForeachKey(handler func(key, val string) error) error {
+	return f.r.ForeachKey(handler)
+}
+
+func pathwayHeaderValue() string {
+	ctx, _ := tracer.SetDataStreamsCheckpoint(context.Background(), "direction:out", "type:kafka", "topic:orders")
+	w := &writeMsg{}
+	datastreams.InjectToBase64Carrier(ctx, NewMessageCarrier(w))
+	for _, h := range w.headers {
+		if h.GetKey() == "dd-pathway-ctx-base64" {
+			return string(h.GetValue())
+		}
+	}
+	return ""
+}
+
+// writeMsg captures headers written by InjectToBase64Carrier.
+type writeMsg struct {
+	headers []Header
+}
+
+func (m *writeMsg) GetValue() []byte                  { return nil }
+func (m *writeMsg) GetKey() []byte                    { return nil }
+func (m *writeMsg) GetHeaders() []Header              { return m.headers }
+func (m *writeMsg) SetHeaders(h []Header)             { m.headers = h }
+func (m *writeMsg) GetTopicPartition() TopicPartition { return nil }
+func (m *writeMsg) Unwrap() any                       { return nil }
+
+func benchExtract(b *testing.B, r datastreams.TextMapReader) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		datastreams.ExtractFromBase64Carrier(context.Background(), r)
+	}
+}
+
+// BenchmarkExtract measures ExtractFromBase64Carrier on a message carrying the
+// pathway header plus 10 other headers (typical of a real message).
+func BenchmarkExtract(b *testing.B) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	raw := []benchHeader{{key: "dd-pathway-ctx-base64", val: []byte(pathwayHeaderValue())}}
+	for i := range 10 {
+		raw = append(raw, benchHeader{
+			key: fmt.Sprintf("x-header-%d", i),
+			val: fmt.Appendf(nil, "some-moderately-long-header-value-%d", i),
+		})
+	}
+	carrier := NewMessageCarrier(&benchMsg{raw: raw})
+	b.Run("ForeachKey", func(b *testing.B) { benchExtract(b, foreachOnlyReader{carrier}) })
+	b.Run("FastPath", func(b *testing.B) { benchExtract(b, carrier) })
+}

--- a/contrib/segmentio/kafka-go/internal/tracing/message_carrier.go
+++ b/contrib/segmentio/kafka-go/internal/tracing/message_carrier.go
@@ -6,6 +6,7 @@
 package tracing
 
 import (
+	"github.com/DataDog/dd-trace-go/v2/datastreams"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 )
 
@@ -19,6 +20,10 @@ var _ interface {
 	tracer.TextMapWriter
 } = (*MessageCarrier)(nil)
 
+// Guard the DSM single-key fast path; if Get drifts, extraction silently falls
+// back to the slow ForeachKey path.
+var _ datastreams.TextMapReaderByKey = (*MessageCarrier)(nil)
+
 // ForeachKey conforms to the TextMapReader interface.
 func (c MessageCarrier) ForeachKey(handler func(key, val string) error) error {
 	for _, h := range c.msg.GetHeaders() {
@@ -28,6 +33,25 @@ func (c MessageCarrier) ForeachKey(handler func(key, val string) error) error {
 		}
 	}
 	return nil
+}
+
+// Get implements datastreams.TextMapReaderByKey, converting only the matched
+// header's value to a string (unlike ForeachKey, which converts them all). When
+// a key appears more than once it returns the last occurrence, matching
+// ForeachKey's last-wins behavior for duplicate headers.
+func (c MessageCarrier) Get(key string) (string, bool) {
+	var val []byte
+	found := false
+	for _, h := range c.msg.GetHeaders() {
+		if h.GetKey() == key {
+			val = h.GetValue()
+			found = true
+		}
+	}
+	if !found {
+		return "", false
+	}
+	return string(val), true
 }
 
 // Set implements TextMapWriter

--- a/contrib/segmentio/kafka-go/internal/tracing/message_carrier.go
+++ b/contrib/segmentio/kafka-go/internal/tracing/message_carrier.go
@@ -20,8 +20,6 @@ var _ interface {
 	tracer.TextMapWriter
 } = (*MessageCarrier)(nil)
 
-// Guard the DSM single-key fast path; if Get drifts, extraction silently falls
-// back to the slow ForeachKey path.
 var _ datastreams.TextMapReaderByKey = (*MessageCarrier)(nil)
 
 // ForeachKey conforms to the TextMapReader interface.

--- a/contrib/segmentio/kafka-go/internal/tracing/message_carrier_bench_test.go
+++ b/contrib/segmentio/kafka-go/internal/tracing/message_carrier_bench_test.go
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package tracing
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/datastreams"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+)
+
+// benchMsg is a minimal tracing.Message used to exercise the real MessageCarrier.
+type benchMsg struct {
+	headers []Header
+}
+
+func (m *benchMsg) GetValue() []byte      { return nil }
+func (m *benchMsg) GetKey() []byte        { return nil }
+func (m *benchMsg) GetHeaders() []Header  { return m.headers }
+func (m *benchMsg) SetHeaders(h []Header) { m.headers = h }
+func (m *benchMsg) GetTopic() string      { return "" }
+func (m *benchMsg) GetPartition() int     { return 0 }
+func (m *benchMsg) GetOffset() int64      { return 0 }
+
+// foreachOnlyReader hides Get so ExtractFromBase64Carrier uses the ForeachKey
+// fallback, letting us benchmark the same message both ways.
+type foreachOnlyReader struct {
+	r datastreams.TextMapReader
+}
+
+func (f foreachOnlyReader) ForeachKey(handler func(key, val string) error) error {
+	return f.r.ForeachKey(handler)
+}
+
+func pathwayHeaderValue() string {
+	ctx, _ := tracer.SetDataStreamsCheckpoint(context.Background(), "direction:out", "type:kafka", "topic:orders")
+	msg := &benchMsg{}
+	datastreams.InjectToBase64Carrier(ctx, NewMessageCarrier(msg))
+	for _, h := range msg.headers {
+		if h.GetKey() == "dd-pathway-ctx-base64" {
+			return string(h.GetValue())
+		}
+	}
+	return ""
+}
+
+func benchExtract(b *testing.B, r datastreams.TextMapReader) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		datastreams.ExtractFromBase64Carrier(context.Background(), r)
+	}
+}
+
+// BenchmarkExtract measures ExtractFromBase64Carrier on a message carrying the
+// pathway header plus 10 other headers (typical of a real message).
+func BenchmarkExtract(b *testing.B) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	hs := []Header{KafkaHeader{Key: "dd-pathway-ctx-base64", Value: []byte(pathwayHeaderValue())}}
+	for i := range 10 {
+		hs = append(hs, KafkaHeader{
+			Key:   fmt.Sprintf("x-header-%d", i),
+			Value: fmt.Appendf(nil, "some-moderately-long-header-value-%d", i),
+		})
+	}
+	carrier := NewMessageCarrier(&benchMsg{headers: hs})
+	b.Run("ForeachKey", func(b *testing.B) { benchExtract(b, foreachOnlyReader{carrier}) })
+	b.Run("FastPath", func(b *testing.B) { benchExtract(b, carrier) })
+}

--- a/datastreams/propagation.go
+++ b/datastreams/propagation.go
@@ -49,9 +49,27 @@ type TextMapReader interface {
 	ForeachKey(handler func(key, val string) error) error
 }
 
+// TextMapReaderByKey is an optional interface a carrier can implement to return a
+// single key directly. Extraction only needs the pathway key (PropagationKeyBase64),
+// but the generic ForeachKey contract forces the carrier to produce a string value
+// for every entry it holds. Carriers backed by many/large entries (e.g. Kafka message
+// headers) should implement this to avoid converting every entry's value to a string
+// on the consume hot path when only the pathway key is used.
+type TextMapReaderByKey interface {
+	// Get returns the value for key, and whether it was present.
+	Get(key string) (val string, ok bool)
+}
+
 // ExtractFromBase64Carrier extracts the pathway context from a carrier to a context object
 func ExtractFromBase64Carrier(ctx context.Context, carrier TextMapReader) (outCtx context.Context) {
 	outCtx = ctx
+	// Fast path: read the single pathway key directly if the carrier supports it.
+	if byKey, ok := carrier.(TextMapReaderByKey); ok {
+		if val, found := byKey.Get(datastreams.PropagationKeyBase64); found {
+			_, outCtx, _ = datastreams.DecodeBase64(ctx, val)
+		}
+		return outCtx
+	}
 	carrier.ForeachKey(func(key, val string) error {
 		if key == datastreams.PropagationKeyBase64 {
 			_, outCtx, _ = datastreams.DecodeBase64(ctx, val)

--- a/datastreams/propagation_test.go
+++ b/datastreams/propagation_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/datastreams"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type carrier map[string]string
@@ -42,4 +43,82 @@ func TestBase64Propagation(t *testing.T) {
 	expected, _ := datastreams.PathwayFromContext(ctx)
 	assert.Equal(t, expected.GetHash(), got.GetHash())
 	assert.NotEqual(t, 0, expected.GetHash())
+}
+
+type kv struct{ k, v string }
+
+// slowCarrier implements only ForeachKey, so ExtractFromBase64Carrier uses the
+// fallback path. It preserves order and duplicate keys (unlike a map carrier).
+type slowCarrier struct{ hs []kv }
+
+func (c *slowCarrier) Set(key, val string) { c.hs = append(c.hs, kv{key, val}) }
+func (c *slowCarrier) ForeachKey(handler func(key, val string) error) error {
+	for _, e := range c.hs {
+		if err := handler(e.k, e.v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// fastCarrier also implements TextMapReaderByKey, so extraction uses the fast path.
+type fastCarrier struct{ slowCarrier }
+
+func (c *fastCarrier) Get(key string) (val string, ok bool) {
+	for _, e := range c.hs {
+		if e.k == key {
+			val, ok = e.v, true // last occurrence wins, matching ForeachKey
+		}
+	}
+	return val, ok
+}
+
+func inject(t *testing.T, ctx context.Context) string {
+	t.Helper()
+	w := &slowCarrier{}
+	InjectToBase64Carrier(ctx, w)
+	require.Len(t, w.hs, 1)
+	return w.hs[0].v
+}
+
+// The fast path (Get) and the fallback path (ForeachKey) must extract the same
+// pathway from the same headers.
+func TestExtractFastPathMatchesFallback(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	ctx, _ := tracer.SetDataStreamsCheckpoint(context.Background(), "direction:out", "type:kafka", "topic:topic1")
+	pathwayVal := inject(t, ctx)
+	hs := []kv{{"other-header", "x"}, {datastreams.PropagationKeyBase64, pathwayVal}, {"another", "y"}}
+
+	slow := &slowCarrier{hs: hs}
+	fast := &fastCarrier{slowCarrier{hs: hs}}
+	_, slowIsByKey := any(slow).(TextMapReaderByKey)
+	_, fastIsByKey := any(fast).(TextMapReaderByKey)
+	require.False(t, slowIsByKey, "slowCarrier must exercise the fallback path")
+	require.True(t, fastIsByKey, "fastCarrier must exercise the fast path")
+
+	expected, _ := datastreams.PathwayFromContext(ctx)
+	gotSlow, _ := datastreams.PathwayFromContext(ExtractFromBase64Carrier(context.Background(), slow))
+	gotFast, _ := datastreams.PathwayFromContext(ExtractFromBase64Carrier(context.Background(), fast))
+	assert.NotEqual(t, uint64(0), expected.GetHash())
+	assert.Equal(t, expected.GetHash(), gotSlow.GetHash())
+	assert.Equal(t, expected.GetHash(), gotFast.GetHash())
+}
+
+// When the pathway header appears more than once, both paths must agree on which
+// one wins (the last), so extraction is deterministic regardless of carrier type.
+func TestExtractDuplicatePathwayHeaderLastWins(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+	ctxA, _ := tracer.SetDataStreamsCheckpoint(context.Background(), "direction:out", "type:kafka", "topic:a")
+	ctxB, _ := tracer.SetDataStreamsCheckpoint(context.Background(), "direction:out", "type:kafka", "topic:b")
+	valA, valB := inject(t, ctxA), inject(t, ctxB)
+	hs := []kv{{datastreams.PropagationKeyBase64, valA}, {datastreams.PropagationKeyBase64, valB}} // B is last
+
+	expectedB, _ := datastreams.PathwayFromContext(ctxB)
+	gotSlow, _ := datastreams.PathwayFromContext(ExtractFromBase64Carrier(context.Background(), &slowCarrier{hs: hs}))
+	gotFast, _ := datastreams.PathwayFromContext(ExtractFromBase64Carrier(context.Background(), &fastCarrier{slowCarrier{hs: hs}}))
+	assert.NotEqual(t, expectedB.GetHash(), datastreams.Pathway{}.GetHash())
+	assert.Equal(t, expectedB.GetHash(), gotSlow.GetHash(), "fallback path: last duplicate wins")
+	assert.Equal(t, expectedB.GetHash(), gotFast.GetHash(), "fast path: last duplicate wins")
 }


### PR DESCRIPTION
## Problem

The DSM consume checkpoint runs on every Kafka message. `datastreams.ExtractFromBase64Carrier` only needs one header (`dd-pathway-ctx-base64`), but it reads the carrier via the generic `ForeachKey` contract, which forces the carrier to convert **every** header value `[]byte`→`string` — one heap allocation per header, all but one immediately discarded. On a high-throughput consumer that allocation rate is a material GC driver.

### Proof (allocation profile)

Profiling the consume hot path of a high-throughput Kafka consumer, a single line accounted for **61.7% of all allocations** in the extract path:

```
ROUTINE ======== MessageCarrier.ForeachKey
 2079588   2376672 (flat, cum) 70.56% of Total
       .         .   for _, h := range c.msg.GetHeaders() {
 2079588   2376672     if err := handler(h.GetKey(), string(h.GetValue())); err != nil {
```

`string(h.GetValue())` allocates a fresh string per header; the DSM callback keeps only the pathway header and discards the rest.

## What changed

- Add an optional `datastreams.TextMapReaderByKey` interface (`Get(key) (string, bool)`). `ExtractFromBase64Carrier` uses it when the carrier implements it, and falls back to `ForeachKey` otherwise.
- Implement `Get` on all Kafka carriers — confluent, Shopify & IBM sarama (producer + consumer), segmentio — converting only the matched header's value.
- APM trace propagation (which legitimately reads many headers via `ForeachKey`) is untouched.
- `Get` matches `ForeachKey`'s last-wins semantics for duplicate headers, and each carrier has a `var _ datastreams.TextMapReaderByKey` compile-time assertion so the fast path can't silently regress.

## Results

`ExtractFromBase64Carrier` on the same message (pathway header + 10 others), Apple M3 Max, measured both ways on the identical carrier:

| Carrier | Before (`ForeachKey`) | After (fast path) |
|---|---|---|
| confluent | 384 ns, 872 B, 17 allocs | 205 ns, 360 B, 6 allocs |
| Shopify/sarama | 449 ns, 880 B, 27 allocs | 133 ns, 184 B, 5 allocs |
| IBM/sarama | 453 ns, 880 B, 27 allocs | 133 ns, 184 B, 5 allocs |
| segmentio | 342 ns, 696 B, 16 allocs | 151 ns, 184 B, 5 allocs |

Benchmarks are committed (`BenchmarkExtract*` in each carrier package) and reproduce the before/after by hiding `Get` to force the fallback path.

## Notes

- Complementary to #4920 (hash-cache fingerprint, edge-tag cache, processtags): that PR reduced allocations on the checkpoint/tag side; this one removes them on the header-extract side. Different files, different allocation sources.
- Scope is Kafka carriers only for now. Any carrier can opt in by implementing `TextMapReaderByKey`.
- This does not remove the header-slice materialization inside each carrier's `GetHeaders()`; that would require a by-key accessor on the carriers' `Message` interfaces (a larger, cross-module change) and is deliberately left as a follow-up.


## End-to-end benchmark (Kafka consumer)

Reproduced the original slow-consume scenario in a standalone app: a DSM-only
consume path (plain confluent consumer + manual extract + checkpoint, no
per-message APM span, matching the reporting service). Local Kafka, 20 headers
per message, consumer CPU-bound at ~80k msg/s, 30s CPU profiles, baseline
(`origin/main`) vs this branch under identical load.

DSM per-message work (`trackConsume` = extract + checkpoint), from `go tool pprof`:

| | Baseline | This PR |
|---|---|---|
| `trackConsume` (whole DSM op) | 2.41s | 1.64s (**-32%**) |
| `ExtractFromBase64Carrier` | 1.74s | 0.98s (**-44%**) |

In the flame graph the per-header `runtime.slicebytetostring` block (the string
copies) disappears after the fix; only the matched pathway header is converted.
(pprof focus-view total for `trackConsume`: 2.41s -> 1.64s.)
