### PR TITLE
test(ddtrace/tracer): cover span pool activation surface

### DIFF
--- a/ddtrace/tracer/payload_v04.go
+++ b/ddtrace/tracer/payload_v04.go
@@ -107,6 +107,11 @@ func (p *payloadV04) push(t spanList) (stats payloadStats, err error) {
 	growTo := max(len(t)*pushSizeHintPerSpan, p.sizeHint)
 	p.sizeHint = 0
 	p.buf.Grow(growTo)
+	// msgp.Encode serializes all of t into p.buf synchronously before push
+	// returns, so tracer.processOutChunk's traceWriter.add(...) call always
+	// completes encoding before releaseSpans clears and recycles these spans.
+	// This is what makes push safe with the span pool, mirroring payloadV1.push's
+	// incremental chunk encoding.
 	if err := msgp.Encode(&p.buf, t); err != nil {
 		return payloadStats{}, err
 	}

--- a/ddtrace/tracer/payload_v1.go
+++ b/ddtrace/tracer/payload_v1.go
@@ -274,8 +274,10 @@ func (p *payloadV1) push(t spanList) (stats payloadStats, err error) {
 		p.staticBufLen = len(p.buf)
 	}
 
-	// Encode the new chunk immediately while spans are still valid (before any
-	// pool release). This is what makes the incremental model safe with span pooling.
+	// Encode the new chunk immediately, synchronously, while spans are still
+	// valid: tracer.processOutChunk calls traceWriter.add (which reaches this
+	// push) before releaseSpans clears and recycles them. payloadV04.push
+	// honors the same contract via its single msgp.Encode call.
 	if p.bm.contains(11) {
 		p.encodeTraceChunk(tc, p.st)
 	}

--- a/ddtrace/tracer/span_pool_config_test.go
+++ b/ddtrace/tracer/span_pool_config_test.go
@@ -218,6 +218,39 @@ func TestSpanPoolActivationReachesHotPath(t *testing.T) {
 	}
 }
 
+// TestSpanPoolUnaffectedByStatsComputationAndDataStreams is a regression
+// guard for a reported production symptom: a service set
+// DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED=true alongside
+// DD_TRACE_STATS_COMPUTATION_ENABLED=false and DD_DATA_STREAMS_ENABLED=true,
+// and observed the trace protocol downgrade to v0.4 — a real, intentional
+// consequence of disabling stats computation (see newConfig: "v1 is not
+// compatible without CSS") — and suspected the span pool was disabled too.
+// It wasn't, and can't be by this config: SetSpanPoolEnabled has exactly two
+// call sites in the whole repo (the env-var load in internal/config and the
+// WithSpanPool/Orchestrion-gate pair in this package's newConfig), and
+// neither references stats computation, trace protocol, or DSM. The one
+// documented mechanism that does force pooling off is the Orchestrion gate
+// (TestSpanPoolOrchestrionGateWiring above; the on-branch requires a woven
+// build, see internal/orchestrion/_integration/gls/span_pool_gate_test.go).
+func TestSpanPoolUnaffectedByStatsComputationAndDataStreams(t *testing.T) {
+	t.Setenv("DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED", "true")
+	t.Setenv("DD_TRACE_STATS_COMPUTATION_ENABLED", "false")
+	t.Setenv("DD_DATA_STREAMS_ENABLED", "true")
+
+	tr, transport, flush, stop, err := startTestTracer(t)
+	require.NoError(t, err)
+	defer stop()
+
+	require.True(t, tr.config.internalConfig.SpanPoolEnabled())
+	assert.False(t, tr.config.canComputeStats(), "sanity check: stats computation must actually be off")
+
+	s := tr.StartSpan("op", ServiceName("svc"), ResourceName("/r"), Tag(ext.ManualKeep, true))
+	s.Finish()
+	flush(1)
+	require.Len(t, transport.Traces(), 1)
+	assert.Empty(t, s.name, "span pool must recycle spans regardless of stats computation / DSM config")
+}
+
 // TestSpanPoolNotUsedWhenTracingDisabled confirms DD_TRACE_ENABLED=false short
 // circuits StartSpan before the pool is ever touched, even if the pool env
 // var resolves to true.

--- a/ddtrace/tracer/span_pool_config_test.go
+++ b/ddtrace/tracer/span_pool_config_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const envSpanPoolEnabled = "DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED"
-
 // TestSpanPoolActivationConfig pins the env var / StartOption precedence for
 // the experimental span pool. span_pool_test.go only ever turns pooling on
 // via WithSpanPool(true); this covers how the flag resolves before any of
@@ -47,7 +45,7 @@ func TestSpanPoolActivationConfig(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.name != "unset" {
-				t.Setenv(envSpanPoolEnabled, tc.env)
+				t.Setenv("DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED", tc.env)
 			}
 			cfg, err := newTestConfig(tc.opts...)
 			require.NoError(t, err)
@@ -73,7 +71,10 @@ func latestConfig(t *testing.T, cfgs []telemetry.Configuration, name string) tel
 
 // TestSpanPoolConfigTelemetry asserts not just that a value is reported, but
 // which source won: the default, the raw env var string, or the StartOption
-// (as a bool, via SetSpanPoolEnabled).
+// (as a bool, via SetSpanPoolEnabled). The "contradicting" case additionally
+// covers env and option disagreeing at the same time: both reports must
+// exist (the losing source is still recorded, per configtelemetry's design),
+// but the option's entry must be the one with the highest SeqID.
 func TestSpanPoolConfigTelemetry(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		telemetryClient := new(telemetrytest.RecordClient)
@@ -82,7 +83,7 @@ func TestSpanPoolConfigTelemetry(t *testing.T) {
 		_, err := newTestConfig()
 		require.NoError(t, err)
 
-		got := latestConfig(t, telemetryClient.Configuration, envSpanPoolEnabled)
+		got := latestConfig(t, telemetryClient.Configuration, "DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED")
 		assert.Equal(t, telemetry.OriginDefault, got.Origin)
 		assert.Equal(t, false, got.Value)
 	})
@@ -90,12 +91,12 @@ func TestSpanPoolConfigTelemetry(t *testing.T) {
 	t.Run("env var", func(t *testing.T) {
 		telemetryClient := new(telemetrytest.RecordClient)
 		defer telemetry.MockClient(telemetryClient)()
-		t.Setenv(envSpanPoolEnabled, "true")
+		t.Setenv("DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED", "true")
 
 		_, err := newTestConfig()
 		require.NoError(t, err)
 
-		got := latestConfig(t, telemetryClient.Configuration, envSpanPoolEnabled)
+		got := latestConfig(t, telemetryClient.Configuration, "DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED")
 		assert.Equal(t, telemetry.OriginEnvVar, got.Origin)
 		// The provider reports the raw string value, not the parsed bool.
 		assert.Equal(t, "true", got.Value)
@@ -108,7 +109,23 @@ func TestSpanPoolConfigTelemetry(t *testing.T) {
 		_, err := newTestConfig(WithSpanPool(true))
 		require.NoError(t, err)
 
-		got := latestConfig(t, telemetryClient.Configuration, envSpanPoolEnabled)
+		got := latestConfig(t, telemetryClient.Configuration, "DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED")
+		assert.Equal(t, telemetry.OriginCode, got.Origin)
+		assert.Equal(t, true, got.Value)
+	})
+
+	t.Run("contradicting env and option, option wins", func(t *testing.T) {
+		telemetryClient := new(telemetrytest.RecordClient)
+		defer telemetry.MockClient(telemetryClient)()
+		t.Setenv("DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED", "false")
+
+		_, err := newTestConfig(WithSpanPool(true))
+		require.NoError(t, err)
+
+		telemetrytest.CheckConfig(t, telemetryClient.Configuration, "DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED", "false")
+		telemetrytest.CheckConfig(t, telemetryClient.Configuration, "DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED", true)
+
+		got := latestConfig(t, telemetryClient.Configuration, "DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED")
 		assert.Equal(t, telemetry.OriginCode, got.Origin)
 		assert.Equal(t, true, got.Value)
 	})
@@ -161,7 +178,10 @@ func TestSpanPoolOrchestrionGateWiring(t *testing.T) {
 // resolved flag actually reaches acquireSpan/releaseSpans, not just that the
 // config value is correct. releaseSpans is the only caller of Span.clear(),
 // so a finished span left un-cleared after a completed flush means the flag
-// never reached the release path.
+// never reached the release path. The "contradicting" cases go one step
+// further than TestSpanPoolActivationConfig: it is not enough for
+// SpanPoolEnabled() to resolve to the option's value when env and option
+// disagree — the actual pooling behavior must follow it too.
 func TestSpanPoolActivationReachesHotPath(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
@@ -172,10 +192,12 @@ func TestSpanPoolActivationReachesHotPath(t *testing.T) {
 		{name: "env only", env: "true", wantPooled: true},
 		{name: "option only", opts: []StartOption{WithSpanPool(true)}, wantPooled: true},
 		{name: "disabled", wantPooled: false},
+		{name: "option true overrides env false", env: "false", opts: []StartOption{WithSpanPool(true)}, wantPooled: true},
+		{name: "option false overrides env true", env: "true", opts: []StartOption{WithSpanPool(false)}, wantPooled: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.env != "" {
-				t.Setenv(envSpanPoolEnabled, tc.env)
+				t.Setenv("DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED", tc.env)
 			}
 			tr, transport, flush, stop, err := startTestTracer(t, tc.opts...)
 			require.NoError(t, err)
@@ -201,7 +223,7 @@ func TestSpanPoolActivationReachesHotPath(t *testing.T) {
 // var resolves to true.
 func TestSpanPoolNotUsedWhenTracingDisabled(t *testing.T) {
 	t.Setenv("DD_TRACE_ENABLED", "false")
-	t.Setenv(envSpanPoolEnabled, "true")
+	t.Setenv("DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED", "true")
 
 	tr, _, _, stop, err := startTestTracer(t)
 	require.NoError(t, err)

--- a/ddtrace/tracer/span_pool_config_test.go
+++ b/ddtrace/tracer/span_pool_config_test.go
@@ -1,0 +1,226 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package tracer
+
+import (
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
+	"github.com/DataDog/dd-trace-go/v2/internal/log"
+	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
+	"github.com/DataDog/dd-trace-go/v2/internal/telemetry/telemetrytest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const envSpanPoolEnabled = "DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED"
+
+// TestSpanPoolActivationConfig pins the env var / StartOption precedence for
+// the experimental span pool. span_pool_test.go only ever turns pooling on
+// via WithSpanPool(true); this covers how the flag resolves before any of
+// that behavioral coverage applies.
+func TestSpanPoolActivationConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		env  string // "" means unset
+		opts []StartOption
+		want bool
+	}{
+		{name: "unset", want: false},
+		{name: "env true", env: "true", want: true},
+		{name: "env TRUE", env: "TRUE", want: true},
+		{name: "env 1", env: "1", want: true},
+		{name: "env t", env: "t", want: true},
+		{name: "env false", env: "false", want: false},
+		{name: "env 0", env: "0", want: false},
+		{name: "env garbage falls back to default", env: "notabool", want: false},
+		{name: "env empty is treated as unset", env: "", want: false},
+		{name: "option true, no env", opts: []StartOption{WithSpanPool(true)}, want: true},
+		{name: "option false, no env", opts: []StartOption{WithSpanPool(false)}, want: false},
+		{name: "option true overrides env false", env: "false", opts: []StartOption{WithSpanPool(true)}, want: true},
+		{name: "option false overrides env true", env: "true", opts: []StartOption{WithSpanPool(false)}, want: false},
+		{name: "last option wins", opts: []StartOption{WithSpanPool(true), WithSpanPool(false)}, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.name != "unset" {
+				t.Setenv(envSpanPoolEnabled, tc.env)
+			}
+			cfg, err := newTestConfig(tc.opts...)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, cfg.internalConfig.SpanPoolEnabled())
+		})
+	}
+}
+
+// latestConfig returns the telemetry.Configuration entry with the highest
+// SeqID for name — the entry that reflects the value actually held by the
+// config, since later Report/ReportWithID calls win over earlier ones.
+func latestConfig(t *testing.T, cfgs []telemetry.Configuration, name string) telemetry.Configuration {
+	t.Helper()
+	var found *telemetry.Configuration
+	for i, c := range cfgs {
+		if c.Name == name && (found == nil || c.SeqID > found.SeqID) {
+			found = &cfgs[i]
+		}
+	}
+	require.NotNil(t, found, "no telemetry config reported for %s", name)
+	return *found
+}
+
+// TestSpanPoolConfigTelemetry asserts not just that a value is reported, but
+// which source won: the default, the raw env var string, or the StartOption
+// (as a bool, via SetSpanPoolEnabled).
+func TestSpanPoolConfigTelemetry(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		telemetryClient := new(telemetrytest.RecordClient)
+		defer telemetry.MockClient(telemetryClient)()
+
+		_, err := newTestConfig()
+		require.NoError(t, err)
+
+		got := latestConfig(t, telemetryClient.Configuration, envSpanPoolEnabled)
+		assert.Equal(t, telemetry.OriginDefault, got.Origin)
+		assert.Equal(t, false, got.Value)
+	})
+
+	t.Run("env var", func(t *testing.T) {
+		telemetryClient := new(telemetrytest.RecordClient)
+		defer telemetry.MockClient(telemetryClient)()
+		t.Setenv(envSpanPoolEnabled, "true")
+
+		_, err := newTestConfig()
+		require.NoError(t, err)
+
+		got := latestConfig(t, telemetryClient.Configuration, envSpanPoolEnabled)
+		assert.Equal(t, telemetry.OriginEnvVar, got.Origin)
+		// The provider reports the raw string value, not the parsed bool.
+		assert.Equal(t, "true", got.Value)
+	})
+
+	t.Run("option", func(t *testing.T) {
+		telemetryClient := new(telemetrytest.RecordClient)
+		defer telemetry.MockClient(telemetryClient)()
+
+		_, err := newTestConfig(WithSpanPool(true))
+		require.NoError(t, err)
+
+		got := latestConfig(t, telemetryClient.Configuration, envSpanPoolEnabled)
+		assert.Equal(t, telemetry.OriginCode, got.Origin)
+		assert.Equal(t, true, got.Value)
+	})
+}
+
+// TestSpanPoolSnapshotTracksConfig guards the asymmetry between the two read
+// sites: acquireSpan reads SpanStartSnapshot().SpanPoolEnabled (tracer.go),
+// while releaseSpans reads the live Config.SpanPoolEnabled() (tracer.go). If
+// the snapshot ever stops carrying the field, spans would be acquired
+// unpooled but released into the pool (or vice versa).
+func TestSpanPoolSnapshotTracksConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opts []StartOption
+	}{
+		{name: "disabled"},
+		{name: "enabled", opts: []StartOption{WithSpanPool(true)}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := newTestConfig(tc.opts...)
+			require.NoError(t, err)
+			assert.Equal(t,
+				cfg.internalConfig.SpanPoolEnabled(),
+				cfg.internalConfig.SpanStartSnapshot().SpanPoolEnabled,
+			)
+		})
+	}
+}
+
+// TestSpanPoolOrchestrionGateWiring covers the reachable branch of the
+// Orchestrion incompatibility gate at newConfig's call site: orchestrion.Enabled()
+// is a build-time constant that is always false under plain `go test`, so
+// WithSpanPool(true) must stay enabled and no warning should be logged. The
+// gate predicate itself is table-tested directly in span_pool_gate_test.go.
+// The on-branch (pooling actually forced off) is only reachable in a woven
+// build; see internal/orchestrion/_integration/gls/span_pool_gate_test.go.
+func TestSpanPoolOrchestrionGateWiring(t *testing.T) {
+	tp := new(log.RecordLogger)
+	defer log.UseLogger(tp)()
+
+	cfg, err := newTestConfig(WithSpanPool(true))
+	require.NoError(t, err)
+	assert.True(t, cfg.internalConfig.SpanPoolEnabled())
+	for _, l := range tp.Logs() {
+		assert.NotContains(t, l, "incompatible with Orchestrion")
+	}
+}
+
+// TestSpanPoolActivationReachesHotPath is the deterministic proof that the
+// resolved flag actually reaches acquireSpan/releaseSpans, not just that the
+// config value is correct. releaseSpans is the only caller of Span.clear(),
+// so a finished span left un-cleared after a completed flush means the flag
+// never reached the release path.
+func TestSpanPoolActivationReachesHotPath(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		env        string
+		opts       []StartOption
+		wantPooled bool
+	}{
+		{name: "env only", env: "true", wantPooled: true},
+		{name: "option only", opts: []StartOption{WithSpanPool(true)}, wantPooled: true},
+		{name: "disabled", wantPooled: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.env != "" {
+				t.Setenv(envSpanPoolEnabled, tc.env)
+			}
+			tr, transport, flush, stop, err := startTestTracer(t, tc.opts...)
+			require.NoError(t, err)
+			defer stop()
+
+			s := tr.StartSpan("op", ServiceName("svc"), ResourceName("/r"), Tag(ext.ManualKeep, true))
+			s.Finish()
+			flush(1)
+			require.Len(t, transport.Traces(), 1)
+
+			if tc.wantPooled {
+				assert.Empty(t, s.name, "releaseSpans should have cleared the span")
+				assert.Zero(t, s.spanID)
+			} else {
+				assert.Equal(t, "op", s.name, "span must not be cleared when pooling is off")
+			}
+		})
+	}
+}
+
+// TestSpanPoolNotUsedWhenTracingDisabled confirms DD_TRACE_ENABLED=false short
+// circuits StartSpan before the pool is ever touched, even if the pool env
+// var resolves to true.
+func TestSpanPoolNotUsedWhenTracingDisabled(t *testing.T) {
+	t.Setenv("DD_TRACE_ENABLED", "false")
+	t.Setenv(envSpanPoolEnabled, "true")
+
+	tr, _, _, stop, err := startTestTracer(t)
+	require.NoError(t, err)
+	defer stop()
+
+	assert.True(t, tr.config.internalConfig.SpanPoolEnabled())
+	assert.Nil(t, tr.StartSpan("op"))
+}
+
+// TestSpanPoolProgrammaticOverrideNotInheritedByNextStart pins that
+// newConfig's internalconfig.CreateNew() rebuilds config from scratch, so a
+// WithSpanPool(true) passed to one tracer.Start does not leak into a later
+// Start that omits it.
+func TestSpanPoolProgrammaticOverrideNotInheritedByNextStart(t *testing.T) {
+	cfg1, err := newTestConfig(WithSpanPool(true))
+	require.NoError(t, err)
+	assert.True(t, cfg1.internalConfig.SpanPoolEnabled())
+
+	cfg2, err := newTestConfig()
+	require.NoError(t, err)
+	assert.False(t, cfg2.internalConfig.SpanPoolEnabled())
+}

--- a/ddtrace/tracer/span_pool_config_test.go
+++ b/ddtrace/tracer/span_pool_config_test.go
@@ -44,9 +44,11 @@ func TestSpanPoolActivationConfig(t *testing.T) {
 		{name: "last option wins", opts: []StartOption{WithSpanPool(true), WithSpanPool(false)}, want: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.name != "unset" {
-				t.Setenv("DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED", tc.env)
-			}
+			// Always set (never skip): the invoking environment may already have
+			// this var set, and tc.env's zero value ("") is itself the "unset"
+			// case per the provider's semantics, so an unconditional Setenv keeps
+			// every case deterministic regardless of the ambient shell/CI env.
+			t.Setenv("DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED", tc.env)
 			cfg, err := newTestConfig(tc.opts...)
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, cfg.internalConfig.SpanPoolEnabled())
@@ -77,6 +79,10 @@ func latestConfig(t *testing.T, cfgs []telemetry.Configuration, name string) tel
 // but the option's entry must be the one with the highest SeqID.
 func TestSpanPoolConfigTelemetry(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
+		// Force the var unset regardless of the invoking environment: an
+		// inherited "true" would report OriginEnvVar instead of OriginDefault
+		// and break this assertion.
+		t.Setenv("DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED", "")
 		telemetryClient := new(telemetrytest.RecordClient)
 		defer telemetry.MockClient(telemetryClient)()
 
@@ -103,6 +109,10 @@ func TestSpanPoolConfigTelemetry(t *testing.T) {
 	})
 
 	t.Run("option", func(t *testing.T) {
+		// Unset too: the option wins over any env value regardless (proven by
+		// the "contradicting" case below), but pinning the starting state keeps
+		// this subtest from silently depending on that fact.
+		t.Setenv("DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED", "")
 		telemetryClient := new(telemetrytest.RecordClient)
 		defer telemetry.MockClient(telemetryClient)()
 
@@ -196,9 +206,9 @@ func TestSpanPoolActivationReachesHotPath(t *testing.T) {
 		{name: "option false overrides env true", env: "true", opts: []StartOption{WithSpanPool(false)}, wantPooled: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.env != "" {
-				t.Setenv("DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED", tc.env)
-			}
+			// Always set, same reasoning as TestSpanPoolActivationConfig: an
+			// inherited ambient value must not leak into the "disabled" case.
+			t.Setenv("DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED", tc.env)
 			tr, transport, flush, stop, err := startTestTracer(t, tc.opts...)
 			require.NoError(t, err)
 			defer stop()
@@ -271,6 +281,10 @@ func TestSpanPoolNotUsedWhenTracingDisabled(t *testing.T) {
 // WithSpanPool(true) passed to one tracer.Start does not leak into a later
 // Start that omits it.
 func TestSpanPoolProgrammaticOverrideNotInheritedByNextStart(t *testing.T) {
+	// cfg2 asserts a hardcoded false below, so the env var must be pinned
+	// unset regardless of the invoking environment.
+	t.Setenv("DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED", "")
+
 	cfg1, err := newTestConfig(WithSpanPool(true))
 	require.NoError(t, err)
 	assert.True(t, cfg1.internalConfig.SpanPoolEnabled())

--- a/internal/orchestrion/_integration/gls/span_pool_gate_test.go
+++ b/internal/orchestrion/_integration/gls/span_pool_gate_test.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package gls
+
+import (
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
+
+	"github.com/DataDog/orchestrion/runtime/built"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSpanPoolDisabledUnderOrchestrion is the woven counterpart to
+// ddtrace/tracer's TestSpanPoolOrchestrionGateWiring: orchestrion.Enabled() is
+// a build-time constant that plain `go test` always sees as false, so the
+// on-branch of the gate (ddtrace/tracer/option.go's newConfig, which forces
+// the experimental span pool off when Orchestrion's GLS weave is active — see
+// orchestrion#782) can only be exercised in a build actually woven by
+// orchestrion. This package already runs woven in the orchestrion CI lane, so
+// it is the natural home for that assertion.
+func TestSpanPoolDisabledUnderOrchestrion(t *testing.T) {
+	if !orchestrionEnabled {
+		t.Skip("the span pool gate only trips in orchestrion builds")
+	}
+	require.True(t, built.WithOrchestrion)
+
+	t.Run("env var", func(t *testing.T) {
+		t.Setenv("DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED", "true")
+		require.NoError(t, tracer.Start(tracer.WithLogStartup(false)))
+		defer tracer.Stop()
+		require.False(t, internalconfig.Get().SpanPoolEnabled(),
+			"span pool must be force-disabled under orchestrion (orchestrion#782)")
+	})
+
+	t.Run("explicit option", func(t *testing.T) {
+		require.NoError(t, tracer.Start(tracer.WithLogStartup(false), tracer.WithSpanPool(true)))
+		defer tracer.Stop()
+		require.False(t, internalconfig.Get().SpanPoolEnabled())
+	})
+}


### PR DESCRIPTION
### What does this PR do?

Adds test coverage for the experimental span pool's **activation surface** — the env var / `StartOption` / Orchestrion-gate precedence logic — which was previously untested. `span_pool_test.go` only ever activates the pool via `WithSpanPool(true)` and asserts recycling *behavior*; nothing pinned how the flag actually resolves or that it reaches the hot path.

New coverage in [`ddtrace/tracer/span_pool_config_test.go`](ddtrace/tracer/span_pool_config_test.go):
- `TestSpanPoolActivationConfig` — env var (`DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED`) vs `WithSpanPool` precedence table: unset/true/false/garbage env values, option overriding env in both directions (including when the two contradict each other), last-option-wins.
- `TestSpanPoolConfigTelemetry` — asserts which telemetry entry actually wins (origin + value type — env reports the raw string, code reports a bool), including a case where env and option contradict each other: both sources' reports must exist, and the option's entry must be the one with the highest `SeqID`.
- `TestSpanPoolSnapshotTracksConfig` — regression guard that `SpanStartSnapshot().SpanPoolEnabled` never drifts from `Config.SpanPoolEnabled()`, since span acquisition reads the snapshot while release reads the live config.
- `TestSpanPoolOrchestrionGateWiring` — the reachable (off) branch of the Orchestrion incompatibility gate as wired through `newConfig`.
- `TestSpanPoolActivationReachesHotPath` — deterministic proof the resolved flag reaches `acquireSpan`/`releaseSpans`, by checking whether a finished span was cleared after flush. Includes contradicting env/option cases to prove the actual pooling *behavior* follows the winning source, not just the config getter.
- `TestSpanPoolUnaffectedByStatsComputationAndDataStreams` — regression guard for a reported production symptom: a service set `DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED=true` alongside `DD_TRACE_STATS_COMPUTATION_ENABLED=false` and `DD_DATA_STREAMS_ENABLED=true`, saw the trace protocol downgrade to v0.4, and suspected the span pool was disabled too. Traced and reproduced: the v0.4 downgrade is a real, intentional, and *separate* consequence of disabling client-side stats (v1 protocol requires CSS — see `newConfig`); it has no code path to the span pool. `SetSpanPoolEnabled` has exactly two call sites in the whole repo (the env-var load and the `WithSpanPool`/Orchestrion-gate pair), neither referencing stats computation, trace protocol, or DSM. This test pins that independence. (The one documented mechanism that *does* force pooling off is the Orchestrion gate, covered separately below.)
- `TestSpanPoolNotUsedWhenTracingDisabled` — `DD_TRACE_ENABLED=false` short-circuits `StartSpan` before the pool is ever touched.
- `TestSpanPoolProgrammaticOverrideNotInheritedByNextStart` — pins that a second `Start`/`newConfig` call rebuilds config from env and drops prior programmatic overrides.

All env-based subtests explicitly pin `DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED` to `""` (unset) at the start of every case that expects default/unset behavior, rather than skipping `t.Setenv` — otherwise a pre-existing value in the invoking shell/CI environment silently leaks into the "unset" and "disabled" assertions. Verified by reproducing the failure with the var pre-set before the fix and confirming it disappears after.

Plus [`internal/orchestrion/_integration/gls/span_pool_gate_test.go`](internal/orchestrion/_integration/gls/span_pool_gate_test.go) — `TestSpanPoolDisabledUnderOrchestrion`, the woven counterpart exercising the gate's on-branch (skipped under plain `go test` since `orchestrion.Enabled()` is a build-time constant; runs in the Orchestrion CI lane).

Also clarifies two comments in [`payload_v1.go`](ddtrace/tracer/payload_v1.go) and [`payload_v04.go`](ddtrace/tracer/payload_v04.go): the original `payloadV1.push` comment read as if only the v1 protocol's incremental encoding made span pooling safe. In fact the safety contract (encode fully before `releaseSpans` clears/recycles the spans) is enforced one layer up in `tracer.processOutChunk`, and both `payloadV04.push` (single synchronous `msgp.Encode`) and `payloadV1.push` (incremental `encodeTraceChunk`) honor it equally — the span pool works identically for both wire protocols, confirmed by the existing `TestSpanPoolAgentPOVMatchesNoPool` and sibling tests, which already run both `v0.4` and `v1.0` subtests.

### Motivation

Requested to validate every input that can influence span pool activation — the environment variable, the tracer option (including when the two contradict each other), and interference from other config (e.g. `DD_TRACE_ENABLED`, stats computation, DSM, Orchestrion) — since a silent regression in any of these would slip past the existing behavior-focused test suite.

This was prompted by a real report: a service running with
```
DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED=true
DD_TRACE_STATS_COMPUTATION_ENABLED=false
DD_PROFILING_ENABLED=true
DD_DATA_STREAMS_ENABLED=true
```
appeared to have the span pool disabled *and* was using the v0.4 trace protocol despite the pool being explicitly enabled. Investigation traced these to two unrelated causes: the v0.4 downgrade is intentional and caused solely by disabling stats computation; the span pool is untouched by any of these four variables. If the pool really is inactive on that service, the most likely explanation is Orchestrion auto-instrumentation (the only mechanism that force-disables it), which is now suspected and being confirmed separately.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

No behavior change: no new `DD_*` config key, no feature, no CI updates required. The `payload_v1.go`/`payload_v04.go` changes are comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)