### PR TITLE
feat(tracer): add whole trace id to pprof labels and enable them with appsec

### DIFF
--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -123,6 +123,20 @@ func (t *traceID) cacheHex() {
 	t.hexEncoded = hex.EncodeToString(t.value[:])
 }
 
+// hexEncodedCached returns HexEncoded and memoizes the result on the traceID so
+// subsequent reads (and child spans, via newSpanContext) reuse it instead of
+// re-encoding. Because it writes t.hexEncoded, it MUST only be called while the
+// enclosing SpanContext is not yet shared with other goroutines (e.g. from
+// tracer.StartSpan, before the span is returned). This lets a whole trace pay a
+// single hex allocation for the profiler's "trace id" label instead of one per
+// span.
+func (t *traceID) hexEncodedCached() string {
+	if t.hexEncoded == "" {
+		t.cacheHex()
+	}
+	return t.hexEncoded
+}
+
 // SpanContext represents a span state that can propagate to descendant spans
 // and across process boundaries. It contains all the information needed to
 // spawn a direct descendant of the span that it belongs to. It can be used
@@ -302,6 +316,13 @@ func newSpanContext(span *Span, parent *SpanContext) *SpanContext {
 		// (We only want 32 bits of time, then the rest is zero)
 		tUp := uint64(uint32(id128)) << 32 // We need the time at the upper 32 bits of the uint
 		context.traceID.SetUpper(tUp)
+	}
+	// A child span shares its parent's trace ID, so reuse the parent's cached hex
+	// string (lazily populated on the pprof "trace id" label path) rather than
+	// re-encoding it. This keeps the whole trace at a single hex allocation. The
+	// value equality check guards against ever copying a mismatched hex.
+	if parent != nil && parent.traceID.hexEncoded != "" && context.traceID.value == parent.traceID.value {
+		context.traceID.hexEncoded = parent.traceID.hexEncoded
 	}
 	if context.trace == nil {
 		context.trace = newTrace()

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -3640,8 +3640,11 @@ func TestSpanContextDebugLoggingSecurity(t *testing.T) {
 // It covers both hex-cache states a shared SpanContext can be in when injected
 // concurrently:
 //
-//   - cold cache: a locally started span. newSpanContext does not populate
-//     hexEncoded, so every UpperHex() takes the non-caching fallback.
+//   - cold cache: a locally started span with the pprof label path disabled.
+//     newSpanContext does not populate hexEncoded, so every UpperHex() takes the
+//     non-caching fallback. Code hotspots must be off here: when it (or AppSec)
+//     is enabled, applyPPROFLabels warms the hex cache at StartSpan (safely,
+//     before the span is shared) via hexEncodedCached.
 //   - hot cache: an extracted context. extractTextMap finalizes the traceID via
 //     cacheHex, so UpperHex() returns the cached string.
 //
@@ -3653,7 +3656,11 @@ func TestConcurrentInjectTraceIDHex(t *testing.T) {
 	t.Setenv(envPropagationStyleExtract, "datadog")
 	t.Setenv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", "true")
 
-	tracer, _, _, stop, err := startTestTracer(t)
+	// Disable code hotspots so locally started spans keep a cold hex cache; with
+	// it (or AppSec) enabled, applyPPROFLabels warms the cache at StartSpan and
+	// the "cold cache" subtest below could no longer exercise the non-caching
+	// HexEncoded read path.
+	tracer, _, _, stop, err := startTestTracer(t, WithProfilerCodeHotspots(false))
 	require.NoError(t, err)
 	defer stop()
 

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -1082,7 +1082,9 @@ func (t *tracer) applyPPROFLabels(ctx gocontext.Context, span *Span, snap intern
 		}
 	}
 	if correlate {
-		labels = append(labels, traceprof.TraceID, span.context.TraceID())
+		// hexEncodedCached memoizes the hex on the (not-yet-shared) context so
+		// child spans reuse it: one hex allocation per trace, not per span.
+		labels = append(labels, traceprof.TraceID, span.context.traceID.hexEncodedCached())
 	}
 	if len(labels) > 0 {
 		pprofActive := pprof.WithLabels(ctx, pprof.Labels(labels...))

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -1018,11 +1018,7 @@ func (t *tracer) StartSpan(operationName string, options ...StartSpanOption) *Sp
 		log.Debug("Started Span: %v, Operation: %s, Resource: %s, Tags: %v, %v", //nolint:gocritic // Debug logging needs full span representation
 			span, span.name, span.resource, &span.meta, span.metrics)
 	}
-	if cSnap.ProfilerHotspotsEnabled || cSnap.ProfilerEndpoints {
-		t.applyPPROFLabels(span.pprofCtxRestore, span, cSnap)
-	} else {
-		span.pprofCtxRestore = nil
-	}
+	t.applyPPROFLabels(span.pprofCtxRestore, span, cSnap)
 	if cSnap.DebugAbandonedSpans {
 		select {
 		case t.abandonedSpansDebugger.In <- newAbandonedSpanCandidate(span, false):
@@ -1052,13 +1048,21 @@ func (t *tracer) StartSpan(operationName string, options ...StartSpanOption) *Sp
 // many times each endpoint is called.
 // +checklocksignore — Initialization time, called from StartSpan before span is shared.
 func (t *tracer) applyPPROFLabels(ctx gocontext.Context, span *Span, snap internalconfig.SpanStartSnapshot) {
+	// "local root span id" and "trace id" are emitted for code hotspots and when
+	// AppSec is enabled, so it can correlate security events with traces/profiles.
+	correlate := snap.ProfilerHotspotsEnabled || appsec.Enabled()
+	if !correlate && !snap.ProfilerEndpoints {
+		// No feature needs pprof labels; nothing to restore when the span finishes.
+		span.pprofCtxRestore = nil
+		return
+	}
 	// Important: The label keys are ordered alphabetically to take advantage of
 	// an upstream optimization that landed in go1.24.  This results in ~10%
 	// better performance on BenchmarkStartSpan. See
 	// https://go-review.googlesource.com/c/go/+/574516 for more information.
-	labels := make([]string, 0, 3*2 /* 3 key value pairs */)
+	labels := make([]string, 0, 4*2 /* up to 4 key value pairs */)
 	localRootSpan := span.Root()
-	if snap.ProfilerHotspotsEnabled && localRootSpan != nil {
+	if correlate && localRootSpan != nil {
 		spanID := localRootSpan.getSpanID()
 		labels = append(labels, traceprof.LocalRootSpanID, strconv.FormatUint(spanID, 10))
 	}
@@ -1076,6 +1080,9 @@ func (t *tracer) applyPPROFLabels(ctx gocontext.Context, span *Span, snap intern
 				traceprof.GlobalEndpointCounter().Inc(resource)
 			}
 		}
+	}
+	if correlate {
+		labels = append(labels, traceprof.TraceID, span.context.TraceID())
 	}
 	if len(labels) > 0 {
 		pprofActive := pprof.WithLabels(ctx, pprof.Labels(labels...))

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -38,6 +38,7 @@ import (
 	traceinternal "github.com/DataDog/dd-trace-go/v2/ddtrace/tracer/internal"
 	tracertest "github.com/DataDog/dd-trace-go/v2/ddtrace/x/agenttest"
 	"github.com/DataDog/dd-trace-go/v2/internal"
+	"github.com/DataDog/dd-trace-go/v2/internal/appsec"
 	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/globalconfig"
 	"github.com/DataDog/dd-trace-go/v2/internal/locking"
@@ -45,6 +46,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/processtags"
 	"github.com/DataDog/dd-trace-go/v2/internal/remoteconfig"
 	"github.com/DataDog/dd-trace-go/v2/internal/statsdtest"
+	"github.com/DataDog/dd-trace-go/v2/internal/traceprof"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/stretchr/testify/assert"
@@ -3220,6 +3222,91 @@ func TestPprofLabels(t *testing.T) {
 		span.Finish()
 		wasteC(time.Second)
 	})
+}
+
+// TestApplyPPROFLabelsTraceID verifies the pprof label gating matrix: the whole
+// 128-bit "trace id" (32-char lowercase hex) and "local root span id" are
+// emitted for code hotspots; "span id" stays hotspots-only; "trace endpoint"
+// stays endpoints-only; and nothing is emitted when no feature is enabled.
+func TestApplyPPROFLabelsTraceID(t *testing.T) {
+	// WithAppSecEnabled(false) disables AppSec so the code-hotspots and endpoints
+	// gates can be tested deterministically; assert the global state to be safe.
+	tr, err := newTracer(WithAppSecEnabled(false))
+	require.NoError(t, err)
+	defer tr.Stop()
+	require.False(t, appsec.Enabled(), "appsec must be off for the deterministic gating cases")
+
+	span := tr.StartSpan("web.request", ResourceName("/things"), SpanType(ext.SpanTypeWeb))
+	defer span.Finish()
+
+	traceID := span.context.TraceID()
+	require.Regexp(t, "^[0-9a-f]{32}$", traceID, "trace id must be the whole 128-bit id as lowercase hex")
+	localRoot := strconv.FormatUint(span.Root().getSpanID(), 10)
+	spanID := strconv.FormatUint(span.spanID, 10)
+
+	// apply resets the label context and (re)applies the labels for snap.
+	apply := func(snap internalconfig.SpanStartSnapshot) context.Context {
+		span.pprofCtxActive = nil
+		tr.applyPPROFLabels(context.Background(), span, snap)
+		return span.pprofCtxActive
+	}
+	present := func(t *testing.T, ctx context.Context, key, want string) {
+		t.Helper()
+		got, ok := pprof.Label(ctx, key)
+		require.Truef(t, ok, "label %q should be present", key)
+		require.Equalf(t, want, got, "value of label %q", key)
+	}
+	absent := func(t *testing.T, ctx context.Context, keys ...string) {
+		t.Helper()
+		for _, key := range keys {
+			_, ok := pprof.Label(ctx, key)
+			require.Falsef(t, ok, "label %q should be absent", key)
+		}
+	}
+
+	t.Run("hotspots", func(t *testing.T) {
+		ctx := apply(internalconfig.SpanStartSnapshot{ProfilerHotspotsEnabled: true})
+		require.NotNil(t, ctx)
+		present(t, ctx, traceprof.TraceID, traceID)
+		present(t, ctx, traceprof.LocalRootSpanID, localRoot)
+		present(t, ctx, traceprof.SpanID, spanID)
+		absent(t, ctx, traceprof.TraceEndpoint)
+	})
+	t.Run("endpoints-only", func(t *testing.T) {
+		ctx := apply(internalconfig.SpanStartSnapshot{ProfilerEndpoints: true})
+		require.NotNil(t, ctx)
+		present(t, ctx, traceprof.TraceEndpoint, "/things")
+		absent(t, ctx, traceprof.TraceID, traceprof.LocalRootSpanID, traceprof.SpanID)
+	})
+	t.Run("none", func(t *testing.T) {
+		require.Nil(t, apply(internalconfig.SpanStartSnapshot{}))
+	})
+}
+
+// TestApplyPPROFLabelsTraceIDAppSec verifies that enabling AppSec (with the
+// profiler features off) still emits "trace id" and "local root span id" for
+// trace/security correlation, but not the hotspots-only "span id".
+func TestApplyPPROFLabelsTraceIDAppSec(t *testing.T) {
+	if err := Start(WithAppSecEnabled(true), WithProfilerCodeHotspots(false), WithProfilerEndpoints(false)); err != nil {
+		t.Fatal(err)
+	}
+	defer Stop()
+	if !appsec.Enabled() {
+		t.Skip("appsec is not enabled on this platform; skipping appsec-only pprof label test")
+	}
+
+	span := StartSpan("web.request")
+	defer span.Finish()
+
+	ctx := span.pprofCtxActive
+	require.NotNil(t, ctx)
+	got, ok := pprof.Label(ctx, traceprof.TraceID)
+	require.True(t, ok, "trace id label should be present under appsec")
+	require.Equal(t, span.context.TraceID(), got)
+	_, ok = pprof.Label(ctx, traceprof.LocalRootSpanID)
+	require.True(t, ok, "local root span id label should be present under appsec")
+	_, ok = pprof.Label(ctx, traceprof.SpanID)
+	require.False(t, ok, "span id is hotspots-only and must be absent under appsec-only")
 }
 
 func TestNoopTracerStartSpan(t *testing.T) {

--- a/internal/traceprof/traceprof.go
+++ b/internal/traceprof/traceprof.go
@@ -11,6 +11,11 @@ const (
 	SpanID          = "span id"
 	LocalRootSpanID = "local root span id"
 	TraceEndpoint   = "trace endpoint"
+	// TraceID is the full 128-bit trace ID encoded as a 32-character lowercase
+	// hex string (unlike SpanID/LocalRootSpanID, which are 64-bit decimal). It
+	// lets consumers correlate a sample with the whole trace, not just the local
+	// root span.
+	TraceID = "trace id"
 )
 
 // env variables used to control cross-cutting tracer/profiling features.


### PR DESCRIPTION
### What does this PR do?

Adds the full 128-bit trace ID as a new `trace id` pprof label so the continuous
profiler can correlate samples with the whole trace, not just the local root span.

- New label constant `traceprof.TraceID = "trace id"`, encoded as the whole
  128-bit trace ID in 32-character lowercase hex (unlike the existing 64-bit
  decimal `span id` / `local root span id`).
- `trace id` and `local root span id` are now emitted for **code hotspots** and
  whenever **AppSec is enabled**, so AppSec can correlate security events with
  traces/profiles. `span id` stays gated behind code hotspots and `trace endpoint`
  behind endpoint profiling.
- The gate was moved into `applyPPROFLabels` so `appsec.Enabled()` is evaluated at
  most once per span start (and not at all in the default hotspots-on path, thanks
  to short-circuiting). Label keys remain in alphabetical order for the go1.24
  label optimization.

### Motivation

Today the pprof labels emitted by the tracer only carry the 64-bit `span id` and
`local root span id`. With 128-bit trace IDs, profiler samples cannot be tied to
the whole trace ID, and AppSec has no trace-correlation labels unless the
profiler's code-hotspots feature happens to be enabled. This change makes the full
trace ID available and ensures the correlation labels are present when AppSec is
on.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

> [!NOTE]
> No new/proven backend pprof contract exists yet for a `trace id` label across
> Datadog tracers; the profiler backend must be set up to read `trace id` before
> relying on it for correlation. Value is high-cardinality (unique per trace),
> emitted only under the same gates as the existing correlation labels.
