### PR TITLE
refactor(ddtrace/tracer): derive the trace-intake URL from the payload's protocol

### DIFF
--- a/ddtrace/tracer/civisibility_transport.go
+++ b/ddtrace/tracer/civisibility_transport.go
@@ -215,11 +215,12 @@ func (t *ciVisibilityTransport) sendStats(*pb.ClientStatsPayload, int) error {
 	return nil
 }
 
-// endpoint returns the URL path of the test cycle endpoint.
+// endpoint returns the URL path of the test cycle endpoint. CI Visibility does
+// not use the Datadog trace protocol, so the protocol argument is ignored.
 //
 // Returns:
 //
 //	The URL path as a string.
-func (t *ciVisibilityTransport) endpoint() string {
+func (t *ciVisibilityTransport) endpoint(float64) string {
 	return t.testCycleURLPath
 }

--- a/ddtrace/tracer/log.go
+++ b/ddtrace/tracer/log.go
@@ -148,13 +148,15 @@ func logStartup(t *tracer) {
 		injectorNames = "custom"
 		extractorNames = "custom"
 	}
+	proto := t.config.internalConfig.TraceProtocol()
+
 	// Determine the agent URL to use in the logs.
 	// Use the source URL from internalConfig for unix sockets (before UDS rewriting).
 	var agentURL string
 	if srcURL := t.config.internalConfig.RawAgentURL(); srcURL != nil && srcURL.Scheme == "unix" {
 		agentURL = srcURL.String()
 	} else {
-		agentURL = t.config.ddTransport.endpoint()
+		agentURL = t.config.ddTransport.endpoint(proto)
 	}
 	info := startupInfo{
 		Date:                        time.Now().Format(time.RFC3339),
@@ -203,7 +205,7 @@ func logStartup(t *tracer) {
 	}
 	if !t.config.internalConfig.LogToStdout() {
 		startupHeaders := traceTransportHeaders(t.config.internalConfig)
-		if err := checkEndpoint(t.config.httpClient, t.config.ddTransport.endpoint(), t.config.internalConfig.TraceProtocol(), startupHeaders); err != nil {
+		if err := checkEndpoint(t.config.httpClient, t.config.ddTransport.endpoint(proto), proto, startupHeaders); err != nil {
 			info.AgentError = err.Error()
 			log.Warn("DIAGNOSTICS Unable to reach agent intake: %s", err.Error())
 		}

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -297,9 +297,8 @@ func newConfig(opts ...StartOption) (*config, error) {
 	processtags.SetServiceNameTag(c.internalConfig.ServiceName(), svcIsUserDefined)
 	if c.ddTransport == nil {
 		agentURL := c.internalConfig.AgentURL().String()
-		traceURL := resolveTraceURL(c.internalConfig)
 		headers := traceTransportHeaders(c.internalConfig)
-		c.ddTransport = newHTTPTransport(traceURL, agentURL+statsAPIPath, c.httpClient, headers)
+		c.ddTransport = newHTTPTransport(agentURL, c.httpClient, headers)
 	}
 	if c.propagator == nil {
 		extractFirst := c.internalConfig.PropagationExtractFirst()
@@ -334,11 +333,12 @@ func newConfig(opts ...StartOption) (*config, error) {
 	// If the agent doesn't support the v1 protocol, downgrade to v0.4.
 	// Also downgrade if CSS is disabled (v1 requires CSS). TraceProtocol() additionally
 	// returns v0.4 when OTLP span metrics are enabled (see internal/config).
+	//
+	// Only the config is downgraded: the transport holds a URL per protocol and
+	// picks between them from the payload's own protocol at send time, so it has
+	// nothing left to keep in sync with this decision.
 	if c.internalConfig.TraceProtocol() == traceProtocolV1 && (!af.v1ProtocolAvailable || !c.canComputeStats()) {
 		c.internalConfig.SetTraceProtocol(traceProtocolV04, internalconfig.OriginCalculated)
-		if t, ok := c.ddTransport.(*httpTransport); ok && t.traceURL == agentURL.String()+tracesAPIPathV1 {
-			t.traceURL = agentURL.String() + tracesAPIPath
-		}
 	}
 
 	info, ok := debug.ReadBuildInfo()
@@ -413,23 +413,10 @@ func apmTracingDisabled(c *config) {
 	c.internalConfig.SetRuntimeMetricsV2Enabled(false, internalconfig.OriginCalculated)
 }
 
-// resolveTraceURL returns the trace URL for the Datadog agent transport,
-// based on the configured trace protocol version. In OTLP export mode the
-// ddTransport is not used for trace sending (otlpTransport handles that),
-// but it may still be used for stats and agent discovery, so it always
-// points at the DD agent.
-func resolveTraceURL(cfg *internalconfig.Config) string {
-	agentURL := cfg.AgentURL().String()
-	if cfg.TraceProtocol() == traceProtocolV1 {
-		return agentURL + tracesAPIPathV1
-	}
-	return agentURL + tracesAPIPath
-}
-
 // traceTransportHeaders returns the headers to send with Datadog agent trace
-// transport requests. Unlike resolveTraceURL, this does not depend on the
-// trace protocol, so callers that only need headers (e.g. the startup
-// diagnostics probe) can call this without an extra TraceProtocol() read.
+// transport requests. This does not depend on the trace protocol, so callers
+// that only need headers (e.g. the startup diagnostics probe) can call this
+// without an extra protocol read.
 func traceTransportHeaders(cfg *internalconfig.Config) map[string]string {
 	headers := datadogHeaders()
 	if cfg.OTLPSpanMetricsEnabled() {
@@ -1539,7 +1526,7 @@ func (t *dummyTransport) send(p payload) (io.ReadCloser, error) {
 	return ok, nil
 }
 
-func (t *dummyTransport) endpoint() string {
+func (t *dummyTransport) endpoint(float64) string {
 	return "http://localhost:9/v1.0/traces"
 }
 
@@ -1565,7 +1552,7 @@ func (discardTransport) sendStats(*pb.ClientStatsPayload, int) error {
 	return nil
 }
 
-func (discardTransport) endpoint() string {
+func (discardTransport) endpoint(float64) string {
 	return "http://localhost:9/v1.0/traces"
 }
 

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1231,7 +1231,7 @@ func TestTracerNoDebugStack(t *testing.T) {
 
 // newDefaultTransport return a default transport for this tracing client
 func newDefaultTransport() ddTransport {
-	return newHTTPTransport(defaultURL+tracesAPIPath, defaultURL+statsAPIPath, internal.DefaultHTTPClient(defaultHTTPTimeout, true), datadogHeaders())
+	return newHTTPTransport(defaultURL, internal.DefaultHTTPClient(defaultHTTPTimeout, true), datadogHeaders())
 }
 
 func TestNewSpan(t *testing.T) {

--- a/ddtrace/tracer/transport.go
+++ b/ddtrace/tracer/transport.go
@@ -60,6 +60,14 @@ const (
 	statsAPIPath    = "/v0.6/stats"
 )
 
+// tracesPathFor returns the trace-intake path for the given protocol.
+func tracesPathFor(protocol float64) string {
+	if protocol == traceProtocolV1 {
+		return tracesAPIPathV1
+	}
+	return tracesAPIPath
+}
+
 // ddTransport is an interface for communicating data to the Datadog agent
 // using Datadog-specific protocols (msgpack traces, stats payloads).
 type ddTransport interface {
@@ -69,29 +77,44 @@ type ddTransport interface {
 	// sendStats sends the given stats payload to the agent.
 	// tracerObfuscationVersion is the version of obfuscation applied (0 if none was applied)
 	sendStats(s *pb.ClientStatsPayload, tracerObfuscationVersion int) error
-	// endpoint returns the URL to which the transport will send traces.
-	endpoint() string
+	// endpoint returns the URL to which the transport would send a trace payload
+	// encoded with the given protocol. Diagnostics only: the URL used for an
+	// actual send is always derived from the payload passed to send.
+	endpoint(protocol float64) string
 }
 
+// httpTransport holds one immutable URL per trace protocol, computed once at
+// construction. send() always picks the URL matching the payload's own
+// protocol, so the wire format and the endpoint it is posted to can never
+// diverge — there is no mutable "current protocol" to keep in sync.
 type httpTransport struct {
-	traceURL string            // the delivery URL for traces
-	statsURL string            // the delivery URL for stats
-	client   *http.Client      // the HTTP client used in the POST
-	headers  map[string]string // the Transport headers
+	traceURLV04 string            // the delivery URL for v0.4 trace payloads
+	traceURLV1  string            // the delivery URL for v1.0 trace payloads
+	statsURL    string            // the delivery URL for stats
+	client      *http.Client      // the HTTP client used in the POST
+	headers     map[string]string // the Transport headers
 }
 
 // newHTTPTransport returns a new Transport implementation that sends traces
-// to the given traceURL and stats to the given statsURL, using the provided
-// *http.Client and headers. The caller is responsible for providing the
-// appropriate headers (e.g. datadogHeaders() for Datadog mode, or OTLP
-// headers resolved from config).
-func newHTTPTransport(traceURL string, statsURL string, client *http.Client, headers map[string]string) *httpTransport {
+// and stats to agentBaseURL, using the provided *http.Client and headers. The
+// caller is responsible for providing the appropriate headers (e.g.
+// datadogHeaders() for Datadog mode, or OTLP headers resolved from config).
+func newHTTPTransport(agentBaseURL string, client *http.Client, headers map[string]string) *httpTransport {
 	return &httpTransport{
-		traceURL: traceURL,
-		statsURL: statsURL,
-		client:   client,
-		headers:  headers,
+		traceURLV04: agentBaseURL + tracesAPIPath,
+		traceURLV1:  agentBaseURL + tracesAPIPathV1,
+		statsURL:    agentBaseURL + statsAPIPath,
+		client:      client,
+		headers:     headers,
 	}
+}
+
+// traceURLFor returns the trace-intake URL for the given protocol.
+func (t *httpTransport) traceURLFor(protocol float64) string {
+	if protocol == traceProtocolV1 {
+		return t.traceURLV1
+	}
+	return t.traceURLV04
 }
 
 func datadogHeaders() map[string]string {
@@ -182,7 +205,8 @@ func (t *httpTransport) sendStats(p *pb.ClientStatsPayload, tracerObfuscationVer
 }
 
 func (t *httpTransport) send(p payload) (body io.ReadCloser, err error) {
-	req, err := http.NewRequest("POST", t.traceURL, p)
+	protocol := p.protocol()
+	req, err := http.NewRequest("POST", t.traceURLFor(protocol), p)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create http request: %s", err)
 	}
@@ -235,11 +259,11 @@ func (t *httpTransport) send(p payload) (body io.ReadCloser, err error) {
 	}
 	response, err := t.doWithStaleConnRetry(req)
 	if err != nil {
-		reportAPIErrorsMetric(response, err, tracesAPIPath)
+		reportAPIErrorsMetric(response, err, tracesPathFor(protocol))
 		return nil, err
 	}
 	if code := response.StatusCode; code >= 400 {
-		reportAPIErrorsMetric(response, err, tracesAPIPath)
+		reportAPIErrorsMetric(response, err, tracesPathFor(protocol))
 		// error, check the body for context information and
 		// return a nice error.
 		msg := make([]byte, 1000)
@@ -360,6 +384,6 @@ func reportAPIErrorsMetric(response *http.Response, err error, endpoint string) 
 	}
 }
 
-func (t *httpTransport) endpoint() string {
-	return t.traceURL
+func (t *httpTransport) endpoint(protocol float64) string {
+	return t.traceURLFor(protocol)
 }

--- a/ddtrace/tracer/transport_bench_test.go
+++ b/ddtrace/tracer/transport_bench_test.go
@@ -24,7 +24,7 @@ func BenchmarkHTTPTransportSend(b *testing.B) {
 	}))
 	defer server.Close()
 
-	transport := newHTTPTransport(server.URL+tracesAPIPath, server.URL+statsAPIPath, internal.DefaultHTTPClient(5*time.Second, false), datadogHeaders())
+	transport := newHTTPTransport(server.URL, internal.DefaultHTTPClient(5*time.Second, false), datadogHeaders())
 
 	payloadSizes := []struct {
 		name     string
@@ -69,7 +69,7 @@ func BenchmarkTransportSendConcurrent(b *testing.B) {
 	}))
 	defer server.Close()
 
-	transport := newHTTPTransport(server.URL+tracesAPIPath, server.URL+statsAPIPath, internal.DefaultHTTPClient(5*time.Second, false), datadogHeaders())
+	transport := newHTTPTransport(server.URL, internal.DefaultHTTPClient(5*time.Second, false), datadogHeaders())
 	concurrencyLevels := []int{1, 2, 4, 8}
 
 	for _, concurrency := range concurrencyLevels {

--- a/ddtrace/tracer/transport_payload_url_test.go
+++ b/ddtrace/tracer/transport_payload_url_test.go
@@ -1,0 +1,86 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package tracer
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
+	"github.com/DataDog/dd-trace-go/v2/internal/statsdtest"
+)
+
+// TestSendURLMatchesPayloadEvenAfterConfigChanges pins the invariant that makes
+// a wire-format/URL mismatch unrepresentable: send() picks its URL from the
+// payload's own protocol, never from live config. A payload encoded as v1.0
+// therefore still goes to /v1.0/traces even if the configured protocol changed
+// after it was created — the alternative (posting v1.0 bytes to /v0.4/traces)
+// is the failure this design rules out.
+func TestSendURLMatchesPayloadEvenAfterConfigChanges(t *testing.T) {
+	agent := startTestAgent(t)
+	tr := newTracerTest(t, agent)
+	defer stopTracerTest(tr)
+
+	require.Equal(t, traceProtocolV1, tr.config.internalConfig.TraceProtocol(),
+		"sanity check: the mock agent advertises /v1.0/traces and /v0.6/stats, so v1 must survive newConfig")
+
+	w := newAgentTraceWriter(tr.config, newPrioritySampler(), tr.statsd)
+	require.Equal(t, traceProtocolV1, w.payload.protocol(), "payload created while v1 was in effect must be v1")
+
+	// Change the configured protocol out from under the already-encoded payload.
+	tr.config.internalConfig.SetTraceProtocol(traceProtocolV04, internalconfig.OriginCalculated)
+	require.Equal(t, traceProtocolV04, tr.config.internalConfig.TraceProtocol(), "sanity check: config did change")
+
+	w.add([]*Span{makeSpan(1)})
+	w.flush()
+	w.wg.Wait()
+
+	assert.Equal(t, []string{tracesAPIPathV1}, agent.Requests(),
+		"the payload's own protocol must win, not the config's current protocol")
+}
+
+// TestSendReportsAPIErrorsWithCorrectEndpointTag covers a reporting bug the
+// per-protocol URLs make impossible: the api.errors metric hardcoded
+// /v0.4/traces, so a v1.0 send failure was attributed to the wrong endpoint.
+func TestSendReportsAPIErrorsWithCorrectEndpointTag(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/info" {
+			w.Write([]byte(`{"endpoints":["/v1.0/traces","/v0.6/stats"],"client_drop_p0s":true}`))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	var tg statsdtest.TestStatsdClient
+	trc, err := newTracer(WithAgentAddr(u.Host), withStatsdClient(&tg))
+	require.NoError(t, err)
+	setGlobalTracer(trc)
+	defer func() {
+		trc.Stop()
+		setGlobalTracer(&NoopTracer{})
+	}()
+
+	require.Equal(t, traceProtocolV1, trc.config.internalConfig.TraceProtocol(), "sanity check: agent must resolve to v1")
+
+	p := newPayload(traceProtocolV1)
+	_, err = p.push(getTestTrace(1, 1)[0])
+	require.NoError(t, err)
+
+	_, err = trc.config.ddTransport.send(p)
+	require.Error(t, err)
+
+	calls := statsdtest.FilterCallsByName(tg.IncrCalls(), "datadog.tracer.api.errors")
+	require.Len(t, calls, 1)
+	assert.Equal(t, []string{"reason:server_response_500", "endpoint:" + tracesAPIPathV1}, calls[0].Tags())
+}

--- a/ddtrace/tracer/transport_test.go
+++ b/ddtrace/tracer/transport_test.go
@@ -94,7 +94,7 @@ func TestTracesAgentIntegration(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		transport := newHTTPTransport(defaultURL+tracesAPIPath, defaultURL+statsAPIPath, internal.DefaultHTTPClient(defaultHTTPTimeout, false), datadogHeaders())
+		transport := newHTTPTransport(defaultURL, internal.DefaultHTTPClient(defaultHTTPTimeout, false), datadogHeaders())
 		p, err := encode(tc.payload)
 		assert.NoError(err)
 		body, err := transport.send(p)
@@ -171,7 +171,7 @@ func TestTransportResponse(t *testing.T) {
 				w.Write([]byte(tt.body))
 			}))
 			defer srv.Close()
-			transport := newHTTPTransport(srv.URL+tracesAPIPath, srv.URL+statsAPIPath, internal.DefaultHTTPClient(defaultHTTPTimeout, false), datadogHeaders())
+			transport := newHTTPTransport(srv.URL, internal.DefaultHTTPClient(defaultHTTPTimeout, false), datadogHeaders())
 			rc, err := transport.send(newPayload(traceProtocolV04))
 			if tt.err != "" {
 				assert.Equal(tt.err, err.Error())
@@ -231,7 +231,7 @@ func TestTraceCountHeader(t *testing.T) {
 	}))
 	defer srv.Close()
 	for _, tc := range testCases {
-		transport := newHTTPTransport(srv.URL+tracesAPIPath, srv.URL+statsAPIPath, internal.DefaultHTTPClient(defaultHTTPTimeout, false), datadogHeaders())
+		transport := newHTTPTransport(srv.URL, internal.DefaultHTTPClient(defaultHTTPTimeout, false), datadogHeaders())
 		p, err := encode(tc.payload)
 		assert.NoError(err)
 		_, err = transport.send(p)
@@ -273,7 +273,7 @@ func TestCustomTransport(t *testing.T) {
 
 	c := &http.Client{}
 	crt := wrapRecordingRoundTripper(c)
-	transport := newHTTPTransport(srv.URL+tracesAPIPath, srv.URL+statsAPIPath, c, datadogHeaders())
+	transport := newHTTPTransport(srv.URL, c, datadogHeaders())
 	p, err := encode(getTestTrace(1, 1))
 	assert.NoError(err)
 	_, err = transport.send(p)
@@ -538,8 +538,7 @@ func TestUDSTransportRecoversFromStaleIdleConn(t *testing.T) {
 	}()
 
 	transport := newHTTPTransport(
-		"http://localhost"+tracesAPIPath,
-		"http://localhost"+statsAPIPath,
+		"http://localhost",
 		internal.UDSClient(socketPath, 5*time.Second),
 		datadogHeaders(),
 	)
@@ -841,7 +840,7 @@ func TestConcurrentTraceFlushOverUDS(t *testing.T) {
 
 	udsURL := internal.UnixDataSocketURL(socketPath).String()
 	client := internal.UDSClient(socketPath, 5*time.Second)
-	transport := newHTTPTransport(udsURL+tracesAPIPath, udsURL+statsAPIPath, client, datadogHeaders())
+	transport := newHTTPTransport(udsURL, client, datadogHeaders())
 
 	const numGoroutines = 20
 

--- a/ddtrace/tracer/writer_test.go
+++ b/ddtrace/tracer/writer_test.go
@@ -827,7 +827,7 @@ func (t *simpleTransport) sendStats(s *pb.ClientStatsPayload, obfVersion int) er
 	return nil
 }
 
-func (t *simpleTransport) endpoint() string {
+func (t *simpleTransport) endpoint(float64) string {
 	return "http://localhost:9/v1.0/traces"
 }
 


### PR DESCRIPTION
## What does this PR do?

Second in a split of [#5122](https://github.com/DataDog/dd-trace-go/pull/5122) into a reviewable stack (see that PR for the full sequence). Stacked on [#5146](https://github.com/DataDog/dd-trace-go/pull/5146) — this PR's diff is scoped to just the change below; merge #5146 first.

`httpTransport` held a single mutable `traceURL` that had to be kept in step with the configured protocol. Keeping them in step was the caller's job: `newConfig` patched `traceURL` by string-comparing it against the v1 path whenever it downgraded the protocol, which only worked as long as every future protocol decision remembered to do the same.

Holds one immutable URL per protocol instead, computed once in `newHTTPTransport`, and has `send()` select between them from the payload's own `protocol()`. A payload is encoded for exactly one protocol and carries that with it, so wire format and destination can no longer diverge — not because a lock protects them, but because there is no shared mutable state left to desynchronize. `newConfig`'s URL patch-up goes away, and `resolveTraceURL` with it.

This also fixes `reportAPIErrorsMetric`, which passed a hardcoded `tracesAPIPath`: a failed v1.0 send was reported to `datadog.tracer.api.errors` tagged `endpoint:/v0.4/traces`.

`endpoint()` gains a protocol argument for the startup diagnostics probe. It is documented as diagnostics-only — an actual send never consults it, so it cannot reintroduce the mismatch.

No behaviour change beyond the metric tag: the protocol downgrade still happens in config, and the writer still reads it when creating a payload.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] All generated files are up to date. You can check this by running `make generate` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)