### PR TITLE
fix(envoyproxy/go-control-plane): resolve client IP from GCP ext_proc source.ip

### DIFF
--- a/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/README.md
+++ b/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/README.md
@@ -58,7 +58,16 @@ The Terraform equivalent, on `google_network_services_lb_traffic_extension` or
 forward_attributes = ["source.ip"]
 ```
 
-Without that attribute the client address is taken from forwarding headers such as
+Envoy's own equivalent attribute, `source.address`, is accepted as a fallback and
+carries the same address as `host:port`. `source.ip` is a Google Cloud addition and
+does not exist in stock Envoy, so a self-managed Envoy configures the Envoy name
+instead:
+
+```yaml
+request_attributes: [source.address]
+```
+
+Without either attribute the client address is taken from forwarding headers such as
 `X-Forwarded-For`. A client connecting directly to the load balancer chooses what it
 sends in that header, so it can present an address that is not its own: the load
 balancer [appends the address it observed](https://cloud.google.com/load-balancing/docs/https#x-forwarded-for_header)

--- a/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/README.md
+++ b/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/README.md
@@ -41,6 +41,47 @@ The ASM Service Extension expose some configuration. The configuration can be tw
 | `DD_AGENT_HOST`       | `N/A`         | Host of a running Datadog Agent. |
 | `DD_TRACE_AGENT_PORT` | `8126`        | Port of a running Datadog Agent. |
 
+### Client IP resolution
+
+App & API Protection identifies clients by IP address, both to attribute traces and to
+enforce IP denylists. Configure the extension to forward the `source.ip` attribute so
+that identification uses the address Google Cloud observed on the connection:
+
+```yaml
+forwardAttributes: [source.ip]
+```
+
+The Terraform equivalent, on `google_network_services_lb_traffic_extension` or
+`google_network_services_lb_route_extension`:
+
+```hcl
+forward_attributes = ["source.ip"]
+```
+
+Without that attribute the client address is taken from forwarding headers such as
+`X-Forwarded-For`. A client connecting directly to the load balancer chooses what it
+sends in that header, so it can present an address that is not its own: the load
+balancer [appends the address it observed](https://cloud.google.com/load-balancing/docs/https#x-forwarded-for_header)
+*after* any value the client supplied, while client IP resolution selects the first
+public address in the list. `source.ip` is set by the infrastructure rather than by the
+client, so it cannot be manipulated the same way.
+
+Forwarding the attribute changes nothing for deployments that identify themselves as
+plain Envoy or Istio, and nothing for requests that arrive without it.
+
+Two limitations:
+
+- **A CDN or proxy sits in front of the load balancer.** `source.ip` describes the
+  connection Google Cloud received, which in that topology comes from the CDN rather
+  than from the end user. Recovering the original address then depends on whatever
+  forwarding mechanism that CDN offers, and on trusting it; this integration does not
+  attempt it.
+- **A private `source.ip` combined with a forged public `X-Forwarded-For`.** Client IP
+  resolution prefers a public address over a private one, so a forged public value
+  still wins in that case. This matches the behaviour of earlier releases and mainly
+  concerns internal load balancers, where clients reach the load balancer from inside
+  the VPC.
+
 ### SSL Configuration
 
 The Envoy of GCP is configured to communicate to the Service Extension with TLS.

--- a/contrib/envoyproxy/go-control-plane/envoy_messages.go
+++ b/contrib/envoyproxy/go-control-plane/envoy_messages.go
@@ -8,12 +8,14 @@ package gocontrolplane
 import (
 	"context"
 	"fmt"
+	"net/netip"
 	"os"
 	"strconv"
 	"sync"
 
 	extproc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
@@ -45,6 +47,21 @@ func (m messageRequestHeaders) ExtractRequest(ctx context.Context) (proxy.Pseudo
 	}
 
 	headers["Host"] = append(headers["Host"], pseudoHeaders[":authority"])
+
+	// The load balancer can forward the address of the TCP peer it observed as
+	// the source.ip attribute, which the client cannot forge. Prepend it to
+	// X-Forwarded-For: client IP resolution scans that header from the left and
+	// stops at the first global address, so the trusted value wins over any
+	// entry the client supplied. Client-supplied values are deliberately kept so
+	// the WAF keeps inspecting the header exactly as it was received.
+	if m.component(ctx) == componentNameGCPServiceExtension {
+		if sourceIP, ok := parseExtProcSourceIP(m.ProcessingRequest.GetAttributes()); ok {
+			addr := sourceIP.String()
+			headers["X-Forwarded-For"] = append([]string{addr}, headers["X-Forwarded-For"]...)
+			remoteAddr = addr
+		}
+	}
+
 	return proxy.PseudoRequest{
 		Method:     pseudoHeaders[":method"],
 		Authority:  pseudoHeaders[":authority"],
@@ -53,6 +70,47 @@ func (m messageRequestHeaders) ExtractRequest(ctx context.Context) (proxy.Pseudo
 		Headers:    headers,
 		RemoteAddr: remoteAddr,
 	}, nil
+}
+
+const (
+	// extProcAttributesNamespace is the key of the ProcessingRequest attributes
+	// map under which Envoy publishes the attributes selected by the extension
+	// configuration. Google Cloud Service Extensions spell that selection
+	// forwardAttributes; the resulting wire format is Envoy's.
+	extProcAttributesNamespace = "envoy.filters.http.ext_proc"
+
+	// sourceIPAttribute holds the address of the TCP peer as seen by the load
+	// balancer. Unlike X-Forwarded-For it is set by the infrastructure rather
+	// than the client, so it is authoritative whenever it is present.
+	sourceIPAttribute = "source.ip"
+)
+
+// parseExtProcSourceIP returns the trusted client address published through the
+// ext_proc source.ip attribute. It reports false unless the attribute is present
+// and holds a single unzoned IP address: a value we cannot interpret must leave
+// client IP resolution exactly as it would have been without it, rather than
+// silently substituting a wrong address.
+func parseExtProcSourceIP(attributes map[string]*structpb.Struct) (netip.Addr, bool) {
+	value, found := attributes[extProcAttributesNamespace].GetFields()[sourceIPAttribute]
+	if !found {
+		return netip.Addr{}, false
+	}
+
+	// Anything other than a plain string is not something we know how to read.
+	stringValue, ok := value.GetKind().(*structpb.Value_StringValue)
+	if !ok {
+		return netip.Addr{}, false
+	}
+
+	// source.ip carries a bare address; the port is a separate attribute.
+	sourceIP, err := netip.ParseAddr(stringValue.StringValue)
+	if err != nil || sourceIP.Zone() != "" {
+		return netip.Addr{}, false
+	}
+
+	// Collapse IPv4-mapped IPv6 so the value matches how the address would be
+	// written anywhere else in the trace.
+	return sourceIP.Unmap(), true
 }
 
 func (m messageRequestHeaders) MessageType() proxy.MessageType {

--- a/contrib/envoyproxy/go-control-plane/envoy_messages.go
+++ b/contrib/envoyproxy/go-control-plane/envoy_messages.go
@@ -8,6 +8,7 @@ package gocontrolplane
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/netip"
 	"os"
 	"strconv"
@@ -86,35 +87,55 @@ const (
 
 	// sourceIPAttribute holds the address of the TCP peer as seen by the load
 	// balancer. Unlike X-Forwarded-For it is set by the infrastructure rather
-	// than the client, so it is authoritative whenever it is present.
+	// than the client, so it is authoritative whenever it is present. Google
+	// Cloud documents it; it is not part of stock Envoy's attribute vocabulary.
 	sourceIPAttribute = "source.ip"
+
+	// sourceAddressAttribute is Envoy's own connection attribute for the same
+	// peer, carrying host:port rather than a bare address. It is checked as a
+	// fallback because it is the one that exists in stock Envoy, so a deployment
+	// that does not publish source.ip can still be identified correctly instead
+	// of silently falling back to client-controlled headers.
+	sourceAddressAttribute = "source.address"
 )
 
-// parseExtProcSourceIP returns the trusted client address published through the
-// ext_proc source.ip attribute. It reports false unless the attribute is present
-// and holds a single unzoned IP address: a value we cannot interpret must leave
-// client IP resolution exactly as it would have been without it, rather than
-// silently substituting a wrong address.
+// parseExtProcSourceIP returns the address of the peer the load balancer observed,
+// as published through the ext_proc attributes. It reports false unless one of the
+// attributes holds an address we can interpret: a value we cannot read must leave
+// client IP resolution exactly as it would have been, rather than silently
+// substituting a wrong address.
 func parseExtProcSourceIP(attributes map[string]*structpb.Struct) (netip.Addr, bool) {
-	value, found := attributes[extProcAttributesNamespace].GetFields()[sourceIPAttribute]
-	if !found {
-		return netip.Addr{}, false
+	fields := attributes[extProcAttributesNamespace].GetFields()
+
+	if sourceIP, ok := parseAttributeAddr(fields[sourceIPAttribute]); ok {
+		return sourceIP, true
 	}
 
+	return parseAttributeAddr(fields[sourceAddressAttribute])
+}
+
+// parseAttributeAddr reads an IP out of an attribute value that may be either a
+// bare address or host:port, accepting both so that the caller does not depend on
+// which of the two spellings a given deployment publishes.
+func parseAttributeAddr(value *structpb.Value) (netip.Addr, bool) {
 	stringValue, ok := value.GetKind().(*structpb.Value_StringValue)
 	if !ok {
 		return netip.Addr{}, false
 	}
 
-	// source.ip carries a bare address; the port is a separate attribute.
-	sourceIP, err := netip.ParseAddr(stringValue.StringValue)
-	if err != nil || sourceIP.Zone() != "" {
+	raw := stringValue.StringValue
+	if host, _, err := net.SplitHostPort(raw); err == nil {
+		raw = host
+	}
+
+	addr, err := netip.ParseAddr(raw)
+	if err != nil || addr.Zone() != "" {
 		return netip.Addr{}, false
 	}
 
 	// Collapse IPv4-mapped IPv6 so the value matches how the address would be
 	// written anywhere else in the trace.
-	return sourceIP.Unmap(), true
+	return addr.Unmap(), true
 }
 
 func (m messageRequestHeaders) MessageType() proxy.MessageType {

--- a/contrib/envoyproxy/go-control-plane/envoy_messages.go
+++ b/contrib/envoyproxy/go-control-plane/envoy_messages.go
@@ -77,6 +77,11 @@ const (
 	// map under which Envoy publishes the attributes selected by the extension
 	// configuration. Google Cloud Service Extensions spell that selection
 	// forwardAttributes; the resulting wire format is Envoy's.
+	//
+	// Envoy keys that map by the filter's own name, so the value below is not
+	// arbitrary and must not be "corrected" to something friendlier:
+	// source/extensions/filters/http/ext_proc/ext_proc.cc does
+	// (*req.mutable_attributes())[FilterName] = std::move(attributes).
 	extProcAttributesNamespace = "envoy.filters.http.ext_proc"
 
 	// sourceIPAttribute holds the address of the TCP peer as seen by the load

--- a/contrib/envoyproxy/go-control-plane/envoy_messages.go
+++ b/contrib/envoyproxy/go-control-plane/envoy_messages.go
@@ -96,7 +96,6 @@ func parseExtProcSourceIP(attributes map[string]*structpb.Struct) (netip.Addr, b
 		return netip.Addr{}, false
 	}
 
-	// Anything other than a plain string is not something we know how to read.
 	stringValue, ok := value.GetKind().(*structpb.Value_StringValue)
 	if !ok {
 		return netip.Addr{}, false

--- a/contrib/envoyproxy/go-control-plane/envoy_messages_test.go
+++ b/contrib/envoyproxy/go-control-plane/envoy_messages_test.go
@@ -1,0 +1,238 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package gocontrolplane
+
+import (
+	"context"
+	"testing"
+
+	envoyextproc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/proxy"
+)
+
+// The namespace and attribute names below are intentionally written as literals
+// rather than referencing the constants used by the implementation: they encode
+// the ext_proc wire contract that Envoy and GCP Service Extensions produce, so
+// the test must fail if the implementation ever drifts away from it.
+const (
+	testExtProcAttributesNamespace = "envoy.filters.http.ext_proc"
+	testSourceIPAttribute          = "source.ip"
+)
+
+// testSourceIPAttributes builds the ext_proc attributes map carrying source.ip.
+// A nil value produces a namespace whose source.ip field is explicitly nil,
+// which is distinct from the field being absent entirely.
+func testSourceIPAttributes(value *structpb.Value) map[string]*structpb.Struct {
+	return map[string]*structpb.Struct{
+		testExtProcAttributesNamespace: {
+			Fields: map[string]*structpb.Value{testSourceIPAttribute: value},
+		},
+	}
+}
+
+// TestExtractRequestSourceIP pins the client-IP resolution contract for the GCP
+// Service Extension integration: a trusted source.ip attribute is prepended to
+// X-Forwarded-For (so the client-IP resolver, which selects the first global
+// address scanning left to right, picks it over any client-supplied entry) and
+// also becomes RemoteAddr. Every other case must leave the request untouched.
+func TestExtractRequestSourceIP(t *testing.T) {
+	const (
+		clientXFF   = "9.9.9.9"
+		customValue = "keep  me"
+	)
+
+	tests := []struct {
+		name           string
+		integration    Integration
+		metadata       metadata.MD
+		attributes     map[string]*structpb.Struct
+		requestHeaders map[string]string
+		wantXFF        []string
+		wantRemoteAddr string
+	}{
+		// --- S1: happy path -------------------------------------------------
+		{
+			name:           "global source.ip with no client XFF",
+			integration:    GCPServiceExtensionIntegration,
+			attributes:     testSourceIPAttributes(structpb.NewStringValue("111.222.111.222")),
+			wantXFF:        []string{"111.222.111.222"},
+			wantRemoteAddr: "111.222.111.222",
+		},
+		// --- S5a: WAF-bypass guard: the client value is PRESERVED ------------
+		{
+			name:           "global source.ip is prepended and preserves client XFF",
+			integration:    GCPServiceExtensionIntegration,
+			attributes:     testSourceIPAttributes(structpb.NewStringValue("18.18.18.18")),
+			requestHeaders: map[string]string{"X-Forwarded-For": clientXFF},
+			wantXFF:        []string{"18.18.18.18", clientXFF},
+			wantRemoteAddr: "18.18.18.18",
+		},
+		// --- S7: private source.ip is still surfaced by this layer -----------
+		// The downstream resolver may still prefer a forged global entry; that
+		// is the documented, pre-existing gap and is not this layer's concern.
+		{
+			name:           "private source.ip is still prepended",
+			integration:    GCPServiceExtensionIntegration,
+			attributes:     testSourceIPAttributes(structpb.NewStringValue("192.168.0.9")),
+			requestHeaders: map[string]string{"X-Forwarded-For": "1.1.1.1"},
+			wantXFF:        []string{"192.168.0.9", "1.1.1.1"},
+			wantRemoteAddr: "192.168.0.9",
+		},
+		// --- canonicalisation ------------------------------------------------
+		{
+			name:           "IPv4-mapped IPv6 source.ip is unmapped",
+			integration:    GCPServiceExtensionIntegration,
+			attributes:     testSourceIPAttributes(structpb.NewStringValue("::ffff:203.0.113.11")),
+			wantXFF:        []string{"203.0.113.11"},
+			wantRemoteAddr: "203.0.113.11",
+		},
+		{
+			name:           "expanded IPv6 source.ip is canonicalised",
+			integration:    GCPServiceExtensionIntegration,
+			attributes:     testSourceIPAttributes(structpb.NewStringValue("2001:0db8:0000:0000:0000:0000:0000:0001")),
+			wantXFF:        []string{"2001:db8::1"},
+			wantRemoteAddr: "2001:db8::1",
+		},
+		// --- S2: present but unusable -> change NOTHING -----------------------
+		{
+			name:           "malformed source.ip changes nothing",
+			integration:    GCPServiceExtensionIntegration,
+			attributes:     testSourceIPAttributes(structpb.NewStringValue("not-an-ip")),
+			requestHeaders: map[string]string{"X-Forwarded-For": clientXFF},
+			wantXFF:        []string{clientXFF},
+		},
+		{
+			name:           "zoned source.ip changes nothing",
+			integration:    GCPServiceExtensionIntegration,
+			attributes:     testSourceIPAttributes(structpb.NewStringValue("fe80::1%eth0")),
+			requestHeaders: map[string]string{"X-Forwarded-For": clientXFF},
+			wantXFF:        []string{clientXFF},
+		},
+		{
+			name:           "non-string source.ip changes nothing",
+			integration:    GCPServiceExtensionIntegration,
+			attributes:     testSourceIPAttributes(structpb.NewNumberValue(42)),
+			requestHeaders: map[string]string{"X-Forwarded-For": clientXFF},
+			wantXFF:        []string{clientXFF},
+		},
+		{
+			name:           "nil source.ip value changes nothing",
+			integration:    GCPServiceExtensionIntegration,
+			attributes:     testSourceIPAttributes(nil),
+			requestHeaders: map[string]string{"X-Forwarded-For": clientXFF},
+			wantXFF:        []string{clientXFF},
+		},
+		// --- S3: absent -> change NOTHING ------------------------------------
+		{
+			name:           "namespace without source.ip field changes nothing",
+			integration:    GCPServiceExtensionIntegration,
+			attributes:     map[string]*structpb.Struct{testExtProcAttributesNamespace: {}},
+			requestHeaders: map[string]string{"X-Forwarded-For": clientXFF},
+			wantXFF:        []string{clientXFF},
+		},
+		{
+			name:           "no attributes at all changes nothing",
+			integration:    GCPServiceExtensionIntegration,
+			requestHeaders: map[string]string{"X-Forwarded-For": clientXFF},
+			wantXFF:        []string{clientXFF},
+		},
+		{
+			name:           "absent source.ip still falls back to metadata remote addr",
+			integration:    GCPServiceExtensionIntegration,
+			metadata:       metadata.Pairs("x-forwarded-for", "192.0.2.20"),
+			wantXFF:        []string{"192.0.2.20"},
+			wantRemoteAddr: "192.0.2.20",
+		},
+		// --- S4: non-GCP effective component -> change NOTHING ---------------
+		{
+			name:           "envoy integration ignores source.ip",
+			integration:    EnvoyIntegration,
+			attributes:     testSourceIPAttributes(structpb.NewStringValue("111.222.111.222")),
+			requestHeaders: map[string]string{"X-Forwarded-For": clientXFF},
+			wantXFF:        []string{clientXFF},
+		},
+		{
+			name:           "GCP downgraded to envoy by metadata ignores source.ip",
+			integration:    GCPServiceExtensionIntegration,
+			metadata:       metadata.Pairs(datadogEnvoyIntegrationHeader, "1"),
+			attributes:     testSourceIPAttributes(structpb.NewStringValue("111.222.111.222")),
+			requestHeaders: map[string]string{"X-Forwarded-For": clientXFF},
+			wantXFF:        []string{clientXFF},
+		},
+		{
+			name:           "GCP downgraded to istio by metadata ignores source.ip",
+			integration:    GCPServiceExtensionIntegration,
+			metadata:       metadata.Pairs(datadogIntegrationHeader, "1"),
+			attributes:     testSourceIPAttributes(structpb.NewStringValue("111.222.111.222")),
+			requestHeaders: map[string]string{"X-Forwarded-For": clientXFF},
+			wantXFF:        []string{clientXFF},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tc.metadata != nil {
+				ctx = metadata.NewIncomingContext(ctx, tc.metadata)
+			}
+
+			requestHeaders := map[string]string{"X-Custom": customValue}
+			for k, v := range tc.requestHeaders {
+				requestHeaders[k] = v
+			}
+
+			message := messageRequestHeaders{
+				ProcessingRequest: &envoyextproc.ProcessingRequest{Attributes: tc.attributes},
+				HttpHeaders: &envoyextproc.HttpHeaders{
+					Headers: makeRequestHeaders(t, requestHeaders, "GET", "/"),
+				},
+				integration: tc.integration,
+			}
+
+			request, err := message.ExtractRequest(ctx)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.wantXFF, request.Headers["X-Forwarded-For"],
+				"X-Forwarded-For must carry the trusted source.ip first while preserving client-supplied entries")
+			require.Equal(t, tc.wantRemoteAddr, request.RemoteAddr)
+
+			// Unrelated headers must survive byte-for-byte so the WAF keeps
+			// inspecting the full, unmodified header set.
+			require.Equal(t, []string{customValue}, request.Headers["X-Custom"])
+		})
+	}
+}
+
+// TestExtractRequestSourceIPDoesNotDropHeaders guards against the tempting but
+// unsafe implementation of stripping client-IP headers to win the resolution:
+// removing X-Forwarded-For from the request would also remove it from the WAF's
+// headers address, so an attack payload placed there would never be inspected.
+func TestExtractRequestSourceIPDoesNotDropHeaders(t *testing.T) {
+	const maliciousXFF = "' OR 1=1 --"
+
+	message := messageRequestHeaders{
+		ProcessingRequest: &envoyextproc.ProcessingRequest{
+			Attributes: testSourceIPAttributes(structpb.NewStringValue("18.18.18.18")),
+		},
+		HttpHeaders: &envoyextproc.HttpHeaders{
+			Headers: makeRequestHeaders(t, map[string]string{"X-Forwarded-For": maliciousXFF}, "GET", "/"),
+		},
+		integration: GCPServiceExtensionIntegration,
+	}
+
+	request, err := message.ExtractRequest(context.Background())
+	require.NoError(t, err)
+
+	require.Contains(t, request.Headers["X-Forwarded-For"], maliciousXFF,
+		"the client-supplied X-Forwarded-For must remain visible to the WAF")
+	require.Equal(t, "18.18.18.18", request.RemoteAddr)
+
+	var _ proxy.PseudoRequest = request
+}

--- a/contrib/envoyproxy/go-control-plane/envoy_messages_test.go
+++ b/contrib/envoyproxy/go-control-plane/envoy_messages_test.go
@@ -85,6 +85,19 @@ func TestExtractRequestSourceIP(t *testing.T) {
 			wantXFF:        []string{"192.168.0.9", "1.1.1.1"},
 			wantRemoteAddr: "192.168.0.9",
 		},
+		// Google Cloud sends a single X-Forwarded-For holding
+		// <client-supplied>,<client-ip>,<load-balancer-ip>. The client-supplied
+		// part comes first, which is exactly the entry client IP resolution would
+		// otherwise settle on.
+		// https://cloud.google.com/load-balancing/docs/https#x-forwarded-for_header
+		{
+			name:           "GCLB-shaped X-Forwarded-For keeps its forged leading entry",
+			integration:    GCPServiceExtensionIntegration,
+			attributes:     testSourceIPAttributes(structpb.NewStringValue("203.0.113.50")),
+			requestHeaders: map[string]string{"X-Forwarded-For": "1.1.1.1, 203.0.113.50, 35.191.10.1"},
+			wantXFF:        []string{"203.0.113.50", "1.1.1.1, 203.0.113.50, 35.191.10.1"},
+			wantRemoteAddr: "203.0.113.50",
+		},
 		// --- canonicalisation ------------------------------------------------
 		{
 			name:           "IPv4-mapped IPv6 source.ip is unmapped",

--- a/contrib/envoyproxy/go-control-plane/envoy_messages_test.go
+++ b/contrib/envoyproxy/go-control-plane/envoy_messages_test.go
@@ -24,16 +24,21 @@ import (
 const (
 	testExtProcAttributesNamespace = "envoy.filters.http.ext_proc"
 	testSourceIPAttribute          = "source.ip"
+	testSourceAddressAttribute     = "source.address"
 )
 
 // testSourceIPAttributes builds the ext_proc attributes map carrying source.ip.
 // A nil value produces a namespace whose source.ip field is explicitly nil,
 // which is distinct from the field being absent entirely.
 func testSourceIPAttributes(value *structpb.Value) map[string]*structpb.Struct {
+	return testExtProcAttributes(map[string]*structpb.Value{testSourceIPAttribute: value})
+}
+
+// testExtProcAttributes builds the ext_proc attributes map with arbitrary fields,
+// for the cases that need something other than a lone source.ip.
+func testExtProcAttributes(fields map[string]*structpb.Value) map[string]*structpb.Struct {
 	return map[string]*structpb.Struct{
-		testExtProcAttributesNamespace: {
-			Fields: map[string]*structpb.Value{testSourceIPAttribute: value},
-		},
+		testExtProcAttributesNamespace: {Fields: fields},
 	}
 }
 
@@ -97,6 +102,74 @@ func TestExtractRequestSourceIP(t *testing.T) {
 			requestHeaders: map[string]string{"X-Forwarded-For": "1.1.1.1, 203.0.113.50, 35.191.10.1"},
 			wantXFF:        []string{"203.0.113.50", "1.1.1.1, 203.0.113.50, 35.191.10.1"},
 			wantRemoteAddr: "203.0.113.50",
+		},
+		// source.address is Envoy's own connection attribute and carries host:port.
+		// Unlike source.ip it exists in stock Envoy, so it is the value that
+		// actually arrives when the deployment does not extend the attribute set.
+		{
+			name:        "source.address is used when source.ip is absent",
+			integration: GCPServiceExtensionIntegration,
+			attributes: testExtProcAttributes(map[string]*structpb.Value{
+				testSourceAddressAttribute: structpb.NewStringValue("203.0.113.77:57360"),
+			}),
+			requestHeaders: map[string]string{"X-Forwarded-For": clientXFF},
+			wantXFF:        []string{"203.0.113.77", clientXFF},
+			wantRemoteAddr: "203.0.113.77",
+		},
+		{
+			name:        "bracketed IPv6 source.address is unwrapped",
+			integration: GCPServiceExtensionIntegration,
+			attributes: testExtProcAttributes(map[string]*structpb.Value{
+				testSourceAddressAttribute: structpb.NewStringValue("[2001:db8::1]:443"),
+			}),
+			wantXFF:        []string{"2001:db8::1"},
+			wantRemoteAddr: "2001:db8::1",
+		},
+		{
+			name:        "source.address without a port still works",
+			integration: GCPServiceExtensionIntegration,
+			attributes: testExtProcAttributes(map[string]*structpb.Value{
+				testSourceAddressAttribute: structpb.NewStringValue("203.0.113.77"),
+			}),
+			wantXFF:        []string{"203.0.113.77"},
+			wantRemoteAddr: "203.0.113.77",
+		},
+		{
+			name:        "source.ip takes precedence over source.address",
+			integration: GCPServiceExtensionIntegration,
+			attributes: testExtProcAttributes(map[string]*structpb.Value{
+				testSourceIPAttribute:      structpb.NewStringValue("18.18.18.18"),
+				testSourceAddressAttribute: structpb.NewStringValue("203.0.113.77:57360"),
+			}),
+			wantXFF:        []string{"18.18.18.18"},
+			wantRemoteAddr: "18.18.18.18",
+		},
+		{
+			name:        "malformed source.address changes nothing",
+			integration: GCPServiceExtensionIntegration,
+			attributes: testExtProcAttributes(map[string]*structpb.Value{
+				testSourceAddressAttribute: structpb.NewStringValue("not-an-address"),
+			}),
+			requestHeaders: map[string]string{"X-Forwarded-For": clientXFF},
+			wantXFF:        []string{clientXFF},
+		},
+		{
+			name:        "non-string source.address changes nothing",
+			integration: GCPServiceExtensionIntegration,
+			attributes: testExtProcAttributes(map[string]*structpb.Value{
+				testSourceAddressAttribute: structpb.NewNumberValue(57360),
+			}),
+			requestHeaders: map[string]string{"X-Forwarded-For": clientXFF},
+			wantXFF:        []string{clientXFF},
+		},
+		{
+			name:        "source.address is ignored for a non-GCP effective component",
+			integration: EnvoyIntegration,
+			attributes: testExtProcAttributes(map[string]*structpb.Value{
+				testSourceAddressAttribute: structpb.NewStringValue("203.0.113.77:57360"),
+			}),
+			requestHeaders: map[string]string{"X-Forwarded-For": clientXFF},
+			wantXFF:        []string{clientXFF},
 		},
 		// --- canonicalisation ------------------------------------------------
 		{

--- a/contrib/envoyproxy/go-control-plane/envoy_test.go
+++ b/contrib/envoyproxy/go-control-plane/envoy_test.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // findSetHeader searches for a header by key name in a slice of HeaderValueOption,
@@ -258,6 +259,128 @@ func TestAppSec(t *testing.T) {
 		require.Equal(t, 1.0, span.Tag("_dd.appsec.enabled"))
 		require.Equal(t, "true", span.Tag("appsec.event"))
 		require.Equal(t, "true", span.Tag("appsec.blocked"))
+	})
+
+	// The denylisted address 111.222.111.222 is the one exercised by
+	// "blocking-client-ip" above via a client-supplied X-Forwarded-For. The
+	// subtests below cover the same denylist reached through the trusted
+	// source.ip attribute instead, and the case where the two disagree.
+	t.Run("blocking-client-ip-from-source-ip", func(t *testing.T) {
+		client, mt, cleanup := setup()
+		defer cleanup()
+
+		stream, err := client.Process(context.Background())
+		require.NoError(t, err)
+
+		sendProcessingRequestHeadersWithSourceIP(t, stream, map[string]string{"User-Agent": "Mistake not..."}, "GET", "/", "111.222.111.222")
+
+		res, err := stream.Recv()
+		require.NoError(t, err)
+		require.IsType(t, &envoyextproc.ProcessingResponse_ImmediateResponse{}, res.GetResponse())
+		require.Equal(t, envoytypes.StatusCode(403), res.GetImmediateResponse().GetStatus().Code)
+
+		require.NoError(t, stream.CloseSend())
+		_, _ = stream.Recv() // to flush the spans
+
+		finished := mt.FinishedSpans()
+		require.Len(t, finished, 1)
+		checkForAppsecEvent(t, finished, map[string]int{"custom-001": 1, "blk-001-001": 1})
+
+		span := finished[0]
+		require.Equal(t, "111.222.111.222", span.Tag("http.client_ip"))
+		require.Equal(t, "true", span.Tag("appsec.blocked"))
+	})
+
+	t.Run("source-ip-wins-over-denylisted-x-forwarded-for", func(t *testing.T) {
+		// This is the vulnerability being fixed: the client controls
+		// X-Forwarded-For, so before this change it decided the identity the
+		// denylist was evaluated against. The trusted source.ip must win, which
+		// means the forged denylisted value no longer causes a block.
+		client, mt, cleanup := setup()
+		defer cleanup()
+
+		stream, err := client.Process(context.Background())
+		require.NoError(t, err)
+
+		sendProcessingRequestHeadersWithSourceIP(t, stream,
+			map[string]string{"User-Agent": "Mistake not...", "X-Forwarded-For": "111.222.111.222"},
+			"GET", "/", "18.18.18.18")
+
+		span := finishUnblockedStream(t, stream, mt)
+		require.Equal(t, "18.18.18.18", span.Tag("http.client_ip"))
+		require.Nil(t, span.Tag("appsec.blocked"))
+	})
+
+	t.Run("source-ip-blocks-despite-benign-x-forwarded-for", func(t *testing.T) {
+		client, mt, cleanup := setup()
+		defer cleanup()
+
+		stream, err := client.Process(context.Background())
+		require.NoError(t, err)
+
+		sendProcessingRequestHeadersWithSourceIP(t, stream,
+			map[string]string{"User-Agent": "Mistake not...", "X-Forwarded-For": "18.18.18.18"},
+			"GET", "/", "111.222.111.222")
+
+		res, err := stream.Recv()
+		require.NoError(t, err)
+		require.IsType(t, &envoyextproc.ProcessingResponse_ImmediateResponse{}, res.GetResponse())
+		require.Equal(t, envoytypes.StatusCode(403), res.GetImmediateResponse().GetStatus().Code)
+
+		require.NoError(t, stream.CloseSend())
+		_, _ = stream.Recv() // to flush the spans
+
+		finished := mt.FinishedSpans()
+		require.Len(t, finished, 1)
+		span := finished[0]
+		require.Equal(t, "111.222.111.222", span.Tag("http.client_ip"))
+		require.Equal(t, "true", span.Tag("appsec.blocked"))
+	})
+
+	t.Run("source-ip-does-not-hide-headers-from-the-waf", func(t *testing.T) {
+		// Resolving identity from source.ip must not stop the WAF from
+		// inspecting request headers: an attack payload in a header still has to
+		// be detected while source.ip drives the client IP.
+		client, mt, cleanup := setup()
+		defer cleanup()
+
+		stream, err := client.Process(context.Background())
+		require.NoError(t, err)
+
+		sendProcessingRequestHeadersWithSourceIP(t, stream,
+			map[string]string{"User-Agent": "dd-test-scanner-log", "X-Forwarded-For": "9.9.9.9"},
+			"GET", "/", "18.18.18.18")
+
+		span := finishUnblockedStream(t, stream, mt)
+		checkForAppsecEvent(t, []*mocktracer.Span{span}, map[string]int{"ua0-600-55x": 1})
+		require.Equal(t, "18.18.18.18", span.Tag("http.client_ip"))
+	})
+
+	t.Run("source-ip-ignored-when-downgraded-to-envoy", func(t *testing.T) {
+		// A deployment that identifies itself as plain Envoy keeps the previous
+		// behaviour exactly, including its reliance on X-Forwarded-For.
+		client, mt, cleanup := setup()
+		defer cleanup()
+
+		ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(datadogEnvoyIntegrationHeader, "1"))
+		stream, err := client.Process(ctx)
+		require.NoError(t, err)
+
+		sendProcessingRequestHeadersWithSourceIP(t, stream,
+			map[string]string{"User-Agent": "Mistake not...", "X-Forwarded-For": "111.222.111.222"},
+			"GET", "/", "18.18.18.18")
+
+		res, err := stream.Recv()
+		require.NoError(t, err)
+		require.IsType(t, &envoyextproc.ProcessingResponse_ImmediateResponse{}, res.GetResponse(),
+			"the client-supplied X-Forwarded-For must still decide identity for the envoy integration")
+
+		require.NoError(t, stream.CloseSend())
+		_, _ = stream.Recv() // to flush the spans
+
+		finished := mt.FinishedSpans()
+		require.Len(t, finished, 1)
+		require.Equal(t, "111.222.111.222", finished[0].Tag("http.client_ip"))
 	})
 
 	t.Run("no-monitoring-event-on-request-body-parsing-disabled", func(t *testing.T) {
@@ -1311,6 +1434,50 @@ func sendProcessingRequestHeaders(t *testing.T, stream envoyextproc.ExternalProc
 		},
 	})
 	require.NoError(t, err)
+}
+
+// sendProcessingRequestHeadersWithSourceIP sends request headers together with
+// the ext_proc attributes through which a load balancer publishes the address of
+// the TCP peer it observed, as GCP does when configured with
+// forwardAttributes: [source.ip].
+func sendProcessingRequestHeadersWithSourceIP(t *testing.T, stream envoyextproc.ExternalProcessor_ProcessClient, headers map[string]string, method string, path string, sourceIP string) {
+	t.Helper()
+
+	err := stream.Send(&envoyextproc.ProcessingRequest{
+		Attributes: testSourceIPAttributes(structpb.NewStringValue(sourceIP)),
+		Request: &envoyextproc.ProcessingRequest_RequestHeaders{
+			RequestHeaders: &envoyextproc.HttpHeaders{
+				Headers:     makeRequestHeaders(t, headers, method, path),
+				EndOfStream: true,
+			},
+		},
+	})
+	require.NoError(t, err)
+}
+
+// finishUnblockedStream drives a request that was allowed through to completion
+// so that its span is flushed, and returns that span.
+func finishUnblockedStream(t *testing.T, stream envoyextproc.ExternalProcessor_ProcessClient, mt mocktracer.Tracer) *mocktracer.Span {
+	t.Helper()
+
+	res, err := stream.Recv()
+	require.NoError(t, err)
+	require.IsType(t, &envoyextproc.ProcessingResponse_RequestHeaders{}, res.GetResponse(),
+		"the request was blocked but this scenario expects it to be allowed through")
+
+	sendProcessingResponseHeaders(t, stream, nil, "200", false)
+	// Both directions signalled end of stream, so the server is free to close it
+	// here; either a response message or EOF is a correct outcome.
+	if _, err := stream.Recv(); err != nil {
+		require.ErrorIs(t, err, io.EOF)
+	}
+
+	require.NoError(t, stream.CloseSend())
+	_, _ = stream.Recv() // to flush the spans
+
+	finished := mt.FinishedSpans()
+	require.Len(t, finished, 1)
+	return finished[0]
 }
 
 // sendProcessingRequestBodyStreamed sends the request body in chunks to simulate streaming

--- a/contrib/envoyproxy/go-control-plane/envoy_test.go
+++ b/contrib/envoyproxy/go-control-plane/envoy_test.go
@@ -337,6 +337,31 @@ func TestAppSec(t *testing.T) {
 		require.Equal(t, "true", span.Tag("appsec.blocked"))
 	})
 
+	t.Run("source-ip-wins-inside-gclb-shaped-x-forwarded-for", func(t *testing.T) {
+		// The real Google Cloud header shape: a single X-Forwarded-For holding
+		// <client-supplied>,<client-ip>,<load-balancer-ip>. Here the
+		// client-supplied entry is a denylisted address, and it comes first, so
+		// without the trusted source.ip it is the one the denylist would be
+		// evaluated against.
+		// https://cloud.google.com/load-balancing/docs/https#x-forwarded-for_header
+		client, mt, cleanup := setup()
+		defer cleanup()
+
+		stream, err := client.Process(context.Background())
+		require.NoError(t, err)
+
+		sendProcessingRequestHeadersWithSourceIP(t, stream,
+			map[string]string{
+				"User-Agent":      "Mistake not...",
+				"X-Forwarded-For": "111.222.111.222, 18.18.18.18, 35.191.10.1",
+			},
+			"GET", "/", "18.18.18.18")
+
+		span := finishUnblockedStream(t, stream, mt)
+		require.Equal(t, "18.18.18.18", span.Tag("http.client_ip"))
+		require.Nil(t, span.Tag("appsec.blocked"))
+	})
+
 	t.Run("source-ip-does-not-hide-headers-from-the-waf", func(t *testing.T) {
 		// Resolving identity from source.ip must not stop the WAF from
 		// inspecting request headers: an attack payload in a header still has to

--- a/contrib/envoyproxy/go-control-plane/go.mod
+++ b/contrib/envoyproxy/go-control-plane/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.21.0
 	google.golang.org/grpc v1.82.0
+	google.golang.org/protobuf v1.36.12-0.20260116114154-8c4c4ae446ca
 )
 
 require (
@@ -83,7 +84,6 @@ require (
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260618152121-87f3d3e198d3 // indirect
-	google.golang.org/protobuf v1.36.12-0.20260116114154-8c4c4ae446ca // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 


### PR DESCRIPTION
### What does this PR do?

Makes the GCP Service Extension resolve the client IP from the ext_proc connection
attributes instead of trusting `X-Forwarded-For`.

When the effective component is the GCP Service Extension and the load balancer
published the peer it observed, that address is prepended to `X-Forwarded-For` and
used as `RemoteAddr`. Client IP resolution scans that header from the left and stops
at the first public address, so the trusted value now decides identity.

Two attribute names are read, `source.ip` first and `source.address` as a fallback,
for reasons covered below. Either a bare address or `host:port` is accepted.

Everything else is left alone: neither attribute present, a value that is not an
interpretable address, and any non-GCP effective component all fall through to the
existing header and connection-address behaviour.

Requires the extension to be configured with `forwardAttributes: [source.ip]` (or
`request_attributes: [source.address]` on a self-managed Envoy).

### Motivation

Reported through SCRS-2230. Addresses blocked in the Datadog UI kept receiving
HTTP 200 on a customer's GCP deployment.

A client connecting straight to a load balancer chooses what it sends in
`X-Forwarded-For`, and the load balancer appends the address it observed *after* that
value. I confirmed this against a stock Envoy: a request sent with
`X-Forwarded-For: 1.2.3.4` reached the callout as `1.2.3.4,172.17.0.1`. Google Cloud
[documents the same ordering](https://cloud.google.com/load-balancing/docs/https#x-forwarded-for_header)
and appends two entries, giving `<client-supplied>,<client-ip>,<load-balancer-ip>`.

Client IP resolution takes the first public entry in that list. The genuine address is
therefore already present, but the forged entry precedes it and wins, so AppSec
evaluates rules — including IP denylists — against an address the client picked. The
connection attributes are set by the infrastructure rather than the client, so they
cannot be manipulated this way.

### Why two attribute names

`source.ip` is a Google Cloud addition and is not part of stock Envoy's attribute
vocabulary. Running Envoy v1.31 with `request_attributes: [source.ip, source.port]`
against a probe that dumps the attributes map, `source.port` arrived and `source.ip`
never appeared at all. Envoy's name for the same peer is `source.address`, which does
arrive, as a string holding `host:port`.

Reading only `source.ip` therefore risked the worst kind of failure: compiling,
passing its own tests, and silently resolving nothing on any deployment that publishes
the Envoy name. Hence the fallback, and hence accepting both spellings.

### Why prepend rather than replace or strip

`X-Forwarded-For` also feeds the WAF's `server.request.headers.no_cookies` address.
Removing or overwriting it to win the resolution would stop an attack payload placed
in that header from ever being inspected, trading an IP-spoofing bug for a WAF bypass.
Prepending leaves every client-supplied value intact and visible to the WAF, which
`TestExtractRequestSourceIPDoesNotDropHeaders` and
`TestAppSec/source-ip-does-not-hide-headers-from-the-waf` both pin.

It also keeps the change confined to the ext_proc path. Resolution itself lives in
`extractRequestHeaders`, which every HTTP integration in the library runs through;
this PR does not touch it, and touches nothing under `internal/appsec/`.

### On the attributes map key

`envoy.filters.http.ext_proc` is the ext_proc filter's own registered name. Envoy keys
the attributes map by it, and the probe run above observed exactly that key on the
wire. For the reader's benefit:

- `source/extensions/filters/http/ext_proc/ext_proc.cc` — `(*req.mutable_attributes())[FilterName] = std::move(attributes);`
- `source/extensions/http/ext_proc/.../mapped_attribute_builder.cc` — `(*request.mutable_attributes())[HttpFilterNames::get().ExternalProcessing]`
- `envoyproxy/ai-gateway`, `internal/extproc/server.go` — `req.GetAttributes()["envoy.filters.http.ext_proc"]`

Worth stating explicitly because a wrong key would not fail loudly. The constant
carries a comment pointing at the Envoy line for the same reason.

### Known limitation

When the observed peer is private *and* the client forged a public `X-Forwarded-For`
entry, the forged entry still wins, because resolution prefers a public address over a
private one. This is unchanged from current behaviour rather than something this PR
introduces, and it mainly concerns internal load balancers. It is documented in the
Service Extension README and covered by
`TestExtractRequestSourceIP/private_source.ip_is_still_prepended`, which pins what this
layer does regardless of that downstream preference.

### Deliberately not included

`getRemoteAddr` returns the last `X-Forwarded-For` *header instance* rather than the
last address, so when a load balancer sends one header holding a list the value is
unparseable and `RemoteAddr` is silently discarded.

Fixing that by taking the rightmost address would be wrong: per Google's documentation
that address is the load balancer's own forwarding rule IP (`server_ip_address` is
"the same as the last IP address in the X-Forwarded-For header"), so `RemoteAddr` would
become a public address belonging to Google and could surface as the client IP where
today it is simply dropped. The correct GCLB value is the next-to-last entry, but
`getRemoteAddr` is shared with the plain Envoy and Istio paths, where only one address
is appended. It needs its own change and its own tests, and the connection attributes
supersede it for the GCP case.

### Relation to #5081

Replaces #5081, which reached the same outcome by threading a client-IP override
through `HandlerOperationArgs` into `internal/appsec/listener/httpsec/http.go`. That
approach changed the resolution path taken by every HTTP integration; this one stays
inside the ext_proc contrib.

### Testing

24 unit tests and 14 `TestAppSec` subtests over a live ext_proc gRPC stream, all green,
nothing skipped.

The unit table was written before the implementation. Every "changes nothing" case
passed against unmodified code, which is what makes them evidence that existing
behaviour is preserved rather than a restatement of the new feature. Only the
behavioural cases failed until the implementation landed.

| Subtest | What it pins |
|---|---|
| `blocking-client-ip-from-source-ip` | denylist reached through the attribute alone: 403, rule `blk-001-001` |
| `source-ip-wins-over-denylisted-x-forwarded-for` | a forged denylisted header no longer decides identity |
| `source-ip-blocks-despite-benign-x-forwarded-for` | the trusted value wins in the other direction too |
| `source-ip-wins-inside-gclb-shaped-x-forwarded-for` | the real `<forged>,<client-ip>,<lb-ip>` single-header shape |
| `source-ip-does-not-hide-headers-from-the-waf` | `ua0-600-55x` still fires while the attribute drives the client IP |
| `source-ip-ignored-when-downgraded-to-envoy` | deployments identifying as plain Envoy keep their previous behaviour |

### Not yet validated

Reviewers should know what this PR has *not* demonstrated:

- **No live Google Cloud run.** The attribute plumbing and the map key were verified
  against a stock Envoy, but `source.ip` itself only exists on GCP, so its presence and
  spelling there still rest on Google's documentation. This is the main reason the
  fallback exists. A `.docker-1` release for customer validation is the follow-up.
- **The system-tests envoy harness cannot cover the happy path.** It injects
  `x-datadog-envoy-integration: '1'` and sets no `request_attributes`
  (`utils/build/docker/envoy/envoy.yaml`), so it exercises the untouched no-op branch.
  A GCP-flavoured variant is needed for real-surface happy-path coverage.
- **SCRS-2230 may not be fully explained by this change.** The ticket also reports the
  ext_proc call returning gRPC `ABORTED` in about 1ms. A correct verdict against the
  wrong IP would not obviously produce that, so it may be a second, independent fault.
  Triage is in progress; this PR should not be presented as closing the ticket until
  that is settled.
