### PR TITLE
fix(ddtrace/tracer): re-evaluate agent v1.0 support at runtime

### DIFF
--- a/ddtrace/tracer/doc.go
+++ b/ddtrace/tracer/doc.go
@@ -161,4 +161,13 @@
 // version does not enable or disable stats computation. The protocol falls
 // back from 1.0 to 0.4 only when the Datadog Agent does not advertise the
 // /v1.0/traces endpoint.
+//
+// Agent capabilities are re-checked periodically, so this fallback is applied
+// at runtime and not only at startup: if a running Agent stops advertising
+// /v1.0/traces (for example after a rollback), the tracer switches to 0.4
+// without needing a restart. Re-upgrading to 1.0 requires several consecutive
+// positive checks, so an intermittently-capable Agent settles on 0.4 rather
+// than alternating wire formats. Traces already encoded as 1.0 when the
+// downgrade lands are still sent to /v1.0/traces and may be rejected, so a
+// downgrade can cost up to one flush interval of buffered traces.
 package tracer // import "github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -478,7 +478,13 @@ type agentFeatures struct {
 	// evpProxyV2 reports if the trace-agent can receive payloads on the /evp_proxy/v2 endpoint.
 	evpProxyV2 bool
 
-	// v1ProtocolAvailable reports whether the trace-agent and tracer are configured to use the v1 protocol.
+	// v1ProtocolAvailable reports whether the trace-agent advertises /v1.0/traces.
+	// Unlike most other fields here, this is refreshed on every /info poll (see
+	// refreshAgentFeatures) rather than frozen at startup, and it is consumed
+	// only at point of use — by (*config).effectiveTraceProtocol (and its
+	// snapshot variant effectiveTraceProtocolWithAgent) and by httpTransport.send
+	// via the payload's own protocol — so there is nothing baked into a component
+	// that a poll could desynchronize from it.
 	v1ProtocolAvailable bool
 
 	// hasTelemetryProxy reports whether the trace-agent exposes the /telemetry/proxy/ endpoint.

--- a/ddtrace/tracer/poll_agent_info_test.go
+++ b/ddtrace/tracer/poll_agent_info_test.go
@@ -7,6 +7,7 @@ package tracer
 
 import (
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -16,6 +17,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/log"
 )
 
 // withAgentInfoPollInterval is a test-only StartOption that overrides the
@@ -62,6 +65,15 @@ func TestRefreshAgentFeaturesUpdatesTraceFilters(t *testing.T) {
 // TestRefreshAgentFeaturesPreservesStaticFields verifies that a call to
 // refreshAgentFeatures preserves fields that are baked into components at
 // startup, while still updating dynamic fields.
+//
+// v1ProtocolAvailable is DELIBERATELY not one of the frozen fields here — it
+// used to be, but nothing bakes it into a component anymore (the trace URL and
+// payload encoding are both derived per-use from the current agent snapshot),
+// so it is now safe, and necessary, to refresh it like the other dynamic
+// fields. A downgrade (as exercised by this test's poll response) applies on
+// the very first negative poll; only re-upgrading to v1 after a downgrade
+// requires v1ProtocolUpgradeStreak consecutive positive polls — see
+// refreshAgentFeatures. Do not "restore" the old freeze.
 func TestRefreshAgentFeaturesPreservesStaticFields(t *testing.T) {
 	// callCount tracks how many times the /info endpoint is hit.
 	var callCount atomic.Int32
@@ -128,8 +140,12 @@ func TestRefreshAgentFeaturesPreservesStaticFields(t *testing.T) {
 	assert.Zero(t, after.obfuscationVersion, "obfuscationVersion must update dynamically")
 	assert.Empty(t, after.peerTags, "peerTags must update dynamically")
 
+	// v1ProtocolAvailable is dynamic: the poll response advertises no
+	// /v1.0/traces, so a downgrade must apply immediately (see comment above).
+	require.True(t, startup.v1ProtocolAvailable, "sanity check: startup snapshot must have advertised v1")
+	assert.False(t, after.v1ProtocolAvailable, "v1ProtocolAvailable must update dynamically")
+
 	// Static fields must be frozen at their startup values.
-	assert.Equal(t, startup.v1ProtocolAvailable, after.v1ProtocolAvailable, "v1ProtocolAvailable must not change after startup")
 	assert.Equal(t, startup.StatsdPort, after.StatsdPort, "StatsdPort must not change after startup")
 	assert.Equal(t, startup.evpProxyV2, after.evpProxyV2, "evpProxyV2 must not change after startup")
 	assert.Equal(t, startup.metaStructAvailable, after.metaStructAvailable, "metaStructAvailable must not change after startup")
@@ -297,4 +313,208 @@ func TestPollAgentInfoRetainsLastKnownGoodOn404(t *testing.T) {
 
 	assert.True(t, tr.config.agent.load().DropP0s, "DropP0s must be retained on 404 poll")
 	assert.True(t, tr.config.agent.load().spanEventsAvailable, "spanEventsAvailable must be retained on 404 poll")
+}
+
+// TestTraceProtocolDowngradesOn404AfterAgentRollback pins the fix for the
+// bug where a v1-capable agent that gets rolled back to a version predating
+// /info support (404 on /info) kept v1ProtocolAvailable=true forever,
+// because a 404 was treated the same as any other fetch error ("keep
+// last-known-good"). A 404 on /info is actually positive evidence v1 is
+// gone: /v1.0/traces support postdates /info support, so an agent without
+// /info cannot serve v1 either.
+func TestTraceProtocolDowngradesOn404AfterAgentRollback(t *testing.T) {
+	var return404 atomic.Bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if return404.Load() {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"endpoints":       []string{"/v0.4/traces", "/v1.0/traces", "/v0.6/stats"},
+			"client_drop_p0s": true,
+		})
+	}))
+	defer srv.Close()
+
+	tr, err := newTracer(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")), WithAgentTimeout(2))
+	require.NoError(t, err)
+	defer tr.Stop()
+
+	require.Equal(t, traceProtocolV1, tr.config.effectiveTraceProtocol(), "sanity check: startup must resolve to v1")
+	require.True(t, tr.config.agent.load().DropP0s, "sanity check: DropP0s must be set at startup")
+
+	// Simulate the agent being rolled back to a version without /info.
+	return404.Store(true)
+	tr.refreshAgentFeatures()
+
+	assert.False(t, tr.config.agent.load().v1ProtocolAvailable, "v1ProtocolAvailable must clear on the first 404 poll")
+	assert.Equal(t, traceProtocolV04, tr.config.effectiveTraceProtocol(), "a 404 on /info must downgrade the effective protocol immediately")
+	assert.True(t, tr.config.agent.load().DropP0s, "unrelated last-known-good fields must be retained on a 404 poll")
+}
+
+// TestTraceProtocolUpgradesAfterAgentBecomesReachable is the fix for the
+// permanent-downgrade bug: previously, a startup /info failure froze the
+// trace protocol at v0.4 for the tracer's entire lifetime, even once the
+// agent became reachable. v1ProtocolAvailable is now refreshed dynamically,
+// so a later successful poll can upgrade back to v1.
+func TestTraceProtocolUpgradesAfterAgentBecomesReachable(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close()) // agent unreachable at startup
+
+	tr, err := newTracer(WithAgentAddr(addr), WithAgentTimeout(1))
+	require.NoError(t, err)
+	defer tr.Stop()
+
+	require.False(t, tr.config.agent.load().v1ProtocolAvailable, "sanity check: agent must be unreachable at startup")
+	require.Equal(t, traceProtocolV04, tr.config.effectiveTraceProtocol())
+	require.Equal(t, traceProtocolV1, tr.config.internalConfig.RequestedTraceProtocol(),
+		"the requested value must never be touched by a capability downgrade")
+
+	// Bring an agent up on the exact same address, advertising v1.
+	ln2, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/info" {
+			w.Write([]byte(`{"endpoints":["/v0.4/traces","/v1.0/traces","/v0.6/stats"],"client_drop_p0s":true}`))
+		}
+	}))
+	srv.Listener.Close()
+	srv.Listener = ln2
+	srv.Start()
+	defer srv.Close()
+
+	// v1ProtocolUpgradeStreak consecutive positive polls are required before
+	// the tracer trusts the agent enough to re-upgrade.
+	for range v1ProtocolUpgradeStreak {
+		tr.refreshAgentFeatures()
+	}
+
+	assert.True(t, tr.config.agent.load().v1ProtocolAvailable, "v1 must become available once the agent is reachable")
+	assert.Equal(t, traceProtocolV1, tr.config.effectiveTraceProtocol(), "the tracer must upgrade to v1 once the agent proves reachable")
+}
+
+// TestTraceProtocolDowngradesImmediatelyOnInfoPoll pins that a downgrade
+// (unlike an upgrade) applies on the very first negative poll, and that the
+// requested protocol survives the downgrade unmodified.
+func TestTraceProtocolDowngradesImmediatelyOnInfoPoll(t *testing.T) {
+	var advertiseV1 atomic.Bool
+	advertiseV1.Store(true)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		endpoints := []string{"/v0.4/traces", "/v0.6/stats"}
+		if advertiseV1.Load() {
+			endpoints = []string{"/v0.4/traces", "/v1.0/traces", "/v0.6/stats"}
+		}
+		json.NewEncoder(w).Encode(map[string]any{"endpoints": endpoints, "client_drop_p0s": true}) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	tr, err := newTracer(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")), WithAgentTimeout(2))
+	require.NoError(t, err)
+	defer tr.Stop()
+
+	require.Equal(t, traceProtocolV1, tr.config.effectiveTraceProtocol(), "sanity check: startup must resolve to v1")
+
+	advertiseV1.Store(false)
+	tr.refreshAgentFeatures()
+
+	assert.Equal(t, traceProtocolV04, tr.config.effectiveTraceProtocol(), "a downgrade must apply on the first negative poll")
+	assert.Equal(t, traceProtocolV1, tr.config.internalConfig.RequestedTraceProtocol(), "the requested value must survive the downgrade")
+}
+
+// TestTraceProtocolUpgradeNeedsConsecutivePolls pins the asymmetric
+// hysteresis: after a downgrade, a single positive poll is not enough to
+// re-upgrade to v1.
+func TestTraceProtocolUpgradeNeedsConsecutivePolls(t *testing.T) {
+	require.Greater(t, v1ProtocolUpgradeStreak, 1, "test assumes the threshold is more than one poll")
+
+	var advertiseV1 atomic.Bool // starts false: agent doesn't support v1 at startup
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		endpoints := []string{"/v0.4/traces", "/v0.6/stats"}
+		if advertiseV1.Load() {
+			endpoints = []string{"/v0.4/traces", "/v1.0/traces", "/v0.6/stats"}
+		}
+		json.NewEncoder(w).Encode(map[string]any{"endpoints": endpoints, "client_drop_p0s": true}) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	tr, err := newTracer(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")), WithAgentTimeout(2))
+	require.NoError(t, err)
+	defer tr.Stop()
+
+	require.Equal(t, traceProtocolV04, tr.config.effectiveTraceProtocol(), "sanity check: v1 must be unavailable at startup")
+
+	advertiseV1.Store(true)
+	tr.refreshAgentFeatures() // just one positive poll
+	assert.Equal(t, traceProtocolV04, tr.config.effectiveTraceProtocol(), "one positive poll must not be enough to re-upgrade")
+
+	for i := 1; i < v1ProtocolUpgradeStreak; i++ {
+		tr.refreshAgentFeatures()
+	}
+	assert.Equal(t, traceProtocolV1, tr.config.effectiveTraceProtocol(), "v1ProtocolUpgradeStreak consecutive positive polls must upgrade")
+}
+
+// TestTraceProtocolFlappingConvergesToV04 verifies that an agent whose
+// advertised endpoints alternate every poll never accumulates enough
+// consecutive positive polls to reach the upgrade streak, and stays on the
+// universally-safe v0.4 instead of oscillating the wire format.
+func TestTraceProtocolFlappingConvergesToV04(t *testing.T) {
+	var toggle atomic.Bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		v1 := toggle.Load()
+		toggle.Store(!v1)
+		endpoints := []string{"/v0.4/traces", "/v0.6/stats"}
+		if v1 {
+			endpoints = []string{"/v0.4/traces", "/v1.0/traces", "/v0.6/stats"}
+		}
+		json.NewEncoder(w).Encode(map[string]any{"endpoints": endpoints, "client_drop_p0s": true}) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	tr, err := newTracer(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")), WithAgentTimeout(2))
+	require.NoError(t, err)
+	defer tr.Stop()
+
+	for range v1ProtocolUpgradeStreak * 3 {
+		tr.refreshAgentFeatures()
+		assert.Equal(t, traceProtocolV04, tr.config.effectiveTraceProtocol(), "an alternating agent must never accumulate a positive streak")
+	}
+}
+
+// TestTraceProtocolChangeLoggedOncePerTransition verifies that repeated,
+// identical polls do not re-log (or re-report to config telemetry) an
+// unchanged effective protocol — ReportEffectiveTraceProtocol dedupes so a
+// periodic poll cannot spam config telemetry seqIDs.
+func TestTraceProtocolChangeLoggedOncePerTransition(t *testing.T) {
+	tp := new(log.RecordLogger)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"endpoints":       []string{"/v0.4/traces", "/v0.6/stats"}, // no v1: startup resolves to v0.4
+			"client_drop_p0s": true,
+		})
+	}))
+	defer srv.Close()
+
+	tr, err := newTracer(WithAgentAddr(strings.TrimPrefix(srv.URL, "http://")), WithAgentTimeout(2), WithLogger(tp))
+	require.NoError(t, err)
+	defer tr.Stop()
+
+	tp.Reset()
+	for range 5 {
+		tr.refreshAgentFeatures() // /info response never changes
+	}
+
+	var changes int
+	for _, l := range tp.Logs() {
+		if strings.Contains(l, "trace protocol changed") {
+			changes++
+		}
+	}
+	assert.Zero(t, changes, "an unchanged effective protocol must never re-log a transition")
 }

--- a/ddtrace/tracer/trace_protocol_runtime_test.go
+++ b/ddtrace/tracer/trace_protocol_runtime_test.go
@@ -1,0 +1,122 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package tracer
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// isV04WireByte reports whether b is the first byte of a msgpack array — the
+// shape of a v0.4 trace payload.
+func isV04WireByte(b byte) bool {
+	return b == msgpackArray16 || b == msgpackArray32 || b&0xf0 == msgpackArrayFix
+}
+
+// TestEmptyPayloadRotatesOnProtocolDowngrade pins that an idle writer does not
+// hold a stale v1 payload after the agent withdraws /v1.0/traces. flush() is
+// the only place that re-reads the effective protocol, and it early-returns on
+// an empty payload — so without the rotation a writer that saw no traffic
+// across the downgrade keeps its v1 payload indefinitely, and the first trace
+// to arrive afterwards is POSTed to /v1.0/traces and rejected.
+func TestEmptyPayloadRotatesOnProtocolDowngrade(t *testing.T) {
+	agent := startTestAgent(t)
+	tr := newTracerTest(t, agent, WithSendRetries(0))
+	defer stopTracerTest(tr)
+
+	require.Equal(t, traceProtocolV1, tr.config.effectiveTraceProtocol(), "sanity check: agent must resolve to v1")
+
+	w := newAgentTraceWriter(tr.config, newPrioritySampler(), tr.statsd)
+	require.Equal(t, traceProtocolV1, w.payload.protocol(), "payload created while v1 was in effect must be v1")
+
+	// Drive the downgrade through the real /info path, not a raw agent.store,
+	// so the streak/hysteresis logic in refreshAgentFeatures is exercised too.
+	agent.SetInfo(`{"endpoints":["/v0.4/traces","/v0.6/stats"],"client_drop_p0s":true}`)
+	tr.refreshAgentFeatures()
+	require.Equal(t, traceProtocolV04, tr.config.effectiveTraceProtocol(), "sanity check: the poll must downgrade")
+
+	// The writer was idle across the downgrade: an empty flush must adopt v0.4.
+	w.flush()
+	require.Equal(t, traceProtocolV04, w.payload.protocol(), "an empty payload must not survive a protocol downgrade")
+
+	agent.Reset()
+	w.add([]*Span{makeSpan(1)})
+	w.flush()
+	w.wg.Wait()
+	assert.Equal(t, []string{tracesAPIPath}, agent.Requests(), "the post-downgrade trace must land on /v0.4/traces")
+}
+
+// TestConcurrentProtocolChangeDuringFlush runs a flush loop and an
+// agent-info-refresh loop concurrently and asserts that every observed
+// request's wire format matches its intake path. Run with -race: making the
+// protocol dynamic is only safe because the payload carries its own protocol,
+// so there is no mutable shared "current protocol" for the two loops to race
+// on.
+func TestConcurrentProtocolChangeDuringFlush(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping concurrent protocol-switch test in short mode")
+	}
+	agent := startTestAgent(t)
+	tr := newTracerTest(t, agent)
+	defer stopTracerTest(tr)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Go(func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			s := tr.StartSpan("op")
+			s.Finish()
+			tr.Flush()
+		}
+	})
+
+	wg.Go(func() {
+		v1 := true
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if v1 {
+				agent.SetInfo(`{"endpoints":["/v0.4/traces","/v1.0/traces","/v0.6/stats"],"client_drop_p0s":true}`)
+			} else {
+				agent.SetInfo(`{"endpoints":["/v0.4/traces","/v0.6/stats"],"client_drop_p0s":true}`)
+			}
+			v1 = !v1
+			tr.refreshAgentFeatures()
+		}
+	})
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+	tr.Flush()
+
+	requests := agent.Requests()
+	firstBytes := agent.RequestFirstBytes()
+	require.Equal(t, len(requests), len(firstBytes))
+	for i, path := range requests {
+		switch path {
+		case tracesAPIPathV1:
+			assert.True(t, isV1WireByte(firstBytes[i]), "request %d: %s must carry a msgpack map body, got 0x%02x", i, path, firstBytes[i])
+		case tracesAPIPath:
+			assert.True(t, isV04WireByte(firstBytes[i]), "request %d: %s must carry a msgpack array body, got 0x%02x", i, path, firstBytes[i])
+		default:
+			t.Fatalf("unexpected request path %q", path)
+		}
+	}
+}

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -200,6 +200,13 @@ type tracer struct {
 	// universalVersion=false so that the version write in StartSpan is a
 	// copy-on-write no-op rather than triggering an unnecessary Clone.
 	sharedAttrsForMainSvc traceinternal.SpanAttributes
+
+	// v1ProtocolStreak counts consecutive /info polls (via refreshAgentFeatures)
+	// that advertised /v1.0/traces since the last one that didn't. Used to gate
+	// re-upgrading to v1 after a downgrade; see v1ProtocolUpgradeStreak. Seeded
+	// to the threshold in newUnstartedTracer when the startup snapshot already
+	// advertises v1, so a healthy agent never has to "re-earn" v1 after boot.
+	v1ProtocolStreak atomic.Int32
 }
 
 type dynInstSubscriptions struct {
@@ -555,6 +562,13 @@ func newUnstartedTracer(opts ...StartOption) (t *tracer, err error) {
 	}
 	t.flushHandler = t.defaultFlushHandler
 	buildSharedAttrs(c, &t.sharedAttrs, &t.sharedAttrsForMainSvc)
+	if c.agent.load().v1ProtocolAvailable {
+		// Trust the startup /info response outright: requiring it to "re-earn"
+		// v1 via v1ProtocolUpgradeStreak would make every process boot on v0.4
+		// and take several poll intervals to reach v1, a behaviour regression
+		// and a guaranteed payload-shape transition on every single boot.
+		t.v1ProtocolStreak.Store(v1ProtocolUpgradeStreak)
+	}
 	return t, nil
 }
 
@@ -642,8 +656,22 @@ func newTracer(opts ...StartOption) (*tracer, error) {
 
 // refreshAgentFeatures fetches a fresh snapshot from /info and atomically
 // updates the dynamic agent capabilities. Static fields that are baked into
-// components at startup (transport URL, statsd address, obfuscator config, etc.)
-// are preserved from the current snapshot so a poll can never change them.
+// components at startup (statsd address, obfuscator config, etc.) are
+// preserved from the current snapshot so a poll can never change them.
+// v1ProtocolAvailable is deliberately NOT one of those static fields: nothing
+// bakes it into a component (the trace URL and payload encoding are both
+// derived at send time from the payload's own protocol), so it is safe to
+// refresh here, subject to the upgrade hysteresis below.
+//
+// v1ProtocolUpgradeStreak is how many consecutive /info responses must
+// advertise /v1.0/traces before refreshAgentFeatures allows re-upgrading to v1
+// after a downgrade. Downgrades apply on the first negative poll instead —
+// v0.4 is universally accepted, so it is the fail-safe direction. This
+// asymmetry makes a flapping agent (e.g. a mixed-version fleet behind one
+// load-balanced VIP) converge on v0.4 and stay there, rather than oscillating
+// the wire format on every poll.
+const v1ProtocolUpgradeStreak = 3
+
 func (t *tracer) refreshAgentFeatures() {
 	ctx, cancel := gocontext.WithCancel(gocontext.Background())
 	defer cancel()
@@ -656,32 +684,63 @@ func (t *tracer) refreshAgentFeatures() {
 		}
 	}()
 	newFeatures, err := fetchAgentFeatures(ctx, t.config.internalConfig.AgentURL(), t.config.httpClient)
-	if err != nil {
-		if !errors.Is(err, errAgentFeaturesNotSupported) {
-			log.Debug("agent info poll failed: %s", err.Error())
-		}
-		return // keep last-known-good
+	if err != nil && !errors.Is(err, errAgentFeaturesNotSupported) {
+		log.Debug("agent info poll failed: %s", err.Error())
+		// Keep last-known-good; a network or decode error is never evidence that
+		// v1 became unavailable.
+		return
 	}
-	// Atomically graft the startup-frozen static fields from the current
-	// snapshot onto the fresh dynamic snapshot. update() handles the CAS
-	// loop in case a concurrent store races this write. fn must be a pure
-	// transform — work on a local copy f so retries start fresh.
-	t.config.agent.update(func(current agentFeatures) agentFeatures {
-		// f is a shallow copy of newFeatures. Reference-typed fields (map, slice)
-		// must be overwritten from current or cloned below to avoid shared mutable
-		// backing storage across CAS retries.
-		f := newFeatures
-		f.v1ProtocolAvailable = current.v1ProtocolAvailable
-		f.StatsdPort = current.StatsdPort
-		f.evpProxyV2 = current.evpProxyV2
-		f.metaStructAvailable = current.metaStructAvailable
-		f.featureFlags = maps.Clone(current.featureFlags) // defensive copy of map
-		f.peerTags = slices.Clone(newFeatures.peerTags)   // defensive copy of slice
-		f.defaultEnv = current.defaultEnv
-		f.reachable = current.reachable
-		f.hasTelemetryProxy = current.hasTelemetryProxy
-		return f
-	})
+	if err != nil {
+		// errAgentFeaturesNotSupported means the agent returned 404 on /info,
+		// i.e. it doesn't support /info at all. Unlike a generic fetch error,
+		// this IS evidence v1 is unavailable: /v1.0/traces support postdates
+		// /info support, so an agent without /info cannot serve v1 either.
+		// Apply the same immediate-downgrade rule a negative poll would, but
+		// leave every other dynamic field at its last-known-good value — we
+		// have no fresh snapshot to refresh them from.
+		t.v1ProtocolStreak.Store(0)
+		t.config.agent.update(func(current agentFeatures) agentFeatures {
+			f := current
+			f.v1ProtocolAvailable = false
+			return f
+		})
+	} else {
+		// Computed once here — not inside the update() closure below, which may
+		// run more than once under CAS contention and must stay a pure transform
+		// with no observable side effects.
+		if newFeatures.v1ProtocolAvailable {
+			t.v1ProtocolStreak.Add(1)
+		} else {
+			t.v1ProtocolStreak.Store(0)
+		}
+		allowV1 := t.v1ProtocolStreak.Load() >= v1ProtocolUpgradeStreak
+		// Atomically graft the startup-frozen static fields from the current
+		// snapshot onto the fresh dynamic snapshot. update() handles the CAS
+		// loop in case a concurrent store races this write. fn must be a pure
+		// transform — work on a local copy f so retries start fresh.
+		t.config.agent.update(func(current agentFeatures) agentFeatures {
+			// f is a shallow copy of newFeatures. Reference-typed fields (map, slice)
+			// must be overwritten from current or cloned below to avoid shared mutable
+			// backing storage across CAS retries.
+			f := newFeatures
+			f.v1ProtocolAvailable = allowV1
+			f.StatsdPort = current.StatsdPort
+			f.evpProxyV2 = current.evpProxyV2
+			f.metaStructAvailable = current.metaStructAvailable
+			f.featureFlags = maps.Clone(current.featureFlags) // defensive copy of map
+			f.peerTags = slices.Clone(newFeatures.peerTags)   // defensive copy of slice
+			f.defaultEnv = current.defaultEnv
+			f.reachable = current.reachable
+			f.hasTelemetryProxy = current.hasTelemetryProxy
+			return f
+		})
+	}
+	proto := t.config.effectiveTraceProtocol()
+	if t.config.internalConfig.ReportEffectiveTraceProtocol(proto) {
+		protoStr := internalconfig.TraceProtocolVersionString(proto)
+		log.Info("trace protocol changed to %s", protoStr)
+		t.statsd.Incr("datadog.tracer.trace_protocol_changed", []string{"to:" + protoStr}, 1)
+	}
 }
 
 // pollAgentInfo polls the agent /info endpoint at the given interval until the

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -2694,6 +2694,21 @@ func startTestTracer(t testing.TB, opts ...StartOption) (trc *tracer, transport 
 	af := tracer.config.agent.load()
 	af.Stats = true
 	af.DropP0s = true
+	// Only force v0.4 when the caller did not pick an agent: at the default
+	// address a developer machine may have a real v1-capable Agent listening,
+	// which would flip the protocol under tests that assert on it. A caller that
+	// points the tracer at a specific agent (a mock, a UDS, a real one) is opting
+	// into that agent's advertised capabilities, so leave those alone —
+	// otherwise benchmarks that stand up a /v1.0/traces mock would silently
+	// measure the v0.4 encoder instead.
+	//
+	// Pin the requested protocol too, not just the capability bit:
+	// v1ProtocolAvailable is now refreshed on every /info poll, so a lone
+	// capability override would expire after one poll interval.
+	if u := tracer.config.internalConfig.AgentURL(); u == nil || u.String() == defaultURL {
+		af.v1ProtocolAvailable = false
+		tracer.config.internalConfig.SetTraceProtocol(traceProtocolV04, internalconfig.OriginCode)
+	}
 	tracer.config.agent.store(af)
 	setGlobalTracer(tracer)
 	flushFunc := func(n int) {

--- a/ddtrace/tracer/writer.go
+++ b/ddtrace/tracer/writer.go
@@ -151,6 +151,20 @@ func (h *agentTraceWriter) flush() {
 	oldp := h.payload
 	// Check after acquiring lock
 	if oldp.itemCount() == 0 {
+		// An empty payload holds no encoded bytes, so it can adopt the current
+		// protocol for free. This is the only place that re-reads the protocol
+		// while idle: without it, a writer that saw no traffic across an
+		// agent-info poll would hold a stale payload indefinitely after the
+		// agent's advertised protocol changed, and the first trace to arrive —
+		// possibly minutes later — would be encoded for a protocol the agent no
+		// longer (or not yet) accepts. oldp was never handed to the transport,
+		// so it is simply dropped rather than recycled through the payloadV1
+		// pool: handoff(pv1StateFlushDone) alone would not return it (the
+		// two-party handoff also needs the transport's bit), and forcing both
+		// bits risks a double pool return.
+		if oldp.protocol() != h.config.effectiveTraceProtocol() {
+			h.payload = h.newPayload(0)
+		}
 		h.mu.Unlock()
 		return
 	}
@@ -166,6 +180,10 @@ func (h *agentTraceWriter) flush() {
 			// may still be kept by faulty transport implementations or the
 			// standard library. See dd-trace-go#976
 			h.statsd.Count("datadog.tracer.queue.enqueued.traces", int64(atomic.SwapUint32(&h.tracesQueued, 0)), nil, 1)
+			// Must branch on p.protocol(), never on config: the effective protocol
+			// can change between the newPayload call that created p and this
+			// deferred cleanup (e.g. an agent-info poll landing mid-flush), so only
+			// the payload's own, immutable protocol is a reliable guide here.
 			if p.protocol() == traceProtocolV1 {
 				p.(*safePayload).p.(*payloadV1).handoff(pv1StateFlushDone)
 			} else {


### PR DESCRIPTION
## What does this PR do?

Fifth in a split of [#5122](https://github.com/DataDog/dd-trace-go/pull/5122) into a reviewable stack (see that PR for the full sequence). Stacked on #5122 — this PR's diff is scoped to just the change below; merge #5122 first.

`v1ProtocolAvailable` was frozen at startup and explicitly preserved across every `/info` poll, alongside genuinely static fields like the statsd address. That was necessary while the protocol was baked into the transport URL, but it is no longer (see #5147): the URL and the payload encoding are both derived at send time from the payload's own protocol, so nothing can desynchronize from a refreshed capability bit.

Freezing it caused a real bug in both directions:

- A transient agent outage at startup pinned the process to v0.4 for its entire lifetime, even after the agent came back advertising v1.0.
- An agent rolled back mid-life to a version without `/v1.0/traces` kept being sent v1 payloads until the process restarted — permanent, total trace loss rather than a bounded blip.

Refreshes it on every poll, behind asymmetric hysteresis: a downgrade applies on the first negative poll, while re-upgrading requires `v1ProtocolUpgradeStreak` consecutive positive ones. v0.4 is universally accepted, so it is the fail-safe direction, and the asymmetry makes a flapping agent (a mixed-version fleet behind one load-balanced VIP) converge on v0.4 rather than oscillating the wire format every poll. The streak is pre-seeded at startup when `/info` already advertises v1, so a healthy agent never has to re-earn v1 across a boot.

A 404 on `/info` is now treated as positive evidence that v1 is gone rather than as a generic "keep last-known-good" error: `/v1.0/traces` support postdates `/info` support, so an agent that cannot serve `/info` cannot serve v1 either. Every other dynamic field stays at its last-known-good value, since a 404 carries no fresh snapshot to refresh them from.

Finally, rotates an empty writer payload in `flush()`. An empty payload holds no encoded bytes, so it can adopt the current protocol for free. Without this, a writer idle across a downgrade held its stale v1 payload indefinitely and the first trace to arrive — possibly minutes later — was POSTed to `/v1.0/traces` and rejected.

A downgrade still costs up to one flush interval of already-encoded traces; that part is unfixable, since those spans are msgpack-encoded and their `*Span` objects released. Documented in `doc.go`.

`TestConcurrentProtocolChangeDuringFlush` drives a flush loop against a protocol-flapping poll loop and asserts every request's wire format matches its intake path; clean under `-race`.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] All generated files are up to date. You can check this by running `make generate` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)