### PR TITLE
ci: attribute build-metrics binary size to dependencies

### DIFF
--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -10,6 +10,9 @@ name: Build Metrics
 # Key features:
 # - Cold cache measurement: cleans build cache before each measurement to capture full compilation cost
 # - Warm module cache: runs go mod download (untimed) so measurement reflects compilation, not network
+# - Dependency attribution (standard mode only): go-size-analyzer breaks the binary down by
+#   vendor package, published as go.build.dependency_size_bytes.<dependency>, so a size
+#   regression can be traced to which dependency grew instead of just the binary total
 # - Datadog CI Visibility: publishes metrics and tags to job spans for dashboard trending and regression monitoring
 # - Runs on: Pull requests (when this file, scripts/*, orchestrion.yml, or any go.mod changes) and pushes to main
 # - Tags metrics by: build.toolchain, build.sample, build.cache, go.version, orchestrion.version
@@ -119,6 +122,14 @@ jobs:
           go-version: stable
           cache: false  # Cold build cache for accurate measurements
           check-latest: true
+
+      - name: Install go-size-analyzer
+        if: matrix.mode == 'standard'
+        run: |
+          curl -L --fail "https://github.com/Zxilly/go-size-analyzer/releases/download/v1.13.0/go-size-analyzer_1.13.0_linux_amd64.tar.gz" -o gsa.tar.gz
+          tar -xzf gsa.tar.gz gsa
+          chmod +x gsa
+          echo "${{ github.workspace }}" >> "$GITHUB_PATH"
 
       - name: Measure build
         id: measure

--- a/scripts/measure_build.sh
+++ b/scripts/measure_build.sh
@@ -17,7 +17,10 @@ set -euo pipefail
 #   -h, --help            Show this help message
 #
 # Output JSON includes all build_duration_samples (one per repeat) and a single
-# binary_size_bytes taken from the last build.
+# binary_size_bytes taken from the last build. In standard mode, if `gsa`
+# (go-size-analyzer) is on PATH, the JSON also includes dependency_sizes: the
+# top 10 vendor (third-party) packages contributing to that binary's size,
+# attributing size to specific dependencies instead of just the binary total.
 #
 # Examples:
 #   scripts/measure_build.sh --sample net_http --mode standard
@@ -180,6 +183,30 @@ for i in $(seq 1 "$REPEATS"); do
 done
 message "Durations: ${durations[*]}, size: $size bytes"
 
+# Dependency size attribution (standard mode only — orchestrion mode builds the
+# same source, so re-running the analysis there would just duplicate this data)
+DEPENDENCY_SIZES="[]"
+if [[ "$MODE" == "standard" ]] && command -v gsa &> /dev/null; then
+  message "Attributing binary size to dependencies with gsa..."
+  bin_path="$OUT_DIR/$SAMPLE-$MODE.test"
+  gsa_json="$OUT_DIR/gsa.json"
+  if gsa "$bin_path" -f json --compact --no-disasm -o "$gsa_json"; then
+    DEPENDENCY_SIZES=$(jq '[
+      .packages
+      | to_entries
+      | map(select(.value.type == "vendor"))
+      | sort_by(-.value.size)
+      | .[0:10]
+      | .[]
+      | { name: .key, metric_key: (.key | ascii_downcase | gsub("[^a-z0-9_]+"; "_")), size_bytes: .value.size }
+    ]' "$gsa_json")
+  else
+    message "  gsa analysis failed; continuing without dependency_sizes"
+  fi
+else
+  message "Skipping dependency attribution (gsa not found or mode is orchestrion)"
+fi
+
 # Build JSON output — durations as array, size as single value
 message "Generating JSON output..."
 DURATION_ARRAY=$(printf '%s\n' "${durations[@]}" | jq -R 'tonumber' | jq -s '.')
@@ -188,8 +215,9 @@ JSON=$(jq -n \
   --arg mode "$MODE" \
   --argjson durations "$DURATION_ARRAY" \
   --argjson size "$size" \
+  --argjson dependency_sizes "$DEPENDENCY_SIZES" \
   --arg go_version "$GO_VERSION" \
-  '{ sample: $sample, mode: $mode, metrics: { build_duration_samples: $durations, binary_size_bytes: $size }, go_version: $go_version }')
+  '{ sample: $sample, mode: $mode, metrics: { build_duration_samples: $durations, binary_size_bytes: $size, dependency_sizes: $dependency_sizes }, go_version: $go_version }')
 
 # Add orchestrion version if in orchestrion mode
 if [[ "$MODE" == "orchestrion" ]]; then

--- a/scripts/publish_build_metrics.sh
+++ b/scripts/publish_build_metrics.sh
@@ -50,21 +50,31 @@ ORCHESTRION_VERSION=$(jq -r '.orchestrion_version // empty' "$METRICS_FILE")
 # Read all duration samples into a bash array
 mapfile -t DURATIONS < <(jq -r '.metrics.build_duration_samples[]' "$METRICS_FILE")
 
+# Read dependency size attribution (standard mode only; empty otherwise)
+mapfile -t DEP_KEYS < <(jq -r '.metrics.dependency_sizes[]?.metric_key' "$METRICS_FILE")
+mapfile -t DEP_SIZES < <(jq -r '.metrics.dependency_sizes[]?.size_bytes' "$METRICS_FILE")
+
 message "Parsed metrics:"
 message "  Sample: $SAMPLE"
 message "  Mode: $MODE"
 message "  Durations: ${DURATIONS[*]}s"
 message "  Size: $SIZE bytes"
+message "  Dependencies attributed: ${#DEP_KEYS[@]}"
 message "  Go version: $GO_VERSION"
 if [[ -n "$ORCHESTRION_VERSION" ]]; then
   message "  Orchestrion version: $ORCHESTRION_VERSION"
 fi
 
-# Publish measures to CI Visibility — one indexed measure per duration sample, one size sample
+# Publish measures to CI Visibility — one indexed measure per duration sample,
+# one size sample, and (standard mode only) one indexed measure per dependency
+# attributed by gsa, following the same duration_seconds.<i> naming convention
 message "Publishing measures to Datadog CI Visibility..."
 MEASURE_ARGS=(--measures "go.build.binary_size_bytes:${SIZE}")
 for i in "${!DURATIONS[@]}"; do
   MEASURE_ARGS+=(--measures "go.build.duration_seconds.${i}:${DURATIONS[$i]}")
+done
+for i in "${!DEP_KEYS[@]}"; do
+  MEASURE_ARGS+=(--measures "go.build.dependency_size_bytes.${DEP_KEYS[$i]}:${DEP_SIZES[$i]}")
 done
 
 DATADOG_SITE="${DATADOG_SITE:-datadoghq.com}" datadog-ci measure --level job \


### PR DESCRIPTION
## Summary
- `build-metrics.yml` already tracks total binary size per sample on every `go.mod` change, but this PR would allow us to trace a regression down to *which* dependency caused it (if a dependency is at fault)
- In standard-mode builds, runs `go-size-analyzer` against the built binary and publishes the top 10 vendor packages' sizes as indexed measures (`go.build.dependency_size_bytes.<dependency>`), following the same naming convention already used for `go.build.duration_seconds.<i>`.
- Skipped in orchestrion-mode builds (same source, so it would just duplicate the standard-mode data).

## Test plan
- [x] Ran the modified `measure_build.sh` against the real `sql` sample locally; confirmed `dependency_sizes` in the output JSON with correct top-10 vendor packages and sanitized metric keys
- [x] Ran `publish_build_metrics.sh` against a stubbed `datadog-ci` binary; confirmed it emits one `go.build.dependency_size_bytes.<dependency>` measure per entry
- [x] Confirmed the orchestrion-mode JSON shape (`dependency_sizes: []`) is handled without error
- [x] `shellcheck` clean on both modified scripts
- [x] Verified the pinned `go-size-analyzer` v1.13.0 linux_amd64 release tarball actually contains a binary named `gsa`
- [ ] Not yet verified against a real Datadog API key / real CI Visibility job span — first real run will be whatever CI does on this PR