### PR TITLE
ci(appsec): propagate core package test failures on macOS

### DIFF
--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -174,6 +174,7 @@ jobs:
                   # shellcheck disable=SC2086
                   if ! env CGO_ENABLED="$cgo" $appsec_enabled_env $goexp_env gotestsum --junitfile "$GITHUB_WORKSPACE/tmp_appsec/gotestsum-report-${cgo}-${appsec_enabled_env:-default}-${goexp_label}.xml" -- -v $PACKAGES; then
                     echo "Failed: env CGO_ENABLED=$cgo $appsec_enabled_env $goexp_env gotestsum --junitfile \"$GITHUB_WORKSPACE/tmp_appsec/gotestsum-report-${cgo}-${appsec_enabled_env:-default}-${goexp_label}.xml\" -- -v $PACKAGES"
+                    report_error=1
                   fi
 
                   # shellcheck disable=SC2086


### PR DESCRIPTION
### What does this PR do?

Records failures from the core AppSec package test command in `report_error`, matching the existing contrib submodule failure handling. The job still runs every configuration and produces all test reports, then exits nonzero if any core or submodule test failed.

### Motivation

The core test command runs inside a negated `if`, so `set -e` does not terminate the script when it fails. Without updating `report_error`, the macOS AppSec job can exit successfully when a core package test fails and all contrib submodule tests pass.

### Validation

- `make lint/action`
- Focused shell regression check confirming execution continues after a failure and exits nonzero at the end