### PR TITLE
test(net/http): add cross-goroutine client integration test

### DIFF
--- a/internal/orchestrion/_integration/net_http/generated_test.go
+++ b/internal/orchestrion/_integration/net_http/generated_test.go
@@ -17,6 +17,10 @@ func TestClientError(t *testing.T) {
 	harness.Run(t, new(TestCaseClientError))
 }
 
+func TestClientGoroutine(t *testing.T) {
+	harness.Run(t, new(TestCaseClientGoroutine))
+}
+
 func TestFuncHandler(t *testing.T) {
 	harness.Run(t, new(TestCaseFuncHandler))
 }

--- a/internal/orchestrion/_integration/net_http/goroutine.go
+++ b/internal/orchestrion/_integration/net_http/goroutine.go
@@ -33,25 +33,37 @@ func (tc *TestCaseClientGoroutine) Setup(ctx context.Context, t *testing.T) {
 	tc.base.Setup(ctx, t)
 }
 
+// clientResult carries the outcome of the client call back to the test
+// goroutine, so the fatal assertions run there and not on the worker goroutine.
+type clientResult struct {
+	status int
+	err    error
+}
+
 func (tc *TestCaseClientGoroutine) Run(ctx context.Context, t *testing.T) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "test.root")
 	defer span.Finish()
 
-	done := make(chan struct{})
-	go getInGoroutine(ctx, t, "http://"+tc.srv.Addr+"/hit", done)
-	<-done
+	res := make(chan clientResult, 1)
+	go getInGoroutine(ctx, "http://"+tc.srv.Addr+"/hit", res)
+	got := <-res
+	require.NoError(t, got.err)
+	require.Equal(t, http.StatusOK, got.status)
 }
 
 // getInGoroutine calls http.Get with a context.Context in scope so the
 // instrumentation injects it into the request. It runs on a goroutine that does
 // not hold the parent span in its GLS, so correct parenting proves the context
-// propagated through the surrounding scope rather than GLS.
-func getInGoroutine(ctx context.Context, t *testing.T, url string, done chan<- struct{}) {
-	defer close(done)
+// propagated through the surrounding scope rather than GLS. The result is sent
+// back to the test goroutine, which performs the fatal assertions.
+func getInGoroutine(ctx context.Context, url string, res chan<- clientResult) {
 	resp, err := http.Get(url)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-	require.Equal(t, http.StatusOK, resp.StatusCode)
+	if err != nil {
+		res <- clientResult{err: err}
+		return
+	}
+	resp.Body.Close()
+	res <- clientResult{status: resp.StatusCode}
 }
 
 func (tc *TestCaseClientGoroutine) ExpectedTraces() trace.Traces {

--- a/internal/orchestrion/_integration/net_http/goroutine.go
+++ b/internal/orchestrion/_integration/net_http/goroutine.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package nethttp
+
+// TestCaseClientGoroutine verifies trace correlation for the net/http client
+// shorthands (http.Get, ...) when the call happens on a goroutine that received
+// a context.Context as a parameter. This distinguishes call-site context
+// injection (which works across goroutines) from GLS-based propagation (which
+// does not cross goroutine boundaries): the parent span is started on the test
+// goroutine, so it is absent from the spawned goroutine's GLS, and correct
+// parenting can only come from the injected context.
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion/_integration/internal/trace"
+)
+
+type TestCaseClientGoroutine struct {
+	base
+}
+
+func (tc *TestCaseClientGoroutine) Setup(ctx context.Context, t *testing.T) {
+	tc.handler = tc.serveMuxHandler()
+	tc.base.Setup(ctx, t)
+}
+
+func (tc *TestCaseClientGoroutine) Run(ctx context.Context, t *testing.T) {
+	span, ctx := tracer.StartSpanFromContext(ctx, "test.root")
+	defer span.Finish()
+
+	done := make(chan struct{})
+	go getInGoroutine(ctx, t, "http://"+tc.srv.Addr+"/hit", done)
+	<-done
+}
+
+// getInGoroutine calls http.Get with a context.Context in scope so the
+// instrumentation injects it into the request. It runs on a goroutine that does
+// not hold the parent span in its GLS, so correct parenting proves the context
+// propagated through the surrounding scope rather than GLS.
+func getInGoroutine(ctx context.Context, t *testing.T, url string, done chan<- struct{}) {
+	defer close(done)
+	resp, err := http.Get(url)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func (tc *TestCaseClientGoroutine) ExpectedTraces() trace.Traces {
+	return trace.Traces{
+		{
+			Tags: map[string]any{
+				"name": "test.root",
+			},
+			Children: trace.Traces{
+				{
+					Tags: map[string]any{
+						"name":     "http.request",
+						"resource": "GET /hit",
+						"type":     "http",
+					},
+					Meta: map[string]string{
+						"component": "net/http",
+						"span.kind": "client",
+					},
+					Children: trace.Traces{
+						{
+							Tags: map[string]any{
+								"name":     "http.request",
+								"resource": "GET /hit",
+								"type":     "web",
+							},
+							Meta: map[string]string{
+								"component": "net/http",
+								"span.kind": "server",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/orchestrion/_integration/net_http/goroutine.go
+++ b/internal/orchestrion/_integration/net_http/goroutine.go
@@ -5,14 +5,6 @@
 
 package nethttp
 
-// TestCaseClientGoroutine verifies trace correlation for the net/http client
-// shorthands (http.Get, ...) when the call happens on a goroutine that received
-// a context.Context as a parameter. This distinguishes call-site context
-// injection (which works across goroutines) from GLS-based propagation (which
-// does not cross goroutine boundaries): the parent span is started on the test
-// goroutine, so it is absent from the spawned goroutine's GLS, and correct
-// parenting can only come from the injected context.
-
 import (
 	"context"
 	"net/http"
@@ -24,6 +16,13 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion/_integration/internal/trace"
 )
 
+// TestCaseClientGoroutine verifies trace correlation for the net/http client
+// shorthands (http.Get, ...) when the call happens on a goroutine that received
+// a context.Context as a parameter. This distinguishes call-site context
+// injection (which works across goroutines) from GLS-based propagation (which
+// does not cross goroutine boundaries): the parent span is started on the test
+// goroutine, so it is absent from the spawned goroutine's GLS, and correct
+// parenting can only come from the injected context.
 type TestCaseClientGoroutine struct {
 	base
 }


### PR DESCRIPTION
### What does this PR do?

Adds a net/http integration test that makes an `http.Get` from a goroutine which
received a `context.Context`, and asserts the resulting client span is a child of
the caller's span.

### Motivation

Trace correlation for the net/http client shorthands should come from the
surrounding context (which works across goroutines), not goroutine-local storage
(which does not). No test covered that case, so this adds one to lock the
behavior in.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] New code is free of linting errors.
- [ ] New code doesn't break existing tests.
- [ ] All generated files are up to date.
