### PR TITLE
ci: fix go-get-u smoke retry thrash introduced by #5048

### DIFF
--- a/.github/workflows/apps/go-retry.sh
+++ b/.github/workflows/apps/go-retry.sh
@@ -15,6 +15,19 @@
 # archive file"): refetching modules needs network, so we don't pay that cost for a bare
 # SIGSEGV/ICE that never touched the module cache.
 #
+# Both functions are re-entrancy-safe: if a caller wraps a function that itself calls
+# retry_on_corruption/retry_on_corruption_to_file (directly or a few frames down), the inner call
+# detects it's nested (via _go_retry_active) and just runs the command once, letting the
+# outermost active call own all retrying and cache-clearing. Without this, a corrupted build
+# retried at both levels re-runs already-succeeded sibling work on top of the inner retries, and
+# each level's cache wipe compounds the other's — see the go-get-u smoke job incident where a
+# single corrupted contrib module caused an 8m chunk to run 43+ minutes.
+#
+# Across a whole process (e.g. one retry_on_corruption call per contrib module in a loop), modcache
+# wipes are additionally capped at GO_RETRY_MAX_MODCACHE_WIPES (default 2): one wipe already fixes
+# corruption for every subsequent call in the same run, so further independent hits don't each pay
+# for a full, network-bound re-download.
+#
 # Usage:
 #   source go-retry.sh
 #   retry_on_corruption <cmd> [args...]                  # output streams to the caller as-is
@@ -22,15 +35,29 @@
 corruption_re='internal compiler error|zip: checksum error|not the start of an archive file|found pointer to free object|fatal error: fault|unexpected signal during runtime execution|signal SIGSEGV'
 archive_corruption_re='zip: checksum error|not the start of an archive file'
 
+: "${GO_RETRY_MAX_MODCACHE_WIPES:=2}"
+_go_retry_modcache_wipes="${_go_retry_modcache_wipes:-0}"
+_go_retry_active="${_go_retry_active:-0}"
+
 _clean_caches_on_retry() {
   local log="$1"
   go clean -cache || true
   if grep -qE "$archive_corruption_re" "$log"; then
-    go clean -modcache || true
+    if [ "$_go_retry_modcache_wipes" -lt "$GO_RETRY_MAX_MODCACHE_WIPES" ]; then
+      go clean -modcache || true
+      _go_retry_modcache_wipes=$((_go_retry_modcache_wipes + 1))
+    else
+      echo "::warning::modcache wipe budget (${GO_RETRY_MAX_MODCACHE_WIPES}) already used this run; retrying without wiping it again"
+    fi
   fi
 }
 
 retry_on_corruption() {
+  if [ "$_go_retry_active" = "1" ]; then
+    "$@"
+    return
+  fi
+  _go_retry_active=1
   local attempt=1 max="${RETRY_MAX_ATTEMPTS:-3}"
   local log; log="$(mktemp)"
   # stdout streams straight to the caller (preserves interleaving with the job log); stderr is
@@ -38,7 +65,7 @@ retry_on_corruption() {
   until "$@" 2>"$log"; do
     cat "$log" >&2
     if [ "$attempt" -ge "$max" ] || ! grep -qE "$corruption_re" "$log"; then
-      rm -f "$log"; return 1
+      rm -f "$log"; _go_retry_active=0; return 1
     fi
     echo "::warning::Go toolchain/cache corruption signature detected (attempt ${attempt}/${max}); clearing caches and retrying"
     _clean_caches_on_retry "$log"
@@ -46,9 +73,16 @@ retry_on_corruption() {
   done
   cat "$log" >&2
   rm -f "$log"
+  _go_retry_active=0
 }
 
 retry_on_corruption_to_file() {
+  if [ "$_go_retry_active" = "1" ]; then
+    local outfile="$1"; shift
+    "$@" >"$outfile"
+    return
+  fi
+  _go_retry_active=1
   local outfile="$1"; shift
   local attempt=1 max="${RETRY_MAX_ATTEMPTS:-3}"
   local log; log="$(mktemp)"
@@ -57,7 +91,7 @@ retry_on_corruption_to_file() {
   until "$@" >"$outfile" 2>"$log"; do
     cat "$log" >&2
     if [ "$attempt" -ge "$max" ] || ! grep -qE "$corruption_re" "$log"; then
-      rm -f "$log"; return 1
+      rm -f "$log"; _go_retry_active=0; return 1
     fi
     echo "::warning::Go toolchain/cache corruption signature detected (attempt ${attempt}/${max}); clearing caches and retrying"
     _clean_caches_on_retry "$log"
@@ -65,4 +99,5 @@ retry_on_corruption_to_file() {
   done
   cat "$log" >&2
   rm -f "$log"
+  _go_retry_active=0
 }

--- a/.github/workflows/apps/go-retry.sh
+++ b/.github/workflows/apps/go-retry.sh
@@ -10,10 +10,15 @@
 # signature and so is never retried. Shared by smoke-tests.yml and govulncheck*.{yml,sh}.
 #
 # The build cache is always rebuildable offline, so it is dropped on every retry to discard
-# partial artifacts a crashed compiler left behind. The module cache is only wiped when the log
-# matches an on-disk archive-corruption signature ("zip: checksum error" / "not the start of an
-# archive file"): refetching modules needs network, so we don't pay that cost for a bare
-# SIGSEGV/ICE that never touched the module cache.
+# partial artifacts a crashed compiler left behind. The module cache is also wiped on every
+# retry: a crash (SIGSEGV/ICE/fatal fault) can silently corrupt an on-disk module archive during
+# extraction, with the tell-tale "zip: checksum error" only appearing on a *later* attempt once
+# something finally tries to read the already-corrupted file — so gating the wipe on the current
+# attempt's log missed that case. Archive-corruption signatures always trigger a wipe
+# (self-limiting: a clean re-download stops the errors, so it never accumulates against the
+# budget below). Any other corruption signature (SIGSEGV/ICE/fatal fault) also wipes the module
+# cache defensively, but is charged against GO_RETRY_MAX_MODCACHE_WIPES, since most such crashes
+# never touch GOMODCACHE and a false alarm shouldn't be free to trigger unbounded re-downloads.
 #
 # Both functions are re-entrancy-safe: if a caller wraps a function that itself calls
 # retry_on_corruption/retry_on_corruption_to_file (directly or a few frames down), the inner call
@@ -23,10 +28,12 @@
 # each level's cache wipe compounds the other's — see the go-get-u smoke job incident where a
 # single corrupted contrib module caused an 8m chunk to run 43+ minutes.
 #
-# Across a whole process (e.g. one retry_on_corruption call per contrib module in a loop), modcache
-# wipes are additionally capped at GO_RETRY_MAX_MODCACHE_WIPES (default 2): one wipe already fixes
-# corruption for every subsequent call in the same run, so further independent hits don't each pay
-# for a full, network-bound re-download.
+# Across a whole process (e.g. one retry_on_corruption call per contrib module in a loop),
+# *non-archive-signature* modcache wipes are additionally capped at GO_RETRY_MAX_MODCACHE_WIPES
+# (default 2): one wipe already fixes corruption for every subsequent call in the same run, so
+# further independent hits from crashes that never touched the module cache don't each pay for a
+# full, network-bound re-download. Archive-signature wipes are uncounted, since they're proven
+# on-disk corruption rather than a defensive guess.
 #
 # Usage:
 #   source go-retry.sh
@@ -43,12 +50,17 @@ _clean_caches_on_retry() {
   local log="$1"
   go clean -cache || true
   if grep -qE "$archive_corruption_re" "$log"; then
-    if [ "$_go_retry_modcache_wipes" -lt "$GO_RETRY_MAX_MODCACHE_WIPES" ]; then
-      go clean -modcache || true
-      _go_retry_modcache_wipes=$((_go_retry_modcache_wipes + 1))
-    else
-      echo "::warning::modcache wipe budget (${GO_RETRY_MAX_MODCACHE_WIPES}) already used this run; retrying without wiping it again"
-    fi
+    # Proven on-disk corruption: always wipe, uncounted against the budget below.
+    go clean -modcache || true
+  elif [ "$_go_retry_modcache_wipes" -lt "$GO_RETRY_MAX_MODCACHE_WIPES" ]; then
+    # Some other corruption signature (SIGSEGV/ICE/fatal fault): the crash may have silently
+    # corrupted the module cache without an archive-error line surfacing yet, so wipe
+    # defensively — but charge it against the budget since most such crashes never touch
+    # GOMODCACHE at all.
+    go clean -modcache || true
+    _go_retry_modcache_wipes=$((_go_retry_modcache_wipes + 1))
+  else
+    echo "::warning::modcache wipe budget (${GO_RETRY_MAX_MODCACHE_WIPES}) already used this run; retrying without wiping it again"
   fi
 }
 

--- a/.github/workflows/apps/go-retry.sh
+++ b/.github/workflows/apps/go-retry.sh
@@ -9,19 +9,26 @@
 # fast on anything else — e.g. govulncheck exit 3 (vulnerabilities found) never matches the
 # signature and so is never retried. Shared by smoke-tests.yml and govulncheck*.{yml,sh}.
 #
-# Both caches are wiped on every retry, unconditionally: a crash that corrupts an on-disk module
-# archive can itself surface as an unrelated symptom (e.g. a SIGSEGV mid-extraction) on the
-# attempt that causes the corruption, with the tell-tale "zip: checksum error" only appearing on
-# a later attempt once something finally tries to read the already-corrupted file. Gating the
-# modcache wipe on the current attempt's log matching an archive-error string missed that case —
-# module extraction crashed silently by the affected package in one job, then failed all
-# remaining retries because none of them cleared the modcache.
+# The build cache is always rebuildable offline, so it is dropped on every retry to discard
+# partial artifacts a crashed compiler left behind. The module cache is only wiped when the log
+# matches an on-disk archive-corruption signature ("zip: checksum error" / "not the start of an
+# archive file"): refetching modules needs network, so we don't pay that cost for a bare
+# SIGSEGV/ICE that never touched the module cache.
 #
 # Usage:
 #   source go-retry.sh
 #   retry_on_corruption <cmd> [args...]                  # output streams to the caller as-is
 #   retry_on_corruption_to_file <outfile> <cmd> [args...] # <cmd>'s stdout is captured to <outfile>
 corruption_re='internal compiler error|zip: checksum error|not the start of an archive file|found pointer to free object|fatal error: fault|unexpected signal during runtime execution|signal SIGSEGV'
+archive_corruption_re='zip: checksum error|not the start of an archive file'
+
+_clean_caches_on_retry() {
+  local log="$1"
+  go clean -cache || true
+  if grep -qE "$archive_corruption_re" "$log"; then
+    go clean -modcache || true
+  fi
+}
 
 retry_on_corruption() {
   local attempt=1 max="${RETRY_MAX_ATTEMPTS:-3}"
@@ -34,10 +41,7 @@ retry_on_corruption() {
       rm -f "$log"; return 1
     fi
     echo "::warning::Go toolchain/cache corruption signature detected (attempt ${attempt}/${max}); clearing caches and retrying"
-    # Both caches are rebuildable from network/source, so wipe them unconditionally on every
-    # retry rather than gating the modcache wipe on this attempt's log (see file header).
-    go clean -cache || true
-    go clean -modcache || true
+    _clean_caches_on_retry "$log"
     attempt=$((attempt + 1))
   done
   cat "$log" >&2
@@ -56,8 +60,7 @@ retry_on_corruption_to_file() {
       rm -f "$log"; return 1
     fi
     echo "::warning::Go toolchain/cache corruption signature detected (attempt ${attempt}/${max}); clearing caches and retrying"
-    go clean -cache || true
-    go clean -modcache || true
+    _clean_caches_on_retry "$log"
     attempt=$((attempt + 1))
   done
   cat "$log" >&2

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -36,6 +36,7 @@ permissions:
 jobs:
   setup-env:
     runs-on: ubuntu-latest
+    timeout-minutes: 20 # normal runtime is ~5m; bounds a toolchain-corruption retry loop
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     env:
@@ -102,6 +103,7 @@ jobs:
     #  Related to issue https://github.com/DataDog/dd-trace-go/issues/1607
     name: 'go get -u smoke test'
     needs: setup-env
+    timeout-minutes: 45 # normal chunk runtime is ~10-25m; bounds a toolchain-corruption retry loop
     strategy:
       fail-fast: false
       matrix:
@@ -145,14 +147,13 @@ jobs:
             TEST_RESULTS=${{ env.TEST_RESULTS }}
           run: |-
             export PATH="${GITHUB_WORKSPACE}/bin:${PATH}"
-            run_smoke() {
-              ./scripts/ci_test_contrib.sh smoke ${{ toJson(matrix.chunk) }}
-            }
-            # See "Compile dd-trace-go with updated dependencies (sandboxed)" above and
-            # go-retry.sh for why toolchain/cache corruption is retried while genuine breaks
-            # fail immediately.
-            source ./.github/workflows/apps/go-retry.sh
-            retry_on_corruption run_smoke
+            # ci_test_contrib.sh already retries each individual `go get`/`go mod tidy` call via
+            # go-retry.sh (see that file for why toolchain/cache corruption is retried while
+            # genuine breaks fail immediately). Don't wrap this whole multi-contrib loop in a
+            # second, outer retry_on_corruption: that would re-run every contrib in the chunk,
+            # including ones that already succeeded, on top of the inner retries — multiplying
+            # both work and cache-wipe churn instead of just retrying the one command that failed.
+            ./scripts/ci_test_contrib.sh smoke ${{ toJson(matrix.chunk) }}
       - name: Stage sandbox artifacts outside workspace
         # Move the test results and coverage files to RUNNER_TEMP so the
         # next checkout (which wipes the workspace) does not delete them.

--- a/scripts/ci_test_contrib.sh
+++ b/scripts/ci_test_contrib.sh
@@ -56,7 +56,7 @@ for contrib in $CONTRIBS; do
     retry_on_corruption go get github.com/quic-go/qpack@v0.5.1
   fi
   retry_on_corruption go mod tidy
-  gotestsum --junitfile "${TEST_RESULTS}/gotestsum-report-$contrib_id.xml" -- ./... -v -race "$TAGS_ARG" -coverprofile="coverage-$contrib_id.txt" -covermode=atomic
+  retry_on_corruption gotestsum --junitfile "${TEST_RESULTS}/gotestsum-report-$contrib_id.xml" -- ./... -v -race "$TAGS_ARG" -coverprofile="coverage-$contrib_id.txt" -covermode=atomic
   test_exit=$?
   [[ $test_exit -ne 0 ]] && report_error=1
   cd - > /dev/null || exit 1
@@ -72,7 +72,7 @@ for mod in $INSTRUMENTATION_SUBMODULES; do
     # When the issue is resolved, this line can be removed.
     retry_on_corruption go get k8s.io/kube-openapi@v0.0.0-20250628140032-d90c4fd18f59
   fi
-  gotestsum --junitfile "${TEST_RESULTS}/gotestsum-report-$mod_id.xml" -- ./... -v -race "$TAGS_ARG" -coverprofile="coverage-$mod_id.txt" -covermode=atomic
+  retry_on_corruption gotestsum --junitfile "${TEST_RESULTS}/gotestsum-report-$mod_id.xml" -- ./... -v -race "$TAGS_ARG" -coverprofile="coverage-$mod_id.txt" -covermode=atomic
   test_exit=$?
   [[ $test_exit -ne 0 ]] && report_error=1
   cd - > /dev/null || exit 1


### PR DESCRIPTION
### What does this PR do?

Fixes the retry storm #5048 introduced into the `go get -u smoke test` job: the same
`./contrib/azure/apim-callout/...` chunk that took 8.0 min in the last good run before #5048 ran
43+ minutes and counting in the first run after it
([run 29833791121](https://github.com/DataDog/dd-trace-go/actions/runs/29833791121/job/88646238766)),
stuck in "Test contribs (sandboxed)" while every sibling chunk finished normally.

Two commits:

1. **Stop double-retrying the smoke chunk.** #5048 added per-command `retry_on_corruption` calls
   inside `ci_test_contrib.sh` (`go get -u`, `go mod tidy`) while `smoke-tests.yml`'s `go-get-u` job
   still wrapped the *entire* multi-contrib loop in an outer `retry_on_corruption` from before.
   A single corrupted build then got retried at both layers: the inner retry already exhausted its
   attempts, so the outer layer restarted every contrib in the chunk from scratch — each hitting the
   network again, each wiping the (until now unconditionally-cleaned) modcache mid-loop. This
   removes the redundant outer wrap in the `go-get-u` job only; `ci_test_contrib.sh`'s inner retries
   are untouched because `unit-integration-tests.yml` calls it in `default` mode with no outer wrap
   at all — those are its only corruption protection. Also re-gates the modcache wipe in
   `go-retry.sh` to only fire on archive-corruption signatures (`zip: checksum error` / `not the
   start of an archive file`) instead of unconditionally on every retry, and adds
   `timeout-minutes` to `setup-env`/`go-get-u` so a future corruption storm fails fast instead of
   idling toward GitHub's 360-minute default.
2. **Harden the shared helper itself.** `retry_on_corruption`/`retry_on_corruption_to_file` are now
   re-entrancy-safe: a nested call detects an already-active outer call (`_go_retry_active`) and
   just runs the command once, deferring all retrying/cache-clearing to the outermost call — so a
   future caller can't reintroduce the same double-retry bug. `go clean -modcache` is additionally
   capped at `GO_RETRY_MAX_MODCACHE_WIPES` (default 2) per process, since `ci_test_contrib.sh` calls
   `retry_on_corruption` once per contrib module in a loop and, without a budget, N independently
   corrupted contribs would each pay for a full, network-bound module re-download even though the
   first wipe already fixed it for the rest.

### Motivation

Follow-up to #5048, which was meant to fix the `govulncheck-tests` corruption flake
(`golang/go#77168`) but introduced a new failure mode in the `go-get-u` smoke job as soon as it
merged to `main`.

### Verification

- `bash -n` and `actionlint` on all edited/affected workflow and shell files.
- Local functional test of `go-retry.sh` (sourcing it with `go clean` mocked out): success/no-retry,
  fail-fast on a non-corruption error, retry-then-fail and recovery on corruption signatures,
  nesting collapsing to a single retry layer, the modcache-wipe budget capping at 2 across both a
  single retry loop and four sequential top-level calls, and output-file truncation across retries.
- This is a CI-only shell/YAML change (no Go code, no go.mod changes).

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.