### PR TITLE
fix(lint): clear pre-existing goleak, checklocks and nolint findings

### DIFF
--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -277,7 +277,9 @@ func TestInternalMetricsDisabled(t *testing.T) {
 	}
 
 	t.Run("default non-Lambda: real client", func(t *testing.T) {
-		tr, err := newUnstartedTracer(WithAgentTimeout(2))
+		// withNoopInfoHTTPClient intercepts the /info agent-discovery request without
+		// DNS/TCP, so no idle keep-alive connection is left for goleak to catch.
+		tr, err := newUnstartedTracer(WithAgentTimeout(2), withNoopInfoHTTPClient())
 		require.NoError(t, err)
 		defer tr.statsd.Close()
 		require.False(t, isNoop(tr.statsd), "statsd should be real by default, got %T", tr.statsd)
@@ -287,7 +289,7 @@ func TestInternalMetricsDisabled(t *testing.T) {
 		// In Lambda the core config layer defaults internal metrics to off so the
 		// tracer emits no statsd traffic by default.
 		t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "my-function")
-		tr, err := newUnstartedTracer(WithAgentTimeout(2))
+		tr, err := newUnstartedTracer(WithAgentTimeout(2), withNoopInfoHTTPClient())
 		require.NoError(t, err)
 		defer tr.statsd.Close()
 		require.True(t, isNoop(tr.statsd), "statsd should be a no-op in Lambda by default, got %T", tr.statsd)
@@ -298,7 +300,7 @@ func TestInternalMetricsDisabled(t *testing.T) {
 		// client is used and their setting is reported with origin env_var.
 		t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "my-function")
 		t.Setenv("DD_TRACE_INTERNAL_METRICS_ENABLED", "true")
-		tr, err := newUnstartedTracer(WithAgentTimeout(2))
+		tr, err := newUnstartedTracer(WithAgentTimeout(2), withNoopInfoHTTPClient())
 		require.NoError(t, err)
 		defer tr.statsd.Close()
 		require.False(t, isNoop(tr.statsd), "statsd should be real when user opts in, got %T", tr.statsd)

--- a/ddtrace/tracer/otlp_writer.go
+++ b/ddtrace/tracer/otlp_writer.go
@@ -31,7 +31,7 @@ type otlpTraceWriter struct {
 	scope     *otlpcommon.InstrumentationScope
 	spans     []*otlptrace.Span // +checklocks:mu
 	buffSize  int               // +checklocks:mu
-	baseSize  int
+	baseSize  int               // +checklocks:mu
 
 	// climit bounds the number of concurrent outgoing sends dispatched by flush.
 	climit chan struct{}

--- a/ddtrace/tracer/span.go
+++ b/ddtrace/tracer/span.go
@@ -1291,12 +1291,12 @@ func (s *Span) Format(f fmt.State, c rune) {
 			tc := tr.TracerConf()
 			if tc.EnvTag != "" {
 				fmt.Fprintf(f, "dd.env=%s ", tc.EnvTag)
-			} else if env := env.Get("DD_ENV"); env != "" { //nolint:configaudit — intentional: read env directly when tracer has stopped and TracerConf is empty
+			} else if env := env.Get("DD_ENV"); env != "" { //configaudit:ignore — intentional: read env directly when tracer has stopped and TracerConf is empty
 				fmt.Fprintf(f, "dd.env=%s ", env)
 			}
 			if tc.VersionTag != "" {
 				fmt.Fprintf(f, "dd.version=%s ", tc.VersionTag)
-			} else if v := env.Get("DD_VERSION"); v != "" { //nolint:configaudit — intentional: read env directly when tracer has stopped and TracerConf is empty
+			} else if v := env.Get("DD_VERSION"); v != "" { //configaudit:ignore — intentional: read env directly when tracer has stopped and TracerConf is empty
 				fmt.Fprintf(f, "dd.version=%s ", v)
 			}
 		}

--- a/ddtrace/tracer/spancontext.go
+++ b/ddtrace/tracer/spancontext.go
@@ -40,7 +40,7 @@ const TraceIDZero string = "00000000000000000000000000000000"
 var traceID128BitEnabled atomic.Bool
 
 func init() {
-	traceID128BitEnabled.Store(sharedinternal.BoolEnv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", true)) //nolint:configaudit — intentional: atomic cache for hot path; re-seeded from internalConfig on tracer.Start
+	traceID128BitEnabled.Store(sharedinternal.BoolEnv("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", true)) //configaudit:ignore — intentional: atomic cache for hot path; re-seeded from internalConfig on tracer.Start
 }
 
 var _ ddtrace.SpanContext = (*SpanContext)(nil)
@@ -657,7 +657,7 @@ var (
 	// reasonable as span is actually way bigger, and avoids re-allocating
 	// over and over. Could be fine-tuned at runtime.
 	traceStartSize = 10
-	traceMaxSize   = internalconfig.TraceMaxSize
+	traceMaxSize   = internalconfig.TraceMaxSize // +checklocksignore — package-level config knob, read under t.mu in trace.push; only ever mutated by tests, never concurrently with a running trace.
 )
 
 // samplingPriorityCache holds pre-allocated pointers for the four standard

--- a/scripts/configaudit/README.md
+++ b/scripts/configaudit/README.md
@@ -33,13 +33,17 @@ make config-audit
 ## Suppressing intentional reads
 
 If a direct env-var read is intentional and not a migration candidate, annotate
-the line with `//nolint:configaudit`:
+the line with `//configaudit:ignore`:
 
 ```go
-} else if v := env.Get("DD_ENV"); v != "" { //nolint:configaudit — intentional: ...
+} else if v := env.Get("DD_ENV"); v != "" { //configaudit:ignore — intentional: ...
 ```
 
-The scanner skips any call site whose source line carries this annotation.
+The scanner skips any call site whose source line carries this directive. This
+is a standalone directive rather than a `//nolint:configaudit` entry:
+`configaudit` is not a golangci-lint linter, so naming it in a `//nolint:`
+comment makes golangci-lint's nolint filter warn about an unknown linter on
+every run.
 
 ## CI
 

--- a/scripts/configaudit/scan.go
+++ b/scripts/configaudit/scan.go
@@ -138,33 +138,28 @@ func scan(root string, r recognizers, exclude []string) (map[string][]CallSite, 
 	return out, nil
 }
 
-// hasNolintConfigaudit reports whether text is a nolint comment that names
-// configaudit as one of its linters (e.g. "//nolint:configaudit" or
-// "// nolint:foo,configaudit").
-func hasNolintConfigaudit(text string) bool {
-	text = strings.TrimSpace(strings.TrimLeft(text, "/"))
-	if !strings.HasPrefix(text, "nolint:") {
-		return false
-	}
-	for _, seg := range strings.Split(strings.TrimPrefix(text, "nolint:"), ",") {
-		// A linter name ends at the first whitespace; anything after (reason
-		// text, em dashes, etc.) is not part of the name.
-		fields := strings.Fields(strings.TrimSpace(seg))
-		if len(fields) > 0 && fields[0] == "configaudit" {
-			return true
-		}
-	}
-	return false
+// configAuditIgnore is a standalone directive, not a //nolint: entry:
+// configaudit is this repo's own scanner, not a golangci-lint linter, so
+// naming it in a //nolint: comment makes golangci-lint's nolint filter warn
+// about an unknown linter on every run.
+const configAuditIgnore = "configaudit:ignore"
+
+// hasIgnoreDirective reports whether text is a comment carrying
+// //configaudit:ignore, with or without a trailing reason
+// (e.g. "//configaudit:ignore — intentional direct read").
+func hasIgnoreDirective(text string) bool {
+	fields := strings.Fields(strings.TrimLeft(text, "/"))
+	return len(fields) > 0 && fields[0] == configAuditIgnore
 }
 
 // suppressedLines returns the set of 1-based line numbers in file that carry
-// a //nolint:configaudit annotation. Calls on those lines are intentionally
+// a //configaudit:ignore directive. Calls on those lines are intentionally
 // not migrated and are excluded from the audit output.
 func suppressedLines(file *ast.File, pkg *packages.Package) map[int]bool {
 	out := map[int]bool{}
 	for _, cg := range file.Comments {
 		for _, c := range cg.List {
-			if hasNolintConfigaudit(c.Text) {
+			if hasIgnoreDirective(c.Text) {
 				out[pkg.Fset.Position(c.Pos()).Line] = true
 			}
 		}

--- a/scripts/configaudit/scan_test.go
+++ b/scripts/configaudit/scan_test.go
@@ -44,9 +44,31 @@ func TestScan_Fixture(t *testing.T) {
 	if len(got["DD_SITE"]) != 1 {
 		t.Errorf("DD_SITE call-site count = %d, want 1", len(got["DD_SITE"]))
 	}
-	// DD_ENV is suppressed with //nolint:configaudit and must not appear.
+	// DD_ENV is suppressed with //configaudit:ignore and must not appear.
 	if len(got["DD_ENV"]) != 0 {
 		t.Errorf("DD_ENV should be suppressed, got %d call sites", len(got["DD_ENV"]))
+	}
+}
+
+func TestHasIgnoreDirective(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{"bare", "//configaudit:ignore", true},
+		{"with reason", "//configaudit:ignore — intentional direct read", true},
+		{"spaced", "// configaudit:ignore", true},
+		{"nolint form is not recognized", "//nolint:configaudit", false},
+		{"unrelated directive", "//nolint:errcheck", false},
+		{"plain comment", "// just a comment", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasIgnoreDirective(tc.text); got != tc.want {
+				t.Errorf("hasIgnoreDirective(%q) = %v, want %v", tc.text, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/scripts/configaudit/testdata/fixture_a/fixture.go
+++ b/scripts/configaudit/testdata/fixture_a/fixture.go
@@ -18,5 +18,5 @@ func ReadAll() {
 	_ = envGet(ddSiteKey)
 	_ = boolEnv("DD_PROFILING_ENABLED", false)
 	_ = intEnv("DD_TRACE_AGENT_PORT", 8126)
-	_ = envGet("DD_ENV") //nolint:configaudit — intentional direct read, not a migration candidate
+	_ = envGet("DD_ENV") //configaudit:ignore — intentional direct read, not a migration candidate
 }


### PR DESCRIPTION
## Summary

Cleans up four small pre-existing, non-gating issues on `main` — none of these currently fail CI, but they're noise that trains reviewers to ignore linter/goleak output.

- **goleak**: `TestInternalMetricsDisabled` builds tracers with `newUnstartedTracer`, which leaves HTTP keep-alives enabled and triggers the `/info` agent-discovery request. Without `Stop()`, the idle pooled connection's `readLoop`/`writeLoop` goroutines outlive the test, so `TestMain`'s `goleak.Find()` fails whenever a local agent answers on `:8126` (see CONTRIBUTING.md § Goroutine Leaks). Bisected via `-run`/`-skip`: this is the *only* leaking test in the package. Fixed by passing the existing `withNoopInfoHTTPClient()` helper, matching other `newUnstartedTracer` call sites that don't `Stop()`.
- **golangci-lint nolint warning**: `configaudit` (our own env-var migration scanner in `scripts/configaudit`) was suppressed via `//nolint:configaudit`, but it isn't a golangci-lint linter, so the nolint filter logs `Found unknown linters in //nolint directives: configaudit` on every run — and there's no config knob to allow-list it. Gave it its own `//configaudit:ignore` directive instead, invisible to golangci-lint's nolint parsing.
- **checklocks suggestions** (2): `may require checklocks annotation for mu, used with lock held 100% of the time` for `traceMaxSize` (package-level knob, only mutated by tests — annotated `+checklocksignore`) and `otlpTraceWriter.baseSize` (always accessed under `w.mu`, like its sibling fields `spans`/`buffSize` — annotated `+checklocks:mu`).

`golangci-lint run ./...` was already `0 issues` before this change; `scripts/checklocks.sh` already exits 0 (suggestions don't fail it). This PR removes the warning noise and the goleak failure rather than fixing a gating check.

## Test plan

- [x] `GOTOOLCHAIN=go1.25.0 go test ./ddtrace/tracer/... -count=1` → ok (goleak passes with a local agent on `:8126`)
- [x] `GOTOOLCHAIN=go1.25.0 go test ./ddtrace/tracer/ -run '^TestInternalMetricsDisabled$' -v` → all 3 subtests pass
- [x] `GOTOOLCHAIN=go1.25.0 ./bin/golangci-lint run ./...` → `0 issues.`, no more nolint_filter warning
- [x] `GOTOOLCHAIN=go1.25.0 ./scripts/checklocks.sh ./ddtrace/tracer` → `No errors found` (0 suggestions)
- [x] `(cd scripts/configaudit && GOWORK=off go test ./...)` → ok
- [x] `(cd scripts/configaudit && GOWORK=off go run . -root ../.. -package ddtrace/tracer -format table)` → `DD_ENV`/`DD_VERSION`/`DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED` correctly absent (still suppressed)