### PR TITLE
fix(internal/config): stop forcing v0.4 when OTLP span metrics are enabled

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -331,8 +331,9 @@ func newConfig(opts ...StartOption) (*config, error) {
 	af := loadAgentFeatures(agentDisabled, agentURL, c.httpClient)
 	c.agent.store(af)
 	// If the agent doesn't support the v1 protocol, downgrade to v0.4.
-	// Also downgrade if CSS is disabled (v1 requires CSS). RequestedTraceProtocol()
-	// additionally returns v0.4 when OTLP span metrics are enabled (see internal/config).
+	// Also downgrade if CSS is disabled (v1 requires CSS); this is independent
+	// of OTLP span metrics, which no longer affect RequestedTraceProtocol()
+	// (see internal/config).
 	//
 	// Only the config is downgraded: the transport holds a URL per protocol and
 	// picks between them from the payload's own protocol at send time, so it has

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1556,19 +1556,13 @@ func (c *Config) SetOTelSemanticsEnabled(enabled bool, origin telemetry.Origin, 
 // asked for, by the user or by a derived override; it carries no information
 // about whether the trace-agent actually supports that protocol. Callers that
 // need the protocol in effect on the wire must combine this with agent
-// capability.
+// capability. It is independent of stats computation: both native Client-Side
+// Stats and OTLP span metrics are signalled out-of-band (the
+// Datadog-Client-Computed-Stats header and the separate /v0.6/stats endpoint)
+// and are handled identically by the Agent on either protocol.
 func (c *Config) RequestedTraceProtocol() float64 {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	// OTLP span metrics use their own concentrator and are not native CSS, so the trace
-	// transport must stay on v0.4 where the Datadog Agent can see the
-	// Datadog-Client-Computed-Stats header. Inline OTLPSpanMetricsEnabled logic to avoid
-	// a deadlock on c.mu.
-	otlpSpanMetrics := (c.otlpSpanMetricsEnabled != nil && *c.otlpSpanMetricsEnabled) ||
-		(c.otlpSpanMetricsEnabled == nil && c.otlpExportMode && c.runtimeMetricsOtel)
-	if otlpSpanMetrics {
-		return TraceProtocolV04
-	}
 	return c.traceProtocol
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -880,6 +880,23 @@ func TestOTLPSpanMetricsConfig(t *testing.T) {
 		assert.True(t, found, "expected a calculated-origin DD_TRACE_STATS_COMPUTATION_ENABLED report")
 	})
 
+	t.Run("does not force v0.4 trace protocol", func(t *testing.T) {
+		// Regression pin: RequestedTraceProtocol used to special-case
+		// OTLPSpanMetricsEnabled and return v0.4 unconditionally. The Agent has
+		// always accepted v1.0 payloads regardless of whether OTLP span metrics
+		// are in use, so that coupling is removed.
+		resetGlobalState()
+		defer resetGlobalState()
+
+		t.Setenv("OTEL_TRACES_SPAN_METRICS_ENABLED", "true")
+
+		cfg := Get()
+		require.NotNil(t, cfg)
+
+		assert.True(t, cfg.OTLPSpanMetricsEnabled())
+		assert.Equal(t, TraceProtocolV1, cfg.RequestedTraceProtocol())
+	})
+
 	t.Run("OTelSemanticsEnabled disabled by default", func(t *testing.T) {
 		resetGlobalState()
 		defer resetGlobalState()


### PR DESCRIPTION
## What does this PR do?

Part of a split of [#5122](https://github.com/DataDog/dd-trace-go/pull/5122) into a reviewable stack (see that PR for the full sequence). Stacked on [#5141](https://github.com/DataDog/dd-trace-go/pull/5141) — this PR's diff is scoped to just the change below; merge #5141 first.

`TraceProtocol` special-cased `OTLPSpanMetricsEnabled` and returned v0.4 unconditionally, on the rationale that the trace transport "must stay on v0.4 where the Datadog Agent can see the `Datadog-Client-Computed-Stats` header". That rationale doesn't hold: the header is a request header the Agent reads on either protocol, and OTLP span metrics are aggregated by their own concentrator and shipped over the separate `/v0.6/stats` endpoint. Neither depends on the `/vX/traces` wire format.

This is the same disproven reasoning as the CSS gate removed by #5122, applied to a second knob, so it goes the same way.

### Cross-repo dependency — already resolved

#5122's description flagged a prerequisite: `tests/parametric/test_otlp_trace_metrics.py:264` in `DataDog/system-tests` filtered trace requests on `("/v0.4/traces", "/v0.5/traces", "/v0.7/traces")`, omitting `/v1.0/traces`, so removing this coupling would make that filter return empty for the span-metrics test configuration.

That's already fixed: [DataDog/system-tests#7403](https://github.com/DataDog/system-tests/pull/7403) added `/v1.0/traces` to the tuple and merged on 2026-07-29, ahead of this PR. No further system-tests work is needed before this can land.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] All generated files are up to date. You can check this by running `make generate` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)