### PR TITLE
fix(stacktrace): parse value receivers

### DIFF
--- a/internal/stacktrace/parse_symbol_bench_test.go
+++ b/internal/stacktrace/parse_symbol_bench_test.go
@@ -11,6 +11,7 @@ func BenchmarkParseSymbol(b *testing.B) {
 	testCases := []string{
 		"github.com/DataDog/dd-trace-go/v2/internal/stacktrace.TestFunc",
 		"github.com/DataDog/dd-trace-go/v2/internal/stacktrace.(*Event).NewException",
+		"github.com/DataDog/dd-trace-go/v2/internal/stacktrace.Event.NewException",
 		"github.com/DataDog/dd-trace-go/v2/internal/stacktrace.TestFunc.func1",
 		"os/exec.(*Cmd).Run.func1",
 		"test.(*Test).Method",

--- a/internal/stacktrace/stacktrace.go
+++ b/internal/stacktrace/stacktrace.go
@@ -141,9 +141,9 @@ func (q *queue[T]) Remove() T {
 //
 // Handles various Go symbol formats:
 //   - Simple function: pkg.Function
-//   - Method with receiver: pkg.(*Type).Method or pkg.(Type).Method
+//   - Method with receiver: pkg.(*Type).Method or pkg.Type.Method
 //   - Lambda/closure: pkg.Function.func1 or pkg.(*Type).Method.func1
-//   - Generics: pkg.(*Type[...]).Method or pkg.Function[...]
+//   - Generics: pkg.(*Type[...]).Method, pkg.Type[...].Method, or pkg.Function[...]
 //
 // Examples:
 //
@@ -162,10 +162,38 @@ func parseSymbol(name string) symbol {
 		// Find the closing paren of the receiver
 		receiverEnd := strings.IndexByte(name[idx+2:], ')')
 		if receiverEnd != -1 {
-			pkg := name[:idx]
-			receiver := name[idx+2 : idx+2+receiverEnd]
-			// Everything after ")." is the function (which may contain dots for lambdas)
-			fn := name[idx+2+receiverEnd+2:] // +2 for ")."
+			receiverEnd += idx + 2
+			if receiverEnd+1 < len(name) && name[receiverEnd+1] == '.' {
+				return symbol{
+					Package:  name[:idx],
+					Receiver: name[idx+2 : receiverEnd],
+					Function: name[receiverEnd+2:],
+				}
+			}
+		}
+	}
+
+	// Find where the package ends and the symbol begins. The package path ends
+	// at the first dot after its final slash.
+	lastSlash := strings.LastIndexByte(name, '/')
+	searchStart := lastSlash + 1
+	firstDotAfterSlash := strings.IndexByte(name[searchStart:], '.')
+	if firstDotAfterSlash == -1 {
+		return symbol{Function: name}
+	}
+
+	pkgEnd := searchStart + firstDotAfterSlash
+	pkg := name[:pkgEnd]
+	remainder := name[pkgEnd+1:]
+
+	// The runtime omits parentheses for value receivers, yielding
+	// pkg.Type.Method. Only classify the unambiguous two-component form: extra
+	// components may belong to closures or compiler-generated wrappers. Dots in
+	// generic type arguments do not delimit components.
+	if receiverEnd := indexSymbolDot(remainder); receiverEnd != -1 {
+		receiver := remainder[:receiverEnd]
+		fn := remainder[receiverEnd+1:]
+		if indexSymbolDot(fn) == -1 && !isCompilerGeneratedFunctionSuffix(receiver, fn) {
 			return symbol{
 				Package:  pkg,
 				Receiver: receiver,
@@ -174,34 +202,60 @@ func parseSymbol(name string) symbol {
 		}
 	}
 
-	// No receiver case: need to find where package ends and function begins
-	// Package path ends at the last '/' followed by a segment before first '.'
-	// Examples:
-	//   "pkg.Function" -> pkg: "pkg", fn: "Function"
-	//   "pkg.Function.func1" -> pkg: "pkg", fn: "Function.func1"
-	//   "github.com/org/pkg.Function" -> pkg: "github.com/org/pkg", fn: "Function"
-
-	// Find the last slash to identify where the package name starts
-	lastSlash := strings.LastIndexByte(name, '/')
-
-	// Find the first dot after the last slash (or from the beginning if no slash)
-	searchStart := 0
-	if lastSlash != -1 {
-		searchStart = lastSlash + 1
-	}
-
-	firstDotAfterSlash := strings.IndexByte(name[searchStart:], '.')
-	if firstDotAfterSlash == -1 {
-		// No dots after last slash, the whole thing is the function name
-		return symbol{Function: name}
-	}
-
-	// Package ends at this dot, function starts after it
-	pkgEnd := searchStart + firstDotAfterSlash
 	return symbol{
-		Package:  name[:pkgEnd],
-		Function: name[pkgEnd+1:], // Everything after the dot, including nested dots for lambdas
+		Package:  pkg,
+		Function: remainder,
 	}
+}
+
+// indexSymbolDot returns the first dot outside generic type arguments.
+func indexSymbolDot(name string) int {
+	bracketDepth := 0
+	for i := range len(name) {
+		switch name[i] {
+		case '[':
+			bracketDepth++
+		case ']':
+			if bracketDepth > 0 {
+				bracketDepth--
+			}
+		case '.':
+			if bracketDepth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// isCompilerGeneratedFunctionSuffix reports whether suffix is a component the
+// compiler appends to a package-level function name.
+func isCompilerGeneratedFunctionSuffix(outer, suffix string) bool {
+	if outer == "init" && hasNumericComponent(suffix, "") {
+		return true
+	}
+	return hasNumericComponent(suffix, "func") ||
+		hasNumericComponent(suffix, "gowrap") ||
+		hasNumericComponent(suffix, "deferwrap")
+}
+
+func hasNumericComponent(name, prefix string) bool {
+	if !strings.HasPrefix(name, prefix) {
+		return false
+	}
+	name = name[len(prefix):]
+	if len(name) == 0 || name[0] < '0' || name[0] > '9' {
+		return false
+	}
+	for i := 1; i < len(name); i++ {
+		if name[i] == '.' {
+			return true
+		}
+		if name[i] < '0' || name[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // Capture create a new stack trace from the current call stack
@@ -561,8 +615,10 @@ func Format(stack StackTrace) string {
 		// Use full function name (namespace + class + function)
 		function := frame.Function
 		if frame.Namespace != "" {
-			if frame.ClassName != "" {
+			if strings.HasPrefix(frame.ClassName, "*") {
 				function = frame.Namespace + ".(" + frame.ClassName + ")." + frame.Function
+			} else if frame.ClassName != "" {
+				function = frame.Namespace + "." + frame.ClassName + "." + frame.Function
 			} else {
 				function = frame.Namespace + "." + frame.Function
 			}

--- a/internal/stacktrace/stacktrace_test.go
+++ b/internal/stacktrace/stacktrace_test.go
@@ -70,6 +70,24 @@ func (t *Test) Method() StackTrace {
 	return CaptureWithRedaction(0)
 }
 
+type valueReceiver struct{}
+
+//go:noinline
+func (valueReceiver) captureStack() StackTrace {
+	return CaptureWithRedaction(0)
+}
+
+func TestStackValueReceiver(t *testing.T) {
+	stack := valueReceiver{}.captureStack()
+	require.NotEmpty(t, stack)
+
+	frame := stack[0]
+	require.Equal(t, "github.com/DataDog/dd-trace-go/v2/internal/stacktrace", frame.Namespace)
+	require.Equal(t, "valueReceiver", frame.ClassName)
+	require.Equal(t, "captureStack", frame.Function)
+	require.Contains(t, Format(stack[:1]), "github.com/DataDog/dd-trace-go/v2/internal/stacktrace.valueReceiver.captureStack\n")
+}
+
 func TestStackMethodReceiver(t *testing.T) {
 	test := &Test{}
 	stack := test.Method()
@@ -200,10 +218,25 @@ func TestParseSymbol(t *testing.T) {
 			"*Test",
 			"Method",
 		}},
-		{"method-receiver", "github.com/DataDog/dd-trace-go/v2/internal/stacktrace.(Test).Method", symbol{
+		{"method-receiver-parenthesized", "github.com/DataDog/dd-trace-go/v2/internal/stacktrace.(Test).Method", symbol{
 			"github.com/DataDog/dd-trace-go/v2/internal/stacktrace",
 			"Test",
 			"Method",
+		}},
+		{"method-receiver", "crypto.Hash.New", symbol{
+			"crypto",
+			"Hash",
+			"New",
+		}},
+		{"generic-method-receiver", "example.com/pkg.Value[...].Method", symbol{
+			"example.com/pkg",
+			"Value[...]",
+			"Method",
+		}},
+		{"generic-function", "example.com/pkg.Function[...]", symbol{
+			"example.com/pkg",
+			"",
+			"Function[...]",
 		}},
 		{"sample", "github.com/DataDog/dd-trace-go/v2/internal/stacktrace.TestGetPackageFromSymbol", symbol{
 			"github.com/DataDog/dd-trace-go/v2/internal/stacktrace",
@@ -214,6 +247,31 @@ func TestParseSymbol(t *testing.T) {
 			"github.com/DataDog/dd-trace-go/v2/internal/stacktrace",
 			"",
 			"TestGetPackageFromSymbol.func1",
+		}},
+		{"generated-wrapper", "github.com/DataDog/dd-trace-go/v2/internal/stacktrace.TestGetPackageFromSymbol.gowrap1", symbol{
+			"github.com/DataDog/dd-trace-go/v2/internal/stacktrace",
+			"",
+			"TestGetPackageFromSymbol.gowrap1",
+		}},
+		{"inlined-closure", "example.com/pkg.Outer.Inlined.func1", symbol{
+			"example.com/pkg",
+			"",
+			"Outer.Inlined.func1",
+		}},
+		{"global-closure", "example.com/pkg.glob..func1", symbol{
+			"example.com/pkg",
+			"",
+			"glob..func1",
+		}},
+		{"package-init", "github.com/DataDog/dd-trace-go/v2/internal/stacktrace.init.0", symbol{
+			"github.com/DataDog/dd-trace-go/v2/internal/stacktrace",
+			"",
+			"init.0",
+		}},
+		{"malformed-receiver", "example.com/pkg.(Value)", symbol{
+			"example.com/pkg",
+			"",
+			"(Value)",
 		}},
 		{"stdlib-sample", "os/exec.NewCmd", symbol{
 			"os/exec",
@@ -640,7 +698,7 @@ func TestFormat(t *testing.T) {
 		require.Equal(t, expected, result)
 	})
 
-	t.Run("frame with class", func(t *testing.T) {
+	t.Run("frame with pointer receiver", func(t *testing.T) {
 		stack := StackTrace{
 			{
 				Function:  "Method",
@@ -653,6 +711,22 @@ func TestFormat(t *testing.T) {
 
 		result := Format(stack)
 		expected := "github.com/example/pkg.(*MyStruct).Method\n\t/path/to/file.go:100"
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("frame with value receiver", func(t *testing.T) {
+		stack := StackTrace{
+			{
+				Function:  "Method",
+				File:      "/path/to/file.go",
+				Line:      100,
+				Namespace: "github.com/example/pkg",
+				ClassName: "MyStruct",
+			},
+		}
+
+		result := Format(stack)
+		expected := "github.com/example/pkg.MyStruct.Method\n\t/path/to/file.go:100"
 		require.Equal(t, expected, result)
 	})
 


### PR DESCRIPTION
### What does this PR do?

Parse unparenthesized value-receiver runtime symbols such as
`crypto.Hash.New` into their package, receiver, and method components.

The parser conservatively recognizes only unambiguous two-component method
symbols, preserving generic functions, closures, and compiler-generated
wrappers. Symbol parsing continues to use slices of the original string and
performs zero allocations. Stack formatting also preserves Go's original
unparenthesized representation for value receivers.

A regression test captures a real stack frame from a value-receiver method and
asserts its symbolicated class and function names.

### Motivation

Go only adds parentheses to pointer-receiver symbols. The symbolizer previously
looked exclusively for the `pkg.(*Type).Method` form, so value-receiver frames
reported no class name and folded the receiver into the function name.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.
