### PR TITLE
perf: backport #5039 and #5040 to v2.10.x

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -1683,4 +1683,3 @@ func (*propagatorBaggage) extractTextMap(reader TextMapReader) (*SpanContext, er
 
 	return &ctx, nil
 }
-

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -736,8 +736,7 @@ func overrideDatadogParentID(ctx, w3cCtx, ddCtx *SpanContext) {
 	if w3cCtx.reparentID != "" {
 		ctx.reparentID = w3cCtx.reparentID
 	} else {
-		// NIT: could be done without using fmt.Sprintf? Is it worth it?
-		ctx.reparentID = fmt.Sprintf("%016x", ddCtx.SpanID())
+		ctx.reparentID = uint64ToHex16(ddCtx.SpanID())
 	}
 }
 
@@ -1683,4 +1682,17 @@ func (*propagatorBaggage) extractTextMap(reader TextMapReader) (*SpanContext, er
 	}
 
 	return &ctx, nil
+}
+
+const hexDigits = "0123456789abcdef"
+
+// uint64ToHex16 formats v as a 16-character zero-padded lowercase hex string
+// without using fmt.Sprintf, saving the fmt reflection overhead.
+func uint64ToHex16(v uint64) string {
+	var buf [16]byte
+	for i := 15; i >= 0; i-- {
+		buf[i] = hexDigits[v&0xf]
+		v >>= 4
+	}
+	return string(buf[:])
 }

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -736,7 +736,7 @@ func overrideDatadogParentID(ctx, w3cCtx, ddCtx *SpanContext) {
 	if w3cCtx.reparentID != "" {
 		ctx.reparentID = w3cCtx.reparentID
 	} else {
-		ctx.reparentID = uint64ToHex16(ddCtx.SpanID())
+		ctx.reparentID = spanIDHexEncoded(ddCtx.SpanID(), 16)
 	}
 }
 
@@ -1684,15 +1684,3 @@ func (*propagatorBaggage) extractTextMap(reader TextMapReader) (*SpanContext, er
 	return &ctx, nil
 }
 
-const hexDigits = "0123456789abcdef"
-
-// uint64ToHex16 formats v as a 16-character zero-padded lowercase hex string
-// without using fmt.Sprintf, saving the fmt reflection overhead.
-func uint64ToHex16(v uint64) string {
-	var buf [16]byte
-	for i := 15; i >= 0; i-- {
-		buf[i] = hexDigits[v&0xf]
-		v >>= 4
-	}
-	return string(buf[:])
-}

--- a/instrumentation/httptrace/httptrace.go
+++ b/instrumentation/httptrace/httptrace.go
@@ -237,7 +237,7 @@ func urlFromRequest(r *http.Request, queryString bool, isClient bool) string {
 		scheme = "https"
 	}
 	if r.Host != "" {
-		url = strings.Join([]string{scheme, "://", r.Host, path}, "")
+		url = scheme + "://" + r.Host + path
 	} else {
 		url = path
 	}
@@ -255,11 +255,11 @@ func urlFromRequest(r *http.Request, queryString bool, isClient bool) string {
 			query = cfg.queryStringRegexp.ReplaceAllLiteralString(query, "<redacted>")
 		}
 		if query != "" {
-			url = strings.Join([]string{url, query}, "?")
+			url = url + "?" + query
 		}
 	}
 	if frag := r.URL.EscapedFragment(); frag != "" {
-		url = strings.Join([]string{url, frag}, "#")
+		url = url + "#" + frag
 	}
 	return url
 }

--- a/instrumentation/httptrace/httptrace_test.go
+++ b/instrumentation/httptrace/httptrace_test.go
@@ -187,7 +187,7 @@ func TestStartRequestSpanSecurityTestingHeaders(t *testing.T) {
 		{
 			name: "present",
 			headers: http.Header{
-				"x-datadog-endpoint-scan": {"scan-uuid"},
+				"X-Datadog-Endpoint-Scan": {"scan-uuid"},
 				"X-Datadog-Security-Test": {" test-uuid "},
 			},
 			expected: map[string]string{

--- a/internal/appsec/listener/httpsec/clientip.go
+++ b/internal/appsec/listener/httpsec/clientip.go
@@ -44,11 +44,7 @@ headersLoop:
 				// Scan comma-separated IPs without allocating a []string via Split.
 				for headerValue != "" {
 					var ip string
-					if i := strings.IndexByte(headerValue, ','); i >= 0 {
-						ip, headerValue = headerValue[:i], headerValue[i+1:]
-					} else {
-						ip, headerValue = headerValue, ""
-					}
+					ip, headerValue, _ = strings.Cut(headerValue, ",")
 					ips = append(ips, ip)
 				}
 			}

--- a/internal/appsec/listener/httpsec/clientip.go
+++ b/internal/appsec/listener/httpsec/clientip.go
@@ -33,13 +33,24 @@ headersLoop:
 		}
 
 		// Assuming a list of comma-separated IP addresses, split them and build
-		// the list of values to try to parse as IP addresses
-		var ips []string
+		// the list of values to try to parse as IP addresses.
+		// isForwarded is computed once per header, not per value.
+		isForwarded := strings.EqualFold(headerName, "forwarded")
+		ips := make([]string, 0, len(headerValues))
 		for _, headerValue := range headerValues {
-			if strings.ToLower(headerName) == "forwarded" {
+			if isForwarded {
 				ips = append(ips, parseForwardedHeader(headerValue)...)
 			} else {
-				ips = append(ips, strings.Split(headerValue, ",")...)
+				// Scan comma-separated IPs without allocating a []string via Split.
+				for headerValue != "" {
+					var ip string
+					if i := strings.IndexByte(headerValue, ','); i >= 0 {
+						ip, headerValue = headerValue[:i], headerValue[i+1:]
+					} else {
+						ip, headerValue = headerValue, ""
+					}
+					ips = append(ips, ip)
+				}
 			}
 		}
 

--- a/internal/appsec/listener/httpsec/clientip_test.go
+++ b/internal/appsec/listener/httpsec/clientip_test.go
@@ -503,3 +503,37 @@ func randPrivateIPv6() netip.Addr {
 		}
 	}
 }
+
+func BenchmarkClientIP(b *testing.B) {
+	headers := []struct {
+		name string
+		hdrs map[string][]string
+	}{
+		{
+			name: "x-forwarded-for/single",
+			hdrs: map[string][]string{"X-Forwarded-For": {"203.0.113.1"}},
+		},
+		{
+			name: "x-forwarded-for/multi",
+			hdrs: map[string][]string{"X-Forwarded-For": {"10.0.0.1, 172.16.0.1, 203.0.113.1"}},
+		},
+		{
+			name: "forwarded",
+			hdrs: map[string][]string{"Forwarded": {`for=203.0.113.1;by=unknown;proto=https`}},
+		},
+		{
+			name: "no_match",
+			hdrs: map[string][]string{"Content-Type": {"application/json"}},
+		},
+	}
+	monitoredHdrs := []string{"X-Forwarded-For", "Forwarded"}
+	for _, tc := range headers {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				ClientIP(tc.hdrs, true, "192.168.1.1:8080", monitoredHdrs)
+			}
+		})
+	}
+}

--- a/internal/appsec/listener/httpsec/request.go
+++ b/internal/appsec/listener/httpsec/request.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"net/http"
 	"net/netip"
+	"net/textproto"
 	"strings"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
@@ -75,9 +76,10 @@ var (
 	// These headers are tagged separately from defaultCollectedHeaders because
 	// they are collected even when AppSec is disabled.
 	securityTestingHeaders = [...]struct {
-		Header      string
-		HeaderBytes []byte
-		Tag         string
+		Header          string
+		HeaderCanonical string // net/http MIME-canonical form; filled at init
+		HeaderBytes     []byte
+		Tag             string
 	}{
 		{Header: securityTestingEndpointScanHeader, HeaderBytes: []byte(securityTestingEndpointScanHeader), Tag: securityTestingEndpointScanTag},
 		{Header: securityTestingHeader, HeaderBytes: []byte(securityTestingHeader), Tag: securityTestingTag},
@@ -147,7 +149,7 @@ func SecurityTestingHeaderTagValues(headers http.Header) ([2]string, [2]string, 
 	var tagValues [2]string
 	var count int
 	for _, h := range securityTestingHeaders {
-		values, ok := securityTestingHeaderValues(headers, h.Header)
+		values, ok := securityTestingHeaderValues(headers, h.HeaderCanonical)
 		if !ok {
 			continue
 		}
@@ -185,13 +187,16 @@ func SecurityTestingHeaderByteTagValues(visit func(func(key, value []byte))) ([2
 	return tagNames, tagValues, count
 }
 
-func securityTestingHeaderValues(headers http.Header, header string) ([]string, bool) {
-	for name, values := range headers {
-		if strings.EqualFold(name, header) {
-			return values, true
-		}
+// securityTestingHeaderValues looks up a header value by its MIME-canonical key.
+// Callers pass net/http-canonical header maps (StartRequestSpan, twirp, fiber's
+// http.Header.Add), so a direct map index is exact and avoids a full
+// case-insensitive scan of every header on the request hot path.
+func securityTestingHeaderValues(headers http.Header, canonicalHeader string) ([]string, bool) {
+	v := headers[canonicalHeader]
+	if len(v) == 0 {
+		return nil, false
 	}
-	return nil, false
+	return v, true
 }
 
 // Remove cookies from the request headers and return the map of headers
@@ -227,6 +232,13 @@ func normalizeHTTPHeaderValue(values []string) string {
 func init() {
 	makeCollectedHTTPHeadersLookupMap()
 	readMonitoredClientIPHeadersConfig()
+	makeSecurityTestingHeadersCanonical()
+}
+
+func makeSecurityTestingHeadersCanonical() {
+	for i := range securityTestingHeaders {
+		securityTestingHeaders[i].HeaderCanonical = textproto.CanonicalMIMEHeaderKey(securityTestingHeaders[i].Header)
+	}
 }
 
 func makeCollectedHTTPHeadersLookupMap() {

--- a/internal/appsec/listener/httpsec/request_test.go
+++ b/internal/appsec/listener/httpsec/request_test.go
@@ -10,6 +10,7 @@ import (
 	_ "embed" // For go:embed
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net"
 	"net/http"
 	"net/netip"
@@ -390,6 +391,58 @@ func TestTraceTagging(t *testing.T) {
 			op.Finish(httpsec.HandlerOperationRes{StatusCode: 200})
 
 			require.Subset(t, span.Tags, tc.ExpectedTags)
+		})
+	}
+}
+
+// BenchmarkSecurityTestingHeaderTagValues measures the hot-path cost of
+// scanning for security testing headers on every HTTP request.
+// The "absent" case represents real user traffic (headers never present);
+// the "present" case represents Datadog scan/test traffic.
+func BenchmarkSecurityTestingHeaderTagValues(b *testing.B) {
+	// Realistic ~20-header request without security testing headers.
+	baseHeaders := http.Header{
+		"Accept":            {"text/html,application/xhtml+xml"},
+		"Accept-Encoding":   {"gzip, deflate, br"},
+		"Accept-Language":   {"en-US,en;q=0.9"},
+		"Cache-Control":     {"no-cache"},
+		"Connection":        {"keep-alive"},
+		"Content-Type":      {"application/json"},
+		"Host":              {"example.com"},
+		"Pragma":            {"no-cache"},
+		"Referer":           {"https://example.com/"},
+		"User-Agent":        {"Mozilla/5.0 (compatible; BenchmarkBot/1.0)"},
+		"X-Forwarded-For":   {"1.2.3.4"},
+		"X-Real-Ip":         {"1.2.3.4"},
+		"X-Request-Id":      {"abc-123-def"},
+		"X-Forwarded-Host":  {"example.com"},
+		"X-Forwarded-Port":  {"443"},
+		"X-Forwarded-Proto": {"https"},
+		"X-Amzn-Trace-Id":   {"Root=1-abc-def"},
+		"Cf-Ray":            {"abc123-LAX"},
+		"Cf-Connecting-Ip":  {"1.2.3.4"},
+		"Via":               {"1.1 proxy.example.com"},
+	}
+
+	headersPresent := make(http.Header, len(baseHeaders)+2)
+	maps.Copy(headersPresent, baseHeaders)
+	headersPresent["X-Datadog-Endpoint-Scan"] = []string{"scan-uuid"}
+	headersPresent["X-Datadog-Security-Test"] = []string{"test-uuid"}
+
+	cases := []struct {
+		name    string
+		headers http.Header
+	}{
+		{"absent", baseHeaders},
+		{"present", headersPresent},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				SecurityTestingHeaderTagValues(tc.headers)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Backports the perf improvements from #5039 and #5040 into the v2.10.x
backport PR (#5019).

## Commits from #5039

- perf(appsec): replace EqualFold header scan with O(1) canonical map lookup

## Commits from #5040

- perf(instrumentation/httptrace): build http.url without strings.Join
- perf(internal/appsec/listener/httpsec): reduce allocations in ClientIP
- perf(ddtrace/tracer): replace fmt.Sprintf("%016x") with direct hex fill
- fix(internal/appsec/listener/httpsec): use strings.Cut in IP header scan
- refactor(ddtrace/tracer): reuse spanIDHexEncoded instead of uint64ToHex16
- style(ddtrace/tracer): fix trailing newline in textmap.go