### PR TITLE
ci(smoke-tests): retry on go1.26.5 build-cache corruption

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -68,16 +68,32 @@ jobs:
             TEST_RESULTS=${{ env.TEST_RESULTS }}
           run: |-
             mkdir -p "$TEST_RESULTS"
-            # shellcheck disable=SC2086
-            go get -u -t $PACKAGES
-            go mod tidy
-            find . -iname go.mod -exec dirname {} \; | while read -r d; do pushd "$d" && go mod tidy && popd; done
-            if [ -n "${GO_LIBDDWAF_REF:-}" ]; then
-              go get -u -t "github.com/DataDog/go-libddwaf/v5@${GO_LIBDDWAF_REF}"
+            compile() {
+              # shellcheck disable=SC2086
+              go get -u -t $PACKAGES
               go mod tidy
+              find . -iname go.mod -exec dirname {} \; | while read -r d; do pushd "$d" && go mod tidy && popd; done
+              if [ -n "${GO_LIBDDWAF_REF:-}" ]; then
+                go get -u -t "github.com/DataDog/go-libddwaf/v5@${GO_LIBDDWAF_REF}"
+                go mod tidy
+              fi
+              # shellcheck disable=SC2086
+              go build $PACKAGES
+            }
+            log="$(mktemp)"
+            if ! compile 2>&1 | tee "$log"; then
+              # The restored GOCACHE/GOMODCACHE (actions/setup-go cache: true) can get
+              # transiently corrupted in transit to a given runner, surfacing as compiler
+              # ICEs or archive/zip checksum errors unrelated to any real code change.
+              # Clear both caches and retry once before failing the job for real.
+              if grep -qE 'internal compiler error|zip: checksum error|not the start of an archive file' "$log"; then
+                echo "::warning::Detected a Go build-cache corruption signature; clearing GOCACHE/GOMODCACHE and retrying once"
+                go clean -cache -modcache
+                compile
+              else
+                exit 1
+              fi
             fi
-            # shellcheck disable=SC2086
-            go build $PACKAGES
 
       - name: Compute Matrix
         id: matrix
@@ -134,7 +150,23 @@ jobs:
             TEST_RESULTS=${{ env.TEST_RESULTS }}
           run: |-
             export PATH="${GITHUB_WORKSPACE}/bin:${PATH}"
-            ./scripts/ci_test_contrib.sh smoke ${{ toJson(matrix.chunk) }}
+            run_smoke() {
+              ./scripts/ci_test_contrib.sh smoke ${{ toJson(matrix.chunk) }}
+            }
+            log="$(mktemp)"
+            if ! run_smoke 2>&1 | tee "$log"; then
+              # See "Compile dd-trace-go with updated dependencies (sandboxed)" above:
+              # transient GOCACHE/GOMODCACHE corruption in the restored cache can
+              # surface as a compiler ICE or archive/zip checksum error. Retry once
+              # after a full cache clear before failing the job for real.
+              if grep -qE 'internal compiler error|zip: checksum error|not the start of an archive file' "$log"; then
+                echo "::warning::Detected a Go build-cache corruption signature; clearing GOCACHE/GOMODCACHE and retrying once"
+                go clean -cache -modcache
+                run_smoke
+              else
+                exit 1
+              fi
+            fi
       - name: Stage sandbox artifacts outside workspace
         # Move the test results and coverage files to RUNNER_TEMP so the
         # next checkout (which wipes the workspace) does not delete them.

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -69,13 +69,17 @@ jobs:
           run: |-
             mkdir -p "$TEST_RESULTS"
             compile() {
+              # `!` and pipelines suspend -e for the commands they wrap, including
+              # inside this function's body (see `if ! compile | tee`, below) — a
+              # failed step here would otherwise go unnoticed as long as the final
+              # `go build` happens to still succeed. Propagate each failure explicitly.
               # shellcheck disable=SC2086
-              go get -u -t $PACKAGES
-              go mod tidy
-              find . -iname go.mod -exec dirname {} \; | while read -r d; do pushd "$d" && go mod tidy && popd; done
+              go get -u -t $PACKAGES || return
+              go mod tidy || return
+              find . -iname go.mod -exec dirname {} \; | while read -r d; do pushd "$d" && go mod tidy && popd || exit 1; done || return
               if [ -n "${GO_LIBDDWAF_REF:-}" ]; then
-                go get -u -t "github.com/DataDog/go-libddwaf/v5@${GO_LIBDDWAF_REF}"
-                go mod tidy
+                go get -u -t "github.com/DataDog/go-libddwaf/v5@${GO_LIBDDWAF_REF}" || return
+                go mod tidy || return
               fi
               # shellcheck disable=SC2086
               go build $PACKAGES


### PR DESCRIPTION
## Summary

- The nightly/scheduled `go get -u smoke test` job (`setup-env` and `go-get-u`) failed with a Go compiler ICE (`internal compiler error: panic: assertion failed`/nil-deref) plus cascading `zip: checksum error` / `not the start of an archive file` errors: [run 29060291135](https://github.com/DataDog/dd-trace-go/actions/runs/29060291135/job/86261781421).
- These two jobs pin `go-version: stable`, which currently resolves to go1.26.5. The ICE signature matches a known, unresolved upstream regression ([golang/go#77168](https://github.com/golang/go/issues/77168) "cmd/compile: SEGV compiling crypto/internal/fips140/nistec test"), where a Go maintainer suspected "another file corruption issue" rather than a deterministic compiler bug.
- I confirmed it's transient and runner-local, not a poisoned shared cache: the identical `actions/setup-go` cache key (`setup-go-Linux-x64-ubuntu24-go-1.26.5-8865de1c...`) was restored successfully in a push-triggered run ~3.5 hours earlier and failed with this exact signature in the scheduled run, using byte-identical cached content (cache keys are immutable in GitHub Actions, so the stored blob can't have changed between the two reads).
- Rather than disable caching outright or drop to Go 1.25 (both viable, but this keeps the job testing against the intended toolchain), this PR adds a narrow self-heal: if the sandboxed build/test step fails matching the known corruption signature, clear `GOCACHE`/`GOMODCACHE` and retry once before failing the job for real. A genuine build break (no matching signature) still fails immediately with no retry.

## Test plan

- [x] `actionlint .github/workflows/smoke-tests.yml` — no errors
- [x] `make lint/action` — passes
- [ ] Confirm the retry path actually triggers and recovers on the next scheduled run (can't force-trigger the exact corruption locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)