### PR TITLE
feat: update eventbridge DSM tags (shadow)

### DIFF
--- a/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
+++ b/contrib/aws/aws-sdk-go-v2/aws/aws_test.go
@@ -895,7 +895,8 @@ func eventBridgeEdgeTagsForTest(entry *eventBridgeTypes.PutEventsRequestEntry) [
 	return []string{
 		"direction:out",
 		"type:eventbridge",
-		"topic:" + eventBridgeNameForTest(entry) + ":" + eventBridgeDetailTypeForTest(entry),
+		"topic:" + eventBridgeDetailTypeForTest(entry),
+		"exchange:" + eventBridgeNameForTest(entry),
 	}
 }
 

--- a/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge.go
+++ b/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge.go
@@ -84,7 +84,8 @@ func eventBridgeEdgeTags(entry *types.PutEventsRequestEntry) []string {
 	return []string{
 		"direction:out",
 		"type:eventbridge",
-		"topic:" + eventBusName(entry) + ":" + detailType(entry),
+		"topic:" + detailType(entry),
+		"exchange:" + eventBusName(entry),
 	}
 }
 

--- a/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge_test.go
+++ b/contrib/aws/aws-sdk-go-v2/internal/eventbridge/eventbridge_test.go
@@ -249,7 +249,7 @@ func TestEventBridgeEdgeTags(t *testing.T) {
 	}
 
 	assert.Equal(t,
-		[]string{"direction:out", "type:eventbridge", "topic:orders-bus:order.created"},
+		[]string{"direction:out", "type:eventbridge", "topic:order.created", "exchange:orders-bus"},
 		eventBridgeEdgeTags(entry),
 	)
 }


### PR DESCRIPTION
Shadow PR for CI jobs that cannot run on fork PRs.

Original PR: https://github.com/DataDog/dd-trace-go/pull/5079 (by @jeastham1993)