### PR TITLE
feat(ddtrace/tracer): carry ot.th/ot.rv and sampled flag on OTLP export

### DIFF
--- a/ddtrace/tracer/doc.go
+++ b/ddtrace/tracer/doc.go
@@ -67,7 +67,9 @@
 // span counts across a mixed Datadog/OpenTelemetry trace. An inbound ot= is honored
 // and forwarded unchanged; non-probability decisions (manual keep, AppSec, or a
 // rate-limiter drop) omit the threshold. This is automatic, requires no configuration,
-// and leaves the existing Datadog propagation unchanged.
+// and leaves the existing Datadog propagation unchanged. When spans are exported over
+// OTLP, the same ot= member is carried on the span's trace_state and the W3C sampled
+// trace-flag is set, so the export matches what wire propagation would emit.
 //
 // To create spans, use the functions StartSpan and StartSpanFromContext. Both accept
 // StartSpanOptions that can be used to configure the span. A span that is started

--- a/ddtrace/tracer/span_to_otlp.go
+++ b/ddtrace/tracer/span_to_otlp.go
@@ -58,12 +58,17 @@ func buildResource(cfg *internalconfig.Config) *otlpresource.Resource {
 // Span conversion (DD Span → OTLP Span and related types)
 // -----------------------------------------------------------------------------
 
+// otlpTraceFlagSampled is the W3C "sampled" trace-flag (bit 0), carried in the
+// low 8 bits of the OTLP Span.Flags field.
+const otlpTraceFlagSampled = uint32(0x1)
+
 // +checklocksignore — Post-finish: reads finished span fields during payload encoding.
 func convertSpan(s *Span, defaultServiceName string, otelSemantics bool) *otlptrace.Span {
-	if p, ok := s.context.SamplingPriority(); ok && p < ext.PriorityAutoKeep {
+	p, ok := s.context.SamplingPriority()
+	if ok && p < ext.PriorityAutoKeep {
 		return nil
 	}
-	return &otlptrace.Span{
+	span := &otlptrace.Span{
 		TraceId:           convertTraceID(s.context.traceID.Upper(), s.context.traceID.Lower()),
 		SpanId:            convertSpanID(s.spanID),
 		ParentSpanId:      convertParentSpanID(s.parentID),
@@ -75,8 +80,14 @@ func convertSpan(s *Span, defaultServiceName string, otelSemantics bool) *otlptr
 		Events:            convertEvents(s),
 		Links:             convertSpanLinks(s.spanLinks),
 		Status:            convertSpanStatus(s),
-		TraceState:        convertTraceState(s.context),
+		TraceState:        convertTraceState(s.context, p),
 	}
+	// Mirror the W3C sampled trace-flag we set on wire injection: kept spans
+	// carry the sampled bit. Priority < AutoKeep already returned nil above.
+	if ok && p >= ext.PriorityAutoKeep {
+		span.Flags = otlpTraceFlagSampled
+	}
+	return span
 }
 
 // +checklocksignore — Post-finish: reads finished span fields during payload encoding.
@@ -283,11 +294,16 @@ func convertEventAttributes(ddAttributes map[string]*spanEventAttribute) []*otlp
 	return out
 }
 
-func convertTraceState(ctx *SpanContext) string {
+// convertTraceState builds the OTLP span's trace_state. It reuses
+// composeTracestate so the exported value is identical to what wire injection
+// would produce: a regenerated dd= member from the live context, the
+// DD-managed ot= member (rv/th) when probability sampling applies, followed by
+// any inbound third-party vendors. priority is the span's sampling priority.
+func convertTraceState(ctx *SpanContext, priority int) string {
 	if ctx.trace == nil {
 		return ""
 	}
-	return ctx.trace.propagatingTag(tracestateHeader)
+	return composeTracestate(ctx, priority, ctx.trace.propagatingTag(tracestateHeader))
 }
 
 // --- AnyValue helpers ---

--- a/ddtrace/tracer/span_to_otlp_test.go
+++ b/ddtrace/tracer/span_to_otlp_test.go
@@ -459,21 +459,29 @@ func TestConvertSpanLinks_EmptyNil(t *testing.T) {
 }
 
 func TestConvertSpanTraceState(t *testing.T) {
-	t.Run("populated from span context", func(t *testing.T) {
+	t.Run("regenerated from live span context", func(t *testing.T) {
 		s := newSpan("op", "svc", "res", 1, 1, 0)
-		setPropagatingTag(s.context, tracestateHeader, "dd=s:2;o:rum,othervendor=abc")
+		s.context.origin = "rum"
+		s.context.setSamplingPriority(ext.PriorityUserKeep, samplernames.Manual)
+		// The inbound dd= (stale priority/origin) is dropped and rebuilt from
+		// the live context; the foreign vendor is preserved.
+		setPropagatingTag(s.context, tracestateHeader, "dd=s:1;o:stale,othervendor=abc")
 
 		otlpSpan := convertSpan(s, "svc", false)
 		require.NotNil(t, otlpSpan)
-		assert.Equal(t, "dd=s:2;o:rum,othervendor=abc", otlpSpan.TraceState)
+		assert.Equal(t, "dd=s:2;o:rum;p:0000000000000001;t.dm:-4,othervendor=abc", otlpSpan.TraceState)
+		assert.Equal(t, otlpTraceFlagSampled, otlpSpan.Flags)
 	})
 
-	t.Run("empty when no tracestate", func(t *testing.T) {
+	t.Run("regenerated for local root without inbound tracestate", func(t *testing.T) {
 		s := newSpan("op", "svc", "res", 1, 1, 0)
+		s.context.setSamplingPriority(ext.PriorityAutoKeep, samplernames.Default)
 
 		otlpSpan := convertSpan(s, "svc", false)
 		require.NotNil(t, otlpSpan)
-		assert.Empty(t, otlpSpan.TraceState)
+		// A locally-started span now carries a regenerated dd= member, matching
+		// what wire injection would emit.
+		assert.Equal(t, "dd=s:1;p:0000000000000001;t.dm:-0", otlpSpan.TraceState)
 	})
 
 	t.Run("empty when trace is nil", func(t *testing.T) {
@@ -483,6 +491,43 @@ func TestConvertSpanTraceState(t *testing.T) {
 		otlpSpan := convertSpan(s, "svc", false)
 		require.NotNil(t, otlpSpan)
 		assert.Empty(t, otlpSpan.TraceState)
+	})
+}
+
+func TestConvertSpanTraceStateOtel(t *testing.T) {
+	t.Run("probability decision emits ot=rv;th and sets sampled flag", func(t *testing.T) {
+		const tid = uint64(0xfff972474538efff)
+		s := newSpan("op", "svc", "res", 1, tid, 0)
+		s.context.setSamplingPriority(ext.PriorityAutoKeep, samplernames.AgentRate)
+		s.context.trace.setOtelProbability(tid, 0.1)
+
+		otlpSpan := convertSpan(s, "svc", false)
+		require.NotNil(t, otlpSpan)
+		assert.Contains(t, otlpSpan.TraceState, "ot=rv:ef284ace7a91e1;th:e6666666666668")
+		assert.Equal(t, otlpTraceFlagSampled, otlpSpan.Flags)
+	})
+
+	t.Run("inherited ot= is forwarded on export", func(t *testing.T) {
+		s := newSpan("op", "svc", "res", 1, 1, 0)
+		s.context.setSamplingPriority(ext.PriorityAutoKeep, samplernames.Unknown)
+		s.context.trace.setOtelUpstream(0xabcdef1234567, true, 0, false, "")
+
+		otlpSpan := convertSpan(s, "svc", false)
+		require.NotNil(t, otlpSpan)
+		assert.Contains(t, otlpSpan.TraceState, "ot=rv:0abcdef1234567")
+	})
+
+	t.Run("malformed inbound ot= is dropped", func(t *testing.T) {
+		s := newSpan("op", "svc", "res", 1, 1, 0)
+		s.context.setSamplingPriority(ext.PriorityAutoKeep, samplernames.Default)
+		// Inbound ot= that was never parsed into managed state must not be
+		// re-emitted; only foreign vendors survive.
+		setPropagatingTag(s.context, tracestateHeader, "dd=s:1,ot=garbage,othervendor=abc")
+
+		otlpSpan := convertSpan(s, "svc", false)
+		require.NotNil(t, otlpSpan)
+		assert.NotContains(t, otlpSpan.TraceState, "ot=")
+		assert.Contains(t, otlpSpan.TraceState, "othervendor=abc")
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?

Carries the OpenTelemetry consistent-probability-sampling pair (`ot.th`/`ot.rv`, OTEP 235) on the OTLP export path and sets the W3C `sampled` trace-flag on exported spans.

- `convertTraceState` now reuses `composeTracestate`, so the exported `trace_state` is identical to what wire injection emits: a regenerated `dd=` member from the live span context, the DD-managed `ot=` member (rv/th) when a probability decision applies, followed by any inbound third-party vendors. Inbound `dd=`/`ot=` are dropped and rebuilt from the live context (single source of truth).
- `convertSpan` sets `Span.Flags` to the W3C `sampled` bit (`0x1`) for kept spans.

Observable change: locally-started spans that previously exported an empty `trace_state` now export a regenerated `dd=...` (plus `ot=...` when probability sampling applies), matching what is already emitted over the wire.

### Motivation

APMAPI-2183. Second step of the cross-tracer RFC for OpenTelemetry consistent probability sampling, stacked on the wire-propagation PR (#5060). OTLP-native downstreams can make and verify the same keep/drop decision and extrapolate span counts across mixed Datadog/OpenTelemetry traces.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] System-Tests covering this feature have been added and enabled with the va.b.c-dev version tag. <!-- follow-up PR stacked on the Go system-tests PR -->
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors.
- [x] New code doesn't break existing tests.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date.
- [x] Non-trivial go.mod changes reviewed by @DataDog/dd-trace-go-guild. <!-- no go.mod changes -->
