### PR TITLE
ci: extend go1.26.4 pin to remaining test workflows (follow-up to #5056)

### DIFF
--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -86,7 +86,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: stable
+          go-version: "1.26.4"
           cache: false
 
       - name: Cache Go modules
@@ -115,7 +115,7 @@ jobs:
     strategy:
       matrix:
         runs-on: [ macos-14, macos-latest ] # oldest and newest macos runners available
-        go-version: [ "1.26", "1.25" ]
+        go-version: [ "1.26.4", "1.25" ]
       fail-fast: true # saving some CI time - macos runners are too long to get
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -248,7 +248,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: stable
+          go-version: "1.26.4"
           cache: false # we manage the caching ourselves
 
       - run: go env -w GOMODCACHE="${{ github.workspace }}\${{ needs.go-mod-caching.outputs.path }}"
@@ -310,7 +310,7 @@ jobs:
       - go-mod-caching
     strategy:
       matrix:
-        go-version: [ "1.26", "1.25" ]
+        go-version: [ "1.26.4", "1.25" ]
         distribution: [ trixie, bookworm, alpine ]
         platform: [ linux/amd64, linux/arm64 ]
 

--- a/.github/workflows/dynamic-checks.yml
+++ b/.github/workflows/dynamic-checks.yml
@@ -35,7 +35,7 @@ jobs:
     name: Dynamic Analysis with Debug Detection
     uses: ./.github/workflows/unit-integration-tests.yml
     with:
-      go-version: stable
+      go-version: "1.26.4"
       build_tags: "debug"
     secrets: inherit
 
@@ -43,7 +43,7 @@ jobs:
     name: Dynamic Analysis with Deadlock Detection
     uses: ./.github/workflows/unit-integration-tests.yml
     with:
-      go-version: stable
+      go-version: "1.26.4"
       build_tags: "deadlock"
     secrets: inherit
 
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["oldstable", "stable"]
+        go-version: ["oldstable", "1.26.4"]
         build_tags: ["debug", "debug,deadlock"]
       fail-fast: false
     env:

--- a/.github/workflows/main-branch-tests.yml
+++ b/.github/workflows/main-branch-tests.yml
@@ -26,7 +26,7 @@ jobs:
       id-token: write
       pull-requests: write
     with:
-      go-version: "1.26" # Should be the highest supported version of Go
+      go-version: "1.26.4" # Should be the highest supported version of Go
     secrets: inherit
 
   warm-repo-cache:
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         runs-on: [ macos-latest, windows-latest, ubuntu-latest ]
-        go-version: [ "1.25", "1.26" ]
+        go-version: [ "1.25", "1.26.4" ]
       fail-fast: false
     uses: ./.github/workflows/multios-unit-tests.yml
     permissions:

--- a/.github/workflows/orchestrion.yml
+++ b/.github/workflows/orchestrion.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Go and development tools
         uses: ./.github/actions/setup-go
         with:
-          go-version: stable
+          go-version: "1.26.4"
           tools-dir: ${{ github.workspace }}/_tools
           tools-bin: ${{ github.workspace }}/bin
       - name: Run generator
@@ -72,7 +72,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: stable
+          go-version: "1.26.4"
           cache: true
           cache-dependency-path: '**/go.mod'
       - name: Compute Matrix

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,7 +31,7 @@ jobs:
       - warm-repo-cache
     strategy:
       matrix:
-        go-version: [ "1.25", "1.26" ]
+        go-version: [ "1.25", "1.26.4" ]
       fail-fast: false
     uses: ./.github/workflows/unit-integration-tests.yml
     with:
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         runs-on: [ macos-latest, windows-latest, ubuntu-latest ]
-        go-version: [ "1.25", "1.26" ]
+        go-version: [ "1.25", "1.26.4" ]
       fail-fast: false
     uses: ./.github/workflows/multios-unit-tests.yml
     with:


### PR DESCRIPTION
### What does this PR do?

Follow-up to #5056, which pinned Go 1.26.4 (off corruption-prone 1.26.5, `golang/go#77168`) but only in `smoke-tests.yml` + `govulncheck-fix.yml`. The remaining test/build workflows still ran 1.26.5 via `stable`/`"1.26"`, so the same `zip: checksum error` kept hitting the default-branch and PR test matrix.

Extends `"1.26.4"` to the test/build workflows still exposed:

- `main-branch-tests.yml` — the default-branch test driver
- `pull-request.yml`
- `appsec.yml` — macOS + container matrices and two `stable` jobs (the container matrix also feeds the `golang:1.26.x-*` image tags)
- `dynamic-checks.yml`
- `orchestrion.yml`

`oldstable` (1.25.x) and `"1.25"` entries are unchanged.

**`govulncheck.yml` is deliberately left on `stable`.** govulncheck scans the toolchain's stdlib, and 1.26.4 still carries GO-2026-5856 (crypto/tls ECH, CVE-2026-42505, fixed in 1.26.5) — pinning it down reintroduces a real finding. Test/build jobs only need to dodge the corruption, so 1.26.4 is fine for them; the vulnerability scanner has to stay on the latest patch.

### Data

On `smoke-tests.yml` (pinned by #5056), the corruption rate dropped from roughly 40% of runs on 1.26.5 to about 10% on 1.26.4 — a reduction, not a fix. 1.26.4 still fails occasionally (e.g. the 2026-07-24 smoke nightly). The residual is expected until Go ships the #77168 fix in a later 1.26.x.

### Motivation

Reduce default-branch and PR CI flakiness (incident #57895) by removing the remaining exposure to the go1.26.5 build/module-cache corruption. This is temporary: revert to `stable`/`"1.26"` once a fixed Go release is out. CI-only; no code or go.mod changes. Verified with `actionlint`.
