### PR TITLE
feat(civisibility): add code coverage report flags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -305,6 +305,10 @@ Once a new environment variable is added to the codebase, Datadog maintainers wi
 
 Upon each tracer release, new configuration keys are automatically tagged by our [CI pipeline](./.gitlab/config-validation.yml) to track when they were introduced.
 
+#### Code coverage report flags
+
+`DD_CODE_COVERAGE_FLAGS` attaches a comma-separated list of flags to uploaded code coverage reports. Whitespace around each flag is trimmed, empty entries are discarded, and order and duplicate flags are preserved. A maximum of 32 normalized flags is accepted; if the value contains more, the report is uploaded without flags and a warning is logged.
+
 #### Adding new environment variables using configinverter
 
 The `configinverter` tool provides a command to add new environment variable keys to the `supported_configurations.json` file and regenerate the corresponding Go code.

--- a/internal/civisibility/constants/env.go
+++ b/internal/civisibility/constants/env.go
@@ -41,6 +41,9 @@ const (
 	// This environment variable should be set to "0" or "false" to skip uploading code coverage reports while keeping CI Visibility enabled.
 	CIVisibilityCodeCoverageReportUploadEnabledEnvironmentVariable = "DD_CIVISIBILITY_CODE_COVERAGE_REPORT_UPLOAD_ENABLED"
 
+	// CodeCoverageFlagsEnvironmentVariable contains flags attached to uploaded code coverage reports.
+	CodeCoverageFlagsEnvironmentVariable = "DD_CODE_COVERAGE_FLAGS"
+
 	// CIVisibilityFlakyRetryCountEnvironmentVariable indicates the maximum number of retry attempts for a single test case.
 	CIVisibilityFlakyRetryCountEnvironmentVariable = "DD_CIVISIBILITY_FLAKY_RETRY_COUNT"
 

--- a/internal/civisibility/utils/net/client.go
+++ b/internal/civisibility/utils/net/client.go
@@ -48,19 +48,20 @@ type (
 
 	// client is a client for sending requests to the Datadog backend.
 	client struct {
-		id                 string
-		agentless          bool
-		baseURL            string
-		environment        string
-		serviceName        string
-		workingDirectory   string
-		repositoryURL      string
-		commitSha          string
-		commitMessage      string
-		headCommitSha      string
-		headCommitMessage  string
-		branchName         string
-		testConfigurations testConfigurations
+		id                  string
+		agentless           bool
+		baseURL             string
+		environment         string
+		serviceName         string
+		workingDirectory    string
+		repositoryURL       string
+		commitSha           string
+		commitMessage       string
+		headCommitSha       string
+		headCommitMessage   string
+		branchName          string
+		testConfigurations  testConfigurations
+		coverageReportFlags []string
 		// readCacheScopeIdentity stores the short-lived read-cache scope derived from already-resolved CI tags.
 		readCacheScopeIdentity readCacheScopeIdentity
 		headers                map[string]string

--- a/internal/civisibility/utils/net/client.go
+++ b/internal/civisibility/utils/net/client.go
@@ -46,6 +46,12 @@ type (
 		SendLogs(logsPayload io.Reader) error
 	}
 
+	// coverageClient is an interface for sending coverage reports to the Datadog backend.
+	coverageClient interface {
+		Client
+		SetCoverageFlags([]string)
+	}
+
 	// client is a client for sending requests to the Datadog backend.
 	client struct {
 		id                  string
@@ -81,7 +87,8 @@ type (
 )
 
 var (
-	_ Client = &client{}
+	_ Client         = &client{}
+	_ coverageClient = &client{}
 
 	// telemetryInit is used to initialize the telemetry client.
 	telemetryInit sync.Once
@@ -294,4 +301,9 @@ func (c *client) getPostRequestConfig(url string, body any) *RequestConfig {
 		MaxRetries: DefaultMaxRetries,
 		Backoff:    DefaultBackoff,
 	}
+}
+
+// SetCoverageFlags sets the coverage report flags to the client
+func (c *client) SetCoverageFlags(flags []string) {
+	c.coverageReportFlags = flags
 }

--- a/internal/civisibility/utils/net/coverage_report.go
+++ b/internal/civisibility/utils/net/coverage_report.go
@@ -35,12 +35,10 @@ const (
 
 // NewClientForCoverageReportUpload creates a new client for sending code coverage reports.
 func NewClientForCoverageReportUpload() Client {
-	clientInterface := NewClientWithServiceNameAndSubdomain("", coverageReportSubDomain)
-	client, ok := clientInterface.(*client)
-	if !ok {
-		return clientInterface
+	client := NewClientWithServiceNameAndSubdomain("", coverageReportSubDomain)
+	if coverageClient, ok := client.(coverageClient); ok {
+		coverageClient.SetCoverageFlags(parseCoverageReportFlags(env.Get(constants.CodeCoverageFlagsEnvironmentVariable)))
 	}
-	client.coverageReportFlags = parseCoverageReportFlags(env.Get(constants.CodeCoverageFlagsEnvironmentVariable))
 	return client
 }
 

--- a/internal/civisibility/utils/net/coverage_report.go
+++ b/internal/civisibility/utils/net/coverage_report.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/telemetry"
+	"github.com/DataDog/dd-trace-go/v2/internal/env"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 )
 
@@ -28,11 +29,19 @@ const (
 	coverageReportSubDomain string = "ci-intake"
 	// coverageReportURLPath is the URL path for the coverage report endpoint.
 	coverageReportURLPath string = "api/v2/cicovreprt"
+	// maxCoverageReportFlags is the maximum number of flags accepted by the coverage report intake.
+	maxCoverageReportFlags = 32
 )
 
 // NewClientForCoverageReportUpload creates a new client for sending code coverage reports.
 func NewClientForCoverageReportUpload() Client {
-	return NewClientWithServiceNameAndSubdomain("", coverageReportSubDomain)
+	clientInterface := NewClientWithServiceNameAndSubdomain("", coverageReportSubDomain)
+	client, ok := clientInterface.(*client)
+	if !ok {
+		return clientInterface
+	}
+	client.coverageReportFlags = parseCoverageReportFlags(env.Get(constants.CodeCoverageFlagsEnvironmentVariable))
+	return client
 }
 
 // SendCoverageReport sends a code coverage report to the backend.
@@ -71,7 +80,7 @@ func (c *client) SendCoverageReport(report io.Reader, format string) error {
 			FieldName:   "event",
 			ContentType: ContentTypeJSON,
 			FileName:    "event.json",
-			Content:     coverageReportEvent(format),
+			Content:     coverageReportEvent(format, c.coverageReportFlags),
 		},
 		{
 			FieldName:   "coverage",
@@ -130,10 +139,13 @@ func coverageReportHeaders(base map[string]string, contentType string) map[strin
 	return headers
 }
 
-func coverageReportEvent(format string) map[string]string {
-	event := map[string]string{
+func coverageReportEvent(format string, flags []string) map[string]any {
+	event := map[string]any{
 		"type":   "coverage_report",
 		"format": format,
+	}
+	if len(flags) > 0 {
+		event["report.flags"] = flags
 	}
 
 	for key, value := range utils.GetCITags() {
@@ -146,4 +158,28 @@ func coverageReportEvent(format string) map[string]string {
 	}
 
 	return event
+}
+
+func parseCoverageReportFlags(raw string) []string {
+	parts := strings.Split(raw, ",")
+	flags := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if flag := strings.TrimSpace(part); flag != "" {
+			flags = append(flags, flag)
+		}
+	}
+
+	if len(flags) == 0 {
+		return nil
+	}
+	if len(flags) > maxCoverageReportFlags {
+		log.Warn(
+			"civisibility.coverage_report: %s contains %d flags, exceeding the maximum of %d; report flags will be omitted",
+			constants.CodeCoverageFlagsEnvironmentVariable,
+			len(flags),
+			maxCoverageReportFlags,
+		)
+		return nil
+	}
+	return flags
 }

--- a/internal/civisibility/utils/net/coverage_report_test.go
+++ b/internal/civisibility/utils/net/coverage_report_test.go
@@ -133,6 +133,8 @@ func TestParseCoverageReportFlags(t *testing.T) {
 		{name: "preserves duplicates", raw: "unit,unit", want: []string{"unit", "unit"}},
 		{name: "accepts maximum", raw: makeCoverageReportFlags(maxCoverageReportFlags), want: makeCoverageReportFlagSlice(maxCoverageReportFlags)},
 		{name: "rejects over maximum", raw: makeCoverageReportFlags(maxCoverageReportFlags + 1), want: nil},
+		{name: "accepts maximum after removing empty entries", raw: " , " + makeCoverageReportFlags(maxCoverageReportFlags) + ", , ", want: makeCoverageReportFlagSlice(maxCoverageReportFlags)},
+		{name: "rejects over maximum after removing empty entries", raw: " , " + makeCoverageReportFlags(maxCoverageReportFlags+1) + ", , ", want: nil},
 	}
 
 	defer log.UseLogger(log.DiscardLogger{})()

--- a/internal/civisibility/utils/net/coverage_report_test.go
+++ b/internal/civisibility/utils/net/coverage_report_test.go
@@ -13,6 +13,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,6 +22,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/bazel"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 	civisibilityutils "github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils"
+	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	coretelemetry "github.com/DataDog/dd-trace-go/v2/internal/telemetry"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry/telemetrytest"
 )
@@ -45,7 +48,7 @@ func TestCoverageReportApiRequest(t *testing.T) {
 		require.Equal(t, ContentTypeJSON, event.contentType)
 		require.Equal(t, "event.json", event.fileName)
 
-		var eventPayload map[string]string
+		var eventPayload map[string]any
 		require.NoError(t, json.Unmarshal(event.body, &eventPayload))
 		require.Equal(t, "coverage_report", eventPayload["type"])
 		require.Equal(t, FormatLCOV, eventPayload["format"])
@@ -54,6 +57,7 @@ func TestCoverageReportApiRequest(t *testing.T) {
 		require.Equal(t, "main", eventPayload[constants.GitBranch])
 		require.Equal(t, "/ci/workspace", eventPayload[constants.CIWorkspacePath])
 		require.Equal(t, "42", eventPayload[constants.PrNumber])
+		require.Equal(t, []any{"type:unit-tests", "jvm-21", "type:unit-tests"}, eventPayload["report.flags"])
 		require.NotContains(t, eventPayload, constants.TestSessionName)
 
 		coverage := parts["coverage"]
@@ -70,6 +74,7 @@ func TestCoverageReportApiRequest(t *testing.T) {
 	defer restoreEnv(origEnv)
 
 	setCiVisibilityEnv(path, server.URL)
+	os.Setenv(constants.CodeCoverageFlagsEnvironmentVariable, "type:unit-tests,jvm-21,type:unit-tests")
 	civisibilityutils.AddCITagsMap(map[string]string{
 		constants.CIWorkspacePath: "/ci/workspace",
 		constants.PrNumber:        "42",
@@ -112,6 +117,114 @@ func TestCoverageReportApiRequest(t *testing.T) {
 		Tags:      "rq_compressed:true",
 		Kind:      "distribution",
 	})
+}
+
+func TestParseCoverageReportFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{name: "unset", want: nil},
+		{name: "empty", raw: "", want: nil},
+		{name: "comma and whitespace only", raw: " , , ", want: nil},
+		{name: "preserves order", raw: "type:unit-tests,jvm-21", want: []string{"type:unit-tests", "jvm-21"}},
+		{name: "trims and removes empty entries", raw: " type:unit-tests, , jvm-21 ", want: []string{"type:unit-tests", "jvm-21"}},
+		{name: "preserves duplicates", raw: "unit,unit", want: []string{"unit", "unit"}},
+		{name: "accepts maximum", raw: makeCoverageReportFlags(maxCoverageReportFlags), want: makeCoverageReportFlagSlice(maxCoverageReportFlags)},
+		{name: "rejects over maximum", raw: makeCoverageReportFlags(maxCoverageReportFlags + 1), want: nil},
+	}
+
+	defer log.UseLogger(log.DiscardLogger{})()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, parseCoverageReportFlags(test.raw))
+		})
+	}
+}
+
+func TestParseCoverageReportFlagsWarnsOnOverflow(t *testing.T) {
+	recordLogger := new(log.RecordLogger)
+	defer log.UseLogger(recordLogger)()
+
+	require.Nil(t, parseCoverageReportFlags(makeCoverageReportFlags(maxCoverageReportFlags+1)))
+
+	logs := recordLogger.Logs()
+	require.Len(t, logs, 1)
+	require.Contains(t, logs[0], constants.CodeCoverageFlagsEnvironmentVariable)
+	require.Contains(t, logs[0], "33")
+	require.Contains(t, logs[0], "32")
+}
+
+func TestCoverageReportApiRequestOmitsInvalidFlags(t *testing.T) {
+	tests := []struct {
+		name  string
+		value *string
+	}{
+		{name: "unset"},
+		{name: "empty", value: stringPointer(" , , ")},
+		{name: "over maximum", value: stringPointer(makeCoverageReportFlags(maxCoverageReportFlags + 1))},
+	}
+
+	defer log.UseLogger(log.DiscardLogger{})()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var requestReceived bool
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestReceived = true
+				parts := readCoverageReportMultipartParts(t, r)
+				var eventPayload map[string]any
+				require.NoError(t, json.Unmarshal(parts["event"].body, &eventPayload))
+				require.NotContains(t, eventPayload, "report.flags")
+				w.WriteHeader(http.StatusAccepted)
+			}))
+			defer server.Close()
+
+			origEnv := saveEnv()
+			path := os.Getenv("PATH")
+			defer restoreEnv(origEnv)
+
+			setCiVisibilityEnv(path, server.URL)
+			if test.value != nil {
+				os.Setenv(constants.CodeCoverageFlagsEnvironmentVariable, *test.value)
+			}
+
+			client := NewClientForCoverageReportUpload()
+			require.NotNil(t, client)
+			require.NoError(t, client.SendCoverageReport(bytes.NewReader([]byte("report")), FormatLCOV))
+			require.True(t, requestReceived)
+		})
+	}
+}
+
+func TestCoverageReportFlagsAreSnapshotted(t *testing.T) {
+	var receivedFlags []any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		parts := readCoverageReportMultipartParts(t, r)
+		var eventPayload map[string]any
+		require.NoError(t, json.Unmarshal(parts["event"].body, &eventPayload))
+		receivedFlags = append(receivedFlags, eventPayload["report.flags"])
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	origEnv := saveEnv()
+	path := os.Getenv("PATH")
+	defer restoreEnv(origEnv)
+
+	setCiVisibilityEnv(path, server.URL)
+	os.Setenv(constants.CodeCoverageFlagsEnvironmentVariable, "first,second")
+	client := NewClientForCoverageReportUpload()
+	require.NotNil(t, client)
+	os.Setenv(constants.CodeCoverageFlagsEnvironmentVariable, "later")
+
+	require.NoError(t, client.SendCoverageReport(bytes.NewReader([]byte("first report")), FormatLCOV))
+	os.Unsetenv(constants.CodeCoverageFlagsEnvironmentVariable)
+	require.NoError(t, client.SendCoverageReport(bytes.NewReader([]byte("second report")), FormatLCOV))
+	require.Equal(t, []any{
+		[]any{"first", "second"},
+		[]any{"first", "second"},
+	}, receivedFlags)
 }
 
 func TestCoverageReportApiRequestDoesNotPersistMultipartContentTypeHeader(t *testing.T) {
@@ -280,4 +393,20 @@ func gunzipCoverageReportPart(t *testing.T, body []byte) string {
 	uncompressed, err := io.ReadAll(reader)
 	require.NoError(t, err)
 	return string(uncompressed)
+}
+
+func makeCoverageReportFlags(count int) string {
+	return strings.Join(makeCoverageReportFlagSlice(count), ",")
+}
+
+func makeCoverageReportFlagSlice(count int) []string {
+	flags := make([]string, count)
+	for i := range flags {
+		flags[i] = "flag-" + strconv.Itoa(i)
+	}
+	return flags
+}
+
+func stringPointer(value string) *string {
+	return &value
 }

--- a/internal/env/supported_configurations.gen.go
+++ b/internal/env/supported_configurations.gen.go
@@ -56,6 +56,7 @@ var SupportedConfigurations = map[string]struct{}{
 	"DD_CIVISIBILITY_SUBTEST_FEATURES_ENABLED":                        {},
 	"DD_CIVISIBILITY_TOTAL_FLAKY_RETRY_COUNT":                         {},
 	"DD_CIVISIBILITY_USE_NOOP_TRACER":                                 {},
+	"DD_CODE_COVERAGE_FLAGS":                                          {},
 	"DD_CUSTOM_PARENT_ID":                                             {},
 	"DD_CUSTOM_TRACE_ID":                                              {},
 	"DD_DATA_STREAMS_ENABLED":                                         {},

--- a/internal/env/supported_configurations.json
+++ b/internal/env/supported_configurations.json
@@ -338,6 +338,13 @@
         "default": "false"
       }
     ],
+    "DD_CODE_COVERAGE_FLAGS": [
+      {
+        "implementation": "A",
+        "type": "array",
+        "default": null
+      }
+    ],
     "DD_CUSTOM_PARENT_ID": [
       {
         "implementation": "A",

--- a/internal/env/supported_configurations.json
+++ b/internal/env/supported_configurations.json
@@ -341,7 +341,7 @@
     "DD_CODE_COVERAGE_FLAGS": [
       {
         "implementation": "A",
-        "type": "array",
+        "type": "string",
         "default": null
       }
     ],


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Adds `DD_CODE_COVERAGE_FLAGS` support to code coverage report uploads. The client snapshots the comma-separated environment variable at construction, trims entries and drops empty values, and sends up to 32 values in the upload event's `report.flags` JSON array while preserving order and duplicates. If more than 32 flags are configured, the client warns once, omits `report.flags`, and continues the upload.

Validation:

- `go run ./scripts/configinverter/main.go add DD_CODE_COVERAGE_FLAGS`
- `go run ./scripts/configinverter/main.go generate`
- `go run ./scripts/configinverter/main.go check`
- `make format/go`
- `go test ./internal/civisibility/utils/net`
- `make generate` (passed after installing Homebrew protobuf; task-created protoc version-comment churn was reverted)
- `./bin/golangci-lint run ./internal/civisibility/constants ./internal/civisibility/utils/net ./internal/env` (`0 issues`)
- `make lint/misc`
- `git diff --check`

Full `make lint` reports 10 pre-existing Go 1.26 `modernize` findings outside the changed files.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

Code coverage uploads need the same flag metadata supported by `datadog-ci coverage upload --flags`, allowing reports to be categorized without changing the public Go client API. `DD_CODE_COVERAGE_FLAGS` also needs an implementation A entry in the Fleet Policy Directory.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
