### PR TITLE
perf(ddtrace/tracer): drop per-extract ToLower in parseTraceparent

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -1160,6 +1160,8 @@ func sanitizeW3C(s string, lut *[128]uint8) string {
 }
 
 const (
+	asciiUpperA = 65
+	asciiUpperF = 70
 	asciiLowerA = 97
 	asciiLowerF = 102
 	asciiZero   = 48
@@ -1183,6 +1185,26 @@ func isValidID(id string) bool {
 		}
 	}
 
+	return true
+}
+
+// isValidIDCaseInsensitive is like isValidID but also accepts uppercase hex
+// digits (equivalent to the regexp ^[0-9a-fA-F]+$). It is used by the W3C
+// traceparent path, which no longer lowercases the header before validation;
+// isValidID stays strict (lowercase-only) for the Datadog propagator's
+// _dd.p.tid check, preserving that path's behavior.
+func isValidIDCaseInsensitive(id string) bool {
+	if len(id) == 0 {
+		return false
+	}
+	for _, c := range id {
+		ascii := int(c)
+		if (ascii < asciiZero || ascii > asciiNine) &&
+			(ascii < asciiUpperA || ascii > asciiUpperF) &&
+			(ascii < asciiLowerA || ascii > asciiLowerF) {
+			return false
+		}
+	}
 	return true
 }
 
@@ -1310,7 +1332,7 @@ func (*propagatorW3c) extractTextMap(reader TextMapReader) (*SpanContext, error)
 // hex-encoded digits into a 64-bit number.
 func parseTraceparent(ctx *SpanContext, header string) error {
 	nonWordCutset := "_-\t \n"
-	header = strings.ToLower(strings.Trim(header, "\t -"))
+	header = strings.Trim(header, "\t -")
 	headerLen := len(header)
 	if headerLen == 0 {
 		return ErrSpanContextNotFound
@@ -1342,7 +1364,7 @@ func parseTraceparent(ctx *SpanContext, header string) error {
 		return ErrSpanContextCorrupted
 	}
 	// checking that the entire TraceID is a valid hex string
-	if !isValidID(fullTraceID) {
+	if !isValidIDCaseInsensitive(fullTraceID) {
 		return ErrSpanContextCorrupted
 	}
 	if ctx.trace != nil {
@@ -1357,7 +1379,7 @@ func parseTraceparent(ctx *SpanContext, header string) error {
 	if len(spanID) != 16 {
 		return ErrSpanContextCorrupted
 	}
-	if !isValidID(spanID) {
+	if !isValidIDCaseInsensitive(spanID) {
 		return ErrSpanContextCorrupted
 	}
 	if ctx.spanID, err = strconv.ParseUint(spanID, 16, 64); err != nil {

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -2736,6 +2736,23 @@ func BenchmarkExtractW3C(b *testing.B) {
 	}
 }
 
+// BenchmarkExtractW3CUppercase mirrors BenchmarkExtractW3C but with an
+// uppercase-hex traceparent, the only shape that exercises the allocation
+// path removed from parseTraceparent (see TestParseTraceparentCaseInsensitive).
+func BenchmarkExtractW3CUppercase(b *testing.B) {
+	b.Setenv(headerPropagationStyleExtract, "tracecontext")
+	propagator := NewPropagator(nil)
+	carrier := TextMapCarrier(map[string]string{
+		traceparentHeader: "00-4BF92F3577B34DA6A3CE929D0E0E4736-00F067AA0BA902B7-01",
+		tracestateHeader:  "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64~~,othervendor=t61rcWkgMzE",
+	})
+	b.ResetTimer()
+	log.SetLevel(log.LevelError)
+	for b.Loop() {
+		propagator.Extract(carrier)
+	}
+}
+
 func FuzzMarshalPropagatingTags(f *testing.F) {
 	f.Add("testA", "testB", "testC", "testD", "testG", "testF")
 	f.Fuzz(func(t *testing.T, key1 string, val1 string,
@@ -2820,6 +2837,29 @@ func FuzzComposeTracestate(f *testing.F) {
 				traceState)
 		}
 	})
+}
+
+func TestParseTraceparentCaseInsensitive(t *testing.T) {
+	lower := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	upper := "00-4BF92F3577B34DA6A3CE929D0E0E4736-00F067AA0BA902B7-01"
+
+	lowerCtx := new(SpanContext)
+	lowerCtx.trace = newTrace()
+	assert.NoError(t, parseTraceparent(lowerCtx, lower))
+
+	upperCtx := new(SpanContext)
+	upperCtx.trace = newTrace()
+	assert.NoError(t, parseTraceparent(upperCtx, upper))
+
+	assert.Equal(t, lowerCtx.traceID.value, upperCtx.traceID.value)
+	assert.Equal(t, lowerCtx.spanID, upperCtx.spanID)
+	lowerPriority, ok := lowerCtx.SamplingPriority()
+	assert.True(t, ok)
+	upperPriority, ok := upperCtx.SamplingPriority()
+	assert.True(t, ok)
+	assert.Equal(t, lowerPriority, upperPriority)
+	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", lowerCtx.TraceID())
+	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", upperCtx.TraceID())
 }
 
 func FuzzParseTraceparent(f *testing.F) {


### PR DESCRIPTION
### What does this PR do?

Drop the ToLower and add isValidIDCaseInsensitive for the W3C trace/span ID checks, preserving the existing lenient (case-insensitive) accept behavior while removing a redundant scan/allocation on every extract. isValidID itself is untouched, so the Datadog propagator's _dd.p.tid check keeps its current (stricter) behavior.

### Motivation

parseTraceparent lowercased the entire traceparent header on every W3C extract, even though every downstream consumer (ParseUint/ParseInt base-16, SetUpperFromHex, cacheHex) is already case-insensitive or canonicalizes to lowercase on write. The only case-sensitive check was isValidID, which rejected uppercase hex.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
