### PR TITLE
perf(ddtrace/tracer): avoid per-header ToLower allocs during context extraction

### DIFF
--- a/.gitlab/benchmarks/micro/gitlab-ci.yml
+++ b/.gitlab/benchmarks/micro/gitlab-ci.yml
@@ -79,7 +79,7 @@ microbenchmarks-1:
 microbenchmarks-2:
   extends: .microbenchmarks
   variables:
-    BENCHMARKS: "BenchmarkStartRequestSpan|BenchmarkStartRequestSpanQueryObfuscation|BenchmarkHttpServeTrace|BenchmarkHttpServeTraceQueryObfuscation|BenchmarkTracerAddSpans|BenchmarkStartSpan|BenchmarkSingleSpanRetention|BenchmarkOTelApiWithCustomTags|BenchmarkInjectW3C|BenchmarkExtractW3C|BenchmarkExtractDatadogHTTPHeaders|BenchmarkPartialFlushing|BenchmarkSampleWAFSubContext"
+    BENCHMARKS: "BenchmarkStartRequestSpan|BenchmarkStartRequestSpanQueryObfuscation|BenchmarkHttpServeTrace|BenchmarkHttpServeTraceQueryObfuscation|BenchmarkTracerAddSpans|BenchmarkStartSpan|BenchmarkSingleSpanRetention|BenchmarkOTelApiWithCustomTags|BenchmarkInjectW3C|BenchmarkExtractW3C|BenchmarkPartialFlushing|BenchmarkSampleWAFSubContext"
     CPUS_PER_BENCHMARK: 1
     REPETITIONS: 10
     GROUP_ID: "group-2"

--- a/.gitlab/benchmarks/micro/gitlab-ci.yml
+++ b/.gitlab/benchmarks/micro/gitlab-ci.yml
@@ -79,7 +79,7 @@ microbenchmarks-1:
 microbenchmarks-2:
   extends: .microbenchmarks
   variables:
-    BENCHMARKS: "BenchmarkStartRequestSpan|BenchmarkStartRequestSpanQueryObfuscation|BenchmarkHttpServeTrace|BenchmarkHttpServeTraceQueryObfuscation|BenchmarkTracerAddSpans|BenchmarkStartSpan|BenchmarkSingleSpanRetention|BenchmarkOTelApiWithCustomTags|BenchmarkInjectW3C|BenchmarkExtractW3C|BenchmarkPartialFlushing|BenchmarkSampleWAFSubContext"
+    BENCHMARKS: "BenchmarkStartRequestSpan|BenchmarkStartRequestSpanQueryObfuscation|BenchmarkHttpServeTrace|BenchmarkHttpServeTraceQueryObfuscation|BenchmarkTracerAddSpans|BenchmarkStartSpan|BenchmarkSingleSpanRetention|BenchmarkOTelApiWithCustomTags|BenchmarkInjectW3C|BenchmarkExtractW3C|BenchmarkExtractDatadogHTTPHeaders|BenchmarkPartialFlushing|BenchmarkSampleWAFSubContext"
     CPUS_PER_BENCHMARK: 1
     REPETITIONS: 10
     GROUP_ID: "group-2"

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -515,6 +515,17 @@ func (c *SpanContext) setBaggageItem(key, val string) {
 	c.setBaggageItemLocked(key, val)
 }
 
+// setOTBaggageItem stores a baggage item extracted from a legacy OpenTracing
+// "ot-baggage-<key>" HTTP header. <key> is derived from a case-insensitive
+// header name, so it must be lowercased here to match how it was matched.
+// This is deliberately not folded into setBaggageItem itself, which is also
+// used by the public Span.SetBaggageItem API (arbitrary user-chosen keys) and
+// by the case-sensitive W3C "baggage" header extractor (opaque token keys) —
+// neither of those should have their keys silently normalized.
+func (c *SpanContext) setOTBaggageItem(key, val string) {
+	c.setBaggageItem(strings.ToLower(key), val)
+}
+
 // baggageItemLocked retrieves a baggage item.
 // c.mu must be held for reading.
 // +checklocksread:c.mu

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -390,7 +390,7 @@ func (p *chainedPropagator) extractIncomingSpanContext(carrier any) (*SpanContex
 	var ctx *SpanContext
 	var producer Propagator // propagator that produced ctx
 	var links []SpanLink
-	pendingBaggage := make(map[string]string) // used to store baggage items temporarily
+	var pendingBaggage map[string]string // used to store baggage items temporarily, allocated lazily
 
 	for _, v := range p.extractors {
 		// If incomingCtx is nil, no extraction has run yet
@@ -400,6 +400,9 @@ func (p *chainedPropagator) extractIncomingSpanContext(carrier any) (*SpanContex
 		// If this is the baggage propagator, just stash its items into pendingBaggage
 		if _, isBaggage := v.(*propagatorBaggage); isBaggage {
 			if extractedCtx != nil && len(extractedCtx.baggage) > 0 { // +checklocksignore - Initialization time, freshly extracted ctx not yet shared.
+				if pendingBaggage == nil {
+					pendingBaggage = make(map[string]string, len(extractedCtx.baggage)) // +checklocksignore - Initialization time, freshly extracted ctx not yet shared.
+				}
 				maps.Copy(pendingBaggage, extractedCtx.baggage) // +checklocksignore - Initialization time, freshly extracted ctx not yet shared.
 			}
 			continue
@@ -480,6 +483,19 @@ func (p *chainedPropagator) extractIncomingSpanContext(carrier any) (*SpanContex
 	}
 	log.Debug("Extracted span context: %s", ctx.safeDebugString())
 	return ctx, producer, nil
+}
+
+// cutPrefixFold reports whether s starts with prefix, ignoring case, and if so
+// returns s with the prefix removed. Unlike strings.ToLower+CutPrefix, it never
+// allocates a lowercased copy of s.
+func cutPrefixFold(s, prefix string) (string, bool) {
+	if len(s) < len(prefix) {
+		return "", false
+	}
+	if !strings.EqualFold(s[:len(prefix)], prefix) {
+		return "", false
+	}
+	return s[len(prefix):], true
 }
 
 func getPropagatorName(p Propagator) string {
@@ -629,33 +645,32 @@ func (p *propagator) extractTextMap(reader TextMapReader) (*SpanContext, error) 
 	var ctx SpanContext
 	err := reader.ForeachKey(func(k, v string) error {
 		var err error
-		key := strings.ToLower(k)
-		switch key {
-		case p.cfg.TraceHeader:
+		switch {
+		case strings.EqualFold(k, p.cfg.TraceHeader):
 			var lowerTid uint64
 			lowerTid, err = parseUint64(v)
 			if err != nil {
 				return ErrSpanContextCorrupted
 			}
 			ctx.traceID.SetLower(lowerTid)
-		case p.cfg.ParentHeader:
+		case strings.EqualFold(k, p.cfg.ParentHeader):
 			ctx.spanID, err = parseUint64(v)
 			if err != nil {
 				return ErrSpanContextCorrupted
 			}
-		case p.cfg.PriorityHeader:
+		case strings.EqualFold(k, p.cfg.PriorityHeader):
 			priority, err := strconv.Atoi(v)
 			if err != nil {
 				return ErrSpanContextCorrupted
 			}
 			ctx.setSamplingPriority(priority, samplernames.Unknown)
-		case originHeader:
+		case strings.EqualFold(k, originHeader):
 			ctx.origin = v // +checklocksignore - Initialization time, freshly extracted ctx not yet shared.
-		case traceTagsHeader:
+		case strings.EqualFold(k, traceTagsHeader):
 			unmarshalPropagatingTags(&ctx, v, p.cfg.MaxTagsHeaderLen)
 		default:
-			if after, ok := strings.CutPrefix(key, p.cfg.BaggagePrefix); ok {
-				ctx.setBaggageItem(after, v)
+			if after, ok := cutPrefixFold(k, p.cfg.BaggagePrefix); ok {
+				ctx.setBaggageItem(strings.ToLower(after), v)
 			}
 		}
 		return nil
@@ -819,18 +834,17 @@ func (*propagatorB3) extractTextMap(reader TextMapReader) (*SpanContext, error) 
 	var ctx SpanContext
 	err := reader.ForeachKey(func(k, v string) error {
 		var err error
-		key := strings.ToLower(k)
-		switch key {
-		case b3TraceIDHeader:
+		switch {
+		case strings.EqualFold(k, b3TraceIDHeader):
 			if err := extractTraceID128(&ctx, v); err != nil {
 				return nil
 			}
-		case b3SpanIDHeader:
+		case strings.EqualFold(k, b3SpanIDHeader):
 			ctx.spanID, err = strconv.ParseUint(v, 16, 64)
 			if err != nil {
 				return ErrSpanContextCorrupted
 			}
-		case b3SampledHeader:
+		case strings.EqualFold(k, b3SampledHeader):
 			priority, err := strconv.Atoi(v)
 			if err != nil {
 				return ErrSpanContextCorrupted
@@ -905,9 +919,8 @@ func (*propagatorB3SingleHeader) extractTextMap(reader TextMapReader) (*SpanCont
 	var ctx SpanContext
 	err := reader.ForeachKey(func(k, v string) error {
 		var err error
-		key := strings.ToLower(k)
-		switch key {
-		case b3SingleHeader:
+		switch {
+		case strings.EqualFold(k, b3SingleHeader):
 			b3Parts := strings.Split(v, "-")
 			if len(b3Parts) >= 2 {
 				if err = extractTraceID128(&ctx, b3Parts[0]); err != nil {
@@ -1270,18 +1283,17 @@ func (*propagatorW3c) extractTextMap(reader TextMapReader) (*SpanContext, error)
 	ctx.isRemote = true
 	// to avoid parsing tracestate header(s) if traceparent is invalid
 	if err := reader.ForeachKey(func(k, v string) error {
-		key := strings.ToLower(k)
-		switch key {
-		case traceparentHeader:
+		switch {
+		case strings.EqualFold(k, traceparentHeader):
 			if parentHeader != "" {
 				return ErrSpanContextCorrupted
 			}
 			parentHeader = v
-		case tracestateHeader:
+		case strings.EqualFold(k, tracestateHeader):
 			stateHeader = v
 		default:
-			if after, ok := strings.CutPrefix(key, DefaultBaggageHeaderPrefix); ok {
-				ctx.setBaggageItem(after, v)
+			if after, ok := cutPrefixFold(k, DefaultBaggageHeaderPrefix); ok {
+				ctx.setBaggageItem(strings.ToLower(after), v)
 			}
 		}
 		return nil
@@ -1603,7 +1615,7 @@ func (*propagatorBaggage) extractTextMap(reader TextMapReader) (*SpanContext, er
 	var baggageHeader string
 	var ctx SpanContext
 	err := reader.ForeachKey(func(k, v string) error {
-		if strings.ToLower(k) == "baggage" {
+		if strings.EqualFold(k, "baggage") {
 			// Expect only one baggage header, return early
 			baggageHeader = v
 			return nil

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -670,7 +670,7 @@ func (p *propagator) extractTextMap(reader TextMapReader) (*SpanContext, error) 
 			unmarshalPropagatingTags(&ctx, v, p.cfg.MaxTagsHeaderLen)
 		default:
 			if after, ok := cutPrefixFold(k, p.cfg.BaggagePrefix); ok {
-				ctx.setBaggageItem(strings.ToLower(after), v)
+				ctx.setOTBaggageItem(after, v)
 			}
 		}
 		return nil
@@ -1293,7 +1293,7 @@ func (*propagatorW3c) extractTextMap(reader TextMapReader) (*SpanContext, error)
 			stateHeader = v
 		default:
 			if after, ok := cutPrefixFold(k, DefaultBaggageHeaderPrefix); ok {
-				ctx.setBaggageItem(strings.ToLower(after), v)
+				ctx.setOTBaggageItem(after, v)
 			}
 		}
 		return nil

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -490,7 +490,7 @@ func (p *chainedPropagator) extractIncomingSpanContext(carrier any) (*SpanContex
 // allocates a lowercased copy of s.
 func cutPrefixFold(s, prefix string) (string, bool) {
 	if len(s) < len(prefix) {
-		return "", false
+		return "", false // required: keeps the s[:len(prefix)] slice below from panicking
 	}
 	if !strings.EqualFold(s[:len(prefix)], prefix) {
 		return "", false

--- a/ddtrace/tracer/textmap_caseinsensitive_test.go
+++ b/ddtrace/tracer/textmap_caseinsensitive_test.go
@@ -1,0 +1,139 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package tracer
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExtractHeaderNameCaseInsensitivity pins the case-insensitive header-name
+// dispatch: extractors match header names with strings.EqualFold, so an
+// incoming carrier may present header names in any case (canonical MIME case
+// from net/http, all-caps, mixed) and still be recognised. It also pins that
+// the OpenTracing "ot-baggage-<key>" suffix is lowercased regardless of the
+// incoming case, and that a user-configured mixed-case header name matches.
+func TestExtractHeaderNameCaseInsensitivity(t *testing.T) {
+	t.Run("datadog default headers, non-canonical case", func(t *testing.T) {
+		t.Setenv(headerPropagationStyleExtract, "datadog")
+		p := NewPropagator(nil)
+		// TextMapCarrier does not canonicalize keys, so the exact case below is
+		// what reaches the extractor.
+		carrier := TextMapCarrier{
+			"X-Datadog-Trace-Id":          "1234",
+			"X-DATADOG-PARENT-ID":         "5678",
+			"x-DaTaDoG-SaMpLiNg-PrIoRiTy": "1",
+			"OT-BAGGAGE-UserID":           "abc",
+		}
+		ctx, err := p.Extract(carrier)
+		require.NoError(t, err)
+		require.NotNil(t, ctx)
+		assert.Equal(t, uint64(1234), ctx.TraceIDLower())
+		assert.Equal(t, uint64(5678), ctx.SpanID())
+		// OT-baggage suffix must be lowercased regardless of incoming case.
+		assert.Equal(t, "abc", ctx.baggageItem("userid"))
+		assert.Equal(t, "", ctx.baggageItem("UserID"))
+	})
+
+	t.Run("b3 headers, non-canonical case", func(t *testing.T) {
+		t.Setenv(headerPropagationStyleExtract, "b3multi")
+		p := NewPropagator(nil)
+		carrier := TextMapCarrier{
+			"X-B3-TraceId": "0000000000000000000000000000007b",
+			"X-B3-SpanId":  "00000000000001c8",
+			"X-B3-Sampled": "1",
+		}
+		ctx, err := p.Extract(carrier)
+		require.NoError(t, err)
+		require.NotNil(t, ctx)
+		assert.Equal(t, uint64(0x7b), ctx.TraceIDLower())
+		assert.Equal(t, uint64(0x1c8), ctx.SpanID())
+	})
+
+	t.Run("w3c traceparent, non-canonical case", func(t *testing.T) {
+		t.Setenv(headerPropagationStyleExtract, "tracecontext")
+		p := NewPropagator(nil)
+		carrier := TextMapCarrier{
+			"TraceParent": "00-00000000000000000000000000000064-00000000000000c8-01",
+		}
+		ctx, err := p.Extract(carrier)
+		require.NoError(t, err)
+		require.NotNil(t, ctx)
+		assert.Equal(t, uint64(0x64), ctx.TraceIDLower())
+		assert.Equal(t, uint64(0xc8), ctx.SpanID())
+	})
+
+	t.Run("custom mixed-case configured header", func(t *testing.T) {
+		t.Setenv(headerPropagationStyleExtract, "datadog")
+		p := NewPropagator(&PropagatorConfig{
+			TraceHeader:  "My-Trace-Id",
+			ParentHeader: "My-Parent-Id",
+		})
+		carrier := TextMapCarrier{
+			"my-trace-id":  "42",
+			"MY-PARENT-ID": "7",
+		}
+		ctx, err := p.Extract(carrier)
+		require.NoError(t, err)
+		require.NotNil(t, ctx)
+		assert.Equal(t, uint64(42), ctx.TraceIDLower())
+		assert.Equal(t, uint64(7), ctx.SpanID())
+	})
+}
+
+// canonicalHTTPHeaders builds an http.Header whose keys are stored in canonical
+// MIME case (as net/http delivers server-side), exercising the case-insensitive
+// dispatch path that the pre-lowercased TextMapCarrier benchmarks do not.
+func canonicalDatadogHeaders() HTTPHeadersCarrier {
+	h := http.Header{}
+	h.Set(DefaultTraceIDHeader, "1123123132131312313123123")
+	h.Set(DefaultParentIDHeader, "1212321131231312312312312")
+	h.Set(DefaultPriorityHeader, "-1")
+	h.Set(DefaultBaggageHeaderPrefix+"userId", "abc123")
+	h.Set("User-Agent", "Go-http-client/1.1")
+	h.Set("Accept-Encoding", "gzip")
+	h.Set("X-Forwarded-For", "10.0.0.1")
+	return HTTPHeadersCarrier(h)
+}
+
+func canonicalW3CHeaders() HTTPHeadersCarrier {
+	h := http.Header{}
+	h.Set(traceparentHeader, "00-00000000000000001111111111111111-2222222222222222-01")
+	h.Set(tracestateHeader, "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64~~,othervendor=t61rcWkgMzE")
+	h.Set("User-Agent", "Go-http-client/1.1")
+	h.Set("Accept-Encoding", "gzip")
+	return HTTPHeadersCarrier(h)
+}
+
+// BenchmarkExtractDatadogHTTPHeaders extracts from a canonical-case http.Header
+// carrier (unlike BenchmarkExtractDatadog, which uses a pre-lowercased
+// TextMapCarrier and so never exercises header-name case folding).
+func BenchmarkExtractDatadogHTTPHeaders(b *testing.B) {
+	b.Setenv(headerPropagationStyleExtract, "datadog")
+	propagator := NewPropagator(nil)
+	carrier := canonicalDatadogHeaders()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		propagator.Extract(carrier)
+	}
+}
+
+// BenchmarkExtractW3CHTTPHeaders is the W3C counterpart to
+// BenchmarkExtractDatadogHTTPHeaders.
+func BenchmarkExtractW3CHTTPHeaders(b *testing.B) {
+	b.Setenv(headerPropagationStyleExtract, "tracecontext")
+	propagator := NewPropagator(nil)
+	carrier := canonicalW3CHeaders()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		propagator.Extract(carrier)
+	}
+}

--- a/instrumentation/httptrace/httptrace.go
+++ b/instrumentation/httptrace/httptrace.go
@@ -41,6 +41,13 @@ type inferredSpanCreatedCtxKey struct{}
 
 type FinishSpanFunc = func(status int, errorFn func(int) bool, opts ...tracer.FinishOption)
 
+// requestSpanTagsSizeHint pre-sizes the tag map built for every request span.
+// SpanType, HTTPMethod, HTTPURL, HTTPUserAgent, and "_dd.measured" are always
+// set (5), "http.host" is set when present (6), and AppSec header tags, IP
+// tags, and baggage tags add a variable amount on top — this only needs to
+// cover the common case to avoid the first few map growths, not be exact.
+const requestSpanTagsSizeHint = 8
+
 // StartRequestSpan starts a server-side HTTP request span with the standard list of HTTP request span tags
 // (http.method, http.url, http.useragent). Any further span start option can be added with opts.
 func StartRequestSpan(r *http.Request, opts ...tracer.StartSpanOption) (*tracer.Span, context.Context, FinishSpanFunc) {
@@ -87,7 +94,7 @@ func StartRequestSpan(r *http.Request, opts ...tracer.StartSpanOption) (*tracer.
 	nopts = append(nopts,
 		func(ssCfg *tracer.StartSpanConfig) {
 			if ssCfg.Tags == nil {
-				ssCfg.Tags = make(map[string]any, 8)
+				ssCfg.Tags = make(map[string]any, requestSpanTagsSizeHint)
 			}
 			ssCfg.Tags[ext.SpanType] = ext.SpanTypeWeb
 			ssCfg.Tags[ext.HTTPMethod] = r.Method

--- a/instrumentation/httptrace/httptrace.go
+++ b/instrumentation/httptrace/httptrace.go
@@ -87,7 +87,7 @@ func StartRequestSpan(r *http.Request, opts ...tracer.StartSpanOption) (*tracer.
 	nopts = append(nopts,
 		func(ssCfg *tracer.StartSpanConfig) {
 			if ssCfg.Tags == nil {
-				ssCfg.Tags = make(map[string]any)
+				ssCfg.Tags = make(map[string]any, 8)
 			}
 			ssCfg.Tags[ext.SpanType] = ext.SpanTypeWeb
 			ssCfg.Tags[ext.HTTPMethod] = r.Method

--- a/instrumentation/httptrace/httptrace.go
+++ b/instrumentation/httptrace/httptrace.go
@@ -46,7 +46,12 @@ type FinishSpanFunc = func(status int, errorFn func(int) bool, opts ...tracer.Fi
 // set (5), "http.host" is set when present (6), and AppSec header tags, IP
 // tags, and baggage tags add a variable amount on top — this only needs to
 // cover the common case to avoid the first few map growths, not be exact.
-const requestSpanTagsSizeHint = 8
+//
+// The value must be at least 9: the runtime rounds any map hint of 8 or less
+// down to a single 8-slot group, so make(map, 8) is identical to make(map) and
+// reserves nothing. 9 is the smallest hint that reserves a second group, so
+// spans that end up with 9+ tags (IP/AppSec/baggage) skip a growth and rehash.
+const requestSpanTagsSizeHint = 9
 
 // StartRequestSpan starts a server-side HTTP request span with the standard list of HTTP request span tags
 // (http.method, http.url, http.useragent). Any further span start option can be added with opts.


### PR DESCRIPTION
### What does this PR do?

Two low-risk, high-confidence allocation reductions on the request path:

- **`ddtrace/tracer/textmap.go`**: propagation extractors ran `strings.ToLower(k)` on every incoming header before comparing it against known header names, allocating a throwaway lowercased string whenever the carrier used canonical case (e.g. Go's `http.Header`, as used by `HTTPHeadersCarrier`). Switches `propagator`, `propagatorB3`, `propagatorB3SingleHeader`, `propagatorW3c`, and `propagatorBaggage` extraction to `strings.EqualFold`-based dispatch instead, and adds a `cutPrefixFold` helper for the OT baggage-prefix checks so only the matched prefix is case-folded, not the whole header. Also makes the `pendingBaggage` map in `extractIncomingSpanContext` lazily allocated instead of eagerly created on every extraction call.
- **`instrumentation/httptrace/httptrace.go`**: pre-sizes the per-request span tag map built in `StartRequestSpan` (it always ends up with several entries, so growing it from empty was wasted work).

### Motivation

Profiling of a small, high-throughput HTTP+Redis+DB edge service showed dd-trace-go contributing a disproportionate share of allocation rate relative to CPU. These two sites were identified as high-confidence, low-risk wins on the extraction/span-start hot path. Verified with a throwaway benchmark using realistic canonical-case HTTP headers (not exercised by the existing checked-in benchmarks, which use pre-lowercased map keys and therefore hit `strings.ToLower`'s no-alloc fast path): Datadog extraction dropped from 5→4 allocs/op, W3C from 24→22 allocs/op.

Caught during implementation: naively swapping `ToLower`→`EqualFold` broke `TestPropagationDefaults`/`TestPropagationDefaultIncludesBaggage`, because the old blanket lowercasing also normalized the *suffix* of OT baggage-prefixed keys (`ot-baggage-X` → baggage key `x`), which callers rely on for map-key matching. Fixed by explicitly lowercasing just that suffix after the case-insensitive prefix match, preserving exact prior behavior.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [x] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.