### PR TITLE
fix: certain build metrics were not sent properly

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -169,7 +169,9 @@ Measures build time and binary size for Orchestrion integration samples. Builds 
 
 ### publish_build_metrics.sh
 
-Publishes build metrics to Datadog CI Visibility using `datadog-ci`. Attaches measures (`go.build.duration_seconds.0`, `go.build.duration_seconds.1`, ..., `go.build.binary_size_bytes`) and tags (`build.toolchain`, `build.sample`, `build.cache`, `go.version`, `orchestrion.version`) to the current CI job span. Each element of `build_duration_samples` is published as an individually-indexed measure.
+Publishes build metrics to Datadog CI Visibility using `datadog-ci`. Attaches measures (`go.build.duration_seconds`, `go.build.duration_seconds.0`, `go.build.duration_seconds.1`, ..., `go.build.binary_size_bytes`, and, in standard mode with dependency attribution, `go.build.dependency_size_bytes.<dep>`, `go.build.top_dependency_size_bytes.0`, `go.build.top_dependency_size_bytes.1`, ...) and tags (`build.toolchain`, `build.sample`, `build.cache`, `go.version`, `orchestrion.version`, and, in standard mode, `build.top_dependency_name.0`, `build.top_dependency_name.1`, ...) to the current CI job span.
+
+Each attributed dependency is published as a measure named after it (`go.build.dependency_size_bytes.<dep>`) for querying one dependency's size trend over time. It's also published by rank — `go.build.top_dependency_size_bytes.<i>` paired with a `build.top_dependency_name.<i>` tag holding that rank's dependency name, where index `0` is the single largest dependency in that build.
 
 ```bash
 # Set environment and publish

--- a/scripts/publish_build_metrics.sh
+++ b/scripts/publish_build_metrics.sh
@@ -26,6 +26,10 @@ die() {
   exit 1
 }
 
+mean() {
+  awk 'BEGIN { s = 0 } { for (i = 1; i <= NF; i++) s += $i } END { print s / NF }' <<< "$*"
+}
+
 # Validate environment
 if [[ -z "${METRICS_FILE:-}" ]]; then
   die "METRICS_FILE environment variable is required"
@@ -50,7 +54,10 @@ ORCHESTRION_VERSION=$(jq -r '.orchestrion_version // empty' "$METRICS_FILE")
 # Read all duration samples into a bash array
 mapfile -t DURATIONS < <(jq -r '.metrics.build_duration_samples[]' "$METRICS_FILE")
 
-# Read dependency size attribution (standard mode only; empty otherwise)
+# Read dependency size attribution (standard mode only; empty otherwise).
+# Sorted descending by size (see measure_build.sh), so index 0 is the single
+# largest dependency, index 1 the second largest, etc.
+mapfile -t DEP_NAMES < <(jq -r '.metrics.dependency_sizes[]?.name' "$METRICS_FILE")
 mapfile -t DEP_KEYS < <(jq -r '.metrics.dependency_sizes[]?.metric_key' "$METRICS_FILE")
 mapfile -t DEP_SIZES < <(jq -r '.metrics.dependency_sizes[]?.size_bytes' "$METRICS_FILE")
 
@@ -65,16 +72,25 @@ if [[ -n "$ORCHESTRION_VERSION" ]]; then
   message "  Orchestrion version: $ORCHESTRION_VERSION"
 fi
 
-# Publish measures to CI Visibility — one indexed measure per duration sample,
-# one size sample, and (standard mode only) one indexed measure per dependency
-# attributed by gsa, following the same duration_seconds.<i> naming convention
+# Publish measures to CI Visibility — one indexed measure per duration
+# sample plus a flat mean duration measure (repeated samples of the same
+# build, so a mean is meaningful), and (standard mode only) one measure per
+# dependency attributed by gsa, named after the dependency for historical,
+# per-dependency trend queries.
 message "Publishing measures to Datadog CI Visibility..."
-MEASURE_ARGS=(--measures "go.build.binary_size_bytes:${SIZE}")
+MEAN_DURATION=$(mean "${DURATIONS[@]}")
+message "  Mean duration: ${MEAN_DURATION}s"
+MEASURE_ARGS=(
+  --measures "go.build.binary_size_bytes:${SIZE}"
+  --measures "go.build.duration_seconds:${MEAN_DURATION}"
+)
 for i in "${!DURATIONS[@]}"; do
   MEASURE_ARGS+=(--measures "go.build.duration_seconds.${i}:${DURATIONS[$i]}")
 done
 for i in "${!DEP_KEYS[@]}"; do
   MEASURE_ARGS+=(--measures "go.build.dependency_size_bytes.${DEP_KEYS[$i]}:${DEP_SIZES[$i]}")
+  # Publish dependency size bytes by rank (0 = single largest dependency in this build)
+  MEASURE_ARGS+=(--measures "go.build.top_dependency_size_bytes.${i}:${DEP_SIZES[$i]}")
 done
 
 DATADOG_SITE="${DATADOG_SITE:-datadoghq.com}" datadog-ci measure --level job \
@@ -93,6 +109,10 @@ TAGS=(
 if [[ -n "$ORCHESTRION_VERSION" ]]; then
   TAGS+=("orchestrion.version:${ORCHESTRION_VERSION}")
 fi
+
+for i in "${!DEP_NAMES[@]}"; do
+  TAGS+=("build.top_dependency_name.${i}:${DEP_NAMES[$i]}")
+done
 
 # Build tag arguments
 TAG_ARGS=()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Fixes and further improves binary metrics reporting as a follow up to #5103 . The goal is to identify the top 10 most "bloating" dependencies when building the tracer. We can expand this later to rank all dependencies, not just the top 10.

Previously, build durations and dependency sizes were not properly displayed. This PR helps support new widgets on the dashboard.

Example of new (or newly working) widgets:
<img width="1303" height="361" alt="image" src="https://github.com/user-attachments/assets/3261390e-8627-4c8c-8546-bac29094dc0f" />
<img width="1299" height="356" alt="image" src="https://github.com/user-attachments/assets/99a022f1-d36b-47cb-9493-c3f20391dcf2" />

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fix the [Tracer Overhead dashboard](https://app.datadoghq.com/dashboard/q2w-mum-u24/tracer-overhead-go?fromUser=false&refresh_mode=paused&tpl_var_git.branch%5B0%5D=hannahkm%2Ffix-build-metrics&from_ts=1785771648619&to_ts=1785773695319&live=false&tile_focus=3652692649954162).

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
