### PR TITLE
fix(civisibility): support Go tip denyParallel layout

### DIFF
--- a/.github/workflows/gotip-testing.yml
+++ b/.github/workflows/gotip-testing.yml
@@ -61,12 +61,15 @@ jobs:
       - name: Run tests with gotip (sandboxed)
         # gotip pulls and runs the latest Go toolchain. Keep that toolchain and
         # the test process inside gVisor, persisting only reports/coverage.
+        # The coverage backfill fixture can exceed Go's default 10-minute package
+        # timeout under gVisor, so give this nightly job explicit headroom.
         uses: geomys/sandboxed-step@a6bfc174e532cea4f378e3427bcde8b714c2e810 # v1.2.2
         with:
           persist-workspace-changes: 'true'
           env: |
             DD_APPSEC_WAF_TIMEOUT=1h
             GO_CMD=gotip
+            GOFLAGS=-timeout=20m
             TEST_RESULTS=${{ env.TEST_RESULTS }}
           run: |-
             mkdir -p "${GITHUB_WORKSPACE}/bin"

--- a/internal/civisibility/integrations/gotesting/reflection_offsets.go
+++ b/internal/civisibility/integrations/gotesting/reflection_offsets.go
@@ -249,7 +249,7 @@ func buildTestingInternalsLayout(tType, bType reflect.Type) (layout *testingInte
 	l.common.cancelCtx, _ = optionalExactField(commonType, "cancelCtx", reflect.TypeFor[context.CancelFunc]())
 	l.common.o, _ = optionalPointerToStructField(commonType, "o")
 
-	l.denyParallel, _ = optionalExactField(tType, "denyParallel", reflect.TypeFor[bool]())
+	l.denyParallel, _ = denyParallelField(tType)
 	l.tstate, _ = optionalWordField(tType, "tstate")
 	l.benchmark.benchFunc, _ = exactField(bType, "benchFunc", reflect.TypeFor[func(*testing.B)](), false)
 	l.benchmark.result, _ = exactField(bType, "result", reflect.TypeFor[testing.BenchmarkResult](), false)
@@ -398,6 +398,17 @@ func (l *testingInternalsLayout) computeSectionFlags() {
 		l.common.tempDir, l.common.tempDirErr, l.common.tempDirSeq,
 		l.common.ctx, l.common.cancelCtx, l.tstate.unsafeField, l.denyParallel,
 	) && l.testStateOK
+}
+
+func denyParallelField(owner reflect.Type) (unsafeField, bool) {
+	field, ok := exactField(owner, "denyParallel", nil, true)
+	if !ok || !field.available {
+		return field, ok
+	}
+	if field.typ != reflect.TypeFor[bool]() && field.typ != reflect.TypeFor[string]() {
+		return unsafeField{name: "denyParallel", optional: true}, false
+	}
+	return field, true
 }
 
 // exactField validates that a struct contains a field with the expected type.
@@ -566,6 +577,17 @@ func commonBaseForBenchmark(b *testing.B, l *testingInternalsLayout) unsafe.Poin
 // write barriers remain intact.
 func copyTypedField[T any](sourceBase, targetBase unsafe.Pointer, field unsafeField) {
 	*fieldPtr[T](targetBase, field) = *fieldPtr[T](sourceBase, field)
+}
+
+func copyDenyParallelField(sourceBase, targetBase unsafe.Pointer, field unsafeField) {
+	switch field.typ {
+	case reflect.TypeFor[bool]():
+		copyTypedField[bool](sourceBase, targetBase, field)
+	case reflect.TypeFor[string]():
+		copyTypedField[string](sourceBase, targetBase, field)
+	default:
+		panic("unsupported testing.T.denyParallel field type")
+	}
 }
 
 // copyConvertedField copies a typed field through a conversion function. It is

--- a/internal/civisibility/integrations/gotesting/reflection_offsets.go
+++ b/internal/civisibility/integrations/gotesting/reflection_offsets.go
@@ -15,6 +15,8 @@ import (
 	"testing"
 	"time"
 	"unsafe"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/log"
 )
 
 // unsafeField describes a private field discovered from a runtime type.
@@ -406,6 +408,7 @@ func denyParallelField(owner reflect.Type) (unsafeField, bool) {
 		return field, ok
 	}
 	if field.typ != reflect.TypeFor[bool]() && field.typ != reflect.TypeFor[string]() {
+		log.Debug("civisibility: testing.T.denyParallel has unexpected type %s; disabling retry fast path", field.typ)
 		return unsafeField{name: "denyParallel", optional: true}, false
 	}
 	return field, true

--- a/internal/civisibility/integrations/gotesting/reflections.go
+++ b/internal/civisibility/integrations/gotesting/reflections.go
@@ -613,7 +613,7 @@ func copyTestWithoutParentFast(source *testing.T, target *testing.T, layout *tes
 		copyTypedField[context.CancelFunc](sourceBase, targetBase, layout.common.cancelCtx)
 	}
 	if layout.denyParallel.available {
-		copyTypedField[bool](unsafe.Pointer(source), unsafe.Pointer(target), layout.denyParallel)
+		copyDenyParallelField(unsafe.Pointer(source), unsafe.Pointer(target), layout.denyParallel)
 	}
 	if layout.tstate.available {
 		copyWordField(unsafe.Pointer(source), unsafe.Pointer(target), layout.tstate)
@@ -688,7 +688,9 @@ func copyTestWithoutParentReflect(source *testing.T, target *testing.T) {
 	_ = copyFieldUsingPointers[context.Context](source, target, "ctx")
 	_ = copyFieldUsingPointers[context.CancelFunc](source, target, "cancelCtx")
 
-	_ = copyFieldUsingPointers[bool](source, target, "denyParallel")
+	if field, ok := denyParallelField(reflect.TypeOf(*source)); ok && field.available {
+		copyDenyParallelField(unsafe.Pointer(source), unsafe.Pointer(target), field)
+	}
 	_ = copyFieldUsingPointers[unsafe.Pointer](source, target, "tstate") // For running tests and subtests.
 }
 

--- a/internal/civisibility/integrations/gotesting/reflections.go
+++ b/internal/civisibility/integrations/gotesting/reflections.go
@@ -688,7 +688,7 @@ func copyTestWithoutParentReflect(source *testing.T, target *testing.T) {
 	_ = copyFieldUsingPointers[context.Context](source, target, "ctx")
 	_ = copyFieldUsingPointers[context.CancelFunc](source, target, "cancelCtx")
 
-	if field, ok := denyParallelField(reflect.TypeOf(*source)); ok && field.available {
+	if field, ok := denyParallelField(reflect.TypeOf(source).Elem()); ok && field.available {
 		copyDenyParallelField(unsafe.Pointer(source), unsafe.Pointer(target), field)
 	}
 	_ = copyFieldUsingPointers[unsafe.Pointer](source, target, "tstate") // For running tests and subtests.

--- a/internal/civisibility/integrations/gotesting/reflections.go
+++ b/internal/civisibility/integrations/gotesting/reflections.go
@@ -688,7 +688,7 @@ func copyTestWithoutParentReflect(source *testing.T, target *testing.T) {
 	_ = copyFieldUsingPointers[context.Context](source, target, "ctx")
 	_ = copyFieldUsingPointers[context.CancelFunc](source, target, "cancelCtx")
 
-	if field, ok := denyParallelField(reflect.TypeOf(source).Elem()); ok && field.available {
+	if field, ok := denyParallelField(reflect.TypeFor[testing.T]()); ok && field.available {
 		copyDenyParallelField(unsafe.Pointer(source), unsafe.Pointer(target), field)
 	}
 	_ = copyFieldUsingPointers[unsafe.Pointer](source, target, "tstate") // For running tests and subtests.

--- a/internal/civisibility/integrations/gotesting/reflections_test.go
+++ b/internal/civisibility/integrations/gotesting/reflections_test.go
@@ -116,6 +116,11 @@ func exerciseDenyParallelFieldCompatibility(t *testing.T) {
 	if ok || field.available {
 		t.Fatalf("expected unsupported denyParallel field type, got field=%+v ok=%t", field, ok)
 	}
+
+	field, ok = denyParallelField(reflect.TypeFor[struct{}]())
+	if !ok || field.available {
+		t.Fatalf("expected missing denyParallel field to be a no-op, got field=%+v ok=%t", field, ok)
+	}
 }
 
 // TestGetInternalTestArray tests the getInternalTestArray function.

--- a/internal/civisibility/integrations/gotesting/reflections_test.go
+++ b/internal/civisibility/integrations/gotesting/reflections_test.go
@@ -67,6 +67,7 @@ func TestGetFieldPointerFrom(t *testing.T) {
 	exerciseTestingInternalsCopyEquivalence(t)
 	exerciseTestingInternalsHelperMapIsolation(t)
 	exerciseTestingInternalsPrivatePointerAssignment(t)
+	exerciseDenyParallelFieldCompatibility(t)
 	exerciseBenchmarkFuncInstrumentationConcurrentWrites(t)
 	// These pure instrumentation assertions run under this existing top-level test
 	// so the subprocess span-count scenarios do not gain extra test spans.
@@ -76,6 +77,45 @@ func TestGetFieldPointerFrom(t *testing.T) {
 	exerciseSlowEFDAbortTagging(t)
 	exerciseITRCoverageBackfillState(t)
 	exerciseNarrowingFlagParsing(t)
+}
+
+func exerciseDenyParallelFieldCompatibility(t *testing.T) {
+	t.Helper()
+
+	tests := []struct {
+		name string
+		typ  reflect.Type
+	}{
+		{name: "bool", typ: reflect.TypeFor[struct{ denyParallel bool }]()},
+		{name: "string", typ: reflect.TypeFor[struct{ denyParallel string }]()},
+	}
+	for _, test := range tests {
+		field, ok := denyParallelField(test.typ)
+		if !ok || !field.available || field.typ.Kind().String() != test.name {
+			t.Fatalf("expected supported denyParallel %s field, got field=%+v ok=%t", test.name, field, ok)
+		}
+	}
+
+	boolSource := struct{ denyParallel bool }{denyParallel: true}
+	boolTarget := struct{ denyParallel bool }{}
+	boolField, _ := denyParallelField(reflect.TypeOf(boolSource))
+	copyDenyParallelField(unsafe.Pointer(&boolSource), unsafe.Pointer(&boolTarget), boolField)
+	if !boolTarget.denyParallel {
+		t.Fatal("expected bool denyParallel value to be preserved")
+	}
+
+	stringSource := struct{ denyParallel string }{denyParallel: "t.Setenv"}
+	stringTarget := struct{ denyParallel string }{}
+	stringField, _ := denyParallelField(reflect.TypeOf(stringSource))
+	copyDenyParallelField(unsafe.Pointer(&stringSource), unsafe.Pointer(&stringTarget), stringField)
+	if stringTarget.denyParallel != stringSource.denyParallel {
+		t.Fatalf("expected string denyParallel value %q, got %q", stringSource.denyParallel, stringTarget.denyParallel)
+	}
+
+	field, ok := denyParallelField(reflect.TypeFor[struct{ denyParallel int }]())
+	if ok || field.available {
+		t.Fatalf("expected unsupported denyParallel field type, got field=%+v ok=%t", field, ok)
+	}
 }
 
 // TestGetInternalTestArray tests the getInternalTestArray function.

--- a/internal/civisibility/integrations/gotesting/retry_attempt.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt.go
@@ -265,8 +265,8 @@ func newRetryAttemptRootInGroup(group *retryAttemptGroup) (*retryAttemptRoot, st
 	}
 	initializeRetryAttemptWriter(originalBase, rootBase, layout, true)
 	initializeRetryAttemptWriter(originalParentBase, parentBase, layout, false)
-	copyTypedField[bool](unsafe.Pointer(original), unsafe.Pointer(root), layout.denyParallel)
-	copyTypedField[bool](originalParentBase, unsafe.Pointer(parent), layout.denyParallel)
+	copyDenyParallelField(unsafe.Pointer(original), unsafe.Pointer(root), layout.denyParallel)
+	copyDenyParallelField(originalParentBase, unsafe.Pointer(parent), layout.denyParallel)
 	group.mu.Lock()
 	rootParallelObserved := group.rootParallelObserved
 	group.mu.Unlock()

--- a/internal/civisibility/integrations/gotesting/retryprocess/burst_benchmark_test.go
+++ b/internal/civisibility/integrations/gotesting/retryprocess/burst_benchmark_test.go
@@ -303,7 +303,11 @@ func (c *processRetryBurstCollector) metrics(start time.Time, elapsed time.Durat
 	c.mu.Unlock()
 
 	firstPassByPackage := make(map[string]struct{})
-	parentPIDs := make(map[int]struct{})
+	type parentIdentity struct {
+		packageName string
+		pid         int
+	}
+	parentProcesses := make(map[parentIdentity]struct{})
 	childPIDs := make(map[int]struct{})
 	activeByPackage := make(map[string]int)
 	maximumByPackage := make(map[string]int)
@@ -313,7 +317,7 @@ func (c *processRetryBurstCollector) metrics(start time.Time, elapsed time.Durat
 	for _, event := range events {
 		switch event.Kind {
 		case "parent_start":
-			parentPIDs[event.PID] = struct{}{}
+			parentProcesses[parentIdentity{packageName: event.Package, pid: event.PID}] = struct{}{}
 		case "first_pass_complete":
 			firstPassByPackage[event.Package] = struct{}{}
 			if event.received.After(lastFirstPass) {
@@ -354,7 +358,7 @@ func (c *processRetryBurstCollector) metrics(start time.Time, elapsed time.Durat
 		elapsed:                  elapsed,
 		firstPass:                firstPass,
 		drain:                    max(elapsed-firstPass, 0),
-		parentProcesses:          len(parentPIDs),
+		parentProcesses:          len(parentProcesses),
 		parentFinishes:           parentFinishes,
 		firstPassCompletions:     len(firstPassByPackage),
 		childProcesses:           len(childPIDs),
@@ -917,6 +921,19 @@ func TestProcessRetryBurstMetricsUseEventOrderAndProcessIdentity(t *testing.T) {
 	}
 	if metrics.firstPass != 4*time.Millisecond || metrics.drain != 4*time.Millisecond {
 		t.Fatalf("durations = first-pass:%s drain:%s, want 4ms each", metrics.firstPass, metrics.drain)
+	}
+}
+
+func TestProcessRetryBurstMetricsDistinguishParentPIDReuseAcrossPackages(t *testing.T) {
+	start := time.Unix(100, 0)
+	collector := newProcessRetryBurstCollector(processRetryBurstScenario{})
+	collector.events = []processRetryBurstRecordedEvent{
+		{processRetryBurstEvent: processRetryBurstEvent{Package: "pkg00", Kind: "parent_start", PID: 1}, received: start.Add(time.Millisecond)},
+		{processRetryBurstEvent: processRetryBurstEvent{Package: "pkg01", Kind: "parent_start", PID: 1}, received: start.Add(2 * time.Millisecond)},
+	}
+	metrics := collector.metrics(start, 3*time.Millisecond, processRetryBurstResourceMetrics{}, "")
+	if metrics.parentProcesses != 2 {
+		t.Fatalf("parent processes = %d, want 2", metrics.parentProcesses)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

- Supports both the historical `bool` and new `string` layouts of `testing.T.denyParallel`.
- Preserves the exact field value when cloning tests and creating in-process or process-isolated retry attempts.
- Adds regression coverage for both supported layouts and rejects unknown field types.
- Gives the sandboxed Go tip nightly a 20-minute package timeout so the ITR coverage backfill fixture has sufficient headroom under gVisor.

### Motivation

The [Go tip nightly](https://github.com/DataDog/dd-trace-go/actions/runs/31059813607/job/92540195158) started failing after Go changed `testing.T.denyParallel` from `bool` to `string`. The incompatible private layout disabled CI Visibility retry setup and caused cascading failures in the gotesting, failnow, subtest-management, and process-retry suites.

The same run also exposed an independent timeout issue: `itrbackfillfixture` completed in 9m55s in the first attempt and hit Go's default 10-minute package timeout in the second attempt under gVisor. The fixture passes functionally when given sufficient headroom.

### Validation

- `go test ./internal/civisibility/integrations/gotesting -run '^TestGetFieldPointerFrom$' -count=1`
- Go tip with `-race -shuffle=on -covermode=atomic`:
  - `./internal/civisibility/integrations/gotesting`
  - `./internal/civisibility/integrations/gotesting/failnow`
  - `./internal/civisibility/integrations/gotesting/subtests`
  - `./internal/civisibility/integrations/gotesting/retryprocess`
- Go tip `itrbackfillfixture`: all 22 scenarios passed in 261s with a 20-minute diagnostic timeout.
- The workflow YAML parses successfully and `GOFLAGS=-timeout=20m` is accepted by both `gotip list` and `gotip test`.
- `git diff --check`

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
