### PR TITLE
ci: harden Go toolchain operations against transient corruption

### DIFF
--- a/.github/workflows/apps/go-retry.sh
+++ b/.github/workflows/apps/go-retry.sh
@@ -1,11 +1,13 @@
 # shellcheck shell=bash
 # go-retry.sh — retry a command when its output shows Go toolchain/cache corruption.
 #
-# Mirrors retry_on_corruption in .github/workflows/smoke-tests.yml. go1.26.5 can corrupt its
-# heap mid-build and leave partial cache/module archives that resurface as zip/archive checksum
-# errors; a "zip: checksum error" during install/download is the same transient class. Retry
-# those; fail fast on anything else — govulncheck exit 3 (vulnerabilities found) never matches
-# the signature and so is never retried.
+# go1.26.5 (currently `stable`) intermittently corrupts its own heap mid-build (fatal errors,
+# faults, SIGSEGVs, frontend ICEs — golang/go#77168) and a crash can leave partially written
+# cache/module archives that later surface as zip/archive checksum errors, e.g. a
+# "zip: checksum error" during `go install`/`go get`/`go build`. These are toolchain flakes, not
+# real breaks, so retry a few times and let a fresh process dodge the probabilistic crash. Fail
+# fast on anything else — e.g. govulncheck exit 3 (vulnerabilities found) never matches the
+# signature and so is never retried. Shared by smoke-tests.yml and govulncheck*.{yml,sh}.
 #
 # Usage:
 #   source go-retry.sh

--- a/.github/workflows/apps/go-retry.sh
+++ b/.github/workflows/apps/go-retry.sh
@@ -9,6 +9,14 @@
 # fast on anything else — e.g. govulncheck exit 3 (vulnerabilities found) never matches the
 # signature and so is never retried. Shared by smoke-tests.yml and govulncheck*.{yml,sh}.
 #
+# Both caches are wiped on every retry, unconditionally: a crash that corrupts an on-disk module
+# archive can itself surface as an unrelated symptom (e.g. a SIGSEGV mid-extraction) on the
+# attempt that causes the corruption, with the tell-tale "zip: checksum error" only appearing on
+# a later attempt once something finally tries to read the already-corrupted file. Gating the
+# modcache wipe on the current attempt's log matching an archive-error string missed that case —
+# module extraction crashed silently by the affected package in one job, then failed all
+# remaining retries because none of them cleared the modcache.
+#
 # Usage:
 #   source go-retry.sh
 #   retry_on_corruption <cmd> [args...]                  # output streams to the caller as-is
@@ -26,12 +34,10 @@ retry_on_corruption() {
       rm -f "$log"; return 1
     fi
     echo "::warning::Go toolchain/cache corruption signature detected (attempt ${attempt}/${max}); clearing caches and retrying"
-    # Build cache is rebuildable offline (drop every retry); wipe the module cache only on
-    # on-disk archive corruption, since refetching it needs network.
+    # Both caches are rebuildable from network/source, so wipe them unconditionally on every
+    # retry rather than gating the modcache wipe on this attempt's log (see file header).
     go clean -cache || true
-    if grep -qE 'zip: checksum error|not the start of an archive file' "$log"; then
-      go clean -modcache || true
-    fi
+    go clean -modcache || true
     attempt=$((attempt + 1))
   done
   cat "$log" >&2
@@ -51,9 +57,7 @@ retry_on_corruption_to_file() {
     fi
     echo "::warning::Go toolchain/cache corruption signature detected (attempt ${attempt}/${max}); clearing caches and retrying"
     go clean -cache || true
-    if grep -qE 'zip: checksum error|not the start of an archive file' "$log"; then
-      go clean -modcache || true
-    fi
+    go clean -modcache || true
     attempt=$((attempt + 1))
   done
   cat "$log" >&2

--- a/.github/workflows/apps/go-retry.sh
+++ b/.github/workflows/apps/go-retry.sh
@@ -1,0 +1,59 @@
+# shellcheck shell=bash
+# go-retry.sh — retry a command when its output shows Go toolchain/cache corruption.
+#
+# Mirrors retry_on_corruption in .github/workflows/smoke-tests.yml. go1.26.5 can corrupt its
+# heap mid-build and leave partial cache/module archives that resurface as zip/archive checksum
+# errors; a "zip: checksum error" during install/download is the same transient class. Retry
+# those; fail fast on anything else — govulncheck exit 3 (vulnerabilities found) never matches
+# the signature and so is never retried.
+#
+# Usage:
+#   source go-retry.sh
+#   retry_on_corruption <cmd> [args...]                  # output streams to the caller as-is
+#   retry_on_corruption_to_file <outfile> <cmd> [args...] # <cmd>'s stdout is captured to <outfile>
+corruption_re='internal compiler error|zip: checksum error|not the start of an archive file|found pointer to free object|fatal error: fault|unexpected signal during runtime execution|signal SIGSEGV'
+
+retry_on_corruption() {
+  local attempt=1 max="${RETRY_MAX_ATTEMPTS:-3}"
+  local log; log="$(mktemp)"
+  # stdout streams straight to the caller (preserves interleaving with the job log); stderr is
+  # captured for signature matching, then echoed back so nothing is lost from the logs.
+  until "$@" 2>"$log"; do
+    cat "$log" >&2
+    if [ "$attempt" -ge "$max" ] || ! grep -qE "$corruption_re" "$log"; then
+      rm -f "$log"; return 1
+    fi
+    echo "::warning::Go toolchain/cache corruption signature detected (attempt ${attempt}/${max}); clearing caches and retrying"
+    # Build cache is rebuildable offline (drop every retry); wipe the module cache only on
+    # on-disk archive corruption, since refetching it needs network.
+    go clean -cache || true
+    if grep -qE 'zip: checksum error|not the start of an archive file' "$log"; then
+      go clean -modcache || true
+    fi
+    attempt=$((attempt + 1))
+  done
+  cat "$log" >&2
+  rm -f "$log"
+}
+
+retry_on_corruption_to_file() {
+  local outfile="$1"; shift
+  local attempt=1 max="${RETRY_MAX_ATTEMPTS:-3}"
+  local log; log="$(mktemp)"
+  # Redirecting stdout to "$outfile" here (inside the loop condition) reopens and truncates it on
+  # every attempt, so a failed first attempt never leaves partial output for a retry to append to.
+  until "$@" >"$outfile" 2>"$log"; do
+    cat "$log" >&2
+    if [ "$attempt" -ge "$max" ] || ! grep -qE "$corruption_re" "$log"; then
+      rm -f "$log"; return 1
+    fi
+    echo "::warning::Go toolchain/cache corruption signature detected (attempt ${attempt}/${max}); clearing caches and retrying"
+    go clean -cache || true
+    if grep -qE 'zip: checksum error|not the start of an archive file' "$log"; then
+      go clean -modcache || true
+    fi
+    attempt=$((attempt + 1))
+  done
+  cat "$log" >&2
+  rm -f "$log"
+}

--- a/.github/workflows/apps/govulncheck-contribs-sarif.sh
+++ b/.github/workflows/apps/govulncheck-contribs-sarif.sh
@@ -9,6 +9,10 @@ set -euo pipefail
 #
 # Requires: govulncheck, jq
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/workflows/apps/go-retry.sh
+source "${SCRIPT_DIR}/go-retry.sh"
+
 OUTPUT="${1:-govulncheck-contribs.sarif}"
 SARIF_DIR=$(mktemp -d)
 trap 'rm -rf "$SARIF_DIR"' EXIT
@@ -30,7 +34,7 @@ grep -E '^\s+\./contrib/' go.work | awk '{print $1}' | while read -r dir; do
 
   safe_name=$(printf '%s' "$module_dir" | tr '/' '_')
   # -format sarif exits 0 even when vulnerabilities are found.
-  govulncheck -format sarif -C "$dir" . >"$SARIF_DIR/${safe_name}.sarif"
+  retry_on_corruption_to_file "$SARIF_DIR/${safe_name}.sarif" govulncheck -format sarif -C "$dir" .
 
   # Rewrite URIs to be repo-root-relative so Code Scanning annotations resolve
   # correctly. govulncheck emits paths relative to the module dir with

--- a/.github/workflows/apps/govulncheck-contribs-v2.sh
+++ b/.github/workflows/apps/govulncheck-contribs-v2.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/workflows/apps/go-retry.sh
+source "${SCRIPT_DIR}/go-retry.sh"
+
 # Use go.work as the authoritative module list — avoids nested test go.mod files.
 grep -E '^\s+\./contrib/' go.work | awk '{print $1}' | while read -r dir; do
   echo "Checking $dir"
@@ -7,5 +11,5 @@ grep -E '^\s+\./contrib/' go.work | awk '{print $1}' | while read -r dir; do
   go_files=$(find $dir -maxdepth 1 -type f -name '*.go' | wc -l)
   [[ $go_files -eq 0 ]] && dir=$(realpath "$(ls -d $dir/*/ | head)")
 
-  govulncheck -C $dir .
+  retry_on_corruption govulncheck -C $dir .
 done

--- a/.github/workflows/apps/govulncheck-fix.sh
+++ b/.github/workflows/apps/govulncheck-fix.sh
@@ -14,6 +14,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/workflows/apps/go-retry.sh
+source "${SCRIPT_DIR}/go-retry.sh"
+
 FIXES_FILE=$(mktemp)
 readonly FIXES_FILE
 GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
@@ -42,9 +46,11 @@ parse_findings() {
 
 # ── Scan core packages ─────────────────────────────────────────────────────────
 echo "==> Scanning core packages..."
-govulncheck -json \
-  ./ddtrace/... ./appsec/... ./profiler/... ./internal/... ./instrumentation/... \
-  2>/dev/null | parse_findings >> "${FIXES_FILE}" || true
+raw=$(mktemp)
+retry_on_corruption_to_file "${raw}" govulncheck -json \
+  ./ddtrace/... ./appsec/... ./profiler/... ./internal/... ./instrumentation/... || true
+parse_findings < "${raw}" >> "${FIXES_FILE}" || true
+rm -f "${raw}"
 
 # ── Scan contrib modules ───────────────────────────────────────────────────────
 echo "==> Scanning contrib modules..."
@@ -56,7 +62,10 @@ while IFS= read -r -d '' gomod; do
   [[ "${go_files}" -eq 0 ]] && dir=$(realpath "$(find "${dir}" -mindepth 1 -maxdepth 1 -type d | head -1)")
 
   echo "  Checking ${dir}"
-  govulncheck -C "${dir}" -json . 2>/dev/null | parse_findings >> "${FIXES_FILE}" || true
+  raw=$(mktemp)
+  retry_on_corruption_to_file "${raw}" govulncheck -C "${dir}" -json . || true
+  parse_findings < "${raw}" >> "${FIXES_FILE}" || true
+  rm -f "${raw}"
 done < <(find ./contrib -mindepth 2 -type f -name go.mod -print0)
 
 # ── Check for fixes ────────────────────────────────────────────────────────────

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -102,7 +102,9 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         env:
           GOMODCACHE: ${{ github.workspace }}/${{ steps.cfg.outputs.path }}
-        run: go mod download -x
+        run: |
+          source ./.github/workflows/apps/go-retry.sh
+          retry_on_corruption go mod download -x
 
 
   macos:
@@ -138,7 +140,8 @@ jobs:
       - name: Setup testing environment
         run: |-
           mkdir -p "tmp_appsec"
-          go install gotest.tools/gotestsum@latest
+          source ./.github/workflows/apps/go-retry.sh
+          retry_on_corruption go install gotest.tools/gotestsum@latest
 
       # go test is being manually called multiple times here for the sake of reusing the runner.
       # Waiting runners is unfortunately so long that we decided to do so for things only requiring recompilation or
@@ -254,9 +257,11 @@ jobs:
         if: runner.os != 'Windows'
 
       - name: Setup testing environment
+        shell: bash
         run: |-
           mkdir -p "tmp_appsec"
-          go install gotest.tools/gotestsum@latest
+          source ./.github/workflows/apps/go-retry.sh
+          retry_on_corruption go install gotest.tools/gotestsum@latest
 
       - name: go test
         shell: bash
@@ -363,7 +368,10 @@ jobs:
       - name: Setup testing environment
         run: |-
           mkdir -p "tmp_appsec"
-          sudo docker exec -i test.runner go install gotest.tools/gotestsum@latest
+          # go-retry.sh is bind-mounted into the container at the same path (-v "$PWD:$PWD" -w "$PWD"
+          # above), so it can be sourced from inside via `docker exec` for the same corruption-retry
+          # protection as the host-side install steps.
+          sudo docker exec -i test.runner bash -c 'source ./.github/workflows/apps/go-retry.sh && retry_on_corruption go install gotest.tools/gotestsum@latest'
 
       - name: NOCGO, undefined appsec state
         run: |

--- a/.github/workflows/govulncheck-fix.yml
+++ b/.github/workflows/govulncheck-fix.yml
@@ -21,7 +21,9 @@ jobs:
           go-version: stable
           cache-dependency-path: '**/go.sum'
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: |
+          source ./.github/workflows/apps/go-retry.sh
+          retry_on_corruption go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Scan and fix vulnerabilities
         id: fix
         run: ./.github/workflows/apps/govulncheck-fix.sh

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -77,9 +77,9 @@ jobs:
       - name: Run govulncheck (OpenVEX)
         if: always()
         run: |-
-          govulncheck -format openvex \
-            ./ddtrace/... ./appsec/... ./profiler/... ./internal/... ./instrumentation/... \
-            > govulncheck-raw.vex || true
+          source ./.github/workflows/apps/go-retry.sh
+          retry_on_corruption_to_file govulncheck-raw.vex govulncheck -format openvex \
+            ./ddtrace/... ./appsec/... ./profiler/... ./internal/... ./instrumentation/... || true
       - name: Patch OpenVEX author and product
         if: always() && hashFiles('govulncheck-raw.vex') != ''
         run: |-
@@ -125,7 +125,8 @@ jobs:
           persist-workspace-changes: 'true'
           run: |-
             mkdir -p "${GITHUB_WORKSPACE}/bin"
-            GOBIN="${GITHUB_WORKSPACE}/bin" go install golang.org/x/vuln/cmd/govulncheck@latest
+            source ./.github/workflows/apps/go-retry.sh
+            retry_on_corruption env GOBIN="${GITHUB_WORKSPACE}/bin" go install golang.org/x/vuln/cmd/govulncheck@latest
             export PATH="${GITHUB_WORKSPACE}/bin:${PATH}"
             ./.github/workflows/apps/govulncheck-contribs-sarif.sh govulncheck-contribs.sarif
       - name: Restore workspace after sandbox
@@ -163,7 +164,8 @@ jobs:
         with:
           run: |
             mkdir -p "${GITHUB_WORKSPACE}/bin"
-            GOBIN="${GITHUB_WORKSPACE}/bin" go install golang.org/x/vuln/cmd/govulncheck@latest
+            source ./.github/workflows/apps/go-retry.sh
+            retry_on_corruption env GOBIN="${GITHUB_WORKSPACE}/bin" go install golang.org/x/vuln/cmd/govulncheck@latest
             export PATH="${GITHUB_WORKSPACE}/bin:${PATH}"
-            govulncheck ./ddtrace/... ./appsec/... ./profiler/... ./internal/... ./instrumentation/...
+            retry_on_corruption govulncheck ./ddtrace/... ./appsec/... ./profiler/... ./internal/... ./instrumentation/...
             ./.github/workflows/apps/govulncheck-contribs-v2.sh

--- a/.github/workflows/orchestrion.yml
+++ b/.github/workflows/orchestrion.yml
@@ -171,7 +171,10 @@ jobs:
         # `go` directive is correctly managed.
         shell: bash
         run: |-
-          source ${{ github.workspace }}/dd-trace-go/.github/workflows/apps/go-retry.sh
+          # Relative to working-directory (.../dd-trace-go/internal/orchestrion/_integration): a
+          # path built from ${{ github.workspace }} would be backslash-separated on Windows and
+          # get mangled by bash's unquoted escape processing, so use a portable relative path.
+          source ../../../.github/workflows/apps/go-retry.sh
           go mod edit -replace="github.com/DataDog/orchestrion=${{ github.workspace }}/orchestrion"
           retry_on_corruption go mod tidy
         working-directory: ${{ github.workspace }}/dd-trace-go/internal/orchestrion/_integration
@@ -182,14 +185,14 @@ jobs:
         if: '!inputs.collect-coverage'
         shell: bash
         run: |-
-          source ${{ github.workspace }}/dd-trace-go/.github/workflows/apps/go-retry.sh
+          source ../../../.github/workflows/apps/go-retry.sh
           retry_on_corruption go install "github.com/DataDog/orchestrion"
         working-directory: ${{ github.workspace }}/dd-trace-go/internal/orchestrion/_integration
       - name: Build orchestrion binary
         if: inputs.collect-coverage
         shell: bash
         run: |-
-          source ${{ github.workspace }}/dd-trace-go/.github/workflows/apps/go-retry.sh
+          source ../../../.github/workflows/apps/go-retry.sh
           bin=$(go env GOPATH)/bin/orchestrion
           if [[ '${{ matrix.runs-on }}' == 'windows' ]]; then
             bin="${bin}.exe"
@@ -208,7 +211,7 @@ jobs:
       - name: Run 'go mod tidy'
         shell: bash
         run: |-
-          source ${{ github.workspace }}/dd-trace-go/.github/workflows/apps/go-retry.sh
+          source ../../../.github/workflows/apps/go-retry.sh
           retry_on_corruption go mod tidy
         working-directory: ${{ github.workspace }}/dd-trace-go/internal/orchestrion/_integration
 

--- a/.github/workflows/orchestrion.yml
+++ b/.github/workflows/orchestrion.yml
@@ -169,27 +169,36 @@ jobs:
         # release without requiring coordination with the other. It also adds
         # the local checkout of orchestrion to the `go.work` so that its own
         # `go` directive is correctly managed.
+        shell: bash
         run: |-
+          source ${{ github.workspace }}/dd-trace-go/.github/workflows/apps/go-retry.sh
           go mod edit -replace="github.com/DataDog/orchestrion=${{ github.workspace }}/orchestrion"
-          go mod tidy
+          retry_on_corruption go mod tidy
         working-directory: ${{ github.workspace }}/dd-trace-go/internal/orchestrion/_integration
         env:
           VERSION: ${{ inputs.orchestrion-version }}
       # We install the binary to the GOBIN, so it's easy to use
       - name: Install orchestrion binary
         if: '!inputs.collect-coverage'
-        run: go install "github.com/DataDog/orchestrion"
+        shell: bash
+        run: |-
+          source ${{ github.workspace }}/dd-trace-go/.github/workflows/apps/go-retry.sh
+          retry_on_corruption go install "github.com/DataDog/orchestrion"
         working-directory: ${{ github.workspace }}/dd-trace-go/internal/orchestrion/_integration
       - name: Build orchestrion binary
         if: inputs.collect-coverage
         shell: bash
         run: |-
+          source ${{ github.workspace }}/dd-trace-go/.github/workflows/apps/go-retry.sh
           bin=$(go env GOPATH)/bin/orchestrion
           if [[ '${{ matrix.runs-on }}' == 'windows' ]]; then
             bin="${bin}.exe"
           fi
           mkdir -p "$(dirname "${bin}")"
-          go build -cover -covermode=atomic -coverpkg="github.com/DataDog/orchestrion/..." "-o=${bin}" "github.com/DataDog/orchestrion"
+          build_orchestrion() {
+            go build -cover -covermode=atomic -coverpkg="github.com/DataDog/orchestrion/..." "-o=${bin}" "github.com/DataDog/orchestrion"
+          }
+          retry_on_corruption build_orchestrion
           echo "GOCOVERDIR=$(mktemp -d)" >> "${GITHUB_ENV}"
         working-directory: ${{ github.workspace }}/dd-trace-go/internal/orchestrion/_integration
 
@@ -197,7 +206,10 @@ jobs:
       # have been dependecy updates on the `main` branch, the `go.mod` and `go.sum` files for the
       # integration test suite may no longer be up-to-date.
       - name: Run 'go mod tidy'
-        run: go mod tidy
+        shell: bash
+        run: |-
+          source ${{ github.workspace }}/dd-trace-go/.github/workflows/apps/go-retry.sh
+          retry_on_corruption go mod tidy
         working-directory: ${{ github.workspace }}/dd-trace-go/internal/orchestrion/_integration
 
       # Pull docker images ahead of time so the pulls of large images don't have to fit within the

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -69,10 +69,10 @@ jobs:
           run: |-
             mkdir -p "$TEST_RESULTS"
             compile() {
-              # `!` and pipelines suspend -e for the commands they wrap, including
-              # inside this function's body (see `if ! compile | tee`, below) — a
-              # failed step here would otherwise go unnoticed as long as the final
-              # `go build` happens to still succeed. Propagate each failure explicitly.
+              # `until` conditions (see retry_on_corruption in go-retry.sh) suspend `-e` for
+              # the commands they wrap, including inside this function's body — a failed step
+              # here would otherwise go unnoticed as long as the final `go build` happens to
+              # still succeed. Propagate each failure explicitly.
               # shellcheck disable=SC2086
               go get -u -t $PACKAGES || return
               go mod tidy || return
@@ -84,34 +84,10 @@ jobs:
               # shellcheck disable=SC2086
               go build $PACKAGES
             }
-            log="$(mktemp)"
-            # go1.26.5 (currently `stable`) intermittently corrupts its own heap mid-build:
-            # `fatal error: found pointer to free object` in the GC sweeper, faults, SIGSEGVs,
-            # and frontend ICEs (golang/go#77168). A crash can also leave partially written
-            # cache/module archives that later surface as zip/archive checksum errors. These
-            # are toolchain flakes, not real code breaks, so retry a few times and let a fresh
-            # compiler process dodge the probabilistic crash. A failure whose log matches none
-            # of the known signatures is a genuine break and fails immediately, without retry.
-            corruption_re='internal compiler error|zip: checksum error|not the start of an archive file|found pointer to free object|fatal error: fault|unexpected signal during runtime execution|signal SIGSEGV'
-            retry_on_corruption() {
-              local attempt=1 max=3
-              # The loop condition is a pipeline: exempt from `set -e` and, with pipefail,
-              # it reflects the wrapped command's real status (same idiom as `if ! compile | tee`).
-              until "$@" 2>&1 | tee "$log"; do
-                if [ "$attempt" -ge "$max" ] || ! grep -qE "$corruption_re" "$log"; then
-                  return 1
-                fi
-                echo "::warning::Go toolchain/cache corruption signature detected (attempt ${attempt}/${max}); clearing caches and retrying"
-                # The build cache is always rebuildable offline, so drop it every retry to
-                # discard partial artifacts a crashed compiler left behind. Only wipe the
-                # module cache on on-disk archive corruption, since refetching needs network.
-                go clean -cache || true
-                if grep -qE 'zip: checksum error|not the start of an archive file' "$log"; then
-                  go clean -modcache || true
-                fi
-                attempt=$((attempt + 1))
-              done
-            }
+            # See go-retry.sh for why toolchain/cache corruption is retried instead of failing
+            # the job outright, and why a failure with none of the known signatures is treated
+            # as a genuine break and fails immediately, without retry.
+            source ./.github/workflows/apps/go-retry.sh
             retry_on_corruption compile
 
       - name: Compute Matrix
@@ -172,28 +148,10 @@ jobs:
             run_smoke() {
               ./scripts/ci_test_contrib.sh smoke ${{ toJson(matrix.chunk) }}
             }
-            log="$(mktemp)"
-            # See "Compile dd-trace-go with updated dependencies (sandboxed)" above for why
-            # go1.26.5 (currently `stable`) intermittently corrupts its own heap mid-build
-            # (found pointer to free object / faults / SIGSEGVs / ICEs, golang/go#77168) and
-            # why these toolchain flakes are retried while genuine breaks fail immediately.
-            corruption_re='internal compiler error|zip: checksum error|not the start of an archive file|found pointer to free object|fatal error: fault|unexpected signal during runtime execution|signal SIGSEGV'
-            retry_on_corruption() {
-              local attempt=1 max=3
-              until "$@" 2>&1 | tee "$log"; do
-                if [ "$attempt" -ge "$max" ] || ! grep -qE "$corruption_re" "$log"; then
-                  return 1
-                fi
-                echo "::warning::Go toolchain/cache corruption signature detected (attempt ${attempt}/${max}); clearing caches and retrying"
-                # Build cache is rebuildable offline (drop every retry); wipe the module
-                # cache only on on-disk archive corruption, since refetching needs network.
-                go clean -cache || true
-                if grep -qE 'zip: checksum error|not the start of an archive file' "$log"; then
-                  go clean -modcache || true
-                fi
-                attempt=$((attempt + 1))
-              done
-            }
+            # See "Compile dd-trace-go with updated dependencies (sandboxed)" above and
+            # go-retry.sh for why toolchain/cache corruption is retried while genuine breaks
+            # fail immediately.
+            source ./.github/workflows/apps/go-retry.sh
             retry_on_corruption run_smoke
       - name: Stage sandbox artifacts outside workspace
         # Move the test results and coverage files to RUNNER_TEMP so the

--- a/scripts/apidiff.sh
+++ b/scripts/apidiff.sh
@@ -5,6 +5,10 @@
 # Copyright 2025 Datadog, Inc.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/workflows/apps/go-retry.sh
+source "${SCRIPT_DIR}/../.github/workflows/apps/go-retry.sh"
+
 # apidiff.sh — compare the public API of Go packages between a base git ref
 # and the current working tree using golang.org/x/exp/cmd/apidiff.
 #
@@ -117,7 +121,10 @@ git -C "${REPO_ROOT}" worktree add --detach --quiet "${WORKTREE_DIR}" "${BASE_RE
 # Download module dependencies in the base worktree so apidiff can type-check
 (
   cd "${WORKTREE_DIR}"
-  GOWORK=off go mod download -x 2> /dev/null || go mod download
+  download_base_deps() {
+    GOWORK=off go mod download -x 2> /dev/null || go mod download
+  }
+  retry_on_corruption download_base_deps
 )
 
 # Compare each package

--- a/scripts/checklocks.sh
+++ b/scripts/checklocks.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/workflows/apps/go-retry.sh
+source "${SCRIPT_DIR}/../.github/workflows/apps/go-retry.sh"
+
 CHECKLOCKS_PACKAGE="${CHECKLOCKS_PACKAGE:-gvisor.dev/gvisor/tools/checklocks/cmd/checklocks@go}"
 CHECKLOCKS_BIN="${CHECKLOCKS_BIN:-}"
 IGNORE_ERRORS=false
@@ -74,7 +78,7 @@ else # Check if checklocks tool exists in standard location, install if not
   if [ ! -f "$CHECKLOCKS_PATH" ]; then
     echo "Installing checklocks tool from $CHECKLOCKS_PACKAGE..."
     pushd /tmp
-    go install "$CHECKLOCKS_PACKAGE"
+    retry_on_corruption go install "$CHECKLOCKS_PACKAGE"
     popd
     echo "checklocks installed at $CHECKLOCKS_PATH"
   fi

--- a/scripts/ci_test_contrib.sh
+++ b/scripts/ci_test_contrib.sh
@@ -6,6 +6,10 @@ set +e
 # It is run by the GitHub Actions CI workflow defined in
 # .github/workflows/unit-integration-tests.yml.
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/workflows/apps/go-retry.sh
+source "${SCRIPT_DIR}/../.github/workflows/apps/go-retry.sh"
+
 [[ -d ./contrib ]] || exit 0
 
 BUILD_TAGS="${BUILD_TAGS:-}"
@@ -38,20 +42,20 @@ for contrib in $CONTRIBS; do
   contrib_id=$(echo "$contrib" | sed 's/^\.\///g;s/[\/\.]/_/g')
   cd "$contrib" || exit 1
   if [[ "$1" = "smoke" ]]; then
-    go get -u -t ./...
+    retry_on_corruption go get -u -t ./...
   fi
   if [[ "$1" = "smoke" && "$contrib" = "./contrib/k8s.io/client-go/" ]]; then
     # This is a temporary workaround due to this issue in apimachinery: https://github.com/kubernetes/apimachinery/issues/190
     # When the issue is resolved, this line can be removed.
-    go get k8s.io/kube-openapi@v0.0.0-20250628140032-d90c4fd18f59
+    retry_on_corruption go get k8s.io/kube-openapi@v0.0.0-20250628140032-d90c4fd18f59
     # Another temporary workaround caused by the upgrade introduced by this commit: https://github.com/kubernetes/client-go/commit/f4d210639bbc61f2f2a8596662d7ad50abaa6544
-    go get k8s.io/client-go@v0.35.0
+    retry_on_corruption go get k8s.io/client-go@v0.35.0
   fi
   if [[ "$1" = "smoke" && "$contrib" = "./contrib/gin-gonic/gin/" ]]; then
     # Temporary workaround, see: https://github.com/gin-gonic/gin/issues/4441
-    go get github.com/quic-go/qpack@v0.5.1
+    retry_on_corruption go get github.com/quic-go/qpack@v0.5.1
   fi
-  go mod tidy
+  retry_on_corruption go mod tidy
   gotestsum --junitfile "${TEST_RESULTS}/gotestsum-report-$contrib_id.xml" -- ./... -v -race "$TAGS_ARG" -coverprofile="coverage-$contrib_id.txt" -covermode=atomic
   test_exit=$?
   [[ $test_exit -ne 0 ]] && report_error=1
@@ -62,11 +66,11 @@ for mod in $INSTRUMENTATION_SUBMODULES; do
   echo "Testing instrumentation submodule: $mod"
   mod_id=$(echo "$mod" | sed 's/^\.\///g;s/[\/\.]/_/g')
   cd "$mod" || exit 1
-  [[ "$1" = "smoke" ]] && go get -u -t ./...
+  [[ "$1" = "smoke" ]] && retry_on_corruption go get -u -t ./...
   if [[ "$1" = "smoke" && "$contrib" = "./contrib/k8s.io/client-go/" ]]; then
     # This is a temporary workaround due to this issue in apimachinery: https://github.com/kubernetes/apimachinery/issues/190
     # When the issue is resolved, this line can be removed.
-    go get k8s.io/kube-openapi@v0.0.0-20250628140032-d90c4fd18f59
+    retry_on_corruption go get k8s.io/kube-openapi@v0.0.0-20250628140032-d90c4fd18f59
   fi
   gotestsum --junitfile "${TEST_RESULTS}/gotestsum-report-$mod_id.xml" -- ./... -v -race "$TAGS_ARG" -coverprofile="coverage-$mod_id.txt" -covermode=atomic
   test_exit=$?

--- a/scripts/cross_build.sh
+++ b/scripts/cross_build.sh
@@ -13,6 +13,10 @@
 # skipped (nothing to build, and they error when passed explicitly to go build).
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/workflows/apps/go-retry.sh
+source "${SCRIPT_DIR}/../.github/workflows/apps/go-retry.sh"
+
 # First-class ports: https://go.dev/wiki/PortingPolicy
 platforms=(
   linux/386 linux/amd64 linux/arm linux/arm64
@@ -32,7 +36,7 @@ echo "Cross-compiling ${#pkgs[@]} package(s) across ${#platforms[@]} port(s)"
 
 rc=0
 for p in "${platforms[@]}"; do
-  if GOOS="${p%/*}" GOARCH="${p#*/}" CGO_ENABLED=0 go build "${pkgs[@]}"; then
+  if GOOS="${p%/*}" GOARCH="${p#*/}" CGO_ENABLED=0 retry_on_corruption go build "${pkgs[@]}"; then
     echo "ok   $p"
   else
     echo "FAIL $p"

--- a/scripts/fix_modules.sh
+++ b/scripts/fix_modules.sh
@@ -2,15 +2,19 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/workflows/apps/go-retry.sh
+source "${SCRIPT_DIR}/../.github/workflows/apps/go-retry.sh"
+
 # This scripts runs go mod tidy on all the go modules of the repo, and additionally it adds missing replace directives
 # for local imports.
 
-go run -tags=scripts ./scripts/fixmodules -root=. .
+retry_on_corruption go run -tags=scripts ./scripts/fixmodules -root=. .
 
 while IFS= read -r -d '' f; do
   (
     cd "$(dirname "$f")" || exit 1
-    go mod tidy
+    retry_on_corruption go mod tidy
   )
 done < <(find . -name go.mod -print0)
 

--- a/scripts/install_tools.sh
+++ b/scripts/install_tools.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/workflows/apps/go-retry.sh
+source "${SCRIPT_DIR}/../.github/workflows/apps/go-retry.sh"
+
 # message: Prints a message to the console with a timestamp and prefix.
 message() {
   local msg="$1"
@@ -94,11 +98,25 @@ BIN_DIR_ABS=$(cd "$BIN_DIR" && pwd 2> /dev/null || echo "$(pwd)/$BIN_DIR")
 
 # Download dependencies
 message "Downloading tool dependencies..."
-run "cd \"$TOOLS_DIR_ABS\" && GOWORK=$GOWORK go mod download"
+download_tool_deps() {
+  cd "$TOOLS_DIR_ABS" && GOWORK=$GOWORK go mod download
+}
+if ! retry_on_corruption download_tool_deps; then
+  message "Command failed: go mod download"
+  exit 1
+fi
+message "Command ran successfully: go mod download"
 
 # Install tools
 message "Installing tools to $BIN_DIR_ABS..."
-run "cd \"$TOOLS_DIR_ABS\" && GOWORK=$GOWORK GOBIN=\"$BIN_DIR_ABS\" go install -v \$(grep -E '^[[:space:]]*_[[:space:]]+\".*\"' tools.go | awk -F'\"' '{print \$2}')"
+install_tool_bins() {
+  cd "$TOOLS_DIR_ABS" && GOWORK=$GOWORK GOBIN="$BIN_DIR_ABS" go install -v $(grep -E '^[[:space:]]*_[[:space:]]+".*"' tools.go | awk -F'"' '{print $2}')
+}
+if ! retry_on_corruption install_tool_bins; then
+  message "Command failed: go install tools"
+  exit 1
+fi
+message "Command ran successfully: go install tools"
 
 message "Tools installation completed successfully"
 message "Installed tools are available in: $BIN_DIR"


### PR DESCRIPTION
### What does this PR do?

Hardens Go toolchain operations across GitHub Actions CI against a transient corruption flake, and deduplicates the retry logic that was starting to accumulate inline copies. Extends from #5046.

`govulncheck-tests` was randomly failing the whole build with:
```
go: downloading golang.org/x/vuln v1.6.0
go: golang.org/x/vuln/cmd/govulncheck@latest: zip: checksum error
```
([example run](https://github.com/DataDog/dd-trace-go/actions/runs/29816782870/job/88589885499)) — a transient Go module cache/download flake, not a real code problem. `go1.26.5` is also known to intermittently corrupt its own build cache mid-compile (heap corruption, ICEs, SIGSEGVs — golang/go#77168), which can leave partial cache/module archives behind that later surface as the same class of error.

`smoke-tests.yml` had already solved this for its own two steps (`retry_on_corruption`, PR #4924 / #5046), but as two near-identical ~20-line inline copies. This PR extracts that pattern into a shared, sourceable helper — [`go-retry.sh`](.github/workflows/apps/go-retry.sh) (`retry_on_corruption` / `retry_on_corruption_to_file`) — and applies it to every govulncheck install/scan, `smoke-tests.yml`'s two steps, and every other network `go install`/`go get`/`go mod` and compile-heavy `go build` call site in GitHub Actions CI.

**govulncheck** (root cause):
- `.github/workflows/govulncheck.yml` — all 3 jobs
- `.github/workflows/govulncheck-fix.yml` — the install step
- `.github/workflows/apps/govulncheck-contribs-v2.sh`, `govulncheck-contribs-sarif.sh`, `govulncheck-fix.sh` — per-module scans

**smoke-tests** (dedup):
- `.github/workflows/smoke-tests.yml` — both steps now source `go-retry.sh` instead of each carrying their own copy

**Everything else with the same risk profile:**
- `scripts/install_tools.sh` — `go mod download` + `go install` for dev tools, used by **8 workflows** via the `setup-go` composite action
- `.github/workflows/appsec.yml` — `go mod download`, and `go install gotestsum` on macOS, Windows (needed an explicit `shell: bash`), and inside a Docker container (sourced via `docker exec`, since `go-retry.sh` is bind-mounted into the container at the same path)
- `.github/workflows/orchestrion.yml` — `go mod edit`/`tidy`, `go install`, and `go build` for the orchestrion binary, across an ubuntu/macos/windows matrix (three steps needed an explicit `shell: bash`, matching what the job already requires elsewhere in the same matrix)
- `scripts/checklocks.sh` — installing the checklocks tool
- `scripts/apidiff.sh` — `go mod download` for the base-ref worktree
- `scripts/fix_modules.sh` — `go run fixmodules` + `go mod tidy` per module
- `scripts/ci_test_contrib.sh` — `go get`/`go mod tidy` across contrib and instrumentation submodules (shared by `unit-integration-tests.yml`, unsandboxed, and `smoke-tests.yml`)
- `scripts/cross_build.sh` — `go build` per cross-compile target

`retry_on_corruption` retries a command up to 3 times only when its stderr matches a known toolchain/cache corruption signature (including `zip: checksum error`), clearing the build cache every retry and the module cache on archive corruption. Anything else — including a real vulnerability finding or a real compile error — fails immediately, no retry. `retry_on_corruption_to_file` is the variant for callers that capture stdout into a file (SARIF, OpenVEX, JSON): it reopens/truncates the destination on every attempt so a failed first try never leaves partial output for a retry to append onto.

**Left for a follow-up:** the non-blocking third-party `golang/govulncheck-action` step (installs Go + govulncheck internally), and GitLab's benchmark pipeline (`.gitlab/benchmarks/micro/bp-runner.yml`) — a separate CI system that would need its own retry helper rather than sourcing the GitHub Actions one.

### Motivation

Fixes the random `govulncheck-tests` CI failures described in https://github.com/DataDog/dd-trace-go/actions/runs/29816782870/job/88589885499, removes duplication between smoke-tests' and govulncheck's copies of the same retry logic, and extends the same protection to every other Go toolchain operation in GitHub Actions CI exposed to the same class of transient flake.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

This is a CI-only shell/YAML change (no Go code, no go.mod changes) — verified with `bash -n`, `actionlint`, and manual runtime tests of the retry helper (success/no-retry, fail-fast on real errors, retry-then-fail on persistent corruption, recovery on transient corruption, clean output-file truncation across retries, and env-var-prefix propagation through the wrapped function call for `cross_build.sh`'s `GOOS`/`GOARCH` usage).
