### PR TITLE
feat: expose `TelemetryClient` from the instrumentation package

### DIFF
--- a/instrumentation/instrumentation.go
+++ b/instrumentation/instrumentation.go
@@ -148,6 +148,12 @@ func (i *Instrumentation) TelemetryLog() *telemetrylog.Logger {
 	return i.telemetrylog
 }
 
+type TelemetryClient = telemetry.Client
+
+func (i *Instrumentation) TelemetryClient() TelemetryClient {
+	return telemetry.GlobalClient()
+}
+
 type TelemetryOrigin = telemetry.Origin
 
 const (

--- a/instrumentation/instrumentation.go
+++ b/instrumentation/instrumentation.go
@@ -61,8 +61,9 @@ func Load(pkg Package) *Instrumentation {
 	tracer.MarkIntegrationImported(info.TracedPackage)
 
 	return &Instrumentation{
-		logger:       newLogger(pkg),
-		telemetrylog: telemetrylog.With(telemetry.WithTags([]string{"integration:" + string(pkg)})),
+		logger:           newLogger(pkg),
+		telemetrylog:     telemetrylog.With(telemetry.WithTags([]string{"integration:" + string(pkg)})),
+		telemetryMetrics: telemetryMetrics{valid: true},
 
 		pkg:  pkg,
 		info: info,
@@ -81,8 +82,9 @@ func Version() string {
 
 // Instrumentation represents instrumentation for a package.
 type Instrumentation struct {
-	logger       Logger
-	telemetrylog *telemetrylog.Logger
+	logger           Logger
+	telemetrylog     *telemetrylog.Logger
+	telemetryMetrics telemetryMetrics
 
 	pkg  Package
 	info PackageInfo
@@ -148,20 +150,13 @@ func (i *Instrumentation) TelemetryLog() *telemetrylog.Logger {
 	return i.telemetrylog
 }
 
-// TelemetryClient is the interface used to submit instrumentation telemetry
-// metrics data.
-//
-// IMPORTANT: If you are not sure what this is for, you probably should be using
-// [StatsdClient] instead.
-type TelemetryClient = telemetry.Client
-
-// TelemetryClient returns the [TelemetryClient] that instrumentation should use
-// to submit internal telemetry metrics data.
+// TelemetryMetrics returns the [TelemetryMetricsClient] that instrumentation
+// should use to submit internal telemetry metrics data. Returns nil
 //
 // IMPORTANT: If you are not sure what this is for, you should probably be using
 // [*Instrumentation.StatsdClient] instead.
-func (i *Instrumentation) TelemetryClient() TelemetryClient {
-	return telemetry.GlobalClient()
+func (i *Instrumentation) TelemetryMetrics() TelemetryMetricsClient {
+	return &i.telemetryMetrics
 }
 
 type TelemetryOrigin = telemetry.Origin

--- a/instrumentation/instrumentation.go
+++ b/instrumentation/instrumentation.go
@@ -148,8 +148,18 @@ func (i *Instrumentation) TelemetryLog() *telemetrylog.Logger {
 	return i.telemetrylog
 }
 
+// TelemetryClient is the interface used to submit instrumentation telemetry
+// metrics data.
+//
+// IMPORTANT: If you are not sure what this is for, you probably should be using
+// [StatsdClient] instead.
 type TelemetryClient = telemetry.Client
 
+// TelemetryClient returns the [TelemetryClient] that instrumentation should use
+// to submit internal telemetry metrics data.
+//
+// IMPORTANT: If you are not sure what this is for, you should probably be using
+// [*Instrumentation.StatsdClient] instead.
 func (i *Instrumentation) TelemetryClient() TelemetryClient {
 	return telemetry.GlobalClient()
 }

--- a/instrumentation/instrumentation.go
+++ b/instrumentation/instrumentation.go
@@ -151,7 +151,7 @@ func (i *Instrumentation) TelemetryLog() *telemetrylog.Logger {
 }
 
 // TelemetryMetrics returns the [TelemetryMetricsClient] that instrumentation
-// should use to submit internal telemetry metrics data. Returns nil
+// should use to submit internal telemetry metrics data.
 //
 // IMPORTANT: If you are not sure what this is for, you should probably be using
 // [*Instrumentation.StatsdClient] instead.

--- a/instrumentation/telemetrymetrics.go
+++ b/instrumentation/telemetrymetrics.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+package instrumentation
+
+import "github.com/DataDog/dd-trace-go/v2/internal/telemetry"
+
+// TelemetryMetric is a handle to a telemetry metric.
+type TelemetryMetric = telemetry.MetricHandle
+
+// TelemetryMetrics is the interface used to submit instrumentation telemetry
+// metrics data.
+//
+// IMPORTANT: If you are not sure what this is for, you should probably be using
+// [StatsdClient] instead.
+type TelemetryMetrics interface {
+	// Count obtains a [TelemetryMetric] for a counter (representing the sum of
+	// submitted values for a given interval).
+	Count(ns telemetry.Namespace, name string, tags []string) TelemetryMetric
+	// Rate obtains a [TelemetryMetric] for a rate metric (representing the value
+	// per interval).
+	Rate(ns telemetry.Namespace, name string, tags []string) TelemetryMetric
+	// Count obtains a [TelemetryMetric] for a gauge (representing the last
+	// submitted value for a given interval).
+	Gauge(ns telemetry.Namespace, name string, tags []string) TelemetryMetric
+	// Distribution obtains a [TelemetryMetric] for a distribution metric
+	// (representing the distribution of submitted values for a given interval).
+	Distribution(ns telemetry.Namespace, name string, tags []string) TelemetryMetric
+}
+
+// TelemetryMetricsClient is the interface used to manage instrumentation
+// telemetry metrics data.
+//
+// IMPORTANT: If you are not sure what this is for, you should probably be using
+// [StatsdClient] instead.
+type TelemetryMetricsClient interface {
+	TelemetryMetrics
+	// OnHeartbeat registers a function to be called at each time the telemetry
+	// client flushes metrics. This is useful for emitting heartbeat metrics.
+	OnHeartbeat(ticket func(TelemetryMetrics))
+}
+
+type telemetryMetrics struct {
+	// valid is a marker to ensure thr zero-value is not usable.
+	valid bool
+}
+
+func (t *telemetryMetrics) Count(ns telemetry.Namespace, name string, tags []string) TelemetryMetric {
+	t.assertValid()
+	return telemetry.Count(ns, name, tags)
+}
+
+func (t *telemetryMetrics) Rate(ns telemetry.Namespace, name string, tags []string) TelemetryMetric {
+	t.assertValid()
+	return telemetry.Count(ns, name, tags)
+}
+
+func (t *telemetryMetrics) Gauge(ns telemetry.Namespace, name string, tags []string) TelemetryMetric {
+	t.assertValid()
+	return telemetry.Count(ns, name, tags)
+}
+
+func (t *telemetryMetrics) Distribution(ns telemetry.Namespace, name string, tags []string) TelemetryMetric {
+	t.assertValid()
+	return telemetry.Count(ns, name, tags)
+}
+
+func (t *telemetryMetrics) OnHeartbeat(ticker func(TelemetryMetrics)) {
+	t.assertValid()
+	telemetry.AddFlushTicker(func(client telemetry.Client) { ticker(client) })
+}
+
+// assertValid panics if the [*telemetryMetrics] is a zero-value.
+func (t *telemetryMetrics) assertValid() {
+	if !t.valid {
+		panic("TelemetryMetricsClient must be obtained from Instrumentation.TelemetryMetrics()")
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Exposes a `TelemetryClient` interface through the `instrumentation` package.

### Motivation

This allows external packages to submit telemetry metrics to the agent.
I need this in order to implement a spec-compliant IAST driver externally to the tracer.
