### PR TITLE
fix(ddtrace/tracer): align OTLP trace-metrics export with span metrics connector conventions

### DIFF
--- a/ddtrace/tracer/stats.go
+++ b/ddtrace/tracer/stats.go
@@ -130,11 +130,8 @@ func (s *otlpStatsSender) shouldObfuscate() bool {
 	return true
 }
 
-func (s *otlpStatsSender) peerTags(_ []string) []string {
-	// Custom OTLP peer tags aren't implemented yet (spec: "Out of scope for
-	// SDK implementation"); suppress agent-advertised peer tags instead of
-	// leaving stale DD-agent state on an OTLP-routed concentrator.
-	return []string{}
+func (s *otlpStatsSender) peerTags(agentPeerTags []string) []string {
+	return agentPeerTags
 }
 
 func (s *otlpStatsSender) httpRouteFallback() bool {

--- a/ddtrace/tracer/stats_test.go
+++ b/ddtrace/tracer/stats_test.go
@@ -553,6 +553,11 @@ func TestShouldObfuscate(t *testing.T) {
 	}
 }
 
+func TestOTLPStatsSenderPeerTags(t *testing.T) {
+	s := &otlpStatsSender{}
+	assert.Equal(t, []string{"db.hostname"}, s.peerTags([]string{"db.hostname"}))
+}
+
 func TestObfuscation(t *testing.T) {
 	bucketSize := int64(500_000)
 	s1 := Span{

--- a/ddtrace/tracer/stats_to_otlp_metrics.go
+++ b/ddtrace/tracer/stats_to_otlp_metrics.go
@@ -50,7 +50,6 @@ var otelSpanKindByDDSpanKind = map[string]string{
 
 // statusCode* are the OTel Span Metrics Connector's string convention for the status.code attribute.
 const (
-	statusCodeUnset = "STATUS_CODE_UNSET"
 	statusCodeOK    = "STATUS_CODE_OK"
 	statusCodeError = "STATUS_CODE_ERROR"
 )
@@ -231,7 +230,9 @@ func buildDataPointAttributes(gs *pb.ClientGroupedStats, isError bool, otelMode 
 		}
 		// top_level is true only when all spans in the group were top-level (TopLevelHits == Hits).
 		attrs = append(attrs, otlpKeyValue("datadog.span.top_level", otlpBoolValue(gs.Hits > 0 && gs.TopLevelHits == gs.Hits)))
-		attrs = append(attrs, otlpKeyValue("datadog.is_trace_root", otlpBoolValue(gs.IsTraceRoot == pb.Trilean_TRUE)))
+		if gs.IsTraceRoot != pb.Trilean_NOT_SET {
+			attrs = append(attrs, otlpKeyValue("datadog.is_trace_root", otlpBoolValue(gs.IsTraceRoot == pb.Trilean_TRUE)))
+		}
 		if len(gs.PeerTags) > 0 {
 			attrs = append(attrs, otlpKeyValue("datadog.peer_tags", otlpStringArrayValue(gs.PeerTags)))
 		}

--- a/ddtrace/tracer/stats_to_otlp_metrics.go
+++ b/ddtrace/tracer/stats_to_otlp_metrics.go
@@ -246,7 +246,7 @@ func buildDataPointAttributes(gs *pb.ClientGroupedStats, isError bool, otelMode 
 }
 
 func isDatadogAttribute(key string) bool {
-	return strings.HasPrefix(key, "datadog.") || strings.HasPrefix(key, "_datadog.")
+	return strings.HasPrefix(key, "datadog.")
 }
 
 func otlpStringArrayValue(values []string) *otlpcommon.AnyValue {

--- a/ddtrace/tracer/stats_to_otlp_metrics.go
+++ b/ddtrace/tracer/stats_to_otlp_metrics.go
@@ -20,6 +20,7 @@ import (
 	otlpmetrics "go.opentelemetry.io/proto/otlp/metrics/v1"
 	otlpresource "go.opentelemetry.io/proto/otlp/resource/v1"
 
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 )
@@ -36,6 +37,23 @@ var grpcStatusCodeByNumber = map[int64]string{
 	10: "ABORTED", 11: "OUT_OF_RANGE", 12: "UNIMPLEMENTED", 13: "INTERNAL",
 	14: "UNAVAILABLE", 15: "DATA_LOSS", 16: "UNAUTHENTICATED",
 }
+
+// otelSpanKindByDDSpanKind maps Datadog span-kind values to the OTel Span Metrics Connector's
+// SPAN_KIND_* string convention.
+var otelSpanKindByDDSpanKind = map[string]string{
+	ext.SpanKindServer:   "SPAN_KIND_SERVER",
+	ext.SpanKindClient:   "SPAN_KIND_CLIENT",
+	ext.SpanKindProducer: "SPAN_KIND_PRODUCER",
+	ext.SpanKindConsumer: "SPAN_KIND_CONSUMER",
+	ext.SpanKindInternal: "SPAN_KIND_INTERNAL",
+}
+
+// statusCode* are the OTel Span Metrics Connector's string convention for the status.code attribute.
+const (
+	statusCodeUnset = "STATUS_CODE_UNSET"
+	statusCodeOK    = "STATUS_CODE_OK"
+	statusCodeError = "STATUS_CODE_ERROR"
+)
 
 // spanMetricBounds are histogram bucket boundaries (seconds), matching OTel Span Metrics Connector defaults.
 var spanMetricBounds = [16]float64{0.002, 0.004, 0.006, 0.008, 0.01, 0.05, 0.1, 0.2, 0.4, 0.8, 1, 1.4, 2, 5, 10, 15}
@@ -96,16 +114,9 @@ func buildMetricsResource(payload *pb.ClientStatsPayload, otelMode bool, reportH
 			attrs = append(attrs, otlpKeyValue("datadog.runtime_id", otlpStringValue(payload.RuntimeID)))
 		}
 		if payload.ProcessTags != "" {
-			for tag := range strings.SplitSeq(payload.ProcessTags, ",") {
-				parts := strings.SplitN(tag, ":", 2)
-				if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-					continue
-				}
-				// datadog.<key> resource attributes for all non-runtime_id process tags.
-				if parts[0] != "runtime_id" {
-					attrs = append(attrs, otlpKeyValue("datadog."+parts[0], otlpStringValue(parts[1])))
-				}
-			}
+			// Mirrors the same comma-separated ProcessTags string the /v0.6/stats (ddStatsSender) path sends as-is; update both if that shape changes.
+			tags := strings.Split(payload.ProcessTags, ",")
+			attrs = append(attrs, otlpKeyValue("datadog.process_tags", otlpStringArrayValue(tags)))
 		}
 	}
 	return &otlpresource.Resource{Attributes: attrs}
@@ -166,7 +177,11 @@ func buildDataPointAttributes(gs *pb.ClientGroupedStats, isError bool, defaultSe
 		attrs = append(attrs, otlpKeyValue("span.name", otlpStringValue(gs.Resource)))
 	}
 	if gs.SpanKind != "" {
-		attrs = append(attrs, otlpKeyValue("span.kind", otlpStringValue(gs.SpanKind)))
+		spanKind := gs.SpanKind
+		if canonical, ok := otelSpanKindByDDSpanKind[spanKind]; ok {
+			spanKind = canonical
+		}
+		attrs = append(attrs, otlpKeyValue("span.kind", otlpStringValue(spanKind)))
 	}
 	if gs.HTTPMethod != "" {
 		attrs = append(attrs, otlpKeyValue("http.request.method", otlpStringValue(gs.HTTPMethod)))
@@ -190,17 +205,23 @@ func buildDataPointAttributes(gs *pb.ClientGroupedStats, isError bool, defaultSe
 		// Non-numeric values are malformed for gRPC and are silently dropped rather than
 		// emitting a value that would change the attribute's type.
 	}
-	// status.code uses the OTel SpanStatus enum integers (UNSET=0, ERROR=2) as an intValue,
-	// per spec. It is emitted in both modes — in OTel-semantics mode it is the only signal
-	// for identifying error data points (datadog.* attributes are absent).
-	statusCode := int64(0) // STATUS_CODE_UNSET for non-error spans
+	statusCode := statusCodeOK
 	if isError {
-		statusCode = 2 // STATUS_CODE_ERROR
+		statusCode = statusCodeError
 	}
-	attrs = append(attrs, otlpKeyValue("status.code", otlpIntValue(statusCode)))
+	attrs = append(attrs, otlpKeyValue("status.code", otlpStringValue(statusCode)))
 
 	if svc := gs.Service; svc != "" && svc != defaultService {
 		attrs = append(attrs, otlpKeyValue("service.name", otlpStringValue(svc)))
+	}
+
+	// additional_metric_tags support is still evolving/TBD across most SDKs.
+	for _, tag := range gs.AdditionalMetricTags {
+		key, value, ok := strings.Cut(tag, ":")
+		if !ok || key == "" || value == "" {
+			continue
+		}
+		attrs = append(attrs, otlpKeyValue(key, otlpStringValue(value)))
 	}
 
 	// Datadog-specific attributes (default mode only).
@@ -213,6 +234,10 @@ func buildDataPointAttributes(gs *pb.ClientGroupedStats, isError bool, defaultSe
 		}
 		// top_level is true only when all spans in the group were top-level (TopLevelHits == Hits).
 		attrs = append(attrs, otlpKeyValue("datadog.span.top_level", otlpBoolValue(gs.Hits > 0 && gs.TopLevelHits == gs.Hits)))
+		attrs = append(attrs, otlpKeyValue("datadog.is_trace_root", otlpBoolValue(gs.IsTraceRoot == pb.Trilean_TRUE)))
+		if len(gs.PeerTags) > 0 {
+			attrs = append(attrs, otlpKeyValue("datadog.peer_tags", otlpStringArrayValue(gs.PeerTags)))
+		}
 		// ClientGroupedStats carries only a boolean Synthetics field; finer-grained
 		// origin values (synthetics-browser, rum, ciapp-test, lambda) are not available
 		// at the stats aggregation layer and require a proto change upstream to support.
@@ -222,6 +247,14 @@ func buildDataPointAttributes(gs *pb.ClientGroupedStats, isError bool, defaultSe
 	}
 
 	return attrs
+}
+
+func otlpStringArrayValue(values []string) *otlpcommon.AnyValue {
+	items := make([]*otlpcommon.AnyValue, 0, len(values))
+	for _, v := range values {
+		items = append(items, otlpStringValue(v))
+	}
+	return &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_ArrayValue{ArrayValue: &otlpcommon.ArrayValue{Values: items}}}
 }
 
 // sketchToHistogram decodes a proto-marshaled DDSketch (values in ns) and maps it into histogram

--- a/ddtrace/tracer/stats_to_otlp_metrics.go
+++ b/ddtrace/tracer/stats_to_otlp_metrics.go
@@ -59,7 +59,7 @@ const (
 var spanMetricBounds = [16]float64{0.002, 0.004, 0.006, 0.008, 0.01, 0.05, 0.1, 0.2, 0.4, 0.8, 1, 1.4, 2, 5, 10, 15}
 
 // buildOTLPMetricsRequest converts a ClientStatsPayload to OTLP ResourceMetrics (DELTA histogram).
-// Non-default services carry service.name as a data-point attribute. Returns nil when empty.
+// Returns nil when empty.
 func buildOTLPMetricsRequest(payload *pb.ClientStatsPayload, cfg *internalconfig.Config) []*otlpmetrics.ResourceMetrics {
 	otelMode := cfg.OTelSemanticsEnabled()
 
@@ -67,7 +67,7 @@ func buildOTLPMetricsRequest(payload *pb.ClientStatsPayload, cfg *internalconfig
 	for _, bucket := range payload.Stats {
 		bucketEnd := bucket.Start + bucket.Duration
 		for _, gs := range bucket.Stats {
-			pts := buildGroupDataPoints(gs, bucket.Start, bucketEnd, payload.Service, otelMode)
+			pts := buildGroupDataPoints(gs, bucket.Start, bucketEnd, otelMode)
 			allPoints = append(allPoints, pts...)
 		}
 	}
@@ -123,23 +123,22 @@ func buildMetricsResource(payload *pb.ClientStatsPayload, otelMode bool, reportH
 }
 
 // buildGroupDataPoints produces up to two OTLP histogram data points (ok + error) from a ClientGroupedStats.
-// Non-default services carry service.name as a data-point attribute.
-func buildGroupDataPoints(gs *pb.ClientGroupedStats, startNs, endNs uint64, defaultService string, otelMode bool) []*otlpmetrics.HistogramDataPoint {
+func buildGroupDataPoints(gs *pb.ClientGroupedStats, startNs, endNs uint64, otelMode bool) []*otlpmetrics.HistogramDataPoint {
 	var pts []*otlpmetrics.HistogramDataPoint
 	if len(gs.OkSummary) > 0 {
-		if dp := decodeAndBuildDataPoint(gs, gs.OkSummary, startNs, endNs, false, defaultService, otelMode); dp != nil {
+		if dp := decodeAndBuildDataPoint(gs, gs.OkSummary, startNs, endNs, false, otelMode); dp != nil {
 			pts = append(pts, dp)
 		}
 	}
 	if len(gs.ErrorSummary) > 0 {
-		if dp := decodeAndBuildDataPoint(gs, gs.ErrorSummary, startNs, endNs, true, defaultService, otelMode); dp != nil {
+		if dp := decodeAndBuildDataPoint(gs, gs.ErrorSummary, startNs, endNs, true, otelMode); dp != nil {
 			pts = append(pts, dp)
 		}
 	}
 	return pts
 }
 
-func decodeAndBuildDataPoint(gs *pb.ClientGroupedStats, sketchBytes []byte, startNs, endNs uint64, isError bool, defaultService string, otelMode bool) *otlpmetrics.HistogramDataPoint {
+func decodeAndBuildDataPoint(gs *pb.ClientGroupedStats, sketchBytes []byte, startNs, endNs uint64, isError bool, otelMode bool) *otlpmetrics.HistogramDataPoint {
 	bucketCounts, sum, minSec, maxSec, count, err := sketchToHistogram(sketchBytes, spanMetricBounds[:])
 	if err != nil {
 		log.Warn("stats_to_otlp_metrics: failed to decode sketch: %v", err.Error())
@@ -159,13 +158,13 @@ func decodeAndBuildDataPoint(gs *pb.ClientGroupedStats, sketchBytes []byte, star
 		Max:               &maxSec,
 		ExplicitBounds:    spanMetricBounds[:],
 		BucketCounts:      bucketCounts,
-		Attributes:        buildDataPointAttributes(gs, isError, defaultService, otelMode),
+		Attributes:        buildDataPointAttributes(gs, isError, otelMode),
 	}
 	return dp
 }
 
-// buildDataPointAttributes returns OTLP data-point attributes; adds service.name for non-default services.
-func buildDataPointAttributes(gs *pb.ClientGroupedStats, isError bool, defaultService string, otelMode bool) []*otlpcommon.KeyValue {
+// buildDataPointAttributes returns OTLP data-point attributes.
+func buildDataPointAttributes(gs *pb.ClientGroupedStats, isError bool, otelMode bool) []*otlpcommon.KeyValue {
 	var attrs []*otlpcommon.KeyValue
 
 	// OTel semantic-convention attributes.
@@ -211,9 +210,7 @@ func buildDataPointAttributes(gs *pb.ClientGroupedStats, isError bool, defaultSe
 	}
 	attrs = append(attrs, otlpKeyValue("status.code", otlpStringValue(statusCode)))
 
-	if svc := gs.Service; svc != "" && svc != defaultService {
-		attrs = append(attrs, otlpKeyValue("service.name", otlpStringValue(svc)))
-	}
+	attrs = append(attrs, otlpKeyValue("service.name", otlpStringValue(gs.Service)))
 
 	// additional_metric_tags support is still evolving/TBD across most SDKs.
 	for _, tag := range gs.AdditionalMetricTags {

--- a/ddtrace/tracer/stats_to_otlp_metrics.go
+++ b/ddtrace/tracer/stats_to_otlp_metrics.go
@@ -174,13 +174,11 @@ func buildDataPointAttributes(gs *pb.ClientGroupedStats, isError bool, otelMode 
 	if gs.Resource != "" {
 		attrs = append(attrs, otlpKeyValue("span.name", otlpStringValue(gs.Resource)))
 	}
-	if gs.SpanKind != "" {
-		spanKind := gs.SpanKind
-		if canonical, ok := otelSpanKindByDDSpanKind[spanKind]; ok {
-			spanKind = canonical
-		}
-		attrs = append(attrs, otlpKeyValue("span.kind", otlpStringValue(spanKind)))
+	spanKind := "SPAN_KIND_INTERNAL"
+	if canonical, ok := otelSpanKindByDDSpanKind[gs.SpanKind]; ok {
+		spanKind = canonical
 	}
+	attrs = append(attrs, otlpKeyValue("span.kind", otlpStringValue(spanKind)))
 	if gs.HTTPMethod != "" {
 		attrs = append(attrs, otlpKeyValue("http.request.method", otlpStringValue(gs.HTTPMethod)))
 	}
@@ -214,7 +212,7 @@ func buildDataPointAttributes(gs *pb.ClientGroupedStats, isError bool, otelMode 
 	// additional_metric_tags support is still evolving/TBD across most SDKs.
 	for _, tag := range gs.AdditionalMetricTags {
 		key, value, ok := strings.Cut(tag, ":")
-		if !ok || key == "" || value == "" {
+		if !ok || key == "" || value == "" || otelMode && isDatadogAttribute(key) {
 			continue
 		}
 		attrs = append(attrs, otlpKeyValue(key, otlpStringValue(value)))
@@ -245,6 +243,10 @@ func buildDataPointAttributes(gs *pb.ClientGroupedStats, isError bool, otelMode 
 	}
 
 	return attrs
+}
+
+func isDatadogAttribute(key string) bool {
+	return strings.HasPrefix(key, "datadog.") || strings.HasPrefix(key, "_datadog.")
 }
 
 func otlpStringArrayValue(values []string) *otlpcommon.AnyValue {

--- a/ddtrace/tracer/stats_to_otlp_metrics_test.go
+++ b/ddtrace/tracer/stats_to_otlp_metrics_test.go
@@ -206,8 +206,8 @@ func TestBuildOTLPMetricsRequestOkAndErrorDataPoints(t *testing.T) {
 }
 
 func TestBuildOTLPMetricsRequestMultipleServices(t *testing.T) {
-	// Multiple services in one payload share a single scope; the non-default service
-	// carries service.name as a data-point attribute.
+	// Multiple services in one payload share a single scope; every data point carries
+	// its own service.name attribute, regardless of whether it matches the payload's service.
 	cfg := internalconfig.CreateNew()
 	gs1 := &pb.ClientGroupedStats{Service: "svc-a", Resource: "res-a", OkSummary: encodeSketch(t, 50e6)}
 	gs2 := &pb.ClientGroupedStats{Service: "svc-b", Resource: "res-b", OkSummary: encodeSketch(t, 100e6)}
@@ -231,8 +231,8 @@ func TestBuildOTLPMetricsRequestMultipleServices(t *testing.T) {
 	}
 	require.NotNil(t, svcAPoint)
 	require.NotNil(t, svcBPoint)
-	assert.NotContains(t, kvAttrsToMap(svcAPoint.Attributes), "service.name", "default service omits service.name on data point")
-	assert.Equal(t, "svc-b", kvAttrsToMap(svcBPoint.Attributes)["service.name"], "non-default service carries service.name on data point")
+	assert.Equal(t, "svc-a", kvAttrsToMap(svcAPoint.Attributes)["service.name"])
+	assert.Equal(t, "svc-b", kvAttrsToMap(svcBPoint.Attributes)["service.name"])
 }
 
 // ---- Resource attributes ----
@@ -309,7 +309,7 @@ func TestDataPointAttributesOTelMode(t *testing.T) {
 		HTTPStatusCode: 200,
 		TopLevelHits:   1,
 	}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, "" /* defaultService */, true /* otelMode */))
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false, true /* otelMode */))
 	assert.Equal(t, "/users", m["span.name"])
 	assert.Equal(t, "SPAN_KIND_SERVER", m["span.kind"])
 	assert.Equal(t, "GET", m["http.request.method"])
@@ -327,7 +327,7 @@ func TestDataPointAttributesDefaultMode(t *testing.T) {
 		Hits:         1,
 		TopLevelHits: 1,
 	}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, "" /* defaultService */, false /* default mode */))
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false, false /* default mode */))
 	assert.Equal(t, "web.request", m["datadog.operation.name"])
 	assert.Equal(t, "web", m["datadog.span.type"])
 	assert.Equal(t, "true", m["datadog.span.top_level"])
@@ -336,37 +336,37 @@ func TestDataPointAttributesDefaultMode(t *testing.T) {
 func TestDataPointAttributesTopLevelFalse(t *testing.T) {
 	t.Run("no top-level spans in group", func(t *testing.T) {
 		gs := &pb.ClientGroupedStats{Resource: "child-resource", Hits: 1, TopLevelHits: 0}
-		m := kvAttrsToMap(buildDataPointAttributes(gs, false, "", false))
+		m := kvAttrsToMap(buildDataPointAttributes(gs, false, false))
 		assert.Equal(t, "false", m["datadog.span.top_level"])
 	})
 	t.Run("mixed group conservatively non-top-level", func(t *testing.T) {
 		gs := &pb.ClientGroupedStats{Resource: "mixed", Hits: 10, TopLevelHits: 5}
-		m := kvAttrsToMap(buildDataPointAttributes(gs, false, "", false))
+		m := kvAttrsToMap(buildDataPointAttributes(gs, false, false))
 		assert.Equal(t, "false", m["datadog.span.top_level"])
 	})
 }
 
 func TestDataPointAttributesStatusCode(t *testing.T) {
 	gs := &pb.ClientGroupedStats{Resource: "/ok"}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false /* isError */, "", true))
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false /* isError */, true))
 	assert.Equal(t, "STATUS_CODE_OK", m["status.code"])
 
 	gs = &pb.ClientGroupedStats{Resource: "/err"}
-	m = kvAttrsToMap(buildDataPointAttributes(gs, true /* isError */, "", true))
+	m = kvAttrsToMap(buildDataPointAttributes(gs, true /* isError */, true))
 	assert.Equal(t, "STATUS_CODE_ERROR", m["status.code"])
 }
 
 func TestDataPointAttributesIsTraceRoot(t *testing.T) {
 	gs := &pb.ClientGroupedStats{Resource: "root", IsTraceRoot: pb.Trilean_TRUE}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, "", false /* default mode */))
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false, false /* default mode */))
 	assert.Equal(t, "true", m["datadog.is_trace_root"])
 
 	gs = &pb.ClientGroupedStats{Resource: "child", IsTraceRoot: pb.Trilean_FALSE}
-	m = kvAttrsToMap(buildDataPointAttributes(gs, false, "", false))
+	m = kvAttrsToMap(buildDataPointAttributes(gs, false, false))
 	assert.Equal(t, "false", m["datadog.is_trace_root"])
 
 	gs = &pb.ClientGroupedStats{Resource: "unknown", IsTraceRoot: pb.Trilean_NOT_SET}
-	m = kvAttrsToMap(buildDataPointAttributes(gs, false, "", true /* otelMode */))
+	m = kvAttrsToMap(buildDataPointAttributes(gs, false, true /* otelMode */))
 	assert.NotContains(t, m, "datadog.is_trace_root")
 }
 
@@ -375,7 +375,7 @@ func TestDataPointAttributesAdditionalMetricTags(t *testing.T) {
 		Resource:             "/users",
 		AdditionalMetricTags: []string{"customer.tier:gold", "region:us-east-1", "malformed", "empty:"},
 	}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, "", true /* otelMode: not gated */))
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false, true /* otelMode: not gated */))
 	assert.Equal(t, "gold", m["customer.tier"])
 	assert.Equal(t, "us-east-1", m["region"])
 	assert.NotContains(t, m, "malformed")
@@ -387,14 +387,14 @@ func TestDataPointAttributesHTTPRoute(t *testing.T) {
 		Resource:     "web.request",
 		HTTPEndpoint: "/users/{id}",
 	}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, "", true))
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false, true))
 	assert.Equal(t, "/users/{id}", m["http.route"])
 }
 
 func TestDataPointAttributesOptionalFieldsAbsentWhenUnset(t *testing.T) {
 	// Optional OTel attributes are omitted when the corresponding source field is zero/empty.
 	gs := &pb.ClientGroupedStats{Resource: "op"}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, "", true))
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false, true))
 	assert.NotContains(t, m, "http.route")
 	assert.NotContains(t, m, "rpc.response.status_code")
 }
@@ -404,10 +404,10 @@ func TestDataPointAttributesPeerTags(t *testing.T) {
 		Resource: "postgres.query",
 		PeerTags: []string{"db.hostname:prod-db-1"},
 	}
-	values := kvArrayValue(buildDataPointAttributes(gs, false, "", false /* default mode */), "datadog.peer_tags")
+	values := kvArrayValue(buildDataPointAttributes(gs, false, false /* default mode */), "datadog.peer_tags")
 	assert.Contains(t, values, "db.hostname:prod-db-1")
 
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, "", true /* otelMode */))
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false, true /* otelMode */))
 	assert.NotContains(t, m, "datadog.peer_tags")
 }
 
@@ -419,31 +419,31 @@ func TestDataPointAttributesGRPCStatusCode(t *testing.T) {
 		"14": "UNAVAILABLE",
 	} {
 		gs := &pb.ClientGroupedStats{Resource: "grpc.request", GRPCStatusCode: code}
-		m := kvAttrsToMap(buildDataPointAttributes(gs, false, "", true))
+		m := kvAttrsToMap(buildDataPointAttributes(gs, false, true))
 		assert.Equal(t, name, m["rpc.response.status_code"], "code %s", code)
 	}
 	// Unknown numeric code: keep as integer (kvAttrsToMap renders it as a decimal string).
 	gs := &pb.ClientGroupedStats{Resource: "grpc.request", GRPCStatusCode: "99"}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, "", true))
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false, true))
 	assert.Equal(t, "99", m["rpc.response.status_code"])
 }
 
 func TestDataPointAttributesSyntheticsOrigin(t *testing.T) {
 	// Synthetics=true emits datadog.origin=synthetics in default mode.
 	gs := &pb.ClientGroupedStats{Resource: "web.request", Synthetics: true}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, "", false /* default mode */))
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false, false /* default mode */))
 	assert.Equal(t, "synthetics", m["datadog.origin"])
 }
 
 func TestDataPointAttributesSyntheticsOriginOmitted(t *testing.T) {
 	t.Run("otel mode", func(t *testing.T) {
 		gs := &pb.ClientGroupedStats{Resource: "web.request", Synthetics: true}
-		m := kvAttrsToMap(buildDataPointAttributes(gs, false, "", true))
+		m := kvAttrsToMap(buildDataPointAttributes(gs, false, true))
 		assert.NotContains(t, m, "datadog.origin")
 	})
 	t.Run("synthetics false", func(t *testing.T) {
 		gs := &pb.ClientGroupedStats{Resource: "web.request", Synthetics: false}
-		m := kvAttrsToMap(buildDataPointAttributes(gs, false, "", false))
+		m := kvAttrsToMap(buildDataPointAttributes(gs, false, false))
 		assert.NotContains(t, m, "datadog.origin")
 	})
 }
@@ -451,13 +451,18 @@ func TestDataPointAttributesSyntheticsOriginOmitted(t *testing.T) {
 func TestDataPointAttributesServiceName(t *testing.T) {
 	t.Run("non-default service carries service.name on data point", func(t *testing.T) {
 		gs := &pb.ClientGroupedStats{Service: "postgres", Resource: "SELECT"}
-		m := kvAttrsToMap(buildDataPointAttributes(gs, false, "my-app", false))
+		m := kvAttrsToMap(buildDataPointAttributes(gs, false, false))
 		assert.Equal(t, "postgres", m["service.name"])
 	})
-	t.Run("default service omits service.name on data point", func(t *testing.T) {
+	t.Run("service matching the default/global service is still emitted", func(t *testing.T) {
 		gs := &pb.ClientGroupedStats{Service: "my-app", Resource: "web.request"}
-		m := kvAttrsToMap(buildDataPointAttributes(gs, false, "my-app", false))
-		assert.NotContains(t, m, "service.name")
+		m := kvAttrsToMap(buildDataPointAttributes(gs, false, false))
+		assert.Equal(t, "my-app", m["service.name"])
+	})
+	t.Run("emitted in OTel-semantics mode too", func(t *testing.T) {
+		gs := &pb.ClientGroupedStats{Service: "my-app", Resource: "web.request"}
+		m := kvAttrsToMap(buildDataPointAttributes(gs, false, true /* otelMode */))
+		assert.Equal(t, "my-app", m["service.name"])
 	})
 }
 
@@ -518,6 +523,6 @@ func TestDataPointAttributesGRPCStatusCodeStringFallback(t *testing.T) {
 	// Non-numeric GRPCStatusCode is malformed; it is dropped rather than emitting a
 	// value that would change rpc.response.status_code's type across data points.
 	gs := &pb.ClientGroupedStats{Resource: "grpc.request", GRPCStatusCode: "CUSTOM_STATUS"}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, "", true))
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false, true))
 	assert.NotContains(t, m, "rpc.response.status_code")
 }

--- a/ddtrace/tracer/stats_to_otlp_metrics_test.go
+++ b/ddtrace/tracer/stats_to_otlp_metrics_test.go
@@ -366,7 +366,7 @@ func TestDataPointAttributesIsTraceRoot(t *testing.T) {
 	assert.Equal(t, "false", m["datadog.is_trace_root"])
 
 	gs = &pb.ClientGroupedStats{Resource: "unknown", IsTraceRoot: pb.Trilean_NOT_SET}
-	m = kvAttrsToMap(buildDataPointAttributes(gs, false, true /* otelMode */))
+	m = kvAttrsToMap(buildDataPointAttributes(gs, false, false))
 	assert.NotContains(t, m, "datadog.is_trace_root")
 }
 

--- a/ddtrace/tracer/stats_to_otlp_metrics_test.go
+++ b/ddtrace/tracer/stats_to_otlp_metrics_test.go
@@ -327,7 +327,6 @@ func TestDataPointAttributesOTelMode(t *testing.T) {
 		AdditionalMetricTags: []string{
 			"customer.tier:gold",
 			"datadog.custom:hidden",
-			"_datadog.legacy:hidden",
 		},
 	}
 	m := kvAttrsToMap(buildDataPointAttributes(gs, false, true /* otelMode */))
@@ -423,7 +422,6 @@ func TestDataPointAttributesAdditionalMetricTags(t *testing.T) {
 			"customer.tier:gold",
 			"region:us-east-1",
 			"datadog.custom:visible-by-default",
-			"_datadog.legacy:visible-by-default",
 			"malformed",
 			"empty:",
 		},
@@ -431,13 +429,11 @@ func TestDataPointAttributesAdditionalMetricTags(t *testing.T) {
 
 	defaultAttrs := kvAttrsToMap(buildDataPointAttributes(gs, false, false))
 	assert.Equal(t, "visible-by-default", defaultAttrs["datadog.custom"])
-	assert.Equal(t, "visible-by-default", defaultAttrs["_datadog.legacy"])
 
 	otelAttrs := kvAttrsToMap(buildDataPointAttributes(gs, false, true))
 	assert.Equal(t, "gold", otelAttrs["customer.tier"])
 	assert.Equal(t, "us-east-1", otelAttrs["region"])
 	assert.NotContains(t, otelAttrs, "datadog.custom")
-	assert.NotContains(t, otelAttrs, "_datadog.legacy")
 	assert.NotContains(t, otelAttrs, "malformed")
 	assert.NotContains(t, otelAttrs, "empty")
 }

--- a/ddtrace/tracer/stats_to_otlp_metrics_test.go
+++ b/ddtrace/tracer/stats_to_otlp_metrics_test.go
@@ -89,6 +89,20 @@ func kvArrayValue(kvs []*otlpcommon.KeyValue, key string) []string {
 	return nil
 }
 
+func assertOTLPBoolAttribute(t *testing.T, kvs []*otlpcommon.KeyValue, key string, want bool) {
+	t.Helper()
+	for _, kv := range kvs {
+		if kv.Key != key {
+			continue
+		}
+		value, ok := kv.Value.Value.(*otlpcommon.AnyValue_BoolValue)
+		require.True(t, ok, "%s must use an OTLP bool value", key)
+		assert.Equal(t, want, value.BoolValue)
+		return
+	}
+	require.Fail(t, "missing OTLP bool attribute", key)
+}
+
 // ---- sketchToHistogram ----
 
 func TestSketchToHistogramEmpty(t *testing.T) {
@@ -301,6 +315,7 @@ func TestBuildMetricsResourceOtelModeSuppressesDatadogAttrs(t *testing.T) {
 
 func TestDataPointAttributesOTelMode(t *testing.T) {
 	gs := &pb.ClientGroupedStats{
+		Service:        "api",
 		Name:           "web.request",
 		Resource:       "/users",
 		Type:           "web",
@@ -308,15 +323,24 @@ func TestDataPointAttributesOTelMode(t *testing.T) {
 		HTTPMethod:     "GET",
 		HTTPStatusCode: 200,
 		TopLevelHits:   1,
+		IsTraceRoot:    pb.Trilean_TRUE,
+		AdditionalMetricTags: []string{
+			"customer.tier:gold",
+			"datadog.custom:hidden",
+			"_datadog.legacy:hidden",
+		},
 	}
 	m := kvAttrsToMap(buildDataPointAttributes(gs, false, true /* otelMode */))
 	assert.Equal(t, "/users", m["span.name"])
 	assert.Equal(t, "SPAN_KIND_SERVER", m["span.kind"])
 	assert.Equal(t, "GET", m["http.request.method"])
 	assert.Equal(t, "200", m["http.response.status_code"])
-	assert.NotContains(t, m, "datadog.operation.name")
-	assert.NotContains(t, m, "datadog.span.type")
-	assert.NotContains(t, m, "datadog.span.top_level")
+	assert.Equal(t, "STATUS_CODE_OK", m["status.code"])
+	assert.Equal(t, "api", m["service.name"])
+	assert.Equal(t, "gold", m["customer.tier"])
+	for key := range m {
+		assert.False(t, isDatadogAttribute(key), "unexpected Datadog attribute %q", key)
+	}
 }
 
 func TestDataPointAttributesDefaultMode(t *testing.T) {
@@ -327,22 +351,23 @@ func TestDataPointAttributesDefaultMode(t *testing.T) {
 		Hits:         1,
 		TopLevelHits: 1,
 	}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, false /* default mode */))
+	attrs := buildDataPointAttributes(gs, false, false /* default mode */)
+	m := kvAttrsToMap(attrs)
 	assert.Equal(t, "web.request", m["datadog.operation.name"])
 	assert.Equal(t, "web", m["datadog.span.type"])
-	assert.Equal(t, "true", m["datadog.span.top_level"])
+	assertOTLPBoolAttribute(t, attrs, "datadog.span.top_level", true)
 }
 
 func TestDataPointAttributesTopLevelFalse(t *testing.T) {
 	t.Run("no top-level spans in group", func(t *testing.T) {
 		gs := &pb.ClientGroupedStats{Resource: "child-resource", Hits: 1, TopLevelHits: 0}
-		m := kvAttrsToMap(buildDataPointAttributes(gs, false, false))
-		assert.Equal(t, "false", m["datadog.span.top_level"])
+		attrs := buildDataPointAttributes(gs, false, false)
+		assertOTLPBoolAttribute(t, attrs, "datadog.span.top_level", false)
 	})
 	t.Run("mixed group conservatively non-top-level", func(t *testing.T) {
 		gs := &pb.ClientGroupedStats{Resource: "mixed", Hits: 10, TopLevelHits: 5}
-		m := kvAttrsToMap(buildDataPointAttributes(gs, false, false))
-		assert.Equal(t, "false", m["datadog.span.top_level"])
+		attrs := buildDataPointAttributes(gs, false, false)
+		assertOTLPBoolAttribute(t, attrs, "datadog.span.top_level", false)
 	})
 }
 
@@ -356,30 +381,65 @@ func TestDataPointAttributesStatusCode(t *testing.T) {
 	assert.Equal(t, "STATUS_CODE_ERROR", m["status.code"])
 }
 
+func TestDataPointAttributesSpanKind(t *testing.T) {
+	for name, tc := range map[string]struct {
+		spanKind string
+		want     string
+	}{
+		"known":   {spanKind: "client", want: "SPAN_KIND_CLIENT"},
+		"missing": {want: "SPAN_KIND_INTERNAL"},
+		"unknown": {spanKind: "invalid", want: "SPAN_KIND_INTERNAL"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			gs := &pb.ClientGroupedStats{SpanKind: tc.spanKind}
+			m := kvAttrsToMap(buildDataPointAttributes(gs, false, true))
+			assert.Equal(t, tc.want, m["span.kind"])
+		})
+	}
+}
+
 func TestDataPointAttributesIsTraceRoot(t *testing.T) {
 	gs := &pb.ClientGroupedStats{Resource: "root", IsTraceRoot: pb.Trilean_TRUE}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, false /* default mode */))
-	assert.Equal(t, "true", m["datadog.is_trace_root"])
+	attrs := buildDataPointAttributes(gs, false, false /* default mode */)
+	assertOTLPBoolAttribute(t, attrs, "datadog.is_trace_root", true)
 
 	gs = &pb.ClientGroupedStats{Resource: "child", IsTraceRoot: pb.Trilean_FALSE}
-	m = kvAttrsToMap(buildDataPointAttributes(gs, false, false))
-	assert.Equal(t, "false", m["datadog.is_trace_root"])
+	attrs = buildDataPointAttributes(gs, false, false)
+	assertOTLPBoolAttribute(t, attrs, "datadog.is_trace_root", false)
 
 	gs = &pb.ClientGroupedStats{Resource: "unknown", IsTraceRoot: pb.Trilean_NOT_SET}
-	m = kvAttrsToMap(buildDataPointAttributes(gs, false, false))
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false, false))
+	assert.NotContains(t, m, "datadog.is_trace_root")
+
+	gs = &pb.ClientGroupedStats{Resource: "root", IsTraceRoot: pb.Trilean_TRUE}
+	m = kvAttrsToMap(buildDataPointAttributes(gs, false, true /* otelMode */))
 	assert.NotContains(t, m, "datadog.is_trace_root")
 }
 
 func TestDataPointAttributesAdditionalMetricTags(t *testing.T) {
 	gs := &pb.ClientGroupedStats{
-		Resource:             "/users",
-		AdditionalMetricTags: []string{"customer.tier:gold", "region:us-east-1", "malformed", "empty:"},
+		Resource: "/users",
+		AdditionalMetricTags: []string{
+			"customer.tier:gold",
+			"region:us-east-1",
+			"datadog.custom:visible-by-default",
+			"_datadog.legacy:visible-by-default",
+			"malformed",
+			"empty:",
+		},
 	}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, true /* otelMode: not gated */))
-	assert.Equal(t, "gold", m["customer.tier"])
-	assert.Equal(t, "us-east-1", m["region"])
-	assert.NotContains(t, m, "malformed")
-	assert.NotContains(t, m, "empty")
+
+	defaultAttrs := kvAttrsToMap(buildDataPointAttributes(gs, false, false))
+	assert.Equal(t, "visible-by-default", defaultAttrs["datadog.custom"])
+	assert.Equal(t, "visible-by-default", defaultAttrs["_datadog.legacy"])
+
+	otelAttrs := kvAttrsToMap(buildDataPointAttributes(gs, false, true))
+	assert.Equal(t, "gold", otelAttrs["customer.tier"])
+	assert.Equal(t, "us-east-1", otelAttrs["region"])
+	assert.NotContains(t, otelAttrs, "datadog.custom")
+	assert.NotContains(t, otelAttrs, "_datadog.legacy")
+	assert.NotContains(t, otelAttrs, "malformed")
+	assert.NotContains(t, otelAttrs, "empty")
 }
 
 func TestDataPointAttributesHTTPRoute(t *testing.T) {

--- a/ddtrace/tracer/stats_to_otlp_metrics_test.go
+++ b/ddtrace/tracer/stats_to_otlp_metrics_test.go
@@ -68,6 +68,27 @@ func kvAttrsToMap(kvs []*otlpcommon.KeyValue) map[string]string {
 	return m
 }
 
+// kvArrayValue returns the stringValue elements of the named arrayValue attribute, or nil if absent/not an array.
+func kvArrayValue(kvs []*otlpcommon.KeyValue, key string) []string {
+	for _, kv := range kvs {
+		if kv.Key != key {
+			continue
+		}
+		arr, ok := kv.Value.Value.(*otlpcommon.AnyValue_ArrayValue)
+		if !ok {
+			return nil
+		}
+		out := make([]string, 0, len(arr.ArrayValue.Values))
+		for _, v := range arr.ArrayValue.Values {
+			if sv, ok := v.Value.(*otlpcommon.AnyValue_StringValue); ok {
+				out = append(out, sv.StringValue)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
 // ---- sketchToHistogram ----
 
 func TestSketchToHistogramEmpty(t *testing.T) {
@@ -249,35 +270,8 @@ func TestBuildMetricsResourceProcessTagsDefaultMode(t *testing.T) {
 	payload := makePayload("svc", "", "", nil)
 	payload.ProcessTags = "entrypoint.name:myapp,entrypoint.type:binary"
 	res := buildMetricsResource(payload, false /* otelMode */, false, "")
-	m := kvAttrsToMap(res.Attributes)
-	assert.Equal(t, "myapp", m["datadog.entrypoint.name"])
-	assert.Equal(t, "binary", m["datadog.entrypoint.type"])
-}
-
-func TestBuildMetricsResourceProcessTagsSkipsEmptyValue(t *testing.T) {
-	payload := makePayload("svc", "", "", nil)
-	payload.ProcessTags = "entrypoint.name:,entrypoint.type:binary"
-	res := buildMetricsResource(payload, false, false, "")
-	m := kvAttrsToMap(res.Attributes)
-	assert.NotContains(t, m, "datadog.entrypoint.name")
-	assert.Equal(t, "binary", m["datadog.entrypoint.type"])
-}
-
-func TestBuildMetricsResourceProcessTagsNoRuntimeIDDuplicate(t *testing.T) {
-	payload := makePayload("svc", "", "", nil)
-	payload.RuntimeID = "explicit-id"
-	payload.ProcessTags = "runtime_id:from-tags,entrypoint.name:myapp"
-	res := buildMetricsResource(payload, false, false, "")
-	m := kvAttrsToMap(res.Attributes)
-	// The explicit RuntimeID field wins; the ProcessTag must not create a second datadog.runtime_id.
-	assert.Equal(t, "explicit-id", m["datadog.runtime_id"])
-	var count int
-	for _, kv := range res.Attributes {
-		if kv.Key == "datadog.runtime_id" {
-			count++
-		}
-	}
-	assert.Equal(t, 1, count, "datadog.runtime_id should appear exactly once")
+	values := kvArrayValue(res.Attributes, "datadog.process_tags")
+	assert.ElementsMatch(t, []string{"entrypoint.name:myapp", "entrypoint.type:binary"}, values)
 }
 
 func TestBuildMetricsResourceRuntimeIDDefaultMode(t *testing.T) {
@@ -299,7 +293,7 @@ func TestBuildMetricsResourceOtelModeSuppressesDatadogAttrs(t *testing.T) {
 	payload.RuntimeID = "abc-123"
 	res := buildMetricsResource(payload, true /* otelMode */, false, "")
 	m := kvAttrsToMap(res.Attributes)
-	assert.NotContains(t, m, "datadog.entrypoint.name")
+	assert.NotContains(t, m, "datadog.process_tags")
 	assert.NotContains(t, m, "datadog.runtime_id")
 }
 
@@ -317,7 +311,7 @@ func TestDataPointAttributesOTelMode(t *testing.T) {
 	}
 	m := kvAttrsToMap(buildDataPointAttributes(gs, false, "" /* defaultService */, true /* otelMode */))
 	assert.Equal(t, "/users", m["span.name"])
-	assert.Equal(t, "server", m["span.kind"])
+	assert.Equal(t, "SPAN_KIND_SERVER", m["span.kind"])
 	assert.Equal(t, "GET", m["http.request.method"])
 	assert.Equal(t, "200", m["http.response.status_code"])
 	assert.NotContains(t, m, "datadog.operation.name")
@@ -353,15 +347,39 @@ func TestDataPointAttributesTopLevelFalse(t *testing.T) {
 }
 
 func TestDataPointAttributesStatusCode(t *testing.T) {
-	// Non-error: STATUS_CODE_UNSET (0) as intValue.
 	gs := &pb.ClientGroupedStats{Resource: "/ok"}
 	m := kvAttrsToMap(buildDataPointAttributes(gs, false /* isError */, "", true))
-	assert.Equal(t, "0", m["status.code"])
+	assert.Equal(t, "STATUS_CODE_OK", m["status.code"])
 
-	// Error: STATUS_CODE_ERROR (2) as intValue.
 	gs = &pb.ClientGroupedStats{Resource: "/err"}
 	m = kvAttrsToMap(buildDataPointAttributes(gs, true /* isError */, "", true))
-	assert.Equal(t, "2", m["status.code"])
+	assert.Equal(t, "STATUS_CODE_ERROR", m["status.code"])
+}
+
+func TestDataPointAttributesIsTraceRoot(t *testing.T) {
+	gs := &pb.ClientGroupedStats{Resource: "root", IsTraceRoot: pb.Trilean_TRUE}
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false, "", false /* default mode */))
+	assert.Equal(t, "true", m["datadog.is_trace_root"])
+
+	gs = &pb.ClientGroupedStats{Resource: "child", IsTraceRoot: pb.Trilean_FALSE}
+	m = kvAttrsToMap(buildDataPointAttributes(gs, false, "", false))
+	assert.Equal(t, "false", m["datadog.is_trace_root"])
+
+	gs = &pb.ClientGroupedStats{Resource: "unknown", IsTraceRoot: pb.Trilean_NOT_SET}
+	m = kvAttrsToMap(buildDataPointAttributes(gs, false, "", true /* otelMode */))
+	assert.NotContains(t, m, "datadog.is_trace_root")
+}
+
+func TestDataPointAttributesAdditionalMetricTags(t *testing.T) {
+	gs := &pb.ClientGroupedStats{
+		Resource:             "/users",
+		AdditionalMetricTags: []string{"customer.tier:gold", "region:us-east-1", "malformed", "empty:"},
+	}
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false, "", true /* otelMode: not gated */))
+	assert.Equal(t, "gold", m["customer.tier"])
+	assert.Equal(t, "us-east-1", m["region"])
+	assert.NotContains(t, m, "malformed")
+	assert.NotContains(t, m, "empty")
 }
 
 func TestDataPointAttributesHTTPRoute(t *testing.T) {
@@ -381,15 +399,16 @@ func TestDataPointAttributesOptionalFieldsAbsentWhenUnset(t *testing.T) {
 	assert.NotContains(t, m, "rpc.response.status_code")
 }
 
-func TestDataPointAttributesPeerTagsNotEmitted(t *testing.T) {
-	// peer.* tags and other non-grpc.method.name peer tags are not forwarded (out of scope per RFC).
+func TestDataPointAttributesPeerTags(t *testing.T) {
 	gs := &pb.ClientGroupedStats{
-		Resource: "web.request",
-		PeerTags: []string{"peer.service:db", "db.system:postgresql"},
+		Resource: "postgres.query",
+		PeerTags: []string{"db.hostname:prod-db-1"},
 	}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, "", true))
-	assert.NotContains(t, m, "peer.service")
-	assert.NotContains(t, m, "db.system")
+	values := kvArrayValue(buildDataPointAttributes(gs, false, "", false /* default mode */), "datadog.peer_tags")
+	assert.Contains(t, values, "db.hostname:prod-db-1")
+
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false, "", true /* otelMode */))
+	assert.NotContains(t, m, "datadog.peer_tags")
 }
 
 func TestDataPointAttributesGRPCStatusCode(t *testing.T) {


### PR DESCRIPTION
## Summary

Aligns Go OTLP trace metrics with the contract exercised by [system-tests#7363](https://github.com/DataDog/system-tests/pull/7363).

- Always emits `service.name` and string-valued `status.code`; canonicalizes `span.kind` to `SPAN_KIND_*` and defaults it to `SPAN_KIND_INTERNAL`.
- Emits `datadog.process_tags` as a resource array and `datadog.peer_tags` as a data-point array.
- Emits `datadog.is_trace_root` separately from `datadog.span.top_level`. Known true/false values use OTLP booleans; unknown trace-root is omitted.
- Emits configured additional metric tags as individual, unprefixed data-point attributes.
- In OTel semantic mode, retains OTel semantic and unprefixed custom attributes while suppressing `datadog.*` attributes.

## Validation

Added focused conversion and attribute tests, including boolean wire types and unknown trace-root behavior. `go test ./ddtrace/tracer -count=1` passes.
