### PR TITLE
fix(internal/orchestrion): exit GLS scopes by token, not by stack position

### DIFF
--- a/ddtrace/tracer/orchestrion.yml
+++ b/ddtrace/tracer/orchestrion.yml
@@ -151,12 +151,13 @@ aspects:
   # WrapContext) so the injected templates stay thin and unit-testable.
 
   # Add the GLS bookkeeping fields to Span, and expose GLSReclaimable so
-  # internal/orchestrion.contextStack can recognise finished entries that were
-  # left behind because the pop did not match the span that finished: Pop takes
-  # the top of the stack, so a non-LIFO finish strands an entry (a cross-goroutine
-  # finish is one way, since its popper is a no-op off-goroutine). Push drops such
-  # entries and Peek refuses to hand them out as the active span, so the flag has
-  # to stay accurate for the lifetime of the entry, not just until the next push.
+  # internal/orchestrion.contextStack can recognise entries left behind by a
+  # cross-goroutine finish. Scope exit is identity-matched, so a finish on the
+  # pushing goroutine always removes its own entry; a finish elsewhere cannot,
+  # because the popper is a no-op off-goroutine and a foreign stack must not be
+  # touched. Push drops such entries and Peek refuses to hand them out as the
+  # active span, so the flag has to stay accurate for the lifetime of the entry,
+  # not just until the next push.
   - id: Span GLS fields
     tracer-internal: true
     join-point:

--- a/internal/orchestrion/_integration/gls/span_gls_test.go
+++ b/internal/orchestrion/_integration/gls/span_gls_test.go
@@ -216,9 +216,9 @@ func TestSpanGLSFinishedParentOnlyHonoredViaExplicitContext(t *testing.T) {
 // TestSpanGLSSequentialRequestsStayIndependent is the APMS-20132 reproduction: the
 // shape that produced a reported 9,780-span trace spanning 50+ unrelated endpoints.
 //
-// Stranding an entry does not need a second goroutine. [contextStack.Pop] removes
-// the top of the stack rather than the span that finished, so any non-LIFO finish
-// strands something:
+// Stranding an entry does not need a second goroutine. An exit that matches
+// position removes the top of the stack rather than the scope that ended, so any
+// non-LIFO finish strands something:
 //
 //	[srv]                  the request's own span
 //	[srv, child]           a child span
@@ -266,6 +266,62 @@ func TestSpanGLSSequentialRequestsStayIndependent(t *testing.T) {
 	require.Lenf(t, seenTraceIDs, requests,
 		"expected %d distinct trace_ids, got %d: requests were chained into a shared trace",
 		requests, len(seenTraceIDs))
+}
+
+// TestSpanGLSLiveSurvivorDoesNotParentNextRequest is the half of APMS-20132 that
+// survives the Peek guard, and the reason the exit has to be by scope rather than
+// by position.
+//
+// TestSpanGLSSequentialRequestsStayIndependent above strands the request's own
+// span, which is FINISHED — Peek skips it. Stranding a LIVE span takes one more
+// level of nesting and nothing else:
+//
+//	[srv]                the request's own span
+//	[srv, child]         a child that outlives the request
+//	[srv, child, leaf]   a child of that child
+//	srv.Finish()         a top-pop takes leaf, leaving [srv(finished), child(live)]
+//
+// Peek walks down, skips the finished srv, and stops at child — which is live, so
+// there is nothing about it for a read-side guard to reject. The next request on
+// this goroutine carries no span in its context, so the GLS is its only parent
+// source, and it joins child's trace. The request after that joins that one, and
+// the connection collapses into a single trace_id.
+//
+// Exiting srv's scope removes srv along with everything opened inside it, so the
+// next request finds an empty stack. This runs on a single goroutine, which is
+// what net/http gives a keep-alive connection serving requests sequentially.
+func TestSpanGLSLiveSurvivorDoesNotParentNextRequest(t *testing.T) {
+	if !orchestrionEnabled {
+		t.Skip("GLS only exists in orchestrion builds")
+	}
+	require.True(t, built.WithOrchestrion)
+
+	require.NoError(t, tracer.Start(tracer.WithLogStartup(false)))
+	defer tracer.Stop()
+
+	const requests = 20
+	seenTraceIDs := make(map[string]struct{}, requests)
+	outliving := make([]*tracer.Span, 0, 2*requests)
+
+	for range requests {
+		span, ctx := tracer.StartSpanFromContext(context.Background(), "http.request")
+		child, childCtx := tracer.StartSpanFromContext(ctx, "async.work")
+		leaf, _ := tracer.StartSpanFromContext(childCtx, "async.work.step")
+		outliving = append(outliving, child, leaf)
+
+		// The non-LIFO finish. A position-matched exit would take leaf's slot
+		// here and leave child live on the stack after the scope that opened it
+		// has ended; the scope exit takes child and leaf along with srv.
+		span.Finish()
+		seenTraceIDs[span.Context().TraceID()] = struct{}{}
+	}
+	for _, span := range outliving {
+		span.Finish()
+	}
+
+	require.Lenf(t, seenTraceIDs, requests,
+		"expected %d distinct trace_ids, got %d: a live span outlived its request's scope "+
+			"and parented the next request", requests, len(seenTraceIDs))
 }
 
 // TestSpanGLSDoubleFinishSameGoroutine verifies the injected pop both restores

--- a/internal/orchestrion/context.go
+++ b/internal/orchestrion/context.go
@@ -96,7 +96,23 @@ type GLSPopper func()
 // most once. The zero value is ready to use; a nil inner pointer means no
 // popper is currently captured.
 type GLSPopperCell struct {
-	ptr atomic.Pointer[GLSPopper]
+	ptr atomic.Pointer[glsExit]
+}
+
+// glsExit is what a [GLSPopperCell] actually holds: the captured exit together
+// with the token of the entry it closes.
+//
+// The token is here so that removing an entry can tell whether the exit it is
+// about to discard is that entry's, or a different and still-live activation's.
+// One value activated more than once shares a single cell, and first-wins means
+// the exit names the FIRST activation. Activate B, then A, then B again: closing
+// A sweeps A and the upper B, but the cell those entries point at is the lower
+// B's only way out, so clearing it unconditionally strands the lower B. Pairing
+// the two in one struct keeps them consistent under a single atomic load, which
+// two separate fields could not do.
+type glsExit struct {
+	pop   GLSPopper
+	token uint64
 }
 
 // GLSActivate is woven into span/operation activation (the tracer's
@@ -135,8 +151,7 @@ func GLSActivate(ctxp *context.Context, key, val any, pop *GLSPopperCell) {
 		// on re-activation). CompareAndSwap keeps this race-free when two
 		// goroutines activate concurrently: only one CAS wins; the other's
 		// closure is discarded, preserving first-wins semantics.
-		fn := GLSPopper(GLSPopFunc(key, token))
-		pop.ptr.CompareAndSwap(nil, &fn)
+		pop.ptr.CompareAndSwap(nil, &glsExit{pop: GLSPopFunc(key, token), token: token})
 	}
 }
 
@@ -158,8 +173,8 @@ func GLSDeactivate(reclaimable *atomic.Bool, pop *GLSPopperCell) {
 	}
 	// Atomically read and clear the popper so a repeated or concurrent finish
 	// invokes it at most once.
-	if fn := pop.ptr.Swap(nil); fn != nil {
-		(*fn)()
+	if e := pop.ptr.Swap(nil); e != nil {
+		e.pop()
 	}
 }
 

--- a/internal/orchestrion/context.go
+++ b/internal/orchestrion/context.go
@@ -38,7 +38,7 @@ func CtxWithValue(parent context.Context, key, val any) context.Context {
 		return context.WithValue(parent, key, val)
 	}
 
-	getDDContextStack().Push(key, val)
+	getDDContextStack().Push(key, val, nil)
 	return context.WithValue(WrapContext(parent), key, val)
 }
 
@@ -62,8 +62,8 @@ func CtxWithScopedValue(parent context.Context, key, val any) (context.Context, 
 		return context.WithValue(parent, key, val), glsNoop
 	}
 
-	token := getDDContextStack().Push(key, val)
-	return context.WithValue(WrapContext(parent), key, val), GLSPopFunc(key, token)
+	token := getDDContextStack().Push(key, val, nil)
+	return context.WithValue(WrapContext(parent), key, val), GLSPopEntryFunc(key, token)
 }
 
 // GLSPopValue pops the value from the GLS slot of orchestrion and returns it. Using context.Context values usually does
@@ -126,7 +126,7 @@ func GLSActivate(ctxp *context.Context, key, val any, pop *GLSPopperCell) {
 	if ctxp != nil {
 		*ctxp = WrapContext(*ctxp)
 	}
-	token := getDDContextStack().Push(key, val)
+	token := getDDContextStack().Push(key, val, pop)
 	if pop != nil && pop.ptr.Load() == nil {
 		// Capture the popper only on the first activation (first-wins) so
 		// re-activating the same span/operation does not overwrite the popper
@@ -200,6 +200,23 @@ func GLSPopFunc(key any, token uint64) func() {
 	return func() {
 		if gls := getDDGLS(); gls != nil && gls.(*contextStack) == pushStack {
 			pushStack.PopScope(key, token)
+		}
+	}
+}
+
+// GLSPopEntryFunc is [GLSPopFunc] for a key whose entries are independent scopes
+// rather than nested ones: it removes only the entry it opened, leaving anything
+// pushed above it to be closed by whatever owns it. Use this whenever the key is
+// shared with a positional [GLSPopValue] exit, which would otherwise reach past
+// its own scope once its entry had been swept. See [contextStack.PopEntry].
+func GLSPopEntryFunc(key any, token uint64) func() {
+	if !Enabled() {
+		return glsNoop
+	}
+	pushStack := getDDContextStack()
+	return func() {
+		if gls := getDDGLS(); gls != nil && gls.(*contextStack) == pushStack {
+			pushStack.PopEntry(key, token)
 		}
 	}
 }

--- a/internal/orchestrion/context.go
+++ b/internal/orchestrion/context.go
@@ -42,10 +42,37 @@ func CtxWithValue(parent context.Context, key, val any) context.Context {
 	return context.WithValue(WrapContext(parent), key, val)
 }
 
+// CtxWithScopedValue is [CtxWithValue] with a matching scope exit: it pushes val
+// under key and returns the derived context along with a cleanup that removes
+// the entry this call pushed, plus anything still stacked above it.
+//
+// Use it wherever the scope can close out of order. [GLSPopValue] takes the top
+// of the stack, so a non-LIFO close pops an unrelated entry and strands its own,
+// leaving a scope on the GLS after it ended.
+//
+// The cleanup is goroutine-scoped (see [GLSPopFunc]): off the pushing goroutine
+// it does nothing, so it cannot corrupt a foreign stack. Calling it more than
+// once is harmless — after the first call the token is gone and the rest are
+// no-ops.
+//
+// When orchestrion is disabled this degrades to context.WithValue and a cleanup
+// that does nothing.
+func CtxWithScopedValue(parent context.Context, key, val any) (context.Context, func()) {
+	if !Enabled() {
+		return context.WithValue(parent, key, val), glsNoop
+	}
+
+	token := getDDContextStack().Push(key, val)
+	return context.WithValue(WrapContext(parent), key, val), GLSPopFunc(key, token)
+}
+
 // GLSPopValue pops the value from the GLS slot of orchestrion and returns it. Using context.Context values usually does
 // not require to pop any stack because the copy of each previous context makes the local variable in the scope disappear
 // when the current function ends. But the GLS is a semi-global variable that can be accessed from any function in the
 // stack, so we need to pop the value when we are done with it.
+//
+// This takes the top of the stack, so it is only correct for keys whose scopes
+// close strictly LIFO. Anything else must use [CtxWithScopedValue].
 func GLSPopValue(key any) any {
 	if !Enabled() {
 		return nil
@@ -77,9 +104,13 @@ type GLSPopperCell struct {
 // goroutine's GLS stack under key and records a goroutine-scoped popper into
 // pop, capturing it only on the first activation so re-activating the same
 // span/operation does not overwrite the popper its matching GLSDeactivate will
-// run. The captured popper pops the top of the pushing goroutine's stack and is
-// a no-op on any other goroutine, so a cross-goroutine finish can never corrupt
-// an unrelated goroutine's stack.
+// run. The captured popper closes the scope this push opened — that entry and
+// anything still stacked above it — and is a no-op on any other goroutine, so a
+// cross-goroutine finish can never corrupt an unrelated goroutine's stack.
+//
+// First-wins and scope exit compose: a re-activated span keeps the popper from
+// its first push, so deactivating removes the scope from where the span first
+// became active, taking any later duplicate push of the same span with it.
 //
 // When ctxp is non-nil the parent context is wrapped (via WrapContext) so the
 // returned context is also GLS-aware, matching the former in-source CtxWithValue.
@@ -95,7 +126,7 @@ func GLSActivate(ctxp *context.Context, key, val any, pop *GLSPopperCell) {
 	if ctxp != nil {
 		*ctxp = WrapContext(*ctxp)
 	}
-	getDDContextStack().Push(key, val)
+	token := getDDContextStack().Push(key, val)
 	if pop != nil && pop.ptr.Load() == nil {
 		// Capture the popper only on the first activation (first-wins) so
 		// re-activating the same span/operation does not overwrite the popper
@@ -104,7 +135,7 @@ func GLSActivate(ctxp *context.Context, key, val any, pop *GLSPopperCell) {
 		// on re-activation). CompareAndSwap keeps this race-free when two
 		// goroutines activate concurrently: only one CAS wins; the other's
 		// closure is discarded, preserving first-wins semantics.
-		fn := GLSPopper(GLSPopFunc(key))
+		fn := GLSPopper(GLSPopFunc(key, token))
 		pop.ptr.CompareAndSwap(nil, &fn)
 	}
 }
@@ -145,20 +176,30 @@ func GLSReset(reclaimable *atomic.Bool, pop *GLSPopperCell) {
 	}
 }
 
-// GLSPopFunc returns a function that pops key from the GLS context stack of the
-// goroutine that called GLSPopFunc. The returned function is safe to call from
-// any goroutine: it compares the current goroutine's GLS contextStack pointer
-// with the one captured at creation time and only pops if they match (i.e.,
-// same goroutine). On a different goroutine the pop is a no-op, preventing
-// accidental corruption of another goroutine's GLS state.
-func GLSPopFunc(key any) func() {
+// GLSPopFunc returns a function that closes the scope token opened under key on
+// the GLS context stack of the goroutine that called GLSPopFunc. token comes
+// from the [contextStack.Push] that opened the scope.
+//
+// The returned function is safe to call from any goroutine: it compares the
+// current goroutine's GLS contextStack pointer with the one captured at creation
+// time and only acts if they match (i.e., same goroutine). On a different
+// goroutine it is a no-op, preventing accidental corruption of another
+// goroutine's GLS state — which is also why the reclaim path in [reclaimable]
+// still has to exist: a cross-goroutine finish cannot reach the foreign slice at
+// all, so those entries are only ever cleaned up lazily.
+//
+// The exit is by token, not by position, so an out-of-order close removes the
+// entry it actually opened (plus anything still stacked above it, which was
+// opened inside that scope) rather than whatever is on top. A token that has
+// already been removed matches nothing, so a late or repeated call does nothing.
+func GLSPopFunc(key any, token uint64) func() {
 	if !Enabled() {
 		return glsNoop
 	}
 	pushStack := getDDContextStack()
 	return func() {
 		if gls := getDDGLS(); gls != nil && gls.(*contextStack) == pushStack {
-			pushStack.Pop(key)
+			pushStack.PopScope(key, token)
 		}
 	}
 }

--- a/internal/orchestrion/context_stack.go
+++ b/internal/orchestrion/context_stack.go
@@ -17,6 +17,12 @@ import "slices"
 type entry struct {
 	val   any
 	token uint64
+	// pop is the cell holding the exit captured for this value, so that removing
+	// the entry can invalidate it. Without that, a value swept away by an
+	// enclosing scope keeps an exit naming a token that no longer exists: its
+	// next activation sees a non-nil cell, keeps the stale exit under first-wins,
+	// and the entry that activation pushes is never closed by anything.
+	pop *GLSPopperCell
 }
 
 // contextStack is stored in the GLS slot of runtime.g inserted by orchestrion.
@@ -79,12 +85,80 @@ func getDDContextStack() *contextStack {
 	return newStack
 }
 
+// PopEntry removes exactly the entry token opened under key, leaving anything
+// pushed above it in place, and reports whether it found one.
+//
+// This is the counterpart to [contextStack.PopScope] for a key whose entries are
+// not nested scopes. PopScope also drops everything above its target, which is
+// right when those entries were opened inside the scope now ending and so cannot
+// outlive it. It is wrong when they are independent scopes owning their own
+// exits: sweeping one away does not cancel its exit, and if that exit is
+// positional ([contextStack.Pop]) it then removes an unrelated entry further
+// down the stack.
+//
+// internal.executionTracedKey is exactly that case. It holds plain bools pushed
+// by WithExecutionTraced, whose paired PopExecutionTraced takes the top of the
+// stack, sharing the key with the scope-exact override from
+// ScopedExecutionNotTraced. Removing only our own entry keeps the two exits from
+// colliding while still fixing what PopScope was introduced for here: the
+// override is removed by identity, so a non-LIFO exit can no longer strand it
+// and leave the stack claiming "not traced" for everything after it.
+func (s *contextStack) PopEntry(key any, token uint64) bool {
+	if s == nil || s.stacks == nil || token == 0 {
+		return false
+	}
+
+	stack := s.stacks[key]
+	for i, e := range slices.Backward(stack) {
+		if e.token == token {
+			s.remove(key, stack, i)
+			return true
+		}
+		if e.token < token {
+			return false
+		}
+	}
+
+	return false
+}
+
+// remove deletes the single entry at i. Deleting from the middle keeps tokens
+// ascending, so [contextStack.PopScope]'s and [contextStack.PopEntry]'s early
+// exit stays valid; slices.Delete zeroes the vacated tail so a dropped value is
+// not retained.
+func (s *contextStack) remove(key any, stack []entry, i int) {
+	invalidatePoppers(stack[i : i+1])
+	stack = slices.Delete(stack, i, i+1)
+
+	if len(stack) == 0 {
+		delete(s.stacks, key)
+		return
+	}
+	s.stacks[key] = stack
+}
+
+// invalidatePoppers clears the captured exit of every entry being removed, so a
+// value activated again later captures a fresh one for its new token instead of
+// keeping an exit that names a scope already gone.
+//
+// Clearing is safe for an entry whose owner has not finished yet: its entry is
+// being removed here, so there is nothing left for its exit to do, and
+// GLSDeactivate's Swap simply finds nil and runs nothing.
+func invalidatePoppers(removed []entry) {
+	for _, e := range removed {
+		if e.pop != nil {
+			e.pop.ptr.Store(nil)
+		}
+	}
+}
+
 // truncate drops stack[i:] from key's slice. The removed elements are zeroed so
 // the GC can collect the values they held, and the key is deleted outright once
 // nothing remains under it, keeping the map from retaining empty slices.
 //
 // stack is passed in rather than re-read because every caller already holds it.
 func (s *contextStack) truncate(key any, stack []entry, i int) {
+	invalidatePoppers(stack[i:])
 	clear(stack[i:])
 	stack = stack[:i]
 
@@ -149,7 +223,7 @@ func (s *contextStack) Peek(key any) any {
 // restore target, so dropping it preserves stack semantics. Entries whose type
 // does not implement [reclaimable] (e.g. the bool stored under
 // executionTracedKey) are never dropped.
-func (s *contextStack) Push(key, val any) uint64 {
+func (s *contextStack) Push(key, val any, pop *GLSPopperCell) uint64 {
 	if s == nil {
 		return 0
 	}
@@ -164,7 +238,7 @@ func (s *contextStack) Push(key, val any) uint64 {
 	}
 
 	s.next++
-	s.stacks[key] = append(stack, entry{val: val, token: s.next})
+	s.stacks[key] = append(stack, entry{val: val, token: s.next, pop: pop})
 	return s.next
 }
 

--- a/internal/orchestrion/context_stack.go
+++ b/internal/orchestrion/context_stack.go
@@ -146,8 +146,16 @@ func (s *contextStack) remove(key any, stack []entry, i int) {
 // GLSDeactivate's Swap simply finds nil and runs nothing.
 func invalidatePoppers(removed []entry) {
 	for _, e := range removed {
-		if e.pop != nil {
-			e.pop.ptr.Store(nil)
+		if e.pop == nil {
+			continue
+		}
+		// Only discard the exit if it is this entry's. A value activated more than
+		// once shares one cell whose exit names the first activation, so an entry
+		// removed from above must leave it alone — it is the surviving lower
+		// entry's only way out. CompareAndSwap rather than Store so an exit
+		// captured between the load and here is not clobbered.
+		if cur := e.pop.ptr.Load(); cur != nil && cur.token == e.token {
+			e.pop.ptr.CompareAndSwap(cur, nil)
 		}
 	}
 }

--- a/internal/orchestrion/context_stack.go
+++ b/internal/orchestrion/context_stack.go
@@ -7,10 +7,35 @@ package orchestrion
 
 import "slices"
 
+// entry is one pushed value together with the token identifying its scope.
+//
+// A token is what makes scope exit possible. A position cannot identify a scope:
+// push, pop, push again lands the new value at the same index, so an index
+// captured at push time can name an entirely different scope by the time the
+// exit runs. Tokens are handed out by a counter that only ever increases, so a
+// stale one matches nothing.
+type entry struct {
+	val   any
+	token uint64
+}
+
 // contextStack is stored in the GLS slot of runtime.g inserted by orchestrion.
 // It holds context values shared within a single goroutine.
+//
+// The stack is per-goroutine and unsynchronised by design, so next is a plain
+// counter rather than an atomic. It lives on the struct rather than alongside
+// each key's slice because Pop and PopScope delete a key once it empties: a
+// per-key counter would restart from zero on the next push under that key and
+// re-issue a token some popper is still holding.
+//
 // TODO: handle cross-goroutine context values
-type contextStack map[any][]any
+type contextStack struct {
+	stacks map[any][]entry
+	// next is the last token handed out. Push pre-increments, so the first
+	// token is 1 and 0 is free to mean "no scope" — what Push returns when it
+	// pushed nothing, and a value PopScope never matches.
+	next uint64
+}
 
 // reclaimable is implemented by GLS values that can signal they no longer
 // represent a live scope. It is used to bound GLS growth when a value is pushed
@@ -54,6 +79,22 @@ func getDDContextStack() *contextStack {
 	return newStack
 }
 
+// truncate drops stack[i:] from key's slice. The removed elements are zeroed so
+// the GC can collect the values they held, and the key is deleted outright once
+// nothing remains under it, keeping the map from retaining empty slices.
+//
+// stack is passed in rather than re-read because every caller already holds it.
+func (s *contextStack) truncate(key any, stack []entry, i int) {
+	clear(stack[i:])
+	stack = stack[:i]
+
+	if len(stack) == 0 {
+		delete(s.stacks, key)
+		return
+	}
+	s.stacks[key] = stack
+}
+
 // Peek returns the innermost live context from the stack without removing it.
 //
 // Entries reporting themselves reclaimable (see [reclaimable]) are skipped: they
@@ -77,26 +118,27 @@ func getDDContextStack() *contextStack {
 // Peek does not mutate the stack. Values that do not implement [reclaimable] are
 // returned as-is.
 //
-// This addresses a finished entry being surfaced as a parent. It does not help
-// when a still-live entry outlives the scope beneath it: because the pop matches
-// position rather than identity, a scope can be left buried under a live sibling
-// that then parents unrelated later work. Fixing that needs scope-exit semantics
-// (removing an entry and everything above it), not a read-side guard.
+// This addresses a finished entry being surfaced as a parent. It is not what
+// keeps a live entry from outliving the scope beneath it — that is [PopScope]'s
+// job, since no read-side guard can tell a live survivor from a legitimately
+// nested scope.
 func (s *contextStack) Peek(key any) any {
-	if s == nil || *s == nil {
+	if s == nil || s.stacks == nil {
 		return nil
 	}
 
-	for _, v := range slices.Backward((*s)[key]) {
-		if !isReclaimable(v) {
-			return v
+	for _, e := range slices.Backward(s.stacks[key]) {
+		if !isReclaimable(e.val) {
+			return e.val
 		}
 	}
 
 	return nil
 }
 
-// Push adds a context to the stack.
+// Push adds a context to the stack and returns the token identifying the scope
+// it just opened. Pass that token to [PopScope] to close the scope; a zero
+// return means nothing was pushed and there is nothing to close.
 //
 // Before appending, Push drops any trailing entries that report themselves
 // reclaimable (see [reclaimable]). This bounds GLS growth when values are
@@ -107,42 +149,76 @@ func (s *contextStack) Peek(key any) any {
 // restore target, so dropping it preserves stack semantics. Entries whose type
 // does not implement [reclaimable] (e.g. the bool stored under
 // executionTracedKey) are never dropped.
-func (s *contextStack) Push(key, val any) {
-	if s == nil || *s == nil {
-		return
+func (s *contextStack) Push(key, val any) uint64 {
+	if s == nil {
+		return 0
+	}
+	if s.stacks == nil {
+		s.stacks = make(map[any][]entry)
 	}
 
-	stack := (*s)[key]
-	for len(stack) > 0 && isReclaimable(stack[len(stack)-1]) {
-		stack[len(stack)-1] = nil // drop reference so GC can collect the value
+	stack := s.stacks[key]
+	for len(stack) > 0 && isReclaimable(stack[len(stack)-1].val) {
+		stack[len(stack)-1] = entry{} // drop reference so GC can collect the value
 		stack = stack[:len(stack)-1]
 	}
 
-	(*s)[key] = append(stack, val)
+	s.next++
+	s.stacks[key] = append(stack, entry{val: val, token: s.next})
+	return s.next
+}
+
+// PopScope closes the scope token opened under key: it removes that entry and
+// every entry pushed above it, and reports whether it found one to remove.
+//
+// This is what [Pop] cannot do. Pop takes the top of the stack, so any finish
+// that is not strictly LIFO takes somebody else's entry and strands its own —
+// leaving a scope on the stack after it ended, where a later read adopts it as
+// the active one. Removing everything above the target is the point rather than
+// a side effect: those entries were opened inside the scope now ending, so none
+// of them can outlive it either.
+//
+// Tokens ascend from the bottom of a key's slice, so the walk from the top can
+// stop as soon as it passes below the target: a smaller token means the scope is
+// already gone and there is nothing to do. That makes a repeated or late exit a
+// cheap no-op rather than a destructive one — the guarantee a stale token needs,
+// since the position it once occupied may now belong to an unrelated scope.
+func (s *contextStack) PopScope(key any, token uint64) bool {
+	if s == nil || s.stacks == nil || token == 0 {
+		return false
+	}
+
+	stack := s.stacks[key]
+	for i, e := range slices.Backward(stack) {
+		if e.token == token {
+			s.truncate(key, stack, i)
+			return true
+		}
+		if e.token < token {
+			return false
+		}
+	}
+
+	return false
 }
 
 // Pop removes the top context from the stack and returns it.
+//
+// Prefer [PopScope] for anything that can finish out of order: Pop matches
+// position, not identity, so it removes whatever happens to be on top.
 func (s *contextStack) Pop(key any) any {
-	if s == nil || *s == nil {
+	if s == nil || s.stacks == nil {
 		return nil
 	}
 
-	stack, ok := (*s)[key]
-	if !ok || len(stack) == 0 {
-		return nil
-	}
-
-	lastIdx := len(stack) - 1
-	val := stack[lastIdx]
-	// slices.Delete zeroes removed elements in the backing array,
-	// allowing GC to collect popped values.
-	stack = slices.Delete(stack, lastIdx, lastIdx+1)
-
+	stack := s.stacks[key]
 	if len(stack) == 0 {
-		delete(*s, key)
-	} else {
-		(*s)[key] = stack
+		return nil
 	}
+
+	last := len(stack) - 1
+	val := stack[last].val
+	s.truncate(key, stack, last)
 
 	return val
 }
@@ -150,12 +226,12 @@ func (s *contextStack) Pop(key any) any {
 // Depth returns the total number of entries across all keys in the stack.
 // This is useful for detecting GLS leaks where entries are pushed but never popped.
 func (s *contextStack) Depth() int {
-	if s == nil || *s == nil {
+	if s == nil || s.stacks == nil {
 		return 0
 	}
 
 	n := 0
-	for _, stack := range *s {
+	for _, stack := range s.stacks {
 		n += len(stack)
 	}
 	return n

--- a/internal/orchestrion/context_stack_test.go
+++ b/internal/orchestrion/context_stack_test.go
@@ -16,7 +16,7 @@ import (
 type stackTestKey struct{}
 
 func TestPopNilsBackingArrayElement(t *testing.T) {
-	s := contextStack(make(map[any][]any))
+	var s contextStack
 
 	// Push two values so popping one keeps the map entry alive (len > 0).
 	// This lets us inspect the backing array for the cleared slot.
@@ -29,19 +29,19 @@ func TestPopNilsBackingArrayElement(t *testing.T) {
 
 	// The map entry still exists (one element remains). Check that the
 	// backing array slot at index 1 was cleared so GC can collect it.
-	stack := s[stackTestKey{}]
+	stack := s.stacks[stackTestKey{}]
 	require.Len(t, stack, 1, "one element should remain")
 	rawSlice := stack[:cap(stack)]
-	assert.Nil(t, rawSlice[1], "popped element should be nil in backing array to allow GC")
+	assert.Zero(t, rawSlice[1], "popped element should be zeroed in backing array to allow GC")
 }
 
 func TestPopCleansUpEmptyMapEntry(t *testing.T) {
-	s := contextStack(make(map[any][]any))
+	var s contextStack
 
 	s.Push(stackTestKey{}, "value")
 	s.Pop(stackTestKey{})
 
-	_, exists := s[stackTestKey{}]
+	_, exists := s.stacks[stackTestKey{}]
 	assert.False(t, exists, "empty stack entry should be removed from the map")
 }
 
@@ -58,7 +58,7 @@ type fakeReclaimable struct {
 func (f *fakeReclaimable) GLSReclaimable() bool { return f == nil || f.reclaimed }
 
 func TestPushReclaimsFinishedTopEntry(t *testing.T) {
-	s := contextStack(make(map[any][]any))
+	var s contextStack
 
 	first := &fakeReclaimable{id: 1}
 	s.Push(stackTestKey{}, first)
@@ -75,7 +75,7 @@ func TestPushReclaimsFinishedTopEntry(t *testing.T) {
 }
 
 func TestPushDrainsMultipleReclaimableEntries(t *testing.T) {
-	s := contextStack(make(map[any][]any))
+	var s contextStack
 
 	// Several entries pile up while live (pushed on this goroutine, e.g. via
 	// ContextWithSpan), building real depth.
@@ -100,7 +100,7 @@ func TestPushDrainsMultipleReclaimableEntries(t *testing.T) {
 }
 
 func TestPushKeepsLiveEntries(t *testing.T) {
-	s := contextStack(make(map[any][]any))
+	var s contextStack
 
 	// A live (non-reclaimable) entry on top must never be dropped — this is
 	// the legitimate same-goroutine nesting case (parent still active).
@@ -114,7 +114,7 @@ func TestPushKeepsLiveEntries(t *testing.T) {
 }
 
 func TestPushDoesNotReclaimBuriedEntryUnderLiveTop(t *testing.T) {
-	s := contextStack(make(map[any][]any))
+	var s contextStack
 
 	// Build [buried, liveTop] with both live, so neither is dropped at push.
 	buried := &fakeReclaimable{id: 1, reclaimed: false}
@@ -136,7 +136,7 @@ func TestPushDoesNotReclaimBuriedEntryUnderLiveTop(t *testing.T) {
 }
 
 func TestPushDoesNotDrainNonReclaimableValues(t *testing.T) {
-	s := contextStack(make(map[any][]any))
+	var s contextStack
 
 	// Values that don't implement reclaimable (e.g. the bool stored under
 	// executionTracedKey) must never be drained, even if they pile up.
@@ -210,7 +210,7 @@ func TestPeekSkipsReclaimableEntries(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := contextStack(make(map[any][]any))
+			var s contextStack
 
 			// Push every entry live so the stack actually reaches len(finished).
 			entries := make([]*fakeReclaimable, len(tt.finished))
@@ -245,7 +245,7 @@ func TestPeekSkipsReclaimableEntries(t *testing.T) {
 // leaves its own span behind. Peek must refuse the survivor every time; returning
 // it would make each request a child of the last.
 func TestPeekBreaksStaleParentChain(t *testing.T) {
-	s := contextStack(make(map[any][]any))
+	var s contextStack
 	k := stackTestKey{}
 
 	for i := range 10 {
@@ -273,7 +273,7 @@ func TestPeekBreaksStaleParentChain(t *testing.T) {
 // advice is guarded by `if s != nil`), which is exactly why this needs a test:
 // the guard lives in the woven method, out of reach of the rest of this suite.
 func TestPeekSkipsNilReclaimableEntry(t *testing.T) {
-	s := contextStack(make(map[any][]any))
+	var s contextStack
 
 	live := &fakeReclaimable{id: 1}
 	s.Push(stackTestKey{}, live)
@@ -288,12 +288,131 @@ func TestPeekSkipsNilReclaimableEntry(t *testing.T) {
 // [reclaimable] — e.g. the bool stored under executionTracedKey. They carry no
 // finished state, so Peek must return them unchanged.
 func TestPeekReturnsNonReclaimableValues(t *testing.T) {
-	s := contextStack(make(map[any][]any))
+	var s contextStack
 
 	s.Push(stackTestKey{}, false)
 	s.Push(stackTestKey{}, true)
 
 	assert.Equal(t, true, s.Peek(stackTestKey{}), "non-reclaimable top value must be returned as-is")
+}
+
+// TestPopScopeRemovesTargetAndEverythingAbove is the half of APMS-20132 the Peek
+// guard cannot reach. Pop takes the top rather than the scope that ended, so a
+// non-LIFO exit strands an entry:
+//
+//	push A, push B, push C
+//	A exits  →  Pop takes C, leaving [A(finished), B(live)]
+//
+// Peek walks down from the top and stops at B, because B is LIVE. It is not a
+// finished span the read-side guard can skip; it is a sibling scope that simply
+// outlived the one that ended. Handing it out makes the next request its child.
+//
+// PopScope closes A by token and takes B and C with it: both were opened inside
+// A's scope, so neither can outlive it.
+func TestPopScopeRemovesTargetAndEverythingAbove(t *testing.T) {
+	var s contextStack
+	k := stackTestKey{}
+
+	a := &fakeReclaimable{id: 1}
+	tokenA := s.Push(k, a)
+	b := &fakeReclaimable{id: 2}
+	s.Push(k, b)
+	c := &fakeReclaimable{id: 3}
+	s.Push(k, c)
+	require.Equal(t, 3, s.Depth())
+
+	// A finishes while it is not the top: the non-LIFO exit.
+	a.reclaimed = true
+	require.True(t, s.PopScope(k, tokenA), "PopScope must find the scope its token opened")
+
+	assert.Equal(t, 0, s.Depth(), "A, B and C must all be gone")
+
+	got := s.Peek(k)
+	assert.Nil(t, got, "nothing survives A's exit, so there is no active scope")
+	assert.NotEqual(t, b, got,
+		"B outlived the scope that opened it and became the active one — the top-pop "+
+			"stranding that produced the APMS-20132 trace merge")
+}
+
+// TestPopScopeKeepsEntriesBelow pins the other side of scope exit: an enclosing
+// scope is still live and must become active again. This is ordinary nesting —
+// a child span finishing inside its parent — and a PopScope that cleared the
+// whole slice would break it while still passing every test above.
+func TestPopScopeKeepsEntriesBelow(t *testing.T) {
+	var s contextStack
+	k := stackTestKey{}
+
+	outer := &fakeReclaimable{id: 1}
+	s.Push(k, outer)
+	inner := &fakeReclaimable{id: 2}
+	tokenInner := s.Push(k, inner)
+	leaf := &fakeReclaimable{id: 3}
+	s.Push(k, leaf)
+
+	inner.reclaimed = true
+	require.True(t, s.PopScope(k, tokenInner))
+
+	assert.Equal(t, 1, s.Depth(), "only inner and what inner opened are removed")
+	assert.Same(t, outer, s.Peek(k), "the enclosing scope becomes active again")
+
+	// The vacated slots are zeroed so the GC can collect the values they held,
+	// matching Pop and Push's drain.
+	raw := s.stacks[k]
+	require.GreaterOrEqual(t, cap(raw), 3, "the backing array must still hold the removed slots")
+	raw = raw[:cap(raw)]
+	assert.Zero(t, raw[1], "inner's slot must be cleared")
+	assert.Zero(t, raw[2], "leaf's slot must be cleared")
+}
+
+// TestPopScopeOnRemovedTokenDoesNothing covers the repeated or late exit: a
+// popper that already ran, or one whose scope was swept away by an enclosing
+// PopScope. It must report that there was nothing to close and leave the stack
+// alone, because by then the position it once held may belong to someone else.
+func TestPopScopeOnRemovedTokenDoesNothing(t *testing.T) {
+	var s contextStack
+	k := stackTestKey{}
+
+	gone := &fakeReclaimable{id: 1}
+	token := s.Push(k, gone)
+	require.True(t, s.PopScope(k, token), "the first exit closes the scope")
+
+	assert.False(t, s.PopScope(k, token), "a second exit finds nothing to close")
+	assert.Equal(t, 0, s.Depth())
+
+	// The same holds with an unrelated scope open: the stale exit must not take it.
+	live := &fakeReclaimable{id: 2}
+	s.Push(k, live)
+
+	assert.False(t, s.PopScope(k, token), "the stale token still matches nothing")
+	assert.Equal(t, 1, s.Depth(), "the unrelated scope must survive the stale exit")
+	assert.Same(t, live, s.Peek(k))
+}
+
+// TestPopScopeIgnoresStaleTokenAfterIndexReuse is the ABA case, and the reason
+// an entry carries a token instead of the popper capturing an index. The slice
+// hands index 0 to the second scope after the first is gone, so an index-based
+// exit would close a scope it never opened.
+//
+// The counter lives on the contextStack rather than alongside each key's slice
+// precisely so this holds: PopScope deletes the key once it empties, and a
+// per-key counter would restart from zero and re-issue the stale token.
+func TestPopScopeIgnoresStaleTokenAfterIndexReuse(t *testing.T) {
+	var s contextStack
+	k := stackTestKey{}
+
+	first := &fakeReclaimable{id: 1}
+	stale := s.Push(k, first)
+	require.True(t, s.PopScope(k, stale))
+	require.Equal(t, 0, s.Depth(), "the key is now empty, so the next push starts at index 0 again")
+
+	second := &fakeReclaimable{id: 2}
+	fresh := s.Push(k, second)
+	require.Same(t, second, s.stacks[k][0].val, "the second scope reuses the first scope's index")
+	require.NotEqual(t, stale, fresh, "a reused index must not come with a reused token")
+
+	assert.False(t, s.PopScope(k, stale), "the stale exit matches nothing")
+	assert.Equal(t, 1, s.Depth(), "the unrelated scope at the same index must survive")
+	assert.Same(t, second, s.Peek(k), "the stale exit must not disturb the active scope")
 }
 
 // BenchmarkPeekSkipReclaimed measures Peek's cost as finished entries pile above
@@ -304,7 +423,7 @@ func BenchmarkPeekSkipReclaimed(b *testing.B) {
 	for _, stale := range []int{0, 1, 10, 100} {
 		b.Run(fmt.Sprintf("%d_reclaimed", stale), func(b *testing.B) {
 			k := stackTestKey{}
-			s := contextStack(make(map[any][]any))
+			var s contextStack
 
 			// A live entry at the bottom is what Peek must find.
 			s.Push(k, &fakeReclaimable{id: -1})
@@ -348,7 +467,7 @@ func BenchmarkPushDrainReclaimed(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
 				b.StopTimer()
-				s := contextStack(make(map[any][]any))
+				var s contextStack
 				entries := make([]*fakeReclaimable, stale)
 				for i := range entries {
 					entries[i] = &fakeReclaimable{id: i}

--- a/internal/orchestrion/context_stack_test.go
+++ b/internal/orchestrion/context_stack_test.go
@@ -20,9 +20,9 @@ func TestPopNilsBackingArrayElement(t *testing.T) {
 
 	// Push two values so popping one keeps the map entry alive (len > 0).
 	// This lets us inspect the backing array for the cleared slot.
-	s.Push(stackTestKey{}, "filler")
+	s.Push(stackTestKey{}, "filler", nil)
 	large := make([]byte, 1<<20) // 1 MiB
-	s.Push(stackTestKey{}, large)
+	s.Push(stackTestKey{}, large, nil)
 
 	popped := s.Pop(stackTestKey{})
 	require.NotNil(t, popped)
@@ -38,7 +38,7 @@ func TestPopNilsBackingArrayElement(t *testing.T) {
 func TestPopCleansUpEmptyMapEntry(t *testing.T) {
 	var s contextStack
 
-	s.Push(stackTestKey{}, "value")
+	s.Push(stackTestKey{}, "value", nil)
 	s.Pop(stackTestKey{})
 
 	_, exists := s.stacks[stackTestKey{}]
@@ -61,14 +61,14 @@ func TestPushReclaimsFinishedTopEntry(t *testing.T) {
 	var s contextStack
 
 	first := &fakeReclaimable{id: 1}
-	s.Push(stackTestKey{}, first)
+	s.Push(stackTestKey{}, first, nil)
 	require.Equal(t, 1, s.Depth(), "first push lands")
 
 	// Mark the top entry reclaimable, as a finished span would be. The next
 	// push must drop it instead of stacking on top, keeping depth at 1.
 	first.reclaimed = true
 	second := &fakeReclaimable{id: 2}
-	s.Push(stackTestKey{}, second)
+	s.Push(stackTestKey{}, second, nil)
 
 	assert.Equal(t, 1, s.Depth(), "reclaimable top entry should be dropped on push")
 	assert.Same(t, second, s.Peek(stackTestKey{}), "new value should be on top")
@@ -82,7 +82,7 @@ func TestPushDrainsMultipleReclaimableEntries(t *testing.T) {
 	entries := make([]*fakeReclaimable, 5)
 	for i := range entries {
 		entries[i] = &fakeReclaimable{id: i}
-		s.Push(stackTestKey{}, entries[i])
+		s.Push(stackTestKey{}, entries[i], nil)
 	}
 	require.Equal(t, 5, s.Depth(), "five live entries pushed")
 
@@ -93,7 +93,7 @@ func TestPushDrainsMultipleReclaimableEntries(t *testing.T) {
 
 	// The next push must drain ALL trailing reclaimable entries, not just the top.
 	live := &fakeReclaimable{id: 99}
-	s.Push(stackTestKey{}, live)
+	s.Push(stackTestKey{}, live, nil)
 
 	assert.Equal(t, 1, s.Depth(), "all trailing reclaimable entries should be drained")
 	assert.Same(t, live, s.Peek(stackTestKey{}))
@@ -105,9 +105,9 @@ func TestPushKeepsLiveEntries(t *testing.T) {
 	// A live (non-reclaimable) entry on top must never be dropped — this is
 	// the legitimate same-goroutine nesting case (parent still active).
 	parent := &fakeReclaimable{id: 1, reclaimed: false}
-	s.Push(stackTestKey{}, parent)
+	s.Push(stackTestKey{}, parent, nil)
 	child := &fakeReclaimable{id: 2, reclaimed: false}
-	s.Push(stackTestKey{}, child)
+	s.Push(stackTestKey{}, child, nil)
 
 	assert.Equal(t, 2, s.Depth(), "live entries must be preserved (nesting)")
 	assert.Same(t, child, s.Peek(stackTestKey{}))
@@ -118,16 +118,16 @@ func TestPushDoesNotReclaimBuriedEntryUnderLiveTop(t *testing.T) {
 
 	// Build [buried, liveTop] with both live, so neither is dropped at push.
 	buried := &fakeReclaimable{id: 1, reclaimed: false}
-	s.Push(stackTestKey{}, buried)
+	s.Push(stackTestKey{}, buried, nil)
 	liveTop := &fakeReclaimable{id: 2, reclaimed: false}
-	s.Push(stackTestKey{}, liveTop)
+	s.Push(stackTestKey{}, liveTop, nil)
 	require.Equal(t, 2, s.Depth())
 
 	// buried becomes reclaimable, but liveTop (still live) sits above it.
 	buried.reclaimed = true
 
 	next := &fakeReclaimable{id: 3, reclaimed: false}
-	s.Push(stackTestKey{}, next)
+	s.Push(stackTestKey{}, next, nil)
 
 	// The drain stops at liveTop (not reclaimable), so buried is preserved.
 	// This is the invariant that protects legitimate nesting: a reclaimable
@@ -140,9 +140,9 @@ func TestPushDoesNotDrainNonReclaimableValues(t *testing.T) {
 
 	// Values that don't implement reclaimable (e.g. the bool stored under
 	// executionTracedKey) must never be drained, even if they pile up.
-	s.Push(stackTestKey{}, true)
-	s.Push(stackTestKey{}, false)
-	s.Push(stackTestKey{}, true)
+	s.Push(stackTestKey{}, true, nil)
+	s.Push(stackTestKey{}, false, nil)
+	s.Push(stackTestKey{}, true, nil)
 
 	assert.Equal(t, 3, s.Depth(), "non-reclaimable values are never dropped")
 }
@@ -216,7 +216,7 @@ func TestPeekSkipsReclaimableEntries(t *testing.T) {
 			entries := make([]*fakeReclaimable, len(tt.finished))
 			for i := range entries {
 				entries[i] = &fakeReclaimable{id: i}
-				s.Push(stackTestKey{}, entries[i])
+				s.Push(stackTestKey{}, entries[i], nil)
 			}
 			require.Equal(t, len(tt.finished), s.Depth(), "stack must reach the intended depth")
 
@@ -250,10 +250,10 @@ func TestPeekBreaksStaleParentChain(t *testing.T) {
 
 	for i := range 10 {
 		req := &fakeReclaimable{id: i}
-		s.Push(k, req)
+		s.Push(k, req, nil)
 
 		stray := &fakeReclaimable{id: 1000 + i}
-		s.Push(k, stray)
+		s.Push(k, stray, nil)
 		stray.reclaimed = true
 
 		req.reclaimed = true
@@ -276,8 +276,8 @@ func TestPeekSkipsNilReclaimableEntry(t *testing.T) {
 	var s contextStack
 
 	live := &fakeReclaimable{id: 1}
-	s.Push(stackTestKey{}, live)
-	s.Push(stackTestKey{}, (*fakeReclaimable)(nil))
+	s.Push(stackTestKey{}, live, nil)
+	s.Push(stackTestKey{}, (*fakeReclaimable)(nil), nil)
 	require.Equal(t, 2, s.Depth(), "the nil entry is pushed on top of the live one")
 
 	assert.Same(t, live, s.Peek(stackTestKey{}),
@@ -290,8 +290,8 @@ func TestPeekSkipsNilReclaimableEntry(t *testing.T) {
 func TestPeekReturnsNonReclaimableValues(t *testing.T) {
 	var s contextStack
 
-	s.Push(stackTestKey{}, false)
-	s.Push(stackTestKey{}, true)
+	s.Push(stackTestKey{}, false, nil)
+	s.Push(stackTestKey{}, true, nil)
 
 	assert.Equal(t, true, s.Peek(stackTestKey{}), "non-reclaimable top value must be returned as-is")
 }
@@ -314,11 +314,11 @@ func TestPopScopeRemovesTargetAndEverythingAbove(t *testing.T) {
 	k := stackTestKey{}
 
 	a := &fakeReclaimable{id: 1}
-	tokenA := s.Push(k, a)
+	tokenA := s.Push(k, a, nil)
 	b := &fakeReclaimable{id: 2}
-	s.Push(k, b)
+	s.Push(k, b, nil)
 	c := &fakeReclaimable{id: 3}
-	s.Push(k, c)
+	s.Push(k, c, nil)
 	require.Equal(t, 3, s.Depth())
 
 	// A finishes while it is not the top: the non-LIFO exit.
@@ -343,11 +343,11 @@ func TestPopScopeKeepsEntriesBelow(t *testing.T) {
 	k := stackTestKey{}
 
 	outer := &fakeReclaimable{id: 1}
-	s.Push(k, outer)
+	s.Push(k, outer, nil)
 	inner := &fakeReclaimable{id: 2}
-	tokenInner := s.Push(k, inner)
+	tokenInner := s.Push(k, inner, nil)
 	leaf := &fakeReclaimable{id: 3}
-	s.Push(k, leaf)
+	s.Push(k, leaf, nil)
 
 	inner.reclaimed = true
 	require.True(t, s.PopScope(k, tokenInner))
@@ -373,7 +373,7 @@ func TestPopScopeOnRemovedTokenDoesNothing(t *testing.T) {
 	k := stackTestKey{}
 
 	gone := &fakeReclaimable{id: 1}
-	token := s.Push(k, gone)
+	token := s.Push(k, gone, nil)
 	require.True(t, s.PopScope(k, token), "the first exit closes the scope")
 
 	assert.False(t, s.PopScope(k, token), "a second exit finds nothing to close")
@@ -381,7 +381,7 @@ func TestPopScopeOnRemovedTokenDoesNothing(t *testing.T) {
 
 	// The same holds with an unrelated scope open: the stale exit must not take it.
 	live := &fakeReclaimable{id: 2}
-	s.Push(k, live)
+	s.Push(k, live, nil)
 
 	assert.False(t, s.PopScope(k, token), "the stale token still matches nothing")
 	assert.Equal(t, 1, s.Depth(), "the unrelated scope must survive the stale exit")
@@ -401,12 +401,12 @@ func TestPopScopeIgnoresStaleTokenAfterIndexReuse(t *testing.T) {
 	k := stackTestKey{}
 
 	first := &fakeReclaimable{id: 1}
-	stale := s.Push(k, first)
+	stale := s.Push(k, first, nil)
 	require.True(t, s.PopScope(k, stale))
 	require.Equal(t, 0, s.Depth(), "the key is now empty, so the next push starts at index 0 again")
 
 	second := &fakeReclaimable{id: 2}
-	fresh := s.Push(k, second)
+	fresh := s.Push(k, second, nil)
 	require.Same(t, second, s.stacks[k][0].val, "the second scope reuses the first scope's index")
 	require.NotEqual(t, stale, fresh, "a reused index must not come with a reused token")
 
@@ -426,13 +426,13 @@ func BenchmarkPeekSkipReclaimed(b *testing.B) {
 			var s contextStack
 
 			// A live entry at the bottom is what Peek must find.
-			s.Push(k, &fakeReclaimable{id: -1})
+			s.Push(k, &fakeReclaimable{id: -1}, nil)
 			// Pushed live so the stack reaches depth N, then marked finished —
 			// pushing them reclaimable would let Push drain each one immediately.
 			entries := make([]*fakeReclaimable, stale)
 			for i := range entries {
 				entries[i] = &fakeReclaimable{id: i}
-				s.Push(k, entries[i])
+				s.Push(k, entries[i], nil)
 			}
 			for _, e := range entries {
 				e.reclaimed = true
@@ -471,7 +471,7 @@ func BenchmarkPushDrainReclaimed(b *testing.B) {
 				entries := make([]*fakeReclaimable, stale)
 				for i := range entries {
 					entries[i] = &fakeReclaimable{id: i}
-					s.Push(k, entries[i]) // pushed live so the stack reaches depth N
+					s.Push(k, entries[i], nil) // pushed live so the stack reaches depth N
 				}
 				for _, e := range entries {
 					e.reclaimed = true // now finished cross-goroutine (pop never ran here)
@@ -479,8 +479,73 @@ func BenchmarkPushDrainReclaimed(b *testing.B) {
 				b.StartTimer()
 
 				// This single Push must drain all `stale` reclaimable entries.
-				s.Push(k, &fakeReclaimable{id: stale})
+				s.Push(k, &fakeReclaimable{id: stale}, nil)
 			}
 		})
 	}
+}
+
+// TestPopEntryRemovesOnlyItsOwnEntry pins the difference from PopScope. Sweeping
+// entries above the target is right for nested scopes, and wrong for a key whose
+// entries are independent scopes holding their own exits: removing one does not
+// cancel its exit, so that exit runs anyway against a stack it no longer owns.
+func TestPopEntryRemovesOnlyItsOwnEntry(t *testing.T) {
+	var s contextStack
+	k := stackTestKey{}
+
+	a := &fakeReclaimable{id: 1}
+	s.Push(k, a, nil)
+	b := &fakeReclaimable{id: 2}
+	tokenB := s.Push(k, b, nil)
+	c := &fakeReclaimable{id: 3}
+	s.Push(k, c, nil)
+
+	require.True(t, s.PopEntry(k, tokenB), "PopEntry must find the entry its token opened")
+
+	assert.Equal(t, 2, s.Depth(), "only B is gone; A below and C above both stay")
+	assert.Same(t, c, s.Peek(k), "C was never inside B's scope, so it is still the active one")
+}
+
+// TestPopEntryLeavesAPositionalPopIntact is the reason PopEntry exists.
+// internal.executionTracedKey carries bools whose exit is PopExecutionTraced, a
+// positional pop. If closing the scope-exact override also swept the marker above
+// it, that marker's own pop would still run and take an unrelated entry further
+// down — silently flipping IsExecutionTraced for everything after it.
+func TestPopEntryLeavesAPositionalPopIntact(t *testing.T) {
+	var s contextStack
+	k := stackTestKey{}
+
+	a := &fakeReclaimable{id: 1} // an unrelated marker nobody here will pop
+	s.Push(k, a, nil)
+	b := &fakeReclaimable{id: 2} // the scope-exact override
+	tokenB := s.Push(k, b, nil)
+	c := &fakeReclaimable{id: 3} // owns a positional pop
+	s.Push(k, c, nil)
+
+	require.True(t, s.PopEntry(k, tokenB))
+	s.Pop(k) // C's positional exit, running after its neighbour closed
+
+	assert.Equal(t, 1, s.Depth(), "C's pop must take C, not reach past it")
+	assert.Same(t, a, s.Peek(k), "the unrelated marker below must survive")
+}
+
+// TestPopEntryIgnoresAStaleToken covers a repeated or late exit. Tokens only ever
+// ascend, so a token already removed matches nothing and the walk stops early
+// rather than destroying whatever now occupies that position.
+func TestPopEntryIgnoresAStaleToken(t *testing.T) {
+	var s contextStack
+	k := stackTestKey{}
+
+	a := &fakeReclaimable{id: 1}
+	tokenA := s.Push(k, a, nil)
+	require.True(t, s.PopEntry(k, tokenA))
+	require.Equal(t, 0, s.Depth())
+
+	later := &fakeReclaimable{id: 2}
+	s.Push(k, later, nil)
+
+	assert.False(t, s.PopEntry(k, tokenA), "a token that is already gone must match nothing")
+	assert.Equal(t, 1, s.Depth(), "the unrelated scope that reused the position must survive")
+	assert.Same(t, later, s.Peek(k))
+	assert.False(t, s.PopEntry(k, 0), "a zero token means no scope and must never match")
 }

--- a/internal/orchestrion/context_test.go
+++ b/internal/orchestrion/context_test.go
@@ -100,7 +100,7 @@ func TestGLSActivate(t *testing.T) {
 		fn := pop.ptr.Load()
 		require.NotNil(t, fn, "popper should be captured")
 
-		(*fn)()
+		fn.pop()
 		require.Nil(t, getDDContextStack().Peek(key("k")), "popper should remove the value")
 	})
 
@@ -145,7 +145,7 @@ func TestGLSReset(t *testing.T) {
 		ran := 0
 		var pop GLSPopperCell
 		fn := GLSPopper(func() { ran++ })
-		pop.ptr.Store(&fn)
+		pop.ptr.Store(&glsExit{pop: fn})
 
 		GLSReset(&reclaimable, &pop)
 		require.False(t, reclaimable.Load(), "reclaimable must be reset to false")
@@ -156,7 +156,7 @@ func TestGLSReset(t *testing.T) {
 	t.Run("tolerates nil reclaimable (dyngo operations)", func(t *testing.T) {
 		var pop GLSPopperCell
 		fn := GLSPopper(func() {})
-		pop.ptr.Store(&fn)
+		pop.ptr.Store(&glsExit{pop: fn})
 		GLSReset(nil, &pop) // must not panic
 		require.Nil(t, pop.ptr.Load())
 	})
@@ -168,7 +168,7 @@ func TestGLSDeactivate(t *testing.T) {
 		popped := 0
 		var pop GLSPopperCell
 		fn := GLSPopper(func() { popped++ })
-		pop.ptr.Store(&fn)
+		pop.ptr.Store(&glsExit{pop: fn})
 
 		GLSDeactivate(&reclaimable, &pop)
 		require.True(t, reclaimable.Load(), "span should be marked reclaimable")
@@ -407,4 +407,31 @@ func TestGLSReactivationAfterSweepStrandsACellessEntry(t *testing.T) {
 		"B's entry outlived B: its popper still named the token PopScope swept, so the exit "+
 			"removed nothing. With no reclaim flag the entry is permanently live, so Peek keeps "+
 			"handing it out and Push never drains it")
+}
+
+// TestGLSSweepKeepsASurvivingEntrysExit covers the case where invalidating a
+// removed entry's exit would discard one that still has work to do.
+//
+// Activate B, then A, then B again. Both B entries share one GLSPopperCell, and
+// first-wins means the exit it holds names the LOWER B. Closing A sweeps A and the
+// upper B, so the upper B's entry is removed — but the cell it points at is still
+// the lower B's only way out. Clearing it unconditionally strands that entry, and
+// with no reclaim flag (dyngo's shape) it stays permanently active.
+func TestGLSSweepKeepsASurvivingEntrysExit(t *testing.T) {
+	t.Cleanup(MockGLS())
+	k := key("celless")
+
+	var popA, popB GLSPopperCell
+	GLSActivate(nil, k, "B", &popB) // lower B: popB's exit names this token
+	GLSActivate(nil, k, "A", &popA)
+	GLSActivate(nil, k, "B", &popB) // upper B: first-wins keeps the lower token
+	require.Equal(t, 3, GLSStackDepth())
+
+	GLSDeactivate(nil, &popA) // sweeps A and the upper B; the lower B survives
+	require.Equal(t, 1, GLSStackDepth(), "A's scope exit removes A and what was opened inside it")
+
+	GLSDeactivate(nil, &popB) // must still close the surviving lower B
+	assert.Equal(t, 0, GLSStackDepth(),
+		"the lower B outlived its own exit: sweeping the upper B cleared the cell whose exit "+
+			"named the lower one, so B's finish removed nothing")
 }

--- a/internal/orchestrion/context_test.go
+++ b/internal/orchestrion/context_test.go
@@ -49,8 +49,8 @@ func TestGLSPopFunc(t *testing.T) {
 	t.Run("same goroutine pops value", func(t *testing.T) {
 		t.Cleanup(MockGLS())
 
-		CtxWithValue(context.Background(), key("k"), "v")
-		popFn := GLSPopFunc(key("k"))
+		token := getDDContextStack().Push(key("k"), "v")
+		popFn := GLSPopFunc(key("k"), token)
 
 		require.Equal(t, "v", getDDContextStack().Peek(key("k")))
 
@@ -62,14 +62,14 @@ func TestGLSPopFunc(t *testing.T) {
 	t.Run("different goroutine is no-op", func(t *testing.T) {
 		t.Cleanup(MockGLS())
 
-		CtxWithValue(context.Background(), key("k"), "v")
-		popFn := GLSPopFunc(key("k"))
+		token := getDDContextStack().Push(key("k"), "v")
+		popFn := GLSPopFunc(key("k"), token)
 
 		// Simulate a different goroutine by swapping the GLS to a new stack.
 		// In production, each goroutine has its own contextStack pointer in
 		// runtime.g, so getDDContextStack() returns different pointers.
 		originalStack := getDDGLS()
-		differentStack := contextStack(make(map[any][]any))
+		var differentStack contextStack
 		setDDGLS(&differentStack)
 		t.Cleanup(func() { setDDGLS(originalStack) })
 
@@ -85,7 +85,7 @@ func TestGLSPopFunc(t *testing.T) {
 		t.Cleanup(MockGLS())
 		enabled = false // Override MockGLS's enabled=true to test disabled path
 
-		popFn := GLSPopFunc(key("k"))
+		popFn := GLSPopFunc(key("k"), 0)
 		popFn() // must not panic
 	})
 }
@@ -226,8 +226,7 @@ func TestGLSPopFuncCrossGoroutine(t *testing.T) {
 	t.Cleanup(MockGLSPerGoroutine())
 
 	// Push a value and capture the pop function on the main goroutine.
-	CtxWithValue(context.Background(), key("k"), "main-val")
-	popFn := GLSPopFunc(key("k"))
+	_, popFn := CtxWithScopedValue(context.Background(), key("k"), "main-val")
 
 	require.Equal(t, "main-val", getDDContextStack().Peek(key("k")),
 		"main goroutine should see its pushed value")
@@ -318,8 +317,7 @@ func BenchmarkGLSPopFuncSameGoroutine(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		CtxWithValue(context.Background(), k, true)
-		popFn := GLSPopFunc(k)
+		_, popFn := CtxWithScopedValue(context.Background(), k, true)
 		popFn()
 	}
 	if depth := GLSStackDepth(); depth != 0 {
@@ -335,8 +333,7 @@ func BenchmarkGLSPopFuncCrossGoroutine(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		CtxWithValue(context.Background(), k, true)
-		popFn := GLSPopFunc(k)
+		_, popFn := CtxWithScopedValue(context.Background(), k, true)
 		done := make(chan struct{})
 		go func() { defer close(done); popFn() }()
 		<-done

--- a/internal/orchestrion/context_test.go
+++ b/internal/orchestrion/context_test.go
@@ -49,7 +49,7 @@ func TestGLSPopFunc(t *testing.T) {
 	t.Run("same goroutine pops value", func(t *testing.T) {
 		t.Cleanup(MockGLS())
 
-		token := getDDContextStack().Push(key("k"), "v")
+		token := getDDContextStack().Push(key("k"), "v", nil)
 		popFn := GLSPopFunc(key("k"), token)
 
 		require.Equal(t, "v", getDDContextStack().Peek(key("k")))
@@ -62,7 +62,7 @@ func TestGLSPopFunc(t *testing.T) {
 	t.Run("different goroutine is no-op", func(t *testing.T) {
 		t.Cleanup(MockGLS())
 
-		token := getDDContextStack().Push(key("k"), "v")
+		token := getDDContextStack().Push(key("k"), "v", nil)
 		popFn := GLSPopFunc(key("k"), token)
 
 		// Simulate a different goroutine by swapping the GLS to a new stack.
@@ -283,7 +283,7 @@ func BenchmarkContextStackPushPop(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		getDDContextStack().Push(k, true)
+		getDDContextStack().Push(k, true, nil)
 		getDDContextStack().Pop(k)
 	}
 	if depth := GLSStackDepth(); depth != 0 {
@@ -299,7 +299,7 @@ func BenchmarkContextStackPushOnly(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		getDDContextStack().Push(k, true)
+		getDDContextStack().Push(k, true, nil)
 	}
 	b.StopTimer()
 	depth := GLSStackDepth()
@@ -356,7 +356,7 @@ func BenchmarkContextStackDepthScaling(b *testing.B) {
 			k := key("bench")
 			// Pre-fill the stack to simulate leaked entries.
 			for range depth {
-				getDDContextStack().Push(k, true)
+				getDDContextStack().Push(k, true, nil)
 			}
 			b.ReportAllocs()
 			b.ResetTimer()
@@ -365,4 +365,46 @@ func BenchmarkContextStackDepthScaling(b *testing.B) {
 			}
 		})
 	}
+}
+
+// TestGLSReactivationAfterSweepStrandsACellessEntry covers the exit-invalidation
+// this change adds. PopScope removes its target and everything above it, so a
+// value swept that way keeps an exit naming a token that no longer exists: its
+// next activation sees a non-nil popper cell, keeps the stale exit under
+// first-wins, and the entry that activation pushes is closed by nothing.
+//
+// The shape here is dyngo's: a popper and a value that does not report itself
+// reclaimable, because AppSec operations are registered and finished on one
+// goroutine and carry no reclaim flag. That is what makes it matter — with
+// nothing to mark, the stranded entry is never drained by Push and never skipped
+// by Peek, so a finished operation keeps answering as the active one. A span in
+// the same position recovers on its own, since GLSDeactivate sets its reclaim
+// flag and the stranded entry becomes collectable.
+func TestGLSReactivationAfterSweepStrandsACellessEntry(t *testing.T) {
+	t.Cleanup(MockGLS())
+	k := key("celless")
+
+	var popA, popB GLSPopperCell
+	GLSActivate(nil, k, "A", &popA)
+	GLSActivate(nil, k, "B", &popB)
+	require.Equal(t, 2, GLSStackDepth())
+
+	// A exits while B is still live: the non-LIFO case PopScope exists for. It
+	// removes A and sweeps B along with it.
+	GLSDeactivate(nil, &popA)
+	require.Equal(t, 0, GLSStackDepth(), "A's scope exit removes A and what was opened inside it")
+
+	// B is activated again on the same goroutine. first-wins would keep the
+	// popper captured the first time, which names the token just swept away.
+	GLSActivate(nil, k, "B", &popB)
+	require.Equal(t, 1, GLSStackDepth())
+
+	// B finishes. Without invalidation its exit targets the stale token and
+	// matches nothing.
+	GLSDeactivate(nil, &popB)
+
+	assert.Equal(t, 0, GLSStackDepth(),
+		"B's entry outlived B: its popper still named the token PopScope swept, so the exit "+
+			"removed nothing. With no reclaim flag the entry is permanently live, so Peek keeps "+
+			"handing it out and Push never drains it")
 }

--- a/internal/orchestrion/gls_deactivate_concurrent_test.go
+++ b/internal/orchestrion/gls_deactivate_concurrent_test.go
@@ -25,7 +25,7 @@ func TestGLSDeactivateConcurrentFinishRaces(t *testing.T) {
 		var reclaimable atomic.Bool
 		var pop GLSPopperCell
 		fn := GLSPopper(func() {})
-		pop.ptr.Store(&fn)
+		pop.ptr.Store(&glsExit{pop: fn})
 
 		start := make(chan struct{})
 		var wg sync.WaitGroup
@@ -58,7 +58,7 @@ func TestGLSDeactivateConcurrentDoubleRunsPopper(t *testing.T) {
 		var reclaimable atomic.Bool
 		var pop GLSPopperCell
 		fn := GLSPopper(func() { total.Add(1) })
-		pop.ptr.Store(&fn)
+		pop.ptr.Store(&glsExit{pop: fn})
 
 		start := make(chan struct{})
 		var wg sync.WaitGroup

--- a/internal/orchestrion/gls_finish_reset_race_test.go
+++ b/internal/orchestrion/gls_finish_reset_race_test.go
@@ -24,7 +24,7 @@ func TestGLSFinishResetConcurrentRaces(t *testing.T) {
 		var reclaimable atomic.Bool
 		var pop GLSPopperCell
 		fn := GLSPopper(func() {})
-		pop.ptr.Store(&fn)
+		pop.ptr.Store(&glsExit{pop: fn})
 
 		start := make(chan struct{})
 		var wg sync.WaitGroup

--- a/internal/orchestrion/mock_gls.go
+++ b/internal/orchestrion/mock_gls.go
@@ -26,8 +26,7 @@ func MockGLS() func() {
 	prevSetDDGLS := setDDGLS
 	prevEnabled := enabled
 
-	tmp := contextStack(make(map[any][]any))
-	var glsValue any = &tmp
+	var glsValue any = &contextStack{}
 	getDDGLS = func() any { return glsValue }
 	setDDGLS = func(a any) { glsValue = a }
 	enabled = true

--- a/internal/trace_context.go
+++ b/internal/trace_context.go
@@ -54,19 +54,22 @@ func PopExecutionTraced() {
 }
 
 // ScopedExecutionNotTraced marks ctx as not covered by an execution trace task
-// and returns a cleanup function that pops the GLS entry. Unlike using
-// WithExecutionNotTraced + PopExecutionTraced separately, the returned cleanup
-// is goroutine-safe: it captures the pushing goroutine's GLS contextStack
-// pointer and only pops if called from the same goroutine. This makes it safe
-// for use with spans that may be finished on a different goroutine than the one
-// that created them.
+// and returns a cleanup function that removes the GLS entry it pushed. Unlike
+// using WithExecutionNotTraced + PopExecutionTraced separately, the cleanup is
+// scope-exact and goroutine-safe: it removes the entry this call pushed rather
+// than whatever is on top, and only when called from the pushing goroutine.
+//
+// Both properties matter here. The only caller is the tracer's
+// startExecutionTracerTask, which hands the cleanup to Span.taskEnd — so it runs
+// when that span finishes, at no fixed position relative to the pushes around
+// it, and possibly on a different goroutine than the one that started it.
 func ScopedExecutionNotTraced(ctx context.Context) (context.Context, func()) {
-	newCtx := WithExecutionNotTraced(ctx)
-	if newCtx == ctx {
-		// Fast path: nothing was pushed, no cleanup needed.
+	if orchestrion.WrapContext(ctx).Value(executionTracedKey{}) == nil {
+		// Fast path: it wasn't marked before, so there is nothing to override
+		// and nothing to clean up. Mirrors WithExecutionNotTraced.
 		return ctx, glsNoop
 	}
-	return newCtx, orchestrion.GLSPopFunc(executionTracedKey{})
+	return orchestrion.CtxWithScopedValue(ctx, executionTracedKey{}, false)
 }
 
 var glsNoop = func() {}

--- a/internal/trace_context_test.go
+++ b/internal/trace_context_test.go
@@ -78,13 +78,54 @@ func TestScopedExecutionNotTraced(t *testing.T) {
 
 		// A pop that matched position would take the top true and strand the
 		// false, leaving the stack claiming "not traced" for everything that
-		// follows. Closing by scope removes the false and the true opened
-		// inside it, restoring the original traced marker.
+		// follows. Closing by identity removes the false specifically.
+		//
+		// The marker pushed above it stays: it is an independent scope holding
+		// its own PopExecutionTraced, so removing it here would not cancel that
+		// exit, and the exit would then land on an unrelated entry. The subtest
+		// below runs that exit and pins the consequence.
+		if got := orchestrion.GLSStackDepth(); got != 2 {
+			t.Fatalf("GLS depth after cleanup = %d, want 2 (only the false override is gone)", got)
+		}
+		// This is the assertion that separates identity from position: a
+		// positional pop also leaves depth 2, but by taking the true above and
+		// stranding the false, so the stack would read "not traced" here.
+		if got := IsExecutionTraced(orchestrion.WrapContext(nil)); got != true {
+			t.Fatalf("IsExecutionTraced after cleanup = %v, want true (the false override was removed, "+
+				"not the marker above it)", got)
+		}
+	})
+
+	t.Run("a swept scope's positional pop must not remove an unrelated marker", func(t *testing.T) {
+		t.Cleanup(orchestrion.MockGLS())
+
+		// Same stack as the subtest above, but this one runs the pop that the
+		// inner WithExecutionTraced still owns. Two exit mechanisms share
+		// executionTracedKey: ScopedExecutionNotTraced closes by token, while
+		// WithExecutionTraced is paired with PopExecutionTraced, which removes
+		// whatever is on top. Sweeping entries above a closing scope therefore
+		// destroys a marker whose owner has not run its pop yet, and that pop
+		// then lands on something it never pushed.
+		//
+		// contrib/database/sql/tx.go is the real caller: startTraceTask pushes
+		// with WithExecutionTraced and defers PopExecutionTraced, so a span
+		// whose taskEnd fires mid-transaction produces exactly this order.
+		outer := WithExecutionTraced(context.Background()) // marker A, owned by nobody here
+		_, cleanup := ScopedExecutionNotTraced(outer)      // scope B, closes by token
+		_ = WithExecutionTraced(context.Background())      // marker C, owns a positional pop
+
+		cleanup() // closes B; C sits above it
+
+		// C is gone either way. The question is what its pop does next: it must
+		// not reach past its own scope and take A.
+		PopExecutionTraced()
+
 		if got := orchestrion.GLSStackDepth(); got != 1 {
-			t.Fatalf("GLS depth after cleanup = %d, want 1 (the scope and what it contained are gone)", got)
+			t.Errorf("GLS depth after the swept scope's pop = %d, want 1 (marker A must survive)", got)
 		}
 		if got := IsExecutionTraced(orchestrion.WrapContext(nil)); got != true {
-			t.Fatalf("IsExecutionTraced after cleanup = %v, want true (the outer traced marker is active again)", got)
+			t.Errorf("IsExecutionTraced = %v, want true (A is still the active marker; a false here means "+
+				"runtime-trace tasks get created or skipped against a marker that was never popped)", got)
 		}
 	})
 }

--- a/internal/trace_context_test.go
+++ b/internal/trace_context_test.go
@@ -63,6 +63,30 @@ func TestScopedExecutionNotTraced(t *testing.T) {
 		}
 		cleanup() // must not panic
 	})
+
+	t.Run("cleanup closes its own scope, not the top of the stack", func(t *testing.T) {
+		t.Cleanup(orchestrion.MockGLS())
+
+		// The tracer hands this cleanup to Span.taskEnd, so it runs whenever
+		// that span finishes — at no fixed position relative to the pushes
+		// around it. Here a later scope is opened on top before it runs.
+		ctx := WithExecutionTraced(context.Background()) // pushes true
+		_, cleanup := ScopedExecutionNotTraced(ctx)      // pushes false
+		_ = WithExecutionTraced(context.Background())    // pushes true above it
+
+		cleanup()
+
+		// A pop that matched position would take the top true and strand the
+		// false, leaving the stack claiming "not traced" for everything that
+		// follows. Closing by scope removes the false and the true opened
+		// inside it, restoring the original traced marker.
+		if got := orchestrion.GLSStackDepth(); got != 1 {
+			t.Fatalf("GLS depth after cleanup = %d, want 1 (the scope and what it contained are gone)", got)
+		}
+		if got := IsExecutionTraced(orchestrion.WrapContext(nil)); got != true {
+			t.Fatalf("IsExecutionTraced after cleanup = %v, want true (the outer traced marker is active again)", got)
+		}
+	})
 }
 
 func TestWithExecutionTracedGLSCleanup(t *testing.T) {


### PR DESCRIPTION
> Was stacked on #5071, now merged, so this targets `main` directly.

`contextStack.Pop` removes the top of the goroutine's stack rather than the span that finished, so any non-LIFO finish strands an entry. #5071 stops a *finished* stranded entry being handed out as a parent. It does not help when the entry left behind is still live:

```
[A, B, C]                three nested scopes
A.Finish()               pops the top, which is C  ->  [A(finished), B(live)]
next request             Peek skips A, returns B, a live span from a previous scope
```

That is a second merge path, and it produces the same symptom: consecutive requests on one keep-alive connection chained into a single `trace_id`.

## What

Scope exit now matches identity rather than position. `Push` returns a monotonic token; leaving a scope removes that entry and everything above it:

```go
type entry struct { val any; token uint64; pop *GLSPopperCell }
func (s *contextStack) Push(key, val any, pop *GLSPopperCell) uint64
func (s *contextStack) PopScope(key any, token uint64) bool
func (s *contextStack) PopEntry(key any, token uint64) bool
```

A token rather than an index because of ABA: `Pop` only truncates, so buried indices are stable, but an index gets reused by a later scope and a stale popper would then truncate the wrong one. Tokens ascend within a key's slice, so both removals walk from the top and stop early once they pass the target.

The token is assigned by the stack, not derived from the value, so entries are identified uniformly. That matters because the stack is not all spans: `internal.executionTracedKey` holds a `bool`, which no pointer-identity or interface-based scheme can handle. The added subtest in `TestScopedExecutionNotTraced` covers that path, where a position-matched pop strands the `false` and leaves the stack claiming "not traced" for everything after it.


#### Not in scope, deliberately

The reclaim flag, `isReclaimable`, `Peek`'s skip loop and `Push`'s drain all stay. A cross-goroutine finish can never remove an entry from a foreign goroutine's slice, so lazy reclaim is still required. This closes the merge, not orchestrion#782 or `Peek`'s walk.

`Pop` and `GLSPopValue` also stay: their only remaining reach is `PopExecutionTraced`, whose caller pushes and pops in the same function under defer. The non-LIFO one, `ScopedExecutionNotTraced`, moves to `CtxWithScopedValue`.

`GLSActivate`, `GLSDeactivate` and `GLSReset` keep their signatures, so **no woven aspect changes** and `Span` gains no field. `Push` gains the popper cell, but `GLSActivate` already had it.

## Tests

Nine added: `PopScope` removing the target and everything above, keeping entries below, no-op on an already-removed token, ignoring a stale token after index reuse; `PopEntry` removing only its own entry, leaving a positional pop intact, and ignoring a stale token; the bool-key non-LIFO case; and a woven integration test running 20 sequential requests on one goroutine with a live child outliving each.

Mutation-proved in three directions:

| Mutation | Result |
|---|---|
| `PopScope` reverted to a top-pop | five unit tests fail, including the ABA case; the integration test fails with `should have 20 item(s), but has 1` |
| `PopEntry` sweeps above (uses `truncate`) | two of its three unit tests fail |
| `invalidatePoppers` made a no-op | the re-activation test fails |

Woven suite passes with no skips, including `TestSpanGLSDoubleFinishSameGoroutine`. `golangci-lint` reports 0 issues.

`TestGLSLeaksOnCrossGoroutineFinish` still passes unchanged: it asserts a 100-entry leak as expected behaviour, and that leak is cross-goroutine, so this change does not affect it.

---

**Review Findings**

Removing everything above the target is right when those entries were opened *inside* the closing scope. It is wrong when they are independent scopes owning their own exits, and there are two such cases. Both came out of the Codex review on this PR; both are fixed in `7a16e3c7c` rather than deferred, since this is the PR that introduces the sweep.

**`executionTracedKey` mixes exit mechanisms.** It holds bools pushed by `WithExecutionTraced`, whose paired `PopExecutionTraced` removes the *top* of the stack, and it shares the key with the scope-exact override from `ScopedExecutionNotTraced`. Sweeping the marker above a closing override did not cancel that marker's pop, so the pop ran anyway and took an unrelated marker further down — leaving `IsExecutionTraced` wrong for everything after it, so runtime-trace tasks get created or skipped against a marker nobody popped. `contrib/database/sql/tx.go` is the real caller, and the tracer hands the override's cleanup to `Span.taskEnd`, which fires at no fixed position relative to those pushes. `PopEntry` removes only its own entry for that key. Reachability is narrow — it needs `trace.IsEnabled()`, so only while a runtime execution trace is being collected — but the fix is small and the failure is silent.

**A swept entry kept its exit.** A value removed by an enclosing scope kept a popper naming a token that no longer exists, so its next activation on the same goroutine saw a non-nil cell, kept the stale exit under first-wins, and the entry *that* activation pushed was closed by nothing. A span recovers on its own, because `GLSDeactivate` sets its reclaim flag and the stranded entry becomes collectable. A value with no flag does not, and dyngo operations are exactly that, so a finished AppSec operation kept answering as the active one. Removing an entry now clears the exit captured for it. Safe for an owner that has not finished yet: its entry is gone either way, so `GLSDeactivate`'s `Swap` finds nil and runs nothing.