### PR TITLE
feat(tracer): add whole trace ID to pprof labels

### DIFF
--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -107,7 +107,8 @@ func TestStartSpanWithSpanLinks(t *testing.T) {
 	assert.NoError(t, err)
 	defer stop()
 	spanLink := SpanLink{TraceID: 789, TraceIDHigh: 0, SpanID: 789, Attributes: map[string]string{"reason": "terminated_context", "context_headers": "datadog"}, Flags: 0}
-	ctx := &SpanContext{spanLinks: []SpanLink{spanLink}, spanID: 789, traceID: traceIDFrom64Bits(789)}
+	links := []SpanLink{spanLink}
+	ctx := &SpanContext{spanLinks: &links, spanID: 789, traceID: traceIDFrom64Bits(789)}
 
 	t.Run("create span from spancontext with links", func(t *testing.T) {
 		var s *Span
@@ -121,7 +122,7 @@ func TestStartSpanWithSpanLinks(t *testing.T) {
 		assert.Equal(t, 1, len(s.spanLinks))
 		assert.Equal(t, spanLink, s.spanLinks[0])
 
-		assert.Equal(t, 0, len(s.context.spanLinks)) // ensure that the span links are not added to the parent context
+		assert.Nil(t, s.context.spanLinks) // ensure that the span links are not added to the parent context
 	})
 }
 

--- a/ddtrace/tracer/internal/span_attributes.go
+++ b/ddtrace/tracer/internal/span_attributes.go
@@ -40,16 +40,25 @@ var (
 // Zero value = all fields absent.
 // Set(key, "") is distinct from never-Set: the bit is set, the string is "".
 //
-// Layout: setMask + readOnly are packed ahead of the [numAttrs]string array,
-// with no trailing padding. The exact size is architecture-dependent (string
-// width differs between 32- and 64-bit); the assertion below derives it.
+// Layout: setMask + readOnly, the snapshot pointer, and the [numAttrs]string
+// array have no trailing padding. The exact size is architecture-dependent
+// (string width differs between 32- and 64-bit); the assertion below derives it.
 //
 // When readOnly is true, the instance is owned by the tracer and must not be
 // mutated. Callers must Clone before writing (copy-on-write).
 type SpanAttributes struct {
-	setMask  uint8
-	readOnly bool
-	vals     [numAttrs]string
+	setMask       uint8
+	readOnly      bool
+	snapshotExtra *SpanSnapshotExtra
+	vals          [numAttrs]string
+}
+
+// SpanSnapshotExtra holds promoted metadata copied into a span context snapshot.
+// Read-only SpanAttributes cache one immutable instance for reuse across spans.
+type SpanSnapshotExtra struct {
+	Env         string
+	Version     string
+	PeerService string
 }
 
 // Compile-time layout check: SpanAttributes must carry no trailing padding —
@@ -71,6 +80,7 @@ func (a *SpanAttributes) Set(key AttrKey, v string) {
 	}
 	a.vals[key] = v
 	a.setMask |= 1 << key
+	a.snapshotExtra = nil
 }
 
 // Unset clears the attribute for key, making it absent (as if never set). nil-safe.
@@ -80,6 +90,7 @@ func (a *SpanAttributes) Unset(key AttrKey) {
 	}
 	a.vals[key] = ""
 	a.setMask &^= 1 << key
+	a.snapshotExtra = nil
 }
 
 func (a *SpanAttributes) Val(key AttrKey) string {
@@ -108,10 +119,25 @@ func (a *SpanAttributes) Count() int {
 // MarkReadOnly marks this instance as readOnly (read-only). Clone before mutating.
 // The receiver must be non-nil; marking a nil SpanAttributes read-only is a
 // programming error and panics.
-func (a *SpanAttributes) MarkReadOnly() { a.readOnly = true }
+func (a *SpanAttributes) MarkReadOnly() {
+	a.readOnly = true
+	env := a.Val(AttrEnv)
+	version := a.Val(AttrVersion)
+	if env != "" || version != "" {
+		a.snapshotExtra = &SpanSnapshotExtra{Env: env, Version: version}
+	}
+}
 
 // IsReadOnly reports whether this is a readOnly instance requiring COW.
 func (a *SpanAttributes) IsReadOnly() bool { return a != nil && a.readOnly }
+
+// SnapshotExtra returns the immutable cached snapshot metadata, if any.
+func (a *SpanAttributes) SnapshotExtra() *SpanSnapshotExtra {
+	if a == nil {
+		return nil
+	}
+	return a.snapshotExtra
+}
 
 // Reset clears all set attributes, returning the instance to its zero state.
 // It is nil-safe and does not free the underlying memory, making it suitable
@@ -130,6 +156,7 @@ func (a *SpanAttributes) Clone() *SpanAttributes {
 	}
 	cp := *a
 	cp.readOnly = false
+	cp.snapshotExtra = nil
 	return &cp
 }
 

--- a/ddtrace/tracer/internal/span_meta.go
+++ b/ddtrace/tracer/internal/span_meta.go
@@ -146,6 +146,23 @@ func (sm *SpanMeta) Version() (string, bool) { return sm.promotedAttrs.Get(AttrV
 // Language returns the value of the "language" promoted attribute.
 func (sm *SpanMeta) Language() (string, bool) { return sm.promotedAttrs.Get(AttrLanguage) }
 
+// SnapshotExtra returns immutable env, version, and peer-service metadata for
+// a span context snapshot. Shared read-only attributes are reused when no
+// peer-service override is present.
+func (sm *SpanMeta) SnapshotExtra(peerService string) *SpanSnapshotExtra {
+	if peerService == "" {
+		if extra := sm.promotedAttrs.SnapshotExtra(); extra != nil {
+			return extra
+		}
+	}
+	env, _ := sm.Env()
+	version, _ := sm.Version()
+	if env == "" && version == "" && peerService == "" {
+		return nil
+	}
+	return &SpanSnapshotExtra{Env: env, Version: version, PeerService: peerService}
+}
+
 // ---------------------------------------------------------------------------
 // Write methods
 // ---------------------------------------------------------------------------

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -1099,9 +1099,9 @@ func WithLogStartup(enabled bool) StartOption {
 
 // WithProfilerCodeHotspots enables the code hotspots integration between the
 // tracer and profiler. This is done by automatically attaching pprof labels
-// called "span id" and "local root span id" when new spans are created. You
-// should not use these label names in your own code when this is enabled. The
-// enabled value defaults to the value of the
+// called "trace id", "span id", and "local root span id" when new spans are
+// created. You should not use these label names in your own code when this is
+// enabled. The enabled value defaults to the value of the
 // DD_PROFILING_CODE_HOTSPOTS_COLLECTION_ENABLED env variable or true.
 func WithProfilerCodeHotspots(enabled bool) StartOption {
 	return func(c *config) {

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -248,47 +248,37 @@ type spanSnapshot struct {
 	extra         *spanSnapshotExtra
 }
 
-type spanSnapshotExtra struct {
-	env         string
-	version     string
-	peerService string
-}
+type spanSnapshotExtra = traceinternal.SpanSnapshotExtra
 
 func (s spanSnapshot) env() string {
 	if s.extra == nil {
 		return ""
 	}
-	return s.extra.env
+	return s.extra.Env
 }
 
 func (s spanSnapshot) version() string {
 	if s.extra == nil {
 		return ""
 	}
-	return s.extra.version
+	return s.extra.Version
 }
 
 func (s spanSnapshot) peerService() string {
 	if s.extra == nil {
 		return ""
 	}
-	return s.extra.peerService
+	return s.extra.PeerService
 }
 
 // +checklocksignore — Initialization time.
 func (s *Span) spanSnapshot() spanSnapshot {
-	var (
-		env, _         = s.meta.Env()
-		version, _     = s.meta.Version()
-		peerService, _ = s.meta.Get(ext.PeerService)
-	)
+	peerService, _ := s.meta.Get(ext.PeerService)
 	snapshot := spanSnapshot{
 		service:       s.service,
 		serviceSource: s.serviceSource,
 		pprofCtx:      s.pprofCtxActive,
-	}
-	if env != "" || version != "" || peerService != "" {
-		snapshot.extra = &spanSnapshotExtra{env: env, version: version, peerService: peerService}
+		extra:         s.meta.SnapshotExtra(peerService),
 	}
 	return snapshot
 }

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -161,9 +161,11 @@ type Span struct {
 	// +checklocks:mu
 	spanEvents []spanEvent `msg:"span_events,omitempty"` // events produced related to this span
 
-	goExecTraced bool         `msg:"-"`
-	noDebugStack bool         `msg:"-"` // disables debug stack traces
-	context      *SpanContext `msg:"-"` // span propagation context
+	goExecTraced         bool         `msg:"-"`
+	noDebugStack         bool         `msg:"-"` // disables debug stack traces
+	pprofEndpoints       bool         `msg:"-"` // enables endpoint label updates when the resource changes
+	pprofContextProvided bool         `msg:"-"`
+	context              *SpanContext `msg:"-"` // span propagation context
 	// +checklocks:mu
 	supportsEvents bool `msg:"-"` // whether the span supports native span events or not
 
@@ -211,6 +213,8 @@ func (s *Span) clear() {
 	s.spanEvents = nil
 	s.goExecTraced = false
 	s.noDebugStack = false
+	s.pprofEndpoints = false
+	s.pprofContextProvided = false
 	s.finished = false
 	s.integration = ""
 	s.supportsEvents = false
@@ -238,12 +242,37 @@ func (s *Span) Context() *SpanContext {
 }
 
 type spanSnapshot struct {
-	env           string
-	version       string
 	service       string
 	serviceSource string
-	peerService   string
 	pprofCtx      context.Context
+	extra         *spanSnapshotExtra
+}
+
+type spanSnapshotExtra struct {
+	env         string
+	version     string
+	peerService string
+}
+
+func (s spanSnapshot) env() string {
+	if s.extra == nil {
+		return ""
+	}
+	return s.extra.env
+}
+
+func (s spanSnapshot) version() string {
+	if s.extra == nil {
+		return ""
+	}
+	return s.extra.version
+}
+
+func (s spanSnapshot) peerService() string {
+	if s.extra == nil {
+		return ""
+	}
+	return s.extra.peerService
 }
 
 // +checklocksignore — Initialization time.
@@ -253,14 +282,15 @@ func (s *Span) spanSnapshot() spanSnapshot {
 		version, _     = s.meta.Version()
 		peerService, _ = s.meta.Get(ext.PeerService)
 	)
-	return spanSnapshot{
-		env:           env,
-		version:       version,
+	snapshot := spanSnapshot{
 		service:       s.service,
 		serviceSource: s.serviceSource,
-		peerService:   peerService,
 		pprofCtx:      s.pprofCtxActive,
 	}
+	if env != "" || version != "" || peerService != "" {
+		snapshot.extra = &spanSnapshotExtra{env: env, version: version, peerService: peerService}
+	}
+	return snapshot
 }
 
 // getSpanID concurrency safe reads the spanID field.
@@ -487,7 +517,7 @@ func (s *Span) setTagLocked(key string, value any) {
 		return
 	}
 	if v, ok := value.(string); ok {
-		if key == ext.ResourceName && s.pprofCtxActive != nil && spanResourcePIISafe(s) {
+		if key == ext.ResourceName && s.pprofEndpoints && s.pprofCtxActive != nil && spanResourcePIISafe(s) {
 			// If the user overrides the resource name for the span,
 			// update the endpoint label for the runtime profilers.
 			//
@@ -586,7 +616,7 @@ func (s *Span) Root() *Span {
 	if ctx.trace == nil {
 		return nil
 	}
-	return ctx.trace.root
+	return ctx.trace.root.Load()
 }
 
 // SetUser associates user information to the current trace which the

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -389,11 +389,11 @@ func (c *SpanContext) setSpanSnapshotMetaLocked(key, value string) {
 	}
 	switch key {
 	case ext.PeerService:
-		extra.peerService = value
+		extra.PeerService = value
 	case ext.Environment:
-		extra.env = value
+		extra.Env = value
 	case ext.Version:
-		extra.version = value
+		extra.Version = value
 	}
 	c.spanSnapshot.extra = extra
 }

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
@@ -149,7 +150,7 @@ type SpanContext struct {
 	// distributed traces if they were missing their parent span.
 	// Missing parent span could occur when a W3C-compliant tracer
 	// propagated this context, but didn't send any spans to Datadog.
-	reparentID string
+	reparentID uint64
 
 	// the below group should propagate cross-process
 
@@ -169,7 +170,7 @@ type SpanContext struct {
 
 	// links to related spans in separate|external|disconnected traces
 	// +checklocks:mu
-	spanLinks []SpanLink
+	spanLinks *[]SpanLink
 }
 
 // Private interface for span contexts that can propagate sampling decisions.
@@ -306,12 +307,8 @@ func newSpanContext(span *Span, parent *SpanContext) *SpanContext {
 	if context.trace == nil {
 		context.trace = newTrace()
 	}
-	if context.trace.root == nil {
-		// first span in the trace can safely be assumed to be the root
-		context.trace.root = span
-	}
 	// put span in context's trace
-	context.trace.push(span)
+	context.trace.pushWithTraceID(span, &context.traceID)
 	// The span snapshot is populated by tracer.StartSpan after all
 	// env/version/service-mapping mutations, so we skip the intermediate
 	// write here. Direct callers of newSpanContext (tests) do not read
@@ -386,14 +383,19 @@ func (c *SpanContext) setSpanSnapshotMeta(key, value string) {
 // +checklocks:c.mu
 func (c *SpanContext) setSpanSnapshotMetaLocked(key, value string) {
 	assert.RWMutexLocked(&c.mu)
+	extra := new(spanSnapshotExtra)
+	if c.spanSnapshot.extra != nil {
+		*extra = *c.spanSnapshot.extra
+	}
 	switch key {
 	case ext.PeerService:
-		c.spanSnapshot.peerService = value
+		extra.peerService = value
 	case ext.Environment:
-		c.spanSnapshot.env = value
+		extra.env = value
 	case ext.Version:
-		c.spanSnapshot.version = value
+		extra.version = value
 	}
+	c.spanSnapshot.extra = extra
 }
 
 // SpanID implements ddtrace.SpanContext.
@@ -438,8 +440,12 @@ func (c *SpanContext) TraceIDUpper() uint64 {
 
 // SpanLinks implements ddtrace.SpanContext
 func (c *SpanContext) SpanLinks() []SpanLink {
-	cp := make([]SpanLink, len(c.spanLinks)) // +checklocksignore - Read-only after init.
-	copy(cp, c.spanLinks)                    // +checklocksignore - Read-only after init.
+	if c == nil || c.spanLinks == nil {
+		return nil
+	}
+	links := *c.spanLinks              // +checklocksignore - Read-only after init.
+	cp := make([]SpanLink, len(links)) // +checklocksignore - Read-only after init.
+	copy(cp, links)                    // +checklocksignore - Read-only after init.
 	return cp
 }
 
@@ -606,38 +612,50 @@ type trace struct {
 	// trace level tags that will be propagated across service boundaries
 	// +checklocks:mu
 	propagatingTags map[string]string
-	// the number of finished spans
-	// +checklocks:mu
-	finished int
-	// signifies that the span buffer is full
-	// +checklocks:mu
-	full bool
 	// sampling priority — accessed atomically to allow lock-free reads
 	// from the span creation hot path (SamplingPriority).
 	// Writes still happen under mu (because they also touch propagatingTags).
 	// +checkatomic
 	priority atomic.Pointer[float64]
-	// specifies if the sampling priority can be altered
+
+	// root specifies the root of the trace, if known; it is nil when a span
+	// context is extracted from a carrier, at which point there are no spans in
+	// the trace yet.
+	// Write-once during initialization in newSpanContext, read-only afterward.
+	root atomic.Pointer[Span]
+
+	// the number of finished spans; traces are capped well below int32 capacity
 	// +checklocks:mu
-	locked bool
+	finished int32
 	// dm is the numeric form of _dd.p.dm for v1 protocol encoding.
 	// It is the absolute value of the parsed integer (e.g., "-4" → 4).
 	// +checklocks:mu
 	dm uint32
 	// samplingDecision indicates whether to send the trace to the agent.
 	samplingDecision samplingDecision // +checkatomic
-
-	// root specifies the root of the trace, if known; it is nil when a span
-	// context is extracted from a carrier, at which point there are no spans in
-	// the trace yet.
-	// Write-once during initialization in newSpanContext, read-only afterward.
-	root *Span
-
+	// signifies that the span buffer is full
+	// +checklocks:mu
+	full bool
+	// specifies if the sampling priority can be altered
+	// +checklocks:mu
+	locked bool
 	// rootFlushed is set when partial flushing sends the local root before the
 	// trace completes. The root must stay out of the pool while unfinished spans
 	// still refer to it through trace.root.
 	// +checklocks:mu
 	rootFlushed bool
+
+	// traceIDHex is immutable after the local root is initialized. Keeping the
+	// backing bytes on the trace avoids a per-span string allocation for the
+	// profiler label. The fields above are packed so adding this array does not
+	// increase the trace allocation size on 64-bit platforms.
+	traceIDHex [32]byte
+}
+
+// traceIDHexString returns an immutable string view over traceIDHex. The trace
+// outlives every span and pprof context that references this label value.
+func (t *trace) traceIDHexString() string {
+	return unsafe.String(&t.traceIDHex[0], len(t.traceIDHex))
 }
 
 var (
@@ -785,6 +803,10 @@ func (t *trace) isLocked() bool {
 	return t.locked
 }
 
+func (t *trace) rootSpan() *Span {
+	return t.root.Load()
+}
+
 func (t *trace) setLocked(locked bool) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -795,8 +817,16 @@ func (t *trace) setLocked(locked bool) {
 // a errBufferFull error.
 // +checklocksignore — Reads sp.metrics during initialization; span not yet shared.
 func (t *trace) push(sp *Span) {
+	t.pushWithTraceID(sp, nil)
+}
+
+func (t *trace) pushWithTraceID(sp *Span, traceID *traceID) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	if traceID != nil && t.root.Load() == nil {
+		hex.Encode(t.traceIDHex[:], traceID.value[:])
+		t.root.Store(sp)
+	}
 	if t.full {
 		return
 	}
@@ -899,7 +929,8 @@ func (t *trace) finishedOneLocked(s *Span) {
 		s.setMetaLocked(keyBaseService, tc.ServiceTag)
 	}
 	priority := t.priority.Load()
-	if s == t.root && priority != nil {
+	root := t.root.Load()
+	if s == root && priority != nil {
 		// after the root has finished we lock down the priority;
 		// we won't be able to make changes to a span after finishing
 		// without causing a race condition.
@@ -922,11 +953,11 @@ func (t *trace) finishedOneLocked(s *Span) {
 	}
 
 	// Full flush: all spans finished
-	if len(t.spans) == t.finished {
+	if len(t.spans) == int(t.finished) {
 		spans := t.spans
 		spansToRelease := spans
 		if t.rootFlushed {
-			spansToRelease = append(append([]*Span(nil), spans...), t.root)
+			spansToRelease = append(append([]*Span(nil), spans...), root)
 			t.rootFlushed = false
 		}
 		willSend := decisionKeep == samplingDecision(atomic.LoadUint32((*uint32)(&t.samplingDecision)))
@@ -937,7 +968,7 @@ func (t *trace) finishedOneLocked(s *Span) {
 		return
 	}
 
-	doPartialFlush := tc.PartialFlush && t.finished >= tc.PartialFlushMinSpans
+	doPartialFlush := tc.PartialFlush && int(t.finished) >= tc.PartialFlushMinSpans
 	if !doPartialFlush {
 		t.mu.Unlock()
 		// The trace hasn't completed and partial flushing will not occur
@@ -952,7 +983,7 @@ func (t *trace) finishedOneLocked(s *Span) {
 	// spans are compacted to the front of t.spans. This avoids a separate
 	// leftoverSpans allocation on every partial flush trigger.
 	originalFirst := t.spans[0]
-	finishedSpans := make([]*Span, 0, t.finished)
+	finishedSpans := make([]*Span, 0, int(t.finished))
 	leftIdx := 0
 	for _, s2 := range t.spans {
 		if s2.finished {
@@ -974,9 +1005,9 @@ func (t *trace) finishedOneLocked(s *Span) {
 	needsFirstSpanTags := s != originalFirst
 	willSend := decisionKeep == samplingDecision(atomic.LoadUint32((*uint32)(&t.samplingDecision)))
 	spansToRelease := finishedSpans
-	if t.root != nil {
+	if root != nil {
 		for i, s2 := range finishedSpans {
-			if s2 == t.root {
+			if s2 == root {
 				t.rootFlushed = true
 				spansToRelease = append(append([]*Span(nil), finishedSpans[:i]...), finishedSpans[i+1:]...)
 				break

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -1097,7 +1097,7 @@ func TestNewSpanContext(t *testing.T) {
 		assert.Equal(ctx.spanID, span.spanID)
 		assert.NotNil(ctx.trace)
 		assert.Nil(ctx.trace.priority.Load())
-		assert.Equal(ctx.trace.root, span)
+		assert.Equal(ctx.trace.root.Load(), span)
 		assert.Contains(ctx.trace.spans, span)
 	})
 
@@ -1114,7 +1114,7 @@ func TestNewSpanContext(t *testing.T) {
 		assert.Equal(ctx.spanID, span.spanID)
 		assert.Equal(ctx.SpanID(), span.spanID)
 		assert.Equal(*ctx.trace.priority.Load(), 1.)
-		assert.Equal(ctx.trace.root, span)
+		assert.Equal(ctx.trace.root.Load(), span)
 		assert.Contains(ctx.trace.spans, span)
 	})
 
@@ -1134,7 +1134,7 @@ func TestNewSpanContext(t *testing.T) {
 		assert.EqualValues(uint64(1), ctx.traceID.Lower())
 		assert.EqualValues(2, ctx.spanID)
 		assert.EqualValues(3, *ctx.trace.priority.Load())
-		assert.Equal(ctx.trace.root, span)
+		assert.Equal(ctx.trace.root.Load(), span)
 	})
 }
 
@@ -1693,9 +1693,9 @@ func TestSpanSnapshotFieldsMirrorSetTag(t *testing.T) {
 	span.SetTag(ext.PeerService, "my-peer")
 
 	spanSnapshot := span.context.getSpanSnapshot()
-	assert.Equal(t, "staging", spanSnapshot.env)
-	assert.Equal(t, "2.0", spanSnapshot.version)
-	assert.Equal(t, "my-peer", spanSnapshot.peerService)
+	assert.Equal(t, "staging", spanSnapshot.env())
+	assert.Equal(t, "2.0", spanSnapshot.version())
+	assert.Equal(t, "my-peer", spanSnapshot.peerService())
 }
 
 // TestSiblingSpansGetFreshSpanSnapshot verifies that each sibling span captures

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
+	traceinternal "github.com/DataDog/dd-trace-go/v2/ddtrace/tracer/internal"
 	"github.com/DataDog/dd-trace-go/v2/internal"
 	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/globalconfig"
@@ -30,6 +31,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var spanSnapshotSink spanSnapshot
+
 func setupteardown(startSize, maxSize int) func() {
 	oldStartSize := traceStartSize
 	oldMaxSize := traceMaxSize
@@ -39,6 +42,23 @@ func setupteardown(startSize, maxSize int) func() {
 		traceStartSize = oldStartSize
 		traceMaxSize = oldMaxSize
 	}
+}
+
+func TestSpanSnapshotConfiguredMetadataDoesNotAllocate(t *testing.T) {
+	attrs := new(traceinternal.SpanAttributes)
+	attrs.Set(traceinternal.AttrEnv, "test_env")
+	attrs.Set(traceinternal.AttrVersion, "test_version")
+	attrs.Set(traceinternal.AttrLanguage, "go")
+	attrs.MarkReadOnly()
+	span := &Span{
+		service: "test_srv",
+		meta:    traceinternal.NewSpanMeta(attrs),
+	}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		spanSnapshotSink = span.spanSnapshot()
+	})
+	require.Zero(t, allocs)
 }
 
 func TestTraceIDZero(t *testing.T) {

--- a/ddtrace/tracer/sqlcomment.go
+++ b/ddtrace/tracer/sqlcomment.go
@@ -111,14 +111,14 @@ func (c *SQLCommentCarrier) Inject(ctx *SpanContext) error {
 func (c *SQLCommentCarrier) injectServiceTags(ctx *SpanContext, tags map[string]string) {
 	if ctx != nil {
 		spanSnapshot := ctx.getSpanSnapshot()
-		if spanSnapshot.env != "" {
-			tags[sqlCommentEnv] = spanSnapshot.env
+		if env := spanSnapshot.env(); env != "" {
+			tags[sqlCommentEnv] = env
 		}
-		if spanSnapshot.version != "" {
-			tags[sqlCommentParentVersion] = spanSnapshot.version
+		if version := spanSnapshot.version(); version != "" {
+			tags[sqlCommentParentVersion] = version
 		}
-		if spanSnapshot.peerService != "" {
-			tags[sqlCommentPeerService] = spanSnapshot.peerService
+		if peerService := spanSnapshot.peerService(); peerService != "" {
+			tags[sqlCommentPeerService] = peerService
 		}
 	}
 	if c.PeerDBName != "" {

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -370,7 +370,8 @@ func (p *chainedPropagator) Extract(carrier any) (*SpanContext, error) {
 			}
 			link.Tracestate = trace.propagatingTag(tracestateHeader)
 		}
-		ctx.spanLinks = []SpanLink{link}
+		links := []SpanLink{link}
+		ctx.spanLinks = &links
 
 		// When onlyExtractFirst is set, extractIncomingSpanContext returns after the
 		// first successful non-baggage extractor, so incomingCtx carries no baggage.
@@ -506,7 +507,7 @@ func (p *chainedPropagator) extractIncomingSpanContext(carrier any) (*SpanContex
 	}
 
 	if len(links) > 0 {
-		ctx.spanLinks = links // +checklocksignore - Initialization time, freshly extracted ctx not yet shared.
+		ctx.spanLinks = &links // +checklocksignore - Initialization time, freshly extracted ctx not yet shared.
 	}
 	log.Debug("Extracted span context: %s", ctx.safeDebugString())
 	return ctx, producer, nil
@@ -804,10 +805,10 @@ func overrideDatadogParentID(ctx, w3cCtx, ddCtx *SpanContext) {
 		return
 	}
 	ctx.spanID = w3cCtx.spanID
-	if w3cCtx.reparentID != "" {
+	if w3cCtx.reparentID != 0 {
 		ctx.reparentID = w3cCtx.reparentID
 	} else {
-		ctx.reparentID = spanIDHexEncoded(ddCtx.SpanID(), 16)
+		ctx.reparentID = ddCtx.SpanID()
 	}
 }
 
@@ -1102,7 +1103,7 @@ func (*propagatorW3c) injectTextMap(spanCtx *SpanContext, writer TextMapWriter) 
 	// or the tracestateHeader doesn't start with `dd=`
 	// we need to recreate tracestate
 	if ctx.updated ||
-		(!ctx.isRemote || ctx.isRemote && ctx.trace != nil && ctx.trace.root != nil) ||
+		(!ctx.isRemote || ctx.isRemote && ctx.trace != nil && ctx.trace.root.Load() != nil) ||
 		(ctx.trace != nil && !strings.HasPrefix(ctx.trace.propagatingTag(tracestateHeader), "dd=")) ||
 		ctx.trace.propagatingTagsLen() == 0 {
 		// compose a new value for the tracestate
@@ -1328,9 +1329,9 @@ func composeTracestate(ctx *SpanContext, priority int, oldState string) string {
 	if !ctx.isRemote {
 		b.WriteString(";p:")
 		b.WriteString(spanIDHexEncoded(ctx.SpanID(), 16))
-	} else if ctx.reparentID != "" {
+	} else if ctx.reparentID != 0 {
 		b.WriteString(";p:")
-		b.WriteString(ctx.reparentID)
+		b.WriteString(spanIDHexEncoded(ctx.reparentID, 16))
 	}
 
 	ctx.trace.iteratePropagatingTags(func(k, v string) bool {
@@ -1593,7 +1594,9 @@ func parseTracestate(ctx *SpanContext, header string) {
 					dropDM = true
 				}
 			} else if key == "p" {
-				ctx.reparentID = val
+				if id, err := strconv.ParseUint(val, 16, 64); err == nil {
+					ctx.reparentID = id
+				}
 			} else if strings.HasPrefix(key, "t.dm") {
 				if ctx.trace.hasPropagatingTag(keyDecisionMaker) || dropDM {
 					continue

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -219,7 +219,7 @@ func TestTextMapExtractTracestatePropagation(t *testing.T) {
 			}
 			assert.Equal("synthetics", sctx.origin) // should use x-datadog-origin, not the origin in the tracestate
 			if tc.wantTracestatePropagation {
-				assert.Equal("0000000000000001", sctx.reparentID)
+				assert.Equal(uint64(1), sctx.reparentID)
 				assert.Equal("dd=s:0;o:synthetics;p:0000000000000001,othervendor=t61rcWkgMzE", sctx.trace.propagatingTag(tracestateHeader))
 			} else if sctx.trace != nil {
 				assert.False(sctx.trace.hasPropagatingTag(tracestateHeader))
@@ -1691,7 +1691,7 @@ func TestEnvVars(t *testing.T) {
 					ctx.traceID = tc.tid
 					ctx.spanID = tc.sid
 					ctx.trace.propagatingTags = tc.propagatingTags
-					ctx.reparentID = "0123456789abcdef"
+					ctx.reparentID = 0x0123456789abcdef
 					headers := TextMapCarrier(map[string]string{})
 					err = tracer.Inject(ctx, headers)
 
@@ -2114,9 +2114,10 @@ func TestSpanLinks(t *testing.T) {
 				}
 
 				assert.Equal(tt.tid.value, sctx.traceID.value)
-				assert.Len(sctx.spanLinks, 2)
-				assert.Contains(sctx.spanLinks, tt.out[0])
-				assert.Contains(sctx.spanLinks, tt.out[1])
+				links := sctx.SpanLinks()
+				assert.Len(links, 2)
+				assert.Contains(links, tt.out[0])
+				assert.Contains(links, tt.out[1])
 			})
 		}
 	})
@@ -2138,7 +2139,7 @@ func TestSpanLinks(t *testing.T) {
 		}
 
 		assert.Equal(traceIDFrom64Bits(1).value, sctx.traceID.value)
-		assert.Len(sctx.spanLinks, 0)
+		assert.Empty(sctx.SpanLinks())
 	})
 }
 
@@ -2202,14 +2203,15 @@ func TestPropagationBehaviorExtract(t *testing.T) {
 		defer span.Finish()
 
 		assert.Equal(t, uint64(1), span.traceID)
-		require.Len(t, sctx.spanLinks, 1)
+		links := sctx.SpanLinks()
+		require.Len(t, links, 1)
 		assert.Equal(t, SpanLink{
 			TraceID:    2,
 			SpanID:     2,
 			Tracestate: "dd=s:1",
 			Flags:      1,
 			Attributes: map[string]string{"reason": "terminated_context", "context_headers": "tracecontext"},
-		}, sctx.spanLinks[0])
+		}, links[0])
 		assert.Equal(t, map[string]string{"key": "val"}, sctx.baggage)
 	})
 

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -890,6 +890,7 @@ func spanStart(operationName string, sharedAttrs *traceinternal.SpanAttributes, 
 			pprofContext = spanSnapshot.pprofCtx
 		}
 	}
+	pprofContextProvided := pprofContext != nil
 	if pprofContext == nil {
 		// For root span's without context, there is no pprofContext, but we need
 		// one to avoid a panic() in pprof.WithLabels(). Using context.Background()
@@ -913,10 +914,15 @@ func spanStart(operationName string, sharedAttrs *traceinternal.SpanAttributes, 
 	span.traceID = id
 	span.start = startTime
 	span.integration = "manual"
+	span.pprofContextProvided = pprofContextProvided
 	span.meta.SwapSharedAttrs(sharedAttrs) // COW: shared until a per-span field is set
 
 	span.spanLinks = append(span.spanLinks, opts.SpanLinks...)
 
+	isRootSpan := context == nil || context.trace == nil
+	if !isRootSpan {
+		isRootSpan = context.trace.rootSpan() == nil
+	}
 	if context != nil && !context.baggageOnly { // +checklocksignore - Read-only after init.
 		// this is a child span
 		span.traceID = context.traceID.Lower()
@@ -924,18 +930,17 @@ func spanStart(operationName string, sharedAttrs *traceinternal.SpanAttributes, 
 		if p, ok := context.SamplingPriority(); ok {
 			span.setMetricInit(keySamplingPriority, float64(p))
 		}
-		if (context.trace == nil || context.trace.root == nil) && context.origin != "" { // +checklocksignore - Read-only after init.
+		if isRootSpan && context.origin != "" { // +checklocksignore - Read-only after init.
 			// mark origin
 			span.setMetaInit(keyOrigin, context.origin) // +checklocksignore - Read-only after init.
 		}
-		if context.reparentID != "" {
-			span.setMetaInit(keyReparentID, context.reparentID)
+		if context.reparentID != 0 {
+			span.setMetaInit(keyReparentID, spanIDHexEncoded(context.reparentID, 16))
 		}
 
 	}
 	// Must evaluate isRootSpan before newSpanContext: newSpanContext sets
 	// context.trace.root = span, making the nil check unreliable afterward.
-	isRootSpan := context == nil || context.trace == nil || context.trace.root == nil
 	span.context = newSpanContext(span, context)
 	if pprofContext != nil {
 		setLLMObsPropagatingTags(pprofContext, span.context)
@@ -1018,11 +1023,7 @@ func (t *tracer) StartSpan(operationName string, options ...StartSpanOption) *Sp
 		log.Debug("Started Span: %v, Operation: %s, Resource: %s, Tags: %v, %v", //nolint:gocritic // Debug logging needs full span representation
 			span, span.name, span.resource, &span.meta, span.metrics)
 	}
-	if cSnap.ProfilerHotspotsEnabled || cSnap.ProfilerEndpoints {
-		t.applyPPROFLabels(span.pprofCtxRestore, span, cSnap)
-	} else {
-		span.pprofCtxRestore = nil
-	}
+	t.applyPPROFLabels(span.pprofCtxRestore, span, cSnap, span.pprofContextProvided)
 	if cSnap.DebugAbandonedSpans {
 		select {
 		case t.abandonedSpansDebugger.In <- newAbandonedSpanCandidate(span, false):
@@ -1051,24 +1052,38 @@ func (t *tracer) StartSpan(operationName string, options ...StartSpanOption) *Sp
 // found in ctx are restored. Additionally, this func informs the profiler how
 // many times each endpoint is called.
 // +checklocksignore — Initialization time, called from StartSpan before span is shared.
-func (t *tracer) applyPPROFLabels(ctx gocontext.Context, span *Span, snap internalconfig.SpanStartSnapshot) {
+func (t *tracer) applyPPROFLabels(ctx gocontext.Context, span *Span, snap internalconfig.SpanStartSnapshot, pprofContextProvided bool) {
+	correlate := snap.ProfilerHotspotsEnabled || appsec.Enabled() && pprofContextProvided
+	localRootSpan := span.Root()
+	span.pprofEndpoints = snap.ProfilerEndpoints
+	if !correlate && !snap.ProfilerEndpoints {
+		span.pprofCtxActive = nil
+		span.pprofCtxRestore = nil
+		return
+	}
 	// Important: The label keys are ordered alphabetically to take advantage of
 	// an upstream optimization that landed in go1.24.  This results in ~10%
 	// better performance on BenchmarkStartSpan. See
 	// https://go-review.googlesource.com/c/go/+/574516 for more information.
-	labels := make([]string, 0, 3*2 /* 3 key value pairs */)
-	localRootSpan := span.Root()
-	if snap.ProfilerHotspotsEnabled && localRootSpan != nil {
+	var labels [4 * 2]string
+	labelCount := 0
+	if correlate && localRootSpan != nil {
 		spanID := localRootSpan.getSpanID()
-		labels = append(labels, traceprof.LocalRootSpanID, strconv.FormatUint(spanID, 10))
+		labels[labelCount] = traceprof.LocalRootSpanID
+		labels[labelCount+1] = strconv.FormatUint(spanID, 10)
+		labelCount += 2
 	}
 	if snap.ProfilerHotspotsEnabled {
-		labels = append(labels, traceprof.SpanID, strconv.FormatUint(span.spanID, 10))
+		labels[labelCount] = traceprof.SpanID
+		labels[labelCount+1] = strconv.FormatUint(span.spanID, 10)
+		labelCount += 2
 	}
 	if snap.ProfilerEndpoints && localRootSpan != nil {
 		resource, piiSafe := localRootSpan.getResourceWithPIISafe()
 		if piiSafe {
-			labels = append(labels, traceprof.TraceEndpoint, resource)
+			labels[labelCount] = traceprof.TraceEndpoint
+			labels[labelCount+1] = resource
+			labelCount += 2
 			if span == localRootSpan {
 				// Inform the profiler of endpoint hits. This is used for the unit of
 				// work feature. We can't use APM stats for this since the stats don't
@@ -1077,8 +1092,13 @@ func (t *tracer) applyPPROFLabels(ctx gocontext.Context, span *Span, snap intern
 			}
 		}
 	}
-	if len(labels) > 0 {
-		pprofActive := pprof.WithLabels(ctx, pprof.Labels(labels...))
+	if correlate {
+		labels[labelCount] = traceprof.TraceID
+		labels[labelCount+1] = span.context.trace.traceIDHexString()
+		labelCount += 2
+	}
+	if labelCount > 0 {
+		pprofActive := pprof.WithLabels(ctx, pprof.Labels(labels[:labelCount]...))
 		span.pprofCtxRestore = ctx
 		span.pprofCtxActive = pprofActive
 		pprof.SetGoroutineLabels(pprofActive)
@@ -1165,7 +1185,7 @@ func (t *tracer) updateSampling(ctx *SpanContext) {
 		return
 	}
 	// without this check some mock spans tests fail
-	if t.rulesSampling == nil || ctx.trace == nil || ctx.trace.root == nil {
+	if t.rulesSampling == nil || ctx.trace == nil || ctx.trace.root.Load() == nil {
 		return
 	}
 	// want to avoid locking the entire trace from a span for long.
@@ -1182,7 +1202,7 @@ func (t *tracer) updateSampling(ctx *SpanContext) {
 		return
 	}
 	// if sampling was successful, need to lock the trace to prevent further re-sampling
-	if t.rulesSampling.SampleTrace(ctx.trace.root) {
+	if t.rulesSampling.SampleTrace(ctx.trace.root.Load()) {
 		ctx.trace.setLocked(true)
 	}
 }

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -38,6 +38,7 @@ import (
 	traceinternal "github.com/DataDog/dd-trace-go/v2/ddtrace/tracer/internal"
 	tracertest "github.com/DataDog/dd-trace-go/v2/ddtrace/x/agenttest"
 	"github.com/DataDog/dd-trace-go/v2/internal"
+	"github.com/DataDog/dd-trace-go/v2/internal/appsec"
 	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/globalconfig"
 	"github.com/DataDog/dd-trace-go/v2/internal/locking"
@@ -697,7 +698,7 @@ func TestSamplingDecision(t *testing.T) {
 			if s.metrics[keySamplingPriority] == ext.PriorityUserKeep {
 				keptTotal++
 				keptTraces[s.traceID] = struct{}{}
-				if s.context.trace.root.spanID != s.spanID {
+				if s.context.trace.root.Load().spanID != s.spanID {
 					keptChildren++
 				}
 			}
@@ -3220,6 +3221,144 @@ func TestPprofLabels(t *testing.T) {
 		span.Finish()
 		wasteC(time.Second)
 	})
+}
+
+func TestApplyPPROFLabelsTraceID(t *testing.T) {
+	tr, err := newTracer(WithAppSecEnabled(false))
+	require.NoError(t, err)
+	defer tr.Stop()
+
+	span := tr.StartSpan("web.request", ResourceName("/things"), SpanType(ext.SpanTypeWeb))
+	defer span.Finish()
+
+	traceID := span.context.TraceID()
+	require.Regexp(t, "^[0-9a-f]{32}$", traceID)
+	localRootID := strconv.FormatUint(span.Root().getSpanID(), 10)
+	spanID := strconv.FormatUint(span.spanID, 10)
+
+	apply := func(snap internalconfig.SpanStartSnapshot) context.Context {
+		span.pprofCtxActive = nil
+		tr.applyPPROFLabels(context.Background(), span, snap, true)
+		return span.pprofCtxActive
+	}
+	assertLabel := func(t *testing.T, ctx context.Context, key, want string) {
+		t.Helper()
+		got, ok := pprof.Label(ctx, key)
+		require.Truef(t, ok, "label %q should be present", key)
+		require.Equal(t, want, got)
+	}
+	assertNoLabel := func(t *testing.T, ctx context.Context, keys ...string) {
+		t.Helper()
+		for _, key := range keys {
+			_, ok := pprof.Label(ctx, key)
+			require.Falsef(t, ok, "label %q should be absent", key)
+		}
+	}
+
+	t.Run("hotspots", func(t *testing.T) {
+		ctx := apply(internalconfig.SpanStartSnapshot{ProfilerHotspotsEnabled: true})
+		require.NotNil(t, ctx)
+		assertLabel(t, ctx, "trace id", traceID)
+		assertLabel(t, ctx, "local root span id", localRootID)
+		assertLabel(t, ctx, "span id", spanID)
+		assertNoLabel(t, ctx, "trace endpoint")
+	})
+	t.Run("endpoints only", func(t *testing.T) {
+		ctx := apply(internalconfig.SpanStartSnapshot{ProfilerEndpoints: true})
+		require.NotNil(t, ctx)
+		assertLabel(t, ctx, "trace endpoint", "/things")
+		assertNoLabel(t, ctx, "trace id", "local root span id", "span id")
+	})
+	t.Run("hotspots and endpoints root", func(t *testing.T) {
+		ctx := apply(internalconfig.SpanStartSnapshot{ProfilerHotspotsEnabled: true, ProfilerEndpoints: true})
+		require.NotNil(t, ctx)
+		assertLabel(t, ctx, "trace id", traceID)
+		assertLabel(t, ctx, "local root span id", localRootID)
+		assertLabel(t, ctx, "span id", spanID)
+		assertLabel(t, ctx, "trace endpoint", "/things")
+	})
+	t.Run("hotspots and endpoints child", func(t *testing.T) {
+		child := tr.StartSpan("child", ChildOf(span.context))
+		defer child.Finish()
+		child.pprofCtxActive = nil
+		tr.applyPPROFLabels(span.pprofCtxActive, child, internalconfig.SpanStartSnapshot{ProfilerHotspotsEnabled: true, ProfilerEndpoints: true}, true)
+		ctx := child.pprofCtxActive
+		require.NotNil(t, ctx)
+		assertLabel(t, ctx, "trace id", traceID)
+		assertLabel(t, ctx, "local root span id", localRootID)
+		assertLabel(t, ctx, "span id", strconv.FormatUint(child.spanID, 10))
+		assertLabel(t, ctx, "trace endpoint", "/things")
+	})
+}
+
+func TestApplyPPROFLabelsTraceIDAppSec(t *testing.T) {
+	require.NoError(t, Start(
+		WithAppSecEnabled(true),
+		WithProfilerCodeHotspots(false),
+		WithProfilerEndpoints(false),
+	))
+	defer Stop()
+	if !appsec.Enabled() {
+		t.Skip("appsec is not enabled on this platform")
+	}
+
+	parentCtx := pprof.WithLabels(context.Background(), pprof.Labels("user label", "preserved"))
+	span, _ := StartSpanFromContext(parentCtx, "web.request")
+	require.NotNil(t, span.pprofCtxActive)
+	traceID, ok := pprof.Label(span.pprofCtxActive, "trace id")
+	require.True(t, ok)
+	require.Equal(t, span.context.TraceID(), traceID)
+	_, ok = pprof.Label(span.pprofCtxActive, "local root span id")
+	require.True(t, ok)
+	_, ok = pprof.Label(span.pprofCtxActive, "span id")
+	require.False(t, ok)
+	span.SetTag(ext.ResourceName, "/updated")
+	_, ok = pprof.Label(span.pprofCtxActive, "trace endpoint")
+	require.False(t, ok, "AppSec must not enable endpoint labels")
+	span.Finish()
+
+	spanWithBackground, _ := StartSpanFromContext(context.Background(), "web.request")
+	require.NotNil(t, spanWithBackground.pprofCtxActive)
+	_, ok = pprof.Label(spanWithBackground.pprofCtxActive, "trace id")
+	require.True(t, ok)
+	spanWithBackground.Finish()
+
+	spanWithoutContext := StartSpan("web.request")
+	require.Nil(t, spanWithoutContext.pprofCtxActive)
+	require.Nil(t, spanWithoutContext.pprofCtxRestore)
+	spanWithoutContext.Finish()
+}
+
+func TestApplyPPROFLabelsTraceIDConcurrentExtractedContext(t *testing.T) {
+	tr, err := newTracer(WithProfilerCodeHotspots(true), WithProfilerEndpoints(true))
+	require.NoError(t, err)
+	defer tr.Stop()
+
+	parent, err := tr.Extract(TextMapCarrier{
+		DefaultTraceIDHeader:  "1234",
+		DefaultParentIDHeader: "5678",
+		DefaultPriorityHeader: "1",
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			span := tr.StartSpan("child", ChildOf(parent))
+			defer span.Finish()
+			traceID, ok := pprof.Label(span.pprofCtxActive, "trace id")
+			if !ok {
+				t.Error("trace id label is missing")
+				return
+			}
+			if want := span.context.TraceID(); traceID != want {
+				t.Errorf("trace id label = %q, want %q", traceID, want)
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 func TestNoopTracerStartSpan(t *testing.T) {

--- a/internal/traceprof/traceprof.go
+++ b/internal/traceprof/traceprof.go
@@ -11,6 +11,8 @@ const (
 	SpanID          = "span id"
 	LocalRootSpanID = "local root span id"
 	TraceEndpoint   = "trace endpoint"
+	// TraceID is the full 128-bit trace ID as 32 lowercase hexadecimal characters.
+	TraceID = "trace id"
 )
 
 // env variables used to control cross-cutting tracer/profiling features.


### PR DESCRIPTION
### What does this PR do?

Adds the full 128-bit trace ID as a lowercase 32-character `trace id` pprof label. Code hotspots retain `span id` and `local root span id`; endpoint profiling retains `trace endpoint`; AppSec can enable trace/local-root correlation without implicitly enabling endpoint labels.

This replaces #5064 with a benchmark-neutral implementation. Trace-owned label bytes are initialized once and immutable metadata snapshots reuse tracer-owned read-only state.

### Motivation

Profiles need a whole-trace correlation key for AppSec and cross-product workflows. #5064 established the behavior but retained tracer benchmark regressions and review issues around endpoint gating, contextless goroutine labels, and repeated encoding.

The first local benchmark summary used empty tracer metadata and was not representative of Benchmarking Platform. CI runs Go 1.25.9 with `DD_ENV=test_env` and `DD_SERVICE=test_srv`; under that configuration the prior head allocated one `spanSnapshotExtra` per span (+1 alloc and +47–48 B).

Commit `13e99ace8` caches immutable env/version snapshot metadata on tracer-owned read-only attributes. Paired 10-run Go 1.25.9 benchmarks with the CI metadata configuration now show:

- `BenchmarkStartSpan`: 15 allocs/op on baseline and candidate; B/op statistically unchanged
- `BenchmarkStartSpanConfig/scenario_none`: 19 allocs/op on both; candidate B/op -1.39%
- `BenchmarkStartSpanConfig/scenario_WithStartSpanConfig`: 17 allocs/op on both; candidate B/op -1.57%
- Complete affected set: no statistically significant sec/op or allocation regressions; nonzero B/op geomean -0.36%

Validation:

- `go test -race -count=1 ./ddtrace/tracer ./internal/traceprof/...`
- `go test -count=1 ./ddtrace/tracer/...`
- nested `internal/traceprof/traceproftest` `TestEndpointsAndCodeHotspots`
- `go vet ./ddtrace/tracer ./internal/traceprof/...`
- public runtime/pprof QA for root, child, AppSec, endpoint updates, restore behavior, and concurrent extracted contexts

The authoritative Benchmarking Platform rerun is triggered by the pushed commit.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [x] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors.
- [x] New code does not break existing tests.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date.
- [x] No go.mod changes.

