### PR TITLE
ci(smoke-tests): broaden toolchain-corruption retry to GC heap crashes

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -85,19 +85,34 @@ jobs:
               go build $PACKAGES
             }
             log="$(mktemp)"
-            if ! compile 2>&1 | tee "$log"; then
-              # The restored GOCACHE/GOMODCACHE (actions/setup-go cache: true) can get
-              # transiently corrupted in transit to a given runner, surfacing as compiler
-              # ICEs or archive/zip checksum errors unrelated to any real code change.
-              # Clear both caches and retry once before failing the job for real.
-              if grep -qE 'internal compiler error|zip: checksum error|not the start of an archive file' "$log"; then
-                echo "::warning::Detected a Go build-cache corruption signature; clearing GOCACHE/GOMODCACHE and retrying once"
-                go clean -cache -modcache
-                compile
-              else
-                exit 1
-              fi
-            fi
+            # go1.26.5 (currently `stable`) intermittently corrupts its own heap mid-build:
+            # `fatal error: found pointer to free object` in the GC sweeper, faults, SIGSEGVs,
+            # and frontend ICEs (golang/go#77168). A crash can also leave partially written
+            # cache/module archives that later surface as zip/archive checksum errors. These
+            # are toolchain flakes, not real code breaks, so retry a few times and let a fresh
+            # compiler process dodge the probabilistic crash. A failure whose log matches none
+            # of the known signatures is a genuine break and fails immediately, without retry.
+            corruption_re='internal compiler error|zip: checksum error|not the start of an archive file|found pointer to free object|fatal error: fault|unexpected signal during runtime execution|signal SIGSEGV'
+            retry_on_corruption() {
+              local attempt=1 max=3
+              # The loop condition is a pipeline: exempt from `set -e` and, with pipefail,
+              # it reflects the wrapped command's real status (same idiom as `if ! compile | tee`).
+              until "$@" 2>&1 | tee "$log"; do
+                if [ "$attempt" -ge "$max" ] || ! grep -qE "$corruption_re" "$log"; then
+                  return 1
+                fi
+                echo "::warning::Go toolchain/cache corruption signature detected (attempt ${attempt}/${max}); clearing caches and retrying"
+                # The build cache is always rebuildable offline, so drop it every retry to
+                # discard partial artifacts a crashed compiler left behind. Only wipe the
+                # module cache on on-disk archive corruption, since refetching needs network.
+                go clean -cache || true
+                if grep -qE 'zip: checksum error|not the start of an archive file' "$log"; then
+                  go clean -modcache || true
+                fi
+                attempt=$((attempt + 1))
+              done
+            }
+            retry_on_corruption compile
 
       - name: Compute Matrix
         id: matrix
@@ -158,19 +173,28 @@ jobs:
               ./scripts/ci_test_contrib.sh smoke ${{ toJson(matrix.chunk) }}
             }
             log="$(mktemp)"
-            if ! run_smoke 2>&1 | tee "$log"; then
-              # See "Compile dd-trace-go with updated dependencies (sandboxed)" above:
-              # transient GOCACHE/GOMODCACHE corruption in the restored cache can
-              # surface as a compiler ICE or archive/zip checksum error. Retry once
-              # after a full cache clear before failing the job for real.
-              if grep -qE 'internal compiler error|zip: checksum error|not the start of an archive file' "$log"; then
-                echo "::warning::Detected a Go build-cache corruption signature; clearing GOCACHE/GOMODCACHE and retrying once"
-                go clean -cache -modcache
-                run_smoke
-              else
-                exit 1
-              fi
-            fi
+            # See "Compile dd-trace-go with updated dependencies (sandboxed)" above for why
+            # go1.26.5 (currently `stable`) intermittently corrupts its own heap mid-build
+            # (found pointer to free object / faults / SIGSEGVs / ICEs, golang/go#77168) and
+            # why these toolchain flakes are retried while genuine breaks fail immediately.
+            corruption_re='internal compiler error|zip: checksum error|not the start of an archive file|found pointer to free object|fatal error: fault|unexpected signal during runtime execution|signal SIGSEGV'
+            retry_on_corruption() {
+              local attempt=1 max=3
+              until "$@" 2>&1 | tee "$log"; do
+                if [ "$attempt" -ge "$max" ] || ! grep -qE "$corruption_re" "$log"; then
+                  return 1
+                fi
+                echo "::warning::Go toolchain/cache corruption signature detected (attempt ${attempt}/${max}); clearing caches and retrying"
+                # Build cache is rebuildable offline (drop every retry); wipe the module
+                # cache only on on-disk archive corruption, since refetching needs network.
+                go clean -cache || true
+                if grep -qE 'zip: checksum error|not the start of an archive file' "$log"; then
+                  go clean -modcache || true
+                fi
+                attempt=$((attempt + 1))
+              done
+            }
+            retry_on_corruption run_smoke
       - name: Stage sandbox artifacts outside workspace
         # Move the test results and coverage files to RUNNER_TEMP so the
         # next checkout (which wipes the workspace) does not delete them.


### PR DESCRIPTION
### What does this PR do?

Hardens the go1.26.5 build-cache/toolchain corruption retry in the two smoke-test jobs (`setup-env` and `go-get-u`), which pin `go-version: stable`. It:

- **Broadens the corruption signature.** Adds `found pointer to free object`, `fatal error: fault`, `unexpected signal during runtime execution`, and `signal SIGSEGV` to the existing `internal compiler error` / `zip: checksum error` / `not the start of an archive file` set.
- **Retries up to 3 attempts** (was a single retry) so a fresh, crash-free compiler process can win.
- **Clears caches precisely.** Drops only the always-rebuildable **build cache** on every retry; wipes the network-dependent **module cache** only when the failure is on-disk archive/zip corruption.
- Keeps the fail-fast contract: a failure whose log matches **none** of the signatures is treated as a genuine break and fails immediately, without retry.

Both jobs now share an identical `retry_on_corruption <fn>` harness (wrapping `compile` and `run_smoke` respectively).

### Motivation

The `setup-env` and `go-get-u` jobs pin `go-version: stable`, which currently resolves to **go1.26.5**. That toolchain intermittently corrupts its own heap mid-build — `fatal error: found pointer to free object` in the GC sweeper (`reportZombies` during `procresize`/`startTheWorldWithSema`), faults, and SIGSEGVs — in addition to the frontend ICEs already handled by #5012. Because it's probabilistic, **Smoke Tests on `main` flip green/red run-to-run on identical code** (e.g. 2026-07-20: 11:04 ✅, 11:07 ❌, 11:14 ✅, 13:21 ❌).

The retry added in #5012 was insufficient against this failure mode:
1. **Signature gap** — its grep didn't match `found pointer to free object` / `fatal error: fault`, so a run dominated by GC-corruption crashes got *no* retry at all.
2. **Wrong/insufficient remedy** — a single `go clean -cache -modcache` + one retry can't fix an in-memory crash; it re-ran the same broken toolchain once and failed again ([run 29737411119](https://github.com/DataDog/dd-trace-go/actions/runs/29737411119): retry fired 11:21:57, job still exited 1 at 11:24:42).

Upstream: [golang/go#77168](https://github.com/golang/go/issues/77168). This is a stopgap to keep `stable` coverage while absorbing the flake until a fixed Go patch release lands.

Follow-up to #5012.

### Reviewer's Checklist

- [ ] New code is free of linting errors — validated with `actionlint` (exit 0); the retry harness was checked with `bash -n` and unit-tested across success / genuine-break / recover-on-retry / never-recover paths under `set -euo pipefail`.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.

_Note: no unit-test/benchmark/system-test/generate/go.mod items apply — this is a CI-workflow-only change._