### PR TITLE
fix(orchestrion): fix flaky TestCmdi server startup race

### DIFF
--- a/internal/orchestrion/_integration/os/cmdi.go
+++ b/internal/orchestrion/_integration/os/cmdi.go
@@ -45,14 +45,15 @@ func (tc *TestCaseCmdi) PreBootstrap(_ context.Context, t *testing.T) {
 
 func (tc *TestCaseCmdi) Setup(_ context.Context, t *testing.T) {
 	mux := http.NewServeMux()
+	ln := net.FreeListener(t)
 	tc.Server = &http.Server{
-		Addr:    fmt.Sprintf("127.0.0.1:%d", net.FreePort(t)),
+		Addr:    ln.Addr().String(),
 		Handler: mux,
 	}
 
 	mux.HandleFunc("/", tc.handleRoot)
 
-	go func() { assert.ErrorIs(t, tc.Server.ListenAndServe(), http.ErrServerClosed) }()
+	go func() { assert.ErrorIs(t, tc.Server.Serve(ln), http.ErrServerClosed) }()
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()


### PR DESCRIPTION
### What does this PR do?

Fixes a startup race in `os.TestCmdi` (orchestrion integration suite). `Setup` allocated a port with `net.FreePort(t)` and started the HTTP server asynchronously with `go tc.Server.ListenAndServe()`, but nothing guaranteed the socket was bound before `Run` issued its `http.Get`. On a busy CI host this occasionally raced, producing `connection refused`.

The fix switches to `net.FreeListener(t)` + `Server.Serve(ln)`: the listener is bound synchronously in `Setup` before the goroutine starts, so the socket is guaranteed ready when `Run` connects. This is the exact same pattern already used by the sibling test case `os/lfi.go` in the same package — `cmdi.go` was the lone straggler still using the racy `ListenAndServe()` form.

### Motivation

CI flake:
```
Get "http://127.0.0.1:50734/?command=/usr/bin/touch%20/tmp/passwd": dial tcp 127.0.0.1:50734: connect: connection refused
```

### Verification

- `go build` / `go vet` clean on the package
- `orchestrion go test -run TestCmdi -count=5 -v .` — 5/5 pass
- `orchestrion go test -race .` — full package passes under race detector
- `golangci-lint run --disable=gocritic ./os/...` — 0 issues

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.