### PR TITLE
feat: ability to externally register instrumentations

### DIFF
--- a/instrumentation/instrumentation.go
+++ b/instrumentation/instrumentation.go
@@ -25,6 +25,23 @@ import (
 // OperationContext holds metadata about an instrumentation operation.
 type OperationContext map[string]string
 
+// Register registers a new [Package] instrumentation. Panics if called multiple
+// times for the same [Package].
+func Register(pkg Package, info PackageInfo) {
+	if _, ok := packages[pkg]; ok {
+		panic("instrumentation package: " + pkg + " was already registered.")
+	}
+	packages[pkg] = info
+}
+
+// RegisterAndLoad registers a new [Package] instrumentation and immediately
+// loads it, returning the associated [Instrumentation] instance. Panics if the
+// package has already been registered previously.
+func RegisterAndLoad(pkg Package, info PackageInfo) *Instrumentation {
+	Register(pkg, info)
+	return Load(pkg)
+}
+
 // Load attempts to load the requested package instrumentation. It panics if the package has not been registered.
 func Load(pkg Package) *Instrumentation {
 	info, ok := packages[pkg]

--- a/instrumentation/instrumentation.go
+++ b/instrumentation/instrumentation.go
@@ -28,9 +28,13 @@ type OperationContext map[string]string
 // Register registers a new [Package] instrumentation. Panics if called multiple
 // times for the same [Package].
 func Register(pkg Package, info PackageInfo) {
+	packagesMu.Lock()
+	defer packagesMu.Unlock()
+
 	if _, ok := packages[pkg]; ok {
 		panic("instrumentation package: " + pkg + " was already registered.")
 	}
+	info.external = true // Marker for external packages
 	packages[pkg] = info
 }
 
@@ -44,6 +48,9 @@ func RegisterAndLoad(pkg Package, info PackageInfo) *Instrumentation {
 
 // Load attempts to load the requested package instrumentation. It panics if the package has not been registered.
 func Load(pkg Package) *Instrumentation {
+	packagesMu.RLock()
+	defer packagesMu.RUnlock()
+
 	info, ok := packages[pkg]
 	if !ok {
 		panic("instrumentation package: " + pkg + " was not found. If this is an external package, you must " +

--- a/instrumentation/packages.go
+++ b/instrumentation/packages.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"maps"
 	"strings"
+	"sync"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 )
@@ -125,6 +126,7 @@ type PackageInfo struct {
 	naming map[Component]componentNames
 }
 
+var packagesMu sync.RWMutex
 var packages = map[Package]PackageInfo{
 	Package99DesignsGQLGen: {
 		TracedPackage: "github.com/99designs/gqlgen",
@@ -1018,6 +1020,9 @@ func isAWSMessagingSendOp(awsService, awsOperation string) bool {
 
 // GetPackages returns a map of Package to the corresponding instrumented module.
 func GetPackages() map[Package]PackageInfo {
+	packagesMu.RLock()
+	defer packagesMu.RUnlock()
+
 	cp := make(map[Package]PackageInfo)
 	maps.Copy(cp, packages)
 	return cp


### PR DESCRIPTION
### What does this PR do?

Added `github.com/DataDog/dd-trace-go/v2/instrumentation.Register` to allow registration of instrumentations/integrations from outside of the tracer. This was intended in the original design but had never been implemented so far.

### Motivation

This is necessary to be able to deliver instrumentation/integration packages outside of the tracer's mono-repository.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
