### PR TITLE
fix(ddtrace/tracer): do not retry client-side stats flush

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -803,7 +803,8 @@ func WithLambdaMode(enabled bool) StartOption {
 
 // WithSendRetries enables re-sending payloads that are not successfully
 // submitted to the agent.  This will cause the tracer to retry the send at
-// most `retries` times.
+// most `retries` times. This applies to the trace-send path only; client-side
+// stats (/v0.6/stats) are never retried.
 func WithSendRetries(retries int) StartOption {
 	return func(c *config) {
 		c.internalConfig.SetSendRetries(retries, telemetry.OriginCode)
@@ -811,6 +812,7 @@ func WithSendRetries(retries int) StartOption {
 }
 
 // WithRetryInterval sets the interval, in seconds, for retrying submitting payloads to the agent.
+// This applies to the trace-send path only; client-side stats (/v0.6/stats) are never retried.
 func WithRetryInterval(interval int) StartOption {
 	return func(c *config) {
 		c.internalConfig.SetRetryInterval(time.Duration(interval)*time.Second, telemetry.OriginCode)

--- a/ddtrace/tracer/stats.go
+++ b/ddtrace/tracer/stats.go
@@ -267,24 +267,14 @@ func (c *concentrator) flushAndSend(timenow time.Time, includeCurrent bool) {
 	flushedBuckets := 0
 	// Given we use a constant PayloadAggregationKey there should only ever be 1 of these, but to be forward
 	// compatible in case this ever changes we can just iterate through all of them.
-	sendRetries := c.cfg.internalConfig.SendRetries()
-	retryInterval := c.cfg.internalConfig.RetryInterval()
 	for _, csp := range csps {
 		csp.RuntimeID = globalconfig.RuntimeID()
 		csp.Service = c.cfg.internalConfig.ServiceName()
 		csp.ProcessTags = processtags.GlobalTags().String()
 		flushedBuckets += len(csp.Stats)
-		var err error
-		for attempt := 0; attempt <= sendRetries; attempt++ {
-			err = c.cfg.ddTransport.sendStats(csp, obfVersion)
-			if err == nil {
-				break
-			}
-			if attempt < sendRetries {
-				time.Sleep(retryInterval)
-			}
-		}
-		if err != nil {
+		// Per the Client Stats Spec, a failed /v0.6/stats flush must not be
+		// retried, regardless of the trace-send retry configuration.
+		if err := c.cfg.ddTransport.sendStats(csp, obfVersion); err != nil {
 			c.statsd().Incr("datadog.tracer.stats.flush_errors", nil, 1)
 			log.Error("Error sending stats payload: %s", err.Error())
 		}

--- a/ddtrace/tracer/stats_test.go
+++ b/ddtrace/tracer/stats_test.go
@@ -482,7 +482,7 @@ func TestStatsServiceSourceNotSetWhenEmpty(t *testing.T) {
 }
 
 // failingStatsTransport is a transport whose sendStats fails a configurable
-// number of times before succeeding, used to test retry behaviour.
+// number of times before succeeding, used to test the stats send path.
 type failingStatsTransport struct {
 	dummyTransport
 	failCount    int
@@ -500,7 +500,9 @@ func (t *failingStatsTransport) sendStats(_ *pb.ClientStatsPayload, _ int) error
 	return nil
 }
 
-func TestStatsFlushRetries(t *testing.T) {
+// TestStatsFlushNoRetries verifies that a failed /v0.6/stats flush is never
+// retried, regardless of the trace-send retry configuration (CSS §9).
+func TestStatsFlushNoRetries(t *testing.T) {
 	testcases := []struct {
 		configRetries int
 		retryInterval time.Duration
@@ -511,14 +513,8 @@ func TestStatsFlushRetries(t *testing.T) {
 		{configRetries: 0, retryInterval: time.Millisecond, failCount: 0, statsSent: true, expAttempts: 1},
 		{configRetries: 0, retryInterval: time.Millisecond, failCount: 1, statsSent: false, expAttempts: 1},
 
-		{configRetries: 1, retryInterval: time.Millisecond, failCount: 0, statsSent: true, expAttempts: 1},
-		{configRetries: 1, retryInterval: time.Millisecond, failCount: 1, statsSent: true, expAttempts: 2},
-		{configRetries: 1, retryInterval: time.Millisecond, failCount: 2, statsSent: false, expAttempts: 2},
-
 		{configRetries: 2, retryInterval: time.Millisecond, failCount: 0, statsSent: true, expAttempts: 1},
-		{configRetries: 2, retryInterval: time.Millisecond, failCount: 1, statsSent: true, expAttempts: 2},
-		{configRetries: 2, retryInterval: time.Millisecond, failCount: 2, statsSent: true, expAttempts: 3},
-		{configRetries: 2, retryInterval: time.Millisecond, failCount: 3, statsSent: false, expAttempts: 3},
+		{configRetries: 2, retryInterval: time.Millisecond, failCount: 1, statsSent: false, expAttempts: 1},
 	}
 
 	bucketSize := int64(500_000)


### PR DESCRIPTION
### What does this PR do?

Stops the client-side stats flush from retrying. `flushAndSend` reused the trace-send `SendRetries`/`RetryInterval` config, so a non-zero `DD_TRACE_SEND_RETRIES` (or `WithSendRetries`) would also retry `/v0.6/stats` POSTs. Each stats payload is now sent exactly once, independent of the trace-send retry config, which is unchanged.

### Motivation

Per the Client Stats Spec (CSS v1.2.0 §9), a failed `/v0.6/stats` flush must not be retried. Fixes APMSP-3663.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
