### PR TITLE
perf(ddtrace/tracer): avoid heap allocations in propagatorBaggage.extractTextMap

### DIFF
--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -424,13 +424,12 @@ func (p *chainedPropagator) extractIncomingSpanContext(carrier any) (*SpanContex
 		firstExtraction := (ctx == nil)
 		extractedCtx, err := v.Extract(carrier)
 
-		// If this is the baggage propagator, just stash its items into pendingBaggage
+		// If this is the baggage propagator, take ownership of its map directly:
+		// there is only one baggage propagator (see extractBaggage below), so
+		// extractedCtx is not shared with anything else and its map needs no copy.
 		if _, isBaggage := v.(*propagatorBaggage); isBaggage {
 			if extractedCtx != nil && len(extractedCtx.baggage) > 0 { // +checklocksignore - Initialization time, freshly extracted ctx not yet shared.
-				if pendingBaggage == nil {
-					pendingBaggage = make(map[string]string, len(extractedCtx.baggage)) // +checklocksignore - Initialization time, freshly extracted ctx not yet shared.
-				}
-				maps.Copy(pendingBaggage, extractedCtx.baggage) // +checklocksignore - Initialization time, freshly extracted ctx not yet shared.
+				pendingBaggage = extractedCtx.baggage // +checklocksignore - Initialization time, freshly extracted ctx not yet shared.
 			}
 			continue
 		}
@@ -487,10 +486,9 @@ func (p *chainedPropagator) extractIncomingSpanContext(carrier any) (*SpanContex
 	if ctx == nil {
 		if len(pendingBaggage) > 0 {
 			ctx := &SpanContext{
-				baggage:     make(map[string]string, len(pendingBaggage)), // +checklocksignore - Initialization time, not shared yet.
-				baggageOnly: true,                                         // +checklocksignore - Initialization time, not shared yet.
+				baggage:     pendingBaggage, // +checklocksignore - Initialization time, not shared yet.
+				baggageOnly: true,           // +checklocksignore - Initialization time, not shared yet.
 			}
-			maps.Copy(ctx.baggage, pendingBaggage) // +checklocksignore - Initialization time, not shared yet.
 			atomic.StoreUint32(&ctx.hasBaggage, 1)
 			return ctx, nil, nil
 		}
@@ -499,9 +497,13 @@ func (p *chainedPropagator) extractIncomingSpanContext(carrier any) (*SpanContex
 	}
 	if len(pendingBaggage) > 0 {
 		if ctx.baggage == nil { // +checklocksignore - Initialization time, freshly extracted ctx not yet shared.
-			ctx.baggage = make(map[string]string, len(pendingBaggage)) // +checklocksignore - Initialization time, freshly extracted ctx not yet shared.
+			// Common case: no OT "ot-baggage-<key>" headers were extracted, so
+			// pendingBaggage can be taken directly instead of copied into a new map.
+			ctx.baggage = pendingBaggage // +checklocksignore - Initialization time, freshly extracted ctx not yet shared.
+		} else {
+			// ctx.baggage already holds OT-baggage items; merge, don't replace.
+			maps.Copy(ctx.baggage, pendingBaggage) // +checklocksignore - Initialization time, freshly extracted ctx not yet shared.
 		}
-		maps.Copy(ctx.baggage, pendingBaggage) // +checklocksignore - Initialization time, freshly extracted ctx not yet shared.
 		atomic.StoreUint32(&ctx.hasBaggage, 1)
 	}
 
@@ -1788,6 +1790,12 @@ const baggageKeyLen = 7
 // implementations fall back to foreachBaggageHeader, which is deliberately
 // its own function so its heap-allocated locals are scoped to calls that
 // actually take that path.
+//
+// This deliberately diverges from the ForeachKey-plus-scratch-struct pattern
+// datadogExtractScratch/w3cExtractScratch use: those extractors must inspect
+// every header key to find several different fields, so a scan is the only
+// option regardless of carrier type. Baggage reads exactly one key, so a
+// direct map/slice lookup on the two built-in carriers beats any scan.
 func lookupBaggageHeader(reader TextMapReader) (string, error) {
 	switch c := reader.(type) {
 	case TextMapCarrier:

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -1774,26 +1774,73 @@ func (p *propagatorBaggage) Extract(carrier any) (*SpanContext, error) {
 	}
 }
 
-func (*propagatorBaggage) extractTextMap(reader TextMapReader) (*SpanContext, error) {
-	var baggageHeader string
-	var ctx SpanContext
+// baggageKeyLen is len("baggage"), used to reject non-matches before paying
+// for strings.EqualFold, which has no length fast path.
+const baggageKeyLen = 7
+
+// lookupBaggageHeader returns the case-insensitive "baggage" header value
+// found in reader, or "" if none is present. TextMapCarrier and
+// HTTPHeadersCarrier get a direct-iteration fast path instead of going
+// through ForeachKey: ForeachKey is an interface method, so the compiler
+// must assume any closure passed to it escapes, which forces both the
+// closure and the local it captures onto the heap on every call -- even the
+// common case where there is no baggage header at all. Other TextMapReader
+// implementations fall back to foreachBaggageHeader, which is deliberately
+// its own function so its heap-allocated locals are scoped to calls that
+// actually take that path.
+func lookupBaggageHeader(reader TextMapReader) (string, error) {
+	switch c := reader.(type) {
+	case TextMapCarrier:
+		for k, v := range c {
+			if len(k) == baggageKeyLen && strings.EqualFold(k, "baggage") {
+				return v, nil
+			}
+		}
+		return "", nil
+	case HTTPHeadersCarrier:
+		// "Baggage" is the canonical form net/http produces and the one
+		// HTTPHeadersCarrier.Set writes via http.Header.Set.
+		if vals := c["Baggage"]; len(vals) > 0 {
+			return vals[len(vals)-1], nil
+		}
+		for k, vals := range c {
+			if len(vals) == 0 || len(k) != baggageKeyLen || !strings.EqualFold(k, "baggage") {
+				continue
+			}
+			return vals[len(vals)-1], nil
+		}
+		return "", nil
+	default:
+		return foreachBaggageHeader(reader)
+	}
+}
+
+func foreachBaggageHeader(reader TextMapReader) (string, error) {
+	var header string
 	err := reader.ForeachKey(func(k, v string) error {
-		if strings.EqualFold(k, "baggage") {
-			// Expect only one baggage header, return early
-			baggageHeader = v
-			return nil
+		if header == "" && len(k) == baggageKeyLen && strings.EqualFold(k, "baggage") {
+			header = v
 		}
 		return nil
 	})
+	return header, err
+}
+
+// extractTextMap parses the incoming "baggage" header into a scratch map and
+// only allocates a *SpanContext once at least one item has been extracted,
+// matching the pattern used by datadogExtractScratch above: the common case
+// of no baggage header should cost nothing.
+func (*propagatorBaggage) extractTextMap(reader TextMapReader) (*SpanContext, error) {
+	baggageHeader, err := lookupBaggageHeader(reader)
 	if err != nil {
 		return nil, err
 	}
-
 	if baggageHeader == "" {
-		return &ctx, nil
+		return nil, nil
 	}
 
 	// Single pass: enforce baggageMaxItems and baggageMaxBytes, validate, and apply.
+	var baggage map[string]string
 	ctr := 0
 	byteCount := 0
 	for kv := range strings.SplitSeq(baggageHeader, ",") {
@@ -1814,14 +1861,22 @@ func (*propagatorBaggage) extractTextMap(reader TextMapReader) (*SpanContext, er
 		trimmedV := strings.TrimSpace(v)
 		if !ok || trimmedK == "" || trimmedV == "" {
 			log.Warn("invalid baggage item: %q, dropping entire header", kv)
-			return &SpanContext{}, nil
+			return nil, nil
 		}
 		key, _ := url.QueryUnescape(trimmedK)
 		val, _ := url.QueryUnescape(trimmedV)
-		ctx.setBaggageItem(key, val)
+		if baggage == nil {
+			baggage = make(map[string]string, 1)
+		}
+		baggage[key] = val
 		byteCount += itemBytes
 		ctr++
 	}
+	if len(baggage) == 0 {
+		return nil, nil
+	}
 
-	return &ctx, nil
+	ctx := &SpanContext{baggage: baggage} // +checklocksignore - Initialization time, freshly extracted ctx not yet shared.
+	atomic.StoreUint32(&ctx.hasBaggage, 1)
+	return ctx, nil
 }

--- a/ddtrace/tracer/textmap.go
+++ b/ddtrace/tracer/textmap.go
@@ -1815,10 +1815,14 @@ func lookupBaggageHeader(reader TextMapReader) (string, error) {
 	}
 }
 
+// foreachBaggageHeader keeps the last matching value, not the first: carriers
+// that reach this fallback (Kafka/gRPC/etc. in contrib/) can have a real,
+// deterministic order where a repeated "baggage" key's last occurrence is the
+// documented winner -- see e.g. contrib/IBM/sarama's ProducerMessageCarrier.Get.
 func foreachBaggageHeader(reader TextMapReader) (string, error) {
 	var header string
 	err := reader.ForeachKey(func(k, v string) error {
-		if header == "" && len(k) == baggageKeyLen && strings.EqualFold(k, "baggage") {
+		if len(k) == baggageKeyLen && strings.EqualFold(k, "baggage") {
 			header = v
 		}
 		return nil

--- a/ddtrace/tracer/textmap_caseinsensitive_test.go
+++ b/ddtrace/tracer/textmap_caseinsensitive_test.go
@@ -125,6 +125,41 @@ func TestExtractHeaderNameCaseInsensitivity(t *testing.T) {
 		require.NotNil(t, ctx)
 		assert.Equal(t, "baz", ctx.baggageItem("foo"))
 	})
+
+	// Carriers other than TextMapCarrier/HTTPHeadersCarrier -- e.g.
+	// contrib/IBM/sarama's ProducerMessageCarrier, whose Get method documents
+	// "last occurrence wins" for a repeated key -- go through the ForeachKey
+	// fallback (foreachBaggageHeader) instead of the fast path above. That
+	// fallback must preserve the same last-value-wins contract.
+	t.Run("baggage header, ForeachKey fallback keeps last of duplicate keys", func(t *testing.T) {
+		t.Setenv(envPropagationStyleExtract, "baggage")
+		p := NewPropagator(nil)
+		carrier := orderedHeaderCarrier{
+			{key: "baggage", val: "foo=bar"},
+			{key: "BAGGAGE", val: "foo=baz"},
+		}
+		ctx, err := p.Extract(carrier)
+		require.NoError(t, err)
+		require.NotNil(t, ctx)
+		assert.Equal(t, "baz", ctx.baggageItem("foo"))
+	})
+}
+
+// orderedHeaderCarrier is a minimal TextMapReader that emits key/value pairs
+// in a fixed slice order and can legitimately contain a duplicate key,
+// mirroring carriers like contrib/IBM/sarama's ProducerMessageCarrier -- unlike
+// TextMapCarrier, whose map iteration order is already randomized. It
+// deliberately does not implement TextMapWriter, so it always reaches the
+// ForeachKey fallback rather than a carrier-specific fast path.
+type orderedHeaderCarrier []struct{ key, val string }
+
+func (c orderedHeaderCarrier) ForeachKey(handler func(key, val string) error) error {
+	for _, kv := range c {
+		if err := handler(kv.key, kv.val); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // canonicalHTTPHeaders builds an http.Header whose keys are stored in canonical

--- a/ddtrace/tracer/textmap_caseinsensitive_test.go
+++ b/ddtrace/tracer/textmap_caseinsensitive_test.go
@@ -85,6 +85,46 @@ func TestExtractHeaderNameCaseInsensitivity(t *testing.T) {
 		assert.Equal(t, uint64(42), ctx.TraceIDLower())
 		assert.Equal(t, uint64(7), ctx.SpanID())
 	})
+
+	// The baggage propagator matches header names via a carrier-specific fast
+	// path (lookupBaggageHeader) rather than the ForeachKey scan the other
+	// propagators use, so it needs its own case-insensitivity coverage.
+	t.Run("baggage header, TextMapCarrier non-canonical case", func(t *testing.T) {
+		t.Setenv(envPropagationStyleExtract, "baggage")
+		p := NewPropagator(nil)
+		carrier := TextMapCarrier{"BAGGAGE": "foo=bar"}
+		ctx, err := p.Extract(carrier)
+		require.NoError(t, err)
+		require.NotNil(t, ctx)
+		assert.Equal(t, "bar", ctx.baggageItem("foo"))
+	})
+
+	// http.Header canonicalizes keys written via Set/Add, but a carrier can be
+	// built by hand with an arbitrary-case key -- lookupBaggageHeader's O(1)
+	// canonical lookup must fall back to a scan in that case.
+	t.Run("baggage header, HTTPHeadersCarrier non-canonical case", func(t *testing.T) {
+		t.Setenv(envPropagationStyleExtract, "baggage")
+		p := NewPropagator(nil)
+		carrier := HTTPHeadersCarrier(http.Header{"baggage": {"foo=bar"}})
+		ctx, err := p.Extract(carrier)
+		require.NoError(t, err)
+		require.NotNil(t, ctx)
+		assert.Equal(t, "bar", ctx.baggageItem("foo"))
+	})
+
+	// Pins that a repeated "baggage" header keeps the same last-value-wins
+	// behavior as before this fast path existed.
+	t.Run("baggage header, HTTPHeadersCarrier multi-value", func(t *testing.T) {
+		t.Setenv(envPropagationStyleExtract, "baggage")
+		p := NewPropagator(nil)
+		h := http.Header{}
+		h.Add("baggage", "foo=bar")
+		h.Add("baggage", "foo=baz")
+		ctx, err := p.Extract(HTTPHeadersCarrier(h))
+		require.NoError(t, err)
+		require.NotNil(t, ctx)
+		assert.Equal(t, "baz", ctx.baggageItem("foo"))
+	})
 }
 
 // canonicalHTTPHeaders builds an http.Header whose keys are stored in canonical

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -3638,6 +3638,36 @@ func TestExtractBaggageFirstThenDatadog(t *testing.T) {
 	assert.Equal(t, "xyz", got["item"])
 }
 
+// TestExtractBaggageMergesWithOTBaggagePrefix pins the merge branch in
+// extractIncomingSpanContext: when the Datadog extractor has already
+// populated ctx.baggage from a legacy "ot-baggage-<key>" header, the W3C
+// "baggage" header's items must be merged into that map, not silently
+// discarded or used to replace it wholesale.
+func TestExtractBaggageMergesWithOTBaggagePrefix(t *testing.T) {
+	tracer, err := newTracer()
+	assert.NoError(t, err)
+	defer tracer.Stop()
+
+	headers := TextMapCarrier(map[string]string{
+		DefaultTraceIDHeader:                  "12345",
+		DefaultParentIDHeader:                 "67890",
+		DefaultBaggageHeaderPrefix + "legacy": "old",
+		"baggage":                             "item=xyz",
+	})
+
+	ctx, err := tracer.Extract(headers)
+	assert.NoError(t, err)
+
+	got := make(map[string]string)
+	ctx.ForeachBaggageItem(func(k, v string) bool {
+		got[k] = v
+		return true
+	})
+	assert.Len(t, got, 2)
+	assert.Equal(t, "old", got["legacy"])
+	assert.Equal(t, "xyz", got["item"])
+}
+
 // TestSpanContextDebugLoggingSecurity verifies that debug logging of span context
 // does not expose sensitive data from baggage or other fields.
 func TestSpanContextDebugLoggingSecurity(t *testing.T) {

--- a/ddtrace/tracer/textmap_test.go
+++ b/ddtrace/tracer/textmap_test.go
@@ -2655,6 +2655,16 @@ func TestExtractNoHeaders(t *testing.T) {
 			extractEnv:   "datadog,tracecontext",
 			extractFirst: true,
 		},
+		{
+			name:         "baggage only",
+			extractEnv:   "baggage",
+			extractFirst: false,
+		},
+		{
+			name:         "baggage only - extractFirst",
+			extractEnv:   "baggage",
+			extractFirst: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2763,6 +2773,57 @@ func BenchmarkExtractW3CUppercase(b *testing.B) {
 	}
 }
 
+// edgeRequestHeaders returns a realistic set of headers seen on an inbound
+// edge request, used by the baggage benchmarks below so the cost of scanning
+// past non-matching keys is represented, not just the cost of matching one.
+func edgeRequestHeaders() map[string]string {
+	return map[string]string{
+		"accept":          "application/json",
+		"accept-encoding": "gzip",
+		"user-agent":      "Go-http-client/1.1",
+		"host":            "api.example.com",
+		"x-forwarded-for": "10.0.0.1",
+		"x-request-id":    "5f2c1e2a-6b3d-4c8e-9b0a-1234567890ab",
+		"content-type":    "application/json",
+		"authorization":   "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+		"traceparent":     "00-00000000000000001111111111111111-2222222222222222-01",
+	}
+}
+
+// baggageHeaderValue includes a "+"/"%" escape so url.QueryUnescape actually
+// does work, instead of returning its input unchanged as it would for an
+// all-clean value.
+const baggageHeaderValue = "userId=amelie,session.id=789,serverNode=DF+28,region=us1"
+
+func BenchmarkExtractBaggage(b *testing.B) {
+	b.Setenv(envPropagationStyleExtract, "baggage")
+
+	b.Run("TextMapCarrier", func(b *testing.B) {
+		propagator := NewPropagator(nil)
+		headers := edgeRequestHeaders()
+		headers["baggage"] = baggageHeaderValue
+		carrier := TextMapCarrier(headers)
+		b.ResetTimer()
+		for b.Loop() {
+			propagator.Extract(carrier)
+		}
+	})
+
+	b.Run("HTTPHeadersCarrier", func(b *testing.B) {
+		propagator := NewPropagator(nil)
+		h := http.Header{}
+		for k, v := range edgeRequestHeaders() {
+			h.Set(k, v)
+		}
+		h.Set("baggage", baggageHeaderValue)
+		carrier := HTTPHeadersCarrier(h)
+		b.ResetTimer()
+		for b.Loop() {
+			propagator.Extract(carrier)
+		}
+	})
+}
+
 // BenchmarkExtractDatadogNoHeaders exercises the common edge-request case of
 // no upstream Datadog trace headers at all, where extraction fails with
 // ErrSpanContextNotFound. See CACHE/alloc backlog item #3: propagator.extractTextMap
@@ -2790,11 +2851,14 @@ func BenchmarkExtractW3CNoHeaders(b *testing.B) {
 	}
 }
 
-// BenchmarkExtractBaggageNoHeaders documents that, unlike the datadog and W3C
-// extractors above, propagatorBaggage.extractTextMap has no allocation to
-// save on the no-headers path: its contract already returns a non-nil,
-// non-error *SpanContext even when no "baggage" header is present (an empty
-// baggage-only context), so a SpanContext must be allocated regardless.
+// BenchmarkExtractBaggageNoHeaders exercises the common edge-request case of
+// no "baggage" header at all. propagatorBaggage.extractTextMap now returns
+// (nil, nil) in that case instead of an allocated empty *SpanContext -- safe
+// because propagatorBaggage is unexported and both of its callers in
+// chainedPropagator already nil-check the result (extractBaggage and
+// extractIncomingSpanContext). Combined with the carrier-specific fast path
+// in lookupBaggageHeader that avoids the ForeachKey closure entirely, this
+// benchmark is 0 allocs/op.
 func BenchmarkExtractBaggageNoHeaders(b *testing.B) {
 	b.Setenv(envPropagationStyleExtract, "baggage")
 	propagator := NewPropagator(nil)


### PR DESCRIPTION
### What does this PR do?

Optimizes `propagatorBaggage.extractTextMap` (`ddtrace/tracer/textmap.go`), which runs on every `Extract` call as part of the default propagator chain (`datadog,tracecontext,baggage`) — including the overwhelmingly common case where no `baggage` header is present.

Two changes:

1. **Avoid the `ForeachKey` closure on the fast path.** `ForeachKey` is an interface method (`TextMapReader`), so escape analysis must assume any closure passed to it escapes — this forced both the closure and the local it captured onto the heap on *every* call. Added `lookupBaggageHeader`, which type-switches on `TextMapCarrier`/`HTTPHeadersCarrier` and iterates directly (no closure). Confirmed via `go build -gcflags=-m` that no heap escapes remain on this path. Other `TextMapReader` implementations still go through `ForeachKey`, isolated in its own function (`foreachBaggageHeader`) so its heap-boxed locals stay scoped to that fallback only.
2. **Return `(nil, nil)` instead of an allocated empty `*SpanContext`** when no baggage is found (or a malformed item forces a drop). `propagatorBaggage` is unexported and only reachable through `chainedPropagator`, whose two callers (`extractBaggage`, `extractIncomingSpanContext`) already nil-check the result — so this is a safe, narrower contract, not a behavior change for any caller.

### Motivation

Measured with escape analysis and `pprof`, not assumed: `BenchmarkExtractBaggageNoHeaders` showed 3 allocs/op (288 B), with the closure pattern responsible for 2 of the 3 and the unconditional `*SpanContext` responsible for 86% of the bytes. In the default chain, baggage was actually the *most expensive* of the three extractors on the no-headers path despite doing the least work.

```
BenchmarkExtractBaggageNoHeaders-10   147.75 ns/op   288 B/op   3 allocs/op   (before)
BenchmarkExtractBaggageNoHeaders-10    18.09 ns/op     0 B/op   0 allocs/op   (after)
```

`benchstat` over all `BenchmarkExtract*` benchmarks confirms every other extractor is noise-level unchanged.

Also added:
- `BenchmarkExtractBaggage` (`/TextMapCarrier` and `/HTTPHeadersCarrier`), since no existing benchmark exercised extraction with a baggage header actually present.
- A baggage case in `TestExtractNoHeaders` and three subtests in `TestExtractHeaderNameCaseInsensitivity` covering non-canonical carrier keys and `http.Header` multi-value last-wins semantics — gaps surfaced during review that the new carrier-specific fast path made load-bearing.
- Rewrote the doc comment on `BenchmarkExtractBaggageNoHeaders`, which asserted the old "a SpanContext must be allocated regardless" contract this PR removes.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [x] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. Verified with `golangci-lint run ./ddtrace/tracer/...` (0 issues) and `checklocks.sh` (no new issues; two pre-existing suggestions are in untouched files).
- [x] New code doesn't break existing tests. Full `ddtrace/tracer` suite passes with `-race`.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date.
- [ ] Non-trivial go.mod changes — N/A, no go.mod changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)