### PR TITLE
fix(ddtrace/tracer): align OTLP trace-metrics export with span metrics connector conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+### :warning: WARNING! This branch is no longer maintained. Development is now on the [`v1` branch](https://github.com/DataDog/dd-trace-go/tree/v1). Please consider upgrading using our [migration guide](https://github.com/DataDog/dd-trace-go/blob/v1/MIGRATING.md).
+
+---
+
 [![CircleCI](https://circleci.com/gh/DataDog/dd-trace-go/tree/master.svg?style=svg)](https://circleci.com/gh/DataDog/dd-trace-go/tree/master)
 [![Godoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/DataDog/dd-trace-go/opentracing)
 

--- a/tracer/ext/tracer.go
+++ b/tracer/ext/tracer.go
@@ -8,7 +8,7 @@ import (
 const (
 	Lang          = "go"
 	Interpreter   = runtime.Compiler + "-" + runtime.GOARCH + "-" + runtime.GOOS
-	TracerVersion = "v0.5.0"
+	TracerVersion = "v0.6.1"
 )
 
 var LangVersion = strings.TrimPrefix(runtime.Version(), Lang)


### PR DESCRIPTION
### What does this PR do?

Fixes several OTLP trace-metrics compliance gaps in `stats_to_otlp_metrics.go`, found during a cross-tracer audit against the OTel Span Metrics Connector's expected attribute conventions:

- `process_tags`: emit a single `datadog.process_tags` resource attribute (arrayValue) instead of per-key `datadog.<key>` resource attributes.
- `is_trace_root`: emit `datadog.is_trace_root` as a data-point attribute, reading the previously-unused `ClientGroupedStats.IsTraceRoot` field.
- `peer_tags`: emit `datadog.peer_tags` as a data-point attribute (arrayValue), mirroring the same peer-tag-key allowlist the `/v0.6/stats` path already uses, instead of always suppressing it.
- `additional_metric_tags`: emit each configured tag as its own unprefixed data-point attribute (support for this is still evolving across most SDKs).
- `span.kind`: canonicalize to the Span Metrics Connector's `SPAN_KIND_*` string convention (e.g. `SPAN_KIND_SERVER`) instead of the raw lowercase Datadog value.
- `status.code`: emit the Span Metrics Connector's `STATUS_CODE_OK`/`STATUS_CODE_ERROR` string convention (previously an OTel int enum), unconditionally on every data point.

All of the above except `additional_metric_tags` are gated by `!otelMode`, consistent with the existing `datadog.*` attribute suppression in OTel-semantics mode. `http.status_code`/gRPC status handling and `service.name` (already correct) are unaffected.

### Motivation

Companion cross-tracer fix: https://github.com/DataDog/system-tests/pull/7363

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.