### PR TITLE
fix(openfeature): make InitWithContext return ready without a first config

### DIFF
--- a/openfeature/provider.go
+++ b/openfeature/provider.go
@@ -44,6 +44,14 @@ const (
 	defaultInitTimeout = 30 * time.Second
 	// Default timeout for provider shutdown
 	defaultShutdownTimeout = 30 * time.Second
+	// initialConfigWait bounds InitWithContext's opportunistic wait for the
+	// first RC configuration. Long enough to catch a normal PollInterval-
+	// bounded delivery, short enough that a service whose RC feed is idle
+	// (no configs targeted at this service, or a slow-responding agent)
+	// still comes ready inside a typical startup-probe budget. Keep this
+	// well below defaultInitTimeout so callers passing a Background ctx
+	// don't collide with their outer probe deadline.
+	initialConfigWait = 5 * time.Second
 )
 
 // ProviderConfig contains configuration options for the Datadog OpenFeature provider
@@ -227,16 +235,42 @@ func (p *DatadogProvider) waitForConfigurationUpdate(ctx context.Context) error 
 }
 
 // InitWithContext initializes the provider with context support.
-// This method respects context cancellation and timeouts, allowing users
-// to cancel the initialization process if needed.
+//
+// The provider is ready as soon as its Remote Config subscription is
+// established, which has already happened by the time this is called
+// (SubscribeProvider / AttachCallback run synchronously in
+// startWithRemoteConfig). This function opportunistically waits a short,
+// bounded time for the first configuration to arrive so that fresh
+// deployments start with real flag data, but returns successfully with no
+// error if the wait deadline expires or the caller's ctx is cancelled
+// first. Flag evaluations before the first config resolve to their
+// caller-supplied defaults with reason DEFAULT; when the first config
+// eventually arrives via the RC callback, in-flight and subsequent
+// evaluations pick it up.
+//
+// Historically this function blocked indefinitely (bounded only by ctx or
+// Init's own timeout) waiting for configuration != nil. That produced
+// startup hangs when the agent's initial RC response omitted the FFE
+// product (no configs targeted at this service, or a slow agent side
+// under container-restart timing) — the callback never fired and Init
+// consumed its full budget every restart. Not delivering a config is a
+// legitimate steady state, not a failure to become ready.
 func (p *DatadogProvider) InitWithContext(ctx context.Context, _ openfeature.EvaluationContext) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	for p.configuration == nil {
-		if err := p.waitForConfigurationUpdate(ctx); err != nil {
-			return err
-		}
+	// Bound the opportunistic wait so it can't outlive the caller-supplied
+	// deadline, but also so a caller passing context.Background() cannot
+	// pin startup indefinitely.
+	waitCtx, cancel := context.WithTimeout(ctx, initialConfigWait)
+	defer cancel()
+
+	if p.configuration == nil {
+		// Best-effort wait for one configuration update. Any error (deadline,
+		// cancellation) is intentionally swallowed — the provider is ready
+		// once the RC subscription is live, which is a precondition for
+		// reaching this point.
+		_ = p.waitForConfigurationUpdate(waitCtx)
 	}
 
 	// Start periodic flushing for exposure writer.

--- a/openfeature/provider_test.go
+++ b/openfeature/provider_test.go
@@ -611,29 +611,63 @@ func TestConcurrentEvaluations(t *testing.T) {
 	}
 }
 
-func TestSetProviderWithContextAndWaitTimeout(t *testing.T) {
-	// Create a provider that doesn't have configuration loaded
-	// This will cause InitWithContext to wait for configuration
+func TestSetProviderWithContextAndWaitNoConfig(t *testing.T) {
+	// A provider whose RC subscription is live but has not yet received a
+	// configuration must still become ready — flag evaluations resolve to
+	// their caller-supplied defaults until the first config arrives. This
+	// is the steady state for services with no flags targeted at them and
+	// for the brief window after container restart before the agent
+	// re-delivers the config; either case previously deadlocked
+	// InitWithContext until its own timeout, defeating startup probes.
 	provider := newDatadogProvider(ProviderConfig{})
 
-	// Use a very short timeout context (50ms)
+	// Short caller deadline — well under initialConfigWait — proves Init
+	// does not consume its full opportunistic wait when the caller wants
+	// out sooner.
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	// Try to set the provider with context and wait - should timeout
+	start := time.Now()
 	err := openfeature.SetProviderWithContextAndWait(ctx, provider)
+	elapsed := time.Since(start)
 
-	// Verify that we get a timeout error
-	if err == nil {
-		t.Fatal("expected timeout error, got nil")
+	if err != nil {
+		t.Fatalf("expected no error becoming ready without a configuration, got: %v", err)
 	}
-
-	// Check that the error is due to context deadline exceeded
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Errorf("expected context.DeadlineExceeded error, got: %v", err)
+	// Give the caller ctx some slack for scheduling — we care that Init
+	// respected it rather than waiting the full initialConfigWait budget.
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("Init took %v — expected it to honor the caller's 50ms deadline, not wait for initialConfigWait", elapsed)
 	}
+}
 
-	t.Logf("Successfully got timeout error as expected: %v", err)
+func TestSetProviderWithContextAndWaitConfigArrivesDuringInit(t *testing.T) {
+	// A configuration update that arrives while Init is waiting should
+	// unblock Init early — the opportunistic wait exists precisely to
+	// pick up real config when it lands within a normal poll interval.
+	provider := newDatadogProvider(ProviderConfig{})
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		provider.updateConfiguration(createTestConfig())
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err := openfeature.SetProviderWithContextAndWait(ctx, provider)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if elapsed > time.Second {
+		t.Errorf("Init took %v — expected it to unblock as soon as the config arrived (~20ms)", elapsed)
+	}
+	if provider.getConfiguration() == nil {
+		t.Error("configuration should be set after Init")
+	}
 }
 
 func TestSetProviderWithContextAndWaitSuccess(t *testing.T) {


### PR DESCRIPTION
## What

Change `openfeature.DatadogProvider.InitWithContext` so it does not block indefinitely waiting for the first Remote Config payload. Init now performs a short, bounded opportunistic wait (`initialConfigWait = 5s`) for the first config, and returns `nil` (ready) whether or not that config arrived — flag evaluations pre-config resolve to caller-supplied defaults with reason `DEFAULT` and pick up the real config as soon as the RC callback fires.

## Why

`InitWithContext` previously looped on `configuration != nil`, waiting on `configChange.Broadcast` and bounded only by the caller's ctx (or `Init`'s own 30s timeout when called without a ctx). That treated "the agent has not yet delivered a config for FFE_FLAGS" as an initialization failure, but it's a legitimate steady state:

- No configs are targeted at this service (nothing published, or targeting excludes it).
- The initial poll response omits the product because the sidecar's cache is cold for the pod's client-id.

The RC subscription being established is a stronger readiness signal than a config arriving — the subscription is a precondition for reaching `InitWithContext` at all (see `startWithRemoteConfig` calling `SubscribeProvider` / `AttachCallback` synchronously).

**Observed failure on ffe-service in staging (gizmo):** every DPA-driven vertical in-place resize triggered a main-container restart (staging-only rapid change `6af559ea4e02d` set `resizePolicy: RestartContainer` for services with vertical autoscaling). The new Go process re-entered `InitWithContext`; the sidecar's response for that fresh subscription contained no FFE_FLAGS payload; `configChange.Broadcast` never fired; the container was killed by the startup probe at 30s. Logs on the crashing pods show `"openfeature-datadog: Init called"` at t=0, `"openfeature-datadog: Init completed successfully"` never, and the container exiting exactly 30s later — repeated across every restart cycle until the DPA was patched to Preview.

## How

- `InitWithContext` wraps `ctx` in `context.WithTimeout(ctx, initialConfigWait)` and calls `waitForConfigurationUpdate` once. Any error (deadline, cancel) is intentionally swallowed.
- Added `initialConfigWait = 5s` — long enough to cover a normal `PollInterval`-bounded delivery on the happy path, short enough that a service with an idle RC feed still comes ready inside a typical startup-probe budget, well below `defaultInitTimeout` so callers passing `context.Background()` don't collide with an outer probe deadline.

Existing behavior preserved:
- If the caller's `ctx` deadline is shorter than `initialConfigWait`, we honor the caller's deadline.
- If a config arrives during the wait, Init returns immediately with the config loaded (see `TestSetProviderWithContextAndWaitConfigArrivesDuringInit`).
- Exposure writer + EVP flag-eval writer still start.
- `Init()` (no-ctx form) still uses `defaultInitTimeout` as its outer bound; the change is what happens *within* that budget.

## Tests

- Renamed `TestSetProviderWithContextAndWaitTimeout` → `TestSetProviderWithContextAndWaitNoConfig`. Old test asserted the buggy behavior (Init returns `context.DeadlineExceeded` when no config arrives). New test asserts Init returns `nil` inside the caller's deadline.
- Added `TestSetProviderWithContextAndWaitConfigArrivesDuringInit` — Init unblocks immediately when a config arrives during the opportunistic wait, and the config is visible on the provider afterward.
- Full `./openfeature/...` and `./internal/openfeature/...` suites pass with `-race`.

## Follow-ups (out of scope)

- The `configChange.Wait` goroutine started by `waitForConfigurationUpdate` is not cancelable by ctx — it only exits when a broadcast eventually fires. Pre-existing, not introduced by this PR. Because `Init` runs at most once per process, this leaks at most one goroutine until the first config eventually arrives; acceptable but worth cleaning up separately.
- The dd-source-side rapid framework change that enabled in-place-restart on staging (`resizePolicy: RestartContainer`) should be reviewed jointly — any service with a startup-probe budget ≤ 30s that depends on RC-delivered config at startup is exposed to the same class of failure. This PR removes the OpenFeature-specific exposure; a broader audit of what else blocks on RC at startup is the Rapid team's call.

Internal tracking: FFL-2809.