### PR TITLE
fix(telemetry): propagate non-error JSON marshal panics through request bodies

### DIFF
--- a/internal/telemetry/internal/writer.go
+++ b/internal/telemetry/internal/writer.go
@@ -239,8 +239,10 @@ func (w *writer) newRequest(endpoint *http.Request, requestType transport.Reques
 					panicErr, ok := panicValue.(error) // check if we can use the panic value as an error
 					if ok {
 						log.Error("telemetry/writer: panic while encoding payload: %v", panicErr.Error())
+					} else {
+						panicErr = fmt.Errorf("telemetry/writer: panic while encoding payload: %v", panicValue)
 					}
-					pipeWriter.CloseWithError(panicErr) // CloseWithError with nil as parameter is like Close()
+					pipeWriter.CloseWithError(panicErr)
 				}
 			}
 		}()

--- a/internal/telemetry/internal/writer_test.go
+++ b/internal/telemetry/internal/writer_test.go
@@ -7,6 +7,7 @@ package internal
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -145,6 +146,32 @@ func TestWriter_Flush_Success(t *testing.T) {
 	assert.NotZero(t, bytesSent)
 	assert.True(t, marshalJSONCalled.Load())
 	assert.True(t, payloadReceived.Load())
+}
+
+func TestWriter_NewRequest_PropagatesMarshalPanic(t *testing.T) {
+	tests := map[string]any{
+		"error":  errors.New("boom"),
+		"string": "boom",
+	}
+
+	for name, panicValue := range tests {
+		t.Run(name, func(t *testing.T) {
+			payload := &testPayload{
+				RequestTypeValue: "test",
+				marshalJSON: func() ([]byte, error) {
+					panic(panicValue)
+				},
+			}
+			w := &writer{body: newBody(TracerConfig{}, false)}
+			w.setPayloadToBody(payload)
+
+			request := w.newRequest(&http.Request{Header: make(http.Header)}, payload.RequestType())
+			defer request.Body.Close()
+
+			_, err := io.ReadAll(request.Body)
+			require.ErrorContains(t, err, "boom")
+		})
+	}
 }
 
 func TestWriter_Flush_Failure(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Converts non-error panic values raised during telemetry JSON encoding into errors before closing the HTTP request body pipe. This matches the existing Bazel payload-file behavior and preserves error-valued panics unchanged.

Adds regression coverage for both `panic("boom")` and `panic(errors.New("boom"))`.

### Motivation

The request-body encoder previously type-asserted recovered panic values to `error`. For string or other non-error panic values, that produced `nil`, and `CloseWithError(nil)` cleanly closed the pipe. The body reader then received EOF instead of the serialization failure, allowing an empty or truncated telemetry payload to lose its original error.

### Validation

- `go test -race ./internal/telemetry/internal -count=1`
- `bin/golangci-lint run ./internal/telemetry/internal`