### PR TITLE
test(ddtrace/x/agenttest): make the mock agent's /info response configurable

### DIFF
--- a/ddtrace/tracer/tracertest.go
+++ b/ddtrace/tracer/tracertest.go
@@ -82,7 +82,13 @@ func handleV1Traces(r io.Reader) []*agenttest.Span {
 	if err != nil {
 		return spans
 	}
-	p := &payloadV1{buf: body}
+	// Must go through newPayloadV1: decodeBuffer calls updateHeader, which
+	// reslices header to its capacity and writes header[7]. A bare
+	// &payloadV1{} leaves header nil, so decoding panicked with an
+	// index-out-of-range. This went unnoticed because the handler was
+	// unreachable — the protocol gate always selected v0.4 here.
+	p := newPayloadV1()
+	p.buf = body
 	if _, err := p.decodeBuffer(); err != nil {
 		return spans
 	}
@@ -106,6 +112,14 @@ func startAgentTest(tb testing.TB) (agenttest.Agent, error) {
 	agent := agenttest.New()
 	agent.HandleTraces("/v0.4/traces", handleV04Traces)
 	agent.HandleTraces("/v1.0/traces", handleV1Traces)
+	// Suites built on bootstrapInspectableTracer/startInspectableTracer already
+	// run on v0.4, but only by accident: this mock advertises no /v0.6/stats, so
+	// client-side stats are unavailable and the tracer's protocol gate downgrades
+	// v1.0 -> v0.4 as a side effect. Pin the wire format on purpose instead —
+	// v1's chunk-level attribute hoisting (env, version, sampling priority) is
+	// not something every one of those suites has been audited against, and they
+	// should not flip encoders the next time that gate is touched.
+	agent.SetInfoEndpoints([]string{"/v0.4/traces"})
 	if err := agent.Start(tb); err != nil {
 		return nil, err
 	}

--- a/ddtrace/tracer/tracertest_v1_test.go
+++ b/ddtrace/tracer/tracertest_v1_test.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package tracer
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleV1TracesDecodesEncodedPayload covers handleV1Traces against a real
+// encoded v1.0 payload. The handler is registered by startAgentTest but has
+// never been reachable — the protocol gate always selects v0.4 for that mock —
+// so it went unexercised, and its bare &payloadV1{} literal left header nil,
+// panicking inside updateHeader on the first decode.
+func TestHandleV1TracesDecodesEncodedPayload(t *testing.T) {
+	p := newPayload(traceProtocolV1)
+	require.Equal(t, traceProtocolV1, p.protocol())
+
+	span := newSpan("v1.op", "v1.service", "v1.resource", 0, 0, 0)
+	_, err := p.push([]*Span{span})
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(p)
+	require.NoError(t, err)
+	require.NotEmpty(t, body)
+
+	spans := handleV1Traces(bytes.NewReader(body))
+	require.Len(t, spans, 1, "handleV1Traces must decode the payload it was handed")
+	assert.Equal(t, "v1.op", spans[0].Operation)
+	assert.Equal(t, "v1.service", spans[0].Service)
+	assert.Equal(t, "v1.resource", spans[0].Resource)
+}

--- a/ddtrace/x/agenttest/agent.go
+++ b/ddtrace/x/agenttest/agent.go
@@ -35,6 +35,13 @@ import (
 // Implementations handle a specific wire format (e.g. msgpack v0.4 or binary v1.0).
 type TraceHandler func(io.Reader) []*Span
 
+// statsPattern is the agent's client-side stats endpoint. New always registers
+// a no-op handler for it: SetInfoEndpoints lets a test advertise this path via
+// /info without a matching HandleTraces call, and the real agent's discovery
+// contract means "advertised" implies "reachable" — a test that advertises
+// stats support should not get spurious 404s when the tracer flushes stats.
+const statsPattern = "/v0.6/stats"
+
 // Info holds agent configuration returned to the tracer on flush responses,
 // such as per-service sampling rates.
 type Info struct {
@@ -112,6 +119,7 @@ func New() Agent {
 		info: newInfo(),
 	}
 	mux.HandleFunc("/info", a.handleInfo)
+	mux.HandleFunc(statsPattern, a.handleStats)
 	return a
 }
 
@@ -154,6 +162,14 @@ func (a *agent) handleInfo(w http.ResponseWriter, _ *http.Request) {
 	a.mu.Unlock()
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"endpoints": endpoints, "client_drop_p0s": true})
+}
+
+// handleStats discards client-side stats payloads and returns 200 OK. It exists
+// so that advertising statsPattern via SetInfoEndpoints doesn't lead the tracer
+// into a route the mock never serves.
+func (a *agent) handleStats(w http.ResponseWriter, r *http.Request) {
+	io.Copy(io.Discard, r.Body)
+	w.WriteHeader(http.StatusOK)
 }
 
 // Addr returns the agent address to pass to the tracer via WithAgentAddr.

--- a/ddtrace/x/agenttest/agent.go
+++ b/ddtrace/x/agenttest/agent.go
@@ -69,6 +69,14 @@ type Agent interface {
 	// Transport returns an optimized transport for interacting with the agent.
 	Transport() http.RoundTripper
 
+	// SetInfoEndpoints overrides the endpoints /info advertises, independent of
+	// which HTTP patterns are actually registered via HandleTraces. By default,
+	// /info advertises every registered pattern, mirroring the real agent
+	// discovery contract. Tests can use this to advertise or withhold specific
+	// endpoints (e.g. /v0.6/stats, /v1.0/traces) to control agent-capability-
+	// driven tracer behavior (such as trace protocol selection) deterministically.
+	SetInfoEndpoints(endpoints []string)
+
 	// FindSpan returns the first collected span matching all provided conditions,
 	// or nil if none is found.
 	FindSpan(...*SpanMatch) *Span
@@ -86,6 +94,11 @@ type agent struct {
 	addr      string
 	endpoints []string
 
+	// infoEndpoints, when non-nil, overrides endpoints as the value /info
+	// advertises. nil means "advertise every registered pattern" (the default,
+	// matching the real agent discovery contract).
+	infoEndpoints []string
+
 	info  *Info
 	spans []*Span
 }
@@ -102,6 +115,14 @@ func New() Agent {
 	return a
 }
 
+// SetInfoEndpoints overrides the endpoints /info advertises, independent of
+// which HTTP patterns are actually registered via HandleTraces.
+func (a *agent) SetInfoEndpoints(endpoints []string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.infoEndpoints = endpoints
+}
+
 // Info returns the agent info configuration (e.g. sampling rates).
 func (a *agent) Info() *Info {
 	return a.info
@@ -110,7 +131,9 @@ func (a *agent) Info() *Info {
 // HandleTraces registers a handler that decodes traces arriving at the given
 // HTTP pattern (e.g. "/v0.4/traces") and stores the resulting spans.
 func (a *agent) HandleTraces(pattern string, handler TraceHandler) {
+	a.mu.Lock()
 	a.endpoints = append(a.endpoints, pattern)
+	a.mu.Unlock()
 	a.mux.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
 		spans := handler(r.Body)
 		a.mu.Lock()
@@ -123,8 +146,14 @@ func (a *agent) HandleTraces(pattern string, handler TraceHandler) {
 }
 
 func (a *agent) handleInfo(w http.ResponseWriter, _ *http.Request) {
+	a.mu.Lock()
+	endpoints := a.endpoints
+	if a.infoEndpoints != nil {
+		endpoints = a.infoEndpoints
+	}
+	a.mu.Unlock()
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"endpoints": a.endpoints, "client_drop_p0s": true})
+	json.NewEncoder(w).Encode(map[string]any{"endpoints": endpoints, "client_drop_p0s": true})
 }
 
 // Addr returns the agent address to pass to the tracer via WithAgentAddr.

--- a/ddtrace/x/agenttest/agenttest_test.go
+++ b/ddtrace/x/agenttest/agenttest_test.go
@@ -254,3 +254,27 @@ func TestAgent_HandleTraces_InProcess(t *testing.T) {
 func newTestRequest(method, url string, body io.Reader) (*http.Request, error) {
 	return http.NewRequest(method, url, body)
 }
+
+// TestAgent_StatsEndpoint_AdvertisedIsReachable verifies that when a test
+// advertises the stats endpoint via SetInfoEndpoints (as its doc comment
+// suggests), a POST to that path actually succeeds instead of 404ing —
+// SetInfoEndpoints controls discovery, not routing.
+func TestAgent_StatsEndpoint_AdvertisedIsReachable(t *testing.T) {
+	a := New()
+	a.HandleTraces("/v0.4/traces", func(io.Reader) []*Span { return nil })
+	a.SetInfoEndpoints([]string{"/v0.4/traces", statsPattern})
+	if err := a.Start(t); err != nil {
+		t.Fatal(err)
+	}
+
+	rt := a.Transport()
+	req, _ := newTestRequest("POST", "http://"+a.Addr()+statsPattern, strings.NewReader("payload"))
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 for advertised stats endpoint, got %d", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

First in a split of [#5122](https://github.com/DataDog/dd-trace-go/pull/5122) into a reviewable stack of smaller PRs (see that PR for the full sequence and rationale). This PR is standalone against `main`.

The mock agent always advertised exactly the patterns registered via `HandleTraces`, which left tests unable to express "the agent serves this endpoint but does not advertise it" — the shape agent-capability negotiation actually has to cope with.

Adds `SetInfoEndpoints` to decouple what `/info` advertises from what is registered, and uses it to pin the `ddtrace/tracer` inspectable-tracer harness to v0.4 on purpose. Those suites already run on v0.4, but only as a side effect: the mock advertises no `/v0.6/stats`, so client-side stats are unavailable and the tracer's protocol gate downgrades v1.0 -> v0.4. Making the pin explicit is a no-op today and keeps the harness on a deterministic wire format the next time that gate is touched (removed later in this stack).

Also fixes `handleV1Traces`, found while testing this stack: it built a bare `&payloadV1{buf: body}`, leaving `header` nil, so `decodeBuffer` panicked with an index-out-of-range inside `updateHeader`. The handler had been registered but unreachable since it was written, because the gate always selected v0.4 for this mock, so the bug never surfaced. `TestHandleV1TracesDecodesEncodedPayload` reproduces the panic without the fix.

Also guards the `endpoints` slice with the existing mutex on both sides — `HandleTraces` appended to it unlocked while `handleInfo` read it.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] All generated files are up to date. You can check this by running `make generate` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)