### PR TITLE
feat(instrumentation): expose telemetry.Product* functions

### DIFF
--- a/instrumentation/instrumentation.go
+++ b/instrumentation/instrumentation.go
@@ -159,6 +159,29 @@ func (i *Instrumentation) TelemetryMetrics() TelemetryMetricsClient {
 	return &i.telemetryMetrics
 }
 
+type TelemetryNamespace = telemetry.Namespace
+
+const (
+	// TelemetryNamespaceIAST is the namespace for IAST telemetry
+	TelemetryNamespaceIAST = telemetry.NamespaceIAST
+)
+
+// TelemetryProductStarted declares a telemetry product as having started.
+func (i *Instrumentation) TelemetryProductStarted(ns TelemetryNamespace) {
+	telemetry.ProductStarted(ns)
+}
+
+// TelemetryProductStartError declares a telemetry product as having failed to
+// start because of the specified error.
+func (i *Instrumentation) TelemetryProductStartError(ns TelemetryNamespace, err error) {
+	telemetry.ProductStartError(ns, err)
+}
+
+// TelemetryProductStopped declares a telemetry product as having stopped.
+func (i *Instrumentation) TelemetryProductStopped(ns TelemetryNamespace) {
+	telemetry.ProductStopped(ns)
+}
+
 type TelemetryOrigin = telemetry.Origin
 
 const (


### PR DESCRIPTION
### What does this PR do?

Have `instrumentation.Instrumentation` expose `telemetry.ProductStarted`, `telemetry.ProductStartError`, and `telemetry.ProductStopped`.

### Motivation

This allows an external implementation of IAST to properly report that the IAST namespace has started.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
