### PR TITLE
fix: matrix doesn't parse contribs correctly for subdirectories

### DIFF
--- a/scripts/ci_contrib_matrix.go
+++ b/scripts/ci_contrib_matrix.go
@@ -4,7 +4,6 @@
 // Copyright 2025 Datadog, Inc.
 
 //go:build ignore
-// +build ignore
 
 // This tool outputs a JSON encoded array that can be used as a matrix input to GitHub workflows.
 // Rather than testing all contribs under one job, we would rather parallelize the jobs
@@ -21,7 +20,8 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"regexp"
+	"path/filepath"
+	"strings"
 )
 
 const numRunners = 6
@@ -35,7 +35,10 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	contribRe := regexp.MustCompile(`/(contrib|instrumentation)/.*/`)
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatalln(err)
+	}
 
 	contribs := make([]string, numRunners)
 	i := 0
@@ -43,16 +46,22 @@ func main() {
 	for dec.More() {
 		var pkg struct {
 			Path string `json:"Path"`
+			Dir  string `json:"Dir"`
 		}
 		if err := dec.Decode(&pkg); err != nil {
 			continue
 		}
-		// we want to only count packages in the contrib directory
-		validContrib := contribRe.FindStringSubmatch(pkg.Path)
-		if validContrib == nil {
+
+		rel, err := filepath.Rel(cwd, pkg.Dir)
+		if err != nil {
 			continue
 		}
-		contribs[i] += "." + validContrib[0] + " "
+		rel = filepath.ToSlash(rel)
+		// we want to only count packages in the contrib or instrumentation directory
+		if !strings.HasPrefix(rel, "contrib/") && !strings.HasPrefix(rel, "instrumentation/") {
+			continue
+		}
+		contribs[i] += "./" + rel + "/ "
 		i = (i + 1) % numRunners
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Adjusts the script for building our contrib matrices for CI so that it will correctly parse contrib paths for subdirectories.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

[Breakages on another PR](https://github.com/DataDog/dd-trace-go/actions/runs/30376248587/job/90332718937?pr=5000) due to a new type of path that wasn't being tested/used by our script before:

```
Testing contrib module: ./contrib/net/http/v2/
./scripts/ci_test_contrib.sh: line 39: cd: ./contrib/net/http/v2/: No such file or directory
```

Input was `./contrib/net/http/v2/otelc` and the expected output should still be `./contrib/net/http`.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
