### PR TITLE
fix(ci): prevent shell injection via milestone title in code freeze workflows

### DIFF
--- a/.github/workflows/code_freeze_end.yml
+++ b/.github/workflows/code_freeze_end.yml
@@ -32,11 +32,14 @@ jobs:
           policy: self.code-freeze-end
 
       - name: Log code freeze end
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MILESTONE_TITLE: ${{ github.event.milestone.title }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             echo "🌡️ Code freeze ended manually"
           else
-            echo "🌡️ Code freeze ended by closing milestone: ${{ github.event.milestone.title }}"
+            echo "🌡️ Code freeze ended by closing milestone: $MILESTONE_TITLE"
           fi
 
       - name: Checkout repository

--- a/.github/workflows/code_freeze_start.yml
+++ b/.github/workflows/code_freeze_start.yml
@@ -40,11 +40,15 @@ jobs:
           policy: self.code-freeze-start
 
       - name: Log code freeze trigger
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_MILESTONE_TITLE: ${{ github.event.inputs.milestone_title }}
+          MILESTONE_TITLE: ${{ github.event.milestone.title }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "🥶 Code freeze triggered manually for milestone: ${{ github.event.inputs.milestone_title }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "🥶 Code freeze triggered manually for milestone: $INPUT_MILESTONE_TITLE"
           else
-            echo "🥶 Code freeze triggered by milestone: ${{ github.event.milestone.title }}"
+            echo "🥶 Code freeze triggered by milestone: $MILESTONE_TITLE"
           fi
 
       - name: Checkout repository


### PR DESCRIPTION
## What

The code freeze workflows passed the milestone title straight into a `run:` shell block via `${{ github.event.milestone.title }}` (and, on start, the `workflow_dispatch` title input). GitHub Actions expands `${{ }}` before bash sees the script, so a crafted milestone title runs as shell on the runner.

This routes those values through `env:` and reads them back as shell variables, so bash treats them as data. It is the same indirection already used for PR titles in `pull-request-title-validation.yml`.

## Why it matters

Creating a milestone needs only the Triage role. The freeze job runs with `id-token: write` after `dd-octo-sts` mints a privileged token, so an injected command would run with that token in scope and could forge the `code-freeze` status check to bypass the merge gate. Low severity: insider-only, no external-attacker path. Still a privilege boundary worth closing.

Tracking: APMSP-3535. Introduced by #4276.

## Test

- `make lint/action` (actionlint) passes on the full workflow set.
- No attacker-controllable `${{ github.event.* }}` remains inside a `run:` block in either file.
- The `github.event_name` / `github.repository` references left in the unrelated `check_remaining` step are trusted GitHub contexts (fixed event enum / `owner/repo` slug), not attacker input.
- `${{ }}` in the `if:` guards is evaluated by the Actions expression engine, not bash, so it is not an injection vector.

> Note: `actionlint` has no script-injection rule (that is `zizmor`'s domain), so the lint pass confirms workflow validity, not the security property. The fix relies on the `env:`-indirection pattern; `zizmor .github/workflows/` can be run in CI to detect this class going forward.
