### PR TITLE
fix(civisibility): avoid reusing Agent UDS client in agentless mode

### DIFF
--- a/ddtrace/tracer/civisibility_transport.go
+++ b/ddtrace/tracer/civisibility_transport.go
@@ -40,6 +40,7 @@ var _ ddTransport = (*ciVisibilityTransport)(nil)
 // to the Datadog endpoint, either in agentless mode or through the EVP proxy.
 type ciVisibilityTransport struct {
 	config           *config           // Configuration for the tracer.
+	httpClient       *http.Client      // HTTP client selected for the configured destination.
 	testCycleURLPath string            // URL path for the test cycle endpoint.
 	headers          map[string]string // HTTP headers to be included in the requests.
 	agentless        bool              // Gets if the transport is configured in agentless mode (eg: Gzip support)
@@ -74,10 +75,12 @@ func newCiVisibilityTransport(config *config) *ciVisibilityTransport {
 
 	// Determine if agentless mode is enabled (sourced from internal/config).
 	agentlessEnabled := config.internalConfig.CIVisibilityAgentless()
+	httpClient := config.httpClient
 
 	testCycleURL := ""
 	if agentlessEnabled {
 		// Agentless mode is enabled.
+		httpClient = internal.DefaultHTTPClient(config.internalConfig.AgentTimeout(), false)
 		APIKeyValue := config.internalConfig.APIKey()
 		if APIKeyValue == "" {
 			log.Error("An API key is required for agentless mode. Use the DD_API_KEY env variable to set it")
@@ -109,6 +112,7 @@ func newCiVisibilityTransport(config *config) *ciVisibilityTransport {
 
 	return &ciVisibilityTransport{
 		config:           config,
+		httpClient:       httpClient,
 		testCycleURLPath: testCycleURL,
 		headers:          defaultHeaders,
 		agentless:        agentlessEnabled,
@@ -176,7 +180,7 @@ func (t *ciVisibilityTransport) send(p payload) (body io.ReadCloser, err error) 
 	log.Debug("ciVisibilityTransport: sending transport request: %d bytes", buffer.Len())
 
 	startTime := time.Now()
-	response, err := t.config.httpClient.Do(req)
+	response, err := t.httpClient.Do(req)
 	telemetry.EndpointPayloadRequestsMs(telemetry.TestCycleEndpointType, float64(time.Since(startTime).Milliseconds()))
 	if err != nil {
 		return nil, err

--- a/ddtrace/tracer/civisibility_transport_test.go
+++ b/ddtrace/tracer/civisibility_transport_test.go
@@ -9,15 +9,20 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
+	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tinylib/msgp/msgp"
 
 	"github.com/DataDog/dd-trace-go/v2/internal"
@@ -119,6 +124,152 @@ func runTransportTest(t *testing.T, agentless, shouldSetAPIKey bool) {
 	}
 	assert.Equal(hits, len(testCases))
 	assert.Equal(remainingEvents, 0)
+}
+
+func TestCIVisibilityAgentlessDoesNotReuseAgentUDSClient(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix domain sockets are not available on Windows")
+	}
+
+	var intakeHits atomic.Int32
+	intake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		intakeHits.Add(1)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(intake.Close)
+
+	var agentHits atomic.Int32
+	socketPath := newCIVisibilityUDSServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		agentHits.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	t.Setenv(constants.CIVisibilityAgentlessEnabledEnvironmentVariable, "true")
+	t.Setenv(constants.CIVisibilityAgentlessURLEnvironmentVariable, intake.URL)
+	t.Setenv(constants.APIKeyEnvironmentVariable, "test-api-key")
+
+	cfg, err := newTestConfig()
+	require.NoError(t, err)
+	cfg.internalConfig.SetCIVisibilityEnabled(true, internalconfig.OriginCode)
+	cfg.internalConfig.SetAgentURL(&url.URL{Scheme: "unix", Path: socketPath}, internalconfig.OriginCode)
+	cfg.httpClient = internal.UDSClient(socketPath, defaultHTTPTimeout)
+	t.Cleanup(cfg.httpClient.CloseIdleConnections)
+
+	transport := newCiVisibilityTransport(cfg)
+	body, err := transport.send(newSingleEventCIVisibilityPayload(t))
+	if body != nil {
+		require.NoError(t, body.Close())
+	}
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, intakeHits.Load())
+	assert.EqualValues(t, 0, agentHits.Load())
+}
+
+func TestCIVisibilityAgentlessDoesNotUseCustomAgentHTTPClient(t *testing.T) {
+	var intakeHits atomic.Int32
+	intake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		intakeHits.Add(1)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(intake.Close)
+
+	t.Setenv(constants.CIVisibilityEnabledEnvironmentVariable, "true")
+	t.Setenv(constants.CIVisibilityAgentlessEnabledEnvironmentVariable, "true")
+	t.Setenv(constants.CIVisibilityAgentlessURLEnvironmentVariable, intake.URL)
+	t.Setenv(constants.APIKeyEnvironmentVariable, "test-api-key")
+
+	agentClient := &http.Client{Transport: &ErrTransport{}}
+	cfg, err := newTestConfig(WithHTTPClient(agentClient))
+	require.NoError(t, err)
+	transport, ok := cfg.ddTransport.(*ciVisibilityTransport)
+	require.True(t, ok)
+	t.Cleanup(transport.httpClient.CloseIdleConnections)
+
+	assert.NotSame(t, agentClient, transport.httpClient)
+	selectedTransport, ok := transport.httpClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	assert.Equal(t,
+		reflect.ValueOf(http.ProxyFromEnvironment).Pointer(),
+		reflect.ValueOf(selectedTransport.Proxy).Pointer(),
+		"agentless requests should continue to honor proxy environment variables",
+	)
+
+	body, err := transport.send(newSingleEventCIVisibilityPayload(t))
+	if body != nil {
+		require.NoError(t, body.Close())
+	}
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, intakeHits.Load())
+}
+
+func TestCIVisibilityAgentModeUsesAgentUDSClient(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix domain sockets are not available on Windows")
+	}
+
+	type agentRequest struct {
+		path      string
+		subdomain string
+	}
+	requests := make(chan agentRequest, 1)
+	socketPath := newCIVisibilityUDSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- agentRequest{
+			path:      r.URL.Path,
+			subdomain: r.Header.Get("X-Datadog-EVP-Subdomain"),
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+
+	t.Setenv(constants.CIVisibilityAgentlessEnabledEnvironmentVariable, "false")
+	cfg, err := newTestConfig()
+	require.NoError(t, err)
+	cfg.internalConfig.SetCIVisibilityEnabled(true, internalconfig.OriginCode)
+	cfg.internalConfig.SetAgentURL(&url.URL{Scheme: "unix", Path: socketPath}, internalconfig.OriginCode)
+	cfg.httpClient = internal.UDSClient(socketPath, defaultHTTPTimeout)
+	t.Cleanup(cfg.httpClient.CloseIdleConnections)
+
+	transport := newCiVisibilityTransport(cfg)
+	body, err := transport.send(newSingleEventCIVisibilityPayload(t))
+	if body != nil {
+		require.NoError(t, body.Close())
+	}
+	require.NoError(t, err)
+
+	request := <-requests
+	assert.Equal(t, "/evp_proxy/v2/api/v2/citestcycle", request.path)
+	assert.Equal(t, TestCycleSubdomain, request.subdomain)
+}
+
+func newCIVisibilityUDSServer(t *testing.T, handler http.Handler) string {
+	t.Helper()
+
+	socketDir, err := os.MkdirTemp("/tmp", "dd-trace-go-civisibility-uds-")
+	require.NoError(t, err)
+	socketPath := filepath.Join(socketDir, "apm.socket")
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+
+	server := &http.Server{Handler: handler}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.Serve(listener)
+	}()
+
+	t.Cleanup(func() {
+		require.NoError(t, server.Close())
+		require.ErrorIs(t, <-errCh, http.ErrServerClosed)
+		require.NoError(t, os.RemoveAll(socketDir))
+	})
+	return socketPath
+}
+
+func newSingleEventCIVisibilityPayload(t *testing.T) payload {
+	t.Helper()
+
+	p := newCiVisibilityPayload()
+	_, err := p.push(getCiVisibilityEvent(getTestTrace(1, 1)[0][0]))
+	require.NoError(t, err)
+	return p.payload
 }
 
 func TestCIVisibilityTransportSecureLogging(t *testing.T) {

--- a/ddtrace/tracer/civisibility_writer.go
+++ b/ddtrace/tracer/civisibility_writer.go
@@ -79,6 +79,9 @@ func (w *ciVisibilityTraceWriter) add(trace []*Span) {
 func (w *ciVisibilityTraceWriter) stop() {
 	w.flush()
 	w.wg.Wait()
+	if transport, ok := w.config.ddTransport.(*ciVisibilityTransport); ok {
+		transport.httpClient.CloseIdleConnections()
+	}
 }
 
 func (w *ciVisibilityTraceWriter) wait() { w.wg.Wait() }

--- a/ddtrace/tracer/civisibility_writer_test.go
+++ b/ddtrace/tracer/civisibility_writer_test.go
@@ -158,6 +158,7 @@ func TestCiVisibilityTraceWriterClosesHTTPResponseBody(t *testing.T) {
 		c.httpClient = server.Client()
 		c.ddTransport = &ciVisibilityTransport{
 			config:           c,
+			httpClient:       c.httpClient,
 			testCycleURLPath: server.URL,
 			headers:          map[string]string{"Content-Type": "application/msgpack"},
 			agentless:        false,


### PR DESCRIPTION
### What does this PR do?

Gives the CI Visibility test-cycle transport its own HTTP client selection:

- agent mode continues to reuse the Agent client, including Unix Domain Socket support;
- agentless mode creates a standard TCP HTTP client for the external intake;
- the agentless client continues to honor proxy environment variables; and
- idle connections owned by the CI Visibility transport are closed on shutdown.

This follows the same ownership model as the OTLP writer, which creates a dedicated HTTP client for its external endpoint instead of reusing the Agent client.

The regression coverage verifies that agentless requests reach the external intake rather than the Agent UDS, that `WithHTTPClient` remains scoped to Agent communication, and that Agent mode still uses the EVP endpoint over UDS.

### Motivation

Native Test Optimization exposed this bug on persistent `dd-go` runners using:

```text
DD_CIVISIBILITY_ENABLED=true
DD_CIVISIBILITY_AGENTLESS_ENABLED=true
DD_TRACE_AGENT_URL=unix:///var/run/datadog-agent/apm.socket
HTTPS_PROXY=http://127.0.0.1:15002
```

CI Visibility correctly selected the external test-cycle intake URL, but sent the request with the Agent's UDS HTTP client. Because that dialer ignores the requested network address, the request was delivered to the local Agent socket and failed with:

```text
Post "https://citestcycle-intake.datadoghq.com/api/v2/citestcycle": Not Found
```

The asynchronous transport failure did not fail the test process, so every native CI Visibility event could be lost while the job remained successful.

The original consumer investigation and runner diagnostics are tracked in [dd-go #7859](https://github.com/ddoghq/dd-go/pull/7859).

### Validation

- The new agentless + Agent UDS regression failed twice with `Not Found` before the fix and passes after it.
- `go test ./ddtrace/tracer -run 'TestCIVisibility|TestCiVisibility' -count=1`
- `go test -race ./ddtrace/tracer -run '^(TestCIVisibilityAgentlessDoesNotReuseAgentUDSClient|TestCIVisibilityAgentlessDoesNotUseCustomAgentHTTPClient|TestCIVisibilityAgentModeUsesAgentUDSClient)$' -count=1`
- `go test ./internal -run 'TestUDSClient|TestUnixDataSocketURL' -count=1`
- `go test ./internal/civisibility/utils/net -run 'UDS' -count=1`

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.
