### PR TITLE
feat(opentelemetry): add DatadogPropagator OTel TextMapPropagator

### DIFF
--- a/ddtrace/opentelemetry/propagator.go
+++ b/ddtrace/opentelemetry/propagator.go
@@ -1,0 +1,97 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+package opentelemetry
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/propagation"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+)
+
+// DatadogPropagator implements propagation.TextMapPropagator using the Datadog
+// trace propagation format. It delegates to the global Datadog tracer for
+// extraction and injection, so it respects all DD_TRACE_PROPAGATION_* env vars,
+// including DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT=restart.
+//
+// Other Datadog tracer integrations (Java, Ruby, .NET) automatically register
+// a Datadog-aware propagator at startup. In Go, include DatadogPropagator
+// explicitly in your composite propagator alongside TraceContext and Baggage
+// to get the same behavior:
+//
+//	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+//	    opentelemetry.DatadogPropagator{},
+//	    propagation.TraceContext{},
+//	    propagation.Baggage{},
+//	))
+type DatadogPropagator struct{}
+
+var _ propagation.TextMapPropagator = DatadogPropagator{}
+
+// Fields returns the Datadog-specific HTTP header keys that Inject writes.
+func (DatadogPropagator) Fields() []string {
+	return []string{
+		tracer.DefaultTraceIDHeader,
+		tracer.DefaultParentIDHeader,
+		tracer.DefaultPriorityHeader,
+		"x-datadog-origin",
+		"x-datadog-tags",
+	}
+}
+
+// Extract reads Datadog trace headers from carrier and returns a context
+// augmented with DD tracer start options. This ensures that env var config
+// like DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT=restart is applied when the next
+// span is started via the OTel bridge (ddotel.NewTracerProvider).
+//
+// The span links produced by the restart behavior are stored in the context via
+// ContextWithStartOptions and are picked up by the bridge when the span is
+// created. Both ChildOf and WithSpanLinks must be passed because ChildOf alone
+// does not transfer span links from a baggageOnly SpanContext.
+func (DatadogPropagator) Extract(ctx context.Context, carrier propagation.TextMapCarrier) context.Context {
+	ddSpanCtx, err := tracer.Extract(otelCarrierAdapter{carrier})
+	if err != nil || ddSpanCtx == nil {
+		return ctx
+	}
+	opts := []tracer.StartSpanOption{tracer.ChildOf(ddSpanCtx)}
+	if links := ddSpanCtx.SpanLinks(); len(links) > 0 {
+		opts = append(opts, tracer.WithSpanLinks(links))
+	}
+	return ContextWithStartOptions(ctx, opts...)
+}
+
+// Inject writes the active Datadog span context from ctx into carrier using
+// the Datadog propagation format.
+func (DatadogPropagator) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
+	span, ok := tracer.SpanFromContext(ctx)
+	if !ok {
+		return
+	}
+	// Errors from Inject are silently ignored to match the OTel propagator contract.
+	tracer.Inject(span.Context(), otelCarrierAdapter{carrier}) //nolint:errcheck
+}
+
+// otelCarrierAdapter wraps an OTel TextMapCarrier so it can be passed to the
+// DD tracer's Extract and Inject, which expect TextMapReader / TextMapWriter.
+type otelCarrierAdapter struct {
+	carrier propagation.TextMapCarrier
+}
+
+// ForeachKey implements tracer.TextMapReader.
+func (a otelCarrierAdapter) ForeachKey(handler func(key, val string) error) error {
+	for _, k := range a.carrier.Keys() {
+		if err := handler(k, a.carrier.Get(k)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Set implements tracer.TextMapWriter.
+func (a otelCarrierAdapter) Set(key, val string) {
+	a.carrier.Set(key, val)
+}

--- a/ddtrace/opentelemetry/propagator.go
+++ b/ddtrace/opentelemetry/propagator.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	"github.com/DataDog/dd-trace-go/v2/internal/log"
 )
 
 // DatadogPropagator implements propagation.TextMapPropagator using the Datadog
@@ -71,8 +72,9 @@ func (DatadogPropagator) Inject(ctx context.Context, carrier propagation.TextMap
 	if !ok {
 		return
 	}
-	// Errors from Inject are silently ignored to match the OTel propagator contract.
-	tracer.Inject(span.Context(), otelCarrierAdapter{carrier}) //nolint:errcheck
+	if err := tracer.Inject(span.Context(), otelCarrierAdapter{carrier}); err != nil {
+		log.Error("DatadogPropagator: failed to inject span context: %v", err)
+	}
 }
 
 // otelCarrierAdapter wraps an OTel TextMapCarrier so it can be passed to the

--- a/ddtrace/opentelemetry/propagator_test.go
+++ b/ddtrace/opentelemetry/propagator_test.go
@@ -1,0 +1,165 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+package opentelemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+)
+
+// mapCarrier is a simple propagation.TextMapCarrier backed by a string map.
+type mapCarrier map[string]string
+
+func (m mapCarrier) Get(key string) string { return m[key] }
+func (m mapCarrier) Set(key, val string)   { m[key] = val }
+func (m mapCarrier) Keys() []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func TestDatadogPropagatorFields(t *testing.T) {
+	fields := DatadogPropagator{}.Fields()
+	assert.Contains(t, fields, tracer.DefaultTraceIDHeader)
+	assert.Contains(t, fields, tracer.DefaultParentIDHeader)
+	assert.Contains(t, fields, tracer.DefaultPriorityHeader)
+}
+
+func TestDatadogPropagatorInject(t *testing.T) {
+	tp, _, cleanup := mockTracerProvider(t)
+	defer cleanup()
+	otel.SetTracerProvider(tp)
+
+	tr := tp.Tracer("")
+	ctx, span := tr.Start(context.Background(), "root")
+	defer span.End()
+
+	carrier := make(mapCarrier)
+	DatadogPropagator{}.Inject(ctx, carrier)
+
+	assert.NotEmpty(t, carrier[tracer.DefaultTraceIDHeader], "trace-id header should be set")
+	assert.NotEmpty(t, carrier[tracer.DefaultParentIDHeader], "parent-id header should be set")
+}
+
+func TestDatadogPropagatorInjectNoSpan(t *testing.T) {
+	_, _, cleanup := mockTracerProvider(t)
+	defer cleanup()
+
+	carrier := make(mapCarrier)
+	DatadogPropagator{}.Inject(context.Background(), carrier)
+	assert.Empty(t, carrier, "no headers should be written when context has no span")
+}
+
+func TestDatadogPropagatorExtractEmpty(t *testing.T) {
+	_, _, cleanup := mockTracerProvider(t)
+	defer cleanup()
+
+	ctx := DatadogPropagator{}.Extract(context.Background(), make(mapCarrier))
+	_, ok := spanOptionsFromContext(ctx)
+	assert.False(t, ok, "no start options should be stored when headers are absent")
+}
+
+func TestDatadogPropagatorExtractContinue(t *testing.T) {
+	tp, _, cleanup := mockTracerProvider(t)
+	defer cleanup()
+	otel.SetTracerProvider(tp)
+
+	carrier := mapCarrier{
+		tracer.DefaultTraceIDHeader:  "1",
+		tracer.DefaultParentIDHeader: "1",
+		tracer.DefaultPriorityHeader: "1",
+	}
+
+	ctx := DatadogPropagator{}.Extract(context.Background(), carrier)
+
+	opts, ok := spanOptionsFromContext(ctx)
+	require.True(t, ok, "ContextWithStartOptions should have been called")
+	// Only ChildOf — no span links for continue behavior.
+	assert.Len(t, opts, 1)
+
+	// Starting a span with these opts should produce a child of trace ID 1.
+	tr := tp.Tracer("")
+	ctx, span := tr.Start(ctx, "child")
+	defer span.End()
+
+	ddSpan, ok := tracer.SpanFromContext(ctx)
+	require.True(t, ok)
+	assert.Equal(t, uint64(1), ddSpan.Context().TraceIDLower(), "should continue the incoming trace")
+}
+
+func TestDatadogPropagatorExtractRestart(t *testing.T) {
+	// Set env var before starting the tracer so the propagator config picks it up.
+	t.Setenv("DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT", "restart")
+
+	tp, _, cleanup := mockTracerProvider(t)
+	defer cleanup()
+	otel.SetTracerProvider(tp)
+
+	carrier := mapCarrier{
+		tracer.DefaultTraceIDHeader:  "1",
+		tracer.DefaultParentIDHeader: "1",
+		tracer.DefaultPriorityHeader: "2",
+	}
+
+	ctx := DatadogPropagator{}.Extract(context.Background(), carrier)
+
+	opts, ok := spanOptionsFromContext(ctx)
+	require.True(t, ok, "ContextWithStartOptions should have been called")
+	// Restart: ChildOf + WithSpanLinks.
+	assert.Len(t, opts, 2, "restart should produce both ChildOf and WithSpanLinks options")
+
+	// Start a span via the OTel bridge — it picks up the options and creates
+	// the span as a restart root with a new trace ID.
+	tr := tp.Tracer("")
+	ctx, span := tr.Start(ctx, "otel_extract_distant_call")
+	defer span.End()
+
+	ddSpan, ok := tracer.SpanFromContext(ctx)
+	require.True(t, ok)
+	assert.NotEqual(t, uint64(1), ddSpan.Context().TraceIDLower(), "restart should produce a new trace ID")
+}
+
+func TestDatadogPropagatorRoundTrip(t *testing.T) {
+	tp, _, cleanup := mockTracerProvider(t)
+	defer cleanup()
+	otel.SetTracerProvider(tp)
+
+	prop := propagation.NewCompositeTextMapPropagator(DatadogPropagator{}, propagation.TraceContext{}, propagation.Baggage{})
+	otel.SetTextMapPropagator(prop)
+
+	tr := tp.Tracer("")
+
+	// Start a root span and inject its context into a carrier.
+	ctx, root := tr.Start(context.Background(), "root")
+	defer root.End()
+
+	carrier := make(mapCarrier)
+	prop.Inject(ctx, carrier)
+	assert.NotEmpty(t, carrier[tracer.DefaultTraceIDHeader], "inject should write trace-id")
+
+	ddRoot, ok := tracer.SpanFromContext(ctx)
+	require.True(t, ok)
+
+	// Extract from the carrier and start a child span.
+	childCtx := prop.Extract(context.Background(), carrier)
+	childCtx, child := tr.Start(childCtx, "child")
+	defer child.End()
+
+	ddChild, ok := tracer.SpanFromContext(childCtx)
+	require.True(t, ok)
+
+	// The child span should be in the same trace as the root.
+	assert.Equal(t, ddRoot.Context().TraceIDLower(), ddChild.Context().TraceIDLower(), "round-trip should preserve trace ID")
+}

--- a/ddtrace/opentelemetry/propagator_test.go
+++ b/ddtrace/opentelemetry/propagator_test.go
@@ -163,3 +163,24 @@ func TestDatadogPropagatorRoundTrip(t *testing.T) {
 	// The child span should be in the same trace as the root.
 	assert.Equal(t, ddRoot.Context().TraceIDLower(), ddChild.Context().TraceIDLower(), "round-trip should preserve trace ID")
 }
+
+func TestNewTracerProviderRegistersPropagator(t *testing.T) {
+	// Set a pre-existing propagator to verify it is preserved, not overwritten.
+	sentinel := propagation.TraceContext{}
+	otel.SetTextMapPropagator(sentinel)
+
+	tp := NewTracerProvider()
+	defer tp.Shutdown()
+
+	prop := otel.GetTextMapPropagator()
+	fields := prop.Fields()
+
+	// DatadogPropagator fields must be present.
+	for _, f := range (DatadogPropagator{}).Fields() {
+		assert.Contains(t, fields, f, "DatadogPropagator field %q should be in the global propagator", f)
+	}
+	// The pre-existing TraceContext propagator fields must still be present.
+	for _, f := range sentinel.Fields() {
+		assert.Contains(t, fields, f, "pre-existing propagator field %q should be preserved", f)
+	}
+}

--- a/ddtrace/opentelemetry/tracer_provider.go
+++ b/ddtrace/opentelemetry/tracer_provider.go
@@ -37,6 +37,8 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 )
@@ -58,8 +60,18 @@ type TracerProvider struct {
 // and initializes the Datadog Tracer with the provided start options.
 // This TracerProvider only supports a singleton tracer, and repeated calls to
 // the Tracer() method will return the same instance each time.
+//
+// NewTracerProvider also prepends DatadogPropagator to the global OTel
+// TextMapPropagator so that Datadog-specific extraction behavior (including
+// DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT) is applied alongside any propagators
+// the caller has already registered.
 func NewTracerProvider(opts ...tracer.StartOption) *TracerProvider {
 	tracer.Start(opts...)
+	// Prepend DatadogPropagator to whatever propagator is already set so that
+	// Datadog header extraction (tracer.Extract) runs before W3C extraction.
+	// This mirrors what Java, Ruby, and .NET Datadog tracers do automatically.
+	existing := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(DatadogPropagator{}, existing))
 	p := &TracerProvider{}
 	t := &oteltracer{
 		DD:       internal.GetGlobalTracer[tracer.Tracer](),


### PR DESCRIPTION
### What does this PR do?

Adds `DatadogPropagator`, an implementation of `propagation.TextMapPropagator` that delegates to the global Datadog tracer for extraction and injection. It lives in `ddtrace/opentelemetry` alongside the existing OTel bridge.

The propagator bridges the OTel propagation API with the DD tracer's extraction logic, so all `DD_TRACE_PROPAGATION_*` env vars — including `DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT=restart` — are respected when using `ddotel.NewTracerProvider()`.

Usage:

```go
otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
    opentelemetry.DatadogPropagator{},
    propagation.TraceContext{},
    propagation.Baggage{},
))
```

### Motivation

When using `ddotel.NewTracerProvider()`, the OTel bridge calls `tracer.Start()` but never `tracer.Extract`. This means Datadog-specific extraction behavior (e.g. `restart`) is completely bypassed when propagation is done via the standard OTel `TextMapPropagator` API.

Java, Ruby, and .NET Datadog tracers automatically register a Datadog-aware OTel propagator at startup. Go has no equivalent, leaving users who rely on `DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT=restart` unable to use the OTel propagation path.

This PR closes that gap by providing `DatadogPropagator` — a drop-in propagator that wraps `tracer.Extract` and stores the resulting start options in the context via `ContextWithStartOptions`, so the OTel bridge picks them up when creating the next span.

Related system-tests PR: https://github.com/DataDog/system-tests/pull/7264

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.