### PR TITLE
fix(ddtrace/tracer): make SpanAttributes layout assertion architecture-aware (#4984)

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -228,3 +228,18 @@ jobs:
         run: |-
           export PATH="${{ github.workspace }}/bin:${PATH}"
           ./scripts/checklocks.sh
+
+  cross-compile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: ${{ inputs.go-version || 'stable' }}
+          cache: false
+      - name: Cross-compile all first-class Go ports
+        run: ./scripts/cross_build.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,7 @@ Our CI pipeline includes several automated checks:
 - **Module Check**: Validates Go module consistency using `make fix-modules`
 - **Lint Check**: Runs comprehensive linting using `golangci-lint`
 - **Lock Analysis**: Runs `checklocks` to detect potential deadlocks and race conditions
+- **Cross-Compile Check**: Runs `scripts/cross_build.sh` to cross-compile the library for every [first class Go port](https://go.dev/wiki/PortingPolicy) (including 32-bit `linux/386`, `windows/386`, `linux/arm`), catching architecture-specific compile regressions. Run locally with `./scripts/cross_build.sh`. Packages that import `go-libddwaf` are skipped until it builds on 32-bit (see DataDog/go-libddwaf#227); they stay covered on 64-bit by the test matrix.
 
 #### Unit and Integration Tests
 

--- a/ddtrace/tracer/internal/span_attributes.go
+++ b/ddtrace/tracer/internal/span_attributes.go
@@ -40,7 +40,9 @@ var (
 // Zero value = all fields absent.
 // Set(key, "") is distinct from never-Set: the bit is set, the string is "".
 //
-// Layout: 1-byte setMask + 1-byte readOnly + 6B padding + [3]string (48B) = 56 bytes.
+// Layout: setMask + readOnly are packed ahead of the [numAttrs]string array,
+// with no trailing padding. The exact size is architecture-dependent (string
+// width differs between 32- and 64-bit); the assertion below derives it.
 //
 // When readOnly is true, the instance is owned by the tracer and must not be
 // mutated. Callers must Clone before writing (copy-on-write).
@@ -50,10 +52,15 @@ type SpanAttributes struct {
 	vals     [numAttrs]string
 }
 
-// Compile-time layout check: SpanAttributes must be exactly 56 bytes.
-// 1B setMask + 1B readOnly + 6B padding + [3]string (48B) = 56B.
-var _ = [1]byte{}[56-unsafe.Sizeof(SpanAttributes{})]
-var _ = [1]byte{}[unsafe.Sizeof(SpanAttributes{})-56]
+// Compile-time layout check: SpanAttributes must carry no trailing padding —
+// its size equals the offset of vals plus the size of the vals array. Derived
+// from the types themselves, so it holds on both 32- and 64-bit platforms
+// (string width, and therefore the total size, differs by architecture).
+const spanAttributesExpectedSize = unsafe.Offsetof(SpanAttributes{}.vals) +
+	unsafe.Sizeof([numAttrs]string{})
+
+var _ = [1]byte{}[spanAttributesExpectedSize-unsafe.Sizeof(SpanAttributes{})]
+var _ = [1]byte{}[unsafe.Sizeof(SpanAttributes{})-spanAttributesExpectedSize]
 
 // All read methods are nil-safe so callers holding a *SpanAttributes don't
 // need nil guards.

--- a/scripts/cross_build.sh
+++ b/scripts/cross_build.sh
@@ -20,10 +20,14 @@ platforms=(
   windows/386 windows/amd64
 )
 
-mapfile -t pkgs < <(
-  go list -f '{{.ImportPath}}|{{if .GoFiles}}Y{{end}}|{{join .Deps " "}}' ./... |
-    awk -F'|' '$2 == "Y" && $3 !~ /go-libddwaf/ { print $1 }'
-)
+# go list runs in $(...) so a discovery failure trips set -e (process
+# substitution would swallow it and leave pkgs empty).
+pkgs_raw=$(go list -f '{{.ImportPath}}|{{if .GoFiles}}Y{{end}}|{{join .Deps " "}}' ./...)
+mapfile -t pkgs < <(awk -F'|' '$2 == "Y" && $3 !~ /go-libddwaf/ { print $1 }' <<< "$pkgs_raw")
+[[ ${#pkgs[@]} -gt 0 ]] || {
+  echo "no packages discovered" >&2
+  exit 1
+}
 echo "Cross-compiling ${#pkgs[@]} package(s) across ${#platforms[@]} port(s)"
 
 rc=0

--- a/scripts/cross_build.sh
+++ b/scripts/cross_build.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Cross-compile dd-trace-go for every first-class Go port to catch
+# architecture-specific compile regressions (e.g. 32-bit size assertions,
+# issue #4984). Runs on a normal amd64 runner — portability is a compile-time
+# property, so no native 32-bit machine is needed.
+#
+# CGO is disabled: this is a pure-Go portability smoke test. cgo paths are
+# covered by the native multi-OS test matrix (multios-unit-tests.yml).
+#
+# Packages importing go-libddwaf are skipped: it does not yet build on 32-bit
+# ports (upstream fix: DataDog/go-libddwaf#227). They are still
+# built and tested on 64-bit by the native matrix. Test-only packages are
+# skipped (nothing to build, and they error when passed explicitly to go build).
+set -euo pipefail
+
+# First-class ports: https://go.dev/wiki/PortingPolicy
+platforms=(
+  linux/386 linux/amd64 linux/arm linux/arm64
+  darwin/amd64 darwin/arm64
+  windows/386 windows/amd64
+)
+
+mapfile -t pkgs < <(
+  go list -f '{{.ImportPath}}|{{if .GoFiles}}Y{{end}}|{{join .Deps " "}}' ./... |
+    awk -F'|' '$2 == "Y" && $3 !~ /go-libddwaf/ { print $1 }'
+)
+echo "Cross-compiling ${#pkgs[@]} package(s) across ${#platforms[@]} port(s)"
+
+rc=0
+for p in "${platforms[@]}"; do
+  if GOOS="${p%/*}" GOARCH="${p#*/}" CGO_ENABLED=0 go build "${pkgs[@]}"; then
+    echo "ok   $p"
+  else
+    echo "FAIL $p"
+    rc=1
+  fi
+done
+exit "$rc"


### PR DESCRIPTION
### What

Fix a 32-bit compile failure ([#4984](https://github.com/DataDog/dd-trace-go/issues/4984)) and add a cross-compile CI guard so it cannot regress.

`ddtrace/tracer/internal/span_attributes.go` had a compile-time layout guard that hardcoded the struct size as `56` bytes:

```go
var _ = [1]byte{}[56-unsafe.Sizeof(SpanAttributes{})]
var _ = [1]byte{}[unsafe.Sizeof(SpanAttributes{})-56]
```

`56` only holds where `string` is 16 bytes (64-bit). On 32-bit first-class ports (`386`, `arm`) `string` is 8 bytes, the struct is 28 bytes, and the assertion underflows at compile time:

```
span_attributes.go:55:19: invalid argument: index 28 out of bounds [0:1]
span_attributes.go:56:19: unsafe.Sizeof(SpanAttributes{}) - 56 (constant -28 of type uintptr) overflows uintptr
```

Every importer targeting a 32-bit port fails to build.

### How

- **Fix**: derive the expected size from the types (`unsafe.Offsetof(vals) + unsafe.Sizeof([numAttrs]string{})`). This asserts the real invariant — no trailing padding — and is correct on every architecture.
- **Guard**: `scripts/cross_build.sh` cross-compiles the library for every [first-class Go port](https://go.dev/wiki/PortingPolicy), wired into `static-checks.yml`. The existing matrix only ran native 64-bit runners, so no 32-bit port was ever built — which is how this shipped. Cross-compilation needs no native 32-bit machine; portability is a compile-time property.

Packages importing `go-libddwaf` are skipped: it does not yet compile on 32-bit (fix pending upstream, DataDog/go-libddwaf#227). They remain covered on 64-bit by the native test matrix. The exclusion is removed once the upstream fix lands.

### Test plan

- Repro before fix: `GOOS=windows GOARCH=386 CGO_ENABLED=0 go build ./ddtrace/tracer/internal/` fails; after fix it succeeds.
- `./scripts/cross_build.sh` — 100 packages build across all 8 first-class ports.
- `go test -race ./ddtrace/tracer/internal/` passes (64-bit assertion still holds at 56 bytes).
- `gofmt`, `shellcheck`, `actionlint` clean.

Note: runtime AppSec/WAF is unaffected — it is already gated off on unsupported architectures (`internal/appsec/appsec.go` checks `libddwaf.Usable()` and degrades gracefully). This change only restores the ability to *compile* for 32-bit ports.