### PR TITLE
test(contrib/modelcontextprotocol/go-sdk): tolerate SEP-2106 content fallback

### DIFF
--- a/contrib/modelcontextprotocol/go-sdk/tracing_test.go
+++ b/contrib/modelcontextprotocol/go-sdk/tracing_test.go
@@ -224,8 +224,12 @@ func TestIntegrationToolCallSuccess(t *testing.T) {
 	err = json.Unmarshal([]byte(outputStr), &outputData)
 	require.NoError(t, err)
 
+	// go-sdk >= v1.7.0 appends a serialized-JSON TextContent fallback when a tool's
+	// structured output is not a JSON object (SEP-2106), so the block count is
+	// upstream-dependent. The handler's own block stays at index 0 because the SDK
+	// appends rather than prepends.
 	content := outputData["content"].([]any)
-	require.Len(t, content, 1)
+	require.NotEmpty(t, content)
 	contentItem := content[0].(map[string]any)
 	assert.Equal(t, "text", contentItem["type"])
 


### PR DESCRIPTION
### What does this PR do?

Relaxes an over-strict assertion in `TestIntegrationToolCallSuccess` so it tolerates the number of `Content` blocks the `modelcontextprotocol/go-sdk` MCP library returns, instead of requiring exactly one.

### Motivation

The `go get -u smoke test` CI job (which upgrades all contrib dependencies to their latest minor version to catch breakage early, see #1607) currently fails on `main`:

```
=== FAIL: . TestIntegrationToolCallSuccess (0.11s)
    tracing_test.go:228:
        Error: "[map[text:{"result":8} type:text] map[text:8 type:text]]" should have 1 item(s), but has 2
```

Root cause: `go get -u` upgrades `github.com/modelcontextprotocol/go-sdk` from the pinned v1.4.1 to v1.7.0. That version introduces SEP-2106 support: when a tool handler's structured output isn't a JSON object, the SDK now *appends* a serialized-JSON `TextContent` fallback block to `Content` (previously it only synthesized a block when `Content` was `nil`).

The test's `calculator` handler returns `Content` holding the JSON object `{"result":8}`, but its structured output (3rd return value) is the bare primitive `float64(8)`. On v1.7.0 that mismatch now produces 2 content blocks instead of 1, and `require.Len(t, content, 1)` fails.

This is not a regression in dd-trace-go's instrumentation — `tracing.go`/`intent_capture.go`/`gosdk.go` never construct or modify `Content`; they only marshal whatever `mcp.CallToolResult` the SDK produces. It's purely a test assertion that was too strict about an SDK implementation detail. Verified locally that all 8 tests in the module pass against both go-sdk v1.4.1 (current pin) and v1.7.0.

Per [contrib/README.md's version-pinning policy](https://github.com/DataDog/dd-trace-go/blob/main/contrib/README.md#version-pinning), the `go.mod` pin stays at v1.4.1 — this PR only fixes the test assertion so the smoke job (which always pulls latest regardless of the pin) goes green.

This also affects `dev-v2.11.x` (#5090); once merged, this commit should be manually cherry-picked there.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.