### PR TITLE
ci(smoke-tests): check orchestrion/all resolves from the module proxy

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -416,21 +416,14 @@ jobs:
   check-orchestrion-all-resolves:
     # Verify that orchestrion/all/v2, and every dd-trace-go module it requires, can be
     # resolved from the module proxy by an external consumer.
-    #
-    # No other job can catch this. In-repo, go.work and the `replace` directives in
-    # orchestrion/all/go.mod point every sibling module at a local path, and `replace`
-    # in a dependency's go.mod is ignored by whoever depends on it. So a nested module
-    # whose tag is missing builds perfectly here while being unresolvable for everyone
-    # else. That is why this job deliberately does not check out the repository: it has
-    # to see dd-trace-go only through the proxy, exactly as a user does.
     name: 'Check orchestrion/all resolves from the module proxy'
     runs-on: ubuntu-latest
     if: github.repository_owner == 'DataDog' # needs a commit pushed to the public repo
     env:
       REF: ${{ inputs.ref || github.sha }}
-      # This job asserts resolvability, not supply chain integrity, which the other jobs
-      # already cover. Skipping the checksum database avoids a spurious failure when it
-      # has not yet caught up with a just-pushed commit.
+      # This job checks that modules can be downloaded, not that their checksums match,
+      # which the other jobs already cover. Skipping the checksum database avoids a false
+      # failure when it has not yet caught up with a just-pushed commit.
       GOSUMDB: "off"
     steps:
       - name: Setup Go

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -413,20 +413,87 @@ jobs:
       - name: Test
         run: docker run -p7777:7777 --rm smoke-test
 
+  check-orchestrion-all-resolves:
+    # Verify that orchestrion/all/v2, and every dd-trace-go module it requires, can be
+    # resolved from the module proxy by an external consumer.
+    #
+    # No other job can catch this. In-repo, go.work and the `replace` directives in
+    # orchestrion/all/go.mod point every sibling module at a local path, and `replace`
+    # in a dependency's go.mod is ignored by whoever depends on it. So a nested module
+    # whose tag is missing builds perfectly here while being unresolvable for everyone
+    # else. That is why this job deliberately does not check out the repository: it has
+    # to see dd-trace-go only through the proxy, exactly as a user does.
+    name: 'Check orchestrion/all resolves from the module proxy'
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'DataDog' # needs a commit pushed to the public repo
+    env:
+      REF: ${{ inputs.ref || github.sha }}
+      # This job asserts resolvability, not supply chain integrity, which the other jobs
+      # already cover. Skipping the checksum database avoids a spurious failure when it
+      # has not yet caught up with a just-pushed commit.
+      GOSUMDB: "off"
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: "1.25" # lowest supported version, so this checks the floor
+      - name: Resolve orchestrion/all as an external consumer would
+        id: resolve
+        run: |-
+          set -euo pipefail
+          module=github.com/DataDog/dd-trace-go/orchestrion/all/v2
+
+          # Build the throwaway consumer outside the workspace, so no go.work or replace
+          # directive above it can influence resolution.
+          work=$(mktemp -d)
+          cd "$work"
+          go mod init ci.local/orchestrion-all-resolve-check
+
+          # orchestrion/all only pulls the contrib modules in under the `tools` build
+          # tag, which is how `orchestrion pin` wires it into a user's project. A plain
+          # `go get` prunes them away and passes even when a tag is missing, so the tool
+          # file plus `go mod tidy`, which considers every build tag, is what actually
+          # forces each contrib module to resolve.
+          printf '//go:build tools\n\npackage tools\n\nimport _ "%s"\n' "$module" > orchestrion.tool.go
+
+          echo "::group::go get $module@$REF"
+          go get "$module@$REF"
+          echo "::endgroup::"
+
+          echo "::group::go mod tidy"
+          go mod tidy
+          echo "::endgroup::"
+      - name: Explain how to fix this
+        if: failure() && steps.resolve.outcome == 'failure'
+        run: |-
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ## `orchestrion/all` is not resolvable from the module proxy
+
+          A new nested module was most likely added without a published tag, so external
+          consumers cannot use `orchestrion/all/v2@main` even though this repository builds
+          fine. Please run the following to cut a new dev release:
+
+          ```sh
+          git checkout -b dev-vX.Y.x origin/main
+          go run ./scripts/autoreleasetagger --version vX.Y.0-dev.N --root .
+          ```
+          EOF
+
   smoke-tests-done:
     name: Smoke Tests
     needs:
       - setup-requirements-linux
       - smoke-test-tracer
       - go-get-u
+      - check-orchestrion-all-resolves
     runs-on: ubuntu-latest
     if: success() || failure()
     steps:
       - name: Success
-        if: needs.setup-requirements-linux.result == 'success' && needs.smoke-test-tracer.result == 'success' && needs.go-get-u.result == 'success'
+        if: needs.setup-requirements-linux.result == 'success' && needs.smoke-test-tracer.result == 'success' && needs.go-get-u.result == 'success' && needs.check-orchestrion-all-resolves.result == 'success'
         run: echo "Success!"
       - name: Failure
-        if: needs.setup-requirements-linux.result != 'success' || needs.smoke-test-tracer.result != 'success' || needs.go-get-u.result != 'success'
+        if: needs.setup-requirements-linux.result != 'success' || needs.smoke-test-tracer.result != 'success' || needs.go-get-u.result != 'success' || needs.check-orchestrion-all-resolves.result != 'success'
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           webhook-type: incoming-webhook
@@ -436,6 +503,7 @@ jobs:
               "linux_result": "${{ needs.setup-requirements-linux.result }}",
               "core_result": "${{ needs.smoke-test-tracer.result }}",
               "contrib_result": "${{ needs.go-get-u.result }}",
+              "proxy_resolution_result": "${{ needs.check-orchestrion-all-resolves.result }}",
               "blocks": [
                 {
                   "type": "header",
@@ -471,6 +539,10 @@ jobs:
                       "type": "mrkdwn",
                       "text": "*Contrib Test Result:*\n${{ needs.go-get-u.result }}"
                     },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Proxy Resolution Result:*\n${{ needs.check-orchestrion-all-resolves.result }}"
+                    }
                   ]
                 }
               ]


### PR DESCRIPTION
### What does this PR do?

Adds a `check-orchestrion-all-resolves` job to the Smoke Tests workflow. It resolves `orchestrion/all/v2` at the current commit from the module proxy in a throwaway module and runs `go mod tidy`, which catches nested modules missing a published tag.

### Motivation

`contrib/go.uber.org/zap` was added in #4729 after that cycle's `v2.11.0-dev` tags were cut, so `orchestrion/all/v2@main` has been unresolvable for external consumers since 2026-07-24 with all of CI green.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.
