### PR TITLE
fix(haproxy): pass SPOE configuration path directly

### DIFF
--- a/contrib/haproxy/stream-processing-offload/cmd/spoa/haproxyconf/CHANGELOG.md
+++ b/contrib/haproxy/stream-processing-offload/cmd/spoa/haproxyconf/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.0.1
+
+### Fixed
+
+- Pass the SPOE configuration path directly to HAProxy's `filter spoe` directive.
+
 ## 1.0.0
 
 ### Added

--- a/contrib/haproxy/stream-processing-offload/cmd/spoa/haproxyconf/frontend-config.cfg
+++ b/contrib/haproxy/stream-processing-offload/cmd/spoa/haproxyconf/frontend-config.cfg
@@ -6,7 +6,7 @@ frontend main
     # This configuration should be placed at the most top of the file
     # to ensure it is executed first.
 
-    filter spoe engine datadog-aap-engine config str("$DD_SPOA_SPOA_CONF_FILE")
+    filter spoe engine datadog-aap-engine config "$DD_SPOA_SPOA_CONF_FILE"
     
     # Process the Request Headers
     http-request set-var(txn.timeout) str("$DD_SPOA_TIMEOUT")

--- a/contrib/haproxy/stream-processing-offload/cmd/spoa/main_test.go
+++ b/contrib/haproxy/stream-processing-offload/cmd/spoa/main_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/proxy"
 )
@@ -129,24 +128,6 @@ func TestLoadConfig_VariousCases(t *testing.T) {
 			assert.Equal(t, tc.want.bodyParsingSizeLimit, cfg.bodyParsingSizeLimit, "bodyParsingSizeLimit")
 		})
 	}
-}
-
-func TestHAProxyFrontendConfigSPOEPath(t *testing.T) {
-	// SPOE config expects a filename, not a sample expression like str("...").
-	configPath := "haproxyconf/frontend-config.cfg"
-	data, err := os.ReadFile(configPath)
-	require.NoError(t, err)
-
-	content := string(data)
-
-	correctLine := `filter spoe engine datadog-aap-engine config "$DD_SPOA_SPOA_CONF_FILE"`
-	assert.Contains(t, content, correctLine)
-
-	invalidLine := `filter spoe engine datadog-aap-engine config str("$DD_SPOA_SPOA_CONF_FILE")`
-	assert.NotContains(t, content, invalidLine)
-
-	validHttpRequestLine := `http-request set-var(txn.timeout) str("$DD_SPOA_TIMEOUT")`
-	assert.Contains(t, content, validHttpRequestLine)
 }
 
 // Helpers

--- a/contrib/haproxy/stream-processing-offload/cmd/spoa/main_test.go
+++ b/contrib/haproxy/stream-processing-offload/cmd/spoa/main_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/proxy"
 )
@@ -128,6 +129,24 @@ func TestLoadConfig_VariousCases(t *testing.T) {
 			assert.Equal(t, tc.want.bodyParsingSizeLimit, cfg.bodyParsingSizeLimit, "bodyParsingSizeLimit")
 		})
 	}
+}
+
+func TestHAProxyFrontendConfigSPOEPath(t *testing.T) {
+	// SPOE config expects a filename, not a sample expression like str("...").
+	configPath := "haproxyconf/frontend-config.cfg"
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	content := string(data)
+
+	correctLine := `filter spoe engine datadog-aap-engine config "$DD_SPOA_SPOA_CONF_FILE"`
+	assert.Contains(t, content, correctLine)
+
+	invalidLine := `filter spoe engine datadog-aap-engine config str("$DD_SPOA_SPOA_CONF_FILE")`
+	assert.NotContains(t, content, invalidLine)
+
+	validHttpRequestLine := `http-request set-var(txn.timeout) str("$DD_SPOA_TIMEOUT")`
+	assert.Contains(t, content, validHttpRequestLine)
 }
 
 // Helpers


### PR DESCRIPTION
### What does this PR do?

Passes `$DD_SPOA_SPOA_CONF_FILE` directly to the HAProxy `filter spoe ... config` directive and records the fix in the config changelog.

### Motivation

`config` expects a file path. Wrapping the value in `str()` makes HAProxy try to open `str(/path)` as the filename and fail at startup.