### PR TITLE
chore: upgrade `geomys/sandboxed-step` to `v1.2.2`

### DIFF
--- a/.github/workflows/gotip-testing.yml
+++ b/.github/workflows/gotip-testing.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run tests with gotip (sandboxed)
         # gotip pulls and runs the latest Go toolchain. Keep that toolchain and
         # the test process inside gVisor, persisting only reports/coverage.
-        uses: geomys/sandboxed-step@7d75eb49d17fdeeb3656b3a57d35932d205bcfb9 # v1.2.1
+        uses: geomys/sandboxed-step@a6bfc174e532cea4f378e3427bcde8b714c2e810 # v1.2.2
         with:
           persist-workspace-changes: 'true'
           env: |

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -120,7 +120,7 @@ jobs:
         # Installs govulncheck and runs govulncheck-contribs-sarif.sh, which
         # scans each contrib module and merges results into one SARIF file.
         # -format sarif exits 0 even when vulnerabilities are found.
-        uses: geomys/sandboxed-step@7d75eb49d17fdeeb3656b3a57d35932d205bcfb9 # v1.2.1
+        uses: geomys/sandboxed-step@a6bfc174e532cea4f378e3427bcde8b714c2e810 # v1.2.2
         with:
           persist-workspace-changes: 'true'
           run: |-
@@ -160,7 +160,7 @@ jobs:
       - name: Run govulncheck (sandboxed)
         # geomys/sandboxed-step uses gVisor to confine execution, preventing
         # supply chain attacks from exfiltrating tokens or making network calls.
-        uses: geomys/sandboxed-step@7d75eb49d17fdeeb3656b3a57d35932d205bcfb9 # v1.2.1
+        uses: geomys/sandboxed-step@a6bfc174e532cea4f378e3427bcde8b714c2e810 # v1.2.2
         with:
           run: |
             mkdir -p "${GITHUB_WORKSPACE}/bin"

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -63,7 +63,7 @@ jobs:
         # go get -u executes dependency code from the network. Keep those
         # changes inside the gVisor sandbox; this setup job only needs to prove
         # the updated dependency graph still compiles.
-        uses: geomys/sandboxed-step@7d75eb49d17fdeeb3656b3a57d35932d205bcfb9 # v1.2.1
+        uses: geomys/sandboxed-step@a6bfc174e532cea4f378e3427bcde8b714c2e810 # v1.2.2
         with:
           env: |
             GOPROXY=${{ env.GOPROXY }}
@@ -145,7 +145,7 @@ jobs:
         # It needs to run before "Test dd-trace-go" to avoid TestTelemetryEnabled tests to fail.
         # The smoke script runs go get -u inside each contrib module, so run it
         # in gVisor and persist only the generated reports/coverage for uploads.
-        uses: geomys/sandboxed-step@7d75eb49d17fdeeb3656b3a57d35932d205bcfb9 # v1.2.1
+        uses: geomys/sandboxed-step@a6bfc174e532cea4f378e3427bcde8b714c2e810 # v1.2.2
         with:
           persist-workspace-changes: 'true'
           env: |
@@ -415,7 +415,7 @@ jobs:
 
   smoke-tests-done:
     name: Smoke Tests
-    needs: 
+    needs:
       - setup-requirements-linux
       - smoke-test-tracer
       - go-get-u


### PR DESCRIPTION
### Motivation

Includes the fix for https://github.com/geomys/sandboxed-step/issues/6 which has been the cause of flakiness in CI.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
