### PR TITLE
fix(contrib/gofiber/fiber.v2): suppress fasthttp double-instrumentation on all listen paths

### DIFF
--- a/contrib/gofiber/fiber.v2/orchestrion.yml
+++ b/contrib/gofiber/fiber.v2/orchestrion.yml
@@ -9,6 +9,15 @@ meta:
   description: An Express inspired web framework built on Fasthttp, the fastest HTTP engine for Go.
 
 aspects:
+  # Wrap fiber.New so every App receives the Fiber tracing middleware, and mark
+  # the underlying fasthttp.Server as already instrumented at construction time.
+  #
+  # Setting DD_Instrumented here (rather than hooking a single listen method)
+  # prevents FastHTTP double-instrumentation on every startup path: Listen,
+  # Listener, ListenTLS, ListenTLSWithCertificate, ListenMutualTLS and their
+  # prefork variants all ultimately call app.Server().Serve(ln), and the FastHTTP
+  # Serve aspect skips wrapping when DD_Instrumented is set. The result is a
+  # single Fiber server span per request instead of a duplicate fasthttp span.
   - id: New
     join-point:
       function-call: github.com/gofiber/fiber/v2.New
@@ -21,19 +30,6 @@ aspects:
             func() *fiber.App {
               app := {{ . }}
               app.Use(fibertrace.Middleware())
+              app.Server().DD_Instrumented = true
               return app
             }()
-  # Prevent FastHTTP double-instrumentation by marking the underlying server
-  # as already instrumented before Fiber starts listening. This ensures that
-  # when Fiber's internal call to fasthttp.Server.Serve() happens, the
-  # DD_Instrumented flag is already set and the FastHTTP aspect will skip.
-  - id: Listen
-    join-point:
-      function-body:
-        function:
-          - receiver: '*github.com/gofiber/fiber/v2.App'
-          - name: Listen
-    advice:
-      - prepend-statements:
-          template: |
-            {{ .Function.Receiver }}.Server().DD_Instrumented = true

--- a/internal/orchestrion/_integration/fiber.v2/fiber.go
+++ b/internal/orchestrion/_integration/fiber.v2/fiber.go
@@ -62,31 +62,20 @@ func (tc *TestCase) ExpectedTraces() trace.Traces {
 			},
 			Children: trace.Traces{
 				{
-					// fasthttp server span (intermediate — fiber uses fasthttp internally)
+					// Single Fiber server span. The intermediate valyala/fasthttp span is
+					// suppressed by the gofiber orchestrion.yml aspect, which marks
+					// app.Server().DD_Instrumented at construction so the FastHTTP Serve
+					// aspect skips wrapping Fiber's internal fasthttp server.
 					Tags: map[string]any{
 						"name":     "http.request",
 						"resource": "GET /ping",
-						"service":  "fasthttp",
+						"service":  "fiber",
 						"type":     "web",
 					},
 					Meta: map[string]string{
-						"component": "valyala/fasthttp",
+						"http.url":  "/ping", // This is implemented incorrectly in the fiber.v2 dd-trace-go integration.
+						"component": "gofiber/fiber.v2",
 						"span.kind": "server",
-					},
-					Children: trace.Traces{
-						{
-							Tags: map[string]any{
-								"name":     "http.request",
-								"resource": "GET /ping",
-								"service":  "fiber",
-								"type":     "web",
-							},
-							Meta: map[string]string{
-								"http.url":  "/ping", // This is implemented incorrectly in the fiber.v2 dd-trace-go integration.
-								"component": "gofiber/fiber.v2",
-								"span.kind": "server",
-							},
-						},
 					},
 				},
 			},


### PR DESCRIPTION
### What does this PR do?

Makes the `gofiber/fiber.v2` Orchestrion integration emit a **single** Fiber server span per request on every server-startup path — not just `App.Listen(addr)`.

The double-instrumentation guard is moved out of a dedicated `Listen` aspect and into the existing `New` aspect: the underlying `fasthttp.Server` is marked `DD_Instrumented` at construction time, so the FastHTTP `Serve` aspect skips wrapping regardless of how the app is started.

- `contrib/gofiber/fiber.v2/orchestrion.yml` — fold `app.Server().DD_Instrumented = true` into the `New` aspect; remove the standalone `Listen` aspect.
- `internal/orchestrion/_integration/fiber.v2/fiber.go` — revert `ExpectedTraces` to the single Fiber span (drop the intermediate `valyala/fasthttp` span).

### Motivation / root cause

The guard added in #4162 only hooked `(*fiber.App).Listen`. But Fiber exposes several independent startup methods — `Listen`, `Listener`, `ListenTLS`, `ListenTLSWithCertificate`, `ListenMutualTLS`, and their prefork variants — and `Listen` does **not** delegate to the others; each calls `app.server.Serve(ln)` directly. So any app started via `Listener` / TLS / prefork never set `DD_Instrumented`, FastHTTP's `Serve` aspect wrapped Fiber's internal server, and the trace gained a duplicate `valyala/fasthttp` span nested under the Fiber span.

This has been latent since #4162 (v2.5.0). It surfaced in #5019, where the integration test switched from `App.Listen(addr)` to `App.Listener(ln)`. Discussion: https://github.com/DataDog/dd-trace-go/pull/5019#discussion_r3569009393

Fixing at construction mirrors the FastHTTP aspect's own "single choke point" design (it targets only `Serve()` precisely because every startup method funnels there). `fiber.New()` always calls `app.init()`, which creates `app.server`, so `app.Server()` is non-nil at `New` time; setting the flag there covers all current and future startup methods, including prefork children (which reconstruct the app via `New`).

### Testing

Ran the woven integration test locally:

```
go run github.com/DataDog/orchestrion go test ./fiber.v2/... -v
```

```
--- PASS: Test (0.40s)
PASS
ok  	github.com/DataDog/dd-trace-go/v2/internal/orchestrion/_integration/fiber.v2	1.543s
```

Confirms a single Fiber server span is now produced (2 total spans: HTTP client + Fiber server) instead of three (client + fasthttp + fiber).

### Backport

This is the upstream fix for the CI failure on #5019 (backport to `release-v2.10.x`). Once this merges, backport it; `release-v2.10.x` already asserts the single Fiber span, so no additional test edits are needed there.

### Reviewer's Checklist

- [ ] Add the appropriate team label so this lands in the right release-notes section (bug fix).
- [ ] Confirm the intended span topology (single Fiber span) with the tracing-semantics owners — this reverses the interim assertion change made during the inspectable-tracer work and assumes Fiber should not emit a separate fasthttp transport span.
- [ ] `golangci-lint run` clean.