### PR TITLE
ci(appsec): tolerate Go module cache miss instead of hard-failing

### DIFF
--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -130,7 +130,9 @@ jobs:
           key: ${{ needs.go-mod-caching.outputs.key }}
           restore-keys: go-pkg-mod-
           enableCrossOsArchive: true
-          fail-on-cache-miss: true
+          # Transient cache-service miss/timeout: fall back to a cold rebuild
+          # (modules re-fetched per go.sum) instead of hard-failing the job.
+          fail-on-cache-miss: false
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
@@ -244,7 +246,9 @@ jobs:
           key: ${{ needs.go-mod-caching.outputs.key }}
           restore-keys: go-pkg-mod-
           enableCrossOsArchive: true
-          fail-on-cache-miss: true
+          # Transient cache-service miss/timeout: fall back to a cold rebuild
+          # (modules re-fetched per go.sum) instead of hard-failing the job.
+          fail-on-cache-miss: false
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
@@ -328,7 +332,9 @@ jobs:
           key: ${{ needs.go-mod-caching.outputs.key }}
           restore-keys: go-pkg-mod-
           enableCrossOsArchive: true
-          fail-on-cache-miss: true
+          # Transient cache-service miss/timeout: fall back to a cold rebuild
+          # (modules re-fetched per go.sum) instead of hard-failing the job.
+          fail-on-cache-miss: false
 
       # Docker is not present on early-access ARM runners
       - name: Prepare ARM Runner


### PR DESCRIPTION
### What does this PR do?

The three `Restore Go modules cache` steps in `appsec.yml` (the `macos`, `disabled`, and `golang-linux-container` jobs) set `fail-on-cache-miss: true`. When the GitHub Actions cache service times out during restore, that turns a transient miss into a hard job failure instead of falling back to a rebuild.

Example: [run 30056911582](https://github.com/DataDog/dd-trace-go/actions/runs/30056911582/job/89370524420) — `linux/arm64 golang:1.26-trixie` failed on an `actions/cache` download timeout plus `fail-on-cache-miss`.

This sets `fail-on-cache-miss: false` on those three restore steps.

### Why it's safe

These jobs manage caching themselves (`actions/setup-go` with `cache: false`) and point `GOMODCACHE` at the restored path with no `-mod=readonly`. On a miss, Go re-fetches the modules pinned by `go.sum` — same versions, just a slower run. The `go-mod-caching` job already relies on this cold path.

### Motivation

Removes a class of infra-only CI failures (cache-service timeouts) seen in the CI report for commit `7e9bb86f`. CI-only; no code or `go.mod` changes. Verified with `actionlint`.
